### PR TITLE
Keep model qualification on canonical selected work

### DIFF
--- a/docs/reference/protocols/model-behavior-qualification-v0.md
+++ b/docs/reference/protocols/model-behavior-qualification-v0.md
@@ -133,13 +133,21 @@ does not accept an arbitrary base URL, does not follow redirects, does not send
 tool definitions, and converts transport failures into bounded errors without
 provider response bodies.
 
-The provider-visible user input contains only the arm, the
-`semantic_contract_required` flag, and that arm's packet. Qualification ids,
-sandbox declarations, actor instructions, and response-contract metadata are
-validated locally but are not repeated in the model prompt. The actor disables
-provider deep thinking for this deterministic extraction task and reserves
-4096 output tokens so the bounded semantic contract is not constrained by the
-former 1200-token response budget.
+The provider-visible user input contains only the arm, a locally derived
+`canonical_selected_todo_id`, the `semantic_contract_required` flag, and that
+arm's packet. Qualification ids, sandbox declarations, actor instructions, and
+response-contract metadata are validated locally but are not repeated in the
+model prompt. The actor disables provider deep thinking for this deterministic
+extraction task and reserves 4096 output tokens so the bounded semantic
+contract is not constrained by the former 1200-token response budget.
+
+The actor derives `canonical_selected_todo_id` independently for each arm from
+the canonical selected-todo field: top-level `selected_todo.todo_id` in a full
+packet or `action.selected_todo.todo_id` in a TurnEnvelope. The model must copy
+that value into `selected_todo_id`, including `null`; todo ids found only in
+summaries, diagnostics, handoffs, history, or other cold-path references are
+not selected work. The pair's pre-provider action-signature check still fails
+closed when the candidate actually omits or changes selected work.
 
 Live use requires `ARK_API_KEY` to be injected into the process environment.
 The key is held only by the in-memory adapter and is never placed in a LoopX

--- a/loopx/control_plane/testing/doubao_model_behavior_actor.py
+++ b/loopx/control_plane/testing/doubao_model_behavior_actor.py
@@ -8,6 +8,10 @@ from typing import Any, Protocol
 from urllib.error import HTTPError, URLError
 from urllib.request import HTTPRedirectHandler, Request, build_opener
 
+from ..quota.turn_envelope import (
+    quota_action_signature_document,
+    turn_envelope_action_signature_document,
+)
 from .model_behavior_qualification import (
     MODEL_BEHAVIOR_ACTOR_RESULT_SCHEMA_VERSION,
     ModelBehaviorActor,
@@ -119,11 +123,20 @@ def _direct_ark_transport(
 def _provider_input(request: Mapping[str, Any]) -> dict[str, Any]:
     """Keep qualification metadata out of the model-visible decision input."""
 
+    arm = str(request["arm"])
+    packet = request["packet"]
+    signature = (
+        quota_action_signature_document(packet)
+        if arm == "full_packet"
+        else turn_envelope_action_signature_document(packet)
+    )
+    selected_todo = dict(dict(signature.get("action") or {}).get("selected_todo") or {})
     return {
         "schema_version": MODEL_BEHAVIOR_PROVIDER_INPUT_SCHEMA_VERSION,
-        "arm": request["arm"],
+        "arm": arm,
+        "canonical_selected_todo_id": selected_todo.get("todo_id"),
         "semantic_contract_required": request["semantic_contract_required"],
-        "packet": request["packet"],
+        "packet": packet,
     }
 
 
@@ -198,13 +211,17 @@ Preserve user gates, selected work, execution obligations, write boundaries,
 spend timing, scheduler duties, and stop conditions from the packet. Output
 JSON only, without markdown or reasoning. Include semantic_contract whenever
 the qualification input sets semantic_contract_required=true; derive it from
-the packet and do not invent or summarize values. Choose intended_action_kinds
-from the execution obligation, not packet verbosity, and use the same ordered
-normalization for both arms. Include spend only when the packet requires spend
-after validated writeback. For intended actions, treat a full packet's
-interaction_contract.agent_channel as equivalent to candidate action, and its
-interaction_contract.cli_channel as equivalent to candidate writeback. When
-spend_after_validation=true, end both arms with writeback then spend."""
+the packet and do not invent or summarize values. Copy
+canonical_selected_todo_id exactly into selected_todo_id, including null; it
+was derived locally from this arm's canonical action signature. Never infer a
+todo id from summaries, diagnostics, handoffs, history, or other cold-path
+references. Choose intended_action_kinds from the execution obligation, not
+packet verbosity, and use the same ordered normalization for both arms.
+Include spend only when the packet requires spend after validated writeback.
+For intended actions, treat a full packet's interaction_contract.agent_channel
+as equivalent to candidate action, and its interaction_contract.cli_channel as
+equivalent to candidate writeback. When spend_after_validation=true, end both
+arms with writeback then spend."""
     if semantic_contract_required:
         instruction += _semantic_contract_instruction()
     return instruction

--- a/tests/control_plane/test_doubao_model_behavior_actor.py
+++ b/tests/control_plane/test_doubao_model_behavior_actor.py
@@ -12,6 +12,7 @@ from loopx.control_plane.testing.doubao_model_behavior_actor import (
     MODEL_BEHAVIOR_PROVIDER_INPUT_SCHEMA_VERSION,
     DoubaoActorTransportError,
     DoubaoModelBehaviorActor,
+    _provider_input,
 )
 from loopx.control_plane.testing.model_behavior_qualification import (
     build_model_behavior_actor_request,
@@ -21,7 +22,10 @@ from loopx.control_plane.testing.model_behavior_qualification import (
 
 def _request() -> dict[str, Any]:
     return build_model_behavior_actor_request(
-        {"schema_version": "loopx_turn_envelope_v0"},
+        {
+            "schema_version": "loopx_turn_envelope_v0",
+            "action": {"selected_todo": {"todo_id": "todo_fixture001"}},
+        },
         qualification_id="case-direct-doubao-001",
         arm="candidate_packet",
     )
@@ -40,6 +44,32 @@ def _decision() -> dict[str, Any]:
         "intended_action_kinds": ["inspect", "test", "writeback"],
         "reason_codes": ["bounded_delivery"],
     }
+
+
+def test_provider_input_does_not_select_a_diagnostic_todo() -> None:
+    request = build_model_behavior_actor_request(
+        {
+            "mode": "should-run",
+            "goal_id": "fixture-goal",
+            "interaction_contract": {},
+            "selected_todo": None,
+            "agent_todo_summary": {
+                "first_executable_items": [{"todo_id": "todo_diagnostic001"}]
+            },
+        },
+        qualification_id="case-diagnostic-todo-001",
+        arm="full_packet",
+    )
+
+    provider_input = _provider_input(request)
+
+    assert provider_input["canonical_selected_todo_id"] is None
+    assert (
+        provider_input["packet"]["agent_todo_summary"]["first_executable_items"][0][
+            "todo_id"
+        ]
+        == "todo_diagnostic001"
+    )
 
 
 def test_direct_actor_uses_canonical_endpoint_without_tools_or_raw_retention() -> None:
@@ -76,12 +106,20 @@ def test_direct_actor_uses_canonical_endpoint_without_tools_or_raw_retention() -
     assert captured["body"]["max_tokens"] == 4096
     assert "tools" not in captured["body"]
     assert captured["timeout_seconds"] == 12
+    system_instruction = captured["body"]["messages"][0]["content"]
+    compact_instruction = " ".join(system_instruction.lower().split())
+    assert "canonical_selected_todo_id exactly" in compact_instruction
+    assert "never infer a todo id from summaries" in compact_instruction
     provider_input = json.loads(captured["body"]["messages"][1]["content"])
     assert provider_input == {
         "schema_version": MODEL_BEHAVIOR_PROVIDER_INPUT_SCHEMA_VERSION,
         "arm": "candidate_packet",
+        "canonical_selected_todo_id": "todo_fixture001",
         "semantic_contract_required": False,
-        "packet": {"schema_version": "loopx_turn_envelope_v0"},
+        "packet": {
+            "schema_version": "loopx_turn_envelope_v0",
+            "action": {"selected_todo": {"todo_id": "todo_fixture001"}},
+        },
     }
     assert "sandbox" not in provider_input
     assert "response_contract" not in provider_input


### PR DESCRIPTION
## Summary

- derive a per-arm canonical selected todo id from the already-verified action signature
- require the direct Doubao actor to preserve that exact value instead of selecting diagnostic todo references
- document the guard and its fail-closed relationship with candidate signature parity

## Motivation and judgment

A retained real quota shadow exposed stable control-text pollution: the full packet had no canonical selected todo, but the model selected a todo id that appeared only in diagnostic summaries. The candidate TurnEnvelope returned null. This narrow guard keeps deterministic controller-owned identity out of model inference while leaving the eight semantic dimensions, execution actions, and safety signals model-derived. A real candidate omission or mutation is still rejected before provider invocation by recomputed action-signature parity.

## Validation

- `32 passed` across the Doubao actor, pair qualification, corpus, and retained-case tests
- Ruff check and format check passed
- live retained case before fix: 2/2 repeats drifted on `selected_todo_id`; one also drifted on action kinds
- live retained case after fix: 2/2 repeats passed, both arm orders observed, semantic contract complete, zero hard/behavior/semantic/stochastic/safety drift
- `loopx canary premerge --from-git-diff`: passed, 10 selected checks, 0 failures, 0 manual holds
- public/private boundary scan passed; no raw packet, model response, conversation, credential, or local path is committed

## Residual boundary

This does not promote TurnEnvelope to the default agent-facing path. Promotion remains separately owner-gated.