### PR TITLE
Preserve immutable update source resolution

### DIFF
--- a/examples/loopx-update-smoke.py
+++ b/examples/loopx-update-smoke.py
@@ -19,6 +19,7 @@ from loopx import __version__  # noqa: E402
 from loopx.release_manifest import release_version_tag  # noqa: E402
 from loopx.self_update import (
     DEFAULT_UPDATE_REF,
+    _installer_env_for_source,
     build_rollback_plan,
     build_update_plan,
     execute_rollback_plan,
@@ -167,12 +168,32 @@ def test_module_plan() -> None:
 
 
 def test_default_source_uses_stable_ref() -> None:
-    payload = build_update_plan(doctor_payload=fake_doctor_payload())
+    with mock.patch.dict(os.environ, {}, clear=True):
+        payload = build_update_plan(doctor_payload=fake_doctor_payload())
     assert payload["source"]["ref"] == DEFAULT_UPDATE_REF == "stable", payload
     assert payload["source"]["channel"] == "github_archive_stable", payload
     assert payload["source"]["ref_source"] == "default_stable", payload
     assert "/tar.gz/stable" in payload["source"]["archive_url"], payload
     assert "LOOPX_REF=stable" in payload["plan"]["install_command"], payload
+    assert "LOOPX_ARCHIVE_URL=" not in payload["plan"]["install_command"], payload
+    default_env = _installer_env_for_source(
+        payload["source"],
+        base_env={"LOOPX_ARCHIVE_URL": "https://stale.invalid/archive.tar.gz"},
+    )
+    assert "LOOPX_ARCHIVE_URL" not in default_env, default_env
+
+
+def test_explicit_archive_url_reaches_installer() -> None:
+    payload = build_update_plan(
+        repo="example/loopx",
+        ref="fixture",
+        archive_url="https://example.invalid/loopx.tar.gz",
+        doctor_payload=fake_doctor_payload(),
+    )
+    assert payload["source"]["channel"] == "github_archive_url_override", payload
+    assert "LOOPX_ARCHIVE_URL=https://example.invalid/loopx.tar.gz" in payload["plan"]["install_command"], payload
+    installer_env = _installer_env_for_source(payload["source"], base_env={})
+    assert installer_env["LOOPX_ARCHIVE_URL"] == "https://example.invalid/loopx.tar.gz", installer_env
 
 
 def test_fresh_check_is_noop_recommendation() -> None:
@@ -358,6 +379,7 @@ def test_cli_rollback_previous_with_temp_home() -> None:
 def main() -> int:
     test_module_plan()
     test_default_source_uses_stable_ref()
+    test_explicit_archive_url_reaches_installer()
     test_fresh_check_is_noop_recommendation()
     test_check_compares_selected_source_version()
     test_check_degrades_when_source_version_is_unavailable()

--- a/loopx/self_update.py
+++ b/loopx/self_update.py
@@ -57,7 +57,7 @@ def _command_for_source(source: dict[str, Any]) -> str:
         f"LOOPX_REF={shlex.quote(str(source['ref']))}",
     ]
     archive_url = source.get("archive_url")
-    if archive_url:
+    if source.get("channel") == "github_archive_url_override" and archive_url:
         exports.append(f"LOOPX_ARCHIVE_URL={shlex.quote(str(archive_url))}")
     return (
         " ".join(exports)
@@ -65,6 +65,21 @@ def _command_for_source(source: dict[str, Any]) -> str:
         'export PATH="$HOME/.local/bin:$PATH"\n'
         "loopx doctor"
     )
+
+
+def _installer_env_for_source(
+    source: dict[str, Any],
+    *,
+    base_env: dict[str, str] | None = None,
+) -> dict[str, str]:
+    env = dict(base_env or os.environ)
+    env["LOOPX_REPO"] = str(source.get("repo") or DEFAULT_UPDATE_REPO)
+    env["LOOPX_REF"] = str(source.get("ref") or DEFAULT_UPDATE_REF)
+    if source.get("channel") == "github_archive_url_override" and source.get("archive_url"):
+        env["LOOPX_ARCHIVE_URL"] = str(source["archive_url"])
+    else:
+        env.pop("LOOPX_ARCHIVE_URL", None)
+    return env
 
 
 def _source_version_check(source: dict[str, Any]) -> dict[str, Any]:
@@ -391,11 +406,7 @@ def build_update_plan(
 def execute_update_plan(payload: dict[str, Any], *, timeout_seconds: int = 600) -> dict[str, Any]:
     source = payload.get("source") if isinstance(payload.get("source"), dict) else {}
     installer_url = str(source.get("installer_url") or NO_CLONE_INSTALL_URL)
-    env = os.environ.copy()
-    env["LOOPX_REPO"] = str(source.get("repo") or DEFAULT_UPDATE_REPO)
-    env["LOOPX_REF"] = str(source.get("ref") or DEFAULT_UPDATE_REF)
-    if source.get("archive_url"):
-        env["LOOPX_ARCHIVE_URL"] = str(source["archive_url"])
+    env = _installer_env_for_source(source)
     install_result = subprocess.run(
         ["bash", "-lc", f"curl -fsSL {shlex.quote(installer_url)} | bash"],
         text=True,


### PR DESCRIPTION
## Motivation

PR #1950 made the default GitHub installer resolve refs to immutable commits, but real `loopx update --ref main` still exported the planner-generated codeload URL as if it were a user override. That bypassed commit resolution and left release provenance with a null source commit.

## Implementation

- pass LOOPX_ARCHIVE_URL only for the explicit custom-archive channel
- remove stale ambient archive overrides from default repo/ref execution
- keep the computed archive URL in the read-only plan for operator visibility
- cover both dry-run command rendering and execution environment behavior

## Validation

- focused loopx update smoke: passed
- Python compile and diff hygiene: passed
- loopx canary premerge --from-git-diff: 5/5 passed, no warnings or manual holds
- install-local and packaged install canaries: passed
- public boundary scan: clean

## Risk and follow-up

This is a narrow planner-to-installer contract correction. Explicit custom archive URLs are unchanged. After merge, the acceptance check is a real default update whose release manifest source commit must equal the merge commit.