### PR TITLE
Fail fast on revoked SkillsBench Codex auth

### DIFF
--- a/examples/codex-cli-goal-tui-session-smoke.py
+++ b/examples/codex-cli-goal-tui-session-smoke.py
@@ -3,11 +3,8 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
-import subprocess
 import sys
-import tempfile
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -38,40 +35,6 @@ def main() -> int:
     original_monotonic = goal_tui.time.monotonic
     original_sleep = goal_tui.time.sleep
     try:
-        with tempfile.TemporaryDirectory() as temp:
-            request_path = Path(temp) / "bridge-request.json"
-            bridge = Path(temp) / "public-bridge"
-            bridge.write_text(
-                "#!/bin/sh\ncat > " + str(request_path) + "\n",
-                encoding="utf-8",
-            )
-            bridge.chmod(0o700)
-            helper = goal_tui.write_codex_cli_goal_bridge_first_action_helper(
-                cwd=temp,
-                bridge_executable=str(bridge),
-            )
-            assert helper.name == goal_tui.CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_FILENAME
-            assert helper.stat().st_mode & 0o100
-            subprocess.run([str(helper)], check=True)
-            request = json.loads(request_path.read_text(encoding="utf-8"))
-            assert request == {
-                "operation": "exec",
-                "cwd": "/app",
-                "command": "pwd && ls -la",
-                "timeout_sec": 10,
-            }
-            task_prompt = Path(temp) / goal_tui.CODEX_CLI_GOAL_TASK_PROMPT_FILENAME
-            goal_tui.release_codex_cli_goal_task_prompt(
-                task_prompt,
-                "public task prompt",
-            )
-            assert task_prompt.read_text(encoding="utf-8") == "public task prompt"
-            goal_tui.release_codex_cli_goal_task_prompt(
-                task_prompt,
-                "replacement must not overwrite",
-            )
-            assert task_prompt.read_text(encoding="utf-8") == "public task prompt"
-
         goal_tui.subprocess.run = fake_run  # type: ignore[assignment]
         goal_tui.tmux_kill_session = fake_kill  # type: ignore[assignment]
         goal_tui.wait_for_codex_cli_tui_ready = (  # type: ignore[assignment]
@@ -123,6 +86,7 @@ def main() -> int:
         goal_tui.prewarm_codex_cli_goal_thread = (  # type: ignore[assignment]
             lambda **_kwargs: False
         )
+        goal_tui.tmux_capture = lambda _tmux_name: ""  # type: ignore[assignment]
         stage, prewarmed = goal_tui.start_codex_cli_goal_tui_session(
             tmux_name="prewarm-failed",
             cwd="/tmp/public-workspace",
@@ -132,6 +96,23 @@ def main() -> int:
         )
         assert (stage, prewarmed) == ("thread_prewarm_timeout", False)
         assert calls[-1] == ("kill", "prewarm-failed")
+
+        calls.clear()
+        goal_tui.tmux_capture = (  # type: ignore[assignment]
+            lambda _tmux_name: (
+                "Your access token could not be refreshed because your refresh "
+                "token was revoked. Please sign in again."
+            )
+        )
+        stage, prewarmed = goal_tui.start_codex_cli_goal_tui_session(
+            tmux_name="prewarm-auth-revoked",
+            cwd="/tmp/public-workspace",
+            shell_command="codex",
+            thread_prewarm=True,
+            thread_prewarm_timeout_sec=120,
+        )
+        assert (stage, prewarmed) == ("auth_refresh_token_revoked", False)
+        assert calls[-1] == ("kill", "prewarm-auth-revoked")
 
         calls.clear()
         goal_tui.prewarm_codex_cli_goal_thread = original_prewarm
@@ -165,6 +146,16 @@ def main() -> int:
         goal_tui.time.sleep = lambda _seconds: None  # type: ignore[assignment]
         assert goal_tui.prewarm_codex_cli_goal_thread(
             tmux_name="active-then-ready",
+            timeout_sec=1,
+        )
+
+        goal_tui.tmux_capture = (  # type: ignore[assignment]
+            lambda _tmux_name: "error: token_invalidated\n› "
+        )
+        clock = iter([0.0, 0.0])
+        goal_tui.time.monotonic = lambda: next(clock)  # type: ignore[assignment]
+        assert not goal_tui.prewarm_codex_cli_goal_thread(
+            tmux_name="revoked-auth",
             timeout_sec=1,
         )
 

--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -605,8 +605,12 @@ def _assert_cli_goal_rate_limit_is_public_safe_retryable_stage() -> None:
         CodexExecConfig,
         SkillsBenchLocalAcpRelay,
     )
-    from loopx.codex_cli_goal_tui import codex_cli_tui_retryable_startup_blocker_stage
+    from loopx.codex_cli_goal_tui import (
+        codex_cli_tui_auth_blocker_stage,
+        codex_cli_tui_retryable_startup_blocker_stage,
+    )
     from scripts.skillsbench_automation_loop import (
+        _apply_codex_cli_goal_countability_guard_attribution,
         _merge_host_local_acp_relay_trace_summary,
         _public_runner_prerequisites,
     )
@@ -618,6 +622,15 @@ def _assert_cli_goal_rate_limit_is_public_safe_retryable_stage() -> None:
         == "rate_limit_before_goal_active"
     )
     assert codex_cli_tui_retryable_startup_blocker_stage("Goal active") == ""
+    revoked_stage = codex_cli_tui_auth_blocker_stage(
+        "Your access token could not be refreshed because your refresh token "
+        "was revoked. Please sign in again."
+    )
+    assert revoked_stage == "auth_refresh_token_revoked"
+    assert codex_cli_tui_retryable_startup_blocker_stage("token_invalidated") == (
+        revoked_stage
+    )
+    assert codex_cli_tui_auth_blocker_stage("Goal active") == ""
 
     with tempfile.TemporaryDirectory() as temp:
         trace_dir = Path(temp) / "trace"
@@ -655,6 +668,42 @@ def _assert_cli_goal_rate_limit_is_public_safe_retryable_stage() -> None:
     assert public_prerequisites["codex_cli_goal_tui_stages"] == [
         "rate_limit_before_goal_active"
     ]
+
+    with tempfile.TemporaryDirectory() as temp:
+        trace_dir = Path(temp) / "trace"
+        relay = SkillsBenchLocalAcpRelay(
+            CodexExecConfig(worker_public_trace_dir=str(trace_dir))
+        )
+        relay._publish_codex_cli_goal_trace(
+            ok=False,
+            stage=revoked_stage,
+            goal_active_observed=False,
+            goal_terminal_observed=False,
+            first_action_observed=False,
+            bridge_summary_path=None,
+        )
+        payload = json.loads(
+            next(trace_dir.glob("*.compact.json")).read_text(encoding="utf-8")
+        )
+    auth_trace = payload["codex_cli_goal"]
+    assert auth_trace["stage"] == "auth_refresh_token_revoked"
+    assert auth_trace["raw_tui_capture_recorded"] is False
+    assert auth_trace["raw_task_text_recorded"] is False
+
+    compact = {
+        "route": "codex-cli-goal-baseline",
+        "official_score_status": "completed",
+        "interaction_counters": {
+            "codex_cli_goal_tui_trace_present": True,
+            "codex_cli_goal_tui_ok_count": 0,
+            "codex_cli_goal_tui_stage": revoked_stage,
+        },
+    }
+    assert _apply_codex_cli_goal_countability_guard_attribution(compact)
+    expected = "skillsbench_codex_cli_goal_uncountable_auth_refresh_token_revoked"
+    assert compact["score_failure_attribution"] == expected
+    assert compact["official_score_comparable_to_native_codex"] is False
+    assert compact["official_score_comparable_to_loopx_treatment"] is False
 
 
 def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
@@ -1425,19 +1474,15 @@ def _assert_cli_goal_active_timeout_is_public_countability_stage() -> None:
 def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> None:
     sys.path.insert(0, str(REPO_ROOT))
     from loopx.codex_cli_goal_tui import (
-        CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_FILENAME,
-        CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_KICKOFF_PROMPT,
-        CODEX_CLI_GOAL_KICKOFF_PROMPT,
         CODEX_CLI_GOAL_OBJECTIVE_MAX_CHARS,
         CODEX_CLI_GOAL_TASK_PROMPT_FILENAME,
         CODEX_CLI_GOAL_THREAD_PREWARM_MARKER,
         CODEX_CLI_GOAL_THREAD_PREWARM_PROMPT,
         CodexCliGoalLifecycleGeneration,
-        build_codex_cli_goal_bridge_first_action_objective,
+        build_codex_cli_goal_file_objective,
         build_codex_cli_tui_command,
         build_codex_cli_goal_tui_input,
         codex_cli_goal_lifecycle_marker_counts,
-        codex_cli_goal_followup_prompt,
         codex_cli_goal_watchdog_expired,
     )
     from loopx.benchmark_adapters.skillsbench_acp_relay import (
@@ -1450,42 +1495,12 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert CODEX_CLI_GOAL_THREAD_PREWARM_MARKER not in (
         CODEX_CLI_GOAL_THREAD_PREWARM_PROMPT
     )
-    objective = build_codex_cli_goal_bridge_first_action_objective()
-    assert CODEX_CLI_GOAL_TASK_PROMPT_FILENAME not in objective, objective
-    assert CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_FILENAME in objective, objective
+    objective = build_codex_cli_goal_file_objective(
+        CODEX_CLI_GOAL_TASK_PROMPT_FILENAME
+    )
+    assert CODEX_CLI_GOAL_TASK_PROMPT_FILENAME in objective, objective
     assert len(objective) < CODEX_CLI_GOAL_OBJECTIVE_MAX_CHARS
     assert build_codex_cli_goal_tui_input(objective).startswith("/goal "), objective
-    followup_state = {
-        "bridge_enabled": True,
-        "goal_active_observed": True,
-        "turn_active": False,
-        "first_action_seen": False,
-        "capture": "Goal active\n› ",
-    }
-    assert codex_cli_goal_followup_prompt(
-        task_prompt_released=False,
-        bridge_first_action_kickoff_submitted=False,
-        task_kickoff_submitted=False,
-        **followup_state,
-    ) == CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_KICKOFF_PROMPT
-    assert not codex_cli_goal_followup_prompt(
-        task_prompt_released=False,
-        bridge_first_action_kickoff_submitted=True,
-        task_kickoff_submitted=False,
-        **followup_state,
-    )
-    assert codex_cli_goal_followup_prompt(
-        task_prompt_released=True,
-        bridge_first_action_kickoff_submitted=True,
-        task_kickoff_submitted=False,
-        **followup_state,
-    ) == CODEX_CLI_GOAL_KICKOFF_PROMPT
-    assert not codex_cli_goal_followup_prompt(
-        task_prompt_released=True,
-        bridge_first_action_kickoff_submitted=True,
-        task_kickoff_submitted=True,
-        **followup_state,
-    )
     cmd = build_codex_cli_tui_command(
         codex_bin="codex",
         sandbox="workspace-write",
@@ -1589,11 +1604,8 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "start_codex_cli_goal_tui_session(" in source
     assert "CODEX_CLI_GOAL_THREAD_PREWARM_TIMEOUT_SEC = 120" in source
     assert "CODEX_CLI_GOAL_TASK_PROMPT_FILENAME" in source
-    assert "release_codex_cli_goal_task_prompt(" in source
-    assert "build_codex_cli_goal_bridge_first_action_objective(" in source
-    assert source.index("release_codex_cli_goal_task_prompt(") < source.index(
-        "text=followup_prompt"
-    )
+    assert "prompt_instruction_path.write_text(" in source
+    assert "build_codex_cli_goal_file_objective(" in source
     assert "tmux_type_text_and_submit(" in source
     assert "build_codex_cli_goal_tui_input(prompt_for_codex)" not in source
     assert "codex_cli_goal_thread_prewarm: bool = False" in source
@@ -1619,15 +1631,14 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "_bridge_summary_has_successful_task_operation(" in source
     assert "turn_active = codex_cli_tui_turn_active(capture)" in source
     assert "goal_kickoff_prompt_submitted = False" in source
-    assert "followup_prompt = codex_cli_goal_followup_prompt(" in source
-    assert "task_prompt_released=task_prompt_released" in source
-    assert "text=followup_prompt" in source
+    assert "kickoff_submitted=goal_kickoff_prompt_submitted" in source
+    assert "text=CODEX_CLI_GOAL_KICKOFF_PROMPT" in source
     assert "goal_failed_now = False" in source
     assert "goal_lifecycle.failed_advanced" in source
     assert "goal_lifecycle.active_observed" in source
     assert "goal_lifecycle.achieved_advanced" in source
     assert "goal_lifecycle.observe(capture, turn_active=turn_active)" in source
-    assert source.count("goal_lifecycle.begin(") == 3
+    assert source.count("goal_lifecycle.begin(") == 2
     assert source.count("goal_kickoff_prompt_submitted = False") >= 2
     assert "terminal_observed=goal_failed_now" in source
     assert "goal_kickoff_prompt_raw_text_recorded" in source
@@ -1669,11 +1680,9 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     )
     assert '"--disable",\n        "apps",' in tui_source
     assert "CODEX_CLI_GOAL_KICKOFF_PROMPT = (" in tui_source
-    assert "CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_KICKOFF_PROMPT = (" in tui_source
     assert "Start working on the active SkillsBench goal now" in tui_source
     assert "def codex_cli_goal_watchdog_expired(" in tui_source
-    assert "bridge_first_action_kickoff_submitted" in tui_source
-    assert "task_kickoff_submitted" in tui_source
+    assert "not kickoff_submitted" in tui_source
     assert "def codex_cli_goal_reset_pre_bridge_deadlines(" in tui_source
     assert '"goal_submission_generation"' in tui_source
     assert 'fields[f"goal_{name}_marker_delta"]' in tui_source
@@ -1704,10 +1713,6 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
         trace = payload["codex_cli_goal"]
         assert trace["goal_prompt_file_used"] is True, trace
         assert trace["goal_prompt_file_raw_path_recorded"] is False, trace
-        assert trace["goal_bridge_first_action_helper_used"] is True, trace
-        assert (
-            trace["goal_bridge_first_action_helper_raw_path_recorded"] is False
-        ), trace
         assert trace["goal_command_submission_method"] == "typed", trace
         assert trace["goal_kickoff_prompt_submitted"] is False, trace
         assert trace["goal_kickoff_prompt_raw_text_recorded"] is False, trace

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -54,29 +54,28 @@ from loopx.benchmark_adapters.skillsbench_codex_goal_recovery import (
     write_private_codex_cli_goal_tui_tail,
 )
 from loopx.codex_cli_goal_tui import (
+    CODEX_CLI_GOAL_KICKOFF_PROMPT,
     CODEX_CLI_GOAL_TASK_PROMPT_FILENAME,
-    build_codex_cli_goal_bridge_first_action_objective,
+    build_codex_cli_goal_file_objective,
     build_codex_cli_goal_tui_input,
     build_codex_cli_tui_command,
     CodexCliGoalLifecycleGeneration,
     codex_cli_goal_watchdog_expired,
     codex_cli_goal_reset_pre_bridge_deadlines,
     codex_cli_goal_should_ignore_stale_terminal,
-    codex_cli_goal_followup_prompt,
+    codex_cli_goal_should_submit_kickoff,
     codex_cli_tui_environment,
     codex_cli_tui_shell_command,
     codex_cli_tui_input_prompt_visible,
     codex_cli_tui_retryable_startup_blocker_stage,
     codex_cli_tui_turn_active,
     resolve_codex_cli_binary,
-    release_codex_cli_goal_task_prompt,
     start_codex_cli_goal_tui_session,
     tmux_capture,
     tmux_kill_session,
     tmux_paste_file_and_submit,
     tmux_submit_enter,
     tmux_type_text_and_submit,
-    write_codex_cli_goal_bridge_first_action_helper,
 )
 
 SAFE_LOOPX_TODO_ID_RE = re.compile(r"^todo_[A-Za-z0-9_-]{6,80}$")
@@ -1038,14 +1037,21 @@ class SkillsBenchLocalAcpRelay:
                     summary_path=bridge_summary_path,
                     bridge_command=agent_bridge_command,
                 )
-                write_codex_cli_goal_bridge_first_action_helper(cwd=local_cwd, bridge_executable=str(instrumented_bridge))
                 prompt_for_codex = self._prompt_with_remote_bridge_packet(
                     prompt_text,
                     bridge_probe=bridge_probe,
                     bridge_command_for_agent=str(instrumented_bridge),
                 )
-                prompt_instruction_path = Path(cwd) / CODEX_CLI_GOAL_TASK_PROMPT_FILENAME
-                prompt_for_goal = build_codex_cli_goal_bridge_first_action_objective()
+                prompt_instruction_path = (
+                    Path(cwd) / CODEX_CLI_GOAL_TASK_PROMPT_FILENAME
+                )
+                prompt_instruction_path.write_text(
+                    prompt_for_codex,
+                    encoding="utf-8",
+                )
+                prompt_for_goal = build_codex_cli_goal_file_objective(
+                    CODEX_CLI_GOAL_TASK_PROMPT_FILENAME
+                )
                 goal_prompt_file_used = True
                 goal_command_submission_method = "typed"
             else:
@@ -1073,11 +1079,9 @@ class SkillsBenchLocalAcpRelay:
             goal_terminal_observed = False
             goal_failed_observed = False
             goal_slash_command_submitted = False
-            goal_bridge_first_action_kickoff_submitted = False
             goal_kickoff_prompt_submitted = False
             post_bridge_terminal_stage = ""
             first_action_seen = False
-            task_prompt_released = False
             bridge_activity_seen = False
             last_bridge_summary_size = 0
             last_bridge_activity_at = time.monotonic()
@@ -1201,10 +1205,11 @@ class SkillsBenchLocalAcpRelay:
                             last_bridge_activity_at = now
                             last_task_output_activity_at = now
                             bridge_activity_seen = True
-                            if not task_prompt_released:
-                                release_codex_cli_goal_task_prompt(prompt_instruction_path, prompt_for_codex)
-                                task_prompt_released = True
-                        if current_bridge_summary_size > 0 and goal_kickoff_prompt_submitted:
+                            first_action_seen = True
+                        elif (
+                            not first_action_seen
+                            and current_bridge_summary_size > 0
+                        ):
                             first_action_seen = True
                         if not meaningful_progress_seen:
                             meaningful_progress_seen = (
@@ -1222,26 +1227,18 @@ class SkillsBenchLocalAcpRelay:
                                     bridge_summary_path
                                 )
                             )
-                    followup_prompt = codex_cli_goal_followup_prompt(
+                    if codex_cli_goal_should_submit_kickoff(
                         bridge_enabled=bridge_summary_path is not None,
                         goal_active_observed=goal_active_observed,
-                        task_prompt_released=task_prompt_released,
-                        bridge_first_action_kickoff_submitted=goal_bridge_first_action_kickoff_submitted,
-                        task_kickoff_submitted=goal_kickoff_prompt_submitted,
+                        kickoff_submitted=goal_kickoff_prompt_submitted,
                         turn_active=turn_active,
                         first_action_seen=first_action_seen,
                         capture=capture,
-                    )
-                    if followup_prompt:
-                        if task_prompt_released:
-                            goal_kickoff_prompt_submitted = True
-                        else:
-                            goal_bridge_first_action_kickoff_submitted = True
-                        goal_lifecycle.begin(capture)
-                        goal_active_observed = False
+                    ):
+                        goal_kickoff_prompt_submitted = True
                         tmux_type_text_and_submit(
                             tmux_name=tmux_name,
-                            text=followup_prompt,
+                            text=CODEX_CLI_GOAL_KICKOFF_PROMPT,
                         )
                         (
                             goal_active_deadline,
@@ -1255,11 +1252,14 @@ class SkillsBenchLocalAcpRelay:
                             first_action_deadline=first_action_deadline,
                             meaningful_progress_deadline=meaningful_progress_deadline,
                         )
-                        next_heartbeat = now + max(1.0, self._config.stream_heartbeat_interval_sec)
+                        next_heartbeat = now + max(
+                            1.0,
+                            self._config.stream_heartbeat_interval_sec,
+                        )
                         continue
                     if codex_cli_goal_should_ignore_stale_terminal(
                         goal_failed_now=goal_failed_now,
-                        kickoff_submitted=(goal_bridge_first_action_kickoff_submitted or goal_kickoff_prompt_submitted),
+                        kickoff_submitted=goal_kickoff_prompt_submitted,
                         first_action_seen=first_action_seen,
                         turn_active=turn_active,
                         first_action_deadline=first_action_deadline,
@@ -1342,7 +1342,6 @@ class SkillsBenchLocalAcpRelay:
                                 if not restart_stage:
                                     goal_lifecycle.begin(capture)
                                     goal_active_observed = False
-                                    goal_bridge_first_action_kickoff_submitted = False
                                     goal_kickoff_prompt_submitted = False
                                     tmux_type_text_and_submit(
                                         tmux_name=tmux_name,
@@ -1843,8 +1842,6 @@ class SkillsBenchLocalAcpRelay:
                 "goal_thread_prewarm_timeout_sec": CODEX_CLI_GOAL_THREAD_PREWARM_TIMEOUT_SEC if self._config.codex_cli_goal_thread_prewarm else 0,
                 "goal_prompt_file_used": bool(goal_prompt_file_used),
                 "goal_prompt_file_raw_path_recorded": False,
-                "goal_bridge_first_action_helper_used": bool(goal_prompt_file_used),
-                "goal_bridge_first_action_helper_raw_path_recorded": False,
                 "goal_command_submission_method": str(
                     goal_command_submission_method or ""
                 )[:40],

--- a/loopx/codex_cli_goal_tui.py
+++ b/loopx/codex_cli_goal_tui.py
@@ -22,11 +22,6 @@ CODEX_CLI_GOAL_THREAD_PREWARM_PROMPT = (
 )
 CODEX_CLI_GOAL_THREAD_PREWARM_HARD_CAP_MULTIPLIER = 2.0
 CODEX_CLI_GOAL_TASK_PROMPT_FILENAME = "skillsbench-task-prompt.md"
-CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_FILENAME = "loopx-task-bridge-first-action"
-CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_KICKOFF_PROMPT = (
-    f"Run ./{CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_FILENAME} now and require it "
-    "to succeed. Wait for more instructions before starting the task."
-)
 CODEX_CLI_GOAL_KICKOFF_PROMPT = (
     "Start working on the active SkillsBench goal now. Read the referenced "
     "task prompt file first, follow it exactly, and perform at least one "
@@ -109,54 +104,22 @@ def build_codex_cli_goal_tui_input(objective: str) -> str:
     return f"{CODEX_CLI_GOAL_COMMAND_PREFIX}{objective}"
 
 
-def build_codex_cli_goal_bridge_first_action_objective() -> str:
-    """Return the bridge-only goal used before private task disclosure."""
+def build_codex_cli_goal_file_objective(prompt_filename: str) -> str:
+    """Return a short goal objective that points Codex at private task details."""
 
+    prompt_ref = (prompt_filename or CODEX_CLI_GOAL_TASK_PROMPT_FILENAME).strip()
+    prompt_ref = prompt_ref.replace("\\", "/").lstrip("/")
+    if not prompt_ref or ".." in Path(prompt_ref).parts:
+        prompt_ref = CODEX_CLI_GOAL_TASK_PROMPT_FILENAME
     objective = (
-        f"First run ./{CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_FILENAME} and require "
-        "it to succeed. Keep this goal active and wait for the task instructions "
-        "that will be provided next; do not finish or fail after the helper."
+        "Complete the SkillsBench task using the private task and bridge "
+        f"instructions in ./{prompt_ref}. Read that file first, follow it "
+        "exactly, and perform at least one task-facing bridge action before "
+        "reporting status."
     )
     if len(objective) > CODEX_CLI_GOAL_OBJECTIVE_MAX_CHARS:
         raise ValueError("codex cli goal file objective exceeds objective cap")
     return objective
-
-
-def release_codex_cli_goal_task_prompt(prompt_path: Path, prompt_text: str) -> None:
-    """Materialize the unchanged task prompt after bridge-first succeeds."""
-
-    if prompt_path.exists():
-        return
-    prompt_path.write_text(prompt_text, encoding="utf-8")
-
-
-def write_codex_cli_goal_bridge_first_action_helper(
-    *,
-    cwd: str | Path,
-    bridge_executable: str,
-) -> Path:
-    """Write the goal's first task-facing bridge action into its workspace."""
-
-    request = json.dumps(
-        {
-            "operation": "exec",
-            "cwd": "/app",
-            "command": "pwd && ls -la",
-            "timeout_sec": 10,
-        },
-        separators=(",", ":"),
-    )
-    helper_path = Path(cwd) / CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_FILENAME
-    command = (
-        f"printf '%s\\n' {shlex.quote(request)} | "
-        f"{shlex.quote(str(bridge_executable))}"
-    )
-    helper_path.write_text(
-        "#!/bin/sh\nset -eu\n" + command + "\n",
-        encoding="utf-8",
-    )
-    helper_path.chmod(0o700)
-    return helper_path
 
 
 def build_codex_cli_tui_command(
@@ -480,8 +443,11 @@ def codex_cli_goal_lifecycle_marker_counts(
 
 
 def codex_cli_tui_retryable_startup_blocker_stage(capture: str) -> str:
-    """Classify public-safe Codex CLI TUI startup blockers from screen text."""
+    """Classify public-safe Codex CLI TUI pre-action blockers."""
 
+    auth_stage = codex_cli_tui_auth_blocker_stage(capture)
+    if auth_stage:
+        return auth_stage
     lowered = str(capture or "").lower()
     if any(
         marker in lowered
@@ -497,33 +463,41 @@ def codex_cli_tui_retryable_startup_blocker_stage(capture: str) -> str:
     return ""
 
 
-def codex_cli_goal_followup_prompt(
+def codex_cli_tui_auth_blocker_stage(capture: str) -> str:
+    """Return a public-safe terminal auth stage from recent TUI text."""
+
+    recent = "\n".join(str(capture or "").splitlines()[-40:]).lower()
+    refresh_revoked = any(
+        marker in recent
+        for marker in (
+            "refresh token was revoked",
+            "refresh token has been revoked",
+            "token_invalidated",
+        )
+    ) or (
+        "access token could not be refreshed" in recent
+        and "sign in again" in recent
+    )
+    return "auth_refresh_token_revoked" if refresh_revoked else ""
+
+
+def codex_cli_goal_should_submit_kickoff(
     *,
     bridge_enabled: bool,
     goal_active_observed: bool,
-    task_prompt_released: bool,
-    bridge_first_action_kickoff_submitted: bool,
-    task_kickoff_submitted: bool,
+    kickoff_submitted: bool,
     turn_active: bool,
     first_action_seen: bool,
     capture: str,
-) -> str:
-    ready = (
+) -> bool:
+    return (
         bridge_enabled
         and goal_active_observed
+        and not kickoff_submitted
         and not turn_active
         and not first_action_seen
         and codex_cli_tui_input_prompt_visible(capture)
     )
-    if not ready:
-        return ""
-    if not task_prompt_released:
-        return (
-            ""
-            if bridge_first_action_kickoff_submitted
-            else CODEX_CLI_GOAL_BRIDGE_FIRST_ACTION_KICKOFF_PROMPT
-        )
-    return "" if task_kickoff_submitted else CODEX_CLI_GOAL_KICKOFF_PROMPT
 
 
 def codex_cli_goal_should_ignore_stale_terminal(
@@ -654,8 +628,9 @@ def start_codex_cli_goal_tui_session(
         timeout_sec=thread_prewarm_timeout_sec,
     )
     if not thread_prewarm_observed:
+        stage = codex_cli_tui_auth_blocker_stage(tmux_capture(tmux_name))
         tmux_kill_session(tmux_name)
-        return "thread_prewarm_timeout", False
+        return stage or "thread_prewarm_timeout", False
     return "", True
 
 
@@ -679,6 +654,8 @@ def prewarm_codex_cli_goal_thread(
     turn_active_observed = False
     while time.monotonic() < hard_deadline:
         capture = tmux_capture(tmux_name)
+        if codex_cli_tui_auth_blocker_stage(capture):
+            return False
         if CODEX_CLI_GOAL_THREAD_PREWARM_MARKER in capture:
             return True
         turn_active = codex_cli_tui_turn_active(capture)

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -4915,6 +4915,7 @@ def _apply_codex_cli_goal_countability_guard_attribution(
         and str(compact.get("official_score_status") or "") == "completed"
     )
     terminal_goal_failure_stages = {
+        "auth_refresh_token_revoked",
         "post_bridge_tui_model_timeout",
         "post_bridge_tui_error_prompt",
         "post_bridge_tui_rate_limit",
@@ -4932,7 +4933,9 @@ def _apply_codex_cli_goal_countability_guard_attribution(
         return False
 
     label = "skillsbench_codex_cli_goal_uncountable_no_task_activity"
-    if goal_stage == "goal_active_timeout":
+    if goal_stage == "auth_refresh_token_revoked":
+        label = "skillsbench_codex_cli_goal_uncountable_auth_refresh_token_revoked"
+    elif goal_stage == "goal_active_timeout":
         label = "skillsbench_codex_cli_goal_uncountable_goal_active_timeout"
     elif goal_stage == "pre_bridge_tui_model_timeout":
         label = "skillsbench_codex_cli_goal_uncountable_pre_bridge_model_timeout"


### PR DESCRIPTION
## Summary
- remove the speculative staged-helper/two-followup path from #1889, #1896, #1903, and #1909 after a public synthetic TUI control identified revoked remote Codex auth as the actual blocker
- detect revoked refresh-token errors from only the recent TUI window and emit the fixed public-safe stage `auth_refresh_token_revoked`
- classify any resulting official zero as `skillsbench_codex_cli_goal_uncountable_auth_refresh_token_revoked`, explicitly non-comparable and non-countable

## Product / architecture judgment
The bad case was diagnostic: auth failure looked like `/goal` lifecycle failure, which triggered increasingly complex bridge staging. This restores the previously validated file-backed `/goal` route and adds attribution at the reusable TUI boundary. It does not change task semantics, scoring, benchmark launches, permissions, or credential handling.

## Validation
- `python3 examples/codex-cli-goal-tui-session-smoke.py`
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- focused Codex CLI Goal countability guard assertion in the route smoke
- `uv run --extra test python -m ruff check loopx/codex_cli_goal_tui.py examples/codex-cli-goal-tui-session-smoke.py examples/skillsbench-codex-cli-goal-route-smoke.py`
- `loopx canary premerge --from-git-diff`: all direct checks, 6/6 catalog canaries, and public boundary passed; benchmark-sensitive manual hold remains and is covered by prior explicit owner authorization for this narrow helper/runtime repair

## Boundary
- no credentials or auth values read, copied, logged, or committed
- no raw TUI capture, task text, trajectories, verifier output, local paths, or benchmark evidence committed
- no benchmark job launched and no score claimed
