### PR TITLE
fix(issue-fix): retry closing reference verification

### DIFF
--- a/docs/capabilities/issue-fix/protocols/issue-fix-discovered-issue-promotion-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-discovered-issue-promotion-v0.md
@@ -30,15 +30,19 @@ requires active `publish` authority and performs this ordered transaction:
 
 1. verify the selected existing issue, or create a structured public issue and
    verify the returned URL;
-2. if a PR exists, add `Fixes #N` only when needed and require the PR readback
-   to expose the canonical closing issue;
+2. if a PR exists, add `Fixes #N` only when needed and use a bounded readback
+   retry to require the PR to expose the canonical closing issue;
 3. atomically replace the local placeholder feasibility row with the canonical
    issue row while preserving revision-pinned context and compact delivery
    evidence;
-4. update the existing PR lifecycle row with the same explicit `issue_ref`.
+4. update an existing PR lifecycle row with the same explicit `issue_ref`; if
+   lifecycle projection has not run yet, return `not_projected` and let the
+   existing lifecycle wrapper fill it instead of failing promotion.
 
-Retries are idempotent. An already verified issue/PR association with one
-canonical feasibility row produces zero external writes and no duplicate
+Retries are idempotent. Closing-reference verification retries at most three
+reads with a short delay, covering GitHub's write-after-read lag without
+creating a background monitor. An already verified issue/PR association with
+one canonical feasibility row produces zero external writes and no duplicate
 Kanban or metrics row.
 
 GitHub cannot provide a cross-issue/PR transaction. If issue creation succeeds

--- a/examples/issue-fix-discovered-issue-promotion-smoke.py
+++ b/examples/issue-fix-discovered-issue-promotion-smoke.py
@@ -10,6 +10,7 @@ import sys
 import tempfile
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -130,11 +131,14 @@ def promotion_input(
 
 
 class FakeGitHub:
-    def __init__(self, *, fail_edit: bool = False) -> None:
+    def __init__(
+        self, *, fail_edit: bool = False, verification_lag_reads: int = 0
+    ) -> None:
         self.linked = False
         self.write_count = 0
         self.last_pr_body = ""
         self.fail_edit = fail_edit
+        self.verification_lag_reads = verification_lag_reads
 
     def __call__(self, args: list[str]) -> dict[str, Any]:
         if args[1:3] == ["issue", "view"]:
@@ -151,6 +155,9 @@ class FakeGitHub:
                 "stderr": "provider response payload",
             }
         if args[1:3] == ["pr", "view"]:
+            linked_visible = self.linked and self.verification_lag_reads == 0
+            if self.linked and self.verification_lag_reads > 0:
+                self.verification_lag_reads -= 1
             return {
                 "returncode": 0,
                 "stdout": json.dumps(
@@ -159,7 +166,7 @@ class FakeGitHub:
                             self.last_pr_body or "Motivation\n\nraw original PR body"
                         ),
                         "closingIssuesReferences": (
-                            [{"number": 42}] if self.linked else []
+                            [{"number": 42}] if linked_visible else []
                         ),
                         "url": "https://github.com/example/public-repo/pull/99",
                     }
@@ -283,17 +290,21 @@ def main() -> int:
         )
         upsert_issue_fix_pr_lifecycle_ledger_jsonl(lifecycle_path, lifecycle)
 
-        github = FakeGitHub()
-        promoted = build_issue_fix_discovered_issue_promotion_packet(
-            promotion_input=promotion_input(),
-            boundary_authority_scopes=["write", "publish"],
-            boundary_authority_resolved=True,
-            execute=True,
-            feasibility_ledger_path=feasibility_path,
-            pr_lifecycle_ledger_path=lifecycle_path,
-            runner=github,
-            generated_at="2026-07-12T00:00:00Z",
-        )
+        github = FakeGitHub(verification_lag_reads=2)
+        with patch(
+            "loopx.capabilities.issue_fix.discovered_issue_promotion.time.sleep"
+        ) as sleep:
+            promoted = build_issue_fix_discovered_issue_promotion_packet(
+                promotion_input=promotion_input(),
+                boundary_authority_scopes=["write", "publish"],
+                boundary_authority_resolved=True,
+                execute=True,
+                feasibility_ledger_path=feasibility_path,
+                pr_lifecycle_ledger_path=lifecycle_path,
+                runner=github,
+                generated_at="2026-07-12T00:00:00Z",
+            )
+        assert sleep.call_count == 2
         assert (
             promoted["schema_version"]
             == ISSUE_FIX_DISCOVERED_ISSUE_PROMOTION_SCHEMA_VERSION
@@ -334,6 +345,25 @@ def main() -> int:
         assert len(read_rows(feasibility_path)) == 1
         assert github.write_count == 1
         assert_public_safe(retry)
+
+        missing_lifecycle = build_issue_fix_discovered_issue_promotion_packet(
+            promotion_input=promotion_input(),
+            boundary_authority_scopes=["publish"],
+            boundary_authority_resolved=True,
+            execute=True,
+            feasibility_ledger_path=feasibility_path,
+            pr_lifecycle_ledger_path=root / "missing-pr-lifecycle.jsonl",
+            runner=github,
+            generated_at="2026-07-12T00:06:00Z",
+        )
+        assert missing_lifecycle["ok"] is True
+        assert missing_lifecycle["external_writes_performed"] is False
+        assert missing_lifecycle["domain_state_reconciliation"]["pr_lifecycle"] == {
+            "write_performed": False,
+            "status": "not_projected",
+            "path_recorded": False,
+        }
+        assert_public_safe(missing_lifecycle)
 
         read_only = build_issue_fix_discovered_issue_promotion_packet(
             promotion_input=promotion_input(),

--- a/loopx/capabilities/issue_fix/discovered_issue_promotion.py
+++ b/loopx/capabilities/issue_fix/discovered_issue_promotion.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import re
 import subprocess
+import time
 from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
@@ -59,6 +60,8 @@ _DUPLICATE_FIELDS = {
 _CLOSING_REFERENCE_PATTERN = re.compile(
     r"(?im)^\s*(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#([1-9][0-9]*)\s*$"
 )
+_CLOSING_REFERENCE_VERIFY_ATTEMPTS = 3
+_CLOSING_REFERENCE_VERIFY_DELAY_SECONDS = 0.5
 
 CommandRunner = Callable[[Sequence[str]], Mapping[str, Any]]
 
@@ -463,13 +466,19 @@ def _ensure_pr_closing_reference(
             if result.get("returncode") != 0:
                 raise ValueError("GitHub PR closing-reference update failed")
             write_performed = True
-    after = read_pr()
-    verified_numbers = {
-        item.get("number")
-        for item in after.get("closingIssuesReferences") or []
-        if isinstance(item, Mapping)
-    }
-    if issue_number not in verified_numbers:
+    verified_numbers: set[Any] = set()
+    for attempt in range(_CLOSING_REFERENCE_VERIFY_ATTEMPTS):
+        after = read_pr()
+        verified_numbers = {
+            item.get("number")
+            for item in after.get("closingIssuesReferences") or []
+            if isinstance(item, Mapping)
+        }
+        if issue_number in verified_numbers:
+            break
+        if attempt + 1 < _CLOSING_REFERENCE_VERIFY_ATTEMPTS:
+            time.sleep(_CLOSING_REFERENCE_VERIFY_DELAY_SECONDS)
+    else:
         raise ValueError(
             "GitHub PR does not visibly report the closing issue reference"
         )
@@ -864,21 +873,24 @@ def build_issue_fix_discovered_issue_promotion_packet(
             ref_value=f"pull_{pr_reference['number']}",
         )
         if lifecycle_source is None:
-            raise ValueError(
-                "PR lifecycle row must exist before discovered issue promotion"
+            packet["domain_state_reconciliation"]["pr_lifecycle"] = {
+                "write_performed": False,
+                "status": "not_projected",
+                "path_recorded": False,
+            }
+        else:
+            lifecycle = promote_issue_fix_pr_lifecycle_packet(
+                lifecycle_source,
+                canonical_issue_ref=issue["issue_ref"],
             )
-        lifecycle = promote_issue_fix_pr_lifecycle_packet(
-            lifecycle_source,
-            canonical_issue_ref=issue["issue_ref"],
-        )
-        lifecycle_write = upsert_issue_fix_pr_lifecycle_ledger_jsonl(
-            lifecycle_path, lifecycle
-        )
-        packet["domain_state_reconciliation"]["pr_lifecycle"] = {
-            "write_performed": lifecycle_write.get("write_performed") is True,
-            "status": lifecycle_write.get("status"),
-            "path_recorded": False,
-        }
+            lifecycle_write = upsert_issue_fix_pr_lifecycle_ledger_jsonl(
+                lifecycle_path, lifecycle
+            )
+            packet["domain_state_reconciliation"]["pr_lifecycle"] = {
+                "write_performed": lifecycle_write.get("write_performed") is True,
+                "status": lifecycle_write.get("status"),
+                "path_recorded": False,
+            }
     packet["dry_run"] = False
     if pr_blocker is not None:
         packet["ok"] = False


### PR DESCRIPTION
## 动机

OpenViking issue-fix 的真实调用暴露了两个连续性缺口：

1. PR body 成功追加 `Fixes #3207` 后，GitHub GraphQL 的 `closingIssuesReferences` 在第一次即时复读中仍为空，promotion 因此误报 blocker；稍后读取已经正确关联。
2. 幂等重试时，canonical feasibility 已存在但 PR lifecycle 还没投影，promotion 会直接抛错，迫使调用方手工补一行状态。

## 改动

- closing-reference 写后验证最多读取 3 次，每次间隔 0.5 秒，总额外等待不超过约 1 秒。
- 只做同步有界复读，不创建后台 monitor 或新状态机。
- canonical issue/PR 已验证但 lifecycle 尚不存在时，返回 `pr_lifecycle.status=not_projected`；后续仍由既有 `pr-lifecycle` wrapper 投影。
- 保持重试幂等：已经关联的 PR 不再写 body，canonical feasibility 不产生重复行。

## 关键路径

```text
PATCH PR body
  → bounded closingIssuesReferences readback (≤3)
  → canonical feasibility reconciliation
  → lifecycle exists: update issue_ref
    lifecycle missing: not_projected
```

## 验证

- `python3 examples/issue-fix-discovered-issue-promotion-smoke.py`
- `python3 examples/issue-fix-capability-guide-smoke.py`
- `python3 -m loopx.cli canary premerge --from-git-diff --git-diff-base origin/main --tier standard`
- `python3 -m loopx.cli check --scan-path ...`：公共边界扫描通过，目标文件 0 error
- `git diff --check`

新增回归覆盖两次不可见、第三次可见的 GitHub read-after-write 延迟，以及 lifecycle 尚未投影的幂等重试。

## 风险与边界

- 最坏增加约 1 秒同步等待，仅在 closing issue 尚不可见时发生。
- 最终仍不可见时继续返回原 blocker，不把未验证关联当成功。
- `not_projected` 不伪造 lifecycle 状态，也不授权 merge、通知或其他外部动作。
