### PR TITLE
Derive protocol packet from TurnEnvelope contracts

### DIFF
--- a/docs/reference/protocols/protocol-action-packet-decision-v0.md
+++ b/docs/reference/protocols/protocol-action-packet-decision-v0.md
@@ -5,6 +5,10 @@
 Keep `protocol_action_packet_v0` as the hot-path protocol simplification
 contract for `quota should-run`.
 
+The opt-in TurnEnvelope may reconstruct this packet from its structured action
+contracts and omit the repeated summary only when field-level parity succeeds;
+the full decision continues to persist the compatibility packet.
+
 The hot path remains deterministic and rule-only:
 
 - `llm=no_api`

--- a/docs/reference/protocols/turn-envelope-v0.md
+++ b/docs/reference/protocols/turn-envelope-v0.md
@@ -29,13 +29,15 @@ envelope; matching hashes prove the covered action dimensions agree for that
 projection. They do not prove that every possible quota state has test
 coverage.
 
-`protocol_action_packet` remains in the full ledger/cold path. Because its
-reconstructability is not yet proven, the capsule conservatively keeps its
-current compact summary plus schema and summary hash with
-`derivation_status=unproven_retain_summary`. LoopX may remove that repeated
-summary from the hot path only after proving that the envelope preserves every
-action-bearing residue; it must not stop persisting the source packet as part
-of this projection change.
+`protocol_action_packet` remains in the full decision/cold path. The envelope
+reconstructs its ordered semantic fields from `action`, `user`, work-lane,
+automation, and scheduler contracts, while carrying the explicit
+`llm_policy=no_api` invariant. When the reconstruction matches exactly, the
+capsule keeps only the source summary hash and derivation status. If a compact
+action differs, it keeps only that field-level `residue`; if an older or opaque
+packet cannot be reconstructed, it retains the original summary. This removes
+repetition only after parity and does not change source packet persistence or
+the default quota output.
 
 Large todo summaries, frontier diagnostics, readiness history, compatibility
 fields, and warning collections stay on the referenced full-decision/status

--- a/loopx/control_plane/quota/turn_envelope.py
+++ b/loopx/control_plane/quota/turn_envelope.py
@@ -5,6 +5,11 @@ from collections.abc import Mapping
 from hashlib import sha256
 from typing import Any
 
+from ..work_items.interaction_contract import (
+    PROTOCOL_ACTION_PACKET_LLM_POLICY,
+    protocol_action_packet_fields,
+    render_protocol_action_packet_summary,
+)
 from ..work_items.primary_action import protocol_action_text
 
 
@@ -328,7 +333,74 @@ def _execution_policy(payload: Mapping[str, Any]) -> dict[str, Any]:
     return {field: payload[field] for field in fields if payload.get(field) is not None}
 
 
-def _contract_capsule(payload: Mapping[str, Any]) -> dict[str, Any]:
+def _derived_protocol_action_packet_fields(
+    *,
+    action: Mapping[str, Any],
+    user: Mapping[str, Any],
+    capsule: Mapping[str, Any],
+    scheduler: Mapping[str, Any],
+) -> dict[str, Any]:
+    interaction = _mapping(capsule.get("interaction_contract"))
+    work_lane = _mapping(capsule.get("work_lane_contract"))
+    automation = _mapping(capsule.get("automation_liveness"))
+    mode = str(interaction.get("mode") or "")
+    user_required = bool(user.get("action_required"))
+    agent_required = bool(action.get("must_attempt"))
+    actor = (
+        "agent_with_user_gate"
+        if user_required
+        and mode in {"scoped_user_gate_fallback", "bounded_delivery_with_user_notice"}
+        else "user"
+        if user_required
+        else "agent"
+    )
+    fields: dict[str, Any] = {
+        "actor": actor,
+        "user_action_required": user_required,
+        "agent_action_required": agent_required,
+        "quiet_noop_allowed": bool(action.get("quiet_noop_allowed")),
+    }
+    if work_lane.get("lane"):
+        fields["lane"] = work_lane.get("lane")
+    if automation.get("automation_action"):
+        fields["automation"] = automation.get("automation_action")
+    if scheduler.get("action"):
+        fields["scheduler"] = scheduler.get("action")
+    if automation.get("pause_allowed") is False:
+        fields["pause_allowed"] = False
+    fields["llm"] = PROTOCOL_ACTION_PACKET_LLM_POLICY
+
+    user_actions = user.get("actions") if isinstance(user.get("actions"), list) else []
+    action_key = "agent_action" if agent_required or not user_required else "user_action"
+    if user_actions and (not user_required or action_key != "user_action"):
+        fields["user_action_pending"] = True
+        user_action = _text(user_actions[0], limit=80)
+        if user_action:
+            fields["user_action"] = user_action
+
+    if agent_required:
+        action_value = action.get("primary_action")
+    elif user_required and user_actions:
+        action_value = user_actions[0]
+    elif work_lane.get("obligation") == "quiet_until_material_monitor_transition":
+        action_value = (
+            "quiet until a material monitor transition, regression, or concrete blocker appears"
+        )
+    else:
+        action_value = action.get("primary_action") or "quiet no-op; no material transition"
+    text = _text(action_value, limit=80)
+    if text:
+        fields[action_key] = text
+    return fields
+
+
+def _contract_capsule(
+    payload: Mapping[str, Any],
+    *,
+    action: Mapping[str, Any],
+    user: Mapping[str, Any],
+    scheduler: Mapping[str, Any],
+) -> dict[str, Any]:
     capsule: dict[str, Any] = {
         "schema_version": CONTRACT_CAPSULE_SCHEMA_VERSION,
         "source": "full_quota_decision",
@@ -361,12 +433,34 @@ def _contract_capsule(payload: Mapping[str, Any]) -> dict[str, Any]:
     packet = _mapping(payload.get("protocol_action_packet"))
     if packet:
         summary = _text(packet.get("summary"), limit=2_000)
-        capsule["protocol_action_packet"] = {
+        source_fields = protocol_action_packet_fields(dict(payload))
+        derived_fields = _derived_protocol_action_packet_fields(
+            action=action,
+            user=user,
+            capsule=capsule,
+            scheduler=scheduler,
+        )
+        residue = {
+            key: value
+            for key, value in source_fields.items()
+            if derived_fields.get(key) != value
+        }
+        reconstructed_fields = {
+            key: residue.get(key, derived_fields.get(key)) for key in source_fields
+        }
+        reconstructed_summary = render_protocol_action_packet_summary(reconstructed_fields)
+        reconstruction_verified = bool(summary) and reconstructed_summary == summary
+        packet_projection: dict[str, Any] = {
             "schema_version": packet.get("schema_version"),
             "present": True,
-            "summary": summary,
             "summary_hash": _canonical_hash(summary or ""),
-            "derivation_status": "unproven_retain_summary",
+            "derivation_status": (
+                "verified_with_residue" if residue else "verified"
+            )
+            if reconstruction_verified
+            else "unverified_retain_summary",
+            "reconstruction_verified": reconstruction_verified,
+            "llm_policy": PROTOCOL_ACTION_PACKET_LLM_POLICY,
             "candidate_derivation_inputs": [
                 "action",
                 "user",
@@ -375,6 +469,11 @@ def _contract_capsule(payload: Mapping[str, Any]) -> dict[str, Any]:
                 "scheduler",
             ],
         }
+        if residue:
+            packet_projection["residue"] = residue
+        if not reconstruction_verified:
+            packet_projection["summary"] = summary
+        capsule["protocol_action_packet"] = packet_projection
 
     warnings = [field for field in ACTIONABLE_WARNING_FIELDS if payload.get(field)]
     if warnings:
@@ -386,20 +485,23 @@ def _action_projection(payload: Mapping[str, Any]) -> dict[str, Any]:
     interaction = _mapping(payload.get("interaction_contract"))
     agent_channel = _mapping(interaction.get("agent_channel"))
     cli_channel = _mapping(interaction.get("cli_channel"))
+    action = {
+        "recommended_action": _text(payload.get("recommended_action"), limit=480),
+        "primary_action": _text(agent_channel.get("primary_action"), limit=480),
+        "must_attempt": bool(agent_channel.get("must_attempt")),
+        "delivery_allowed": bool(agent_channel.get("delivery_allowed")),
+        "quiet_noop_allowed": bool(agent_channel.get("quiet_noop_allowed")),
+        "selected_todo": _selected_todo(payload),
+    }
+    user = _user_channel(interaction, payload)
+    scheduler = _scheduler(payload)
     return {
         "decision": payload.get("decision"),
         "should_run": bool(payload.get("should_run")),
         "effective_action": payload.get("effective_action"),
         "state": payload.get("state"),
-        "action": {
-            "recommended_action": _text(payload.get("recommended_action"), limit=480),
-            "primary_action": _text(agent_channel.get("primary_action"), limit=480),
-            "must_attempt": bool(agent_channel.get("must_attempt")),
-            "delivery_allowed": bool(agent_channel.get("delivery_allowed")),
-            "quiet_noop_allowed": bool(agent_channel.get("quiet_noop_allowed")),
-            "selected_todo": _selected_todo(payload),
-        },
-        "user": _user_channel(interaction, payload),
+        "action": action,
+        "user": user,
         "required_reads": _required_reads(interaction, payload),
         "boundary": _boundary(payload),
         "execution_policy": _execution_policy(payload),
@@ -413,8 +515,13 @@ def _action_projection(payload: Mapping[str, Any]) -> dict[str, Any]:
             "spend_after_validation": bool(cli_channel.get("spend_after_validation")),
             "spend_policy": _text(cli_channel.get("spend_policy"), limit=280),
         },
-        "scheduler": _scheduler(payload),
-        "contract_capsule": _contract_capsule(payload),
+        "scheduler": scheduler,
+        "contract_capsule": _contract_capsule(
+            payload,
+            action=action,
+            user=user,
+            scheduler=scheduler,
+        ),
     }
 
 

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -21,6 +21,7 @@ from .primary_action import (
 
 INTERACTION_CONTRACT_SCHEMA_VERSION = "loopx_interaction_contract_v0"
 PROTOCOL_ACTION_PACKET_SCHEMA_VERSION = "protocol_action_packet_v0"
+PROTOCOL_ACTION_PACKET_LLM_POLICY = "no_api"
 
 
 def _user_todo_item_is_explicitly_non_gating(item: dict[str, Any]) -> bool:
@@ -98,7 +99,9 @@ def attach_user_action_compat_fields(payload: dict[str, Any]) -> None:
     payload["open_count"] = open_todo_count(payload.get("user_todo_summary"))
 
 
-def build_protocol_action_packet(payload: dict[str, Any]) -> dict[str, Any]:
+def protocol_action_packet_fields(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return the ordered semantic fields rendered by protocol_action_packet_v0."""
+
     execution_obligation = (
         payload.get("execution_obligation")
         if isinstance(payload.get("execution_obligation"), dict)
@@ -197,32 +200,48 @@ def build_protocol_action_packet(payload: dict[str, Any]) -> dict[str, Any]:
         if requires_user_action and user_actions
         else agent_action
     )
-    summary_parts = [
-        f"actor={primary_actor}",
-        f"user_action_required={str(requires_user_action).lower()}",
-        f"agent_action_required={str(agent_action_required).lower()}",
-        f"quiet_noop_allowed={str(quiet_noop_allowed).lower()}",
-    ]
+    fields: dict[str, Any] = {
+        "actor": primary_actor,
+        "user_action_required": requires_user_action,
+        "agent_action_required": agent_action_required,
+        "quiet_noop_allowed": quiet_noop_allowed,
+    }
     if work_lane.get("lane"):
-        summary_parts.append(f"lane={work_lane.get('lane')}")
+        fields["lane"] = work_lane.get("lane")
     if automation_liveness.get("automation_action"):
-        summary_parts.append(f"automation={automation_liveness.get('automation_action')}")
+        fields["automation"] = automation_liveness.get("automation_action")
     if scheduler_hint.get("action"):
-        summary_parts.append(f"scheduler={scheduler_hint.get('action')}")
+        fields["scheduler"] = scheduler_hint.get("action")
     if automation_liveness.get("pause_allowed") is False:
-        summary_parts.append("pause_allowed=false")
-    summary_parts.append("llm=no_api")
+        fields["pause_allowed"] = False
+    fields["llm"] = PROTOCOL_ACTION_PACKET_LLM_POLICY
     if user_actions and (not requires_user_action or action_key != "user_action"):
-        summary_parts.append("user_action_pending=true")
+        fields["user_action_pending"] = True
         text = protocol_action_text(user_actions[0], limit=80)
         if text:
-            summary_parts.append(f"user_action={text}")
+            fields["user_action"] = text
     text = protocol_action_text(action_value, limit=80)
     if text:
-        summary_parts.append(f"{action_key}={text}")
+        fields[action_key] = text
+    return fields
+
+
+def render_protocol_action_packet_summary(fields: dict[str, Any]) -> str:
+    parts: list[str] = []
+    for key, value in fields.items():
+        if isinstance(value, bool):
+            rendered = str(value).lower()
+        else:
+            rendered = str(value)
+        parts.append(f"{key}={rendered}")
+    return " ".join(parts)
+
+
+def build_protocol_action_packet(payload: dict[str, Any]) -> dict[str, Any]:
+    fields = protocol_action_packet_fields(payload)
     return {
         "schema_version": PROTOCOL_ACTION_PACKET_SCHEMA_VERSION,
-        "summary": " ".join(summary_parts),
+        "summary": render_protocol_action_packet_summary(fields),
     }
 
 

--- a/tests/test_turn_envelope.py
+++ b/tests/test_turn_envelope.py
@@ -8,10 +8,11 @@ from loopx.control_plane.quota.turn_envelope import (
     quota_action_signature_document,
     turn_envelope_action_signature_document,
 )
+from loopx.control_plane.work_items.interaction_contract import build_protocol_action_packet
 
 
 def _full_decision() -> dict[str, object]:
-    return {
+    source: dict[str, object] = {
         "ok": True,
         "goal_id": "fixture-goal",
         "decision": "run",
@@ -46,7 +47,7 @@ def _full_decision() -> dict[str, object]:
                 "must_attempt": True,
                 "delivery_allowed": True,
                 "quiet_noop_allowed": False,
-                "primary_action": "todo_fixture0001: implement the fixture",
+                "primary_action": "advance one product-path slice",
             },
             "cli_channel": {
                 "next_cli_actions": [
@@ -142,14 +143,12 @@ def _full_decision() -> dict[str, object]:
             "post_handoff_run_seen": True,
             "post_handoff_recent_runs": ["diagnostic-only"],
         },
-        "protocol_action_packet": {
-            "schema_version": "protocol_action_packet_v0",
-            "summary": "actor=agent agent_action_required=true",
-        },
         "agent_todo_summary": {"large_diagnostic_lane": ["x" * 4_000]},
         "goal_frontier_projection": {"large_diagnostic_lane": ["y" * 4_000]},
         "plan_summary": {"large_diagnostic_lane": ["z" * 4_000]},
     }
+    source["protocol_action_packet"] = build_protocol_action_packet(source)
+    return source
 
 
 def test_turn_envelope_preserves_action_boundary_and_writeback() -> None:
@@ -189,9 +188,10 @@ def test_turn_envelope_preserves_action_boundary_and_writeback() -> None:
     assert envelope["contract_capsule"]["protocol_action_packet"] == {
         "schema_version": "protocol_action_packet_v0",
         "present": True,
-        "summary": "actor=agent agent_action_required=true",
         "summary_hash": envelope["contract_capsule"]["protocol_action_packet"]["summary_hash"],
-        "derivation_status": "unproven_retain_summary",
+        "derivation_status": "verified",
+        "reconstruction_verified": True,
+        "llm_policy": "no_api",
         "candidate_derivation_inputs": [
             "action",
             "user",
@@ -250,6 +250,64 @@ def test_action_signature_detects_semantic_drift() -> None:
     envelope["execution_policy"]["safe_bypass_allowed"] = True
 
     assert quota_action_signature_document(source) != turn_envelope_action_signature_document(envelope)
+
+
+def test_protocol_packet_derivation_keeps_only_real_residue() -> None:
+    source = _full_decision()
+    source["interaction_contract"]["agent_channel"]["primary_action"] = (
+        "a newer canonical action projection"
+    )
+
+    envelope = build_turn_envelope(source)
+    packet = envelope["contract_capsule"]["protocol_action_packet"]
+
+    assert packet["derivation_status"] == "verified_with_residue"
+    assert packet["reconstruction_verified"] is True
+    assert packet["residue"] == {"agent_action": "advance one product-path slice"}
+    assert "summary" not in packet
+    assert envelope["action_signature"]["matches"] is True
+
+
+def test_protocol_packet_derivation_retains_unverified_summary() -> None:
+    source = _full_decision()
+    source["protocol_action_packet"]["summary"] = "legacy opaque packet"
+
+    envelope = build_turn_envelope(source)
+    packet = envelope["contract_capsule"]["protocol_action_packet"]
+
+    assert packet["derivation_status"] == "unverified_retain_summary"
+    assert packet["reconstruction_verified"] is False
+    assert packet["summary"] == "legacy opaque packet"
+
+
+def test_protocol_packet_monitor_action_derives_without_residue() -> None:
+    source = _full_decision()
+    source["execution_obligation"]["must_attempt_work"] = False
+    source["interaction_contract"]["mode"] = "monitor_quiet_skip"
+    source["interaction_contract"]["agent_channel"].update(
+        {
+            "must_attempt": False,
+            "delivery_allowed": False,
+            "quiet_noop_allowed": True,
+            "primary_action": "record at most one monitor poll, then stay quiet",
+        }
+    )
+    source["work_lane_contract"].update(
+        {
+            "lane": "continuous_monitor",
+            "obligation": "quiet_until_material_monitor_transition",
+            "must_attempt_work": False,
+        }
+    )
+    source["protocol_action_packet"] = build_protocol_action_packet(source)
+
+    envelope = build_turn_envelope(source)
+    packet = envelope["contract_capsule"]["protocol_action_packet"]
+
+    assert packet["derivation_status"] == "verified"
+    assert packet["reconstruction_verified"] is True
+    assert "residue" not in packet
+    assert "summary" not in packet
 
 
 def test_contract_capsule_stays_bounded_with_replan_and_vision_contracts() -> None:


### PR DESCRIPTION
## Summary
- split `protocol_action_packet_v0` into ordered semantic fields plus a behavior-preserving renderer
- reconstruct the packet from TurnEnvelope action/user/work-lane/automation/scheduler contracts
- omit repeated summary only after exact parity; retain field residue or the full summary on mismatch

## Validation
- 7 focused TurnEnvelope tests
- 8 protocol/quota/heartbeat smokes
- full default decision and packet exactly match `origin/main` after dynamic-time normalization
- live `loopx-meta`: 53,439B -> 6,554B, no residue, matching action signature
- standard premerge canary: 17/17 passed, boundary clean, no holds

## Risk
- default full quota output and packet schema are unchanged
- opaque or legacy packets fail safe by retaining their summary
- full packet remains persisted on the cold path; only the opt-in envelope projection is deduplicated