### PR TITLE
feat(preference): add thin provider-neutral recall hook

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -587,6 +587,10 @@ revision and focused smokes, not the pilot narrative, remain authoritative.
 - rolling-default-branch OpenViking retrieval, one fresh-issue measured
   dogfood, and explicit reusable-knowledge writeback with honest
   decision-influence accounting;
+- optional `semantic-preference` recall before reviewer-facing PR description
+  work. Issue-fix owns the `issue_fix.pr_description` query and how results
+  influence the description; the generic hook only returns bounded provider
+  results and a stateless compact receipt for existing evidence/state writeback;
 - LoopX todo/quota/monitor/Kanban integration through the host agent.
 
 ### Next stage

--- a/docs/capabilities/issue-fix/README.zh-CN.md
+++ b/docs/capabilities/issue-fix/README.zh-CN.md
@@ -561,6 +561,9 @@ smoke，而不是 pilot 叙事本身。
 - issue/outcome Kanban、repository snapshot、可归因 impact metric 与 `Monthly Impact`；
 - rolling 默认分支 OpenViking retrieval、一次 fresh-issue 实测、显式
   reusable-knowledge writeback 与诚实的 decision-influence 计数；
+- reviewer-facing PR 描述工作前可选调用 `semantic-preference`。Issue-Fix 自己拥有
+  `issue_fix.pr_description` query 及结果应用方式；通用 hook 只返回有界 provider
+  结果和无状态 compact receipt，再由现有 evidence/state 路径写回；
 - host agent 驱动的 LoopX todo/quota/monitor/Kanban 集成。
 
 ### 下一阶段

--- a/docs/capabilities/semantic-preference/README.md
+++ b/docs/capabilities/semantic-preference/README.md
@@ -1,0 +1,109 @@
+# Semantic preference hook
+
+LoopX can optionally recall semantic preferences before a domain action and
+build a compact application receipt afterwards. The hook is deliberately thin:
+the provider owns storage, ranking, and semantic content; the caller owns how a
+preference affects its output and writes the receipt through existing LoopX
+evidence or state surfaces.
+
+The hook is disabled unless a caller supplies an enabled local-private JSON
+config. Config files inside a git project must be ignored; tracked configs are
+rejected. LoopX never copies the provider command, config path, recalled
+semantic content, or raw provider errors into receipts.
+
+## Module-owned surfaces
+
+`surfaces` is a mapping keyed by arbitrary module-qualified ids. The runtime
+does not branch on `issue_fix`, `content_ops`, or any other domain name.
+
+```json
+{
+  "schema_version": "semantic_preference_hook_config_v0",
+  "enabled": true,
+  "provider": {
+    "argv": ["semantic-preference-provider"],
+    "timeout_seconds": 30
+  },
+  "surfaces": {
+    "issue_fix.pr_description": {
+      "query": "PR description structure and reviewer language preferences"
+    },
+    "content_ops.draft_language": {
+      "query": "Draft language and section preferences",
+      "limit": 3
+    }
+  }
+}
+```
+
+A domain module owns the surface id, query, context keys, and decision about
+how recalled items influence its output. Adding another module is a config
+change, not a LoopX runtime change.
+
+## Provider protocol
+
+On `recall --execute`, LoopX sends one
+`semantic_preference_provider_request_v0` JSON object on stdin. A provider
+returns one `semantic_preference_provider_response_v0` object on stdout:
+
+```json
+{
+  "schema_version": "semantic_preference_provider_response_v0",
+  "items": [
+    {
+      "preference_ref": "provider-owned-reference",
+      "summary": "Use concise Chinese sections for this surface."
+    }
+  ]
+}
+```
+
+Provider stderr and non-zero output are reduced to a bounded failure kind.
+`fail_open` returns no items and lets the domain continue; `fail_closed` stops
+the caller with an actionable error. Provider failures do not become user
+gates automatically.
+
+## CLI
+
+```bash
+loopx semantic-preference recall \
+  --project . \
+  --config <ignored-config.json> \
+  --surface issue_fix.pr_description \
+  --context repository=owner/repo \
+  --execute
+
+loopx semantic-preference receipt \
+  --surface issue_fix.pr_description \
+  --application-id pr-123-description-v2 \
+  --outcome applied \
+  --preference-ref <provider-owned-reference> \
+  --artifact-ref https://github.com/owner/repo/pull/123
+```
+
+Receipts contain only surface, application id, outcome, optional public
+artifact reference, and hashes of provider-owned preference references. The
+command returns the receipt without writing a file. Callers can attach it to
+the existing evidence log, todo evidence, or `refresh-state` record; the hook
+does not maintain a second reward or memory ledger.
+
+## Domain integration
+
+```python
+from loopx.capabilities.semantic_preference import application_receipt, recall
+
+preferences = recall(
+    config_path,
+    project=project_root,
+    surface="issue_fix.pr_description",
+    execute=True,
+)
+# The issue-fix module decides whether and how to apply preferences["items"].
+receipt = application_receipt(
+    surface="issue_fix.pr_description",
+    application_id="pr-123-description-v2",
+    outcome="applied",
+    preference_refs=[item["preference_ref"] for item in preferences["items"]],
+)
+# Write `receipt` through an existing LoopX evidence/state surface.
+```

--- a/examples/semantic-preference-hook-smoke.py
+++ b/examples/semantic-preference-hook-smoke.py
@@ -10,7 +10,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from loopx.capabilities.semantic_preference import recall  # noqa: E402
+from loopx.capabilities.semantic_preference import application_receipt, recall  # noqa: E402
 
 
 def run(*args: str) -> dict[str, object]:
@@ -130,5 +130,17 @@ json.dump({
         assert "provider unavailable" in str(exc), exc
     else:
         raise AssertionError("fail_closed must stop the caller")
+
+    try:
+        application_receipt(
+            surface="other_module.summary",
+            application_id="bounded-receipt",
+            outcome="applied",
+            preference_refs=[f"memory://{index}" for index in range(21)],
+        )
+    except ValueError as exc:
+        assert "at most 20" in str(exc), exc
+    else:
+        raise AssertionError("receipt references must stay bounded")
 
 print("semantic preference hook smoke: ok")

--- a/examples/semantic-preference-hook-smoke.py
+++ b/examples/semantic-preference-hook-smoke.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from loopx.capabilities.semantic_preference import recall  # noqa: E402
+
+
+def run(*args: str) -> dict[str, object]:
+    result = subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--format", "json", *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    return json.loads(result.stdout)
+
+
+def recall_cli(project: Path, config: Path, surface: str, *, execute: bool = False):
+    args = [
+        "semantic-preference",
+        "recall",
+        "--project",
+        str(project),
+        "--config",
+        str(config),
+        "--surface",
+        surface,
+    ]
+    return run(*args, *(["--execute"] if execute else []))
+
+
+with tempfile.TemporaryDirectory(prefix="loopx-semantic-preference-") as raw_temp:
+    temp = Path(raw_temp)
+    project = temp / "project"
+    project.mkdir()
+    provider = temp / "provider.py"
+    provider.write_text(
+        """import json, sys
+request = json.load(sys.stdin)
+surface = request["surface"]
+json.dump({
+    "schema_version": "semantic_preference_provider_response_v0",
+    "items": [{"preference_ref": f"memory://{surface}", "summary": f"prefer {surface}"}],
+}, sys.stdout)
+""",
+        encoding="utf-8",
+    )
+    config = temp / "config.json"
+    config.write_text(
+        json.dumps(
+            {
+                "schema_version": "semantic_preference_hook_config_v0",
+                "enabled": True,
+                "provider": {"argv": [sys.executable, str(provider)]},
+                "surfaces": {
+                    "issue_fix.pr_description": {"query": "PR description preferences"},
+                    "content_ops.draft_language": {
+                        "query": "Draft language preferences"
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    for surface in ("issue_fix.pr_description", "content_ops.draft_language"):
+        preview = recall_cli(project, config, surface)
+        assert preview["status"] == "preview_ready", preview
+        recalled = recall_cli(project, config, surface, execute=True)
+        assert recalled["status"] == "completed", recalled
+        assert recalled["items"][0]["summary"] == f"prefer {surface}", recalled
+
+    receipt = run(
+        "semantic-preference",
+        "receipt",
+        "--surface",
+        "issue_fix.pr_description",
+        "--application-id",
+        "pr-17-description",
+        "--outcome",
+        "applied",
+        "--preference-ref",
+        "memory://issue_fix.pr_description",
+        "--artifact-ref",
+        "https://example.com/pr/17",
+    )
+    assert receipt["preference_ref_digests"], receipt
+    assert "memory://" not in json.dumps(receipt), receipt
+    assert not list(project.rglob("*receipt*")), "receipt must remain stateless"
+
+    disabled = temp / "disabled.json"
+    disabled.write_text(
+        json.dumps(
+            {"schema_version": "semantic_preference_hook_config_v0", "enabled": False}
+        ),
+        encoding="utf-8",
+    )
+    result = recall_cli(project, disabled, "other_module.summary", execute=True)
+    assert result["status"] == "disabled", result
+
+    failing = temp / "failing.json"
+    failing_payload = {
+        "schema_version": "semantic_preference_hook_config_v0",
+        "enabled": True,
+        "provider": {"argv": [sys.executable, "-c", "raise SystemExit(7)"]},
+        "surfaces": {"other_module.summary": {"query": "preferences"}},
+    }
+    failing.write_text(json.dumps(failing_payload), encoding="utf-8")
+    unavailable = recall(
+        failing, project=project, surface="other_module.summary", execute=True
+    )
+    assert unavailable["status"] == "provider_unavailable", unavailable
+    failing_payload["surfaces"]["other_module.summary"]["failure_policy"] = (
+        "fail_closed"
+    )
+    failing.write_text(json.dumps(failing_payload), encoding="utf-8")
+    try:
+        recall(failing, project=project, surface="other_module.summary", execute=True)
+    except ValueError as exc:
+        assert "provider unavailable" in str(exc), exc
+    else:
+        raise AssertionError("fail_closed must stop the caller")
+
+print("semantic preference hook smoke: ok")

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -209,6 +209,57 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
         ),
     },
     {
+        "id": "semantic-preference",
+        "title": "Optional semantic preference hook",
+        "status": "active-preview",
+        "real_world_anchor": "provider-neutral preference recall before domain work",
+        "user_value": (
+            "Let any LoopX module recall provider-owned semantic preferences and "
+            "record a compact application receipt without creating a second memory ledger."
+        ),
+        "entry_command": "loopx semantic-preference recall --config <ignored-config.json> --surface <module.surface> --format json",
+        "commands": [
+            {
+                "command": "loopx semantic-preference recall --config <ignored-config.json> --surface <module.surface> --execute --format json",
+                "purpose": "Send one bounded recall request to a configured command_json_v0 provider.",
+                "write_boundary": "provider read only; LoopX does not persist recalled semantic content",
+            },
+            {
+                "command": "loopx semantic-preference receipt --surface <module.surface> --application-id <id> --outcome applied --format json",
+                "purpose": "Build a compact receipt with hashed preference references for existing evidence/state writeback.",
+                "write_boundary": "stateless output only; no provider, file, or external write",
+            },
+        ],
+        "implemented_protocols": [
+            {
+                "schema_version": "semantic_preference_hook_config_v0",
+                "module": "loopx.capabilities.semantic_preference.contract",
+                "doc": "docs/capabilities/semantic-preference/README.md",
+            },
+            {
+                "schema_version": "semantic_preference_provider_request_v0",
+                "module": "loopx.capabilities.semantic_preference.contract",
+                "doc": "docs/capabilities/semantic-preference/README.md",
+            },
+            {
+                "schema_version": "semantic_preference_application_receipt_v0",
+                "module": "loopx.capabilities.semantic_preference.contract",
+                "doc": "docs/capabilities/semantic-preference/README.md",
+            },
+        ],
+        "smokes": ["python3 examples/semantic-preference-hook-smoke.py"],
+        "docs": ["docs/capabilities/semantic-preference/README.md"],
+        "boundaries": [
+            "The hook is disabled until an enabled local-private config is supplied.",
+            "Surface ids and queries are domain-owned configuration; the runtime has no issue-fix branch.",
+            "LoopX does not persist recalled semantic content, receipts, provider commands, config paths, or raw errors.",
+            "Provider failures follow explicit fail-open/fail-closed policy and do not become user gates automatically.",
+        ],
+        "next_real_step": (
+            "Keep the hook opt-in until a second domain module proves useful recall and existing-state receipt writeback."
+        ),
+    },
+    {
         "id": "content-ops",
         "title": "Creator/content operations loop",
         "status": "active-preview",

--- a/loopx/capabilities/semantic_preference/__init__.py
+++ b/loopx/capabilities/semantic_preference/__init__.py
@@ -1,0 +1,5 @@
+"""Optional provider-neutral semantic preference recall."""
+
+from .contract import application_receipt, recall
+
+__all__ = ["application_receipt", "recall"]

--- a/loopx/capabilities/semantic_preference/cli.py
+++ b/loopx/capabilities/semantic_preference/cli.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+from .contract import application_receipt, recall
+
+
+def _render(payload: dict[str, object]) -> str:
+    lines = ["# Semantic Preference", ""]
+    for key in ("status", "surface", "outcome", "application_id"):
+        if key in payload:
+            lines.append(f"- {key}: `{payload.get(key)}`")
+    items = payload.get("items")
+    if isinstance(items, list):
+        lines.append(f"- item_count: `{len(items)}`")
+    return "\n".join(lines) + "\n"
+
+
+def register_semantic_preference_commands(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    parser = subparsers.add_parser(
+        "semantic-preference",
+        help="Recall optional provider-owned preferences and build compact receipts.",
+    )
+    commands = parser.add_subparsers(dest="semantic_preference_command", required=True)
+    recall_parser = commands.add_parser("recall")
+    add_subcommand_format(recall_parser)
+    recall_parser.add_argument("--config", required=True)
+    recall_parser.add_argument("--project", default=".")
+    recall_parser.add_argument("--surface", required=True)
+    recall_parser.add_argument("--context", action="append", default=[])
+    recall_parser.add_argument("--execute", action="store_true")
+
+    receipt_parser = commands.add_parser("receipt")
+    add_subcommand_format(receipt_parser)
+    receipt_parser.add_argument("--surface", required=True)
+    receipt_parser.add_argument("--application-id", required=True)
+    receipt_parser.add_argument(
+        "--outcome", choices=["applied", "ignored", "failed"], required=True
+    )
+    receipt_parser.add_argument("--preference-ref", action="append", default=[])
+    receipt_parser.add_argument("--artifact-ref")
+
+
+def handle_semantic_preference_command(
+    args: argparse.Namespace,
+    *,
+    output_format: Callable[..., str],
+    print_payload: Callable[[dict[str, object], str, Callable], None],
+) -> int | None:
+    if args.command != "semantic-preference":
+        return None
+    if args.semantic_preference_command == "recall":
+        payload = recall(
+            args.config,
+            project=args.project,
+            surface=args.surface,
+            context=args.context,
+            execute=args.execute,
+        )
+    else:
+        payload = application_receipt(
+            surface=args.surface,
+            application_id=args.application_id,
+            outcome=args.outcome,
+            preference_refs=args.preference_ref,
+            artifact_ref=args.artifact_ref,
+        )
+    print_payload(payload, output_format(args), _render)
+    return 0

--- a/loopx/capabilities/semantic_preference/contract.py
+++ b/loopx/capabilities/semantic_preference/contract.py
@@ -15,6 +15,9 @@ RECALL_SCHEMA = "semantic_preference_recall_v0"
 RECEIPT_SCHEMA = "semantic_preference_application_receipt_v0"
 SURFACE_RE = re.compile(r"^[a-z][a-z0-9_-]*(?:\.[a-z][a-z0-9_-]*)+$")
 TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/#-]{0,199}$")
+MAX_PROVIDER_OUTPUT_BYTES = 256_000
+MAX_ITEM_BYTES = 8_000
+MAX_RECEIPT_REFS = 20
 
 
 def _surface(value: object) -> str:
@@ -168,6 +171,8 @@ def recall(
         return _unavailable(surface_id, policy, "execution_failed")
     if completed.returncode != 0:
         return _unavailable(surface_id, policy, "nonzero_exit")
+    if len(completed.stdout.encode("utf-8")) > MAX_PROVIDER_OUTPUT_BYTES:
+        return _unavailable(surface_id, policy, "response_too_large")
     try:
         response = json.loads(completed.stdout)
     except json.JSONDecodeError:
@@ -181,6 +186,11 @@ def recall(
     ):
         return _unavailable(surface_id, policy, "invalid_response")
     bounded = [dict(item) for item in items[:limit]]
+    if any(
+        len(json.dumps(item, ensure_ascii=False).encode("utf-8")) > MAX_ITEM_BYTES
+        for item in bounded
+    ):
+        return _unavailable(surface_id, policy, "item_too_large")
     return {
         "ok": True,
         "schema_version": RECALL_SCHEMA,
@@ -208,17 +218,16 @@ def application_receipt(
 ) -> dict[str, Any]:
     if outcome not in {"applied", "ignored", "failed"}:
         raise ValueError("outcome must be applied, ignored, or failed")
+    refs = [str(ref) for ref in preference_refs or [] if str(ref).strip()]
+    if len(refs) > MAX_RECEIPT_REFS:
+        raise ValueError(f"preference_refs supports at most {MAX_RECEIPT_REFS} items")
     return {
         "schema_version": RECEIPT_SCHEMA,
         "surface": _surface(surface),
         "application_id": _token(application_id, "application_id"),
         "outcome": outcome,
         "preference_ref_digests": sorted(
-            {
-                hashlib.sha256(str(ref).encode()).hexdigest()[:16]
-                for ref in preference_refs or []
-                if str(ref).strip()
-            }
+            {hashlib.sha256(str(ref).encode()).hexdigest()[:16] for ref in refs}
         ),
         "artifact_ref": _token(artifact_ref, "artifact_ref") if artifact_ref else None,
     }

--- a/loopx/capabilities/semantic_preference/contract.py
+++ b/loopx/capabilities/semantic_preference/contract.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+CONFIG_SCHEMA = "semantic_preference_hook_config_v0"
+REQUEST_SCHEMA = "semantic_preference_provider_request_v0"
+RESPONSE_SCHEMA = "semantic_preference_provider_response_v0"
+RECALL_SCHEMA = "semantic_preference_recall_v0"
+RECEIPT_SCHEMA = "semantic_preference_application_receipt_v0"
+SURFACE_RE = re.compile(r"^[a-z][a-z0-9_-]*(?:\.[a-z][a-z0-9_-]*)+$")
+TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/#-]{0,199}$")
+
+
+def _surface(value: object) -> str:
+    result = str(value or "").strip()
+    if not SURFACE_RE.fullmatch(result):
+        raise ValueError(
+            "surface must be a module-qualified token such as pr_review.reply"
+        )
+    return result
+
+
+def _config(config: str | Path, project: str | Path) -> dict[str, Any]:
+    root = Path(project).expanduser().resolve()
+    path = Path(config).expanduser().resolve()
+    if not root.is_dir():
+        raise ValueError("project directory does not exist")
+    try:
+        relative = path.relative_to(root)
+    except ValueError:
+        relative = None
+    if relative is not None:
+        tracked = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(root),
+                "ls-files",
+                "--error-unmatch",
+                "--",
+                str(relative),
+            ],
+            capture_output=True,
+            check=False,
+        )
+        ignored = subprocess.run(
+            ["git", "-C", str(root), "check-ignore", "--quiet", "--", str(relative)],
+            capture_output=True,
+            check=False,
+        )
+        if tracked.returncode == 0 or ignored.returncode != 0:
+            raise ValueError("config inside the project must be ignored and untracked")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("config must be a readable JSON object") from exc
+    if not isinstance(payload, dict) or payload.get("schema_version") != CONFIG_SCHEMA:
+        raise ValueError(f"config schema_version must be {CONFIG_SCHEMA}")
+    if not isinstance(payload.get("enabled", False), bool):
+        raise ValueError("config enabled must be a boolean")
+    return payload
+
+
+def _context(values: Sequence[str] | None) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for value in values or []:
+        key, separator, item = value.partition("=")
+        if not separator or not re.fullmatch(r"[a-z][a-z0-9_-]{0,63}", key):
+            raise ValueError("context must use lower-snake key=value syntax")
+        if len(item) > 500:
+            raise ValueError(f"context value for {key} exceeds 500 characters")
+        result[key] = item
+    return result
+
+
+def _unavailable(surface: str, policy: str, kind: str) -> dict[str, Any]:
+    if policy == "fail_closed":
+        raise ValueError(f"semantic preference provider unavailable: {kind}")
+    return {
+        "ok": True,
+        "schema_version": RECALL_SCHEMA,
+        "status": "provider_unavailable",
+        "surface": surface,
+        "items": [],
+        "failure_kind": kind,
+    }
+
+
+def recall(
+    config: str | Path,
+    *,
+    project: str | Path,
+    surface: str,
+    context: Sequence[str] | None = None,
+    execute: bool = False,
+) -> dict[str, Any]:
+    payload = _config(config, project)
+    surface_id = _surface(surface)
+    if not payload.get("enabled", False):
+        return {
+            "ok": True,
+            "schema_version": RECALL_SCHEMA,
+            "status": "disabled",
+            "surface": surface_id,
+            "items": [],
+        }
+    surfaces = payload.get("surfaces")
+    if not isinstance(surfaces, Mapping) or not isinstance(
+        surfaces.get(surface_id), Mapping
+    ):
+        raise ValueError(f"surface is not configured: {surface_id}")
+    surface_config = surfaces[surface_id]
+    query = str(surface_config.get("query") or "").strip()
+    policy = str(surface_config.get("failure_policy") or "fail_open")
+    try:
+        limit = int(surface_config.get("limit", 5))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("surface limit must be an integer") from exc
+    if not 1 <= len(query) <= 500 or not 1 <= limit <= 20:
+        raise ValueError("surface query or limit is outside the bounded contract")
+    if policy not in {"fail_open", "fail_closed"}:
+        raise ValueError("failure_policy must be fail_open or fail_closed")
+    provider = payload.get("provider")
+    argv = provider.get("argv") if isinstance(provider, Mapping) else None
+    if (
+        not isinstance(argv, list)
+        or not argv
+        or not all(isinstance(v, str) and v for v in argv)
+    ):
+        raise ValueError("enabled provider requires a non-empty string argv list")
+    try:
+        timeout = int(provider.get("timeout_seconds", 30))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("provider timeout_seconds must be an integer") from exc
+    if not 1 <= timeout <= 120:
+        raise ValueError("provider timeout_seconds must be between 1 and 120")
+    request = {
+        "schema_version": REQUEST_SCHEMA,
+        "surface": surface_id,
+        "query": query,
+        "limit": limit,
+        "context": _context(context),
+    }
+    if not execute:
+        return {
+            "ok": True,
+            "schema_version": RECALL_SCHEMA,
+            "status": "preview_ready",
+            "surface": surface_id,
+            "request": request,
+        }
+    try:
+        completed = subprocess.run(
+            argv,
+            input=json.dumps(request, ensure_ascii=False),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return _unavailable(surface_id, policy, "execution_failed")
+    if completed.returncode != 0:
+        return _unavailable(surface_id, policy, "nonzero_exit")
+    try:
+        response = json.loads(completed.stdout)
+    except json.JSONDecodeError:
+        return _unavailable(surface_id, policy, "invalid_json")
+    items = response.get("items") if isinstance(response, Mapping) else None
+    if (
+        not isinstance(response, Mapping)
+        or response.get("schema_version") != RESPONSE_SCHEMA
+        or not isinstance(items, list)
+        or not all(isinstance(item, Mapping) for item in items)
+    ):
+        return _unavailable(surface_id, policy, "invalid_response")
+    bounded = [dict(item) for item in items[:limit]]
+    return {
+        "ok": True,
+        "schema_version": RECALL_SCHEMA,
+        "status": "completed",
+        "surface": surface_id,
+        "items": bounded,
+        "truncated": len(items) > len(bounded),
+    }
+
+
+def _token(value: object, label: str) -> str:
+    result = str(value or "").strip()
+    if not TOKEN_RE.fullmatch(result):
+        raise ValueError(f"{label} must be a compact public-safe token")
+    return result
+
+
+def application_receipt(
+    *,
+    surface: str,
+    application_id: str,
+    outcome: str,
+    preference_refs: Sequence[str] | None = None,
+    artifact_ref: str | None = None,
+) -> dict[str, Any]:
+    if outcome not in {"applied", "ignored", "failed"}:
+        raise ValueError("outcome must be applied, ignored, or failed")
+    return {
+        "schema_version": RECEIPT_SCHEMA,
+        "surface": _surface(surface),
+        "application_id": _token(application_id, "application_id"),
+        "outcome": outcome,
+        "preference_ref_digests": sorted(
+            {
+                hashlib.sha256(str(ref).encode()).hexdigest()[:16]
+                for ref in preference_refs or []
+                if str(ref).strip()
+            }
+        ),
+        "artifact_ref": _token(artifact_ref, "artifact_ref") if artifact_ref else None,
+    }

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -14,6 +14,10 @@ from .capabilities.issue_fix.cli import (
     handle_issue_fix_command,
     register_issue_fix_commands,
 )
+from .capabilities.semantic_preference.cli import (
+    handle_semantic_preference_command,
+    register_semantic_preference_commands,
+)
 from .capabilities.auto_research.cli import (
     handle_auto_research_command,
     register_auto_research_commands,
@@ -174,6 +178,8 @@ def main(argv: list[str] | None = None) -> int:
     register_content_ops_commands(sub, add_subcommand_format)
 
     register_issue_fix_commands(sub, add_subcommand_format)
+
+    register_semantic_preference_commands(sub, add_subcommand_format)
 
     register_value_connector_commands(sub, add_subcommand_format)
 
@@ -364,6 +370,14 @@ def main(argv: list[str] | None = None) -> int:
             output_format=output_format,
             print_payload=print_payload,
         )
+
+    semantic_preference_result = handle_semantic_preference_command(
+        args,
+        output_format=output_format,
+        print_payload=print_payload,
+    )
+    if semantic_preference_result is not None:
+        return semantic_preference_result
 
     if args.command == "value-connectors":
         return handle_value_connector_command(args, output_format=output_format, print_payload=print_payload)


### PR DESCRIPTION
## Summary

- add an opt-in, provider-neutral `semantic_preference.recall()` seam keyed by module-owned `surface` and `query` configuration
- return bounded provider results with explicit fail-open/fail-closed behavior
- build deterministic compact application receipts for existing evidence/state writeback, without a second ledger or receipt file
- expose thin CLI commands and document how Issue-Fix owns `issue_fix.pr_description` application policy

## Why

Domain modules need a small way to reuse provider-owned semantic preferences without moving storage, ranking, or semantic policy into LoopX. The earlier prototype also maintained its own receipt persistence and configuration-summary abstractions; those were removed because existing LoopX evidence and state surfaces already own durable writeback.

## Real callsite

An enabled local-private OpenViking provider recalled a reviewer-facing PR-description preference before editing public OpenViking PR #3190. The description was changed from English to concise structured Chinese, remote readback matched the intended body, and the generated receipt retained only the public artifact reference plus a digest of the provider-owned preference reference. No provider config, recalled content, or receipt ledger is included in this PR.

## Validation

- `python3 examples/semantic-preference-hook-smoke.py`
- `python3 examples/issue-fix-capability-guide-smoke.py`
- Ruff check on the new module, CLI glue, and smoke
- `py_compile` on changed Python files
- `loopx check` public-boundary scan
- standard premerge canary: 4 direct checks and 17 selected catalog/risk/boundary checks passed; 0 failures, warnings, or manual holds

## Risk and compatibility

- default-off: no config means no caller behavior changes
- provider command and config remain local-private and are never copied into receipts
- provider failures never become user gates automatically
- no existing domain module is forced to apply a preference; each module owns its surface, query, and application decision
