### PR TITLE
Make Explore Feishu sync incremental and resumable

### DIFF
--- a/docs/capabilities/explore/README.md
+++ b/docs/capabilities/explore/README.md
@@ -471,8 +471,11 @@ cooldown guidance.
 
 Record identity follows the Lark Kanban adapter contract: rows are matched by
 the `LoopX Goal ID` + `LoopX Result ID` columns, remembered in the local
-config as `result_records`, and the map is rebuilt from the remote table
-before executed upserts.
+config as `result_records`, and the map is rebuilt from all goal-filtered
+remote pages before executed upserts. Executed sync compares canonical values
+with the remote row and skips unchanged records. Newly created record ids are
+persisted immediately, so an interrupted large-graph sync can resume without
+recreating rows that were already delivered.
 
 The text `From Node` / `To Node` columns remain stable public ids for
 automation and review, while the linked-record columns are the Feishu-native
@@ -522,8 +525,9 @@ python3 examples/explore-harness-runtime-resume-smoke.py
 ```
 
 The smoke proves the projection contract (folding, blocked reasons, tree,
-Mermaid), record-time path rejection, dry-run default, idempotent second sync
-by remembered record id, shared-visibility redaction, transport-free card
+Mermaid), record-time path rejection, dry-run default, paginated discovery,
+zero-write idempotent resync, single-row drift repair, nested create-receipt
+handling, shared-visibility redaction, transport-free card
 content, the experimental todo branch-plan packet, the adaptive resilient
 worker harness profile, and the CLI surface against a temp registry, without
 live Lark credentials. It additionally proves the worker-lane router

--- a/examples/explore-result-layer-smoke.py
+++ b/examples/explore-result-layer-smoke.py
@@ -230,6 +230,21 @@ def lark_list_fixture(records: list[tuple[str, str, str]]) -> dict[str, object]:
     }
 
 
+def lark_value_list_fixture(
+    records: list[tuple[str, dict[str, object]]], *, has_more: bool = False
+) -> dict[str, object]:
+    fields = sorted({field for _, values in records for field in values})
+    return {
+        "ok": True,
+        "data": {
+            "fields": fields,
+            "data": [[values.get(field) for field in fields] for _, values in records],
+            "record_id_list": [record_id for record_id, _ in records],
+            "has_more": has_more,
+        },
+    }
+
+
 def check_lark_sync_contract() -> None:
     goal_id = "explore-smoke-goal"
     events = build_sample_events(goal_id)
@@ -259,27 +274,89 @@ def check_lark_sync_contract() -> None:
 
         # Executed sync creates records and remembers record ids.
         upsert_calls: list[list[str]] = []
+        upsert_attempts = 0
+        created_records = 0
+        fail_on_upsert_attempt = 2
+        remote_records: dict[str, dict[str, dict[str, object]]] = {
+            "tblN": {},
+            "tblE": {},
+            "tblF": {},
+        }
+        for index in range(205):
+            remote_records["tblN"][f"rec_filler_{index}"] = {
+                "LoopX Goal ID": goal_id,
+                "LoopX Result ID": f"filler-{index}",
+                "Title": f"filler {index}",
+            }
+
+        def arg_value(args: list[str], flag: str) -> str:
+            return args[args.index(flag) + 1]
 
         def fake_runner(args: list[str], cwd: Path | None, timeout: float | None) -> dict[str, object]:
+            nonlocal upsert_attempts, created_records
             if "+record-list" in args:
+                table_id = arg_value(args, "--table-id")
+                offset = int(arg_value(args, "--offset"))
+                limit = int(arg_value(args, "--limit"))
+                records = list(remote_records[table_id].items())
+                page = records[offset : offset + limit]
                 return {
                     "returncode": 0,
-                    "stdout": json.dumps(lark_list_fixture([])),
+                    "stdout": json.dumps(
+                        lark_value_list_fixture(page, has_more=offset + len(page) < len(records))
+                    ),
                     "stderr": "",
                     "timed_out": False,
                 }
             if "+record-upsert" in args:
+                upsert_attempts += 1
                 upsert_calls.append(list(args))
+                if upsert_attempts == fail_on_upsert_attempt:
+                    return {
+                        "returncode": 1,
+                        "stdout": json.dumps({"ok": False, "error": "simulated interruption"}),
+                        "stderr": "",
+                        "timed_out": False,
+                    }
+                table_id = arg_value(args, "--table-id")
+                values = json.loads(arg_value(args, "--json"))
+                if "--record-id" in args:
+                    record_id = arg_value(args, "--record-id")
+                else:
+                    created_records += 1
+                    record_id = f"rec_new_{created_records}"
+                remote_records[table_id][record_id] = values
                 return {
                     "returncode": 0,
                     "stdout": json.dumps(
-                        {"ok": True, "data": {"record_id_list": [f"rec_new_{len(upsert_calls)}"]}}
+                        {
+                            "ok": True,
+                            "data": {
+                                "created": 1,
+                                "record": {"record_id_list": [record_id]},
+                            },
+                        }
                     ),
                     "stderr": "",
                     "timed_out": False,
                 }
             raise AssertionError(args)
 
+        interrupted = explore_results.sync_explore_results_to_lark(
+            config,
+            projection=projection,
+            config_path=config_path,
+            execute=True,
+            runner=fake_runner,
+        )
+        assert interrupted["ok"] is False, interrupted
+        assert len(upsert_calls) == 2, upsert_calls
+        stored = json.loads(config_path.read_text(encoding="utf-8"))
+        assert len(stored["result_records"]) == 1, stored
+
+        # Resume skips the delivered row and fills only the missing records.
+        upsert_calls.clear()
+        fail_on_upsert_attempt = -1
         first = explore_results.sync_explore_results_to_lark(
             config,
             projection=projection,
@@ -288,12 +365,14 @@ def check_lark_sync_contract() -> None:
             runner=fake_runner,
         )
         assert first["ok"] is True, first
-        assert len(upsert_calls) == 4, upsert_calls
+        assert len(upsert_calls) == 3, upsert_calls
         assert all("--record-id" not in call for call in upsert_calls), upsert_calls
+        assert first["written_rows"] == 3 and first["skipped_rows"] == 1, first
+        assert len([item for item in first["commands"] if "+record-list" in item["command"]]) == 4
         stored = json.loads(config_path.read_text(encoding="utf-8"))
         assert len(stored["result_records"]) == 4, stored
 
-        # Second executed sync updates the same rows by remembered record id.
+        # Second executed sync discovers all pages and performs no unchanged writes.
         upsert_calls.clear()
         second = explore_results.sync_explore_results_to_lark(
             config,
@@ -303,11 +382,25 @@ def check_lark_sync_contract() -> None:
             runner=fake_runner,
         )
         assert second["ok"] is True, second
-        assert len(upsert_calls) == 4, upsert_calls
-        assert all("--record-id" in call for call in upsert_calls), upsert_calls
+        assert not upsert_calls, upsert_calls
+        assert second["written_rows"] == 0 and second["skipped_rows"] == 4, second
         edge_record = next(item for item in second["records"] if item["table"] == "edges")
         assert edge_record["values"]["From Node Link"] == [{"id": "rec_new_2"}], edge_record
         assert edge_record["values"]["To Node Link"] == [{"id": "rec_new_1"}], edge_record
+
+        # A remote single-row drift is repaired without rewriting the full graph.
+        remote_records["tblN"]["rec_new_1"]["Title"] = "manually drifted title"
+        third = explore_results.sync_explore_results_to_lark(
+            config,
+            projection=projection,
+            config_path=config_path,
+            execute=True,
+            runner=fake_runner,
+        )
+        assert third["ok"] is True, third
+        assert len(upsert_calls) == 1, upsert_calls
+        assert "--record-id" in upsert_calls[0], upsert_calls
+        assert third["written_rows"] == 1 and third["skipped_rows"] == 3, third
 
         # Shared visibility redacts private links in row values.
         shared = explore_results.sync_explore_results_to_lark(

--- a/examples/explore-result-layer-smoke.py
+++ b/examples/explore-result-layer-smoke.py
@@ -373,6 +373,7 @@ def check_lark_sync_contract() -> None:
         assert len(stored["result_records"]) == 4, stored
 
         # Second executed sync discovers all pages and performs no unchanged writes.
+        stored_before_second = config_path.read_text(encoding="utf-8")
         upsert_calls.clear()
         second = explore_results.sync_explore_results_to_lark(
             config,
@@ -384,6 +385,7 @@ def check_lark_sync_contract() -> None:
         assert second["ok"] is True, second
         assert not upsert_calls, upsert_calls
         assert second["written_rows"] == 0 and second["skipped_rows"] == 4, second
+        assert config_path.read_text(encoding="utf-8") == stored_before_second
         edge_record = next(item for item in second["records"] if item["table"] == "edges")
         assert edge_record["values"]["From Node Link"] == [{"id": "rec_new_2"}], edge_record
         assert edge_record["values"]["To Node Link"] == [{"id": "rec_new_1"}], edge_record

--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -413,6 +413,13 @@ def _persist_lark_explore_record_map(
 ) -> None:
     if not config_path:
         return
+    existing_records = (
+        dict(local.get("result_records") or {})
+        if isinstance(local.get("result_records"), dict)
+        else {}
+    )
+    if existing_records == dict(record_map) and bool(local.get("exists")):
+        return
     board = local.get("board") if isinstance(local.get("board"), dict) else {}
     if not board:
         board = {
@@ -867,14 +874,6 @@ def sync_explore_results_to_lark(
                 _with_edge_link_values(values, record_map=record_map, goal_id=goal_id)
                 for values in rows_by_table[TABLE_EDGES]
             ]
-
-    if execute and ok:
-        _persist_lark_explore_record_map(
-            config,
-            config_path=config_path,
-            local=local,
-            record_map=record_map,
-        )
 
     return {
         "ok": ok,

--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -329,7 +329,13 @@ def _build_upsert_command(
     return args
 
 
-def _build_record_list_command(config: LarkExploreConfig, *, table_id: str) -> list[str]:
+def _build_record_list_command(
+    config: LarkExploreConfig,
+    *,
+    table_id: str,
+    goal_id: str,
+    offset: int = 0,
+) -> list[str]:
     return [
         config.cli_bin,
         "base",
@@ -340,13 +346,90 @@ def _build_record_list_command(config: LarkExploreConfig, *, table_id: str) -> l
         config.base_token,
         "--table-id",
         table_id,
+        "--filter-json",
+        _record_json_args(
+            {
+                "logic": "and",
+                "conditions": [[_GOAL_ID_FIELD, "==", goal_id]],
+            }
+        ),
         "--format",
         "json",
         "--offset",
-        "0",
+        str(offset),
         "--limit",
         "200",
     ]
+
+
+def _record_list_has_more(payload: Mapping[str, Any]) -> bool:
+    data = payload.get("data") if isinstance(payload.get("data"), Mapping) else payload
+    return bool(data.get("has_more")) if isinstance(data, Mapping) else False
+
+
+def _normalize_lark_value(value: Any) -> Any:
+    if value is None or value == "":
+        return ""
+    if isinstance(value, Mapping):
+        return {
+            str(key): _normalize_lark_value(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+    if isinstance(value, list):
+        normalized = [_normalize_lark_value(item) for item in value]
+        if len(normalized) == 1 and isinstance(normalized[0], str):
+            return normalized[0]
+        return normalized
+    return value
+
+
+def _lark_values_match(values: Mapping[str, Any], record: Mapping[str, Any]) -> bool:
+    return all(
+        _normalize_lark_value(record.get(field_name)) == _normalize_lark_value(expected)
+        for field_name, expected in values.items()
+    )
+
+
+def _skipped_sync_command() -> dict[str, Any]:
+    return {
+        "command": "",
+        "executed": False,
+        "ok": True,
+        "returncode": None,
+        "stdout": "",
+        "stderr": "",
+        "json": None,
+        "skipped": True,
+        "reason": "unchanged",
+    }
+
+
+def _persist_lark_explore_record_map(
+    config: LarkExploreConfig,
+    *,
+    config_path: Path | None,
+    local: Mapping[str, Any],
+    record_map: Mapping[str, str],
+) -> None:
+    if not config_path:
+        return
+    board = local.get("board") if isinstance(local.get("board"), dict) else {}
+    if not board:
+        board = {
+            "base_token": config.base_token,
+            "tables": dict(config.table_ids),
+            "cli_bin": config.cli_bin,
+            "identity": config.identity,
+        }
+    write_lark_explore_local_config(
+        config_path,
+        {
+            "schema_version": LARK_EXPLORE_LOCAL_CONFIG_VERSION,
+            "board": board,
+            "result_records": dict(record_map),
+            "card": local.get("card") if isinstance(local.get("card"), dict) else {},
+        },
+    )
 
 
 def setup_lark_explore_board(
@@ -655,50 +738,115 @@ def sync_explore_results_to_lark(
     )
     commands: list[dict[str, Any]] = []
     warnings: list[str] = []
+    remote_records: dict[str, dict[str, Any]] = {}
+    duplicate_remote_rows = 0
+    expected_keys = {
+        f"{goal_id}:{table_key}:{str(values.get(_RESULT_ID_FIELD) or '').strip()}"
+        for table_key in EXPLORE_TABLE_KEYS
+        for values in rows_by_table[table_key]
+    }
 
     if execute:
         for table_key in EXPLORE_TABLE_KEYS:
             if not rows_by_table[table_key]:
                 continue
-            list_result = _run_command(
-                _build_record_list_command(config, table_id=config.table_id(table_key)),
-                execute=True,
-                runner=runner,
-            )
-            commands.append(list_result)
-            if not list_result.get("ok"):
-                warnings.append(
-                    f"record-list for {table_key} failed; continuing with cached record ids"
+            offset = 0
+            while True:
+                list_result = _run_command(
+                    _build_record_list_command(
+                        config,
+                        table_id=config.table_id(table_key),
+                        goal_id=goal_id,
+                        offset=offset,
+                    ),
+                    execute=True,
+                    runner=runner,
                 )
-                continue
-            payload = list_result.get("json") if isinstance(list_result.get("json"), dict) else {}
-            for record in lark_record_rows(payload):
-                result_id = str(record.get(_RESULT_ID_FIELD) or "").strip()
-                row_goal_id = str(record.get(_GOAL_ID_FIELD) or "").strip()
-                record_id = str(record.get("_record_id") or "").strip()
-                if result_id and row_goal_id and record_id:
-                    record_map[f"{row_goal_id}:{table_key}:{result_id}"] = record_id
+                commands.append(list_result)
+                if not list_result.get("ok"):
+                    warnings.append(
+                        f"record-list for {table_key} failed; continuing with cached record ids"
+                    )
+                    break
+                payload = (
+                    list_result.get("json")
+                    if isinstance(list_result.get("json"), dict)
+                    else {}
+                )
+                page_records = lark_record_rows(payload)
+                for record in page_records:
+                    result_id = str(record.get(_RESULT_ID_FIELD) or "").strip()
+                    row_goal_id = str(record.get(_GOAL_ID_FIELD) or "").strip()
+                    record_id = str(record.get("_record_id") or "").strip()
+                    if not (result_id and row_goal_id and record_id):
+                        continue
+                    key = f"{row_goal_id}:{table_key}:{result_id}"
+                    if key not in expected_keys:
+                        continue
+                    if key in remote_records:
+                        duplicate_remote_rows += 1
+                        continue
+                    remote_records[key] = record
+                    record_map[key] = record_id
+                if not _record_list_has_more(payload):
+                    break
+                if not page_records:
+                    warnings.append(
+                        f"record-list for {table_key} reported more rows but returned an empty page"
+                    )
+                    break
+                offset += len(page_records)
+
+        if duplicate_remote_rows:
+            warnings.append(
+                f"found {duplicate_remote_rows} duplicate remote result rows; reused the first row"
+            )
+        _persist_lark_explore_record_map(
+            config,
+            config_path=config_path,
+            local=local,
+            record_map=record_map,
+        )
 
     results: list[dict[str, Any]] = []
     ok = True
+    skipped_rows = 0
+    written_rows = 0
     for table_key in EXPLORE_TABLE_KEYS:
         for values in rows_by_table[table_key]:
             result_id = str(values.get(_RESULT_ID_FIELD) or "").strip()
             key = f"{goal_id}:{table_key}:{result_id}"
-            result = _run_command(
-                _build_upsert_command(
-                    config,
-                    table_id=config.table_id(table_key),
-                    record_id=record_map.get(key),
-                    values=values,
-                ),
-                execute=execute,
-                runner=runner,
-            )
-            commands.append(result)
+            remote_record = remote_records.get(key)
+            if execute and record_map.get(key) and remote_record and _lark_values_match(
+                values, remote_record
+            ):
+                result = _skipped_sync_command()
+                skipped_rows += 1
+            else:
+                result = _run_command(
+                    _build_upsert_command(
+                        config,
+                        table_id=config.table_id(table_key),
+                        record_id=record_map.get(key),
+                        values=values,
+                    ),
+                    execute=execute,
+                    runner=runner,
+                )
+                commands.append(result)
+                if execute and result.get("ok"):
+                    written_rows += 1
             record_id = _extract_created_record_id(result.get("json")) or record_map.get(key)
             if execute and result.get("ok") and record_id:
                 record_map[key] = record_id
+                if not result.get("skipped"):
+                    remote_records[key] = {**values, "_record_id": record_id}
+                    _persist_lark_explore_record_map(
+                        config,
+                        config_path=config_path,
+                        local=local,
+                        record_map=record_map,
+                    )
             results.append(
                 {
                     "table": table_key,
@@ -720,23 +868,12 @@ def sync_explore_results_to_lark(
                 for values in rows_by_table[TABLE_EDGES]
             ]
 
-    if execute and config_path and ok:
-        board = local.get("board") if isinstance(local.get("board"), dict) else {}
-        if not board:
-            board = {
-                "base_token": config.base_token,
-                "tables": dict(config.table_ids),
-                "cli_bin": config.cli_bin,
-                "identity": config.identity,
-            }
-        write_lark_explore_local_config(
-            config_path,
-            {
-                "schema_version": LARK_EXPLORE_LOCAL_CONFIG_VERSION,
-                "board": board,
-                "result_records": record_map,
-                "card": local.get("card") if isinstance(local.get("card"), dict) else {},
-            },
+    if execute and ok:
+        _persist_lark_explore_record_map(
+            config,
+            config_path=config_path,
+            local=local,
+            record_map=record_map,
         )
 
     return {
@@ -749,6 +886,9 @@ def sync_explore_results_to_lark(
         "public_safe_redaction": public_safe,
         "projection_schema_version": projection.get("schema_version"),
         "row_counts": {table_key: len(rows_by_table[table_key]) for table_key in EXPLORE_TABLE_KEYS},
+        "written_rows": written_rows,
+        "skipped_rows": skipped_rows,
+        "duplicate_remote_rows": duplicate_remote_rows,
         "records": results,
         "commands": commands,
         "warnings": warnings,


### PR DESCRIPTION
## Summary
- discover goal-scoped Explore rows across every Feishu Base page
- skip unchanged rows and repair only remote drift
- persist created record IDs immediately so interrupted syncs resume without duplicate creation

## Validation
- `python3 examples/explore-result-layer-smoke.py`
- `python3 -m py_compile loopx/presentation/sinks/lark/explore_results.py examples/explore-result-layer-smoke.py`
- `python3 -m loopx.cli canary premerge --from-git-diff --tier standard --format json --no-progress` (17 selected checks passed, no warnings or manual holds)
- public/private boundary scan clean

## Safety
- presentation sink only; no worker, quota, lease, launch, or promotion authority changes
- no live credentials or private project evidence in code, fixtures, docs, commit metadata, or this PR