### PR TITLE
Clarify todo lifecycle agent attribution

### DIFF
--- a/examples/cli-control-plane-command-modularization-smoke.py
+++ b/examples/cli-control-plane-command-modularization-smoke.py
@@ -62,6 +62,24 @@ def assert_help_surfaces() -> None:
     assert_contains(todo_help.stdout, "--self-merged", "todo help")
     assert_contains(todo_help.stdout, "--next-agent-todo", "todo help")
 
+    complete_help = run_cli("todo", "complete", "--help")
+    assert complete_help.returncode == 0, complete_help.stderr
+    assert_contains(
+        complete_help.stdout,
+        "The options below are the union for every todo command",
+        "todo complete help",
+    )
+    assert_contains(
+        complete_help.stdout,
+        "This is not lifecycle actor",
+        "todo complete agent-id help",
+    )
+    assert_contains(
+        complete_help.stdout,
+        "attribution; todo complete uses --claimed-by",
+        "todo complete claimed-by help",
+    )
+
     quota_help = run_cli("quota", "--help")
     assert quota_help.returncode == 0, quota_help.stderr
     assert_contains(quota_help.stdout, "should-run", "quota help")
@@ -89,6 +107,31 @@ def assert_todo_error_payload() -> None:
     assert payload["ok"] is False, payload
     assert payload["goal_id"] == "cli-modular-smoke", payload
     assert payload["error"] == "todo add requires --role", payload
+
+    with tempfile.TemporaryDirectory(prefix="loopx-cli-todo-agent-id-smoke-") as tmp:
+        result = run_cli(
+            "--format",
+            "json",
+            "--registry",
+            str(Path(tmp) / "missing-registry.json"),
+            "todo",
+            "complete",
+            "--goal-id",
+            "cli-modular-smoke",
+            "--todo-id",
+            "todo_123456789abc",
+            "--agent-id",
+            "codex-side-bypass",
+        )
+    assert result.returncode == 1, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False, payload
+    assert payload["error"] == (
+        "todo complete does not support --agent-id; --agent-id scopes todo "
+        "list/suggest and user-gate authoring, not lifecycle actor attribution. "
+        "Omit it; use --claimed-by only on commands that explicitly support "
+        "ownership changes."
+    ), payload
 
 
 def assert_todo_markdown_error_payload() -> None:

--- a/examples/control_plane/todo-suggestion-prompt-smoke.py
+++ b/examples/control_plane/todo-suggestion-prompt-smoke.py
@@ -185,7 +185,10 @@ def main() -> int:
         )
         assert rejected.returncode == 1, rejected.stdout
         error_payload = json.loads(rejected.stdout)
-        assert "only supported by `todo suggest`" in error_payload["error"], error_payload
+        assert error_payload["error"].startswith(
+            "todo add does not support --agent-id;"
+        ), error_payload
+        assert "not lifecycle actor attribution" in error_payload["error"], error_payload
 
     print("todo-suggestion-prompt-smoke: ok")
     return 0

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -36,6 +36,11 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
     todo_parser = subparsers.add_parser(
         "todo",
         help="Add a user or agent todo to a goal's active state.",
+        description=(
+            "Manage goal todos. The options below are the union for every todo "
+            "command; each option's help names the commands that accept it, and "
+            "unsupported combinations fail before state is read or written."
+        ),
     )
     todo_parser.add_argument(
         "todo_command",
@@ -331,7 +336,9 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
             "For todo add/update on role=user task-class=user_gate, mark the "
             "authoring registered agent; when --blocks-agent is omitted, the "
             "gate blocks this agent. For todo suggest, name the project agent "
-            "that should perform the repository analysis."
+            "that should perform the repository analysis. This is not lifecycle "
+            "actor attribution; todo complete uses --claimed-by only when changing "
+            "the current todo owner."
         ),
     )
     todo_parser.add_argument(

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -77,23 +77,32 @@ def validate_shared_todo_options(args: argparse.Namespace) -> None:
     )
     agent_id_allowed_for_read = args.todo_command == "list"
     global_gate_allowed = args.todo_command in {"add", "update"}
-    if args.todo_command not in {"suggest", "capture-followups"} and (
-        (
-            args.agent_id
-            and not agent_id_allowed_for_gate_authoring
-            and not agent_id_allowed_for_read
-        )
-        or (args.global_gate and not global_gate_allowed)
-        or args.suggestion_sources
-        or args.suggestion_limit is not None
-        or args.suggestion_trigger
+    if (
+        args.todo_command not in {"suggest", "capture-followups"}
+        and args.agent_id
+        and not agent_id_allowed_for_gate_authoring
+        and not agent_id_allowed_for_read
     ):
         raise ValueError(
-            "todo --agent-id is supported by `todo list`, `todo suggest`, and "
-            "by `todo add/update --role user --task-class user_gate` for "
-            "agent-scoped user gates; --global-gate is supported by "
-            "`todo add/update --role user --task-class user_gate`; --from, --limit, and "
-            "--trigger are only supported by `todo suggest`"
+            f"todo {args.todo_command} does not support --agent-id; --agent-id "
+            "scopes todo list/suggest and user-gate authoring, not lifecycle "
+            "actor attribution. Omit it; use --claimed-by only on commands that "
+            "explicitly support ownership changes."
+        )
+    if args.global_gate and not global_gate_allowed:
+        raise ValueError(
+            "--global-gate is supported only by todo add/update for user_gate items"
+        )
+    if (
+        args.todo_command not in {"suggest", "capture-followups"}
+        and (
+            args.suggestion_sources
+            or args.suggestion_limit is not None
+            or args.suggestion_trigger
+        )
+    ):
+        raise ValueError(
+            "--from, --limit, and --trigger are supported only by todo suggest"
         )
 
 


### PR DESCRIPTION
## Summary
- explain that `loopx todo` help shows the union of options across positional command variants
- return a command-specific error when `--agent-id` is used as lifecycle actor attribution
- preserve `--agent-id` for list/suggest and scoped user-gate authoring, with focused help and parser regressions

## Validation
- `python3 examples/cli-control-plane-command-modularization-smoke.py`
- `python3 examples/control_plane/todo-cli-smoke.py`
- `python3 examples/control_plane/todo-lifecycle-cli-smoke.py`
- `python3 examples/control_plane/todo-user-gate-scope-smoke.py`
- `python3 examples/control_plane/todo-suggestion-prompt-smoke.py`
- `uv run --with ruff ruff check ...`
- `scripts/loopx canary premerge --from-git-diff` (8 catalog + 8 risk-profile checks, public boundary clean, zero warnings/holds)

## Scope
No todo state mutation, routing, authorization, or ownership semantics change; this only aligns help and validation errors with the existing contract.