### PR TITLE
Move benchmark result projection inward

### DIFF
--- a/loopx/control_plane/runtime/benchmark_result.py
+++ b/loopx/control_plane/runtime/benchmark_result.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .public_safety import (
+    compact_numeric_map,
+    public_safe_compact_list,
+    public_safe_compact_text,
+)
+
+BENCHMARK_RESULT_SCHEMA_VERSION = "benchmark_result_v0"
+CONTROL_PLANE_SCORE_COMPONENTS = (
+    "restartability",
+    "stale_state_avoidance",
+    "evidence_discipline",
+    "boundary_safety",
+    "writeback_quality",
+    "gate_compliance",
+    "failure_attribution",
+    "overhead",
+)
+MAX_BENCHMARK_RESULT_LIST_ITEMS = 5
+
+
+def _benchmark_result_source(run: dict[str, Any]) -> dict[str, Any] | None:
+    nested = run.get("benchmark_result")
+    if (
+        isinstance(nested, dict)
+        and nested.get("schema_version") == BENCHMARK_RESULT_SCHEMA_VERSION
+    ):
+        return nested
+    if run.get("schema_version") == BENCHMARK_RESULT_SCHEMA_VERSION:
+        return run
+    return None
+
+
+def _compact_score_layer(value: Any, *, include_schema: bool = False) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    compact: dict[str, Any] = {}
+    if include_schema:
+        schema = public_safe_compact_text(value.get("schema_version"), limit=80)
+        if schema:
+            compact["schema_version"] = schema
+    for field in ("kind", "aggregation"):
+        text = public_safe_compact_text(value.get(field), limit=80)
+        if text:
+            compact[field] = text
+    if isinstance(value.get("passed"), bool):
+        compact["passed"] = value["passed"]
+    score_value = value.get("value")
+    if isinstance(score_value, (int, float)) and not isinstance(score_value, bool):
+        compact["value"] = score_value
+    return compact
+
+
+def _compact_control_plane_score(value: Any) -> dict[str, Any]:
+    compact = _compact_score_layer(value, include_schema=True)
+    if not isinstance(value, dict):
+        return compact
+    components = (
+        value.get("components") if isinstance(value.get("components"), dict) else {}
+    )
+    compact_components: dict[str, Any] = {}
+    for component in CONTROL_PLANE_SCORE_COMPONENTS:
+        score = components.get(component)
+        if isinstance(score, (int, float)) and not isinstance(score, bool):
+            compact_components[component] = score
+    if compact_components:
+        compact["components"] = compact_components
+        compact["component_order"] = list(compact_components)
+    return compact
+
+
+def compact_benchmark_result(run: dict[str, Any]) -> dict[str, Any] | None:
+    source = _benchmark_result_source(run)
+    if not source:
+        return None
+
+    compact: dict[str, Any] = {"schema_version": BENCHMARK_RESULT_SCHEMA_VERSION}
+    for field in (
+        "task_id",
+        "scenario_id",
+        "worker_mode",
+        "harness_identity",
+        "worker_surface",
+        "terminal_state",
+        "trace_publicness",
+    ):
+        value = public_safe_compact_text(source.get(field), limit=120)
+        if value:
+            compact[field] = value
+
+    official_score = _compact_score_layer(source.get("official_task_score"))
+    if official_score:
+        compact["official_task_score"] = official_score
+    control_score = _compact_control_plane_score(source.get("control_plane_score"))
+    if control_score:
+        compact["control_plane_score"] = control_score
+
+    counts = compact_numeric_map(
+        source,
+        keys=(
+            "step_count",
+            "wall_time_ms",
+            "validation_pass_count",
+            "validation_fail_count",
+            "changed_file_count",
+            "forbidden_access_count",
+            "stale_state_error_count",
+            "writeback_count",
+            "spend_count",
+            "spend_before_validation_count",
+            "goal_tick_phase_coverage",
+        ),
+    )
+    if counts:
+        compact["counts"] = counts
+
+    for field in (
+        "open_todo_preserved",
+        "archive_hygiene_passed",
+        "queue_contract_passed",
+        "state_reconstructable",
+    ):
+        if isinstance(source.get(field), bool):
+            compact[field] = source[field]
+
+    labels = public_safe_compact_list(
+        source.get("failure_attribution_labels"),
+        limit=MAX_BENCHMARK_RESULT_LIST_ITEMS,
+    )
+    if labels:
+        compact["failure_attribution_labels"] = labels
+
+    if set(compact) == {"schema_version"}:
+        return None
+    return compact

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -204,6 +204,7 @@ from .control_plane.runtime.benchmark_experiment_report import (
 from .control_plane.runtime.benchmark_learning_ledger import (
     compact_benchmark_learning_ledger,
 )
+from .control_plane.runtime.benchmark_result import compact_benchmark_result
 from .control_plane.runtime.benchmark_lifecycle_contracts import (
     compact_app_server_goal_round_semantics as _compact_app_server_goal_round_semantics,
     compact_native_goal_worker_contract as _compact_native_goal_worker_contract,
@@ -454,20 +455,8 @@ BENCHMARK_VALIDATION_NEUTRAL_FALSE_FIELDS = {
     "assisted_collaboration_claim_allowed",
 }
 BENCHMARK_RUN_SCHEMA_VERSION = "benchmark_run_v0"
-BENCHMARK_RESULT_SCHEMA_VERSION = "benchmark_result_v0"
 ACTIVE_USER_ASSISTED_PILOT_SCHEMA_VERSION = "active_user_assisted_pilot_v0"
 OPERATOR_SIMULATOR_RUN_SCHEMA_VERSION = "operator_simulator_run_v0"
-CONTROL_PLANE_SCORE_SCHEMA_VERSION = "control_plane_score_core_v0"
-CONTROL_PLANE_SCORE_COMPONENTS = (
-    "restartability",
-    "stale_state_avoidance",
-    "evidence_discipline",
-    "boundary_safety",
-    "writeback_quality",
-    "gate_compliance",
-    "failure_attribution",
-    "overhead",
-)
 MAX_BENCHMARK_RUN_TRIALS = 3
 MAX_BENCHMARK_RUN_LIST_ITEMS = 5
 STATUS_CONTRACT_SCHEMA_VERSION = 2
@@ -3676,111 +3665,6 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
     if set(compact.keys()) == {"schema_version"}:
         return None
     return compact
-
-
-def _benchmark_result_source(run: dict[str, Any]) -> dict[str, Any] | None:
-    nested = run.get("benchmark_result")
-    if isinstance(nested, dict) and nested.get("schema_version") == BENCHMARK_RESULT_SCHEMA_VERSION:
-        return nested
-    if run.get("schema_version") == BENCHMARK_RESULT_SCHEMA_VERSION:
-        return run
-    return None
-
-
-def _compact_score_layer(value: Any, *, include_schema: bool = False) -> dict[str, Any]:
-    if not isinstance(value, dict):
-        return {}
-    compact: dict[str, Any] = {}
-    if include_schema:
-        schema = public_safe_compact_text(value.get("schema_version"), limit=80)
-        if schema:
-            compact["schema_version"] = schema
-    for field in ("kind", "aggregation"):
-        text = public_safe_compact_text(value.get(field), limit=80)
-        if text:
-            compact[field] = text
-    if isinstance(value.get("passed"), bool):
-        compact["passed"] = value.get("passed")
-    score_value = value.get("value")
-    if isinstance(score_value, (int, float)) and not isinstance(score_value, bool):
-        compact["value"] = score_value
-    return compact
-
-
-def _compact_control_plane_score(value: Any) -> dict[str, Any]:
-    compact = _compact_score_layer(value, include_schema=True)
-    if not isinstance(value, dict):
-        return compact
-    components = value.get("components") if isinstance(value.get("components"), dict) else {}
-    compact_components: dict[str, Any] = {}
-    for component in CONTROL_PLANE_SCORE_COMPONENTS:
-        score = components.get(component)
-        if isinstance(score, (int, float)) and not isinstance(score, bool):
-            compact_components[component] = score
-    if compact_components:
-        compact["components"] = compact_components
-        compact["component_order"] = list(compact_components.keys())
-    return compact
-
-
-def compact_benchmark_result(run: dict[str, Any]) -> dict[str, Any] | None:
-    source = _benchmark_result_source(run)
-    if not source:
-        return None
-
-    compact: dict[str, Any] = {"schema_version": BENCHMARK_RESULT_SCHEMA_VERSION}
-    for field in (
-        "task_id",
-        "scenario_id",
-        "worker_mode",
-        "harness_identity",
-        "worker_surface",
-        "terminal_state",
-        "trace_publicness",
-    ):
-        value = public_safe_compact_text(source.get(field), limit=120)
-        if value:
-            compact[field] = value
-
-    official_score = _compact_score_layer(source.get("official_task_score"))
-    if official_score:
-        compact["official_task_score"] = official_score
-    control_score = _compact_control_plane_score(source.get("control_plane_score"))
-    if control_score:
-        compact["control_plane_score"] = control_score
-
-    counts = _compact_numeric_map(
-        source,
-        keys=(
-            "step_count",
-            "wall_time_ms",
-            "validation_pass_count",
-            "validation_fail_count",
-            "changed_file_count",
-            "forbidden_access_count",
-            "stale_state_error_count",
-            "writeback_count",
-            "spend_count",
-            "spend_before_validation_count",
-            "goal_tick_phase_coverage",
-        ),
-    )
-    if counts:
-        compact["counts"] = counts
-
-    for field in ("open_todo_preserved", "archive_hygiene_passed", "queue_contract_passed", "state_reconstructable"):
-        if isinstance(source.get(field), bool):
-            compact[field] = source.get(field)
-
-    labels = public_safe_compact_list(source.get("failure_attribution_labels"), limit=MAX_BENCHMARK_RUN_LIST_ITEMS)
-    if labels:
-        compact["failure_attribution_labels"] = labels
-
-    if set(compact.keys()) == {"schema_version"}:
-        return None
-    return compact
-
-
 
 
 def _active_user_assisted_pilot_source(run: dict[str, Any]) -> dict[str, Any] | None:

--- a/tests/control_plane/test_benchmark_result.py
+++ b/tests/control_plane/test_benchmark_result.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from loopx import status
+from loopx.control_plane.runtime.benchmark_result import compact_benchmark_result
+
+
+def test_status_preserves_benchmark_result_import() -> None:
+    assert status.compact_benchmark_result is compact_benchmark_result
+
+
+def test_compact_benchmark_result_preserves_public_score_contract() -> None:
+    compact = compact_benchmark_result(
+        {
+            "benchmark_result": {
+                "schema_version": "benchmark_result_v0",
+                "task_id": "task-1",
+                "scenario_id": "scenario-1",
+                "worker_mode": "passive",
+                "harness_identity": "loopx",
+                "worker_surface": "codex_cli",
+                "terminal_state": "completed",
+                "trace_publicness": "compact_public",
+                "official_task_score": {
+                    "kind": "verifier_reward",
+                    "aggregation": "final",
+                    "passed": True,
+                    "value": 1.0,
+                    "private_detail": "drop",
+                },
+                "control_plane_score": {
+                    "schema_version": "control_plane_score_core_v0",
+                    "kind": "coordination",
+                    "value": 0.75,
+                    "components": {
+                        "restartability": 1.0,
+                        "writeback_quality": 0.5,
+                        "unknown_component": 1.0,
+                    },
+                    "private_detail": "drop",
+                },
+                "step_count": "3",
+                "wall_time_ms": 120,
+                "validation_pass_count": 2,
+                "open_todo_preserved": True,
+                "state_reconstructable": False,
+                "failure_attribution_labels": [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                    "drop",
+                ],
+                "private_detail": "drop",
+            }
+        }
+    )
+
+    assert compact is not None
+    assert compact["official_task_score"] == {
+        "kind": "verifier_reward",
+        "aggregation": "final",
+        "passed": True,
+        "value": 1.0,
+    }
+    assert compact["control_plane_score"] == {
+        "schema_version": "control_plane_score_core_v0",
+        "kind": "coordination",
+        "value": 0.75,
+        "components": {
+            "restartability": 1.0,
+            "writeback_quality": 0.5,
+        },
+        "component_order": ["restartability", "writeback_quality"],
+    }
+    assert compact["counts"] == {
+        "step_count": 3,
+        "wall_time_ms": 120,
+        "validation_pass_count": 2,
+    }
+    assert compact["open_todo_preserved"] is True
+    assert compact["state_reconstructable"] is False
+    assert compact["failure_attribution_labels"] == [
+        "one",
+        "two",
+        "three",
+        "four",
+        "five",
+    ]
+    assert "private_detail" not in compact
+
+
+def test_result_accepts_direct_rows_and_rejects_unrelated_payloads() -> None:
+    direct = compact_benchmark_result(
+        {
+            "schema_version": "benchmark_result_v0",
+            "task_id": "task-2",
+        }
+    )
+    assert direct == {
+        "schema_version": "benchmark_result_v0",
+        "task_id": "task-2",
+    }
+    assert compact_benchmark_result({}) is None
+    assert (
+        compact_benchmark_result(
+            {"schema_version": "benchmark_run_v0", "task_id": "task-3"}
+        )
+        is None
+    )


### PR DESCRIPTION
## Summary
- move benchmark result source selection, score-layer compaction, control-plane component ordering, and compact projection into the runtime bounded context
- preserve `loopx.status.compact_benchmark_result` as a direct compatibility import
- add focused public score/count/filtering and compatibility tests

## Validation
- focused pytest: 14 passed across result, learning-ledger, report, and comparison projections
- benchmark result status, append CLI, run-compaction, and status-runtime-summary smokes passed
- `loopx canary premerge --from-git-diff --tier standard`: 16/16 selected checks, 0 failures, 0 warnings, 0 manual holds
- public/private boundary scan clean

## Boundary
Behavior-preserving compact read-model move only. No benchmark scoring, runner, task semantics, launch/submission, permission, or evidence-policy changes.