### PR TITLE
Add reviewer context to issue-fix outputs

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -225,10 +225,13 @@ receipt. It names the linked issue and compact PR-title change summary, points
 to the PR description for motivation, validation, and risk, and does not expose
 an idempotency marker.
 The workflow plan also projects an `issue_fix_pr_description_contract_v0`
-template adapted from the PR-review five-block structure: motivation, approach,
-concrete changes, validation, and main-branch risk/uncovered scope. The
-reviewer's verdict section remains review-only and is not authored into the PR
-description.
+template adapted from the PR-review five-block structure. Code changes add two
+reviewer-context sections: the smallest key-code or pseudocode slice, and a
+post-fix reproduction using the repository CLI or focused code/test surface.
+Motivation, approach, concrete changes, validation, and main-branch
+risk/uncovered scope remain required. An infographic is optional only for a
+complex change and never replaces textual evidence. The reviewer's verdict
+section remains review-only and is not authored into the PR description.
 When a human confirms that an unresolved git display name belongs to a specific
 GitHub account, `--identity-map-json` records that compact mapping as verified
 identity evidence and reranks the same repository-native contribution evidence.
@@ -948,10 +951,12 @@ Repeating the same compact evidence is an unchanged, no-write operation.
 The Lark adapter renders this as a first-class issue dimension rather than
 only flattening the packet into `Evidence`. Outcome rows set
 `Work Item Type=Issue Fix` and populate `Repository`, `Issue`, `Pull Request`,
-`Route`, `Stage`, `Validation`, and `Outcome`. `Issue Fix Outcomes` provides the
-table view; `Issue Fix Kanban` groups the same rows by `Stage`. Existing boards
-gain the missing fields and views through idempotent `lark-kanban setup
---execute` schema reconciliation.
+`Route`, `Stage`, `Validation`, `Outcome`, and `Context Tags`. The bounded
+multi-select tags expose route, stage, reproduction/validation status, test
+changes, multi-file scope, and grounded repository context without copying
+free-form evidence. `Issue Fix Outcomes` provides the table view; `Issue Fix
+Kanban` groups the same rows by `Stage`. Existing boards gain the missing fields
+and views through idempotent `lark-kanban setup --execute` schema reconciliation.
 
 ## Commands
 

--- a/docs/capabilities/issue-fix/README.zh-CN.md
+++ b/docs/capabilities/issue-fix/README.zh-CN.md
@@ -254,7 +254,9 @@ revision，避免 feature branch 自己的提交把作者推荐回来；
 issue 和 PR 标题概括的改动，并指向 PR 描述中的动机、验证与风险；新评论不再暴露
 幂等 marker。
 workflow plan 还会投影 `issue_fix_pr_description_contract_v0`，复用 PR review
-五块结构中的动机、改动思路、具体改动、验证、对主干风险与未覆盖；“我的整体评价”
+五块结构中的动机、改动思路、具体改动、验证、对主干风险与未覆盖。代码类改动还必须
+提供最小的“关键代码或伪代码”与“修复后复现”；后者可使用仓库 CLI，或 focused
+代码/测试入口。只有复杂改动才可选配 infographic，且不能替代文字证据。“我的整体评价”
 属于 reviewer verdict，不会让 PR 作者预先写进描述。
 当人确认某个 unresolved git display name 对应具体 GitHub 账号时，
 `--identity-map-json` 会把这条紧凑映射作为 verified identity evidence，并基于原有
@@ -865,8 +867,10 @@ commit、output links 与 risks，而不会降回 feasibility 阶段的声明值
 
 Lark adapter 会把它渲染成一等 issue 维度，而不只是把 packet 压平写进 `Evidence`。
 Outcome 行设置 `Work Item Type=Issue Fix`，并填写 `Repository`、`Issue`、
-`Pull Request`、`Route`、`Stage`、`Validation` 和 `Outcome`。`Issue Fix Outcomes`
-提供表格视图，`Issue Fix Kanban` 按 `Stage` 分组展示同一批行。已有看板通过幂等的
+`Pull Request`、`Route`、`Stage`、`Validation`、`Outcome` 和 `Context Tags`。
+这个有界多选字段独立展示 route、stage、复现/验证状态、测试改动、多文件范围与已落地的
+repository context，不复制自由文本 evidence。`Issue Fix Outcomes` 提供表格视图，
+`Issue Fix Kanban` 按 `Stage` 分组展示同一批行。已有看板通过幂等的
 `lark-kanban setup --execute` schema reconciliation 自动补齐缺失字段和视图。
 
 ## 命令

--- a/docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md
@@ -59,7 +59,12 @@ open PRs, merge, publish, or run destructive git without an explicit gate.
    passing-after evidence when that repro path is available.
 9. **PR review packet:** emit `issue_fix_pr_review_packet_v0` only when branch,
    validation, and repo-relative changed-file evidence are sufficient for human
-   review. The packet is review evidence, not external publication authority.
+   review. Its `issue_fix_pr_description_contract_v0` keeps the PR-review
+   motivation/approach/change/validation/risk structure, requires a compact key
+   code or pseudocode section for code changes, and requires a post-fix
+   repository CLI or focused code/test reproduction when applicable. Optional
+   infographics are limited to complex changes and cannot replace textual
+   evidence. The packet is review evidence, not external publication authority.
 10. **PR lifecycle monitor:** after a PR exists, use
    `issue_fix_pr_lifecycle_monitor_v0` to project compact public PR state into
    exactly one of `runnable_successor`, `monitor_continuation`, `user_gate`, or
@@ -81,7 +86,8 @@ open PRs, merge, publish, or run destructive git without an explicit gate.
    context, optional `issue_fix_delivery_evidence_input_v0`, and optional PR
    lifecycle row. This projection writes no source state and creates no parallel
    workflow state machine. It must keep unknown delivery evidence explicit,
-   retain terminal outputs, and remain consumable by generic projection sinks.
+   retain terminal outputs, derive only bounded public-safe `context_tags`, and
+   remain consumable by generic projection sinks.
    Default goal-level Kanban sync derives an
    `issue_fix_outcome_collection_projection_v0` from all feasibility rows and
    explicitly linked lifecycle rows before upserting issue outcome cards.

--- a/docs/lark-kanban-control-plane-adapter.md
+++ b/docs/lark-kanban-control-plane-adapter.md
@@ -43,7 +43,7 @@ or command payload with auth material.
 | Scope | `Scope` text, advisory in v0. |
 | Quota | Omitted in v0; the prototype assumes no quota limit. |
 | Worker launch | `Worker Command` and `Workdir`, consumed by heartbeat. |
-| Issue-fix outcome | One stable `Work Item Type=Issue Fix` row with `Repository`, `Issue`, `Pull Request`, `Route`, `Stage`, `Validation`, and `Outcome`. |
+| Issue-fix outcome | One stable `Work Item Type=Issue Fix` row with `Repository`, `Issue`, `Pull Request`, `Route`, `Stage`, `Validation`, `Outcome`, and bounded multi-select `Context Tags`. |
 
 The Kanban view groups by `Status`, so the board is the operator-facing
 control surface. Agent workers use the filtered `Worker Queue` view.
@@ -77,8 +77,10 @@ queue:
 - `Issue Fix Kanban`: Kanban view with the same filter, grouped by `Stage`.
 
 Their visible fields are `Task`, `Repository`, `Issue`, `Pull Request`,
-`Route`, `Stage`, `Validation`, `Outcome`, and `Status`. This keeps the existing
-todo Kanban compact while making per-issue state and output directly scannable.
+`Route`, `Stage`, `Validation`, `Outcome`, `Context Tags`, and `Status`. Context
+tags expose stable route, stage, reproduction, validation, and focused-change
+signals without copying free-form evidence. This keeps the existing todo Kanban
+compact while making per-issue state and output directly scannable.
 
 `lark-cli` 1.0.56 exposes `base +view-set-visible-fields`, so
 `lark-kanban setup` writes this compact Kanban card field list directly. Verify

--- a/examples/issue-fix-outcome-projection-smoke.py
+++ b/examples/issue-fix-outcome-projection-smoke.py
@@ -193,9 +193,7 @@ def assert_default_goal_sync_composes_outcomes() -> None:
                 "state": "OPEN",
                 "reviewDecision": "REVIEW_REQUIRED",
                 "mergeStateStatus": "CLEAN",
-                "statusCheckRollup": [
-                    {"name": "focused", "conclusion": "SUCCESS"}
-                ],
+                "statusCheckRollup": [{"name": "focused", "conclusion": "SUCCESS"}],
             },
         )
         assert linked["observation"]["issue_ref"] == "issues_42", linked
@@ -209,9 +207,7 @@ def assert_default_goal_sync_composes_outcomes() -> None:
                 "state": "OPEN",
                 "reviewDecision": "REVIEW_REQUIRED",
                 "mergeStateStatus": "CLEAN",
-                "statusCheckRollup": [
-                    {"name": "focused", "conclusion": "SUCCESS"}
-                ],
+                "statusCheckRollup": [{"name": "focused", "conclusion": "SUCCESS"}],
             },
         )
         retry_write = upsert_issue_fix_pr_lifecycle_ledger_jsonl(
@@ -296,7 +292,9 @@ def assert_default_goal_sync_composes_outcomes() -> None:
             check=True,
         )
         preview_packet = json.loads(preview.stdout)
-        assert preview_packet["issue_fix_outcomes"][0]["validation"]["status"] == "passed"
+        assert (
+            preview_packet["issue_fix_outcomes"][0]["validation"]["status"] == "passed"
+        )
         assert preview_packet["source_contract"]["writes_source_state"] is False
         assert feasibility_ledger.read_text(encoding="utf-8") == ledger_before_preview
 
@@ -415,6 +413,15 @@ def main() -> None:
         "src/parser.py",
         "tests/test_parser.py",
     ], outcome
+    assert outcome["context_tags"] == [
+        "fix_pr",
+        "ci_pending",
+        "reproduction_confirmed",
+        "validation_passed",
+        "tests_changed",
+        "multi_file",
+        "repository_context_grounded",
+    ], outcome
     assert outcome["pull_request"]["checks"]["aggregate"] == "PENDING", outcome
     assert outcome["result"]["kind"] == "fix_pr_open", outcome
     assert projection["source_contract"]["creates_parallel_state_machine"] is False
@@ -441,12 +448,18 @@ def main() -> None:
     assert row["values"]["Action Kind"] == "issue_fix_outcome", row
     assert row["values"]["Work Item Type"] == "Issue Fix", row
     assert row["values"]["Repository"] == "public-fixture/widgets", row
-    assert row["values"]["Issue"] == "https://github.com/public-fixture/widgets/issues/42", row
-    assert row["values"]["Pull Request"] == "https://github.com/public-fixture/widgets/pull/77", row
+    assert (
+        row["values"]["Issue"] == "https://github.com/public-fixture/widgets/issues/42"
+    ), row
+    assert (
+        row["values"]["Pull Request"]
+        == "https://github.com/public-fixture/widgets/pull/77"
+    ), row
     assert row["values"]["Route"] == "fix_pr", row
     assert row["values"]["Stage"] == "ci_pending", row
     assert row["values"]["Validation"].startswith("passed:"), row
     assert row["values"]["Outcome"] == "fix_pr_open", row
+    assert row["values"]["Context Tags"] == outcome["context_tags"], row
     assert "stage=ci_pending" in row["values"]["Evidence"], row
     assert "commit=fix-parser-abc1234" in row["values"]["Evidence"], row
     assert "risks=full integration suite" in row["values"]["Evidence"], row

--- a/examples/issue-fix-workflow-plan-smoke.py
+++ b/examples/issue-fix-workflow-plan-smoke.py
@@ -126,10 +126,22 @@ def assert_workflow_shape(payload: dict[str, Any]) -> None:
     assert [section["label"] for section in description["sections"]] == [
         "动机",
         "改动思路",
+        "关键代码或伪代码",
         "具体改动",
+        "修复后复现",
         "验证",
         "对主干的风险与未覆盖",
     ]
+    assert description["sections"][2]["applicability"] == "code_changes"
+    assert description["sections"][4]["accepted_surfaces"] == [
+        "repository_cli",
+        "focused_code_or_test",
+    ]
+    assert description["infographic_policy"] == {
+        "required": False,
+        "allowed_when": "complex_change",
+        "must_not_replace_textual_evidence": True,
+    }
     assert description["review_only_section_excluded"] == "我的整体评价"
     assert description["requires_current_diff_evidence"] is True
 
@@ -146,9 +158,10 @@ def main() -> int:
     )
     assert_workflow_shape(packet)
     assert packet["branch_plan"]["status"] == "needs_approved_repo_context", packet
-    assert "approved_repo_context_missing" in packet["review_packet_preview"][
-        "readiness_blockers"
-    ]
+    assert (
+        "approved_repo_context_missing"
+        in packet["review_packet_preview"]["readiness_blockers"]
+    )
 
     with tempfile.TemporaryDirectory(prefix="loopx-issue-fix-plan-") as tmpdir:
         tmp = Path(tmpdir)

--- a/examples/lark-kanban-control-plane-smoke.py
+++ b/examples/lark-kanban-control-plane-smoke.py
@@ -285,7 +285,7 @@ def main() -> int:
     assert schema["task_spawning_model"]["board_creates_tasks"] is False, schema
     assert "LoopX todo lifecycle" in schema["task_spawning_model"]["rule"], schema
     field_names = [field["name"] for field in schema["fields"]]
-    for expected in ["Task", "Status", "Claim", "Handoff", "Evidence", "Run History", "Worker Command", "Work Item Type", "Repository", "Issue", "Pull Request", "Route", "Stage", "Validation", "Outcome", "Metric Group", "Metric", "Baseline", "Current", "Delta", "Numerator", "Denominator", "Metric Source", "Metric Updated At", "Missing Data"]:
+    for expected in ["Task", "Status", "Claim", "Handoff", "Evidence", "Run History", "Worker Command", "Work Item Type", "Repository", "Issue", "Pull Request", "Route", "Stage", "Validation", "Outcome", "Context Tags", "Metric Group", "Metric", "Baseline", "Current", "Delta", "Numerator", "Denominator", "Metric Source", "Metric Updated At", "Missing Data"]:
         assert expected in field_names, field_names
     assert schema["heartbeat_model"]["fallback"].startswith("agent heartbeat"), schema
     assert schema["operator_view"]["kanban_card_fields"] == lark_kanban_operator_card_fields(), schema
@@ -301,6 +301,17 @@ def main() -> int:
     issue_fields = {field["name"]: field for field in schema["fields"]}
     assert issue_fields["Issue"]["style"]["type"] == "url", issue_fields["Issue"]
     assert issue_fields["Pull Request"]["style"]["type"] == "url", issue_fields["Pull Request"]
+    assert issue_fields["Context Tags"]["type"] == "select", issue_fields["Context Tags"]
+    assert issue_fields["Context Tags"]["multiple"] is True, issue_fields["Context Tags"]
+    assert {
+        "fix_pr",
+        "ci_pending",
+        "reproduction_confirmed",
+        "validation_passed",
+        "tests_changed",
+    } <= {
+        option["name"] for option in issue_fields["Context Tags"]["options"]
+    }, issue_fields["Context Tags"]
     assert issue_fix_surface.ISSUE_FIX_STAGE_OPTIONS[:6] == [
         "reproduction_planned",
         "fix_in_progress",
@@ -440,7 +451,7 @@ def main() -> int:
         use_lark_kanban_board(config_path=config_path, base_url="https://example.invalid/base/base_existing?table=tbl_existing", cli_bin="lark-cli", identity="user")
         migrated = setup_lark_kanban_board(config_path=config_path, base_name="LoopX Existing Board Fixture", cli_bin="lark-cli", identity="user", execute=True, runner=existing_setup_runner)
         assert migrated["ok"] is True, migrated
-        assert {"Work Item Type", "Repository", "Route", "Validation", "Outcome"} <= set(migrated["created_fields"]), migrated
+        assert {"Work Item Type", "Repository", "Route", "Validation", "Outcome", "Context Tags"} <= set(migrated["created_fields"]), migrated
         assert set(migrated["updated_fields"]) == {"Issue", "Pull Request", "Stage"}, migrated
         field_updates = [args for args in existing_setup_calls if "+field-update" in args]
         assert len(field_updates) == 3, field_updates

--- a/loopx/capabilities/issue_fix/outcome_projection.py
+++ b/loopx/capabilities/issue_fix/outcome_projection.py
@@ -170,9 +170,7 @@ def _reusable_knowledge(value: Any) -> dict[str, Any] | None:
             }
         )
     missing = [
-        key
-        for key, item in compact.items()
-        if key != "schema_version" and not item
+        key for key, item in compact.items() if key != "schema_version" and not item
     ]
     if missing:
         raise ValueError(
@@ -244,9 +242,7 @@ def _delivery_evidence(value: Mapping[str, Any] | None) -> dict[str, Any]:
             value.get("recorded_at"), field="recorded_at", limit=80
         )
         or None,
-        "reusable_knowledge": _reusable_knowledge(
-            value.get("reusable_knowledge")
-        ),
+        "reusable_knowledge": _reusable_knowledge(value.get("reusable_knowledge")),
     }
 
 
@@ -335,6 +331,35 @@ def _stage_and_card_status(
     if reproduction_status in {"missing", "blocked"}:
         return "reproduction_blocked", "blocked", "P0"
     return "fix_in_progress", "open", "P0"
+
+
+def _context_tags(
+    *,
+    route: str,
+    stage: str,
+    reproduction_status: str,
+    validation_status: str,
+    repository_context_status: str,
+    changed_files: Sequence[str],
+) -> list[str]:
+    """Build bounded, filterable reviewer context without free-form prose."""
+
+    tags = [
+        route,
+        stage,
+        f"reproduction_{reproduction_status}",
+        f"validation_{validation_status}",
+    ]
+    if any(
+        PurePosixPath(path).parts and PurePosixPath(path).parts[0] in {"test", "tests"}
+        for path in changed_files
+    ):
+        tags.append("tests_changed")
+    if len(changed_files) > 1:
+        tags.append("multi_file")
+    if repository_context_status == "grounded":
+        tags.append("repository_context_grounded")
+    return list(dict.fromkeys(tags))
 
 
 def _result(
@@ -497,6 +522,20 @@ def build_issue_fix_outcome_projection(
         field="validation label",
         limit=260,
     )
+    validation_status = str(
+        delivery.get("validation_status")
+        or ("declared" if validation_label else "unknown")
+    )
+    repository_context_status = (
+        _safe_text(
+            repository_context.get("context_status")
+            or context_effect.get("context_status"),
+            field="context status",
+            limit=80,
+        )
+        or "unknown"
+    )
+    changed_files = list(delivery.get("changed_files") or [])
     feasibility_transition = _mapping(feasibility_packet.get("transition"))
     projected_todo = _mapping(feasibility_transition.get("projected_todo"))
     next_action = _safe_text(
@@ -562,8 +601,7 @@ def build_issue_fix_outcome_projection(
             ),
         },
         "validation": {
-            "status": delivery.get("validation_status")
-            or ("declared" if validation_label else "unknown"),
+            "status": validation_status,
             "label": validation_label or None,
             "evidence_refs": list(context_effect.get("validation_evidence_refs") or []),
         },
@@ -571,7 +609,7 @@ def build_issue_fix_outcome_projection(
             "evidence_provided": delivery.get("provided") is True,
             "outcome_status": delivery.get("outcome_status"),
             "commit_ref": delivery.get("commit_ref"),
-            "changed_files": list(delivery.get("changed_files") or []),
+            "changed_files": changed_files,
             "recorded_at": delivery.get("recorded_at"),
         },
         "reusable_knowledge": delivery.get("reusable_knowledge"),
@@ -599,6 +637,14 @@ def build_issue_fix_outcome_projection(
             delivery=delivery,
         ),
         "risks": list(delivery.get("risks") or []),
+        "context_tags": _context_tags(
+            route=route,
+            stage=stage,
+            reproduction_status=reproduction_status,
+            validation_status=validation_status,
+            repository_context_status=repository_context_status,
+            changed_files=changed_files,
+        ),
         "next_action": next_action or None,
         "handoff": next_action or "No further action projected.",
         "scope": "issue_fix_outcome",
@@ -747,18 +793,17 @@ def build_issue_fix_outcome_collection_from_domain_state(
                 pr_lifecycle_packet=lifecycle_packet,
                 delivery_evidence_input=(
                     feasibility_packet.get("delivery_evidence")
-                    if isinstance(
-                        feasibility_packet.get("delivery_evidence"), Mapping
-                    )
+                    if isinstance(feasibility_packet.get("delivery_evidence"), Mapping)
                     else None
                 ),
                 agent_id=agent_id,
                 generated_at=generated_at,
             )
         except ValueError as exc:
-            safe_identity = public_safe_compact_text(
-                f"{repo}:{issue_ref}", limit=220
-            ) or "unknown issue"
+            safe_identity = (
+                public_safe_compact_text(f"{repo}:{issue_ref}", limit=220)
+                or "unknown issue"
+            )
             safe_error = public_safe_compact_text(exc, limit=260) or "invalid row"
             warnings.append(f"skipped {safe_identity}: {safe_error}")
             continue

--- a/loopx/capabilities/issue_fix/workflow_plan.py
+++ b/loopx/capabilities/issue_fix/workflow_plan.py
@@ -348,6 +348,7 @@ def build_issue_fix_workflow_plan_packet(
         "pr_description_contract": {
             "schema_version": "issue_fix_pr_description_contract_v0",
             "source_contract": "pr_review_five_block_template_v0",
+            "extension_contract": "issue_fix_reviewer_context_v0",
             "sections": [
                 {
                     "label": "动机",
@@ -358,8 +359,28 @@ def build_issue_fix_workflow_plan_packet(
                     "purpose": "Explain the chosen fix route and the main design tradeoff.",
                 },
                 {
+                    "label": "关键代码或伪代码",
+                    "purpose": (
+                        "Show the smallest code or pseudocode slice that lets a "
+                        "reviewer verify the behavioral change quickly."
+                    ),
+                    "applicability": "code_changes",
+                },
+                {
                     "label": "具体改动",
                     "purpose": "Name the reviewer-relevant modules, behavior, and focused regression coverage.",
+                },
+                {
+                    "label": "修复后复现",
+                    "purpose": (
+                        "Provide a post-fix reproduction path using the repository "
+                        "CLI or focused code/test surface."
+                    ),
+                    "applicability": "reproducible_changes",
+                    "accepted_surfaces": [
+                        "repository_cli",
+                        "focused_code_or_test",
+                    ],
                 },
                 {
                     "label": "验证",
@@ -370,6 +391,11 @@ def build_issue_fix_workflow_plan_packet(
                     "purpose": "State compatibility risk, residual gaps, and checks not run.",
                 },
             ],
+            "infographic_policy": {
+                "required": False,
+                "allowed_when": "complex_change",
+                "must_not_replace_textual_evidence": True,
+            },
             "review_only_section_excluded": "我的整体评价",
             "requires_current_diff_evidence": True,
         },
@@ -441,7 +467,9 @@ def build_issue_fix_workflow_plan_packet(
     return packet
 
 
-def validate_issue_fix_workflow_plan_packet(packet: Mapping[str, Any]) -> dict[str, Any]:
+def validate_issue_fix_workflow_plan_packet(
+    packet: Mapping[str, Any],
+) -> dict[str, Any]:
     errors: list[str] = []
     if packet.get("schema_version") != ISSUE_FIX_WORKFLOW_PLAN_PACKET_SCHEMA_VERSION:
         errors.append("packet schema_version must be issue_fix_workflow_plan_packet_v0")
@@ -491,20 +519,18 @@ def validate_issue_fix_workflow_plan_packet(packet: Mapping[str, Any]) -> dict[s
         if repository_context.get("external_writes_performed") is not False:
             errors.append("repository_context must not perform external writes")
         truth_contract = repository_context.get("truth_contract")
-        if not isinstance(truth_contract, Mapping) or truth_contract.get(
-            "context_cannot_authorize_external_writes"
-        ) is not True:
+        if (
+            not isinstance(truth_contract, Mapping)
+            or truth_contract.get("context_cannot_authorize_external_writes")
+            is not True
+        ):
             errors.append("repository_context must deny external-write authority")
 
     routes = packet.get("resolution_route_candidates")
     if not isinstance(routes, Sequence) or isinstance(routes, (str, bytes)):
         errors.append("resolution_route_candidates must be a list")
         routes = []
-    route_names = {
-        route.get("route")
-        for route in routes
-        if isinstance(route, Mapping)
-    }
+    route_names = {route.get("route") for route in routes if isinstance(route, Mapping)}
     for route_name in ("fix_pr", "comment_only", "triage_only"):
         if route_name not in route_names:
             errors.append(f"resolution route {route_name} is required")
@@ -608,11 +634,33 @@ def validate_issue_fix_workflow_plan_packet(packet: Mapping[str, Any]) -> dict[s
         if labels != [
             "动机",
             "改动思路",
+            "关键代码或伪代码",
             "具体改动",
+            "修复后复现",
             "验证",
             "对主干的风险与未覆盖",
         ]:
             errors.append("PR description contract sections are incomplete")
+        section_by_label = {
+            str(section.get("label") or ""): section
+            for section in sections or []
+            if isinstance(section, Mapping)
+        }
+        if section_by_label.get("关键代码或伪代码", {}).get("applicability") != (
+            "code_changes"
+        ):
+            errors.append("key code section must apply to code changes")
+        if section_by_label.get("修复后复现", {}).get("accepted_surfaces") != [
+            "repository_cli",
+            "focused_code_or_test",
+        ]:
+            errors.append("post-fix reproduction surfaces are incomplete")
+        if description.get("infographic_policy") != {
+            "required": False,
+            "allowed_when": "complex_change",
+            "must_not_replace_textual_evidence": True,
+        }:
+            errors.append("PR description infographic policy is incomplete")
         if description.get("review_only_section_excluded") != "我的整体评价":
             errors.append("PR description contract must exclude reviewer verdict")
     if review.get("external_issue_comment_performed") is not False:
@@ -766,9 +814,26 @@ def render_issue_fix_workflow_plan_markdown(payload: dict[str, Any]) -> str:
                 f"- merge_performed: `{review.get('merge_performed')}`",
             ]
         )
+        description = review.get("pr_description_contract")
+        if isinstance(description, Mapping):
+            lines.extend(["", "### PR Description Contract", ""])
+            for section in description.get("sections") or []:
+                if isinstance(section, Mapping):
+                    lines.append(
+                        f"- **{section.get('label')}**: {section.get('purpose')}"
+                    )
+            infographic = description.get("infographic_policy")
+            if isinstance(infographic, Mapping):
+                lines.append(
+                    "- infographic: optional for complex changes; textual evidence remains required"
+                )
     validation = payload.get("validation")
     if isinstance(validation, Mapping):
-        errors = validation.get("errors") if isinstance(validation.get("errors"), list) else []
+        errors = (
+            validation.get("errors")
+            if isinstance(validation.get("errors"), list)
+            else []
+        )
         lines.extend(
             [
                 "",

--- a/loopx/presentation/sinks/lark/issue_fix_surface.py
+++ b/loopx/presentation/sinks/lark/issue_fix_surface.py
@@ -21,6 +21,7 @@ ISSUE_FIX_CARD_FIELDS = [
     "Stage",
     "Validation",
     "Outcome",
+    "Context Tags",
     "Status",
 ]
 
@@ -61,6 +62,28 @@ ISSUE_FIX_STAGE_OPTIONS = [
     "triage_complete",
 ]
 
+ISSUE_FIX_CONTEXT_TAG_OPTIONS = list(
+    dict.fromkeys(
+        [
+            "fix_pr",
+            "comment_only",
+            "triage_only",
+            *ISSUE_FIX_STAGE_OPTIONS,
+            "reproduction_confirmed",
+            "reproduction_missing",
+            "validation_passed",
+            "validation_failed",
+            "validation_partial",
+            "validation_not_run",
+            "validation_declared",
+            "validation_unknown",
+            "tests_changed",
+            "multi_file",
+            "repository_context_grounded",
+        ]
+    )
+)
+
 
 def issue_fix_field_definitions(
     select_options: Callable[[list[str]], list[dict[str, str]]],
@@ -89,6 +112,12 @@ def issue_fix_field_definitions(
         },
         {"name": "Validation", "type": "text", "style": {"type": "plain"}},
         {"name": "Outcome", "type": "text", "style": {"type": "plain"}},
+        {
+            "name": "Context Tags",
+            "type": "select",
+            "multiple": True,
+            "options": select_options(ISSUE_FIX_CONTEXT_TAG_OPTIONS),
+        },
         {
             "name": "Metric Group",
             "type": "select",
@@ -171,6 +200,7 @@ def issue_fix_record_values(
             "Stage": "",
             "Validation": "",
             "Outcome": "",
+            "Context Tags": [],
             "Metric Group": compact_text(block.get("metric_group"), limit=80),
             "Metric": compact_text(block.get("metric"), limit=180),
             "Baseline": _number_or_none(block.get("baseline")),
@@ -222,6 +252,11 @@ def issue_fix_record_values(
             limit=300,
         ),
         "Outcome": compact_text(result.get("kind"), limit=120),
+        "Context Tags": [
+            safe_tag
+            for tag in block.get("context_tags") or []
+            if (safe_tag := compact_text(tag, limit=80))
+        ],
         "Metric Group": "",
         "Metric": "",
         "Baseline": None,
@@ -245,6 +280,7 @@ def todo_record_values() -> dict[str, str]:
         "Stage": "",
         "Validation": "",
         "Outcome": "",
+        "Context Tags": [],
         "Metric Group": "",
         "Metric": "",
         "Baseline": None,
@@ -319,7 +355,14 @@ def field_definition_migrations(
     for definition in definitions:
         name = str(definition.get("name") or "").strip()
         if (
-            name not in {"Work Item Type", "Issue", "Pull Request", "Stage"}
+            name
+            not in {
+                "Work Item Type",
+                "Issue",
+                "Pull Request",
+                "Stage",
+                "Context Tags",
+            }
             or name not in existing
         ):
             continue


### PR DESCRIPTION
## Motivation

Issue-fix review packets already carry motivation, approach, changes, validation, and risk, but they do not require the two pieces reviewers often need to validate a focused fix quickly: the key code/pseudocode and a post-fix reproduction path. The Lark issue-fix surface also keeps route, stage, reproduction, and validation context inside separate prose fields instead of filterable tags.

## What changed

- extend `issue_fix_pr_description_contract_v0` with required reviewer-context sections for code changes and reproducible fixes
- limit optional infographics to complex changes and keep textual evidence mandatory
- derive bounded public-safe `context_tags` from existing issue-fix outcome state
- add a multi-select `Context Tags` field to issue-fix Lark rows and visible card fields
- update English/Chinese capability docs and the workflow protocol

## Key code / pseudocode

```text
workflow plan
  -> five review blocks
  + key code or pseudocode (code changes)
  + post-fix CLI/code/test reproduction (when applicable)

outcome state
  -> route + stage + reproduction + validation
  + tests_changed / multi_file / repository_context_grounded
  -> bounded Context Tags multi-select
```

## Post-fix reproduction

```bash
python3 examples/issue-fix-workflow-plan-smoke.py
python3 examples/issue-fix-outcome-projection-smoke.py
python3 examples/lark-kanban-control-plane-smoke.py
```

The workflow packet now exposes seven author-facing sections plus the infographic policy. The projected issue-fix row contains stable context tags and the Lark schema creates or reconciles the `Context Tags` multi-select field.

## Validation

- 6 focused issue-fix/Lark smokes passed
- standard premerge canary: 17/17 selected checks passed
- public/private boundary scan: clean
- Ruff and diff checks: passed
- warnings, failures, skips, and manual holds: 0

## Main-branch risk and uncovered scope

The change is additive to the v0 packet and Lark schema. It does not post PRs, send notifications, or copy free-form evidence into tags. Live schema reconciliation and board sync remain the existing explicit operator actions.
