### PR TITLE
fix(explore): fit executive atlas to wide embeds

### DIFF
--- a/loopx/cli_commands/explore.py
+++ b/loopx/cli_commands/explore.py
@@ -225,6 +225,12 @@ def register_explore_commands(
         default=True,
     )
     visual.add_argument("--mermaid-node-limit", type=int, default=100)
+    visual.add_argument(
+        "--atlas-columns",
+        type=int,
+        default=1,
+        help="Arrange evidence epochs into this many whiteboard columns.",
+    )
     visual.add_argument("--execute", action="store_true")
 
     sync = sub.add_parser(
@@ -765,6 +771,7 @@ def handle_explore_command(
                 }.get(args.view_role, "canonical_filtered"),
                 include_ancestors=bool(args.include_ancestors),
                 mermaid_node_limit=args.mermaid_node_limit,
+                atlas_column_count=args.atlas_columns,
                 view_role=args.view_role,
                 execute=bool(args.execute),
             )

--- a/loopx/presentation/explore_views.py
+++ b/loopx/presentation/explore_views.py
@@ -68,6 +68,7 @@ DEFAULT_EXPLORE_PRESENTATION_POLICY: dict[str, float | int] = {
     "readability_root_count_floor": 16,
     "readability_root_ratio_floor": 0.30,
     "atlas_group_node_limit": 10,
+    "atlas_column_count": 1,
     "executive_counterevidence_limit": 8,
     "executive_hub_edge_degree_floor": 4,
 }
@@ -199,19 +200,35 @@ def build_vertical_explore_mermaid(
     *,
     view_role: str,
     group_node_limit: int = 10,
+    column_count: int = 1,
 ) -> dict[str, Any]:
-    """Render a complete top-to-bottom evidence atlas for a large graph."""
+    """Render a complete evidence atlas for a large graph.
+
+    The single-column default preserves the timeline view. Wider embedded
+    whiteboards can opt into multiple columns without changing the canonical
+    source projection.
+    """
 
     node_list = [node for node in nodes if str(node.get("node_id") or "")]
     group_limit = max(4, int(group_node_limit))
     groups = _canonical_group_specs(node_list, group_node_limit=group_limit)
+    columns = min(max(1, int(column_count)), max(1, len(groups)))
+    multi_column = columns > 1
     role = "executive" if view_role == "executive" else "canonical"
-    atlas_title = f"{role.title()} evidence timeline"
+    atlas_title = (
+        f"{role.title()} evidence atlas"
+        if multi_column
+        else f"{role.title()} evidence timeline"
+    )
 
     node_by_id = {str(node.get("node_id") or ""): node for node in node_list}
     shown_ids = set(node_by_id)
-    lines = ["flowchart TB", f'    subgraph {role}_atlas["{atlas_title}"]']
-    lines.append("        direction TB")
+    flow_direction = "LR" if multi_column else "TB"
+    lines = [
+        f"flowchart {flow_direction}",
+        f'    subgraph {role}_atlas["{atlas_title}"]',
+    ]
+    lines.append(f"        direction {flow_direction}")
     group_chains = []
     for group_index, group in enumerate(groups, start=1):
         group_id = f"{role}_group_{group_index}"
@@ -264,11 +281,15 @@ def build_vertical_explore_mermaid(
     )
     return {
         "mermaid": "\n".join(lines),
-        "strategy": "vertical_evidence_timeline",
+        "strategy": (
+            "multi_column_evidence_atlas"
+            if multi_column
+            else "vertical_evidence_timeline"
+        ),
         "view_role": role,
         "group_count": len(groups),
-        "column_count": 1,
-        "orientation": "top_to_bottom",
+        "column_count": columns,
+        "orientation": "left_to_right" if multi_column else "top_to_bottom",
         "max_group_node_count": group_limit,
     }
 
@@ -570,6 +591,7 @@ def build_explore_presentation_bundle(
         canonical_edges,
         view_role="canonical",
         group_node_limit=int(thresholds["atlas_group_node_limit"]),
+        column_count=int(thresholds["atlas_column_count"]),
     )
     canonical = {
         "schema_version": EXPLORE_CANONICAL_VIEW_VERSION,
@@ -618,6 +640,7 @@ def build_explore_presentation_bundle(
         executive_edges,
         view_role="executive",
         group_node_limit=int(thresholds["atlas_group_node_limit"]),
+        column_count=int(thresholds["atlas_column_count"]),
     )
     executive_findings = [
         finding

--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -455,6 +455,7 @@ def configure_lark_explore_visual_sink(
     projection_mode: str = "canonical_filtered",
     include_ancestors: bool = True,
     mermaid_node_limit: int = 100,
+    atlas_column_count: int = 1,
     view_role: str | None = None,
     execute: bool = False,
 ) -> dict[str, Any]:
@@ -489,6 +490,7 @@ def configure_lark_explore_visual_sink(
         "projection_mode": projection_mode,
         "include_ancestors": bool(include_ancestors),
         "mermaid_node_limit": max(1, int(mermaid_node_limit)),
+        "atlas_column_count": max(1, int(atlas_column_count)),
     }
     if role:
         visual_sink["view_role"] = role
@@ -683,13 +685,23 @@ def sync_explore_visuals_to_lark(
                 "view_role": role,
             }
             continue
+        role_sink = visual_sinks[role]
+        role_bundle = build_explore_presentation_bundle(
+            projection,
+            policy={
+                "atlas_column_count": max(
+                    1,
+                    int(role_sink.get("atlas_column_count") or 1),
+                )
+            },
+        )
         results[role] = sync_explore_visual_to_lark(
             config,
             projection=projection,
-            visual_sink=visual_sinks[role],
+            visual_sink=role_sink,
             config_path=config_path,
-            semantic_digest=bundle["source_digest"],
-            display_projection=bundle[role],
+            semantic_digest=role_bundle["source_digest"],
+            display_projection=role_bundle[role],
             view_key=role,
             execute=execute,
             runner=runner,

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -167,6 +167,19 @@ def test_flat_large_graph_is_classified_as_a_readability_failure() -> None:
     assert bundle["canonical"]["filter"]["layout"]["column_count"] == 1
 
 
+def test_configured_atlas_columns_fit_wide_whiteboard_embeds() -> None:
+    bundle = build_explore_presentation_bundle(
+        _complex_projection(),
+        policy={"atlas_column_count": 4},
+    )
+
+    assert bundle["executive"]["mermaid"].startswith("flowchart LR")
+    layout = bundle["executive"]["filter"]["layout"]
+    assert layout["strategy"] == "multi_column_evidence_atlas"
+    assert layout["column_count"] == layout["group_count"] == 2
+    assert layout["orientation"] == "left_to_right"
+
+
 def test_executive_view_suppresses_dense_hub_scaffolding_edges() -> None:
     nodes = [_node("hub", status="open", tags=["decision"])]
     nodes.extend(
@@ -250,6 +263,7 @@ def test_visual_configuration_preserves_legacy_and_supports_roles(tmp_path) -> N
         whiteboard_token="wb_executive_fixture",
         projection_mode="executive_auto",
         view_role="executive",
+        atlas_column_count=4,
         execute=True,
     )
 
@@ -257,6 +271,28 @@ def test_visual_configuration_preserves_legacy_and_supports_roles(tmp_path) -> N
     assert stored["visual_sink"]["whiteboard_token"] == "wb_legacy_fixture"
     assert stored["visual_sinks"]["canonical"]["view_role"] == "canonical"
     assert stored["visual_sinks"]["executive"]["view_role"] == "executive"
+    assert stored["visual_sinks"]["executive"]["atlas_column_count"] == 4
+
+
+def test_dual_visual_sync_applies_role_specific_atlas_columns(tmp_path) -> None:
+    projection = _complex_projection()
+    config = LarkExploreConfig(base_token="PUBLIC_FIXTURE_BASE")
+    synced = sync_explore_visuals_to_lark(
+        config,
+        projection=projection,
+        visual_sinks={
+            "executive": {
+                "whiteboard_token": "wb_executive_fixture",
+                "view_role": "executive",
+                "atlas_column_count": 4,
+            }
+        },
+        config_path=tmp_path / "lark-explore.json",
+    )
+
+    view = synced["views"]["executive"]
+    assert view["filter"]["layout"]["column_count"] == 2
+    assert view["filter"]["layout"]["orientation"] == "left_to_right"
 
 
 def test_dual_visual_sync_uses_one_revision_and_rejects_stale_view(tmp_path) -> None:


### PR DESCRIPTION
## 动机

同源 executive Explore 视图在白板嵌入宽屏文档时仍固定为单列 vertical timeline。虽然 PR #2039 已压缩密集脚手架边，但目标端会显示成过窄的长图，阅读密度仍不合格。

## 改动

- 为 visual sink 增加显式、默认关闭的 `--atlas-columns` 配置。
- 单列继续保持现有 top-to-bottom timeline；多列改为 left-to-right evidence atlas。
- 每个 role 独立应用布局配置，不影响 canonical source、semantic digest 或其他 visual sink。
- sink 配置与输出 receipt 均记录实际 column count/orientation。

## 验证

- `uv run --extra test pytest -q tests/test_explore_presentation_views.py`（12 passed）
- `uv run --extra test ruff check loopx/presentation/explore_views.py loopx/presentation/sinks/lark/explore_results.py loopx/cli_commands/explore.py tests/test_explore_presentation_views.py`
- `uv run loopx --format json canary premerge --from-git-diff --tier standard --no-progress`（merge gate passed，0 failures，0 holds）

## 风险与兼容

默认 `atlas_column_count=1`，现有配置与输出不变；只有显式配置多列的 sink 改变白板布局。