### PR TITLE
release: LoopX v0.2.3

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -226,6 +226,21 @@ path, and canary route rather than as a user-facing release baseline.
   preserving compatibility imports and restoring the full-public smoke shard
   (#1961, #1968, #1970, #1972). No persisted-state migration is required;
   Explore execution and visual sinks remain explicit opt-ins.
+- `v0.2.3` on 2026-07-13: control-plane truthfulness and maintainer-surface
+  release at the matching `v0.2.3` tag. LoopX adds a provider-neutral
+  model-behavior qualification contract with public-safe corpus and decision
+  receipts plus an optional direct provider actor (#1994, #1998-#1999, #2001,
+  #2003). Optional capability discovery and the Lark event inbox/collector
+  become clearer product surfaces without adding mandatory first-run
+  configuration (#1978, #1986, #1997, #2000). Monitor, todo, quota, and vision
+  routing now preserve capabilities and attribution, prefer advancement over
+  stale monitor pressure, keep future waits quiet, and correlate material
+  transition receipts (#1989-#1993, #2008, #2011, #2013-#2015). Explore graph
+  activation now respects run-scoped sink authority (#1995, #2016), while
+  deterministic update notes and project governance make the public repository
+  easier to maintain (#1983, #1996, #2012). No persisted-state migration is
+  required; optional provider, Lark, semantic-preference, and Explore surfaces
+  remain opt-in.
 
 When a new public release is promoted, add it here only after the matching tag,
 release note, stable ref, update path, and focused release canary agree.

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.2.2"
+version = "0.2.3"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- bump both package version sources from `0.2.2` to `0.2.3`
- record the v0.2.3 control-plane truthfulness and maintainer-surface release
- preserve opt-in defaults and require no persisted-state migration

## Validation

- `uv run --extra test pytest -q` (261 passed, 2 skipped)
- release smokes: no-clone Codex CLI, fresh-clone quickstart, update, version contract, readiness doc
- `loopx canary premerge --from-git-diff` (17/17, no manual holds, self-merge allowed)
- `loopx check --scan-path README.md --scan-path docs/ --scan-path examples/` (public boundary clean; one unrelated existing OpenViking index warning)
- `uvx ruff check loopx/__init__.py`
- `python3 -m py_compile loopx/*.py`
- `git diff --check`

## Compatibility

No persisted-state migration is required. Optional provider, Lark, semantic-preference, and Explore surfaces remain opt-in.

## Excluded

The locally generated untracked `uv.lock` is intentionally excluded; this repository does not currently ship a lockfile.