### PR TITLE
Fix monitor-poll runtime capability parity

### DIFF
--- a/examples/control_plane/monitor-poll-writeback-smoke.py
+++ b/examples/control_plane/monitor-poll-writeback-smoke.py
@@ -70,6 +70,7 @@ def write_fixture(
     include_user_gate: bool = False,
     include_advancement: bool = False,
     primary_monitor_priority: str = "P0",
+    monitor_required_capabilities: tuple[str, ...] = (),
 ) -> tuple[Path, Path]:
     project = root / "project"
     runtime = root / "runtime"
@@ -80,6 +81,11 @@ def write_fixture(
     monitor_metadata = (
         f"target_key={selected_target_key} "
         if selected_target_key
+        else ""
+    )
+    monitor_capability_metadata = (
+        f"required_capabilities={','.join(monitor_required_capabilities)} "
+        if monitor_required_capabilities
         else ""
     )
     other_monitor = (
@@ -152,6 +158,7 @@ def write_fixture(
         "status=open "
         "task_class=continuous_monitor "
         "action_kind=poll "
+        f"{monitor_capability_metadata}"
         f"claimed_by={AGENT_ID} "
         f"{monitor_metadata}"
         "cadence=15m "
@@ -620,6 +627,104 @@ def assert_compacted_auxiliary_due_monitor_can_write_back() -> None:
         assert other["next_due_at"] != "2026-01-01T00:00:00+00:00", other
 
 
+def assert_capability_gated_monitor_poll_requires_declaration_parity() -> None:
+    capabilities = ("network", "external_evidence_poll")
+    capability_args = tuple(
+        arg
+        for capability in capabilities
+        for arg in ("--available-capability", capability)
+    )
+    with tempfile.TemporaryDirectory(prefix="loopx-monitor-poll-capability-parity-") as tmp:
+        registry_path, state_file = write_fixture(
+            Path(tmp),
+            monitor_required_capabilities=capabilities,
+        )
+
+        should_run = run_cli(
+            registry_path,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            *capability_args,
+        )
+        assert should_run["work_lane_contract"]["obligation"] == "attempt_due_monitor", should_run
+
+        failure = run_cli_expect_error(
+            registry_path,
+            "quota",
+            "monitor-poll",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--todo-id",
+            TODO_ID,
+            "--target-key",
+            TARGET_KEY,
+            "--result-hash",
+            "old",
+        )
+        assert "monitor-poll recomputes should-run" in failure["reason"], failure
+        retry = failure["capability_retry"]
+        assert retry["missing"] == list(capabilities), retry
+        assert retry["cli_args"] == list(capability_args), retry
+
+        option_failure = run_cli_expect_error(
+            registry_path,
+            "quota",
+            "monitor-poll",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--material-change",
+        )
+        assert "capability_retry" not in option_failure, option_failure
+
+        success = run_cli(
+            registry_path,
+            "quota",
+            "monitor-poll",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            *capability_args,
+            "--todo-id",
+            TODO_ID,
+            "--target-key",
+            TARGET_KEY,
+            "--result-hash",
+            "old",
+        )
+        assert success["ok"] is True, success
+        assert success["before"]["work_lane_contract"]["obligation"] == "attempt_due_monitor", success
+        assert success["todo_writeback"]["todo_id"] == TODO_ID, success
+        assert find_todo(state_file, TODO_ID)["consecutive_no_change"] == "1"
+
+
+def assert_cli_help_names_capability_sensitive_commands() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "quota", "--help"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    option_help = result.stdout[result.stdout.index("--available-capability") :]
+    for command in (
+        "quota should-run",
+        "quota monitor-poll",
+        "quota scheduler-ack",
+        "quota scheduler-ack-current",
+        "quota spend-slot",
+    ):
+        assert command in option_help, (command, option_help)
+
+
 def assert_writeback_helper_preview_contract() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-monitor-poll-helper-parity-") as tmp:
         registry_path, _state_file = write_fixture(Path(tmp))
@@ -721,6 +826,7 @@ def assert_cli_monitor_poll_uses_should_run_lookback() -> None:
 
 
 def main() -> int:
+    assert_cli_help_names_capability_sensitive_commands()
     assert_cli_monitor_poll_uses_should_run_lookback()
     assert_writeback_helper_preview_contract()
     assert_unchanged_writeback()
@@ -729,6 +835,7 @@ def main() -> int:
     assert_due_monitor_poll_allowed_with_open_user_gate()
     assert_target_key_cannot_hijack_selected_due_monitor()
     assert_compacted_auxiliary_due_monitor_can_write_back()
+    assert_capability_gated_monitor_poll_requires_declaration_parity()
     return 0
 
 

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -73,9 +73,11 @@ def register_quota_command(subparsers: argparse._SubParsersAction) -> None:
         dest="available_capabilities",
         action="append",
         help=(
-            "For `quota should-run` and `quota spend-slot`, declare a capability "
-            "available in this current agent environment. Repeat for multiple "
-            "capabilities; basic local shell/filesystem capabilities are assumed."
+            "For `quota should-run`, `quota monitor-poll`, `quota scheduler-ack`, "
+            "`quota scheduler-ack-current`, and `quota spend-slot`, declare a "
+            "capability available in this current agent environment. Repeat the "
+            "same declarations for commands that recompute should-run; basic local "
+            "shell/filesystem capabilities are assumed."
         ),
     )
     quota_parser.add_argument(

--- a/loopx/control_plane/quota/monitor_poll.py
+++ b/loopx/control_plane/quota/monitor_poll.py
@@ -218,6 +218,29 @@ def _monitor_poll_failure(
     }
 
 
+def _capability_declaration_retry(before: dict[str, Any]) -> dict[str, Any] | None:
+    gate = (
+        before.get("capability_gate")
+        if isinstance(before.get("capability_gate"), dict)
+        else {}
+    )
+    raw_missing = gate.get("missing") if isinstance(gate.get("missing"), list) else []
+    missing = [str(item).strip() for item in raw_missing if str(item).strip()]
+    if not missing:
+        return None
+    cli_args = [arg for capability in missing for arg in ("--available-capability", capability)]
+    return {
+        "schema_version": "monitor_poll_capability_retry_v0",
+        "command": "quota monitor-poll",
+        "missing": missing,
+        "cli_args": cli_args,
+        "reason": (
+            "monitor-poll recomputes should-run; if these capabilities are present "
+            "in the current agent environment, repeat the runtime capability declarations"
+        ),
+    }
+
+
 def record_quota_monitor_poll_for_decision(
     before: dict[str, Any],
     status_payload: dict[str, Any],
@@ -243,8 +266,8 @@ def record_quota_monitor_poll_for_decision(
     safe_target_key = str(target_key or "").strip() or None
     safe_result_hash = str(result_hash or "").strip() or None
 
-    def failure(reason: str) -> dict[str, Any]:
-        return _monitor_poll_failure(
+    def failure(reason: str, *, include_capability_retry: bool = False) -> dict[str, Any]:
+        payload = _monitor_poll_failure(
             goal_id=goal_id,
             execute=execute,
             source=source,
@@ -256,6 +279,13 @@ def record_quota_monitor_poll_for_decision(
             reason=reason,
             before=before,
         )
+        retry = _capability_declaration_retry(before) if include_capability_retry else None
+        if retry:
+            payload["capability_retry"] = retry
+            payload["reason"] = (
+                f"{reason}; {retry['reason']}: {', '.join(retry['missing'])}"
+            )
+        return payload
 
     if material_change and not (normalized_todo_id or safe_target_key):
         return failure("`quota monitor-poll --material-change` requires --todo-id or --target-key")
@@ -279,7 +309,8 @@ def record_quota_monitor_poll_for_decision(
     ):
         return failure(
             "monitor-poll requires monitor_quiet_skip, due monitor todo, "
-            "or external monitor observation"
+            "or external monitor observation",
+            include_capability_retry=True,
         )
 
     generated_at = _now_local()


### PR DESCRIPTION
## Summary

- document every quota command that recomputes `should-run` with runtime capability declarations
- return a structured `capability_retry` receipt when `monitor-poll` loses its route because declarations are missing
- cover the real paired flow: failure without declarations, success with identical declarations, and no retry noise for unrelated option errors

## Validation

- `python3 examples/control_plane/monitor-poll-writeback-smoke.py`
- adjacent monitor and quota policy smokes
- `python3 -m compileall -q` on changed Python files
- `loopx check` on all changed paths
- `loopx canary premerge --from-git-diff --tier standard`: 17/17 selected checks passed

No failures, skips, manual holds, credentials, local paths, private state, or generated logs.