### PR TITLE
feat(issue-fix): compose evidence-backed impact metrics

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -343,6 +343,7 @@ tests whether the system is a durable employee rather than a scripted demo.
 | Maintainer correction | `loopx issue-fix pr-lifecycle --maintainer-correction-json ... --execute-transition` | Turn bounded public review feedback into one claimed patch successor, a concrete user gate, or a quiet unchanged poll. |
 | Metrics projection | [`loopx issue-fix metrics`](protocols/issue-fix-metrics-projection-v0.md) | Keep repository baseline separate from attributable agent output, combine existing feasibility/PR lifecycle rows with caller-supplied public snapshots, and report deltas, ratios, inventory, and missing data without another ledger. |
 | Repository snapshot | `loopx issue-fix repository-snapshot` | Explicitly collect bounded public GitHub stock/flow and known issue/PR state; optionally retain only material daily changes in the existing issue-fix domain state. |
+| Metrics supplement | `loopx issue-fix metrics-supplement` | Derive screened issues, triage outcomes, automatic terminal closeouts, and explicit memory evidence from existing issue-fix state; accept a compact event batch for first-push CI, human interventions, public comments, duplicate writes, and capability-gap lifecycle counts while preserving honest missing-data semantics. |
 | Acceptance fixture | `loopx issue-fix acceptance-fixture` | Prove failure-before, minimal patch, and pass-after in a deterministic fixture. |
 | Git branch fixture | `loopx issue-fix repo-branch-fixture` | Exercise the same repair contract through a temporary git branch. |
 | Caller repo branch | `loopx issue-fix caller-repo-branch` | Inspect an approved local repo, create/claim an issue branch, and run caller-declared validation. |
@@ -848,6 +849,7 @@ python3 examples/issue-fix-feasibility-smoke.py
 python3 examples/issue-fix-pr-lifecycle-smoke.py
 python3 examples/issue-fix-metrics-projection-smoke.py
 python3 examples/issue-fix-repository-snapshot-smoke.py
+python3 examples/issue-fix-metrics-supplement-smoke.py
 python3 examples/issue-fix-maintainer-correction-smoke.py
 python3 examples/issue-fix-outcome-projection-smoke.py
 python3 examples/issue-fix-acceptance-loop-smoke.py

--- a/docs/capabilities/issue-fix/README.zh-CN.md
+++ b/docs/capabilities/issue-fix/README.zh-CN.md
@@ -355,6 +355,7 @@ state 仍优先于迟到反馈。
 | Maintainer correction | `loopx issue-fix pr-lifecycle --maintainer-correction-json ... --execute-transition` | 把有限公开反馈转成一个已认领 patch successor、具体 user gate，或安静的 unchanged poll。 |
 | 指标投影 | [`loopx issue-fix metrics`](protocols/issue-fix-metrics-projection-v0.md) | 严格区分仓库存量基线与 agent 可归因产出；组合现有 feasibility/PR lifecycle 行和调用方提供的公开快照，输出 delta、比例、产出清单与缺失数据，不新增 ledger。 |
 | 仓库快照 | `loopx issue-fix repository-snapshot` | 显式采集有界的公开 GitHub stock/flow 与已知 issue/PR 状态；可选地只把物质日变化写入现有 issue-fix domain state。 |
+| 指标补充组合 | `loopx issue-fix metrics-supplement` | 从现有 issue-fix 状态派生已筛选 issue、triage 终局、自动 terminal closeout 和显式 memory 证据；对首推 CI、人工介入、有效公开评论、重复外部写和能力缺口生命周期，只接受紧凑事件批次，并对尚无证据的指标保持缺失而非填零。 |
 | Acceptance fixture | `loopx issue-fix acceptance-fixture` | 在 deterministic fixture 中证明 failure-before、minimal patch、pass-after。 |
 | Git branch fixture | `loopx issue-fix repo-branch-fixture` | 在临时 git branch 中运行同一修复 contract。 |
 | Caller repo branch | `loopx issue-fix caller-repo-branch` | 检查获批本地 repo、创建/认领 issue branch、运行 caller-declared validation。 |
@@ -814,6 +815,7 @@ python3 examples/issue-fix-feasibility-smoke.py
 python3 examples/issue-fix-pr-lifecycle-smoke.py
 python3 examples/issue-fix-metrics-projection-smoke.py
 python3 examples/issue-fix-repository-snapshot-smoke.py
+python3 examples/issue-fix-metrics-supplement-smoke.py
 python3 examples/issue-fix-maintainer-correction-smoke.py
 python3 examples/issue-fix-outcome-projection-smoke.py
 python3 examples/issue-fix-acceptance-loop-smoke.py

--- a/docs/capabilities/issue-fix/protocols/issue-fix-metrics-projection-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-metrics-projection-v0.md
@@ -78,6 +78,36 @@ This is an allowlisted compact input, not a raw provider payload. Missing counts
 remain `null` and produce a `missing_data` reason code. A missing measure is never
 coerced to zero.
 
+`loopx issue-fix metrics-supplement` composes that input from evidence already
+owned by the issue-fix domain state and from optional explicit event evidence:
+
+```bash
+loopx --format json issue-fix metrics-supplement \
+  --goal-id public-issue-fix-goal \
+  --project /path/to/project \
+  --repo public-org/public-repo \
+  --period-start 2026-07-01T00:00:00Z \
+  --period-end 2026-08-01T00:00:00Z \
+  --event-json /path/to/public-safe-events.json \
+  --repository-memory-json /path/to/explicit-memory-read-result.json
+```
+
+Feasibility and lifecycle rows supply screened issues, triage outcomes, and
+automatic terminal closeouts. Explicit repository-memory read results supply
+retrieval, verified patch-influence, and stale-result counts. An optional
+`issue_fix_metrics_event_batch_v0` supplies stable event identities for
+first-push CI, human interventions, useful public comments, duplicate external
+writes, and capability-gap `found` / `fixed` / `real_callsite_verified`
+transitions. Events outside the reporting period are ignored, duplicate event
+identities are rejected, and a capability gap is counted once per gap identity.
+
+The composer performs no provider call and does not infer absent events. When no
+explicit memory result is supplied, it may use a compact feasibility memory hook
+only when that hook records `read_performed=true`; otherwise memory fields remain
+absent. With no event batch, event-backed fields also remain absent. In both
+cases `loopx issue-fix metrics` reports unavailable evidence rather than
+coercing it to zero.
+
 ## Attribution contract
 
 - The repository baseline contains repository stock only.
@@ -164,4 +194,5 @@ through the normal schema-reconciliation path.
 ```bash
 python3 examples/issue-fix-metrics-projection-smoke.py
 python3 examples/issue-fix-repository-snapshot-smoke.py
+python3 examples/issue-fix-metrics-supplement-smoke.py
 ```

--- a/examples/issue-fix-metrics-supplement-smoke.py
+++ b/examples/issue-fix-metrics-supplement-smoke.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Contract smoke for evidence-backed issue-fix supplemental metrics."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value) + "\n", encoding="utf-8")
+
+
+def _write_jsonl(path: Path, values: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(value) + "\n" for value in values),
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    repo = "public-fixture/widgets"
+    with tempfile.TemporaryDirectory(prefix="loopx-issue-fix-supplement-") as tmp:
+        root = Path(tmp)
+        domain = root / ".loopx" / "domain-state" / "fixture-goal" / "issue_fix"
+        _write_jsonl(
+            domain / "feasibility.jsonl",
+            [
+                {
+                    "observation": {"repo": repo, "issue_ref": "issues_42"},
+                    "decision": {"route": "fix_pr"},
+                },
+                {
+                    "observation": {"repo": repo, "issue_ref": "issues_43"},
+                    "decision": {"route": "fix_pr"},
+                },
+                {
+                    "observation": {"repo": repo, "issue_ref": "issues_44"},
+                    "decision": {"route": "triage_only"},
+                },
+            ],
+        )
+        _write_jsonl(
+            domain / "pr-lifecycle.jsonl",
+            [
+                {
+                    "observation": {
+                        "repo": repo,
+                        "pr_ref": "pull_77",
+                        "state": "MERGED",
+                    },
+                    "transition": {"decision": "no_followup"},
+                },
+                {
+                    "observation": {
+                        "repo": repo,
+                        "pr_ref": "pull_78",
+                        "state": "CLOSED",
+                    },
+                    "transition": {"decision": "no_followup"},
+                },
+                {
+                    "observation": {
+                        "repo": repo,
+                        "pr_ref": "pull_79",
+                        "state": "OPEN",
+                    },
+                    "transition": {"decision": "monitor_continuation"},
+                },
+            ],
+        )
+        events = root / "events.json"
+        _write_json(
+            events,
+            {
+                "schema_version": "issue_fix_metrics_event_batch_v0",
+                "events": [
+                    {
+                        "event_id": "human-1",
+                        "event_type": "human_intervention",
+                        "occurred_at": "2026-07-03T00:00:00Z",
+                    },
+                    {
+                        "event_id": "human-2",
+                        "event_type": "human_intervention",
+                        "occurred_at": "2026-07-04T00:00:00Z",
+                    },
+                    {
+                        "event_id": "ci-77",
+                        "event_type": "first_push_ci",
+                        "occurred_at": "2026-07-05T00:00:00Z",
+                        "pr_ref": "pull_77",
+                        "status": "PASSING",
+                    },
+                    {
+                        "event_id": "ci-78",
+                        "event_type": "first_push_ci",
+                        "occurred_at": "2026-07-06T00:00:00Z",
+                        "pr_ref": "pull_78",
+                        "status": "FAILING",
+                    },
+                    {
+                        "event_id": "gap-found",
+                        "event_type": "capability_gap",
+                        "occurred_at": "2026-07-07T00:00:00Z",
+                        "gap_id": "projection-gap",
+                        "status": "found",
+                    },
+                    {
+                        "event_id": "gap-fixed",
+                        "event_type": "capability_gap",
+                        "occurred_at": "2026-07-08T00:00:00Z",
+                        "gap_id": "projection-gap",
+                        "status": "fixed",
+                    },
+                    {
+                        "event_id": "gap-verified",
+                        "event_type": "capability_gap",
+                        "occurred_at": "2026-07-09T00:00:00Z",
+                        "gap_id": "projection-gap",
+                        "status": "real_callsite_verified",
+                    },
+                    {
+                        "event_id": "comment-1",
+                        "event_type": "useful_public_comment",
+                        "occurred_at": "2026-07-10T00:00:00Z",
+                    },
+                    {
+                        "event_id": "outside-period",
+                        "event_type": "human_intervention",
+                        "occurred_at": "2026-06-01T00:00:00Z",
+                    },
+                ],
+            },
+        )
+        memory = root / "memory.json"
+        _write_json(
+            memory,
+            {
+                "schema_version": "issue_fix_repository_memory_read_result_v0",
+                "results": [
+                    {
+                        "verification_status": "confirmed",
+                        "patch_influence_allowed": True,
+                    },
+                    {
+                        "verification_status": "unverified",
+                        "patch_influence_allowed": False,
+                    },
+                ],
+            },
+        )
+        command = [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "issue-fix",
+            "metrics-supplement",
+            "--goal-id",
+            "fixture-goal",
+            "--project",
+            str(root),
+            "--repo",
+            repo,
+            "--period-start",
+            "2026-07-01T00:00:00Z",
+            "--period-end",
+            "2026-08-01T00:00:00Z",
+            "--event-json",
+            str(events),
+            "--repository-memory-json",
+            str(memory),
+            "--generated-at",
+            "2026-08-01T00:01:00Z",
+        ]
+        result = subprocess.run(
+            command,
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        packet = json.loads(result.stdout)
+        counts = packet["supplement"]["counts"]
+        assert counts["issues_screened"] == 3, packet
+        assert counts["triage_outcomes"] == 1, packet
+        assert counts["automatic_terminal_closeouts"] == 2, packet
+        assert counts["human_interventions"] == 2, packet
+        assert counts["first_push_ci_passed"] == 1, packet
+        assert counts["first_push_ci_total"] == 2, packet
+        assert counts["loopx_capability_gaps_found"] == 1, packet
+        assert counts["loopx_capability_gaps_fixed"] == 1, packet
+        assert counts["loopx_capability_gaps_real_callsite_verified"] == 1, packet
+        assert counts["memory_retrievals"] == 2, packet
+        assert counts["memory_verified_patch_influence"] == 1, packet
+        assert counts["memory_stale_results"] == 0, packet
+        assert counts["useful_public_comments"] == 1, packet
+        assert "duplicate_external_writes" not in packet["missing_fields"], packet
+        serialized = json.dumps(packet, sort_keys=True)
+        assert str(root) not in serialized, serialized
+        for field in (
+            "raw_event_payload_captured",
+            "raw_memory_captured",
+            "credentials_captured",
+            "local_paths_captured",
+        ):
+            assert packet[field] is False, packet
+
+    print("issue-fix metrics supplement smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -40,6 +40,10 @@ from .metrics_projection import (
     build_issue_fix_metrics_projection,
     render_issue_fix_metrics_projection_markdown,
 )
+from .metrics_supplement import (
+    build_issue_fix_metrics_supplement,
+    render_issue_fix_metrics_supplement_markdown,
+)
 from .pr_lifecycle import (
     build_issue_fix_pr_lifecycle_monitor_packet,
     render_issue_fix_pr_lifecycle_monitor_markdown,
@@ -793,6 +797,34 @@ def register_issue_fix_commands(
         help="Optional PR lifecycle JSONL override; defaults to goal domain state.",
     )
     _add_generated_at_arg(metrics_parser, artifact="the metrics projection")
+    supplement_parser = issue_fix_sub.add_parser(
+        "metrics-supplement",
+        help=(
+            "Compose public-safe supplemental counts from existing issue-fix "
+            "domain state and explicit bounded event or memory evidence."
+        ),
+    )
+    add_subcommand_format(supplement_parser)
+    supplement_parser.add_argument("--goal-id", required=True)
+    supplement_parser.add_argument("--project", default=".")
+    supplement_parser.add_argument("--repo", required=True)
+    supplement_parser.add_argument("--period-start", required=True)
+    supplement_parser.add_argument("--period-end", required=True)
+    supplement_parser.add_argument(
+        "--event-json",
+        default=None,
+        help="Optional issue_fix_metrics_event_batch_v0 file, inline object, or stdin.",
+    )
+    supplement_parser.add_argument(
+        "--repository-memory-json",
+        action="append",
+        default=[],
+        help=(
+            "Optional issue_fix_repository_memory_read_result_v0 file or inline "
+            "object. Repeat for multiple issue-scoped reads."
+        ),
+    )
+    _add_generated_at_arg(supplement_parser, artifact="the metrics supplement")
     snapshot_parser = issue_fix_sub.add_parser(
         "repository-snapshot",
         help=(
@@ -1641,6 +1673,39 @@ def handle_issue_fix_command(
                 generated_at=generated_at,
             )
             renderer = render_issue_fix_metrics_projection_markdown
+        elif args.issue_fix_command == "metrics-supplement":
+            stdin_input_count = sum(
+                value == "-"
+                for value in [args.event_json, *args.repository_memory_json]
+                if value is not None
+            )
+            if stdin_input_count > 1:
+                raise ValueError("only one metrics supplement input may read from stdin")
+            project = Path(args.project).expanduser()
+            payload = build_issue_fix_metrics_supplement(
+                repo=args.repo,
+                period_start=args.period_start,
+                period_end=args.period_end,
+                feasibility_rows=_load_jsonl_rows(
+                    default_issue_fix_feasibility_ledger_path(
+                        project=project, goal_id=args.goal_id
+                    )
+                ),
+                pr_lifecycle_rows=_load_jsonl_rows(
+                    default_issue_fix_domain_state_ledger_path(
+                        project=project, goal_id=args.goal_id
+                    )
+                ),
+                event_batch=(
+                    _load_json_object(args.event_json) if args.event_json else None
+                ),
+                repository_memory_results=[
+                    _load_json_object(value)
+                    for value in args.repository_memory_json
+                ],
+                generated_at=generated_at,
+            )
+            renderer = render_issue_fix_metrics_supplement_markdown
         elif args.issue_fix_command == "repository-snapshot":
             if not args.fetch_public_github:
                 raise ValueError("repository-snapshot requires --fetch-public-github")
@@ -1892,6 +1957,7 @@ def handle_issue_fix_command(
             raise ValueError(
                 "issue-fix requires `repository-memory-sync`, `workflow-plan`, `feasibility`, "
                 "`acceptance-fixture`, `pr-lifecycle`, `outcome`, `metrics`, "
+                "`metrics-supplement`, "
                 "`repository-snapshot`, `reviewer-plan`, "
                 "`reviewer-request`, "
                 "`repo-branch-fixture`, or `caller-repo-branch`"
@@ -1915,6 +1981,8 @@ def handle_issue_fix_command(
             if getattr(args, "issue_fix_command", None) == "outcome"
             else render_issue_fix_metrics_projection_markdown
             if getattr(args, "issue_fix_command", None) == "metrics"
+            else render_issue_fix_metrics_supplement_markdown
+            if getattr(args, "issue_fix_command", None) == "metrics-supplement"
             else render_repository_snapshot_markdown
             if getattr(args, "issue_fix_command", None) == "repository-snapshot"
             else render_issue_fix_reviewer_recommendation_markdown

--- a/loopx/capabilities/issue_fix/metrics_supplement.py
+++ b/loopx/capabilities/issue_fix/metrics_supplement.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+
+SUPPLEMENT_SCHEMA_VERSION = "issue_fix_metrics_supplement_v0"
+EVENT_BATCH_SCHEMA_VERSION = "issue_fix_metrics_event_batch_v0"
+PROJECTION_SCHEMA_VERSION = "issue_fix_metrics_supplement_projection_v0"
+
+_EVENT_TYPES = {
+    "capability_gap",
+    "duplicate_external_write",
+    "first_push_ci",
+    "human_intervention",
+    "useful_public_comment",
+}
+_SUPPLEMENT_FIELDS = (
+    "human_interventions",
+    "automatic_terminal_closeouts",
+    "duplicate_external_writes",
+    "loopx_capability_gaps_found",
+    "loopx_capability_gaps_fixed",
+    "loopx_capability_gaps_real_callsite_verified",
+    "memory_retrievals",
+    "memory_verified_patch_influence",
+    "memory_stale_results",
+    "useful_public_comments",
+    "triage_outcomes",
+    "issues_screened",
+    "first_push_ci_passed",
+    "first_push_ci_total",
+)
+
+
+def _timestamp(value: Any, *, field: str) -> datetime:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{field} is required")
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        raise ValueError(f"{field} must be an ISO-8601 timestamp") from None
+    if parsed.utcoffset() is None:
+        raise ValueError(f"{field} must include a timezone")
+    return parsed
+
+
+def _latest_rows(
+    rows: list[dict[str, Any]], *, repo: str, ref_field: str
+) -> list[dict[str, Any]]:
+    latest: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        observation = row.get("observation") if isinstance(row, dict) else None
+        if not isinstance(observation, dict) or observation.get("repo") != repo:
+            continue
+        reference = str(observation.get(ref_field) or "").strip()
+        if reference:
+            latest[reference] = row
+    return [latest[key] for key in sorted(latest)]
+
+
+def _events_in_period(
+    event_batch: dict[str, Any] | None,
+    *,
+    period_start: datetime,
+    period_end: datetime,
+) -> list[dict[str, Any]]:
+    if event_batch is None:
+        return []
+    if event_batch.get("schema_version") != EVENT_BATCH_SCHEMA_VERSION:
+        raise ValueError(f"event batch must use {EVENT_BATCH_SCHEMA_VERSION}")
+    raw_events = event_batch.get("events")
+    if not isinstance(raw_events, list):
+        raise ValueError("event batch events must be a list")
+    events: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for index, item in enumerate(raw_events):
+        if not isinstance(item, dict):
+            raise ValueError(f"events[{index}] must be an object")
+        event_id = str(item.get("event_id") or "").strip()
+        event_type = str(item.get("event_type") or "").strip()
+        if not event_id or event_type not in _EVENT_TYPES:
+            raise ValueError(
+                f"events[{index}] requires event_id and a known event_type"
+            )
+        if event_id in seen_ids:
+            raise ValueError(f"duplicate event_id: {event_id}")
+        seen_ids.add(event_id)
+        occurred_at = _timestamp(
+            item.get("occurred_at"), field=f"events[{index}].occurred_at"
+        )
+        if period_start <= occurred_at <= period_end:
+            events.append(dict(item))
+    return events
+
+
+def _memory_counts(
+    memory_results: list[dict[str, Any]], feasibility: list[dict[str, Any]]
+) -> dict[str, int] | None:
+    results: list[dict[str, Any]] = []
+    for index, payload in enumerate(memory_results):
+        if (
+            payload.get("schema_version")
+            != "issue_fix_repository_memory_read_result_v0"
+        ):
+            raise ValueError(
+                f"repository memory input {index} must use issue_fix_repository_memory_read_result_v0"
+            )
+        raw_results = payload.get("results")
+        if not isinstance(raw_results, list):
+            raise ValueError(f"repository memory input {index} results must be a list")
+        results.extend(item for item in raw_results if isinstance(item, dict))
+    if results:
+        return {
+            "memory_retrievals": len(results),
+            "memory_verified_patch_influence": sum(
+                str(item.get("verification_status") or "").lower() == "confirmed"
+                and item.get("patch_influence_allowed") is True
+                for item in results
+            ),
+            "memory_stale_results": sum(
+                str(item.get("verification_status") or "").lower() == "stale"
+                for item in results
+            ),
+        }
+
+    hooks = []
+    for row in feasibility:
+        observation = row.get("observation") or {}
+        repository_context = observation.get("repository_context") or {}
+        memory = repository_context.get("memory_projection") or {}
+        hook = memory.get("retrieval_hook")
+        if isinstance(hook, dict) and hook.get("read_performed") is True:
+            hooks.append(hook)
+    if not hooks:
+        return None
+    return {
+        "memory_retrievals": sum(int(item.get("result_count") or 0) for item in hooks),
+        "memory_verified_patch_influence": sum(
+            int(item.get("patch_influence_allowed_count") or 0) for item in hooks
+        ),
+        "memory_stale_results": sum(
+            int(item.get("stale_count") or 0) for item in hooks
+        ),
+    }
+
+
+def build_issue_fix_metrics_supplement(
+    *,
+    repo: str,
+    period_start: str,
+    period_end: str,
+    feasibility_rows: list[dict[str, Any]],
+    pr_lifecycle_rows: list[dict[str, Any]],
+    event_batch: dict[str, Any] | None,
+    repository_memory_results: list[dict[str, Any]],
+    generated_at: str,
+) -> dict[str, Any]:
+    repo = str(repo or "").strip()
+    if not repo:
+        raise ValueError("repo is required")
+    start = _timestamp(period_start, field="period_start")
+    end = _timestamp(period_end, field="period_end")
+    _timestamp(generated_at, field="generated_at")
+    if end < start:
+        raise ValueError("period_end must not predate period_start")
+
+    feasibility = _latest_rows(feasibility_rows, repo=repo, ref_field="issue_ref")
+    lifecycles = _latest_rows(pr_lifecycle_rows, repo=repo, ref_field="pr_ref")
+    events = _events_in_period(event_batch, period_start=start, period_end=end)
+    counts: dict[str, int] = {
+        "issues_screened": len(feasibility),
+        "triage_outcomes": sum(
+            str((row.get("decision") or {}).get("route") or "") == "triage_only"
+            for row in feasibility
+        ),
+        "automatic_terminal_closeouts": sum(
+            str((row.get("transition") or {}).get("decision") or "") == "no_followup"
+            and str((row.get("observation") or {}).get("state") or "").upper()
+            in {"MERGED", "CLOSED"}
+            for row in lifecycles
+        ),
+    }
+
+    if event_batch is not None:
+        counts["human_interventions"] = sum(
+            item.get("event_type") == "human_intervention" for item in events
+        )
+        counts["duplicate_external_writes"] = sum(
+            item.get("event_type") == "duplicate_external_write" for item in events
+        )
+        counts["useful_public_comments"] = sum(
+            item.get("event_type") == "useful_public_comment" for item in events
+        )
+        first_push = [
+            item for item in events if item.get("event_type") == "first_push_ci"
+        ]
+        pr_refs = [str(item.get("pr_ref") or "").strip() for item in first_push]
+        if any(not value for value in pr_refs) or len(set(pr_refs)) != len(pr_refs):
+            raise ValueError("first_push_ci events require unique pr_ref values")
+        statuses = [str(item.get("status") or "").upper() for item in first_push]
+        if any(status not in {"PASSING", "FAILING"} for status in statuses):
+            raise ValueError("first_push_ci status must be PASSING or FAILING")
+        counts["first_push_ci_total"] = len(first_push)
+        counts["first_push_ci_passed"] = sum(status == "PASSING" for status in statuses)
+
+        gaps = [item for item in events if item.get("event_type") == "capability_gap"]
+        gap_states: dict[str, set[str]] = {}
+        for item in gaps:
+            gap_id = str(item.get("gap_id") or "").strip()
+            status = str(item.get("status") or "").strip().lower()
+            if not gap_id or status not in {"found", "fixed", "real_callsite_verified"}:
+                raise ValueError(
+                    "capability_gap events require gap_id and a known status"
+                )
+            gap_states.setdefault(gap_id, set()).add(status)
+        counts["loopx_capability_gaps_found"] = len(gap_states)
+        counts["loopx_capability_gaps_fixed"] = sum(
+            bool(states & {"fixed", "real_callsite_verified"})
+            for states in gap_states.values()
+        )
+        counts["loopx_capability_gaps_real_callsite_verified"] = sum(
+            "real_callsite_verified" in states for states in gap_states.values()
+        )
+
+    memory = _memory_counts(repository_memory_results, feasibility)
+    if memory is not None:
+        counts.update(memory)
+
+    missing_fields = [field for field in _SUPPLEMENT_FIELDS if field not in counts]
+    supplement = {
+        "schema_version": SUPPLEMENT_SCHEMA_VERSION,
+        "counts": counts,
+    }
+    return {
+        "ok": True,
+        "schema_version": PROJECTION_SCHEMA_VERSION,
+        "mode": "issue-fix-metrics-supplement",
+        "repo": repo,
+        "period": {"start": period_start, "end": period_end},
+        "supplement": supplement,
+        "missing_fields": missing_fields,
+        "source_summary": {
+            "feasibility_rows": len(feasibility),
+            "pr_lifecycle_rows": len(lifecycles),
+            "event_rows": len(events),
+            "repository_memory_inputs": len(repository_memory_results),
+        },
+        "generated_at": generated_at,
+        "external_reads_performed": False,
+        "external_writes_performed": False,
+        "raw_event_payload_captured": False,
+        "raw_memory_captured": False,
+        "credentials_captured": False,
+        "local_paths_captured": False,
+    }
+
+
+def render_issue_fix_metrics_supplement_markdown(payload: dict[str, Any]) -> str:
+    if payload.get("ok") is not True:
+        return f"# Issue-fix metrics supplement\n\n- Error: {payload.get('error') or 'invalid input'}"
+    counts = (payload.get("supplement") or {}).get("counts") or {}
+    return "\n".join(
+        [
+            "# Issue-fix metrics supplement",
+            "",
+            f"- repository: `{payload.get('repo')}`",
+            f"- issues screened: `{counts.get('issues_screened')}`",
+            f"- automatic terminal closeouts: `{counts.get('automatic_terminal_closeouts')}`",
+            f"- memory retrievals: `{counts.get('memory_retrievals', 'not available')}`",
+            f"- missing fields: `{len(payload.get('missing_fields') or [])}`",
+        ]
+    )


### PR DESCRIPTION
## Motivation

Long-running issue-fix reporting already projects repository stock and attributable PR output, but several month-end measures were still manual or silently unavailable. We need one reusable seam that derives what LoopX already knows, accepts only explicit compact events for what it does not know, and never turns missing evidence into a flattering zero.

## Approach

- add `loopx issue-fix metrics-supplement` over existing feasibility and PR lifecycle domain state
- derive screened issues, triage outcomes, automatic terminal closeouts, and verified repository-memory counts
- accept an allowlisted event batch for first-push CI, human interventions, useful public comments, duplicate external writes, and capability-gap lifecycle transitions
- reject duplicate event ids and duplicate first-push PR observations; filter events to the reporting period
- document the contract in English and Chinese

## Validation

- `python3 examples/issue-fix-metrics-supplement-smoke.py`
- `python3 examples/issue-fix-metrics-projection-smoke.py`
- `python3 examples/issue-fix-repository-snapshot-smoke.py`
- `python3 examples/issue-fix-capability-guide-smoke.py`
- `python3 examples/issue-fix-workflow-contract-smoke.py`
- `python3 examples/lark-kanban-control-plane-smoke.py`
- Ruff, py_compile, diff check, and repository Python line-budget smoke
- `loopx canary premerge --from-git-diff`: 17/17 selected checks passed; public boundary clean; self-merge allowed
- real OpenViking dogfood: 7 screened issues, 3 automatic terminal closeouts, 1 explicit memory retrieval, 0 verified memory patch influences; event-backed metrics remain unavailable without event evidence

## Risk and non-goals

The command is read-only and performs no provider calls or external writes. It does not yet capture first-push CI, human-intervention, or capability-gap events automatically; those remain explicit successor work. It stores neither raw event/provider payloads nor local paths, credentials, transcripts, or tool logs.