### PR TITLE
Project stage SVG sources into visual sync

### DIFF
--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -991,6 +991,7 @@ def sync_explore_visuals_to_lark(
             stage_node_ids = {str(item) for item in stage.get("node_ids") or []}
             stage_projection = dict(role_view)
             stage_projection["mermaid"] = str(stage.get("mermaid") or "")
+            stage_projection["svg"] = str(stage.get("svg") or "")
             stage_projection["nodes"] = [
                 role_nodes[node_id]
                 for node_id in stage.get("node_ids") or []

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -639,7 +639,19 @@ def test_visual_configuration_can_create_all_stage_boards_from_docx(tmp_path) ->
     assert sink["stage_whiteboards"] == []
 
 
-def test_visual_sync_publishes_one_mermaid_whiteboard_per_stage(tmp_path) -> None:
+@pytest.mark.parametrize(
+    ("board_style", "renderer", "input_format"),
+    [
+        ("auto_flow", "mermaid", "mermaid"),
+        ("semantic_lane_columns", "stage_svg", "svg"),
+    ],
+)
+def test_visual_sync_publishes_one_whiteboard_per_stage_style(
+    tmp_path,
+    board_style,
+    renderer,
+    input_format,
+) -> None:
     projection = _complex_projection()
     config = LarkExploreConfig(base_token="PUBLIC_FIXTURE_BASE")
     bundle = build_explore_presentation_bundle(
@@ -654,6 +666,7 @@ def test_visual_sync_publishes_one_mermaid_whiteboard_per_stage(tmp_path) -> Non
             "executive": {
                 "whiteboard_token": "wb_stage_01",
                 "view_role": "executive",
+                "board_style": board_style,
                 "stage_capacity": 14,
                 "stage_whiteboards": [
                     {
@@ -671,10 +684,11 @@ def test_visual_sync_publishes_one_mermaid_whiteboard_per_stage(tmp_path) -> Non
     assert view["stage_count"] == stage_count
     assert view["stage_capacity"] == 14
     assert view["presentation_mode"] == "stage_document"
-    assert all(stage["renderer"] == "mermaid" for stage in view["stages"])
-    assert all(stage["input_format"] == "mermaid" for stage in view["stages"])
+    assert view["board_style"] == board_style
+    assert all(stage["renderer"] == renderer for stage in view["stages"])
+    assert all(stage["input_format"] == input_format for stage in view["stages"])
     assert all(
-        "--input_format mermaid" in stage["command"]["command"]
+        f"--input_format {input_format}" in stage["command"]["command"]
         for stage in view["stages"]
     )
 


### PR DESCRIPTION
## Summary

- include each Evidence Stage SVG source when stage-document sync builds its per-board projection
- exercise both first-class board styles through the full multi-stage sync path
- preserve fail-closed behavior when a selected style lacks its source

## Root cause

The lower-level SVG publish path was covered, but the stage-document integration copied only each stage Mermaid source into the display projection. Real OpenViking dogfood therefore returned `invalid_projection` before any whiteboard write. Base row readback remained correct.

## Validation

- `pytest -q tests/test_explore_presentation_views.py -x` (27 passed)
- `python3 examples/explore-result-layer-smoke.py`
- targeted Ruff, compile, and diff checks
- `loopx canary premerge --from-git-diff --tier standard`: passed with no holds

Local `uv.lock` remains untracked and excluded.