### PR TITLE
Fix wrapped LoopX bridge command enforcement

### DIFF
--- a/examples/skillsbench-goal-start-product-mode-route-smoke.py
+++ b/examples/skillsbench-goal-start-product-mode-route-smoke.py
@@ -138,36 +138,100 @@ def _assert_bridge_rejects_batched_loopx_commands() -> None:
             tmp_path=temp_path,
             summary_path=summary_path,
         )
-        request = {
-            "operation": "exec",
-            "cwd": "/app",
-            "command": (
+        commands = {
+            "newline": (
                 "/app/.local/bin/loopx todo add --goal-id case "
                 "--todo-id todo_agent_first --role agent --text first\n"
                 "/app/.local/bin/loopx todo add --goal-id case "
                 "--todo-id todo_agent_second --role agent --text second"
             ),
+            "if": (
+                "if /app/.local/bin/loopx todo add --goal-id case "
+                "--todo-id todo_agent_first --role agent --text first; then "
+                "/app/.local/bin/loopx todo claim --goal-id case "
+                "--todo-id todo_agent_first --claimed-by agent; fi"
+            ),
+            "command": (
+                "command /app/.local/bin/loopx todo add --goal-id case "
+                "--todo-id todo_agent_first --role agent --text first && "
+                "command /app/.local/bin/loopx todo claim --goal-id case "
+                "--todo-id todo_agent_first --claimed-by agent"
+            ),
+            "nested-shell": "sh -c "
+            + shlex.quote(
+                "/app/.local/bin/loopx todo add --goal-id case "
+                "--todo-id todo_agent_first --role agent --text first; "
+                "/app/.local/bin/loopx todo claim --goal-id case "
+                "--todo-id todo_agent_first --claimed-by agent"
+            ),
         }
-        result = subprocess.run(
-            [str(wrapper)],
-            input=json.dumps(request),
-            text=True,
-            check=False,
-            capture_output=True,
-        )
-        records = [
-            json.loads(line)
-            for line in summary_path.read_text(encoding="utf-8").splitlines()
-        ]
-        marker_exists = marker.exists()
-    assert result.returncode == 2, result
-    assert "exactly one LoopX CLI command" in result.stderr, result.stderr
-    assert marker_exists is False
-    completed = [record for record in records if record.get("record_phase") == "complete"]
-    assert completed[-1]["loopx_invocation_count"] == 2, completed
-    assert completed[-1]["failure_category"] == (
-        "multiple_loopx_commands_per_bridge_request"
-    ), completed
+        for label, command in commands.items():
+            request = {"operation": "exec", "cwd": "/app", "command": command}
+            result = subprocess.run(
+                [str(wrapper)],
+                input=json.dumps(request),
+                text=True,
+                check=False,
+                capture_output=True,
+            )
+            records = [
+                json.loads(line)
+                for line in summary_path.read_text(encoding="utf-8").splitlines()
+            ]
+            assert result.returncode == 2, (label, result)
+            assert "exactly one LoopX CLI command" in result.stderr, (
+                label,
+                result.stderr,
+            )
+            assert marker.exists() is False, label
+            completed = [
+                record for record in records if record.get("record_phase") == "complete"
+            ]
+            assert completed[-1]["loopx_invocation_count"] == 2, (label, completed)
+            assert completed[-1]["failure_category"] == (
+                "multiple_loopx_commands_per_bridge_request"
+            ), (label, completed)
+
+        wrapped_single_commands = {
+            "command": (
+                "command /app/.local/bin/loopx todo add --goal-id case "
+                "--todo-id todo_agent_command --role agent "
+                "--text 'mention sh -c loopx safely'"
+            ),
+            "nested-shell": "sh -c "
+            + shlex.quote(
+                "/app/.local/bin/loopx todo add --goal-id case "
+                "--todo-id todo_agent_nested_shell --role agent --text nested"
+            ),
+        }
+        for label, command in wrapped_single_commands.items():
+            marker.unlink(missing_ok=True)
+            request = {"operation": "exec", "cwd": "/app", "command": command}
+            result = subprocess.run(
+                [str(wrapper)],
+                input=json.dumps(request),
+                text=True,
+                check=False,
+                capture_output=True,
+            )
+            records = [
+                json.loads(line)
+                for line in summary_path.read_text(encoding="utf-8").splitlines()
+            ]
+            assert result.returncode == 0, (label, result)
+            assert marker.exists() is True, label
+            completed = [
+                record for record in records if record.get("record_phase") == "complete"
+            ]
+            assert completed[-1]["loopx_invocation_count"] == 1, (label, completed)
+            assert completed[-1]["loopx_subcommands"] == ["todo", "add"], (
+                label,
+                completed,
+            )
+            assert completed[-1]["loopx_todo_id"] == f"todo_agent_{label.replace('-', '_')}", (
+                label,
+                completed,
+            )
 
 
 def _assert_generated_prompt_requires_agent_authored_separate_requests() -> None:

--- a/examples/skillsbench-reverse-channel-bridge-smoke.py
+++ b/examples/skillsbench-reverse-channel-bridge-smoke.py
@@ -137,38 +137,60 @@ def test_prompt_bridge_rejects_batched_loopx_commands() -> None:
             ),
             private_bridge_command=None,
         )
-        request = {
-            "operation": "exec",
-            "cwd": "/app",
-            "command": (
+        commands = {
+            "newline": (
                 "/app/.local/bin/loopx todo add --goal-id case "
                 "--todo-id todo_agent_first --role agent --text first\n"
                 "/app/.local/bin/loopx todo claim --goal-id case "
                 "--todo-id todo_agent_first --claimed-by agent"
             ),
+            "if": (
+                "if /app/.local/bin/loopx todo add --goal-id case "
+                "--todo-id todo_agent_first --role agent --text first; then "
+                "/app/.local/bin/loopx todo claim --goal-id case "
+                "--todo-id todo_agent_first --claimed-by agent; fi"
+            ),
+            "command": (
+                "command /app/.local/bin/loopx todo add --goal-id case "
+                "--todo-id todo_agent_first --role agent --text first && "
+                "command /app/.local/bin/loopx todo claim --goal-id case "
+                "--todo-id todo_agent_first --claimed-by agent"
+            ),
+            "nested-shell": "sh -c "
+            + shlex.quote(
+                "/app/.local/bin/loopx todo add --goal-id case "
+                "--todo-id todo_agent_first --role agent --text first; "
+                "/app/.local/bin/loopx todo claim --goal-id case "
+                "--todo-id todo_agent_first --claimed-by agent"
+            ),
         }
-        result = subprocess.run(
-            [str(wrapper)],
-            input=json.dumps(request),
-            check=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-        records = [
-            json.loads(line)
-            for line in summary_path.read_text(encoding="utf-8").splitlines()
-        ]
-        marker_exists = marker.exists()
-
-    assert result.returncode == 2, result
-    assert "exactly one LoopX CLI command" in result.stderr, result.stderr
-    assert marker_exists is False
-    completed = [record for record in records if record.get("record_phase") == "complete"]
-    assert completed[-1]["loopx_invocation_count"] == 2, completed
-    assert completed[-1]["failure_category"] == (
-        "multiple_loopx_commands_per_bridge_request"
-    ), completed
+        for label, command in commands.items():
+            request = {"operation": "exec", "cwd": "/app", "command": command}
+            result = subprocess.run(
+                [str(wrapper)],
+                input=json.dumps(request),
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            records = [
+                json.loads(line)
+                for line in summary_path.read_text(encoding="utf-8").splitlines()
+            ]
+            assert result.returncode == 2, (label, result)
+            assert "exactly one LoopX CLI command" in result.stderr, (
+                label,
+                result.stderr,
+            )
+            assert marker.exists() is False, label
+            completed = [
+                record for record in records if record.get("record_phase") == "complete"
+            ]
+            assert completed[-1]["loopx_invocation_count"] == 2, (label, completed)
+            assert completed[-1]["failure_category"] == (
+                "multiple_loopx_commands_per_bridge_request"
+            ), (label, completed)
 
 
 def test_codex_client_writes_last_message_and_rewrites_bridge() -> None:

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -2334,10 +2334,8 @@ SAFE_LOOPX_TODO_ID_RE = re.compile(r"^todo_[A-Za-z0-9_-]{{6,80}}$")
 SAFE_LOOPX_GOAL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{{0,120}}$")
 
 def loopx_public_fields(command: str) -> dict[str, str]:
-    try:
-        tokens = shlex.split(command or "")
-    except ValueError:
-        tokens = (command or "").split()
+    invocations = loopx_invocation_argvs(command)
+    tokens = invocations[0] if invocations else []
     fields: dict[str, str] = {{}}
     i = 0
     while i < len(tokens):

--- a/loopx/benchmark_adapters/skillsbench_bridge_guard.py
+++ b/loopx/benchmark_adapters/skillsbench_bridge_guard.py
@@ -2,21 +2,108 @@ from __future__ import annotations
 
 
 LOOPX_COMMAND_INSTRUMENTATION_SOURCE = r'''
-def loopx_subcommands(command: str) -> list[str]:
+_SHELL_COMMAND_PREFIXES = {
+    "if", "then", "elif", "else", "while", "until", "do", "!", "time", "{",
+}
+_SHELL_COMMAND_WRAPPERS = {"command", "exec", "builtin", "nohup"}
+_NESTED_SHELLS = {"sh", "bash", "dash", "zsh", "ksh"}
+
+def _shell_tokens(command: str) -> list[str]:
     try:
-        tokens = shlex.split(command or "")
+        lexer = shlex.shlex(
+            command or "",
+            posix=True,
+            punctuation_chars=";&|()" + chr(10),
+        )
+        lexer.whitespace = " " + chr(9) + chr(13)
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        return list(lexer)
     except ValueError:
-        tokens = (command or "").split()
-    index = next(
-        (
-            offset
-            for offset, token in enumerate(tokens)
-            if token == "loopx" or token.endswith("/loopx")
-        ),
-        -1,
-    )
-    if index < 0:
+        return (command or "").replace(chr(10), " ; ").split()
+
+def _shell_basename(token: str) -> str:
+    return token.rsplit("/", 1)[-1]
+
+def _shell_separator(token: str) -> bool:
+    return bool(token) and all(char in ";&|()" or char == chr(10) for char in token)
+
+def _nested_shell_command(tokens: list[str], index: int) -> str | None:
+    cursor = index + 1
+    while cursor < len(tokens) and not _shell_separator(tokens[cursor]):
+        option = tokens[cursor]
+        if option == "--":
+            cursor += 1
+            continue
+        if option == "--command" or (
+            option.startswith("-")
+            and not option.startswith("--")
+            and "c" in option[1:]
+        ):
+            return tokens[cursor + 1] if cursor + 1 < len(tokens) else None
+        if not option.startswith("-"):
+            return None
+        cursor += 1
+    return None
+
+def loopx_invocation_argvs(command: str, *, _depth: int = 0) -> list[list[str]]:
+    tokens = _shell_tokens(command)
+    invocations: list[list[str]] = []
+    assignment_re = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*$")
+    expect_command = True
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if _shell_separator(token):
+            expect_command = True
+            index += 1
+            continue
+        if not expect_command:
+            index += 1
+            continue
+        basename = _shell_basename(token)
+        if token in _SHELL_COMMAND_PREFIXES or assignment_re.match(token):
+            index += 1
+            continue
+        if basename in _SHELL_COMMAND_WRAPPERS:
+            index += 1
+            while index < len(tokens) and tokens[index].startswith("-"):
+                index += 1
+            continue
+        if basename == "env":
+            index += 1
+            while index < len(tokens) and (
+                tokens[index].startswith("-") or assignment_re.match(tokens[index])
+            ):
+                index += 1
+            continue
+        if basename in _NESTED_SHELLS:
+            nested = _nested_shell_command(tokens, index)
+            if nested is not None:
+                if _depth < 4:
+                    invocations.extend(loopx_invocation_argvs(nested, _depth=_depth + 1))
+                elif any(
+                    _shell_basename(item) == "loopx" for item in _shell_tokens(nested)
+                ):
+                    # Depth-limited nested shell requests are ambiguous; reject closed.
+                    invocations.extend([["loopx"], ["loopx"]])
+            expect_command = False
+            index += 1
+            continue
+        if basename == "loopx":
+            end = index + 1
+            while end < len(tokens) and not _shell_separator(tokens[end]):
+                end += 1
+            invocations.append(tokens[index:end])
+        expect_command = False
+        index += 1
+    return invocations
+
+def loopx_subcommands(command: str) -> list[str]:
+    invocations = loopx_invocation_argvs(command)
+    if not invocations:
         return []
+    tokens = invocations[0]
     out: list[str] = []
     skip = False
     valued_options = {
@@ -26,7 +113,7 @@ def loopx_subcommands(command: str) -> list[str]:
         "--agent-id", "--host-surface", "--role", "--task-class",
         "--action-kind", "--text",
     }
-    for token in tokens[index + 1:]:
+    for token in tokens[1:]:
         if skip:
             skip = False
             continue
@@ -43,46 +130,7 @@ def loopx_subcommands(command: str) -> list[str]:
     return out
 
 def loopx_invocation_count(command: str) -> int:
-    try:
-        lexer = shlex.shlex(
-            command or "",
-            posix=True,
-            punctuation_chars=";&|" + chr(10),
-        )
-        lexer.whitespace = " " + chr(9) + chr(13)
-        lexer.whitespace_split = True
-        lexer.commenters = ""
-        tokens = list(lexer)
-    except ValueError:
-        tokens = (command or "").replace(chr(10), " ; ").split()
-    segments = []
-    current = []
-    for token in tokens:
-        if token and all(char in ";&|" or char == chr(10) for char in token):
-            if current:
-                segments.append(current)
-                current = []
-            continue
-        current.append(token)
-    if current:
-        segments.append(current)
-
-    count = 0
-    assignment_re = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*$")
-    for segment in segments:
-        index = 0
-        while index < len(segment) and assignment_re.match(segment[index]):
-            index += 1
-        if index < len(segment) and segment[index] == "env":
-            index += 1
-            while index < len(segment) and (
-                segment[index].startswith("-")
-                or assignment_re.match(segment[index])
-            ):
-                index += 1
-        if index < len(segment) and segment[index].rsplit("/", 1)[-1] == "loopx":
-            count += 1
-    return count
+    return len(loopx_invocation_argvs(command))
 
 def enforce_single_loopx_invocation(count, record, append_record) -> None:
     if count <= 1:


### PR DESCRIPTION
## Summary

- recognize LoopX invocations at shell command positions under `if`/`then`, `command`/`exec`/`env`, separators, pipes, and subshells
- recursively inspect literal `sh`/`bash`/`dash`/`zsh`/`ksh -c` commands and fail closed at the recursion boundary
- derive ACP public-safe goal/todo fields from the recognized first LoopX argv so allowed single wrapped commands remain countable
- cover newline, `if`, `command`, and nested-shell multi-command rejection on both generated bridge paths, plus allowed single wrapped commands

## Product / architecture judgment

This closes the remaining fidelity blocker from #2052: ordinary shell wrappers could execute multiple LoopX lifecycle commands while the public trace projected only one. The fix stays in the shared bridge instrumentation seam used by ACP and reverse-channel wrappers. It does not change SkillsBench scoring, task semantics, runner launch behavior, or submission behavior.

## Validation

- `python3 examples/skillsbench-goal-start-product-mode-route-smoke.py`
- `python3 examples/skillsbench-reverse-channel-bridge-smoke.py`
- `python3 examples/benchmark-case-active-state-contract-smoke.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- changed-file `py_compile`
- `git diff --check`
- `loopx check` on all four changed paths: 9 checks, 0 errors/warnings
- standard premerge: 7/7 executed checks passed, 0 failures, 0 warnings; public boundary clean

## Holds / exclusions

- The standard premerge gate retains one benchmark-sensitive manual review hold. Owner-authorized self-merge is limited to this narrow public helper/runtime repair after GitHub CI passes.
- No benchmark job was launched.
- No scoring, task semantics, permission boundary, raw benchmark evidence, private state, credentials, local paths, or generated logs are included.
