### PR TITLE
Drive SkillsBench goal through two-stage followups

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -1426,6 +1426,8 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     sys.path.insert(0, str(REPO_ROOT))
     from loopx.codex_cli_goal_tui import (
         CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_FILENAME,
+        CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_KICKOFF_PROMPT,
+        CODEX_CLI_GOAL_KICKOFF_PROMPT,
         CODEX_CLI_GOAL_OBJECTIVE_MAX_CHARS,
         CODEX_CLI_GOAL_TASK_PROMPT_FILENAME,
         CODEX_CLI_GOAL_THREAD_PREWARM_MARKER,
@@ -1435,7 +1437,7 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
         build_codex_cli_tui_command,
         build_codex_cli_goal_tui_input,
         codex_cli_goal_lifecycle_marker_counts,
-        codex_cli_goal_should_submit_kickoff,
+        codex_cli_goal_followup_prompt,
         codex_cli_goal_watchdog_expired,
     )
     from loopx.benchmark_adapters.skillsbench_acp_relay import (
@@ -1453,21 +1455,36 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_FILENAME in objective, objective
     assert len(objective) < CODEX_CLI_GOAL_OBJECTIVE_MAX_CHARS
     assert build_codex_cli_goal_tui_input(objective).startswith("/goal "), objective
-    kickoff_state = {
+    followup_state = {
         "bridge_enabled": True,
         "goal_active_observed": True,
-        "kickoff_submitted": False,
         "turn_active": False,
         "first_action_seen": False,
         "capture": "Goal active\n› ",
     }
-    assert not codex_cli_goal_should_submit_kickoff(
+    assert codex_cli_goal_followup_prompt(
         task_prompt_released=False,
-        **kickoff_state,
+        bridge_first_action_kickoff_submitted=False,
+        task_kickoff_submitted=False,
+        **followup_state,
+    ) == CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_KICKOFF_PROMPT
+    assert not codex_cli_goal_followup_prompt(
+        task_prompt_released=False,
+        bridge_first_action_kickoff_submitted=True,
+        task_kickoff_submitted=False,
+        **followup_state,
     )
-    assert codex_cli_goal_should_submit_kickoff(
+    assert codex_cli_goal_followup_prompt(
         task_prompt_released=True,
-        **kickoff_state,
+        bridge_first_action_kickoff_submitted=True,
+        task_kickoff_submitted=False,
+        **followup_state,
+    ) == CODEX_CLI_GOAL_KICKOFF_PROMPT
+    assert not codex_cli_goal_followup_prompt(
+        task_prompt_released=True,
+        bridge_first_action_kickoff_submitted=True,
+        task_kickoff_submitted=True,
+        **followup_state,
     )
     cmd = build_codex_cli_tui_command(
         codex_bin="codex",
@@ -1575,7 +1592,7 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "release_codex_cli_goal_task_prompt(" in source
     assert "build_codex_cli_goal_bridge_first_action_objective(" in source
     assert source.index("release_codex_cli_goal_task_prompt(") < source.index(
-        "text=CODEX_CLI_GOAL_KICKOFF_PROMPT"
+        "text=followup_prompt"
     )
     assert "tmux_type_text_and_submit(" in source
     assert "build_codex_cli_goal_tui_input(prompt_for_codex)" not in source
@@ -1602,9 +1619,9 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "_bridge_summary_has_successful_task_operation(" in source
     assert "turn_active = codex_cli_tui_turn_active(capture)" in source
     assert "goal_kickoff_prompt_submitted = False" in source
-    assert "kickoff_submitted=goal_kickoff_prompt_submitted" in source
+    assert "followup_prompt = codex_cli_goal_followup_prompt(" in source
     assert "task_prompt_released=task_prompt_released" in source
-    assert "text=CODEX_CLI_GOAL_KICKOFF_PROMPT" in source
+    assert "text=followup_prompt" in source
     assert "goal_failed_now = False" in source
     assert "goal_lifecycle.failed_advanced" in source
     assert "goal_lifecycle.active_observed" in source
@@ -1652,9 +1669,11 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     )
     assert '"--disable",\n        "apps",' in tui_source
     assert "CODEX_CLI_GOAL_KICKOFF_PROMPT = (" in tui_source
+    assert "CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_KICKOFF_PROMPT = (" in tui_source
     assert "Start working on the active SkillsBench goal now" in tui_source
     assert "def codex_cli_goal_watchdog_expired(" in tui_source
-    assert "not kickoff_submitted" in tui_source
+    assert "bridge_first_action_kickoff_submitted" in tui_source
+    assert "task_kickoff_submitted" in tui_source
     assert "def codex_cli_goal_reset_pre_bridge_deadlines(" in tui_source
     assert '"goal_submission_generation"' in tui_source
     assert 'fields[f"goal_{name}_marker_delta"]' in tui_source

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -54,7 +54,6 @@ from loopx.benchmark_adapters.skillsbench_codex_goal_recovery import (
     write_private_codex_cli_goal_tui_tail,
 )
 from loopx.codex_cli_goal_tui import (
-    CODEX_CLI_GOAL_KICKOFF_PROMPT,
     CODEX_CLI_GOAL_TASK_PROMPT_FILENAME,
     build_codex_cli_goal_bridge_first_action_objective,
     build_codex_cli_goal_tui_input,
@@ -63,7 +62,7 @@ from loopx.codex_cli_goal_tui import (
     codex_cli_goal_watchdog_expired,
     codex_cli_goal_reset_pre_bridge_deadlines,
     codex_cli_goal_should_ignore_stale_terminal,
-    codex_cli_goal_should_submit_kickoff,
+    codex_cli_goal_followup_prompt,
     codex_cli_tui_environment,
     codex_cli_tui_shell_command,
     codex_cli_tui_input_prompt_visible,
@@ -1074,6 +1073,7 @@ class SkillsBenchLocalAcpRelay:
             goal_terminal_observed = False
             goal_failed_observed = False
             goal_slash_command_submitted = False
+            goal_bridge_first_action_kickoff_submitted = False
             goal_kickoff_prompt_submitted = False
             post_bridge_terminal_stage = ""
             first_action_seen = False
@@ -1222,21 +1222,26 @@ class SkillsBenchLocalAcpRelay:
                                     bridge_summary_path
                                 )
                             )
-                    if codex_cli_goal_should_submit_kickoff(
+                    followup_prompt = codex_cli_goal_followup_prompt(
                         bridge_enabled=bridge_summary_path is not None,
                         goal_active_observed=goal_active_observed,
                         task_prompt_released=task_prompt_released,
-                        kickoff_submitted=goal_kickoff_prompt_submitted,
+                        bridge_first_action_kickoff_submitted=goal_bridge_first_action_kickoff_submitted,
+                        task_kickoff_submitted=goal_kickoff_prompt_submitted,
                         turn_active=turn_active,
                         first_action_seen=first_action_seen,
                         capture=capture,
-                    ):
-                        goal_kickoff_prompt_submitted = True
+                    )
+                    if followup_prompt:
+                        if task_prompt_released:
+                            goal_kickoff_prompt_submitted = True
+                        else:
+                            goal_bridge_first_action_kickoff_submitted = True
                         goal_lifecycle.begin(capture)
                         goal_active_observed = False
                         tmux_type_text_and_submit(
                             tmux_name=tmux_name,
-                            text=CODEX_CLI_GOAL_KICKOFF_PROMPT,
+                            text=followup_prompt,
                         )
                         (
                             goal_active_deadline,
@@ -1250,14 +1255,11 @@ class SkillsBenchLocalAcpRelay:
                             first_action_deadline=first_action_deadline,
                             meaningful_progress_deadline=meaningful_progress_deadline,
                         )
-                        next_heartbeat = now + max(
-                            1.0,
-                            self._config.stream_heartbeat_interval_sec,
-                        )
+                        next_heartbeat = now + max(1.0, self._config.stream_heartbeat_interval_sec)
                         continue
                     if codex_cli_goal_should_ignore_stale_terminal(
                         goal_failed_now=goal_failed_now,
-                        kickoff_submitted=goal_kickoff_prompt_submitted,
+                        kickoff_submitted=(goal_bridge_first_action_kickoff_submitted or goal_kickoff_prompt_submitted),
                         first_action_seen=first_action_seen,
                         turn_active=turn_active,
                         first_action_deadline=first_action_deadline,
@@ -1340,6 +1342,7 @@ class SkillsBenchLocalAcpRelay:
                                 if not restart_stage:
                                     goal_lifecycle.begin(capture)
                                     goal_active_observed = False
+                                    goal_bridge_first_action_kickoff_submitted = False
                                     goal_kickoff_prompt_submitted = False
                                     tmux_type_text_and_submit(
                                         tmux_name=tmux_name,

--- a/loopx/codex_cli_goal_tui.py
+++ b/loopx/codex_cli_goal_tui.py
@@ -23,6 +23,10 @@ CODEX_CLI_GOAL_THREAD_PREWARM_PROMPT = (
 CODEX_CLI_GOAL_THREAD_PREWARM_HARD_CAP_MULTIPLIER = 2.0
 CODEX_CLI_GOAL_TASK_PROMPT_FILENAME = "skillsbench-task-prompt.md"
 CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_FILENAME = "loopx-task-bridge-first-action"
+CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_KICKOFF_PROMPT = (
+    f"Run ./{CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_FILENAME} now and require it "
+    "to succeed. Wait for more instructions before starting the task."
+)
 CODEX_CLI_GOAL_KICKOFF_PROMPT = (
     "Start working on the active SkillsBench goal now. Read the referenced "
     "task prompt file first, follow it exactly, and perform at least one "
@@ -493,25 +497,33 @@ def codex_cli_tui_retryable_startup_blocker_stage(capture: str) -> str:
     return ""
 
 
-def codex_cli_goal_should_submit_kickoff(
+def codex_cli_goal_followup_prompt(
     *,
     bridge_enabled: bool,
     goal_active_observed: bool,
     task_prompt_released: bool,
-    kickoff_submitted: bool,
+    bridge_first_action_kickoff_submitted: bool,
+    task_kickoff_submitted: bool,
     turn_active: bool,
     first_action_seen: bool,
     capture: str,
-) -> bool:
-    return (
+) -> str:
+    ready = (
         bridge_enabled
         and goal_active_observed
-        and task_prompt_released
-        and not kickoff_submitted
         and not turn_active
         and not first_action_seen
         and codex_cli_tui_input_prompt_visible(capture)
     )
+    if not ready:
+        return ""
+    if not task_prompt_released:
+        return (
+            ""
+            if bridge_first_action_kickoff_submitted
+            else CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_KICKOFF_PROMPT
+        )
+    return "" if task_kickoff_submitted else CODEX_CLI_GOAL_KICKOFF_PROMPT
 
 
 def codex_cli_goal_should_ignore_stale_terminal(


### PR DESCRIPTION
## Summary
- model Codex CLI goal follow-up selection as a two-stage state machine
- submit one helper-only follow-up after `/goal` registers, then release the unchanged task prompt after bridge activity
- submit the task kickoff only in the second stage and reset both stage flags on bounded recovery

## Validation
- `python3 examples/codex-cli-goal-tui-session-smoke.py`
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 examples/skillsbench-host-local-launch-plan-smoke.py`
- `python3 examples/skillsbench-reverse-channel-bridge-smoke.py`
- `python3 examples/skillsbench-benchmark-egress-policy-smoke.py`
- `python3 examples/skillsbench-failure-attribution-smoke.py`
- `python3 examples/skillsbench-runner-core-contract-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- changed-file `py_compile` and `git diff --check`
- `loopx canary premerge --from-git-diff` (all selected checks passed; expected benchmark-sensitive manual hold)

## Boundary
No scoring, verifier, task semantics, permissions, submission, or launch-policy changes. The protocol remains fail-closed: task content is absent until the helper reaches the bridge, and each follow-up is submitted at most once per generation.