### PR TITLE
fix(quota): preserve scheduler ACK capability context

### DIFF
--- a/examples/control_plane/quota-scheduler-state-ack-smoke.py
+++ b/examples/control_plane/quota-scheduler-state-ack-smoke.py
@@ -31,7 +31,11 @@ from loopx.control_plane.scheduler.state import (  # noqa: E402
     load_scheduler_state,
     write_scheduler_state,
 )
-from loopx.quota import AgentScopeFrontierAction  # noqa: E402
+from loopx.control_plane.testing.quota_fixtures import (  # noqa: E402
+    quota_status_payload,
+    quota_todo_item,
+)
+from loopx.quota import AgentScopeFrontierAction, build_quota_should_run  # noqa: E402
 from loopx.status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK  # noqa: E402
 
 
@@ -505,6 +509,46 @@ def assert_scheduler_ack_plan_validation() -> None:
     }, already_applied
 
 
+def assert_normal_run_ack_preserves_runtime_capabilities() -> None:
+    status = quota_status_payload(
+        goal_id="scheduler-state-ack-runtime-capabilities",
+        status="active",
+        recommended_action="Run the bounded delivery.",
+        next_action="Run the bounded delivery.",
+        active_state_next_action="Run the bounded delivery.",
+        agent_todo_items=[
+            quota_todo_item(
+                todo_id="todo_runtime_capabilities",
+                title="Run the bounded delivery.",
+                claimed_by="codex-side-agent",
+            )
+        ],
+        coordination={
+            "agent_model": "peer_v1",
+            "registered_agents": ["codex-side-agent"],
+        },
+        latest_runs=[],
+    )
+    decision = build_quota_should_run(
+        status,
+        goal_id="scheduler-state-ack-runtime-capabilities",
+        agent_id="codex-side-agent",
+        available_capabilities=["shell", "network", "lark_read"],
+    )
+    assert decision["effective_action"] == "normal_run", decision
+    assert "capability_gate" not in decision, decision
+    ack_hint = decision["scheduler_hint"]["codex_app"]["ack_hint"]
+    assert ack_hint["args"]["available_capabilities"] == [
+        "network",
+        "lark_read",
+    ], ack_hint
+    cli_args = ack_hint["cli_args"]
+    assert cli_args.count("--available-capability") == 2, ack_hint
+    for capability in ("network", "lark_read"):
+        capability_index = cli_args.index(capability)
+        assert cli_args[capability_index - 1] == "--available-capability", ack_hint
+
+
 def assert_monitor_wait_stale_ack_hint_is_accepted() -> None:
     base = monitor_window_payload(minutes_until_due=59)
     first = build_hint_at(base, now=FROZEN_NOW)
@@ -972,6 +1016,7 @@ def main() -> int:
     assert_monitor_wait_ignores_goal_recommended_action_identity_noise()
     assert_active_work_keeps_initial_cadence()
     assert_scheduler_ack_plan_validation()
+    assert_normal_run_ack_preserves_runtime_capabilities()
     assert_monitor_wait_stale_ack_hint_is_accepted()
     assert_scheduler_state_scope_validation()
     assert_cli_scheduler_ack_progression()

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -616,6 +616,7 @@ def build_scheduler_hint(
     agent_scope_frontier_actions: Collection[str] = (),
     include_detail: bool = False,
     codex_app_scheduler_state: dict[str, Any] | None = None,
+    available_capabilities: Any = None,
 ) -> dict[str, Any]:
     """Project host-runtime cadence/backoff policy from a quota decision.
 
@@ -665,7 +666,9 @@ def build_scheduler_hint(
         else {}
     )
     scheduler_ack_capabilities = (
-        capability_gate.get("available")
+        available_capabilities
+        if available_capabilities is not None
+        else capability_gate.get("available")
         if isinstance(capability_gate.get("available"), list)
         else []
     )

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -729,10 +729,8 @@ def _compact_autonomous_candidate_context(
 
 
 def _scheduler_hint(
-    payload: dict[str, Any],
-    *,
-    include_detail: bool = False,
-    codex_app_scheduler_state: dict[str, Any] | None = None,
+    payload: dict[str, Any], *, include_detail: bool = False,
+    codex_app_scheduler_state: dict[str, Any] | None = None, available_capabilities: Any = None,
 ) -> dict[str, Any]:
     return build_scheduler_hint(
         payload,
@@ -740,6 +738,7 @@ def _scheduler_hint(
         agent_scope_frontier_actions=[action.value for action in AgentScopeFrontierAction],
         include_detail=include_detail,
         codex_app_scheduler_state=codex_app_scheduler_state,
+        available_capabilities=available_capabilities,
     )
 
 
@@ -2174,6 +2173,7 @@ def build_quota_should_run(
         payload["scheduler_hint"] = _scheduler_hint(
             payload,
             include_detail=include_scheduler_detail,
+            available_capabilities=effective_available_capabilities,
             codex_app_scheduler_state=_load_codex_app_scheduler_state(
                 status_payload,
                 goal_id=safe_goal_id,


### PR DESCRIPTION
## 动机

`quota should-run` 接收了本轮 `--available-capability`，但正常执行路径没有 `capability_gate`。此前 scheduler ACK hint 只从 gate 读取能力，导致生成的 `scheduler-ack-current` 命令丢失运行时能力；ACK 内部重算后会把实际可用的 network/Lark 能力误判为缺失，并把 3 分钟 cadence 错配成 30 分钟的伪 user gate。

## 改动方案

- 将本轮 effective runtime capabilities 显式注入 scheduler hint 构建边界。
- 直接调用 `build_scheduler_hint()` 时仍兼容旧的 `capability_gate.available` 回退。
- ACK 命令继续省略 shell/filesystem 等默认本地能力，只携带会改变 quota 路由的能力。

关键流程：

```text
effective_available_capabilities
        -> build_scheduler_hint(..., available_capabilities=...)
        -> ack_hint.cli_args
        -> scheduler-ack-current 以相同能力重算
        -> cadence 与原 should-run 决策一致
```

## 复现与验证

- 新增 normal-run 回归：不存在 `capability_gate` 时，network/lark_read 仍各出现一次，shell 不写入 ACK。
- `quota-scheduler-state-ack-smoke.py` 通过。
- scheduler hint compaction 与 monitor-poll smokes 通过。
- 标准 premerge 17/17 通过，0 manual hold；public boundary 通过。

## 风险

改动只影响 scheduler ACK 命令的能力上下文传递，不改变 quota 选题、权限边界或 cadence 算法。显式参数为 `None` 时保留现有 gate 回退行为。