### PR TITLE
fix(quota): gate due monitors by capability

### DIFF
--- a/examples/control_plane/monitor-scheduler-contract-smoke.py
+++ b/examples/control_plane/monitor-scheduler-contract-smoke.py
@@ -524,6 +524,44 @@ def assert_due_monitor_capability_resolution_is_preserved() -> None:
     assert repair_guard["interaction_contract"]["agent_channel"]["must_attempt"] is True, repair_guard
 
 
+def assert_due_monitor_capability_resolution_uses_full_lane() -> None:
+    items = [
+        monitor_item(
+            index=index,
+            todo_id=f"todo_private_monitor_due_{index}",
+            priority="P0",
+            next_due_at=PAST_DUE_AT,
+            target_key=f"private-source-watch-{index}",
+            required_capabilities=["private_read"],
+        )
+        for index in (1, 2)
+    ]
+    items.append(
+        monitor_item(
+            index=3,
+            todo_id="todo_network_monitor_due_after_display_limit",
+            priority="P0",
+            next_due_at=PAST_DUE_AT,
+            target_key="public-network-watch-after-display-limit",
+            required_capabilities=["network"],
+        )
+    )
+    guard = guard_for(items)
+    summary = guard["agent_todo_summary"]
+    gate = guard["capability_gate"]
+    assert summary["monitor_capability_blocked_due_count"] == 3, summary
+    assert len(summary["monitor_capability_blocked_due_items"]) == 2, summary
+    compaction = summary["payload_compaction"]["compacted_lanes"]
+    assert compaction["monitor_capability_blocked_due_items"] == {
+        "shown": 2,
+        "total": 3,
+    }, compaction
+    assert gate["action"] == "ask_owner", gate
+    assert gate["owner_missing"] == ["network"], gate
+    assert "network" in gate["missing"], gate
+    assert guard["heartbeat_recommendation"]["notify"] == "NOTIFY", guard
+
+
 def assert_expired_monitor_does_not_catch_up() -> None:
     guard = guard_for(
         [
@@ -826,6 +864,7 @@ def main() -> int:
     assert_due_monitor_requires_explicit_attempt()
     assert_due_monitor_requires_available_capabilities()
     assert_due_monitor_capability_resolution_is_preserved()
+    assert_due_monitor_capability_resolution_uses_full_lane()
     assert_expired_monitor_does_not_catch_up()
     assert_due_monitor_priority_does_not_steal_advancement_lane()
     assert_capability_skip_yields_to_monitor_schedule_repair()

--- a/examples/control_plane/monitor-scheduler-contract-smoke.py
+++ b/examples/control_plane/monitor-scheduler-contract-smoke.py
@@ -78,6 +78,7 @@ def monitor_item(
     claimed_by: str | None = AGENT_ID,
     expires_at: str | None = None,
     last_checked_at: str | None = None,
+    required_capabilities: list[str] | None = None,
 ) -> dict:
     item = {
         "index": index,
@@ -100,6 +101,8 @@ def monitor_item(
         item["expires_at"] = expires_at
     if last_checked_at:
         item["last_checked_at"] = last_checked_at
+    if required_capabilities:
+        item["required_capabilities"] = required_capabilities
     return item
 
 
@@ -157,6 +160,7 @@ def guard_for(
     latest_runs: list[dict] | None = None,
     include_scheduler_detail: bool = False,
     now: datetime = FROZEN_NOW,
+    available_capabilities: list[str] | None = None,
 ) -> dict:
     original_scheduler_now = scheduler_hint_module.now_utc
     original_monitor_now = monitor_todo_module.now_utc
@@ -171,6 +175,7 @@ def guard_for(
             ),
             goal_id=GOAL_ID,
             agent_id=agent_id,
+            available_capabilities=available_capabilities,
             include_scheduler_detail=include_scheduler_detail,
         )
     finally:
@@ -427,6 +432,48 @@ def assert_due_monitor_requires_explicit_attempt() -> None:
     assert lane["selected_todo_id"] == "todo_monitor_due", lane
     assert guard["interaction_contract"]["agent_channel"]["must_attempt"] is True, guard
     assert guard["interaction_contract"]["agent_channel"]["quiet_noop_allowed"] is False, guard
+
+
+def assert_due_monitor_requires_available_capabilities() -> None:
+    item = monitor_item(
+        index=1,
+        todo_id="todo_private_read_monitor_due",
+        priority="P0",
+        next_due_at=PAST_DUE_AT,
+        target_key="private-source-watch",
+        required_capabilities=["private_read"],
+    )
+    blocked_guard = guard_for([item])
+    blocked_summary = blocked_guard["agent_todo_summary"]
+    blocked_lane = blocked_guard.get("work_lane_contract") or {}
+    assert blocked_guard["decision"] == "skip", blocked_guard
+    assert blocked_guard["effective_action"] == "monitor_quiet_skip", blocked_guard
+    assert blocked_summary["monitor_due_count"] == 0, blocked_summary
+    assert blocked_summary["monitor_open_items"][0]["todo_id"] == item["todo_id"], blocked_summary
+    assert blocked_summary["monitor_capability_blocked_due_count"] == 1, blocked_summary
+    blocked_item = blocked_summary["monitor_capability_blocked_due_items"][0]
+    assert blocked_item["todo_id"] == item["todo_id"], blocked_item
+    assert blocked_item["required_capabilities"] == ["private_read"], blocked_item
+    assert blocked_item["missing_capabilities"] == ["private_read"], blocked_item
+    assert blocked_lane.get("selected_todo_id") != item["todo_id"], blocked_lane
+    assert blocked_guard["interaction_contract"]["agent_channel"]["must_attempt"] is False, blocked_guard
+
+    excluded_guard = guard_for([{**item, "excluded_agents": [AGENT_ID]}])
+    excluded_summary = excluded_guard["agent_todo_summary"]
+    excluded_scope = excluded_summary["claim_scope"]
+    assert excluded_summary["monitor_due_count"] == 0, excluded_summary
+    assert excluded_summary["monitor_capability_blocked_due_count"] == 0, excluded_summary
+    assert excluded_scope["executor_excluded_self_count"] == 1, excluded_scope
+    assert excluded_scope["executor_excluded_self_items"][0]["todo_id"] == item["todo_id"], excluded_scope
+
+    runnable_guard = guard_for([item], available_capabilities=["private_read"])
+    runnable_lane = runnable_guard["work_lane_contract"]
+    assert runnable_guard["decision"] == "run", runnable_guard
+    assert runnable_guard["effective_action"] == "normal_run", runnable_guard
+    assert runnable_guard["agent_todo_summary"]["monitor_due_count"] == 1, runnable_guard
+    assert runnable_guard["agent_todo_summary"]["monitor_capability_blocked_due_count"] == 0, runnable_guard
+    assert runnable_lane["selected_todo_id"] == item["todo_id"], runnable_lane
+    assert runnable_lane["obligation"] == "attempt_due_monitor", runnable_lane
 
 
 def assert_expired_monitor_does_not_catch_up() -> None:
@@ -729,6 +776,7 @@ def main() -> int:
     assert_unscheduled_monitor_requires_metadata_repair()
     assert_unscheduled_monitor_repair_survives_handoff_gates()
     assert_due_monitor_requires_explicit_attempt()
+    assert_due_monitor_requires_available_capabilities()
     assert_expired_monitor_does_not_catch_up()
     assert_due_monitor_priority_does_not_steal_advancement_lane()
     assert_capability_skip_yields_to_monitor_schedule_repair()

--- a/examples/control_plane/monitor-scheduler-contract-smoke.py
+++ b/examples/control_plane/monitor-scheduler-contract-smoke.py
@@ -448,6 +448,7 @@ def assert_due_monitor_requires_available_capabilities() -> None:
     blocked_lane = blocked_guard.get("work_lane_contract") or {}
     assert blocked_guard["decision"] == "skip", blocked_guard
     assert blocked_guard["effective_action"] == "monitor_quiet_skip", blocked_guard
+    assert blocked_guard["capability_gate"]["action"] == "skip", blocked_guard
     assert blocked_summary["monitor_due_count"] == 0, blocked_summary
     assert blocked_summary["monitor_open_items"][0]["todo_id"] == item["todo_id"], blocked_summary
     assert blocked_summary["monitor_capability_blocked_due_count"] == 1, blocked_summary
@@ -474,6 +475,49 @@ def assert_due_monitor_requires_available_capabilities() -> None:
     assert runnable_guard["agent_todo_summary"]["monitor_capability_blocked_due_count"] == 0, runnable_guard
     assert runnable_lane["selected_todo_id"] == item["todo_id"], runnable_lane
     assert runnable_lane["obligation"] == "attempt_due_monitor", runnable_lane
+
+
+def assert_due_monitor_capability_resolution_is_preserved() -> None:
+    owner_guard = guard_for(
+        [
+            monitor_item(
+                index=1,
+                todo_id="todo_network_monitor_due",
+                priority="P0",
+                next_due_at=PAST_DUE_AT,
+                target_key="public-network-watch",
+                required_capabilities=["network"],
+            )
+        ]
+    )
+    owner_gate = owner_guard["capability_gate"]
+    assert owner_gate["action"] == "ask_owner", owner_guard
+    assert owner_gate["owner_missing"] == ["network"], owner_gate
+    assert owner_guard["heartbeat_recommendation"]["notify"] == "NOTIFY", owner_guard
+    assert owner_guard["interaction_contract"]["user_channel"]["action_required"] is True, owner_guard
+    assert owner_guard["interaction_contract"]["agent_channel"]["must_attempt"] is False, owner_guard
+    assert owner_guard["requires_user_action"] is True, owner_guard
+    owner_markdown = render_quota_should_run_markdown(owner_guard)
+    assert "capability_gate: action=ask_owner" in owner_markdown, owner_markdown
+    assert "missing=['network']" in owner_markdown, owner_markdown
+
+    repair_guard = guard_for(
+        [
+            monitor_item(
+                index=1,
+                todo_id="todo_bridge_monitor_due",
+                priority="P1",
+                next_due_at=PAST_DUE_AT,
+                target_key="runner-bridge-watch",
+                required_capabilities=["benchmark_runner"],
+            )
+        ]
+    )
+    repair_gate = repair_guard["capability_gate"]
+    assert repair_gate["action"] == "repair_bridge", repair_guard
+    assert repair_gate["repair_missing"] == ["benchmark_runner"], repair_gate
+    assert repair_guard["capability_repair_allowed"] is True, repair_guard
+    assert repair_guard["interaction_contract"]["agent_channel"]["must_attempt"] is True, repair_guard
 
 
 def assert_expired_monitor_does_not_catch_up() -> None:
@@ -777,6 +821,7 @@ def main() -> int:
     assert_unscheduled_monitor_repair_survives_handoff_gates()
     assert_due_monitor_requires_explicit_attempt()
     assert_due_monitor_requires_available_capabilities()
+    assert_due_monitor_capability_resolution_is_preserved()
     assert_expired_monitor_does_not_catch_up()
     assert_due_monitor_priority_does_not_steal_advancement_lane()
     assert_capability_skip_yields_to_monitor_schedule_repair()

--- a/examples/control_plane/monitor-scheduler-contract-smoke.py
+++ b/examples/control_plane/monitor-scheduler-contract-smoke.py
@@ -449,6 +449,10 @@ def assert_due_monitor_requires_available_capabilities() -> None:
     assert blocked_guard["decision"] == "skip", blocked_guard
     assert blocked_guard["effective_action"] == "monitor_quiet_skip", blocked_guard
     assert blocked_guard["capability_gate"]["action"] == "skip", blocked_guard
+    blocked_fallback = blocked_guard["capability_monitor_fallback"]
+    assert blocked_fallback["blocked_advancement_count"] == 0, blocked_fallback
+    assert blocked_fallback["blocked_due_monitor_count"] == 1, blocked_fallback
+    assert blocked_lane["reason_codes"][0] == "due_monitor_unavailable_by_capability", blocked_lane
     assert blocked_summary["monitor_due_count"] == 0, blocked_summary
     assert blocked_summary["monitor_open_items"][0]["todo_id"] == item["todo_id"], blocked_summary
     assert blocked_summary["monitor_capability_blocked_due_count"] == 1, blocked_summary

--- a/loopx/control_plane/agents/capability_gate.py
+++ b/loopx/control_plane/agents/capability_gate.py
@@ -113,6 +113,21 @@ def available_capabilities_with_defaults(value: Any) -> list[str]:
     return capabilities
 
 
+def missing_required_capabilities(
+    item: dict[str, Any],
+    *,
+    available_capabilities: Any,
+) -> list[str]:
+    available = set(available_capabilities_with_defaults(available_capabilities))
+    required = normalize_required_capabilities(item.get("required_capabilities"))
+    targets = set(normalize_target_capabilities(item.get("target_capabilities")))
+    return [
+        capability
+        for capability in required
+        if capability not in targets and capability not in available
+    ]
+
+
 def _capability_candidate_item(
     item: dict[str, Any],
     *,
@@ -262,12 +277,10 @@ def build_capability_gate(
         targets = normalize_target_capabilities(item.get("target_capabilities"))
         if required or targets:
             saw_requirement = True
-        hard_required = [
-            capability for capability in required if capability not in targets
-        ]
-        missing = [
-            capability for capability in hard_required if capability not in available
-        ]
+        missing = missing_required_capabilities(
+            item,
+            available_capabilities=available,
+        )
         missing_targets = [
             capability for capability in targets if capability not in available
         ]

--- a/loopx/control_plane/agents/capability_gate.py
+++ b/loopx/control_plane/agents/capability_gate.py
@@ -128,6 +128,13 @@ def missing_required_capabilities(
     ]
 
 
+def _capability_item_identity(item: dict[str, Any]) -> tuple[str, str]:
+    return (
+        str(item.get("todo_id") or ""),
+        str(item.get("text") or "").strip(),
+    )
+
+
 def _capability_candidate_item(
     item: dict[str, Any],
     *,
@@ -216,6 +223,14 @@ def build_capability_gate(
 ) -> dict[str, Any] | None:
     if not isinstance(agent_todo_summary, dict):
         return None
+    monitor_capability_blocked_due_items = agent_todo_summary.get(
+        "monitor_capability_blocked_due_items"
+    )
+    blocked_monitor_items = (
+        monitor_capability_blocked_due_items
+        if isinstance(monitor_capability_blocked_due_items, list)
+        else []
+    )
     active_next_action_executable_items = agent_todo_summary.get(
         "active_next_action_executable_items"
     )
@@ -243,27 +258,40 @@ def build_capability_gate(
     else:
         raw_items = []
         source = "agent_todo_summary.executable_backlog_items"
+    if blocked_monitor_items:
+        has_advancement_items = bool(raw_items)
+        raw_items = [*raw_items, *blocked_monitor_items]
+        source = (
+            f"{source}+agent_todo_summary.monitor_capability_blocked_due_items"
+            if has_advancement_items
+            else "agent_todo_summary.monitor_capability_blocked_due_items"
+        )
     deduped_raw_items: list[Any] = []
     seen_raw: set[tuple[str, str]] = set()
     for item in raw_items:
         if not isinstance(item, dict):
             deduped_raw_items.append(item)
             continue
-        identity = (
-            str(item.get("todo_id") or ""),
-            str(item.get("text") or "").strip(),
-        )
+        identity = _capability_item_identity(item)
         if identity in seen_raw:
             continue
         seen_raw.add(identity)
         deduped_raw_items.append(item)
     raw_items = deduped_raw_items
+    blocked_monitor_identities = {
+        _capability_item_identity(item)
+        for item in blocked_monitor_items
+        if isinstance(item, dict)
+    }
     candidates = [
         item
         for item in raw_items
         if isinstance(item, dict)
         and todo_item_is_actionable_open(item)
-        and todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+        and (
+            todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+            or _capability_item_identity(item) in blocked_monitor_identities
+        )
     ]
     if not candidates:
         return None

--- a/loopx/control_plane/quota/turn_envelope.py
+++ b/loopx/control_plane/quota/turn_envelope.py
@@ -111,6 +111,7 @@ CONTRACT_CAPSULE_FIELDS = {
         "schema_version",
         "capability_gate_action",
         "blocked_advancement_count",
+        "blocked_due_monitor_count",
         "mode",
     ),
 }

--- a/loopx/control_plane/todos/quota_summary.py
+++ b/loopx/control_plane/todos/quota_summary.py
@@ -304,9 +304,7 @@ def summarize_user_todos_for_quota(
             lanes.monitor_capability_blocked_due_items
         ),
         "monitor_capability_blocked_due_items": (
-            lanes.monitor_capability_blocked_due_items[
-                :QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT
-            ]
+            lanes.monitor_capability_blocked_due_items
         ),
         "monitor_schedule_gap_count": len(monitor_schedule_gap_items),
         "monitor_schedule_gap_items": monitor_schedule_gap_items[:MONITOR_DUE_ITEM_LIMIT],
@@ -547,9 +545,7 @@ def summarize_project_asset_todos_for_quota(
             lanes.monitor_capability_blocked_due_items
         ),
         "monitor_capability_blocked_due_items": (
-            lanes.monitor_capability_blocked_due_items[
-                :QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT
-            ]
+            lanes.monitor_capability_blocked_due_items
         ),
         "active_next_action_items": lanes.active_next_action_items,
         "active_next_action_executable_items": lanes.active_next_action_executable_items,

--- a/loopx/control_plane/todos/quota_summary.py
+++ b/loopx/control_plane/todos/quota_summary.py
@@ -7,6 +7,7 @@ from ..agents.agent_scope import (
     _agent_scope_filter_user_gate_items,
     _agent_scope_selectable_todo_item,
 )
+from ..agents.capability_gate import missing_required_capabilities
 from .claim_visibility import (
     build_agent_claim_scoped_open_items,
     build_todo_claim_visibility_lanes,
@@ -55,6 +56,8 @@ QUOTA_PAYLOAD_ITEM_FIELDS = (
     "task_class",
     "action_kind",
     "continuation_policy",
+    "required_capabilities",
+    "missing_capabilities",
     "claimed_by",
     "blocks_agent",
     "excluded_agents",
@@ -85,6 +88,7 @@ QUOTA_PAYLOAD_ITEM_FIELDS = (
 )
 QUOTA_PAYLOAD_LANE_LIMITS = {
     "monitor_due_items": MONITOR_DUE_ITEM_LIMIT,
+    "monitor_capability_blocked_due_items": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
     "monitor_schedule_gap_items": MONITOR_DUE_ITEM_LIMIT,
     "first_open_items": 3,
     "first_executable_items": 3,
@@ -122,6 +126,7 @@ class _QuotaTodoLanes:
     executable_items: list[dict[str, Any]]
     monitor_items: list[dict[str, Any]]
     monitor_due_items: list[dict[str, Any]]
+    monitor_capability_blocked_due_items: list[dict[str, Any]]
     claimed_open_items: list[dict[str, Any]]
     display_open_items: list[dict[str, Any]]
     active_next_action_items: list[dict[str, Any]]
@@ -136,6 +141,7 @@ def _build_quota_todo_lanes(
     source_open_count: Any,
     agent_identity: dict[str, Any] | None,
     filter_user_gate_blocks_agent: bool,
+    available_capabilities: Any,
 ) -> _QuotaTodoLanes:
     blocking_open_items = all_open_items
     user_action_open_items: list[dict[str, Any]] = []
@@ -173,7 +179,7 @@ def _build_quota_todo_lanes(
         if todo_item_is_actionable_open(item)
         if todo_item_task_class(item) == TODO_TASK_CLASS_MONITOR
     ]
-    monitor_due_items = (
+    monitor_due_candidates = (
         [
             item
             for item in monitor_items
@@ -183,6 +189,22 @@ def _build_quota_todo_lanes(
         if todo_summary_monitor_writeback_supported(value)
         else []
     )
+    monitor_due_items: list[dict[str, Any]] = []
+    monitor_capability_blocked_due_items: list[dict[str, Any]] = []
+    for item in monitor_due_candidates:
+        missing = missing_required_capabilities(
+            item,
+            available_capabilities=available_capabilities,
+        )
+        if missing:
+            diagnostic_item = compact_todo_summary_item(
+                item,
+                text=str(item.get("text") or "").strip(),
+            )
+            diagnostic_item["missing_capabilities"] = missing
+            monitor_capability_blocked_due_items.append(diagnostic_item)
+            continue
+        monitor_due_items.append(item)
     active_next_action_items = (
         [
             compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
@@ -219,6 +241,7 @@ def _build_quota_todo_lanes(
         executable_items=executable_items,
         monitor_items=monitor_items,
         monitor_due_items=monitor_due_items,
+        monitor_capability_blocked_due_items=monitor_capability_blocked_due_items,
         claimed_open_items=[
             item for item in blocking_open_items if item.get("claimed_by")
         ],
@@ -238,6 +261,7 @@ def summarize_user_todos_for_quota(
     *,
     agent_identity: dict[str, Any] | None = None,
     filter_user_gate_blocks_agent: bool = False,
+    available_capabilities: Any = None,
 ) -> dict[str, Any] | None:
     if not isinstance(value, dict):
         return None
@@ -251,6 +275,7 @@ def summarize_user_todos_for_quota(
         source_open_count=value.get("open_count", len(all_open_items)),
         agent_identity=agent_identity,
         filter_user_gate_blocks_agent=filter_user_gate_blocks_agent,
+        available_capabilities=available_capabilities,
     )
     monitor_schedule_gap_items = todo_summary_monitor_schedule_gap_items(
         {
@@ -275,6 +300,14 @@ def summarize_user_todos_for_quota(
         "monitor_open_items": lanes.monitor_items,
         "monitor_due_count": len(lanes.monitor_due_items),
         "monitor_due_items": lanes.monitor_due_items[:MONITOR_DUE_ITEM_LIMIT],
+        "monitor_capability_blocked_due_count": len(
+            lanes.monitor_capability_blocked_due_items
+        ),
+        "monitor_capability_blocked_due_items": (
+            lanes.monitor_capability_blocked_due_items[
+                :QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT
+            ]
+        ),
         "monitor_schedule_gap_count": len(monitor_schedule_gap_items),
         "monitor_schedule_gap_items": monitor_schedule_gap_items[:MONITOR_DUE_ITEM_LIMIT],
         "active_next_action_items": lanes.active_next_action_items,
@@ -463,6 +496,7 @@ def summarize_project_asset_todos_for_quota(
     *,
     agent_identity: dict[str, Any] | None = None,
     filter_user_gate_blocks_agent: bool = False,
+    available_capabilities: Any = None,
 ) -> dict[str, Any] | None:
     if not isinstance(value, dict):
         return None
@@ -476,6 +510,7 @@ def summarize_project_asset_todos_for_quota(
             value,
             agent_identity=agent_identity,
             filter_user_gate_blocks_agent=filter_user_gate_blocks_agent,
+            available_capabilities=available_capabilities,
         )
 
     all_open_items = sorted(
@@ -495,6 +530,7 @@ def summarize_project_asset_todos_for_quota(
         source_open_count=value.get("open", value.get("open_count", len(all_open_items))),
         agent_identity=agent_identity,
         filter_user_gate_blocks_agent=filter_user_gate_blocks_agent,
+        available_capabilities=available_capabilities,
     )
     summary = {
         "schema_version": value.get("schema_version"),
@@ -507,6 +543,14 @@ def summarize_project_asset_todos_for_quota(
         "monitor_open_items": lanes.monitor_items,
         "monitor_due_count": len(lanes.monitor_due_items),
         "monitor_due_items": lanes.monitor_due_items[:MONITOR_DUE_ITEM_LIMIT],
+        "monitor_capability_blocked_due_count": len(
+            lanes.monitor_capability_blocked_due_items
+        ),
+        "monitor_capability_blocked_due_items": (
+            lanes.monitor_capability_blocked_due_items[
+                :QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT
+            ]
+        ),
         "active_next_action_items": lanes.active_next_action_items,
         "active_next_action_executable_items": lanes.active_next_action_executable_items,
         "backlog_items": lanes.display_open_items[:TODO_BACKLOG_ITEM_LIMIT],
@@ -605,11 +649,13 @@ def select_quota_todo_summary(
         canonical_value,
         agent_identity=agent_identity,
         filter_user_gate_blocks_agent=filter_user_gate_blocks_agent,
+        available_capabilities=available_capabilities,
     )
     project_asset_summary = summarize_project_asset_todos_for_quota(
         project_asset_value,
         agent_identity=agent_identity,
         filter_user_gate_blocks_agent=filter_user_gate_blocks_agent,
+        available_capabilities=available_capabilities,
     )
     if is_canonical_attention_todo_summary(canonical_value):
         return canonical_summary or project_asset_summary

--- a/loopx/control_plane/work_items/capability_monitor_fallback.py
+++ b/loopx/control_plane/work_items/capability_monitor_fallback.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import Any
 
 from ..agents.capability_gate import build_capability_gate
+from ..todos.contract import TODO_TASK_CLASS_ADVANCEMENT, TODO_TASK_CLASS_MONITOR
+from ..todos.projection import todo_item_task_class
 from ..todos.summary_item import compact_todo_summary_item
 
 
@@ -58,20 +60,50 @@ def build_capability_skip_monitor_fallback_contract(
     if not monitor_items:
         return None, None
 
-    blocked_advancement_count = len(
+    blocked_candidates = (
         capability_gate.get("blocked_candidates")
         if isinstance(capability_gate.get("blocked_candidates"), list)
         else []
     )
+    blocked_advancement_count = sum(
+        1
+        for item in blocked_candidates
+        if isinstance(item, dict)
+        and todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+    )
+    blocked_due_monitor_count = sum(
+        1
+        for item in blocked_candidates
+        if isinstance(item, dict)
+        and todo_item_task_class(item) == TODO_TASK_CLASS_MONITOR
+    )
+    capability_unavailable_reason = (
+        "advancement_unavailable_by_capability"
+        if blocked_advancement_count
+        else "due_monitor_unavailable_by_capability"
+    )
+    if blocked_advancement_count and blocked_due_monitor_count:
+        fallback_reason = (
+            "advancement and due-monitor candidates require unavailable capabilities, "
+            "so remaining current-agent monitor work must stay visible to the scheduler"
+        )
+    elif blocked_due_monitor_count:
+        fallback_reason = (
+            "due-monitor candidates require unavailable capabilities, so their "
+            "diagnostic monitor state must stay visible to the scheduler"
+        )
+    else:
+        fallback_reason = (
+            "all advancement candidates require unavailable capabilities, so "
+            "current-agent monitor work must remain visible to the scheduler"
+        )
     base_fallback = {
         "schema_version": CAPABILITY_MONITOR_FALLBACK_SCHEMA_VERSION,
         "source": "quota.capability_gate",
         "capability_gate_action": "skip",
         "blocked_advancement_count": blocked_advancement_count,
-        "reason": (
-            "all advancement candidates require unavailable capabilities, "
-            "so current-agent monitor work must remain visible to the scheduler"
-        ),
+        "blocked_due_monitor_count": blocked_due_monitor_count,
+        "reason": fallback_reason,
     }
 
     due_items = (
@@ -91,7 +123,7 @@ def build_capability_skip_monitor_fallback_contract(
                 "obligation": "attempt_due_monitor",
                 "must_attempt_work": True,
                 "reason_codes": [
-                    "advancement_unavailable_by_capability",
+                    capability_unavailable_reason,
                     "monitor_due",
                 ],
                 "monitor_policy": "attempt_due_monitor_once_then_writeback_or_no_spend_if_unchanged",
@@ -126,7 +158,7 @@ def build_capability_skip_monitor_fallback_contract(
                 "obligation": "repair_monitor_schedule_metadata",
                 "must_attempt_work": True,
                 "reason_codes": [
-                    "advancement_unavailable_by_capability",
+                    capability_unavailable_reason,
                     "monitor_schedule_metadata_gap",
                 ],
                 "monitor_policy": "repair_schedule_metadata_before_quiet_wait",
@@ -151,7 +183,7 @@ def build_capability_skip_monitor_fallback_contract(
             "obligation": "quiet_until_material_monitor_transition",
             "must_attempt_work": False,
             "reason_codes": [
-                "advancement_unavailable_by_capability",
+                capability_unavailable_reason,
                 "monitor_todo_present",
             ],
             "monitor_policy": "write_once_per_material_transition_else_no_spend",


### PR DESCRIPTION
## Summary
- gate due monitors with the same default-capability and resolution semantics as advancement work
- keep unavailable due monitors visible in a bounded diagnostic lane without selecting them for unauthorized execution
- route owner-held misses to user action, repairable misses to bridge repair, and unsupported misses to quiet diagnostics
- distinguish blocked monitor and advancement counts in scheduler fallback and turn-envelope projections

## Validation
- focused capability, scheduler, quota lane, private-boundary, read-model, payload, parity, and performance smokes passed
- owner-held `network`, repairable `benchmark_runner`, unsupported `private_read`, explicit availability, and executor-exclusion paths are covered
- default Markdown exposes the owner-held missing capability
- `loopx canary premerge --from-git-diff`: 17/17 selected checks passed; no failures, skips, warnings, or manual holds
- GitHub `pytest` passes and public-boundary scan passes for all five changed paths

## Review
- initial independent review found the owner-resolution gap; current head includes the requested fix and awaits re-review

## Boundary
- changed paths are four core control-plane modules and one durable scheduler smoke
- no private state, credentials, raw benchmark evidence, local paths, generated logs, or learning-queue material included