### PR TITLE
Fix peer exclusion handling for resumed todos

### DIFF
--- a/examples/control_plane/agent-scope-projection-characterization-smoke.py
+++ b/examples/control_plane/agent-scope-projection-characterization-smoke.py
@@ -14,8 +14,11 @@ if str(REPO_ROOT) not in sys.path:
 
 from loopx.control_plane.agents.agent_scope import (  # noqa: E402
     _agent_lane_frontier_hint,
+    _agent_scope_deferred_resume_candidates,
     _agent_scope_filter_user_gate_items,
+    _agent_scope_monitor_blocked_resume_candidates,
     _agent_scope_no_candidate_frontier,
+    _agent_scope_route_continuation_replan_candidates,
     _agent_scoped_user_gate_override,
     _scoped_user_gate_fallback,
 )
@@ -324,6 +327,70 @@ def assert_agent_scope_frontier_and_hint_contract() -> None:
     assert hint["quiet_noop_allowed"] is False
 
 
+def assert_executor_exclusions_survive_precomputed_resume_lanes() -> None:
+    excluded_ready = todo(
+        "todo_excluded_ready",
+        "[P1] Ready work owned by another peer.",
+        index=1,
+        status="deferred",
+        resume_ready=True,
+        excluded_agents=[AGENT_ID],
+    )
+    eligible_ready = todo(
+        "todo_eligible_ready",
+        "[P1] Ready work available to this peer.",
+        index=2,
+        status="deferred",
+        resume_ready=True,
+    )
+    ready = _agent_scope_deferred_resume_candidates(
+        {
+            "unclaimed_deferred_resume_candidates": [
+                excluded_ready,
+                eligible_ready,
+            ]
+        },
+        agent_id=AGENT_ID,
+    )
+    assert [item["todo_id"] for item in ready] == ["todo_eligible_ready"], ready
+
+    blocked_condition = {
+        "target_status": "open",
+        "target_task_class": "continuous_monitor",
+        "target_todo_id": "todo_monitor",
+    }
+    excluded_blocked = todo(
+        "todo_excluded_blocked",
+        "[P1] Monitor-gated work owned by another peer.",
+        index=3,
+        resume_ready=False,
+        resume_condition=blocked_condition,
+        excluded_agents=[AGENT_ID],
+    )
+    assert (
+        _agent_scope_monitor_blocked_resume_candidates(
+            {"unclaimed_monitor_blocked_resume_candidates": [excluded_blocked]},
+            agent_id=AGENT_ID,
+        )
+        == []
+    )
+
+    excluded_route = todo(
+        "todo_excluded_route",
+        "[P1] Route continuation owned by another peer.",
+        index=4,
+        route_continuation_replan_required=True,
+        excluded_agents=[AGENT_ID],
+    )
+    assert (
+        _agent_scope_route_continuation_replan_candidates(
+            {"unclaimed_route_continuation_replan_candidates": [excluded_route]},
+            agent_id=AGENT_ID,
+        )
+        == []
+    )
+
+
 def assert_other_agent_frontier_wait_contract() -> None:
     other_agent_item = todo(
         "todo_primary_owned",
@@ -388,6 +455,7 @@ def main() -> None:
     assert_agent_scoped_user_gate_override_contract()
     assert_agent_scope_frontier_builder_contract()
     assert_agent_scope_frontier_and_hint_contract()
+    assert_executor_exclusions_survive_precomputed_resume_lanes()
     assert_other_agent_frontier_wait_contract()
     print("agent-scope-projection-characterization-smoke ok")
 

--- a/examples/control_plane/todo-deferred-resume-lanes-smoke.py
+++ b/examples/control_plane/todo-deferred-resume-lanes-smoke.py
@@ -64,7 +64,13 @@ def blocked_advancement(
     return {key: value for key, value in item.items() if value is not None}
 
 
-def ready_deferred(todo_id: str, *, index: int, claimed_by: str | None) -> dict:
+def ready_deferred(
+    todo_id: str,
+    *,
+    index: int,
+    claimed_by: str | None,
+    excluded_agents: list[str] | None = None,
+) -> dict:
     item = {
         "index": index,
         "todo_id": todo_id,
@@ -76,6 +82,7 @@ def ready_deferred(todo_id: str, *, index: int, claimed_by: str | None) -> dict:
         "resume_ready": True,
         "required_write_scopes": [" loopx/** ", "loopx/**"],
         "decision_scope": "direction:action:resume",
+        "excluded_agents": excluded_agents,
     }
     return {key: value for key, value in item.items() if value is not None}
 
@@ -96,8 +103,14 @@ def assert_deferred_resume_lanes_filter_current_unclaimed_and_other_agents() -> 
             ready_deferred("todo_current_ready", index=2, claimed_by=CURRENT_AGENT),
             ready_deferred("todo_unclaimed_ready", index=3, claimed_by=None),
             ready_deferred("todo_other_ready", index=4, claimed_by=OTHER_AGENT),
+            ready_deferred(
+                "todo_excluded_ready",
+                index=5,
+                claimed_by=None,
+                excluded_agents=[CURRENT_AGENT],
+            ),
             {
-                **ready_deferred("todo_not_ready", index=5, claimed_by=CURRENT_AGENT),
+                **ready_deferred("todo_not_ready", index=6, claimed_by=CURRENT_AGENT),
                 "resume_ready": False,
             },
         ],
@@ -115,10 +128,15 @@ def assert_deferred_resume_lanes_filter_current_unclaimed_and_other_agents() -> 
         "todo_current_ready",
         "todo_unclaimed_ready",
         "todo_other_ready",
+        "todo_excluded_ready",
     ], lanes
     assert lanes["current_agent_deferred_resume_count"] == 1, lanes
     assert lanes["unclaimed_deferred_resume_count"] == 1, lanes
     assert lanes["other_agent_deferred_resume_count"] == 1, lanes
+    assert lanes["executor_excluded_self_deferred_resume_count"] == 1, lanes
+    assert lanes["executor_excluded_self_deferred_resume_candidates"][0]["todo_id"] == (
+        "todo_excluded_ready"
+    ), lanes
     current = lanes["current_agent_deferred_resume_candidates"][0]
     assert current["required_write_scopes"] == ["loopx/**"], current
     assert current["decision_scope"]["scope_key"] == "resume", current
@@ -151,9 +169,15 @@ def assert_monitor_blocked_resume_lanes_filter_by_claim_and_monitor_target() -> 
         target_task_class="advancement_task",
     )
     non_monitor["resume_condition"]["target_todo_id"] = "todo_regular_open"
+    excluded = blocked_advancement(
+        "todo_excluded_blocked",
+        index=6,
+        claimed_by=None,
+    )
+    excluded["excluded_agents"] = [CURRENT_AGENT]
     summary = {
         "schema_version": "todo_summary_v0",
-        "items": [monitor_todo(), current, unclaimed, other, non_monitor],
+        "items": [monitor_todo(), current, unclaimed, other, non_monitor, excluded],
         "backlog_items": [current],
     }
 
@@ -163,12 +187,14 @@ def assert_monitor_blocked_resume_lanes_filter_by_claim_and_monitor_target() -> 
         "todo_unclaimed_blocked",
         "todo_other_blocked",
         "todo_non_monitor_blocked",
+        "todo_excluded_blocked",
     ], resume_blocked
     monitor_blocked = todo_summary_monitor_blocked_resume_items(summary)
     assert [item["todo_id"] for item in monitor_blocked] == [
         "todo_current_blocked",
         "todo_unclaimed_blocked",
         "todo_other_blocked",
+        "todo_excluded_blocked",
     ], monitor_blocked
     assert all(
         item["blocking_monitor_todo_id"] == "todo_monitor_open"
@@ -180,11 +206,12 @@ def assert_monitor_blocked_resume_lanes_filter_by_claim_and_monitor_target() -> 
         agent_identity={"agent_id": CURRENT_AGENT},
         item_limit=10,
     )
-    assert lanes["resume_blocked_count"] == 4, lanes
-    assert lanes["monitor_blocked_resume_count"] == 3, lanes
+    assert lanes["resume_blocked_count"] == 5, lanes
+    assert lanes["monitor_blocked_resume_count"] == 4, lanes
     assert lanes["current_agent_monitor_blocked_resume_count"] == 1, lanes
     assert lanes["unclaimed_monitor_blocked_resume_count"] == 1, lanes
     assert lanes["other_agent_monitor_blocked_resume_count"] == 1, lanes
+    assert lanes["executor_excluded_self_monitor_blocked_resume_count"] == 1, lanes
     assert lanes["monitor_blocked_resume_selection_policy"] == (
         TODO_MONITOR_BLOCKED_RESUME_SELECTION_POLICY
     ), lanes

--- a/loopx/control_plane/agents/agent_scope.py
+++ b/loopx/control_plane/agents/agent_scope.py
@@ -726,6 +726,8 @@ def _agent_scope_deferred_resume_candidates(
     unique: list[dict[str, Any]] = []
     seen: set[str] = set()
     for item in candidates:
+        if todo_item_excludes_agent(item, agent_id=agent_id):
+            continue
         if item.get("resume_ready") is not True:
             continue
         if not todo_item_is_deferred(item):
@@ -762,6 +764,8 @@ def _agent_scope_monitor_blocked_resume_candidates(
     unique: list[dict[str, Any]] = []
     seen: set[str] = set()
     for item in candidates:
+        if todo_item_excludes_agent(item, agent_id=agent_id):
+            continue
         if _todo_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
             continue
         if item.get("resume_ready") is not False:
@@ -900,6 +904,11 @@ def _agent_scope_route_continuation_replan_candidates(
     unique: list[dict[str, Any]] = []
     seen: set[str] = set()
     for item in candidates:
+        if not _route_continuation_candidate_matches_agent(
+            item,
+            agent_id=agent_id,
+        ):
+            continue
         if item.get("route_continuation_replan_required") is False:
             continue
         identity = str(

--- a/loopx/control_plane/todos/deferred_resume.py
+++ b/loopx/control_plane/todos/deferred_resume.py
@@ -17,13 +17,18 @@ from .contract import (
     normalize_todo_status,
     normalize_todo_task_class,
 )
-from .projection import todo_item_is_deferred, todo_projection_sort_key
+from .projection import (
+    todo_item_excludes_agent,
+    todo_item_is_deferred,
+    todo_projection_sort_key,
+)
 
 
 TODO_DEFERRED_RESUME_SELECTION_POLICY = (
     "quota may wake the current peer only for ready deferred todos "
     "claimed by that agent or unclaimed; other-agent deferred todos remain "
-    "diagnostic visibility"
+    "diagnostic visibility and executor-excluded todos remain visible but "
+    "non-selectable"
 )
 TODO_MONITOR_BLOCKED_RESUME_SELECTION_POLICY = (
     "open advancement todos gated by todo_done:<continuous_monitor> must "
@@ -302,6 +307,14 @@ def _agent_claim_filtered_deferred_items(
     selected: list[dict[str, Any]] = []
     for item in items:
         claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
+        excluded = todo_item_excludes_agent(item, agent_id=agent_id)
+        if claim == "excluded":
+            if not excluded:
+                continue
+            selected.append(item)
+            continue
+        if excluded:
+            continue
         if claim == "current" and claimed_by != agent_id:
             continue
         if claim == "unclaimed" and claimed_by:
@@ -356,6 +369,11 @@ def build_todo_resume_blocked_visibility_lanes(
             agent_id=agent_id,
             claim="other",
         )
+        excluded_self_candidates = _agent_claim_filtered_deferred_items(
+            monitor_blocked_items,
+            agent_id=agent_id,
+            claim="excluded",
+        )
         lanes.update(
             {
                 "current_agent_monitor_blocked_resume_candidates": (
@@ -372,6 +390,12 @@ def build_todo_resume_blocked_visibility_lanes(
                 ),
                 "unclaimed_monitor_blocked_resume_count": len(unclaimed_candidates),
                 "other_agent_monitor_blocked_resume_count": len(other_agent_candidates),
+                "executor_excluded_self_monitor_blocked_resume_candidates": (
+                    excluded_self_candidates[:item_limit]
+                ),
+                "executor_excluded_self_monitor_blocked_resume_count": len(
+                    excluded_self_candidates
+                ),
                 "monitor_blocked_resume_selection_policy": (
                     TODO_MONITOR_BLOCKED_RESUME_SELECTION_POLICY
                 ),
@@ -424,6 +448,11 @@ def build_todo_deferred_visibility_lanes(
             agent_id=agent_id,
             claim="other",
         )
+        excluded_self_candidates = _agent_claim_filtered_deferred_items(
+            deferred_resume_candidates,
+            agent_id=agent_id,
+            claim="excluded",
+        )
         lanes.update(
             {
                 "current_agent_deferred_resume_candidates": (
@@ -438,6 +467,12 @@ def build_todo_deferred_visibility_lanes(
                 "current_agent_deferred_resume_count": len(current_agent_candidates),
                 "unclaimed_deferred_resume_count": len(unclaimed_candidates),
                 "other_agent_deferred_resume_count": len(other_agent_candidates),
+                "executor_excluded_self_deferred_resume_candidates": (
+                    excluded_self_candidates[:item_limit]
+                ),
+                "executor_excluded_self_deferred_resume_count": len(
+                    excluded_self_candidates
+                ),
                 "deferred_resume_selection_policy": (
                     TODO_DEFERRED_RESUME_SELECTION_POLICY
                 ),


### PR DESCRIPTION
## Summary
- keep executor-excluded deferred and monitor-blocked todos visible as diagnostics but out of current-peer selectable lanes
- defensively re-check peer exclusions in deferred, monitor-blocked, and route-continuation selectors
- add focused parity coverage for eligible fallback selection and excluded resume lanes

## Validation
- `python -m pytest -q -n auto` (107 passed, 2 skipped)
- focused deferred-resume, agent-scope, quota replan, and work-lane smokes
- Ruff checks on changed files
- `loopx canary premerge --from-git-diff` (17/17 passed; no manual holds; public boundary clean)