### PR TITLE
fix: dedupe multi-reviewer notifications

### DIFF
--- a/examples/issue-fix-reviewer-request-smoke.py
+++ b/examples/issue-fix-reviewer-request-smoke.py
@@ -533,6 +533,42 @@ def main() -> int:
         assert semantic_retry_runner.comments == 0
         assert_public_safe(semantic_retry)
 
+        multi_semantic_url = "https://github.com/owner/repo/pull/42#issuecomment-1003"
+        multi_semantic_runner = FakeGitHubRunner(
+            before=metadata(
+                comments=[
+                    semantic_reviewer_comment(
+                        url=multi_semantic_url,
+                        body=(
+                            "Hi @service-owner @t0saki, could you please review "
+                            "this focused fix when convenient?"
+                        ),
+                    )
+                ]
+            )
+        )
+        multi_semantic = build_issue_fix_reviewer_request_packet(
+            repo_path=path,
+            url="https://github.com/owner/repo/pull/42",
+            base_ref="main",
+            execute=True,
+            runner=multi_semantic_runner,
+        )
+        assert multi_semantic["ok"] is True, multi_semantic
+        assert multi_semantic["selected_reviewers"] == []
+        assert multi_semantic["existing_semantic_comment_notified_reviewers"] == [
+            "@service-owner",
+            "@t0saki",
+        ]
+        assert multi_semantic["reviewer_notification_mode"] == (
+            "existing_review_comment"
+        )
+        assert multi_semantic["reviewer_comment_url"] == multi_semantic_url
+        assert multi_semantic["external_writes_performed"] is False
+        assert multi_semantic_runner.edits == 0
+        assert multi_semantic_runner.comments == 0
+        assert_public_safe(multi_semantic)
+
         discussion_comment = semantic_reviewer_comment(
             login="service-owner",
             body=(

--- a/examples/issue-fix-reviewer-request-smoke.py
+++ b/examples/issue-fix-reviewer-request-smoke.py
@@ -569,6 +569,33 @@ def main() -> int:
         assert multi_semantic_runner.comments == 0
         assert_public_safe(multi_semantic)
 
+        bounded_semantic_runner = FakeGitHubRunner(
+            before=metadata(
+                comments=[
+                    semantic_reviewer_comment(
+                        body=(
+                            "@fallback-owner; @service-owner, could you please "
+                            "review this focused fix?"
+                        ),
+                    )
+                ]
+            )
+        )
+        bounded_semantic = build_issue_fix_reviewer_request_packet(
+            repo_path=path,
+            url="https://github.com/owner/repo/pull/42",
+            base_ref="main",
+            execute=True,
+            runner=bounded_semantic_runner,
+        )
+        assert bounded_semantic["existing_semantic_comment_notified_reviewers"] == [
+            "@service-owner"
+        ]
+        assert bounded_semantic["external_writes_performed"] is False
+        assert bounded_semantic_runner.edits == 0
+        assert bounded_semantic_runner.comments == 0
+        assert_public_safe(bounded_semantic)
+
         discussion_comment = semantic_reviewer_comment(
             login="service-owner",
             body=(

--- a/loopx/capabilities/issue_fix/reviewer_request.py
+++ b/loopx/capabilities/issue_fix/reviewer_request.py
@@ -83,6 +83,13 @@ def _is_automated_reviewer_handle(value: Any) -> bool:
     return bool(handle and REVIEWER_BOT_HANDLE_PATTERN.search(handle.lstrip("@")))
 
 
+def _is_mention_cluster_separator(value: str) -> bool:
+    if "\n" in value or "\r" in value:
+        return False
+    remainder = re.sub(r"\b(?:and|or)\b|[和与及]", "", value, flags=re.IGNORECASE)
+    return bool(re.fullmatch(r"[ \t,，、:：;&+/]*", remainder))
+
+
 def _semantic_review_request_mentions(body: str) -> list[str]:
     visible_body = re.sub(r"<!--.*?-->", " ", body, flags=re.DOTALL)
     visible_body = re.sub(r"```.*?```", " ", visible_body, flags=re.DOTALL)
@@ -91,6 +98,31 @@ def _semantic_review_request_mentions(body: str) -> list[str]:
     )
     handles: list[str] = []
     mentions = list(REVIEWER_COMMENT_MENTION_PATTERN.finditer(visible_body))
+    for intent_pattern in REVIEWER_COMMENT_INTENT_PATTERNS:
+        for intent in intent_pattern.finditer(visible_body):
+            preceding = [
+                mention
+                for mention in mentions
+                if mention.end() <= intent.start()
+                and intent.start() - mention.end() <= 160
+            ]
+            if not preceding:
+                continue
+            cluster = [preceding[-1]]
+            if not _is_mention_cluster_separator(
+                visible_body[cluster[0].end() : intent.start()]
+            ):
+                continue
+            for mention in reversed(preceding[:-1]):
+                gap = visible_body[mention.end() : cluster[0].start()]
+                if not _is_mention_cluster_separator(gap):
+                    break
+                cluster.insert(0, mention)
+            for mention in cluster:
+                handle = _normalise_login(mention.group(1))
+                if handle and handle not in handles:
+                    handles.append(handle)
+
     for index, mention in enumerate(mentions):
         next_mention_start = (
             mentions[index + 1].start()

--- a/loopx/capabilities/issue_fix/reviewer_request.py
+++ b/loopx/capabilities/issue_fix/reviewer_request.py
@@ -87,7 +87,7 @@ def _is_mention_cluster_separator(value: str) -> bool:
     if "\n" in value or "\r" in value:
         return False
     remainder = re.sub(r"\b(?:and|or)\b|[和与及]", "", value, flags=re.IGNORECASE)
-    return bool(re.fullmatch(r"[ \t,，、:：;&+/]*", remainder))
+    return bool(re.fullmatch(r"[ \t,，、:：&+/]*", remainder))
 
 
 def _semantic_review_request_mentions(body: str) -> list[str]:


### PR DESCRIPTION
## Summary

- recognize every reviewer in a leading multi-handle mention cluster when one bounded explicit review intent follows
- keep cross-line, quoted, code-block, FYI-only, and ordinary discussion mentions outside semantic notification dedupe
- add a repository-neutral regression matching the real multi-reviewer comment shape

## Root cause

The semantic parser bounded each reviewer window at the next mention. In a comment such as `@a @b, could you review`, only `@b` could see the review intent, so `@a` remained eligible for a duplicate fallback comment.

## Validation

- `python3 examples/issue-fix-reviewer-request-smoke.py`
- `uvx ruff check loopx/capabilities/issue_fix/reviewer_request.py examples/issue-fix-reviewer-request-smoke.py`
- `python3 -m py_compile ...`
- `loopx check --scan-path ...`
- `loopx canary premerge --from-git-diff`: 9/9 selected checks passed, no warnings or manual holds
- real no-write preview against OpenViking PR #3175: both existing handles recognized, no reviewer selected, zero external writes

## Risk

The new association is intentionally narrow: only same-line mention clusters separated by punctuation/conjunctions immediately before an explicit review-request phrase are grouped.