### PR TITLE
fix(explore): bound owner board by evidence stages

### DIFF
--- a/loopx/cli_commands/explore.py
+++ b/loopx/cli_commands/explore.py
@@ -232,6 +232,12 @@ def register_explore_commands(
         help="Arrange evidence epochs into this many whiteboard columns.",
     )
     visual.add_argument(
+        "--stage-capacity",
+        type=int,
+        default=12,
+        help="Maximum compact work nodes per vertical evidence stage (8-16).",
+    )
+    visual.add_argument(
         "--renderer",
         choices=["mermaid", "svg_atlas", "svg_board"],
         default="mermaid",
@@ -783,6 +789,7 @@ def handle_explore_command(
                 include_ancestors=bool(args.include_ancestors),
                 mermaid_node_limit=args.mermaid_node_limit,
                 atlas_column_count=args.atlas_columns,
+                stage_capacity=args.stage_capacity,
                 renderer=args.renderer,
                 view_role=args.view_role,
                 execute=bool(args.execute),

--- a/loopx/presentation/explore_views.py
+++ b/loopx/presentation/explore_views.py
@@ -71,6 +71,7 @@ DEFAULT_EXPLORE_PRESENTATION_POLICY: dict[str, float | int] = {
     "readability_root_ratio_floor": 0.30,
     "atlas_group_node_limit": 10,
     "atlas_column_count": 1,
+    "board_stage_capacity": 12,
     "executive_counterevidence_limit": 8,
     "executive_hub_edge_degree_floor": 4,
 }
@@ -972,6 +973,284 @@ def build_explore_svg_board(
     }
 
 
+def build_explore_svg_stage_board(
+    nodes: Sequence[Mapping[str, Any]],
+    edges: Sequence[Mapping[str, Any]],
+    *,
+    view_role: str,
+    stage_capacity: int = 12,
+) -> dict[str, Any]:
+    """Render a compact vertical evidence-stage board over canonical data.
+
+    Structural area nodes stay in the header/lineage context. Material work
+    nodes are ordered by the canonical source and split into bounded stages;
+    the Base remains the full-detail surface. The default capacity is slightly
+    larger than the reference eleven-node evidence stages while preventing one
+    visually unbounded owner board.
+    """
+
+    node_list = [dict(node) for node in nodes if str(node.get("node_id") or "")]
+    node_by_id = {str(node.get("node_id") or ""): node for node in node_list}
+    visible_ids = set(node_by_id)
+    role = "executive" if view_role == "executive" else "canonical"
+    capacity = max(8, min(16, int(stage_capacity)))
+    detail_coverage = _node_detail_coverage(node_list)
+    if not detail_coverage["complete"]:
+        raise ValueError("Explore node detail projection lost summary or metric evidence")
+
+    context_nodes = [
+        node for node in node_list if str(node.get("node_kind") or "") == "area"
+    ]
+    work_nodes = [
+        node for node in node_list if str(node.get("node_kind") or "") != "area"
+    ]
+    if not work_nodes:
+        work_nodes = node_list
+        context_nodes = []
+    stages = [
+        work_nodes[offset : offset + capacity]
+        for offset in range(0, len(work_nodes), capacity)
+    ]
+
+    canvas_width = 1800
+    margin = 42
+    header_height = 136
+    footer_height = 42
+    stage_gap = 28
+    stage_padding = 20
+    stage_header_height = 54
+    card_columns = 3
+    card_gap_x = 18
+    card_gap_y = 16
+    card_height = 94
+    stage_width = canvas_width - 2 * margin
+    card_width = (
+        stage_width
+        - 2 * stage_padding
+        - (card_columns - 1) * card_gap_x
+    ) / card_columns
+    stage_heights = []
+    for stage in stages:
+        card_rows = max(1, (len(stage) + card_columns - 1) // card_columns)
+        stage_heights.append(
+            stage_header_height
+            + 2 * stage_padding
+            + card_rows * card_height
+            + max(0, card_rows - 1) * card_gap_y
+        )
+    canvas_height = (
+        header_height
+        + sum(stage_heights)
+        + max(0, len(stages) - 1) * stage_gap
+        + footer_height
+        + margin
+    )
+
+    stage_geometry: list[tuple[float, float, float, float]] = []
+    card_geometry: dict[str, tuple[float, float, float, float]] = {}
+    node_stage: dict[str, int] = {}
+    stage_y = header_height
+    for stage_index, (stage, stage_height) in enumerate(
+        zip(stages, stage_heights),
+        start=1,
+    ):
+        stage_geometry.append((margin, stage_y, stage_width, stage_height))
+        for item_index, node in enumerate(stage):
+            item_row = item_index // card_columns
+            item_column = item_index % card_columns
+            x = margin + stage_padding + item_column * (card_width + card_gap_x)
+            y = (
+                stage_y
+                + stage_header_height
+                + stage_padding
+                + item_row * (card_height + card_gap_y)
+            )
+            node_id = str(node.get("node_id") or "")
+            card_geometry[node_id] = (x, y, card_width, card_height)
+            node_stage[node_id] = stage_index
+        stage_y += stage_height + stage_gap
+
+    material_edges = [
+        dict(edge)
+        for edge in edges
+        if str(edge.get("from_node") or "") in card_geometry
+        and str(edge.get("to_node") or "") in card_geometry
+        and str(edge.get("edge_type") or "") != "subtopic_of"
+    ]
+    source_edge_count = sum(
+        1
+        for edge in edges
+        if str(edge.get("from_node") or "") in visible_ids
+        and str(edge.get("to_node") or "") in visible_ids
+    )
+    cross_stage_count = sum(
+        1
+        for edge in material_edges
+        if node_stage[str(edge.get("from_node") or "")]
+        != node_stage[str(edge.get("to_node") or "")]
+    )
+    frontier_count = sum(1 for node in work_nodes if _is_board_frontier(node))
+    root_summary = _truncate_display(
+        str(context_nodes[0].get("summary") or "") if context_nodes else "",
+        limit=150,
+    )
+
+    svg = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {canvas_width} {canvas_height:.0f}" width="{canvas_width}" height="{canvas_height:.0f}">',
+        "<defs>",
+        '<filter id="stage-shadow" x="-10%" y="-10%" width="120%" height="130%">',
+        '<feDropShadow dx="0" dy="1" stdDeviation="2" flood-color="#1F2329" flood-opacity="0.08"/>',
+        "</filter>",
+    ]
+    for edge_type, (color, _) in _BOARD_EDGE_STYLE.items():
+        svg.extend(
+            [
+                f'<marker id="stage-arrow-{edge_type}" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">',
+                f'<path d="M0,0 L8,4 L0,8 Z" fill="{color}"/>',
+                "</marker>",
+            ]
+        )
+    svg.extend(
+        [
+            "</defs>",
+            f'<rect width="{canvas_width}" height="{canvas_height:.0f}" rx="18" fill="#F7F8FA"/>',
+            '<text x="42" y="43" font-size="28" font-weight="700" fill="#1F2329" font-family="Arial, PingFang SC, sans-serif">Live Explore Evidence Stages</text>',
+            f'<text x="42" y="73" font-size="14" fill="#646A73" font-family="Arial, PingFang SC, sans-serif">{html.escape(root_summary or "Canonical source order → bounded evidence stages → real material relations → current frontier")}</text>',
+            f'<text x="42" y="108" font-size="13" font-weight="600" fill="#1456B8" font-family="Arial, PingFang SC, sans-serif">{len(work_nodes)} compact nodes</text>',
+            f'<text x="218" y="108" font-size="13" font-weight="600" fill="#207A50" font-family="Arial, PingFang SC, sans-serif">{len(material_edges)} real relations</text>',
+            f'<text x="390" y="108" font-size="13" font-weight="600" fill="#AD5700" font-family="Arial, PingFang SC, sans-serif">{frontier_count} frontier</text>',
+            f'<text x="1758" y="108" text-anchor="end" font-size="12" fill="#8F959E" font-family="Arial, PingFang SC, sans-serif">{role} · capacity {capacity} / stage · full detail in Base</text>',
+        ]
+    )
+
+    stage_palette = (
+        ("#F4F8FF", "#7AA7E8"),
+        ("#F2FAF5", "#78BA8C"),
+        ("#FAF6FF", "#A58ADA"),
+        ("#FFF9ED", "#D7AD59"),
+    )
+    for stage_index, (stage, geometry) in enumerate(
+        zip(stages, stage_geometry),
+        start=1,
+    ):
+        x, y, width, height = geometry
+        fill, border = stage_palette[(stage_index - 1) % len(stage_palette)]
+        stage_frontier = sum(1 for node in stage if _is_board_frontier(node))
+        first_title = _truncate_display(
+            str(stage[0].get("title") or stage[0].get("node_id") or "Evidence"),
+            limit=54,
+        )
+        svg.extend(
+            [
+                f'<g data-evidence-stage="{stage_index}" data-stage-capacity="{capacity}">',
+                f'<rect x="{x:.1f}" y="{y:.1f}" width="{width:.1f}" height="{height:.1f}" rx="15" fill="{fill}" stroke="{border}" stroke-width="1.8"/>',
+                f'<text x="{x + stage_padding:.1f}" y="{y + 34:.1f}" font-size="17" font-weight="700" fill="#1F2329" font-family="Arial, PingFang SC, sans-serif">Evidence stage {stage_index:02d} · {html.escape(first_title)}</text>',
+                f'<text x="{x + width - stage_padding:.1f}" y="{y + 34:.1f}" text-anchor="end" font-size="12" fill="#646A73" font-family="Arial, PingFang SC, sans-serif">{len(stage)} / {capacity} nodes · {stage_frontier} frontier</text>',
+                "</g>",
+            ]
+        )
+
+    for edge in material_edges:
+        source_id = str(edge.get("from_node") or "")
+        target_id = str(edge.get("to_node") or "")
+        edge_id = str(edge.get("edge_id") or f"{source_id}-{target_id}")
+        edge_type = str(edge.get("edge_type") or "leads_to")
+        color, dash = _BOARD_EDGE_STYLE.get(edge_type, ("#8F959E", "4 4"))
+        source_x, source_y, source_w, source_h = card_geometry[source_id]
+        target_x, target_y, target_w, target_h = card_geometry[target_id]
+        if node_stage[source_id] != node_stage[target_id]:
+            forward = node_stage[source_id] < node_stage[target_id]
+            start_x = source_x + source_w / 2
+            start_y = source_y + source_h if forward else source_y
+            end_x = target_x + target_w / 2
+            end_y = target_y if forward else target_y + target_h
+            bend = max(36.0, abs(end_y - start_y) * 0.35)
+            direction = 1 if forward else -1
+            path = (
+                f"M {start_x:.1f} {start_y:.1f} "
+                f"C {start_x:.1f} {start_y + direction * bend:.1f}, "
+                f"{end_x:.1f} {end_y - direction * bend:.1f}, "
+                f"{end_x:.1f} {end_y:.1f}"
+            )
+        else:
+            forward = target_x >= source_x
+            start_x = source_x + source_w if forward else source_x
+            start_y = source_y + source_h / 2
+            end_x = target_x if forward else target_x + target_w
+            end_y = target_y + target_h / 2
+            bend = max(32.0, abs(end_x - start_x) * 0.35)
+            direction = 1 if forward else -1
+            path = (
+                f"M {start_x:.1f} {start_y:.1f} "
+                f"C {start_x + direction * bend:.1f} {start_y:.1f}, "
+                f"{end_x - direction * bend:.1f} {end_y:.1f}, "
+                f"{end_x:.1f} {end_y:.1f}"
+            )
+        dash_attr = f' stroke-dasharray="{dash}"' if dash else ""
+        marker = edge_type if edge_type in _BOARD_EDGE_STYLE else "leads_to"
+        svg.append(
+            f'<path data-edge-id="{html.escape(edge_id)}" data-edge-type="{html.escape(edge_type)}" d="{path}" fill="none" stroke="{color}" stroke-width="1.8" opacity="0.72"{dash_attr} marker-end="url(#stage-arrow-{marker})"/>'
+        )
+
+    for node in work_nodes:
+        node_id = str(node.get("node_id") or "")
+        x, y, width, height = card_geometry[node_id]
+        status = str(node.get("status") or "open")
+        status_color = _ATLAS_STATUS_COLOR.get(status, "#9E9E9E")
+        frontier = _is_board_frontier(node)
+        display_lines = _node_display_lines(
+            node,
+            title_limit=46,
+            detail_limit=62,
+        )
+        stroke = "#FF8F1F" if frontier else "#AAB2BD"
+        stroke_width = 2.4 if frontier else 1.1
+        svg.extend(
+            [
+                f'<g data-node-id="{html.escape(node_id)}" data-status="{html.escape(status)}" data-frontier="{str(frontier).lower()}">',
+                f'<rect x="{x:.1f}" y="{y:.1f}" width="{width:.1f}" height="{height:.1f}" rx="9" fill="#FFFFFF" stroke="{stroke}" stroke-width="{stroke_width}" filter="url(#stage-shadow)"/>',
+                f'<rect x="{x:.1f}" y="{y:.1f}" width="6" height="{height:.1f}" rx="3" fill="{status_color}"/>',
+            ]
+        )
+        for line_index, line in enumerate(display_lines[:3]):
+            svg.append(
+                f'<text x="{x + 18:.1f}" y="{y + 25 + line_index * 23:.1f}" font-size="{13 if line_index == 0 else 10}" font-weight="{600 if line_index == 0 else 400}" fill="{"#1F2329" if line_index == 0 else "#646A73"}" font-family="Arial, PingFang SC, sans-serif">{html.escape(line)}</text>'
+            )
+        svg.append("</g>")
+
+    svg.extend(
+        [
+            f'<text x="42" y="{canvas_height - 18:.1f}" font-size="11" fill="#646A73" font-family="Arial, PingFang SC, sans-serif">Stage capacity is bounded; structural context and complete Nodes / Edges / Findings remain in the canonical Base.</text>',
+            f'<text x="1758" y="{canvas_height - 18:.1f}" text-anchor="end" font-size="11" fill="#8F959E" font-family="Arial, PingFang SC, sans-serif">solid: supports / leads_to / answers · dashed: depends_on / refutes</text>',
+            "</svg>",
+        ]
+    )
+    return {
+        "svg": "\n".join(svg),
+        "strategy": "vertical_evidence_stage_board",
+        "view_role": role,
+        "stage_count": len(stages),
+        "stage_capacity": capacity,
+        "stage_sizes": [len(stage) for stage in stages],
+        "rendered_node_count": len(card_geometry),
+        "context_node_count": len(context_nodes),
+        "frontier_node_count": frontier_count,
+        "rendered_relation_count": len(material_edges),
+        "cross_stage_relation_count": cross_stage_count,
+        "suppressed_relation_count": source_edge_count - len(material_edges),
+        "source_edge_count": source_edge_count,
+        "semantic_contract": {
+            "real_relations_only": True,
+            "frontier_explicit": True,
+            "evidence_stage_capacity_bounded": True,
+            "canonical_detail_in_base": True,
+        },
+        "node_detail_coverage": detail_coverage,
+        "canvas_width": canvas_width,
+        "canvas_height": round(canvas_height),
+    }
+
+
 def _tags(node: Mapping[str, Any]) -> set[str]:
     return {str(tag or "").strip().lower() for tag in node.get("tags") or [] if str(tag or "").strip()}
 
@@ -1285,10 +1564,11 @@ def build_explore_presentation_bundle(
         group_node_limit=int(thresholds["atlas_group_node_limit"]),
         column_count=int(thresholds["atlas_column_count"]),
     )
-    canonical_board_layout = build_explore_svg_board(
+    canonical_board_layout = build_explore_svg_stage_board(
         canonical_nodes,
         canonical_edges,
         view_role="canonical",
+        stage_capacity=int(thresholds["board_stage_capacity"]),
     )
     canonical = {
         "schema_version": EXPLORE_CANONICAL_VIEW_VERSION,
@@ -1360,10 +1640,11 @@ def build_explore_presentation_bundle(
         group_node_limit=int(thresholds["atlas_group_node_limit"]),
         column_count=int(thresholds["atlas_column_count"]),
     )
-    executive_board_layout = build_explore_svg_board(
+    executive_board_layout = build_explore_svg_stage_board(
         executive_nodes,
         executive_edges,
         view_role="executive",
+        stage_capacity=int(thresholds["board_stage_capacity"]),
     )
     executive_findings = [
         finding

--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -15,7 +15,9 @@ topology source in the projection is for Feishu docs or any diagram renderer.
 from __future__ import annotations
 
 import hashlib
+import html
 import json
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Mapping
@@ -78,6 +80,8 @@ VISUAL_RENDERERS = {
     VISUAL_RENDERER_SVG_ATLAS,
     VISUAL_RENDERER_SVG_BOARD,
 }
+
+_SVG_HEIGHT_PATTERN = re.compile(r'\bheight="(?P<height>\d+(?:\.\d+)?)"')
 
 TABLE_NODES = "nodes"
 TABLE_EDGES = "edges"
@@ -464,6 +468,7 @@ def configure_lark_explore_visual_sink(
     include_ancestors: bool = True,
     mermaid_node_limit: int = 100,
     atlas_column_count: int = 1,
+    stage_capacity: int = 12,
     renderer: str = VISUAL_RENDERER_MERMAID,
     view_role: str | None = None,
     execute: bool = False,
@@ -499,6 +504,8 @@ def configure_lark_explore_visual_sink(
         and role is None
     ):
         raise ValueError(f"{selected_renderer} renderer requires a canonical or executive view_role")
+    if not 8 <= int(stage_capacity) <= 16:
+        raise ValueError("stage_capacity must be between 8 and 16")
     local = read_lark_explore_local_config(config_path)
     if not local.get("ok") or not local.get("exists"):
         raise ValueError("run `loopx explore feishu-setup` before configuring a visual sink")
@@ -512,6 +519,7 @@ def configure_lark_explore_visual_sink(
         "include_ancestors": bool(include_ancestors),
         "mermaid_node_limit": max(1, int(mermaid_node_limit)),
         "atlas_column_count": max(1, int(atlas_column_count)),
+        "stage_capacity": int(stage_capacity),
         "renderer": selected_renderer,
     }
     if role:
@@ -533,6 +541,95 @@ def configure_lark_explore_visual_sink(
         "config_path": str(config_path),
         "view_role": role,
         "visual_sink": visual_sink,
+    }
+
+
+def _svg_with_delivery_marker(source: str, marker: str) -> str:
+    """Add a small visible audit marker that survives Lark SVG conversion."""
+
+    closing_tag = "</svg>"
+    if closing_tag not in source:
+        raise ValueError("svg visual source must contain a closing </svg> tag")
+    height_match = _SVG_HEIGHT_PATTERN.search(source)
+    marker_y = (
+        max(12.0, float(height_match.group("height")) - 8.0)
+        if height_match
+        else 12.0
+    )
+    marker_node = (
+        f'<text x="12" y="{marker_y:g}" font-family="Arial, sans-serif" '
+        f'font-size="8" fill="#8f959e">{html.escape(marker)}</text>'
+    )
+    return source.replace(closing_tag, f"{marker_node}\n{closing_tag}", 1)
+
+
+def _whiteboard_raw_texts(payload: Any) -> list[str]:
+    if not isinstance(payload, Mapping):
+        return []
+    data = payload.get("data")
+    nodes = data.get("nodes") if isinstance(data, Mapping) else None
+    texts: list[str] = []
+    for node in nodes if isinstance(nodes, list) else []:
+        if not isinstance(node, Mapping):
+            continue
+        text_node = node.get("text")
+        if isinstance(text_node, Mapping) and str(text_node.get("text") or "").strip():
+            texts.append(str(text_node.get("text")))
+    return texts
+
+
+def _readback_svg_delivery_marker(
+    config: LarkExploreConfig,
+    *,
+    whiteboard_token: str,
+    marker: str,
+    runner: CommandRunner,
+) -> dict[str, Any]:
+    command = [
+        config.cli_bin,
+        "whiteboard",
+        "+query",
+        "--as",
+        config.identity,
+        "--whiteboard-token",
+        whiteboard_token,
+        "--output_as",
+        "raw",
+        "--format",
+        "json",
+    ]
+    result = _run_command(command, execute=True, runner=runner)
+    texts = _whiteboard_raw_texts(result.get("json"))
+    marker_observed = marker in texts
+    command_receipt = {
+        key: result.get(key)
+        for key in (
+            "command",
+            "executed",
+            "ok",
+            "returncode",
+            "timed_out",
+            "stderr",
+        )
+        if result.get(key) not in (None, "")
+    }
+    return {
+        "ok": bool(result.get("ok") and marker_observed),
+        "schema_version": "loopx_lark_explore_visual_readback_v0",
+        "performed": True,
+        "verified": marker_observed,
+        "source": "whiteboard_raw_nodes",
+        "expected_marker": marker,
+        "observed_marker": marker if marker_observed else None,
+        "remote_text_node_count": len(texts),
+        "command": command_receipt,
+        "error": (
+            None
+            if result.get("ok") and marker_observed
+            else _command_error(result)
+            if not result.get("ok")
+            else "remote whiteboard raw nodes do not contain the expected delivery marker"
+        ),
     }
 
 
@@ -640,6 +737,16 @@ def sync_explore_visual_to_lark(
         separators=(",", ":"),
     ).encode("utf-8")
     delivery_digest = hashlib.sha256(delivery_material).hexdigest()
+    delivery_marker = (
+        f"LoopX delivery {delivery_digest[:20]}"
+        if input_format == "svg"
+        else None
+    )
+    published_source = (
+        _svg_with_delivery_marker(rendered_source, delivery_marker)
+        if delivery_marker
+        else rendered_source
+    )
     source_name = f".loopx-explore-{sink_key}-{delivery_digest[:12]}.{extension}"
     command = [
         config.cli_bin,
@@ -664,7 +771,7 @@ def sync_explore_visual_to_lark(
     else:
         config_path.parent.mkdir(parents=True, exist_ok=True)
         source_path = config_path.parent / source_name
-        source_path.write_text(rendered_source, encoding="utf-8")
+        source_path.write_text(published_source, encoding="utf-8")
         try:
             result = _run_command(
                 command,
@@ -674,12 +781,44 @@ def sync_explore_visual_to_lark(
             )
         finally:
             source_path.unlink(missing_ok=True)
+    readback: dict[str, Any] = {
+        "ok": True,
+        "schema_version": "loopx_lark_explore_visual_readback_v0",
+        "performed": False,
+        "verified": False,
+        "source": (
+            "not_required"
+            if not delivery_marker
+            else "would_query_whiteboard_raw_nodes"
+        ),
+        "expected_marker": delivery_marker,
+        "observed_marker": None,
+        "error": None,
+    }
+    if execute and result.get("ok") and delivery_marker:
+        readback = _readback_svg_delivery_marker(
+            config,
+            whiteboard_token=whiteboard_token,
+            marker=delivery_marker,
+            runner=runner,
+        )
+    delivery_ok = bool(
+        result.get("ok") and (not delivery_marker or readback.get("ok"))
+    )
     return {
-        "ok": bool(result.get("ok")),
+        "ok": delivery_ok,
         "schema_version": LARK_EXPLORE_VISUAL_SYNC_VERSION,
-        "status": "published" if execute and result.get("ok") else "would_publish" if not execute else "publish_failed",
+        "status": (
+            "published"
+            if execute and delivery_ok
+            else "would_publish"
+            if not execute
+            else "publish_unverified"
+            if result.get("ok") and delivery_marker
+            else "publish_failed"
+        ),
         "execute": execute,
-        "published": bool(execute and result.get("ok")),
+        "published": bool(execute and delivery_ok),
         "semantic_digest": semantic_digest,
         "delivery_digest": delivery_digest,
         "source_digest": source_digest,
@@ -691,7 +830,14 @@ def sync_explore_visual_to_lark(
         "graph_counts": graph.get("graph_counts"),
         "filter": graph.get("filter"),
         "command": result,
-        "error": None if result.get("ok") else _command_error(result),
+        "readback": readback,
+        "error": (
+            None
+            if delivery_ok
+            else str(readback.get("error") or "")
+            if result.get("ok")
+            else _command_error(result)
+        ),
     }
 
 
@@ -744,7 +890,10 @@ def sync_explore_visuals_to_lark(
                 "atlas_column_count": max(
                     1,
                     int(role_sink.get("atlas_column_count") or 1),
-                )
+                ),
+                "board_stage_capacity": int(
+                    role_sink.get("stage_capacity") or 12
+                ),
             },
         )
         results[role] = sync_explore_visual_to_lark(

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 
 import pytest
 
@@ -297,29 +298,47 @@ def test_svg_atlas_owns_a_fixed_grid_and_keeps_executive_nodes_visible() -> None
         assert str(node["title"]) in svg
 
 
-def test_svg_board_preserves_lanes_frontier_and_real_relations() -> None:
-    bundle = build_explore_presentation_bundle(_lane_projection())
+def test_svg_board_preserves_bounded_stages_frontier_and_real_relations() -> None:
+    bundle = build_explore_presentation_bundle(
+        _lane_projection(),
+        policy={"board_stage_capacity": 8},
+    )
 
     canonical = bundle["canonical"]
     svg = canonical["svg_board"]
     layout = canonical["filter"]["renderer_layouts"]["svg_board"]
     assert svg.startswith('<svg xmlns="http://www.w3.org/2000/svg"')
-    assert "Live Explore Decision Board" in svg
-    assert "Epoch" not in svg
-    assert 'data-lane-id="delivery-lane"' in svg
-    assert 'data-lane-id="capability-lane"' in svg
+    assert "Live Explore Evidence Stages" in svg
+    assert "Evidence stage 01" in svg
+    assert 'data-evidence-stage="1"' in svg
+    assert 'data-stage-capacity="8"' in svg
     assert 'data-node-id="fix-pr"' in svg
     assert 'data-frontier="true"' in svg
     assert 'data-edge-id="edge-fix-supports-capability"' in svg
     assert 'data-edge-id="edge-fix-subtopic"' not in svg
-    assert layout["strategy"] == "semantic_lane_decision_board"
-    assert layout["lane_count"] == 2
+    assert layout["strategy"] == "vertical_evidence_stage_board"
+    assert layout["stage_count"] == 1
+    assert layout["stage_capacity"] == 8
+    assert layout["stage_sizes"] == [2]
     assert layout["frontier_node_count"] == 1
     assert layout["rendered_relation_count"] == 1
-    assert layout["cross_lane_relation_count"] == 1
+    assert layout["cross_stage_relation_count"] == 0
     assert layout["suppressed_relation_count"] == 1
     assert layout["source_edge_count"] == 2
-    assert layout["semantic_contract"]["chronological_buckets"] is False
+    assert layout["semantic_contract"]["evidence_stage_capacity_bounded"] is True
+
+
+def test_svg_board_caps_each_evidence_stage() -> None:
+    bundle = build_explore_presentation_bundle(
+        _complex_projection(),
+        policy={"board_stage_capacity": 12},
+    )
+
+    layout = bundle["executive"]["filter"]["renderer_layouts"]["svg_board"]
+    assert layout["stage_count"] >= 2
+    assert layout["stage_capacity"] == 12
+    assert all(1 <= size <= 12 for size in layout["stage_sizes"])
+    assert sum(layout["stage_sizes"]) == layout["rendered_node_count"]
 
 
 def test_executive_view_suppresses_dense_hub_scaffolding_edges() -> None:
@@ -610,6 +629,119 @@ def test_visual_delivery_digest_and_command_include_renderer(tmp_path) -> None:
     assert mermaid["input_format"] == "mermaid"
     assert svg["input_format"] == "svg"
     assert board["input_format"] == "svg"
+
+
+def test_svg_visual_publish_reads_back_remote_delivery_marker(tmp_path) -> None:
+    projection = _complex_projection()
+    config = LarkExploreConfig(base_token="PUBLIC_FIXTURE_BASE")
+    bundle = build_explore_presentation_bundle(projection)
+    calls: list[list[str]] = []
+    published_marker = ""
+
+    def runner(args, cwd, _timeout):
+        nonlocal published_marker
+        calls.append(args)
+        if "+update" in args:
+            source_arg = args[args.index("--source") + 1]
+            source = (cwd / source_arg.removeprefix("@")).read_text(
+                encoding="utf-8"
+            )
+            marker_match = re.search(r"LoopX delivery [0-9a-f]{20}", source)
+            assert marker_match
+            published_marker = marker_match.group(0)
+            return {
+                "returncode": 0,
+                "stdout": json.dumps({"ok": True}),
+                "stderr": "",
+            }
+        assert "+query" in args
+        return {
+            "returncode": 0,
+            "stdout": json.dumps(
+                {
+                    "ok": True,
+                    "data": {
+                        "nodes": [
+                            {
+                                "type": "text_shape",
+                                "text": {"text": published_marker},
+                            }
+                        ]
+                    },
+                }
+            ),
+            "stderr": "",
+        }
+
+    synced = sync_explore_visual_to_lark(
+        config,
+        projection=projection,
+        visual_sink={
+            "whiteboard_token": "wb_executive_fixture",
+            "view_role": "executive",
+            "renderer": "svg_board",
+        },
+        config_path=tmp_path / "lark-explore.json",
+        semantic_digest=bundle["source_digest"],
+        display_projection=bundle["executive"],
+        view_key="executive",
+        execute=True,
+        runner=runner,
+    )
+
+    assert len(calls) == 2
+    assert synced["ok"] is True
+    assert synced["status"] == "published"
+    assert synced["published"] is True
+    assert synced["readback"]["performed"] is True
+    assert synced["readback"]["verified"] is True
+    assert synced["readback"]["observed_marker"] == published_marker
+
+
+def test_svg_visual_publish_fails_closed_when_remote_marker_is_missing(
+    tmp_path,
+) -> None:
+    projection = _complex_projection()
+    config = LarkExploreConfig(base_token="PUBLIC_FIXTURE_BASE")
+    bundle = build_explore_presentation_bundle(projection)
+
+    def runner(args, _cwd, _timeout):
+        payload = (
+            {
+                "ok": True,
+                "data": {"nodes": [{"text": {"text": "stale visual"}}]},
+            }
+            if "+query" in args
+            else {"ok": True}
+        )
+        return {
+            "returncode": 0,
+            "stdout": json.dumps(payload),
+            "stderr": "",
+        }
+
+    synced = sync_explore_visual_to_lark(
+        config,
+        projection=projection,
+        visual_sink={
+            "whiteboard_token": "wb_executive_fixture",
+            "view_role": "executive",
+            "renderer": "svg_board",
+        },
+        config_path=tmp_path / "lark-explore.json",
+        semantic_digest=bundle["source_digest"],
+        display_projection=bundle["executive"],
+        view_key="executive",
+        execute=True,
+        runner=runner,
+    )
+
+    assert synced["ok"] is False
+    assert synced["status"] == "publish_unverified"
+    assert synced["published"] is False
+    assert synced["readback"]["performed"] is True
+    assert synced["readback"]["verified"] is False
+    assert "expected delivery marker" in synced["error"]
 
 
 def test_visual_delivery_digest_changes_when_target_whiteboard_changes(tmp_path) -> None:


### PR DESCRIPTION
## Motivation

The svg_board renderer merged in #2045 preserved real relations but still projected every issue and capability as an oversized lane card. On a real OpenViking graph, the owner view became another large inventory rather than a readable evidence board.

## Changes

- render compact work nodes in vertical Evidence Stages
- cap each stage at 8-16 nodes, default 12, configurable with --stage-capacity
- keep structural area nodes as context and full detail in canonical Base
- preserve material edges, frontier state, metrics, and conclusions
- embed a delivery marker in SVG and verify it through remote whiteboard raw-node readback
- fail closed as publish_unverified when update succeeds but remote content is stale

## Validation

- 20 focused presentation and sink tests pass
- ruff passes on all changed files
- standard LoopX premerge gate passes
- 3 catalog canaries pass; no warnings or manual holds
- real OpenViking projection renders 38 compact nodes as stages 12/12/12/2 with 15 real relations and complete node-detail coverage
- local SVG visually inspected against the reference evidence timeline

## Risk

The new stage renderer is opt-in through svg_board. Mermaid and svg_atlas remain unchanged. Full canonical Nodes, Edges, and Findings remain in Base.