### PR TITLE
Explore: add same-source canonical and executive views

### DIFF
--- a/docs/capabilities/explore/README.md
+++ b/docs/capabilities/explore/README.md
@@ -123,6 +123,22 @@ or digest matches the validated projection. The canonical JSON and
 Nodes/Edges/Findings tables remain complete and authoritative throughout this
 presentation step.
 
+`loopx explore presentation --goal-id <id>` builds a presentation bundle from
+one canonical result projection. It always includes a complete `canonical`
+view and a derived `executive` view with source-node lineage. Both views carry
+the same timestamp-free `source_digest` and event-based `source_revision`.
+The executive view selects active and decision-tagged nodes, representative
+counterevidence neighborhoods, material one-hop relations, and ancestors; it
+does not store facts independently.
+
+The bundle recommends `presentation_mode=canonical_only|dual_view` from
+multiple advisory signals rather than a single node-count cutoff. Current
+reason codes are `low_decision_density`, `excessive_terminal_branches`,
+`deep_decision_path`, and `readability_check_failed`. Static graph shape can
+estimate readability risk; a caller may also supply renderer observations for
+overlap, text overflow, or abnormal canvas expansion. These signals only
+control presentation advice. They never authorize canonical truncation.
+
 ## Optional Todo Branch Plan
 
 `loopx explore todo-branch-plan` is a narrow opt-in harness for
@@ -671,6 +687,27 @@ filters. Issue-fix callers may choose `--projection-mode issue_fix_two_lane` to
 render one deduplicated delivery lane plus curated capability milestones from
 the same canonical graph; this changes presentation only, never evidence state.
 
+For a same-source dual view, configure two whiteboards by role:
+
+```bash
+loopx explore feishu-visual-configure \
+  --view-role canonical \
+  --projection-mode canonical_full \
+  --whiteboard-token <canonical-token> \
+  --execute
+loopx explore feishu-visual-configure \
+  --view-role executive \
+  --projection-mode executive_auto \
+  --whiteboard-token <executive-token> \
+  --execute
+```
+
+`feishu-sync` then generates both views in one local projection step. It always
+publishes the canonical role and publishes the executive role when the bundle
+recommends `dual_view`. A derived view whose source revision or digest differs
+from the current canonical projection is rejected before any whiteboard
+command runs. Legacy single-whiteboard configuration remains supported.
+
 The text `From Node` / `To Node` columns remain stable public ids for
 automation and review, while the linked-record columns are the Feishu-native
 graph substrate. A Base plugin, relationship-aware view, or Feishu dashboard
@@ -689,11 +726,12 @@ loopx explore node --goal-id <id> --title <t> [--node-id ...] [--status ...] [--
 loopx explore edge --goal-id <id> --from <node> --to <node> --type <edge-type>
 loopx explore finding --goal-id <id> --title <t> [--node ...] [--status ...] [--confidence ...]
 loopx explore summary --goal-id <id>
+loopx explore presentation --goal-id <id>
 loopx explore graph --goal-id <id> [--graph-format mermaid|json] [--out <file>]
 loopx explore todo-branch-plan --goal-id <id> [--agent-id <agent>] [--width 3]
 loopx explore worker-branch-plan --goal-id <id> [--agent-id <agent>] [--harness-profile generic|adaptive-resilient|moe-router] [--worker-width 3] [--max-todos-per-branch 3] [--router-state <file>] [--load-profile <file>]
 loopx explore feishu-setup [--base-url ...] [--execute]
-loopx explore feishu-visual-configure --whiteboard-token <token> [--docx-token <token>] [--projection-mode canonical_filtered|issue_fix_two_lane] [--tag <tag>] [--status <status>] [--execute]
+loopx explore feishu-visual-configure --whiteboard-token <token> [--docx-token <token>] [--view-role canonical|executive] [--projection-mode canonical_filtered|issue_fix_two_lane|canonical_full|executive_auto] [--tag <tag>] [--status <status>] [--execute]
 loopx explore feishu-sync --goal-id <id> [--sink-visibility owner-only|shared] [--execute]
 loopx explore feishu-card --goal-id <id> [--card-file <file>] [--message-id om_...]
 ```

--- a/docs/capabilities/explore/README.md
+++ b/docs/capabilities/explore/README.md
@@ -135,9 +135,14 @@ The bundle recommends `presentation_mode=canonical_only|dual_view` from
 multiple advisory signals rather than a single node-count cutoff. Current
 reason codes are `low_decision_density`, `excessive_terminal_branches`,
 `deep_decision_path`, and `readability_check_failed`. Static graph shape can
-estimate readability risk; a caller may also supply renderer observations for
-overlap, text overflow, or abnormal canvas expansion. These signals only
-control presentation advice. They never authorize canonical truncation.
+estimate readability risk, including excessively flat root topology; a caller
+may also supply renderer observations for overlap, text overflow, or abnormal
+canvas expansion. Both canonical and executive views use a top-to-bottom
+evidence timeline: stable source order starts at the top, bounded epochs add
+navigation, and later evidence extends the board downward instead of widening
+the first rank. Every original canonical node and edge remains present. These
+signals and layout choices only control presentation. They never authorize
+canonical truncation.
 
 ## Optional Todo Branch Plan
 

--- a/examples/explore-result-layer-smoke.py
+++ b/examples/explore-result-layer-smoke.py
@@ -1027,6 +1027,18 @@ def check_cli_surface() -> None:
         summary = run_cli("explore", "summary", "--goal-id", goal_id)
         assert summary["counts"]["node_count"] == 1, summary
         assert summary["counts"]["finding_count"] == 1, summary
+        presentation = run_cli(
+            "explore",
+            "presentation",
+            "--goal-id",
+            goal_id,
+        )
+        assert presentation["presentation_mode"] == "canonical_only", presentation
+        assert presentation["canonical"]["graph_counts"]["node_count"] == 1, presentation
+        assert (
+            presentation["canonical"]["source_revision"]
+            == presentation["executive"]["source_revision"]
+        ), presentation
         graph = run_cli("explore", "graph", "--goal-id", goal_id)
         assert str(graph["mermaid"]).startswith("flowchart TD"), graph
         focused_graph = run_cli(
@@ -1247,6 +1259,40 @@ def check_cli_surface() -> None:
         assert stored_cli_sync["commands"][0]["command"].startswith("stored-lark-cli "), stored_cli_sync
         assert stored_cli_sync["visual_sync"]["status"] == "would_publish", stored_cli_sync
         assert "whiteboard +update" in stored_cli_sync["visual_sync"]["command"]["command"], stored_cli_sync
+
+        for role, mode in (
+            ("canonical", "canonical_full"),
+            ("executive", "executive_auto"),
+        ):
+            role_config = run_cli(
+                "explore",
+                "feishu-visual-configure",
+                "--config-path",
+                str(config_path),
+                "--whiteboard-token",
+                f"wb_{role}_fixture",
+                "--view-role",
+                role,
+                "--projection-mode",
+                mode,
+                "--execute",
+            )
+            assert role_config["status"] == "configured", role_config
+        dual_config_sync = run_cli(
+            "explore",
+            "feishu-sync",
+            "--goal-id",
+            goal_id,
+            "--config-path",
+            str(config_path),
+        )
+        assert dual_config_sync["visual_sync"]["presentation_mode"] == "canonical_only", dual_config_sync
+        assert dual_config_sync["visual_sync"]["views"]["canonical"]["status"] == "would_publish", (
+            dual_config_sync
+        )
+        assert dual_config_sync["visual_sync"]["views"]["executive"]["status"] == "not_recommended", (
+            dual_config_sync
+        )
 
         # Error contract: unknown target without config fails with exit 1.
         error = subprocess.run(

--- a/loopx/cli_commands/explore.py
+++ b/loopx/cli_commands/explore.py
@@ -45,8 +45,10 @@ from ..presentation.sinks.lark.explore_results import (
     setup_lark_explore_board,
     sync_explore_results_to_lark,
     sync_explore_visual_to_lark,
+    sync_explore_visuals_to_lark,
     write_lark_explore_local_config,
 )
+from ..presentation.explore_views import build_explore_presentation_bundle
 from ..presentation.sinks.lark.kanban import DEFAULT_CLI_BIN
 from ..history import load_registry
 from ..paths import resolve_runtime_root
@@ -125,6 +127,14 @@ def register_explore_commands(
     summary.add_argument("--goal-id", required=True)
     _add_projection_limit_args(summary)
 
+    presentation = sub.add_parser(
+        "presentation",
+        help="Assess readability and derive same-source canonical/executive views.",
+    )
+    add_subcommand_format(presentation)
+    presentation.add_argument("--goal-id", required=True)
+    _add_projection_limit_args(presentation)
+
     graph = sub.add_parser(
         "graph",
         help="Export the exploration topology as Mermaid flowchart source or graph JSON.",
@@ -197,8 +207,17 @@ def register_explore_commands(
     visual.add_argument("--tag", dest="visual_tags", action="append", default=[])
     visual.add_argument(
         "--projection-mode",
-        choices=["canonical_filtered", "issue_fix_two_lane"],
-        default="canonical_filtered",
+        choices=[
+            "canonical_filtered",
+            "issue_fix_two_lane",
+            "canonical_full",
+            "executive_auto",
+        ],
+    )
+    visual.add_argument(
+        "--view-role",
+        choices=["canonical", "executive"],
+        help="Configure one role in a same-source dual-view presentation.",
     )
     visual.add_argument(
         "--include-ancestors",
@@ -295,13 +314,25 @@ def _target_config(args: argparse.Namespace, *, config_path: Path) -> LarkExplor
     )
 
 
-def _projection_for(args: argparse.Namespace, *, runtime_root: Path) -> dict[str, object]:
+def _projection_for(
+    args: argparse.Namespace,
+    *,
+    runtime_root: Path,
+    finding_limit_override: int | None = None,
+) -> dict[str, object]:
     log_path = explore_result_log_path(runtime_root, args.goal_id)
     events = load_explore_result_events(log_path, goal_id=args.goal_id)
+    finding_limit = (
+        int(args.finding_limit)
+        if finding_limit_override is None
+        else int(finding_limit_override)
+    )
+    if finding_limit < 0:
+        finding_limit = len(events)
     projection = build_explore_result_projection(
         events,
         goal_id=args.goal_id,
-        finding_limit=max(0, int(args.finding_limit)),
+        finding_limit=max(0, finding_limit),
         mermaid_node_limit=max(1, int(args.mermaid_node_limit)),
     )
     projection["log_path"] = str(log_path)
@@ -365,6 +396,8 @@ def render_explore_markdown(payload: dict[str, object]) -> str:
         "message_id",
         "card_file",
         "out",
+        "presentation_mode",
+        "source_revision",
     ):
         if payload.get(key) not in (None, ""):
             lines.append(f"- {key}: `{payload.get(key)}`")
@@ -378,6 +411,9 @@ def render_explore_markdown(payload: dict[str, object]) -> str:
     if isinstance(row_counts, dict):
         joined = ", ".join(f"{key}={value}" for key, value in row_counts.items())
         lines.append(f"- rows: `{joined}`")
+    reason_codes = payload.get("reason_codes")
+    if isinstance(reason_codes, list) and reason_codes:
+        lines.append(f"- reason_codes: `{', '.join(str(item) for item in reason_codes)}`")
     if payload.get("strategy"):
         lines.append(f"- strategy: `{payload.get('strategy')}`")
     if payload.get("harness_profile"):
@@ -545,6 +581,13 @@ def handle_explore_command(
             payload = _append_event_payload(event, runtime_root=runtime_root, goal_id=args.goal_id)
         elif args.explore_command == "summary":
             payload = _projection_for(args, runtime_root=runtime_root)
+        elif args.explore_command == "presentation":
+            projection = _projection_for(
+                args,
+                runtime_root=runtime_root,
+                finding_limit_override=-1,
+            )
+            payload = build_explore_presentation_bundle(projection)
         elif args.explore_command == "graph":
             projection = _projection_for(args, runtime_root=runtime_root)
             graph_view = build_explore_graph_view(
@@ -715,9 +758,14 @@ def handle_explore_command(
                 docx_token=args.docx_token,
                 statuses=args.visual_statuses,
                 tags=args.visual_tags,
-                projection_mode=args.projection_mode,
+                projection_mode=args.projection_mode
+                or {
+                    "canonical": "canonical_full",
+                    "executive": "executive_auto",
+                }.get(args.view_role, "canonical_filtered"),
                 include_ancestors=bool(args.include_ancestors),
                 mermaid_node_limit=args.mermaid_node_limit,
+                view_role=args.view_role,
                 execute=bool(args.execute),
             )
         elif args.explore_command == "feishu-sync":
@@ -731,14 +779,31 @@ def handle_explore_command(
                 execute=bool(args.execute),
             )
             local = read_lark_explore_local_config(config_path)
-            payload["visual_sync"] = sync_explore_visual_to_lark(
-                target,
-                projection=projection,
-                visual_sink=local.get("visual_sink") if isinstance(local.get("visual_sink"), dict) else None,
-                config_path=config_path,
-                semantic_digest=explore_visual_semantic_digest(projection),
-                execute=bool(args.execute),
-            )
+            visual_sinks = local.get("visual_sinks")
+            if isinstance(visual_sinks, dict) and visual_sinks:
+                visual_projection = _projection_for(
+                    args,
+                    runtime_root=runtime_root,
+                    finding_limit_override=-1,
+                )
+                payload["visual_sync"] = sync_explore_visuals_to_lark(
+                    target,
+                    projection=visual_projection,
+                    visual_sinks=visual_sinks,
+                    config_path=config_path,
+                    execute=bool(args.execute),
+                )
+            else:
+                payload["visual_sync"] = sync_explore_visual_to_lark(
+                    target,
+                    projection=projection,
+                    visual_sink=local.get("visual_sink")
+                    if isinstance(local.get("visual_sink"), dict)
+                    else None,
+                    config_path=config_path,
+                    semantic_digest=explore_visual_semantic_digest(projection),
+                    execute=bool(args.execute),
+                )
             payload["ok"] = bool(payload.get("ok")) and bool(payload["visual_sync"].get("ok"))
         elif args.explore_command == "feishu-card":
             projection = _projection_for(args, runtime_root=runtime_root)

--- a/loopx/presentation/explore_views.py
+++ b/loopx/presentation/explore_views.py
@@ -1,0 +1,498 @@
+"""Same-source canonical and executive views over Explore evidence.
+
+The Explore result projection remains the only evidence source.  This module
+adds presentation advice and derived display views; it never mutates or
+truncates the canonical node, edge, or finding collections.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from ..capabilities.explore.result_log import build_explore_mermaid
+
+
+EXPLORE_PRESENTATION_BUNDLE_VERSION = "loopx_explore_presentation_bundle_v0"
+EXPLORE_PRESENTATION_ASSESSMENT_VERSION = "loopx_explore_presentation_assessment_v0"
+EXPLORE_CANONICAL_VIEW_VERSION = "loopx_explore_canonical_view_v0"
+EXPLORE_EXECUTIVE_VIEW_VERSION = "loopx_explore_executive_view_v0"
+
+PRESENTATION_MODE_CANONICAL_ONLY = "canonical_only"
+PRESENTATION_MODE_DUAL_VIEW = "dual_view"
+
+_ACTIVE_STATUSES = {"open", "exploring", "blocked"}
+_TERMINAL_STATUSES = {"resolved", "dead_end"}
+_DECISION_TAGS = {
+    "active",
+    "baseline",
+    "capacity",
+    "contract",
+    "current-best",
+    "decision",
+    "executive",
+    "guardrail",
+    "incumbent",
+    "resource",
+    "risk",
+}
+_LEGACY_LEADER_TAGS = {"leader", "provisional-leader", "winner"}
+_COUNTEREVIDENCE_TAGS = {
+    "counterevidence",
+    "negative",
+    "no-promote",
+    "no_promote",
+    "refuted",
+    "retired",
+}
+_EXECUTIVE_EXPANSION_EDGE_TYPES = {"answers", "depends_on", "leads_to", "refutes"}
+_VOLATILE_VIEW_KEYS = {
+    "first_recorded_at",
+    "last_updated_at",
+    "update_count",
+    "generated_at",
+    "log_path",
+}
+
+DEFAULT_EXPLORE_PRESENTATION_POLICY: dict[str, float | int] = {
+    "decision_density_node_floor": 24,
+    "decision_density_ceiling": 0.35,
+    "terminal_ratio_node_floor": 30,
+    "terminal_ratio_floor": 0.60,
+    "terminal_neighborhood_floor": 2,
+    "decision_depth_floor": 6,
+    "readability_node_floor": 60,
+    "readability_edge_density_floor": 2.0,
+    "readability_label_chars": 96,
+    "executive_counterevidence_limit": 8,
+}
+
+
+def _material_rows(values: Sequence[Any] | None, *, id_key: str) -> list[dict[str, Any]]:
+    rows = []
+    for value in values or []:
+        if not isinstance(value, Mapping):
+            continue
+        row = {
+            key: item
+            for key, item in value.items()
+            if key not in _VOLATILE_VIEW_KEYS
+        }
+        if row.get(id_key):
+            rows.append(row)
+    return sorted(rows, key=lambda item: str(item.get(id_key) or ""))
+
+
+def explore_source_digest(projection: Mapping[str, Any]) -> str:
+    """Return a stable digest for the complete canonical evidence projection."""
+
+    material = {
+        "goal_id": projection.get("goal_id"),
+        "nodes": _material_rows(projection.get("nodes"), id_key="node_id"),
+        "edges": _material_rows(projection.get("edges"), id_key="edge_id"),
+        "findings": _material_rows(projection.get("findings"), id_key="finding_id"),
+    }
+    encoded = json.dumps(
+        material,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def explore_source_revision(projection: Mapping[str, Any], *, digest: str | None = None) -> str:
+    source_digest = digest or explore_source_digest(projection)
+    event_count = max(0, int(projection.get("source_event_count") or 0))
+    return f"events-{event_count}-{source_digest[:12]}"
+
+
+def _parent_map(
+    nodes: Sequence[Mapping[str, Any]],
+    edges: Sequence[Mapping[str, Any]],
+) -> dict[str, str]:
+    parents = {
+        str(node.get("node_id") or ""): str(node.get("parent_id") or "")
+        for node in nodes
+        if str(node.get("node_id") or "") and str(node.get("parent_id") or "")
+    }
+    for edge in edges:
+        if str(edge.get("edge_type") or "") != "subtopic_of":
+            continue
+        child = str(edge.get("from_node") or "")
+        parent = str(edge.get("to_node") or "")
+        if child and parent:
+            parents.setdefault(child, parent)
+    return parents
+
+
+def _lineage(node_id: str, parents: Mapping[str, str], node_ids: set[str]) -> list[str]:
+    path = [node_id]
+    seen = {node_id}
+    parent = parents.get(node_id)
+    while parent and parent in node_ids and parent not in seen:
+        path.append(parent)
+        seen.add(parent)
+        parent = parents.get(parent)
+    path.reverse()
+    return path
+
+
+def _node_depths(node_ids: set[str], parents: Mapping[str, str]) -> dict[str, int]:
+    return {
+        node_id: max(0, len(_lineage(node_id, parents, node_ids)) - 1)
+        for node_id in node_ids
+    }
+
+
+def _tags(node: Mapping[str, Any]) -> set[str]:
+    return {str(tag or "").strip().lower() for tag in node.get("tags") or [] if str(tag or "").strip()}
+
+
+def _decision_seed_ids(nodes: Sequence[Mapping[str, Any]]) -> set[str]:
+    seeds = set()
+    has_current_incumbent = any(
+        _tags(node).intersection({"current-best", "incumbent"})
+        for node in nodes
+    )
+    for node in nodes:
+        node_id = str(node.get("node_id") or "")
+        if not node_id:
+            continue
+        tags = _tags(node)
+        if (
+            str(node.get("status") or "") in _ACTIVE_STATUSES
+            or tags.intersection(_DECISION_TAGS)
+            or (not has_current_incumbent and tags.intersection(_LEGACY_LEADER_TAGS))
+        ):
+            seeds.add(node_id)
+    return seeds
+
+
+def _terminal_neighborhood_count(
+    nodes: Sequence[Mapping[str, Any]],
+    parents: Mapping[str, str],
+) -> int:
+    statuses = {
+        str(node.get("node_id") or ""): str(node.get("status") or "")
+        for node in nodes
+    }
+    children: dict[str, list[str]] = defaultdict(list)
+    for child, parent in parents.items():
+        children[parent].append(child)
+    return sum(
+        1
+        for child_ids in children.values()
+        if len(child_ids) >= 3
+        and sum(statuses.get(child) in _TERMINAL_STATUSES for child in child_ids) >= 3
+    )
+
+
+def assess_explore_presentation(
+    projection: Mapping[str, Any],
+    *,
+    readability_check: Mapping[str, Any] | None = None,
+    policy: Mapping[str, float | int] | None = None,
+) -> dict[str, Any]:
+    """Recommend one or two views from several advisory readability signals."""
+
+    thresholds = dict(DEFAULT_EXPLORE_PRESENTATION_POLICY)
+    thresholds.update(policy or {})
+    nodes = [item for item in projection.get("nodes") or [] if isinstance(item, Mapping)]
+    edges = [item for item in projection.get("edges") or [] if isinstance(item, Mapping)]
+    node_ids = {str(node.get("node_id") or "") for node in nodes if str(node.get("node_id") or "")}
+    parents = _parent_map(nodes, edges)
+    depths = _node_depths(node_ids, parents)
+    decision_ids = _decision_seed_ids(nodes)
+    terminal_count = sum(str(node.get("status") or "") in _TERMINAL_STATUSES for node in nodes)
+    node_count = len(nodes)
+    edge_count = len(edges)
+    decision_density = len(decision_ids) / node_count if node_count else 1.0
+    terminal_ratio = terminal_count / node_count if node_count else 0.0
+    edge_density = edge_count / node_count if node_count else 0.0
+    max_depth = max(depths.values(), default=0)
+    terminal_neighborhoods = _terminal_neighborhood_count(nodes, parents)
+    long_label_count = sum(
+        len(str(node.get("title") or "")) > int(thresholds["readability_label_chars"])
+        for node in nodes
+    )
+
+    reasons = []
+    if (
+        node_count >= int(thresholds["decision_density_node_floor"])
+        and decision_density < float(thresholds["decision_density_ceiling"])
+    ):
+        reasons.append("low_decision_density")
+    if (
+        terminal_neighborhoods >= int(thresholds["terminal_neighborhood_floor"])
+        or (
+            node_count >= int(thresholds["terminal_ratio_node_floor"])
+            and terminal_ratio >= float(thresholds["terminal_ratio_floor"])
+        )
+    ):
+        reasons.append("excessive_terminal_branches")
+    if max_depth >= int(thresholds["decision_depth_floor"]):
+        reasons.append("deep_decision_path")
+
+    observed_readability_failure = any(
+        readability_check and readability_check.get(key) is True
+        for key in ("overlap_detected", "text_overflow_detected", "canvas_expansion_detected")
+    )
+    estimated_readability_failure = (
+        node_count >= int(thresholds["readability_node_floor"])
+        and (
+            edge_density >= float(thresholds["readability_edge_density_floor"])
+            or long_label_count > 0
+            or max_depth >= int(thresholds["decision_depth_floor"])
+        )
+    )
+    if observed_readability_failure or estimated_readability_failure:
+        reasons.append("readability_check_failed")
+
+    mode = (
+        PRESENTATION_MODE_DUAL_VIEW
+        if "readability_check_failed" in reasons or len(reasons) >= 2
+        else PRESENTATION_MODE_CANONICAL_ONLY
+    )
+    return {
+        "schema_version": EXPLORE_PRESENTATION_ASSESSMENT_VERSION,
+        "presentation_mode": mode,
+        "reason_codes": reasons,
+        "metrics": {
+            "node_count": node_count,
+            "edge_count": edge_count,
+            "decision_node_count": len(decision_ids),
+            "decision_density": round(decision_density, 4),
+            "terminal_node_count": terminal_count,
+            "terminal_ratio": round(terminal_ratio, 4),
+            "terminal_neighborhood_count": terminal_neighborhoods,
+            "max_depth": max_depth,
+            "edge_density": round(edge_density, 4),
+            "long_label_count": long_label_count,
+        },
+        "readability_check": {
+            "source": "observed" if readability_check else "static_estimate",
+            "failed": observed_readability_failure or estimated_readability_failure,
+        },
+        "policy": thresholds,
+        "advisory_only": True,
+        "canonical_truncation_allowed": False,
+    }
+
+
+def _executive_roles(node: Mapping[str, Any]) -> list[str]:
+    roles = []
+    status = str(node.get("status") or "")
+    tags = _tags(node)
+    if status in _ACTIVE_STATUSES:
+        roles.append("active_work")
+    for role, role_tags in (
+        ("decision_contract", {"contract", "decision"}),
+        ("baseline", {"baseline"}),
+        ("incumbent", {"current-best", "incumbent", "leader", "provisional-leader", "winner"}),
+        ("guardrail", {"guardrail", "risk"}),
+        ("resource_state", {"capacity", "resource"}),
+        ("counterevidence", {"counterevidence", "negative", "no-promote", "retired"}),
+    ):
+        if tags.intersection(role_tags):
+            roles.append(role)
+    if status == "dead_end" and "counterevidence" not in roles:
+        roles.append("counterevidence")
+    return roles or ["lineage_context"]
+
+
+def _executive_node_ids(
+    nodes: Sequence[Mapping[str, Any]],
+    edges: Sequence[Mapping[str, Any]],
+    parents: Mapping[str, str],
+    *,
+    counterevidence_limit: int,
+) -> set[str]:
+    node_ids = {str(node.get("node_id") or "") for node in nodes if str(node.get("node_id") or "")}
+    selected = _decision_seed_ids(nodes)
+    if not selected:
+        selected = {node_id for node_id in node_ids if not parents.get(node_id)}
+    counterevidence_by_parent: dict[str, str] = {}
+    for node in nodes:
+        node_id = str(node.get("node_id") or "")
+        status = str(node.get("status") or "")
+        if not node_id or not (
+            status == "dead_end" or _tags(node).intersection(_COUNTEREVIDENCE_TAGS)
+        ):
+            continue
+        neighborhood = parents.get(node_id) or node_id
+        counterevidence_by_parent.setdefault(neighborhood, node_id)
+    selected.update(
+        list(counterevidence_by_parent.values())[: max(0, counterevidence_limit)]
+    )
+    relation_seeds = set(selected)
+    for edge in edges:
+        if str(edge.get("edge_type") or "") not in _EXECUTIVE_EXPANSION_EDGE_TYPES:
+            continue
+        source = str(edge.get("from_node") or "")
+        target = str(edge.get("to_node") or "")
+        if source in relation_seeds or target in relation_seeds:
+            selected.update({source, target}.intersection(node_ids))
+    for node_id in tuple(selected):
+        selected.update(_lineage(node_id, parents, node_ids))
+    return selected
+
+
+def _view_node(
+    node: Mapping[str, Any],
+    *,
+    parents: Mapping[str, str],
+    node_ids: set[str],
+    executive: bool,
+) -> dict[str, Any]:
+    view = dict(node)
+    node_id = str(node.get("node_id") or "")
+    view["source_node_id"] = node_id
+    view["lineage"] = _lineage(node_id, parents, node_ids)
+    if executive:
+        view["executive_roles"] = _executive_roles(node)
+    return view
+
+
+def build_explore_presentation_bundle(
+    projection: Mapping[str, Any],
+    *,
+    readability_check: Mapping[str, Any] | None = None,
+    policy: Mapping[str, float | int] | None = None,
+) -> dict[str, Any]:
+    """Build canonical and executive views atomically from one projection."""
+
+    nodes = [dict(item) for item in projection.get("nodes") or [] if isinstance(item, Mapping)]
+    edges = [dict(item) for item in projection.get("edges") or [] if isinstance(item, Mapping)]
+    findings = [dict(item) for item in projection.get("findings") or [] if isinstance(item, Mapping)]
+    counts = projection.get("counts")
+    declared_finding_count = (
+        int(counts.get("finding_count") or 0)
+        if isinstance(counts, Mapping)
+        else len(findings)
+    )
+    if declared_finding_count > len(findings):
+        raise ValueError(
+            "Explore presentation requires the complete canonical finding set"
+        )
+    node_ids = {str(node.get("node_id") or "") for node in nodes if str(node.get("node_id") or "")}
+    parents = _parent_map(nodes, edges)
+    digest = explore_source_digest(projection)
+    revision = explore_source_revision(projection, digest=digest)
+    assessment = assess_explore_presentation(
+        projection,
+        readability_check=readability_check,
+        policy=policy,
+    )
+
+    canonical_nodes = [
+        _view_node(node, parents=parents, node_ids=node_ids, executive=False)
+        for node in nodes
+    ]
+    canonical_edges = [dict(edge, source_edge_id=str(edge.get("edge_id") or "")) for edge in edges]
+    canonical = {
+        "schema_version": EXPLORE_CANONICAL_VIEW_VERSION,
+        "goal_id": projection.get("goal_id"),
+        "view_role": "canonical",
+        "source_revision": revision,
+        "source_digest": digest,
+        "nodes": canonical_nodes,
+        "edges": canonical_edges,
+        "findings": findings,
+        "mermaid": build_explore_mermaid(canonical_nodes, canonical_edges, node_limit=max(1, len(nodes))),
+        "graph_counts": {
+            "node_count": len(canonical_nodes),
+            "edge_count": len(canonical_edges),
+            "finding_count": len(findings),
+        },
+        "filter": {"projection_mode": "canonical_full", "truncated": False},
+    }
+
+    thresholds = dict(DEFAULT_EXPLORE_PRESENTATION_POLICY)
+    thresholds.update(policy or {})
+    executive_ids = _executive_node_ids(
+        nodes,
+        edges,
+        parents,
+        counterevidence_limit=int(thresholds["executive_counterevidence_limit"]),
+    )
+    executive_nodes = [
+        _view_node(node, parents=parents, node_ids=node_ids, executive=True)
+        for node in nodes
+        if str(node.get("node_id") or "") in executive_ids
+    ]
+    executive_edges = [
+        dict(edge, source_edge_id=str(edge.get("edge_id") or ""))
+        for edge in edges
+        if str(edge.get("from_node") or "") in executive_ids
+        and str(edge.get("to_node") or "") in executive_ids
+    ]
+    executive_findings = [
+        finding
+        for finding in findings
+        if str(finding.get("node_id") or "") in executive_ids
+    ]
+    executive = {
+        "schema_version": EXPLORE_EXECUTIVE_VIEW_VERSION,
+        "goal_id": projection.get("goal_id"),
+        "view_role": "executive",
+        "source_revision": revision,
+        "source_digest": digest,
+        "source_node_ids": sorted(executive_ids),
+        "nodes": executive_nodes,
+        "edges": executive_edges,
+        "findings": executive_findings,
+        "mermaid": build_explore_mermaid(
+            executive_nodes,
+            executive_edges,
+            node_limit=max(1, len(executive_nodes)),
+        ),
+        "graph_counts": {
+            "node_count": len(executive_nodes),
+            "edge_count": len(executive_edges),
+            "finding_count": len(executive_findings),
+            "canonical_node_count": len(canonical_nodes),
+        },
+        "filter": {
+            "projection_mode": "executive_auto",
+            "selection": "active_or_tagged_plus_material_neighbors_and_lineage",
+            "truncated": False,
+        },
+    }
+    return {
+        "ok": True,
+        "schema_version": EXPLORE_PRESENTATION_BUNDLE_VERSION,
+        "goal_id": projection.get("goal_id"),
+        "presentation_mode": assessment["presentation_mode"],
+        "reason_codes": assessment["reason_codes"],
+        "source_revision": revision,
+        "source_digest": digest,
+        "assessment": assessment,
+        "canonical": canonical,
+        "executive": executive,
+    }
+
+
+def validate_explore_view_freshness(
+    projection: Mapping[str, Any],
+    view: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Fail closed when a derived display view is not from this projection."""
+
+    digest = explore_source_digest(projection)
+    revision = explore_source_revision(projection, digest=digest)
+    observed_digest = str(view.get("source_digest") or "")
+    observed_revision = str(view.get("source_revision") or "")
+    fresh = observed_digest == digest and observed_revision == revision
+    return {
+        "ok": fresh,
+        "fresh": fresh,
+        "expected_source_digest": digest,
+        "observed_source_digest": observed_digest or None,
+        "expected_source_revision": revision,
+        "observed_source_revision": observed_revision or None,
+        "reason": None if fresh else "derived Explore view is stale; rebuild it from the current canonical projection",
+    }

--- a/loopx/presentation/explore_views.py
+++ b/loopx/presentation/explore_views.py
@@ -9,12 +9,10 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from typing import Any
-
-from ..capabilities.explore.result_log import build_explore_mermaid
-
 
 EXPLORE_PRESENTATION_BUNDLE_VERSION = "loopx_explore_presentation_bundle_v0"
 EXPLORE_PRESENTATION_ASSESSMENT_VERSION = "loopx_explore_presentation_assessment_v0"
@@ -67,7 +65,18 @@ DEFAULT_EXPLORE_PRESENTATION_POLICY: dict[str, float | int] = {
     "readability_node_floor": 60,
     "readability_edge_density_floor": 2.0,
     "readability_label_chars": 96,
+    "readability_root_count_floor": 16,
+    "readability_root_ratio_floor": 0.30,
+    "atlas_group_node_limit": 10,
     "executive_counterevidence_limit": 8,
+}
+
+_MERMAID_STATUS_CLASS = {
+    "open": "open",
+    "exploring": "exploring",
+    "blocked": "blocked",
+    "resolved": "resolved",
+    "dead_end": "deadend",
 }
 
 
@@ -148,6 +157,121 @@ def _node_depths(node_ids: set[str], parents: Mapping[str, str]) -> dict[str, in
     }
 
 
+def _mermaid_id(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_]", "_", str(value))
+
+
+def _mermaid_label(value: str) -> str:
+    cleaned = re.sub(r'["\[\]{}<>`|]', "'", str(value or ""))
+    return cleaned[:60].strip() or "untitled"
+
+
+def _canonical_group_specs(
+    nodes: Sequence[Mapping[str, Any]],
+    *,
+    group_node_limit: int,
+) -> list[dict[str, Any]]:
+    """Split stable source order into navigable evidence epochs."""
+
+    node_by_id = {str(node.get("node_id") or ""): node for node in nodes}
+    ordered_ids = list(node_by_id)
+    specs = []
+    for offset in range(0, len(ordered_ids), group_node_limit):
+        chunk = ordered_ids[offset : offset + group_node_limit]
+        first_title = str(node_by_id[chunk[0]].get("title") or chunk[0])
+        specs.append(
+            {
+                "title": (
+                    f"Evidence epoch {offset // group_node_limit + 1:02d} · "
+                    f"{first_title}"
+                ),
+                "node_ids": chunk,
+                "order": offset,
+            }
+        )
+    return specs
+
+
+def build_vertical_explore_mermaid(
+    nodes: Sequence[Mapping[str, Any]],
+    edges: Sequence[Mapping[str, Any]],
+    *,
+    view_role: str,
+    group_node_limit: int = 10,
+) -> dict[str, Any]:
+    """Render a complete top-to-bottom evidence atlas for a large graph."""
+
+    node_list = [node for node in nodes if str(node.get("node_id") or "")]
+    group_limit = max(4, int(group_node_limit))
+    groups = _canonical_group_specs(node_list, group_node_limit=group_limit)
+    role = "executive" if view_role == "executive" else "canonical"
+    atlas_title = f"{role.title()} evidence timeline"
+
+    node_by_id = {str(node.get("node_id") or ""): node for node in node_list}
+    shown_ids = set(node_by_id)
+    lines = ["flowchart TB", f'    subgraph {role}_atlas["{atlas_title}"]']
+    lines.append("        direction TB")
+    group_chains = []
+    for group_index, group in enumerate(groups, start=1):
+        group_id = f"{role}_group_{group_index}"
+        lines.append(f'        subgraph {group_id}["{_mermaid_label(group["title"])}"]')
+        lines.append("            direction TB")
+        chain = []
+        for node_id in group["node_ids"]:
+            node = node_by_id[node_id]
+            status = str(node.get("status") or "open")
+            marker = {
+                "blocked": " (BLOCKED)",
+                "resolved": " (done)",
+                "dead_end": " (dead end)",
+            }.get(status, "")
+            label = _mermaid_label(f"{node.get('title')}{marker}")
+            mermaid_id = _mermaid_id(node_id)
+            chain.append(mermaid_id)
+            lines.append(
+                f'            {mermaid_id}["{label}"]:::{_MERMAID_STATUS_CLASS.get(status, "open")}'
+            )
+        if len(chain) > 1:
+            lines.append(f"            {' ~~~ '.join(chain)}")
+        lines.append("        end")
+        group_chains.append(chain)
+    for previous, current in zip(group_chains, group_chains[1:]):
+        lines.append(f"        {previous[-1]} ~~~ {current[0]}")
+    lines.append("    end")
+    for edge in edges:
+        source = str(edge.get("from_node") or "")
+        target = str(edge.get("to_node") or "")
+        if source not in shown_ids or target not in shown_ids:
+            continue
+        label = _mermaid_label(str(edge.get("edge_type") or ""))
+        lines.append(f"    {_mermaid_id(source)} -->|{label}| {_mermaid_id(target)}")
+    lines.append(
+        f"    style {role}_atlas fill:#ffffff,stroke:#90a4ae,stroke-width:2px"
+    )
+    for group_index in range(1, len(groups) + 1):
+        lines.append(
+            f"    style {role}_group_{group_index} fill:#fafafa,stroke:#cfd8dc"
+        )
+    lines.extend(
+        [
+            "    classDef open fill:#f5f5f5,stroke:#9e9e9e",
+            "    classDef exploring fill:#e3f2fd,stroke:#1e88e5",
+            "    classDef blocked fill:#ffebee,stroke:#e53935,stroke-width:2px",
+            "    classDef resolved fill:#e8f5e9,stroke:#43a047",
+            "    classDef deadend fill:#eeeeee,stroke:#9e9e9e,stroke-dasharray: 4 4",
+        ]
+    )
+    return {
+        "mermaid": "\n".join(lines),
+        "strategy": "vertical_evidence_timeline",
+        "view_role": role,
+        "group_count": len(groups),
+        "column_count": 1,
+        "orientation": "top_to_bottom",
+        "max_group_node_count": group_limit,
+    }
+
+
 def _tags(node: Mapping[str, Any]) -> set[str]:
     return {str(tag or "").strip().lower() for tag in node.get("tags") or [] if str(tag or "").strip()}
 
@@ -214,6 +338,8 @@ def assess_explore_presentation(
     terminal_ratio = terminal_count / node_count if node_count else 0.0
     edge_density = edge_count / node_count if node_count else 0.0
     max_depth = max(depths.values(), default=0)
+    root_count = sum(not parents.get(node_id) for node_id in node_ids)
+    root_ratio = root_count / node_count if node_count else 0.0
     terminal_neighborhoods = _terminal_neighborhood_count(nodes, parents)
     long_label_count = sum(
         len(str(node.get("title") or "")) > int(thresholds["readability_label_chars"])
@@ -247,6 +373,10 @@ def assess_explore_presentation(
             edge_density >= float(thresholds["readability_edge_density_floor"])
             or long_label_count > 0
             or max_depth >= int(thresholds["decision_depth_floor"])
+            or (
+                root_count >= int(thresholds["readability_root_count_floor"])
+                and root_ratio >= float(thresholds["readability_root_ratio_floor"])
+            )
         )
     )
     if observed_readability_failure or estimated_readability_failure:
@@ -270,6 +400,8 @@ def assess_explore_presentation(
             "terminal_ratio": round(terminal_ratio, 4),
             "terminal_neighborhood_count": terminal_neighborhoods,
             "max_depth": max_depth,
+            "root_node_count": root_count,
+            "root_ratio": round(root_ratio, 4),
             "edge_density": round(edge_density, 4),
             "long_label_count": long_label_count,
         },
@@ -393,6 +525,14 @@ def build_explore_presentation_bundle(
         for node in nodes
     ]
     canonical_edges = [dict(edge, source_edge_id=str(edge.get("edge_id") or "")) for edge in edges]
+    thresholds = dict(DEFAULT_EXPLORE_PRESENTATION_POLICY)
+    thresholds.update(policy or {})
+    canonical_layout = build_vertical_explore_mermaid(
+        canonical_nodes,
+        canonical_edges,
+        view_role="canonical",
+        group_node_limit=int(thresholds["atlas_group_node_limit"]),
+    )
     canonical = {
         "schema_version": EXPLORE_CANONICAL_VIEW_VERSION,
         "goal_id": projection.get("goal_id"),
@@ -402,17 +542,23 @@ def build_explore_presentation_bundle(
         "nodes": canonical_nodes,
         "edges": canonical_edges,
         "findings": findings,
-        "mermaid": build_explore_mermaid(canonical_nodes, canonical_edges, node_limit=max(1, len(nodes))),
+        "mermaid": canonical_layout["mermaid"],
         "graph_counts": {
             "node_count": len(canonical_nodes),
             "edge_count": len(canonical_edges),
             "finding_count": len(findings),
         },
-        "filter": {"projection_mode": "canonical_full", "truncated": False},
+        "filter": {
+            "projection_mode": "canonical_full",
+            "truncated": False,
+            "layout": {
+                key: value
+                for key, value in canonical_layout.items()
+                if key != "mermaid"
+            },
+        },
     }
 
-    thresholds = dict(DEFAULT_EXPLORE_PRESENTATION_POLICY)
-    thresholds.update(policy or {})
     executive_ids = _executive_node_ids(
         nodes,
         edges,
@@ -430,6 +576,12 @@ def build_explore_presentation_bundle(
         if str(edge.get("from_node") or "") in executive_ids
         and str(edge.get("to_node") or "") in executive_ids
     ]
+    executive_layout = build_vertical_explore_mermaid(
+        executive_nodes,
+        executive_edges,
+        view_role="executive",
+        group_node_limit=int(thresholds["atlas_group_node_limit"]),
+    )
     executive_findings = [
         finding
         for finding in findings
@@ -445,11 +597,7 @@ def build_explore_presentation_bundle(
         "nodes": executive_nodes,
         "edges": executive_edges,
         "findings": executive_findings,
-        "mermaid": build_explore_mermaid(
-            executive_nodes,
-            executive_edges,
-            node_limit=max(1, len(executive_nodes)),
-        ),
+        "mermaid": executive_layout["mermaid"],
         "graph_counts": {
             "node_count": len(executive_nodes),
             "edge_count": len(executive_edges),
@@ -460,6 +608,11 @@ def build_explore_presentation_bundle(
             "projection_mode": "executive_auto",
             "selection": "active_or_tagged_plus_material_neighbors_and_lineage",
             "truncated": False,
+            "layout": {
+                key: value
+                for key, value in executive_layout.items()
+                if key != "mermaid"
+            },
         },
     }
     return {

--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -14,7 +14,6 @@ topology source in the projection is for Feishu docs or any diagram renderer.
 
 from __future__ import annotations
 
-import hashlib
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -33,6 +32,13 @@ from ....capabilities.explore.result_log import (
     NODE_STATUS_RESOLVED,
     EDGE_TYPES,
     build_explore_graph_view,
+)
+from ...explore_views import (
+    PRESENTATION_MODE_DUAL_VIEW,
+    build_explore_presentation_bundle,
+    explore_source_digest,
+    explore_source_revision,
+    validate_explore_view_freshness,
 )
 from .kanban import (
     DEFAULT_CLI_BIN,
@@ -57,6 +63,7 @@ LARK_EXPLORE_SYNC_VERSION = "loopx_lark_explore_sync_v0"
 LARK_EXPLORE_READBACK_VERSION = "loopx_lark_explore_readback_v0"
 LARK_EXPLORE_CARD_VERSION = "loopx_lark_explore_card_v0"
 LARK_EXPLORE_VISUAL_SYNC_VERSION = "loopx_lark_explore_visual_sync_v0"
+LARK_EXPLORE_VISUALS_SYNC_VERSION = "loopx_lark_explore_visuals_sync_v0"
 
 DEFAULT_EXPLORE_BASE_NAME = "LoopX Exploration Results"
 SINK_VISIBILITY_OWNER_ONLY = "owner-only"
@@ -447,6 +454,7 @@ def configure_lark_explore_visual_sink(
     projection_mode: str = "canonical_filtered",
     include_ancestors: bool = True,
     mermaid_node_limit: int = 100,
+    view_role: str | None = None,
     execute: bool = False,
 ) -> dict[str, Any]:
     """Configure an optional owner-facing whiteboard over canonical Explore data."""
@@ -454,8 +462,20 @@ def configure_lark_explore_visual_sink(
     token = str(whiteboard_token or "").strip()
     if not token:
         raise ValueError("whiteboard_token is required")
-    if projection_mode not in {"canonical_filtered", "issue_fix_two_lane"}:
-        raise ValueError("projection_mode must be canonical_filtered or issue_fix_two_lane")
+    valid_modes = {
+        "canonical_filtered",
+        "issue_fix_two_lane",
+        "canonical_full",
+        "executive_auto",
+    }
+    if projection_mode not in valid_modes:
+        raise ValueError(f"projection_mode must be one of {sorted(valid_modes)}")
+    role = str(view_role or "").strip() or None
+    if role not in {None, "canonical", "executive"}:
+        raise ValueError("view_role must be canonical or executive")
+    expected_mode = {"canonical": "canonical_full", "executive": "executive_auto"}.get(role)
+    if expected_mode and projection_mode != expected_mode:
+        raise ValueError(f"view_role {role} requires projection_mode {expected_mode}")
     local = read_lark_explore_local_config(config_path)
     if not local.get("ok") or not local.get("exists"):
         raise ValueError("run `loopx explore feishu-setup` before configuring a visual sink")
@@ -469,9 +489,16 @@ def configure_lark_explore_visual_sink(
         "include_ancestors": bool(include_ancestors),
         "mermaid_node_limit": max(1, int(mermaid_node_limit)),
     }
+    if role:
+        visual_sink["view_role"] = role
     if execute:
         updated = {key: value for key, value in local.items() if key not in {"ok", "exists", "path", "updated_at"}}
-        updated["visual_sink"] = visual_sink
+        if role:
+            visual_sinks = dict(updated.get("visual_sinks") or {})
+            visual_sinks[role] = visual_sink
+            updated["visual_sinks"] = visual_sinks
+        else:
+            updated["visual_sink"] = visual_sink
         write_lark_explore_local_config(config_path, updated)
     return {
         "ok": True,
@@ -479,6 +506,7 @@ def configure_lark_explore_visual_sink(
         "execute": execute,
         "status": "configured" if execute else "would_configure",
         "config_path": str(config_path),
+        "view_role": role,
         "visual_sink": visual_sink,
     }
 
@@ -491,6 +519,7 @@ def sync_explore_visual_to_lark(
     config_path: Path,
     semantic_digest: str,
     display_projection: Mapping[str, Any] | None = None,
+    view_key: str | None = None,
     execute: bool = False,
     runner: CommandRunner = default_subprocess_runner,
 ) -> dict[str, Any]:
@@ -514,6 +543,24 @@ def sync_explore_visual_to_lark(
             "published": False,
             "error": "visual_sink.whiteboard_token is required",
         }
+    source_digest = explore_source_digest(projection)
+    source_revision = explore_source_revision(projection, digest=source_digest)
+    if isinstance(display_projection, Mapping) and (
+        display_projection.get("source_digest") or display_projection.get("source_revision")
+    ):
+        freshness = validate_explore_view_freshness(projection, display_projection)
+        if not freshness["fresh"]:
+            return {
+                "ok": False,
+                "schema_version": LARK_EXPLORE_VISUAL_SYNC_VERSION,
+                "status": "stale_projection",
+                "execute": execute,
+                "published": False,
+                "source_digest": source_digest,
+                "source_revision": source_revision,
+                "freshness": freshness,
+                "error": freshness["reason"],
+            }
     graph = (
         dict(display_projection)
         if isinstance(display_projection, Mapping)
@@ -526,7 +573,16 @@ def sync_explore_visual_to_lark(
             node_limit=max(1, int(visual_sink.get("mermaid_node_limit") or 100)),
         )
     )
-    source_name = f".loopx-explore-visual-{semantic_digest[:12] or 'preview'}.mmd"
+    sink_key = str(view_key or visual_sink.get("view_role") or "visual").strip() or "visual"
+    sink_digest = explore_source_digest(
+        {
+            "goal_id": projection.get("goal_id"),
+            "nodes": [{"node_id": sink_key, "title": semantic_digest}],
+            "edges": [],
+            "findings": [],
+        }
+    )
+    source_name = f".loopx-explore-{sink_key}-{sink_digest[:12]}.mmd"
     command = [
         config.cli_bin,
         "whiteboard",
@@ -541,7 +597,7 @@ def sync_explore_visual_to_lark(
         f"@{source_name}",
         "--overwrite",
         "--idempotent-token",
-        f"loopx-explore-{semantic_digest[:24] or 'visual-preview'}",
+        f"loopx-explore-{sink_key}-{sink_digest[:20]}",
         "--format",
         "json",
     ]
@@ -567,6 +623,9 @@ def sync_explore_visual_to_lark(
         "execute": execute,
         "published": bool(execute and result.get("ok")),
         "semantic_digest": semantic_digest,
+        "source_digest": source_digest,
+        "source_revision": source_revision,
+        "view_role": str(graph.get("view_role") or sink_key),
         "docx_token": str(visual_sink.get("docx_token") or "") or None,
         "graph_counts": graph.get("graph_counts"),
         "filter": graph.get("filter"),
@@ -578,48 +637,76 @@ def sync_explore_visual_to_lark(
 def explore_visual_semantic_digest(projection: Mapping[str, Any]) -> str:
     """Return a timestamp-free digest for an explicit visual projection sync."""
 
-    semantic = {
-        "goal_id": projection.get("goal_id"),
-        "nodes": [
-            {
-                key: node.get(key)
-                for key in (
-                    "node_id",
-                    "title",
-                    "node_kind",
-                    "status",
-                    "summary",
-                    "blocked_reason",
-                    "parent_id",
-                    "tags",
-                    "supersedes",
-                )
+    return explore_source_digest(projection)
+
+
+def sync_explore_visuals_to_lark(
+    config: LarkExploreConfig,
+    *,
+    projection: Mapping[str, Any],
+    visual_sinks: Mapping[str, Any],
+    config_path: Path,
+    execute: bool = False,
+    runner: CommandRunner = default_subprocess_runner,
+) -> dict[str, Any]:
+    """Generate and publish configured same-source Explore views."""
+
+    bundle = build_explore_presentation_bundle(projection)
+    requested_roles = [
+        role
+        for role in ("canonical", "executive")
+        if isinstance(visual_sinks.get(role), Mapping)
+    ]
+    active_roles = ["canonical"]
+    if bundle["presentation_mode"] == PRESENTATION_MODE_DUAL_VIEW:
+        active_roles.append("executive")
+    missing_recommended_roles = [
+        role for role in active_roles if role not in requested_roles
+    ]
+    results: dict[str, Any] = {}
+    for role in requested_roles:
+        if role not in active_roles:
+            results[role] = {
+                "ok": True,
+                "status": "not_recommended",
+                "execute": execute,
+                "published": False,
+                "source_digest": bundle["source_digest"],
+                "source_revision": bundle["source_revision"],
+                "view_role": role,
             }
-            for node in projection.get("nodes") or []
-            if isinstance(node, Mapping)
-        ],
-        "edges": [
-            {
-                key: edge.get(key)
-                for key in (
-                    "edge_id",
-                    "from_node",
-                    "to_node",
-                    "edge_type",
-                    "summary",
-                )
-            }
-            for edge in projection.get("edges") or []
-            if isinstance(edge, Mapping)
-        ],
+            continue
+        results[role] = sync_explore_visual_to_lark(
+            config,
+            projection=projection,
+            visual_sink=visual_sinks[role],
+            config_path=config_path,
+            semantic_digest=bundle["source_digest"],
+            display_projection=bundle[role],
+            view_key=role,
+            execute=execute,
+            runner=runner,
+        )
+    ok = all(bool(item.get("ok")) for item in results.values())
+    if not results:
+        status = "not_configured"
+    elif not ok:
+        status = "publish_failed" if execute else "invalid_projection"
+    else:
+        status = "published" if execute else "would_publish"
+    return {
+        "ok": ok,
+        "schema_version": LARK_EXPLORE_VISUALS_SYNC_VERSION,
+        "status": status,
+        "execute": execute,
+        "presentation_mode": bundle["presentation_mode"],
+        "reason_codes": bundle["reason_codes"],
+        "source_digest": bundle["source_digest"],
+        "source_revision": bundle["source_revision"],
+        "recommended_roles": active_roles,
+        "missing_recommended_roles": missing_recommended_roles,
+        "views": results,
     }
-    encoded = json.dumps(
-        semantic,
-        ensure_ascii=False,
-        sort_keys=True,
-        separators=(",", ":"),
-    ).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()
 
 
 def setup_lark_explore_board(

--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -14,6 +14,7 @@ topology source in the projection is for Feishu docs or any diagram renderer.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -574,15 +575,19 @@ def sync_explore_visual_to_lark(
         )
     )
     sink_key = str(view_key or visual_sink.get("view_role") or "visual").strip() or "visual"
-    sink_digest = explore_source_digest(
+    delivery_material = json.dumps(
         {
-            "goal_id": projection.get("goal_id"),
-            "nodes": [{"node_id": sink_key, "title": semantic_digest}],
-            "edges": [],
-            "findings": [],
-        }
-    )
-    source_name = f".loopx-explore-{sink_key}-{sink_digest[:12]}.mmd"
+            "source_digest": semantic_digest,
+            "source_revision": source_revision,
+            "view_role": sink_key,
+            "mermaid": str(graph.get("mermaid") or ""),
+        },
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    delivery_digest = hashlib.sha256(delivery_material).hexdigest()
+    source_name = f".loopx-explore-{sink_key}-{delivery_digest[:12]}.mmd"
     command = [
         config.cli_bin,
         "whiteboard",
@@ -597,7 +602,7 @@ def sync_explore_visual_to_lark(
         f"@{source_name}",
         "--overwrite",
         "--idempotent-token",
-        f"loopx-explore-{sink_key}-{sink_digest[:20]}",
+        f"loopx-explore-{sink_key}-{delivery_digest[:20]}",
         "--format",
         "json",
     ]
@@ -623,6 +628,7 @@ def sync_explore_visual_to_lark(
         "execute": execute,
         "published": bool(execute and result.get("ok")),
         "semantic_digest": semantic_digest,
+        "delivery_digest": delivery_digest,
         "source_digest": source_digest,
         "source_revision": source_revision,
         "view_role": str(graph.get("view_role") or sink_key),

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -120,12 +120,51 @@ def test_complex_graph_recommends_traceable_dual_view() -> None:
     }.issubset(bundle["reason_codes"])
     assert bundle["canonical"]["source_digest"] == bundle["executive"]["source_digest"]
     assert bundle["canonical"]["source_revision"] == bundle["executive"]["source_revision"]
+    assert bundle["canonical"]["mermaid"].startswith("flowchart TB")
+    assert "subgraph canonical_atlas" in bundle["canonical"]["mermaid"]
+    assert (
+        bundle["canonical"]["filter"]["layout"]["strategy"]
+        == "vertical_evidence_timeline"
+    )
+    assert bundle["canonical"]["filter"]["layout"]["column_count"] == 1
+    assert bundle["executive"]["mermaid"].startswith("flowchart TB")
+    assert "subgraph executive_atlas" in bundle["executive"]["mermaid"]
+    assert "Canonical evidence timeline" not in bundle["executive"]["mermaid"]
+    assert (
+        bundle["executive"]["filter"]["layout"]["orientation"]
+        == "top_to_bottom"
+    )
+    canonical_mermaid = bundle["canonical"]["mermaid"]
+    for node in projection["nodes"]:
+        assert f'{str(node["node_id"]).replace("-", "_")}["' in canonical_mermaid
+    for edge in projection["edges"]:
+        source = str(edge["from_node"]).replace("-", "_")
+        target = str(edge["to_node"]).replace("-", "_")
+        assert f"{source} -->|supports| {target}" in canonical_mermaid
     canonical_ids = {node["node_id"] for node in bundle["canonical"]["nodes"]}
     assert len(bundle["executive"]["nodes"]) < len(canonical_ids)
     for node in bundle["executive"]["nodes"]:
         assert node["source_node_id"] in canonical_ids
         assert node["lineage"][-1] == node["source_node_id"]
     assert bundle["assessment"]["canonical_truncation_allowed"] is False
+
+
+def test_flat_large_graph_is_classified_as_a_readability_failure() -> None:
+    projection = {
+        "ok": True,
+        "goal_id": "goal-public-fixture",
+        "source_event_count": 80,
+        "nodes": [_node(f"root-{index}") for index in range(80)],
+        "edges": [],
+        "findings": [],
+    }
+
+    bundle = build_explore_presentation_bundle(projection)
+
+    assert "readability_check_failed" in bundle["reason_codes"]
+    assert bundle["assessment"]["metrics"]["root_node_count"] == 80
+    assert bundle["assessment"]["readability_check"]["failed"] is True
+    assert bundle["canonical"]["filter"]["layout"]["column_count"] == 1
 
 
 def test_findings_change_digest_and_stale_view_is_rejected() -> None:

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from loopx.presentation.explore_views import (
+    PRESENTATION_MODE_CANONICAL_ONLY,
+    PRESENTATION_MODE_DUAL_VIEW,
+    build_explore_presentation_bundle,
+    explore_source_digest,
+    validate_explore_view_freshness,
+)
+from loopx.presentation.sinks.lark.explore_results import (
+    LarkExploreConfig,
+    configure_lark_explore_visual_sink,
+    read_lark_explore_local_config,
+    sync_explore_visual_to_lark,
+    sync_explore_visuals_to_lark,
+    write_lark_explore_local_config,
+)
+
+
+def _node(
+    node_id: str,
+    *,
+    parent_id: str = "",
+    status: str = "resolved",
+    tags: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "node_id": node_id,
+        "title": f"Public fixture {node_id}",
+        "node_kind": "experiment",
+        "status": status,
+        "parent_id": parent_id,
+        "tags": tags or [],
+    }
+
+
+def _edge(source: str, target: str) -> dict[str, object]:
+    return {
+        "edge_id": f"edge-{source}-{target}",
+        "from_node": source,
+        "to_node": target,
+        "edge_type": "supports",
+    }
+
+
+def _small_projection() -> dict[str, object]:
+    return {
+        "ok": True,
+        "goal_id": "goal-public-fixture",
+        "source_event_count": 3,
+        "nodes": [
+            _node("root", status="resolved", tags=["baseline"]),
+            _node("candidate", parent_id="root", status="exploring", tags=["current-best"]),
+        ],
+        "edges": [_edge("root", "candidate")],
+        "findings": [
+            {
+                "finding_id": "finding-candidate",
+                "finding": "Candidate evidence",
+                "node_id": "candidate",
+                "status": "confirmed",
+            }
+        ],
+    }
+
+
+def _complex_projection() -> dict[str, object]:
+    nodes = [_node("root", status="open", tags=["decision"])]
+    edges = []
+    for branch_index in range(8):
+        branch_id = f"branch-{branch_index}"
+        nodes.append(_node(branch_id, parent_id="root"))
+        edges.append(_edge("root", branch_id))
+        for leaf_index in range(4):
+            leaf_id = f"leaf-{branch_index}-{leaf_index}"
+            nodes.append(_node(leaf_id, parent_id=branch_id, status="dead_end"))
+            edges.append(_edge(branch_id, leaf_id))
+    nodes.append(
+        _node(
+            "candidate",
+            parent_id="root",
+            status="exploring",
+            tags=["current-best"],
+        )
+    )
+    edges.append(_edge("root", "candidate"))
+    return {
+        "ok": True,
+        "goal_id": "goal-public-fixture",
+        "source_event_count": len(nodes) + len(edges),
+        "nodes": nodes,
+        "edges": edges,
+        "findings": [],
+    }
+
+
+def test_small_graph_keeps_canonical_only_and_complete() -> None:
+    projection = _small_projection()
+
+    bundle = build_explore_presentation_bundle(projection)
+
+    assert bundle["presentation_mode"] == PRESENTATION_MODE_CANONICAL_ONLY
+    assert bundle["canonical"]["graph_counts"]["node_count"] == len(projection["nodes"])
+    assert bundle["canonical"]["filter"]["truncated"] is False
+
+
+def test_complex_graph_recommends_traceable_dual_view() -> None:
+    projection = _complex_projection()
+
+    bundle = build_explore_presentation_bundle(projection)
+
+    assert bundle["presentation_mode"] == PRESENTATION_MODE_DUAL_VIEW
+    assert {
+        "low_decision_density",
+        "excessive_terminal_branches",
+    }.issubset(bundle["reason_codes"])
+    assert bundle["canonical"]["source_digest"] == bundle["executive"]["source_digest"]
+    assert bundle["canonical"]["source_revision"] == bundle["executive"]["source_revision"]
+    canonical_ids = {node["node_id"] for node in bundle["canonical"]["nodes"]}
+    assert len(bundle["executive"]["nodes"]) < len(canonical_ids)
+    for node in bundle["executive"]["nodes"]:
+        assert node["source_node_id"] in canonical_ids
+        assert node["lineage"][-1] == node["source_node_id"]
+    assert bundle["assessment"]["canonical_truncation_allowed"] is False
+
+
+def test_findings_change_digest_and_stale_view_is_rejected() -> None:
+    projection = _small_projection()
+    bundle = build_explore_presentation_bundle(projection)
+    changed = json.loads(json.dumps(projection))
+    changed["findings"][0]["finding"] = "Updated candidate evidence"
+
+    assert explore_source_digest(changed) != bundle["source_digest"]
+    freshness = validate_explore_view_freshness(changed, bundle["executive"])
+    assert freshness["fresh"] is False
+    assert freshness["reason"]
+
+
+def test_presentation_rejects_a_bounded_canonical_finding_projection() -> None:
+    projection = _small_projection()
+    projection["counts"] = {"finding_count": 2}
+
+    with pytest.raises(ValueError, match="complete canonical finding set"):
+        build_explore_presentation_bundle(projection)
+
+
+def test_visual_configuration_preserves_legacy_and_supports_roles(tmp_path) -> None:
+    config_path = tmp_path / "lark-explore.json"
+    write_lark_explore_local_config(
+        config_path,
+        {
+            "board": {
+                "base_token": "PUBLIC_FIXTURE_BASE",
+                "tables": {"nodes": "tblN", "edges": "tblE", "findings": "tblF"},
+            }
+        },
+    )
+    configure_lark_explore_visual_sink(
+        config_path=config_path,
+        whiteboard_token="wb_legacy_fixture",
+        execute=True,
+    )
+    configure_lark_explore_visual_sink(
+        config_path=config_path,
+        whiteboard_token="wb_canonical_fixture",
+        projection_mode="canonical_full",
+        view_role="canonical",
+        execute=True,
+    )
+    configure_lark_explore_visual_sink(
+        config_path=config_path,
+        whiteboard_token="wb_executive_fixture",
+        projection_mode="executive_auto",
+        view_role="executive",
+        execute=True,
+    )
+
+    stored = read_lark_explore_local_config(config_path)
+    assert stored["visual_sink"]["whiteboard_token"] == "wb_legacy_fixture"
+    assert stored["visual_sinks"]["canonical"]["view_role"] == "canonical"
+    assert stored["visual_sinks"]["executive"]["view_role"] == "executive"
+
+
+def test_dual_visual_sync_uses_one_revision_and_rejects_stale_view(tmp_path) -> None:
+    projection = _complex_projection()
+    config = LarkExploreConfig(
+        base_token="PUBLIC_FIXTURE_BASE",
+        table_ids={"nodes": "tblN", "edges": "tblE", "findings": "tblF"},
+    )
+    sinks = {
+        "canonical": {
+            "whiteboard_token": "wb_canonical_fixture",
+            "view_role": "canonical",
+        },
+        "executive": {
+            "whiteboard_token": "wb_executive_fixture",
+            "view_role": "executive",
+        },
+    }
+
+    synced = sync_explore_visuals_to_lark(
+        config,
+        projection=projection,
+        visual_sinks=sinks,
+        config_path=tmp_path / "lark-explore.json",
+    )
+
+    assert synced["ok"] is True
+    assert synced["presentation_mode"] == PRESENTATION_MODE_DUAL_VIEW
+    revisions = {view["source_revision"] for view in synced["views"].values()}
+    assert revisions == {synced["source_revision"]}
+
+    bundle = build_explore_presentation_bundle(projection)
+    changed = json.loads(json.dumps(projection))
+    changed["nodes"][0]["title"] = "Changed canonical source"
+    stale = sync_explore_visual_to_lark(
+        config,
+        projection=changed,
+        visual_sink=sinks["executive"],
+        config_path=tmp_path / "lark-explore.json",
+        semantic_digest=bundle["source_digest"],
+        display_projection=bundle["executive"],
+    )
+    assert stale["ok"] is False
+    assert stale["status"] == "stale_projection"
+    assert "command" not in stale

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -267,3 +267,39 @@ def test_dual_visual_sync_uses_one_revision_and_rejects_stale_view(tmp_path) -> 
     assert stale["ok"] is False
     assert stale["status"] == "stale_projection"
     assert "command" not in stale
+
+
+def test_visual_delivery_digest_changes_when_only_rendered_mermaid_changes(tmp_path) -> None:
+    projection = _complex_projection()
+    config = LarkExploreConfig(base_token="PUBLIC_FIXTURE_BASE")
+    sink = {
+        "whiteboard_token": "wb_canonical_fixture",
+        "view_role": "canonical",
+    }
+    bundle = build_explore_presentation_bundle(projection)
+    first_view = bundle["canonical"]
+    changed_view = json.loads(json.dumps(first_view))
+    changed_view["mermaid"] += "\n    %% renderer contract changed"
+
+    first = sync_explore_visual_to_lark(
+        config,
+        projection=projection,
+        visual_sink=sink,
+        config_path=tmp_path / "lark-explore.json",
+        semantic_digest=bundle["source_digest"],
+        display_projection=first_view,
+        view_key="canonical",
+    )
+    changed = sync_explore_visual_to_lark(
+        config,
+        projection=projection,
+        visual_sink=sink,
+        config_path=tmp_path / "lark-explore.json",
+        semantic_digest=bundle["source_digest"],
+        display_projection=changed_view,
+        view_key="canonical",
+    )
+
+    assert first["source_digest"] == changed["source_digest"]
+    assert first["delivery_digest"] != changed["delivery_digest"]
+    assert first["command"]["command"] != changed["command"]["command"]


### PR DESCRIPTION
## Summary
- derive complete canonical and concise executive Explore views from one source projection
- recommend dual view from advisory complexity and readability signals
- reject stale derived projections and preserve source lineage
- support role-based Lark whiteboard configuration while retaining the legacy single-view path

## Validation
- `pytest -q tests` (271 passed, 2 skipped)
- Explore result-layer and issue-fix projection smokes
- `loopx canary premerge --from-git-diff` (17 checks passed, no warnings)
- public/private boundary scan clean

## Skipped checks
- none beyond the repository test suite

## Merge decision
- ready for review; not self-merged