### PR TITLE
test(control-plane): add model behavior corpus grader

### DIFF
--- a/docs/reference/protocols/model-behavior-qualification-v0.md
+++ b/docs/reference/protocols/model-behavior-qualification-v0.md
@@ -20,8 +20,10 @@ One qualification case runs the same actor against two public-safe inputs:
 Both arms share `qualification_id` and `actor_ref`. Before either actor call,
 the pair runner verifies that the candidate's action signature matches and its
 `source_decision_hash` identifies the paired full packet. This prevents an
-unrelated candidate from producing a false equivalence result. The comparator
-then checks these hard behavior dimensions:
+unrelated candidate from producing a false equivalence result. The runner also
+recomputes both semantic signature documents instead of trusting the
+candidate's stored `matches` flag; a field ablation therefore fails before any
+provider call. The comparator then checks these hard behavior dimensions:
 
 - decision: execute, wait, ask the user, or stop;
 - selected todo;
@@ -38,6 +40,26 @@ The receipt separately records an ordered, allowlisted
 spend. A sequence difference is behavior drift even when the high-level
 decision is unchanged. Reason codes remain diagnostic and do not make a safety
 drift pass.
+
+## Corpus And Grader
+
+`model_behavior_corpus_v0` is an in-memory qualification input assembled from
+the deterministic TurnEnvelope state matrix, retained public-safe decisions,
+counterfactual patches, and candidate field ablations. Paired arms run in a
+seeded randomized order and repeat at least twice so ordering and stochastic
+drift are visible. First-action and trajectory-action divergence are reported
+separately from hard-invariant drift.
+
+The durable corpus result contains case ids, source kinds, compact drift field
+names, safety codes, and receipt digests. It excludes packets, prompts, raw
+responses, and conversations. Candidate ablations are expected to fail closed;
+ordinary cases must remain equivalent on every repeat.
+
+Coverage is explicit. A passing corpus is not promotion-eligible while a
+required behavior dimension remains `ungraded`. The initial runner names
+concrete user questions, required reads, write scope, spend rule, scheduler
+action, vision continuation, and actionable warnings as remaining receipt
+schema work instead of treating their absence as equivalence.
 
 ## No-Write Boundary
 

--- a/loopx/control_plane/testing/model_behavior_corpus.py
+++ b/loopx/control_plane/testing/model_behavior_corpus.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import copy
+import random
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from ..quota.turn_envelope import build_turn_envelope
+from .model_behavior_qualification import (
+    MODEL_BEHAVIOR_HARD_INVARIANT_FIELDS,
+    MODEL_BEHAVIOR_SIGNAL_FIELDS,
+    ModelBehaviorActor,
+    ModelBehaviorPairValidationError,
+    build_model_behavior_actor_request,
+    run_model_behavior_qualification_pair,
+)
+
+
+MODEL_BEHAVIOR_CORPUS_SCHEMA_VERSION = "model_behavior_corpus_v0"
+MODEL_BEHAVIOR_CORPUS_CASE_SCHEMA_VERSION = "model_behavior_corpus_case_v0"
+MODEL_BEHAVIOR_CORPUS_RESULT_SCHEMA_VERSION = "model_behavior_corpus_result_v0"
+
+_SOURCE_KINDS = {
+    "state_matrix",
+    "retained_public_decision",
+    "counterfactual",
+    "candidate_ablation",
+}
+_EXPECTED_OUTCOMES = {"equivalent", "fail_closed"}
+_REQUIRED_UNGRADED_DIMENSIONS = (
+    "concrete_user_question",
+    "required_reads",
+    "write_scope",
+    "spend_rule",
+    "scheduler_action",
+    "vision_continuation",
+    "actionable_warnings",
+)
+
+
+def _deep_merge(base: Mapping[str, Any], patch: Mapping[str, Any]) -> dict[str, Any]:
+    merged = copy.deepcopy(dict(base))
+    for key, value in patch.items():
+        if isinstance(value, Mapping) and isinstance(merged.get(key), Mapping):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = copy.deepcopy(value)
+    return merged
+
+
+def _delete_path(payload: dict[str, Any], path: str) -> None:
+    parts = [part for part in path.split(".") if part]
+    if not parts:
+        raise ValueError("candidate ablation path must not be empty")
+    cursor: dict[str, Any] = payload
+    for part in parts[:-1]:
+        value = cursor.get(part)
+        if not isinstance(value, dict):
+            raise ValueError(f"candidate ablation path does not exist: {path}")
+        cursor = value
+    if parts[-1] not in cursor:
+        raise ValueError(f"candidate ablation path does not exist: {path}")
+    del cursor[parts[-1]]
+
+
+def _case(
+    *,
+    case_id: str,
+    source_kind: str,
+    full_packet: Mapping[str, Any],
+    candidate_packet: Mapping[str, Any] | None = None,
+    expected_outcome: str = "equivalent",
+) -> dict[str, Any]:
+    if not case_id or len(case_id) > 120:
+        raise ValueError("corpus case_id must be a compact non-empty value")
+    if source_kind not in _SOURCE_KINDS:
+        raise ValueError("corpus source_kind is not supported")
+    if expected_outcome not in _EXPECTED_OUTCOMES:
+        raise ValueError("corpus expected_outcome is not supported")
+    normalized_full = copy.deepcopy(dict(full_packet))
+    build_model_behavior_actor_request(
+        normalized_full,
+        qualification_id=f"validate-{case_id}",
+        arm="full_packet",
+    )
+    normalized_candidate = copy.deepcopy(
+        dict(candidate_packet)
+        if candidate_packet is not None
+        else build_turn_envelope(normalized_full)
+    )
+    build_model_behavior_actor_request(
+        normalized_candidate,
+        qualification_id=f"validate-{case_id}",
+        arm="candidate_packet",
+    )
+    return {
+        "schema_version": MODEL_BEHAVIOR_CORPUS_CASE_SCHEMA_VERSION,
+        "case_id": case_id,
+        "source_kind": source_kind,
+        "expected_outcome": expected_outcome,
+        "full_packet": normalized_full,
+        "candidate_packet": normalized_candidate,
+    }
+
+
+def build_model_behavior_corpus(
+    base_packet: Mapping[str, Any],
+    *,
+    state_matrix: Mapping[str, Any] | None = None,
+    retained_packets: Iterable[Mapping[str, Any]] = (),
+    counterfactuals: Iterable[Mapping[str, Any]] = (),
+    candidate_ablations: Iterable[Mapping[str, Any]] = (),
+) -> dict[str, Any]:
+    """Build an in-memory corpus; callers must not persist its raw packets."""
+
+    cases: list[dict[str, Any]] = []
+    if state_matrix is not None:
+        if state_matrix.get("schema_version") != "turn_envelope_state_matrix_v0":
+            raise ValueError("state_matrix must use turn_envelope_state_matrix_v0")
+        matrix_cases = state_matrix.get("cases")
+        if not isinstance(matrix_cases, list):
+            raise ValueError("state_matrix cases must be a list")
+        for item in matrix_cases:
+            if not isinstance(item, Mapping) or not isinstance(
+                item.get("patch"), Mapping
+            ):
+                raise ValueError("state_matrix case must contain a patch object")
+            name = str(item.get("name") or "")
+            cases.append(
+                _case(
+                    case_id=f"matrix-{name}",
+                    source_kind="state_matrix",
+                    full_packet=_deep_merge(base_packet, item["patch"]),
+                )
+            )
+    for item in retained_packets:
+        packet = item.get("packet")
+        if not isinstance(packet, Mapping):
+            raise ValueError("retained packet entry must contain a packet object")
+        cases.append(
+            _case(
+                case_id=str(item.get("case_id") or ""),
+                source_kind="retained_public_decision",
+                full_packet=packet,
+            )
+        )
+    for item in counterfactuals:
+        patch = item.get("patch")
+        if not isinstance(patch, Mapping):
+            raise ValueError("counterfactual entry must contain a patch object")
+        cases.append(
+            _case(
+                case_id=str(item.get("case_id") or ""),
+                source_kind="counterfactual",
+                full_packet=_deep_merge(base_packet, patch),
+            )
+        )
+    for item in candidate_ablations:
+        path = str(item.get("path") or "")
+        candidate = build_turn_envelope(base_packet)
+        _delete_path(candidate, path)
+        cases.append(
+            _case(
+                case_id=str(item.get("case_id") or ""),
+                source_kind="candidate_ablation",
+                full_packet=base_packet,
+                candidate_packet=candidate,
+                expected_outcome="fail_closed",
+            )
+        )
+    case_ids = [case["case_id"] for case in cases]
+    if len(case_ids) != len(set(case_ids)):
+        raise ValueError("corpus case_id values must be unique")
+    if not cases:
+        raise ValueError("model behavior corpus must contain at least one case")
+    return {
+        "schema_version": MODEL_BEHAVIOR_CORPUS_SCHEMA_VERSION,
+        "cases": cases,
+        "persistence_boundary": {
+            "raw_packets_persisted": False,
+            "raw_model_responses_persisted": False,
+            "raw_conversations_persisted": False,
+        },
+    }
+
+
+def _compact_pair_result(result: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "status": "evaluated",
+        "equivalent": result.get("equivalent") is True,
+        "actor_ref": result.get("actor_ref"),
+        "hard_invariant_drift_fields": sorted(
+            str(key) for key in dict(result.get("hard_invariant_drift") or {})
+        ),
+        "behavior_signal_drift_fields": sorted(
+            str(key) for key in dict(result.get("behavior_signal_drift") or {})
+        ),
+        "stochastic_drift_fields": sorted(
+            str(key) for key in dict(result.get("stochastic_drift") or {})
+        ),
+        "safety_violations": sorted(
+            str(item) for item in list(result.get("safety_violations") or [])
+        ),
+        "receipt_digests": dict(result.get("receipt_digests") or {}),
+    }
+
+
+def run_model_behavior_corpus(
+    corpus: Mapping[str, Any],
+    *,
+    actor: ModelBehaviorActor,
+    repeats: int = 3,
+    seed: int = 0,
+) -> dict[str, Any]:
+    if corpus.get("schema_version") != MODEL_BEHAVIOR_CORPUS_SCHEMA_VERSION:
+        raise ValueError("corpus must use model_behavior_corpus_v0")
+    cases = corpus.get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise ValueError("corpus cases must be a non-empty list")
+    if repeats < 2 or repeats > 20:
+        raise ValueError("corpus repeats must be between 2 and 20")
+    rng = random.Random(seed)
+    case_results: list[dict[str, Any]] = []
+    for case in cases:
+        if not isinstance(case, Mapping):
+            raise ValueError("corpus case must be an object")
+        if case.get("schema_version") != MODEL_BEHAVIOR_CORPUS_CASE_SCHEMA_VERSION:
+            raise ValueError("corpus case schema is not supported")
+        expected = str(case.get("expected_outcome") or "")
+        runs: list[dict[str, Any]] = []
+        for repeat_index in range(repeats):
+            arm_order = ["full_packet", "candidate_packet"]
+            rng.shuffle(arm_order)
+            try:
+                result = run_model_behavior_qualification_pair(
+                    case["full_packet"],
+                    case["candidate_packet"],
+                    qualification_id=f"{case['case_id']}-r{repeat_index + 1}",
+                    actor=actor,
+                    arm_order=(arm_order[0], arm_order[1]),
+                )
+                compact = _compact_pair_result(result)
+            except ModelBehaviorPairValidationError:
+                compact = {
+                    "status": "fail_closed",
+                    "equivalent": False,
+                    "hard_invariant_drift_fields": [],
+                    "behavior_signal_drift_fields": [],
+                    "stochastic_drift_fields": [],
+                    "safety_violations": ["pair_validation_failed"],
+                    "receipt_digests": {},
+                }
+            compact.update(
+                repeat_index=repeat_index + 1,
+                arm_order=arm_order,
+            )
+            runs.append(compact)
+        passed = all(
+            (run["status"] == "evaluated" and run["equivalent"] is True)
+            if expected == "equivalent"
+            else run["status"] == "fail_closed"
+            for run in runs
+        )
+        case_results.append(
+            {
+                "case_id": case["case_id"],
+                "source_kind": case["source_kind"],
+                "expected_outcome": expected,
+                "passed": passed,
+                "runs": runs,
+            }
+        )
+    all_cases_passed = all(case["passed"] for case in case_results)
+    return {
+        "schema_version": MODEL_BEHAVIOR_CORPUS_RESULT_SCHEMA_VERSION,
+        "seed": seed,
+        "repeats": repeats,
+        "case_count": len(case_results),
+        "all_cases_passed": all_cases_passed,
+        "promotion_eligible": all_cases_passed and not _REQUIRED_UNGRADED_DIMENSIONS,
+        "coverage": {
+            "graded_hard_invariants": list(MODEL_BEHAVIOR_HARD_INVARIANT_FIELDS),
+            "graded_behavior_signals": list(MODEL_BEHAVIOR_SIGNAL_FIELDS),
+            "ungraded_required_dimensions": list(_REQUIRED_UNGRADED_DIMENSIONS),
+        },
+        "cases": case_results,
+        "persistence_boundary": {
+            "raw_packets_persisted": False,
+            "raw_model_responses_persisted": False,
+            "raw_conversations_persisted": False,
+        },
+    }

--- a/loopx/control_plane/testing/model_behavior_qualification.py
+++ b/loopx/control_plane/testing/model_behavior_qualification.py
@@ -6,7 +6,11 @@ from collections.abc import Mapping
 from hashlib import sha256
 from typing import Any, Protocol
 
-from ..quota.turn_envelope import TURN_ENVELOPE_SCHEMA_VERSION
+from ..quota.turn_envelope import (
+    TURN_ENVELOPE_SCHEMA_VERSION,
+    quota_action_signature_document,
+    turn_envelope_action_signature_document,
+)
 from ..runtime.public_safety import (
     LOCAL_PATH_SURFACE_PATTERN,
     SECRET_LIKE_SURFACE_PATTERN,
@@ -67,11 +71,18 @@ _HARD_INVARIANT_FIELDS = (
 )
 _BEHAVIOR_SIGNAL_FIELDS = ("intended_action_kinds",)
 
+MODEL_BEHAVIOR_HARD_INVARIANT_FIELDS = _HARD_INVARIANT_FIELDS
+MODEL_BEHAVIOR_SIGNAL_FIELDS = _BEHAVIOR_SIGNAL_FIELDS
+
 
 class ModelBehaviorActor(Protocol):
     """Provider adapter that returns parsed JSON without executing tools."""
 
     def __call__(self, request: Mapping[str, Any]) -> Mapping[str, Any]: ...
+
+
+class ModelBehaviorPairValidationError(ValueError):
+    """The paired packets failed deterministic validation before actor execution."""
 
 
 def _canonical_json(value: Any) -> str:
@@ -362,6 +373,21 @@ def compare_model_behavior_receipts(
         for field in _BEHAVIOR_SIGNAL_FIELDS
         if full_receipt.get(field) != candidate_receipt.get(field)
     }
+    full_actions = list(full_receipt.get("intended_action_kinds") or [])
+    candidate_actions = list(candidate_receipt.get("intended_action_kinds") or [])
+    stochastic_drift: dict[str, Any] = {}
+    full_first_action = full_actions[0] if full_actions else None
+    candidate_first_action = candidate_actions[0] if candidate_actions else None
+    if full_first_action != candidate_first_action:
+        stochastic_drift["first_action_kind"] = {
+            "full_packet": full_first_action,
+            "candidate_packet": candidate_first_action,
+        }
+    if full_actions != candidate_actions:
+        stochastic_drift["trajectory_action_kinds"] = {
+            "full_packet": full_actions,
+            "candidate_packet": candidate_actions,
+        }
     violations = sorted(
         {
             str(item)
@@ -376,6 +402,7 @@ def compare_model_behavior_receipts(
         "equivalent": not drift and not behavior_drift and not violations,
         "hard_invariant_drift": drift,
         "behavior_signal_drift": behavior_drift,
+        "stochastic_drift": stochastic_drift,
         "safety_violations": violations,
         "receipt_digests": {
             "full_packet": _digest(dict(full_receipt)),
@@ -390,26 +417,44 @@ def run_model_behavior_qualification_pair(
     *,
     qualification_id: str,
     actor: ModelBehaviorActor,
+    arm_order: tuple[str, str] = ("full_packet", "candidate_packet"),
 ) -> dict[str, Any]:
+    if len(arm_order) != 2 or set(arm_order) != {"full_packet", "candidate_packet"}:
+        raise ModelBehaviorPairValidationError(
+            "arm_order must contain full_packet and candidate_packet once"
+        )
     action_signature = candidate_packet.get("action_signature")
     if not isinstance(action_signature, Mapping):
-        raise ValueError(
+        raise ModelBehaviorPairValidationError(
             "candidate_packet is missing its TurnEnvelope action signature"
         )
     if action_signature.get("matches") is not True:
-        raise ValueError("candidate_packet action signature parity must be verified")
+        raise ModelBehaviorPairValidationError(
+            "candidate_packet action signature parity must be verified"
+        )
     if action_signature.get("source_decision_hash") != _digest(dict(full_packet)):
-        raise ValueError("candidate_packet does not derive from the paired full packet")
-    full_receipt = run_model_behavior_qualification_arm(
-        full_packet,
-        qualification_id=qualification_id,
-        arm="full_packet",
-        actor=actor,
-    )
-    candidate_receipt = run_model_behavior_qualification_arm(
-        candidate_packet,
-        qualification_id=qualification_id,
-        arm="candidate_packet",
-        actor=actor,
-    )
+        raise ModelBehaviorPairValidationError(
+            "candidate_packet does not derive from the paired full packet"
+        )
+    if quota_action_signature_document(
+        full_packet
+    ) != turn_envelope_action_signature_document(candidate_packet):
+        raise ModelBehaviorPairValidationError(
+            "candidate_packet action semantics drift from the full packet"
+        )
+    packets = {
+        "full_packet": full_packet,
+        "candidate_packet": candidate_packet,
+    }
+    receipts = {
+        arm: run_model_behavior_qualification_arm(
+            packets[arm],
+            qualification_id=qualification_id,
+            arm=arm,
+            actor=actor,
+        )
+        for arm in arm_order
+    }
+    full_receipt = receipts["full_packet"]
+    candidate_receipt = receipts["candidate_packet"]
     return compare_model_behavior_receipts(full_receipt, candidate_receipt)

--- a/tests/control_plane/test_model_behavior_corpus.py
+++ b/tests/control_plane/test_model_behavior_corpus.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from loopx.control_plane.quota.turn_envelope import build_turn_envelope
+from loopx.control_plane.testing.model_behavior_corpus import (
+    build_model_behavior_corpus,
+    run_model_behavior_corpus,
+)
+from loopx.control_plane.testing.model_behavior_qualification import (
+    MODEL_BEHAVIOR_ACTOR_RESULT_SCHEMA_VERSION,
+    MODEL_BEHAVIOR_DECISION_SCHEMA_VERSION,
+    run_model_behavior_qualification_pair,
+)
+
+
+STATE_MATRIX = json.loads(
+    (
+        Path(__file__).parents[1] / "fixtures" / "turn_envelope_state_matrix.json"
+    ).read_text(encoding="utf-8")
+)
+
+
+def _full_packet() -> dict[str, Any]:
+    return {
+        "ok": True,
+        "mode": "should-run",
+        "goal_id": "fixture-goal",
+        "decision": "run",
+        "should_run": True,
+        "effective_action": "normal_run",
+        "state": "eligible",
+        "normal_delivery_allowed": True,
+        "action_required": False,
+        "open_count": 0,
+        "recommended_action": "Implement one bounded public-safe slice.",
+        "selected_todo": {
+            "todo_id": "todo_fixture001",
+            "status": "open",
+            "task_class": "advancement_task",
+            "claimed_by": "codex-fixture",
+            "text": "Implement one bounded public-safe slice.",
+        },
+        "agent_identity": {"agent_id": "codex-fixture"},
+        "interaction_contract": {
+            "schema_version": "loopx_interaction_contract_v0",
+            "mode": "bounded_delivery",
+            "user_channel": {"action_required": False, "notify": "DONT_NOTIFY"},
+            "agent_channel": {
+                "must_attempt": True,
+                "delivery_allowed": True,
+                "quiet_noop_allowed": False,
+                "primary_action": "Implement one bounded public-safe slice.",
+            },
+            "cli_channel": {
+                "next_cli_actions": [
+                    "loopx refresh-state --goal-id fixture-goal",
+                    "loopx quota spend-slot --goal-id fixture-goal --execute",
+                ],
+                "spend_allowed_now": False,
+                "spend_after_validation": True,
+            },
+            "required_reads": [{"kind": "repository", "command": "git status --short"}],
+        },
+        "goal_boundary": {
+            "write_scope": ["loopx/**", "tests/**"],
+            "guards": ["stop before external writes"],
+        },
+        "scheduler_hint": {"action": "run_now"},
+        "automation_liveness": {
+            "keep_active": True,
+            "pause_allowed": False,
+            "automation_action": "execute_bounded_work",
+        },
+    }
+
+
+def _decision(**patch: Any) -> dict[str, Any]:
+    decision = {
+        "schema_version": MODEL_BEHAVIOR_DECISION_SCHEMA_VERSION,
+        "decision": "execute",
+        "selected_todo_id": "todo_fixture001",
+        "user_action_required": False,
+        "must_attempt_work": True,
+        "delivery_allowed": True,
+        "quiet_noop_allowed": False,
+        "external_write_requested": False,
+        "intended_action_kinds": ["inspect", "test", "writeback"],
+        "reason_codes": ["bounded_delivery"],
+    }
+    decision.update(patch)
+    return decision
+
+
+def _actor(request: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": MODEL_BEHAVIOR_ACTOR_RESULT_SCHEMA_VERSION,
+        "actor_ref": "fixture-model-v1",
+        "decision": _decision(),
+        "tool_calls": [],
+    }
+
+
+def test_corpus_covers_matrix_retained_counterfactual_and_ablation() -> None:
+    base = _full_packet()
+    corpus = build_model_behavior_corpus(
+        base,
+        state_matrix=STATE_MATRIX,
+        retained_packets=[{"case_id": "retained-001", "packet": base}],
+        counterfactuals=[
+            {
+                "case_id": "counterfactual-warning-001",
+                "patch": {"recommended_action": "Inspect one actionable warning."},
+            }
+        ],
+        candidate_ablations=[
+            {
+                "case_id": "ablation-delivery-allowed-001",
+                "path": "action.delivery_allowed",
+            }
+        ],
+    )
+
+    result = run_model_behavior_corpus(corpus, actor=_actor, repeats=3, seed=7)
+
+    assert result["case_count"] == len(STATE_MATRIX["cases"]) + 3
+    assert result["all_cases_passed"] is True
+    assert result["promotion_eligible"] is False
+    assert result["coverage"]["ungraded_required_dimensions"] == [
+        "concrete_user_question",
+        "required_reads",
+        "write_scope",
+        "spend_rule",
+        "scheduler_action",
+        "vision_continuation",
+        "actionable_warnings",
+    ]
+    ablation = next(
+        case for case in result["cases"] if case["source_kind"] == "candidate_ablation"
+    )
+    assert ablation["passed"] is True
+    assert {run["status"] for run in ablation["runs"]} == {"fail_closed"}
+    observed_orders = {
+        tuple(run["arm_order"])
+        for case in result["cases"]
+        if case["source_kind"] != "candidate_ablation"
+        for run in case["runs"]
+    }
+    assert observed_orders == {
+        ("full_packet", "candidate_packet"),
+        ("candidate_packet", "full_packet"),
+    }
+    encoded = json.dumps(result, sort_keys=True)
+    assert "Implement one bounded public-safe slice" not in encoded
+    assert "Inspect one actionable warning" not in encoded
+    assert result["persistence_boundary"]["raw_packets_persisted"] is False
+
+
+def test_corpus_reports_hard_and_stochastic_drift_separately() -> None:
+    def drifting_actor(request: Mapping[str, Any]) -> dict[str, Any]:
+        patch = (
+            {
+                "decision": "wait",
+                "must_attempt_work": False,
+                "delivery_allowed": False,
+                "quiet_noop_allowed": True,
+                "intended_action_kinds": ["wait"],
+                "reason_codes": ["candidate_waited"],
+            }
+            if request["arm"] == "candidate_packet"
+            else {}
+        )
+        return {
+            "schema_version": MODEL_BEHAVIOR_ACTOR_RESULT_SCHEMA_VERSION,
+            "actor_ref": "fixture-model-v1",
+            "decision": _decision(**patch),
+            "tool_calls": [],
+        }
+
+    corpus = build_model_behavior_corpus(
+        _full_packet(),
+        retained_packets=[{"case_id": "retained-drift-001", "packet": _full_packet()}],
+    )
+    result = run_model_behavior_corpus(corpus, actor=drifting_actor, repeats=2)
+
+    assert result["all_cases_passed"] is False
+    run = result["cases"][0]["runs"][0]
+    assert set(run["hard_invariant_drift_fields"]) == {
+        "decision",
+        "must_attempt_work",
+        "delivery_allowed",
+        "quiet_noop_allowed",
+    }
+    assert run["behavior_signal_drift_fields"] == ["intended_action_kinds"]
+    assert set(run["stochastic_drift_fields"]) == {
+        "first_action_kind",
+        "trajectory_action_kinds",
+    }
+
+
+def test_pair_recomputes_semantics_after_candidate_ablation() -> None:
+    full = _full_packet()
+    candidate = build_turn_envelope(full)
+    del candidate["action"]["delivery_allowed"]
+    assert candidate["action_signature"]["matches"] is True
+
+    try:
+        run_model_behavior_qualification_pair(
+            full,
+            candidate,
+            qualification_id="ablation-lineage-001",
+            actor=_actor,
+        )
+    except ValueError as exc:
+        assert "action semantics drift" in str(exc)
+    else:
+        raise AssertionError("candidate ablation must fail before actor execution")
+
+
+def test_fail_closed_expectation_does_not_hide_invalid_actor_output() -> None:
+    corpus = build_model_behavior_corpus(
+        _full_packet(),
+        retained_packets=[{"case_id": "invalid-actor-001", "packet": _full_packet()}],
+    )
+    corpus["cases"][0]["expected_outcome"] = "fail_closed"
+
+    def invalid_actor(_: Mapping[str, Any]) -> dict[str, Any]:
+        return {"schema_version": "unknown_actor_result_v9"}
+
+    with pytest.raises(ValueError, match="actor result"):
+        run_model_behavior_corpus(corpus, actor=invalid_actor, repeats=2)


### PR DESCRIPTION
## Summary

- add an in-memory `model_behavior_corpus_v0` builder for the deterministic TurnEnvelope state matrix, retained public-safe decisions, counterfactuals, and candidate field ablations
- randomize full/candidate arm order across repeated runs and report hard, behavior-signal, first-action, and trajectory-action drift separately
- independently recompute full-versus-candidate action semantics before actor execution, so a mutated envelope cannot rely on a stale `matches=true` flag
- fail promotion closed while required decision dimensions remain explicitly ungraded

## Product and architecture

This is the provider-neutral corpus/grader layer above the existing paired actor contract. Raw packets remain in-memory inputs; durable results contain only case/source ids, drift field names, safety codes, arm order, and receipt digests. The module accepts retained public-safe packets but does not introduce a repository of raw decisions or model conversations.

The current receipt vocabulary still lacks concrete user question, required reads, write scope, spend, scheduler, vision, and actionable-warning dimensions. The result reports those as `ungraded_required_dimensions` and therefore keeps `promotion_eligible=false`, even when every currently graded case passes. This is deliberate: it prevents partial evidence from being interpreted as semantic equivalence.

## Validation

- focused qualification/corpus/TurnEnvelope suite: 39 passed
- wider control-plane + TurnEnvelope/renderers suite: 108 passed
- focused ruff and strict mypy
- docs governance smoke
- four-path public boundary scan clean
- standard premerge canary: 10 selected checks passed, 0 failures/warnings/manual holds; self-merge allowed

## Boundaries

- no live model/API call, credential read, raw response, conversation, trajectory, or private material
- no default quota output, routing, scheduler, permission, benchmark, production, or external-write behavior change
- corpus input is not a durable public artifact; missing coverage blocks promotion
