### PR TITLE
fix(history): recognize compact reward overlays

### DIFF
--- a/examples/contract-reward-overlay-smoke.py
+++ b/examples/contract-reward-overlay-smoke.py
@@ -39,6 +39,43 @@ def write_run(run_dir: Path, goal_id: str, *, duplicate_kind: str) -> None:
                 },
             }
         )
+    elif duplicate_kind == "projected_reward_overlay":
+        projected = {
+            key: record[key]
+            for key in (
+                "generated_at",
+                "goal_id",
+                "classification",
+                "recommended_action",
+                "json_path",
+                "markdown_path",
+            )
+        }
+        lines = [
+            {
+                **record,
+                "agent_id": "fixture-agent",
+                "progress_scope": "agent_lane",
+                "delivery_batch_scale": "multi_surface",
+                "delivery_outcome": "outcome_progress",
+            },
+            {
+                **projected,
+                "human_reward": {
+                    "recorded_at": "2026-01-01T00:00:01+00:00",
+                    "decision": "continue",
+                    "reward": "positive",
+                },
+            },
+            {
+                **projected,
+                "human_reward": {
+                    "recorded_at": "2026-01-01T00:00:02+00:00",
+                    "decision": "refine",
+                    "reward": "mixed",
+                },
+            },
+        ]
     elif duplicate_kind == "plain_duplicate":
         lines.append(dict(record))
     elif duplicate_kind == "artifact_identity_collision":
@@ -83,27 +120,72 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
     runtime_root = root / "runtime"
     project = root / "project"
     project.mkdir(parents=True)
-    reward_state_file = project / ".codex" / "goals" / "reward-overlay-goal" / "ACTIVE_GOAL_STATE.md"
-    duplicate_state_file = project / ".codex" / "goals" / "plain-duplicate-goal" / "ACTIVE_GOAL_STATE.md"
-    bundle_state_file = project / ".codex" / "goals" / "structured-bundle-goal" / "ACTIVE_GOAL_STATE.md"
+    reward_state_file = (
+        project / ".codex" / "goals" / "reward-overlay-goal" / "ACTIVE_GOAL_STATE.md"
+    )
+    projected_reward_state_file = (
+        project
+        / ".codex"
+        / "goals"
+        / "projected-reward-overlay-goal"
+        / "ACTIVE_GOAL_STATE.md"
+    )
+    duplicate_state_file = (
+        project / ".codex" / "goals" / "plain-duplicate-goal" / "ACTIVE_GOAL_STATE.md"
+    )
+    bundle_state_file = (
+        project / ".codex" / "goals" / "structured-bundle-goal" / "ACTIVE_GOAL_STATE.md"
+    )
     artifact_collision_state_file = (
-        project / ".codex" / "goals" / "artifact-collision-goal" / "ACTIVE_GOAL_STATE.md"
+        project
+        / ".codex"
+        / "goals"
+        / "artifact-collision-goal"
+        / "ACTIVE_GOAL_STATE.md"
     )
     reward_state_file.parent.mkdir(parents=True)
+    projected_reward_state_file.parent.mkdir(parents=True)
     duplicate_state_file.parent.mkdir(parents=True)
     bundle_state_file.parent.mkdir(parents=True)
     artifact_collision_state_file.parent.mkdir(parents=True)
-    reward_state_file.write_text("---\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n", encoding="utf-8")
-    duplicate_state_file.write_text("---\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n", encoding="utf-8")
-    bundle_state_file.write_text("---\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n", encoding="utf-8")
-    artifact_collision_state_file.write_text("---\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n", encoding="utf-8")
+    reward_state_file.write_text(
+        "---\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n", encoding="utf-8"
+    )
+    projected_reward_state_file.write_text(
+        "---\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n",
+        encoding="utf-8",
+    )
+    duplicate_state_file.write_text(
+        "---\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n", encoding="utf-8"
+    )
+    bundle_state_file.write_text(
+        "---\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n", encoding="utf-8"
+    )
+    artifact_collision_state_file.write_text(
+        "---\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n", encoding="utf-8"
+    )
     local_private_doc = project / ".local" / "managed_doc" / "PRIVATE_DRAFT.md"
     local_private_doc.parent.mkdir(parents=True)
     private_host = "private-docs.example.invalid"
-    local_private_doc.write_text(f"https://{private_host}/docx/private-draft\n", encoding="utf-8")
+    local_private_doc.write_text(
+        f"https://{private_host}/docx/private-draft\n", encoding="utf-8"
+    )
 
-    write_run(runtime_root / "goals" / "reward-overlay-goal" / "runs", "reward-overlay-goal", duplicate_kind="reward_overlay")
-    write_run(runtime_root / "goals" / "plain-duplicate-goal" / "runs", "plain-duplicate-goal", duplicate_kind="plain_duplicate")
+    write_run(
+        runtime_root / "goals" / "reward-overlay-goal" / "runs",
+        "reward-overlay-goal",
+        duplicate_kind="reward_overlay",
+    )
+    write_run(
+        runtime_root / "goals" / "projected-reward-overlay-goal" / "runs",
+        "projected-reward-overlay-goal",
+        duplicate_kind="projected_reward_overlay",
+    )
+    write_run(
+        runtime_root / "goals" / "plain-duplicate-goal" / "runs",
+        "plain-duplicate-goal",
+        duplicate_kind="plain_duplicate",
+    )
     write_run(
         runtime_root / "goals" / "structured-bundle-goal" / "runs",
         "structured-bundle-goal",
@@ -125,6 +207,14 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
                         "id": "reward-overlay-goal",
                         "repo": str(project),
                         "state_file": ".codex/goals/reward-overlay-goal/ACTIVE_GOAL_STATE.md",
+                        "domain": "smoke",
+                        "status": "connected-read-only",
+                        "adapter": {"kind": "smoke", "status": "connected-read-only"},
+                    },
+                    {
+                        "id": "projected-reward-overlay-goal",
+                        "repo": str(project),
+                        "state_file": ".codex/goals/projected-reward-overlay-goal/ACTIVE_GOAL_STATE.md",
                         "domain": "smoke",
                         "status": "connected-read-only",
                         "adapter": {"kind": "smoke", "status": "connected-read-only"},
@@ -176,20 +266,49 @@ def main() -> None:
         checks = "\n".join(payload["checks"])
         warnings = "\n".join(payload["warnings"])
         assert payload["ok"] is True, payload
-        assert "reward-overlay-goal: reward overlay rows raw=2 unique=1 overlays=1" in checks, payload
+        assert (
+            "reward-overlay-goal: reward overlay rows raw=2 unique=1 overlays=1"
+            in checks
+        ), payload
         assert "reward-overlay-goal: duplicate index rows" not in warnings, payload
-        assert "structured-bundle-goal: structured artifact bundle rows raw=2 unique=1 bundles=1" in checks, payload
+        assert (
+            "projected-reward-overlay-goal: reward overlay rows raw=3 unique=1 overlays=2"
+            in checks
+        ), payload
+        assert "projected-reward-overlay-goal: duplicate index rows" not in warnings, (
+            payload
+        )
+        assert (
+            "structured-bundle-goal: structured artifact bundle rows raw=2 unique=1 bundles=1"
+            in checks
+        ), payload
         assert "structured-bundle-goal: duplicate index rows" not in warnings, payload
-        assert "plain-duplicate-goal: duplicate index rows raw=2 unique=1 unexpected=1 auto_repairable=1" in warnings, payload
-        assert "loopx history --goal-id plain-duplicate-goal inspect-index-duplicates" in warnings, payload
-        assert "loopx history --goal-id plain-duplicate-goal repair-index-duplicates" in warnings, payload
+        assert (
+            "plain-duplicate-goal: duplicate index rows raw=2 unique=1 unexpected=1 auto_repairable=1"
+            in warnings
+        ), payload
+        assert (
+            "loopx history --goal-id plain-duplicate-goal inspect-index-duplicates"
+            in warnings
+        ), payload
+        assert (
+            "loopx history --goal-id plain-duplicate-goal repair-index-duplicates"
+            in warnings
+        ), payload
         assert (
             "artifact-collision-goal: duplicate index rows raw=2 unique=1 unexpected=1 "
             "artifact_identity_collisions=1 artifact_collision_rows=1"
         ) in warnings, payload
-        assert "artifact identity collisions need reviewed merge semantics" in warnings, payload
-        assert "loopx history --goal-id artifact-collision-goal repair-index-duplicates" not in warnings, payload
-        assert not any(".local/managed_doc" in item for item in payload["errors"]), payload
+        assert (
+            "artifact identity collisions need reviewed merge semantics" in warnings
+        ), payload
+        assert (
+            "loopx history --goal-id artifact-collision-goal repair-index-duplicates"
+            not in warnings
+        ), payload
+        assert not any(".local/managed_doc" in item for item in payload["errors"]), (
+            payload
+        )
 
     print("contract-reward-overlay-smoke ok")
 

--- a/examples/history-index-duplicate-inspection-smoke.py
+++ b/examples/history-index-duplicate-inspection-smoke.py
@@ -43,6 +43,57 @@ def write_index_fixture(root: Path, goal_id: str, duplicate_kind: str) -> None:
                 },
             },
         ]
+    elif duplicate_kind == "projected_reward_overlay":
+        projected = {
+            key: base[key]
+            for key in (
+                "generated_at",
+                "goal_id",
+                "classification",
+                "recommended_action",
+                "health_check",
+                "json_path",
+                "markdown_path",
+            )
+        }
+        rows = [
+            {
+                **base,
+                "agent_id": "fixture-agent",
+                "progress_scope": "agent_lane",
+                "delivery_batch_scale": "multi_surface",
+                "delivery_outcome": "outcome_progress",
+            },
+            {
+                **projected,
+                "human_reward": {
+                    "recorded_at": "2026-01-01T00:00:01+00:00",
+                    "decision": "continue",
+                    "reward": "positive",
+                },
+            },
+            {
+                **projected,
+                "human_reward": {
+                    "recorded_at": "2026-01-01T00:00:02+00:00",
+                    "decision": "refine",
+                    "reward": "mixed",
+                },
+            },
+        ]
+    elif duplicate_kind == "conflicting_projected_reward_overlay":
+        rows = [
+            base,
+            {
+                **base,
+                "recommended_action": "conflicting compact projection must stay visible",
+                "human_reward": {
+                    "recorded_at": "2026-01-01T00:00:01+00:00",
+                    "decision": "continue",
+                    "reward": "positive",
+                },
+            },
+        ]
     elif duplicate_kind == "plain_duplicate":
         rows = [base, dict(base)]
     elif duplicate_kind == "structured_artifact_collision":
@@ -90,7 +141,11 @@ def write_index_fixture(root: Path, goal_id: str, duplicate_kind: str) -> None:
         ]
     elif duplicate_kind == "artifact_identity_collision":
         rows = [
-            {**base, "classification": "benchmark_run_v0", "health_check": "benchmark_run_v0 compact event public-safe"},
+            {
+                **base,
+                "classification": "benchmark_run_v0",
+                "health_check": "benchmark_run_v0 compact event public-safe",
+            },
             {**base, "classification": "state_refreshed"},
         ]
     else:
@@ -109,6 +164,11 @@ def write_registry(root: Path) -> Path:
     goals = []
     for goal_id, kind in (
         ("reward-overlay-goal", "reward_overlay"),
+        ("projected-reward-overlay-goal", "projected_reward_overlay"),
+        (
+            "conflicting-projected-reward-overlay-goal",
+            "conflicting_projected_reward_overlay",
+        ),
         ("plain-duplicate-goal", "plain_duplicate"),
         ("structured-artifact-goal", "structured_artifact_collision"),
         ("structured-bundle-goal", "structured_artifact_bundle"),
@@ -116,7 +176,9 @@ def write_registry(root: Path) -> Path:
     ):
         state_file = project / ".codex" / "goals" / goal_id / "ACTIVE_GOAL_STATE.md"
         state_file.parent.mkdir(parents=True, exist_ok=True)
-        state_file.write_text("---\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n", encoding="utf-8")
+        state_file.write_text(
+            "---\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n", encoding="utf-8"
+        )
         write_index_fixture(root, goal_id, kind)
         goals.append(
             {
@@ -168,36 +230,95 @@ def run_cli(registry_path: Path, *args: str) -> dict:
 def main() -> None:
     with tempfile.TemporaryDirectory() as raw_tmp:
         registry_path = write_registry(Path(raw_tmp))
-        payload = run_cli(registry_path, "history", "inspect-index-duplicates", "--limit", "10")
+        payload = run_cli(
+            registry_path, "history", "inspect-index-duplicates", "--limit", "10"
+        )
         assert payload["ok"] is True, payload
-        assert payload["duplicate_group_count"] == 5, payload
-        assert payload["duplicate_row_count"] == 5, payload
+        assert payload["duplicate_group_count"] == 7, payload
+        assert payload["duplicate_row_count"] == 8, payload
         by_goal = {group["goal_id"]: group for group in payload["groups"]}
-        assert by_goal["reward-overlay-goal"]["duplicate_kind"] == "reward_overlay", payload
+        assert by_goal["reward-overlay-goal"]["duplicate_kind"] == "reward_overlay", (
+            payload
+        )
         assert by_goal["reward-overlay-goal"]["severity"] == "info", payload
-        assert by_goal["plain-duplicate-goal"]["duplicate_kind"] == "plain_duplicate", payload
+        assert (
+            by_goal["projected-reward-overlay-goal"]["duplicate_kind"]
+            == "reward_overlay"
+        ), payload
+        assert by_goal["projected-reward-overlay-goal"]["severity"] == "info", payload
+        assert by_goal["projected-reward-overlay-goal"]["reward_overlay_rows"] == 2, (
+            payload
+        )
+        assert (
+            by_goal["conflicting-projected-reward-overlay-goal"]["duplicate_kind"]
+            == "artifact_identity_collision"
+        ), payload
+        assert (
+            by_goal["conflicting-projected-reward-overlay-goal"]["severity"]
+            == "warning"
+        ), payload
+        assert by_goal["plain-duplicate-goal"]["duplicate_kind"] == "plain_duplicate", (
+            payload
+        )
         assert by_goal["plain-duplicate-goal"]["severity"] == "warning", payload
-        assert by_goal["structured-artifact-goal"]["duplicate_kind"] == "artifact_identity_collision", payload
-        assert by_goal["structured-bundle-goal"]["duplicate_kind"] == "structured_artifact_bundle", payload
+        assert (
+            by_goal["structured-artifact-goal"]["duplicate_kind"]
+            == "artifact_identity_collision"
+        ), payload
+        assert (
+            by_goal["structured-bundle-goal"]["duplicate_kind"]
+            == "structured_artifact_bundle"
+        ), payload
         assert by_goal["structured-bundle-goal"]["severity"] == "info", payload
-        assert by_goal["artifact-collision-goal"]["duplicate_kind"] == "artifact_identity_collision", payload
-        assert by_goal["artifact-collision-goal"]["classifications"] == ["benchmark_run_v0", "state_refreshed"], payload
+        assert (
+            by_goal["artifact-collision-goal"]["duplicate_kind"]
+            == "artifact_identity_collision"
+        ), payload
+        assert by_goal["artifact-collision-goal"]["classifications"] == [
+            "benchmark_run_v0",
+            "state_refreshed",
+        ], payload
         assert payload["groups"][0]["severity"] == "warning", payload
 
-        repair_preview = run_cli(registry_path, "history", "repair-index-duplicates", "--limit", "10")
+        repair_preview = run_cli(
+            registry_path, "history", "repair-index-duplicates", "--limit", "10"
+        )
         assert repair_preview["ok"] is True, repair_preview
         assert repair_preview["dry_run"] is True, repair_preview
         assert repair_preview["repaired"] is False, repair_preview
         assert repair_preview["removed_row_count"] == 2, repair_preview
-        assert repair_preview["preserved_reward_overlay_rows"] == 1, repair_preview
-        assert repair_preview["preserved_structured_artifact_bundle_rows"] == 1, repair_preview
-        assert repair_preview["unrepaired_group_count"] == 1, repair_preview
-        repair_actions = {group["goal_id"]: group["action"] for group in repair_preview["groups"]}
-        assert repair_actions["reward-overlay-goal"] == "preserve_reward_overlay", repair_preview
-        assert repair_actions["plain-duplicate-goal"] == "drop_plain_duplicate_rows", repair_preview
-        assert repair_actions["structured-artifact-goal"] == "keep_structured_artifact_row", repair_preview
-        assert repair_actions["structured-bundle-goal"] == "preserve_structured_artifact_bundle", repair_preview
-        assert repair_actions["artifact-collision-goal"] == "blocked_artifact_identity_collision", repair_preview
+        assert repair_preview["preserved_reward_overlay_rows"] == 3, repair_preview
+        assert repair_preview["preserved_structured_artifact_bundle_rows"] == 1, (
+            repair_preview
+        )
+        assert repair_preview["unrepaired_group_count"] == 2, repair_preview
+        repair_actions = {
+            group["goal_id"]: group["action"] for group in repair_preview["groups"]
+        }
+        assert repair_actions["reward-overlay-goal"] == "preserve_reward_overlay", (
+            repair_preview
+        )
+        assert (
+            repair_actions["projected-reward-overlay-goal"] == "preserve_reward_overlay"
+        ), repair_preview
+        assert (
+            repair_actions["conflicting-projected-reward-overlay-goal"]
+            == "blocked_artifact_identity_collision"
+        ), repair_preview
+        assert repair_actions["plain-duplicate-goal"] == "drop_plain_duplicate_rows", (
+            repair_preview
+        )
+        assert (
+            repair_actions["structured-artifact-goal"] == "keep_structured_artifact_row"
+        ), repair_preview
+        assert (
+            repair_actions["structured-bundle-goal"]
+            == "preserve_structured_artifact_bundle"
+        ), repair_preview
+        assert (
+            repair_actions["artifact-collision-goal"]
+            == "blocked_artifact_identity_collision"
+        ), repair_preview
 
         repair_execute = run_cli(
             registry_path,
@@ -212,15 +333,33 @@ def main() -> None:
         assert repair_execute["repaired"] is True, repair_execute
         assert repair_execute["removed_row_count"] == 2, repair_execute
 
-        after_repair = run_cli(registry_path, "history", "inspect-index-duplicates", "--limit", "10")
+        after_repair = run_cli(
+            registry_path, "history", "inspect-index-duplicates", "--limit", "10"
+        )
         assert after_repair["ok"] is True, after_repair
-        assert after_repair["duplicate_group_count"] == 3, after_repair
+        assert after_repair["duplicate_group_count"] == 5, after_repair
         after_by_goal = {group["goal_id"]: group for group in after_repair["groups"]}
         assert "plain-duplicate-goal" not in after_by_goal, after_repair
         assert "structured-artifact-goal" not in after_by_goal, after_repair
-        assert after_by_goal["reward-overlay-goal"]["duplicate_kind"] == "reward_overlay", after_repair
-        assert after_by_goal["structured-bundle-goal"]["duplicate_kind"] == "structured_artifact_bundle", after_repair
-        assert after_by_goal["artifact-collision-goal"]["duplicate_kind"] == "artifact_identity_collision", after_repair
+        assert (
+            after_by_goal["reward-overlay-goal"]["duplicate_kind"] == "reward_overlay"
+        ), after_repair
+        assert (
+            after_by_goal["projected-reward-overlay-goal"]["duplicate_kind"]
+            == "reward_overlay"
+        ), after_repair
+        assert (
+            after_by_goal["conflicting-projected-reward-overlay-goal"]["duplicate_kind"]
+            == "artifact_identity_collision"
+        ), after_repair
+        assert (
+            after_by_goal["structured-bundle-goal"]["duplicate_kind"]
+            == "structured_artifact_bundle"
+        ), after_repair
+        assert (
+            after_by_goal["artifact-collision-goal"]["duplicate_kind"]
+            == "artifact_identity_collision"
+        ), after_repair
 
         filtered = run_cli(
             registry_path,

--- a/loopx/control_plane/runtime/run_index_duplicates.py
+++ b/loopx/control_plane/runtime/run_index_duplicates.py
@@ -12,6 +12,13 @@ STRUCTURED_INDEX_KEYS = (
     "benchmark_experiment_report",
     "active_user_assisted_pilot",
 )
+REWARD_OVERLAY_IDENTITY_KEYS = (
+    "generated_at",
+    "goal_id",
+    "classification",
+    "json_path",
+    "markdown_path",
+)
 
 
 def index_identity(record: dict[str, Any]) -> tuple[str, str, str]:
@@ -38,10 +45,40 @@ def _normalized_key(record: dict[str, Any]) -> str:
     return json.dumps(record, sort_keys=True, ensure_ascii=False)
 
 
+def is_reward_overlay_bundle(records: list[dict[str, Any]]) -> bool:
+    """Return true when compact reward rows are projections of one base run."""
+
+    base_rows = [
+        record for record in records if not isinstance(record.get("human_reward"), dict)
+    ]
+    reward_rows = [
+        record for record in records if isinstance(record.get("human_reward"), dict)
+    ]
+    if len(base_rows) != 1 or not reward_rows:
+        return False
+
+    base = base_rows[0]
+    for overlay in reward_rows:
+        projected = _normalized_index_record(overlay)
+        if not all(key in projected for key in REWARD_OVERLAY_IDENTITY_KEYS):
+            return False
+        if any(
+            key not in base or base[key] != value for key, value in projected.items()
+        ):
+            return False
+    return True
+
+
 def is_repairable_structured_artifact_duplicate(records: list[dict[str, Any]]) -> bool:
     classifications = {str(record.get("classification") or "") for record in records}
-    health_checks = {str(record.get("health_check") or "") for record in records if record.get("health_check")}
-    structured_rows = [record for record in records if has_structured_index_payload(record)]
+    health_checks = {
+        str(record.get("health_check") or "")
+        for record in records
+        if record.get("health_check")
+    }
+    structured_rows = [
+        record for record in records if has_structured_index_payload(record)
+    ]
     return (
         len(structured_rows) == 1
         and len(classifications) == 1
@@ -66,16 +103,22 @@ def is_structured_artifact_bundle(records: list[dict[str, Any]]) -> bool:
     if not all(len(structured_index_payload_keys(record)) == 1 for record in records):
         return False
     payload_fingerprints = {
-        _normalized_key({key: record[key] for key in structured_index_payload_keys(record)})
+        _normalized_key(
+            {key: record[key] for key in structured_index_payload_keys(record)}
+        )
         for record in records
     }
     return len(payload_fingerprints) == len(records)
 
 
 def classify_index_duplicate_records(records: list[dict[str, Any]]) -> dict[str, Any]:
-    normalized_keys = {_normalized_key(_normalized_index_record(record)) for record in records}
-    reward_records = sum(1 for record in records if isinstance(record.get("human_reward"), dict))
-    if reward_records and len(normalized_keys) == 1:
+    normalized_keys = {
+        _normalized_key(_normalized_index_record(record)) for record in records
+    }
+    reward_records = sum(
+        1 for record in records if isinstance(record.get("human_reward"), dict)
+    )
+    if is_reward_overlay_bundle(records):
         return {
             "duplicate_kind": "reward_overlay",
             "severity": "info",
@@ -85,7 +128,7 @@ def classify_index_duplicate_records(records: list[dict[str, Any]]) -> dict[str,
             "reason": "reward overlay rows are intentionally merged by status checks",
         }
 
-    if len(normalized_keys) == 1:
+    if not reward_records and len(normalized_keys) == 1:
         return {
             "duplicate_kind": "plain_duplicate",
             "severity": "warning",
@@ -128,7 +171,9 @@ def classify_index_duplicate_records(records: list[dict[str, Any]]) -> dict[str,
     }
 
 
-def duplicate_repair_decision(records: list[tuple[int, dict[str, Any]]]) -> dict[str, Any]:
+def duplicate_repair_decision(
+    records: list[tuple[int, dict[str, Any]]],
+) -> dict[str, Any]:
     line_numbers = [line_number for line_number, _ in records]
     payload = classify_index_duplicate_records([record for _, record in records])
     action = payload.get("action")
@@ -144,7 +189,11 @@ def duplicate_repair_decision(records: list[tuple[int, dict[str, Any]]]) -> dict
             if has_structured_index_payload(record)
         ]
         kept_line_numbers = [structured_lines[0]]
-        removed_line_numbers = [line_number for line_number in line_numbers if line_number != structured_lines[0]]
+        removed_line_numbers = [
+            line_number
+            for line_number in line_numbers
+            if line_number != structured_lines[0]
+        ]
 
     return {
         "action": action,


### PR DESCRIPTION
## 问题

`feedback record` 会把 human reward 作为紧凑 overlay 追加到同一 run identity。writer 只投影少量稳定字段，但重复索引检查此前要求 overlay 去掉 `human_reward` 后与 base row 完全相等，因此把合法 reward overlay 误报成 `artifact_identity_collision`。

## 改动

- 将 reward overlay 定义为“恰好一个 base run + 一个或多个紧凑投影”
- 要求 overlay 的稳定 identity 字段完整，且每个投影字段都与 base 一致
- overlay-only、多个 base 或字段冲突仍保持 `artifact_identity_collision/warning`
- 补充 history inspect/repair 与 contract 两层回归

## 验证

- `python3 examples/history-index-duplicate-inspection-smoke.py`
- `python3 examples/contract-reward-overlay-smoke.py`
- `uvx ruff check ...`
- `uvx ruff format --check ...`
- `python3 -m loopx.cli canary premerge --from-git-diff --tier standard --format json --no-progress`
- 用真实 `openviking-goal` 只读验证：两组历史记录均识别为 `reward_overlay/info`，contract warning 为 0；未修改实际 run index

## 风险

规则只接受 base 的严格字段投影；冲突 fixture 继续保持 warning，因此不会掩盖真实 artifact identity collision。