### PR TITLE
Expose capability-gap impact rows

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -523,7 +523,9 @@ human interventions, first-push CI, capability deltas, and memory leverage.
 Absent evidence is emitted as `not_available` plus a reason code, never as zero.
 The same packet exposes stable `impact_rows`; the generic Lark sink maps them to
 the `Monthly Impact` view with baseline, current, delta, ratio lineage, source,
-freshness, and missing-data columns.
+freshness, and missing-data columns. Capability impact keeps found, fixed, and
+real-callsite-verified gaps as separate rows so delivery volume is not confused
+with product-path proof.
 
 ## Conversational `/loopx` Entry
 

--- a/docs/capabilities/issue-fix/README.zh-CN.md
+++ b/docs/capabilities/issue-fix/README.zh-CN.md
@@ -522,7 +522,8 @@ revision 仍是事实源。
 原生进入这些行的公开计数。证据缺失时输出 `not_available` 和原因码，绝不偷填 0。
 同一 packet 还提供稳定的 `impact_rows`；通用 Lark sink 会把它们投影到
 `Monthly Impact` 视图，保留 baseline、current、delta、比例分子分母、公开来源、
-更新时间和缺失数据原因。
+更新时间和缺失数据原因。能力增量会把 found、fixed 和
+real-callsite-verified 分成三行，避免把发现量、交付量和真实产品路径证明混为一谈。
 
 ## 对话式 `/loopx` 入口
 

--- a/docs/capabilities/issue-fix/protocols/issue-fix-metrics-projection-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-metrics-projection-v0.md
@@ -214,6 +214,12 @@ delivery, quality, autonomy, capability, and memory. Every row keeps its
 baseline, current value, delta, numerator/denominator when applicable, public
 source URL, freshness timestamp, and missing-data reason.
 
+Capability delta is represented by three separate rows: gaps found, gaps
+fixed, and gaps verified on a real callsite. This keeps discovery volume,
+delivery, and product-path proof distinguishable instead of collapsing all
+three into a single success count. Each row remains `not_available` until its
+own evidence-backed count is present.
+
 The generic Lark sink renders those rows into the `Monthly Impact` view without
 storing another metrics ledger:
 

--- a/examples/issue-fix-metrics-projection-smoke.py
+++ b/examples/issue-fix-metrics-projection-smoke.py
@@ -108,6 +108,8 @@ def main() -> int:
                     "first_push_ci_passed": 1,
                     "first_push_ci_total": 2,
                     "loopx_capability_gaps_found": 2,
+                    "loopx_capability_gaps_fixed": 1,
+                    "loopx_capability_gaps_real_callsite_verified": 1,
                     "memory_retrievals": 3,
                 },
             },
@@ -232,12 +234,16 @@ def main() -> int:
             packet["ratios"]["pilot_share_of_repository_prs_opened"]["value"] == 0.5
         ), packet
         assert len(packet["output_inventory"]["pull_requests"]) == 2, packet
-        assert len(packet["impact_rows"]) == 17, packet
+        assert len(packet["impact_rows"]) == 19, packet
         impact_by_id = {row["metric_id"]: row for row in packet["impact_rows"]}
         assert impact_by_id["agent_pull_requests"]["current"] == 2, packet
         assert impact_by_id["repository_open_issues"]["delta"] == 2, packet
         assert impact_by_id["quality_first_push_ci_pass_rate"]["current"] == 0.5
-        assert impact_by_id["capability_gaps_fixed"]["status"] == "not_available"
+        assert impact_by_id["capability_gaps_found"]["current"] == 2, packet
+        assert impact_by_id["capability_gaps_fixed"]["current"] == 1, packet
+        assert (
+            impact_by_id["capability_gaps_real_callsite_verified"]["current"] == 1
+        ), packet
 
         schema = lark_kanban_schema_payload()
         assert any(view["name"] == "Monthly Impact" for view in schema["views"]), schema
@@ -256,7 +262,7 @@ def main() -> int:
                 execute=False,
             )
         assert sync["ok"] is True, sync
-        assert sync["row_count"] == 17, sync
+        assert sync["row_count"] == 19, sync
         metric_records = {
             record["values"]["Metric"]: record for record in sync["records"]
         }
@@ -337,7 +343,7 @@ def main() -> int:
             check=True,
         )
         cli_sync_packet = json.loads(cli_sync.stdout)
-        assert cli_sync_packet["row_count"] == 17, cli_sync_packet
+        assert cli_sync_packet["row_count"] == 19, cli_sync_packet
         serialized = json.dumps(packet, sort_keys=True)
         assert str(root) not in serialized, serialized
         assert packet["external_writes_performed"] is False, packet

--- a/loopx/capabilities/issue_fix/metrics_projection.py
+++ b/loopx/capabilities/issue_fix/metrics_projection.py
@@ -786,10 +786,22 @@ def build_issue_fix_metrics_projection(
         )
     for metric_id, metric_group, metric, supplement_field in (
         (
+            "capability_gaps_found",
+            "Capability",
+            "LoopX capability gaps found",
+            "loopx_capability_gaps_found",
+        ),
+        (
             "capability_gaps_fixed",
             "Capability",
             "LoopX capability gaps fixed",
             "loopx_capability_gaps_fixed",
+        ),
+        (
+            "capability_gaps_real_callsite_verified",
+            "Capability",
+            "LoopX capability gaps real-callsite verified",
+            "loopx_capability_gaps_real_callsite_verified",
         ),
         (
             "memory_verified_patch_influence",


### PR DESCRIPTION
## Motivation

Issue-fix metrics already carry capability gaps found, fixed, and real-callsite-verified, but Monthly Impact exposes only the fixed count. Operators cannot distinguish discovery volume from delivery and real product-path proof.

## Implementation

- add stable impact rows for capability gaps found and real-callsite-verified alongside fixed
- preserve independent unavailable/missing-data behavior for each count
- update the provider-neutral projection/Lark smoke from 17 to 19 rows and assert all three capability values
- document the three-row capability delta in the English and Chinese issue-fix entry points

## Validation

- `python3 examples/issue-fix-metrics-projection-smoke.py`
- `python3 examples/issue-fix-capability-guide-smoke.py`
- Python compile for the changed projection and smoke
- `loopx canary premerge --from-git-diff`
- `loopx check` public-boundary scan: 0 errors, 0 warnings

## Risk and uncovered cases

This is an additive read-model change: existing metric ids remain stable and no provider, permission, state-machine, or deletion behavior changes. Sinks that render all impact rows will receive two additional stable rows. Existing stored rows are not retired automatically.