### PR TITLE
Fit live peer heartbeat prompts within the thin budget

### DIFF
--- a/examples/control_plane/heartbeat-prompt-smoke.py
+++ b/examples/control_plane/heartbeat-prompt-smoke.py
@@ -84,6 +84,22 @@ def main() -> int:
         registered_agents=["codex-main-control", "codex-side-bypass"],
         available_capabilities=["network", "external_evidence_poll", "network"],
     )
+    live_peer_payload = build_heartbeat_prompt(
+        goal_id="loopx-meta",
+        active_state=Path("the registry-declared active state"),
+        thin=True,
+        agent_id="codex-product-capability",
+        agent_profile={
+            "schema_version": "agent_profile_v1",
+            "agent_id": "codex-product-capability",
+            "scope_summary": (
+                "Peer task claims, task leases, agent profile routing, and related "
+                "control-plane correctness."
+            ),
+        },
+        registered_agents=["codex-main-control", "codex-product-capability"],
+        available_capabilities=["network", "external_evidence_poll"],
+    )
     missing_agent_id = None
     try:
         build_heartbeat_prompt(
@@ -142,9 +158,9 @@ def main() -> int:
         task_body = str(prompt_payload["task_body"])
         assert "lark_event_inbox" in task_body, task_body
         assert "drain" in task_body and "ACK" in task_body, task_body
-        assert "Graph-on: material refresh must sync configured sinks" in task_body, task_body
-        assert "row/result-id readback before final delivery" in task_body, task_body
-        assert "Explore Harness stays independent" in task_body, task_body
+        assert "Graph-on" in task_body and "sync" in task_body and "sinks" in task_body, task_body
+        assert "row/result-id readback before" in task_body and "delivery" in task_body, task_body
+        assert "Explore Harness" in task_body and "independent" in task_body, task_body
         if prompt_payload is not payload:
             assert "drain_command" in task_body, task_body
             assert "writeback" in task_body, task_body
@@ -155,7 +171,7 @@ def main() -> int:
     assert payload["interface_budget"]["mode"] == "full", payload
     assert "full" not in default_payload, default_payload
     assert "full" not in payload, payload
-    assert "Observed runtime capabilities -> `--available-capability`, never user gates." in thin_task, thin_task
+    assert "Observed capabilities -> `--available-capability`; never user gates." in thin_task, thin_task
     assert payload["quota_guard_command"] == (
         'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" '
         "quota should-run --goal-id public-heartbeat-goal"
@@ -270,6 +286,47 @@ def main() -> int:
     assert "productization showcase docs lane" in normalized(str(profile_scoped_payload["task_body"])), (
         profile_scoped_payload
     )
+    live_peer_task = normalized(str(live_peer_payload["task_body"]))
+    live_peer_budget = live_peer_payload["interface_budget"]
+    assert isinstance(live_peer_budget, dict), live_peer_payload
+    assert live_peer_budget["mode"] == "thin", live_peer_budget
+    assert live_peer_budget["char_count"] == len(str(live_peer_payload["task_body"])), live_peer_budget
+    assert live_peer_budget["budget_char_count"] <= live_peer_budget["max_chars"], live_peer_budget
+    assert live_peer_budget["within_budget"] is True, live_peer_budget
+    assert len(str(live_peer_payload["task_body"])) <= int(live_peer_budget["max_chars"]), live_peer_budget
+    assert "control-plane correctness.." not in live_peer_task, live_peer_task
+    for phrase in (
+        "Equal peer `codex-product-capability` (peer_v1)",
+        "Peer task claims, task leases, agent profile routing, and related control-plane correctness",
+        "Claim/lease first",
+        "independent repo worktree",
+        "todo continuation",
+        "no cross-agent authority",
+        "no scope in todo metadata",
+        'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota should-run '
+        "--goal-id loopx-meta --agent-id codex-product-capability --available-capability network "
+        "--available-capability external_evidence_poll",
+        "follow `interaction_contract`",
+        "User NOTIFY: concrete Chinese actions even non_blocking false/0",
+        'never only "owner gate"',
+        "具体 user todo 未投影，需修复 LoopX 状态投影",
+        "Quiet only if DONT_NOTIFY+false/0",
+        "Observed capabilities -> `--available-capability`; never user gates",
+        "Scheduler: App apply_needed -> RRULE + `ack_hint.cli_args`",
+        "final-check CLI/Claude; no spend",
+        "spend post-writeback",
+        "Plans/done -> todo/rationale; 2 stalls -> self-repair",
+        "`lark_event_inbox`: `drain_command` -> writeback -> ACK",
+        "Graph-on: sync sinks",
+        "row/result-id readback before delivery",
+        "retry/blocker/successor",
+        "Explore Harness independent",
+        "P0 blocked: safe P1/P2; monitor-only quiet/no-spend",
+        "No project branches",
+        "Do not consume learning queue unless asked",
+        "Stop for private material, credentials, destructive git, or unauthorized production actions",
+    ):
+        assert phrase in live_peer_task, phrase
     for phrase in (
         "Agent identity and scope",
         "model: peer_v1",
@@ -288,8 +345,8 @@ def main() -> int:
     assert "model: peer_v1" in primary_task, primary_task
     assert "single primary agent" not in primary_task, primary_task
     thin_scoped_task = normalized(str(thin_scoped_payload["task_body"]))
-    assert "model: peer_v1" in thin_scoped_task, thin_scoped_task
-    assert "independent worktree" in thin_scoped_task, thin_scoped_task
+    assert "(peer_v1)" in thin_scoped_task, thin_scoped_task
+    assert "independent repo worktree" in thin_scoped_task, thin_scoped_task
     assert "primary_agent" not in thin_scoped_task, thin_scoped_task
     assert "--active-state" not in registry_default_payload["expanded_prompt_command"], registry_default_payload
     assert brief_payload["brief"] is True, brief_payload
@@ -342,24 +399,23 @@ def main() -> int:
     thin_task = normalized(str(thin_payload["task_body"]))
     for phrase in (
         "Advance `public-heartbeat-goal` from /tmp/public-heartbeat-goal/ACTIVE_GOAL_STATE.md",
-        "Use skills: `loopx-project`; if surprising/tiny/contradictory",
+        "Skills: `loopx-project`; surprise/tiny/conflict",
         "`loopx-self-repair`",
-        "LoopX CLI is source of truth",
-        "registry/global quota, active state, status/history, repo",
+        "LoopX CLI = truth",
+        "registry/state/status/history/repo",
         "`quota should-run`; follow `interaction_contract`",
-        "User NOTIFY: Chinese actions incl. non_blocking at false/0",
+        "User NOTIFY: concrete Chinese actions even non_blocking false/0",
         'never only "owner gate"',
-        "Only DONT_NOTIFY+false/0: quiet",
+        "Quiet only if DONT_NOTIFY+false/0",
         "具体 user todo 未投影，需修复 LoopX 状态投影",
-        "Apply `scheduler_hint`: if App `stateful_backoff.apply_needed`",
-        "RRULE then run `ack_hint.cli_args`",
-        "CLI/Claude final-check; no spend",
-        "Bounded batch/quiet no-op; spend after writeback",
+        "Scheduler: App apply_needed -> RRULE + `ack_hint.cli_args`",
+        "final-check CLI/Claude; no spend",
+        "Bounded batch/no-op; spend post-writeback",
         "Plans/done -> todo/rationale; 2 stalls -> self-repair",
-        "P0 blocked: continue safe P1/P2",
+        "P0 blocked: safe P1/P2",
         "monitor-only quiet/no-spend",
-        "No project-specific branches here",
-        "Do not consume the learning material queue unless explicitly asked",
+        "No project branches",
+        "Do not consume learning queue unless asked",
         "Stop for private material, credentials, destructive git, or unauthorized production actions",
     ):
         assert phrase in thin_task, phrase

--- a/loopx/heartbeat_prompt.py
+++ b/loopx/heartbeat_prompt.py
@@ -40,16 +40,21 @@ SCHEDULER_HINT_COMPACT_RULE = (
     "Scheduler: no spend. App if apply_needed: update RRULE, ack via `ack_hint`; else skip."
 )
 SCHEDULER_HINT_THIN_RULE = (
-    "Apply `scheduler_hint`: if App `stateful_backoff.apply_needed`, "
-    "RRULE then run `ack_hint.cli_args`; CLI/Claude final-check; no spend."
+    "Scheduler: App apply_needed -> RRULE + `ack_hint.cli_args`; "
+    "final-check CLI/Claude; no spend."
 )
 RUNTIME_CAPABILITY_PROJECTION_THIN_RULE = (
-    "Observed runtime capabilities -> `--available-capability`, never user gates."
+    "Observed capabilities -> `--available-capability`; never user gates."
 )
 EXPLORE_GRAPH_DELIVERY_RULE = (
     "Graph-on: material refresh must sync configured sinks and verify "
     "row/result-id readback before final delivery; unsatisfied -> retry or "
     "blocker/successor. Explore Harness stays independent."
+)
+EXPLORE_GRAPH_DELIVERY_THIN_RULE = (
+    "Graph-on: sync sinks; verify row/result-id readback before delivery; "
+    "else retry/blocker/successor. "
+    "Explore Harness independent."
 )
 INTERFACE_BUDGET_CHARS = {
     "full": 12_000,
@@ -199,6 +204,7 @@ def render_peer_agent_scope_instruction(
         return ""
     identity = agent_id or "<registered-agent-id>"
     scope_text = "; ".join(agent_scopes) if agent_scopes else "registered peer lane"
+    scope_text = scope_text.rstrip(".!?")
     claim_command = (
         f"{cli_bin} todo claim --goal-id {goal_id} --todo-id <todo_id> "
         f"--claimed-by {agent_id}"
@@ -214,10 +220,9 @@ def render_peer_agent_scope_instruction(
     )
     if thin:
         return (
-            f"Agent: `{identity}`; model: peer_v1; scope: {scope_text}. Equal peer: "
-            "claim/lease before delivery; use an independent worktree; follow todo "
-            "continuation policy; no cross-agent authority. Do not write scope into "
-            "todo metadata."
+            f"Equal peer `{identity}` (peer_v1); scope: {scope_text}. Claim/lease first; "
+            "independent repo worktree; todo continuation; no cross-agent authority; "
+            "no scope in todo metadata."
         )
     if compact:
         return (
@@ -931,11 +936,11 @@ def render_thin_heartbeat_task_body(
 ) -> str:
     permission_tail = "" if permission_rule == DEFAULT_PERMISSION_RULE else f" {permission_rule}"
     material_sentence = (
-        "Do not consume the learning material queue unless explicitly asked."
+        "Do not consume learning queue unless asked."
         if material_queue_rule == DEFAULT_MATERIAL_QUEUE_RULE
         else material_queue_rule
     )
-    scope_sentence = f"\n\n{agent_scope_instruction}" if agent_scope_instruction else ""
+    scope_sentence = f"\n{agent_scope_instruction}" if agent_scope_instruction else ""
     quota_guard_instruction = (
         f"`{quota_guard_command}`"
         if "--available-capability" in quota_guard_command
@@ -943,25 +948,25 @@ def render_thin_heartbeat_task_body(
     )
     return f"""Advance `{goal_id}` from {active_state}.
 
-Use skills: `loopx-project`; if surprising/tiny/contradictory,
-`loopx-self-repair`. LoopX CLI is source of truth.
+Skills: `loopx-project`; surprise/tiny/conflict -> `loopx-self-repair`.
+LoopX CLI = truth.
 {scope_sentence}
 
-Inspect registry/global quota, active state, status/history, repo; run
+Inspect registry/state/status/history/repo; run
 {quota_guard_instruction}; follow `interaction_contract`.
-User NOTIFY: Chinese actions incl. non_blocking at false/0;
-never only "owner gate"; required missing ->
-"具体 user todo 未投影，需修复 LoopX 状态投影". Only DONT_NOTIFY+false/0: quiet.
+User NOTIFY: concrete Chinese actions even non_blocking false/0; never only
+"owner gate"; required missing -> "具体 user todo 未投影，需修复 LoopX 状态投影".
+Quiet only if DONT_NOTIFY+false/0.
 {RUNTIME_CAPABILITY_PROJECTION_THIN_RULE}
 {SCHEDULER_HINT_THIN_RULE}
-Bounded batch/quiet no-op; spend after writeback.
+Bounded batch/no-op; spend post-writeback.
 Plans/done -> todo/rationale; 2 stalls -> self-repair.
 `lark_event_inbox`: `drain_command` -> writeback -> ACK.
-{EXPLORE_GRAPH_DELIVERY_RULE}
+{EXPLORE_GRAPH_DELIVERY_THIN_RULE}
 
-P0 blocked: continue safe P1/P2; monitor-only quiet/no-spend.
+P0 blocked: safe P1/P2; monitor-only quiet/no-spend.
 
-No project-specific branches here. {material_sentence} Stop for private material,
+No project branches; {material_sentence} Stop for private material,
 credentials, destructive git, or unauthorized production actions{permission_tail}"""
 
 


### PR DESCRIPTION
## Summary
- compact the thin peer heartbeat wording without dropping control-plane contracts
- normalize trailing punctuation in projected agent scope text
- add a live-shape regression for peer identity plus network and external evidence capabilities

## Validation
- `python3 examples/control_plane/heartbeat-prompt-smoke.py`
- `python3 examples/control_plane/peer-agent-runtime-v1-smoke.py`
- `python3 examples/control_plane/heartbeat-prompt-error-smoke.py`
- `python3 examples/control_plane/interaction-contract-state-machine-smoke.py`
- `python3 -m compileall -q loopx/heartbeat_prompt.py examples/control_plane/heartbeat-prompt-smoke.py`
- `python3 -m loopx.cli check --scan-path loopx/heartbeat_prompt.py --scan-path examples/control_plane/heartbeat-prompt-smoke.py`
- `python3 -m loopx.cli canary premerge --from-git-diff`

The real peer prompt shape now renders at 1,566 characters against the 1,570-character thin interface limit.