### PR TITLE
Align task lease docs with shipped behavior

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,14 +148,17 @@ The server path should land in layers:
    concurrency with per-goal locks, idempotency keys, and optimistic revision
    checks. `todo`, `refresh-state`, reward writeback, quota spend, and history
    append paths should fail closed on stale revision or overlapping write scope.
-2. **Lease projection**: add `task_lease_v0` records for claimed todos,
-   including owner, TTL, write scope, idempotency key, and conflict policy.
+2. **Lease adoption**: the optional local `task_lease_v0` CLI already provides
+   owner, TTL, write scope, idempotency, conflict, transfer, and release
+   semantics. Keep `claimed_by` as the default soft route and adopt hard leases
+   only for hosts with a demonstrated concurrent-write problem.
    The pending/lease key should be per todo: `(goal_id, todo_id)` is the
    contention unit, not the whole goal or project. Different todos under the
    same goal may proceed in parallel when their write scopes and gates allow
    it; competing claims on the same todo fail closed or renew.
-   Status and quota should expose active leases so Codex/App/CLI loops can
-   avoid duplicate work without reading chat history.
+   Status currently exposes capability availability; quota does not enforce or
+   consume hard leases. A later host integration may project active lease rows
+   after its adoption contract and fallback behavior are validated.
 3. **Loopback coordinator**: extend the existing local status server into a
    loopback-only coordinator that can centralize per-goal locks, leases, quota
    decisions, compact status projection, and heartbeat scheduling. It must bind

--- a/docs/frontstage-channel-lease-roadmap.md
+++ b/docs/frontstage-channel-lease-roadmap.md
@@ -128,7 +128,7 @@ The v0 source map should stay boring and inspectable:
 | `decision_frame` | `interaction_contract` from `quota should-run` and review-packet routing |
 | `quota` | `quota should-run`, including the spend policy and capability/workspace guards when present |
 | `artifacts` | public-safe docs, compact run artifacts, review packets, or showcase assets already allowed by `goal_boundary` |
-| `active_leases` | current soft claims and future `task_lease_v0` records |
+| `active_leases` | current soft claims and explicitly supplied optional `task_lease_v0` rows |
 | `recent_events` | compact run-history rows only, not raw logs or transcripts |
 | `source_warnings` | stale state, todo projection gaps, private-boundary omissions, or missing authority sources |
 
@@ -196,7 +196,9 @@ identity rank or default permission. Concrete authority comes from
 
 ### `task_lease_v0`
 
-This is the concurrency contract that should eventually back task claim. The
+This optional local file-backed concurrency contract is shipped through
+`loopx task-lease acquire|renew|transfer|release|inspect`. It does not replace
+the default soft `claimed_by` route or participate in quota decisions. The
 pending key is per todo: `(goal_id, todo_id)`. Do not serialize an entire
 goal just because one todo is claimed; independent todos under the same goal
 should remain independently claimable when gates and write scopes allow it.
@@ -212,19 +214,22 @@ review action over an independent handoff, optionally excluding the author.
 ```json
 {
   "schema_version": "task_lease_v0",
-  "todo_id": "todo_123",
-  "owner_agent": "codex-local-controller",
   "goal_id": "loopx-meta",
-  "lease_until": "2026-06-15T12:30:00Z",
-  "write_scope": ["docs/frontstage-channel-lease-roadmap.md"],
+  "todo_id": "todo_123",
+  "owner": "codex-local-controller",
   "idempotency_key": "loopx-meta:todo_123:20260615T1230Z",
-  "conflict_policy": "fail_closed_on_scope_overlap",
+  "write_scopes": ["docs/frontstage-channel-lease-roadmap.md"],
+  "version": 1,
+  "acquired_at": "2026-06-15T12:00:00Z",
+  "updated_at": "2026-06-15T12:00:00Z",
+  "expires_at": "2026-06-15T12:30:00Z",
   "status": "active"
 }
 ```
 
-The first implementation can be local and file-backed. A later server can own
-the same schema with stronger locking, lease renewal, and stale-claim cleanup.
+The current implementation is local and file-backed, with per-goal locking,
+renewal, transfer, release, registered-owner validation, and stale-owner
+invalidation. A later server can own the same schema and coordination surface.
 Conflicts should be detected by `(goal_id, todo_id)` plus overlapping
 write-scope checks: another agent may claim a different todo in the same goal,
 but a second pending claim on the same todo must fail closed, renew, or
@@ -234,10 +239,9 @@ explicitly transfer ownership.
 
 P1:
 
-- Design and test `task_lease_v0` first. It prevents lost writes and concurrent
-  controller confusion, and it naturally extends the existing todo locking
-  lane. The durable invariant is per-todo pending: one active pending lease per
-  `(goal_id, todo_id)`, not one active lease per goal or project.
+- Keep the shipped optional `task_lease_v0` runtime and conflict smoke stable.
+  Adopt it in a host execution path only after a concrete concurrent-write bad
+  case demonstrates value; do not silently turn it into a default quota gate.
 - Treat the shipped React `/frontstage` route as the baseline
   `goal_channel_projection_v0` reader. Future work should polish visual
   acceptance, operator onboarding, and local fixture realism while preserving
@@ -246,8 +250,8 @@ P1:
 
 P2:
 
-- Add agent-member projection to status/review packets after leases exist, so
-  agent identity is useful rather than decorative.
+- Decide whether active hard-lease rows should join the existing agent-member
+  status/review projection after an adoption case proves the extra signal useful.
 - Build a Raft-style local frontstage view that renders channel timelines and
   member activity from LoopX projections.
 - Let dreaming/planning proposals appear as a separate channel lane or badge.

--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -1370,14 +1370,17 @@ material belongs to another connected project.
 
 **Expected behavior**
 
-A task claim should become `task_lease_v0`: an explicit, expiring claim over
-one bounded todo. The pending key is `(goal_id, todo_id)`: `goal_id` names the
-control-plane lane, while `todo_id` names the work item inside it. Different
+`claimed_by` remains the default soft routing signal. When a host has a concrete
+exclusive-write need, it may explicitly acquire `task_lease_v0`: an expiring
+hard lease over one bounded todo. The pending key is `(goal_id, todo_id)`:
+`goal_id` names the control-plane lane, while `todo_id` names the work item
+inside it. Different
 todos inside the same goal do not conflict merely because they share a goal;
 only competing pending leases for the same `todo_id` or overlapping write
-scopes should conflict. Status and future channel projections may render the
-claim, but the lease remains a projection over the LoopX ledger and does
-not override `goal_boundary`, user gates, quota, or write-scope checks.
+scopes should conflict. Status exposes whether the optional lease capability is
+available, and channel projections may render supplied lease rows. The lease is
+not enforced by `quota should-run` and does not override `goal_boundary`, user
+gates, capabilities, or write-scope checks.
 
 When a lease is active and the selected action is inside its scope, the owner
 may proceed. When a competing worker sees an active overlapping lease, it must
@@ -1408,7 +1411,7 @@ files because the only ownership signal was a chat message or dashboard label.
 
 - `docs/frontstage-channel-lease-roadmap.md`
 - `docs/architecture.md` local server / daemon roadmap
-- future `task_lease_v0` status and conflict smoke.
+- `examples/control_plane/task-lease-runtime-smoke.py`.
 
 #### IP-019 Peer Scoped Continuation
 

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -103,8 +103,8 @@ runtime contract, benchmark route, or launch draft.
   same-TUI attach stays blocked until proof and idle evidence pass.
 - [Agent profile contract](agent-profile-contract.md): the registry-owned
   advisory capability/scope contract for peers, while task and repository
-  policy own workspace/review requirements and todos retain ownership through
-  `claimed_by` and future leases.
+  policy own workspace/review requirements and todos retain soft ownership
+  through `claimed_by`, with optional hard leases for explicit contention cases.
 - [Non-technical operator status model](nontechnical-operator-status-model.md):
   first-screen Agent Work Feed and card model for people who need to review
   agent outputs, progress, blockers, next moves, signal inbox, anchor

--- a/docs/product/nontechnical-operator-status-model.md
+++ b/docs/product/nontechnical-operator-status-model.md
@@ -338,15 +338,15 @@ before adding new UI state.
 | Since Last Check | run history, refresh-state delivery outcome, validation evidence |
 | Signal Inbox | connector events, user feedback, issue/PR metadata, doc changes |
 | Anchor Selection | planning queue proposals, promoted todos, future anchor packets |
-| Current Work | agent todos, `claimed_by`, advisory `agent_profile_v1`, future leases |
+| Current Work | agent todos, `claimed_by`, advisory `agent_profile_v1`, optional hard leases when explicitly supplied |
 | Blocker Or Gate | user todos, operator gate, interaction contract, goal boundary |
 | Next Agent Move | quota decision, recommended action, next action, stop condition |
 | What I Need From You | user todo summary and concrete operator question |
 | Feedback Capture | reward overlay, gate command, todo update, future feedback signal |
 | Performance Review | run evidence, reward overlays, outcome classification, cost summary |
 
-Missing fields should degrade gracefully. For example, before hard leases exist,
-show `claimed_by` as soft ownership and avoid claiming exclusive execution.
+Missing fields should degrade gracefully. When no explicit hard-lease row is
+supplied, show `claimed_by` as soft ownership and avoid claiming exclusive execution.
 Without `agent_profile_v1`, show the registered peer id and current claims; do
 not infer rank or authority from the identity name.
 

--- a/docs/product/scenario-capability-gap-map.md
+++ b/docs/product/scenario-capability-gap-map.md
@@ -141,7 +141,8 @@ P0 gaps:
 
 P1 gaps:
 
-- claim-aware worktree lease beyond soft `claimed_by`;
+- host-integrated worktree lease enforcement beyond soft `claimed_by` and the
+  standalone opt-in `task-lease` CLI;
 - connector support for GitHub-like issue/PR/CI surfaces through a thin host
   adapter or MCP facade;
 - frontstage card that explains "ready to patch", "waiting for repro",

--- a/docs/product/server-client-product-shape.md
+++ b/docs/product/server-client-product-shape.md
@@ -28,7 +28,7 @@ long-running facts become coherent:
   defaults;
 - maintainer-facing signal inbox, selected anchors, and performance-review
   summaries;
-- per-todo claim and future lease state;
+- per-todo soft claim and optional hard-lease state;
 - quota, spend, idempotency, and concurrency policy;
 - compact public/private boundary summaries;
 - compact mental-model and management projections for clients;

--- a/docs/showcases/cases/0620-creator-operator-case-spec.md
+++ b/docs/showcases/cases/0620-creator-operator-case-spec.md
@@ -60,7 +60,7 @@ LoopX turns the workflow into visible control-plane objects:
 | Synthetic demo data versus private user material | boundary note |
 | What changed since last check | run history summary |
 | Safe work while a publishing gate waits | safe side path |
-| Agent identity and lane ownership | claim / future lease |
+| Agent identity and lane ownership | soft claim / optional hard lease |
 
 The important behavior is gate-aware continuation. The agent should not
 autopublish or treat private drafts as public evidence. But while a publishing


### PR DESCRIPTION
## Summary
- replace stale claims that `task_lease_v0` is future work
- document the current boundary: soft `claimed_by` is default; hard lease CLI is explicit opt-in; quota does not enforce it
- align the raw lease example with shipped field names
- preserve host-integrated worktree enforcement as an explicit remaining gap

## Scope
This is a targeted truth sync across canonical architecture, interaction, product, frontstage, and showcase references. It does not change runtime behavior or broadly rewrite the documents.

## Validation
- task-lease runtime smoke
- host integration surface smoke
- goal-channel projection and frontstage fixture smokes
- `loopx check` across all eight changed docs: 0 errors, 0 warnings
- `loopx canary premerge --from-git-diff`: 17 selected, 0 failures, 0 manual holds

## Risk
Docs-only. Existing links, section structure, soft-claim semantics, and the opt-in adoption gate are preserved.
