### PR TITLE
Add opt-in peer supervisor prototype

### DIFF
--- a/docs/reference/protocols/peer-agent-runtime-v1.md
+++ b/docs/reference/protocols/peer-agent-runtime-v1.md
@@ -100,6 +100,11 @@ writer later reintroduces a hierarchy field, peer runtime ignores that field
 and does not wake the user with the same automation migration again. Upgrade
 diagnostics may still expose the stale input for cleanup.
 
+Implementation boundary: legacy field names, detection, profile conversion,
+and completion bookkeeping live in the isolated `legacy_migration` module.
+`runtime_model` contains only the live `peer_v1` model and does not branch on
+primary/side identity concepts.
+
 Rollback restores the returned `backup_path`, then regenerates installed host
 loops from that restored registry. Registry restoration and host-loop
 regeneration are one operational rollback.
@@ -114,3 +119,6 @@ migration can be validated against v0.1 state. v0.2 is not releasable until:
   longer execute hierarchy branches;
 - old hierarchy fields are accepted only by migration/history readers;
 - the peer-agent canary profile and full smoke suite pass.
+
+An optional supervisor is an overlay on this peer model, not a replacement for
+it. See [Peer Supervisor v0](peer-supervisor-v0.md).

--- a/docs/reference/protocols/peer-supervisor-v0.md
+++ b/docs/reference/protocols/peer-supervisor-v0.md
@@ -60,6 +60,25 @@ loopx supervisor-prompt \
   --agent-id <supervisor-agent-id>
 ```
 
+The prompt runs the supervisor's own quota guard, then consumes one read-only
+observation packet:
+
+```bash
+loopx supervisor-observe \
+  --goal-id <goal-id> \
+  --agent-id <supervisor-agent-id>
+```
+
+`supervisor_observation_v0` selects from existing public-safe projections. For
+each supervised peer it includes current claim, state, next action, last
+activity, workspace/handoff references, recent thin evidence rows, and compact
+effect references. It does not run another peer's quota guard, include raw
+history or transcripts, or introduce write authority. Missing peer status or
+evidence is projected as a warning and makes `decision_input_complete=false`.
+Degraded status contracts behave the same way: the packet preserves the usable
+read-only projection, reports compact health counts, and does not claim that
+the decision input is complete.
+
 ## Decision Contract
 
 `supervisor_decision_v0` uses an enum-like closed set:

--- a/docs/reference/protocols/peer-supervisor-v0.md
+++ b/docs/reference/protocols/peer-supervisor-v0.md
@@ -1,0 +1,102 @@
+# Peer Supervisor v0
+
+## Status
+
+Experimental and default-off. This protocol adds an observation and proposal
+layer over registered `peer_v1` agents. It does not add a new scheduler, create
+agent sessions, or grant one identity durable authority over another.
+
+The design is informed by Shepherd's runtime-supervisor experiments, where a
+stronger observer can compare concurrent effect streams and choose to inject,
+handoff, or discard a branch. LoopX keeps those actions as typed proposals until
+a host runtime exposes the required execution capabilities and returns evidence.
+
+## Why A Supervisor
+
+Several equal peers are useful for independent progress, but they give the user
+multiple places to inspect. An optional supervisor provides one synthesis
+channel that can compare:
+
+- goal status and user gates;
+- each peer's quota and interaction contract;
+- todo claims, leases, and continuation state;
+- recent agent-scoped evidence;
+- compact runtime effect or state references.
+
+The user can use the supervisor task as the preferred control-room conversation
+while several peers run. The user may still talk directly to any peer. Decisions
+that change goal authority remain LoopX user todos or gates, so they do not live
+only in a supervisor transcript.
+
+## Configuration
+
+The supervisor must already be a registered peer. Enabling it is explicit:
+
+```bash
+loopx configure-goal \
+  --goal-id <goal-id> \
+  --supervisor-agent <registered-agent-id> \
+  --supervised-agent <peer-a> \
+  --supervised-agent <peer-b> \
+  --execute
+```
+
+Omit `--supervised-agent` to observe every registered peer except the supervisor.
+Disable the feature with:
+
+```bash
+loopx configure-goal --goal-id <goal-id> --clear-supervisor --execute
+```
+
+Configuration is stored as `coordination.supervisor` with schema
+`peer_supervisor_v0`. Absence means disabled. The canonical configuration has
+`execution_mode=proposal_only`.
+
+Generate the dedicated task body after configuration:
+
+```bash
+loopx supervisor-prompt \
+  --goal-id <goal-id> \
+  --agent-id <supervisor-agent-id>
+```
+
+## Decision Contract
+
+`supervisor_decision_v0` uses an enum-like closed set:
+
+| Kind | Meaning | Required host capability |
+| --- | --- | --- |
+| `observe` | Keep watching; no intervention is justified. | none |
+| `inject` | Propose a bounded message to an existing session. | `session_message_injection` |
+| `handoff` | Propose continuing a target from a named source state. | `session_state_fork`, `workspace_state_transfer` |
+| `discard` | Propose terminating a failed branch while retaining compact evidence. | `session_termination` |
+
+Every proposal names reason codes and compact evidence references. `inject`
+names a target and message. `handoff` names source, target, and state reference.
+`discard` names target and state reference.
+
+The v0 CLI does not execute these actions. Missing host capabilities leave the
+proposal unexecuted; a model response is never accepted as proof that a session
+was injected, forked, or terminated. Destructive actions require explicit host
+authority even after an executor exists.
+
+## Authority Boundaries
+
+- The supervisor is an equal peer with an extra observation responsibility.
+- It cannot claim another peer's todo, spend another peer's quota, or rewrite a
+  user gate merely to resolve a proposal.
+- Review and handoff remain ordinary task policies; the supervisor does not
+  become a hidden review owner.
+- Legacy `primary_agent` fields remain confined to the existing exactly-once
+  migration reader. They are not a live configuration model and are not used by
+  this protocol.
+
+This separation lets LoopX test whether richer synthesis improves delivery
+without coupling the State Kernel to a particular session runtime or bringing
+durable hierarchy back into `peer_v1`.
+
+## References
+
+- [Shepherd: A Meta-Agent for Versioned Execution](https://arxiv.org/abs/2605.10913)
+- [CooperBench](https://arxiv.org/abs/2601.13295)
+- [Shepherd repository](https://github.com/shepherd-agents/shepherd)

--- a/docs/reference/protocols/peer-supervisor-v0.md
+++ b/docs/reference/protocols/peer-supervisor-v0.md
@@ -106,9 +106,9 @@ authority even after an executor exists.
   user gate merely to resolve a proposal.
 - Review and handoff remain ordinary task policies; the supervisor does not
   become a hidden review owner.
-- Legacy `primary_agent` fields remain confined to the existing exactly-once
-  migration reader. They are not a live configuration model and are not used by
-  this protocol.
+- Pre-peer hierarchy fields remain confined to the existing exactly-once
+  migration reader. They are not a live configuration model and are not used
+  by this protocol.
 
 This separation lets LoopX test whether richer synthesis improves delivery
 without coupling the State Kernel to a particular session runtime or bringing

--- a/examples/control_plane/peer-agent-hard-cut-boundary-smoke.py
+++ b/examples/control_plane/peer-agent-hard-cut-boundary-smoke.py
@@ -29,8 +29,7 @@ SCAN_FILES = (
     REPO_ROOT / "examples" / "dashboard-home-browser-smoke.mjs",
 )
 ALLOWED_LEGACY_PATHS = {
-    REPO_ROOT / "loopx" / "configure_goal.py",
-    REPO_ROOT / "loopx" / "control_plane" / "agents" / "runtime_model.py",
+    REPO_ROOT / "loopx" / "control_plane" / "agents" / "legacy_migration.py",
     REPO_ROOT / "loopx" / "control_plane" / "todos" / "contract.py",
     REPO_ROOT / "docs" / "reference" / "protocols" / "peer-agent-runtime-v1.md",
     REPO_ROOT / "docs" / "project-agent-todo-contract.md",

--- a/examples/control_plane/peer-agent-migration-smoke.py
+++ b/examples/control_plane/peer-agent-migration-smoke.py
@@ -247,6 +247,55 @@ def main() -> int:
         assert repeated_after_legacy_write["changed"] is False, repeated_after_legacy_write
         assert repeated_after_legacy_write["backup_path"] is None, repeated_after_legacy_write
 
+        custom_role_registry = Path(tmp) / "custom-role-registry.json"
+        custom_role_registry.write_text(
+            json.dumps(
+                {
+                    "goals": [
+                        {
+                            "id": GOAL_ID,
+                            "coordination": {
+                                "registered_agents": AGENTS,
+                                "agent_model": "peer_v1",
+                                "agent_profiles": {
+                                    AGENTS[0]: {
+                                        "role": "researcher",
+                                        "scope_summary": "research synthesis",
+                                    }
+                                },
+                            },
+                        }
+                    ]
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        custom_goal = json.loads(custom_role_registry.read_text(encoding="utf-8"))[
+            "goals"
+        ][0]
+        custom_identity = build_quota_agent_identity(custom_goal, agent_id=AGENTS[0])
+        custom_upgrade = build_identity_aware_prompt_upgrade(
+            custom_goal,
+            goal_id=GOAL_ID,
+            agent_identity=custom_identity,
+        )
+        assert custom_upgrade["registry_migration_required"] is True, custom_upgrade
+        custom_applied = configure_goal(
+            registry_path=custom_role_registry,
+            goal_id=GOAL_ID,
+            automation_prompt_migration_ack=custom_upgrade["migration_id"],
+            execute=True,
+        )
+        assert custom_applied["written"] is True, custom_applied
+        custom_migrated_goal = json.loads(
+            custom_role_registry.read_text(encoding="utf-8")
+        )["goals"][0]
+        custom_profile = custom_migrated_goal["coordination"]["agent_profiles"][AGENTS[0]]
+        assert custom_profile["profile_role"] == "researcher", custom_profile
+        assert custom_profile["scope_summary"] == "research synthesis", custom_profile
+        assert "role" not in custom_profile, custom_profile
+
         fresh_registry = Path(tmp) / "fresh-registry.json"
         fresh_registry.write_text(
             json.dumps({"goals": [{"id": GOAL_ID}]}) + "\n",

--- a/examples/control_plane/peer-agent-migration-smoke.py
+++ b/examples/control_plane/peer-agent-migration-smoke.py
@@ -18,7 +18,7 @@ from loopx.control_plane.agents.identity import (  # noqa: E402
     build_identity_aware_prompt_upgrade,
     build_quota_agent_identity,
 )
-from loopx.control_plane.agents.runtime_model import (  # noqa: E402
+from loopx.control_plane.agents.legacy_migration import (  # noqa: E402
     PEER_AGENT_RUNTIME_MIGRATION,
 )
 from loopx.heartbeat_prompt import build_heartbeat_prompt  # noqa: E402

--- a/examples/control_plane/peer-supervisor-smoke.py
+++ b/examples/control_plane/peer-supervisor-smoke.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Exercise the default-off peer supervisor configuration and prompt contract."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.cli import main as cli_main  # noqa: E402
+from loopx.configure_goal import configure_goal  # noqa: E402
+from loopx.control_plane.agents.supervisor import (  # noqa: E402
+    HOST_CAPABILITIES_BY_DECISION,
+    SupervisorDecisionKind,
+    build_supervisor_prompt,
+    normalize_supervisor_decision,
+    peer_supervisor_for_goal,
+)
+
+
+GOAL_ID = "peer-supervisor-fixture"
+AGENTS = ["codex-alpha", "codex-beta", "codex-gamma"]
+
+
+def read_goal(registry_path: Path) -> dict:
+    return json.loads(registry_path.read_text(encoding="utf-8"))["goals"][0]
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-peer-supervisor-") as tmp:
+        root = Path(tmp)
+        state_file = root / "ACTIVE_GOAL_STATE.md"
+        state_file.write_text("# Active Goal State\n", encoding="utf-8")
+        registry_path = root / "registry.json"
+        registry_path.write_text(
+            json.dumps(
+                {
+                    "goals": [
+                        {
+                            "id": GOAL_ID,
+                            "repo": str(root),
+                            "state_file": state_file.name,
+                            "coordination": {
+                                "agent_model": "peer_v1",
+                                "registered_agents": AGENTS,
+                            },
+                        }
+                    ]
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        assert peer_supervisor_for_goal(read_goal(registry_path)) is None
+
+        preview = configure_goal(
+            registry_path=registry_path,
+            goal_id=GOAL_ID,
+            supervisor_agent=AGENTS[0],
+        )
+        supervisor = preview["after"]["supervisor"]
+        assert preview["dry_run"] is True, preview
+        assert supervisor == {
+            "schema_version": "peer_supervisor_v0",
+            "enabled": True,
+            "agent_id": AGENTS[0],
+            "supervised_agents": AGENTS[1:],
+            "execution_mode": "proposal_only",
+        }, supervisor
+        assert read_goal(registry_path)["coordination"].get("supervisor") is None
+
+        applied = configure_goal(
+            registry_path=registry_path,
+            goal_id=GOAL_ID,
+            supervisor_agent=AGENTS[0],
+            supervised_agents=[AGENTS[2]],
+            execute=True,
+        )
+        assert applied["written"] is True, applied
+        assert applied["supervisor_prompt"]["status"] == "ready", applied
+        assert "supervisor-prompt" in applied["supervisor_prompt"]["command"], applied
+        goal = read_goal(registry_path)
+        assert "primary_agent" not in goal["coordination"], goal
+        configured = peer_supervisor_for_goal(goal)
+        assert configured["supervised_agents"] == [AGENTS[2]], configured
+
+        prompt = build_supervisor_prompt(
+            goal_id=GOAL_ID,
+            active_state=str(state_file),
+            supervisor=configured,
+        )
+        contract = prompt["supervisor_contract"]
+        assert contract["peer_authority"] == "equal_identity_authority", contract
+        assert contract["supervisor_authority"] == "proposal_only", contract
+        assert contract["user_interaction"]["user_may_interact_with_any_peer"] is True
+        assert contract["decision_contract"]["kinds"] == [
+            kind.value for kind in SupervisorDecisionKind
+        ]
+        assert HOST_CAPABILITIES_BY_DECISION["inject"] == [
+            "session_message_injection"
+        ]
+        assert HOST_CAPABILITIES_BY_DECISION["discard"] == ["session_termination"]
+        task_body = prompt["task_body"]
+        assert "not a durable leader" in task_body, task_body
+        assert "proposal-only" in task_body, task_body
+        assert "evidence-log" in task_body and "quota should-run" in task_body, task_body
+        assert f"status --goal-id {GOAL_ID} --agent-id {AGENTS[2]}" in task_body
+        assert f"quota should-run --goal-id {GOAL_ID} --agent-id {AGENTS[2]}" not in task_body
+
+        decision = normalize_supervisor_decision(
+            {
+                "decision_id": "handoff-1",
+                "kind": "handoff",
+                "source_agent_id": AGENTS[2],
+                "target_agent_id": AGENTS[1],
+                "state_ref": "runtime-state:42",
+                "reason_codes": ["scope-overlap"],
+                "evidence_refs": ["effect:42"],
+            },
+            supervisor={**configured, "supervised_agents": AGENTS[1:]},
+        )
+        assert decision["execution_status"] == "proposal_only", decision
+        assert decision["required_host_capabilities"] == [
+            "session_state_fork",
+            "workspace_state_transfer",
+        ], decision
+
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exit_code = cli_main(
+                [
+                    "--registry",
+                    str(registry_path),
+                    "supervisor-prompt",
+                    "--format",
+                    "json",
+                    "--goal-id",
+                    GOAL_ID,
+                    "--agent-id",
+                    AGENTS[0],
+                ]
+            )
+        assert exit_code == 0, stdout.getvalue()
+        cli_payload = json.loads(stdout.getvalue())
+        assert cli_payload["agent_id"] == AGENTS[0], cli_payload
+        assert cli_payload["supervisor_contract"]["supervised_agents"] == [
+            AGENTS[2]
+        ], cli_payload
+
+        try:
+            configure_goal(
+                registry_path=registry_path,
+                goal_id=GOAL_ID,
+                supervisor_agent=AGENTS[0],
+                supervised_agents=[AGENTS[0]],
+            )
+        except ValueError as exc:
+            assert "cannot supervise its own" in str(exc), exc
+        else:
+            raise AssertionError("self-supervision must fail closed")
+
+        try:
+            normalize_supervisor_decision(
+                {
+                    "decision_id": "bad-handoff",
+                    "kind": "handoff",
+                    "source_agent_id": AGENTS[1],
+                    "target_agent_id": AGENTS[1],
+                    "state_ref": "runtime-state:43",
+                    "reason_codes": ["scope-overlap"],
+                    "evidence_refs": ["effect:43"],
+                },
+                supervisor={**configured, "supervised_agents": AGENTS[1:]},
+            )
+        except ValueError as exc:
+            assert "must differ" in str(exc), exc
+        else:
+            raise AssertionError("same-session handoff must fail closed")
+
+        cleared = configure_goal(
+            registry_path=registry_path,
+            goal_id=GOAL_ID,
+            clear_supervisor=True,
+            execute=True,
+        )
+        assert cleared["after"]["supervisor"] is None, cleared
+        assert cleared["supervisor_prompt"]["status"] == "disabled", cleared
+
+    print("peer-supervisor-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/control_plane/peer-supervisor-smoke.py
+++ b/examples/control_plane/peer-supervisor-smoke.py
@@ -20,6 +20,7 @@ from loopx.configure_goal import configure_goal  # noqa: E402
 from loopx.control_plane.agents.supervisor import (  # noqa: E402
     HOST_CAPABILITIES_BY_DECISION,
     SupervisorDecisionKind,
+    build_supervisor_observation_packet,
     build_supervisor_prompt,
     normalize_supervisor_decision,
     peer_supervisor_for_goal,
@@ -34,11 +35,86 @@ def read_goal(registry_path: Path) -> dict:
     return json.loads(registry_path.read_text(encoding="utf-8"))["goals"][0]
 
 
+def observation_status() -> dict:
+    return {
+        "ok": True,
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": GOAL_ID,
+                    "status": "active",
+                    "severity": "info",
+                    "recommended_action": "Compare peer effects before proposing a branch.",
+                    "project_asset": {"user_todos": {"open": 0}},
+                }
+            ]
+        },
+        "agent_management_projection": {
+            "schema_version": "agent_management_projection_v0",
+            "generated_at": "2026-07-12T08:00:00Z",
+            "agents": [
+                {
+                    "agent_id": AGENTS[2],
+                    "state": "active",
+                    "current_todo": {
+                        "todo_id": "todo-gamma",
+                        "text": "Validate the bounded peer branch.",
+                    },
+                    "next_action": "Run the focused smoke.",
+                    "last_activity_at": "2026-07-12T07:59:00Z",
+                    "workspace_ref": {
+                        "kind": "worktree",
+                        "branch": "codex/gamma",
+                        "path_safe": False,
+                    },
+                    "handoff_refs": ["handoff-gamma"],
+                    "evidence_refs": ["todo:todo-gamma:evidence"],
+                }
+            ],
+        },
+    }
+
+
+def observation_evidence() -> dict:
+    return {
+        "ok": True,
+        "schema_version": "agent_scoped_evidence_log_v0",
+        "ledger_count": 2,
+        "matched_count": 2,
+        "truncated": False,
+        "ledger": [
+            {
+                "source": "rollout_event_log",
+                "recorded_at": "2026-07-12T07:59:30Z",
+                "event_id": "event-gamma-2",
+                "event_kind": "refresh_state",
+                "summary": "Focused smoke passed.",
+            },
+            {
+                "source": "run_history",
+                "recorded_at": "2026-07-12T07:58:00Z",
+                "run_ref": "2026-07-12T07:58:00Z",
+                "delivery_outcome": "implementation_progress",
+            },
+        ],
+    }
+
+
 def main() -> int:
     with tempfile.TemporaryDirectory(prefix="loopx-peer-supervisor-") as tmp:
         root = Path(tmp)
         state_file = root / "ACTIVE_GOAL_STATE.md"
-        state_file.write_text("# Active Goal State\n", encoding="utf-8")
+        state_file.write_text(
+            "---\n"
+            "status: active\n"
+            "---\n\n"
+            "# Active Goal State\n\n"
+            "## Objective\n\n"
+            "Exercise the opt-in peer supervisor contract.\n\n"
+            "## Next Action\n\n"
+            "- Observe peer projections before proposing an action.\n",
+            encoding="utf-8",
+        )
         registry_path = root / "registry.json"
         registry_path.write_text(
             json.dumps(
@@ -46,8 +122,13 @@ def main() -> int:
                     "goals": [
                         {
                             "id": GOAL_ID,
+                            "domain": "peer-supervisor-smoke",
                             "repo": str(root),
                             "state_file": state_file.name,
+                            "adapter": {
+                                "kind": "generic_project_goal_v0",
+                                "status": "connected",
+                            },
                             "coordination": {
                                 "agent_model": "peer_v1",
                                 "registered_agents": AGENTS,
@@ -113,9 +194,59 @@ def main() -> int:
         task_body = prompt["task_body"]
         assert "not a durable leader" in task_body, task_body
         assert "proposal-only" in task_body, task_body
-        assert "evidence-log" in task_body and "quota should-run" in task_body, task_body
-        assert f"status --goal-id {GOAL_ID} --agent-id {AGENTS[2]}" in task_body
+        assert "supervisor-observe" in task_body and "quota should-run" in task_body
+        assert "evidence-log" not in task_body, task_body
+        assert f"status --goal-id {GOAL_ID} --agent-id {AGENTS[2]}" not in task_body
         assert f"quota should-run --goal-id {GOAL_ID} --agent-id {AGENTS[2]}" not in task_body
+
+        observation = build_supervisor_observation_packet(
+            goal_id=GOAL_ID,
+            supervisor=configured,
+            status_payload=observation_status(),
+            evidence_logs={AGENTS[2]: observation_evidence()},
+        )
+        assert observation["schema_version"] == "supervisor_observation_v0", observation
+        assert observation["mode"] == "read_only", observation
+        assert observation["decision_input_complete"] is True, observation
+        assert observation["warnings"] == [], observation
+        assert observation["goal"]["user_open_count"] == 0, observation
+        peer = observation["peers"][0]
+        assert peer["agent_id"] == AGENTS[2], peer
+        assert peer["current_todo"]["todo_id"] == "todo-gamma", peer
+        assert peer["evidence"]["latest_recorded_at"] == "2026-07-12T07:59:30Z", peer
+        assert peer["evidence"]["effect_refs"] == [
+            "todo:todo-gamma:evidence",
+            "rollout_event:event-gamma-2",
+            "run_history:2026-07-12T07:58:00Z",
+        ], peer
+        assert observation["boundary"]["raw_transcripts_included"] is False
+        assert observation["boundary"]["write_authority"] == "none"
+
+        incomplete = build_supervisor_observation_packet(
+            goal_id=GOAL_ID,
+            supervisor={**configured, "supervised_agents": AGENTS[1:]},
+            status_payload=observation_status(),
+            evidence_logs={AGENTS[2]: observation_evidence()},
+        )
+        assert incomplete["decision_input_complete"] is False, incomplete
+        assert incomplete["warnings"] == [
+            f"missing_agent_status:{AGENTS[1]}",
+            f"missing_evidence_log:{AGENTS[1]}",
+        ], incomplete
+
+        degraded_status = observation_status()
+        degraded_status["ok"] = False
+        degraded_status["contract_errors"] = ["fixture contract error"]
+        degraded = build_supervisor_observation_packet(
+            goal_id=GOAL_ID,
+            supervisor=configured,
+            status_payload=degraded_status,
+            evidence_logs={AGENTS[2]: observation_evidence()},
+        )
+        assert degraded["ok"] is True, degraded
+        assert degraded["decision_input_complete"] is False, degraded
+        assert degraded["warnings"] == ["status_projection_degraded"], degraded
+        assert degraded["status_health"]["contract_error_count"] == 1, degraded
 
         decision = normalize_supervisor_decision(
             {
@@ -156,6 +287,28 @@ def main() -> int:
         assert cli_payload["supervisor_contract"]["supervised_agents"] == [
             AGENTS[2]
         ], cli_payload
+
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exit_code = cli_main(
+                [
+                    "--registry",
+                    str(registry_path),
+                    "--runtime-root",
+                    str(root / "runtime"),
+                    "supervisor-observe",
+                    "--format",
+                    "json",
+                    "--goal-id",
+                    GOAL_ID,
+                    "--agent-id",
+                    AGENTS[0],
+                ]
+            )
+        assert exit_code == 0, stdout.getvalue()
+        cli_observation = json.loads(stdout.getvalue())
+        assert cli_observation["schema_version"] == "supervisor_observation_v0"
+        assert [peer["agent_id"] for peer in cli_observation["peers"]] == [AGENTS[2]]
 
         try:
             configure_goal(

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -226,6 +226,7 @@ def main(argv: list[str] | None = None) -> int:
             "start-goal",
             "slash-commands",
             "heartbeat-prompt",
+            "supervisor-prompt",
             "sync-global",
             "uninstall-project",
             "version",

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -226,6 +226,7 @@ def main(argv: list[str] | None = None) -> int:
             "start-goal",
             "slash-commands",
             "heartbeat-prompt",
+            "supervisor-observe",
             "supervisor-prompt",
             "sync-global",
             "uninstall-project",

--- a/loopx/cli_commands/evidence_log.py
+++ b/loopx/cli_commands/evidence_log.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import argparse
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
 
-from ..control_plane.runtime.agent_scoped_evidence_log import build_agent_scoped_evidence_log
+from ..control_plane.runtime.agent_scoped_evidence_log import (
+    build_agent_scoped_evidence_log,
+    goal_history_runs,
+)
 from ..history import collect_history, load_registry
 from ..paths import resolve_runtime_root
 from ..rollout_event_log import load_rollout_events, rollout_event_log_path
@@ -59,16 +61,6 @@ def register_evidence_log_command(
         action="store_true",
         help="Return the thin public-safe shape. This is the only current mode and is accepted for clarity.",
     )
-
-
-def _goal_runs(history_payload: dict[str, Any], goal_id: str) -> list[dict[str, Any]]:
-    goals = history_payload.get("goals") if isinstance(history_payload.get("goals"), list) else []
-    for goal in goals:
-        if isinstance(goal, dict) and str(goal.get("id") or "") == goal_id:
-            latest_runs = goal.get("latest_runs")
-            return [dict(item) for item in latest_runs if isinstance(item, dict)] if isinstance(latest_runs, list) else []
-    runs = history_payload.get("runs") if isinstance(history_payload.get("runs"), list) else []
-    return [dict(item) for item in runs if isinstance(item, dict) and str(item.get("goal_id") or "") == goal_id]
 
 
 def render_evidence_log_markdown(payload: dict[str, object]) -> str:
@@ -164,7 +156,7 @@ def handle_evidence_log_command(
             event_kinds=args.event_kind,
             limit=max(0, int(args.limit)),
             rollout_events=rollout_events,
-            history_runs=_goal_runs(history_payload, args.goal_id),
+            history_runs=goal_history_runs(history_payload, args.goal_id),
         )
     except Exception as exc:
         payload = {

--- a/loopx/cli_commands/registry_admin.py
+++ b/loopx/cli_commands/registry_admin.py
@@ -314,6 +314,28 @@ def register_registry_admin_commands(subparsers: argparse._SubParsersAction) -> 
     )
     register_peer_runtime_arguments(configure_goal_parser)
     configure_goal_parser.add_argument(
+        "--supervisor-agent",
+        help=(
+            "Opt in one registered peer as a proposal-only supervisor. The peer keeps "
+            "equal identity authority and gains no implicit session-control rights."
+        ),
+    )
+    configure_goal_parser.add_argument(
+        "--supervised-agent",
+        dest="supervised_agents",
+        action="append",
+        default=None,
+        help=(
+            "Registered peer observed by the supervisor. Repeatable; defaults to every "
+            "registered peer except the supervisor."
+        ),
+    )
+    configure_goal_parser.add_argument(
+        "--clear-supervisor",
+        action="store_true",
+        help="Remove the optional coordination.supervisor configuration.",
+    )
+    configure_goal_parser.add_argument(
         "--write-scope",
         action="append",
         default=None,
@@ -564,6 +586,9 @@ def handle_registry_admin_command(
                 clear_registered_agents=bool(args.clear_registered_agents),
                 agent_model=args.agent_model,
                 automation_prompt_migration_ack=args.ack_automation_prompt_migration,
+                supervisor_agent=args.supervisor_agent,
+                supervised_agents=args.supervised_agents,
+                clear_supervisor=bool(args.clear_supervisor),
                 write_scope=args.write_scope,
                 replace_write_scope=bool(args.replace_write_scope),
                 clear_write_scope=bool(args.clear_write_scope),

--- a/loopx/cli_commands/support_control.py
+++ b/loopx/cli_commands/support_control.py
@@ -11,16 +11,22 @@ from ..agent_registry import (
     require_registered_agent_id,
 )
 from ..control_plane.agents.supervisor import (
+    build_supervisor_observation_packet,
     build_supervisor_prompt,
     peer_supervisor_for_goal,
+    render_supervisor_observation_markdown,
     render_supervisor_prompt_markdown,
+)
+from ..control_plane.runtime.agent_scoped_evidence_log import (
+    build_agent_scoped_evidence_log,
+    goal_history_runs,
 )
 from ..heartbeat_prompt import (
     build_heartbeat_prompt,
     build_heartbeat_prompt_error_payload,
     render_heartbeat_prompt_markdown,
 )
-from ..history import load_registry
+from ..history import collect_history, load_registry
 from ..paths import DEFAULT_RUNTIME_ROOT, global_registry_path, resolve_runtime_root
 from ..promotion_gate import build_promotion_gate, render_promotion_gate_markdown
 from ..registry import (
@@ -31,6 +37,7 @@ from ..registry import (
     render_registry_markdown,
     resolve_state_file,
 )
+from ..rollout_event_log import load_rollout_events, rollout_event_log_path
 from ..self_update import (
     build_rollback_plan,
     build_update_plan,
@@ -43,7 +50,7 @@ from ..state_backup import (
     execute_state_backup_plan,
     render_state_backup_markdown,
 )
-from ..status import render_status_markdown
+from ..status import collect_status, render_status_markdown
 from ..status_server import (
     DEFAULT_STATUS_HOST,
     DEFAULT_STATUS_PATH,
@@ -69,6 +76,7 @@ SUPPORT_CONTROL_COMMANDS = {
     "registry",
     "registry-boundary",
     "serve-status",
+    "supervisor-observe",
     "supervisor-prompt",
 }
 
@@ -257,6 +265,22 @@ def register_support_control_commands(
         "--cli-bin",
         default="loopx",
         help="Command name embedded in generated observation commands.",
+    )
+
+    supervisor_observe_parser = subparsers.add_parser(
+        "supervisor-observe",
+        help="Build one read-only supervisor packet over peer status and evidence.",
+    )
+    add_subcommand_format(supervisor_observe_parser)
+    supervisor_observe_parser.add_argument(
+        "--goal-id",
+        required=True,
+        help="Stable LoopX goal id.",
+    )
+    supervisor_observe_parser.add_argument(
+        "--agent-id",
+        required=True,
+        help="Registered peer configured as coordination.supervisor.agent_id.",
     )
 
     promotion_gate_parser = subparsers.add_parser(
@@ -544,6 +568,71 @@ def handle_support_control_command(
                 "error": str(exc),
             }
         print_payload(payload, output_format(args), render_supervisor_prompt_markdown)
+        return 0 if payload.get("ok") else 1
+
+    if args.command == "supervisor-observe":
+        try:
+            agent_registry_path = fallback_global_registry(registry_path, args.runtime_root)
+            agent_id = require_registered_agent_id(
+                registry_path=agent_registry_path,
+                goal_id=args.goal_id,
+                agent_id=args.agent_id,
+                field="agent_id",
+            )
+            goal = load_goal_from_registry(agent_registry_path, args.goal_id)
+            supervisor = peer_supervisor_for_goal(goal)
+            if supervisor is None:
+                raise ValueError("peer supervisor is disabled for this goal")
+            if supervisor.get("agent_id") != agent_id:
+                raise ValueError(
+                    f"agent_id={agent_id!r} is not the configured supervisor; "
+                    f"supervisor_agent={supervisor.get('agent_id')!r}"
+                )
+            registry = load_registry(agent_registry_path)
+            runtime_root = resolve_runtime_root(registry, args.runtime_root)
+            status_payload = collect_status(
+                registry_path=agent_registry_path,
+                runtime_root_override=str(runtime_root),
+                scan_roots=[Path(default_public_scan_root())],
+                limit=5,
+                goal_id=args.goal_id,
+            )
+            rollout_events = load_rollout_events(
+                rollout_event_log_path(runtime_root, args.goal_id),
+                limit=400,
+            )
+            history = collect_history(
+                registry_path=agent_registry_path,
+                runtime_root=runtime_root,
+                goal_id=args.goal_id,
+                limit=80,
+            )
+            history_runs = goal_history_runs(history, args.goal_id)
+            evidence_logs = {
+                peer: build_agent_scoped_evidence_log(
+                    goal_id=args.goal_id,
+                    agent_id=peer,
+                    rollout_events=rollout_events,
+                    history_runs=history_runs,
+                    limit=6,
+                )
+                for peer in supervisor.get("supervised_agents") or []
+            }
+            payload = build_supervisor_observation_packet(
+                goal_id=args.goal_id,
+                supervisor=supervisor,
+                status_payload=status_payload,
+                evidence_logs=evidence_logs,
+            )
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "schema_version": "supervisor_observation_v0",
+                "goal_id": args.goal_id,
+                "supervisor_agent_id": args.agent_id,
+                "error": str(exc),
+            }
+        print_payload(payload, output_format(args), render_supervisor_observation_markdown)
         return 0 if payload.get("ok") else 1
 
     if args.command == "promotion-gate":

--- a/loopx/cli_commands/support_control.py
+++ b/loopx/cli_commands/support_control.py
@@ -6,8 +6,14 @@ from pathlib import Path
 
 from ..agent_registry import (
     agent_profile_from_registry,
+    load_goal_from_registry,
     registered_agent_ids_from_registry,
     require_registered_agent_id,
+)
+from ..control_plane.agents.supervisor import (
+    build_supervisor_prompt,
+    peer_supervisor_for_goal,
+    render_supervisor_prompt_markdown,
 )
 from ..heartbeat_prompt import (
     build_heartbeat_prompt,
@@ -63,6 +69,7 @@ SUPPORT_CONTROL_COMMANDS = {
     "registry",
     "registry-boundary",
     "serve-status",
+    "supervisor-prompt",
 }
 
 
@@ -225,6 +232,31 @@ def register_support_control_commands(
         "--thin",
         action="store_true",
         help="Generate the thinnest generic dispatcher body for trusted agents that inspect LoopX state themselves.",
+    )
+
+    supervisor_prompt_parser = subparsers.add_parser(
+        "supervisor-prompt",
+        help="Generate the dedicated prompt for an opt-in proposal-only peer supervisor.",
+    )
+    add_subcommand_format(supervisor_prompt_parser)
+    supervisor_prompt_parser.add_argument(
+        "--goal-id",
+        required=True,
+        help="Stable LoopX goal id.",
+    )
+    supervisor_prompt_parser.add_argument(
+        "--agent-id",
+        required=True,
+        help="Registered peer configured as coordination.supervisor.agent_id.",
+    )
+    supervisor_prompt_parser.add_argument(
+        "--active-state",
+        help="Active goal state file. Defaults to the registry goal state_file.",
+    )
+    supervisor_prompt_parser.add_argument(
+        "--cli-bin",
+        default="loopx",
+        help="Command name embedded in generated observation commands.",
     )
 
     promotion_gate_parser = subparsers.add_parser(
@@ -394,12 +426,14 @@ def handle_support_control_command(
         registered_agents = None
         effective_agent_id = args.agent_id
         try:
-            active_state, resolved_active_state, active_state_source = resolve_heartbeat_active_state(
-                goal_id=args.goal_id,
-                active_state_arg=args.active_state,
-                registry_path=registry_path,
-                runtime_root_arg=args.runtime_root,
-                allow_global_goal_lookup_fallback=not registry_was_supplied,
+            active_state, resolved_active_state, active_state_source = (
+                resolve_heartbeat_active_state(
+                    goal_id=args.goal_id,
+                    active_state_arg=args.active_state,
+                    registry_path=registry_path,
+                    runtime_root_arg=args.runtime_root,
+                    allow_global_goal_lookup_fallback=not registry_was_supplied,
+                )
             )
             agent_registry_path = registry_path
             if active_state_source.startswith("registry:"):
@@ -459,6 +493,57 @@ def handle_support_control_command(
                 available_capabilities=args.available_capabilities,
             )
         print_payload(payload, output_format(args), render_heartbeat_prompt_markdown)
+        return 0 if payload.get("ok") else 1
+
+    if args.command == "supervisor-prompt":
+        try:
+            active_state, resolved_active_state, active_state_source = resolve_heartbeat_active_state(
+                goal_id=args.goal_id,
+                active_state_arg=args.active_state,
+                registry_path=registry_path,
+                runtime_root_arg=args.runtime_root,
+                allow_global_goal_lookup_fallback=not registry_was_supplied,
+            )
+            agent_registry_path = registry_path
+            if active_state_source.startswith("registry:"):
+                agent_registry_path = Path(active_state_source.removeprefix("registry:"))
+            agent_id = require_registered_agent_id(
+                registry_path=agent_registry_path,
+                goal_id=args.goal_id,
+                agent_id=args.agent_id,
+                field="agent_id",
+            )
+            goal = load_goal_from_registry(agent_registry_path, args.goal_id)
+            supervisor = peer_supervisor_for_goal(goal)
+            if supervisor is None:
+                raise ValueError(
+                    "peer supervisor is disabled; configure it with "
+                    "loopx configure-goal --supervisor-agent ... --execute"
+                )
+            if supervisor.get("agent_id") != agent_id:
+                raise ValueError(
+                    f"agent_id={agent_id!r} is not the configured supervisor; "
+                    f"supervisor_agent={supervisor.get('agent_id')!r}"
+                )
+            state_text = str(
+                resolved_active_state
+                or active_state
+                or "the registry-declared active state"
+            )
+            payload = build_supervisor_prompt(
+                goal_id=args.goal_id,
+                active_state=state_text,
+                supervisor=supervisor,
+                cli_bin=args.cli_bin,
+            )
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "goal_id": args.goal_id,
+                "agent_id": args.agent_id,
+                "error": str(exc),
+            }
+        print_payload(payload, output_format(args), render_supervisor_prompt_markdown)
         return 0 if payload.get("ok") else 1
 
     if args.command == "promotion-gate":

--- a/loopx/configure_goal.py
+++ b/loopx/configure_goal.py
@@ -26,17 +26,18 @@ from .orchestration import (
 from .quota import goal_quota_config
 from .registry import read_json, registry_goals
 from .control_plane.todos.contract import normalize_todo_claimed_by
-from .control_plane.agents.runtime_model import (
-    AgentRuntimeModel,
-    PEER_AGENT_RUNTIME_MIGRATION,
-    agent_runtime_model_for_goal,
+from .control_plane.agents.legacy_migration import (
     completed_peer_agent_runtime_migration,
     legacy_agent_hierarchy_present,
-    migrate_agent_profiles_to_peer_v1,
-    normalized_peer_agent_ids,
+    migrate_coordination_to_peer_v1,
     peer_agent_runtime_migration_completed,
     peer_agent_runtime_migration_id,
 )
+from .control_plane.agents.runtime_model import (
+    AgentRuntimeModel,
+    agent_runtime_model_for_goal,
+)
+from .control_plane.agents.supervisor import normalize_peer_supervisor
 
 
 WAITING_ON_CHOICES = (
@@ -180,6 +181,14 @@ def _settings_summary(goal: dict[str, Any]) -> dict[str, Any]:
         "peer_runtime_migration": deepcopy(
             completed_peer_agent_runtime_migration(goal)
         ),
+        "supervisor": deepcopy(
+            normalize_peer_supervisor(
+                coordination.get("supervisor"),
+                registered_agents=normalize_registered_agents(
+                    coordination.get("registered_agents")
+                ),
+            )
+        ),
     }
     return summary
 
@@ -278,6 +287,34 @@ def _build_heartbeat_prompt_migration(
     return payload
 
 
+def _build_supervisor_prompt_setup(
+    *,
+    goal_id: str,
+    changed_fields: list[str],
+    after: dict[str, Any],
+) -> dict[str, Any] | None:
+    if "supervisor" not in changed_fields:
+        return None
+    supervisor = after.get("supervisor")
+    if not isinstance(supervisor, dict):
+        return {
+            "schema_version": "supervisor_prompt_setup_v0",
+            "status": "disabled",
+            "command": None,
+        }
+    agent_id = str(supervisor.get("agent_id") or "")
+    return {
+        "schema_version": "supervisor_prompt_setup_v0",
+        "status": "ready",
+        "agent_id": agent_id,
+        "command": (
+            "loopx supervisor-prompt "
+            f"--goal-id {shlex.quote(goal_id)} "
+            f"--agent-id {shlex.quote(agent_id)}"
+        ),
+    }
+
+
 def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     descriptor, temporary = tempfile.mkstemp(
@@ -319,6 +356,9 @@ def configure_goal(
     clear_registered_agents: bool = False,
     agent_model: str | None = None,
     automation_prompt_migration_ack: str | None = None,
+    supervisor_agent: str | None = None,
+    supervised_agents: list[str] | None = None,
+    clear_supervisor: bool = False,
     write_scope: list[str] | None = None,
     replace_write_scope: bool = False,
     clear_write_scope: bool = False,
@@ -359,6 +399,13 @@ def configure_goal(
                 "--ack-automation-prompt-migration cannot change registered agents; "
                 "complete the runtime cutover first, then update the peer set separately"
             )
+    if clear_supervisor and (supervisor_agent or supervised_agents):
+        raise ValueError(
+            "--clear-supervisor cannot be combined with --supervisor-agent or "
+            "--supervised-agent"
+        )
+    if supervised_agents and not supervisor_agent:
+        raise ValueError("--supervised-agent requires --supervisor-agent")
     if clear_write_scope and write_scope:
         raise ValueError("--clear-write-scope cannot be combined with --write-scope")
     if replace_write_scope and not write_scope:
@@ -414,6 +461,7 @@ def configure_goal(
         if allowed_domains:
             raise ValueError("--multi-subagent-feature off cannot be combined with --allowed-domain")
     registered_agents = _clean_registered_agents(registered_agents)
+    supervised_agents = _clean_registered_agents(supervised_agents)
     write_scope = _clean_write_scope(write_scope)
     issue_fix_reviewer_notification_config = _local_private_config_path(
         issue_fix_reviewer_notification_config
@@ -582,6 +630,9 @@ def configure_goal(
         or registered_agents is not None
         or agent_model is not None
         or automation_prompt_migration_ack is not None
+        or supervisor_agent is not None
+        or supervised_agents is not None
+        or clear_supervisor
         or write_scope is not None
         or clear_write_scope
         or clear_boundary_authority
@@ -592,34 +643,32 @@ def configure_goal(
         if clear_registered_agents:
             coordination.pop("registered_agents", None)
             coordination.pop("agent_model", None)
+            coordination.pop("supervisor", None)
         elif registered_agents is not None:
             coordination["registered_agents"] = registered_agents
         if not clear_registered_agents:
             coordination["agent_model"] = effective_agent_model
         if automation_prompt_migration_ack is not None and not migration_already_completed:
-            coordination.pop("primary_agent", None)
-            coordination.pop("side_agent_handoff_agent", None)
-            coordination["registered_agents"] = normalized_peer_agent_ids(
-                coordination.get("registered_agents") or []
+            coordination = migrate_coordination_to_peer_v1(
+                coordination,
+                migration_id=automation_prompt_migration_ack,
+                completed_at=_now_iso() if execute else None,
             )
-            migrated_profiles = migrate_agent_profiles_to_peer_v1(
-                coordination.get("agent_profiles")
+        if clear_supervisor:
+            coordination.pop("supervisor", None)
+        elif supervisor_agent is not None:
+            normalized_supervisor_agent = normalize_todo_claimed_by(supervisor_agent)
+            if not normalized_supervisor_agent:
+                raise ValueError("--supervisor-agent must be a registered agent id")
+            coordination["supervisor"] = normalize_peer_supervisor(
+                {
+                    "agent_id": normalized_supervisor_agent,
+                    "supervised_agents": supervised_agents,
+                },
+                registered_agents=normalize_registered_agents(
+                    coordination.get("registered_agents")
+                ),
             )
-            if migrated_profiles:
-                coordination["agent_profiles"] = migrated_profiles
-            else:
-                coordination.pop("agent_profiles", None)
-            completed_migrations = (
-                coordination.get("completed_migrations")
-                if isinstance(coordination.get("completed_migrations"), dict)
-                else {}
-            )
-            completed_migrations[PEER_AGENT_RUNTIME_MIGRATION] = {
-                "migration_id": automation_prompt_migration_ack,
-                "status": "completed",
-                "completed_at": _now_iso() if execute else None,
-            }
-            coordination["completed_migrations"] = completed_migrations
         if clear_write_scope:
             coordination["write_scope"] = []
         elif write_scope is not None:
@@ -699,6 +748,7 @@ def configure_goal(
                 (after.get("orchestration") or {}).get("explore_harness")
                 or {"enabled": False}
             ),
+            "peer_supervisor": deepcopy(after.get("supervisor") or {"enabled": False}),
             "default": "off",
             "configuration_entry": "multi_subagent_feature",
         },
@@ -714,6 +764,11 @@ def configure_goal(
                 else None
             ),
             migration_acknowledged=automation_prompt_migration_ack is not None,
+        ),
+        "supervisor_prompt": _build_supervisor_prompt_setup(
+            goal_id=goal_id,
+            changed_fields=changed_fields,
+            after=after,
         ),
     }
 
@@ -747,6 +802,12 @@ def render_configure_goal_markdown(payload: dict[str, Any]) -> str:
             if harness.get("profile"):
                 harness_state += f"({harness.get('profile')})"
             lines.append(f"- feature_explore_harness: `{harness_state}`")
+        supervisor = feature_summary.get("peer_supervisor")
+        if isinstance(supervisor, dict):
+            supervisor_state = "on" if supervisor.get("enabled") else "off"
+            if supervisor.get("agent_id"):
+                supervisor_state += f"({supervisor.get('agent_id')})"
+            lines.append(f"- feature_peer_supervisor: `{supervisor_state}`")
     migration = payload.get("heartbeat_prompt_migration")
     if isinstance(migration, dict):
         lines.append(f"- heartbeat_prompt_migration: {migration.get('action')}")
@@ -756,6 +817,11 @@ def render_configure_goal_markdown(payload: dict[str, Any]) -> str:
             lines.append(
                 f"  - {command.get('agent_id')}: `{command.get('command')}`"
             )
+    supervisor_prompt = payload.get("supervisor_prompt")
+    if isinstance(supervisor_prompt, dict):
+        lines.append(f"- supervisor_prompt_status: `{supervisor_prompt.get('status')}`")
+        if supervisor_prompt.get("command"):
+            lines.append(f"- supervisor_prompt: `{supervisor_prompt.get('command')}`")
     activation = payload.get("host_loop_activation")
     if isinstance(activation, dict):
         lines.append(

--- a/loopx/control_plane/agents/identity.py
+++ b/loopx/control_plane/agents/identity.py
@@ -4,13 +4,12 @@ from typing import Any
 
 from ...agent_registry import registered_agent_ids_for_goal
 from ..todos.contract import normalize_todo_claimed_by
-from .runtime_model import (
-    PEER_AGENT_IDENTITY_SCHEMA_VERSION,
-    agent_runtime_model_for_goal,
+from .legacy_migration import (
     legacy_agent_hierarchy_present,
     peer_agent_runtime_migration_completed,
     peer_agent_runtime_migration_id,
 )
+from .runtime_model import PEER_AGENT_IDENTITY_SCHEMA_VERSION, agent_runtime_model_for_goal
 
 
 def quota_registered_agents(goal: dict[str, Any]) -> list[str]:

--- a/loopx/control_plane/agents/legacy_migration.py
+++ b/loopx/control_plane/agents/legacy_migration.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping
+
+from ..todos.contract import normalize_todo_claimed_by
+from .runtime_model import (
+    PEER_AGENT_PROFILE_SCHEMA_VERSION,
+    normalized_peer_agent_ids,
+)
+
+
+PEER_AGENT_RUNTIME_MIGRATION = "peer_agent_runtime_v1"
+LEGACY_AGENT_PROFILE_SCHEMA_VERSION = "agent_profile_v0"
+LEGACY_HIERARCHY_ROLES = {"primary-agent", "side-agent"}
+
+
+def legacy_agent_hierarchy_present(goal: Mapping[str, Any] | None) -> bool:
+    """Detect v0.1 input only for the isolated migration path."""
+
+    if not isinstance(goal, Mapping):
+        return False
+    coordination = goal.get("coordination")
+    if not isinstance(coordination, Mapping):
+        return False
+    profiles = coordination.get("agent_profiles")
+    profile_items = (
+        profiles.values()
+        if isinstance(profiles, Mapping)
+        else profiles
+        if isinstance(profiles, list)
+        else []
+    )
+    legacy_profile_present = any(
+        isinstance(profile, Mapping)
+        and (
+            profile.get("schema_version") == LEGACY_AGENT_PROFILE_SCHEMA_VERSION
+            or profile.get("role") in LEGACY_HIERARCHY_ROLES
+            or profile.get("primary_agent")
+            or (
+                isinstance(profile.get("review_policy"), Mapping)
+                and (
+                    profile["review_policy"].get("handoff_agent")
+                    or profile["review_policy"].get("reviews_side_agent_work")
+                )
+            )
+        )
+        for profile in profile_items
+    )
+    return bool(
+        coordination.get("primary_agent")
+        or coordination.get("side_agent_handoff_agent")
+        or coordination.get("agent_model") == "legacy_hierarchy"
+        or legacy_profile_present
+    )
+
+
+def peer_agent_runtime_migration_id(
+    goal_id: str,
+    goal: Mapping[str, Any] | None,
+) -> str:
+    coordination = goal.get("coordination") if isinstance(goal, Mapping) else None
+    registered_agents = (
+        normalized_peer_agent_ids(coordination.get("registered_agents") or [])
+        if isinstance(coordination, Mapping)
+        else []
+    )
+    encoded = json.dumps(
+        {
+            "goal_id": str(goal_id),
+            "migration": PEER_AGENT_RUNTIME_MIGRATION,
+            "registered_agents": registered_agents,
+        },
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:16]
+    return f"peer_runtime_v1_{digest}"
+
+
+def completed_peer_agent_runtime_migration(
+    goal: Mapping[str, Any] | None,
+) -> Mapping[str, Any] | None:
+    if not isinstance(goal, Mapping):
+        return None
+    coordination = goal.get("coordination")
+    if not isinstance(coordination, Mapping):
+        return None
+    completed = coordination.get("completed_migrations")
+    if not isinstance(completed, Mapping):
+        return None
+    migration = completed.get(PEER_AGENT_RUNTIME_MIGRATION)
+    return migration if isinstance(migration, Mapping) else None
+
+
+def peer_agent_runtime_migration_completed(
+    goal: Mapping[str, Any] | None,
+) -> bool:
+    migration = completed_peer_agent_runtime_migration(goal)
+    return bool(migration and migration.get("status") == "completed")
+
+
+def migrate_agent_profiles_to_peer_v1(raw_profiles: Any) -> dict[str, dict[str, Any]]:
+    """Normalize advisory profiles while deleting v0.1 hierarchy policy."""
+
+    if isinstance(raw_profiles, Mapping):
+        candidates = [(key, value) for key, value in raw_profiles.items()]
+    elif isinstance(raw_profiles, list):
+        candidates = [
+            (
+                value.get("agent_id") or value.get("id") or value.get("name"),
+                value,
+            )
+            for value in raw_profiles
+            if isinstance(value, Mapping)
+        ]
+    else:
+        return {}
+    migrated: dict[str, dict[str, Any]] = {}
+    for raw_agent_id, raw_profile in candidates:
+        agent_id = normalize_todo_claimed_by(raw_agent_id)
+        if not agent_id or not isinstance(raw_profile, Mapping):
+            continue
+        profile = dict(raw_profile)
+        legacy_role = str(profile.pop("role", "") or "").strip()
+        profile.pop("primary_agent", None)
+        profile["schema_version"] = PEER_AGENT_PROFILE_SCHEMA_VERSION
+        profile["agent_id"] = agent_id
+        if legacy_role and legacy_role not in LEGACY_HIERARCHY_ROLES:
+            profile.setdefault("profile_role", legacy_role)
+        profile.pop("worktree_policy", None)
+        profile.pop("review_policy", None)
+        migrated[agent_id] = profile
+    return migrated
+
+
+def migrate_coordination_to_peer_v1(
+    coordination: Mapping[str, Any],
+    *,
+    migration_id: str,
+    completed_at: str | None,
+) -> dict[str, Any]:
+    """Apply the isolated hierarchy cleanup after host prompt migration."""
+
+    migrated = dict(coordination)
+    migrated.pop("primary_agent", None)
+    migrated.pop("side_agent_handoff_agent", None)
+    migrated["registered_agents"] = normalized_peer_agent_ids(
+        migrated.get("registered_agents") or []
+    )
+    profiles = migrate_agent_profiles_to_peer_v1(migrated.get("agent_profiles"))
+    if profiles:
+        migrated["agent_profiles"] = profiles
+    else:
+        migrated.pop("agent_profiles", None)
+    completed_migrations = (
+        dict(migrated.get("completed_migrations"))
+        if isinstance(migrated.get("completed_migrations"), Mapping)
+        else {}
+    )
+    completed_migrations[PEER_AGENT_RUNTIME_MIGRATION] = {
+        "migration_id": migration_id,
+        "status": "completed",
+        "completed_at": completed_at,
+    }
+    migrated["completed_migrations"] = completed_migrations
+    return migrated

--- a/loopx/control_plane/agents/legacy_migration.py
+++ b/loopx/control_plane/agents/legacy_migration.py
@@ -36,7 +36,7 @@ def legacy_agent_hierarchy_present(goal: Mapping[str, Any] | None) -> bool:
         isinstance(profile, Mapping)
         and (
             profile.get("schema_version") == LEGACY_AGENT_PROFILE_SCHEMA_VERSION
-            or profile.get("role") in LEGACY_HIERARCHY_ROLES
+            or "role" in profile
             or profile.get("primary_agent")
             or (
                 isinstance(profile.get("review_policy"), Mapping)

--- a/loopx/control_plane/agents/runtime_model.py
+++ b/loopx/control_plane/agents/runtime_model.py
@@ -9,10 +9,7 @@ from ..todos.contract import normalize_todo_claimed_by
 
 
 PEER_AGENT_IDENTITY_SCHEMA_VERSION = "peer_agent_identity_v1"
-PEER_AGENT_RUNTIME_MIGRATION = "peer_agent_runtime_v1"
 PEER_AGENT_PROFILE_SCHEMA_VERSION = "agent_profile_v1"
-LEGACY_AGENT_PROFILE_SCHEMA_VERSION = "agent_profile_v0"
-LEGACY_HIERARCHY_ROLES = {"primary-agent", "side-agent"}
 
 
 class AgentRuntimeModel(str, Enum):
@@ -20,11 +17,7 @@ class AgentRuntimeModel(str, Enum):
 
 
 def agent_runtime_model_for_goal(goal: Mapping[str, Any] | None) -> AgentRuntimeModel:
-    """Return the only live agent runtime model.
-
-    v0.1 hierarchy fields may still exist in registry snapshots until the
-    explicit migration writes them out. They never select hierarchy behavior.
-    """
+    """Return the only live agent runtime model."""
 
     if isinstance(goal, Mapping):
         coordination = goal.get("coordination")
@@ -33,94 +26,6 @@ def agent_runtime_model_for_goal(goal: Mapping[str, Any] | None) -> AgentRuntime
         if raw not in {None, "", AgentRuntimeModel.PEER_V1.value, "legacy_hierarchy"}:
             raise ValueError("coordination.agent_model must be peer_v1")
     return AgentRuntimeModel.PEER_V1
-
-
-def legacy_agent_hierarchy_present(goal: Mapping[str, Any] | None) -> bool:
-    """Detect v0.1 registry input for migration/status warnings only."""
-
-    if not isinstance(goal, Mapping):
-        return False
-    coordination = goal.get("coordination")
-    if not isinstance(coordination, Mapping):
-        return False
-    profiles = coordination.get("agent_profiles")
-    profile_items = (
-        profiles.values()
-        if isinstance(profiles, Mapping)
-        else profiles
-        if isinstance(profiles, list)
-        else []
-    )
-    legacy_profile_present = any(
-        isinstance(profile, Mapping)
-        and (
-            profile.get("schema_version") == LEGACY_AGENT_PROFILE_SCHEMA_VERSION
-            or profile.get("role") in LEGACY_HIERARCHY_ROLES
-            or profile.get("primary_agent")
-            or (
-                isinstance(profile.get("review_policy"), Mapping)
-                and (
-                    profile["review_policy"].get("handoff_agent")
-                    or profile["review_policy"].get("reviews_side_agent_work")
-                )
-            )
-        )
-        for profile in profile_items
-    )
-    return bool(
-        coordination.get("primary_agent")
-        or coordination.get("side_agent_handoff_agent")
-        or coordination.get("agent_model") == "legacy_hierarchy"
-        or legacy_profile_present
-    )
-
-
-def peer_agent_runtime_migration_id(
-    goal_id: str,
-    goal: Mapping[str, Any] | None,
-) -> str:
-    """Return the stable idempotency key for the v0.1 -> peer_v1 cutover."""
-
-    coordination = goal.get("coordination") if isinstance(goal, Mapping) else None
-    registered_agents = (
-        normalized_peer_agent_ids(coordination.get("registered_agents") or [])
-        if isinstance(coordination, Mapping)
-        else []
-    )
-    encoded = json.dumps(
-        {
-            "goal_id": str(goal_id),
-            "migration": PEER_AGENT_RUNTIME_MIGRATION,
-            "registered_agents": registered_agents,
-        },
-        ensure_ascii=True,
-        sort_keys=True,
-        separators=(",", ":"),
-    )
-    digest = hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:16]
-    return f"peer_runtime_v1_{digest}"
-
-
-def completed_peer_agent_runtime_migration(
-    goal: Mapping[str, Any] | None,
-) -> Mapping[str, Any] | None:
-    if not isinstance(goal, Mapping):
-        return None
-    coordination = goal.get("coordination")
-    if not isinstance(coordination, Mapping):
-        return None
-    completed = coordination.get("completed_migrations")
-    if not isinstance(completed, Mapping):
-        return None
-    migration = completed.get(PEER_AGENT_RUNTIME_MIGRATION)
-    return migration if isinstance(migration, Mapping) else None
-
-
-def peer_agent_runtime_migration_completed(
-    goal: Mapping[str, Any] | None,
-) -> bool:
-    migration = completed_peer_agent_runtime_migration(goal)
-    return bool(migration and migration.get("status") == "completed")
 
 
 def agent_identity_is_peer(agent_identity: Mapping[str, Any] | None) -> bool:
@@ -146,43 +51,6 @@ def normalized_peer_agent_ids(values: Iterable[Any]) -> list[str]:
         }
     )
     return agents
-
-
-def migrate_agent_profiles_to_peer_v1(raw_profiles: Any) -> dict[str, dict[str, Any]]:
-    """Normalize advisory profiles while deleting v0.1 hierarchy policy."""
-
-    if isinstance(raw_profiles, Mapping):
-        candidates = [(key, value) for key, value in raw_profiles.items()]
-    elif isinstance(raw_profiles, list):
-        candidates = [
-            (
-                value.get("agent_id") or value.get("id") or value.get("name"),
-                value,
-            )
-            for value in raw_profiles
-            if isinstance(value, Mapping)
-        ]
-    else:
-        return {}
-    migrated: dict[str, dict[str, Any]] = {}
-    for raw_agent_id, raw_profile in candidates:
-        agent_id = normalize_todo_claimed_by(raw_agent_id)
-        if not agent_id or not isinstance(raw_profile, Mapping):
-            continue
-        profile = dict(raw_profile)
-        legacy_role = str(profile.pop("role", "") or "").strip()
-        profile.pop("primary_agent", None)
-        profile["schema_version"] = PEER_AGENT_PROFILE_SCHEMA_VERSION
-        profile["agent_id"] = agent_id
-        if legacy_role and legacy_role not in LEGACY_HIERARCHY_ROLES:
-            profile.setdefault("profile_role", legacy_role)
-        # Workspace isolation, merge eligibility, and review routing are task
-        # and repository policy. Carrying them in identity profiles recreates
-        # rank by another name.
-        profile.pop("worktree_policy", None)
-        profile.pop("review_policy", None)
-        migrated[agent_id] = profile
-    return migrated
 
 
 def peer_work_key(value: Mapping[str, Any] | None, *, fallback: str) -> str:

--- a/loopx/control_plane/agents/supervisor.py
+++ b/loopx/control_plane/agents/supervisor.py
@@ -12,6 +12,7 @@ from ..todos.contract import normalize_todo_claimed_by
 PEER_SUPERVISOR_SCHEMA_VERSION = "peer_supervisor_v0"
 SUPERVISOR_CONTRACT_SCHEMA_VERSION = "peer_supervisor_contract_v0"
 SUPERVISOR_DECISION_SCHEMA_VERSION = "supervisor_decision_v0"
+SUPERVISOR_OBSERVATION_SCHEMA_VERSION = "supervisor_observation_v0"
 
 
 class SupervisorDecisionKind(str, Enum):
@@ -176,6 +177,163 @@ def build_peer_supervisor_contract(
     }
 
 
+def _goal_attention_item(status_payload: Mapping[str, Any], goal_id: str) -> dict[str, Any]:
+    attention = status_payload.get("attention_queue")
+    items = attention.get("items") if isinstance(attention, Mapping) else None
+    if not isinstance(items, list):
+        return {}
+    return next(
+        (
+            dict(item)
+            for item in items
+            if isinstance(item, Mapping) and str(item.get("goal_id") or "") == goal_id
+        ),
+        {},
+    )
+
+
+def _agent_management_items(status_payload: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    projection = status_payload.get("agent_management_projection")
+    items = projection.get("agents") if isinstance(projection, Mapping) else None
+    if not isinstance(items, list):
+        return {}
+    return {
+        agent_id: dict(item)
+        for item in items
+        if isinstance(item, Mapping)
+        for agent_id in [normalize_todo_claimed_by(item.get("agent_id"))]
+        if agent_id
+    }
+
+
+def _evidence_refs(
+    member: Mapping[str, Any],
+    evidence_log: Mapping[str, Any],
+) -> list[str]:
+    refs = [
+        str(value)
+        for value in member.get("evidence_refs") or []
+        if isinstance(value, str) and value.strip()
+    ]
+    ledger = evidence_log.get("ledger")
+    for row in ledger if isinstance(ledger, list) else []:
+        if not isinstance(row, Mapping):
+            continue
+        candidates = (
+            ("rollout_event", row.get("event_id")),
+            ("runtime_run", row.get("run_id")),
+            ("run_history", row.get("run_ref")),
+        )
+        for kind, raw_value in candidates:
+            value = " ".join(str(raw_value or "").split())
+            ref = f"{kind}:{value}" if value else ""
+            if ref and ref not in refs:
+                refs.append(ref)
+    return refs[:8]
+
+
+def build_supervisor_observation_packet(
+    *,
+    goal_id: str,
+    supervisor: Mapping[str, Any],
+    status_payload: Mapping[str, Any],
+    evidence_logs: Mapping[str, Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Build one read-only public-safe supervisor input over existing projections."""
+
+    contract = build_peer_supervisor_contract(goal_id=goal_id, supervisor=supervisor)
+    attention = _goal_attention_item(status_payload, goal_id)
+    members = _agent_management_items(status_payload)
+    warnings = []
+    if status_payload.get("ok") is not True:
+        warnings.append("status_projection_degraded")
+    if not attention:
+        warnings.append(f"missing_goal_status:{goal_id}")
+    peer_rows = []
+    for agent_id in contract["supervised_agents"]:
+        member = members.get(agent_id, {})
+        evidence = evidence_logs.get(agent_id, {})
+        ledger = evidence.get("ledger") if isinstance(evidence.get("ledger"), list) else []
+        if not member:
+            warnings.append(f"missing_agent_status:{agent_id}")
+        if evidence.get("ok") is not True:
+            warnings.append(f"missing_evidence_log:{agent_id}")
+        current_todo = member.get("current_todo")
+        peer_rows.append(
+            {
+                "agent_id": agent_id,
+                "state": member.get("state") or "unknown",
+                "current_todo": dict(current_todo) if isinstance(current_todo, Mapping) else None,
+                "next_action": member.get("next_action"),
+                "last_activity_at": member.get("last_activity_at"),
+                "workspace_ref": member.get("workspace_ref"),
+                "handoff_refs": list(member.get("handoff_refs") or [])[:4],
+                "stale_claim_hint": member.get("stale_claim_hint"),
+                "evidence": {
+                    "ledger_count": int(evidence.get("ledger_count") or 0),
+                    "matched_count": int(evidence.get("matched_count") or 0),
+                    "truncated": evidence.get("truncated") is True,
+                    "latest_recorded_at": ledger[0].get("recorded_at") if ledger else None,
+                    "latest_rows": [dict(row) for row in ledger[:3] if isinstance(row, Mapping)],
+                    "effect_refs": _evidence_refs(member, evidence),
+                },
+            }
+        )
+    project_asset = attention.get("project_asset")
+    raw_user_todos = (
+        project_asset.get("user_todos")
+        if isinstance(project_asset, Mapping)
+        else None
+    )
+    if not isinstance(raw_user_todos, Mapping):
+        raw_user_todos = attention.get("user_todos")
+    user_todos = raw_user_todos if isinstance(raw_user_todos, Mapping) else {}
+    generated_at = None
+    management = status_payload.get("agent_management_projection")
+    if isinstance(management, Mapping):
+        generated_at = management.get("generated_at")
+    return {
+        "ok": True,
+        "schema_version": SUPERVISOR_OBSERVATION_SCHEMA_VERSION,
+        "mode": "read_only",
+        "goal_id": goal_id,
+        "supervisor_agent_id": contract["supervisor_agent_id"],
+        "observed_at": generated_at,
+        "status_health": {
+            "ok": status_payload.get("ok") is True,
+            "contract_error_count": int(
+                status_payload.get("contract_errors_total_count")
+                or len(status_payload.get("contract_errors") or [])
+            ),
+            "contract_warning_count": int(
+                status_payload.get("contract_warnings_total_count")
+                or len(status_payload.get("contract_warnings") or [])
+            ),
+        },
+        "goal": {
+            "status": attention.get("status"),
+            "waiting_on": attention.get("waiting_on"),
+            "severity": attention.get("severity"),
+            "recommended_action": attention.get("recommended_action"),
+            "user_open_count": int(
+                user_todos.get("open") or user_todos.get("open_count") or 0
+            ),
+        },
+        "peers": peer_rows,
+        "warnings": warnings,
+        "decision_input_complete": not warnings,
+        "decision_contract": contract["decision_contract"],
+        "execution_policy": contract["execution_policy"],
+        "boundary": {
+            "source": "LoopX public-safe status and agent evidence projections",
+            "raw_logs_included": False,
+            "raw_trajectories_included": False,
+            "raw_transcripts_included": False,
+            "write_authority": "none",
+        },
+    }
+
+
 def normalize_supervisor_decision(
     raw: Mapping[str, Any],
     *,
@@ -237,21 +395,10 @@ def build_supervisor_prompt(
         supervisor=supervisor,
     )
     agent_id = str(contract["supervisor_agent_id"])
-    supervised_agents = list(contract["supervised_agents"])
-    status_commands = [
-        (
-            f"{cli_bin} --format json status --goal-id "
-            f"{shlex.quote(goal_id)} --agent-id {shlex.quote(peer)}"
-        )
-        for peer in supervised_agents
-    ]
-    evidence_commands = [
-        (
-            f"{cli_bin} --format json evidence-log --goal-id "
-            f"{shlex.quote(goal_id)} --agent-id {shlex.quote(peer)} --thin"
-        )
-        for peer in supervised_agents
-    ]
+    observe_command = (
+        f"{cli_bin} --format json supervisor-observe --goal-id "
+        f"{shlex.quote(goal_id)} --agent-id {shlex.quote(agent_id)}"
+    )
     decision_template = {
         "schema_version": SUPERVISOR_DECISION_SCHEMA_VERSION,
         "decision_id": "<stable_public_safe_id>",
@@ -275,15 +422,13 @@ The user may use this task as the preferred synthesis channel while several
 peers run, but may still talk to any peer. Keep all user decisions and gates in
 LoopX state so every peer sees the same authority.
 
-Run your own quota guard. Then read each supervised peer through its read-only
-agent status projection and thin evidence log. Do not impersonate another
-peer's quota guard. Prefer compact runtime effect references over raw
-transcripts or private logs:
+Run your own quota guard. Then read one supervisor observation packet assembled
+from read-only agent status and thin evidence projections. Do not impersonate
+another peer's quota guard or reconstruct this packet from raw transcripts:
 
 ```bash
 {cli_bin} --format json quota should-run --goal-id {shlex.quote(goal_id)} --agent-id {shlex.quote(agent_id)}
-{chr(10).join(status_commands)}
-{chr(10).join(evidence_commands)}
+{observe_command}
 ```
 
 Compare the peers' claimed work, evidence freshness, blockers, workspace state,
@@ -313,8 +458,48 @@ resolved.
         "active_state": active_state,
         "agent_id": agent_id,
         "supervisor_contract": contract,
+        "observe_command": observe_command,
         "task_body": task_body,
     }
+
+
+def render_supervisor_observation_markdown(payload: dict[str, Any]) -> str:
+    if not payload.get("ok"):
+        return "\n".join(
+            [
+                "# LoopX Supervisor Observation",
+                "",
+                "- ok: `False`",
+                f"- error: {payload.get('error') or 'unknown error'}",
+            ]
+        )
+    lines = [
+        "# LoopX Supervisor Observation",
+        "",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- supervisor_agent_id: `{payload.get('supervisor_agent_id')}`",
+        f"- observed_at: `{payload.get('observed_at') or ''}`",
+        f"- decision_input_complete: `{payload.get('decision_input_complete')}`",
+        f"- warning_count: `{len(payload.get('warnings') or [])}`",
+        "",
+        "## Peers",
+        "",
+    ]
+    for peer in payload.get("peers") or []:
+        if not isinstance(peer, dict):
+            continue
+        current_todo = peer.get("current_todo") or {}
+        evidence = peer.get("evidence") or {}
+        lines.append(
+            f"- `{peer.get('agent_id')}` state=`{peer.get('state')}` "
+            f"todo=`{current_todo.get('todo_id') or ''}` "
+            f"evidence=`{evidence.get('ledger_count') or 0}`"
+        )
+    warnings = payload.get("warnings") or []
+    if warnings:
+        lines.extend(["", "## Warnings", ""])
+        lines.extend(f"- `{warning}`" for warning in warnings)
+    return "\n".join(lines)
 
 
 def render_supervisor_prompt_markdown(payload: dict[str, Any]) -> str:

--- a/loopx/control_plane/agents/supervisor.py
+++ b/loopx/control_plane/agents/supervisor.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+import json
+import shlex
+from enum import Enum
+from typing import Any, Mapping
+
+from ...agent_registry import normalize_registered_agents
+from ..todos.contract import normalize_todo_claimed_by
+
+
+PEER_SUPERVISOR_SCHEMA_VERSION = "peer_supervisor_v0"
+SUPERVISOR_CONTRACT_SCHEMA_VERSION = "peer_supervisor_contract_v0"
+SUPERVISOR_DECISION_SCHEMA_VERSION = "supervisor_decision_v0"
+
+
+class SupervisorDecisionKind(str, Enum):
+    OBSERVE = "observe"
+    INJECT = "inject"
+    HANDOFF = "handoff"
+    DISCARD = "discard"
+
+
+HOST_CAPABILITIES_BY_DECISION = {
+    SupervisorDecisionKind.OBSERVE.value: [],
+    SupervisorDecisionKind.INJECT.value: ["session_message_injection"],
+    SupervisorDecisionKind.HANDOFF.value: [
+        "session_state_fork",
+        "workspace_state_transfer",
+    ],
+    SupervisorDecisionKind.DISCARD.value: ["session_termination"],
+}
+
+
+def _normalized_tokens(values: Any, *, field: str) -> list[str]:
+    if not isinstance(values, list):
+        raise ValueError(f"{field} must be a list")
+    normalized = []
+    for value in values:
+        token = normalize_todo_claimed_by(value)
+        if not token:
+            raise ValueError(f"{field} must contain public-safe tokens")
+        if token not in normalized:
+            normalized.append(token)
+    if not normalized:
+        raise ValueError(f"{field} must not be empty")
+    return normalized
+
+
+def _required_text(payload: Mapping[str, Any], field: str, *, limit: int = 400) -> str:
+    value = " ".join(str(payload.get(field) or "").strip().split())
+    if not value:
+        raise ValueError(f"{field} is required")
+    if len(value) > limit:
+        raise ValueError(f"{field} exceeds {limit} characters")
+    return value
+
+
+def normalize_peer_supervisor(
+    raw: Any,
+    *,
+    registered_agents: list[str] | tuple[str, ...],
+) -> dict[str, Any] | None:
+    if raw in (None, {}):
+        return None
+    if not isinstance(raw, Mapping):
+        raise ValueError("coordination.supervisor must be an object")
+    if raw.get("enabled") is False:
+        return None
+
+    registered = normalize_registered_agents(list(registered_agents))
+    agent_id = normalize_todo_claimed_by(raw.get("agent_id"))
+    if not agent_id:
+        raise ValueError("coordination.supervisor.agent_id must be a registered agent id")
+    if agent_id not in registered:
+        raise ValueError(
+            f"supervisor agent_id={agent_id!r} is not registered; "
+            f"registered_agents={', '.join(registered)}"
+        )
+
+    raw_supervised = raw.get("supervised_agents")
+    supervised = (
+        normalize_registered_agents(raw_supervised)
+        if raw_supervised is not None
+        else [agent for agent in registered if agent != agent_id]
+    )
+    if agent_id in supervised:
+        raise ValueError("a supervisor cannot supervise its own agent session")
+    unknown = [agent for agent in supervised if agent not in registered]
+    if unknown:
+        raise ValueError(
+            "supervised agents must be registered peers; unknown=" + ", ".join(unknown)
+        )
+    if not supervised:
+        raise ValueError("a supervisor requires at least one other supervised peer")
+
+    return {
+        "schema_version": PEER_SUPERVISOR_SCHEMA_VERSION,
+        "enabled": True,
+        "agent_id": agent_id,
+        "supervised_agents": supervised,
+        "execution_mode": "proposal_only",
+    }
+
+
+def peer_supervisor_for_goal(goal: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(goal, Mapping):
+        return None
+    coordination = goal.get("coordination")
+    if not isinstance(coordination, Mapping):
+        return None
+    return normalize_peer_supervisor(
+        coordination.get("supervisor"),
+        registered_agents=normalize_registered_agents(
+            coordination.get("registered_agents")
+        ),
+    )
+
+
+def build_peer_supervisor_contract(
+    *,
+    goal_id: str,
+    supervisor: Mapping[str, Any],
+) -> dict[str, Any]:
+    agent_id = str(supervisor.get("agent_id") or "")
+    supervised_agents = normalize_registered_agents(
+        supervisor.get("supervised_agents")
+    )
+    return {
+        "schema_version": SUPERVISOR_CONTRACT_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "supervisor_agent_id": agent_id,
+        "supervised_agents": supervised_agents,
+        "peer_authority": "equal_identity_authority",
+        "supervisor_authority": "proposal_only",
+        "user_interaction": {
+            "recommended_channel": agent_id,
+            "reason": "one synthesis channel is useful while several peers run",
+            "user_may_interact_with_any_peer": True,
+            "user_gates_remain_loopx_state": True,
+        },
+        "observation_sources": [
+            "goal_status",
+            "supervisor_quota_contract",
+            "agent_status_projections",
+            "todo_projection",
+            "agent_evidence_logs",
+            "compact_runtime_effect_refs",
+        ],
+        "decision_contract": {
+            "schema_version": SUPERVISOR_DECISION_SCHEMA_VERSION,
+            "kinds": [kind.value for kind in SupervisorDecisionKind],
+            "required_fields": [
+                "decision_id",
+                "kind",
+                "reason_codes",
+                "evidence_refs",
+                "execution_status",
+            ],
+            "conditional_fields": {
+                "inject": ["target_agent_id", "message"],
+                "handoff": [
+                    "source_agent_id",
+                    "target_agent_id",
+                    "state_ref",
+                ],
+                "discard": ["target_agent_id", "state_ref"],
+            },
+        },
+        "execution_policy": {
+            "mode": "proposal_only",
+            "required_host_capabilities_by_kind": HOST_CAPABILITIES_BY_DECISION,
+            "missing_capability_behavior": "leave proposal unexecuted",
+            "destructive_actions_require_explicit_host_authority": True,
+        },
+    }
+
+
+def normalize_supervisor_decision(
+    raw: Mapping[str, Any],
+    *,
+    supervisor: Mapping[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise ValueError("supervisor decision must be an object")
+    try:
+        kind = SupervisorDecisionKind(str(raw.get("kind") or ""))
+    except ValueError as exc:
+        choices = ", ".join(item.value for item in SupervisorDecisionKind)
+        raise ValueError(f"kind must be one of: {choices}") from exc
+
+    decision_id = normalize_todo_claimed_by(raw.get("decision_id"))
+    if not decision_id:
+        raise ValueError("decision_id must be a public-safe token")
+    supervised = normalize_registered_agents(supervisor.get("supervised_agents"))
+    result = {
+        "schema_version": SUPERVISOR_DECISION_SCHEMA_VERSION,
+        "decision_id": decision_id,
+        "kind": kind.value,
+        "reason_codes": _normalized_tokens(raw.get("reason_codes"), field="reason_codes"),
+        "evidence_refs": _normalized_tokens(raw.get("evidence_refs"), field="evidence_refs"),
+        "execution_status": "proposal_only",
+        "required_host_capabilities": list(HOST_CAPABILITIES_BY_DECISION[kind.value]),
+    }
+    if kind is SupervisorDecisionKind.OBSERVE:
+        return result
+
+    target_agent_id = normalize_todo_claimed_by(raw.get("target_agent_id"))
+    if target_agent_id not in supervised:
+        raise ValueError("target_agent_id must be one of the configured supervised peers")
+    result["target_agent_id"] = target_agent_id
+
+    if kind is SupervisorDecisionKind.INJECT:
+        result["message"] = _required_text(raw, "message")
+    elif kind is SupervisorDecisionKind.HANDOFF:
+        source_agent_id = normalize_todo_claimed_by(raw.get("source_agent_id"))
+        if source_agent_id not in supervised:
+            raise ValueError("source_agent_id must be one of the configured supervised peers")
+        if source_agent_id == target_agent_id:
+            raise ValueError("handoff source and target agents must differ")
+        result["source_agent_id"] = source_agent_id
+        result["state_ref"] = _required_text(raw, "state_ref", limit=240)
+    elif kind is SupervisorDecisionKind.DISCARD:
+        result["state_ref"] = _required_text(raw, "state_ref", limit=240)
+    return result
+
+
+def build_supervisor_prompt(
+    *,
+    goal_id: str,
+    active_state: str,
+    supervisor: Mapping[str, Any],
+    cli_bin: str = "loopx",
+) -> dict[str, Any]:
+    contract = build_peer_supervisor_contract(
+        goal_id=goal_id,
+        supervisor=supervisor,
+    )
+    agent_id = str(contract["supervisor_agent_id"])
+    supervised_agents = list(contract["supervised_agents"])
+    status_commands = [
+        (
+            f"{cli_bin} --format json status --goal-id "
+            f"{shlex.quote(goal_id)} --agent-id {shlex.quote(peer)}"
+        )
+        for peer in supervised_agents
+    ]
+    evidence_commands = [
+        (
+            f"{cli_bin} --format json evidence-log --goal-id "
+            f"{shlex.quote(goal_id)} --agent-id {shlex.quote(peer)} --thin"
+        )
+        for peer in supervised_agents
+    ]
+    decision_template = {
+        "schema_version": SUPERVISOR_DECISION_SCHEMA_VERSION,
+        "decision_id": "<stable_public_safe_id>",
+        "kind": "observe|inject|handoff|discard",
+        "target_agent_id": "<required_except_observe>",
+        "source_agent_id": "<required_for_handoff>",
+        "message": "<required_for_inject>",
+        "state_ref": "<required_for_handoff_or_discard>",
+        "reason_codes": ["<typed_reason>"],
+        "evidence_refs": ["<public_safe_compact_ref>"],
+        "execution_status": "proposal_only",
+        "required_host_capabilities": ["<from_contract>"],
+    }
+    task_body = f"""Supervise `{goal_id}` using `{active_state}`.
+
+You are `{agent_id}`, an equal LoopX peer with an additional opt-in supervisor
+observation responsibility. You are not a durable leader and do not own other
+peers' todos, sessions, merge rights, user gates, or quota.
+
+The user may use this task as the preferred synthesis channel while several
+peers run, but may still talk to any peer. Keep all user decisions and gates in
+LoopX state so every peer sees the same authority.
+
+Run your own quota guard. Then read each supervised peer through its read-only
+agent status projection and thin evidence log. Do not impersonate another
+peer's quota guard. Prefer compact runtime effect references over raw
+transcripts or private logs:
+
+```bash
+{cli_bin} --format json quota should-run --goal-id {shlex.quote(goal_id)} --agent-id {shlex.quote(agent_id)}
+{chr(10).join(status_commands)}
+{chr(10).join(evidence_commands)}
+```
+
+Compare the peers' claimed work, evidence freshness, blockers, workspace state,
+and effect references. Emit at most one typed decision:
+
+- `observe`: no intervention; evidence does not justify changing a run.
+- `inject`: propose a bounded message to one existing session.
+- `handoff`: propose continuing a target session from a named source state.
+- `discard`: propose terminating a failed or harmful branch while preserving its
+  compact evidence reference.
+
+Return the decision in this shape:
+
+```json
+{json.dumps(decision_template, ensure_ascii=True, indent=2)}
+```
+
+This prototype is proposal-only. Never claim an injection, handoff, discard, or
+session termination happened unless a host adapter exposes every required
+capability and returns execution evidence. Missing capabilities leave the
+proposal unexecuted. Do not mutate peer claims merely to make the proposal look
+resolved.
+"""
+    return {
+        "ok": True,
+        "goal_id": goal_id,
+        "active_state": active_state,
+        "agent_id": agent_id,
+        "supervisor_contract": contract,
+        "task_body": task_body,
+    }
+
+
+def render_supervisor_prompt_markdown(payload: dict[str, Any]) -> str:
+    if not payload.get("ok"):
+        return "\n".join(
+            [
+                "# LoopX Supervisor Prompt",
+                "",
+                "- ok: `False`",
+                f"- error: {payload.get('error') or 'unknown error'}",
+            ]
+        )
+    contract = payload.get("supervisor_contract") or {}
+    return "\n".join(
+        [
+            "# LoopX Supervisor Prompt",
+            "",
+            "- ok: `True`",
+            f"- goal_id: `{payload.get('goal_id')}`",
+            f"- agent_id: `{payload.get('agent_id')}`",
+            "- supervised_agents: `"
+            + ", ".join(contract.get("supervised_agents") or [])
+            + "`",
+            "- execution_mode: `proposal_only`",
+            "",
+            "## Task Body",
+            "",
+            str(payload.get("task_body") or ""),
+        ]
+    )

--- a/loopx/control_plane/runtime/agent_scoped_evidence_log.py
+++ b/loopx/control_plane/runtime/agent_scoped_evidence_log.py
@@ -139,6 +139,28 @@ def _sort_key(row: Mapping[str, Any]) -> tuple[str, str]:
     return (str(row.get("recorded_at") or ""), str(row.get("source") or ""))
 
 
+def goal_history_runs(
+    history_payload: Mapping[str, Any],
+    goal_id: str,
+) -> list[dict[str, Any]]:
+    """Select compact history rows for one goal from either supported history shape."""
+
+    goals = history_payload.get("goals")
+    for goal in goals if isinstance(goals, list) else []:
+        if not isinstance(goal, Mapping) or str(goal.get("id") or "") != goal_id:
+            continue
+        latest_runs = goal.get("latest_runs")
+        if not isinstance(latest_runs, list):
+            return []
+        return [dict(row) for row in latest_runs if isinstance(row, Mapping)]
+    runs = history_payload.get("runs")
+    return [
+        dict(row)
+        for row in (runs if isinstance(runs, list) else [])
+        if isinstance(row, Mapping) and str(row.get("goal_id") or "") == goal_id
+    ]
+
+
 def build_agent_scoped_evidence_log_command(
     *,
     goal_id: str,

--- a/loopx/heartbeat_prompt.py
+++ b/loopx/heartbeat_prompt.py
@@ -18,7 +18,6 @@ from .control_plane.todos.contract import (
 )
 from .control_plane.agents.runtime_model import (
     AgentRuntimeModel,
-    LEGACY_HIERARCHY_ROLES,
     PEER_AGENT_PROFILE_SCHEMA_VERSION,
 )
 
@@ -122,9 +121,6 @@ def agent_profile_prompt_projection(profile: dict[str, Any] | None) -> dict[str,
         "avoid_action_kinds",
     }
     projection = {key: value for key, value in profile.items() if key in public_keys}
-    legacy_role = str(profile.get("role") or "").strip()
-    if legacy_role and legacy_role not in LEGACY_HIERARCHY_ROLES:
-        projection.setdefault("profile_role", legacy_role)
     projection["schema_version"] = PEER_AGENT_PROFILE_SCHEMA_VERSION
     return projection or None
 

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -121,6 +121,10 @@ COMMAND_GROUPS: list[dict[str, object]] = [
                 "purpose": "Check public-safe visible Codex CLI attach evidence.",
             },
             {"command": "loopx heartbeat-prompt", "purpose": "Generate a guarded heartbeat automation body."},
+            {
+                "command": "loopx supervisor-prompt",
+                "purpose": "Generate the dedicated task body for an opt-in proposal-only peer supervisor.",
+            },
             {"command": "loopx upgrade-plan", "purpose": "Plan default heartbeat upgrade propagation."},
             {"command": "loopx update", "purpose": "Check, dry-run, or execute the no-clone update path."},
         ],

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -125,6 +125,10 @@ COMMAND_GROUPS: list[dict[str, object]] = [
                 "command": "loopx supervisor-prompt",
                 "purpose": "Generate the dedicated task body for an opt-in proposal-only peer supervisor.",
             },
+            {
+                "command": "loopx supervisor-observe",
+                "purpose": "Read one public-safe supervisor packet over peer status and evidence.",
+            },
             {"command": "loopx upgrade-plan", "purpose": "Plan default heartbeat upgrade propagation."},
             {"command": "loopx update", "purpose": "Check, dry-run, or execute the no-clone update path."},
         ],

--- a/loopx/status_server.py
+++ b/loopx/status_server.py
@@ -57,6 +57,9 @@ CONFIGURE_GOAL_REQUEST_FIELDS = {
     "registered_agents",
     "clear_registered_agents",
     "agent_model",
+    "supervisor_agent",
+    "supervised_agents",
+    "clear_supervisor",
     "write_scope",
     "replace_write_scope",
     "clear_write_scope",
@@ -341,6 +344,9 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
         registered_agents = body.get("registered_agents")
         if registered_agents is not None and not isinstance(registered_agents, list):
             raise ValueError("registered_agents must be a list of strings")
+        supervised_agents = body.get("supervised_agents")
+        if supervised_agents is not None and not isinstance(supervised_agents, list):
+            raise ValueError("supervised_agents must be a list of strings")
         boundary_authority_scopes = body.get("boundary_authority_scopes")
         if boundary_authority_scopes is not None and not isinstance(boundary_authority_scopes, list):
             raise ValueError("boundary_authority_scopes must be a list of strings")
@@ -363,6 +369,13 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             "registered_agents": [str(item) for item in registered_agents] if registered_agents is not None else None,
             "clear_registered_agents": bool(body.get("clear_registered_agents", False)),
             "agent_model": body.get("agent_model"),
+            "supervisor_agent": body.get("supervisor_agent"),
+            "supervised_agents": (
+                [str(item) for item in supervised_agents]
+                if supervised_agents is not None
+                else None
+            ),
+            "clear_supervisor": bool(body.get("clear_supervisor", False)),
             "write_scope": [str(item) for item in write_scope] if write_scope is not None else None,
             "replace_write_scope": bool(body.get("replace_write_scope", False)),
             "clear_write_scope": bool(body.get("clear_write_scope", False)),
@@ -397,6 +410,9 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             registered_agents=values["registered_agents"],
             clear_registered_agents=values["clear_registered_agents"],
             agent_model=values["agent_model"],
+            supervisor_agent=values["supervisor_agent"],
+            supervised_agents=values["supervised_agents"],
+            clear_supervisor=values["clear_supervisor"],
             write_scope=values["write_scope"],
             replace_write_scope=values["replace_write_scope"],
             clear_write_scope=values["clear_write_scope"],
@@ -425,6 +441,7 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             "orchestration_summary": payload.get("orchestration_summary"),
             "feature_summary": payload.get("feature_summary"),
             "heartbeat_prompt_migration": payload.get("heartbeat_prompt_migration"),
+            "supervisor_prompt": payload.get("supervisor_prompt"),
         }
 
     def _handle_configure_goal_dry_run(self) -> None:

--- a/loopx/upgrade.py
+++ b/loopx/upgrade.py
@@ -15,7 +15,7 @@ from .heartbeat_prompt import build_heartbeat_prompt
 from .history import load_registry
 from .paths import DEFAULT_RUNTIME_ROOT, global_registry_path, resolve_runtime_root
 from .registry import registry_goals, resolve_state_file
-from .control_plane.agents.runtime_model import (
+from .control_plane.agents.legacy_migration import (
     completed_peer_agent_runtime_migration,
     legacy_agent_hierarchy_present,
     peer_agent_runtime_migration_completed,


### PR DESCRIPTION
## Summary

- add default-off `coordination.supervisor` configuration for one registered peer observing selected peers
- add a dedicated `supervisor-prompt` and typed `observe` / `inject` / `handoff` / `discard` proposal contract
- keep execution proposal-only and require explicit host capabilities before any session mutation
- isolate all primary/side hierarchy recognition and cleanup in `legacy_migration.py`; preserve the existing exactly-once migration path
- document user interaction and authority boundaries, with focused public smokes

## Validation

- `python3 examples/control_plane/peer-supervisor-smoke.py`
- `python3 examples/control_plane/peer-agent-migration-smoke.py`
- `python3 examples/project/configure-goal-smoke.py`
- `python3 examples/control_plane/control-plane-configure-api-smoke.py`
- `python3 examples/control_plane/heartbeat-prompt-smoke.py`
- `python3 examples/upgrade-plan-smoke.py`
- `python3 examples/cli-help-manpage-smoke.py`
- `PYTHONPATH=. loopx check`
- `PYTHONPATH=. loopx canary premerge --from-git-diff --tier quick`

The full `pytest` command was unavailable in this workspace (`pytest: command not found`). No host session injection, state fork, or termination executor is enabled by this PR.