### PR TITLE
feat(agents): route quota with advisory profiles

### DIFF
--- a/docs/product/agent-profile-contract.md
+++ b/docs/product/agent-profile-contract.md
@@ -55,6 +55,19 @@ claim or lease.
 }
 ```
 
+Profiles are written through the same validated registry path as other goal
+coordination settings:
+
+```bash
+loopx configure-goal --goal-id <goal-id> \
+  --agent-profile-json '{"schema_version":"agent_profile_v1","agent_id":"codex-runtime","profile_role":"runtime-validation","preferred_action_kinds":["runtime_*"]}' \
+  --execute
+```
+
+Use `--clear-agent-profile <agent-id>` to remove one profile. The command
+rejects unregistered peers, unknown fields, hierarchy roles, invalid task
+classes, and unsafe action-kind globs before writing the registry.
+
 `profile_role` is a human-readable functional label. It is advisory and must
 not use hierarchy labels such as `primary-agent` or `side-agent`.
 
@@ -97,6 +110,11 @@ Profile-backed selection may:
 3. avoid mismatched action kinds when another eligible peer or unclaimed task
    is available;
 4. project a concrete reassignment request when only other-peer claims remain.
+
+The preference rank is applied inside the existing claim bucket. A current
+peer claim remains ahead of an unclaimed todo even when the unclaimed todo is a
+better profile match. An explicit active-next todo also keeps its existing
+route. Without a valid profile, candidate ordering is unchanged.
 
 Selection must then enforce capability gates, task leases, workspace guards,
 write scope, and continuation policy. A profile preference never transfers a

--- a/examples/control_plane/agent-identity-readmodel-smoke.py
+++ b/examples/control_plane/agent-identity-readmodel-smoke.py
@@ -38,7 +38,6 @@ def legacy_goal() -> dict:
     goal = peer_goal()
     goal["coordination"].update(
         {
-            "agent_model": "legacy_hierarchy",
             "agent_model": "peer_v1",
             "side_agent_handoff_agent": AGENTS[2],
         }
@@ -62,6 +61,30 @@ def assert_peer_identity_has_no_rank() -> None:
         goal_id="sample-goal",
         agent_identity=identity,
     ) is None
+
+
+def assert_peer_identity_projects_only_valid_advisory_profile() -> None:
+    goal = peer_goal()
+    profile = {
+        "schema_version": "agent_profile_v1",
+        "agent_id": AGENTS[1],
+        "profile_role": "runtime-validation",
+        "scope_summary": "Runtime checks and focused control-plane repairs.",
+        "default_task_classes": ["advancement_task"],
+        "preferred_action_kinds": ["runtime_*"],
+        "avoid_action_kinds": ["production_*"],
+    }
+    goal["coordination"]["agent_profiles"] = {AGENTS[1]: profile}
+    identity = build_quota_agent_identity(goal, agent_id=AGENTS[1])
+    assert identity is not None
+    assert identity["agent_profile"] == profile, identity
+
+    goal["coordination"]["agent_profiles"][AGENTS[1]]["profile_role"] = (
+        "primary-agent"
+    )
+    invalid_identity = build_quota_agent_identity(goal, agent_id=AGENTS[1])
+    assert invalid_identity is not None
+    assert "agent_profile" not in invalid_identity, invalid_identity
 
 
 def assert_legacy_state_only_projects_migration() -> None:
@@ -112,6 +135,7 @@ def assert_errors_are_actionable() -> None:
 
 def main() -> None:
     assert_peer_identity_has_no_rank()
+    assert_peer_identity_projects_only_valid_advisory_profile()
     assert_legacy_state_only_projects_migration()
     assert_assignment_is_deterministic()
     assert_errors_are_actionable()

--- a/examples/control_plane/todo-claim-visibility-lanes-smoke.py
+++ b/examples/control_plane/todo-claim-visibility-lanes-smoke.py
@@ -11,6 +11,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from loopx.control_plane.agents.capability_gate import (  # noqa: E402
+    _agent_lane_candidate_sort_key,
+)
 from loopx.control_plane.todos.claim_visibility import (  # noqa: E402
     TODO_AGENT_CLAIM_SCOPE_SCHEMA_VERSION,
     build_agent_claim_scoped_open_items,
@@ -33,6 +36,7 @@ def todo(
     text: str,
     task_class: str,
     claimed_by: str | None = None,
+    action_kind: str | None = None,
     continuation_policy: str | None = None,
     removed_continuation_policy: str | None = None,
     blocks_agent: str | None = None,
@@ -45,6 +49,7 @@ def todo(
         "status": "open",
         "task_class": task_class,
         "claimed_by": claimed_by,
+        "action_kind": action_kind,
         "continuation_policy": continuation_policy,
         "removed_continuation_policy": removed_continuation_policy,
         "blocks_agent": blocks_agent,
@@ -111,6 +116,116 @@ def assert_agent_claim_scope_prefers_current_then_unclaimed() -> None:
     assert claim_scope["other_agent_claimed_weight"] == "diagnostic_only"
     assert claim_scope["other_agent_claimed_items"][0]["todo_id"] == "todo_other_p0"
     assert claim_scope["blocked_claimed_items"][0]["todo_id"] == "todo_other_p0"
+
+
+def assert_agent_profile_ranks_only_within_claim_buckets() -> None:
+    current_avoided = todo(
+        "todo_current_avoided",
+        index=1,
+        text="[P0] Current claimed but usually avoided.",
+        task_class="advancement_task",
+        action_kind="docs_cleanup",
+        claimed_by=CURRENT_AGENT,
+    )
+    current_preferred = todo(
+        "todo_current_preferred",
+        index=2,
+        text="[P2] Current claimed and preferred.",
+        task_class="advancement_task",
+        action_kind="task_lease_repair",
+        claimed_by=CURRENT_AGENT,
+    )
+    unclaimed_preferred = todo(
+        "todo_unclaimed_preferred",
+        index=3,
+        text="[P2] Unclaimed and preferred.",
+        task_class="advancement_task",
+        action_kind="todo_claim_projection",
+    )
+    unclaimed_neutral = todo(
+        "todo_unclaimed_neutral",
+        index=4,
+        text="[P0] Unclaimed and neutral.",
+        task_class="advancement_task",
+        action_kind="runtime_cleanup",
+    )
+    unclaimed_avoided = todo(
+        "todo_unclaimed_avoided",
+        index=5,
+        text="[P0] Unclaimed and avoided.",
+        task_class="advancement_task",
+        action_kind="docs_rewrite",
+    )
+    profile = {
+        "schema_version": "agent_profile_v1",
+        "agent_id": CURRENT_AGENT,
+        "preferred_action_kinds": ["task_lease_*", "todo_claim_*"],
+        "avoid_action_kinds": ["docs_*"],
+    }
+    identity = {
+        "agent_id": CURRENT_AGENT,
+        "agent_model": "peer_v1",
+        "agent_profile": profile,
+    }
+    selectable, claim_scope = build_agent_claim_scoped_open_items(
+        [
+            unclaimed_avoided,
+            unclaimed_neutral,
+            current_avoided,
+            unclaimed_preferred,
+            current_preferred,
+        ],
+        agent_identity=identity,
+        diagnostic_item_limit=3,
+    )
+    assert [item["todo_id"] for item in selectable] == [
+        "todo_current_preferred",
+        "todo_current_avoided",
+        "todo_unclaimed_preferred",
+        "todo_unclaimed_neutral",
+        "todo_unclaimed_avoided",
+    ], selectable
+    assert claim_scope is not None
+    assert claim_scope["profile_routing"]["within_claim_bucket_only"] is True
+
+    coordination = {
+        "agent_model": "peer_v1",
+        "registered_agents": [CURRENT_AGENT, OTHER_AGENT],
+        "agent_profiles": {CURRENT_AGENT: profile},
+    }
+    quota_items = [dict(current_avoided), dict(current_preferred)]
+    for item in quota_items:
+        item.pop("required_write_scopes", None)
+    quota = build_quota_should_run(
+        status_payload(
+            status="agent_profile_advisory_routing",
+            next_action=current_avoided["text"],
+            coordination=coordination,
+            agent_todo_items=quota_items,
+        ),
+        goal_id=GOAL_ID,
+        agent_id=CURRENT_AGENT,
+    )
+    assert quota["agent_identity"]["agent_profile"] == profile, quota
+    assert quota["agent_lane_next_action"]["todo_id"] == (
+        "todo_current_preferred"
+    ), quota
+    assert quota["agent_lane_next_action"]["selected_by"] == (
+        "current_agent_claimed_todo"
+    ), quota
+    active_avoided_key = _agent_lane_candidate_sort_key(
+        current_avoided,
+        agent_id=CURRENT_AGENT,
+        preferred_todo_ids={"todo_current_avoided"},
+        agent_profile=profile,
+    )
+    preferred_key = _agent_lane_candidate_sort_key(
+        current_preferred,
+        agent_id=CURRENT_AGENT,
+        preferred_todo_ids={"todo_current_avoided"},
+        agent_profile=profile,
+    )
+    assert active_avoided_key < preferred_key
 
 
 def assert_executor_exclusion_filters_only_the_named_peer() -> None:
@@ -390,6 +505,7 @@ def assert_claim_visibility_lanes_split_current_other_and_task_class() -> None:
 
 def main() -> int:
     assert_agent_claim_scope_prefers_current_then_unclaimed()
+    assert_agent_profile_ranks_only_within_claim_buckets()
     assert_executor_exclusion_filters_only_the_named_peer()
     assert_quota_routes_unclaimed_handoff_to_an_eligible_peer()
     assert_legacy_review_handoff_fails_closed_until_repaired()

--- a/examples/project/configure-goal-smoke.py
+++ b/examples/project/configure-goal-smoke.py
@@ -95,6 +95,16 @@ def main() -> int:
         root = Path(tmp)
         registry_path = write_registry(root)
         original = registry_path.read_text(encoding="utf-8")
+        agent_profile = {
+            "schema_version": "agent_profile_v1",
+            "agent_id": "codex-side-bypass",
+            "profile_role": "runtime-validation",
+            "scope_summary": "Focused runtime validation and peer claim repairs.",
+            "default_task_classes": ["advancement_task"],
+            "preferred_action_kinds": ["todo_claim_*", "task_lease_*"],
+            "avoid_action_kinds": ["production_*"],
+        }
+        agent_profile_json = json.dumps(agent_profile)
 
         dry = payload(run_cli(
             registry_path,
@@ -120,6 +130,8 @@ def main() -> int:
             "codex-side-bypass,codex-main-control",
             "--agent-model",
             "peer_v1",
+            "--agent-profile-json",
+            agent_profile_json,
             "--write-scope",
             "docs/**",
             "--write-scope",
@@ -188,6 +200,8 @@ def main() -> int:
             "codex-main-control,codex-side-bypass",
             "--agent-model",
             "peer_v1",
+            "--agent-profile-json",
+            agent_profile_json,
             "--write-scope",
             "docs/**,tests/**",
             "--waiting-on",
@@ -218,6 +232,9 @@ def main() -> int:
         assert goal["spawn_policy"]["allowed_domains"] == ["docs", "validation"], goal
         assert goal["coordination"]["registered_agents"] == ["codex-main-control", "codex-side-bypass"], goal
         assert goal["coordination"]["agent_model"] == "peer_v1", goal
+        assert goal["coordination"]["agent_profiles"] == {
+            "codex-side-bypass": agent_profile,
+        }, goal
         assert goal["coordination"]["write_scope"] == ["docs/**", "tests/**"], goal
         assert goal["waiting_on"] == "user_or_controller", goal
         reviewer_policy = goal["control_plane"]["issue_fix"][
@@ -326,6 +343,48 @@ def main() -> int:
         assert authority_cleared["changed"] is True, authority_cleared
         assert "checkpointed_boundary_authority" in authority_cleared["changed_fields"], authority_cleared
         assert "checkpointed_boundary_authority" not in goal_from_registry(registry_path)["coordination"], authority_cleared
+
+        invalid_profile = dict(agent_profile, profile_role="primary-agent")
+        invalid_profile_result = payload(run_cli(
+            registry_path,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-profile-json",
+            json.dumps(invalid_profile),
+            check=False,
+        ))
+        assert invalid_profile_result["ok"] is False, invalid_profile_result
+        assert "hierarchy role" in invalid_profile_result["error"], invalid_profile_result
+
+        private_profile = dict(
+            agent_profile,
+            scope_summary="Read /Users/example/private-state before routing.",
+        )
+        private_profile_result = payload(run_cli(
+            registry_path,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-profile-json",
+            json.dumps(private_profile),
+            check=False,
+        ))
+        assert private_profile_result["ok"] is False, private_profile_result
+        assert "public-safe" in private_profile_result["error"], private_profile_result
+
+        profile_cleared = payload(run_cli(
+            registry_path,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--clear-agent-profile",
+            "codex-side-bypass",
+            "--execute",
+        ))
+        assert profile_cleared["ok"] is True, profile_cleared
+        assert "agent_profiles" in profile_cleared["changed_fields"], profile_cleared
+        assert "agent_profiles" not in goal_from_registry(registry_path)["coordination"]
 
         agents_cleared = payload(run_cli(
             registry_path,

--- a/loopx/cli_commands/registry_admin.py
+++ b/loopx/cli_commands/registry_admin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 from collections.abc import Callable
 from pathlib import Path
 
@@ -313,6 +314,23 @@ def register_registry_admin_commands(subparsers: argparse._SubParsersAction) -> 
         action="store_true",
         help="Clear coordination.registered_agents.",
     )
+    configure_goal_parser.add_argument(
+        "--agent-profile-json",
+        dest="agent_profile_jsons",
+        action="append",
+        default=None,
+        help=(
+            "Validated agent_profile_v1 JSON object for a registered peer. "
+            "Repeatable; writes advisory task routing hints only."
+        ),
+    )
+    configure_goal_parser.add_argument(
+        "--clear-agent-profile",
+        dest="clear_agent_profiles",
+        action="append",
+        default=None,
+        help="Registered agent id whose advisory profile should be removed. Repeatable.",
+    )
     register_peer_runtime_arguments(configure_goal_parser)
     register_peer_supervisor_arguments(configure_goal_parser)
     configure_goal_parser.add_argument(
@@ -545,6 +563,10 @@ def handle_registry_admin_command(
 
     if args.command == "configure-goal":
         try:
+            agent_profiles = [
+                json.loads(raw_profile)
+                for raw_profile in (args.agent_profile_jsons or [])
+            ]
             payload = configure_goal(
                 registry_path=registry_path,
                 goal_id=args.goal_id,
@@ -564,6 +586,8 @@ def handle_registry_admin_command(
                 clear_explore_harness_profile=bool(args.clear_explore_harness_profile),
                 registered_agents=args.registered_agents,
                 clear_registered_agents=bool(args.clear_registered_agents),
+                agent_profiles=agent_profiles,
+                clear_agent_profiles=args.clear_agent_profiles,
                 agent_model=args.agent_model,
                 automation_prompt_migration_ack=args.ack_automation_prompt_migration,
                 supervisor_agent=args.supervisor_agent,

--- a/loopx/configure_goal.py
+++ b/loopx/configure_goal.py
@@ -5,6 +5,7 @@ import os
 import shlex
 import shutil
 import tempfile
+from collections.abc import Mapping
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path, PurePosixPath
@@ -33,6 +34,7 @@ from .control_plane.agents.legacy_migration import (
     peer_agent_runtime_migration_completed,
     peer_agent_runtime_migration_id,
 )
+from .control_plane.agents.profile import normalize_agent_profile
 from .control_plane.agents.runtime_model import (
     AgentRuntimeModel,
     agent_runtime_model_for_goal,
@@ -175,6 +177,11 @@ def _settings_summary(goal: dict[str, Any]) -> dict[str, Any]:
         "write_scope": _clean_write_scope(coordination.get("write_scope") or []) or [],
         "checkpointed_boundary_authority": checkpointed_boundary_authority_summary(coordination),
         "registered_agents": normalize_registered_agents(coordination.get("registered_agents")),
+        "agent_profiles": deepcopy(
+            coordination.get("agent_profiles")
+            if isinstance(coordination.get("agent_profiles"), dict)
+            else {}
+        ),
         "agent_model": agent_model.value,
         "configured_agent_model": coordination.get("agent_model"),
         "legacy_hierarchy_present": legacy_agent_hierarchy_present(goal),
@@ -354,6 +361,8 @@ def configure_goal(
     clear_explore_harness_profile: bool = False,
     registered_agents: list[str] | None = None,
     clear_registered_agents: bool = False,
+    agent_profiles: list[dict[str, Any]] | None = None,
+    clear_agent_profiles: list[str] | None = None,
     agent_model: str | None = None,
     automation_prompt_migration_ack: str | None = None,
     supervisor_agent: str | None = None,
@@ -461,6 +470,7 @@ def configure_goal(
         if allowed_domains:
             raise ValueError("--multi-subagent-feature off cannot be combined with --allowed-domain")
     registered_agents = _clean_registered_agents(registered_agents)
+    clear_agent_profiles = _clean_registered_agents(clear_agent_profiles)
     supervised_agents = _clean_registered_agents(supervised_agents)
     write_scope = _clean_write_scope(write_scope)
     issue_fix_reviewer_notification_config = _local_private_config_path(
@@ -472,6 +482,39 @@ def configure_goal(
     goal = next((item for item in goals if str(item.get("id")) == goal_id), None)
     if goal is None:
         raise ValueError(f"goal_id not found in registry: {goal_id}")
+
+    existing_coordination = (
+        goal.get("coordination")
+        if isinstance(goal.get("coordination"), dict)
+        else {}
+    )
+    effective_registered_agents = (
+        []
+        if clear_registered_agents
+        else registered_agents
+        if registered_agents is not None
+        else normalize_registered_agents(existing_coordination.get("registered_agents"))
+    )
+    normalized_agent_profiles: dict[str, dict[str, Any]] = {}
+    for raw_profile in agent_profiles or []:
+        if not isinstance(raw_profile, Mapping):
+            raise ValueError("--agent-profile-json must contain a JSON object")
+        profile = normalize_agent_profile(
+            raw_profile,
+            registered_agents=effective_registered_agents,
+        )
+        profile_agent_id = str(profile["agent_id"])
+        if profile_agent_id in normalized_agent_profiles:
+            raise ValueError(f"duplicate agent profile for {profile_agent_id}")
+        normalized_agent_profiles[profile_agent_id] = profile
+    profile_conflicts = sorted(
+        set(normalized_agent_profiles) & set(clear_agent_profiles or [])
+    )
+    if profile_conflicts:
+        raise ValueError(
+            "cannot write and clear the same agent profile: "
+            + ", ".join(profile_conflicts)
+        )
 
     before_goal = deepcopy(goal)
     before = _settings_summary(before_goal)
@@ -628,6 +671,8 @@ def configure_goal(
     if (
         clear_registered_agents
         or registered_agents is not None
+        or normalized_agent_profiles
+        or clear_agent_profiles
         or agent_model is not None
         or automation_prompt_migration_ack is not None
         or supervisor_agent is not None
@@ -643,11 +688,41 @@ def configure_goal(
         if clear_registered_agents:
             coordination.pop("registered_agents", None)
             coordination.pop("agent_model", None)
+            coordination.pop("agent_profiles", None)
             coordination.pop("supervisor", None)
         elif registered_agents is not None:
             coordination["registered_agents"] = registered_agents
+            existing_profiles = (
+                coordination.get("agent_profiles")
+                if isinstance(coordination.get("agent_profiles"), dict)
+                else {}
+            )
+            retained_profiles = {
+                agent: profile
+                for agent, profile in existing_profiles.items()
+                if agent in registered_agents
+            }
+            if retained_profiles:
+                coordination["agent_profiles"] = retained_profiles
+            else:
+                coordination.pop("agent_profiles", None)
         if not clear_registered_agents:
             coordination["agent_model"] = effective_agent_model
+        if not clear_registered_agents and (
+            normalized_agent_profiles or clear_agent_profiles
+        ):
+            profiles = (
+                dict(coordination.get("agent_profiles"))
+                if isinstance(coordination.get("agent_profiles"), dict)
+                else {}
+            )
+            for profile_agent_id in clear_agent_profiles or []:
+                profiles.pop(profile_agent_id, None)
+            profiles.update(normalized_agent_profiles)
+            if profiles:
+                coordination["agent_profiles"] = profiles
+            else:
+                coordination.pop("agent_profiles", None)
         if automation_prompt_migration_ack is not None and not migration_already_completed:
             coordination = migrate_coordination_to_peer_v1(
                 coordination,

--- a/loopx/control_plane/agents/agent_lane_recommendation.py
+++ b/loopx/control_plane/agents/agent_lane_recommendation.py
@@ -213,6 +213,11 @@ def build_agent_lane_next_action(
     agent_id = normalize_todo_claimed_by(agent_identity.get("agent_id"))
     if not agent_id or not isinstance(agent_todo_summary, dict):
         return None
+    agent_profile = (
+        agent_identity.get("agent_profile")
+        if isinstance(agent_identity.get("agent_profile"), dict)
+        else None
+    )
 
     if isinstance(scoped_user_gate_fallback, dict):
         selected = scoped_user_gate_fallback.get("selected_executable")
@@ -331,6 +336,7 @@ def build_agent_lane_next_action(
                 candidate,
                 agent_id=agent_id,
                 preferred_todo_ids=preferred_todo_ids,
+                agent_profile=agent_profile,
             ),
         ):
             text = protocol_action_text(raw_item.get("text"), limit=500)

--- a/loopx/control_plane/agents/capability_gate.py
+++ b/loopx/control_plane/agents/capability_gate.py
@@ -16,6 +16,7 @@ from ..todos.projection import (
 )
 from ..todos.summary_item import compact_todo_summary_item
 from .agent_scope import agent_scope_item_claimed_by
+from .profile import agent_profile_candidate_rank
 
 
 CAPABILITY_GATE_SCHEMA_VERSION = "capability_gate_v0"
@@ -141,7 +142,8 @@ def _agent_lane_candidate_sort_key(
     *,
     agent_id: str | None,
     preferred_todo_ids: set[str] | None = None,
-) -> tuple[int, int, int, int, int]:
+    agent_profile: dict[str, Any] | None = None,
+) -> tuple[int, int, int, int, int, int]:
     preferred_todo_ids = preferred_todo_ids or set()
     todo_id = str(raw_item.get("todo_id") or "").strip()
     active_next_rank = 0 if todo_id and todo_id in preferred_todo_ids else 1
@@ -151,6 +153,7 @@ def _agent_lane_candidate_sort_key(
     return (
         active_next_rank,
         claim_rank,
+        agent_profile_candidate_rank(raw_item, agent_profile=agent_profile),
         todo_priority_rank(raw_item),
         repair_rank,
         todo_index_rank(raw_item),
@@ -167,13 +170,23 @@ def _sort_capability_runnable_candidates(
     agent_id = normalize_todo_claimed_by(agent_identity.get("agent_id"))
     if not agent_id:
         return runnable, None
-    policy = "active_next_then_claim_then_priority_then_repair"
+    agent_profile = (
+        agent_identity.get("agent_profile")
+        if isinstance(agent_identity.get("agent_profile"), dict)
+        else None
+    )
+    policy = (
+        "active_next_then_claim_then_profile_then_priority_then_repair"
+        if agent_profile
+        else "active_next_then_claim_then_priority_then_repair"
+    )
     return (
         sorted(
             runnable,
             key=lambda item: _agent_lane_candidate_sort_key(
                 item,
                 agent_id=agent_id,
+                agent_profile=agent_profile,
             ),
         ),
         policy,

--- a/loopx/control_plane/agents/identity.py
+++ b/loopx/control_plane/agents/identity.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from typing import Any
 
-from ...agent_registry import registered_agent_ids_for_goal
+from ...agent_registry import agent_profile_for_goal, registered_agent_ids_for_goal
 from ..todos.contract import normalize_todo_claimed_by
 from .legacy_migration import (
     legacy_agent_hierarchy_present,
     peer_agent_runtime_migration_completed,
     peer_agent_runtime_migration_id,
 )
+from .profile import normalize_agent_profile
 from .runtime_model import PEER_AGENT_IDENTITY_SCHEMA_VERSION, agent_runtime_model_for_goal
 
 
@@ -38,13 +39,26 @@ def build_quota_agent_identity(
             f"registered_agents={', '.join(registered_agents)}"
         )
     runtime_model = agent_runtime_model_for_goal(goal)
-    return {
+    identity = {
         "schema_version": PEER_AGENT_IDENTITY_SCHEMA_VERSION,
         "agent_model": runtime_model.value,
         "agent_id": normalized_agent_id,
         "registered": True,
         "registered_agents": registered_agents,
     }
+    raw_profile = agent_profile_for_goal(goal, normalized_agent_id)
+    if raw_profile:
+        try:
+            identity["agent_profile"] = normalize_agent_profile(
+                raw_profile,
+                registered_agents=registered_agents,
+                expected_agent_id=normalized_agent_id,
+                reject_unknown_fields=False,
+            )
+        except ValueError:
+            # Advisory metadata must not block an otherwise valid peer identity.
+            pass
+    return identity
 
 
 def build_identity_aware_prompt_upgrade(

--- a/loopx/control_plane/agents/profile.py
+++ b/loopx/control_plane/agents/profile.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import re
+from fnmatch import fnmatchcase
+from typing import Any, Mapping
+
+from ..runtime.public_safety import public_safe_compact_text
+from ..todos.contract import (
+    TODO_TASK_CLASS_VALUES,
+    normalize_todo_action_kind,
+)
+from .runtime_model import PEER_AGENT_PROFILE_SCHEMA_VERSION
+
+
+AGENT_PROFILE_FIELDS = {
+    "schema_version",
+    "agent_id",
+    "profile_role",
+    "scope_summary",
+    "default_task_classes",
+    "preferred_action_kinds",
+    "avoid_action_kinds",
+}
+AGENT_PROFILE_ACTION_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_*-]{0,79}$")
+AGENT_PROFILE_ACTION_PATTERN_LIMIT = 16
+AGENT_PROFILE_HIERARCHY_ROLES = {
+    "leader",
+    "manager",
+    "supervisor",
+    "worker",
+}
+AGENT_PROFILE_HIERARCHY_AGENT_ROLE = re.compile(
+    r"(?:^|-)(?:main|primary|side)-agent(?:-|$)"
+)
+
+
+def _bounded_text(value: Any, *, field: str, limit: int) -> str | None:
+    text = " ".join(str(value or "").strip().split())
+    if not text:
+        return None
+    if len(text) > limit:
+        raise ValueError(f"agent profile {field} must be at most {limit} characters")
+    if public_safe_compact_text(text, limit=limit) != text:
+        raise ValueError(f"agent profile {field} must be public-safe")
+    return text
+
+
+def _profile_role(value: Any) -> str | None:
+    role = _bounded_text(value, field="profile_role", limit=80)
+    if not role:
+        return None
+    normalized_role = re.sub(r"[^a-z0-9]+", "-", role.lower()).strip("-")
+    padded_role = f"-{normalized_role}-"
+    if (
+        any(
+            f"-{forbidden}-" in padded_role
+            for forbidden in AGENT_PROFILE_HIERARCHY_ROLES
+        )
+        or AGENT_PROFILE_HIERARCHY_AGENT_ROLE.search(normalized_role)
+    ):
+        raise ValueError(
+            "agent profile_role must be functional and advisory, not a hierarchy role"
+        )
+    return role
+
+
+def _task_classes(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError("agent profile default_task_classes must be a list")
+    task_classes: list[str] = []
+    for item in value:
+        task_class = str(item or "").strip().lower()
+        if task_class not in TODO_TASK_CLASS_VALUES:
+            raise ValueError(
+                "agent profile default_task_classes must use known todo task classes"
+            )
+        if task_class not in task_classes:
+            task_classes.append(task_class)
+    return task_classes
+
+
+def _action_patterns(value: Any, *, field: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError(f"agent profile {field} must be a list")
+    patterns: list[str] = []
+    for item in value:
+        pattern = str(item or "").strip().lower()
+        if not AGENT_PROFILE_ACTION_PATTERN.fullmatch(pattern):
+            raise ValueError(
+                f"agent profile {field} entries must be public-safe action_kind globs"
+            )
+        if pattern not in patterns:
+            patterns.append(pattern)
+        if len(patterns) > AGENT_PROFILE_ACTION_PATTERN_LIMIT:
+            raise ValueError(
+                f"agent profile {field} must contain at most "
+                f"{AGENT_PROFILE_ACTION_PATTERN_LIMIT} entries"
+            )
+    return patterns
+
+
+def normalize_agent_profile(
+    raw_profile: Mapping[str, Any],
+    *,
+    registered_agents: list[str],
+    expected_agent_id: str | None = None,
+    reject_unknown_fields: bool = True,
+) -> dict[str, Any]:
+    unknown = sorted(set(raw_profile) - AGENT_PROFILE_FIELDS)
+    if reject_unknown_fields and unknown:
+        raise ValueError(f"unknown agent profile field(s): {', '.join(unknown)}")
+    schema_version = str(
+        raw_profile.get("schema_version") or PEER_AGENT_PROFILE_SCHEMA_VERSION
+    ).strip()
+    if schema_version != PEER_AGENT_PROFILE_SCHEMA_VERSION:
+        raise ValueError(
+            f"agent profile schema_version must be {PEER_AGENT_PROFILE_SCHEMA_VERSION}"
+        )
+    agent_id = str(raw_profile.get("agent_id") or expected_agent_id or "").strip()
+    if not agent_id or agent_id not in registered_agents:
+        raise ValueError("agent profile agent_id must name a registered peer")
+    if expected_agent_id and agent_id != expected_agent_id:
+        raise ValueError("agent profile key and agent_id must match")
+
+    preferred = _action_patterns(
+        raw_profile.get("preferred_action_kinds"),
+        field="preferred_action_kinds",
+    )
+    avoided = _action_patterns(
+        raw_profile.get("avoid_action_kinds"),
+        field="avoid_action_kinds",
+    )
+    overlap = sorted(set(preferred) & set(avoided))
+    if overlap:
+        raise ValueError(
+            "agent profile action kind globs cannot be both preferred and avoided: "
+            + ", ".join(overlap)
+        )
+    profile = {
+        "schema_version": PEER_AGENT_PROFILE_SCHEMA_VERSION,
+        "agent_id": agent_id,
+        "profile_role": _profile_role(raw_profile.get("profile_role")),
+        "scope_summary": _bounded_text(
+            raw_profile.get("scope_summary"),
+            field="scope_summary",
+            limit=320,
+        ),
+        "default_task_classes": _task_classes(
+            raw_profile.get("default_task_classes")
+        ),
+        "preferred_action_kinds": preferred,
+        "avoid_action_kinds": avoided,
+    }
+    return {
+        key: value
+        for key, value in profile.items()
+        if value not in (None, [], "")
+    }
+
+
+def agent_profile_candidate_rank(
+    item: Mapping[str, Any],
+    *,
+    agent_profile: Mapping[str, Any] | None,
+) -> int:
+    if not isinstance(agent_profile, Mapping):
+        return 1
+    action_kind = normalize_todo_action_kind(item.get("action_kind")) or ""
+    avoided = agent_profile.get("avoid_action_kinds")
+    if action_kind and isinstance(avoided, list) and any(
+        fnmatchcase(action_kind, str(pattern)) for pattern in avoided
+    ):
+        return 2
+    preferred = agent_profile.get("preferred_action_kinds")
+    if action_kind and isinstance(preferred, list) and any(
+        fnmatchcase(action_kind, str(pattern)) for pattern in preferred
+    ):
+        return 0
+    default_task_classes = agent_profile.get("default_task_classes")
+    if isinstance(default_task_classes, list):
+        task_class = str(item.get("task_class") or "").strip().lower()
+        if task_class and task_class in default_task_classes:
+            return 0
+    return 1

--- a/loopx/control_plane/todos/claim_visibility.py
+++ b/loopx/control_plane/todos/claim_visibility.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from ..agents.profile import agent_profile_candidate_rank
 from .contract import (
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_MONITOR,
@@ -43,6 +44,11 @@ def build_agent_claim_scoped_open_items(
     agent_id = normalize_todo_claimed_by(agent_identity.get("agent_id"))
     if not agent_id:
         return open_items, None
+    agent_profile = (
+        agent_identity.get("agent_profile")
+        if isinstance(agent_identity.get("agent_profile"), dict)
+        else None
+    )
 
     def claim_bucket(item: dict[str, Any]) -> int:
         claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
@@ -77,7 +83,11 @@ def build_agent_claim_scoped_open_items(
     other_agent_claimed_items = [item for item in open_items if claim_bucket(item) == 2]
     selectable_items = sorted(
         [*current_agent_items, *unclaimed_items],
-        key=lambda item: (claim_bucket(item), *todo_projection_sort_key(item)),
+        key=lambda item: (
+            claim_bucket(item),
+            agent_profile_candidate_rank(item, agent_profile=agent_profile),
+            *todo_projection_sort_key(item),
+        ),
     )
     other_agent_visibility = todo_claimed_visibility_items(
         other_agent_claimed_items,
@@ -115,6 +125,16 @@ def build_agent_claim_scoped_open_items(
         ),
         "removed_continuation_policy": "legacy_review_handoffs_fail_closed_until_repaired",
     }
+    if agent_profile:
+        claim_scope["profile_routing"] = {
+            "schema_version": "agent_profile_routing_v0",
+            "applied": True,
+            "within_claim_bucket_only": True,
+            "preferred_action_kinds": list(
+                agent_profile.get("preferred_action_kinds") or []
+            ),
+            "avoid_action_kinds": list(agent_profile.get("avoid_action_kinds") or []),
+        }
     return selectable_items, claim_scope
 
 

--- a/loopx/status_server.py
+++ b/loopx/status_server.py
@@ -56,6 +56,8 @@ CONFIGURE_GOAL_REQUEST_FIELDS = {
     "clear_allowed_domains",
     "registered_agents",
     "clear_registered_agents",
+    "agent_profiles",
+    "clear_agent_profiles",
     "agent_model",
     "supervisor_agent",
     "supervised_agents",
@@ -344,6 +346,12 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
         registered_agents = body.get("registered_agents")
         if registered_agents is not None and not isinstance(registered_agents, list):
             raise ValueError("registered_agents must be a list of strings")
+        agent_profiles = body.get("agent_profiles")
+        if agent_profiles is not None and not isinstance(agent_profiles, list):
+            raise ValueError("agent_profiles must be a list of objects")
+        clear_agent_profiles = body.get("clear_agent_profiles")
+        if clear_agent_profiles is not None and not isinstance(clear_agent_profiles, list):
+            raise ValueError("clear_agent_profiles must be a list of strings")
         supervised_agents = body.get("supervised_agents")
         if supervised_agents is not None and not isinstance(supervised_agents, list):
             raise ValueError("supervised_agents must be a list of strings")
@@ -368,6 +376,12 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             "clear_allowed_domains": bool(body.get("clear_allowed_domains", False)),
             "registered_agents": [str(item) for item in registered_agents] if registered_agents is not None else None,
             "clear_registered_agents": bool(body.get("clear_registered_agents", False)),
+            "agent_profiles": agent_profiles,
+            "clear_agent_profiles": (
+                [str(item) for item in clear_agent_profiles]
+                if clear_agent_profiles is not None
+                else None
+            ),
             "agent_model": body.get("agent_model"),
             "supervisor_agent": body.get("supervisor_agent"),
             "supervised_agents": (
@@ -409,6 +423,8 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             clear_allowed_domains=values["clear_allowed_domains"],
             registered_agents=values["registered_agents"],
             clear_registered_agents=values["clear_registered_agents"],
+            agent_profiles=values["agent_profiles"],
+            clear_agent_profiles=values["clear_agent_profiles"],
             agent_model=values["agent_model"],
             supervisor_agent=values["supervisor_agent"],
             supervised_agents=values["supervised_agents"],


### PR DESCRIPTION
## Summary
- add validated `agent_profile_v1` write/clear support to `configure-goal` and the loopback control-plane API
- project valid advisory profiles into quota agent identity
- rank preferred/avoided action kinds inside existing active-next and claim buckets without changing hard eligibility
- document the contract and cover configuration, compatibility, identity, claim ordering, and final quota routing

## Product / architecture judgment
This makes the existing profile contract operational instead of prompt-only. The profile stays advisory: it cannot transfer claims, bypass leases/gates/capabilities/write scopes, or create peer hierarchy. One shared rank helper is reused by todo projection, capability candidates, and final lane selection so the read model and selected action cannot drift. Invalid legacy advisory metadata is ignored on read, while new writes are strict and bounded.

## Validation
- `python -m pytest -q -n auto`: 97 passed, 2 skipped
- focused agent identity, todo claim visibility, configure-goal, and peer runtime smokes: passed
- targeted `ruff`: passed
- `loopx canary premerge --from-git-diff`: 17/17 passed, 0 failures, 0 warnings, no manual holds
- public/private boundary scan: clean across 12 changed files

The first final canary attempt correctly caught an old hierarchy literal in the new validator; the implementation was rewritten to preserve the hard-cut boundary and the complete gate then passed.

## Excluded
No local state, raw trajectories/logs, credentials, private links, benchmark artifacts, or production actions.