### PR TITLE
Reconcile terminal PR approval gates

### DIFF
--- a/examples/issue-fix-pr-lifecycle-smoke.py
+++ b/examples/issue-fix-pr-lifecycle-smoke.py
@@ -266,6 +266,24 @@ def main() -> int:
             + "\n",
             encoding="utf-8",
         )
+        state_file = (
+            project
+            / ".codex"
+            / "goals"
+            / "example-goal"
+            / "ACTIVE_GOAL_STATE.md"
+        )
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text(
+            "# Active Goal State\n\n"
+            "## User Todo / Owner Review Reading Queue\n\n"
+            "- [ ] Approve public PR merge.\n"
+            "  <!-- loopx:todo todo_id=todo_merge_gate_1716 status=open "
+            "task_class=user_gate decision_scope=direction:action:merge_pr_1716 "
+            "blocks_agent=codex-test -->\n\n"
+            "## Agent Todo\n\n",
+            encoding="utf-8",
+        )
         ledger = default_issue_fix_domain_state_ledger_path(
             project=project,
             goal_id="example-goal",
@@ -376,6 +394,119 @@ def main() -> int:
             ),
             encoding="utf-8",
         )
+        gate_open_metadata_path = project / "gate-open-pr.json"
+        gate_open_metadata_path.write_text(
+            json.dumps(
+                {
+                    "state": "OPEN",
+                    "reviewDecision": "APPROVED",
+                    "statusCheckRollup": [
+                        {"name": "lint", "conclusion": "SUCCESS"}
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        gate_merged_metadata_path = project / "gate-merged-pr.json"
+        gate_merged_metadata_path.write_text(
+            json.dumps(
+                {
+                    "state": "MERGED",
+                    "mergedAt": "2026-06-25T00:00:00Z",
+                    "reviewDecision": "APPROVED",
+                    "statusCheckRollup": [
+                        {"name": "lint", "conclusion": "SUCCESS"}
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        gate_base_args = [
+            "issue-fix",
+            "pr-gate-reconcile",
+            "--url",
+            "https://github.com/huangruiteng/loopx/pull/1716",
+            "--goal-id",
+            "example-goal",
+            "--todo-id",
+            "todo_merge_gate_1716",
+            "--project",
+            str(project),
+        ]
+        open_gate = json.loads(
+            run_cli(
+                [
+                    *gate_base_args,
+                    "--metadata-json",
+                    str(gate_open_metadata_path),
+                    "--execute",
+                ],
+                registry_path=registry_path,
+                runtime_root=runtime_root,
+            ).stdout
+        )
+        assert open_gate["terminal"] is False, open_gate
+        assert open_gate["write_performed"] is False, open_gate
+        assert open_gate["skip_reason"] == "pr_not_terminal", open_gate
+        assert "status=open" in state_file.read_text(encoding="utf-8")
+
+        preview_gate = json.loads(
+            run_cli(
+                [
+                    *gate_base_args,
+                    "--metadata-json",
+                    str(gate_merged_metadata_path),
+                ],
+                registry_path=registry_path,
+                runtime_root=runtime_root,
+            ).stdout
+        )
+        assert preview_gate["terminal"] is True, preview_gate
+        assert preview_gate["would_reconcile"] is True, preview_gate
+        assert preview_gate["write_performed"] is False, preview_gate
+        assert preview_gate["skip_reason"] == "execute_required", preview_gate
+
+        reconciled_gate = json.loads(
+            run_cli(
+                [
+                    *gate_base_args,
+                    "--metadata-json",
+                    str(gate_merged_metadata_path),
+                    "--execute",
+                ],
+                registry_path=registry_path,
+                runtime_root=runtime_root,
+            ).stdout
+        )
+        assert reconciled_gate["reconciled"] is True, reconciled_gate
+        assert reconciled_gate["write_performed"] is True, reconciled_gate
+        assert reconciled_gate["todo_completion"]["status"] == "done", reconciled_gate
+        assert reconciled_gate["rollout_event"]["appended"] is True, reconciled_gate
+        assert "status=done" in state_file.read_text(encoding="utf-8")
+        gate_projection = parse_active_state_todos(
+            state_file.read_text(encoding="utf-8")
+        )
+        gate_item = gate_projection["user_todos"]["items"][0]
+        assert gate_item["status"] == "done", gate_item
+        assert "state=MERGED" in gate_item["evidence"], gate_item
+        assert_public_safe(reconciled_gate)
+
+        repeated_gate = json.loads(
+            run_cli(
+                [
+                    *gate_base_args,
+                    "--metadata-json",
+                    str(gate_merged_metadata_path),
+                    "--execute",
+                ],
+                registry_path=registry_path,
+                runtime_root=runtime_root,
+            ).stdout
+        )
+        assert repeated_gate["already_reconciled"] is True, repeated_gate
+        assert repeated_gate["write_performed"] is False, repeated_gate
+        assert repeated_gate["rollout_event"]["already_recorded"] is True, repeated_gate
+
         merged_args = [
             "issue-fix",
             "pr-lifecycle",
@@ -412,7 +543,10 @@ def main() -> int:
         rollout_events = load_rollout_events(
             rollout_event_log_path(runtime_root, "example-goal")
         )
-        assert len(rollout_events) == 1, rollout_events
+        assert len(rollout_events) == 2, rollout_events
+        assert {
+            event["code_refs"]["pr_ref"] for event in rollout_events
+        } == {"huangruiteng/loopx#1715", "huangruiteng/loopx#1716"}
         parsed = parse_active_state_todos(
             "## Agent Todo\n\n"
             "- [ ] Resume after merge.\n"

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -58,6 +58,7 @@ from .pr_lifecycle import (
     validate_issue_fix_pr_lifecycle_monitor_packet,
 )
 from .pr_lifecycle_rollout import append_pr_merge_rollout_event
+from . import pr_gate_reconcile_cli
 from .reviewer_recommendation import (
     build_issue_fix_reviewer_recommendation_packet,
     render_issue_fix_reviewer_recommendation_markdown,
@@ -694,6 +695,7 @@ def register_issue_fix_commands(
             "by the generated concrete user gate."
         ),
     )
+    pr_gate_reconcile_cli.register_pr_gate_reconciliation_command(issue_fix_sub)
     outcome_parser = issue_fix_sub.add_parser(
         "outcome",
         help=(
@@ -1324,6 +1326,9 @@ def handle_issue_fix_command(
                         "goal_id_or_ledger_path_missing"
                     )
             renderer = render_issue_fix_feasibility_markdown
+        elif args.issue_fix_command == "pr-gate-reconcile":
+            payload = pr_gate_reconcile_cli.build_pr_gate_reconciliation_from_args(args, registry_path, runtime_root_arg, generated_at)
+            renderer = pr_gate_reconcile_cli.render_issue_fix_pr_gate_reconciliation_markdown
         elif args.issue_fix_command == "pr-lifecycle":
             if args.fetch_metadata and args.metadata_json:
                 raise ValueError("--fetch-metadata cannot be combined with --metadata-json")
@@ -1953,7 +1958,7 @@ def handle_issue_fix_command(
             raise ValueError(
                 "issue-fix requires `repository-memory-sync`, `promote-discovered-issue`, "
                 "`workflow-plan`, `feasibility`, "
-                "`acceptance-fixture`, `pr-lifecycle`, `outcome`, `metrics`, "
+                "`acceptance-fixture`, `pr-lifecycle`, `pr-gate-reconcile`, `outcome`, `metrics`, "
                 "`metrics-supplement`, "
                 "`repository-snapshot`, `reviewer-plan`, "
                 "`reviewer-request`, "
@@ -1975,7 +1980,7 @@ def handle_issue_fix_command(
             else render_issue_fix_feasibility_markdown
             if getattr(args, "issue_fix_command", None) == "feasibility"
             else render_issue_fix_pr_lifecycle_monitor_markdown
-            if getattr(args, "issue_fix_command", None) == "pr-lifecycle"
+            if getattr(args, "issue_fix_command", None) in {"pr-lifecycle", "pr-gate-reconcile"}
             else render_issue_fix_outcome_projection_markdown
             if getattr(args, "issue_fix_command", None) == "outcome"
             else render_issue_fix_metrics_projection_markdown

--- a/loopx/capabilities/issue_fix/pr_gate_reconcile.py
+++ b/loopx/capabilities/issue_fix/pr_gate_reconcile.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from ...control_plane.todos.contract import normalize_todo_decision_scope
+from ...control_plane.todos.projection import todo_item_task_class
+from ...todos import complete_goal_todo, list_goal_todos
+from .pr_lifecycle import build_issue_fix_pr_lifecycle_monitor_packet
+from .pr_lifecycle_rollout import append_pr_merge_rollout_event
+
+
+PR_GATE_RECONCILIATION_SCHEMA_VERSION = "issue_fix_pr_gate_reconciliation_v0"
+TERMINAL_PR_STATES = {"MERGED", "CLOSED"}
+
+
+def _validate_merge_gate(todo: Mapping[str, Any], *, pr_number: int) -> None:
+    if str(todo.get("role") or "") != "user":
+        raise ValueError("PR gate reconciliation requires a user todo")
+    if todo_item_task_class(dict(todo)) != "user_gate":
+        raise ValueError("PR gate reconciliation requires task_class=user_gate")
+    decision_scope = normalize_todo_decision_scope(todo.get("decision_scope"))
+    expected_scope_key = f"merge_pr_{pr_number}"
+    if not decision_scope or decision_scope.get("scope_key") != expected_scope_key:
+        raise ValueError(
+            "PR gate decision_scope must match "
+            f"direction:action:{expected_scope_key}"
+        )
+
+
+def reconcile_issue_fix_pr_gate(
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    goal_id: str,
+    todo_id: str,
+    project: Path,
+    url: str,
+    provider_payload: Mapping[str, Any] | None = None,
+    fetch_metadata: bool = False,
+    fetch_timeout_seconds: int = 10,
+    execute: bool = False,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    lifecycle = build_issue_fix_pr_lifecycle_monitor_packet(
+        url=url,
+        provider_payload=provider_payload,
+        fetch_metadata=fetch_metadata,
+        fetch_timeout_seconds=fetch_timeout_seconds,
+        generated_at=generated_at,
+    )
+    observation = lifecycle.get("observation")
+    if not isinstance(observation, dict):
+        raise ValueError("PR lifecycle observation is missing")
+    number = observation.get("number")
+    if not isinstance(number, int) or number <= 0:
+        raise ValueError("PR lifecycle observation requires a numeric PR")
+
+    todo_payload = list_goal_todos(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        role="user",
+        todo_id=todo_id,
+        project=project,
+    )
+    todo = todo_payload.get("todo")
+    if not isinstance(todo, dict):
+        raise ValueError(f"user todo {todo_id!r} was not found")
+    _validate_merge_gate(todo, pr_number=number)
+
+    state = str(observation.get("state") or "UNKNOWN").upper()
+    terminal = state in TERMINAL_PR_STATES
+    already_reconciled = bool(todo.get("done")) or str(todo.get("status") or "") == "done"
+    receipt: dict[str, Any] = {
+        "ok": True,
+        "schema_version": PR_GATE_RECONCILIATION_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "todo_id": todo_id,
+        "pr": {
+            "repo": observation.get("repo"),
+            "number": number,
+            "url": observation.get("permalink"),
+            "state": state,
+            "merged_at": observation.get("merged_at"),
+            "closed_at": observation.get("closed_at"),
+        },
+        "terminal": terminal,
+        "execute": execute,
+        "would_reconcile": terminal and not already_reconciled,
+        "write_performed": False,
+        "already_reconciled": already_reconciled,
+        "external_read_performed": lifecycle.get("external_reads_performed") is True,
+        "external_write_performed": False,
+        "private_material_read": False,
+        "raw_provider_payload_recorded": False,
+    }
+    if not terminal:
+        receipt["skip_reason"] = "pr_not_terminal"
+        return receipt
+    if not execute:
+        receipt["skip_reason"] = "execute_required"
+        return receipt
+
+    if not already_reconciled:
+        permalink = str(observation.get("permalink") or url)
+        terminal_at = str(
+            observation.get("merged_at")
+            or observation.get("closed_at")
+            or generated_at
+            or ""
+        ).strip()
+        completion = complete_goal_todo(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            todo_id=todo_id,
+            role="user",
+            note=(
+                f"Public PR lifecycle reached terminal state {state}; "
+                "the merge approval gate is obsolete."
+            ),
+            evidence=(
+                f"{permalink} state={state}"
+                + (f" terminal_at={terminal_at}" if terminal_at else "")
+            ),
+            no_followup=True,
+            project=project,
+        )
+        receipt["write_performed"] = bool(completion.get("changed"))
+        receipt["todo_completion"] = {
+            "completed": completion.get("completed"),
+            "status": completion.get("status"),
+            "status_changed": completion.get("status_changed"),
+            "metadata_updated": completion.get("metadata_updated"),
+        }
+    if state == "MERGED":
+        receipt["rollout_event"] = append_pr_merge_rollout_event(
+            payload=lifecycle,
+            goal_id=goal_id,
+            registry_path=registry_path,
+            runtime_root_arg=runtime_root_arg,
+        )
+    receipt["reconciled"] = True
+    return receipt
+
+
+def render_issue_fix_pr_gate_reconciliation_markdown(payload: dict[str, Any]) -> str:
+    pr = payload.get("pr") if isinstance(payload.get("pr"), dict) else {}
+    return "\n".join(
+        [
+            "# LoopX Issue Fix PR Gate Reconciliation",
+            "",
+            f"- ok: `{payload.get('ok')}`",
+            f"- todo_id: `{payload.get('todo_id')}`",
+            f"- pr: `{pr.get('repo')}#{pr.get('number')}`",
+            f"- state: `{pr.get('state')}`",
+            f"- terminal: `{payload.get('terminal')}`",
+            f"- write_performed: `{payload.get('write_performed')}`",
+            f"- already_reconciled: `{payload.get('already_reconciled')}`",
+            f"- skip_reason: `{payload.get('skip_reason')}`",
+        ]
+    )

--- a/loopx/capabilities/issue_fix/pr_gate_reconcile_cli.py
+++ b/loopx/capabilities/issue_fix/pr_gate_reconcile_cli.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+from .pr_gate_reconcile import (
+    reconcile_issue_fix_pr_gate,
+    render_issue_fix_pr_gate_reconciliation_markdown,
+)
+
+
+def register_pr_gate_reconciliation_command(
+    issue_fix_sub: argparse._SubParsersAction,
+) -> None:
+    parser = issue_fix_sub.add_parser(
+        "pr-gate-reconcile",
+        help=(
+            "Reconcile a merge-scoped user gate against compact public PR "
+            "lifecycle state before notifying the owner."
+        ),
+    )
+    parser.add_argument(
+        "--format",
+        dest="subcommand_format",
+        choices=["markdown", "json"],
+        help="Output format for this subcommand.",
+    )
+    parser.add_argument(
+        "--url",
+        required=True,
+        help="Public https://github.com/owner/repo/pull/123 URL.",
+    )
+    parser.add_argument(
+        "--goal-id",
+        required=True,
+        help="Goal containing the merge-scoped user gate.",
+    )
+    parser.add_argument(
+        "--todo-id",
+        required=True,
+        help="User gate todo id whose decision_scope is merge_pr_<number>.",
+    )
+    parser.add_argument(
+        "--project",
+        default=".",
+        help="Project root containing the goal state.",
+    )
+    parser.add_argument(
+        "--metadata-json",
+        default=None,
+        help="Path to mocked compact gh pr view JSON metadata, or '-' for stdin.",
+    )
+    parser.add_argument(
+        "--fetch-metadata",
+        action="store_true",
+        help="Explicitly fetch compact public PR state with gh pr view.",
+    )
+    parser.add_argument(
+        "--fetch-timeout-seconds",
+        type=int,
+        default=10,
+        help="Timeout for --fetch-metadata.",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Complete the obsolete gate only when the observed PR is terminal.",
+    )
+    parser.add_argument(
+        "--generated-at",
+        default=None,
+        help="Public-safe reconciliation timestamp; defaults to current UTC.",
+    )
+
+
+def _load_json_object(input_text: str) -> dict[str, Any]:
+    if input_text == "-":
+        raw = sys.stdin.read()
+    else:
+        raw = Path(input_text).expanduser().read_text(encoding="utf-8")
+    if len(raw) > 1_048_576:
+        raise ValueError("PR metadata JSON exceeds the 1 MiB limit")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        raise ValueError("PR metadata JSON is invalid") from None
+    if not isinstance(payload, dict):
+        raise ValueError("PR metadata JSON must contain an object")
+    return payload
+
+
+def build_pr_gate_reconciliation_from_args(
+    args: argparse.Namespace,
+    registry_path: Path | None,
+    runtime_root_arg: str | None,
+    generated_at: str,
+) -> dict[str, Any]:
+    if registry_path is None:
+        raise ValueError("pr-gate-reconcile requires a LoopX registry")
+    if args.fetch_metadata and args.metadata_json:
+        raise ValueError("--fetch-metadata cannot be combined with --metadata-json")
+    return reconcile_issue_fix_pr_gate(
+        registry_path=registry_path,
+        runtime_root_arg=runtime_root_arg,
+        goal_id=args.goal_id,
+        todo_id=args.todo_id,
+        project=Path(args.project).expanduser(),
+        url=args.url,
+        provider_payload=(
+            _load_json_object(args.metadata_json) if args.metadata_json else None
+        ),
+        fetch_metadata=args.fetch_metadata,
+        fetch_timeout_seconds=args.fetch_timeout_seconds,
+        execute=args.execute,
+        generated_at=generated_at,
+    )
+
+
+__all__ = [
+    "build_pr_gate_reconciliation_from_args",
+    "register_pr_gate_reconciliation_command",
+    "render_issue_fix_pr_gate_reconciliation_markdown",
+]

--- a/skills/loopx-project/SKILL.md
+++ b/skills/loopx-project/SKILL.md
@@ -281,6 +281,25 @@ interaction, not a silent skip. Read `gate_prompt`, `operator_question`,
 `recommended_action`, `next_handoff_condition`, `missing_gates`, and
 `user_todo_summary` and `agent_todo_summary` when present, then ask the concrete gate in Chinese unless
 the same unresolved question was already surfaced in the recent visible thread.
+Before repeating a public PR merge-approval gate, reconcile it against current
+compact PR lifecycle state. When the todo has a merge-scoped decision such as
+`direction:action:merge_pr_<number>` and the public PR URL is unambiguous, run:
+
+```bash
+loopx issue-fix pr-gate-reconcile \
+  --goal-id <STABLE_GOAL_ID> \
+  --todo-id <USER_GATE_TODO_ID> \
+  --url <PUBLIC_GITHUB_PR_URL> \
+  --fetch-metadata \
+  --execute
+```
+
+Then rerun `quota should-run`. The command may complete only the matching
+`user_gate`, and only after compact public metadata reports `MERGED` or
+`CLOSED`; it records no body, comments, logs, provider payload, or external
+write. If the URL is ambiguous or the public read fails, preserve the gate and
+surface that exact resolution failure instead of claiming the owner still needs
+to approve an already-terminal PR.
 Only when `interaction_contract.user_channel.action_required=true` or
 `user_todo_summary.open_count > 0`, the notification must name concrete payload
 todo(s)/questions, never only "owner gate"; if those required user-facing items


### PR DESCRIPTION
## Summary
- add an explicit `issue-fix pr-gate-reconcile` command for merge-scoped user gates
- complete only the matching gate when compact public PR metadata is `MERGED` or `CLOSED`
- preserve compact terminal evidence, append merged rollout events idempotently, and teach heartbeat agents to reconcile before notifying owners

## Validation
- `python3 examples/issue-fix-pr-lifecycle-smoke.py`
- Ruff and changed-file compile checks
- premerge canary: 9/9 selected checks passed
- live #1951 reconciliation: terminal state confirmed; second execution zero-write and `already_recorded=true`
- public/private boundary scan clean