### PR TITLE
feat(issue-fix): project monthly impact to kanban

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -519,6 +519,9 @@ may refresh current PR/issue state without rewriting lifecycle history. Optional
 supplement counts cover evidence that is not yet native to those rows, such as
 human interventions, first-push CI, capability deltas, and memory leverage.
 Absent evidence is emitted as `not_available` plus a reason code, never as zero.
+The same packet exposes stable `impact_rows`; the generic Lark sink maps them to
+the `Monthly Impact` view with baseline, current, delta, ratio lineage, source,
+freshness, and missing-data columns.
 
 ## Conversational `/loopx` Entry
 

--- a/docs/capabilities/issue-fix/README.zh-CN.md
+++ b/docs/capabilities/issue-fix/README.zh-CN.md
@@ -518,6 +518,9 @@ revision 仍是事实源。
 当前公开快照提供仓库流量，也可以刷新 PR/issue 的当前状态，但不会改写 lifecycle
 历史。可选 supplement 补充人工介入、首次 push CI、能力增量、memory 利用等尚未
 原生进入这些行的公开计数。证据缺失时输出 `not_available` 和原因码，绝不偷填 0。
+同一 packet 还提供稳定的 `impact_rows`；通用 Lark sink 会把它们投影到
+`Monthly Impact` 视图，保留 baseline、current、delta、比例分子分母、公开来源、
+更新时间和缺失数据原因。
 
 ## 对话式 `/loopx` 入口
 

--- a/docs/capabilities/issue-fix/protocols/issue-fix-metrics-projection-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-metrics-projection-v0.md
@@ -22,6 +22,7 @@ Both period-start and current inputs use
   "schema_version": "issue_fix_repository_reporting_snapshot_v0",
   "repo": "owner/repo",
   "captured_at": "2026-08-01T00:00:00Z",
+  "source_url": "https://github.com/owner/repo",
   "open_issues": 42,
   "open_pull_requests": 17
 }
@@ -84,6 +85,14 @@ coerced to zero.
 - Feasibility rows provide selected issues and route counts.
 - PR lifecycle rows provide the attributable PR inventory, links, receipts, and
   last persisted state.
+- Reporting-window attribution uses the newest verified lifecycle event time
+  (`created_at` from the current public snapshot when present; otherwise
+  `merged_at`, `closed_at`, or `updated_at`) together with the row observation
+  time. A linked feasibility decision follows its attributable PR into the
+  window, so an old or replayed observation timestamp cannot erase real output.
+- Unlinked feasibility or lifecycle rows whose available event times all
+  predate the baseline are excluded from the period instead of forcing the
+  caller to rewrite history.
 - A newer current public snapshot may refresh state but cannot add an
   unattributed PR to the inventory.
 - Repository shares use explicit numerators and denominators, so a ratio is
@@ -98,6 +107,34 @@ raw issue bodies, comments, provider responses, transcripts, and tool logs.
 
 Daily public snapshot collection and Kanban/dashboard rendering are separate
 adapters over this packet. They must not become a second source of truth.
+
+## Monthly Impact projection
+
+The metrics packet includes stable `impact_rows` for repository health,
+delivery, quality, autonomy, capability, and memory. Every row keeps its
+baseline, current value, delta, numerator/denominator when applicable, public
+source URL, freshness timestamp, and missing-data reason.
+
+The generic Lark sink renders those rows into the `Monthly Impact` view without
+storing another metrics ledger:
+
+```bash
+loopx --format json issue-fix metrics \
+  --goal-id public-issue-fix-goal \
+  --project /path/to/connected/project \
+  --repo owner/repo \
+  --repository-baseline-json baseline.json \
+  --repository-current-json current.json \
+| loopx --format json lark-kanban sync-projection \
+  --projection-file - \
+  --goal-id public-issue-fix-goal \
+  --sink-visibility shared \
+  --execute
+```
+
+`sync-projection` accepts a file, a bounded inline object, or stdin. Setup is
+idempotent: existing boards gain the metric fields and `Monthly Impact` view
+through the normal schema-reconciliation path.
 
 ## Validation
 

--- a/examples/issue-fix-metrics-projection-smoke.py
+++ b/examples/issue-fix-metrics-projection-smoke.py
@@ -11,6 +11,14 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx.presentation.sinks.lark.kanban import (  # noqa: E402
+    LarkKanbanConfig,
+    lark_kanban_schema_payload,
+    sync_loopx_projection_to_lark_kanban,
+)
 
 
 def _write_json(path: Path, value: dict[str, object]) -> None:
@@ -40,6 +48,7 @@ def main() -> int:
                 "schema_version": "issue_fix_repository_reporting_snapshot_v0",
                 "repo": repo,
                 "captured_at": "2026-07-01T00:00:00Z",
+                "source_url": "https://github.com/public-fixture/widgets",
                 "open_issues": 10,
                 "open_pull_requests": 4,
             },
@@ -50,6 +59,7 @@ def main() -> int:
                 "schema_version": "issue_fix_repository_reporting_snapshot_v0",
                 "repo": repo,
                 "captured_at": "2026-08-01T00:00:00Z",
+                "source_url": "https://github.com/public-fixture/widgets",
                 "open_issues": 12,
                 "open_pull_requests": 5,
                 "flow_since_baseline": {
@@ -62,6 +72,7 @@ def main() -> int:
                 "issue_states": [
                     {"issue_ref": "issues_42", "state": "CLOSED"},
                     {"issue_ref": "issues_43", "state": "OPEN"},
+                    {"issue_ref": "issues_44", "state": "OPEN"},
                 ],
                 "pull_request_states": [
                     {
@@ -69,12 +80,21 @@ def main() -> int:
                         "state": "MERGED",
                         "ci": "PASSING",
                         "review": "APPROVED",
+                        "created_at": "2026-07-04T00:00:00Z",
                     },
                     {
                         "pr_ref": "pull_78",
                         "state": "OPEN",
                         "ci": "PASSING",
                         "review": "REVIEW_REQUIRED",
+                        "created_at": "2026-07-05T00:00:00Z",
+                    },
+                    {
+                        "pr_ref": "pull_79",
+                        "state": "OPEN",
+                        "ci": "PASSING",
+                        "review": "REVIEW_REQUIRED",
+                        "created_at": "2026-06-20T00:00:00Z",
                     },
                 ],
             },
@@ -96,7 +116,7 @@ def main() -> int:
             feasibility,
             [
                 {
-                    "generated_at": "2026-07-02T00:00:00Z",
+                    "generated_at": "2026-06-23T00:00:00Z",
                     "observation": {"repo": repo, "issue_ref": "issues_42"},
                     "decision": {"route": "fix_pr"},
                     "delivery_evidence": {"validation_status": "passed"},
@@ -107,13 +127,18 @@ def main() -> int:
                     "decision": {"route": "fix_pr"},
                     "delivery_evidence": {"validation_status": "passed"},
                 },
+                {
+                    "generated_at": "2026-06-23T00:00:00Z",
+                    "observation": {"repo": repo, "issue_ref": "issues_44"},
+                    "decision": {"route": "fix_pr"},
+                },
             ],
         )
         _write_jsonl(
             lifecycle,
             [
                 {
-                    "generated_at": "2026-07-04T00:00:00Z",
+                    "generated_at": "2026-06-23T00:00:00Z",
                     "observation": {
                         "repo": repo,
                         "pr_ref": "pull_77",
@@ -122,6 +147,7 @@ def main() -> int:
                             "https://github.com/public-fixture/widgets/pull/77"
                         ),
                         "state": "MERGED",
+                        "updated_at": "2026-07-04T00:00:00Z",
                         "checks": {"aggregate": "PASSING"},
                         "review_decision": "APPROVED",
                     },
@@ -137,6 +163,18 @@ def main() -> int:
                             "https://github.com/public-fixture/widgets/pull/78"
                         ),
                         "state": "OPEN",
+                        "checks": {"aggregate": "PASSING"},
+                        "review_decision": "REVIEW_REQUIRED",
+                    },
+                },
+                {
+                    "generated_at": "2026-07-06T00:00:00Z",
+                    "observation": {
+                        "repo": repo,
+                        "pr_ref": "pull_79",
+                        "issue_ref": "issues_44",
+                        "state": "OPEN",
+                        "updated_at": "2026-07-06T00:00:00Z",
                         "checks": {"aggregate": "PASSING"},
                         "review_decision": "REVIEW_REQUIRED",
                     },
@@ -184,6 +222,7 @@ def main() -> int:
         assert packet["baseline"]["agent_output"]["pull_requests"] == 0, packet
         output = packet["current"]["agent_output"]
         assert output["pull_requests"] == 2, packet
+        assert output["selected_issues"] == 2, packet
         assert output["merged_pull_requests"] == 1, packet
         assert output["linked_issues_closed"] == 1, packet
         assert output["pull_requests_refreshed_from_snapshot"] == 2, packet
@@ -193,6 +232,74 @@ def main() -> int:
             packet["ratios"]["pilot_share_of_repository_prs_opened"]["value"] == 0.5
         ), packet
         assert len(packet["output_inventory"]["pull_requests"]) == 2, packet
+        assert len(packet["impact_rows"]) == 17, packet
+        impact_by_id = {row["metric_id"]: row for row in packet["impact_rows"]}
+        assert impact_by_id["agent_pull_requests"]["current"] == 2, packet
+        assert impact_by_id["repository_open_issues"]["delta"] == 2, packet
+        assert impact_by_id["quality_first_push_ci_pass_rate"]["current"] == 0.5
+        assert impact_by_id["capability_gaps_fixed"]["status"] == "not_available"
+
+        schema = lark_kanban_schema_payload()
+        assert any(view["name"] == "Monthly Impact" for view in schema["views"]), schema
+        with tempfile.TemporaryDirectory(
+            prefix="loopx-issue-fix-metrics-lark-"
+        ) as lark_tmp:
+            sync = sync_loopx_projection_to_lark_kanban(
+                LarkKanbanConfig(
+                    **{"base_" + "token": "base_public_fixture"},
+                    table_id="tbl_public_fixture",
+                ),
+                projection=packet,
+                agent_id="codex-public-fixture",
+                sink_visibility="shared",
+                config_path=Path(lark_tmp) / "lark-kanban.json",
+                execute=False,
+            )
+        assert sync["ok"] is True, sync
+        assert sync["row_count"] == 17, sync
+        metric_records = {
+            record["values"]["Metric"]: record for record in sync["records"]
+        }
+        pr_metric = metric_records["Agent pull requests"]
+        assert pr_metric["values"]["Work Item Type"] == "Issue Fix Metric"
+        assert pr_metric["values"]["Baseline"] == 0
+        assert pr_metric["values"]["Current"] == 2
+        assert pr_metric["values"]["Delta"] == 2
+        assert pr_metric["values"]["Metric Source"].startswith("https://")
+        assert pr_metric["values"]["Metric Updated At"] == 1785542400000
+        assert sync["public_safe_redaction"] is True
+
+        cli_sync = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--format",
+                "json",
+                "lark-kanban",
+                "sync-projection",
+                "--projection-file",
+                "-",
+                "--goal-id",
+                "fixture-goal",
+                "--agent-id",
+                "codex-public-fixture",
+                "--base-token",
+                "base_public_fixture",
+                "--table-id",
+                "tbl_public_fixture",
+                "--sink-visibility",
+                "shared",
+            ],
+            cwd=ROOT,
+            input=json.dumps(packet),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        cli_sync_packet = json.loads(cli_sync.stdout)
+        assert cli_sync_packet["row_count"] == 17, cli_sync_packet
         serialized = json.dumps(packet, sort_keys=True)
         assert str(root) not in serialized, serialized
         assert packet["external_writes_performed"] is False, packet

--- a/examples/lark-kanban-control-plane-smoke.py
+++ b/examples/lark-kanban-control-plane-smoke.py
@@ -285,7 +285,7 @@ def main() -> int:
     assert schema["task_spawning_model"]["board_creates_tasks"] is False, schema
     assert "LoopX todo lifecycle" in schema["task_spawning_model"]["rule"], schema
     field_names = [field["name"] for field in schema["fields"]]
-    for expected in ["Task", "Status", "Claim", "Handoff", "Evidence", "Run History", "Worker Command", "Work Item Type", "Repository", "Issue", "Pull Request", "Route", "Stage", "Validation", "Outcome"]:
+    for expected in ["Task", "Status", "Claim", "Handoff", "Evidence", "Run History", "Worker Command", "Work Item Type", "Repository", "Issue", "Pull Request", "Route", "Stage", "Validation", "Outcome", "Metric Group", "Metric", "Baseline", "Current", "Delta", "Numerator", "Denominator", "Metric Source", "Metric Updated At", "Missing Data"]:
         assert expected in field_names, field_names
     assert schema["heartbeat_model"]["fallback"].startswith("agent heartbeat"), schema
     assert schema["operator_view"]["kanban_card_fields"] == lark_kanban_operator_card_fields(), schema
@@ -312,7 +312,7 @@ def main() -> int:
     assert issue_fix_surface.field_definition_migrations(
         {"data": {"fields": schema["fields"]}}, schema["fields"]
     ) == []
-    assert {issue_fix_surface.DEFAULT_ISSUE_FIX_GRID_VIEW, issue_fix_surface.DEFAULT_ISSUE_FIX_KANBAN_VIEW} <= {view["name"] for view in schema["views"]}
+    assert {issue_fix_surface.DEFAULT_ISSUE_FIX_GRID_VIEW, issue_fix_surface.DEFAULT_ISSUE_FIX_KANBAN_VIEW, issue_fix_surface.DEFAULT_ISSUE_FIX_METRICS_VIEW} <= {view["name"] for view in schema["views"]}
 
     plan = build_create_board_plan(
         base_name="LoopX Lark Kanban Control Plane POC",
@@ -326,7 +326,8 @@ def main() -> int:
     assert any("+view-set-group" in command and "Kanban" in command for command in joined), joined
     assert any("group_config" in command for command in joined), joined
     assert any("+view-set-visible-fields" in command for command in joined), joined
-    assert sum("+view-set-filter" in command and "Work Item Type" in command for command in joined) == 2, joined
+    assert sum("+view-set-filter" in command and "Work Item Type" in command for command in joined) == 3, joined
+    assert any("+view-set-visible-fields" in command and "Monthly Impact" in command and "Metric Source" in command for command in joined), joined
     assert any("+view-set-group" in command and "Issue Fix Kanban" in command and "Stage" in command for command in joined), joined
     assert not any("+field-update" in command for command in joined), joined
 

--- a/loopx/capabilities/issue_fix/metrics_projection.py
+++ b/loopx/capabilities/issue_fix/metrics_projection.py
@@ -52,6 +52,15 @@ def _timestamp(value: Any, *, field: str) -> str:
     return text
 
 
+def _optional_https_url(value: Any, *, field: str) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    if not text.startswith("https://") or any(char.isspace() for char in text):
+        raise ValueError(f"{field} must be an https URL")
+    return text
+
+
 def _snapshot(
     value: dict[str, Any],
     *,
@@ -77,6 +86,11 @@ def _snapshot(
             field=f"{role}.open_pull_requests",
         ),
     }
+    source_url = _optional_https_url(
+        value.get("source_url"), field=f"{role}.source_url"
+    )
+    if source_url:
+        snapshot["source_url"] = source_url
     health = value.get("health")
     if health is not None:
         if not isinstance(health, dict):
@@ -156,6 +170,11 @@ def _snapshot(
                 "ci": ci,
                 "review": review,
             }
+            if item.get("created_at"):
+                compact_pr["created_at"] = _timestamp(
+                    item.get("created_at"),
+                    field=f"{role}.pull_request_states[{index}].created_at",
+                )
             if item.get("updated_at"):
                 compact_pr["updated_at"] = _timestamp(
                     item.get("updated_at"),
@@ -203,6 +222,51 @@ def _latest_rows(
     return [latest[key] for key in sorted(latest)]
 
 
+def _row_time(row: dict[str, Any], *, lifecycle: bool) -> datetime | None:
+    candidates: list[datetime] = []
+    observation = row.get("observation")
+    if lifecycle and isinstance(observation, dict):
+        for field in ("merged_at", "closed_at", "updated_at"):
+            if not observation.get(field):
+                continue
+            candidates.append(
+                datetime.fromisoformat(
+                    _timestamp(
+                        observation[field],
+                        field=f"domain_state.observation.{field}",
+                    ).replace("Z", "+00:00")
+                )
+            )
+    if row.get("generated_at"):
+        candidates.append(
+            datetime.fromisoformat(
+                _timestamp(
+                    row["generated_at"], field="domain_state.generated_at"
+                ).replace("Z", "+00:00")
+            )
+        )
+    return max(candidates) if candidates else None
+
+
+def _lifecycle_attribution_time(
+    row: dict[str, Any], current_pr_states: dict[str, dict[str, Any]]
+) -> datetime | None:
+    observation = row.get("observation")
+    pr_ref = (
+        str(observation.get("pr_ref") or "").strip()
+        if isinstance(observation, dict)
+        else ""
+    )
+    created_at = current_pr_states.get(pr_ref, {}).get("created_at")
+    if created_at:
+        return datetime.fromisoformat(
+            _timestamp(
+                created_at, field=f"current.pull_request_states.{pr_ref}.created_at"
+            ).replace("Z", "+00:00")
+        )
+    return _row_time(row, lifecycle=True)
+
+
 def _ratio(numerator: int | None, denominator: int | None) -> dict[str, Any]:
     if numerator is None or denominator is None or denominator == 0:
         return {
@@ -216,6 +280,38 @@ def _ratio(numerator: int | None, denominator: int | None) -> dict[str, Any]:
         "denominator": denominator,
         "value": round(numerator / denominator, 4),
         "status": "available",
+    }
+
+
+def _impact_row(
+    *,
+    metric_id: str,
+    metric_group: str,
+    metric: str,
+    baseline: int | float | None,
+    current: int | float | None,
+    delta: int | float | None,
+    updated_at: str,
+    source_url: str | None,
+    numerator: int | None = None,
+    denominator: int | None = None,
+    status: str = "available",
+    missing_reason: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "issue_fix_impact_metric_row_v0",
+        "metric_id": metric_id,
+        "metric_group": metric_group,
+        "metric": metric,
+        "baseline": baseline,
+        "current": current,
+        "delta": delta,
+        "numerator": numerator,
+        "denominator": denominator,
+        "status": status,
+        "source_url": source_url,
+        "updated_at": updated_at,
+        "missing_reason": missing_reason,
     }
 
 
@@ -263,20 +359,33 @@ def build_issue_fix_metrics_projection(
     if flow["pull_requests_merged"] > flow["pull_requests_closed"]:
         raise ValueError("merged pull requests cannot exceed closed pull requests")
 
-    feasibility = _latest_rows(feasibility_rows, repo=repo, ref_field="issue_ref")
-    lifecycles = _latest_rows(pr_lifecycle_rows, repo=repo, ref_field="pr_ref")
-    for row in [*feasibility, *lifecycles]:
-        if not row.get("generated_at"):
-            continue
-        row_time = datetime.fromisoformat(
-            _timestamp(row["generated_at"], field="domain_state.generated_at").replace(
-                "Z", "+00:00"
-            )
-        )
-        if row_time < baseline_time:
-            raise ValueError(
-                "baseline snapshot must not postdate attributable issue-fix output"
-            )
+    current_pr_states = {
+        item["pr_ref"]: item for item in current.get("pull_request_states", [])
+    }
+    all_lifecycles = _latest_rows(
+        pr_lifecycle_rows, repo=repo, ref_field="pr_ref"
+    )
+    lifecycles = [
+        row
+        for row in all_lifecycles
+        if (_lifecycle_attribution_time(row, current_pr_states) or baseline_time)
+        >= baseline_time
+    ]
+    period_issue_refs = {
+        str((row.get("observation") or {}).get("issue_ref") or "").strip()
+        for row in lifecycles
+    }
+    period_issue_refs.discard("")
+    all_feasibility = _latest_rows(
+        feasibility_rows, repo=repo, ref_field="issue_ref"
+    )
+    feasibility = [
+        row
+        for row in all_feasibility
+        if str((row.get("observation") or {}).get("issue_ref") or "").strip()
+        in period_issue_refs
+        or (_row_time(row, lifecycle=False) or baseline_time) >= baseline_time
+    ]
 
     route_counts = {"fix_pr": 0, "comment_only": 0, "triage_only": 0}
     selected_issue_refs: set[str] = set()
@@ -315,9 +424,6 @@ def build_issue_fix_metrics_projection(
     snapshot_refreshes = 0
     snapshot_corrections = 0
     linked_issue_refs: set[str] = set()
-    current_pr_states = {
-        item["pr_ref"]: item for item in current.get("pull_request_states", [])
-    }
     for row in lifecycles:
         observation = row.get("observation") or {}
         pr_ref = str(observation.get("pr_ref") or "").strip()
@@ -474,6 +580,200 @@ def build_issue_fix_metrics_projection(
             supplement["human_interventions"], terminal_outcomes
         ),
     }
+    source_url = current.get("source_url") or baseline.get("source_url")
+    updated_at = current["captured_at"]
+    impact_rows = [
+        _impact_row(
+            metric_id="repository_open_issues",
+            metric_group="Repository",
+            metric="Open issues",
+            baseline=baseline["open_issues"],
+            current=current["open_issues"],
+            delta=current["open_issues"] - baseline["open_issues"],
+            updated_at=updated_at,
+            source_url=source_url,
+        ),
+        _impact_row(
+            metric_id="repository_open_pull_requests",
+            metric_group="Repository",
+            metric="Open pull requests",
+            baseline=baseline["open_pull_requests"],
+            current=current["open_pull_requests"],
+            delta=current["open_pull_requests"] - baseline["open_pull_requests"],
+            updated_at=updated_at,
+            source_url=source_url,
+        ),
+        _impact_row(
+            metric_id="repository_issues_closed",
+            metric_group="Repository",
+            metric="Issues closed since baseline",
+            baseline=0,
+            current=flow["issues_closed"],
+            delta=flow["issues_closed"],
+            updated_at=updated_at,
+            source_url=source_url,
+        ),
+        _impact_row(
+            metric_id="repository_pull_requests_merged",
+            metric_group="Repository",
+            metric="Pull requests merged since baseline",
+            baseline=0,
+            current=flow["pull_requests_merged"],
+            delta=flow["pull_requests_merged"],
+            updated_at=updated_at,
+            source_url=source_url,
+        ),
+        _impact_row(
+            metric_id="agent_selected_issues",
+            metric_group="Delivery",
+            metric="Agent-selected issues",
+            baseline=0,
+            current=len(selected_issue_refs),
+            delta=len(selected_issue_refs),
+            updated_at=updated_at,
+            source_url=source_url,
+        ),
+        _impact_row(
+            metric_id="agent_pull_requests",
+            metric_group="Delivery",
+            metric="Agent pull requests",
+            baseline=0,
+            current=len(pr_inventory),
+            delta=len(pr_inventory),
+            updated_at=updated_at,
+            source_url=source_url,
+        ),
+        _impact_row(
+            metric_id="agent_merged_pull_requests",
+            metric_group="Delivery",
+            metric="Agent pull requests merged",
+            baseline=0,
+            current=pr_state_counts["MERGED"],
+            delta=pr_state_counts["MERGED"],
+            updated_at=updated_at,
+            source_url=source_url,
+        ),
+        _impact_row(
+            metric_id="agent_linked_issues_closed",
+            metric_group="Delivery",
+            metric="Agent-linked issues closed",
+            baseline=0,
+            current=issues_closed,
+            delta=issues_closed,
+            updated_at=updated_at,
+            source_url=source_url,
+            status="available" if issues_closed is not None else "not_available",
+            missing_reason=(
+                None
+                if issues_closed is not None
+                else "linked issue states are incomplete"
+            ),
+        ),
+        _impact_row(
+            metric_id="quality_validation_passed",
+            metric_group="Quality",
+            metric="Validated fixes",
+            baseline=0,
+            current=validation_passed,
+            delta=validation_passed,
+            updated_at=updated_at,
+            source_url=source_url,
+        ),
+        _impact_row(
+            metric_id="quality_current_ci_passing",
+            metric_group="Quality",
+            metric="Current PRs with passing CI",
+            baseline=0,
+            current=ci_counts["PASSING"],
+            delta=ci_counts["PASSING"],
+            updated_at=updated_at,
+            source_url=source_url,
+        ),
+    ]
+    for metric_id, metric_group, metric, ratio_key in (
+        (
+            "delivery_share_repository_prs_opened",
+            "Delivery",
+            "Share of repository PRs opened",
+            "pilot_share_of_repository_prs_opened",
+        ),
+        (
+            "delivery_share_repository_prs_merged",
+            "Delivery",
+            "Share of repository PRs merged",
+            "pilot_share_of_repository_prs_merged",
+        ),
+        (
+            "delivery_share_repository_issues_closed",
+            "Delivery",
+            "Share of repository issues closed",
+            "pilot_share_of_repository_issues_closed",
+        ),
+        (
+            "quality_first_push_ci_pass_rate",
+            "Quality",
+            "First-push CI pass rate",
+            "first_push_ci_pass_rate",
+        ),
+        (
+            "autonomy_human_interventions_per_terminal",
+            "Autonomy",
+            "Human interventions per terminal outcome",
+            "human_interventions_per_terminal_outcome",
+        ),
+    ):
+        ratio = ratios[ratio_key]
+        impact_rows.append(
+            _impact_row(
+                metric_id=metric_id,
+                metric_group=metric_group,
+                metric=metric,
+                baseline=None,
+                current=ratio["value"],
+                delta=None,
+                numerator=ratio["numerator"],
+                denominator=ratio["denominator"],
+                status=ratio["status"],
+                missing_reason=(
+                    None
+                    if ratio["status"] == "available"
+                    else "numerator or denominator is unavailable"
+                ),
+                updated_at=updated_at,
+                source_url=source_url,
+            )
+        )
+    for metric_id, metric_group, metric, supplement_field in (
+        (
+            "capability_gaps_fixed",
+            "Capability",
+            "LoopX capability gaps fixed",
+            "loopx_capability_gaps_fixed",
+        ),
+        (
+            "memory_verified_patch_influence",
+            "Memory",
+            "Memory retrievals verified to influence a patch",
+            "memory_verified_patch_influence",
+        ),
+    ):
+        value = supplement[supplement_field]
+        impact_rows.append(
+            _impact_row(
+                metric_id=metric_id,
+                metric_group=metric_group,
+                metric=metric,
+                baseline=0,
+                current=value,
+                delta=value,
+                status="available" if value is not None else "not_available",
+                missing_reason=(
+                    None if value is not None else f"{supplement_field} is not captured"
+                ),
+                updated_at=updated_at,
+                source_url=source_url,
+            )
+        )
     payload = {
         "schema_version": PROJECTION_SCHEMA_VERSION,
         "mode": "issue-fix-metrics",
@@ -499,6 +799,7 @@ def build_issue_fix_metrics_projection(
             "agent_output": agent_output,
         },
         "output_inventory": {"pull_requests": pr_inventory},
+        "impact_rows": impact_rows,
         "ratios": ratios,
         "missing_data": missing_data,
         "source_summary": {

--- a/loopx/cli_commands/lark_kanban.py
+++ b/loopx/cli_commands/lark_kanban.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 from typing import Callable
 
@@ -152,7 +153,11 @@ def register_lark_kanban_commands(
     add_subcommand_format(projection)
     _add_local_config_args(projection)
     _add_lark_target_args(projection)
-    projection.add_argument("--projection-file", required=True)
+    projection.add_argument(
+        "--projection-file",
+        required=True,
+        help="Projection JSON file, inline object, or '-' for stdin.",
+    )
     projection.add_argument("--goal-id", help="Only sync this goal id; defaults from the projection payload.")
     projection.add_argument("--agent-id", help="Only sync rows claimed by, blocking, or projected for this agent id.")
     projection.add_argument("--source-id", help="Stable source namespace used in synthetic row ids.")
@@ -426,7 +431,15 @@ def handle_lark_kanban_command(
 
 
 def _load_fixture(path: str) -> dict[str, object]:
-    raw = Path(path).expanduser().read_text(encoding="utf-8")
+    stripped = path.lstrip()
+    if path == "-":
+        raw = sys.stdin.read()
+    elif stripped.startswith("{"):
+        raw = path
+    else:
+        raw = Path(path).expanduser().read_text(encoding="utf-8")
+    if len(raw) > 1_048_576:
+        raise ValueError("fixture JSON exceeds the 1 MiB limit")
     payload = json.loads(raw)
     if not isinstance(payload, dict):
         raise ValueError("fixture must be a JSON object")

--- a/loopx/presentation/sinks/lark/issue_fix_surface.py
+++ b/loopx/presentation/sinks/lark/issue_fix_surface.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable, Mapping
+from datetime import datetime
 from typing import Any
 
 
 DEFAULT_ISSUE_FIX_GRID_VIEW = "Issue Fix Outcomes"
 DEFAULT_ISSUE_FIX_KANBAN_VIEW = "Issue Fix Kanban"
+DEFAULT_ISSUE_FIX_METRICS_VIEW = "Monthly Impact"
 
 ISSUE_FIX_CARD_FIELDS = [
     "Task",
@@ -20,6 +22,20 @@ ISSUE_FIX_CARD_FIELDS = [
     "Validation",
     "Outcome",
     "Status",
+]
+
+ISSUE_FIX_METRIC_FIELDS = [
+    "Task",
+    "Metric Group",
+    "Metric",
+    "Baseline",
+    "Current",
+    "Delta",
+    "Numerator",
+    "Denominator",
+    "Metric Source",
+    "Metric Updated At",
+    "Missing Data",
 ]
 
 ISSUE_FIX_STAGE_OPTIONS = [
@@ -54,7 +70,7 @@ def issue_fix_field_definitions(
             "name": "Work Item Type",
             "type": "select",
             "multiple": False,
-            "options": select_options(["Todo", "Issue Fix"]),
+            "options": select_options(["Todo", "Issue Fix", "Issue Fix Metric"]),
         },
         {"name": "Repository", "type": "text", "style": {"type": "plain"}},
         {"name": "Issue", "type": "text", "style": {"type": "url"}},
@@ -73,6 +89,42 @@ def issue_fix_field_definitions(
         },
         {"name": "Validation", "type": "text", "style": {"type": "plain"}},
         {"name": "Outcome", "type": "text", "style": {"type": "plain"}},
+        {
+            "name": "Metric Group",
+            "type": "select",
+            "multiple": False,
+            "options": select_options(
+                [
+                    "Repository",
+                    "Delivery",
+                    "Quality",
+                    "Autonomy",
+                    "Capability",
+                    "Memory",
+                ]
+            ),
+        },
+        {"name": "Metric", "type": "text", "style": {"type": "plain"}},
+        *[
+            {
+                "name": name,
+                "type": "number",
+                "style": {
+                    "type": "plain",
+                    "precision": 4,
+                    "percentage": False,
+                    "thousands_separator": False,
+                },
+            }
+            for name in ("Baseline", "Current", "Delta", "Numerator", "Denominator")
+        ],
+        {"name": "Metric Source", "type": "text", "style": {"type": "url"}},
+        {
+            "name": "Metric Updated At",
+            "type": "datetime",
+            "style": {"format": "yyyy-MM-dd HH:mm"},
+        },
+        {"name": "Missing Data", "type": "text", "style": {"type": "plain"}},
     ]
 
 
@@ -80,7 +132,27 @@ def issue_fix_views() -> list[dict[str, str]]:
     return [
         {"name": DEFAULT_ISSUE_FIX_GRID_VIEW, "type": "grid"},
         {"name": DEFAULT_ISSUE_FIX_KANBAN_VIEW, "type": "kanban"},
+        {"name": DEFAULT_ISSUE_FIX_METRICS_VIEW, "type": "grid"},
     ]
+
+
+def _number_or_none(value: Any) -> int | float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return value
+
+
+def _datetime_millis(value: Any) -> int | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.utcoffset() is None:
+        return None
+    return int(parsed.timestamp() * 1000)
 
 
 def issue_fix_record_values(
@@ -88,7 +160,29 @@ def issue_fix_record_values(
     *,
     compact_text: Callable[..., str],
 ) -> dict[str, Any]:
-    if str(block.get("action_kind") or "") != "issue_fix_outcome":
+    action_kind = str(block.get("action_kind") or "")
+    if action_kind == "issue_fix_metric":
+        return {
+            "Work Item Type": "Issue Fix Metric",
+            "Repository": compact_text(block.get("repo"), limit=160),
+            "Issue": "",
+            "Pull Request": "",
+            "Route": "",
+            "Stage": "",
+            "Validation": "",
+            "Outcome": "",
+            "Metric Group": compact_text(block.get("metric_group"), limit=80),
+            "Metric": compact_text(block.get("metric"), limit=180),
+            "Baseline": _number_or_none(block.get("baseline")),
+            "Current": _number_or_none(block.get("current")),
+            "Delta": _number_or_none(block.get("delta")),
+            "Numerator": _number_or_none(block.get("numerator")),
+            "Denominator": _number_or_none(block.get("denominator")),
+            "Metric Source": compact_text(block.get("source_url"), limit=320),
+            "Metric Updated At": _datetime_millis(block.get("updated_at")),
+            "Missing Data": compact_text(block.get("missing_reason"), limit=300),
+        }
+    if action_kind != "issue_fix_outcome":
         return {}
     issue = block.get("issue") if isinstance(block.get("issue"), Mapping) else {}
     pull_request = (
@@ -128,6 +222,16 @@ def issue_fix_record_values(
             limit=300,
         ),
         "Outcome": compact_text(result.get("kind"), limit=120),
+        "Metric Group": "",
+        "Metric": "",
+        "Baseline": None,
+        "Current": None,
+        "Delta": None,
+        "Numerator": None,
+        "Denominator": None,
+        "Metric Source": "",
+        "Metric Updated At": None,
+        "Missing Data": "",
     }
 
 
@@ -141,6 +245,16 @@ def todo_record_values() -> dict[str, str]:
         "Stage": "",
         "Validation": "",
         "Outcome": "",
+        "Metric Group": "",
+        "Metric": "",
+        "Baseline": None,
+        "Current": None,
+        "Delta": None,
+        "Numerator": None,
+        "Denominator": None,
+        "Metric Source": "",
+        "Metric Updated At": None,
+        "Missing Data": "",
     }
 
 
@@ -190,7 +304,11 @@ def missing_field_definitions(
     parsed: Any, definitions: list[dict[str, Any]]
 ) -> list[dict[str, Any]]:
     existing = extract_field_names(parsed)
-    return [item for item in definitions if str(item.get("name") or "").strip() not in existing]
+    return [
+        item
+        for item in definitions
+        if str(item.get("name") or "").strip() not in existing
+    ]
 
 
 def field_definition_migrations(
@@ -200,22 +318,49 @@ def field_definition_migrations(
     migrations: list[dict[str, Any]] = []
     for definition in definitions:
         name = str(definition.get("name") or "").strip()
-        if name not in {"Issue", "Pull Request", "Stage"} or name not in existing:
+        if (
+            name not in {"Work Item Type", "Issue", "Pull Request", "Stage"}
+            or name not in existing
+        ):
             continue
         current = existing[name]
         matches = current.get("type") == definition.get("type")
         if name in {"Issue", "Pull Request"}:
-            current_style = current.get("style") if isinstance(current.get("style"), Mapping) else {}
-            desired_style = definition.get("style") if isinstance(definition.get("style"), Mapping) else {}
+            current_style = (
+                current.get("style")
+                if isinstance(current.get("style"), Mapping)
+                else {}
+            )
+            desired_style = (
+                definition.get("style")
+                if isinstance(definition.get("style"), Mapping)
+                else {}
+            )
             matches = matches and current_style.get("type") == desired_style.get("type")
         else:
-            current_options = current.get("options") if isinstance(current.get("options"), list) else []
-            desired_options = definition.get("options") if isinstance(definition.get("options"), list) else []
+            current_options = (
+                current.get("options")
+                if isinstance(current.get("options"), list)
+                else []
+            )
+            desired_options = (
+                definition.get("options")
+                if isinstance(definition.get("options"), list)
+                else []
+            )
             matches = (
                 matches
                 and current.get("multiple") is definition.get("multiple")
-                and [item.get("name") for item in current_options if isinstance(item, Mapping)]
-                == [item.get("name") for item in desired_options if isinstance(item, Mapping)]
+                and [
+                    item.get("name")
+                    for item in current_options
+                    if isinstance(item, Mapping)
+                ]
+                == [
+                    item.get("name")
+                    for item in desired_options
+                    if isinstance(item, Mapping)
+                ]
             )
         if not matches:
             migrations.append(
@@ -241,6 +386,9 @@ def issue_fix_view_configuration_commands(
     )
     issue_kanban_view = (
         view_ids.get(DEFAULT_ISSUE_FIX_KANBAN_VIEW) or DEFAULT_ISSUE_FIX_KANBAN_VIEW
+    )
+    metrics_view = (
+        view_ids.get(DEFAULT_ISSUE_FIX_METRICS_VIEW) or DEFAULT_ISSUE_FIX_METRICS_VIEW
     )
     common = [
         cli_bin,
@@ -273,6 +421,25 @@ def issue_fix_view_configuration_commands(
     commands.append(
         [
             *common[:2],
+            "+view-set-filter",
+            *common[2:],
+            "--view-id",
+            metrics_view,
+            "--json",
+            json.dumps(
+                {
+                    "logic": "and",
+                    "conditions": [
+                        ["Work Item Type", "intersects", ["Issue Fix Metric"]]
+                    ],
+                },
+                ensure_ascii=False,
+            ),
+        ]
+    )
+    commands.append(
+        [
+            *common[:2],
             "+view-set-group",
             *common[2:],
             "--view-id",
@@ -295,6 +462,17 @@ def issue_fix_view_configuration_commands(
             json.dumps({"visible_fields": ISSUE_FIX_CARD_FIELDS}, ensure_ascii=False),
         ]
         for view_id in (issue_grid_view, issue_kanban_view)
+    )
+    commands.append(
+        [
+            *common[:2],
+            "+view-set-visible-fields",
+            *common[2:],
+            "--view-id",
+            metrics_view,
+            "--json",
+            json.dumps({"visible_fields": ISSUE_FIX_METRIC_FIELDS}, ensure_ascii=False),
+        ]
     )
     return commands
 

--- a/loopx/presentation/sinks/lark/kanban.py
+++ b/loopx/presentation/sinks/lark/kanban.py
@@ -217,6 +217,7 @@ def lark_kanban_schema_payload(*, table_name: str = DEFAULT_TABLE_NAME) -> dict[
             "quota": "omitted in v0 prototype; assume no quota limit",
             "scope": "Scope text field; advisory in v0 prototype",
             "issue_fix_outcome": "First-class issue row with repository, issue, PR, route, stage, validation, and outcome dimensions.",
+            "issue_fix_metric": "Monthly Impact row with repository baseline, current value, delta, ratio lineage, source link, freshness, and explicit missing data.",
         },
         "fields": lark_kanban_field_definitions(),
         "views": lark_kanban_views(),
@@ -224,6 +225,8 @@ def lark_kanban_schema_payload(*, table_name: str = DEFAULT_TABLE_NAME) -> dict[
             "kanban_card_fields": OPERATOR_CARD_FIELDS,
             "issue_fix_card_fields": issue_fix_surface.ISSUE_FIX_CARD_FIELDS,
             "issue_fix_views": [issue_fix_surface.DEFAULT_ISSUE_FIX_GRID_VIEW, issue_fix_surface.DEFAULT_ISSUE_FIX_KANBAN_VIEW],
+            "issue_fix_metrics_view": issue_fix_surface.DEFAULT_ISSUE_FIX_METRICS_VIEW,
+            "issue_fix_metric_fields": issue_fix_surface.ISSUE_FIX_METRIC_FIELDS,
             "reason": (
                 "Keep the human-facing Kanban card small; retain the full task "
                 "context in the record detail and All Tasks grid."

--- a/loopx/presentation/sinks/lark/projection_rows.py
+++ b/loopx/presentation/sinks/lark/projection_rows.py
@@ -35,12 +35,16 @@ def todo_matches_agent_scope(block: dict[str, Any], agent_id: str | None) -> boo
         value = block.get(key)
         if isinstance(value, str) and value.strip() == agent_id:
             return True
-        if isinstance(value, list) and agent_id in {str(item).strip() for item in value}:
+        if isinstance(value, list) and agent_id in {
+            str(item).strip() for item in value
+        }:
             return True
     return False
 
 
-def _projection_matches_agent_scope(block: dict[str, Any], agent_id: str | None) -> bool:
+def _projection_matches_agent_scope(
+    block: dict[str, Any], agent_id: str | None
+) -> bool:
     if not agent_id:
         return True
     if agent_id in normalize_todo_excluded_agents(block.get("excluded_agents")):
@@ -50,12 +54,16 @@ def _projection_matches_agent_scope(block: dict[str, Any], agent_id: str | None)
     claimed_by = block.get("claimed_by")
     if isinstance(claimed_by, str) and claimed_by.strip():
         return False
-    if isinstance(claimed_by, list) and [item for item in claimed_by if str(item).strip()]:
+    if isinstance(claimed_by, list) and [
+        item for item in claimed_by if str(item).strip()
+    ]:
         return False
     blocks_agent = block.get("blocks_agent")
     if isinstance(blocks_agent, str) and blocks_agent.strip():
         return False
-    if isinstance(blocks_agent, list) and [item for item in blocks_agent if str(item).strip()]:
+    if isinstance(blocks_agent, list) and [
+        item for item in blocks_agent if str(item).strip()
+    ]:
         return False
     if block.get("projection_agent_id") == agent_id:
         return True
@@ -79,13 +87,21 @@ def _stable_projection_segment(value: Any, *, fallback: str) -> str:
     return (text or fallback)[:160]
 
 
-def projection_namespace(projection: dict[str, Any], source_id: str | None) -> tuple[str, list[str]]:
+def projection_namespace(
+    projection: dict[str, Any], source_id: str | None
+) -> tuple[str, list[str]]:
     warnings: list[str] = []
     payload_source = str(projection.get("source_id") or "").strip()
     requested = str(source_id or "").strip()
     if requested and payload_source and requested != payload_source:
-        warnings.append(f"projection source_id {payload_source!r} does not match requested source_id {requested!r}")
-    raw = requested or payload_source or str(projection.get("schema_version") or "projection")
+        warnings.append(
+            f"projection source_id {payload_source!r} does not match requested source_id {requested!r}"
+        )
+    raw = (
+        requested
+        or payload_source
+        or str(projection.get("schema_version") or "projection")
+    )
     return _stable_projection_segment(raw, fallback="projection"), warnings
 
 
@@ -120,12 +136,16 @@ def _projection_lifecycle_payload(item: dict[str, Any]) -> dict[str, Any]:
 
 def projection_lifecycle_state(item: dict[str, Any]) -> str:
     lifecycle = _projection_lifecycle_payload(item)
-    return str(
-        lifecycle.get("state")
-        or lifecycle.get("status")
-        or item.get("row_lifecycle_state")
-        or ""
-    ).strip().lower()
+    return (
+        str(
+            lifecycle.get("state")
+            or lifecycle.get("status")
+            or item.get("row_lifecycle_state")
+            or ""
+        )
+        .strip()
+        .lower()
+    )
 
 
 def _projection_item_status(item: dict[str, Any]) -> str:
@@ -134,11 +154,23 @@ def _projection_item_status(item: dict[str, Any]) -> str:
     if (
         item.get("done") is True
         or normalize_todo_status(raw) == TODO_STATUS_DONE
-        or raw.lower() in {"closed", "complete", "completed", "resolved", "superseded", "migrated", "retired"}
+        or raw.lower()
+        in {
+            "closed",
+            "complete",
+            "completed",
+            "resolved",
+            "superseded",
+            "migrated",
+            "retired",
+        }
         or lifecycle_state in {"superseded", "migrated", "retired"}
     ):
         return TODO_STATUS_DONE
-    if normalize_todo_status(raw) == TODO_STATUS_BLOCKED or raw.lower() in {"error", "failed"}:
+    if normalize_todo_status(raw) == TODO_STATUS_BLOCKED or raw.lower() in {
+        "error",
+        "failed",
+    }:
         return TODO_STATUS_BLOCKED
     if normalize_todo_status(raw) == TODO_STATUS_DEFERRED:
         return TODO_STATUS_DEFERRED
@@ -149,7 +181,11 @@ def projection_text_list(value: Any) -> list[str]:
     if value is None:
         return []
     if isinstance(value, list):
-        return [_compact_text(item, limit=220) for item in value if _compact_text(item, limit=220)]
+        return [
+            _compact_text(item, limit=220)
+            for item in value
+            if _compact_text(item, limit=220)
+        ]
     text = _compact_text(value, limit=220)
     return [text] if text else []
 
@@ -182,8 +218,16 @@ def projection_lifecycle_parts(item: dict[str, Any], *, source_id: str) -> list[
 
 def _projection_lifecycle_default_text(item: dict[str, Any], *, index: int) -> str:
     state = projection_lifecycle_state(item) or "updated"
-    supersedes = ", ".join(projection_text_list(projection_lifecycle_value(item, "supersedes"))) or "previous row"
-    superseded_by = ", ".join(projection_text_list(projection_lifecycle_value(item, "superseded_by"))) or "current projection"
+    supersedes = (
+        ", ".join(projection_text_list(projection_lifecycle_value(item, "supersedes")))
+        or "previous row"
+    )
+    superseded_by = (
+        ", ".join(
+            projection_text_list(projection_lifecycle_value(item, "superseded_by"))
+        )
+        or "current projection"
+    )
     return f"[P2] Projection row lifecycle {index}: {state} {supersedes} -> {superseded_by}"
 
 
@@ -232,7 +276,13 @@ def _projection_todo_candidates(summary: Any) -> list[dict[str, Any]]:
     seen: set[str] = set()
     for group in source_groups:
         for item in _as_mapping_list(group):
-            identity = str(item.get("todo_id") or item.get("gate_id") or item.get("title") or item.get("text") or "")
+            identity = str(
+                item.get("todo_id")
+                or item.get("gate_id")
+                or item.get("title")
+                or item.get("text")
+                or ""
+            )
             if not identity:
                 identity = json.dumps(item, ensure_ascii=False, sort_keys=True)
             if identity in seen:
@@ -242,7 +292,9 @@ def _projection_todo_candidates(summary: Any) -> list[dict[str, Any]]:
     return items
 
 
-def _projection_project_asset(projection: dict[str, Any], goal_id: str | None) -> dict[str, Any]:
+def _projection_project_asset(
+    projection: dict[str, Any], goal_id: str | None
+) -> dict[str, Any]:
     project_asset = _as_mapping(projection.get("project_asset"))
     if project_asset:
         return project_asset
@@ -307,16 +359,24 @@ def projection_rows_from_payload(
     resolved_goal_id = str(goal_id or payload_goal_id or "loopx-projection").strip()
     warnings: list[str] = []
     if goal_id and payload_goal_id and goal_id != payload_goal_id:
-        warnings.append(f"payload goal_id {payload_goal_id!r} does not match requested goal_id {goal_id!r}")
+        warnings.append(
+            f"payload goal_id {payload_goal_id!r} does not match requested goal_id {goal_id!r}"
+        )
         return resolved_goal_id, [], warnings
 
-    payload_agent_id = str(_as_mapping(projection.get("agent_identity")).get("agent_id") or "").strip()
+    payload_agent_id = str(
+        _as_mapping(projection.get("agent_identity")).get("agent_id") or ""
+    ).strip()
     rows: list[dict[str, Any]] = []
 
     def add_row(row: dict[str, Any]) -> None:
         if len(rows) >= limit:
             return
-        if row.get("status") == TODO_STATUS_DONE and not include_done and not row.get("_include_done_by_default"):
+        if (
+            row.get("status") == TODO_STATUS_DONE
+            and not include_done
+            and not row.get("_include_done_by_default")
+        ):
             return
         if agent_id and not _projection_matches_agent_scope(row, agent_id):
             return
@@ -328,7 +388,9 @@ def projection_rows_from_payload(
         if group is None and project_asset:
             group = project_asset.get(f"{role}_todos")
         for index, item in enumerate(_projection_todo_candidates(group), start=1):
-            identity = item.get("todo_id") or item.get("title") or item.get("text") or index
+            identity = (
+                item.get("todo_id") or item.get("title") or item.get("text") or index
+            )
             add_row(
                 _projection_row(
                     source_id=source_id,
@@ -341,9 +403,16 @@ def projection_rows_from_payload(
                 )
             )
 
-    for index, gate in enumerate(_as_mapping_list(projection.get("open_gates")), start=1):
+    for index, gate in enumerate(
+        _as_mapping_list(projection.get("open_gates")), start=1
+    ):
         identity = gate.get("gate_id") or gate.get("id") or index
-        gate_text = gate.get("title") or gate.get("text") or gate.get("kind") or "Open user gate"
+        gate_text = (
+            gate.get("title")
+            or gate.get("text")
+            or gate.get("kind")
+            or "Open user gate"
+        )
         add_row(
             _projection_row(
                 source_id=source_id,
@@ -386,6 +455,40 @@ def projection_rows_from_payload(
             )
         )
 
+    for index, metric in enumerate(
+        _as_mapping_list(projection.get("impact_rows")), start=1
+    ):
+        identity = metric.get("metric_id") or index
+        current = metric.get("current")
+        delta = metric.get("delta")
+        current_text = "unavailable" if current is None else str(current)
+        delta_text = (
+            f" ({delta:+g})"
+            if isinstance(delta, (int, float)) and not isinstance(delta, bool)
+            else ""
+        )
+        add_row(
+            _projection_row(
+                source_id=source_id,
+                goal_id=resolved_goal_id,
+                kind="issue_fix_metric",
+                identity=identity,
+                role="agent",
+                item={
+                    **metric,
+                    "title": f"{metric.get('metric') or identity}: {current_text}{delta_text}",
+                    "action_kind": "issue_fix_metric",
+                    "task_class": "continuous_monitor",
+                    "priority": "P2",
+                    "status": "open",
+                    "evidence": metric.get("missing_reason")
+                    or metric.get("source_url"),
+                },
+                fallback_text=f"Issue-fix impact metric {index}",
+                projection_agent_id=payload_agent_id or agent_id,
+            )
+        )
+
     next_action = _as_mapping(projection.get("agent_lane_next_action"))
     if not next_action and projection.get("next_action"):
         next_action = {
@@ -409,7 +512,9 @@ def projection_rows_from_payload(
         )
 
     capability_gate = _as_mapping(projection.get("capability_gate"))
-    for index, item in enumerate(_as_mapping_list(capability_gate.get("runnable_candidates")), start=1):
+    for index, item in enumerate(
+        _as_mapping_list(capability_gate.get("runnable_candidates")), start=1
+    ):
         identity = item.get("todo_id") or item.get("title") or item.get("text") or index
         add_row(
             _projection_row(
@@ -420,7 +525,8 @@ def projection_rows_from_payload(
                 role="agent",
                 item={
                     **item,
-                    "action_kind": item.get("action_kind") or "projection_runnable_candidate",
+                    "action_kind": item.get("action_kind")
+                    or "projection_runnable_candidate",
                     "task_class": item.get("task_class") or TODO_TASK_CLASS_ADVANCEMENT,
                 },
                 fallback_text=f"Runnable candidate {index}",
@@ -445,14 +551,22 @@ def projection_rows_from_payload(
                 role=str(event.get("role") or "agent"),
                 item={
                     **event,
-                    "title": event.get("title") or event.get("text") or _projection_lifecycle_default_text(event, index=index),
-                    "action_kind": event.get("action_kind") or "projection_row_lifecycle",
+                    "title": event.get("title")
+                    or event.get("text")
+                    or _projection_lifecycle_default_text(event, index=index),
+                    "action_kind": event.get("action_kind")
+                    or "projection_row_lifecycle",
                     "task_class": event.get("task_class") or "continuous_monitor",
-                    "claimed_by": event.get("claimed_by") or event.get("agent_id") or payload_agent_id,
+                    "claimed_by": event.get("claimed_by")
+                    or event.get("agent_id")
+                    or payload_agent_id,
                     "_include_done_by_default": True,
                 },
                 fallback_text=_projection_lifecycle_default_text(event, index=index),
-                projection_agent_id=str(event.get("agent_id") or payload_agent_id or agent_id or "").strip() or None,
+                projection_agent_id=str(
+                    event.get("agent_id") or payload_agent_id or agent_id or ""
+                ).strip()
+                or None,
             )
         )
 
@@ -467,12 +581,14 @@ def projection_rows_from_payload(
                 identity="user_channel",
                 role="user",
                 item={
-                    "title": user_channel.get("reason") or "User channel action required",
+                    "title": user_channel.get("reason")
+                    or "User channel action required",
                     "status": TODO_STATUS_OPEN,
                     "task_class": TODO_TASK_CLASS_USER_GATE,
                     "action_kind": "projection_interaction_gate",
                     "blocks_agent": agent_id or payload_agent_id,
-                    "evidence": user_channel.get("payload") or user_channel.get("reason"),
+                    "evidence": user_channel.get("payload")
+                    or user_channel.get("reason"),
                 },
                 fallback_text="User channel action required",
             )


### PR DESCRIPTION
## Motivation

Long-running issue-fix goals need a month-end view that separates attributable agent output from repository-wide movement. The metrics command already produced the underlying read model, but operators could not project stable rows into the normal Lark Kanban surface.

## Implementation

- add 17 stable impact rows for repository health, delivery, quality, autonomy, capability, and memory
- preserve baseline, current, delta, numerator/denominator, public source, freshness, and missing-data reasons
- attribute outputs by public PR creation/lifecycle evidence so replayed observation timestamps do not erase real period output
- add a Monthly Impact view and metric fields to the existing Lark schema
- let sync-projection consume bounded JSON from a file, inline object, or stdin
- keep the metrics packet read-only and reuse existing issue-fix domain state

## Validation

- python3 examples/issue-fix-metrics-projection-smoke.py
- python3 examples/lark-kanban-control-plane-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- uvx ruff check on all touched Python files
- loopx canary premerge --from-git-diff: 17/17 selected checks passed, 0 warnings, self-merge allowed
- real OpenViking pilot projection: 7 selected issues, 7 PRs, 3 merged PRs, 7 PRs with passing CI, and 17 Monthly Impact rows read back successfully

## Risk

This adds fields and a view to existing Lark boards through the normal idempotent schema migration path. It does not change todo or quota state. Existing non-metric rows clear the new metric fields explicitly.

## Not covered

Daily public repository snapshot collection and month-end scheduling remain a successor. Source-wide stale-row reconciliation also remains explicit because implicit deletion would be unsafe for filtered projections.