### PR TITLE
Recover transient SkillsBench ACP transport turns

### DIFF
--- a/examples/skillsbench-acp-recoverable-transport-smoke.py
+++ b/examples/skillsbench-acp-recoverable-transport-smoke.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from examples.skillsbench_fixtures import write_official_skillsbench_result  # noqa: E402
+from loopx.benchmark_adapters.skillsbench import (  # noqa: E402
+    build_skillsbench_benchflow_result_benchmark_run,
+)
+from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
+    CodexExecConfig,
+    SkillsBenchLocalAcpRelay,
+    run_skillsbench_local_acp_relay_probe,
+)
+from loopx.status import compact_benchmark_run  # noqa: E402
+from scripts.skillsbench_automation_loop import (  # noqa: E402
+    _merge_host_local_acp_relay_trace_summary,
+    _public_runner_prerequisites,
+)
+
+
+def write_failing_codex(path: Path) -> None:
+    path.write_text(
+        """#!/usr/bin/env python3
+import sys
+
+print(
+    "failed to refresh available models: stream disconnected before completion",
+    file=sys.stderr,
+)
+raise SystemExit(125)
+""",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def test_runtime_transport_failure_is_recoverable() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-acp-transport-") as tmp:
+        root = Path(tmp)
+        fake_codex = root / "network-failing-codex"
+        write_failing_codex(fake_codex)
+
+        preflight_trace_dir = root / "preflight-traces"
+        preflight = run_skillsbench_local_acp_relay_probe(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "skillsbench_local_acp_relay.py"),
+                "--codex-bin",
+                str(fake_codex),
+                "--route",
+                "loopx-product-mode",
+                "--dataset",
+                "skillsbench-v1.1",
+                "--task-id",
+                "demo-task",
+                "--worker-public-trace-dir",
+                str(preflight_trace_dir),
+            ],
+            timeout_sec=20,
+        )
+        assert preflight["ready"] is False, preflight
+        preflight_failure = read_only_trace(preflight_trace_dir)
+        assert preflight_failure["codex_exec_process"][
+            "recoverable_turn_failure"
+        ] is False
+
+        runtime_trace_dir = root / "runtime-traces"
+        relay = SkillsBenchLocalAcpRelay(
+            CodexExecConfig(
+                codex_bin=str(fake_codex),
+                sandbox="workspace-write",
+                route="loopx-product-mode",
+                dataset="skillsbench-v1.1",
+                task_id="demo-task",
+                timeout_sec=20,
+                worker_public_trace_dir=str(runtime_trace_dir),
+            )
+        )
+        response = relay._run_codex(
+            "Continue the current product-mode benchmark turn.",
+            session={"cwd": str(root)},
+            session_id="network-runtime-demo",
+            stdout=io.StringIO(),
+        )
+        assert "LoopX recoverable Codex turn failure" in response
+        assert "codex_network_or_api_unreachable" in response
+        runtime_failure = read_only_trace(runtime_trace_dir)
+        process = runtime_failure["codex_exec_process"]
+        assert process["failure_category"] == "codex_network_or_api_unreachable"
+        assert process["recoverable_turn_failure"] is True
+        assert process["raw_stdout_recorded"] is False
+        assert process["raw_stderr_recorded"] is False
+
+        controller_trace, prerequisites = reduce_trace_dir(runtime_trace_dir)
+        assert controller_trace[
+            "host_local_acp_codex_exec_recoverable_failure_trace_count"
+        ] == 1
+        assert controller_trace[
+            "host_local_acp_codex_exec_fatal_failure_trace_count"
+        ] == 0
+        public_prerequisites = _public_runner_prerequisites(prerequisites)
+        assert public_prerequisites[
+            "host_local_acp_codex_exec_recoverable_failure_trace_count"
+        ] == 1
+
+        legacy_trace = dict(runtime_failure)
+        legacy_process = dict(legacy_trace["codex_exec_process"])
+        legacy_process.pop("recoverable_turn_failure")
+        legacy_trace["codex_exec_process"] = legacy_process
+        legacy_trace_dir = root / "legacy-traces"
+        legacy_trace_dir.mkdir()
+        (legacy_trace_dir / "legacy.compact.json").write_text(
+            json.dumps(legacy_trace, sort_keys=True),
+            encoding="utf-8",
+        )
+        legacy_controller, _ = reduce_trace_dir(legacy_trace_dir)
+        assert legacy_controller[
+            "host_local_acp_codex_exec_recoverable_failure_trace_count"
+        ] == 1
+        assert legacy_controller[
+            "host_local_acp_codex_exec_fatal_failure_trace_count"
+        ] == 0
+
+
+def test_recoverable_transport_score_policy() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-acp-score-") as tmp:
+        result_path = write_official_skillsbench_result(Path(tmp), reward=0.0)
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        result["error"] = "synthetic codex network transport interruption"
+        result_path.write_text(json.dumps(result, sort_keys=True), encoding="utf-8")
+
+        trace = product_mode_trace()
+        compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                result_path,
+                route="loopx-goal-start-product-mode",
+                controller_trace=trace,
+            )
+        )
+        assert compact is not None
+        assert compact["score_failure_attribution"] == (
+            "official_score_zero_case_failure"
+        ), compact
+        labels = compact["failure_attribution_labels"]
+        assert "skillsbench_runner_setup_error" not in labels, compact
+        assert "skillsbench_product_mode_transport_failure" not in labels, compact
+        assert (
+            "skillsbench_host_local_acp_recoverable_transport_after_bridge_attempt"
+            in compact["runner_warning_labels"]
+        ), compact
+        assert "runner_failure" not in compact, compact
+        accounting = compact["attempt_accounting"]
+        assert accounting["case_attempt_countable"] is True, accounting
+        assert accounting["official_score_attempt_countable"] is True, accounting
+
+        mixed_trace = dict(trace)
+        mixed_trace.update(
+            {
+                "host_local_acp_codex_exec_failure_trace_count": 2,
+                "host_local_acp_codex_exec_recoverable_failure_trace_count": 1,
+                "host_local_acp_codex_exec_fatal_failure_trace_count": 1,
+                "host_local_acp_codex_exec_failure_categories": [
+                    "codex_network_or_api_unreachable",
+                    "codex_usage_limit",
+                ],
+            }
+        )
+        mixed = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                result_path,
+                route="loopx-goal-start-product-mode",
+                controller_trace=mixed_trace,
+            )
+        )
+        assert mixed is not None
+        assert "skillsbench_runner_setup_error" in mixed["failure_attribution_labels"]
+        assert mixed["attempt_accounting"]["case_attempt_countable"] is False
+        assert mixed["attempt_accounting"][
+            "official_score_attempt_countable"
+        ] is False
+
+
+def read_only_trace(trace_dir: Path) -> dict[str, Any]:
+    paths = list(trace_dir.glob("*.compact.json"))
+    assert len(paths) == 1, paths
+    return json.loads(paths[0].read_text(encoding="utf-8"))
+
+
+def reduce_trace_dir(trace_dir: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    controller_trace: dict[str, Any] = {
+        "schema_version": "skillsbench_loopx_controller_trace_v0"
+    }
+    plan: dict[str, Any] = {
+        "host_local_acp_relay_trace_dir": str(trace_dir),
+        "runner_prerequisites": {},
+    }
+    _merge_host_local_acp_relay_trace_summary(plan, controller_trace)
+    return controller_trace, plan["runner_prerequisites"]
+
+
+def product_mode_trace() -> dict[str, Any]:
+    return {
+        "schema_version": "skillsbench_loopx_controller_trace_v0",
+        "route": "loopx-goal-start-product-mode",
+        "trace_publicness": "public_counts_only_no_task_text_no_verifier_output",
+        "product_mode": True,
+        "remote_command_file_bridge_driver_lifecycle_execution_style": (
+            "orchestrated_agentloop_loopx_cli"
+        ),
+        "remote_command_file_bridge_driver_lifecycle_trace_count": 3,
+        "remote_command_file_bridge_driver_lifecycle_checkpoint_count": 3,
+        "remote_command_file_bridge_driver_lifecycle_request_count": 12,
+        "remote_command_file_bridge_driver_lifecycle_success_count": 12,
+        "remote_command_file_bridge_driver_lifecycle_failure_count": 0,
+        "remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count": 12,
+        "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count": 3,
+        "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count": 9,
+        "remote_command_file_bridge_agent_operation_trace_status": (
+            "agent_operation_trace_recorded"
+        ),
+        "remote_command_file_bridge_agent_operation_trace_count": 3,
+        "remote_command_file_bridge_agent_operation_trace_satisfied": True,
+        "remote_command_file_bridge_agent_request_count": 8,
+        "remote_command_file_bridge_agent_task_facing_operation_count": 6,
+        "remote_command_file_bridge_agent_task_facing_success_count": 6,
+        "remote_command_file_bridge_agent_loopx_state_read_count": 3,
+        "remote_command_file_bridge_agent_loopx_state_write_count": 3,
+        "remote_command_file_bridge_agent_todo_closeout_count": 1,
+        "remote_command_file_bridge_agent_refresh_state_count": 1,
+        "remote_command_file_bridge_agent_quota_spend_slot_count": 1,
+        "host_local_acp_codex_exec_failure_trace_present": True,
+        "host_local_acp_codex_exec_failure_trace_count": 1,
+        "host_local_acp_codex_exec_recoverable_failure_trace_count": 1,
+        "host_local_acp_codex_exec_fatal_failure_trace_count": 0,
+        "host_local_acp_codex_exec_failure_category": (
+            "codex_network_or_api_unreachable"
+        ),
+        "host_local_acp_codex_exec_failure_categories": [
+            "codex_network_or_api_unreachable"
+        ],
+        "host_local_acp_codex_exec_failure_raw_material_recorded": False,
+        "raw_task_text_recorded": False,
+        "raw_verifier_output_recorded": False,
+        "raw_agent_trajectory_recorded": False,
+    }
+
+
+if __name__ == "__main__":
+    test_runtime_transport_failure_is_recoverable()
+    test_recoverable_transport_score_policy()
+    print("skillsbench ACP recoverable transport smoke passed")

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -24,6 +24,10 @@ from .skillsbench_failure_signals import (
     skillsbench_pip_bootstrap_failure_evidence,
     skillsbench_runner_error_fingerprint,
 )
+from .skillsbench_acp_failure_policy import (
+    recoverable_transport_after_bridge_attempt,
+    without_recoverable_transport_infra_labels,
+)
 from .skillsbench_signals import build_skillsbench_solution_quality_signals
 from .skillsbench_result_discovery import (
     SKILLSBENCH_RESULT_DISCOVERY_SCHEMA_VERSION,
@@ -2664,6 +2668,12 @@ def _skillsbench_controller_trace_counters(
         "host_local_acp_codex_exec_failure_trace_count": count(
             "host_local_acp_codex_exec_failure_trace_count"
         ),
+        "host_local_acp_codex_exec_recoverable_failure_trace_count": count(
+            "host_local_acp_codex_exec_recoverable_failure_trace_count"
+        ),
+        "host_local_acp_codex_exec_fatal_failure_trace_count": count(
+            "host_local_acp_codex_exec_fatal_failure_trace_count"
+        ),
         "host_local_acp_codex_exec_failure_trace_present": controller_trace.get(
             "host_local_acp_codex_exec_failure_trace_present"
         )
@@ -4378,6 +4388,13 @@ def build_skillsbench_benchflow_result_benchmark_run(
     host_local_acp_codex_exec_failure_category = str(
         controller_counters.get("host_local_acp_codex_exec_failure_category") or ""
     )
+    host_local_acp_recoverable_transport_after_bridge_attempt = (
+        recoverable_transport_after_bridge_attempt(
+            controller_counters,
+            official_score_present=reward_value is not None,
+            task_facing_success_count=agent_bridge_task_facing_success_count,
+        )
+    )
     host_local_acp_idle_timeout_after_countable_closeout = bool(
         host_local_acp_codex_exec_failure_present
         and host_local_acp_codex_exec_failure_category == "codex_exec_bridge_idle_timeout"
@@ -4404,6 +4421,7 @@ def build_skillsbench_benchflow_result_benchmark_run(
         and not official_passed
         and not host_local_acp_idle_timeout_after_countable_closeout
         and not host_local_acp_task_output_quiet_after_bridge_attempt
+        and not host_local_acp_recoverable_transport_after_bridge_attempt
     ):
         if host_local_acp_idle_no_task_output_progress_stop:
             host_failure_label = (
@@ -4459,6 +4477,25 @@ def build_skillsbench_benchflow_result_benchmark_run(
         for item in host_failure_extra_labels:
             if item and item not in failure_labels:
                 failure_labels.append(item)
+    elif host_local_acp_recoverable_transport_after_bridge_attempt:
+        warning_label = (
+            "skillsbench_host_local_acp_recoverable_transport_after_bridge_attempt"
+        )
+        failure_labels = without_recoverable_transport_infra_labels(failure_labels)
+        if reward_value == 0 and score_failure_attribution in {
+            "",
+            "none",
+            "skillsbench_runner_error",
+            "skillsbench_codex_acp_jsonrpc_internal_error",
+            "skillsbench_codex_acp_transport_error",
+        }:
+            exception_type = "none"
+            score_failure_attribution = "official_score_zero_case_failure"
+            runner_score_failure_attribution = "none"
+            if "official_score_zero_case_failure" not in failure_labels:
+                failure_labels.append("official_score_zero_case_failure")
+        if warning_label not in warning_labels:
+            warning_labels.append(warning_label)
     elif host_local_acp_task_output_quiet_after_bridge_attempt:
         warning_label = (
             "skillsbench_host_local_acp_task_output_quiet_after_bridge_attempt"
@@ -4557,6 +4594,7 @@ def build_skillsbench_benchflow_result_benchmark_run(
     if (
         error_text
         and not host_local_acp_task_output_quiet_after_bridge_attempt
+        and not host_local_acp_recoverable_transport_after_bridge_attempt
     ) or native_goal_worker_uncountable:
         runner_failure = {
             "schema_version": "skillsbench_runner_failure_v0",

--- a/loopx/benchmark_adapters/skillsbench_acp_failure_policy.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_failure_policy.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+
+RECOVERABLE_CODEX_TRANSPORT_FAILURE_CATEGORIES = frozenset(
+    {
+        "codex_network_or_api_unreachable",
+        "codex_responses_stream_unavailable",
+        "codex_reverse_channel_unavailable",
+    }
+)
+
+RECOVERABLE_CODEX_TURN_FAILURE_CATEGORIES = frozenset(
+    {
+        "codex_exec_timeout",
+        "codex_exec_first_action_timeout",
+        "codex_exec_task_output_quiet_timeout",
+        "codex_exec_bridge_idle_timeout",
+    }
+) | RECOVERABLE_CODEX_TRANSPORT_FAILURE_CATEGORIES
+
+RECOVERABLE_TRANSPORT_INFRA_FAILURE_LABELS = frozenset(
+    {
+        "skillsbench_runner_error",
+        "skillsbench_codex_acp_jsonrpc_internal_error",
+        "skillsbench_codex_acp_transport_error",
+        "skillsbench_product_mode_transport_failure",
+        "skillsbench_host_local_acp_codex_exec_failed",
+        "skillsbench_runner_setup_error",
+        "verifier_infrastructure_failure",
+        "official_verifier_solution_failure",
+    }
+)
+
+
+def recoverable_transport_after_bridge_attempt(
+    counters: Mapping[str, Any],
+    *,
+    official_score_present: bool,
+    task_facing_success_count: int,
+) -> bool:
+    categories = {
+        str(category)
+        for category in counters.get(
+            "host_local_acp_codex_exec_failure_categories", []
+        )
+        if isinstance(category, str) and category
+    }
+    first_category = counters.get("host_local_acp_codex_exec_failure_category")
+    if not categories and isinstance(first_category, str) and first_category:
+        categories.add(first_category)
+
+    failure_count = _count(counters, "host_local_acp_codex_exec_failure_trace_count")
+    recoverable_count = _count(
+        counters,
+        "host_local_acp_codex_exec_recoverable_failure_trace_count",
+    )
+    fatal_count = _count(
+        counters,
+        "host_local_acp_codex_exec_fatal_failure_trace_count",
+    )
+    return bool(
+        counters.get("host_local_acp_codex_exec_failure_trace_present") is True
+        and failure_count > 0
+        and categories
+        and categories.issubset(RECOVERABLE_CODEX_TRANSPORT_FAILURE_CATEGORIES)
+        and fatal_count == 0
+        and recoverable_count in {0, failure_count}
+        and official_score_present
+        and task_facing_success_count > 0
+    )
+
+
+def without_recoverable_transport_infra_labels(labels: Iterable[str]) -> list[str]:
+    return [
+        label
+        for label in labels
+        if label not in RECOVERABLE_TRANSPORT_INFRA_FAILURE_LABELS
+        and not label.startswith("skillsbench_host_local_acp_codex_exec_failed_")
+    ]
+
+
+def _count(counters: Mapping[str, Any], key: str) -> int:
+    value = counters.get(key)
+    if isinstance(value, int) and not isinstance(value, bool):
+        return max(0, value)
+    return 0

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -42,6 +42,9 @@ from loopx.benchmark_adapters.skillsbench_bridge_summary import (
 from loopx.benchmark_adapters.skillsbench_bridge_guard import (
     LOOPX_COMMAND_INSTRUMENTATION_SOURCE,
 )
+from loopx.benchmark_adapters.skillsbench_acp_failure_policy import (
+    RECOVERABLE_CODEX_TURN_FAILURE_CATEGORIES,
+)
 from loopx.benchmark_adapters.skillsbench_codex_goal_recovery import (
     CODEX_CLI_GOAL_POST_BRIDGE_CONTINUE_PROMPT,
     POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
@@ -344,13 +347,6 @@ def _codex_exec_failure_category(
     if returncode is not None:
         return "codex_exec_exit_nonzero"
     return "codex_exec_failed"
-
-
-RECOVERABLE_CODEX_TURN_FAILURE_CATEGORIES = {
-    "codex_exec_first_action_timeout",
-    "codex_exec_task_output_quiet_timeout",
-    "codex_exec_bridge_idle_timeout",
-}
 
 
 def _prompt_with_app_server_closeout_instruction(prompt_text: str) -> str:
@@ -925,6 +921,12 @@ class SkillsBenchLocalAcpRelay:
                     returncode=proc.returncode,
                     stderr_text=stderr_text,
                 )
+                recoverable_turn_failure = bool(
+                    category in RECOVERABLE_CODEX_TURN_FAILURE_CATEGORIES
+                    and prompt_text.strip()
+                    != SKILLSBENCH_LOCAL_ACP_RELAY_HEALTH_PROMPT
+                    and not _is_bridge_action_preflight_prompt(prompt_text)
+                )
                 self._publish_codex_exec_failure_trace(
                     stage="exit_nonzero",
                     returncode=proc.returncode,
@@ -935,12 +937,13 @@ class SkillsBenchLocalAcpRelay:
                         output_path.stat().st_size if output_path.exists() else 0
                     ),
                     failure_category=category,
+                    recoverable_turn_failure=recoverable_turn_failure,
                 )
                 if bridge_summary_path is not None:
                     self._publish_remote_bridge_agent_operations_trace(
                         bridge_summary_path=bridge_summary_path,
                     )
-                if category in RECOVERABLE_CODEX_TURN_FAILURE_CATEGORIES:
+                if recoverable_turn_failure:
                     return _recoverable_codex_turn_failure_message(category)
                 raise RuntimeError(f"local codex execution failed: {category}")
             try:
@@ -2775,6 +2778,7 @@ raise SystemExit(proc.returncode)
         final_message_present: bool,
         final_message_bytes: int,
         failure_category: str | None = None,
+        recoverable_turn_failure: bool | None = None,
     ) -> None:
         if not self._config.worker_public_trace_dir:
             return
@@ -2788,6 +2792,10 @@ raise SystemExit(proc.returncode)
             returncode=returncode,
             stderr_text=stderr_text,
         )
+        if recoverable_turn_failure is None:
+            recoverable_turn_failure = (
+                category in RECOVERABLE_CODEX_TURN_FAILURE_CATEGORIES
+            )
         trace = {
             "schema_version": "skillsbench_host_local_acp_relay_public_trace_v0",
             "ok": False,
@@ -2799,6 +2807,7 @@ raise SystemExit(proc.returncode)
                 "schema_version": "skillsbench_codex_exec_process_failure_v0",
                 "stage": safe_stage,
                 "failure_category": str(category or "codex_exec_failed")[:120],
+                "recoverable_turn_failure": recoverable_turn_failure,
                 "returncode": (
                     returncode
                     if isinstance(returncode, int)

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -830,6 +830,8 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count",
         "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count",
         "host_local_acp_codex_exec_failure_trace_count",
+        "host_local_acp_codex_exec_recoverable_failure_trace_count",
+        "host_local_acp_codex_exec_fatal_failure_trace_count",
     ):
         if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
             compact[field] = value[field]

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -128,6 +128,9 @@ from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
     run_skillsbench_host_local_acp_transport_probe,
     run_skillsbench_local_acp_relay_probe,
 )
+from loopx.benchmark_adapters.skillsbench_acp_failure_policy import (  # noqa: E402
+    RECOVERABLE_CODEX_TURN_FAILURE_CATEGORIES,
+)
 from loopx.benchmark_adapters.skillsbench_codex_goal_trace import (  # noqa: E402
     codex_cli_goal_recovery_public_fields,
     merge_codex_cli_goal_recovery_trace,
@@ -2838,6 +2841,8 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "host_local_acp_codex_exec_preflight_bridge_task_facing_success_count",
         "host_local_acp_codex_exec_preflight_bridge_task_facing_failure_count",
         "host_local_acp_codex_exec_failure_trace_count",
+        "host_local_acp_codex_exec_recoverable_failure_trace_count",
+        "host_local_acp_codex_exec_fatal_failure_trace_count",
         "codex_api_reverse_tunnel_proxy_endpoint_port",
         "benchmark_egress_proxy_endpoint_port",
         "benchmark_egress_no_proxy_entry_count",
@@ -10260,6 +10265,8 @@ def _merge_host_local_acp_relay_trace_summary(
     probe_ready_count = 0
     operation_count = 0
     codex_exec_failure_trace_count = 0
+    codex_exec_recoverable_failure_trace_count = 0
+    codex_exec_fatal_failure_trace_count = 0
     codex_exec_failure_categories: list[str] = []
     agent_bridge_trace_count = 0
     agent_bridge_request_count = 0
@@ -10340,6 +10347,16 @@ def _merge_host_local_acp_relay_trace_summary(
             )
             codex_exec_failure_trace_count += 1
             category = process.get("failure_category")
+            recoverable_turn_failure = process.get("recoverable_turn_failure")
+            if not isinstance(recoverable_turn_failure, bool):
+                recoverable_turn_failure = (
+                    isinstance(category, str)
+                    and category in RECOVERABLE_CODEX_TURN_FAILURE_CATEGORIES
+                )
+            if recoverable_turn_failure:
+                codex_exec_recoverable_failure_trace_count += 1
+            else:
+                codex_exec_fatal_failure_trace_count += 1
             if (
                 isinstance(category, str)
                 and category
@@ -10583,6 +10600,12 @@ def _merge_host_local_acp_relay_trace_summary(
     )
     trace["host_local_acp_codex_exec_failure_trace_count"] = (
         codex_exec_failure_trace_count
+    )
+    trace["host_local_acp_codex_exec_recoverable_failure_trace_count"] = (
+        codex_exec_recoverable_failure_trace_count
+    )
+    trace["host_local_acp_codex_exec_fatal_failure_trace_count"] = (
+        codex_exec_fatal_failure_trace_count
     )
     trace["host_local_acp_codex_exec_failure_trace_present"] = (
         codex_exec_failure_trace_count > 0
@@ -10832,6 +10855,12 @@ def _merge_host_local_acp_relay_trace_summary(
     )
     prerequisites["host_local_acp_codex_exec_failure_trace_count"] = (
         codex_exec_failure_trace_count
+    )
+    prerequisites["host_local_acp_codex_exec_recoverable_failure_trace_count"] = (
+        codex_exec_recoverable_failure_trace_count
+    )
+    prerequisites["host_local_acp_codex_exec_fatal_failure_trace_count"] = (
+        codex_exec_fatal_failure_trace_count
     )
     prerequisites["host_local_acp_codex_exec_failure_trace_present"] = (
         codex_exec_failure_trace_count > 0


### PR DESCRIPTION
## Summary

- classify transient Codex network, response-stream, and reverse-channel failures as recoverable benchmark turns outside preflight
- project recoverable and fatal failure counts through runner prerequisites and compact status
- preserve completed official scores only after task-facing bridge success and only when no fatal failure is mixed in
- keep preflight, usage-limit, environment, and mixed-fatal failures fail-closed

## Validation

- `python3 examples/skillsbench-acp-recoverable-transport-smoke.py`
- `python3 examples/skillsbench-host-local-launch-plan-smoke.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/benchmark-run-v0-status-projection-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `loopx check` on all changed public paths
- `loopx canary premerge --from-git-diff`: 17/17 checks passed; benchmark-sensitive manual review hold remains

## Scope

This changes turn recovery and attempt attribution only. It does not change task semantics, verifier scoring, leaderboard/submission behavior, permissions, or launch benchmark jobs. No raw task text, trajectories, logs, credentials, local paths, uploads, or submissions are included.