### PR TITLE
Make Lark inbox thread-complete

### DIFF
--- a/docs/capabilities/lark-event-inbox.md
+++ b/docs/capabilities/lark-event-inbox.md
@@ -14,9 +14,16 @@ Lark event stream
 
 The collector is host infrastructure. On macOS it may be supervised by
 `launchd`; other hosts may use systemd or another restart policy. It should
-filter before persistence, keep only messages explicitly addressed to the
-configured bot, and write one compact event per Lark `event_id`/`message_id`.
-The agent does not need to keep a websocket open.
+filter before persistence and write one compact event per Lark
+`event_id`/`message_id`. The agent does not need to keep a websocket open.
+
+Use `addressed_only` only when direct bot mentions are the entire feedback
+contract. Lark's real-time `im.message.receive_v1` projection does not expose a
+thread id, so it cannot recognize later replies in a bot-started thread. A
+review or collaboration inbox that must learn from the whole discussion should
+use `configured_chat_all`: the host collector filters by its local-private chat
+id, persists every message from that chat, and lets the domain binding group or
+ignore messages during durable writeback.
 
 ## Local-private configuration
 
@@ -26,13 +33,19 @@ The inbox is opt-in. Create a local-private generic Lark inbox config:
 {
   "schema_version": "lark_event_inbox_config_v0",
   "enabled": true,
-  "inbox_dir": ".loopx/inbox/team-feedback"
+  "inbox_dir": ".loopx/inbox/team-feedback",
+  "capture_scope": "configured_chat_all"
 }
 ```
 
 `inbox_dir` must stay under `.loopx/inbox`. Destination ids, member ids,
 profile names, raw provider payloads, and credentials stay in local-private
 configuration or host state and must not enter public LoopX packets.
+
+`capture_scope` defaults to `addressed_only` for compatibility. Drain output
+reports `thread_complete=false` and a coverage warning for that mode. For
+`configured_chat_all`, the collector's jq filter should select the configured
+chat only; do not add a content-level `@bot` predicate.
 
 ## Drain and acknowledge
 
@@ -51,6 +64,27 @@ loopx lark-inbox ack \
 Drain is read-only and returns bounded local-private message content. A message
 must be acknowledged only after its effect is written back. Duplicate event
 files collapse by `message_id`; repeated acknowledgement is idempotent.
+
+## Bounded history reconciliation
+
+Real-time event subscriptions do not backfill messages sent before a collector
+started, and an earlier `addressed_only` collector will already have omitted
+unaddressed replies. Fetch the bounded source conversation with the Lark CLI,
+project each message into `lark_event_inbox_event_v0`, then pipe the JSON array
+or NDJSON into the generic importer:
+
+```bash
+<bounded-lark-message-export> \
+  | loopx lark-inbox ingest \
+      --project . \
+      --config .loopx/config/lark/event-inbox.json \
+      --execute
+```
+
+Ingest validates ids and schema, deduplicates by `message_id`, writes only to
+the configured local-private inbox, and returns counts rather than message
+content. It does not acknowledge imported messages; the domain agent must still
+write each actionable effect before ACK.
 
 ## Domain bindings
 

--- a/examples/lark-event-inbox-smoke.py
+++ b/examples/lark-event-inbox-smoke.py
@@ -10,8 +10,9 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from loopx.capabilities.lark.event_inbox import (
+from loopx.capabilities.lark.event_inbox import (  # noqa: E402
     acknowledge_lark_event_inbox,
+    ingest_lark_event_inbox,
     inspect_lark_event_inbox,
 )
 
@@ -40,9 +41,7 @@ def main() -> None:
             "create_time": "2026-07-12T10:00:00Z",
             "content": "@LoopX Bot please record this feedback for the owning domain",
         }
-        (inbox / "evt-review-1.json").write_text(
-            json.dumps(event), encoding="utf-8"
-        )
+        (inbox / "evt-review-1.json").write_text(json.dumps(event), encoding="utf-8")
         (inbox / "duplicate.json").write_text(
             json.dumps({**event, "event_id": "evt-review-1-retry"}),
             encoding="utf-8",
@@ -56,6 +55,49 @@ def main() -> None:
         assert pending["pending_count"] == 1, pending
         assert pending["invalid_count"] == 1, pending
         assert pending["items"][0]["message_id"] == "om_review_1", pending
+        assert pending["thread_complete"] is False, pending
+        assert "thread replies" in pending["coverage_warning"], pending
+
+        config.write_text(
+            json.dumps(
+                {
+                    "schema_version": "lark_event_inbox_config_v0",
+                    "enabled": True,
+                    "inbox_dir": ".loopx/inbox/team-feedback",
+                    "capture_scope": "configured_chat_all",
+                }
+            ),
+            encoding="utf-8",
+        )
+        pending = inspect_lark_event_inbox(project=project, config_path=config)
+        assert pending["thread_complete"] is True, pending
+
+        imported = ingest_lark_event_inbox(
+            project=project,
+            config_path=config,
+            events=[
+                {
+                    "schema_version": "lark_event_inbox_event_v0",
+                    "event_id": "evt-thread-reply-2",
+                    "message_id": "om_review_2",
+                    "create_time": "2026-07-12T10:01:00Z",
+                    "content": "A thread reply without a direct bot mention",
+                },
+                event,
+                {"schema_version": "wrong"},
+            ],
+            execute=True,
+        )
+        assert imported["accepted_count"] == 1, imported
+        assert imported["duplicate_count"] == 1, imported
+        assert imported["invalid_count"] == 1, imported
+        assert (
+            inspect_lark_event_inbox(
+                project=project,
+                config_path=config,
+            )["pending_count"]
+            == 2
+        )
 
         preview = acknowledge_lark_event_inbox(
             project=project,
@@ -71,10 +113,20 @@ def main() -> None:
             execute=True,
         )
         assert written["write_performed"] is True, written
-        assert inspect_lark_event_inbox(
+        assert (
+            inspect_lark_event_inbox(
+                project=project,
+                config_path=config,
+            )["pending_count"]
+            == 1
+        )
+
+        acknowledge_lark_event_inbox(
             project=project,
             config_path=config,
-        )["pending_count"] == 0
+            message_ids=["om_review_2"],
+            execute=True,
+        )
 
         repeated = acknowledge_lark_event_inbox(
             project=project,

--- a/loopx/capabilities/lark/event_inbox.py
+++ b/loopx/capabilities/lark/event_inbox.py
@@ -10,6 +10,7 @@ from typing import Any, Mapping, Sequence
 EVENT_SCHEMA_VERSION = "lark_event_inbox_event_v0"
 CONFIG_SCHEMA_VERSION = "lark_event_inbox_config_v0"
 PROCESSED_SCHEMA_VERSION = "lark_event_inbox_processed_v0"
+CAPTURE_SCOPES = {"addressed_only", "configured_chat_all"}
 MESSAGE_ID_PATTERN = re.compile(r"om_[A-Za-z0-9_-]+")
 EVENT_ID_PATTERN = re.compile(r"[A-Za-z0-9:_-]{1,200}")
 
@@ -44,16 +45,26 @@ def load_lark_event_inbox_config(
     except ValueError as exc:
         raise ValueError("lark inbox config must stay inside the project") from exc
     payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict) or payload.get("schema_version") != CONFIG_SCHEMA_VERSION:
+    if (
+        not isinstance(payload, dict)
+        or payload.get("schema_version") != CONFIG_SCHEMA_VERSION
+    ):
         raise ValueError("lark inbox config schema is invalid")
     enabled = payload.get("enabled") is True
     inbox_dir = str(payload.get("inbox_dir") or "").strip()
     if enabled and not inbox_dir:
         raise ValueError("enabled lark event inbox requires inbox_dir")
+    capture_scope = str(payload.get("capture_scope") or "addressed_only").strip()
+    if capture_scope not in CAPTURE_SCOPES:
+        raise ValueError(
+            "lark inbox capture_scope must be addressed_only or configured_chat_all"
+        )
     return {
         "enabled": enabled,
         "configured": True,
         "inbox_path": _safe_inbox_path(root, inbox_dir) if enabled else None,
+        "capture_scope": capture_scope,
+        "thread_complete": capture_scope == "configured_chat_all",
     }
 
 
@@ -74,16 +85,17 @@ def _load_processed(path: Path) -> set[str]:
     }
 
 
-def _event_from_file(path: Path) -> dict[str, Any] | None:
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
-    if not isinstance(payload, Mapping) or payload.get("schema_version") != EVENT_SCHEMA_VERSION:
+def _event_from_payload(payload: object) -> dict[str, Any] | None:
+    if (
+        not isinstance(payload, Mapping)
+        or payload.get("schema_version") != EVENT_SCHEMA_VERSION
+    ):
         return None
     message_id = str(payload.get("message_id") or "").strip()
     event_id = str(payload.get("event_id") or message_id).strip()
-    if not MESSAGE_ID_PATTERN.fullmatch(message_id) or not EVENT_ID_PATTERN.fullmatch(event_id):
+    if not MESSAGE_ID_PATTERN.fullmatch(message_id) or not EVENT_ID_PATTERN.fullmatch(
+        event_id
+    ):
         return None
     content = " ".join(str(payload.get("content") or "").split())[:1200]
     if not content:
@@ -93,6 +105,78 @@ def _event_from_file(path: Path) -> dict[str, Any] | None:
         "message_id": message_id,
         "create_time": str(payload.get("create_time") or "")[:40],
         "content": content,
+    }
+
+
+def _event_from_file(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return _event_from_payload(payload)
+
+
+def ingest_lark_event_inbox(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    events: Sequence[object],
+    execute: bool = False,
+) -> dict[str, Any]:
+    """Persist canonical compact events supplied by a host collector or backfill."""
+
+    config = load_lark_event_inbox_config(project=project, config_path=config_path)
+    if not config["enabled"]:
+        raise ValueError("lark event inbox is not enabled")
+    inbox = config["inbox_path"]
+    existing_message_ids = {
+        event["message_id"]
+        for path in sorted(inbox.glob("*.json"))
+        if inbox.is_dir()
+        if path.name != "processed.json"
+        if (event := _event_from_file(path)) is not None
+    }
+    accepted: dict[str, dict[str, Any]] = {}
+    invalid_count = 0
+    duplicate_count = 0
+    for payload in events:
+        event = _event_from_payload(payload)
+        if event is None:
+            invalid_count += 1
+            continue
+        message_id = event["message_id"]
+        if message_id in existing_message_ids or message_id in accepted:
+            duplicate_count += 1
+            continue
+        accepted[message_id] = event
+
+    if execute and accepted:
+        inbox.mkdir(parents=True, exist_ok=True)
+        for event in accepted.values():
+            path = inbox / f"{event['message_id']}.json"
+            temporary = path.with_suffix(".json.tmp")
+            temporary.write_text(
+                json.dumps(
+                    {"schema_version": EVENT_SCHEMA_VERSION, **event},
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            temporary.replace(path)
+    return {
+        "ok": True,
+        "schema_version": "lark_event_inbox_ingest_v0",
+        "execute": execute,
+        "requested_count": len(events),
+        "accepted_count": len(accepted),
+        "invalid_count": invalid_count,
+        "duplicate_count": duplicate_count,
+        "write_performed": bool(execute and accepted),
+        "local_private_content_returned": False,
+        "external_reads_performed": False,
+        "external_writes_performed": False,
     }
 
 
@@ -106,6 +190,8 @@ def inspect_lark_event_inbox(
             "schema_version": "lark_event_inbox_projection_v0",
             "enabled": False,
             "configured": config["configured"],
+            "capture_scope": config["capture_scope"],
+            "thread_complete": config["thread_complete"],
             "pending_count": 0,
             "items": [],
             "local_private_content_returned": False,
@@ -131,6 +217,13 @@ def inspect_lark_event_inbox(
         "schema_version": "lark_event_inbox_projection_v0",
         "enabled": True,
         "configured": True,
+        "capture_scope": config["capture_scope"],
+        "thread_complete": config["thread_complete"],
+        "coverage_warning": (
+            None
+            if config["thread_complete"]
+            else "addressed_only capture does not include unaddressed thread replies"
+        ),
         "pending_count": len(pending),
         "returned_count": len(bounded),
         "processed_count": len(processed),

--- a/loopx/cli_commands/lark_inbox.py
+++ b/loopx/cli_commands/lark_inbox.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import argparse
+import json
+import sys
 from typing import Callable
 
 from ..capabilities.lark.event_inbox import (
     acknowledge_lark_event_inbox,
+    ingest_lark_event_inbox,
     inspect_lark_event_inbox,
 )
 
@@ -35,6 +38,32 @@ def register_lark_inbox_commands(
     ack.add_argument("--config", required=True)
     ack.add_argument("--message-id", action="append", required=True)
     ack.add_argument("--execute", action="store_true")
+    ingest = sub.add_parser(
+        "ingest",
+        help=(
+            "Persist canonical compact events from stdin JSON/NDJSON for host "
+            "collection or bounded history reconciliation."
+        ),
+    )
+    add_subcommand_format(ingest)
+    ingest.add_argument("--project", default=".")
+    ingest.add_argument("--config", required=True)
+    ingest.add_argument("--execute", action="store_true")
+
+
+def _read_stdin_events() -> list[object]:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        raise ValueError("lark inbox ingest requires JSON or NDJSON on stdin")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        payload = [json.loads(line) for line in raw.splitlines() if line.strip()]
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        return [payload]
+    raise ValueError("lark inbox ingest input must be an event object or event array")
 
 
 def _render(payload: dict[str, object]) -> str:
@@ -67,14 +96,21 @@ def handle_lark_inbox_command(
                 config_path=args.config,
                 limit=args.limit,
             )
-        else:
+        elif args.lark_inbox_command == "ack":
             payload = acknowledge_lark_event_inbox(
                 project=args.project,
                 config_path=args.config,
                 message_ids=args.message_id,
                 execute=args.execute,
             )
-    except (OSError, ValueError) as exc:
+        else:
+            payload = ingest_lark_event_inbox(
+                project=args.project,
+                config_path=args.config,
+                events=_read_stdin_events(),
+                execute=args.execute,
+            )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
         payload = {
             "ok": False,
             "schema_version": "lark_event_inbox_error_v0",


### PR DESCRIPTION
## 修复的问题

`addressed_only` collector 只能捕获直接 @bot 的消息。真实 reviewer 线程中有 31 条回复，旧过滤器只保留了其中 1 条；后续未直接 @bot 的反馈会永久丢失，而且 drain 的 `pending=0` 无法暴露这个覆盖缺口。

## 根因

Lark `im.message.receive_v1` 的实时投影没有 `thread_id`。因此 collector 无法在事件层判断一条未 @bot 的消息是否属于 bot 发起的 review 线程；继续使用内容过滤会把“线程内回复”误当成无关消息。

## 方案

- 新增 `capture_scope`：保留 `addressed_only` 兼容默认值，同时支持 `configured_chat_all`。
- drain 显式返回 `thread_complete`；旧模式返回 coverage warning，不再把“已入箱数据处理完”误报成“讨论收全”。
- 新增 `loopx lark-inbox ingest`，从 stdin 接收 canonical JSON/NDJSON，用于 collector 启动前或旧过滤器漏收后的有界历史对账。
- ingest 校验 schema/id、按 `message_id` 去重、只写配置的本地私有 inbox，并且不自动 ACK。

## 关键行为

```text
configured chat 全量事件
  -> 本地私有 inbox
  -> domain 聚合为 todo / vision / artifact / rationale
  -> durable writeback 成功后 ACK

旧 addressed_only 数据
  -> drain 显示 thread_complete=false
  -> 有界源端导出 | lark-inbox ingest
  -> 按 message_id 补齐且不重复
```

## 验证

- `python3 examples/lark-event-inbox-smoke.py`
- Ruff check / format check
- Python compile
- `loopx canary premerge --from-git-diff --tier standard`：通过
- public-boundary scan：4 个候选文件，0 error / 0 warning
- 真实回放：31 条线程消息请求，30 条补入、1 条去重、0 条非法；随后 durable writeback + ACK 后 pending=0

## 风险与边界

- `configured_chat_all` 会增加本地私有 inbox 的消息量；领域层仍需聚合和忽略无行动价值的消息。
- LoopX 不保存目标 chat id、成员 id、profile 或原始 provider payload；这些仍留在 host/local-private 配置。
- ingest 仅解决有界历史对账，不替代 host collector 的生命周期管理。
