### PR TITLE
Track capability-gap lifecycle metrics

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -343,7 +343,7 @@ tests whether the system is a durable employee rather than a scripted demo.
 | Maintainer correction | `loopx issue-fix pr-lifecycle --maintainer-correction-json ... --execute-transition` | Turn bounded public review feedback into one claimed patch successor, a concrete user gate, or a quiet unchanged poll. |
 | Metrics projection | [`loopx issue-fix metrics`](protocols/issue-fix-metrics-projection-v0.md) | Keep repository baseline separate from attributable agent output, combine existing feasibility/PR lifecycle rows with caller-supplied public snapshots, and report deltas, ratios, inventory, and missing data without another ledger. |
 | Repository snapshot | `loopx issue-fix repository-snapshot` | Explicitly collect bounded public GitHub stock/flow and known issue/PR state; optionally retain only material daily changes in the existing issue-fix domain state. |
-| Metrics supplement | `loopx issue-fix metrics-supplement` | Derive screened issues, triage outcomes, automatic terminal closeouts, complete-coverage first-push CI, and explicit memory evidence from existing issue-fix state; compose coverage-gated human interventions from compact operator-gate/correction history, while accepting a compact event batch for other lifecycle counts and preserving honest missing-data semantics. |
+| Metrics supplement | `loopx issue-fix metrics-supplement` | Derive screened issues, triage outcomes, automatic terminal closeouts, complete-coverage first-push CI, and explicit memory evidence from existing issue-fix state; compose coverage-gated human interventions and typed capability-gap todo transitions from existing rollout evidence, while accepting a compact event batch for other lifecycle counts and preserving honest missing-data semantics. |
 | Acceptance fixture | `loopx issue-fix acceptance-fixture` | Prove failure-before, minimal patch, and pass-after in a deterministic fixture. |
 | Git branch fixture | `loopx issue-fix repo-branch-fixture` | Exercise the same repair contract through a temporary git branch. |
 | Caller repo branch | `loopx issue-fix caller-repo-branch` | Inspect an approved local repo, create/claim an issue branch, and run caller-declared validation. |
@@ -850,6 +850,7 @@ python3 examples/issue-fix-pr-lifecycle-smoke.py
 python3 examples/issue-fix-metrics-projection-smoke.py
 python3 examples/issue-fix-repository-snapshot-smoke.py
 python3 examples/issue-fix-metrics-supplement-smoke.py
+python3 examples/issue-fix-capability-gap-metrics-smoke.py
 python3 examples/issue-fix-maintainer-correction-smoke.py
 python3 examples/issue-fix-outcome-projection-smoke.py
 python3 examples/issue-fix-acceptance-loop-smoke.py

--- a/docs/capabilities/issue-fix/README.zh-CN.md
+++ b/docs/capabilities/issue-fix/README.zh-CN.md
@@ -355,7 +355,7 @@ state 仍优先于迟到反馈。
 | Maintainer correction | `loopx issue-fix pr-lifecycle --maintainer-correction-json ... --execute-transition` | 把有限公开反馈转成一个已认领 patch successor、具体 user gate，或安静的 unchanged poll。 |
 | 指标投影 | [`loopx issue-fix metrics`](protocols/issue-fix-metrics-projection-v0.md) | 严格区分仓库存量基线与 agent 可归因产出；组合现有 feasibility/PR lifecycle 行和调用方提供的公开快照，输出 delta、比例、产出清单与缺失数据，不新增 ledger。 |
 | 仓库快照 | `loopx issue-fix repository-snapshot` | 显式采集有界的公开 GitHub stock/flow 与已知 issue/PR 状态；可选地只把物质日变化写入现有 issue-fix domain state。 |
-| 指标补充组合 | `loopx issue-fix metrics-supplement` | 从现有 issue-fix 状态派生已筛选 issue、triage 终局、自动 terminal closeout、完整覆盖的首推 CI 和显式 memory 证据；按覆盖起点从紧凑 operator-gate/纠正历史组合人工介入，其他生命周期计数仍可通过紧凑事件批次进入，对覆盖不足或尚无证据的指标保持缺失而非填零。 |
+| 指标补充组合 | `loopx issue-fix metrics-supplement` | 从现有 issue-fix 状态派生已筛选 issue、triage 终局、自动 terminal closeout、完整覆盖的首推 CI 和显式 memory 证据；按覆盖起点从紧凑 operator-gate/纠正历史组合人工介入，并从已有 rollout evidence 组合显式 capability-gap todo 生命周期；其他计数仍可通过紧凑事件批次进入，对覆盖不足或尚无证据的指标保持缺失而非填零。 |
 | Acceptance fixture | `loopx issue-fix acceptance-fixture` | 在 deterministic fixture 中证明 failure-before、minimal patch、pass-after。 |
 | Git branch fixture | `loopx issue-fix repo-branch-fixture` | 在临时 git branch 中运行同一修复 contract。 |
 | Caller repo branch | `loopx issue-fix caller-repo-branch` | 检查获批本地 repo、创建/认领 issue branch、运行 caller-declared validation。 |
@@ -816,6 +816,7 @@ python3 examples/issue-fix-pr-lifecycle-smoke.py
 python3 examples/issue-fix-metrics-projection-smoke.py
 python3 examples/issue-fix-repository-snapshot-smoke.py
 python3 examples/issue-fix-metrics-supplement-smoke.py
+python3 examples/issue-fix-capability-gap-metrics-smoke.py
 python3 examples/issue-fix-maintainer-correction-smoke.py
 python3 examples/issue-fix-outcome-projection-smoke.py
 python3 examples/issue-fix-acceptance-loop-smoke.py

--- a/docs/capabilities/issue-fix/protocols/issue-fix-metrics-projection-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-metrics-projection-v0.md
@@ -89,6 +89,7 @@ loopx --format json issue-fix metrics-supplement \
   --period-start 2026-07-01T00:00:00Z \
   --period-end 2026-08-01T00:00:00Z \
   --human-intervention-coverage-start 2026-07-01T00:00:00Z \
+  --capability-gap-coverage-start 2026-07-01T00:00:00Z \
   --event-json /path/to/public-safe-events.json \
   --repository-memory-json /path/to/explicit-memory-read-result.json
 ```
@@ -112,6 +113,30 @@ coverage start exposes the observed count only under
 `coverage.human_intervention` and keeps the metric unavailable, so older
 unprojected conversations are never reconstructed or silently treated as zero.
 
+Capability gaps can use the same no-guessing path without a hand-authored event
+batch. An agent marks an existing agent todo explicitly:
+
+```bash
+loopx todo update \
+  --goal-id public-issue-fix-goal \
+  --todo-id todo_gap_id \
+  --role agent \
+  --target-capability issue_fix_monthly_metrics \
+  --capability-gap-status real_callsite_verified \
+  --evidence 'PR merged and the original pilot callsite passed'
+```
+
+LoopX appends a typed `capability_gap` rollout event; the todo id is the stable
+gap identity and the existing target-capability metadata remains the human
+work surface. The composer folds `found`, `fixed`, and
+`real_callsite_verified` transitions once per todo. It publishes the three
+counts only when `--capability-gap-coverage-start` covers the reporting period;
+otherwise `coverage.capability_gap` exposes partial observation and the counts
+stay unavailable. Backdating that coverage is valid only after auditing and
+backfilling every in-period gap todo. `fixed` and `real_callsite_verified`
+markers require public-safe evidence; `found` may be recorded before a fix
+artifact exists.
+
 PR lifecycle collection also captures first-push CI evidence without another
 ledger when public metadata proves that the PR still has exactly one commit and
 its check rollup is terminal (`PASSING` or `FAILING`). The compact evidence is
@@ -123,10 +148,11 @@ surfaces its observed/eligible coverage instead of reporting a biased rate.
 The composer performs no provider call and does not infer absent events. When no
 explicit memory result is supplied, it may use a compact feasibility memory hook
 only when that hook records `read_performed=true`; otherwise memory fields remain
-absent. With no event batch, event-backed fields other than the coverage-gated
-human-intervention count remain absent. In both
-cases `loopx issue-fix metrics` reports unavailable evidence rather than
-coercing it to zero.
+absent. With no event batch, useful-comment, duplicate-write, and other
+event-backed fields remain absent; only coverage-gated human-intervention and
+typed capability-gap rollout evidence can be composed from existing LoopX
+sources. In both cases `loopx issue-fix metrics` reports unavailable evidence
+rather than coercing it to zero.
 
 ## Attribution contract
 
@@ -215,4 +241,5 @@ through the normal schema-reconciliation path.
 python3 examples/issue-fix-metrics-projection-smoke.py
 python3 examples/issue-fix-repository-snapshot-smoke.py
 python3 examples/issue-fix-metrics-supplement-smoke.py
+python3 examples/issue-fix-capability-gap-metrics-smoke.py
 ```

--- a/examples/issue-fix-capability-gap-metrics-smoke.py
+++ b/examples/issue-fix-capability-gap-metrics-smoke.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Contract smoke for typed capability-gap lifecycle metrics."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTROL_PLANE_EXAMPLES = ROOT / "examples" / "control_plane"
+for path in (ROOT, CONTROL_PLANE_EXAMPLES):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+from todo_lifecycle_fixtures import (  # noqa: E402
+    GOAL_ID,
+    run_cli,
+    run_cli_error,
+    write_fixture,
+)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-capability-gap-metrics-") as tmp:
+        registry_path, _state_file = write_fixture(Path(tmp))
+        project = registry_path.parents[1]
+        runtime = Path(
+            json.loads(registry_path.read_text(encoding="utf-8"))["common_runtime_root"]
+        )
+        domain = project / ".loopx" / "domain-state" / GOAL_ID / "issue_fix"
+        domain.mkdir(parents=True, exist_ok=True)
+        (domain / "feasibility.jsonl").write_text("", encoding="utf-8")
+        (domain / "pr-lifecycle.jsonl").write_text("", encoding="utf-8")
+
+        invalid = run_cli_error(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            "Record one missing metric contract.",
+            "--capability-gap-status",
+            "found",
+        )
+        assert "requires at least one --target-capability" in invalid["error"], invalid
+
+        added = run_cli(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            "Record one missing metric contract.",
+            "--target-capability",
+            "issue_fix_monthly_metrics",
+            "--capability-gap-status",
+            "found",
+        )
+        assert added["capability_gap_event"]["event_kind"] == "capability_gap", added
+        todo_id = added["todo_id"]
+
+        missing_evidence = run_cli_error(
+            registry_path,
+            "todo",
+            "update",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            todo_id,
+            "--role",
+            "agent",
+            "--target-capability",
+            "issue_fix_monthly_metrics",
+            "--capability-gap-status",
+            "real_callsite_verified",
+        )
+        assert "require public-safe --evidence" in missing_evidence["error"], (
+            missing_evidence
+        )
+
+        verified = run_cli(
+            registry_path,
+            "todo",
+            "update",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            todo_id,
+            "--role",
+            "agent",
+            "--target-capability",
+            "issue_fix_monthly_metrics",
+            "--capability-gap-status",
+            "real_callsite_verified",
+            "--evidence",
+            "fixture replay composed one verified gap",
+        )
+        assert verified["capability_gap_event"]["status"] == "real_callsite_verified", verified
+
+        event_log = runtime / "goals" / GOAL_ID / "rollout-event-log.jsonl"
+        events = [json.loads(line) for line in event_log.read_text(encoding="utf-8").splitlines()]
+        gap_events = [event for event in events if event.get("event_kind") == "capability_gap"]
+        assert [event["status"] for event in gap_events] == [
+            "found",
+            "real_callsite_verified",
+        ], gap_events
+        assert all(event["todo_id"] == todo_id for event in gap_events), gap_events
+        assert gap_events[-1]["details"]["evidence"] == (
+            "fixture replay composed one verified gap"
+        ), gap_events
+
+        common_args = (
+            "issue-fix",
+            "metrics-supplement",
+            "--goal-id",
+            GOAL_ID,
+            "--project",
+            str(project),
+            "--repo",
+            "public-fixture/widgets",
+            "--period-start",
+            "2026-07-01T00:00:00Z",
+            "--period-end",
+            "2026-08-01T00:00:00Z",
+            "--generated-at",
+            "2026-08-01T00:01:00Z",
+        )
+        partial = run_cli(registry_path, *common_args)
+        assert partial["supplement"]["coverage"]["capability_gap"] == {
+            "source": "loopx_rollout_event_log",
+            "observed_gaps": 1,
+            "complete": False,
+        }, partial
+        assert "loopx_capability_gaps_found" in partial["missing_fields"], partial
+
+        complete = run_cli(
+            registry_path,
+            *common_args,
+            "--capability-gap-coverage-start",
+            "2026-07-01T00:00:00Z",
+        )
+        counts = complete["supplement"]["counts"]
+        assert counts["loopx_capability_gaps_found"] == 1, complete
+        assert counts["loopx_capability_gaps_fixed"] == 1, complete
+        assert counts["loopx_capability_gaps_real_callsite_verified"] == 1, complete
+        assert complete["supplement"]["coverage"]["capability_gap"] == {
+            "source": "loopx_rollout_event_log",
+            "observed_gaps": 1,
+            "complete": True,
+            "complete_from": "2026-07-01T00:00:00Z",
+        }, complete
+        assert complete["source_summary"]["rollout_event_rows"] >= 4, complete
+
+    print("issue-fix capability-gap metrics smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/issue_fix/metrics_supplement.py
+++ b/loopx/capabilities/issue_fix/metrics_supplement.py
@@ -242,6 +242,56 @@ def _history_human_interventions(
     return sorted(event_ids)
 
 
+def _rollout_capability_gap_states(
+    rollout_event_rows: list[dict[str, Any]],
+    *,
+    period_start: datetime,
+    period_end: datetime,
+) -> dict[str, set[str]]:
+    states: dict[str, set[str]] = {}
+    for index, event in enumerate(rollout_event_rows):
+        if not isinstance(event, dict) or event.get("event_kind") != "capability_gap":
+            continue
+        occurred_at = _timestamp(
+            event.get("recorded_at"),
+            field=f"rollout_event_rows[{index}].recorded_at",
+        )
+        if not period_start <= occurred_at <= period_end:
+            continue
+        gap_id = str(event.get("todo_id") or "").strip()
+        status = str(event.get("status") or "").strip().lower()
+        details = event.get("details")
+        target_capabilities = (
+            details.get("target_capabilities")
+            if isinstance(details, dict)
+            else None
+        )
+        if (
+            not gap_id
+            or status not in {"found", "fixed", "real_callsite_verified"}
+            or not str(target_capabilities or "").strip()
+        ):
+            raise ValueError(
+                "capability_gap rollout events require todo_id, a known status, "
+                "and non-empty details.target_capabilities"
+            )
+        states.setdefault(gap_id, set()).add(status)
+    return states
+
+
+def _capability_gap_counts(gap_states: dict[str, set[str]]) -> dict[str, int]:
+    return {
+        "loopx_capability_gaps_found": len(gap_states),
+        "loopx_capability_gaps_fixed": sum(
+            bool(states & {"fixed", "real_callsite_verified"})
+            for states in gap_states.values()
+        ),
+        "loopx_capability_gaps_real_callsite_verified": sum(
+            "real_callsite_verified" in states for states in gap_states.values()
+        ),
+    }
+
+
 def build_issue_fix_metrics_supplement(
     *,
     repo: str,
@@ -252,6 +302,8 @@ def build_issue_fix_metrics_supplement(
     event_batch: dict[str, Any] | None,
     run_history_rows: list[dict[str, Any]],
     human_intervention_coverage_start: str | None,
+    rollout_event_rows: list[dict[str, Any]],
+    capability_gap_coverage_start: str | None,
     repository_memory_results: list[dict[str, Any]],
     generated_at: str,
 ) -> dict[str, Any]:
@@ -271,6 +323,15 @@ def build_issue_fix_metrics_supplement(
         run_history_rows,
         period_start=start,
         period_end=end,
+    )
+    rollout_gap_states = (
+        _rollout_capability_gap_states(
+            rollout_event_rows,
+            period_start=start,
+            period_end=end,
+        )
+        if event_batch is None
+        else {}
     )
     first_push_eligible, first_push_statuses = _lifecycle_first_push_ci(
         lifecycles,
@@ -335,14 +396,12 @@ def build_issue_fix_metrics_supplement(
                     "capability_gap events require gap_id and a known status"
                 )
             gap_states.setdefault(gap_id, set()).add(status)
-        counts["loopx_capability_gaps_found"] = len(gap_states)
-        counts["loopx_capability_gaps_fixed"] = sum(
-            bool(states & {"fixed", "real_callsite_verified"})
-            for states in gap_states.values()
-        )
-        counts["loopx_capability_gaps_real_callsite_verified"] = sum(
-            "real_callsite_verified" in states for states in gap_states.values()
-        )
+        counts.update(_capability_gap_counts(gap_states))
+        capability_gap_coverage: dict[str, Any] = {
+            "source": EVENT_BATCH_SCHEMA_VERSION,
+            "observed_gaps": len(gap_states),
+            "complete": True,
+        }
     else:
         capture_start = (
             _timestamp(
@@ -364,6 +423,26 @@ def build_issue_fix_metrics_supplement(
             )
         if complete:
             counts["human_interventions"] = len(history_intervention_ids)
+        gap_capture_start = (
+            _timestamp(
+                capability_gap_coverage_start,
+                field="capability_gap_coverage_start",
+            )
+            if capability_gap_coverage_start
+            else None
+        )
+        gap_complete = gap_capture_start is not None and gap_capture_start <= start
+        capability_gap_coverage = {
+            "source": "loopx_rollout_event_log",
+            "observed_gaps": len(rollout_gap_states),
+            "complete": gap_complete,
+        }
+        if gap_capture_start is not None:
+            capability_gap_coverage["complete_from"] = (
+                capability_gap_coverage_start
+            )
+        if gap_complete:
+            counts.update(_capability_gap_counts(rollout_gap_states))
 
     first_push_complete = bool(first_push_eligible) and len(first_push_statuses) == len(
         first_push_eligible
@@ -384,6 +463,7 @@ def build_issue_fix_metrics_supplement(
         "counts": counts,
         "coverage": {
             "human_intervention": human_intervention_coverage,
+            "capability_gap": capability_gap_coverage,
             "first_push_ci": {
                 "eligible_prs": len(first_push_eligible),
                 "observed_prs": len(first_push_statuses),
@@ -404,6 +484,7 @@ def build_issue_fix_metrics_supplement(
             "pr_lifecycle_rows": len(lifecycles),
             "event_rows": len(events),
             "run_history_rows": len(run_history_rows),
+            "rollout_event_rows": len(rollout_event_rows),
             "repository_memory_inputs": len(repository_memory_results),
         },
         "generated_at": generated_at,

--- a/loopx/capabilities/issue_fix/metrics_supplement_cli.py
+++ b/loopx/capabilities/issue_fix/metrics_supplement_cli.py
@@ -11,6 +11,7 @@ from ...domain_packs.issue_fix import (
 )
 from ...history import load_index, load_registry
 from ...paths import resolve_runtime_root
+from ...rollout_event_log import load_rollout_events, rollout_event_log_path
 from .metrics_supplement import build_issue_fix_metrics_supplement
 
 
@@ -48,6 +49,15 @@ def register_issue_fix_metrics_supplement_command(
         ),
     )
     parser.add_argument(
+        "--capability-gap-coverage-start",
+        default=None,
+        help=(
+            "Earliest ISO-8601 time from which capability-gap todo lifecycle "
+            "events have been audited or captured completely. Without it, observed "
+            "events are reported as partial and counts remain unavailable."
+        ),
+    )
+    parser.add_argument(
         "--repository-memory-json",
         action="append",
         default=[],
@@ -77,11 +87,15 @@ def build_issue_fix_metrics_supplement_from_args(
         raise ValueError("only one metrics supplement input may read from stdin")
 
     run_history_rows: list[dict[str, Any]] = []
+    rollout_event_rows: list[dict[str, Any]] = []
     if registry_path is not None:
         registry = load_registry(registry_path)
         runtime_root = resolve_runtime_root(registry, runtime_root_arg)
         run_history_rows, _ = load_index(
             runtime_root / "goals" / args.goal_id / "runs" / "index.jsonl"
+        )
+        rollout_event_rows = load_rollout_events(
+            rollout_event_log_path(runtime_root, args.goal_id)
         )
     project = Path(args.project).expanduser()
     return build_issue_fix_metrics_supplement(
@@ -101,6 +115,8 @@ def build_issue_fix_metrics_supplement_from_args(
         event_batch=load_json_object(args.event_json) if args.event_json else None,
         run_history_rows=run_history_rows,
         human_intervention_coverage_start=args.human_intervention_coverage_start,
+        rollout_event_rows=rollout_event_rows,
+        capability_gap_coverage_start=args.capability_gap_coverage_start,
         repository_memory_results=[
             load_json_object(value) for value in args.repository_memory_json
         ],

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -129,6 +129,14 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
     todo_parser.add_argument(
+        "--capability-gap-status",
+        choices=["found", "fixed", "real_callsite_verified"],
+        help=(
+            "For agent todo add/update, append an auditable capability-gap lifecycle "
+            "event. Requires --target-capability; the todo_id is the stable gap id."
+        ),
+    )
+    todo_parser.add_argument(
         "--explore-result-node-ref",
         dest="explore_result_node_refs",
         action="append",
@@ -366,6 +374,27 @@ def handle_todo_command(
     )
     try:
         validate_shared_todo_options(args)
+        if args.capability_gap_status:
+            if args.todo_command not in {"add", "update"}:
+                raise ValueError(
+                    "--capability-gap-status is supported only by todo add/update"
+                )
+            if args.role != "agent":
+                raise ValueError(
+                    "--capability-gap-status requires --role agent"
+                )
+            if not args.target_capabilities:
+                raise ValueError(
+                    "--capability-gap-status requires at least one --target-capability"
+                )
+            if (
+                args.capability_gap_status in {"fixed", "real_callsite_verified"}
+                and not args.evidence
+            ):
+                raise ValueError(
+                    "fixed and real_callsite_verified capability gaps require "
+                    "public-safe --evidence"
+                )
         if args.todo_command == "list":
             unsupported = unsupported_todo_options(
                 args,
@@ -538,6 +567,7 @@ def handle_todo_command(
                 args.required_write_scopes,
                 args.required_capabilities,
                 args.target_capabilities,
+                args.capability_gap_status,
                 args.explore_result_node_refs,
                 args.clear_explore_result_node_refs,
                 args.decision_scope,

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -19,6 +19,7 @@ TODO_OPTION_FIELDS = (
     ("--required-write-scope", "required_write_scopes"),
     ("--required-capability", "required_capabilities"),
     ("--target-capability", "target_capabilities"),
+    ("--capability-gap-status", "capability_gap_status"),
     ("--explore-result-node-ref", "explore_result_node_refs"),
     ("--clear-explore-result-node-refs", "clear_explore_result_node_refs"),
     ("--decision-scope", "decision_scope"),

--- a/loopx/cli_commands/todo_event.py
+++ b/loopx/cli_commands/todo_event.py
@@ -49,3 +49,37 @@ def append_todo_rollout_event(
             "already_exists": bool(payload.get("already_exists")),
         },
     )
+    capability_gap_status = str(
+        getattr(args, "capability_gap_status", None) or ""
+    ).strip()
+    if not capability_gap_status:
+        return
+    gap_payload: dict[str, object] = {
+        "ok": True,
+        "goal_id": payload.get("goal_id"),
+    }
+    append_cli_rollout_event(
+        gap_payload,
+        registry_path=registry_path,
+        runtime_root_arg=runtime_root_arg,
+        event_kind="capability_gap",
+        agent_id=args.agent_id or args.claimed_by,
+        todo_id=args.todo_id or str(payload.get("todo_id") or "").strip() or None,
+        status=capability_gap_status,
+        summary=(
+            f"capability gap {capability_gap_status} for "
+            f"{payload.get('todo_id') or args.todo_id}"
+        ),
+        details={
+            "command": "todo",
+            "todo_command": args.todo_command,
+            "target_capabilities": ",".join(args.target_capabilities or []),
+            "evidence": args.evidence or "not_required_for_found",
+        },
+    )
+    if gap_payload.get("rollout_event"):
+        payload["capability_gap_event"] = gap_payload["rollout_event"]
+    elif gap_payload.get("rollout_event_log_error"):
+        payload["capability_gap_event_error"] = gap_payload[
+            "rollout_event_log_error"
+        ]

--- a/loopx/rollout_event_log.py
+++ b/loopx/rollout_event_log.py
@@ -16,6 +16,7 @@ ROLLOUT_EVENT_KINDS = {
     "benchmark_launch",
     "benchmark_status",
     "codex_session_observed",
+    "capability_gap",
     "compact_blocker",
     "compact_case_result",
     "failure_attribution",


### PR DESCRIPTION
## Motivation

The issue-fix monthly report can count capability gaps only from a hand-authored event batch. That makes the found/fixed/real-callsite-verified capability delta easy to omit and hard to audit against the Kanban work that produced it.

## Implementation

- add an explicit `--capability-gap-status` marker to agent todo add/update, requiring target-capability metadata
- append a typed, goal-scoped `capability_gap` rollout event keyed by the existing todo id
- compose found/fixed/real-callsite-verified counts from rollout evidence when audited coverage spans the reporting period
- keep partial observation visible under coverage while leaving incomplete metrics unavailable
- document the contract in the English and Chinese issue-fix entry points and protocol

## Validation

- `python3 examples/issue-fix-capability-gap-metrics-smoke.py`
- `python3 examples/issue-fix-metrics-supplement-smoke.py`
- `python3 examples/issue-fix-capability-guide-smoke.py`
- `python3 examples/control_plane/todo-lifecycle-cli-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `loopx canary premerge --from-git-diff`
- `loopx check` public-boundary scan: 0 errors, 0 warnings

## Risk and uncovered cases

The new marker is opt-in and does not infer gaps from prose. Older gaps remain unavailable until an operator audits/backfills the reporting window and declares its coverage start. Repeated lifecycle markers may append duplicate events, but metrics fold by todo id and status, so counts remain idempotent. No external provider behavior, permissions, credentials, or private runtime state are changed.