### PR TITLE
Fix task lease scope overlap matching

### DIFF
--- a/examples/control_plane/task-lease-runtime-smoke.py
+++ b/examples/control_plane/task-lease-runtime-smoke.py
@@ -13,6 +13,11 @@ from typing import Any
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.work_items.task_lease import write_scopes_overlap  # noqa: E402
+
+
 GOAL_ID = "task-lease-runtime-goal"
 TODO_A = "todo_taskleasea"
 TODO_B = "todo_taskleaseb"
@@ -147,6 +152,11 @@ def quota_should_run(registry_path: Path, *, agent_id: str) -> dict[str, Any]:
 
 
 def main() -> int:
+    assert write_scopes_overlap(["docs/**"], ["docs/a.md"])
+    assert write_scopes_overlap(["docs/sub/**"], ["docs/sub/a.md"])
+    assert write_scopes_overlap(["docs/a*.md"], ["docs/ab.md"])
+    assert not write_scopes_overlap(["docs/a.md"], ["docs/b.md"])
+
     with tempfile.TemporaryDirectory(prefix="loopx-task-lease-smoke-") as tmp:
         registry_path, state_file = write_fixture(Path(tmp))
 
@@ -336,7 +346,7 @@ def main() -> int:
             "--ttl-seconds",
             "120",
             "--write-scope",
-            "loopx/cli_commands/**",
+            "loopx/cli_commands/todo.py",
             check=False,
         )
         assert conflict.returncode == 1, conflict.stdout

--- a/loopx/control_plane/work_items/task_lease.py
+++ b/loopx/control_plane/work_items/task_lease.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import fnmatch
 import json
 import re
 from datetime import datetime, timedelta
@@ -291,6 +292,51 @@ def scope_root(scope: str) -> str:
     return value.rstrip("/")
 
 
+def _scope_has_glob(scope: str) -> bool:
+    return any(token in scope for token in ("*", "?", "["))
+
+
+def _scope_literal_prefix(scope: str) -> str:
+    indexes = [scope.find(token) for token in ("*", "?", "[") if scope.find(token) >= 0]
+    return scope[: min(indexes)] if indexes else scope
+
+
+def _scope_pair_overlaps(left: str, right: str) -> bool:
+    if left == right:
+        return True
+    if left in {"*", "**", "./"} or right in {"*", "**", "./"}:
+        return True
+
+    left_has_glob = _scope_has_glob(left)
+    right_has_glob = _scope_has_glob(right)
+    if left_has_glob and not right_has_glob:
+        prefix = _scope_literal_prefix(left)
+        return fnmatch.fnmatchcase(right, left) or (
+            prefix.endswith("/") and right.rstrip("/") == prefix.rstrip("/")
+        )
+    if right_has_glob and not left_has_glob:
+        prefix = _scope_literal_prefix(right)
+        return fnmatch.fnmatchcase(left, right) or (
+            prefix.endswith("/") and left.rstrip("/") == prefix.rstrip("/")
+        )
+    if left_has_glob and right_has_glob:
+        left_prefix = _scope_literal_prefix(left)
+        right_prefix = _scope_literal_prefix(right)
+        return bool(
+            not left_prefix
+            or not right_prefix
+            or left_prefix.startswith(right_prefix)
+            or right_prefix.startswith(left_prefix)
+        )
+
+    left_root = left.rstrip("/")
+    right_root = right.rstrip("/")
+    return bool(
+        (left.endswith("/") and right.startswith(left_root + "/"))
+        or (right.endswith("/") and left.startswith(right_root + "/"))
+    )
+
+
 def write_scopes_overlap(left: list[str], right: list[str]) -> bool:
     left_scopes = normalize_required_write_scopes(left)
     right_scopes = normalize_required_write_scopes(right)
@@ -298,15 +344,7 @@ def write_scopes_overlap(left: list[str], right: list[str]) -> bool:
         return False
     for left_scope in left_scopes:
         for right_scope in right_scopes:
-            if left_scope == right_scope:
-                return True
-            left_root = scope_root(left_scope)
-            right_root = scope_root(right_scope)
-            if not left_root or not right_root:
-                return True
-            if left_root.startswith(right_root.rstrip("/") + "/"):
-                return True
-            if right_root.startswith(left_root.rstrip("/") + "/"):
+            if _scope_pair_overlaps(left_scope, right_scope):
                 return True
     return False
 


### PR DESCRIPTION
## Summary
- fix hard-lease scope overlap checks for glob scopes versus concrete child paths
- preserve non-overlap for distinct exact sibling files
- add a durable runtime regression smoke for the original false-negative case

## Root cause
The previous implementation normalized both scopes to directory roots and only checked strict ancestor prefixes. That made `docs/**` and `docs/a.md` collapse to equal roots without being treated as overlapping.

## Validation
- `uv run --no-project --with pytest --with pytest-cov pytest -q` (97 passed, 2 skipped)
- `python3 examples/control_plane/task-lease-runtime-smoke.py`
- bounded-context, control-plane-risk, and Python line-budget smokes
- `loopx check` on both changed paths (0 errors, 0 warnings)
- `loopx canary premerge --from-git-diff` (standard tier, 14 selected, 0 failures, 0 manual holds)