### PR TITLE
Harden concurrent release promotion

### DIFF
--- a/examples/release/release-promotion-concurrency-smoke.py
+++ b/examples/release/release-promotion-concurrency-smoke.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Regression coverage for collision-safe, revision-verifiable promotions."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SCRIPT = REPO_ROOT / "scripts" / "install-local.sh"
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.release_manifest import build_release_manifest  # noqa: E402
+
+
+def install_env(root: Path) -> dict[str, str]:
+    home = root / "home"
+    return {
+        **os.environ,
+        "HOME": str(home),
+        "CODEX_HOME": str(home / ".codex"),
+        "LOOPX_BIN_DIR": str(home / ".local" / "bin"),
+        "LOOPX_RELEASES_DIR": str(home / ".local" / "share" / "loopx" / "releases"),
+        "LOOPX_SHELL_PROFILE": str(home / ".zshrc"),
+        "LOOPX_INSTALL_CANARY": "0",
+        "LOOPX_INSTALL_SKILL": "0",
+        "LOOPX_INSTALL_SLASH_COMMANDS": "0",
+        "LOOPX_PROMOTE_DEFAULT": "1",
+        "LOOPX_PYTHON": sys.executable,
+        "PATH": os.environ.get("PATH", ""),
+        "SHELL": "/bin/zsh",
+    }
+
+
+def release_path(stdout: str) -> Path:
+    prefix = "- release: "
+    for line in stdout.splitlines():
+        if line.startswith(prefix):
+            return Path(line.removeprefix(prefix))
+    raise AssertionError(stdout)
+
+
+def assert_concurrent_release_ids_are_distinct(root: Path) -> None:
+    env = {**install_env(root), "LOOPX_RELEASE_ID": "same-second"}
+    releases_dir = Path(env["LOOPX_RELEASES_DIR"])
+    stale_lock = releases_dir / ".install-lock"
+    stale_lock.mkdir(parents=True)
+    (stale_lock / "pid").write_text("999999999\n", encoding="utf-8")
+    processes = [
+        subprocess.Popen(
+            [str(INSTALL_SCRIPT)],
+            cwd=REPO_ROOT,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for _ in range(2)
+    ]
+    completed = [process.communicate(timeout=120) for process in processes]
+    for process, (stdout, stderr) in zip(processes, completed):
+        assert process.returncode == 0, (stdout, stderr)
+
+    release_paths = [release_path(stdout).resolve() for stdout, _ in completed]
+    assert len(set(release_paths)) == 2, release_paths
+    for path in release_paths:
+        manifest = json.loads((path / "release.json").read_text(encoding="utf-8"))
+        assert manifest["release_id"] == path.name, manifest
+
+    wrapper = Path(env["LOOPX_BIN_DIR"]) / "loopx"
+    assert wrapper.is_symlink(), wrapper
+    assert wrapper.resolve().parents[1] in release_paths, wrapper.resolve()
+
+
+def assert_resolved_archive_commit_is_recorded(root: Path) -> None:
+    release_root = root / "manifest-release"
+    release_root.mkdir()
+    expected_commit = "1" * 40
+    manifest = build_release_manifest(
+        release_root=release_root,
+        release_id="archive-fixture",
+        source_root=None,
+        env={
+            "LOOPX_ARCHIVE_URL": "https://example.com/loopx.tar.gz",
+            "LOOPX_RESOLVED_SOURCE_GIT_COMMIT": expected_commit,
+        },
+    )
+    assert manifest["source"]["git_commit"] == expected_commit, manifest
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-release-promotion-concurrency-") as tmp:
+        root = Path(tmp)
+        assert_concurrent_release_ids_are_distinct(root)
+        assert_resolved_archive_commit_is_recorded(root)
+    print("release-promotion-concurrency-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/release_manifest.py
+++ b/loopx/release_manifest.py
@@ -193,6 +193,7 @@ def build_release_manifest(
 ) -> dict[str, Any]:
     source_env = env or os.environ
     source_metadata = _source_metadata(source_root)
+    resolved_source_git_commit = source_env.get("LOOPX_RESOLVED_SOURCE_GIT_COMMIT")
     archive_url = source_env.get("LOOPX_ARCHIVE_URL") or source_metadata.get("archive_url")
     archive_sha256 = source_env.get("LOOPX_ARCHIVE_SHA256") or source_metadata.get("archive_sha256")
     repo = source_env.get("LOOPX_REPO") or source_metadata.get("repo")
@@ -217,7 +218,7 @@ def build_release_manifest(
             "promotion_mode": promotion_mode,
             "repo": repo,
             "ref": ref,
-            "git_commit": source_metadata["git_commit"],
+            "git_commit": resolved_source_git_commit or source_metadata["git_commit"],
             "git_ref": source_metadata["git_ref"],
             "git_dirty": source_metadata["git_dirty"],
             "archive_url": archive_url,

--- a/scripts/install-from-github.sh
+++ b/scripts/install-from-github.sh
@@ -3,10 +3,10 @@ set -euo pipefail
 
 repo="${LOOPX_REPO:-huangruiteng/loopx}"
 ref="${LOOPX_REF:-stable}"
-archive_url="${LOOPX_ARCHIVE_URL:-https://codeload.github.com/$repo/tar.gz/$ref}"
+archive_url_override="${LOOPX_ARCHIVE_URL:-}"
+archive_url="$archive_url_override"
 export LOOPX_REPO="$repo"
 export LOOPX_REF="$ref"
-export LOOPX_ARCHIVE_URL="$archive_url"
 
 need() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -18,6 +18,49 @@ need() {
 need curl
 need tar
 need python3
+
+if [[ -n "${LOOPX_RESOLVED_SOURCE_GIT_COMMIT:-}" \
+  && ! "$LOOPX_RESOLVED_SOURCE_GIT_COMMIT" =~ ^[0-9a-fA-F]{40}$ ]]; then
+  echo "loopx installer error: LOOPX_RESOLVED_SOURCE_GIT_COMMIT must be a full Git commit SHA" >&2
+  exit 2
+fi
+
+if [[ -z "$archive_url" ]]; then
+  if [[ ! "$repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+    echo "loopx installer error: LOOPX_REPO must use GitHub owner/name syntax" >&2
+    exit 2
+  fi
+  commit_api_url="$(python3 - "$repo" "$ref" <<'PY'
+from urllib.parse import quote
+import sys
+
+repo, ref = sys.argv[1:]
+owner, name = repo.split("/", 1)
+print(
+    "https://api.github.com/repos/"
+    f"{quote(owner, safe='')}/{quote(name, safe='')}/commits/{quote(ref, safe='')}"
+)
+PY
+)"
+  commit_json="$(curl -fsSL \
+    -H 'Accept: application/vnd.github+json' \
+    -H 'User-Agent: LoopX-installer' \
+    "$commit_api_url")"
+  resolved_commit="$(LOOPX_COMMIT_JSON="$commit_json" python3 - <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["LOOPX_COMMIT_JSON"])
+sha = payload.get("sha")
+if not isinstance(sha, str) or len(sha) != 40:
+    raise SystemExit("GitHub commit response did not include a full SHA")
+print(sha)
+PY
+)"
+  export LOOPX_RESOLVED_SOURCE_GIT_COMMIT="$resolved_commit"
+  archive_url="https://codeload.github.com/$repo/tar.gz/$resolved_commit"
+fi
+export LOOPX_ARCHIVE_URL="$archive_url"
 
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/loopx-install.XXXXXX")"
 cleanup() {

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -14,11 +14,65 @@ install_skill="${LOOPX_INSTALL_SKILL:-1}"
 install_canary="${LOOPX_INSTALL_CANARY:-1}"
 promote_default_request="${LOOPX_PROMOTE_DEFAULT:-auto}"
 releases_dir="${LOOPX_RELEASES_DIR:-$HOME/.local/share/loopx/releases}"
-release_id="${LOOPX_RELEASE_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
-release_dir="$releases_dir/$release_id"
-release_tmp="$release_dir.tmp.$$"
+release_id_request="${LOOPX_RELEASE_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+release_id=""
+release_dir=""
+release_tmp=""
+install_lock=""
 legacy_line=""
 installed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+cleanup_install_lock() {
+  if [[ -n "$release_tmp" && -d "$release_tmp" ]]; then
+    rm -rf "$release_tmp"
+  fi
+  if [[ -n "$install_lock" && -d "$install_lock" ]]; then
+    rm -rf "$install_lock"
+  fi
+}
+
+trap cleanup_install_lock EXIT
+
+reserve_release_id() {
+  if [[ ! "$release_id_request" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+    echo "loopx installer error: LOOPX_RELEASE_ID must be a safe release directory name" >&2
+    exit 2
+  fi
+  local candidate="$release_id_request"
+  local suffix=2
+  while [[ -e "$releases_dir/$candidate" || -L "$releases_dir/$candidate" ]]; do
+    candidate="$release_id_request-$suffix"
+    suffix=$((suffix + 1))
+  done
+  release_id="$candidate"
+  release_dir="$releases_dir/$release_id"
+  release_tmp="$(mktemp -d "$releases_dir/.${release_id}.tmp.XXXXXX")"
+}
+
+acquire_install_lock() {
+  install_lock="$releases_dir/.install-lock"
+  local attempt=0
+  until mkdir "$install_lock" 2>/dev/null; do
+    local owner_pid=""
+    if [[ -f "$install_lock/pid" ]]; then
+      owner_pid="$(cat "$install_lock/pid" 2>/dev/null || true)"
+    fi
+    if [[ "$owner_pid" =~ ^[0-9]+$ ]] && ! kill -0 "$owner_pid" 2>/dev/null; then
+      local stale_lock="$install_lock.stale.$$"
+      if mv "$install_lock" "$stale_lock" 2>/dev/null; then
+        rm -rf "$stale_lock"
+        continue
+      fi
+    fi
+    attempt=$((attempt + 1))
+    if [[ "$attempt" -ge 600 ]]; then
+      echo "loopx installer error: timed out waiting for another local install to finish" >&2
+      exit 1
+    fi
+    sleep 0.1
+  done
+  printf '%s\n' "$$" >"$install_lock/pid"
+}
 
 warn_stale_promotion_readiness() {
   local python_bin="${LOOPX_PYTHON:-python3}"
@@ -92,15 +146,59 @@ install_symlink() {
   local link="$2"
   local tmp="$link.tmp.$$"
   rm -f "$tmp"
-  if [[ -e "$link" || -L "$link" ]]; then
-    if [[ ! -L "$link" && -d "$link" ]]; then
-      echo "loopx installer error: $link is a directory; remove it before installing" >&2
-      return 1
-    fi
-    rm -f "$link"
+  if [[ ! -L "$link" && -d "$link" ]]; then
+    echo "loopx installer error: $link is a directory; remove it before installing" >&2
+    return 1
   fi
   ln -s "$target" "$tmp"
-  mv -f "$tmp" "$link"
+  LOOPX_LINK_TMP="$tmp" LOOPX_LINK_TARGET="$link" "${LOOPX_PYTHON:-python3}" - <<'PY'
+import os
+
+os.replace(os.environ["LOOPX_LINK_TMP"], os.environ["LOOPX_LINK_TARGET"])
+PY
+}
+
+verify_default_promotion() {
+  LOOPX_VERIFY_LINK="$bin_dir/loopx" \
+    LOOPX_VERIFY_RELEASE_DIR="$release_dir" \
+    LOOPX_VERIFY_SOURCE_COMMIT="${LOOPX_RESOLVED_SOURCE_GIT_COMMIT:-$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || true)}" \
+    "${LOOPX_PYTHON:-python3}" - <<'PY'
+from pathlib import Path
+import json
+import os
+import sys
+
+link = Path(os.environ["LOOPX_VERIFY_LINK"])
+release_dir = Path(os.environ["LOOPX_VERIFY_RELEASE_DIR"])
+expected = (release_dir / "scripts" / "loopx").resolve()
+try:
+    actual = link.resolve(strict=True)
+except OSError as exc:
+    print(f"loopx installer error: default executable cannot be resolved: {exc}", file=sys.stderr)
+    raise SystemExit(1)
+if actual != expected:
+    print(
+        "loopx installer error: default executable changed before promotion verification",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+manifest_path = release_dir / "release.json"
+try:
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError) as exc:
+    print(f"loopx installer error: release manifest is unreadable: {exc}", file=sys.stderr)
+    raise SystemExit(1)
+if manifest.get("release_id") != release_dir.name:
+    print("loopx installer error: release manifest id does not match its directory", file=sys.stderr)
+    raise SystemExit(1)
+
+expected_commit = os.environ.get("LOOPX_VERIFY_SOURCE_COMMIT") or ""
+source = manifest.get("source") if isinstance(manifest.get("source"), dict) else {}
+if expected_commit and source.get("git_commit") != expected_commit:
+    print("loopx installer error: release manifest does not match the intended source commit", file=sys.stderr)
+    raise SystemExit(1)
+PY
 }
 
 resolve_default_promotion() {
@@ -185,15 +283,15 @@ export LOOPX_PROMOTION_MODE="$promotion_mode"
 
 warn_stale_promotion_readiness
 
+mkdir -p "$releases_dir"
+acquire_install_lock
 mkdir -p "$bin_dir"
 disable_legacy_shim "goal-harness"
 disable_legacy_shim "goal-harness-canary"
 if [[ -z "$legacy_line" ]]; then
   legacy_line="- legacy command disabled: not present"
 fi
-mkdir -p "$releases_dir"
-rm -rf "$release_tmp"
-mkdir -p "$release_tmp"
+reserve_release_id
 copy_path "$repo_root/loopx" "$release_tmp/loopx"
 copy_path "$repo_root/scripts" "$release_tmp/scripts"
 copy_path "$repo_root/skills" "$release_tmp/skills"
@@ -222,12 +320,10 @@ fi
     --installed-at "$installed_at"
 )
 chmod +x "$release_tmp/scripts/loopx"
-if [[ -e "$release_dir" ]]; then
-  rm -rf "$release_tmp"
-else
-  mv "$release_tmp" "$release_dir"
-fi
+mv "$release_tmp" "$release_dir"
+release_tmp=""
 install_symlink "$release_dir/scripts/loopx" "$bin_dir/loopx"
+verify_default_promotion
 
 canary_line="- canary executable: skipped"
 if [[ "$install_canary" != "0" ]]; then


### PR DESCRIPTION
## Motivation

Concurrent local promotions currently derive the same second-level release id. One installer can reuse or collide with another installer snapshot, while the default symlink is reported successful without proving that it points to the source revision requested by this install.

## Implementation

- serialize local promotion writes with a recoverable process lock
- allocate a unique suffix when a requested release id already exists
- atomically replace executable symlinks and verify the promoted target and manifest before success
- resolve default GitHub refs to a full commit SHA, download that immutable archive, and preserve the SHA in release provenance
- retain custom archive URL compatibility

## Validation

- focused concurrency regression: two same-id installers produce distinct manifests and a valid final symlink
- install-local overwrite smoke
- install-local full smoke
- no-clone archive verification smoke
- catalog planner smoke
- shell syntax and Python compile checks
- loopx canary premerge --from-git-diff: 17 selected checks passed, 0 failures, 0 warnings, 0 manual holds
- public boundary scan: clean

## Risk and gaps

The local installer now serializes the shared promotion section, so a second concurrent install waits rather than racing. A live process can hold the lock for up to 60 seconds; dead process locks with a recorded PID are recovered. Custom archive URLs remain usable but only carry commit provenance when the caller supplies LOOPX_RESOLVED_SOURCE_GIT_COMMIT.