### PR TITLE
Preserve due monitor routing across peer reassignment

### DIFF
--- a/examples/control_plane/agent-scope-work-lane-consistency-smoke.py
+++ b/examples/control_plane/agent-scope-work-lane-consistency-smoke.py
@@ -11,12 +11,14 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.quota import build_quota_should_run, render_quota_should_run_markdown
 from loopx.status import compact_todo_group
+from loopx.control_plane.testing.quota_fixtures import quota_status_payload
 
 
 GOAL_ID = "agent-scope-work-lane-consistency-fixture"
 PRIMARY_AGENT = "codex-main-control"
 SIDE_AGENT = "codex-product-capability"
 FUTURE_DUE_AT = "2999-01-01T00:00:00+00:00"
+PAST_DUE_AT = "2000-01-01T00:00:00+00:00"
 
 
 def _status_payload() -> dict:
@@ -143,6 +145,68 @@ def main() -> None:
     assert (
         "work_lane_contract: lane=reassignment_required next=advancement_task" in markdown
     ), markdown
+
+    due_monitor_text = (
+        "[P2] Monitor the todo succession contract and reschedule after checking."
+    )
+    external_action = (
+        "Monitor public run_group compact artifacts until the batch closes."
+    )
+    due_guard = build_quota_should_run(
+        quota_status_payload(
+            goal_id=GOAL_ID,
+            status="side_agent_due_monitor_with_other_claimed_frontier",
+            recommended_action=external_action,
+            next_action=external_action,
+            claim_scope_agent_id=SIDE_AGENT,
+            coordination={
+                "agent_model": "peer_v1",
+                "registered_agents": [PRIMARY_AGENT, SIDE_AGENT],
+            },
+            agent_todo_items=[
+                {
+                    "index": 1,
+                    "text": due_monitor_text,
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P2",
+                    "task_class": "continuous_monitor",
+                    "action_kind": "todo_succession_contract_monitor",
+                    "claimed_by": SIDE_AGENT,
+                    "todo_id": "todo_side_due_monitor",
+                    "target_key": "todo-succession-contract",
+                    "cadence": "1d",
+                    "next_due_at": PAST_DUE_AT,
+                },
+                {
+                    "index": 2,
+                    "text": external_action,
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P0",
+                    "task_class": "advancement_task",
+                    "claimed_by": PRIMARY_AGENT,
+                    "todo_id": "todo_primary_external_run",
+                },
+            ],
+        ),
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert due_guard["decision"] == "observe", due_guard
+    assert due_guard["should_run"] is True, due_guard
+    assert due_guard["effective_action"] == "external_evidence_observe", due_guard
+    assert "agent_scope_frontier" not in due_guard, due_guard
+    due_lane = due_guard["work_lane_contract"]
+    assert due_lane["lane"] == "continuous_monitor", due_lane
+    assert due_lane["monitor_kind"] == "external_evidence", due_lane
+    assert due_lane["obligation"] == "observe_external_evidence_or_blocker", due_lane
+    assert due_lane["selected_todo_id"] == "todo_side_due_monitor", due_lane
+    assert due_guard["selected_todo"]["todo_id"] == "todo_side_due_monitor", due_guard
+    assert (
+        "Monitor the todo succession contract"
+        in due_guard["interaction_contract"]["agent_channel"]["primary_action"]
+    ), due_guard
     print("agent-scope-work-lane-consistency-smoke ok")
 
 

--- a/loopx/control_plane/work_items/work_lane.py
+++ b/loopx/control_plane/work_items/work_lane.py
@@ -11,6 +11,9 @@ WORK_LANE_CURRENT_AGENT_MONITOR_REPAIR_OBLIGATIONS = {
     "repair_monitor_schedule_metadata",
     "repair_resume_gate_or_close_standing_monitor",
 }
+WORK_LANE_EXTERNAL_EVIDENCE_OBSERVATION_OBLIGATION = (
+    "observe_external_evidence_or_blocker"
+)
 WORK_LANE_TODO_MONITOR_DUE_KIND = "todo_monitor_due"
 WORK_LANE_TODO_ITEM_FIELDS = (
     "index",
@@ -85,7 +88,13 @@ def work_lane_contract_requires_current_agent_attempt(
     if contract.get("must_attempt_work") is not True:
         return False
     obligation = str(contract.get("obligation") or "")
-    return obligation in WORK_LANE_CURRENT_AGENT_MONITOR_REPAIR_OBLIGATIONS
+    if obligation in WORK_LANE_CURRENT_AGENT_MONITOR_REPAIR_OBLIGATIONS:
+        return True
+    return bool(
+        obligation == WORK_LANE_EXTERNAL_EVIDENCE_OBSERVATION_OBLIGATION
+        and contract.get("selected_todo_id")
+        and int(contract.get("monitor_due_count") or 0) > 0
+    )
 
 
 def work_lane_contract_is_due_monitor_attempt(
@@ -221,7 +230,7 @@ def build_work_lane_contract(
                 contract["outcome_followthrough"] = outcome_followthrough
             return contract
         if external_poll_signal:
-            return {
+            contract = {
                 "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,
                 "lane": "continuous_monitor",
                 "monitor_kind": "external_evidence",
@@ -235,6 +244,19 @@ def build_work_lane_contract(
                     "write a compact blocker instead of rerunning launched work"
                 ),
             }
+            if first_due_monitor:
+                contract.update(
+                    {
+                        "monitor_due_count": max(0, int(monitor_due_count)),
+                        "monitor_due_items": _compact_work_lane_todo_items(
+                            due_monitor_items,
+                            limit=monitor_due_item_limit,
+                        ),
+                        "selected_todo_id": first_due_monitor.get("todo_id"),
+                        "selected_next_due_at": first_due_monitor.get("next_due_at"),
+                    }
+                )
+            return contract
         if resume_blocked_by_monitor_count > 0 and not first_due_monitor:
             selected = blocked_by_monitor_items[0] if blocked_by_monitor_items else {}
             reason_codes = ["resume_blocked_by_open_monitor"]


### PR DESCRIPTION
## Summary
- preserve explicit due-monitor identity when an implicit external-evidence signal is also present
- prevent peer reassignment from suppressing a current-agent due monitor
- keep other-agent claimed monitors diagnostic-only through the existing claim-scope filter

## Validation
- agent-scope-work-lane-consistency-smoke
- external-evidence-observation-smoke
- work-lane-contract-smoke
- private-boundary-monitor-priority-smoke
- Python compile and diff checks
- LoopX premerge canary: 17 selected checks passed, 0 failures, no manual holds

## Boundary
Public runtime code and one durable regression smoke only. No private state, logs, local paths, credentials, or benchmark evidence are included.