### PR TITLE
Allow monitored as-needed vision waits

### DIFF
--- a/docs/reference/protocols/goal-vision-replan-contract-v0.md
+++ b/docs/reference/protocols/goal-vision-replan-contract-v0.md
@@ -69,8 +69,12 @@ loopx refresh-state \
 
 `advancement_policy` is a small machine-readable frontier rule, not a domain
 label. It defaults to `as_needed`, which preserves bounded external waits: an
-implicit open-acceptance gap may remain quiet when a monitor lane has recorded
-an exact `watch_lane_continuation` ACK. Use `repeat_until_closed` for campaigns,
+open acceptance gap, whether implicit or paired with an explicit replan
+trigger, may remain quiet when a continuous monitor lane has recorded an exact
+`watch_lane_continuation` ACK. The ACK does not prove acceptance or close the
+vision; it records that current monitors cover the next decision checkpoint and
+keeps the gap visible for audit. Without that ACK or monitor coverage, the same
+gap still requires bounded replan. Use `repeat_until_closed` for campaigns,
 iterative research, sweepers, and other visions whose open acceptance requires
 another advancement iteration whenever the runnable advancement frontier is
 empty. In that mode, monitor successors and a watch ACK remain useful evidence,

--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -1367,7 +1367,7 @@ def assert_projected_replan_ack_is_agent_scoped() -> None:
     assert scoped_guard["goal_frontier_projection"]["replan_required"] is False, scoped_guard
 
 
-def assert_agent_vision_gap_beats_replan_ack() -> None:
+def assert_explicit_as_needed_vision_gap_uses_watch_lane_continuation_ack() -> None:
     guard = build_quota_should_run(
         status_payload(
             [monitor_item()],
@@ -1394,12 +1394,14 @@ def assert_agent_vision_gap_beats_replan_ack() -> None:
         goal_id=GOAL_ID,
         agent_id=SIDE_AGENT,
     )
-    assert guard["decision"] == "autonomous_replan_required", guard
-    assert guard["effective_action"] == "autonomous_replan_required", guard
+    assert guard["decision"] == "skip", guard
+    assert guard["effective_action"] == "monitor_quiet_skip", guard
     gaps = guard["goal_frontier_projection"]["acceptance_gaps"]
     assert len(gaps) == 1, guard
     assert gaps[0]["kind"] == "vision_acceptance_gap", guard
-    assert guard["goal_frontier_projection"]["replan_required"] is True, guard
+    assert gaps[0]["replan_trigger_source"] == "explicit_vision_trigger", guard
+    assert guard["goal_frontier_projection"]["replan_required"] is False, guard
+    assert guard.get("autonomous_replan_obligation") is None, guard
     assert guard["vision_continuation_audit"]["required"] is True, guard
     assert "autonomous_replan_ack_alone" in guard["vision_continuation_audit"]["not_satisfied_by"], guard
 
@@ -1449,7 +1451,7 @@ def main() -> None:
     assert_agent_ack_survives_other_agent_run_and_monitor_poll()
     assert_non_frontier_replan_ack_does_not_clear_monitor_replan()
     assert_projected_replan_ack_is_agent_scoped()
-    assert_agent_vision_gap_beats_replan_ack()
+    assert_explicit_as_needed_vision_gap_uses_watch_lane_continuation_ack()
     assert_blocking_handoff_gate_beats_derived_monitor_replan()
     print("quota-replan-decision-plane-smoke ok")
 

--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -1007,14 +1007,8 @@ def derive_goal_frontier_replan_obligation_from_summaries(
     compact_acceptance_gaps = [
         item for item in (acceptance_gaps or []) if isinstance(item, dict)
     ]
-    explicit_acceptance_gaps = [
-        gap
-        for gap in compact_acceptance_gaps
-        if gap.get("replan_trigger_source") != "implicit_open_acceptance"
-    ]
-    implicit_acceptance_allows_watch_lane_continuation = bool(
+    acceptance_allows_watch_lane_continuation = bool(
         compact_acceptance_gaps
-        and not explicit_acceptance_gaps
         and not any(
             goal_vision_repeats_advancement_until_closed(
                 gap.get("advancement_policy")
@@ -1089,7 +1083,7 @@ def derive_goal_frontier_replan_obligation_from_summaries(
         compact_acceptance_gaps
         and agent_counts.get("advancement", 0) == 0
         and total_frontier_advancement == 0
-        and not implicit_acceptance_allows_watch_lane_continuation
+        and not acceptance_allows_watch_lane_continuation
     ):
         return build_autonomous_replan_obligation_payload(
             schema_version=AUTONOMOUS_REPLAN_OBLIGATION_SCHEMA_VERSION,


### PR DESCRIPTION
## Summary
- let explicit and implicit as-needed acceptance gaps remain monitor-covered after an exact watch-lane continuation ACK
- keep repeat-until-closed visions and unacknowledged gaps on the autonomous replan path
- document that watch coverage defers replan without proving acceptance or closing the vision

## Validation
- focused quota replan, heartbeat quota, monitor scheduler, and goal vision smokes
- standard premerge canary: 17 selected checks plus 4 direct checks
- public/private boundary scan clean

No production actions or external workloads are triggered by this change.