### PR TITLE
feat(reward): project inbox feedback into operating lessons

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -650,6 +650,27 @@ loopx reward \
   --reason-summary "validation improved and the route is worth extending"
 ```
 
+For a durable operating correction, add a typed lesson. `required` lessons are
+included in the next agent interaction contract; `advisory` lessons remain
+preferences:
+
+```bash
+loopx reward \
+  --goal-id your-project-goal \
+  --decision owner_correction \
+  --reward negative \
+  --reason-summary "The next route must respect the review boundary." \
+  --lesson-kind safety_boundary \
+  --lesson-summary "Keep new pull requests in draft review." \
+  --lesson-strength required \
+  --lesson-scope workspace
+```
+
+When feedback arrives through a configured Lark inbox, prefer
+`loopx lark-inbox project-reward ... --execute`; it records the reward event
+before acknowledging the source message and stores only a digest of the source
+reference.
+
 ## Heartbeats And Quota
 
 Quota is compute eligibility, not strategy. It answers whether an automatic

--- a/docs/reward-gate-direct-write-contract.md
+++ b/docs/reward-gate-direct-write-contract.md
@@ -23,7 +23,8 @@ write is enabled:
 - `follow_up`: optional public-safe next condition.
 - `preview_id`: required for browser reward append; omitted for CLI-only gate
   append until a separate gate preview endpoint exists.
-- `source_of_truth`: `run_bound_human_reward_overlay` or
+- `source_of_truth`: `goal_reward_event_ledger`,
+  `run_bound_human_reward_overlay` (legacy compatibility), or
   `operator_gate_decision_run`.
 - `write_effect`: what will be appended and what remains unchanged.
 - `project_agent_visibility`: the read path a target project agent should use
@@ -61,8 +62,42 @@ Browser append is allowed only when all of these are true:
 - The selected `run_generated_at`, compact reward payload, and raw index count
   still match the preview.
 
-Successful append writes one run-bound `human_reward` overlay row. Active state
-may carry a summary, but the run overlay remains the durable source of truth.
+Successful append writes one run-bound `human_reward` overlay row for backward
+compatibility and one idempotent `user_reward_event_v0` row under the goal's
+local reward-event ledger. The event ledger preserves multiple corrections that
+target the same run; the run overlay remains the compact dashboard annotation.
+Source adapters persist only a source kind and SHA-256 digest, never the raw
+message id or source text.
+
+A reward lesson may be `advisory` or `required`, and scoped to a goal,
+workspace, repository, or delivery surface. Required lessons are projected into
+the next `quota should-run` interaction contract as operating constraints.
+Later corrections may list prior `reward_id` values in `supersedes`; superseded
+lessons stay auditable but leave the active lesson projection.
+
+For a configured Lark event inbox, use the generic atomic projection path:
+
+```bash
+loopx lark-inbox project-reward \
+  --project . \
+  --config .loopx/config/lark/event-inbox.json \
+  --goal-id your-project-goal \
+  --message-id om_example \
+  --decision owner_correction \
+  --reward negative \
+  --reason-summary "The current route violates an explicit operating rule." \
+  --lesson-kind operating_rule \
+  --lesson-summary "Keep new deliveries in the required review state." \
+  --lesson-strength required \
+  --lesson-scope workspace \
+  --execute
+```
+
+This command appends or reuses the idempotent reward event, writes the compact
+active-state summary, and only then acknowledges the inbox message. A retry is
+safe: the source digest resolves to the same reward id and cannot duplicate the
+event. Raw inbox content remains local-private and is not copied into reward
+state.
 
 ## Operator Gate
 

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1849,7 +1849,8 @@ Both dry-run and append responses include:
 {
   "active_state_summary": "dry-run：将记录目标 `example-experiment-goal` ...",
   "project_agent_visibility": {
-    "source_of_truth": "run_bound_human_reward_overlay",
+    "source_of_truth": "goal_reward_event_ledger",
+    "run_overlay_role": "compatibility_annotation",
     "history_command": "loopx history --goal-id example-experiment-goal --limit 3",
     "active_state_role": "summary_only",
     "review_packet_role": "optional_handoff_only"

--- a/examples/reward-gate-direct-write-contract-smoke.py
+++ b/examples/reward-gate-direct-write-contract-smoke.py
@@ -121,7 +121,8 @@ def assert_reward_preview(registry: Path, runtime_root: Path, state_file: Path) 
     assert payload["active_state_update"]["would_write"] is True, payload
     assert payload["active_state_update"]["written"] is False, payload
     visibility = payload["project_agent_visibility"]
-    assert visibility["source_of_truth"] == "run_bound_human_reward_overlay", visibility
+    assert visibility["source_of_truth"] == "goal_reward_event_ledger", visibility
+    assert visibility["run_overlay_role"] == "compatibility_annotation", visibility
     assert visibility["history_command"] == f"loopx history --goal-id {GOAL_ID} --limit 3", visibility
     assert "human_reward" not in state_file.read_text(encoding="utf-8"), "dry-run must not write state"
 
@@ -166,6 +167,7 @@ def assert_contract_doc() -> None:
         "write_effect",
         "project_agent_visibility",
         "run_bound_human_reward_overlay",
+        "goal_reward_event_ledger",
         "operator_gate_decision_run",
         "--enable-reward-write-api",
         "There is no dashboard `operator_gate` apply endpoint",

--- a/loopx/capabilities/lark/event_inbox.py
+++ b/loopx/capabilities/lark/event_inbox.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any, Mapping, Sequence
+
+from ...feedback import append_human_reward
 
 
 EVENT_SCHEMA_VERSION = "lark_event_inbox_event_v0"
@@ -114,6 +117,16 @@ def _event_from_file(path: Path) -> dict[str, Any] | None:
     except (OSError, json.JSONDecodeError):
         return None
     return _event_from_payload(payload)
+
+
+def _event_by_message_id(inbox: Path, message_id: str) -> dict[str, Any] | None:
+    for path in sorted(inbox.glob("*.json")) if inbox.is_dir() else []:
+        if path.name == "processed.json":
+            continue
+        event = _event_from_file(path)
+        if event and event.get("message_id") == message_id:
+            return event
+    return None
 
 
 def ingest_lark_event_inbox(
@@ -285,5 +298,77 @@ def acknowledge_lark_event_inbox(
         "write_performed": bool(execute and added),
         "message_ids": normalized,
         "local_private_content_captured": False,
+        "external_writes_performed": False,
+    }
+
+
+def project_lark_event_inbox_reward(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    registry_path: Path,
+    runtime_root_override: str | None,
+    goal_id: str,
+    message_id: str,
+    reward: dict[str, Any],
+    run_generated_at: str | None = None,
+    state_file_override: Path | None = None,
+    execute: bool = False,
+) -> dict[str, Any]:
+    """Project one local Lark event into reward state before acknowledging it."""
+
+    if not MESSAGE_ID_PATTERN.fullmatch(str(message_id or "").strip()):
+        raise ValueError("project-reward requires a valid Lark message id")
+    config = load_lark_event_inbox_config(project=project, config_path=config_path)
+    if not config["enabled"]:
+        raise ValueError("lark event inbox is not enabled")
+    event = _event_by_message_id(config["inbox_path"], message_id)
+    if event is None:
+        raise ValueError("project-reward message is not present in the configured inbox")
+
+    reward_payload = dict(reward)
+    reward_payload["source"] = {
+        "schema_version": "user_reward_source_v0",
+        "kind": "lark",
+        "digest": "sha256:"
+        + hashlib.sha256(f"lark:{message_id}".encode("utf-8")).hexdigest(),
+    }
+    projected = append_human_reward(
+        registry_path=registry_path,
+        runtime_root_override=runtime_root_override,
+        goal_id=goal_id,
+        run_generated_at=run_generated_at,
+        reward=reward_payload,
+        dry_run=not execute,
+        state_file_override=state_file_override,
+        write_active_state_summary=True,
+    )
+    ledger = (
+        projected.get("reward_event_ledger")
+        if isinstance(projected.get("reward_event_ledger"), dict)
+        else {}
+    )
+    acknowledged = acknowledge_lark_event_inbox(
+        project=project,
+        config_path=config_path,
+        message_ids=[message_id],
+        execute=bool(execute and (ledger.get("appended") or ledger.get("already_exists"))),
+    )
+    return {
+        "ok": True,
+        "schema_version": "lark_event_reward_projection_v0",
+        "execute": execute,
+        "goal_id": goal_id,
+        "reward_id": ledger.get("reward_id"),
+        "reward_event_appended": ledger.get("appended"),
+        "reward_event_already_exists": ledger.get("already_exists"),
+        "active_state_written": (
+            projected.get("active_state_update") or {}
+        ).get("written"),
+        "acknowledged": acknowledged.get("write_performed"),
+        "ack_already_present": bool(acknowledged.get("already_acknowledged_count")),
+        "source_content_returned": False,
+        "source_ref_persisted_raw": False,
+        "external_reads_performed": False,
         "external_writes_performed": False,
     }

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -408,6 +408,8 @@ def main(argv: list[str] | None = None) -> int:
 
     lark_inbox_result = handle_lark_inbox_command(
         args,
+        registry_path=registry_path,
+        runtime_root_arg=args.runtime_root,
         output_format=output_format,
         print_payload=print_payload,
     )

--- a/loopx/cli_commands/lark_inbox.py
+++ b/loopx/cli_commands/lark_inbox.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from pathlib import Path
 from typing import Callable
 
 from ..capabilities.lark.event_inbox import (
     acknowledge_lark_event_inbox,
     ingest_lark_event_inbox,
     inspect_lark_event_inbox,
+    project_lark_event_inbox_reward,
 )
+from ..feedback import LESSON_KINDS, compact_reward
 
 
 def register_lark_inbox_commands(
@@ -49,6 +52,39 @@ def register_lark_inbox_commands(
     ingest.add_argument("--project", default=".")
     ingest.add_argument("--config", required=True)
     ingest.add_argument("--execute", action="store_true")
+    project_reward = sub.add_parser(
+        "project-reward",
+        help="Atomically project one inbox event into reward state, then acknowledge it.",
+    )
+    add_subcommand_format(project_reward)
+    project_reward.add_argument("--project", default=".")
+    project_reward.add_argument("--config", required=True)
+    project_reward.add_argument("--goal-id", required=True)
+    project_reward.add_argument("--message-id", required=True)
+    project_reward.add_argument("--run-generated-at")
+    project_reward.add_argument("--recorded-at")
+    project_reward.add_argument("--decision", required=True)
+    project_reward.add_argument(
+        "--reward", required=True, choices=["positive", "negative", "mixed", "neutral"]
+    )
+    project_reward.add_argument("--reason-summary", required=True)
+    project_reward.add_argument("--follow-up")
+    project_reward.add_argument("--lesson-kind", choices=sorted(LESSON_KINDS), required=True)
+    project_reward.add_argument("--lesson-summary", required=True)
+    project_reward.add_argument("--lesson-avoid", action="append", default=[])
+    project_reward.add_argument("--lesson-prefer", action="append", default=[])
+    project_reward.add_argument(
+        "--lesson-strength", choices=["advisory", "required"], default="advisory"
+    )
+    project_reward.add_argument(
+        "--lesson-scope",
+        choices=["goal", "workspace", "repository", "delivery_surface"],
+        default="goal",
+    )
+    project_reward.add_argument("--lesson-scope-key")
+    project_reward.add_argument("--lesson-supersedes", action="append", default=[])
+    project_reward.add_argument("--state-file")
+    project_reward.add_argument("--execute", action="store_true")
 
 
 def _read_stdin_events() -> list[object]:
@@ -67,6 +103,21 @@ def _read_stdin_events() -> list[object]:
 
 
 def _render(payload: dict[str, object]) -> str:
+    if payload.get("schema_version") == "lark_event_reward_projection_v0":
+        return "\n".join(
+            [
+                "# Lark Event Reward Projection",
+                "",
+                f"- ok: {payload.get('ok')}",
+                f"- execute: {payload.get('execute')}",
+                f"- goal_id: {payload.get('goal_id')}",
+                f"- reward_id: {payload.get('reward_id')}",
+                f"- reward_event_appended: {payload.get('reward_event_appended')}",
+                f"- reward_event_already_exists: {payload.get('reward_event_already_exists')}",
+                f"- active_state_written: {payload.get('active_state_written')}",
+                f"- acknowledged: {payload.get('acknowledged')}",
+            ]
+        ).rstrip() + "\n"
     lines = [
         "# Lark Event Inbox",
         "",
@@ -84,6 +135,8 @@ def _render(payload: dict[str, object]) -> str:
 def handle_lark_inbox_command(
     args: argparse.Namespace,
     *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
     output_format: Callable[..., str],
     print_payload: Callable,
 ) -> int | None:
@@ -103,11 +156,41 @@ def handle_lark_inbox_command(
                 message_ids=args.message_id,
                 execute=args.execute,
             )
-        else:
+        elif args.lark_inbox_command == "ingest":
             payload = ingest_lark_event_inbox(
                 project=args.project,
                 config_path=args.config,
                 events=_read_stdin_events(),
+                execute=args.execute,
+            )
+        else:
+            reward = compact_reward(
+                recorded_at=args.recorded_at,
+                decision=args.decision,
+                reward=args.reward,
+                reason_summary=args.reason_summary,
+                follow_up=args.follow_up,
+                lesson={
+                    "kind": args.lesson_kind,
+                    "summary": args.lesson_summary,
+                    "avoid": args.lesson_avoid,
+                    "prefer": args.lesson_prefer,
+                    "strength": args.lesson_strength,
+                    "scope": args.lesson_scope,
+                    "scope_key": args.lesson_scope_key,
+                    "supersedes": args.lesson_supersedes,
+                },
+            )
+            payload = project_lark_event_inbox_reward(
+                project=args.project,
+                config_path=args.config,
+                registry_path=registry_path,
+                runtime_root_override=runtime_root_arg,
+                goal_id=args.goal_id,
+                message_id=args.message_id,
+                reward=reward,
+                run_generated_at=args.run_generated_at,
+                state_file_override=Path(args.state_file).expanduser() if args.state_file else None,
                 execute=args.execute,
             )
     except (OSError, ValueError, json.JSONDecodeError) as exc:

--- a/loopx/cli_commands/project_lifecycle.py
+++ b/loopx/cli_commands/project_lifecycle.py
@@ -332,6 +332,37 @@ def register_project_lifecycle_commands(
         help="Public-safe phrase/action that future recommended_action should prefer. Repeatable.",
     )
     reward_parser.add_argument(
+        "--lesson-strength",
+        choices=["advisory", "required"],
+        default="advisory",
+        help="Whether the lesson is advisory guidance or a required operating constraint.",
+    )
+    reward_parser.add_argument(
+        "--lesson-scope",
+        choices=["goal", "workspace", "repository", "delivery_surface"],
+        default="goal",
+        help="Scope where the lesson applies.",
+    )
+    reward_parser.add_argument(
+        "--lesson-scope-key",
+        help="Optional public-safe scope identifier, such as a repository or delivery surface.",
+    )
+    reward_parser.add_argument(
+        "--lesson-supersedes",
+        action="append",
+        default=[],
+        help="Reward id superseded by this correction. Repeatable.",
+    )
+    reward_parser.add_argument(
+        "--source-kind",
+        choices=["direct", "github", "lark", "operator", "other"],
+        help="Optional feedback source kind; requires --source-event-ref.",
+    )
+    reward_parser.add_argument(
+        "--source-event-ref",
+        help="Local source event reference. Only its SHA-256 digest is persisted.",
+    )
+    reward_parser.add_argument(
         "--state-file",
         help="Active goal state path for optional summary writeback. Defaults to the registry goal state_file.",
     )
@@ -522,9 +553,15 @@ def handle_project_lifecycle_command(
                     "summary": args.lesson_summary,
                     "avoid": args.lesson_avoid,
                     "prefer": args.lesson_prefer,
+                    "strength": args.lesson_strength,
+                    "scope": args.lesson_scope,
+                    "scope_key": args.lesson_scope_key,
+                    "supersedes": args.lesson_supersedes,
                 }
                 if args.lesson_kind
                 else None,
+                source_kind=args.source_kind,
+                source_event_ref=args.source_event_ref,
             )
             payload = append_human_reward(
                 registry_path=registry_path,

--- a/loopx/control_plane/quota/reward_lessons.py
+++ b/loopx/control_plane/quota/reward_lessons.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..agents.agent_scope import _action_scope_tokens_from_text
+from .recent_runs import goal_latest_runs
+
+
+def recent_reward_lessons(
+    status_payload: dict[str, Any], *, goal_id: str
+) -> list[dict[str, Any]]:
+    lessons: list[dict[str, Any]] = []
+    run_history = (
+        status_payload.get("run_history")
+        if isinstance(status_payload.get("run_history"), dict)
+        else {}
+    )
+    for goal in run_history.get("goals") or []:
+        if not isinstance(goal, dict) or str(goal.get("id") or "") != goal_id:
+            continue
+        lessons.extend(
+            dict(lesson)
+            for lesson in (goal.get("active_reward_lessons") or [])
+            if isinstance(lesson, dict)
+        )
+        break
+    seen_reward_ids = {
+        str(lesson.get("reward_id") or "") for lesson in lessons if lesson.get("reward_id")
+    }
+    for run in goal_latest_runs(status_payload, goal_id=goal_id):
+        reward = run.get("human_reward") if isinstance(run.get("human_reward"), dict) else {}
+        lesson = reward.get("lesson") if isinstance(reward.get("lesson"), dict) else {}
+        if not lesson:
+            continue
+        reward_id = str(reward.get("reward_id") or "")
+        if reward_id and reward_id in seen_reward_ids:
+            continue
+        lessons.append(
+            {
+                "reward_id": reward_id or None,
+                "generated_at": run.get("generated_at"),
+                "decision": reward.get("decision"),
+                "reward": reward.get("reward"),
+                "kind": lesson.get("kind"),
+                "summary": lesson.get("summary"),
+                "strength": lesson.get("strength") or "advisory",
+                "scope": lesson.get("scope") or "goal",
+                "scope_key": lesson.get("scope_key"),
+                "avoid": lesson.get("avoid") if isinstance(lesson.get("avoid"), list) else [],
+                "prefer": lesson.get("prefer") if isinstance(lesson.get("prefer"), list) else [],
+            }
+        )
+    return lessons
+
+
+def reward_lesson_projection(
+    status_payload: dict[str, Any], *, goal_id: str
+) -> dict[str, Any] | None:
+    lessons = recent_reward_lessons(status_payload, goal_id=goal_id)
+    if not lessons:
+        return None
+    items = [
+        {
+            key: lesson.get(key)
+            for key in (
+                "reward_id",
+                "recorded_at",
+                "generated_at",
+                "kind",
+                "summary",
+                "strength",
+                "scope",
+                "scope_key",
+                "avoid",
+                "prefer",
+            )
+            if lesson.get(key) not in (None, [], "")
+        }
+        for lesson in lessons[:5]
+    ]
+    return {
+        "schema_version": "reward_lesson_projection_v0",
+        "source": "goal_reward_event_ledger",
+        "goal_id": goal_id,
+        "active_count": len(lessons),
+        "required_count": sum(
+            1 for lesson in lessons if lesson.get("strength") == "required"
+        ),
+        "items": items,
+        "application_evidence_required": any(
+            lesson.get("strength") == "required" for lesson in lessons
+        ),
+    }
+
+
+def reward_lesson_projection_warning(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+    recommended_action: str | None,
+) -> dict[str, Any] | None:
+    action = str(recommended_action or "").strip()
+    if not action:
+        return None
+    action_lower = action.lower()
+    action_tokens = _action_scope_tokens_from_text(action)
+    matches: list[dict[str, Any]] = []
+    for lesson in recent_reward_lessons(status_payload, goal_id=goal_id):
+        for avoid in lesson.get("avoid") or []:
+            avoid_text = str(avoid or "").strip()
+            if not avoid_text:
+                continue
+            avoid_tokens = _action_scope_tokens_from_text(avoid_text)
+            exact_match = avoid_text.lower() in action_lower
+            if not exact_match and not avoid_tokens:
+                continue
+            token_overlap = sorted(action_tokens & avoid_tokens)
+            if not exact_match and len(token_overlap) < min(2, len(avoid_tokens)):
+                continue
+            matches.append(
+                {
+                    "generated_at": lesson.get("generated_at"),
+                    "decision": lesson.get("decision"),
+                    "kind": lesson.get("kind"),
+                    "summary": lesson.get("summary"),
+                    "reward_id": lesson.get("reward_id"),
+                    "strength": lesson.get("strength") or "advisory",
+                    "scope": lesson.get("scope") or "goal",
+                    "avoid": avoid_text,
+                    "token_overlap": token_overlap[:5],
+                }
+            )
+    if not matches:
+        return None
+    return {
+        "schema_version": "reward_lesson_projection_warning_v0",
+        "source": "goal_reward_event_ledger",
+        "goal_id": goal_id,
+        "message": (
+            "recommended_action overlaps a recent human_reward lesson avoid rule; "
+            "rebase the route or update the affected todo/next action before continuing"
+        ),
+        "recommended_action": action,
+        "match_count": len(matches),
+        "matches": matches[:3],
+    }

--- a/loopx/control_plane/runtime/reward_events.py
+++ b/loopx/control_plane/runtime/reward_events.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+
+REWARD_EVENT_SCHEMA_VERSION = "user_reward_event_v0"
+REWARD_SOURCE_SCHEMA_VERSION = "user_reward_source_v0"
+REWARD_SOURCE_KINDS = {"direct", "github", "lark", "operator", "other"}
+
+
+def compact_reward_source(kind: str | None, raw_ref: str | None) -> dict[str, str] | None:
+    source_kind = str(kind or "").strip().lower()
+    source_ref = str(raw_ref or "").strip()
+    if not source_kind and not source_ref:
+        return None
+    if source_kind not in REWARD_SOURCE_KINDS:
+        raise ValueError(
+            "reward source kind must be one of: "
+            + ", ".join(sorted(REWARD_SOURCE_KINDS))
+        )
+    if not source_ref:
+        raise ValueError("reward source ref is required when source kind is set")
+    if len(source_ref) > 500:
+        raise ValueError("reward source ref must stay within 500 characters")
+    return {
+        "schema_version": REWARD_SOURCE_SCHEMA_VERSION,
+        "kind": source_kind,
+        "digest": "sha256:"
+        + hashlib.sha256(f"{source_kind}:{source_ref}".encode("utf-8")).hexdigest(),
+    }
+
+
+def reward_event_id(goal_id: str, reward: Mapping[str, Any]) -> str:
+    source = reward.get("source") if isinstance(reward.get("source"), Mapping) else {}
+    stable_source = str(source.get("digest") or "")
+    identity = stable_source or json.dumps(
+        {
+            key: reward.get(key)
+            for key in (
+                "recorded_at",
+                "decision",
+                "reward",
+                "reason_summary",
+                "follow_up",
+                "lesson",
+            )
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(f"{goal_id}\n{identity}".encode("utf-8")).hexdigest()[:16]
+    return f"reward_{digest}"
+
+
+def load_reward_events(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+    events: dict[str, dict[str, Any]] = {}
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            if not line.strip():
+                continue
+            try:
+                item = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(item, dict):
+                continue
+            if item.get("schema_version") != REWARD_EVENT_SCHEMA_VERSION:
+                continue
+            reward_id = str(item.get("reward_id") or "").strip()
+            if reward_id:
+                events.setdefault(reward_id, item)
+    return sorted(
+        events.values(),
+        key=lambda item: (str(item.get("recorded_at") or ""), str(item.get("reward_id") or "")),
+        reverse=True,
+    )
+
+
+def append_reward_event(
+    path: Path,
+    *,
+    goal_id: str,
+    run_generated_at: str,
+    reward: dict[str, Any],
+    dry_run: bool,
+) -> dict[str, Any]:
+    payload = dict(reward)
+    reward_id = str(payload.get("reward_id") or reward_event_id(goal_id, payload))
+    payload["reward_id"] = reward_id
+    existing = next(
+        (item for item in load_reward_events(path) if item.get("reward_id") == reward_id),
+        None,
+    )
+    if existing is not None:
+        return {
+            "path": str(path),
+            "reward_id": reward_id,
+            "record": existing,
+            "appended": False,
+            "already_exists": True,
+            "dry_run": dry_run,
+        }
+    record = {
+        "schema_version": REWARD_EVENT_SCHEMA_VERSION,
+        "reward_id": reward_id,
+        "goal_id": goal_id,
+        "run_generated_at": run_generated_at,
+        "recorded_at": payload.get("recorded_at"),
+        "human_reward": payload,
+    }
+    if not dry_run:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, ensure_ascii=False, separators=(",", ":")) + "\n")
+    return {
+        "path": str(path),
+        "reward_id": reward_id,
+        "record": record,
+        "appended": not dry_run,
+        "already_exists": False,
+        "dry_run": dry_run,
+    }
+
+
+def active_reward_lessons(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    superseded: set[str] = set()
+    active: list[dict[str, Any]] = []
+    for event in events:
+        reward_id = str(event.get("reward_id") or "")
+        reward = event.get("human_reward") if isinstance(event.get("human_reward"), dict) else {}
+        lesson = reward.get("lesson") if isinstance(reward.get("lesson"), dict) else {}
+        if not reward_id or not lesson or reward_id in superseded:
+            continue
+        active.append(
+            {
+                "reward_id": reward_id,
+                "recorded_at": event.get("recorded_at"),
+                "decision": reward.get("decision"),
+                "reward": reward.get("reward"),
+                "kind": lesson.get("kind"),
+                "summary": lesson.get("summary"),
+                "strength": lesson.get("strength") or "advisory",
+                "scope": lesson.get("scope") or "goal",
+                "scope_key": lesson.get("scope_key"),
+                "avoid": lesson.get("avoid") if isinstance(lesson.get("avoid"), list) else [],
+                "prefer": lesson.get("prefer") if isinstance(lesson.get("prefer"), list) else [],
+            }
+        )
+        superseded.update(
+            str(value)
+            for value in (lesson.get("supersedes") or [])
+            if str(value).startswith("reward_")
+        )
+    return active

--- a/loopx/control_plane/runtime/run_compaction.py
+++ b/loopx/control_plane/runtime/run_compaction.py
@@ -4,12 +4,14 @@ from typing import Any, Callable, Optional
 
 
 HUMAN_REWARD_COMPACT_FIELDS = (
+    "reward_id",
     "recorded_at",
     "decision",
     "reward",
     "reason_summary",
     "follow_up",
     "lesson",
+    "source",
 )
 OPERATOR_GATE_COMPACT_FIELDS = (
     "recorded_at",
@@ -108,7 +110,17 @@ def compact_human_reward(reward: Any) -> dict[str, Any] | None:
     if isinstance(lesson, dict):
         compact["lesson"] = {
             field: lesson[field]
-            for field in ("schema_version", "kind", "summary", "avoid", "prefer")
+            for field in (
+                "schema_version",
+                "kind",
+                "summary",
+                "strength",
+                "scope",
+                "scope_key",
+                "supersedes",
+                "avoid",
+                "prefer",
+            )
             if field in lesson
         }
     return compact or None

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -511,6 +511,37 @@ def _interaction_required_reads(payload: dict[str, Any]) -> list[dict[str, Any]]
     return result
 
 
+def _interaction_operating_lessons(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    projection = (
+        payload.get("reward_lesson_projection")
+        if isinstance(payload.get("reward_lesson_projection"), dict)
+        else {}
+    )
+    result: list[dict[str, Any]] = []
+    for item in projection.get("items") or []:
+        if not isinstance(item, dict):
+            continue
+        summary = protocol_action_text(item.get("summary"), limit=240)
+        if not summary:
+            continue
+        compact = {
+            key: item.get(key)
+            for key in (
+                "reward_id",
+                "kind",
+                "strength",
+                "scope",
+                "scope_key",
+                "avoid",
+                "prefer",
+            )
+            if item.get(key) not in (None, [], "")
+        }
+        compact["summary"] = summary
+        result.append(compact)
+    return result[:5]
+
+
 def _interaction_spend_policy(
     execution_obligation: dict[str, Any],
     heartbeat_recommendation: dict[str, Any],
@@ -830,6 +861,7 @@ def build_interaction_contract(payload: dict[str, Any]) -> dict[str, Any]:
     )
     spend_after_validation = _interaction_spend_after_validation(mode)
     required_reads = _interaction_required_reads(payload)
+    operating_lessons = _interaction_operating_lessons(payload)
 
     contract = {
         "schema_version": INTERACTION_CONTRACT_SCHEMA_VERSION,
@@ -855,6 +887,11 @@ def build_interaction_contract(payload: dict[str, Any]) -> dict[str, Any]:
         ),
     }
     _attach_interaction_required_reads(contract, required_reads)
+    if operating_lessons:
+        contract["agent_channel"]["operating_lessons"] = operating_lessons
+        contract["agent_channel"]["operating_lesson_policy"] = (
+            "required lessons are hard operating constraints; advisory lessons are preferences"
+        )
     _attach_interaction_vision_continuation_audit(contract, payload)
     if _interaction_fallback_policy_required(payload, mode=mode):
         contract["fallback_policy"] = {"do_not_cancel_on_block": True}

--- a/loopx/feedback.py
+++ b/loopx/feedback.py
@@ -9,6 +9,10 @@ from typing import Any
 from .history import load_index, load_registry
 from .paths import resolve_runtime_root
 from .registry import registry_goals, resolve_state_file
+from .control_plane.runtime.reward_events import (
+    append_reward_event,
+    compact_reward_source,
+)
 
 
 REWARD_VALUES = {"positive", "negative", "mixed", "neutral"}
@@ -49,12 +53,14 @@ LOCAL_CONTROL_TEXT_PATTERNS = (
     re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b"),
 )
 HUMAN_REWARD_FIELDS = (
+    "reward_id",
     "recorded_at",
     "decision",
     "reward",
     "reason_summary",
     "follow_up",
     "lesson",
+    "source",
 )
 RUN_OVERLAY_FIELDS = (
     "generated_at",
@@ -139,6 +145,8 @@ def compact_reward(
     reason_summary: str,
     follow_up: str | None,
     lesson: dict[str, Any] | None = None,
+    source_kind: str | None = None,
+    source_event_ref: str | None = None,
 ) -> dict[str, Any]:
     if reward not in REWARD_VALUES:
         raise ValueError(f"reward must be one of: {', '.join(sorted(REWARD_VALUES))}")
@@ -155,6 +163,9 @@ def compact_reward(
         payload["follow_up"] = follow_up
     if lesson:
         payload["lesson"] = compact_reward_lesson(lesson)
+    source = compact_reward_source(source_kind, source_event_ref)
+    if source:
+        payload["source"] = source
     return payload
 
 
@@ -166,11 +177,40 @@ def compact_reward_lesson(lesson: dict[str, Any]) -> dict[str, Any]:
     if not summary:
         raise ValueError("lesson summary is required when lesson metadata is provided")
     validate_public_safe_text("lesson summary", summary)
+    strength = str(lesson.get("strength") or "advisory").strip()
+    if strength not in {"advisory", "required"}:
+        raise ValueError("lesson strength must be advisory or required")
+    scope = str(lesson.get("scope") or "goal").strip()
+    if scope not in {"goal", "workspace", "repository", "delivery_surface"}:
+        raise ValueError(
+            "lesson scope must be goal, workspace, repository, or delivery_surface"
+        )
+    scope_key = str(lesson.get("scope_key") or "").strip()
+    validate_public_safe_text("lesson scope_key", scope_key)
+    supersedes: list[str] = []
+    for raw_value in lesson.get("supersedes") or []:
+        value = str(raw_value or "").strip()
+        if not re.fullmatch(r"reward_[0-9a-f]{16}", value):
+            raise ValueError("lesson supersedes values must be reward_<16 hex> ids")
+        if value not in supersedes:
+            supersedes.append(value)
+    advanced_contract = any(
+        key in lesson for key in ("strength", "scope", "scope_key", "supersedes")
+    )
     payload: dict[str, Any] = {
-        "schema_version": "human_reward_lesson_v0",
+        "schema_version": (
+            "human_reward_lesson_v1" if advanced_contract else "human_reward_lesson_v0"
+        ),
         "kind": kind,
         "summary": summary,
     }
+    if advanced_contract:
+        payload["strength"] = strength
+        payload["scope"] = scope
+        if scope_key:
+            payload["scope_key"] = scope_key
+        if supersedes:
+            payload["supersedes"] = supersedes[:5]
     for field in ("avoid", "prefer"):
         raw_items = lesson.get(field) or []
         if isinstance(raw_items, str):
@@ -239,7 +279,7 @@ def build_reward_coordination(
     summary = (
         f"{verb}目标 `{goal_id}` 的 run `{run_generated_at}` "
         f"human_reward={reward_value}，decision=`{decision}`。"
-        "权威来源是 run-bound `human_reward` overlay；"
+        "权威来源是 goal-scoped reward event ledger；run-bound overlay 仅作兼容摘要；"
         "active state 只摘要这个指针和下一步。"
     )
     if reason_summary:
@@ -254,7 +294,8 @@ def build_reward_coordination(
             f"{lesson.get('summary')}"
         )
     visibility = {
-        "source_of_truth": "run_bound_human_reward_overlay",
+        "source_of_truth": "goal_reward_event_ledger",
+        "run_overlay_role": "compatibility_annotation",
         "history_command": f"loopx history --goal-id {goal_id} --limit 3",
         "active_state_role": "summary_only",
         "review_packet_role": "optional_handoff_only",
@@ -392,6 +433,23 @@ def append_human_reward(
     if missing_paths:
         raise ValueError(f"selected run is missing required index path fields: {', '.join(missing_paths)}")
 
+    reward_event_path = runtime_root / "goals" / goal_id / "reward-events" / "index.jsonl"
+    reward_event = append_reward_event(
+        reward_event_path,
+        goal_id=goal_id,
+        run_generated_at=str(selected.get("generated_at") or ""),
+        reward=reward,
+        dry_run=dry_run,
+    )
+    event_record = reward_event.get("record") if isinstance(reward_event.get("record"), dict) else {}
+    event_reward = (
+        event_record.get("human_reward")
+        if isinstance(event_record.get("human_reward"), dict)
+        else reward
+    )
+    reward = dict(event_reward)
+    reward["reward_id"] = reward_event["reward_id"]
+
     index_record = {
         field: selected[field]
         for field in RUN_OVERLAY_FIELDS
@@ -433,14 +491,22 @@ def append_human_reward(
         dry_run=dry_run,
     )
 
-    if not dry_run:
+    existing_overlay = (
+        selected.get("human_reward")
+        if isinstance(selected.get("human_reward"), dict)
+        else {}
+    )
+    overlay_already_present = existing_overlay.get("reward_id") == reward_event["reward_id"]
+    overlay_written = False
+    if not dry_run and not overlay_already_present:
         index_path.parent.mkdir(parents=True, exist_ok=True)
         with index_path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
-        if state_file_to_write and state_text_to_write is not None:
-            state_file_to_write.write_text(state_text_to_write, encoding="utf-8")
-            active_state_update["written"] = True
-            active_state_update["would_write"] = False
+        overlay_written = True
+    if not dry_run and state_file_to_write and state_text_to_write is not None:
+        state_file_to_write.write_text(state_text_to_write, encoding="utf-8")
+        active_state_update["written"] = True
+        active_state_update["would_write"] = False
 
     return {
         "ok": True,
@@ -452,10 +518,16 @@ def append_human_reward(
         "dry_run": dry_run,
         "selected_run": selected_run,
         "human_reward": index_record["human_reward"],
+        "reward_event_ledger": {
+            key: reward_event.get(key)
+            for key in ("path", "reward_id", "appended", "already_exists", "dry_run")
+        },
+        "overlay_written": overlay_written,
+        "overlay_already_present": overlay_already_present,
         **coordination,
         "active_state_update": active_state_update,
         "index_record": index_record,
-        "appended": not dry_run,
+        "appended": bool(reward_event.get("appended") or overlay_written),
     }
 
 
@@ -555,6 +627,7 @@ def render_reward_markdown(payload: dict[str, Any]) -> str:
                 "",
                 "## Project-Agent Visibility",
                 f"- source_of_truth: `{visibility.get('source_of_truth')}`",
+                f"- run_overlay_role: `{visibility.get('run_overlay_role')}`",
                 f"- history_command: `{visibility.get('history_command')}`",
                 f"- active_state_role: `{visibility.get('active_state_role')}`",
                 f"- review_packet_role: `{visibility.get('review_packet_role')}`",

--- a/loopx/history.py
+++ b/loopx/history.py
@@ -9,6 +9,10 @@ from typing import Any, Callable
 from .authority import goal_authority_registry_summary
 from .control_plane import compact_control_plane_policy
 from .control_plane.runtime.time import now_local_iso
+from .control_plane.runtime.reward_events import (
+    active_reward_lessons,
+    load_reward_events,
+)
 from .control_plane.runtime.run_index_duplicates import (
     classify_index_duplicate_records,
     duplicate_repair_decision,
@@ -748,6 +752,11 @@ def collect_history(
         include_runtime_goals=include_runtime_goals,
     ):
         index_path = runtime_root / "goals" / current_goal_id / "runs" / "index.jsonl"
+        reward_event_path = (
+            runtime_root / "goals" / current_goal_id / "reward-events" / "index.jsonl"
+        )
+        reward_events = load_reward_events(reward_event_path)
+        active_lessons = active_reward_lessons(reward_events)
         runs, raw_count = load_index(index_path)
         runs = [
             run
@@ -789,6 +798,11 @@ def collect_history(
             "unique_runs": len(runs),
             "latest_status_run": latest_status_run(runs),
             "latest_runs": latest_runs_with_agent_context(runs, limit=limit),
+            "reward_event_path": str(reward_event_path),
+            "reward_event_count": len(reward_events),
+            "reward_events": reward_events[: max(1, limit)],
+            "active_reward_lesson_count": len(active_lessons),
+            "active_reward_lessons": active_lessons[: max(1, limit)],
         }
         if registry_member:
             for field in REGISTRY_ATTENTION_FIELDS:

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -7,7 +7,6 @@ from typing import Any
 
 from .control_plane.agents.agent_scope import (
     AgentScopeFrontierAction,
-    _action_scope_tokens_from_text,
     _agent_lane_frontier_hint,
     _agent_scope_deferred_resume_candidates,
     _agent_scope_frontier_action,
@@ -75,8 +74,11 @@ from .control_plane.quota.monitor_poll import (
     render_quota_monitor_poll_markdown,
 )
 from .control_plane.quota.recent_runs import (
-    goal_latest_runs as _goal_latest_runs,
     recent_external_monitor_observation_unchanged as _recent_external_monitor_observation_unchanged,
+)
+from .control_plane.quota.reward_lessons import (
+    reward_lesson_projection as _reward_lesson_projection,
+    reward_lesson_projection_warning as _reward_lesson_projection_warning,
 )
 from .control_plane.quota.markdown import (
     render_quota_markdown,
@@ -1133,77 +1135,6 @@ def _quota_plan_items(plan: dict[str, Any]) -> list[dict[str, Any]]:
     return items
 
 
-def _recent_reward_lessons(status_payload: dict[str, Any], *, goal_id: str) -> list[dict[str, Any]]:
-    lessons: list[dict[str, Any]] = []
-    for run in _goal_latest_runs(status_payload, goal_id=goal_id):
-        reward = run.get("human_reward") if isinstance(run.get("human_reward"), dict) else {}
-        lesson = reward.get("lesson") if isinstance(reward.get("lesson"), dict) else {}
-        if not lesson:
-            continue
-        lessons.append(
-            {
-                "generated_at": run.get("generated_at"),
-                "decision": reward.get("decision"),
-                "reward": reward.get("reward"),
-                "kind": lesson.get("kind"),
-                "summary": lesson.get("summary"),
-                "avoid": lesson.get("avoid") if isinstance(lesson.get("avoid"), list) else [],
-                "prefer": lesson.get("prefer") if isinstance(lesson.get("prefer"), list) else [],
-            }
-        )
-    return lessons
-
-
-def _reward_lesson_projection_warning(
-    status_payload: dict[str, Any],
-    *,
-    goal_id: str,
-    recommended_action: str | None,
-) -> dict[str, Any] | None:
-    action = str(recommended_action or "").strip()
-    if not action:
-        return None
-    action_lower = action.lower()
-    action_tokens = _action_scope_tokens_from_text(action)
-    matches: list[dict[str, Any]] = []
-    for lesson in _recent_reward_lessons(status_payload, goal_id=goal_id):
-        for avoid in lesson.get("avoid") or []:
-            avoid_text = str(avoid or "").strip()
-            if not avoid_text:
-                continue
-            avoid_tokens = _action_scope_tokens_from_text(avoid_text)
-            exact_match = avoid_text.lower() in action_lower
-            if not exact_match and not avoid_tokens:
-                continue
-            token_overlap = sorted(action_tokens & avoid_tokens)
-            if not exact_match and len(token_overlap) < min(2, len(avoid_tokens)):
-                continue
-            matches.append(
-                {
-                    "generated_at": lesson.get("generated_at"),
-                    "decision": lesson.get("decision"),
-                    "kind": lesson.get("kind"),
-                    "summary": lesson.get("summary"),
-                    "avoid": avoid_text,
-                    "token_overlap": token_overlap[:5],
-                }
-            )
-    if not matches:
-        return None
-    return {
-        "schema_version": "reward_lesson_projection_warning_v0",
-        "source": "run_history.human_reward.lesson",
-        "goal_id": goal_id,
-        "message": (
-            "recommended_action overlaps a recent human_reward lesson avoid rule; "
-            "rebase the route or update the affected todo/next action before continuing"
-        ),
-        "recommended_action": action,
-        "match_count": len(matches),
-        "matches": matches[:3],
-    }
-
-
 def _registry_goal_by_id(status_payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
     registry_value = status_payload.get("registry")
     if not registry_value:
@@ -2131,6 +2062,12 @@ def build_quota_should_run(
         promotion_warning = _promotion_readiness_warning(status_payload)
         if promotion_warning:
             payload["promotion_readiness_warning"] = promotion_warning
+        reward_lesson_projection = _reward_lesson_projection(
+            status_payload,
+            goal_id=safe_goal_id,
+        )
+        if reward_lesson_projection:
+            payload["reward_lesson_projection"] = reward_lesson_projection
         reward_lesson_warning = _reward_lesson_projection_warning(
             status_payload,
             goal_id=safe_goal_id,

--- a/tests/test_user_reward_event_projection.py
+++ b/tests/test_user_reward_event_projection.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from loopx.capabilities.lark.event_inbox import (
+    inspect_lark_event_inbox,
+    project_lark_event_inbox_reward,
+)
+from loopx.feedback import compact_reward
+from loopx.control_plane.runtime.reward_events import (
+    active_reward_lessons,
+    append_reward_event,
+    load_reward_events,
+)
+from loopx.history import collect_history
+from loopx.quota import build_quota_should_run
+
+
+GOAL_ID = "user-reward-projection-goal"
+RUN_AT = "2026-07-12T00:00:00+00:00"
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    project = tmp_path / "project"
+    runtime = tmp_path / "runtime"
+    inbox = project / ".loopx" / "inbox" / "feedback"
+    config = project / ".loopx" / "config" / "lark-inbox.json"
+    inbox.mkdir(parents=True)
+    config.parent.mkdir(parents=True)
+    config.write_text(
+        json.dumps(
+            {
+                "schema_version": "lark_event_inbox_config_v0",
+                "enabled": True,
+                "inbox_dir": ".loopx/inbox/feedback",
+                "capture_scope": "configured_chat_all",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (inbox / "feedback.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "lark_event_inbox_event_v0",
+                "event_id": "event-feedback-1",
+                "message_id": "om_feedback_1",
+                "create_time": "2026-07-12T00:01:00Z",
+                "content": "raw source content must not enter reward state",
+            }
+        ),
+        encoding="utf-8",
+    )
+    state = project / "ACTIVE_GOAL_STATE.md"
+    state.write_text("# Goal\n\n## Progress Ledger\n\n", encoding="utf-8")
+    run_dir = runtime / "goals" / GOAL_ID / "runs"
+    run_dir.mkdir(parents=True)
+    run_json = run_dir / "run.json"
+    run_md = run_dir / "run.md"
+    run_json.write_text("{}\n", encoding="utf-8")
+    run_md.write_text("# run\n", encoding="utf-8")
+    (run_dir / "index.jsonl").write_text(
+        json.dumps(
+            {
+                "generated_at": RUN_AT,
+                "goal_id": GOAL_ID,
+                "classification": "fixture_run",
+                "recommended_action": "Publish a ready pull request before memory acceptance.",
+                "json_path": str(run_json),
+                "markdown_path": str(run_md),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    registry = project / ".loopx" / "registry.json"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text(
+        json.dumps(
+            {
+                "runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "repo": str(project),
+                        "state_file": "ACTIVE_GOAL_STATE.md",
+                        "status": "eligible",
+                        "adapter": {"kind": "fixture", "status": "connected-read-only"},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return project, runtime, registry, config
+
+
+def _status_payload(history: dict) -> dict:
+    action = "Publish a ready pull request before memory acceptance."
+    todo = {
+        "todo_id": "todo_reward_projection",
+        "text": action,
+        "role": "agent",
+        "status": "open",
+        "priority": "P0",
+        "task_class": "advancement_task",
+    }
+    summary = {
+        "schema_version": "todo_summary_v0",
+        "source_section": "Agent Todo",
+        "total_count": 1,
+        "open_count": 1,
+        "done_count": 0,
+        "first_open_items": [todo],
+    }
+    return {
+        "ok": True,
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": GOAL_ID,
+                    "status": "eligible",
+                    "waiting_on": "codex",
+                    "source": "project_asset",
+                    "recommended_action": action,
+                    "quota": {
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 10,
+                        "spent_slots": 0,
+                        "state": "eligible",
+                    },
+                    "project_asset": {"next_action": action, "agent_todos": summary},
+                }
+            ]
+        },
+        "run_history": history,
+    }
+
+
+def test_lark_reward_projection_is_idempotent_and_quota_visible(tmp_path: Path) -> None:
+    project, runtime, registry, config = _fixture(tmp_path)
+    reward = compact_reward(
+        recorded_at="2026-07-12T00:02:00+00:00",
+        decision="owner_constraint",
+        reward="negative",
+        reason_summary="Publication must wait for the memory acceptance gate.",
+        follow_up="Keep new pull requests in draft state.",
+        lesson={
+            "kind": "safety_boundary",
+            "summary": "New pull requests must remain drafts until memory acceptance closes.",
+            "strength": "required",
+            "scope": "workspace",
+            "scope_key": "example-project",
+            "avoid": ["Publish a ready pull request"],
+            "prefer": ["Create a draft pull request"],
+        },
+    )
+    first = project_lark_event_inbox_reward(
+        project=project,
+        config_path=config,
+        registry_path=registry,
+        runtime_root_override=str(runtime),
+        goal_id=GOAL_ID,
+        message_id="om_feedback_1",
+        reward=reward,
+        execute=True,
+    )
+    assert first["reward_event_appended"] is True
+    assert first["acknowledged"] is True
+    assert inspect_lark_event_inbox(project=project, config_path=config)["pending_count"] == 0
+
+    second = project_lark_event_inbox_reward(
+        project=project,
+        config_path=config,
+        registry_path=registry,
+        runtime_root_override=str(runtime),
+        goal_id=GOAL_ID,
+        message_id="om_feedback_1",
+        reward=reward,
+        execute=True,
+    )
+    assert second["reward_event_already_exists"] is True
+    ledger = runtime / "goals" / GOAL_ID / "reward-events" / "index.jsonl"
+    text = ledger.read_text(encoding="utf-8")
+    assert len(text.splitlines()) == 1
+    assert "om_feedback_1" not in text
+    assert "raw source content" not in text
+
+    history = collect_history(
+        registry_path=registry,
+        runtime_root=runtime,
+        goal_id=GOAL_ID,
+        limit=10,
+    )
+    goal = history["goals"][0]
+    assert goal["reward_event_count"] == 1
+    assert goal["active_reward_lessons"][0]["strength"] == "required"
+
+    quota = build_quota_should_run(_status_payload(history), goal_id=GOAL_ID)
+    projection = quota["reward_lesson_projection"]
+    assert projection["required_count"] == 1
+    assert quota["reward_lesson_projection_warning"]["match_count"] == 1
+    lessons = quota["interaction_contract"]["agent_channel"]["operating_lessons"]
+    assert lessons[0]["strength"] == "required"
+
+
+def test_new_reward_can_supersede_an_older_lesson(tmp_path: Path) -> None:
+    ledger = tmp_path / "reward-events.jsonl"
+    first_reward = compact_reward(
+        recorded_at="2026-07-12T00:00:00+00:00",
+        decision="initial_preference",
+        reward="positive",
+        reason_summary="Initial preference.",
+        follow_up=None,
+        lesson={
+            "kind": "operating_rule",
+            "summary": "Use the initial delivery format.",
+            "strength": "advisory",
+            "scope": "workspace",
+        },
+        source_kind="direct",
+        source_event_ref="initial-preference",
+    )
+    first = append_reward_event(
+        ledger,
+        goal_id=GOAL_ID,
+        run_generated_at=RUN_AT,
+        reward=first_reward,
+        dry_run=False,
+    )
+    correction = compact_reward(
+        recorded_at="2026-07-12T00:01:00+00:00",
+        decision="corrected_preference",
+        reward="mixed",
+        reason_summary="The owner replaced the initial format.",
+        follow_up=None,
+        lesson={
+            "kind": "operating_rule",
+            "summary": "Use the corrected delivery format.",
+            "strength": "required",
+            "scope": "workspace",
+            "supersedes": [first["reward_id"]],
+        },
+        source_kind="direct",
+        source_event_ref="corrected-preference",
+    )
+    append_reward_event(
+        ledger,
+        goal_id=GOAL_ID,
+        run_generated_at=RUN_AT,
+        reward=correction,
+        dry_run=False,
+    )
+    active = active_reward_lessons(load_reward_events(ledger))
+    assert len(active) == 1
+    assert active[0]["summary"] == "Use the corrected delivery format."
+    assert active[0]["strength"] == "required"


### PR DESCRIPTION
## 动机

LoopX 已能保存 run-bound human reward，也能将 Lark 消息落入本地 inbox；但两者之间缺少可靠闭环。多个反馈若指向同一 run，旧 overlay 读模型只能保留一个；消息 ACK 与 reward 写入也由 agent 手工协调，容易出现反馈已读却未成为后续约束的问题。

## 改动思路

把 user reward 建模为 goal-scoped append-only event ledger，同时保留原 run overlay 作为兼容摘要。来源只持久化类型和 SHA-256 digest；lesson 增加 advisory/required、作用域和 supersedes。quota 将活跃 lesson 投影进 interaction contract，供下一轮 agent 直接执行。

## 具体改动

- 新增 user_reward_event_v0 账本：稳定 reward id、来源摘要、幂等追加和 lesson supersession。
- 扩展 loopx reward：支持 required/advisory、goal/workspace/repository/delivery_surface scope、scope key、supersedes 与 hash-only source ref。
- 新增通用 loopx lark-inbox project-reward：先写 reward event 和 active-state 摘要，再 ACK；重试不会重复。
- history 暴露 reward event 与 active lesson；quota/interaction contract 投影 operating_lessons。
- 保留 human_reward_lesson_v0 与 run-bound overlay 兼容路径。
- 更新 reward/getting-started/status 合同文档。

## 验证

- tests/test_user_reward_event_projection.py：2 passed，覆盖 Lark 原子投影、重试幂等、原始 message id/正文不落 reward ledger、required lesson 可见与 supersession。
- reward lesson、Lark inbox、reward direct-write 三个既有 smoke 通过。
- loopx canary premerge --from-git-diff：17/17 通过；包含 control-plane、interaction、quota、line-budget、public-boundary 与 canary-runner。
- 第一次 canary 发现 quota.py 超出行数预算；已将 lesson 读模型抽到 control_plane/quota/reward_lessons.py，未放宽预算。

## 对主干的风险与未覆盖面

- history/status 会读取 goal 的 reward-event ledger；当前按本地小型控制面账本设计，尚未加入大规模压缩/分片。
- required lesson 已成为 interaction contract 中的硬运行约束，但本 PR 不替代 goal boundary、todo 或 operator gate；外部权限仍必须由原控制面负责。
- OpenViking 用户偏好记忆写入/召回不在本 PR 内；它是 reward lesson 之后的可选记忆 sink，失败时不得削弱 LoopX 硬约束。

本 PR 按当前 owner gate 保持 Draft，不自动合并。