### PR TITLE
Invalidate leases for non-open todos

### DIFF
--- a/examples/control_plane/task-lease-runtime-smoke.py
+++ b/examples/control_plane/task-lease-runtime-smoke.py
@@ -85,6 +85,17 @@ def set_excluded_agents(state_file: Path, *, todo_id: str, agents: list[str]) ->
     raise AssertionError(f"todo metadata not found: {todo_id}")
 
 
+def set_todo_status(state_file: Path, *, todo_id: str, status: str) -> None:
+    lines = state_file.read_text(encoding="utf-8").splitlines()
+    for index, line in enumerate(lines):
+        if f"todo_id={todo_id}" not in line:
+            continue
+        lines[index] = re.sub(r"\bstatus=[^\s<>]+", f"status={status}", line)
+        state_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return
+    raise AssertionError(f"todo metadata not found: {todo_id}")
+
+
 def cli(registry_path: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [
@@ -160,6 +171,49 @@ def main() -> int:
         assert first["ok"] is True and first["acquired"] is True, first
         assert first["lease"]["schema_version"] == "task_lease_v0", first
         assert first["lease"]["version"] == 1, first
+
+        set_todo_status(state_file, todo_id=TODO_A, status="done")
+        terminal_inspect = payload(
+            cli(registry_path, "inspect", "--goal-id", GOAL_ID, "--todo-id", TODO_A)
+        )
+        assert terminal_inspect["active"] is False, terminal_inspect
+        assert terminal_inspect["executor_constraint"]["reason"] == "todo_not_open", (
+            terminal_inspect
+        )
+        terminal_renew = cli(
+            registry_path,
+            "renew",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            TODO_A,
+            "--owner",
+            "codex-main-control",
+            "--idempotency-key",
+            "turn-1",
+            check=False,
+        )
+        assert terminal_renew.returncode == 1, terminal_renew.stdout
+        assert payload(terminal_renew)["error_code"] == "todo_not_open", terminal_renew.stdout
+        set_todo_status(state_file, todo_id=TODO_A, status="open")
+
+        set_todo_status(state_file, todo_id=TODO_C, status="deferred")
+        terminal_acquire = cli(
+            registry_path,
+            "acquire",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            TODO_C,
+            "--owner",
+            "codex-side-bypass",
+            "--idempotency-key",
+            "deferred-acquire",
+            check=False,
+        )
+        assert terminal_acquire.returncode == 1, terminal_acquire.stdout
+        assert payload(terminal_acquire)["error_code"] == "todo_not_open", terminal_acquire.stdout
+        set_todo_status(state_file, todo_id=TODO_C, status="open")
 
         unregistered_acquire = cli(
             registry_path,

--- a/loopx/control_plane/work_items/task_lease.py
+++ b/loopx/control_plane/work_items/task_lease.py
@@ -135,6 +135,13 @@ def task_lease_owner_constraint(
 ) -> dict[str, Any]:
     if todo is None:
         return {"effective": False, "reason": "todo_not_found"}
+    todo_status = str(todo.get("status") or "").strip().lower()
+    if todo_status != "open":
+        return {
+            "effective": False,
+            "reason": "todo_not_open",
+            "todo_status": todo_status or "unknown",
+        }
     normalized_owner = normalize_todo_claimed_by(owner)
     if not normalized_owner:
         return {"effective": False, "reason": "invalid_owner"}
@@ -203,6 +210,11 @@ def require_task_lease_owner_allowed(
         reason = str(constraint.get("reason") or "owner_not_allowed")
         if reason == "todo_not_found":
             message = "todo is missing from the canonical projection"
+        elif reason == "todo_not_open":
+            message = (
+                f"task lease requires an open todo; "
+                f"{todo_id!r} is {constraint.get('todo_status')!r}"
+            )
         elif reason == "owner_excluded_from_todo":
             message = f"task lease owner {owner!r} is excluded from todo {todo_id!r}"
         elif reason == "owner_not_registered":


### PR DESCRIPTION
## Summary
- make a task lease effective only while its canonical todo status is `open`
- reject acquire/renew/transfer against done, blocked, deferred, or otherwise non-open todos
- make inspect and overlapping-scope conflict evaluation ignore stale leases from non-open todos
- preserve explicit release for cleanup and audit

## Root cause
Lease eligibility checked todo existence, registered ownership, exclusions, and TTL, but not todo lifecycle status. A completed todo could therefore retain an active hard lease and block overlapping work until TTL expiry.

## Validation
- installed bad-case reproduction before the fix: completed todo still inspected as active
- task-lease runtime smoke now covers done inspect, done renew, deferred acquire, and reopening
- full pytest: 97 passed, 2 skipped
- bounded-context, risk-characterization, and line-budget smokes
- `loopx canary premerge --from-git-diff`: 14 selected, 0 failures, 0 manual holds
- public/private boundary scan: 0 errors, 0 warnings

## Risk
One central eligibility rule changes only opt-in hard leases. Soft claims, quota, todo lifecycle writes, TTL/CAS behavior, and release remain unchanged.
