### PR TITLE
Retire the status Markdown compatibility edge

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,18 +41,18 @@ facades are split. `loopx.control_plane` may not gain dependencies on
 presentation, CLI, capability, or benchmark-adapter layers; the architecture
 test keeps one explicit quota-Markdown migration edge as debt.
 
-The legacy `loopx.status` facade currently has exactly three additional outward
-edges: two SkillsBench signal enrichers and the status Markdown renderer. These
-are migration debt, not extension points. The architecture test records their
-exact module targets so the set can only shrink: a new outward edge fails, and
-removing an edge requires deleting its stale allowlist entry in the same change.
+The legacy `loopx.status` facade currently has exactly two additional outward
+edges, both SkillsBench signal enrichers. These are migration debt, not
+extension points. The architecture test records their exact module targets so
+the set can only shrink: a new outward edge fails, and removing an edge requires
+deleting its stale allowlist entry in the same change.
 
 Each edge should move only after characterization parity exists. Adapter-specific
 enrichment belongs behind application/plugin composition rather than in the
-status core. Presentation callers should migrate to the renderer module before
-the public `loopx.status.render_status_markdown` compatibility entry point is
-retired. Hiding either dependency inside a function or dynamic import does not
-count as architectural separation.
+status core. Status Markdown callers now use the presentation renderer directly;
+the former `loopx.status.render_status_markdown` wrapper was retired after parity
+fixtures and repository callers migrated. Hiding an adapter dependency inside a
+function or dynamic import does not count as architectural separation.
 
 LoopX should still absorb field-tested project-control mechanisms such
 as authority registries, current-belief TODOs, managed external-source

--- a/docs/product/core-control-plane/rule-seam-map.md
+++ b/docs/product/core-control-plane/rule-seam-map.md
@@ -111,7 +111,7 @@ The next module-boundary PR should therefore:
 | Attention queue | `loopx.control_plane.work_items.attention_queue.build_attention_queue` with `loopx.status.build_attention_queue` as the compatibility entry | Queue builder over normalized goal status, todos, gates, and project assets. | Queue ordering, project-asset enrichment, quota guards, and candidate lanes remain explicit and stable. |
 | Task graph projection | `loopx.control_plane.work_items.task_graph.build_task_graph_projection` with `loopx.status.build_task_graph_projection` as the status-facing wrapper | Read-only graph projection module. | Node caps include truncation metadata; full cold-path detail remains outside the hot graph. |
 | Status collection assembly | `loopx.control_plane.status_collection.collect_status` with `loopx.status.collect_status` as the compatibility entry | Thin collector/orchestrator that wires registry, runtime, state, and read models. | CLI status JSON shape remains compatible; wrapper/direct parity stays covered by `examples/control_plane/status-collection-readmodel-smoke.py`. |
-| Markdown rendering | `loopx/presentation/renderers/status_markdown.py` with `loopx.status.render_status_markdown` as the compatibility entry | Render-only module/helpers over the status payload. | Rendering cannot become the source of scheduler or quota truth. |
+| Markdown rendering | `loopx/presentation/renderers/status_markdown.py` | Render-only module/helpers over the status payload. | Rendering cannot become the source of scheduler or quota truth. |
 
 ## Proposed Extraction Order
 

--- a/examples/benchmark-run-v0-status-projection-smoke.py
+++ b/examples/benchmark-run-v0-status-projection-smoke.py
@@ -16,7 +16,8 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.review_packet import build_review_packet  # noqa: E402
-from loopx.status import collect_status, compact_benchmark_run, render_status_markdown  # noqa: E402
+from loopx.presentation.renderers.status_markdown import render_status_markdown  # noqa: E402
+from loopx.status import collect_status, compact_benchmark_run  # noqa: E402
 from loopx.control_plane.runtime.benchmark_projection import (  # noqa: E402
     compact_benchmark_run_core,
 )

--- a/examples/control_plane/status-global-registry-markdown-smoke.py
+++ b/examples/control_plane/status-global-registry-markdown-smoke.py
@@ -11,7 +11,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from loopx.status import render_status_markdown  # noqa: E402
+from loopx.presentation.renderers.status_markdown import render_status_markdown  # noqa: E402
 
 
 def main() -> None:

--- a/examples/control_plane/status-markdown-smoke.py
+++ b/examples/control_plane/status-markdown-smoke.py
@@ -25,8 +25,8 @@ from loopx.status import (  # noqa: E402
     delivery_batch_scale_for_run,
     delivery_outcome_for_run,
     project_asset_summary_is_public_safe,
-    render_status_markdown,
 )
+from loopx.presentation.renderers.status_markdown import render_status_markdown  # noqa: E402
 from loopx.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
 from loopx.review_packet import build_review_packet  # noqa: E402
 from loopx.handoff_budget import PROJECT_AGENT_HANDOFF_BUDGET  # noqa: E402

--- a/examples/control_plane/status-overview-markdown-smoke.py
+++ b/examples/control_plane/status-overview-markdown-smoke.py
@@ -13,9 +13,8 @@ if str(REPO_ROOT) not in sys.path:
 
 from loopx.presentation.renderers.status_markdown import (  # noqa: E402
     append_status_overview_markdown,
-    render_status_markdown as render_presentation_status_markdown,
+    render_status_markdown,
 )
-from loopx.status import render_status_markdown  # noqa: E402
 
 
 def overview_payload() -> dict:
@@ -120,11 +119,11 @@ def main() -> int:
     assert_overview(full_markdown)
     assert_contract_details(full_markdown)
 
-    presentation_markdown = render_presentation_status_markdown(
+    explicit_event_classes_markdown = render_status_markdown(
         payload,
         event_classes=("accounting", "decision", "evidence", "state", "work"),
     )
-    assert presentation_markdown == full_markdown, presentation_markdown
+    assert explicit_event_classes_markdown == full_markdown, explicit_event_classes_markdown
     print("status-overview-markdown-smoke ok")
     return 0
 

--- a/examples/control_plane/status_markdown_agent_lane_fixtures.py
+++ b/examples/control_plane/status_markdown_agent_lane_fixtures.py
@@ -9,7 +9,8 @@ from loopx.cli_commands.status import (
     attach_agent_lane_next_actions,
 )
 from loopx.review_packet import build_review_packet
-from loopx.status import project_asset_todo_summary, render_status_markdown
+from loopx.presentation.renderers.status_markdown import render_status_markdown
+from loopx.status import project_asset_todo_summary
 
 
 def assert_status_agent_lane_next_action_projection() -> None:

--- a/examples/control_plane/status_markdown_fixtures.py
+++ b/examples/control_plane/status_markdown_fixtures.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from loopx.status import render_status_markdown
+from loopx.presentation.renderers.status_markdown import render_status_markdown
 
 
 OLD_PLANNED_ACTION = "先审阅 LoopX operator gate；同意后再发送项目 agent 命令"

--- a/examples/project/next-action-projection-contract-smoke.py
+++ b/examples/project/next-action-projection-contract-smoke.py
@@ -12,13 +12,14 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 import loopx.state_refresh as state_refresh
+from loopx.presentation.renderers.status_markdown import render_status_markdown
 from loopx.quota import build_quota_should_run, render_quota_should_run_markdown
 from loopx.state_projection import (
     actions_are_projection_aligned,
     next_action_resolution_trace,
     state_action_projection_warning,
 )
-from loopx.status import collect_status, render_status_markdown
+from loopx.status import collect_status
 
 
 GOAL_ID = "next-action-projection-goal"

--- a/examples/project/subagent-status-projection-smoke.py
+++ b/examples/project/subagent-status-projection-smoke.py
@@ -13,10 +13,10 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from loopx.presentation.renderers.status_markdown import render_status_markdown  # noqa: E402
 from loopx.status import (  # noqa: E402
     collect_status,
     project_asset_summary_is_public_safe,
-    render_status_markdown,
 )
 
 

--- a/examples/session_runtime/session-runtime-readonly-projection-smoke.py
+++ b/examples/session_runtime/session-runtime-readonly-projection-smoke.py
@@ -16,10 +16,10 @@ from loopx.session_runtime import (  # noqa: E402
     SESSION_RUNTIME_READONLY_PROJECTION_SCHEMA_VERSION,
     build_session_runtime_readonly_projection,
 )
+from loopx.presentation.renderers.status_markdown import render_status_markdown  # noqa: E402
 from loopx.status import (  # noqa: E402
     build_attention_queue,
     build_status_runtime_summaries,
-    render_status_markdown,
 )
 
 

--- a/examples/user-todo-review-material-smoke.py
+++ b/examples/user-todo-review-material-smoke.py
@@ -180,7 +180,10 @@ def review_material_url(base_url: str, *, path: str) -> str:
 def main() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     sys.path.insert(0, str(repo_root))
-    from loopx.status import collect_status, render_status_markdown  # noqa: PLC0415
+    from loopx.presentation.renderers.status_markdown import (  # noqa: PLC0415
+        render_status_markdown,
+    )
+    from loopx.status import collect_status  # noqa: PLC0415
 
     with tempfile.TemporaryDirectory() as raw_tmp:
         root = Path(raw_tmp)

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -9,11 +9,11 @@ from ..contract import check_contract, render_contract_markdown
 from ..diagnose import collect_diagnosis, render_diagnosis_markdown
 from ..handoff_budget import build_handoff_interface_budget
 from ..quota import build_quota_should_run
+from ..presentation.renderers.status_markdown import render_status_markdown
 from ..review_packet import build_review_packet, render_review_packet_markdown
 from ..status import (
     AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK,
     collect_status,
-    render_status_markdown,
 )
 from ..control_plane.runtime.status_projection_cache import (
     load_status_projection_cache,

--- a/loopx/cli_commands/support_control.py
+++ b/loopx/cli_commands/support_control.py
@@ -16,6 +16,7 @@ from ..heartbeat_prompt import (
 )
 from ..history import load_registry
 from ..paths import resolve_runtime_root
+from ..presentation.renderers.status_markdown import render_status_markdown
 from ..promotion_gate import build_promotion_gate, render_promotion_gate_markdown
 from ..registry import (
     inspect_registry,
@@ -35,7 +36,6 @@ from ..state_backup import (
     execute_state_backup_plan,
     render_state_backup_markdown,
 )
-from ..status import render_status_markdown
 from ..status_server import (
     DEFAULT_STATUS_HOST,
     DEFAULT_STATUS_PATH,

--- a/loopx/presentation/renderers/status_markdown.py
+++ b/loopx/presentation/renderers/status_markdown.py
@@ -4,6 +4,7 @@ from collections.abc import Collection
 from typing import Any
 
 from ...control_plane import control_plane_policy_summary
+from ...control_plane.runtime.event_ledger import EVENT_LEDGER_CLASSES
 from ...execution_profile import execution_profile_summary
 from ...long_task_cadence import long_task_cadence_hint_summary
 from ...orchestration import orchestration_policy_summary
@@ -920,7 +921,7 @@ def append_attention_queue_summary_markdown(
 def render_status_markdown(
     payload: dict[str, Any],
     *,
-    event_classes: Collection[str],
+    event_classes: Collection[str] = EVENT_LEDGER_CLASSES,
 ) -> str:
     lines: list[str] = []
     append_status_overview_markdown(lines, payload)

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -198,7 +198,6 @@ from .control_plane.runtime.run_history import (
     latest_run as _latest_run_read_model,
 )
 from .control_plane.runtime.event_ledger import (
-    EVENT_LEDGER_CLASSES,
     blank_event_class_counts,
     blank_event_ledger_goal,
     event_ledger_event_class as _event_ledger_event_class_read_model,
@@ -321,9 +320,6 @@ from .control_plane.quota.usage_summary import (
 from .promotion_gate import build_promotion_gate
 from .quota import quota_status, quota_with_handoff_outcome_floor
 from .registry import registry_goals
-from .presentation.renderers.status_markdown import (
-    render_status_markdown as _render_status_markdown,
-)
 from .rollout_event_log import load_rollout_events, rollout_event_log_path
 from .state_projection import (
     active_state_next_action_entries,
@@ -6730,7 +6726,3 @@ def collect_status(
         goal_id=goal_id,
         context=build_status_collection_context(),
     )
-
-
-def render_status_markdown(payload: dict[str, Any]) -> str:
-    return _render_status_markdown(payload, event_classes=EVENT_LEDGER_CLASSES)

--- a/tests/architecture/test_control_plane_import_boundaries.py
+++ b/tests/architecture/test_control_plane_import_boundaries.py
@@ -34,10 +34,6 @@ STATUS_OUTWARD_DEPENDENCY_DEBT = {
         "loopx.status",
         "loopx.benchmark_adapters.skillsbench_verifier_bootstrap",
     ),
-    (
-        "loopx.status",
-        "loopx.presentation.renderers.status_markdown",
-    ),
 }
 
 


### PR DESCRIPTION
## Summary

- make \`loopx.presentation.renderers.status_markdown\` the single status Markdown entry point
- migrate CLI and repository smoke callers off \`loopx.status.render_status_markdown\`
- remove the \`status -> presentation\` reverse dependency and tighten its architecture debt budget from three edges to two
- preserve renderer behavior with a stable event-class default and explicit/default parity coverage

## Validation

- \`python -m ruff check tests loopx/canary loopx/control_plane loopx/domain_packs loopx/presentation\`
- \`python -m pytest -q -n 2 --cov=loopx --cov-report=term --cov-fail-under=19.6\` (82 passed, 2 skipped, 19.71%)
- \`python -m mypy\`
- architecture boundary tests (2 passed)
- 8 focused status/CLI projection smokes
- \`loopx canary premerge --from-git-diff\`: 17/17 executed checks passed; public boundary clean

## Review note

Canary reports a manual \`benchmark_sensitive\` hold because one benchmark status-projection smoke imports the renderer. That file only changes its import path; runner behavior, task semantics, scoring, evidence policy, and benchmark execution are untouched. This is a bounded architecture migration under the owner's standing self-merge authorization.
