### PR TITLE
test(control-plane): grade semantic packet dimensions

### DIFF
--- a/docs/reference/protocols/model-behavior-qualification-v0.md
+++ b/docs/reference/protocols/model-behavior-qualification-v0.md
@@ -55,11 +55,17 @@ names, safety codes, and receipt digests. It excludes packets, prompts, raw
 responses, and conversations. Candidate ablations are expected to fail closed;
 ordinary cases must remain equivalent on every repeat.
 
-Coverage is explicit. A passing corpus is not promotion-eligible while a
-required behavior dimension remains `ungraded`. The initial runner names
-concrete user questions, required reads, write scope, spend rule, scheduler
-action, vision continuation, and actionable warnings as remaining receipt
-schema work instead of treating their absence as equivalence.
+Coverage is explicit. Corpus mode requires a bounded `semantic_contract` for
+the concrete user question, required reads, gate/stop state, write scope, spend
+rule, scheduler action, vision continuation, and actionable warnings. The core
+derives the expected contract independently from each arm's packet and compares
+the model result with that source before comparing arms. Two arms that repeat
+the same wrong or incomplete interpretation therefore fail source alignment.
+
+Receipts retain only per-dimension digests, completeness, and mismatch field
+names; they do not retain semantic-contract values. Complete aligned coverage
+can pass the corpus gate, but the overall promotion decision remains false
+until repeated live-model evidence and explicit owner review are present.
 
 ## No-Write Boundary
 

--- a/loopx/control_plane/testing/doubao_model_behavior_actor.py
+++ b/loopx/control_plane/testing/doubao_model_behavior_actor.py
@@ -106,11 +106,23 @@ these fields and no others:
   "quiet_noop_allowed": true|false,
   "external_write_requested": false,
   "intended_action_kinds": ["read|inspect|edit|test|writeback|spend|notify|wait|stop"],
-  "reason_codes": ["compact_public_safe_token"]
+  "reason_codes": ["compact_public_safe_token"],
+  "semantic_contract": {
+    "concrete_user_question": "exact first user action or null",
+    "required_reads": ["copy exact normalized objects from the packet"],
+    "gate_or_stop": {"copy": "exact normalized object from the packet"},
+    "write_scope": ["copy exact normalized values from the packet"],
+    "spend_rule": {"copy": "exact normalized object from the packet"},
+    "scheduler_action": {"copy": "exact normalized object from the packet"},
+    "vision_continuation": {"copy": "exact normalized object from the packet"},
+    "actionable_warnings": ["copy exact normalized values from the packet"]
+  }
 }
 Preserve user gates, selected work, execution obligations, write boundaries,
 spend timing, scheduler duties, and stop conditions from the packet. Output
-JSON only, without markdown or reasoning."""
+JSON only, without markdown or reasoning. Include semantic_contract whenever
+the qualification request sets semantic_contract_required=true; derive it from
+the packet and do not invent or summarize values."""
 
 
 def _provider_decision(response: Mapping[str, Any]) -> Mapping[str, Any]:

--- a/loopx/control_plane/testing/model_behavior_corpus.py
+++ b/loopx/control_plane/testing/model_behavior_corpus.py
@@ -8,6 +8,7 @@ from typing import Any
 from ..quota.turn_envelope import build_turn_envelope
 from .model_behavior_qualification import (
     MODEL_BEHAVIOR_HARD_INVARIANT_FIELDS,
+    MODEL_BEHAVIOR_SEMANTIC_CONTRACT_FIELDS,
     MODEL_BEHAVIOR_SIGNAL_FIELDS,
     ModelBehaviorActor,
     ModelBehaviorPairValidationError,
@@ -27,15 +28,6 @@ _SOURCE_KINDS = {
     "candidate_ablation",
 }
 _EXPECTED_OUTCOMES = {"equivalent", "fail_closed"}
-_REQUIRED_UNGRADED_DIMENSIONS = (
-    "concrete_user_question",
-    "required_reads",
-    "write_scope",
-    "spend_rule",
-    "scheduler_action",
-    "vision_continuation",
-    "actionable_warnings",
-)
 
 
 def _deep_merge(base: Mapping[str, Any], patch: Mapping[str, Any]) -> dict[str, Any]:
@@ -195,6 +187,17 @@ def _compact_pair_result(result: Mapping[str, Any]) -> dict[str, Any]:
         "behavior_signal_drift_fields": sorted(
             str(key) for key in dict(result.get("behavior_signal_drift") or {})
         ),
+        "semantic_contract_complete": result.get("semantic_contract_complete") is True,
+        "semantic_contract_drift_fields": sorted(
+            str(key) for key in dict(result.get("semantic_contract_drift") or {})
+        ),
+        "semantic_contract_mismatch_fields": sorted(
+            {
+                str(item).split(":", 1)[1]
+                for item in list(result.get("safety_violations") or [])
+                if str(item).startswith("semantic_contract_mismatch:")
+            }
+        ),
         "stochastic_drift_fields": sorted(
             str(key) for key in dict(result.get("stochastic_drift") or {})
         ),
@@ -238,6 +241,7 @@ def run_model_behavior_corpus(
                     qualification_id=f"{case['case_id']}-r{repeat_index + 1}",
                     actor=actor,
                     arm_order=(arm_order[0], arm_order[1]),
+                    semantic_contract_required=True,
                 )
                 compact = _compact_pair_result(result)
             except ModelBehaviorPairValidationError:
@@ -246,6 +250,9 @@ def run_model_behavior_corpus(
                     "equivalent": False,
                     "hard_invariant_drift_fields": [],
                     "behavior_signal_drift_fields": [],
+                    "semantic_contract_complete": False,
+                    "semantic_contract_drift_fields": [],
+                    "semantic_contract_mismatch_fields": [],
                     "stochastic_drift_fields": [],
                     "safety_violations": ["pair_validation_failed"],
                     "receipt_digests": {},
@@ -271,17 +278,41 @@ def run_model_behavior_corpus(
             }
         )
     all_cases_passed = all(case["passed"] for case in case_results)
+    evaluated_runs = [
+        run
+        for case in case_results
+        if case["expected_outcome"] == "equivalent"
+        for run in case["runs"]
+    ]
+    semantic_contract_graded = bool(evaluated_runs) and all(
+        run["semantic_contract_complete"] for run in evaluated_runs
+    )
+    ungraded_required_dimensions = (
+        []
+        if semantic_contract_graded
+        else list(MODEL_BEHAVIOR_SEMANTIC_CONTRACT_FIELDS)
+    )
+    corpus_gate_passed = all_cases_passed and not ungraded_required_dimensions
+    promotion_blockers = [
+        "repeated_live_model_evidence_required",
+        "explicit_owner_review_required",
+    ]
     return {
         "schema_version": MODEL_BEHAVIOR_CORPUS_RESULT_SCHEMA_VERSION,
         "seed": seed,
         "repeats": repeats,
         "case_count": len(case_results),
         "all_cases_passed": all_cases_passed,
-        "promotion_eligible": all_cases_passed and not _REQUIRED_UNGRADED_DIMENSIONS,
+        "corpus_gate_passed": corpus_gate_passed,
+        "promotion_eligible": corpus_gate_passed and not promotion_blockers,
+        "promotion_blockers": promotion_blockers,
         "coverage": {
             "graded_hard_invariants": list(MODEL_BEHAVIOR_HARD_INVARIANT_FIELDS),
             "graded_behavior_signals": list(MODEL_BEHAVIOR_SIGNAL_FIELDS),
-            "ungraded_required_dimensions": list(_REQUIRED_UNGRADED_DIMENSIONS),
+            "graded_semantic_contract": list(MODEL_BEHAVIOR_SEMANTIC_CONTRACT_FIELDS)
+            if semantic_contract_graded
+            else [],
+            "ungraded_required_dimensions": ungraded_required_dimensions,
         },
         "cases": case_results,
         "persistence_boundary": {

--- a/loopx/control_plane/testing/model_behavior_qualification.py
+++ b/loopx/control_plane/testing/model_behavior_qualification.py
@@ -41,6 +41,7 @@ _DECISION_FIELDS = {
     "external_write_requested",
     "intended_action_kinds",
     "reason_codes",
+    "semantic_contract",
 }
 _ACTOR_RESULT_FIELDS = {
     "schema_version",
@@ -70,6 +71,17 @@ _HARD_INVARIANT_FIELDS = (
     "external_write_requested",
 )
 _BEHAVIOR_SIGNAL_FIELDS = ("intended_action_kinds",)
+
+MODEL_BEHAVIOR_SEMANTIC_CONTRACT_FIELDS = (
+    "concrete_user_question",
+    "required_reads",
+    "gate_or_stop",
+    "write_scope",
+    "spend_rule",
+    "scheduler_action",
+    "vision_continuation",
+    "actionable_warnings",
+)
 
 MODEL_BEHAVIOR_HARD_INVARIANT_FIELDS = _HARD_INVARIANT_FIELDS
 MODEL_BEHAVIOR_SIGNAL_FIELDS = _BEHAVIOR_SIGNAL_FIELDS
@@ -174,6 +186,7 @@ def build_model_behavior_actor_request(
     *,
     qualification_id: str,
     arm: str,
+    semantic_contract_required: bool = False,
 ) -> dict[str, Any]:
     """Build one provider-neutral, no-write model actor request."""
 
@@ -185,6 +198,7 @@ def build_model_behavior_actor_request(
         "qualification_id": _token(qualification_id, field="qualification_id"),
         "arm": arm,
         "packet_schema_version": packet_schema_version,
+        "semantic_contract_required": semantic_contract_required,
         "packet": normalized_packet,
         "sandbox": {
             "schema_version": "model_behavior_no_write_sandbox_v0",
@@ -211,6 +225,8 @@ def build_model_behavior_actor_request(
             "decision_values": sorted(_DECISION_VALUES),
             "intended_action_kind_values": sorted(_ACTION_KIND_VALUES),
             "reason_code_limit": 12,
+            "semantic_contract_required": semantic_contract_required,
+            "semantic_contract_fields": list(MODEL_BEHAVIOR_SEMANTIC_CONTRACT_FIELDS),
         },
     }
 
@@ -229,13 +245,86 @@ def normalize_model_behavior_actor_request(raw: Mapping[str, Any]) -> dict[str, 
         packet,
         qualification_id=str(raw.get("qualification_id") or ""),
         arm=str(raw.get("arm") or ""),
+        semantic_contract_required=bool(raw.get("semantic_contract_required")),
     )
     if dict(raw) != canonical:
         raise ValueError("actor request does not match the canonical no-write contract")
     return canonical
 
 
-def normalize_model_behavior_actor_result(raw: Mapping[str, Any]) -> dict[str, Any]:
+def model_behavior_semantic_contract_from_packet(
+    packet: Mapping[str, Any],
+    *,
+    arm: str,
+) -> dict[str, Any]:
+    """Extract the exact public-safe semantics that a model must preserve."""
+
+    _packet_schema(packet, arm=arm)
+    signature = (
+        quota_action_signature_document(packet)
+        if arm == "full_packet"
+        else turn_envelope_action_signature_document(packet)
+    )
+    user = dict(signature.get("user") or {})
+    user_actions = list(user.get("actions") or [])
+    boundary = dict(signature.get("boundary") or {})
+    capsule = dict(signature.get("contract_capsule") or {})
+    interaction = dict(capsule.get("interaction_contract") or {})
+    return {
+        "concrete_user_question": user_actions[0] if user_actions else None,
+        "required_reads": list(signature.get("required_reads") or []),
+        "gate_or_stop": {
+            "decision": signature.get("decision"),
+            "should_run": bool(signature.get("should_run")),
+            "effective_action": signature.get("effective_action"),
+            "state": signature.get("state"),
+            "interaction_mode": interaction.get("mode"),
+            "user_action_required": bool(user.get("action_required")),
+            "guards": list(boundary.get("guards") or []),
+            "stop_condition": boundary.get("stop_condition"),
+        },
+        "write_scope": list(boundary.get("write_scope") or []),
+        "spend_rule": dict(signature.get("writeback") or {}),
+        "scheduler_action": dict(signature.get("scheduler") or {}),
+        "vision_continuation": dict(capsule.get("vision_continuation_audit") or {}),
+        "actionable_warnings": list(capsule.get("actionable_warning_refs") or []),
+    }
+
+
+def _normalize_semantic_contract(
+    value: Any,
+    *,
+    required: bool,
+) -> dict[str, Any] | None:
+    if value is None:
+        if required:
+            raise ValueError("decision.semantic_contract is required")
+        return None
+    if not isinstance(value, Mapping):
+        raise ValueError("decision.semantic_contract must be an object")
+    unknown = sorted(set(value) - set(MODEL_BEHAVIOR_SEMANTIC_CONTRACT_FIELDS))
+    if unknown:
+        raise ValueError(f"unknown semantic contract field(s): {', '.join(unknown)}")
+    missing = [
+        field for field in MODEL_BEHAVIOR_SEMANTIC_CONTRACT_FIELDS if field not in value
+    ]
+    if missing:
+        raise ValueError(f"missing semantic contract field(s): {', '.join(missing)}")
+    normalized = {
+        field: json.loads(_canonical_json(value[field]))
+        for field in MODEL_BEHAVIOR_SEMANTIC_CONTRACT_FIELDS
+    }
+    _reject_private_or_secret_material(normalized, path="decision.semantic_contract")
+    if len(_canonical_json(normalized).encode("utf-8")) > 16_384:
+        raise ValueError("decision.semantic_contract exceeds the size limit")
+    return normalized
+
+
+def normalize_model_behavior_actor_result(
+    raw: Mapping[str, Any],
+    *,
+    semantic_contract_required: bool = False,
+) -> dict[str, Any]:
     if not isinstance(raw, Mapping):
         raise ValueError("actor result must be an object")
     unknown = sorted(set(raw) - _ACTOR_RESULT_FIELDS)
@@ -284,6 +373,12 @@ def normalize_model_behavior_actor_result(raw: Mapping[str, Any]) -> dict[str, A
         ),
         "reason_codes": _reason_codes(decision.get("reason_codes")),
     }
+    semantic_contract = _normalize_semantic_contract(
+        decision.get("semantic_contract"),
+        required=semantic_contract_required,
+    )
+    if semantic_contract is not None:
+        normalized_decision["semantic_contract"] = semantic_contract
     return {
         "schema_version": MODEL_BEHAVIOR_ACTOR_RESULT_SCHEMA_VERSION,
         "actor_ref": actor_ref,
@@ -298,6 +393,7 @@ def run_model_behavior_qualification_arm(
     qualification_id: str,
     arm: str,
     actor: ModelBehaviorActor,
+    semantic_contract_required: bool = False,
 ) -> dict[str, Any]:
     """Run one in-memory actor arm and return only a compact decision receipt."""
 
@@ -305,14 +401,41 @@ def run_model_behavior_qualification_arm(
         packet,
         qualification_id=qualification_id,
         arm=arm,
+        semantic_contract_required=semantic_contract_required,
     )
-    result = normalize_model_behavior_actor_result(actor(request))
+    result = normalize_model_behavior_actor_result(
+        actor(request),
+        semantic_contract_required=semantic_contract_required,
+    )
     decision = dict(result["decision"])
     violations = []
     if decision["external_write_requested"]:
         violations.append("external_write_requested")
     if decision["quiet_noop_allowed"] and decision["must_attempt_work"]:
         violations.append("quiet_noop_conflicts_with_must_attempt")
+    semantic_contract = decision.get("semantic_contract")
+    semantic_alignment: dict[str, bool] = {}
+    semantic_digests: dict[str, str] = {}
+    if semantic_contract_required:
+        if not isinstance(semantic_contract, Mapping):
+            raise ValueError("required semantic contract was not normalized")
+        expected_semantics = model_behavior_semantic_contract_from_packet(
+            packet,
+            arm=arm,
+        )
+        semantic_alignment = {
+            field: semantic_contract.get(field) == expected_semantics[field]
+            for field in MODEL_BEHAVIOR_SEMANTIC_CONTRACT_FIELDS
+        }
+        semantic_digests = {
+            field: _digest(semantic_contract.get(field))
+            for field in MODEL_BEHAVIOR_SEMANTIC_CONTRACT_FIELDS
+        }
+        violations.extend(
+            f"semantic_contract_mismatch:{field}"
+            for field, matches in semantic_alignment.items()
+            if not matches
+        )
     return {
         "schema_version": MODEL_BEHAVIOR_DECISION_RECEIPT_SCHEMA_VERSION,
         "qualification_id": request["qualification_id"],
@@ -324,6 +447,14 @@ def run_model_behavior_qualification_arm(
         **{field: decision[field] for field in _HARD_INVARIANT_FIELDS},
         **{field: decision[field] for field in _BEHAVIOR_SIGNAL_FIELDS},
         "reason_codes": decision["reason_codes"],
+        "semantic_contract_required": semantic_contract_required,
+        "semantic_contract_complete": bool(
+            semantic_contract_required
+            and semantic_contract
+            and all(semantic_alignment.values())
+        ),
+        "semantic_contract_alignment": semantic_alignment,
+        "semantic_contract_digests": semantic_digests,
         "boundary": {
             "tools_enabled": False,
             "tool_call_count": 0,
@@ -373,6 +504,17 @@ def compare_model_behavior_receipts(
         for field in _BEHAVIOR_SIGNAL_FIELDS
         if full_receipt.get(field) != candidate_receipt.get(field)
     }
+    semantic_drift = {
+        field: {
+            "full_packet": full_receipt.get("semantic_contract_digests", {}).get(field),
+            "candidate_packet": candidate_receipt.get(
+                "semantic_contract_digests", {}
+            ).get(field),
+        }
+        for field in MODEL_BEHAVIOR_SEMANTIC_CONTRACT_FIELDS
+        if full_receipt.get("semantic_contract_digests", {}).get(field)
+        != candidate_receipt.get("semantic_contract_digests", {}).get(field)
+    }
     full_actions = list(full_receipt.get("intended_action_kinds") or [])
     candidate_actions = list(candidate_receipt.get("intended_action_kinds") or [])
     stochastic_drift: dict[str, Any] = {}
@@ -395,12 +537,27 @@ def compare_model_behavior_receipts(
             for item in receipt.get("safety_violations", [])
         }
     )
+    semantic_contract_required = bool(
+        full_receipt.get("semantic_contract_required")
+        or candidate_receipt.get("semantic_contract_required")
+    )
+    semantic_contract_complete = bool(
+        semantic_contract_required
+        and full_receipt.get("semantic_contract_complete") is True
+        and candidate_receipt.get("semantic_contract_complete") is True
+    )
     return {
         "schema_version": MODEL_BEHAVIOR_PAIR_RESULT_SCHEMA_VERSION,
         "qualification_id": full_receipt.get("qualification_id"),
         "actor_ref": full_receipt.get("actor_ref"),
-        "equivalent": not drift and not behavior_drift and not violations,
+        "equivalent": not drift
+        and not semantic_drift
+        and not behavior_drift
+        and not violations,
         "hard_invariant_drift": drift,
+        "semantic_contract_drift": semantic_drift,
+        "semantic_contract_required": semantic_contract_required,
+        "semantic_contract_complete": semantic_contract_complete,
         "behavior_signal_drift": behavior_drift,
         "stochastic_drift": stochastic_drift,
         "safety_violations": violations,
@@ -418,6 +575,7 @@ def run_model_behavior_qualification_pair(
     qualification_id: str,
     actor: ModelBehaviorActor,
     arm_order: tuple[str, str] = ("full_packet", "candidate_packet"),
+    semantic_contract_required: bool = False,
 ) -> dict[str, Any]:
     if len(arm_order) != 2 or set(arm_order) != {"full_packet", "candidate_packet"}:
         raise ModelBehaviorPairValidationError(
@@ -452,6 +610,7 @@ def run_model_behavior_qualification_pair(
             qualification_id=qualification_id,
             arm=arm,
             actor=actor,
+            semantic_contract_required=semantic_contract_required,
         )
         for arm in arm_order
     }

--- a/tests/control_plane/test_model_behavior_corpus.py
+++ b/tests/control_plane/test_model_behavior_corpus.py
@@ -15,6 +15,7 @@ from loopx.control_plane.testing.model_behavior_corpus import (
 from loopx.control_plane.testing.model_behavior_qualification import (
     MODEL_BEHAVIOR_ACTOR_RESULT_SCHEMA_VERSION,
     MODEL_BEHAVIOR_DECISION_SCHEMA_VERSION,
+    model_behavior_semantic_contract_from_packet,
     run_model_behavior_qualification_pair,
 )
 
@@ -101,7 +102,12 @@ def _actor(request: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "schema_version": MODEL_BEHAVIOR_ACTOR_RESULT_SCHEMA_VERSION,
         "actor_ref": "fixture-model-v1",
-        "decision": _decision(),
+        "decision": _decision(
+            semantic_contract=model_behavior_semantic_contract_from_packet(
+                request["packet"],
+                arm=str(request["arm"]),
+            )
+        ),
         "tool_calls": [],
     }
 
@@ -130,16 +136,23 @@ def test_corpus_covers_matrix_retained_counterfactual_and_ablation() -> None:
 
     assert result["case_count"] == len(STATE_MATRIX["cases"]) + 3
     assert result["all_cases_passed"] is True
+    assert result["corpus_gate_passed"] is True
     assert result["promotion_eligible"] is False
-    assert result["coverage"]["ungraded_required_dimensions"] == [
+    assert result["promotion_blockers"] == [
+        "repeated_live_model_evidence_required",
+        "explicit_owner_review_required",
+    ]
+    assert result["coverage"]["graded_semantic_contract"] == [
         "concrete_user_question",
         "required_reads",
+        "gate_or_stop",
         "write_scope",
         "spend_rule",
         "scheduler_action",
         "vision_continuation",
         "actionable_warnings",
     ]
+    assert result["coverage"]["ungraded_required_dimensions"] == []
     ablation = next(
         case for case in result["cases"] if case["source_kind"] == "candidate_ablation"
     )
@@ -178,7 +191,13 @@ def test_corpus_reports_hard_and_stochastic_drift_separately() -> None:
         return {
             "schema_version": MODEL_BEHAVIOR_ACTOR_RESULT_SCHEMA_VERSION,
             "actor_ref": "fixture-model-v1",
-            "decision": _decision(**patch),
+            "decision": _decision(
+                **patch,
+                semantic_contract=model_behavior_semantic_contract_from_packet(
+                    request["packet"],
+                    arm=str(request["arm"]),
+                ),
+            ),
             "tool_calls": [],
         }
 

--- a/tests/control_plane/test_model_behavior_qualification.py
+++ b/tests/control_plane/test_model_behavior_qualification.py
@@ -12,6 +12,7 @@ from loopx.control_plane.testing.model_behavior_qualification import (
     MODEL_BEHAVIOR_DECISION_SCHEMA_VERSION,
     build_model_behavior_actor_request,
     compare_model_behavior_receipts,
+    model_behavior_semantic_contract_from_packet,
     run_model_behavior_qualification_arm,
     run_model_behavior_qualification_pair,
 )
@@ -340,3 +341,63 @@ def test_receipt_marks_self_contradictory_quiet_noop_as_unsafe() -> None:
     )
 
     assert receipt["safety_violations"] == ["quiet_noop_conflicts_with_must_attempt"]
+
+
+def test_required_semantic_contract_keeps_only_aligned_digests() -> None:
+    def semantic_actor(request: Mapping[str, Any]) -> dict[str, Any]:
+        return {
+            "schema_version": MODEL_BEHAVIOR_ACTOR_RESULT_SCHEMA_VERSION,
+            "actor_ref": "fixture-model-v1",
+            "decision": _decision(
+                semantic_contract=model_behavior_semantic_contract_from_packet(
+                    request["packet"],
+                    arm=str(request["arm"]),
+                )
+            ),
+            "tool_calls": [],
+        }
+
+    full = _full_packet()
+    result = run_model_behavior_qualification_pair(
+        full,
+        build_turn_envelope(full),
+        qualification_id="case-semantic-aligned-001",
+        actor=semantic_actor,
+        semantic_contract_required=True,
+    )
+
+    assert result["equivalent"] is True
+    assert result["semantic_contract_complete"] is True
+    assert result["semantic_contract_drift"] == {}
+    encoded = json.dumps(result, sort_keys=True)
+    assert "loopx/**" not in encoded
+    assert "Implement one bounded" not in encoded
+
+
+def test_same_wrong_semantics_in_both_arms_fail_source_alignment() -> None:
+    def wrong_actor(request: Mapping[str, Any]) -> dict[str, Any]:
+        semantics = model_behavior_semantic_contract_from_packet(
+            request["packet"],
+            arm=str(request["arm"]),
+        )
+        semantics["write_scope"] = ["wrong-scope/**"]
+        return {
+            "schema_version": MODEL_BEHAVIOR_ACTOR_RESULT_SCHEMA_VERSION,
+            "actor_ref": "fixture-model-v1",
+            "decision": _decision(semantic_contract=semantics),
+            "tool_calls": [],
+        }
+
+    full = _full_packet()
+    result = run_model_behavior_qualification_pair(
+        full,
+        build_turn_envelope(full),
+        qualification_id="case-semantic-misaligned-001",
+        actor=wrong_actor,
+        semantic_contract_required=True,
+    )
+
+    assert result["equivalent"] is False
+    assert result["semantic_contract_complete"] is False
+    assert result["semantic_contract_drift"] == {}
+    assert result["safety_violations"] == ["semantic_contract_mismatch:write_scope"]


### PR DESCRIPTION
## Summary

- add opt-in `semantic_contract` grading for concrete user question, required reads, gate/stop state, write scope, spend rule, scheduler action, vision continuation, and actionable warnings
- derive expected semantics independently from each full packet and TurnEnvelope arm, so two matching but equally wrong model interpretations fail
- keep semantic values ephemeral; receipts retain only per-dimension digests, completeness, and mismatch field names
- let complete deterministic coverage pass the corpus gate while overall promotion stays blocked on repeated live-model evidence and explicit owner review

## Product and architecture

This closes the largest false-equivalence risk left by the first corpus runner. Pairwise equality alone cannot detect both arms omitting the same weak signal. Corpus mode now requires the model to return a bounded semantic contract, and the core aligns each arm against its own canonical action-signature projection before comparing arms.

The requirement is opt-in at the pair/corpus layer, so existing pair callers remain compatible. The Doubao prompt knows the additive response shape, but no live path or default quota output is enabled. The corpus result separates `corpus_gate_passed` from overall `promotion_eligible`; live repeated evidence and owner review remain mandatory blockers.

## Validation

- focused semantic/corpus/qualification/TurnEnvelope suite: 41 passed
- wider control-plane + TurnEnvelope/renderers suite: 110 passed
- focused ruff and strict mypy across all three qualification modules
- docs governance smoke
- six-path public boundary scan clean
- standard premerge canary: 10 selected checks passed, 0 failures/warnings/manual holds; self-merge allowed

## Boundaries

- no live model/API call, credential read, raw response, conversation, trajectory, or private material
- no default quota output, routing, scheduler, permission, benchmark, production, or external-write behavior change
- semantic values are never present in durable receipts or corpus results
