### PR TITLE
feat(issue-fix): collect material repository snapshots

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -342,6 +342,7 @@ tests whether the system is a durable employee rather than a scripted demo.
 | PR lifecycle | `loopx issue-fix pr-lifecycle` | Project CI, review, merge state, draft, merged, and closed signals into monitor transitions. |
 | Maintainer correction | `loopx issue-fix pr-lifecycle --maintainer-correction-json ... --execute-transition` | Turn bounded public review feedback into one claimed patch successor, a concrete user gate, or a quiet unchanged poll. |
 | Metrics projection | [`loopx issue-fix metrics`](protocols/issue-fix-metrics-projection-v0.md) | Keep repository baseline separate from attributable agent output, combine existing feasibility/PR lifecycle rows with caller-supplied public snapshots, and report deltas, ratios, inventory, and missing data without another ledger. |
+| Repository snapshot | `loopx issue-fix repository-snapshot` | Explicitly collect bounded public GitHub stock/flow and known issue/PR state; optionally retain only material daily changes in the existing issue-fix domain state. |
 | Acceptance fixture | `loopx issue-fix acceptance-fixture` | Prove failure-before, minimal patch, and pass-after in a deterministic fixture. |
 | Git branch fixture | `loopx issue-fix repo-branch-fixture` | Exercise the same repair contract through a temporary git branch. |
 | Caller repo branch | `loopx issue-fix caller-repo-branch` | Inspect an approved local repo, create/claim an issue branch, and run caller-declared validation. |
@@ -846,6 +847,7 @@ python3 examples/issue-fix-validated-memory-writeback-smoke.py
 python3 examples/issue-fix-feasibility-smoke.py
 python3 examples/issue-fix-pr-lifecycle-smoke.py
 python3 examples/issue-fix-metrics-projection-smoke.py
+python3 examples/issue-fix-repository-snapshot-smoke.py
 python3 examples/issue-fix-maintainer-correction-smoke.py
 python3 examples/issue-fix-outcome-projection-smoke.py
 python3 examples/issue-fix-acceptance-loop-smoke.py

--- a/docs/capabilities/issue-fix/README.zh-CN.md
+++ b/docs/capabilities/issue-fix/README.zh-CN.md
@@ -354,6 +354,7 @@ state 仍优先于迟到反馈。
 | PR lifecycle | `loopx issue-fix pr-lifecycle` | 把 CI、review、merge state、draft、merged、closed 信号投影为 monitor transition。 |
 | Maintainer correction | `loopx issue-fix pr-lifecycle --maintainer-correction-json ... --execute-transition` | 把有限公开反馈转成一个已认领 patch successor、具体 user gate，或安静的 unchanged poll。 |
 | 指标投影 | [`loopx issue-fix metrics`](protocols/issue-fix-metrics-projection-v0.md) | 严格区分仓库存量基线与 agent 可归因产出；组合现有 feasibility/PR lifecycle 行和调用方提供的公开快照，输出 delta、比例、产出清单与缺失数据，不新增 ledger。 |
+| 仓库快照 | `loopx issue-fix repository-snapshot` | 显式采集有界的公开 GitHub stock/flow 与已知 issue/PR 状态；可选地只把物质日变化写入现有 issue-fix domain state。 |
 | Acceptance fixture | `loopx issue-fix acceptance-fixture` | 在 deterministic fixture 中证明 failure-before、minimal patch、pass-after。 |
 | Git branch fixture | `loopx issue-fix repo-branch-fixture` | 在临时 git branch 中运行同一修复 contract。 |
 | Caller repo branch | `loopx issue-fix caller-repo-branch` | 检查获批本地 repo、创建/认领 issue branch、运行 caller-declared validation。 |
@@ -812,6 +813,7 @@ python3 examples/issue-fix-validated-memory-writeback-smoke.py
 python3 examples/issue-fix-feasibility-smoke.py
 python3 examples/issue-fix-pr-lifecycle-smoke.py
 python3 examples/issue-fix-metrics-projection-smoke.py
+python3 examples/issue-fix-repository-snapshot-smoke.py
 python3 examples/issue-fix-maintainer-correction-smoke.py
 python3 examples/issue-fix-outcome-projection-smoke.py
 python3 examples/issue-fix-acceptance-loop-smoke.py

--- a/docs/capabilities/issue-fix/protocols/issue-fix-metrics-projection-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-metrics-projection-v0.md
@@ -108,6 +108,29 @@ raw issue bodies, comments, provider responses, transcripts, and tool logs.
 Daily public snapshot collection and Kanban/dashboard rendering are separate
 adapters over this packet. They must not become a second source of truth.
 
+`loopx issue-fix repository-snapshot` is the bounded public GitHub collector.
+It reads repository stock/flow plus the current state of issue/PR references
+already present in the goal's issue-fix domain state. The command never retains
+raw provider payloads. With `--retain-material-snapshot`, it writes at most one
+row per day to the existing `issue_fix/repository-snapshots.jsonl` stream and
+skips the write when stock, flow, issue state, PR state, CI, and review are
+unchanged:
+
+```bash
+loopx --format json issue-fix repository-snapshot \
+  --goal-id public-issue-fix-goal \
+  --project /path/to/connected/project \
+  --repo owner/repo \
+  --repository-baseline-json baseline.json \
+  --fetch-public-github \
+  --retain-material-snapshot
+```
+
+The returned `snapshot` object can be passed directly as
+`--repository-current-json` to `loopx issue-fix metrics`. Scheduling remains a
+normal LoopX `continuous_monitor` todo; the collector does not install a second
+scheduler or invent another workflow state machine.
+
 ## Monthly Impact projection
 
 The metrics packet includes stable `impact_rows` for repository health,
@@ -140,4 +163,5 @@ through the normal schema-reconciliation path.
 
 ```bash
 python3 examples/issue-fix-metrics-projection-smoke.py
+python3 examples/issue-fix-repository-snapshot-smoke.py
 ```

--- a/examples/issue-fix-repository-snapshot-smoke.py
+++ b/examples/issue-fix-repository-snapshot-smoke.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Contract smoke for bounded public issue-fix repository snapshots."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value) + "\n", encoding="utf-8")
+
+
+def _write_jsonl(path: Path, values: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(value) + "\n" for value in values),
+        encoding="utf-8",
+    )
+
+
+def _fake_gh(path: Path) -> None:
+    path.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+
+args = sys.argv[1:]
+changed = os.environ.get("FAKE_GH_VARIANT") == "changed"
+if args[:2] == ["api", "graphql"]:
+    query = next((item.split("=", 1)[1] for item in args if item.startswith("query=")), "")
+    if "issues(states:OPEN)" in query:
+        print(json.dumps({"data": {"repository": {
+            "issues": {"totalCount": 13 if changed else 12},
+            "pullRequests": {"totalCount": 5},
+        }}}))
+    else:
+        nodes = [
+            {"__typename": "Issue", "createdAt": "2026-07-02T00:00:00Z", "closedAt": None},
+            {"__typename": "Issue", "createdAt": "2026-07-03T00:00:00Z", "closedAt": "2026-07-20T00:00:00Z"},
+            {"__typename": "Issue", "createdAt": "2026-07-04T00:00:00Z", "closedAt": "2026-07-21T00:00:00Z"},
+            {"__typename": "Issue", "createdAt": "2026-07-05T00:00:00Z", "closedAt": "2026-07-22T00:00:00Z"},
+            {"__typename": "Issue", "createdAt": "2026-07-06T00:00:00Z", "closedAt": None},
+            {"__typename": "PullRequest", "createdAt": "2026-07-07T00:00:00Z", "closedAt": "2026-07-25T00:00:00Z", "mergedAt": "2026-07-25T00:00:00Z"},
+            {"__typename": "PullRequest", "createdAt": "2026-07-08T00:00:00Z", "closedAt": "2026-07-26T00:00:00Z", "mergedAt": "2026-07-26T00:00:00Z"},
+            {"__typename": "PullRequest", "createdAt": "2026-07-09T00:00:00Z", "closedAt": "2026-07-27T00:00:00Z", "mergedAt": None},
+            {"__typename": "PullRequest", "createdAt": "2026-07-10T00:00:00Z", "closedAt": None, "mergedAt": None},
+        ]
+        if changed:
+            nodes.append({"__typename": "Issue", "createdAt": "2026-07-11T00:00:00Z", "closedAt": None})
+        print(json.dumps([{"data": {"search": {"nodes": nodes}}}]))
+elif args[:2] == ["issue", "view"]:
+    number = int(args[2])
+    closed = number == 42
+    print(json.dumps({
+        "number": number,
+        "state": "CLOSED" if closed else "OPEN",
+        "url": f"https://github.com/public-fixture/widgets/issues/{number}",
+        "closedAt": "2026-07-25T00:00:00Z" if closed else None,
+        "updatedAt": "2026-07-25T00:00:00Z",
+    }))
+elif args[:2] == ["pr", "view"]:
+    number = int(args[2])
+    merged = number == 77
+    print(json.dumps({
+        "number": number,
+        "state": "MERGED" if merged else "OPEN",
+        "url": f"https://github.com/public-fixture/widgets/pull/{number}",
+        "createdAt": f"2026-07-{number - 70:02d}T00:00:00Z",
+        "updatedAt": "2026-07-25T00:00:00Z",
+        "reviewDecision": "APPROVED" if merged else "REVIEW_REQUIRED",
+        "statusCheckRollup": [{"status": "COMPLETED", "conclusion": "SUCCESS"}],
+    }))
+else:
+    raise SystemExit(2)
+""",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-issue-fix-snapshot-") as tmp:
+        root = Path(tmp)
+        fake_bin = root / "bin"
+        fake_bin.mkdir()
+        _fake_gh(fake_bin / "gh")
+        baseline = root / "baseline.json"
+        _write_json(
+            baseline,
+            {
+                "schema_version": "issue_fix_repository_reporting_snapshot_v0",
+                "repo": "public-fixture/widgets",
+                "captured_at": "2026-07-01T00:00:00Z",
+                "open_issues": 10,
+                "open_pull_requests": 4,
+            },
+        )
+        domain = root / ".loopx" / "domain-state" / "fixture-goal" / "issue_fix"
+        _write_jsonl(
+            domain / "feasibility.jsonl",
+            [
+                {
+                    "observation": {
+                        "repo": "public-fixture/widgets",
+                        "issue_ref": "issues_42",
+                    }
+                },
+                {
+                    "observation": {
+                        "repo": "public-fixture/widgets",
+                        "issue_ref": "issues_43",
+                    }
+                },
+            ],
+        )
+        _write_jsonl(
+            domain / "pr-lifecycle.jsonl",
+            [
+                {
+                    "observation": {
+                        "repo": "public-fixture/widgets",
+                        "pr_ref": "pull_77",
+                    }
+                },
+                {
+                    "observation": {
+                        "repo": "public-fixture/widgets",
+                        "pr_ref": "pull_78",
+                    }
+                },
+            ],
+        )
+        command = [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "issue-fix",
+            "repository-snapshot",
+            "--goal-id",
+            "fixture-goal",
+            "--project",
+            str(root),
+            "--repo",
+            "public-fixture/widgets",
+            "--repository-baseline-json",
+            str(baseline),
+            "--fetch-public-github",
+            "--retain-material-snapshot",
+            "--generated-at",
+            "2026-08-01T00:00:00Z",
+        ]
+        env = {**os.environ, "PATH": f"{fake_bin}:{os.environ['PATH']}"}
+        first = subprocess.run(
+            command,
+            cwd=ROOT,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        packet = json.loads(first.stdout)
+        snapshot = packet["snapshot"]
+        assert snapshot["open_issues"] == 12, packet
+        assert snapshot["open_pull_requests"] == 5, packet
+        assert snapshot["flow_since_baseline"]["issues_closed"] == 3, packet
+        assert len(snapshot["issue_states"]) == 2, packet
+        assert len(snapshot["pull_request_states"]) == 2, packet
+        assert packet["retention"]["write_performed"] is True, packet
+        assert packet["raw_provider_payload_captured"] is False, packet
+        assert packet["credentials_captured"] is False, packet
+        assert packet["local_paths_captured"] is False, packet
+
+        second = subprocess.run(
+            command,
+            cwd=ROOT,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        second_packet = json.loads(second.stdout)
+        assert second_packet["retention"]["write_performed"] is False, second_packet
+
+        changed = subprocess.run(
+            command,
+            cwd=ROOT,
+            env={**env, "FAKE_GH_VARIANT": "changed"},
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        changed_packet = json.loads(changed.stdout)
+        assert changed_packet["snapshot"]["open_issues"] == 13, changed_packet
+        assert changed_packet["retention"]["write_performed"] is True, changed_packet
+        ledger = domain / "repository-snapshots.jsonl"
+        rows = [json.loads(line) for line in ledger.read_text().splitlines()]
+        assert len(rows) == 1, rows
+        assert rows[0]["snapshot"]["open_issues"] == 13, rows
+        serialized = json.dumps(changed_packet, sort_keys=True)
+        assert str(root) not in serialized, serialized
+
+    print("issue-fix repository snapshot smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -13,7 +13,9 @@ from ...control_plane.runtime.time import now_utc_iso
 from ...domain_packs.issue_fix import (
     default_issue_fix_domain_state_ledger_path,
     default_issue_fix_feasibility_ledger_path,
+    default_issue_fix_repository_snapshot_ledger_path,
     persist_issue_fix_reviewer_notification_receipts,
+    retain_issue_fix_repository_snapshot_jsonl,
     upsert_issue_fix_feasibility_ledger_jsonl,
     upsert_issue_fix_pr_lifecycle_ledger_jsonl,
 )
@@ -63,6 +65,11 @@ from .repository_memory_provider import (
     retrieve_issue_fix_repository_memory,
     sync_issue_fix_repository_memory,
     write_issue_fix_validated_outcome_memory,
+)
+from .repository_snapshot import (
+    collect_public_github_repository_snapshot,
+    render_repository_snapshot_markdown,
+    repository_snapshot_record,
 )
 from .workflow_plan import (
     build_issue_fix_workflow_plan_packet,
@@ -786,6 +793,35 @@ def register_issue_fix_commands(
         help="Optional PR lifecycle JSONL override; defaults to goal domain state.",
     )
     _add_generated_at_arg(metrics_parser, artifact="the metrics projection")
+    snapshot_parser = issue_fix_sub.add_parser(
+        "repository-snapshot",
+        help=(
+            "Collect a compact public GitHub repository snapshot for issue-fix "
+            "metrics and optionally retain one material snapshot per day."
+        ),
+    )
+    add_subcommand_format(snapshot_parser)
+    snapshot_parser.add_argument("--goal-id", required=True)
+    snapshot_parser.add_argument("--project", default=".")
+    snapshot_parser.add_argument("--repo", required=True)
+    snapshot_parser.add_argument("--repository-baseline-json", required=True)
+    snapshot_parser.add_argument(
+        "--fetch-public-github",
+        action="store_true",
+        help="Explicitly read bounded public repository metadata through gh.",
+    )
+    snapshot_parser.add_argument(
+        "--retain-material-snapshot",
+        action="store_true",
+        help=(
+            "Write only a material daily change into the existing issue_fix "
+            "domain-state stream."
+        ),
+    )
+    snapshot_parser.add_argument(
+        "--fetch-timeout-seconds", type=int, default=30
+    )
+    _add_generated_at_arg(snapshot_parser, artifact="the repository snapshot")
     reviewer_parser = issue_fix_sub.add_parser(
         "reviewer-plan",
         help=(
@@ -1605,6 +1641,46 @@ def handle_issue_fix_command(
                 generated_at=generated_at,
             )
             renderer = render_issue_fix_metrics_projection_markdown
+        elif args.issue_fix_command == "repository-snapshot":
+            if not args.fetch_public_github:
+                raise ValueError("repository-snapshot requires --fetch-public-github")
+            project = Path(args.project).expanduser()
+            payload = collect_public_github_repository_snapshot(
+                repo=args.repo,
+                baseline_snapshot=_load_json_object(
+                    args.repository_baseline_json
+                ),
+                feasibility_rows=_load_jsonl_rows(
+                    default_issue_fix_feasibility_ledger_path(
+                        project=project, goal_id=args.goal_id
+                    )
+                ),
+                pr_lifecycle_rows=_load_jsonl_rows(
+                    default_issue_fix_domain_state_ledger_path(
+                        project=project, goal_id=args.goal_id
+                    )
+                ),
+                generated_at=generated_at,
+                timeout_seconds=args.fetch_timeout_seconds,
+            )
+            if args.retain_material_snapshot:
+                write_result = retain_issue_fix_repository_snapshot_jsonl(
+                    default_issue_fix_repository_snapshot_ledger_path(
+                        project=project, goal_id=args.goal_id
+                    ),
+                    repository_snapshot_record(payload["snapshot"]),
+                )
+                payload["retention"] = {
+                    "schema_version": "issue_fix_repository_snapshot_retention_v0",
+                    "domain_pack": "issue_fix",
+                    "stream": "repository_snapshots",
+                    "write_performed": write_result.get("write_performed") is True,
+                    "status": write_result.get("status"),
+                    "row_count": write_result.get("row_count"),
+                    "path_recorded": False,
+                }
+                payload["source_contract"]["writes_source_state"] = True
+            renderer = render_repository_snapshot_markdown
         elif args.issue_fix_command == "reviewer-plan":
             payload = build_issue_fix_reviewer_recommendation_packet(
                 repo_path=args.repo_path,
@@ -1815,7 +1891,8 @@ def handle_issue_fix_command(
         else:
             raise ValueError(
                 "issue-fix requires `repository-memory-sync`, `workflow-plan`, `feasibility`, "
-                "`acceptance-fixture`, `pr-lifecycle`, `outcome`, `metrics`, `reviewer-plan`, "
+                "`acceptance-fixture`, `pr-lifecycle`, `outcome`, `metrics`, "
+                "`repository-snapshot`, `reviewer-plan`, "
                 "`reviewer-request`, "
                 "`repo-branch-fixture`, or `caller-repo-branch`"
             )
@@ -1838,6 +1915,8 @@ def handle_issue_fix_command(
             if getattr(args, "issue_fix_command", None) == "outcome"
             else render_issue_fix_metrics_projection_markdown
             if getattr(args, "issue_fix_command", None) == "metrics"
+            else render_repository_snapshot_markdown
+            if getattr(args, "issue_fix_command", None) == "repository-snapshot"
             else render_issue_fix_reviewer_recommendation_markdown
             if getattr(args, "issue_fix_command", None) == "reviewer-plan"
             else render_issue_fix_reviewer_request_markdown

--- a/loopx/capabilities/issue_fix/repository_snapshot.py
+++ b/loopx/capabilities/issue_fix/repository_snapshot.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from typing import Any
+
+
+SNAPSHOT_SCHEMA_VERSION = "issue_fix_repository_reporting_snapshot_v0"
+COLLECTION_SCHEMA_VERSION = "issue_fix_repository_snapshot_collection_v0"
+RECORD_SCHEMA_VERSION = "issue_fix_repository_snapshot_record_v0"
+
+_REPO_PATTERN = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+_REF_NUMBER_PATTERN = re.compile(r"(?:issues|pull)_(\d+)")
+_FAILED_CHECK_CONCLUSIONS = {
+    "ACTION_REQUIRED",
+    "CANCELLED",
+    "FAILURE",
+    "TIMED_OUT",
+}
+_PENDING_CHECK_STATES = {"IN_PROGRESS", "PENDING", "QUEUED", "REQUESTED", "WAITING"}
+
+
+def _timestamp(value: Any, *, field: str) -> tuple[str, datetime]:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{field} is required")
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        raise ValueError(f"{field} must be an ISO-8601 timestamp") from None
+    if parsed.utcoffset() is None:
+        raise ValueError(f"{field} must include a timezone")
+    return text, parsed
+
+
+def _run_gh_json(arguments: list[str], *, timeout_seconds: int, operation: str) -> Any:
+    try:
+        completed = subprocess.run(
+            ["gh", *arguments],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout_seconds,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        raise ValueError(f"public GitHub {operation} failed") from None
+    if completed.returncode != 0:
+        raise ValueError(f"public GitHub {operation} failed")
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError:
+        raise ValueError(f"public GitHub {operation} returned invalid JSON") from None
+
+
+def _repo_parts(repo: str) -> tuple[str, str]:
+    repo = str(repo or "").strip()
+    if not _REPO_PATTERN.fullmatch(repo):
+        raise ValueError("repo must use owner/name")
+    owner, name = repo.split("/", 1)
+    return owner, name
+
+
+def _reference_numbers(
+    rows: list[dict[str, Any]], *, repo: str, ref_field: str
+) -> list[int]:
+    numbers: set[int] = set()
+    for row in rows:
+        observation = row.get("observation") if isinstance(row, dict) else None
+        if not isinstance(observation, dict) or observation.get("repo") != repo:
+            continue
+        match = _REF_NUMBER_PATTERN.fullmatch(
+            str(observation.get(ref_field) or "").strip()
+        )
+        if match:
+            numbers.add(int(match.group(1)))
+    if len(numbers) > 50:
+        raise ValueError(f"at most 50 {ref_field} references may be refreshed")
+    return sorted(numbers)
+
+
+def _check_state(rollups: Any) -> str:
+    if not isinstance(rollups, list) or not rollups:
+        return "UNKNOWN"
+    for item in rollups:
+        if (
+            isinstance(item, dict)
+            and str(item.get("conclusion") or "").upper() in _FAILED_CHECK_CONCLUSIONS
+        ):
+            return "FAILING"
+    for item in rollups:
+        if not isinstance(item, dict):
+            continue
+        status = str(item.get("status") or "").upper()
+        if status in _PENDING_CHECK_STATES or item.get("conclusion") is None:
+            return "PENDING"
+    return "PASSING"
+
+
+def _public_stock(repo: str, *, timeout_seconds: int) -> dict[str, int]:
+    owner, name = _repo_parts(repo)
+    query = (
+        "query($owner:String!,$name:String!){repository(owner:$owner,name:$name){"
+        "issues(states:OPEN){totalCount} pullRequests(states:OPEN){totalCount}}}"
+    )
+    payload = _run_gh_json(
+        [
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-f",
+            f"owner={owner}",
+            "-f",
+            f"name={name}",
+        ],
+        timeout_seconds=timeout_seconds,
+        operation="repository stock read",
+    )
+    repository = (payload.get("data") or {}).get("repository") or {}
+    try:
+        return {
+            "open_issues": int(repository["issues"]["totalCount"]),
+            "open_pull_requests": int(repository["pullRequests"]["totalCount"]),
+        }
+    except (KeyError, TypeError, ValueError):
+        raise ValueError("public GitHub repository stock is incomplete") from None
+
+
+def _public_flow(
+    repo: str, *, baseline_at: str, baseline_time: datetime, timeout_seconds: int
+) -> dict[str, int]:
+    query = (
+        "query($queryString:String!,$endCursor:String){search("
+        "query:$queryString,type:ISSUE,first:100,after:$endCursor){"
+        "pageInfo{hasNextPage endCursor} nodes{"
+        "... on Issue{__typename createdAt closedAt} "
+        "... on PullRequest{__typename createdAt closedAt mergedAt}}}}"
+    )
+    day = baseline_at[:10]
+    pages = _run_gh_json(
+        [
+            "api",
+            "graphql",
+            "--paginate",
+            "--slurp",
+            "-f",
+            f"query={query}",
+            "-f",
+            f"queryString=repo:{repo} updated:>={day}",
+        ],
+        timeout_seconds=timeout_seconds,
+        operation="repository flow read",
+    )
+    nodes: list[dict[str, Any]] = []
+    for page in pages if isinstance(pages, list) else []:
+        search = (page.get("data") or {}).get("search") or {}
+        nodes.extend(
+            item for item in search.get("nodes") or [] if isinstance(item, dict)
+        )
+
+    def after(value: Any) -> bool:
+        if not value:
+            return False
+        _, parsed = _timestamp(value, field="github.event_at")
+        return parsed >= baseline_time
+
+    return {
+        "issues_opened": sum(
+            item.get("__typename") == "Issue" and after(item.get("createdAt"))
+            for item in nodes
+        ),
+        "issues_closed": sum(
+            item.get("__typename") == "Issue" and after(item.get("closedAt"))
+            for item in nodes
+        ),
+        "pull_requests_opened": sum(
+            item.get("__typename") == "PullRequest" and after(item.get("createdAt"))
+            for item in nodes
+        ),
+        "pull_requests_closed": sum(
+            item.get("__typename") == "PullRequest" and after(item.get("closedAt"))
+            for item in nodes
+        ),
+        "pull_requests_merged": sum(
+            item.get("__typename") == "PullRequest" and after(item.get("mergedAt"))
+            for item in nodes
+        ),
+    }
+
+
+def _issue_state(repo: str, number: int, *, timeout_seconds: int) -> dict[str, Any]:
+    payload = _run_gh_json(
+        [
+            "issue",
+            "view",
+            str(number),
+            "--repo",
+            repo,
+            "--json",
+            "number,state,url,closedAt,updatedAt",
+        ],
+        timeout_seconds=timeout_seconds,
+        operation=f"issue {number} state read",
+    )
+    result = {
+        "issue_ref": f"issues_{number}",
+        "state": str(payload.get("state") or "").upper(),
+    }
+    if payload.get("closedAt"):
+        result["closed_at"] = payload["closedAt"]
+    return result
+
+
+def _pr_state(repo: str, number: int, *, timeout_seconds: int) -> dict[str, Any]:
+    payload = _run_gh_json(
+        [
+            "pr",
+            "view",
+            str(number),
+            "--repo",
+            repo,
+            "--json",
+            "number,state,url,createdAt,updatedAt,reviewDecision,statusCheckRollup",
+        ],
+        timeout_seconds=timeout_seconds,
+        operation=f"pull request {number} state read",
+    )
+    review = str(payload.get("reviewDecision") or "UNKNOWN").upper()
+    if review not in {"APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED"}:
+        review = "UNKNOWN"
+    return {
+        "pr_ref": f"pull_{number}",
+        "state": str(payload.get("state") or "").upper(),
+        "ci": _check_state(payload.get("statusCheckRollup")),
+        "review": review,
+        "created_at": payload.get("createdAt"),
+        "updated_at": payload.get("updatedAt"),
+    }
+
+
+def material_snapshot_fingerprint(snapshot: dict[str, Any]) -> str:
+    material = {
+        "repo": snapshot.get("repo"),
+        "open_issues": snapshot.get("open_issues"),
+        "open_pull_requests": snapshot.get("open_pull_requests"),
+        "flow_since_baseline": snapshot.get("flow_since_baseline"),
+        "issue_states": [
+            {"issue_ref": item.get("issue_ref"), "state": item.get("state")}
+            for item in snapshot.get("issue_states") or []
+            if isinstance(item, dict)
+        ],
+        "pull_request_states": [
+            {
+                "pr_ref": item.get("pr_ref"),
+                "state": item.get("state"),
+                "ci": item.get("ci"),
+                "review": item.get("review"),
+            }
+            for item in snapshot.get("pull_request_states") or []
+            if isinstance(item, dict)
+        ],
+    }
+    encoded = json.dumps(
+        material, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    )
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def repository_snapshot_record(snapshot: dict[str, Any]) -> dict[str, Any]:
+    captured_at, _ = _timestamp(
+        snapshot.get("captured_at"), field="snapshot.captured_at"
+    )
+    return {
+        "schema_version": RECORD_SCHEMA_VERSION,
+        "repo": snapshot.get("repo"),
+        "snapshot_date": captured_at[:10],
+        "captured_at": captured_at,
+        "material_fingerprint": material_snapshot_fingerprint(snapshot),
+        "snapshot": snapshot,
+        "raw_provider_payload_captured": False,
+        "credentials_captured": False,
+        "local_paths_captured": False,
+    }
+
+
+def collect_public_github_repository_snapshot(
+    *,
+    repo: str,
+    baseline_snapshot: dict[str, Any],
+    feasibility_rows: list[dict[str, Any]],
+    pr_lifecycle_rows: list[dict[str, Any]],
+    generated_at: str,
+    timeout_seconds: int = 30,
+) -> dict[str, Any]:
+    _repo_parts(repo)
+    if timeout_seconds < 1 or timeout_seconds > 120:
+        raise ValueError("timeout_seconds must be between 1 and 120")
+    if baseline_snapshot.get("schema_version") != SNAPSHOT_SCHEMA_VERSION:
+        raise ValueError(f"baseline snapshot must use {SNAPSHOT_SCHEMA_VERSION}")
+    if baseline_snapshot.get("repo") != repo:
+        raise ValueError("baseline snapshot repo must match repo")
+    baseline_at, baseline_time = _timestamp(
+        baseline_snapshot.get("captured_at"), field="baseline.captured_at"
+    )
+    captured_at, captured_time = _timestamp(generated_at, field="generated_at")
+    if captured_time < baseline_time:
+        raise ValueError("generated_at must not predate the baseline")
+
+    stock = _public_stock(repo, timeout_seconds=timeout_seconds)
+    flow = _public_flow(
+        repo,
+        baseline_at=baseline_at,
+        baseline_time=baseline_time,
+        timeout_seconds=timeout_seconds,
+    )
+    expected_issues = (
+        int(baseline_snapshot.get("open_issues"))
+        + flow["issues_opened"]
+        - flow["issues_closed"]
+    )
+    expected_prs = (
+        int(baseline_snapshot.get("open_pull_requests"))
+        + flow["pull_requests_opened"]
+        - flow["pull_requests_closed"]
+    )
+    if (
+        expected_issues != stock["open_issues"]
+        or expected_prs != stock["open_pull_requests"]
+    ):
+        raise ValueError("public GitHub stock and flow do not reconcile")
+
+    issue_numbers = _reference_numbers(
+        feasibility_rows, repo=repo, ref_field="issue_ref"
+    )
+    pr_numbers = _reference_numbers(pr_lifecycle_rows, repo=repo, ref_field="pr_ref")
+    with ThreadPoolExecutor(
+        max_workers=min(8, max(1, len(issue_numbers) + len(pr_numbers)))
+    ) as pool:
+        issue_states = list(
+            pool.map(
+                lambda number: _issue_state(
+                    repo, number, timeout_seconds=timeout_seconds
+                ),
+                issue_numbers,
+            )
+        )
+        pr_states = list(
+            pool.map(
+                lambda number: _pr_state(repo, number, timeout_seconds=timeout_seconds),
+                pr_numbers,
+            )
+        )
+    snapshot = {
+        "schema_version": SNAPSHOT_SCHEMA_VERSION,
+        "repo": repo,
+        "captured_at": captured_at,
+        "source_url": f"https://github.com/{repo}",
+        **stock,
+        "flow_since_baseline": flow,
+        "issue_states": issue_states,
+        "pull_request_states": pr_states,
+    }
+    return {
+        "ok": True,
+        "schema_version": COLLECTION_SCHEMA_VERSION,
+        "mode": "issue-fix-repository-snapshot",
+        "repo": repo,
+        "baseline_at": baseline_at,
+        "snapshot": snapshot,
+        "material_fingerprint": material_snapshot_fingerprint(snapshot),
+        "source_contract": {
+            "provider": "public_github_cli",
+            "reads_existing_issue_fix_domain_state": True,
+            "writes_source_state": False,
+        },
+        "external_reads_performed": True,
+        "external_writes_performed": False,
+        "raw_provider_payload_captured": False,
+        "credentials_captured": False,
+        "local_paths_captured": False,
+    }
+
+
+def render_repository_snapshot_markdown(payload: dict[str, Any]) -> str:
+    if payload.get("ok") is not True:
+        return f"# Issue-fix repository snapshot\n\n- Error: {payload.get('error') or 'collection failed'}"
+    snapshot = payload.get("snapshot") or {}
+    flow = snapshot.get("flow_since_baseline") or {}
+    return "\n".join(
+        [
+            "# Issue-fix repository snapshot",
+            "",
+            f"- repository: `{snapshot.get('repo')}`",
+            f"- captured at: `{snapshot.get('captured_at')}`",
+            f"- open issues: `{snapshot.get('open_issues')}`",
+            f"- open pull requests: `{snapshot.get('open_pull_requests')}`",
+            f"- issues closed since baseline: `{flow.get('issues_closed')}`",
+            f"- pull requests merged since baseline: `{flow.get('pull_requests_merged')}`",
+            f"- material snapshot retained: `{(payload.get('retention') or {}).get('write_performed', False)}`",
+        ]
+    )

--- a/loopx/domain_packs/issue_fix.py
+++ b/loopx/domain_packs/issue_fix.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Callable
 from pathlib import Path
@@ -10,6 +11,7 @@ from ..domain_state import default_domain_state_file_path, upsert_domain_state_j
 
 ISSUE_FIX_DOMAIN_STATE_LEDGER_FILENAME = "pr-lifecycle.jsonl"
 ISSUE_FIX_FEASIBILITY_LEDGER_FILENAME = "feasibility.jsonl"
+ISSUE_FIX_REPOSITORY_SNAPSHOT_LEDGER_FILENAME = "repository-snapshots.jsonl"
 REVIEWER_NOTIFICATION_RECEIPT_PATTERN = re.compile(r"sha256:[a-f0-9]{64}")
 
 
@@ -234,4 +236,51 @@ def default_issue_fix_feasibility_ledger_path(
         goal_id=goal_id,
         domain_pack="issue_fix",
         filename=ISSUE_FIX_FEASIBILITY_LEDGER_FILENAME,
+    )
+
+
+def default_issue_fix_repository_snapshot_ledger_path(
+    *, project: str | Path = ".", goal_id: str
+) -> Path:
+    return default_domain_state_file_path(
+        project=project,
+        goal_id=goal_id,
+        domain_pack="issue_fix",
+        filename=ISSUE_FIX_REPOSITORY_SNAPSHOT_LEDGER_FILENAME,
+    )
+
+
+def retain_issue_fix_repository_snapshot_jsonl(
+    ledger_path: str | Path, record: dict[str, Any]
+) -> dict[str, Any]:
+    path = Path(ledger_path)
+    existing_rows: list[dict[str, Any]] = []
+    if path.exists():
+        for line in path.read_text(encoding="utf-8").splitlines():
+            try:
+                value = json.loads(line)
+            except (TypeError, ValueError):
+                continue
+            if isinstance(value, dict):
+                existing_rows.append(value)
+    repo = str(record.get("repo") or "")
+    fingerprint = str(record.get("material_fingerprint") or "")
+    latest = next(
+        (row for row in reversed(existing_rows) if row.get("repo") == repo), None
+    )
+    if latest and latest.get("material_fingerprint") == fingerprint:
+        return {
+            "status": "unchanged",
+            "write_performed": False,
+            "row_count": len(existing_rows),
+            "path_recorded": False,
+        }
+    return upsert_domain_state_jsonl(
+        path,
+        record,
+        key={"repo": repo, "snapshot_date": record.get("snapshot_date")},
+        existing_key_fn=lambda row: {
+            "repo": row.get("repo"),
+            "snapshot_date": row.get("snapshot_date"),
+        },
     )


### PR DESCRIPTION
## Motivation

Monthly issue-fix reporting previously required an agent to hand-compose GitHub GraphQL and lifecycle queries. That made daily refreshes hard to audit and easy to drift from the metrics contract.

## Implementation

- add `loopx issue-fix repository-snapshot` with explicit public GitHub reads
- collect repository open issue/PR stock and exact flow since the supplied baseline
- refresh only issue and PR references already present in issue-fix domain state
- include compact PR CI/review state for direct metrics consumption
- optionally retain one material snapshot per day in the existing issue-fix domain pack
- skip unchanged snapshots using a fingerprint that excludes timestamps and raw provider output
- fail closed when stock and flow do not reconcile

## Validation

- `python3 examples/issue-fix-repository-snapshot-smoke.py`
- `python3 examples/issue-fix-metrics-projection-smoke.py`
- `python3 examples/issue-fix-capability-guide-smoke.py`
- `python3 examples/issue-fix-workflow-contract-smoke.py`
- `python3 examples/lark-kanban-control-plane-smoke.py`
- Ruff and Python compile checks on touched modules
- LoopX premerge canary: 17/17 selected checks passed, zero warnings
- real OpenViking dogfood: 97 open issues, 211 open PRs, 31 PRs opened and 20 merged since baseline; seven linked issue/PR states refreshed; first snapshot retained and identical retry skipped
- end-to-end metrics/Kanban readback: 17 rows and repository PR share updated to 7/31 = 0.2258

## Risk

The command performs bounded public network reads only when `--fetch-public-github` is explicit. GitHub search incompleteness or provider failure is surfaced as a reconciliation error instead of emitting an apparently successful snapshot. Retention writes compact public metadata only and records no local path.

## Not covered

Event-derived supplemental autonomy/capability/memory metrics and explicit source-row reconciliation remain separate successors. Daily scheduling stays in the existing LoopX monitor todo rather than installing another scheduler.