### PR TITLE
Resolve newest Codex CLI for visible agents

### DIFF
--- a/examples/generic-multi-agent-one-command-smoke.py
+++ b/examples/generic-multi-agent-one-command-smoke.py
@@ -438,7 +438,7 @@ def main() -> int:
             start_payloads.append(
                 command_path.read_text(encoding="utf-8") if command_path.is_file() else command
             )
-        assert all("LOOPX_CODEX_BIN=codex" in command for command in start_payloads), start_payloads
+        assert all("LOOPX_RESOLVED_CODEX_BIN" in command for command in start_payloads), start_payloads
         assert all("LOOPX_CODEX_REASONING_EFFORT=high" in command for command in start_payloads), start_payloads
         assert all("exec python3 -c" in command for command in start_payloads), start_payloads
         assert all("LOOPX_PANE_ARTIFACT_DIR" in command for command in start_payloads), start_payloads

--- a/examples/visible-codex-executable-resolution-smoke.py
+++ b/examples/visible-codex-executable-resolution-smoke.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Smoke-test durable Codex executable selection for visible agents."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from loopx.capabilities.multi_agent.codex_executable import (  # noqa: E402
+    resolve_codex_executable,
+    write_codex_compatibility_shim,
+)
+
+
+def write_codex(path: Path, version: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "#!/bin/sh\n"
+        f"if [ \"${{1:-}}\" = --version ]; then echo 'codex-cli {version}'; exit 0; fi\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-codex-resolution-smoke.") as tmp:
+        temp = Path(tmp)
+        path_bin = temp / "path-bin"
+        home = temp / "home"
+        old_codex = path_bin / "codex"
+        new_codex = home / ".npm-global" / "bin" / "codex"
+        explicit = temp / "explicit-codex"
+        write_codex(old_codex, "0.142.0-alpha.7")
+        write_codex(new_codex, "0.144.1")
+        write_codex(explicit, "0.141.0")
+        env = {
+            "PATH": str(path_bin),
+            "HOME": str(home),
+        }
+
+        selected, packet = resolve_codex_executable("codex", env=env)
+        assert Path(selected) == new_codex, (selected, packet)
+        assert packet["selection_policy"] == (
+            "newest_version_across_host_candidates"
+        ), packet
+        assert packet["selected_source"] == "user_npm_global", packet
+        assert packet["selected_version"] == "0.144.1", packet
+        assert packet["path_default_bypassed"] is True, packet
+        assert packet["path_frozen"] is True, packet
+        assert packet["candidate_count"] >= 2, packet
+
+        selected_explicit, explicit_packet = resolve_codex_executable(
+            str(explicit), env=env
+        )
+        assert Path(selected_explicit) == explicit, explicit_packet
+        assert explicit_packet["selection_policy"] == "explicit_authoritative"
+        assert explicit_packet["selected_version"] == "0.141.0"
+
+        shim = write_codex_compatibility_shim(
+            directory=temp / "shim-bin",
+            executable=str(explicit),
+        )
+        assert shim.name == "codex" and os.access(shim, os.X_OK), shim
+        assert str(explicit) in shim.read_text(encoding="utf-8"), shim
+
+        public_packet = json.dumps(packet, sort_keys=True)
+        assert str(temp) not in public_packet, public_packet
+        assert not public_packet.startswith("/"), public_packet
+
+    print("visible-codex-executable-resolution-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -365,6 +365,9 @@ def main() -> int:
                 [
                     "#!/usr/bin/env python3",
                     "import json, os, sys",
+                    "if '--version' in sys.argv:",
+                    "    print('codex-cli 9.9.9')",
+                    "    raise SystemExit(0)",
                     "path = os.environ.get('FAKE_CODEX_ARGV_LOG')",
                     "if path:",
                     "    with open(path, 'w', encoding='utf-8') as f:",
@@ -898,6 +901,10 @@ def main() -> int:
         assert launch["auto_wake"]["broadcaster_reads_todo_readiness"] is True, launch
         assert launch["auto_wake"]["broadcaster_selects_todo"] is False, launch
         assert launch["auto_wake"]["artifact"] == "auto-wake.public.jsonl", launch
+        codex_resolution = launch["codex_executable_resolution"]
+        assert codex_resolution["selected_version"] == "9.9.9", codex_resolution
+        assert codex_resolution["path_frozen"] is True, codex_resolution
+        assert "selected_path" not in codex_resolution, codex_resolution
         acceptance = launch["visible_acceptance"]
         assert acceptance["schema_version"] == "multi_agent_visible_launch_acceptance_v0", acceptance
         assert acceptance["accepted"] is True, acceptance

--- a/loopx/capabilities/multi_agent/codex_executable.py
+++ b/loopx/capabilities/multi_agent/codex_executable.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import shutil
+import subprocess
+from collections.abc import Mapping
+from pathlib import Path
+
+
+CODEX_EXECUTABLE_RESOLUTION_SCHEMA_VERSION = "visible_codex_executable_resolution_v0"
+_VERSION_PATTERN = re.compile(
+    r"(?<!\d)(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)"
+    r"(?:-(?P<prerelease>[0-9A-Za-z.-]+))?"
+)
+
+
+def _candidate_version(path: Path) -> tuple[str | None, tuple[object, ...] | None]:
+    try:
+        completed = subprocess.run(
+            [str(path), "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5.0,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None, None
+    output = "\n".join(part for part in (completed.stdout, completed.stderr) if part)
+    match = _VERSION_PATTERN.search(output)
+    if not match:
+        return None, None
+    version = match.group(0)
+    prerelease = match.group("prerelease")
+    prerelease_key = tuple(
+        (0, int(part)) if part.isdigit() else (1, part)
+        for part in (prerelease or "").split(".")
+        if part
+    )
+    key: tuple[object, ...] = (
+        int(match.group("major")),
+        int(match.group("minor")),
+        int(match.group("patch")),
+        1 if prerelease is None else 0,
+        prerelease_key,
+    )
+    return version, key
+
+
+def _append_candidate(
+    candidates: list[dict[str, object]],
+    seen: set[str],
+    *,
+    path: Path,
+    source: str,
+    public_ref: str,
+) -> None:
+    expanded = path.expanduser()
+    if not expanded.is_file() or not os.access(expanded, os.X_OK):
+        return
+    identity = str(expanded.resolve())
+    if identity in seen:
+        return
+    seen.add(identity)
+    version, version_key = _candidate_version(expanded)
+    candidates.append(
+        {
+            "path": str(expanded.absolute()),
+            "source": source,
+            "public_ref": public_ref,
+            "version": version,
+            "version_key": version_key,
+        }
+    )
+
+
+def _default_codex_candidates(env: Mapping[str, str]) -> list[dict[str, object]]:
+    candidates: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for index, directory in enumerate(str(env.get("PATH") or "").split(os.pathsep), start=1):
+        if directory:
+            _append_candidate(
+                candidates,
+                seen,
+                path=Path(directory) / "codex",
+                source="path",
+                public_ref=f"PATH candidate #{index}",
+            )
+
+    home = Path(env.get("HOME") or str(Path.home()))
+    _append_candidate(
+        candidates,
+        seen,
+        path=home / ".npm-global" / "bin" / "codex",
+        source="user_npm_global",
+        public_ref="~/.npm-global/bin/codex",
+    )
+    npm_prefix = str(env.get("NPM_CONFIG_PREFIX") or "").strip()
+    if npm_prefix:
+        _append_candidate(
+            candidates,
+            seen,
+            path=Path(npm_prefix) / "bin" / "codex",
+            source="npm_config_prefix",
+            public_ref="$NPM_CONFIG_PREFIX/bin/codex",
+        )
+    npm = shutil.which("npm", path=env.get("PATH"))
+    if npm:
+        try:
+            prefix = subprocess.run(
+                [npm, "prefix", "-g"],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=5.0,
+                env=dict(env),
+            ).stdout.strip()
+        except (OSError, subprocess.TimeoutExpired):
+            prefix = ""
+        if prefix:
+            _append_candidate(
+                candidates,
+                seen,
+                path=Path(prefix) / "bin" / "codex",
+                source="npm_global_prefix",
+                public_ref="$(npm prefix -g)/bin/codex",
+            )
+
+    _append_candidate(
+        candidates,
+        seen,
+        path=Path("/Applications/ChatGPT.app/Contents/Resources/codex"),
+        source="chatgpt_app_bundle",
+        public_ref="ChatGPT.app bundled codex",
+    )
+    return candidates
+
+
+def resolve_codex_executable(
+    requested: str,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> tuple[str, dict[str, object]]:
+    effective_env = dict(os.environ if env is None else env)
+    requested_value = str(requested or "codex").strip() or "codex"
+    if requested_value != "codex":
+        resolved = shutil.which(requested_value, path=effective_env.get("PATH"))
+        if not resolved:
+            raise ValueError(f"codex_bin executable not found: {requested_value}")
+        path = Path(resolved).absolute()
+        version, _version_key = _candidate_version(path)
+        return str(path), {
+            "schema_version": CODEX_EXECUTABLE_RESOLUTION_SCHEMA_VERSION,
+            "requested": "explicit",
+            "selection_policy": "explicit_authoritative",
+            "selected_source": "explicit_codex_bin",
+            "selected_public_ref": "explicit codex_bin",
+            "selected_version": version,
+            "path_frozen": True,
+            "candidate_count": 1,
+        }
+
+    candidates = _default_codex_candidates(effective_env)
+    if not candidates:
+        raise ValueError("codex_bin executable not found in PATH or known host locations")
+    versioned = [item for item in candidates if item.get("version_key") is not None]
+    selected = (
+        max(versioned, key=lambda item: item["version_key"])
+        if versioned
+        else candidates[0]
+    )
+    path_default = next(
+        (item for item in candidates if item.get("source") == "path"), None
+    )
+    return str(selected["path"]), {
+        "schema_version": CODEX_EXECUTABLE_RESOLUTION_SCHEMA_VERSION,
+        "requested": "default_codex",
+        "selection_policy": "newest_version_across_host_candidates",
+        "selected_source": selected["source"],
+        "selected_public_ref": selected["public_ref"],
+        "selected_version": selected["version"],
+        "path_default_version": path_default.get("version") if path_default else None,
+        "path_default_bypassed": bool(
+            path_default and selected["path"] != path_default["path"]
+        ),
+        "path_frozen": True,
+        "candidate_count": len(candidates),
+        "candidate_versions": [
+            {
+                "source": item["source"],
+                "version": item["version"],
+            }
+            for item in candidates
+        ],
+    }
+
+
+def write_codex_compatibility_shim(*, directory: Path, executable: str) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    shim = directory / "codex"
+    shim.write_text(
+        "#!/bin/sh\n" f"exec {shlex.quote(executable)} \"$@\"\n",
+        encoding="utf-8",
+    )
+    shim.chmod(0o700)
+    return shim

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -21,6 +21,10 @@ from .capabilities.multi_agent.contract import (
     generic_role_prompt as _generic_role_prompt,
     role_skill_profile as _role_skill_profile,
 )
+from .capabilities.multi_agent.codex_executable import (
+    resolve_codex_executable,
+    write_codex_compatibility_shim,
+)
 from .capabilities.multi_agent.runtime_scripts import (
     CODEX_TUI_EXEC_PY as _CODEX_TUI_EXEC_PY,
     SCOPED_LOOPX_WRAPPER_PY as _SCOPED_LOOPX_WRAPPER_PY,
@@ -188,7 +192,10 @@ def build_visible_lane_command(
     visible_lane_count: int | None = None,
 ) -> str:
     codex_exec_env = (
+        'export LOOPX_CODEX_BIN="${LOOPX_RESOLVED_CODEX_BIN:-}"; '
+        'if [ -z "$LOOPX_CODEX_BIN" ]; then '
         f"export LOOPX_CODEX_BIN={_q(codex_bin)}; "
+        "fi; "
         f"export LOOPX_CODEX_REASONING_EFFORT={_q(reasoning_effort)}; "
     )
     scoped_loopx_wrapper = (
@@ -802,7 +809,7 @@ def execute_visible_multi_agent_launcher(
     lane_default: str = "agent-lane",
 ) -> tuple[dict[str, object], str, str]:
     require_executable(cli_bin, field="cli_bin")
-    require_executable(codex_bin, field="codex_bin")
+    resolved_codex_bin, codex_resolution = resolve_codex_executable(codex_bin)
     chosen = resolve_visible_launcher(requested=requested_launcher, tmux_bin=tmux_bin)
     project, workspace_mode = resolve_visible_workspace(workspace, create=create_workspace, cwd=cwd)
     worker_skills = _materialize_worker_skills(
@@ -824,7 +831,7 @@ def execute_visible_multi_agent_launcher(
         runtime_root=runtime_root,
         tmux_bin=tmux_bin,
         cli_bin=cli_bin,
-        codex_bin=codex_bin,
+        codex_bin=resolved_codex_bin,
         attach=attach,
         replace_existing=replace_existing,
         launch_result_schema=launch_result_schema,
@@ -835,6 +842,7 @@ def execute_visible_multi_agent_launcher(
         auto_wake_interval_seconds=auto_wake_interval_seconds,
     )
     result["worker_skill_materialization"] = worker_skills
+    result["codex_executable_resolution"] = codex_resolution
     return result, chosen, workspace_mode
 
 
@@ -898,6 +906,10 @@ def _launch_with_tmux(
         subprocess.run([tmux_bin, "kill-session", "-t", session], check=True, env=env)
 
     script_dir = runtime_root / "visible-launcher" / _script_slug(session)
+    codex_shim = write_codex_compatibility_shim(
+        directory=script_dir / "resolved-codex-bin",
+        executable=codex_bin,
+    )
     goal_id = str(payload.get("goal_id") or "").strip()
     initial_wake_plan = resolve_initial_wake_plan(
         lanes=lanes,
@@ -927,6 +939,8 @@ def _launch_with_tmux(
             name=lane_id,
             command=runtime_shell_command(
                 f"export LOOPX_CODEX_TRUST_WORKSPACE={_q('1' if codex_trust_workspace else '0')}; "
+                f"export LOOPX_RESOLVED_CODEX_BIN={_q(codex_bin)}; "
+                f"export PATH={_q(str(codex_shim.parent))}:\"$PATH\"; "
                 "export LOOPX_CODEX_INITIAL_PROMPT_ENABLED="
                 f"{_q('1' if not state_aware_initial_prompt or lane_id in initial_runnable_lanes else '0')}; "
                 f"export LOOPX_VISIBLE_LANE_COUNT={_q(len(lanes))}; "


### PR DESCRIPTION
## Summary

- resolve default `codex` across PATH, user npm-global, npm prefix, and the host ChatGPT app, selecting the newest parseable CLI version
- freeze the selected executable before tmux launch and provide a runtime-local `codex` compatibility shim for generated and raw lane commands
- keep explicit `--codex-bin` wrappers authoritative
- expose public-safe source/version diagnostics without recording absolute paths

## Root cause

The launcher validated `codex_bin` but discarded the resolved path. Pane scripts retained the late-bound string `codex`, so the Codex App PATH selected `/opt/homebrew/bin/codex` 0.142.0 even though npm-global held 0.144.1. This caused gpt-5.6-sol requests to fail with HTTP 400.

## Live validation

A fresh KNN visible launch used the unchanged default `--codex-bin codex` and reported `selected_source=user_npm_global`, `selected_version=0.144.1`, `path_frozen=true`. All four panes showed OpenAI Codex v0.144.1 with gpt-5.6-sol high; curator executed its first LoopX tick without the version error.

## Checks

- executable-resolution, visible-launcher, generic multi-agent, Auto Research policy/user-contract, and line-budget smokes passed
- post-rebase `loopx canary premerge --from-git-diff`: passed, no warnings or manual holds
- public/private boundary scan clean across all five changed files
