### PR TITLE
Fix SkillsBench goal lifecycle generation detection

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -767,6 +767,14 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
     )
     assert (
         codex_cli_tui_pre_bridge_blocker_stage(
+            "Goal active\nGoal failed\n› ",
+            prompt_visible=True,
+            terminal_observed=False,
+        )
+        == ""
+    )
+    assert (
+        codex_cli_tui_pre_bridge_blocker_stage(
             stale_goal_failed_scrollback,
             prompt_visible=True,
             terminal_observed=True,
@@ -799,6 +807,7 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
         codex_cli_tui_pre_bridge_blocker_stage(
             "Goal active\nGoal failed\n› ",
             prompt_visible=True,
+            terminal_observed=True,
         )
         == "pre_bridge_tui_error_prompt"
     )
@@ -1420,9 +1429,11 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
         CODEX_CLI_GOAL_TASK_PROMPT_FILENAME,
         CODEX_CLI_GOAL_THREAD_PREWARM_MARKER,
         CODEX_CLI_GOAL_THREAD_PREWARM_PROMPT,
+        CodexCliGoalLifecycleGeneration,
         build_codex_cli_goal_file_objective,
         build_codex_cli_tui_command,
         build_codex_cli_goal_tui_input,
+        codex_cli_goal_lifecycle_marker_counts,
         codex_cli_goal_watchdog_expired,
     )
     from loopx.benchmark_adapters.skillsbench_acp_relay import (
@@ -1481,6 +1492,32 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
         )
         is False
     )
+    lifecycle_baseline = codex_cli_goal_lifecycle_marker_counts(
+        "Goal active\nGoal failed\n› "
+    )
+    lifecycle_unchanged = codex_cli_goal_lifecycle_marker_counts(
+        "Goal active\nGoal failed\nold scrollback\n› "
+    )
+    assert lifecycle_unchanged == lifecycle_baseline
+    lifecycle_current = codex_cli_goal_lifecycle_marker_counts(
+        "Goal active\nGoal failed\nGoal active\nGoal achieved\nGoal blocked\n› "
+    )
+    assert lifecycle_current.active - lifecycle_baseline.active == 1
+    assert lifecycle_current.achieved - lifecycle_baseline.achieved == 1
+    assert lifecycle_current.failed - lifecycle_baseline.failed == 1
+    lifecycle = CodexCliGoalLifecycleGeneration()
+    lifecycle.begin("Goal active\nGoal failed\n› ")
+    lifecycle.observe("Goal active\nGoal failed\nold scrollback\n› ")
+    assert lifecycle.active_advanced is False
+    assert lifecycle.failed_advanced is False
+    lifecycle.begin("Goal active\nGoal failed\nold scrollback\n› ")
+    lifecycle.observe(
+        "Goal active\nGoal failed\nold scrollback\nGoal active\nGoal achieved\n› "
+    )
+    assert lifecycle.generation == 2
+    assert lifecycle.active_advanced is True
+    assert lifecycle.achieved_advanced is True
+    assert lifecycle.trace_fields()["goal_failed_marker_delta"] == 0
     assert (
         codex_cli_goal_watchdog_expired(
             deadline=100.0,
@@ -1538,6 +1575,10 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "kickoff_submitted=goal_kickoff_prompt_submitted" in source
     assert "text=CODEX_CLI_GOAL_KICKOFF_PROMPT" in source
     assert "goal_failed_now = False" in source
+    assert "goal_lifecycle.failed_advanced" in source
+    assert "goal_lifecycle.active_advanced" in source
+    assert "goal_lifecycle.achieved_advanced" in source
+    assert source.count("goal_lifecycle.begin(") == 2
     assert source.count("goal_kickoff_prompt_submitted = False") >= 2
     assert "terminal_observed=goal_failed_now" in source
     assert "goal_kickoff_prompt_raw_text_recorded" in source
@@ -1583,6 +1624,8 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "def codex_cli_goal_watchdog_expired(" in tui_source
     assert "not kickoff_submitted" in tui_source
     assert "def codex_cli_goal_reset_pre_bridge_deadlines(" in tui_source
+    assert '"goal_submission_generation"' in tui_source
+    assert 'fields[f"goal_{name}_marker_delta"]' in tui_source
     assert "goal-thread-prewarm.txt" in tui_source
     assert CODEX_CLI_GOAL_TASK_PROMPT_FILENAME in tui_source
     assert "tmux_send_plain_enter" in tui_source

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -59,6 +59,7 @@ from loopx.codex_cli_goal_tui import (
     build_codex_cli_goal_file_objective,
     build_codex_cli_goal_tui_input,
     build_codex_cli_tui_command,
+    CodexCliGoalLifecycleGeneration,
     codex_cli_goal_watchdog_expired,
     codex_cli_goal_reset_pre_bridge_deadlines,
     codex_cli_goal_should_ignore_stale_terminal,
@@ -1093,6 +1094,7 @@ class SkillsBenchLocalAcpRelay:
             post_bridge_recovery_action = ""
             post_bridge_recovery_skip_reason = ""
             pre_bridge_terminal_stage = ""
+            self._last_codex_cli_goal_lifecycle = goal_lifecycle = CodexCliGoalLifecycleGeneration()
             try:
                 subprocess.run(
                     [
@@ -1150,6 +1152,7 @@ class SkillsBenchLocalAcpRelay:
                         return _recoverable_codex_turn_failure_message(
                             "codex_exec_first_action_timeout"
                         )
+                goal_lifecycle.begin(tmux_capture(tmux_name))
                 if goal_prompt_file_used:
                     tmux_type_text_and_submit(
                         tmux_name=tmux_name,
@@ -1219,11 +1222,12 @@ class SkillsBenchLocalAcpRelay:
                     now = time.monotonic()
                     capture = self._last_codex_cli_goal_tui_capture = tmux_capture(tmux_name)
                     turn_active = codex_cli_tui_turn_active(capture)
+                    goal_lifecycle.observe(capture)
                     if turn_active:
                         last_task_output_activity_at = now
-                    if "Goal active" in capture or "Pursuing goal" in capture:
+                    if goal_lifecycle.active_advanced:
                         goal_active_observed = True
-                    goal_failed_now = "Goal failed" in capture or "Goal blocked" in capture
+                    goal_failed_now = goal_lifecycle.failed_advanced
                     if bridge_summary_path is not None:
                         try:
                             current_bridge_summary_size = bridge_summary_path.stat().st_size
@@ -1295,7 +1299,7 @@ class SkillsBenchLocalAcpRelay:
                         now=now,
                     ):
                         goal_failed_now = False
-                    if "Goal achieved" in capture:
+                    if goal_lifecycle.achieved_advanced:
                         goal_terminal_observed = True
                         break
                     retryable_startup_blocker_stage = ""
@@ -1350,27 +1354,22 @@ class SkillsBenchLocalAcpRelay:
                             if recovery_action == "press_enter":
                                 tmux_submit_enter(tmux_name)
                             else:
+                                goal_lifecycle.begin(capture)
+                                goal_active_observed = False
                                 goal_kickoff_prompt_submitted = False
                                 tmux_type_text_and_submit(
                                     tmux_name=tmux_name,
                                     text=goal_command_text,
                                 )
-                            first_action_timeout_sec = max(
-                                1.0,
-                                float(self._config.first_action_timeout_sec or 0.0),
+                            deadlines = codex_cli_goal_reset_pre_bridge_deadlines(
+                                now=now,
+                                first_action_timeout_sec=self._config.first_action_timeout_sec,
+                                goal_active_deadline=goal_active_deadline,
+                                goal_active_timeout_sec=self._config.goal_active_timeout_sec,
+                                first_action_deadline=first_action_deadline,
+                                meaningful_progress_deadline=meaningful_progress_deadline,
                             )
-                            if goal_active_deadline:
-                                goal_active_deadline = now + max(
-                                    1.0,
-                                    float(self._config.goal_active_timeout_sec or 0.0),
-                                )
-                            if first_action_deadline:
-                                first_action_deadline = now + first_action_timeout_sec
-                            if meaningful_progress_deadline:
-                                meaningful_progress_deadline = now + max(
-                                    1.0,
-                                    first_action_timeout_sec,
-                                )
+                            goal_active_deadline, first_action_deadline, meaningful_progress_deadline = deadlines
                             if recovery_action == "typed_goal_resubmit":
                                 next_heartbeat = now + max(
                                     1.0,
@@ -1409,6 +1408,7 @@ class SkillsBenchLocalAcpRelay:
                             goal_command_submission_method=(
                                 goal_command_submission_method
                             ),
+                            goal_kickoff_prompt_submitted=goal_kickoff_prompt_submitted,
                             post_bridge_recovery_attempt_count=pre_bridge_recovery_attempt_count,
                             post_bridge_recovery_action=pre_bridge_recovery_action,
                             post_bridge_recovery_skip_reason=pre_bridge_recovery_skip_reason,
@@ -1854,6 +1854,7 @@ class SkillsBenchLocalAcpRelay:
                     goal_kickoff_prompt_submitted
                 ),
                 "goal_kickoff_prompt_raw_text_recorded": False,
+                **getattr(self, "_last_codex_cli_goal_lifecycle", CodexCliGoalLifecycleGeneration()).trace_fields(),
                 "first_action_observed": bool(first_action_observed),
                 "bridge_request_count": bridge_request_count,
                 "task_facing_success_count": task_facing_success_count,

--- a/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
+++ b/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
@@ -86,8 +86,14 @@ def _capture_has_model_timeout(capture: str) -> bool:
     )
 
 
-def _capture_has_error_marker(capture: str) -> bool:
+def _capture_has_error_marker(
+    capture: str,
+    *,
+    include_goal_terminal_markers: bool = True,
+) -> bool:
     lowered = _recent_capture_region(capture).lower()
+    if not include_goal_terminal_markers:
+        lowered = lowered.replace("goal failed", "").replace("goal blocked", "")
     return any(
         marker in lowered
         for marker in ("error", "failed", "timed out", "timeout")
@@ -113,7 +119,10 @@ def codex_cli_tui_pre_bridge_blocker_stage(
         return "pre_bridge_tui_rate_limit"
     if _capture_has_model_timeout(capture):
         return "pre_bridge_tui_model_timeout"
-    if _capture_has_error_marker(capture):
+    if _capture_has_error_marker(
+        capture,
+        include_goal_terminal_markers=terminal_observed,
+    ):
         return "pre_bridge_tui_error_prompt"
     if terminal_observed and ("Goal failed" in capture or "Goal blocked" in capture):
         return "pre_bridge_tui_stale_terminal"

--- a/loopx/codex_cli_goal_tui.py
+++ b/loopx/codex_cli_goal_tui.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+from dataclasses import dataclass
 from pathlib import Path
 import re
 import shlex
@@ -27,6 +28,52 @@ CODEX_CLI_GOAL_KICKOFF_PROMPT = (
 )
 CODEX_CLI_TUI_READY_STARTUP_GRACE_SEC = 15.0
 CODEX_CLI_TUI_READY_STABLE_SEC = 2.0
+
+
+@dataclass(frozen=True)
+class CodexCliGoalLifecycleMarkerCounts:
+    active: int = 0
+    achieved: int = 0
+    failed: int = 0
+
+
+@dataclass
+class CodexCliGoalLifecycleGeneration:
+    generation: int = 0
+    baseline: CodexCliGoalLifecycleMarkerCounts = (
+        CodexCliGoalLifecycleMarkerCounts()
+    )
+    current: CodexCliGoalLifecycleMarkerCounts = CodexCliGoalLifecycleMarkerCounts()
+
+    def begin(self, capture: str) -> None:
+        self.generation += 1
+        self.baseline = codex_cli_goal_lifecycle_marker_counts(capture)
+        self.current = self.baseline
+
+    def observe(self, capture: str) -> None:
+        self.current = codex_cli_goal_lifecycle_marker_counts(capture)
+
+    @property
+    def active_advanced(self) -> bool:
+        return self.current.active > self.baseline.active
+
+    @property
+    def achieved_advanced(self) -> bool:
+        return self.current.achieved > self.baseline.achieved
+
+    @property
+    def failed_advanced(self) -> bool:
+        return self.current.failed > self.baseline.failed
+
+    def trace_fields(self) -> dict[str, int]:
+        fields = {"goal_submission_generation": max(0, self.generation)}
+        for name in ("active", "achieved", "failed"):
+            baseline = getattr(self.baseline, name)
+            current = getattr(self.current, name)
+            fields[f"goal_{name}_marker_baseline"] = baseline
+            fields[f"goal_{name}_marker_current"] = current
+            fields[f"goal_{name}_marker_delta"] = max(0, current - baseline)
+        return fields
 
 
 def resolve_codex_cli_binary(codex_bin: str) -> str | None:
@@ -369,6 +416,19 @@ def codex_cli_goal_watchdog_expired(
     """Keep bounded watchdogs from interrupting an active Codex turn."""
 
     return bool(deadline and now >= deadline and not turn_active)
+
+
+def codex_cli_goal_lifecycle_marker_counts(
+    capture: str,
+) -> CodexCliGoalLifecycleMarkerCounts:
+    """Count public lifecycle markers in a TUI scrollback capture."""
+
+    text = str(capture or "")
+    return CodexCliGoalLifecycleMarkerCounts(
+        active=text.count("Goal active") + text.count("Pursuing goal"),
+        achieved=text.count("Goal achieved"),
+        failed=text.count("Goal failed") + text.count("Goal blocked"),
+    )
 
 
 def codex_cli_tui_retryable_startup_blocker_stage(capture: str) -> str:


### PR DESCRIPTION
## Summary
- isolate Codex CLI `/goal` active/achieved/failed markers by submission generation
- ignore stale goal-terminal text when classifying current-generation pre-bridge blockers
- publish only marker counts/deltas and generation metadata in the public compact trace
- preserve kickoff state on pre-bridge recovery closeout

## Evidence
The post-#1869 `hvac-control` canary reached two bounded `typed_goal_resubmit` attempts but remained uncountable with `bridge_request_count=0`; the full TUI scrollback retained old lifecycle markers across both submissions. This change snapshots lifecycle marker counts before every initial/resubmitted `/goal` and only reacts to positive current-generation deltas.

## Validation
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- changed-file `py_compile`
- `git diff --check`
- `loopx canary premerge --from-git-diff`: direct checks, 6/6 catalog canaries, and public-boundary scan passed; benchmark-sensitive manual hold only

Owner has standing authorization in this task for benchmark helper/runtime self-merge after focused validation. No benchmark jobs are launched by this PR; scoring and task semantics are unchanged.