### PR TITLE
Characterize operator Markdown renderers

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -57,4 +57,4 @@ jobs:
           python -m pytest -q -n 2
           --cov=loopx
           --cov-report=term
-          --cov-fail-under=19.5
+          --cov-fail-under=19.6

--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -319,13 +319,13 @@ python3 -m pytest tests/test_smoke_suite.py \
 
 The required Python test workflow keeps `tests/**`, `canary/**`,
 `control_plane/**`, `domain_packs/**`, and `presentation/**` Ruff-clean. It also
-enforces an initial 19.5% package coverage floor.
-The floor is intentionally a regression guard, not a claim that 19.5% is
+enforces an initial 19.6% package coverage floor.
+The floor is intentionally a regression guard, not a claim that 19.6% is
 sufficient; raise it as durable behavior moves from subprocess smokes into
 focused tests. An architecture test also prevents new control-plane dependencies
 on presentation, CLI, capability, or benchmark-adapter layers while preserving
 one explicit quota-Markdown migration debt edge. Existing source-wide lint debt
-is characterized separately. Strict mypy checking covers ten characterized
+is characterized separately. Strict mypy checking covers twelve characterized
 kernel and runtime contracts and should expand only as each next boundary
 becomes clean;
 expand the protected namespace list only after a bounded cleanup, rather than

--- a/loopx/presentation/renderers/trajectory_hygiene_markdown.py
+++ b/loopx/presentation/renderers/trajectory_hygiene_markdown.py
@@ -9,13 +9,14 @@ def render_trajectory_hygiene_markdown(payload: dict[str, Any]) -> str:
     if not payload.get("ok"):
         return "# LoopX Trajectory Hygiene\n\n- ok: `False`\n- error: " + str(payload.get("error"))
 
-    sample = payload.get("sample") if isinstance(payload.get("sample"), dict) else {}
-    metrics = payload.get("metrics") if isinstance(payload.get("metrics"), dict) else {}
-    boundary = (
-        payload.get("training_boundary")
-        if isinstance(payload.get("training_boundary"), dict)
-        else {}
-    )
+    sample_value = payload.get("sample")
+    metrics_value = payload.get("metrics")
+    boundary_value = payload.get("training_boundary")
+    channels_value = payload.get("channel_counts")
+    sample = sample_value if isinstance(sample_value, dict) else {}
+    metrics = metrics_value if isinstance(metrics_value, dict) else {}
+    boundary = boundary_value if isinstance(boundary_value, dict) else {}
+    channels = channels_value if isinstance(channels_value, dict) else {}
     lines = [
         "# LoopX Trajectory Hygiene",
         "",
@@ -33,6 +34,6 @@ def render_trajectory_hygiene_markdown(payload: dict[str, Any]) -> str:
         lines.append(markdown_table_row([markdown_code(name), markdown_code(value)]))
 
     lines.extend(["", "## Channels"])
-    for name, value in (payload.get("channel_counts") or {}).items():
+    for name, value in channels.items():
         lines.append(f"- `{name}`: `{value}`")
     return "\n".join(lines)

--- a/loopx/presentation/renderers/turn_envelope_markdown.py
+++ b/loopx/presentation/renderers/turn_envelope_markdown.py
@@ -4,11 +4,16 @@ from typing import Any
 
 
 def render_turn_envelope_markdown(payload: dict[str, Any]) -> str:
-    action = payload.get("action") if isinstance(payload.get("action"), dict) else {}
-    user = payload.get("user") if isinstance(payload.get("user"), dict) else {}
-    writeback = payload.get("writeback") if isinstance(payload.get("writeback"), dict) else {}
-    scheduler = payload.get("scheduler") if isinstance(payload.get("scheduler"), dict) else {}
-    compaction = payload.get("compaction") if isinstance(payload.get("compaction"), dict) else {}
+    action_value = payload.get("action")
+    user_value = payload.get("user")
+    writeback_value = payload.get("writeback")
+    scheduler_value = payload.get("scheduler")
+    compaction_value = payload.get("compaction")
+    action = action_value if isinstance(action_value, dict) else {}
+    user = user_value if isinstance(user_value, dict) else {}
+    writeback = writeback_value if isinstance(writeback_value, dict) else {}
+    scheduler = scheduler_value if isinstance(scheduler_value, dict) else {}
+    compaction = compaction_value if isinstance(compaction_value, dict) else {}
     lines = [
         "# LoopX Turn Envelope",
         "",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,4 +44,6 @@ files = [
   "loopx/control_plane/work_items/delivery_batch_scale.py",
   "loopx/control_plane/work_items/delivery_outcome.py",
   "loopx/control_plane/work_items/lifecycle.py",
+  "loopx/presentation/renderers/trajectory_hygiene_markdown.py",
+  "loopx/presentation/renderers/turn_envelope_markdown.py",
 ]

--- a/tests/test_operator_markdown_renderers.py
+++ b/tests/test_operator_markdown_renderers.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from loopx.presentation.renderers.trajectory_hygiene_markdown import (
+    render_trajectory_hygiene_markdown,
+)
+from loopx.presentation.renderers.turn_envelope_markdown import (
+    render_turn_envelope_markdown,
+)
+
+
+def test_turn_envelope_markdown_keeps_hot_path_contract() -> None:
+    markdown = render_turn_envelope_markdown(
+        {
+            "ok": True,
+            "goal_id": "loopx-meta",
+            "agent_id": "codex-product-capability",
+            "decision": "run",
+            "should_run": True,
+            "effective_action": "normal_run",
+            "action": {"primary_action": "todo_fixture: advance quality"},
+            "user": {"action_required": False},
+            "writeback": {"spend_policy": "spend_after_validation"},
+            "scheduler": {"action": "run_now"},
+            "compaction": {"envelope_json_bytes": 3902, "within_budget": True},
+        }
+    )
+
+    assert "# LoopX Turn Envelope" in markdown
+    assert "- action: todo_fixture: advance quality" in markdown
+    assert "- user_action_required: `False`" in markdown
+    assert "- spend_policy: spend_after_validation" in markdown
+    assert "- envelope_bytes: `3902`" in markdown
+    assert "- within_budget: `True`" in markdown
+
+
+def test_turn_envelope_markdown_tolerates_malformed_nested_values() -> None:
+    markdown = render_turn_envelope_markdown(
+        {
+            "ok": True,
+            "action": None,
+            "user": "not-a-mapping",
+            "writeback": [],
+            "scheduler": 1,
+            "compaction": False,
+        }
+    )
+
+    assert "- action: " in markdown
+    assert "- user_action_required: `None`" in markdown
+    assert "- scheduler: `None`" in markdown
+    assert "- within_budget: `None`" in markdown
+
+
+def test_trajectory_hygiene_markdown_renders_boundary_metrics_and_channels() -> None:
+    markdown = render_trajectory_hygiene_markdown(
+        {
+            "ok": True,
+            "schema_version": "trajectory_hygiene_summary_v0",
+            "goal_filter": "fixture",
+            "sample": {
+                "compact_history_row_count": 5,
+                "source": "public_safe_compact_run_index",
+            },
+            "metrics": {"controller_event_ratio": 0.4},
+            "training_boundary": {
+                "seed_model_training_eligible": False,
+                "reason": "compact history is audit evidence only",
+            },
+            "channel_counts": {"controller": 2, "outcome": 3},
+        }
+    )
+
+    assert "# LoopX Trajectory Hygiene" in markdown
+    assert "- compact_history_rows: `5`" in markdown
+    assert "- seed_model_training_eligible: `False`" in markdown
+    assert "| `controller_event_ratio` | `0.4` |" in markdown
+    assert "- `controller`: `2`" in markdown
+    assert "- `outcome`: `3`" in markdown
+
+
+def test_trajectory_hygiene_markdown_fails_closed() -> None:
+    markdown = render_trajectory_hygiene_markdown(
+        {"ok": False, "error": "compact index unavailable"}
+    )
+
+    assert markdown == (
+        "# LoopX Trajectory Hygiene\n\n"
+        "- ok: `False`\n"
+        "- error: compact index unavailable"
+    )
+
+
+def test_trajectory_hygiene_markdown_tolerates_malformed_nested_values() -> None:
+    markdown = render_trajectory_hygiene_markdown(
+        {
+            "ok": True,
+            "sample": None,
+            "metrics": "not-a-mapping",
+            "training_boundary": [],
+            "channel_counts": 1,
+        }
+    )
+
+    assert "- compact_history_rows: `None`" in markdown
+    assert "| metric | value |" in markdown
+    assert markdown.endswith("## Channels")


### PR DESCRIPTION
## Summary
- directly characterize the TurnEnvelope and trajectory-hygiene Markdown renderers
- preserve malformed-input fallback behavior while making nested mapping narrowing strict-type clean
- add both renderers to the strict mypy gate
- raise the package coverage regression floor from 19.5% to 19.6%

## Validation
- focused pytest: 5 passed
- full pytest: 81 passed, 2 skipped; coverage 19.71% against the new 19.6% floor
- strict mypy: 12/12
- required Ruff boundary: clean
- workflow YAML change is a scalar threshold update; `actionlint` was unavailable locally
- `loopx canary premerge --from-git-diff`: 17/17, no failures, warnings, or manual holds
- public/private boundary scan: clean
