### PR TITLE
Add opt-in bounded TurnEnvelope view

### DIFF
--- a/docs/reference/protocols/turn-envelope-v0.md
+++ b/docs/reference/protocols/turn-envelope-v0.md
@@ -1,0 +1,31 @@
+# TurnEnvelope v0
+
+`loopx_turn_envelope_v0` is an additive, bounded read model over an already
+computed `quota should-run` decision. It gives an agent the next action and its
+safety contract without replaying every diagnostic lane in the full quota
+payload.
+
+Preview it explicitly:
+
+```bash
+loopx quota should-run --goal-id <goal-id> --agent-id <agent-id> --turn-envelope
+```
+
+The default `quota should-run` output remains unchanged. The v0 envelope keeps:
+
+- the selected todo, claim, and effective action;
+- concrete user actions and gate reasons;
+- required reads;
+- write scope, approvals, guards, workspace/capability gates, and stop rule;
+- validation/writeback and quota-spend policy;
+- the current scheduler action and cadence acknowledgement command.
+
+Large todo summaries, frontier diagnostics, readiness history, compatibility
+fields, and warning collections stay on the referenced full-decision/status
+cold paths. The envelope has an 8 KiB JSON budget and reports its measured
+source/envelope byte counts.
+
+This contract is a projection only. It does not change quota selection, todo
+routing, scheduler state, history writes, or state transitions. Promoting it to
+the default agent view requires separate parity evidence across delivery,
+monitor, user-gate, capability-gate, workspace-guard, and blocked states.

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -18,11 +18,13 @@ from ..quota import (
     void_quota_slot,
 )
 from ..status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, collect_status
+from ..control_plane.quota.turn_envelope import build_turn_envelope
 from ..control_plane.runtime.status_projection_cache import (
     load_status_projection_cache,
     resolve_status_projection_cache_runtime_root,
     write_status_projection_cache,
 )
+from ..presentation.renderers.turn_envelope_markdown import render_turn_envelope_markdown
 
 
 PrintPayload = Callable[
@@ -82,6 +84,14 @@ def register_quota_command(subparsers: argparse._SubParsersAction) -> None:
         help=(
             "Include cold-path scheduler detail for local scheduler, Codex CLI, "
             "and Claude loop runtimes in `quota should-run` JSON."
+        ),
+    )
+    quota_parser.add_argument(
+        "--turn-envelope",
+        action="store_true",
+        help=(
+            "For `quota should-run`, return the additive bounded TurnEnvelope view. "
+            "The default full decision remains unchanged."
         ),
     )
     quota_parser.add_argument("--slots", type=int, default=1, help="Slots to account for `quota spend-slot`.")
@@ -156,6 +166,8 @@ def handle_quota_command(
     append_cli_rollout_event: RolloutEventAppender,
 ) -> int:
     try:
+        if bool(getattr(args, "turn_envelope", False)) and args.quota_command != "should-run":
+            raise ValueError("--turn-envelope is only valid with `quota should-run`")
         scan_roots = [Path(item).expanduser() for item in args.scan_path]
         if not scan_roots:
             scan_roots = [Path(args.scan_root).expanduser()]
@@ -396,8 +408,12 @@ def handle_quota_command(
             },
             allow_failed=args.quota_command == "should-run",
         )
+    if bool(getattr(args, "turn_envelope", False)):
+        payload = build_turn_envelope(payload)
     renderer = (
-        render_quota_should_run_markdown
+        render_turn_envelope_markdown
+        if bool(getattr(args, "turn_envelope", False))
+        else render_quota_should_run_markdown
         if args.quota_command == "should-run"
         else render_quota_monitor_poll_markdown
         if args.quota_command == "monitor-poll"

--- a/loopx/control_plane/quota/turn_envelope.py
+++ b/loopx/control_plane/quota/turn_envelope.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from ..work_items.primary_action import protocol_action_text
+
+
+TURN_ENVELOPE_SCHEMA_VERSION = "loopx_turn_envelope_v0"
+TURN_ENVELOPE_BUDGET_BYTES = 8_192
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _text(value: Any, *, limit: int) -> str | None:
+    return protocol_action_text(value, limit=limit) or None
+
+
+def _text_list(value: Any, *, limit: int, item_limit: int = 240) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    result: list[str] = []
+    for item in value:
+        text = _text(item, limit=item_limit)
+        if not text or text in result:
+            continue
+        result.append(text)
+        if len(result) >= limit:
+            break
+    return result
+
+
+def _selected_todo(payload: Mapping[str, Any]) -> dict[str, Any] | None:
+    source = _mapping(payload.get("selected_todo"))
+    if not source:
+        return None
+    fields = (
+        "todo_id",
+        "priority",
+        "status",
+        "task_class",
+        "action_kind",
+        "claimed_by",
+        "blocks_agent",
+        "unblocks_todo_id",
+        "next_due_at",
+        "expires_at",
+        "selected_by",
+        "confidence",
+    )
+    compact = {field: source[field] for field in fields if source.get(field) is not None}
+    text = _text(source.get("text"), limit=360)
+    if text:
+        compact["text"] = text
+    return compact or None
+
+
+def _user_channel(interaction: Mapping[str, Any], payload: Mapping[str, Any]) -> dict[str, Any]:
+    source = _mapping(interaction.get("user_channel"))
+    channel: dict[str, Any] = {
+        "action_required": bool(source.get("action_required", payload.get("action_required"))),
+        "open_count": int(payload.get("open_count") or 0),
+        "notify": str(source.get("notify") or "DONT_NOTIFY"),
+    }
+    actions = _text_list(source.get("actions"), limit=3, item_limit=360)
+    if actions:
+        channel["actions"] = actions
+    reason = _text(source.get("reason"), limit=360)
+    if reason:
+        channel["reason"] = reason
+    return channel
+
+
+def _required_reads(interaction: Mapping[str, Any], payload: Mapping[str, Any]) -> list[dict[str, Any]]:
+    raw_reads = interaction.get("required_reads") or payload.get("required_reads")
+    if not isinstance(raw_reads, list):
+        return []
+    reads: list[dict[str, Any]] = []
+    for item in raw_reads[:5]:
+        if not isinstance(item, Mapping):
+            continue
+        command = _text(item.get("command"), limit=360)
+        if not command:
+            continue
+        compact = {"command": command}
+        for field in ("kind", "reason", "source"):
+            text = _text(item.get(field), limit=240)
+            if text:
+                compact[field] = text
+        reads.append(compact)
+    return reads
+
+
+def _boundary(payload: Mapping[str, Any]) -> dict[str, Any]:
+    source = _mapping(payload.get("goal_boundary"))
+    boundary: dict[str, Any] = {
+        "rule": str(source.get("rule") or "stay_in_scope_or_stop"),
+    }
+    adapter = _mapping(source.get("adapter"))
+    if adapter:
+        boundary["adapter"] = {
+            field: adapter[field]
+            for field in ("kind", "status")
+            if adapter.get(field) is not None
+        }
+    for field in ("write_scope", "available_capabilities", "requires_parent_approval"):
+        values = _text_list(source.get(field), limit=16, item_limit=180)
+        if values:
+            boundary[field] = values
+    guards = _text_list(source.get("guards"), limit=8, item_limit=280)
+    if guards:
+        boundary["guards"] = guards
+    stop_condition = _text(source.get("stop_condition"), limit=320)
+    if stop_condition:
+        boundary["stop_condition"] = stop_condition
+    for field in ("execution_profile", "orchestration"):
+        value = _mapping(source.get(field))
+        if value:
+            boundary[field] = value
+
+    workspace_guard = _mapping(payload.get("workspace_guard"))
+    if workspace_guard:
+        boundary["workspace_guard"] = workspace_guard
+    capability_gate = _mapping(payload.get("capability_gate"))
+    if capability_gate:
+        boundary["capability_gate"] = {
+            field: capability_gate[field]
+            for field in (
+                "action",
+                "reason",
+                "required_capabilities",
+                "missing_capabilities",
+                "owner_action",
+            )
+            if capability_gate.get(field) is not None
+        }
+    return boundary
+
+
+def _scheduler(payload: Mapping[str, Any]) -> dict[str, Any]:
+    source = _mapping(payload.get("scheduler_hint"))
+    scheduler: dict[str, Any] = {
+        field: source[field]
+        for field in ("action", "cadence_class", "spend_policy")
+        if source.get(field) is not None
+    }
+    codex_app = _mapping(source.get("codex_app"))
+    if not codex_app:
+        return scheduler
+    app: dict[str, Any] = {
+        field: codex_app[field]
+        for field in ("apply", "host_action", "recommended_rrule", "no_spend_for_cadence_change")
+        if codex_app.get(field) is not None
+    }
+    state = _mapping(codex_app.get("stateful_backoff"))
+    if state:
+        app["stateful_backoff"] = {
+            field: state[field]
+            for field in ("state_key", "current_rrule", "apply_needed", "state_status")
+            if state.get(field) is not None
+        }
+    ack = _mapping(codex_app.get("ack_hint"))
+    cli_args = _text_list(ack.get("cli_args"), limit=20, item_limit=180)
+    if cli_args:
+        app["ack_cli_args"] = cli_args
+    if app:
+        scheduler["codex_app"] = app
+    return scheduler
+
+
+def _cold_path(payload: Mapping[str, Any], agent_id: str | None) -> dict[str, Any]:
+    goal_id = str(payload.get("goal_id") or "<goal-id>")
+    agent_arg = f" --agent-id {agent_id}" if agent_id else ""
+    return {
+        "full_decision": (
+            f"loopx --format json quota should-run --goal-id {goal_id}{agent_arg}"
+        ),
+        "todo_detail": f"loopx --format json todo list --goal-id {goal_id}",
+        "status_detail": f"loopx --format json status --goal-id {goal_id}",
+        "contains": [
+            "quota accounting detail",
+            "goal frontier and route diagnostics",
+            "full todo summaries",
+            "handoff and readiness diagnostics",
+            "promotion, archive, and projection warnings",
+            "scheduler runtime detail",
+        ],
+    }
+
+
+def build_turn_envelope(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Project a full quota decision into an additive, model-facing hot-path view."""
+
+    interaction = _mapping(payload.get("interaction_contract"))
+    agent_channel = _mapping(interaction.get("agent_channel"))
+    cli_channel = _mapping(interaction.get("cli_channel"))
+    agent_identity = _mapping(payload.get("agent_identity"))
+    agent_id = str(agent_identity.get("agent_id") or "").strip() or None
+
+    envelope: dict[str, Any] = {
+        "ok": bool(payload.get("ok")),
+        "schema_version": TURN_ENVELOPE_SCHEMA_VERSION,
+        "mode": "should-run",
+        "view": "turn_envelope",
+        "goal_id": payload.get("goal_id"),
+        "agent_id": agent_id,
+        "decision": payload.get("decision"),
+        "should_run": bool(payload.get("should_run")),
+        "effective_action": payload.get("effective_action"),
+        "state": payload.get("state"),
+        "reason": _text(payload.get("reason"), limit=360),
+        "action_required": bool(payload.get("action_required")),
+        "open_count": int(payload.get("open_count") or 0),
+        "action": {
+            "recommended_action": _text(payload.get("recommended_action"), limit=480),
+            "primary_action": _text(agent_channel.get("primary_action"), limit=480),
+            "must_attempt": bool(agent_channel.get("must_attempt")),
+            "delivery_allowed": bool(agent_channel.get("delivery_allowed")),
+            "quiet_noop_allowed": bool(agent_channel.get("quiet_noop_allowed")),
+            "selected_todo": _selected_todo(payload),
+        },
+        "user": _user_channel(interaction, payload),
+        "required_reads": _required_reads(interaction, payload),
+        "boundary": _boundary(payload),
+        "writeback": {
+            "next_cli_actions": _text_list(
+                cli_channel.get("next_cli_actions"),
+                limit=5,
+                item_limit=420,
+            ),
+            "spend_allowed_now": bool(cli_channel.get("spend_allowed_now")),
+            "spend_after_validation": bool(cli_channel.get("spend_after_validation")),
+            "spend_policy": _text(cli_channel.get("spend_policy"), limit=280),
+        },
+        "scheduler": _scheduler(payload),
+        "detail_ref": _cold_path(payload, agent_id),
+    }
+
+    source_bytes = len(json.dumps(dict(payload), ensure_ascii=False, separators=(",", ":")))
+    envelope["compaction"] = {
+        "source_json_bytes": source_bytes,
+        "envelope_json_bytes": 0,
+        "byte_reduction_ratio": 0.0,
+        "budget_bytes": TURN_ENVELOPE_BUDGET_BYTES,
+        "within_budget": True,
+    }
+    for _ in range(3):
+        envelope_bytes = len(json.dumps(envelope, ensure_ascii=False, separators=(",", ":")))
+        envelope["compaction"].update(
+            {
+                "envelope_json_bytes": envelope_bytes,
+                "byte_reduction_ratio": (
+                    round(1 - envelope_bytes / source_bytes, 4) if source_bytes else 0.0
+                ),
+                "within_budget": envelope_bytes <= TURN_ENVELOPE_BUDGET_BYTES,
+            }
+        )
+    return envelope

--- a/loopx/presentation/renderers/turn_envelope_markdown.py
+++ b/loopx/presentation/renderers/turn_envelope_markdown.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def render_turn_envelope_markdown(payload: dict[str, Any]) -> str:
+    action = payload.get("action") if isinstance(payload.get("action"), dict) else {}
+    user = payload.get("user") if isinstance(payload.get("user"), dict) else {}
+    writeback = payload.get("writeback") if isinstance(payload.get("writeback"), dict) else {}
+    scheduler = payload.get("scheduler") if isinstance(payload.get("scheduler"), dict) else {}
+    compaction = payload.get("compaction") if isinstance(payload.get("compaction"), dict) else {}
+    lines = [
+        "# LoopX Turn Envelope",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- agent_id: `{payload.get('agent_id')}`",
+        f"- decision: `{payload.get('decision')}`",
+        f"- should_run: `{payload.get('should_run')}`",
+        f"- effective_action: `{payload.get('effective_action')}`",
+        f"- action: {action.get('primary_action') or action.get('recommended_action') or ''}",
+        f"- user_action_required: `{user.get('action_required')}`",
+        f"- spend_policy: {writeback.get('spend_policy') or ''}",
+        f"- scheduler: `{scheduler.get('action')}`",
+        f"- envelope_bytes: `{compaction.get('envelope_json_bytes')}`",
+        f"- within_budget: `{compaction.get('within_budget')}`",
+    ]
+    return "\n".join(lines)

--- a/tests/test_turn_envelope.py
+++ b/tests/test_turn_envelope.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+
+from loopx.control_plane.quota.turn_envelope import (
+    TURN_ENVELOPE_BUDGET_BYTES,
+    build_turn_envelope,
+)
+
+
+def _full_decision() -> dict[str, object]:
+    return {
+        "ok": True,
+        "goal_id": "fixture-goal",
+        "decision": "run",
+        "should_run": True,
+        "effective_action": "normal_run",
+        "state": "eligible",
+        "reason": "eligible fixture",
+        "action_required": False,
+        "open_count": 0,
+        "recommended_action": "implement one bounded public-safe slice",
+        "agent_identity": {"agent_id": "codex-fixture"},
+        "selected_todo": {
+            "todo_id": "todo_fixture0001",
+            "priority": "P0",
+            "status": "open",
+            "task_class": "advancement_task",
+            "action_kind": "fixture_action",
+            "claimed_by": "codex-fixture",
+            "text": "Implement one bounded public-safe slice",
+        },
+        "interaction_contract": {
+            "mode": "bounded_delivery",
+            "user_channel": {"action_required": False, "notify": "DONT_NOTIFY"},
+            "agent_channel": {
+                "must_attempt": True,
+                "delivery_allowed": True,
+                "quiet_noop_allowed": False,
+                "primary_action": "todo_fixture0001: implement the fixture",
+            },
+            "cli_channel": {
+                "next_cli_actions": [
+                    "loopx refresh-state --goal-id fixture-goal --classification validated",
+                    "loopx quota spend-slot --goal-id fixture-goal --execute",
+                ],
+                "spend_allowed_now": False,
+                "spend_after_validation": True,
+                "spend_policy": "spend once after validated writeback",
+            },
+            "required_reads": [
+                {"kind": "repository", "command": "git status --short", "reason": "inspect state"}
+            ],
+        },
+        "goal_boundary": {
+            "adapter": {"kind": "fixture", "status": "connected-read-only"},
+            "write_scope": ["loopx/**", "tests/**"],
+            "requires_parent_approval": ["publish"],
+            "guards": ["stop on private material"],
+            "stop_condition": "stop before unauthorized production action",
+            "rule": "stay_in_scope_or_stop",
+        },
+        "scheduler_hint": {
+            "action": "run_now",
+            "cadence_class": "active_work",
+            "spend_policy": "spend after validated writeback",
+            "codex_app": {
+                "apply": "update_automation_cadence_if_possible",
+                "host_action": "update_current_heartbeat_rrule",
+                "recommended_rrule": "FREQ=MINUTELY;INTERVAL=3",
+                "no_spend_for_cadence_change": True,
+                "stateful_backoff": {
+                    "state_key": "scheduler_hint.codex_app.stateful_backoff",
+                    "current_rrule": "FREQ=MINUTELY;INTERVAL=60",
+                    "apply_needed": True,
+                    "state_status": "reset_required",
+                },
+                "ack_hint": {
+                    "cli_args": [
+                        "quota",
+                        "scheduler-ack-current",
+                        "--goal-id",
+                        "fixture-goal",
+                        "--execute",
+                    ]
+                },
+            },
+        },
+        "agent_todo_summary": {"large_diagnostic_lane": ["x" * 2_000]},
+        "goal_frontier_projection": {"large_diagnostic_lane": ["y" * 2_000]},
+        "plan_summary": {"large_diagnostic_lane": ["z" * 2_000]},
+    }
+
+
+def test_turn_envelope_preserves_action_boundary_and_writeback() -> None:
+    source = _full_decision()
+    envelope = build_turn_envelope(source)
+
+    assert envelope["schema_version"] == "loopx_turn_envelope_v0"
+    assert envelope["view"] == "turn_envelope"
+    assert envelope["goal_id"] == "fixture-goal"
+    assert envelope["agent_id"] == "codex-fixture"
+    assert envelope["action"]["selected_todo"]["todo_id"] == "todo_fixture0001"
+    assert envelope["action"]["must_attempt"] is True
+    assert envelope["user"] == {
+        "action_required": False,
+        "open_count": 0,
+        "notify": "DONT_NOTIFY",
+    }
+    assert envelope["required_reads"][0]["command"] == "git status --short"
+    assert envelope["boundary"]["write_scope"] == ["loopx/**", "tests/**"]
+    assert envelope["writeback"]["spend_after_validation"] is True
+    assert envelope["scheduler"]["codex_app"]["stateful_backoff"]["apply_needed"] is True
+    assert envelope["scheduler"]["codex_app"]["ack_cli_args"][0] == "quota"
+
+    assert "agent_todo_summary" not in envelope
+    assert "goal_frontier_projection" not in envelope
+    assert "plan_summary" not in envelope
+    assert envelope["compaction"]["source_json_bytes"] == len(
+        json.dumps(source, ensure_ascii=False, separators=(",", ":"))
+    )
+    assert envelope["compaction"]["envelope_json_bytes"] < TURN_ENVELOPE_BUDGET_BYTES
+    assert envelope["compaction"]["within_budget"] is True
+    assert envelope["compaction"]["byte_reduction_ratio"] > 0.5
+
+
+def test_turn_envelope_keeps_concrete_user_gate() -> None:
+    source = _full_decision()
+    source["action_required"] = True
+    source["open_count"] = 1
+    source["interaction_contract"]["user_channel"] = {
+        "action_required": True,
+        "notify": "NOTIFY",
+        "actions": ["Approve public release"],
+        "reason": "release approval required",
+    }
+
+    envelope = build_turn_envelope(source)
+
+    assert envelope["user"]["action_required"] is True
+    assert envelope["user"]["actions"] == ["Approve public release"]
+    assert envelope["user"]["reason"] == "release approval required"
+    assert envelope["action_required"] is True
+    assert envelope["open_count"] == 1


### PR DESCRIPTION
## Summary

- add opt-in `loopx quota should-run --turn-envelope`
- project an already-computed quota decision into selected action/todo, concrete user gate, required reads, safety boundary, writeback/spend policy, scheduler action, and cold-path references
- enforce/report an 8 KiB envelope budget while leaving the default full quota response unchanged

## Risk boundary

This PR does **not** change quota selection, status collection, todo routing, scheduler state, history writes, or default JSON output. The projection runs only after the full decision and rollout event have been produced, and only when `--turn-envelope` is explicit.

No private state, raw sessions/trajectories, benchmark evidence, credentials, local paths, or generated logs are included.

## Validation

- focused pytest: `2 passed`
- Ruff and Python compile checks passed
- quota contract, interaction state-machine, scheduler compaction, quota/status performance, review-packet parity, and CLI modularization smokes passed
- `loopx canary premerge --from-git-diff --tier standard`: 17/17 passed, zero warnings/skips/manual holds, changed-file public-boundary scan clean

## Live parity/size evidence

Against the current `loopx-meta` decision, the explicit envelope retained the same `decision=run`, `should_run=true`, `effective_action=normal_run`, selected todo, boundary, writeback, and scheduler action. JSON size fell from 54,336 bytes to 3,902 bytes (92.82% reduction), within the 8 KiB budget.

Promotion to the default agent view is intentionally out of scope and requires separate parity coverage across delivery, monitor, user-gate, capability-gate, workspace-guard, and blocked states.
