### PR TITLE
Prioritize ready deferred successors by todo priority

### DIFF
--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -498,7 +498,10 @@ rewrite either form automatically.
 Deferred successors may carry `resume_when`, `resume_condition`, and
 `resume_ready`; `resume_ready=true` means the deferred item should be considered
 for a successor replan before any agent-scoped no-candidate wait, not that
-normal delivery may skip the todo lifecycle.
+normal delivery may skip the todo lifecycle. A ready deferred successor also
+preempts a strictly lower-priority open advancement todo for this lifecycle
+replan. It does not preempt an equal-priority open todo, and it never enters the
+normal executable backlog until a lifecycle command reopens it.
 The `todo_id` is first-class when written by the CLI.
 `claimed_by` values are normalized public-safe agent ids and should correspond to
 `coordination.registered_agents`. Legacy Markdown without metadata still gets a

--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -358,6 +358,16 @@ ordinary delivery work. Only when no ready current-agent/unclaimed deferred
 resume exists should agent-scoped quota fall through to `agent_scope_wait`,
 `reassignment_required`, or `scope_exhausted`.
 
+Priority remains authoritative across the resume boundary. When a ready
+current-agent or unclaimed deferred successor has strictly higher priority than
+the selected open advancement todo, quota also returns
+`successor_replan_required` before lower-priority delivery. The deferred item
+does not become executable in place: `selected_todo` points to the deferred
+successor so the worker can reopen, supersede, or close it explicitly, while
+`goal_frontier_projection.deferred_successors.top_ready_todo_id` reports the
+same lifecycle target. An equal-priority open todo remains executable, avoiding
+unnecessary lifecycle churn within a priority bucket.
+
 Open todos with `resume_when` use the same readiness signal before they enter
 ordinary execution lanes. Until `resume_ready=true`, quota must not include the
 todo in `capability_gate.runnable_candidates` or `agent_lane_next_action`; it

--- a/examples/control_plane/quota-resume-gated-open-todo-smoke.py
+++ b/examples/control_plane/quota-resume-gated-open-todo-smoke.py
@@ -26,6 +26,7 @@ GATED_TODO_ID = "todo_projection_wording"
 FALLBACK_TODO_ID = "todo_catalog_canary"
 ARCHIVED_DONE_TODO_ID = "todo_archived_pr_merge"
 ARCHIVE_GATED_MONITOR_ID = "todo_archive_gated_monitor"
+READY_DEFERRED_ID = "todo_ready_deferred_p0"
 GATED_ACTION = "[P0] Review refreshed projection wording."
 FALLBACK_ACTION = "[P1] Continue catalog-driven product canary coverage."
 ARCHIVE_MONITOR_ACTION = "[P1] Monitor product refactor/catalog canary continuation."
@@ -136,6 +137,66 @@ def assert_ready_open_resume_todo_can_run() -> None:
     assert quota_payload["recommended_action"] == GATED_ACTION, quota_payload
 
 
+def assert_ready_deferred_p0_preempts_open_p1_for_successor_replan() -> None:
+    deferred_action = "[P0] Resume the validated release successor."
+    agent_todos = quota_todo_summary(
+        [
+            quota_todo_item(
+                todo_id=BLOCKING_TODO_ID,
+                index=1,
+                text="[P0] Complete the release prerequisite.",
+                status="done",
+                claimed_by=PRIMARY_AGENT,
+            ),
+            quota_todo_item(
+                todo_id=READY_DEFERRED_ID,
+                index=2,
+                text=deferred_action,
+                status="deferred",
+                claimed_by=AGENT_ID,
+                resume_when=f"todo_done:{BLOCKING_TODO_ID}",
+            ),
+            quota_todo_item(
+                todo_id=FALLBACK_TODO_ID,
+                index=3,
+                priority="P1",
+                text=FALLBACK_ACTION,
+                claimed_by=AGENT_ID,
+                required_capabilities=["shell"],
+            ),
+        ],
+        role="agent",
+    )
+    quota_payload = build_quota_should_run(
+        status_payload(agent_todos, next_action=FALLBACK_ACTION),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+    assert quota_payload["decision"] == "successor_replan_required", quota_payload
+    assert quota_payload["normal_delivery_allowed"] is False, quota_payload
+    assert quota_payload.get("agent_lane_next_action") is None, quota_payload
+    frontier = quota_payload["agent_scope_frontier"]
+    assert frontier["priority_preemption"] is True, frontier
+    assert frontier["deferred_resume_candidates"][0]["todo_id"] == READY_DEFERRED_ID, frontier
+    assert quota_payload["selected_todo"]["todo_id"] == READY_DEFERRED_ID, quota_payload
+    assert quota_payload["selected_todo"]["source"] == (
+        "agent_scope_frontier.deferred_resume_candidates"
+    ), quota_payload
+    assert quota_payload["goal_frontier_projection"]["deferred_successors"][
+        "top_ready_todo_id"
+    ] == READY_DEFERRED_ID, quota_payload
+
+    for item in agent_todos["deferred_items"]:
+        item["priority"] = "P1"
+    equal_priority = build_quota_should_run(
+        status_payload(agent_todos, next_action=FALLBACK_ACTION),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+    assert equal_priority["decision"] == "run", equal_priority
+    assert equal_priority["selected_todo"]["todo_id"] == FALLBACK_TODO_ID, equal_priority
+
+
 def assert_archived_done_resume_target_wakes_claimed_monitor() -> None:
     fields = parse_active_state_todos(
         "# Active Goal State\n\n"
@@ -195,6 +256,7 @@ def assert_archived_done_resume_target_wakes_claimed_monitor() -> None:
 def main() -> int:
     assert_not_ready_open_resume_todo_is_not_executable()
     assert_ready_open_resume_todo_can_run()
+    assert_ready_deferred_p0_preempts_open_p1_for_successor_replan()
     assert_archived_done_resume_target_wakes_claimed_monitor()
     print("quota-resume-gated-open-todo-smoke ok")
     return 0

--- a/loopx/control_plane/agents/agent_scope.py
+++ b/loopx/control_plane/agents/agent_scope.py
@@ -941,9 +941,58 @@ def _agent_scope_no_candidate_frontier(
     if not agent_id or not isinstance(agent_todo_summary, dict):
         return None
     agent_label = "agent"
-    if isinstance(agent_lane_next_action, dict):
-        return None
     if work_lane_contract_is_due_monitor_attempt(work_lane_contract):
+        return None
+    if isinstance(agent_lane_next_action, dict):
+        deferred_resume_candidates = _agent_scope_deferred_resume_candidates(
+            agent_todo_summary,
+            agent_id=agent_id,
+        )
+        if deferred_resume_candidates:
+            first_candidate = deferred_resume_candidates[0]
+            if _todo_projection_sort_key(first_candidate)[0] < _todo_projection_sort_key(
+                agent_lane_next_action
+            )[0]:
+                candidate_todo_id = (
+                    str(first_candidate.get("todo_id") or "").strip() or "<todo_id>"
+                )
+                selected_todo_id = (
+                    str(agent_lane_next_action.get("todo_id") or "").strip()
+                    or "<open_todo_id>"
+                )
+                return build_agent_scope_frontier_payload(
+                    agent_id=agent_id,
+                    action=AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED,
+                    quiet_noop_allowed=False,
+                    spend_policy=(
+                        "spend once after validated priority successor replan/todo writeback"
+                    ),
+                    reason=(
+                        f"ready deferred successor {candidate_todo_id} has higher priority "
+                        f"than selected open advancement {selected_todo_id}; its lifecycle "
+                        "must be resolved before lower-priority delivery"
+                    ),
+                    recommended_action=(
+                        "Run a bounded successor replan before lower-priority delivery: "
+                        f"reopen, supersede, or record a no-follow-up rationale for "
+                        f"{candidate_todo_id}."
+                    ),
+                    requires_replan=True,
+                    candidate_counts={
+                        "deferred_resume_candidate_count": len(
+                            deferred_resume_candidates
+                        ),
+                        "preempted_open_candidate_count": 1,
+                    },
+                    extra_fields={
+                        "deferred_resume_candidates": deferred_resume_candidates[:3],
+                        "preempted_open_candidate": compact_todo_summary_item(
+                            agent_lane_next_action,
+                            text=str(agent_lane_next_action.get("text") or "").strip(),
+                        ),
+                        "priority_preemption": True,
+                    },
+                )
         return None
     if work_lane_contract_requires_current_agent_attempt(work_lane_contract):
         return None

--- a/loopx/control_plane/quota/selected_todo_projection.py
+++ b/loopx/control_plane/quota/selected_todo_projection.py
@@ -38,7 +38,21 @@ def selected_todo_projection(
     *,
     agent_lane_next_action: dict[str, Any] | None,
     work_lane_contract: dict[str, Any] | None,
+    agent_scope_frontier: dict[str, Any] | None = None,
 ) -> dict[str, Any] | None:
+    if (
+        isinstance(agent_scope_frontier, dict)
+        and agent_scope_frontier.get("action") == "successor_replan_required"
+    ):
+        candidates = agent_scope_frontier.get("deferred_resume_candidates")
+        if isinstance(candidates, list) and candidates and isinstance(candidates[0], dict):
+            selected = _compact_selected_todo(
+                candidates[0],
+                source="agent_scope_frontier.deferred_resume_candidates",
+            )
+            if selected:
+                return selected
+
     if isinstance(agent_lane_next_action, dict):
         source = str(agent_lane_next_action.get("source") or "agent_lane_next_action")
         selected = _compact_selected_todo(agent_lane_next_action, source=source)

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -1754,6 +1754,11 @@ def build_quota_should_run(
                     or ready_deferred_resume_candidates
                 ),
             )
+        if (
+            isinstance(agent_scope_frontier, dict)
+            and agent_scope_frontier.get("priority_preemption") is True
+        ):
+            agent_lane_next_action = None
         agent_lane_frontier_hint = None
         if not replan_decision_allowed:
             agent_lane_frontier_hint = _agent_lane_frontier_hint(
@@ -1935,6 +1940,7 @@ def build_quota_should_run(
         selected_todo_projection = _selected_todo_projection(
             agent_lane_next_action=agent_lane_next_action,
             work_lane_contract=payload_work_lane_contract,
+            agent_scope_frontier=agent_scope_frontier,
         )
         if selected_todo_projection:
             payload["selected_todo"] = selected_todo_projection


### PR DESCRIPTION
## Motivation

When a ready deferred P0 successor and an ordinary open P1 advancement coexist, quota currently selects the P1 even though `goal_frontier_projection` reports the deferred P0 as the top ready successor. That splits the selected action from the lifecycle frontier and can postpone required continuation work indefinitely.

## Implementation

- keep deferred todos out of the executable backlog;
- if a ready current-agent or unclaimed deferred successor has strictly higher priority than the selected open advancement, route to `successor_replan_required` first;
- project the same deferred todo through `selected_todo` and the frontier;
- let equal-priority open work continue to avoid unnecessary lifecycle churn;
- document the cross-lane priority contract.

## Validation

- red-first regression for ready deferred P0 plus open P1;
- equal-priority non-preemption regression;
- focused deferred, quota-replan, todo-projection, and work-lane smokes;
- `loopx canary premerge --from-git-diff`: 17/17 checks passed;
- Python compile, line budget, diff hygiene, and public/private boundary checks passed.

## Risk and gaps

This changes quota selection only when the deferred successor is strictly higher priority. It does not automatically reopen or execute deferred work, change persisted todo state, or alter equal-priority ordering. The real project call site will be rechecked after the default LoopX release is promoted.
