### PR TITLE
Fix vision replan starvation under monitor load

### DIFF
--- a/examples/control_plane/monitor-poll-writeback-smoke.py
+++ b/examples/control_plane/monitor-poll-writeback-smoke.py
@@ -309,7 +309,7 @@ def assert_unchanged_writeback() -> None:
         assert payload["before"]["work_lane_contract"]["obligation"] == "attempt_due_monitor", payload
         assert summary["after"]["effective_action"] == payload["after"]["effective_action"], payload
         assert "interaction_contract" not in summary["after"], payload
-        assert payload["after"]["interaction_contract"]["mode"] == "bounded_delivery", payload
+        assert payload["after"]["interaction_contract"]["mode"] == "autonomous_replan", payload
         records = monitor_poll_records(registry_path)
         assert [record["classification"] for record in records] == ["quota_monitor_poll"], records
 
@@ -499,7 +499,7 @@ def assert_target_key_cannot_hijack_selected_due_monitor() -> None:
         )
         assert "- ok: `False`" in markdown, markdown
         assert "- mode: `monitor-poll`" in markdown, markdown
-        assert f"- todo_id: ``" in markdown, markdown
+        assert "- todo_id: ``" in markdown, markdown
         assert f"- target_key: `{OTHER_TARGET_KEY}`" in markdown, markdown
         assert "- material_change: `True`" in markdown, markdown
         assert "- appended: `False`" in markdown, markdown

--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -544,6 +544,25 @@ def assert_future_scheduled_monitor_requires_replan_without_frontier_delta() -> 
     assert "required_reads" in guard["interaction_contract"]["cli_channel"], guard
 
 
+def assert_due_monitor_requires_replan_without_advancement_frontier() -> None:
+    guard = build_quota_should_run(
+        status_payload(
+            [monitor_item(next_due_at="2000-01-01T00:00:00+00:00")],
+            replan_obligation=None,
+        ),
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert guard["decision"] == "autonomous_replan_required", guard
+    assert guard["effective_action"] == "autonomous_replan_required", guard
+    assert guard["should_run"] is True, guard
+    assert guard["goal_frontier_projection"]["replan_required"] is True, guard
+    assert guard["goal_frontier_projection"]["monitor_only_lanes"]["present"] is True, guard
+    obligation = guard["autonomous_replan_obligation"]
+    assert obligation["triggers"][0]["kind"] == "frontier_exhausted_monitor_lane", guard
+    assert obligation["triggers"][0]["future_monitor_schedule_present"] is False, guard
+
+
 def assert_ready_deferred_successor_beats_monitor_quiet_skip() -> None:
     guard = build_quota_should_run(
         status_payload(
@@ -1426,6 +1445,7 @@ def main() -> None:
     assert_replan_beats_monitor_quiet_skip()
     assert_frontier_delta_ack_clears_existing_replan_obligation()
     assert_future_scheduled_monitor_requires_replan_without_frontier_delta()
+    assert_due_monitor_requires_replan_without_advancement_frontier()
     assert_ready_deferred_successor_beats_monitor_quiet_skip()
     assert_completed_advancement_without_successor_beats_monitor_quiet_skip()
     assert_replan_preserves_current_agent_runnable_frontier()

--- a/examples/control_plane/run-history-agent-context-retention-smoke.py
+++ b/examples/control_plane/run-history-agent-context-retention-smoke.py
@@ -103,6 +103,31 @@ def write_fixture(root: Path) -> tuple[Path, Path]:
 def main() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-agent-context-retention-") as raw_tmp:
         registry_path, runtime = write_fixture(Path(raw_tmp))
+        runs_dir = runtime / "goals" / GOAL_ID / "runs"
+        with (runs_dir / "index.jsonl").open("a", encoding="utf-8") as handle:
+            handle.write(
+                json.dumps(
+                    {
+                        "generated_at": "2026-07-06T00:07:00+00:00",
+                        "goal_id": GOAL_ID,
+                        "classification": "state_refreshed",
+                        "agent_id": SIDE_AGENT,
+                        "recommended_action": "keep side vision unchanged",
+                        "json_path": str(runs_dir / "unchanged-side-vision.json"),
+                        "markdown_path": str(runs_dir / "unchanged-side-vision.md"),
+                        "vision_checkpoint": {
+                            "schema_version": "vision_checkpoint_v0",
+                            "agent_id": SIDE_AGENT,
+                            "required": True,
+                            "satisfied": True,
+                            "decision": "unchanged_with_reason",
+                            "unchanged_reason": "The active side vision still applies.",
+                        },
+                    },
+                    ensure_ascii=False,
+                )
+                + "\n"
+            )
         history = collect_history(
             registry_path=registry_path,
             runtime_root=runtime,
@@ -112,9 +137,9 @@ def main() -> None:
         goal = history["goals"][0]
         latest_runs = goal["latest_runs"]
         assert [run["recommended_action"] for run in latest_runs[:3]] == [
+            "keep side vision unchanged",
             "latest main",
             "latest product",
-            "second main",
         ], latest_runs
         assert any(
             run.get("agent_id") == SIDE_AGENT and run.get("agent_vision")

--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -874,7 +874,10 @@ def _is_monitor_only_lane(
 ) -> bool:
     return bool(
         _is_continuous_monitor_lane(work_lane_contract)
-        and work_lane_contract.get("must_attempt_work") is False
+        and (
+            work_lane_contract.get("must_attempt_work") is False
+            or work_lane_contract.get("monitor_kind") == "todo_monitor_due"
+        )
     )
 
 
@@ -1259,7 +1262,12 @@ def build_goal_frontier_projection_from_summaries(
         agent_todo_summary=agent_todo_summary,
         agent_id=agent_id,
     )
-    monitor_only_lane = _is_monitor_only_lane(work_lane_contract)
+    monitor_only_lane = bool(
+        _is_monitor_only_lane(work_lane_contract)
+        and agent_counts.get("monitor", 0) > 0
+        and agent_counts.get("advancement", 0) == 0
+        and sum(frontier_counts.values()) == 0
+    )
     return build_goal_frontier_projection(
         goal_id=goal_id,
         agent_id=agent_id,

--- a/loopx/history.py
+++ b/loopx/history.py
@@ -10,7 +10,6 @@ from .authority import goal_authority_registry_summary
 from .control_plane import compact_control_plane_policy
 from .control_plane.runtime.time import now_local_iso
 from .control_plane.runtime.run_index_duplicates import (
-    STRUCTURED_INDEX_KEYS,
     classify_index_duplicate_records,
     duplicate_repair_decision,
     index_identity,
@@ -22,7 +21,6 @@ from .execution_profile import compact_execution_profile
 from .paths import resolve_runtime_root
 from .presentation.markdown import (
     markdown_code,
-    markdown_scalar,
     markdown_table_row,
     markdown_table_separator,
 )
@@ -687,21 +685,44 @@ def latest_runs_with_agent_context(
     *,
     limit: int,
 ) -> list[dict[str, Any]]:
-    """Keep recent runs plus each agent's newest vision/replan context run."""
+    """Keep recent runs plus each agent's newest durable context per field."""
 
     bounded = max(0, limit)
     selected = list(runs[:bounded])
     selected_ids = {id(run) for run in selected}
-    agents_with_context: set[str] = set()
+    retained_context_fields: set[tuple[str, str]] = set()
+    retired_agent_visions: set[str] = set()
 
     for run in runs:
         agent_id = str(run.get("agent_id") or "").strip()
-        if not agent_id or agent_id in agents_with_context:
+        if not agent_id:
             continue
-        if not any(isinstance(run.get(field), dict) for field in PER_AGENT_CONTEXT_RUN_FIELDS):
-            continue
-        agents_with_context.add(agent_id)
-        if id(run) not in selected_ids:
+        fields_to_retain: list[str] = []
+        checkpoint = (
+            run.get("vision_checkpoint")
+            if isinstance(run.get("vision_checkpoint"), dict)
+            else {}
+        )
+        if (
+            checkpoint.get("satisfied") is True
+            and str(checkpoint.get("decision") or "").strip()
+            == "retired_or_superseded"
+        ):
+            retired_agent_visions.add(agent_id)
+            retained_context_fields.add((agent_id, "agent_vision"))
+
+        for field in PER_AGENT_CONTEXT_RUN_FIELDS:
+            context_key = (agent_id, field)
+            if context_key in retained_context_fields:
+                continue
+            if not isinstance(run.get(field), dict):
+                continue
+            if field == "agent_vision" and agent_id in retired_agent_visions:
+                continue
+            retained_context_fields.add(context_key)
+            fields_to_retain.append(field)
+
+        if fields_to_retain and id(run) not in selected_ids:
             selected.append(run)
             selected_ids.add(id(run))
     return selected


### PR DESCRIPTION
## Summary

- retain each agent's latest durable context per field so a newer vision checkpoint cannot evict an older still-active vision
- classify an ordinary due todo monitor as monitor-only when no advancement frontier exists, so goal-level replan runs before repeated monitor cycling
- preserve explicit external-evidence and dependency observations as bounded read-only work

## Root cause

The compact run-history retention code used one shared slot for `agent_vision`, `vision_checkpoint`, and `autonomous_replan_ack`. A newer `unchanged_with_reason` checkpoint therefore hid the still-active vision outside the display window. Separately, due monitors set `must_attempt_work=true`, which excluded them from monitor-only frontier detection even when advancement was zero.

## Validation

- `python3 examples/control_plane/run-history-agent-context-retention-smoke.py`
- `python3 examples/control_plane/quota-replan-decision-plane-smoke.py`
- `python3 examples/control_plane/monitor-poll-writeback-smoke.py`
- `python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `python3 examples/control_plane/status-neutral-run-window-smoke.py`
- `python3 examples/control_plane/peer-agent-continuation-state-machine-smoke.py`
- `python3 examples/control_plane/interaction-contract-state-machine-smoke.py`
- `python3 examples/control_plane/monitor-scheduler-contract-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `uvx ruff check` on all changed Python files
- `loopx check` on all changed public files: 0 errors, 0 warnings
- `git diff --check origin/main...HEAD`

The standard premerge selector ran but did not emit its final JSON summary in this environment. Its preview-selected checks were executed directly above; there are no manual holds. No private state, credentials, raw runtime logs, or project-specific fixtures are included.
