### PR TITLE
fix: prevent due-monitor backlog from starving advancement

### DIFF
--- a/examples/control_plane/quota-work-lane-policy-smoke.py
+++ b/examples/control_plane/quota-work-lane-policy-smoke.py
@@ -41,6 +41,7 @@ def status_payload(
     agent_todo_items: list[dict] | None = None,
     next_action: str = "Observe dependency state and then advance backlog if unchanged.",
     post_handoff_latest_run: dict | None = None,
+    latest_runs: list[dict] | None = None,
 ) -> dict:
     if agent_todo_items is None:
         agent_todo_items = [
@@ -59,7 +60,72 @@ def status_payload(
         recommended_action=next_action,
         next_action=next_action,
         post_handoff_latest_run=post_handoff_latest_run,
+        latest_runs=latest_runs,
     )
+
+
+def assert_unchanged_monitor_attempt_yields_to_advancement() -> None:
+    due_todo = "[P0] Monitor one overdue dependency."
+    advancement_todo = "[P1] Advance the bounded product slice."
+    items = [
+        {
+            "index": 1,
+            "text": due_todo,
+            "role": "agent",
+            "status": "open",
+            "priority": "P0",
+            "task_class": "continuous_monitor",
+            "action_kind": "monitor",
+            "next_due_at": PAST_DUE_AT,
+        },
+        {
+            "index": 2,
+            "text": advancement_todo,
+            "role": "agent",
+            "status": "open",
+            "priority": "P1",
+            "task_class": "advancement_task",
+        },
+    ]
+    unchanged_poll = {
+        "classification": "quota_monitor_poll",
+        "agent_id": "codex-fixture",
+        "health_check": "due monitor observation unchanged; no quota spend",
+        "monitor_event": {
+            "monitor_mode": "due_monitor_observed_without_material_transition",
+            "material_change": False,
+        },
+    }
+    payload = status_payload(
+        status="monitor_backlog_fairness",
+        agent_todo_items=items,
+        latest_runs=[unchanged_poll],
+    )
+    guard = build_quota_should_run(payload, goal_id=GOAL_ID)
+    lane = guard["work_lane_contract"]
+    assert lane["lane"] == "advancement_task", lane
+    assert lane["reason_codes"] == [
+        "open_agent_todo",
+        "due_monitor_context",
+        "monitor_attempt_already_recorded",
+    ], lane
+    assert guard["recommended_action"] == advancement_todo, guard
+
+    payload = status_payload(
+        status="monitor_priority_reset_after_delivery",
+        agent_todo_items=items,
+        latest_runs=[
+            {
+                "classification": "validated_delivery",
+                "delivery_outcome": "outcome_progress",
+            },
+            unchanged_poll,
+        ],
+    )
+    guard = build_quota_should_run(payload, goal_id=GOAL_ID)
+    lane = guard["work_lane_contract"]
+    assert lane["lane"] == "continuous_monitor", lane
+    assert lane["selected_todo_id"], lane
 
 
 def assert_work_lane_context_matches_quota_state_machine_cases() -> None:
@@ -138,6 +204,7 @@ def assert_work_lane_context_progress_scope_sources() -> None:
 
 
 def main() -> int:
+    assert_unchanged_monitor_attempt_yields_to_advancement()
     assert_work_lane_context_matches_quota_state_machine_cases()
     assert_work_lane_context_progress_scope_sources()
 

--- a/loopx/control_plane/quota/recent_runs.py
+++ b/loopx/control_plane/quota/recent_runs.py
@@ -61,3 +61,51 @@ def recent_external_monitor_observation_unchanged(
                 "reason": "recent monitor observation was unchanged",
             }
     return None
+
+
+def latest_unchanged_monitor_observation(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+    agent_id: str | None = None,
+    scan_limit: int = 8,
+) -> dict[str, Any] | None:
+    """Return an unchanged monitor poll only when it is the latest work event.
+
+    Quota accounting and scheduler acknowledgements do not start a new work
+    lane. Any other current-agent or legacy-unscoped run does, so an older
+    monitor poll cannot suppress monitor priority after later delivery.
+    """
+
+    safe_agent_id = normalize_todo_claimed_by(agent_id)
+    for run in goal_latest_runs(status_payload, goal_id=goal_id)[: max(1, scan_limit)]:
+        run_agent_id = normalize_todo_claimed_by(run.get("agent_id"))
+        if safe_agent_id and run_agent_id and run_agent_id != safe_agent_id:
+            continue
+        classification = str(run.get("classification") or "").strip()
+        if classification.startswith("quota_slot_") or classification.startswith(
+            "quota_scheduler_"
+        ):
+            continue
+        if classification != QUOTA_MONITOR_POLL_CLASSIFICATION:
+            return None
+        monitor_event = run.get("monitor_event") if isinstance(run.get("monitor_event"), dict) else {}
+        if monitor_event.get("material_change") is True or run.get("material_change") is True:
+            return None
+        monitor_mode = str(monitor_event.get("monitor_mode") or "").strip()
+        health_check = str(run.get("health_check") or "").strip().lower()
+        if not (
+            monitor_mode.endswith("_observed_without_material_transition")
+            or "monitor observation unchanged" in health_check
+            or "due monitor observation unchanged" in health_check
+            or "external monitor observation unchanged" in health_check
+        ):
+            return None
+        return {
+            "classification": QUOTA_MONITOR_POLL_CLASSIFICATION,
+            "generated_at": run.get("generated_at"),
+            "agent_id": run_agent_id or None,
+            "monitor_mode": monitor_mode or "monitor_observed_without_material_transition",
+            "reason": "latest work event was an unchanged monitor observation",
+        }
+    return None

--- a/loopx/control_plane/quota/task_orchestration.py
+++ b/loopx/control_plane/quota/task_orchestration.py
@@ -7,6 +7,7 @@ from ..agents.runtime_model import peer_work_key, select_peer_for_work
 from ..todos.todo_summary import normalize_todo_claimed_by
 from ..work_items.work_lane import WORK_LANE_CONTRACT_SCHEMA_VERSION
 from ..work_items.work_lane_context import build_work_lane_context_contract
+from .recent_runs import latest_unchanged_monitor_observation
 
 
 AGENT_SCOPE_NON_EXECUTION_ACTIONS = {
@@ -19,13 +20,24 @@ AGENT_SCOPE_NON_EXECUTION_ACTIONS = {
 def build_quota_work_lane_contract(
     item: dict[str, Any],
     *,
+    status_payload: dict[str, Any],
+    goal_id: str,
+    agent_id: str | None,
     agent_todo_summary: dict[str, Any] | None,
     monitor_due_item_limit: int,
 ) -> dict[str, Any] | None:
+    monitor_attempt_already_recorded = bool(
+        latest_unchanged_monitor_observation(
+            status_payload,
+            goal_id=goal_id,
+            agent_id=agent_id,
+        )
+    )
     return build_work_lane_context_contract(
         item,
         agent_todo_summary=agent_todo_summary,
         monitor_due_item_limit=monitor_due_item_limit,
+        monitor_attempt_already_recorded=monitor_attempt_already_recorded,
     )
 
 

--- a/loopx/control_plane/work_items/work_lane.py
+++ b/loopx/control_plane/work_items/work_lane.py
@@ -143,6 +143,7 @@ def build_work_lane_contract(
     monitor_schedule_gap_items: list[dict[str, Any]] | None = None,
     resume_blocked_by_monitor_count: int = 0,
     resume_blocked_by_monitor_items: list[dict[str, Any]] | None = None,
+    monitor_attempt_already_recorded: bool = False,
 ) -> dict[str, Any] | None:
     """Return the work-lane execution contract from precomputed quota facts.
 
@@ -163,6 +164,9 @@ def build_work_lane_contract(
     blocked_by_monitor_items = resume_blocked_by_monitor_items or []
     schedule_gap_items = monitor_schedule_gap_items or []
     first_schedule_gap = schedule_gap_items[0] if schedule_gap_items else None
+    effective_due_monitor_preemption = due_monitor_preempts_advancement and not (
+        has_advancement_todos and monitor_attempt_already_recorded
+    )
 
     def due_monitor_contract(*, reason_codes: list[str]) -> dict[str, Any]:
         selected = first_due_monitor or {}
@@ -189,7 +193,7 @@ def build_work_lane_contract(
         }
 
     if progress_scope != "dependency_observation":
-        if has_advancement_todos and due_monitor_preempts_advancement:
+        if has_advancement_todos and effective_due_monitor_preemption:
             return due_monitor_contract(
                 reason_codes=["monitor_due", "due_monitor_priority_preempts_advancement"]
             )
@@ -197,6 +201,8 @@ def build_work_lane_contract(
             reason_codes = ["open_agent_todo"]
             if first_due_monitor:
                 reason_codes.append("due_monitor_context")
+            if first_due_monitor and monitor_attempt_already_recorded:
+                reason_codes.append("monitor_attempt_already_recorded")
             if external_poll_signal:
                 reason_codes.append("external_monitor_context")
             if outcome_followthrough:
@@ -345,7 +351,7 @@ def build_work_lane_contract(
     reason_codes = ["dependency_observation"]
     if has_advancement_todos:
         reason_codes.append("open_agent_todo")
-        if due_monitor_preempts_advancement:
+        if effective_due_monitor_preemption:
             reason_codes.append("due_monitor_priority_preempts_advancement")
     elif monitor_only_todos:
         reason_codes.append("monitor_todo_only")
@@ -353,7 +359,7 @@ def build_work_lane_contract(
             reason_codes.append("monitor_due")
     else:
         reason_codes.append("no_open_agent_todo")
-    if due_monitor_preempts_advancement:
+    if effective_due_monitor_preemption:
         return due_monitor_contract(reason_codes=reason_codes)
     return {
         "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,

--- a/loopx/control_plane/work_items/work_lane_context.py
+++ b/loopx/control_plane/work_items/work_lane_context.py
@@ -93,6 +93,7 @@ def build_work_lane_context_contract(
     *,
     agent_todo_summary: dict[str, Any] | None,
     monitor_due_item_limit: int = DEFAULT_MONITOR_DUE_ITEM_LIMIT,
+    monitor_attempt_already_recorded: bool = False,
 ) -> dict[str, Any] | None:
     progress_scope = item_progress_scope(item)
     external_poll_signal = build_external_evidence_poll_signal(
@@ -135,4 +136,5 @@ def build_work_lane_context_contract(
         monitor_due_item_limit=monitor_due_item_limit,
         resume_blocked_by_monitor_count=len(monitor_blocked_resume_candidates),
         resume_blocked_by_monitor_items=monitor_blocked_resume_candidates,
+        monitor_attempt_already_recorded=monitor_attempt_already_recorded,
     )

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -1389,6 +1389,9 @@ def build_quota_should_run(
         self_repair_allowed = bool(stall_self_repair and stall_self_repair.get("allowed"))
         work_lane_contract = build_quota_work_lane_contract(
             item,
+            status_payload=status_payload,
+            goal_id=safe_goal_id,
+            agent_id=normalize_todo_claimed_by((agent_identity or {}).get("agent_id")),
             agent_todo_summary=agent_todo_summary,
             monitor_due_item_limit=MONITOR_DUE_ITEM_LIMIT,
         )


### PR DESCRIPTION
## 动机

当同一目标积压多个到期 monitor 时，`quota should-run` 每次都会重新选择另一个 monitor。即使上一轮已经完成一次“无实质变化”的 monitor poll，只要还有其他 monitor 到期，真正可执行的 advancement 仍会被持续抢占。

OpenViking 真实现场中有 18 个到期 monitor 和 2 个 advancement，结果是 heartbeat 在不同 PR/看板 monitor 间轮转，却迟迟回不到“继续选择并修复 issue”。

## 改动思路

本 PR 增加一个很窄的公平性规则：

```text
latest work event == unchanged monitor poll
AND runnable advancement exists
    => 本轮不再让另一个 due monitor 抢占
    => 选择 advancement，并把 due monitors 保留为观察上下文
```

以下情况保持原行为：

- 目标只有 monitor、没有 advancement：继续正常轮询。
- monitor 出现实质状态变化：仍按高优先级处理。
- 后续已有一次真实 delivery：重新允许 due monitor 优先。
- quota spend / scheduler ack 只是记账，不会误判为新的工作轮次。

## 关键实现

- 从最近运行记录中识别“当前 agent 最新工作事件是否为 unchanged monitor poll”。
- 将该事实投影到通用 work-lane contract。
- 在 due monitor 与 advancement 同时存在时，仅抑制一次重复 monitor 抢占。
- 输出 `monitor_attempt_already_recorded` reason code，便于诊断实际路由。

## 复现与验证

真实 OpenViking backlog 复测：

- 到期 monitor：18
- 可执行 advancement：2
- 修复前：继续选择另一个 continuous_monitor
- 修复后：选择 P0 advancement，`work_lane_contract.lane=advancement_task`
- reason codes：`open_agent_todo`、`due_monitor_context`、`monitor_attempt_already_recorded`

测试：

- quota work-lane policy smoke
- work-lane contract smoke
- monitor poll writeback smoke
- monitor scheduler contract smoke
- quota contract smoke
- repository Python line budget
- Ruff / py_compile / diff check
- standard premerge canary：17/17 通过
- public boundary scan：通过

## 风险

这是调度优先级修复，不改变 monitor 的到期计算或状态写回。最主要风险是过度抑制 monitor；因此实现只在“已有一次无变化 poll + 同时存在 runnable advancement”时生效，并由后续真实 delivery 自动重置。