### PR TITLE
feat(lark): productize event inbox collector lifecycle

### DIFF
--- a/docs/capabilities/lark-event-inbox.md
+++ b/docs/capabilities/lark-event-inbox.md
@@ -12,9 +12,14 @@ Lark event stream
   -> loopx lark-inbox ack --message-id ... --execute
 ```
 
-The collector is host infrastructure. On macOS it may be supervised by
-`launchd`; other hosts may use systemd or another restart policy. It should
-filter before persistence and write one compact event per Lark
+The collector is host infrastructure. LoopX can validate a local-private
+collector config, preview or explicitly install a macOS `launchd` / Linux
+`systemd` user service, and report supervisor plus event-bus health. The
+installed service runs `lark-cli event consume` directly with a bounded timeout,
+so stdin EOF under a supervisor cannot terminate an otherwise unbounded
+consumer. When the official npm package exposes a Node wrapper, LoopX records
+absolute paths for both Node and the wrapper so launchd does not depend on an
+interactive-shell PATH. It filters before persistence and writes one compact event per Lark
 `event_id`/`message_id`. The agent does not need to keep a websocket open.
 
 Use `addressed_only` only when direct bot mentions are the entire feedback
@@ -46,6 +51,85 @@ configuration or host state and must not enter public LoopX packets.
 reports `thread_complete=false` and a coverage warning for that mode. For
 `configured_chat_all`, the collector's jq filter should select the configured
 chat only; do not add a content-level `@bot` predicate.
+
+## Host collector lifecycle
+
+Keep the collector config ignored and untracked. It references the generic
+inbox config but owns host-only details such as the chat id and supervisor:
+
+```json
+{
+  "schema_version": "lark_event_collector_config_v0",
+  "enabled": true,
+  "service_name": "loopx-lark-feedback",
+  "event_key": "im.message.receive_v1",
+  "identity": "bot",
+  "supervisor": "launchd",
+  "chat_id": "oc_<local-private-chat-id>",
+  "consume_timeout": "30m",
+  "lark_cli_bin": "lark-cli",
+  "event_inbox_config": ".loopx/config/lark/event-inbox.json"
+}
+```
+
+The packaged v0 lifecycle accepts only `im.message.receive_v1`, bot identity,
+an isolated `loopx-` service name, and `configured_chat_all`. These constraints
+match the canonical inbox schema, avoid collisions with unrelated user services,
+and make thread completeness explicit instead of pretending that an
+`addressed_only` consumer sees later unaddressed replies. Plan and install
+output never returns the chat id, local paths, generated jq, or credentials.
+
+```bash
+loopx lark-inbox collector-plan \
+  --project . \
+  --config .loopx/config/lark/collector.json
+
+# Preview first; this writes nothing and starts no process.
+loopx lark-inbox collector-install \
+  --project . \
+  --config .loopx/config/lark/collector.json
+
+# Explicitly write the user service and start/restart it.
+loopx lark-inbox collector-install \
+  --project . \
+  --config .loopx/config/lark/collector.json \
+  --execute
+
+# Read-only supervisor, event-bus, and real-event evidence check.
+loopx lark-inbox collector-status \
+  --project . \
+  --config .loopx/config/lark/collector.json \
+  --probe-event-bus
+```
+
+Missing `lark-cli` produces a non-blocking install hint. Missing scopes or bot
+configuration still belong to `lark-cli`; LoopX does not authenticate a bot,
+copy app credentials, or silently install packages. Service installation is a
+local host write and therefore requires explicit `--execute`. Status separates
+`healthy` from `real_event_evidence_present`: a running subscriber can be
+healthy before the first message, while acceptance of a real integration still
+requires one post-install event to appear in the inbox.
+
+Register the generic inbox pointer once at the goal boundary:
+
+```bash
+loopx configure-goal \
+  --goal-id <goal-id> \
+  --lark-event-inbox-config .loopx/config/lark/event-inbox.json
+
+# Review the preview, then apply explicitly.
+loopx configure-goal \
+  --goal-id <goal-id> \
+  --lark-event-inbox-config .loopx/config/lark/event-inbox.json \
+  --execute
+```
+
+The configuration catalog exposes this optional capability on demand. Quota
+projects only `enabled`, `config_pointer_registered`, and a public-safe command,
+never the private path. Generated heartbeat bodies conditionally run the actual
+goal-boundary `drain_command`; `loopx lark-inbox drain --goal-id <goal-id> --project .`
+resolves the ignored config from the goal registry. A disabled or empty inbox
+is a quiet zero-spend path, so projects without Lark keep the default behavior.
 
 ## Drain and acknowledge
 

--- a/examples/control_plane/heartbeat-prompt-smoke.py
+++ b/examples/control_plane/heartbeat-prompt-smoke.py
@@ -134,6 +134,13 @@ def main() -> int:
     assert_no_project_specific_prompt_leaks("compact", str(compact_payload["task_body"]))
     assert_no_project_specific_prompt_leaks("brief", str(brief_payload["task_body"]))
     assert_no_project_specific_prompt_leaks("thin", str(thin_payload["task_body"]))
+    for prompt_payload in (payload, compact_payload, brief_payload, thin_payload):
+        task_body = str(prompt_payload["task_body"])
+        assert "lark_event_inbox" in task_body, task_body
+        assert "drain" in task_body and "ACK" in task_body, task_body
+        if prompt_payload is not payload:
+            assert "drain_command" in task_body, task_body
+            assert "writeback" in task_body, task_body
     thin_task = str(thin_payload["task_body"])
     assert "Observed runtime capabilities -> `--available-capability`, never user gates." in thin_task, thin_task
     assert payload["quota_guard_command"] == (
@@ -332,9 +339,9 @@ def main() -> int:
         "RRULE then run `ack_hint.cli_args`",
         "CLI/Claude final-check; no spend",
         "Bounded batch/quiet no-op; spend after writeback",
-        "Plans/done -> LoopX todo/rationale; 2 no-progress -> self-repair",
-        "If P0 is blocked but CLI contract permits safe work",
-        "monitor-only quiet skips stay active/no-spend",
+        "Plans/done -> todo/rationale; 2 stalls -> self-repair",
+        "P0 blocked: continue safe P1/P2",
+        "monitor-only quiet/no-spend",
         "No project-specific branches here",
         "Do not consume the learning material queue unless explicitly asked",
         "Stop for private material, credentials, destructive git, or unauthorized production actions",

--- a/examples/lark-event-collector-lifecycle-smoke.py
+++ b/examples/lark-event-collector-lifecycle-smoke.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from loopx.capabilities.lark.event_collector import (  # noqa: E402
+    inspect_lark_event_collector,
+    install_lark_event_collector,
+    plan_lark_event_collector,
+)
+
+
+def completed(argv: list[str], returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(argv, returncode, stdout="", stderr="")
+
+
+with tempfile.TemporaryDirectory(prefix="loopx-lark-collector-") as raw:
+    temp = Path(raw)
+    project = temp / "project"
+    home = temp / "home"
+    bin_dir = temp / "bin"
+    project.mkdir()
+    home.mkdir()
+    bin_dir.mkdir()
+    subprocess.run(["git", "init", "-q", str(project)], check=True)
+    (project / ".gitignore").write_text(".loopx/\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(project), "add", ".gitignore"], check=True)
+    lark_cli = bin_dir / "lark-cli"
+    lark_cli.write_text("#!/usr/bin/env node\n", encoding="utf-8")
+    lark_cli.chmod(0o755)
+    node = bin_dir / "node"
+    node.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    node.chmod(0o755)
+    config_dir = project / ".loopx" / "config" / "lark"
+    config_dir.mkdir(parents=True)
+    inbox_config = config_dir / "event-inbox.json"
+    inbox_config.write_text(
+        json.dumps(
+            {
+                "schema_version": "lark_event_inbox_config_v0",
+                "enabled": True,
+                "inbox_dir": ".loopx/inbox/team-feedback",
+                "capture_scope": "configured_chat_all",
+            }
+        ),
+        encoding="utf-8",
+    )
+    collector_config = config_dir / "collector.json"
+    collector_config.write_text(
+        json.dumps(
+            {
+                "schema_version": "lark_event_collector_config_v0",
+                "enabled": True,
+                "service_name": "loopx-lark-feedback",
+                "event_key": "im.message.receive_v1",
+                "identity": "bot",
+                "supervisor": "launchd",
+                "chat_id": "oc_private_fixture_chat",
+                "consume_timeout": "30m",
+                "lark_cli_bin": "lark-cli",
+                "event_inbox_config": ".loopx/config/lark/event-inbox.json",
+            }
+        ),
+        encoding="utf-8",
+    )
+    previous_home = os.environ.get("HOME")
+    previous_path = os.environ.get("PATH")
+    os.environ["HOME"] = str(home)
+    os.environ["PATH"] = f"{bin_dir}:{previous_path or ''}"
+    calls: list[list[str]] = []
+
+    def runner(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        calls.append(list(argv))
+        if argv[:2] == ["launchctl", "print"]:
+            return subprocess.CompletedProcess(
+                argv, 0, stdout="state = running\n", stderr=""
+            )
+        return completed(argv)
+
+    try:
+        plan = plan_lark_event_collector(project=project, config_path=collector_config)
+        assert plan["status"] == "install_ready", plan
+        assert plan["thread_complete"] is True, plan
+        assert plan["chat_id_returned"] is False, plan
+        assert "oc_private_fixture_chat" not in json.dumps(plan), plan
+        preview = install_lark_event_collector(
+            project=project,
+            config_path=collector_config,
+            runner=runner,
+        )
+        assert preview["status"] == "preview_ready", preview
+        assert preview["would_write_service"] is True, preview
+        assert calls == [
+            [str(node), str(lark_cli), "event", "consume", "--help"]
+        ], calls
+
+        installed = install_lark_event_collector(
+            project=project,
+            config_path=collector_config,
+            execute=True,
+            runner=runner,
+        )
+        assert installed["status"] == "installed", installed
+        assert installed["write_performed"] is True, installed
+        assert any(call[:2] == ["launchctl", "bootstrap"] for call in calls), calls
+        plist = home / "Library" / "LaunchAgents" / "loopx-lark-feedback.plist"
+        assert plist.is_file(), plist
+        plist_text = plist.read_text(encoding="utf-8")
+        assert str(node) in plist_text, plist_text
+        assert str(lark_cli) in plist_text, plist_text
+
+        inbox = project / ".loopx" / "inbox" / "team-feedback"
+        inbox.mkdir(parents=True)
+        (inbox / "om_fixture.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "lark_event_inbox_event_v0",
+                    "event_id": "om_fixture",
+                    "message_id": "om_fixture",
+                    "create_time": "1",
+                    "content": "public-safe fixture",
+                }
+            ),
+            encoding="utf-8",
+        )
+        status = inspect_lark_event_collector(
+            project=project,
+            config_path=collector_config,
+            probe_event_bus=True,
+            runner=runner,
+        )
+        assert status["healthy"] is True, status
+        assert status["real_event_evidence_present"] is True, status
+        assert status["captured_event_count"] == 1, status
+        assert status["local_paths_returned"] is False, status
+        assert status["chat_id_returned"] is False, status
+
+        unsupported = json.loads(collector_config.read_text())
+        unsupported["event_key"] = "im.message.reaction.created_v1"
+        collector_config.write_text(json.dumps(unsupported), encoding="utf-8")
+        try:
+            plan_lark_event_collector(
+                project=project,
+                config_path=collector_config,
+            )
+        except ValueError as exc:
+            assert "im.message.receive_v1" in str(exc), exc
+        else:
+            raise AssertionError("unsupported event key should fail closed")
+        unsupported["event_key"] = "im.message.receive_v1"
+        unsupported["identity"] = "user"
+        collector_config.write_text(json.dumps(unsupported), encoding="utf-8")
+        try:
+            plan_lark_event_collector(
+                project=project,
+                config_path=collector_config,
+            )
+        except ValueError as exc:
+            assert "identity must be bot" in str(exc), exc
+        else:
+            raise AssertionError("unsupported identity should fail closed")
+        unsupported["identity"] = "bot"
+        collector_config.write_text(json.dumps(unsupported), encoding="utf-8")
+
+        addressed = json.loads(inbox_config.read_text())
+        addressed["capture_scope"] = "addressed_only"
+        inbox_config.write_text(json.dumps(addressed), encoding="utf-8")
+        failed = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--format",
+                "json",
+                "lark-inbox",
+                "collector-plan",
+                "--project",
+                str(project),
+                "--config",
+                str(collector_config),
+            ],
+            cwd=ROOT,
+            env=os.environ,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert failed.returncode == 1, failed.stdout
+        error = json.loads(failed.stdout)
+        assert "configured_chat_all" in error["error"], error
+    finally:
+        if previous_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = previous_home
+        if previous_path is None:
+            os.environ.pop("PATH", None)
+        else:
+            os.environ["PATH"] = previous_path
+
+print("lark event collector lifecycle smoke: ok")

--- a/examples/lark-event-inbox-smoke.py
+++ b/examples/lark-event-inbox-smoke.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -138,6 +139,51 @@ def main() -> None:
 
         processed = json.loads((inbox / "processed.json").read_text(encoding="utf-8"))
         assert processed["schema_version"] == "lark_event_inbox_processed_v0"
+
+        registry = project / ".loopx" / "registry.json"
+        registry.write_text(
+            json.dumps(
+                {
+                    "goals": [
+                        {
+                            "id": "lark-inbox-fixture",
+                            "control_plane": {
+                                "lark_event_inbox": {
+                                    "enabled": True,
+                                    "config_path": ".loopx/config/lark-event-inbox.json",
+                                }
+                            },
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        discovered = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--registry",
+                str(registry),
+                "--format",
+                "json",
+                "lark-inbox",
+                "drain",
+                "--goal-id",
+                "lark-inbox-fixture",
+                "--project",
+                str(project),
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert discovered.returncode == 0, discovered.stderr
+        discovered_payload = json.loads(discovered.stdout)
+        assert discovered_payload["configured"] is True, discovered_payload
+        assert discovered_payload["pending_count"] == 0, discovered_payload
 
         outside = project / ".loopx" / "config" / "outside.json"
         outside.write_text(

--- a/examples/project/configure-goal-smoke.py
+++ b/examples/project/configure-goal-smoke.py
@@ -152,6 +152,8 @@ def main() -> int:
             "gate-fixture-1",
             "--issue-fix-reviewer-notification-config",
             ".loopx/config/issue-fix/reviewer-notification-sinks.json",
+            "--lark-event-inbox-config",
+            ".loopx/config/lark/event-inbox.json",
         ))
         assert dry["ok"] is True, dry
         assert dry["dry_run"] is True, dry
@@ -162,6 +164,7 @@ def main() -> int:
         assert "configured_agent_model" in dry["changed_fields"], dry
         assert "write_scope" in dry["changed_fields"], dry
         assert "issue_fix_reviewer_notification" in dry["changed_fields"], dry
+        assert "lark_event_inbox" in dry["changed_fields"], dry
         assert dry["after"]["waiting_on"] == "user_or_controller", dry
         assert dry["after"]["write_scope"] == ["docs/**", "tests/**"], dry
         assert dry["after"]["checkpointed_boundary_authority"]["active_write_scope"] == ["docs/**"], dry
@@ -171,19 +174,31 @@ def main() -> int:
             "enabled": True,
             "config_pointer_registered": True,
         }, dry
+        assert dry["after"]["lark_event_inbox"] == {
+            "enabled": True,
+            "config_pointer_registered": True,
+        }, dry
         assert dry["feature_summary"]["multi_subagent"] == "enabled", dry
         catalog = dry["configuration_catalog"]
         assert catalog["schema_version"] == "loopx_goal_configuration_catalog_v0", catalog
         assert catalog["scope"] == "default_off_optional_capabilities", catalog
         assert catalog["disclosure_policy"]["first_run_configuration_required"] is False
         features = {item["feature_id"]: item for item in catalog["features"]}
-        assert set(features) == {"multi_subagent", "explore_graph", "explore_harness"}
+        assert set(features) == {
+            "multi_subagent",
+            "explore_graph",
+            "explore_harness",
+            "lark_event_inbox",
+        }
         assert features["multi_subagent"]["current"]["enabled"] is True
         assert features["explore_graph"]["current"]["enabled"] is False
         assert "--execute" not in features["explore_harness"]["commands"]["preview_enable"]
         assert "--execute" in features["explore_harness"]["commands"]["apply_enable"]
         assert "--execute" not in features["explore_graph"]["commands"]["preview_disable"]
         assert "--execute" in features["explore_graph"]["commands"]["apply_disable"]
+        assert features["lark_event_inbox"]["current"]["enabled"] is True
+        assert "--execute" not in features["lark_event_inbox"]["commands"]["preview_enable"]
+        assert "--execute" in features["lark_event_inbox"]["commands"]["apply_enable"]
         migration = dry["heartbeat_prompt_migration"]
         assert migration["schema_version"] == "heartbeat_prompt_migration_v1", migration
         assert "agent identity changed" in migration["reason"], migration
@@ -232,6 +247,8 @@ def main() -> int:
             "gate-fixture-1",
             "--issue-fix-reviewer-notification-config",
             ".loopx/config/issue-fix/reviewer-notification-sinks.json",
+            "--lark-event-inbox-config",
+            ".loopx/config/lark/event-inbox.json",
             "--execute",
         ))
         assert applied["ok"] is True, applied
@@ -262,10 +279,21 @@ def main() -> int:
             "enabled": True,
             "config_path": ".loopx/config/issue-fix/reviewer-notification-sinks.json",
         }, reviewer_policy
+        assert goal["control_plane"]["lark_event_inbox"] == {
+            "enabled": True,
+            "config_path": ".loopx/config/lark/event-inbox.json",
+        }, goal
         boundary = goal_boundary(goal)
         assert boundary["capabilities"]["issue_fix_reviewer_notification"] == {
             "enabled": True,
             "config_pointer_registered": True,
+        }, boundary
+        assert boundary["capabilities"]["lark_event_inbox"] == {
+            "enabled": True,
+            "config_pointer_registered": True,
+            "drain_command": (
+                "loopx lark-inbox drain --goal-id configure-goal-fixture --project ."
+            ),
         }, boundary
         authority = goal["coordination"]["checkpointed_boundary_authority"][0]
         assert authority["schema_version"] == "checkpointed_boundary_authority_v0", authority

--- a/loopx/capabilities/lark/__init__.py
+++ b/loopx/capabilities/lark/__init__.py
@@ -1,6 +1,12 @@
 """Lark/Feishu capability facade for presentation sinks."""
 
 from ...presentation.sinks.lark import explore_results, kanban, message_card
-from . import event_inbox
+from . import event_collector, event_inbox
 
-__all__ = ["event_inbox", "explore_results", "kanban", "message_card"]
+__all__ = [
+    "event_collector",
+    "event_inbox",
+    "explore_results",
+    "kanban",
+    "message_card",
+]

--- a/loopx/capabilities/lark/event_collector.py
+++ b/loopx/capabilities/lark/event_collector.py
@@ -1,0 +1,403 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import plistlib
+import re
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from .event_inbox import inspect_lark_event_inbox, load_lark_event_inbox_config
+
+
+CONFIG_SCHEMA_VERSION = "lark_event_collector_config_v0"
+PLAN_SCHEMA_VERSION = "lark_event_collector_plan_v0"
+STATUS_SCHEMA_VERSION = "lark_event_collector_status_v0"
+INSTALL_SCHEMA_VERSION = "lark_event_collector_install_v0"
+SERVICE_RE = re.compile(r"^loopx-[a-z0-9][a-z0-9._-]{1,73}$")
+CHAT_RE = re.compile(r"^oc_[A-Za-z0-9_-]+$")
+TIMEOUT_RE = re.compile(r"^[1-9][0-9]*(?:s|m|h)$")
+SUPPORTED_SUPERVISORS = {"launchd", "systemd"}
+SUPPORTED_EVENT_KEY = "im.message.receive_v1"
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def _project_config_path(project: str | Path, raw: str | Path) -> Path:
+    root = Path(project).expanduser().resolve()
+    path = Path(raw).expanduser()
+    path = path if path.is_absolute() else root / path
+    path = path.resolve()
+    try:
+        relative = path.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("lark collector config must stay inside the project") from exc
+    tracked = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "--error-unmatch", "--", str(relative)],
+        capture_output=True,
+        check=False,
+    )
+    ignored = subprocess.run(
+        ["git", "-C", str(root), "check-ignore", "--quiet", "--", str(relative)],
+        capture_output=True,
+        check=False,
+    )
+    if tracked.returncode == 0 or ignored.returncode != 0:
+        raise ValueError("lark collector config must be ignored and untracked")
+    return path
+
+
+def _relative_project_path(root: Path, raw: object, label: str) -> tuple[str, Path]:
+    value = str(raw or "").strip().replace("\\", "/")
+    if not value or value.startswith("/") or ".." in Path(value).parts:
+        raise ValueError(f"{label} must be a project-relative path")
+    path = (root / value).resolve()
+    try:
+        path.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"{label} escapes the project") from exc
+    return value, path
+
+
+def load_lark_event_collector_config(
+    *, project: str | Path, config_path: str | Path
+) -> dict[str, Any]:
+    root = Path(project).expanduser().resolve()
+    path = _project_config_path(root, config_path)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            "lark collector config must be a readable JSON object"
+        ) from exc
+    if (
+        not isinstance(payload, Mapping)
+        or payload.get("schema_version") != CONFIG_SCHEMA_VERSION
+    ):
+        raise ValueError(
+            f"lark collector config schema_version must be {CONFIG_SCHEMA_VERSION}"
+        )
+    enabled = payload.get("enabled") is True
+    service_name = str(payload.get("service_name") or "loopx-lark-collector").strip()
+    event_key = str(payload.get("event_key") or "im.message.receive_v1").strip()
+    identity = str(payload.get("identity") or "bot").strip()
+    supervisor = str(payload.get("supervisor") or "").strip()
+    chat_id = str(payload.get("chat_id") or "").strip()
+    timeout = str(payload.get("consume_timeout") or "30m").strip()
+    lark_cli_bin = str(payload.get("lark_cli_bin") or "lark-cli").strip()
+    if not SERVICE_RE.fullmatch(service_name):
+        raise ValueError("service_name must be a lowercase loopx- service token")
+    if event_key != SUPPORTED_EVENT_KEY:
+        raise ValueError(
+            f"collector v0 event_key must be {SUPPORTED_EVENT_KEY}"
+        )
+    if identity != "bot":
+        raise ValueError("collector v0 identity must be bot")
+    if supervisor not in SUPPORTED_SUPERVISORS:
+        raise ValueError("supervisor must be launchd or systemd")
+    if not CHAT_RE.fullmatch(chat_id):
+        raise ValueError("chat_id must be a Lark oc_ chat id")
+    if not TIMEOUT_RE.fullmatch(timeout):
+        raise ValueError("consume_timeout must use a bounded duration such as 30m")
+    if Path(lark_cli_bin).name != lark_cli_bin or not lark_cli_bin:
+        raise ValueError("lark_cli_bin must be a command name, not a path")
+    inbox_config_ref, inbox_config_path = _relative_project_path(
+        root, payload.get("event_inbox_config"), "event_inbox_config"
+    )
+    inbox = load_lark_event_inbox_config(project=root, config_path=inbox_config_path)
+    if enabled and not inbox["enabled"]:
+        raise ValueError("enabled collector requires an enabled event inbox")
+    if enabled and not inbox["thread_complete"]:
+        raise ValueError(
+            "collector lifecycle currently requires configured_chat_all capture"
+        )
+    return {
+        "enabled": enabled,
+        "project": root,
+        "config_path": path,
+        "service_name": service_name,
+        "event_key": event_key,
+        "identity": identity,
+        "supervisor": supervisor,
+        "chat_id": chat_id,
+        "consume_timeout": timeout,
+        "lark_cli_bin": lark_cli_bin,
+        "event_inbox_config_ref": inbox_config_ref,
+        "inbox": inbox,
+    }
+
+
+def _jq_projection(chat_id: str) -> str:
+    chat_literal = json.dumps(chat_id, ensure_ascii=False)
+    return (
+        f"select(.chat_id == {chat_literal}) | "
+        '{schema_version:"lark_event_inbox_event_v0",'
+        "event_id:(.event_id // .message_id),message_id:.message_id,"
+        "create_time:.create_time,content:.content,sender_id:.sender_id,"
+        "chat_id:.chat_id}"
+    )
+
+
+def _executable_prefix(executable: str) -> list[str]:
+    path = Path(executable)
+    try:
+        first_line = path.open(encoding="utf-8").readline().strip()
+    except (OSError, UnicodeDecodeError):
+        return [executable]
+    if first_line == "#!/usr/bin/env node":
+        node = shutil.which("node")
+        if node is None:
+            raise ValueError(
+                "lark-cli uses a Node wrapper but node is not available on PATH"
+            )
+        return [node, executable]
+    return [executable]
+
+
+def _collector_argv(config: Mapping[str, Any], executable: str) -> list[str]:
+    inbox_path = Path(config["inbox"]["inbox_path"])
+    relative_inbox = inbox_path.relative_to(Path(config["project"]))
+    return [
+        *_executable_prefix(executable),
+        "event",
+        "consume",
+        str(config["event_key"]),
+        "--as",
+        str(config["identity"]),
+        "--timeout",
+        str(config["consume_timeout"]),
+        "--jq",
+        _jq_projection(str(config["chat_id"])),
+        "--output-dir",
+        relative_inbox.as_posix(),
+    ]
+
+
+def _service_file(config: Mapping[str, Any]) -> Path:
+    name = str(config["service_name"])
+    if config["supervisor"] == "launchd":
+        return Path.home() / "Library" / "LaunchAgents" / f"{name}.plist"
+    return Path.home() / ".config" / "systemd" / "user" / f"{name}.service"
+
+
+def _service_payload(config: Mapping[str, Any], argv: Sequence[str]) -> bytes:
+    root = Path(config["project"])
+    runtime = root / ".loopx" / "runtime" / "lark-collector"
+    if config["supervisor"] == "launchd":
+        return plistlib.dumps(
+            {
+                "Label": str(config["service_name"]),
+                "ProgramArguments": list(argv),
+                "WorkingDirectory": str(root),
+                "RunAtLoad": True,
+                "KeepAlive": True,
+                "ThrottleInterval": 5,
+                "StandardOutPath": str(runtime / "collector.stdout.log"),
+                "StandardErrorPath": str(runtime / "collector.stderr.log"),
+            },
+            sort_keys=True,
+        )
+    command = " ".join(shlex.quote(value) for value in argv)
+    return (
+        "[Unit]\nDescription=LoopX Lark event collector\nAfter=network-online.target\n\n"
+        "[Service]\nType=simple\n"
+        f"WorkingDirectory={root}\nExecStart={command}\n"
+        "Restart=always\nRestartSec=5\n\n"
+        "[Install]\nWantedBy=default.target\n"
+    ).encode()
+
+
+def _plan(config: Mapping[str, Any]) -> tuple[dict[str, Any], list[str], bytes]:
+    executable = shutil.which(str(config["lark_cli_bin"]))
+    argv = _collector_argv(config, executable or str(config["lark_cli_bin"]))
+    service_payload = _service_payload(config, argv)
+    return (
+        {
+            "ok": True,
+            "schema_version": PLAN_SCHEMA_VERSION,
+            "enabled": config["enabled"],
+            "status": "install_ready" if executable else "dependency_missing",
+            "service_name": config["service_name"],
+            "supervisor": config["supervisor"],
+            "event_key": config["event_key"],
+            "identity": config["identity"],
+            "capture_scope": config["inbox"]["capture_scope"],
+            "thread_complete": config["inbox"]["thread_complete"],
+            "lark_cli_available": executable is not None,
+            "install_hint": (
+                None
+                if executable
+                else "Install and configure lark-cli, then rerun the collector plan."
+            ),
+            "service_digest": hashlib.sha256(service_payload).hexdigest()[:16],
+            "local_paths_returned": False,
+            "chat_id_returned": False,
+            "credentials_returned": False,
+            "external_writes_performed": False,
+        },
+        argv,
+        service_payload,
+    )
+
+
+def plan_lark_event_collector(
+    *, project: str | Path, config_path: str | Path
+) -> dict[str, Any]:
+    config = load_lark_event_collector_config(project=project, config_path=config_path)
+    plan, _, _ = _plan(config)
+    return plan
+
+
+def _run(runner: Runner, argv: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return runner(list(argv), capture_output=True, text=True, check=False)
+
+
+def _event_consume_available(runner: Runner, executable: str) -> bool:
+    support = _run(
+        runner,
+        [*_executable_prefix(executable), "event", "consume", "--help"],
+    )
+    return support.returncode == 0
+
+
+def install_lark_event_collector(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    execute: bool = False,
+    runner: Runner = subprocess.run,
+) -> dict[str, Any]:
+    config = load_lark_event_collector_config(project=project, config_path=config_path)
+    plan, _, _ = _plan(config)
+    if not config["enabled"]:
+        raise ValueError("cannot install a disabled lark collector")
+    if not plan["lark_cli_available"]:
+        return {**plan, "schema_version": INSTALL_SCHEMA_VERSION, "execute": execute}
+    executable = shutil.which(str(config["lark_cli_bin"]))
+    if not _event_consume_available(runner, str(executable)):
+        return {
+            **plan,
+            "schema_version": INSTALL_SCHEMA_VERSION,
+            "ok": False,
+            "status": "dependency_incompatible",
+            "execute": execute,
+            "install_hint": "Upgrade lark-cli to a version with event consume support.",
+        }
+    argv = _collector_argv(config, str(executable))
+    service_payload = _service_payload(config, argv)
+    if not execute:
+        return {
+            **plan,
+            "schema_version": INSTALL_SCHEMA_VERSION,
+            "status": "preview_ready",
+            "execute": False,
+            "would_write_service": True,
+        }
+    service_path = _service_file(config)
+    service_path.parent.mkdir(parents=True, exist_ok=True)
+    (Path(config["project"]) / ".loopx" / "runtime" / "lark-collector").mkdir(
+        parents=True, exist_ok=True
+    )
+    temporary = service_path.with_suffix(service_path.suffix + ".tmp")
+    temporary.write_bytes(service_payload)
+    temporary.replace(service_path)
+    if config["supervisor"] == "launchd":
+        domain = f"gui/{os.getuid()}"
+        _run(runner, ["launchctl", "bootout", f"{domain}/{config['service_name']}"])
+        started = _run(runner, ["launchctl", "bootstrap", domain, str(service_path)])
+        if started.returncode == 0:
+            started = _run(
+                runner,
+                ["launchctl", "kickstart", "-k", f"{domain}/{config['service_name']}"],
+            )
+    else:
+        reloaded = _run(runner, ["systemctl", "--user", "daemon-reload"])
+        started = (
+            _run(
+                runner,
+                ["systemctl", "--user", "enable", "--now", str(config["service_name"])],
+            )
+            if reloaded.returncode == 0
+            else reloaded
+        )
+    return {
+        **plan,
+        "schema_version": INSTALL_SCHEMA_VERSION,
+        "status": "installed" if started.returncode == 0 else "supervisor_start_failed",
+        "ok": started.returncode == 0,
+        "execute": True,
+        "write_performed": True,
+        "supervisor_start_performed": True,
+        "supervisor_start_succeeded": started.returncode == 0,
+    }
+
+
+def inspect_lark_event_collector(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    probe_event_bus: bool = False,
+    runner: Runner = subprocess.run,
+) -> dict[str, Any]:
+    config = load_lark_event_collector_config(project=project, config_path=config_path)
+    plan, _, _ = _plan(config)
+    service_path = _service_file(config)
+    if config["supervisor"] == "launchd":
+        observed = _run(
+            runner,
+            ["launchctl", "print", f"gui/{os.getuid()}/{config['service_name']}"],
+        )
+    else:
+        observed = _run(
+            runner,
+            ["systemctl", "--user", "is-active", str(config["service_name"])],
+        )
+    bus_healthy = None
+    if probe_event_bus and plan["lark_cli_available"]:
+        executable = shutil.which(str(config["lark_cli_bin"]))
+        bus = _run(
+            runner, [str(executable), "event", "status", "--json", "--fail-on-orphan"]
+        )
+        bus_healthy = bus.returncode == 0
+    inbox_status = inspect_lark_event_inbox(
+        project=config["project"],
+        config_path=config["event_inbox_config_ref"],
+        limit=1,
+    )
+    event_count = int(inbox_status.get("captured_count") or 0)
+    active = observed.returncode == 0 and (
+        config["supervisor"] != "launchd" or "state = running" in observed.stdout
+    )
+    installed = service_path.is_file()
+    healthy = bool(
+        config["enabled"]
+        and plan["lark_cli_available"]
+        and installed
+        and active
+        and (bus_healthy is not False)
+    )
+    return {
+        "ok": True,
+        "schema_version": STATUS_SCHEMA_VERSION,
+        "enabled": config["enabled"],
+        "status": "healthy" if healthy else "attention_required",
+        "healthy": healthy,
+        "service_name": config["service_name"],
+        "supervisor": config["supervisor"],
+        "installed": installed,
+        "active": active,
+        "lark_cli_available": plan["lark_cli_available"],
+        "event_bus_probe_performed": probe_event_bus,
+        "event_bus_healthy": bus_healthy,
+        "captured_event_count": event_count,
+        "real_event_evidence_present": event_count > 0,
+        "thread_complete": config["inbox"]["thread_complete"],
+        "local_paths_returned": False,
+        "chat_id_returned": False,
+        "credentials_returned": False,
+        "external_writes_performed": False,
+    }

--- a/loopx/capabilities/lark/event_inbox.py
+++ b/loopx/capabilities/lark/event_inbox.py
@@ -225,6 +225,7 @@ def inspect_lark_event_inbox(
             else "addressed_only capture does not include unaddressed thread replies"
         ),
         "pending_count": len(pending),
+        "captured_count": len(events),
         "returned_count": len(bounded),
         "processed_count": len(processed),
         "invalid_count": invalid_count,

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -430,6 +430,7 @@ def main(argv: list[str] | None = None) -> int:
 
     lark_inbox_result = handle_lark_inbox_command(
         args,
+        registry_path=registry_path,
         output_format=output_format,
         print_payload=print_payload,
     )

--- a/loopx/cli_commands/lark_inbox.py
+++ b/loopx/cli_commands/lark_inbox.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from pathlib import Path
 from typing import Callable
 
 from ..capabilities.lark.event_inbox import (
@@ -10,6 +11,43 @@ from ..capabilities.lark.event_inbox import (
     ingest_lark_event_inbox,
     inspect_lark_event_inbox,
 )
+from ..capabilities.lark.event_collector import (
+    inspect_lark_event_collector,
+    install_lark_event_collector,
+    plan_lark_event_collector,
+)
+from ..registry import read_json, registry_goals
+
+
+def _goal_inbox_config(registry_path: Path, goal_id: str) -> str | None:
+    payload = read_json(registry_path)
+    goal = next(
+        (item for item in registry_goals(payload) if str(item.get("id")) == goal_id),
+        None,
+    )
+    if goal is None:
+        raise ValueError(f"goal_id not found in registry: {goal_id}")
+    control_plane = (
+        goal.get("control_plane")
+        if isinstance(goal.get("control_plane"), dict)
+        else {}
+    )
+    inbox = (
+        control_plane.get("lark_event_inbox")
+        if isinstance(control_plane.get("lark_event_inbox"), dict)
+        else {}
+    )
+    if inbox.get("enabled") is not True:
+        return None
+    return str(inbox.get("config_path") or "").strip() or None
+
+
+def _inbox_config(args: argparse.Namespace, registry_path: Path) -> str | None:
+    if getattr(args, "config", None):
+        return str(args.config)
+    if getattr(args, "goal_id", None):
+        return _goal_inbox_config(registry_path, str(args.goal_id))
+    raise ValueError("lark inbox requires --config or --goal-id")
 
 
 def register_lark_inbox_commands(
@@ -27,7 +65,8 @@ def register_lark_inbox_commands(
     )
     add_subcommand_format(drain)
     drain.add_argument("--project", default=".")
-    drain.add_argument("--config", required=True)
+    drain.add_argument("--config")
+    drain.add_argument("--goal-id")
     drain.add_argument("--limit", type=int, default=20)
     ack = sub.add_parser(
         "ack",
@@ -35,7 +74,8 @@ def register_lark_inbox_commands(
     )
     add_subcommand_format(ack)
     ack.add_argument("--project", default=".")
-    ack.add_argument("--config", required=True)
+    ack.add_argument("--config")
+    ack.add_argument("--goal-id")
     ack.add_argument("--message-id", action="append", required=True)
     ack.add_argument("--execute", action="store_true")
     ingest = sub.add_parser(
@@ -47,8 +87,32 @@ def register_lark_inbox_commands(
     )
     add_subcommand_format(ingest)
     ingest.add_argument("--project", default=".")
-    ingest.add_argument("--config", required=True)
+    ingest.add_argument("--config")
+    ingest.add_argument("--goal-id")
     ingest.add_argument("--execute", action="store_true")
+    collector_plan = sub.add_parser(
+        "collector-plan",
+        help="Validate a local-private collector config and preview host setup.",
+    )
+    add_subcommand_format(collector_plan)
+    collector_plan.add_argument("--project", default=".")
+    collector_plan.add_argument("--config", required=True)
+    collector_install = sub.add_parser(
+        "collector-install",
+        help="Preview or explicitly install the configured launchd/systemd collector.",
+    )
+    add_subcommand_format(collector_install)
+    collector_install.add_argument("--project", default=".")
+    collector_install.add_argument("--config", required=True)
+    collector_install.add_argument("--execute", action="store_true")
+    collector_status = sub.add_parser(
+        "collector-status",
+        help="Inspect collector installation, supervisor state, and event evidence.",
+    )
+    add_subcommand_format(collector_status)
+    collector_status.add_argument("--project", default=".")
+    collector_status.add_argument("--config", required=True)
+    collector_status.add_argument("--probe-event-bus", action="store_true")
 
 
 def _read_stdin_events() -> list[object]:
@@ -84,6 +148,7 @@ def _render(payload: dict[str, object]) -> str:
 def handle_lark_inbox_command(
     args: argparse.Namespace,
     *,
+    registry_path: Path,
     output_format: Callable[..., str],
     print_payload: Callable,
 ) -> int | None:
@@ -91,24 +156,61 @@ def handle_lark_inbox_command(
         return None
     try:
         if args.lark_inbox_command == "drain":
+            config_path = _inbox_config(args, registry_path)
+            if config_path is None:
+                payload = {
+                    "ok": True,
+                    "schema_version": "lark_event_inbox_projection_v0",
+                    "enabled": False,
+                    "configured": False,
+                    "pending_count": 0,
+                    "items": [],
+                    "local_private_content_returned": False,
+                    "external_reads_performed": False,
+                }
+                print_payload(payload, output_format(args), _render)
+                return 0
             payload = inspect_lark_event_inbox(
                 project=args.project,
-                config_path=args.config,
+                config_path=config_path,
                 limit=args.limit,
             )
         elif args.lark_inbox_command == "ack":
+            config_path = _inbox_config(args, registry_path)
+            if config_path is None:
+                raise ValueError("goal does not configure a Lark event inbox")
             payload = acknowledge_lark_event_inbox(
                 project=args.project,
-                config_path=args.config,
+                config_path=config_path,
                 message_ids=args.message_id,
                 execute=args.execute,
             )
-        else:
+        elif args.lark_inbox_command == "ingest":
+            config_path = _inbox_config(args, registry_path)
+            if config_path is None:
+                raise ValueError("goal does not configure a Lark event inbox")
             payload = ingest_lark_event_inbox(
                 project=args.project,
-                config_path=args.config,
+                config_path=config_path,
                 events=_read_stdin_events(),
                 execute=args.execute,
+            )
+        elif args.lark_inbox_command == "collector-plan":
+            payload = plan_lark_event_collector(
+                project=args.project,
+                config_path=args.config,
+            )
+        elif args.lark_inbox_command == "collector-install":
+            payload = install_lark_event_collector(
+                project=args.project,
+                config_path=args.config,
+                execute=args.execute,
+            )
+        else:
+            payload = inspect_lark_event_collector(
+                project=args.project,
+                config_path=args.config,
+                probe_event_bus=args.probe_event_bus,
             )
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         payload = {

--- a/loopx/cli_commands/registry_admin.py
+++ b/loopx/cli_commands/registry_admin.py
@@ -422,6 +422,18 @@ def register_registry_admin_commands(subparsers: argparse._SubParsersAction) -> 
         help="Remove the goal's automatic reviewer-notification config pointer.",
     )
     configure_goal_parser.add_argument(
+        "--lark-event-inbox-config",
+        help=(
+            "Register a repo-relative local-private generic Lark event inbox "
+            "config pointer under .loopx/config/."
+        ),
+    )
+    configure_goal_parser.add_argument(
+        "--clear-lark-event-inbox-config",
+        action="store_true",
+        help="Remove the goal's generic Lark event inbox config pointer.",
+    )
+    configure_goal_parser.add_argument(
         "--execute",
         action="store_true",
         help="Write the registry. Without this flag, configure-goal is a dry-run preview.",
@@ -627,6 +639,10 @@ def handle_registry_admin_command(
                 ),
                 clear_issue_fix_reviewer_notification_config=bool(
                     args.clear_issue_fix_reviewer_notification_config
+                ),
+                lark_event_inbox_config=args.lark_event_inbox_config,
+                clear_lark_event_inbox_config=bool(
+                    args.clear_lark_event_inbox_config
                 ),
                 execute=bool(args.execute),
             )

--- a/loopx/configuration_catalog.py
+++ b/loopx/configuration_catalog.py
@@ -41,6 +41,11 @@ def build_goal_configuration_catalog(
         if isinstance(feature_summary.get("explore_harness"), Mapping)
         else {}
     )
+    lark_event_inbox = (
+        feature_summary.get("lark_event_inbox")
+        if isinstance(feature_summary.get("lark_event_inbox"), Mapping)
+        else {}
+    )
     inspect_command = _configure_command(goal_id)
     multi_enable_args = (
         "--multi-subagent-feature",
@@ -223,6 +228,77 @@ def build_goal_configuration_catalog(
                     "url": (
                         "https://github.com/huangruiteng/loopx/blob/main/"
                         "docs/capabilities/explore/README.md"
+                    ),
+                },
+            },
+            {
+                "feature_id": "lark_event_inbox",
+                "display_name": "Lark event inbox",
+                "availability": "supported_opt_in",
+                "default": {"enabled": False},
+                "current": {
+                    "enabled": lark_event_inbox.get("enabled") is True,
+                    "config_pointer_registered": lark_event_inbox.get(
+                        "config_pointer_registered"
+                    )
+                    is True,
+                },
+                "required_inputs": {
+                    "ignored-inbox-config": (
+                        "Replace the placeholder with a repo-relative ignored JSON "
+                        "config under .loopx/config/."
+                    )
+                },
+                "consider_when": (
+                    "A goal should consume durable Lark feedback without keeping an "
+                    "agent process or hand-editing its heartbeat prompt."
+                ),
+                "effect": (
+                    "Projects a goal-configured generic inbox into quota and generated "
+                    "heartbeat drain behavior."
+                ),
+                "does_not": [
+                    "install lark-cli, authenticate a user, or configure bot credentials",
+                    "send Lark messages or turn inbound feedback into an automatic write",
+                ],
+                "commands": {
+                    "preview_enable": _configure_command(
+                        goal_id,
+                        "--lark-event-inbox-config",
+                        "<ignored-inbox-config>",
+                    ),
+                    "apply_enable": _configure_command(
+                        goal_id,
+                        "--lark-event-inbox-config",
+                        "<ignored-inbox-config>",
+                        execute=True,
+                    ),
+                    "preview_disable": _configure_command(
+                        goal_id, "--clear-lark-event-inbox-config"
+                    ),
+                    "apply_disable": _configure_command(
+                        goal_id, "--clear-lark-event-inbox-config", execute=True
+                    ),
+                    "verify": [
+                        inspect_command,
+                        shlex.join(
+                            [
+                                "loopx",
+                                "lark-inbox",
+                                "drain",
+                                "--goal-id",
+                                goal_id,
+                                "--project",
+                                ".",
+                            ]
+                        ),
+                    ],
+                },
+                "documentation": {
+                    "path": "docs/capabilities/lark-event-inbox.md",
+                    "url": (
+                        "https://github.com/huangruiteng/loopx/blob/main/"
+                        "docs/capabilities/lark-event-inbox.md"
                     ),
                 },
             },

--- a/loopx/configure_goal.py
+++ b/loopx/configure_goal.py
@@ -78,7 +78,26 @@ def _reviewer_notification_config_summary(goal: dict[str, Any]) -> dict[str, boo
     }
 
 
-def _local_private_config_path(value: str | None) -> str | None:
+def _lark_event_inbox_config_summary(goal: dict[str, Any]) -> dict[str, bool]:
+    control_plane = (
+        goal.get("control_plane")
+        if isinstance(goal.get("control_plane"), dict)
+        else {}
+    )
+    inbox = (
+        control_plane.get("lark_event_inbox")
+        if isinstance(control_plane.get("lark_event_inbox"), dict)
+        else {}
+    )
+    return {
+        "enabled": inbox.get("enabled") is True,
+        "config_pointer_registered": bool(inbox.get("config_path")),
+    }
+
+
+def _local_private_config_path(
+    value: str | None, *, label: str = "local-private config"
+) -> str | None:
     if value is None:
         return None
     text = str(value).strip().replace("\\", "/")
@@ -92,7 +111,7 @@ def _local_private_config_path(value: str | None) -> str | None:
         or path.suffix != ".json"
     ):
         raise ValueError(
-            "reviewer notification config must be a repo-relative JSON path "
+            f"{label} must be a repo-relative JSON path "
             "under .loopx/config/"
         )
     return path.as_posix()
@@ -174,6 +193,7 @@ def _settings_summary(goal: dict[str, Any]) -> dict[str, Any]:
         "issue_fix_reviewer_notification": _reviewer_notification_config_summary(
             goal
         ),
+        "lark_event_inbox": _lark_event_inbox_config_summary(goal),
         "explore_graph": compact_explore_graph_policy(goal.get("explore_graph")),
         "orchestration": orchestration,
         "waiting_on": goal.get("waiting_on"),
@@ -385,6 +405,8 @@ def configure_goal(
     clear_boundary_authority: bool = False,
     issue_fix_reviewer_notification_config: str | None = None,
     clear_issue_fix_reviewer_notification_config: bool = False,
+    lark_event_inbox_config: str | None = None,
+    clear_lark_event_inbox_config: bool = False,
     execute: bool = False,
 ) -> dict[str, Any]:
     if not registry_path.exists():
@@ -447,6 +469,11 @@ def configure_goal(
             "--clear-issue-fix-reviewer-notification-config cannot be combined "
             "with --issue-fix-reviewer-notification-config"
         )
+    if clear_lark_event_inbox_config and lark_event_inbox_config:
+        raise ValueError(
+            "--clear-lark-event-inbox-config cannot be combined with "
+            "--lark-event-inbox-config"
+        )
     if waiting_on and waiting_on not in WAITING_ON_CHOICES:
         raise ValueError("--waiting-on must be one of: " + ", ".join(WAITING_ON_CHOICES))
     if multi_subagent_feature is not None and multi_subagent_feature not in MULTI_SUBAGENT_FEATURE_CHOICES:
@@ -478,7 +505,12 @@ def configure_goal(
     supervised_agents = _clean_registered_agents(supervised_agents)
     write_scope = _clean_write_scope(write_scope)
     issue_fix_reviewer_notification_config = _local_private_config_path(
-        issue_fix_reviewer_notification_config
+        issue_fix_reviewer_notification_config,
+        label="reviewer notification config",
+    )
+    lark_event_inbox_config = _local_private_config_path(
+        lark_event_inbox_config,
+        label="lark event inbox config",
     )
 
     payload = read_json(registry_path)
@@ -605,6 +637,21 @@ def configure_goal(
             control_plane["issue_fix"] = issue_fix
         else:
             control_plane.pop("issue_fix", None)
+        goal["control_plane"] = control_plane
+
+    if lark_event_inbox_config is not None or clear_lark_event_inbox_config:
+        control_plane = (
+            goal.get("control_plane")
+            if isinstance(goal.get("control_plane"), dict)
+            else {}
+        )
+        if clear_lark_event_inbox_config:
+            control_plane.pop("lark_event_inbox", None)
+        else:
+            control_plane["lark_event_inbox"] = {
+                "enabled": True,
+                "config_path": lark_event_inbox_config,
+            }
         goal["control_plane"] = control_plane
 
     if explore_graph_enabled is not None:
@@ -805,6 +852,7 @@ def configure_goal(
             or {"enabled": False}
         ),
         "peer_supervisor": deepcopy(after.get("supervisor") or {"enabled": False}),
+        "lark_event_inbox": _lark_event_inbox_config_summary(goal),
         "default": "off",
         "configuration_entry": "multi_subagent_feature",
     }

--- a/loopx/control_plane/quota/goal_boundary.py
+++ b/loopx/control_plane/quota/goal_boundary.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shlex
 from typing import Any
 
 from ...benchmark_core import compact_run_permission_policy_for_quota
@@ -129,6 +130,28 @@ def goal_boundary(goal: dict[str, Any], item: dict[str, Any] | None = None) -> d
             "config_pointer_registered": bool(
                 reviewer_notification.get("config_path")
             ),
+        }
+    lark_event_inbox = (
+        control_plane.get("lark_event_inbox")
+        if isinstance(control_plane.get("lark_event_inbox"), dict)
+        else {}
+    )
+    if lark_event_inbox.get("enabled") is True:
+        drain_command = shlex.join(
+            [
+                "loopx",
+                "lark-inbox",
+                "drain",
+                "--goal-id",
+                str(goal.get("id") or ""),
+                "--project",
+                ".",
+            ]
+        )
+        boundary.setdefault("capabilities", {})["lark_event_inbox"] = {
+            "enabled": True,
+            "config_pointer_registered": bool(lark_event_inbox.get("config_path")),
+            "drain_command": drain_command,
         }
     if goal.get("next_probe"):
         boundary["next_probe"] = str(goal.get("next_probe"))

--- a/loopx/heartbeat_prompt.py
+++ b/loopx/heartbeat_prompt.py
@@ -537,6 +537,8 @@ run the quota guard:
 If that preflight still fails, do no implementation, adapter, file edit,
 research, exploration, or spend; return quiet `DONT_NOTIFY` with exact failure.
 
+`lark_event_inbox`: if configured, drain -> writeback -> ACK.
+
 If the result says `should_run=false`:
 
 - If `state=operator_gate`, treat it as a user/controller interaction. Read
@@ -743,6 +745,8 @@ Else quiet.
 Apply `scheduler_hint` stateful backoff for RRULE/backoff/self-stop; no spend.
 Action/open todo: list todos/questions; never only "owner gate";
 missing -> "具体 user todo 未投影，需修复 LoopX 状态投影"; false/0: 无用户待办/无需通知 or quiet.
+`lark_event_inbox`: `drain_command` -> writeback -> ACK;
+empty=no gate/spend.
 
 If `should_run=true`: fetch compact; read needed state priority slice + guard
 payload. Use `status --limit 3`; `review-packet --handoff-only`.
@@ -789,19 +793,22 @@ def render_compact_heartbeat_task_body(
     scope_block = f"\n{agent_scope_instruction}\n" if agent_scope_instruction else ""
     return f"""Advance `{goal_id}` using `{active_state}`.
 
-This compact LoopX heartbeat body keeps project-specific branches out.
+This compact LoopX heartbeat body stays generic.
 Put local policy in registry/state/adapter/`goal_boundary`.
 Expanded lifecycle contract: `{expanded_prompt_command}`.
 {scope_block}
 
-Before delivery, make CLI reachable; run guard:
+Run CLI preflight/guard:
 
 ```bash
 {cli_preflight}
 {quota_guard_command}
 ```
 
-Preflight fail: quiet `DONT_NOTIFY`; no work/spend.
+Preflight fail: quiet; no work/spend.
+
+`lark_event_inbox`: `drain_command` -> writeback -> ACK;
+empty=no gate/spend.
 
 If `should_run=false`: `monitor_quiet_skip` appends at most one no-spend
 `quota monitor-poll --execute`, reruns guard, then stays quiet unless
@@ -916,10 +923,10 @@ Chinese concrete todos/questions; never only "owner gate"; missing ->
 {RUNTIME_CAPABILITY_PROJECTION_THIN_RULE}
 {SCHEDULER_HINT_THIN_RULE}
 Bounded batch/quiet no-op; spend after writeback.
-Plans/done -> LoopX todo/rationale; 2 no-progress -> self-repair.
+Plans/done -> todo/rationale; 2 stalls -> self-repair.
+`lark_event_inbox`: `drain_command` -> writeback -> ACK.
 
-If P0 is blocked but CLI contract permits safe work, continue verifiable
-P1/P2; monitor-only quiet skips stay active/no-spend.
+P0 blocked: continue safe P1/P2; monitor-only quiet/no-spend.
 
 No project-specific branches here. {material_sentence} Stop for private material,
 credentials, destructive git, or unauthorized production actions{permission_tail}"""


### PR DESCRIPTION
## 动机

现有 Lark inbox 只定义了本地事件格式和 drain/ACK，但没有把无人值守收集器的安装、运行状态和 goal 接入做成产品能力。结果是 bot 能否持续收件依赖人工脚本，heartbeat 也无法从 goal 配置自动发现收件箱。

## 改动

- 新增默认关闭、provider-neutral 的 Lark event collector lifecycle：支持 macOS launchd / Linux systemd 的 plan、显式 install 和 status。
- 直接运行 `lark-cli event consume`，使用有界 timeout 避免 supervisor stdin EOF 终止订阅；按配置群过滤并以 0600 JSON 落盘。
- status 区分服务运行态、event bus 健康与真实事件证据；launchd 只有 `state = running` 才算 active。
- goal 可注册 ignored inbox config；quota 投影实际 `drain_command`，heartbeat 仅在配置后执行 drain → durable writeback → ACK。
- configuration catalog 暴露该可选能力；未安装 lark-cli 时只给提示，不静默安装、登录或处理凭据。

## 验证

- `python3 examples/lark-event-collector-lifecycle-smoke.py`
- `python3 examples/lark-event-inbox-smoke.py`
- `python3 examples/project/configure-goal-smoke.py`
- `python3 examples/control_plane/heartbeat-prompt-smoke.py`
- diff-driven standard premerge canary：17/17 passed，0 warning，public boundary clean。

## 边界与风险

- 默认关闭；安装 host service 必须显式 `--execute`。
- 不发送 Lark 消息，不返回 chat id、路径、jq 或凭据。
- 当前 packaged collector 要求 `configured_chat_all`，避免把只接收 @bot 的不完整线程误报为完整反馈。