### PR TITLE
Add read-only trajectory hygiene audit

### DIFF
--- a/docs/reference/protocols/trajectory-hygiene-v0.md
+++ b/docs/reference/protocols/trajectory-hygiene-v0.md
@@ -1,0 +1,36 @@
+# Trajectory Hygiene v0
+
+LoopX keeps control-plane history for audit and continuation. That history is
+not automatically suitable for model training: quota accounting, scheduler
+acknowledgements, unchanged monitor polls, and repeated state projections can
+outnumber task-facing actions in a long session.
+
+`trajectory_hygiene_summary_v0` is a read-only audit over the existing compact
+run index:
+
+```bash
+loopx history trajectory-hygiene --goal-id <goal-id> --limit 100
+```
+
+It reports controller-event density, compact controller-character density,
+non-material event density, repeated task-action labels, and action/outcome
+attribution coverage. These are proxies for deciding whether the current event
+mix needs a separate learning projection. They are not training-quality scores.
+
+## Boundary
+
+The audit:
+
+- reads only the public-safe compact run index;
+- does not open run artifacts, raw sessions, raw trajectories, task bodies, or
+  verifier output;
+- does not change history, status, quota, todo, scheduler, or state semantics;
+- always reports `seed_model_training_eligible=false`.
+
+A future learning projection should keep model-visible task context, assistant
+actions, tool observations, human decisions, and attributed outcomes. Controller
+events should remain in the audit ledger and link to learning turns by stable
+ids instead of being replayed as ordinary user/model turns.
+
+The raw audit trail remains useful for reproduction and incident analysis. It
+must not be silently rewritten into a training sample.

--- a/loopx/cli_commands/history.py
+++ b/loopx/cli_commands/history.py
@@ -11,6 +11,7 @@ from ..benchmark_adapters.agents_last_exam import (
 )
 from ..control_plane.work_items.delivery_batch_scale import DELIVERY_BATCH_SCALE_CHOICES
 from ..control_plane.work_items.delivery_outcome import DELIVERY_OUTCOME_CHOICES
+from ..control_plane.runtime.trajectory_hygiene import build_trajectory_hygiene_summary
 from ..global_registry import sync_project_registry_to_global
 from ..history import (
     append_active_user_assisted_pilot,
@@ -34,6 +35,9 @@ from ..history import (
     render_index_duplicate_repair_markdown,
 )
 from ..paths import resolve_runtime_root
+from ..presentation.renderers.trajectory_hygiene_markdown import (
+    render_trajectory_hygiene_markdown,
+)
 from ..status import (
     compact_active_user_assisted_pilot,
     compact_benchmark_comparison,
@@ -69,12 +73,13 @@ def register_history_command(subparsers: argparse._SubParsersAction) -> None:
             "append-active-user-assisted-pilot",
             "inspect-index-duplicates",
             "repair-index-duplicates",
+            "trajectory-hygiene",
         ],
         help=(
             "Append a compact benchmark_run_v0, benchmark_result_v0, benchmark_comparison_v0, "
             "benchmark_learning_ledger_v0, benchmark_experiment_report_v0, ALE compact result report, or "
             "active_user_assisted_pilot_v0 event; inspect duplicate run-index identities; "
-            "or repair safe duplicate index rows."
+            "repair safe duplicate index rows; or audit compact-history trajectory hygiene."
         ),
     )
     history_parser.add_argument("--goal-id", help="Only show one goal.")
@@ -157,6 +162,32 @@ def handle_history_command(
     append_benchmark_run_rollout_event: BenchmarkRolloutEventAppender,
     append_benchmark_result_rollout_event: BenchmarkRolloutEventAppender,
 ) -> int:
+    if args.history_action == "trajectory-hygiene":
+        try:
+            if not args.goal_id:
+                raise ValueError("history trajectory-hygiene requires --goal-id")
+            registry = load_registry(registry_path)
+            runtime_root = resolve_runtime_root(registry, runtime_root_arg)
+            history = collect_history(
+                registry_path=registry_path,
+                runtime_root=runtime_root,
+                goal_id=args.goal_id,
+                limit=max(0, args.limit),
+            )
+            payload = build_trajectory_hygiene_summary(history)
+            payload["registry"] = str(registry_path)
+            payload["runtime_root"] = str(runtime_root)
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "registry": str(registry_path),
+                "runtime_root": runtime_root_arg,
+                "goal_filter": args.goal_id,
+                "error": str(exc),
+            }
+        print_payload(payload, args.format, render_trajectory_hygiene_markdown)
+        return 0 if payload.get("ok") else 1
+
     if args.history_action == "inspect-index-duplicates":
         try:
             payload = inspect_index_duplicates(

--- a/loopx/control_plane/runtime/trajectory_hygiene.py
+++ b/loopx/control_plane/runtime/trajectory_hygiene.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+from collections.abc import Mapping
+from typing import Any
+
+
+TRAJECTORY_HYGIENE_SCHEMA_VERSION = "trajectory_hygiene_summary_v0"
+CONTROLLER_CLASSIFICATION_PREFIXES = ("quota_",)
+CONTROLLER_CLASSIFICATIONS = {
+    "state_refreshed",
+}
+MATERIAL_DELIVERY_OUTCOMES = {
+    "outcome_gap",
+    "outcome_progress",
+    "primary_goal_outcome",
+}
+
+
+def _ratio(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return round(numerator / denominator, 4)
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value or "").strip().lower() in {"1", "true", "yes"}
+
+
+def _compact_chars(run: Mapping[str, Any]) -> int:
+    return len(json.dumps(dict(run), ensure_ascii=False, sort_keys=True, separators=(",", ":")))
+
+
+def compact_history_event_channel(run: Mapping[str, Any]) -> str:
+    """Classify one public-safe compact history row without reading run artifacts."""
+
+    if isinstance(run.get("human_reward"), Mapping) or isinstance(run.get("operator_gate"), Mapping):
+        return "human_decision"
+
+    classification = str(run.get("classification") or "").strip().lower()
+    if classification in CONTROLLER_CLASSIFICATIONS or classification.startswith(
+        CONTROLLER_CLASSIFICATION_PREFIXES
+    ):
+        return "controller"
+
+    if str(run.get("delivery_outcome") or "").strip() in MATERIAL_DELIVERY_OUTCOMES:
+        return "outcome"
+    return "task_event"
+
+
+def _material_transition(run: Mapping[str, Any], channel: str) -> bool:
+    if _truthy(run.get("material_change")):
+        return True
+    if channel == "human_decision":
+        return True
+    return str(run.get("delivery_outcome") or "").strip() in MATERIAL_DELIVERY_OUTCOMES
+
+
+def build_trajectory_hygiene_summary(history: Mapping[str, Any]) -> dict[str, Any]:
+    """Build training-hygiene proxies from compact history metadata only.
+
+    The summary intentionally does not claim that compact run history is a model
+    training trajectory. It measures controller density and attribution gaps so
+    maintainers can decide whether a separate learning projection is warranted.
+    """
+
+    runs = [run for run in history.get("runs") or [] if isinstance(run, Mapping)]
+    channel_counts: Counter[str] = Counter()
+    classification_counts: Counter[str] = Counter()
+    controller_chars = 0
+    total_chars = 0
+    non_material_count = 0
+    learning_candidate_count = 0
+    learning_action_count = 0
+    learning_outcome_count = 0
+    decision_anchor_count = 0
+    learning_actions: list[str] = []
+
+    for run in runs:
+        channel = compact_history_event_channel(run)
+        channel_counts[channel] += 1
+        classification = str(run.get("classification") or "unknown").strip() or "unknown"
+        classification_counts[classification] += 1
+
+        char_count = _compact_chars(run)
+        total_chars += char_count
+        if channel == "controller":
+            controller_chars += char_count
+        if not _material_transition(run, channel):
+            non_material_count += 1
+
+        if channel == "controller":
+            continue
+
+        learning_candidate_count += 1
+        action = " ".join(str(run.get("recommended_action") or "").split())
+        outcome = str(run.get("delivery_outcome") or "").strip()
+        if action:
+            learning_action_count += 1
+            learning_actions.append(action)
+        if outcome:
+            learning_outcome_count += 1
+        if action and outcome:
+            decision_anchor_count += 1
+
+    action_counts = Counter(learning_actions)
+    duplicate_action_count = sum(max(0, count - 1) for count in action_counts.values())
+    total_count = len(runs)
+    controller_count = channel_counts["controller"]
+
+    return {
+        "ok": True,
+        "schema_version": TRAJECTORY_HYGIENE_SCHEMA_VERSION,
+        "goal_filter": history.get("goal_filter"),
+        "sample": {
+            "compact_history_row_count": total_count,
+            "goal_count": history.get("goal_count"),
+            "source": "public_safe_compact_run_index",
+        },
+        "channel_counts": dict(sorted(channel_counts.items())),
+        "classification_counts": dict(classification_counts.most_common()),
+        "metrics": {
+            "controller_event_ratio": _ratio(controller_count, total_count),
+            "compact_controller_char_ratio": _ratio(controller_chars, total_chars),
+            "non_material_event_ratio": _ratio(non_material_count, total_count),
+            "learning_candidate_count": learning_candidate_count,
+            "learning_action_coverage": _ratio(learning_action_count, learning_candidate_count),
+            "learning_outcome_coverage": _ratio(learning_outcome_count, learning_candidate_count),
+            "decision_anchor_coverage": _ratio(decision_anchor_count, learning_candidate_count),
+            "duplicate_learning_action_ratio": _ratio(
+                duplicate_action_count,
+                learning_action_count,
+            ),
+        },
+        "training_boundary": {
+            "raw_session_read": False,
+            "raw_trajectory_read": False,
+            "run_artifact_read": False,
+            "compact_index_only": True,
+            "seed_model_training_eligible": False,
+            "reason": (
+                "compact history is an audit baseline, not a learning trajectory; "
+                "export model-visible task turns separately and link controller events by stable ids"
+            ),
+        },
+    }

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -73,6 +73,10 @@ COMMAND_GROUPS: list[dict[str, object]] = [
             },
             {"command": "loopx quota should-run", "purpose": "Decide whether the next agent turn should run."},
             {"command": "loopx history --goal-id <goal-id>", "purpose": "Read compact run history."},
+            {
+                "command": "loopx history trajectory-hygiene --goal-id <goal-id> --limit 100",
+                "purpose": "Measure controller density and attribution gaps from compact history without reading raw sessions.",
+            },
         ],
     },
     {

--- a/loopx/presentation/renderers/trajectory_hygiene_markdown.py
+++ b/loopx/presentation/renderers/trajectory_hygiene_markdown.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..markdown import markdown_code, markdown_table_row, markdown_table_separator
+
+
+def render_trajectory_hygiene_markdown(payload: dict[str, Any]) -> str:
+    if not payload.get("ok"):
+        return "# LoopX Trajectory Hygiene\n\n- ok: `False`\n- error: " + str(payload.get("error"))
+
+    sample = payload.get("sample") if isinstance(payload.get("sample"), dict) else {}
+    metrics = payload.get("metrics") if isinstance(payload.get("metrics"), dict) else {}
+    boundary = (
+        payload.get("training_boundary")
+        if isinstance(payload.get("training_boundary"), dict)
+        else {}
+    )
+    lines = [
+        "# LoopX Trajectory Hygiene",
+        "",
+        f"- schema: `{payload.get('schema_version')}`",
+        f"- goal_filter: `{payload.get('goal_filter')}`",
+        f"- compact_history_rows: `{sample.get('compact_history_row_count')}`",
+        f"- source: `{sample.get('source')}`",
+        f"- seed_model_training_eligible: `{boundary.get('seed_model_training_eligible')}`",
+        f"- boundary: {boundary.get('reason')}",
+        "",
+        markdown_table_row(["metric", "value"]),
+        markdown_table_separator(2),
+    ]
+    for name, value in metrics.items():
+        lines.append(markdown_table_row([markdown_code(name), markdown_code(value)]))
+
+    lines.extend(["", "## Channels"])
+    for name, value in (payload.get("channel_counts") or {}).items():
+        lines.append(f"- `{name}`: `{value}`")
+    return "\n".join(lines)

--- a/tests/test_trajectory_hygiene.py
+++ b/tests/test_trajectory_hygiene.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from loopx.control_plane.runtime.trajectory_hygiene import (
+    build_trajectory_hygiene_summary,
+    compact_history_event_channel,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _runs() -> list[dict[str, object]]:
+    return [
+        {
+            "classification": "quota_monitor_poll",
+            "recommended_action": "wait for evidence",
+            "material_change": False,
+        },
+        {
+            "classification": "quota_slot_spent",
+            "delivery_outcome": "surface_only",
+        },
+        {
+            "classification": "patch_validated",
+            "agent_id": "codex-test",
+            "recommended_action": "open the reviewed pull request",
+            "delivery_outcome": "outcome_progress",
+        },
+        {
+            "classification": "patch_rechecked",
+            "agent_id": "codex-test",
+            "recommended_action": "open the reviewed pull request",
+            "delivery_outcome": "outcome_progress",
+        },
+        {
+            "classification": "owner_feedback",
+            "human_reward": {"decision": "continue", "reason_summary": "fixture accepted"},
+        },
+    ]
+
+
+def test_trajectory_hygiene_summary_separates_controller_rows() -> None:
+    payload = build_trajectory_hygiene_summary(
+        {"goal_filter": "fixture", "goal_count": 1, "runs": _runs()}
+    )
+
+    assert payload["schema_version"] == "trajectory_hygiene_summary_v0"
+    assert payload["channel_counts"] == {
+        "controller": 2,
+        "human_decision": 1,
+        "outcome": 2,
+    }
+    assert payload["metrics"]["controller_event_ratio"] == 0.4
+    assert payload["metrics"]["non_material_event_ratio"] == 0.4
+    assert payload["metrics"]["learning_candidate_count"] == 3
+    assert payload["metrics"]["learning_action_coverage"] == 0.6667
+    assert payload["metrics"]["learning_outcome_coverage"] == 0.6667
+    assert payload["metrics"]["decision_anchor_coverage"] == 0.6667
+    assert payload["metrics"]["duplicate_learning_action_ratio"] == 0.5
+    assert 0 < payload["metrics"]["compact_controller_char_ratio"] < 1
+    assert payload["training_boundary"] == {
+        "raw_session_read": False,
+        "raw_trajectory_read": False,
+        "run_artifact_read": False,
+        "compact_index_only": True,
+        "seed_model_training_eligible": False,
+        "reason": (
+            "compact history is an audit baseline, not a learning trajectory; "
+            "export model-visible task turns separately and link controller events by stable ids"
+        ),
+    }
+
+
+def test_trajectory_hygiene_channel_precedence_keeps_human_decisions() -> None:
+    assert compact_history_event_channel(
+        {"classification": "quota_monitor_poll", "operator_gate": {"decision": "approve"}}
+    ) == "human_decision"
+    assert compact_history_event_channel({"classification": "state_refreshed"}) == "controller"
+    assert compact_history_event_channel(
+        {"classification": "implementation", "delivery_outcome": "primary_goal_outcome"}
+    ) == "outcome"
+    assert compact_history_event_channel(
+        {"classification": "blocked_writeback", "delivery_outcome": "outcome_gap"}
+    ) == "outcome"
+
+
+def test_history_trajectory_hygiene_cli_reads_compact_index_only(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    runtime = tmp_path / "runtime"
+    goal_id = "trajectory-hygiene-fixture"
+    state_file = project / ".codex" / "goals" / goal_id / "ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text("---\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n", encoding="utf-8")
+
+    registry_path = project / ".loopx" / "registry.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": goal_id,
+                        "domain": "fixture",
+                        "status": "active-read-only",
+                        "repo": str(project),
+                        "state_file": str(state_file.relative_to(project)),
+                        "adapter": {"kind": "fixture", "status": "connected-read-only"},
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    runs_dir = runtime / "goals" / goal_id / "runs"
+    runs_dir.mkdir(parents=True)
+    (runs_dir / "index.jsonl").write_text(
+        "".join(
+            json.dumps(
+                {
+                    **run,
+                    "goal_id": goal_id,
+                    "generated_at": f"2026-01-01T00:00:0{index}+00:00",
+                }
+            )
+            + "\n"
+            for index, run in enumerate(_runs())
+        ),
+        encoding="utf-8",
+    )
+    # The command must not need or inspect a raw trajectory artifact.
+    (runs_dir / "trajectory.json").write_text("not-json-private-fixture", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry_path),
+            "--format",
+            "json",
+            "history",
+            "trajectory-hygiene",
+            "--goal-id",
+            goal_id,
+            "--limit",
+            "10",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["sample"]["compact_history_row_count"] == 5
+    assert payload["training_boundary"]["raw_trajectory_read"] is False
+    assert payload["training_boundary"]["seed_model_training_eligible"] is False


### PR DESCRIPTION
## Summary

- add `loopx history trajectory-hygiene` as a read-only audit over public-safe compact run-index rows
- report controller density, compact-character density, non-material event ratio, duplicate learning-action labels, and action/outcome attribution coverage
- document the v0 boundary: no raw sessions, trajectories, run artifacts, task bodies, or verifier output are read; output is never marked seed-model training eligible

## Risk boundary

This is additive and read-only. It does not change history writes, status, quota, todo, scheduler, state transitions, or existing JSON schemas. The classifier lives in a separate runtime read-model module and the CLI action requires an explicit goal id.

No local/private state, raw benchmark evidence, credentials, absolute local paths, or generated logs are included.

## Validation

- `uv run --no-project --with 'pytest>=8,<9' pytest -q tests/test_trajectory_hygiene.py` (3 passed)
- `python3 examples/cli-history-command-modularization-smoke.py`
- `python3 examples/history-index-duplicate-inspection-smoke.py`
- `python3 examples/cli-help-manpage-smoke.py`
- `python3 examples/control_plane/run-history-readmodel-smoke.py`
- `python3 examples/control_plane/run-history-agent-context-retention-smoke.py`
- `uvx ruff check ...` on all changed Python files
- `loopx canary premerge --from-git-diff --tier standard` (17/17 passed, no warnings, no manual holds, public-boundary scan clean)

## Compact evidence

On the latest 100 public-safe `loopx-meta` compact history rows, the audit reports controller-event ratio `0.58`, compact-controller-character ratio `0.4216`, and non-material-event ratio `0.58`. This is a baseline signal only, not a training-quality score.
