### PR TITLE
Prime SkillsBench goal bridge first action

### DIFF
--- a/examples/codex-cli-goal-tui-session-smoke.py
+++ b/examples/codex-cli-goal-tui-session-smoke.py
@@ -3,8 +3,11 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+import subprocess
 import sys
+import tempfile
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -35,6 +38,29 @@ def main() -> int:
     original_monotonic = goal_tui.time.monotonic
     original_sleep = goal_tui.time.sleep
     try:
+        with tempfile.TemporaryDirectory() as temp:
+            request_path = Path(temp) / "bridge-request.json"
+            bridge = Path(temp) / "public-bridge"
+            bridge.write_text(
+                "#!/bin/sh\ncat > " + str(request_path) + "\n",
+                encoding="utf-8",
+            )
+            bridge.chmod(0o700)
+            helper = goal_tui.write_codex_cli_goal_bridge_first_action_helper(
+                cwd=temp,
+                bridge_executable=str(bridge),
+            )
+            assert helper.name == goal_tui.CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_FILENAME
+            assert helper.stat().st_mode & 0o100
+            subprocess.run([str(helper)], check=True)
+            request = json.loads(request_path.read_text(encoding="utf-8"))
+            assert request == {
+                "operation": "exec",
+                "cwd": "/app",
+                "command": "pwd && ls -la",
+                "timeout_sec": 10,
+            }
+
         goal_tui.subprocess.run = fake_run  # type: ignore[assignment]
         goal_tui.tmux_kill_session = fake_kill  # type: ignore[assignment]
         goal_tui.wait_for_codex_cli_tui_ready = (  # type: ignore[assignment]

--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -1425,6 +1425,7 @@ def _assert_cli_goal_active_timeout_is_public_countability_stage() -> None:
 def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> None:
     sys.path.insert(0, str(REPO_ROOT))
     from loopx.codex_cli_goal_tui import (
+        CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_FILENAME,
         CODEX_CLI_GOAL_OBJECTIVE_MAX_CHARS,
         CODEX_CLI_GOAL_TASK_PROMPT_FILENAME,
         CODEX_CLI_GOAL_THREAD_PREWARM_MARKER,
@@ -1450,6 +1451,7 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
         CODEX_CLI_GOAL_TASK_PROMPT_FILENAME
     )
     assert CODEX_CLI_GOAL_TASK_PROMPT_FILENAME in objective, objective
+    assert CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_FILENAME in objective, objective
     assert len(objective) < CODEX_CLI_GOAL_OBJECTIVE_MAX_CHARS
     assert build_codex_cli_goal_tui_input(objective).startswith("/goal "), objective
     cmd = build_codex_cli_tui_command(
@@ -1664,6 +1666,10 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
         trace = payload["codex_cli_goal"]
         assert trace["goal_prompt_file_used"] is True, trace
         assert trace["goal_prompt_file_raw_path_recorded"] is False, trace
+        assert trace["goal_bridge_first_action_helper_used"] is True, trace
+        assert (
+            trace["goal_bridge_first_action_helper_raw_path_recorded"] is False
+        ), trace
         assert trace["goal_command_submission_method"] == "typed", trace
         assert trace["goal_kickoff_prompt_submitted"] is False, trace
         assert trace["goal_kickoff_prompt_raw_text_recorded"] is False, trace

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -76,6 +76,7 @@ from loopx.codex_cli_goal_tui import (
     tmux_paste_file_and_submit,
     tmux_submit_enter,
     tmux_type_text_and_submit,
+    write_codex_cli_goal_bridge_first_action_helper,
 )
 
 SAFE_LOOPX_TODO_ID_RE = re.compile(r"^todo_[A-Za-z0-9_-]{6,80}$")
@@ -1037,6 +1038,7 @@ class SkillsBenchLocalAcpRelay:
                     summary_path=bridge_summary_path,
                     bridge_command=agent_bridge_command,
                 )
+                write_codex_cli_goal_bridge_first_action_helper(cwd=local_cwd, bridge_executable=str(instrumented_bridge))
                 prompt_for_codex = self._prompt_with_remote_bridge_packet(
                     prompt_text,
                     bridge_probe=bridge_probe,
@@ -1842,6 +1844,8 @@ class SkillsBenchLocalAcpRelay:
                 "goal_thread_prewarm_timeout_sec": CODEX_CLI_GOAL_THREAD_PREWARM_TIMEOUT_SEC if self._config.codex_cli_goal_thread_prewarm else 0,
                 "goal_prompt_file_used": bool(goal_prompt_file_used),
                 "goal_prompt_file_raw_path_recorded": False,
+                "goal_bridge_first_action_helper_used": bool(goal_prompt_file_used),
+                "goal_bridge_first_action_helper_raw_path_recorded": False,
                 "goal_command_submission_method": str(
                     goal_command_submission_method or ""
                 )[:40],

--- a/loopx/codex_cli_goal_tui.py
+++ b/loopx/codex_cli_goal_tui.py
@@ -22,6 +22,7 @@ CODEX_CLI_GOAL_THREAD_PREWARM_PROMPT = (
 )
 CODEX_CLI_GOAL_THREAD_PREWARM_HARD_CAP_MULTIPLIER = 2.0
 CODEX_CLI_GOAL_TASK_PROMPT_FILENAME = "skillsbench-task-prompt.md"
+CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_FILENAME = "loopx-task-bridge-first-action"
 CODEX_CLI_GOAL_KICKOFF_PROMPT = (
     "Start working on the active SkillsBench goal now. Read the referenced "
     "task prompt file first, follow it exactly, and perform at least one "
@@ -112,14 +113,44 @@ def build_codex_cli_goal_file_objective(prompt_filename: str) -> str:
     if not prompt_ref or ".." in Path(prompt_ref).parts:
         prompt_ref = CODEX_CLI_GOAL_TASK_PROMPT_FILENAME
     objective = (
-        "Complete the SkillsBench task using the private task and bridge "
-        f"instructions in ./{prompt_ref}. Read that file first, follow it "
+        f"First run ./{CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_FILENAME} and require "
+        "it to succeed. Then complete the SkillsBench task using the private "
+        f"task and bridge instructions in ./{prompt_ref}. Read that file, follow it "
         "exactly, and perform at least one task-facing bridge action before "
         "reporting status."
     )
     if len(objective) > CODEX_CLI_GOAL_OBJECTIVE_MAX_CHARS:
         raise ValueError("codex cli goal file objective exceeds objective cap")
     return objective
+
+
+def write_codex_cli_goal_bridge_first_action_helper(
+    *,
+    cwd: str | Path,
+    bridge_executable: str,
+) -> Path:
+    """Write the goal's first task-facing bridge action into its workspace."""
+
+    request = json.dumps(
+        {
+            "operation": "exec",
+            "cwd": "/app",
+            "command": "pwd && ls -la",
+            "timeout_sec": 10,
+        },
+        separators=(",", ":"),
+    )
+    helper_path = Path(cwd) / CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_FILENAME
+    command = (
+        f"printf '%s\\n' {shlex.quote(request)} | "
+        f"{shlex.quote(str(bridge_executable))}"
+    )
+    helper_path.write_text(
+        "#!/bin/sh\nset -eu\n" + command + "\n",
+        encoding="utf-8",
+    )
+    helper_path.chmod(0o700)
+    return helper_path
 
 
 def build_codex_cli_tui_command(


### PR DESCRIPTION
## Summary
- create a cwd-local executable that performs the existing exact first JSON bridge exec
- make the file-backed `/goal` objective run that helper before reading the full task prompt
- expose public-safe helper-use metadata without recording its path or task material
- cover helper execution, stdin JSON shape, objective ordering, and trace fields

## Motivation
Public positive controls show direct `/goal`, file-backed `/goal`, and file-backed `/goal` plus a JSON bridge all work. The real SkillsBench goal still becomes active and then fails before any bridge request. This narrows the compatibility gap to starting the first task-facing bridge action before the full task prompt is processed.

## Validation
- `python3 examples/codex-cli-goal-tui-session-smoke.py`
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- changed-file `py_compile`
- `loopx canary premerge --from-git-diff`
- `git diff --check origin/main...HEAD`

## Boundary
No task text, raw trajectories, verifier output, credentials, local paths, or generated benchmark logs are included. The change does not alter scoring, task semantics, verifier behavior, permission boundaries, or launch jobs.