### PR TITLE
Observe current goal active transitions

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -1510,6 +1510,13 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     lifecycle.observe("Goal active\nGoal failed\nold scrollback\n› ")
     assert lifecycle.active_advanced is False
     assert lifecycle.failed_advanced is False
+    lifecycle.observe(
+        "Goal active\nold scrollback\n› ",
+        turn_active=True,
+    )
+    assert lifecycle.active_advanced is False
+    assert lifecycle.active_observed is True
+    assert lifecycle.trace_fields()["goal_turn_active_observed"] is True
     lifecycle.begin("Goal active\nGoal failed\nold scrollback\n› ")
     lifecycle.observe(
         "Goal active\nGoal failed\nold scrollback\nGoal active\nGoal achieved\n› "
@@ -1576,8 +1583,9 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "text=CODEX_CLI_GOAL_KICKOFF_PROMPT" in source
     assert "goal_failed_now = False" in source
     assert "goal_lifecycle.failed_advanced" in source
-    assert "goal_lifecycle.active_advanced" in source
+    assert "goal_lifecycle.active_observed" in source
     assert "goal_lifecycle.achieved_advanced" in source
+    assert "goal_lifecycle.observe(capture, turn_active=turn_active)" in source
     assert source.count("goal_lifecycle.begin(") == 2
     assert source.count("goal_kickoff_prompt_submitted = False") >= 2
     assert "terminal_observed=goal_failed_now" in source

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -1222,10 +1222,10 @@ class SkillsBenchLocalAcpRelay:
                     now = time.monotonic()
                     capture = self._last_codex_cli_goal_tui_capture = tmux_capture(tmux_name)
                     turn_active = codex_cli_tui_turn_active(capture)
-                    goal_lifecycle.observe(capture)
+                    goal_lifecycle.observe(capture, turn_active=turn_active)
                     if turn_active:
                         last_task_output_activity_at = now
-                    if goal_lifecycle.active_advanced:
+                    if goal_lifecycle.active_observed:
                         goal_active_observed = True
                     goal_failed_now = goal_lifecycle.failed_advanced
                     if bridge_summary_path is not None:

--- a/loopx/codex_cli_goal_tui.py
+++ b/loopx/codex_cli_goal_tui.py
@@ -44,18 +44,25 @@ class CodexCliGoalLifecycleGeneration:
         CodexCliGoalLifecycleMarkerCounts()
     )
     current: CodexCliGoalLifecycleMarkerCounts = CodexCliGoalLifecycleMarkerCounts()
+    turn_active_observed: bool = False
 
     def begin(self, capture: str) -> None:
         self.generation += 1
         self.baseline = codex_cli_goal_lifecycle_marker_counts(capture)
         self.current = self.baseline
+        self.turn_active_observed = False
 
-    def observe(self, capture: str) -> None:
+    def observe(self, capture: str, *, turn_active: bool = False) -> None:
         self.current = codex_cli_goal_lifecycle_marker_counts(capture)
+        self.turn_active_observed = self.turn_active_observed or bool(turn_active)
 
     @property
     def active_advanced(self) -> bool:
         return self.current.active > self.baseline.active
+
+    @property
+    def active_observed(self) -> bool:
+        return self.active_advanced or self.turn_active_observed
 
     @property
     def achieved_advanced(self) -> bool:
@@ -65,8 +72,11 @@ class CodexCliGoalLifecycleGeneration:
     def failed_advanced(self) -> bool:
         return self.current.failed > self.baseline.failed
 
-    def trace_fields(self) -> dict[str, int]:
-        fields = {"goal_submission_generation": max(0, self.generation)}
+    def trace_fields(self) -> dict[str, int | bool]:
+        fields: dict[str, int | bool] = {
+            "goal_submission_generation": max(0, self.generation),
+            "goal_turn_active_observed": self.turn_active_observed,
+        }
         for name in ("active", "achieved", "failed"):
             baseline = getattr(self.baseline, name)
             current = getattr(self.current, name)


### PR DESCRIPTION
## Summary
- treat a current-generation Codex TUI turn-active observation as positive goal-active evidence
- retain marker deltas as a second signal when scrollback remains monotonic
- reset turn-active evidence on every `/goal` generation and publish the boolean in public compact traces
- cover redraw/non-monotonic marker behavior in the focused SkillsBench route smoke

## Evidence
The merged #1872 retry4 canary materialized successfully but closed uncountable at `goal_active_timeout`. Public compact evidence showed generation 2 with active marker baseline/current `1/1` and failed marker baseline/current `1/0`: TUI redraw removed old markers, so total counts were not monotonic and the current generation never qualified for kickoff despite a post-submit working/pursuing transition.

## Validation
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- repository Python line-budget smoke
- changed-file `py_compile`
- `git diff --check`
- `loopx canary premerge --from-git-diff`: direct checks, 6/6 catalog canaries, and public-boundary scan passed; benchmark-sensitive manual hold only
- focused smoke rerun passed after rebase onto current `origin/main`

No scoring/task-semantic/permission change, benchmark launch, raw task text, trajectory, TUI body, verifier output, credential, or private evidence is included. Owner has standing benchmark helper/runtime self-merge authorization in this task.