### PR TITLE
Fix rollout event occurrence identity

### DIFF
--- a/examples/project/goal-rollout-event-log-smoke.py
+++ b/examples/project/goal-rollout-event-log-smoke.py
@@ -133,6 +133,38 @@ def main() -> None:
         runtime_root = tmp_root / "runtime"
         goal_id = "loopx-meta"
         log_path = rollout_event_log_path(runtime_root, goal_id)
+        identity_log_path = tmp_root / "rollout-event-identity.jsonl"
+        first_occurrence = build_rollout_event(
+            goal_id=goal_id,
+            event_kind="validation",
+            status="passed",
+            summary="Focused validation passed.",
+            recorded_at="2026-07-12T00:00:00Z",
+        )
+        append_rollout_event(identity_log_path, first_occurrence)
+        replayed = append_rollout_event(identity_log_path, dict(first_occurrence))
+        assert replayed == first_occurrence, replayed
+        assert len(load_rollout_events(identity_log_path)) == 1
+        later_occurrence = build_rollout_event(
+            goal_id=goal_id,
+            event_kind="validation",
+            status="passed",
+            summary="Focused validation passed.",
+            recorded_at="2026-07-12T00:01:00Z",
+        )
+        assert later_occurrence["event_id"] != first_occurrence["event_id"]
+        append_rollout_event(identity_log_path, later_occurrence)
+        assert len(load_rollout_events(identity_log_path)) == 2
+        conflicting = dict(first_occurrence)
+        conflicting["summary"] = "Conflicting content must not reuse an event id."
+        try:
+            append_rollout_event(identity_log_path, conflicting)
+        except ValueError as exc:
+            assert "conflicting rollout event_id" in str(exc), exc
+        else:
+            raise AssertionError("conflicting rollout event_id was appended")
+        assert len(load_rollout_events(identity_log_path)) == 2
+
         event = build_rollout_event(
             goal_id=goal_id,
             event_kind="quota_should_run",

--- a/loopx/rollout_event_log.py
+++ b/loopx/rollout_event_log.py
@@ -7,6 +7,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
 
+from .file_lock import exclusive_file_lock
+
 
 ROLLOUT_EVENT_SCHEMA_VERSION = "loopx_rollout_event_v0"
 ROLLOUT_EVENT_SUMMARY_SCHEMA_VERSION = "loopx_rollout_event_summary_v0"
@@ -79,9 +81,7 @@ RAW_KEY_HINTS = (
 
 
 def _now_iso() -> str:
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace(
-        "+00:00", "Z"
-    )
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def _compact_text(value: Any, *, limit: int = 500, field: str = "value") -> str | None:
@@ -171,13 +171,19 @@ def _normalized_event_kind(event_kind: str) -> str:
 
 
 def _event_id(payload: Mapping[str, Any]) -> str:
+    """Identify one event occurrence, including its observation timestamp."""
+
     stable = {
         key: value
         for key, value in payload.items()
-        if key not in {"event_id", "recorded_at"}
+        if key != "event_id"
     }
     encoded = json.dumps(stable, sort_keys=True, ensure_ascii=True).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()[:16]
+
+
+def _idempotency_body(payload: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in payload.items() if key != "event_id"}
 
 
 def rollout_event_log_path(runtime_root: Path, goal_id: str) -> Path:
@@ -358,12 +364,31 @@ def build_rollout_event(
 
 
 def append_rollout_event(log_path: Path, event: Mapping[str, Any]) -> dict[str, Any]:
+    """Append once by event id, preserving distinct timestamped observations."""
+
     payload = dict(event)
     if payload.get("schema_version") != ROLLOUT_EVENT_SCHEMA_VERSION:
         raise ValueError("unsupported rollout event schema")
+    event_id = str(payload.get("event_id") or "").strip()
+    if not event_id:
+        raise ValueError("rollout event_id is required")
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    with log_path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(payload, sort_keys=True, ensure_ascii=False) + "\n")
+    with exclusive_file_lock(log_path):
+        with log_path.open("a+", encoding="utf-8") as handle:
+            handle.seek(0)
+            for line in handle:
+                if event_id not in line:
+                    continue
+                try:
+                    existing = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(existing, dict) or existing.get("event_id") != event_id:
+                    continue
+                if _idempotency_body(existing) == _idempotency_body(payload):
+                    return existing
+                raise ValueError(f"conflicting rollout event_id: {event_id}")
+            handle.write(json.dumps(payload, sort_keys=True, ensure_ascii=False) + "\n")
     return payload
 
 


### PR DESCRIPTION
## Summary

- include `recorded_at` in deterministic rollout event identity so repeated observations at different times remain distinct audit events
- make the shared append boundary idempotent for exact event replay and fail closed on conflicting `event_id` reuse under the existing file lock
- add focused coverage for exact replay, later equivalent observations, and conflicting reuse

## Design boundary

Raw rollout history keeps distinct timestamped observations. Agent-facing trajectory compaction remains a projection concern; this change does not silently collapse or delete audit events.

## Validation

- `python3 examples/project/goal-rollout-event-log-smoke.py`
- `python3 examples/issue-fix-pr-lifecycle-smoke.py`
- `python -m ruff check ...`
- `python -m mypy`
- `python -m pytest -q -n 2 --cov=loopx --cov-report=term --cov-fail-under=19.6` (97 passed, 2 skipped; 20.31%)
- `loopx canary premerge --from-git-diff` (17/17 selected checks passed; no warnings or manual holds)
- public boundary scan clean

## Risk

Low and localized to rollout-event identity/append semantics. Existing explicit timestamps remain deterministic for retry idempotency; generated timestamps now retain microseconds to avoid same-second occurrence collisions.