### PR TITLE
feat(lark): bind inbox replies to configured bot profiles

### DIFF
--- a/docs/capabilities/lark-event-inbox.md
+++ b/docs/capabilities/lark-event-inbox.md
@@ -9,6 +9,7 @@ Lark event stream
   -> .loopx/inbox/<channel>/*.json
   -> loopx lark-inbox drain
   -> domain agent writes a todo, vision correction, artifact update, or rationale
+  -> direct bot question: loopx lark-inbox reply (optional, configured sender only)
   -> loopx lark-inbox ack --message-id ... --execute
 ```
 
@@ -51,6 +52,35 @@ configuration or host state and must not enter public LoopX packets.
 reports `thread_complete=false` and a coverage warning for that mode. For
 `configured_chat_all`, the collector's jq filter should select the configured
 chat only; do not add a content-level `@bot` predicate.
+
+Optional source-thread replies are a separate, default-off boundary. Enable
+them only for a `configured_chat_all` inbox and bind an explicit non-default
+bot profile to the same local-private chat:
+
+```json
+{
+  "schema_version": "lark_event_inbox_config_v0",
+  "enabled": true,
+  "inbox_dir": ".loopx/inbox/team-feedback",
+  "capture_scope": "configured_chat_all",
+  "reply": {
+    "enabled": true,
+    "sender_profile": "project-review-bot",
+    "sender_identity": "bot",
+    "bot_display_name": "Project Review Bot",
+    "chat_id": "oc_<local-private-chat-id>"
+  }
+}
+```
+
+The reply path never uses the machine default profile. Before any send it
+verifies that the named profile resolves to the expected bot and that the bot
+can read the configured chat. A profile/app mismatch fails with
+`lark_inbox_reply_sender_identity_mismatch`; a profile that cannot access the
+configured chat fails with
+`lark_inbox_reply_sender_not_in_configured_chat`. Neither failure falls back
+to another app. Public results contain only compact status/receipt fields, not
+the profile, chat id, message id, reply text, or provider payload.
 
 ## Host collector lifecycle
 
@@ -148,6 +178,31 @@ loopx lark-inbox ack \
 Drain is read-only and returns bounded local-private message content. A message
 must be acknowledged only after its effect is written back. Duplicate event
 files collapse by `message_id`; repeated acknowledgement is idempotent.
+
+For a direct question or explicit bot mention, write the requested durable
+effect first, preview one concise source-thread reply, execute it, require
+readback, and only then ACK:
+
+```bash
+loopx lark-inbox reply \
+  --project . \
+  --config .loopx/config/lark/event-inbox.json \
+  --message-id om_xxx \
+  --text '已记录并修正。'
+
+loopx lark-inbox reply \
+  --project . \
+  --config .loopx/config/lark/event-inbox.json \
+  --message-id om_xxx \
+  --text '已记录并修正。' \
+  --execute
+```
+
+The command uses an idempotency key derived from the source message and reply
+text, sends with `--reply-in-thread`, and reads the created message back through
+the same configured profile. Ordinary chatter remains a no-reply path;
+enabling this capability does not grant reviewer-notification or other
+outbound authority.
 
 ## Bounded history reconciliation
 

--- a/examples/lark-event-inbox-smoke.py
+++ b/examples/lark-event-inbox-smoke.py
@@ -16,6 +16,7 @@ from loopx.capabilities.lark.event_inbox import (  # noqa: E402
     ingest_lark_event_inbox,
     inspect_lark_event_inbox,
 )
+from loopx.capabilities.lark.inbox_reply import reply_lark_event_inbox  # noqa: E402
 
 
 def main() -> None:
@@ -140,6 +141,137 @@ def main() -> None:
         processed = json.loads((inbox / "processed.json").read_text(encoding="utf-8"))
         assert processed["schema_version"] == "lark_event_inbox_processed_v0"
 
+        config.write_text(
+            json.dumps(
+                {
+                    "schema_version": "lark_event_inbox_config_v0",
+                    "enabled": True,
+                    "inbox_dir": ".loopx/inbox/team-feedback",
+                    "capture_scope": "configured_chat_all",
+                    "reply": {
+                        "enabled": True,
+                        "sender_profile": "project-review-bot",
+                        "sender_identity": "bot",
+                        "bot_display_name": "Project Review Bot",
+                        "chat_id": "oc_project_review",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        calls: list[list[str]] = []
+
+        def successful_runner(args):
+            calls.append(list(args))
+            if args[3:6] == ["auth", "status", "--verify"]:
+                return {
+                    "returncode": 0,
+                    "stdout": json.dumps(
+                        {
+                            "identities": {
+                                "bot": {
+                                    "available": True,
+                                    "verified": True,
+                                    "appName": "Project Review Bot",
+                                }
+                            }
+                        }
+                    ),
+                    "stderr": "",
+                }
+            if args[3:6] == ["im", "chats", "get"]:
+                return {"returncode": 0, "stdout": "{}", "stderr": ""}
+            if "+messages-reply" in args:
+                return {
+                    "returncode": 0,
+                    "stdout": json.dumps({"message_id": "om_reply_1"}),
+                    "stderr": "",
+                }
+            if "+messages-mget" in args:
+                return {
+                    "returncode": 0,
+                    "stdout": json.dumps(
+                        {
+                            "items": [
+                                {
+                                    "message_id": "om_reply_1",
+                                    "content": "已记录并修正。",
+                                }
+                            ]
+                        },
+                        ensure_ascii=False,
+                    ),
+                    "stderr": "",
+                }
+            raise AssertionError(args)
+
+        replied = reply_lark_event_inbox(
+            project=project,
+            config_path=config,
+            message_id="om_review_2",
+            text="已记录并修正。",
+            execute=True,
+            runner=successful_runner,
+        )
+        assert replied["status"] == "sent_verified", replied
+        assert replied["sender_identity_verified"] is True, replied
+        assert replied["sender_chat_membership_verified"] is True, replied
+        assert replied["private_sender_profile_captured"] is False, replied
+        assert calls and all(
+            call[:3] == ["lark-cli", "--profile", "project-review-bot"]
+            for call in calls
+        ), calls
+        assert any("+messages-reply" in call for call in calls), calls
+        assert all(
+            "--as" in call and call[call.index("--as") + 1] == "bot"
+            for call in calls[1:]
+        ), calls
+
+        membership_calls: list[list[str]] = []
+
+        def missing_membership_runner(args):
+            membership_calls.append(list(args))
+            if args[3:6] == ["auth", "status", "--verify"]:
+                return successful_runner(args)
+            if args[3:6] == ["im", "chats", "get"]:
+                return {
+                    "returncode": 1,
+                    "stdout": "",
+                    "stderr": "bot is not in the chat",
+                }
+            raise AssertionError("send must not run after membership failure")
+
+        blocked = reply_lark_event_inbox(
+            project=project,
+            config_path=config,
+            message_id="om_review_2",
+            text="不会发送",
+            execute=True,
+            runner=missing_membership_runner,
+        )
+        assert blocked["status"] == "gate_required", blocked
+        assert blocked["blocker"] == "lark_inbox_reply_sender_not_in_configured_chat", (
+            blocked
+        )
+        assert not any("+messages-reply" in call for call in membership_calls), (
+            membership_calls
+        )
+
+        try:
+            reply_lark_event_inbox(
+                project=project,
+                config_path=config,
+                message_id="om_not_captured",
+                text="不应发送",
+                execute=True,
+                runner=lambda args: (_ for _ in ()).throw(AssertionError(args)),
+            )
+        except ValueError as exc:
+            assert "not captured" in str(exc)
+        else:
+            raise AssertionError("reply must stay bound to a captured inbox message")
+
         registry = project / ".loopx" / "registry.json"
         registry.write_text(
             json.dumps(
@@ -184,6 +316,37 @@ def main() -> None:
         discovered_payload = json.loads(discovered.stdout)
         assert discovered_payload["configured"] is True, discovered_payload
         assert discovered_payload["pending_count"] == 0, discovered_payload
+
+        reply_preview = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--registry",
+                str(registry),
+                "--format",
+                "json",
+                "lark-inbox",
+                "reply",
+                "--goal-id",
+                "lark-inbox-fixture",
+                "--project",
+                str(project),
+                "--message-id",
+                "om_review_2",
+                "--text",
+                "已记录并修正。",
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert reply_preview.returncode == 0, reply_preview.stderr
+        reply_preview_payload = json.loads(reply_preview.stdout)
+        assert reply_preview_payload["status"] == "preview_ready", reply_preview_payload
+        assert reply_preview_payload["private_sender_profile_captured"] is False
+        assert "project-review-bot" not in reply_preview.stdout
 
         outside = project / ".loopx" / "config" / "outside.json"
         outside.write_text(

--- a/loopx/capabilities/lark/__init__.py
+++ b/loopx/capabilities/lark/__init__.py
@@ -1,11 +1,12 @@
 """Lark/Feishu capability facade for presentation sinks."""
 
 from ...presentation.sinks.lark import explore_results, kanban, message_card
-from . import event_collector, event_inbox
+from . import event_collector, event_inbox, inbox_reply
 
 __all__ = [
     "event_collector",
     "event_inbox",
+    "inbox_reply",
     "explore_results",
     "kanban",
     "message_card",

--- a/loopx/capabilities/lark/event_inbox.py
+++ b/loopx/capabilities/lark/event_inbox.py
@@ -13,6 +13,8 @@ PROCESSED_SCHEMA_VERSION = "lark_event_inbox_processed_v0"
 CAPTURE_SCOPES = {"addressed_only", "configured_chat_all"}
 MESSAGE_ID_PATTERN = re.compile(r"om_[A-Za-z0-9_-]+")
 EVENT_ID_PATTERN = re.compile(r"[A-Za-z0-9:_-]{1,200}")
+SAFE_PROFILE_PATTERN = re.compile(r"[A-Za-z0-9._-]{1,100}")
+CHAT_ID_PATTERN = re.compile(r"oc_[A-Za-z0-9_-]+")
 
 
 def _safe_inbox_path(project: str | Path, raw_path: str) -> Path:
@@ -59,12 +61,42 @@ def load_lark_event_inbox_config(
         raise ValueError(
             "lark inbox capture_scope must be addressed_only or configured_chat_all"
         )
+    reply_payload = payload.get("reply")
+    if reply_payload is not None and not isinstance(reply_payload, Mapping):
+        raise ValueError("lark inbox reply config must be an object")
+    reply_payload = reply_payload if isinstance(reply_payload, Mapping) else {}
+    reply_enabled = reply_payload.get("enabled") is True
+    sender_profile = str(reply_payload.get("sender_profile") or "").strip()
+    sender_identity = str(reply_payload.get("sender_identity") or "").strip()
+    bot_display_name = " ".join(
+        str(reply_payload.get("bot_display_name") or "").split()
+    )[:100]
+    chat_id = str(reply_payload.get("chat_id") or "").strip()
+    if reply_enabled and (
+        capture_scope != "configured_chat_all"
+        or not SAFE_PROFILE_PATTERN.fullmatch(sender_profile)
+        or sender_profile.lower() == "default"
+        or sender_identity != "bot"
+        or not bot_display_name
+        or not CHAT_ID_PATTERN.fullmatch(chat_id)
+    ):
+        raise ValueError(
+            "enabled lark inbox reply requires configured_chat_all plus an explicit "
+            "non-default sender_profile, bot identity, bot_display_name, and chat_id"
+        )
     return {
         "enabled": enabled,
         "configured": True,
         "inbox_path": _safe_inbox_path(root, inbox_dir) if enabled else None,
         "capture_scope": capture_scope,
         "thread_complete": capture_scope == "configured_chat_all",
+        "reply": {
+            "enabled": reply_enabled,
+            "sender_profile": sender_profile,
+            "sender_identity": sender_identity,
+            "bot_display_name": bot_display_name,
+            "chat_id": chat_id,
+        },
     }
 
 

--- a/loopx/capabilities/lark/inbox_reply.py
+++ b/loopx/capabilities/lark/inbox_reply.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from .event_inbox import (
+    MESSAGE_ID_PATTERN,
+    _event_from_file,
+    load_lark_event_inbox_config,
+)
+
+
+CommandRunner = Callable[[Sequence[str]], Mapping[str, Any]]
+
+
+def _default_runner(args: Sequence[str]) -> Mapping[str, Any]:
+    result = subprocess.run(
+        list(args),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+    )
+    return {
+        "returncode": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+
+
+def _call(runner: CommandRunner, args: Sequence[str]) -> Mapping[str, Any]:
+    try:
+        return runner(args)
+    except (OSError, subprocess.SubprocessError):
+        return {"returncode": 1}
+
+
+def _json_object(value: Any) -> Mapping[str, Any]:
+    try:
+        payload = json.loads(str(value or ""))
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, Mapping) else {}
+
+
+def _message_id(value: Any) -> str | None:
+    if isinstance(value, Mapping):
+        candidate = value.get("message_id")
+        if isinstance(candidate, str) and MESSAGE_ID_PATTERN.fullmatch(candidate):
+            return candidate
+        return next(
+            (found for child in value.values() if (found := _message_id(child))),
+            None,
+        )
+    if isinstance(value, list):
+        return next(
+            (found for child in value if (found := _message_id(child))),
+            None,
+        )
+    return None
+
+
+def _result(
+    *,
+    status: str,
+    ok: bool,
+    execute: bool,
+    receipt: str | None,
+    identity_verified: bool = False,
+    membership_verified: bool = False,
+    write_performed: bool = False,
+    readback_performed: bool = False,
+    reply_verified: bool = False,
+    blocker: str | None = None,
+) -> dict[str, Any]:
+    packet: dict[str, Any] = {
+        "ok": ok,
+        "schema_version": "lark_event_inbox_reply_v0",
+        "status": status,
+        "execute": execute,
+        "idempotency_key": receipt,
+        "external_write_authority_asserted": execute,
+        "external_write_performed": write_performed,
+        "verification_performed": readback_performed,
+        "reply_verified": reply_verified,
+        "sender_identity_verified": identity_verified,
+        "sender_chat_membership_verified": membership_verified,
+        "private_sender_profile_captured": False,
+        "private_chat_id_captured": False,
+        "private_message_id_captured": False,
+        "private_reply_content_captured": False,
+        "raw_provider_payload_captured": False,
+    }
+    if blocker:
+        packet["blocker"] = blocker
+    return packet
+
+
+def reply_lark_event_inbox(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    message_id: str,
+    text: str,
+    execute: bool = False,
+    runner: CommandRunner = _default_runner,
+) -> dict[str, Any]:
+    """Reply in the source thread with the explicit inbox-configured bot."""
+
+    config = load_lark_event_inbox_config(project=project, config_path=config_path)
+    if not config["enabled"]:
+        raise ValueError("lark event inbox is not enabled")
+    source_message_id = str(message_id or "").strip()
+    if not MESSAGE_ID_PATTERN.fullmatch(source_message_id):
+        raise ValueError("lark inbox reply requires a valid message id")
+    inbox = config["inbox_path"]
+    source_captured = any(
+        event.get("message_id") == source_message_id
+        for path in (inbox.glob("*.json") if inbox.is_dir() else [])
+        if path.name != "processed.json"
+        if (event := _event_from_file(path)) is not None
+    )
+    if not source_captured:
+        raise ValueError(
+            "lark inbox reply source message is not captured by this inbox"
+        )
+    reply_text = " ".join(str(text or "").split())[:1200]
+    if not reply_text:
+        raise ValueError("lark inbox reply requires non-empty text")
+
+    reply_config = config["reply"]
+    if reply_config.get("enabled") is not True:
+        return _result(
+            status="gate_required",
+            ok=False,
+            execute=execute,
+            receipt=None,
+            blocker="lark_inbox_reply_sender_unconfigured",
+        )
+
+    profile = str(reply_config["sender_profile"])
+    chat_id = str(reply_config["chat_id"])
+    digest = hashlib.sha256(
+        json.dumps(
+            {"message_id": source_message_id, "text": reply_text},
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    receipt = f"sha256:{digest}"
+    if not execute:
+        return _result(
+            status="preview_ready",
+            ok=True,
+            execute=False,
+            receipt=receipt,
+        )
+
+    base = ["lark-cli", "--profile", profile]
+    auth = _call(runner, base + ["auth", "status", "--verify", "--json"])
+    identities = _json_object(auth.get("stdout")).get("identities")
+    identity = identities.get("bot", {}) if isinstance(identities, Mapping) else {}
+    identity_verified = bool(
+        auth.get("returncode") == 0
+        and isinstance(identity, Mapping)
+        and identity.get("available") is True
+        and identity.get("verified") is True
+        and str(identity.get("appName") or "") == reply_config["bot_display_name"]
+    )
+    if not identity_verified:
+        return _result(
+            status="gate_required",
+            ok=False,
+            execute=True,
+            receipt=receipt,
+            blocker="lark_inbox_reply_sender_identity_mismatch",
+        )
+
+    membership = _call(
+        runner,
+        base
+        + [
+            "im",
+            "chats",
+            "get",
+            "--chat-id",
+            chat_id,
+            "--as",
+            "bot",
+            "--format",
+            "json",
+        ],
+    )
+    if membership.get("returncode") != 0:
+        return _result(
+            status="gate_required",
+            ok=False,
+            execute=True,
+            receipt=receipt,
+            identity_verified=True,
+            blocker="lark_inbox_reply_sender_not_in_configured_chat",
+        )
+
+    send = _call(
+        runner,
+        base
+        + [
+            "im",
+            "+messages-reply",
+            "--message-id",
+            source_message_id,
+            "--text",
+            reply_text,
+            "--reply-in-thread",
+            "--idempotency-key",
+            f"loopx-{digest[:32]}",
+            "--as",
+            "bot",
+            "--format",
+            "json",
+        ],
+    )
+    if send.get("returncode") != 0:
+        return _result(
+            status="gate_required",
+            ok=False,
+            execute=True,
+            receipt=receipt,
+            identity_verified=True,
+            membership_verified=True,
+            blocker="lark_inbox_reply_provider_failed",
+        )
+
+    reply_message_id = _message_id(_json_object(send.get("stdout")))
+    if not reply_message_id:
+        return _result(
+            status="sent_unverified",
+            ok=False,
+            execute=True,
+            receipt=receipt,
+            identity_verified=True,
+            membership_verified=True,
+            write_performed=True,
+            blocker="lark_inbox_reply_not_verified",
+        )
+    readback = _call(
+        runner,
+        base
+        + [
+            "im",
+            "+messages-mget",
+            "--message-ids",
+            reply_message_id,
+            "--as",
+            "bot",
+            "--no-reactions",
+            "--format",
+            "json",
+        ],
+    )
+    readback_text = json.dumps(
+        _json_object(readback.get("stdout")), ensure_ascii=False, sort_keys=True
+    )
+    verified = bool(
+        readback.get("returncode") == 0
+        and reply_message_id in readback_text
+        and reply_text in readback_text
+    )
+    return _result(
+        status="sent_verified" if verified else "sent_unverified",
+        ok=verified,
+        execute=True,
+        receipt=receipt,
+        identity_verified=True,
+        membership_verified=True,
+        write_performed=True,
+        readback_performed=True,
+        reply_verified=verified,
+        blocker=None if verified else "lark_inbox_reply_not_verified",
+    )

--- a/loopx/cli_commands/lark_inbox.py
+++ b/loopx/cli_commands/lark_inbox.py
@@ -11,6 +11,7 @@ from ..capabilities.lark.event_inbox import (
     ingest_lark_event_inbox,
     inspect_lark_event_inbox,
 )
+from ..capabilities.lark.inbox_reply import reply_lark_event_inbox
 from ..capabilities.lark.event_collector import (
     inspect_lark_event_collector,
     install_lark_event_collector,
@@ -28,9 +29,7 @@ def _goal_inbox_config(registry_path: Path, goal_id: str) -> str | None:
     if goal is None:
         raise ValueError(f"goal_id not found in registry: {goal_id}")
     control_plane = (
-        goal.get("control_plane")
-        if isinstance(goal.get("control_plane"), dict)
-        else {}
+        goal.get("control_plane") if isinstance(goal.get("control_plane"), dict) else {}
     )
     inbox = (
         control_plane.get("lark_event_inbox")
@@ -78,6 +77,20 @@ def register_lark_inbox_commands(
     ack.add_argument("--goal-id")
     ack.add_argument("--message-id", action="append", required=True)
     ack.add_argument("--execute", action="store_true")
+    reply = sub.add_parser(
+        "reply",
+        help=(
+            "Reply once in the source thread with the inbox-configured bot profile; "
+            "never falls back to the default app."
+        ),
+    )
+    add_subcommand_format(reply)
+    reply.add_argument("--project", default=".")
+    reply.add_argument("--config")
+    reply.add_argument("--goal-id")
+    reply.add_argument("--message-id", required=True)
+    reply.add_argument("--text", required=True)
+    reply.add_argument("--execute", action="store_true")
     ingest = sub.add_parser(
         "ingest",
         help=(
@@ -183,6 +196,17 @@ def handle_lark_inbox_command(
                 project=args.project,
                 config_path=config_path,
                 message_ids=args.message_id,
+                execute=args.execute,
+            )
+        elif args.lark_inbox_command == "reply":
+            config_path = _inbox_config(args, registry_path)
+            if config_path is None:
+                raise ValueError("goal does not configure a Lark event inbox")
+            payload = reply_lark_event_inbox(
+                project=args.project,
+                config_path=config_path,
+                message_id=args.message_id,
+                text=args.text,
                 execute=args.execute,
             )
         elif args.lark_inbox_command == "ingest":


### PR DESCRIPTION
## Summary

- add an opt-in generic `lark-inbox reply` boundary for direct source-thread answers
- require an explicit non-default bot profile, expected app identity, and configured-chat access before send
- bind replies to captured inbox messages, use semantic idempotency, and verify the created reply through the same profile
- keep ordinary chatter, reviewer notifications, and other outbound authority independent

## Commit grouping

1. Runtime/API: config validation, sender identity and chat-membership checks, reply/send/readback CLI.
2. Public docs and focused smoke: preview, success, missing-membership, uncaptured-message, no-private-field, and CLI projection coverage.

## Validation

- `uv run --with ruff ruff check ...`
- `python3 examples/lark-event-collector-lifecycle-smoke.py`
- `python3 examples/lark-event-inbox-smoke.py`
- `python3 -m loopx.cli --format json canary premerge --from-git-diff --tier standard --no-progress`
  - 4 direct checks passed
  - 12 catalog/risk/public-boundary checks passed
  - 0 failures, warnings, skips, or manual holds
  - gate: `self_merge_allowed=true`

## Boundary and risk

- local profile names, chat IDs, message IDs, reply text, and provider payloads are never returned in public result packets
- the command never falls back to the default app
- no credentials, local state, raw logs, or private destination values are committed
- residual risk is limited to provider CLI response-shape drift; malformed or unverifiable responses fail closed before ACK