### PR TITLE
Add reward-memory corpus registry and health contract

### DIFF
--- a/docs/reference/protocols/reward-memory-architecture-v0.md
+++ b/docs/reference/protocols/reward-memory-architecture-v0.md
@@ -137,7 +137,9 @@ loopx reward-memory route-check --case pr-3237 --format json
 ## Staged ownership
 
 - Stage 0: this classification, precedence, and delegation contract.
-- Stage 1: corpus inventory, ownership, authority, freshness, retirement, and
+- Stage 1: the implemented provider-neutral
+  [corpus registry and health contract](reward-memory-corpus-registry-v0.md),
+  including ownership, authority, freshness, retirement, scope isolation, and
   retrieval-health distinctions.
 - Stage 2: inspectable candidate distillation and explicit human review.
 - Stage 3: opt-in cross-module recall and compact application receipts.
@@ -145,4 +147,5 @@ loopx reward-memory route-check --case pr-3237 --format json
 - Stage 5: bounded cross-module dogfood and operator edit/retire controls.
 
 Later stages must extend this contract rather than collapsing these classes or
-turning provider availability into a user gate.
+turning provider availability into a user gate. Stage 1 remains a stateless
+read model and performs no provider or external write.

--- a/docs/reference/protocols/reward-memory-corpus-registry-v0.md
+++ b/docs/reference/protocols/reward-memory-corpus-registry-v0.md
@@ -1,0 +1,126 @@
+# Reward Memory Corpus Registry v0
+
+Stage 1 turns the five Stage-0 reward-memory classes into a provider-neutral
+corpus inventory and health contract. The registry is a stateless read model;
+it does not mirror provider content, become a second memory store, or grant an
+agent permission to write or apply recalled material.
+
+```bash
+loopx reward-memory corpus-registry --format json
+loopx reward-memory health-check --case wrong-project --format json
+```
+
+## Corpus declaration
+
+Every corpus declares:
+
+- `corpus_id`, Stage-0 `class_id`, `provider_id`, and `owner_ref`;
+- the canonical `source_of_truth`;
+- separate read and write authority;
+- workspace, project, module surface, and optional user, peer, or session scope;
+- freshness mode and optional source revision or maximum age;
+- active, superseded, or retired lifecycle plus lineage;
+- whether an index, result readback, and application receipt are required;
+- writeback triggers, closure policy, and retirement authority;
+- privacy visibility and the invariant that raw content is absent.
+
+The reference registry covers all five classes through seven corpus families:
+
+| Corpus family | Class | Source and lifecycle |
+| --- | --- | --- |
+| `run_reward_overlays` | `run_bound_reward` | LoopX human-reward event ledger; append-only exact goal/run overlay. |
+| `authority_policy_sources` | `hard_policy` | Canonical user, repository, and operator authority; never inferred from provider memory. |
+| `scoped_preferences` | `soft_preference` | Provider-managed, explicitly reviewed feedback for module-owned surfaces. |
+| `execution_trajectories` | `procedural_experience` | Revision-stamped execution evidence. |
+| `distilled_experiences` | `procedural_experience` | Reviewed and supersedable procedural or architectural learning. |
+| `session_working_memory` | `working_context` | Session/archive-revision-bound continuation context. |
+| `fresh_execution_context` | `working_context` | Current registry, todo, checkout, and bounded tool observation. |
+
+These reference entries are declarative families, not claims that a live
+provider or corpus is configured. A live module builds a `registered` packet
+from its provider-owned inventory. The existing semantic-preference provider
+inventory can be bridged without exposing its raw scope URI; the generic
+registry retains only a digest and the explicit project and surface scope.
+
+## Authority and maintenance
+
+Read and write authority remain separate. A module-scoped read does not grant a
+provider write, a provider-managed write does not grant repository publication,
+and neither grants patch authority. Corpus maintenance follows these rules:
+
+1. inventory is owned by the provider or canonical source owner;
+2. writes use only the declared write authority;
+3. source revision, archive revision, or freshness window is verified before use;
+4. superseded and retired corpora remain in compact lineage but stop influencing recall;
+5. project or surface mismatch fails closed;
+6. retirement keeps a compact reason, never raw memory content.
+
+Confidence is intentionally absent from the health promotion path. Stage 0
+already establishes that confidence cannot increase authority.
+
+## Health states
+
+`reward_memory_corpus_health_v0` keeps inventory, retrieval, readback, and use
+as distinct observations. The classifier applies this precedence:
+
+| State | Meaning |
+| --- | --- |
+| `wrong_project` | The requested project differs from the corpus scope. |
+| `wrong_surface` | The consuming module surface is not registered. |
+| `unavailable` | The provider cannot be reached or the declared corpus is absent. |
+| `empty` | The corpus exists and is readable but contains no records. |
+| `stale` | Lifecycle, source revision, archive revision, or freshness evidence is not current. |
+| `index_unavailable` | A required derived index is absent even though the corpus exists. |
+| `retrieval_failed` | The scoped query failed or has not run. |
+| `readback_unverified` | Retrieval returned but the selected result was not read back. |
+| `retrieval_verified` | A current in-scope result was read back but has no application receipt. |
+| `applied_verified` | A verified result also has a compact application receipt. |
+
+The output always preserves the individual pipeline fields:
+
+- `provider_available`;
+- `corpus_present` and `record_count`;
+- `index_required` and `index_present`;
+- `retrieval_query_succeeded`;
+- `result_readback_verified`;
+- `memory_applied_with_receipt`.
+
+An empty corpus is therefore not reported as unavailable. An existing index is
+not proof that the content corpus exists. Retrieval success is not proof that a
+result was expanded and verified, and verified readback is not proof that the
+memory influenced an artifact.
+
+Contradictory observations fail validation: application requires readback,
+readback requires retrieval, and retrieval requires an available present
+corpus. A healthy result can make memory eligible for advisory use, but still
+returns `memory_patch_authority=false` and
+`external_write_authorized=false`.
+
+## OpenViking alignment
+
+For OpenViking, AGFS content remains the source of truth and the vector index
+is a derived retrieval reference. Preferences map to scoped preferences,
+trajectories and experiences map to the two procedural corpus families, and a
+completed Working Memory archive maps to session working context. Cases remain
+training and evaluation fixtures and are not registered as executable memory.
+
+Account, user, peer, session, project, surface, and repository revision remain
+independent scope dimensions. In particular, a project-peer preference corpus
+cannot be reused for another project or surface merely because the provider
+returned a high-scoring match.
+
+OpenViking's default type-quota recall currently allows an experience corpus to
+exist while the experiences quota is zero. The registry therefore never
+derives retrieval health from corpus or index presence.
+
+## Stage boundary
+
+Stage 1 implements corpus declarations, the semantic-preference inventory
+bridge, maintenance invariants, and deterministic health classification. It
+does not perform provider writes, persist a second registry, read raw memory,
+distill candidates, enable cross-module recall, or promote a release.
+
+Stage 2 owns inspectable candidate distillation and explicit human review.
+Stage 3 owns live cross-module recall and application receipts. Stage 4 owns
+evaluation and the release gate; Stage 5 owns bounded dogfood and operator
+edit or retirement controls.

--- a/examples/reward-memory-corpus-registry-smoke.py
+++ b/examples/reward-memory-corpus-registry-smoke.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Smoke-test the Stage-1 reward-memory corpus registry and health contract."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.reward_memory import (  # noqa: E402
+    build_reward_memory_corpus_health_packet,
+    build_reward_memory_corpus_registry_packet,
+    reward_memory_health_case,
+    semantic_preference_inventory_to_reward_corpora,
+)
+
+
+def run_cli(*args: str) -> dict[str, object]:
+    completed = subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--format", "json", *args],
+        cwd=REPO_ROOT,
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    return json.loads(completed.stdout)
+
+
+def expect_value_error(callable_) -> None:
+    try:
+        callable_()
+    except ValueError:
+        return
+    raise AssertionError("expected a ValueError")
+
+
+def main() -> int:
+    registry = build_reward_memory_corpus_registry_packet()
+    assert registry["schema_version"] == "reward_memory_corpus_registry_v0"
+    assert registry["status"] == "reference_registry"
+    assert registry["corpus_count"] == 7
+    assert set(registry["class_coverage"]) == {
+        "run_bound_reward",
+        "hard_policy",
+        "soft_preference",
+        "procedural_experience",
+        "working_context",
+    }
+    assert registry["class_coverage"]["procedural_experience"] == [
+        "distilled_experiences",
+        "execution_trajectories",
+    ]
+    assert registry["registry_role"] == (
+        "stateless_read_model_not_memory_source_of_truth"
+    )
+    assert registry["raw_memory_captured"] is False
+    assert registry["registry_persisted"] is False
+    assert registry["external_writes_performed"] is False
+
+    serialized = json.dumps(registry, ensure_ascii=False)
+    assert "raw chat" not in serialized.lower()
+    assert all(
+        item["privacy"]["raw_content_in_registry"] is False
+        for item in registry["corpora"]
+    )
+
+    preference_inventory = [
+        {
+            "corpus_id": "project_peer_preferences",
+            "scope_ref": "viking://user/example/agents/project/memories/preferences",
+            "read_role": "primary",
+            "write_mode": "provider_managed",
+            "write_actor_ref": "peer:project",
+            "source_of_truth": "repository_revision_and_explicit_feedback",
+            "writeback_triggers": ["explicit_feedback", "source_truth_changed"],
+            "closure_policy": "write_wait_l2_read_scoped_recall",
+        }
+    ]
+    bridged = semantic_preference_inventory_to_reward_corpora(
+        preference_inventory,
+        provider_id="openviking",
+        workspace_ref="workspace:example",
+        project_ref="project:example",
+        surface="issue_fix.pr_description",
+        source_revision="revision:abc123",
+    )
+    assert bridged["status"] == "registered"
+    assert bridged["bridge_schema_version"] == (
+        "reward_memory_semantic_preference_registry_bridge_v0"
+    )
+    bridged_corpus = bridged["corpora"][0]
+    assert bridged_corpus["class_id"] == "soft_preference"
+    assert bridged_corpus["write_authority"] == "provider_managed"
+    assert bridged_corpus["freshness"] == {
+        "mode": "revision_bound",
+        "source_revision": "revision:abc123",
+        "max_age_seconds": None,
+    }
+    assert bridged_corpus["provider_scope_ref_digest"]
+    assert bridged_corpus["maintenance"] == {
+        "writeback_triggers": ["explicit_feedback", "source_truth_changed"],
+        "closure_policy": "write_wait_l2_read_scoped_recall",
+        "retirement_authority": "peer:project",
+    }
+    assert "viking://" not in json.dumps(bridged), bridged
+
+    expected_states = {
+        "unavailable": "unavailable",
+        "empty": "empty",
+        "stale": "stale",
+        "wrong-project": "wrong_project",
+        "wrong-surface": "wrong_surface",
+        "index-unavailable": "index_unavailable",
+        "retrieval-failed": "retrieval_failed",
+        "readback-unverified": "readback_unverified",
+        "retrieval-verified": "retrieval_verified",
+        "applied-verified": "applied_verified",
+    }
+    health_packets: dict[str, dict[str, object]] = {}
+    for case, expected in expected_states.items():
+        corpus, observation = reward_memory_health_case(case)
+        packet = build_reward_memory_corpus_health_packet(corpus, observation)
+        health_packets[case] = packet
+        assert packet["health_state"] == expected, packet
+        assert packet["memory_patch_authority"] is False
+        assert packet["external_write_authorized"] is False
+        assert packet["raw_memory_captured"] is False
+
+    assert health_packets["empty"]["pipeline"]["corpus_present"] is True
+    assert health_packets["empty"]["pipeline"]["record_count"] == 0
+    assert health_packets["index-unavailable"]["pipeline"]["corpus_present"] is True
+    assert health_packets["index-unavailable"]["pipeline"]["index_present"] is False
+    assert health_packets["retrieval-failed"]["pipeline"]["index_present"] is True
+    assert (
+        health_packets["readback-unverified"]["pipeline"]["retrieval_query_succeeded"]
+        is True
+    )
+    assert (
+        health_packets["readback-unverified"]["pipeline"]["result_readback_verified"]
+        is False
+    )
+    assert health_packets["retrieval-verified"]["may_apply_memory"] is True
+    assert (
+        health_packets["retrieval-verified"]["pipeline"]["memory_applied_with_receipt"]
+        is False
+    )
+    assert (
+        health_packets["applied-verified"]["pipeline"]["memory_applied_with_receipt"]
+        is True
+    )
+
+    corpus, observation = reward_memory_health_case("retrieval-verified")
+    contradictory = observation | {
+        "result_readback_verified": False,
+        "memory_applied_with_receipt": True,
+    }
+    expect_value_error(
+        lambda: build_reward_memory_corpus_health_packet(corpus, contradictory)
+    )
+
+    duplicate = [deepcopy(registry["corpora"][0])] * 2
+    expect_value_error(lambda: build_reward_memory_corpus_registry_packet(duplicate))
+    unsafe = deepcopy(registry["corpora"][0])
+    unsafe["privacy"]["raw_content_in_registry"] = True
+    expect_value_error(lambda: build_reward_memory_corpus_registry_packet([unsafe]))
+
+    cli_registry = run_cli("reward-memory", "corpus-registry")
+    assert cli_registry["corpus_count"] == 7
+    cli_health = run_cli("reward-memory", "health-check", "--case", "wrong-surface")
+    assert cli_health["health_state"] == "wrong_surface"
+    assert cli_health["may_apply_memory"] is False
+
+    print("reward-memory-corpus-registry-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -287,9 +287,11 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
     },
     {
         "id": "reward-memory",
-        "title": "Reward-memory architecture and routing",
-        "status": "design-contract",
-        "real_world_anchor": "typed feedback memory and pilot/meta delegation",
+        "title": "Reward-memory architecture, corpus health, and routing",
+        "status": "foundation",
+        "real_world_anchor": (
+            "typed feedback memory, provider-owned corpus health, and pilot/meta delegation"
+        ),
         "user_value": (
             "Keep run judgments, policies, preferences, reusable experience, and "
             "working context distinct so recalled material cannot silently become authority."
@@ -306,6 +308,16 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "purpose": "Exercise the public negative regression for semantic-contract, cross-surface, high-complexity issue-fix routing.",
                 "write_boundary": "deterministic public fixture only; no issue body, memory content, repository, or external write",
             },
+            {
+                "command": "loopx reward-memory corpus-registry --format json",
+                "purpose": "Render the Stage-1 corpus ownership, authority, scope, freshness, lifecycle, and maintenance registry.",
+                "write_boundary": "stateless read model only; provider content stays at its source of truth",
+            },
+            {
+                "command": "loopx reward-memory health-check --case wrong-project --format json",
+                "purpose": "Exercise deterministic project, surface, freshness, index, retrieval, readback, and application health states.",
+                "write_boundary": "public fixture classification only; no memory, index, receipt, state, or external write",
+            },
         ],
         "implemented_protocols": [
             {
@@ -318,20 +330,37 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "module": "loopx.capabilities.reward_memory.architecture",
                 "doc": "docs/reference/protocols/reward-memory-architecture-v0.md",
             },
+            {
+                "schema_version": "reward_memory_corpus_registry_v0",
+                "module": "loopx.capabilities.reward_memory.registry",
+                "doc": "docs/reference/protocols/reward-memory-corpus-registry-v0.md",
+            },
+            {
+                "schema_version": "reward_memory_corpus_health_v0",
+                "module": "loopx.capabilities.reward_memory.health",
+                "doc": "docs/reference/protocols/reward-memory-corpus-registry-v0.md",
+            },
         ],
-        "smokes": ["python3 examples/reward-memory-architecture-smoke.py"],
-        "docs": ["docs/reference/protocols/reward-memory-architecture-v0.md"],
+        "smokes": [
+            "python3 examples/reward-memory-architecture-smoke.py",
+            "python3 examples/reward-memory-corpus-registry-smoke.py",
+        ],
+        "docs": [
+            "docs/reference/protocols/reward-memory-architecture-v0.md",
+            "docs/reference/protocols/reward-memory-corpus-registry-v0.md",
+        ],
         "boundaries": [
             "Run-bound reward is outcome evidence and requires explicit review before any promotion.",
             "Hard policy, fresh source truth, action authority, and privacy always outrank preferences and experience.",
             "Retrieval without current-artifact verification has zero patch authority.",
             "OpenViking cases are evaluation fixtures, provider soul text is not action authority, and session working memory remains continuation context.",
             "Corpus presence, index presence, retrieval success, readback, and applied receipts are distinct health states.",
-            "Stage 0 writes no corpus, candidate, provider memory, evaluation result, or external artifact.",
+            "Project or surface mismatch fails closed before provider availability can influence application.",
+            "Stages 0-1 write no corpus, candidate, provider memory, evaluation result, or external artifact.",
         ],
         "next_real_step": (
-            "Implement the deferred Stage-1 corpus registry and retrieval-health "
-            "contract without collapsing the five classes."
+            "Implement the deferred Stage-2 candidate distillation and explicit "
+            "human-review queue without enabling cross-module recall."
         ),
     },
     {

--- a/loopx/capabilities/reward_memory/__init__.py
+++ b/loopx/capabilities/reward_memory/__init__.py
@@ -5,9 +5,23 @@ from .architecture import (
     build_reward_memory_route_packet,
     pr_3237_regression_observation,
 )
+from .health import (
+    build_reward_memory_corpus_health_packet,
+    reward_memory_health_case,
+)
+from .registry import (
+    build_reward_memory_corpus_registry_packet,
+    normalize_reward_memory_corpus,
+    semantic_preference_inventory_to_reward_corpora,
+)
 
 __all__ = [
     "build_reward_memory_architecture_packet",
+    "build_reward_memory_corpus_health_packet",
+    "build_reward_memory_corpus_registry_packet",
     "build_reward_memory_route_packet",
+    "normalize_reward_memory_corpus",
     "pr_3237_regression_observation",
+    "reward_memory_health_case",
+    "semantic_preference_inventory_to_reward_corpora",
 ]

--- a/loopx/capabilities/reward_memory/cli.py
+++ b/loopx/capabilities/reward_memory/cli.py
@@ -8,16 +8,23 @@ from .architecture import (
     build_reward_memory_route_packet,
     pr_3237_regression_observation,
 )
+from .health import (
+    build_reward_memory_corpus_health_packet,
+    reward_memory_health_case,
+)
+from .registry import build_reward_memory_corpus_registry_packet
 
 
 def _render(payload: dict[str, object]) -> str:
     lines = ["# Reward Memory", ""]
-    for key in ("status", "decision", "case_ref"):
+    for key in ("status", "decision", "health_state", "case_ref"):
         if key in payload:
             lines.append(f"- {key}: `{payload[key]}`")
     classes = payload.get("memory_classes")
     if isinstance(classes, list):
         lines.append(f"- memory_classes: `{len(classes)}`")
+    if "corpus_count" in payload:
+        lines.append(f"- corpus_count: `{payload['corpus_count']}`")
     reasons = payload.get("reason_codes")
     if isinstance(reasons, list):
         lines.append("- reason_codes: `" + ", ".join(map(str, reasons)) + "`")
@@ -38,6 +45,35 @@ def register_reward_memory_commands(
         help="Render the provider-neutral Stage-0 architecture contract.",
     )
     add_subcommand_format(architecture)
+
+    registry = sub.add_parser(
+        "corpus-registry",
+        help="Render the Stage-1 corpus ownership and maintenance registry.",
+    )
+    add_subcommand_format(registry)
+
+    health = sub.add_parser(
+        "health-check",
+        help="Exercise a Stage-1 scope, freshness, retrieval, and readback state.",
+    )
+    add_subcommand_format(health)
+    health.add_argument(
+        "--case",
+        choices=[
+            "unavailable",
+            "empty",
+            "stale",
+            "wrong-project",
+            "wrong-surface",
+            "index-unavailable",
+            "retrieval-failed",
+            "readback-unverified",
+            "retrieval-verified",
+            "applied-verified",
+        ],
+        default="retrieval-verified",
+        help="Use a compact public health fixture.",
+    )
 
     route = sub.add_parser(
         "route-check",
@@ -84,6 +120,11 @@ def handle_reward_memory_command(
     try:
         if args.reward_memory_command == "architecture":
             payload = build_reward_memory_architecture_packet()
+        elif args.reward_memory_command == "corpus-registry":
+            payload = build_reward_memory_corpus_registry_packet()
+        elif args.reward_memory_command == "health-check":
+            corpus, observation = reward_memory_health_case(args.case)
+            payload = build_reward_memory_corpus_health_packet(corpus, observation)
         else:
             observation = (
                 pr_3237_regression_observation()
@@ -95,12 +136,8 @@ def handle_reward_memory_command(
                     "generic_boundary_for_specific_policy": (
                         args.generic_boundary_for_specific_policy
                     ),
-                    "user_visible_behavior_change": (
-                        args.user_visible_behavior_change
-                    ),
-                    "hot_path_or_storage_change": (
-                        args.hot_path_or_storage_change
-                    ),
+                    "user_visible_behavior_change": (args.user_visible_behavior_change),
+                    "hot_path_or_storage_change": (args.hot_path_or_storage_change),
                     "retrieval_or_memory_quality_claim": (
                         args.retrieval_or_memory_quality_claim
                     ),

--- a/loopx/capabilities/reward_memory/health.py
+++ b/loopx/capabilities/reward_memory/health.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .registry import (
+    SURFACE_RE,
+    TOKEN_RE,
+    build_reward_memory_corpus_registry_packet,
+    normalize_reward_memory_corpus,
+)
+
+
+REWARD_MEMORY_CORPUS_HEALTH_SCHEMA_VERSION = "reward_memory_corpus_health_v0"
+
+
+def _token(value: object, label: str) -> str:
+    result = str(value or "").strip()
+    if not TOKEN_RE.fullmatch(result):
+        raise ValueError(f"{label} must be a compact public-safe token")
+    return result
+
+
+def _optional_token(value: object, label: str) -> str | None:
+    if value in (None, ""):
+        return None
+    return _token(value, label)
+
+
+def _boolean(mapping: Mapping[str, Any], key: str) -> bool:
+    value = mapping.get(key)
+    if not isinstance(value, bool):
+        raise ValueError(f"{key} must be a boolean")
+    return value
+
+
+def build_reward_memory_corpus_health_packet(
+    corpus: Mapping[str, Any],
+    observation: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Classify one corpus without collapsing inventory, retrieval, and use states."""
+
+    item = normalize_reward_memory_corpus(corpus)
+    requested_project = _token(
+        observation.get("requested_project_ref"), "requested_project_ref"
+    )
+    requested_surface = str(observation.get("requested_surface") or "").strip()
+    if not SURFACE_RE.fullmatch(requested_surface):
+        raise ValueError("requested_surface must be a module-qualified token")
+    current_revision = _optional_token(
+        observation.get("current_source_revision"), "current_source_revision"
+    )
+    provider_available = _boolean(observation, "provider_available")
+    corpus_present = _boolean(observation, "corpus_present")
+    index_present = _boolean(observation, "index_present")
+    retrieval_succeeded = _boolean(observation, "retrieval_query_succeeded")
+    readback_verified = _boolean(observation, "result_readback_verified")
+    application_receipt = _boolean(observation, "memory_applied_with_receipt")
+    freshness_window_satisfied = _boolean(observation, "freshness_window_satisfied")
+    record_count = observation.get("record_count")
+    if (
+        isinstance(record_count, bool)
+        or not isinstance(record_count, int)
+        or record_count < 0
+    ):
+        raise ValueError("record_count must be a non-negative integer")
+    if not corpus_present and record_count:
+        raise ValueError("record_count must be zero when corpus_present is false")
+    if retrieval_succeeded and (not provider_available or not corpus_present):
+        raise ValueError("retrieval success requires an available present corpus")
+    if readback_verified and not retrieval_succeeded:
+        raise ValueError("readback verification requires retrieval success")
+    if application_receipt and not readback_verified:
+        raise ValueError("application receipt requires verified readback")
+
+    scope = item["scope"]
+    freshness = item["freshness"]
+    lifecycle = item["lifecycle"]
+    revision_matches = (
+        freshness["source_revision"] is None
+        or current_revision == freshness["source_revision"]
+    )
+    reasons: list[str] = []
+    if requested_project != scope["project_ref"]:
+        state = "wrong_project"
+        reasons.append("requested_project_outside_corpus_scope")
+    elif requested_surface not in scope["surface_ids"]:
+        state = "wrong_surface"
+        reasons.append("requested_surface_outside_corpus_scope")
+    elif not provider_available:
+        state = "unavailable"
+        reasons.append("provider_unavailable")
+    elif not corpus_present:
+        state = "unavailable"
+        reasons.append("corpus_missing")
+    elif record_count == 0:
+        state = "empty"
+        reasons.append("corpus_present_without_records")
+    elif lifecycle["state"] != "active":
+        state = "stale"
+        reasons.append(f"lifecycle_{lifecycle['state']}")
+    elif not revision_matches:
+        state = "stale"
+        reasons.append("source_revision_mismatch_or_unverified")
+    elif not freshness_window_satisfied:
+        state = "stale"
+        reasons.append("freshness_window_unsatisfied")
+    elif item["retrieval"]["index_required"] and not index_present:
+        state = "index_unavailable"
+        reasons.append("required_index_missing")
+    elif not retrieval_succeeded:
+        state = "retrieval_failed"
+        reasons.append("retrieval_query_failed_or_not_run")
+    elif item["retrieval"]["readback_required"] and not readback_verified:
+        state = "readback_unverified"
+        reasons.append("retrieval_result_not_read_back")
+    elif application_receipt:
+        state = "applied_verified"
+        reasons.append("verified_result_has_application_receipt")
+    else:
+        state = "retrieval_verified"
+        reasons.append("verified_result_not_yet_applied")
+
+    may_apply = state in {"retrieval_verified", "applied_verified"}
+    return {
+        "ok": True,
+        "schema_version": REWARD_MEMORY_CORPUS_HEALTH_SCHEMA_VERSION,
+        "corpus_id": item["corpus_id"],
+        "class_id": item["class_id"],
+        "health_state": state,
+        "reason_codes": reasons,
+        "scope_check": {
+            "project_matches": requested_project == scope["project_ref"],
+            "surface_matches": requested_surface in scope["surface_ids"],
+        },
+        "freshness_check": {
+            "lifecycle_state": lifecycle["state"],
+            "source_revision_matches": revision_matches,
+            "freshness_window_satisfied": freshness_window_satisfied,
+        },
+        "pipeline": {
+            "provider_available": provider_available,
+            "corpus_present": corpus_present,
+            "record_count": record_count,
+            "index_required": item["retrieval"]["index_required"],
+            "index_present": index_present,
+            "retrieval_query_succeeded": retrieval_succeeded,
+            "result_readback_verified": readback_verified,
+            "memory_applied_with_receipt": application_receipt,
+        },
+        "may_apply_memory": may_apply,
+        "memory_patch_authority": False,
+        "external_write_authorized": False,
+        "raw_memory_captured": False,
+    }
+
+
+def reward_memory_health_case(case: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return one public fixture for CLI and contract regression coverage."""
+
+    valid_cases = {
+        "unavailable",
+        "empty",
+        "stale",
+        "wrong-project",
+        "wrong-surface",
+        "index-unavailable",
+        "retrieval-failed",
+        "readback-unverified",
+        "retrieval-verified",
+        "applied-verified",
+    }
+    if case not in valid_cases:
+        raise ValueError("unknown reward-memory health case")
+    registry = build_reward_memory_corpus_registry_packet()
+    corpus = next(
+        item
+        for item in registry["corpora"]
+        if item["corpus_id"] == "distilled_experiences"
+    )
+    observation: dict[str, Any] = {
+        "requested_project_ref": "project:exact",
+        "requested_surface": "issue_fix.routing",
+        "current_source_revision": "revision:observed",
+        "provider_available": True,
+        "corpus_present": True,
+        "record_count": 1,
+        "index_present": True,
+        "retrieval_query_succeeded": True,
+        "result_readback_verified": True,
+        "memory_applied_with_receipt": False,
+        "freshness_window_satisfied": True,
+    }
+    if case == "unavailable":
+        observation |= {
+            "provider_available": False,
+            "corpus_present": False,
+            "record_count": 0,
+            "index_present": False,
+            "retrieval_query_succeeded": False,
+            "result_readback_verified": False,
+        }
+    elif case == "empty":
+        observation["record_count"] = 0
+    elif case == "stale":
+        observation["current_source_revision"] = "revision:newer"
+    elif case == "wrong-project":
+        observation["requested_project_ref"] = "project:other"
+    elif case == "wrong-surface":
+        observation["requested_surface"] = "content_ops.draft"
+    elif case == "index-unavailable":
+        observation["index_present"] = False
+        observation["retrieval_query_succeeded"] = False
+        observation["result_readback_verified"] = False
+    elif case == "retrieval-failed":
+        observation["retrieval_query_succeeded"] = False
+        observation["result_readback_verified"] = False
+    elif case == "readback-unverified":
+        observation["result_readback_verified"] = False
+    elif case == "applied-verified":
+        observation["memory_applied_with_receipt"] = True
+    return corpus, observation

--- a/loopx/capabilities/reward_memory/registry.py
+++ b/loopx/capabilities/reward_memory/registry.py
@@ -1,0 +1,596 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from .architecture import MEMORY_CLASS_IDS
+
+
+REWARD_MEMORY_CORPUS_REGISTRY_SCHEMA_VERSION = "reward_memory_corpus_registry_v0"
+REWARD_MEMORY_SEMANTIC_PREFERENCE_BRIDGE_SCHEMA_VERSION = (
+    "reward_memory_semantic_preference_registry_bridge_v0"
+)
+
+MAX_CORPORA = 50
+MAX_SURFACES = 20
+CORPUS_ID_RE = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
+TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/#-]{0,199}$")
+SURFACE_RE = re.compile(r"^[a-z][a-z0-9_-]*(?:\.[a-z][a-z0-9_-]*)+$")
+
+READ_AUTHORITIES = {
+    "goal_run_scoped",
+    "authority_scoped",
+    "module_scoped",
+    "actor_scoped",
+    "session_scoped",
+}
+WRITE_AUTHORITIES = {
+    "append_only_overlay",
+    "authorized_policy_source",
+    "provider_managed",
+    "read_only",
+    "ephemeral_runtime",
+}
+FRESHNESS_MODES = {
+    "source_truth_bound",
+    "revision_bound",
+    "time_bound",
+    "session_archive_bound",
+    "execution_bound",
+}
+LIFECYCLE_STATES = {"active", "superseded", "retired"}
+VISIBILITIES = {"private", "workspace", "public_safe"}
+
+
+def _token(value: object, label: str) -> str:
+    result = str(value or "").strip()
+    if not TOKEN_RE.fullmatch(result):
+        raise ValueError(f"{label} must be a compact public-safe token")
+    return result
+
+
+def _optional_token(value: object, label: str) -> str | None:
+    if value in (None, ""):
+        return None
+    return _token(value, label)
+
+
+def _boolean(mapping: Mapping[str, Any], key: str) -> bool:
+    value = mapping.get(key)
+    if not isinstance(value, bool):
+        raise ValueError(f"{key} must be a boolean")
+    return value
+
+
+def _tokens(
+    values: object,
+    label: str,
+    *,
+    maximum: int,
+    surface: bool = False,
+) -> list[str]:
+    if not isinstance(values, list) or len(values) > maximum:
+        raise ValueError(f"{label} must be a bounded list")
+    normalized: list[str] = []
+    for value in values:
+        item = str(value or "").strip()
+        pattern = SURFACE_RE if surface else TOKEN_RE
+        if not pattern.fullmatch(item):
+            raise ValueError(f"{label} contains an invalid token")
+        normalized.append(item)
+    if len(normalized) != len(set(normalized)):
+        raise ValueError(f"{label} must not contain duplicates")
+    return sorted(normalized)
+
+
+def _normalize_scope(raw: object) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise ValueError("corpus scope must be an object")
+    surfaces = _tokens(
+        raw.get("surface_ids"),
+        "scope.surface_ids",
+        maximum=MAX_SURFACES,
+        surface=True,
+    )
+    if not surfaces:
+        raise ValueError("scope.surface_ids must not be empty")
+    return {
+        "workspace_ref": _token(raw.get("workspace_ref"), "scope.workspace_ref"),
+        "project_ref": _token(raw.get("project_ref"), "scope.project_ref"),
+        "surface_ids": surfaces,
+        "user_ref": _optional_token(raw.get("user_ref"), "scope.user_ref"),
+        "peer_ref": _optional_token(raw.get("peer_ref"), "scope.peer_ref"),
+        "session_ref": _optional_token(raw.get("session_ref"), "scope.session_ref"),
+    }
+
+
+def _normalize_freshness(raw: object) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise ValueError("corpus freshness must be an object")
+    mode = str(raw.get("mode") or "").strip()
+    if mode not in FRESHNESS_MODES:
+        raise ValueError("freshness.mode is invalid")
+    max_age = raw.get("max_age_seconds")
+    if max_age is not None and (
+        isinstance(max_age, bool) or not isinstance(max_age, int) or max_age < 1
+    ):
+        raise ValueError("freshness.max_age_seconds must be a positive integer")
+    source_revision = _optional_token(
+        raw.get("source_revision"), "freshness.source_revision"
+    )
+    if mode in {"revision_bound", "session_archive_bound"} and not source_revision:
+        raise ValueError(f"freshness mode {mode} requires source_revision")
+    if mode == "time_bound" and max_age is None:
+        raise ValueError("time_bound freshness requires max_age_seconds")
+    return {
+        "mode": mode,
+        "source_revision": source_revision,
+        "max_age_seconds": max_age,
+    }
+
+
+def _normalize_lifecycle(raw: object) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise ValueError("corpus lifecycle must be an object")
+    state = str(raw.get("state") or "").strip()
+    if state not in LIFECYCLE_STATES:
+        raise ValueError("lifecycle.state is invalid")
+    supersedes = _tokens(
+        raw.get("supersedes") or [],
+        "lifecycle.supersedes",
+        maximum=MAX_CORPORA,
+    )
+    if any(not CORPUS_ID_RE.fullmatch(item) for item in supersedes):
+        raise ValueError("lifecycle.supersedes must contain corpus ids")
+    superseded_by = _optional_token(raw.get("superseded_by"), "lifecycle.superseded_by")
+    if superseded_by and not CORPUS_ID_RE.fullmatch(superseded_by):
+        raise ValueError("lifecycle.superseded_by must be a corpus id")
+    retirement_reason = _optional_token(
+        raw.get("retirement_reason"), "lifecycle.retirement_reason"
+    )
+    if state == "superseded" and not superseded_by:
+        raise ValueError("superseded corpus requires lifecycle.superseded_by")
+    if state == "retired" and not retirement_reason:
+        raise ValueError("retired corpus requires lifecycle.retirement_reason")
+    return {
+        "state": state,
+        "supersedes": supersedes,
+        "superseded_by": superseded_by,
+        "retirement_reason": retirement_reason,
+    }
+
+
+def _normalize_retrieval(raw: object) -> dict[str, bool]:
+    if not isinstance(raw, Mapping):
+        raise ValueError("corpus retrieval must be an object")
+    return {
+        key: _boolean(raw, key)
+        for key in (
+            "index_required",
+            "readback_required",
+            "application_receipt_required",
+        )
+    }
+
+
+def _normalize_maintenance(raw: object) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise ValueError("corpus maintenance must be an object")
+    triggers = _tokens(
+        raw.get("writeback_triggers") or [],
+        "maintenance.writeback_triggers",
+        maximum=10,
+    )
+    closure_policy = _token(raw.get("closure_policy"), "maintenance.closure_policy")
+    retirement_authority = _token(
+        raw.get("retirement_authority"), "maintenance.retirement_authority"
+    )
+    return {
+        "writeback_triggers": triggers,
+        "closure_policy": closure_policy,
+        "retirement_authority": retirement_authority,
+    }
+
+
+def _normalize_privacy(raw: object) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise ValueError("corpus privacy must be an object")
+    visibility = str(raw.get("visibility") or "").strip()
+    if visibility not in VISIBILITIES:
+        raise ValueError("privacy.visibility is invalid")
+    raw_content = _boolean(raw, "raw_content_in_registry")
+    if raw_content:
+        raise ValueError("reward-memory registry must not contain raw memory content")
+    return {
+        "visibility": visibility,
+        "raw_content_in_registry": False,
+    }
+
+
+def normalize_reward_memory_corpus(corpus: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate one compact corpus declaration without reading provider content."""
+
+    corpus_id = str(corpus.get("corpus_id") or "").strip()
+    if not CORPUS_ID_RE.fullmatch(corpus_id):
+        raise ValueError("corpus_id must be a lower-snake token")
+    class_id = str(corpus.get("class_id") or "").strip()
+    if class_id not in MEMORY_CLASS_IDS:
+        raise ValueError("class_id is not a Stage-0 reward-memory class")
+    read_authority = str(corpus.get("read_authority") or "").strip()
+    write_authority = str(corpus.get("write_authority") or "").strip()
+    if read_authority not in READ_AUTHORITIES:
+        raise ValueError("read_authority is invalid")
+    if write_authority not in WRITE_AUTHORITIES:
+        raise ValueError("write_authority is invalid")
+    entry = {
+        "corpus_id": corpus_id,
+        "class_id": class_id,
+        "provider_id": _token(corpus.get("provider_id"), "provider_id"),
+        "owner_ref": _token(corpus.get("owner_ref"), "owner_ref"),
+        "source_of_truth": _token(corpus.get("source_of_truth"), "source_of_truth"),
+        "read_authority": read_authority,
+        "write_authority": write_authority,
+        "scope": _normalize_scope(corpus.get("scope")),
+        "freshness": _normalize_freshness(corpus.get("freshness")),
+        "lifecycle": _normalize_lifecycle(corpus.get("lifecycle")),
+        "retrieval": _normalize_retrieval(corpus.get("retrieval")),
+        "maintenance": _normalize_maintenance(corpus.get("maintenance")),
+        "privacy": _normalize_privacy(corpus.get("privacy")),
+    }
+    scope_digest = _optional_token(
+        corpus.get("provider_scope_ref_digest"), "provider_scope_ref_digest"
+    )
+    if scope_digest:
+        entry["provider_scope_ref_digest"] = scope_digest
+    read_role = _optional_token(corpus.get("read_role"), "read_role")
+    if read_role:
+        entry["read_role"] = read_role
+    return entry
+
+
+def _reference_corpora() -> list[dict[str, Any]]:
+    base_scope = {
+        "workspace_ref": "workspace:exact",
+        "project_ref": "project:exact",
+        "surface_ids": ["control_plane.reward_review"],
+    }
+    private = {"visibility": "private", "raw_content_in_registry": False}
+    active = {"state": "active", "supersedes": []}
+    return [
+        {
+            "corpus_id": "run_reward_overlays",
+            "class_id": "run_bound_reward",
+            "provider_id": "loopx_control_plane",
+            "owner_ref": "loopx_reward_ledger",
+            "source_of_truth": "human_reward_event_ledger",
+            "read_authority": "goal_run_scoped",
+            "write_authority": "append_only_overlay",
+            "scope": base_scope,
+            "freshness": {"mode": "source_truth_bound"},
+            "lifecycle": active,
+            "retrieval": {
+                "index_required": False,
+                "readback_required": True,
+                "application_receipt_required": False,
+            },
+            "maintenance": {
+                "writeback_triggers": [
+                    "explicit_human_reward",
+                    "correction_or_revocation",
+                ],
+                "closure_policy": "append_event_then_readback",
+                "retirement_authority": "loopx_reward_ledger",
+            },
+            "privacy": private,
+        },
+        {
+            "corpus_id": "authority_policy_sources",
+            "class_id": "hard_policy",
+            "provider_id": "loopx_control_plane",
+            "owner_ref": "canonical_authority_sources",
+            "source_of_truth": "user_repository_operator_authority",
+            "read_authority": "authority_scoped",
+            "write_authority": "authorized_policy_source",
+            "scope": base_scope | {"surface_ids": ["control_plane.action_gate"]},
+            "freshness": {"mode": "source_truth_bound"},
+            "lifecycle": active,
+            "retrieval": {
+                "index_required": False,
+                "readback_required": True,
+                "application_receipt_required": False,
+            },
+            "maintenance": {
+                "writeback_triggers": [
+                    "authority_source_changed",
+                    "expiry_reached",
+                ],
+                "closure_policy": "canonical_source_then_readback",
+                "retirement_authority": "canonical_authority_sources",
+            },
+            "privacy": private,
+        },
+        {
+            "corpus_id": "scoped_preferences",
+            "class_id": "soft_preference",
+            "provider_id": "configured_memory_provider",
+            "owner_ref": "provider_scope_owner",
+            "source_of_truth": "explicit_reviewed_feedback",
+            "read_authority": "module_scoped",
+            "write_authority": "provider_managed",
+            "scope": base_scope | {"surface_ids": ["module.owned_surface"]},
+            "freshness": {"mode": "source_truth_bound"},
+            "lifecycle": active,
+            "retrieval": {
+                "index_required": True,
+                "readback_required": True,
+                "application_receipt_required": True,
+            },
+            "maintenance": {
+                "writeback_triggers": [
+                    "explicit_feedback",
+                    "source_truth_changed",
+                ],
+                "closure_policy": "provider_write_index_read_and_scoped_recall",
+                "retirement_authority": "provider_scope_owner",
+            },
+            "privacy": private,
+        },
+        {
+            "corpus_id": "execution_trajectories",
+            "class_id": "procedural_experience",
+            "provider_id": "configured_memory_provider",
+            "owner_ref": "provider_scope_owner",
+            "source_of_truth": "revision_stamped_execution",
+            "read_authority": "module_scoped",
+            "write_authority": "provider_managed",
+            "scope": base_scope | {"surface_ids": ["issue_fix.diagnosis"]},
+            "freshness": {
+                "mode": "revision_bound",
+                "source_revision": "revision:observed",
+            },
+            "lifecycle": active,
+            "retrieval": {
+                "index_required": True,
+                "readback_required": True,
+                "application_receipt_required": True,
+            },
+            "maintenance": {
+                "writeback_triggers": ["validated_execution"],
+                "closure_policy": "provider_write_then_revision_verified_read",
+                "retirement_authority": "provider_scope_owner",
+            },
+            "privacy": private,
+        },
+        {
+            "corpus_id": "distilled_experiences",
+            "class_id": "procedural_experience",
+            "provider_id": "configured_memory_provider",
+            "owner_ref": "provider_scope_owner",
+            "source_of_truth": "reviewed_revision_lineage",
+            "read_authority": "module_scoped",
+            "write_authority": "provider_managed",
+            "scope": base_scope | {"surface_ids": ["issue_fix.routing"]},
+            "freshness": {
+                "mode": "revision_bound",
+                "source_revision": "revision:observed",
+            },
+            "lifecycle": active,
+            "retrieval": {
+                "index_required": True,
+                "readback_required": True,
+                "application_receipt_required": True,
+            },
+            "maintenance": {
+                "writeback_triggers": [
+                    "reviewed_candidate",
+                    "source_truth_changed",
+                ],
+                "closure_policy": "provider_write_then_revision_verified_read",
+                "retirement_authority": "provider_scope_owner",
+            },
+            "privacy": private,
+        },
+        {
+            "corpus_id": "session_working_memory",
+            "class_id": "working_context",
+            "provider_id": "configured_session_provider",
+            "owner_ref": "session_owner",
+            "source_of_truth": "completed_session_archive",
+            "read_authority": "session_scoped",
+            "write_authority": "provider_managed",
+            "scope": base_scope
+            | {
+                "surface_ids": ["session.continuation"],
+                "session_ref": "session:exact",
+            },
+            "freshness": {
+                "mode": "session_archive_bound",
+                "source_revision": "archive:completed",
+            },
+            "lifecycle": active,
+            "retrieval": {
+                "index_required": False,
+                "readback_required": True,
+                "application_receipt_required": False,
+            },
+            "maintenance": {
+                "writeback_triggers": ["completed_session_archive"],
+                "closure_policy": "completed_archive_then_direct_read",
+                "retirement_authority": "session_owner",
+            },
+            "privacy": private,
+        },
+        {
+            "corpus_id": "fresh_execution_context",
+            "class_id": "working_context",
+            "provider_id": "loopx_runtime",
+            "owner_ref": "current_execution",
+            "source_of_truth": "registry_todo_checkout_observation",
+            "read_authority": "actor_scoped",
+            "write_authority": "ephemeral_runtime",
+            "scope": base_scope | {"surface_ids": ["control_plane.current_execution"]},
+            "freshness": {"mode": "execution_bound"},
+            "lifecycle": active,
+            "retrieval": {
+                "index_required": False,
+                "readback_required": True,
+                "application_receipt_required": False,
+            },
+            "maintenance": {
+                "writeback_triggers": ["fresh_source_observed"],
+                "closure_policy": "fresh_read_replaces_prior_context",
+                "retirement_authority": "current_execution",
+            },
+            "privacy": private,
+        },
+    ]
+
+
+def build_reward_memory_corpus_registry_packet(
+    corpora: Sequence[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a stateless registry read model over provider-owned corpora."""
+
+    raw_corpora = list(corpora) if corpora is not None else _reference_corpora()
+    if not raw_corpora or len(raw_corpora) > MAX_CORPORA:
+        raise ValueError(f"corpora must contain between 1 and {MAX_CORPORA} items")
+    normalized = [normalize_reward_memory_corpus(item) for item in raw_corpora]
+    ids = [item["corpus_id"] for item in normalized]
+    if len(ids) != len(set(ids)):
+        raise ValueError("corpus_id values must be unique")
+    known_ids = set(ids)
+    for item in normalized:
+        lifecycle = item["lifecycle"]
+        refs = set(lifecycle["supersedes"])
+        if lifecycle["superseded_by"]:
+            refs.add(lifecycle["superseded_by"])
+        if item["corpus_id"] in refs:
+            raise ValueError("corpus lifecycle must not reference itself")
+        if refs - known_ids:
+            raise ValueError("corpus lifecycle references an unknown corpus_id")
+    coverage = {
+        class_id: sorted(
+            item["corpus_id"] for item in normalized if item["class_id"] == class_id
+        )
+        for class_id in MEMORY_CLASS_IDS
+    }
+    return {
+        "ok": True,
+        "schema_version": REWARD_MEMORY_CORPUS_REGISTRY_SCHEMA_VERSION,
+        "status": "reference_registry" if corpora is None else "registered",
+        "registry_role": "stateless_read_model_not_memory_source_of_truth",
+        "corpus_count": len(normalized),
+        "corpora": normalized,
+        "class_coverage": coverage,
+        "maintenance_contract": {
+            "inventory_owner": "provider_or_canonical_source_owner",
+            "write_rule": "write_only_through_declared_write_authority",
+            "freshness_rule": "verify_source_truth_revision_or_archive_before_use",
+            "supersession_rule": "preserve_lineage_and_stop_recalling_inactive_items",
+            "retirement_rule": "retain_compact_reason_without_raw_content",
+            "scope_rule": "fail_closed_on_project_or_surface_mismatch",
+        },
+        "provider_alignment": {
+            "openviking": {
+                "content_source_of_truth": "agfs_content",
+                "index_role": "derived_retrieval_reference",
+                "preferences": "scoped_preferences",
+                "trajectories": "execution_trajectories",
+                "experiences": "distilled_experiences",
+                "working_memory": "session_working_memory",
+                "cases": "evaluation_fixture_not_registered_as_executable_memory",
+            }
+        },
+        "raw_memory_captured": False,
+        "registry_persisted": False,
+        "provider_write_performed": False,
+        "external_writes_performed": False,
+    }
+
+
+def semantic_preference_inventory_to_reward_corpora(
+    inventory: Sequence[Mapping[str, Any]],
+    *,
+    provider_id: str,
+    workspace_ref: str,
+    project_ref: str,
+    surface: str,
+    source_revision: str | None = None,
+) -> dict[str, Any]:
+    """Bridge the shipped semantic-preference inventory into the Stage-1 registry."""
+
+    provider = _token(provider_id, "provider_id")
+    workspace = _token(workspace_ref, "workspace_ref")
+    project = _token(project_ref, "project_ref")
+    if not SURFACE_RE.fullmatch(surface):
+        raise ValueError("surface must be a module-qualified token")
+    if not isinstance(inventory, Sequence) or isinstance(inventory, (str, bytes)):
+        raise ValueError("inventory must be a bounded sequence")
+    if not inventory or len(inventory) > MAX_CORPORA:
+        raise ValueError("inventory must contain a bounded non-empty corpus list")
+    corpora: list[dict[str, Any]] = []
+    for item in inventory:
+        if not isinstance(item, Mapping):
+            raise ValueError("inventory items must be objects")
+        corpus_id = str(item.get("corpus_id") or "").strip()
+        if not CORPUS_ID_RE.fullmatch(corpus_id):
+            raise ValueError("inventory corpus_id is invalid")
+        scope_ref = _token(item.get("scope_ref"), "inventory.scope_ref")
+        write_mode = str(item.get("write_mode") or "").strip()
+        if write_mode not in {"read_only", "provider_managed"}:
+            raise ValueError("inventory write_mode is invalid")
+        owner_ref = str(item.get("write_actor_ref") or provider).strip()
+        freshness: dict[str, Any] = {"mode": "source_truth_bound"}
+        if source_revision:
+            freshness = {
+                "mode": "revision_bound",
+                "source_revision": _token(source_revision, "source_revision"),
+            }
+        corpora.append(
+            {
+                "corpus_id": corpus_id,
+                "class_id": "soft_preference",
+                "provider_id": provider,
+                "owner_ref": owner_ref,
+                "source_of_truth": _token(
+                    item.get("source_of_truth"), "inventory.source_of_truth"
+                ),
+                "read_authority": "module_scoped",
+                "write_authority": write_mode,
+                "scope": {
+                    "workspace_ref": workspace,
+                    "project_ref": project,
+                    "surface_ids": [surface],
+                },
+                "freshness": freshness,
+                "lifecycle": {"state": "active", "supersedes": []},
+                "retrieval": {
+                    "index_required": True,
+                    "readback_required": True,
+                    "application_receipt_required": True,
+                },
+                "maintenance": {
+                    "writeback_triggers": list(item.get("writeback_triggers") or []),
+                    "closure_policy": _token(
+                        item.get("closure_policy"), "inventory.closure_policy"
+                    ),
+                    "retirement_authority": owner_ref,
+                },
+                "privacy": {
+                    "visibility": "private",
+                    "raw_content_in_registry": False,
+                },
+                "provider_scope_ref_digest": hashlib.sha256(
+                    scope_ref.encode("utf-8")
+                ).hexdigest()[:16],
+                "read_role": _token(item.get("read_role"), "inventory.read_role"),
+            }
+        )
+    packet = build_reward_memory_corpus_registry_packet(corpora)
+    packet["bridge_schema_version"] = (
+        REWARD_MEMORY_SEMANTIC_PREFERENCE_BRIDGE_SCHEMA_VERSION
+    )
+    packet["source_inventory_schema"] = "semantic_preference_provider_response_v0"
+    return packet


### PR DESCRIPTION
## Summary

- add a provider-neutral reward-memory corpus registry covering ownership, source of truth, read/write authority, project and surface scope, freshness, lifecycle, maintenance closure, and privacy
- bridge the shipped semantic-preference corpus inventory without retaining raw provider scope references
- classify unavailable, empty, stale, wrong-project, wrong-surface, index, retrieval, readback, and applied-receipt states without collapsing them
- expose corpus-registry and health-check CLI surfaces with public contract documentation and a durable smoke

## Product and architecture

This completes the Stage-1 foundation without creating a second memory store. Provider content remains at its source of truth; the registry is a stateless read model and every health result keeps patch and external-write authority false. Project and surface isolation fail closed before a recalled item can become advisory input.

The main compatibility seam is the existing semantic-preference inventory, which now maps into the generic registry while preserving provider ownership. Live cross-module recall, candidate review, provider writes, and rollout remain deferred to later stages.

## Validation

- reward-memory architecture smoke: passed
- reward-memory corpus-registry smoke: passed
- semantic-preference hook smoke: passed
- OpenViking project-peer provider smoke: passed
- Ruff, Python compile, and diff checks: passed
- full pytest: 299 passed, 2 skipped
- standard premerge canary: 4 direct checks and 13 selected checks passed; zero failures, warnings, or manual holds
- public/private boundary scan: clean across 8 changed files

## Boundary

No provider call, corpus write, index write, raw memory capture, state mutation, external write, benchmark change, permission change, or first-screen product change is included.