### PR TITLE
Reconcile uncertain context-provider writes before retry

### DIFF
--- a/examples/issue-fix-repository-memory-smoke.py
+++ b/examples/issue-fix-repository-memory-smoke.py
@@ -28,6 +28,7 @@ from loopx.capabilities.issue_fix.repository_memory_provider import (  # noqa: E
 from loopx.capabilities.context_providers.base import (  # noqa: E402
     ContextProviderItem,
     ContextProviderRetrieval,
+    ContextProviderSync,
 )
 from loopx.capabilities.context_providers.openviking import (  # noqa: E402
     OpenVikingContextProvider,
@@ -102,6 +103,68 @@ class OpenVikingContractRunner:
         else:
             raise AssertionError(command)
         return subprocess.CompletedProcess(command, 0, stdout=stdout)
+
+
+class UncertainWriteRunner:
+    def __init__(
+        self,
+        *,
+        target: str,
+        source_content: str,
+        post_write_state: str = "pending",
+    ) -> None:
+        self.target = target
+        self.source_content = source_content
+        self.post_write_state = post_write_state
+        self.calls: list[list[str]] = []
+        self.write_attempted = False
+
+    def __call__(
+        self, command: list[str], **_kwargs: Any
+    ) -> subprocess.CompletedProcess[str]:
+        self.calls.append(command)
+        args = command[1:]
+        if args == ["--version"]:
+            return subprocess.CompletedProcess(
+                command, 0, stdout="openviking 0.4.9.dev40\n"
+            )
+        if args[:2] == ["status", "-o"]:
+            return subprocess.CompletedProcess(
+                command, 0, stdout=json.dumps({"status": "healthy"})
+            )
+        if args[0] == "add-resource":
+            self.write_attempted = True
+            return subprocess.CompletedProcess(command, 1, stdout="Connection Error")
+        if args[0] == "read":
+            if self.write_attempted and self.post_write_state == "verified":
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    stdout=json.dumps({"result": self.source_content}),
+                )
+            return subprocess.CompletedProcess(command, 1, stdout="not found")
+        if args[0] == "tree":
+            rows = (
+                [{"uri": self.target}]
+                if self.write_attempted and self.post_write_state == "pending"
+                else []
+            )
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=json.dumps({"result": {"resources": rows}}),
+            )
+        if args[0] == "ls":
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=json.dumps({"result": {"resources": []}}),
+            )
+        if args[0] == "mkdir":
+            return subprocess.CompletedProcess(
+                command, 0, stdout=json.dumps({"ok": True})
+            )
+        raise AssertionError(command)
 
 
 def repository_context() -> dict[str, object]:
@@ -302,6 +365,101 @@ def main() -> int:
         assert sync_plan["ok"] is True, sync_plan
         assert sync_plan["external_writes_performed"] is False, sync_plan
         assert_boundary(sync_plan)
+
+        target = f"viking://resources/public-repo/{REVISION}/src/worker.py"
+        uncertain_runner = UncertainWriteRunner(
+            target=target,
+            source_content=source.read_text(encoding="utf-8"),
+        )
+        uncertain_provider = OpenVikingContextProvider(
+            executable="ov-contract",
+            runner=uncertain_runner,
+        )
+        uncertain = uncertain_provider.sync(
+            namespace="public-repository",
+            resources=[(str(source), target)],
+            timeout_seconds=5,
+            observed_at="2026-07-11T03:30:00+08:00",
+            execute=True,
+        ).public_packet()
+        assert uncertain["status"] == "committed_pending", uncertain
+        assert uncertain["ok"] is True, uncertain
+        assert uncertain["completed_count"] == 0, uncertain
+        assert uncertain["pending_count"] == 1, uncertain
+        assert uncertain["write_count"] == 1, uncertain
+        assert uncertain["reconciliation_performed"] is True, uncertain
+        assert uncertain["retry_disposition"] == "wait_and_reconcile", uncertain
+        assert uncertain["external_writes_performed"] is True, uncertain
+        assert_boundary(uncertain)
+
+        verified_runner = UncertainWriteRunner(
+            target=target,
+            source_content=source.read_text(encoding="utf-8"),
+            post_write_state="verified",
+        )
+        verified = (
+            OpenVikingContextProvider(
+                executable="ov-contract",
+                runner=verified_runner,
+            )
+            .sync(
+                namespace="public-repository",
+                resources=[(str(source), target)],
+                timeout_seconds=5,
+                observed_at="2026-07-11T03:30:00+08:00",
+                execute=True,
+            )
+            .public_packet()
+        )
+        assert verified["status"] == "completed", verified
+        assert verified["completed_count"] == 1, verified
+        assert verified["pending_count"] == 0, verified
+        assert verified["write_count"] == 1, verified
+        assert verified["reconciliation_performed"] is True, verified
+        assert verified["retry_disposition"] == "no_retry", verified
+
+        absent_runner = UncertainWriteRunner(
+            target=target,
+            source_content=source.read_text(encoding="utf-8"),
+            post_write_state="absent",
+        )
+        absent = (
+            OpenVikingContextProvider(
+                executable="ov-contract",
+                runner=absent_runner,
+            )
+            .sync(
+                namespace="public-repository",
+                resources=[(str(source), target)],
+                timeout_seconds=5,
+                observed_at="2026-07-11T03:30:00+08:00",
+                execute=True,
+            )
+            .public_packet()
+        )
+        assert absent["status"] == "partial", absent
+        assert absent["completed_count"] == 0, absent
+        assert absent["pending_count"] == 0, absent
+        assert absent["write_count"] == 0, absent
+        assert absent["reconciliation_performed"] is True, absent
+        assert absent["retry_disposition"] == "safe_to_retry", absent
+        assert absent["reason_code"] == "provider_sync_write_failed_absent", absent
+
+        generic_pending = ContextProviderSync(
+            provider="fake-provider",
+            namespace="public-repository",
+            status="committed_pending",
+            observed_at="2026-07-11T03:30:00+08:00",
+            requested_count=1,
+            completed_count=0,
+            write_count=1,
+            pending_count=1,
+            reconciliation_performed=True,
+            retry_disposition="wait_and_reconcile",
+        ).public_packet()
+        assert generic_pending["ok"] is True, generic_pending
+        assert generic_pending["retry_disposition"] == "wait_and_reconcile"
+        assert_boundary(generic_pending)
         provider_result = retrieve_issue_fix_repository_memory(
             config={
                 "schema_version": "issue_fix_repository_memory_provider_config_v0",

--- a/loopx/capabilities/context_providers/base.py
+++ b/loopx/capabilities/context_providers/base.py
@@ -126,11 +126,14 @@ class ContextProviderSync:
     provider_version: str | None = None
     latency_ms: int = 0
     result_refs: tuple[str, ...] = field(default_factory=tuple)
+    pending_count: int = 0
+    reconciliation_performed: bool = False
+    retry_disposition: str = "no_retry"
 
     def public_packet(self) -> dict[str, object]:
         return {
             "schema_version": CONTEXT_PROVIDER_SYNC_SCHEMA_VERSION,
-            "ok": self.status in {"completed", "planned"},
+            "ok": self.status in {"completed", "planned", "committed_pending"},
             "provider": self.provider,
             "namespace": self.namespace,
             "visibility": "public",
@@ -141,6 +144,9 @@ class ContextProviderSync:
             "requested_count": self.requested_count,
             "completed_count": self.completed_count,
             "write_count": self.write_count,
+            "pending_count": self.pending_count,
+            "reconciliation_performed": self.reconciliation_performed,
+            "retry_disposition": self.retry_disposition,
             "result_refs": [
                 opaque_provider_ref(
                     provider=self.provider,

--- a/loopx/capabilities/context_providers/openviking.py
+++ b/loopx/capabilities/context_providers/openviking.py
@@ -319,6 +319,113 @@ class OpenVikingContextProvider:
             requested_limit=requested_limit,
         )
 
+    def _reconcile_uncertain_sync_write(
+        self,
+        *,
+        target: str,
+        source_content: str,
+        timeout_seconds: float,
+    ) -> str:
+        """Classify an uncertain write without retrying it.
+
+        ``add-resource --wait`` can lose its transport after the server has
+        already materialized the target and queued semantic work.  Read back
+        the immutable target before deciding whether another write is safe.
+        """
+
+        try:
+            exact = self._run(
+                ["read", target, "-o", "json", "-c", "true"],
+                timeout_seconds=timeout_seconds,
+            )
+        except subprocess.TimeoutExpired:
+            return "reconciliation_unavailable"
+        if exact.returncode == 0:
+            try:
+                content = _read_content(_extract_json(exact.stdout))
+            except ValueError:
+                content = ""
+            if content and canonical_context_matches(content, source_content):
+                return "verified_success"
+            return "committed_pending"
+
+        try:
+            tree = self._run(
+                ["tree", target, "-L", "3", "-o", "json", "-c", "true"],
+                timeout_seconds=timeout_seconds,
+            )
+        except subprocess.TimeoutExpired:
+            return "reconciliation_unavailable"
+        if tree.returncode == 0:
+            try:
+                refs = [
+                    ref
+                    for row in _mapping_candidates(_extract_json(tree.stdout))
+                    if (ref := _resource_ref(row))
+                ]
+            except ValueError:
+                refs = []
+            if refs:
+                contents: list[str] = []
+                for ref in refs:
+                    try:
+                        read = self._run(
+                            ["read", ref, "-o", "json", "-c", "true"],
+                            timeout_seconds=timeout_seconds,
+                        )
+                    except subprocess.TimeoutExpired:
+                        continue
+                    if read.returncode != 0:
+                        continue
+                    try:
+                        content = _read_content(_extract_json(read.stdout))
+                    except ValueError:
+                        continue
+                    if content:
+                        contents.append(content)
+                source_lines = set(canonical_context_lines(source_content))
+                matched_source_lines = {
+                    line
+                    for content in contents
+                    for line in canonical_context_lines(content)
+                    if line in source_lines
+                }
+                coverage = len(matched_source_lines) / max(1, len(source_lines))
+                if (
+                    contents
+                    and all(
+                        canonical_context_matches(content, source_content)
+                        for content in contents
+                    )
+                    and coverage >= 0.8
+                ):
+                    return "verified_success"
+                return "committed_pending"
+
+        parent = target.rstrip("/").rsplit("/", 1)[0]
+        try:
+            listing = self._run(
+                ["ls", parent, "-n", "100", "-o", "json", "-c", "true"],
+                timeout_seconds=timeout_seconds,
+            )
+        except subprocess.TimeoutExpired:
+            return "reconciliation_unavailable"
+        if listing.returncode == 0:
+            try:
+                listed_refs = [
+                    ref
+                    for row in _mapping_candidates(_extract_json(listing.stdout))
+                    if (ref := _resource_ref(row))
+                ]
+            except ValueError:
+                return "reconciliation_unavailable"
+            if any(
+                ref == target or ref.startswith(target.rstrip("/") + "/")
+                for ref in listed_refs
+            ):
+                return "committed_pending"
+        return "absent_safe_to_retry"
+
     def sync(
         self,
         *,
@@ -358,6 +465,7 @@ class OpenVikingContextProvider:
                 write_count=0,
                 reason_code="execute_required_for_resource_write",
                 latency_ms=int((time.monotonic() - started) * 1000),
+                retry_disposition="execute_required",
             )
 
         version, blocker = self._preflight(timeout_seconds=timeout_seconds)
@@ -376,8 +484,11 @@ class OpenVikingContextProvider:
             )
 
         completed_refs: list[str] = []
+        pending_refs: list[str] = []
         write_count = 0
         sync_reason: str | None = None
+        reconciliation_performed = False
+        retry_disposition = "no_retry"
         for source, target in bounded:
             parent = target.rstrip("/").rsplit("/", 1)[0]
             try:
@@ -486,6 +597,8 @@ class OpenVikingContextProvider:
                 if mkdir_result.returncode != 0:
                     sync_reason = "provider_sync_parent_create_failed"
                     break
+            reserve = min(15.0, max(1.0, remaining * 0.2))
+            write_timeout = max(1.0, remaining - reserve)
             try:
                 result = self._run(
                     [
@@ -495,23 +608,54 @@ class OpenVikingContextProvider:
                         target,
                         "--wait",
                         "--timeout",
-                        str(max(1, int(remaining))),
+                        str(max(1, int(write_timeout))),
                         "-o",
                         "json",
                         "-c",
                         "true",
                     ],
-                    timeout_seconds=remaining,
+                    timeout_seconds=write_timeout,
                 )
             except subprocess.TimeoutExpired:
-                break
-            if result.returncode != 0:
-                sync_reason = "provider_sync_write_failed"
+                result = None
+            if result is None or result.returncode != 0:
+                reconciliation_performed = True
+                reconciliation = self._reconcile_uncertain_sync_write(
+                    target=target,
+                    source_content=source_content,
+                    timeout_seconds=reserve,
+                )
+                if reconciliation == "verified_success":
+                    completed_refs.append(target)
+                    write_count += 1
+                    continue
+                if reconciliation == "committed_pending":
+                    pending_refs.append(target)
+                    write_count += 1
+                    retry_disposition = "wait_and_reconcile"
+                    continue
+                if reconciliation == "absent_safe_to_retry":
+                    sync_reason = (
+                        "provider_sync_write_timeout_absent"
+                        if result is None
+                        else "provider_sync_write_failed_absent"
+                    )
+                    retry_disposition = "safe_to_retry"
+                else:
+                    sync_reason = "provider_sync_reconciliation_unavailable"
+                    retry_disposition = "manual_reconcile"
                 break
             completed_refs.append(target)
             write_count += 1
 
-        status = "completed" if len(completed_refs) == len(bounded) else "partial"
+        accounted_count = len(completed_refs) + len(pending_refs)
+        if len(completed_refs) == len(bounded):
+            status = "completed"
+        elif accounted_count == len(bounded) and pending_refs:
+            status = "committed_pending"
+            sync_reason = "provider_sync_committed_pending"
+        else:
+            status = "partial"
         return ContextProviderSync(
             provider=self.provider_id,
             namespace=namespace,
@@ -527,5 +671,8 @@ class OpenVikingContextProvider:
             ),
             provider_version=version,
             latency_ms=int((time.monotonic() - started) * 1000),
-            result_refs=tuple(completed_refs),
+            result_refs=tuple([*completed_refs, *pending_refs]),
+            pending_count=len(pending_refs),
+            reconciliation_performed=reconciliation_performed,
+            retry_disposition=retry_disposition,
         )


### PR DESCRIPTION
## Motivation

OpenViking `add-resource --wait` can return a transport error after the server has already accepted the resource and queued semantic processing. Treating every non-zero exit as a failed write makes a generic repository-context provider retry blindly and risks duplicate work.

This was reproduced by the OpenViking issue-fix pilot while indexing a public, revision-scoped repository snapshot.

## Implementation

- reserve a bounded reconciliation window for uncertain provider writes
- read back the exact target, then its tree/listing, before deciding whether a retry is safe
- distinguish `completed`, `committed_pending`, and `partial`
- expose public-safe `pending_count`, `reconciliation_performed`, and `retry_disposition`
- never copy raw provider payloads or source content into the public packet

## Validation

- `python3 examples/issue-fix-repository-memory-smoke.py`
- `python3 examples/issue-fix-validated-memory-writeback-smoke.py`
- `python3 examples/issue-fix-capability-guide-smoke.py`
- Python compile and diff hygiene checks
- `loopx canary premerge --from-git-diff --format markdown`
  - passed, 6 selected checks, 0 failures
  - public-boundary check passed
  - self-merge allowed
- real OpenViking call: a non-zero/timeout write was reconciled by exact-target read as completed; one write was recorded and no duplicate retry was issued

## Risk and limits

The change is confined to the provider adapter and additive public packet fields. A target that is visible but not yet fully readable is classified as `committed_pending` and must be polled instead of retried. This PR does not yet implement revision activation/supersession for repository snapshots; that remains a separate provider-neutral lifecycle successor.
