### PR TITLE
Protect clean core namespaces with Ruff

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -41,7 +41,16 @@ jobs:
         run: python -m pip install --disable-pip-version-check -e ".[test]"
 
       - name: Lint test suite
-        run: python -m ruff check tests
+        run: >-
+          python -m ruff check
+          tests
+          loopx/canary
+          loopx/control_plane/agents
+          loopx/control_plane/goals
+          loopx/control_plane/handoff
+          loopx/control_plane/quota
+          loopx/control_plane/work_items
+          loopx/domain_packs
 
       - name: Run fast tests
         run: >-

--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -317,12 +317,14 @@ python3 -m pytest tests/test_smoke_suite.py \
   --junitxml smoke-suite.xml
 ```
 
-The required Python test workflow also keeps `tests/**` Ruff-clean and enforces
-an initial 19% package coverage floor. The floor is intentionally a
-regression guard, not a claim that 19% is sufficient; raise it as durable
-behavior moves from subprocess smokes into focused tests. Existing source-wide
-lint debt is characterized separately and must not be mass-fixed merely to
-make the first gate green.
+The required Python test workflow keeps `tests/**` and the currently clean
+`canary`, `domain_packs`, `control_plane/{agents,goals,handoff,quota,work_items}`
+namespaces Ruff-clean. It also enforces an initial 19% package coverage floor.
+The floor is intentionally a regression guard, not a claim that 19% is
+sufficient; raise it as durable behavior moves from subprocess smokes into
+focused tests. Existing source-wide lint debt is characterized separately;
+expand the protected namespace list only after a bounded cleanup, rather than
+mass-fixing unrelated code merely to make a broad gate green.
 
 If the source checkout has optional frontend dependencies installed, dashboard
 readiness can be included in the same canary. If a release snapshot omits the


### PR DESCRIPTION
## Summary
- extend the required Ruff check from tests into seven currently debt-free core namespaces
- document the protected production boundary and the incremental expansion policy

## Protected namespaces
- `loopx/canary`
- `loopx/domain_packs`
- `loopx/control_plane/{agents,goals,handoff,quota,work_items}`

## Characterization
Source-wide Ruff still has 506 historical findings. `runtime`, `scheduler`, `todos`, and `presentation` each retain known findings and are intentionally not swept into this gate.

## Validation
- exact expanded Ruff command passed after rebasing through PR #1904
- actionlint passed
- standard premerge canary: 16/16 selected checks passed; public boundary clean; no manual holds

## Scope
No runtime behavior or automated source rewrite.