### PR TITLE
Fix deterministic biweekly update-note drafts

### DIFF
--- a/.github/workflows/update-notes.yml
+++ b/.github/workflows/update-notes.yml
@@ -21,8 +21,7 @@ on:
     - cron: "17 3 * * 0"
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: biweekly-update-notes
@@ -58,34 +57,28 @@ jobs:
       - name: Validate update-note archive
         if: steps.generate.outputs.changed == 'true'
         run: |
-          python3 -m py_compile scripts/update_notes_release_job.py examples/update-notes-archive-smoke.py
+          python3 -m py_compile scripts/update_notes_release_job.py examples/update-notes-archive-smoke.py examples/update-notes-generator-quality-smoke.py
           python3 examples/update-notes-archive-smoke.py
+          python3 examples/update-notes-generator-quality-smoke.py
           git diff --check
           python3 -m loopx.cli check \
             --scan-path .github/workflows/update-notes.yml \
             --scan-path scripts/update_notes_release_job.py \
             --scan-path docs/update-notes \
-            --scan-path examples/update-notes-archive-smoke.py
+            --scan-path examples/update-notes-archive-smoke.py \
+            --scan-path examples/update-notes-generator-quality-smoke.py
 
-      - name: Open update-note PR
+      - name: Package reviewable draft
         if: steps.generate.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v6
+        run: git diff --binary > update-note.patch
+
+      - name: Upload update-note draft
+        if: steps.generate.outputs.changed == 'true'
+        uses: actions/upload-artifact@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: codex/biweekly-update-notes-${{ steps.generate.outputs.window_slug }}
-          delete-branch: true
-          draft: true
-          title: Add biweekly update note ${{ steps.generate.outputs.window }}
-          commit-message: Add biweekly update note ${{ steps.generate.outputs.window }}
-          body: |
-            ## Summary
-            - generated the next public-safe biweekly update-note source draft from public git history
-            - updated the update-note archive and latest pointer
-
-            This workflow does not use an LLM. Treat the generated note as a factual source packet and draft PR; a maintainer or LoopX agent should refine the narrative before marking this PR ready.
-
-            ## Validation
-            - python3 -m py_compile scripts/update_notes_release_job.py examples/update-notes-archive-smoke.py
-            - python3 examples/update-notes-archive-smoke.py
-            - git diff --check
-            - python3 -m loopx.cli check --scan-path .github/workflows/update-notes.yml --scan-path scripts/update_notes_release_job.py --scan-path docs/update-notes --scan-path examples/update-notes-archive-smoke.py
+          name: biweekly-update-note-${{ steps.generate.outputs.window_slug }}
+          path: |
+            ${{ steps.generate.outputs.note_file }}
+            docs/update-notes/README.md
+            update-note.patch
+          retention-days: 30

--- a/docs/update-notes/README.md
+++ b/docs/update-notes/README.md
@@ -36,5 +36,6 @@ operator-only state are intentionally excluded.
 
 See [Biweekly update-note automation](automation.md) for the recommended
 publication path. The short version: `.github/workflows/update-notes.yml` runs
-a separate release-note job that opens a reviewable PR, not custom logic inside
-the active LoopX heartbeat.
+a separate read-only release-note job that uploads a reviewable draft artifact;
+a human opens a PR when the draft is ready. This is not custom logic inside the
+active LoopX heartbeat.

--- a/docs/update-notes/automation.md
+++ b/docs/update-notes/automation.md
@@ -22,7 +22,7 @@ Mixing the two would create avoidable friction:
 
 ## Recommended Shape
 
-Use a dedicated release-note job that opens a draft PR. The repository ships
+Use a dedicated release-note job that uploads a reviewable draft artifact. The repository ships
 the first version as `.github/workflows/update-notes.yml`, backed by
 `scripts/update_notes_release_job.py`. A future `loopx update-notes` CLI
 subcommand can wrap the same contract once the generator is stable.
@@ -35,13 +35,15 @@ The job should:
 
 1. Determine the next window from existing note filenames in
    `docs/update-notes/`.
-2. Collect public git history for that window.
-3. Group changes into stable product themes rather than dumping commit logs.
+2. Collect first-parent merged-PR evidence for that exact UTC window.
+3. Remove direct-commit and branch-merge noise, then rank the remaining PRs
+   into compact product themes.
 4. Write a new note under `docs/update-notes/`.
 5. Update the archive table and latest-note pointer.
 6. Keep the root README as a compact pointer, not a long changelog.
 7. Run the update-note smoke and `loopx check` over the touched public docs.
-8. Open a reviewable draft PR instead of pushing directly to `main`.
+8. Upload the note, updated archive, and patch as a reviewable artifact. PR
+   creation remains an explicit human action.
 
 ## Trigger Policy
 
@@ -65,7 +67,8 @@ The recommended first scheduled publication after this archive is for
   verifier output, local paths, credentials, or operator-only state.
 - Keep generated notes short enough to review manually.
 - Fail closed if the generator cannot determine the prior window.
-- Prefer opening a draft PR when classification confidence is low.
+- Keep GitHub Actions permissions read-only and upload a draft artifact when
+  classification confidence is low.
 - Do not require an LLM secret for the default job.
 - Treat update notes as a summary surface. They do not replace git history,
   review packets, or LoopX state.
@@ -87,7 +90,7 @@ loopx update-notes write --since 2026-06-28 --until 2026-07-11 --dry-run
 loopx update-notes write --since 2026-06-28 --until 2026-07-11 --open-pr
 ```
 
-Publishing remains a reviewed PR until the public/private boundary and grouping
+Publishing remains a reviewed human action until the public/private boundary and grouping
 quality are proven stable. If the project later wants fully written prose from
 CI, add an explicit optional LLM step with a repository secret and fail closed
 when that secret is absent; keep the deterministic source-draft mode as the

--- a/examples/update-notes-archive-smoke.py
+++ b/examples/update-notes-archive-smoke.py
@@ -15,6 +15,7 @@ NOTES_INDEX = NOTES_DIR / "README.md"
 AUTOMATION = NOTES_DIR / "automation.md"
 WORKFLOW = ROOT / ".github" / "workflows" / "update-notes.yml"
 GENERATOR = ROOT / "scripts" / "update_notes_release_job.py"
+QUALITY_SMOKE = ROOT / "examples" / "update-notes-generator-quality-smoke.py"
 NOTE_FILE_RE = re.compile(r"\d{4}-\d{2}-\d{2}-to-\d{4}-\d{2}-\d{2}\.md$")
 
 FORBIDDEN_PUBLIC_STRINGS = [
@@ -96,7 +97,8 @@ def validate_automation_plan() -> None:
     assert_contains(text, "workflow_dispatch", "automation plan")
     assert_contains(text, "since", "automation plan")
     assert_contains(text, "until", "automation plan")
-    assert_contains(text, "Open a reviewable draft PR", "automation plan")
+    assert_contains(text, "reviewable draft artifact", "automation plan")
+    assert_contains(text, "explicit human action", "automation plan")
     assert_contains(text, "2026-07-12", "automation plan")
     assert_contains(text, "--dry-run", "automation plan")
     assert_contains(text, "--open-pr", "automation plan")
@@ -109,17 +111,31 @@ def validate_project_automation() -> None:
     assert_contains(workflow, "workflow_dispatch:", "update notes workflow")
     assert_contains(workflow, "fetch-depth: 0", "update notes workflow")
     assert_contains(workflow, "scripts/update_notes_release_job.py", "update notes workflow")
-    assert_contains(workflow, "peter-evans/create-pull-request", "update notes workflow")
-    assert_contains(workflow, "draft: true", "update notes workflow")
+    assert_contains(workflow, "actions/upload-artifact@v4", "update notes workflow")
+    assert_contains(workflow, "contents: read", "update notes workflow")
+    assert_not_contains(workflow, "create-pull-request", "update notes workflow")
+    assert_not_contains(workflow, "pull-requests: write", "update notes workflow")
+    assert_contains(workflow, "examples/update-notes-generator-quality-smoke.py", "update notes workflow")
     assert_contains(generator, "def infer_next_window", "update notes generator")
     assert_contains(generator, "def collect_commits", "update notes generator")
+    assert_contains(generator, "--first-parent", "update notes generator")
+    assert_contains(generator, "T00:00:00Z", "update notes generator")
     assert_contains(generator, "GITHUB_OUTPUT", "update notes generator")
     assert_contains(generator, "does not use an LLM", "update notes generator")
     assert_contains(generator, "does not include private operator state", "update notes generator")
 
 
 def main() -> None:
-    for path in [README, DOCS_INDEX, NOTES_INDEX, AUTOMATION, WORKFLOW, GENERATOR, *note_files()]:
+    for path in [
+        README,
+        DOCS_INDEX,
+        NOTES_INDEX,
+        AUTOMATION,
+        WORKFLOW,
+        GENERATOR,
+        QUALITY_SMOKE,
+        *note_files(),
+    ]:
         validate_public_boundary(path)
     validate_indexes()
     validate_notes()

--- a/examples/update-notes-generator-quality-smoke.py
+++ b/examples/update-notes-generator-quality-smoke.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Validate deterministic, compact update-note source-draft generation."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GENERATOR = ROOT / "scripts" / "update_notes_release_job.py"
+
+
+def load_generator():
+    spec = importlib.util.spec_from_file_location("update_notes_release_job", GENERATOR)
+    if spec is None or spec.loader is None:
+        raise AssertionError("cannot load update-note generator")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def validate_merged_pr_collection(module) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run_git(args: list[str]) -> str:
+        calls.append(args)
+        fs = module.FIELD_SEPARATOR
+        rs = module.RECORD_SEPARATOR
+        return rs.join(
+            [
+                fs.join(["aaa1111", "feat: ship useful capability (#42)", ""]),
+                fs.join(
+                    [
+                        "bbb2222",
+                        "Merge pull request #41 from example/topic",
+                        "Fix quota boundary\n\nMore detail.",
+                    ]
+                ),
+                fs.join(["ccc3333", "Merge branch 'main' into example/topic", ""]),
+                fs.join(["ddd4444", "direct maintenance commit", ""]),
+            ]
+        )
+
+    original = module.run_git
+    module.run_git = fake_run_git
+    try:
+        commits = module.collect_commits(
+            module.Window(module.parse_date("2026-07-01"), module.parse_date("2026-07-14"))
+        )
+    finally:
+        module.run_git = original
+
+    assert calls and "--first-parent" in calls[0], calls
+    assert "--since=2026-07-01T00:00:00Z" in calls[0], calls
+    assert "--until=2026-07-14T23:59:59Z" in calls[0], calls
+    assert [(item.pr_number, item.subject) for item in commits] == [
+        (42, "feat: ship useful capability"),
+        (41, "Fix quota boundary"),
+    ], commits
+
+
+def validate_compact_ranking(module) -> None:
+    commits = [
+        module.Commit("a", "docs: explain issue-fix", 40),
+        module.Commit("b", "fix: preserve issue-fix evidence", 39),
+        module.Commit("c", "feat: add issue-fix lifecycle", 38),
+    ]
+    grouped = module.classify_commits(commits)
+    ranked = grouped["Issue-fix workflow"]
+    assert [item.pr_number for item in ranked] == [38, 39, 40], ranked
+    bullets = module.bulletize(ranked, limit=2)
+    assert bullets[0].startswith("- [#38](https://github.com/huangruiteng/loopx/pull/38)"), bullets
+    assert bullets[-1] == "- ...and 1 more merged PR in this theme.", bullets
+    note = module.render_note(
+        module.Window(module.parse_date("2026-07-01"), module.parse_date("2026-07-14")),
+        [*commits, module.Commit("d", "miscellaneous maintenance", 37)],
+    )
+    assert "Other public changes" not in note, note
+    assert "Unclassified maintenance remains available in git history" in note, note
+
+
+def validate_archive_insertion(module) -> None:
+    index = """# Notes
+
+## Latest
+
+- [old](old.md)
+
+## Unrelated
+
+| Window | Note | Focus |
+| --- | --- | --- |
+| unrelated | row | keep |
+
+## Archive
+
+| Window | Note | Focus |
+| --- | --- | --- |
+| old | [Read note](old.md) | Old. |
+
+## Publication Rules
+
+Next expected window: 2026-07-01 to 2026-07-14.
+"""
+    window = module.Window(module.parse_date("2026-07-01"), module.parse_date("2026-07-14"))
+    updated = module.replace_latest(index, window)
+    updated = module.update_archive(updated, window, "Control plane reliability.")
+    row = "| 2026-07-01 to 2026-07-14 | [Read note](2026-07-01-to-2026-07-14.md) |"
+    assert updated.count(row) == 1, updated
+    archive = updated.split("## Archive", 1)[1].split("## Publication Rules", 1)[0]
+    assert row in archive, archive
+    unrelated = updated.split("## Unrelated", 1)[1].split("## Archive", 1)[0]
+    assert row not in unrelated, unrelated
+
+
+def main() -> None:
+    module = load_generator()
+    validate_merged_pr_collection(module)
+    validate_compact_ranking(module)
+    validate_archive_insertion(module)
+    print("update notes generator quality smoke: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update_notes_release_job.py
+++ b/scripts/update_notes_release_job.py
@@ -14,7 +14,7 @@ import os
 import re
 import subprocess
 from dataclasses import dataclass
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 
@@ -22,6 +22,11 @@ ROOT = Path(__file__).resolve().parents[1]
 NOTES_DIR = ROOT / "docs" / "update-notes"
 NOTES_INDEX = NOTES_DIR / "README.md"
 WINDOW_RE = re.compile(r"(?P<since>\d{4}-\d{2}-\d{2})-to-(?P<until>\d{4}-\d{2}-\d{2})\.md$")
+SQUASH_PR_RE = re.compile(r"^(?P<title>.+?)\s+\(#(?P<pr>\d+)\)$")
+MERGE_PR_RE = re.compile(r"^Merge pull request #(?P<pr>\d+)\b")
+FIELD_SEPARATOR = "\x1f"
+RECORD_SEPARATOR = "\x1e"
+PULL_URL = "https://github.com/huangruiteng/loopx/pull"
 
 
 @dataclass(frozen=True)
@@ -55,6 +60,7 @@ class Window:
 class Commit:
     sha: str
     subject: str
+    pr_number: int
 
 
 THEMES: list[tuple[str, tuple[str, ...], str]] = [
@@ -129,26 +135,64 @@ def collect_commits(window: Window) -> list[Commit]:
     output = run_git(
         [
             "log",
-            f"--since={window.since.isoformat()}T00:00:00",
-            f"--until={window.until.isoformat()}T23:59:59",
-            "--pretty=format:%h%x09%s",
+            "HEAD",
+            "--first-parent",
+            f"--since={window.since.isoformat()}T00:00:00Z",
+            f"--until={window.until.isoformat()}T23:59:59Z",
+            "--pretty=format:%h%x1f%s%x1f%b%x1e",
         ]
     )
     commits: list[Commit] = []
-    seen_subjects: set[str] = set()
-    for line in output.splitlines():
-        if "\t" not in line:
+    seen_prs: set[int] = set()
+    for record in output.split(RECORD_SEPARATOR):
+        record = record.strip("\r\n")
+        if not record:
             continue
-        sha, subject = line.split("\t", 1)
+        fields = record.split(FIELD_SEPARATOR, 2)
+        if len(fields) != 3:
+            continue
+        sha, subject, body = fields
         subject = subject.strip()
-        if not subject or subject.startswith("Merge pull request "):
+        squash_match = SQUASH_PR_RE.match(subject)
+        merge_match = MERGE_PR_RE.match(subject)
+        if squash_match:
+            pr_number = int(squash_match.group("pr"))
+            subject = squash_match.group("title").strip()
+        elif merge_match:
+            pr_number = int(merge_match.group("pr"))
+            body_lines = [line.strip() for line in body.splitlines() if line.strip()]
+            if not body_lines:
+                continue
+            subject = body_lines[0]
+            nested_match = SQUASH_PR_RE.match(subject)
+            if nested_match:
+                subject = nested_match.group("title").strip()
+        else:
+            # Direct and branch-merge commits are useful in git history but are
+            # noisy evidence for a public update-note summary.
             continue
-        key = subject.lower()
-        if key in seen_subjects:
+        if pr_number in seen_prs:
             continue
-        seen_subjects.add(key)
-        commits.append(Commit(sha=sha, subject=subject))
+        seen_prs.add(pr_number)
+        commits.append(Commit(sha=sha, subject=subject, pr_number=pr_number))
     return commits
+
+
+def commit_rank(commit: Commit) -> tuple[int, int]:
+    lowered = commit.subject.lower()
+    rank_groups = [
+        (40, ("feat", "add", "introduce", "support", "enable", "ship", "release", "expose")),
+        (30, ("fix", "harden", "guard", "preserve", "stabilize", "repair", "prevent")),
+        (20, ("refactor", "move", "extract", "split", "retire", "simplify")),
+        (10, ("docs", "test", "ci", "chore", "bump", "refresh")),
+    ]
+    for score, signals in rank_groups:
+        if any(
+            re.search(rf"(?<![a-z0-9-]){re.escape(signal)}(?![a-z0-9-])", lowered)
+            for signal in signals
+        ):
+            return score, commit.pr_number
+    return 15, commit.pr_number
 
 
 def classify_commits(commits: list[Commit]) -> dict[str, list[Commit]]:
@@ -162,14 +206,22 @@ def classify_commits(commits: list[Commit]) -> dict[str, list[Commit]]:
                 break
         else:
             grouped["Other public changes"].append(commit)
-    return {theme: values for theme, values in grouped.items() if values}
+    return {
+        theme: sorted(values, key=commit_rank, reverse=True)
+        for theme, values in grouped.items()
+        if values
+    }
 
 
-def bulletize(commits: list[Commit], limit: int = 8) -> list[str]:
-    bullets = [f"- `{commit.sha}` {commit.subject}" for commit in commits[:limit]]
+def bulletize(commits: list[Commit], limit: int = 4) -> list[str]:
+    bullets = [
+        f"- [#{commit.pr_number}]({PULL_URL}/{commit.pr_number}) {commit.subject}"
+        for commit in commits[:limit]
+    ]
     remaining = len(commits) - limit
     if remaining > 0:
-        bullets.append(f"- ...and {remaining} more public commits in this theme.")
+        noun = "PR" if remaining == 1 else "PRs"
+        bullets.append(f"- ...and {remaining} more merged {noun} in this theme.")
     return bullets
 
 
@@ -182,20 +234,22 @@ def focus_for(grouped: dict[str, list[Commit]]) -> str:
 
 def render_note(window: Window, commits: list[Commit]) -> str:
     grouped = classify_commits(commits)
+    product_groups = {
+        theme: values for theme, values in grouped.items() if theme != "Other public changes"
+    }
     highlight_lines = []
     for theme, _needles, summary in THEMES:
-        if theme in grouped:
+        if theme in product_groups:
             highlight_lines.append(f"- {summary}")
-    if grouped.get("Other public changes"):
-        highlight_lines.append("- Additional public repository changes shipped in smaller maintenance slices.")
     if not highlight_lines:
-        highlight_lines.append("- No public commits were found for this window; review the draft before publishing.")
+        highlight_lines.append("- No merged PR evidence was found for this window; review the draft before publishing.")
 
     sections: list[str] = []
-    for theme, values in grouped.items():
+    for theme, values in product_groups.items():
         sections.append(f"### {theme}\n\n" + "\n".join(bulletize(values)))
     if not sections:
-        sections.append("### Public change review\n\n- No public commits were collected for this window.")
+        sections.append("### Public change review\n\n- No merged PR evidence was collected for this window.")
+    matched_count = sum(len(values) for values in product_groups.values())
 
     return "\n".join(
         [
@@ -213,6 +267,10 @@ def render_note(window: Window, commits: list[Commit]) -> str:
             "\n".join(highlight_lines),
             "",
             "## What Shipped",
+            "",
+            f"The generator reviewed {len(commits)} merged PRs and selected the highest-ranked "
+            f"evidence from {matched_count} PRs across stable product themes. Unclassified "
+            "maintenance remains available in git history instead of being copied into this draft.",
             "",
             "\n\n".join(sections),
             "",
@@ -232,22 +290,40 @@ def render_note(window: Window, commits: list[Commit]) -> str:
     )
 
 
+def section_bounds(index_text: str, heading: str) -> tuple[int, int]:
+    marker = f"{heading}\n"
+    start = index_text.find(marker)
+    if start < 0:
+        raise SystemExit(f"docs/update-notes/README.md missing {heading} section")
+    content_start = start + len(marker)
+    next_heading = re.search(r"^## ", index_text[content_start:], re.MULTILINE)
+    end = content_start + next_heading.start() if next_heading else len(index_text)
+    return content_start, end
+
+
 def replace_latest(index_text: str, window: Window) -> str:
     latest_line = f"- [{window.label}]({window.filename})"
-    pattern = re.compile(r"(## Latest\n\n)(?:- \[[^\n]+\]\([^)]+\)\n?)", re.MULTILINE)
-    if pattern.search(index_text):
-        return pattern.sub(rf"\1{latest_line}\n", index_text)
-    return index_text.replace("## Latest\n\n", f"## Latest\n\n{latest_line}\n\n")
+    start, end = section_bounds(index_text, "## Latest")
+    section = index_text[start:end]
+    pattern = re.compile(r"^- \[[^\n]+\]\([^)]+\)$", re.MULTILINE)
+    if pattern.search(section):
+        section = pattern.sub(latest_line, section, count=1)
+    else:
+        section = f"\n{latest_line}\n" + section.lstrip("\n")
+    return index_text[:start] + section + index_text[end:]
 
 
 def update_archive(index_text: str, window: Window, focus: str) -> str:
     row = f"| {window.label} | [Read note]({window.filename}) | {focus} |"
-    if row in index_text or window.filename in index_text:
+    start, end = section_bounds(index_text, "## Archive")
+    section = index_text[start:end]
+    if row in section or window.filename in section:
         return index_text
-    marker = "| --- | --- | --- |\n"
-    if marker not in index_text:
+    marker = "| Window | Note | Focus |\n| --- | --- | --- |\n"
+    if marker not in section:
         raise SystemExit("docs/update-notes/README.md archive table marker not found")
-    return index_text.replace(marker, marker + row + "\n", 1)
+    section = section.replace(marker, marker + row + "\n", 1)
+    return index_text[:start] + section + index_text[end:]
 
 
 def update_next_expected(index_text: str, window: Window) -> str:
@@ -272,7 +348,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--since", help="Window start date, YYYY-MM-DD.")
     parser.add_argument("--until", help="Window end date, YYYY-MM-DD.")
-    parser.add_argument("--today", default=date.today().isoformat(), help="Current date for due checks.")
+    parser.add_argument("--today", help="Current UTC date for due checks, YYYY-MM-DD.")
     parser.add_argument("--force", action="store_true", help="Write even before the inferred open-after date.")
     parser.add_argument("--overwrite", action="store_true", help="Overwrite an existing note file.")
     parser.add_argument("--dry-run", action="store_true", help="Print the plan without writing files.")
@@ -286,7 +362,7 @@ def main() -> None:
         if args.since and args.until
         else infer_next_window()
     )
-    today = parse_date(args.today)
+    today = parse_date(args.today) if args.today else datetime.now(timezone.utc).date()
     note_path = NOTES_DIR / window.filename
 
     if today < window.open_after and not args.force:
@@ -308,7 +384,10 @@ def main() -> None:
     index_text = update_archive(index_text, window, focus)
     index_text = update_next_expected(index_text, window)
 
-    print(f"update notes: window={window.label} commits={len(commits)} file={note_path.relative_to(ROOT)}")
+    print(
+        f"update notes: window={window.label} merged_prs={len(commits)} "
+        f"file={note_path.relative_to(ROOT)}"
+    )
     if args.dry_run:
         print(note)
         write_github_output({"changed": "false", "window": window.label, "window_slug": window.slug})


### PR DESCRIPTION
## Summary

- make update-note windows deterministic in UTC and collect first-parent merged-PR evidence instead of the full branch DAG
- normalize squash/merge PR titles, remove direct/branch-merge noise, rank evidence by stable product themes, and link the selected PRs
- repair archive insertion so updating `Latest` no longer suppresses the new archive row
- honor the owner's least-privilege delivery choice: the scheduled workflow now uses read-only contents permission and uploads the note, index, and patch as an artifact; a human opens the PR
- add a focused generator-quality smoke and extend the archive/workflow contract smoke

## Product judgment

The previous draft expanded 1,135 raw commits into a noisy changelog and could miss the archive row because `Latest` already contained the new filename. The repaired dry run reviews 984 merged PRs, presents six stable product themes with four ranked PR links each, and leaves unclassified maintenance in git history. This is a factual source packet rather than auto-written release prose.

## Validation

- `python3 -m py_compile scripts/update_notes_release_job.py examples/update-notes-archive-smoke.py examples/update-notes-generator-quality-smoke.py`
- `python3 examples/update-notes-generator-quality-smoke.py`
- `python3 examples/update-notes-archive-smoke.py`
- deterministic 2026-06-28 through 2026-07-11 dry run plus merge-noise scan
- `loopx check` across all six changed public files: 0 errors, 0 warnings
- standard premerge canary: 17/17 selected checks passed, no warnings or manual holds
- post-rebase focused smokes passed

## Boundary

No note was published and no external PR was created by the workflow. The branch changes only the public generator, read-only artifact workflow, public docs, and durable smokes; no private state, raw benchmark material, local paths, or credentials are included.
