### PR TITLE
Budget status outward dependency debt

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,6 +34,26 @@ The core repository intentionally avoids domain logic. A data experiment goal,
 a note-maintenance goal, and a harness self-improvement goal should share the
 same runtime and contract, but use different adapters.
 
+## Current Dependency Budget
+
+Dependency direction is enforced incrementally while large compatibility
+facades are split. `loopx.control_plane` may not gain dependencies on
+presentation, CLI, capability, or benchmark-adapter layers; the architecture
+test keeps one explicit quota-Markdown migration edge as debt.
+
+The legacy `loopx.status` facade currently has exactly three additional outward
+edges: two SkillsBench signal enrichers and the status Markdown renderer. These
+are migration debt, not extension points. The architecture test records their
+exact module targets so the set can only shrink: a new outward edge fails, and
+removing an edge requires deleting its stale allowlist entry in the same change.
+
+Each edge should move only after characterization parity exists. Adapter-specific
+enrichment belongs behind application/plugin composition rather than in the
+status core. Presentation callers should migrate to the renderer module before
+the public `loopx.status.render_status_markdown` compatibility entry point is
+retired. Hiding either dependency inside a function or dynamic import does not
+count as architectural separation.
+
 LoopX should still absorb field-tested project-control mechanisms such
 as authority registries, current-belief TODOs, managed external-source
 manifests, experiment boards, validation surface maps, and gated handoff

--- a/tests/architecture/test_control_plane_import_boundaries.py
+++ b/tests/architecture/test_control_plane_import_boundaries.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "loopx"
 CONTROL_PLANE_ROOT = PACKAGE_ROOT / "control_plane"
+STATUS_MODULE = PACKAGE_ROOT / "status.py"
 FORBIDDEN_DEPENDENCY_PREFIXES = (
     "loopx.benchmark_adapters",
     "loopx.capabilities",
@@ -18,6 +19,24 @@ ALLOWED_DEPENDENCY_DEBT = {
     (
         "loopx.control_plane.quota.markdown",
         "loopx.presentation.markdown",
+    ),
+}
+STATUS_FORBIDDEN_DEPENDENCY_PREFIXES = (
+    "loopx.benchmark_adapters",
+    "loopx.presentation",
+)
+STATUS_OUTWARD_DEPENDENCY_DEBT = {
+    (
+        "loopx.status",
+        "loopx.benchmark_adapters.skillsbench_signals",
+    ),
+    (
+        "loopx.status",
+        "loopx.benchmark_adapters.skillsbench_verifier_bootstrap",
+    ),
+    (
+        "loopx.status",
+        "loopx.presentation.renderers.status_markdown",
     ),
 }
 
@@ -61,4 +80,26 @@ def test_control_plane_does_not_gain_outward_dependencies() -> None:
     assert not unexpected, (
         "control-plane code must not depend on presentation, CLI, capability, or "
         f"benchmark-adapter layers; unexpected edges: {sorted(unexpected)}"
+    )
+
+
+def test_status_outward_dependency_debt_only_shrinks() -> None:
+    outward_dependencies = {
+        (_module_name(STATUS_MODULE), dependency)
+        for dependency in _resolved_imports(STATUS_MODULE)
+        if any(
+            dependency == prefix or dependency.startswith(prefix + ".")
+            for prefix in STATUS_FORBIDDEN_DEPENDENCY_PREFIXES
+        )
+    }
+
+    unexpected = outward_dependencies - STATUS_OUTWARD_DEPENDENCY_DEBT
+    stale_debt = STATUS_OUTWARD_DEPENDENCY_DEBT - outward_dependencies
+    assert not unexpected, (
+        "loopx.status must not gain new benchmark-adapter or presentation dependencies; "
+        f"unexpected edges: {sorted(unexpected)}"
+    )
+    assert not stale_debt, (
+        "remove resolved loopx.status edges from STATUS_OUTWARD_DEPENDENCY_DEBT; "
+        f"stale entries: {sorted(stale_debt)}"
     )


### PR DESCRIPTION
## Summary
- prevent `loopx.status` from gaining new benchmark-adapter or presentation dependencies
- record the exact three current outward edges as shrinking migration debt
- fail when an edge is removed but its stale allowlist entry is not cleaned up
- document the parity-first migration sequence and reject lazy/dynamic imports as fake separation

## Validation
- focused architecture tests: 2 passed
- full pytest: 82 passed, 2 skipped; coverage 19.71% against the 19.6% floor
- strict mypy: 12/12
- required Ruff boundary: clean
- `loopx canary premerge --from-git-diff`: 10/10, no failures, warnings, or manual holds
- public/private boundary scan: clean
