### PR TITLE
Consume replan frontier acknowledgements

### DIFF
--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -436,6 +436,34 @@ def projected_autonomous_replan_ack(
     return ack
 
 
+def assert_frontier_delta_ack_clears_existing_replan_obligation() -> None:
+    payload = status_payload(
+        [side_agent_claimed_advancement()],
+        replan_obligation=SIDE_AGENT_REPLAN_OBLIGATION,
+        latest_runs=[
+            {
+                "classification": "autonomous_replan_recorded",
+                "agent_id": SIDE_AGENT,
+                "progress_scope": "goal",
+                "delivery_outcome": "outcome_progress",
+                "autonomous_replan_ack": projected_autonomous_replan_ack(
+                    ["runnable_todo_set", "successor_or_supersede"],
+                    agent_id=SIDE_AGENT,
+                ),
+            }
+        ],
+    )
+    guard = build_quota_should_run(
+        payload,
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert guard["effective_action"] == "normal_run", guard
+    assert guard["normal_delivery_allowed"] is True, guard
+    assert guard.get("autonomous_replan_obligation") is None, guard
+    assert guard["goal_frontier_projection"]["replan_required"] is False, guard
+
+
 def assert_replan_beats_monitor_quiet_skip() -> None:
     payload = status_payload([monitor_item()], replan_obligation=SIDE_AGENT_REPLAN_OBLIGATION)
     guard = build_quota_should_run(payload, goal_id=GOAL_ID, agent_id=SIDE_AGENT)
@@ -1394,6 +1422,7 @@ def assert_blocking_handoff_gate_beats_derived_monitor_replan() -> None:
 
 def main() -> None:
     assert_replan_beats_monitor_quiet_skip()
+    assert_frontier_delta_ack_clears_existing_replan_obligation()
     assert_future_scheduled_monitor_requires_replan_without_frontier_delta()
     assert_ready_deferred_successor_beats_monitor_quiet_skip()
     assert_completed_advancement_without_successor_beats_monitor_quiet_skip()

--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -1342,13 +1342,25 @@ def build_goal_frontier_projection_context_from_status(
         project_asset,
         agent_id=agent_id,
     )
+    effective_replan_ack = latest_agent_replan_ack or projected_replan_ack
+    if (
+        autonomous_replan_is_required(replan_obligation)
+        and autonomous_replan_ack_has_frontier_delta(effective_replan_ack)
+        and not acceptance_gaps
+    ):
+        replan_obligation = None
+        replan_scope = autonomous_replan_scope_decision(
+            replan_obligation,
+            agent_id=agent_id,
+            registered_agent_ids=registered_agent_ids,
+        )
     frontier_replan_obligation = derive_goal_frontier_replan_obligation_from_summaries(
         user_todo_summary=user_todo_summary,
         agent_todo_summary=agent_todo_summary,
         work_lane_contract=work_lane_contract,
         agent_id=agent_id,
         existing_replan_obligation=replan_obligation,
-        latest_replan_ack=latest_agent_replan_ack or projected_replan_ack,
+        latest_replan_ack=effective_replan_ack,
         acceptance_gaps=acceptance_gaps,
     )
     if frontier_replan_obligation:


### PR DESCRIPTION
## 动机

真实长程 issue-fix 运行完成了一次带 `runnable_todo_set` 和 `successor_or_supersede` delta 的 autonomous replan ACK，但下一次 quota 仍返回 `autonomous_replan_required`。Status 同时展示了有效 ACK 和旧 `no_progress_streak` obligation，导致 agent 无法回到已选中的 runnable todo。

## 改动思路

问题位于 goal-frontier reducer 的消费顺序：existing obligation 被保留后，derive 阶段提前返回，最新 ACK 从未有机会清除它。修复在同一 reducer 中先解析 agent-scoped ACK；当 ACK 含 frontier delta 且没有开放 vision acceptance gap 时，清除旧 obligation，再按当前 todo frontier 重新派生。

## 具体改动

- goal-frontier context 在 derive 前消费最新或已投影的 matching ACK
- 仅 `runnable_todo_set`、`successor_or_supersede` 等 frontier delta 生效
- vision acceptance gap 仍优先于 ACK
- 增加通用 quota decision-plane 回归：existing obligation + same-agent frontier ACK 恢复 normal delivery

## 验证

- quota replan decision-plane smoke：passed
- heartbeat quota flow、work-lane contract：passed
- control-plane integrated canary：passed（约 69 秒）
- premerge canary：17/17 selected checks passed
- Python line budget 与 public boundary：passed
- failures/skips/manual holds：none

## 对主干的风险与未覆盖

风险集中在 replan 生命周期：过度清除可能跳过仍有效的规划义务。现有 wrong-agent、unscoped、non-frontier ACK、vision gap 和 ACK 过期测试继续约束这些边界；本补丁不改变 todo 写入、quota 计费或 scheduler。合并后还必须用真实 `openviking-goal` 回放，确认 quota 从 replan obligation 恢复到已选 #3154 successor。
