### PR TITLE
fix(quota): preserve completion across neutral refresh

### DIFF
--- a/loopx/control_plane/quota/slot_accounting.py
+++ b/loopx/control_plane/quota/slot_accounting.py
@@ -114,9 +114,11 @@ def _latest_unspent_accountable_delivery_run(
 ) -> dict[str, Any] | None:
     """Return the latest same-agent delivery that still needs accounting.
 
-    Unchanged monitor polls and scheduler acknowledgements are quota-neutral.
-    They may occur after validation and before accounting, so they must not
-    hide the accountable run. Other non-delivery events remain fail closed.
+    Unchanged monitor polls, scheduler acknowledgements, and plain state
+    refreshes are quota-neutral. They may occur after validation and before
+    accounting, so they must not hide the accountable run. A state refresh
+    with an explicit non-accountable delivery outcome and other non-delivery
+    events remain fail closed.
     """
 
     safe_agent_id = normalize_todo_claimed_by(agent_id)
@@ -135,6 +137,10 @@ def _latest_unspent_accountable_delivery_run(
         ):
             continue
         if classification == QUOTA_SCHEDULER_ACK_CLASSIFICATION:
+            continue
+        if classification == "state_refreshed" and not str(
+            run.get("delivery_outcome") or ""
+        ).strip():
             continue
         delivery_outcome = normalize_delivery_outcome(run.get("delivery_outcome"))
         if delivery_outcome in ACCOUNTABLE_DELIVERY_OUTCOMES:

--- a/tests/control_plane/test_quota_slot_accounting.py
+++ b/tests/control_plane/test_quota_slot_accounting.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from loopx.control_plane.quota.slot_accounting import (
     build_quota_slot_preview_for_decision,
     build_quota_slot_spend_event,
@@ -90,6 +92,25 @@ def _spent(generated_at: str, *, agent_id: str | None = None) -> dict[str, Any]:
     return payload
 
 
+def _run(
+    generated_at: str,
+    *,
+    classification: str,
+    agent_id: str | None = None,
+    delivery_outcome: str | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "generated_at": generated_at,
+        "goal_id": GOAL_ID,
+        "classification": classification,
+    }
+    if agent_id:
+        payload["agent_id"] = agent_id
+    if delivery_outcome:
+        payload["delivery_outcome"] = delivery_outcome
+    return payload
+
+
 def test_unchanged_monitor_poll_is_not_accountable_delivery(tmp_path: Path) -> None:
     runtime = tmp_path / "runtime"
     _write_run_index(runtime, [_poll("2026-01-01T00:00:00+00:00", material=False)])
@@ -157,6 +178,109 @@ def test_interleaved_peer_spend_does_not_hide_scoped_delivery(tmp_path: Path) ->
     assert scoped_a["delivery_run_agent_id"] == AGENT_A
     assert _preview(runtime, agent_id=AGENT_B)["ok"] is False
     assert _preview(runtime)["ok"] is False
+
+
+@pytest.mark.parametrize(
+    "neutral_classification",
+    ["state_refreshed", "quota_scheduler_ack"],
+)
+def test_same_agent_neutral_event_does_not_hide_scoped_delivery(
+    tmp_path: Path,
+    neutral_classification: str,
+) -> None:
+    runtime = tmp_path / "runtime"
+    material_poll = _poll(
+        "2026-01-01T00:01:00+00:00",
+        material=True,
+        agent_id=AGENT_A,
+    )
+    _write_run_index(
+        runtime,
+        [
+            material_poll,
+            _run(
+                "2026-01-01T00:02:00+00:00",
+                classification=neutral_classification,
+                agent_id=AGENT_A,
+            ),
+        ],
+    )
+
+    preview = _preview(runtime, agent_id=AGENT_A)
+
+    assert preview["ok"] is True
+    assert preview["delivery_run_generated_at"] == material_poll["generated_at"]
+    assert preview["delivery_run_classification"] == "quota_monitor_poll"
+
+
+def test_explicit_non_accountable_refresh_still_fails_closed(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    _write_run_index(
+        runtime,
+        [
+            _poll(
+                "2026-01-01T00:01:00+00:00",
+                material=True,
+                agent_id=AGENT_A,
+            ),
+            _run(
+                "2026-01-01T00:02:00+00:00",
+                classification="state_refreshed",
+                agent_id=AGENT_A,
+                delivery_outcome="surface_only",
+            ),
+        ],
+    )
+
+    assert _preview(runtime, agent_id=AGENT_A)["ok"] is False
+
+
+def test_accountable_refresh_becomes_latest_delivery(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    accountable_refresh = _run(
+        "2026-01-01T00:02:00+00:00",
+        classification="state_refreshed",
+        agent_id=AGENT_A,
+        delivery_outcome="outcome_progress",
+    )
+    _write_run_index(
+        runtime,
+        [
+            _poll(
+                "2026-01-01T00:01:00+00:00",
+                material=True,
+                agent_id=AGENT_A,
+            ),
+            accountable_refresh,
+        ],
+    )
+
+    preview = _preview(runtime, agent_id=AGENT_A)
+
+    assert preview["ok"] is True
+    assert preview["delivery_run_generated_at"] == accountable_refresh["generated_at"]
+    assert preview["delivery_run_classification"] == "state_refreshed"
+
+
+def test_other_same_agent_non_delivery_event_still_fails_closed(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    _write_run_index(
+        runtime,
+        [
+            _poll(
+                "2026-01-01T00:01:00+00:00",
+                material=True,
+                agent_id=AGENT_A,
+            ),
+            _run(
+                "2026-01-01T00:02:00+00:00",
+                classification="operator_note",
+                agent_id=AGENT_A,
+            ),
+        ],
+    )
+
+    assert _preview(runtime, agent_id=AGENT_A)["ok"] is False
 
 
 def test_legacy_unscoped_delivery_remains_attributable(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- keep the latest same-agent accountable delivery discoverable when a plain `state_refreshed` event is appended before `quota spend-slot`
- treat only refreshes with no declared `delivery_outcome` as quota-neutral
- retain fail-closed behavior for explicit `surface_only`/other non-delivery events and let accountable refreshes replace the older delivery

## Validation
- `uv run pytest -q tests/control_plane/test_quota_slot_accounting.py` (`11 passed`)
- `uv run pytest -q` (`261 passed, 2 skipped`)
- `uv run ruff check loopx/control_plane/quota/slot_accounting.py tests/control_plane/test_quota_slot_accounting.py`
- `uv run loopx canary premerge --from-git-diff` (standard tier; 12 selected checks passed; no manual holds)

## Boundary and risk
- changes only the post-delivery quota attribution lookup; quota eligibility, slot arithmetic, todo routing, scheduler behavior, and persisted event schemas are unchanged
- an explicit non-accountable outcome remains a causal stop, so this does not spend through failed or surface-only delivery attempts
- generated `uv.lock`, local state, credentials, private links, raw logs, trajectories, and verifier output are excluded