### PR TITLE
fix(quota): preserve delivery attribution across neutral events

### DIFF
--- a/examples/control_plane/quota-spend-agent-identity-smoke.py
+++ b/examples/control_plane/quota-spend-agent-identity-smoke.py
@@ -19,6 +19,9 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.control_plane.work_items.interaction_contract import interaction_next_cli_actions  # noqa: E402
+from loopx.control_plane.quota.slot_accounting import (  # noqa: E402
+    _latest_unspent_accountable_delivery_run,
+)
 from loopx.quota import build_quota_monitor_poll_event, build_quota_slot_spend_event  # noqa: E402
 
 
@@ -144,6 +147,75 @@ def assert_delivery_completion_spend_preserves_requested_agent_id(agent_id: str)
     assert "validated delivery" in event["health_check"], event
 
 
+def assert_quota_neutral_events_do_not_hide_same_agent_delivery(agent_id: str) -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-quota-spend-neutral-events-") as tmp:
+        runtime = Path(tmp)
+        goal_id = "neutral-events-goal"
+        index_path = runtime / "goals" / goal_id / "runs" / "index.jsonl"
+        index_path.parent.mkdir(parents=True, exist_ok=True)
+        delivery = {
+            "generated_at": "2026-01-01T00:00:00+00:00",
+            "classification": "validated_delivery_fixture",
+            "delivery_outcome": "outcome_progress",
+            "agent_id": agent_id,
+        }
+        neutral_runs = [
+            delivery,
+            {
+                "generated_at": "2026-01-01T00:01:00+00:00",
+                "classification": "quota_monitor_poll",
+                "delivery_outcome": "surface_only",
+                "material_change": False,
+                "agent_id": agent_id,
+            },
+            {
+                "generated_at": "2026-01-01T00:02:00+00:00",
+                "classification": "quota_scheduler_ack",
+                "agent_id": agent_id,
+            },
+        ]
+        index_path.write_text(
+            "".join(json.dumps(row) + "\n" for row in neutral_runs),
+            encoding="utf-8",
+        )
+        selected = _latest_unspent_accountable_delivery_run(
+            runtime, goal_id, agent_id=agent_id
+        )
+        assert selected == delivery, selected
+
+        material_monitor = {
+            "generated_at": "2026-01-01T00:03:00+00:00",
+            "classification": "quota_monitor_poll",
+            "delivery_outcome": "outcome_progress",
+            "material_change": True,
+            "agent_id": agent_id,
+        }
+        with index_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(material_monitor) + "\n")
+        selected = _latest_unspent_accountable_delivery_run(
+            runtime, goal_id, agent_id=agent_id
+        )
+        assert selected == material_monitor, selected
+
+        with index_path.open("a", encoding="utf-8") as handle:
+            handle.write(
+                json.dumps(
+                    {
+                        "generated_at": "2026-01-01T00:04:00+00:00",
+                        "classification": "quota_slot_spent",
+                        "agent_id": agent_id,
+                    }
+                )
+                + "\n"
+            )
+        assert (
+            _latest_unspent_accountable_delivery_run(
+                runtime, goal_id, agent_id=agent_id
+            )
+            is None
+        )
+
+
 def main() -> int:
     fixture = load_quota_plan_fixture()
     agent_id = fixture.SCOPED_AGENT_ID
@@ -151,6 +223,7 @@ def main() -> int:
     assert_monitor_poll_event_carries_agent_id(agent_id)
     assert_monitor_poll_next_cli_action_preserves_agent_id(agent_id)
     assert_delivery_completion_spend_preserves_requested_agent_id(agent_id)
+    assert_quota_neutral_events_do_not_hide_same_agent_delivery(agent_id)
 
     with tempfile.TemporaryDirectory(prefix="loopx-quota-spend-agent-identity-") as tmp:
         root = Path(tmp)

--- a/loopx/control_plane/quota/slot_accounting.py
+++ b/loopx/control_plane/quota/slot_accounting.py
@@ -7,6 +7,7 @@ from typing import Any, Callable
 
 from .decision_summary import compact_quota_decision, quota_decision_agent_id
 from .monitor_poll import QUOTA_MONITOR_POLL_CLASSIFICATION
+from .scheduler_ack import QUOTA_SCHEDULER_ACK_CLASSIFICATION
 from .spend_sources import DEFAULT_SLOT_SPEND_SOURCE, VALID_SLOT_SPEND_SOURCES
 from ..runtime.time import now_local_iso
 from ..runtime.run_artifacts import run_file_stem, unique_run_artifact_paths
@@ -111,7 +112,12 @@ def _latest_unspent_accountable_delivery_run(
     *,
     agent_id: str | None = None,
 ) -> dict[str, Any] | None:
-    """Return the latest run only when it is a delivery that still needs accounting."""
+    """Return the latest same-agent delivery that still needs accounting.
+
+    Unchanged monitor polls and scheduler acknowledgements are quota-neutral.
+    They may occur after validation and before accounting, so they must not
+    hide the accountable run. Other non-delivery events remain fail closed.
+    """
 
     safe_agent_id = normalize_todo_claimed_by(agent_id)
     for run in reversed(_load_goal_run_index_records(runtime_root, goal_id)):
@@ -127,7 +133,9 @@ def _latest_unspent_accountable_delivery_run(
             classification == QUOTA_MONITOR_POLL_CLASSIFICATION
             and run.get("material_change") is not True
         ):
-            return None
+            continue
+        if classification == QUOTA_SCHEDULER_ACK_CLASSIFICATION:
+            continue
         delivery_outcome = normalize_delivery_outcome(run.get("delivery_outcome"))
         if delivery_outcome in ACCOUNTABLE_DELIVERY_OUTCOMES:
             return run


### PR DESCRIPTION
## 动机

`quota spend-slot --agent-id` 会从 run index 反向寻找当前 agent 最近一次尚未记账的 accountable delivery。当前实现遇到无变化的 `quota_monitor_poll` 就立即停止，因此正常的 `refresh-state → monitor-poll → spend-slot` 顺序会产生一条缺少 `delivery_run_*` 归因的 spend event。

## 改动思路

只把两类明确 quota-neutral 的事件当作可跨越记录：

- `quota_monitor_poll` 且 `material_change != true`；
- `quota_scheduler_ack`。

material monitor 仍可作为 accountable delivery；同 agent 的既有 spend 仍阻止重复记账；其他未知非 delivery 事件继续 fail closed。

## 关键逻辑

```text
scan same-agent runs newest → oldest
  spent            => stop, already accounted
  unchanged poll   => continue
  scheduler ack    => continue
  accountable run  => attribute spend to it
  anything else    => stop, fail closed
```

## 验证

- `quota-spend-agent-identity-smoke.py`：通过；新增 delivery → unchanged poll → scheduler ack → spend lookup 回归，并覆盖 material poll 与 duplicate-spend 边界；
- Ruff check：通过；
- Python compile、`git diff --check`：通过；
- quick premerge gate：4 direct + 3 catalog + 1 public-boundary checks 全部通过；
- standard canary：4 catalog checks 与 8 个 risk-profile checks 均逐项通过；
- repository line-budget smoke：通过；
- public/private boundary：clean。

当前 Ruff formatter 会同时重排这两个历史文件，且 `origin/main` 对同样的 format check 也失败，因此没有提交整文件格式化噪声。

## 对主干的风险与未覆盖

风险集中在 quota attribution 的反向扫描边界。补丁没有扩大 accountable delivery 集合，也没有跨越未知事件；只允许两个已有、明确不消耗配额的事件不遮挡前一个 delivery。未修改 quota 数值、scheduler 策略、monitor 状态或 CLI schema。
