### PR TITLE
test(peer): align thin prompt assertion

### DIFF
--- a/examples/control_plane/peer-agent-migration-smoke.py
+++ b/examples/control_plane/peer-agent-migration-smoke.py
@@ -323,7 +323,8 @@ def main() -> int:
         assert "side_agent_handoff_agent" not in heartbeat, heartbeat
         assert "single primary" not in heartbeat["task_body"].lower(), heartbeat
         assert "side-agent" not in heartbeat["task_body"].lower(), heartbeat
-        assert "equal peer agent" in heartbeat["task_body"].lower(), heartbeat
+        assert "equal peer" in heartbeat["task_body"].lower(), heartbeat
+        assert "no cross-agent authority" in heartbeat["task_body"].lower(), heartbeat
 
     print("peer-agent-migration-smoke ok")
     return 0


### PR DESCRIPTION
## Summary
- align the peer migration smoke with the intentionally compressed thin heartbeat prompt
- keep the durable semantic checks for equal-peer status and absence of cross-agent authority

## Validation
- `python3 examples/control_plane/peer-agent-migration-smoke.py`
- `python3 examples/control_plane/peer-agent-runtime-v1-smoke.py`
- `python3 examples/control_plane/heartbeat-prompt-smoke.py`
- `python3 -m py_compile examples/control_plane/peer-agent-migration-smoke.py`
- `loopx canary premerge --from-git-diff`: 3/3 passed, self-merge allowed

## Boundary
- validation-only change; no runtime semantics changed
- no private state, credentials, local paths, raw logs, or generated artifacts included