### PR TITLE
Prepare LoopX v0.2.1

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -200,6 +200,19 @@ path, and canary route rather than as a user-facing release baseline.
   public result contracts, while install/update, release provenance, quota,
   todo, scheduler, and protocol-action smokes were swept under the full-public
   suite for the 0.2 release cut.
+- `v0.2.1` on 2026-07-12: agent-facing quality and long-run reliability
+  fast-follow at the matching `v0.2.1` tag. This release makes bounded turn
+  context explicit through TurnEnvelope contracts, adds trajectory-hygiene
+  and packet-duplication measurements, and preserves action contracts while
+  trimming repeated hot-path material. Issue-Fix gains repository snapshots,
+  decision-useful memory, Explore projection, reviewer/CI receipts, impact
+  metrics, and guarded promotion of newly discovered public defects. Optional
+  Explore planning now preserves independent experiment lanes and supports
+  resource-aware portfolio decisions. Peer routing is hardened across task
+  lease validity, advisory agent profiles, deferred successor exclusions, and
+  non-blocking user actions. The repository also establishes parallel pytest,
+  Ruff, strict typing, import-boundary, coverage-floor, and release-promotion
+  concurrency checks so these broader capabilities remain maintainable.
 
 When a new public release is promoted, add it here only after the matching tag,
 release note, stable ref, update path, and focused release canary agree.

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.2.0"
+version = "0.2.1"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- bump the package and runtime version to 0.2.1
- record the v0.2.1 release scope in the release-readiness history
- frame this release as an agent-facing quality and long-run reliability fast-follow

## Validation

- python examples/release/release-version-contract-smoke.py
- python examples/release/release-readiness-doc-smoke.py
- full pytest: 111 passed, 2 skipped
- loopx canary premerge --from-git-diff: 17/17 passed
- release/update/no-clone/fresh-clone smokes passed
- public/private boundary scan passed
- dashboard browser check skipped because the dashboard is unchanged and npm dependencies are not installed in this release worktree

## Risk

Low and reversible. This PR changes version metadata and release documentation only; it does not change runtime behavior.
