### PR TITLE
Restore Full Public smoke parity

### DIFF
--- a/examples/control_plane/control-plane-integrated-canary-smoke.py
+++ b/examples/control_plane/control-plane-integrated-canary-smoke.py
@@ -531,12 +531,14 @@ def assert_due_monitor_poll_state_machine(root: Path) -> None:
     )
     assert quota_payload["ok"] is True, quota_payload
     assert quota_payload["should_run"] is True, quota_payload
-    assert quota_payload["effective_action"] == "normal_run", quota_payload
+    assert quota_payload["decision"] == "autonomous_replan_required", quota_payload
+    assert quota_payload["effective_action"] == "autonomous_replan_required", quota_payload
     lane = quota_payload["work_lane_contract"]
     assert lane["monitor_kind"] == "todo_monitor_due", lane
     assert lane["obligation"] == "attempt_due_monitor", lane
     assert lane["selected_todo_id"] == MONITOR_TODO_ID, lane
     contract = quota_payload["interaction_contract"]
+    assert contract["mode"] == "autonomous_replan", contract
     assert contract["agent_channel"]["must_attempt"] is True, contract
     assert contract["agent_channel"]["quiet_noop_allowed"] is False, contract
     assert contract["cli_channel"]["spend_allowed_now"] is False, contract

--- a/examples/control_plane/goal-attention-readmodel-smoke.py
+++ b/examples/control_plane/goal-attention-readmodel-smoke.py
@@ -97,6 +97,14 @@ def main() -> int:
     )
     assert connected["source"] == "run_history", connected
 
+    connected_delivery = assert_routed(
+        goal(adapter_status="connected-delivery"),
+        status="connected_without_run",
+        waiting_on="codex",
+        severity="action",
+    )
+    assert connected_delivery["source"] == "run_history", connected_delivery
+
     planned = assert_routed(
         goal(adapter_status="planned", adapter_kind="demo_read_only_map_v0"),
         status="active",

--- a/examples/control_plane/primary-action-resolution-parity-smoke.py
+++ b/examples/control_plane/primary-action-resolution-parity-smoke.py
@@ -153,11 +153,14 @@ def main() -> int:
             "resolution_summary": "source=mode:user_gate drift=true",
         },
         "monitor": {
-            "decision": "run",
-            "effective_action": "normal_run",
-            "mode": "bounded_delivery",
-            "primary_action": "todo_monitor: [P0] Poll the due monitor.",
-            "resolution_summary": "source=selected drift=true",
+            "decision": "autonomous_replan_required",
+            "effective_action": "autonomous_replan_required",
+            "mode": "autonomous_replan",
+            "primary_action": (
+                "run one bounded autonomous replan slice around todo_monitor: "
+                "[P0] Poll the due monitor."
+            ),
+            "resolution_summary": "source=mode:autonomous_replan drift=true",
         },
         "replan": {
             "decision": "autonomous_replan_required",

--- a/examples/control_plane/work-lane-contract-smoke.py
+++ b/examples/control_plane/work-lane-contract-smoke.py
@@ -706,9 +706,9 @@ def assert_due_monitor_only_requires_attempt() -> None:
         goal_id=GOAL_ID,
     )
     lane = guard["work_lane_contract"]
-    assert guard["decision"] == "run", guard
+    assert guard["decision"] == "autonomous_replan_required", guard
     assert guard["should_run"] is True, guard
-    assert guard["effective_action"] == "normal_run", guard
+    assert guard["effective_action"] == "autonomous_replan_required", guard
     assert lane["lane"] == "continuous_monitor", lane
     assert lane["monitor_kind"] == "todo_monitor_due", lane
     assert lane["obligation"] == "attempt_due_monitor", lane
@@ -717,8 +717,11 @@ def assert_due_monitor_only_requires_attempt() -> None:
     assert lane["monitor_due_count"] == 1, lane
     assert lane["selected_next_due_at"] == PAST_DUE_AT, lane
     assert guard["agent_todo_summary"]["monitor_due_count"] == 1, guard
-    assert guard["recommended_action"] == due_todo, guard
-    assert guard["interaction_contract"]["agent_channel"]["primary_action"] == due_todo, guard
+    assert guard["goal_frontier_projection"]["replan_required"] is True, guard
+    assert guard["interaction_contract"]["mode"] == "autonomous_replan", guard
+    assert guard["interaction_contract"]["agent_channel"]["primary_action"] == (
+        f"run one bounded autonomous replan slice around {due_todo}"
+    ), guard
     assert "agent_lane_next_action" not in guard, guard
     markdown = render_quota_should_run_markdown(guard)
     assert "work_lane_monitor_due: count=1" in markdown, markdown

--- a/examples/dashboard-tracked-fixtures-smoke.py
+++ b/examples/dashboard-tracked-fixtures-smoke.py
@@ -28,6 +28,13 @@ PRIVATE_SHAPES = [
     re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
     re.compile(r"\bBearer\s+[A-Za-z0-9._-]+"),
 ]
+IMAGE_SIGNATURES = {
+    ".gif": (b"GIF87a", b"GIF89a"),
+    ".jpeg": (b"\xff\xd8\xff",),
+    ".jpg": (b"\xff\xd8\xff",),
+    ".png": (b"\x89PNG\r\n\x1a\n",),
+    ".webp": (b"RIFF",),
+}
 
 
 def tracked_dashboard_files() -> list[Path]:
@@ -56,14 +63,30 @@ def assert_public_safe(text: str, *, label: str) -> None:
             raise AssertionError(f"{label} matched private shape {pattern.pattern!r}")
 
 
+def assert_tracked_file_public_safe(path: Path) -> None:
+    payload = path.read_bytes()
+    signatures = IMAGE_SIGNATURES.get(path.suffix.lower())
+    if signatures is not None:
+        if not any(payload.startswith(signature) for signature in signatures):
+            raise AssertionError(f"{path} does not match its image signature")
+        if path.suffix.lower() == ".webp" and payload[8:12] != b"WEBP":
+            raise AssertionError(f"{path} does not match its WebP signature")
+        return
+
+    try:
+        text = payload.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise AssertionError(f"unrecognized binary tracked fixture: {path}") from exc
+    assert_public_safe(text, label=str(path))
+
+
 def main() -> int:
     files = tracked_dashboard_files()
     if not files:
         raise AssertionError("no tracked dashboard files found")
 
     for path in files:
-        text = (REPO_ROOT / path).read_text(encoding="utf-8")
-        assert_public_safe(text, label=str(path))
+        assert_tracked_file_public_safe(REPO_ROOT / path)
 
     assert_public_safe("./fixtures/runtime", label="relative fixture path")
     assert_public_safe("/tmp/loopx-dashboard-smoke", label="temporary path")

--- a/loopx/control_plane/work_items/attention_routing.py
+++ b/loopx/control_plane/work_items/attention_routing.py
@@ -59,7 +59,10 @@ def goal_attention(
         return legacy_runtime_goal_attention(goal, current_run, readiness_fields)
 
     if not current_run:
-        if adapter_status in connected_adapter_statuses:
+        if (
+            adapter_status in connected_adapter_statuses
+            or adapter_status in connected_delivery_adapter_statuses
+        ):
             return attention_item(
                 goal_id=goal_id,
                 status="connected_without_run",


### PR DESCRIPTION
## Summary
- route connected-delivery goals without a current run to Codex work instead of an adapter-connect gate
- align monitor-only smokes with the autonomous replan precedence contract while preserving due-monitor context
- validate dashboard image fixtures by binary signatures and retain public-safe text scanning

## Validation
- focused regression smokes: 6 passed
- full public suite: 558/558 passed, 0 failures, 0 timeouts, 0 warnings
- `loopx canary premerge --from-git-diff --format json`: passed 17/17 selected checks
- public/private boundary scan: clean across 6 changed files
- failures/skips/manual holds: none

## Review notes
The runtime change is intentionally one branch: connected-delivery is already an operational adapter state, so a missing run should request the first tick rather than ask the user to connect an adapter again. The remaining changes restore durable public validation without altering scheduler behavior.