### PR TITLE
fix(lark): preserve complete issue outcome projection

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -1000,7 +1000,9 @@ even before a PR exists; a PR enriches that row only when its lifecycle
 observation carries the matching `repo` and explicit `issue_ref`. Numeric issue
 aliases (`#123`, `issue_123`, `issues/123`) canonicalize to `issues_123` on
 write and when reading legacy rows, so equivalent explicit links cannot silently
-fall into the unlinked count. This automatic closeout projection adds no outcome
+fall into the unlinked count. The command's `--limit` applies only to active todo
+rows; all derived outcome rows remain in scope, and the receipt exposes the
+split through `limit_policy`. This automatic closeout projection adds no outcome
 ledger or second state machine.
 
 Supplying `--delivery-evidence-json` alone is a read-only preview. Add

--- a/docs/capabilities/issue-fix/README.zh-CN.md
+++ b/docs/capabilities/issue-fix/README.zh-CN.md
@@ -907,8 +907,10 @@ lifecycle domain state 推导全部 issue outcome，并与 todo 行一起 upsert
 一经落盘，即使还没有 PR，也会作为 issue work 出现在看板；只有 lifecycle observation
 带有相同 `repo` 和显式 `issue_ref` 时，PR 才会补充到该行。数字 issue 别名
 （`#123`、`issue_123`、`issues/123`）会在写入和读取旧行时统一为 `issues_123`，
-避免等价的显式关联静默落入 unlinked 计数。这个自动 closeout projection 不会新增
-outcome ledger，也不会建立第二套状态机。
+避免等价的显式关联静默落入 unlinked 计数。命令的 `--limit` 只限制 active todo
+行；所有推导出的 outcome 行仍在同步范围内，receipt 通过 `limit_policy` 显式说明
+这个边界。这个自动 closeout projection 不会新增 outcome ledger，也不会建立第二套
+状态机。
 
 只传 `--delivery-evidence-json` 仍是只读预览。focused validation 完成后，加上
 `--write-delivery-evidence`，LoopX 会把经过校验、public-safe 的紧凑证据写回现有

--- a/docs/lark-kanban-control-plane-adapter.md
+++ b/docs/lark-kanban-control-plane-adapter.md
@@ -200,7 +200,10 @@ active-state paths.
 Issue outcomes are derived, not persisted separately. Every feasibility row is
 projected; a PR lifecycle row enriches it only through an explicit matching
 `repo` and `issue_ref`. This avoids title/branch guessing and makes the issue
-grid and stage Kanban part of the default sync path.
+grid and stage Kanban part of the default sync path. `--limit` bounds active
+todo rows only; it never truncates the derived issue-outcome source projection.
+The sync receipt publishes this split as `limit_policy` so a successful command
+cannot silently imply completeness after dropping newer outcomes.
 
 Normal projection sync is intentionally non-destructive: rows missing from a
 filtered, limited, or newer payload are never deleted implicitly. When a

--- a/examples/issue-fix-outcome-projection-smoke.py
+++ b/examples/issue-fix-outcome-projection-smoke.py
@@ -393,6 +393,25 @@ def assert_default_goal_sync_composes_outcomes() -> None:
         assert unlinked_record["values"]["Pull Request"] == ""
         assert str(project) not in json.dumps(sync["records"], ensure_ascii=False)
 
+        bounded_todo_sync = sync_loopx_todos_to_lark_kanban(
+            LarkKanbanConfig(
+                **{"base_" + "token": "base_public_fixture"},
+                table_id="tbl_public_fixture",
+            ),
+            registry_path=registry,
+            goal_id=goal_id,
+            agent_id="codex-public-fixture",
+            limit=1,
+            execute=False,
+        )
+        assert bounded_todo_sync["todo_count"] == 1, bounded_todo_sync
+        assert bounded_todo_sync["issue_fix_outcome_count"] == 2, bounded_todo_sync
+        assert bounded_todo_sync["limit_policy"] == {
+            "todo_rows": 1,
+            "issue_fix_outcomes": "complete_source_projection",
+        }, bounded_todo_sync
+        assert bounded_todo_sync["issue_fix_source_counts"]["outcomes"] == 2
+
 
 def main() -> None:
     projection = build_issue_fix_outcome_projection(

--- a/loopx/cli_commands/lark_kanban.py
+++ b/loopx/cli_commands/lark_kanban.py
@@ -158,7 +158,15 @@ def register_lark_kanban_commands(
     sync.add_argument("--project")
     sync.add_argument("--state-file")
     sync.add_argument("--include-done", action="store_true")
-    sync.add_argument("--limit", type=int, default=50)
+    sync.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help=(
+            "Maximum active todo rows to sync. Derived issue-fix outcomes always "
+            "use the complete source projection."
+        ),
+    )
     sync.add_argument(
         "--include-command-details",
         action="store_true",

--- a/loopx/presentation/sinks/lark/kanban.py
+++ b/loopx/presentation/sinks/lark/kanban.py
@@ -2110,13 +2110,14 @@ def sync_loopx_todos_to_lark_kanban(
         outcome_projection,
         None,
     )
+    outcome_source_count = len(outcome_projection.get("issue_fix_outcomes") or [])
     _, outcome_rows, outcome_row_warnings = _projection_rows_from_payload(
         outcome_projection,
         goal_id=goal_id,
         agent_id=agent_id,
         source_id=outcome_source_id,
         include_done=True,
-        limit=limit,
+        limit=outcome_source_count,
     )
     outcome_warnings = [
         *outcome_namespace_warnings,
@@ -2219,6 +2220,9 @@ def sync_loopx_todos_to_lark_kanban(
         "state_file": str(resolved_state_file),
         "todo_count": len(todos),
         "issue_fix_outcome_count": len(outcome_rows),
+        "limit_policy": {
+            "todo_rows": limit, "issue_fix_outcomes": "complete_source_projection",
+        },
         "issue_fix_source_counts": outcome_projection.get("source_counts"),
         "warnings": outcome_warnings,
         "records": results,


### PR DESCRIPTION
## 动机

`lark-kanban sync-loopx-todos --limit N` 原本把同一个 `limit` 同时用于 active todo 与派生 issue outcome。目标累计较多 outcome 时，命令仍返回成功，但较新的 issue 可能静默缺席看板；这与文档承诺的“推导全部 issue outcome”不一致。

## 方法

- 将 `--limit` 明确定义为仅限制 active todo 行。
- issue outcome 按完整 domain-state source projection 同步，不再复用 todo limit。
- 在 receipt 中增加结构化 `limit_policy`，同时保留 `issue_fix_source_counts.outcomes` 供完整性核对。
- 更新 CLI help 与中英文能力文档。

## 关键逻辑

```text
active todos --limit N --> at most N todo rows
issue-fix domain state --> all derived outcome rows
                         --> limit_policy + source_counts receipt
```

## 复现

回归用例构造 1 条 active todo 和 2 条 issue outcome，并执行 `limit=1`。修复前 `issue_fix_outcome_count=1`；修复后 todo 仍为 1，但 outcome 保持 2。

## 验证

- `python3 examples/issue-fix-outcome-projection-smoke.py`
- `python3 examples/lark-kanban-control-plane-smoke.py`
- `uv run --extra test ruff check ...`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `loopx canary premerge --from-git-diff --tier standard`：17/17 通过，0 manual hold
- public/private boundary scan 通过

## 风险

本次会让 outcome 较多的目标同步更多行，这是恢复既有完整性契约所需的行为；todo 行仍受 `--limit` 约束。没有新增状态机、远端删除或权限变化。
