### PR TITLE
Fix diagnose runtime capability projection

### DIFF
--- a/examples/agent-diagnose-packet-smoke.py
+++ b/examples/agent-diagnose-packet-smoke.py
@@ -17,6 +17,7 @@ from loopx.diagnose import _first_agent_todo_text, render_diagnosis_markdown  # 
 
 GOAL_ID = "diagnose-smoke-goal"
 SCOPED_GOAL_ID = "diagnose-smoke-agent-scoped"
+CAPABILITY_GOAL_ID = "diagnose-smoke-runtime-capability"
 
 
 def run_cli(*args: str, cwd: Path = REPO_ROOT) -> dict:
@@ -216,6 +217,69 @@ def write_agent_scoped_registry(root: Path, runtime: Path) -> Path:
     return registry
 
 
+def write_capability_scoped_registry(root: Path, runtime: Path) -> Path:
+    project = write_project(root, "capability-scoped-project")
+    state_file = f".codex/goals/{CAPABILITY_GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_path = project / state_file
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Runtime-Capability Diagnose Fixture\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P1] Fetch bounded public evidence for the selected repair.\n"
+        "  <!-- loopx:todo todo_id=todo_network_repair status=open "
+        "task_class=advancement_task action_kind=fetch_evidence "
+        "claimed_by=codex-main-control priority=P1 "
+        "required_capabilities=network -->\n",
+        encoding="utf-8",
+    )
+    registry = project / ".loopx" / "registry.json"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": CAPABILITY_GOAL_ID,
+                        "domain": "agent-diagnose-fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": state_file,
+                        "adapter": {
+                            "kind": "fixture_connected_delivery_v0",
+                            "status": "connected-delivery",
+                        },
+                        "quota": {"compute": 1.0, "window_hours": 24},
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": ["codex-main-control"],
+                            "agent_profiles": {
+                                "codex-main-control": {
+                                    "schema_version": "agent_profile_v1",
+                                    "profile_role": "delivery",
+                                    "scope": "bounded public delivery",
+                                }
+                            },
+                            "write_scope": ["docs/**"],
+                        },
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry
+
+
 def main() -> int:
     assert_selected_agent_todo_preferred()
     assert_diagnose_markdown_separates_status_and_packet_goal_counts()
@@ -330,6 +394,47 @@ def main() -> int:
         assert any(
             f"--goal-id {SCOPED_GOAL_ID}" in command for command in scoped_selected["agent_commands"]
         ), scoped_selected
+
+        capability_registry = write_capability_scoped_registry(root, runtime)
+        capability_blocked = run_cli(
+            "--registry",
+            str(capability_registry),
+            "--runtime-root",
+            str(runtime),
+            "diagnose",
+            "--goal-id",
+            CAPABILITY_GOAL_ID,
+            "--agent-id",
+            "codex-main-control",
+        )
+        assert capability_blocked["selected"]["machine_signal"] == "user_or_controller_attention", (
+            capability_blocked
+        )
+
+        capability_ready = run_cli(
+            "--registry",
+            str(capability_registry),
+            "--runtime-root",
+            str(runtime),
+            "diagnose",
+            "--goal-id",
+            CAPABILITY_GOAL_ID,
+            "--agent-id",
+            "codex-main-control",
+            "--available-capability",
+            "network",
+        )
+        capability_selected = capability_ready["selected"]
+        assert capability_ready["available_capabilities"] == ["network"], capability_ready
+        assert capability_selected["available_capabilities"] == ["network"], capability_selected
+        assert capability_selected["machine_signal"] == "agent_work_attention", capability_selected
+        assert capability_selected["quota_signals"]["should_run"] is True, capability_selected
+        assert capability_selected["quota_signals"]["action_required"] is False, capability_selected
+        assert capability_selected["quota_signals"]["open_count"] == 0, capability_selected
+        assert any(
+            "--available-capability network" in command
+            for command in capability_selected["agent_commands"]
+        ), capability_selected
 
     print("agent-diagnose-packet-smoke ok")
     return 0

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -206,6 +206,16 @@ def register_status_commands(
         ),
     )
     diagnose_parser.add_argument(
+        "--available-capability",
+        dest="available_capabilities",
+        action="append",
+        help=(
+            "Declare a capability available in the current agent environment. "
+            "Repeat for multiple capabilities so diagnose uses the same runtime "
+            "envelope as quota should-run."
+        ),
+    )
+    diagnose_parser.add_argument(
         "--scan-root",
         default=default_public_scan_root(),
         help="Public files to scan for obvious private material. Defaults to the LoopX install root.",
@@ -811,6 +821,7 @@ def handle_diagnose_command(
             limit=max(1, args.limit),
             goal_id=args.goal_id,
             agent_id=args.agent_id,
+            available_capabilities=args.available_capabilities,
         )
     except Exception as exc:
         payload = {

--- a/loopx/diagnose.py
+++ b/loopx/diagnose.py
@@ -7,8 +7,10 @@ from typing import Any
 from .presentation.markdown import as_dict as _as_dict
 from .presentation.markdown import as_list as _as_list
 from .presentation.markdown import markdown_scalar
+from .project_prompt import render_available_capability_args
 from .quota import build_quota_should_run
 from .status import collect_status
+from .control_plane.todos.contract import normalize_required_capabilities
 
 
 DIAGNOSIS_SCHEMA_VERSION = "loopx_agent_diagnosis_packet_v0"
@@ -106,9 +108,20 @@ def _goal_ids_for_packet(status_payload: dict[str, Any], *, goal_id: str | None,
     return ids
 
 
-def _quota_for_goal(status_payload: dict[str, Any], goal_id: str, *, agent_id: str | None) -> dict[str, Any]:
+def _quota_for_goal(
+    status_payload: dict[str, Any],
+    goal_id: str,
+    *,
+    agent_id: str | None,
+    available_capabilities: Any = None,
+) -> dict[str, Any]:
     try:
-        return build_quota_should_run(status_payload, goal_id=goal_id, agent_id=agent_id)
+        return build_quota_should_run(
+            status_payload,
+            goal_id=goal_id,
+            agent_id=agent_id,
+            available_capabilities=available_capabilities,
+        )
     except Exception as exc:  # noqa: BLE001 - diagnosis packets should preserve compact failure context.
         return {
             "ok": False,
@@ -187,25 +200,27 @@ def _agent_commands(
     scan_roots: list[Path],
     limit: int,
     agent_id: str | None,
+    available_capabilities: Any = None,
 ) -> list[str]:
     registry_arg = shlex.quote(str(registry_path))
     scan_args = " ".join(f"--scan-path {shlex.quote(str(path))}" for path in scan_roots)
     diagnose = f"loopx --registry {registry_arg} diagnose"
     status = f"loopx --registry {registry_arg} status"
     agent_arg = f" --agent-id {shlex.quote(agent_id)}" if agent_id else ""
+    capability_args = render_available_capability_args(available_capabilities)
     goal_arg = f" --goal-id {shlex.quote(goal_id)}" if goal_id else ""
     if scan_args:
         diagnose = f"{diagnose} {scan_args}"
         status = f"{status} {scan_args}"
     commands = [
-        f"{diagnose}{goal_arg}{agent_arg} --limit {max(1, limit)}",
+        f"{diagnose}{goal_arg}{agent_arg}{capability_args} --limit {max(1, limit)}",
         f"{status}{goal_arg}{agent_arg} --limit {max(1, limit)}",
     ]
     if goal_id:
         quoted_goal = shlex.quote(goal_id)
         commands.append(
             f"loopx --registry {registry_arg} --format json quota should-run "
-            f"--goal-id {quoted_goal}{agent_arg}"
+            f"--goal-id {quoted_goal}{agent_arg}{capability_args}"
         )
         commands.append(f"loopx --registry {registry_arg} history --goal-id {quoted_goal} --limit {max(1, limit)}")
     return commands
@@ -354,6 +369,7 @@ def _build_goal_packet(
     scan_roots: list[Path],
     limit: int,
     agent_id: str | None,
+    available_capabilities: Any = None,
 ) -> dict[str, Any]:
     goal_id = str((item or {}).get("goal_id") or quota.get("goal_id") or "")
     item = item or {}
@@ -378,6 +394,7 @@ def _build_goal_packet(
         },
         "quota_signals": _compact_quota_signals(quota),
         "agent_id": agent_id,
+        "available_capabilities": normalize_required_capabilities(available_capabilities),
         "interaction_contract": _as_dict(quota.get("interaction_contract")),
         "work_lane_contract": _as_dict(quota.get("work_lane_contract")),
         "goal_boundary": _as_dict(quota.get("goal_boundary")),
@@ -394,6 +411,7 @@ def _build_goal_packet(
             scan_roots=scan_roots,
             limit=limit,
             agent_id=agent_id,
+            available_capabilities=available_capabilities,
         ),
     }
 
@@ -406,6 +424,7 @@ def collect_diagnosis(
     limit: int,
     goal_id: str | None = None,
     agent_id: str | None = None,
+    available_capabilities: Any = None,
 ) -> dict[str, Any]:
     limit = max(1, limit)
     registry_path = registry_path.expanduser()
@@ -424,7 +443,12 @@ def collect_diagnosis(
     goal_packets = []
     for current_goal_id in goal_ids:
         item = item_by_goal.get(current_goal_id)
-        quota = _quota_for_goal(status_payload, current_goal_id, agent_id=agent_id)
+        quota = _quota_for_goal(
+            status_payload,
+            current_goal_id,
+            agent_id=agent_id,
+            available_capabilities=available_capabilities,
+        )
         goal_packets.append(
             _build_goal_packet(
                 status_payload=status_payload,
@@ -434,6 +458,7 @@ def collect_diagnosis(
                 scan_roots=scan_roots,
                 limit=limit,
                 agent_id=agent_id,
+                available_capabilities=available_capabilities,
             )
         )
     selected_item = _select_attention_item(status_payload, goal_id=goal_id)
@@ -448,6 +473,7 @@ def collect_diagnosis(
             scan_roots=scan_roots,
             limit=limit,
             agent_id=agent_id,
+            available_capabilities=available_capabilities,
         )
     contract = _as_dict(status_payload.get("contract"))
     contract_errors = _compact_text_signals(contract.get("errors"))
@@ -461,6 +487,7 @@ def collect_diagnosis(
         "runtime_root": status_payload.get("runtime_root"),
         "goal_id": goal_id,
         "agent_id": agent_id,
+        "available_capabilities": normalize_required_capabilities(available_capabilities),
         "selected_goal_id": selected.get("goal_id"),
         "status_ok": status_payload.get("ok"),
         "goal_count": status_payload.get("goal_count"),


### PR DESCRIPTION
## Motivation

`quota should-run` already accepts an agent identity and observed runtime capabilities, but `diagnose` only forwarded the identity. A network-requiring todo could therefore be eligible in scoped quota while the diagnostic packet incorrectly described `network` as a user-held gate.

## Implementation

- add repeatable `diagnose --available-capability`
- forward the runtime capability envelope into the same quota decision builder used by `quota should-run`
- preserve the envelope in diagnosis packets and generated drill-down commands
- extend the existing diagnose smoke with a network-required, agent-claimed todo

## Validation

- `python3 examples/agent-diagnose-packet-smoke.py`
- `uvx ruff check loopx/diagnose.py loopx/cli_commands/status.py examples/agent-diagnose-packet-smoke.py`
- real connected-goal comparison: diagnosis reports `agent_work_attention`, `should_run=true`, and no user action when `network` is supplied
- `loopx check` on all three changed public files: 0 errors, 0 warnings
- `loopx canary premerge --from-git-diff`: standard tier passed, including selected catalog and risk-profile smokes

## Risk and non-goals

The option is additive and omitted calls preserve existing behavior. This does not infer host capabilities automatically or change quota policy; callers remain responsible for declaring capabilities actually present in the current runtime.
