### PR TITLE
fix(heartbeat): surface non-blocking user actions

### DIFF
--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -294,16 +294,17 @@ If the result says should_run=false:
   unresolved gate has not already been asked in the recent visible thread,
   return heartbeat NOTIFY with
   one concise Chinese question that lists the gate and the expected reply
-  format. Only when `interaction_contract.user_channel.action_required=true` or
-  `user_todo_summary.open_count > 0`, the notification must name concrete payload
-  todo(s)/questions, never only "owner gate"; if those required user-facing
-  items are not projected, say "具体 user todo 未投影，需修复 LoopX 状态投影";
-  never say "no new user action" for this case. When
-  `interaction_contract.user_channel.action_required=false` and
-  `user_todo_summary.open_count=0`, allow "无用户待办/无需通知" or a quiet
-  no-notification result; do not imply a state projection bug. Do not execute
-  agent_command, adapter work, write-control, production actions, or the gated
-  path while asking.
+  format. Treat `interaction_contract.user_channel.notify` as the final
+  notification signal. When it is `NOTIFY`, name concrete projected
+  `actions`, todos, or questions even when `action_required=false`,
+  `user_todo_summary.open_count=0`, and `non_blocking=true`; non-blocking means
+  the agent may continue independent work, not that the user action is silent.
+  Never say only "owner gate". If required user-facing items are not projected,
+  say "具体 user todo 未投影，需修复 LoopX 状态投影"; never say "no new user
+  action" for this case. Only when `notify=DONT_NOTIFY`,
+  `action_required=false`, and `open_count=0` may the heartbeat say
+  "无用户待办/无需通知" or stay quiet. Do not execute agent_command, adapter
+  work, write-control, production actions, or the gated path while asking.
 - If the payload says notify_user_on_open_todo=true, treat the existing open
   user_todo_summary as a blocker-push opportunity, not as a silent skip. This
   is especially important for state=focus_wait, state=waiting, and
@@ -326,8 +327,9 @@ If the result says should_run=false:
   another P0/P1 item that does not depend on that gate. If you do a safe-bypass
   step, validate it, write back progress/critic/next action, optionally refresh
   state, append exactly one spend event, and report compactly. If
-  user_todo_summary.open_count > 0, include those todos as concrete todos and do not say
-  there is "no new user action". If
+  `interaction_contract.user_channel.notify=NOTIFY` or
+  `user_todo_summary.open_count > 0`, include the projected user actions or
+  todos concretely and do not say there is "no new user action". If
   agent_todo_summary.open_count > 0, the report should also name the first safe
   agent todo it can execute next. If no useful
   safe-bypass step exists, report the pending gate compactly instead of doing

--- a/examples/control_plane/heartbeat-prompt-smoke.py
+++ b/examples/control_plane/heartbeat-prompt-smoke.py
@@ -184,6 +184,8 @@ def main() -> int:
         "state=operator_gate",
         "notify_user_on_open_todo=true",
         "open_todo_notification_policy=repeat_until_resolved",
+        "`user_channel.notify=NOTIFY`",
+        "including non_blocking",
         "safe_bypass_allowed=true",
         "safe_bypass_kind=outcome_floor_recovery",
         "unchanged monitor-only polls are not self-stop signals",
@@ -307,7 +309,9 @@ def main() -> int:
         "loopx heartbeat-prompt --compact --goal-id public-heartbeat-goal --active-state /tmp/public-heartbeat-goal/ACTIVE_GOAL_STATE.md",
         "Preflight and quota guard",
         'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota should-run --goal-id public-heartbeat-goal',
-        "Gate/open todo ->",
+        "User NOTIFY: Chinese actions incl. non_blocking at false/0",
+        "Only DONT_NOTIFY+false/0: quiet",
+        "Otherwise obey user channel",
         "status/log/metric/marker poll",
         "safe_bypass_kind=outcome_floor_recovery",
         "ranker/cross-domain evidence recovery",
@@ -343,10 +347,9 @@ def main() -> int:
         "LoopX CLI is source of truth",
         "registry/global quota, active state, status/history, repo",
         "`quota should-run`; follow `interaction_contract`",
-        "action_required/open_count",
-        "Chinese concrete todos/questions",
+        "User NOTIFY: Chinese actions incl. non_blocking at false/0",
         'never only "owner gate"',
-        "If false/0: quiet/no-user-todo",
+        "Only DONT_NOTIFY+false/0: quiet",
         "具体 user todo 未投影，需修复 LoopX 状态投影",
         "Apply `scheduler_hint`: if App `stateful_backoff.apply_needed`",
         "RRULE then run `ack_hint.cli_args`",
@@ -361,6 +364,7 @@ def main() -> int:
     ):
         assert phrase in thin_task, phrase
     assert "if absent say" not in thin_task, thin_task
+    assert "If false/0: quiet/no-user-todo" not in thin_task, thin_task
 
     doc = DOC.read_text(encoding="utf-8")
     readme = README.read_text(encoding="utf-8")
@@ -391,13 +395,15 @@ def main() -> int:
         "user_todo_summary",
         "user_todo_summary.open_count > 0",
         "never say \"no new user action\"",
-        "Only when",
-        "`interaction_contract.user_channel.action_required=true`",
-        "name concrete payload todo(s)/questions",
-        'never only "owner gate"',
-        "When `interaction_contract.user_channel.action_required=false`",
+        "Treat `interaction_contract.user_channel.notify` as the final notification signal",
+        "When it is `NOTIFY`",
+        "even when `action_required=false`",
         "`user_todo_summary.open_count=0`",
-        "allow \"无用户待办/无需通知\"",
+        "`non_blocking=true`",
+        "non-blocking means the agent may continue independent work",
+        'Never say only "owner gate"',
+        "Only when `notify=DONT_NOTIFY`",
+        '"无用户待办/无需通知"',
         "具体 user todo 未投影，需修复 LoopX 状态投影",
         "NOTIFY",
         "notify_user_on_open_todo=true",
@@ -412,7 +418,7 @@ def main() -> int:
         "safe_bypass_allowed=true",
         "gate blocks only the gated delivery path",
         "one bounded safe-bypass step",
-        "include those todos",
+        "include the projected user actions or todos concretely",
         "quota monitor-poll --goal-id",
         "--source heartbeat --execute",
         "delivery edits",
@@ -515,10 +521,10 @@ def main() -> int:
         "user_todo_summary",
         "user_todo_summary.open_count > 0",
         "never say \"no new user action\"",
-        "Only if action_required=true/open_count>0",
-        "name concrete payload todo(s)/questions",
+        "notify=NOTIFY: concrete actions/todos",
+        "including non_blocking at false/0",
         'never only "owner gate"',
-        "If false/0, allow quiet/no-user-todo",
+        "Only notify=DONT_NOTIFY + false/0: quiet",
         "具体 user todo 未投影，需修复 LoopX 状态投影",
         "NOTIFY",
         "notify_user_on_open_todo=true",
@@ -596,6 +602,8 @@ def main() -> int:
     ):
         assert phrase in compact_generated, phrase
     assert "if absent say" not in compact_generated, compact_generated
+    assert "Only if action_required=true/open_count>0" not in compact_generated, compact_generated
+    assert "If false/0, allow quiet/no-user-todo" not in compact_generated, compact_generated
 
     assert_ordered(
         doc,

--- a/loopx/heartbeat_prompt.py
+++ b/loopx/heartbeat_prompt.py
@@ -25,10 +25,10 @@ from .control_plane.agents.runtime_model import (
 DEFAULT_MATERIAL_QUEUE_RULE = "Do not consume the learning material queue unless the user explicitly asks."
 DEFAULT_PERMISSION_RULE = "Do not ask for permissions when the current Codex session is already trusted."
 USER_TODO_FINAL_MESSAGE_RULE = (
-    "Only if action_required=true/open_count>0: name concrete payload todo(s)/questions, "
-    'never only "owner gate"; missing -> '
+    "notify=NOTIFY: concrete actions/todos, including non_blocking at false/0; "
+    "never only \"owner gate\"; required missing -> "
     '"具体 user todo 未投影，需修复 LoopX 状态投影". '
-    "If false/0, allow quiet/no-user-todo."
+    "Only notify=DONT_NOTIFY + false/0: quiet."
 )
 SCHEDULER_HINT_APPLICATION_RULE = (
     "Apply `scheduler_hint` for wait backoff and CLI/Claude final-check/self-stop; no spend. "
@@ -565,6 +565,8 @@ If that preflight still fails: no work/spend; quiet `DONT_NOTIFY`.
 
 `lark_event_inbox`: if configured, drain -> writeback -> ACK.
 
+{USER_TODO_FINAL_MESSAGE_RULE}
+
 If the result says `should_run=false`:
 
 - If `state=operator_gate`, treat it as a user/controller interaction. Read
@@ -574,8 +576,8 @@ If the result says `should_run=false`:
   with one concise Chinese question listing the gate and expected reply format.
   If `user_todo_summary.open_count > 0`, list existing open user todos even
   when nothing new was found; never say "no new user action".
-  {USER_TODO_FINAL_MESSAGE_RULE} Do not execute `agent_command`, adapter work,
-  write-control, production actions, or the gated path while asking.
+  Do not execute `agent_command`, adapter work, write-control, production
+  actions, or the gated path while asking.
 - If `notify_user_on_open_todo=true`, existing open `user_todo_summary` is a
   blocker-push opportunity, not a silent skip. For focus/wait/evidence lanes,
   a user/owner answer can unlock progress. If the payload explicitly includes
@@ -764,13 +766,14 @@ Preflight and quota guard:
 
 Preflight fail: quiet.
 
+User NOTIFY: Chinese actions incl. non_blocking at false/0; never only "owner
+gate"; required missing -> "具体 user todo 未投影，需修复 LoopX 状态投影".
+Only DONT_NOTIFY+false/0: quiet.
+
 If `should_run=false`: no work/spend except `safe_bypass_allowed=true`.
-Gate/open todo -> Chinese `NOTIFY`. external/wait monitor -> one read-only
-status/log/metric/marker poll; new evidence -> writeback/spend once.
-Else quiet.
+external/wait monitor -> one read-only status/log/metric/marker poll;
+new evidence -> writeback/spend once. Otherwise obey user channel.
 Apply `scheduler_hint` stateful backoff for RRULE/backoff/self-stop; no spend.
-Action/open todo: list todos/questions; never only "owner gate";
-missing -> "具体 user todo 未投影，需修复 LoopX 状态投影"; false/0: 无用户待办/无需通知 or quiet.
 `lark_event_inbox`: `drain_command` -> writeback -> ACK;
 empty=no gate/spend.
 
@@ -841,10 +844,10 @@ If `should_run=false`: `monitor_quiet_skip` appends at most one no-spend
 `quota monitor-poll --execute`, reruns guard, then stays quiet unless
 `autonomous_replan_required` / `must_attempt_work=true`; no edits/spend;
 unchanged monitor-only polls are not self-stop signals.
-`state=operator_gate` or `notify_user_on_open_todo=true`: blocker-push;
-`open_todo_notification_policy=repeat_until_resolved`: repeat `NOTIFY`;
-if action/open todo exists, list payload todo(s)/questions, never only
-"owner gate"; no delivery/spend. `safe_bypass_allowed=true`: one
+`state=operator_gate` / `notify_user_on_open_todo=true` /
+`user_channel.notify=NOTIFY`: blocker-push with actions, including
+non_blocking; `open_todo_notification_policy=repeat_until_resolved`: repeat;
+never only "owner gate"; no delivery/spend. `safe_bypass_allowed=true`: one
 gate-independent safe-bypass, validate/writeback/spend. External/wait monitor:
 one read-only status/log/metric/marker poll; unchanged quiet, new evidence
 writeback/spend. Otherwise quiet `DONT_NOTIFY`.
@@ -945,9 +948,10 @@ Use skills: `loopx-project`; if surprising/tiny/contradictory,
 {scope_sentence}
 
 Inspect registry/global quota, active state, status/history, repo; run
-{quota_guard_instruction}; follow `interaction_contract`. If action_required/open_count:
-Chinese concrete todos/questions; never only "owner gate"; missing ->
-"具体 user todo 未投影，需修复 LoopX 状态投影". If false/0: quiet/no-user-todo.
+{quota_guard_instruction}; follow `interaction_contract`.
+User NOTIFY: Chinese actions incl. non_blocking at false/0;
+never only "owner gate"; required missing ->
+"具体 user todo 未投影，需修复 LoopX 状态投影". Only DONT_NOTIFY+false/0: quiet.
 {RUNTIME_CAPABILITY_PROJECTION_THIN_RULE}
 {SCHEDULER_HINT_THIN_RULE}
 Bounded batch/quiet no-op; spend after writeback.


### PR DESCRIPTION
## Summary

- make generated heartbeat prompts obey interaction_contract.user_channel.notify
- surface concrete non-blocking user actions even when action_required is false and open_count is zero
- keep all full, compact, brief, and thin prompt budgets enforced
- update the canonical heartbeat contract and focused regression smoke

## Validation

- heartbeat-prompt-smoke
- interaction-contract-state-machine-smoke
- heartbeat-prompt-error-smoke
- Python compileall
- LoopX public boundary check
- standard premerge canary: 14/14 passed, no manual holds

Ruff was not available in the local runtime; compile and the repository canary Python checks passed.