### PR TITLE
Characterize the Claude goal baseline contract

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -325,7 +325,7 @@ sufficient; raise it as durable behavior moves from subprocess smokes into
 focused tests. An architecture test also prevents new control-plane dependencies
 on presentation, CLI, capability, or benchmark-adapter layers while preserving
 one explicit quota-Markdown migration debt edge. Existing source-wide lint debt
-is characterized separately. Strict mypy checking covers nine characterized
+is characterized separately. Strict mypy checking covers ten characterized
 kernel and runtime contracts and should expand only as each next boundary
 becomes clean;
 expand the protected namespace list only after a bounded cleanup, rather than

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ include = ["loopx*"]
 python_version = "3.11"
 strict = true
 files = [
+  "loopx/claude_goal_baseline.py",
   "loopx/control_plane/__init__.py",
   "loopx/control_plane/quota/states.py",
   "loopx/control_plane/runtime/event_store_migration_bridge.py",

--- a/tests/test_claude_goal_baseline.py
+++ b/tests/test_claude_goal_baseline.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import pytest
+
+from loopx.claude_goal_baseline import (
+    CLAUDE_CODE_GOAL_SEAMS,
+    build_claude_code_goal_baseline_plan,
+    build_claude_code_goal_baseline_proof,
+    stable_text_digest,
+)
+
+
+def test_claude_goal_baseline_plan_describes_supported_control_plane() -> None:
+    write_scope = ["src/**", "tests/**"]
+
+    plan = build_claude_code_goal_baseline_plan(
+        objective="Fix the failing parser contract",
+        write_scope=write_scope,
+        token_budget=4_000,
+    )
+    write_scope.append("docs/**")
+
+    assert plan["schema_version"] == "claude_code_goal_baseline_v0"
+    assert plan["native_goal_api_present"] is False
+    assert plan["seams"] == list(CLAUDE_CODE_GOAL_SEAMS)
+    assert plan["objective_sha256"] == stable_text_digest(
+        "Fix the failing parser contract"
+    )
+    assert plan["objective_chars"] == 31
+    assert plan["status"] == "active"
+    assert plan["write_scope"] == ["src/**", "tests/**"]
+    assert plan["token_budget_present"] is True
+    assert plan["claim_boundary"]["permission_decision_is_deterministic"] is True
+
+
+@pytest.mark.parametrize(
+    ("objective", "status", "message"),
+    [
+        ("  ", "active", "objective must be non-empty"),
+        ("Fix parser", "running", "unsupported goal status: running"),
+    ],
+)
+def test_claude_goal_baseline_plan_rejects_invalid_inputs(
+    objective: str,
+    status: str,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        build_claude_code_goal_baseline_plan(objective=objective, status=status)
+
+
+def test_claude_goal_baseline_proof_allows_complete_deterministic_evidence() -> None:
+    proof = build_claude_code_goal_baseline_proof(
+        expected_objective="Fix parser",
+        hook_installed=True,
+        hook_denied_out_of_scope=True,
+        hook_allowed_in_scope=True,
+        should_run_consulted=True,
+        todo_completed_via_cli_or_mcp=True,
+    )
+
+    assert proof["schema_version"] == "claude_code_goal_baseline_proof_v0"
+    assert proof["deterministic_gate_evidence"] is True
+    assert proof["loop_evidence"] is True
+    assert proof["baseline_claim_allowed"] is True
+    assert proof["expected_objective_sha256"] == stable_text_digest("Fix parser")
+    assert proof["negative_controls"] == {
+        "prompt_only_loop": False,
+        "included_loopx_state_in_prompt": False,
+    }
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"hook_denied_out_of_scope": False},
+        {"should_run_consulted": False},
+        {"used_unverified_prompt_only_loop": True},
+        {"included_loopx_state_in_prompt": True},
+    ],
+)
+def test_claude_goal_baseline_proof_fails_closed(
+    override: dict[str, bool],
+) -> None:
+    kwargs = {
+        "expected_objective": "Fix parser",
+        "hook_installed": True,
+        "hook_denied_out_of_scope": True,
+        "hook_allowed_in_scope": True,
+        "should_run_consulted": True,
+        "todo_completed_via_cli_or_mcp": True,
+        **override,
+    }
+
+    proof = build_claude_code_goal_baseline_proof(**kwargs)
+
+    assert proof["baseline_claim_allowed"] is False


### PR DESCRIPTION
## Summary
- add focused pytest characterization for the Claude goal baseline plan and proof reducers
- cover invalid plan inputs, deterministic happy-path evidence, and fail-closed negative controls
- add the characterized module to the strict mypy gate and update the protected-contract count

## Validation
- focused pytest: 8 passed
- full pytest: 76 passed, 2 skipped; coverage 19.66% against the 19.5% floor
- strict mypy: 10/10
- required Ruff boundary: clean
- `loopx canary premerge --from-git-diff`: 16/16, no failures, warnings, or manual holds
- public/private boundary scan: clean
