### PR TITLE
Add no-sync controls to SkillsBench launcher

### DIFF
--- a/examples/skillsbench-benchmark-egress-policy-smoke.py
+++ b/examples/skillsbench-benchmark-egress-policy-smoke.py
@@ -146,6 +146,8 @@ def test_public_launcher_uses_container_reachable_benchmark_proxy() -> None:
             "SKILLSBENCH_TUNNEL_HEALTH_INTERVAL_SEC": "29",
             "SKILLSBENCH_TUNNEL_HEALTH_FAILURE_THRESHOLD": "3",
             "SKILLSBENCH_TUNNEL_RECONNECT_ATTEMPTS": "4",
+            "SKILLSBENCH_SKIP_GLOBAL_LEDGER_SYNC": "1",
+            "SKILLSBENCH_SKIP_CURRENT_AGGREGATE_UPDATE": "1",
         }
     )
     env.pop("SKILLSBENCH_APPEND_HISTORY", None)
@@ -191,6 +193,10 @@ def test_public_launcher_uses_container_reachable_benchmark_proxy() -> None:
         "20260709T000000CST" in output
     ), output
     assert "--append-history" not in output, output
+    assert "skip_global_ledger_sync=1" in output, output
+    assert "skip_current_aggregate_update=1" in output, output
+    assert "--skip-global-ledger-sync" in output, output
+    assert "--skip-current-aggregate-update" in output, output
 
 
 def test_public_launcher_batches_three_cases_with_closeout_sync() -> None:

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -50,6 +50,11 @@ Optional env:
   SKILLSBENCH_SSH_OPTIONS              Extra ssh options, one shell word each
   SKILLSBENCH_APPEND_HISTORY           Set to 1 to append LoopX history
   SKILLSBENCH_REGISTRY                 Optional registry path for history append
+  SKILLSBENCH_SKIP_GLOBAL_LEDGER_SYNC  Set to 1 to keep the remote run out of
+                                       the global benchmark ledger
+  SKILLSBENCH_SKIP_CURRENT_AGGREGATE_UPDATE
+                                       Set to 1 to skip the remote current
+                                       aggregate update
   SKILLSBENCH_LOCAL_RUN_LEDGER_PATH    Local private live ledger; default below
                                        the goal's skillsbench-ledgers directory
   SKILLSBENCH_LOCAL_RUN_LEDGER_SEED    Optional accepted-lane ledger copied
@@ -132,6 +137,19 @@ if [[ "$codex_cli_goal_thread_prewarm" != "0" && "$codex_cli_goal_thread_prewarm
   echo "SKILLSBENCH_CLI_GOAL_THREAD_PREWARM must be 0 or 1" >&2
   exit 2
 fi
+skip_global_ledger_sync="${SKILLSBENCH_SKIP_GLOBAL_LEDGER_SYNC:-0}"
+skip_current_aggregate_update="${SKILLSBENCH_SKIP_CURRENT_AGGREGATE_UPDATE:-0}"
+validate_bool_toggle() {
+  local env_name="$1"
+  local value="$2"
+  if [[ "$value" != "0" && "$value" != "1" ]]; then
+    echo "${env_name} must be 0 or 1" >&2
+    exit 2
+  fi
+}
+validate_bool_toggle SKILLSBENCH_SKIP_GLOBAL_LEDGER_SYNC "$skip_global_ledger_sync"
+validate_bool_toggle \
+  SKILLSBENCH_SKIP_CURRENT_AGGREGATE_UPDATE "$skip_current_aggregate_update"
 remote_codex_bin_mode="path_lookup"
 if [[ -n "${SKILLSBENCH_REMOTE_CODEX_BIN:-}" ]]; then
   remote_codex_bin_mode="explicit"
@@ -284,6 +302,12 @@ fi
 if [[ "${SKILLSBENCH_APPEND_HISTORY:-0}" == "1" ]]; then
   extra_runner_args+=(--append-history)
 fi
+if [[ "$skip_global_ledger_sync" == "1" ]]; then
+  extra_runner_args+=(--skip-global-ledger-sync)
+fi
+if [[ "$skip_current_aggregate_update" == "1" ]]; then
+  extra_runner_args+=(--skip-current-aggregate-update)
+fi
 
 run_group="skillsbench-codex-cli-goal-xhigh-${safe_task}-${tag}-${stamp}"
 job_name="${safe_task}__codex_cli_goal_xhigh_${tag}_${stamp}"
@@ -395,6 +419,8 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'remote_codex_bin_mode=%s\n' "$remote_codex_bin_mode"
   printf 'local_codex_sandbox=%s\n' "$local_codex_sandbox"
   printf 'codex_cli_goal_thread_prewarm=%s\n' "$codex_cli_goal_thread_prewarm"
+  printf 'skip_global_ledger_sync=%s\n' "$skip_global_ledger_sync"
+  printf 'skip_current_aggregate_update=%s\n' "$skip_current_aggregate_update"
   printf 'local_run_ledger=%s\n' "$local_run_ledger"
   if [[ -n "${standard_aggregate:-}" ]]; then
     printf 'standard_aggregate=%s\n' "$standard_aggregate"


### PR DESCRIPTION
## Summary\n- add opt-in launcher env toggles for remote global-ledger and current-aggregate suppression\n- validate toggle values before SSH or benchmark work\n- expose the effective no-sync state in dry-run output and cover argument forwarding\n\n## Validation\n- skillsbench-benchmark-egress-policy-smoke: ok\n- \n- \n- \n- # LoopX Contract Check

- ok: `True`
- registry: `/Users/bytedance/.codex/loopx/registry.global.json`
- runtime_root: `/Users/bytedance/.codex/loopx`
- scan_roots: `['scripts/skillsbench-launch-goal-xhigh.sh', 'examples/skillsbench-benchmark-egress-policy-smoke.py']`
- summary: errors=0, warnings=0, checks=9

## Checks
- registry goals checked: 14
- registry boundary: shared_local_registry push_allowed=False tracked=False ignored=False
- user-gate scopes checked: 7 open multi-agent gates
- runtime root resolved: /Users/bytedance/.codex/loopx
- run-history goals=33 runs=13796
- loopx-meta: reward overlay rows raw=10425 unique=10421 overlays=1
- loopx-meta: structured artifact bundle rows raw=10425 unique=10421 bundles=3
- openviking-goal: reward overlay rows raw=539 unique=536 overlays=3
- public boundary scan clean: 2 files\n- # Pre-Merge Validation Gate

- status: `manual_review_required`
- ok: `false`
- merge_gate_passed: `false`
- self_merge_allowed: `false`
- tier: `standard`
- dry_run: `false`
- changed_files: `2`
- surfaces: `public_boundary, benchmark_sensitive, python`
- risk_profiles: ``
- manual_holds: `1`

Pre-merge validation is a risk-based gate: it runs diff hygiene, changed Python compile checks, catalog-selected canaries, risk-profile smokes, and public/private boundary checks. It reports manual holds for benchmark-sensitive or reviewer-gated surfaces instead of treating local smoke success as self-merge permission.

## Direct Checks
- `diff_check_committed`: `passed` `git diff --check origin/main...HEAD`
- `diff_check_staged`: `passed` `git diff --cached --check`
- `diff_check_unstaged`: `passed` `git diff --check`
- `changed_python_py_compile`: `passed` `python3 -m py_compile examples/skillsbench-benchmark-egress-policy-smoke.py`

## Catalog Canaries
- ok: `true`
- selected_checks: `6`
- executed_checks: `6`
- failures: `0`
- advisory_failures: `0`
- warnings: `0`
- `passed` python3 examples/control_plane/repo-python-line-budget-smoke.py
- `passed` python3 examples/terminal-bench-adapter-readiness-characterization-smoke.py
- `passed` python3 examples/benchmark-core-adapter-contract-smoke.py
- `passed` python3 examples/benchmark-artifact-path-filter-smoke.py
- `passed` python3 examples/benchmark-run-ledger-smoke.py
- `passed` python3 examples/benchmark-case-analysis-smoke.py

## Public Boundary
- ok: `true`
- selected_checks: `1`
- executed_checks: `1`
- failures: `0`
- advisory_failures: `0`
- warnings: `0`
- `passed` loopx check --scan-path examples/skillsbench-benchmark-egress-policy-smoke.py --scan-path scripts/skillsbench-launch-goal-xhigh.sh

## Manual Holds
- `benchmark_sensitive`: benchmark adapter, scoring, runner, or evidence paths require explicit maintainer review before self-merge: 3 direct checks, compile, 6 selected canaries, and public boundary passed; generic benchmark-sensitive manual hold remains\n\n## Scope\nThis only changes the public benchmark launcher workflow. Defaults are unchanged. It does not change scoring, task semantics, runner route behavior, permissions, uploads, submissions, or launch a benchmark. Local/private run artifacts and credentials are excluded.