### PR TITLE
Guard control-plane import boundaries

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -322,7 +322,10 @@ The required Python test workflow keeps `tests/**`, `canary/**`,
 enforces an initial 19% package coverage floor.
 The floor is intentionally a regression guard, not a claim that 19% is
 sufficient; raise it as durable behavior moves from subprocess smokes into
-focused tests. Existing source-wide lint debt is characterized separately;
+focused tests. An architecture test also prevents new control-plane dependencies
+on presentation, CLI, capability, or benchmark-adapter layers while preserving
+one explicit quota-Markdown migration debt edge. Existing source-wide lint debt
+is characterized separately;
 expand the protected namespace list only after a bounded cleanup, rather than
 mass-fixing unrelated code merely to make a broad gate green.
 

--- a/tests/architecture/test_control_plane_import_boundaries.py
+++ b/tests/architecture/test_control_plane_import_boundaries.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import ast
+from importlib.util import resolve_name
+from pathlib import Path
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "loopx"
+CONTROL_PLANE_ROOT = PACKAGE_ROOT / "control_plane"
+FORBIDDEN_DEPENDENCY_PREFIXES = (
+    "loopx.benchmark_adapters",
+    "loopx.capabilities",
+    "loopx.cli",
+    "loopx.cli_commands",
+    "loopx.presentation",
+)
+ALLOWED_DEPENDENCY_DEBT = {
+    (
+        "loopx.control_plane.quota.markdown",
+        "loopx.presentation.markdown",
+    ),
+}
+
+
+def _module_name(path: Path) -> str:
+    relative = path.relative_to(PACKAGE_ROOT).with_suffix("")
+    parts = list(relative.parts)
+    if parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(("loopx", *parts))
+
+
+def _resolved_imports(path: Path) -> set[str]:
+    module_name = _module_name(path)
+    package_name = module_name if path.name == "__init__.py" else module_name.rpartition(".")[0]
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if node.level:
+                module = resolve_name("." * node.level + module, package_name)
+            imports.add(module)
+    return imports
+
+
+def test_control_plane_does_not_gain_outward_dependencies() -> None:
+    outward_dependencies = {
+        (_module_name(path), dependency)
+        for path in CONTROL_PLANE_ROOT.rglob("*.py")
+        for dependency in _resolved_imports(path)
+        if any(
+            dependency == prefix or dependency.startswith(prefix + ".")
+            for prefix in FORBIDDEN_DEPENDENCY_PREFIXES
+        )
+    }
+
+    unexpected = outward_dependencies - ALLOWED_DEPENDENCY_DEBT
+    assert not unexpected, (
+        "control-plane code must not depend on presentation, CLI, capability, or "
+        f"benchmark-adapter layers; unexpected edges: {sorted(unexpected)}"
+    )


### PR DESCRIPTION
## Summary
- add an AST-based architecture test that blocks new control-plane dependencies on presentation, CLI, capability, and benchmark-adapter layers
- preserve the one existing quota-Markdown dependency as explicit migration debt without requiring it to remain
- document the import-boundary budget alongside the existing lint and coverage floors

## Validation
- `pytest -q -n 2 --cov=loopx --cov-report= --cov-fail-under=19` (59 passed, 2 skipped; 19.55%)
- required Ruff namespaces passed
- presentation Markdown primitives smoke passed
- standard premerge canary after rebase: 17/17 selected checks passed, public-boundary scan clean, no manual holds
