### PR TITLE
Add conservative test quality floors

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -40,5 +40,12 @@ jobs:
       - name: Install test dependencies
         run: python -m pip install --disable-pip-version-check -e ".[test]"
 
+      - name: Lint test suite
+        run: python -m ruff check tests
+
       - name: Run fast tests
-        run: python -m pytest -q -n 2
+        run: >-
+          python -m pytest -q -n 2
+          --cov=loopx
+          --cov-report=term
+          --cov-fail-under=19

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ build/
 dist/
 .pytest_cache/
 .ruff_cache/
+.coverage
+coverage.xml
+htmlcov/
 .playwright-cli/
 output/playwright/
 

--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -317,6 +317,13 @@ python3 -m pytest tests/test_smoke_suite.py \
   --junitxml smoke-suite.xml
 ```
 
+The required Python test workflow also keeps `tests/**` Ruff-clean and enforces
+an initial 19% package coverage floor. The floor is intentionally a
+regression guard, not a claim that 19% is sufficient; raise it as durable
+behavior moves from subprocess smokes into focused tests. Existing source-wide
+lint debt is characterized separately and must not be mass-fixed merely to
+make the first gate green.
+
 If the source checkout has optional frontend dependencies installed, dashboard
 readiness can be included in the same canary. If a release snapshot omits the
 dashboard app, the canary should degrade gracefully and record that boundary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,12 @@ authors = [{ name = "LoopX contributors" }]
 dependencies = []
 
 [project.optional-dependencies]
-test = ["pytest>=8,<9", "pytest-xdist>=3,<4"]
+test = [
+  "pytest>=8,<9",
+  "pytest-cov>=5,<7",
+  "pytest-xdist>=3,<4",
+  "ruff>=0.12,<1",
+]
 
 [project.scripts]
 loopx = "loopx.cli:main"


### PR DESCRIPTION
## Summary
- keep `tests/**` Ruff-clean in the fast Python workflow
- establish a conservative 19% package coverage regression floor
- ignore standard local coverage artifacts
- document why these gates are incremental rather than a mass cleanup of existing source debt

## Characterization
- source-wide Ruff currently reports 506 pre-existing findings, so this PR does not make that historical debt a required check
- clean Python 3.11 coverage is 19.52%; the initial 19% floor leaves a small platform margin and can ratchet upward with future test migrations

## Validation
- clean Python 3.11 editable install: Ruff tests gate passed
- `55 passed, 2 skipped`; 19.52% coverage; 19% floor passed
- actionlint passed
- standard premerge canary after rebase: 16/16 selected checks passed; public boundary clean; no manual holds

## Scope
No production behavior changes and no automated rewrite of existing lint debt.