### PR TITLE
fix(explore): parse Lark applying errors from stderr

### DIFF
--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -580,6 +580,17 @@ def _whiteboard_raw_texts(payload: Any) -> list[str]:
     return texts
 
 
+def _structured_command_error(result: Mapping[str, Any]) -> Mapping[str, Any]:
+    parsed = result.get("json")
+    if not isinstance(parsed, Mapping):
+        try:
+            parsed = json.loads(str(result.get("stderr") or ""))
+        except (TypeError, json.JSONDecodeError):
+            parsed = None
+    error = parsed.get("error") if isinstance(parsed, Mapping) else None
+    return error if isinstance(error, Mapping) else {}
+
+
 def _readback_svg_delivery_marker(
     config: LarkExploreConfig,
     *,
@@ -608,10 +619,9 @@ def _readback_svg_delivery_marker(
         result = _run_command(command, execute=True, runner=runner)
         texts = _whiteboard_raw_texts(result.get("json"))
         marker_observed = marker in texts
-        parsed = result.get("json")
-        error = parsed.get("error") if isinstance(parsed, Mapping) else None
-        error_code = error.get("code") if isinstance(error, Mapping) else None
-        error_message = str(error.get("message") or "") if isinstance(error, Mapping) else ""
+        error = _structured_command_error(result)
+        error_code = error.get("code")
+        error_message = str(error.get("message") or "")
         is_applying = error_code == 4003101 and "doc is applying" in error_message
         attempts.append(
             {

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -742,8 +742,8 @@ def test_svg_visual_readback_retries_lark_doc_applying(tmp_path, monkeypatch) ->
             )
         return {
             "returncode": 0 if payload.get("ok") else 1,
-            "stdout": json.dumps(payload),
-            "stderr": "",
+            "stdout": json.dumps(payload) if payload.get("ok") else "",
+            "stderr": "" if payload.get("ok") else json.dumps(payload),
         }
 
     synced = sync_explore_visual_to_lark(


### PR DESCRIPTION
## Motivation

Real Lark dogfood showed lark-cli writes API error JSON to stderr when whiteboard raw query returns 4003101. The bounded retry added in #2048 inspected stdout JSON only, so the real applying response was not classified as retryable.

## Changes

- parse structured Lark error payloads from stdout JSON or stderr JSON
- keep the retry predicate unchanged: code 4003101 plus doc-is-applying text
- update the regression test to use the actual stderr transport shape

## Validation

- 21 focused tests pass
- ruff and diff checks pass
- standard LoopX premerge gate passes with no warnings or holds

No renderer, Base, or retry-policy behavior changes beyond recognizing the real lark-cli error channel.