### PR TITLE
Reject task lease idempotency key reuse

### DIFF
--- a/examples/control_plane/task-lease-runtime-smoke.py
+++ b/examples/control_plane/task-lease-runtime-smoke.py
@@ -181,6 +181,7 @@ def main() -> int:
         assert first["ok"] is True and first["acquired"] is True, first
         assert first["lease"]["schema_version"] == "task_lease_v0", first
         assert first["lease"]["version"] == 1, first
+        assert first["lease"]["acquire_ttl_seconds"] == 120, first
 
         set_todo_status(state_file, todo_id=TODO_A, status="done")
         terminal_inspect = payload(
@@ -287,6 +288,29 @@ def main() -> int:
         )
         assert idempotent["ok"] is True and idempotent["idempotent"] is True, idempotent
         assert idempotent["lease"]["version"] == 1, idempotent
+
+        for retry_ttl, retry_scope in ((120, "docs/**"), (600, "loopx/**")):
+            changed_retry = cli(
+                registry_path,
+                "acquire",
+                "--goal-id",
+                GOAL_ID,
+                "--todo-id",
+                TODO_A,
+                "--owner",
+                "codex-main-control",
+                "--idempotency-key",
+                "turn-1",
+                "--ttl-seconds",
+                str(retry_ttl),
+                "--write-scope",
+                retry_scope,
+                check=False,
+            )
+            assert changed_retry.returncode == 1, changed_retry.stdout
+            assert payload(changed_retry)["error_code"] == "idempotency_key_reuse", (
+                changed_retry.stdout
+            )
 
         set_excluded_agents(
             state_file,

--- a/loopx/control_plane/work_items/task_lease.py
+++ b/loopx/control_plane/work_items/task_lease.py
@@ -413,6 +413,7 @@ def build_lease(
     owner: str,
     idempotency_key: str,
     write_scopes: list[str],
+    acquire_ttl_seconds: int,
     version: int,
     acquired_at: str,
     updated_at: str,
@@ -425,6 +426,7 @@ def build_lease(
         "owner": owner,
         "idempotency_key": idempotency_key,
         "write_scopes": write_scopes,
+        "acquire_ttl_seconds": acquire_ttl_seconds,
         "version": version,
         "acquired_at": acquired_at,
         "updated_at": updated_at,
@@ -478,6 +480,24 @@ def acquire_task_lease(
                 existing.get("owner") == owner
                 and existing.get("idempotency_key") == idempotency_key
             ):
+                existing_write_scopes = normalize_required_write_scopes(
+                    existing.get("write_scopes")
+                )
+                existing_ttl = existing.get("acquire_ttl_seconds")
+                request_matches = set(existing_write_scopes) == set(normalized_write_scopes)
+                if existing_ttl is not None:
+                    request_matches = request_matches and int(existing_ttl) == ttl
+                if not request_matches:
+                    raise TaskLeaseError(
+                        "idempotency key was reused with different acquire parameters",
+                        code="idempotency_key_reuse",
+                        payload={
+                            "lease": existing,
+                            "lease_path": str(lease_path),
+                            "requested_write_scopes": normalized_write_scopes,
+                            "requested_ttl_seconds": ttl,
+                        },
+                    )
                 return {
                     "ok": True,
                     "schema_version": TASK_LEASE_SCHEMA_VERSION,
@@ -514,6 +534,7 @@ def acquire_task_lease(
             owner=owner,
             idempotency_key=idempotency_key,
             write_scopes=normalized_write_scopes,
+            acquire_ttl_seconds=ttl,
             version=int((existing or {}).get("version") or 0) + 1,
             acquired_at=updated_at,
             updated_at=updated_at,


### PR DESCRIPTION
## Summary
- persist the original acquire TTL on new hard task leases
- treat acquire retries as idempotent only when write scopes and original TTL match
- reject a reused key with changed request semantics instead of returning a misleading success

## Compatibility
Existing lease files without `acquire_ttl_seconds` remain readable and keep scope-based retry compatibility. Renew, transfer, release, claim, quota, and todo lifecycle behavior are unchanged.

## Validation
- reproduced the previous false success with changed scope and TTL
- `uv run --no-project --with pytest --with pytest-cov pytest -q` (97 passed, 2 skipped)
- focused task-lease runtime smoke
- bounded-context, control-plane-risk, and Python line-budget smokes
- `loopx check` on both changed paths (0 errors, 0 warnings)
- `loopx canary premerge --from-git-diff` (standard tier, 14 selected, 0 failures, 0 manual holds)