### PR TITLE
Refine reward-memory authority inference and reasoning boundaries

### DIFF
--- a/docs/reference/protocols/reward-memory-architecture-v0.md
+++ b/docs/reference/protocols/reward-memory-architecture-v0.md
@@ -1,11 +1,17 @@
 # Reward Memory Architecture v0
 
-LoopX separates feedback evidence from durable behavior so a useful judgment
-does not silently become a permission, policy, or universal personal profile.
-This Stage-0 contract defines five memory classes, their precedence and the
-pilot/meta delegation boundary. It does not yet implement a corpus registry,
-candidate queue, provider write, cross-module recall, evaluation harness, or
-rollout.
+LoopX separates feedback evidence, policy content, and action authority so a
+useful judgment does not silently become a universal personal profile or create
+permissions that the actor never held. Feedback from a verified repository
+owner or core contributor may still derive durable policy content inside that
+actor's independently verified repository scope. The distinction is between
+inferring what the contributor wants and inventing what the contributor is
+authorized to permit.
+
+This Stage-0 contract defines five memory classes, guarded precedence, and the
+pilot/meta delegation boundary. Stage 1 adds the corpus registry and health
+read model. Neither stage adds a second memory store, candidate scheduler,
+provider write, cross-module recall, evaluation harness, or rollout.
 
 The machine-readable contract is available through:
 
@@ -17,11 +23,11 @@ loopx reward-memory architecture --format json
 
 | Class | Source and scope | Authority and use | Lifecycle |
 | --- | --- | --- | --- |
-| `run_bound_reward` | Explicit human judgment attached to one exact goal/run. | Evidence about that outcome only. It cannot alter future behavior until a later candidate-review stage explicitly promotes a distilled item. | Append-only overlay; corrections and revocations append references instead of rewriting the judged run. |
-| `hard_policy` | Explicit user boundary, repository policy, operator gate, or authority checkpoint scoped to a project/goal and action/surface. | Deterministic constraint or veto while active and in scope. It is never inferred from reward, preference, recalled experience, or provider `soul`/boundary text without a canonical policy binding. | Active until explicitly superseded, revoked, or expired; temporary policy requires expiry. |
+| `run_bound_reward` | Explicit human judgment attached to one exact goal/run. | Evidence about that outcome only. Future influence requires compact candidate derivation and an activation policy; the overlay itself is not a standing instruction. | Append-only overlay; corrections and revocations append references instead of rewriting the judged run. |
+| `hard_policy` | Explicit user/repository/operator authority, or policy content inferred from verified owner/core-contributor evidence and bound to an existing project/action authority scope. | Constraint or veto inside the verified scope. Reasoning may infer policy meaning from rewards, preferences, current-artifact-verified experience, selected options, accepted/rejected outcomes, and maintainer corrections; it may not infer credentials, new publish/production scope, or cross-user/repository authority. | Active records retain actor, evidence, scope, and derivation provenance until superseded, revoked, or expired; temporary or weakly reinforced inference should expire or return to review. |
 | `soft_preference` | Explicit feedback, selected options, or later reviewed candidates scoped to a workspace/project and module-owned surface. | Advisory ranking or rewrite only. It cannot grant publish, merge, write, credential, or production authority. | Durable only after explicit review; editable, rejectable, supersedable, revocable, and retireable. |
 | `procedural_experience` | Revision-stamped trajectories, distilled experiences, maintainer corrections, accepted/rejected changes, and reviewed architectural learning, with repository/module/revision/applicability scope. | Advisory diagnosis, scope, routing, or validation guidance only after current-artifact verification. A training/evaluation case is evidence, not an executable instruction. Retrieval alone has zero patch authority. | Trajectories may be add-only; distilled or architectural experiences are supersedable. New source truth can stale, quarantine, refute, or retire them. |
-| `working_context` | Either fresh execution state (`fresh_execution_context`) or a revisioned session-continuation summary (`session_working_memory`). | Supports only the current execution/session continuation. Neither subtype becomes reusable policy or grants action authority. Fresh source-of-truth reads outrank recalled material. | Fresh context expires quickly; a session summary remains bound to its session/archive revision and becomes stale when a newer completed archive exists. |
+| `working_context` | Either fresh execution state (`fresh_execution_context`) or a revisioned session-continuation summary (`session_working_memory`). | Supports only the current execution/session continuation. Neither subtype becomes reusable policy or grants action authority. Fresh source-of-truth reads outrank recalled material. | `fresh_execution_context` already exists in LoopX registry/state/todo/quota/checkout observations and is reused, not rebuilt. Session context remains bound to its session/archive revision. |
 
 Every durable record must name `source`, `scope`, `authority`, `confidence`,
 `lifecycle_state`, `supersession`, `revocation`, `expiry`, and `privacy` in
@@ -32,9 +38,37 @@ project/repository, module/surface, and revision/time boundaries. Lifecycle
 records state plus supersession, revocation, expiry, and retirement references.
 Privacy names visibility, retention class, and whether raw content was captured.
 
-## Precedence and conflicts
+## Policy content versus authority
 
-The deterministic order is:
+Hard policy has two independent questions:
+
+1. **What is the policy?** LoopX may infer compact policy content from explicit
+   feedback, reviewed preferences, current-artifact-verified experience,
+   selected options, repeated accepted or rejected outcomes, and maintainer
+   corrections.
+2. **Where does that policy have force?** Actor identity and repository/action
+   authority must come from an independently verified source. Memory confidence
+   cannot create or widen that scope.
+
+For a verified repository owner or core contributor, an unambiguous inferred
+policy may become active without asking the same question after every run when
+all of these hold: actor and authority scope are verified, provenance is
+compact and inspectable, no higher-authority source conflicts, and the record
+is reversible through edit, supersede, revoke, retire, or expiry. Ambiguous
+meaning, unclear scope, identity uncertainty, or a conflict returns the item to
+review. Inference never creates credentials, external-write capability,
+production permission, cross-agent authority, or authority in another
+repository.
+
+Inference may derive a reusable boundary or gate policy, but it cannot fabricate
+the current state transition of a concrete operator gate or authority
+checkpoint. A current approve/reject/consume receipt still comes from that
+gate's source of truth.
+
+## Guarded precedence and model reasoning
+
+The following order is a safety and attention envelope, not an exhaustive
+decision table:
 
 1. explicit action authority and privacy boundaries;
 2. active in-scope hard policy;
@@ -43,11 +77,66 @@ The deterministic order is:
 5. active in-scope soft preference;
 6. run-bound reward as evidence only.
 
-Reject revoked, expired, out-of-scope, or unverified items before ranking.
-Within the same authority class, prefer explicit provenance, narrower scope,
-then newer source truth. If a same-authority conflict remains unresolved, do
-not apply either item. Raw chat, transcripts, tool logs, credentials, and local
-paths are not reward-memory records.
+Deterministic code should reject illegal states: unverified authority, wrong
+project or surface, revoked/expired material, privacy violations, unresolved
+same-authority conflicts, and missing current-artifact verification. Within the
+remaining allowed action set, the model keeps responsibility for interpreting
+feedback, judging relevance and evidence sufficiency, balancing trade-offs,
+and deciding to apply, ignore, or seek more evidence. Its compact receipt names
+the reasoning summary, memory references, artifact verification, and
+authority/scope check.
+
+Prefer explicit provenance when evidence is otherwise equal, but do not turn
+that preference into a hard-coded router that suppresses useful inference. Raw
+chat, transcripts, tool logs, credentials, and local paths are not
+reward-memory records.
+
+`loopx reward-memory route-check` is a deterministic regression fixture for
+obvious safety/escalation conditions such as PR #3237. It is not the live Issue
+Fix decision engine and does not replace model reasoning.
+
+## Architecture layers and reuse
+
+```mermaid
+flowchart TD
+  OV["OpenViking memory substrate<br/>AGFS source truth, index, scoped retrieval,<br/>preferences, trajectories, experiences, session memory"]
+  CTX["Existing LoopX fresh execution context<br/>registry, active state, todo/quota, checkout, bounded observations"]
+  CORE["LoopX reward-memory core<br/>classes, scope/authority, corpus health,<br/>candidate and activation decisions"]
+  IF["Issue Fix adapter<br/>run outcome and maintainer feedback in;<br/>routing/validation influence receipt out"]
+  OTHER["Later module adapters<br/>same core contract, module-owned surfaces"]
+
+  OV --> CORE
+  CTX --> CORE
+  CORE --> IF
+  CORE --> OTHER
+```
+
+OpenViking owns memory storage, indexing, scoped retrieval, and session-memory
+building blocks. LoopX owns action semantics: class, scope, authority,
+lifecycle, candidate derivation, activation, and application receipts. The
+Issue Fix adapter maps issue/PR evidence into the shared core and consumes its
+decisions; it must not grow a parallel memory store, policy schema, or ranking
+pipeline. Other modules join only after this reuse seam is proven.
+
+### Issue Fix as the first adapter
+
+Issue Fix contributes only domain mapping:
+
+- exact run reward, maintainer correction, selected fix direction, and durable
+  issue/PR outcome become compact inputs to the shared candidate contract;
+- repository identity, contributor role, current checkout, issue/PR state, and
+  active LoopX gates supply current authority and execution context;
+- OpenViking supplies scoped preference or experience retrieval when the
+  module asks for it;
+- the shared core returns apply, ignore, seek-evidence, or review, together
+  with a compact influence receipt;
+- Issue Fix still verifies any recalled technical claim against current code
+  and tests before it can affect a patch.
+
+The adapter does not own candidate lifecycle, contributor-policy semantics,
+retrieval health, or provider persistence. Those stay reusable core concerns.
+This keeps the issue-fix scenario valuable without letting it define the whole
+memory product.
 
 ## OpenViking alignment
 
@@ -69,9 +158,10 @@ against OpenViking's current public architecture and code:
   session continuation. It maps to `working_context/session_working_memory`,
   not long-term policy. LoopX's fresh registry/todo/checkout observations map to
   the separate `fresh_execution_context` subtype.
-- OpenViking `soul.md` may contain semantic boundary text, but recalled provider
-  content is not a LoopX `hard_policy` unless an explicit user, repository, or
-  operator source binds it to action authority.
+- OpenViking `soul.md` or another provider record may contain policy evidence,
+  but it becomes LoopX `hard_policy` only when the actor and repository/action
+  authority scope are independently verified. The content may be inferred; the
+  authority may not.
 - Account, user, peer, session, and repository-revision boundaries remain part
   of scope and privacy. A peer label does not grant cross-user or cross-agent
   authority.
@@ -110,9 +200,10 @@ a meta trigger produces `hold_for_evidence`. This allows a bounded bug inside a
 core module to remain pilot-sized while still escalating a deceptively small
 change that alters a public or storage contract.
 
-This is routing, not cross-agent authority. The meta lane does not edit or
-claim the pilot's todos, and the pilot cannot bypass the design gate with a
-memory hit.
+This is guarded routing, not cross-agent authority. The live agent still
+reasons about semantics and evidence inside the guards. The meta lane does not
+edit or claim the pilot's todos, and the pilot cannot bypass the design gate
+with a memory hit.
 
 ## PR #3237 regression
 
@@ -140,12 +231,19 @@ loopx reward-memory route-check --case pr-3237 --format json
 - Stage 1: the implemented provider-neutral
   [corpus registry and health contract](reward-memory-corpus-registry-v0.md),
   including ownership, authority, freshness, retirement, scope isolation, and
-  retrieval-health distinctions.
-- Stage 2: inspectable candidate distillation and explicit human review.
-- Stage 3: opt-in cross-module recall and compact application receipts.
+  retrieval-health distinctions. Its `fresh_execution_context` entry describes
+  an existing LoopX capability; it is not a request for another context system.
+- Stage 2: one thin candidate and activation-decision seam over existing
+  LoopX/OpenViking evidence. It adds no second store, scheduler, automatic
+  recall, or raw-content retention. Issue Fix is the first adapter and reuses
+  the generic record/decision shape.
+- Stage 3: opt-in cross-module recall with model reasoning inside deterministic
+  scope, authority, privacy, freshness, and conflict guards, plus compact
+  application receipts.
 - Stage 4: evaluation harness and release gate.
 - Stage 5: bounded cross-module dogfood and operator edit/retire controls.
 
-Later stages must extend this contract rather than collapsing these classes or
-turning provider availability into a user gate. Stage 1 remains a stateless
-read model and performs no provider or external write.
+Later stages must extend this contract rather than collapsing these classes,
+duplicating existing context/provider capabilities, or turning provider
+availability into a user gate. Stage 1 remains a stateless read model and
+performs no provider or external write.

--- a/docs/reference/protocols/reward-memory-corpus-registry-v0.md
+++ b/docs/reference/protocols/reward-memory-corpus-registry-v0.md
@@ -29,7 +29,7 @@ The reference registry covers all five classes through seven corpus families:
 | Corpus family | Class | Source and lifecycle |
 | --- | --- | --- |
 | `run_reward_overlays` | `run_bound_reward` | LoopX human-reward event ledger; append-only exact goal/run overlay. |
-| `authority_policy_sources` | `hard_policy` | Canonical user, repository, and operator authority; never inferred from provider memory. |
+| `authority_policy_sources` | `hard_policy` | Explicit or verified-contributor-derived policy content, always bound to independently verified user/repository/operator authority scope. |
 | `scoped_preferences` | `soft_preference` | Provider-managed, explicitly reviewed feedback for module-owned surfaces. |
 | `execution_trajectories` | `procedural_experience` | Revision-stamped execution evidence. |
 | `distilled_experiences` | `procedural_experience` | Reviewed and supersedable procedural or architectural learning. |
@@ -55,8 +55,14 @@ and neither grants patch authority. Corpus maintenance follows these rules:
 5. project or surface mismatch fails closed;
 6. retirement keeps a compact reason, never raw memory content.
 
-Confidence is intentionally absent from the health promotion path. Stage 0
-already establishes that confidence cannot increase authority.
+Policy content may be derived from a verified owner or core contributor's
+rewards, preferences, current-artifact-verified experience, selections, and
+accepted/rejected outcomes. The registry records this as a maintenance trigger
+only after actor identity and repository/action scope are independently
+verified; inference cannot create a new write, publish, production, cross-user,
+or cross-repository authority scope, and cannot fabricate the current state of
+a concrete gate. Confidence is intentionally absent from the health promotion
+path because it cannot widen authority.
 
 ## Health states
 
@@ -104,6 +110,10 @@ trajectories and experiences map to the two procedural corpus families, and a
 completed Working Memory archive maps to session working context. Cases remain
 training and evaluation fixtures and are not registered as executable memory.
 
+The `fresh_execution_context` corpus family is an inventory view over LoopX's
+already complete registry, active-state, todo/quota, checkout, and bounded tool
+observations. Stage 2 does not add another context store or retrieval path.
+
 Account, user, peer, session, project, surface, and repository revision remain
 independent scope dimensions. In particular, a project-peer preference corpus
 cannot be reused for another project or surface merely because the provider
@@ -120,7 +130,11 @@ bridge, maintenance invariants, and deterministic health classification. It
 does not perform provider writes, persist a second registry, read raw memory,
 distill candidates, enable cross-module recall, or promote a release.
 
-Stage 2 owns inspectable candidate distillation and explicit human review.
-Stage 3 owns live cross-module recall and application receipts. Stage 4 owns
-evaluation and the release gate; Stage 5 owns bounded dogfood and operator
-edit or retirement controls.
+Stage 2 owns one thin candidate and activation-decision seam. It may derive
+policy content from verified contributor signals but does not create authority,
+add a second store or scheduler, perform provider writes, or enable automatic
+recall. Issue Fix consumes the same generic seam rather than a parallel design.
+Stage 3 owns reasoning-mediated cross-module recall and application receipts;
+deterministic code remains limited to scope, authority, privacy, freshness, and
+conflict guards. Stage 4 owns evaluation and the release gate; Stage 5 owns
+bounded dogfood and operator edit or retirement controls.

--- a/examples/reward-memory-architecture-smoke.py
+++ b/examples/reward-memory-architecture-smoke.py
@@ -35,9 +35,7 @@ def run_cli(*args: str) -> dict[str, object]:
 
 def main() -> int:
     architecture = build_reward_memory_architecture_packet()
-    classes = {
-        item["class_id"]: item for item in architecture["memory_classes"]
-    }
+    classes = {item["class_id"]: item for item in architecture["memory_classes"]}
     assert set(classes) == {
         "run_bound_reward",
         "hard_policy",
@@ -46,12 +44,22 @@ def main() -> int:
         "working_context",
     }
     assert classes["run_bound_reward"]["future_influence"] == (
-        "candidate_review_required"
+        "candidate_derivation_and_activation_policy_required"
     )
-    assert classes["hard_policy"]["authority"] == "constraint_or_veto"
-    assert classes["soft_preference"]["authority"] == (
-        "advisory_ranking_or_rewrite"
+    hard_policy = classes["hard_policy"]
+    assert hard_policy["authority"] == (
+        "constraint_or_veto_within_verified_actor_scope"
     )
+    assert hard_policy["derivation"]["policy_content_may_be_inferred"] is True
+    assert (
+        hard_policy["derivation"]["authority_scope_must_be_verified_independently"]
+        is True
+    )
+    assert (
+        "verified_repository_core_contributor"
+        in hard_policy["derivation"]["eligible_actor_roles"]
+    )
+    assert classes["soft_preference"]["authority"] == ("advisory_ranking_or_rewrite")
     assert classes["procedural_experience"]["authority"] == (
         "advisory_until_current_artifact_verification"
     )
@@ -67,6 +75,9 @@ def main() -> int:
     assert classes["working_context"]["durability"] == (
         "fresh_context_expires_quickly_session_summary_is_archive_revision_bound"
     )
+    assert classes["working_context"]["subtype_status"]["fresh_execution_context"] == (
+        "existing_loopx_control_plane_capability"
+    )
     assert architecture["precedence"][0] == (
         "explicit_action_authority_and_privacy_boundary"
     )
@@ -78,6 +89,16 @@ def main() -> int:
         "basis_required": True,
         "may_increase_authority": False,
     }
+    assert architecture["routing_contract"]["mode"] == (
+        "model_reasoning_inside_deterministic_safety_guards"
+    )
+    assert architecture["routing_contract"]["not_an_exhaustive_decision_table"]
+    assert (
+        architecture["existing_capability_reuse"]["fresh_execution_context"][
+            "new_stage_2_runtime_required"
+        ]
+        is False
+    )
     openviking = architecture["provider_alignment"]["openviking"]
     assert openviking["content_source_of_truth"] == "agfs_content"
     assert openviking["non_instruction_artifacts"]["openviking_cases"] == (
@@ -87,11 +108,13 @@ def main() -> int:
         "memory_applied_with_receipt"
     )
 
-    regression = build_reward_memory_route_packet(
-        pr_3237_regression_observation()
-    )
+    regression = build_reward_memory_route_packet(pr_3237_regression_observation())
     assert regression["decision"] == "meta_design_gate", regression
     assert regression["pilot_authorized"] is False
+    assert regression["route_check_role"] == (
+        "deterministic_guard_fixture_not_live_reasoner"
+    )
+    assert regression["live_reasoning_required"] is True
     assert {
         "semantics_by_design",
         "semantic_contract_change",

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -294,7 +294,8 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
         ),
         "user_value": (
             "Keep run judgments, policies, preferences, reusable experience, and "
-            "working context distinct so recalled material cannot silently become authority."
+            "working context distinct; derive policy content from verified contributor "
+            "signals without inventing or widening authority."
         ),
         "entry_command": "loopx reward-memory architecture --format json",
         "commands": [
@@ -305,8 +306,8 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
             },
             {
                 "command": "loopx reward-memory route-check --case pr-3237 --format json",
-                "purpose": "Exercise the public negative regression for semantic-contract, cross-surface, high-complexity issue-fix routing.",
-                "write_boundary": "deterministic public fixture only; no issue body, memory content, repository, or external write",
+                "purpose": "Exercise deterministic safety guards for the public PR #3237 regression; this fixture is not the live reasoning router.",
+                "write_boundary": "stateless public guard fixture only; no issue body, memory content, repository, provider, or external write",
             },
             {
                 "command": "loopx reward-memory corpus-registry --format json",
@@ -350,17 +351,20 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
             "docs/reference/protocols/reward-memory-corpus-registry-v0.md",
         ],
         "boundaries": [
-            "Run-bound reward is outcome evidence and requires explicit review before any promotion.",
-            "Hard policy, fresh source truth, action authority, and privacy always outrank preferences and experience.",
+            "Run-bound reward is outcome evidence; future influence requires compact candidate derivation and an activation policy.",
+            "Verified owner or core-contributor feedback may derive hard-policy content only inside independently verified repository and action authority scope.",
+            "Deterministic code enforces authority, scope, privacy, freshness, verification, and conflict guards; model reasoning owns interpretation and trade-offs inside those guards.",
             "Retrieval without current-artifact verification has zero patch authority.",
             "OpenViking cases are evaluation fixtures, provider soul text is not action authority, and session working memory remains continuation context.",
+            "LoopX fresh execution context already exists and Stage 2 must reuse it rather than add another context system.",
             "Corpus presence, index presence, retrieval success, readback, and applied receipts are distinct health states.",
             "Project or surface mismatch fails closed before provider availability can influence application.",
             "Stages 0-1 write no corpus, candidate, provider memory, evaluation result, or external artifact.",
         ],
         "next_real_step": (
-            "Implement the deferred Stage-2 candidate distillation and explicit "
-            "human-review queue without enabling cross-module recall."
+            "Implement one thin Stage-2 candidate and activation-decision seam over "
+            "existing LoopX/OpenViking evidence, with Issue Fix as the first adapter; "
+            "do not add a second store, scheduler, or automatic recall."
         ),
     },
     {

--- a/loopx/capabilities/reward_memory/architecture.py
+++ b/loopx/capabilities/reward_memory/architecture.py
@@ -28,7 +28,7 @@ def _memory_classes() -> list[dict[str, Any]]:
             "source_kinds": ["explicit_human_reward"],
             "scope_floor": ["goal_id", "run_id"],
             "authority": "outcome_evidence_only",
-            "future_influence": "candidate_review_required",
+            "future_influence": "candidate_derivation_and_activation_policy_required",
             "durability": "append_only_run_overlay",
             "supersession": "append_correction_without_rewriting_the_judged_run",
             "revocation": "append_revocation_reference",
@@ -37,25 +37,57 @@ def _memory_classes() -> list[dict[str, Any]]:
         },
         {
             "class_id": "hard_policy",
-            "purpose": "Constrain or veto actions at an explicit boundary.",
+            "purpose": (
+                "Constrain or veto actions within an independently verified "
+                "actor and repository authority scope."
+            ),
             "source_kinds": [
                 "explicit_user_boundary",
                 "repository_policy",
                 "operator_gate",
                 "authority_checkpoint",
+                "verified_contributor_feedback_inference",
             ],
             "excluded_sources": [
-                "recalled_semantic_memory_without_canonical_policy_binding",
-                "provider_soul_or_boundary_text_without_action_authority",
+                "recalled_semantic_memory_without_verified_actor_and_scope_binding",
+                "provider_soul_or_boundary_text_without_verified_action_authority",
             ],
             "scope_floor": ["project_or_goal", "action_or_surface"],
-            "authority": "constraint_or_veto",
-            "future_influence": "deterministic_when_active_and_in_scope",
+            "authority": "constraint_or_veto_within_verified_actor_scope",
+            "future_influence": (
+                "reasoned_application_with_provenance_and_conflict_checks"
+            ),
             "durability": "durable_until_superseded_revoked_or_expired",
-            "supersession": "explicit_narrower_or_newer_policy_reference",
+            "supersession": ("explicit_or_stronger_newer_verified_policy_reference"),
             "revocation": "explicit_authorized_revocation",
             "expiry": "required_for_temporary_policy",
             "privacy": "private_by_default_unless_rewritten_public_safe",
+            "derivation": {
+                "policy_content_may_be_inferred": True,
+                "authority_scope_must_be_verified_independently": True,
+                "eligible_actor_roles": [
+                    "verified_repository_core_contributor",
+                    "verified_project_owner_or_operator",
+                ],
+                "evidence_inputs": [
+                    "explicit_feedback",
+                    "selected_option",
+                    "verified_scoped_preference",
+                    "current_artifact_verified_procedural_experience",
+                    "repeated_accepted_or_rejected_outcome",
+                    "maintainer_correction",
+                ],
+                "activation_rule": (
+                    "may_activate_with_compact_provenance_when_content_and_scope_"
+                    "are_unambiguous_and_no_higher_authority_conflict_exists"
+                ),
+                "cannot_derive": [
+                    "credentials",
+                    "new_write_publish_or_production_scope",
+                    "current_gate_transition_without_source_receipt",
+                    "cross_user_cross_agent_or_cross_repository_authority",
+                ],
+            },
         },
         {
             "class_id": "soft_preference",
@@ -116,6 +148,10 @@ def _memory_classes() -> list[dict[str, Any]]:
                 "fresh_execution_context",
                 "session_working_memory",
             ],
+            "subtype_status": {
+                "fresh_execution_context": "existing_loopx_control_plane_capability",
+                "session_working_memory": "provider_backed_capability_reuse",
+            },
             "purpose": (
                 "Carry fresh execution state or a revisioned session-continuation "
                 "summary without promoting either into reusable policy."
@@ -156,7 +192,8 @@ def _openviking_alignment() -> dict[str, Any]:
                 "loopx_overlay_no_direct_openviking_memory_equivalent"
             ),
             "hard_policy": (
-                "loopx_repository_operator_or_user_authority_only_provider_soul_is_advisory"
+                "explicit_or_verified_contributor_derived_policy_content_bound_to_"
+                "existing_loopx_repository_operator_or_user_authority"
             ),
             "soft_preference": "reviewed_openviking_preference_candidate",
             "procedural_experience": {
@@ -170,7 +207,8 @@ def _openviking_alignment() -> dict[str, Any]:
             },
             "working_context": {
                 "fresh_execution_context": (
-                    "loopx_registry_todo_checkout_and_tool_observation"
+                    "existing_loopx_registry_todo_checkout_and_tool_observation_"
+                    "no_new_reward_memory_store"
                 ),
                 "session_working_memory": (
                     "openviking_archive_overview_bound_to_session_and_archive_revision"
@@ -256,6 +294,29 @@ def build_reward_memory_architecture_packet() -> dict[str, Any]:
             "expired",
             "retired",
         ],
+        "routing_contract": {
+            "mode": "model_reasoning_inside_deterministic_safety_guards",
+            "deterministic_guards": [
+                "verified_actor_and_action_authority_scope",
+                "project_surface_and_revision_scope",
+                "privacy_and_external_write_boundary",
+                "revoked_expired_or_unresolved_conflict_rejection",
+                "current_artifact_verification_when_required",
+            ],
+            "reasoner_discretion": [
+                "interpret_feedback_and_candidate_meaning",
+                "judge_relevance_and_evidence_sufficiency",
+                "choose_tradeoffs_within_the_allowed_action_set",
+                "decide_whether_to_apply_ignore_or_seek_more_evidence",
+            ],
+            "required_receipt": [
+                "reasoning_summary",
+                "applied_or_ignored_memory_refs",
+                "current_artifact_verification",
+                "authority_and_scope_check",
+            ],
+            "not_an_exhaustive_decision_table": True,
+        },
         "precedence": [
             "explicit_action_authority_and_privacy_boundary",
             "active_in_scope_hard_policy",
@@ -272,15 +333,32 @@ def build_reward_memory_architecture_packet() -> dict[str, Any]:
         ],
         "safety_invariants": [
             "confidence_never_increases_authority",
-            "reward_or_preference_never_grants_permission",
+            "verified_actor_feedback_may_derive_policy_content_but_not_new_authority_scope",
+            "reward_or_preference_never_grants_new_credentials_or_action_scope",
             "memory_never_overrides_a_gate_policy_or_current_source_of_truth",
             "raw_chat_tool_logs_credentials_and_local_paths_are_not_memory_records",
             "retrieval_without_current_artifact_verification_has_zero_patch_authority",
-            "promotion_from_reward_requires_explicit_candidate_review",
-            "provider_soul_boundary_or_experience_text_never_grants_action_authority",
+            "promotion_from_reward_requires_compact_candidate_provenance_and_verified_actor_scope",
+            "provider_soul_boundary_or_experience_text_without_verified_actor_binding_never_grants_action_authority",
             "evaluation_cases_are_not_executable_instructions",
             "corpus_or_index_presence_is_not_retrieval_or_application_health",
         ],
+        "existing_capability_reuse": {
+            "fresh_execution_context": {
+                "status": "complete_in_current_loopx_control_plane",
+                "sources": [
+                    "registry",
+                    "active_state",
+                    "todo_and_quota_projection",
+                    "current_checkout_and_bounded_tool_observation",
+                ],
+                "new_stage_2_runtime_required": False,
+            },
+            "openviking_memory": {
+                "role": "provider_storage_index_retrieval_and_session_memory",
+                "reuse_before_new_infrastructure": True,
+            },
+        },
         "provider_alignment": {"openviking": _openviking_alignment()},
         "pilot_meta_delegation": {
             "schema_version": "reward_memory_pilot_meta_delegation_v0",
@@ -313,8 +391,10 @@ def build_reward_memory_architecture_packet() -> dict[str, Any]:
         "stage_boundaries": {
             "stage_0": "classification_precedence_and_delegation_only",
             "stage_1": "corpus_registry_ownership_and_retrieval_health",
-            "stage_2": "candidate_distillation_and_human_review",
-            "stage_3": "cross_module_recall_and_application",
+            "stage_2": (
+                "thin_candidate_and_review_seam_no_second_store_scheduler_or_recall"
+            ),
+            "stage_3": "reasoning_mediated_cross_module_recall_and_application",
             "stage_4": "evaluation_harness_and_release_gate",
             "stage_5": "bounded_dogfood_and_operator_controls",
         },
@@ -355,18 +435,15 @@ def _boolean(observation: Mapping[str, Any], key: str) -> bool:
 def build_reward_memory_route_packet(
     observation: Mapping[str, Any],
 ) -> dict[str, Any]:
-    """Route a bounded issue-fix observation to pilot, meta, or evidence hold."""
+    """Check a bounded issue-fix guard fixture, not the live reasoning router."""
 
     behavior_status = str(observation.get("behavior_status") or "").strip()
     if behavior_status not in BEHAVIOR_STATUSES:
-        raise ValueError(
-            f"behavior_status must be one of {sorted(BEHAVIOR_STATUSES)}"
-        )
+        raise ValueError(f"behavior_status must be one of {sorted(BEHAVIOR_STATUSES)}")
     complexity = str(observation.get("edge_case_complexity") or "").strip()
     if complexity not in EDGE_CASE_COMPLEXITIES:
         raise ValueError(
-            "edge_case_complexity must be one of "
-            f"{sorted(EDGE_CASE_COMPLEXITIES)}"
+            f"edge_case_complexity must be one of {sorted(EDGE_CASE_COMPLEXITIES)}"
         )
     surface_count = observation.get("surface_count")
     if isinstance(surface_count, bool) or not isinstance(surface_count, int):
@@ -459,6 +536,8 @@ def build_reward_memory_route_packet(
         ],
         "pilot_authorized": decision == "pilot_fix",
         "meta_review_required": decision == "meta_design_gate",
+        "route_check_role": "deterministic_guard_fixture_not_live_reasoner",
+        "live_reasoning_required": True,
         "memory_patch_authority": False,
         "external_write_authorized": False,
         "raw_issue_or_memory_captured": False,

--- a/loopx/capabilities/reward_memory/registry.py
+++ b/loopx/capabilities/reward_memory/registry.py
@@ -304,9 +304,12 @@ def _reference_corpora() -> list[dict[str, Any]]:
             "maintenance": {
                 "writeback_triggers": [
                     "authority_source_changed",
+                    "verified_contributor_policy_derived",
                     "expiry_reached",
                 ],
-                "closure_policy": "canonical_source_then_readback",
+                "closure_policy": (
+                    "verified_actor_scope_then_canonical_policy_readback"
+                ),
                 "retirement_authority": "canonical_authority_sources",
             },
             "privacy": private,


### PR DESCRIPTION
## Summary
- allow hard-policy content to be derived from verified contributor feedback while keeping authority scope independently verified
- make routing model-reasoned inside narrow deterministic safety guards instead of an exhaustive rule table
- document the restrained shared OpenViking/LoopX foundation and Issue Fix as the first adapter
- reuse LoopX fresh execution context and avoid a second store, scheduler, or automatic cross-module recall

## Validation
- `loopx canary premerge --from-git-diff --format json` (13/13 selected checks passed; 0 failures, warnings, or manual holds; public boundary clean)
- full pytest: 299 passed, 2 skipped
- reward-memory architecture, corpus-registry, and semantic-preference-hook smokes passed
- Ruff check and format check passed
- `loopx check` passed with 0 errors and 0 warnings

## Product judgment
This deliberately corrects the Stage 0/1 contract without expanding Stage 2 runtime. OpenViking remains the storage/index/retrieval substrate; LoopX owns scoped candidate, authority, lifecycle, activation, and application semantics. The Issue Fix path is an adapter over that shared core, not a parallel memory product.