### PR TITLE
Compact Lark Kanban sync receipts by default

### DIFF
--- a/examples/lark-kanban-control-plane-smoke.py
+++ b/examples/lark-kanban-control-plane-smoke.py
@@ -33,6 +33,7 @@ from loopx.presentation.sinks.lark.kanban import (  # noqa: E402
     lark_kanban_schema_payload,
     lark_kanban_ux_task,
     read_lark_kanban_local_config,
+    render_lark_kanban_markdown,
     seed_lark_kanban_records,
     setup_lark_kanban_board,
     sync_loopx_projection_to_lark_kanban,
@@ -527,6 +528,53 @@ def main() -> int:
         assert all(item["values"]["Workdir"] == "" for item in sync_payload["records"]), sync_payload
         assert str(root) not in json.dumps(sync_payload["records"], ensure_ascii=False), sync_payload
         assert all(item["command"]["executed"] is False for item in sync_payload["records"]), sync_payload
+        compact_cli = run_cli(
+            "--registry",
+            str(registry),
+            "lark-kanban",
+            "sync-loopx-todos",
+            "--base-token",
+            "base_public_fixture",
+            "--table-id",
+            "tbl_public_fixture",
+            "--goal-id",
+            "goal_lark_sync_fixture",
+        )
+        assert compact_cli["detail_level"] == "compact", compact_cli
+        assert compact_cli["record_count"] == 4, compact_cli
+        assert compact_cli["record_success_count"] == 4, compact_cli
+        assert compact_cli["record_failure_count"] == 0, compact_cli
+        assert compact_cli["base_token"] == "base_public_fixture", compact_cli
+        assert compact_cli["table_id"] == "tbl_public_fixture", compact_cli
+        assert "commands" not in compact_cli, compact_cli
+        assert all("command" not in item for item in compact_cli["records"]), compact_cli
+        assert all("values" not in item for item in compact_cli["records"]), compact_cli
+        compact_markdown = render_lark_kanban_markdown(compact_cli)
+        assert "- detail_level: `compact`" in compact_markdown, compact_markdown
+        assert "- record_success_count: `4`" in compact_markdown, compact_markdown
+        assert "## Records" in compact_markdown, compact_markdown
+        assert "## Commands" not in compact_markdown, compact_markdown
+
+        detailed_cli = run_cli(
+            "--registry",
+            str(registry),
+            "lark-kanban",
+            "sync-loopx-todos",
+            "--base-token",
+            "base_public_fixture",
+            "--table-id",
+            "tbl_public_fixture",
+            "--goal-id",
+            "goal_lark_sync_fixture",
+            "--include-command-details",
+        )
+        assert detailed_cli["detail_level"] == "full", detailed_cli
+        assert len(detailed_cli["commands"]) == 4, detailed_cli
+        assert all("command" in item for item in detailed_cli["records"]), detailed_cli
+        assert all("values" in item for item in detailed_cli["records"]), detailed_cli
+        compact_size = len(json.dumps(compact_cli, ensure_ascii=False))
+        detailed_size = len(json.dumps(detailed_cli, ensure_ascii=False))
+        assert compact_size * 3 < detailed_size, (compact_size, detailed_size)
         scoped_payload = sync_loopx_todos_to_lark_kanban(
             LarkKanbanConfig(
                 **{"base_" + "token": "base_public_fixture"},

--- a/loopx/cli_commands/lark_kanban.py
+++ b/loopx/cli_commands/lark_kanban.py
@@ -12,6 +12,7 @@ from ..presentation.sinks.lark.kanban import (
     DEFAULT_TABLE_NAME,
     LarkKanbanConfig,
     build_create_board_plan,
+    compact_lark_kanban_sync_receipt,
     create_lark_kanban_board,
     default_lark_kanban_config_path,
     lark_kanban_doctor,
@@ -134,6 +135,14 @@ def register_lark_kanban_commands(
     sync.add_argument("--state-file")
     sync.add_argument("--include-done", action="store_true")
     sync.add_argument("--limit", type=int, default=50)
+    sync.add_argument(
+        "--include-command-details",
+        action="store_true",
+        help=(
+            "Include full generated commands, provider stdout/stderr, parsed JSON, "
+            "and record values. The default returns a compact operator receipt."
+        ),
+    )
     sync.add_argument("--execute", action="store_true", help="Actually upsert records and remember record ids.")
 
     projection = sub.add_parser(
@@ -361,8 +370,9 @@ def handle_lark_kanban_command(
             payload["execute"] = bool(args.execute)
             payload["operator_card_fields"] = lark_kanban_operator_card_fields()
         elif args.lark_kanban_command == "sync-loopx-todos":
+            target_config = _target_config(args, config_path=config_path)
             payload = sync_loopx_todos_to_lark_kanban(
-                _target_config(args, config_path=config_path),
+                target_config,
                 registry_path=registry_path,
                 goal_id=args.goal_id,
                 agent_id=args.agent_id,
@@ -372,6 +382,10 @@ def handle_lark_kanban_command(
                 include_done=bool(args.include_done),
                 limit=args.limit,
                 execute=bool(args.execute),
+            )
+            payload = compact_lark_kanban_sync_receipt(
+                payload,
+                include_command_details=bool(args.include_command_details),
             )
         elif args.lark_kanban_command == "sync-projection":
             payload = sync_loopx_projection_to_lark_kanban(

--- a/loopx/presentation/sinks/lark/kanban.py
+++ b/loopx/presentation/sinks/lark/kanban.py
@@ -31,6 +31,7 @@ from .projection_rows import (
     projection_text_list as _as_text_list,
     todo_matches_agent_scope,
 )
+from .sync_receipt import compact_lark_kanban_sync_receipt, render_lark_kanban_markdown
 
 LARK_KANBAN_SCHEMA_VERSION = "loopx_lark_kanban_control_plane_v0"
 LARK_KANBAN_HEARTBEAT_VERSION = "loopx_lark_kanban_heartbeat_v0"
@@ -2118,6 +2119,9 @@ def sync_loopx_todos_to_lark_kanban(
         "execute": execute,
         "goal_id": goal_id,
         "agent_id": agent_id,
+        "base_token": config.base_token,
+        "table_id": config.table_id,
+        "view_id": config.view_id,
         "project": str(resolved_project) if resolved_project else None,
         "state_file": str(resolved_state_file),
         "todo_count": len(todos),
@@ -2508,30 +2512,3 @@ def _heartbeat_payload(
         "writeback": writeback,
         "commands": commands,
     }
-
-
-def render_lark_kanban_markdown(payload: dict[str, Any]) -> str:
-    lines = [
-        "# LoopX Lark Kanban",
-        "",
-        f"- ok: `{payload.get('ok')}`",
-        f"- schema_version: `{payload.get('schema_version')}`",
-    ]
-    for key in ("base_token", "table_id", "agent_id", "decision", "selected_record_id", "final_status"):
-        if payload.get(key) is not None:
-            lines.append(f"- {key}: `{payload.get(key)}`")
-    if payload.get("error"):
-        lines.append(f"- error: {payload.get('error')}")
-    if isinstance(payload.get("commands"), list):
-        lines.append("")
-        lines.append("## Commands")
-        for item in payload["commands"]:
-            if isinstance(item, dict):
-                marker = "ran" if item.get("executed") else "dry-run"
-                lines.append(f"- `{marker}` `{item.get('command')}`")
-    if isinstance(payload.get("writeback"), dict):
-        lines.append("")
-        lines.append("## Writeback")
-        for key, value in payload["writeback"].items():
-            lines.append(f"- {key}: `{_compact_text(value, limit=220)}`")
-    return "\n".join(lines)

--- a/loopx/presentation/sinks/lark/sync_receipt.py
+++ b/loopx/presentation/sinks/lark/sync_receipt.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+OUTPUT_LIMIT = 1800
+
+
+def _compact_text(value: Any, *, limit: int) -> str:
+    text = " ".join(str(value or "").split())
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "..."
+
+
+def _command_error(command_result: dict[str, Any]) -> str:
+    parsed = command_result.get("json")
+    if isinstance(parsed, dict):
+        error = parsed.get("error")
+        if isinstance(error, dict):
+            return str(error.get("message") or error)
+        if error:
+            return str(error)
+        if parsed.get("msg") and parsed.get("code") not in (None, 0):
+            return str(parsed.get("msg"))
+    stderr = " ".join(str(command_result.get("stderr") or "").split())
+    if stderr:
+        return stderr[:OUTPUT_LIMIT]
+    stdout = " ".join(str(command_result.get("stdout") or "").split())
+    return stdout[:OUTPUT_LIMIT]
+
+
+def compact_lark_kanban_sync_receipt(
+    payload: dict[str, Any],
+    *,
+    include_command_details: bool = False,
+) -> dict[str, Any]:
+    records = [item for item in payload.get("records", []) if isinstance(item, dict)]
+    commands = [item for item in payload.get("commands", []) if isinstance(item, dict)]
+    result = dict(payload)
+    result.update(
+        {
+            "detail_level": "full" if include_command_details else "compact",
+            "record_count": len(records),
+            "record_success_count": sum(
+                1
+                for item in records
+                if isinstance(item.get("command"), dict)
+                and item["command"].get("ok") is True
+            ),
+            "record_failure_count": sum(
+                1
+                for item in records
+                if not isinstance(item.get("command"), dict)
+                or item["command"].get("ok") is not True
+            ),
+            "command_count": len(commands),
+            "command_failure_count": sum(
+                1 for item in commands if item.get("ok") is not True
+            ),
+        }
+    )
+    if include_command_details:
+        return result
+
+    compact_records: list[dict[str, Any]] = []
+    for item in records:
+        command = item.get("command") if isinstance(item.get("command"), dict) else {}
+        values = item.get("values") if isinstance(item.get("values"), dict) else {}
+        compact_records.append(
+            {
+                "todo_id": item.get("todo_id"),
+                "record_id": item.get("record_id"),
+                "ok": command.get("ok") is True,
+                "executed": bool(command.get("executed")),
+                "returncode": command.get("returncode"),
+                "error": _command_error(command) if command.get("ok") is not True else None,
+                "work_item_type": values.get("Work Item Type"),
+                "repository": values.get("Repository"),
+                "issue": values.get("Issue"),
+                "pull_request": values.get("Pull Request"),
+            }
+        )
+    result["records"] = compact_records
+    result.pop("commands", None)
+    return result
+
+
+def render_lark_kanban_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# LoopX Lark Kanban",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- schema_version: `{payload.get('schema_version')}`",
+    ]
+    summary_keys = (
+        "base_token",
+        "table_id",
+        "view_id",
+        "agent_id",
+        "decision",
+        "selected_record_id",
+        "final_status",
+        "detail_level",
+        "todo_count",
+        "issue_fix_outcome_count",
+        "record_count",
+        "record_success_count",
+        "record_failure_count",
+        "command_count",
+        "command_failure_count",
+    )
+    for key in summary_keys:
+        if payload.get(key) is not None:
+            lines.append(f"- {key}: `{payload.get(key)}`")
+    if payload.get("error"):
+        lines.append(f"- error: {payload.get('error')}")
+    if isinstance(payload.get("commands"), list):
+        lines.extend(("", "## Commands"))
+        for item in payload["commands"]:
+            if isinstance(item, dict):
+                marker = "ran" if item.get("executed") else "dry-run"
+                lines.append(f"- `{marker}` `{item.get('command')}`")
+    if payload.get("detail_level") == "compact" and isinstance(payload.get("records"), list):
+        lines.extend(("", "## Records"))
+        for item in payload["records"]:
+            if not isinstance(item, dict):
+                continue
+            status = "ok" if item.get("ok") else "failed"
+            summary = (
+                f"- `{item.get('todo_id') or ''}` -> `{item.get('record_id') or ''}` "
+                f"status={status}"
+            )
+            if item.get("issue"):
+                summary += f" issue={_compact_text(item.get('issue'), limit=160)}"
+            if item.get("pull_request"):
+                summary += f" pr={_compact_text(item.get('pull_request'), limit=160)}"
+            if item.get("error"):
+                summary += f" error={_compact_text(item.get('error'), limit=220)}"
+            lines.append(summary)
+    if isinstance(payload.get("writeback"), dict):
+        lines.extend(("", "## Writeback"))
+        for key, value in payload["writeback"].items():
+            lines.append(f"- {key}: `{_compact_text(value, limit=220)}`")
+    return "\n".join(lines)


### PR DESCRIPTION
## Motivation

A real OpenViking issue-fix Kanban sync returned more than 100k characters for 13 projected records because the default CLI receipt embedded every generated command, provider stdout/stderr, parsed response, and full record values. This made routine automation output hard to audit and easy to truncate.

## Implementation

- default `lark-kanban sync-loopx-todos` to a compact operator receipt
- retain Base/Table/View ids, counts, per-record status, and Issue/PR links
- add `--include-command-details` for explicit full diagnostics
- isolate receipt shaping/rendering in a dedicated module instead of growing the legacy Kanban module
- preserve the full programmatic sync result below the CLI presentation boundary

## Validation

- `python3 examples/lark-kanban-control-plane-smoke.py`
- `python3 examples/issue-fix-outcome-projection-smoke.py`
- `python3 -m py_compile ...` for all changed Python files
- `loopx canary premerge --from-git-diff`: 8/8 selected checks passed
- public-boundary scan: 4 files clean
- red/green CLI smoke proves compact output is over 3x smaller while explicit detailed output remains available

## Risk

Low. This changes only the default CLI presentation receipt. The underlying sync function still returns full command/record details, and callers can opt back into the previous verbose CLI shape.

## Not covered

This PR does not change Lark write authority, credential handling, record selection, or provider behavior.
