### PR TITLE
Right-size CLI module ownership budgets

### DIFF
--- a/examples/cli-command-module-size-ownership-command-modularization-smoke.py
+++ b/examples/cli-command-module-size-ownership-command-modularization-smoke.py
@@ -8,21 +8,10 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 CLI_COMMANDS = ROOT / "loopx" / "cli_commands"
 
-DEFAULT_MAX_LINES = 500
+DEFAULT_MAX_LINES = 1000
 LEGACY_MODULE_LIMITS = {
     "benchmark_review_lifecycle.py": 1300,
-    "benchmark_run_ledger.py": 820,
-    "canary.py": 580,
-    "explore.py": 800,
-    "history.py": 720,
-    "project_lifecycle.py": 580,
-    "registry_admin.py": 780,
-    "status.py": 940,
-    "support_control.py": 620,
-    "terminal_bench_adapter.py": 760,
     "terminal_bench_environment_result.py": 1280,
-    "todo.py": 860,
-    "worker_bridge.py": 700,
 }
 STARTER_MODULE_LIMITS = {
     "starter.py": 180,
@@ -96,7 +85,7 @@ def assert_module_size_budgets() -> None:
         require(
             count <= limit,
             f"{path.name} has {count} lines, above budget {limit}; "
-            "split the command family before adding more code",
+            "extract a cohesive command owner before adding more code",
         )
 
     for module_name in sorted(LEGACY_MODULE_LIMITS):


### PR DESCRIPTION
## Summary

- raise the default `loopx/cli_commands` ownership budget from 500 to 1000 lines
- keep the intentionally narrow starter-family budgets unchanged
- retain temporary legacy exceptions only for the two modules that are actually above 1000 lines
- replace the prescriptive split-only failure text with a cohesive-owner extraction hint

This is a validation-policy correction, not a runtime behavior change. It avoids mechanical module moves that add indirection without a concrete ownership benefit.

## Validation

- `python3 examples/cli-command-module-size-ownership-command-modularization-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- exact Full Public shard 1: 100/100 checks passed with the CI timeout of 120 seconds
- `loopx canary premerge --from-git-diff`: 4/4 selected checks passed, public boundary clean, self-merge allowed
- `git diff --check`

## Scope

One durable public validation smoke only. No runtime, CLI behavior, permission, benchmark, evidence-policy, private state, or generated log changes.