### PR TITLE
Retry stale Lark visual readbacks

### DIFF
--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -614,16 +614,17 @@ def _readback_visual_delivery_marker(
         error_code = error.get("code")
         error_message = str(error.get("message") or "")
         is_applying = error_code == 4003101 and "doc is applying" in error_message
+        retryable = is_applying or bool(result.get("ok") and not marker_observed)
         attempts.append(
             {
                 "attempt": attempt_index + 1,
                 "ok": bool(result.get("ok")),
                 "marker_observed": marker_observed,
                 "error_code": error_code,
-                "retryable": is_applying,
+                "retryable": retryable,
             }
         )
-        if result.get("ok") or not is_applying:
+        if marker_observed or not retryable:
             break
         if attempt_index < len(_VISUAL_READBACK_RETRY_DELAYS_SECONDS):
             time.sleep(_VISUAL_READBACK_RETRY_DELAYS_SECONDS[attempt_index])

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -1077,12 +1077,98 @@ def test_mermaid_visual_readback_retries_lark_doc_applying(tmp_path, monkeypatch
     assert delays == [0.25]
 
 
-def test_mermaid_visual_publish_fails_closed_when_remote_marker_is_missing(
+def test_mermaid_visual_readback_retries_successful_stale_marker(
     tmp_path,
+    monkeypatch,
 ) -> None:
     projection = _complex_projection()
     config = LarkExploreConfig(base_token="PUBLIC_FIXTURE_BASE")
     bundle = build_explore_presentation_bundle(projection)
+    published_marker = ""
+    query_count = 0
+    delays: list[float] = []
+    monkeypatch.setattr(
+        "loopx.presentation.sinks.lark.explore_results.time.sleep",
+        delays.append,
+    )
+
+    def runner(args, cwd, _timeout):
+        nonlocal published_marker, query_count
+        if "+update" in args:
+            source_arg = args[args.index("--source") + 1]
+            source = (cwd / source_arg.removeprefix("@")).read_text(
+                encoding="utf-8"
+            )
+            published_marker = re.search(
+                r"LoopX delivery [0-9a-f]{20}",
+                source,
+            ).group(0)
+            payload = {"ok": True}
+        else:
+            query_count += 1
+            payload = {
+                "ok": True,
+                "data": {
+                    "nodes": [
+                        {
+                            "text": {
+                                "text": (
+                                    "stale visual"
+                                    if query_count == 1
+                                    else published_marker
+                                )
+                            }
+                        }
+                    ]
+                },
+            }
+        return {
+            "returncode": 0,
+            "stdout": json.dumps(payload),
+            "stderr": "",
+        }
+
+    synced = sync_explore_visual_to_lark(
+        config,
+        projection=projection,
+        visual_sink={
+            "whiteboard_token": "wb_executive_fixture",
+            "view_role": "executive",
+            "renderer": "mermaid",
+        },
+        config_path=tmp_path / "lark-explore.json",
+        semantic_digest=bundle["source_digest"],
+        display_projection=bundle["executive"],
+        view_key="executive",
+        execute=True,
+        runner=runner,
+    )
+
+    assert synced["ok"] is True
+    assert synced["published"] is True
+    assert synced["readback"]["verified"] is True
+    assert synced["readback"]["attempt_count"] == 2
+    assert synced["readback"]["attempts"][0] == {
+        "attempt": 1,
+        "ok": True,
+        "marker_observed": False,
+        "error_code": None,
+        "retryable": True,
+    }
+    assert delays == [0.25]
+
+
+def test_mermaid_visual_publish_fails_closed_when_remote_marker_is_missing(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    projection = _complex_projection()
+    config = LarkExploreConfig(base_token="PUBLIC_FIXTURE_BASE")
+    bundle = build_explore_presentation_bundle(projection)
+    monkeypatch.setattr(
+        "loopx.presentation.sinks.lark.explore_results.time.sleep",
+        lambda _delay: None,
+    )
 
     def runner(args, _cwd, _timeout):
         payload = (
@@ -1120,6 +1206,7 @@ def test_mermaid_visual_publish_fails_closed_when_remote_marker_is_missing(
     assert synced["published"] is False
     assert synced["readback"]["performed"] is True
     assert synced["readback"]["verified"] is False
+    assert synced["readback"]["attempt_count"] == 6
     assert "expected delivery marker" in synced["error"]
 
 


### PR DESCRIPTION
## Summary

- keep retrying when a successful whiteboard query still returns the previous delivery marker
- continue failing fast for non-retryable query errors
- cover stale-success recovery and bounded fail-closed exhaustion

## Validation

- `pytest -q tests/test_explore_presentation_views.py` (27 passed)
- `loopx canary premerge --from-git-diff` (passed)