### PR TITLE
feat(semantic-preference): add OpenViking project peer provider

### DIFF
--- a/docs/capabilities/semantic-preference/README.md
+++ b/docs/capabilities/semantic-preference/README.md
@@ -1,5 +1,8 @@
 # Semantic preference hook
 
+For the built-in OpenViking project-scoped adapter, see
+[OpenViking project peer provider](openviking-project-peer.md).
+
 LoopX can optionally recall semantic preferences before a domain action and
 build a compact application receipt afterwards. The hook is deliberately thin:
 the provider owns storage, ranking, and semantic content; the caller owns how a

--- a/docs/capabilities/semantic-preference/openviking-project-peer.md
+++ b/docs/capabilities/semantic-preference/openviking-project-peer.md
@@ -1,0 +1,77 @@
+# OpenViking project peer provider
+
+LoopX includes a thin, opt-in OpenViking provider for project-scoped semantic
+preferences. One canonical project maps to one reserved OpenViking peer. Git
+worktrees and fresh clones of the same `origin` therefore share a memory scope,
+while another repository resolves to a different scope.
+
+This adapter does not implement memory extraction, ranking, update, or
+supersede semantics. OpenViking owns those behaviors. LoopX only derives the
+project peer, performs bounded `find` calls, and returns the existing semantic
+preference provider protocol for a function-owned application and receipt.
+
+## Scope contract
+
+- Identity comes from the normalized Git `origin`, never the checkout path.
+- A non-Git project must provide a stable `--loopx-project-id`.
+- Recall targets the exact project peer by default.
+- User-global memory is available only through `--include-global-fallback`.
+- The default budget is one `find`; explicit global fallback needs at least two.
+- Only concrete preference nodes under the selected target are returned.
+- OpenViking failures remain subject to the outer surface's `fail_open` or
+  `fail_closed` policy.
+
+Inspect the local scope without contacting OpenViking:
+
+```bash
+loopx semantic-preference openviking-provider \
+  --project . \
+  --user-space default \
+  --describe-scope
+```
+
+The output contains the peer id and target URIs, but not the repository URL or
+local checkout path. An OpenViking agent integration can use the returned
+`peer_id` when adding a user message to a session; OpenViking then owns memory
+write, update, and supersede under that peer.
+
+## Local-private hook config
+
+Keep the config ignored and untracked. Provider paths and OpenViking service
+configuration remain local:
+
+```json
+{
+  "schema_version": "semantic_preference_hook_config_v0",
+  "enabled": true,
+  "provider": {
+    "argv": [
+      "loopx",
+      "semantic-preference",
+      "openviking-provider",
+      "--project",
+      ".",
+      "--user-space",
+      "default",
+      "--max-find-calls",
+      "1"
+    ],
+    "timeout_seconds": 30
+  },
+  "surfaces": {
+    "issue_fix.pr_description": {
+      "query": "PR description structure and validation preferences",
+      "limit": 3,
+      "failure_policy": "fail_open"
+    }
+  }
+}
+```
+
+Add `--ov-bin` or `--cli-config` to the provider argv only when the local
+OpenViking installation needs explicit paths. Use `--doctor` with the same
+arguments for a read-only `ov status` probe.
+
+The consuming function remains the final application boundary. For Issue Fix,
+`build_issue_fix_pr_description()` owns one recall, fail-open preservation,
+preference attribution, and the compact application receipt.

--- a/examples/openviking-project-peer-provider-smoke.py
+++ b/examples/openviking-project-peer-provider-smoke.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from loopx.capabilities.issue_fix import build_issue_fix_pr_description  # noqa: E402
+from loopx.capabilities.semantic_preference.project_peer import (  # noqa: E402
+    normalize_repository_identity,
+    resolve_project_peer_scope,
+)
+
+
+REMOTE = "https://github.com/volcengine/OpenViking.git"
+WRONG_REMOTE = "https://github.com/example/Other.git"
+REQUEST = {
+    "schema_version": "semantic_preference_provider_request_v0",
+    "surface": "issue_fix.pr_description",
+    "query": "PR description structure and validation preferences",
+    "limit": 3,
+    "context": {"repository": "volcengine/OpenViking"},
+}
+
+
+def provider_command(
+    *,
+    project: Path,
+    ov_bin: Path,
+    cli_config: Path,
+    remote_url: str,
+    fallback: bool = False,
+) -> list[str]:
+    command = [
+        sys.executable,
+        "-m",
+        "loopx.cli",
+        "semantic-preference",
+        "openviking-provider",
+        "--project",
+        str(project),
+        "--remote-url",
+        remote_url,
+        "--ov-bin",
+        str(ov_bin),
+        "--cli-config",
+        str(cli_config),
+        "--user-space",
+        "pilot",
+    ]
+    if fallback:
+        command.extend(["--include-global-fallback", "--max-find-calls", "2"])
+    return command
+
+
+def run_provider(
+    command: Sequence[str], environment: Mapping[str, str]
+) -> dict[str, object]:
+    completed = subprocess.run(
+        command,
+        cwd=ROOT,
+        input=json.dumps(REQUEST),
+        capture_output=True,
+        check=False,
+        env=dict(environment),
+        text=True,
+        timeout=30,
+    )
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    payload = json.loads(completed.stdout)
+    assert payload["schema_version"] == "semantic_preference_provider_response_v0"
+    return payload
+
+
+def read_calls(log: Path) -> list[list[str]]:
+    if not log.exists():
+        return []
+    return [json.loads(line) for line in log.read_text(encoding="utf-8").splitlines()]
+
+
+identities = {
+    normalize_repository_identity(value)
+    for value in (
+        "git@github.com:volcengine/OpenViking.git",
+        "ssh://git@github.com/volcengine/OpenViking.git",
+        REMOTE,
+    )
+}
+assert identities == {"git:github.com/volcengine/OpenViking"}, identities
+
+with tempfile.TemporaryDirectory(prefix="loopx-openviking-project-peer-") as raw_temp:
+    temp = Path(raw_temp)
+    project = temp / "project"
+    project.mkdir()
+    log = temp / "ov-calls.jsonl"
+    cli_config = temp / "openviking.conf"
+    cli_config.write_text("local-only", encoding="utf-8")
+    expected = resolve_project_peer_scope(
+        project, user_space="pilot", remote_url=REMOTE
+    )
+    wrong = resolve_project_peer_scope(
+        project, user_space="pilot", remote_url=WRONG_REMOTE
+    )
+    assert expected.peer_id != wrong.peer_id
+    assert expected.recall_targets() == (expected.memory_uri,)
+    assert expected.recall_targets(include_global_fallback=True)[1] == (
+        "viking://user/pilot/memories"
+    )
+
+    fallback_scope = resolve_project_peer_scope(
+        project, user_space="pilot", loopx_project_id="docs-agent"
+    )
+    assert fallback_scope.project_identity == "loopx:docs-agent"
+
+    ov_bin = temp / "ov"
+    ov_bin.write_text(
+        """#!/usr/bin/env python3
+import json, os, pathlib, sys
+
+args = sys.argv[1:]
+with pathlib.Path(os.environ["FAKE_OV_LOG"]).open("a", encoding="utf-8") as handle:
+    handle.write(json.dumps(args) + "\\n")
+if os.environ.get("FAKE_OV_FAIL") == "1":
+    raise SystemExit(7)
+if args[0] == "status":
+    result = {"healthy": True}
+elif args[0] == "find":
+    target = args[args.index("-u") + 1]
+    expected = os.environ["EXPECTED_PROJECT_TARGET"]
+    global_target = os.environ["EXPECTED_GLOBAL_TARGET"]
+    if target == expected:
+        memories = [{
+            "uri": target + "/preferences/pr-description.md",
+            "abstract": "For this repository, keep a concise Validation section.",
+        }]
+    elif target == global_target:
+        memories = [{
+            "uri": target + "/preferences/global.md",
+            "abstract": "Use the global fallback only when explicitly requested.",
+        }]
+    else:
+        memories = []
+    result = {"memories": memories}
+else:
+    raise SystemExit(9)
+print(json.dumps({"ok": True, "result": result}))
+""",
+        encoding="utf-8",
+    )
+    ov_bin.chmod(0o755)
+    environment = dict(os.environ)
+    environment.update(
+        {
+            "FAKE_OV_LOG": str(log),
+            "EXPECTED_PROJECT_TARGET": expected.memory_uri,
+            "EXPECTED_GLOBAL_TARGET": expected.global_memory_uri,
+        }
+    )
+
+    describe = subprocess.run(
+        [
+            *provider_command(
+                project=project,
+                ov_bin=ov_bin,
+                cli_config=cli_config,
+                remote_url=REMOTE,
+            ),
+            "--describe-scope",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        check=False,
+        env=environment,
+        text=True,
+    )
+    assert describe.returncode == 0, describe.stderr
+    described = json.loads(describe.stdout)
+    assert described["peer_id"] == expected.peer_id
+    assert described["memory_uri"] == expected.memory_uri
+    assert str(project) not in describe.stdout
+    assert REMOTE not in describe.stdout
+    assert read_calls(log) == [], "describe-scope must not contact OpenViking"
+
+    doctor = subprocess.run(
+        [
+            *provider_command(
+                project=project,
+                ov_bin=ov_bin,
+                cli_config=cli_config,
+                remote_url=REMOTE,
+            ),
+            "--doctor",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        check=False,
+        env=environment,
+        text=True,
+    )
+    assert doctor.returncode == 0, doctor.stderr
+    assert read_calls(log)[-1][0] == "status"
+
+    log.unlink()
+    recalled = run_provider(
+        provider_command(
+            project=project,
+            ov_bin=ov_bin,
+            cli_config=cli_config,
+            remote_url=REMOTE,
+        ),
+        environment,
+    )
+    assert len(recalled["items"]) == 1, recalled
+    calls = read_calls(log)
+    assert len(calls) == 1, calls
+    assert calls[0][calls[0].index("-u") + 1] == expected.memory_uri
+
+    log.unlink()
+    wrong_result = run_provider(
+        provider_command(
+            project=project,
+            ov_bin=ov_bin,
+            cli_config=cli_config,
+            remote_url=WRONG_REMOTE,
+        ),
+        environment,
+    )
+    assert wrong_result["items"] == [], wrong_result
+    assert len(read_calls(log)) == 1, "no implicit global fallback is allowed"
+
+    log.unlink()
+    fallback_result = run_provider(
+        provider_command(
+            project=project,
+            ov_bin=ov_bin,
+            cli_config=cli_config,
+            remote_url=WRONG_REMOTE,
+            fallback=True,
+        ),
+        environment,
+    )
+    assert len(fallback_result["items"]) == 1, fallback_result
+    calls = read_calls(log)
+    assert len(calls) == 2, calls
+    assert calls[-1][calls[-1].index("-u") + 1] == expected.global_memory_uri
+
+    config = temp / "semantic-preference.json"
+    config.write_text(
+        json.dumps(
+            {
+                "schema_version": "semantic_preference_hook_config_v0",
+                "enabled": True,
+                "provider": {
+                    "argv": provider_command(
+                        project=project,
+                        ov_bin=ov_bin,
+                        cli_config=cli_config,
+                        remote_url=REMOTE,
+                    ),
+                    "timeout_seconds": 30,
+                },
+                "surfaces": {
+                    "issue_fix.pr_description": {
+                        "query": "PR description structure and validation preferences",
+                        "limit": 3,
+                        "failure_policy": "fail_open",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    previous = {
+        key: os.environ.get(key)
+        for key in ("FAKE_OV_LOG", "EXPECTED_PROJECT_TARGET", "EXPECTED_GLOBAL_TARGET")
+    }
+    os.environ.update(
+        {
+            "FAKE_OV_LOG": str(log),
+            "EXPECTED_PROJECT_TARGET": expected.memory_uri,
+            "EXPECTED_GLOBAL_TARGET": expected.global_memory_uri,
+        }
+    )
+
+    def apply_preferences(
+        base: str, items: Sequence[Mapping[str, object]]
+    ) -> Mapping[str, object]:
+        return {
+            "description": f"{base}\n\n## Validation\n\nRun focused checks.\n",
+            "applied_preference_refs": [items[0]["preference_ref"]],
+        }
+
+    built = build_issue_fix_pr_description(
+        "## Motivation\n\nFix the reproduced behavior.",
+        project=project,
+        semantic_preference_config=config,
+        context=("repository=volcengine/OpenViking",),
+        application_id="project-peer-provider-smoke",
+        artifact_ref="project-peer-provider-smoke",
+        apply_preferences=apply_preferences,
+    )
+    assert built["semantic_preference"]["application_status"] == "applied", built
+    assert built["semantic_preference"]["receipt"]["outcome"] == "applied", built
+    assert built["raw_preference_content_returned"] is False
+
+    os.environ["FAKE_OV_FAIL"] = "1"
+    failed_open = build_issue_fix_pr_description(
+        "## Motivation\n\nPreserve this base.",
+        project=project,
+        semantic_preference_config=config,
+        application_id="project-peer-provider-fail-open",
+        apply_preferences=apply_preferences,
+    )
+    os.environ.pop("FAKE_OV_FAIL", None)
+    assert failed_open["fail_open_preserved_base"] is True, failed_open
+    assert failed_open["description"] == "## Motivation\n\nPreserve this base."
+
+    for key, value in previous.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+print("OpenViking project peer provider smoke: ok")

--- a/loopx/capabilities/semantic_preference/cli.py
+++ b/loopx/capabilities/semantic_preference/cli.py
@@ -4,6 +4,10 @@ import argparse
 from collections.abc import Callable
 
 from .contract import application_receipt, recall
+from .openviking_provider import (
+    handle_openviking_provider,
+    register_openviking_provider_arguments,
+)
 
 
 def _render(payload: dict[str, object]) -> str:
@@ -34,6 +38,12 @@ def register_semantic_preference_commands(
     recall_parser.add_argument("--context", action="append", default=[])
     recall_parser.add_argument("--execute", action="store_true")
 
+    provider_parser = commands.add_parser(
+        "openviking-provider",
+        help="Run the opt-in OpenViking project-as-peer provider protocol.",
+    )
+    register_openviking_provider_arguments(provider_parser)
+
     receipt_parser = commands.add_parser("receipt")
     add_subcommand_format(receipt_parser)
     receipt_parser.add_argument("--surface", required=True)
@@ -53,6 +63,8 @@ def handle_semantic_preference_command(
 ) -> int | None:
     if args.command != "semantic-preference":
         return None
+    if args.semantic_preference_command == "openviking-provider":
+        return handle_openviking_provider(args)
     if args.semantic_preference_command == "recall":
         payload = recall(
             args.config,

--- a/loopx/capabilities/semantic_preference/openviking_provider.py
+++ b/loopx/capabilities/semantic_preference/openviking_provider.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from .project_peer import ProjectPeerScope, resolve_project_peer_scope
+
+
+REQUEST_SCHEMA = "semantic_preference_provider_request_v0"
+RESPONSE_SCHEMA = "semantic_preference_provider_response_v0"
+SCOPE_SCHEMA = "openviking_project_peer_scope_v0"
+PREFERENCE_PATH_MARKER = "/memories/preferences/"
+MAX_FIND_CALLS = 3
+
+
+def _environment(cli_config: str | None) -> dict[str, str]:
+    environment = dict(os.environ)
+    if cli_config:
+        environment["OPENVIKING_CLI_CONFIG_FILE"] = cli_config
+    return environment
+
+
+def _json_result(raw: str) -> Any:
+    lines = raw.splitlines()
+    start = next(
+        (index for index, line in enumerate(lines) if line.lstrip().startswith("{")),
+        None,
+    )
+    if start is None:
+        raise RuntimeError("OpenViking returned no JSON object")
+    try:
+        payload = json.loads("\n".join(lines[start:]))
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("OpenViking returned invalid JSON") from exc
+    if not isinstance(payload, Mapping) or payload.get("ok") is not True:
+        raise RuntimeError("OpenViking returned an unsuccessful response")
+    return payload.get("result")
+
+
+def _run_ov(
+    ov_bin: str,
+    args: Sequence[str],
+    *,
+    cli_config: str | None,
+    timeout_seconds: int,
+) -> Any:
+    try:
+        completed = subprocess.run(
+            [ov_bin, *args],
+            capture_output=True,
+            check=False,
+            env=_environment(cli_config),
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError("OpenViking command execution failed") from exc
+    if completed.returncode != 0:
+        raise RuntimeError("OpenViking command returned a non-zero exit")
+    return _json_result(completed.stdout)
+
+
+def _request() -> tuple[str, int]:
+    payload = json.load(sys.stdin)
+    if (
+        not isinstance(payload, Mapping)
+        or payload.get("schema_version") != REQUEST_SCHEMA
+    ):
+        raise ValueError(f"provider request must use {REQUEST_SCHEMA}")
+    query = str(payload.get("query") or "").strip()
+    if not 1 <= len(query) <= 500:
+        raise ValueError("provider query must contain 1 to 500 characters")
+    try:
+        limit = int(payload.get("limit") or 5)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("provider limit must be an integer") from exc
+    if not 1 <= limit <= 20:
+        raise ValueError("provider limit must be between 1 and 20")
+    context = payload.get("context")
+    if isinstance(context, Mapping) and context:
+        scoped = " ".join(f"{key}={value}" for key, value in sorted(context.items()))
+        query = f"{query}\nScope: {scoped}"
+    return query, limit
+
+
+def _find(
+    *,
+    ov_bin: str,
+    cli_config: str | None,
+    timeout_seconds: int,
+    query: str,
+    target_uri: str,
+    limit: int,
+) -> list[dict[str, str]]:
+    result = _run_ov(
+        ov_bin,
+        [
+            "find",
+            "-o",
+            "json",
+            "-n",
+            str(min(limit * 3, 20)),
+            "-u",
+            target_uri,
+            query,
+        ],
+        cli_config=cli_config,
+        timeout_seconds=timeout_seconds,
+    )
+    memories = result.get("memories") if isinstance(result, Mapping) else []
+    target_prefix = f"{target_uri.rstrip('/')}/"
+    items: list[dict[str, str]] = []
+    for memory in memories if isinstance(memories, list) else []:
+        if not isinstance(memory, Mapping):
+            continue
+        uri = str(memory.get("uri") or "").strip()
+        summary = str(memory.get("abstract") or memory.get("overview") or "").strip()
+        if (
+            not uri.startswith(target_prefix)
+            or PREFERENCE_PATH_MARKER not in uri
+            or not summary
+        ):
+            continue
+        items.append({"preference_ref": uri, "summary": summary[:2_000]})
+        if len(items) >= limit:
+            break
+    return items
+
+
+def _scope(args: argparse.Namespace) -> ProjectPeerScope:
+    return resolve_project_peer_scope(
+        args.project,
+        user_space=args.user_space,
+        loopx_project_id=args.loopx_project_id,
+        remote_url=args.remote_url,
+    )
+
+
+def _describe_scope(scope: ProjectPeerScope) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "schema_version": SCOPE_SCHEMA,
+        "project_identity_digest": hashlib.sha256(
+            scope.project_identity.encode("utf-8")
+        ).hexdigest()[:16],
+        "peer_id": scope.peer_id,
+        "memory_uri": scope.memory_uri,
+        "preferences_uri": scope.preferences_uri,
+        "global_memory_uri": scope.global_memory_uri,
+        "global_fallback_default": False,
+    }
+
+
+def register_openviking_provider_arguments(parser: argparse.ArgumentParser) -> None:
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--doctor", action="store_true")
+    mode.add_argument("--describe-scope", action="store_true")
+    parser.add_argument("--ov-bin", default="ov")
+    parser.add_argument("--cli-config")
+    parser.add_argument("--project", type=Path, default=Path.cwd())
+    parser.add_argument("--user-space", default="default")
+    parser.add_argument("--loopx-project-id")
+    parser.add_argument("--remote-url")
+    parser.add_argument("--include-global-fallback", action="store_true")
+    parser.add_argument("--max-find-calls", type=int, default=1)
+    parser.add_argument("--timeout-seconds", type=int, default=25)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="OpenViking project-as-peer semantic preference provider."
+    )
+    register_openviking_provider_arguments(parser)
+    return parser
+
+
+def run_openviking_provider(args: argparse.Namespace) -> int:
+    if not 1 <= args.timeout_seconds <= 120:
+        raise ValueError("timeout-seconds must be between 1 and 120")
+
+    if args.doctor:
+        _run_ov(
+            args.ov_bin,
+            ["status", "-o", "json"],
+            cli_config=args.cli_config,
+            timeout_seconds=args.timeout_seconds,
+        )
+        return 0
+
+    scope = _scope(args)
+    if args.describe_scope:
+        json.dump(_describe_scope(scope), sys.stdout, ensure_ascii=False)
+        return 0
+
+    if not 1 <= args.max_find_calls <= MAX_FIND_CALLS:
+        raise ValueError(f"max-find-calls must be between 1 and {MAX_FIND_CALLS}")
+    if args.include_global_fallback and args.max_find_calls < 2:
+        raise ValueError("global fallback requires max-find-calls >= 2")
+
+    query, limit = _request()
+    items: list[dict[str, str]] = []
+    find_calls = 0
+    for target_uri in scope.recall_targets(
+        include_global_fallback=args.include_global_fallback
+    ):
+        if find_calls >= args.max_find_calls:
+            break
+        find_calls += 1
+        items = _find(
+            ov_bin=args.ov_bin,
+            cli_config=args.cli_config,
+            timeout_seconds=args.timeout_seconds,
+            query=query,
+            target_uri=target_uri,
+            limit=limit,
+        )
+        if items:
+            break
+    json.dump({"schema_version": RESPONSE_SCHEMA, "items": items}, sys.stdout)
+    return 0
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    return run_openviking_provider(_parser().parse_args(argv))
+
+
+def handle_openviking_provider(args: argparse.Namespace) -> int:
+    try:
+        return run_openviking_provider(args)
+    except Exception as exc:  # Provider stderr is reduced by the outer hook.
+        print(
+            f"OpenViking project peer provider failed: {type(exc).__name__}",
+            file=sys.stderr,
+        )
+        return 2
+
+
+def main() -> int:
+    try:
+        return run()
+    except Exception as exc:  # Provider stderr is reduced by the outer hook.
+        print(
+            f"OpenViking project peer provider failed: {type(exc).__name__}",
+            file=sys.stderr,
+        )
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/semantic_preference/project_peer.py
+++ b/loopx/capabilities/semantic_preference/project_peer.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import hashlib
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+PROJECT_PEER_PREFIX = "project-"
+_SAFE_PROJECT_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$")
+_SAFE_USER_SPACE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+def normalize_repository_identity(remote_url: str) -> str:
+    """Return a credential-free identity shared by common Git transports."""
+
+    raw = str(remote_url or "").strip()
+    if not raw:
+        raise ValueError("repository remote URL is required")
+
+    scp_match = re.fullmatch(r"(?:[^@/]+@)?([^:/]+):(.+)", raw)
+    if scp_match and "://" not in raw:
+        raw = f"ssh://{scp_match.group(1)}/{scp_match.group(2)}"
+
+    parsed = urlsplit(raw)
+    if (
+        parsed.scheme not in {"git", "http", "https", "ssh"}
+        or not parsed.hostname
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("repository remote must be a supported repository URL")
+
+    host = parsed.hostname.casefold()
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("repository remote has an invalid port") from exc
+    if port and not (
+        (parsed.scheme in {"http", "git"} and port == 80)
+        or (parsed.scheme in {"https", "ssh"} and port in {22, 443})
+    ):
+        host = f"{host}:{port}"
+
+    path = re.sub(r"/+", "/", parsed.path).strip("/")
+    if path.endswith(".git"):
+        path = path[:-4]
+    if not path:
+        raise ValueError("repository remote must include a repository path")
+    return f"git:{host}/{path}"
+
+
+def _origin_remote(project: Path, git_bin: str) -> str:
+    try:
+        completed = subprocess.run(
+            [git_bin, "-C", str(project), "config", "--get", "remote.origin.url"],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ValueError("project origin remote could not be read") from exc
+    if completed.returncode != 0 or not completed.stdout.strip():
+        raise ValueError(
+            "project has no canonical origin remote; provide a stable LoopX project id"
+        )
+    return completed.stdout.strip()
+
+
+def resolve_project_identity(
+    project: str | Path,
+    *,
+    loopx_project_id: str | None = None,
+    remote_url: str | None = None,
+    git_bin: str = "git",
+) -> str:
+    """Resolve a durable project identity without using a checkout path."""
+
+    try:
+        remote = remote_url or _origin_remote(Path(project), git_bin)
+        return normalize_repository_identity(remote)
+    except ValueError:
+        project_id = str(loopx_project_id or "").strip()
+        if not _SAFE_PROJECT_ID.fullmatch(project_id):
+            raise
+        return f"loopx:{project_id}"
+
+
+def project_peer_id(project_identity: str) -> str:
+    digest = hashlib.sha256(project_identity.encode("utf-8")).hexdigest()[:16]
+    return f"{PROJECT_PEER_PREFIX}{digest}"
+
+
+@dataclass(frozen=True)
+class ProjectPeerScope:
+    project_identity: str
+    peer_id: str
+    user_space: str
+
+    @property
+    def memory_uri(self) -> str:
+        return f"viking://user/{self.user_space}/peers/{self.peer_id}/memories"
+
+    @property
+    def preferences_uri(self) -> str:
+        return f"{self.memory_uri}/preferences"
+
+    @property
+    def global_memory_uri(self) -> str:
+        return f"viking://user/{self.user_space}/memories"
+
+    def recall_targets(
+        self, *, include_global_fallback: bool = False
+    ) -> tuple[str, ...]:
+        targets = [self.memory_uri]
+        if include_global_fallback:
+            targets.append(self.global_memory_uri)
+        return tuple(targets)
+
+
+def resolve_project_peer_scope(
+    project: str | Path,
+    *,
+    user_space: str = "default",
+    loopx_project_id: str | None = None,
+    remote_url: str | None = None,
+    git_bin: str = "git",
+) -> ProjectPeerScope:
+    normalized_user = str(user_space or "").strip()
+    if not _SAFE_USER_SPACE.fullmatch(normalized_user):
+        raise ValueError("user space must be a path-safe identifier")
+    identity = resolve_project_identity(
+        project,
+        loopx_project_id=loopx_project_id,
+        remote_url=remote_url,
+        git_bin=git_bin,
+    )
+    return ProjectPeerScope(
+        project_identity=identity,
+        peer_id=project_peer_id(identity),
+        user_space=normalized_user,
+    )


### PR DESCRIPTION
## Motivation

A semantic-preference consumer should not need to normalize Git remotes, derive OpenViking peer URIs, or reproduce fallback and call-budget rules. Those details currently make provider reuse expensive and make cross-repository leakage easier to introduce.

## Changes

- Add a canonical project identity and reserved `project-<digest>` peer scope derived from Git origin, with a stable LoopX project id fallback for non-Git projects.
- Add `loopx semantic-preference openviking-provider` with `--describe-scope`, read-only `--doctor`, exact-project recall by default, explicit global fallback, and bounded find calls.
- Add public integration guidance and a focused smoke covering transport normalization, wrong-project zero recall, explicit fallback, one-find default, Issue Fix application receipt, and fail-open preservation.

## Product and architecture judgment

OpenViking remains the owner of memory extraction, ranking, write, update, and supersede semantics. LoopX only owns project identity, target selection, the existing provider protocol, and the function-owned application receipt. This is a reusable adapter contract rather than a new memory ledger or an Issue Fix-specific branch.

The project peer is a routing boundary, not a security tenant. Account and user isolation remain OpenViking concerns, and the consuming function remains the final application boundary.

## Validation

- `python3 -m py_compile loopx/*.py loopx/cli_commands/*.py loopx/capabilities/semantic_preference/*.py`
- `python3 examples/openviking-project-peer-provider-smoke.py`
- `python3 examples/semantic-preference-hook-smoke.py`
- `python3 examples/issue-fix-pr-description-builder-smoke.py`
- `uvx ruff check` and `uvx ruff format --check` on changed Python files
- `loopx canary premerge --from-git-diff`: standard tier, 14/14 selected checks passed; public boundary passed; no manual holds
- Read-only live OpenViking scope probe derived the expected stable project peer; no memory or service state was mutated

## Risk and compatibility

- Disabled configurations and existing provider commands are unchanged.
- Global fallback requires an explicit flag and at least two allowed find calls.
- Provider errors expose only a bounded failure type to stderr; raw provider output and local paths do not enter receipts.
- PR #2002 touches the same semantic-preference CLI and documentation area but is not a functional dependency; whichever lands second may need a small rebase.

## Public/private boundary

No local config, endpoint, credential, memory content, raw log, private state, or machine path is included.