### PR TITLE
Fix Codex goal thread prewarm submission

### DIFF
--- a/examples/codex-cli-goal-tui-session-smoke.py
+++ b/examples/codex-cli-goal-tui-session-smoke.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from pathlib import Path
 import sys
-import tempfile
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -24,81 +23,103 @@ def main() -> int:
     def fake_kill(tmux_name: str) -> None:
         calls.append(("kill", tmux_name))
 
+    def fake_type_text_and_submit(*, tmux_name: str, text: str) -> None:
+        calls.append(("type", (tmux_name, text)))
+
     original_run = goal_tui.subprocess.run
     original_wait = goal_tui.wait_for_codex_cli_tui_ready
     original_prewarm = goal_tui.prewarm_codex_cli_goal_thread
     original_kill = goal_tui.tmux_kill_session
+    original_capture = goal_tui.tmux_capture
+    original_type_text_and_submit = goal_tui.tmux_type_text_and_submit
     try:
         goal_tui.subprocess.run = fake_run  # type: ignore[assignment]
         goal_tui.tmux_kill_session = fake_kill  # type: ignore[assignment]
-        with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
-            goal_tui.wait_for_codex_cli_tui_ready = (  # type: ignore[assignment]
-                lambda *_args, **_kwargs: True
-            )
-            goal_tui.prewarm_codex_cli_goal_thread = (  # type: ignore[assignment]
-                lambda **_kwargs: True
-            )
-            stage, prewarmed = goal_tui.start_codex_cli_goal_tui_session(
-                tmux_name="fresh-goal",
-                cwd="/tmp/public-workspace",
-                shell_command="codex --no-alt-screen",
-                tmp_path=temp_path,
-                thread_prewarm=True,
-                thread_prewarm_timeout_sec=120,
-            )
-            assert (stage, prewarmed) == ("", True)
-            assert calls[0] == (
-                "run",
-                [
-                    "tmux",
-                    "new-session",
-                    "-d",
-                    "-s",
-                    "fresh-goal",
-                    "-c",
-                    "/tmp/public-workspace",
-                    "codex --no-alt-screen",
-                ],
-            )
+        goal_tui.wait_for_codex_cli_tui_ready = (  # type: ignore[assignment]
+            lambda *_args, **_kwargs: True
+        )
+        goal_tui.prewarm_codex_cli_goal_thread = (  # type: ignore[assignment]
+            lambda **_kwargs: True
+        )
+        stage, prewarmed = goal_tui.start_codex_cli_goal_tui_session(
+            tmux_name="fresh-goal",
+            cwd="/tmp/public-workspace",
+            shell_command="codex --no-alt-screen",
+            thread_prewarm=True,
+            thread_prewarm_timeout_sec=120,
+        )
+        assert (stage, prewarmed) == ("", True)
+        assert calls[0] == (
+            "run",
+            [
+                "tmux",
+                "new-session",
+                "-d",
+                "-s",
+                "fresh-goal",
+                "-c",
+                "/tmp/public-workspace",
+                "codex --no-alt-screen",
+            ],
+        )
 
-            calls.clear()
-            goal_tui.wait_for_codex_cli_tui_ready = (  # type: ignore[assignment]
-                lambda *_args, **_kwargs: False
-            )
-            stage, prewarmed = goal_tui.start_codex_cli_goal_tui_session(
-                tmux_name="not-ready",
-                cwd="/tmp/public-workspace",
-                shell_command="codex",
-                tmp_path=temp_path,
-                thread_prewarm=False,
-                thread_prewarm_timeout_sec=120,
-            )
-            assert (stage, prewarmed) == ("tui_ready_timeout", False)
-            assert calls[-1] == ("kill", "not-ready")
+        calls.clear()
+        goal_tui.wait_for_codex_cli_tui_ready = (  # type: ignore[assignment]
+            lambda *_args, **_kwargs: False
+        )
+        stage, prewarmed = goal_tui.start_codex_cli_goal_tui_session(
+            tmux_name="not-ready",
+            cwd="/tmp/public-workspace",
+            shell_command="codex",
+            thread_prewarm=False,
+            thread_prewarm_timeout_sec=120,
+        )
+        assert (stage, prewarmed) == ("tui_ready_timeout", False)
+        assert calls[-1] == ("kill", "not-ready")
 
-            calls.clear()
-            goal_tui.wait_for_codex_cli_tui_ready = (  # type: ignore[assignment]
-                lambda *_args, **_kwargs: True
+        calls.clear()
+        goal_tui.wait_for_codex_cli_tui_ready = (  # type: ignore[assignment]
+            lambda *_args, **_kwargs: True
+        )
+        goal_tui.prewarm_codex_cli_goal_thread = (  # type: ignore[assignment]
+            lambda **_kwargs: False
+        )
+        stage, prewarmed = goal_tui.start_codex_cli_goal_tui_session(
+            tmux_name="prewarm-failed",
+            cwd="/tmp/public-workspace",
+            shell_command="codex",
+            thread_prewarm=True,
+            thread_prewarm_timeout_sec=120,
+        )
+        assert (stage, prewarmed) == ("thread_prewarm_timeout", False)
+        assert calls[-1] == ("kill", "prewarm-failed")
+
+        calls.clear()
+        goal_tui.prewarm_codex_cli_goal_thread = original_prewarm
+        goal_tui.tmux_type_text_and_submit = fake_type_text_and_submit  # type: ignore[assignment]
+        goal_tui.tmux_capture = (  # type: ignore[assignment]
+            lambda _tmux_name: goal_tui.CODEX_CLI_GOAL_THREAD_PREWARM_MARKER
+        )
+        assert goal_tui.prewarm_codex_cli_goal_thread(
+            tmux_name="typed-prewarm",
+            timeout_sec=1,
+        )
+        assert calls == [
+            (
+                "type",
+                (
+                    "typed-prewarm",
+                    goal_tui.CODEX_CLI_GOAL_THREAD_PREWARM_PROMPT,
+                ),
             )
-            goal_tui.prewarm_codex_cli_goal_thread = (  # type: ignore[assignment]
-                lambda **_kwargs: False
-            )
-            stage, prewarmed = goal_tui.start_codex_cli_goal_tui_session(
-                tmux_name="prewarm-failed",
-                cwd="/tmp/public-workspace",
-                shell_command="codex",
-                tmp_path=temp_path,
-                thread_prewarm=True,
-                thread_prewarm_timeout_sec=120,
-            )
-            assert (stage, prewarmed) == ("thread_prewarm_timeout", False)
-            assert calls[-1] == ("kill", "prewarm-failed")
+        ]
     finally:
         goal_tui.subprocess.run = original_run  # type: ignore[assignment]
         goal_tui.wait_for_codex_cli_tui_ready = original_wait  # type: ignore[assignment]
         goal_tui.prewarm_codex_cli_goal_thread = original_prewarm  # type: ignore[assignment]
         goal_tui.tmux_kill_session = original_kill  # type: ignore[assignment]
+        goal_tui.tmux_capture = original_capture  # type: ignore[assignment]
+        goal_tui.tmux_type_text_and_submit = original_type_text_and_submit  # type: ignore[assignment]
 
     print("codex-cli-goal-tui-session-smoke ok")
     return 0

--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -1637,7 +1637,8 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "def codex_cli_goal_reset_pre_bridge_deadlines(" in tui_source
     assert '"goal_submission_generation"' in tui_source
     assert 'fields[f"goal_{name}_marker_delta"]' in tui_source
-    assert "goal-thread-prewarm.txt" in tui_source
+    assert "goal-thread-prewarm.txt" not in tui_source
+    assert "text=CODEX_CLI_GOAL_THREAD_PREWARM_PROMPT" in tui_source
     assert CODEX_CLI_GOAL_TASK_PROMPT_FILENAME in tui_source
     assert "tmux_send_plain_enter" in tui_source
     assert "tmux_type_text_and_submit" in tui_source

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -1100,7 +1100,6 @@ class SkillsBenchLocalAcpRelay:
                     tmux_name=tmux_name,
                     cwd=cwd,
                     shell_command=shell_command,
-                    tmp_path=tmp_path,
                     thread_prewarm=thread_prewarm,
                     thread_prewarm_timeout_sec=CODEX_CLI_GOAL_THREAD_PREWARM_TIMEOUT_SEC,
                 )
@@ -1333,7 +1332,6 @@ class SkillsBenchLocalAcpRelay:
                                         tmux_name=tmux_name,
                                         cwd=cwd,
                                         shell_command=shell_command,
-                                        tmp_path=tmp_path,
                                         thread_prewarm=thread_prewarm,
                                         thread_prewarm_timeout_sec=CODEX_CLI_GOAL_THREAD_PREWARM_TIMEOUT_SEC,
                                     )

--- a/loopx/codex_cli_goal_tui.py
+++ b/loopx/codex_cli_goal_tui.py
@@ -572,7 +572,6 @@ def start_codex_cli_goal_tui_session(
     tmux_name: str,
     cwd: str,
     shell_command: str,
-    tmp_path: Path,
     thread_prewarm: bool,
     thread_prewarm_timeout_sec: float,
 ) -> tuple[str, bool]:
@@ -604,7 +603,6 @@ def start_codex_cli_goal_tui_session(
         return "", False
     thread_prewarm_observed = prewarm_codex_cli_goal_thread(
         tmux_name=tmux_name,
-        tmp_path=tmp_path,
         timeout_sec=thread_prewarm_timeout_sec,
     )
     if not thread_prewarm_observed:
@@ -616,17 +614,13 @@ def start_codex_cli_goal_tui_session(
 def prewarm_codex_cli_goal_thread(
     *,
     tmux_name: str,
-    tmp_path: Path,
     timeout_sec: float = 90.0,
 ) -> bool:
     """Create the persisted TUI thread before submitting ``/goal``."""
 
-    prompt_path = tmp_path / "goal-thread-prewarm.txt"
-    prompt_path.write_text(CODEX_CLI_GOAL_THREAD_PREWARM_PROMPT, encoding="utf-8")
-    tmux_paste_file_and_submit(
+    tmux_type_text_and_submit(
         tmux_name=tmux_name,
-        prompt_path=prompt_path,
-        buffer_suffix="prewarm",
+        text=CODEX_CLI_GOAL_THREAD_PREWARM_PROMPT,
     )
     deadline = time.monotonic() + max(1.0, float(timeout_sec or 0.0))
     while time.monotonic() < deadline:


### PR DESCRIPTION
## Summary
- submit the short public persisted-thread prewarm prompt through the reliable typed-input path
- remove the obsolete temporary prompt-file parameter from the internal TUI startup helper
- add focused smoke coverage for typed prewarm submission and marker detection

## Evidence
The post-#1882 hvac canary ended at `thread_prewarm_timeout` before `/goal` submission (`generation=0`, `goal_slash_command_submitted=false`, zero bridge requests). The prewarm path still used file paste while `/goal` uses typed input.

## Validation
- `python3 examples/codex-cli-goal-tui-session-smoke.py`
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- changed Python `py_compile` and diff checks
- `loopx canary premerge --from-git-diff` (all selected checks/public-boundary checks passed; expected benchmark-sensitive manual hold remains)

## Scope
This changes only prewarm input transport. It does not change scoring, task semantics, permissions, launcher defaults, or launch a benchmark job.