### PR TITLE
fix(explore): compress executive scaffolding edges

### DIFF
--- a/loopx/presentation/explore_views.py
+++ b/loopx/presentation/explore_views.py
@@ -69,6 +69,7 @@ DEFAULT_EXPLORE_PRESENTATION_POLICY: dict[str, float | int] = {
     "readability_root_ratio_floor": 0.30,
     "atlas_group_node_limit": 10,
     "executive_counterevidence_limit": 8,
+    "executive_hub_edge_degree_floor": 4,
 }
 
 _MERMAID_STATUS_CLASS = {
@@ -489,6 +490,43 @@ def _view_node(
     return view
 
 
+def _executive_edge_projection(
+    edges: Sequence[Mapping[str, Any]],
+    executive_ids: set[str],
+    *,
+    hub_degree_floor: int,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Hide lineage and dense hub scaffolding that the executive layout already conveys."""
+
+    candidates = [
+        edge
+        for edge in edges
+        if str(edge.get("from_node") or "") in executive_ids
+        and str(edge.get("to_node") or "") in executive_ids
+    ]
+    outgoing_counts: dict[str, int] = defaultdict(int)
+    for edge in candidates:
+        outgoing_counts[str(edge.get("from_node") or "")] += 1
+
+    visible = []
+    suppressed = []
+    degree_floor = max(2, int(hub_degree_floor))
+    for edge in candidates:
+        edge_type = str(edge.get("edge_type") or "")
+        source = str(edge.get("from_node") or "")
+        suppression_reason = None
+        if edge_type == "subtopic_of":
+            suppression_reason = "lineage_encoded_on_node"
+        elif edge_type == "supports" and outgoing_counts[source] >= degree_floor:
+            suppression_reason = "dense_hub_scaffolding"
+        projected = dict(edge, source_edge_id=str(edge.get("edge_id") or ""))
+        if suppression_reason:
+            suppressed.append(dict(projected, suppression_reason=suppression_reason))
+        else:
+            visible.append(projected)
+    return visible, suppressed
+
+
 def build_explore_presentation_bundle(
     projection: Mapping[str, Any],
     *,
@@ -570,12 +608,11 @@ def build_explore_presentation_bundle(
         for node in nodes
         if str(node.get("node_id") or "") in executive_ids
     ]
-    executive_edges = [
-        dict(edge, source_edge_id=str(edge.get("edge_id") or ""))
-        for edge in edges
-        if str(edge.get("from_node") or "") in executive_ids
-        and str(edge.get("to_node") or "") in executive_ids
-    ]
+    executive_edges, suppressed_executive_edges = _executive_edge_projection(
+        edges,
+        executive_ids,
+        hub_degree_floor=int(thresholds["executive_hub_edge_degree_floor"]),
+    )
     executive_layout = build_vertical_explore_mermaid(
         executive_nodes,
         executive_edges,
@@ -601,6 +638,8 @@ def build_explore_presentation_bundle(
         "graph_counts": {
             "node_count": len(executive_nodes),
             "edge_count": len(executive_edges),
+            "canonical_edge_count": len(canonical_edges),
+            "suppressed_edge_count": len(suppressed_executive_edges),
             "finding_count": len(executive_findings),
             "canonical_node_count": len(canonical_nodes),
         },
@@ -608,6 +647,24 @@ def build_explore_presentation_bundle(
             "projection_mode": "executive_auto",
             "selection": "active_or_tagged_plus_material_neighbors_and_lineage",
             "truncated": False,
+            "edge_projection": {
+                "selection": "material_edges_without_lineage_or_dense_hub_scaffolding",
+                "suppressed_source_edge_ids": [
+                    str(edge.get("source_edge_id") or "")
+                    for edge in suppressed_executive_edges
+                ],
+                "suppression_counts": {
+                    reason: sum(
+                        1
+                        for edge in suppressed_executive_edges
+                        if edge.get("suppression_reason") == reason
+                    )
+                    for reason in (
+                        "lineage_encoded_on_node",
+                        "dense_hub_scaffolding",
+                    )
+                },
+            },
             "layout": {
                 key: value
                 for key, value in executive_layout.items()

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -167,6 +167,41 @@ def test_flat_large_graph_is_classified_as_a_readability_failure() -> None:
     assert bundle["canonical"]["filter"]["layout"]["column_count"] == 1
 
 
+def test_executive_view_suppresses_dense_hub_scaffolding_edges() -> None:
+    nodes = [_node("hub", status="open", tags=["decision"])]
+    nodes.extend(
+        _node(f"active-{index}", parent_id="hub", status="exploring")
+        for index in range(6)
+    )
+    edges = [_edge("hub", f"active-{index}") for index in range(6)]
+    edges.append(
+        {
+            "edge_id": "edge-active-sequence",
+            "from_node": "active-0",
+            "to_node": "active-1",
+            "edge_type": "leads_to",
+        }
+    )
+    projection = {
+        "ok": True,
+        "goal_id": "goal-public-fixture",
+        "source_event_count": len(nodes) + len(edges),
+        "nodes": nodes,
+        "edges": edges,
+        "findings": [],
+    }
+
+    bundle = build_explore_presentation_bundle(projection)
+
+    assert bundle["canonical"]["graph_counts"]["edge_count"] == 7
+    assert bundle["executive"]["graph_counts"]["edge_count"] == 1
+    assert bundle["executive"]["graph_counts"]["suppressed_edge_count"] == 6
+    edge_projection = bundle["executive"]["filter"]["edge_projection"]
+    assert edge_projection["suppression_counts"]["dense_hub_scaffolding"] == 6
+    assert "hub -->|supports|" not in bundle["executive"]["mermaid"]
+    assert "active_0 -->|leads_to| active_1" in bundle["executive"]["mermaid"]
+
+
 def test_findings_change_digest_and_stale_view_is_rejected() -> None:
     projection = _small_projection()
     bundle = build_explore_presentation_bundle(projection)


### PR DESCRIPTION
## 动机

PR #2027 将大图拆成纵向 canonical / executive 时间线，但真实 OpenViking 图在 executive 节点压缩后仍保留两个 lane hub 指向几乎所有节点的 `supports` 边。目标白板读回显示这些长弧跨越整张图，仍然不可读。

## 改动

- executive 视觉层省略已由 node lineage 表达的 `subtopic_of` 边。
- 当一个 source 成为高出度 hub 时，省略其展示用 `supports` scaffolding；canonical 边和 Base 证据保持完整。
- 在 executive filter 中记录 suppressed source edge ids 与原因计数，保留审计性。
- 新增高出度 hub 回归测试，保证 material `leads_to` 关系仍显示。

## 真实投影结果

OpenViking 当前 canonical 保持 113 nodes / 149 edges / 106 findings；executive 保持 40 nodes，展示边从 52 降为 15，并记录 37 条被压缩 scaffolding 边。Lark 目标 parser dry-run 通过。

## 验证

- presentation tests：10 passed
- ruff：passed
- `loopx canary premerge --from-git-diff --tier standard`：通过，0 失败，0 manual hold
- `git diff --check`：passed

## 风险

只改变 executive 派生视图的展示边；canonical projection、source digest、节点/发现选择及底表证据不变。