### PR TITLE
fix(explore): activate graph sync from goal refresh

### DIFF
--- a/docs/capabilities/explore/README.md
+++ b/docs/capabilities/explore/README.md
@@ -279,7 +279,48 @@ deny-by-default disabled packet carries the `boundary` block plus the opt-in
 operator to decide which workers to start, but it cannot launch workers or
 mutate the control plane on its own.
 
-### Per-Goal Opt-In Gate
+### Independent Per-Goal Opt-In Gates
+
+Explore Graph and Explore Harness are separate optional capabilities. Enabling
+one never enables the other:
+
+- `explore_graph.enabled` controls durable graph projection and any already
+  configured presentation sink. After each successful material
+  `refresh-state` transaction, LoopX folds the canonical Explore evidence and
+  runs the configured sink. Semantic digests make an unchanged refresh a
+  zero-write operation. A failed sink does not advance its digest, so the next
+  material refresh retries it.
+- `spawn_policy.explore_harness.enabled` controls only the read-only branch
+  planners described below. It does not create, update, or publish a graph.
+
+Both gates are absent/false by default. A common operating mode is Graph on
+and Harness off: keep an operator-facing topology current without changing
+how work is planned.
+
+```yaml
+# inside the registered goal entry
+explore_graph:
+  enabled: true
+
+spawn_policy:
+  explore_harness:
+    enabled: false
+```
+
+Configure the gates independently instead of editing the registry:
+
+```bash
+loopx configure-goal --goal-id <id> \
+  --explore-graph-enabled \
+  --no-explore-harness-enabled \
+  --execute
+```
+
+Use `--no-explore-graph-enabled` to stop automatic graph work. Disabling the
+gate preserves existing evidence and display state; it only prevents future
+automatic projection and sink writes.
+
+#### Explore Harness planning gate
 
 Both opt-in planners — `todo-branch-plan` and `worker-branch-plan` —
 are deny-by-default. The gate lives on the registered goal's `spawn_policy`,

--- a/examples/explore-configure-goal-smoke.py
+++ b/examples/explore-configure-goal-smoke.py
@@ -108,6 +108,37 @@ def main() -> int:
         )
         assert disabled["orchestration_gate"]["state"] == "disabled", disabled
 
+        graph_preview = run_cli(
+            registry,
+            runtime_root,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--explore-graph-enabled",
+        )
+        assert graph_preview["dry_run"] is True, graph_preview
+        assert graph_preview["feature_summary"]["explore_graph"] == {
+            "enabled": True
+        }, graph_preview
+        assert graph_preview["feature_summary"]["explore_harness"] == {
+            "enabled": False
+        }, graph_preview
+        assert registry.read_text(encoding="utf-8") == original
+
+        graph_applied = run_cli(
+            registry,
+            runtime_root,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--explore-graph-enabled",
+            "--execute",
+        )
+        assert graph_applied["written"] is True, graph_applied
+        assert goal(registry)["explore_graph"] == {"enabled": True}
+        assert goal(registry)["spawn_policy"].get("explore_harness") is None
+        graph_configured = registry.read_text(encoding="utf-8")
+
         clear_absent = run_cli(
             registry,
             runtime_root,
@@ -134,7 +165,7 @@ def main() -> int:
             "enabled": True,
             "profile": "moe-router",
         }, preview
-        assert registry.read_text(encoding="utf-8") == original
+        assert registry.read_text(encoding="utf-8") == graph_configured
 
         applied = run_cli(
             registry,
@@ -168,6 +199,7 @@ def main() -> int:
         assert quota["ok"] is False and quota["status_health_ok"] is False, quota
         boundary = quota["goal_boundary"]["orchestration"]
         assert boundary["explore_harness"] == configured["explore_harness"], boundary
+        assert quota["goal_boundary"]["explore_graph"] == {"enabled": True}, quota
 
         worker = run_cli(
             registry,
@@ -217,6 +249,20 @@ def main() -> int:
         )
         assert closed["written"] is True, closed
         assert goal(registry)["spawn_policy"]["explore_harness"] == {"enabled": False}
+
+        graph_closed_harness_open = run_cli(
+            registry,
+            runtime_root,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--no-explore-graph-enabled",
+            "--explore-harness-enabled",
+            "--execute",
+        )
+        assert graph_closed_harness_open["written"] is True, graph_closed_harness_open
+        assert goal(registry)["explore_graph"] == {"enabled": False}
+        assert goal(registry)["spawn_policy"]["explore_harness"] == {"enabled": True}
 
         conflict = run_cli(
             registry,

--- a/examples/issue-fix-explore-projection-smoke.py
+++ b/examples/issue-fix-explore-projection-smoke.py
@@ -22,6 +22,9 @@ from loopx.capabilities.issue_fix.feasibility import (  # noqa: E402
 from loopx.capabilities.issue_fix.pr_lifecycle import (  # noqa: E402
     build_issue_fix_pr_lifecycle_monitor_packet,
 )
+from loopx.capabilities.explore.activation import (  # noqa: E402
+    sync_explore_graph_after_material_refresh,
+)
 from loopx.domain_packs.issue_fix import (  # noqa: E402
     default_issue_fix_domain_state_ledger_path,
     default_issue_fix_feasibility_ledger_path,
@@ -108,6 +111,71 @@ def main() -> None:
             ),
             encoding="utf-8",
         )
+        activation_calls: list[bool] = []
+
+        def activation_syncer(**kwargs: object) -> dict[str, object]:
+            activation_calls.append(bool(kwargs.get("execute")))
+            return {
+                "ok": True,
+                "status": "unchanged",
+                "needs_row_sync": False,
+                "needs_visual_sync": False,
+                "semantic_digest": "fixture-digest",
+                "projection": {
+                    "applicable": True,
+                    "material_change": False,
+                    "material_event_count": 0,
+                    "appended_event_count": 0,
+                },
+            }
+
+        graph_disabled = sync_explore_graph_after_material_refresh(
+            registry_path=registry,
+            goal_id=goal_id,
+            agent_id="codex-fixture",
+            project=project,
+            syncer=activation_syncer,
+        )
+        assert graph_disabled["status"] == "disabled", graph_disabled
+        assert activation_calls == [], activation_calls
+
+        registry_payload = json.loads(registry.read_text(encoding="utf-8"))
+        registry_payload["goals"][0]["explore_graph"] = {"enabled": True}
+        registry.write_text(json.dumps(registry_payload), encoding="utf-8")
+        graph_enabled = sync_explore_graph_after_material_refresh(
+            registry_path=registry,
+            goal_id=goal_id,
+            agent_id="codex-fixture",
+            project=project,
+            syncer=activation_syncer,
+        )
+        assert graph_enabled["status"] == "unchanged", graph_enabled
+        assert graph_enabled["needs_row_sync"] is False, graph_enabled
+        assert activation_calls == [True], activation_calls
+
+        failure_calls: list[bool] = []
+
+        def failing_syncer(**kwargs: object) -> dict[str, object]:
+            failure_calls.append(bool(kwargs.get("execute")))
+            raise RuntimeError("fixture transport failure")
+
+        first_failure = sync_explore_graph_after_material_refresh(
+            registry_path=registry,
+            goal_id=goal_id,
+            project=project,
+            syncer=failing_syncer,
+        )
+        retry_failure = sync_explore_graph_after_material_refresh(
+            registry_path=registry,
+            goal_id=goal_id,
+            project=project,
+            syncer=failing_syncer,
+        )
+        assert first_failure["status"] == "sync_failed", first_failure
+        assert first_failure["error_type"] == "RuntimeError", first_failure
+        assert retry_failure["status"] == "sync_failed", retry_failure
+        assert failure_calls == [True, True], failure_calls
+
         unrelated = project_issue_fix_explore_graph(
             registry_path=registry,
             goal_id="unrelated-goal",

--- a/loopx/capabilities/explore/activation.py
+++ b/loopx/capabilities/explore/activation.py
@@ -5,17 +5,10 @@ from pathlib import Path
 from typing import Any
 
 from ...agent_registry import load_goal_from_registry
+from ...explore_graph import compact_explore_graph_policy
 
 
 EXPLORE_GRAPH_ACTIVATION_SCHEMA_VERSION = "loopx_explore_graph_activation_v0"
-
-
-def compact_explore_graph_policy(value: Any) -> dict[str, bool]:
-    """Return the strict, default-off per-goal Explore Graph gate."""
-
-    policy = value if isinstance(value, Mapping) else {}
-    return {"enabled": policy.get("enabled") is True}
-
 
 def sync_explore_graph_after_material_refresh(
     *,

--- a/loopx/capabilities/explore/activation.py
+++ b/loopx/capabilities/explore/activation.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+from ...agent_registry import load_goal_from_registry
+
+
+EXPLORE_GRAPH_ACTIVATION_SCHEMA_VERSION = "loopx_explore_graph_activation_v0"
+
+
+def compact_explore_graph_policy(value: Any) -> dict[str, bool]:
+    """Return the strict, default-off per-goal Explore Graph gate."""
+
+    policy = value if isinstance(value, Mapping) else {}
+    return {"enabled": policy.get("enabled") is True}
+
+
+def sync_explore_graph_after_material_refresh(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    agent_id: str | None = None,
+    project: Path | None = None,
+    state_file: Path | None = None,
+    syncer: Callable[..., Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Flush an enabled graph after the goal-level refresh transaction.
+
+    Explore Graph activation is independent from Explore Harness planning.  A
+    configured graph reuses the existing idempotent projection/sink adapter;
+    disabled or absent policy performs no graph reads or writes.
+    """
+
+    goal = load_goal_from_registry(registry_path, goal_id)
+    policy = compact_explore_graph_policy(
+        goal.get("explore_graph") if isinstance(goal, dict) else None
+    )
+    base = {
+        "ok": True,
+        "schema_version": EXPLORE_GRAPH_ACTIVATION_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "enabled": policy["enabled"],
+        "trigger": "material_refresh",
+    }
+    if goal is None:
+        return {**base, "ok": False, "status": "goal_not_found"}
+    if not policy["enabled"]:
+        return {**base, "status": "disabled"}
+
+    if syncer is None:
+        from ...presentation.sinks.lark.explore_results import (
+            sync_issue_fix_explore_on_material_change,
+        )
+
+        syncer = sync_issue_fix_explore_on_material_change
+
+    try:
+        result = syncer(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            agent_id=agent_id,
+            project=project,
+            state_file=state_file,
+            execute=True,
+        )
+    except Exception as exc:
+        return {
+            **base,
+            "ok": False,
+            "status": "sync_failed",
+            "error_type": type(exc).__name__,
+        }
+
+    projection = (
+        result.get("projection")
+        if isinstance(result.get("projection"), Mapping)
+        else {}
+    )
+    return {
+        **base,
+        "ok": result.get("ok") is True,
+        "status": str(result.get("status") or "unknown"),
+        "applicable": projection.get("applicable"),
+        "material_change": projection.get("material_change"),
+        "material_event_count": projection.get("material_event_count"),
+        "appended_event_count": projection.get("appended_event_count"),
+        "needs_row_sync": result.get("needs_row_sync"),
+        "needs_visual_sync": result.get("needs_visual_sync"),
+        "semantic_digest": result.get("semantic_digest"),
+    }

--- a/loopx/cli_commands/project_lifecycle.py
+++ b/loopx/cli_commands/project_lifecycle.py
@@ -8,6 +8,9 @@ from pathlib import Path
 from ..control_plane.goals.goal_vision_policy import (
     GOAL_VISION_ADVANCEMENT_POLICY_CHOICES,
 )
+from ..capabilities.explore.activation import (
+    sync_explore_graph_after_material_refresh,
+)
 from ..control_plane.work_items.delivery_batch_scale import (
     DELIVERY_BATCH_SCALE_INPUT_CHOICES,
 )
@@ -479,6 +482,18 @@ def handle_project_lifecycle_command(
                     ),
                 },
             )
+            graph_sync = sync_explore_graph_after_material_refresh(
+                registry_path=registry_path,
+                goal_id=args.goal_id,
+                agent_id=args.agent_id,
+                project=Path(args.project).expanduser() if args.project else None,
+                state_file=Path(args.state_file).expanduser() if args.state_file else None,
+            )
+            payload["explore_graph_sync"] = graph_sync
+            if graph_sync.get("enabled") and not graph_sync.get("ok"):
+                payload.setdefault("warnings", []).append(
+                    "enabled Explore Graph sync failed; the unchanged sink digest keeps it retryable"
+                )
         print_payload(payload, fmt, render_state_refresh_markdown)
         return 0 if payload.get("ok") else 1
 

--- a/loopx/cli_commands/registry_admin.py
+++ b/loopx/cli_commands/registry_admin.py
@@ -281,6 +281,15 @@ def register_registry_admin_commands(subparsers: argparse._SubParsersAction) -> 
         help="Clear allowed child-agent domains.",
     )
     configure_goal_parser.add_argument(
+        "--explore-graph-enabled",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "Enable or disable automatic Explore Graph projection at material "
+            "refresh boundaries. This is independent from Explore Harness planning."
+        ),
+    )
+    configure_goal_parser.add_argument(
         "--explore-harness-enabled",
         action=argparse.BooleanOptionalAction,
         default=None,
@@ -584,6 +593,7 @@ def handle_registry_admin_command(
                 explore_harness_enabled=args.explore_harness_enabled,
                 explore_harness_profile=args.explore_harness_profile,
                 clear_explore_harness_profile=bool(args.clear_explore_harness_profile),
+                explore_graph_enabled=args.explore_graph_enabled,
                 registered_agents=args.registered_agents,
                 clear_registered_agents=bool(args.clear_registered_agents),
                 agent_profiles=agent_profiles,

--- a/loopx/configure_goal.py
+++ b/loopx/configure_goal.py
@@ -17,7 +17,7 @@ from .boundary_authority import (
 )
 from .agent_registry import normalize_registered_agents
 from .control_plane import compact_control_plane_policy, control_plane_policy_summary
-from .capabilities.explore.activation import compact_explore_graph_policy
+from .explore_graph import compact_explore_graph_policy
 from .orchestration import (
     DEFAULT_ORCHESTRATION_MODE,
     EXPLORE_HARNESS_PROFILES,

--- a/loopx/configure_goal.py
+++ b/loopx/configure_goal.py
@@ -17,6 +17,7 @@ from .boundary_authority import (
 )
 from .agent_registry import normalize_registered_agents
 from .control_plane import compact_control_plane_policy, control_plane_policy_summary
+from .capabilities.explore.activation import compact_explore_graph_policy
 from .orchestration import (
     DEFAULT_ORCHESTRATION_MODE,
     EXPLORE_HARNESS_PROFILES,
@@ -172,6 +173,7 @@ def _settings_summary(goal: dict[str, Any]) -> dict[str, Any]:
         "issue_fix_reviewer_notification": _reviewer_notification_config_summary(
             goal
         ),
+        "explore_graph": compact_explore_graph_policy(goal.get("explore_graph")),
         "orchestration": orchestration,
         "waiting_on": goal.get("waiting_on"),
         "write_scope": _clean_write_scope(coordination.get("write_scope") or []) or [],
@@ -359,6 +361,7 @@ def configure_goal(
     explore_harness_enabled: bool | None = None,
     explore_harness_profile: str | None = None,
     clear_explore_harness_profile: bool = False,
+    explore_graph_enabled: bool | None = None,
     registered_agents: list[str] | None = None,
     clear_registered_agents: bool = False,
     agent_profiles: list[dict[str, Any]] | None = None,
@@ -603,6 +606,9 @@ def configure_goal(
             control_plane.pop("issue_fix", None)
         goal["control_plane"] = control_plane
 
+    if explore_graph_enabled is not None:
+        goal["explore_graph"] = {"enabled": explore_graph_enabled}
+
     if (
         multi_subagent_feature is not None
         or
@@ -819,6 +825,9 @@ def configure_goal(
         "orchestration_summary": orchestration_policy_summary(after.get("orchestration")),
         "feature_summary": {
             "multi_subagent": _multi_subagent_feature_status(after.get("orchestration") or {}),
+            "explore_graph": deepcopy(
+                after.get("explore_graph") or {"enabled": False}
+            ),
             "explore_harness": deepcopy(
                 (after.get("orchestration") or {}).get("explore_harness")
                 or {"enabled": False}
@@ -871,6 +880,11 @@ def render_configure_goal_markdown(payload: dict[str, Any]) -> str:
     feature_summary = payload.get("feature_summary")
     if isinstance(feature_summary, dict):
         lines.append(f"- feature_multi_subagent: `{feature_summary.get('multi_subagent')}`")
+        graph = feature_summary.get("explore_graph")
+        if isinstance(graph, dict):
+            lines.append(
+                f"- feature_explore_graph: `{'on' if graph.get('enabled') else 'off'}`"
+            )
         harness = feature_summary.get("explore_harness")
         if isinstance(harness, dict):
             harness_state = "on" if harness.get("enabled") else "off"

--- a/loopx/control_plane/quota/goal_boundary.py
+++ b/loopx/control_plane/quota/goal_boundary.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from ...benchmark_core import compact_run_permission_policy_for_quota
 from ...boundary_authority import checkpointed_boundary_authority_summary
+from ...capabilities.explore.activation import compact_explore_graph_policy
 from ...execution_profile import execution_profile_outcome_floor
 from ...orchestration import compact_orchestration_policy
 from ..todos.contract import (
@@ -131,6 +132,10 @@ def goal_boundary(goal: dict[str, Any], item: dict[str, Any] | None = None) -> d
         }
     if goal.get("next_probe"):
         boundary["next_probe"] = str(goal.get("next_probe"))
+    if isinstance(goal.get("explore_graph"), dict):
+        boundary["explore_graph"] = compact_explore_graph_policy(
+            goal.get("explore_graph")
+        )
     spawn_policy = goal.get("spawn_policy") if isinstance(goal.get("spawn_policy"), dict) else None
     if spawn_policy is not None:
         boundary["orchestration"] = compact_orchestration_policy(spawn_policy)

--- a/loopx/control_plane/quota/goal_boundary.py
+++ b/loopx/control_plane/quota/goal_boundary.py
@@ -4,8 +4,8 @@ from typing import Any
 
 from ...benchmark_core import compact_run_permission_policy_for_quota
 from ...boundary_authority import checkpointed_boundary_authority_summary
-from ...capabilities.explore.activation import compact_explore_graph_policy
 from ...execution_profile import execution_profile_outcome_floor
+from ...explore_graph import compact_explore_graph_policy
 from ...orchestration import compact_orchestration_policy
 from ..todos.contract import (
     normalize_required_capabilities,

--- a/loopx/control_plane/runtime/run_history.py
+++ b/loopx/control_plane/runtime/run_history.py
@@ -87,6 +87,9 @@ def build_run_history(
                 "adapter_kind": goal.get("adapter_kind"),
                 "adapter_status": goal.get("adapter_status"),
                 "coordination": compact_goal_coordination(goal.get("coordination")),
+                "explore_graph": goal.get("explore_graph")
+                if isinstance(goal.get("explore_graph"), dict)
+                else None,
                 "guards": goal.get("guards") if isinstance(goal.get("guards"), list) else [],
                 "next_probe": goal.get("next_probe"),
                 "authority_registry": goal.get("authority_registry"),

--- a/loopx/explore_graph.py
+++ b/loopx/explore_graph.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def compact_explore_graph_policy(value: Any) -> dict[str, bool]:
+    """Return the strict, default-off per-goal Explore Graph gate."""
+
+    policy = value if isinstance(value, Mapping) else {}
+    return {"enabled": policy.get("enabled") is True}

--- a/loopx/history.py
+++ b/loopx/history.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from .authority import goal_authority_registry_summary
+from .capabilities.explore.activation import compact_explore_graph_policy
 from .control_plane import compact_control_plane_policy
 from .control_plane.runtime.time import now_local_iso
 from .control_plane.runtime.run_index_duplicates import (
@@ -776,6 +777,9 @@ def collect_history(
             "adapter_kind": adapter.get("kind"),
             "adapter_status": adapter.get("status"),
             "coordination": meta.get("coordination") if isinstance(meta.get("coordination"), dict) else None,
+            "explore_graph": compact_explore_graph_policy(meta.get("explore_graph"))
+            if isinstance(meta.get("explore_graph"), dict)
+            else None,
             "spawn_policy": meta.get("spawn_policy") if isinstance(meta.get("spawn_policy"), dict) else None,
             "execution_profile": compact_execution_profile(meta.get("execution_profile")) if registry_member else None,
             "control_plane": compact_control_plane_policy(meta.get("control_plane")) if registry_member else None,

--- a/loopx/history.py
+++ b/loopx/history.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Any, Callable
 
 from .authority import goal_authority_registry_summary
-from .capabilities.explore.activation import compact_explore_graph_policy
 from .control_plane import compact_control_plane_policy
 from .control_plane.runtime.time import now_local_iso
 from .control_plane.runtime.run_index_duplicates import (
@@ -19,6 +18,7 @@ from .control_plane.work_items.delivery_batch_scale import require_delivery_batc
 from .control_plane.work_items.delivery_outcome import require_delivery_outcome
 from .doctor import PROMOTION_READINESS_CLASSIFICATIONS
 from .execution_profile import compact_execution_profile
+from .explore_graph import compact_explore_graph_policy
 from .paths import resolve_runtime_root
 from .presentation.markdown import (
     markdown_code,

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -1048,6 +1048,9 @@ def build_quota_plan(status_payload: dict[str, Any], *, mode: str = "status") ->
                 or status_goal.get("root")
             ),
             "coordination": goal.get("coordination") if isinstance(goal.get("coordination"), dict) else None,
+            "explore_graph": goal.get("explore_graph")
+            if isinstance(goal.get("explore_graph"), dict)
+            else None,
             "spawn_policy": goal.get("spawn_policy") if isinstance(goal.get("spawn_policy"), dict) else None,
             "guards": goal.get("guards") if isinstance(goal.get("guards"), list) else [],
             "next_probe": goal.get("next_probe"),

--- a/loopx/registry.py
+++ b/loopx/registry.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from .authority import authority_registry_summary
+from .capabilities.explore.activation import compact_explore_graph_policy
 from .control_plane import compact_control_plane_policy, control_plane_policy_summary
 from .execution_profile import compact_execution_profile, execution_profile_summary
 from .orchestration import compact_orchestration_policy, orchestration_policy_summary
@@ -365,6 +366,11 @@ def inspect_registry(path: Path) -> dict[str, Any]:
                 "operator_question": raw_goal.get("operator_question"),
                 "recommended_action": raw_goal.get("recommended_action"),
                 "next_handoff_condition": raw_goal.get("next_handoff_condition"),
+                "explore_graph": compact_explore_graph_policy(
+                    raw_goal.get("explore_graph")
+                )
+                if isinstance(raw_goal.get("explore_graph"), dict)
+                else None,
                 "orchestration": orchestration,
                 "orchestration_mode": orchestration.get("mode"),
                 "spawn_allowed": spawn_policy.get("allowed"),

--- a/loopx/registry.py
+++ b/loopx/registry.py
@@ -8,9 +8,9 @@ from pathlib import Path
 from typing import Any
 
 from .authority import authority_registry_summary
-from .capabilities.explore.activation import compact_explore_graph_policy
 from .control_plane import compact_control_plane_policy, control_plane_policy_summary
 from .execution_profile import compact_execution_profile, execution_profile_summary
+from .explore_graph import compact_explore_graph_policy
 from .orchestration import compact_orchestration_policy, orchestration_policy_summary
 from .presentation.markdown import markdown_code, markdown_table_row, markdown_table_separator
 from .quota import goal_quota_config


### PR DESCRIPTION
## 问题

Explore Graph 此前只是 `lark-kanban sync-loopx-todos` 的隐式副作用，不是注册目标上的行为开关。只要没有再次执行 Kanban 同步，新的 PR、todo、vision 和能力节点就不会进入图；`explore_harness.enabled` 又只控制分析规划，无法表达“图开启、Harness 关闭”。

## 改动

- 新增独立、默认关闭的 `explore_graph.enabled`，并通过 `configure-goal` 与 quota `goal_boundary` 显式投影。
- 成功的 material `refresh-state` 事务结束后，仅在 Graph 开启时运行现有 canonical projection 和已配置 sink。
- 语义 digest 未变化时零远端写；sink 失败不推进 digest，下一次 refresh 自动重试。
- `explore_harness.enabled` 保持独立、默认关闭，只影响 read-only branch planning。
- 更新 Explore 能力文档，说明 Graph 与 Harness 的四种组合。

## 验证

- `uvx ruff check ...`（本次涉及文件）
- `uv run python examples/explore-configure-goal-smoke.py`
- `uv run python examples/issue-fix-explore-projection-smoke.py`
- `uv run python examples/cli-project-lifecycle-command-modularization-smoke.py`
- `uv run python -m compileall -q loopx`

覆盖 Graph on/Harness off、Graph off/Harness on、disabled 零调用、unchanged 零写与失败重试。

## 风险与边界

- 默认行为不变：未显式启用 Graph 的目标不会读写图或 Lark sink。
- 不新增调度器，不改变 spawn 权限，不把 Graph 开关当作 Harness 授权。
- sink 失败只附加可诊断 warning，不让已成功的 `refresh-state` 回滚。