### PR TITLE
fix(doctor): use trusted release ref for install freshness

### DIFF
--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -545,7 +545,7 @@ def main() -> int:
         assert fresh_install["status"] == "fresh", fresh_install
         assert fresh_install["requires_upgrade"] is False, fresh_install
 
-        commit_mismatch_install = build_install_freshness(
+        canary_mismatch_install = build_install_freshness(
             command_path=wrapper,
             release_root=root / "releases" / "20260108T000000Z",
             repo_root=REPO_ROOT,
@@ -576,15 +576,16 @@ def main() -> int:
                 "git_commit": "b" * 40,
                 "git_ref": "main",
                 "git_dirty": False,
+                "revision_relation": "unknown",
             },
             now=datetime(2026, 1, 8, 1, tzinfo=timezone.utc),
         )
-        assert commit_mismatch_install["status"] == "stale", commit_mismatch_install
-        assert commit_mismatch_install["requires_upgrade"] is True, commit_mismatch_install
-        assert commit_mismatch_install["release_age_hours"] == 1.0, commit_mismatch_install
-        assert commit_mismatch_install["manifest_source_matches_comparison"] is False, commit_mismatch_install
-        assert commit_mismatch_install["comparison_source_git_commit_short"] == "b" * 12, commit_mismatch_install
-        assert "differs from loopx-canary commit" in commit_mismatch_install["reason"], commit_mismatch_install
+        assert canary_mismatch_install["status"] == "fresh", canary_mismatch_install
+        assert canary_mismatch_install["requires_upgrade"] is False, canary_mismatch_install
+        assert canary_mismatch_install["release_age_hours"] == 1.0, canary_mismatch_install
+        assert canary_mismatch_install["manifest_source_matches_comparison"] is False, canary_mismatch_install
+        assert canary_mismatch_install["comparison_source_git_commit_short"] == "b" * 12, canary_mismatch_install
+        assert canary_mismatch_install["manifest_source_comparison_relation"] == "unknown", canary_mismatch_install
 
         cli = subprocess.run(
             [

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -244,6 +244,80 @@ def git_revision_relation(
     return GitRevisionRelation.DIVERGED
 
 
+def _github_repository_from_remote_url(value: Any) -> str | None:
+    text = str(value or "").strip().removesuffix(".git")
+    match = re.search(r"github\.com(?::|/)([^/\s]+/[^/\s]+)$", text, flags=re.IGNORECASE)
+    return match.group(1).lower() if match else None
+
+
+def trusted_release_ref_for_root(
+    root: Path | None,
+    *,
+    repository: Any,
+    ref: Any,
+) -> dict[str, Any] | None:
+    """Resolve the manifest repository's fetched ref without trusting canary HEAD."""
+    expected_repository = _github_repository_from_remote_url(repository) or (
+        str(repository or "").strip().removesuffix(".git").lower()
+    )
+    expected_ref = str(ref or "").strip().removeprefix("refs/heads/")
+    if root is None or not expected_repository or not expected_ref:
+        return None
+    try:
+        source_root = root.expanduser().resolve()
+    except OSError:
+        source_root = root.expanduser()
+    if not source_root.exists():
+        return None
+
+    try:
+        remotes = subprocess.run(
+            ["git", "-C", str(source_root), "remote"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return None
+    if remotes.returncode != 0:
+        return None
+
+    for remote in remotes.stdout.splitlines():
+        remote = remote.strip()
+        if not remote:
+            continue
+        try:
+            remote_url = subprocess.run(
+                ["git", "-C", str(source_root), "remote", "get-url", remote],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except OSError:
+            continue
+        if (
+            remote_url.returncode != 0
+            or _github_repository_from_remote_url(remote_url.stdout) != expected_repository
+        ):
+            continue
+        trusted_ref = f"refs/remotes/{remote}/{expected_ref}"
+        resolved = subprocess.run(
+            ["git", "-C", str(source_root), "rev-parse", "--verify", f"{trusted_ref}^{{commit}}"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        commit = resolved.stdout.strip() if resolved.returncode == 0 else ""
+        if commit:
+            return {
+                "label": f"{expected_repository}@{expected_ref}",
+                "root": str(source_root),
+                "git_commit": commit,
+                "git_ref": f"{remote}/{expected_ref}",
+            }
+    return None
+
+
 def build_install_freshness(
     *,
     command_path: Path | None,
@@ -252,6 +326,7 @@ def build_install_freshness(
     skills: dict[str, dict[str, Any]],
     release_manifest: dict[str, Any] | None = None,
     comparison_source: dict[str, Any] | None = None,
+    freshness_source: dict[str, Any] | None = None,
     now: datetime | None = None,
 ) -> dict[str, Any]:
     reference = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
@@ -326,19 +401,23 @@ def build_install_freshness(
         if manifest_source_git_commit and comparison_source_git_commit
         else None
     )
-    source_commit_mismatch = (
-        manifest_source_matches_comparison is False
-        and comparison_revision_relation != GitRevisionRelation.INSTALLED_AHEAD
+    trusted = freshness_source if isinstance(freshness_source, dict) else {}
+    freshness_source_git_commit = trusted.get("git_commit")
+    freshness_source_label = trusted.get("label") or "trusted release source"
+    freshness_revision_relation = trusted.get("revision_relation")
+    manifest_source_matches_freshness_source = (
+        manifest_source_git_commit == freshness_source_git_commit
+        if manifest_source_git_commit and freshness_source_git_commit
+        else None
+    )
+    source_commit_is_behind = (
+        manifest_source_matches_freshness_source is False
+        and freshness_revision_relation == GitRevisionRelation.INSTALLED_BEHIND
     )
 
-    if release_id and source_commit_mismatch and command_path is not None and not skill_problem:
+    if release_id and source_commit_is_behind and command_path is not None and not skill_problem:
         status = "stale"
-        if comparison_revision_relation == GitRevisionRelation.INSTALLED_BEHIND:
-            reason = f"release manifest source commit is behind {comparison_source_label} commit"
-        elif comparison_revision_relation == GitRevisionRelation.DIVERGED:
-            reason = f"release manifest source commit diverges from {comparison_source_label} commit"
-        else:
-            reason = f"release manifest source commit differs from {comparison_source_label} commit"
+        reason = f"release manifest source commit is behind {freshness_source_label} commit"
         requires_upgrade = True
 
     if (
@@ -393,6 +472,17 @@ def build_install_freshness(
             comparison_revision_relation.value
             if isinstance(comparison_revision_relation, GitRevisionRelation)
             else comparison_revision_relation
+        ),
+        "freshness_source_label": freshness_source_label if trusted else None,
+        "freshness_source_root": trusted.get("root"),
+        "freshness_source_git_commit": freshness_source_git_commit,
+        "freshness_source_git_commit_short": short_revision(freshness_source_git_commit),
+        "freshness_source_git_ref": trusted.get("git_ref"),
+        "manifest_source_matches_freshness_source": manifest_source_matches_freshness_source,
+        "manifest_source_freshness_relation": (
+            freshness_revision_relation.value
+            if isinstance(freshness_revision_relation, GitRevisionRelation)
+            else freshness_revision_relation
         ),
         "manifest_archive_sha256": manifest_source.get("archive_sha256"),
         "manifest_skills_digest": manifest_skills.get("digest"),
@@ -601,6 +691,19 @@ def collect_doctor() -> dict[str, Any]:
             installed_commit=release_manifest_source.get("git_commit"),
             comparison_commit=comparison_source.get("git_commit"),
         )
+    freshness_source = trusted_release_ref_for_root(
+        Path(str(comparison_source.get("root")))
+        if comparison_source and comparison_source.get("root")
+        else None,
+        repository=release_manifest_source.get("repo"),
+        ref=release_manifest_source.get("ref"),
+    )
+    if freshness_source:
+        freshness_source["revision_relation"] = git_revision_relation(
+            Path(str(freshness_source.get("root"))),
+            installed_commit=release_manifest_source.get("git_commit"),
+            comparison_commit=freshness_source.get("git_commit"),
+        )
     default_release["promotion_mode"] = release_manifest_source.get("promotion_mode")
     release_provenance = {
         "runtime_root": str(DEFAULT_RUNTIME_ROOT),
@@ -625,6 +728,7 @@ def collect_doctor() -> dict[str, Any]:
         skills=skills,
         release_manifest=release_manifest,
         comparison_source=comparison_source,
+        freshness_source=freshness_source,
     )
     default_global_registry = global_registry_path(DEFAULT_RUNTIME_ROOT)
     global_registry_writability = probe_registry_write_path(default_global_registry, create_parent=True)
@@ -875,6 +979,9 @@ def render_doctor_markdown(payload: dict[str, Any]) -> str:
                 f"- comparison_source: `{freshness.get('comparison_source_label')}` @ `{freshness.get('comparison_source_git_commit_short')}`",
                 f"- manifest_source_matches_comparison: `{freshness.get('manifest_source_matches_comparison')}`",
                 f"- manifest_source_comparison_relation: `{freshness.get('manifest_source_comparison_relation')}`",
+                f"- freshness_source: `{freshness.get('freshness_source_label')}` @ `{freshness.get('freshness_source_git_commit_short')}`",
+                f"- manifest_source_matches_freshness_source: `{freshness.get('manifest_source_matches_freshness_source')}`",
+                f"- manifest_source_freshness_relation: `{freshness.get('manifest_source_freshness_relation')}`",
                 f"- manifest_archive_sha256: `{freshness.get('manifest_archive_sha256')}`",
                 f"- manifest_skills_digest: `{freshness.get('manifest_skills_digest')}`",
                 "- upgrade_command:",

--- a/tests/test_doctor_install_freshness.py
+++ b/tests/test_doctor_install_freshness.py
@@ -5,7 +5,11 @@ import subprocess
 from pathlib import Path
 
 from loopx import __version__
-from loopx.doctor import build_install_freshness, git_revision_relation
+from loopx.doctor import (
+    build_install_freshness,
+    git_revision_relation,
+    trusted_release_ref_for_root,
+)
 
 
 def _git(root: Path, *args: str) -> str:
@@ -31,6 +35,8 @@ def _freshness(
     installed_commit: str,
     comparison_commit: str,
     revision_relation: str,
+    freshness_commit: str | None = None,
+    freshness_relation: str | None = None,
 ) -> dict[str, object]:
     return build_install_freshness(
         command_path=tmp_path / "loopx",
@@ -50,6 +56,17 @@ def _freshness(
             "git_commit": comparison_commit,
             "revision_relation": revision_relation,
         },
+        freshness_source=(
+            {
+                "label": "loopx/loopx@main",
+                "root": str(tmp_path),
+                "git_commit": freshness_commit,
+                "git_ref": "origin/main",
+                "revision_relation": freshness_relation,
+            }
+            if freshness_commit
+            else None
+        ),
         now=datetime(2026, 7, 13, 4, tzinfo=timezone.utc),
     )
 
@@ -71,6 +88,8 @@ def test_older_canary_does_not_stale_newer_default_release(tmp_path: Path) -> No
         installed_commit=newer,
         comparison_commit=older,
         revision_relation=relation,
+        freshness_commit=newer,
+        freshness_relation="same",
     )
 
     assert relation == "installed_ahead"
@@ -80,7 +99,7 @@ def test_older_canary_does_not_stale_newer_default_release(tmp_path: Path) -> No
     assert freshness["manifest_source_comparison_relation"] == "installed_ahead"
 
 
-def test_newer_canary_stales_older_default_release(tmp_path: Path) -> None:
+def test_newer_canary_does_not_stale_current_default_release(tmp_path: Path) -> None:
     _git(tmp_path, "init")
     _git(tmp_path, "config", "user.email", "loopx@example.invalid")
     _git(tmp_path, "config", "user.name", "LoopX Test")
@@ -97,9 +116,77 @@ def test_newer_canary_stales_older_default_release(tmp_path: Path) -> None:
         installed_commit=older,
         comparison_commit=newer,
         revision_relation=relation,
+        freshness_commit=older,
+        freshness_relation="same",
     )
 
     assert relation == "installed_behind"
+    assert freshness["status"] == "fresh"
+    assert freshness["requires_upgrade"] is False
+    assert freshness["manifest_source_comparison_relation"] == "installed_behind"
+    assert freshness["manifest_source_freshness_relation"] == "same"
+
+
+def test_trusted_main_ref_stales_older_default_release(tmp_path: Path) -> None:
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "loopx@example.invalid")
+    _git(tmp_path, "config", "user.name", "LoopX Test")
+    older = _commit(tmp_path, "older")
+    newer = _commit(tmp_path, "newer")
+
+    freshness = _freshness(
+        tmp_path,
+        installed_commit=older,
+        comparison_commit=newer,
+        revision_relation="diverged",
+        freshness_commit=newer,
+        freshness_relation="installed_behind",
+    )
+
     assert freshness["status"] == "stale"
     assert freshness["requires_upgrade"] is True
-    assert "is behind loopx-canary" in str(freshness["reason"])
+    assert "is behind loopx/loopx@main" in str(freshness["reason"])
+
+
+def test_unknown_canary_relation_does_not_stale_current_default_release(tmp_path: Path) -> None:
+    current = "a" * 40
+    freshness = _freshness(
+        tmp_path,
+        installed_commit=current,
+        comparison_commit="b" * 40,
+        revision_relation="unknown",
+        freshness_commit=current,
+        freshness_relation="same",
+    )
+
+    assert freshness["status"] == "fresh"
+    assert freshness["requires_upgrade"] is False
+    assert freshness["manifest_source_comparison_relation"] == "unknown"
+    assert freshness["manifest_source_freshness_relation"] == "same"
+
+
+def test_trusted_release_ref_matches_manifest_repository(tmp_path: Path) -> None:
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "loopx@example.invalid")
+    _git(tmp_path, "config", "user.name", "LoopX Test")
+    commit = _commit(tmp_path, "main")
+    _git(tmp_path, "remote", "add", "origin", "git@github.com:loopx/loopx.git")
+    _git(tmp_path, "update-ref", "refs/remotes/origin/main", commit)
+
+    trusted = trusted_release_ref_for_root(
+        tmp_path,
+        repository="loopx/loopx",
+        ref="main",
+    )
+
+    assert trusted is not None
+    assert trusted["git_commit"] == commit
+    assert trusted["git_ref"] == "origin/main"
+    assert (
+        trusted_release_ref_for_root(
+            tmp_path,
+            repository="someone-else/loopx",
+            ref="main",
+        )
+        is None
+    )


### PR DESCRIPTION
## 动机

PR #2019 修正了 revision 的方向判断，但仍把任意 `loopx-canary` 工作树 HEAD 当作默认安装的升级权威。canary 指向 feature branch 时，即使可信 main archive 当前可用，也可能因为 canary 领先、分叉或对象关系未知而误报 `requires_upgrade=true`。

## 改动

- 保留 canary HEAD 的 commit/relation，作为 doctor 诊断信息。
- 从 release manifest 的 `repo + ref` 定位匹配的 Git remote tracking ref，例如 `huangruiteng/loopx@main -> origin/main`。
- 只有可信 ref 明确判定为 `installed_behind` 时，commit 差异才会把安装标为 stale。
- canary 的 `installed_behind`、`diverged` 或 `unknown` 不再单独触发升级。
- JSON 与 Markdown 增加 freshness authority、匹配结果与 relation，便于解释决策。

关键路径：

```text
canary HEAD -> diagnostic comparison only
manifest repo/ref -> matching remote tracking ref -> ancestry
                                               -> installed_behind => stale
                                               -> same/diverged/unknown => keep base freshness
```

## 验证

- `PYTHONPATH=. uv run --no-project --with pytest pytest -q tests/test_doctor_install_freshness.py`：5 passed
- `python3 examples/install-local-smoke.py`：passed
- `python3 examples/release/release-version-contract-smoke.py`：passed
- focused Ruff、py_compile、`git diff --check`：passed
- `loopx canary premerge --from-git-diff`：5/5 selected checks passed，0 failures，0 manual holds
  - install-local
  - packaged install
  - update
  - Python line budget
  - public/private boundary

## 风险边界

doctor 不执行网络 fetch，只读取本地已经获取的 remote tracking ref。若 manifest 仓库/ref 无法与本地 remote 对应，commit 差异不会单独触发升级；release age、package version 与 skill freshness 的原有 stale/repair 检查保持不变。

Follow-up to #2019.