### PR TITLE
fix(explore): retry Lark visual readback while applying

### DIFF
--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -18,6 +18,7 @@ import hashlib
 import html
 import json
 import re
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Mapping
@@ -82,6 +83,7 @@ VISUAL_RENDERERS = {
 }
 
 _SVG_HEIGHT_PATTERN = re.compile(r'\bheight="(?P<height>\d+(?:\.\d+)?)"')
+_VISUAL_READBACK_RETRY_DELAYS_SECONDS = (0.25, 0.5, 1.0, 2.0, 4.0)
 
 TABLE_NODES = "nodes"
 TABLE_EDGES = "edges"
@@ -598,9 +600,32 @@ def _readback_svg_delivery_marker(
         "--format",
         "json",
     ]
-    result = _run_command(command, execute=True, runner=runner)
-    texts = _whiteboard_raw_texts(result.get("json"))
-    marker_observed = marker in texts
+    attempts: list[dict[str, Any]] = []
+    result: dict[str, Any] = {}
+    texts: list[str] = []
+    marker_observed = False
+    for attempt_index in range(len(_VISUAL_READBACK_RETRY_DELAYS_SECONDS) + 1):
+        result = _run_command(command, execute=True, runner=runner)
+        texts = _whiteboard_raw_texts(result.get("json"))
+        marker_observed = marker in texts
+        parsed = result.get("json")
+        error = parsed.get("error") if isinstance(parsed, Mapping) else None
+        error_code = error.get("code") if isinstance(error, Mapping) else None
+        error_message = str(error.get("message") or "") if isinstance(error, Mapping) else ""
+        is_applying = error_code == 4003101 and "doc is applying" in error_message
+        attempts.append(
+            {
+                "attempt": attempt_index + 1,
+                "ok": bool(result.get("ok")),
+                "marker_observed": marker_observed,
+                "error_code": error_code,
+                "retryable": is_applying,
+            }
+        )
+        if result.get("ok") or not is_applying:
+            break
+        if attempt_index < len(_VISUAL_READBACK_RETRY_DELAYS_SECONDS):
+            time.sleep(_VISUAL_READBACK_RETRY_DELAYS_SECONDS[attempt_index])
     command_receipt = {
         key: result.get(key)
         for key in (
@@ -622,6 +647,8 @@ def _readback_svg_delivery_marker(
         "expected_marker": marker,
         "observed_marker": marker if marker_observed else None,
         "remote_text_node_count": len(texts),
+        "attempt_count": len(attempts),
+        "attempts": attempts,
         "command": command_receipt,
         "error": (
             None

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -698,6 +698,78 @@ def test_svg_visual_publish_reads_back_remote_delivery_marker(tmp_path) -> None:
     assert synced["readback"]["observed_marker"] == published_marker
 
 
+def test_svg_visual_readback_retries_lark_doc_applying(tmp_path, monkeypatch) -> None:
+    projection = _complex_projection()
+    config = LarkExploreConfig(base_token="PUBLIC_FIXTURE_BASE")
+    bundle = build_explore_presentation_bundle(projection)
+    published_marker = ""
+    query_count = 0
+    delays: list[float] = []
+    monkeypatch.setattr(
+        "loopx.presentation.sinks.lark.explore_results.time.sleep",
+        delays.append,
+    )
+
+    def runner(args, cwd, _timeout):
+        nonlocal published_marker, query_count
+        if "+update" in args:
+            source_arg = args[args.index("--source") + 1]
+            source = (cwd / source_arg.removeprefix("@")).read_text(
+                encoding="utf-8"
+            )
+            published_marker = re.search(
+                r"LoopX delivery [0-9a-f]{20}",
+                source,
+            ).group(0)
+            payload = {"ok": True}
+        else:
+            query_count += 1
+            payload = (
+                {
+                    "ok": False,
+                    "error": {
+                        "code": 4003101,
+                        "message": "doc is applying; doc data is not ready",
+                    },
+                }
+                if query_count == 1
+                else {
+                    "ok": True,
+                    "data": {
+                        "nodes": [{"text": {"text": published_marker}}]
+                    },
+                }
+            )
+        return {
+            "returncode": 0 if payload.get("ok") else 1,
+            "stdout": json.dumps(payload),
+            "stderr": "",
+        }
+
+    synced = sync_explore_visual_to_lark(
+        config,
+        projection=projection,
+        visual_sink={
+            "whiteboard_token": "wb_executive_fixture",
+            "view_role": "executive",
+            "renderer": "svg_board",
+        },
+        config_path=tmp_path / "lark-explore.json",
+        semantic_digest=bundle["source_digest"],
+        display_projection=bundle["executive"],
+        view_key="executive",
+        execute=True,
+        runner=runner,
+    )
+
+    assert synced["ok"] is True
+    assert synced["published"] is True
+    assert synced["readback"]["verified"] is True
+    assert synced["readback"]["attempt_count"] == 2
+    assert synced["readback"]["attempts"][0]["error_code"] == 4003101
+    assert delays == [0.25]
+
+
 def test_svg_visual_publish_fails_closed_when_remote_marker_is_missing(
     tmp_path,
 ) -> None:


### PR DESCRIPTION
## Motivation

Real OpenViking dogfood of #2046 showed that Lark returns API 4003101 while a whiteboard update is still applying. The delivery marker appears correctly moments later, but the immediate fail-closed readback produces a false negative.

## Changes

- retry only the explicit 4003101 doc-is-applying response
- bounded delays: 0.25, 0.5, 1, 2, and 4 seconds
- keep marker absence and all other errors fail-closed without retry
- include compact attempt evidence in the readback receipt

## Validation

- 21 focused tests pass, including applying-then-success and stale-marker failure
- ruff and diff checks pass
- standard LoopX premerge gate passes with no warnings or holds

This preserves the #2046 remote marker contract while accommodating the documented asynchronous Lark write window.