### PR TITLE
Expose complete memory impact metrics

### DIFF
--- a/docs/capabilities/issue-fix/protocols/issue-fix-metrics-projection-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-metrics-projection-v0.md
@@ -69,7 +69,8 @@ native to feasibility or PR lifecycle rows:
     "loopx_capability_gaps_found": 3,
     "loopx_capability_gaps_fixed": 2,
     "memory_retrievals": 4,
-    "memory_verified_patch_influence": 1
+    "memory_verified_patch_influence": 1,
+    "memory_stale_results": 1
   }
 }
 ```
@@ -219,6 +220,12 @@ fixed, and gaps verified on a real callsite. This keeps discovery volume,
 delivery, and product-path proof distinguishable instead of collapsing all
 three into a single success count. Each row remains `not_available` until its
 own evidence-backed count is present.
+
+Repository-memory impact is likewise represented by three separate rows:
+retrieved results, results verified to influence a patch, and results verified
+stale. This separates usage volume from demonstrated engineering leverage and
+retrieval quality; zero is retained as evidence, while missing counts remain
+`not_available`.
 
 The generic Lark sink renders those rows into the `Monthly Impact` view without
 storing another metrics ledger:

--- a/examples/issue-fix-metrics-projection-smoke.py
+++ b/examples/issue-fix-metrics-projection-smoke.py
@@ -111,6 +111,8 @@ def main() -> int:
                     "loopx_capability_gaps_fixed": 1,
                     "loopx_capability_gaps_real_callsite_verified": 1,
                     "memory_retrievals": 3,
+                    "memory_verified_patch_influence": 1,
+                    "memory_stale_results": 1,
                 },
             },
         )
@@ -234,7 +236,7 @@ def main() -> int:
             packet["ratios"]["pilot_share_of_repository_prs_opened"]["value"] == 0.5
         ), packet
         assert len(packet["output_inventory"]["pull_requests"]) == 2, packet
-        assert len(packet["impact_rows"]) == 19, packet
+        assert len(packet["impact_rows"]) == 21, packet
         impact_by_id = {row["metric_id"]: row for row in packet["impact_rows"]}
         assert impact_by_id["agent_pull_requests"]["current"] == 2, packet
         assert impact_by_id["repository_open_issues"]["delta"] == 2, packet
@@ -244,6 +246,9 @@ def main() -> int:
         assert (
             impact_by_id["capability_gaps_real_callsite_verified"]["current"] == 1
         ), packet
+        assert impact_by_id["memory_retrievals"]["current"] == 3, packet
+        assert impact_by_id["memory_verified_patch_influence"]["current"] == 1, packet
+        assert impact_by_id["memory_stale_results"]["current"] == 1, packet
 
         schema = lark_kanban_schema_payload()
         assert any(view["name"] == "Monthly Impact" for view in schema["views"]), schema
@@ -262,7 +267,7 @@ def main() -> int:
                 execute=False,
             )
         assert sync["ok"] is True, sync
-        assert sync["row_count"] == 19, sync
+        assert sync["row_count"] == 21, sync
         metric_records = {
             record["values"]["Metric"]: record for record in sync["records"]
         }
@@ -312,6 +317,8 @@ def main() -> int:
             "observed_prs": 1,
             "complete": False,
         }, partial_packet
+        assert partial_rows["memory_retrievals"]["status"] == "not_available"
+        assert partial_rows["memory_stale_results"]["status"] == "not_available"
 
         cli_sync = subprocess.run(
             [
@@ -343,7 +350,7 @@ def main() -> int:
             check=True,
         )
         cli_sync_packet = json.loads(cli_sync.stdout)
-        assert cli_sync_packet["row_count"] == 19, cli_sync_packet
+        assert cli_sync_packet["row_count"] == 21, cli_sync_packet
         serialized = json.dumps(packet, sort_keys=True)
         assert str(root) not in serialized, serialized
         assert packet["external_writes_performed"] is False, packet

--- a/loopx/capabilities/issue_fix/metrics_projection.py
+++ b/loopx/capabilities/issue_fix/metrics_projection.py
@@ -804,10 +804,22 @@ def build_issue_fix_metrics_projection(
             "loopx_capability_gaps_real_callsite_verified",
         ),
         (
+            "memory_retrievals",
+            "Memory",
+            "Repository-memory results retrieved",
+            "memory_retrievals",
+        ),
+        (
             "memory_verified_patch_influence",
             "Memory",
             "Memory retrievals verified to influence a patch",
             "memory_verified_patch_influence",
+        ),
+        (
+            "memory_stale_results",
+            "Memory",
+            "Repository-memory results verified stale",
+            "memory_stale_results",
         ),
     ):
         value = supplement[supplement_field]


### PR DESCRIPTION
## Motivation

The issue-fix metrics supplement already computes repository-memory retrieval, verified patch influence, and stale-result counts. Monthly Impact projected only patch influence, hiding usage and retrieval-quality evidence.

## What changed

- add stable Monthly Impact rows for repository-memory retrievals and stale results
- preserve verified patch influence as a separate row
- keep evidence-backed zero distinct from missing (`not_available`)
- document the three-row memory contract

## Validation

- `python3 examples/issue-fix-metrics-projection-smoke.py`
- `python3 examples/issue-fix-metrics-supplement-smoke.py`
- `loopx canary premerge --from-git-diff` (passed; 14 selected checks; self-merge allowed)

## Risk

Low. This adds two provider-neutral projection rows and updates row-count contracts. Existing row identifiers are unchanged. Shared sinks will upsert the new rows on their next canonical sync.

## Not covered

This does not change memory retrieval/writeback policy or claim that retrieval influenced a patch; it only exposes already computed counts.