### PR TITLE
Upgrade GitHub Actions to native Node 24 runtimes

### DIFF
--- a/.github/workflows/frontstage-pages.yml
+++ b/.github/workflows/frontstage-pages.yml
@@ -40,10 +40,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: npm

--- a/.github/workflows/full-public-smokes.yml
+++ b/.github/workflows/full-public-smokes.yml
@@ -58,10 +58,10 @@ jobs:
       SMOKE_JOBS: "4"
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload smoke result
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: full-public-smokes-shard-${{ matrix.shard }}
           path: smoke-results/full-public-shard-${{ matrix.shard }}.json

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -29,10 +29,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip

--- a/.github/workflows/update-notes.yml
+++ b/.github/workflows/update-notes.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload update-note draft
         if: steps.generate.outputs.changed == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: biweekly-update-note-${{ steps.generate.outputs.window_slug }}
           path: |

--- a/examples/full-public-smokes-workflow-smoke.py
+++ b/examples/full-public-smokes-workflow-smoke.py
@@ -24,7 +24,7 @@ def main() -> int:
         "contents: read",
         "fail-fast: false",
         "timeout-minutes: 120",
-        "actions/setup-python@v5",
+        "actions/setup-python@",
         "python-version: \"3.11\"",
         "python3 examples/run-smokes.py",
         "--suite full-public",
@@ -35,7 +35,7 @@ def main() -> int:
         "--jobs \"${SMOKE_JOBS}\"",
         "--no-execute",
         "--json",
-        "actions/upload-artifact@v4",
+        "actions/upload-artifact@",
         "smoke-results/full-public-shard-${{ matrix.shard }}.json",
     ]:
         assert required in text, required

--- a/examples/github-actions-runtime-smoke.py
+++ b/examples/github-actions-runtime-smoke.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Keep public workflows on official Actions with a native Node 24 runtime."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+NODE24_ACTION_MAJORS = {
+    "actions/checkout": "v7",
+    "actions/setup-node": "v6",
+    "actions/setup-python": "v6",
+    "actions/upload-artifact": "v7",
+}
+
+
+def main() -> int:
+    workflow_text = "\n".join(
+        path.read_text(encoding="utf-8") for path in sorted(WORKFLOWS.glob("*.yml"))
+    )
+
+    for action, major in NODE24_ACTION_MAJORS.items():
+        references = [
+            line.strip()
+            for line in workflow_text.splitlines()
+            if f"uses: {action}@" in line
+        ]
+        assert references, f"missing workflow reference for {action}"
+        assert all(reference.endswith(f"@{major}") for reference in references), references
+
+    print("github-actions-runtime-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/update-notes-archive-smoke.py
+++ b/examples/update-notes-archive-smoke.py
@@ -111,7 +111,7 @@ def validate_project_automation() -> None:
     assert_contains(workflow, "workflow_dispatch:", "update notes workflow")
     assert_contains(workflow, "fetch-depth: 0", "update notes workflow")
     assert_contains(workflow, "scripts/update_notes_release_job.py", "update notes workflow")
-    assert_contains(workflow, "actions/upload-artifact@v4", "update notes workflow")
+    assert_contains(workflow, "actions/upload-artifact@", "update notes workflow")
     assert_contains(workflow, "contents: read", "update notes workflow")
     assert_not_contains(workflow, "create-pull-request", "update notes workflow")
     assert_not_contains(workflow, "pull-requests: write", "update notes workflow")


### PR DESCRIPTION
## Summary
- upgrade `actions/checkout` to v7, `setup-node`/`setup-python` to v6, and `upload-artifact` to v7 across all public workflows
- preserve existing triggers, permissions, inputs, caching, artifact paths, and retention behavior
- centralize the runtime-major contract in a thin public smoke so Node 20 actions cannot drift back in

## Why
GitHub-hosted runners now warn that the previous action majors target deprecated Node 20 and are being forced onto Node 24. The selected official majors declare `using: node24`; their published `action.yml` inputs cover every input used here.

## Validation
- parsed all 4 workflow YAML files with PyYAML
- verified official action metadata for Node 24 runtime and retained inputs
- `github-actions-runtime-smoke.py`: passed
- workflow-related full-public selection: 7/7 passed
- update-notes archive smoke: passed
- Ruff and Python compile: passed
- `loopx canary premerge --from-git-diff`: 8/8 selected checks passed
- public/private boundary scan: 7 candidate files clean

## Coverage and hold
The PR-triggered Python Tests and Frontstage Pages workflows exercise the new checkout/setup majors on GitHub-hosted runners. Full Public Smokes and Biweekly Update Notes are not PR-triggered, so their `upload-artifact@v7` paths are covered by official input-contract verification and local workflow smokes rather than an externally dispatched run. No workflow was manually dispatched. Keep independent review before merge because this changes CI runtime dependencies.