### PR TITLE
test(control-plane): add direct Doubao qualification actor

### DIFF
--- a/docs/reference/protocols/model-behavior-qualification-v0.md
+++ b/docs/reference/protocols/model-behavior-qualification-v0.md
@@ -5,10 +5,10 @@ agent-facing control-plane packet changes. It complements deterministic smokes;
 it does not replace them and does not change the default `quota should-run`
 view.
 
-The first implementation is intentionally provider-neutral. It defines the
-actor request, no-write sandbox, strict model decision, compact receipt, and
-paired comparison. A provider adapter can be added separately after its secret
-injection, redaction, cost, and rate-limit boundaries are validated.
+The core is provider-neutral. It defines the actor request, no-write sandbox,
+strict model decision, compact receipt, and paired comparison. The optional
+direct Ark adapter supports low-frequency Doubao 2.1 shadow runs without
+changing the default quota path.
 
 ## Pair Contract
 
@@ -72,6 +72,28 @@ does not contain:
 `model_behavior_pair_result_v0` retains only the drift map, safety violations,
 and receipt digests. Raw model conversations belong in ignored local runtime
 state and are never a public repository artifact.
+
+## Direct Doubao Shadow Actor
+
+`DoubaoModelBehaviorActor` calls only the canonical Ark Chat Completions
+endpoint and allowlists the versioned Doubao 2.1 Pro and Turbo model ids. It
+does not accept an arbitrary base URL, does not follow redirects, does not send
+tool definitions, and converts transport failures into bounded errors without
+provider response bodies.
+
+Live use requires `ARK_API_KEY` to be injected into the process environment.
+The key is held only by the in-memory adapter and is never placed in a LoopX
+packet, receipt, error, command argument, fixture, or repository file. The
+optional `LOOPX_MODEL_BEHAVIOR_MODEL` selector can choose one of the two
+allowlisted Doubao 2.1 model ids. Missing credentials, unsupported models,
+malformed provider JSON, or non-conforming decisions fail closed. LoopX does
+not search credential stores and does not route these calls through a memory
+system or another agent service.
+
+The live actor is deliberately absent from PR smoke and normal CI. It belongs
+in manually triggered or low-frequency shadow qualification where cost,
+repetition, corpus selection, and promotion policy are explicit. Only compact
+decision receipts and paired drift results may become durable evidence.
 
 ## Promotion Boundary
 

--- a/loopx/control_plane/testing/doubao_model_behavior_actor.py
+++ b/loopx/control_plane/testing/doubao_model_behavior_actor.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from typing import Any, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from .model_behavior_qualification import (
+    MODEL_BEHAVIOR_ACTOR_RESULT_SCHEMA_VERSION,
+    ModelBehaviorActor,
+    normalize_model_behavior_actor_request,
+)
+
+
+DOUBAO_2_1_PRO_MODEL = "doubao-seed-2-1-pro-260628"
+DOUBAO_2_1_TURBO_MODEL = "doubao-seed-2-1-turbo-260628"
+DOUBAO_CHAT_COMPLETIONS_ENDPOINT = (
+    "https://ark.cn-beijing.volces.com/api/v3/chat/completions"
+)
+ARK_API_KEY_ENV = "ARK_API_KEY"
+DOUBAO_MODEL_ENV = "LOOPX_MODEL_BEHAVIOR_MODEL"
+
+_ALLOWED_MODELS = {DOUBAO_2_1_PRO_MODEL, DOUBAO_2_1_TURBO_MODEL}
+_MAX_PROVIDER_RESPONSE_BYTES = 1_048_576
+
+
+class DoubaoActorTransport(Protocol):
+    def __call__(
+        self,
+        *,
+        endpoint: str,
+        headers: Mapping[str, str],
+        body: bytes,
+        timeout_seconds: float,
+    ) -> Mapping[str, Any]: ...
+
+
+class DoubaoActorTransportError(RuntimeError):
+    pass
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    def redirect_request(
+        self,
+        req: Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> None:
+        return None
+
+
+def _direct_ark_transport(
+    *,
+    endpoint: str,
+    headers: Mapping[str, str],
+    body: bytes,
+    timeout_seconds: float,
+) -> Mapping[str, Any]:
+    if endpoint != DOUBAO_CHAT_COMPLETIONS_ENDPOINT:
+        raise DoubaoActorTransportError(
+            "Doubao actor endpoint is not the canonical Ark endpoint"
+        )
+    request = Request(endpoint, data=body, headers=dict(headers), method="POST")
+    opener = build_opener(_NoRedirectHandler())
+    try:
+        with opener.open(request, timeout=timeout_seconds) as response:
+            payload = response.read(_MAX_PROVIDER_RESPONSE_BYTES + 1)
+    except HTTPError as exc:
+        raise DoubaoActorTransportError(
+            f"Doubao actor request failed with HTTP status {exc.code}"
+        ) from None
+    except (URLError, TimeoutError):
+        raise DoubaoActorTransportError(
+            "Doubao actor provider transport failed"
+        ) from None
+    if len(payload) > _MAX_PROVIDER_RESPONSE_BYTES:
+        raise DoubaoActorTransportError("Doubao actor response exceeded the size limit")
+    try:
+        decoded = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        raise DoubaoActorTransportError("Doubao actor returned invalid JSON") from None
+    if not isinstance(decoded, Mapping):
+        raise DoubaoActorTransportError(
+            "Doubao actor provider response must be an object"
+        )
+    return decoded
+
+
+def _decision_instruction() -> str:
+    return """You are a LoopX control-plane decision simulator.
+Use only the qualification request supplied by the user. Do not call tools,
+execute work, or request external writes. Return exactly one JSON object with
+these fields and no others:
+{
+  "schema_version": "model_behavior_decision_v0",
+  "decision": "execute|wait|ask_user|stop",
+  "selected_todo_id": "todo_... or null",
+  "user_action_required": true|false,
+  "must_attempt_work": true|false,
+  "delivery_allowed": true|false,
+  "quiet_noop_allowed": true|false,
+  "external_write_requested": false,
+  "intended_action_kinds": ["read|inspect|edit|test|writeback|spend|notify|wait|stop"],
+  "reason_codes": ["compact_public_safe_token"]
+}
+Preserve user gates, selected work, execution obligations, write boundaries,
+spend timing, scheduler duties, and stop conditions from the packet. Output
+JSON only, without markdown or reasoning."""
+
+
+def _provider_decision(response: Mapping[str, Any]) -> Mapping[str, Any]:
+    choices = response.get("choices")
+    if not isinstance(choices, list) or len(choices) != 1:
+        raise RuntimeError("Doubao actor response must contain exactly one choice")
+    choice = choices[0]
+    if not isinstance(choice, Mapping):
+        raise RuntimeError("Doubao actor choice must be an object")
+    message = choice.get("message")
+    if not isinstance(message, Mapping):
+        raise RuntimeError("Doubao actor choice is missing its message")
+    content = message.get("content")
+    if not isinstance(content, str) or not content.strip():
+        raise RuntimeError("Doubao actor message content must be non-empty JSON")
+    try:
+        decision = json.loads(content)
+    except json.JSONDecodeError:
+        raise RuntimeError("Doubao actor message content is not valid JSON") from None
+    if not isinstance(decision, Mapping):
+        raise RuntimeError("Doubao actor decision must be an object")
+    return decision
+
+
+class DoubaoModelBehaviorActor(ModelBehaviorActor):
+    """Direct Ark actor for low-frequency, no-tool behavior qualification."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str = DOUBAO_2_1_PRO_MODEL,
+        timeout_seconds: float = 90.0,
+        transport: DoubaoActorTransport = _direct_ark_transport,
+    ) -> None:
+        if not api_key.strip():
+            raise RuntimeError("Doubao actor requires a runtime-injected API key")
+        if model not in _ALLOWED_MODELS:
+            raise ValueError(
+                "Doubao actor model must be an allowlisted Doubao 2.1 model"
+            )
+        if timeout_seconds <= 0 or timeout_seconds > 300:
+            raise ValueError("Doubao actor timeout must be between 0 and 300 seconds")
+        self._api_key = api_key
+        self._model = model
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    @classmethod
+    def from_environment(
+        cls,
+        *,
+        environ: Mapping[str, str] | None = None,
+        transport: DoubaoActorTransport = _direct_ark_transport,
+        timeout_seconds: float = 90.0,
+    ) -> DoubaoModelBehaviorActor:
+        values = os.environ if environ is None else environ
+        api_key = values.get(ARK_API_KEY_ENV, "")
+        if not api_key.strip():
+            raise RuntimeError(
+                "ARK_API_KEY is not injected; live Doubao qualification is unavailable"
+            )
+        model = values.get(DOUBAO_MODEL_ENV, DOUBAO_2_1_PRO_MODEL)
+        return cls(
+            api_key=api_key,
+            model=model,
+            timeout_seconds=timeout_seconds,
+            transport=transport,
+        )
+
+    def __call__(self, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        canonical_request = normalize_model_behavior_actor_request(request)
+        body = {
+            "model": self._model,
+            "messages": [
+                {"role": "system", "content": _decision_instruction()},
+                {
+                    "role": "user",
+                    "content": json.dumps(
+                        canonical_request,
+                        ensure_ascii=False,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                },
+            ],
+            "response_format": {"type": "json_object"},
+            "temperature": 0,
+            "max_tokens": 1200,
+            "stream": False,
+        }
+        try:
+            response = self._transport(
+                endpoint=DOUBAO_CHAT_COMPLETIONS_ENDPOINT,
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+                body=json.dumps(
+                    body,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode("utf-8"),
+                timeout_seconds=self._timeout_seconds,
+            )
+        except DoubaoActorTransportError:
+            raise
+        except Exception:
+            raise DoubaoActorTransportError(
+                "Doubao actor provider transport failed"
+            ) from None
+        return {
+            "schema_version": MODEL_BEHAVIOR_ACTOR_RESULT_SCHEMA_VERSION,
+            "actor_ref": f"ark:{self._model}",
+            "decision": dict(_provider_decision(response)),
+            "tool_calls": [],
+        }

--- a/loopx/control_plane/testing/model_behavior_qualification.py
+++ b/loopx/control_plane/testing/model_behavior_qualification.py
@@ -204,6 +204,26 @@ def build_model_behavior_actor_request(
     }
 
 
+def normalize_model_behavior_actor_request(raw: Mapping[str, Any]) -> dict[str, Any]:
+    """Rebuild and verify a canonical actor request before provider transport."""
+
+    if not isinstance(raw, Mapping):
+        raise ValueError("actor request must be an object")
+    if raw.get("schema_version") != MODEL_BEHAVIOR_ACTOR_REQUEST_SCHEMA_VERSION:
+        raise ValueError("actor request must use model_behavior_actor_request_v0")
+    packet = raw.get("packet")
+    if not isinstance(packet, Mapping):
+        raise ValueError("actor request packet must be an object")
+    canonical = build_model_behavior_actor_request(
+        packet,
+        qualification_id=str(raw.get("qualification_id") or ""),
+        arm=str(raw.get("arm") or ""),
+    )
+    if dict(raw) != canonical:
+        raise ValueError("actor request does not match the canonical no-write contract")
+    return canonical
+
+
 def normalize_model_behavior_actor_result(raw: Mapping[str, Any]) -> dict[str, Any]:
     if not isinstance(raw, Mapping):
         raise ValueError("actor result must be an object")

--- a/tests/control_plane/test_doubao_model_behavior_actor.py
+++ b/tests/control_plane/test_doubao_model_behavior_actor.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from loopx.control_plane.testing.doubao_model_behavior_actor import (
+    DOUBAO_2_1_PRO_MODEL,
+    DOUBAO_CHAT_COMPLETIONS_ENDPOINT,
+    DoubaoModelBehaviorActor,
+)
+from loopx.control_plane.testing.model_behavior_qualification import (
+    build_model_behavior_actor_request,
+    normalize_model_behavior_actor_result,
+)
+
+
+def _request() -> dict[str, Any]:
+    return build_model_behavior_actor_request(
+        {"schema_version": "loopx_turn_envelope_v0"},
+        qualification_id="case-direct-doubao-001",
+        arm="candidate_packet",
+    )
+
+
+def _decision() -> dict[str, Any]:
+    return {
+        "schema_version": "model_behavior_decision_v0",
+        "decision": "execute",
+        "selected_todo_id": "todo_fixture001",
+        "user_action_required": False,
+        "must_attempt_work": True,
+        "delivery_allowed": True,
+        "quiet_noop_allowed": False,
+        "external_write_requested": False,
+        "intended_action_kinds": ["inspect", "test", "writeback"],
+        "reason_codes": ["bounded_delivery"],
+    }
+
+
+def test_direct_actor_uses_canonical_endpoint_without_tools_or_raw_retention() -> None:
+    captured: dict[str, Any] = {}
+
+    def transport(
+        *,
+        endpoint: str,
+        headers: Mapping[str, str],
+        body: bytes,
+        timeout_seconds: float,
+    ) -> Mapping[str, Any]:
+        captured.update(
+            endpoint=endpoint,
+            headers=dict(headers),
+            body=json.loads(body),
+            timeout_seconds=timeout_seconds,
+        )
+        return {"choices": [{"message": {"content": json.dumps(_decision())}}]}
+
+    actor = DoubaoModelBehaviorActor(
+        api_key="fixture-key-not-a-secret",
+        transport=transport,
+        timeout_seconds=12,
+    )
+    result = normalize_model_behavior_actor_result(actor(_request()))
+
+    assert captured["endpoint"] == DOUBAO_CHAT_COMPLETIONS_ENDPOINT
+    expected_authorization = "Bearer " + "fixture-key-not-a-secret"
+    assert captured["headers"]["Authorization"] == expected_authorization
+    assert captured["body"]["model"] == DOUBAO_2_1_PRO_MODEL
+    assert captured["body"]["response_format"] == {"type": "json_object"}
+    assert "tools" not in captured["body"]
+    assert captured["timeout_seconds"] == 12
+    assert result["actor_ref"] == f"ark:{DOUBAO_2_1_PRO_MODEL}"
+    assert result["tool_calls"] == []
+    assert "fixture-key" not in json.dumps(result, sort_keys=True)
+
+
+def test_environment_factory_fails_closed_without_injected_key() -> None:
+    with pytest.raises(RuntimeError, match="ARK_API_KEY is not injected"):
+        DoubaoModelBehaviorActor.from_environment(environ={})
+
+    with pytest.raises(ValueError, match="allowlisted Doubao 2.1"):
+        DoubaoModelBehaviorActor.from_environment(
+            environ={
+                "ARK_API_KEY": "fixture-key-not-a-secret",
+                "LOOPX_MODEL_BEHAVIOR_MODEL": "future-model-v9",
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "response, message",
+    [
+        ({}, "exactly one choice"),
+        ({"choices": [{"message": {"content": "not-json"}}]}, "not valid JSON"),
+        (
+            {"choices": [{"message": {"content": "[]"}}]},
+            "decision must be an object",
+        ),
+    ],
+)
+def test_actor_rejects_malformed_provider_responses(
+    response: Mapping[str, Any], message: str
+) -> None:
+    actor = DoubaoModelBehaviorActor(
+        api_key="fixture-key-not-a-secret",
+        transport=lambda **_: response,
+    )
+    with pytest.raises(RuntimeError, match=message):
+        actor(_request())
+
+
+def test_actor_sanitizes_unexpected_transport_errors() -> None:
+    def transport(**_: Any) -> Mapping[str, Any]:
+        raise OSError("provider error containing private transport detail")
+
+    actor = DoubaoModelBehaviorActor(
+        api_key="fixture-key-not-a-secret",
+        transport=transport,
+    )
+    with pytest.raises(RuntimeError) as exc_info:
+        actor(_request())
+
+    assert str(exc_info.value) == "Doubao actor provider transport failed"
+
+
+def test_actor_rejects_noncanonical_request_before_transport() -> None:
+    called = False
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal called
+        called = True
+        return {}
+
+    actor = DoubaoModelBehaviorActor(
+        api_key="fixture-key-not-a-secret",
+        transport=transport,
+    )
+    request = _request()
+    request["sandbox"] = {**request["sandbox"], "tools_enabled": True}
+
+    with pytest.raises(ValueError, match="canonical no-write contract"):
+        actor(request)
+    assert called is False


### PR DESCRIPTION
## Summary

- add a direct Ark `DoubaoModelBehaviorActor` for low-frequency full-packet versus TurnEnvelope behavior qualification
- allowlist the versioned Doubao 2.1 Pro/Turbo models and canonical Ark endpoint, reject redirects, tools, arbitrary base URLs, malformed responses, and non-canonical actor requests
- keep `ARK_API_KEY` runtime-only, sanitize transport failures, and retain only the existing compact receipts and pair results

## Product and architecture

The provider-neutral qualification core remains unchanged in ownership. This PR adds one optional provider edge under `control_plane.testing`; it is not wired into `quota should-run`, CI, PR smoke, or any default agent path. The adapter reconstructs and validates the canonical no-write request before provider transport, so direct calls cannot silently bypass packet redaction and sandbox constraints.

The live model call remains a manual or low-frequency shadow operation. The current host did not expose `ARK_API_KEY`, so no credential store was inspected and no live call was attempted through OpenViking or another service.

## Validation

- `pytest -q tests/control_plane/test_doubao_model_behavior_actor.py tests/control_plane/test_model_behavior_qualification.py tests/test_turn_envelope.py` (35 passed)
- `pytest -q tests/control_plane tests/test_turn_envelope.py tests/test_operator_markdown_renderers.py` (104 passed)
- focused `ruff check` and `ruff format --check`
- strict mypy on both qualification modules
- docs governance smoke
- public-boundary check clean for all four changed paths
- standard premerge canary passed all selected checks with no failures

## Boundaries

- no default-output, routing, quota, scheduler, permission, benchmark, or production behavior change
- no live API call, tool call, filesystem/external write, raw model response, conversation, trajectory, credential, local path, or private material committed
- missing provider access and any behavior drift keep the full packet as the default
