### PR TITLE
Fix duplicate projection reconciliation

### DIFF
--- a/examples/lark-projection-source-reconcile-smoke.py
+++ b/examples/lark-projection-source-reconcile-smoke.py
@@ -46,11 +46,12 @@ def projection_payload(*, extra_row: bool = False) -> dict[str, object]:
 class FixtureRunner:
     def __init__(self) -> None:
         self.calls: list[list[str]] = []
-        self.remote: dict[str, str] = {
-            DESIRED_ID: "recDesired",
-            ORPHAN_ID: "recOrphan",
-            OTHER_ID: "recOther",
-        }
+        self.remote: list[tuple[str, str]] = [
+            (DESIRED_ID, "recDuplicate"),
+            (DESIRED_ID, "recDesired"),
+            (ORPHAN_ID, "recOrphan"),
+            (OTHER_ID, "recOther"),
+        ]
         self.has_more = False
 
     def __call__(
@@ -58,7 +59,7 @@ class FixtureRunner:
     ) -> dict[str, object]:
         self.calls.append(args)
         if "+record-list" in args:
-            rows = [[GOAL_ID, todo_id] for todo_id in self.remote]
+            rows = [[GOAL_ID, todo_id] for todo_id, _ in self.remote]
             return {
                 "returncode": 0,
                 "stdout": json.dumps(
@@ -67,7 +68,9 @@ class FixtureRunner:
                         "data": {
                             "fields": ["LoopX Goal ID", "LoopX Todo ID"],
                             "data": rows,
-                            "record_id_list": list(self.remote.values()),
+                            "record_id_list": [
+                                record_id for _, record_id in self.remote
+                            ],
                             "has_more": self.has_more,
                         },
                     }
@@ -93,11 +96,11 @@ class FixtureRunner:
                 for index, value in enumerate(args)
                 if value == "--record-id"
             ]
-            self.remote = {
-                todo_id: record_id
-                for todo_id, record_id in self.remote.items()
+            self.remote = [
+                (todo_id, record_id)
+                for todo_id, record_id in self.remote
                 if record_id not in record_ids
-            }
+            ]
             return {
                 "returncode": 0,
                 "stdout": json.dumps({"ok": True, "data": {"deleted": record_ids}}),
@@ -197,11 +200,17 @@ def main() -> int:
         assert preview["ok"] is True, preview
         assert receipt["mode"] == "preview", receipt
         assert receipt["remote_orphan_record_ids"] == ["recOrphan"], receipt
+        assert receipt["remote_duplicate_record_ids"] == ["recDuplicate"], receipt
+        assert receipt["remote_delete_record_ids"] == [
+            "recDuplicate",
+            "recOrphan",
+        ], receipt
+        assert receipt["remote_duplicate_key_count"] == 1, receipt
         assert set(receipt["local_mapping_keys_to_remove"]) == {
             f"{GOAL_ID}:{ORPHAN_ID}",
             f"{GOAL_ID}:{STALE_ID}",
         }, receipt
-        assert receipt["remote_delete_count"] == 1, receipt
+        assert receipt["remote_delete_count"] == 2, receipt
         assert receipt["local_mapping_delete_count"] == 2, receipt
         assert not any("+record-delete" in call for call in runner.calls), runner.calls
         assert read_lark_kanban_local_config(config_path)["todo_records"] == local_map
@@ -214,10 +223,15 @@ def main() -> int:
         receipt = executed["source_reconcile"]
         assert executed["ok"] is True, executed
         assert receipt["mode"] == "execute", receipt
-        assert receipt["executed_remote_delete_count"] == 1, receipt
+        assert receipt["executed_remote_delete_count"] == 2, receipt
         delete_calls = [call for call in runner.calls if "+record-delete" in call]
         assert len(delete_calls) == 1, runner.calls
-        assert "recOrphan" in delete_calls[0] and "--yes" in delete_calls[0]
+        assert {
+            delete_calls[0][index + 1]
+            for index, value in enumerate(delete_calls[0])
+            if value == "--record-id"
+        } == {"recDuplicate", "recOrphan"}
+        assert "--yes" in delete_calls[0]
         stored = read_lark_kanban_local_config(config_path)["todo_records"]
         assert f"{GOAL_ID}:{DESIRED_ID}" in stored, stored
         assert f"{GOAL_ID}:{OTHER_ID}" in stored, stored

--- a/loopx/presentation/projection_source_reconcile.py
+++ b/loopx/presentation/projection_source_reconcile.py
@@ -77,8 +77,40 @@ def plan_projection_source_reconcile(
         if key.startswith(prefix) and record_id:
             remote_source_records.append({"key": key, "record_id": record_id})
 
+    remote_by_key: dict[str, list[dict[str, str]]] = {}
+    for item in remote_source_records:
+        remote_by_key.setdefault(item["key"], []).append(item)
+
     remote_orphans = sorted(
-        (item for item in remote_source_records if item["key"] not in desired),
+        (
+            item
+            for key, items in remote_by_key.items()
+            if key not in desired
+            for item in items
+        ),
+        key=lambda item: (item["key"], item["record_id"]),
+    )
+    remote_duplicates: list[dict[str, str]] = []
+    duplicate_keys: list[str] = []
+    for key, items in sorted(remote_by_key.items()):
+        if key not in desired or len(items) < 2:
+            continue
+        ordered = sorted(items, key=lambda item: item["record_id"])
+        preferred_record_id = str(local_record_map.get(key) or "").strip()
+        keeper_record_id = (
+            preferred_record_id
+            if any(item["record_id"] == preferred_record_id for item in ordered)
+            else ordered[0]["record_id"]
+        )
+        duplicates = [
+            item for item in ordered if item["record_id"] != keeper_record_id
+        ]
+        if duplicates:
+            duplicate_keys.append(key)
+            remote_duplicates.extend(duplicates)
+
+    remote_delete_records = sorted(
+        [*remote_orphans, *remote_duplicates],
         key=lambda item: (item["key"], item["record_id"]),
     )
     local_mapping_keys_to_remove = sorted(local_source_keys - desired)
@@ -89,10 +121,20 @@ def plan_projection_source_reconcile(
         "namespace_prefix": prefix,
         "desired_key_count": len(desired),
         "remote_source_record_count": len(remote_source_records),
+        "remote_source_key_count": len(remote_by_key),
         "local_source_mapping_count": len(local_source_keys),
         "remote_orphans": remote_orphans,
         "remote_orphan_record_ids": [item["record_id"] for item in remote_orphans],
+        "remote_duplicate_key_count": len(duplicate_keys),
+        "remote_duplicate_keys": duplicate_keys,
+        "remote_duplicates": remote_duplicates,
+        "remote_duplicate_record_ids": [
+            item["record_id"] for item in remote_duplicates
+        ],
+        "remote_delete_record_ids": [
+            item["record_id"] for item in remote_delete_records
+        ],
         "local_mapping_keys_to_remove": local_mapping_keys_to_remove,
-        "remote_delete_count": len(remote_orphans),
+        "remote_delete_count": len(remote_delete_records),
         "local_mapping_delete_count": len(local_mapping_keys_to_remove),
     }

--- a/loopx/presentation/sinks/lark/kanban.py
+++ b/loopx/presentation/sinks/lark/kanban.py
@@ -1964,6 +1964,8 @@ def sync_loopx_projection_to_lark_kanban(
             "goal_id": resolved_goal_id,
             "source_id": resolved_source_id,
             "remote_orphan_record_ids": [],
+            "remote_duplicate_record_ids": [],
+            "remote_delete_record_ids": [],
             "local_mapping_keys_to_remove": [],
             "remote_delete_count": 0,
             "local_mapping_delete_count": 0,
@@ -2004,11 +2006,11 @@ def sync_loopx_projection_to_lark_kanban(
             break
 
     executed_remote_delete_count = 0
-    if ok and reconcile_source and reconcile_plan["remote_orphan_record_ids"]:
+    if ok and reconcile_source and reconcile_plan["remote_delete_record_ids"]:
         delete_result = _run_command(
             build_record_delete_command(
                 config,
-                record_ids=reconcile_plan["remote_orphan_record_ids"],
+                record_ids=reconcile_plan["remote_delete_record_ids"],
             ),
             execute=execute,
             runner=runner,
@@ -2248,7 +2250,16 @@ def _load_lark_todo_record_map(
     remote_complete = False
     if list_result.get("ok"):
         remote_records = todo_record_entries(list_result.get("json"))
-        record_map.update({item["key"]: item["record_id"] for item in remote_records})
+        remote_by_key: dict[str, list[str]] = {}
+        for item in remote_records:
+            remote_by_key.setdefault(item["key"], []).append(item["record_id"])
+        for key, record_ids in remote_by_key.items():
+            preferred_record_id = record_map.get(key)
+            record_map[key] = (
+                preferred_record_id
+                if preferred_record_id in record_ids
+                else sorted(record_ids)[0]
+            )
         remote_complete = record_list_is_complete(list_result.get("json"))
     return local, record_map, remote_records, remote_complete
 


### PR DESCRIPTION
## Motivation

A complete projection-source reconcile only removed keys absent from the desired namespace. Multiple remote rows with the same desired canonical key were all retained, and remote map hydration could overwrite the locally selected authoritative record.

## What changed

- group complete remote records by canonical projection key;
- preserve the locally mapped record when it still exists remotely, otherwise choose a deterministic record;
- classify extra rows as duplicates and include them with ordinary orphans in the preview-first delete plan;
- expose duplicate/delete evidence in the reconcile receipt;
- extend the durable Lark projection reconcile smoke with duplicate, orphan, execute, and idempotent retry coverage.

## Product / architecture judgment

The fix stays in the generic projection reconciliation layer. Domain projections continue to decide which canonical keys are desired; Lark only performs complete-namespace, preview-first reconciliation. This avoids adding OpenViking or issue-fix-specific cleanup rules to the sink.

## Validation

- `git diff --check`
- changed Python `py_compile`
- `examples/lark-projection-source-reconcile-smoke.py`
- `examples/lark-kanban-control-plane-smoke.py`
- standard `loopx canary premerge --from-git-diff`: 9/9 selected checks passed, public-boundary scan clean, no manual holds
- real no-write OpenViking preview: 13 remote rows / 12 keys / 11 desired keys; exactly one stale placeholder and one duplicate selected for deletion

`ruff` was unavailable in the isolated environment; syntax, focused smokes, catalog canaries, and boundary checks passed.

## Exclusions and risk

No credentials, local state, Base identifiers, raw connector payloads, or project-specific evidence are committed. Deletion remains gated by the existing complete-source attestation, full remote-list requirement, explicit reconcile flag, and execute mode.