### PR TITLE
refactor(todos): share quota summary lane construction

### DIFF
--- a/examples/control_plane/quota-todo-summary-readmodel-smoke.py
+++ b/examples/control_plane/quota-todo-summary-readmodel-smoke.py
@@ -249,6 +249,78 @@ def assert_agent_due_monitor_survives_claimed_lane_compaction() -> None:
     ), selected
 
 
+def assert_legacy_and_canonical_shared_lanes_stay_in_parity() -> None:
+    items = [
+        {
+            "index": 1,
+            "todo_id": "todo_shared_monitor",
+            "text": "[P1] Observe the shared due monitor.",
+            "status": "open",
+            "task_class": "continuous_monitor",
+            "claimed_by": "codex-product-capability",
+            "target_key": "shared-monitor",
+            "next_due_at": "2000-01-01T00:00:00+00:00",
+        },
+        {
+            "index": 2,
+            "todo_id": "todo_shared_advancement",
+            "text": "[P1] Continue the shared advancement lane.",
+            "status": "open",
+            "task_class": "advancement_task",
+            "claimed_by": "codex-product-capability",
+        },
+    ]
+    active_next = [items[1]]
+    monitor_writeback = {"supported": True, "source": "active_state"}
+    canonical = summarize_user_todos_for_quota(
+        {
+            "schema_version": "todo_summary_v0",
+            "source_section": "Agent Todo",
+            "total_count": 2,
+            "open_count": 2,
+            "done_count": 0,
+            "items": items,
+            "active_next_action_items": active_next,
+            "monitor_writeback": monitor_writeback,
+        },
+        agent_identity=AGENT_IDENTITY,
+    )
+    legacy = summarize_project_asset_todos_for_quota(
+        {
+            "source_section": "project_asset",
+            "open": 2,
+            "done": 0,
+            "first_open_items": items,
+            "active_next_action_items": active_next,
+            "monitor_writeback": monitor_writeback,
+        },
+        agent_identity=AGENT_IDENTITY,
+    )
+    assert canonical is not None and legacy is not None
+    shared_keys = {
+        "open_count",
+        "first_open_items",
+        "first_executable_items",
+        "monitor_open_items",
+        "monitor_due_count",
+        "monitor_due_items",
+        "active_next_action_items",
+        "active_next_action_executable_items",
+        "backlog_items",
+        "executable_backlog_items",
+        "claimed_open_count",
+        "unclaimed_open_count",
+        "claimed_open_items",
+        "claimed_advancement_open_items",
+        "claimed_monitor_open_items",
+        "current_agent_claimed_open_items",
+        "current_agent_claimed_advancement_items",
+        "current_agent_claimed_monitor_items",
+    }
+    for key in shared_keys:
+        assert canonical.get(key) == legacy.get(key), (key, canonical, legacy)
+
+
 def assert_user_gate_hint_detection_is_preserved() -> None:
     assert is_user_gate_todo_item(
         {
@@ -337,6 +409,7 @@ def main() -> None:
     assert_project_asset_fallback_and_canonical_precedence()
     assert_project_asset_summary_reuses_canonical_shape()
     assert_agent_due_monitor_survives_claimed_lane_compaction()
+    assert_legacy_and_canonical_shared_lanes_stay_in_parity()
     assert_user_gate_hint_detection_is_preserved()
     assert_quota_payload_summary_compacts_hot_path_lanes()
     print("quota todo summary read model smoke passed")

--- a/loopx/control_plane/todos/quota_summary.py
+++ b/loopx/control_plane/todos/quota_summary.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from ..agents.agent_scope import (
@@ -109,18 +110,33 @@ QUOTA_PAYLOAD_LANE_LIMITS = {
 }
 
 
-def summarize_user_todos_for_quota(
-    value: Any,
+@dataclass(frozen=True)
+class _QuotaTodoLanes:
+    all_open_items: list[dict[str, Any]]
+    blocking_open_items: list[dict[str, Any]]
+    user_action_open_items: list[dict[str, Any]]
+    other_agent_scoped_items: list[dict[str, Any]]
+    agent_scope_filter: dict[str, Any] | None
+    open_items: list[dict[str, Any]]
+    claim_scope: dict[str, Any] | None
+    executable_items: list[dict[str, Any]]
+    monitor_items: list[dict[str, Any]]
+    monitor_due_items: list[dict[str, Any]]
+    claimed_open_items: list[dict[str, Any]]
+    display_open_items: list[dict[str, Any]]
+    active_next_action_items: list[dict[str, Any]]
+    active_next_action_executable_items: list[dict[str, Any]]
+    open_count: Any
+
+
+def _build_quota_todo_lanes(
+    value: dict[str, Any],
     *,
-    agent_identity: dict[str, Any] | None = None,
-    filter_user_gate_blocks_agent: bool = False,
-) -> dict[str, Any] | None:
-    if not isinstance(value, dict):
-        return None
-    all_open_items = sorted(
-        todo_summary_source_items(value),
-        key=todo_projection_sort_key,
-    )
+    all_open_items: list[dict[str, Any]],
+    source_open_count: Any,
+    agent_identity: dict[str, Any] | None,
+    filter_user_gate_blocks_agent: bool,
+) -> _QuotaTodoLanes:
     blocking_open_items = all_open_items
     user_action_open_items: list[dict[str, Any]] = []
     other_agent_scoped_items: list[dict[str, Any]] = []
@@ -157,7 +173,6 @@ def summarize_user_todos_for_quota(
         if todo_item_is_actionable_open(item)
         if todo_item_task_class(item) == TODO_TASK_CLASS_MONITOR
     ]
-    monitor_writeback_supported = todo_summary_monitor_writeback_supported(value)
     monitor_due_items = (
         [
             item
@@ -165,22 +180,9 @@ def summarize_user_todos_for_quota(
             if todo_item_is_due_monitor(item)
             if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
         ]
-        if monitor_writeback_supported
+        if todo_summary_monitor_writeback_supported(value)
         else []
     )
-    monitor_schedule_gap_items = todo_summary_monitor_schedule_gap_items(
-        {
-            "monitor_open_items": monitor_items,
-            "monitor_writeback": value.get("monitor_writeback"),
-        }
-    )
-    claimed_open_items = [item for item in blocking_open_items if item.get("claimed_by")]
-    gate_items = [
-        item
-        for item in open_items
-        if is_user_gate_todo_item(item)
-    ]
-    display_open_items = open_items + user_action_open_items if filter_user_gate_blocks_agent else open_items
     active_next_action_items = (
         [
             compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
@@ -201,36 +203,91 @@ def summarize_user_todos_for_quota(
         if isinstance(value.get("active_next_action_executable_items"), list)
         else []
     )
-    open_count = value.get("open_count", len(all_open_items))
+    open_count = source_open_count
     if claim_scope is not None:
         open_count = len(open_items)
     if agent_scope_filter is not None:
         open_count = len(blocking_open_items)
+    return _QuotaTodoLanes(
+        all_open_items=all_open_items,
+        blocking_open_items=blocking_open_items,
+        user_action_open_items=user_action_open_items,
+        other_agent_scoped_items=other_agent_scoped_items,
+        agent_scope_filter=agent_scope_filter,
+        open_items=open_items,
+        claim_scope=claim_scope,
+        executable_items=executable_items,
+        monitor_items=monitor_items,
+        monitor_due_items=monitor_due_items,
+        claimed_open_items=[
+            item for item in blocking_open_items if item.get("claimed_by")
+        ],
+        display_open_items=(
+            open_items + user_action_open_items
+            if filter_user_gate_blocks_agent
+            else open_items
+        ),
+        active_next_action_items=active_next_action_items,
+        active_next_action_executable_items=active_next_action_executable_items,
+        open_count=open_count,
+    )
+
+
+def summarize_user_todos_for_quota(
+    value: Any,
+    *,
+    agent_identity: dict[str, Any] | None = None,
+    filter_user_gate_blocks_agent: bool = False,
+) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    all_open_items = sorted(
+        todo_summary_source_items(value),
+        key=todo_projection_sort_key,
+    )
+    lanes = _build_quota_todo_lanes(
+        value,
+        all_open_items=all_open_items,
+        source_open_count=value.get("open_count", len(all_open_items)),
+        agent_identity=agent_identity,
+        filter_user_gate_blocks_agent=filter_user_gate_blocks_agent,
+    )
+    monitor_schedule_gap_items = todo_summary_monitor_schedule_gap_items(
+        {
+            "monitor_open_items": lanes.monitor_items,
+            "monitor_writeback": value.get("monitor_writeback"),
+        }
+    )
+    gate_items = [
+        item
+        for item in lanes.open_items
+        if is_user_gate_todo_item(item)
+    ]
     summary = {
         "schema_version": value.get("schema_version"),
         "source_section": value.get("source_section"),
         "total_count": value.get("total_count"),
-        "open_count": open_count,
+        "open_count": lanes.open_count,
         "done_count": value.get("done_count"),
-        "first_open_items": display_open_items[:3],
-        "first_executable_items": executable_items[:3],
+        "first_open_items": lanes.display_open_items[:3],
+        "first_executable_items": lanes.executable_items[:3],
         "gate_open_items": gate_items[:3],
-        "monitor_open_items": monitor_items,
-        "monitor_due_count": len(monitor_due_items),
-        "monitor_due_items": monitor_due_items[:MONITOR_DUE_ITEM_LIMIT],
+        "monitor_open_items": lanes.monitor_items,
+        "monitor_due_count": len(lanes.monitor_due_items),
+        "monitor_due_items": lanes.monitor_due_items[:MONITOR_DUE_ITEM_LIMIT],
         "monitor_schedule_gap_count": len(monitor_schedule_gap_items),
         "monitor_schedule_gap_items": monitor_schedule_gap_items[:MONITOR_DUE_ITEM_LIMIT],
-        "active_next_action_items": active_next_action_items,
-        "active_next_action_executable_items": active_next_action_executable_items,
-        "backlog_items": display_open_items[:TODO_BACKLOG_ITEM_LIMIT],
-        "executable_backlog_items": executable_items[:TODO_BACKLOG_ITEM_LIMIT],
+        "active_next_action_items": lanes.active_next_action_items,
+        "active_next_action_executable_items": lanes.active_next_action_executable_items,
+        "backlog_items": lanes.display_open_items[:TODO_BACKLOG_ITEM_LIMIT],
+        "executable_backlog_items": lanes.executable_items[:TODO_BACKLOG_ITEM_LIMIT],
     }
     monitor_writeback = todo_summary_monitor_writeback_contract(value)
     if monitor_writeback:
         summary["monitor_writeback"] = monitor_writeback
     summary.update(
         build_todo_claim_visibility_lanes(
-            blocking_open_items,
+            lanes.blocking_open_items,
             agent_identity=agent_identity,
             backlog_item_limit=TODO_BACKLOG_ITEM_LIMIT,
             visibility_lane_limit=TODO_VISIBILITY_LANE_LIMIT,
@@ -271,31 +328,31 @@ def summarize_user_todos_for_quota(
         )
     )
     source_claimed_open_count = None if filter_user_gate_blocks_agent else value.get("claimed_open_count")
-    if claimed_open_items or source_claimed_open_count:
-        summary["claimed_open_count"] = source_claimed_open_count or len(claimed_open_items)
+    if lanes.claimed_open_items or source_claimed_open_count:
+        summary["claimed_open_count"] = source_claimed_open_count or len(lanes.claimed_open_items)
         summary["unclaimed_open_count"] = (
-            max(0, int(open_count or 0) - len(claimed_open_items))
+            max(0, int(lanes.open_count or 0) - len(lanes.claimed_open_items))
             if filter_user_gate_blocks_agent
             else value.get(
                 "unclaimed_open_count",
-                max(0, int(open_count or 0) - len(claimed_open_items)),
+                max(0, int(lanes.open_count or 0) - len(lanes.claimed_open_items)),
             )
         )
-    if claim_scope:
-        summary["claim_scope"] = claim_scope
-    if agent_scope_filter:
-        summary["agent_scope_filter"] = agent_scope_filter
+    if lanes.claim_scope:
+        summary["claim_scope"] = lanes.claim_scope
+    if lanes.agent_scope_filter:
+        summary["agent_scope_filter"] = lanes.agent_scope_filter
         summary["all_open_count"] = value.get("open_count", len(all_open_items))
-        summary["other_agent_scoped_open_count"] = len(other_agent_scoped_items)
+        summary["other_agent_scoped_open_count"] = len(lanes.other_agent_scoped_items)
         summary["other_agent_scoped_items"] = [
             compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
-            for item in other_agent_scoped_items[:TODO_VISIBILITY_LANE_LIMIT]
+            for item in lanes.other_agent_scoped_items[:TODO_VISIBILITY_LANE_LIMIT]
         ]
-    if filter_user_gate_blocks_agent and user_action_open_items:
-        summary["user_action_open_count"] = len(user_action_open_items)
+    if filter_user_gate_blocks_agent and lanes.user_action_open_items:
+        summary["user_action_open_count"] = len(lanes.user_action_open_items)
         summary["user_action_items"] = [
             compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
-            for item in user_action_open_items[:TODO_VISIBILITY_LANE_LIMIT]
+            for item in lanes.user_action_open_items[:TODO_VISIBILITY_LANE_LIMIT]
         ]
     return summary
 
@@ -432,102 +489,35 @@ def summarize_project_asset_todos_for_quota(
         next_claimed_by = str(value.get("next_claimed_by") or "").strip()
         if all_open_items and next_claimed_by:
             all_open_items[0]["claimed_by"] = next_claimed_by
-    blocking_open_items = all_open_items
-    user_action_open_items: list[dict[str, Any]] = []
-    other_agent_scoped_items: list[dict[str, Any]] = []
-    agent_scope_filter: dict[str, Any] | None = None
-    if filter_user_gate_blocks_agent:
-        gate_candidate_items = [
-            item for item in all_open_items if is_user_gate_todo_item(item)
-        ]
-        user_action_open_items = [
-            item for item in all_open_items if not is_user_gate_todo_item(item)
-        ]
-        (
-            blocking_open_items,
-            other_agent_scoped_items,
-            agent_scope_filter,
-        ) = _agent_scope_filter_user_gate_items(
-            gate_candidate_items,
-            agent_identity=agent_identity,
-        )
-    open_items, claim_scope = build_agent_claim_scoped_open_items(
-        blocking_open_items,
+    lanes = _build_quota_todo_lanes(
+        value,
+        all_open_items=all_open_items,
+        source_open_count=value.get("open", value.get("open_count", len(all_open_items))),
         agent_identity=agent_identity,
-        diagnostic_item_limit=3,
+        filter_user_gate_blocks_agent=filter_user_gate_blocks_agent,
     )
-    executable_items = [
-        item
-        for item in open_items
-        if todo_item_is_actionable_open(item)
-        if todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
-    ]
-    monitor_items = [
-        item
-        for item in open_items
-        if todo_item_is_actionable_open(item)
-        if todo_item_task_class(item) == TODO_TASK_CLASS_MONITOR
-    ]
-    monitor_writeback_supported = todo_summary_monitor_writeback_supported(value)
-    monitor_due_items = (
-        [
-            item
-            for item in monitor_items
-            if todo_item_is_due_monitor(item)
-            if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
-        ]
-        if monitor_writeback_supported
-        else []
-    )
-    active_next_action_items = (
-        [
-            compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
-            for item in (value.get("active_next_action_items") or [])
-            if isinstance(item, dict)
-            if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
-        ]
-        if isinstance(value.get("active_next_action_items"), list)
-        else []
-    )
-    active_next_action_executable_items = (
-        [
-            compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
-            for item in (value.get("active_next_action_executable_items") or [])
-            if isinstance(item, dict)
-            if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
-        ]
-        if isinstance(value.get("active_next_action_executable_items"), list)
-        else []
-    )
-    claimed_open_items = [item for item in blocking_open_items if item.get("claimed_by")]
-    display_open_items = open_items + user_action_open_items if filter_user_gate_blocks_agent else open_items
-    open_count = value.get("open", value.get("open_count", len(all_open_items)))
-    if claim_scope is not None:
-        open_count = len(open_items)
-    if agent_scope_filter is not None:
-        open_count = len(blocking_open_items)
     summary = {
         "schema_version": value.get("schema_version"),
         "source_section": value.get("source_section") or "project_asset",
         "total_count": value.get("total", value.get("total_count")),
-        "open_count": open_count,
+        "open_count": lanes.open_count,
         "done_count": value.get("done", value.get("done_count")),
-        "first_open_items": display_open_items[:3],
-        "first_executable_items": executable_items[:3],
-        "monitor_open_items": monitor_items,
-        "monitor_due_count": len(monitor_due_items),
-        "monitor_due_items": monitor_due_items[:MONITOR_DUE_ITEM_LIMIT],
-        "active_next_action_items": active_next_action_items,
-        "active_next_action_executable_items": active_next_action_executable_items,
-        "backlog_items": display_open_items[:TODO_BACKLOG_ITEM_LIMIT],
-        "executable_backlog_items": executable_items[:TODO_BACKLOG_ITEM_LIMIT],
+        "first_open_items": lanes.display_open_items[:3],
+        "first_executable_items": lanes.executable_items[:3],
+        "monitor_open_items": lanes.monitor_items,
+        "monitor_due_count": len(lanes.monitor_due_items),
+        "monitor_due_items": lanes.monitor_due_items[:MONITOR_DUE_ITEM_LIMIT],
+        "active_next_action_items": lanes.active_next_action_items,
+        "active_next_action_executable_items": lanes.active_next_action_executable_items,
+        "backlog_items": lanes.display_open_items[:TODO_BACKLOG_ITEM_LIMIT],
+        "executable_backlog_items": lanes.executable_items[:TODO_BACKLOG_ITEM_LIMIT],
     }
     monitor_writeback = todo_summary_monitor_writeback_contract(value)
     if monitor_writeback:
         summary["monitor_writeback"] = monitor_writeback
     summary.update(
         build_todo_claim_visibility_lanes(
-            blocking_open_items,
+            lanes.blocking_open_items,
             agent_identity=agent_identity,
             backlog_item_limit=TODO_BACKLOG_ITEM_LIMIT,
             visibility_lane_limit=TODO_VISIBILITY_LANE_LIMIT,
@@ -555,31 +545,31 @@ def summarize_project_asset_todos_for_quota(
         )
     )
     source_claimed_open_count = None if filter_user_gate_blocks_agent else value.get("claimed_open_count")
-    if claimed_open_items or source_claimed_open_count:
-        summary["claimed_open_count"] = source_claimed_open_count or len(claimed_open_items)
+    if lanes.claimed_open_items or source_claimed_open_count:
+        summary["claimed_open_count"] = source_claimed_open_count or len(lanes.claimed_open_items)
         summary["unclaimed_open_count"] = (
-            max(0, int(open_count or 0) - len(claimed_open_items))
+            max(0, int(lanes.open_count or 0) - len(lanes.claimed_open_items))
             if filter_user_gate_blocks_agent
             else value.get(
                 "unclaimed_open_count",
-                max(0, int(open_count or 0) - len(claimed_open_items)),
+                max(0, int(lanes.open_count or 0) - len(lanes.claimed_open_items)),
             )
         )
-    if claim_scope:
-        summary["claim_scope"] = claim_scope
-    if agent_scope_filter:
-        summary["agent_scope_filter"] = agent_scope_filter
+    if lanes.claim_scope:
+        summary["claim_scope"] = lanes.claim_scope
+    if lanes.agent_scope_filter:
+        summary["agent_scope_filter"] = lanes.agent_scope_filter
         summary["all_open_count"] = value.get("open", value.get("open_count", len(all_open_items)))
-        summary["other_agent_scoped_open_count"] = len(other_agent_scoped_items)
+        summary["other_agent_scoped_open_count"] = len(lanes.other_agent_scoped_items)
         summary["other_agent_scoped_items"] = [
             compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
-            for item in other_agent_scoped_items[:TODO_VISIBILITY_LANE_LIMIT]
+            for item in lanes.other_agent_scoped_items[:TODO_VISIBILITY_LANE_LIMIT]
         ]
-    if filter_user_gate_blocks_agent and user_action_open_items:
-        summary["user_action_open_count"] = len(user_action_open_items)
+    if filter_user_gate_blocks_agent and lanes.user_action_open_items:
+        summary["user_action_open_count"] = len(lanes.user_action_open_items)
         summary["user_action_items"] = [
             compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
-            for item in user_action_open_items[:TODO_VISIBILITY_LANE_LIMIT]
+            for item in lanes.user_action_open_items[:TODO_VISIBILITY_LANE_LIMIT]
         ]
     return summary
 


### PR DESCRIPTION
## Summary
- extract one shared quota todo-lane read model for canonical and legacy/project-asset summaries
- preserve canonical-only resume/succession diagnostics and legacy fallback behavior
- add focused parity coverage across both input shapes

## Validation
- `ruff check` on changed files
- quota todo-summary read-model smoke
- monitor todo-policy seam smoke
- 22 focused pytest cases
- `loopx canary premerge --from-git-diff` (17/17 selected checks passed, no manual holds)

## Risk
Behavior-preserving control-plane refactor only. No quota ordering, monitor lifecycle, default agent-facing output, benchmark behavior, or public/private boundary changes.