### PR TITLE
Fit semantic lane text within SVG nodes

### DIFF
--- a/loopx/presentation/explore_views.py
+++ b/loopx/presentation/explore_views.py
@@ -89,6 +89,8 @@ _SVG_STATUS_STYLE = {
     "resolved": ("#e8f5e9", "#43a047"),
     "dead_end": ("#eeeeee", "#9e9e9e"),
 }
+_SVG_NODE_HEADER_DISPLAY_WIDTH = 50
+_SVG_NODE_DETAIL_DISPLAY_WIDTH = 62
 
 
 def build_stage_lane_svg(
@@ -203,9 +205,7 @@ def build_stage_lane_svg(
         parts.append(
             f'<rect x="{node_x:.1f}" y="{node_y:.1f}" width="{node_width}" height="{node_height}" rx="10" fill="{fill}" stroke="{stroke}" stroke-width="2"/>'
         )
-        display_lines = _node_display_lines(
-            node, title_limit=54, detail_limit=76
-        )[:3]
+        display_lines = _svg_node_display_lines(node)
         for line_index, line in enumerate(display_lines):
             weight = "700" if line_index == 0 else "400"
             size = 14 if line_index == 0 else 12
@@ -383,6 +383,26 @@ def _node_display_lines(
     )
     header = f"{title} · {_NODE_STATUS_LABEL.get(status, status.upper())}"
     return [header, *_node_decision_lines(node, detail_limit=detail_limit)]
+
+
+def _svg_node_display_lines(node: Mapping[str, Any]) -> list[str]:
+    status = str(node.get("status") or "open")
+    status_suffix = f" · {_NODE_STATUS_LABEL.get(status, status.upper())}"
+    title_limit = max(
+        1,
+        _SVG_NODE_HEADER_DISPLAY_WIDTH - _display_width(status_suffix),
+    )
+    title = _truncate_display(
+        str(node.get("title") or node.get("node_id") or "untitled"),
+        limit=title_limit,
+    )
+    return [
+        f"{title}{status_suffix}",
+        *_node_decision_lines(
+            node,
+            detail_limit=_SVG_NODE_DETAIL_DISPLAY_WIDTH,
+        ),
+    ][:3]
 
 
 def _node_detail_coverage(nodes: Sequence[Mapping[str, Any]]) -> dict[str, Any]:

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -8,6 +8,7 @@ import pytest
 from loopx.presentation.explore_views import (
     PRESENTATION_MODE_CANONICAL_ONLY,
     PRESENTATION_MODE_DUAL_VIEW,
+    _display_width,
     build_explore_presentation_bundle,
     explore_source_digest,
     validate_explore_view_freshness,
@@ -464,6 +465,32 @@ def test_stage_board_preserves_two_lanes_and_real_cross_lane_relation() -> None:
     assert "LoopX capability" in stage["svg"]
     assert "supports" in stage["svg"]
     assert 'marker-end="url(#loopx-arrow)"' in stage["svg"]
+
+
+def test_stage_svg_fits_mixed_width_node_text_and_preserves_status() -> None:
+    projection = _lane_projection()
+    fix_node = next(
+        node for node in projection["nodes"] if node["node_id"] == "fix-pr"
+    )
+    fix_node["title"] = (
+        "Issue #3207 → Draft PR #3208: restore stats API unit-test isolation"
+    )
+    fix_node["summary"] = (
+        "在 shared SessionExtractContextProvider 强制可配置 conversation prompt 上限，"
+        "保留稳定配置语义并验证完整回归"
+    )
+
+    stage = build_explore_presentation_bundle(
+        projection,
+        policy={"stage_node_capacity": 10},
+    )["canonical"]["stage_views"][0]
+    headers = re.findall(r'font-size="14"[^>]*>([^<]+)</text>', stage["svg"])
+    details = re.findall(r'font-size="12"[^>]*>([^<]+)</text>', stage["svg"])
+
+    assert any(header.endswith("· ACTIVE") for header in headers)
+    assert all(_display_width(header) <= 50 for header in headers)
+    assert all(_display_width(detail) <= 62 for detail in details)
+    assert any(detail.endswith("…") for detail in details)
 
 
 def test_single_lane_project_does_not_invent_a_second_lane() -> None:


### PR DESCRIPTION
## Summary

- bound semantic-lane SVG node headers by display width while reserving space for the status suffix
- use a narrower display-width budget for detail lines so mixed CJK/ASCII text stays inside the real Lark node box
- add a mixed-width regression that verifies header/detail bounds and preserved status

## Root cause

The fixed-lane renderer truncated the title before appending `ACTIVE`/`DONE`, and used display-width budgets that were wider than the 436px node at Lark's actual Arial font metrics. Remote Stage 2/3 previews therefore showed long text crossing node borders even though the SVG coordinates themselves were valid.

## Validation

- `pytest -q tests/test_explore_presentation_views.py -x` (29 passed)
- `python3 examples/explore-result-layer-smoke.py`
- targeted Ruff, compile, and diff checks
- `loopx canary premerge --from-git-diff --tier standard`: passed with no holds

The optional external `whiteboard-cli` geometry rerun was unavailable from the configured npm registry; the durable mixed-width renderer regression covers the observed failure. Local `uv.lock` remains untracked and excluded.