### PR TITLE
Add semantic preference corpus maintenance guidance

### DIFF
--- a/docs/capabilities/semantic-preference/README.md
+++ b/docs/capabilities/semantic-preference/README.md
@@ -63,9 +63,35 @@ returns one `semantic_preference_provider_response_v0` object on stdout:
       "preference_ref": "provider-owned-reference",
       "summary": "Use concise Chinese sections for this surface."
     }
+  ],
+  "corpus_inventory": [
+    {
+      "corpus_id": "project_preferences",
+      "scope_ref": "provider-owned-scope-reference",
+      "read_role": "primary",
+      "write_mode": "provider_managed",
+      "write_actor_ref": "provider-owned-actor-reference",
+      "source_of_truth": "repository_revision_and_explicit_feedback",
+      "writeback_triggers": ["explicit_feedback", "source_truth_changed"],
+      "closure_policy": "write_wait_l2_read_scoped_recall"
+    }
   ]
 }
 ```
+
+`corpus_inventory` is optional and provider-neutral. It describes which bounded
+corpora contributed to the recall and what closes a maintenance decision; it
+does not contain raw memory. LoopX validates the inventory and derives
+`semantic_preference_maintenance_guidance_v0`. A fixed function boundary can
+therefore expose the corpus ids, writeback triggers, and closure policy in the
+same provider call instead of relying on the agent to remember a separate
+runbook. Providers that omit the field remain compatible.
+
+An explicit feedback or source-of-truth change does not imply that every corpus
+must be rewritten. The caller either performs the provider-owned update and
+verifies the configured closure policy, or records a `no_write_rationale`.
+LoopX does not infer semantic updates, mirror provider storage, or turn a soft
+preference into an execution permission.
 
 Provider stderr and non-zero output are reduced to a bounded failure kind.
 `fail_open` returns no items and lets the domain continue; `fail_closed` stops
@@ -99,6 +125,13 @@ loopx semantic-preference receipt \
   --outcome applied \
   --preference-ref <provider-owned-reference> \
   --artifact-ref https://github.com/owner/repo/pull/123
+
+loopx semantic-preference maintenance-receipt \
+  --trigger source_truth_changed \
+  --outcome verified \
+  --corpus-id project_preferences \
+  --scope-ref <provider-owned-scope-reference> \
+  --evidence-ref project-preference-readback-v2
 ```
 
 Receipts contain only surface, application id, outcome, optional public
@@ -106,6 +139,13 @@ artifact reference, and hashes of provider-owned preference references. The
 command returns the receipt without writing a file. Callers can attach it to
 the existing evidence log, todo evidence, or `refresh-state` record; the hook
 does not maintain a second reward or memory ledger.
+
+Maintenance receipts are also stateless. They contain only the trigger,
+outcome, corpus ids, optional compact evidence reference, and hashes of scope
+references. A `verified` outcome means the provider-specific write, queue or
+index wait, direct read, and scoped recall required by the inventory have all
+passed. A `no_write_rationale` outcome records that the trigger was assessed
+but no durable semantic change was needed.
 
 `--context` is repeatable and each entry uses `lower_snake=value` syntax.
 Invalid config, context, surface, or fail-closed requests return a structured
@@ -123,6 +163,9 @@ preferences = recall(
     surface="issue_fix.pr_description",
     execute=True,
 )
+# The same result identifies provider-owned corpora that must be assessed after
+# explicit feedback or a source-of-truth change.
+guidance = preferences.get("maintenance_guidance")
 # The issue-fix module decides whether and how to apply preferences["items"].
 receipt = application_receipt(
     surface="issue_fix.pr_description",

--- a/docs/capabilities/semantic-preference/openviking-project-peer.md
+++ b/docs/capabilities/semantic-preference/openviking-project-peer.md
@@ -32,12 +32,44 @@ loopx semantic-preference openviking-provider \
 ```
 
 The output contains the peer id and target URIs, but not the repository URL or
-local checkout path. An OpenViking agent integration can use the returned
-`peer_id` when adding a user message to a session. For an isolated native
-write, create that session with self memory disabled, peer memory enabled, and
-the desired memory types allowed. `peer_id` alone identifies the speaker but
-does not force an extractor operation away from user-global memory. OpenViking
-then owns write, update, and supersede semantics inside the selected peer.
+local checkout path. It also contains a bounded corpus inventory. The project
+peer preference corpus is primary; user-global preferences appear only when
+the caller explicitly enables global fallback.
+
+An OpenViking agent integration can use the returned `peer_id` when adding a
+user message to a session. For an isolated native write, create that session
+with self memory disabled, peer memory enabled, and the desired memory types
+allowed. Both the message peer and the request actor must be the same derived
+project peer. A message `peer_id` alone identifies the speaker; it does not
+authorize an extractor running as a different actor to update that peer.
+OpenViking then owns extraction, update, and supersede semantics inside the
+selected corpus.
+
+Do not treat a completed extraction task as sufficient write evidence. A
+maintenance closure for this provider requires all of the following:
+
+1. The task reports the expected add or update count and memory diff.
+2. Pending embedding or indexing work reaches zero without errors.
+3. A direct L2 read returns the new semantic content.
+4. A scoped `find` through the same project-peer provider recalls that content.
+
+If a trigger does not require a semantic change, emit a compact
+`no_write_rationale` maintenance receipt instead. Never persist raw memory in
+the receipt.
+
+## Repository template versus semantic preference
+
+For PR descriptions, the repository's current
+`.github/PULL_REQUEST_TEMPLATE.md` is the authoritative hard structure. Read it
+from the working revision when building the artifact. OpenViking stores only
+soft semantic preferences for how to fill that structure, such as reviewer
+language, useful detail, and risk-based validation. Do not copy the template
+body into OpenViking: doing so would create a stale second source of truth.
+
+When the repository template changes, assess the project-peer preference
+corpus because its interpretation may need to change. When explicit user
+feedback changes the prose preference, update that corpus through OpenViking's
+native extractor and complete the four-step readback above.
 
 ## Local-private hook config
 
@@ -78,4 +110,6 @@ arguments for a read-only `ov status` probe.
 
 The consuming function remains the final application boundary. For Issue Fix,
 `build_issue_fix_pr_description()` owns one recall, fail-open preservation,
-preference attribution, and the compact application receipt.
+preference attribution, the compact application receipt, and propagation of
+the provider's corpus inventory and maintenance guidance. It does not perform
+an automatic write or add a second provider call.

--- a/examples/issue-fix-pr-description-builder-smoke.py
+++ b/examples/issue-fix-pr-description-builder-smoke.py
@@ -35,6 +35,16 @@ json.dump({
         "preference_ref": "viking://user/preferences/pr-description-chinese",
         "summary": "Use concise structured Chinese for PR descriptions",
     }],
+    "corpus_inventory": [{
+        "corpus_id": "project_peer_preferences",
+        "scope_ref": "viking://user/pilot/peers/project-example/memories/preferences",
+        "read_role": "primary",
+        "write_mode": "provider_managed",
+        "write_actor_ref": "project-example",
+        "source_of_truth": "repository_revision_and_explicit_feedback",
+        "writeback_triggers": ["explicit_feedback", "source_truth_changed"],
+        "closure_policy": "write_wait_l2_read_scoped_recall",
+    }],
 }, sys.stdout)
 """,
         encoding="utf-8",
@@ -77,6 +87,13 @@ json.dump({
     preference = applied["semantic_preference"]
     assert preference["application_status"] == "applied", preference
     assert preference["receipt"]["outcome"] == "applied", preference
+    assert preference["corpus_inventory"][0]["corpus_id"] == (
+        "project_peer_preferences"
+    ), preference
+    assert preference["maintenance_guidance"]["writeback_triggers"] == [
+        "explicit_feedback",
+        "source_truth_changed",
+    ], preference
     assert PREFERENCE_REF not in json.dumps(applied), applied
     assert applied["description"].endswith(
         "## 关联 Issue\n\nFixes #17\nFixes octo-org/example#18\nRelated to #19\n"

--- a/examples/openviking-project-peer-provider-smoke.py
+++ b/examples/openviking-project-peer-provider-smoke.py
@@ -187,6 +187,11 @@ print(json.dumps({"ok": True, "result": result}))
     described = json.loads(describe.stdout)
     assert described["peer_id"] == expected.peer_id
     assert described["memory_uri"] == expected.memory_uri
+    described_inventory = described["corpus_inventory"]
+    assert len(described_inventory) == 1, described_inventory
+    assert described_inventory[0]["corpus_id"] == "project_peer_preferences"
+    assert described_inventory[0]["scope_ref"] == expected.preferences_uri
+    assert described_inventory[0]["write_actor_ref"] == expected.peer_id
     assert str(project) not in describe.stdout
     assert REMOTE not in describe.stdout
     assert read_calls(log) == [], "describe-scope must not contact OpenViking"
@@ -221,6 +226,9 @@ print(json.dumps({"ok": True, "result": result}))
         environment,
     )
     assert len(recalled["items"]) == 1, recalled
+    assert recalled["corpus_inventory"][0]["scope_ref"] == (
+        expected.preferences_uri
+    )
     calls = read_calls(log)
     assert len(calls) == 1, calls
     assert calls[0][:3] == ["--actor-peer-id", expected.peer_id, "find"]
@@ -253,6 +261,9 @@ print(json.dumps({"ok": True, "result": result}))
         environment,
     )
     assert len(fallback_result["items"]) == 1, fallback_result
+    assert [
+        item["corpus_id"] for item in fallback_result["corpus_inventory"]
+    ] == ["project_peer_preferences", "user_global_preferences"]
     calls = read_calls(log)
     assert len(calls) == 2, calls
     assert all(call[:3] == ["--actor-peer-id", wrong.peer_id, "find"] for call in calls)
@@ -316,6 +327,12 @@ print(json.dumps({"ok": True, "result": result}))
     )
     assert built["semantic_preference"]["application_status"] == "applied", built
     assert built["semantic_preference"]["receipt"]["outcome"] == "applied", built
+    assert built["semantic_preference"]["corpus_inventory"][0]["corpus_id"] == (
+        "project_peer_preferences"
+    ), built
+    assert built["semantic_preference"]["maintenance_guidance"]["completion"] == (
+        "provider_write_then_wait_l2_read_and_scoped_recall"
+    ), built
     assert built["raw_preference_content_returned"] is False
 
     os.environ["FAKE_OV_FAIL"] = "1"

--- a/examples/semantic-preference-hook-smoke.py
+++ b/examples/semantic-preference-hook-smoke.py
@@ -184,6 +184,17 @@ json.dump({
         outcome="no_write_rationale",
         corpus_ids=["fixture_preferences"],
     )["outcome"] == "no_write_rationale"
+    try:
+        maintenance_receipt(
+            trigger="explicit_feedback",
+            outcome="verified",
+            corpus_ids=["fixture_preferences"],
+            scope_refs=["not a public-safe scope"],
+        )
+    except ValueError as exc:
+        assert "public-safe" in str(exc), exc
+    else:
+        raise AssertionError("maintenance scope references must stay bounded")
 
     disabled = temp / "disabled.json"
     disabled.write_text(

--- a/examples/semantic-preference-hook-smoke.py
+++ b/examples/semantic-preference-hook-smoke.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(ROOT))
 
 from loopx.capabilities.semantic_preference import (  # noqa: E402
     application_receipt,
+    maintenance_receipt,
     provider_doctor,
     recall,
 )
@@ -67,7 +68,20 @@ request = json.load(sys.stdin)
 surface = request["surface"]
 json.dump({
     "schema_version": "semantic_preference_provider_response_v0",
-    "items": [{"preference_ref": f"memory://{surface}", "summary": f"prefer {surface}"}],
+    "items": [{
+        "preference_ref": f"memory://{surface}",
+        "summary": f"prefer {surface}",
+    }],
+    "corpus_inventory": [{
+        "corpus_id": "fixture_preferences",
+        "scope_ref": "memory://fixture/preferences",
+        "read_role": "primary",
+        "write_mode": "provider_managed",
+        "write_actor_ref": "fixture-peer",
+        "source_of_truth": "explicit_user_feedback",
+        "writeback_triggers": ["explicit_feedback"],
+        "closure_policy": "write_wait_l2_read_scoped_recall",
+    }],
 }, sys.stdout)
 """,
         encoding="utf-8",
@@ -104,6 +118,16 @@ json.dump({
         recalled = recall_cli(project, config, surface, execute=True)
         assert recalled["status"] == "completed", recalled
         assert recalled["items"][0]["summary"] == f"prefer {surface}", recalled
+        assert recalled["corpus_inventory"][0]["corpus_id"] == (
+            "fixture_preferences"
+        ), recalled
+        assert recalled["maintenance_guidance"] == {
+            "schema_version": "semantic_preference_maintenance_guidance_v0",
+            "corpus_ids": ["fixture_preferences"],
+            "writeback_triggers": ["explicit_feedback"],
+            "closure_outcomes": ["verified", "no_write_rationale"],
+            "completion": "provider_write_then_wait_l2_read_and_scoped_recall",
+        }, recalled
 
     doctor_preview = run(
         "semantic-preference",
@@ -135,6 +159,31 @@ json.dump({
     assert receipt["preference_ref_digests"], receipt
     assert "memory://" not in json.dumps(receipt), receipt
     assert not list(project.rglob("*receipt*")), "receipt must remain stateless"
+
+    maintenance = run(
+        "semantic-preference",
+        "maintenance-receipt",
+        "--trigger",
+        "explicit_feedback",
+        "--outcome",
+        "verified",
+        "--corpus-id",
+        "fixture_preferences",
+        "--scope-ref",
+        "memory://fixture/preferences",
+        "--evidence-ref",
+        "fixture-readback-v1",
+    )
+    assert maintenance["schema_version"] == (
+        "semantic_preference_maintenance_receipt_v0"
+    ), maintenance
+    assert maintenance["scope_ref_digests"], maintenance
+    assert "memory://" not in json.dumps(maintenance), maintenance
+    assert maintenance_receipt(
+        trigger="source_truth_changed",
+        outcome="no_write_rationale",
+        corpus_ids=["fixture_preferences"],
+    )["outcome"] == "no_write_rationale"
 
     disabled = temp / "disabled.json"
     disabled.write_text(
@@ -192,6 +241,40 @@ json.dump({
         missing, project=project, surface="other_module.summary", execute=True
     )
     assert missing_recall["status"] == "provider_unavailable", missing_recall
+
+    invalid_provider = temp / "invalid-provider.py"
+    invalid_provider.write_text(
+        """import json, sys
+json.load(sys.stdin)
+json.dump({
+    "schema_version": "semantic_preference_provider_response_v0",
+    "items": [],
+    "corpus_inventory": [{"corpus_id": "INVALID"}],
+}, sys.stdout)
+""",
+        encoding="utf-8",
+    )
+    invalid_inventory = temp / "invalid-inventory.json"
+    invalid_inventory.write_text(
+        json.dumps(
+            {
+                "schema_version": "semantic_preference_hook_config_v0",
+                "enabled": True,
+                "provider": {"argv": [sys.executable, str(invalid_provider)]},
+                "surfaces": {"other_module.summary": {"query": "preferences"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    invalid_recall = recall(
+        invalid_inventory,
+        project=project,
+        surface="other_module.summary",
+        execute=True,
+    )
+    assert invalid_recall["failure_kind"] == "invalid_corpus_inventory", (
+        invalid_recall
+    )
 
     invalid_context = run_failure(
         "semantic-preference",

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -234,6 +234,11 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "purpose": "Build a compact receipt with hashed preference references for existing evidence/state writeback.",
                 "write_boundary": "stateless output only; no provider, file, or external write",
             },
+            {
+                "command": "loopx semantic-preference maintenance-receipt --trigger explicit_feedback --outcome verified --corpus-id <id> --format json",
+                "purpose": "Build a compact receipt after a provider-owned corpus maintenance decision and readback closure.",
+                "write_boundary": "stateless output only; scope references are hashed and semantic content is excluded",
+            },
         ],
         "implemented_protocols": [
             {
@@ -253,6 +258,16 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
             },
             {
                 "schema_version": "semantic_preference_application_receipt_v0",
+                "module": "loopx.capabilities.semantic_preference.contract",
+                "doc": "docs/capabilities/semantic-preference/README.md",
+            },
+            {
+                "schema_version": "semantic_preference_maintenance_guidance_v0",
+                "module": "loopx.capabilities.semantic_preference.contract",
+                "doc": "docs/capabilities/semantic-preference/README.md",
+            },
+            {
+                "schema_version": "semantic_preference_maintenance_receipt_v0",
                 "module": "loopx.capabilities.semantic_preference.contract",
                 "doc": "docs/capabilities/semantic-preference/README.md",
             },

--- a/loopx/capabilities/issue_fix/pr_description.py
+++ b/loopx/capabilities/issue_fix/pr_description.py
@@ -168,6 +168,8 @@ def _result(
     fail_open_preserved_base: bool = False,
     description_changed: bool = False,
     issue_reference_policy: Mapping[str, Any] | None = None,
+    corpus_inventory: Sequence[Mapping[str, Any]] | None = None,
+    maintenance_guidance: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     policy = dict(issue_reference_policy or {})
     description, issue_reference_changed = _apply_issue_reference_policy(
@@ -185,6 +187,12 @@ def _result(
             "recalled_item_count": recalled_item_count,
             "applied_preference_count": applied_preference_count,
             "receipt": dict(receipt) if receipt is not None else None,
+            "corpus_inventory": [dict(item) for item in corpus_inventory or []],
+            "maintenance_guidance": (
+                dict(maintenance_guidance)
+                if maintenance_guidance is not None
+                else None
+            ),
         },
         "raw_preference_content_returned": False,
         "fail_open_preserved_base": fail_open_preserved_base,
@@ -271,6 +279,16 @@ def build_issue_fix_pr_description(
         if isinstance(raw_items, list)
         else []
     )
+    raw_inventory = recalled.get("corpus_inventory")
+    corpus_inventory = (
+        [dict(item) for item in raw_inventory if isinstance(item, Mapping)]
+        if isinstance(raw_inventory, list)
+        else []
+    )
+    raw_guidance = recalled.get("maintenance_guidance")
+    maintenance_guidance = (
+        dict(raw_guidance) if isinstance(raw_guidance, Mapping) else None
+    )
     if recall_status != "completed" or not items:
         return _result(
             description=base_description,
@@ -278,6 +296,8 @@ def build_issue_fix_pr_description(
             application_status=recall_status,
             fail_open_preserved_base=recall_status == "provider_unavailable",
             issue_reference_policy=issue_reference_policy,
+            corpus_inventory=corpus_inventory,
+            maintenance_guidance=maintenance_guidance,
         )
     if apply_preferences is None:
         return _result(
@@ -286,6 +306,8 @@ def build_issue_fix_pr_description(
             application_status="available_not_applied",
             recalled_item_count=len(items),
             issue_reference_policy=issue_reference_policy,
+            corpus_inventory=corpus_inventory,
+            maintenance_guidance=maintenance_guidance,
         )
     if not application_id:
         raise ValueError("application_id is required when preferences are applied")
@@ -324,6 +346,8 @@ def build_issue_fix_pr_description(
             ),
             fail_open_preserved_base=True,
             issue_reference_policy=issue_reference_policy,
+            corpus_inventory=corpus_inventory,
+            maintenance_guidance=maintenance_guidance,
         )
 
     outcome = "applied" if applied_refs else "ignored"
@@ -342,4 +366,6 @@ def build_issue_fix_pr_description(
         ),
         description_changed=description != base_description,
         issue_reference_policy=issue_reference_policy,
+        corpus_inventory=corpus_inventory,
+        maintenance_guidance=maintenance_guidance,
     )

--- a/loopx/capabilities/semantic_preference/__init__.py
+++ b/loopx/capabilities/semantic_preference/__init__.py
@@ -1,5 +1,5 @@
 """Optional provider-neutral semantic preference recall."""
 
-from .contract import application_receipt, provider_doctor, recall
+from .contract import application_receipt, maintenance_receipt, provider_doctor, recall
 
-__all__ = ["application_receipt", "provider_doctor", "recall"]
+__all__ = ["application_receipt", "maintenance_receipt", "provider_doctor", "recall"]

--- a/loopx/capabilities/semantic_preference/cli.py
+++ b/loopx/capabilities/semantic_preference/cli.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import argparse
 from collections.abc import Callable
 
-from .contract import application_receipt, provider_doctor, recall
+from .contract import (
+    application_receipt,
+    maintenance_receipt,
+    provider_doctor,
+    recall,
+)
 from .openviking_provider import (
     handle_openviking_provider,
     register_openviking_provider_arguments,
@@ -82,6 +87,28 @@ def register_semantic_preference_commands(
     receipt_parser.add_argument("--preference-ref", action="append", default=[])
     receipt_parser.add_argument("--artifact-ref")
 
+    maintenance_parser = commands.add_parser(
+        "maintenance-receipt",
+        help=(
+            "Build a compact receipt after a provider-owned corpus "
+            "maintenance decision."
+        ),
+    )
+    add_subcommand_format(maintenance_parser)
+    maintenance_parser.add_argument(
+        "--trigger",
+        choices=["explicit_feedback", "source_truth_changed"],
+        required=True,
+    )
+    maintenance_parser.add_argument(
+        "--outcome",
+        choices=["verified", "no_write_rationale", "failed"],
+        required=True,
+    )
+    maintenance_parser.add_argument("--corpus-id", action="append", default=[])
+    maintenance_parser.add_argument("--scope-ref", action="append", default=[])
+    maintenance_parser.add_argument("--evidence-ref")
+
 
 def handle_semantic_preference_command(
     args: argparse.Namespace,
@@ -108,13 +135,21 @@ def handle_semantic_preference_command(
                 project=args.project,
                 execute=args.execute,
             )
-        else:
+        elif args.semantic_preference_command == "receipt":
             payload = application_receipt(
                 surface=args.surface,
                 application_id=args.application_id,
                 outcome=args.outcome,
                 preference_refs=args.preference_ref,
                 artifact_ref=args.artifact_ref,
+            )
+        else:
+            payload = maintenance_receipt(
+                trigger=args.trigger,
+                outcome=args.outcome,
+                corpus_ids=args.corpus_id,
+                scope_refs=args.scope_ref,
+                evidence_ref=args.evidence_ref,
             )
     except ValueError as exc:
         payload = {

--- a/loopx/capabilities/semantic_preference/contract.py
+++ b/loopx/capabilities/semantic_preference/contract.py
@@ -444,9 +444,11 @@ def maintenance_receipt(
         not CORPUS_ID_RE.fullmatch(value) for value in ids
     ):
         raise ValueError("corpus_ids must contain bounded lower-snake tokens")
-    refs = [str(ref) for ref in scope_refs or [] if str(ref).strip()]
+    refs = [str(ref).strip() for ref in scope_refs or [] if str(ref).strip()]
     if len(refs) > MAX_CORPORA:
         raise ValueError(f"scope_refs supports at most {MAX_CORPORA} items")
+    if any(not TOKEN_RE.fullmatch(ref) for ref in refs):
+        raise ValueError("scope_refs must contain compact public-safe tokens")
     return {
         "schema_version": MAINTENANCE_RECEIPT_SCHEMA,
         "trigger": trigger,

--- a/loopx/capabilities/semantic_preference/contract.py
+++ b/loopx/capabilities/semantic_preference/contract.py
@@ -14,13 +14,22 @@ REQUEST_SCHEMA = "semantic_preference_provider_request_v0"
 RESPONSE_SCHEMA = "semantic_preference_provider_response_v0"
 RECALL_SCHEMA = "semantic_preference_recall_v0"
 RECEIPT_SCHEMA = "semantic_preference_application_receipt_v0"
+MAINTENANCE_GUIDANCE_SCHEMA = "semantic_preference_maintenance_guidance_v0"
+MAINTENANCE_RECEIPT_SCHEMA = "semantic_preference_maintenance_receipt_v0"
 DOCTOR_SCHEMA = "semantic_preference_provider_doctor_v0"
 SURFACE_RE = re.compile(r"^[a-z][a-z0-9_-]*(?:\.[a-z][a-z0-9_-]*)+$")
 TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/#-]{0,199}$")
+CORPUS_ID_RE = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
 MAX_PROVIDER_OUTPUT_BYTES = 256_000
 MAX_ITEM_BYTES = 8_000
 MAX_RECEIPT_REFS = 20
+MAX_CORPORA = 20
 MAX_SETUP_HINT_LENGTH = 1_000
+
+_READ_ROLES = {"primary", "fallback", "reference"}
+_WRITE_MODES = {"read_only", "provider_managed"}
+_WRITEBACK_TRIGGERS = {"explicit_feedback", "source_truth_changed"}
+_CLOSURE_POLICIES = {"none", "write_wait_l2_read_scoped_recall"}
 
 
 def _surface(value: object) -> str:
@@ -207,6 +216,80 @@ def _unavailable(surface: str, policy: str, kind: str) -> dict[str, Any]:
     }
 
 
+def _corpus_inventory(response: Mapping[str, Any]) -> list[dict[str, Any]]:
+    raw = response.get("corpus_inventory")
+    if raw is None:
+        return []
+    if not isinstance(raw, list) or len(raw) > MAX_CORPORA:
+        raise ValueError("provider corpus_inventory must be a bounded list")
+    inventory: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in raw:
+        if not isinstance(item, Mapping):
+            raise ValueError("provider corpus_inventory items must be objects")
+        corpus_id = str(item.get("corpus_id") or "").strip()
+        scope_ref = str(item.get("scope_ref") or "").strip()
+        read_role = str(item.get("read_role") or "").strip()
+        write_mode = str(item.get("write_mode") or "").strip()
+        source_of_truth = str(item.get("source_of_truth") or "").strip()
+        closure_policy = str(item.get("closure_policy") or "none").strip()
+        write_actor_ref = str(item.get("write_actor_ref") or "").strip()
+        triggers = item.get("writeback_triggers") or []
+        if not CORPUS_ID_RE.fullmatch(corpus_id) or corpus_id in seen:
+            raise ValueError("provider corpus_id must be unique lower-snake tokens")
+        if not TOKEN_RE.fullmatch(scope_ref):
+            raise ValueError("provider corpus scope_ref must be a compact token")
+        if read_role not in _READ_ROLES or write_mode not in _WRITE_MODES:
+            raise ValueError("provider corpus read_role or write_mode is invalid")
+        if not TOKEN_RE.fullmatch(source_of_truth):
+            raise ValueError("provider corpus source_of_truth must be a compact token")
+        if closure_policy not in _CLOSURE_POLICIES:
+            raise ValueError("provider corpus closure_policy is invalid")
+        if write_actor_ref and not TOKEN_RE.fullmatch(write_actor_ref):
+            raise ValueError("provider corpus write_actor_ref must be a compact token")
+        if (
+            not isinstance(triggers, list)
+            or len(triggers) > len(_WRITEBACK_TRIGGERS)
+            or any(trigger not in _WRITEBACK_TRIGGERS for trigger in triggers)
+        ):
+            raise ValueError("provider corpus writeback_triggers are invalid")
+        seen.add(corpus_id)
+        inventory.append(
+            {
+                "corpus_id": corpus_id,
+                "scope_ref": scope_ref,
+                "read_role": read_role,
+                "write_mode": write_mode,
+                "write_actor_ref": write_actor_ref or None,
+                "source_of_truth": source_of_truth,
+                "writeback_triggers": sorted(set(triggers)),
+                "closure_policy": closure_policy,
+            }
+        )
+    return inventory
+
+
+def _maintenance_guidance(
+    inventory: Sequence[Mapping[str, Any]],
+) -> dict[str, Any] | None:
+    writable = [item for item in inventory if item.get("write_mode") != "read_only"]
+    if not writable:
+        return None
+    return {
+        "schema_version": MAINTENANCE_GUIDANCE_SCHEMA,
+        "corpus_ids": [str(item["corpus_id"]) for item in writable],
+        "writeback_triggers": sorted(
+            {
+                str(trigger)
+                for item in writable
+                for trigger in item.get("writeback_triggers") or []
+            }
+        ),
+        "closure_outcomes": ["verified", "no_write_rationale"],
+        "completion": "provider_write_then_wait_l2_read_and_scoped_recall",
+    }
+
+
 def recall(
     config: str | Path,
     *,
@@ -296,6 +379,10 @@ def recall(
         for item in bounded
     ):
         return _unavailable(surface_id, policy, "item_too_large")
+    try:
+        inventory = _corpus_inventory(response)
+    except ValueError:
+        return _unavailable(surface_id, policy, "invalid_corpus_inventory")
     return {
         "ok": True,
         "schema_version": RECALL_SCHEMA,
@@ -303,6 +390,8 @@ def recall(
         "surface": surface_id,
         "items": bounded,
         "truncated": len(items) > len(bounded),
+        "corpus_inventory": inventory,
+        "maintenance_guidance": _maintenance_guidance(inventory),
     }
 
 
@@ -335,4 +424,36 @@ def application_receipt(
             {hashlib.sha256(str(ref).encode()).hexdigest()[:16] for ref in refs}
         ),
         "artifact_ref": _token(artifact_ref, "artifact_ref") if artifact_ref else None,
+    }
+
+
+def maintenance_receipt(
+    *,
+    trigger: str,
+    outcome: str,
+    corpus_ids: Sequence[str],
+    scope_refs: Sequence[str] | None = None,
+    evidence_ref: str | None = None,
+) -> dict[str, Any]:
+    if trigger not in _WRITEBACK_TRIGGERS:
+        raise ValueError("trigger must be explicit_feedback or source_truth_changed")
+    if outcome not in {"verified", "no_write_rationale", "failed"}:
+        raise ValueError("outcome must be verified, no_write_rationale, or failed")
+    ids = sorted({str(value or "").strip() for value in corpus_ids})
+    if not ids or len(ids) > MAX_CORPORA or any(
+        not CORPUS_ID_RE.fullmatch(value) for value in ids
+    ):
+        raise ValueError("corpus_ids must contain bounded lower-snake tokens")
+    refs = [str(ref) for ref in scope_refs or [] if str(ref).strip()]
+    if len(refs) > MAX_CORPORA:
+        raise ValueError(f"scope_refs supports at most {MAX_CORPORA} items")
+    return {
+        "schema_version": MAINTENANCE_RECEIPT_SCHEMA,
+        "trigger": trigger,
+        "outcome": outcome,
+        "corpus_ids": ids,
+        "scope_ref_digests": sorted(
+            {hashlib.sha256(ref.encode()).hexdigest()[:16] for ref in refs}
+        ),
+        "evidence_ref": _token(evidence_ref, "evidence_ref") if evidence_ref else None,
     }

--- a/loopx/capabilities/semantic_preference/openviking_provider.py
+++ b/loopx/capabilities/semantic_preference/openviking_provider.py
@@ -146,7 +146,40 @@ def _scope(args: argparse.Namespace) -> ProjectPeerScope:
     )
 
 
-def _describe_scope(scope: ProjectPeerScope) -> dict[str, Any]:
+def _corpus_inventory(
+    scope: ProjectPeerScope, *, include_global_fallback: bool
+) -> list[dict[str, Any]]:
+    inventory: list[dict[str, Any]] = [
+        {
+            "corpus_id": "project_peer_preferences",
+            "scope_ref": scope.preferences_uri,
+            "read_role": "primary",
+            "write_mode": "provider_managed",
+            "write_actor_ref": scope.peer_id,
+            "source_of_truth": "repository_revision_and_explicit_feedback",
+            "writeback_triggers": ["explicit_feedback", "source_truth_changed"],
+            "closure_policy": "write_wait_l2_read_scoped_recall",
+        }
+    ]
+    if include_global_fallback:
+        inventory.append(
+            {
+                "corpus_id": "user_global_preferences",
+                "scope_ref": f"{scope.global_memory_uri}/preferences",
+                "read_role": "fallback",
+                "write_mode": "provider_managed",
+                "write_actor_ref": None,
+                "source_of_truth": "explicit_user_feedback",
+                "writeback_triggers": ["explicit_feedback"],
+                "closure_policy": "write_wait_l2_read_scoped_recall",
+            }
+        )
+    return inventory
+
+
+def _describe_scope(
+    scope: ProjectPeerScope, *, include_global_fallback: bool
+) -> dict[str, Any]:
     return {
         "ok": True,
         "schema_version": SCOPE_SCHEMA,
@@ -158,6 +191,9 @@ def _describe_scope(scope: ProjectPeerScope) -> dict[str, Any]:
         "preferences_uri": scope.preferences_uri,
         "global_memory_uri": scope.global_memory_uri,
         "global_fallback_default": False,
+        "corpus_inventory": _corpus_inventory(
+            scope, include_global_fallback=include_global_fallback
+        ),
     }
 
 
@@ -199,7 +235,13 @@ def run_openviking_provider(args: argparse.Namespace) -> int:
 
     scope = _scope(args)
     if args.describe_scope:
-        json.dump(_describe_scope(scope), sys.stdout, ensure_ascii=False)
+        json.dump(
+            _describe_scope(
+                scope, include_global_fallback=args.include_global_fallback
+            ),
+            sys.stdout,
+            ensure_ascii=False,
+        )
         return 0
 
     if not 1 <= args.max_find_calls <= MAX_FIND_CALLS:
@@ -227,7 +269,16 @@ def run_openviking_provider(args: argparse.Namespace) -> int:
         )
         if items:
             break
-    json.dump({"schema_version": RESPONSE_SCHEMA, "items": items}, sys.stdout)
+    json.dump(
+        {
+            "schema_version": RESPONSE_SCHEMA,
+            "items": items,
+            "corpus_inventory": _corpus_inventory(
+                scope, include_global_fallback=args.include_global_fallback
+            ),
+        },
+        sys.stdout,
+    )
     return 0
 
 


### PR DESCRIPTION
## Summary

- extend provider-neutral semantic preference responses with an optional bounded corpus inventory
- propagate maintenance guidance through the Issue Fix PR-description boundary without an extra provider call
- add stateless hashed maintenance receipts and document OpenViking write/readback closure
- keep repository PR templates authoritative; OpenViking stores only soft fill preferences

## Issue Or Task

- Contributor task ID: `todo_6a1dc80085c2`

## Validation

- [x] `python3 examples/semantic-preference-hook-smoke.py`
- [x] `python3 examples/openviking-project-peer-provider-smoke.py`
- [x] `python3 examples/issue-fix-pr-description-builder-smoke.py`
- [x] `loopx canary premerge --from-git-diff` (17 selected checks, no failures; self-merge allowed)
- [x] public/private boundary scan clean for all 11 changed files
- [x] real OpenViking project-peer provider call returned the updated PR-description preference plus the exact corpus inventory

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked task.

## Residual risk

- Provider-specific writes remain outside LoopX by design; LoopX reports which corpus and closure policy apply, but never performs an implicit semantic write.