### PR TITLE
Add a strict kernel type-check budget

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -49,6 +49,9 @@ jobs:
           loopx/domain_packs
           loopx/presentation
 
+      - name: Type-check kernel contracts
+        run: python -m mypy
+
       - name: Run fast tests
         run: >-
           python -m pytest -q -n 2

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build/
 dist/
 .pytest_cache/
 .ruff_cache/
+.mypy_cache/
 .coverage
 coverage.xml
 htmlcov/

--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -325,7 +325,8 @@ sufficient; raise it as durable behavior moves from subprocess smokes into
 focused tests. An architecture test also prevents new control-plane dependencies
 on presentation, CLI, capability, or benchmark-adapter layers while preserving
 one explicit quota-Markdown migration debt edge. Existing source-wide lint debt
-is characterized separately;
+is characterized separately. Strict mypy checking starts with seven leaf kernel
+contracts and should expand only as each next boundary becomes clean;
 expand the protected namespace list only after a bounded cleanup, rather than
 mass-fixing unrelated code merely to make a broad gate green.
 

--- a/loopx/control_plane/__init__.py
+++ b/loopx/control_plane/__init__.py
@@ -19,7 +19,8 @@ def compact_control_plane_policy(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
         return {}
     compact: dict[str, Any] = {}
-    self_repair = value.get("self_repair") if isinstance(value.get("self_repair"), dict) else {}
+    raw_self_repair = value.get("self_repair")
+    self_repair: dict[str, Any] = raw_self_repair if isinstance(raw_self_repair, dict) else {}
     if self_repair:
         enabled = _flag(self_repair.get("enabled"), default=False)
         compact["self_repair"] = {
@@ -38,7 +39,8 @@ def compact_control_plane_policy(value: Any) -> dict[str, Any]:
 
 def control_plane_self_repair_allows(policy: Any, mode: str) -> bool:
     compact = compact_control_plane_policy(policy)
-    self_repair = compact.get("self_repair") if isinstance(compact.get("self_repair"), dict) else {}
+    raw_self_repair = compact.get("self_repair")
+    self_repair: dict[str, Any] = raw_self_repair if isinstance(raw_self_repair, dict) else {}
     if self_repair.get("enabled") is not True:
         return False
     flag_name = SELF_REPAIR_MODES.get(mode)
@@ -49,7 +51,8 @@ def control_plane_self_repair_allows(policy: Any, mode: str) -> bool:
 
 def control_plane_policy_summary(policy: Any) -> str:
     compact = compact_control_plane_policy(policy)
-    self_repair = compact.get("self_repair") if isinstance(compact.get("self_repair"), dict) else {}
+    raw_self_repair = compact.get("self_repair")
+    self_repair: dict[str, Any] = raw_self_repair if isinstance(raw_self_repair, dict) else {}
     if not self_repair:
         return "self_repair=default_off"
     enabled = "on" if self_repair.get("enabled") else "off"

--- a/loopx/control_plane/work_items/lifecycle.py
+++ b/loopx/control_plane/work_items/lifecycle.py
@@ -12,7 +12,12 @@ def ordered_lifecycle_flags(
     lifecycle_priority: tuple[str, ...],
 ) -> list[str]:
     seen: set[str] = set()
-    deduped = [flag for flag in flags if flag and not (flag in seen or seen.add(flag))]
+    deduped: list[str] = []
+    for flag in flags:
+        if not flag or flag in seen:
+            continue
+        seen.add(flag)
+        deduped.append(flag)
     priority = {phase: index for index, phase in enumerate(lifecycle_priority)}
     return sorted(deduped, key=lambda phase: priority.get(phase, len(priority)))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ test = [
   "pytest-cov>=5,<7",
   "pytest-xdist>=3,<4",
   "ruff>=0.12,<1",
+  "mypy>=1.18,<2",
 ]
 
 [project.scripts]
@@ -28,3 +29,16 @@ include = ["loopx*"]
 
 [tool.setuptools.package-data]
 "loopx.capabilities.auto_research" = ["worker_skill/SKILL.md"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+files = [
+  "loopx/control_plane/__init__.py",
+  "loopx/control_plane/quota/states.py",
+  "loopx/control_plane/runtime/time.py",
+  "loopx/control_plane/scheduler/time.py",
+  "loopx/control_plane/work_items/delivery_batch_scale.py",
+  "loopx/control_plane/work_items/delivery_outcome.py",
+  "loopx/control_plane/work_items/lifecycle.py",
+]

--- a/tests/control_plane/test_contract_quality.py
+++ b/tests/control_plane/test_contract_quality.py
@@ -5,8 +5,10 @@ from typing import get_type_hints
 
 import pytest
 
+from loopx.control_plane import compact_control_plane_policy
 from loopx.control_plane.scheduler.time import parse_scheduler_timestamp
 from loopx.control_plane.todos.contract import format_todo_metadata_line
+from loopx.control_plane.work_items.lifecycle import ordered_lifecycle_flags
 from loopx.presentation.sinks.lark import kanban, sync_receipt
 
 
@@ -14,6 +16,17 @@ def test_scheduler_timestamp_return_annotation_resolves() -> None:
     hints = get_type_hints(parse_scheduler_timestamp)
 
     assert hints["return"] == datetime | None
+
+
+def test_control_plane_policy_ignores_non_mapping_self_repair() -> None:
+    assert compact_control_plane_policy({"self_repair": None}) == {}
+
+
+def test_lifecycle_flags_are_deduplicated_before_priority_sort() -> None:
+    assert ordered_lifecycle_flags(
+        ["unknown", "waiting", "running", "waiting", "", "unknown"],
+        lifecycle_priority=("running", "waiting"),
+    ) == ["running", "waiting", "unknown"]
 
 
 def test_invalid_removed_continuation_policy_reports_allowed_values() -> None:


### PR DESCRIPTION
## Summary
- add strict mypy checking for seven small control-plane kernel contracts rather than enabling a noisy repository-wide gate
- replace two type-hostile control-flow idioms with explicit, behavior-preserving code and focused tests
- run the bounded type budget in the required Python Tests workflow and ignore local mypy cache artifacts

## Validation
- fresh Python 3.11 editable install with `.[test]`, including mypy 1.20.2
- `python -m mypy`: 7 source files clean under strict mode
- required Ruff namespaces passed
- `pytest -q -n 2 --cov=loopx --cov-report= --cov-fail-under=19`: 61 passed, 2 skipped; 19.56% coverage
- attention-queue read-model smoke and workflow actionlint passed
- standard premerge canary: 17/17 selected checks passed, public-boundary scan clean, no manual holds
