### PR TITLE
Retire duplicate status runtime wrappers

### DIFF
--- a/examples/control_plane/decision-freshness-readmodel-smoke.py
+++ b/examples/control_plane/decision-freshness-readmodel-smoke.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import sys
+import tempfile
 from typing import Any
 
 
@@ -14,14 +15,25 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx import status as status_module  # noqa: E402
+from loopx.control_plane import status_runtime_summaries  # noqa: E402
 from loopx.control_plane.runtime import decision_freshness as decision_read_model  # noqa: E402
+from loopx.control_plane.runtime import event_ledger as event_ledger_read_model  # noqa: E402
+
+
+RUNTIME_CONTEXT = status_module.build_status_runtime_summary_context()
 
 
 def direct_decision_kinds(run: dict[str, Any]) -> list[str]:
-    return decision_read_model.decision_event_kinds(
+    return status_runtime_summaries.decision_event_kinds(
         run,
-        decision_classifications=status_module.EVENT_LEDGER_DECISION_CLASSIFICATIONS,
-        classification_prefixes=status_module.DECISION_FRESHNESS_CLASSIFICATION_PREFIXES,
+        context=RUNTIME_CONTEXT,
+    )
+
+
+def direct_event_class(run: dict[str, Any]) -> str:
+    return status_runtime_summaries.event_ledger_event_class(
+        run,
+        context=RUNTIME_CONTEXT,
     )
 
 
@@ -30,8 +42,8 @@ def direct_summary(history: dict[str, Any]) -> dict[str, Any]:
         history,
         parse_timestamp=status_module.parse_timestamp,
         decision_event_kinds=direct_decision_kinds,
-        event_class_for_run=status_module.event_ledger_event_class,
-        blank_event_class_counts=status_module.blank_event_class_counts,
+        event_class_for_run=direct_event_class,
+        blank_event_class_counts=event_ledger_read_model.blank_event_class_counts,
         window_days=status_module.DECISION_FRESHNESS_WINDOW_DAYS,
         item_limit=status_module.DECISION_FRESHNESS_ITEM_LIMIT,
         proxy_note=status_module.DECISION_FRESHNESS_PROXY_NOTE,
@@ -95,17 +107,25 @@ def main() -> None:
     ]
     history = {"runs": runs}
 
-    assert status_module.decision_event_kinds(runs[0]) == direct_decision_kinds(runs[0]) == ["operator_gate"]
-    assert status_module.decision_event_kinds(runs[2]) == direct_decision_kinds(runs[2]) == ["human_reward"]
-    assert status_module.decision_event_kinds(runs[6]) == direct_decision_kinds(runs[6]) == [
+    assert direct_decision_kinds(runs[0]) == ["operator_gate"]
+    assert direct_decision_kinds(runs[2]) == ["human_reward"]
+    assert direct_decision_kinds(runs[6]) == [
         "decision_classification"
     ]
-    assert status_module.decision_freshness_reason(
+    assert decision_read_model.decision_freshness_reason(
         stale_by_age=True,
         newer_event_count=1,
-    ) == decision_read_model.decision_freshness_reason(stale_by_age=True, newer_event_count=1)
+    ) == "decision older than freshness window and newer sampled events exist; rebase at decision point"
 
-    wrapper = status_module.build_decision_freshness_summary(history)
+    with tempfile.TemporaryDirectory(prefix="loopx-decision-freshness-summary-") as raw_tmp:
+        wrapper = status_module.build_status_runtime_summaries(
+            history=history,
+            queue={"items": []},
+            runtime_root=Path(raw_tmp),
+            goal_id_filter=None,
+            display_limit=10,
+            todo_index_limit=10,
+        )["decision_freshness_summary"]
     direct = direct_summary(history)
     assert normalize_generated_at(direct, wrapper) == wrapper, (direct, wrapper)
 

--- a/examples/control_plane/event-ledger-readmodel-smoke.py
+++ b/examples/control_plane/event-ledger-readmodel-smoke.py
@@ -15,23 +15,17 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx import status as status_module  # noqa: E402
+from loopx.control_plane import status_runtime_summaries  # noqa: E402
 from loopx.control_plane.runtime import event_ledger as event_ledger_read_model  # noqa: E402
 
 
+RUNTIME_CONTEXT = status_module.build_status_runtime_summary_context()
+
+
 def direct_event_class(run: dict[str, Any]) -> str:
-    return event_ledger_read_model.event_ledger_event_class(
+    return status_runtime_summaries.event_ledger_event_class(
         run,
-        compact_benchmark_run=status_module.compact_benchmark_run,
-        compact_benchmark_result=status_module.compact_benchmark_result,
-        compact_benchmark_comparison=status_module.compact_benchmark_comparison,
-        compact_benchmark_learning_ledger=status_module.compact_benchmark_learning_ledger,
-        compact_benchmark_experiment_report=status_module.compact_benchmark_experiment_report,
-        compact_active_user_assisted_pilot=status_module.compact_active_user_assisted_pilot,
-        run_has_external_evidence_watch_signal=status_module.run_has_external_evidence_watch_signal,
-        decision_classifications=status_module.EVENT_LEDGER_DECISION_CLASSIFICATIONS,
-        evidence_classifications=status_module.EVENT_LEDGER_EVIDENCE_CLASSIFICATIONS,
-        evidence_hints=status_module.EVENT_LEDGER_EVIDENCE_HINTS,
-        state_classifications=status_module.EVENT_LEDGER_STATE_CLASSIFICATIONS,
+        context=RUNTIME_CONTEXT,
     )
 
 
@@ -101,7 +95,13 @@ def main() -> None:
     history = {"runs": runs}
 
     for run in runs:
-        assert status_module.event_ledger_event_class(run) == direct_event_class(run), run
+        assert direct_event_class(run) in {
+            "accounting",
+            "decision",
+            "evidence",
+            "state",
+            "work",
+        }, run
 
     with tempfile.TemporaryDirectory(prefix="loopx-event-ledger-summary-") as raw_tmp:
         wrapper = status_module.build_status_runtime_summaries(
@@ -115,10 +115,14 @@ def main() -> None:
     direct = direct_summary(history)
     assert normalize_generated_at(direct, wrapper) == wrapper, (direct, wrapper)
 
-    assert status_module.blank_event_class_counts() == event_ledger_read_model.blank_event_class_counts()
-    assert status_module.blank_event_ledger_goal("project-z") == event_ledger_read_model.blank_event_ledger_goal(
-        "project-z"
-    )
+    assert event_ledger_read_model.blank_event_class_counts() == {
+        "accounting": 0,
+        "decision": 0,
+        "evidence": 0,
+        "state": 0,
+        "work": 0,
+    }
+    assert event_ledger_read_model.blank_event_ledger_goal("project-z")["goal_id"] == "project-z"
 
     totals = wrapper["totals"]
     assert wrapper["available"] is True, wrapper

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -195,19 +195,11 @@ from .control_plane.runtime.time import parse_timestamp
 from .control_plane.runtime.run_history import (
     latest_run as _latest_run_read_model,
 )
-from .control_plane.runtime.event_ledger import (
-    blank_event_class_counts,
-    blank_event_ledger_goal,
-    event_ledger_event_class as _event_ledger_event_class_read_model,
-)
 from .control_plane.runtime.decision_freshness import (
     DECISION_FRESHNESS_CLASSIFICATION_PREFIXES,
     DECISION_FRESHNESS_ITEM_LIMIT,
     DECISION_FRESHNESS_PROXY_NOTE,
     DECISION_FRESHNESS_WINDOW_DAYS,
-    build_decision_freshness_summary as _build_decision_freshness_summary_read_model,
-    decision_event_kinds as _decision_event_kinds_read_model,
-    decision_freshness_reason,
 )
 from .control_plane.runtime.promotion_readiness import (
     PROMOTION_READINESS_PROXY_NOTE,
@@ -484,43 +476,6 @@ EVENT_LEDGER_EVIDENCE_HINTS = (
     "validation",
 )
 
-
-def decision_event_kinds(run: dict[str, Any]) -> list[str]:
-    return _decision_event_kinds_read_model(
-        run,
-        decision_classifications=EVENT_LEDGER_DECISION_CLASSIFICATIONS,
-        classification_prefixes=DECISION_FRESHNESS_CLASSIFICATION_PREFIXES,
-    )
-
-
-def event_ledger_event_class(run: dict[str, Any]) -> str:
-    return _event_ledger_event_class_read_model(
-        run,
-        compact_benchmark_run=compact_benchmark_run,
-        compact_benchmark_result=compact_benchmark_result,
-        compact_benchmark_comparison=compact_benchmark_comparison,
-        compact_benchmark_learning_ledger=compact_benchmark_learning_ledger,
-        compact_benchmark_experiment_report=compact_benchmark_experiment_report,
-        compact_active_user_assisted_pilot=compact_active_user_assisted_pilot,
-        run_has_external_evidence_watch_signal=run_has_external_evidence_watch_signal,
-        decision_classifications=EVENT_LEDGER_DECISION_CLASSIFICATIONS,
-        evidence_classifications=EVENT_LEDGER_EVIDENCE_CLASSIFICATIONS,
-        evidence_hints=EVENT_LEDGER_EVIDENCE_HINTS,
-        state_classifications=EVENT_LEDGER_STATE_CLASSIFICATIONS,
-    )
-
-
-def build_decision_freshness_summary(history: dict[str, Any]) -> dict[str, Any]:
-    return _build_decision_freshness_summary_read_model(
-        history,
-        parse_timestamp=parse_timestamp,
-        decision_event_kinds=decision_event_kinds,
-        event_class_for_run=event_ledger_event_class,
-        blank_event_class_counts=blank_event_class_counts,
-        window_days=DECISION_FRESHNESS_WINDOW_DAYS,
-        item_limit=DECISION_FRESHNESS_ITEM_LIMIT,
-        proxy_note=DECISION_FRESHNESS_PROXY_NOTE,
-    )
 
 DELIVERY_BATCH_SCALE_TEST_ONLY_CLASSIFICATION_HINTS = (
     "_test",


### PR DESCRIPTION
## Summary
- remove three unused `loopx.status` wrappers whose production composition already lives in `control_plane.status_runtime_summaries`
- remove accidental read-model re-exports used only by parity smokes
- migrate the smokes to exercise the real `StatusRuntimeSummaryContext` composition path

This is a behavior-preserving cleanup: 53 insertions, 74 deletions, net -21 lines. The remaining SkillsBench verifier-bootstrap enrichment is intentionally unchanged because it still carries domain-specific score-attribution semantics.

## Validation
- `python -m ruff check tests loopx/canary loopx/control_plane loopx/domain_packs loopx/presentation`
- `python -m mypy`
- `pytest -q -n 2 --cov=loopx --cov-fail-under=19.6` (83 passed, 2 skipped; 19.80%)
- `loopx canary premerge --from-git-diff` (17/17 passed; no manual holds; self-merge allowed)
- `loopx check` public boundary scan (3 files, 0 warnings/errors)

## Risk
Low. No CLI/schema/persisted-state change; the deleted symbols had no production or documented callers. The smokes now validate the actual production composition path.