### PR TITLE
fix(quota): keep future monitor waits quiet

### DIFF
--- a/examples/control_plane/external-evidence-observation-smoke.py
+++ b/examples/control_plane/external-evidence-observation-smoke.py
@@ -336,6 +336,28 @@ def assert_future_scoped_monitor_does_not_fake_external_poll() -> None:
     assert "external_evidence_observation" not in guard, guard
 
 
+def assert_unavailable_advancement_does_not_wake_future_monitor() -> None:
+    summary = agent_todos(
+        [
+            monitor_todo(
+                todo_id="todo_monitor_future",
+                priority="P1",
+                next_due_at=FUTURE_DUE_AT,
+            ),
+            unavailable_advancement_todo(),
+        ]
+    )
+    item = selected_item(status_payload(summary))
+    counts = todo_summary_open_task_counts(summary)
+    assert counts["monitor"] == 1 and counts["advancement"] == 1, counts
+    assert build_external_evidence_poll_signal(item, agent_todo_summary=summary), item
+
+    guard = build_quota_should_run(status_payload(summary), goal_id=GOAL_ID, agent_id=AGENT_ID)
+    assert "external_evidence_observation" not in guard, guard
+    assert guard["interaction_contract"]["agent_channel"]["must_attempt"] is False, guard
+    assert guard["interaction_contract"]["agent_channel"]["quiet_noop_allowed"] is True, guard
+
+
 def assert_selected_monitor_handle(
     items: list[dict[str, Any]],
     *,
@@ -514,6 +536,7 @@ def main() -> int:
     assert_recent_due_monitor_no_change_quiets_external_monitor()
     assert_advancement_lane_keeps_external_monitor_as_context()
     assert_future_scoped_monitor_does_not_fake_external_poll()
+    assert_unavailable_advancement_does_not_wake_future_monitor()
     assert_monitor_handle_precedence()
     assert_pr_dependency_wait_requires_first_observation()
     assert_pr_dependency_wait_with_observation_does_not_reobserve_before_due()

--- a/loopx/control_plane/scheduler/external_evidence_observation.py
+++ b/loopx/control_plane/scheduler/external_evidence_observation.py
@@ -168,6 +168,30 @@ def _monitor_window_allows_poll_signal(
     return True
 
 
+def _external_evidence_observation_is_early_future_monitor(
+    observation: dict[str, Any] | None,
+    *,
+    agent_todo_summary: dict[str, Any] | None,
+) -> bool:
+    if not isinstance(observation, dict):
+        return False
+    handle = (
+        observation.get("monitor_handle")
+        if isinstance(observation.get("monitor_handle"), dict)
+        else {}
+    )
+    if not str(handle.get("next_due_at") or "").strip():
+        return False
+    return bool(
+        todo_summary_monitor_due_count(agent_todo_summary) <= 0
+        and todo_summary_monitor_schedule_gap_count(agent_todo_summary) <= 0
+        and not _selected_monitor_needs_first_dependency_observation(
+            agent_todo_summary,
+            handle,
+        )
+    )
+
+
 def build_external_evidence_poll_signal(
     item: dict[str, Any],
     *,
@@ -382,6 +406,11 @@ def build_external_evidence_observation_obligation(
     monitor_handle = poll_signal.get("monitor_handle") if isinstance(poll_signal, dict) else None
     if isinstance(monitor_handle, dict) and monitor_handle:
         obligation["monitor_handle"] = monitor_handle
+    if _external_evidence_observation_is_early_future_monitor(
+        obligation,
+        agent_todo_summary=agent_todo_summary,
+    ):
+        obligation["poll_window_status"] = "before_next_due"
     return obligation
 
 

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -1636,6 +1636,8 @@ def build_quota_should_run(
             )
             if external_evidence_observation_recent:
                 external_evidence_observation = None
+            elif external_evidence_observation.get("poll_window_status") == "before_next_due":
+                external_evidence_observation = None
         ready_deferred_resume_candidates: list[dict[str, Any]] = []
         if (
             isinstance(agent_identity, dict)


### PR DESCRIPTION
## Summary

- mark external-evidence obligations whose selected monitor handle is explicitly before `next_due_at`
- after preserving recent-observation cooldown evidence, suppress only those early future observations when no due monitor, schedule gap, or selected first-observation dependency exists
- cover the real fallback shape: unavailable advancement plus a future scheduled monitor remains quiet/no-spend

## Why

PR #2008 fixed monitor handle and signal correlation, but a capability-unavailable advancement lane could still bypass the future-monitor window guard because `scoped_monitor_watch_without_advancement` was false. That made a non-due regression monitor wake every heartbeat.

## Validation

- external-evidence observation smoke: passed
- todo projection shared-helper smoke: passed
- execution-obligation policy smoke: passed
- monitor poll writeback and scheduler smokes: passed
- quota work-lane policy smoke: passed
- Python compile and diff checks: passed
- risk-based premerge: 17/17 passed, 0 warnings, 0 failures, 0 manual holds
- public/private boundary: passed

The first premerge run found only the `loopx/quota.py` line-budget guard. The policy marker was moved into the scheduler bounded context; the line-budget smoke and full premerge then passed.

## Boundaries

- no benchmark jobs or production actions
- no quota-spend, monitor-writeback, permission, or benchmark semantics changed
- no credentials, private state, local paths, raw benchmark evidence, or generated logs

Core quota/scheduler runtime change; hold for independent peer review before merge.