### PR TITLE
docs: surface real long-running loops earlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,24 @@ LoopX is not an autonomous production controller. It is a local coordination
 substrate: dangerous permissions, publishing, production writes, and final
 ownership stay with the human/operator.
 
+## Two Real Long-Running Loops
+
+Open the graphs to inspect the actual nodes, edges, evidence branches, and
+terminal decisions preserved across agent turns.
+
+**Open-source issue fix: PR delivery and reusable capability evolve together.**
+
+<a href="docs/assets/openviking-issue-fix-explore.png">
+  <img src="docs/assets/openviking-issue-fix-explore.png" alt="Open-source issue-fix Explore graph linking focused PR delivery with reusable LoopX capabilities">
+</a>
+
+**Auto ML Experiment: hypotheses, matched evidence, invalid lineages, running
+replicates, and promote/stop gates remain visible in one graph.**
+
+<a href="docs/assets/auto-ml-experiment-explore.jpg">
+  <img src="docs/assets/auto-ml-experiment-explore.jpg" alt="Auto ML Experiment Explore graph with experiment lineages, evidence gates, and promotion decisions" width="760">
+</a>
+
 ## Quick Start
 
 Requirements: Python 3.11+, `curl`, `tar`, macOS or Linux shell. Git is only
@@ -365,25 +383,6 @@ manual, then use the short proof surfaces:
 
 For more cases, open the [showcase catalog](docs/showcases/README.md). For a
 full presenter material, see the optional and emerging features below.
-
-### Two Real Long-Running Loops
-
-These are full public-safe Explore projections, not simplified process
-illustrations. Open the images to inspect the actual nodes, edges, evidence
-branches, and terminal decisions preserved across agent turns.
-
-**Open-source issue fix: PR delivery and reusable capability evolve together.**
-
-<a href="docs/assets/openviking-issue-fix-explore.png">
-  <img src="docs/assets/openviking-issue-fix-explore.png" alt="Open-source issue-fix Explore graph linking focused PR delivery with reusable LoopX capabilities">
-</a>
-
-**Auto ML Experiment: hypotheses, matched evidence, invalid lineages, running
-replicates, and promote/stop gates remain visible in one graph.**
-
-<a href="docs/assets/auto-ml-experiment-explore.jpg">
-  <img src="docs/assets/auto-ml-experiment-explore.jpg" alt="Auto ML Experiment Explore graph with experiment lineages, evidence gates, and promotion decisions" width="760">
-</a>
 
 ## Optional And Emerging Features
 


### PR DESCRIPTION
## Summary
- move `Two Real Long-Running Loops` ahead of the long Quick Start section
- promote it to a standalone README section between audience fit and onboarding
- remove the redundant public-safe / non-simplified disclaimer while preserving both original graphs, links, and descriptions

## Product judgment
The README previously made readers traverse the full installation guide before seeing LoopX's two strongest real long-running loop examples. This keeps onboarding intact while exposing concrete product value earlier. The Chinese README already places the same examples early enough, so it is intentionally unchanged.

## Validation
- `python3 examples/public_entry/readme-demo-surface-smoke.py`
- `python3 examples/showcase-catalog-smoke.py`
- `python3 examples/issue-fix-capability-guide-smoke.py`
- `loopx check --scan-path README.md`: 0 errors, 0 warnings
- repository CLI premerge gate: 13/13 selected checks passed, 0 warnings, 0 manual holds
- `git diff --check`

## Validation note
The installed `loopx 0.2.1` canary attempted to resolve its catalog below `site-packages/docs` and failed before running the gate. The same gate was rerun from this current checkout with `PYTHONPATH=. python3 -m loopx.cli`; all direct checks, catalog canaries, risk-profile smokes, and public-boundary checks passed.

## Boundary
Public README ordering and copy only. No private state, internal links, local paths, credentials, generated evidence, or runtime behavior changes.
