### PR TITLE
Require open todo for soft claims

### DIFF
--- a/examples/control_plane/todo-cli-smoke.py
+++ b/examples/control_plane/todo-cli-smoke.py
@@ -125,7 +125,36 @@ def main() -> int:
         root = Path(tmp)
         registry_path, state_file = write_fixture(root)
         legacy_registry_path, _ = write_fixture(root / "legacy", register_agents=False)
+        claim_state_registry_path, _ = write_fixture(root / "claim-state")
         original = state_file.read_text(encoding="utf-8")
+
+        blocked_todo = run_cli(
+            claim_state_registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            "Reopen blocked work before assigning a new soft owner.",
+            "--status",
+            "blocked",
+            "--task-class",
+            "advancement_task",
+        )
+        blocked_claim = run_cli_error(
+            claim_state_registry_path,
+            "todo",
+            "claim",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            blocked_todo["todo_id"],
+            "--claimed-by",
+            "codex-main-control",
+        )
+        assert "todo claim requires status=open" in blocked_claim["error"], blocked_claim
 
         bare_user_error = run_cli_error(
             registry_path,

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -1086,6 +1086,11 @@ def apply_todo_update_to_lines(
     if status and not normalized_status:
         raise ValueError("todo status must be one of: open, done, blocked, deferred")
     target_status = normalized_status or str(block.get("status") or TODO_STATUS_OPEN)
+    if claim_only and target_status != TODO_STATUS_OPEN:
+        raise ValueError(
+            f"todo claim requires status=open; todo_id {normalized_todo_id!r} "
+            f"is status={target_status!r}"
+        )
     status_changed = False
     if normalized_status:
         status_changed = set_todo_marker(lines, block, normalized_status)


### PR DESCRIPTION
## Summary
- enforce the documented `Open -> Claimed` transition in the canonical todo update seam
- reject dedicated `todo claim` writes for blocked, deferred, or done todos
- preserve ordinary lifecycle updates and existing claim ownership

## Root cause
The claim-only path checked agent registration and conflicting owners but did not check the todo lifecycle state, so a blocked todo could receive a new `claimed_by` owner and return `ok=true`.

## Validation
- reproduced blocked todo claim false success through the CLI
- `uv run --no-project --with pytest --with pytest-cov pytest -q` (97 passed, 2 skipped)
- focused todo CLI smoke
- bounded-context, control-plane-risk, and Python line-budget smokes
- `loopx check` on both changed paths (0 errors, 0 warnings)
- `loopx canary premerge --from-git-diff` (standard tier, 17 selected, 0 failures, 0 manual holds)