### PR TITLE
fix(cli): reject abbreviated option mismatches

### DIFF
--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -98,6 +98,14 @@ from .help_surface import (
 from .paths import DEFAULT_RUNTIME_ROOT, default_registry_path, global_registry_path
 
 
+class LoopXArgumentParser(argparse.ArgumentParser):
+    """Require complete option names across the automation-facing CLI."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        kwargs.setdefault("allow_abbrev", False)
+        super().__init__(*args, **kwargs)
+
+
 def print_payload(payload: dict[str, object], fmt: str, markdown_renderer) -> None:
     if fmt == "json":
         print(json.dumps(payload, ensure_ascii=False, indent=2))
@@ -134,7 +142,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     raw_argv = rewrite_auto_research_question_argv(raw_argv)
 
-    parser = argparse.ArgumentParser(description="LoopX control-plane helper.")
+    parser = LoopXArgumentParser(description="LoopX control-plane helper.")
     parser.add_argument("--version", action="version", version=f"loopx {__version__}")
     parser.add_argument("--registry", default=str(default_registry_path()), help="Path to a project-local registry.")
     parser.add_argument("--runtime-root", help="Override registry common_runtime_root.")

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+
+from loopx.cli import main
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["status", "--goal-id", "example-goal", "--project", "."],
+        ["quota", "should-run", "--goal-id", "example-goal", "--project", "."],
+    ],
+)
+def test_unsupported_project_option_is_not_misparsed_as_projection_cache_ttl(
+    argv: list[str],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(argv)
+
+    assert exc_info.value.code == 2
+    stderr = capsys.readouterr().err
+    assert "unrecognized arguments: --project ." in stderr
+    assert "projection-cache-ttl-seconds" not in stderr
+    assert "invalid int value" not in stderr


### PR DESCRIPTION
## 动机

LoopX 的 status 与 quota 都包含 --projection-cache-ttl-seconds。argparse 默认接受长参数缩写，因此不受支持的 --project . 会被误解析成 TTL 参数，最终报告 invalid int value: .，掩盖了真正的命令契约错误。

## 改动思路

自动化控制面应要求完整参数名，让旧命令或错误参数在边界处以 unrecognized arguments 明确失败，而不是悄悄命中另一个选项。

## 具体改动

- 为主 CLI 引入默认禁用 allow_abbrev 的 ArgumentParser；子命令解析器沿用同一 parser class。
- 添加 status 与 quota 两条回归，确保 --project . 不再被识别为 projection cache TTL。

## 验证

- uv run --with pytest pytest -q tests/test_cli_argument_diagnostics.py：2 passed。
- tests/test_smoke_suite.py：2 skipped，未出现失败。
- loopx canary premerge --from-git-diff：passed，3 个 catalog canary 全通过。
- 手工验证 status/quota 均返回 unrecognized arguments: --project .。

## 对主干的风险与未覆盖面

这会停止 argparse 未文档化的长参数缩写行为；使用完整公开参数名的命令不受影响。未引入 --project 的兼容别名，因为 status/quota 当前以 registry/goal 为路由真值，静默接受一个无语义参数会继续掩盖调用方漂移。