### PR TITLE
Fix and protect remaining core Ruff boundaries

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -45,12 +45,9 @@ jobs:
           python -m ruff check
           tests
           loopx/canary
-          loopx/control_plane/agents
-          loopx/control_plane/goals
-          loopx/control_plane/handoff
-          loopx/control_plane/quota
-          loopx/control_plane/work_items
+          loopx/control_plane
           loopx/domain_packs
+          loopx/presentation
 
       - name: Run fast tests
         run: >-

--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -317,9 +317,9 @@ python3 -m pytest tests/test_smoke_suite.py \
   --junitxml smoke-suite.xml
 ```
 
-The required Python test workflow keeps `tests/**` and the currently clean
-`canary`, `domain_packs`, `control_plane/{agents,goals,handoff,quota,work_items}`
-namespaces Ruff-clean. It also enforces an initial 19% package coverage floor.
+The required Python test workflow keeps `tests/**`, `canary/**`,
+`control_plane/**`, `domain_packs/**`, and `presentation/**` Ruff-clean. It also
+enforces an initial 19% package coverage floor.
 The floor is intentionally a regression guard, not a claim that 19% is
 sufficient; raise it as durable behavior moves from subprocess smokes into
 focused tests. Existing source-wide lint debt is characterized separately;

--- a/loopx/control_plane/runtime/event_ledger.py
+++ b/loopx/control_plane/runtime/event_ledger.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Any, Callable, Iterable, Optional
 
 from .time import now_utc

--- a/loopx/control_plane/scheduler/time.py
+++ b/loopx/control_plane/scheduler/time.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 from ..runtime.time import parse_timestamp

--- a/loopx/control_plane/status_runtime_summaries.py
+++ b/loopx/control_plane/status_runtime_summaries.py
@@ -100,8 +100,11 @@ def build_status_runtime_summaries(
     todo_index_limit: int,
     context: StatusRuntimeSummaryContext,
 ) -> dict[str, Any]:
-    event_class_for_run = lambda run: event_ledger_event_class(run, context=context)
-    decision_kinds = lambda run: decision_event_kinds(run, context=context)
+    def event_class_for_run(run: dict[str, Any]) -> str:
+        return event_ledger_event_class(run, context=context)
+
+    def decision_kinds(run: dict[str, Any]) -> list[str]:
+        return decision_event_kinds(run, context=context)
 
     return {
         "run_history": build_run_history(

--- a/loopx/control_plane/todos/contract.py
+++ b/loopx/control_plane/todos/contract.py
@@ -799,7 +799,7 @@ def format_todo_metadata_line(
     if removed_continuation_policy and not normalized_removed_continuation_policy:
         raise ValueError(
             "removed_continuation_policy must be one of: "
-            + ", ".join(sorted(REMOVED_TODO_CONTINUATION_POLICY_VALUES))
+            + ", ".join(sorted(TODO_REMOVED_REVIEW_CONTINUATION_POLICY_VALUES))
         )
     if normalized_continuation_policy and normalized_removed_continuation_policy:
         raise ValueError(

--- a/loopx/presentation/sinks/lark/kanban.py
+++ b/loopx/presentation/sinks/lark/kanban.py
@@ -31,7 +31,10 @@ from .projection_rows import (
     projection_text_list as _as_text_list,
     todo_matches_agent_scope,
 )
-from .sync_receipt import compact_lark_kanban_sync_receipt, render_lark_kanban_markdown
+from .sync_receipt import (
+    compact_lark_kanban_sync_receipt as compact_lark_kanban_sync_receipt,
+    render_lark_kanban_markdown as render_lark_kanban_markdown,
+)
 
 LARK_KANBAN_SCHEMA_VERSION = "loopx_lark_kanban_control_plane_v0"
 LARK_KANBAN_HEARTBEAT_VERSION = "loopx_lark_kanban_heartbeat_v0"

--- a/tests/control_plane/test_contract_quality.py
+++ b/tests/control_plane/test_contract_quality.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import get_type_hints
+
+import pytest
+
+from loopx.control_plane.scheduler.time import parse_scheduler_timestamp
+from loopx.control_plane.todos.contract import format_todo_metadata_line
+from loopx.presentation.sinks.lark import kanban, sync_receipt
+
+
+def test_scheduler_timestamp_return_annotation_resolves() -> None:
+    hints = get_type_hints(parse_scheduler_timestamp)
+
+    assert hints["return"] == datetime | None
+
+
+def test_invalid_removed_continuation_policy_reports_allowed_values() -> None:
+    with pytest.raises(
+        ValueError,
+        match=(
+            "removed_continuation_policy must be one of: primary_review, review_handoff"
+        ),
+    ):
+        format_todo_metadata_line(
+            todo_id="todo_contract_quality",
+            removed_continuation_policy="invalid_policy",
+        )
+
+
+def test_lark_kanban_preserves_sync_receipt_compatibility_exports() -> None:
+    assert (
+        kanban.compact_lark_kanban_sync_receipt
+        is sync_receipt.compact_lark_kanban_sync_receipt
+    )
+    assert (
+        kanban.render_lark_kanban_markdown is sync_receipt.render_lark_kanban_markdown
+    )


### PR DESCRIPTION
## Summary
- fix scheduler annotation resolution and the invalid removed-continuation-policy error path
- preserve the Lark kanban compatibility re-exports explicitly and cover them with contract tests
- extend required Ruff coverage to all of `loopx/control_plane/**` and `loopx/presentation/**`

## Validation
- `python -m ruff check tests loopx/canary loopx/control_plane loopx/domain_packs loopx/presentation`
- `pytest -q -n 2 --cov=loopx --cov-report= --cov-fail-under=19` (58 passed, 2 skipped; 19.51%)
- focused status, scheduler, todo, and compatibility contract tests/smokes
- `actionlint .github/workflows/python-tests.yml`
- standard `loopx canary premerge --from-git-diff`: 17/17 checks passed, public-boundary scan clean, no manual holds
