### PR TITLE
Fix SkillsBench stale pre-bridge goal recovery

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -750,6 +750,51 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
         )
         == "pre_bridge_tui_error_prompt"
     )
+    stale_goal_failed_scrollback = "\n".join(
+        [
+            "Goal active",
+            "Goal failed",
+            *[f"historical tui line {index}" for index in range(50)],
+            "› ",
+        ]
+    )
+    assert (
+        codex_cli_tui_pre_bridge_blocker_stage(
+            stale_goal_failed_scrollback,
+            prompt_visible=True,
+        )
+        == ""
+    )
+    assert (
+        codex_cli_tui_pre_bridge_blocker_stage(
+            stale_goal_failed_scrollback,
+            prompt_visible=True,
+            terminal_observed=True,
+        )
+        == "pre_bridge_tui_stale_terminal"
+    )
+    assert (
+        codex_cli_tui_pre_bridge_terminal_stage(
+            stale_goal_failed_scrollback,
+            prompt_visible=True,
+        )
+        == "pre_bridge_tui_stale_terminal"
+    )
+    assert (
+        codex_cli_tui_pre_bridge_recovery_action(
+            stale_goal_failed_scrollback,
+            stage="pre_bridge_tui_stale_terminal",
+        )
+        == "typed_goal_resubmit"
+    )
+    assert (
+        codex_cli_tui_pre_bridge_recovery_skip_reason(
+            stale_goal_failed_scrollback,
+            stage="pre_bridge_tui_stale_terminal",
+            recovery_action="typed_goal_resubmit",
+        )
+        == ""
+    )
     assert (
         codex_cli_tui_pre_bridge_blocker_stage(
             "Goal active\nGoal failed\n› ",
@@ -1493,6 +1538,8 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "kickoff_submitted=goal_kickoff_prompt_submitted" in source
     assert "text=CODEX_CLI_GOAL_KICKOFF_PROMPT" in source
     assert "goal_failed_now = False" in source
+    assert source.count("goal_kickoff_prompt_submitted = False") >= 2
+    assert "terminal_observed=goal_failed_now" in source
     assert "goal_kickoff_prompt_raw_text_recorded" in source
     assert source.count("codex_cli_goal_watchdog_expired(") == 2
     assert "and not turn_active" in source

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -1323,16 +1323,14 @@ class SkillsBenchLocalAcpRelay:
                             "codex_cli_goal_" + retryable_startup_blocker_stage
                         )
                     pre_bridge_blocker_stage = ""
-                    if (
-                        bridge_summary_path is not None
-                        and not first_action_seen
-                    ):
+                    if bridge_summary_path is not None and not first_action_seen:
                         pre_bridge_blocker_stage = (
                             codex_cli_tui_pre_bridge_blocker_stage(
                                 capture,
                                 prompt_visible=(
                                     codex_cli_tui_input_prompt_visible(capture)
                                 ),
+                                terminal_observed=goal_failed_now,
                             )
                         )
                     if pre_bridge_blocker_stage:
@@ -1352,6 +1350,7 @@ class SkillsBenchLocalAcpRelay:
                             if recovery_action == "press_enter":
                                 tmux_submit_enter(tmux_name)
                             else:
+                                goal_kickoff_prompt_submitted = False
                                 tmux_type_text_and_submit(
                                     tmux_name=tmux_name,
                                     text=goal_command_text,

--- a/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
+++ b/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
@@ -103,6 +103,7 @@ def codex_cli_tui_pre_bridge_blocker_stage(
     capture: str,
     *,
     prompt_visible: bool,
+    terminal_observed: bool = False,
 ) -> str:
     """Classify public-safe Codex CLI TUI blockers before bridge activity."""
 
@@ -114,6 +115,8 @@ def codex_cli_tui_pre_bridge_blocker_stage(
         return "pre_bridge_tui_model_timeout"
     if _capture_has_error_marker(capture):
         return "pre_bridge_tui_error_prompt"
+    if terminal_observed and ("Goal failed" in capture or "Goal blocked" in capture):
+        return "pre_bridge_tui_stale_terminal"
     return ""
 
 
@@ -123,6 +126,7 @@ def codex_cli_tui_pre_bridge_recovery_action(capture: str, *, stage: str) -> str
     if stage not in {
         "pre_bridge_tui_model_timeout",
         "pre_bridge_tui_error_prompt",
+        "pre_bridge_tui_stale_terminal",
     }:
         return ""
     if stage == "pre_bridge_tui_error_prompt" and codex_cli_tui_input_prompt_visible(
@@ -151,6 +155,7 @@ def codex_cli_tui_pre_bridge_recovery_skip_reason(
     if stage not in {
         "pre_bridge_tui_model_timeout",
         "pre_bridge_tui_error_prompt",
+        "pre_bridge_tui_stale_terminal",
     }:
         return ""
     if not _capture_has_retry_affordance(capture) and not codex_cli_tui_input_prompt_visible(
@@ -175,6 +180,8 @@ def codex_cli_tui_pre_bridge_terminal_stage(
         return "pre_bridge_tui_model_timeout"
     if _capture_has_error_marker(capture):
         return "pre_bridge_tui_error_prompt"
+    if "Goal failed" in capture or "Goal blocked" in capture:
+        return "pre_bridge_tui_stale_terminal"
     return ""
 
 


### PR DESCRIPTION
## Summary
- classify a terminal Goal failed marker outside the recent TUI error window as a stale pre-bridge terminal
- boundedly resubmit /goal and reset kickoff state before declaring the case uncountable
- cover stale scrollback classification, recovery action, and relay wiring in the focused route smoke

## Validation
- python3 examples/skillsbench-codex-cli-goal-route-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- python3 -m py_compile on all three changed Python files
- loopx canary premerge --from-git-diff: direct checks, 6 catalog canaries, and public boundary passed

## Boundary
- no scoring, task semantics, credentials, raw trajectories, verifier tails, or private paths changed
- benchmark-sensitive manual hold reviewed under the existing owner authorization for benchmark self-merge
- live reproduction was public compact only: kickoff submitted and goal active observed, but Goal failed was seen from scrollback with zero bridge requests and no recent timeout, rate-limit, retry, or error marker