### PR TITLE
feat(issue-fix): project attributed impact metrics

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -341,6 +341,7 @@ tests whether the system is a durable employee rather than a scripted demo.
 | Reviewer notification | `loopx issue-fix reviewer-request` | Under standing authority, exclude the live PR author and existing coverage, request the top candidate, fall back to one verified `@reviewer` comment only on permission denial, and avoid duplicates. |
 | PR lifecycle | `loopx issue-fix pr-lifecycle` | Project CI, review, merge state, draft, merged, and closed signals into monitor transitions. |
 | Maintainer correction | `loopx issue-fix pr-lifecycle --maintainer-correction-json ... --execute-transition` | Turn bounded public review feedback into one claimed patch successor, a concrete user gate, or a quiet unchanged poll. |
+| Metrics projection | [`loopx issue-fix metrics`](protocols/issue-fix-metrics-projection-v0.md) | Keep repository baseline separate from attributable agent output, combine existing feasibility/PR lifecycle rows with caller-supplied public snapshots, and report deltas, ratios, inventory, and missing data without another ledger. |
 | Acceptance fixture | `loopx issue-fix acceptance-fixture` | Prove failure-before, minimal patch, and pass-after in a deterministic fixture. |
 | Git branch fixture | `loopx issue-fix repo-branch-fixture` | Exercise the same repair contract through a temporary git branch. |
 | Caller repo branch | `loopx issue-fix caller-repo-branch` | Inspect an approved local repo, create/claim an issue branch, and run caller-declared validation. |
@@ -492,8 +493,8 @@ the current repository revision remains authoritative.
   default enablement or session-memory expansion;
 - Open Knowledge Format interoperability after the repository-context contract
   stabilizes;
-- project-level metrics for accepted fixes, cycle time, human attention,
-  regressions, and boundary incidents.
+- automated daily public snapshot collection and monthly Kanban/dashboard rollup
+  for the implemented provider-neutral metrics projection.
 
 ## Success Metrics
 
@@ -509,6 +510,15 @@ Track outcomes, not agent activity:
 - unchanged monitor polls skipped;
 - public/private boundary incidents;
 - LoopX generic gaps fixed or converted into concrete claimed todos.
+
+`loopx issue-fix metrics` is the read-only reporting seam for these measures.
+The period-start repository snapshot describes repository stock only; agent
+output starts at zero and is attributed from the goal's existing feasibility
+and PR lifecycle rows. The current public snapshot supplies repository flow and
+may refresh current PR/issue state without rewriting lifecycle history. Optional
+supplement counts cover evidence that is not yet native to those rows, such as
+human interventions, first-push CI, capability deltas, and memory leverage.
+Absent evidence is emitted as `not_available` plus a reason code, never as zero.
 
 ## Conversational `/loopx` Entry
 
@@ -762,6 +772,16 @@ loopx issue-fix feasibility \
   --goal-id example-goal \
   --format json
 
+# Project repository impact and attributed outputs without writing state.
+loopx issue-fix metrics \
+  --goal-id public-issue-fix-goal \
+  --project /path/to/connected/project \
+  --repo owner/repo \
+  --repository-baseline-json baseline.json \
+  --repository-current-json current.json \
+  --supplement-json optional-public-counts.json \
+  --format json
+
 # Recommend reviewers without requesting external review.
 loopx issue-fix reviewer-plan \
   --repo-path /path/to/approved/repo \
@@ -822,6 +842,7 @@ python3 examples/issue-fix-repository-memory-smoke.py
 python3 examples/issue-fix-validated-memory-writeback-smoke.py
 python3 examples/issue-fix-feasibility-smoke.py
 python3 examples/issue-fix-pr-lifecycle-smoke.py
+python3 examples/issue-fix-metrics-projection-smoke.py
 python3 examples/issue-fix-maintainer-correction-smoke.py
 python3 examples/issue-fix-outcome-projection-smoke.py
 python3 examples/issue-fix-acceptance-loop-smoke.py

--- a/docs/capabilities/issue-fix/README.zh-CN.md
+++ b/docs/capabilities/issue-fix/README.zh-CN.md
@@ -353,6 +353,7 @@ state 仍优先于迟到反馈。
 | Reviewer notification | `loopx issue-fix reviewer-request` | 在持续 authority 下排除 live PR author 与已有覆盖，优先正式邀请；仅在权限不足时降级为一条经回读验证的 `@reviewer` comment，并保证重试不重复。 |
 | PR lifecycle | `loopx issue-fix pr-lifecycle` | 把 CI、review、merge state、draft、merged、closed 信号投影为 monitor transition。 |
 | Maintainer correction | `loopx issue-fix pr-lifecycle --maintainer-correction-json ... --execute-transition` | 把有限公开反馈转成一个已认领 patch successor、具体 user gate，或安静的 unchanged poll。 |
+| 指标投影 | [`loopx issue-fix metrics`](protocols/issue-fix-metrics-projection-v0.md) | 严格区分仓库存量基线与 agent 可归因产出；组合现有 feasibility/PR lifecycle 行和调用方提供的公开快照，输出 delta、比例、产出清单与缺失数据，不新增 ledger。 |
 | Acceptance fixture | `loopx issue-fix acceptance-fixture` | 在 deterministic fixture 中证明 failure-before、minimal patch、pass-after。 |
 | Git branch fixture | `loopx issue-fix repo-branch-fixture` | 在临时 git branch 中运行同一修复 contract。 |
 | Caller repo branch | `loopx issue-fix caller-repo-branch` | 检查获批本地 repo、创建/认领 issue branch、运行 caller-declared validation。 |
@@ -491,7 +492,8 @@ revision 仍是事实源。
 - 跨多个重复 issue 评估 validated-outcome memory 的实际价值，再决定是否默认开启或扩展到
   session memory；
 - repository-context contract 稳定后的 Open Knowledge Format 互操作；
-- accepted fix、cycle time、human attention、regression、boundary incident 等项目级指标。
+- 在已实现的 provider-neutral 指标投影之上，自动采集每日公开快照并生成月度
+  Kanban/dashboard rollup。
 
 ## 成功指标
 
@@ -510,6 +512,12 @@ revision 仍是事实源。
 - 跳过的 unchanged monitor poll；
 - public/private boundary incident；
 - pilot 暴露的通用 LoopX gap 是否修复或转成具体 claimed todo。
+
+`loopx issue-fix metrics` 是这些指标的只读汇总边界。期初仓库快照只描述仓库
+存量；agent 产出从 0 开始，由当前 goal 已有的 feasibility 和 PR lifecycle 行归因。
+当前公开快照提供仓库流量，也可以刷新 PR/issue 的当前状态，但不会改写 lifecycle
+历史。可选 supplement 补充人工介入、首次 push CI、能力增量、memory 利用等尚未
+原生进入这些行的公开计数。证据缺失时输出 `not_available` 和原因码，绝不偷填 0。
 
 ## 对话式 `/loopx` 入口
 
@@ -730,6 +738,16 @@ loopx issue-fix feasibility \
   --goal-id example-goal \
   --format json
 
+# 只读投影仓库影响与可归因产出，不写入新状态。
+loopx issue-fix metrics \
+  --goal-id public-issue-fix-goal \
+  --project /path/to/connected/project \
+  --repo owner/repo \
+  --repository-baseline-json baseline.json \
+  --repository-current-json current.json \
+  --supplement-json optional-public-counts.json \
+  --format json
+
 # 推荐 reviewer，但不发送外部 review request。
 loopx issue-fix reviewer-plan \
   --repo-path /path/to/approved/repo \
@@ -790,6 +808,7 @@ python3 examples/issue-fix-repository-memory-smoke.py
 python3 examples/issue-fix-validated-memory-writeback-smoke.py
 python3 examples/issue-fix-feasibility-smoke.py
 python3 examples/issue-fix-pr-lifecycle-smoke.py
+python3 examples/issue-fix-metrics-projection-smoke.py
 python3 examples/issue-fix-maintainer-correction-smoke.py
 python3 examples/issue-fix-outcome-projection-smoke.py
 python3 examples/issue-fix-acceptance-loop-smoke.py

--- a/docs/capabilities/issue-fix/protocols/issue-fix-metrics-projection-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-metrics-projection-v0.md
@@ -1,0 +1,106 @@
+# Issue-Fix Metrics Projection v0
+
+## Purpose
+
+`loopx issue-fix metrics` produces a read-only reporting packet for a long-running
+issue-fix goal. It answers two different questions without mixing them:
+
+1. how the public repository changed during the reporting window; and
+2. what outputs are attributable to the connected issue-fix goal.
+
+The command derives agent output from the goal's existing feasibility and PR
+lifecycle domain state. It does not create a metrics ledger or lifecycle state
+machine.
+
+## Repository snapshot input
+
+Both period-start and current inputs use
+`issue_fix_repository_reporting_snapshot_v0`:
+
+```json
+{
+  "schema_version": "issue_fix_repository_reporting_snapshot_v0",
+  "repo": "owner/repo",
+  "captured_at": "2026-08-01T00:00:00Z",
+  "open_issues": 42,
+  "open_pull_requests": 17
+}
+```
+
+The current snapshot additionally requires `flow_since_baseline`:
+
+```json
+{
+  "flow_since_baseline": {
+    "issues_opened": 8,
+    "issues_closed": 6,
+    "pull_requests_opened": 12,
+    "pull_requests_closed": 10,
+    "pull_requests_merged": 9
+  }
+}
+```
+
+LoopX rejects a snapshot unless both stock equations reconcile:
+
+```text
+baseline open + opened - closed = current open
+```
+
+Optional `issue_states` and `pull_request_states` contain compact public current
+state. They let the projection compute issue-close attribution and refresh stale
+PR state without rewriting lifecycle history. Every output inventory row records
+whether its current state came from the lifecycle ledger or the newer repository
+snapshot.
+
+## Supplemental counts
+
+`issue_fix_metrics_supplement_v0` can supply public-safe counts that are not yet
+native to feasibility or PR lifecycle rows:
+
+```json
+{
+  "schema_version": "issue_fix_metrics_supplement_v0",
+  "counts": {
+    "human_interventions": 2,
+    "first_push_ci_passed": 5,
+    "first_push_ci_total": 7,
+    "loopx_capability_gaps_found": 3,
+    "loopx_capability_gaps_fixed": 2,
+    "memory_retrievals": 4,
+    "memory_verified_patch_influence": 1
+  }
+}
+```
+
+This is an allowlisted compact input, not a raw provider payload. Missing counts
+remain `null` and produce a `missing_data` reason code. A missing measure is never
+coerced to zero.
+
+## Attribution contract
+
+- The repository baseline contains repository stock only.
+- Agent output at the goal-start baseline is zero.
+- Feasibility rows provide selected issues and route counts.
+- PR lifecycle rows provide the attributable PR inventory, links, receipts, and
+  last persisted state.
+- A newer current public snapshot may refresh state but cannot add an
+  unattributed PR to the inventory.
+- Repository shares use explicit numerators and denominators, so a ratio is
+  `not_available` when its denominator is zero or evidence is missing.
+- Open PRs are work in progress, not terminal outcomes.
+
+## Boundary contract
+
+The projection performs no network read and no external write. Inputs are
+caller-supplied compact public metadata. Output excludes local paths, credentials,
+raw issue bodies, comments, provider responses, transcripts, and tool logs.
+
+Daily public snapshot collection and Kanban/dashboard rendering are separate
+adapters over this packet. They must not become a second source of truth.
+
+## Validation
+
+```bash
+python3 examples/issue-fix-metrics-projection-smoke.py
+```

--- a/examples/issue-fix-metrics-projection-smoke.py
+++ b/examples/issue-fix-metrics-projection-smoke.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Contract smoke for provider-neutral issue-fix monthly metrics projection."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_json(path: Path, value: dict[str, object]) -> None:
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    repo = "public-fixture/widgets"
+    with tempfile.TemporaryDirectory(prefix="loopx-issue-fix-metrics-") as tmp:
+        root = Path(tmp)
+        baseline = root / "baseline.json"
+        current = root / "current.json"
+        supplement = root / "supplement.json"
+        feasibility = root / "feasibility.jsonl"
+        lifecycle = root / "pr-lifecycle.jsonl"
+
+        _write_json(
+            baseline,
+            {
+                "schema_version": "issue_fix_repository_reporting_snapshot_v0",
+                "repo": repo,
+                "captured_at": "2026-07-01T00:00:00Z",
+                "open_issues": 10,
+                "open_pull_requests": 4,
+            },
+        )
+        _write_json(
+            current,
+            {
+                "schema_version": "issue_fix_repository_reporting_snapshot_v0",
+                "repo": repo,
+                "captured_at": "2026-08-01T00:00:00Z",
+                "open_issues": 12,
+                "open_pull_requests": 5,
+                "flow_since_baseline": {
+                    "issues_opened": 5,
+                    "issues_closed": 3,
+                    "pull_requests_opened": 4,
+                    "pull_requests_closed": 3,
+                    "pull_requests_merged": 2,
+                },
+                "issue_states": [
+                    {"issue_ref": "issues_42", "state": "CLOSED"},
+                    {"issue_ref": "issues_43", "state": "OPEN"},
+                ],
+                "pull_request_states": [
+                    {
+                        "pr_ref": "pull_77",
+                        "state": "MERGED",
+                        "ci": "PASSING",
+                        "review": "APPROVED",
+                    },
+                    {
+                        "pr_ref": "pull_78",
+                        "state": "OPEN",
+                        "ci": "PASSING",
+                        "review": "REVIEW_REQUIRED",
+                    },
+                ],
+            },
+        )
+        _write_json(
+            supplement,
+            {
+                "schema_version": "issue_fix_metrics_supplement_v0",
+                "counts": {
+                    "human_interventions": 1,
+                    "first_push_ci_passed": 1,
+                    "first_push_ci_total": 2,
+                    "loopx_capability_gaps_found": 2,
+                    "memory_retrievals": 3,
+                },
+            },
+        )
+        _write_jsonl(
+            feasibility,
+            [
+                {
+                    "generated_at": "2026-07-02T00:00:00Z",
+                    "observation": {"repo": repo, "issue_ref": "issues_42"},
+                    "decision": {"route": "fix_pr"},
+                    "delivery_evidence": {"validation_status": "passed"},
+                },
+                {
+                    "generated_at": "2026-07-03T00:00:00Z",
+                    "observation": {"repo": repo, "issue_ref": "issues_43"},
+                    "decision": {"route": "fix_pr"},
+                    "delivery_evidence": {"validation_status": "passed"},
+                },
+            ],
+        )
+        _write_jsonl(
+            lifecycle,
+            [
+                {
+                    "generated_at": "2026-07-04T00:00:00Z",
+                    "observation": {
+                        "repo": repo,
+                        "pr_ref": "pull_77",
+                        "issue_ref": "issues_42",
+                        "permalink": (
+                            "https://github.com/public-fixture/widgets/pull/77"
+                        ),
+                        "state": "MERGED",
+                        "checks": {"aggregate": "PASSING"},
+                        "review_decision": "APPROVED",
+                    },
+                    "reviewer_notification_receipts": ["sha256:" + "a" * 64],
+                },
+                {
+                    "generated_at": "2026-07-05T00:00:00Z",
+                    "observation": {
+                        "repo": repo,
+                        "pr_ref": "pull_78",
+                        "issue_ref": "issues_43",
+                        "permalink": (
+                            "https://github.com/public-fixture/widgets/pull/78"
+                        ),
+                        "state": "OPEN",
+                        "checks": {"aggregate": "PASSING"},
+                        "review_decision": "REVIEW_REQUIRED",
+                    },
+                },
+            ],
+        )
+
+        command = [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "issue-fix",
+            "metrics",
+            "--goal-id",
+            "fixture-goal",
+            "--project",
+            str(root),
+            "--repo",
+            repo,
+            "--repository-baseline-json",
+            str(baseline),
+            "--repository-current-json",
+            str(current),
+            "--supplement-json",
+            str(supplement),
+            "--feasibility-ledger",
+            str(feasibility),
+            "--pr-lifecycle-ledger",
+            str(lifecycle),
+            "--generated-at",
+            "2026-08-01T00:01:00Z",
+        ]
+        result = subprocess.run(
+            command,
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        packet = json.loads(result.stdout)
+        assert packet["ok"] is True, packet
+        assert packet["baseline"]["agent_output"]["pull_requests"] == 0, packet
+        output = packet["current"]["agent_output"]
+        assert output["pull_requests"] == 2, packet
+        assert output["merged_pull_requests"] == 1, packet
+        assert output["linked_issues_closed"] == 1, packet
+        assert output["pull_requests_refreshed_from_snapshot"] == 2, packet
+        assert output["stale_lifecycle_rows_corrected_by_snapshot"] == 0, packet
+        assert packet["delta"]["repository"]["open_issues"] == 2, packet
+        assert (
+            packet["ratios"]["pilot_share_of_repository_prs_opened"]["value"] == 0.5
+        ), packet
+        assert len(packet["output_inventory"]["pull_requests"]) == 2, packet
+        serialized = json.dumps(packet, sort_keys=True)
+        assert str(root) not in serialized, serialized
+        assert packet["external_writes_performed"] is False, packet
+
+        missing_current = json.loads(current.read_text(encoding="utf-8"))
+        missing_current.pop("issue_states")
+        missing_current.pop("pull_request_states")
+        _write_json(current, missing_current)
+        without_supplement = [
+            value
+            for value in command
+            if value not in {"--supplement-json", str(supplement)}
+        ]
+        missing = subprocess.run(
+            without_supplement,
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        missing_packet = json.loads(missing.stdout)
+        assert missing_packet["current"]["agent_output"]["linked_issues_closed"] is None
+        missing_codes = {item["code"] for item in missing_packet["missing_data"]}
+        assert "linked_issue_states_not_captured" in missing_codes, missing_packet
+        assert "human_interventions_not_captured" in missing_codes, missing_packet
+
+        bad_current = json.loads(current.read_text(encoding="utf-8"))
+        bad_current["open_issues"] = 99
+        _write_json(current, bad_current)
+        bad = subprocess.run(
+            command,
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        assert bad.returncode == 1, bad.stdout
+        assert "does not reconcile" in json.loads(bad.stdout)["error"], bad.stdout
+
+    print("issue-fix metrics projection smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -34,6 +34,10 @@ from .outcome_projection import (
     render_issue_fix_outcome_projection_markdown,
 )
 from .metadata_preview import normalise_github_issue_reference
+from .metrics_projection import (
+    build_issue_fix_metrics_projection,
+    render_issue_fix_metrics_projection_markdown,
+)
 from .pr_lifecycle import (
     build_issue_fix_pr_lifecycle_monitor_packet,
     render_issue_fix_pr_lifecycle_monitor_markdown,
@@ -227,6 +231,25 @@ def _load_jsonl_row(
             f"{path.name} has no row for repo={repo} {ref_field}={ref_value}"
         )
     return match
+
+
+def _load_jsonl_rows(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        raise ValueError(f"issue-fix domain-state source is missing: {path.name}")
+    rows: list[dict[str, Any]] = []
+    for line_number, line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{path.name}:{line_number} is not valid JSON") from exc
+        if not isinstance(row, dict):
+            raise ValueError(f"{path.name}:{line_number} must contain an object")
+        rows.append(row)
+    return rows
 
 
 def _goal_boundary_authority_projection(
@@ -720,6 +743,49 @@ def register_issue_fix_commands(
         help="Optional registered agent id projected as the case owner.",
     )
     _add_generated_at_arg(outcome_parser, artifact="the read model")
+    metrics_parser = issue_fix_sub.add_parser(
+        "metrics",
+        help=(
+            "Compose a read-only baseline, attributable output inventory, repository "
+            "delta, and missing-data projection from existing issue-fix domain state."
+        ),
+    )
+    add_subcommand_format(metrics_parser)
+    metrics_parser.add_argument("--goal-id", required=True)
+    metrics_parser.add_argument("--project", default=".")
+    metrics_parser.add_argument("--repo", required=True)
+    metrics_parser.add_argument(
+        "--repository-baseline-json",
+        required=True,
+        help="Public-safe issue_fix_repository_reporting_snapshot_v0 at period start.",
+    )
+    metrics_parser.add_argument(
+        "--repository-current-json",
+        required=True,
+        help=(
+            "Public-safe issue_fix_repository_reporting_snapshot_v0 at current time, "
+            "including flow_since_baseline."
+        ),
+    )
+    metrics_parser.add_argument(
+        "--supplement-json",
+        default=None,
+        help=(
+            "Optional public-safe issue_fix_metrics_supplement_v0 for autonomy, "
+            "first-push CI, memory, and capability-delta counts."
+        ),
+    )
+    metrics_parser.add_argument(
+        "--feasibility-ledger",
+        default=None,
+        help="Optional feasibility JSONL override; defaults to goal domain state.",
+    )
+    metrics_parser.add_argument(
+        "--pr-lifecycle-ledger",
+        default=None,
+        help="Optional PR lifecycle JSONL override; defaults to goal domain state.",
+    )
+    _add_generated_at_arg(metrics_parser, artifact="the metrics projection")
     reviewer_parser = issue_fix_sub.add_parser(
         "reviewer-plan",
         help=(
@@ -1496,6 +1562,49 @@ def handle_issue_fix_command(
                 payload["domain_state_write"] = domain_state_write
                 payload["source_contract"]["writes_source_state"] = True
             renderer = render_issue_fix_outcome_projection_markdown
+        elif args.issue_fix_command == "metrics":
+            stdin_input_count = sum(
+                value == "-"
+                for value in (
+                    args.repository_baseline_json,
+                    args.repository_current_json,
+                    args.supplement_json,
+                )
+            )
+            if stdin_input_count > 1:
+                raise ValueError("only one metrics JSON input may read from stdin")
+            project = Path(args.project).expanduser()
+            feasibility_path = (
+                Path(args.feasibility_ledger).expanduser()
+                if args.feasibility_ledger
+                else default_issue_fix_feasibility_ledger_path(
+                    project=project,
+                    goal_id=args.goal_id,
+                )
+            )
+            lifecycle_path = (
+                Path(args.pr_lifecycle_ledger).expanduser()
+                if args.pr_lifecycle_ledger
+                else default_issue_fix_domain_state_ledger_path(
+                    project=project,
+                    goal_id=args.goal_id,
+                )
+            )
+            payload = build_issue_fix_metrics_projection(
+                goal_id=args.goal_id,
+                repo=args.repo,
+                baseline_snapshot=_load_json_object(args.repository_baseline_json),
+                current_snapshot=_load_json_object(args.repository_current_json),
+                feasibility_rows=_load_jsonl_rows(feasibility_path),
+                pr_lifecycle_rows=_load_jsonl_rows(lifecycle_path),
+                supplement_input=(
+                    _load_json_object(args.supplement_json)
+                    if args.supplement_json
+                    else None
+                ),
+                generated_at=generated_at,
+            )
+            renderer = render_issue_fix_metrics_projection_markdown
         elif args.issue_fix_command == "reviewer-plan":
             payload = build_issue_fix_reviewer_recommendation_packet(
                 repo_path=args.repo_path,
@@ -1706,7 +1815,7 @@ def handle_issue_fix_command(
         else:
             raise ValueError(
                 "issue-fix requires `repository-memory-sync`, `workflow-plan`, `feasibility`, "
-                "`acceptance-fixture`, `pr-lifecycle`, `outcome`, `reviewer-plan`, "
+                "`acceptance-fixture`, `pr-lifecycle`, `outcome`, `metrics`, `reviewer-plan`, "
                 "`reviewer-request`, "
                 "`repo-branch-fixture`, or `caller-repo-branch`"
             )
@@ -1727,6 +1836,8 @@ def handle_issue_fix_command(
             if getattr(args, "issue_fix_command", None) == "pr-lifecycle"
             else render_issue_fix_outcome_projection_markdown
             if getattr(args, "issue_fix_command", None) == "outcome"
+            else render_issue_fix_metrics_projection_markdown
+            if getattr(args, "issue_fix_command", None) == "metrics"
             else render_issue_fix_reviewer_recommendation_markdown
             if getattr(args, "issue_fix_command", None) == "reviewer-plan"
             else render_issue_fix_reviewer_request_markdown

--- a/loopx/capabilities/issue_fix/metrics_projection.py
+++ b/loopx/capabilities/issue_fix/metrics_projection.py
@@ -1,0 +1,575 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+
+SNAPSHOT_SCHEMA_VERSION = "issue_fix_repository_reporting_snapshot_v0"
+SUPPLEMENT_SCHEMA_VERSION = "issue_fix_metrics_supplement_v0"
+PROJECTION_SCHEMA_VERSION = "issue_fix_metrics_projection_v0"
+
+_FLOW_FIELDS = (
+    "issues_opened",
+    "issues_closed",
+    "pull_requests_opened",
+    "pull_requests_closed",
+    "pull_requests_merged",
+)
+_SUPPLEMENT_FIELDS = (
+    "human_interventions",
+    "automatic_terminal_closeouts",
+    "duplicate_external_writes",
+    "loopx_capability_gaps_found",
+    "loopx_capability_gaps_fixed",
+    "loopx_capability_gaps_real_callsite_verified",
+    "memory_retrievals",
+    "memory_verified_patch_influence",
+    "memory_stale_results",
+    "useful_public_comments",
+    "triage_outcomes",
+    "issues_screened",
+    "first_push_ci_passed",
+    "first_push_ci_total",
+)
+
+
+def _nonnegative_int(value: Any, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field} must be a non-negative integer")
+    return value
+
+
+def _timestamp(value: Any, *, field: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{field} is required")
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        raise ValueError(f"{field} must be an ISO-8601 timestamp") from None
+    if parsed.utcoffset() is None:
+        raise ValueError(f"{field} must include a timezone")
+    return text
+
+
+def _snapshot(
+    value: dict[str, Any],
+    *,
+    expected_repo: str,
+    role: str,
+) -> dict[str, Any]:
+    if value.get("schema_version") != SNAPSHOT_SCHEMA_VERSION:
+        raise ValueError(f"{role} snapshot must use {SNAPSHOT_SCHEMA_VERSION}")
+    repo = str(value.get("repo") or "").strip()
+    if repo != expected_repo:
+        raise ValueError(f"{role} snapshot repo must match --repo")
+    snapshot = {
+        "schema_version": SNAPSHOT_SCHEMA_VERSION,
+        "repo": repo,
+        "captured_at": _timestamp(
+            value.get("captured_at"), field=f"{role}.captured_at"
+        ),
+        "open_issues": _nonnegative_int(
+            value.get("open_issues"), field=f"{role}.open_issues"
+        ),
+        "open_pull_requests": _nonnegative_int(
+            value.get("open_pull_requests"),
+            field=f"{role}.open_pull_requests",
+        ),
+    }
+    health = value.get("health")
+    if health is not None:
+        if not isinstance(health, dict):
+            raise ValueError(f"{role}.health must be an object")
+        snapshot["health"] = {
+            str(key): _nonnegative_int(item, field=f"{role}.health.{key}")
+            for key, item in sorted(health.items())
+            if str(key).strip()
+        }
+    flow = value.get("flow_since_baseline")
+    if role == "current":
+        if not isinstance(flow, dict):
+            raise ValueError("current.flow_since_baseline must be an object")
+        snapshot["flow_since_baseline"] = {
+            field: _nonnegative_int(
+                flow.get(field), field=f"current.flow_since_baseline.{field}"
+            )
+            for field in _FLOW_FIELDS
+        }
+    elif flow:
+        raise ValueError("baseline snapshot must not include flow_since_baseline")
+    issue_states = value.get("issue_states")
+    if issue_states is not None:
+        if not isinstance(issue_states, list):
+            raise ValueError(f"{role}.issue_states must be a list")
+        compact_states: list[dict[str, Any]] = []
+        for index, item in enumerate(issue_states):
+            if not isinstance(item, dict):
+                raise ValueError(f"{role}.issue_states[{index}] must be an object")
+            issue_ref = str(item.get("issue_ref") or "").strip()
+            state = str(item.get("state") or "").strip().upper()
+            if not issue_ref or state not in {"OPEN", "CLOSED"}:
+                raise ValueError(
+                    f"{role}.issue_states[{index}] requires issue_ref and OPEN/CLOSED"
+                )
+            compact = {"issue_ref": issue_ref, "state": state}
+            if item.get("closed_at"):
+                compact["closed_at"] = _timestamp(
+                    item.get("closed_at"),
+                    field=f"{role}.issue_states[{index}].closed_at",
+                )
+            compact_states.append(compact)
+        snapshot["issue_states"] = compact_states
+    pull_request_states = value.get("pull_request_states")
+    if pull_request_states is not None:
+        if not isinstance(pull_request_states, list):
+            raise ValueError(f"{role}.pull_request_states must be a list")
+        compact_pr_states: list[dict[str, Any]] = []
+        for index, item in enumerate(pull_request_states):
+            if not isinstance(item, dict):
+                raise ValueError(
+                    f"{role}.pull_request_states[{index}] must be an object"
+                )
+            pr_ref = str(item.get("pr_ref") or "").strip()
+            state = str(item.get("state") or "").strip().upper()
+            ci = str(item.get("ci") or "UNKNOWN").strip().upper()
+            review = str(item.get("review") or "UNKNOWN").strip().upper()
+            if not pr_ref or state not in {"OPEN", "MERGED", "CLOSED"}:
+                raise ValueError(
+                    f"{role}.pull_request_states[{index}] requires pr_ref and "
+                    "OPEN/MERGED/CLOSED"
+                )
+            if ci not in {"PASSING", "FAILING", "PENDING", "UNKNOWN"}:
+                raise ValueError(f"{role}.pull_request_states[{index}].ci is invalid")
+            if review not in {
+                "APPROVED",
+                "CHANGES_REQUESTED",
+                "REVIEW_REQUIRED",
+                "UNKNOWN",
+            }:
+                raise ValueError(
+                    f"{role}.pull_request_states[{index}].review is invalid"
+                )
+            compact_pr = {
+                "pr_ref": pr_ref,
+                "state": state,
+                "ci": ci,
+                "review": review,
+            }
+            if item.get("updated_at"):
+                compact_pr["updated_at"] = _timestamp(
+                    item.get("updated_at"),
+                    field=f"{role}.pull_request_states[{index}].updated_at",
+                )
+            compact_pr_states.append(compact_pr)
+        snapshot["pull_request_states"] = compact_pr_states
+    return snapshot
+
+
+def _supplement(value: dict[str, Any] | None) -> dict[str, int | None]:
+    if value is None:
+        return {field: None for field in _SUPPLEMENT_FIELDS}
+    if value.get("schema_version") != SUPPLEMENT_SCHEMA_VERSION:
+        raise ValueError(f"supplement must use {SUPPLEMENT_SCHEMA_VERSION}")
+    counts = value.get("counts")
+    if not isinstance(counts, dict):
+        raise ValueError("supplement.counts must be an object")
+    return {
+        field: (
+            _nonnegative_int(counts[field], field=f"supplement.counts.{field}")
+            if field in counts
+            else None
+        )
+        for field in _SUPPLEMENT_FIELDS
+    }
+
+
+def _latest_rows(
+    rows: list[dict[str, Any]],
+    *,
+    repo: str,
+    ref_field: str,
+) -> list[dict[str, Any]]:
+    latest: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        observation = row.get("observation") if isinstance(row, dict) else None
+        if not isinstance(observation, dict):
+            continue
+        if str(observation.get("repo") or "").strip() != repo:
+            continue
+        reference = str(observation.get(ref_field) or "").strip()
+        if reference:
+            latest[reference] = row
+    return [latest[key] for key in sorted(latest)]
+
+
+def _ratio(numerator: int | None, denominator: int | None) -> dict[str, Any]:
+    if numerator is None or denominator is None or denominator == 0:
+        return {
+            "numerator": numerator,
+            "denominator": denominator,
+            "value": None,
+            "status": "not_available",
+        }
+    return {
+        "numerator": numerator,
+        "denominator": denominator,
+        "value": round(numerator / denominator, 4),
+        "status": "available",
+    }
+
+
+def build_issue_fix_metrics_projection(
+    *,
+    goal_id: str,
+    repo: str,
+    baseline_snapshot: dict[str, Any],
+    current_snapshot: dict[str, Any],
+    feasibility_rows: list[dict[str, Any]],
+    pr_lifecycle_rows: list[dict[str, Any]],
+    supplement_input: dict[str, Any] | None = None,
+    generated_at: str,
+) -> dict[str, Any]:
+    goal_id = str(goal_id or "").strip()
+    repo = str(repo or "").strip()
+    if not goal_id or not repo:
+        raise ValueError("goal_id and repo are required")
+    baseline = _snapshot(baseline_snapshot, expected_repo=repo, role="baseline")
+    current = _snapshot(current_snapshot, expected_repo=repo, role="current")
+    baseline_time = datetime.fromisoformat(
+        baseline["captured_at"].replace("Z", "+00:00")
+    )
+    current_time = datetime.fromisoformat(current["captured_at"].replace("Z", "+00:00"))
+    if current_time < baseline_time:
+        raise ValueError("current snapshot must not predate baseline snapshot")
+
+    flow = current["flow_since_baseline"]
+    expected_open_issues = (
+        baseline["open_issues"] + flow["issues_opened"] - flow["issues_closed"]
+    )
+    expected_open_prs = (
+        baseline["open_pull_requests"]
+        + flow["pull_requests_opened"]
+        - flow["pull_requests_closed"]
+    )
+    if expected_open_issues != current["open_issues"]:
+        raise ValueError(
+            "issue flow does not reconcile baseline and current open issues"
+        )
+    if expected_open_prs != current["open_pull_requests"]:
+        raise ValueError(
+            "pull request flow does not reconcile baseline and current open PRs"
+        )
+    if flow["pull_requests_merged"] > flow["pull_requests_closed"]:
+        raise ValueError("merged pull requests cannot exceed closed pull requests")
+
+    feasibility = _latest_rows(feasibility_rows, repo=repo, ref_field="issue_ref")
+    lifecycles = _latest_rows(pr_lifecycle_rows, repo=repo, ref_field="pr_ref")
+    for row in [*feasibility, *lifecycles]:
+        if not row.get("generated_at"):
+            continue
+        row_time = datetime.fromisoformat(
+            _timestamp(row["generated_at"], field="domain_state.generated_at").replace(
+                "Z", "+00:00"
+            )
+        )
+        if row_time < baseline_time:
+            raise ValueError(
+                "baseline snapshot must not postdate attributable issue-fix output"
+            )
+
+    route_counts = {"fix_pr": 0, "comment_only": 0, "triage_only": 0}
+    selected_issue_refs: set[str] = set()
+    validation_passed = 0
+    validation_missing = 0
+    for row in feasibility:
+        observation = row.get("observation") or {}
+        decision = row.get("decision") or {}
+        issue_ref = str(observation.get("issue_ref") or "").strip()
+        if issue_ref:
+            selected_issue_refs.add(issue_ref)
+        route = str(decision.get("route") or "").strip()
+        if route in route_counts:
+            route_counts[route] += 1
+        delivery = row.get("delivery_evidence")
+        validation = (
+            str(delivery.get("validation_status") or "").strip().lower()
+            if isinstance(delivery, dict)
+            else ""
+        )
+        if validation == "passed":
+            validation_passed += 1
+        elif route == "fix_pr":
+            validation_missing += 1
+
+    pr_inventory: list[dict[str, Any]] = []
+    pr_state_counts = {"OPEN": 0, "MERGED": 0, "CLOSED": 0}
+    ci_counts = {"PASSING": 0, "FAILING": 0, "PENDING": 0, "UNKNOWN": 0}
+    review_counts = {
+        "APPROVED": 0,
+        "CHANGES_REQUESTED": 0,
+        "REVIEW_REQUIRED": 0,
+        "UNKNOWN": 0,
+    }
+    receipt_rows = 0
+    snapshot_refreshes = 0
+    snapshot_corrections = 0
+    linked_issue_refs: set[str] = set()
+    current_pr_states = {
+        item["pr_ref"]: item for item in current.get("pull_request_states", [])
+    }
+    for row in lifecycles:
+        observation = row.get("observation") or {}
+        pr_ref = str(observation.get("pr_ref") or "").strip()
+        issue_ref = str(observation.get("issue_ref") or "").strip() or None
+        ledger_state = str(observation.get("state") or "").strip().upper()
+        checks = observation.get("checks") or {}
+        ledger_ci = str(checks.get("aggregate") or "UNKNOWN").strip().upper()
+        ledger_review = (
+            str(observation.get("review_decision") or "UNKNOWN").strip().upper()
+        )
+        current_pr = current_pr_states.get(pr_ref)
+        state = str((current_pr or {}).get("state") or ledger_state).upper()
+        ci_state = str((current_pr or {}).get("ci") or ledger_ci).upper()
+        review_state = str((current_pr or {}).get("review") or ledger_review).upper()
+        if current_pr:
+            snapshot_refreshes += 1
+            if (state, ci_state, review_state) != (
+                ledger_state,
+                ledger_ci,
+                ledger_review,
+            ):
+                snapshot_corrections += 1
+        if state not in pr_state_counts:
+            state = "OPEN"
+        if ci_state not in ci_counts:
+            ci_state = "UNKNOWN"
+        if review_state not in review_counts:
+            review_state = "UNKNOWN"
+        pr_state_counts[state] += 1
+        ci_counts[ci_state] += 1
+        review_counts[review_state] += 1
+        if issue_ref:
+            linked_issue_refs.add(issue_ref)
+        receipts = row.get("reviewer_notification_receipts")
+        if isinstance(receipts, list) and receipts:
+            receipt_rows += 1
+        compact = {
+            "pr_ref": pr_ref,
+            "issue_ref": issue_ref,
+            "url": observation.get("permalink"),
+            "state": state,
+            "ci": ci_state,
+            "review": review_state,
+            "current_state_source": (
+                "repository_current_snapshot" if current_pr else "pr_lifecycle"
+            ),
+        }
+        for field in ("created_at", "updated_at", "merged_at", "closed_at"):
+            if observation.get(field):
+                compact[field] = observation[field]
+        pr_inventory.append(compact)
+
+    issue_states = {
+        item["issue_ref"]: item["state"] for item in current.get("issue_states", [])
+    }
+    missing_issue_states = sorted(linked_issue_refs - issue_states.keys())
+    issues_closed = (
+        sum(issue_states.get(ref) == "CLOSED" for ref in linked_issue_refs)
+        if linked_issue_refs and not missing_issue_states
+        else None
+    )
+    supplement = _supplement(supplement_input)
+    terminal_outcomes = (
+        pr_state_counts["MERGED"]
+        + (supplement["useful_public_comments"] or 0)
+        + (supplement["triage_outcomes"] or 0)
+    )
+
+    agent_output = {
+        "selected_issues": len(selected_issue_refs),
+        "route_counts": route_counts,
+        "pull_requests": len(pr_inventory),
+        "open_pull_requests": pr_state_counts["OPEN"],
+        "merged_pull_requests": pr_state_counts["MERGED"],
+        "closed_unmerged_pull_requests": pr_state_counts["CLOSED"],
+        "linked_issues_closed": issues_closed,
+        "linked_issue_state_coverage": {
+            "captured": len(linked_issue_refs) - len(missing_issue_states),
+            "total": len(linked_issue_refs),
+            "complete": not missing_issue_states,
+        },
+        "validation_passed": validation_passed,
+        "validation_missing": validation_missing,
+        "current_ci": ci_counts,
+        "current_review": review_counts,
+        "reviewer_notification_receipt_rows": receipt_rows,
+        "pull_requests_refreshed_from_snapshot": snapshot_refreshes,
+        "stale_lifecycle_rows_corrected_by_snapshot": snapshot_corrections,
+        "terminal_outcomes": terminal_outcomes,
+        "supplement": supplement,
+    }
+    zero_agent_output = {
+        "selected_issues": 0,
+        "route_counts": {key: 0 for key in route_counts},
+        "pull_requests": 0,
+        "open_pull_requests": 0,
+        "merged_pull_requests": 0,
+        "closed_unmerged_pull_requests": 0,
+        "linked_issues_closed": 0,
+        "linked_issue_state_coverage": {
+            "captured": 0,
+            "total": 0,
+            "complete": True,
+        },
+        "validation_passed": 0,
+        "reviewer_notification_receipt_rows": 0,
+        "pull_requests_refreshed_from_snapshot": 0,
+        "stale_lifecycle_rows_corrected_by_snapshot": 0,
+        "terminal_outcomes": 0,
+    }
+
+    missing_data: list[dict[str, str]] = []
+    if missing_issue_states:
+        missing_data.append(
+            {
+                "code": "linked_issue_states_not_captured",
+                "impact": (
+                    "pilot-linked issue closure count and share are unavailable; "
+                    f"{len(missing_issue_states)} linked issue states are missing"
+                ),
+            }
+        )
+    if validation_missing:
+        missing_data.append(
+            {
+                "code": "fix_pr_validation_not_captured",
+                "impact": "validation pass coverage is incomplete",
+            }
+        )
+    for field, impact in (
+        ("human_interventions", "autonomy rate is unavailable"),
+        ("first_push_ci_total", "first-push CI rate is unavailable"),
+        ("loopx_capability_gaps_found", "capability delta is unavailable"),
+        ("memory_retrievals", "memory leverage is unavailable"),
+    ):
+        if supplement[field] is None:
+            missing_data.append({"code": f"{field}_not_captured", "impact": impact})
+
+    ratios = {
+        "pilot_merge_rate": _ratio(pr_state_counts["MERGED"], len(pr_inventory)),
+        "pilot_share_of_repository_prs_opened": _ratio(
+            len(pr_inventory), flow["pull_requests_opened"]
+        ),
+        "pilot_share_of_repository_prs_merged": _ratio(
+            pr_state_counts["MERGED"], flow["pull_requests_merged"]
+        ),
+        "pilot_share_of_repository_issues_closed": _ratio(
+            issues_closed, flow["issues_closed"]
+        ),
+        "first_push_ci_pass_rate": _ratio(
+            supplement["first_push_ci_passed"], supplement["first_push_ci_total"]
+        ),
+        "human_interventions_per_terminal_outcome": _ratio(
+            supplement["human_interventions"], terminal_outcomes
+        ),
+    }
+    payload = {
+        "schema_version": PROJECTION_SCHEMA_VERSION,
+        "mode": "issue-fix-metrics",
+        "generated_at": _timestamp(generated_at, field="generated_at"),
+        "goal_id": goal_id,
+        "repo": repo,
+        "baseline": {
+            "repository": baseline,
+            "agent_output": zero_agent_output,
+        },
+        "current": {
+            "repository": current,
+            "agent_output": agent_output,
+        },
+        "delta": {
+            "repository": {
+                "open_issues": current["open_issues"] - baseline["open_issues"],
+                "open_pull_requests": (
+                    current["open_pull_requests"] - baseline["open_pull_requests"]
+                ),
+                "flow": flow,
+            },
+            "agent_output": agent_output,
+        },
+        "output_inventory": {"pull_requests": pr_inventory},
+        "ratios": ratios,
+        "missing_data": missing_data,
+        "source_summary": {
+            "feasibility_rows": len(feasibility),
+            "pr_lifecycle_rows": len(lifecycles),
+            "repository_snapshots": 2,
+            "supplement_supplied": supplement_input is not None,
+            "local_paths_recorded": False,
+            "raw_provider_payloads_recorded": False,
+        },
+        "external_reads_performed": False,
+        "external_writes_performed": False,
+        "ok": True,
+    }
+    payload["validation"] = validate_issue_fix_metrics_projection(payload)
+    payload["ok"] = payload["validation"]["ok"] is True
+    return payload
+
+
+def validate_issue_fix_metrics_projection(payload: dict[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    if payload.get("schema_version") != PROJECTION_SCHEMA_VERSION:
+        errors.append("schema_version mismatch")
+    baseline_output = (payload.get("baseline") or {}).get("agent_output") or {}
+    if any(
+        baseline_output.get(field) != 0
+        for field in (
+            "selected_issues",
+            "pull_requests",
+            "merged_pull_requests",
+            "terminal_outcomes",
+        )
+    ):
+        errors.append("baseline agent output must remain zero")
+    if payload.get("external_writes_performed") is not False:
+        errors.append("metrics projection must not perform external writes")
+    return {
+        "schema_version": "issue_fix_metrics_projection_validation_v0",
+        "ok": not errors,
+        "errors": errors,
+    }
+
+
+def render_issue_fix_metrics_projection_markdown(payload: dict[str, Any]) -> str:
+    if payload.get("ok") is not True:
+        return f"# Issue-fix metrics projection\n\n- Error: {payload.get('error') or 'invalid projection'}"
+    current = payload["current"]
+    output = current["agent_output"]
+    repository = current["repository"]
+    lines = [
+        "# Issue-fix metrics projection",
+        "",
+        f"- Repository: `{payload['repo']}`",
+        f"- Reporting start: `{payload['baseline']['repository']['captured_at']}`",
+        f"- Selected issues: `{output['selected_issues']}`",
+        f"- Pull requests: `{output['pull_requests']}` "
+        f"(`{output['merged_pull_requests']}` merged, "
+        f"`{output['open_pull_requests']}` open)",
+        f"- Repository open issues / PRs: `{repository['open_issues']}` / "
+        f"`{repository['open_pull_requests']}`",
+        f"- Missing-data items: `{len(payload['missing_data'])}`",
+        "",
+        "## Output inventory",
+        "",
+    ]
+    for item in payload["output_inventory"]["pull_requests"]:
+        link = item.get("url") or item["pr_ref"]
+        lines.append(
+            f"- [{item['pr_ref']}]({link}) -> `{item.get('issue_ref') or 'unlinked'}`: "
+            f"{item['state']} / CI {item['ci']} / review {item['review']}"
+        )
+    if not payload["output_inventory"]["pull_requests"]:
+        lines.append("- None")
+    return "\n".join(lines)


### PR DESCRIPTION
## Motivation

Long-running issue-fix goals need to report both repository-level movement and agent-attributable delivery. The current pilot exposed an attribution bug: seven PRs created after the pilot started were described as if they belonged to the repository baseline. It also showed that persisted PR lifecycle rows can lag newer public repository state.

## What changed

- add `loopx issue-fix metrics`, a read-only provider-neutral projection over existing feasibility and PR lifecycle domain state
- require caller-supplied public baseline/current snapshots and reconcile stock against opened/closed flow
- keep goal-start agent output at zero and emit an explicit attributable PR inventory
- allow current public issue/PR state to refresh the read model without rewriting lifecycle history
- report repository contribution ratios and explicit `not_available` missing-data reasons
- accept an allowlisted optional supplement for human-intervention, first-push CI, capability-delta, and memory-leverage counts
- document the protocol in the bilingual issue-fix capability entry

## Validation

- `python3 examples/issue-fix-metrics-projection-smoke.py`
- `python3 examples/issue-fix-capability-guide-smoke.py`
- existing feasibility, PR lifecycle, and outcome projection smokes
- `loopx canary premerge --from-git-diff --tier standard`: passed, 17 selected checks, no warnings or manual holds
- public/private boundary scan: clean
- real OpenViking goal dogfood: 7 selected issues / 7 PRs / 3 merged / 4 open, with 7 current PR states refreshed and 3 stale lifecycle rows identified

## Risk

Low-to-moderate read-model risk. The command performs no network reads or external writes and creates no ledger. Bad repository snapshots fail closed when stock/flow does not reconcile. Missing evidence remains unavailable instead of becoming zero.

## Not covered

Daily public snapshot collection and Kanban/monthly dashboard rendering remain separate follow-up adapters. This PR does not add provider-specific GitHub or OpenViking behavior.