### PR TITLE
Add start-goal packet summary refs

### DIFF
--- a/examples/bootstrap-command-pack-smoke.py
+++ b/examples/bootstrap-command-pack-smoke.py
@@ -31,6 +31,55 @@ def run_json(*args: str, env: dict[str, str] | None = None) -> dict[str, object]
     return payload
 
 
+def assert_packet_summary_refs(
+    payload: dict[str, object],
+    *,
+    packet_kind: str,
+) -> dict[str, object]:
+    summary = payload["packet_summary"]
+    assert isinstance(summary, dict)
+    assert summary["schema_version"] == "loopx_start_goal_packet_summary_v0"
+    assert summary["packet_kind"] == packet_kind
+    compatibility = summary["compatibility"]
+    assert isinstance(compatibility, dict)
+    assert compatibility == {
+        "legacy_fields_retained": True,
+        "compact_projection_default": False,
+        "removal_gate": "explicit_host_shadow_parity",
+    }
+    detail_refs = summary["detail_refs"]
+    assert isinstance(detail_refs, dict)
+    for detail_ref in detail_refs.values():
+        assert isinstance(detail_ref, dict)
+        assert detail_ref["schema_version"] == "loopx_packet_json_pointer_ref_v0"
+        pointer = str(detail_ref["json_pointer"])
+        assert pointer.startswith("#/"), pointer
+        current: object = payload
+        for escaped_part in pointer[2:].split("/"):
+            part = escaped_part.replace("~1", "/").replace("~0", "~")
+            if isinstance(current, dict):
+                current = current[part]
+            elif isinstance(current, list):
+                current = current[int(part)]
+            else:
+                raise AssertionError((pointer, current))
+    measurement = summary["duplication_measurement"]
+    assert isinstance(measurement, dict)
+    assert measurement["schema_version"] == "loopx_packet_duplication_measurement_v0"
+    assert (
+        measurement["measurement_scope"]
+        == "compatibility_projection_without_packet_summary"
+    )
+    assert int(measurement["serialized_bytes"]) > 0
+    current_bytes = len(
+        json.dumps(
+            payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+        ).encode("utf-8")
+    )
+    assert current_bytes > int(measurement["serialized_bytes"])
+    return summary
+
+
 def test_missing_project_stops_before_mutation() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         project = Path(tmp) / "fresh-project"
@@ -62,6 +111,10 @@ def test_missing_project_stops_before_mutation() -> None:
         assert "LoopX command surface is available. Useful commands:" in onboarding["suggested_user_note"]
         assert "loopx slash-commands" in onboarding["suggested_user_note"]
         assert payload["read_only"] is True
+        summary = assert_packet_summary_refs(
+            payload, packet_kind="bootstrap_command_pack"
+        )
+        assert summary["next_step_kind"] == "confirm_before_bootstrap_mutation"
         assert connection["connection_state"] == "not_connected"
         assert connection["mutation_confirmation_required"] is True
         assert not (project / ".loopx").exists()
@@ -99,6 +152,19 @@ def test_goal_text_invocation_plans_ranked_todos_before_activation() -> None:
         )
 
         assert payload["goal_text"] == "Ship the lightweight issue triage workflow"
+        summary = assert_packet_summary_refs(
+            payload, packet_kind="bootstrap_command_pack"
+        )
+        assert summary["objective"] == "Ship the lightweight issue triage workflow"
+        measurement = summary["duplication_measurement"]
+        assert isinstance(measurement, dict)
+        objective_measurement = measurement["objective_content"]
+        assert isinstance(objective_measurement, dict)
+        assert int(objective_measurement["substring_occurrences"]) > 1
+        assert int(objective_measurement["duplicate_occurrences"]) > 0
+        command_measurement = measurement["command_content"]
+        assert isinstance(command_measurement, dict)
+        assert int(command_measurement["duplicate_occurrences"]) > 0
         next_step = payload["recommended_next_step"]
         assert isinstance(next_step, dict)
         assert next_step["kind"] == "goal_plan_write_and_activate"
@@ -212,6 +278,23 @@ def test_start_goal_guided_previews_transaction_without_mutation() -> None:
         assert payload["guided"] is True
         assert payload["goal_text"] == "Connect this repo and start an auto research lane"
         assert payload["goal_id"] == "guided-goal"
+        summary = assert_packet_summary_refs(payload, packet_kind="guided_start_goal")
+        assert summary["objective"] == "Connect this repo and start an auto research lane"
+        assert summary["next_step_kind"] == "goal_plan_write_and_activate"
+        detail_refs = summary["detail_refs"]
+        assert isinstance(detail_refs, dict)
+        assert (
+            detail_refs["command_pack_summary"]["json_pointer"]
+            == "#/command_pack/packet_summary"
+        )
+        measurement = summary["duplication_measurement"]
+        assert isinstance(measurement, dict)
+        objective_measurement = measurement["objective_content"]
+        assert isinstance(objective_measurement, dict)
+        assert int(objective_measurement["substring_occurrences"]) > 1
+        command_measurement = measurement["command_content"]
+        assert isinstance(command_measurement, dict)
+        assert int(command_measurement["duplicate_occurrences"]) > 0
 
         safety = payload["safety_contract"]
         assert isinstance(safety, dict)

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -23,6 +23,129 @@ SCHEMA_VERSION = "loopx_bootstrap_command_pack_v0"
 CANONICAL_SLASH_COMMAND = "/loopx"
 GOAL_START_SCHEMA_VERSION = "loopx_goal_start_command_v0"
 GUIDED_START_SCHEMA_VERSION = "loopx_start_goal_guided_v0"
+PACKET_SUMMARY_SCHEMA_VERSION = "loopx_start_goal_packet_summary_v0"
+PACKET_MEASUREMENT_SCHEMA_VERSION = "loopx_packet_duplication_measurement_v0"
+
+
+def _iter_string_leaves(
+    value: Any, path: tuple[str, ...] = ()
+) -> list[tuple[tuple[str, ...], str]]:
+    leaves: list[tuple[tuple[str, ...], str]] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key == "packet_summary":
+                continue
+            leaves.extend(_iter_string_leaves(child, (*path, str(key))))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            leaves.extend(_iter_string_leaves(child, (*path, str(index))))
+    elif isinstance(value, str):
+        leaves.append((path, value))
+    return leaves
+
+
+def _without_packet_summary(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _without_packet_summary(child)
+            for key, child in value.items()
+            if key != "packet_summary"
+        }
+    if isinstance(value, list):
+        return [_without_packet_summary(child) for child in value]
+    return value
+
+
+def _is_command_value(path: tuple[str, ...]) -> bool:
+    if not path:
+        return False
+    leaf = path[-1]
+    return (
+        (len(path) >= 2 and path[-2] == "commands")
+        or leaf in {"command", "command_template", "prompt", "canonical_cli_command"}
+        or leaf.endswith("_command")
+        or leaf.endswith("_prompt")
+        or leaf.endswith("_command_if_needed")
+    )
+
+
+def _measure_packet_duplication(
+    payload: dict[str, Any], *, objective: str | None
+) -> dict[str, Any]:
+    compatibility_payload = _without_packet_summary(payload)
+    leaves = _iter_string_leaves(compatibility_payload)
+    objective_occurrences = 0
+    objective_field_count = 0
+    if objective:
+        for _, value in leaves:
+            count = value.count(objective)
+            if count:
+                objective_occurrences += count
+                objective_field_count += 1
+
+    command_values: list[str] = []
+    for path, value in leaves:
+        if not value or not _is_command_value(path):
+            continue
+        command_values.append(value)
+    unique_command_count = len(set(command_values))
+
+    compatibility_json = json.dumps(
+        compatibility_payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return {
+        "schema_version": PACKET_MEASUREMENT_SCHEMA_VERSION,
+        "measurement_scope": "compatibility_projection_without_packet_summary",
+        "serialized_bytes": len(compatibility_json.encode("utf-8")),
+        "objective_content": {
+            "substring_occurrences": objective_occurrences,
+            "containing_field_count": objective_field_count,
+            "duplicate_occurrences": max(0, objective_occurrences - 1),
+        },
+        "command_content": {
+            "candidate_occurrences": len(command_values),
+            "unique_values": unique_command_count,
+            "duplicate_occurrences": len(command_values) - unique_command_count,
+        },
+    }
+
+
+def _build_packet_summary(
+    payload: dict[str, Any],
+    *,
+    packet_kind: str,
+    detail_refs: dict[str, str],
+) -> dict[str, Any]:
+    next_step = payload.get("recommended_next_step")
+    next_step = next_step if isinstance(next_step, dict) else {}
+    return {
+        "schema_version": PACKET_SUMMARY_SCHEMA_VERSION,
+        "packet_kind": packet_kind,
+        "goal_id": payload.get("goal_id"),
+        "objective": payload.get("goal_text"),
+        "next_step_kind": next_step.get("kind"),
+        "detail_refs": {
+            name: {
+                "schema_version": "loopx_packet_json_pointer_ref_v0",
+                "json_pointer": pointer,
+            }
+            for name, pointer in detail_refs.items()
+        },
+        "compatibility": {
+            "legacy_fields_retained": True,
+            "compact_projection_default": False,
+            "removal_gate": "explicit_host_shadow_parity",
+        },
+        "duplication_measurement": _measure_packet_duplication(
+            payload,
+            objective=str(payload.get("goal_text"))
+            if payload.get("goal_text")
+            else None,
+        ),
+    }
 
 
 def _resolve_project(project: Path) -> Path:
@@ -602,6 +725,19 @@ def build_loopx_bootstrap_command_pack(
         },
     }
     payload["message"] = render_loopx_bootstrap_command_pack_message(payload)
+    payload["packet_summary"] = _build_packet_summary(
+        payload,
+        packet_kind="bootstrap_command_pack",
+        detail_refs={
+            "project_connection": "#/project_connection",
+            "host_loop_activation": "#/host_loop_activation",
+            "recommended_next_step": "#/recommended_next_step",
+            "goal_start_contract": "#/goal_start_contract",
+            "commands": "#/commands",
+            "safety_contract": "#/safety_contract",
+            "compatibility_message": "#/message",
+        },
+    )
     return payload
 
 
@@ -742,6 +878,19 @@ def build_start_goal_guided_packet(
         },
     }
     payload["message"] = render_start_goal_guided_markdown(payload)
+    payload["packet_summary"] = _build_packet_summary(
+        payload,
+        packet_kind="guided_start_goal",
+        detail_refs={
+            "command_pack_summary": "#/command_pack/packet_summary",
+            "project_connection": "#/project_connection",
+            "recommended_next_step": "#/recommended_next_step",
+            "guided_transaction": "#/guided_transaction",
+            "commands": "#/command_pack/commands",
+            "safety_contract": "#/safety_contract",
+            "compatibility_message": "#/message",
+        },
+    )
     return payload
 
 


### PR DESCRIPTION
## Summary
- add an additive packet summary for bootstrap-command-pack and guided start-goal outputs
- expose stable JSON Pointer detail refs plus objective/command duplication measurements
- retain all legacy fields and keep compact projection disabled until explicit host shadow parity

## Validation
- `python3 examples/bootstrap-command-pack-smoke.py`
- `ruff check loopx/bootstrap_command_pack.py examples/bootstrap-command-pack-smoke.py`
- `loopx canary premerge --from-git-diff`
- public/private boundary scan clean