### PR TITLE
Repair stale Full Public smoke contracts

### DIFF
--- a/examples/benchmark-developer-workflow-doc-smoke.py
+++ b/examples/benchmark-developer-workflow-doc-smoke.py
@@ -170,7 +170,15 @@ def main() -> int:
     tasks = TASKS.read_text(encoding="utf-8")
     require(readme, ["docs/benchmark-developer-workflow.md"], source=README)
     require(docs_index, ["benchmark-developer-workflow.md"], source=DOCS_INDEX)
-    require(tasks, ["GH-C40", "benchmark developer workflow"], source=TASKS)
+    require(
+        tasks,
+        [
+            "GH-C40",
+            "bounded benchmark lifecycle/read-model seams",
+            "raw logs, task text, verifier output, or host paths",
+        ],
+        source=TASKS,
+    )
 
     print("benchmark-developer-workflow-doc-smoke ok")
     return 0

--- a/examples/blocker-push-runtime-smoke.py
+++ b/examples/blocker-push-runtime-smoke.py
@@ -209,9 +209,11 @@ def main() -> int:
         compact_prompt = " ".join(prompt.split())
         assert "state=operator_gate" not in compact_prompt, prompt
         assert "follow `interaction_contract`" in compact_prompt, prompt
-        assert "If action_required/open_count:" in compact_prompt, prompt
+        assert "User NOTIFY: concrete Chinese actions even non_blocking false/0" in compact_prompt, prompt
         assert 'never only "owner gate"' in compact_prompt, prompt
-        assert "spend after writeback" in compact_prompt, prompt
+        assert "具体 user todo 未投影，需修复 LoopX 状态投影" in compact_prompt, prompt
+        assert "Quiet only if DONT_NOTIFY+false/0" in compact_prompt, prompt
+        assert "spend post-writeback" in compact_prompt, prompt
 
     print("blocker-push-runtime-smoke ok")
     return 0

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -621,7 +621,7 @@ def main() -> int:
         assert "--delivery-outcome outcome_progress" in payload["progress_refresh_state_command"], payload
         assert "<PUBLIC_SAFE_PROGRESS_CLASSIFICATION>" in payload["progress_refresh_state_command"], payload
         assert "follow `interaction_contract`" in payload["task_body"], payload
-        assert "spend after writeback" in payload["task_body"], payload
+        assert "spend post-writeback" in payload["task_body"], payload
         assert payload["cli_bin"] == "loopx", payload
 
         canary_cli = subprocess.run(


### PR DESCRIPTION
## Summary
- align installer and blocker-push smoke assertions with the canonical thin heartbeat prompt notification and post-writeback semantics
- validate the current GH-C40 benchmark contributor task through its durable lifecycle/read-model and raw-evidence boundary terms
- keep runtime behavior, benchmark execution/scoring, coverage, and public evidence policy unchanged

## Validation
- `python3 examples/benchmark-developer-workflow-doc-smoke.py`
- `python3 examples/blocker-push-runtime-smoke.py`
- `python3 examples/install-local-smoke.py`
- `python3 examples/canary/canary-promotion-readiness-smoke.py` (passed; dashboard browser portion skipped because local npm dependencies are unavailable)
- Full Public shards at offsets 0, 100, and 300: 300/300 passed, zero failures/timeouts/tracked side effects
- `python3 -m loopx.cli canary premerge --from-git-diff --tier standard`: 4 direct checks and 9 selected checks passed; public-boundary scan clean

## Manual hold
The premerge classifier conservatively marks the PR benchmark-sensitive because one changed validation filename starts with `benchmark-`. The change only updates a documentation smoke to match the existing GH-C40 public task contract; it does not touch an adapter, runner, scoring, task semantics, launch path, or evidence policy. The affected Full Public shard and benchmark boundary canaries passed.

## Boundary
No private state, credentials, raw benchmark evidence, local paths, generated logs, or runtime artifacts are included.