### PR TITLE
Classify promotion readiness as validation evidence

### DIFF
--- a/examples/canary/canary-promotion-readiness-smoke.py
+++ b/examples/canary/canary-promotion-readiness-smoke.py
@@ -30,6 +30,7 @@ READINESS_GOAL_ID = "loopx-meta"
 DEFAULT_READINESS_AGENT_ID = "codex-product-capability"
 DEFAULT_READINESS_AGENT_LANE = "product_capability_catalog_canary"
 READINESS_CLASSIFICATION = "canary_promotion_readiness_smoke_group"
+READINESS_DELIVERY_OUTCOME = "surface_only"
 READINESS_RECOMMENDED_ACTION = (
     "Canary promotion-readiness smoke passed; promotion may proceed after doctor/status reports fresh evidence."
 )
@@ -136,7 +137,7 @@ def write_readiness_evidence(
         "--delivery-batch-scale",
         "multi_surface",
         "--delivery-outcome",
-        "primary_goal_outcome",
+        READINESS_DELIVERY_OUTCOME,
     ]
     if resolved_agent_id:
         command.extend(["--agent-id", resolved_agent_id])

--- a/examples/canary/canary-promotion-readiness-writeback-smoke.py
+++ b/examples/canary/canary-promotion-readiness-writeback-smoke.py
@@ -173,11 +173,13 @@ def main() -> int:
         assert record["classification"] == module.READINESS_CLASSIFICATION, record
         assert record["goal_id"] == GOAL_ID, record
         assert record["delivery_batch_scale"] == "multi_surface", record
-        assert record["delivery_outcome"] == "primary_goal_outcome", record
+        assert record["delivery_outcome"] == module.READINESS_DELIVERY_OUTCOME, record
         assert record["recommended_action"] == module.READINESS_RECOMMENDED_ACTION, record
         assert record["progress_scope"] == "agent_lane", record
         assert record["agent_id"] == module.DEFAULT_READINESS_AGENT_ID, record
         assert record["agent_lane"] == module.DEFAULT_READINESS_AGENT_LANE, record
+        assert record["vision_checkpoint"]["required"] is False, record
+        assert record["vision_checkpoint"]["decision"] == "not_required", record
 
         json_path = Path(record["json_path"])
         markdown_path = Path(record["markdown_path"])
@@ -189,10 +191,12 @@ def main() -> int:
         payload = json.loads(json_path.read_text(encoding="utf-8"))
         assert payload["classification"] == module.READINESS_CLASSIFICATION, payload
         assert payload["delivery_batch_scale"] == "multi_surface", payload
-        assert payload["delivery_outcome"] == "primary_goal_outcome", payload
+        assert payload["delivery_outcome"] == module.READINESS_DELIVERY_OUTCOME, payload
         assert payload["progress_scope"] == "agent_lane", payload
         assert payload["agent_id"] == module.DEFAULT_READINESS_AGENT_ID, payload
         assert payload["agent_lane"] == module.DEFAULT_READINESS_AGENT_LANE, payload
+        assert payload["vision_checkpoint"]["required"] is False, payload
+        assert payload["vision_checkpoint"]["decision"] == "not_required", payload
         assert payload["state"]["path"] == str(state_path), payload
 
         global_registry = runtime / "registry.global.json"


### PR DESCRIPTION
## Summary
- classify promotion-readiness writeback as `surface_only` validation evidence instead of `primary_goal_outcome`
- prevent readiness runs from creating false missing vision checkpoints for the attributed agent
- extend the isolated writeback smoke to require `vision_checkpoint.decision=not_required`

## Root cause
The release readiness smoke validates an installation/promotion boundary; it does not advance the current agent vision. Labeling it as a primary goal outcome polluted delivery trajectories and caused the next quota projection to report a missing vision decision.

## Validation
- isolated promotion-readiness writeback smoke passed
- full readiness smoke passed without evidence writeback
- full pytest: 87 passed, 2 skipped; coverage 20.03%
- Ruff and public-boundary scan passed
- premerge canary: 13/13 passed, no manual holds

## Risk
The promotion-gate classification, freshness lookup, installer consumption, agent identity, and recommended action are unchanged. Only the delivery-outcome semantics are corrected.