### PR TITLE
Move worker outcome projection inward

### DIFF
--- a/loopx/control_plane/runtime/run_ingest_health.py
+++ b/loopx/control_plane/runtime/run_ingest_health.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from .public_safety import public_safe_compact_text
+from .public_safety import public_safe_compact_list, public_safe_compact_text
 
 WORKER_BRIDGE_INGEST_HEALTH_SCHEMA_VERSION = "worker_bridge_ingest_health_note_v0"
 _BENCHMARK_RUN_SCHEMA_VERSION = "benchmark_run_v0"
+_MAX_LIST_ITEMS = 5
 
 
 def compact_environment_setup_failure_context(value: Any) -> dict[str, Any]:
@@ -176,3 +177,160 @@ def worker_bridge_ingest_health_note(
     if env_context:
         note["environment_setup_failure_context"] = env_context
     return note
+
+
+def compact_worker_bridge_outcome(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+
+    compact: dict[str, Any] = {}
+    for field in (
+        "schema_version",
+        "bridge_surface",
+        "runner_return_status",
+        "official_score_status",
+        "trace_publicness",
+        "next_action",
+        "score_failure_attribution",
+        "worker_submit_eligible_mismatch_reason",
+        "worker_bridge_writeback_loss_reason",
+        "worker_bridge_materialization_status",
+        "worker_bridge_materialization_blocker",
+        "worker_bridge_failure_attribution",
+        "prompt_driven_first_blocker",
+        "controller_last_decision",
+        "repeat_blocked_by",
+        "pre_worker_startup_blocker",
+    ):
+        text = public_safe_compact_text(value.get(field), limit=160)
+        if text:
+            compact[field] = text
+    for field in (
+        "worker_bridge_verified",
+        "prompt_driven_loopx_trace_observed",
+        "prompt_driven_loopx_lifecycle_observed",
+        "counter_trace_present",
+        "runner_return_completed",
+        "official_score_completed",
+        "side_effect_audit_passed",
+        "raw_paths_recorded",
+        "raw_trace_recorded",
+        "credential_values_recorded",
+        "runner_side_writeback_guaranteed",
+        "worker_submit_eligible_mismatch_observed",
+        "worker_bridge_writeback_loss_observed",
+        "loopx_controller_trace_present",
+        "loopx_controller_trace_public_safe",
+        "controller_turn_completed_observed",
+    ):
+        if isinstance(value.get(field), bool):
+            compact[field] = value[field]
+    for field in (
+        "worker_loopx_cli_call_total",
+        "loopx_prompt_driven_case_cli_call_count",
+        "required_worker_loopx_cli_call_total_min",
+        "worker_self_validation_official_score_mismatch_count",
+        "worker_validation_scope_ambiguous_official_score_failure_count",
+        "worker_bridge_connected_official_score_failure_count",
+        "worker_startup_blocker_count",
+        "worker_setup_diagnostic_file_count",
+        "worker_setup_diagnostic_schema_ok_count",
+        "worker_submit_eligible_mismatch_count",
+        "worker_bridge_writeback_loss_count",
+        "environment_setup_failure_before_worker_count",
+        "pre_worker_agent_setup_failure_count",
+        "worker_runtime_exception_before_checkpoint_count",
+        "verifier_failure_attribution_count",
+        "verifier_dependency_failure_count",
+        "controller_max_round_observed",
+        "controller_max_rounds_budget",
+        "controller_followup_prompt_count",
+    ):
+        if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
+            compact[field] = value[field]
+    round_timeout = value.get("controller_round_timeout_sec")
+    if isinstance(round_timeout, (int, float)) and not isinstance(round_timeout, bool):
+        compact["controller_round_timeout_sec"] = round_timeout
+    score = value.get("official_score_value")
+    if isinstance(score, (int, float)) and not isinstance(score, bool):
+        compact["official_score_value"] = score
+
+    policy = (
+        value.get("wall_time_policy")
+        if isinstance(value.get("wall_time_policy"), dict)
+        else {}
+    )
+    if policy:
+        compact_policy: dict[str, Any] = {}
+        for field in ("schema_version", "kind", "timeout_tier", "interrupt_reason"):
+            text = public_safe_compact_text(policy.get(field), limit=140)
+            if text:
+                compact_policy[field] = text
+        for field in (
+            "interrupted",
+            "changes_official_benchmark_timeout",
+            "changes_official_task_resources",
+            "official_timeout_comparable",
+            "leaderboard_claim_allowed",
+            "observed_true_long_task_bar_met",
+            "expected_true_long_task_bar_met",
+            "true_long_task_bar_met",
+            "expected_hours_scale_bar_met",
+        ):
+            if isinstance(policy.get(field), bool):
+                compact_policy[field] = policy[field]
+        for field in (
+            "wall_time_seconds",
+            "wall_time_limit_seconds",
+            "true_long_task_bar_seconds",
+            "preferred_hours_scale_bar_seconds",
+        ):
+            number = policy.get(field)
+            if isinstance(number, (int, float)) and not isinstance(number, bool):
+                compact_policy[field] = number
+        if compact_policy:
+            compact["wall_time_policy"] = compact_policy
+
+    labels = public_safe_compact_list(
+        value.get("failure_attribution_labels"),
+        limit=_MAX_LIST_ITEMS,
+    )
+    if labels:
+        compact["failure_attribution_labels"] = labels
+
+    boundary = (
+        value.get("claim_boundary")
+        if isinstance(value.get("claim_boundary"), dict)
+        else {}
+    )
+    if boundary:
+        compact_boundary: dict[str, Any] = {}
+        allowed = public_safe_compact_text(
+            boundary.get("public_claim_allowed"), limit=180
+        )
+        if allowed:
+            compact_boundary["public_claim_allowed"] = allowed
+        for field in (
+            "bridge_connectivity_claim_allowed",
+            "case_success_claim_allowed",
+            "official_score_claim_allowed",
+            "leaderboard_claim_allowed",
+        ):
+            if isinstance(boundary.get(field), bool):
+                compact_boundary[field] = boundary[field]
+        forbidden = public_safe_compact_list(
+            boundary.get("forbidden_claims"),
+            limit=_MAX_LIST_ITEMS,
+        )
+        if forbidden:
+            compact_boundary["forbidden_claims"] = forbidden
+        if compact_boundary:
+            compact["claim_boundary"] = compact_boundary
+
+    env_context = compact_environment_setup_failure_context(
+        value.get("environment_setup_failure_context")
+    )
+    if env_context:
+        compact["environment_setup_failure_context"] = env_context
+
+    return compact

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -193,6 +193,7 @@ from .control_plane.runtime.public_safety import (
 )
 from .control_plane.runtime.run_ingest_health import (
     compact_environment_setup_failure_context,
+    compact_worker_bridge_outcome,
     worker_bridge_ingest_health_note,
 )
 from .control_plane.runtime.time import parse_timestamp
@@ -3554,153 +3555,6 @@ def _compact_benchmark_attempt_accounting(value: Any) -> dict[str, Any]:
     return compact
 
 
-def _compact_worker_bridge_outcome(value: Any) -> dict[str, Any]:
-    if not isinstance(value, dict):
-        return {}
-
-    compact: dict[str, Any] = {}
-    for field in (
-        "schema_version",
-        "bridge_surface",
-        "runner_return_status",
-        "official_score_status",
-        "trace_publicness",
-        "next_action",
-        "score_failure_attribution",
-        "worker_submit_eligible_mismatch_reason",
-        "worker_bridge_writeback_loss_reason",
-        "worker_bridge_materialization_status",
-        "worker_bridge_materialization_blocker",
-        "worker_bridge_failure_attribution",
-        "prompt_driven_first_blocker",
-        "controller_last_decision",
-        "repeat_blocked_by",
-        "pre_worker_startup_blocker",
-    ):
-        text = public_safe_compact_text(value.get(field), limit=160)
-        if text:
-            compact[field] = text
-    for field in (
-        "worker_bridge_verified",
-        "prompt_driven_loopx_trace_observed",
-        "prompt_driven_loopx_lifecycle_observed",
-        "counter_trace_present",
-        "runner_return_completed",
-        "official_score_completed",
-        "side_effect_audit_passed",
-        "raw_paths_recorded",
-        "raw_trace_recorded",
-        "credential_values_recorded",
-        "runner_side_writeback_guaranteed",
-        "worker_submit_eligible_mismatch_observed",
-        "worker_bridge_writeback_loss_observed",
-        "loopx_controller_trace_present",
-        "loopx_controller_trace_public_safe",
-        "controller_turn_completed_observed",
-    ):
-        if isinstance(value.get(field), bool):
-            compact[field] = value[field]
-    for field in (
-        "worker_loopx_cli_call_total",
-        "loopx_prompt_driven_case_cli_call_count",
-        "required_worker_loopx_cli_call_total_min",
-        "worker_self_validation_official_score_mismatch_count",
-        "worker_validation_scope_ambiguous_official_score_failure_count",
-        "worker_bridge_connected_official_score_failure_count",
-        "worker_startup_blocker_count",
-        "worker_setup_diagnostic_file_count",
-        "worker_setup_diagnostic_schema_ok_count",
-        "worker_submit_eligible_mismatch_count",
-        "worker_bridge_writeback_loss_count",
-        "environment_setup_failure_before_worker_count",
-        "pre_worker_agent_setup_failure_count",
-        "worker_runtime_exception_before_checkpoint_count",
-        "verifier_failure_attribution_count",
-        "verifier_dependency_failure_count",
-        "controller_max_round_observed",
-        "controller_max_rounds_budget",
-        "controller_followup_prompt_count",
-    ):
-        if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
-            compact[field] = value[field]
-    round_timeout = value.get("controller_round_timeout_sec")
-    if isinstance(round_timeout, (int, float)) and not isinstance(round_timeout, bool):
-        compact["controller_round_timeout_sec"] = round_timeout
-    score = value.get("official_score_value")
-    if isinstance(score, (int, float)) and not isinstance(score, bool):
-        compact["official_score_value"] = score
-
-    policy = value.get("wall_time_policy") if isinstance(value.get("wall_time_policy"), dict) else {}
-    if policy:
-        compact_policy: dict[str, Any] = {}
-        for field in ("schema_version", "kind", "timeout_tier", "interrupt_reason"):
-            text = public_safe_compact_text(policy.get(field), limit=140)
-            if text:
-                compact_policy[field] = text
-        for field in (
-            "interrupted",
-            "changes_official_benchmark_timeout",
-            "changes_official_task_resources",
-            "official_timeout_comparable",
-            "leaderboard_claim_allowed",
-            "observed_true_long_task_bar_met",
-            "expected_true_long_task_bar_met",
-            "true_long_task_bar_met",
-            "expected_hours_scale_bar_met",
-        ):
-            if isinstance(policy.get(field), bool):
-                compact_policy[field] = policy[field]
-        for field in (
-            "wall_time_seconds",
-            "wall_time_limit_seconds",
-            "true_long_task_bar_seconds",
-            "preferred_hours_scale_bar_seconds",
-        ):
-            number = policy.get(field)
-            if isinstance(number, (int, float)) and not isinstance(number, bool):
-                compact_policy[field] = number
-        if compact_policy:
-            compact["wall_time_policy"] = compact_policy
-
-    labels = public_safe_compact_list(
-        value.get("failure_attribution_labels"),
-        limit=MAX_BENCHMARK_RUN_LIST_ITEMS,
-    )
-    if labels:
-        compact["failure_attribution_labels"] = labels
-
-    boundary = value.get("claim_boundary") if isinstance(value.get("claim_boundary"), dict) else {}
-    if boundary:
-        compact_boundary: dict[str, Any] = {}
-        allowed = public_safe_compact_text(boundary.get("public_claim_allowed"), limit=180)
-        if allowed:
-            compact_boundary["public_claim_allowed"] = allowed
-        for field in (
-            "bridge_connectivity_claim_allowed",
-            "case_success_claim_allowed",
-            "official_score_claim_allowed",
-            "leaderboard_claim_allowed",
-        ):
-            if isinstance(boundary.get(field), bool):
-                compact_boundary[field] = boundary[field]
-        forbidden = public_safe_compact_list(
-            boundary.get("forbidden_claims"),
-            limit=MAX_BENCHMARK_RUN_LIST_ITEMS,
-        )
-        if forbidden:
-            compact_boundary["forbidden_claims"] = forbidden
-        if compact_boundary:
-            compact["claim_boundary"] = compact_boundary
-
-    env_context = compact_environment_setup_failure_context(
-        value.get("environment_setup_failure_context")
-    )
-    if env_context:
-        compact["environment_setup_failure_context"] = env_context
-
-    return compact
-
-
 def _compact_benchmark_episode_policy(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
         return {}
@@ -4172,7 +4026,7 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
     if env_context:
         compact["environment_setup_failure_context"] = env_context
 
-    worker_bridge_outcome = _compact_worker_bridge_outcome(
+    worker_bridge_outcome = compact_worker_bridge_outcome(
         source.get("worker_bridge_outcome")
     )
     if worker_bridge_outcome:

--- a/tests/control_plane/test_run_ingest_health.py
+++ b/tests/control_plane/test_run_ingest_health.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from loopx.control_plane.runtime.run_ingest_health import (
+    compact_worker_bridge_outcome,
+    worker_bridge_ingest_health_note,
+)
+
+
+def test_compact_worker_bridge_outcome_preserves_public_contract() -> None:
+    compact = compact_worker_bridge_outcome(
+        {
+            "schema_version": "worker_bridge_outcome_v0",
+            "bridge_surface": "command_file_bridge",
+            "runner_return_status": "completed",
+            "official_score_status": "completed",
+            "worker_bridge_verified": True,
+            "worker_loopx_cli_call_total": 3,
+            "official_score_value": 1.0,
+            "failure_attribution_labels": ["a", "b", "c", "d", "e", "f"],
+            "wall_time_policy": {
+                "schema_version": "wall_time_policy_v0",
+                "kind": "bounded",
+                "interrupted": False,
+                "wall_time_seconds": 42.5,
+                "private_detail": "drop",
+            },
+            "claim_boundary": {
+                "public_claim_allowed": "bridge connectivity only",
+                "bridge_connectivity_claim_allowed": True,
+                "forbidden_claims": ["one", "two", "three", "four", "five", "six"],
+            },
+            "environment_setup_failure_context": {
+                "schema_version": "environment_setup_failure_context_v0",
+                "surface": "worker_startup",
+                "environment_setup_present": True,
+                "environment_setup_duration_seconds": 12.0,
+                "private_detail": "drop",
+            },
+            "private_detail": "drop",
+        }
+    )
+
+    assert compact["schema_version"] == "worker_bridge_outcome_v0"
+    assert compact["worker_bridge_verified"] is True
+    assert compact["worker_loopx_cli_call_total"] == 3
+    assert compact["official_score_value"] == 1.0
+    assert compact["failure_attribution_labels"] == ["a", "b", "c", "d", "e"]
+    assert compact["wall_time_policy"] == {
+        "schema_version": "wall_time_policy_v0",
+        "kind": "bounded",
+        "interrupted": False,
+        "wall_time_seconds": 42.5,
+    }
+    assert compact["claim_boundary"]["forbidden_claims"] == [
+        "one",
+        "two",
+        "three",
+        "four",
+        "five",
+    ]
+    assert compact["environment_setup_failure_context"] == {
+        "schema_version": "environment_setup_failure_context_v0",
+        "surface": "worker_startup",
+        "environment_setup_present": True,
+        "environment_setup_duration_seconds": 12.0,
+    }
+    assert "private_detail" not in compact
+
+
+def test_worker_bridge_health_uses_compact_outcome() -> None:
+    outcome = compact_worker_bridge_outcome(
+        {
+            "worker_bridge_verified": True,
+            "runner_return_status": "completed",
+            "official_score_status": "completed",
+            "worker_loopx_cli_call_total": 2,
+            "required_worker_loopx_cli_call_total_min": 1,
+        }
+    )
+
+    health = worker_bridge_ingest_health_note(
+        {
+            "schema_version": "benchmark_run_v0",
+            "worker_bridge_outcome": outcome,
+            "validation": {"all_passed": True},
+        }
+    )
+
+    assert health is not None
+    assert health["health_state"] == "official_score_ingested"
+    assert health["evidence_layer"] == "official_sample_score"
+    assert health["validation_all_passed"] is True


### PR DESCRIPTION
## Summary
- move the adjacent `worker_bridge_outcome` public-safe field projection from `status.py` into the established `control_plane/runtime/run_ingest_health.py` bounded context
- preserve `compact_benchmark_run` output and all worker-ingest health behavior
- add a fast pytest contract for field allowlisting, nested wall-time/claim-boundary projection, environment context, and health-state derivation

This removes another 149 implementation lines from the status facade without adding an outward dependency.

## Validation
- Ruff CI scope passed
- mypy passed
- pytest: 85 passed, 2 skipped; coverage increased to 19.98%
- architecture boundary 2/2 and focused run-ingest tests passed
- benchmark status projection and worker-ingest smokes passed
- premerge canary: 16/16 passed, no manual holds, `self_merge_allowed=true`
- explicit staged public boundary scan: 3 files, 0 warnings/errors

## Risk
Low. The compactor body is mechanically moved, field limits and nested projections are unchanged, and direct contract coverage now catches drift faster than the large end-to-end smokes alone.