### PR TITLE
fix(explore): preserve role views on material refresh

### DIFF
--- a/examples/issue-fix-explore-projection-smoke.py
+++ b/examples/issue-fix-explore-projection-smoke.py
@@ -287,15 +287,17 @@ def main() -> None:
             config_path=config_path,
             whiteboard_token="wb_public_fixture",
             docx_token="doc_public_fixture",
-            tags=["issue-fix"],
-            projection_mode="issue_fix_two_lane",
+            projection_mode="executive_auto",
+            view_role="executive",
             execute=True,
         )
         assert configured["status"] == "configured", configured
         sync_calls: list[str] = []
-        visual_calls: list[str] = []
+        visual_preview_calls: list[str] = []
+        visual_publish_calls: list[str] = []
+        delivery_version = ["delivery-v1"]
         original_sync = explore_results.sync_explore_results_to_lark
-        original_visual_sync = explore_results.sync_explore_visual_to_lark
+        original_visuals_sync = explore_results.sync_explore_visuals_to_lark
 
         def fake_sync(*args: object, **kwargs: object) -> dict[str, object]:
             projection = kwargs["projection"]
@@ -313,33 +315,62 @@ def main() -> None:
                 "error": None,
             }
 
-        def fake_visual_sync(*args: object, **kwargs: object) -> dict[str, object]:
-            digest = str(kwargs["semantic_digest"])
-            display = kwargs["display_projection"]
-            assert isinstance(display, dict), display
-            assert display["schema_version"] == "issue_fix_executive_visual_projection_v0"
-            assert display["graph_counts"]["delivery_node_count"] == 1, display
-            expected_capability_nodes = 0 if len(visual_calls) >= 2 else 1
-            assert display["graph_counts"]["capability_node_count"] == expected_capability_nodes, display
-            visual_calls.append(digest)
-            if len(visual_calls) == 1:
+        def fake_visuals_sync(*args: object, **kwargs: object) -> dict[str, object]:
+            projection = kwargs["projection"]
+            assert isinstance(projection, dict), projection
+            digest = explore_results.explore_visual_semantic_digest(projection)
+            delivery_digest = f"{delivery_version[0]}:{digest[:12]}"
+            execute_visual = bool(kwargs.get("execute"))
+            if not execute_visual:
+                visual_preview_calls.append(delivery_digest)
+                return {
+                    "ok": True,
+                    "status": "would_publish",
+                    "presentation_mode": "dual_view",
+                    "source_digest": digest,
+                    "views": {
+                        "executive": {
+                            "ok": True,
+                            "status": "would_publish",
+                            "published": False,
+                            "delivery_digest": delivery_digest,
+                        }
+                    },
+                }
+            visual_publish_calls.append(delivery_digest)
+            if len(visual_publish_calls) == 1:
                 return {
                     "ok": False,
                     "status": "publish_failed",
-                    "published": False,
+                    "presentation_mode": "dual_view",
+                    "source_digest": digest,
+                    "views": {
+                        "executive": {
+                            "ok": False,
+                            "status": "publish_failed",
+                            "published": False,
+                            "delivery_digest": delivery_digest,
+                        }
+                    },
                     "error": "fixture visual transport failure",
                 }
             return {
                 "ok": True,
                 "status": "published",
-                "published": True,
-                "semantic_digest": digest,
-                "graph_counts": {"node_count": 3, "edge_count": 2},
-                "error": None,
+                "presentation_mode": "dual_view",
+                "source_digest": digest,
+                "views": {
+                    "executive": {
+                        "ok": True,
+                        "status": "published",
+                        "published": True,
+                        "delivery_digest": delivery_digest,
+                    }
+                },
             }
 
         explore_results.sync_explore_results_to_lark = fake_sync
-        explore_results.sync_explore_visual_to_lark = fake_visual_sync
+        explore_results.sync_explore_visuals_to_lark = fake_visuals_sync
         try:
             suppressed = explore_results.sync_issue_fix_explore_on_material_change(
                 registry_path=registry,
@@ -355,7 +386,8 @@ def main() -> None:
             assert suppressed["needs_visual_sync"] is True, suppressed
             assert suppressed["projection"]["applicable"] is True, suppressed
             assert sync_calls == [], sync_calls
-            assert visual_calls == [], visual_calls
+            assert visual_publish_calls == [], visual_publish_calls
+            assert len(visual_preview_calls) == 1, visual_preview_calls
             suppressed_config = json.loads(config_path.read_text(encoding="utf-8"))
             assert goal_id not in suppressed_config.get("automatic_projection_sync", {}), suppressed_config
 
@@ -389,7 +421,21 @@ def main() -> None:
             assert unchanged["status"] == "unchanged", unchanged
             assert unchanged["row_readback_verified"] is True, unchanged
             assert len(sync_calls) == 1, sync_calls
-            assert len(visual_calls) == 2, visual_calls
+            assert len(visual_publish_calls) == 2, visual_publish_calls
+
+            delivery_version[0] = "delivery-v2"
+            renderer_changed = explore_results.sync_issue_fix_explore_on_material_change(
+                registry_path=registry,
+                goal_id=goal_id,
+                agent_id="codex-fixture",
+                project=project,
+                execute=True,
+            )
+            assert renderer_changed["status"] == "synced", renderer_changed
+            assert renderer_changed["canonical_rows_sync"] is None, renderer_changed
+            assert renderer_changed["visual_sync"]["status"] == "published", renderer_changed
+            assert len(sync_calls) == 1, sync_calls
+            assert len(visual_publish_calls) == 3, visual_publish_calls
 
             append_rollout_event(
                 rollout_log,
@@ -415,18 +461,21 @@ def main() -> None:
             )
             assert changed["status"] == "synced", changed
             assert len(sync_calls) == 2, sync_calls
-            assert len(visual_calls) == 3, visual_calls
+            assert len(visual_publish_calls) == 4, visual_publish_calls
             changed_nodes = {item["node_id"]: item for item in changed["projection"]["projection"]["nodes"]}
             assert changed_nodes["cap_explore_projection"]["status"] == "resolved"
         finally:
             explore_results.sync_explore_results_to_lark = original_sync
-            explore_results.sync_explore_visual_to_lark = original_visual_sync
+            explore_results.sync_explore_visuals_to_lark = original_visuals_sync
 
         stored = json.loads(config_path.read_text(encoding="utf-8"))
         assert stored["result_records"] == {"public-remote-row": "rec_public"}, stored
-        assert stored["visual_sink"]["whiteboard_token"] == "wb_public_fixture", stored
+        assert stored["visual_sinks"]["executive"]["whiteboard_token"] == "wb_public_fixture", stored
         assert stored["automatic_projection_sync"][goal_id]["semantic_digest"] == changed["semantic_digest"]
         assert stored["automatic_projection_sync"][goal_id]["visual_semantic_digest"] == changed["semantic_digest"]
+        assert stored["automatic_projection_sync"][goal_id]["visual_delivery_digests"]["executive"].startswith(
+            "delivery-v2:"
+        ), stored
         assert str(project) not in json.dumps(changed["projection"]["projection"])
 
     print("issue-fix explore projection smoke: ok")

--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -580,6 +580,7 @@ def sync_explore_visual_to_lark(
             "source_digest": semantic_digest,
             "source_revision": source_revision,
             "view_role": sink_key,
+            "whiteboard_token": whiteboard_token,
             "mermaid": str(graph.get("mermaid") or ""),
         },
         ensure_ascii=True,
@@ -712,6 +713,21 @@ def sync_explore_visuals_to_lark(
         "recommended_roles": active_roles,
         "missing_recommended_roles": missing_recommended_roles,
         "views": results,
+    }
+
+
+def _visual_delivery_digests(sync_payload: Mapping[str, Any] | None) -> dict[str, str]:
+    """Return the configured role digests that make a visual write idempotent."""
+
+    if not isinstance(sync_payload, Mapping):
+        return {}
+    views = sync_payload.get("views")
+    if not isinstance(views, Mapping):
+        return {}
+    return {
+        str(role): str(view.get("delivery_digest"))
+        for role, view in views.items()
+        if isinstance(view, Mapping) and str(view.get("delivery_digest") or "").strip()
     }
 
 
@@ -1288,10 +1304,28 @@ def sync_issue_fix_explore_on_material_change(
     digest = str(projection_result.get("semantic_digest") or "")
     prior_digest = str(prior.get("canonical_rows_semantic_digest") or prior.get("semantic_digest") or "")
     prior_row_readback_digest = str(prior.get("canonical_rows_readback_semantic_digest") or "")
-    visual_sink = local.get("visual_sink") if isinstance(local.get("visual_sink"), dict) else None
+    visual_sinks = (
+        local.get("visual_sinks")
+        if isinstance(local.get("visual_sinks"), dict) and local.get("visual_sinks")
+        else None
+    )
+    visual_sink = (
+        local.get("visual_sink")
+        if visual_sinks is None and isinstance(local.get("visual_sink"), dict)
+        else None
+    )
     prior_visual_digest = str(prior.get("visual_semantic_digest") or "")
+    prior_visual_delivery_digests = (
+        prior.get("visual_delivery_digests")
+        if isinstance(prior.get("visual_delivery_digests"), dict)
+        else {}
+    )
     needs_row_sync = bool(digest and (digest != prior_digest or digest != prior_row_readback_digest))
-    needs_visual_sync = bool(visual_sink and digest and digest != prior_visual_digest)
+    needs_visual_sync = bool(
+        (visual_sinks or visual_sink) and digest and digest != prior_visual_digest
+    )
+    visual_preview: dict[str, Any] | None = None
+    expected_visual_delivery_digests: dict[str, str] = {}
     needs_sync = needs_row_sync or needs_visual_sync
     if not projection_result.get("applicable"):
         return {
@@ -1326,6 +1360,27 @@ def sync_issue_fix_explore_on_material_change(
             "lark_sync": None,
             "config_path": str(config_path),
         }
+    if visual_sinks:
+        visual_preview = sync_explore_visuals_to_lark(
+            config,
+            projection=projection_result["projection"],
+            visual_sinks=visual_sinks,
+            config_path=config_path,
+            execute=False,
+            runner=runner,
+        )
+        expected_visual_delivery_digests = _visual_delivery_digests(visual_preview)
+        needs_visual_sync = bool(
+            digest
+            and (
+                not visual_preview.get("ok")
+                or any(
+                    prior_visual_delivery_digests.get(role) != delivery_digest
+                    for role, delivery_digest in expected_visual_delivery_digests.items()
+                )
+            )
+        )
+    needs_sync = needs_row_sync or needs_visual_sync
     if not needs_sync:
         return {
             "ok": True,
@@ -1340,6 +1395,7 @@ def sync_issue_fix_explore_on_material_change(
             "prior_semantic_digest": prior_digest or None,
             "projection": projection_result,
             "lark_sync": None,
+            "visual_preview": visual_preview,
             "config_path": str(config_path),
         }
     if not execute:
@@ -1356,6 +1412,7 @@ def sync_issue_fix_explore_on_material_change(
             "prior_semantic_digest": prior_digest or None,
             "projection": projection_result,
             "lark_sync": None,
+            "visual_preview": visual_preview,
             "config_path": str(config_path),
         }
     if not external_sink_delivery_authorized:
@@ -1372,9 +1429,11 @@ def sync_issue_fix_explore_on_material_change(
             "semantic_digest": digest,
             "prior_semantic_digest": prior_digest or None,
             "prior_visual_semantic_digest": prior_visual_digest or None,
+            "prior_visual_delivery_digests": dict(prior_visual_delivery_digests),
             "projection": projection_result,
             "lark_sync": None,
             "canonical_rows_sync": None,
+            "visual_preview": visual_preview,
             "visual_sync": None,
             "retryable": True,
             "config_path": str(config_path),
@@ -1390,8 +1449,19 @@ def sync_issue_fix_explore_on_material_change(
         if needs_row_sync
         else None
     )
-    visual_sync = (
-        sync_explore_visual_to_lark(
+    if not needs_visual_sync:
+        visual_sync = None
+    elif visual_sinks:
+        visual_sync = sync_explore_visuals_to_lark(
+            config,
+            projection=projection_result["projection"],
+            visual_sinks=visual_sinks,
+            config_path=config_path,
+            execute=True,
+            runner=runner,
+        )
+    else:
+        visual_sync = sync_explore_visual_to_lark(
             config,
             projection=projection_result["projection"],
             visual_sink=visual_sink,
@@ -1403,9 +1473,6 @@ def sync_issue_fix_explore_on_material_change(
             execute=True,
             runner=runner,
         )
-        if needs_visual_sync
-        else None
-    )
     row_ok = lark_sync is None or bool(lark_sync.get("ok"))
     row_readback_verified = bool(
         lark_sync is None
@@ -1435,6 +1502,10 @@ def sync_issue_fix_explore_on_material_change(
                     "visual_published_at": now_lark_datetime(),
                 }
             )
+            if visual_sinks:
+                updated_goal_state["visual_delivery_digests"] = _visual_delivery_digests(
+                    visual_sync
+                )
         updated_goal_state["synced_at"] = now_lark_datetime()
         updated_sync_state[goal_id] = updated_goal_state
         # The row sync persists record ids incrementally. Re-read that write
@@ -1457,9 +1528,11 @@ def sync_issue_fix_explore_on_material_change(
         "semantic_digest": digest,
         "prior_semantic_digest": prior_digest or None,
         "prior_visual_semantic_digest": prior_visual_digest or None,
+        "prior_visual_delivery_digests": dict(prior_visual_delivery_digests),
         "projection": projection_result,
         "lark_sync": lark_sync,
         "canonical_rows_sync": lark_sync,
+        "visual_preview": visual_preview,
         "visual_sync": visual_sync,
         "config_path": str(config_path),
     }

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -303,3 +303,32 @@ def test_visual_delivery_digest_changes_when_only_rendered_mermaid_changes(tmp_p
     assert first["source_digest"] == changed["source_digest"]
     assert first["delivery_digest"] != changed["delivery_digest"]
     assert first["command"]["command"] != changed["command"]["command"]
+
+
+def test_visual_delivery_digest_changes_when_target_whiteboard_changes(tmp_path) -> None:
+    projection = _complex_projection()
+    config = LarkExploreConfig(base_token="PUBLIC_FIXTURE_BASE")
+    bundle = build_explore_presentation_bundle(projection)
+
+    first = sync_explore_visual_to_lark(
+        config,
+        projection=projection,
+        visual_sink={"whiteboard_token": "wb_first", "view_role": "executive"},
+        config_path=tmp_path / "lark-explore.json",
+        semantic_digest=bundle["source_digest"],
+        display_projection=bundle["executive"],
+        view_key="executive",
+    )
+    changed = sync_explore_visual_to_lark(
+        config,
+        projection=projection,
+        visual_sink={"whiteboard_token": "wb_second", "view_role": "executive"},
+        config_path=tmp_path / "lark-explore.json",
+        semantic_digest=bundle["source_digest"],
+        display_projection=bundle["executive"],
+        view_key="executive",
+    )
+
+    assert first["source_digest"] == changed["source_digest"]
+    assert first["delivery_digest"] != changed["delivery_digest"]
+    assert first["command"]["command"] != changed["command"]["command"]


### PR DESCRIPTION
## 动机

PR #2027 已支持同源 canonical / executive 视图，但 issue-fix 的 material-change 自动刷新仍只读取 legacy `visual_sink`。因此手工切到 executive 后，后续自动刷新可能重新覆盖成旧布局。

## 改动

- 自动刷新优先消费 role-based `visual_sinks`，legacy 单视图继续作为 fallback。
- 持久化每个 role 的 delivery digest；仅 source、renderer 或目标 whiteboard 任一变化时重绘。
- 保留 canonical Base row readback、失败重试与外部 sink suppression 语义。
- 扩充真实 issue-fix projection smoke，覆盖 preview、失败重试、zero-write unchanged、renderer-only 变化和 material change。

## 验证

- `pytest -q tests/test_explore_presentation_views.py`：9 passed
- `python examples/issue-fix-explore-projection-smoke.py`：passed
- `ruff check`：passed
- `loopx canary premerge --from-git-diff --tier standard`：6 组检查通过，0 失败，0 manual hold
- public/private boundary scan：clean

## 风险

改动限于 Explore Lark visual sink 的刷新与幂等 checkpoint；未改变 canonical Nodes / Edges / Findings 语义，也未新增外部写权限。