### PR TITLE
Fix archived todo contract role projection

### DIFF
--- a/examples/control_plane/todo-archive-completed-smoke.py
+++ b/examples/control_plane/todo-archive-completed-smoke.py
@@ -26,6 +26,10 @@ def state_text() -> str:
         done_lines.append(f"- [x] [P1] Completed implementation lane {index}.\n")
         if index == 1:
             done_lines.append("  Continuation detail must move with the archived item.\n")
+            done_lines.append(
+                "  <!-- loopx:todo todo_id=todo_completed_lane_1 status=done "
+                "task_class=advancement_task excluded_agents=codex-reviewer -->\n"
+            )
     return (
         "---\n"
         "status: active\n"
@@ -66,6 +70,9 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
                         "adapter": {
                             "kind": "harness_self_improvement",
                             "status": "connected-read-only",
+                        },
+                        "coordination": {
+                            "registered_agents": ["codex-reviewer"],
                         },
                         "authority_sources": [],
                     }
@@ -181,7 +188,40 @@ def main() -> int:
         assert "Continuation detail must move with the archived item." in updated
         assert updated.count("[P1] Completed implementation lane 1.") == 1
         assert updated.count("[P1] Completed implementation lane 2.") == 1
+        assert "excluded_agents=codex-reviewer" in updated
         assert "updated_at: 2026-01-01T00:00:00+00:00" not in updated
+
+        status_after = run_cli(registry_path, runtime, "status")
+        assert status_after["ok"] is True, status_after
+        assert status_after["contract_errors"] == [], status_after
+
+        state_path.write_text(
+            updated
+            + "- [ ] [P1] Contradictory archived work item.\n"
+            + "  <!-- loopx:todo todo_id=todo_archived_open status=done "
+            + "task_class=advancement_task excluded_agents=codex-reviewer -->\n"
+            + "- [x] [P1] Malformed archived work item.\n"
+            + "  <!-- loopx:todo todo_id=todo_archived_malformed status=<bad> "
+            + "task_class=advancement_task excluded_agents=codex-reviewer -->\n"
+            + "- [x] [P1] Empty-status archived work item.\n"
+            + "  <!-- loopx:todo todo_id=todo_archived_empty status= "
+            + "task_class=advancement_task excluded_agents=codex-reviewer -->\n",
+            encoding="utf-8",
+        )
+        invalid_status = run_cli(registry_path, runtime, "status", check=False)
+        assert invalid_status["ok"] is False, invalid_status
+        assert any(
+            "todo_archived_open" in item and "executor exclusions" in item
+            for item in invalid_status["contract_errors"]
+        ), invalid_status
+        assert any(
+            "todo_archived_malformed" in item and "malformed status metadata" in item
+            for item in invalid_status["contract_errors"]
+        ), invalid_status
+        assert any(
+            "todo_archived_empty" in item and "malformed status metadata" in item
+            for item in invalid_status["contract_errors"]
+        ), invalid_status
 
     print("todo-archive-completed-smoke ok")
     return 0

--- a/loopx/contract.py
+++ b/loopx/contract.py
@@ -12,18 +12,22 @@ from .control_plane.runtime.run_index_duplicates import (
     classify_index_duplicate_records,
     index_identity,
 )
+from .control_plane.todos.active_state_editing import COMPLETED_WORK_ARCHIVE_HEADING
 from .history import collect_history, load_registry
 from .paths import DEFAULT_RUNTIME_ROOT, rel_or_abs, resolve_runtime_root
 from .registry import inspect_registry, inspect_registry_boundary, registry_goals, resolve_state_file
 from .control_plane.todos.contract import (
     TODO_STATUS_DEFERRED,
     TODO_STATUS_DONE,
+    TODO_METADATA_PATTERN,
     TODO_TASK_CLASS_USER_ACTION,
     TODO_TASK_CLASS_USER_GATE,
     TODO_TASK_PATTERN,
+    decode_metadata_value,
     normalize_todo_claimed_by,
     normalize_todo_excluded_agents,
     normalize_removed_todo_continuation_policy,
+    normalize_todo_status,
     parse_todo_metadata_line,
     parse_todo_metadata_tokens,
     require_todo_excluded_agents,
@@ -284,11 +288,16 @@ def _active_state_user_gate_scope_errors(registry: dict[str, Any]) -> tuple[list
             continue
 
         role: str | None = None
+        in_completed_work_archive = False
         index = 0
         while index < len(lines):
             line = lines[index]
             if line.startswith("## "):
-                heading = line.lstrip("#").strip().lower()
+                heading_text = line.lstrip("#").strip()
+                heading = heading_text.lower()
+                in_completed_work_archive = (
+                    heading_text.casefold() == COMPLETED_WORK_ARCHIVE_HEADING.casefold()
+                )
                 if "user todo" in heading or "owner review" in heading:
                     role = "user"
                 elif "agent todo" in heading:
@@ -304,19 +313,31 @@ def _active_state_user_gate_scope_errors(registry: dict[str, Any]) -> tuple[list
             marker, text = match.groups()
             metadata: dict[str, Any] = {}
             malformed_excluded_agents = False
+            malformed_status = False
             next_index = index + 1
             while next_index < len(lines):
                 if lines[next_index].startswith("## ") or TODO_TASK_PATTERN.match(lines[next_index]):
                     break
-                raw_metadata = parse_todo_metadata_tokens(lines[next_index])
+                raw_line = lines[next_index]
+                raw_metadata = parse_todo_metadata_tokens(raw_line)
+                metadata_match = TODO_METADATA_PATTERN.match(raw_line)
+                if metadata_match:
+                    for raw_field in metadata_match.group("body").split():
+                        if not raw_field.startswith("status="):
+                            continue
+                        raw_status = decode_metadata_value(raw_field.split("=", 1)[1])
+                        if normalize_todo_status(raw_status) is None:
+                            malformed_status = True
                 for key, value in raw_metadata or []:
+                    if key == "status" and normalize_todo_status(value) is None:
+                        malformed_status = True
                     if key not in {"excluded_agent", "excluded_agents"}:
                         continue
                     try:
                         require_todo_excluded_agents(value)
                     except ValueError:
                         malformed_excluded_agents = True
-                parsed = parse_todo_metadata_line(lines[next_index])
+                parsed = parse_todo_metadata_line(raw_line)
                 if parsed:
                     metadata.update(parsed)
                 next_index += 1
@@ -331,6 +352,12 @@ def _active_state_user_gate_scope_errors(registry: dict[str, Any]) -> tuple[list
                     f"{goal_id}: todo {todo_id} has malformed excluded_agents metadata; "
                     "replace it with --excluded-agent <registered-agent> or remove it "
                     "with --clear-excluded-agents"
+                )
+            if malformed_status:
+                errors.append(
+                    f"{goal_id}: todo {todo_id} has malformed status metadata; "
+                    "replace it with status=open, status=done, status=blocked, or "
+                    "status=deferred"
                 )
             if role == "agent" and removed_continuation_policy:
                 errors.append(
@@ -355,7 +382,12 @@ def _active_state_user_gate_scope_errors(registry: dict[str, Any]) -> tuple[list
                     f"{goal_id}: agent todo {todo_id} has claimed_by={claimed_by!r} "
                     "also listed in excluded_agents"
                 )
-            if role != "agent" and excluded_agents:
+            archived_terminal_todo = (
+                in_completed_work_archive
+                and todo_status_from_marker(marker) in TERMINAL_TODO_STATUSES
+                and status in TERMINAL_TODO_STATUSES
+            )
+            if role != "agent" and excluded_agents and not archived_terminal_todo:
                 errors.append(
                     f"{goal_id}: {role or 'unscoped'} todo {todo_id} uses excluded_agents; "
                     "executor exclusions are only valid for agent todos"


### PR DESCRIPTION
## Summary
- preserve archived agent `excluded_agents` metadata without treating terminal archive rows as active unscoped todos
- require a terminal checkbox and valid terminal status before applying the archive exemption
- reject malformed explicit todo status metadata and cover fail-closed archive cases

## Validation
- `python3 examples/control_plane/todo-archive-completed-smoke.py`
- `python3 examples/control_plane/todo-user-gate-scope-smoke.py`
- `python3 examples/backlog-hygiene-smoke.py`
- `python3 examples/control_plane/todo-lifecycle-cli-smoke.py`
- `python3 examples/control_plane/todo-contract-smoke.py`
- live `loopx-meta` status through branch code: 0 contract errors
- `loopx canary premerge --from-git-diff`: 8/8 selected checks passed, 0 failures, 0 warnings, 0 manual holds
- independent review approved after two fail-closed refinements

## Boundary
- only public runtime contract code and its focused durable smoke are included
- no credentials, private state, raw benchmark evidence, local paths, or generated logs are included