### PR TITLE
fix(quota): select actionable monitor handles

### DIFF
--- a/examples/control_plane/external-evidence-observation-smoke.py
+++ b/examples/control_plane/external-evidence-observation-smoke.py
@@ -325,6 +325,40 @@ def assert_future_scoped_monitor_does_not_fake_external_poll() -> None:
     assert "external_evidence_observation" not in guard, guard
 
 
+def assert_schedule_gap_monitor_outranks_future_handle() -> None:
+    summary = agent_todos(
+        [
+            monitor_todo(
+                todo_id="todo_monitor_future",
+                priority="P1",
+                next_due_at=FUTURE_DUE_AT,
+            ),
+            todo(
+                2,
+                "[P2] Monitor the ledger after the next batch completes.",
+                task_class=TODO_TASK_CLASS_MONITOR,
+                todo_id="todo_monitor_schedule_gap",
+                target_key="ledger:next-batch",
+                claimed_by=AGENT_ID,
+            ),
+        ]
+    )
+    item = selected_item(status_payload(summary))
+
+    handle = projected_monitor_handle(summary)
+    assert handle and handle["todo_id"] == "todo_monitor_schedule_gap", handle
+    assert handle["target_key"] == "ledger:next-batch", handle
+
+    signal = build_external_evidence_poll_signal(item, agent_todo_summary=summary)
+    assert signal and signal["monitor_handle"]["todo_id"] == "todo_monitor_schedule_gap", signal
+
+    guard = build_quota_should_run(status_payload(summary), goal_id=GOAL_ID, agent_id=AGENT_ID)
+    observation = guard["external_evidence_observation"]
+    assert observation["monitor_handle"]["todo_id"] == "todo_monitor_schedule_gap", guard
+    assert "Monitor the ledger" in observation["observation_target"], observation
+    assert "Monitor the ledger" in guard["interaction_contract"]["agent_channel"]["primary_action"], guard
+
+
 def assert_pr_dependency_wait_requires_first_observation() -> None:
     summary = agent_todos([pr_dependency_monitor_todo()])
     next_action = (
@@ -427,6 +461,7 @@ def main() -> int:
     assert_recent_due_monitor_no_change_quiets_external_monitor()
     assert_advancement_lane_keeps_external_monitor_as_context()
     assert_future_scoped_monitor_does_not_fake_external_poll()
+    assert_schedule_gap_monitor_outranks_future_handle()
     assert_pr_dependency_wait_requires_first_observation()
     assert_pr_dependency_wait_with_observation_does_not_reobserve_before_due()
     assert_explicit_external_wait_builds_registry_obligation()

--- a/examples/control_plane/external-evidence-observation-smoke.py
+++ b/examples/control_plane/external-evidence-observation-smoke.py
@@ -107,6 +107,17 @@ def pr_dependency_monitor_todo(
     )
 
 
+def schedule_gap_monitor_todo(*, index: int = 2, priority: str = "P2") -> dict[str, Any]:
+    return todo(
+        index,
+        f"[{priority}] Monitor the ledger after the next batch completes.",
+        task_class=TODO_TASK_CLASS_MONITOR,
+        todo_id="todo_monitor_schedule_gap",
+        target_key="ledger:next-batch",
+        claimed_by=AGENT_ID,
+    )
+
+
 def advancement_todo() -> dict[str, Any]:
     return todo(
         2,
@@ -325,38 +336,71 @@ def assert_future_scoped_monitor_does_not_fake_external_poll() -> None:
     assert "external_evidence_observation" not in guard, guard
 
 
-def assert_schedule_gap_monitor_outranks_future_handle() -> None:
-    summary = agent_todos(
-        [
-            monitor_todo(
-                todo_id="todo_monitor_future",
-                priority="P1",
-                next_due_at=FUTURE_DUE_AT,
-            ),
-            todo(
-                2,
-                "[P2] Monitor the ledger after the next batch completes.",
-                task_class=TODO_TASK_CLASS_MONITOR,
-                todo_id="todo_monitor_schedule_gap",
-                target_key="ledger:next-batch",
-                claimed_by=AGENT_ID,
-            ),
-        ]
+def assert_selected_monitor_handle(
+    items: list[dict[str, Any]],
+    *,
+    expected_todo_id: str,
+    expected_target_key: str,
+    expected_text: str,
+    expected_signal: str | None = None,
+    **status_options: Any,
+) -> None:
+    summary = agent_todos(items)
+    payload = status_payload(summary, **status_options)
+    signal = build_external_evidence_poll_signal(
+        selected_item(payload),
+        agent_todo_summary=summary,
     )
-    item = selected_item(status_payload(summary))
-
     handle = projected_monitor_handle(summary)
-    assert handle and handle["todo_id"] == "todo_monitor_schedule_gap", handle
-    assert handle["target_key"] == "ledger:next-batch", handle
-
-    signal = build_external_evidence_poll_signal(item, agent_todo_summary=summary)
-    assert signal and signal["monitor_handle"]["todo_id"] == "todo_monitor_schedule_gap", signal
-
-    guard = build_quota_should_run(status_payload(summary), goal_id=GOAL_ID, agent_id=AGENT_ID)
+    assert handle and handle["todo_id"] == expected_todo_id, handle
+    assert handle["target_key"] == expected_target_key, handle
+    assert signal and signal["monitor_handle"]["todo_id"] == expected_todo_id, signal
+    if expected_signal:
+        assert signal["matched_signal"] == expected_signal, signal
+    guard = build_quota_should_run(payload, goal_id=GOAL_ID, agent_id=AGENT_ID)
     observation = guard["external_evidence_observation"]
-    assert observation["monitor_handle"]["todo_id"] == "todo_monitor_schedule_gap", guard
-    assert "Monitor the ledger" in observation["observation_target"], observation
-    assert "Monitor the ledger" in guard["interaction_contract"]["agent_channel"]["primary_action"], guard
+    assert observation["monitor_handle"]["todo_id"] == expected_todo_id, guard
+    assert expected_text in observation["observation_target"], observation
+    assert expected_text in guard["interaction_contract"]["agent_channel"]["primary_action"], guard
+
+
+def assert_monitor_handle_precedence() -> None:
+    future = monitor_todo(
+        todo_id="todo_monitor_future",
+        priority="P1",
+        next_due_at=FUTURE_DUE_AT,
+    )
+    assert_selected_monitor_handle(
+        [future, schedule_gap_monitor_todo()],
+        expected_todo_id="todo_monitor_schedule_gap",
+        expected_target_key="ledger:next-batch",
+        expected_text="Monitor the ledger",
+    )
+    dependency_action = (
+        "Keep PR #532 in review-required state; after maintainer review/merge, "
+        "resume dependent validation lane."
+    )
+    dependency = pr_dependency_monitor_todo()
+    assert_selected_monitor_handle(
+        [dependency, schedule_gap_monitor_todo()],
+        expected_todo_id="todo_pr_dependency_monitor",
+        expected_target_key="pr_merged:#532",
+        expected_text="Monitor PR #532",
+        expected_signal="external_dependency_wait",
+        status="active",
+        next_action=dependency_action,
+        lifecycle_flags=[],
+    )
+    assert_selected_monitor_handle(
+        [
+            monitor_todo(todo_id="todo_monitor_due", priority="P2"),
+            dependency,
+            schedule_gap_monitor_todo(index=4, priority="P3"),
+        ],
+        expected_todo_id="todo_monitor_due",
+        expected_target_key="job:compact-result",
+        expected_text="Monitor compact result",
+    )
 
 
 def assert_pr_dependency_wait_requires_first_observation() -> None:
@@ -461,7 +505,7 @@ def main() -> int:
     assert_recent_due_monitor_no_change_quiets_external_monitor()
     assert_advancement_lane_keeps_external_monitor_as_context()
     assert_future_scoped_monitor_does_not_fake_external_poll()
-    assert_schedule_gap_monitor_outranks_future_handle()
+    assert_monitor_handle_precedence()
     assert_pr_dependency_wait_requires_first_observation()
     assert_pr_dependency_wait_with_observation_does_not_reobserve_before_due()
     assert_explicit_external_wait_builds_registry_obligation()

--- a/examples/control_plane/external-evidence-observation-smoke.py
+++ b/examples/control_plane/external-evidence-observation-smoke.py
@@ -343,6 +343,7 @@ def assert_selected_monitor_handle(
     expected_target_key: str,
     expected_text: str,
     expected_signal: str | None = None,
+    expected_channel: str | None = None,
     **status_options: Any,
 ) -> None:
     summary = agent_todos(items)
@@ -357,6 +358,8 @@ def assert_selected_monitor_handle(
     assert signal and signal["monitor_handle"]["todo_id"] == expected_todo_id, signal
     if expected_signal:
         assert signal["matched_signal"] == expected_signal, signal
+    if expected_channel:
+        assert signal["matched_channel"] == expected_channel, signal
     guard = build_quota_should_run(payload, goal_id=GOAL_ID, agent_id=AGENT_ID)
     observation = guard["external_evidence_observation"]
     assert observation["monitor_handle"]["todo_id"] == expected_todo_id, guard
@@ -387,6 +390,7 @@ def assert_monitor_handle_precedence() -> None:
         expected_target_key="pr_merged:#532",
         expected_text="Monitor PR #532",
         expected_signal="external_dependency_wait",
+        expected_channel="state",
         status="active",
         next_action=dependency_action,
         lifecycle_flags=[],
@@ -400,6 +404,11 @@ def assert_monitor_handle_precedence() -> None:
         expected_todo_id="todo_monitor_due",
         expected_target_key="job:compact-result",
         expected_text="Monitor compact result",
+        expected_signal="direct_observe",
+        expected_channel="todo",
+        status="active",
+        next_action=dependency_action,
+        lifecycle_flags=[],
     )
 
 

--- a/loopx/control_plane/scheduler/external_evidence_observation.py
+++ b/loopx/control_plane/scheduler/external_evidence_observation.py
@@ -8,8 +8,10 @@ from ..todos.projection import (
     todo_summary_claim_scope_agent_id,
     todo_summary_has_only_future_scoped_monitor_work,
     todo_summary_monitor_due_count,
+    todo_summary_monitor_due_items,
     todo_summary_monitor_items,
     todo_summary_monitor_schedule_gap_count,
+    todo_summary_monitor_schedule_gap_items,
     todo_summary_open_count,
     todo_summary_open_task_counts,
 )
@@ -50,7 +52,12 @@ EXTERNAL_DEPENDENCY_TARGET_KEY_PATTERN = re.compile(
 
 
 def projected_monitor_handle(summary: dict[str, Any] | None) -> dict[str, Any] | None:
-    for item in todo_summary_monitor_items(summary):
+    actionable_items = [
+        *todo_summary_monitor_due_items(summary),
+        *todo_summary_monitor_schedule_gap_items(summary),
+    ]
+    monitor_items = actionable_items or todo_summary_monitor_items(summary)
+    for item in monitor_items:
         target_key = str(item.get("target_key") or "").strip()
         if not target_key:
             continue

--- a/loopx/control_plane/scheduler/external_evidence_observation.py
+++ b/loopx/control_plane/scheduler/external_evidence_observation.py
@@ -115,10 +115,29 @@ def scoped_monitor_watch_without_advancement(summary: dict[str, Any] | None) -> 
     return todo_summary_open_task_counts(summary).get("advancement", 0) <= 0
 
 
-def _external_dependency_monitor_needs_first_observation(
-    summary: dict[str, Any] | None,
+def _monitor_item_matches_handle(
+    item: dict[str, Any],
+    handle: dict[str, Any] | None,
 ) -> bool:
-    return bool(_external_dependency_monitors_needing_first_observation(summary))
+    if not isinstance(handle, dict):
+        return False
+    item_todo_id = normalize_todo_id(item.get("todo_id"))
+    handle_todo_id = normalize_todo_id(handle.get("todo_id"))
+    if item_todo_id and handle_todo_id:
+        return item_todo_id == handle_todo_id
+    item_target_key = str(item.get("target_key") or "").strip()
+    handle_target_key = str(handle.get("target_key") or "").strip()
+    return bool(item_target_key and item_target_key == handle_target_key)
+
+
+def _selected_monitor_needs_first_dependency_observation(
+    summary: dict[str, Any] | None,
+    handle: dict[str, Any] | None,
+) -> bool:
+    return any(
+        _monitor_item_matches_handle(item, handle)
+        for item in _external_dependency_monitors_needing_first_observation(summary)
+    )
 
 
 def _matches_any(patterns: tuple[re.Pattern[str], ...], texts: list[str]) -> bool:
@@ -130,11 +149,11 @@ def _monitor_window_allows_poll_signal(
     *,
     scoped_monitor_watch: bool,
     scoped_monitor_handle: dict[str, Any] | None,
-    dependency_monitor_pending: bool,
+    selected_dependency_monitor_pending: bool,
 ) -> bool:
     if (
         todo_summary_has_only_future_scoped_monitor_work(summary)
-        and not dependency_monitor_pending
+        and not selected_dependency_monitor_pending
     ):
         return False
     if scoped_monitor_watch and not scoped_monitor_handle:
@@ -143,7 +162,7 @@ def _monitor_window_allows_poll_signal(
         scoped_monitor_watch
         and todo_summary_monitor_due_count(summary) <= 0
         and todo_summary_monitor_schedule_gap_count(summary) <= 0
-        and not dependency_monitor_pending
+        and not selected_dependency_monitor_pending
     ):
         return False
     return True
@@ -165,8 +184,11 @@ def build_external_evidence_poll_signal(
 
     scoped_monitor_handle = projected_monitor_handle(agent_todo_summary)
     scoped_monitor_watch = scoped_monitor_watch_without_advancement(agent_todo_summary)
-    dependency_monitor_pending = _external_dependency_monitor_needs_first_observation(
-        agent_todo_summary
+    selected_dependency_monitor_pending = (
+        _selected_monitor_needs_first_dependency_observation(
+            agent_todo_summary,
+            scoped_monitor_handle,
+        )
     )
     project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
     action_texts = [
@@ -229,7 +251,7 @@ def build_external_evidence_poll_signal(
     if launched_wait:
         matched_signal = "launched_wait"
         matched_channel = "action"
-    elif dependency_monitor_pending:
+    elif selected_dependency_monitor_pending:
         matched_signal = "external_dependency_wait"
         matched_channel = "state"
     elif direct_observe:
@@ -247,7 +269,7 @@ def build_external_evidence_poll_signal(
         agent_todo_summary,
         scoped_monitor_watch=scoped_monitor_watch,
         scoped_monitor_handle=scoped_monitor_handle,
-        dependency_monitor_pending=dependency_monitor_pending,
+        selected_dependency_monitor_pending=selected_dependency_monitor_pending,
     ):
         return None
 

--- a/loopx/control_plane/scheduler/external_evidence_observation.py
+++ b/loopx/control_plane/scheduler/external_evidence_observation.py
@@ -51,9 +51,33 @@ EXTERNAL_DEPENDENCY_TARGET_KEY_PATTERN = re.compile(
 )
 
 
+def _monitor_item_has_observation_state(item: dict[str, Any]) -> bool:
+    if str(item.get("result_hash") or "").strip():
+        return True
+    if str(item.get("last_checked_at") or "").strip():
+        return True
+    return False
+
+
+def _external_dependency_monitors_needing_first_observation(
+    summary: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for item in todo_summary_monitor_items(summary):
+        target_key = str(item.get("target_key") or "").strip()
+        if not target_key:
+            continue
+        if not EXTERNAL_DEPENDENCY_TARGET_KEY_PATTERN.search(target_key):
+            continue
+        if not _monitor_item_has_observation_state(item):
+            items.append(item)
+    return items
+
+
 def projected_monitor_handle(summary: dict[str, Any] | None) -> dict[str, Any] | None:
     actionable_items = [
         *todo_summary_monitor_due_items(summary),
+        *_external_dependency_monitors_needing_first_observation(summary),
         *todo_summary_monitor_schedule_gap_items(summary),
     ]
     monitor_items = actionable_items or todo_summary_monitor_items(summary)
@@ -91,26 +115,10 @@ def scoped_monitor_watch_without_advancement(summary: dict[str, Any] | None) -> 
     return todo_summary_open_task_counts(summary).get("advancement", 0) <= 0
 
 
-def _monitor_item_has_observation_state(item: dict[str, Any]) -> bool:
-    if str(item.get("result_hash") or "").strip():
-        return True
-    if str(item.get("last_checked_at") or "").strip():
-        return True
-    return False
-
-
 def _external_dependency_monitor_needs_first_observation(
     summary: dict[str, Any] | None,
 ) -> bool:
-    for item in todo_summary_monitor_items(summary):
-        target_key = str(item.get("target_key") or "").strip()
-        if not target_key:
-            continue
-        if not EXTERNAL_DEPENDENCY_TARGET_KEY_PATTERN.search(target_key):
-            continue
-        if not _monitor_item_has_observation_state(item):
-            return True
-    return False
+    return bool(_external_dependency_monitors_needing_first_observation(summary))
 
 
 def _matches_any(patterns: tuple[re.Pattern[str], ...], texts: list[str]) -> bool:


### PR DESCRIPTION
## Summary

- prefer due monitor items, then schedule-gap monitor items, when projecting the external-evidence observation handle
- keep future scheduled monitors from becoming the primary action when a different monitor actually authorizes the poll
- cover the mixed future-monitor plus schedule-gap shape in the external-evidence smoke

## Validation

- `python3 examples/control_plane/external-evidence-observation-smoke.py`
- `python3 examples/control_plane/todo-projection-shared-helper-smoke.py`
- `python3 examples/execution-obligation-policy-smoke.py`
- `git diff --check`
- `python3 -m compileall -q ...`
- `loopx canary premerge --from-git-diff`: 17/17 selected checks passed, 0 warnings, 0 failures, 0 manual holds

## Boundaries

- changed surfaces: quota scheduler projection and focused public smoke
- no credentials, private state, raw benchmark evidence, local paths, or generated logs
- no benchmark jobs launched

## Review

Core quota/scheduler runtime change; hold for independent peer review before merge.