### PR TITLE
Stop advertising TTL for soft claims

### DIFF
--- a/docs/frontstage-channel-lease-roadmap.md
+++ b/docs/frontstage-channel-lease-roadmap.md
@@ -24,8 +24,9 @@ truth into chat history:
 - An **agent can project as a workspace member**: controller, executor,
   reviewer, monitor, critic, or dreaming/planning proposer, each with scope and
   last action.
-- A **task claim should be a per-todo lease**: explicit ownership of one
-  `todo_id` with TTL, write scope, idempotency key, and conflict policy.
+- A **task claim is a soft per-todo route by default**. When a concrete
+  contention case needs exclusivity, an optional hard lease adds TTL, write
+  scope, idempotency, and conflict handling for one `todo_id`.
 - A **chat or channel thread is a projection**: useful for human collaboration,
   but never the only durable authority.
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -378,7 +378,6 @@ Minimal registry fields for this pattern are:
     "agent_model": "peer_v1",
     "registered_agents": ["codex-main-control", "codex-side-bypass"],
     "write_scope": ["docs/**", "examples/**"],
-    "claim_ttl_minutes": 30,
     "requires_parent_approval": ["write", "publish", "production-action"]
   }
 }
@@ -398,11 +397,12 @@ authority. Repository-writing peers use isolated worktrees when the selected
 task requires it. Small AGENTS-eligible validated changes may self-merge with
 explicit evidence; broader or higher-risk work uses an explicit
 `independent_handoff` with `action_kind=review`, optionally excluding the author
-when executor separation is required. A future version can add
-claim files, stale-claim detection, overlap warnings, TTLs, and
-compare-and-swap conflict responses. That future pending contract should be per
-todo: a pending lease is keyed by `(goal_id, todo_id)`, so unrelated todos under
-the same goal can still run in parallel when scopes permit.
+when executor separation is required. Soft claims do not expire. The legacy
+bootstrap option `--claim-ttl-minutes` is accepted but ignored; use the optional
+`loopx task-lease` CLI when a concrete contention case needs TTL, overlap
+checks, transfer, and compare-and-swap behavior. Hard leases remain keyed by
+`(goal_id, todo_id)`, so unrelated todos under the same goal can still run in
+parallel when scopes permit.
 
 ## Shared Runtime
 

--- a/examples/control_plane/todo-claim-lease-roadmap-smoke.py
+++ b/examples/control_plane/todo-claim-lease-roadmap-smoke.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
-"""Smoke-test the public todo claim and future per-todo lease contract."""
+"""Smoke-test the public soft-claim and optional hard-lease contract."""
 
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
+import tempfile
 from pathlib import Path
 
 
@@ -48,11 +51,13 @@ def main() -> int:
     require(
         roadmap,
         [
-            "A **task claim should be a per-todo lease**",
+            "A **task claim is a soft per-todo route by default**",
+            "an optional hard lease adds TTL",
             "pending key is per todo: `(goal_id, todo_id)`",
             "LoopX does not have a separate issue object",
-            "one active pending lease per\n  `(goal_id, todo_id)`",
-            "not one active lease per goal or project",
+            "Do not serialize an entire\ngoal",
+            "does not replace\nthe default soft `claimed_by` route or participate in quota decisions",
+            "registered-owner validation",
             "repository-writing peers use isolated worktrees",
             "self-merge with\nevidence",
             "review action over an independent handoff",
@@ -75,16 +80,52 @@ def main() -> int:
         registry = json.loads(source.read_text(encoding="utf-8"))
         for goal in registry.get("goals") or []:
             coordination = goal.get("coordination") or {}
-            if "claim_ttl_minutes" not in coordination:
-                continue
-            registered_agents = coordination.get("registered_agents")
-            assert isinstance(registered_agents, list) and registered_agents, (
-                f"{source}: goal {goal.get('id')} has claim_ttl_minutes but no registered_agents"
+            assert "claim_ttl_minutes" not in coordination, (
+                f"{source}: soft claims must not advertise an inert TTL"
             )
-            assert coordination.get("agent_model") == "peer_v1", (
-                f"{source}: goal {goal.get('id')} must use the peer runtime"
-            )
-            assert "primary_agent" not in coordination, f"{source}: durable hierarchy is forbidden"
+
+    help_result = subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "bootstrap", "--help"],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    assert "--claim-ttl-minutes" not in help_result.stdout, help_result.stdout
+
+    with tempfile.TemporaryDirectory(prefix="loopx-soft-claim-ttl-smoke-") as tmp:
+        root = Path(tmp)
+        registry_path = root / "registry.json"
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--registry",
+                str(registry_path),
+                "--format",
+                "json",
+                "bootstrap",
+                "--project",
+                str(root / "project"),
+                "--goal-id",
+                "soft-claim-ttl-smoke",
+                "--objective",
+                "verify soft claim TTL compatibility",
+                "--claim-ttl-minutes",
+                "5",
+                "--no-onboarding-scan",
+                "--no-global-sync",
+            ],
+            cwd=REPO_ROOT,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        assert result.returncode == 0, result.stdout or result.stderr
+        registry = json.loads(registry_path.read_text(encoding="utf-8"))
+        coordination = registry["goals"][0]["coordination"]
+        assert "claim_ttl_minutes" not in coordination, coordination
 
     print("todo-claim-lease-roadmap-smoke ok")
     return 0

--- a/examples/peer-agent-task-orchestration.registry.example.json
+++ b/examples/peer-agent-task-orchestration.registry.example.json
@@ -42,7 +42,6 @@
           "examples/**",
           "src/adapters/**"
         ],
-        "claim_ttl_minutes": 30,
         "requires_parent_approval": [
           "publish",
           "production-action"

--- a/examples/registry.example.json
+++ b/examples/registry.example.json
@@ -70,7 +70,6 @@
           "docs/**",
           "examples/**"
         ],
-        "claim_ttl_minutes": 30,
         "requires_parent_approval": [
           "write",
           "publish",

--- a/loopx/bootstrap.py
+++ b/loopx/bootstrap.py
@@ -491,7 +491,6 @@ def build_goal_entry(
     max_children: int,
     allowed_domains: list[str],
     write_scope: list[str],
-    claim_ttl_minutes: int,
     execution_profile: dict[str, Any] | None,
 ) -> dict[str, Any]:
     authority_sources = []
@@ -528,7 +527,6 @@ def build_goal_entry(
         },
         "coordination": {
             "write_scope": write_scope,
-            "claim_ttl_minutes": max(1, claim_ttl_minutes),
             "requires_parent_approval": [
                 "write",
                 "publish",
@@ -589,7 +587,6 @@ def bootstrap_project(
     max_children: int,
     allowed_domains: list[str] | None,
     write_scope: list[str] | None,
-    claim_ttl_minutes: int,
     execution_minimum_scale: str | None = None,
     execution_must_include: list[str] | None = None,
     execution_small_streak_threshold: int | None = None,
@@ -665,7 +662,6 @@ def bootstrap_project(
         max_children=max_children,
         allowed_domains=allowed_domains or [],
         write_scope=write_scope or [],
-        claim_ttl_minutes=claim_ttl_minutes,
         execution_profile=execution_profile,
     )
     registry, registry_goal_action = merge_goal(registry, goal_entry, force=force)

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -141,7 +141,6 @@ def _seed_visible_demo_control_plane(
         max_children=4,
         allowed_domains=["auto-research-demo"],
         write_scope=_visible_demo_goal_write_scope(preset_context),
-        claim_ttl_minutes=60,
         onboarding_scan_enabled=False,
         accept_onboarding_agent_todos=False,
         begin_autonomous_advance=True,

--- a/loopx/cli_commands/bootstrap_connect.py
+++ b/loopx/cli_commands/bootstrap_connect.py
@@ -58,7 +58,12 @@ def register_bootstrap_connect_command(subparsers: argparse._SubParsersAction) -
         default=[],
         help="Allowed write scope such as docs/**. Repeatable.",
     )
-    bootstrap_parser.add_argument("--claim-ttl-minutes", type=int, default=30)
+    bootstrap_parser.add_argument(
+        "--claim-ttl-minutes",
+        type=int,
+        default=30,
+        help=argparse.SUPPRESS,
+    )
     bootstrap_parser.add_argument(
         "--execution-minimum-scale",
         default=str(DEFAULT_EXECUTION_PROFILE["minimum_scale"]),
@@ -197,7 +202,6 @@ def handle_bootstrap_connect_command(
             max_children=args.max_children,
             allowed_domains=args.allowed_domain,
             write_scope=args.write_scope,
-            claim_ttl_minutes=args.claim_ttl_minutes,
             execution_minimum_scale=args.execution_minimum_scale,
             execution_must_include=args.execution_must_include or None,
             execution_small_streak_threshold=args.execution_small_streak_threshold,

--- a/loopx/demo.py
+++ b/loopx/demo.py
@@ -69,7 +69,6 @@ def run_demo(
         max_children=3,
         allowed_domains=[],
         write_scope=[],
-        claim_ttl_minutes=30,
         onboarding_scan_enabled=False,
         force=False,
         dry_run=False,


### PR DESCRIPTION
## Summary
- stop writing inert `coordination.claim_ttl_minutes` into newly bootstrapped goals
- keep legacy `--claim-ttl-minutes` accepted but hide and ignore it for script compatibility
- remove the false TTL from public registry examples
- document that soft `claimed_by` does not expire and explicit `task-lease --ttl-seconds` owns hard TTL semantics
- preserve old registry fixtures to keep legacy state readable

## Root cause
`claim_ttl_minutes` was emitted by bootstrap but never read anywhere in runtime selection, claim, status, or quota code. It implied that soft claims expired even though they do not, duplicating and contradicting the explicit hard-lease model.

## Validation
- full pytest: 97 passed, 2 skipped
- todo claim/lease roadmap smoke, including legacy option compatibility and hidden help
- demo CLI, bootstrap preserve-todos, connect route collision, and auto-research goal-isolation smokes
- `loopx canary premerge --from-git-diff`: 17 selected, 0 failures, 0 manual holds
- public/private boundary scan: 0 errors, 0 warnings

## Compatibility
Existing registries containing `claim_ttl_minutes` remain readable. Existing scripts passing the CLI flag continue to succeed. Only new bootstrap output stops persisting the inert field.
