### PR TITLE
Fix stale Codex goal TUI recovery

### DIFF
--- a/examples/codex-cli-goal-tui-session-smoke.py
+++ b/examples/codex-cli-goal-tui-session-smoke.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Focused smoke for fresh Codex CLI goal TUI session startup."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import tempfile
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import loopx.codex_cli_goal_tui as goal_tui  # noqa: E402
+
+
+def main() -> int:
+    calls: list[tuple[str, object]] = []
+
+    def fake_run(command: list[str], **_kwargs: object) -> None:
+        calls.append(("run", command))
+
+    def fake_kill(tmux_name: str) -> None:
+        calls.append(("kill", tmux_name))
+
+    original_run = goal_tui.subprocess.run
+    original_wait = goal_tui.wait_for_codex_cli_tui_ready
+    original_prewarm = goal_tui.prewarm_codex_cli_goal_thread
+    original_kill = goal_tui.tmux_kill_session
+    try:
+        goal_tui.subprocess.run = fake_run  # type: ignore[assignment]
+        goal_tui.tmux_kill_session = fake_kill  # type: ignore[assignment]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            goal_tui.wait_for_codex_cli_tui_ready = (  # type: ignore[assignment]
+                lambda *_args, **_kwargs: True
+            )
+            goal_tui.prewarm_codex_cli_goal_thread = (  # type: ignore[assignment]
+                lambda **_kwargs: True
+            )
+            stage, prewarmed = goal_tui.start_codex_cli_goal_tui_session(
+                tmux_name="fresh-goal",
+                cwd="/tmp/public-workspace",
+                shell_command="codex --no-alt-screen",
+                tmp_path=temp_path,
+                thread_prewarm=True,
+                thread_prewarm_timeout_sec=120,
+            )
+            assert (stage, prewarmed) == ("", True)
+            assert calls[0] == (
+                "run",
+                [
+                    "tmux",
+                    "new-session",
+                    "-d",
+                    "-s",
+                    "fresh-goal",
+                    "-c",
+                    "/tmp/public-workspace",
+                    "codex --no-alt-screen",
+                ],
+            )
+
+            calls.clear()
+            goal_tui.wait_for_codex_cli_tui_ready = (  # type: ignore[assignment]
+                lambda *_args, **_kwargs: False
+            )
+            stage, prewarmed = goal_tui.start_codex_cli_goal_tui_session(
+                tmux_name="not-ready",
+                cwd="/tmp/public-workspace",
+                shell_command="codex",
+                tmp_path=temp_path,
+                thread_prewarm=False,
+                thread_prewarm_timeout_sec=120,
+            )
+            assert (stage, prewarmed) == ("tui_ready_timeout", False)
+            assert calls[-1] == ("kill", "not-ready")
+
+            calls.clear()
+            goal_tui.wait_for_codex_cli_tui_ready = (  # type: ignore[assignment]
+                lambda *_args, **_kwargs: True
+            )
+            goal_tui.prewarm_codex_cli_goal_thread = (  # type: ignore[assignment]
+                lambda **_kwargs: False
+            )
+            stage, prewarmed = goal_tui.start_codex_cli_goal_tui_session(
+                tmux_name="prewarm-failed",
+                cwd="/tmp/public-workspace",
+                shell_command="codex",
+                tmp_path=temp_path,
+                thread_prewarm=True,
+                thread_prewarm_timeout_sec=120,
+            )
+            assert (stage, prewarmed) == ("thread_prewarm_timeout", False)
+            assert calls[-1] == ("kill", "prewarm-failed")
+    finally:
+        goal_tui.subprocess.run = original_run  # type: ignore[assignment]
+        goal_tui.wait_for_codex_cli_tui_ready = original_wait  # type: ignore[assignment]
+        goal_tui.prewarm_codex_cli_goal_thread = original_prewarm  # type: ignore[assignment]
+        goal_tui.tmux_kill_session = original_kill  # type: ignore[assignment]
+
+    print("codex-cli-goal-tui-session-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -793,13 +793,13 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
             stale_goal_failed_scrollback,
             stage="pre_bridge_tui_stale_terminal",
         )
-        == "typed_goal_resubmit"
+        == "restart_tui_goal"
     )
     assert (
         codex_cli_tui_pre_bridge_recovery_skip_reason(
             stale_goal_failed_scrollback,
             stage="pre_bridge_tui_stale_terminal",
-            recovery_action="typed_goal_resubmit",
+            recovery_action="restart_tui_goal",
         )
         == ""
     )
@@ -1552,7 +1552,7 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     source = (
         REPO_ROOT / "loopx/benchmark_adapters/skillsbench_acp_relay.py"
     ).read_text(encoding="utf-8")
-    assert "auto_accept_trust_prompt=True" in source
+    assert "start_codex_cli_goal_tui_session(" in source
     assert "CODEX_CLI_GOAL_THREAD_PREWARM_TIMEOUT_SEC = 120" in source
     assert "CODEX_CLI_GOAL_TASK_PROMPT_FILENAME" in source
     assert "prompt_instruction_path.write_text(" in source
@@ -1560,10 +1560,13 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "tmux_type_text_and_submit(" in source
     assert "build_codex_cli_goal_tui_input(prompt_for_codex)" not in source
     assert "codex_cli_goal_thread_prewarm: bool = False" in source
-    assert "if self._config.codex_cli_goal_thread_prewarm:" in source
-    assert "prewarm_codex_cli_goal_thread(" in source
+    assert source.count("start_codex_cli_goal_tui_session(") == 2
+    assert 'recovery_action == "restart_tui_goal"' in source
+    assert source.index('restart_stage = ""') < source.index(
+        'if recovery_action == "press_enter"'
+    )
     assert "thread_prewarm_timeout" in source
-    assert "timeout_sec=CODEX_CLI_GOAL_THREAD_PREWARM_TIMEOUT_SEC" in source
+    assert "thread_prewarm_timeout_sec=CODEX_CLI_GOAL_THREAD_PREWARM_TIMEOUT_SEC" in source
     assert (
         "max(90.0, float(self._config.first_action_timeout_sec or 0.0))"
         not in source

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -69,14 +69,13 @@ from loopx.codex_cli_goal_tui import (
     codex_cli_tui_input_prompt_visible,
     codex_cli_tui_retryable_startup_blocker_stage,
     codex_cli_tui_turn_active,
-    prewarm_codex_cli_goal_thread,
     resolve_codex_cli_binary,
+    start_codex_cli_goal_tui_session,
     tmux_capture,
     tmux_kill_session,
     tmux_paste_file_and_submit,
     tmux_submit_enter,
     tmux_type_text_and_submit,
-    wait_for_codex_cli_tui_ready,
 )
 
 SAFE_LOOPX_TODO_ID_RE = re.compile(r"^todo_[A-Za-z0-9_-]{6,80}$")
@@ -1094,33 +1093,26 @@ class SkillsBenchLocalAcpRelay:
             post_bridge_recovery_action = ""
             post_bridge_recovery_skip_reason = ""
             pre_bridge_terminal_stage = ""
+            thread_prewarm = self._config.codex_cli_goal_thread_prewarm
             self._last_codex_cli_goal_lifecycle = goal_lifecycle = CodexCliGoalLifecycleGeneration()
             try:
-                subprocess.run(
-                    [
-                        "tmux",
-                        "new-session",
-                        "-d",
-                        "-s",
-                        tmux_name,
-                        "-c",
-                        cwd,
-                        shell_command,
-                    ],
-                    check=True,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.PIPE,
-                    text=True,
+                startup_stage, thread_prewarm_observed = start_codex_cli_goal_tui_session(
+                    tmux_name=tmux_name,
+                    cwd=cwd,
+                    shell_command=shell_command,
+                    tmp_path=tmp_path,
+                    thread_prewarm=thread_prewarm,
+                    thread_prewarm_timeout_sec=CODEX_CLI_GOAL_THREAD_PREWARM_TIMEOUT_SEC,
                 )
-                if not wait_for_codex_cli_tui_ready(tmux_name, auto_accept_trust_prompt=True):
-                    tmux_kill_session(tmux_name)
+                if startup_stage:
                     self._publish_codex_cli_goal_trace(
                         ok=False,
-                        stage="tui_ready_timeout",
+                        stage=startup_stage,
                         goal_active_observed=False,
                         goal_terminal_observed=False,
                         first_action_observed=False,
                         bridge_summary_path=bridge_summary_path,
+                        thread_prewarm_observed=thread_prewarm_observed,
                         goal_prompt_file_used=goal_prompt_file_used,
                         goal_command_submission_method=goal_command_submission_method,
                         goal_slash_command_submitted=False,
@@ -1128,30 +1120,6 @@ class SkillsBenchLocalAcpRelay:
                     return _recoverable_codex_turn_failure_message(
                         "codex_exec_first_action_timeout"
                     )
-                thread_prewarm_observed = False
-                if self._config.codex_cli_goal_thread_prewarm:
-                    thread_prewarm_observed = prewarm_codex_cli_goal_thread(
-                        tmux_name=tmux_name,
-                        tmp_path=tmp_path,
-                        timeout_sec=CODEX_CLI_GOAL_THREAD_PREWARM_TIMEOUT_SEC,
-                    )
-                    if not thread_prewarm_observed:
-                        tmux_kill_session(tmux_name)
-                        self._publish_codex_cli_goal_trace(
-                            ok=False,
-                            stage="thread_prewarm_timeout",
-                            goal_active_observed=False,
-                            goal_terminal_observed=False,
-                            first_action_observed=False,
-                            bridge_summary_path=bridge_summary_path,
-                            thread_prewarm_observed=False,
-                            goal_prompt_file_used=goal_prompt_file_used,
-                            goal_command_submission_method=goal_command_submission_method,
-                            goal_slash_command_submitted=False,
-                        )
-                        return _recoverable_codex_turn_failure_message(
-                            "codex_exec_first_action_timeout"
-                        )
                 goal_lifecycle.begin(tmux_capture(tmux_name))
                 if goal_prompt_file_used:
                     tmux_type_text_and_submit(
@@ -1344,6 +1312,7 @@ class SkillsBenchLocalAcpRelay:
                         )
                         if recovery_action in {
                             "press_enter",
+                            "restart_tui_goal",
                             "typed_goal_resubmit",
                         } and (
                             pre_bridge_recovery_attempt_count
@@ -1351,34 +1320,60 @@ class SkillsBenchLocalAcpRelay:
                         ):
                             pre_bridge_recovery_attempt_count += 1
                             pre_bridge_recovery_action = recovery_action
+                            restart_stage = ""
                             if recovery_action == "press_enter":
                                 tmux_submit_enter(tmux_name)
                             else:
-                                goal_lifecycle.begin(capture)
-                                goal_active_observed = False
-                                goal_kickoff_prompt_submitted = False
-                                tmux_type_text_and_submit(
-                                    tmux_name=tmux_name,
-                                    text=goal_command_text,
-                                )
-                            deadlines = codex_cli_goal_reset_pre_bridge_deadlines(
-                                now=now,
-                                first_action_timeout_sec=self._config.first_action_timeout_sec,
-                                goal_active_deadline=goal_active_deadline,
-                                goal_active_timeout_sec=self._config.goal_active_timeout_sec,
-                                first_action_deadline=first_action_deadline,
-                                meaningful_progress_deadline=meaningful_progress_deadline,
-                            )
-                            goal_active_deadline, first_action_deadline, meaningful_progress_deadline = deadlines
-                            if recovery_action == "typed_goal_resubmit":
-                                next_heartbeat = now + max(
-                                    1.0,
-                                    self._config.stream_heartbeat_interval_sec,
-                                )
+                                if recovery_action == "restart_tui_goal":
+                                    tmux_kill_session(tmux_name)
+                                    (
+                                        restart_stage,
+                                        thread_prewarm_observed,
+                                    ) = start_codex_cli_goal_tui_session(
+                                        tmux_name=tmux_name,
+                                        cwd=cwd,
+                                        shell_command=shell_command,
+                                        tmp_path=tmp_path,
+                                        thread_prewarm=thread_prewarm,
+                                        thread_prewarm_timeout_sec=CODEX_CLI_GOAL_THREAD_PREWARM_TIMEOUT_SEC,
+                                    )
+                                    if not restart_stage:
+                                        capture = tmux_capture(tmux_name)
+                                        goal_terminal_observed = False
+                                        goal_failed_observed = False
+                                if not restart_stage:
+                                    goal_lifecycle.begin(capture)
+                                    goal_active_observed = False
+                                    goal_kickoff_prompt_submitted = False
+                                    tmux_type_text_and_submit(
+                                        tmux_name=tmux_name,
+                                        text=goal_command_text,
+                                    )
+                            if restart_stage:
+                                pre_bridge_blocker_stage = restart_stage
+                                pre_bridge_recovery_skip_reason = "restart_failed"
                             else:
-                                time.sleep(1.0)
-                            continue
-                        pre_bridge_recovery_skip_reason = (
+                                deadlines = codex_cli_goal_reset_pre_bridge_deadlines(
+                                    now=now,
+                                    first_action_timeout_sec=self._config.first_action_timeout_sec,
+                                    goal_active_deadline=goal_active_deadline,
+                                    goal_active_timeout_sec=self._config.goal_active_timeout_sec,
+                                    first_action_deadline=first_action_deadline,
+                                    meaningful_progress_deadline=meaningful_progress_deadline,
+                                )
+                                goal_active_deadline, first_action_deadline, meaningful_progress_deadline = deadlines
+                                if recovery_action in {
+                                    "restart_tui_goal",
+                                    "typed_goal_resubmit",
+                                }:
+                                    next_heartbeat = now + max(
+                                        1.0,
+                                        self._config.stream_heartbeat_interval_sec,
+                                    )
+                                else:
+                                    time.sleep(1.0)
+                                continue
+                        pre_bridge_recovery_skip_reason = pre_bridge_recovery_skip_reason or (
                             codex_cli_tui_pre_bridge_recovery_skip_reason(
                                 capture,
                                 stage=pre_bridge_blocker_stage,
@@ -1388,7 +1383,11 @@ class SkillsBenchLocalAcpRelay:
                         if (
                             not pre_bridge_recovery_skip_reason
                             and recovery_action
-                            in {"press_enter", "typed_goal_resubmit"}
+                            in {
+                                "press_enter",
+                                "restart_tui_goal",
+                                "typed_goal_resubmit",
+                            }
                         ):
                             pre_bridge_recovery_skip_reason = "retry_limit_reached"
                         tmux_kill_session(tmux_name)

--- a/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
+++ b/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
@@ -138,6 +138,8 @@ def codex_cli_tui_pre_bridge_recovery_action(capture: str, *, stage: str) -> str
         "pre_bridge_tui_stale_terminal",
     }:
         return ""
+    if stage == "pre_bridge_tui_stale_terminal":
+        return "restart_tui_goal"
     if stage == "pre_bridge_tui_error_prompt" and codex_cli_tui_input_prompt_visible(
         capture
     ):

--- a/loopx/codex_cli_goal_tui.py
+++ b/loopx/codex_cli_goal_tui.py
@@ -567,6 +567,52 @@ def wait_for_codex_cli_tui_ready(
     return False
 
 
+def start_codex_cli_goal_tui_session(
+    *,
+    tmux_name: str,
+    cwd: str,
+    shell_command: str,
+    tmp_path: Path,
+    thread_prewarm: bool,
+    thread_prewarm_timeout_sec: float,
+) -> tuple[str, bool]:
+    """Start one fresh Codex TUI session and return its public-safe stage."""
+
+    subprocess.run(
+        [
+            "tmux",
+            "new-session",
+            "-d",
+            "-s",
+            tmux_name,
+            "-c",
+            cwd,
+            shell_command,
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if not wait_for_codex_cli_tui_ready(
+        tmux_name,
+        auto_accept_trust_prompt=True,
+    ):
+        tmux_kill_session(tmux_name)
+        return "tui_ready_timeout", False
+    if not thread_prewarm:
+        return "", False
+    thread_prewarm_observed = prewarm_codex_cli_goal_thread(
+        tmux_name=tmux_name,
+        tmp_path=tmp_path,
+        timeout_sec=thread_prewarm_timeout_sec,
+    )
+    if not thread_prewarm_observed:
+        tmux_kill_session(tmux_name)
+        return "thread_prewarm_timeout", False
+    return "", True
+
+
 def prewarm_codex_cli_goal_thread(
     *,
     tmux_name: str,


### PR DESCRIPTION
## Summary
- start Codex goal TUI sessions through one shared readiness/prewarm helper
- replace stale-terminal in-place `/goal` resubmission with a bounded fresh TUI session restart
- reset lifecycle state before resubmitting the file-backed goal
- add focused startup and route smokes

## Validation
- `python3 examples/codex-cli-goal-tui-session-smoke.py`
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- changed Python `py_compile`
- `loopx canary premerge --from-git-diff` (all selected checks and public-boundary scan passed; expected benchmark-sensitive manual hold remains)

## Scope
This changes pre-bridge TUI recovery only. It does not change scoring, task semantics, permissions, leaderboard/submission behavior, or launch benchmark jobs.