### PR TITLE
release: prepare v0.2.2

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -213,6 +213,19 @@ path, and canary route rather than as a user-facing release baseline.
   non-blocking user actions. The repository also establishes parallel pytest,
   Ruff, strict typing, import-boundary, coverage-floor, and release-promotion
   concurrency checks so these broader capabilities remain maintainable.
+- `v0.2.2` on 2026-07-12: visible execution and projection reliability
+  fast-follow at the matching `v0.2.2` tag. Explore gains recoverable execution
+  episodes and ReplayPoint-based counterfactual branches, plus an optional
+  owner-facing visual sink and real graph examples in the public entry
+  surfaces (#1892, #1962, #1965-#1966, #1971). Visible multi-agent runs now
+  wake only lanes whose runnable state changed and freeze the newest compatible
+  host Codex CLI before launch (#1967, #1973). Diagnose capability projection,
+  terminal PR-gate reconciliation, and vision replanning under monitor load are
+  repaired (#1963-#1964, #1969). Benchmark comparison, report, learning-ledger,
+  and result read models move into their control-plane runtime owner while
+  preserving compatibility imports and restoring the full-public smoke shard
+  (#1961, #1968, #1970, #1972). No persisted-state migration is required;
+  Explore execution and visual sinks remain explicit opt-ins.
 
 When a new public release is promoted, add it here only after the matching tag,
 release note, stable ref, update path, and focused release canary agree.

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.2.1"
+version = "0.2.2"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- bump the package and runtime version contract from 0.2.1 to 0.2.2
- record a balanced release-readiness entry covering every merged change since v0.2.1
- preserve opt-in boundaries for Explore execution and visual sinks; no persisted-state migration is required

## Release scope

- Explore recoverable episodes / ReplayPoint V2 and owner-facing visual projections (#1892, #1962, #1965-#1966, #1971)
- state-aware visible wakeups and frozen compatible Codex CLI selection (#1967, #1973)
- diagnose capability, terminal PR-gate, and vision-replan reliability (#1963-#1964, #1969)
- benchmark projection ownership and Full Public regression restoration (#1961, #1968, #1970, #1972)

## Validation

- full pytest: 184 passed, 2 skipped
- release version/readiness, update, fresh-clone, and no-clone smokes: passed
- standard risk-based premerge canary: 17/17 passed, no warnings or manual holds
- public/private boundary scan: 0 errors, 0 warnings
- diff and Python compile checks: passed

## Merge and promotion

This is a three-file release-contract PR. After GitHub checks pass, it is eligible for maintainer self-review and self-merge. Tagging, stable-branch promotion, GitHub Release creation, and post-promotion update verification happen only from the merged commit.