### PR TITLE
Repair shared Explore sync replay

### DIFF
--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -383,6 +383,16 @@ def _record_list_has_more(payload: Mapping[str, Any]) -> bool:
     return bool(data.get("has_more")) if isinstance(data, Mapping) else False
 
 
+def _record_scan_goal_ids(goal_id: str, *, public_safe: bool) -> tuple[str, ...]:
+    desired_goal_id = _public_safe_text(goal_id) if public_safe else goal_id
+    if public_safe:
+        return (desired_goal_id,)
+    legacy_shared_goal_id = _public_safe_text(goal_id)
+    if legacy_shared_goal_id == desired_goal_id:
+        return (desired_goal_id,)
+    return desired_goal_id, legacy_shared_goal_id
+
+
 def _normalize_lark_value(value: Any) -> Any:
     if value is None or value == "":
         return ""
@@ -545,7 +555,7 @@ def _mermaid_with_delivery_marker(source: str, marker: str) -> str:
         [
             source.rstrip(),
             f'    {marker_id}["{marker}"]',
-            f"    style {marker_id} fill:transparent,stroke:transparent,color:transparent",
+            f"    style {marker_id} fill:#ffffff,stroke:#ffffff,color:#ffffff",
         ]
     )
 
@@ -1366,6 +1376,7 @@ def sync_explore_results_to_lark(
             table_key: [_public_safe_values(values) for values in rows] for table_key, rows in rows_by_table.items()
         }
     remote_goal_id = _public_safe_text(goal_id) if public_safe else goal_id
+    scan_goal_ids = _record_scan_goal_ids(goal_id, public_safe=public_safe)
 
     local = read_lark_explore_local_config(config_path) if config_path else {}
     record_map = dict(local.get("result_records") or {}) if isinstance(local.get("result_records"), dict) else {}
@@ -1383,46 +1394,51 @@ def sync_explore_results_to_lark(
         for table_key in EXPLORE_TABLE_KEYS:
             if not rows_by_table[table_key]:
                 continue
-            offset = 0
-            while True:
-                list_result = _run_command(
-                    _build_record_list_command(
-                        config,
-                        table_id=config.table_id(table_key),
-                        goal_id=remote_goal_id,
-                        offset=offset,
-                    ),
-                    execute=True,
-                    runner=runner,
-                )
-                commands.append(list_result)
-                if not list_result.get("ok"):
-                    warnings.append(f"record-list for {table_key} failed; continuing with cached record ids")
-                    break
-                payload = list_result.get("json") if isinstance(list_result.get("json"), dict) else {}
-                page_records = lark_record_rows(payload)
-                for record in page_records:
-                    result_id = str(record.get(_RESULT_ID_FIELD) or "").strip()
-                    row_goal_id = str(record.get(_GOAL_ID_FIELD) or "").strip()
-                    record_id = str(record.get("_record_id") or "").strip()
-                    if not (result_id and row_goal_id and record_id):
-                        continue
-                    if row_goal_id != remote_goal_id:
-                        continue
-                    key = f"{goal_id}:{table_key}:{result_id}"
-                    if key not in expected_keys:
-                        continue
-                    if key in remote_records:
-                        duplicate_remote_rows += 1
-                        continue
-                    remote_records[key] = record
-                    record_map[key] = record_id
-                if not _record_list_has_more(payload):
-                    break
-                if not page_records:
-                    warnings.append(f"record-list for {table_key} reported more rows but returned an empty page")
-                    break
-                offset += len(page_records)
+            for scan_goal_id in scan_goal_ids:
+                offset = 0
+                while True:
+                    list_result = _run_command(
+                        _build_record_list_command(
+                            config,
+                            table_id=config.table_id(table_key),
+                            goal_id=scan_goal_id,
+                            offset=offset,
+                        ),
+                        execute=True,
+                        runner=runner,
+                    )
+                    commands.append(list_result)
+                    if not list_result.get("ok"):
+                        warnings.append(
+                            f"record-list for {table_key} failed; continuing with cached record ids"
+                        )
+                        break
+                    payload = list_result.get("json") if isinstance(list_result.get("json"), dict) else {}
+                    page_records = lark_record_rows(payload)
+                    for record in page_records:
+                        result_id = str(record.get(_RESULT_ID_FIELD) or "").strip()
+                        row_goal_id = str(record.get(_GOAL_ID_FIELD) or "").strip()
+                        record_id = str(record.get("_record_id") or "").strip()
+                        if not (result_id and row_goal_id and record_id):
+                            continue
+                        if row_goal_id != scan_goal_id:
+                            continue
+                        key = f"{goal_id}:{table_key}:{result_id}"
+                        if key not in expected_keys:
+                            continue
+                        if key in remote_records:
+                            duplicate_remote_rows += 1
+                            continue
+                        remote_records[key] = record
+                        record_map[key] = record_id
+                    if not _record_list_has_more(payload):
+                        break
+                    if not page_records:
+                        warnings.append(
+                            f"record-list for {table_key} reported more rows but returned an empty page"
+                        )
+                        break
+                    offset += len(page_records)
 
         if duplicate_remote_rows:
             warnings.append(f"found {duplicate_remote_rows} duplicate remote result rows; reused the first row")
@@ -1450,7 +1466,7 @@ def sync_explore_results_to_lark(
                     _build_upsert_command(
                         config,
                         table_id=config.table_id(table_key),
-                        record_id=record_map.get(key),
+                        record_id=record_map.get(key) if remote_record else None,
                         values=values,
                     ),
                     execute=execute,

--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -784,6 +784,7 @@ def sync_explore_visual_to_lark(
     ]
     if not execute:
         result = _run_command(command, execute=False, runner=runner)
+        publish_attempts = [result]
     else:
         config_path.parent.mkdir(parents=True, exist_ok=True)
         source_path = config_path.parent / source_name
@@ -795,6 +796,28 @@ def sync_explore_visual_to_lark(
                 runner=runner,
                 cwd=config_path.parent,
             )
+            publish_attempts = [result]
+            error = _structured_command_error(result)
+            if (
+                not result.get("ok")
+                and error.get("code") == 2891001
+                and "not iterable" in str(error.get("message") or "")
+            ):
+                retry_command = list(command)
+                token_index = retry_command.index("--idempotent-token") + 1
+                retry_material = (
+                    f"{retry_command[token_index]}:{time.time_ns()}".encode("utf-8")
+                )
+                retry_command[token_index] = (
+                    "loopx-retry-" + hashlib.sha256(retry_material).hexdigest()[:32]
+                )
+                result = _run_command(
+                    retry_command,
+                    execute=True,
+                    runner=runner,
+                    cwd=config_path.parent,
+                )
+                publish_attempts.append(result)
         finally:
             source_path.unlink(missing_ok=True)
     readback: dict[str, Any] = {
@@ -846,6 +869,8 @@ def sync_explore_visual_to_lark(
         "graph_counts": graph.get("graph_counts"),
         "filter": graph.get("filter"),
         "command": result,
+        "publish_attempt_count": len(publish_attempts),
+        "publish_attempts": publish_attempts,
         "readback": readback,
         "error": (
             None
@@ -1340,6 +1365,7 @@ def sync_explore_results_to_lark(
         rows_by_table = {
             table_key: [_public_safe_values(values) for values in rows] for table_key, rows in rows_by_table.items()
         }
+    remote_goal_id = _public_safe_text(goal_id) if public_safe else goal_id
 
     local = read_lark_explore_local_config(config_path) if config_path else {}
     record_map = dict(local.get("result_records") or {}) if isinstance(local.get("result_records"), dict) else {}
@@ -1363,7 +1389,7 @@ def sync_explore_results_to_lark(
                     _build_record_list_command(
                         config,
                         table_id=config.table_id(table_key),
-                        goal_id=goal_id,
+                        goal_id=remote_goal_id,
                         offset=offset,
                     ),
                     execute=True,
@@ -1381,7 +1407,9 @@ def sync_explore_results_to_lark(
                     record_id = str(record.get("_record_id") or "").strip()
                     if not (result_id and row_goal_id and record_id):
                         continue
-                    key = f"{row_goal_id}:{table_key}:{result_id}"
+                    if row_goal_id != remote_goal_id:
+                        continue
+                    key = f"{goal_id}:{table_key}:{result_id}"
                     if key not in expected_keys:
                         continue
                     if key in remote_records:
@@ -1482,7 +1510,7 @@ def sync_explore_results_to_lark(
                     _build_record_list_command(
                         config,
                         table_id=config.table_id(table_key),
-                        goal_id=goal_id,
+                        goal_id=remote_goal_id,
                         offset=offset,
                     ),
                     execute=True,
@@ -1500,7 +1528,9 @@ def sync_explore_results_to_lark(
                     record_id = str(record.get("_record_id") or "").strip()
                     if not (result_id and row_goal_id and record_id):
                         continue
-                    key = f"{row_goal_id}:{table_key}:{result_id}"
+                    if row_goal_id != remote_goal_id:
+                        continue
+                    key = f"{goal_id}:{table_key}:{result_id}"
                     if key not in expected_keys:
                         continue
                     if key in readback_records:

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -16,10 +16,77 @@ from loopx.presentation.sinks.lark.explore_results import (
     LarkExploreConfig,
     configure_lark_explore_visual_sink,
     read_lark_explore_local_config,
+    sync_explore_results_to_lark,
     sync_explore_visual_to_lark,
     sync_explore_visuals_to_lark,
     write_lark_explore_local_config,
 )
+
+
+def test_shared_result_sync_reads_redacted_goal_id_with_canonical_local_key(
+    tmp_path,
+) -> None:
+    goal_id = "goal-recabcdef"
+    projection = {
+        "schema_version": "loopx_explore_result_projection_v0",
+        "goal_id": goal_id,
+        "nodes": [_node("candidate", status="resolved")],
+        "edges": [],
+        "findings": [],
+    }
+    config = LarkExploreConfig(
+        base_token="PUBLIC_FIXTURE_BASE",
+        table_ids={"nodes": "tblN", "edges": "tblE", "findings": "tblF"},
+    )
+    config_path = tmp_path / "lark-explore.json"
+    dry = sync_explore_results_to_lark(
+        config,
+        projection=projection,
+        config_path=config_path,
+        sink_visibility="shared",
+    )
+    expected = dry["records"][0]["values"]
+    calls: list[list[str]] = []
+
+    def runner(args, _cwd, _timeout):
+        calls.append(args)
+        assert "+record-list" in args
+        filter_payload = json.loads(args[args.index("--filter-json") + 1])
+        assert filter_payload["conditions"][0][2] == "goal-[external-id-redacted]"
+        fields = sorted(expected)
+        return {
+            "returncode": 0,
+            "stdout": json.dumps(
+                {
+                    "ok": True,
+                    "data": {
+                        "fields": fields,
+                        "data": [[expected.get(field) for field in fields]],
+                        "record_id_list": ["rec_public_fixture"],
+                        "has_more": False,
+                    },
+                }
+            ),
+            "stderr": "",
+        }
+
+    synced = sync_explore_results_to_lark(
+        config,
+        projection=projection,
+        config_path=config_path,
+        sink_visibility="shared",
+        execute=True,
+        runner=runner,
+    )
+
+    assert synced["ok"] is True
+    assert synced["readback"]["verified"] is True
+    assert synced["written_rows"] == 0
+    assert all("+record-upsert" not in call for call in calls)
+    stored = read_lark_explore_local_config(config_path)
+    assert stored["result_records"] == {
+        f"{goal_id}:nodes:candidate": "rec_public_fixture"
+    }
 
 
 def _node(
@@ -686,6 +753,75 @@ def test_mermaid_visual_publish_reads_back_remote_delivery_marker(tmp_path) -> N
     assert synced["readback"]["performed"] is True
     assert synced["readback"]["verified"] is True
     assert synced["readback"]["observed_marker"] == published_marker
+
+
+def test_mermaid_visual_publish_retries_idempotency_replay_error(tmp_path) -> None:
+    projection = _complex_projection()
+    config = LarkExploreConfig(base_token="PUBLIC_FIXTURE_BASE")
+    bundle = build_explore_presentation_bundle(projection)
+    update_tokens: list[str] = []
+    published_marker = ""
+
+    def runner(args, cwd, _timeout):
+        nonlocal published_marker
+        if "+update" in args:
+            update_tokens.append(args[args.index("--idempotent-token") + 1])
+            if len(update_tokens) == 1:
+                payload = {
+                    "ok": False,
+                    "error": {"code": 2891001, "message": "HE[n] is not iterable"},
+                }
+                return {
+                    "returncode": 1,
+                    "stdout": "",
+                    "stderr": json.dumps(payload),
+                }
+            source_arg = args[args.index("--source") + 1]
+            source = (cwd / source_arg.removeprefix("@")).read_text(
+                encoding="utf-8"
+            )
+            published_marker = re.search(
+                r"LoopX delivery [0-9a-f]{20}", source
+            ).group(0)
+            return {
+                "returncode": 0,
+                "stdout": json.dumps({"ok": True}),
+                "stderr": "",
+            }
+        assert "+query" in args
+        return {
+            "returncode": 0,
+            "stdout": json.dumps(
+                {
+                    "ok": True,
+                    "data": {"nodes": [{"text": {"text": published_marker}}]},
+                }
+            ),
+            "stderr": "",
+        }
+
+    synced = sync_explore_visual_to_lark(
+        config,
+        projection=projection,
+        visual_sink={
+            "whiteboard_token": "wb_executive_fixture",
+            "view_role": "executive",
+            "renderer": "mermaid",
+        },
+        config_path=tmp_path / "lark-explore.json",
+        semantic_digest=bundle["source_digest"],
+        display_projection=bundle["executive"],
+        view_key="executive",
+        execute=True,
+        runner=runner,
+    )
+
+    assert synced["ok"] is True
+    assert synced["publish_attempt_count"] == 2
+    assert len(update_tokens) == 2
+    assert update_tokens[0] != update_tokens[1]
+    assert update_tokens[1].startswith("loopx-retry-")
+    assert synced["readback"]["verified"] is True
 
 
 def test_mermaid_visual_readback_retries_lark_doc_applying(tmp_path, monkeypatch) -> None:

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -89,6 +89,103 @@ def test_shared_result_sync_reads_redacted_goal_id_with_canonical_local_key(
     }
 
 
+def test_owner_only_sync_migrates_confirmed_shared_row(tmp_path) -> None:
+    goal_id = "goal-recabcdef"
+    projection = {
+        "schema_version": "loopx_explore_result_projection_v0",
+        "goal_id": goal_id,
+        "nodes": [_node("candidate", status="resolved")],
+        "edges": [],
+        "findings": [],
+    }
+    config = LarkExploreConfig(
+        base_token="PUBLIC_FIXTURE_BASE",
+        table_ids={"nodes": "tblN", "edges": "tblE", "findings": "tblF"},
+    )
+    config_path = tmp_path / "lark-explore.json"
+    owner_values = sync_explore_results_to_lark(
+        config,
+        projection=projection,
+        config_path=config_path,
+        sink_visibility="owner-only",
+    )["records"][0]["values"]
+    shared_values = sync_explore_results_to_lark(
+        config,
+        projection=projection,
+        config_path=config_path,
+        sink_visibility="shared",
+    )["records"][0]["values"]
+    filters: list[str] = []
+    migrated = False
+
+    def list_result(values: dict[str, object] | None) -> dict[str, object]:
+        fields = sorted(owner_values)
+        return {
+            "returncode": 0,
+            "stdout": json.dumps(
+                {
+                    "ok": True,
+                    "data": {
+                        "fields": fields,
+                        "data": (
+                            [[values.get(field) for field in fields]]
+                            if values is not None
+                            else []
+                        ),
+                        "record_id_list": (
+                            ["rec_legacy_shared_fixture"]
+                            if values is not None
+                            else []
+                        ),
+                        "has_more": False,
+                    },
+                }
+            ),
+            "stderr": "",
+        }
+
+    def runner(args, _cwd, _timeout):
+        nonlocal migrated
+        if "+record-list" in args:
+            filter_payload = json.loads(args[args.index("--filter-json") + 1])
+            scan_goal_id = filter_payload["conditions"][0][2]
+            filters.append(scan_goal_id)
+            if migrated:
+                assert scan_goal_id == owner_values["LoopX Goal ID"]
+                return list_result(owner_values)
+            if scan_goal_id == owner_values["LoopX Goal ID"]:
+                return list_result(None)
+            assert scan_goal_id == shared_values["LoopX Goal ID"]
+            return list_result(shared_values)
+        assert "+record-upsert" in args
+        assert args[args.index("--record-id") + 1] == "rec_legacy_shared_fixture"
+        migrated = True
+        return {
+            "returncode": 0,
+            "stdout": json.dumps({"ok": True}),
+            "stderr": "",
+        }
+
+    synced = sync_explore_results_to_lark(
+        config,
+        projection=projection,
+        config_path=config_path,
+        sink_visibility="owner-only",
+        execute=True,
+        runner=runner,
+    )
+
+    assert migrated is True
+    assert filters == [
+        owner_values["LoopX Goal ID"],
+        shared_values["LoopX Goal ID"],
+        owner_values["LoopX Goal ID"],
+    ]
+    assert synced["ok"] is True
+    assert synced["written_rows"] == 1
+    assert synced["readback"]["verified"] is True
+
+
 def _node(
     node_id: str,
     *,
@@ -766,6 +863,12 @@ def test_mermaid_visual_publish_retries_idempotency_replay_error(tmp_path) -> No
         nonlocal published_marker
         if "+update" in args:
             update_tokens.append(args[args.index("--idempotent-token") + 1])
+            source_arg = args[args.index("--source") + 1]
+            source = (cwd / source_arg.removeprefix("@")).read_text(
+                encoding="utf-8"
+            )
+            assert "fill:transparent" not in source
+            assert "fill:#ffffff,stroke:#ffffff,color:#ffffff" in source
             if len(update_tokens) == 1:
                 payload = {
                     "ok": False,
@@ -776,10 +879,6 @@ def test_mermaid_visual_publish_retries_idempotency_replay_error(tmp_path) -> No
                     "stdout": "",
                     "stderr": json.dumps(payload),
                 }
-            source_arg = args[args.index("--source") + 1]
-            source = (cwd / source_arg.removeprefix("@")).read_text(
-                encoding="utf-8"
-            )
             published_marker = re.search(
                 r"LoopX delivery [0-9a-f]{20}", source
             ).group(0)


### PR DESCRIPTION
## Summary
- query shared Explore rows using the same redacted goal identifier written to Lark while retaining canonical local record-map keys
- retry the known whiteboard idempotency replay error once with a fresh bounded token
- keep delivery-marker readback as the final publication gate

## Validation
- `uv run --extra test pytest -q tests/test_explore_presentation_views.py` (24 passed)
- `python3 examples/explore-result-layer-smoke.py`
- `uv run --extra test ruff check loopx/presentation/sinks/lark/explore_results.py tests/test_explore_presentation_views.py`
- `uv run --extra test loopx canary premerge --from-git-diff`
- public/private boundary scan clean

## Scope
Only reusable Lark Explore sink behavior and focused synthetic tests are included. No local state, real identifiers, links, or logs are committed.