### PR TITLE
Move benchmark learning ledger projection inward

### DIFF
--- a/loopx/control_plane/runtime/benchmark_learning_ledger.py
+++ b/loopx/control_plane/runtime/benchmark_learning_ledger.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .benchmark_comparison import compact_comparison_delta
+from .public_safety import public_safe_compact_list, public_safe_compact_text
+
+BENCHMARK_LEARNING_LEDGER_SCHEMA_VERSION = "benchmark_learning_ledger_v0"
+MAX_BENCHMARK_LEARNING_LEDGER_LIST_ITEMS = 5
+
+
+def _benchmark_learning_ledger_source(
+    run: dict[str, Any],
+) -> dict[str, Any] | None:
+    nested = run.get("benchmark_learning_ledger")
+    if (
+        isinstance(nested, dict)
+        and nested.get("schema_version") == BENCHMARK_LEARNING_LEDGER_SCHEMA_VERSION
+    ):
+        return nested
+    if run.get("schema_version") == BENCHMARK_LEARNING_LEDGER_SCHEMA_VERSION:
+        return run
+    return None
+
+
+def compact_benchmark_learning_ledger(
+    run: dict[str, Any],
+) -> dict[str, Any] | None:
+    source = _benchmark_learning_ledger_source(run)
+    if not source:
+        return None
+
+    compact: dict[str, Any] = {
+        "schema_version": BENCHMARK_LEARNING_LEDGER_SCHEMA_VERSION
+    }
+    for field in ("task_id", "comparison_id", "learning_status", "claim_strength"):
+        value = public_safe_compact_text(source.get(field), limit=180)
+        if value:
+            compact[field] = value
+
+    for field in ("official_task_score_delta", "control_plane_score_delta"):
+        delta = compact_comparison_delta(source.get(field))
+        if delta is not None:
+            compact[field] = delta
+
+    for field in ("repair_candidates", "claim_blockers"):
+        values = public_safe_compact_list(
+            source.get(field), limit=MAX_BENCHMARK_LEARNING_LEDGER_LIST_ITEMS
+        )
+        if values:
+            compact[field] = values
+
+    lifecycle_gate = source.get("lifecycle_gate")
+    if isinstance(lifecycle_gate, dict):
+        compact_gate: dict[str, Any] = {}
+        for field in ("budget_count_allowed", "blocked_reason"):
+            value = lifecycle_gate.get(field)
+            if isinstance(value, bool):
+                compact_gate[field] = value
+            elif field == "blocked_reason":
+                text = public_safe_compact_text(value, limit=160)
+                if text:
+                    compact_gate[field] = text
+        if compact_gate:
+            compact["lifecycle_gate"] = compact_gate
+
+    learning_gate = source.get("learning_quota_gate")
+    if isinstance(learning_gate, dict):
+        compact_learning_gate: dict[str, Any] = {}
+        for field in (
+            "actionable_learning_present",
+            "spend_allowed",
+            "blocked_reason",
+        ):
+            value = learning_gate.get(field)
+            if isinstance(value, bool):
+                compact_learning_gate[field] = value
+            elif field == "blocked_reason":
+                text = public_safe_compact_text(value, limit=160)
+                if text:
+                    compact_learning_gate[field] = text
+        reasons = public_safe_compact_list(
+            learning_gate.get("actionable_reasons"),
+            limit=MAX_BENCHMARK_LEARNING_LEDGER_LIST_ITEMS,
+        )
+        if reasons:
+            compact_learning_gate["actionable_reasons"] = reasons
+        if compact_learning_gate:
+            compact["learning_quota_gate"] = compact_learning_gate
+
+    overhead = source.get("overhead")
+    if isinstance(overhead, dict):
+        compact_overhead: dict[str, Any] = {}
+        for field in ("cost_delta_usd", "wall_time_delta_seconds_or_ms"):
+            delta = compact_comparison_delta(overhead.get(field))
+            if delta is not None:
+                compact_overhead[field] = delta
+        label = public_safe_compact_text(overhead.get("label"), limit=120)
+        if label:
+            compact_overhead["label"] = label
+        if compact_overhead:
+            compact["overhead"] = compact_overhead
+
+    routing = source.get("routing")
+    if isinstance(routing, dict):
+        compact_routing: dict[str, Any] = {}
+        for field in ("repeat_allowed", "new_candidate_allowed"):
+            if isinstance(routing.get(field), bool):
+                compact_routing[field] = routing[field]
+        next_action = public_safe_compact_text(
+            routing.get("next_allowed_action"), limit=180
+        )
+        if next_action:
+            compact_routing["next_allowed_action"] = next_action
+        if compact_routing:
+            compact["routing"] = compact_routing
+
+    read_boundary = source.get("read_boundary")
+    if isinstance(read_boundary, dict):
+        compact_boundary: dict[str, bool] = {}
+        for field in (
+            "compact_only",
+            "raw_artifacts_read",
+            "task_text_read",
+            "local_paths_recorded",
+        ):
+            if isinstance(read_boundary.get(field), bool):
+                compact_boundary[field] = read_boundary[field]
+        if compact_boundary:
+            compact["read_boundary"] = compact_boundary
+
+    if set(compact) == {"schema_version"}:
+        return None
+    return compact

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -201,6 +201,9 @@ from .control_plane.runtime.benchmark_experiment_report import (
     benchmark_experiment_report_replay_decision,
     compact_benchmark_experiment_report,
 )
+from .control_plane.runtime.benchmark_learning_ledger import (
+    compact_benchmark_learning_ledger,
+)
 from .control_plane.runtime.benchmark_lifecycle_contracts import (
     compact_app_server_goal_round_semantics as _compact_app_server_goal_round_semantics,
     compact_native_goal_worker_contract as _compact_native_goal_worker_contract,
@@ -452,7 +455,6 @@ BENCHMARK_VALIDATION_NEUTRAL_FALSE_FIELDS = {
 }
 BENCHMARK_RUN_SCHEMA_VERSION = "benchmark_run_v0"
 BENCHMARK_RESULT_SCHEMA_VERSION = "benchmark_result_v0"
-BENCHMARK_LEARNING_LEDGER_SCHEMA_VERSION = "benchmark_learning_ledger_v0"
 ACTIVE_USER_ASSISTED_PILOT_SCHEMA_VERSION = "active_user_assisted_pilot_v0"
 OPERATOR_SIMULATOR_RUN_SCHEMA_VERSION = "operator_simulator_run_v0"
 CONTROL_PLANE_SCORE_SCHEMA_VERSION = "control_plane_score_core_v0"
@@ -3773,111 +3775,6 @@ def compact_benchmark_result(run: dict[str, Any]) -> dict[str, Any] | None:
     labels = public_safe_compact_list(source.get("failure_attribution_labels"), limit=MAX_BENCHMARK_RUN_LIST_ITEMS)
     if labels:
         compact["failure_attribution_labels"] = labels
-
-    if set(compact.keys()) == {"schema_version"}:
-        return None
-    return compact
-
-
-
-
-def _benchmark_learning_ledger_source(run: dict[str, Any]) -> dict[str, Any] | None:
-    nested = run.get("benchmark_learning_ledger")
-    if isinstance(nested, dict) and nested.get("schema_version") == BENCHMARK_LEARNING_LEDGER_SCHEMA_VERSION:
-        return nested
-    if run.get("schema_version") == BENCHMARK_LEARNING_LEDGER_SCHEMA_VERSION:
-        return run
-    return None
-
-
-def compact_benchmark_learning_ledger(run: dict[str, Any]) -> dict[str, Any] | None:
-    source = _benchmark_learning_ledger_source(run)
-    if not source:
-        return None
-
-    compact: dict[str, Any] = {"schema_version": BENCHMARK_LEARNING_LEDGER_SCHEMA_VERSION}
-    for field in ("task_id", "comparison_id", "learning_status", "claim_strength"):
-        value = public_safe_compact_text(source.get(field), limit=180)
-        if value:
-            compact[field] = value
-
-    for field in ("official_task_score_delta", "control_plane_score_delta"):
-        delta = _compact_comparison_delta(source.get(field))
-        if delta is not None:
-            compact[field] = delta
-
-    for field in ("repair_candidates", "claim_blockers"):
-        values = public_safe_compact_list(source.get(field), limit=MAX_BENCHMARK_RUN_LIST_ITEMS)
-        if values:
-            compact[field] = values
-
-    lifecycle_gate = source.get("lifecycle_gate")
-    if isinstance(lifecycle_gate, dict):
-        compact_gate: dict[str, Any] = {}
-        for field in ("budget_count_allowed", "blocked_reason"):
-            value = lifecycle_gate.get(field)
-            if isinstance(value, bool):
-                compact_gate[field] = value
-            elif field == "blocked_reason":
-                text = public_safe_compact_text(value, limit=160)
-                if text:
-                    compact_gate[field] = text
-        if compact_gate:
-            compact["lifecycle_gate"] = compact_gate
-
-    learning_gate = source.get("learning_quota_gate")
-    if isinstance(learning_gate, dict):
-        compact_learning_gate: dict[str, Any] = {}
-        for field in ("actionable_learning_present", "spend_allowed", "blocked_reason"):
-            value = learning_gate.get(field)
-            if isinstance(value, bool):
-                compact_learning_gate[field] = value
-            elif field == "blocked_reason":
-                text = public_safe_compact_text(value, limit=160)
-                if text:
-                    compact_learning_gate[field] = text
-        reasons = public_safe_compact_list(
-            learning_gate.get("actionable_reasons"),
-            limit=MAX_BENCHMARK_RUN_LIST_ITEMS,
-        )
-        if reasons:
-            compact_learning_gate["actionable_reasons"] = reasons
-        if compact_learning_gate:
-            compact["learning_quota_gate"] = compact_learning_gate
-
-    overhead = source.get("overhead")
-    if isinstance(overhead, dict):
-        compact_overhead: dict[str, Any] = {}
-        for field in ("cost_delta_usd", "wall_time_delta_seconds_or_ms"):
-            delta = _compact_comparison_delta(overhead.get(field))
-            if delta is not None:
-                compact_overhead[field] = delta
-        label = public_safe_compact_text(overhead.get("label"), limit=120)
-        if label:
-            compact_overhead["label"] = label
-        if compact_overhead:
-            compact["overhead"] = compact_overhead
-
-    routing = source.get("routing")
-    if isinstance(routing, dict):
-        compact_routing: dict[str, Any] = {}
-        for field in ("repeat_allowed", "new_candidate_allowed"):
-            if isinstance(routing.get(field), bool):
-                compact_routing[field] = routing[field]
-        next_action = public_safe_compact_text(routing.get("next_allowed_action"), limit=180)
-        if next_action:
-            compact_routing["next_allowed_action"] = next_action
-        if compact_routing:
-            compact["routing"] = compact_routing
-
-    read_boundary = source.get("read_boundary")
-    if isinstance(read_boundary, dict):
-        compact_boundary: dict[str, bool] = {}
-        for field in ("compact_only", "raw_artifacts_read", "task_text_read", "local_paths_recorded"):
-            if isinstance(read_boundary.get(field), bool):
-                compact_boundary[field] = read_boundary[field]
-        if compact_boundary:
-            compact["read_boundary"] = compact_boundary
 
     if set(compact.keys()) == {"schema_version"}:
         return None

--- a/tests/control_plane/test_benchmark_learning_ledger.py
+++ b/tests/control_plane/test_benchmark_learning_ledger.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from loopx import status
+from loopx.control_plane.runtime.benchmark_learning_ledger import (
+    compact_benchmark_learning_ledger,
+)
+
+
+def test_status_preserves_benchmark_learning_ledger_import() -> None:
+    assert status.compact_benchmark_learning_ledger is compact_benchmark_learning_ledger
+
+
+def test_compact_learning_ledger_preserves_public_routing_contract() -> None:
+    compact = compact_benchmark_learning_ledger(
+        {
+            "benchmark_learning_ledger": {
+                "schema_version": "benchmark_learning_ledger_v0",
+                "task_id": "task-1",
+                "comparison_id": "pair-1",
+                "learning_status": "actionable",
+                "claim_strength": "fixture_only",
+                "official_task_score_delta": "not_available",
+                "control_plane_score_delta": 1.5,
+                "repair_candidates": [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                    "drop",
+                ],
+                "claim_blockers": ["official uplift"],
+                "lifecycle_gate": {
+                    "budget_count_allowed": True,
+                    "blocked_reason": "none",
+                    "private_detail": "drop",
+                },
+                "learning_quota_gate": {
+                    "actionable_learning_present": True,
+                    "spend_allowed": True,
+                    "actionable_reasons": ["public fixture"],
+                    "private_detail": "drop",
+                },
+                "overhead": {
+                    "cost_delta_usd": "0.25",
+                    "wall_time_delta_seconds_or_ms": 120,
+                    "label": "bounded",
+                },
+                "routing": {
+                    "repeat_allowed": False,
+                    "new_candidate_allowed": True,
+                    "next_allowed_action": "select next candidate",
+                    "private_detail": "drop",
+                },
+                "read_boundary": {
+                    "compact_only": True,
+                    "raw_artifacts_read": False,
+                    "task_text_read": False,
+                    "local_paths_recorded": False,
+                    "private_detail": True,
+                },
+                "private_detail": "drop",
+            }
+        }
+    )
+
+    assert compact is not None
+    assert compact["schema_version"] == "benchmark_learning_ledger_v0"
+    assert compact["official_task_score_delta"] == "not_available"
+    assert compact["control_plane_score_delta"] == 1.5
+    assert compact["repair_candidates"] == [
+        "one",
+        "two",
+        "three",
+        "four",
+        "five",
+    ]
+    assert compact["lifecycle_gate"] == {
+        "budget_count_allowed": True,
+        "blocked_reason": "none",
+    }
+    assert compact["learning_quota_gate"] == {
+        "actionable_learning_present": True,
+        "spend_allowed": True,
+        "actionable_reasons": ["public fixture"],
+    }
+    assert compact["overhead"] == {
+        "cost_delta_usd": "0.25",
+        "wall_time_delta_seconds_or_ms": 120,
+        "label": "bounded",
+    }
+    assert compact["routing"] == {
+        "repeat_allowed": False,
+        "new_candidate_allowed": True,
+        "next_allowed_action": "select next candidate",
+    }
+    assert compact["read_boundary"] == {
+        "compact_only": True,
+        "raw_artifacts_read": False,
+        "task_text_read": False,
+        "local_paths_recorded": False,
+    }
+    assert "private_detail" not in compact
+
+
+def test_learning_ledger_accepts_direct_rows_and_rejects_unrelated_payloads() -> None:
+    direct = compact_benchmark_learning_ledger(
+        {
+            "schema_version": "benchmark_learning_ledger_v0",
+            "task_id": "task-2",
+        }
+    )
+    assert direct == {
+        "schema_version": "benchmark_learning_ledger_v0",
+        "task_id": "task-2",
+    }
+    assert compact_benchmark_learning_ledger({}) is None
+    assert (
+        compact_benchmark_learning_ledger(
+            {"schema_version": "benchmark_result_v0", "task_id": "task-3"}
+        )
+        is None
+    )


### PR DESCRIPTION
## Summary
- move compact benchmark learning-ledger projection into its control-plane runtime owner
- keep `loopx.status.compact_benchmark_learning_ledger` as a direct compatibility import
- add focused filtering, routing, nested/direct-row, and compatibility tests

## Validation
- focused pytest: 11 passed across learning-ledger, experiment-report, and comparison projections
- benchmark learning-ledger, attempt-learning-gate, run-compaction, and status-runtime-summary smokes passed
- `loopx canary premerge --from-git-diff --tier standard`: 16/16 selected checks, 0 failures, 0 warnings, 0 manual holds
- public/private boundary scan found no new private paths, credentials, raw logs, or internal material

## Boundary
Behavior-preserving read-model move only. No benchmark scoring, runner, task semantics, launch/submission, permission, or evidence-policy changes.