### PR TITLE
Fix SkillsBench runner source attribution precedence

### DIFF
--- a/examples/skillsbench-verifier-bootstrap-missing-score-smoke.py
+++ b/examples/skillsbench-verifier-bootstrap-missing-score-smoke.py
@@ -116,6 +116,40 @@ def _package_install_pre_agent_plan() -> dict:
     }
 
 
+def _runner_source_mismatch_prerequisites() -> dict:
+    return {
+        "loopx_runner_source_fingerprint_status": "mismatched_expected",
+        "loopx_runner_source_first_blocker": (
+            "loopx_runner_source_git_head_mismatch"
+        ),
+        "loopx_runner_source_git_head": "1" * 40,
+        "loopx_runner_source_expected_git_head": "2" * 40,
+        "loopx_runner_source_git_head_recorded": True,
+        "loopx_runner_source_expected_git_head_recorded": True,
+        "loopx_runner_source_matches_expected": False,
+        "loopx_runner_source_path_recorded": False,
+        "loopx_runner_source_raw_git_output_recorded": False,
+    }
+
+
+def _countable_attempt_accounting() -> dict:
+    phases = ("launcher", "case", "solver", "verifier", "official_score")
+    return {
+        "schema_version": "benchmark_attempt_accounting_v0",
+        "lifecycle_phase": "runner_accepted_args",
+        "failure_class": "verifier_bootstrap_failed",
+        "failure_label": "verifier_dependency_install_failure",
+        "launcher_attempt_countable": True,
+        "case_attempt_countable": True,
+        "solver_attempt_countable": True,
+        "verifier_attempt_countable": True,
+        "official_score_attempt_countable": True,
+        "attempts": {
+            phase: {"attempted": True, "countable": True} for phase in phases
+        },
+    }
+
+
 def test_missing_score_uv_bootstrap_risk_gets_verifier_dependency_attribution() -> None:
     compact = _missing_score_compact()
     plan = _uv_bootstrap_plan()
@@ -320,28 +354,13 @@ def test_runner_source_mismatch_overrides_verifier_package_risk() -> None:
                 "verifier_dependency_install_failure",
                 "skillsbench_verifier_bootstrap_missing_official_score",
                 "skillsbench_verifier_package_install_risk",
+                "official_score_missing",
+                "skillsbench_runner_error",
             ],
-            "runner_prerequisites": {
-                "loopx_runner_source_fingerprint_status": "mismatched_expected",
-                "loopx_runner_source_first_blocker": (
-                    "loopx_runner_source_git_head_mismatch"
-                ),
-                "loopx_runner_source_git_head": "1" * 40,
-                "loopx_runner_source_expected_git_head": "2" * 40,
-                "loopx_runner_source_git_head_recorded": True,
-                "loopx_runner_source_expected_git_head_recorded": True,
-                "loopx_runner_source_matches_expected": False,
-                "loopx_runner_source_path_recorded": False,
-                "loopx_runner_source_raw_git_output_recorded": False,
-            },
+            "runner_prerequisites": _runner_source_mismatch_prerequisites(),
             "task_staging": plan["task_staging"],
             "task_setup_preflight": plan["task_setup_preflight"],
-            "attempt_accounting": {
-                "schema_version": "skillsbench_attempt_accounting_v0",
-                "attempt_lifecycle_phase": "not_started",
-                "failure_class": "verifier_bootstrap_failed",
-                "failure_label": "verifier_dependency_install_failure",
-            },
+            "attempt_accounting": _countable_attempt_accounting(),
         }
     )
 
@@ -352,6 +371,7 @@ def test_runner_source_mismatch_overrides_verifier_package_risk() -> None:
     assert reduced["score_failure_attribution"] == blocker, reduced
     assert reduced["first_blocker"] == blocker, reduced
     assert reduced["repeat_blocked_by"] == blocker, reduced
+    assert reduced["failure_attribution_labels"][0] == blocker, reduced
     assert reduced["runner_failure"]["failure_class"] == blocker, reduced
     assert reduced["attempt_accounting"]["failure_label"] == blocker, reduced
     assert reduced["attempt_accounting"]["failure_class"] == (
@@ -363,6 +383,17 @@ def test_runner_source_mismatch_overrides_verifier_package_risk() -> None:
     assert reduced["runner_prerequisites"][
         "loopx_runner_source_matches_expected"
     ] is False, reduced
+    attempt_accounting = reduced["attempt_accounting"]
+    for field in (
+        "launcher_attempt_countable",
+        "case_attempt_countable",
+        "solver_attempt_countable",
+        "verifier_attempt_countable",
+        "official_score_attempt_countable",
+    ):
+        assert attempt_accounting[field] is False, attempt_accounting
+    for phase in attempt_accounting["attempts"].values():
+        assert phase["countable"] is False, attempt_accounting
     assert "verifier_dependency_install_failure" not in reduced[
         "failure_attribution_labels"
     ], reduced
@@ -370,6 +401,53 @@ def test_runner_source_mismatch_overrides_verifier_package_risk() -> None:
         "failure_attribution_labels"
     ], reduced
     assert "verifier_bootstrap_diagnostic" not in reduced, reduced
+
+
+def test_egress_preflight_wins_three_way_attribution() -> None:
+    compact = _missing_score_compact()
+    plan = _package_install_pre_agent_plan()
+    compact.update(
+        {
+            "mode": "skillsbench_codex_cli_goal_baseline",
+            "route": "codex-cli-goal-baseline",
+            "failure_attribution_labels": [
+                "official_score_missing",
+                "skillsbench_runner_error",
+                "skillsbench_runner_setup_error",
+                "skillsbench_product_mode_uncountable_treatment",
+                "skillsbench_remote_bridge_agent_operation_trace_missing",
+            ],
+            "runner_prerequisites": _runner_source_mismatch_prerequisites(),
+            "runner_config": {
+                "benchmark_egress_proxy_required": True,
+                "benchmark_egress_proxy_ready": False,
+                "benchmark_egress_proxy_status": "invalid_proxy_value",
+                "benchmark_egress_proxy_error_kind": "unexpanded_placeholder",
+            },
+            "task_staging": plan["task_staging"],
+            "task_setup_preflight": plan["task_setup_preflight"],
+            "attempt_accounting": _countable_attempt_accounting(),
+        }
+    )
+
+    reduced = compact_benchmark_run(compact)
+
+    assert reduced is not None, compact
+    blocker = "skillsbench_benchmark_egress_proxy_preflight_blocked"
+    assert reduced["score_failure_attribution"] == blocker, reduced
+    assert reduced["first_blocker"] == blocker, reduced
+    assert reduced["failure_attribution_labels"][0] == blocker, reduced
+    assert "verifier_bootstrap_diagnostic" not in reduced, reduced
+    for field in (
+        "launcher_attempt_countable",
+        "case_attempt_countable",
+        "solver_attempt_countable",
+        "verifier_attempt_countable",
+        "official_score_attempt_countable",
+    ):
+        assert reduced["attempt_accounting"][field] is False, reduced
+    for phase in reduced["attempt_accounting"]["attempts"].values():
+        assert phase["countable"] is False, reduced
 
 
 def test_completed_score_is_not_reclassified_by_bootstrap_risk() -> None:
@@ -407,5 +485,6 @@ if __name__ == "__main__":
     test_pre_agent_package_install_risk_overrides_bridge_trace_missing()
     test_benchmark_egress_preflight_overrides_verifier_package_risk()
     test_runner_source_mismatch_overrides_verifier_package_risk()
+    test_egress_preflight_wins_three_way_attribution()
     test_completed_score_is_not_reclassified_by_bootstrap_risk()
     print("skillsbench-verifier-bootstrap-missing-score-smoke: ok")

--- a/examples/skillsbench-verifier-bootstrap-missing-score-smoke.py
+++ b/examples/skillsbench-verifier-bootstrap-missing-score-smoke.py
@@ -384,15 +384,19 @@ def test_runner_source_mismatch_overrides_verifier_package_risk() -> None:
         "loopx_runner_source_matches_expected"
     ] is False, reduced
     attempt_accounting = reduced["attempt_accounting"]
+    assert attempt_accounting["launcher_attempt_countable"] is True, attempt_accounting
     for field in (
-        "launcher_attempt_countable",
         "case_attempt_countable",
         "solver_attempt_countable",
         "verifier_attempt_countable",
         "official_score_attempt_countable",
     ):
         assert attempt_accounting[field] is False, attempt_accounting
-    for phase in attempt_accounting["attempts"].values():
+    launcher = attempt_accounting["attempts"]["launcher"]
+    assert launcher == {"attempted": True, "countable": True}, attempt_accounting
+    for phase_name in ("case", "solver", "verifier", "official_score"):
+        phase = attempt_accounting["attempts"][phase_name]
+        assert phase["attempted"] is False, attempt_accounting
         assert phase["countable"] is False, attempt_accounting
     assert "verifier_dependency_install_failure" not in reduced[
         "failure_attribution_labels"
@@ -438,15 +442,20 @@ def test_egress_preflight_wins_three_way_attribution() -> None:
     assert reduced["first_blocker"] == blocker, reduced
     assert reduced["failure_attribution_labels"][0] == blocker, reduced
     assert "verifier_bootstrap_diagnostic" not in reduced, reduced
+    attempt_accounting = reduced["attempt_accounting"]
+    assert attempt_accounting["launcher_attempt_countable"] is True, reduced
     for field in (
-        "launcher_attempt_countable",
         "case_attempt_countable",
         "solver_attempt_countable",
         "verifier_attempt_countable",
         "official_score_attempt_countable",
     ):
-        assert reduced["attempt_accounting"][field] is False, reduced
-    for phase in reduced["attempt_accounting"]["attempts"].values():
+        assert attempt_accounting[field] is False, reduced
+    launcher = attempt_accounting["attempts"]["launcher"]
+    assert launcher == {"attempted": True, "countable": True}, reduced
+    for phase_name in ("case", "solver", "verifier", "official_score"):
+        phase = attempt_accounting["attempts"][phase_name]
+        assert phase["attempted"] is False, reduced
         assert phase["countable"] is False, reduced
 
 

--- a/examples/skillsbench-verifier-bootstrap-missing-score-smoke.py
+++ b/examples/skillsbench-verifier-bootstrap-missing-score-smoke.py
@@ -307,6 +307,71 @@ def test_benchmark_egress_preflight_overrides_verifier_package_risk() -> None:
     assert diagnostic["raw_trajectory_read"] is False, diagnostic
 
 
+def test_runner_source_mismatch_overrides_verifier_package_risk() -> None:
+    compact = _missing_score_compact()
+    plan = _package_install_pre_agent_plan()
+    compact.update(
+        {
+            "mode": "skillsbench_codex_cli_goal_baseline",
+            "route": "codex-cli-goal-baseline",
+            "score_failure_attribution": "verifier_dependency_install_failure",
+            "first_blocker": "verifier_dependency_install_failure",
+            "failure_attribution_labels": [
+                "verifier_dependency_install_failure",
+                "skillsbench_verifier_bootstrap_missing_official_score",
+                "skillsbench_verifier_package_install_risk",
+            ],
+            "runner_prerequisites": {
+                "loopx_runner_source_fingerprint_status": "mismatched_expected",
+                "loopx_runner_source_first_blocker": (
+                    "loopx_runner_source_git_head_mismatch"
+                ),
+                "loopx_runner_source_git_head": "1" * 40,
+                "loopx_runner_source_expected_git_head": "2" * 40,
+                "loopx_runner_source_git_head_recorded": True,
+                "loopx_runner_source_expected_git_head_recorded": True,
+                "loopx_runner_source_matches_expected": False,
+                "loopx_runner_source_path_recorded": False,
+                "loopx_runner_source_raw_git_output_recorded": False,
+            },
+            "task_staging": plan["task_staging"],
+            "task_setup_preflight": plan["task_setup_preflight"],
+            "attempt_accounting": {
+                "schema_version": "skillsbench_attempt_accounting_v0",
+                "attempt_lifecycle_phase": "not_started",
+                "failure_class": "verifier_bootstrap_failed",
+                "failure_label": "verifier_dependency_install_failure",
+            },
+        }
+    )
+
+    reduced = compact_benchmark_run(compact)
+
+    assert reduced is not None, compact
+    blocker = "loopx_runner_source_git_head_mismatch"
+    assert reduced["score_failure_attribution"] == blocker, reduced
+    assert reduced["first_blocker"] == blocker, reduced
+    assert reduced["repeat_blocked_by"] == blocker, reduced
+    assert reduced["runner_failure"]["failure_class"] == blocker, reduced
+    assert reduced["attempt_accounting"]["failure_label"] == blocker, reduced
+    assert reduced["attempt_accounting"]["failure_class"] == (
+        "job_materialization_failed"
+    ), reduced
+    assert reduced["runner_prerequisites"][
+        "loopx_runner_source_first_blocker"
+    ] == blocker, reduced
+    assert reduced["runner_prerequisites"][
+        "loopx_runner_source_matches_expected"
+    ] is False, reduced
+    assert "verifier_dependency_install_failure" not in reduced[
+        "failure_attribution_labels"
+    ], reduced
+    assert "skillsbench_verifier_package_install_risk" not in reduced[
+        "failure_attribution_labels"
+    ], reduced
+    assert "verifier_bootstrap_diagnostic" not in reduced, reduced
+
+
 def test_completed_score_is_not_reclassified_by_bootstrap_risk() -> None:
     compact = _missing_score_compact()
     plan = _uv_bootstrap_plan()
@@ -341,5 +406,6 @@ if __name__ == "__main__":
     test_missing_score_uv_bootstrap_risk_gets_verifier_dependency_attribution()
     test_pre_agent_package_install_risk_overrides_bridge_trace_missing()
     test_benchmark_egress_preflight_overrides_verifier_package_risk()
+    test_runner_source_mismatch_overrides_verifier_package_risk()
     test_completed_score_is_not_reclassified_by_bootstrap_risk()
     print("skillsbench-verifier-bootstrap-missing-score-smoke: ok")

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -1889,10 +1889,11 @@ def _apply_skillsbench_runner_source_fingerprint_compact_projection(
 
     attempt_accounting = compact.get("attempt_accounting")
     if isinstance(attempt_accounting, dict):
+        attempt_accounting["lifecycle_phase"] = "runner_accepted_args"
         attempt_accounting["failure_label"] = blocker
         attempt_accounting["failure_class"] = "job_materialization_failed"
+        attempt_accounting["launcher_attempt_countable"] = True
         for field in (
-            "launcher_attempt_countable",
             "case_attempt_countable",
             "solver_attempt_countable",
             "verifier_attempt_countable",
@@ -1901,8 +1902,14 @@ def _apply_skillsbench_runner_source_fingerprint_compact_projection(
             attempt_accounting[field] = False
         attempts = attempt_accounting.get("attempts")
         if isinstance(attempts, dict):
-            for phase in attempts.values():
+            launcher = attempts.get("launcher")
+            if isinstance(launcher, dict):
+                launcher["attempted"] = True
+                launcher["countable"] = True
+            for phase_name in ("case", "solver", "verifier", "official_score"):
+                phase = attempts.get(phase_name)
                 if isinstance(phase, dict):
+                    phase["attempted"] = False
                     phase["countable"] = False
     runner_failure = compact.get("runner_failure")
     if isinstance(runner_failure, dict):

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -1766,13 +1766,14 @@ def _apply_skillsbench_benchmark_egress_preflight_compact_projection(
             "skillsbench_remote_bridge_agent_operation_trace_missing",
         }
     ]
-    for item in (
+    primary_labels = (
         label,
         "skillsbench_environment_setup_error",
         f"skillsbench_benchmark_egress_proxy_{proxy_status}",
-    ):
-        if item not in labels:
-            labels.append(item)
+    )
+    labels = list(primary_labels) + [
+        item for item in labels if item not in primary_labels
+    ]
     compact["failure_attribution_labels"] = labels[:MAX_BENCHMARK_RUN_LIST_ITEMS]
 
     attempt_accounting = compact.get("attempt_accounting")
@@ -1876,19 +1877,33 @@ def _apply_skillsbench_runner_source_fingerprint_compact_projection(
         for item in compact.get("failure_attribution_labels", [])
         if isinstance(item, str) and item and item not in verifier_labels
     ]
-    for item in (
+    primary_labels = (
         blocker,
         "skillsbench_runner_source_fingerprint_mismatch",
         "skillsbench_runner_setup_error",
-    ):
-        if item not in labels:
-            labels.append(item)
+    )
+    labels = list(primary_labels) + [
+        item for item in labels if item not in primary_labels
+    ]
     compact["failure_attribution_labels"] = labels[:MAX_BENCHMARK_RUN_LIST_ITEMS]
 
     attempt_accounting = compact.get("attempt_accounting")
     if isinstance(attempt_accounting, dict):
         attempt_accounting["failure_label"] = blocker
         attempt_accounting["failure_class"] = "job_materialization_failed"
+        for field in (
+            "launcher_attempt_countable",
+            "case_attempt_countable",
+            "solver_attempt_countable",
+            "verifier_attempt_countable",
+            "official_score_attempt_countable",
+        ):
+            attempt_accounting[field] = False
+        attempts = attempt_accounting.get("attempts")
+        if isinstance(attempts, dict):
+            for phase in attempts.values():
+                if isinstance(phase, dict):
+                    phase["countable"] = False
     runner_failure = compact.get("runner_failure")
     if isinstance(runner_failure, dict):
         runner_failure["failure_class"] = blocker
@@ -1902,6 +1917,10 @@ def _apply_skillsbench_runner_source_fingerprint_compact_projection(
     validation["runner_source_fingerprint_mismatch"] = True
     validation["all_passed"] = False
     compact["validation"] = validation
+
+    compose_setup_diagnostic = compact.get("compose_setup_diagnostic")
+    if isinstance(compose_setup_diagnostic, dict):
+        compose_setup_diagnostic["case_attempt_budget_should_count"] = False
 
 
 def _compact_benchmark_result_discovery(value: Any) -> dict[str, Any]:

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -1163,6 +1163,11 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
         "codex_api_reverse_tunnel_proxy_source",
         "codex_api_reverse_tunnel_proxy_scheme",
         "codex_api_reverse_tunnel_proxy_endpoint_kind",
+        "loopx_runner_source_fingerprint_status",
+        "loopx_runner_source_first_blocker",
+        "loopx_runner_source_git_head",
+        "loopx_runner_source_expected_git_head",
+        "loopx_runner_source_error_kind",
         "remote_command_file_bridge_consumption_status",
         "remote_command_file_bridge_agent_operation_trace_status",
         "remote_command_file_bridge_driver_lifecycle_execution_style",
@@ -1254,6 +1259,11 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
         "runner_interrupted_before_official_result",
         "runner_interruption_compact_closeout_expected",
         "runner_interruption_raw_material_recorded",
+        "loopx_runner_source_git_head_recorded",
+        "loopx_runner_source_expected_git_head_recorded",
+        "loopx_runner_source_matches_expected",
+        "loopx_runner_source_path_recorded",
+        "loopx_runner_source_raw_git_output_recorded",
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
@@ -1812,6 +1822,86 @@ def _apply_skillsbench_benchmark_egress_preflight_compact_projection(
         "raw_trajectory_read": False,
         "next_diagnostic_action": "configure_valid_private_benchmark_egress_proxy",
     }
+
+
+def _apply_skillsbench_runner_source_fingerprint_compact_projection(
+    compact: dict[str, Any],
+    *,
+    source: dict[str, Any] | None = None,
+) -> None:
+    source = source if isinstance(source, dict) else {}
+    prerequisites = (
+        compact.get("runner_prerequisites")
+        if isinstance(compact.get("runner_prerequisites"), dict)
+        else {}
+    )
+    source_config = (
+        source.get("runner_config")
+        if isinstance(source.get("runner_config"), dict)
+        else {}
+    )
+    status = public_safe_compact_text(
+        prerequisites.get("loopx_runner_source_fingerprint_status")
+        or source_config.get("loopx_runner_source_fingerprint_status"),
+        limit=80,
+    )
+    blocker = public_safe_compact_text(
+        prerequisites.get("loopx_runner_source_first_blocker")
+        or source_config.get("loopx_runner_source_first_blocker"),
+        limit=120,
+    )
+    if (
+        status != "mismatched_expected"
+        or blocker != "loopx_runner_source_git_head_mismatch"
+        or not _skillsbench_compact_official_score_missing(compact)
+    ):
+        return
+
+    compact["score_failure_attribution"] = blocker
+    compact["first_blocker"] = blocker
+    compact["repeat_blocked_by"] = blocker
+    compact["official_score_comparable_to_native_codex"] = False
+    compact["official_score_comparable_to_loopx_treatment"] = False
+
+    verifier_labels = {
+        "verifier_dependency_bootstrap_timeout",
+        "verifier_dependency_install_failure",
+        "verifier_uv_install_or_download_failure",
+        "skillsbench_verifier_bootstrap_missing_official_score",
+        "skillsbench_verifier_bootstrap_preflight_blocked",
+        "skillsbench_verifier_package_install_risk",
+    }
+    labels = [
+        item
+        for item in compact.get("failure_attribution_labels", [])
+        if isinstance(item, str) and item and item not in verifier_labels
+    ]
+    for item in (
+        blocker,
+        "skillsbench_runner_source_fingerprint_mismatch",
+        "skillsbench_runner_setup_error",
+    ):
+        if item not in labels:
+            labels.append(item)
+    compact["failure_attribution_labels"] = labels[:MAX_BENCHMARK_RUN_LIST_ITEMS]
+
+    attempt_accounting = compact.get("attempt_accounting")
+    if isinstance(attempt_accounting, dict):
+        attempt_accounting["failure_label"] = blocker
+        attempt_accounting["failure_class"] = "job_materialization_failed"
+    runner_failure = compact.get("runner_failure")
+    if isinstance(runner_failure, dict):
+        runner_failure["failure_class"] = blocker
+        runner_failure["runner_source_fingerprint_mismatch"] = True
+
+    validation = (
+        compact.get("validation")
+        if isinstance(compact.get("validation"), dict)
+        else {}
+    )
+    validation["runner_source_fingerprint_mismatch"] = True
+    validation["all_passed"] = False
+    compact["validation"] = validation
 
 
 def _compact_benchmark_result_discovery(value: Any) -> dict[str, Any]:
@@ -3110,6 +3200,10 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         compact["validation"] = compact_validation
         _apply_skillsbench_pre_agent_setup_compact_projection(compact)
 
+    _apply_skillsbench_runner_source_fingerprint_compact_projection(
+        compact,
+        source=source,
+    )
     _apply_skillsbench_benchmark_egress_preflight_compact_projection(
         compact,
         source=source,


### PR DESCRIPTION
## Summary
- preserve public runner-source fingerprint fields in compact SkillsBench evidence
- attribute confirmed pre-task git-head mismatch before planned verifier bootstrap risk
- keep benchmark egress preflight precedence intact and mark mismatched attempts uncountable
- add a focused combined regression for source mismatch plus verifier package-install risk

## Validation
- `python3 examples/skillsbench-runner-source-fingerprint-smoke.py`
- `python3 examples/skillsbench-verifier-bootstrap-missing-score-smoke.py`
- `python3 -m py_compile loopx/status.py examples/skillsbench-verifier-bootstrap-missing-score-smoke.py`
- `ruff check` on both changed Python files
- `loopx check` on both changed public paths
- `loopx canary premerge --from-git-diff`: 17/17 selected checks passed, 0 failures

## Review gate
Premerge reports `manual_review_required` because the diff is benchmark-sensitive. This PR must not self-merge without independent maintainer review.

## Boundary
No benchmark jobs, scoring changes, raw logs, task text, trajectories, credentials, local paths, or private evidence are included.