### PR TITLE
fix(frontstage): honor Pages base path for showcase assets

### DIFF
--- a/apps/presentation/dashboard/smoke/frontstage-route-smoke.ts
+++ b/apps/presentation/dashboard/smoke/frontstage-route-smoke.ts
@@ -151,6 +151,10 @@ includes(frontstageSource, "Start the loop from one TUI message", "developer one
 includes(frontstageSource, "workspace_guard isolates peer writes", "developer workspace guard copy");
 includes(frontstageSource, "Developer mode ignores statusUrl", "developer public statusUrl guard");
 includes(frontstageSource, 'data-testid="frontstage-public-showcase-contract"', "public showcase contract panel");
+includes(frontstageSource, "import.meta.env.BASE_URL", "showcase asset base path");
+includes(frontstageSource, 'showcaseAssetPath("openviking-issue-fix-explore.png")', "issue-fix showcase asset");
+includes(frontstageSource, 'showcaseAssetPath("auto-ml-experiment-explore.jpg")', "Auto ML showcase asset");
+excludes(frontstageSource, 'image: "/showcase/', "root-relative showcase asset path");
 includes(frontstageSource, "Local status URLs stay behind explicit Ops live URLs", "ops-only live status copy");
 includes(frontstageSource, 'data-testid="frontstage-ops-entry-hint"', "explicit ops entry hint");
 includes(frontstageSource, "Use mode=ops with statusUrl.", "wrapped ops entry hint copy");

--- a/apps/presentation/dashboard/src/views/frontstage-page.tsx
+++ b/apps/presentation/dashboard/src/views/frontstage-page.tsx
@@ -2903,19 +2903,21 @@ function PublicShowcaseBoundaryPanel() {
   );
 }
 
+const showcaseAssetPath = (assetName: string) => `${import.meta.env.BASE_URL}showcase/${assetName}`;
+
 const showcaseGraphStories = [
   {
     eyebrow: "Open-source issue fix",
     title: "PR delivery and reusable capability evolve together",
     body: "Merged and open fixes stay connected to reviewer routing, repository knowledge, terminal resume, and the next reusable discovery loop.",
-    image: "/showcase/openviking-issue-fix-explore.png",
+    image: showcaseAssetPath("openviking-issue-fix-explore.png"),
     imageAlt: "Open-source issue-fix Explore graph linking focused PR delivery with reusable LoopX capabilities",
   },
   {
     eyebrow: "Auto ML Experiment",
     title: "Evidence branches stay visible until promote or stop",
     body: "Matched baselines, invalid lineages, negative results, running replicates, capacity slots, and decision gates remain traceable in one Explore topology.",
-    image: "/showcase/auto-ml-experiment-explore.jpg",
+    image: showcaseAssetPath("auto-ml-experiment-explore.jpg"),
     imageAlt: "Auto ML Experiment Explore graph with experiment lineages, evidence gates, and promotion decisions",
   },
 ];


### PR DESCRIPTION
## Summary
- resolve first-screen showcase graph URLs through Vite's `BASE_URL`
- keep root-local previews and the `/loopx/` GitHub Pages deployment on the same component path contract
- add a focused route smoke that rejects root-relative showcase image paths

## Why
The approved graph assets were published under `/loopx/showcase/...`, but the component used `/showcase/...`. That works in a root-local preview and 404s on GitHub Pages, where LoopX is hosted below `/loopx/`.

## Validation
- `npm run smoke:frontstage-route`
- `npm run build -- --base /loopx/`
- `npm run smoke:frontstage-share-bundle`
- `npm run smoke:frontstage-browser`
- `npm run smoke:frontstage-design-baseline`
- production export with `--base /loopx/`; both graph files present and bundle path verified
- `loopx check` on both changed files: 0 errors, 0 warnings
- `loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard`: passed, no manual holds

## Boundary
Public frontstage code and one focused smoke only. No private state, internal links, local artifacts, credentials, or raw evidence are included.
