### PR TITLE
test(task-lease): split rules from CLI smoke

### DIFF
--- a/examples/control_plane/task-lease-runtime-smoke.py
+++ b/examples/control_plane/task-lease-runtime-smoke.py
@@ -15,9 +15,6 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
-from loopx.control_plane.work_items.task_lease import write_scopes_overlap  # noqa: E402
-
-
 GOAL_ID = "task-lease-runtime-goal"
 TODO_A = "todo_taskleasea"
 TODO_B = "todo_taskleaseb"
@@ -76,20 +73,6 @@ def write_fixture(root: Path) -> tuple[Path, Path]:
     return registry_path, state_file
 
 
-def set_excluded_agents(state_file: Path, *, todo_id: str, agents: list[str]) -> None:
-    lines = state_file.read_text(encoding="utf-8").splitlines()
-    for index, line in enumerate(lines):
-        if f"todo_id={todo_id}" not in line:
-            continue
-        line = re.sub(r"\s+excluded_agents=[^\s<>]+", "", line)
-        if agents:
-            line = line.replace(" -->", f" excluded_agents={','.join(agents)} -->")
-        lines[index] = line
-        state_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
-        return
-    raise AssertionError(f"todo metadata not found: {todo_id}")
-
-
 def set_claimed_by(state_file: Path, *, todo_id: str, owner: str | None) -> None:
     lines = state_file.read_text(encoding="utf-8").splitlines()
     for index, line in enumerate(lines):
@@ -99,17 +82,6 @@ def set_claimed_by(state_file: Path, *, todo_id: str, owner: str | None) -> None
         if owner:
             line = line.replace(" -->", f" claimed_by={owner} -->")
         lines[index] = line
-        state_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
-        return
-    raise AssertionError(f"todo metadata not found: {todo_id}")
-
-
-def set_todo_status(state_file: Path, *, todo_id: str, status: str) -> None:
-    lines = state_file.read_text(encoding="utf-8").splitlines()
-    for index, line in enumerate(lines):
-        if f"todo_id={todo_id}" not in line:
-            continue
-        lines[index] = re.sub(r"\bstatus=[^\s<>]+", f"status={status}", line)
         state_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
         return
     raise AssertionError(f"todo metadata not found: {todo_id}")
@@ -139,38 +111,7 @@ def payload(result: subprocess.CompletedProcess[str]) -> dict[str, Any]:
     return json.loads(result.stdout)
 
 
-def quota_should_run(registry_path: Path, *, agent_id: str) -> dict[str, Any]:
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "loopx.cli",
-            "--registry",
-            str(registry_path),
-            "--format",
-            "json",
-            "quota",
-            "should-run",
-            "--goal-id",
-            GOAL_ID,
-            "--agent-id",
-            agent_id,
-        ],
-        cwd=REPO_ROOT,
-        check=False,
-        text=True,
-        capture_output=True,
-    )
-    assert result.stdout, result.stderr
-    return json.loads(result.stdout)
-
-
 def main() -> int:
-    assert write_scopes_overlap(["docs/**"], ["docs/a.md"])
-    assert write_scopes_overlap(["docs/sub/**"], ["docs/sub/a.md"])
-    assert write_scopes_overlap(["docs/a*.md"], ["docs/ab.md"])
-    assert not write_scopes_overlap(["docs/a.md"], ["docs/b.md"])
-
     with tempfile.TemporaryDirectory(prefix="loopx-task-lease-smoke-") as tmp:
         registry_path, state_file = write_fixture(Path(tmp))
 
@@ -202,112 +143,6 @@ def main() -> int:
         assert first["lease"]["version"] == 1, first
         assert first["lease"]["acquire_ttl_seconds"] == 120, first
 
-        set_claimed_by(
-            state_file,
-            todo_id=TODO_A,
-            owner="codex-side-bypass",
-        )
-        claim_conflict_inspect = payload(
-            cli(registry_path, "inspect", "--goal-id", GOAL_ID, "--todo-id", TODO_A)
-        )
-        assert claim_conflict_inspect["active"] is False, claim_conflict_inspect
-        assert claim_conflict_inspect["executor_constraint"]["reason"] == (
-            "owner_conflicts_with_claim"
-        ), claim_conflict_inspect
-        assert claim_conflict_inspect["executor_constraint"]["claimed_by"] == (
-            "codex-side-bypass"
-        ), claim_conflict_inspect
-        set_claimed_by(
-            state_file,
-            todo_id=TODO_A,
-            owner="codex-main-control",
-        )
-
-        set_todo_status(state_file, todo_id=TODO_A, status="done")
-        terminal_inspect = payload(
-            cli(registry_path, "inspect", "--goal-id", GOAL_ID, "--todo-id", TODO_A)
-        )
-        assert terminal_inspect["active"] is False, terminal_inspect
-        assert terminal_inspect["executor_constraint"]["reason"] == "todo_not_open", (
-            terminal_inspect
-        )
-        terminal_renew = cli(
-            registry_path,
-            "renew",
-            "--goal-id",
-            GOAL_ID,
-            "--todo-id",
-            TODO_A,
-            "--owner",
-            "codex-main-control",
-            "--idempotency-key",
-            "turn-1",
-            check=False,
-        )
-        assert terminal_renew.returncode == 1, terminal_renew.stdout
-        assert payload(terminal_renew)["error_code"] == "todo_not_open", terminal_renew.stdout
-        set_todo_status(state_file, todo_id=TODO_A, status="open")
-
-        set_todo_status(state_file, todo_id=TODO_C, status="deferred")
-        terminal_acquire = cli(
-            registry_path,
-            "acquire",
-            "--goal-id",
-            GOAL_ID,
-            "--todo-id",
-            TODO_C,
-            "--owner",
-            "codex-side-bypass",
-            "--idempotency-key",
-            "deferred-acquire",
-            check=False,
-        )
-        assert terminal_acquire.returncode == 1, terminal_acquire.stdout
-        assert payload(terminal_acquire)["error_code"] == "todo_not_open", terminal_acquire.stdout
-        set_todo_status(state_file, todo_id=TODO_C, status="open")
-
-        unregistered_acquire = cli(
-            registry_path,
-            "acquire",
-            "--goal-id",
-            GOAL_ID,
-            "--todo-id",
-            TODO_C,
-            "--owner",
-            "codex-unregistered-peer",
-            "--idempotency-key",
-            "unregistered-acquire",
-            "--write-scope",
-            "scripts/**",
-            check=False,
-        )
-        assert unregistered_acquire.returncode == 1, unregistered_acquire.stdout
-        assert payload(unregistered_acquire)["error_code"] == "owner_not_registered", (
-            unregistered_acquire.stdout
-        )
-
-        legacy_unregistered_path = Path(first["lease_path"]).with_name(f"{TODO_C}.json")
-        legacy_unregistered_path.write_text(
-            json.dumps(
-                {
-                    **first["lease"],
-                    "todo_id": TODO_C,
-                    "owner": "codex-unregistered-peer",
-                    "write_scopes": ["scripts/**"],
-                }
-            )
-            + "\n",
-            encoding="utf-8",
-        )
-        legacy_inspect = payload(
-            cli(registry_path, "inspect", "--goal-id", GOAL_ID, "--todo-id", TODO_C)
-        )
-        assert legacy_inspect["active"] is False, legacy_inspect
-        assert legacy_inspect["executor_constraint"]["reason"] == "owner_not_registered", (
-            legacy_inspect
-        )
-        legacy_unregistered_path.unlink()
-
         idempotent = payload(
             cli(
                 registry_path,
@@ -329,53 +164,6 @@ def main() -> int:
         assert idempotent["ok"] is True and idempotent["idempotent"] is True, idempotent
         assert idempotent["lease"]["version"] == 1, idempotent
 
-        for retry_ttl, retry_scope in ((120, "docs/**"), (600, "loopx/**")):
-            changed_retry = cli(
-                registry_path,
-                "acquire",
-                "--goal-id",
-                GOAL_ID,
-                "--todo-id",
-                TODO_A,
-                "--owner",
-                "codex-main-control",
-                "--idempotency-key",
-                "turn-1",
-                "--ttl-seconds",
-                str(retry_ttl),
-                "--write-scope",
-                retry_scope,
-                check=False,
-            )
-            assert changed_retry.returncode == 1, changed_retry.stdout
-            assert payload(changed_retry)["error_code"] == "idempotency_key_reuse", (
-                changed_retry.stdout
-            )
-
-        set_excluded_agents(
-            state_file,
-            todo_id=TODO_B,
-            agents=["codex-side-bypass"],
-        )
-        blocked_acquire = cli(
-            registry_path,
-            "acquire",
-            "--goal-id",
-            GOAL_ID,
-            "--todo-id",
-            TODO_B,
-            "--owner",
-            "codex-side-bypass",
-            "--idempotency-key",
-            "side-blocked",
-            check=False,
-        )
-        assert blocked_acquire.returncode == 1, blocked_acquire.stdout
-        assert payload(blocked_acquire)["error_code"] == "owner_excluded_from_todo", (
-            blocked_acquire.stdout
-        )
-
-        set_excluded_agents(state_file, todo_id=TODO_B, agents=[])
         same_goal_different_scope = payload(
             cli(
                 registry_path,
@@ -418,24 +206,6 @@ def main() -> int:
         assert conflict_payload["error_code"] == "write_scope_conflict", conflict_payload
         assert conflict_payload["conflicts"][0]["todo_id"] == TODO_A, conflict_payload
 
-        mismatch = cli(
-            registry_path,
-            "renew",
-            "--goal-id",
-            GOAL_ID,
-            "--todo-id",
-            TODO_A,
-            "--owner",
-            "codex-main-control",
-            "--idempotency-key",
-            "turn-1",
-            "--expected-version",
-            "99",
-            check=False,
-        )
-        assert mismatch.returncode == 1, mismatch.stdout
-        assert payload(mismatch)["error_code"] == "version_mismatch", mismatch.stdout
-
         renewed = payload(
             cli(
                 registry_path,
@@ -454,60 +224,6 @@ def main() -> int:
         )
         assert renewed["ok"] is True and renewed["lease"]["version"] == 2, renewed
 
-        set_excluded_agents(
-            state_file,
-            todo_id=TODO_A,
-            agents=["codex-side-bypass"],
-        )
-        blocked_transfer = cli(
-            registry_path,
-            "transfer",
-            "--goal-id",
-            GOAL_ID,
-            "--todo-id",
-            TODO_A,
-            "--owner",
-            "codex-main-control",
-            "--idempotency-key",
-            "turn-1",
-            "--new-owner",
-            "codex-side-bypass",
-            "--new-idempotency-key",
-            "side-transfer",
-            "--expected-version",
-            "2",
-            check=False,
-        )
-        assert blocked_transfer.returncode == 1, blocked_transfer.stdout
-        assert payload(blocked_transfer)["error_code"] == "owner_excluded_from_todo", (
-            blocked_transfer.stdout
-        )
-
-        unregistered_transfer = cli(
-            registry_path,
-            "transfer",
-            "--goal-id",
-            GOAL_ID,
-            "--todo-id",
-            TODO_A,
-            "--owner",
-            "codex-main-control",
-            "--idempotency-key",
-            "turn-1",
-            "--new-owner",
-            "codex-unregistered-peer",
-            "--new-idempotency-key",
-            "unregistered-transfer",
-            "--expected-version",
-            "2",
-            check=False,
-        )
-        assert unregistered_transfer.returncode == 1, unregistered_transfer.stdout
-        assert payload(unregistered_transfer)["error_code"] == "owner_not_registered", (
-            unregistered_transfer.stdout
-        )
-
-        set_excluded_agents(state_file, todo_id=TODO_A, agents=[])
         claim_blocked_transfer = cli(
             registry_path,
             "transfer",
@@ -555,60 +271,6 @@ def main() -> int:
         assert transferred["lease"]["owner"] == "codex-side-bypass", transferred
         assert transferred["lease"]["version"] == 3, transferred
 
-        set_excluded_agents(
-            state_file,
-            todo_id=TODO_A,
-            agents=["codex-side-bypass"],
-        )
-        inspected = payload(cli(registry_path, "inspect", "--goal-id", GOAL_ID, "--todo-id", TODO_A))
-        assert inspected["active"] is False and inspected["lease"]["version"] == 3, inspected
-        assert inspected["executor_constraint"]["reason"] == "owner_excluded_from_todo", inspected
-
-        blocked_renew = cli(
-            registry_path,
-            "renew",
-            "--goal-id",
-            GOAL_ID,
-            "--todo-id",
-            TODO_A,
-            "--owner",
-            "codex-side-bypass",
-            "--idempotency-key",
-            "side-transfer",
-            "--expected-version",
-            "3",
-            check=False,
-        )
-        assert blocked_renew.returncode == 1, blocked_renew.stdout
-        assert payload(blocked_renew)["error_code"] == "owner_excluded_from_todo", (
-            blocked_renew.stdout
-        )
-
-        quota = quota_should_run(registry_path, agent_id="codex-side-bypass")
-        assert (quota.get("selected_todo") or {}).get("todo_id") != TODO_A, quota
-
-        reacquired = payload(
-            cli(
-                registry_path,
-                "acquire",
-                "--goal-id",
-                GOAL_ID,
-                "--todo-id",
-                TODO_A,
-                "--owner",
-                "codex-main-control",
-                "--idempotency-key",
-                "main-takeover",
-                "--expected-version",
-                "3",
-                "--write-scope",
-                "loopx/**",
-            )
-        )
-        assert reacquired["acquired"] is True, reacquired
-        assert reacquired["lease"]["owner"] == "codex-main-control", reacquired
-        assert reacquired["lease"]["version"] == 4, reacquired
-
         released = payload(
             cli(
                 registry_path,
@@ -618,11 +280,11 @@ def main() -> int:
                 "--todo-id",
                 TODO_A,
                 "--owner",
-                "codex-main-control",
+                "codex-side-bypass",
                 "--idempotency-key",
-                "main-takeover",
+                "side-transfer",
                 "--expected-version",
-                "4",
+                "3",
             )
         )
         assert released["released"] is True, released

--- a/tests/control_plane/test_task_lease.py
+++ b/tests/control_plane/test_task_lease.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from loopx.control_plane.work_items import task_lease
+from loopx.control_plane.work_items.task_lease import (
+    MAX_TASK_LEASE_TTL_SECONDS,
+    TaskLeaseError,
+    acquire_task_lease,
+    assert_expected_version,
+    normalize_idempotency_key,
+    normalize_ttl_seconds,
+    release_task_lease,
+    renew_task_lease,
+    task_lease_owner_constraint,
+    transfer_task_lease,
+    write_scopes_overlap,
+)
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "expected"),
+    [
+        (["docs/**"], ["docs/a.md"], True),
+        (["docs/sub/**"], ["docs/sub/a.md"], True),
+        (["docs/a*.md"], ["docs/ab.md"], True),
+        (["docs/**"], ["docs/sub/**"], True),
+        (["**"], ["loopx/cli.py"], True),
+        (["docs/a.md"], ["docs/b.md"], False),
+        ([], ["docs/a.md"], False),
+    ],
+)
+def test_write_scopes_overlap(
+    left: list[str],
+    right: list[str],
+    expected: bool,
+) -> None:
+    assert write_scopes_overlap(left, right) is expected
+
+
+@pytest.mark.parametrize(
+    ("todo", "owner", "registered_agents", "reason"),
+    [
+        (None, "agent-a", ["agent-a"], "todo_not_found"),
+        ({"status": "done"}, "agent-a", ["agent-a"], "todo_not_open"),
+        ({"status": "open"}, "", ["agent-a"], "invalid_owner"),
+        ({"status": "open"}, "agent-b", ["agent-a"], "owner_not_registered"),
+        (
+            {"status": "open", "excluded_agents": ["agent-a"]},
+            "agent-a",
+            ["agent-a"],
+            "owner_excluded_from_todo",
+        ),
+        (
+            {"status": "open", "claimed_by": "agent-b"},
+            "agent-a",
+            ["agent-a", "agent-b"],
+            "owner_conflicts_with_claim",
+        ),
+    ],
+)
+def test_task_lease_owner_constraint_rejects_ineligible_owner(
+    todo: dict[str, Any] | None,
+    owner: str,
+    registered_agents: list[str],
+    reason: str,
+) -> None:
+    constraint = task_lease_owner_constraint(
+        todo,
+        owner=owner,
+        registered_agents=registered_agents,
+    )
+
+    assert constraint["effective"] is False
+    assert constraint["reason"] == reason
+
+
+def test_task_lease_owner_constraint_accepts_matching_claim() -> None:
+    constraint = task_lease_owner_constraint(
+        {
+            "status": "open",
+            "claimed_by": "agent-a",
+            "excluded_agents": ["agent-b"],
+        },
+        owner="agent-a",
+        registered_agents=["agent-a", "agent-b"],
+    )
+
+    assert constraint == {"effective": True}
+
+
+@pytest.mark.parametrize("ttl", [0, -1, MAX_TASK_LEASE_TTL_SECONDS + 1])
+def test_normalize_ttl_seconds_rejects_out_of_range(ttl: int) -> None:
+    with pytest.raises(TaskLeaseError, match="ttl seconds") as error:
+        normalize_ttl_seconds(ttl)
+
+    assert error.value.code == "invalid_ttl"
+
+
+@pytest.mark.parametrize("key", ["", "contains space", "bad$key"])
+def test_normalize_idempotency_key_rejects_non_token(key: str) -> None:
+    with pytest.raises(TaskLeaseError) as error:
+        normalize_idempotency_key(key)
+
+    assert error.value.code == "invalid_idempotency_key"
+
+
+def test_expected_version_is_compare_and_swap_guard() -> None:
+    with pytest.raises(TaskLeaseError) as error:
+        assert_expected_version({"version": 3}, 2)
+
+    assert error.value.code == "version_mismatch"
+    assert error.value.payload == {"expected_version": 2, "actual_version": 3}
+
+
+def test_task_lease_lifecycle_preserves_idempotency_and_versions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime(2026, 7, 13, tzinfo=timezone.utc)
+    monkeypatch.setattr(task_lease, "now_utc", lambda: now)
+    monkeypatch.setattr(task_lease, "require_task_lease_owner_allowed", lambda **_: {})
+    monkeypatch.setattr(
+        task_lease,
+        "require_registered_task_lease_owner",
+        lambda **kwargs: kwargs["owner"],
+    )
+    monkeypatch.setattr(
+        task_lease,
+        "task_lease_owner_constraint",
+        lambda *_args, **_kwargs: {"effective": True},
+    )
+    monkeypatch.setattr(task_lease, "active_conflicts", lambda **_: [])
+    registry_path = tmp_path / "registry.json"
+    runtime_root = tmp_path / "runtime"
+    arguments = {
+        "registry_path": registry_path,
+        "runtime_root": runtime_root,
+        "goal_id": "goal-a",
+        "todo_id": "todo_leasea",
+        "owner": "agent-a",
+        "idempotency_key": "turn-1",
+        "ttl_seconds": 120,
+        "write_scopes": ["loopx/**"],
+    }
+
+    acquired = acquire_task_lease(**arguments)
+    assert acquired["acquired"] is True
+    assert acquired["lease"]["version"] == 1
+    assert acquired["lease"]["expires_at"] == (
+        now + timedelta(seconds=120)
+    ).isoformat().replace("+00:00", "Z")
+
+    repeated = acquire_task_lease(**arguments)
+    assert repeated["idempotent"] is True
+    assert repeated["lease"]["version"] == 1
+
+    with pytest.raises(TaskLeaseError) as reuse_error:
+        acquire_task_lease(**{**arguments, "ttl_seconds": 600})
+    assert reuse_error.value.code == "idempotency_key_reuse"
+
+    renewed = renew_task_lease(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        goal_id="goal-a",
+        todo_id="todo_leasea",
+        owner="agent-a",
+        idempotency_key="turn-1",
+        expected_version=1,
+    )
+    assert renewed["lease"]["version"] == 2
+
+    transferred = transfer_task_lease(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        goal_id="goal-a",
+        todo_id="todo_leasea",
+        owner="agent-a",
+        idempotency_key="turn-1",
+        new_owner="agent-b",
+        new_idempotency_key="turn-2",
+        expected_version=2,
+    )
+    assert transferred["lease"]["owner"] == "agent-b"
+    assert transferred["lease"]["version"] == 3
+
+    released = release_task_lease(
+        runtime_root=runtime_root,
+        goal_id="goal-a",
+        todo_id="todo_leasea",
+        owner="agent-b",
+        idempotency_key="turn-2",
+        expected_version=3,
+    )
+    assert released["released"] is True


### PR DESCRIPTION
## Summary
- move task-lease scope, owner eligibility, normalization, CAS, idempotency, and lifecycle rules into focused pytest coverage
- keep a thin CLI smoke for acquire, inspect, disjoint/concurrent scopes, conflict, renew, claim-aware transfer, and release
- reduce the durable integration smoke from 636 to 298 lines without changing runtime behavior

## Validation
- `uv run pytest -q` (`256 passed, 2 skipped`)
- `uv run python examples/control_plane/task-lease-runtime-smoke.py`
- `uv run python examples/control_plane/todo-claim-lease-roadmap-smoke.py`
- `uv run ruff check tests/control_plane/test_task_lease.py examples/control_plane/task-lease-runtime-smoke.py`
- `uv run loopx canary premerge --from-git-diff` (standard tier, 6 selected checks passed, no manual holds)

## Boundary and risk
- test-only cleanup; no task-lease runtime, quota gate, scheduler, permission, or persisted-state behavior changes
- excludes generated `uv.lock`, local state, credentials, private links, raw logs, trajectories, and verifier output
- residual risk is limited to whether the thinner CLI smoke omits an incidental cross-command assertion; the moved rule tests and full suite cover the retained contracts