### PR TITLE
Make local release promotion fail closed

### DIFF
--- a/examples/release/release-promotion-concurrency-smoke.py
+++ b/examples/release/release-promotion-concurrency-smoke.py
@@ -152,6 +152,69 @@ def assert_concurrent_release_ids_are_distinct(root: Path) -> None:
     wrapper = Path(env["LOOPX_BIN_DIR"]) / "loopx"
     assert wrapper.is_symlink(), wrapper
     assert wrapper.resolve().parents[1] in release_paths, wrapper.resolve()
+    doctor_env = {**env, "PATH": f"{wrapper.parent}:{env['PATH']}"}
+    standard_doctor = subprocess.run(
+        [str(wrapper), "--format", "json", "doctor"],
+        cwd=root,
+        env=doctor_env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    standard_payload = json.loads(standard_doctor.stdout)
+    standard_check_ids = {item["id"] for item in standard_payload["checks"]}
+    assert standard_payload["mode"] == "standard", standard_payload
+    assert not {
+        "command_package_same_root",
+        "representative_cli_commands",
+        "representative_cli_imports",
+        "representative_package_paths",
+    } & standard_check_ids, standard_payload
+
+    deep_doctor = subprocess.run(
+        [str(wrapper), "--format", "json", "doctor", "--deep"],
+        cwd=root,
+        env=doctor_env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    deep_payload = json.loads(deep_doctor.stdout)
+    deep_checks = {item["id"]: item for item in deep_payload["checks"]}
+    assert deep_payload["mode"] == "deep", deep_payload
+    for check_id in (
+        "command_package_same_root",
+        "representative_cli_commands",
+        "representative_cli_imports",
+        "representative_package_paths",
+    ):
+        assert deep_checks[check_id]["ok"] is True, deep_payload
+
+
+def assert_incomplete_candidate_does_not_replace_default(root: Path) -> None:
+    env = {**install_env(root), "LOOPX_RELEASE_ID": "broken-candidate"}
+    wrapper = Path(env["LOOPX_BIN_DIR"]) / "loopx"
+    good_target = wrapper.resolve(strict=True)
+
+    broken_root = root / "broken-source"
+    shutil.copytree(REPO_ROOT / "loopx", broken_root / "loopx")
+    shutil.copytree(REPO_ROOT / "scripts", broken_root / "scripts")
+    for filename in ("LICENSE", "README.md", "pyproject.toml"):
+        shutil.copy2(REPO_ROOT / filename, broken_root / filename)
+    (broken_root / "loopx" / "quota.py").unlink()
+
+    result = subprocess.run(
+        [str(broken_root / "scripts" / "install-local.sh")],
+        cwd=broken_root,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0, result.stdout
+    assert "release candidate doctor validation failed" in result.stderr, result.stderr
+    assert wrapper.resolve(strict=True) == good_target, wrapper.resolve()
+    assert not (Path(env["LOOPX_RELEASES_DIR"]) / "broken-candidate").exists()
 
 
 def assert_resolved_archive_commit_is_recorded(root: Path) -> None:
@@ -176,6 +239,7 @@ def main() -> int:
         assert_install_waits_for_promotion_guard(root)
         assert_legacy_lock_timeout_preserves_live_owner(root)
         assert_concurrent_release_ids_are_distinct(root)
+        assert_incomplete_candidate_does_not_replace_default(root)
         assert_resolved_archive_commit_is_recorded(root)
     print("release-promotion-concurrency-smoke ok")
     return 0

--- a/loopx/cli_commands/doctor.py
+++ b/loopx/cli_commands/doctor.py
@@ -13,13 +13,19 @@ PrintPayload = Callable[
 
 
 def register_doctor_command(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
-    return subparsers.add_parser(
+    parser = subparsers.add_parser(
         "doctor",
         help="Diagnose local CLI installation, PATH, wrapper, and import health.",
     )
+    parser.add_argument(
+        "--deep",
+        action="store_true",
+        help="Run slower representative release-candidate checks.",
+    )
+    return parser
 
 
 def handle_doctor_command(args: argparse.Namespace, print_payload: PrintPayload) -> int:
-    payload = collect_doctor()
+    payload = collect_doctor(deep=bool(args.deep))
     print_payload(payload, args.format, render_doctor_markdown)
     return 0 if payload.get("ok") else 1

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -643,7 +643,7 @@ def latest_promotion_readiness_event(runtime_root: Path, goal_id: str | None = N
     return latest
 
 
-def collect_doctor() -> dict[str, Any]:
+def collect_doctor(*, deep: bool = False) -> dict[str, Any]:
     loopx_path = resolve_command_path("loopx")
     invocation_path = current_script_invocation_path()
     loopx_canary_path = resolve_command_path("loopx-canary")
@@ -652,7 +652,6 @@ def collect_doctor() -> dict[str, Any]:
     command_path = command_path_primary
     command_realpath = command_path.resolve() if command_path else None
     canary_realpath = canary_path.resolve() if canary_path else None
-    loopx_realpath = loopx_path.resolve() if loopx_path else None
     loopx_canary_realpath = loopx_canary_path.resolve() if loopx_canary_path else None
     module_path = Path(__file__).resolve()
     package_dir = module_path.parent
@@ -732,6 +731,21 @@ def collect_doctor() -> dict[str, Any]:
     )
     default_global_registry = global_registry_path(DEFAULT_RUNTIME_ROOT)
     global_registry_writability = probe_registry_write_path(default_global_registry, create_parent=True)
+    deep_validation = None
+    if deep:
+        from .release_candidate import collect_release_candidate_checks
+
+        invocation_root_text = os.environ.get("LOOPX_RELEASE_ROOT")
+        invocation_root = (
+            Path(invocation_root_text).expanduser().resolve()
+            if invocation_root_text
+            else release_root
+        )
+        deep_validation = collect_release_candidate_checks(
+            command_path=command_path,
+            package_root=repo_root,
+            invocation_root=invocation_root,
+        )
     checks = [
         {
             "id": "command_available",
@@ -834,8 +848,11 @@ def collect_doctor() -> dict[str, Any]:
             else str(global_registry_writability.get("error") or default_global_registry),
         },
     ]
-    return {
+    if deep_validation:
+        checks.extend(deep_validation["checks"])
+    payload = {
         "ok": all(check["ok"] for check in checks if check["required"]),
+        "mode": "deep" if deep else "standard",
         "python": {
             "executable": sys.executable,
             "version": sys.version.split()[0],
@@ -877,6 +894,9 @@ def collect_doctor() -> dict[str, Any]:
             f"`curl -fsSL {NO_CLONE_INSTALL_URL} | bash`."
         ),
     }
+    if deep_validation:
+        payload["release_candidate"] = deep_validation
+    return payload
 
 
 def render_doctor_markdown(payload: dict[str, Any]) -> str:

--- a/loopx/release_candidate.py
+++ b/loopx/release_candidate.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import importlib
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+REPRESENTATIVE_CLI_IMPORTS = (
+    "loopx.cli",
+    "loopx.history",
+    "loopx.quota",
+    "loopx.status",
+)
+REPRESENTATIVE_CLI_COMMANDS = (
+    ("version", ("--version",)),
+    ("commands", ("commands", "--format", "json")),
+    ("status_help", ("status", "--help")),
+    ("quota_help", ("quota", "--help")),
+)
+REPRESENTATIVE_PACKAGE_PATHS = (
+    "loopx/cli.py",
+    "loopx/doctor.py",
+    "loopx/history.py",
+    "loopx/quota.py",
+    "loopx/release_candidate.py",
+    "loopx/status.py",
+    "loopx/cli_commands/doctor.py",
+    "loopx/cli_commands/quota.py",
+    "loopx/cli_commands/status.py",
+    "scripts/loopx",
+)
+
+
+def _import_summary() -> dict[str, Any]:
+    results: dict[str, str] = {}
+    for module_name in REPRESENTATIVE_CLI_IMPORTS:
+        try:
+            importlib.import_module(module_name)
+        except Exception as exc:  # pragma: no cover - partial-package errors vary
+            results[module_name] = f"{type(exc).__name__}: {exc}"
+        else:
+            results[module_name] = "ok"
+    failed = sorted(name for name, result in results.items() if result != "ok")
+    return {
+        "ok": not failed,
+        "results": results,
+        "failed": failed,
+    }
+
+
+def _command_summary(command_path: Path | None) -> dict[str, Any]:
+    if command_path is None:
+        return {"ok": False, "results": {}, "failed": ["command_missing"]}
+
+    results: dict[str, dict[str, Any]] = {}
+    for probe_name, args in REPRESENTATIVE_CLI_COMMANDS:
+        try:
+            result = subprocess.run(
+                [str(command_path), *args],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            results[probe_name] = {
+                "ok": False,
+                "detail": f"{type(exc).__name__}: {exc}",
+            }
+            continue
+        results[probe_name] = {
+            "ok": result.returncode == 0,
+            "returncode": result.returncode,
+        }
+    failed = sorted(name for name, result in results.items() if not result.get("ok"))
+    return {
+        "ok": not failed,
+        "results": results,
+        "failed": failed,
+    }
+
+
+def _package_path_summary(package_root: Path) -> dict[str, Any]:
+    missing = [
+        relative
+        for relative in REPRESENTATIVE_PACKAGE_PATHS
+        if not (package_root / relative).is_file()
+    ]
+    return {
+        "ok": not missing,
+        "required": list(REPRESENTATIVE_PACKAGE_PATHS),
+        "missing": missing,
+    }
+
+
+def collect_release_candidate_checks(
+    *,
+    command_path: Path | None,
+    package_root: Path,
+    invocation_root: Path | None,
+) -> dict[str, Any]:
+    """Run the slower checks used only before promoting a release candidate."""
+
+    imports = _import_summary()
+    commands = _command_summary(command_path)
+    package_paths = _package_path_summary(package_root)
+    command_package_same_root = bool(
+        invocation_root and package_root.resolve() == invocation_root.resolve()
+    )
+    checks = [
+        {
+            "id": "command_package_same_root",
+            "required": True,
+            "ok": command_package_same_root,
+            "detail": (
+                f"invocation_root={invocation_root}; package_root={package_root}"
+            ),
+        },
+        {
+            "id": "representative_cli_imports",
+            "required": True,
+            "ok": bool(imports.get("ok")),
+            "detail": ",".join(imports.get("failed") or []) or "ok",
+        },
+        {
+            "id": "representative_cli_commands",
+            "required": True,
+            "ok": bool(commands.get("ok")),
+            "detail": ",".join(commands.get("failed") or []) or "ok",
+        },
+        {
+            "id": "representative_package_paths",
+            "required": True,
+            "ok": bool(package_paths.get("ok")),
+            "detail": ",".join(package_paths.get("missing") or []) or "ok",
+        },
+    ]
+    return {
+        "schema_version": "loopx_release_candidate_checks_v0",
+        "ok": all(check["ok"] for check in checks),
+        "checks": checks,
+        "representative_cli": {
+            "imports": imports,
+            "commands": commands,
+            "package_paths": package_paths,
+        },
+    }

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -245,6 +245,57 @@ if expected_commit and source.get("git_commit") != expected_commit:
 PY
 }
 
+validate_release_candidate() {
+  local candidate="$1"
+  local candidate_wrapper="$candidate/scripts/loopx"
+  if [[ ! -x "$candidate_wrapper" ]]; then
+    echo "loopx installer error: release candidate is missing an executable wrapper" >&2
+    return 1
+  fi
+
+  local doctor_json
+  if ! doctor_json="$(PATH="$candidate/scripts:$PATH" "$candidate_wrapper" --format json doctor --deep)"; then
+    echo "loopx installer error: release candidate doctor validation failed" >&2
+    return 1
+  fi
+  LOOPX_CANDIDATE_DOCTOR_JSON="$doctor_json" "${LOOPX_PYTHON:-python3}" - <<'PY'
+import json
+import os
+import sys
+
+try:
+    payload = json.loads(os.environ["LOOPX_CANDIDATE_DOCTOR_JSON"])
+except (KeyError, json.JSONDecodeError) as exc:
+    print(f"loopx installer error: release candidate doctor output is invalid: {exc}", file=sys.stderr)
+    raise SystemExit(1)
+
+required_checks = {
+    "command_package_same_root",
+    "representative_cli_commands",
+    "representative_cli_imports",
+    "representative_package_paths",
+}
+checks = {
+    str(item.get("id")): item
+    for item in payload.get("checks", [])
+    if isinstance(item, dict)
+}
+missing = sorted(required_checks - checks.keys())
+failed = sorted(
+    check_id
+    for check_id in required_checks
+    if not checks.get(check_id, {}).get("ok")
+)
+if payload.get("mode") != "deep" or not payload.get("ok") or missing or failed:
+    print(
+        "loopx installer error: release candidate is incomplete "
+        f"(missing_checks={missing}, failed_checks={failed})",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+PY
+}
+
 resolve_default_promotion() {
   case "$promote_default_request" in
     1|true|yes)
@@ -366,6 +417,10 @@ fi
 chmod +x "$release_tmp/scripts/loopx"
 mv "$release_tmp" "$release_dir"
 release_tmp=""
+if ! validate_release_candidate "$release_dir"; then
+  rm -rf "$release_dir"
+  exit 1
+fi
 install_symlink "$release_dir/scripts/loopx" "$bin_dir/loopx"
 verify_default_promotion
 


### PR DESCRIPTION
## Summary
- validate a complete release candidate with `doctor` before atomically switching the default `loopx` symlink
- keep install-lock cleanup ownership-safe so a waiting process cannot remove another installer's lock
- extend `doctor` with representative import, command, package-path, and invocation-root coherence checks
- preserve the previous default when an incomplete concurrent update fails validation

## Validation
- `bash -n scripts/install-local.sh`
- `uvx ruff check loopx/doctor.py examples/install-local-smoke.py examples/release/release-promotion-concurrency-smoke.py`
- `python3 -m py_compile loopx/doctor.py examples/install-local-smoke.py examples/release/release-promotion-concurrency-smoke.py`
- `python3 examples/release/release-promotion-concurrency-smoke.py`
- `python3 examples/install-local-smoke.py`
- `./scripts/loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard --timeout-seconds 180` (17/17 selected checks passed; public-boundary passed; no manual holds)

## Validation note
An initial premerge invocation through the PATH-installed `loopx` failed before running catalog checks because that installed package did not contain `docs/interaction-pattern-catalog.md`. Re-running through the checkout wrapper, which is the documented premerge source-selection path, passed all 17 selected checks. No check was skipped.

## Review focus
The changed surface is installer/doctor runtime behavior. The focused smoke proves the prior default remains usable after an intentionally incomplete candidate, while the broader premerge set covers install, overwrite, packaged CLI, no-clone release verification, update, promotion readiness, task lease, and public-boundary behavior. Independent review is requested because this changes default installation semantics.
