### PR TITLE
feat(semantic-preference): add provider doctor

### DIFF
--- a/docs/capabilities/semantic-preference/README.md
+++ b/docs/capabilities/semantic-preference/README.md
@@ -24,8 +24,14 @@ does not branch on `issue_fix`, `content_ops`, or any other domain name.
   "schema_version": "semantic_preference_hook_config_v0",
   "enabled": true,
   "provider": {
+    "id": "local_memory",
     "argv": ["semantic-preference-provider"],
-    "timeout_seconds": 30
+    "timeout_seconds": 30,
+    "probe_argv": ["semantic-preference-provider", "doctor"],
+    "setup_hints": {
+      "install": "Install the provider from its official distribution.",
+      "configure": "Configure it locally, then rerun this doctor with --execute."
+    }
   },
   "surfaces": {
     "issue_fix.pr_description": {
@@ -66,6 +72,12 @@ Provider stderr and non-zero output are reduced to a bounded failure kind.
 the caller with an actionable error. Provider failures do not become user
 gates automatically.
 
+`provider.id`, `probe_argv`, and `setup_hints` are optional. They provide
+provider-neutral discovery without teaching LoopX how to install one specific
+memory system. `probe_argv` must be a read-only health check owned by the
+provider. The doctor never installs packages, starts services, changes config,
+or writes credentials; setup hints are guidance for an explicit operator action.
+
 ## CLI
 
 ```bash
@@ -74,6 +86,11 @@ loopx semantic-preference recall \
   --config <ignored-config.json> \
   --surface issue_fix.pr_description \
   --context repository=owner/repo \
+  --execute
+
+loopx semantic-preference doctor \
+  --project . \
+  --config <ignored-config.json> \
   --execute
 
 loopx semantic-preference receipt \
@@ -89,6 +106,11 @@ artifact reference, and hashes of provider-owned preference references. The
 command returns the receipt without writing a file. Callers can attach it to
 the existing evidence log, todo evidence, or `refresh-state` record; the hook
 does not maintain a second reward or memory ledger.
+
+`--context` is repeatable and each entry uses `lower_snake=value` syntax.
+Invalid config, context, surface, or fail-closed requests return a structured
+`semantic_preference_error_v0` payload with exit code 2 instead of a Python
+traceback.
 
 ## Domain integration
 

--- a/examples/semantic-preference-hook-smoke.py
+++ b/examples/semantic-preference-hook-smoke.py
@@ -10,7 +10,11 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from loopx.capabilities.semantic_preference import application_receipt, recall  # noqa: E402
+from loopx.capabilities.semantic_preference import (  # noqa: E402
+    application_receipt,
+    provider_doctor,
+    recall,
+)
 
 
 def run(*args: str) -> dict[str, object]:
@@ -22,6 +26,19 @@ def run(*args: str) -> dict[str, object]:
         check=False,
     )
     assert result.returncode == 0, result.stderr or result.stdout
+    return json.loads(result.stdout)
+
+
+def run_failure(*args: str) -> dict[str, object]:
+    result = subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--format", "json", *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 2, result.stderr or result.stdout
+    assert "Traceback" not in result.stderr, result.stderr
     return json.loads(result.stdout)
 
 
@@ -61,7 +78,15 @@ json.dump({
             {
                 "schema_version": "semantic_preference_hook_config_v0",
                 "enabled": True,
-                "provider": {"argv": [sys.executable, str(provider)]},
+                "provider": {
+                    "id": "fixture_memory",
+                    "argv": [sys.executable, str(provider)],
+                    "probe_argv": [sys.executable, "-c", "raise SystemExit(0)"],
+                    "setup_hints": {
+                        "install": "Install the fixture provider explicitly.",
+                        "configure": "Configure the fixture provider explicitly.",
+                    },
+                },
                 "surfaces": {
                     "issue_fix.pr_description": {"query": "PR description preferences"},
                     "content_ops.draft_language": {
@@ -79,6 +104,19 @@ json.dump({
         recalled = recall_cli(project, config, surface, execute=True)
         assert recalled["status"] == "completed", recalled
         assert recalled["items"][0]["summary"] == f"prefer {surface}", recalled
+
+    doctor_preview = run(
+        "semantic-preference",
+        "doctor",
+        "--project",
+        str(project),
+        "--config",
+        str(config),
+    )
+    assert doctor_preview["status"] == "probe_required", doctor_preview
+    assert doctor_preview["automatic_setup_performed"] is False, doctor_preview
+    doctor = provider_doctor(config, project=project, execute=True)
+    assert doctor["status"] == "ready" and doctor["verified"] is True, doctor
 
     receipt = run(
         "semantic-preference",
@@ -130,6 +168,45 @@ json.dump({
         assert "provider unavailable" in str(exc), exc
     else:
         raise AssertionError("fail_closed must stop the caller")
+
+    missing = temp / "missing.json"
+    missing.write_text(
+        json.dumps(
+            {
+                "schema_version": "semantic_preference_hook_config_v0",
+                "enabled": True,
+                "provider": {
+                    "id": "missing_fixture",
+                    "argv": ["definitely-missing-semantic-provider"],
+                    "setup_hints": {"install": "Install it explicitly."},
+                },
+                "surfaces": {"other_module.summary": {"query": "preferences"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    missing_doctor = provider_doctor(missing, project=project)
+    assert missing_doctor["status"] == "provider_missing", missing_doctor
+    assert missing_doctor["setup_hints"]["install"] == "Install it explicitly."
+    missing_recall = recall(
+        missing, project=project, surface="other_module.summary", execute=True
+    )
+    assert missing_recall["status"] == "provider_unavailable", missing_recall
+
+    invalid_context = run_failure(
+        "semantic-preference",
+        "recall",
+        "--project",
+        str(project),
+        "--config",
+        str(config),
+        "--surface",
+        "issue_fix.pr_description",
+        "--context",
+        "not-a-key-value",
+    )
+    assert invalid_context["status"] == "invalid_request", invalid_context
+    assert "lower-snake key=value" in invalid_context["error"], invalid_context
 
     try:
         application_receipt(

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -220,6 +220,11 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
         "entry_command": "loopx semantic-preference recall --config <ignored-config.json> --surface <module.surface> --format json",
         "commands": [
             {
+                "command": "loopx semantic-preference doctor --config <ignored-config.json> --execute --format json",
+                "purpose": "Check a configured provider entry point and optional read-only probe, then return explicit install/config guidance when unavailable.",
+                "write_boundary": "read-only discovery; never installs packages, starts services, changes config, or writes credentials",
+            },
+            {
                 "command": "loopx semantic-preference recall --config <ignored-config.json> --surface <module.surface> --execute --format json",
                 "purpose": "Send one bounded recall request to a configured command_json_v0 provider.",
                 "write_boundary": "provider read only; LoopX does not persist recalled semantic content",
@@ -242,6 +247,11 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "doc": "docs/capabilities/semantic-preference/README.md",
             },
             {
+                "schema_version": "semantic_preference_provider_doctor_v0",
+                "module": "loopx.capabilities.semantic_preference.contract",
+                "doc": "docs/capabilities/semantic-preference/README.md",
+            },
+            {
                 "schema_version": "semantic_preference_application_receipt_v0",
                 "module": "loopx.capabilities.semantic_preference.contract",
                 "doc": "docs/capabilities/semantic-preference/README.md",
@@ -254,6 +264,7 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
             "Surface ids and queries are domain-owned configuration; the runtime has no issue-fix branch.",
             "LoopX does not persist recalled semantic content, receipts, provider commands, config paths, or raw errors.",
             "Provider failures follow explicit fail-open/fail-closed policy and do not become user gates automatically.",
+            "Provider setup remains guidance-only: package, service, config, and credential writes require an explicit operator action.",
         ],
         "next_real_step": (
             "Keep the hook opt-in until a second domain module proves useful recall and existing-state receipt writeback."
@@ -467,7 +478,9 @@ def get_capability(capability_id: str) -> dict[str, Any]:
     for record in CAPABILITIES:
         if record["id"] == wanted:
             return dict(record)
-    raise ValueError(f"unknown capability `{wanted}`; expected one of {capability_ids()}")
+    raise ValueError(
+        f"unknown capability `{wanted}`; expected one of {capability_ids()}"
+    )
 
 
 def build_capability_catalog_packet() -> dict[str, Any]:

--- a/loopx/capabilities/semantic_preference/__init__.py
+++ b/loopx/capabilities/semantic_preference/__init__.py
@@ -1,5 +1,5 @@
 """Optional provider-neutral semantic preference recall."""
 
-from .contract import application_receipt, recall
+from .contract import application_receipt, provider_doctor, recall
 
-__all__ = ["application_receipt", "recall"]
+__all__ = ["application_receipt", "provider_doctor", "recall"]

--- a/loopx/capabilities/semantic_preference/cli.py
+++ b/loopx/capabilities/semantic_preference/cli.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 from collections.abc import Callable
 
-from .contract import application_receipt, recall
+from .contract import application_receipt, provider_doctor, recall
 from .openviking_provider import (
     handle_openviking_provider,
     register_openviking_provider_arguments,
@@ -12,7 +12,16 @@ from .openviking_provider import (
 
 def _render(payload: dict[str, object]) -> str:
     lines = ["# Semantic Preference", ""]
-    for key in ("status", "surface", "outcome", "application_id"):
+    for key in (
+        "status",
+        "surface",
+        "outcome",
+        "application_id",
+        "provider_id",
+        "available",
+        "verified",
+        "error",
+    ):
         if key in payload:
             lines.append(f"- {key}: `{payload.get(key)}`")
     items = payload.get("items")
@@ -35,8 +44,27 @@ def register_semantic_preference_commands(
     recall_parser.add_argument("--config", required=True)
     recall_parser.add_argument("--project", default=".")
     recall_parser.add_argument("--surface", required=True)
-    recall_parser.add_argument("--context", action="append", default=[])
+    recall_parser.add_argument(
+        "--context",
+        action="append",
+        default=[],
+        metavar="LOWER_SNAKE=VALUE",
+        help="Repeatable bounded context entry, for example repository=owner/repo.",
+    )
     recall_parser.add_argument("--execute", action="store_true")
+
+    doctor_parser = commands.add_parser(
+        "doctor",
+        help="Inspect provider availability and configured setup hints without changing the host.",
+    )
+    add_subcommand_format(doctor_parser)
+    doctor_parser.add_argument("--config", required=True)
+    doctor_parser.add_argument("--project", default=".")
+    doctor_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Run the optional read-only provider probe; never install, configure, or write credentials.",
+    )
 
     provider_parser = commands.add_parser(
         "openviking-provider",
@@ -65,21 +93,37 @@ def handle_semantic_preference_command(
         return None
     if args.semantic_preference_command == "openviking-provider":
         return handle_openviking_provider(args)
-    if args.semantic_preference_command == "recall":
-        payload = recall(
-            args.config,
-            project=args.project,
-            surface=args.surface,
-            context=args.context,
-            execute=args.execute,
-        )
-    else:
-        payload = application_receipt(
-            surface=args.surface,
-            application_id=args.application_id,
-            outcome=args.outcome,
-            preference_refs=args.preference_ref,
-            artifact_ref=args.artifact_ref,
-        )
+    try:
+        if args.semantic_preference_command == "recall":
+            payload = recall(
+                args.config,
+                project=args.project,
+                surface=args.surface,
+                context=args.context,
+                execute=args.execute,
+            )
+        elif args.semantic_preference_command == "doctor":
+            payload = provider_doctor(
+                args.config,
+                project=args.project,
+                execute=args.execute,
+            )
+        else:
+            payload = application_receipt(
+                surface=args.surface,
+                application_id=args.application_id,
+                outcome=args.outcome,
+                preference_refs=args.preference_ref,
+                artifact_ref=args.artifact_ref,
+            )
+    except ValueError as exc:
+        payload = {
+            "ok": False,
+            "schema_version": "semantic_preference_error_v0",
+            "status": "invalid_request",
+            "error": str(exc),
+        }
+        print_payload(payload, output_format(args), _render)
+        return 2
     print_payload(payload, output_format(args), _render)
     return 0

--- a/loopx/capabilities/semantic_preference/contract.py
+++ b/loopx/capabilities/semantic_preference/contract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Any, Mapping, Sequence
@@ -13,11 +14,13 @@ REQUEST_SCHEMA = "semantic_preference_provider_request_v0"
 RESPONSE_SCHEMA = "semantic_preference_provider_response_v0"
 RECALL_SCHEMA = "semantic_preference_recall_v0"
 RECEIPT_SCHEMA = "semantic_preference_application_receipt_v0"
+DOCTOR_SCHEMA = "semantic_preference_provider_doctor_v0"
 SURFACE_RE = re.compile(r"^[a-z][a-z0-9_-]*(?:\.[a-z][a-z0-9_-]*)+$")
 TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/#-]{0,199}$")
 MAX_PROVIDER_OUTPUT_BYTES = 256_000
 MAX_ITEM_BYTES = 8_000
 MAX_RECEIPT_REFS = 20
+MAX_SETUP_HINT_LENGTH = 1_000
 
 
 def _surface(value: object) -> str:
@@ -82,6 +85,115 @@ def _context(values: Sequence[str] | None) -> dict[str, str]:
     return result
 
 
+def _provider(payload: Mapping[str, Any]) -> tuple[Mapping[str, Any], list[str]]:
+    provider = payload.get("provider")
+    argv = provider.get("argv") if isinstance(provider, Mapping) else None
+    if (
+        not isinstance(argv, list)
+        or not argv
+        or not all(isinstance(value, str) and value for value in argv)
+    ):
+        raise ValueError("enabled provider requires a non-empty string argv list")
+    return provider, argv
+
+
+def _command_available(command: str) -> bool:
+    if "/" in command or "\\" in command:
+        path = Path(command).expanduser()
+        return path.is_file() and path.stat().st_mode & 0o111 != 0
+    return shutil.which(command) is not None
+
+
+def _setup_hints(provider: Mapping[str, Any]) -> dict[str, str]:
+    raw = provider.get("setup_hints")
+    if raw is None:
+        return {}
+    if not isinstance(raw, Mapping):
+        raise ValueError("provider setup_hints must be an object")
+    result: dict[str, str] = {}
+    for key in ("install", "configure"):
+        value = str(raw.get(key) or "").strip()
+        if len(value) > MAX_SETUP_HINT_LENGTH:
+            raise ValueError(f"provider setup_hints.{key} exceeds 1000 characters")
+        if value:
+            result[key] = value
+    return result
+
+
+def provider_doctor(
+    config: str | Path,
+    *,
+    project: str | Path,
+    execute: bool = False,
+) -> dict[str, Any]:
+    """Inspect an optional provider without installing or configuring it."""
+
+    payload = _config(config, project)
+    if not payload.get("enabled", False):
+        return {
+            "ok": True,
+            "schema_version": DOCTOR_SCHEMA,
+            "status": "disabled",
+            "available": False,
+            "verified": False,
+            "external_writes_performed": False,
+        }
+    provider, argv = _provider(payload)
+    provider_id = str(provider.get("id") or "configured_provider").strip()
+    if not re.fullmatch(r"[a-z][a-z0-9_-]{0,63}", provider_id):
+        raise ValueError("provider id must use lower-snake token syntax")
+    hints = _setup_hints(provider)
+    command_available = _command_available(argv[0])
+    probe_argv = provider.get("probe_argv")
+    if probe_argv is not None and (
+        not isinstance(probe_argv, list)
+        or not probe_argv
+        or not all(isinstance(value, str) and value for value in probe_argv)
+    ):
+        raise ValueError("provider probe_argv must be a non-empty string list")
+    status = "ready" if command_available else "provider_missing"
+    available = command_available
+    verified = False
+    failure_kind = None
+    if command_available and probe_argv and not execute:
+        status = "probe_required"
+    elif command_available and probe_argv and execute:
+        try:
+            completed = subprocess.run(
+                probe_argv,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=30,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            completed = None
+            failure_kind = "probe_execution_failed"
+        if completed is None or completed.returncode != 0:
+            status = "provider_unavailable"
+            available = False
+            failure_kind = failure_kind or "probe_nonzero_exit"
+        else:
+            status = "ready"
+            verified = True
+    return {
+        "ok": True,
+        "schema_version": DOCTOR_SCHEMA,
+        "status": status,
+        "provider_id": provider_id,
+        "available": available,
+        "verified": verified,
+        "probe_configured": bool(probe_argv),
+        "failure_kind": failure_kind,
+        "setup_hints": hints,
+        "automatic_setup_performed": False,
+        "credential_writes_performed": False,
+        "service_writes_performed": False,
+        "external_writes_performed": False,
+    }
+
+
 def _unavailable(surface: str, policy: str, kind: str) -> dict[str, Any]:
     if policy == "fail_closed":
         raise ValueError(f"semantic preference provider unavailable: {kind}")
@@ -129,14 +241,7 @@ def recall(
         raise ValueError("surface query or limit is outside the bounded contract")
     if policy not in {"fail_open", "fail_closed"}:
         raise ValueError("failure_policy must be fail_open or fail_closed")
-    provider = payload.get("provider")
-    argv = provider.get("argv") if isinstance(provider, Mapping) else None
-    if (
-        not isinstance(argv, list)
-        or not argv
-        or not all(isinstance(v, str) and v for v in argv)
-    ):
-        raise ValueError("enabled provider requires a non-empty string argv list")
+    provider, argv = _provider(payload)
     try:
         timeout = int(provider.get("timeout_seconds", 30))
     except (TypeError, ValueError) as exc:


### PR DESCRIPTION
## 动机

semantic-preference 只能直接调用 provider：provider 未安装或未配置时，调用方拿不到可操作的能力提示；同时 `--context` 的 `lower_snake=value` 契约未出现在 help 中，非法输入会泄漏 Python traceback。

## 方案

- 新增 provider-neutral 的 `semantic-preference doctor`，检查入口与可选只读 probe。
- provider 可在本地私有配置声明 install/config hints；LoopX 只展示，不自动装包、启动服务、改配置或写凭据。
- missing provider 继续遵循既有 fail-open/fail-closed 策略，不自动升级为 user gate。
- recall/doctor/receipt 的 ValueError 统一投影为结构化 `semantic_preference_error_v0`，退出码为 2。
- `--context` help 显式说明可重复的 `lower_snake=value` 语法。

## 关键流程

```text
module config
  -> doctor entrypoint
  -> optional read-only probe
  -> ready / provider_missing / provider_unavailable
  -> configured install/config guidance
  -> explicit operator action only
```

## 复现

修复前执行 `loopx semantic-preference recall ... --context invalid` 会输出完整 traceback；provider 缺失时也没有独立的 discovery/setup 入口。

## 验证

- `python3 examples/semantic-preference-hook-smoke.py`
- `uvx ruff check ...`
- `uvx ruff format --check ...`
- `loopx canary premerge --from-git-diff`：standard tier，17/17 通过
- 真实本地 semantic-preference 配置 doctor：入口可用，未配置 probe 时明确返回 `verified=false`

## 风险与边界

- `doctor --execute` 只运行本地私有配置显式声明的只读 probe；stdout/stderr 均不进入结果。
- hints 有长度边界，不包含 provider argv 或 config path。
- 不引入 OpenViking 专用分支；未来模块只需配置新的 surface/provider。