### PR TITLE
feat(explore): add fixed-grid whiteboard renderer

### DIFF
--- a/loopx/cli_commands/explore.py
+++ b/loopx/cli_commands/explore.py
@@ -231,6 +231,15 @@ def register_explore_commands(
         default=1,
         help="Arrange evidence epochs into this many whiteboard columns.",
     )
+    visual.add_argument(
+        "--renderer",
+        choices=["mermaid", "svg_atlas"],
+        default="mermaid",
+        help=(
+            "Whiteboard renderer. svg_atlas owns final geometry and requires "
+            "--view-role; mermaid preserves the compatibility default."
+        ),
+    )
     visual.add_argument("--execute", action="store_true")
 
     sync = sub.add_parser(
@@ -772,6 +781,7 @@ def handle_explore_command(
                 include_ancestors=bool(args.include_ancestors),
                 mermaid_node_limit=args.mermaid_node_limit,
                 atlas_column_count=args.atlas_columns,
+                renderer=args.renderer,
                 view_role=args.view_role,
                 execute=bool(args.execute),
             )

--- a/loopx/presentation/explore_views.py
+++ b/loopx/presentation/explore_views.py
@@ -8,8 +8,10 @@ truncates the canonical node, edge, or finding collections.
 from __future__ import annotations
 
 import hashlib
+import html
 import json
 import re
+import unicodedata
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from typing import Any
@@ -291,6 +293,185 @@ def build_vertical_explore_mermaid(
         "column_count": columns,
         "orientation": "left_to_right" if multi_column else "top_to_bottom",
         "max_group_node_count": group_limit,
+    }
+
+
+_ATLAS_PALETTE = (
+    ("#F0F4FC", "#5178C6"),
+    ("#EAE2FE", "#8569CB"),
+    ("#DFF5E5", "#509863"),
+    ("#FEF1CE", "#D4B45B"),
+)
+_ATLAS_STATUS_COLOR = {
+    "open": "#9E9E9E",
+    "exploring": "#1E88E5",
+    "blocked": "#E53935",
+    "resolved": "#43A047",
+    "dead_end": "#9E9E9E",
+}
+
+
+def _display_width(value: str) -> int:
+    return sum(2 if unicodedata.east_asian_width(character) in {"W", "F"} else 1 for character in value)
+
+
+def _truncate_display(value: str, *, limit: int) -> str:
+    cleaned = re.sub(r"\s+", " ", str(value or "")).strip()
+    if _display_width(cleaned) <= limit:
+        return cleaned
+    result = []
+    width = 0
+    for character in cleaned:
+        character_width = 2 if unicodedata.east_asian_width(character) in {"W", "F"} else 1
+        if width + character_width > max(1, limit - 1):
+            break
+        result.append(character)
+        width += character_width
+    return "".join(result).rstrip() + "…"
+
+
+def build_explore_svg_atlas(
+    nodes: Sequence[Mapping[str, Any]],
+    edges: Sequence[Mapping[str, Any]],
+    *,
+    view_role: str,
+    group_node_limit: int = 10,
+    column_count: int = 2,
+) -> dict[str, Any]:
+    """Render a deterministic owner-facing evidence atlas as standalone SVG.
+
+    Mermaid remains useful for topology exchange, but target layout engines are
+    free to ignore subgraph hints. This renderer owns the final geometry so a
+    material refresh cannot collapse the evidence epochs into a thin strip.
+    """
+
+    node_list = [node for node in nodes if str(node.get("node_id") or "")]
+    group_limit = max(4, int(group_node_limit))
+    groups = _canonical_group_specs(node_list, group_node_limit=group_limit)
+    columns = min(max(1, int(column_count)), max(1, len(groups)))
+    row_count = max(1, (len(groups) + columns - 1) // columns)
+    role = "executive" if view_role == "executive" else "canonical"
+
+    canvas_width = 1400
+    margin = 40
+    column_gap = 28
+    row_gap = 28
+    header_height = 142
+    footer_height = 42
+    card_width = (canvas_width - 2 * margin - (columns - 1) * column_gap) / columns
+    item_columns = 2 if card_width >= 560 else 1
+    item_gap = 12
+    item_height = 44
+    card_padding = 20
+    card_header_height = 54
+    item_rows = max(1, (group_limit + item_columns - 1) // item_columns)
+    card_height = card_header_height + item_rows * item_height + (item_rows - 1) * 10 + 2 * card_padding
+    canvas_height = (
+        header_height
+        + row_count * card_height
+        + max(0, row_count - 1) * row_gap
+        + footer_height
+        + margin
+    )
+    item_width = (
+        card_width - 2 * card_padding - max(0, item_columns - 1) * item_gap
+    ) / item_columns
+
+    node_by_id = {str(node.get("node_id") or ""): node for node in node_list}
+    visible_ids = set(node_by_id)
+    visible_edge_count = sum(
+        1
+        for edge in edges
+        if str(edge.get("from_node") or "") in visible_ids
+        and str(edge.get("to_node") or "") in visible_ids
+    )
+    svg = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {canvas_width} {canvas_height:.0f}" width="{canvas_width}" height="{canvas_height:.0f}">',
+        "<defs>",
+        '<filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">',
+        '<feDropShadow dx="0" dy="3" stdDeviation="5" flood-color="#1F2329" flood-opacity="0.10"/>',
+        "</filter>",
+        '<marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">',
+        '<path d="M0,0 L8,4 L0,8 Z" fill="#BBBFC4"/>',
+        "</marker>",
+        "</defs>",
+        f'<rect width="{canvas_width}" height="{canvas_height:.0f}" rx="18" fill="#FFFFFF"/>',
+        '<text x="700" y="42" text-anchor="middle" font-size="28" font-weight="700" fill="#1F2329" font-family="Arial, PingFang SC, sans-serif">'
+        f'{role.title()} Explore Evidence Atlas</text>',
+        '<text x="700" y="72" text-anchor="middle" font-size="14" fill="#646A73" font-family="Arial, PingFang SC, sans-serif">'
+        f'{len(node_list)} decision nodes · {visible_edge_count} material relations · same-source owner projection</text>',
+    ]
+
+    if groups:
+        pill_width = min(210.0, (canvas_width - 2 * margin - (len(groups) - 1) * 18) / len(groups))
+        total_pill_width = len(groups) * pill_width + max(0, len(groups) - 1) * 18
+        pill_x = (canvas_width - total_pill_width) / 2
+        for group_index, group in enumerate(groups):
+            x = pill_x + group_index * (pill_width + 18)
+            fill, border = _ATLAS_PALETTE[group_index % len(_ATLAS_PALETTE)]
+            if group_index:
+                previous_right = x - 18
+                svg.append(
+                    f'<line x1="{previous_right + 3:.1f}" y1="104" x2="{x - 4:.1f}" y2="104" stroke="#BBBFC4" stroke-width="2" marker-end="url(#arrow)"/>'
+                )
+            svg.extend(
+                [
+                    f'<rect x="{x:.1f}" y="87" width="{pill_width:.1f}" height="34" rx="17" fill="{fill}" stroke="{border}" stroke-width="2"/>',
+                    f'<text x="{x + pill_width / 2:.1f}" y="109" text-anchor="middle" font-size="14" font-weight="600" fill="#1F2329" font-family="Arial, PingFang SC, sans-serif">Epoch {group_index + 1:02d}</text>',
+                ]
+            )
+
+    for group_index, group in enumerate(groups):
+        row = group_index // columns
+        column = group_index % columns
+        x = margin + column * (card_width + column_gap)
+        y = header_height + row * (card_height + row_gap)
+        fill, border = _ATLAS_PALETTE[group_index % len(_ATLAS_PALETTE)]
+        first_title = _truncate_display(
+            str(node_by_id[group["node_ids"][0]].get("title") or "Evidence"),
+            limit=48,
+        )
+        svg.extend(
+            [
+                f'<rect x="{x:.1f}" y="{y:.1f}" width="{card_width:.1f}" height="{card_height:.1f}" rx="14" fill="{fill}" stroke="{border}" stroke-width="2" filter="url(#shadow)"/>',
+                f'<text x="{x + card_padding:.1f}" y="{y + 30:.1f}" font-size="16" font-weight="700" fill="#1F2329" font-family="Arial, PingFang SC, sans-serif">{html.escape(f"Epoch {group_index + 1:02d} · {first_title}")}</text>',
+                f'<text x="{x + card_width - card_padding:.1f}" y="{y + 30:.1f}" text-anchor="end" font-size="13" fill="#646A73" font-family="Arial, PingFang SC, sans-serif">{len(group["node_ids"])} nodes</text>',
+            ]
+        )
+        for item_index, node_id in enumerate(group["node_ids"]):
+            node = node_by_id[node_id]
+            item_row = item_index // item_columns
+            item_column = item_index % item_columns
+            item_x = x + card_padding + item_column * (item_width + item_gap)
+            item_y = y + card_header_height + card_padding + item_row * (item_height + 10)
+            status = str(node.get("status") or "open")
+            status_color = _ATLAS_STATUS_COLOR.get(status, "#9E9E9E")
+            label = _truncate_display(str(node.get("title") or node_id), limit=34)
+            svg.extend(
+                [
+                    f'<rect x="{item_x:.1f}" y="{item_y:.1f}" width="{item_width:.1f}" height="{item_height}" rx="8" fill="#FFFFFF" stroke="{border}" stroke-width="2"/>',
+                    f'<circle cx="{item_x + 15:.1f}" cy="{item_y + item_height / 2:.1f}" r="5" fill="{status_color}"/>',
+                    f'<text x="{item_x + 28:.1f}" y="{item_y + 27:.1f}" font-size="13" fill="#1F2329" font-family="Arial, PingFang SC, sans-serif">{html.escape(label)}</text>',
+                ]
+            )
+
+    svg.append(
+        f'<text x="700" y="{canvas_height - 22:.1f}" text-anchor="middle" font-size="13" fill="#646A73" font-family="Arial, PingFang SC, sans-serif">Complete Nodes / Edges / Findings remain in the linked canonical result board.</text>'
+    )
+    svg.append("</svg>")
+    return {
+        "svg": "\n".join(svg),
+        "strategy": "fixed_grid_evidence_atlas",
+        "view_role": role,
+        "group_count": len(groups),
+        "column_count": columns,
+        "row_count": row_count,
+        "item_column_count": item_columns,
+        "max_group_node_count": group_limit,
+        "rendered_relation_count": max(0, len(groups) - 1),
+        "source_edge_count": visible_edge_count,
+        "canvas_width": canvas_width,
+        "canvas_height": round(canvas_height),
     }
 
 
@@ -593,6 +774,13 @@ def build_explore_presentation_bundle(
         group_node_limit=int(thresholds["atlas_group_node_limit"]),
         column_count=int(thresholds["atlas_column_count"]),
     )
+    canonical_svg_layout = build_explore_svg_atlas(
+        canonical_nodes,
+        canonical_edges,
+        view_role="canonical",
+        group_node_limit=int(thresholds["atlas_group_node_limit"]),
+        column_count=int(thresholds["atlas_column_count"]),
+    )
     canonical = {
         "schema_version": EXPLORE_CANONICAL_VIEW_VERSION,
         "goal_id": projection.get("goal_id"),
@@ -603,6 +791,7 @@ def build_explore_presentation_bundle(
         "edges": canonical_edges,
         "findings": findings,
         "mermaid": canonical_layout["mermaid"],
+        "svg": canonical_svg_layout["svg"],
         "graph_counts": {
             "node_count": len(canonical_nodes),
             "edge_count": len(canonical_edges),
@@ -615,6 +804,13 @@ def build_explore_presentation_bundle(
                 key: value
                 for key, value in canonical_layout.items()
                 if key != "mermaid"
+            },
+            "renderer_layouts": {
+                "svg_atlas": {
+                    key: value
+                    for key, value in canonical_svg_layout.items()
+                    if key != "svg"
+                }
             },
         },
     }
@@ -642,6 +838,13 @@ def build_explore_presentation_bundle(
         group_node_limit=int(thresholds["atlas_group_node_limit"]),
         column_count=int(thresholds["atlas_column_count"]),
     )
+    executive_svg_layout = build_explore_svg_atlas(
+        executive_nodes,
+        executive_edges,
+        view_role="executive",
+        group_node_limit=int(thresholds["atlas_group_node_limit"]),
+        column_count=int(thresholds["atlas_column_count"]),
+    )
     executive_findings = [
         finding
         for finding in findings
@@ -658,6 +861,7 @@ def build_explore_presentation_bundle(
         "edges": executive_edges,
         "findings": executive_findings,
         "mermaid": executive_layout["mermaid"],
+        "svg": executive_svg_layout["svg"],
         "graph_counts": {
             "node_count": len(executive_nodes),
             "edge_count": len(executive_edges),
@@ -692,6 +896,13 @@ def build_explore_presentation_bundle(
                 key: value
                 for key, value in executive_layout.items()
                 if key != "mermaid"
+            },
+            "renderer_layouts": {
+                "svg_atlas": {
+                    key: value
+                    for key, value in executive_svg_layout.items()
+                    if key != "svg"
+                }
             },
         },
     }

--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -70,6 +70,9 @@ DEFAULT_EXPLORE_BASE_NAME = "LoopX Exploration Results"
 SINK_VISIBILITY_OWNER_ONLY = "owner-only"
 SINK_VISIBILITY_SHARED = "shared"
 SINK_VISIBILITIES = {SINK_VISIBILITY_OWNER_ONLY, SINK_VISIBILITY_SHARED}
+VISUAL_RENDERER_MERMAID = "mermaid"
+VISUAL_RENDERER_SVG_ATLAS = "svg_atlas"
+VISUAL_RENDERERS = {VISUAL_RENDERER_MERMAID, VISUAL_RENDERER_SVG_ATLAS}
 
 TABLE_NODES = "nodes"
 TABLE_EDGES = "edges"
@@ -456,6 +459,7 @@ def configure_lark_explore_visual_sink(
     include_ancestors: bool = True,
     mermaid_node_limit: int = 100,
     atlas_column_count: int = 1,
+    renderer: str = VISUAL_RENDERER_MERMAID,
     view_role: str | None = None,
     execute: bool = False,
 ) -> dict[str, Any]:
@@ -478,6 +482,11 @@ def configure_lark_explore_visual_sink(
     expected_mode = {"canonical": "canonical_full", "executive": "executive_auto"}.get(role)
     if expected_mode and projection_mode != expected_mode:
         raise ValueError(f"view_role {role} requires projection_mode {expected_mode}")
+    selected_renderer = str(renderer or VISUAL_RENDERER_MERMAID).strip()
+    if selected_renderer not in VISUAL_RENDERERS:
+        raise ValueError(f"renderer must be one of {sorted(VISUAL_RENDERERS)}")
+    if selected_renderer == VISUAL_RENDERER_SVG_ATLAS and role is None:
+        raise ValueError("svg_atlas renderer requires a canonical or executive view_role")
     local = read_lark_explore_local_config(config_path)
     if not local.get("ok") or not local.get("exists"):
         raise ValueError("run `loopx explore feishu-setup` before configuring a visual sink")
@@ -491,6 +500,7 @@ def configure_lark_explore_visual_sink(
         "include_ancestors": bool(include_ancestors),
         "mermaid_node_limit": max(1, int(mermaid_node_limit)),
         "atlas_column_count": max(1, int(atlas_column_count)),
+        "renderer": selected_renderer,
     }
     if role:
         visual_sink["view_role"] = role
@@ -526,7 +536,7 @@ def sync_explore_visual_to_lark(
     execute: bool = False,
     runner: CommandRunner = default_subprocess_runner,
 ) -> dict[str, Any]:
-    """Publish a configured Mermaid whiteboard without conflating it with Base rows."""
+    """Publish a configured whiteboard without conflating it with Base rows."""
 
     if not isinstance(visual_sink, Mapping):
         return {
@@ -577,20 +587,47 @@ def sync_explore_visual_to_lark(
         )
     )
     sink_key = str(view_key or visual_sink.get("view_role") or "visual").strip() or "visual"
+    renderer = str(visual_sink.get("renderer") or VISUAL_RENDERER_MERMAID).strip()
+    if renderer not in VISUAL_RENDERERS:
+        return {
+            "ok": False,
+            "schema_version": LARK_EXPLORE_VISUAL_SYNC_VERSION,
+            "status": "invalid_config",
+            "execute": execute,
+            "published": False,
+            "error": f"visual_sink.renderer must be one of {sorted(VISUAL_RENDERERS)}",
+        }
+    source_key, input_format, extension = {
+        VISUAL_RENDERER_MERMAID: ("mermaid", "mermaid", "mmd"),
+        VISUAL_RENDERER_SVG_ATLAS: ("svg", "svg", "svg"),
+    }[renderer]
+    rendered_source = str(graph.get(source_key) or "")
+    if not rendered_source.strip():
+        return {
+            "ok": False,
+            "schema_version": LARK_EXPLORE_VISUAL_SYNC_VERSION,
+            "status": "invalid_projection",
+            "execute": execute,
+            "published": False,
+            "view_role": str(graph.get("view_role") or sink_key),
+            "renderer": renderer,
+            "error": f"display projection does not contain {source_key} source",
+        }
     delivery_material = json.dumps(
         {
             "source_digest": semantic_digest,
             "source_revision": source_revision,
             "view_role": sink_key,
             "whiteboard_token": whiteboard_token,
-            "mermaid": str(graph.get("mermaid") or ""),
+            "renderer": renderer,
+            "rendered_source": rendered_source,
         },
         ensure_ascii=True,
         sort_keys=True,
         separators=(",", ":"),
     ).encode("utf-8")
     delivery_digest = hashlib.sha256(delivery_material).hexdigest()
-    source_name = f".loopx-explore-{sink_key}-{delivery_digest[:12]}.mmd"
+    source_name = f".loopx-explore-{sink_key}-{delivery_digest[:12]}.{extension}"
     command = [
         config.cli_bin,
         "whiteboard",
@@ -600,7 +637,7 @@ def sync_explore_visual_to_lark(
         "--whiteboard-token",
         whiteboard_token,
         "--input_format",
-        "mermaid",
+        input_format,
         "--source",
         f"@{source_name}",
         "--overwrite",
@@ -614,7 +651,7 @@ def sync_explore_visual_to_lark(
     else:
         config_path.parent.mkdir(parents=True, exist_ok=True)
         source_path = config_path.parent / source_name
-        source_path.write_text(str(graph.get("mermaid") or ""), encoding="utf-8")
+        source_path.write_text(rendered_source, encoding="utf-8")
         try:
             result = _run_command(
                 command,
@@ -635,6 +672,8 @@ def sync_explore_visual_to_lark(
         "source_digest": source_digest,
         "source_revision": source_revision,
         "view_role": str(graph.get("view_role") or sink_key),
+        "renderer": renderer,
+        "input_format": input_format,
         "docx_token": str(visual_sink.get("docx_token") or "") or None,
         "graph_counts": graph.get("graph_counts"),
         "filter": graph.get("filter"),

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -180,6 +180,25 @@ def test_configured_atlas_columns_fit_wide_whiteboard_embeds() -> None:
     assert layout["orientation"] == "left_to_right"
 
 
+def test_svg_atlas_owns_a_fixed_grid_and_keeps_executive_nodes_visible() -> None:
+    bundle = build_explore_presentation_bundle(
+        _complex_projection(),
+        policy={"atlas_column_count": 2},
+    )
+
+    executive = bundle["executive"]
+    svg = executive["svg"]
+    layout = executive["filter"]["renderer_layouts"]["svg_atlas"]
+    assert svg.startswith('<svg xmlns="http://www.w3.org/2000/svg"')
+    assert "Executive Explore Evidence Atlas" in svg
+    assert layout["strategy"] == "fixed_grid_evidence_atlas"
+    assert layout["column_count"] == 2
+    assert layout["row_count"] >= 1
+    assert layout["rendered_relation_count"] == layout["group_count"] - 1
+    for node in executive["nodes"]:
+        assert str(node["title"]) in svg
+
+
 def test_executive_view_suppresses_dense_hub_scaffolding_edges() -> None:
     nodes = [_node("hub", status="open", tags=["decision"])]
     nodes.extend(
@@ -264,6 +283,7 @@ def test_visual_configuration_preserves_legacy_and_supports_roles(tmp_path) -> N
         projection_mode="executive_auto",
         view_role="executive",
         atlas_column_count=4,
+        renderer="svg_atlas",
         execute=True,
     )
 
@@ -272,6 +292,27 @@ def test_visual_configuration_preserves_legacy_and_supports_roles(tmp_path) -> N
     assert stored["visual_sinks"]["canonical"]["view_role"] == "canonical"
     assert stored["visual_sinks"]["executive"]["view_role"] == "executive"
     assert stored["visual_sinks"]["executive"]["atlas_column_count"] == 4
+    assert stored["visual_sinks"]["executive"]["renderer"] == "svg_atlas"
+
+
+def test_svg_atlas_configuration_requires_an_explicit_view_role(tmp_path) -> None:
+    config_path = tmp_path / "lark-explore.json"
+    write_lark_explore_local_config(
+        config_path,
+        {
+            "board": {
+                "base_token": "PUBLIC_FIXTURE_BASE",
+                "tables": {"nodes": "tblN", "edges": "tblE", "findings": "tblF"},
+            }
+        },
+    )
+
+    with pytest.raises(ValueError, match="requires a canonical or executive"):
+        configure_lark_explore_visual_sink(
+            config_path=config_path,
+            whiteboard_token="wb_legacy_fixture",
+            renderer="svg_atlas",
+        )
 
 
 def test_dual_visual_sync_applies_role_specific_atlas_columns(tmp_path) -> None:
@@ -285,14 +326,19 @@ def test_dual_visual_sync_applies_role_specific_atlas_columns(tmp_path) -> None:
                 "whiteboard_token": "wb_executive_fixture",
                 "view_role": "executive",
                 "atlas_column_count": 4,
+                "renderer": "svg_atlas",
             }
         },
         config_path=tmp_path / "lark-explore.json",
     )
 
     view = synced["views"]["executive"]
-    assert view["filter"]["layout"]["column_count"] == 2
-    assert view["filter"]["layout"]["orientation"] == "left_to_right"
+    assert view["filter"]["renderer_layouts"]["svg_atlas"]["column_count"] == 2
+    assert view["renderer"] == "svg_atlas"
+    assert view["input_format"] == "svg"
+    command = view["command"]["command"]
+    assert "--input_format svg" in command
+    assert ".svg --overwrite" in command
 
 
 def test_dual_visual_sync_uses_one_revision_and_rejects_stale_view(tmp_path) -> None:
@@ -374,6 +420,48 @@ def test_visual_delivery_digest_changes_when_only_rendered_mermaid_changes(tmp_p
     assert first["source_digest"] == changed["source_digest"]
     assert first["delivery_digest"] != changed["delivery_digest"]
     assert first["command"]["command"] != changed["command"]["command"]
+
+
+def test_visual_delivery_digest_and_command_include_renderer(tmp_path) -> None:
+    projection = _complex_projection()
+    config = LarkExploreConfig(base_token="PUBLIC_FIXTURE_BASE")
+    bundle = build_explore_presentation_bundle(
+        projection,
+        policy={"atlas_column_count": 2},
+    )
+    view = bundle["executive"]
+
+    mermaid = sync_explore_visual_to_lark(
+        config,
+        projection=projection,
+        visual_sink={
+            "whiteboard_token": "wb_executive_fixture",
+            "view_role": "executive",
+            "renderer": "mermaid",
+        },
+        config_path=tmp_path / "lark-explore.json",
+        semantic_digest=bundle["source_digest"],
+        display_projection=view,
+        view_key="executive",
+    )
+    svg = sync_explore_visual_to_lark(
+        config,
+        projection=projection,
+        visual_sink={
+            "whiteboard_token": "wb_executive_fixture",
+            "view_role": "executive",
+            "renderer": "svg_atlas",
+        },
+        config_path=tmp_path / "lark-explore.json",
+        semantic_digest=bundle["source_digest"],
+        display_projection=view,
+        view_key="executive",
+    )
+
+    assert mermaid["source_digest"] == svg["source_digest"]
+    assert mermaid["delivery_digest"] != svg["delivery_digest"]
+    assert mermaid["input_format"] == "mermaid"
+    assert svg["input_format"] == "svg"
 
 
 def test_visual_delivery_digest_changes_when_target_whiteboard_changes(tmp_path) -> None:


### PR DESCRIPTION
## Motivation

Mermaid layout hints are not a target-geometry contract. A valid multi-column Explore graph can still be imported as a thin, unreadable strip.

Fixes #2041.

## Changes

- add an opt-in `svg_atlas` renderer for canonical/executive Explore views
- render a deterministic card grid with stable CJK-aware truncation, status color, group epochs, and bounded canvas geometry
- preserve `mermaid` as the compatibility default
- include renderer and rendered source in the delivery digest
- route the selected file type and `--input_format` through the existing Lark whiteboard sink
- fail closed when `svg_atlas` lacks an explicit view role or the projected source

## Validation

- `pytest -q tests/test_explore_presentation_views.py` (15 passed)
- `ruff check` on changed files
- `loopx canary premerge --from-git-diff` (passed; 3 selected canaries, no holds)
- real owner-facing whiteboard import and image readback: 2x2 atlas, 40 decision nodes, 15 material relations

## Boundary

No private board ids, local paths, credentials, or raw transcripts are committed. Canonical Nodes / Edges / Findings remain the authoritative evidence surface.