### PR TITLE
Activate repository context by checkout revision

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -679,12 +679,43 @@ Minimal local provider config (the revision must also appear in `scope_ref`):
 }
 ```
 
+For a long-running repository, use the provider-neutral `checkout_head`
+revision policy instead of rewriting the whole config after every pull:
+
+```json
+{
+  "schema_version": "issue_fix_repository_memory_provider_config_v0",
+  "enabled": true,
+  "provider": "openviking",
+  "namespace": "public-repository",
+  "visibility": "public",
+  "revision_policy": "checkout_head",
+  "repository_scope_root": "viking://resources/public-repository/owner-repo",
+  "active_repository_revision": "<last-activated-full-revision>",
+  "resource_references": ["src/module.py", "tests/test_module.py"]
+}
+```
+
+On the next issue-fix run after a pull, LoopX derives the current immutable
+scope from the checkout revision. It does not install a mutating git hook. If
+the checkout has advanced, retrieval returns `current_revision_not_activated`
+without searching the previous revision. `repository-memory-sync` indexes the
+new scope and returns a compact activation receipt; the caller projects the
+activated revision into the existing issue-fix domain state for the next run.
+Old scopes are kept
+for audit but excluded from patch guidance. A provider write that is visible
+but still processing remains `activation_pending`, so it is polled rather than
+activated or blindly retried. This is the missing lifecycle around VikingBot's
+explicit add/search/read tools; VikingBot itself does not watch local
+`git pull` events.
+
 Resource indexing is intentionally separate from retrieval. Use
 `loopx issue-fix repository-memory-sync` to preview a bounded set of
 repo-relative public files; add `--execute` only after the provider-resource
 write is authorized. Re-running the same immutable revision scope is
 idempotent when stored content still matches and stops on a conflict instead
-of replacing or auto-renaming it. Retrieval and resource sync use separate
+of replacing or auto-renaming it. Transport failure after a provider commit is
+reconciled by bounded target readback before any retry. Retrieval and resource sync use separate
 bounded timeouts because semantic indexing can legitimately take longer than
 read-only search.
 

--- a/docs/capabilities/issue-fix/README.zh-CN.md
+++ b/docs/capabilities/issue-fix/README.zh-CN.md
@@ -657,10 +657,37 @@ memory body、自动 transcript capture、私有 namespace、凭据和 provider 
 }
 ```
 
+长程运行的仓库可以使用通用的 `checkout_head` revision policy，不必每次 pull 后手工重写
+整份配置：
+
+```json
+{
+  "schema_version": "issue_fix_repository_memory_provider_config_v0",
+  "enabled": true,
+  "provider": "openviking",
+  "namespace": "public-repository",
+  "visibility": "public",
+  "revision_policy": "checkout_head",
+  "repository_scope_root": "viking://resources/public-repository/owner-repo",
+  "active_repository_revision": "<last-activated-full-revision>",
+  "resource_references": ["src/module.py", "tests/test_module.py"]
+}
+```
+
+仓库 pull 后的下一次 issue-fix 运行会根据当前 checkout revision 派生新的 immutable
+scope；LoopX 不安装会改写仓库的 git hook。发现 checkout 已前进时，
+retrieval 会返回 `current_revision_not_activated`，不会搜索旧 revision；
+`repository-memory-sync` 为新 scope 建索引并返回紧凑 activation receipt，调用方把已激活
+revision 投影回现有 issue-fix domain state 供下一轮使用。旧 scope 保留作审计，但禁止影响
+新 patch。Provider 已写入但仍在处理时保持 `activation_pending`，只继续确认，不提前激活
+也不盲目重试。这补上了 VikingBot 显式 add/search/read 工具外缺失的生命周期；VikingBot
+本身不会监听本地 `git pull`。
+
 Resource indexing 与 retrieval 刻意分离。先用
 `loopx issue-fix repository-memory-sync` 预览有限数量的 repo-relative 公开文件；只有
 provider resource write 已获授权时才加 `--execute`。同一个 immutable revision scope
-重复执行时，内容一致会幂等通过；出现冲突则停止，不会覆盖或自动改名。只读 retrieval
+重复执行时，内容一致会幂等通过；出现冲突则停止，不会覆盖或自动改名。Provider 提交后
+发生 transport failure 时，会先有界读回目标再决定是否重试。只读 retrieval
 与 resource sync 使用独立且有上限的 timeout，因为语义索引通常比 search/read 更慢。
 
 Validated-outcome writeback 是另一条默认关闭的 hook。只有调用方显式增加

--- a/examples/issue-fix-repository-memory-smoke.py
+++ b/examples/issue-fix-repository-memory-smoke.py
@@ -24,6 +24,7 @@ from loopx.capabilities.issue_fix.repository_context import (  # noqa: E402
 )
 from loopx.capabilities.issue_fix.repository_memory_provider import (  # noqa: E402
     retrieve_issue_fix_repository_memory,
+    sync_issue_fix_repository_memory,
 )
 from loopx.capabilities.context_providers.base import (  # noqa: E402
     ContextProviderItem,
@@ -35,6 +36,7 @@ from loopx.capabilities.context_providers.openviking import (  # noqa: E402
 )
 
 REVISION = "9cf42405a8bb0a8a17a66d4f953515f5a2c82620"
+PREVIOUS_REVISION = "3aa42405a8bb0a8a17a66d4f953515f5a2c82111"
 ISSUE_URL = "https://github.com/volcengine/OpenViking/issues/3124"
 
 
@@ -67,6 +69,41 @@ class ContractProvider:
 
     def sync(self, **kwargs: Any) -> Any:  # pragma: no cover - retrieval contract only.
         raise AssertionError(kwargs)
+
+
+class LifecycleProvider(ContractProvider):
+    def __init__(
+        self,
+        *,
+        resource_ref: str,
+        content: str,
+        sync_status: str = "completed",
+    ) -> None:
+        super().__init__(resource_ref=resource_ref, content=content)
+        self.sync_status = sync_status
+        self.retrieve_count = 0
+        self.sync_count = 0
+
+    def retrieve(self, **kwargs: Any) -> ContextProviderRetrieval:
+        self.retrieve_count += 1
+        return super().retrieve(**kwargs)
+
+    def sync(self, **kwargs: Any) -> ContextProviderSync:
+        self.sync_count += 1
+        resources = list(kwargs["resources"])
+        return ContextProviderSync(
+            provider="contract_provider",
+            namespace=str(kwargs["namespace"]),
+            status=self.sync_status,
+            observed_at=str(kwargs["observed_at"]),
+            requested_count=len(resources),
+            completed_count=len(resources) if self.sync_status == "completed" else 0,
+            write_count=len(resources) if kwargs["execute"] else 0,
+            result_refs=tuple(target for _source, target in resources),
+            pending_count=(
+                len(resources) if self.sync_status == "committed_pending" else 0
+            ),
+        )
 
 
 class OpenVikingContractRunner:
@@ -503,6 +540,113 @@ def main() -> int:
             "verification_mode": "canonical_text_or_parser_chunk",
         }
         assert_boundary(provider_result)
+
+        lifecycle_root = "viking://resources/public-repository/example-repo"
+        lifecycle_scope = f"{lifecycle_root}/{REVISION[:12]}/repository-context"
+        lifecycle_provider = LifecycleProvider(
+            resource_ref=f"{lifecycle_scope}/src/worker.py",
+            content=source.read_text(encoding="utf-8"),
+        )
+        lifecycle_config = {
+            "schema_version": "issue_fix_repository_memory_provider_config_v0",
+            "enabled": True,
+            "provider": "contract_provider",
+            "namespace": "public-repository",
+            "visibility": "public",
+            "revision_policy": "checkout_head",
+            "repository_scope_root": lifecycle_root,
+            "active_repository_revision": PREVIOUS_REVISION,
+            "resource_references": ["src/worker.py"],
+            "max_results": 3,
+            "timeout_seconds": 5,
+            "sync_timeout_seconds": 5,
+        }
+        stale_retrieval = retrieve_issue_fix_repository_memory(
+            config=lifecycle_config,
+            repo_path=checkout,
+            repository_revision=REVISION,
+            query="current worker contract validation",
+            query_summary="Current worker contract evidence.",
+            supports=["change_scope", "validation"],
+            observed_at="2026-07-11T03:30:00+08:00",
+            provider=lifecycle_provider,
+        )
+        assert stale_retrieval["memory_input"]["status"] == "unavailable"
+        assert (
+            stale_retrieval["memory_input"]["reason_code"]
+            == "current_revision_not_activated"
+        )
+        lifecycle_plan = stale_retrieval["provider_projection"][
+            "repository_context_lifecycle"
+        ]
+        assert lifecycle_plan["revision_changed"] is True, lifecycle_plan
+        assert lifecycle_plan["sync_required"] is True, lifecycle_plan
+        assert lifecycle_plan["retrieval_allowed"] is False, lifecycle_plan
+        assert lifecycle_provider.retrieve_count == 0
+        assert_boundary(stale_retrieval)
+
+        lifecycle_sync = sync_issue_fix_repository_memory(
+            config=lifecycle_config,
+            repo_path=checkout,
+            repository_revision=REVISION,
+            references=["src/worker.py"],
+            observed_at="2026-07-11T03:31:00+08:00",
+            execute=True,
+            provider=lifecycle_provider,
+        )
+        activation = lifecycle_sync["repository_context_activation"]
+        assert activation["status"] == "activated", activation
+        assert activation["active_repository_revision"] == REVISION, activation
+        assert activation["previous_repository_revision"] == PREVIOUS_REVISION
+        assert activation["retrieval_allowed"] is True, activation
+        assert lifecycle_provider.sync_count == 1
+        assert_boundary(lifecycle_sync)
+
+        pending_provider = LifecycleProvider(
+            resource_ref=f"{lifecycle_scope}/src/worker.py",
+            content=source.read_text(encoding="utf-8"),
+            sync_status="committed_pending",
+        )
+        pending_sync = sync_issue_fix_repository_memory(
+            config=lifecycle_config,
+            repo_path=checkout,
+            repository_revision=REVISION,
+            references=["src/worker.py"],
+            observed_at="2026-07-11T03:31:30+08:00",
+            execute=True,
+            provider=pending_provider,
+        )
+        pending_activation = pending_sync["repository_context_activation"]
+        assert pending_activation["status"] == "activation_pending"
+        assert pending_activation["active_repository_revision"] is None
+        assert pending_activation["retrieval_allowed"] is False
+        assert_boundary(pending_sync)
+
+        activated_config = {
+            **lifecycle_config,
+            "active_repository_revision": REVISION,
+        }
+        activated_retrieval = retrieve_issue_fix_repository_memory(
+            config=activated_config,
+            repo_path=checkout,
+            repository_revision=REVISION,
+            query="current worker contract validation",
+            query_summary="Current worker contract evidence.",
+            supports=["change_scope", "validation"],
+            observed_at="2026-07-11T03:32:00+08:00",
+            provider=lifecycle_provider,
+        )
+        active_plan = activated_retrieval["provider_projection"][
+            "repository_context_lifecycle"
+        ]
+        assert active_plan["sync_required"] is False, active_plan
+        assert active_plan["retrieval_allowed"] is True, active_plan
+        assert lifecycle_provider.retrieve_count == 1
+        assert (
+            activated_retrieval["memory_input"]["results"][0]["verification_status"]
+            == "confirmed"
+        )
+        assert_boundary(activated_retrieval)
 
     invalid_capture = dict(memory_input)
     invalid_capture["automatic_capture_performed"] = True

--- a/examples/issue-fix-repository-memory-smoke.py
+++ b/examples/issue-fix-repository-memory-smoke.py
@@ -583,6 +583,7 @@ def main() -> int:
         assert lifecycle_plan["sync_required"] is True, lifecycle_plan
         assert lifecycle_plan["retrieval_allowed"] is False, lifecycle_plan
         assert lifecycle_provider.retrieve_count == 0
+        assert lifecycle_root not in json.dumps(stale_retrieval)
         assert_boundary(stale_retrieval)
 
         lifecycle_sync = sync_issue_fix_repository_memory(
@@ -600,6 +601,7 @@ def main() -> int:
         assert activation["previous_repository_revision"] == PREVIOUS_REVISION
         assert activation["retrieval_allowed"] is True, activation
         assert lifecycle_provider.sync_count == 1
+        assert lifecycle_root not in json.dumps(lifecycle_sync)
         assert_boundary(lifecycle_sync)
 
         pending_provider = LifecycleProvider(

--- a/loopx/capabilities/context_providers/__init__.py
+++ b/loopx/capabilities/context_providers/__init__.py
@@ -10,12 +10,20 @@ from .base import (
 )
 from .openviking import OpenVikingContextProvider
 from .factory import build_context_provider
+from .repository_lifecycle import (
+    RepositoryContextActivation,
+    RepositoryContextRevisionPlan,
+    activate_repository_context_revision,
+)
 
 __all__ = [
     "ContextProviderItem",
     "ContextProviderRetrieval",
     "ContextProviderSync",
     "OpenVikingContextProvider",
+    "RepositoryContextActivation",
+    "RepositoryContextRevisionPlan",
+    "activate_repository_context_revision",
     "build_context_provider",
     "canonical_context_text",
     "canonical_context_lines",

--- a/loopx/capabilities/context_providers/repository_lifecycle.py
+++ b/loopx/capabilities/context_providers/repository_lifecycle.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .base import ContextProviderSync, opaque_provider_ref
+
+
+REPOSITORY_CONTEXT_REVISION_PLAN_SCHEMA_VERSION = "repository_context_revision_plan_v0"
+REPOSITORY_CONTEXT_ACTIVATION_SCHEMA_VERSION = "repository_context_activation_v0"
+
+
+@dataclass(frozen=True)
+class RepositoryContextRevisionPlan:
+    """Provider-neutral plan for one checkout's repository context.
+
+    Provider resource identifiers remain internal. Public projections expose
+    only opaque references, revisions, and the activation decision.
+    """
+
+    provider: str
+    namespace: str
+    revision_policy: str
+    repository_revision: str
+    current_scope_ref: str
+    active_repository_revision: str | None = None
+    active_scope_ref: str | None = None
+
+    @property
+    def revision_changed(self) -> bool:
+        return bool(
+            self.active_repository_revision
+            and self.active_repository_revision != self.repository_revision
+        )
+
+    @property
+    def sync_required(self) -> bool:
+        return self.revision_policy == "checkout_head" and (
+            self.active_repository_revision != self.repository_revision
+            or self.active_scope_ref != self.current_scope_ref
+        )
+
+    @property
+    def retrieval_scope_ref(self) -> str | None:
+        if self.revision_policy == "pinned" or not self.sync_required:
+            return self.current_scope_ref
+        return None
+
+    def public_packet(self) -> dict[str, object]:
+        return {
+            "schema_version": REPOSITORY_CONTEXT_REVISION_PLAN_SCHEMA_VERSION,
+            "ok": True,
+            "provider": self.provider,
+            "namespace": self.namespace,
+            "visibility": "public",
+            "revision_policy": self.revision_policy,
+            "repository_revision": self.repository_revision,
+            "active_repository_revision": self.active_repository_revision,
+            "revision_changed": self.revision_changed,
+            "sync_required": self.sync_required,
+            "retrieval_allowed": self.retrieval_scope_ref is not None,
+            "current_scope_ref": opaque_provider_ref(
+                provider=self.provider,
+                namespace=self.namespace,
+                resource_ref=self.current_scope_ref,
+            ),
+            "active_scope_ref": (
+                opaque_provider_ref(
+                    provider=self.provider,
+                    namespace=self.namespace,
+                    resource_ref=self.active_scope_ref,
+                )
+                if self.active_scope_ref
+                else None
+            ),
+            "stale_revision_policy": "preserve_for_audit_exclude_from_retrieval",
+            "raw_provider_refs_captured": False,
+        }
+
+
+@dataclass(frozen=True)
+class RepositoryContextActivation:
+    provider: str
+    namespace: str
+    repository_revision: str
+    status: str
+    active_repository_revision: str | None
+    active_scope_ref: str | None
+    previous_repository_revision: str | None
+    previous_scope_ref: str | None
+    reason_code: str | None = None
+
+    @property
+    def retrieval_scope_ref(self) -> str | None:
+        if (
+            self.status == "activated"
+            and self.active_repository_revision == self.repository_revision
+        ):
+            return self.active_scope_ref
+        return None
+
+    def public_packet(self) -> dict[str, object]:
+        return {
+            "schema_version": REPOSITORY_CONTEXT_ACTIVATION_SCHEMA_VERSION,
+            "ok": self.status in {"activated", "planned"},
+            "provider": self.provider,
+            "namespace": self.namespace,
+            "visibility": "public",
+            "status": self.status,
+            "reason_code": self.reason_code,
+            "repository_revision": self.repository_revision,
+            "active_repository_revision": self.active_repository_revision,
+            "previous_repository_revision": self.previous_repository_revision,
+            "retrieval_allowed": self.retrieval_scope_ref is not None,
+            "active_scope_ref": (
+                opaque_provider_ref(
+                    provider=self.provider,
+                    namespace=self.namespace,
+                    resource_ref=self.active_scope_ref,
+                )
+                if self.active_scope_ref
+                else None
+            ),
+            "previous_scope_ref": (
+                opaque_provider_ref(
+                    provider=self.provider,
+                    namespace=self.namespace,
+                    resource_ref=self.previous_scope_ref,
+                )
+                if self.previous_scope_ref
+                else None
+            ),
+            "stale_revision_policy": "preserve_for_audit_exclude_from_retrieval",
+            "raw_provider_refs_captured": False,
+        }
+
+
+def activate_repository_context_revision(
+    plan: RepositoryContextRevisionPlan,
+    sync: ContextProviderSync,
+) -> RepositoryContextActivation:
+    """Activate only a fully verified current-revision sync.
+
+    A committed-but-pending provider mutation is not yet safe for retrieval.
+    The previous revision remains auditable but is never returned as a patch
+    guidance fallback for the new checkout.
+    """
+
+    if sync.provider != plan.provider or sync.namespace != plan.namespace:
+        raise ValueError("repository context sync does not match the revision plan")
+    if (
+        sync.status == "completed"
+        and sync.requested_count > 0
+        and sync.completed_count == sync.requested_count
+    ):
+        status = "activated"
+        reason_code = None
+        active_revision = plan.repository_revision
+        active_scope = plan.current_scope_ref
+    elif sync.status == "planned":
+        status = "planned"
+        reason_code = "execute_required_for_revision_activation"
+        active_revision = None
+        active_scope = None
+    elif sync.status == "committed_pending":
+        status = "activation_pending"
+        reason_code = "current_revision_index_pending"
+        active_revision = None
+        active_scope = None
+    else:
+        status = "activation_blocked"
+        reason_code = sync.reason_code or "current_revision_sync_incomplete"
+        active_revision = None
+        active_scope = None
+    return RepositoryContextActivation(
+        provider=plan.provider,
+        namespace=plan.namespace,
+        repository_revision=plan.repository_revision,
+        status=status,
+        active_repository_revision=active_revision,
+        active_scope_ref=active_scope,
+        previous_repository_revision=plan.active_repository_revision,
+        previous_scope_ref=plan.active_scope_ref,
+        reason_code=reason_code,
+    )

--- a/loopx/capabilities/issue_fix/repository_memory_provider.py
+++ b/loopx/capabilities/issue_fix/repository_memory_provider.py
@@ -11,7 +11,12 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 from urllib.parse import unquote
 
-from ..context_providers import build_context_provider, canonical_context_matches
+from ..context_providers import (
+    RepositoryContextRevisionPlan,
+    activate_repository_context_revision,
+    build_context_provider,
+    canonical_context_matches,
+)
 from ..context_providers.base import ContextProvider, opaque_provider_ref
 from ...control_plane.runtime.public_safety import public_safe_compact_text
 from .repository_memory import (
@@ -38,7 +43,11 @@ _CONFIG_FIELDS = {
     "namespace",
     "visibility",
     "scope_ref",
+    "revision_policy",
+    "repository_scope_root",
     "repository_revision",
+    "active_repository_revision",
+    "active_scope_ref",
     "max_results",
     "timeout_seconds",
     "sync_timeout_seconds",
@@ -156,22 +165,73 @@ def _normalise_config(
     namespace = _label(config.get("namespace"), field="namespace")
     if config.get("visibility") != "public":
         raise ValueError("repository memory provider visibility must be public")
-    configured_revision = _compact(
-        config.get("repository_revision"),
-        field="repository_revision",
-        limit=120,
-    )
-    if not re.fullmatch(r"[0-9a-fA-F]{12,64}", configured_revision):
-        raise ValueError("repository memory provider revision must be a git object id")
-    if configured_revision != repository_revision:
-        raise ValueError(
-            "repository memory provider revision must match current checkout"
+    if not re.fullmatch(r"[0-9a-fA-F]{12,64}", repository_revision):
+        raise ValueError("current repository revision must be a git object id")
+    revision_policy = str(config.get("revision_policy") or "pinned").strip()
+    if revision_policy not in {"pinned", "checkout_head"}:
+        raise ValueError("revision_policy must be pinned or checkout_head")
+    configured_revision = str(config.get("repository_revision") or "").strip()
+    if revision_policy == "pinned":
+        configured_revision = _compact(
+            configured_revision,
+            field="repository_revision",
+            limit=120,
         )
-    scope_ref = _compact(config.get("scope_ref"), field="scope_ref", limit=500)
+        if not re.fullmatch(r"[0-9a-fA-F]{12,64}", configured_revision):
+            raise ValueError(
+                "repository memory provider revision must be a git object id"
+            )
+        if configured_revision != repository_revision:
+            raise ValueError(
+                "repository memory provider revision must match current checkout"
+            )
+        scope_ref = _compact(
+            config.get("scope_ref"), field="scope_ref", limit=500
+        ).rstrip("/")
+        repository_scope_root = ""
+    else:
+        if configured_revision and configured_revision != repository_revision:
+            raise ValueError(
+                "checkout_head repository_revision, when supplied, must match current checkout"
+            )
+        configured_revision = repository_revision
+        repository_scope_root = _compact(
+            config.get("repository_scope_root"),
+            field="repository_scope_root",
+            limit=500,
+        ).rstrip("/")
+        if not repository_scope_root.startswith("viking://resources/"):
+            raise ValueError(
+                "checkout_head repository_scope_root must use viking://resources/"
+            )
+        scope_ref = (
+            f"{repository_scope_root}/{repository_revision[:12]}/repository-context"
+        )
     if not scope_ref.startswith("viking://"):
         raise ValueError("repository memory provider scope_ref must use viking://")
     if repository_revision[:12] not in scope_ref:
         raise ValueError("repository memory provider scope_ref must be revision-scoped")
+    active_repository_revision = str(
+        config.get("active_repository_revision") or ""
+    ).strip()
+    if active_repository_revision and not re.fullmatch(
+        r"[0-9a-fA-F]{12,64}", active_repository_revision
+    ):
+        raise ValueError("active_repository_revision must be a git object id")
+    active_scope_ref = str(config.get("active_scope_ref") or "").strip().rstrip("/")
+    if active_scope_ref and not active_scope_ref.startswith("viking://"):
+        raise ValueError("active_scope_ref must use viking://")
+    if revision_policy == "checkout_head" and active_repository_revision:
+        if not active_scope_ref:
+            active_scope_ref = (
+                f"{repository_scope_root}/{active_repository_revision[:12]}/"
+                "repository-context"
+            )
+        if active_repository_revision[:12] not in active_scope_ref:
+            raise ValueError("active_scope_ref must match active_repository_revision")
+    elif revision_policy == "pinned":
+        active_repository_revision = repository_revision
+        active_scope_ref = scope_ref
     max_results = min(
         max(1, int(config.get("max_results") or 3)),
         MAX_MEMORY_RESULTS,
@@ -227,8 +287,12 @@ def _normalise_config(
         **dict(config),
         "provider": provider,
         "namespace": namespace,
-        "scope_ref": scope_ref.rstrip("/"),
+        "scope_ref": scope_ref,
+        "revision_policy": revision_policy,
+        "repository_scope_root": repository_scope_root,
         "repository_revision": configured_revision,
+        "active_repository_revision": active_repository_revision,
+        "active_scope_ref": active_scope_ref,
         "max_results": max_results,
         "timeout_seconds": timeout_seconds,
         "sync_timeout_seconds": sync_timeout_seconds,
@@ -239,6 +303,28 @@ def _normalise_config(
         "workspace_scope": workspace_scope,
         "peer_scope": peer_scope,
     }
+
+
+def _repository_context_revision_plan(
+    normalised: Mapping[str, Any],
+) -> RepositoryContextRevisionPlan:
+    return RepositoryContextRevisionPlan(
+        provider=str(normalised["provider"]),
+        namespace=str(normalised["namespace"]),
+        revision_policy=str(normalised["revision_policy"]),
+        repository_revision=str(normalised["repository_revision"]),
+        current_scope_ref=str(normalised["scope_ref"]),
+        active_repository_revision=(
+            str(normalised["active_repository_revision"])
+            if normalised.get("active_repository_revision")
+            else None
+        ),
+        active_scope_ref=(
+            str(normalised["active_scope_ref"])
+            if normalised.get("active_scope_ref")
+            else None
+        ),
+    )
 
 
 def _validated_outcome_fact(
@@ -664,6 +750,7 @@ def retrieve_issue_fix_repository_memory(
         raise ValueError(f"supports must use {sorted(SUPPORT_ASPECTS)}")
     provider_id = str(normalised["provider"])
     namespace = str(normalised["namespace"])
+    revision_plan = _repository_context_revision_plan(normalised)
     if not normalised["enabled"]:
         memory_input = _disabled_memory_input(
             provider=provider_id,
@@ -680,6 +767,26 @@ def retrieve_issue_fix_repository_memory(
             },
         }
 
+    if revision_plan.sync_required:
+        memory_input = _unavailable_memory_input(
+            provider=provider_id,
+            namespace=namespace,
+            query_summary=query_summary,
+            observed_at=observed_at,
+            search_performed=False,
+            read_performed=False,
+            reason_code="current_revision_not_activated",
+        )
+        return {
+            "memory_input": memory_input,
+            "provider_projection": {
+                "status": "sync_required",
+                "fail_open": True,
+                "result_count": 0,
+                "repository_context_lifecycle": revision_plan.public_packet(),
+            },
+        }
+
     provider = provider or build_context_provider(normalised)
     retrieval = provider.retrieve(
         namespace=namespace,
@@ -691,6 +798,7 @@ def retrieve_issue_fix_repository_memory(
         observed_at=observed_at,
     )
     provider_projection = retrieval.public_packet()
+    provider_projection["repository_context_lifecycle"] = revision_plan.public_packet()
     if retrieval.status != "completed":
         memory_input = _unavailable_memory_input(
             provider=provider_id,
@@ -802,6 +910,7 @@ def sync_issue_fix_repository_memory(
     """Bound an explicit provider resource refresh to one revision checkout."""
 
     normalised = _normalise_config(config, repository_revision=repository_revision)
+    revision_plan = _repository_context_revision_plan(normalised)
     if not normalised["enabled"]:
         return {
             "schema_version": "issue_fix_repository_memory_sync_v0",
@@ -813,6 +922,7 @@ def sync_issue_fix_repository_memory(
             "requested_reference_count": 0,
             "external_writes_performed": False,
             "fail_open": True,
+            "repository_context_lifecycle": revision_plan.public_packet(),
         }
     scope_ref = str(normalised["scope_ref"])
     if not scope_ref.startswith("viking://resources/"):
@@ -855,6 +965,7 @@ def sync_issue_fix_repository_memory(
         observed_at=observed_at,
         execute=execute,
     )
+    activation = activate_repository_context_revision(revision_plan, sync)
     packet = sync.public_packet()
     packet.update(
         {
@@ -864,6 +975,8 @@ def sync_issue_fix_repository_memory(
             "revision_scoped": True,
             "automatic_capture_performed": False,
             "memory_writeback_performed": False,
+            "repository_context_lifecycle": revision_plan.public_packet(),
+            "repository_context_activation": activation.public_packet(),
         }
     )
     return packet


### PR DESCRIPTION
## Motivation

OpenViking resources do not automatically follow a local repository `git pull`, and VikingBot provides explicit add/search/read tools rather than a revision lifecycle. A long-running issue-fix agent therefore needs a lower-level contract that prevents an old repository index from guiding a patch against a newer checkout.

## Implementation

- add a provider-neutral repository revision plan and activation receipt
- support a stable `checkout_head` provider config that derives an immutable scope from the current revision
- block retrieval with `current_revision_not_activated` when the checkout and active index differ
- activate only a fully verified current-revision sync
- keep `committed_pending` writes pending instead of activating or retrying them
- preserve old scopes for audit while excluding them from current patch guidance
- call the generic lifecycle from issue-fix repository-memory sync/retrieval
- document the behavior in English and Chinese, including the deliberate absence of a mutating git hook

## VikingBot / OpenViking reuse

The design reuses OpenViking's resource parser and L0/L1/L2 search/read surface through the existing provider adapter. It does not copy VikingBot's experimental mount or pretend VikingBot watches local pulls. OpenViking remote watch can still serve remote URL refresh cases, but immutable revision activation remains a LoopX responsibility.

## Validation

- repository-memory, validated-writeback, and capability-guide smokes passed
- Ruff check, Python compile, and diff hygiene passed
- final `loopx canary premerge --from-git-diff` passed: 17 selected checks, 0 failures, public boundary clean, self-merge allowed
- real OpenViking 0.4.9.dev40 call at revision `5bfa9b617ecf...`:
  - previous revision was detected as stale
  - two already-indexed current-revision resources were verified without a rewrite
  - activation moved to the current revision
  - a subsequent workflow-plan search/read returned current-revision source/test evidence

## Risk and limits

This adds optional config fields; pinned configs retain their existing behavior. Activation state is returned as a compact receipt and must be projected by the caller into the existing issue-fix domain state. This PR does not install a filesystem watcher or git hook, and it does not delete old provider resources.
