### PR TITLE
Retry Explore visual marker readback until visible

### DIFF
--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -614,16 +614,18 @@ def _readback_visual_delivery_marker(
         error_code = error.get("code")
         error_message = str(error.get("message") or "")
         is_applying = error_code == 4003101 and "doc is applying" in error_message
+        is_marker_pending = bool(result.get("ok")) and not marker_observed
+        is_retryable = is_applying or is_marker_pending
         attempts.append(
             {
                 "attempt": attempt_index + 1,
                 "ok": bool(result.get("ok")),
                 "marker_observed": marker_observed,
                 "error_code": error_code,
-                "retryable": is_applying,
+                "retryable": is_retryable,
             }
         )
-        if result.get("ok") or not is_applying:
+        if marker_observed or not is_retryable:
             break
         if attempt_index < len(_VISUAL_READBACK_RETRY_DELAYS_SECONDS):
             time.sleep(_VISUAL_READBACK_RETRY_DELAYS_SECONDS[attempt_index])

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -1091,12 +1091,92 @@ def test_mermaid_visual_readback_retries_lark_doc_applying(tmp_path, monkeypatch
     assert delays == [0.25]
 
 
-def test_mermaid_visual_publish_fails_closed_when_remote_marker_is_missing(
+def test_mermaid_visual_readback_retries_until_remote_marker_is_visible(
     tmp_path,
+    monkeypatch,
 ) -> None:
     projection = _complex_projection()
     config = LarkExploreConfig(base_token="PUBLIC_FIXTURE_BASE")
     bundle = build_explore_presentation_bundle(projection)
+    published_marker = ""
+    query_count = 0
+    delays: list[float] = []
+    monkeypatch.setattr(
+        "loopx.presentation.sinks.lark.explore_results.time.sleep",
+        delays.append,
+    )
+
+    def runner(args, cwd, _timeout):
+        nonlocal published_marker, query_count
+        if "+update" in args:
+            source_arg = args[args.index("--source") + 1]
+            source = (cwd / source_arg.removeprefix("@")).read_text(
+                encoding="utf-8"
+            )
+            published_marker = re.search(
+                r"LoopX delivery [0-9a-f]{20}",
+                source,
+            ).group(0)
+            payload = {"ok": True}
+        else:
+            query_count += 1
+            payload = {
+                "ok": True,
+                "data": {
+                    "nodes": [
+                        {
+                            "text": {
+                                "text": (
+                                    "stale visual"
+                                    if query_count == 1
+                                    else published_marker
+                                )
+                            }
+                        }
+                    ]
+                },
+            }
+        return {
+            "returncode": 0,
+            "stdout": json.dumps(payload),
+            "stderr": "",
+        }
+
+    synced = sync_explore_visual_to_lark(
+        config,
+        projection=projection,
+        visual_sink={
+            "whiteboard_token": "wb_executive_fixture",
+            "view_role": "executive",
+            "renderer": "mermaid",
+        },
+        config_path=tmp_path / "lark-explore.json",
+        semantic_digest=bundle["source_digest"],
+        display_projection=bundle["executive"],
+        view_key="executive",
+        execute=True,
+        runner=runner,
+    )
+
+    assert synced["ok"] is True
+    assert synced["published"] is True
+    assert synced["readback"]["verified"] is True
+    assert synced["readback"]["attempt_count"] == 2
+    assert synced["readback"]["attempts"][0]["retryable"] is True
+    assert delays == [0.25]
+
+
+def test_mermaid_visual_publish_fails_closed_when_remote_marker_is_missing(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    projection = _complex_projection()
+    config = LarkExploreConfig(base_token="PUBLIC_FIXTURE_BASE")
+    bundle = build_explore_presentation_bundle(projection)
+    monkeypatch.setattr(
+        "loopx.presentation.sinks.lark.explore_results.time.sleep",
+        lambda _delay: None,
+    )
 
     def runner(args, _cwd, _timeout):
         payload = (


### PR DESCRIPTION
## Summary

- treat a successful whiteboard query without the expected delivery marker as an eventual-consistency state
- retry marker readback with the existing bounded backoff schedule
- keep non-retryable query errors fail-closed and add focused regression coverage

## Root cause

Lark can return a successful raw whiteboard query before the just-published marker is visible. The readback loop previously stopped on any successful query, so a transient stale result surfaced as `publish_unverified` even though a following read contained the marker.

## Validation

- `pytest -q tests/test_explore_presentation_views.py -x` (28 passed)
- `python3 examples/explore-result-layer-smoke.py`
- targeted Ruff, compile, and diff checks
- `loopx canary premerge --from-git-diff --tier standard`: passed with no holds

Local `uv.lock` remains untracked and excluded.