### PR TITLE
feat(config): expose optional capability catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,20 @@ Some, including Explore Graph and Explore Harness, are supported opt-in
 features that remain default-off; newer adapters are still settling their UX,
 safety defaults, and evidence contracts across more repositories.
 
+The first useful loop requires no optional configuration. When a concrete task
+would benefit from bounded child agents, Explore Graph, or Explore Harness,
+inspect the goal's read-only catalog first:
+
+```bash
+loopx configure-goal --goal-id <goal-id>
+```
+
+The catalog reports current and default state, when each feature is useful,
+what it does not authorize, and copyable preview/apply/disable/verify command
+templates. Use `loopx configure-goal --help` for the complete settings surface.
+Preview changes without `--execute`; do not enable a feature only because it is
+available.
+
 ### Start With A Useful Loop
 
 Use a preset to see LoopX's value before wiring up a full automation:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -335,6 +335,18 @@ benchmark 证据边界。
 Explore Graph / Explore Harness 已经是正式支持、默认关闭、按 goal opt-in 的可选
 能力；更新的 adapter 仍会继续打磨 first-run UX、安全默认值和 evidence contract。
 
+第一次跑出有用结果不需要配置这些可选能力。只有当具体任务确实需要 bounded child
+agent、Explore Graph 或 Explore Harness 时，再先查看该 goal 的只读配置目录：
+
+```bash
+loopx configure-goal --goal-id <goal-id>
+```
+
+目录会给出当前值、默认值、适用条件、不会授予的权限，以及可复制的 preview /
+apply / disable / verify 命令模板；完整设置面仍由
+`loopx configure-goal --help` 提供。没有 `--execute` 时只做预览；不要因为能力存在
+就主动开启。
+
 ### 先跑一个有用的 Loop
 
 想先感受 LoopX 能做什么，可以从只读 preset 开始：

--- a/examples/project/configure-goal-smoke.py
+++ b/examples/project/configure-goal-smoke.py
@@ -182,6 +182,8 @@ def main() -> int:
         assert features["explore_graph"]["current"]["enabled"] is False
         assert "--execute" not in features["explore_harness"]["commands"]["preview_enable"]
         assert "--execute" in features["explore_harness"]["commands"]["apply_enable"]
+        assert "--execute" not in features["explore_graph"]["commands"]["preview_disable"]
+        assert "--execute" in features["explore_graph"]["commands"]["apply_disable"]
         migration = dry["heartbeat_prompt_migration"]
         assert migration["schema_version"] == "heartbeat_prompt_migration_v1", migration
         assert "agent identity changed" in migration["reason"], migration

--- a/examples/project/configure-goal-smoke.py
+++ b/examples/project/configure-goal-smoke.py
@@ -106,6 +106,12 @@ def main() -> int:
         }
         agent_profile_json = json.dumps(agent_profile)
 
+        inspected = payload(run_cli(registry_path, "configure-goal", "--goal-id", GOAL_ID))
+        assert inspected["changed"] is False, inspected
+        assert inspected["configuration_catalog"]["disclosure_policy"][
+            "first_run_configuration_required"
+        ] is False
+
         dry = payload(run_cli(
             registry_path,
             "configure-goal",
@@ -166,6 +172,16 @@ def main() -> int:
             "config_pointer_registered": True,
         }, dry
         assert dry["feature_summary"]["multi_subagent"] == "enabled", dry
+        catalog = dry["configuration_catalog"]
+        assert catalog["schema_version"] == "loopx_goal_configuration_catalog_v0", catalog
+        assert catalog["scope"] == "default_off_optional_capabilities", catalog
+        assert catalog["disclosure_policy"]["first_run_configuration_required"] is False
+        features = {item["feature_id"]: item for item in catalog["features"]}
+        assert set(features) == {"multi_subagent", "explore_graph", "explore_harness"}
+        assert features["multi_subagent"]["current"]["enabled"] is True
+        assert features["explore_graph"]["current"]["enabled"] is False
+        assert "--execute" not in features["explore_harness"]["commands"]["preview_enable"]
+        assert "--execute" in features["explore_harness"]["commands"]["apply_enable"]
         migration = dry["heartbeat_prompt_migration"]
         assert migration["schema_version"] == "heartbeat_prompt_migration_v1", migration
         assert "agent identity changed" in migration["reason"], migration

--- a/examples/slash-command-install-smoke.py
+++ b/examples/slash-command-install-smoke.py
@@ -111,6 +111,8 @@ def main() -> int:
         assert "LoopX `/loopx`" in codex_skill_text
         assert "start-goal --guided --project . --goal-text" in codex_skill_text
         assert "bootstrap-command-pack --project . --goal-text" not in codex_skill_text
+        assert "Do not configure optional features during first-run" in codex_skill_text
+        assert "configure-goal --goal-id <resolved-goal-id>" in codex_skill_text
         codex_metadata = codex_home / "skills" / "loopx" / "agents" / "openai.yaml"
         codex_metadata_text = codex_metadata.read_text(encoding="utf-8")
         assert "allow_implicit_invocation: false" in codex_metadata_text

--- a/loopx/cli_commands/registry_admin.py
+++ b/loopx/cli_commands/registry_admin.py
@@ -226,7 +226,15 @@ def loop_activation_for_goal(
 def register_registry_admin_commands(subparsers: argparse._SubParsersAction) -> None:
     configure_goal_parser = subparsers.add_parser(
         "configure-goal",
-        help="Preview or apply per-goal registry settings for quota, self-repair, and orchestration.",
+        help=(
+            "Inspect current goal settings and optional features, or preview/apply an "
+            "incremental configuration change."
+        ),
+        description=(
+            "Inspect current per-goal settings, or preview/apply an incremental change. "
+            "With no setting flags this is read-only and includes the on-demand optional "
+            "feature catalog; first-run setup requires no optional configuration."
+        ),
     )
     configure_goal_parser.add_argument("--goal-id", required=True, help="Goal id to configure.")
     configure_goal_parser.add_argument("--quota-compute", type=float, help="Per-goal quota compute multiplier.")

--- a/loopx/configuration_catalog.py
+++ b/loopx/configuration_catalog.py
@@ -103,7 +103,10 @@ def build_goal_configuration_catalog(
                     "apply_enable": _configure_command(
                         goal_id, *multi_enable_args, execute=True
                     ),
-                    "disable": _configure_command(
+                    "preview_disable": _configure_command(
+                        goal_id, "--multi-subagent-feature", "off"
+                    ),
+                    "apply_disable": _configure_command(
                         goal_id, "--multi-subagent-feature", "off", execute=True
                     ),
                     "verify": [
@@ -141,7 +144,10 @@ def build_goal_configuration_catalog(
                     "apply_enable": _configure_command(
                         goal_id, *graph_enable_args, execute=True
                     ),
-                    "disable": _configure_command(
+                    "preview_disable": _configure_command(
+                        goal_id, "--no-explore-graph-enabled"
+                    ),
+                    "apply_disable": _configure_command(
                         goal_id, "--no-explore-graph-enabled", execute=True
                     ),
                     "verify": [
@@ -191,7 +197,10 @@ def build_goal_configuration_catalog(
                     "apply_enable": _configure_command(
                         goal_id, *harness_enable_args, execute=True
                     ),
-                    "disable": _configure_command(
+                    "preview_disable": _configure_command(
+                        goal_id, "--no-explore-harness-enabled"
+                    ),
+                    "apply_disable": _configure_command(
                         goal_id, "--no-explore-harness-enabled", execute=True
                     ),
                     "verify": [

--- a/loopx/configuration_catalog.py
+++ b/loopx/configuration_catalog.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import shlex
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+def _configure_command(
+    goal_id: str,
+    *arguments: str,
+    execute: bool = False,
+) -> str:
+    parts = ["loopx", "configure-goal", "--goal-id", goal_id, *arguments]
+    if execute:
+        parts.append("--execute")
+    return shlex.join(parts)
+
+
+def build_goal_configuration_catalog(
+    *,
+    goal_id: str,
+    settings: Mapping[str, Any],
+    feature_summary: Mapping[str, Any],
+    default_multi_subagent_max_children: int,
+    explore_harness_profiles: Sequence[str],
+) -> dict[str, Any]:
+    """Build the on-demand configuration read model for optional features."""
+
+    orchestration = (
+        settings.get("orchestration")
+        if isinstance(settings.get("orchestration"), Mapping)
+        else {}
+    )
+    graph = (
+        feature_summary.get("explore_graph")
+        if isinstance(feature_summary.get("explore_graph"), Mapping)
+        else {}
+    )
+    harness = (
+        feature_summary.get("explore_harness")
+        if isinstance(feature_summary.get("explore_harness"), Mapping)
+        else {}
+    )
+    inspect_command = _configure_command(goal_id)
+    multi_enable_args = (
+        "--multi-subagent-feature",
+        "enabled",
+        "--max-children",
+        str(default_multi_subagent_max_children),
+        "--allowed-domain",
+        "<bounded-domain>",
+    )
+    graph_enable_args = ("--explore-graph-enabled",)
+    harness_enable_args = (
+        "--explore-harness-enabled",
+        "--explore-harness-profile",
+        "generic",
+    )
+
+    return {
+        "schema_version": "loopx_goal_configuration_catalog_v0",
+        "scope": "default_off_optional_capabilities",
+        "all_settings_help_command": "loopx configure-goal --help",
+        "disclosure_policy": {
+            "mode": "on_demand",
+            "first_run_configuration_required": False,
+            "inspect_command": inspect_command,
+            "mutation_policy": "preview_without_execute_then_apply_explicitly",
+            "agent_rule": (
+                "Do not enable optional features during onboarding or merely because they "
+                "exist. Inspect this catalog only when the task needs the capability, then "
+                "preview and explain the boundary change before apply."
+            ),
+        },
+        "features": [
+            {
+                "feature_id": "multi_subagent",
+                "display_name": "Bounded child agents",
+                "availability": "supported_opt_in",
+                "default": {"enabled": False},
+                "current": {
+                    "enabled": feature_summary.get("multi_subagent") == "enabled",
+                    "max_children": orchestration.get("max_children"),
+                    "allowed_domains": list(orchestration.get("allowed_domains") or []),
+                },
+                "required_inputs": {
+                    "bounded-domain": (
+                        "Replace the placeholder with one public-safe child-agent "
+                        "responsibility domain. Repeat --allowed-domain when needed."
+                    )
+                },
+                "consider_when": (
+                    "The goal has at least two independent, non-overlapping work items and "
+                    "the host can run child agents."
+                ),
+                "effect": "Allows bounded host child-agent orchestration for this goal.",
+                "does_not": [
+                    "create an agent hierarchy or durable authority",
+                    "bypass todo claims, quota, gates, capabilities, or write scope",
+                ],
+                "commands": {
+                    "preview_enable": _configure_command(goal_id, *multi_enable_args),
+                    "apply_enable": _configure_command(
+                        goal_id, *multi_enable_args, execute=True
+                    ),
+                    "disable": _configure_command(
+                        goal_id, "--multi-subagent-feature", "off", execute=True
+                    ),
+                    "verify": [
+                        inspect_command,
+                        shlex.join(
+                            ["loopx", "quota", "should-run", "--goal-id", goal_id]
+                        ),
+                    ],
+                },
+                "documentation": {
+                    "path": "docs/codex-subagent-orchestration.md",
+                    "url": (
+                        "https://github.com/huangruiteng/loopx/blob/main/"
+                        "docs/codex-subagent-orchestration.md"
+                    ),
+                },
+            },
+            {
+                "feature_id": "explore_graph",
+                "display_name": "Explore Graph",
+                "availability": "supported_opt_in",
+                "default": {"enabled": False},
+                "current": {"enabled": graph.get("enabled") is True},
+                "consider_when": (
+                    "The goal needs a durable topology of hypotheses, evidence, decisions, "
+                    "or an already configured operator-facing graph sink."
+                ),
+                "effect": "Projects durable Explore evidence after material refreshes.",
+                "does_not": [
+                    "enable Explore Harness",
+                    "spawn workers, claim todos, or spend quota by itself",
+                ],
+                "commands": {
+                    "preview_enable": _configure_command(goal_id, *graph_enable_args),
+                    "apply_enable": _configure_command(
+                        goal_id, *graph_enable_args, execute=True
+                    ),
+                    "disable": _configure_command(
+                        goal_id, "--no-explore-graph-enabled", execute=True
+                    ),
+                    "verify": [
+                        inspect_command,
+                        shlex.join(
+                            [
+                                "loopx",
+                                "explore",
+                                "graph",
+                                "--goal-id",
+                                goal_id,
+                                "--graph-format",
+                                "mermaid",
+                            ]
+                        ),
+                    ],
+                },
+                "documentation": {
+                    "path": "docs/capabilities/explore/README.md",
+                    "url": (
+                        "https://github.com/huangruiteng/loopx/blob/main/"
+                        "docs/capabilities/explore/README.md"
+                    ),
+                },
+            },
+            {
+                "feature_id": "explore_harness",
+                "display_name": "Explore Harness",
+                "availability": "supported_opt_in",
+                "default": {"enabled": False, "profile": "generic"},
+                "current": {
+                    "enabled": harness.get("enabled") is True,
+                    "profile": harness.get("profile"),
+                },
+                "profiles": list(explore_harness_profiles),
+                "consider_when": (
+                    "The goal benefits from comparing alternative branches with explicit "
+                    "evaluation criteria and guardrails."
+                ),
+                "effect": "Enables read-only Explore branch and worker-lane planning.",
+                "does_not": [
+                    "enable Explore Graph",
+                    "launch workers, claim todos, acquire leases, mutate state, or spend quota",
+                ],
+                "commands": {
+                    "preview_enable": _configure_command(goal_id, *harness_enable_args),
+                    "apply_enable": _configure_command(
+                        goal_id, *harness_enable_args, execute=True
+                    ),
+                    "disable": _configure_command(
+                        goal_id, "--no-explore-harness-enabled", execute=True
+                    ),
+                    "verify": [
+                        inspect_command,
+                        shlex.join(
+                            [
+                                "loopx",
+                                "explore",
+                                "worker-branch-plan",
+                                "--goal-id",
+                                goal_id,
+                                "--harness-profile",
+                                str(harness.get("profile") or "generic"),
+                            ]
+                        ),
+                    ],
+                },
+                "documentation": {
+                    "path": "docs/capabilities/explore/README.md",
+                    "url": (
+                        "https://github.com/huangruiteng/loopx/blob/main/"
+                        "docs/capabilities/explore/README.md"
+                    ),
+                },
+            },
+        ],
+    }

--- a/loopx/configure_goal.py
+++ b/loopx/configure_goal.py
@@ -17,6 +17,7 @@ from .boundary_authority import (
 )
 from .agent_registry import normalize_registered_agents
 from .control_plane import compact_control_plane_policy, control_plane_policy_summary
+from .configuration_catalog import build_goal_configuration_catalog
 from .explore_graph import compact_explore_graph_policy
 from .orchestration import (
     DEFAULT_ORCHESTRATION_MODE,
@@ -796,6 +797,18 @@ def configure_goal(
             shutil.copy2(registry_path, backup_path)
         _atomic_write_json(registry_path, payload)
 
+    feature_summary = {
+        "multi_subagent": _multi_subagent_feature_status(after.get("orchestration") or {}),
+        "explore_graph": deepcopy(after.get("explore_graph") or {"enabled": False}),
+        "explore_harness": deepcopy(
+            (after.get("orchestration") or {}).get("explore_harness")
+            or {"enabled": False}
+        ),
+        "peer_supervisor": deepcopy(after.get("supervisor") or {"enabled": False}),
+        "default": "off",
+        "configuration_entry": "multi_subagent_feature",
+    }
+
     return {
         "ok": True,
         "dry_run": dry_run,
@@ -823,19 +836,14 @@ def configure_goal(
         },
         "control_plane_summary": control_plane_policy_summary(after.get("control_plane")),
         "orchestration_summary": orchestration_policy_summary(after.get("orchestration")),
-        "feature_summary": {
-            "multi_subagent": _multi_subagent_feature_status(after.get("orchestration") or {}),
-            "explore_graph": deepcopy(
-                after.get("explore_graph") or {"enabled": False}
-            ),
-            "explore_harness": deepcopy(
-                (after.get("orchestration") or {}).get("explore_harness")
-                or {"enabled": False}
-            ),
-            "peer_supervisor": deepcopy(after.get("supervisor") or {"enabled": False}),
-            "default": "off",
-            "configuration_entry": "multi_subagent_feature",
-        },
+        "feature_summary": feature_summary,
+        "configuration_catalog": build_goal_configuration_catalog(
+            goal_id=goal_id,
+            settings=after,
+            feature_summary=feature_summary,
+            default_multi_subagent_max_children=DEFAULT_MULTI_SUBAGENT_MAX_CHILDREN,
+            explore_harness_profiles=EXPLORE_HARNESS_PROFILES,
+        ),
         "heartbeat_prompt_migration": _build_heartbeat_prompt_migration(
             goal_id=goal_id,
             changed_fields=changed_fields,
@@ -897,6 +905,40 @@ def render_configure_goal_markdown(payload: dict[str, Any]) -> str:
             if supervisor.get("agent_id"):
                 supervisor_state += f"({supervisor.get('agent_id')})"
             lines.append(f"- feature_peer_supervisor: `{supervisor_state}`")
+    catalog = payload.get("configuration_catalog")
+    if isinstance(catalog, dict):
+        disclosure = catalog.get("disclosure_policy") or {}
+        lines.extend(
+            [
+                "",
+                "## Optional Features (On Demand)",
+                "",
+                "First run requires no optional feature configuration.",
+                "",
+                f"- inspect: `{disclosure.get('inspect_command')}`",
+                f"- all_settings_help: `{catalog.get('all_settings_help_command')}`",
+                "- apply_policy: preview first; add `--execute` only after review",
+            ]
+        )
+        for feature in catalog.get("features") or []:
+            if not isinstance(feature, dict):
+                continue
+            current = feature.get("current") or {}
+            state = "on" if current.get("enabled") else "off"
+            commands = feature.get("commands") or {}
+            verify_commands = commands.get("verify") or []
+            documentation = feature.get("documentation") or {}
+            lines.extend(
+                [
+                    f"- `{feature.get('feature_id')}` ({feature.get('display_name')}): `{state}`",
+                    f"  - consider: {feature.get('consider_when')}",
+                    f"  - preview: `{commands.get('preview_enable')}`",
+                    f"  - apply: `{commands.get('apply_enable')}`",
+                    f"  - disable: `{commands.get('disable')}`",
+                    f"  - verify: {'; '.join(f'`{command}`' for command in verify_commands)}",
+                    f"  - docs: [{documentation.get('path')}]({documentation.get('url')})",
+                ]
+            )
     migration = payload.get("heartbeat_prompt_migration")
     if isinstance(migration, dict):
         lines.append(f"- heartbeat_prompt_migration: {migration.get('action')}")
@@ -920,20 +962,32 @@ def render_configure_goal_markdown(payload: dict[str, Any]) -> str:
         )
         if activation.get("activated") is not True:
             lines.append(f"- host_loop_action: {activation.get('recommended_action')}")
-    lines.extend(
-        [
-            "",
-            "## Before",
-            "",
-            "```json",
-            json.dumps(payload.get("before") or {}, ensure_ascii=False, indent=2),
-            "```",
-            "",
-            "## After",
-            "",
-            "```json",
-            json.dumps(payload.get("after") or {}, ensure_ascii=False, indent=2),
-            "```",
-        ]
-    )
+    if payload.get("changed"):
+        lines.extend(
+            [
+                "",
+                "## Before",
+                "",
+                "```json",
+                json.dumps(payload.get("before") or {}, ensure_ascii=False, indent=2),
+                "```",
+                "",
+                "## After",
+                "",
+                "```json",
+                json.dumps(payload.get("after") or {}, ensure_ascii=False, indent=2),
+                "```",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "",
+                "## Current Settings",
+                "",
+                "```json",
+                json.dumps(payload.get("after") or {}, ensure_ascii=False, indent=2),
+                "```",
+            ]
+        )
     return "\n".join(lines)

--- a/loopx/configure_goal.py
+++ b/loopx/configure_goal.py
@@ -934,7 +934,8 @@ def render_configure_goal_markdown(payload: dict[str, Any]) -> str:
                     f"  - consider: {feature.get('consider_when')}",
                     f"  - preview: `{commands.get('preview_enable')}`",
                     f"  - apply: `{commands.get('apply_enable')}`",
-                    f"  - disable: `{commands.get('disable')}`",
+                    f"  - preview_disable: `{commands.get('preview_disable')}`",
+                    f"  - apply_disable: `{commands.get('apply_disable')}`",
                     f"  - verify: {'; '.join(f'`{command}`' for command in verify_commands)}",
                     f"  - docs: [{documentation.get('path')}]({documentation.get('url')})",
                 ]

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -88,6 +88,7 @@ def _command_prompt_specs(*, cli_bin: str, include_legacy_aliases: bool) -> list
                 f"If arguments are present, preserve them as the task text and run `{cli_bin} start-goal --guided --project . --goal-text \"$ARGUMENTS\"` before planning work.",
                 f"If arguments are empty, inspect `{cli_bin} bootstrap-command-pack --project .`, `{cli_bin} status`, and `{cli_bin} slash-commands` before changing files.",
                 f"Use `{cli_bin} agent-onboard --list-agent-types` when the host runtime is unclear; pass an exact type such as `codex-app`, `codex-cli`, or `claude-code`, never ambiguous `codex`.",
+                f"Do not configure optional features during first-run. Only when the task needs bounded child agents or Explore, inspect `{cli_bin} configure-goal --goal-id <resolved-goal-id>` and its `configuration_catalog`; preview before explicit apply and never auto-enable a feature merely because it exists.",
                 "When project work is started, plan ordered P0/P1/P2 todos, write them through LoopX todo state, refresh state, activate the host loop if missing/stale, run quota, and take one bounded allowed step.",
                 "Host loop activation means Codex App heartbeat automation, Codex CLI visible `/goal <task_body>`, Claude Code native `/loop`, or a custom host-loop gate from `loopx agent-onboard`.",
                 "If this session cannot mutate the host loop surface, surface the exact pasteable gate instead of saying LoopX is autonomously connected.",


### PR DESCRIPTION
## Summary

- add an on-demand `configuration_catalog` to the existing read-only `configure-goal` response for bounded child agents, Explore Graph, and Explore Harness
- report current/default state, task-fit guidance, non-effects, preview/apply/disable/verify commands, required placeholders, and local/public documentation references
- keep first-run configuration unnecessary and every optional capability default-off
- make unchanged human-readable inspection show one `Current Settings` block instead of duplicate Before/After payloads
- add one conditional `/loopx` agent instruction and concise README guidance below the onboarding path; no first-screen or first-run step changes

## Validation

- `python3 examples/project/configure-goal-smoke.py`
- `python3 examples/explore-configure-goal-smoke.py`
- `python3 examples/slash-command-install-smoke.py`
- `python3 examples/docs-governance-smoke.py`
- `python3 examples/codex-subagent-orchestration-contract-smoke.py`
- `uv run --extra test ruff check <changed Python paths>`
- `loopx canary premerge --from-git-diff --tier standard` (17/17 passed, 0 warnings, 0 manual holds)
- public/private boundary scan passed for all 8 changed paths

## Compatibility And Boundaries

`configure-goal` JSON keeps the existing `before`, `after`, and `feature_summary` fields and adds a cold/on-demand catalog. Registry shape, defaults, feature gates, quota/status hot paths, and execution permissions are unchanged. Applying a setting still requires explicit `--execute`; the generated `/loopx` contract says not to configure optional features during first-run or auto-enable them merely because they exist.

## Residual Risk

The main risk is documentation/command drift as optional features evolve. The focused configure-goal and generated-skill smokes assert the catalog schema, default-off disclosure policy, feature ids, state projection, and preview-versus-apply distinction.