### PR TITLE
Widen SkillsBench tunnel startup budgets

### DIFF
--- a/examples/skillsbench-benchmark-egress-policy-smoke.py
+++ b/examples/skillsbench-benchmark-egress-policy-smoke.py
@@ -140,6 +140,8 @@ def test_public_launcher_uses_container_reachable_benchmark_proxy() -> None:
             "SKILLSBENCH_REMOTE_CODEX_BIN": "/remote/bin/codex",
             "SKILLSBENCH_LOCAL_CODEX_SANDBOX": "danger-full-access",
             "SKILLSBENCH_RUN_STAMP": "20260709T000000CST",
+            "SKILLSBENCH_TUNNEL_PROBE_TIMEOUT_SEC": "19",
+            "SKILLSBENCH_TUNNEL_READY_TIMEOUT_SEC": "71",
         }
     )
     env.pop("SKILLSBENCH_APPEND_HISTORY", None)
@@ -171,6 +173,8 @@ def test_public_launcher_uses_container_reachable_benchmark_proxy() -> None:
     assert "--local-codex-sandbox danger-full-access" in output, output
     assert "local_codex_sandbox=danger-full-access" in output, output
     assert "remote_codex_bin_mode=explicit" in output, output
+    assert "--probe-timeout-sec 19" in output, output
+    assert "--tunnel-ready-timeout-sec 71" in output, output
     assert (
         "--local-ledger-catchup-run-group-contains "
         "skillsbench-codex-cli-goal-xhigh-citation-check-egress-smoke-"
@@ -216,6 +220,8 @@ def test_public_launcher_batches_three_cases_with_closeout_sync() -> None:
     ), output
     assert "--parallel-cases 3" in output, output
     assert "--remote-public-artifact-root" in output, output
+    assert "--probe-timeout-sec 20" in output, output
+    assert "--tunnel-ready-timeout-sec 60" in output, output
     assert "benchmark_run.compact.json" in output, output
     assert "--local-run-ledger-path" in output, output
     assert "--local-ledger-catchup-root" in output, output

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -32,6 +32,10 @@ Optional env:
   SKILLSBENCH_BUILD_STALL_TIMEOUT_SEC  Setup stall timeout, default 3600;
                                        0 disables cap
   SKILLSBENCH_RUN_TIMEOUT_SEC          Supervisor timeout, default 28800
+  SKILLSBENCH_TUNNEL_PROBE_TIMEOUT_SEC Reverse-tunnel CONNECT probe timeout,
+                                       default 20
+  SKILLSBENCH_TUNNEL_READY_TIMEOUT_SEC Reverse-tunnel readiness budget,
+                                       default 60
   SKILLSBENCH_PARALLEL_CASES           Batch concurrency, default 3
   SKILLSBENCH_BATCH_CASE_START_GAP_SEC Delay between case starts, default 3
   SKILLSBENCH_GOAL_ID                  Local evidence goal id, default loopx-meta
@@ -152,6 +156,8 @@ model="${SKILLSBENCH_MODEL:-gpt-5.5}"
 reasoning_effort="${SKILLSBENCH_REASONING_EFFORT:-xhigh}"
 build_stall_timeout="${SKILLSBENCH_BUILD_STALL_TIMEOUT_SEC:-3600}"
 run_timeout="${SKILLSBENCH_RUN_TIMEOUT_SEC:-28800}"
+tunnel_probe_timeout="${SKILLSBENCH_TUNNEL_PROBE_TIMEOUT_SEC:-20}"
+tunnel_ready_timeout="${SKILLSBENCH_TUNNEL_READY_TIMEOUT_SEC:-60}"
 parallel_cases="${SKILLSBENCH_PARALLEL_CASES:-3}"
 if ((parallel_cases > task_count)); then
   parallel_cases="$task_count"
@@ -318,6 +324,8 @@ supervisor_cmd=(
   "${ssh_options[@]}"
   --cleanup-stale-local-forward
   --remote-forward "127.0.0.1:${remote_proxy_port}:${local_proxy_host}:${local_proxy_port}"
+  --probe-timeout-sec "$tunnel_probe_timeout"
+  --tunnel-ready-timeout-sec "$tunnel_ready_timeout"
   --run-timeout-sec "$run_timeout"
   --remote-failure-cleanup-pattern "$job_name"
   --remote-failure-cleanup-include-docker


### PR DESCRIPTION
## Summary
- expose reverse-tunnel CONNECT probe and readiness budgets in the canonical SkillsBench goal launcher
- raise launcher defaults from the supervisor defaults of 8/30 seconds to 20/60 seconds
- preserve explicit environment overrides and cover both overrides and defaults in dry-run smoke output

## Evidence
Three post-#1872 hvac launches ended before the remote benchmark command ran: the public supervisor closeouts showed `probe_timeout` or `reverse_tunnel_process_exited_before_ready`, no benchmark compacts, and no score. A controlled exact `ssh -R` probe passed, while the local proxy CONNECT path took about 3.7 seconds on top of current SSH handshake latency, exceeding the launcher effective probe subprocess budget.

## Validation
- `python3 examples/skillsbench-benchmark-egress-policy-smoke.py`
- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`
- `git diff --check`
- `loopx canary premerge --from-git-diff`: direct checks passed, 6/6 catalog canaries passed, public-boundary scan passed; benchmark-sensitive manual hold only

No benchmark job, scoring behavior, task semantics, credentials, raw logs, or private evidence are included. Owner has standing authorization in this task for benchmark helper/runtime self-merge after focused validation.