### PR TITLE
Expose Codex goal thread prewarm canaries

### DIFF
--- a/examples/skillsbench-benchmark-egress-policy-smoke.py
+++ b/examples/skillsbench-benchmark-egress-policy-smoke.py
@@ -139,6 +139,7 @@ def test_public_launcher_uses_container_reachable_benchmark_proxy() -> None:
             "SKILLSBENCH_DOCKER_API_VERSION": "1.43",
             "SKILLSBENCH_REMOTE_CODEX_BIN": "/remote/bin/codex",
             "SKILLSBENCH_LOCAL_CODEX_SANDBOX": "danger-full-access",
+            "SKILLSBENCH_CLI_GOAL_THREAD_PREWARM": "1",
             "SKILLSBENCH_RUN_STAMP": "20260709T000000CST",
             "SKILLSBENCH_TUNNEL_PROBE_TIMEOUT_SEC": "19",
             "SKILLSBENCH_TUNNEL_READY_TIMEOUT_SEC": "71",
@@ -172,6 +173,8 @@ def test_public_launcher_uses_container_reachable_benchmark_proxy() -> None:
     assert "--local-codex-bin /remote/bin/codex" in output, output
     assert "--local-codex-sandbox danger-full-access" in output, output
     assert "local_codex_sandbox=danger-full-access" in output, output
+    assert "codex_cli_goal_thread_prewarm=1" in output, output
+    assert "--codex-cli-goal-thread-prewarm" in output, output
     assert "remote_codex_bin_mode=explicit" in output, output
     assert "--probe-timeout-sec 19" in output, output
     assert "--tunnel-ready-timeout-sec 71" in output, output
@@ -232,6 +235,7 @@ def test_public_launcher_batches_three_cases_with_closeout_sync() -> None:
     assert "--remote-failure-cleanup-pattern" in output, output
     assert "--remote-failure-cleanup-include-docker" in output, output
     assert "--update-ledger" not in output, output
+    assert "--codex-cli-goal-thread-prewarm" not in output, output
     assert "--local-target-lane-id codex-cli-goal-xhigh" in output, output
     assert "--local-target-run-group-contains" not in output, output
     assert "--local-target-backfill-run-group-contains" not in output, output

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -29,6 +29,8 @@ Optional env:
                                        default codex from remote PATH
   SKILLSBENCH_LOCAL_CODEX_SANDBOX      Host Codex sandbox mode; default
                                        workspace-write
+  SKILLSBENCH_CLI_GOAL_THREAD_PREWARM  Set to 1 to prewarm the persisted Codex
+                                       TUI thread before submitting /goal
   SKILLSBENCH_BUILD_STALL_TIMEOUT_SEC  Setup stall timeout, default 3600;
                                        0 disables cap
   SKILLSBENCH_RUN_TIMEOUT_SEC          Supervisor timeout, default 28800
@@ -120,6 +122,11 @@ fi
 
 remote_codex_bin="${SKILLSBENCH_REMOTE_CODEX_BIN:-codex}"
 local_codex_sandbox="${SKILLSBENCH_LOCAL_CODEX_SANDBOX:-workspace-write}"
+codex_cli_goal_thread_prewarm="${SKILLSBENCH_CLI_GOAL_THREAD_PREWARM:-0}"
+if [[ "$codex_cli_goal_thread_prewarm" != "0" && "$codex_cli_goal_thread_prewarm" != "1" ]]; then
+  echo "SKILLSBENCH_CLI_GOAL_THREAD_PREWARM must be 0 or 1" >&2
+  exit 2
+fi
 remote_codex_bin_mode="path_lookup"
 if [[ -n "${SKILLSBENCH_REMOTE_CODEX_BIN:-}" ]]; then
   remote_codex_bin_mode="explicit"
@@ -250,6 +257,9 @@ while True:
     threading.Thread(target=pipe, args=(client, upstream), daemon=True).start()
 '
 extra_runner_args=()
+if [[ "$codex_cli_goal_thread_prewarm" == "1" ]]; then
+  extra_runner_args+=(--codex-cli-goal-thread-prewarm)
+fi
 if [[ -n "${SKILLSBENCH_REGISTRY:-}" ]]; then
   extra_runner_args+=(--registry "$SKILLSBENCH_REGISTRY")
 fi
@@ -372,6 +382,7 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'docker_api_version=%s\n' "$docker_api_version"
   printf 'remote_codex_bin_mode=%s\n' "$remote_codex_bin_mode"
   printf 'local_codex_sandbox=%s\n' "$local_codex_sandbox"
+  printf 'codex_cli_goal_thread_prewarm=%s\n' "$codex_cli_goal_thread_prewarm"
   printf 'local_run_ledger=%s\n' "$local_run_ledger"
   if [[ -n "${standard_aggregate:-}" ]]; then
     printf 'standard_aggregate=%s\n' "$standard_aggregate"
@@ -419,4 +430,5 @@ docker_proxy_endpoint_mode=${docker_proxy_endpoint_mode}
 docker_api_version=${docker_api_version}
 remote_codex_bin_mode=${remote_codex_bin_mode}
 local_codex_sandbox=${local_codex_sandbox}
+codex_cli_goal_thread_prewarm=${codex_cli_goal_thread_prewarm}
 EOF


### PR DESCRIPTION
## Summary
- add an explicit `SKILLSBENCH_CLI_GOAL_THREAD_PREWARM=1` opt-in to the canonical xhigh launcher
- forward the existing runner `--codex-cli-goal-thread-prewarm` flag only when requested
- keep the default launcher behavior unchanged
- cover opt-in and default behavior in the public launcher smoke

## Validation
- `python3 examples/skillsbench-benchmark-egress-policy-smoke.py`
- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`
- `loopx canary premerge --from-git-diff` (all selected checks/public-boundary checks passed; expected benchmark-sensitive manual hold remains)

## Scope
This is a benchmark developer-workflow control for a bounded canary. It does not change scoring, task semantics, runner defaults, permissions, or launch a benchmark job.