### PR TITLE
Prevent task leases from stealing soft claims

### DIFF
--- a/examples/control_plane/task-lease-runtime-smoke.py
+++ b/examples/control_plane/task-lease-runtime-smoke.py
@@ -90,6 +90,20 @@ def set_excluded_agents(state_file: Path, *, todo_id: str, agents: list[str]) ->
     raise AssertionError(f"todo metadata not found: {todo_id}")
 
 
+def set_claimed_by(state_file: Path, *, todo_id: str, owner: str | None) -> None:
+    lines = state_file.read_text(encoding="utf-8").splitlines()
+    for index, line in enumerate(lines):
+        if f"todo_id={todo_id}" not in line:
+            continue
+        line = re.sub(r"\s+claimed_by=[^\s<>]+", "", line)
+        if owner:
+            line = line.replace(" -->", f" claimed_by={owner} -->")
+        lines[index] = line
+        state_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return
+    raise AssertionError(f"todo metadata not found: {todo_id}")
+
+
 def set_todo_status(state_file: Path, *, todo_id: str, status: str) -> None:
     lines = state_file.read_text(encoding="utf-8").splitlines()
     for index, line in enumerate(lines):
@@ -160,6 +174,11 @@ def main() -> int:
     with tempfile.TemporaryDirectory(prefix="loopx-task-lease-smoke-") as tmp:
         registry_path, state_file = write_fixture(Path(tmp))
 
+        set_claimed_by(
+            state_file,
+            todo_id=TODO_A,
+            owner="codex-main-control",
+        )
         first = payload(
             cli(
                 registry_path,
@@ -182,6 +201,27 @@ def main() -> int:
         assert first["lease"]["schema_version"] == "task_lease_v0", first
         assert first["lease"]["version"] == 1, first
         assert first["lease"]["acquire_ttl_seconds"] == 120, first
+
+        set_claimed_by(
+            state_file,
+            todo_id=TODO_A,
+            owner="codex-side-bypass",
+        )
+        claim_conflict_inspect = payload(
+            cli(registry_path, "inspect", "--goal-id", GOAL_ID, "--todo-id", TODO_A)
+        )
+        assert claim_conflict_inspect["active"] is False, claim_conflict_inspect
+        assert claim_conflict_inspect["executor_constraint"]["reason"] == (
+            "owner_conflicts_with_claim"
+        ), claim_conflict_inspect
+        assert claim_conflict_inspect["executor_constraint"]["claimed_by"] == (
+            "codex-side-bypass"
+        ), claim_conflict_inspect
+        set_claimed_by(
+            state_file,
+            todo_id=TODO_A,
+            owner="codex-main-control",
+        )
 
         set_todo_status(state_file, todo_id=TODO_A, status="done")
         terminal_inspect = payload(
@@ -468,6 +508,30 @@ def main() -> int:
         )
 
         set_excluded_agents(state_file, todo_id=TODO_A, agents=[])
+        claim_blocked_transfer = cli(
+            registry_path,
+            "transfer",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            TODO_A,
+            "--owner",
+            "codex-main-control",
+            "--idempotency-key",
+            "turn-1",
+            "--new-owner",
+            "codex-side-bypass",
+            "--new-idempotency-key",
+            "side-transfer",
+            "--expected-version",
+            "2",
+            check=False,
+        )
+        assert claim_blocked_transfer.returncode == 1, claim_blocked_transfer.stdout
+        assert payload(claim_blocked_transfer)["error_code"] == (
+            "owner_conflicts_with_claim"
+        )
+        set_claimed_by(state_file, todo_id=TODO_A, owner=None)
         transferred = payload(
             cli(
                 registry_path,

--- a/loopx/control_plane/work_items/task_lease.py
+++ b/loopx/control_plane/work_items/task_lease.py
@@ -159,6 +159,13 @@ def task_lease_owner_constraint(
             "reason": "owner_excluded_from_todo",
             "excluded_agents": excluded_agents,
         }
+    claimed_by = normalize_todo_claimed_by(todo.get("claimed_by"))
+    if claimed_by and claimed_by != normalized_owner:
+        return {
+            "effective": False,
+            "reason": "owner_conflicts_with_claim",
+            "claimed_by": claimed_by,
+        }
     return {"effective": True}
 
 
@@ -218,6 +225,11 @@ def require_task_lease_owner_allowed(
             )
         elif reason == "owner_excluded_from_todo":
             message = f"task lease owner {owner!r} is excluded from todo {todo_id!r}"
+        elif reason == "owner_conflicts_with_claim":
+            message = (
+                f"task lease owner {owner!r} conflicts with todo claim "
+                f"{constraint.get('claimed_by')!r}"
+            )
         elif reason == "owner_not_registered":
             message = f"task lease owner {owner!r} is not registered for goal {goal_id!r}"
         else:


### PR DESCRIPTION
## Summary

- make optional hard-lease ownership respect an existing todo `claimed_by`
- mark legacy active leases ineffective when their owner conflicts with the current soft claim
- fail closed for acquire/renew/transfer through the shared owner constraint
- cover matching claim acquisition, conflicting active-lease inspection, and blocked transfer

## Product boundary

This does not make task leases mandatory or add lease enforcement to `quota should-run`. `claimed_by` remains the default soft route; the opt-in hard lease can only strengthen that ownership, not silently contradict it.

## Validation

- `python3 examples/control_plane/task-lease-runtime-smoke.py`
- ruff and mypy passed
- pytest: 97 passed, 2 skipped; 20.31% coverage
- premerge canary: 14/14 selected checks passed, no warnings or manual holds
- public boundary scan clean

## Risk

Localized fail-closed behavior change for callers that previously acquired or transferred a lease to an agent different from the todo soft claim. Such callers must explicitly clear or transfer the claim first.