### PR TITLE
Stage SkillsBench goal task disclosure after bridge action

### DIFF
--- a/examples/codex-cli-goal-tui-session-smoke.py
+++ b/examples/codex-cli-goal-tui-session-smoke.py
@@ -60,6 +60,17 @@ def main() -> int:
                 "command": "pwd && ls -la",
                 "timeout_sec": 10,
             }
+            task_prompt = Path(temp) / goal_tui.CODEX_CLI_GOAL_TASK_PROMPT_FILENAME
+            goal_tui.release_codex_cli_goal_task_prompt(
+                task_prompt,
+                "public task prompt",
+            )
+            assert task_prompt.read_text(encoding="utf-8") == "public task prompt"
+            goal_tui.release_codex_cli_goal_task_prompt(
+                task_prompt,
+                "replacement must not overwrite",
+            )
+            assert task_prompt.read_text(encoding="utf-8") == "public task prompt"
 
         goal_tui.subprocess.run = fake_run  # type: ignore[assignment]
         goal_tui.tmux_kill_session = fake_kill  # type: ignore[assignment]

--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -1431,7 +1431,7 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
         CODEX_CLI_GOAL_THREAD_PREWARM_MARKER,
         CODEX_CLI_GOAL_THREAD_PREWARM_PROMPT,
         CodexCliGoalLifecycleGeneration,
-        build_codex_cli_goal_file_objective,
+        build_codex_cli_goal_bridge_first_action_objective,
         build_codex_cli_tui_command,
         build_codex_cli_goal_tui_input,
         codex_cli_goal_lifecycle_marker_counts,
@@ -1447,10 +1447,8 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert CODEX_CLI_GOAL_THREAD_PREWARM_MARKER not in (
         CODEX_CLI_GOAL_THREAD_PREWARM_PROMPT
     )
-    objective = build_codex_cli_goal_file_objective(
-        CODEX_CLI_GOAL_TASK_PROMPT_FILENAME
-    )
-    assert CODEX_CLI_GOAL_TASK_PROMPT_FILENAME in objective, objective
+    objective = build_codex_cli_goal_bridge_first_action_objective()
+    assert CODEX_CLI_GOAL_TASK_PROMPT_FILENAME not in objective, objective
     assert CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_FILENAME in objective, objective
     assert len(objective) < CODEX_CLI_GOAL_OBJECTIVE_MAX_CHARS
     assert build_codex_cli_goal_tui_input(objective).startswith("/goal "), objective
@@ -1557,8 +1555,11 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "start_codex_cli_goal_tui_session(" in source
     assert "CODEX_CLI_GOAL_THREAD_PREWARM_TIMEOUT_SEC = 120" in source
     assert "CODEX_CLI_GOAL_TASK_PROMPT_FILENAME" in source
-    assert "prompt_instruction_path.write_text(" in source
-    assert "build_codex_cli_goal_file_objective(" in source
+    assert "release_codex_cli_goal_task_prompt(" in source
+    assert "build_codex_cli_goal_bridge_first_action_objective(" in source
+    assert source.index("release_codex_cli_goal_task_prompt(") < source.index(
+        "text=CODEX_CLI_GOAL_KICKOFF_PROMPT"
+    )
     assert "tmux_type_text_and_submit(" in source
     assert "build_codex_cli_goal_tui_input(prompt_for_codex)" not in source
     assert "codex_cli_goal_thread_prewarm: bool = False" in source
@@ -1591,7 +1592,7 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "goal_lifecycle.active_observed" in source
     assert "goal_lifecycle.achieved_advanced" in source
     assert "goal_lifecycle.observe(capture, turn_active=turn_active)" in source
-    assert source.count("goal_lifecycle.begin(") == 2
+    assert source.count("goal_lifecycle.begin(") == 3
     assert source.count("goal_kickoff_prompt_submitted = False") >= 2
     assert "terminal_observed=goal_failed_now" in source
     assert "goal_kickoff_prompt_raw_text_recorded" in source

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -56,7 +56,7 @@ from loopx.benchmark_adapters.skillsbench_codex_goal_recovery import (
 from loopx.codex_cli_goal_tui import (
     CODEX_CLI_GOAL_KICKOFF_PROMPT,
     CODEX_CLI_GOAL_TASK_PROMPT_FILENAME,
-    build_codex_cli_goal_file_objective,
+    build_codex_cli_goal_bridge_first_action_objective,
     build_codex_cli_goal_tui_input,
     build_codex_cli_tui_command,
     CodexCliGoalLifecycleGeneration,
@@ -70,6 +70,7 @@ from loopx.codex_cli_goal_tui import (
     codex_cli_tui_retryable_startup_blocker_stage,
     codex_cli_tui_turn_active,
     resolve_codex_cli_binary,
+    release_codex_cli_goal_task_prompt,
     start_codex_cli_goal_tui_session,
     tmux_capture,
     tmux_kill_session,
@@ -1044,16 +1045,8 @@ class SkillsBenchLocalAcpRelay:
                     bridge_probe=bridge_probe,
                     bridge_command_for_agent=str(instrumented_bridge),
                 )
-                prompt_instruction_path = (
-                    Path(cwd) / CODEX_CLI_GOAL_TASK_PROMPT_FILENAME
-                )
-                prompt_instruction_path.write_text(
-                    prompt_for_codex,
-                    encoding="utf-8",
-                )
-                prompt_for_goal = build_codex_cli_goal_file_objective(
-                    CODEX_CLI_GOAL_TASK_PROMPT_FILENAME
-                )
+                prompt_instruction_path = Path(cwd) / CODEX_CLI_GOAL_TASK_PROMPT_FILENAME
+                prompt_for_goal = build_codex_cli_goal_bridge_first_action_objective()
                 goal_prompt_file_used = True
                 goal_command_submission_method = "typed"
             else:
@@ -1084,6 +1077,7 @@ class SkillsBenchLocalAcpRelay:
             goal_kickoff_prompt_submitted = False
             post_bridge_terminal_stage = ""
             first_action_seen = False
+            task_prompt_released = False
             bridge_activity_seen = False
             last_bridge_summary_size = 0
             last_bridge_activity_at = time.monotonic()
@@ -1207,11 +1201,10 @@ class SkillsBenchLocalAcpRelay:
                             last_bridge_activity_at = now
                             last_task_output_activity_at = now
                             bridge_activity_seen = True
-                            first_action_seen = True
-                        elif (
-                            not first_action_seen
-                            and current_bridge_summary_size > 0
-                        ):
+                            if not task_prompt_released:
+                                release_codex_cli_goal_task_prompt(prompt_instruction_path, prompt_for_codex)
+                                task_prompt_released = True
+                        if current_bridge_summary_size > 0 and goal_kickoff_prompt_submitted:
                             first_action_seen = True
                         if not meaningful_progress_seen:
                             meaningful_progress_seen = (
@@ -1238,6 +1231,8 @@ class SkillsBenchLocalAcpRelay:
                         capture=capture,
                     ):
                         goal_kickoff_prompt_submitted = True
+                        goal_lifecycle.begin(capture)
+                        goal_active_observed = False
                         tmux_type_text_and_submit(
                             tmux_name=tmux_name,
                             text=CODEX_CLI_GOAL_KICKOFF_PROMPT,

--- a/loopx/codex_cli_goal_tui.py
+++ b/loopx/codex_cli_goal_tui.py
@@ -105,23 +105,25 @@ def build_codex_cli_goal_tui_input(objective: str) -> str:
     return f"{CODEX_CLI_GOAL_COMMAND_PREFIX}{objective}"
 
 
-def build_codex_cli_goal_file_objective(prompt_filename: str) -> str:
-    """Return a short goal objective that points Codex at private task details."""
+def build_codex_cli_goal_bridge_first_action_objective() -> str:
+    """Return the bridge-only goal used before private task disclosure."""
 
-    prompt_ref = (prompt_filename or CODEX_CLI_GOAL_TASK_PROMPT_FILENAME).strip()
-    prompt_ref = prompt_ref.replace("\\", "/").lstrip("/")
-    if not prompt_ref or ".." in Path(prompt_ref).parts:
-        prompt_ref = CODEX_CLI_GOAL_TASK_PROMPT_FILENAME
     objective = (
         f"First run ./{CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_FILENAME} and require "
-        "it to succeed. Then complete the SkillsBench task using the private "
-        f"task and bridge instructions in ./{prompt_ref}. Read that file, follow it "
-        "exactly, and perform at least one task-facing bridge action before "
-        "reporting status."
+        "it to succeed. Keep this goal active and wait for the task instructions "
+        "that will be provided next; do not finish or fail after the helper."
     )
     if len(objective) > CODEX_CLI_GOAL_OBJECTIVE_MAX_CHARS:
         raise ValueError("codex cli goal file objective exceeds objective cap")
     return objective
+
+
+def release_codex_cli_goal_task_prompt(prompt_path: Path, prompt_text: str) -> None:
+    """Materialize the unchanged task prompt after bridge-first succeeds."""
+
+    if prompt_path.exists():
+        return
+    prompt_path.write_text(prompt_text, encoding="utf-8")
 
 
 def write_codex_cli_goal_bridge_first_action_helper(


### PR DESCRIPTION
## Summary
- start the Codex CLI `/goal` route with only the bridge-first helper objective
- materialize the unchanged task prompt only after the helper reaches the bridge
- reset lifecycle baselines before the same-thread task kickoff and keep release idempotent

## Validation
- `python3 examples/codex-cli-goal-tui-session-smoke.py`
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 examples/skillsbench-host-local-launch-plan-smoke.py`
- `python3 examples/skillsbench-reverse-channel-bridge-smoke.py`
- `python3 examples/skillsbench-benchmark-egress-policy-smoke.py`
- `python3 examples/skillsbench-failure-attribution-smoke.py`
- `python3 examples/skillsbench-post-run-debug-gate-smoke.py`
- `python3 examples/skillsbench-runner-core-contract-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- changed-file `py_compile` and `git diff --check`
- `loopx canary premerge --from-git-diff` (all selected checks passed; expected benchmark-sensitive manual hold)

## Boundary
No scoring, verifier, task semantics, permission, or benchmark launch behavior changes. Raw task text remains local to the isolated case workspace and is not recorded in public traces.