### PR TITLE
Add first-class Explore board styles

### DIFF
--- a/docs/capabilities/explore/README.md
+++ b/docs/capabilities/explore/README.md
@@ -681,10 +681,22 @@ Base rows and rendered graphs are different delivery receipts. Configure the
 Docx and its first whiteboard with `explore feishu-visual-configure`; the Docx
 may be a root-level resource inside the same Base so the graph and Kanban share
 one operator entry point. Each bounded Evidence Stage owns one document section
-and one independent Mermaid whiteboard. Missing sections and blank whiteboards
-are created automatically when the sink has a Docx token. Stage capacity is
+and one independent whiteboard. Missing sections and blank whiteboards are
+created automatically when the sink has a Docx token. Stage capacity is
 configurable from 10 through 20 nodes and defaults to 14. Full Nodes, Edges, and
 Findings always remain in the canonical Base.
+
+`board_style` is the first-class layout contract and is independent from
+`projection_mode`, which controls evidence selection. Two styles are supported:
+
+| Board style | Best fit | Rendering behavior |
+| --- | --- | --- |
+| `auto_flow` | Generic or single-lane Explore graphs | Mermaid chooses the graph layout while LoopX preserves stage order, lanes, statuses, and real directed edges. |
+| `semantic_lane_columns` | Operator boards with meaningful parallel lanes such as PR issue-fix and capability work | LoopX emits deterministic SVG columns, keeps each lane top-to-bottom, and draws the real within-stage directed edges. |
+
+The renderer (`mermaid` or `stage_svg`) is an implementation detail derived
+from `board_style`. Existing local configs that only store `renderer=mermaid`
+remain readable as `auto_flow`.
 
 A material sync checkpoints `canonical_rows_semantic_digest`
 and `visual_semantic_digest` independently. If whiteboard publication fails
@@ -719,6 +731,7 @@ loopx explore feishu-visual-configure \
   --whiteboard-token <executive-token> \
   --docx-token <executive-doc-token> \
   --stage-capacity 14 \
+  --board-style semantic_lane_columns \
   --execute
 ```
 
@@ -753,7 +766,7 @@ loopx explore graph --goal-id <id> [--graph-format mermaid|json] [--out <file>]
 loopx explore todo-branch-plan --goal-id <id> [--agent-id <agent>] [--width 3]
 loopx explore worker-branch-plan --goal-id <id> [--agent-id <agent>] [--harness-profile generic|adaptive-resilient|moe-router] [--worker-width 3] [--max-todos-per-branch 3] [--router-state <file>] [--load-profile <file>]
 loopx explore feishu-setup [--base-url ...] [--execute]
-loopx explore feishu-visual-configure [--whiteboard-token <token>] --docx-token <token> [--stage-whiteboard-token <token> ...] [--stage-capacity 10..20] [--view-role canonical|executive] [--projection-mode canonical_filtered|issue_fix_two_lane|canonical_full|executive_auto] [--tag <tag>] [--status <status>] [--execute]
+loopx explore feishu-visual-configure [--whiteboard-token <token>] --docx-token <token> [--stage-whiteboard-token <token> ...] [--stage-capacity 10..20] [--board-style auto_flow|semantic_lane_columns] [--view-role canonical|executive] [--projection-mode canonical_filtered|issue_fix_two_lane|canonical_full|executive_auto] [--tag <tag>] [--status <status>] [--execute]
 loopx explore feishu-sync --goal-id <id> [--sink-visibility owner-only|shared] [--execute]
 loopx explore feishu-card --goal-id <id> [--card-file <file>] [--message-id om_...]
 ```

--- a/examples/explore-result-layer-smoke.py
+++ b/examples/explore-result-layer-smoke.py
@@ -1264,7 +1264,7 @@ def check_cli_surface() -> None:
             ("canonical", "canonical_full"),
             ("executive", "executive_auto"),
         ):
-            role_config = run_cli(
+            role_args = [
                 "explore",
                 "feishu-visual-configure",
                 "--config-path",
@@ -1275,9 +1275,18 @@ def check_cli_surface() -> None:
                 role,
                 "--projection-mode",
                 mode,
-                "--execute",
-            )
+            ]
+            if role == "executive":
+                role_args.extend(
+                    ["--board-style", "semantic_lane_columns"]
+                )
+            role_args.append("--execute")
+            role_config = run_cli(*role_args)
             assert role_config["status"] == "configured", role_config
+            expected_style = (
+                "semantic_lane_columns" if role == "executive" else "auto_flow"
+            )
+            assert role_config["visual_sink"]["board_style"] == expected_style, role_config
         dual_config_sync = run_cli(
             "explore",
             "feishu-sync",

--- a/loopx/cli_commands/explore.py
+++ b/loopx/cli_commands/explore.py
@@ -232,6 +232,16 @@ def register_explore_commands(
     )
     visual.add_argument("--mermaid-node-limit", type=int, default=100)
     visual.add_argument(
+        "--board-style",
+        choices=["auto_flow", "semantic_lane_columns"],
+        default="auto_flow",
+        help=(
+            "Whiteboard layout style. auto_flow uses Mermaid's generic graph "
+            "layout; semantic_lane_columns fixes semantic lanes into "
+            "left/right columns while retaining real directed edges."
+        ),
+    )
+    visual.add_argument(
         "--stage-capacity",
         type=int,
         default=14,
@@ -789,6 +799,7 @@ def handle_explore_command(
                 mermaid_node_limit=args.mermaid_node_limit,
                 stage_capacity=args.stage_capacity,
                 stage_whiteboard_tokens=args.stage_whiteboard_token,
+                board_style=args.board_style,
                 view_role=args.view_role,
                 execute=bool(args.execute),
             )

--- a/loopx/presentation/explore_views.py
+++ b/loopx/presentation/explore_views.py
@@ -8,6 +8,7 @@ truncates the canonical node, edge, or finding collections.
 from __future__ import annotations
 
 import hashlib
+import html
 import json
 import re
 import unicodedata
@@ -80,6 +81,139 @@ _MERMAID_STATUS_CLASS = {
     "resolved": "resolved",
     "dead_end": "deadend",
 }
+
+_SVG_STATUS_STYLE = {
+    "open": ("#f5f5f5", "#9e9e9e"),
+    "exploring": ("#e3f2fd", "#1e88e5"),
+    "blocked": ("#ffebee", "#e53935"),
+    "resolved": ("#e8f5e9", "#43a047"),
+    "dead_end": ("#eeeeee", "#9e9e9e"),
+}
+
+
+def build_stage_lane_svg(
+    *,
+    title: str,
+    node_order: Sequence[str],
+    node_by_id: Mapping[str, Mapping[str, Any]],
+    edges: Sequence[Mapping[str, Any]],
+) -> str:
+    """Render one Evidence Stage as fixed left/right semantic lanes.
+
+    Mermaid ignores a nested subgraph's direction when one of its nodes has an
+    edge to another subgraph. That turns intended vertical lanes into a wide
+    card row on the real whiteboard renderer. SVG keeps the semantic lane and
+    edge model while making placement deterministic.
+    """
+
+    lane_nodes: dict[str, list[str]] = defaultdict(list)
+    for node_id in node_order:
+        lane_nodes[_explore_lane(node_by_id[node_id], node_by_id=node_by_id)].append(
+            node_id
+        )
+    preferred = [lane for lane in ("fix_pr", "capability") if lane in lane_nodes]
+    lanes = preferred + sorted(lane for lane in lane_nodes if lane not in preferred)
+    margin, lane_width, lane_gap = 32, 500, 44
+    lane_top, lane_header_height, lane_padding = 76, 48, 24
+    node_width, node_height, node_gap = 436, 96, 34
+    max_lane_nodes = max((len(lane_nodes[lane]) for lane in lanes), default=1)
+    lane_height = (
+        lane_header_height
+        + lane_padding * 2
+        + max_lane_nodes * node_height
+        + max(0, max_lane_nodes - 1) * node_gap
+    )
+    width = margin * 2 + len(lanes) * lane_width + max(0, len(lanes) - 1) * lane_gap
+    height = lane_top + lane_height + margin
+    positions: dict[str, tuple[float, float]] = {}
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">',
+        "<defs>",
+        '<marker id="loopx-arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">',
+        '<path d="M0,0 L0,6 L9,3 z" fill="#607d8b"/>',
+        "</marker>",
+        "</defs>",
+        '<rect width="100%" height="100%" fill="#ffffff"/>',
+        f'<text x="{width / 2:.1f}" y="34" text-anchor="middle" font-family="Arial, sans-serif" font-size="20" font-weight="700" fill="#263238">{html.escape(title)}</text>',
+    ]
+    lane_titles = {"fix_pr": "PR issue-fix", "capability": "LoopX capability"}
+    for lane_index, lane in enumerate(lanes):
+        lane_x = margin + lane_index * (lane_width + lane_gap)
+        parts.extend(
+            [
+                f'<rect x="{lane_x}" y="{lane_top}" width="{lane_width}" height="{lane_height}" rx="16" fill="#fffde7" stroke="#c0b94f" stroke-width="2"/>',
+                f'<text x="{lane_x + lane_width / 2:.1f}" y="{lane_top + 31}" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" font-weight="700" fill="#37474f">{html.escape(lane_titles.get(lane, lane.replace("_", " ").title()))}</text>',
+            ]
+        )
+        node_x = lane_x + (lane_width - node_width) / 2
+        node_y = lane_top + lane_header_height + lane_padding
+        for offset, node_id in enumerate(lane_nodes[lane]):
+            positions[node_id] = (node_x, node_y + offset * (node_height + node_gap))
+
+    edge_parts: list[str] = []
+    grouped_edges: dict[tuple[str, str], set[str]] = {}
+    for edge in edges:
+        source_id = str(edge.get("from_node") or "")
+        target_id = str(edge.get("to_node") or "")
+        if source_id not in positions or target_id not in positions:
+            continue
+        grouped_edges.setdefault((source_id, target_id), set()).add(
+            str(edge.get("edge_type") or "").strip()
+        )
+    for (source_id, target_id), edge_types in grouped_edges.items():
+        source_x, source_y = positions[source_id]
+        target_x, target_y = positions[target_id]
+        same_lane = _explore_lane(
+            node_by_id[source_id], node_by_id=node_by_id
+        ) == _explore_lane(node_by_id[target_id], node_by_id=node_by_id)
+        if same_lane:
+            if target_y >= source_y:
+                start_x = source_x + node_width / 2
+                end_x = target_x + node_width / 2
+                start_y = source_y + node_height
+                end_y = target_y
+                middle_y = (start_y + end_y) / 2
+                path = f"M {start_x:.1f} {start_y:.1f} C {start_x:.1f} {middle_y:.1f}, {end_x:.1f} {middle_y:.1f}, {end_x:.1f} {end_y:.1f}"
+            else:
+                start_x = source_x + node_width
+                end_x = target_x + node_width
+                start_y = source_y + node_height / 2
+                end_y = target_y + node_height / 2
+                side_x = max(source_x, target_x) + node_width + 18
+                path = f"M {start_x:.1f} {start_y:.1f} C {side_x:.1f} {start_y:.1f}, {side_x:.1f} {end_y:.1f}, {end_x:.1f} {end_y:.1f}"
+        else:
+            left_to_right = source_x < target_x
+            start_x = source_x + (node_width if left_to_right else 0)
+            end_x = target_x + (0 if left_to_right else node_width)
+            start_y = source_y + node_height / 2
+            end_y = target_y + node_height / 2
+            middle_x = (start_x + end_x) / 2
+            path = f"M {start_x:.1f} {start_y:.1f} C {middle_x:.1f} {start_y:.1f}, {middle_x:.1f} {end_y:.1f}, {end_x:.1f} {end_y:.1f}"
+        label = " / ".join(sorted(edge_type for edge_type in edge_types if edge_type))
+        edge_parts.append(
+            f'<path d="{path}" data-edge-types="{html.escape(label)}" fill="none" stroke="#607d8b" stroke-width="2" marker-end="url(#loopx-arrow)"/>'
+        )
+    parts.extend(edge_parts)
+    for node_id in node_order:
+        node = node_by_id[node_id]
+        node_x, node_y = positions[node_id]
+        fill, stroke = _SVG_STATUS_STYLE.get(
+            str(node.get("status") or "open"), _SVG_STATUS_STYLE["open"]
+        )
+        parts.append(
+            f'<rect x="{node_x:.1f}" y="{node_y:.1f}" width="{node_width}" height="{node_height}" rx="10" fill="{fill}" stroke="{stroke}" stroke-width="2"/>'
+        )
+        display_lines = _node_display_lines(
+            node, title_limit=54, detail_limit=76
+        )[:3]
+        for line_index, line in enumerate(display_lines):
+            weight = "700" if line_index == 0 else "400"
+            size = 14 if line_index == 0 else 12
+            parts.append(
+                f'<text x="{node_x + node_width / 2:.1f}" y="{node_y + 27 + line_index * 24:.1f}" text-anchor="middle" font-family="Arial, sans-serif" font-size="{size}" font-weight="{weight}" fill="#263238">{html.escape(line)}</text>'
+            )
+    parts.append("</svg>")
+    return "\n".join(parts)
 
 
 def _material_rows(values: Sequence[Any] | None, *, id_key: str) -> list[dict[str, Any]]:
@@ -556,6 +690,12 @@ def build_vertical_explore_mermaid(
             if str(edge.get("from_node") or "") in stage_node_ids
             and str(edge.get("to_node") or "") not in stage_node_ids
         ]
+        stage_svg = build_stage_lane_svg(
+            title=group["title"],
+            node_order=stage_node_order,
+            node_by_id=node_by_id,
+            edges=stage_edges,
+        )
         stage_views.append(
             {
                 "stage_index": group_index,
@@ -606,6 +746,21 @@ def build_vertical_explore_mermaid(
                 "incoming_edge_count": len(incoming_edges),
                 "outgoing_edge_count": len(outgoing_edges),
                 "mermaid": "\n".join(stage_lines),
+                "svg": stage_svg,
+                "svg_layout": {
+                    "strategy": "semantic_lane_columns",
+                    "lane_order": [
+                        lane
+                        for lane in ("fix_pr", "capability")
+                        if lane in stage_lanes
+                    ]
+                    + sorted(
+                        lane
+                        for lane in stage_lanes
+                        if lane not in {"fix_pr", "capability"}
+                    ),
+                    "orientation": "left_to_right_lanes_top_to_bottom_nodes",
+                },
             }
         )
     for previous, current in zip(group_chains, group_chains[1:]):

--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -58,6 +58,12 @@ from .kanban import (
     parse_lark_base_url,
 )
 from .explore_stage_document import ensure_stage_whiteboards
+from .explore_visual_styles import (
+    BOARD_STYLE_AUTO_FLOW,
+    board_source_with_delivery_marker,
+    explore_board_style,
+    resolve_explore_board_style,
+)
 from .message_card import build_lark_markdown_reply_card
 
 LARK_EXPLORE_SCHEMA_VERSION = "loopx_lark_explore_result_board_v0"
@@ -72,8 +78,6 @@ DEFAULT_EXPLORE_BASE_NAME = "LoopX Exploration Results"
 SINK_VISIBILITY_OWNER_ONLY = "owner-only"
 SINK_VISIBILITY_SHARED = "shared"
 SINK_VISIBILITIES = {SINK_VISIBILITY_OWNER_ONLY, SINK_VISIBILITY_SHARED}
-VISUAL_RENDERER_MERMAID = "mermaid"
-VISUAL_RENDERERS = {VISUAL_RENDERER_MERMAID}
 
 _VISUAL_READBACK_RETRY_DELAYS_SECONDS = (0.25, 0.5, 1.0, 2.0, 4.0)
 
@@ -473,6 +477,7 @@ def configure_lark_explore_visual_sink(
     mermaid_node_limit: int = 100,
     stage_capacity: int = 14,
     stage_whiteboard_tokens: list[str] | None = None,
+    board_style: str = BOARD_STYLE_AUTO_FLOW,
     view_role: str | None = None,
     execute: bool = False,
 ) -> dict[str, Any]:
@@ -498,6 +503,7 @@ def configure_lark_explore_visual_sink(
         raise ValueError(f"view_role {role} requires projection_mode {expected_mode}")
     if not 10 <= int(stage_capacity) <= 20:
         raise ValueError("stage_capacity must be between 10 and 20")
+    style = explore_board_style(board_style)
     tokens = [
         str(item).strip()
         for item in stage_whiteboard_tokens or []
@@ -520,7 +526,8 @@ def configure_lark_explore_visual_sink(
         "include_ancestors": bool(include_ancestors),
         "mermaid_node_limit": max(1, int(mermaid_node_limit)),
         "stage_capacity": int(stage_capacity),
-        "renderer": VISUAL_RENDERER_MERMAID,
+        "board_style": style.name,
+        "renderer": style.renderer,
         "presentation_mode": "stage_document",
         "stage_whiteboards": [
             {"stage_index": index, "whiteboard_token": stage_token}
@@ -547,17 +554,6 @@ def configure_lark_explore_visual_sink(
         "view_role": role,
         "visual_sink": visual_sink,
     }
-
-
-def _mermaid_with_delivery_marker(source: str, marker: str) -> str:
-    marker_id = f"loopx_delivery_{hashlib.sha256(marker.encode('utf-8')).hexdigest()[:10]}"
-    return "\n".join(
-        [
-            source.rstrip(),
-            f'    {marker_id}["{marker}"]',
-            f"    style {marker_id} fill:#ffffff,stroke:#ffffff,color:#ffffff",
-        ]
-    )
 
 
 def _whiteboard_raw_texts(payload: Any) -> list[str]:
@@ -728,21 +724,18 @@ def sync_explore_visual_to_lark(
         )
     )
     sink_key = str(view_key or visual_sink.get("view_role") or "visual").strip() or "visual"
-    renderer = str(visual_sink.get("renderer") or VISUAL_RENDERER_MERMAID).strip()
-    if renderer != VISUAL_RENDERER_MERMAID:
+    try:
+        style = resolve_explore_board_style(visual_sink)
+    except ValueError as exc:
         return {
             "ok": False,
             "schema_version": LARK_EXPLORE_VISUAL_SYNC_VERSION,
             "status": "invalid_config",
             "execute": execute,
             "published": False,
-            "error": (
-                "grid/SVG Explore renderers were removed; migrate this sink to "
-                "renderer=mermaid with one whiteboard per Evidence Stage"
-            ),
+            "error": str(exc),
         }
-    source_key, input_format, extension = ("mermaid", "mermaid", "mmd")
-    rendered_source = str(graph.get(source_key) or "")
+    rendered_source = str(graph.get(style.source_key) or "")
     if not rendered_source.strip():
         return {
             "ok": False,
@@ -751,8 +744,8 @@ def sync_explore_visual_to_lark(
             "execute": execute,
             "published": False,
             "view_role": str(graph.get("view_role") or sink_key),
-            "renderer": renderer,
-            "error": f"display projection does not contain {source_key} source",
+            "renderer": style.renderer,
+            "error": f"display projection does not contain {style.source_key} source",
         }
     delivery_material = json.dumps(
         {
@@ -760,7 +753,8 @@ def sync_explore_visual_to_lark(
             "source_revision": source_revision,
             "view_role": sink_key,
             "whiteboard_token": whiteboard_token,
-            "renderer": renderer,
+            "board_style": style.name,
+            "renderer": style.renderer,
             "rendered_source": rendered_source,
         },
         ensure_ascii=True,
@@ -769,11 +763,12 @@ def sync_explore_visual_to_lark(
     ).encode("utf-8")
     delivery_digest = hashlib.sha256(delivery_material).hexdigest()
     delivery_marker = f"LoopX delivery {delivery_digest[:20]}"
-    published_source = _mermaid_with_delivery_marker(
+    published_source = board_source_with_delivery_marker(
         rendered_source,
         delivery_marker,
+        style=style,
     )
-    source_name = f".loopx-explore-{sink_key}-{delivery_digest[:12]}.{extension}"
+    source_name = f".loopx-explore-{sink_key}-{delivery_digest[:12]}.{style.extension}"
     command = [
         config.cli_bin,
         "whiteboard",
@@ -783,7 +778,7 @@ def sync_explore_visual_to_lark(
         "--whiteboard-token",
         whiteboard_token,
         "--input_format",
-        input_format,
+        style.input_format,
         "--source",
         f"@{source_name}",
         "--overwrite",
@@ -873,8 +868,9 @@ def sync_explore_visual_to_lark(
         "source_digest": source_digest,
         "source_revision": source_revision,
         "view_role": str(graph.get("view_role") or sink_key),
-        "renderer": renderer,
-        "input_format": input_format,
+        "board_style": style.name,
+        "renderer": style.renderer,
+        "input_format": style.input_format,
         "docx_token": str(visual_sink.get("docx_token") or "") or None,
         "graph_counts": graph.get("graph_counts"),
         "filter": graph.get("filter"),
@@ -1035,7 +1031,16 @@ def sync_explore_visuals_to_lark(
             "execute": execute,
             "published": bool(execute and role_ok),
             "view_role": role,
-            "renderer": VISUAL_RENDERER_MERMAID,
+            "board_style": (
+                str(stage_results[0].get("board_style") or "")
+                if stage_results
+                else ""
+            ),
+            "renderer": (
+                str(stage_results[0].get("renderer") or "")
+                if stage_results
+                else ""
+            ),
             "presentation_mode": "stage_document",
             "source_digest": role_bundle["source_digest"],
             "source_revision": role_bundle["source_revision"],

--- a/loopx/presentation/sinks/lark/explore_visual_styles.py
+++ b/loopx/presentation/sinks/lark/explore_visual_styles.py
@@ -1,0 +1,96 @@
+"""First-class Explore board styles and their Lark rendering contracts."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+BOARD_STYLE_AUTO_FLOW = "auto_flow"
+BOARD_STYLE_SEMANTIC_LANE_COLUMNS = "semantic_lane_columns"
+
+
+@dataclass(frozen=True)
+class ExploreBoardStyle:
+    name: str
+    renderer: str
+    source_key: str
+    input_format: str
+    extension: str
+
+
+_BOARD_STYLES = {
+    BOARD_STYLE_AUTO_FLOW: ExploreBoardStyle(
+        name=BOARD_STYLE_AUTO_FLOW,
+        renderer="mermaid",
+        source_key="mermaid",
+        input_format="mermaid",
+        extension="mmd",
+    ),
+    BOARD_STYLE_SEMANTIC_LANE_COLUMNS: ExploreBoardStyle(
+        name=BOARD_STYLE_SEMANTIC_LANE_COLUMNS,
+        renderer="stage_svg",
+        source_key="svg",
+        input_format="svg",
+        extension="svg",
+    ),
+}
+BOARD_STYLES = frozenset(_BOARD_STYLES)
+_RENDERER_BOARD_STYLES = {
+    style.renderer: style for style in _BOARD_STYLES.values()
+}
+
+
+def explore_board_style(name: str) -> ExploreBoardStyle:
+    style_name = str(name or BOARD_STYLE_AUTO_FLOW).strip()
+    if style_name not in _BOARD_STYLES:
+        raise ValueError(f"board_style must be one of {sorted(BOARD_STYLES)}")
+    return _BOARD_STYLES[style_name]
+
+
+def resolve_explore_board_style(
+    visual_sink: Mapping[str, Any],
+) -> ExploreBoardStyle:
+    """Resolve new style configs plus legacy renderer-only Mermaid configs."""
+
+    style_name = str(visual_sink.get("board_style") or "").strip()
+    renderer = str(visual_sink.get("renderer") or "").strip()
+    if style_name:
+        style = explore_board_style(style_name)
+        if renderer and renderer != style.renderer:
+            raise ValueError(
+                f"board_style {style.name} requires renderer {style.renderer}"
+            )
+        return style
+    renderer = renderer or "mermaid"
+    if renderer not in _RENDERER_BOARD_STYLES:
+        raise ValueError(
+            "legacy grid/SVG Explore renderers were removed; use "
+            "board_style=auto_flow or board_style=semantic_lane_columns"
+        )
+    return _RENDERER_BOARD_STYLES[renderer]
+
+
+def board_source_with_delivery_marker(
+    source: str,
+    marker: str,
+    *,
+    style: ExploreBoardStyle,
+) -> str:
+    if style.input_format == "svg":
+        marker_text = (
+            f'<text x="1" y="1" fill="#ffffff" font-size="1">{marker}</text>'
+        )
+        closing = source.rfind("</svg>")
+        if closing < 0:
+            raise ValueError("stage SVG source is missing the closing </svg> tag")
+        return source[:closing] + marker_text + source[closing:]
+    marker_id = f"loopx_delivery_{hashlib.sha256(marker.encode('utf-8')).hexdigest()[:10]}"
+    return "\n".join(
+        [
+            source.rstrip(),
+            f'    {marker_id}["{marker}"]',
+            f"    style {marker_id} fill:#ffffff,stroke:#ffffff,color:#ffffff",
+        ]
+    )

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -455,6 +455,15 @@ def test_stage_board_preserves_two_lanes_and_real_cross_lane_relation() -> None:
     assert 'subgraph canonical_stage_1_lane_2["LoopX capability"]' in stage["mermaid"]
     assert "fix_pr -->|supports| durable_capability" in stage["mermaid"]
     assert "edge-fix-subtopic" not in stage["mermaid"]
+    assert stage["svg_layout"] == {
+        "strategy": "semantic_lane_columns",
+        "lane_order": ["capability", "delivery"],
+        "orientation": "left_to_right_lanes_top_to_bottom_nodes",
+    }
+    assert stage["svg"].startswith('<svg xmlns="http://www.w3.org/2000/svg"')
+    assert "LoopX capability" in stage["svg"]
+    assert "supports" in stage["svg"]
+    assert 'marker-end="url(#loopx-arrow)"' in stage["svg"]
 
 
 def test_single_lane_project_does_not_invent_a_second_lane() -> None:
@@ -555,6 +564,7 @@ def test_visual_configuration_preserves_legacy_and_supports_stage_boards(tmp_pat
         view_role="executive",
         stage_capacity=18,
         stage_whiteboard_tokens=["wb_executive_fixture", "wb_stage_02"],
+        board_style="semantic_lane_columns",
         execute=True,
     )
 
@@ -562,7 +572,11 @@ def test_visual_configuration_preserves_legacy_and_supports_stage_boards(tmp_pat
     assert stored["visual_sink"]["whiteboard_token"] == "wb_legacy_fixture"
     assert stored["visual_sinks"]["canonical"]["view_role"] == "canonical"
     assert stored["visual_sinks"]["executive"]["view_role"] == "executive"
-    assert stored["visual_sinks"]["executive"]["renderer"] == "mermaid"
+    assert (
+        stored["visual_sinks"]["executive"]["board_style"]
+        == "semantic_lane_columns"
+    )
+    assert stored["visual_sinks"]["executive"]["renderer"] == "stage_svg"
     assert stored["visual_sinks"]["executive"]["presentation_mode"] == "stage_document"
     assert stored["visual_sinks"]["executive"]["stage_capacity"] == 18
     assert stored["visual_sinks"]["executive"]["stage_whiteboards"] == [
@@ -782,7 +796,75 @@ def test_legacy_grid_renderer_config_fails_with_migration_message(tmp_path) -> N
 
     assert result["ok"] is False
     assert result["status"] == "invalid_config"
-    assert "grid/SVG Explore renderers were removed" in result["error"]
+    assert "legacy grid/SVG Explore renderers were removed" in result["error"]
+
+
+def test_stage_svg_visual_publish_preserves_lane_source_and_remote_marker(
+    tmp_path,
+) -> None:
+    projection = _lane_projection()
+    config = LarkExploreConfig(base_token="PUBLIC_FIXTURE_BASE")
+    bundle = build_explore_presentation_bundle(
+        projection,
+        policy={"stage_node_capacity": 10},
+    )
+    stage = bundle["canonical"]["stage_views"][0]
+    calls: list[list[str]] = []
+    published_marker = ""
+
+    def runner(args, cwd, _timeout):
+        nonlocal published_marker
+        calls.append(args)
+        if "+update" in args:
+            assert args[args.index("--input_format") + 1] == "svg"
+            source_arg = args[args.index("--source") + 1]
+            source = (cwd / source_arg.removeprefix("@")).read_text(
+                encoding="utf-8"
+            )
+            assert source.startswith('<svg xmlns="http://www.w3.org/2000/svg"')
+            assert "supports" in source
+            published_marker = re.search(
+                r"LoopX delivery [0-9a-f]{20}", source
+            ).group(0)
+            return {
+                "returncode": 0,
+                "stdout": json.dumps({"ok": True}),
+                "stderr": "",
+            }
+        assert "+query" in args
+        return {
+            "returncode": 0,
+            "stdout": json.dumps(
+                {
+                    "ok": True,
+                    "data": {"nodes": [{"text": {"text": published_marker}}]},
+                }
+            ),
+            "stderr": "",
+        }
+
+    synced = sync_explore_visual_to_lark(
+        config,
+        projection=projection,
+        visual_sink={
+            "whiteboard_token": "wb_canonical_fixture",
+            "view_role": "canonical",
+            "board_style": "semantic_lane_columns",
+        },
+        config_path=tmp_path / "lark-explore.json",
+        semantic_digest=bundle["source_digest"],
+        display_projection=stage,
+        view_key="canonical_stage_01",
+        execute=True,
+        runner=runner,
+    )
+
+    assert len(calls) == 2
+    assert synced["ok"] is True
+    assert synced["board_style"] == "semantic_lane_columns"
+    assert synced["renderer"] == "stage_svg"
+    assert synced["input_format"] == "svg"
+    assert synced["readback"]["observed_marker"] == published_marker
 
 
 def test_mermaid_visual_publish_reads_back_remote_delivery_marker(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- add `board_style=auto_flow|semantic_lane_columns` as the product-facing Explore layout contract
- render semantic lane columns as deterministic SVG with real directed edges and remote delivery-marker readback
- keep legacy `renderer=mermaid` configs readable while deriving renderer details from the selected style
- document the style matrix and cover the CLI, sink, geometry, and result-layer contracts

## Validation

- `pytest -q tests/test_explore_presentation_views.py -x` (26 passed)
- `python3 examples/explore-result-layer-smoke.py`
- targeted Ruff and Python compile checks
- three real OpenViking stage SVG geometry checks: zero text overflow, overlap, or occlusion
- `loopx canary premerge --from-git-diff --tier standard`: 4 direct checks plus 17 risk/boundary checks passed; zero manual holds

## Boundary and risk

- no credentials, local paths, private evidence, or generated preview artifacts are included
- local `uv.lock` and ignored preview files remain untracked
- main compatibility risk is legacy visual config; renderer-only Mermaid configs map to `auto_flow`, while removed grid renderers still fail closed with migration guidance