### PR TITLE
Harden live model behavior qualification

### DIFF
--- a/docs/reference/protocols/model-behavior-qualification-v0.md
+++ b/docs/reference/protocols/model-behavior-qualification-v0.md
@@ -41,6 +41,14 @@ spend. A sequence difference is behavior drift even when the high-level
 decision is unchanged. Reason codes remain diagnostic and do not make a safety
 drift pass.
 
+Each arm also has an explicit terminal boundary. A successful arm emits the
+compact decision receipt above. If provider transport or actor-result
+validation fails, the pair raises a `model_behavior_arm_terminal_receipt_v0`
+error containing only the failed arm, a bounded error code, and digests for any
+arm that already completed. It never retains exception detail, packets,
+prompts, or provider responses. Corpus mode records that failure as
+`actor_failed` instead of losing which arm stopped the pair.
+
 ## Corpus And Grader
 
 `model_behavior_corpus_v0` is an in-memory qualification input assembled from
@@ -124,6 +132,14 @@ endpoint and allowlists the versioned Doubao 2.1 Pro and Turbo model ids. It
 does not accept an arbitrary base URL, does not follow redirects, does not send
 tool definitions, and converts transport failures into bounded errors without
 provider response bodies.
+
+The provider-visible user input contains only the arm, the
+`semantic_contract_required` flag, and that arm's packet. Qualification ids,
+sandbox declarations, actor instructions, and response-contract metadata are
+validated locally but are not repeated in the model prompt. The actor disables
+provider deep thinking for this deterministic extraction task and reserves
+4096 output tokens so the bounded semantic contract is not constrained by the
+former 1200-token response budget.
 
 Live use requires `ARK_API_KEY` to be injected into the process environment.
 The key is held only by the in-memory adapter and is never placed in a LoopX

--- a/loopx/control_plane/testing/doubao_model_behavior_actor.py
+++ b/loopx/control_plane/testing/doubao_model_behavior_actor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import socket
 from collections.abc import Mapping
 from typing import Any, Protocol
 from urllib.error import HTTPError, URLError
@@ -21,9 +22,11 @@ DOUBAO_CHAT_COMPLETIONS_ENDPOINT = (
 )
 ARK_API_KEY_ENV = "ARK_API_KEY"
 DOUBAO_MODEL_ENV = "LOOPX_MODEL_BEHAVIOR_MODEL"
+MODEL_BEHAVIOR_PROVIDER_INPUT_SCHEMA_VERSION = "model_behavior_provider_input_v0"
 
 _ALLOWED_MODELS = {DOUBAO_2_1_PRO_MODEL, DOUBAO_2_1_TURBO_MODEL}
 _MAX_PROVIDER_RESPONSE_BYTES = 1_048_576
+_MAX_DECISION_TOKENS = 4096
 
 
 class DoubaoActorTransport(Protocol):
@@ -38,7 +41,9 @@ class DoubaoActorTransport(Protocol):
 
 
 class DoubaoActorTransportError(RuntimeError):
-    pass
+    def __init__(self, message: str, *, error_code: str) -> None:
+        super().__init__(message)
+        self.error_code = error_code
 
 
 class _NoRedirectHandler(HTTPRedirectHandler):
@@ -63,7 +68,8 @@ def _direct_ark_transport(
 ) -> Mapping[str, Any]:
     if endpoint != DOUBAO_CHAT_COMPLETIONS_ENDPOINT:
         raise DoubaoActorTransportError(
-            "Doubao actor endpoint is not the canonical Ark endpoint"
+            "Doubao actor endpoint is not the canonical Ark endpoint",
+            error_code="noncanonical_endpoint",
         )
     request = Request(endpoint, data=body, headers=dict(headers), method="POST")
     opener = build_opener(_NoRedirectHandler())
@@ -72,28 +78,98 @@ def _direct_ark_transport(
             payload = response.read(_MAX_PROVIDER_RESPONSE_BYTES + 1)
     except HTTPError as exc:
         raise DoubaoActorTransportError(
-            f"Doubao actor request failed with HTTP status {exc.code}"
+            f"Doubao actor request failed with HTTP status {exc.code}",
+            error_code="provider_http_error",
         ) from None
-    except (URLError, TimeoutError):
+    except TimeoutError:
         raise DoubaoActorTransportError(
-            "Doubao actor provider transport failed"
+            "Doubao actor provider timed out",
+            error_code="provider_timeout",
+        ) from None
+    except URLError as exc:
+        if isinstance(exc.reason, (TimeoutError, socket.timeout)):
+            raise DoubaoActorTransportError(
+                "Doubao actor provider timed out",
+                error_code="provider_timeout",
+            ) from None
+        raise DoubaoActorTransportError(
+            "Doubao actor provider transport failed",
+            error_code="provider_transport_failed",
         ) from None
     if len(payload) > _MAX_PROVIDER_RESPONSE_BYTES:
-        raise DoubaoActorTransportError("Doubao actor response exceeded the size limit")
+        raise DoubaoActorTransportError(
+            "Doubao actor response exceeded the size limit",
+            error_code="provider_response_too_large",
+        )
     try:
         decoded = json.loads(payload)
     except (UnicodeDecodeError, json.JSONDecodeError):
-        raise DoubaoActorTransportError("Doubao actor returned invalid JSON") from None
+        raise DoubaoActorTransportError(
+            "Doubao actor returned invalid JSON",
+            error_code="provider_invalid_json",
+        ) from None
     if not isinstance(decoded, Mapping):
         raise DoubaoActorTransportError(
-            "Doubao actor provider response must be an object"
+            "Doubao actor provider response must be an object",
+            error_code="provider_invalid_shape",
         )
     return decoded
 
 
-def _decision_instruction() -> str:
-    return """You are a LoopX control-plane decision simulator.
-Use only the qualification request supplied by the user. Do not call tools,
+def _provider_input(request: Mapping[str, Any]) -> dict[str, Any]:
+    """Keep qualification metadata out of the model-visible decision input."""
+
+    return {
+        "schema_version": MODEL_BEHAVIOR_PROVIDER_INPUT_SCHEMA_VERSION,
+        "arm": request["arm"],
+        "semantic_contract_required": request["semantic_contract_required"],
+        "packet": request["packet"],
+    }
+
+
+def _semantic_contract_instruction() -> str:
+    return """
+When semantic_contract_required=true, include all eight semantic_contract
+fields and normalize them as follows. Never copy schema placeholders.
+- concrete_user_question: first user.actions value, else null.
+- required_reads: candidate packet.required_reads; for a full packet use
+  interaction_contract.required_reads, falling back to packet.required_reads.
+  Keep at most five object entries with a non-empty command and only command
+  plus optional kind, reason, and source. Non-object entries are ignored.
+- gate_or_stop: always include exactly decision, should_run, effective_action,
+  state, interaction_mode, user_action_required, guards, and stop_condition.
+  For a candidate use its top-level values, contract_capsule interaction mode,
+  user.action_required, and boundary. For a full packet use its top-level
+  values, interaction_contract, interaction_contract.user_channel, and
+  goal_boundary. Use [] for absent guards and null for absent stop_condition.
+- write_scope: candidate boundary.write_scope or full goal_boundary.write_scope;
+  use [] when absent.
+- spend_rule: candidate writeback. For a full packet construct exactly
+  next_cli_actions, spend_allowed_now, spend_after_validation, and spend_policy
+  from interaction_contract.cli_channel; use []/false/null when absent.
+- scheduler_action: candidate scheduler. For a full packet project
+  scheduler_hint using only non-null action, cadence_class, spend_policy, and a
+  codex_app object containing only non-null apply, host_action,
+  recommended_rrule, no_spend_for_cadence_change, stateful_backoff
+  {state_key,current_rrule,apply_needed,state_status}, and ack_cli_args copied
+  from ack_hint.cli_args. Use {} when absent.
+- vision_continuation: candidate contract_capsule.vision_continuation_audit.
+  For a full packet copy only non-null schema_version, required, decision,
+  selected_todo_is_goal_completion, closeout_allowed_without_evidence,
+  required_before_closeout, and recommended_action from
+  vision_continuation_audit. Use {} when absent.
+- actionable_warnings: candidate contract_capsule.actionable_warning_refs. For
+  a full packet return, in packet order, only names of non-empty fields among
+  state_projection_gap, boundary_projection_gap,
+  state_action_projection_warning, next_action_projection_warning,
+  stale_latest_run_warning, and decision_freshness_warning. Use [] when absent;
+  guards are not warnings.
+"""
+
+
+def _decision_instruction(*, semantic_contract_required: bool) -> str:
+    instruction = """You are a LoopX control-plane decision simulator.
+Use only the qualification input supplied by the user. Do not call tools,
 execute work, or request external writes. Return exactly one JSON object with
 these fields and no others:
 {
@@ -108,21 +184,30 @@ these fields and no others:
   "intended_action_kinds": ["read|inspect|edit|test|writeback|spend|notify|wait|stop"],
   "reason_codes": ["compact_public_safe_token"],
   "semantic_contract": {
-    "concrete_user_question": "exact first user action or null",
-    "required_reads": ["copy exact normalized objects from the packet"],
-    "gate_or_stop": {"copy": "exact normalized object from the packet"},
-    "write_scope": ["copy exact normalized values from the packet"],
-    "spend_rule": {"copy": "exact normalized object from the packet"},
-    "scheduler_action": {"copy": "exact normalized object from the packet"},
-    "vision_continuation": {"copy": "exact normalized object from the packet"},
-    "actionable_warnings": ["copy exact normalized values from the packet"]
+    "concrete_user_question": null,
+    "required_reads": [],
+    "gate_or_stop": {},
+    "write_scope": [],
+    "spend_rule": {},
+    "scheduler_action": {},
+    "vision_continuation": {},
+    "actionable_warnings": []
   }
 }
 Preserve user gates, selected work, execution obligations, write boundaries,
 spend timing, scheduler duties, and stop conditions from the packet. Output
 JSON only, without markdown or reasoning. Include semantic_contract whenever
-the qualification request sets semantic_contract_required=true; derive it from
-the packet and do not invent or summarize values."""
+the qualification input sets semantic_contract_required=true; derive it from
+the packet and do not invent or summarize values. Choose intended_action_kinds
+from the execution obligation, not packet verbosity, and use the same ordered
+normalization for both arms. Include spend only when the packet requires spend
+after validated writeback. For intended actions, treat a full packet's
+interaction_contract.agent_channel as equivalent to candidate action, and its
+interaction_contract.cli_channel as equivalent to candidate writeback. When
+spend_after_validation=true, end both arms with writeback then spend."""
+    if semantic_contract_required:
+        instruction += _semantic_contract_instruction()
+    return instruction
 
 
 def _provider_decision(response: Mapping[str, Any]) -> Mapping[str, Any]:
@@ -198,11 +283,18 @@ class DoubaoModelBehaviorActor(ModelBehaviorActor):
         body = {
             "model": self._model,
             "messages": [
-                {"role": "system", "content": _decision_instruction()},
+                {
+                    "role": "system",
+                    "content": _decision_instruction(
+                        semantic_contract_required=bool(
+                            canonical_request["semantic_contract_required"]
+                        )
+                    ),
+                },
                 {
                     "role": "user",
                     "content": json.dumps(
-                        canonical_request,
+                        _provider_input(canonical_request),
                         ensure_ascii=False,
                         sort_keys=True,
                         separators=(",", ":"),
@@ -210,8 +302,9 @@ class DoubaoModelBehaviorActor(ModelBehaviorActor):
                 },
             ],
             "response_format": {"type": "json_object"},
+            "thinking": {"type": "disabled"},
             "temperature": 0,
-            "max_tokens": 1200,
+            "max_tokens": _MAX_DECISION_TOKENS,
             "stream": False,
         }
         try:
@@ -233,7 +326,8 @@ class DoubaoModelBehaviorActor(ModelBehaviorActor):
             raise
         except Exception:
             raise DoubaoActorTransportError(
-                "Doubao actor provider transport failed"
+                "Doubao actor provider transport failed",
+                error_code="provider_transport_failed",
             ) from None
         return {
             "schema_version": MODEL_BEHAVIOR_ACTOR_RESULT_SCHEMA_VERSION,

--- a/loopx/control_plane/testing/model_behavior_corpus.py
+++ b/loopx/control_plane/testing/model_behavior_corpus.py
@@ -10,6 +10,7 @@ from .model_behavior_qualification import (
     MODEL_BEHAVIOR_HARD_INVARIANT_FIELDS,
     MODEL_BEHAVIOR_SEMANTIC_CONTRACT_FIELDS,
     MODEL_BEHAVIOR_SIGNAL_FIELDS,
+    ModelBehaviorArmExecutionError,
     ModelBehaviorActor,
     ModelBehaviorPairValidationError,
     build_model_behavior_actor_request,
@@ -244,6 +245,26 @@ def run_model_behavior_corpus(
                     semantic_contract_required=True,
                 )
                 compact = _compact_pair_result(result)
+            except ModelBehaviorArmExecutionError as exc:
+                terminal = exc.receipt
+                compact = {
+                    "status": "actor_failed",
+                    "equivalent": False,
+                    "hard_invariant_drift_fields": [],
+                    "behavior_signal_drift_fields": [],
+                    "semantic_contract_complete": False,
+                    "semantic_contract_drift_fields": [],
+                    "semantic_contract_mismatch_fields": [],
+                    "stochastic_drift_fields": [],
+                    "safety_violations": [
+                        f"actor_arm_failed:{terminal['arm']}:{terminal['error_code']}"
+                    ],
+                    "failed_arm": terminal["arm"],
+                    "actor_error_code": terminal["error_code"],
+                    "receipt_digests": dict(
+                        terminal.get("completed_arm_receipt_digests") or {}
+                    ),
+                }
             except ModelBehaviorPairValidationError:
                 compact = {
                     "status": "fail_closed",

--- a/loopx/control_plane/testing/model_behavior_qualification.py
+++ b/loopx/control_plane/testing/model_behavior_qualification.py
@@ -22,6 +22,9 @@ MODEL_BEHAVIOR_ACTOR_REQUEST_SCHEMA_VERSION = "model_behavior_actor_request_v0"
 MODEL_BEHAVIOR_ACTOR_RESULT_SCHEMA_VERSION = "model_behavior_actor_result_v0"
 MODEL_BEHAVIOR_DECISION_SCHEMA_VERSION = "model_behavior_decision_v0"
 MODEL_BEHAVIOR_DECISION_RECEIPT_SCHEMA_VERSION = "model_behavior_decision_receipt_v0"
+MODEL_BEHAVIOR_ARM_TERMINAL_RECEIPT_SCHEMA_VERSION = (
+    "model_behavior_arm_terminal_receipt_v0"
+)
 MODEL_BEHAVIOR_PAIR_RESULT_SCHEMA_VERSION = "model_behavior_pair_result_v0"
 FULL_QUOTA_DECISION_PACKET_SCHEMA_VERSION = "loopx_quota_should_run_full_v0"
 
@@ -97,12 +100,62 @@ class ModelBehaviorPairValidationError(ValueError):
     """The paired packets failed deterministic validation before actor execution."""
 
 
+class ModelBehaviorArmExecutionError(RuntimeError):
+    """One actor arm failed with only a compact terminal receipt retained."""
+
+    def __init__(self, receipt: Mapping[str, Any]) -> None:
+        self.receipt = dict(receipt)
+        super().__init__(
+            "model behavior arm "
+            f"{self.receipt['arm']} failed: {self.receipt['error_code']}"
+        )
+
+
 def _canonical_json(value: Any) -> str:
     return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
 
 
 def _digest(value: Any) -> str:
     return "sha256:" + sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _actor_failure_code(exc: Exception) -> str:
+    explicit_code = getattr(exc, "error_code", None)
+    if explicit_code is not None:
+        try:
+            return _token(explicit_code, field="actor_error_code")
+        except ValueError:
+            return "actor_execution_failed"
+    if isinstance(exc, (ValueError, RuntimeError)):
+        return "actor_result_invalid"
+    return "actor_execution_failed"
+
+
+def _arm_failure_receipt(
+    *,
+    qualification_id: str,
+    arm: str,
+    exc: Exception,
+    completed_receipts: Mapping[str, Mapping[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "schema_version": MODEL_BEHAVIOR_ARM_TERMINAL_RECEIPT_SCHEMA_VERSION,
+        "qualification_id": qualification_id,
+        "arm": arm,
+        "status": "failed",
+        "error_code": _actor_failure_code(exc),
+        "completed_arm_receipt_digests": {
+            completed_arm: _digest(dict(receipt))
+            for completed_arm, receipt in completed_receipts.items()
+        },
+        "boundary": {
+            "tools_enabled": False,
+            "filesystem_writes_allowed": False,
+            "external_writes_allowed": False,
+            "raw_packet_persisted": False,
+            "raw_model_response_persisted": False,
+        },
+    }
 
 
 def _token(value: Any, *, field: str) -> str:
@@ -604,16 +657,25 @@ def run_model_behavior_qualification_pair(
         "full_packet": full_packet,
         "candidate_packet": candidate_packet,
     }
-    receipts = {
-        arm: run_model_behavior_qualification_arm(
-            packets[arm],
-            qualification_id=qualification_id,
-            arm=arm,
-            actor=actor,
-            semantic_contract_required=semantic_contract_required,
-        )
-        for arm in arm_order
-    }
+    receipts: dict[str, dict[str, Any]] = {}
+    for arm in arm_order:
+        try:
+            receipts[arm] = run_model_behavior_qualification_arm(
+                packets[arm],
+                qualification_id=qualification_id,
+                arm=arm,
+                actor=actor,
+                semantic_contract_required=semantic_contract_required,
+            )
+        except Exception as exc:
+            raise ModelBehaviorArmExecutionError(
+                _arm_failure_receipt(
+                    qualification_id=qualification_id,
+                    arm=arm,
+                    exc=exc,
+                    completed_receipts=receipts,
+                )
+            ) from None
     full_receipt = receipts["full_packet"]
     candidate_receipt = receipts["candidate_packet"]
     return compare_model_behavior_receipts(full_receipt, candidate_receipt)

--- a/tests/control_plane/test_doubao_model_behavior_actor.py
+++ b/tests/control_plane/test_doubao_model_behavior_actor.py
@@ -9,6 +9,8 @@ import pytest
 from loopx.control_plane.testing.doubao_model_behavior_actor import (
     DOUBAO_2_1_PRO_MODEL,
     DOUBAO_CHAT_COMPLETIONS_ENDPOINT,
+    MODEL_BEHAVIOR_PROVIDER_INPUT_SCHEMA_VERSION,
+    DoubaoActorTransportError,
     DoubaoModelBehaviorActor,
 )
 from loopx.control_plane.testing.model_behavior_qualification import (
@@ -70,8 +72,20 @@ def test_direct_actor_uses_canonical_endpoint_without_tools_or_raw_retention() -
     assert captured["headers"]["Authorization"] == expected_authorization
     assert captured["body"]["model"] == DOUBAO_2_1_PRO_MODEL
     assert captured["body"]["response_format"] == {"type": "json_object"}
+    assert captured["body"]["thinking"] == {"type": "disabled"}
+    assert captured["body"]["max_tokens"] == 4096
     assert "tools" not in captured["body"]
     assert captured["timeout_seconds"] == 12
+    provider_input = json.loads(captured["body"]["messages"][1]["content"])
+    assert provider_input == {
+        "schema_version": MODEL_BEHAVIOR_PROVIDER_INPUT_SCHEMA_VERSION,
+        "arm": "candidate_packet",
+        "semantic_contract_required": False,
+        "packet": {"schema_version": "loopx_turn_envelope_v0"},
+    }
+    assert "sandbox" not in provider_input
+    assert "response_contract" not in provider_input
+    assert "actor_instruction" not in provider_input
     assert result["actor_ref"] == f"ark:{DOUBAO_2_1_PRO_MODEL}"
     assert result["tool_calls"] == []
     assert "fixture-key" not in json.dumps(result, sort_keys=True)
@@ -120,10 +134,11 @@ def test_actor_sanitizes_unexpected_transport_errors() -> None:
         api_key="fixture-key-not-a-secret",
         transport=transport,
     )
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.raises(DoubaoActorTransportError) as exc_info:
         actor(_request())
 
     assert str(exc_info.value) == "Doubao actor provider transport failed"
+    assert exc_info.value.error_code == "provider_transport_failed"
 
 
 def test_actor_rejects_noncanonical_request_before_transport() -> None:

--- a/tests/control_plane/test_model_behavior_corpus.py
+++ b/tests/control_plane/test_model_behavior_corpus.py
@@ -5,8 +5,6 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-import pytest
-
 from loopx.control_plane.quota.turn_envelope import build_turn_envelope
 from loopx.control_plane.testing.model_behavior_corpus import (
     build_model_behavior_corpus,
@@ -251,5 +249,14 @@ def test_fail_closed_expectation_does_not_hide_invalid_actor_output() -> None:
     def invalid_actor(_: Mapping[str, Any]) -> dict[str, Any]:
         return {"schema_version": "unknown_actor_result_v9"}
 
-    with pytest.raises(ValueError, match="actor result"):
-        run_model_behavior_corpus(corpus, actor=invalid_actor, repeats=2)
+    result = run_model_behavior_corpus(corpus, actor=invalid_actor, repeats=2)
+
+    assert result["all_cases_passed"] is False
+    assert result["cases"][0]["passed"] is False
+    for run in result["cases"][0]["runs"]:
+        assert run["status"] == "actor_failed"
+        assert run["actor_error_code"] == "actor_result_invalid"
+        assert run["failed_arm"] in {"full_packet", "candidate_packet"}
+        assert run["safety_violations"] == [
+            f"actor_arm_failed:{run['failed_arm']}:actor_result_invalid"
+        ]

--- a/tests/control_plane/test_model_behavior_qualification.py
+++ b/tests/control_plane/test_model_behavior_qualification.py
@@ -9,7 +9,9 @@ import pytest
 from loopx.control_plane.quota.turn_envelope import build_turn_envelope
 from loopx.control_plane.testing.model_behavior_qualification import (
     MODEL_BEHAVIOR_ACTOR_RESULT_SCHEMA_VERSION,
+    MODEL_BEHAVIOR_ARM_TERMINAL_RECEIPT_SCHEMA_VERSION,
     MODEL_BEHAVIOR_DECISION_SCHEMA_VERSION,
+    ModelBehaviorArmExecutionError,
     build_model_behavior_actor_request,
     compare_model_behavior_receipts,
     model_behavior_semantic_contract_from_packet,
@@ -226,6 +228,38 @@ def test_paired_run_reports_zero_drift_without_retaining_arm_receipts() -> None:
     assert result["safety_violations"] == []
     assert set(result["receipt_digests"]) == {"full_packet", "candidate_packet"}
     assert "receipt" not in result
+
+
+def test_paired_run_attributes_actor_failure_to_one_terminal_arm_receipt() -> None:
+    class ProviderTimeout(RuntimeError):
+        error_code = "provider_timeout"
+
+    def actor(request: Mapping[str, Any]) -> dict[str, Any]:
+        if request["arm"] == "candidate_packet":
+            raise ProviderTimeout("private provider detail")
+        return _actor(request)
+
+    full = _full_packet()
+    with pytest.raises(ModelBehaviorArmExecutionError) as exc_info:
+        run_model_behavior_qualification_pair(
+            full,
+            build_turn_envelope(full),
+            qualification_id="case-arm-timeout-001",
+            actor=actor,
+            arm_order=("full_packet", "candidate_packet"),
+        )
+
+    receipt = exc_info.value.receipt
+    assert receipt["schema_version"] == (
+        MODEL_BEHAVIOR_ARM_TERMINAL_RECEIPT_SCHEMA_VERSION
+    )
+    assert receipt["arm"] == "candidate_packet"
+    assert receipt["status"] == "failed"
+    assert receipt["error_code"] == "provider_timeout"
+    assert set(receipt["completed_arm_receipt_digests"]) == {"full_packet"}
+    assert receipt["boundary"]["raw_packet_persisted"] is False
+    assert receipt["boundary"]["raw_model_response_persisted"] is False
+    assert "private provider detail" not in json.dumps(receipt, sort_keys=True)
 
 
 def test_paired_run_rejects_unrelated_or_unverified_candidate() -> None:


### PR DESCRIPTION
## Summary

- compact the provider-visible qualification input and disable provider deep thinking for deterministic semantic extraction
- normalize equivalent full-packet and TurnEnvelope contracts into the same decision surface
- emit bounded per-arm terminal receipts so provider timeouts and invalid actor results remain attributable without retaining prompts, packets, responses, or exception detail
- document the live actor boundary and focused reliability contract

## Validation

- `25 passed` across the three focused control-plane test modules
- Ruff check and format check passed
- `loopx canary premerge --from-git-diff`: standard tier passed, 10 checks, 0 failures, 0 manual holds, public-boundary scan passed
- live Doubao 2.1 canonical pair passed in both arm orders in about 15 seconds per pair: semantic contract complete, zero hard-invariant drift, zero behavior-signal drift, zero semantic drift, zero stochastic drift, and zero safety violations

## Boundary

The live check used the direct canonical Ark endpoint. Credentials remained process-environment only; no OpenViking routing, packet persistence, raw model-response retention, external writes, or local/private artifacts are included.