### PR TITLE
fix(heartbeat): default prompt body to thin

### DIFF
--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -77,8 +77,9 @@ loopx heartbeat-prompt \
   --active-state <ACTIVE_GOAL_STATE_PATH>
 ```
 
-For recurring App heartbeats, prefer the compact body after the full lifecycle
-has been reviewed:
+For recurring App heartbeats, the default body is the thin local dispatcher.
+Use the compact body after the full lifecycle has been reviewed when the
+installed prompt should carry more lifecycle detail inline:
 
 ```bash
 loopx heartbeat-prompt \
@@ -86,9 +87,17 @@ loopx heartbeat-prompt \
   --compact
 ```
 
-The expanded prompt remains the audit source and compatibility default. The
-compact prompt is the daily driver: it reduces per-tick context while preserving
-the same commands and decision points.
+The expanded prompt remains available as the explicit audit source:
+
+```bash
+loopx heartbeat-prompt \
+  --goal-id <GOAL_ID> \
+  --full
+```
+
+The thin prompt is the installed default. It keeps per-tick context small and
+expects trusted agents to pull the current LoopX state before acting. The
+compact prompt is the heavier inline lifecycle body.
 
 When multiple agents share the same project control plane, first register the
 public-safe agent ids on the goal, then give each automation an explicit

--- a/examples/control_plane/heartbeat-prompt-smoke.py
+++ b/examples/control_plane/heartbeat-prompt-smoke.py
@@ -30,7 +30,8 @@ from loopx.heartbeat_prompt import build_heartbeat_prompt  # noqa: E402
 
 
 def main() -> int:
-    payload = build_heartbeat_prompt(goal_id=GOAL_ID, active_state=ACTIVE_STATE)
+    default_payload = build_heartbeat_prompt(goal_id=GOAL_ID, active_state=ACTIVE_STATE)
+    payload = build_heartbeat_prompt(goal_id=GOAL_ID, active_state=ACTIVE_STATE, full=True)
     compact_payload = build_heartbeat_prompt(goal_id=GOAL_ID, active_state=ACTIVE_STATE, compact=True)
     brief_payload = build_heartbeat_prompt(goal_id=GOAL_ID, active_state=ACTIVE_STATE, brief=True)
     thin_payload = build_heartbeat_prompt(goal_id=GOAL_ID, active_state=ACTIVE_STATE, thin=True)
@@ -119,10 +120,12 @@ def main() -> int:
         unregistered_agent = str(exc)
     assert unregistered_agent and "is not registered" in unregistered_agent, unregistered_agent
     assert_prompt_budget("full", str(payload["task_body"]))
+    assert_prompt_budget("thin", str(default_payload["task_body"]))
     assert_prompt_budget("compact", str(compact_payload["task_body"]))
     assert_prompt_budget("brief", str(brief_payload["task_body"]))
     assert_prompt_budget("thin", str(thin_payload["task_body"]))
     assert_interface_budget_payload("full", payload)
+    assert_interface_budget_payload("thin", default_payload)
     assert_interface_budget_payload("compact", compact_payload)
     assert_interface_budget_payload("brief", brief_payload)
     assert_interface_budget_payload("thin", thin_payload)
@@ -131,10 +134,11 @@ def main() -> int:
     assert_interface_budget_payload("thin", thin_scoped_payload)
     assert_interface_budget_payload("thin", profile_scoped_payload)
     assert_no_project_specific_prompt_leaks("full", str(payload["task_body"]))
+    assert_no_project_specific_prompt_leaks("thin", str(default_payload["task_body"]))
     assert_no_project_specific_prompt_leaks("compact", str(compact_payload["task_body"]))
     assert_no_project_specific_prompt_leaks("brief", str(brief_payload["task_body"]))
     assert_no_project_specific_prompt_leaks("thin", str(thin_payload["task_body"]))
-    for prompt_payload in (payload, compact_payload, brief_payload, thin_payload):
+    for prompt_payload in (payload, default_payload, compact_payload, brief_payload, thin_payload):
         task_body = str(prompt_payload["task_body"])
         assert "lark_event_inbox" in task_body, task_body
         assert "drain" in task_body and "ACK" in task_body, task_body
@@ -145,6 +149,10 @@ def main() -> int:
             assert "drain_command" in task_body, task_body
             assert "writeback" in task_body, task_body
     thin_task = str(thin_payload["task_body"])
+    assert default_payload["task_body"] == thin_payload["task_body"], default_payload
+    assert default_payload["thin"] is True, default_payload
+    assert default_payload["full"] is False, default_payload
+    assert payload["full"] is True, payload
     assert "Observed runtime capabilities -> `--available-capability`, never user gates." in thin_task, thin_task
     assert payload["quota_guard_command"] == (
         'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" '
@@ -169,7 +177,7 @@ def main() -> int:
     for phrase in (
         "compact LoopX heartbeat body",
         "Expanded lifecycle contract",
-        "loopx heartbeat-prompt --goal-id public-heartbeat-goal --active-state /tmp/public-heartbeat-goal/ACTIVE_GOAL_STATE.md",
+        "loopx heartbeat-prompt --full --goal-id public-heartbeat-goal --active-state /tmp/public-heartbeat-goal/ACTIVE_GOAL_STATE.md",
         'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota should-run --goal-id public-heartbeat-goal',
         "state=operator_gate",
         "notify_user_on_open_todo=true",
@@ -205,7 +213,7 @@ def main() -> int:
     assert registry_default_payload["active_state"] == "the registry-declared active state", registry_default_payload
     assert registry_default_payload["active_state_source"] == "registry", registry_default_payload
     assert registry_default_payload["expanded_prompt_command"] == (
-        "loopx heartbeat-prompt --goal-id public-heartbeat-goal"
+        "loopx heartbeat-prompt --full --goal-id public-heartbeat-goal"
     ), registry_default_payload
     assert registry_default_payload["compact_prompt_command"] == (
         "loopx heartbeat-prompt --compact --goal-id public-heartbeat-goal"
@@ -738,11 +746,37 @@ def main() -> int:
         text=True,
     )
     cli_payload = json.loads(cli_json.stdout)
-    assert cli_payload["task_body"] == payload["task_body"], cli_payload
+    assert cli_payload["task_body"] == default_payload["task_body"], cli_payload
     assert cli_payload["compact"] is False, cli_payload
     assert cli_payload["brief"] is False, cli_payload
+    assert cli_payload["thin"] is True, cli_payload
+    assert cli_payload["full"] is False, cli_payload
     assert cli_payload["cli_bin"] == "loopx", cli_payload
     assert cli_payload["active_state_source"] == "explicit", cli_payload
+
+    cli_full_json = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "heartbeat-prompt",
+            "--goal-id",
+            GOAL_ID,
+            "--active-state",
+            str(ACTIVE_STATE),
+            "--full",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    cli_full_payload = json.loads(cli_full_json.stdout)
+    assert cli_full_payload["task_body"] == payload["task_body"], cli_full_payload
+    assert cli_full_payload["full"] is True, cli_full_payload
+    assert cli_full_payload["thin"] is False, cli_full_payload
 
     cli_compact_json = subprocess.run(
         [
@@ -938,7 +972,7 @@ def main() -> int:
         assert cli_registry_default_payload["active_state_source"].startswith("registry:"), cli_registry_default_payload
         assert cli_registry_default_payload["resolved_active_state"] == str(state_file), cli_registry_default_payload
         assert cli_registry_default_payload["expanded_prompt_command"] == (
-            "loopx heartbeat-prompt --goal-id public-heartbeat-goal "
+            "loopx heartbeat-prompt --full --goal-id public-heartbeat-goal "
             "--agent-id codex-main-control --agent-scope 'primary review and coordination'"
         ), cli_registry_default_payload
         assert "loopx heartbeat-prompt --compact --goal-id public-heartbeat-goal" in (
@@ -1306,7 +1340,7 @@ def main() -> int:
         text=True,
     ).stdout
     assert "# Heartbeat Automation Prompt" in cli_markdown, cli_markdown
-    assert "Copy this task body into a Codex App heartbeat automation." in cli_markdown, cli_markdown
+    assert "Copy this thin task body into a Codex App heartbeat automation." in cli_markdown, cli_markdown
     assert str(ACTIVE_STATE) in cli_markdown, cli_markdown
     print("heartbeat-prompt-smoke ok")
     return 0

--- a/loopx/cli_commands/support_control.py
+++ b/loopx/cli_commands/support_control.py
@@ -166,6 +166,11 @@ def register_support_control_commands(
     )
     heartbeat_style_group = heartbeat_prompt_parser.add_mutually_exclusive_group()
     heartbeat_style_group.add_argument(
+        "--full",
+        action="store_true",
+        help="Generate the expanded audit body. The default installed heartbeat body is thin.",
+    )
+    heartbeat_style_group.add_argument(
         "--compact",
         action="store_true",
         help="Generate a shorter automation body that points edge cases back to the expanded lifecycle contract.",
@@ -379,6 +384,7 @@ def handle_support_control_command(
                 resolved_active_state=resolved_active_state,
                 material_queue_rule=args.material_rule,
                 permission_rule=args.permission_rule,
+                full=bool(args.full),
                 compact=bool(args.compact),
                 brief=bool(args.brief),
                 thin=bool(args.thin),
@@ -407,6 +413,7 @@ def handle_support_control_command(
                 resolved_active_state=fallback_resolved_active_state,
                 material_queue_rule=args.material_rule,
                 permission_rule=args.permission_rule,
+                full=bool(args.full),
                 compact=bool(args.compact),
                 brief=bool(args.brief),
                 thin=bool(args.thin),

--- a/loopx/heartbeat_prompt.py
+++ b/loopx/heartbeat_prompt.py
@@ -59,14 +59,22 @@ INTERFACE_BUDGET_CHARS = {
 }
 
 
-def heartbeat_prompt_mode(*, compact: bool = False, brief: bool = False, thin: bool = False) -> str:
+def heartbeat_prompt_mode(
+    *,
+    full: bool = False,
+    compact: bool = False,
+    brief: bool = False,
+    thin: bool = False,
+) -> str:
+    if full:
+        return "full"
     if thin:
         return "thin"
     if brief:
         return "brief"
     if compact:
         return "compact"
-    return "full"
+    return "thin"
 
 
 def prompt_budget_text(text: str, *, goal_id: str, active_state: str) -> str:
@@ -144,6 +152,7 @@ def build_peer_identity_required_error(
     goal_id: str,
     cli_bin: str,
     active_state_arg: str,
+    full: bool,
     compact: bool,
     brief: bool,
     thin: bool,
@@ -156,6 +165,8 @@ def build_peer_identity_required_error(
         if brief
         else " --compact"
         if compact
+        else " --full"
+        if full
         else ""
     )
     base = (
@@ -238,11 +249,12 @@ def build_interface_budget(
     task_body: str,
     goal_id: str,
     active_state: str,
+    full: bool = False,
     compact: bool = False,
     brief: bool = False,
     thin: bool = False,
 ) -> dict[str, Any]:
-    mode = heartbeat_prompt_mode(compact=compact, brief=brief, thin=thin)
+    mode = heartbeat_prompt_mode(full=full, compact=compact, brief=brief, thin=thin)
     budget_text = prompt_budget_text(task_body, goal_id=goal_id, active_state=active_state)
     budget_chars = len(budget_text)
     max_chars = INTERFACE_BUDGET_CHARS[mode]
@@ -264,6 +276,7 @@ def build_heartbeat_prompt(
     resolved_active_state: Path | None = None,
     material_queue_rule: str | None = None,
     permission_rule: str | None = None,
+    full: bool = False,
     compact: bool = False,
     brief: bool = False,
     thin: bool = False,
@@ -274,6 +287,8 @@ def build_heartbeat_prompt(
     registered_agents: list[str] | tuple[str, ...] | None = None,
     available_capabilities: list[str] | tuple[str, ...] | None = None,
 ) -> dict[str, Any]:
+    if not (full or compact or brief or thin):
+        thin = True
     effective_resolved_active_state = resolved_active_state or active_state
     active_state_text = str(active_state.expanduser()) if active_state else "the registry-declared active state"
     if active_state:
@@ -299,6 +314,7 @@ def build_heartbeat_prompt(
                 goal_id=goal_id,
                 cli_bin=cli_bin,
                 active_state_arg=active_state_arg,
+                full=full,
                 compact=compact,
                 brief=brief,
                 thin=thin,
@@ -360,7 +376,7 @@ def build_heartbeat_prompt(
         delivery_outcome="outcome_progress",
     )
     cli_preflight = render_cli_preflight(cli_bin=cli_bin)
-    expanded_prompt_command = f"{cli_bin} heartbeat-prompt --goal-id {goal_id}{active_state_arg}{agent_args}{capability_args}"
+    expanded_prompt_command = f"{cli_bin} heartbeat-prompt --full --goal-id {goal_id}{active_state_arg}{agent_args}{capability_args}"
     compact_prompt_command = f"{cli_bin} heartbeat-prompt --compact --goal-id {goal_id}{active_state_arg}{agent_args}{capability_args}"
     brief_prompt_command = f"{cli_bin} heartbeat-prompt --brief --goal-id {goal_id}{active_state_arg}{agent_args}{capability_args}"
     thin_prompt_command = f"{cli_bin} heartbeat-prompt --thin --goal-id {goal_id}{active_state_arg}{agent_args}{capability_args}"
@@ -400,6 +416,7 @@ def build_heartbeat_prompt(
         "compact": compact,
         "brief": brief,
         "thin": thin,
+        "full": full,
         "cli_bin": cli_bin,
         "agent_id": normalized_agent_id,
         "agent_role": agent_role,
@@ -422,6 +439,7 @@ def build_heartbeat_prompt(
             task_body=task_body,
             goal_id=goal_id,
             active_state=active_state_text,
+            full=full,
             compact=compact,
             brief=brief,
             thin=thin,
@@ -439,6 +457,7 @@ def build_heartbeat_prompt_error_payload(
     active_state: Path | None = None,
     active_state_source: str | None = None,
     resolved_active_state: Path | None = None,
+    full: bool = False,
     compact: bool = False,
     brief: bool = False,
     thin: bool = False,
@@ -450,6 +469,8 @@ def build_heartbeat_prompt_error_payload(
     material_queue_rule: str | None = None,
     permission_rule: str | None = None,
 ) -> dict[str, Any]:
+    if not (full or compact or brief or thin):
+        thin = True
     active_state_text = str(active_state.expanduser()) if active_state else "the registry-declared active state"
     source = active_state_source or ("explicit" if active_state else "registry")
     active_state_arg = f" --active-state {active_state_text}" if active_state else ""
@@ -468,7 +489,7 @@ def build_heartbeat_prompt_error_payload(
     capability_args = render_available_capability_args(
         projected_available_capabilities
     )
-    expanded_prompt_command = f"{cli_bin} heartbeat-prompt --goal-id {goal_id}{active_state_arg}{agent_args}{capability_args}"
+    expanded_prompt_command = f"{cli_bin} heartbeat-prompt --full --goal-id {goal_id}{active_state_arg}{agent_args}{capability_args}"
     compact_prompt_command = f"{cli_bin} heartbeat-prompt --compact --goal-id {goal_id}{active_state_arg}{agent_args}{capability_args}"
     brief_prompt_command = f"{cli_bin} heartbeat-prompt --brief --goal-id {goal_id}{active_state_arg}{agent_args}{capability_args}"
     thin_prompt_command = f"{cli_bin} heartbeat-prompt --thin --goal-id {goal_id}{active_state_arg}{agent_args}{capability_args}"
@@ -483,6 +504,7 @@ def build_heartbeat_prompt_error_payload(
         "compact": compact,
         "brief": brief,
         "thin": thin,
+        "full": full,
         "cli_bin": cli_bin,
         "agent_id": str(agent_id).strip() if agent_id else None,
         "agent_role": None,

--- a/skills/loopx-project/SKILL.md
+++ b/skills/loopx-project/SKILL.md
@@ -419,9 +419,9 @@ goal, prefer the generator instead of hand-copying the quota lifecycle:
 loopx heartbeat-prompt --goal-id <STABLE_GOAL_ID>
 ```
 
-For live Codex App automations, prefer the thin body as the local machine
-default when the target Codex agent can inspect LoopX state and CLI
-output itself:
+The default generated body is thin when the target Codex agent can inspect
+LoopX state and CLI output itself. Passing `--thin` remains accepted and
+explicit:
 
 ```bash
 loopx heartbeat-prompt --thin --goal-id <STABLE_GOAL_ID>
@@ -457,16 +457,16 @@ from the registry goal `state_file`, which keeps installed automations from
 pinning a stale path. Pass `--active-state <ACTIVE_GOAL_STATE_PATH>` only for
 detached state files, migration checks, or compatibility tests.
 
-Copy the generated task body into the Codex App heartbeat automation. The full
-body is the audit source and compatibility default. The thin body is the daily
-driver for trusted local workers: it keeps the automation prompt project-agnostic
-and tells Codex to re-read registry/global quota truth, active state,
-status/run history, repo state, and project signals on each wakeup. The compact
-body is useful when context pressure matters but the installed prompt should
-still carry the quota, gate, blocker-push, recommendation, steering-audit,
-writeback, refresh, and spend lifecycle inline. The brief body keeps only
-preflight/guard, core invariants, and spend accounting in the installed prompt
-while delegating detailed branches back to the generated compact/full contracts.
+Copy the generated task body into the Codex App heartbeat automation. The thin
+body is the installed default for trusted local workers: it keeps the automation
+prompt project-agnostic and tells Codex to re-read registry/global quota truth,
+active state, status/run history, repo state, and project signals on each
+wakeup. Use `--full` for the expanded audit source. The compact body is useful
+when context pressure matters but the installed prompt should still carry the
+quota, gate, blocker-push, recommendation, steering-audit, writeback, refresh,
+and spend lifecycle inline. The brief body keeps only preflight/guard, core
+invariants, and spend accounting in the installed prompt while delegating
+detailed branches back to the generated compact/full contracts.
 The generated guard and spend commands explicitly use the shared global
 registry so project heartbeats read the same operator gates and user todos as
 the dashboard, regardless of their current repo. Completed heartbeat delivery


### PR DESCRIPTION
## Summary
- make bare `loopx heartbeat-prompt` generate the thin dispatcher body by default
- add explicit `--full` for the expanded audit body
- update heartbeat prompt docs and the LoopX project skill guidance to match the new default

## Validation
- `python3 examples/control_plane/heartbeat-prompt-smoke.py`
- `python3 -m compileall -q loopx/heartbeat_prompt.py loopx/cli_commands/support_control.py examples/control_plane/heartbeat-prompt-smoke.py`
- `uvx ruff check loopx/heartbeat_prompt.py loopx/cli_commands/support_control.py examples/control_plane/heartbeat-prompt-smoke.py`
- `git diff --check`
- `loopx check --scan-path docs/heartbeat-automation-prompt.md --scan-path skills/loopx-project/SKILL.md --scan-path examples/control_plane/heartbeat-prompt-smoke.py --scan-path loopx/cli_commands/support_control.py --scan-path loopx/heartbeat_prompt.py`
- `loopx canary premerge --from-git-diff` (passed: 16 selected, 0 failures, 0 warnings, 0 manual holds; self_merge_allowed=true)
