### PR TITLE
Add opt-in supervisor inject adapter

### DIFF
--- a/docs/reference/protocols/peer-supervisor-v0.md
+++ b/docs/reference/protocols/peer-supervisor-v0.md
@@ -106,12 +106,14 @@ loopx supervisor-event receipt \
 
 An `executed` receipt is stricter: it can only be appended through the host
 adapter API, which supplies verified capabilities outside the editable receipt
-JSON. It also requires an opaque authority reference and compact evidence
-references. Missing capability, authority, or evidence fails closed. A normal
-CLI caller therefore cannot promote a proposal to executed merely by naming a
-capability. `rejected` and `failed` receipts remain durable attempt evidence
-without projecting success. Reusing the same record id is idempotent when the
-payload matches and a conflict when it differs.
+JSON. It also requires an opaque authority reference, compact evidence
+references, and an explicit rollback boundary. Rollback mode is closed to
+`compensating_action` or `not_reversible`; neither mode authorizes automatic
+rollback. Missing capability, authority, evidence, or rollback boundary fails
+closed. A normal CLI caller therefore cannot promote a proposal to executed
+merely by naming a capability. `rejected` and `failed` receipts remain durable
+attempt evidence without projecting success. Reusing the same record id is
+idempotent when the payload matches and a conflict when it differs.
 
 Read the compact projection with:
 
@@ -143,6 +145,23 @@ The v0 CLI does not execute these actions. Missing host capabilities leave the
 proposal unexecuted; a model response is never accepted as proof that a session
 was injected, forked, or terminated. Destructive actions require explicit host
 authority even after an executor exists.
+
+## Opt-In Inject Adapter Canary
+
+`loopx.control_plane.agents.supervisor_inject` exposes one narrow Python host
+seam for `inject`. LoopX ships no default adapter and no CLI switch that enables
+it. A host must explicitly supply an adapter with
+`session_message_injection`, a rollback mode and opaque rollback policy ref,
+plus an authority ref for the individual execution. Dry-run validates the
+entire request without calling the host.
+
+On execution, the adapter receives a stable `SupervisorInjectRequest` and must
+return a typed `SupervisorInjectResult`. LoopX then appends the capability-
+matched receipt. A prior executed receipt suppresses a second host call, so a
+repeated control-plane request is idempotent. The rollback field records the
+boundary; it does not retract a message or grant authority to send a
+compensating message. `handoff` and `discard` remain proposal-only until their
+own host contracts and safety evidence exist.
 
 ## Authority Boundaries
 

--- a/examples/control_plane/peer-supervisor-event-smoke.py
+++ b/examples/control_plane/peer-supervisor-event-smoke.py
@@ -90,6 +90,11 @@ def executed_receipt(receipt_id: str = "receipt-inject-1") -> dict:
         "adapter_id": "fixture-host",
         "outcome": "executed",
         "authority_ref": "owner-gate:inject-1",
+        "rollback_boundary": {
+            "mode": "compensating_action",
+            "ref": "policy:fixture-inject-compensation",
+            "automatic": False,
+        },
         "evidence_refs": ["host-effect:inject-1"],
         "reason_codes": ["adapter-success"],
     }
@@ -159,6 +164,21 @@ def main() -> int:
             assert "missing required host capabilities" in str(exc), exc
         else:
             raise AssertionError("executed receipt must prove required capabilities")
+
+        receipt_without_rollback = executed_receipt("receipt-missing-rollback")
+        receipt_without_rollback.pop("rollback_boundary")
+        try:
+            record_supervisor_receipt(
+                log_path=event_log,
+                goal_id=GOAL_ID,
+                receipt=receipt_without_rollback,
+                host_capabilities=["session_message_injection"],
+                execute=True,
+            )
+        except ValueError as exc:
+            assert "requires rollback_boundary" in str(exc), exc
+        else:
+            raise AssertionError("executed receipt must declare a rollback boundary")
 
         receipt = record_supervisor_receipt(
             log_path=event_log,

--- a/examples/control_plane/peer-supervisor-inject-adapter-smoke.py
+++ b/examples/control_plane/peer-supervisor-inject-adapter-smoke.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Exercise the default-off supervisor inject host adapter seam."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.configure_goal import configure_goal  # noqa: E402
+from loopx.control_plane.agents.supervisor_events import (  # noqa: E402
+    SupervisorReceiptOutcome,
+    SupervisorRollbackMode,
+    record_supervisor_proposal,
+    supervisor_event_log_path,
+)
+from loopx.control_plane.agents.supervisor_inject import (  # noqa: E402
+    SupervisorInjectRequest,
+    SupervisorInjectResult,
+    execute_supervisor_inject,
+)
+
+
+GOAL_ID = "peer-supervisor-inject-adapter-fixture"
+AGENTS = ["codex-alpha", "codex-beta"]
+
+
+class FixtureInjectAdapter:
+    adapter_id = "fixture-inject-host"
+    capabilities = ("session_message_injection",)
+    rollback_mode = SupervisorRollbackMode.COMPENSATING_ACTION
+    rollback_ref = "policy:fixture-compensating-message"
+
+    def __init__(self) -> None:
+        self.requests: list[SupervisorInjectRequest] = []
+
+    def inject(self, request: SupervisorInjectRequest) -> SupervisorInjectResult:
+        self.requests.append(request)
+        return SupervisorInjectResult(
+            outcome=SupervisorReceiptOutcome.EXECUTED,
+            evidence_refs=(f"host-effect:{request.execution_id}",),
+            reason_codes=("adapter-success",),
+        )
+
+
+class MissingCapabilityAdapter(FixtureInjectAdapter):
+    capabilities = ()
+
+
+class MissingRollbackAdapter(FixtureInjectAdapter):
+    rollback_ref = ""
+
+
+def write_registry(root: Path) -> tuple[Path, dict]:
+    state_file = root / "ACTIVE_GOAL_STATE.md"
+    state_file.write_text("---\nstatus: active\n---\n", encoding="utf-8")
+    registry_path = root / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "peer-supervisor-inject-adapter-smoke",
+                        "repo": str(root),
+                        "state_file": state_file.name,
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": AGENTS,
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    configure_goal(
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        supervisor_agent=AGENTS[0],
+        supervised_agents=[AGENTS[1]],
+        execute=True,
+    )
+    goal = json.loads(registry_path.read_text(encoding="utf-8"))["goals"][0]
+    return registry_path, goal["coordination"]["supervisor"]
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-supervisor-inject-") as tmp:
+        root = Path(tmp)
+        _, supervisor = write_registry(root)
+        log_path = supervisor_event_log_path(root / "runtime", GOAL_ID)
+        record_supervisor_proposal(
+            log_path=log_path,
+            goal_id=GOAL_ID,
+            supervisor=supervisor,
+            decision={
+                "decision_id": "inject-canary",
+                "kind": "inject",
+                "target_agent_id": AGENTS[1],
+                "message": "Inspect the compact effect reference before continuing.",
+                "reason_codes": ["evidence-gap"],
+                "evidence_refs": ["effect:inject-canary"],
+            },
+            execute=True,
+        )
+
+        adapter = FixtureInjectAdapter()
+        preview = execute_supervisor_inject(
+            log_path=log_path,
+            goal_id=GOAL_ID,
+            decision_id="inject-canary",
+            execution_id="inject-execution-1",
+            authority_ref="owner-gate:inject-canary",
+            adapter=adapter,
+            execute=False,
+        )
+        assert preview["dry_run"] is True and preview["would_execute"] is True, preview
+        assert preview["host_called"] is False and not adapter.requests, preview
+
+        missing = MissingCapabilityAdapter()
+        try:
+            execute_supervisor_inject(
+                log_path=log_path,
+                goal_id=GOAL_ID,
+                decision_id="inject-canary",
+                execution_id="inject-execution-missing-capability",
+                authority_ref="owner-gate:inject-canary",
+                adapter=missing,
+                execute=True,
+            )
+        except ValueError as exc:
+            assert "missing declared capability" in str(exc), exc
+        else:
+            raise AssertionError("missing adapter capability must fail before host execution")
+        assert not missing.requests
+
+        missing_rollback = MissingRollbackAdapter()
+        try:
+            execute_supervisor_inject(
+                log_path=log_path,
+                goal_id=GOAL_ID,
+                decision_id="inject-canary",
+                execution_id="inject-execution-missing-rollback",
+                authority_ref="owner-gate:inject-canary",
+                adapter=missing_rollback,
+                execute=True,
+            )
+        except ValueError as exc:
+            assert "adapter rollback_ref" in str(exc), exc
+        else:
+            raise AssertionError("missing rollback policy must fail before host execution")
+        assert not missing_rollback.requests
+
+        executed = execute_supervisor_inject(
+            log_path=log_path,
+            goal_id=GOAL_ID,
+            decision_id="inject-canary",
+            execution_id="inject-execution-1",
+            authority_ref="owner-gate:inject-canary",
+            adapter=adapter,
+            execute=True,
+        )
+        assert executed["host_called"] is True and len(adapter.requests) == 1, executed
+        receipt = executed["receipt"]
+        assert receipt["outcome"] == "executed", receipt
+        assert receipt["capabilities"] == ["session_message_injection"], receipt
+        assert receipt["rollback_boundary"] == {
+            "mode": "compensating_action",
+            "ref": "policy:fixture-compensating-message",
+            "automatic": False,
+            "requires_explicit_authority": True,
+        }, receipt
+
+        repeated = execute_supervisor_inject(
+            log_path=log_path,
+            goal_id=GOAL_ID,
+            decision_id="inject-canary",
+            execution_id="inject-execution-2",
+            authority_ref="owner-gate:inject-canary",
+            adapter=adapter,
+            execute=True,
+        )
+        assert repeated["already_executed"] is True, repeated
+        assert repeated["host_called"] is False and len(adapter.requests) == 1, repeated
+
+    print("peer-supervisor-inject-adapter-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/control_plane/agents/supervisor.py
+++ b/loopx/control_plane/agents/supervisor.py
@@ -459,7 +459,7 @@ only after validation; the local JSON path is not stored:
 
 This prototype is proposal-only. Never claim an injection, handoff, discard, or
 session termination happened unless a host adapter exposes every required
-capability and appends a capability-matched `supervisor_host_receipt_v0` with
+capability and appends a capability-matched `supervisor_host_receipt_v1` with
 authority and evidence references. A proposal record is never execution
 evidence. Missing capabilities leave the proposal unexecuted. Do not mutate
 peer claims merely to make the proposal look resolved.

--- a/loopx/control_plane/agents/supervisor_events.py
+++ b/loopx/control_plane/agents/supervisor_events.py
@@ -20,7 +20,7 @@ from .supervisor import normalize_supervisor_decision
 
 SUPERVISOR_EVENT_LOG_NAME = "supervisor-events.jsonl"
 SUPERVISOR_EVENT_PROJECTION_SCHEMA_VERSION = "supervisor_event_projection_v0"
-SUPERVISOR_RECEIPT_SCHEMA_VERSION = "supervisor_host_receipt_v0"
+SUPERVISOR_RECEIPT_SCHEMA_VERSION = "supervisor_host_receipt_v1"
 
 _INLINE_SECRET_PATTERN = re.compile(
     r"(?i)\b(?:ak|sk|access[_-]?key|secret[_-]?key)\b\s*[:=]\s*\S+"
@@ -31,6 +31,11 @@ class SupervisorReceiptOutcome(str, Enum):
     EXECUTED = "executed"
     REJECTED = "rejected"
     FAILED = "failed"
+
+
+class SupervisorRollbackMode(str, Enum):
+    COMPENSATING_ACTION = "compensating_action"
+    NOT_REVERSIBLE = "not_reversible"
 
 
 def supervisor_event_log_path(runtime_root: Path, goal_id: str) -> Path:
@@ -126,6 +131,25 @@ def normalize_supervisor_receipt(
     required_capabilities = list(decision.get("required_host_capabilities") or [])
     missing_capabilities = sorted(set(required_capabilities) - set(capabilities))
     authority_ref = normalize_todo_claimed_by(raw.get("authority_ref"))
+    raw_rollback = raw.get("rollback_boundary")
+    rollback_boundary = None
+    if raw_rollback is not None:
+        if not isinstance(raw_rollback, Mapping):
+            raise ValueError("rollback_boundary must be an object")
+        try:
+            rollback_mode = SupervisorRollbackMode(str(raw_rollback.get("mode") or ""))
+        except ValueError as exc:
+            choices = ", ".join(item.value for item in SupervisorRollbackMode)
+            raise ValueError(f"rollback_boundary.mode must be one of: {choices}") from exc
+        rollback_ref = _required_token(raw_rollback, "ref")
+        if raw_rollback.get("automatic") is not False:
+            raise ValueError("rollback_boundary.automatic must be false")
+        rollback_boundary = {
+            "mode": rollback_mode.value,
+            "ref": rollback_ref,
+            "automatic": False,
+            "requires_explicit_authority": True,
+        }
     if outcome is SupervisorReceiptOutcome.EXECUTED:
         if missing_capabilities:
             raise ValueError(
@@ -134,6 +158,8 @@ def normalize_supervisor_receipt(
             )
         if not authority_ref:
             raise ValueError("executed receipt requires authority_ref")
+        if rollback_boundary is None:
+            raise ValueError("executed receipt requires rollback_boundary")
 
     receipt = {
         "schema_version": SUPERVISOR_RECEIPT_SCHEMA_VERSION,
@@ -147,6 +173,7 @@ def normalize_supervisor_receipt(
         "capability_match": not missing_capabilities,
         "missing_capabilities": missing_capabilities,
         "authority_ref": authority_ref,
+        "rollback_boundary": rollback_boundary,
         "evidence_refs": evidence_refs,
         "reason_codes": reason_codes,
     }

--- a/loopx/control_plane/agents/supervisor_inject.py
+++ b/loopx/control_plane/agents/supervisor_inject.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from ...event_sourced_state import SUPERVISOR_PROPOSED, AppendOnlyStateEventStore
+from ..todos.contract import normalize_todo_claimed_by
+from .supervisor_events import (
+    SupervisorReceiptOutcome,
+    SupervisorRollbackMode,
+    load_supervisor_event_projection,
+    record_supervisor_receipt,
+)
+
+
+SUPERVISOR_INJECT_CAPABILITY = "session_message_injection"
+SUPERVISOR_INJECT_ADAPTER_SCHEMA_VERSION = "supervisor_inject_adapter_v0"
+
+
+@dataclass(frozen=True)
+class SupervisorInjectRequest:
+    goal_id: str
+    decision_id: str
+    execution_id: str
+    target_agent_id: str
+    message: str
+    authority_ref: str
+
+
+@dataclass(frozen=True)
+class SupervisorInjectResult:
+    outcome: SupervisorReceiptOutcome
+    evidence_refs: tuple[str, ...]
+    reason_codes: tuple[str, ...]
+
+
+class SupervisorInjectHostAdapter(Protocol):
+    """One opt-in host seam; LoopX does not provide a default implementation."""
+
+    adapter_id: str
+    capabilities: tuple[str, ...]
+    rollback_mode: SupervisorRollbackMode
+    rollback_ref: str
+
+    def inject(self, request: SupervisorInjectRequest) -> SupervisorInjectResult:
+        ...
+
+
+def _required_token(raw: object, *, field: str) -> str:
+    token = normalize_todo_claimed_by(raw)
+    if not token:
+        raise ValueError(f"{field} must be a compact token")
+    return token
+
+
+def _capabilities(adapter: SupervisorInjectHostAdapter) -> list[str]:
+    capabilities = []
+    for raw in adapter.capabilities:
+        token = _required_token(raw, field="adapter capabilities")
+        if token not in capabilities:
+            capabilities.append(token)
+    if SUPERVISOR_INJECT_CAPABILITY not in capabilities:
+        raise ValueError(
+            "inject adapter is missing declared capability: "
+            + SUPERVISOR_INJECT_CAPABILITY
+        )
+    return capabilities
+
+
+def _proposal(log_path: Path, *, goal_id: str, decision_id: str) -> dict:
+    for event in AppendOnlyStateEventStore(log_path).load():
+        if (
+            event.get("event_type") == SUPERVISOR_PROPOSED
+            and event.get("goal_id") == goal_id
+            and (event.get("refs") or {}).get("decision_id") == decision_id
+        ):
+            return event
+    raise ValueError(f"no recorded supervisor proposal for decision_id={decision_id}")
+
+
+def execute_supervisor_inject(
+    *,
+    log_path: Path,
+    goal_id: str,
+    decision_id: str,
+    execution_id: str,
+    authority_ref: str,
+    adapter: SupervisorInjectHostAdapter,
+    execute: bool,
+) -> dict:
+    """Preview or execute one proposal through an explicitly supplied host adapter."""
+
+    normalized_decision_id = _required_token(decision_id, field="decision_id")
+    normalized_execution_id = _required_token(execution_id, field="execution_id")
+    normalized_authority_ref = _required_token(authority_ref, field="authority_ref")
+    adapter_id = _required_token(adapter.adapter_id, field="adapter_id")
+    capabilities = _capabilities(adapter)
+    try:
+        rollback_mode = SupervisorRollbackMode(adapter.rollback_mode)
+    except ValueError as exc:
+        choices = ", ".join(item.value for item in SupervisorRollbackMode)
+        raise ValueError(f"adapter rollback_mode must be one of: {choices}") from exc
+    rollback_ref = _required_token(adapter.rollback_ref, field="adapter rollback_ref")
+
+    proposal_event = _proposal(
+        log_path,
+        goal_id=goal_id,
+        decision_id=normalized_decision_id,
+    )
+    decision = ((proposal_event.get("payload") or {}).get("decision") or {})
+    if decision.get("kind") != "inject":
+        raise ValueError("supervisor inject adapter only accepts inject proposals")
+    if decision.get("required_host_capabilities") != [SUPERVISOR_INJECT_CAPABILITY]:
+        raise ValueError("inject proposal capability contract is not canonical")
+
+    projection = load_supervisor_event_projection(log_path, goal_id=goal_id)
+    prior = next(
+        (
+            item
+            for item in projection.get("items") or []
+            if item.get("decision_id") == normalized_decision_id
+            and item.get("execution_status") == SupervisorReceiptOutcome.EXECUTED.value
+        ),
+        None,
+    )
+    request = SupervisorInjectRequest(
+        goal_id=goal_id,
+        decision_id=normalized_decision_id,
+        execution_id=normalized_execution_id,
+        target_agent_id=str(decision.get("target_agent_id") or ""),
+        message=str(decision.get("message") or ""),
+        authority_ref=normalized_authority_ref,
+    )
+    adapter_contract = {
+        "adapter_id": adapter_id,
+        "capabilities": capabilities,
+        "rollback_boundary": {
+            "mode": rollback_mode.value,
+            "ref": rollback_ref,
+            "automatic": False,
+            "requires_explicit_authority": True,
+        },
+    }
+    if prior is not None:
+        return {
+            "ok": True,
+            "schema_version": SUPERVISOR_INJECT_ADAPTER_SCHEMA_VERSION,
+            "mode": "supervisor_inject",
+            "dry_run": not execute,
+            "host_called": False,
+            "already_executed": True,
+            "adapter": adapter_contract,
+            "request": request.__dict__,
+            "receipt": prior.get("latest_receipt"),
+            "projection": projection,
+        }
+    if not execute:
+        return {
+            "ok": True,
+            "schema_version": SUPERVISOR_INJECT_ADAPTER_SCHEMA_VERSION,
+            "mode": "supervisor_inject",
+            "dry_run": True,
+            "host_called": False,
+            "already_executed": False,
+            "would_execute": True,
+            "adapter": adapter_contract,
+            "request": request.__dict__,
+            "projection": projection,
+        }
+
+    result = adapter.inject(request)
+    if not isinstance(result, SupervisorInjectResult):
+        raise ValueError("inject adapter must return SupervisorInjectResult")
+    outcome = SupervisorReceiptOutcome(result.outcome)
+    receipt_payload = {
+        "receipt_id": normalized_execution_id,
+        "decision_id": normalized_decision_id,
+        "adapter_id": adapter_id,
+        "outcome": outcome.value,
+        "authority_ref": normalized_authority_ref,
+        "evidence_refs": list(result.evidence_refs),
+        "reason_codes": list(result.reason_codes),
+        "rollback_boundary": adapter_contract["rollback_boundary"],
+    }
+    recorded = record_supervisor_receipt(
+        log_path=log_path,
+        goal_id=goal_id,
+        receipt=receipt_payload,
+        host_capabilities=capabilities,
+        execute=True,
+    )
+    return {
+        "ok": True,
+        "schema_version": SUPERVISOR_INJECT_ADAPTER_SCHEMA_VERSION,
+        "mode": "supervisor_inject",
+        "dry_run": False,
+        "host_called": True,
+        "already_executed": False,
+        "adapter": adapter_contract,
+        "request": request.__dict__,
+        "receipt": ((recorded.get("event") or {}).get("payload") or {}).get("receipt"),
+        "projection": recorded.get("projection"),
+    }


### PR DESCRIPTION
## Summary
- add one default-off Python host adapter seam for supervisor `inject`
- require declared session injection capability, per-execution authority, and an explicit non-automatic rollback boundary
- persist typed host receipts and suppress repeat host calls after an executed receipt
- keep `handoff` and `discard` proposal-only

## Validation
- `.venv/bin/pytest -q -n 2`: 55 passed, 2 skipped
- focused peer supervisor proposal, event, and inject smokes passed
- ruff passed on changed Python surfaces
- `loopx canary premerge --from-git-diff`: 11 selected, 11 passed, 0 manual holds
- public/private boundary scan clean

## Boundary
Experimental and opt-in. LoopX ships no default adapter, CLI activation switch, session runtime integration, automatic rollback, or destructive intervention.