### PR TITLE
Keep scheduler ACKs on the originating registry route

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -745,6 +745,11 @@ After a successful host RRULE update, the agent records that fact with
 advances the per goal/agent scheduler state without spending quota. Human gates
 can move to `[30, 60, 120]` after the
 concrete user todo has been surfaced.
+CLI-produced ACK hints bind that argument vector to the exact registry and
+effective runtime root that produced `quota should-run`. Hosts must execute the
+complete vector; stripping its leading global options can route a
+project-launched ACK into project-local scheduler state instead of the shared
+control plane.
 Monitor-only quiet waits move through `[15, 30, 60]` while preserving the
 same no-spend monitor-poll contract, unless a monitor cadence or due time caps
 the progression earlier.

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1348,6 +1348,10 @@ LoopX advances the progression until the max interval; when the reset token
 changes, the next projected RRULE returns to
 `reset_policy.codex_app_initial_rrule`. If the current desired RRULE is already
 applied, `recommended_rrule` is omitted and the host update should be skipped.
+For CLI payloads, `ack_hint.cli_args` begins with the registry and effective
+runtime-root binding used by the originating `should-run` call. Consumers must
+preserve that prefix so the ACK cannot split scheduler state between project
+and shared registries.
 `scheduler-ack` only records the applied host cadence; the next RRULE, if any,
 is projected by a future `quota should-run`, not by the ack response.
 The payload also includes `execution_obligation`, which is the compatibility

--- a/examples/control_plane/quota-scheduler-hint-compaction-smoke.py
+++ b/examples/control_plane/quota-scheduler-hint-compaction-smoke.py
@@ -71,6 +71,8 @@ def assert_compact_runtime_policy_complete(
     *,
     expected_goal_id: str,
     expected_agent_id: str,
+    expected_registry_path: Path | None = None,
+    expected_runtime_root: Path | None = None,
 ) -> None:
     codex_app = compact["codex_app"]
     unchanged_poll = compact["unchanged_poll"]
@@ -109,7 +111,7 @@ def assert_compact_runtime_policy_complete(
     assert ack_args["applied_rrule"] == codex_app["recommended_rrule"], (name, compact)
     assert ack_args["reset_token"] == stateful_backoff["reset_token"], (name, compact)
     assert ack_args["identity_signature"] == stateful_backoff["identity_signature"], (name, compact)
-    assert ack_cli_args == [
+    expected_cli_args = [
         "quota",
         "scheduler-ack-current",
         "--goal-id",
@@ -123,7 +125,24 @@ def assert_compact_runtime_policy_complete(
         "--applied-rrule",
         ack_args["applied_rrule"],
         "--execute",
-    ], (name, compact)
+    ]
+    if expected_registry_path is not None and expected_runtime_root is not None:
+        expected_cli_args = [
+            "--registry",
+            str(expected_registry_path.resolve()),
+            "--runtime-root",
+            str(expected_runtime_root.resolve()),
+            *expected_cli_args,
+        ]
+        assert ack_hint["route_binding"] == {
+            "schema_version": "scheduler_ack_cli_route_v0",
+            "source": "quota_cli_invocation",
+            "registry_bound": True,
+            "runtime_root_bound": True,
+        }, (name, compact)
+    else:
+        assert "route_binding" not in ack_hint, (name, compact)
+    assert ack_cli_args == expected_cli_args, (name, compact)
     for omitted in (
         "progression_minutes",
         "current_interval_minutes",
@@ -288,6 +307,8 @@ def assert_cli_compact_and_detail_contract() -> None:
         compact,
         expected_goal_id="needs-operator",
         expected_agent_id=fixture.SCOPED_AGENT_ID,
+        expected_registry_path=registry_path,
+        expected_runtime_root=runtime,
     )
     for key in RUNTIME_KEYS:
         assert key not in compact, (key, compact)

--- a/examples/control_plane/quota-scheduler-registry-route-smoke.py
+++ b/examples/control_plane/quota-scheduler-registry-route-smoke.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Keep scheduler ACK writes on the registry/runtime that emitted the hint."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENT_ID = "codex-scheduler-route-smoke"
+GOAL_ID = "scheduler-route-smoke"
+
+
+def write_registry(path: Path, *, project: Path, runtime: Path) -> None:
+    state_file = project / ".loopx" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(
+        "---\nstatus: active\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n\n"
+        f"# {GOAL_ID}\n\n## Agent Todo\n\n- [ ] Run scheduler route smoke.\n",
+        encoding="utf-8",
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "scheduler-route-smoke",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": str(state_file.relative_to(project)),
+                        "adapter": {
+                            "kind": "read_only_project_map_v0",
+                            "status": "connected-read-only",
+                        },
+                        "coordination": {
+                            "registered_agents": [AGENT_ID],
+                            "agent_model": "peer_v1",
+                        },
+                        "quota": {"compute": 1.0, "window_hours": 24},
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def run_cli(*args: str, cwd: Path) -> dict:
+    result = subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--format", "json", *args],
+        cwd=cwd,
+        check=False,
+        text=True,
+        capture_output=True,
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict), payload
+    return payload
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-scheduler-registry-route-") as tmp:
+        root = Path(tmp)
+        project = root / "project"
+        project.mkdir()
+        project_registry = project / ".loopx" / "registry.json"
+        project_runtime = project / ".loopx" / "runtime"
+        global_registry = root / "shared" / "registry.global.json"
+        global_runtime = root / "shared" / "runtime"
+        write_registry(project_registry, project=project, runtime=project_runtime)
+        write_registry(global_registry, project=project, runtime=global_runtime)
+
+        decision = run_cli(
+            "--registry",
+            str(global_registry),
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--scan-path",
+            str(project),
+            cwd=project,
+        )
+        ack_hint = decision["scheduler_hint"]["codex_app"]["ack_hint"]
+        ack_cli_args = ack_hint["cli_args"]
+        assert ack_cli_args[:4] == [
+            "--registry",
+            str(global_registry.resolve()),
+            "--runtime-root",
+            str(global_runtime.resolve()),
+        ], ack_hint
+        assert ack_hint["route_binding"] == {
+            "schema_version": "scheduler_ack_cli_route_v0",
+            "source": "quota_cli_invocation",
+            "registry_bound": True,
+            "runtime_root_bound": True,
+        }, ack_hint
+
+        ack = run_cli(*ack_cli_args, "--scan-path", str(project), cwd=project)
+        state_path = Path(ack["scheduler_state_path"])
+        assert state_path.resolve().is_relative_to(global_runtime.resolve()), ack
+        assert state_path.exists(), ack
+        assert not project_runtime.exists(), project_runtime
+
+        follow_up = run_cli(
+            "--registry",
+            str(global_registry),
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--scan-path",
+            str(project),
+            cwd=project,
+        )
+        stateful = follow_up["scheduler_hint"]["codex_app"]["stateful_backoff"]
+        assert stateful["state_status"] == "same_identity", follow_up
+
+    print("quota scheduler registry route smoke passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/control_plane/quota-scheduler-state-ack-smoke.py
+++ b/examples/control_plane/quota-scheduler-state-ack-smoke.py
@@ -9,6 +9,7 @@ import importlib.util
 import json
 import os
 from pathlib import Path
+import subprocess
 import sys
 import tempfile
 
@@ -765,7 +766,13 @@ def assert_cli_scheduler_ack_progression() -> None:
         assert first_ack_args["applied_rrule"] == first_rrule, first
         assert first_ack_args["reset_token"], first
         assert first_ack_args["identity_signature"], first
-        assert first_ack_cli_args[:2] == ["quota", "scheduler-ack-current"], first
+        assert first_ack_cli_args[:4] == [
+            "--registry",
+            str(registry_path.resolve()),
+            "--runtime-root",
+            str(runtime.resolve()),
+        ], first
+        assert first_ack_cli_args[4:6] == ["quota", "scheduler-ack-current"], first
         assert "--reset-token" not in first_ack_cli_args, first
         assert "--identity-signature" not in first_ack_cli_args, first
 
@@ -1159,6 +1166,11 @@ def main() -> int:
     assert_cli_host_rrule_repairs_false_ack()
     assert_cli_ignores_corrupt_scheduler_state()
     assert_cli_scheduler_ack_uses_should_run_lookback()
+    subprocess.run(
+        [sys.executable, str(REPO_ROOT / "examples/control_plane/quota-scheduler-registry-route-smoke.py")],
+        cwd=REPO_ROOT,
+        check=True,
+    )
     print("quota-scheduler-state-ack-smoke ok")
     return 0
 

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -35,6 +35,43 @@ PrintPayload = Callable[
 RolloutEventAppender = Callable[..., dict[str, object]]
 
 
+def _bind_scheduler_ack_cli_route(
+    payload: dict[str, object],
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+) -> None:
+    """Keep the follow-up ACK on the registry/runtime that built the hint."""
+
+    scheduler_hint = payload.get("scheduler_hint")
+    if not isinstance(scheduler_hint, dict):
+        return
+    codex_app = scheduler_hint.get("codex_app")
+    if not isinstance(codex_app, dict):
+        return
+    ack_hint = codex_app.get("ack_hint")
+    if not isinstance(ack_hint, dict):
+        return
+    cli_args = ack_hint.get("cli_args")
+    if not isinstance(cli_args, list) or not cli_args:
+        return
+    if cli_args[0] == "--registry":
+        return
+    ack_hint["cli_args"] = [
+        "--registry",
+        str(registry_path.expanduser().resolve()),
+        "--runtime-root",
+        str(runtime_root.expanduser().resolve()),
+        *cli_args,
+    ]
+    ack_hint["route_binding"] = {
+        "schema_version": "scheduler_ack_cli_route_v0",
+        "source": "quota_cli_invocation",
+        "registry_bound": True,
+        "runtime_root_bound": True,
+    }
+
+
 def default_public_scan_root() -> str:
     return str(Path(__file__).resolve().parents[2])
 
@@ -242,6 +279,11 @@ def handle_quota_command(
                 available_capabilities=args.available_capabilities,
                 include_scheduler_detail=bool(args.include_scheduler_detail),
                 codex_app_current_rrule=codex_app_rrule,
+            )
+            _bind_scheduler_ack_cli_route(
+                payload,
+                registry_path=registry_path,
+                runtime_root=runtime_root,
             )
         elif args.quota_command == "monitor-poll":
             if not args.goal_id:


### PR DESCRIPTION
## Summary

- bind CLI scheduler ACK arguments to the registry and effective runtime root that produced quota should-run
- prevent a project-launched scheduler-ack-current from falling back to project-local state after a shared-registry decision
- add a focused two-registry subprocess smoke and update the scheduler contract docs

## Commit grouping

1. Runtime CLI route binding
2. Focused regression coverage and public protocol documentation

## Validation

- 299 pytest tests passed, 2 skipped
- focused scheduler registry/state/compaction/policy and heartbeat smokes passed
- Ruff passed on touched Python files
- LoopX premerge canary passed 17/17 with no warnings or manual holds
- public/private boundary scan passed for all six changed files

## Boundary

The bound paths are local CLI execution arguments only. No project state, raw logs, credentials, or private evidence is committed or projected into shared public artifacts.