### PR TITLE
fix(quota): correlate material monitor receipts

### DIFF
--- a/examples/control_plane/monitor-poll-writeback-smoke.py
+++ b/examples/control_plane/monitor-poll-writeback-smoke.py
@@ -17,6 +17,9 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 import loopx.cli_commands.quota as quota_command  # noqa: E402
+from loopx.control_plane.quota.monitor_poll import (  # noqa: E402
+    build_quota_monitor_poll_event,
+)
 from loopx.control_plane.scheduler.monitor_poll_writeback import (  # noqa: E402
     resolve_monitor_todo_item,
     write_monitor_poll_todo_state,
@@ -387,6 +390,11 @@ def assert_material_transition_followup() -> None:
         records = monitor_poll_records(registry_path)
         assert [record["classification"] for record in records] == ["quota_monitor_poll"], records
         assert records[0]["delivery_outcome"] == "outcome_progress", records[0]
+        event = payload["monitor_event"]
+        assert event["monitor_mode"] == "due_monitor_material_transition", event
+        assert event["reason_summary"] == "due monitor observation produced a material transition", event
+        assert "due monitor material transition observed" in payload["health_check"], payload
+        assert "unchanged" not in payload["health_check"], payload
 
         handoff = run_cli(
             registry_path,
@@ -414,6 +422,52 @@ def assert_material_transition_followup() -> None:
         contract = handoff["interaction_contract"]
         assert contract["agent_channel"]["must_attempt"] is True, contract
         assert contract["cli_channel"]["spend_after_validation"] is True, contract
+
+
+def assert_external_material_transition_receipt_correlation() -> None:
+    before = {
+        "goal_id": GOAL_ID,
+        "should_run": True,
+        "requires_user_action": False,
+        "effective_action": "external_evidence_observe",
+        "recommended_action": "Observe the external result handle.",
+        "external_evidence_observation": {
+            "required": True,
+            "must_attempt_observation": True,
+            "delivery_allowed": False,
+            "if_handle_live_and_unchanged": "quiet_noop_no_spend",
+        },
+        "work_lane_contract": {
+            "lane": "continuous_monitor",
+            "must_attempt_work": True,
+            "monitor_policy": "read_only_observation_then_no_spend_if_unchanged",
+            "reason_codes": ["external_monitor_context"],
+        },
+        "heartbeat_recommendation": {
+            "recommended_mode": "external_evidence_observe_or_blocker",
+            "reason": "Observe the external result handle before deciding whether to continue.",
+        },
+        "agent_identity": {"agent_id": AGENT_ID},
+    }
+
+    record = build_quota_monitor_poll_event(
+        before,
+        todo_id=TODO_ID,
+        target_key=TARGET_KEY,
+        result_hash="external-result-ready",
+        material_change=True,
+    )
+
+    event = record["monitor_event"]
+    assert event["material_change"] is True, record
+    assert event["monitor_mode"] == "external_monitor_material_transition", record
+    assert event["reason_summary"] == (
+        "external monitor observation produced a material transition"
+    ), record
+    assert "external monitor material transition observed" in record["health_check"], record
+    assert "unchanged" not in record["health_check"], record
+    assert "no material transition" not in record["health_check"], record
+    assert record["delivery_outcome"] == "outcome_progress", record
 
 
 def assert_due_monitor_poll_allowed_with_open_user_gate() -> None:
@@ -671,6 +725,7 @@ def main() -> int:
     assert_writeback_helper_preview_contract()
     assert_unchanged_writeback()
     assert_material_transition_followup()
+    assert_external_material_transition_receipt_correlation()
     assert_due_monitor_poll_allowed_with_open_user_gate()
     assert_target_key_cannot_hijack_selected_due_monitor()
     assert_compacted_auxiliary_due_monitor_can_write_back()

--- a/loopx/control_plane/quota/monitor_poll.py
+++ b/loopx/control_plane/quota/monitor_poll.py
@@ -72,29 +72,44 @@ def build_quota_monitor_poll_event(
         and not due_monitor_poll
     ):
         raise ValueError("quota monitor-poll requires monitor_quiet_until_material_transition mode")
-    monitor_mode = (
-        "external_monitor_observed_without_material_transition"
-        if external_monitor_poll
-        else (
-            "due_monitor_material_transition"
-            if due_monitor_poll and material_change
-            else (
-                "due_monitor_observed_without_material_transition"
-                if due_monitor_poll
-                else "monitor_quiet_until_material_transition"
-            )
+    if external_monitor_poll:
+        monitor_kind = "external monitor"
+        monitor_mode_prefix = "external_monitor"
+    elif due_monitor_poll:
+        monitor_kind = "due monitor"
+        monitor_mode_prefix = "due_monitor"
+    else:
+        monitor_kind = "monitor"
+        monitor_mode_prefix = "monitor"
+    if material_change:
+        monitor_mode = f"{monitor_mode_prefix}_material_transition"
+        default_reason_summary = f"{monitor_kind} observation produced a material transition"
+        health_check = (
+            f"{monitor_kind} material transition observed; follow-up state updated; "
+            "no quota spend by monitor-poll"
         )
-    )
-    monitor_target = build_quota_monitor_target(before, monitor_mode=monitor_mode)
-    safe_reason_summary = str(reason_summary or "").strip()
-    if not safe_reason_summary:
-        safe_reason_summary = (
-            "external monitor observation produced no material transition"
-            if external_monitor_poll
-            else recommendation.get("reason")
+    elif external_monitor_poll:
+        monitor_mode = "external_monitor_observed_without_material_transition"
+        default_reason_summary = "external monitor observation produced no material transition"
+        health_check = "external monitor observation unchanged; no quota spend; no material transition"
+    elif due_monitor_poll:
+        monitor_mode = "due_monitor_observed_without_material_transition"
+        default_reason_summary = (
+            recommendation.get("reason")
+            or before.get("reason")
+            or "due monitor poll had no material transition"
+        )
+        health_check = "due monitor observation unchanged; no quota spend; next due updated"
+    else:
+        monitor_mode = "monitor_quiet_until_material_transition"
+        default_reason_summary = (
+            recommendation.get("reason")
             or before.get("reason")
             or "monitor-only poll had no material transition"
         )
+        health_check = "monitor-only poll unchanged; no quota spend; no material transition"
+    monitor_target = build_quota_monitor_target(before, monitor_mode=monitor_mode)
+    safe_reason_summary = str(reason_summary or "").strip() or default_reason_summary
     safe_agent_id = quota_decision_agent_id(before)
 
     record = {
@@ -102,22 +117,10 @@ def build_quota_monitor_poll_event(
         "goal_id": before.get("goal_id"),
         "classification": QUOTA_MONITOR_POLL_CLASSIFICATION,
         "recommended_action": before.get("recommended_action") or recommendation.get("reason") or before.get("reason"),
-        "health_check": (
-            "due monitor material transition observed; follow-up state updated; no quota spend by monitor-poll"
-            if due_monitor_poll and material_change
-            else (
-                "due monitor observation unchanged; no quota spend; next due updated"
-                if due_monitor_poll
-                else (
-                    "external monitor observation unchanged; no quota spend; no material transition"
-                    if external_monitor_poll
-                    else "monitor-only poll unchanged; no quota spend; no material transition"
-                )
-            )
-        ),
+        "health_check": health_check,
         "delivery_outcome": (
             DeliveryOutcome.OUTCOME_PROGRESS.value
-            if due_monitor_poll and material_change
+            if material_change
             else DeliveryOutcome.SURFACE_ONLY.value
         ),
         "monitor_target": monitor_target,


### PR DESCRIPTION
## Summary

- make `material_change=true` the first receipt-correlation decision for external, due, and quiet monitor paths
- emit material-transition monitor modes, default reasons, health checks, and `outcome_progress` consistently
- add focused external-evidence and due-monitor regression assertions

## Motivation

A material external-evidence poll could write a contradictory receipt: `material_change=true` alongside an unchanged monitor mode, no-transition reason, unchanged health check, and `surface_only`. That makes history and downstream control-plane reasoning disagree about the same event.

## Validation

- monitor-poll writeback smoke
- monitor-poll policy smoke
- external-evidence observation smoke
- heartbeat quota-flow smoke
- quota-plan smoke
- Python compile and `uvx ruff check`
- `loopx canary premerge --from-git-diff` (16 selected, 16 passed, 0 failures, 0 manual holds)
- `git diff --check`

## Risk

The unchanged path is preserved. The behavior change is limited to receipt fields when callers explicitly set `material_change=true`; no quota-spend or monitor authorization policy changes.
