### PR TITLE
Make visible agent wakeups state-aware

### DIFF
--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -117,7 +117,7 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
     assert kernel["surface_count"] == 4, payload
     assert kernel["state_bus"] == "loopx_registry_runtime_todo_quota_frontier", payload
     assert kernel["kernel_driver"] == "decentralized_a2a_driver", payload
-    assert kernel["kernel_driver_schema"] == "multi_agent_decentralized_a2a_driver_contract_v0", payload
+    assert kernel["kernel_driver_schema"] == "multi_agent_decentralized_a2a_driver_contract_v1", payload
     assert kernel["worker_turn_owner"] == "generic_multi_agent_kernel", payload
     assert "pane_local_a2a_status_check" in kernel["delegated_kernel_mechanics"], payload
     assert kernel["presentation_layers_in_kernel"] is False, payload

--- a/examples/auto-research-visible-launch-policy-smoke.py
+++ b/examples/auto-research-visible-launch-policy-smoke.py
@@ -154,7 +154,7 @@ def assert_visible_wake_loader_requires_prompt_delivery() -> None:
             "prompt_submit_checks": [{"target": "%2", "retry_count": 0}],
             "prompt_delivery": "tmux_paste_buffer_after_codex_tui_first_turn_ready",
             "driver_contract": {
-                "schema_version": "multi_agent_decentralized_a2a_driver_contract_v0",
+                "schema_version": "multi_agent_decentralized_a2a_driver_contract_v1",
                 "owner_layer": "generic_multi_agent_kernel",
             },
         },
@@ -196,7 +196,7 @@ def assert_visible_wake_loader_requires_prompt_delivery() -> None:
             "prompt_submit_checks": [],
             "prompt_delivery": "skipped_no_input_ready_panes",
             "driver_contract": {
-                "schema_version": "multi_agent_decentralized_a2a_driver_contract_v0",
+                "schema_version": "multi_agent_decentralized_a2a_driver_contract_v1",
                 "owner_layer": "generic_multi_agent_kernel",
             },
         },

--- a/examples/generic-multi-agent-one-command-smoke.py
+++ b/examples/generic-multi-agent-one-command-smoke.py
@@ -272,21 +272,22 @@ def main() -> int:
             "loopx multi-agent wake --session-name <session>"
         ), dry_packet
         assert dry_packet["runner_contract"]["pane_local_a2a"]["cadence_wakeup_model"] == (
-            "fixed_prompt_broadcast"
+            "todo_readiness_targeted_wake"
         ), dry_packet
         assert dry_packet["runner_contract"]["pane_local_a2a"]["cadence_broadcaster_decides_work"] is False, dry_packet
         driver = dry_packet["runner_contract"]["decentralized_a2a_driver"]
-        assert driver["schema_version"] == "multi_agent_decentralized_a2a_driver_contract_v0", driver
+        assert driver["schema_version"] == "multi_agent_decentralized_a2a_driver_contract_v1", driver
         assert driver["owner_layer"] == "generic_multi_agent_kernel", driver
         assert driver["driver_model"] == (
-            "fixed_prompt_broadcast_plus_pane_local_state_check"
+            "todo_readiness_edge_plus_fixed_retry"
         ), driver
         assert driver["broadcaster"]["decides_work"] is False, driver
+        assert driver["broadcaster"]["reads_todo_readiness"] is True, driver
         assert driver["pane"]["tick_command"] == "$LOOPX_PANE_A2A_TICK", driver
         assert driver["prompt"]["tick_summary_ref"] == "$LOOPX_PANE_TICK_SUMMARY", driver
         assert "own_prior_status_summary" in driver["pane"]["reads"], driver
         assert driver["pane"]["cadence_action"] == (
-            "fixed_prompt_wakeup_then_own_quota_frontier_check_when_runnable"
+            "targeted_wakeup_then_own_quota_frontier_check_when_runnable"
         ), driver
         assert driver["prompt"]["tick_summary_semantics"] == (
             "prior_pane_status_not_research_evidence"
@@ -311,7 +312,7 @@ def main() -> int:
         assert compact["role_count"] == 2, compact
         assert compact["first_action"] == "$LOOPX_PANE_A2A_TICK", compact
         assert compact["driver_model"] == (
-            "fixed_prompt_broadcast_plus_pane_local_state_check"
+            "todo_readiness_edge_plus_fixed_retry"
         ), compact
         assert compact["user_takeover"] == "attach to the session and type into any role pane", compact
         assert dry_packet["interactive_tui_contract"]["schema_version"] == "multi_agent_visible_interactive_tui_contract_v0", dry_packet
@@ -382,11 +383,10 @@ def main() -> int:
         assert dry_wake["broadcaster_reads_frontier"] is False, dry_wake
         assert dry_wake["broadcaster_selects_todo"] is False, dry_wake
         assert "$LOOPX_PANE_A2A_TICK" in dry_wake["prompt"], dry_wake
-        assert "$LOOPX_PANE_TICK_SUMMARY" in dry_wake["prompt"], dry_wake
-        assert "fresh decentralized state check" in dry_wake["prompt"], dry_wake
-        assert "not as a completed research round" in dry_wake["prompt"], dry_wake
-        assert "prior pane-local status summary" in dry_wake["prompt"], dry_wake
-        assert "Run $LOOPX_PANE_A2A_TICK once" in dry_wake["prompt"], dry_wake
+        assert "LoopX targeted wake" in dry_wake["prompt"], dry_wake
+        assert "do not inspect skills" in dry_wake["prompt"], dry_wake
+        assert "not research evidence or completion" in dry_wake["prompt"], dry_wake
+        assert "First run $LOOPX_PANE_A2A_TICK once" in dry_wake["prompt"], dry_wake
         assert "\n" not in dry_wake["prompt"], dry_wake
         exec_wake = run_wake_command(
             env,

--- a/examples/generic-multi-agent-runner-kernel-smoke.py
+++ b/examples/generic-multi-agent-runner-kernel-smoke.py
@@ -75,7 +75,7 @@ def main() -> int:
     assert role_prompt["default_kernel_skill_policy"][
         "preset_should_not_repeat_skill_playbooks"
     ] is True, runner
-    assert role_prompt["fixed_wake_prompt_owner"] == "generic_multi_agent_kernel", runner
+    assert role_prompt["wake_prompt_owner"] == "generic_multi_agent_kernel", runner
     assert (
         runner["decentralized_a2a_driver"]["prompt"]["owner_layer"]
         == "generic_multi_agent_kernel"

--- a/examples/generic-multi-agent-spec-contract-smoke.py
+++ b/examples/generic-multi-agent-spec-contract-smoke.py
@@ -136,7 +136,9 @@ def main() -> int:
     assert driver["schema_version"] == DECENTRALIZED_A2A_DRIVER_CONTRACT_SCHEMA_VERSION, driver
     assert driver["owner_layer"] == "generic_multi_agent_kernel", driver
     assert driver["coordination_pattern"] == "decentralized_state_a2a", driver
-    assert driver["broadcaster"]["model"] == "fixed_prompt_broadcast", driver
+    assert driver["schema_version"] == "multi_agent_decentralized_a2a_driver_contract_v1", driver
+    assert driver["broadcaster"]["model"] == "todo_readiness_targeted_wake", driver
+    assert driver["broadcaster"]["reads_todo_readiness"] is True, driver
     assert driver["broadcaster"]["decides_work"] is False, driver
     assert driver["pane"]["decision_owner"] == "codex_tui_agent_via_loopx_state", driver
     assert driver["acceptance"]["user_and_preset_do_not_own_tick_driver"] is True, driver
@@ -209,7 +211,7 @@ def main() -> int:
     assert compact["schema_version"] == GENERIC_MULTI_AGENT_COMPACT_STATUS_SCHEMA_VERSION, compact
     assert compact["role_count"] == 2, compact
     assert compact["first_action"] == "$LOOPX_PANE_A2A_TICK", compact
-    assert compact["driver_model"] == "fixed_prompt_broadcast_plus_pane_local_state_check", compact
+    assert compact["driver_model"] == "todo_readiness_edge_plus_fixed_retry", compact
     assert compact["coordination_pattern"] == "decentralized_state_a2a", compact
     assert compact["machine_json_policy"] == "artifact_only_in_visible_panes", compact
     assert [role["lane_id"] for role in compact["roles"]] == ["planner", "builder"], compact

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -132,12 +132,12 @@ def main() -> int:
     assert "ungated open todo for this role" in runtime_source
     assert "selected_todo_id" in runtime_source
     assert "claim_allowed_rule" in runtime_source
-    assert "Honor the role prompt's human output language" in contract_source
-    assert "This Codex TUI owns the first visible research turn" in contract_source
+    assert "Human output language:" in contract_source
+    assert "receives an initial or targeted wake prompt" in contract_source
     assert "tick reads your quota/frontier; it runs a role worker only when" in contract_source
     assert "manual research is required" in contract_source
     assert "Treat `$LOOPX_PANE_TICK_SUMMARY` as previous pane-local evidence" in contract_source
-    assert "not a gate that cancels later fixed wakes" in contract_source
+    assert "not a gate that cancels later targeted retries" in contract_source
     assert "Use $loopx-project" in contract_source
     assert "Use $loopx-doc-registry" in contract_source
     assert "LOOPX_VISIBLE_FORCE_MARKDOWN" in launcher_source
@@ -212,20 +212,21 @@ def main() -> int:
     assert runner_contract["pane_local_a2a"]["cadence_wakeup_command"] == (
         "loopx multi-agent wake --session-name <session>"
     )
-    assert runner_contract["pane_local_a2a"]["cadence_wakeup_model"] == "fixed_prompt_broadcast"
+    assert runner_contract["pane_local_a2a"]["cadence_wakeup_model"] == "todo_readiness_targeted_wake"
     assert runner_contract["pane_local_a2a"]["cadence_broadcaster_decides_work"] is False
     driver = runner_contract["decentralized_a2a_driver"]
-    assert driver["schema_version"] == "multi_agent_decentralized_a2a_driver_contract_v0", driver
+    assert driver["schema_version"] == "multi_agent_decentralized_a2a_driver_contract_v1", driver
     assert driver["owner_layer"] == "generic_multi_agent_kernel", driver
-    assert driver["driver_model"] == "fixed_prompt_broadcast_plus_pane_local_state_check", driver
+    assert driver["driver_model"] == "todo_readiness_edge_plus_fixed_retry", driver
     assert driver["broadcaster"]["reads_frontier"] is False, driver
+    assert driver["broadcaster"]["reads_todo_readiness"] is True, driver
     assert driver["broadcaster"]["selects_todo"] is False, driver
     assert driver["broadcaster"]["runs_worker_turn"] is False, driver
     assert driver["pane"]["decision_owner"] == "codex_tui_agent_via_loopx_state", driver
     assert driver["prompt"]["tick_summary_ref"] == "$LOOPX_PANE_TICK_SUMMARY", driver
     assert "own_prior_status_summary" in driver["pane"]["reads"], driver
     assert driver["pane"]["cadence_action"] == (
-        "fixed_prompt_wakeup_then_own_quota_frontier_check_when_runnable"
+        "targeted_wakeup_then_own_quota_frontier_check_when_runnable"
     ), driver
     assert driver["prompt"]["wake_round"] == "fresh_agent_scoped_quota_frontier_check", driver
     assert (
@@ -628,11 +629,10 @@ def main() -> int:
             assert wake["schema_version"] == "multi_agent_pane_a2a_wakeup_v0", wake
             assert wake["mode"] == "execute", wake
             assert wake["wakeup_model"] == "fixed_prompt_broadcast", wake
-            assert "$LOOPX_PANE_TICK_SUMMARY" in wake["prompt"], wake
-            assert "fresh decentralized state check" in wake["prompt"], wake
-            assert "not as a completed research round" in wake["prompt"], wake
-            assert "prior pane-local status summary" in wake["prompt"], wake
-            assert "Run $LOOPX_PANE_A2A_TICK once" in wake["prompt"], wake
+            assert "LoopX targeted wake" in wake["prompt"], wake
+            assert "do not inspect skills" in wake["prompt"], wake
+            assert "not research evidence or completion" in wake["prompt"], wake
+            assert "First run $LOOPX_PANE_A2A_TICK once" in wake["prompt"], wake
             assert wake["pane_input_ready_verified"] is True, wake
             assert wake["prompt_delivery"] == (
                 "tmux_paste_buffer_after_codex_tui_first_turn_ready"
@@ -670,9 +670,8 @@ def main() -> int:
             ), footer_ready_wake
             os.environ["FAKE_TMUX_CAPTURE_TEXT"] = (
                 "\n"
-                "› Honor the role prompt's human output language for summaries while keeping "
-                "machine artifact schema keys unchanged. Do not ask the broadcaster for "
-                "direction; LoopX state is the source of truth.\n\n"
+                "› quiet with a brief no-action note. This wake is not research evidence or "
+                "completion. LoopX state, not the scheduler, decides the work.\n\n"
                 "  gpt-5.5 high · /tmp/loopx-visible-workspace\n"
             )
             tail_retry_wake = wake_visible_multi_agent_panes(
@@ -724,6 +723,27 @@ def main() -> int:
                 item["not_ready_reason"] == "codex_tui_busy_or_not_ready"
                 for item in busy_wake["pane_input_ready_checks"]
             ), busy_wake
+            os.environ["FAKE_TMUX_CAPTURE_TEXT"] = (
+                "╭────────────────────────╮\n"
+                "│ >_ OpenAI Codex        │\n"
+                "│ model: gpt-5.6-sol high│\n"
+                "╰────────────────────────╯\n\n"
+                "• Working (45s • esc to interrupt)\n\n"
+                "› Queue another request\n\n"
+                "  gpt-5.6-sol high · /tmp/loopx-visible-workspace\n"
+            )
+            queueable_busy_wake = wake_visible_multi_agent_panes(
+                session_name="loopx-visible-launcher-smoke",
+                tmux_bin="tmux",
+                lanes=["planner", "reviewer"],
+                execute=True,
+                input_ready_timeout_seconds=0.25,
+            )
+            assert queueable_busy_wake["prompt_delivery"] == (
+                "skipped_no_input_ready_panes"
+            ), queueable_busy_wake
+            assert queueable_busy_wake["ready_lanes"] == [], queueable_busy_wake
+            assert queueable_busy_wake["prompt_submit_checks"] == [], queueable_busy_wake
             before_usage_limit_log_count = len(
                 tmux_log.read_text(encoding="utf-8").splitlines()
             )
@@ -875,6 +895,7 @@ def main() -> int:
         assert launch["auto_wake"]["target_lanes"] == ["planner", "reviewer"], launch
         assert launch["auto_wake"]["workflow_driver"] is False, launch
         assert launch["auto_wake"]["broadcaster_reads_frontier"] is False, launch
+        assert launch["auto_wake"]["broadcaster_reads_todo_readiness"] is True, launch
         assert launch["auto_wake"]["broadcaster_selects_todo"] is False, launch
         assert launch["auto_wake"]["artifact"] == "auto-wake.public.jsonl", launch
         acceptance = launch["visible_acceptance"]

--- a/examples/visible-multi-agent-state-aware-wake-smoke.py
+++ b/examples/visible-multi-agent-state-aware-wake-smoke.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Smoke-test readiness-targeted visible multi-agent wake scheduling."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from loopx.capabilities.multi_agent.runtime_scripts import CODEX_TUI_EXEC_PY  # noqa: E402
+from loopx.capabilities.multi_agent.visible_wake_scheduler import (  # noqa: E402
+    lane_agent_map,
+    run_state_aware_wake_loop,
+    todo_readiness_projection,
+)
+
+
+def write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def main() -> int:
+    lanes = [
+        {"lane_id": "curator", "agent_id": "research-curator"},
+        {"lane_id": "proposer", "agent_id": "hypothesis-proposer"},
+        {"lane_id": "fallback-agent"},
+    ]
+    agents = lane_agent_map(lanes)
+    assert agents == {
+        "curator": "research-curator",
+        "proposer": "hypothesis-proposer",
+        "fallback-agent": "fallback-agent",
+    }, agents
+
+    initial = todo_readiness_projection(
+        {
+            "todos": [
+                {
+                    "todo_id": "todo_curate",
+                    "status": "open",
+                    "done": False,
+                    "claimed_by": "research-curator",
+                },
+                {
+                    "todo_id": "todo_propose",
+                    "status": "open",
+                    "done": False,
+                    "claimed_by": "hypothesis-proposer",
+                    "resume_ready": False,
+                },
+            ]
+        },
+        lane_agents=agents,
+    )
+    assert initial["recognized"] is True, initial
+    assert initial["goal_todo_count"] == 2, initial
+    assert initial["mapped_todo_count"] == 2, initial
+    assert initial["runnable_lane_tokens"] == {"curator": ("todo_curate",)}, initial
+
+    successor = todo_readiness_projection(
+        {
+            "todos": [
+                {
+                    "todo_id": "todo_curate",
+                    "status": "done",
+                    "done": True,
+                    "claimed_by": "research-curator",
+                },
+                {
+                    "todo_id": "todo_propose_v2",
+                    "status": "open",
+                    "done": False,
+                    "claimed_by": "hypothesis-proposer",
+                    "resume_ready": True,
+                },
+            ]
+        },
+        lane_agents=agents,
+    )
+    assert successor["runnable_lane_tokens"] == {
+        "proposer": ("todo_propose_v2",)
+    }, successor
+
+    unmapped = todo_readiness_projection(
+        {"todos": [{"todo_id": "todo_other", "claimed_by": "other-agent"}]},
+        lane_agents=agents,
+    )
+    assert unmapped["recognized"] is True, unmapped
+    assert unmapped["runnable_lane_tokens"] == {}, unmapped
+
+    unclaimed = todo_readiness_projection(
+        {
+            "todos": [
+                {
+                    "todo_id": "todo_unclaimed",
+                    "status": "open",
+                    "done": False,
+                    "task_class": "advancement_task",
+                    "excluded_agents": ["hypothesis-proposer"],
+                }
+            ]
+        },
+        lane_agents=agents,
+    )
+    assert unclaimed["runnable_lane_tokens"] == {
+        "curator": ("todo_unclaimed",),
+        "fallback-agent": ("todo_unclaimed",),
+    }, unclaimed
+
+    with tempfile.TemporaryDirectory(prefix="loopx-state-aware-wake-smoke.") as tmp:
+        temp = Path(tmp)
+        fake_bin = temp / "bin"
+        fake_bin.mkdir()
+        state = temp / "todo-state.json"
+        wake_log = temp / "wake-argv.json"
+        stop = temp / "stop"
+        artifact = temp / "auto-wake.public.jsonl"
+        state.write_text(
+            json.dumps(
+                {
+                    "todos": [
+                        {
+                            "todo_id": "todo_propose_v2",
+                            "status": "open",
+                            "done": False,
+                            "claimed_by": "hypothesis-proposer",
+                            "resume_ready": True,
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        write_executable(
+            fake_bin / "tmux",
+            """#!/usr/bin/env python3
+import os
+import sys
+raise SystemExit(1 if os.path.exists(os.environ['FAKE_STOP']) else 0)
+""",
+        )
+        write_executable(
+            fake_bin / "loopx",
+            """#!/usr/bin/env python3
+import json
+import os
+import sys
+args = sys.argv[1:]
+if 'todo' in args and 'list' in args:
+    print(open(os.environ['FAKE_TODO_STATE'], encoding='utf-8').read())
+    raise SystemExit(0)
+if 'multi-agent' in args and 'wake' in args:
+    with open(os.environ['FAKE_WAKE_LOG'], 'w', encoding='utf-8') as handle:
+        json.dump(args, handle)
+    open(os.environ['FAKE_STOP'], 'w', encoding='utf-8').write('stop')
+    print(json.dumps({'ok': True, 'auto_wake_backoff_recommended': False}))
+    raise SystemExit(0)
+raise SystemExit(2)
+""",
+        )
+        old_env = os.environ.copy()
+        os.environ.update(
+            {
+                "FAKE_STOP": str(stop),
+                "FAKE_TODO_STATE": str(state),
+                "FAKE_WAKE_LOG": str(wake_log),
+            }
+        )
+        try:
+            run_state_aware_wake_loop(
+                cli_bin=str(fake_bin / "loopx"),
+                tmux_bin=str(fake_bin / "tmux"),
+                registry=temp / "registry.json",
+                runtime_root=temp / "runtime",
+                goal_id="demo-goal",
+                session="demo-session",
+                lane_agents={
+                    "curator": "research-curator",
+                    "proposer": "hypothesis-proposer",
+                },
+                initial_projection=initial,
+                artifact=artifact,
+                retry_interval_seconds=45.0,
+                poll_interval_seconds=0.5,
+            )
+        finally:
+            os.environ.clear()
+            os.environ.update(old_env)
+        wake_args = json.loads(wake_log.read_text(encoding="utf-8"))
+        assert wake_args.count("--lane") == 1, wake_args
+        assert wake_args[wake_args.index("--lane") + 1] == "proposer", wake_args
+        events = [
+            json.loads(line)
+            for line in artifact.read_text(encoding="utf-8").splitlines()
+        ]
+        assert events[0]["mode"] == "todo_readiness_edge_plus_fixed_retry", events
+        assert events[1]["trigger"] == "readiness_edge", events
+        assert events[1]["target_lanes"] == ["proposer"], events
+
+        codex_args = temp / "codex-args.json"
+        prompt = temp / "prompt.txt"
+        prompt.write_text("must-not-run-yet", encoding="utf-8")
+        write_executable(
+            fake_bin / "codex",
+            """#!/usr/bin/env python3
+import json
+import os
+import sys
+open(os.environ['FAKE_CODEX_ARGS'], 'w', encoding='utf-8').write(json.dumps(sys.argv[1:]))
+""",
+        )
+        env = {
+            **os.environ,
+            "FAKE_CODEX_ARGS": str(codex_args),
+            "LOOPX_CODEX_BIN": str(fake_bin / "codex"),
+            "LOOPX_PROJECT": str(temp),
+            "LOOPX_CODEX_REASONING_EFFORT": "high",
+            "LOOPX_CODEX_TUI_PROMPT_ARTIFACT": str(prompt),
+            "LOOPX_CODEX_INITIAL_PROMPT_ENABLED": "0",
+        }
+        import subprocess
+
+        subprocess.run([sys.executable, "-c", CODEX_TUI_EXEC_PY], env=env, check=True)
+        assert "must-not-run-yet" not in json.loads(codex_args.read_text(encoding="utf-8"))
+
+    print("visible multi-agent state-aware wake smoke passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -1074,6 +1074,9 @@ def _load_visible_wake_into_payload(
         "wakeup_model": wake.get("wakeup_model"),
         "workflow_driver": bool(wake.get("workflow_driver")),
         "broadcaster_reads_frontier": bool(wake.get("broadcaster_reads_frontier")),
+        "broadcaster_reads_todo_readiness": bool(
+            wake.get("broadcaster_reads_todo_readiness")
+        ),
         "broadcaster_selects_todo": bool(wake.get("broadcaster_selects_todo")),
         "pane_decision_owner": wake.get("pane_decision_owner"),
         "pane_input_ready_verified": wake.get("pane_input_ready_verified") is True,
@@ -1248,7 +1251,7 @@ def _build_visible_readiness(payload: dict[str, object]) -> dict[str, object]:
         "coordination_pattern": "decentralized_state_a2a",
         "wake_model": wake.get("wakeup_model"),
         "workflow_model": driver.get("driver_model")
-        or "fixed_prompt_broadcast_plus_pane_local_state_check",
+        or "todo_readiness_edge_plus_fixed_retry",
         "driver_owner_layer": driver.get("owner_layer"),
         "auto_research_preset_role": "thin_domain_defaults_only",
         "user_contract_invocation": contract_acceptance.get("canonical_invocation"),

--- a/loopx/capabilities/multi_agent/contract.py
+++ b/loopx/capabilities/multi_agent/contract.py
@@ -10,7 +10,7 @@ VISIBLE_LAUNCHER_ACCEPTANCE_CONTRACT_SCHEMA_VERSION = (
     "multi_agent_visible_launcher_acceptance_contract_v0"
 )
 DECENTRALIZED_A2A_DRIVER_CONTRACT_SCHEMA_VERSION = (
-    "multi_agent_decentralized_a2a_driver_contract_v0"
+    "multi_agent_decentralized_a2a_driver_contract_v1"
 )
 GENERIC_MULTI_AGENT_ROLE_PROFILE_SCHEMA_VERSION = "generic_multi_agent_role_profile_v0"
 GENERIC_MULTI_AGENT_COMPACT_STATUS_SCHEMA_VERSION = "generic_multi_agent_compact_status_v0"
@@ -20,16 +20,12 @@ THREE_LAYER_MINIMALITY_CONTRACT_SCHEMA_VERSION = (
 GENERIC_MULTI_AGENT_DEFAULT_KERNEL_SKILLS = ("loopx-project", "loopx-doc-registry")
 
 PANE_LOCAL_A2A_WAKEUP_PROMPT = (
-    "LoopX pane-local A2A wakeup: read $LOOPX_CODEX_TUI_PROMPT_ARTIFACT for role/scope if needed. "
-    "Treat this fixed wake as a fresh decentralized state check, not as a completed research round. "
-    "Inspect $LOOPX_PANE_TICK_SUMMARY only as your own prior pane-local status summary, then read your own LoopX quota/frontier. "
-    "Run $LOOPX_PANE_A2A_TICK once to refresh guard/frontier state when your own state shows runnable work or the user asked for another step. "
-    "The status check is never research completion unless a configured worker explicitly writes real public-safe evidence. "
-    "Use only your own LOOPX_GOAL_ID/LOOPX_AGENT_ID quota/frontier; "
-    "if no runnable frontier remains, stay quiet with a brief no-action note; "
-    "if frontier remains, do the role's visible research work yourself and summarize public evidence and next handoff. "
-    "Honor the role prompt's human output language for summaries while keeping machine artifact schema keys unchanged. "
-    "Do not ask the broadcaster for direction; LoopX state is the source of truth."
+    "LoopX targeted wake. First run $LOOPX_PANE_A2A_TICK once; do not inspect skills "
+    "or role artifacts before this gate. The tick reads only your own LOOPX_GOAL_ID and "
+    "LOOPX_AGENT_ID state. If it reports runnable work, read "
+    "$LOOPX_CODEX_TUI_PROMPT_ARTIFACT as needed and continue your role. If not, stay "
+    "quiet with a brief no-action note. This wake is not research evidence or completion. "
+    "LoopX state, not the scheduler, decides the work."
 )
 
 GENERIC_MULTI_AGENT_KERNEL_MECHANICS = (
@@ -154,9 +150,9 @@ def generic_role_prompt(
             "",
             "How to work:",
             "- Treat LoopX state as the shared A2A surface.",
-            "- This Codex TUI owns the first visible research turn; run `$LOOPX_PANE_A2A_TICK` once to refresh guard/frontier state before deciding what to do.",
-            "- Treat `$LOOPX_PANE_TICK_SUMMARY` as previous pane-local evidence; it is not a gate that cancels later fixed wakes.",
-            "- On each fixed wake, read your own LoopX quota/frontier and run the bounded `$LOOPX_PANE_A2A_TICK` once when runnable work remains or the user asks for another round.",
+            "- When this pane receives an initial or targeted wake prompt, run `$LOOPX_PANE_A2A_TICK` once to refresh guard/frontier state before deciding what to do.",
+            "- Treat `$LOOPX_PANE_TICK_SUMMARY` as previous pane-local evidence; it is not a gate that cancels later targeted retries.",
+            "- On each wake, read your own LoopX quota/frontier and run the bounded `$LOOPX_PANE_A2A_TICK` once when runnable work remains or the user asks for another round.",
             "- If no runnable frontier remains, stay quiet with a brief no-action note.",
             "- The tick reads your quota/frontier; it runs a role worker only when the preset explicitly configures one.",
             "- If the tick says no worker is configured or manual research is required, do the role's research work visibly and write public-safe evidence/todos yourself.",
@@ -178,12 +174,12 @@ def build_decentralized_a2a_driver_contract(
     *,
     wake_command: str = "loopx multi-agent wake --session-name <session>",
 ) -> dict[str, object]:
-    """Describe the reusable fixed-prompt driver for live Codex TUI agents."""
+    """Describe the reusable state-aware wake driver for live Codex TUI agents."""
 
     return {
         "schema_version": DECENTRALIZED_A2A_DRIVER_CONTRACT_SCHEMA_VERSION,
         "owner_layer": "generic_multi_agent_kernel",
-        "driver_model": "fixed_prompt_broadcast_plus_pane_local_state_check",
+        "driver_model": "todo_readiness_edge_plus_fixed_retry",
         "coordination_pattern": "decentralized_state_a2a",
         "prompt": {
             "owner_layer": "generic_multi_agent_kernel",
@@ -199,8 +195,9 @@ def build_decentralized_a2a_driver_contract(
         },
         "broadcaster": {
             "command": wake_command,
-            "model": "fixed_prompt_broadcast",
+            "model": "todo_readiness_targeted_wake",
             "reads_frontier": False,
+            "reads_todo_readiness": True,
             "selects_todo": False,
             "runs_worker_turn": False,
             "writes_loopx_state": False,
@@ -211,7 +208,7 @@ def build_decentralized_a2a_driver_contract(
             "decision_owner": "codex_tui_agent_via_loopx_state",
             "tick_command": "$LOOPX_PANE_A2A_TICK",
             "first_action": "codex_tui_first_turn_status_check",
-            "cadence_action": "fixed_prompt_wakeup_then_own_quota_frontier_check_when_runnable",
+            "cadence_action": "targeted_wakeup_then_own_quota_frontier_check_when_runnable",
             "reads": [
                 "own_LOOPX_GOAL_ID",
                 "own_LOOPX_AGENT_ID",
@@ -229,7 +226,8 @@ def build_decentralized_a2a_driver_contract(
             "preset_layer": ["domain_roles", "handoff_hints", "optional_worker_hook"],
             "kernel_layer": [
                 "tmux_codex_tui_lifecycle",
-                "fixed_prompt_wakeup",
+                "todo_readiness_edge_wakeup",
+                "fixed_retry_wakeup",
                 "pane_local_status_check_runtime",
                 "loopx_state_protocol",
             ],
@@ -309,7 +307,7 @@ def build_tui_multi_agent_runner_contract(
             "all_lane_workspace_isolation": all_lane_workspace_isolation,
         },
         "role_prompt_and_skill": {
-            "bootstrap_prompt": "written_to_public_artifact_for_fixed_wake_context",
+            "bootstrap_prompt": "written_to_public_artifact_for_targeted_wake_context",
             "role_profile": "role-local public json artifact",
             "default_kernel_skills": list(GENERIC_MULTI_AGENT_DEFAULT_KERNEL_SKILLS),
             "default_kernel_skill_policy": {
@@ -318,7 +316,7 @@ def build_tui_multi_agent_runner_contract(
                 "preset_should_not_repeat_skill_playbooks": True,
                 "worker_skill_scope": "role_specific_semantics_and_successor_declarations",
             },
-            "fixed_wake_prompt_owner": "generic_multi_agent_kernel",
+            "wake_prompt_owner": "generic_multi_agent_kernel",
             "skill_materialization": ".codex/skills/<skill>/SKILL.md",
             "worker_local_skill_scope": "role_specific_semantics_only",
         },
@@ -468,7 +466,7 @@ def build_compact_human_status(payload: dict[str, object]) -> dict[str, object]:
         "stop": commands.get("stop"),
         "first_action": "$LOOPX_PANE_A2A_TICK",
         "driver_model": driver.get("driver_model")
-        or "fixed_prompt_broadcast_plus_pane_local_state_check",
+        or "todo_readiness_edge_plus_fixed_retry",
         "coordination_pattern": driver.get("coordination_pattern")
         or "decentralized_state_a2a",
         "machine_json_policy": "artifact_only_in_visible_panes",

--- a/loopx/capabilities/multi_agent/runtime_scripts.py
+++ b/loopx/capabilities/multi_agent/runtime_scripts.py
@@ -415,7 +415,7 @@ if os.environ.get("LOOPX_CODEX_TRUST_WORKSPACE") == "1":
 
 args.extend(["-c", f"model_reasoning_effort={reasoning_effort}", "-C", project])
 prompt_path = os.environ.get("LOOPX_CODEX_TUI_PROMPT_ARTIFACT")
-if prompt_path:
+if prompt_path and os.environ.get("LOOPX_CODEX_INITIAL_PROMPT_ENABLED", "1") != "0":
     try:
         prompt = Path(prompt_path).read_text(encoding="utf-8").strip()
     except Exception:

--- a/loopx/capabilities/multi_agent/visible_wake_scheduler.py
+++ b/loopx/capabilities/multi_agent/visible_wake_scheduler.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+from collections.abc import Iterable, Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+STATE_AWARE_WAKE_MODEL = "todo_readiness_edge_plus_fixed_retry"
+DEFAULT_READINESS_POLL_SECONDS = 2.0
+
+
+def lane_agent_map(lanes: Iterable[Mapping[str, object]]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for lane in lanes:
+        lane_id = str(lane.get("lane_id") or "").strip()
+        agent_id = str(lane.get("agent_id") or lane_id).strip()
+        if lane_id:
+            result[lane_id] = agent_id
+    return result
+
+
+def todo_readiness_projection(
+    payload: Mapping[str, object],
+    *,
+    lane_agents: Mapping[str, str],
+) -> dict[str, object]:
+    todos = payload.get("todos")
+    if not isinstance(todos, list):
+        return {
+            "recognized": False,
+            "reason": "todo_projection_missing",
+            "mapped_todo_count": 0,
+            "runnable_lane_tokens": {},
+        }
+
+    lanes_by_agent: dict[str, list[str]] = {}
+    for lane_id, agent_id in lane_agents.items():
+        lanes_by_agent.setdefault(agent_id, []).append(lane_id)
+
+    goal_todo_count = sum(1 for item in todos if isinstance(item, Mapping))
+    mapped_count = 0
+    runnable: dict[str, list[str]] = {}
+    for raw_item in todos:
+        if not isinstance(raw_item, Mapping):
+            continue
+        claimed_by = str(raw_item.get("claimed_by") or "").strip()
+        raw_excluded = raw_item.get("excluded_agents") or []
+        excluded_values = (
+            raw_excluded
+            if isinstance(raw_excluded, (list, tuple, set))
+            else [raw_excluded]
+        )
+        excluded = {
+            str(value).strip() for value in excluded_values if str(value).strip()
+        }
+        target_lanes = lanes_by_agent.get(claimed_by, [])
+        if target_lanes:
+            mapped_count += 1
+        elif not claimed_by and str(
+            raw_item.get("task_class") or "advancement_task"
+        ).strip() == "advancement_task":
+            target_lanes = [
+                lane_id
+                for lane_id, agent_id in lane_agents.items()
+                if agent_id not in excluded
+            ]
+        else:
+            continue
+        if (
+            raw_item.get("done") is True
+            or str(raw_item.get("status") or "open").strip().lower() != "open"
+            or raw_item.get("resume_ready") is False
+            or claimed_by in excluded
+        ):
+            continue
+        todo_id = str(raw_item.get("todo_id") or raw_item.get("index") or "").strip()
+        for lane_id in target_lanes:
+            runnable.setdefault(lane_id, []).append(todo_id or "open")
+
+    tokens = {
+        lane_id: tuple(sorted(todo_ids))
+        for lane_id, todo_ids in runnable.items()
+        if todo_ids
+    }
+    return {
+        "recognized": goal_todo_count > 0,
+        "reason": "goal_todo_projection" if goal_todo_count else "no_goal_todos",
+        "goal_todo_count": goal_todo_count,
+        "mapped_todo_count": mapped_count,
+        "runnable_lane_tokens": tokens,
+    }
+
+
+def read_todo_readiness(
+    *,
+    cli_bin: str,
+    registry: Path,
+    runtime_root: Path,
+    goal_id: str,
+    lane_agents: Mapping[str, str],
+    timeout_seconds: float = 10.0,
+) -> dict[str, object]:
+    command = [
+        cli_bin,
+        "--format",
+        "json",
+        "--registry",
+        str(registry),
+        "--runtime-root",
+        str(runtime_root),
+        "todo",
+        "list",
+        "--goal-id",
+        goal_id,
+        "--role",
+        "agent",
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {
+            "recognized": False,
+            "reason": "todo_projection_command_failed",
+            "error": str(exc),
+            "mapped_todo_count": 0,
+            "runnable_lane_tokens": {},
+        }
+    if completed.returncode != 0:
+        return {
+            "recognized": False,
+            "reason": "todo_projection_command_failed",
+            "error": (completed.stderr or completed.stdout).strip()[:500],
+            "mapped_todo_count": 0,
+            "runnable_lane_tokens": {},
+        }
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        return {
+            "recognized": False,
+            "reason": "todo_projection_invalid_json",
+            "error": str(exc),
+            "mapped_todo_count": 0,
+            "runnable_lane_tokens": {},
+        }
+    if not isinstance(payload, Mapping):
+        return {
+            "recognized": False,
+            "reason": "todo_projection_invalid_payload",
+            "mapped_todo_count": 0,
+            "runnable_lane_tokens": {},
+        }
+    return todo_readiness_projection(payload, lane_agents=lane_agents)
+
+
+def resolve_initial_wake_plan(
+    *,
+    lanes: Iterable[Mapping[str, object]],
+    cli_bin: str,
+    registry: Path,
+    runtime_root: Path,
+    goal_id: str,
+) -> dict[str, object]:
+    agents = lane_agent_map(lanes)
+    projection = (
+        read_todo_readiness(
+            cli_bin=cli_bin,
+            registry=registry,
+            runtime_root=runtime_root,
+            goal_id=goal_id,
+            lane_agents=agents,
+        )
+        if goal_id and agents
+        else {
+            "recognized": False,
+            "reason": "goal_or_lane_agent_mapping_missing",
+            "mapped_todo_count": 0,
+            "runnable_lane_tokens": {},
+        }
+    )
+    tokens = projection.get("runnable_lane_tokens", {})
+    return {
+        "lane_agents": agents,
+        "projection": projection,
+        "state_aware": bool(projection.get("recognized")),
+        "target_lanes": list(tokens) if isinstance(tokens, Mapping) else [],
+    }
+
+
+def _jsonable_tokens(tokens: Mapping[str, tuple[str, ...]]) -> dict[str, list[str]]:
+    return {lane_id: list(value) for lane_id, value in tokens.items()}
+
+
+def _append_event(path: Path, payload: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    event = {
+        "recorded_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        **payload,
+    }
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def run_state_aware_wake_loop(
+    *,
+    cli_bin: str,
+    tmux_bin: str,
+    registry: Path,
+    runtime_root: Path,
+    goal_id: str,
+    session: str,
+    lane_agents: Mapping[str, str],
+    initial_projection: Mapping[str, object],
+    artifact: Path,
+    retry_interval_seconds: float,
+    poll_interval_seconds: float = DEFAULT_READINESS_POLL_SECONDS,
+) -> None:
+    all_lanes = list(lane_agents)
+    state_aware = bool(initial_projection.get("recognized"))
+    previous_tokens = {
+        str(lane_id): tuple(str(item) for item in token)
+        for lane_id, token in (
+            initial_projection.get("runnable_lane_tokens", {})
+            if isinstance(initial_projection.get("runnable_lane_tokens"), Mapping)
+            else {}
+        ).items()
+        if isinstance(token, (list, tuple))
+    }
+    now = time.monotonic()
+    last_wake = {lane_id: now for lane_id in previous_tokens}
+    projection_error_active = False
+    _append_event(
+        artifact,
+        {
+            "event": "scheduler_started",
+            "goal_id": goal_id,
+            "mode": STATE_AWARE_WAKE_MODEL if state_aware else "fixed_retry_fallback",
+            "runnable_lane_tokens": _jsonable_tokens(previous_tokens),
+        },
+    )
+
+    retry_interval = max(5.0, float(retry_interval_seconds or 0))
+    poll_interval = max(0.5, float(poll_interval_seconds or 0))
+    while subprocess.run(
+        [tmux_bin, "has-session", "-t", session],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    ).returncode == 0:
+        time.sleep(poll_interval)
+        projection = read_todo_readiness(
+            cli_bin=cli_bin,
+            registry=registry,
+            runtime_root=runtime_root,
+            goal_id=goal_id,
+            lane_agents=lane_agents,
+        )
+        if projection.get("recognized"):
+            state_aware = True
+            projection_error_active = False
+            raw_tokens = projection.get("runnable_lane_tokens", {})
+            if not isinstance(raw_tokens, Mapping):
+                raw_tokens = {}
+            current_tokens = {
+                str(lane_id): tuple(str(item) for item in token)
+                for lane_id, token in raw_tokens.items()
+                if isinstance(token, (list, tuple))
+            }
+        elif state_aware:
+            if not projection_error_active:
+                _append_event(
+                    artifact,
+                    {
+                        "event": "projection_read_failed",
+                        "reason": projection.get("reason"),
+                        "error": projection.get("error"),
+                    },
+                )
+                projection_error_active = True
+            continue
+        else:
+            current_tokens = {lane_id: ("fallback",) for lane_id in all_lanes}
+
+        now = time.monotonic()
+        edge_lanes = [
+            lane_id
+            for lane_id, token in current_tokens.items()
+            if token != previous_tokens.get(lane_id)
+        ]
+        retry_lanes = [
+            lane_id
+            for lane_id in current_tokens
+            if lane_id not in edge_lanes
+            and now - last_wake.get(lane_id, 0.0) >= retry_interval
+        ]
+        targets = [*edge_lanes, *retry_lanes]
+        previous_tokens = current_tokens
+        if not targets:
+            continue
+
+        command = [
+            cli_bin,
+            "--format",
+            "json",
+            "multi-agent",
+            "wake",
+            "--session-name",
+            session,
+            "--tmux-bin",
+            tmux_bin,
+        ]
+        for lane_id in targets:
+            command.extend(["--lane", lane_id])
+        command.append("--execute")
+        completed = subprocess.run(command, check=False, capture_output=True, text=True)
+        try:
+            wake_payload: Any = json.loads(completed.stdout)
+        except json.JSONDecodeError:
+            wake_payload = {
+                "ok": False,
+                "returncode": completed.returncode,
+                "error": (completed.stderr or completed.stdout).strip()[:500],
+            }
+        _append_event(
+            artifact,
+            {
+                "event": "wake",
+                "trigger": "readiness_edge" if edge_lanes else "fixed_retry",
+                "target_lanes": targets,
+                "runnable_lane_tokens": _jsonable_tokens(current_tokens),
+                "wake": wake_payload,
+            },
+        )
+        for lane_id in targets:
+            last_wake[lane_id] = now
+        if isinstance(wake_payload, Mapping) and wake_payload.get(
+            "auto_wake_backoff_recommended"
+        ) is True:
+            break
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--cli-bin", required=True)
+    parser.add_argument("--tmux-bin", required=True)
+    parser.add_argument("--registry", type=Path, required=True)
+    parser.add_argument("--runtime-root", type=Path, required=True)
+    parser.add_argument("--goal-id", required=True)
+    parser.add_argument("--session", required=True)
+    parser.add_argument("--lane-agents-json", required=True)
+    parser.add_argument("--initial-projection-json", required=True)
+    parser.add_argument("--artifact", type=Path, required=True)
+    parser.add_argument("--retry-interval-seconds", type=float, required=True)
+    parser.add_argument(
+        "--poll-interval-seconds",
+        type=float,
+        default=DEFAULT_READINESS_POLL_SECONDS,
+    )
+    args = parser.parse_args()
+    lane_agents = json.loads(args.lane_agents_json)
+    initial_projection = json.loads(args.initial_projection_json)
+    if not isinstance(lane_agents, dict) or not isinstance(initial_projection, dict):
+        raise ValueError("state-aware wake scheduler requires object projections")
+    run_state_aware_wake_loop(
+        cli_bin=args.cli_bin,
+        tmux_bin=args.tmux_bin,
+        registry=args.registry,
+        runtime_root=args.runtime_root,
+        goal_id=args.goal_id,
+        session=args.session,
+        lane_agents=lane_agents,
+        initial_projection=initial_projection,
+        artifact=args.artifact,
+        retry_interval_seconds=args.retry_interval_seconds,
+        poll_interval_seconds=args.poll_interval_seconds,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -25,6 +25,11 @@ from .capabilities.multi_agent.runtime_scripts import (
     CODEX_TUI_EXEC_PY as _CODEX_TUI_EXEC_PY,
     SCOPED_LOOPX_WRAPPER_PY as _SCOPED_LOOPX_WRAPPER_PY,
 )
+from .capabilities.multi_agent.visible_wake_scheduler import (
+    DEFAULT_READINESS_POLL_SECONDS,
+    STATE_AWARE_WAKE_MODEL,
+    resolve_initial_wake_plan,
+)
 from .visible_multi_agent_tmux import (
     PANE_A2A_INPUT_READY_TIMEOUT_SECONDS,
     PANE_A2A_WAKEUP_PROMPT,
@@ -697,28 +702,31 @@ def _start_auto_wake_loop(
     registry: Path,
     runtime_root: Path,
     session: str,
-    lanes: list[str],
+    lane_agents: dict[str, str],
+    goal_id: str,
+    initial_projection: dict[str, object],
     tmux_bin: str,
     cli_bin: str,
     interval_seconds: float,
     env: dict[str, str],
 ) -> dict[str, object]:
     interval = max(5.0, float(interval_seconds or 0))
-    lane_flags = " ".join(f"--lane {_q(lane)}" for lane in lanes if lane)
+    artifact = (
+        runtime_root
+        / "visible-launcher-artifacts"
+        / _script_slug(session)
+        / "auto-wake.public.jsonl"
+    )
     wake_command = (
-        'WAKE_LOG="$LOOPX_VISIBLE_ARTIFACT_DIR/auto-wake.public.jsonl"; '
-        'WAKE_TMP="$LOOPX_VISIBLE_ARTIFACT_DIR/auto-wake.last.public.json"; '
-        f"while {_q(tmux_bin)} has-session -t \"$LOOPX_VISIBLE_SESSION\" >/dev/null 2>&1; do "
-        f"sleep {_q(f'{interval:g}')}; "
-        f"{_q(cli_bin)} --format json multi-agent wake "
-        '--session-name "$LOOPX_VISIBLE_SESSION" '
-        f"--tmux-bin {_q(tmux_bin)} "
-        f"{lane_flags} --execute > \"$WAKE_TMP\" 2>&1 || true; "
-        "cat \"$WAKE_TMP\" >> \"$WAKE_LOG\"; printf '\\n' >> \"$WAKE_LOG\"; "
-        "if grep -Eq '\"auto_wake_backoff_recommended\"[[:space:]]*:[[:space:]]*true' \"$WAKE_TMP\"; then "
-        "break; "
-        "fi; "
-        "done"
+        "exec python3 -m loopx.capabilities.multi_agent.visible_wake_scheduler "
+        f"--cli-bin {_q(cli_bin)} --tmux-bin {_q(tmux_bin)} "
+        f"--registry {_q(registry)} --runtime-root {_q(runtime_root)} "
+        f"--goal-id {_q(goal_id)} --session {_q(session)} "
+        f"--lane-agents-json {_q(json.dumps(lane_agents, sort_keys=True))} "
+        f"--initial-projection-json {_q(json.dumps(initial_projection, sort_keys=True))} "
+        f"--artifact {_q(artifact)} "
+        f"--retry-interval-seconds {_q(f'{interval:g}')} "
+        f"--poll-interval-seconds {_q(f'{DEFAULT_READINESS_POLL_SECONDS:g}')}"
     )
     script = _write_tmux_script(
         script_dir=script_dir,
@@ -744,13 +752,21 @@ def _start_auto_wake_loop(
         "enabled": True,
         "mode": "background_process",
         "interval_seconds": interval,
-        "target_lanes": lanes,
-        "wakeup_model": "fixed_prompt_broadcast",
+        "target_lanes": list(lane_agents),
+        "wakeup_model": (
+            STATE_AWARE_WAKE_MODEL
+            if initial_projection.get("recognized")
+            else "fixed_prompt_broadcast_fallback"
+        ),
         "workflow_driver": False,
         "broadcaster_reads_frontier": False,
+        "broadcaster_reads_todo_readiness": True,
         "broadcaster_selects_todo": False,
         "pane_decision_owner": "codex_tui_agent_via_loopx_state",
         "artifact": "auto-wake.public.jsonl",
+        "artifact_path": str(artifact),
+        "readiness_poll_seconds": DEFAULT_READINESS_POLL_SECONDS,
+        "initial_projection": initial_projection,
         "process_started": True,
         "pid_recorded": False,
         "boundary": {
@@ -882,6 +898,18 @@ def _launch_with_tmux(
         subprocess.run([tmux_bin, "kill-session", "-t", session], check=True, env=env)
 
     script_dir = runtime_root / "visible-launcher" / _script_slug(session)
+    goal_id = str(payload.get("goal_id") or "").strip()
+    initial_wake_plan = resolve_initial_wake_plan(
+        lanes=lanes,
+        cli_bin=cli_bin,
+        registry=registry,
+        runtime_root=runtime_root,
+        goal_id=goal_id,
+    )
+    lane_agents = dict(initial_wake_plan["lane_agents"])
+    initial_projection = dict(initial_wake_plan["projection"])
+    initial_runnable_lanes = set(initial_wake_plan["target_lanes"])
+    state_aware_initial_prompt = bool(initial_wake_plan["state_aware"])
     started_lanes = []
     lane_targets: dict[str, str] = {}
     launcher_scripts: dict[str, str] = {}
@@ -899,6 +927,8 @@ def _launch_with_tmux(
             name=lane_id,
             command=runtime_shell_command(
                 f"export LOOPX_CODEX_TRUST_WORKSPACE={_q('1' if codex_trust_workspace else '0')}; "
+                "export LOOPX_CODEX_INITIAL_PROMPT_ENABLED="
+                f"{_q('1' if not state_aware_initial_prompt or lane_id in initial_runnable_lanes else '0')}; "
                 f"export LOOPX_VISIBLE_LANE_COUNT={_q(len(lanes))}; "
                 f"{launch_command}",
                 project=lane_project,
@@ -984,7 +1014,13 @@ def _launch_with_tmux(
             registry=registry,
             runtime_root=runtime_root,
             session=session,
-            lanes=started_lanes,
+            lane_agents={
+                lane_id: lane_agents[lane_id]
+                for lane_id in started_lanes
+                if lane_id in lane_agents
+            },
+            goal_id=goal_id,
+            initial_projection=initial_projection,
             tmux_bin=tmux_bin,
             cli_bin=cli_bin,
             interval_seconds=auto_wake_interval_seconds,
@@ -1028,6 +1064,24 @@ def _launch_with_tmux(
         "operator_takeover": "attach to the tmux session, interrupt any lane, or kill the session",
         "auto_wake": auto_wake_result,
         "visible_acceptance": acceptance,
+        "initial_prompt": {
+            "mode": (
+                "todo_readiness_targeted"
+                if state_aware_initial_prompt
+                else "all_lanes_compatibility_fallback"
+            ),
+            "target_lanes": [
+                lane_id for lane_id in started_lanes if lane_id in initial_runnable_lanes
+            ]
+            if state_aware_initial_prompt
+            else started_lanes,
+            "deferred_lanes": [
+                lane_id for lane_id in started_lanes if lane_id not in initial_runnable_lanes
+            ]
+            if state_aware_initial_prompt
+            else [],
+            "projection": initial_projection,
+        },
         "tmux_layout": {
             "window_name": window_name,
             "single_window": True,

--- a/loopx/visible_multi_agent_tmux.py
+++ b/loopx/visible_multi_agent_tmux.py
@@ -54,9 +54,12 @@ def _codex_tui_input_ready(capture: str) -> bool:
     has_codex_surface = "OpenAI Codex" in capture or "gpt-" in capture[prompt_index:]
     if not has_codex_surface:
         return False
-    current_view = capture[prompt_index:]
-    if "Queued follow-up inputs" in current_view or "Working (" in current_view:
+    # Codex keeps a queueable input prompt visible while a turn is still running.
+    # Busy markers render immediately above that prompt, so checking only the
+    # text after the final prompt incorrectly treats an active turn as idle.
+    if "Queued follow-up inputs" in capture or "Working (" in capture:
         return False
+    current_view = capture[prompt_index:]
     if "Starting MCP servers" in current_view:
         return False
     return True
@@ -392,6 +395,9 @@ def wake_visible_multi_agent_panes(
         "driver_contract": driver_contract,
         "workflow_driver": False,
         "broadcaster_reads_frontier": driver_contract["broadcaster"]["reads_frontier"],
+        "broadcaster_reads_todo_readiness": driver_contract["broadcaster"].get(
+            "reads_todo_readiness", False
+        ),
         "broadcaster_selects_todo": driver_contract["broadcaster"]["selects_todo"],
         "pane_decision_owner": driver_contract["pane"]["decision_owner"],
         "pane_input_ready_verified": (


### PR DESCRIPTION
## Summary

- suppress initial model prompts for lanes whose claimed todos are still resume-gated
- wake only lanes whose runnable todo token changes, with the existing interval retained as a targeted retry
- reject queueable-but-busy Codex TUI panes and keep unclaimed advancement work visible to eligible peers
- bump the generic A2A driver contract to v1 and add durable scheduler/launcher smokes

## Observed startup effect

A fresh KNN auto-research run reduced curator-complete to proposer-wake latency from about 44.6s to 1.18s. Blocked panes received no initial model prompt, and fixed retries against an active curator were skipped instead of queued. The proposer later hit the local Codex usage limit; no claim is made about downstream research quality from that run.

## Validation

- focused visible wake, launcher, generic multi-agent, and auto-research contract smokes
- `loopx canary premerge --from-git-diff`: passed, 8/8 selected checks, no warnings or manual holds
- public/private boundary scan: clean across all 13 changed files
