### PR TITLE
Expand strict typing to characterized runtime contracts

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -325,8 +325,9 @@ sufficient; raise it as durable behavior moves from subprocess smokes into
 focused tests. An architecture test also prevents new control-plane dependencies
 on presentation, CLI, capability, or benchmark-adapter layers while preserving
 one explicit quota-Markdown migration debt edge. Existing source-wide lint debt
-is characterized separately. Strict mypy checking starts with seven leaf kernel
-contracts and should expand only as each next boundary becomes clean;
+is characterized separately. Strict mypy checking covers nine characterized
+kernel and runtime contracts and should expand only as each next boundary
+becomes clean;
 expand the protected namespace list only after a bounded cleanup, rather than
 mass-fixing unrelated code merely to make a broad gate green.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,9 @@ strict = true
 files = [
   "loopx/control_plane/__init__.py",
   "loopx/control_plane/quota/states.py",
+  "loopx/control_plane/runtime/event_store_migration_bridge.py",
   "loopx/control_plane/runtime/time.py",
+  "loopx/control_plane/runtime/trajectory_hygiene.py",
   "loopx/control_plane/scheduler/time.py",
   "loopx/control_plane/work_items/delivery_batch_scale.py",
   "loopx/control_plane/work_items/delivery_outcome.py",


### PR DESCRIPTION
## Summary
- add the characterized event-store migration bridge to the strict mypy gate
- add trajectory hygiene to the same gate
- update release-readiness documentation from seven to nine protected contracts

## Validation
- `python -m mypy` (9/9)
- focused pytest: 10 passed
- full pytest: 68 passed, 2 skipped; coverage 19.63% against 19.5% floor
- required Ruff boundary: clean
- `loopx canary premerge --from-git-diff`: 16/16, no failures, warnings, or manual holds
- public/private boundary scan: clean
