### PR TITLE
fix(quota): preserve monitor poll capabilities

### DIFF
--- a/examples/control_plane/monitor-poll-writeback-smoke.py
+++ b/examples/control_plane/monitor-poll-writeback-smoke.py
@@ -114,6 +114,7 @@ def write_fixture(
         "todo_id=todo_monitorpolladvance "
         "status=open "
         "task_class=advancement_task "
+        "required_capabilities=network "
         f"claimed_by={AGENT_ID} "
         "-->\n"
         if include_advancement
@@ -529,6 +530,8 @@ def assert_compacted_auxiliary_due_monitor_can_write_back() -> None:
             GOAL_ID,
             "--agent-id",
             AGENT_ID,
+            "--available-capability",
+            "network",
         )
         assert quota["work_lane_contract"]["obligation"] == "advance_one_bounded_segment", quota
         assert quota["agent_todo_summary"]["monitor_due_count"] == 2, quota
@@ -544,6 +547,8 @@ def assert_compacted_auxiliary_due_monitor_can_write_back() -> None:
             GOAL_ID,
             "--agent-id",
             AGENT_ID,
+            "--available-capability",
+            "network",
             "--todo-id",
             "todo_monitorpoll111",
             "--target-key",
@@ -554,6 +559,8 @@ def assert_compacted_auxiliary_due_monitor_can_write_back() -> None:
         )
         assert payload["ok"] is True, payload
         assert payload["todo_writeback"]["todo_id"] == "todo_monitorpoll111", payload
+        assert "network" in payload["before"]["capability_gate"]["available"], payload
+        assert "network" in payload["after"]["capability_gate"]["available"], payload
         other = find_todo(state_file, "todo_monitorpoll111")
         assert other["consecutive_no_change"] == "2", other
         assert other["next_due_at"] != "2026-01-01T00:00:00+00:00", other
@@ -610,7 +617,7 @@ def assert_cli_monitor_poll_uses_should_run_lookback() -> None:
         quota_command="monitor-poll",
         goal_id=GOAL_ID,
         agent_id=AGENT_ID,
-        available_capabilities=None,
+        available_capabilities=["network"],
         include_scheduler_detail=False,
         slots=1,
         source="heartbeat",
@@ -655,6 +662,7 @@ def assert_cli_monitor_poll_uses_should_run_lookback() -> None:
 
     assert rc == 0, rc
     assert seen["limit"] == AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, seen
+    assert seen["record_kwargs"]["available_capabilities"] == ["network"], seen
     assert seen["payload"] == {"ok": True, "mode": "monitor-poll", "dry_run": True, "appended": False}, seen
 
 

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -236,6 +236,7 @@ def handle_quota_command(
                 source=args.source,
                 reason_summary=args.reason_summary,
                 agent_id=args.agent_id,
+                available_capabilities=args.available_capabilities,
                 todo_id=args.todo_id,
                 target_key=args.target_key,
                 result_hash=args.result_hash,

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -2327,6 +2327,7 @@ def record_quota_monitor_poll(
     source: str = DEFAULT_SLOT_SPEND_SOURCE,
     reason_summary: str | None = None,
     agent_id: str | None = None,
+    available_capabilities: Any = None,
     todo_id: str | None = None,
     target_key: str | None = None,
     result_hash: str | None = None,
@@ -2338,7 +2339,12 @@ def record_quota_monitor_poll(
     next_claimed_by: str | None = None,
 ) -> dict[str, Any]:
     safe_goal_id = _validate_goal_id_path_segment(str(goal_id or ""))
-    before = build_quota_should_run(status_payload, goal_id=safe_goal_id, agent_id=agent_id)
+    before = build_quota_should_run(
+        status_payload,
+        goal_id=safe_goal_id,
+        agent_id=agent_id,
+        available_capabilities=available_capabilities,
+    )
     return record_quota_monitor_poll_for_decision(
         before,
         status_payload,
@@ -2347,6 +2353,7 @@ def record_quota_monitor_poll(
             after_status,
             goal_id=safe_goal_id,
             agent_id=agent_id,
+            available_capabilities=available_capabilities,
         ),
         registry_path=registry_path,
         execute=execute,


### PR DESCRIPTION
## 动机

`quota monitor-poll` 的 CLI 已接受 `--available-capability`，但调用运行层时没有继续传递。monitor 完成真实网络读取后，内部 before/after `should-run` 会把 `network` 误判为缺失，并错误投影用户授权 gate。

## 改动

- CLI 将运行时 capability 列表传给 `record_quota_monitor_poll`。
- monitor-poll 的 before/after 两次 `build_quota_should_run` 使用同一份 capability 列表。
- 扩展真实 monitor writeback smoke，覆盖 CLI 透传以及 before/after 都保留 `network`。

## 关键路径

```text
quota monitor-poll --available-capability network
  -> record_quota_monitor_poll(available_capabilities)
  -> before = build_quota_should_run(..., available_capabilities)
  -> monitor writeback
  -> after = build_quota_should_run(..., available_capabilities)
```

## 验证

- `python3 examples/control_plane/monitor-poll-writeback-smoke.py`
- `python3 -m py_compile`（3 个变更文件）
- `ruff check --ignore F401`（仓库主线已有未使用兼容导入，因此忽略既有 F401）
- `loopx canary premerge --from-git-diff --tier standard`：17/17 通过
- public/private boundary：3 个文件，0 命中
- `git diff --check`

## 风险

改动只补齐已有 CLI 参数的传递，不改变 capability 解析、monitor cadence、quota spend 或 todo writeback 语义。未提供参数时仍保持原行为。