### PR TITLE
Move the migration bridge matrix into pytest

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -57,4 +57,4 @@ jobs:
           python -m pytest -q -n 2
           --cov=loopx
           --cov-report=term
-          --cov-fail-under=19
+          --cov-fail-under=19.5

--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -319,8 +319,8 @@ python3 -m pytest tests/test_smoke_suite.py \
 
 The required Python test workflow keeps `tests/**`, `canary/**`,
 `control_plane/**`, `domain_packs/**`, and `presentation/**` Ruff-clean. It also
-enforces an initial 19% package coverage floor.
-The floor is intentionally a regression guard, not a claim that 19% is
+enforces an initial 19.5% package coverage floor.
+The floor is intentionally a regression guard, not a claim that 19.5% is
 sufficient; raise it as durable behavior moves from subprocess smokes into
 focused tests. An architecture test also prevents new control-plane dependencies
 on presentation, CLI, capability, or benchmark-adapter layers while preserving

--- a/examples/control_plane/event-store-migration-bridge-smoke.py
+++ b/examples/control_plane/event-store-migration-bridge-smoke.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Smoke-test the event-store migration bridge promotion gates."""
+"""Smoke-test the fail-closed event-store promotion boundary."""
 
 from __future__ import annotations
 
@@ -18,88 +18,9 @@ from loopx.control_plane.runtime.event_store_migration_bridge import (  # noqa: 
 )
 
 
-GOAL_ID = "event-store-migration-bridge-fixture"
-
-
-def test_fail_closed_before_event_read_path() -> None:
+def main() -> int:
     bridge = build_event_store_migration_bridge(
-        goal_id=GOAL_ID,
-        event_read_path_ready=False,
-        active_state_projection_ready=False,
-    )
-    assert bridge["schema_version"] == "event_store_migration_bridge_v0", bridge
-    assert bridge["source_of_truth"] == MARKDOWN_ACTIVE_STATE_SOURCE, bridge
-    assert bridge["candidate_source"] == EVENT_PROJECTION_SOURCE, bridge
-    assert bridge["stage"] == "wait_for_event_read_path", bridge
-    assert bridge["promotion_allowed"] is False, bridge
-    assert bridge["promotion_candidate"] is False, bridge
-    assert bridge["dual_read"]["enabled"] is False, bridge
-    assert bridge["canary"]["ready"] is False, bridge
-    assert bridge["rollback"]["fallback_source"] == MARKDOWN_ACTIVE_STATE_SOURCE, bridge
-    assert bridge["missing_for_shadow"] == [
-        "event_read_path_ready",
-        "active_state_projection_ready",
-    ], bridge
-    assert "bounded_canary_passed" in bridge["missing_for_promotion"], bridge
-
-
-def test_shadow_mode_requires_parity_and_rollback() -> None:
-    bridge = build_event_store_migration_bridge(
-        goal_id=GOAL_ID,
-        event_read_path_ready=True,
-        active_state_projection_ready=True,
-        dual_read_parity_clean=False,
-        rollback_plan_recorded=False,
-        idempotency_conflicts_clean=False,
-        public_boundary_clean=False,
-    )
-    assert bridge["stage"] == "dual_read_shadow", bridge
-    assert bridge["dual_read"]["enabled"] is True, bridge
-    assert bridge["dual_read"]["failure_policy"] == "prefer_markdown_and_record_parity_delta", bridge
-    assert bridge["promotion_allowed"] is False, bridge
-    assert bridge["canary"]["ready"] is False, bridge
-    assert bridge["missing_for_canary"] == [
-        "dual_read_parity_clean",
-        "event_projection_head_matches_store",
-        "rollback_plan_recorded",
-        "idempotency_conflicts_clean",
-        "public_boundary_clean",
-    ], bridge
-
-
-def test_canary_ready_does_not_promote_automatically() -> None:
-    bridge = build_event_store_migration_bridge(
-        goal_id=GOAL_ID,
-        event_read_path_ready=True,
-        active_state_projection_ready=True,
-        dual_read_parity_clean=True,
-        event_projection_head_matches_store=True,
-        rollback_plan_recorded=True,
-        idempotency_conflicts_clean=True,
-        public_boundary_clean=True,
-        bounded_canary_passed=False,
-        canary_goal_limit=2,
-        canary_duration_minutes=45,
-        evidence_refs=["event-projection-parity-smoke"],
-    )
-    assert bridge["stage"] == "bounded_canary", bridge
-    assert bridge["promotion_candidate"] is False, bridge
-    assert bridge["promotion_allowed"] is False, bridge
-    assert bridge["missing_for_canary"] == [], bridge
-    assert bridge["missing_for_promotion"] == ["bounded_canary_passed"], bridge
-    assert bridge["canary"]["ready"] is True, bridge
-    assert bridge["canary"]["scope"] == {
-        "max_goals": 2,
-        "duration_minutes": 45,
-        "write_path": "disabled",
-        "read_preference": MARKDOWN_ACTIVE_STATE_SOURCE,
-    }, bridge
-    assert bridge["evidence_refs"] == ["event-projection-parity-smoke"], bridge
-
-
-def test_promotion_candidate_still_requires_reviewed_write_path_change() -> None:
-    bridge = build_event_store_migration_bridge(
-        goal_id=GOAL_ID,
+        goal_id="event-store-migration-bridge-smoke",
         event_read_path_ready=True,
         active_state_projection_ready=True,
         dual_read_parity_clean=True,
@@ -109,20 +30,12 @@ def test_promotion_candidate_still_requires_reviewed_write_path_change() -> None
         public_boundary_clean=True,
         bounded_canary_passed=True,
     )
+    assert bridge["source_of_truth"] == MARKDOWN_ACTIVE_STATE_SOURCE, bridge
+    assert bridge["candidate_source"] == EVENT_PROJECTION_SOURCE, bridge
     assert bridge["stage"] == "promotion_candidate", bridge
     assert bridge["promotion_candidate"] is True, bridge
     assert bridge["promotion_allowed"] is False, bridge
-    assert bridge["missing_for_promotion"] == [], bridge
-    assert "explicit reviewed write-path change" in bridge["next_action"], bridge
-    assert bridge["rollback"]["recorded"] is True, bridge
-    assert bridge["canary"]["passed"] is True, bridge
-
-
-def main() -> int:
-    test_fail_closed_before_event_read_path()
-    test_shadow_mode_requires_parity_and_rollback()
-    test_canary_ready_does_not_promote_automatically()
-    test_promotion_candidate_still_requires_reviewed_write_path_change()
+    assert bridge["rollback"]["fallback_source"] == MARKDOWN_ACTIVE_STATE_SOURCE, bridge
     print("event-store-migration-bridge-smoke ok")
     return 0
 

--- a/tests/control_plane/test_event_store_migration_bridge.py
+++ b/tests/control_plane/test_event_store_migration_bridge.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import pytest
+
+from loopx.control_plane.runtime.event_store_migration_bridge import (
+    EVENT_PROJECTION_SOURCE,
+    MARKDOWN_ACTIVE_STATE_SOURCE,
+    build_event_store_migration_bridge,
+)
+
+
+GOAL_ID = "event-store-migration-bridge-fixture"
+
+
+def test_bridge_fails_closed_before_event_read_path() -> None:
+    bridge = build_event_store_migration_bridge(
+        goal_id=GOAL_ID,
+        event_read_path_ready=False,
+        active_state_projection_ready=False,
+    )
+
+    assert bridge["schema_version"] == "event_store_migration_bridge_v0"
+    assert bridge["source_of_truth"] == MARKDOWN_ACTIVE_STATE_SOURCE
+    assert bridge["candidate_source"] == EVENT_PROJECTION_SOURCE
+    assert bridge["stage"] == "wait_for_event_read_path"
+    assert bridge["promotion_allowed"] is False
+    assert bridge["promotion_candidate"] is False
+    assert bridge["dual_read"]["enabled"] is False
+    assert bridge["canary"]["ready"] is False
+    assert bridge["rollback"]["fallback_source"] == MARKDOWN_ACTIVE_STATE_SOURCE
+    assert bridge["missing_for_shadow"] == [
+        "event_read_path_ready",
+        "active_state_projection_ready",
+    ]
+    assert "bounded_canary_passed" in bridge["missing_for_promotion"]
+
+
+def test_shadow_mode_requires_parity_and_rollback() -> None:
+    bridge = build_event_store_migration_bridge(
+        goal_id=GOAL_ID,
+        event_read_path_ready=True,
+        active_state_projection_ready=True,
+        dual_read_parity_clean=False,
+        rollback_plan_recorded=False,
+        idempotency_conflicts_clean=False,
+        public_boundary_clean=False,
+    )
+
+    assert bridge["stage"] == "dual_read_shadow"
+    assert bridge["dual_read"]["enabled"] is True
+    assert bridge["dual_read"]["failure_policy"] == (
+        "prefer_markdown_and_record_parity_delta"
+    )
+    assert bridge["promotion_allowed"] is False
+    assert bridge["canary"]["ready"] is False
+    assert bridge["missing_for_canary"] == [
+        "dual_read_parity_clean",
+        "event_projection_head_matches_store",
+        "rollback_plan_recorded",
+        "idempotency_conflicts_clean",
+        "public_boundary_clean",
+    ]
+
+
+def test_canary_ready_does_not_promote_automatically() -> None:
+    bridge = build_event_store_migration_bridge(
+        goal_id=GOAL_ID,
+        event_read_path_ready=True,
+        active_state_projection_ready=True,
+        dual_read_parity_clean=True,
+        event_projection_head_matches_store=True,
+        rollback_plan_recorded=True,
+        idempotency_conflicts_clean=True,
+        public_boundary_clean=True,
+        bounded_canary_passed=False,
+        canary_goal_limit=2,
+        canary_duration_minutes=45,
+        evidence_refs=["event-projection-parity-smoke"],
+    )
+
+    assert bridge["stage"] == "bounded_canary"
+    assert bridge["promotion_candidate"] is False
+    assert bridge["promotion_allowed"] is False
+    assert bridge["missing_for_canary"] == []
+    assert bridge["missing_for_promotion"] == ["bounded_canary_passed"]
+    assert bridge["canary"]["ready"] is True
+    assert bridge["canary"]["scope"] == {
+        "max_goals": 2,
+        "duration_minutes": 45,
+        "write_path": "disabled",
+        "read_preference": MARKDOWN_ACTIVE_STATE_SOURCE,
+    }
+    assert bridge["evidence_refs"] == ["event-projection-parity-smoke"]
+
+
+def test_promotion_candidate_still_requires_reviewed_write_path_change() -> None:
+    bridge = build_event_store_migration_bridge(
+        goal_id=GOAL_ID,
+        event_read_path_ready=True,
+        active_state_projection_ready=True,
+        dual_read_parity_clean=True,
+        event_projection_head_matches_store=True,
+        rollback_plan_recorded=True,
+        idempotency_conflicts_clean=True,
+        public_boundary_clean=True,
+        bounded_canary_passed=True,
+    )
+
+    assert bridge["stage"] == "promotion_candidate"
+    assert bridge["promotion_candidate"] is True
+    assert bridge["promotion_allowed"] is False
+    assert bridge["missing_for_promotion"] == []
+    assert "explicit reviewed write-path change" in bridge["next_action"]
+    assert bridge["rollback"]["recorded"] is True
+    assert bridge["canary"]["passed"] is True
+
+
+@pytest.mark.parametrize("goal_id", ["", "  "])
+def test_bridge_requires_a_goal_id(goal_id: str) -> None:
+    with pytest.raises(ValueError, match="goal_id is required"):
+        build_event_store_migration_bridge(
+            goal_id=goal_id,
+            event_read_path_ready=False,
+        )
+
+
+def test_bridge_normalizes_bounded_canary_inputs() -> None:
+    bridge = build_event_store_migration_bridge(
+        goal_id="  fixture   goal  ",
+        event_read_path_ready=False,
+        canary_goal_limit=0,
+        canary_duration_minutes=0,
+        evidence_refs=[" parity   packet ", "", "  "],
+    )
+
+    assert bridge["goal_id"] == "fixture goal"
+    assert bridge["canary"]["scope"]["max_goals"] == 1
+    assert bridge["canary"]["scope"]["duration_minutes"] == 1
+    assert bridge["evidence_refs"] == ["parity packet"]


### PR DESCRIPTION
## Summary
- move the four-stage event-store migration bridge matrix plus input-boundary cases into focused pytest coverage
- shrink the public subprocess smoke to the one durable release canary: a promotion candidate still cannot auto-promote
- ratchet the package coverage floor from 19% to 19.5% after measured coverage reaches 19.63%

## Validation
- focused bridge tests: 7 passed; thin public smoke passed
- full pytest: 68 passed, 2 skipped; coverage 19.63% against the new 19.5% floor
- strict mypy 7/7 and required Ruff namespaces passed
- adjacent event-state and status read-path smokes passed
- workflow actionlint passed
- standard premerge canary: 17/17 selected checks passed, public-boundary scan clean, no manual holds
