### PR TITLE
Gate SkillsBench goal kickoff on prompt release

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -1435,6 +1435,7 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
         build_codex_cli_tui_command,
         build_codex_cli_goal_tui_input,
         codex_cli_goal_lifecycle_marker_counts,
+        codex_cli_goal_should_submit_kickoff,
         codex_cli_goal_watchdog_expired,
     )
     from loopx.benchmark_adapters.skillsbench_acp_relay import (
@@ -1452,6 +1453,22 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_FILENAME in objective, objective
     assert len(objective) < CODEX_CLI_GOAL_OBJECTIVE_MAX_CHARS
     assert build_codex_cli_goal_tui_input(objective).startswith("/goal "), objective
+    kickoff_state = {
+        "bridge_enabled": True,
+        "goal_active_observed": True,
+        "kickoff_submitted": False,
+        "turn_active": False,
+        "first_action_seen": False,
+        "capture": "Goal active\n› ",
+    }
+    assert not codex_cli_goal_should_submit_kickoff(
+        task_prompt_released=False,
+        **kickoff_state,
+    )
+    assert codex_cli_goal_should_submit_kickoff(
+        task_prompt_released=True,
+        **kickoff_state,
+    )
     cmd = build_codex_cli_tui_command(
         codex_bin="codex",
         sandbox="workspace-write",
@@ -1586,6 +1603,7 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "turn_active = codex_cli_tui_turn_active(capture)" in source
     assert "goal_kickoff_prompt_submitted = False" in source
     assert "kickoff_submitted=goal_kickoff_prompt_submitted" in source
+    assert "task_prompt_released=task_prompt_released" in source
     assert "text=CODEX_CLI_GOAL_KICKOFF_PROMPT" in source
     assert "goal_failed_now = False" in source
     assert "goal_lifecycle.failed_advanced" in source

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -1225,6 +1225,7 @@ class SkillsBenchLocalAcpRelay:
                     if codex_cli_goal_should_submit_kickoff(
                         bridge_enabled=bridge_summary_path is not None,
                         goal_active_observed=goal_active_observed,
+                        task_prompt_released=task_prompt_released,
                         kickoff_submitted=goal_kickoff_prompt_submitted,
                         turn_active=turn_active,
                         first_action_seen=first_action_seen,

--- a/loopx/codex_cli_goal_tui.py
+++ b/loopx/codex_cli_goal_tui.py
@@ -497,6 +497,7 @@ def codex_cli_goal_should_submit_kickoff(
     *,
     bridge_enabled: bool,
     goal_active_observed: bool,
+    task_prompt_released: bool,
     kickoff_submitted: bool,
     turn_active: bool,
     first_action_seen: bool,
@@ -505,6 +506,7 @@ def codex_cli_goal_should_submit_kickoff(
     return (
         bridge_enabled
         and goal_active_observed
+        and task_prompt_released
         and not kickoff_submitted
         and not turn_active
         and not first_action_seen


### PR DESCRIPTION
## Summary
- require staged task prompt release before same-thread SkillsBench goal kickoff
- pass the explicit release state through the relay
- cover both rejected-before-release and accepted-after-release decisions

## Validation
- `python3 examples/codex-cli-goal-tui-session-smoke.py`
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 examples/skillsbench-host-local-launch-plan-smoke.py`
- `python3 examples/skillsbench-reverse-channel-bridge-smoke.py`
- `python3 examples/skillsbench-benchmark-egress-policy-smoke.py`
- `python3 examples/skillsbench-failure-attribution-smoke.py`
- `python3 examples/skillsbench-runner-core-contract-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- changed-file `py_compile` and `git diff --check`
- `loopx canary premerge --from-git-diff` (all selected checks passed; expected benchmark-sensitive manual hold)

## Boundary
No scoring, verifier, task, permission, submission, or launch-policy changes. This closes the public-trace failure where kickoff was submitted before any bridge request and before the staged prompt existed.