### PR TITLE
Reconcile generated Explore stage sections

### DIFF
--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -946,7 +946,7 @@ def sync_explore_visuals_to_lark(
             for item in role_view.get("stage_views") or []
             if isinstance(item, Mapping)
         ]
-        configured_stages, section_commands, stage_config_error = ensure_stage_whiteboards(
+        configured_stages, section_commands, _, reconciliation, stage_config_error = ensure_stage_whiteboards(
             config,
             role=role,
             role_sink=role_sink,
@@ -975,6 +975,7 @@ def sync_explore_visuals_to_lark(
                 "configured_stage_count": len(configured_stages),
                 "missing_stage_indexes": missing_stage_indexes,
                 "section_commands": section_commands,
+                "reconciliation": reconciliation,
                 "error": stage_config_error
                 or "configure one document section and whiteboard token for each Evidence Stage",
             }
@@ -1052,6 +1053,7 @@ def sync_explore_visuals_to_lark(
             "stage_capacity": stage_capacity,
             "stages": stage_results,
             "section_commands": section_commands,
+            "reconciliation": reconciliation,
         }
     ok = all(bool(item.get("ok")) for item in results.values())
     if not results:
@@ -1754,6 +1756,7 @@ def sync_issue_fix_explore_on_material_change(
             digest
             and (
                 not visual_preview.get("ok")
+                or any(bool(view.get("reconciliation", {}).get("required")) for view in visual_preview.get("views", {}).values())
                 or any(
                     prior_visual_delivery_digests.get(role) != delivery_digest
                     for role, delivery_digest in expected_visual_delivery_digests.items()

--- a/loopx/presentation/sinks/lark/explore_stage_document.py
+++ b/loopx/presentation/sinks/lark/explore_stage_document.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import html
+import re
+import xml.etree.ElementTree as ET
+from collections import defaultdict
 from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any, Protocol
@@ -17,6 +20,11 @@ class StageDocumentConfig(Protocol):
 
 LocalConfigReader = Callable[[Path], dict[str, Any]]
 LocalConfigWriter = Callable[[Path, Mapping[str, Any]], None]
+
+_STAGE_HEADING_RE = re.compile(r"^Evidence Stage (\d+)$")
+_MANAGED_STAGE_PARAGRAPH_SUFFIX = (
+    "完整 Nodes / Edges / Findings 仍以同一 Base 为准。"
+)
 
 
 def _stage_section_xml(stage: Mapping[str, Any]) -> str:
@@ -45,12 +53,12 @@ def _stage_section_xml(stage: Mapping[str, Any]) -> str:
     )
 
 
-def _created_whiteboard_block(command: Mapping[str, Any]) -> dict[str, Any] | None:
+def _created_stage_section(command: Mapping[str, Any]) -> dict[str, Any] | None:
     payload = command.get("json")
     data = payload.get("data") if isinstance(payload, Mapping) else None
     document = data.get("document") if isinstance(data, Mapping) else None
     blocks = document.get("new_blocks") if isinstance(document, Mapping) else None
-    return next(
+    whiteboard = next(
         (
             dict(block)
             for block in blocks or []
@@ -60,6 +68,132 @@ def _created_whiteboard_block(command: Mapping[str, Any]) -> dict[str, Any] | No
         ),
         None,
     )
+    if not whiteboard:
+        return None
+    return {
+        "whiteboard_block_id": str(whiteboard.get("block_id") or "").strip()
+        or None,
+        "whiteboard_token": str(whiteboard.get("block_token") or "").strip(),
+        "generated_block_ids": [
+            str(block.get("block_id") or "").strip()
+            for block in blocks or []
+            if isinstance(block, Mapping)
+            and str(block.get("block_id") or "").strip()
+        ],
+    }
+
+
+def _document_content(command: Mapping[str, Any]) -> str:
+    payload = command.get("json")
+    data = payload.get("data") if isinstance(payload, Mapping) else None
+    document = data.get("document") if isinstance(data, Mapping) else None
+    return str(document.get("content") or "") if isinstance(document, Mapping) else ""
+
+
+def _document_revision(command: Mapping[str, Any]) -> int | None:
+    payload = command.get("json")
+    data = payload.get("data") if isinstance(payload, Mapping) else None
+    document = data.get("document") if isinstance(data, Mapping) else None
+    revision = document.get("revision_id") if isinstance(document, Mapping) else None
+    try:
+        return int(revision) if revision is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _xml_root(command: Mapping[str, Any]) -> ET.Element | None:
+    content = _document_content(command).strip()
+    if not content:
+        return None
+    try:
+        return ET.fromstring(content)
+    except ET.ParseError:
+        return None
+
+
+def _stage_headings(command: Mapping[str, Any]) -> list[dict[str, Any]] | None:
+    root = _xml_root(command)
+    if root is None:
+        return None
+    headings: list[dict[str, Any]] = []
+    for element in root.iter():
+        if element.tag != "h2":
+            continue
+        title = "".join(element.itertext()).strip()
+        match = _STAGE_HEADING_RE.fullmatch(title)
+        block_id = str(element.get("id") or "").strip()
+        if match and block_id:
+            headings.append(
+                {
+                    "stage_index": int(match.group(1)),
+                    "heading_block_id": block_id,
+                }
+            )
+    return headings
+
+
+def _managed_stage_section(
+    command: Mapping[str, Any], *, stage_index: int
+) -> dict[str, Any] | None:
+    root = _xml_root(command)
+    if root is None:
+        return None
+    blocks = list(root) if root.tag == "fragment" else [root]
+    if len(blocks) != 3:
+        return None
+    heading, paragraph, whiteboard = blocks
+    expected_title = f"Evidence Stage {stage_index:02d}"
+    if (
+        heading.tag != "h2"
+        or "".join(heading.itertext()).strip() != expected_title
+        or paragraph.tag != "p"
+        or not "".join(paragraph.itertext()).strip().endswith(
+            _MANAGED_STAGE_PARAGRAPH_SUFFIX
+        )
+        or whiteboard.tag != "whiteboard"
+    ):
+        return None
+    block_ids = [
+        str(block.get("id") or "").strip()
+        for block in (heading, paragraph, whiteboard)
+    ]
+    whiteboard_token = str(whiteboard.get("token") or "").strip()
+    if not all(block_ids) or not whiteboard_token:
+        return None
+    return {
+        "stage_index": stage_index,
+        "section_title": expected_title,
+        "heading_block_id": block_ids[0],
+        "whiteboard_block_id": block_ids[2],
+        "whiteboard_token": whiteboard_token,
+        "generated_block_ids": block_ids,
+    }
+
+
+def _docs_fetch_command(
+    config: StageDocumentConfig,
+    *,
+    docx_token: str,
+    scope: str,
+    start_block_id: str | None = None,
+) -> list[str]:
+    command = [
+        config.cli_bin,
+        "docs",
+        "+fetch",
+        "--as",
+        config.identity,
+        "--doc",
+        docx_token,
+        "--scope",
+        scope,
+    ]
+    if scope == "outline":
+        command.extend(["--max-depth", "2"])
+    if start_block_id:
+        command.extend(["--start-block-id", start_block_id])
+    command.extend(["--detail", "with-ids", "--format", "json"])
+    return command
 
 
 def ensure_stage_whiteboards(
@@ -73,8 +207,14 @@ def ensure_stage_whiteboards(
     runner: CommandRunner,
     read_local_config: LocalConfigReader,
     write_local_config: LocalConfigWriter,
-) -> tuple[dict[int, dict[str, Any]], list[dict[str, Any]], str | None]:
-    """Resolve or create the stage boards and checkpoint each created token."""
+) -> tuple[
+    dict[int, dict[str, Any]],
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    dict[str, Any],
+    str | None,
+]:
+    """Reconcile, resolve, or create stage boards and checkpoint every mutation."""
 
     configured = {
         int(item.get("stage_index") or 0): dict(item)
@@ -88,18 +228,14 @@ def ensure_stage_whiteboards(
             "stage_index": 1,
             "whiteboard_token": str(role_sink.get("whiteboard_token") or "").strip(),
         }
-    missing = [
-        stage
+    configured_before = {index: dict(item) for index, item in configured.items()}
+    desired_indexes = {
+        int(stage.get("stage_index") or 0)
         for stage in stage_views
-        if int(stage.get("stage_index") or 0) not in configured
-    ]
-    if not missing:
-        return configured, [], None
+        if int(stage.get("stage_index") or 0) > 0
+    }
+    stale_configured_indexes = sorted(set(configured) - desired_indexes)
     docx_token = str(role_sink.get("docx_token") or "").strip()
-    if not docx_token:
-        return configured, [], (
-            "docx_token is required to create missing Evidence Stage sections"
-        )
 
     def persist_configured_stages() -> None:
         local = read_local_config(config_path)
@@ -117,7 +253,293 @@ def ensure_stage_whiteboards(
         updated["visual_sinks"] = sinks
         write_local_config(config_path, updated)
 
-    commands = []
+    reconciliation_commands: list[dict[str, Any]] = []
+    reconciliation: dict[str, Any] = {
+        "required": bool(stale_configured_indexes),
+        "performed": False,
+        "remote_checked": False,
+        "stale_stage_indexes": stale_configured_indexes,
+        "duplicate_stage_indexes": [],
+        "adopted_stage_indexes": [],
+        "deleted_section_count": 0,
+        "deleted_block_count": 0,
+    }
+
+    def observe(command: Mapping[str, Any], *, action: str) -> None:
+        reconciliation_commands.append(
+            {
+                "action": action,
+                "ok": bool(command.get("ok")),
+                "returncode": command.get("returncode"),
+                "error": None if command.get("ok") else _command_error(command),
+            }
+        )
+
+    if execute and docx_token:
+        outline_command = _run_command(
+            _docs_fetch_command(
+                config,
+                docx_token=docx_token,
+                scope="outline",
+            ),
+            execute=True,
+            runner=runner,
+            cwd=config_path.parent,
+        )
+        observe(outline_command, action="fetch_stage_outline")
+        headings = _stage_headings(outline_command) if outline_command.get("ok") else None
+        if headings is None:
+            reconciliation["required"] = True
+            return (
+                configured,
+                [],
+                reconciliation_commands,
+                reconciliation,
+                _command_error(outline_command)
+                if not outline_command.get("ok")
+                else "Evidence Stage outline could not be parsed",
+            )
+        reconciliation["remote_checked"] = True
+        headings_by_stage: dict[int, list[str]] = defaultdict(list)
+        for heading in headings:
+            headings_by_stage[int(heading["stage_index"])].append(
+                str(heading["heading_block_id"])
+            )
+        stale_remote_indexes = sorted(
+            index for index in headings_by_stage if index not in desired_indexes
+        )
+        duplicate_stage_indexes = sorted(
+            index
+            for index, block_ids in headings_by_stage.items()
+            if index in desired_indexes and len(block_ids) > 1
+        )
+        reconciliation["stale_stage_indexes"] = sorted(
+            set(stale_configured_indexes) | set(stale_remote_indexes)
+        )
+        reconciliation["duplicate_stage_indexes"] = duplicate_stage_indexes
+        reconciliation["required"] = bool(
+            reconciliation["stale_stage_indexes"] or duplicate_stage_indexes
+        )
+
+        sections_by_stage: dict[int, list[dict[str, Any]]] = defaultdict(list)
+        indexes_to_inspect = sorted(
+            set(stale_remote_indexes)
+            | set(duplicate_stage_indexes)
+            | {
+                index
+                for index in desired_indexes
+                if index not in configured and headings_by_stage.get(index)
+            }
+        )
+        for stage_index in indexes_to_inspect:
+            for heading_block_id in headings_by_stage.get(stage_index, []):
+                section_command = _run_command(
+                    _docs_fetch_command(
+                        config,
+                        docx_token=docx_token,
+                        scope="section",
+                        start_block_id=heading_block_id,
+                    ),
+                    execute=True,
+                    runner=runner,
+                    cwd=config_path.parent,
+                )
+                observe(
+                    section_command,
+                    action=f"fetch_stage_section_{stage_index:02d}",
+                )
+                section = (
+                    _managed_stage_section(section_command, stage_index=stage_index)
+                    if section_command.get("ok")
+                    else None
+                )
+                if section is None:
+                    reconciliation["required"] = True
+                    return (
+                        configured,
+                        [],
+                        reconciliation_commands,
+                        reconciliation,
+                        _command_error(section_command)
+                        if not section_command.get("ok")
+                        else (
+                            f"Evidence Stage {stage_index:02d} conflicts with an "
+                            "unmanaged document section; refusing destructive cleanup"
+                        ),
+                    )
+                sections_by_stage[stage_index].append(section)
+
+        sections_to_delete: list[dict[str, Any]] = []
+        for stage_index in stale_remote_indexes:
+            sections_to_delete.extend(sections_by_stage[stage_index])
+        adopted_stage_indexes: list[int] = []
+        for stage_index in sorted(desired_indexes):
+            sections = sections_by_stage.get(stage_index, [])
+            if stage_index not in configured and sections:
+                keep = sections[-1]
+                configured[stage_index] = {
+                    key: value
+                    for key, value in keep.items()
+                    if key != "heading_block_id"
+                }
+                adopted_stage_indexes.append(stage_index)
+                sections_to_delete.extend(sections[:-1])
+                continue
+            if len(sections) <= 1:
+                continue
+            configured_token = str(
+                configured[stage_index].get("whiteboard_token") or ""
+            ).strip()
+            matching = [
+                section
+                for section in sections
+                if section["whiteboard_token"] == configured_token
+            ]
+            if len(matching) != 1:
+                reconciliation["required"] = True
+                return (
+                    configured,
+                    [],
+                    reconciliation_commands,
+                    reconciliation,
+                    (
+                        f"Evidence Stage {stage_index:02d} has duplicate managed "
+                        "sections but no unique configured whiteboard match"
+                    ),
+                )
+            keep = matching[0]
+            sections_to_delete.extend(
+                section for section in sections if section is not keep
+            )
+
+        reconciliation["adopted_stage_indexes"] = adopted_stage_indexes
+        if sections_to_delete:
+            block_ids = [
+                block_id
+                for section in sections_to_delete
+                for block_id in section["generated_block_ids"]
+            ]
+            delete_args = [
+                config.cli_bin,
+                "docs",
+                "+update",
+                "--as",
+                config.identity,
+                "--doc",
+                docx_token,
+                "--command",
+                "block_delete",
+                "--block-id",
+                ",".join(block_ids),
+            ]
+            revision = _document_revision(outline_command)
+            if revision is not None:
+                delete_args.extend(["--revision-id", str(revision)])
+            delete_args.extend(["--format", "json"])
+            delete_command = _run_command(
+                delete_args,
+                execute=True,
+                runner=runner,
+                cwd=config_path.parent,
+            )
+            observe(delete_command, action="delete_stale_stage_sections")
+            if not delete_command.get("ok"):
+                reconciliation["required"] = True
+                return (
+                    configured,
+                    [],
+                    reconciliation_commands,
+                    reconciliation,
+                    _command_error(delete_command),
+                )
+            verification_command = _run_command(
+                _docs_fetch_command(
+                    config,
+                    docx_token=docx_token,
+                    scope="outline",
+                ),
+                execute=True,
+                runner=runner,
+                cwd=config_path.parent,
+            )
+            observe(verification_command, action="verify_stage_outline")
+            remaining = (
+                _stage_headings(verification_command)
+                if verification_command.get("ok")
+                else None
+            )
+            if remaining is None:
+                reconciliation["required"] = True
+                return (
+                    configured,
+                    [],
+                    reconciliation_commands,
+                    reconciliation,
+                    _command_error(verification_command)
+                    if not verification_command.get("ok")
+                    else "updated Evidence Stage outline could not be parsed",
+                )
+            remaining_by_stage: dict[int, int] = defaultdict(int)
+            for heading in remaining:
+                remaining_by_stage[int(heading["stage_index"])] += 1
+            if any(
+                index not in desired_indexes or count > 1
+                for index, count in remaining_by_stage.items()
+            ):
+                reconciliation["required"] = True
+                return (
+                    configured,
+                    [],
+                    reconciliation_commands,
+                    reconciliation,
+                    "Evidence Stage cleanup did not converge on remote readback",
+                )
+            reconciliation["deleted_section_count"] = len(sections_to_delete)
+            reconciliation["deleted_block_count"] = len(block_ids)
+
+        configured = {
+            index: item
+            for index, item in configured.items()
+            if index in desired_indexes
+        }
+        if configured != configured_before:
+            persist_configured_stages()
+        reconciliation["performed"] = bool(
+            reconciliation["stale_stage_indexes"]
+            or reconciliation["duplicate_stage_indexes"]
+            or adopted_stage_indexes
+        )
+        reconciliation["required"] = False
+    elif stale_configured_indexes:
+        if not docx_token:
+            return (
+                configured,
+                [],
+                reconciliation_commands,
+                reconciliation,
+                "docx_token is required to reconcile stale Evidence Stage sections",
+            )
+        configured = {
+            index: item
+            for index, item in configured.items()
+            if index in desired_indexes
+        }
+
+    missing = [
+        stage
+        for stage in stage_views
+        if int(stage.get("stage_index") or 0) not in configured
+    ]
+    if missing and not docx_token:
+        return (
+            configured,
+            [],
+            reconciliation_commands,
+            reconciliation,
+            "docx_token is required to create missing Evidence Stage sections",
+        )
+
+    section_commands: list[dict[str, Any]] = []
     for stage in missing:
         stage_index = int(stage.get("stage_index") or 0)
         command = _run_command(
@@ -140,23 +562,30 @@ def ensure_stage_whiteboards(
             runner=runner,
             cwd=config_path.parent,
         )
-        commands.append(command)
+        section_commands.append(command)
         if not command.get("ok"):
-            return configured, commands, _command_error(command)
+            return (
+                configured,
+                section_commands,
+                reconciliation_commands,
+                reconciliation,
+                _command_error(command),
+            )
         if execute:
-            block = _created_whiteboard_block(command)
-            if not block:
-                return configured, commands, (
+            section = _created_stage_section(command)
+            if not section:
+                return (
+                    configured,
+                    section_commands,
+                    reconciliation_commands,
+                    reconciliation,
                     f"Evidence Stage {stage_index:02d} section was created "
-                    "without a whiteboard token"
+                    "without a whiteboard token",
                 )
             configured[stage_index] = {
                 "stage_index": stage_index,
                 "section_title": f"Evidence Stage {stage_index:02d}",
-                "whiteboard_block_id": (
-                    str(block.get("block_id") or "").strip() or None
-                ),
-                "whiteboard_token": str(block.get("block_token") or "").strip(),
+                **section,
             }
             persist_configured_stages()
         else:
@@ -165,4 +594,10 @@ def ensure_stage_whiteboards(
                 "section_title": f"Evidence Stage {stage_index:02d}",
                 "whiteboard_token": f"planned-stage-{stage_index:02d}",
             }
-    return configured, commands, None
+    return (
+        configured,
+        section_commands,
+        reconciliation_commands,
+        reconciliation,
+        None,
+    )

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -1273,7 +1273,21 @@ def test_visual_sync_creates_one_document_section_and_board_per_missing_stage(
 
     def runner(args, cwd, _timeout):
         nonlocal created_stage
-        if "docs" in args and "+update" in args:
+        if "docs" in args and "+fetch" in args:
+            payload = {
+                "ok": True,
+                "data": {
+                    "document": {
+                        "revision_id": 1,
+                        "content": (
+                            '<fragment mode="outline"><outline>'
+                            '<h2 id="heading_stage_01">Evidence Stage 01</h2>'
+                            "</outline></fragment>"
+                        ),
+                    }
+                },
+            }
+        elif "docs" in args and "+update" in args:
             created_stage += 1
             payload = {
                 "ok": True,
@@ -1333,6 +1347,171 @@ def test_visual_sync_creates_one_document_section_and_board_per_missing_stage(
     assert [item["whiteboard_token"] for item in stage_boards] == [
         f"wb_stage_{index:02d}" for index in range(1, stage_count + 1)
     ]
+
+
+def test_stage_document_reconciliation_removes_all_stale_duplicate_sections(
+    tmp_path,
+) -> None:
+    projection = _complex_projection()
+    bundle = build_explore_presentation_bundle(projection)
+    stage_count = len(bundle["executive"]["stage_views"])
+    stale_index = stage_count + 1
+    config = LarkExploreConfig(base_token="PUBLIC_FIXTURE_BASE")
+    config_path = tmp_path / "lark-explore.json"
+    sink = {
+        "docx_token": "doc_public_fixture",
+        "view_role": "executive",
+        "renderer": "mermaid",
+        "stage_whiteboards": [
+            {
+                "stage_index": index,
+                "whiteboard_token": f"wb_stage_{index:02d}",
+            }
+            for index in range(1, stale_index + 1)
+        ],
+    }
+    write_lark_explore_local_config(
+        config_path,
+        {
+            "board": {"base_token": "PUBLIC_FIXTURE_BASE"},
+            "visual_sinks": {"executive": sink},
+        },
+    )
+    stale_headings = [f"stale_heading_{number}" for number in range(1, 4)]
+    deleted_block_ids: list[str] = []
+    published_markers: dict[str, str] = {}
+
+    def outline_xml() -> str:
+        headings = [
+            f'<h2 id="heading_stage_{index:02d}">Evidence Stage {index:02d}</h2>'
+            for index in range(1, stage_count + 1)
+        ]
+        headings.extend(
+            f'<h2 id="{heading}">Evidence Stage {stale_index:02d}</h2>'
+            for heading in stale_headings
+        )
+        return '<fragment mode="outline"><outline>' + "".join(headings) + "</outline></fragment>"
+
+    def runner(args, cwd, _timeout):
+        if "docs" in args and "+fetch" in args and "outline" in args:
+            payload = {
+                "ok": True,
+                "data": {
+                    "document": {
+                        "revision_id": 7,
+                        "content": outline_xml(),
+                    }
+                },
+            }
+        elif "docs" in args and "+fetch" in args and "section" in args:
+            heading = args[args.index("--start-block-id") + 1]
+            number = heading.rsplit("_", 1)[-1]
+            payload = {
+                "ok": True,
+                "data": {
+                    "document": {
+                        "revision_id": 7,
+                        "content": (
+                            f'<fragment mode="section"><h2 id="{heading}">'
+                            f"Evidence Stage {stale_index:02d}</h2>"
+                            f'<p id="stale_paragraph_{number}">本阶段包含 1 个主节点、'
+                            "0 个关系上下文节点；主线：Explore work；跨主线真实关系：0 条。"
+                            "完整 Nodes / Edges / Findings 仍以同一 Base 为准。</p>"
+                            f'<whiteboard id="stale_board_{number}" token="wb_stale_{number}">'
+                            "</whiteboard></fragment>"
+                        ),
+                    }
+                },
+            }
+        elif "docs" in args and "+update" in args:
+            deleted_block_ids.extend(
+                args[args.index("--block-id") + 1].split(",")
+            )
+            stale_headings.clear()
+            payload = {
+                "ok": True,
+                "data": {"document": {"revision_id": 8}},
+            }
+        elif "+update" in args:
+            token = args[args.index("--whiteboard-token") + 1]
+            source_arg = args[args.index("--source") + 1]
+            source = (cwd / source_arg.removeprefix("@")).read_text(
+                encoding="utf-8"
+            )
+            published_markers[token] = re.search(
+                r"LoopX delivery [0-9a-f]{20}", source
+            ).group(0)
+            payload = {"ok": True}
+        else:
+            token = args[args.index("--whiteboard-token") + 1]
+            payload = {
+                "ok": True,
+                "data": {
+                    "nodes": [{"text": {"text": published_markers[token]}}]
+                },
+            }
+        return {
+            "returncode": 0,
+            "stdout": json.dumps(payload),
+            "stderr": "",
+        }
+
+    synced = sync_explore_visuals_to_lark(
+        config,
+        projection=projection,
+        visual_sinks={"executive": sink},
+        config_path=config_path,
+        execute=True,
+        runner=runner,
+    )
+
+    view = synced["views"]["executive"]
+    assert synced["ok"] is True
+    assert view["reconciliation"] == {
+        "required": False,
+        "performed": True,
+        "remote_checked": True,
+        "stale_stage_indexes": [stale_index],
+        "duplicate_stage_indexes": [],
+        "adopted_stage_indexes": [],
+        "deleted_section_count": 3,
+        "deleted_block_count": 9,
+    }
+    assert len(deleted_block_ids) == 9
+    stored = read_lark_explore_local_config(config_path)
+    assert [
+        item["stage_index"]
+        for item in stored["visual_sinks"]["executive"]["stage_whiteboards"]
+    ] == list(range(1, stage_count + 1))
+
+
+def test_stage_document_preview_surfaces_stale_config_reconciliation(tmp_path) -> None:
+    projection = _complex_projection()
+    bundle = build_explore_presentation_bundle(projection)
+    stage_count = len(bundle["executive"]["stage_views"])
+    sink = {
+        "docx_token": "doc_public_fixture",
+        "view_role": "executive",
+        "stage_whiteboards": [
+            {
+                "stage_index": index,
+                "whiteboard_token": f"wb_stage_{index:02d}",
+            }
+            for index in range(1, stage_count + 2)
+        ],
+    }
+
+    preview = sync_explore_visuals_to_lark(
+        LarkExploreConfig(base_token="PUBLIC_FIXTURE_BASE"),
+        projection=projection,
+        visual_sinks={"executive": sink},
+        config_path=tmp_path / "lark-explore.json",
+    )
+
+    reconciliation = preview["views"]["executive"]["reconciliation"]
+    assert reconciliation["required"] is True
+    assert reconciliation["performed"] is False
+    assert reconciliation["stale_stage_indexes"] == [stage_count + 1]
 
 
 def test_visual_delivery_digest_changes_when_target_whiteboard_changes(tmp_path) -> None:


### PR DESCRIPTION
Summary:
- reconcile remote Evidence Stage headings against the current projected stage set before publishing
- remove only validated LoopX-managed stale or duplicate heading/paragraph/whiteboard triples, then verify the remote outline
- recover created stage boards after interrupted config checkpointing and surface reconciliation in dry-run sync decisions

Validation:
- 31 focused Explore presentation tests passed
- ruff check passed for touched files
- Python compile passed
- LoopX standard premerge canary passed, including repository Python line-budget smoke
- real configured dry-run reported stage_count=3 and reconciliation.required=true for stale Stage 04 state

Boundary:
- no project-specific document ids, links, local state, credentials, or raw remote content are committed
- destructive cleanup fails closed for sections that do not match the LoopX-managed three-block contract