### PR TITLE
Scope quota health to the selected goal

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -538,6 +538,12 @@ the displayed gate, evidence, or health reason.
 `quota should-run` is the per-goal guard for heartbeat jobs. It returns a small
 JSON or Markdown decision:
 
+The per-goal guard, monitor, scheduler acknowledgment, and slot-accounting
+commands isolate active-state todo contract errors to their selected goal. A
+stale todo in another goal therefore remains visible in broad health inventory
+without blocking an otherwise healthy goal. Global registry, routing, and
+public-boundary failures still fail closed for every goal.
+
 ```json
 {
   "goal_id": "project-main-control",

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -650,6 +650,11 @@ enough to support an operator decision without exposing local paths or private
 evidence. They must be public-safe before a project exposes this export outside
 the local machine.
 
+Goal-filtered status and quota guards validate active-state todo semantics only
+for the selected goal. Registry structure, routing ambiguity, and public-boundary
+scan failures remain global health blockers. Broad status and quota inventory
+commands continue to report active-state contract errors from every goal.
+
 ## Attention Queue
 
 The attention queue is sorted by LoopX status logic. A UI should render

--- a/examples/control_plane/status-goal-filter-smoke.py
+++ b/examples/control_plane/status-goal-filter-smoke.py
@@ -19,7 +19,13 @@ GOAL_A = "status-filter-a"
 GOAL_B = "status-filter-b"
 
 
-def write_state(project: Path, goal_id: str, todo_text: str) -> str:
+def write_state(
+    project: Path,
+    goal_id: str,
+    todo_text: str,
+    *,
+    invalid_agent_route: bool = False,
+) -> str:
     state_file = f".codex/goals/{goal_id}/ACTIVE_GOAL_STATE.md"
     path = project / state_file
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -31,7 +37,9 @@ def write_state(project: Path, goal_id: str, todo_text: str) -> str:
         f"# {goal_id}\n\n"
         "## Agent Todo\n\n"
         f"- [ ] {todo_text}\n"
-        f"  <!-- loopx:todo todo_id=todo_{goal_id} status=open task_class=advancement_task -->\n",
+        f"  <!-- loopx:todo todo_id=todo_{goal_id} status=open "
+        "task_class=advancement_task"
+        f"{' blocks_agent=legacy-agent' if invalid_agent_route else ''} -->\n",
         encoding="utf-8",
     )
     return state_file
@@ -51,7 +59,12 @@ def write_registry(project: Path, runtime: Path) -> Path:
                 "domain": "status-filter-smoke",
                 "status": "active",
                 "repo": str(project),
-                "state_file": write_state(project, goal_id, todo_text),
+                "state_file": write_state(
+                    project,
+                    goal_id,
+                    todo_text,
+                    invalid_agent_route=goal_id == GOAL_B,
+                ),
                 "adapter": {"kind": "smoke_v0", "status": "connected-read-only"},
                 "authority_sources": [],
             }
@@ -90,7 +103,13 @@ def write_run_history(runtime: Path) -> None:
         )
 
 
-def run_status(registry_path: Path, runtime: Path, project: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+def run_status(
+    registry_path: Path,
+    runtime: Path,
+    project: Path,
+    *extra: str,
+    goal_id: str | None = GOAL_A,
+) -> subprocess.CompletedProcess[str]:
     command = [
         sys.executable,
         "-m",
@@ -100,16 +119,50 @@ def run_status(registry_path: Path, runtime: Path, project: Path, *extra: str) -
         "--runtime-root",
         str(runtime),
         "status",
-        "--goal-id",
-        GOAL_A,
         "--scan-path",
         str(project / "PUBLIC.md"),
         "--limit",
         "10",
-        *extra,
     ]
+    if goal_id:
+        command.extend(["--goal-id", goal_id])
+    command.extend(extra)
     return subprocess.run(
         command,
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def run_quota_should_run(
+    registry_path: Path,
+    runtime: Path,
+    project: Path,
+    goal_id: str,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime),
+            "--format",
+            "json",
+            "quota",
+            "should-run",
+            "--goal-id",
+            goal_id,
+            "--scan-path",
+            str(project / "PUBLIC.md"),
+            "--limit",
+            "10",
+        ],
         cwd=REPO_ROOT,
         text=True,
         stdout=subprocess.PIPE,
@@ -158,6 +211,32 @@ def main() -> int:
         assert markdown_result.returncode == 0, (markdown_result.stdout, markdown_result.stderr)
         assert f"- goal_filter: `{GOAL_A}`" in markdown_result.stdout, markdown_result.stdout
         assert GOAL_B not in markdown_result.stdout, markdown_result.stdout
+
+        broad_result = run_status(
+            registry_path,
+            runtime,
+            project,
+            "--format",
+            "json",
+            goal_id=None,
+        )
+        assert broad_result.returncode != 0, broad_result.stdout
+        broad_payload = json.loads(broad_result.stdout)
+        assert broad_payload["ok"] is False, broad_payload
+        assert any(GOAL_B in item for item in broad_payload["contract_errors"]), broad_payload
+
+        selected_quota = run_quota_should_run(registry_path, runtime, project, GOAL_A)
+        assert selected_quota.returncode == 0, (selected_quota.stdout, selected_quota.stderr)
+        selected_payload = json.loads(selected_quota.stdout)
+        assert selected_payload["decision"] == "run", selected_payload
+        assert selected_payload["should_run"] is True, selected_payload
+        assert selected_payload["effective_action"] == "normal_run", selected_payload
+
+        invalid_quota = run_quota_should_run(registry_path, runtime, project, GOAL_B)
+        assert invalid_quota.returncode != 0, invalid_quota.stdout
+        invalid_payload = json.loads(invalid_quota.stdout)
+        assert invalid_payload["status_health_ok"] is False, invalid_payload
+        assert invalid_payload["should_run"] is False, invalid_payload
 
     print("status-goal-filter-smoke ok")
     return 0

--- a/loopx/contract.py
+++ b/loopx/contract.py
@@ -269,11 +269,17 @@ def _index_duplicate_warning(
     return f"{safe_goal_id}: duplicate index rows raw={raw} unique={unique}{detail}; {action}"
 
 
-def _active_state_user_gate_scope_errors(registry: dict[str, Any]) -> tuple[list[str], int]:
+def _active_state_user_gate_scope_errors(
+    registry: dict[str, Any],
+    *,
+    goal_id_filter: str | None = None,
+) -> tuple[list[str], int]:
     errors: list[str] = []
     checked = 0
     for goal in registry_goals(registry):
         goal_id = str(goal.get("id") or "")
+        if goal_id_filter and goal_id != goal_id_filter:
+            continue
         registered_agents = registered_agent_ids_for_goal(goal)
         repo_text = str(goal.get("repo") or "").strip()
         if not repo_text:
@@ -582,6 +588,7 @@ def check_contract(
     scan_roots: list[Path],
     limit: int,
     allow_missing_registry: bool = False,
+    goal_id_filter: str | None = None,
 ) -> dict[str, Any]:
     errors: list[str] = []
     warnings: list[str] = []
@@ -618,7 +625,10 @@ def check_contract(
             errors.append(f"registry boundary risk: {risk}")
 
     registry = load_registry(registry_path)
-    user_gate_scope_errors, checked_user_gates = _active_state_user_gate_scope_errors(registry)
+    user_gate_scope_errors, checked_user_gates = _active_state_user_gate_scope_errors(
+        registry,
+        goal_id_filter=goal_id_filter,
+    )
     if checked_user_gates:
         checks.append(f"user-gate scopes checked: {checked_user_gates} open multi-agent gates")
     errors.extend(user_gate_scope_errors)
@@ -680,6 +690,20 @@ def check_contract(
         )
     warnings.extend(str(item) for item in boundary.get("private_state_git_warnings") or [])
 
+    goal_errors: dict[str, list[str]] = {}
+    for goal in registry_goals(registry):
+        goal_id = str(goal.get("id") or "")
+        if not goal_id:
+            continue
+        scoped = [item for item in user_gate_scope_errors if item.startswith(f"{goal_id}:")]
+        if scoped:
+            goal_errors[goal_id] = scoped
+    scoped_error_set = {
+        item
+        for items in goal_errors.values()
+        for item in items
+    }
+
     return {
         "ok": not errors,
         "registry": str(registry_path),
@@ -691,6 +715,8 @@ def check_contract(
             "checks": len(checks),
         },
         "errors": errors,
+        "global_errors": [item for item in errors if item not in scoped_error_set],
+        "goal_errors": goal_errors,
         "warnings": warnings,
         "checks": checks,
     }

--- a/loopx/control_plane/quota/decision_summary.py
+++ b/loopx/control_plane/quota/decision_summary.py
@@ -34,3 +34,27 @@ def quota_decision_agent_id(decision: dict[str, Any]) -> str | None:
         else {}
     )
     return normalize_todo_claimed_by(agent_identity.get("agent_id"))
+
+
+def goal_status_health_ok(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+    fallback: bool,
+) -> bool:
+    """Isolate goal-owned todo errors while keeping global guards fail-closed."""
+
+    contract = status_payload.get("contract")
+    if not isinstance(contract, dict) or "global_errors" not in contract:
+        return fallback
+    global_registry = status_payload.get("global_registry")
+    if isinstance(global_registry, dict) and global_registry.get("ok") is False:
+        return False
+    global_errors = contract.get("global_errors")
+    if isinstance(global_errors, list) and global_errors:
+        return False
+    goal_errors = contract.get("goal_errors")
+    if not isinstance(goal_errors, dict):
+        return fallback
+    selected_errors = goal_errors.get(goal_id)
+    return not (isinstance(selected_errors, list) and selected_errors)

--- a/loopx/control_plane/status_collection.py
+++ b/loopx/control_plane/status_collection.py
@@ -58,6 +58,7 @@ def collect_status(
         runtime_root_override=runtime_root_override,
         scan_roots=scan_roots,
         limit=limit,
+        goal_id_filter=goal_filter,
     )
     queue = context.build_attention_queue(
         contract=contract,
@@ -92,6 +93,8 @@ def collect_status(
             "ok": contract.get("ok"),
             "summary": contract.get("summary"),
             "errors": contract.get("errors") or [],
+            "global_errors": contract.get("global_errors") or [],
+            "goal_errors": contract.get("goal_errors") or {},
             "warnings": contract.get("warnings") or [],
             "checks": contract.get("checks") or [],
         },

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -60,9 +60,7 @@ from .control_plane.quota.projection_repair import (
     build_state_projection_gap,
     build_state_projection_gap_repair_hint,
 )
-from .control_plane.quota.decision_summary import (
-    quota_decision_agent_id,
-)
+from .control_plane.quota.decision_summary import goal_status_health_ok, quota_decision_agent_id
 from .control_plane.quota.goal_boundary import (
     effective_available_capabilities as _effective_available_capabilities,
     goal_boundary as _goal_boundary,
@@ -1283,6 +1281,7 @@ def build_quota_should_run(
     safe_goal_id = str(goal_id or "").strip()
     registry_goal = _registry_goal_by_id(status_payload).get(safe_goal_id) or {}
     plan = build_quota_plan(status_payload, mode="should-run")
+    goal_health_ok = goal_status_health_ok(status_payload, goal_id=safe_goal_id, fallback=bool(plan.get("ok")))
     item = next((candidate for candidate in _quota_plan_items(plan) if candidate.get("goal_id") == safe_goal_id), None)
     health_items = plan.get("health_items") if isinstance(plan.get("health_items"), list) else []
     health_item = next(
@@ -1297,10 +1296,10 @@ def build_quota_should_run(
     if item:
         quota = item.get("quota") if isinstance(item.get("quota"), dict) else {}
         state = str(quota.get("state") or "unknown")
-        normal_delivery_allowed = bool(plan.get("ok")) and state == "eligible"
-        recovery_allowed = _recovery_delivery_allowed(quota, plan_ok=bool(plan.get("ok")))
+        normal_delivery_allowed = goal_health_ok and state == "eligible"
+        recovery_allowed = _recovery_delivery_allowed(quota, plan_ok=goal_health_ok)
         reason = str(quota.get("reason") or "quota state is not eligible")
-        if not plan.get("ok"):
+        if not goal_health_ok:
             reason = "status or contract health is not ok; skip automatic compute"
         project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
         agent_identity = build_quota_agent_identity(item, agent_id=agent_id)
@@ -1337,10 +1336,10 @@ def build_quota_should_run(
                 "reason": agent_scoped_user_gate_override["reason"],
             }
             state = "eligible"
-            normal_delivery_allowed = bool(plan.get("ok"))
+            normal_delivery_allowed = goal_health_ok
             recovery_allowed = _recovery_delivery_allowed(
                 quota,
-                plan_ok=bool(plan.get("ok")),
+                plan_ok=goal_health_ok,
             )
             reason = str(agent_scoped_user_gate_override["reason"])
         outcome_floor_blocker_projected = (
@@ -1380,7 +1379,7 @@ def build_quota_should_run(
         stall_self_repair = _stall_self_repair_hint(
             item,
             state=state,
-            plan_ok=bool(plan.get("ok")),
+            plan_ok=goal_health_ok,
             health_items=health_items,
             user_todo_summary=user_todo_summary,
             agent_todo_summary=agent_todo_summary,
@@ -1517,7 +1516,7 @@ def build_quota_should_run(
         )
         replan_decision_allowed = autonomous_replan_decision_allowed(
             replan_obligation=replan_obligation,
-            plan_ok=bool(plan.get("ok")),
+            plan_ok=goal_health_ok,
             workspace_blocked=bool(workspace_guard),
             automation_prompt_upgrade_required=automation_prompt_upgrade_required,
             agent_id=agent_frontier_id,
@@ -1842,8 +1841,8 @@ def build_quota_should_run(
             agent_scope_frontier=agent_scope_frontier,
         )
         payload = {
-            "ok": bool(plan.get("ok")) or self_repair_allowed or capability_repair_allowed or workspace_repair_allowed,
-            "status_health_ok": bool(plan.get("ok")),
+            "ok": goal_health_ok or self_repair_allowed or capability_repair_allowed or workspace_repair_allowed,
+            "status_health_ok": goal_health_ok,
             "mode": "should-run",
             "goal_id": safe_goal_id,
             "decision": (


### PR DESCRIPTION
## What changed

- classify active-state todo contract failures by owning goal while preserving global registry, routing, and public-boundary failures
- make per-goal quota health use the selected goal contract errors without losing the global quota plan
- extend the goal-filter smoke to prove a healthy goal can run while an unrelated invalid goal remains visible and blocked
- document the goal-scoped health contract

## Root cause

quota should-run with goal A reused the global status health bit. A legacy todo contract error in goal B therefore forced goal A into quota_skip even when goal A had an eligible advancement todo. This also produced a contradictory payload where the work lane required an attempt but the interaction contract prohibited delivery.

## Impact

Per-goal heartbeat, monitor, scheduler, and accounting decisions no longer stall on another goal active-state todo semantics. Broad status and quota inventory still report every error, and global structural or public-boundary failures remain fail-closed.

## Validation

- live local-private registry check: target decision changed from quota_skip to normal_run while the global plan retained the unrelated health blocker
- python3 examples/control_plane/status-goal-filter-smoke.py
- python3 examples/control_plane/status-collection-readmodel-smoke.py
- python3 examples/control_plane/quota-plan-smoke.py
- python3 examples/control_plane/status-projection-cache-smoke.py
- loopx canary premerge --from-git-diff: 17/17 selected checks passed, public boundary clean, no manual holds