### PR TITLE
docs: publish update note for 2026-06-28 to 2026-07-11

### DIFF
--- a/docs/update-notes/2026-06-28-to-2026-07-11.md
+++ b/docs/update-notes/2026-06-28-to-2026-07-11.md
@@ -1,0 +1,155 @@
+# Biweekly Update Note: 2026-06-28 to 2026-07-11
+
+## Source Boundary
+
+This note summarizes public repository history from 2026-06-28 through
+2026-07-11. It uses public commits, pull requests, releases, shipped docs,
+examples, and smoke tests. It excludes private operator state, raw benchmark
+evidence, private links, local paths, and credentials.
+
+## Highlights
+
+- Released [LoopX v0.2.0](https://github.com/huangruiteng/loopx/releases/tag/v0.2.0),
+  completing the peer-agent runtime cutover and defining claims as soft
+  routing and writeback signals rather than runtime authority.
+- Extended issue-fix from patch generation into a maintainer loop with
+  repository context, feasibility, CI and acceptance evidence, reviewer
+  routing, PR lifecycle observation, and durable outcome writeback.
+- Made Explore and Explore Harness more useful for real long-running work:
+  resumable experiments, focused graph exports, independent lanes, semantic
+  topic affinity, and resource-aware portfolio planning.
+- Turned Auto Research into a visible evidence loop over a real workspace,
+  with role-based rounds, automatic wakeups, summarized evidence writeback,
+  and explicit promotion or continuation frontiers.
+- Reduced control-plane ambiguity through typed todo continuations, peer
+  routing, compact quota payloads, selected-todo projection, and more reliable
+  monitor, vision, and quota-spend transitions.
+
+## What Shipped
+
+### LoopX v0.2: Peer Agents, Not Runtime Hierarchies
+
+[v0.2.0](https://github.com/huangruiteng/loopx/releases/tag/v0.2.0) made the
+peer-agent model the public control-plane contract. A claim now answers who is
+expected to take the next step and write back the result; quota, gates,
+capabilities, exclusions, and write scope still decide whether execution is
+allowed. The release also replaced special reviewer-lane assumptions with
+typed continuation and independent-handoff contracts.
+
+Representative changes:
+
+- [#1787](https://github.com/huangruiteng/loopx/pull/1787) cut the runtime over
+  to peer agents.
+- [#1773](https://github.com/huangruiteng/loopx/pull/1773) added typed todo
+  continuation policies.
+- [#1867](https://github.com/huangruiteng/loopx/pull/1867) preserved due-monitor
+  routing across peer reassignment.
+- [#1852](https://github.com/huangruiteng/loopx/pull/1852) validated and shipped
+  the v0.2.0 release.
+
+### Issue-Fix Became a Maintainer Loop
+
+The issue-fix path now carries work beyond the first code change. It can bring
+repository context into planning, capture first-push CI and acceptance
+evidence, route a reviewer request with fallback, observe merge state, and
+write the outcome back into the domain lifecycle. Repository memory was also
+narrowed toward decision-useful context rather than undifferentiated history.
+
+Representative changes:
+
+- [#1780](https://github.com/huangruiteng/loopx/pull/1780) added caller-repository
+  context to issue-fix workflows.
+- [#1835](https://github.com/huangruiteng/loopx/pull/1835) added an optional
+  OpenViking context provider without making it a control-plane dependency.
+- [#1865](https://github.com/huangruiteng/loopx/pull/1865) improved reviewer
+  context, while [#1876](https://github.com/huangruiteng/loopx/pull/1876)
+  captured first-push CI evidence.
+- [#1883](https://github.com/huangruiteng/loopx/pull/1883) projected merged-PR
+  events so dependent work can resume.
+- [#1887](https://github.com/huangruiteng/loopx/pull/1887) made repository
+  memory decision-useful for issue fixing.
+
+### Explore and Auto Research Became Resumable
+
+Explore gained graph projections that preserve real topology while supporting
+focused owner views. Independent experiment lanes and semantic topic affinity
+survive projection, and portfolio planning can account for limited resources
+instead of ranking every branch as if capacity were unlimited. Explore Harness
+also became configurable and resumable rather than a one-shot experiment.
+
+Auto Research moved from a scripted demonstration toward a visible multi-agent
+loop over a real KNN workspace. Fake metrics were removed; rounds now retain
+role ownership, summarized evidence, automatic wakeups, and an explicit next
+frontier.
+
+Representative changes:
+
+- [#1785](https://github.com/huangruiteng/loopx/pull/1785) made Explore Harness
+  configurable and resumable.
+- [#1804](https://github.com/huangruiteng/loopx/pull/1804) added focused Explore
+  graph exports; [#1859](https://github.com/huangruiteng/loopx/pull/1859)
+  preserved independent lanes; [#1863](https://github.com/huangruiteng/loopx/pull/1863)
+  added resource-aware portfolio planning.
+- [#1448](https://github.com/huangruiteng/loopx/pull/1448) removed fake
+  Auto Research metrics, and [#1455](https://github.com/huangruiteng/loopx/pull/1455)
+  moved the KNN demo to a real benchmark workspace.
+- [#1590](https://github.com/huangruiteng/loopx/pull/1590) enabled automatic
+  wakeups, while [#1677](https://github.com/huangruiteng/loopx/pull/1677)
+  simplified the visible frontier projection.
+
+### Control-Plane State Became Easier to Read and Trust
+
+This window tightened the state machine around todos, monitors, vision, quota,
+and scheduler decisions. Agent-facing hot paths became smaller without losing
+the selected todo or its lineage, monitor transitions stopped consuming quota
+before material writeback, and terminal todo/vision states became more
+explicit. Several large CLI modules were split along existing ownership
+boundaries rather than replaced with a parallel framework.
+
+Representative changes:
+
+- [#1694](https://github.com/huangruiteng/loopx/pull/1694) compacted quota todo
+  summaries, and [#1731](https://github.com/huangruiteng/loopx/pull/1731)
+  exposed the selected todo directly.
+- [#1764](https://github.com/huangruiteng/loopx/pull/1764) preserved due monitors
+  through quota compaction; [#1769](https://github.com/huangruiteng/loopx/pull/1769)
+  canonicalized agent vision lifecycle states.
+- [#1774](https://github.com/huangruiteng/loopx/pull/1774) reduced the todo CLI
+  module budget without changing the public state machine.
+- [#1855](https://github.com/huangruiteng/loopx/pull/1855) fixed quota spending
+  after material monitor transitions.
+
+### Validation and Failure Attribution Improved
+
+Full-public smoke sweeps became a regular release gate, with parallel shards
+and explicit handling for git-heavy checks. Benchmark and host paths also
+gained more fail-fast attribution for unavailable sandboxes, remote runtimes,
+setup dependencies, and missing score evidence. These checks do not replace
+real long-running validation, but they make a failed run easier to classify
+before another expensive attempt.
+
+Representative changes:
+
+- [#1727](https://github.com/huangruiteng/loopx/pull/1727) repaired and
+  parallelized the full-public smoke runner.
+- [#1743](https://github.com/huangruiteng/loopx/pull/1743) restored reliable
+  full-public smoke coverage.
+- [#1803](https://github.com/huangruiteng/loopx/pull/1803) failed fast when the
+  Codex sandbox could not execute.
+- The v0.2.0 release passed all six public smoke shards, a 539-check local
+  public sweep, and a 17-surface premerge canary.
+
+## Validation And Public Boundary
+
+The changes summarized here were validated through focused contract smokes,
+full-public sweeps, release checks, and risk-based premerge canaries. This note
+links only public repository evidence and does not copy private state, raw
+benchmark logs or trajectories, local paths, credentials, or operator-only
+material into the publication surface.
+
+## Next Window
+
+The next expected window is 2026-07-12 to 2026-07-25. The publication workflow
+will continue to generate a deterministic, reviewable artifact from public
+history; a maintainer or LoopX agent remains responsible for narrative quality
+and the final pull request.

--- a/docs/update-notes/README.md
+++ b/docs/update-notes/README.md
@@ -11,12 +11,13 @@ operator-only state are intentionally excluded.
 
 ## Latest
 
-- [2026-06-14 to 2026-06-27](2026-06-14-to-2026-06-27.md)
+- [2026-06-28 to 2026-07-11](2026-06-28-to-2026-07-11.md)
 
 ## Archive
 
 | Window | Note | Focus |
 | --- | --- | --- |
+| 2026-06-28 to 2026-07-11 | [Read note](2026-06-28-to-2026-07-11.md) | v0.2 peer-agent runtime, issue-fix maintainer loops, resumable Explore and Auto Research, control-plane state reliability, and public validation. |
 | 2026-06-14 to 2026-06-27 | [Read note](2026-06-14-to-2026-06-27.md) | LoopX rename, benchmark workflow hardening, host commands, issue-fix workflow, evented state, task graph, and scheduler reliability. |
 | 2026-05-31 to 2026-06-13 | [Read note](2026-05-31-to-2026-06-13.md) | Public scaffold, local control plane, dashboard surface, quota/heartbeat loop, review packets, and project-agent todo contracts. |
 
@@ -30,7 +31,7 @@ operator-only state are intentionally excluded.
   history, LoopX CLI behavior, and shipped docs.
 - Publish on a two-week cadence anchored at the initial public scaffold on
   2026-05-31.
-- Next expected window: 2026-06-28 to 2026-07-11.
+- Next expected window: 2026-07-12 to 2026-07-25.
 
 ## Automation
 


### PR DESCRIPTION
## Summary

- publish the 2026-06-28 to 2026-07-11 biweekly update note
- replace the generated commit dump with a reviewed narrative around v0.2, issue-fix, Explore/Auto Research, peer control-plane state, and validation
- update the archive pointer while preserving the artifact-only publication contract

## Validation

- `python3 examples/update-notes-archive-smoke.py`
- `python3 examples/update-notes-generator-quality-smoke.py`
- `python3 -m loopx.cli check --scan-path docs/update-notes/2026-06-28-to-2026-07-11.md --scan-path docs/update-notes/README.md`
- merged-state verification for every linked PR
- `loopx canary premerge --from-git-diff` (13 selected, 13 passed, 0 failures, 0 manual holds)
- `git diff --check`

## Boundary

Public repository history and public GitHub links only. No private state, raw benchmark evidence, credentials, local paths, or internal links are included.
