### PR TITLE
fix(semantic-preference): bind OpenViking project actor

### DIFF
--- a/docs/capabilities/semantic-preference/openviking-project-peer.md
+++ b/docs/capabilities/semantic-preference/openviking-project-peer.md
@@ -15,6 +15,7 @@ preference provider protocol for a function-owned application and receipt.
 - Identity comes from the normalized Git `origin`, never the checkout path.
 - A non-Git project must provide a stable `--loopx-project-id`.
 - Recall targets the exact project peer by default.
+- Each `find` binds the OpenViking request actor to the derived project peer.
 - User-global memory is available only through `--include-global-fallback`.
 - The default budget is one `find`; explicit global fallback needs at least two.
 - Only concrete preference nodes under the selected target are returned.
@@ -32,8 +33,11 @@ loopx semantic-preference openviking-provider \
 
 The output contains the peer id and target URIs, but not the repository URL or
 local checkout path. An OpenViking agent integration can use the returned
-`peer_id` when adding a user message to a session; OpenViking then owns memory
-write, update, and supersede under that peer.
+`peer_id` when adding a user message to a session. For an isolated native
+write, create that session with self memory disabled, peer memory enabled, and
+the desired memory types allowed. `peer_id` alone identifies the speaker but
+does not force an extractor operation away from user-global memory. OpenViking
+then owns write, update, and supersede semantics inside the selected peer.
 
 ## Local-private hook config
 

--- a/examples/openviking-project-peer-provider-smoke.py
+++ b/examples/openviking-project-peer-provider-smoke.py
@@ -129,10 +129,13 @@ with pathlib.Path(os.environ["FAKE_OV_LOG"]).open("a", encoding="utf-8") as hand
     handle.write(json.dumps(args) + "\\n")
 if os.environ.get("FAKE_OV_FAIL") == "1":
     raise SystemExit(7)
-if args[0] == "status":
+command_args = args
+if args[:1] == ["--actor-peer-id"]:
+    command_args = args[2:]
+if command_args[0] == "status":
     result = {"healthy": True}
-elif args[0] == "find":
-    target = args[args.index("-u") + 1]
+elif command_args[0] == "find":
+    target = command_args[command_args.index("-u") + 1]
     expected = os.environ["EXPECTED_PROJECT_TARGET"]
     global_target = os.environ["EXPECTED_GLOBAL_TARGET"]
     if target == expected:
@@ -220,6 +223,7 @@ print(json.dumps({"ok": True, "result": result}))
     assert len(recalled["items"]) == 1, recalled
     calls = read_calls(log)
     assert len(calls) == 1, calls
+    assert calls[0][:3] == ["--actor-peer-id", expected.peer_id, "find"]
     assert calls[0][calls[0].index("-u") + 1] == expected.memory_uri
 
     log.unlink()
@@ -233,7 +237,9 @@ print(json.dumps({"ok": True, "result": result}))
         environment,
     )
     assert wrong_result["items"] == [], wrong_result
-    assert len(read_calls(log)) == 1, "no implicit global fallback is allowed"
+    calls = read_calls(log)
+    assert len(calls) == 1, "no implicit global fallback is allowed"
+    assert calls[0][:3] == ["--actor-peer-id", wrong.peer_id, "find"]
 
     log.unlink()
     fallback_result = run_provider(
@@ -249,6 +255,7 @@ print(json.dumps({"ok": True, "result": result}))
     assert len(fallback_result["items"]) == 1, fallback_result
     calls = read_calls(log)
     assert len(calls) == 2, calls
+    assert all(call[:3] == ["--actor-peer-id", wrong.peer_id, "find"] for call in calls)
     assert calls[-1][calls[-1].index("-u") + 1] == expected.global_memory_uri
 
     config = temp / "semantic-preference.json"

--- a/loopx/capabilities/semantic_preference/openviking_provider.py
+++ b/loopx/capabilities/semantic_preference/openviking_provider.py
@@ -94,6 +94,7 @@ def _find(
     *,
     ov_bin: str,
     cli_config: str | None,
+    actor_peer_id: str,
     timeout_seconds: int,
     query: str,
     target_uri: str,
@@ -102,6 +103,8 @@ def _find(
     result = _run_ov(
         ov_bin,
         [
+            "--actor-peer-id",
+            actor_peer_id,
             "find",
             "-o",
             "json",
@@ -216,6 +219,7 @@ def run_openviking_provider(args: argparse.Namespace) -> int:
         items = _find(
             ov_bin=args.ov_bin,
             cli_config=args.cli_config,
+            actor_peer_id=scope.peer_id,
             timeout_seconds=args.timeout_seconds,
             query=query,
             target_uri=target_uri,


### PR DESCRIPTION
## Motivation

PR #2030 derives an exact project-peer URI, but OpenViking 0.4 also enforces the request actor-peer view. If a local CLI config names another actor, an exact peer URI is rejected before retrieval. That leaves the reusable provider dependent on an easy-to-miss local identity setting.

## Changes

- Invoke every provider `find` with `--actor-peer-id <derived-project-peer>`.
- Extend the focused smoke to prove correct-project, wrong-project, and global-fallback calls all use the derived actor.
- Clarify that native isolated writes need `memory_policy.self=false`, peer writes enabled, allowed memory types, and the message `peer_id`; speaker attribution alone does not force a peer write.

## Product and architecture judgment

LoopX should own deterministic project routing end to end. OpenViking still owns extraction, update, supersede, ranking, and storage. Binding the actor at the same seam as the target URI removes a hidden integration precondition without adding a memory ledger.

## Validation

- Python compile: passed
- project-peer provider smoke: passed
- existing semantic-preference and Issue Fix PR-description smokes: passed
- ruff check / format: passed
- standard premerge canary: all selected checks passed; public boundary passed
- live OpenViking 0.4 probe: a CLI config with a different actor was safely overridden; exact project returned one preference and a different project returned zero

## Risk

OpenViking versions without actor-peer CLI support will fail through the existing provider failure policy. Existing default-off and fail-open behavior is unchanged.
