### PR TITLE
Fix active Codex goal thread prewarm completion

### DIFF
--- a/examples/codex-cli-goal-tui-session-smoke.py
+++ b/examples/codex-cli-goal-tui-session-smoke.py
@@ -32,6 +32,8 @@ def main() -> int:
     original_kill = goal_tui.tmux_kill_session
     original_capture = goal_tui.tmux_capture
     original_type_text_and_submit = goal_tui.tmux_type_text_and_submit
+    original_monotonic = goal_tui.time.monotonic
+    original_sleep = goal_tui.time.sleep
     try:
         goal_tui.subprocess.run = fake_run  # type: ignore[assignment]
         goal_tui.tmux_kill_session = fake_kill  # type: ignore[assignment]
@@ -113,6 +115,39 @@ def main() -> int:
                 ),
             )
         ]
+
+        captures = iter(
+            [
+                "Working (10s • esc to interrupt)",
+                "persisted thread ready\n› ",
+            ]
+        )
+        clock = iter([0.0, 0.0, 0.5, 1.5, 1.5])
+        goal_tui.tmux_capture = lambda _tmux_name: next(captures)  # type: ignore[assignment]
+        goal_tui.time.monotonic = lambda: next(clock)  # type: ignore[assignment]
+        goal_tui.time.sleep = lambda _seconds: None  # type: ignore[assignment]
+        assert goal_tui.prewarm_codex_cli_goal_thread(
+            tmux_name="active-then-ready",
+            timeout_sec=1,
+        )
+
+        clock = iter([0.0, 0.0, 1.0, 1.0])
+        goal_tui.tmux_capture = lambda _tmux_name: "waiting"  # type: ignore[assignment]
+        goal_tui.time.monotonic = lambda: next(clock)  # type: ignore[assignment]
+        assert not goal_tui.prewarm_codex_cli_goal_thread(
+            tmux_name="nominal-timeout",
+            timeout_sec=1,
+        )
+
+        clock = iter([0.0, 0.0, 0.5, 1.0, 1.5, 2.0])
+        goal_tui.tmux_capture = (  # type: ignore[assignment]
+            lambda _tmux_name: "Working (10s • esc to interrupt)"
+        )
+        goal_tui.time.monotonic = lambda: next(clock)  # type: ignore[assignment]
+        assert not goal_tui.prewarm_codex_cli_goal_thread(
+            tmux_name="hard-timeout",
+            timeout_sec=1,
+        )
     finally:
         goal_tui.subprocess.run = original_run  # type: ignore[assignment]
         goal_tui.wait_for_codex_cli_tui_ready = original_wait  # type: ignore[assignment]
@@ -120,6 +155,8 @@ def main() -> int:
         goal_tui.tmux_kill_session = original_kill  # type: ignore[assignment]
         goal_tui.tmux_capture = original_capture  # type: ignore[assignment]
         goal_tui.tmux_type_text_and_submit = original_type_text_and_submit  # type: ignore[assignment]
+        goal_tui.time.monotonic = original_monotonic  # type: ignore[assignment]
+        goal_tui.time.sleep = original_sleep  # type: ignore[assignment]
 
     print("codex-cli-goal-tui-session-smoke ok")
     return 0

--- a/loopx/codex_cli_goal_tui.py
+++ b/loopx/codex_cli_goal_tui.py
@@ -20,6 +20,7 @@ CODEX_CLI_GOAL_THREAD_PREWARM_PROMPT = (
     "Start this persisted Codex thread. Reply with exactly the token formed by "
     "joining LOOPX, GOAL, THREAD, and READY with underscores. Do not use tools."
 )
+CODEX_CLI_GOAL_THREAD_PREWARM_HARD_CAP_MULTIPLIER = 2.0
 CODEX_CLI_GOAL_TASK_PROMPT_FILENAME = "skillsbench-task-prompt.md"
 CODEX_CLI_GOAL_KICKOFF_PROMPT = (
     "Start working on the active SkillsBench goal now. Read the referenced "
@@ -622,10 +623,26 @@ def prewarm_codex_cli_goal_thread(
         tmux_name=tmux_name,
         text=CODEX_CLI_GOAL_THREAD_PREWARM_PROMPT,
     )
-    deadline = time.monotonic() + max(1.0, float(timeout_sec or 0.0))
-    while time.monotonic() < deadline:
+    timeout = max(1.0, float(timeout_sec or 0.0))
+    started_at = time.monotonic()
+    nominal_deadline = started_at + timeout
+    hard_deadline = started_at + (
+        timeout * CODEX_CLI_GOAL_THREAD_PREWARM_HARD_CAP_MULTIPLIER
+    )
+    turn_active_observed = False
+    while time.monotonic() < hard_deadline:
         capture = tmux_capture(tmux_name)
         if CODEX_CLI_GOAL_THREAD_PREWARM_MARKER in capture:
             return True
+        turn_active = codex_cli_tui_turn_active(capture)
+        turn_active_observed = turn_active_observed or turn_active
+        if (
+            turn_active_observed
+            and not turn_active
+            and codex_cli_tui_input_prompt_visible(capture)
+        ):
+            return True
+        if time.monotonic() >= nominal_deadline and not turn_active:
+            return False
         time.sleep(0.5)
     return False


### PR DESCRIPTION
## Summary
- let persisted-thread prewarm continue past its nominal timeout while the Codex TUI visibly has an active turn
- accept a completed active turn when the TUI returns to its input prompt, even if the requested marker is absent
- preserve a two-times hard cap and keep inactive prewarm attempts on the nominal timeout

## Validation
- `python3 examples/codex-cli-goal-tui-session-smoke.py`
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `python3 -m py_compile loopx/codex_cli_goal_tui.py examples/codex-cli-goal-tui-session-smoke.py`
- `loopx canary premerge --from-git-diff`
- `git diff --check origin/main...HEAD`

## Boundary
No task text, trajectories, verifier output, credentials, local paths, or generated benchmark logs are included.