### PR TITLE
fix(issue-fix): persist explicit reviewer receipts

### DIFF
--- a/examples/issue-fix-reviewer-request-smoke.py
+++ b/examples/issue-fix-reviewer-request-smoke.py
@@ -996,6 +996,52 @@ def main() -> int:
         )
         assert stored_lifecycle["reviewer_notification_receipts"] == [receipt]
         assert stored_lifecycle["maintainer_correction_body_captured"] is False
+        explicit_scoped_cli = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--registry",
+                str(registry),
+                "--format",
+                "json",
+                "issue-fix",
+                "reviewer-request",
+                "--url",
+                "https://github.com/owner/repo/pull/42",
+                "--repo-path",
+                str(path),
+                "--base-ref",
+                "main",
+                "--changed-file",
+                "src/map_only.py",
+                "--exclude-reviewer",
+                "@fallback-owner",
+                "--reviewer-sources-json",
+                str(reviewer_sources_path),
+                "--metadata-json",
+                str(metadata_path),
+                "--notification-sinks-json",
+                str(goal_config_path),
+                "--goal-id",
+                goal_id,
+                "--project",
+                str(path),
+            ],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        explicit_scoped_packet = json.loads(explicit_scoped_cli.stdout)
+        assert explicit_scoped_packet["secondary_notification_source"] == "explicit"
+        assert (
+            explicit_scoped_packet["secondary_notification_status"]
+            == "already_notified"
+        )
+        assert explicit_scoped_packet["external_writes_performed"] is False
+        assert_public_safe(explicit_scoped_packet)
         unsafe_lifecycle = json.loads(json.dumps(stored_lifecycle))
         unsafe_lifecycle["maintainer_correction_body_captured"] = True
         try:

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -274,7 +274,7 @@ def _load_goal_for_project(
         goal_repo = str(goal.get("repo") or "").strip()
         if not goal_repo:
             raise ValueError(
-                "connected goal repository is required for goal-default "
+                "connected goal repository is required for goal-scoped "
                 "reviewer notification"
             )
         if Path(goal_repo).expanduser().resolve() == requested_project:
@@ -284,10 +284,10 @@ def _load_goal_for_project(
     if mismatched_goal:
         raise ValueError(
             "--project must match the connected goal repository for "
-            "goal-default reviewer notification"
+            "goal-scoped reviewer notification"
         )
     raise ValueError(
-        "goal-default reviewer notification goal was not found in the active "
+        "goal-scoped reviewer notification goal was not found in the active "
         "or project-local registry"
     )
 
@@ -1537,18 +1537,22 @@ def handle_issue_fix_command(
             notification_lifecycle_packet: dict[str, Any] | None = None
             notification_lifecycle_path: Path | None = None
             notification_lifecycle_materialized = False
-            if notification_sinks_input is None and args.goal_id:
+            if args.goal_id:
                 goal, requested_project = _load_goal_for_project(
                     registry_path=registry_path,
                     goal_id=args.goal_id,
                     project=args.project,
                 )
-                notification_sinks_input = load_goal_reviewer_notification_sinks_input(
-                    goal=goal,
-                    project=requested_project,
-                )
+                if notification_sinks_input is None:
+                    notification_sinks_input = (
+                        load_goal_reviewer_notification_sinks_input(
+                            goal=goal,
+                            project=requested_project,
+                        )
+                    )
                 if notification_sinks_input is not None:
-                    notification_sinks_source = "goal_default"
+                    if notification_sinks_source == "not_configured":
+                        notification_sinks_source = "goal_default"
                     reference = normalise_github_issue_reference(
                         repo="public_repo_fixture",
                         issue_ref="pull_request_fixture",
@@ -1556,11 +1560,11 @@ def handle_issue_fix_command(
                     )
                     if reference.get("kind") != "pull_request":
                         raise ValueError(
-                            "goal-default reviewer notification requires a GitHub PR"
+                            "goal-scoped reviewer notification requires a GitHub PR"
                         )
                     notification_lifecycle_path = (
                         default_issue_fix_domain_state_ledger_path(
-                            project=args.project,
+                            project=requested_project,
                             goal_id=args.goal_id,
                         )
                     )
@@ -1584,7 +1588,7 @@ def handle_issue_fix_command(
                                 )
                             except (OSError, RuntimeError, ValueError):
                                 raise ValueError(
-                                    "goal-default reviewer notification could not "
+                                    "goal-scoped reviewer notification could not "
                                     "materialize a verified PR lifecycle row before "
                                     "external send"
                                 ) from None
@@ -1638,7 +1642,6 @@ def handle_issue_fix_command(
             )
             if (
                 args.execute
-                and notification_sinks_source == "goal_default"
                 and notification_lifecycle_packet is not None
                 and notification_lifecycle_path is not None
                 and new_receipts


### PR DESCRIPTION
## 为什么要修

当调用方显式传入本地私有 reviewer notification sink，同时也提供 `--goal-id/--project` 时，通知会成功发送，但 verified receipt 不会写入该 PR 的 lifecycle ledger。跨进程重试因此可能再次通知同一 reviewer。

## 改动思路

显式 sink 继续保持本地私有输入；只要调用已经绑定有效 goal/project，就让它与 goal-default sink 一样复用该 goal 的 PR lifecycle receipt。没有 goal 的独立 preview 行为不变。

## 具体改动

- goal-scoped reviewer request 对显式 sink 也加载并合并已有 lifecycle receipts。
- verified secondary receipt 的持久化不再依赖 sink 来源必须为 `goal_default`。
- 将相关错误文案从 goal-default 收窄语义调整为 goal-scoped。
- 增加 provider-neutral CLI smoke，证明显式 sink 能读取 lifecycle receipt，并在重试时返回 `already_notified`、零外部写。

## 验证

- `python3 examples/issue-fix-reviewer-request-smoke.py`
- `python3 -m py_compile loopx/capabilities/issue_fix/cli.py examples/issue-fix-reviewer-request-smoke.py`
- `python3 -m loopx.cli check --scan-path ...`：8 checks，0 errors/warnings
- `python3 -m loopx.cli canary premerge --from-git-diff`：9 selected checks 全部通过，0 failures，self-merge allowed
- `git diff --check`

## 风险与未覆盖

改动只影响同时提供 notification sink 与 goal/project lifecycle 的路径，不改变 reviewer 选择、provider payload、权限边界或无 goal 的独立调用。receipt 仍只保存 SHA-256 key，不保存群、成员或凭据。