### PR TITLE
Add durable supervisor proposal receipts

### DIFF
--- a/docs/reference/protocols/peer-supervisor-v0.md
+++ b/docs/reference/protocols/peer-supervisor-v0.md
@@ -79,6 +79,51 @@ Degraded status contracts behave the same way: the packet preserves the usable
 read-only projection, reports compact health counts, and does not claim that
 the decision input is complete.
 
+## Durable Proposals And Host Receipts
+
+The supervisor records its exact normalized decision before reporting it:
+
+```bash
+loopx supervisor-event propose \
+  --goal-id <goal-id> \
+  --agent-id <supervisor-agent-id> \
+  --decision-json <decision.json> \
+  --execute
+```
+
+This appends a goal-local `supervisor_proposed` event. It remains
+`proposal_only`; the proposal is never proof that a host changed a session.
+
+The CLI can validate or append a `rejected` or `failed` attempt receipt:
+
+```bash
+loopx supervisor-event receipt \
+  --goal-id <goal-id> \
+  --agent-id <supervisor-agent-id> \
+  --receipt-json <receipt.json> \
+  --execute
+```
+
+An `executed` receipt is stricter: it can only be appended through the host
+adapter API, which supplies verified capabilities outside the editable receipt
+JSON. It also requires an opaque authority reference and compact evidence
+references. Missing capability, authority, or evidence fails closed. A normal
+CLI caller therefore cannot promote a proposal to executed merely by naming a
+capability. `rejected` and `failed` receipts remain durable attempt evidence
+without projecting success. Reusing the same record id is idempotent when the
+payload matches and a conflict when it differs.
+
+Read the compact projection with:
+
+```bash
+loopx supervisor-event list \
+  --goal-id <goal-id> \
+  --agent-id <supervisor-agent-id>
+```
+
+The ledger is local-private goal runtime state. JSON input paths are never
+recorded, and inline credential-shaped values are rejected.
+
 ## Decision Contract
 
 `supervisor_decision_v0` uses an enum-like closed set:

--- a/examples/control_plane/peer-supervisor-event-smoke.py
+++ b/examples/control_plane/peer-supervisor-event-smoke.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Exercise durable supervisor proposals and capability-matched host receipts."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.cli import main as cli_main  # noqa: E402
+from loopx.configure_goal import configure_goal  # noqa: E402
+from loopx.control_plane.agents.supervisor_events import (  # noqa: E402
+    load_supervisor_event_projection,
+    record_supervisor_proposal,
+    record_supervisor_receipt,
+    supervisor_event_log_path,
+)
+
+
+GOAL_ID = "peer-supervisor-event-fixture"
+AGENTS = ["codex-alpha", "codex-beta"]
+
+
+def write_registry(root: Path) -> Path:
+    state_file = root / "ACTIVE_GOAL_STATE.md"
+    state_file.write_text(
+        "---\nstatus: active\n---\n\n# Active Goal State\n\n"
+        "## Objective\n\nExercise supervisor event durability.\n",
+        encoding="utf-8",
+    )
+    registry_path = root / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "peer-supervisor-event-smoke",
+                        "repo": str(root),
+                        "state_file": state_file.name,
+                        "adapter": {
+                            "kind": "generic_project_goal_v0",
+                            "status": "connected",
+                        },
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": AGENTS,
+                        },
+                    }
+                ]
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    configure_goal(
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        supervisor_agent=AGENTS[0],
+        supervised_agents=[AGENTS[1]],
+        execute=True,
+    )
+    return registry_path
+
+
+def inject_decision(decision_id: str = "inject-1") -> dict:
+    return {
+        "decision_id": decision_id,
+        "kind": "inject",
+        "target_agent_id": AGENTS[1],
+        "message": "Compare the latest focused validation evidence.",
+        "reason_codes": ["evidence-gap"],
+        "evidence_refs": [f"effect:{decision_id}"],
+    }
+
+
+def executed_receipt(receipt_id: str = "receipt-inject-1") -> dict:
+    return {
+        "receipt_id": receipt_id,
+        "decision_id": "inject-1",
+        "adapter_id": "fixture-host",
+        "outcome": "executed",
+        "authority_ref": "owner-gate:inject-1",
+        "evidence_refs": ["host-effect:inject-1"],
+        "reason_codes": ["adapter-success"],
+    }
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-peer-supervisor-events-") as tmp:
+        root = Path(tmp)
+        registry_path = write_registry(root)
+        supervisor = json.loads(registry_path.read_text(encoding="utf-8"))["goals"][0][
+            "coordination"
+        ]["supervisor"]
+        event_log = supervisor_event_log_path(root / "runtime", GOAL_ID)
+
+        preview = record_supervisor_proposal(
+            log_path=event_log,
+            goal_id=GOAL_ID,
+            supervisor=supervisor,
+            decision=inject_decision(),
+            execute=False,
+        )
+        assert preview["dry_run"] is True and preview["would_append"] is True, preview
+        assert not event_log.exists(), preview
+        assert preview["projection"]["items"][0]["execution_status"] == "proposal_only"
+
+        proposal = record_supervisor_proposal(
+            log_path=event_log,
+            goal_id=GOAL_ID,
+            supervisor=supervisor,
+            decision=inject_decision(),
+            execute=True,
+        )
+        assert proposal["appended"] is True, proposal
+        repeated = record_supervisor_proposal(
+            log_path=event_log,
+            goal_id=GOAL_ID,
+            supervisor=supervisor,
+            decision=inject_decision(),
+            execute=True,
+        )
+        assert repeated["appended"] is False, repeated
+
+        try:
+            record_supervisor_proposal(
+                log_path=event_log,
+                goal_id=GOAL_ID,
+                supervisor=supervisor,
+                decision={
+                    **inject_decision("inject-secret"),
+                    "message": "ak=must-not-be-recorded",
+                },
+                execute=True,
+            )
+        except ValueError as exc:
+            assert "inline credential" in str(exc), exc
+        else:
+            raise AssertionError("proposal ledger must reject inline credentials")
+
+        try:
+            record_supervisor_receipt(
+                log_path=event_log,
+                goal_id=GOAL_ID,
+                receipt=executed_receipt("receipt-missing-capability"),
+                execute=True,
+            )
+        except ValueError as exc:
+            assert "missing required host capabilities" in str(exc), exc
+        else:
+            raise AssertionError("executed receipt must prove required capabilities")
+
+        receipt = record_supervisor_receipt(
+            log_path=event_log,
+            goal_id=GOAL_ID,
+            receipt=executed_receipt(),
+            host_capabilities=["session_message_injection"],
+            execute=True,
+        )
+        assert receipt["appended"] is True, receipt
+        repeated_receipt = record_supervisor_receipt(
+            log_path=event_log,
+            goal_id=GOAL_ID,
+            receipt=executed_receipt(),
+            host_capabilities=["session_message_injection"],
+            execute=True,
+        )
+        assert repeated_receipt["appended"] is False, repeated_receipt
+        projection = load_supervisor_event_projection(event_log, goal_id=GOAL_ID)
+        assert projection["proposal_count"] == 1, projection
+        assert projection["receipt_count"] == 1, projection
+        assert projection["items"][0]["execution_status"] == "executed", projection
+        assert projection["boundary"]["proposal_is_execution_evidence"] is False
+
+        decision_path = root / "decision.json"
+        decision_path.write_text(json.dumps(inject_decision("inject-cli")), encoding="utf-8")
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exit_code = cli_main(
+                [
+                    "--registry",
+                    str(registry_path),
+                    "--runtime-root",
+                    str(root / "runtime"),
+                    "supervisor-event",
+                    "propose",
+                    "--format",
+                    "json",
+                    "--goal-id",
+                    GOAL_ID,
+                    "--agent-id",
+                    AGENTS[0],
+                    "--decision-json",
+                    str(decision_path),
+                    "--execute",
+                ]
+            )
+        assert exit_code == 0, stdout.getvalue()
+        cli_payload = json.loads(stdout.getvalue())
+        assert cli_payload["appended"] is True, cli_payload
+        assert cli_payload["projection"]["proposal_count"] == 2, cli_payload
+
+        cli_receipt_path = root / "receipt.json"
+        cli_receipt_path.write_text(
+            json.dumps(
+                {
+                    **executed_receipt("receipt-cli"),
+                    "decision_id": "inject-cli",
+                    "evidence_refs": ["host-effect:inject-cli"],
+                }
+            ),
+            encoding="utf-8",
+        )
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exit_code = cli_main(
+                [
+                    "--registry",
+                    str(registry_path),
+                    "--runtime-root",
+                    str(root / "runtime"),
+                    "supervisor-event",
+                    "receipt",
+                    "--format",
+                    "json",
+                    "--goal-id",
+                    GOAL_ID,
+                    "--agent-id",
+                    AGENTS[0],
+                    "--receipt-json",
+                    str(cli_receipt_path),
+                    "--execute",
+                ]
+            )
+        assert exit_code == 1, stdout.getvalue()
+        cli_receipt = json.loads(stdout.getvalue())
+        assert "missing required host capabilities" in cli_receipt["error"], cli_receipt
+
+    print("peer-supervisor-event-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/control_plane/peer-supervisor-smoke.py
+++ b/examples/control_plane/peer-supervisor-smoke.py
@@ -195,6 +195,7 @@ def main() -> int:
         assert "not a durable leader" in task_body, task_body
         assert "proposal-only" in task_body, task_body
         assert "supervisor-observe" in task_body and "quota should-run" in task_body
+        assert "supervisor-event propose" in task_body, task_body
         assert "evidence-log" not in task_body, task_body
         assert f"status --goal-id {GOAL_ID} --agent-id {AGENTS[2]}" not in task_body
         assert f"quota should-run --goal-id {GOAL_ID} --agent-id {AGENTS[2]}" not in task_body

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -226,6 +226,7 @@ def main(argv: list[str] | None = None) -> int:
             "start-goal",
             "slash-commands",
             "heartbeat-prompt",
+            "supervisor-event",
             "supervisor-observe",
             "supervisor-prompt",
             "sync-global",

--- a/loopx/cli_commands/support_control.py
+++ b/loopx/cli_commands/support_control.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 from collections.abc import Callable
 from pathlib import Path
 
@@ -16,6 +17,13 @@ from ..control_plane.agents.supervisor import (
     peer_supervisor_for_goal,
     render_supervisor_observation_markdown,
     render_supervisor_prompt_markdown,
+)
+from ..control_plane.agents.supervisor_events import (
+    load_supervisor_event_projection,
+    record_supervisor_proposal,
+    record_supervisor_receipt,
+    render_supervisor_event_markdown,
+    supervisor_event_log_path,
 )
 from ..control_plane.runtime.agent_scoped_evidence_log import (
     build_agent_scoped_evidence_log,
@@ -76,6 +84,7 @@ SUPPORT_CONTROL_COMMANDS = {
     "registry",
     "registry-boundary",
     "serve-status",
+    "supervisor-event",
     "supervisor-observe",
     "supervisor-prompt",
 }
@@ -281,6 +290,35 @@ def register_support_control_commands(
         "--agent-id",
         required=True,
         help="Registered peer configured as coordination.supervisor.agent_id.",
+    )
+
+    supervisor_event_parser = subparsers.add_parser(
+        "supervisor-event",
+        help="Preview, append, or read durable supervisor proposals and host receipts.",
+    )
+    add_subcommand_format(supervisor_event_parser)
+    supervisor_event_parser.add_argument(
+        "supervisor_event_action",
+        choices=("propose", "receipt", "list"),
+    )
+    supervisor_event_parser.add_argument("--goal-id", required=True)
+    supervisor_event_parser.add_argument(
+        "--agent-id",
+        required=True,
+        help="Registered peer configured as coordination.supervisor.agent_id.",
+    )
+    supervisor_event_parser.add_argument(
+        "--decision-json",
+        help="Local JSON object for `propose`; its path is never recorded.",
+    )
+    supervisor_event_parser.add_argument(
+        "--receipt-json",
+        help="Local JSON object for `receipt`; its path is never recorded.",
+    )
+    supervisor_event_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Append the validated event. Omit for a no-write preview.",
     )
 
     promotion_gate_parser = subparsers.add_parser(
@@ -633,6 +671,64 @@ def handle_support_control_command(
                 "error": str(exc),
             }
         print_payload(payload, output_format(args), render_supervisor_observation_markdown)
+        return 0 if payload.get("ok") else 1
+
+    if args.command == "supervisor-event":
+        try:
+            agent_registry_path = fallback_global_registry(registry_path, args.runtime_root)
+            agent_id = require_registered_agent_id(
+                registry_path=agent_registry_path,
+                goal_id=args.goal_id,
+                agent_id=args.agent_id,
+                field="agent_id",
+            )
+            goal = load_goal_from_registry(agent_registry_path, args.goal_id)
+            supervisor = peer_supervisor_for_goal(goal)
+            if supervisor is None:
+                raise ValueError("peer supervisor is disabled for this goal")
+            if supervisor.get("agent_id") != agent_id:
+                raise ValueError(
+                    f"agent_id={agent_id!r} is not the configured supervisor; "
+                    f"supervisor_agent={supervisor.get('agent_id')!r}"
+                )
+            registry = load_registry(agent_registry_path)
+            runtime_root = resolve_runtime_root(registry, args.runtime_root)
+            log_path = supervisor_event_log_path(runtime_root, args.goal_id)
+            if args.supervisor_event_action == "list":
+                if args.execute or args.decision_json or args.receipt_json:
+                    raise ValueError("list does not accept event JSON or --execute")
+                payload = load_supervisor_event_projection(log_path, goal_id=args.goal_id)
+            elif args.supervisor_event_action == "propose":
+                if not args.decision_json or args.receipt_json:
+                    raise ValueError("propose requires only --decision-json")
+                decision = json.loads(Path(args.decision_json).read_text(encoding="utf-8"))
+                payload = record_supervisor_proposal(
+                    log_path=log_path,
+                    goal_id=args.goal_id,
+                    supervisor=supervisor,
+                    decision=decision,
+                    execute=bool(args.execute),
+                )
+            else:
+                if not args.receipt_json or args.decision_json:
+                    raise ValueError("receipt requires only --receipt-json")
+                receipt = json.loads(Path(args.receipt_json).read_text(encoding="utf-8"))
+                payload = record_supervisor_receipt(
+                    log_path=log_path,
+                    goal_id=args.goal_id,
+                    receipt=receipt,
+                    execute=bool(args.execute),
+                )
+            payload.setdefault("goal_id", args.goal_id)
+            payload.setdefault("supervisor_agent_id", agent_id)
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "goal_id": args.goal_id,
+                "supervisor_agent_id": args.agent_id,
+                "error": str(exc),
+            }
+        print_payload(payload, output_format(args), render_supervisor_event_markdown)
         return 0 if payload.get("ok") else 1
 
     if args.command == "promotion-gate":

--- a/loopx/control_plane/agents/supervisor.py
+++ b/loopx/control_plane/agents/supervisor.py
@@ -173,6 +173,9 @@ def build_peer_supervisor_contract(
             "required_host_capabilities_by_kind": HOST_CAPABILITIES_BY_DECISION,
             "missing_capability_behavior": "leave proposal unexecuted",
             "destructive_actions_require_explicit_host_authority": True,
+            "durable_proposal_required": True,
+            "host_receipt_required_for_executed_status": True,
+            "proposal_is_execution_evidence": False,
         },
     }
 
@@ -446,11 +449,20 @@ Return the decision in this shape:
 {json.dumps(decision_template, ensure_ascii=True, indent=2)}
 ```
 
+Persist the exact decision before reporting it. Preview first, then append it
+only after validation; the local JSON path is not stored:
+
+```bash
+{cli_bin} --format json supervisor-event propose --goal-id {shlex.quote(goal_id)} --agent-id {shlex.quote(agent_id)} --decision-json <decision.json>
+{cli_bin} --format json supervisor-event propose --goal-id {shlex.quote(goal_id)} --agent-id {shlex.quote(agent_id)} --decision-json <decision.json> --execute
+```
+
 This prototype is proposal-only. Never claim an injection, handoff, discard, or
 session termination happened unless a host adapter exposes every required
-capability and returns execution evidence. Missing capabilities leave the
-proposal unexecuted. Do not mutate peer claims merely to make the proposal look
-resolved.
+capability and appends a capability-matched `supervisor_host_receipt_v0` with
+authority and evidence references. A proposal record is never execution
+evidence. Missing capabilities leave the proposal unexecuted. Do not mutate
+peer claims merely to make the proposal look resolved.
 """
     return {
         "ok": True,

--- a/loopx/control_plane/agents/supervisor_events.py
+++ b/loopx/control_plane/agents/supervisor_events.py
@@ -1,0 +1,435 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from ...event_sourced_state import (
+    LOCAL_PRIVATE_PRIVACY,
+    SUPERVISOR_PROPOSED,
+    SUPERVISOR_RECEIPT_RECORDED,
+    AppendOnlyStateEventStore,
+    StateEventConflictError,
+    make_state_event,
+)
+from ..todos.contract import normalize_todo_claimed_by
+from .supervisor import normalize_supervisor_decision
+
+
+SUPERVISOR_EVENT_LOG_NAME = "supervisor-events.jsonl"
+SUPERVISOR_EVENT_PROJECTION_SCHEMA_VERSION = "supervisor_event_projection_v0"
+SUPERVISOR_RECEIPT_SCHEMA_VERSION = "supervisor_host_receipt_v0"
+
+_INLINE_SECRET_PATTERN = re.compile(
+    r"(?i)\b(?:ak|sk|access[_-]?key|secret[_-]?key)\b\s*[:=]\s*\S+"
+)
+
+
+class SupervisorReceiptOutcome(str, Enum):
+    EXECUTED = "executed"
+    REJECTED = "rejected"
+    FAILED = "failed"
+
+
+def supervisor_event_log_path(runtime_root: Path, goal_id: str) -> Path:
+    return runtime_root.expanduser() / "goals" / str(goal_id) / SUPERVISOR_EVENT_LOG_NAME
+
+
+def _tokens(values: Any, *, field: str, required: bool) -> list[str]:
+    if values is None and not required:
+        return []
+    if not isinstance(values, list):
+        raise ValueError(f"{field} must be a list")
+    normalized: list[str] = []
+    for raw in values:
+        token = normalize_todo_claimed_by(raw)
+        if not token:
+            raise ValueError(f"{field} must contain compact opaque references")
+        if token not in normalized:
+            normalized.append(token)
+    if required and not normalized:
+        raise ValueError(f"{field} must not be empty")
+    return normalized
+
+
+def _required_token(payload: Mapping[str, Any], field: str) -> str:
+    token = normalize_todo_claimed_by(payload.get(field))
+    if not token:
+        raise ValueError(f"{field} must be a compact token")
+    return token
+
+
+def _reject_inline_secrets(value: Any, *, field: str) -> None:
+    if _INLINE_SECRET_PATTERN.search(str(value or "")):
+        raise ValueError(f"{field} contains an inline credential")
+
+
+def build_supervisor_proposal_event(
+    *,
+    goal_id: str,
+    supervisor: Mapping[str, Any],
+    decision: Mapping[str, Any],
+    recorded_at: str | None = None,
+) -> dict[str, Any]:
+    normalized = normalize_supervisor_decision(decision, supervisor=supervisor)
+    _reject_inline_secrets(normalized, field="decision")
+    decision_id = str(normalized["decision_id"])
+    supervisor_agent_id = str(supervisor.get("agent_id") or "")
+    return make_state_event(
+        event_id=f"supervisor-proposal-{decision_id}",
+        goal_id=goal_id,
+        event_type=SUPERVISOR_PROPOSED,
+        refs={
+            "decision_id": decision_id,
+            "supervisor_agent_id": supervisor_agent_id,
+        },
+        payload={"decision": normalized},
+        recorded_at=recorded_at,
+        producer="loopx.supervisor",
+        privacy=LOCAL_PRIVATE_PRIVACY,
+    )
+
+
+def normalize_supervisor_receipt(
+    raw: Mapping[str, Any],
+    *,
+    proposal: Mapping[str, Any],
+    host_capabilities: list[str] | tuple[str, ...] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise ValueError("supervisor receipt must be an object")
+    decision = proposal.get("decision")
+    if not isinstance(decision, Mapping):
+        raise ValueError("proposal is missing its normalized decision")
+    if decision.get("kind") == "observe":
+        raise ValueError("observe decisions do not accept host execution receipts")
+    receipt_id = _required_token(raw, "receipt_id")
+    decision_id = _required_token(raw, "decision_id")
+    if decision_id != decision.get("decision_id"):
+        raise ValueError("receipt decision_id does not match the proposal")
+    adapter_id = _required_token(raw, "adapter_id")
+    try:
+        outcome = SupervisorReceiptOutcome(str(raw.get("outcome") or ""))
+    except ValueError as exc:
+        choices = ", ".join(item.value for item in SupervisorReceiptOutcome)
+        raise ValueError(f"outcome must be one of: {choices}") from exc
+
+    capabilities = _tokens(
+        list(host_capabilities or []),
+        field="host_capabilities",
+        required=False,
+    )
+    evidence_refs = _tokens(raw.get("evidence_refs"), field="evidence_refs", required=True)
+    reason_codes = _tokens(raw.get("reason_codes"), field="reason_codes", required=True)
+    required_capabilities = list(decision.get("required_host_capabilities") or [])
+    missing_capabilities = sorted(set(required_capabilities) - set(capabilities))
+    authority_ref = normalize_todo_claimed_by(raw.get("authority_ref"))
+    if outcome is SupervisorReceiptOutcome.EXECUTED:
+        if missing_capabilities:
+            raise ValueError(
+                "executed receipt is missing required host capabilities: "
+                + ", ".join(missing_capabilities)
+            )
+        if not authority_ref:
+            raise ValueError("executed receipt requires authority_ref")
+
+    receipt = {
+        "schema_version": SUPERVISOR_RECEIPT_SCHEMA_VERSION,
+        "receipt_id": receipt_id,
+        "decision_id": decision_id,
+        "adapter_id": adapter_id,
+        "outcome": outcome.value,
+        "capabilities": capabilities,
+        "capability_source": "host_adapter_context",
+        "required_host_capabilities": required_capabilities,
+        "capability_match": not missing_capabilities,
+        "missing_capabilities": missing_capabilities,
+        "authority_ref": authority_ref,
+        "evidence_refs": evidence_refs,
+        "reason_codes": reason_codes,
+    }
+    _reject_inline_secrets(receipt, field="receipt")
+    return receipt
+
+
+def build_supervisor_receipt_event(
+    *,
+    goal_id: str,
+    proposal_event: Mapping[str, Any],
+    receipt: Mapping[str, Any],
+    host_capabilities: list[str] | tuple[str, ...] | None = None,
+    recorded_at: str | None = None,
+) -> dict[str, Any]:
+    proposal = proposal_event.get("payload")
+    if not isinstance(proposal, Mapping):
+        raise ValueError("proposal event is missing payload")
+    normalized = normalize_supervisor_receipt(
+        receipt,
+        proposal=proposal,
+        host_capabilities=host_capabilities,
+    )
+    return make_state_event(
+        event_id=f"supervisor-receipt-{normalized['receipt_id']}",
+        goal_id=goal_id,
+        event_type=SUPERVISOR_RECEIPT_RECORDED,
+        refs={
+            "decision_id": normalized["decision_id"],
+            "receipt_id": normalized["receipt_id"],
+        },
+        payload={"receipt": normalized},
+        recorded_at=recorded_at,
+        producer="loopx.supervisor",
+        privacy=LOCAL_PRIVATE_PRIVACY,
+    )
+
+
+def _matching_event(
+    events: list[dict[str, Any]],
+    *,
+    event_type: str,
+    ref_name: str,
+    ref_value: str,
+) -> dict[str, Any] | None:
+    return next(
+        (
+            event
+            for event in events
+            if event.get("event_type") == event_type
+            and (event.get("refs") or {}).get(ref_name) == ref_value
+        ),
+        None,
+    )
+
+
+def _append_idempotent(
+    store: AppendOnlyStateEventStore,
+    event: dict[str, Any],
+) -> tuple[dict[str, Any], bool]:
+    prior = next(
+        (item for item in store.load() if item.get("event_id") == event.get("event_id")),
+        None,
+    )
+    if prior is not None:
+        if prior.get("refs") != event.get("refs") or prior.get("payload") != event.get("payload"):
+            raise StateEventConflictError(f"conflicting event_id: {event.get('event_id')}")
+        return prior, False
+    try:
+        return store.append(event), True
+    except StateEventConflictError:
+        concurrent = next(
+            (
+                item
+                for item in store.load()
+                if item.get("event_id") == event.get("event_id")
+            ),
+            None,
+        )
+        if (
+            concurrent is not None
+            and concurrent.get("refs") == event.get("refs")
+            and concurrent.get("payload") == event.get("payload")
+        ):
+            return concurrent, False
+        raise
+
+
+def record_supervisor_proposal(
+    *,
+    log_path: Path,
+    goal_id: str,
+    supervisor: Mapping[str, Any],
+    decision: Mapping[str, Any],
+    execute: bool,
+) -> dict[str, Any]:
+    store = AppendOnlyStateEventStore(log_path)
+    events = store.load()
+    event = build_supervisor_proposal_event(
+        goal_id=goal_id,
+        supervisor=supervisor,
+        decision=decision,
+    )
+    prior = next(
+        (item for item in events if item.get("event_id") == event.get("event_id")),
+        None,
+    )
+    if execute:
+        appended, created = _append_idempotent(store, event)
+        projection_events = store.load()
+    elif prior is not None:
+        appended, created = _append_idempotent(store, event)
+        projection_events = events
+    else:
+        appended, created = event, False
+        projection_events = [*events, event]
+    return {
+        "ok": True,
+        "mode": "supervisor_proposal",
+        "dry_run": not execute,
+        "appended": created,
+        "would_append": prior is None,
+        "event": appended,
+        "projection": build_supervisor_event_projection(projection_events, goal_id=goal_id),
+    }
+
+
+def record_supervisor_receipt(
+    *,
+    log_path: Path,
+    goal_id: str,
+    receipt: Mapping[str, Any],
+    execute: bool,
+    host_capabilities: list[str] | tuple[str, ...] | None = None,
+) -> dict[str, Any]:
+    store = AppendOnlyStateEventStore(log_path)
+    events = store.load()
+    decision_id = _required_token(receipt, "decision_id")
+    proposal = _matching_event(
+        events,
+        event_type=SUPERVISOR_PROPOSED,
+        ref_name="decision_id",
+        ref_value=decision_id,
+    )
+    if proposal is None:
+        raise ValueError(f"no recorded supervisor proposal for decision_id={decision_id}")
+    prior_executed = next(
+        (
+            event
+            for event in events
+            if event.get("event_type") == SUPERVISOR_RECEIPT_RECORDED
+            and (event.get("refs") or {}).get("decision_id") == decision_id
+            and ((event.get("payload") or {}).get("receipt") or {}).get("outcome")
+            == SupervisorReceiptOutcome.EXECUTED.value
+        ),
+        None,
+    )
+    event = build_supervisor_receipt_event(
+        goal_id=goal_id,
+        proposal_event=proposal,
+        receipt=receipt,
+        host_capabilities=host_capabilities,
+    )
+    if prior_executed is not None and prior_executed.get("event_id") != event.get("event_id"):
+        raise ValueError(f"decision_id={decision_id} already has an executed receipt")
+    prior = next(
+        (item for item in events if item.get("event_id") == event.get("event_id")),
+        None,
+    )
+    if execute:
+        appended, created = _append_idempotent(store, event)
+        projection_events = store.load()
+    elif prior is not None:
+        appended, created = _append_idempotent(store, event)
+        projection_events = events
+    else:
+        appended, created = event, False
+        projection_events = [*events, event]
+    return {
+        "ok": True,
+        "mode": "supervisor_receipt",
+        "dry_run": not execute,
+        "appended": created,
+        "would_append": prior is None,
+        "event": appended,
+        "projection": build_supervisor_event_projection(projection_events, goal_id=goal_id),
+    }
+
+
+def build_supervisor_event_projection(
+    events: list[dict[str, Any]],
+    *,
+    goal_id: str,
+) -> dict[str, Any]:
+    proposals: dict[str, dict[str, Any]] = {}
+    receipts: dict[str, list[dict[str, Any]]] = {}
+    for event in sorted(events, key=lambda item: int(item.get("append_sequence") or 0)):
+        if event.get("goal_id") != goal_id:
+            continue
+        decision_id = str((event.get("refs") or {}).get("decision_id") or "")
+        if not decision_id:
+            continue
+        if event.get("event_type") == SUPERVISOR_PROPOSED:
+            proposals[decision_id] = event
+        elif event.get("event_type") == SUPERVISOR_RECEIPT_RECORDED:
+            receipts.setdefault(decision_id, []).append(event)
+
+    rows = []
+    for decision_id, proposal_event in proposals.items():
+        decision = ((proposal_event.get("payload") or {}).get("decision") or {})
+        decision_receipts = receipts.get(decision_id, [])
+        latest_receipt_event = decision_receipts[-1] if decision_receipts else None
+        latest_receipt = (
+            ((latest_receipt_event.get("payload") or {}).get("receipt") or {})
+            if latest_receipt_event
+            else None
+        )
+        rows.append(
+            {
+                "decision_id": decision_id,
+                "kind": decision.get("kind"),
+                "target_agent_id": decision.get("target_agent_id"),
+                "proposal_event_id": proposal_event.get("event_id"),
+                "proposed_at": proposal_event.get("recorded_at"),
+                "required_host_capabilities": list(
+                    decision.get("required_host_capabilities") or []
+                ),
+                "execution_status": (
+                    "not_required"
+                    if decision.get("kind") == "observe"
+                    else latest_receipt.get("outcome")
+                    if latest_receipt
+                    else "proposal_only"
+                ),
+                "receipt_count": len(decision_receipts),
+                "latest_receipt": latest_receipt,
+            }
+        )
+    return {
+        "ok": True,
+        "schema_version": SUPERVISOR_EVENT_PROJECTION_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "proposal_count": len(rows),
+        "receipt_count": sum(len(items) for items in receipts.values()),
+        "items": rows,
+        "orphan_receipt_count": len(set(receipts) - set(proposals)),
+        "boundary": {
+            "proposal_is_execution_evidence": False,
+            "executed_requires_capability_matched_receipt": True,
+            "ledger_privacy": LOCAL_PRIVATE_PRIVACY,
+        },
+    }
+
+
+def load_supervisor_event_projection(log_path: Path, *, goal_id: str) -> dict[str, Any]:
+    return build_supervisor_event_projection(
+        AppendOnlyStateEventStore(log_path).load(),
+        goal_id=goal_id,
+    )
+
+
+def render_supervisor_event_markdown(payload: dict[str, Any]) -> str:
+    if not payload.get("ok"):
+        return "\n".join(
+            [
+                "# LoopX Supervisor Event",
+                "",
+                "- ok: `False`",
+                f"- error: {payload.get('error') or 'unknown error'}",
+            ]
+        )
+    projection = payload.get("projection") or payload
+    lines = [
+        "# LoopX Supervisor Events",
+        "",
+        f"- goal_id: `{projection.get('goal_id')}`",
+        f"- proposals: `{projection.get('proposal_count') or 0}`",
+        f"- receipts: `{projection.get('receipt_count') or 0}`",
+        "",
+    ]
+    for item in projection.get("items") or []:
+        lines.append(
+            f"- `{item.get('decision_id')}` kind=`{item.get('kind')}` "
+            f"status=`{item.get('execution_status')}`"
+        )
+    return "\n".join(lines)

--- a/loopx/event_sourced_state.py
+++ b/loopx/event_sourced_state.py
@@ -55,6 +55,8 @@ REFRESH_RECORDED = "refresh_recorded"
 RUN_RECORDED = "run_recorded"
 QUOTA_SPENT = "quota_spent"
 EVIDENCE_ATTACHED = "evidence_attached"
+SUPERVISOR_PROPOSED = "supervisor_proposed"
+SUPERVISOR_RECEIPT_RECORDED = "supervisor_receipt_recorded"
 
 MARKDOWN_BACKFILL_PRODUCER = "loopx.backfill"
 MARKDOWN_HEADING_PATTERN = re.compile(r"^##\s+(.+?)\s*$")
@@ -77,6 +79,8 @@ SUPPORTED_EVENT_TYPES = {
     RUN_RECORDED,
     QUOTA_SPENT,
     EVIDENCE_ATTACHED,
+    SUPERVISOR_PROPOSED,
+    SUPERVISOR_RECEIPT_RECORDED,
 }
 
 TODO_EVENT_TYPES = {

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -129,6 +129,10 @@ COMMAND_GROUPS: list[dict[str, object]] = [
                 "command": "loopx supervisor-observe",
                 "purpose": "Read one public-safe supervisor packet over peer status and evidence.",
             },
+            {
+                "command": "loopx supervisor-event",
+                "purpose": "Preview, append, or read supervisor proposals and host execution receipts.",
+            },
             {"command": "loopx upgrade-plan", "purpose": "Plan default heartbeat upgrade propagation."},
             {"command": "loopx update", "purpose": "Check, dry-run, or execute the no-clone update path."},
         ],


### PR DESCRIPTION
## Summary

- add an append-only, goal-local supervisor proposal and receipt ledger
- keep proposals `proposal_only` until a host adapter supplies verified capabilities, authority, and evidence
- expose one `supervisor-event {propose,receipt,list}` CLI surface with dry-run previews
- document the contract and split durable event coverage from the existing supervisor configuration smoke

## Safety

This remains an opt-in experimental feature. A normal CLI caller cannot promote a proposal to `executed`; verified host capabilities are supplied outside editable receipt JSON. No session mutation adapter is included.

## Validation

- standard premerge canary: 16/16 selected checks passed, 0 failures, 0 manual holds
- focused supervisor configuration/event smokes passed
- event-sourced state contract/replay smokes passed
- peer runtime aggregate and CLI help smokes passed
- `loopx check`: 0 errors, 0 warnings; public boundary clean
