### PR TITLE
Guard rolling context provider sync ownership

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -707,6 +707,7 @@ issue-fix caller for verification; it is not encoded into the provider scope:
   "timeout_seconds": 15,
   "sync_timeout_seconds": 180,
   "resource_references": ["src/module.py", "tests/test_module.py"],
+  "service_ownership_receipt_path": ".loopx/context-provider-service.json",
   "writeback_enabled": false,
   "writeback_scope_ref": "viking://resources/public-repository/owner-repo/outcomes/<git-revision>",
   "workspace_scope": "owner-repo",
@@ -722,6 +723,19 @@ on an activation receipt. A hit from the rolling index remains advisory: LoopX
 maps it to a repo-relative file and verifies it against the current checkout
 before it can influence reproduction, change scope, patch, or validation.
 Unverified or stale hits remain counts only.
+
+Retrieval and a provider-owned watch do not need a LoopX process lease. A
+LoopX-triggered rolling sync is different because it can start a long external
+write from a short-lived agent host. Before that write, LoopX requires a local
+`context_provider_service_ownership_receipt_v0` from a persistent external
+service or supervisor. The receipt names the provider, an opaque service
+identity, its generation, and a live process id. LoopX reads it before and
+after the sync, never publishes its path or process id, and blocks with zero
+writes when ownership is absent. If the generation or process changes during
+the call, the result is `restart_detected_no_resume`: completed or pending
+writes and elapsed time remain recorded as an additional attempt rather than
+being reported as resumed progress. This contract is provider-neutral and
+does not make LoopX a provider process manager.
 
 `pinned` remains available for an intentionally immutable corpus. In that
 compatibility mode, `repository_revision` must match the caller checkout and

--- a/docs/capabilities/issue-fix/README.zh-CN.md
+++ b/docs/capabilities/issue-fix/README.zh-CN.md
@@ -677,6 +677,7 @@ memory body、自动 transcript capture、私有 namespace、凭据和 provider 
   "timeout_seconds": 15,
   "sync_timeout_seconds": 180,
   "resource_references": ["src/module.py", "tests/test_module.py"],
+  "service_ownership_receipt_path": ".loopx/context-provider-service.json",
   "writeback_enabled": false,
   "writeback_scope_ref": "viking://resources/public-repository/owner-repo/outcomes/<git-revision>",
   "workspace_scope": "owner-repo",
@@ -689,6 +690,15 @@ memory body、自动 transcript capture、私有 namespace、凭据和 provider 
 scope，不保存 active revision，也不会等待 activation receipt 才允许检索。rolling index 的
 命中始终只是 advisory：LoopX 把它映射回 repo-relative 文件，并在当前 checkout 验证后，
 才允许影响 reproduction、change scope、patch 或 validation；未验证或过期命中只保留计数。
+
+普通 retrieval 与 provider 自己维护的 watch 不需要 LoopX 进程租约；但由 LoopX 主动触发的
+rolling sync 可能从短生命周期 agent host 发起长时间外部写入，因此语义不同。写入前，LoopX
+要求持久外部服务或 supervisor 提供本地
+`context_provider_service_ownership_receipt_v0`，其中声明 provider、服务身份、generation 与
+仍存活的进程 id。LoopX 会在 sync 前后各读取一次，不向公开 packet 暴露收据路径或进程 id；
+缺失时保持零写入并明确阻塞。若调用期间 generation 或进程发生变化，结果会标为
+`restart_detected_no_resume`：已经完成或 pending 的写入与耗时仍作为新增的一次 attempt 计入，
+但不会伪装成断点续跑。该 contract 对 provider 通用，也不会让 LoopX 变成 provider 进程管理器。
 
 有意维护 immutable corpus 时仍可使用 `pinned` 兼容模式。此时
 `repository_revision` 必须匹配调用方 checkout，且 revision 必须出现在 `scope_ref`：

--- a/examples/context-provider-service-ownership-smoke.py
+++ b/examples/context-provider-service-ownership-smoke.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Smoke-test persistent context-provider service ownership receipts."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx.capabilities.context_providers.service_ownership import (  # noqa: E402
+    context_provider_service_restarted,
+    load_context_provider_service_ownership,
+)
+
+
+def write_receipt(path: Path, *, generation: str, pid: int) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "context_provider_service_ownership_receipt_v0",
+                "provider": "contract-provider",
+                "service_ref": "public-index-service",
+                "ownership_mode": "persistent_external",
+                "generation": generation,
+                "pid": pid,
+                "observed_at": "2026-07-12T04:30:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-provider-ownership-") as tmpdir:
+        receipt = Path(tmpdir) / "service.json"
+
+        missing = load_context_provider_service_ownership(
+            receipt,
+            expected_provider="contract-provider",
+        )
+        assert missing.verified is False
+        assert missing.reason_code == "provider_service_ownership_receipt_unavailable"
+
+        write_receipt(receipt, generation="generation-1", pid=os.getpid())
+        before = load_context_provider_service_ownership(
+            receipt,
+            expected_provider="contract-provider",
+        )
+        assert before.verified is True
+        public = before.public_packet(required=True, attempt_latency_ms=37)
+        assert public["status"] == "verified"
+        assert public["progress_disposition"] == "fresh_attempt"
+        assert public["cost_accounting"] == "append_attempt"
+        assert public["attempt_latency_ms"] == 37
+
+        encoded = json.dumps(public, sort_keys=True)
+        assert str(receipt) not in encoded
+        assert str(os.getpid()) not in encoded
+        assert "public-index-service" not in encoded
+
+        write_receipt(receipt, generation="generation-2", pid=os.getpid())
+        after = load_context_provider_service_ownership(
+            receipt,
+            expected_provider="contract-provider",
+        )
+        assert context_provider_service_restarted(before, after) is True
+        restarted = after.public_packet(required=True, restart_detected=True)
+        assert restarted["ok"] is False
+        assert restarted["status"] == "restarted"
+        assert restarted["progress_disposition"] == "restart_detected_no_resume"
+        assert restarted["cost_accounting"] == "append_attempt"
+
+        malformed = json.loads(receipt.read_text(encoding="utf-8"))
+        malformed.pop("observed_at")
+        receipt.write_text(json.dumps(malformed), encoding="utf-8")
+        invalid = load_context_provider_service_ownership(
+            receipt,
+            expected_provider="contract-provider",
+        )
+        assert invalid.verified is False
+        assert invalid.reason_code == "provider_service_ownership_receipt_invalid"
+
+    print("context-provider-service-ownership-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/issue-fix-repository-memory-smoke.py
+++ b/examples/issue-fix-repository-memory-smoke.py
@@ -77,11 +77,13 @@ class RollingProvider(ContractProvider):
         resource_ref: str,
         content: str,
         sync_status: str = "completed",
+        restart_receipt_path: Path | None = None,
     ) -> None:
         super().__init__(resource_ref=resource_ref, content=content)
         self.sync_status = sync_status
         self.retrieve_count = 0
         self.sync_count = 0
+        self.restart_receipt_path = restart_receipt_path
 
     def retrieve(self, **kwargs: Any) -> ContextProviderRetrieval:
         self.retrieve_count += 1
@@ -89,6 +91,13 @@ class RollingProvider(ContractProvider):
 
     def sync(self, **kwargs: Any) -> ContextProviderSync:
         self.sync_count += 1
+        if self.restart_receipt_path is not None:
+            receipt = json.loads(self.restart_receipt_path.read_text(encoding="utf-8"))
+            receipt["generation"] = "provider-generation-2"
+            receipt["pid"] = os.getpid()
+            self.restart_receipt_path.write_text(
+                json.dumps(receipt), encoding="utf-8"
+            )
         resources = list(kwargs["resources"])
         return ContextProviderSync(
             provider="contract_provider",
@@ -228,6 +237,23 @@ def repository_context() -> dict[str, object]:
             },
         ],
     }
+
+
+def write_service_receipt(path: Path, *, generation: str = "provider-generation-1") -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "context_provider_service_ownership_receipt_v0",
+                "provider": "contract_provider",
+                "service_ref": "public-repository-index-service",
+                "ownership_mode": "persistent_external",
+                "generation": generation,
+                "pid": os.getpid(),
+                "observed_at": "2026-07-11T03:30:00+08:00",
+            }
+        ),
+        encoding="utf-8",
+    )
 
 
 def completed_memory() -> dict[str, object]:
@@ -541,6 +567,8 @@ def main() -> int:
         assert_boundary(provider_result)
 
         rolling_scope = "viking://resources/public-repository/example-repo/main"
+        service_receipt_path = checkout / "provider-service-receipt.json"
+        write_service_receipt(service_receipt_path)
         rolling_provider = RollingProvider(
             resource_ref=f"{rolling_scope}/src/worker.py",
             content=source.read_text(encoding="utf-8"),
@@ -557,6 +585,7 @@ def main() -> int:
             "max_results": 3,
             "timeout_seconds": 5,
             "sync_timeout_seconds": 5,
+            "service_ownership_receipt_path": str(service_receipt_path),
         }
         rolling_retrieval = retrieve_issue_fix_repository_memory(
             config=rolling_config,
@@ -596,11 +625,60 @@ def main() -> int:
             provider=rolling_provider,
         )
         assert rolling_sync["status"] == "completed", rolling_sync
+        assert rolling_sync["provider_service_ownership"]["status"] == "verified"
+        assert rolling_sync["provider_service_ownership"]["restart_detected"] is False
+        assert rolling_sync["provider_service_ownership"]["progress_disposition"] == "fresh_attempt"
+        assert rolling_sync["provider_service_ownership"]["cost_accounting"] == "append_attempt"
         assert rolling_sync["revision_scoped"] is False
         assert "repository_context_activation" not in rolling_sync
         assert rolling_provider.sync_count == 1
         assert rolling_scope not in json.dumps(rolling_sync)
         assert_boundary(rolling_sync)
+
+        missing_receipt_provider = RollingProvider(
+            resource_ref=f"{rolling_scope}/src/worker.py",
+            content=source.read_text(encoding="utf-8"),
+        )
+        missing_receipt_sync = sync_issue_fix_repository_memory(
+            config={
+                key: value
+                for key, value in rolling_config.items()
+                if key != "service_ownership_receipt_path"
+            },
+            repo_path=checkout,
+            repository_revision=REVISION,
+            references=["src/worker.py"],
+            observed_at="2026-07-11T03:31:15+08:00",
+            execute=True,
+            provider=missing_receipt_provider,
+        )
+        assert missing_receipt_sync["status"] == "blocked", missing_receipt_sync
+        assert missing_receipt_sync["reason_code"] == "provider_service_ownership_receipt_required"
+        assert missing_receipt_sync["external_writes_performed"] is False
+        assert missing_receipt_provider.sync_count == 0
+
+        restarting_provider = RollingProvider(
+            resource_ref=f"{rolling_scope}/src/worker.py",
+            content=source.read_text(encoding="utf-8"),
+            restart_receipt_path=service_receipt_path,
+        )
+        restarted_sync = sync_issue_fix_repository_memory(
+            config=rolling_config,
+            repo_path=checkout,
+            repository_revision=REVISION,
+            references=["src/worker.py"],
+            observed_at="2026-07-11T03:31:20+08:00",
+            execute=True,
+            provider=restarting_provider,
+        )
+        assert restarted_sync["status"] == "partial", restarted_sync
+        ownership = restarted_sync["provider_service_ownership"]
+        assert ownership["restart_detected"] is True, ownership
+        assert ownership["progress_disposition"] == "restart_detected_no_resume", ownership
+        assert ownership["cost_accounting"] == "append_attempt", ownership
+        assert restarted_sync["write_count"] == 1, restarted_sync
+        assert restarted_sync["external_writes_performed"] is True, restarted_sync
+        assert restarted_sync["reason_code"] == "provider_service_restarted", restarted_sync
 
         pending_provider = RollingProvider(
             resource_ref=f"{rolling_scope}/src/worker.py",

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -962,6 +962,7 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
             "examples/issue-fix-validated-memory-writeback-smoke.py",
             "loopx/capabilities/issue_fix/outcome_projection.py",
             "loopx/capabilities/issue_fix/repository_memory_provider.py",
+            "loopx/capabilities/context_providers/service_ownership.py",
             "loopx/presentation/sinks/lark/projection_rows.py",
             "projection_source_reconcile",
         ),
@@ -976,6 +977,7 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
                 "tier": "default",
                 "reason": "guards explicit owner gating, validated distilled facts, idempotent provider writes, and unsafe-capture rejection",
             },
+            {"command": "python3 examples/context-provider-service-ownership-smoke.py", "tier": "default", "reason": "guards persistent ownership, restart detection, append-attempt accounting, and public-safe receipts"},
             {"command": "python3 examples/lark-projection-source-reconcile-smoke.py",
              "tier": "default", "reason": "guards preview-first complete-source "
              "orphan and stale-mapping reconciliation"},

--- a/loopx/capabilities/context_providers/__init__.py
+++ b/loopx/capabilities/context_providers/__init__.py
@@ -10,6 +10,10 @@ from .base import (
 )
 from .openviking import OpenVikingContextProvider
 from .factory import build_context_provider
+from .service_ownership import (
+    context_provider_service_restarted,
+    load_context_provider_service_ownership,
+)
 
 __all__ = [
     "ContextProviderItem",
@@ -17,6 +21,8 @@ __all__ = [
     "ContextProviderSync",
     "OpenVikingContextProvider",
     "build_context_provider",
+    "context_provider_service_restarted",
+    "load_context_provider_service_ownership",
     "canonical_context_text",
     "canonical_context_lines",
     "canonical_context_matches",

--- a/loopx/capabilities/context_providers/service_ownership.py
+++ b/loopx/capabilities/context_providers/service_ownership.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+
+CONTEXT_PROVIDER_SERVICE_RECEIPT_SCHEMA_VERSION = (
+    "context_provider_service_ownership_receipt_v0"
+)
+_RECEIPT_FIELDS = {
+    "schema_version",
+    "provider",
+    "service_ref",
+    "ownership_mode",
+    "generation",
+    "pid",
+    "observed_at",
+}
+_LABEL = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,119}$")
+
+
+def _opaque_ref(kind: str, value: str) -> str:
+    digest = hashlib.sha256(f"{kind}\n{value}".encode("utf-8")).hexdigest()[:20]
+    return f"{kind}-{digest}"
+
+
+def _process_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+@dataclass(frozen=True)
+class ContextProviderServiceOwnership:
+    provider: str
+    status: str
+    reason_code: str
+    ownership_mode: str = "unknown"
+    service_ref: str = ""
+    generation: str = ""
+    pid: int = 0
+    process_alive: bool = False
+
+    @property
+    def verified(self) -> bool:
+        return self.status == "verified"
+
+    def public_packet(
+        self,
+        *,
+        required: bool,
+        restart_detected: bool = False,
+        attempt_latency_ms: int = 0,
+    ) -> dict[str, object]:
+        if restart_detected:
+            status = "restarted"
+            reason_code = "provider_service_restarted"
+            progress_disposition = "restart_detected_no_resume"
+        elif self.verified:
+            status = "verified"
+            reason_code = None
+            progress_disposition = "fresh_attempt"
+        else:
+            status = self.status
+            reason_code = self.reason_code
+            progress_disposition = "not_started"
+        return {
+            "schema_version": "context_provider_service_ownership_v0",
+            "ok": status == "verified",
+            "required": required,
+            "status": status,
+            "reason_code": reason_code,
+            "provider": self.provider,
+            "ownership_mode": self.ownership_mode,
+            "service_ref": (
+                _opaque_ref("service", self.service_ref) if self.service_ref else None
+            ),
+            "generation_ref": (
+                _opaque_ref("generation", self.generation)
+                if self.generation
+                else None
+            ),
+            "process_alive": self.process_alive,
+            "restart_detected": restart_detected,
+            "progress_disposition": progress_disposition,
+            "cost_accounting": "append_attempt",
+            "attempt_latency_ms": max(0, int(attempt_latency_ms)),
+            "raw_receipt_captured": False,
+            "process_id_captured": False,
+            "local_path_captured": False,
+        }
+
+
+def load_context_provider_service_ownership(
+    receipt_path: str | Path | None,
+    *,
+    expected_provider: str,
+) -> ContextProviderServiceOwnership:
+    if not receipt_path:
+        return ContextProviderServiceOwnership(
+            provider=expected_provider,
+            status="missing",
+            reason_code="provider_service_ownership_receipt_required",
+        )
+    try:
+        payload = json.loads(Path(receipt_path).expanduser().read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return ContextProviderServiceOwnership(
+            provider=expected_provider,
+            status="unavailable",
+            reason_code="provider_service_ownership_receipt_unavailable",
+        )
+    if not isinstance(payload, Mapping):
+        return ContextProviderServiceOwnership(
+            provider=expected_provider,
+            status="invalid",
+            reason_code="provider_service_ownership_receipt_invalid",
+        )
+    if payload.get("schema_version") != CONTEXT_PROVIDER_SERVICE_RECEIPT_SCHEMA_VERSION:
+        return ContextProviderServiceOwnership(
+            provider=expected_provider,
+            status="invalid",
+            reason_code="provider_service_ownership_receipt_invalid",
+        )
+    if set(payload) != _RECEIPT_FIELDS:
+        return ContextProviderServiceOwnership(
+            provider=expected_provider,
+            status="invalid",
+            reason_code="provider_service_ownership_receipt_invalid",
+        )
+    provider = str(payload.get("provider") or "")
+    service_ref = str(payload.get("service_ref") or "")
+    generation = str(payload.get("generation") or "")
+    ownership_mode = str(payload.get("ownership_mode") or "")
+    pid = payload.get("pid")
+    if (
+        provider != expected_provider
+        or not _LABEL.fullmatch(provider)
+        or not _LABEL.fullmatch(service_ref)
+        or not _LABEL.fullmatch(generation)
+        or ownership_mode != "persistent_external"
+        or not isinstance(pid, int)
+        or isinstance(pid, bool)
+        or pid <= 0
+    ):
+        return ContextProviderServiceOwnership(
+            provider=expected_provider,
+            status="invalid",
+            reason_code="provider_service_ownership_receipt_invalid",
+            ownership_mode=ownership_mode or "unknown",
+        )
+    alive = _process_alive(pid)
+    return ContextProviderServiceOwnership(
+        provider=provider,
+        status="verified" if alive else "unavailable",
+        reason_code=("" if alive else "provider_service_process_unavailable"),
+        ownership_mode=ownership_mode,
+        service_ref=service_ref,
+        generation=generation,
+        pid=pid,
+        process_alive=alive,
+    )
+
+
+def context_provider_service_restarted(
+    before: ContextProviderServiceOwnership,
+    after: ContextProviderServiceOwnership,
+) -> bool:
+    return bool(
+        before.verified
+        and after.verified
+        and (
+            before.generation != after.generation
+            or before.pid != after.pid
+        )
+    )

--- a/loopx/capabilities/issue_fix/repository_memory_provider.py
+++ b/loopx/capabilities/issue_fix/repository_memory_provider.py
@@ -11,7 +11,12 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 from urllib.parse import unquote
 
-from ..context_providers import build_context_provider, canonical_context_matches
+from ..context_providers import (
+    build_context_provider,
+    canonical_context_matches,
+    context_provider_service_restarted,
+    load_context_provider_service_ownership,
+)
 from ..context_providers.base import ContextProvider, opaque_provider_ref
 from ...control_plane.runtime.public_safety import public_safe_compact_text
 from .repository_memory import (
@@ -48,6 +53,7 @@ _CONFIG_FIELDS = {
     "writeback_scope_ref",
     "workspace_scope",
     "peer_scope",
+    "service_ownership_receipt_path",
 }
 _REMOVED_REVISION_LIFECYCLE_FIELDS = {
     "repository_scope_root",
@@ -251,6 +257,9 @@ def _normalise_config(
     writeback_scope_ref = str(config.get("writeback_scope_ref") or "").strip()
     workspace_scope = str(config.get("workspace_scope") or "").strip()
     peer_scope = str(config.get("peer_scope") or "").strip()
+    service_ownership_receipt_path = str(
+        config.get("service_ownership_receipt_path") or ""
+    ).strip()
     if writeback_enabled:
         writeback_scope_ref = _compact(
             writeback_scope_ref,
@@ -283,6 +292,7 @@ def _normalise_config(
         "writeback_scope_ref": writeback_scope_ref,
         "workspace_scope": workspace_scope,
         "peer_scope": peer_scope,
+        "service_ownership_receipt_path": service_ownership_receipt_path,
     }
 
 
@@ -931,6 +941,38 @@ def sync_issue_fix_repository_memory(
         resources.append((str(source), f"{scope_ref}/{reference.as_posix()}"))
 
     provider = provider or build_context_provider(normalised)
+    ownership_required = normalised["revision_policy"] == "rolling_default_branch"
+    ownership_before = (
+        load_context_provider_service_ownership(
+            normalised["service_ownership_receipt_path"],
+            expected_provider=str(normalised["provider"]),
+        )
+        if ownership_required
+        else None
+    )
+    if execute and ownership_before is not None and not ownership_before.verified:
+        return {
+            "schema_version": "issue_fix_repository_memory_sync_v0",
+            "ok": False,
+            "status": "blocked",
+            "reason_code": ownership_before.reason_code,
+            "provider": normalised["provider"],
+            "namespace": normalised["namespace"],
+            "repository_revision": repository_revision,
+            "requested_reference_count": len(resources),
+            "completed_count": 0,
+            "write_count": 0,
+            "pending_count": 0,
+            "external_writes_performed": False,
+            "fail_open": True,
+            "revision_scoped": False,
+            "automatic_capture_performed": False,
+            "memory_writeback_performed": False,
+            "repository_context": repository_context,
+            "provider_service_ownership": ownership_before.public_packet(
+                required=True
+            ),
+        }
     sync = provider.sync(
         namespace=str(normalised["namespace"]),
         resources=resources,
@@ -939,6 +981,37 @@ def sync_issue_fix_repository_memory(
         execute=execute,
     )
     packet = sync.public_packet()
+    ownership_after = (
+        load_context_provider_service_ownership(
+            normalised["service_ownership_receipt_path"],
+            expected_provider=str(normalised["provider"]),
+        )
+        if ownership_required
+        else None
+    )
+    restart_detected = bool(
+        ownership_before is not None
+        and ownership_after is not None
+        and context_provider_service_restarted(ownership_before, ownership_after)
+    )
+    if execute and restart_detected:
+        packet.update(
+            {
+                "ok": False,
+                "status": "partial",
+                "reason_code": "provider_service_restarted",
+                "retry_disposition": "restart_detected_no_resume",
+            }
+        )
+    elif execute and ownership_after is not None and not ownership_after.verified:
+        packet.update(
+            {
+                "ok": False,
+                "status": "partial",
+                "reason_code": "provider_service_ownership_lost",
+                "retry_disposition": "manual_reconcile",
+            }
+        )
     packet.update(
         {
             "schema_version": "issue_fix_repository_memory_sync_v0",
@@ -950,6 +1023,12 @@ def sync_issue_fix_repository_memory(
             "repository_context": repository_context,
         }
     )
+    if ownership_after is not None:
+        packet["provider_service_ownership"] = ownership_after.public_packet(
+            required=True,
+            restart_detected=restart_detected,
+            attempt_latency_ms=sync.latency_ms,
+        )
     return packet
 
 


### PR DESCRIPTION
## Summary

- require a provider-neutral persistent service ownership receipt before an explicit rolling context-provider sync can write
- compare service generation and process identity around the call so a restart becomes `restart_detected_no_resume` instead of false resumed progress
- preserve completed/pending writes and elapsed time as an additional attempt, while keeping retrieval, provider-owned watch, and pinned sync behavior unchanged
- document the contract in the bilingual issue-fix guide and register focused canary coverage

## Validation

- `python3 examples/context-provider-service-ownership-smoke.py`
- `python3 examples/issue-fix-repository-memory-smoke.py`
- `python3 examples/issue-fix-capability-guide-smoke.py`
- `uvx ruff check` on all touched Python paths
- `python3 -m loopx.cli canary premerge --from-git-diff` (17/17 checks passed)
- real OpenViking CLI call: missing receipt blocked before provider invocation with zero writes; a live persistent-service receipt completed the same rolling sync with verified ownership and no restart

## Risk and compatibility

The intentional behavior change is limited to `rolling_default_branch` syncs executed with external writes enabled. They now fail closed when no live persistent-service receipt is available. LoopX does not launch or supervise the provider, and public packets never include the receipt path or process id. Retrieval, provider-owned refresh/watch, and pinned syncs keep their existing behavior.
