### PR TITLE
Move benchmark event timeline projection inward

### DIFF
--- a/loopx/control_plane/runtime/benchmark_event_timeline.py
+++ b/loopx/control_plane/runtime/benchmark_event_timeline.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .public_safety import public_safe_compact_list, public_safe_compact_text
+
+
+MAX_BENCHMARK_EVENT_LABELS = 5
+MAX_BENCHMARK_EVENTS = 12
+
+
+def compact_benchmark_case_event_timeline(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+
+    events: list[dict[str, Any]] = []
+    for raw_event in value.get("events", []):
+        if not isinstance(raw_event, dict):
+            continue
+        event: dict[str, Any] = {}
+        for field in ("phase", "event", "status"):
+            text = public_safe_compact_text(raw_event.get(field), limit=120)
+            if text:
+                event[field] = text
+        if not {"phase", "event", "status"} <= set(event):
+            continue
+        for field in (
+            "execution_style",
+            "agent_operation_trace_status",
+            "host_local_acp_bridge_progress_status",
+            "host_local_acp_bridge_progress_signal_source",
+            "last_decision",
+            "recovery_stage",
+            "recovery_exception_type",
+            "runner_failure_class",
+            "official_score_status",
+            "score_failure_attribution",
+        ):
+            text = public_safe_compact_text(raw_event.get(field), limit=140)
+            if text:
+                event[field] = text
+        for field in (
+            "required",
+            "initialized_before_agent",
+            "consumed_by_solver",
+            "official_score_passed",
+            "selected_todo_completed_observed",
+            "quota_spend_missing_after_repeated_complete",
+        ):
+            if isinstance(raw_event.get(field), bool):
+                event[field] = raw_event[field]
+        for field in (
+            "index",
+            "checkpoint_count",
+            "state_read_count",
+            "state_write_count",
+            "solver_operation_count",
+            "solver_probe_ready_count",
+            "trajectory_event_count",
+            "trajectory_round_count",
+            "trajectory_tool_call_count",
+            "acp_protocol_tool_call_count",
+            "agent_bridge_request_count",
+            "agent_bridge_task_facing_operation_count",
+            "action_decision_count",
+            "initial_prompt_count",
+            "followup_prompt_count",
+            "stop_decision_count",
+            "max_rounds_budget",
+            "host_local_idle_no_task_output_progress_streak",
+            "host_local_idle_no_task_output_progress_streak_threshold",
+            "final_round",
+            "recovery_delta_events",
+            "recovery_delta_tool_calls",
+            "benchflow_agent_timeout_effective_sec",
+            "local_codex_exec_timeout_sec",
+            "todo_closeout_count",
+            "refresh_state_count",
+            "quota_spend_slot_count",
+            "selected_todo_complete_count",
+            "selected_todo_duplicate_complete_count",
+            "agent_todo_complete_unique_todo_count",
+            "non_selected_todo_complete_count",
+            "todo_complete_without_todo_id_count",
+        ):
+            raw = raw_event.get(field)
+            if isinstance(raw, int) and not isinstance(raw, bool):
+                event[field] = max(0, raw)
+        for field in ("best_round_reward", "official_score_value"):
+            raw = raw_event.get(field)
+            if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+                event[field] = raw
+        labels = public_safe_compact_list(
+            raw_event.get("failure_attribution_labels"),
+            limit=MAX_BENCHMARK_EVENT_LABELS,
+        )
+        if labels:
+            event["failure_attribution_labels"] = labels
+        events.append(event)
+
+    if not events:
+        return {}
+
+    return {
+        "schema_version": "skillsbench_case_event_timeline_v0",
+        "source": "compact_public_signals",
+        "raw_material_recorded": False,
+        "event_count": len(events),
+        "events": events[:MAX_BENCHMARK_EVENTS],
+    }

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -185,6 +185,9 @@ from .control_plane.runtime.benchmark_projection import (
     build_benchmark_solution_quality_signals,
     compact_benchmark_run_core as _compact_benchmark_run_core_read_model,
 )
+from .control_plane.runtime.benchmark_event_timeline import (
+    compact_benchmark_case_event_timeline,
+)
 from .control_plane.runtime.public_safety import (
     compact_loopx_command_records as _compact_loopx_command_records,
     compact_numeric_map as _compact_numeric_map,
@@ -574,108 +577,6 @@ AUTONOMOUS_RUN_HISTORY_STALL_PATTERN = re.compile(
 )
 
 
-def _compact_benchmark_case_event_timeline(value: Any) -> dict[str, Any]:
-    if not isinstance(value, dict):
-        return {}
-
-    events: list[dict[str, Any]] = []
-    for raw_event in value.get("events", []):
-        if not isinstance(raw_event, dict):
-            continue
-        event: dict[str, Any] = {}
-        for field in ("phase", "event", "status"):
-            text = public_safe_compact_text(raw_event.get(field), limit=120)
-            if text:
-                event[field] = text
-        if not {"phase", "event", "status"} <= set(event):
-            continue
-        for field in (
-            "execution_style",
-            "agent_operation_trace_status",
-            "host_local_acp_bridge_progress_status",
-            "host_local_acp_bridge_progress_signal_source",
-            "last_decision",
-            "recovery_stage",
-            "recovery_exception_type",
-            "runner_failure_class",
-            "official_score_status",
-            "score_failure_attribution",
-        ):
-            text = public_safe_compact_text(raw_event.get(field), limit=140)
-            if text:
-                event[field] = text
-        for field in (
-            "required",
-            "initialized_before_agent",
-            "consumed_by_solver",
-            "official_score_passed",
-            "selected_todo_completed_observed",
-            "quota_spend_missing_after_repeated_complete",
-        ):
-            if isinstance(raw_event.get(field), bool):
-                event[field] = raw_event[field]
-        for field in (
-            "index",
-            "checkpoint_count",
-            "state_read_count",
-            "state_write_count",
-            "solver_operation_count",
-            "solver_probe_ready_count",
-            "trajectory_event_count",
-            "trajectory_round_count",
-            "trajectory_tool_call_count",
-            "acp_protocol_tool_call_count",
-            "agent_bridge_request_count",
-            "agent_bridge_task_facing_operation_count",
-            "action_decision_count",
-            "initial_prompt_count",
-            "followup_prompt_count",
-            "stop_decision_count",
-            "max_rounds_budget",
-            "host_local_idle_no_task_output_progress_streak",
-            "host_local_idle_no_task_output_progress_streak_threshold",
-            "final_round",
-            "recovery_delta_events",
-            "recovery_delta_tool_calls",
-            "benchflow_agent_timeout_effective_sec",
-            "local_codex_exec_timeout_sec",
-            "todo_closeout_count",
-            "refresh_state_count",
-            "quota_spend_slot_count",
-            "selected_todo_complete_count",
-            "selected_todo_duplicate_complete_count",
-            "agent_todo_complete_unique_todo_count",
-            "non_selected_todo_complete_count",
-            "todo_complete_without_todo_id_count",
-        ):
-            raw = raw_event.get(field)
-            if isinstance(raw, int) and not isinstance(raw, bool):
-                event[field] = max(0, raw)
-        for field in ("best_round_reward", "official_score_value"):
-            raw = raw_event.get(field)
-            if isinstance(raw, (int, float)) and not isinstance(raw, bool):
-                event[field] = raw
-        labels = public_safe_compact_list(
-            raw_event.get("failure_attribution_labels"),
-            limit=MAX_BENCHMARK_RUN_LIST_ITEMS,
-        )
-        if labels:
-            event["failure_attribution_labels"] = labels
-        events.append(event)
-
-    if not events:
-        return {}
-
-    compact: dict[str, Any] = {
-        "schema_version": "skillsbench_case_event_timeline_v0",
-        "source": "compact_public_signals",
-        "raw_material_recorded": False,
-        "event_count": len(events),
-        "events": events[:12],
-    }
-    return compact
-
-
 def _compact_goal_start_todo_snapshot(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
         return {}
@@ -836,7 +737,7 @@ def build_skillsbench_post_run_debug_gate(
     if not isinstance(run, dict):
         return {}
     benchmark_id = public_safe_compact_text(run.get("benchmark_id"), limit=120) or ""
-    timeline = _compact_benchmark_case_event_timeline(run.get("case_event_timeline"))
+    timeline = compact_benchmark_case_event_timeline(run.get("case_event_timeline"))
     if not benchmark_id.startswith("skillsbench"):
         return {}
 
@@ -3976,7 +3877,7 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
     if app_server_goal_round_semantics:
         compact["app_server_goal_round_semantics"] = app_server_goal_round_semantics
 
-    case_event_timeline = _compact_benchmark_case_event_timeline(
+    case_event_timeline = compact_benchmark_case_event_timeline(
         source.get("case_event_timeline")
     )
     if case_event_timeline:

--- a/tests/control_plane/test_benchmark_event_timeline.py
+++ b/tests/control_plane/test_benchmark_event_timeline.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from loopx.control_plane.runtime.benchmark_event_timeline import (
+    compact_benchmark_case_event_timeline,
+)
+
+
+def test_compact_benchmark_event_timeline_preserves_public_contract() -> None:
+    compact = compact_benchmark_case_event_timeline(
+        {
+            "events": [
+                {
+                    "phase": "agent",
+                    "event": "task_facing_activity",
+                    "status": "observed",
+                    "required": True,
+                    "checkpoint_count": -3,
+                    "official_score_value": 0.5,
+                    "failure_attribution_labels": ["a", "b", "c", "d", "e", "f"],
+                    "private_detail": "drop",
+                },
+                {"phase": "missing-status", "event": "ignored"},
+            ]
+        }
+    )
+
+    assert compact == {
+        "schema_version": "skillsbench_case_event_timeline_v0",
+        "source": "compact_public_signals",
+        "raw_material_recorded": False,
+        "event_count": 1,
+        "events": [
+            {
+                "phase": "agent",
+                "event": "task_facing_activity",
+                "status": "observed",
+                "required": True,
+                "checkpoint_count": 0,
+                "official_score_value": 0.5,
+                "failure_attribution_labels": ["a", "b", "c", "d", "e"],
+            }
+        ],
+    }
+
+
+def test_compact_benchmark_event_timeline_caps_visible_events() -> None:
+    compact = compact_benchmark_case_event_timeline(
+        {
+            "events": [
+                {"phase": "agent", "event": f"event-{index}", "status": "observed"}
+                for index in range(14)
+            ]
+        }
+    )
+
+    assert compact["event_count"] == 14
+    assert len(compact["events"]) == 12
+    assert compact["events"][-1]["event"] == "event-11"


### PR DESCRIPTION
## Summary
- move the public-safe benchmark event timeline compactor from the status facade into `control_plane/runtime`
- preserve the existing schema, field allowlist, count normalization, label limits, and event cap
- add direct fast tests while retaining status and SkillsBench end-to-end smokes

## Validation
- `pytest`: 87 passed, 2 skipped; total coverage 20.03%
- focused pytest: 3 passed
- Mypy: passed
- focused benchmark/status smokes: passed
- public-boundary scan: 0 errors, 0 warnings
- `loopx canary premerge --from-git-diff`: 16/16 passed, no manual holds

## Risk
Behavior-preserving read-model move only. SkillsBench post-run composition and benchmark scoring/runner semantics remain unchanged.