### PR TITLE
Add stateless reward-memory candidate review seam

### DIFF
--- a/docs/reference/protocols/reward-memory-architecture-v0.md
+++ b/docs/reference/protocols/reward-memory-architecture-v0.md
@@ -10,15 +10,17 @@ actor's independently verified repository scope. The distinction is between
 inferring what the contributor wants and inventing what the contributor is
 authorized to permit.
 
-This Stage-0 contract defines five memory classes, guarded precedence, and the
+This contract defines five memory classes, guarded precedence, and the
 pilot/meta delegation boundary. Stage 1 adds the corpus registry and health
-read model. Neither stage adds a second memory store, candidate scheduler,
-provider write, cross-module recall, evaluation harness, or rollout.
+read model. Stage 2 adds one stateless candidate/review seam. These stages add
+no second memory store, candidate scheduler, provider write, cross-module
+recall, evaluation harness, or rollout.
 
 The machine-readable contract is available through:
 
 ```bash
 loopx reward-memory architecture --format json
+loopx reward-memory candidate-review --case issue-fix-verified-contributor --decision accept --format json
 ```
 
 ## Five first-class classes
@@ -140,6 +142,45 @@ retrieval health, or provider persistence. Those stay reusable core concerns.
 This keeps the issue-fix scenario valuable without letting it define the whole
 memory product.
 
+## Implemented Stage-2 seam
+
+Stage 2 accepts a model-proposed compact candidate: target class, content
+summary, source actor and evidence reference, workspace/project/surface scope,
+reasoning summary, confidence, and any requested action scopes. The model owns
+interpretation and the proposed policy meaning. Deterministic code only checks
+the public-safe shape, scope binding, raw-content boundary, source freshness,
+unresolved conflicts, current-artifact proof where required, and authority
+checkpoint.
+
+For `hard_policy`, the checkpoint must independently bind the same actor, role,
+project, and action scopes. A verified core-contributor correction can
+therefore produce an activation-ready policy candidate directly, but only for
+the subset of action scopes already present in that checkpoint. An unverified,
+mismatched, or wider request remains inspectable as `guard_blocked`; an
+attempted `accept` or `edit` becomes `no_write` instead of gaining authority.
+Advisory preference and experience candidates cannot request action authority.
+
+The review contract exposes five decisions:
+
+- `accept` emits an active record;
+- `edit` emits a revised candidate linked to the prior candidate;
+- `reject` closes the candidate as rejected;
+- `retire` closes an already active reviewed record;
+- `no_write` records that no provider write should occur.
+
+These are decision records, not persistence operations. `accept` and `retire`
+only return a next-step instruction for the caller to use the declared corpus
+write authority and verify readback. The seam itself writes no LoopX state,
+OpenViking corpus, index, receipt, or external system. It also does not ingest
+raw chat or tool transcripts.
+
+`issue_fix_reward_memory_candidate_adapter_v0` is deliberately a field-mapping
+adapter. It maps a compact issue reference, repository revision, module-owned
+surface, contributor evidence, and model reasoning into
+`reward_memory_candidate_v0`; all guards and lifecycle decisions remain in the
+shared core. This is the first reuse proof, not an Issue Fix-specific memory
+implementation.
+
 ## OpenViking alignment
 
 The five classes are provider-neutral, but the Stage-0 boundary was checked
@@ -235,10 +276,10 @@ loopx reward-memory route-check --case pr-3237 --format json
   including ownership, authority, freshness, retirement, scope isolation, and
   retrieval-health distinctions. Its `fresh_execution_context` entry describes
   an existing LoopX capability; it is not a request for another context system.
-- Stage 2: one thin candidate and activation-decision seam over existing
-  LoopX/OpenViking evidence. It adds no second store, scheduler, automatic
-  recall, or raw-content retention. Issue Fix is the first adapter and reuses
-  the generic record/decision shape.
+- Stage 2: the implemented stateless candidate and activation-decision seam
+  over existing LoopX/OpenViking evidence. It adds no second store, scheduler,
+  automatic recall, or raw-content retention. Issue Fix is the first adapter
+  and reuses the generic record/decision shape.
 - Stage 3: opt-in cross-module recall with model reasoning inside deterministic
   scope, authority, privacy, freshness, and conflict guards, plus compact
   application receipts.

--- a/docs/reference/protocols/reward-memory-architecture-v0.zh-CN.md
+++ b/docs/reference/protocols/reward-memory-architecture-v0.zh-CN.md
@@ -7,14 +7,16 @@ Reward Memory 的核心边界是把反馈证据、策略内容和动作 authorit
 权限。经过验证的仓库 owner 或核心贡献者反馈，可以在其独立验证过的仓库作用域内推导出
 持久策略。这里需要区分的是“贡献者希望系统怎么做”和“贡献者有权允许系统做什么”。
 
-Stage 0 定义五类一等记忆、带护栏的优先级和 pilot/meta 分工；Stage 1 增加 corpus
-registry 与健康状态 read model。两个阶段都不新增第二套 memory store、候选调度器、
-provider 写入、跨模块 recall、评测框架或 rollout。
+这份合同定义五类一等记忆、带护栏的优先级和 pilot/meta 分工；Stage 1 增加 corpus
+registry 与健康状态 read model；Stage 2 增加一条无状态 candidate/review 薄缝。这些阶段
+都不新增第二套 memory store、候选调度器、provider 写入、跨模块 recall、评测框架或
+rollout。
 
 机器可读合同通过下面的命令查看：
 
 ```bash
 loopx reward-memory architecture --format json
+loopx reward-memory candidate-review --case issue-fix-verified-contributor --decision accept --format json
 ```
 
 ## 五类一等记忆
@@ -118,6 +120,38 @@ Candidate lifecycle、contributor-policy semantics、retrieval health 和 provid
 persistence 归共享 core 所有，不由 adapter 重复实现。Issue Fix 可以充分发挥场景价值，
 但不会反过来把整个 memory 产品做成 Issue Fix 特化方案。
 
+## 已实现的 Stage 2 薄缝
+
+Stage 2 接收模型提出的紧凑候选：target class、content summary、source actor 与 evidence
+reference、workspace/project/surface scope、reasoning summary、confidence，以及请求影响的
+action scopes。候选的含义、策略内容和权衡继续由模型推理；确定性代码只检查公共安全
+shape、scope binding、raw-content boundary、source freshness、未解决冲突、必要的当前
+artifact proof 和 authority checkpoint。
+
+对于 `hard_policy`，checkpoint 必须独立绑定同一个 actor、role、project 和 action
+scopes。因此，经过验证的核心贡献者 correction 可以直接形成 activation-ready policy
+candidate，但只能约束 checkpoint 已有 action scope 的子集。checkpoint 未验证、actor 或
+project 不一致、或者候选要求更大 scope 时，候选仍可检视，但状态为 `guard_blocked`；此时
+即使请求 `accept` 或 `edit`，有效决策也会收敛为 `no_write`，不会扩大 authority。
+Advisory preference 与 experience candidate 不允许请求 action authority。
+
+Review contract 暴露五个一等决策：
+
+- `accept`：产出 active record；
+- `edit`：产出带 prior-candidate lineage 的修订候选；
+- `reject`：关闭并拒绝候选；
+- `retire`：关闭一个已经 active 的 reviewed record；
+- `no_write`：明确记录本次不应写 provider。
+
+这些只是 decision record，不是 persistence 操作。`accept` 与 `retire` 只返回下一步提示：
+调用方必须使用 corpus 声明的 write authority，再完成 readback 验证。薄缝自身不写 LoopX
+state、OpenViking corpus、index、receipt 或外部系统，也不摄取 raw chat 或 tool transcript。
+
+`issue_fix_reward_memory_candidate_adapter_v0` 刻意保持为字段映射 adapter：把紧凑 issue
+reference、repository revision、模块自有 surface、contributor evidence 和模型 reasoning
+映射到 `reward_memory_candidate_v0`。所有 guard 与 lifecycle decision 仍由共享 core 所有。
+这是第一条复用证据，不是 Issue Fix 专用 memory 实现。
+
 ## 与 OpenViking 的对齐关系
 
 五类记忆保持 provider-neutral；Stage 0 的边界已经结合 OpenViking 当前公开架构和代码
@@ -199,9 +233,9 @@ loopx reward-memory route-check --case pr-3237 --format json
   [corpus registry 与 health contract](reward-memory-corpus-registry-v0.md)，覆盖 ownership、
   authority、freshness、retirement、scope isolation 和 retrieval-health 区分。其中的
   `fresh_execution_context` 描述 LoopX 已有能力，不要求建设另一套 context system。
-- Stage 2：在现有 LoopX/OpenViking evidence 之上增加一条最薄的 candidate 与
-  activation-decision seam。不新增第二套 store、scheduler、automatic recall 或 raw-content
-  retention；Issue Fix 是首个 adapter，复用通用 record/decision shape。
+- Stage 2：已实现的无状态 candidate 与 activation-decision seam，建立在现有
+  LoopX/OpenViking evidence 之上。不新增第二套 store、scheduler、automatic recall 或
+  raw-content retention；Issue Fix 是首个 adapter，复用通用 record/decision shape。
 - Stage 3：opt-in cross-module recall。模型在确定性的 scope、authority、privacy、
   freshness 和 conflict guard 内推理，并生成紧凑 application receipt。
 - Stage 4：evaluation harness 与 release gate。

--- a/examples/reward-memory-architecture-smoke.py
+++ b/examples/reward-memory-architecture-smoke.py
@@ -99,6 +99,16 @@ def main() -> int:
         ]
         is False
     )
+    candidate_review = architecture["existing_capability_reuse"]["candidate_review"]
+    assert candidate_review["status"] == "implemented_stateless_stage_2_seam"
+    assert candidate_review["review_decisions"] == [
+        "accept",
+        "edit",
+        "reject",
+        "retire",
+        "no_write",
+    ]
+    assert candidate_review["provider_write_performed_by_seam"] is False
     openviking = architecture["provider_alignment"]["openviking"]
     assert openviking["content_source_of_truth"] == "agfs_content"
     assert openviking["non_instruction_artifacts"]["openviking_cases"] == (

--- a/examples/reward-memory-candidate-review-smoke.py
+++ b/examples/reward-memory-candidate-review-smoke.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Smoke-test the stateless Stage-2 candidate and review seam."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.reward_memory import (  # noqa: E402
+    build_reward_memory_candidate,
+    issue_fix_verified_contributor_candidate_fixture,
+    review_reward_memory_candidate,
+)
+
+
+def run_cli(*args: str) -> dict[str, object]:
+    completed = subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--format", "json", *args],
+        cwd=REPO_ROOT,
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    return json.loads(completed.stdout)
+
+
+def review(decision: str, **extra: str) -> dict[str, str]:
+    return {
+        "decision": decision,
+        "reviewer_ref": "github:user:maintainer",
+        "review_ref": f"review:smoke:{decision}",
+        "reasoning_summary": "The scoped candidate was reviewed.",
+        **extra,
+    }
+
+
+def expect_value_error(callable_) -> None:
+    try:
+        callable_()
+    except ValueError:
+        return
+    raise AssertionError("expected a ValueError")
+
+
+def main() -> int:
+    adapter = issue_fix_verified_contributor_candidate_fixture()
+    assert adapter["schema_version"] == ("issue_fix_reward_memory_candidate_adapter_v0")
+    assert adapter["adapter_role"] == (
+        "field_mapping_only_shared_core_owns_semantics_and_lifecycle"
+    )
+    assert adapter["fresh_execution_context_source"] == ("existing_loopx_control_plane")
+    candidate = adapter["shared_candidate"]
+    assert candidate["schema_version"] == "reward_memory_candidate_v0"
+    assert candidate["status"] == "review_ready"
+    assert candidate["guard"]["passed"] is True
+    assert candidate["guard"]["semantic_reasoning_preserved"] is True
+    assert candidate["candidate"]["target_class"] == "hard_policy"
+    assert candidate["candidate"]["requested_action_scopes"] == [
+        "issue_fix:scope_selection"
+    ]
+    assert candidate["candidate"]["guard_context"] == {
+        "source_freshness": "current",
+        "conflict_state": "clear",
+        "current_artifact_verified": True,
+    }
+    assert candidate["authority_checkpoint"]["action_scopes"] == [
+        "issue_fix:scope_selection"
+    ]
+    assert candidate["candidate_persisted"] is False
+    assert candidate["provider_write_performed"] is False
+
+    accepted = review_reward_memory_candidate(candidate, review("accept"))
+    assert accepted["effective_decision"] == "accept"
+    assert accepted["status"] == "active"
+    assert accepted["record"]["lifecycle"]["state"] == "active"
+    assert accepted["grants_new_action_authority"] is False
+    assert accepted["persistence_next_step"] == (
+        "caller_uses_declared_corpus_write_authority_then_readback"
+    )
+    assert accepted["provider_write_performed"] is False
+
+    retired = review_reward_memory_candidate(accepted, review("retire"))
+    assert retired["status"] == "retired"
+    assert retired["record"]["lifecycle"]["state"] == "retired"
+
+    edited = review_reward_memory_candidate(
+        candidate,
+        review(
+            "edit",
+            edited_content_summary=(
+                "Keep focused fixes within the affected module unless current "
+                "evidence requires a broader surface."
+            ),
+        ),
+    )
+    assert edited["status"] == "review_ready"
+    assert (
+        edited["record"]["candidate_ref"] != (candidate["candidate"]["candidate_ref"])
+    )
+    assert edited["record"]["lifecycle"]["supersedes_refs"] == [
+        candidate["candidate"]["candidate_ref"]
+    ]
+    accepted_edit = review_reward_memory_candidate(edited, review("accept"))
+    assert accepted_edit["record"]["lifecycle"]["supersedes_refs"] == [
+        candidate["candidate"]["candidate_ref"]
+    ]
+
+    rejected = review_reward_memory_candidate(candidate, review("reject"))
+    assert rejected["status"] == "rejected"
+    no_write = review_reward_memory_candidate(candidate, review("no_write"))
+    assert no_write["status"] == "no_write"
+    assert no_write["persistence_next_step"] == "none"
+
+    unverified = deepcopy(candidate)
+    unverified["authority_checkpoint"]["verified"] = False
+    unverified["authority_checkpoint"]["source_ref"] = None
+    proposal = deepcopy(unverified["candidate"])
+    proposal.pop("schema_version")
+    proposal.pop("candidate_ref")
+    proposal.pop("lifecycle")
+    proposal.pop("privacy")
+    proposal["raw_content_captured"] = False
+    blocked = build_reward_memory_candidate(
+        proposal,
+        authority_checkpoint=unverified["authority_checkpoint"],
+    )
+    assert blocked["status"] == "guard_blocked"
+    blocked_review = review_reward_memory_candidate(blocked, review("accept"))
+    assert blocked_review["requested_decision"] == "accept"
+    assert blocked_review["effective_decision"] == "no_write"
+    assert blocked_review["status"] == "guard_blocked"
+    assert blocked_review["persistence_next_step"] == "none"
+    blocked_retry = review_reward_memory_candidate(blocked_review, review("accept"))
+    assert blocked_retry["effective_decision"] == "no_write"
+    assert blocked_retry["guard_passed"] is False
+
+    widened = deepcopy(proposal)
+    widened["requested_action_scopes"] = [
+        "issue_fix:scope_selection",
+        "repository:publish",
+    ]
+    widened_packet = build_reward_memory_candidate(
+        widened,
+        authority_checkpoint=candidate["authority_checkpoint"],
+    )
+    assert (
+        "requested_action_scope_exceeds_verified_authority"
+        in (widened_packet["guard"]["reason_codes"])
+    )
+
+    conflicted = deepcopy(proposal)
+    conflicted["guard_context"]["conflict_state"] = "unresolved"
+    conflicted_packet = build_reward_memory_candidate(
+        conflicted,
+        authority_checkpoint=candidate["authority_checkpoint"],
+    )
+    assert (
+        "unresolved_higher_authority_conflict"
+        in conflicted_packet["guard"]["reason_codes"]
+    )
+
+    advisory = deepcopy(proposal)
+    advisory["target_class"] = "soft_preference"
+    advisory_packet = build_reward_memory_candidate(advisory)
+    assert advisory_packet["status"] == "guard_blocked"
+    assert (
+        "advisory_class_requested_action_authority"
+        in (advisory_packet["guard"]["reason_codes"])
+    )
+
+    raw = deepcopy(proposal)
+    raw["raw_content_captured"] = True
+    expect_value_error(lambda: build_reward_memory_candidate(raw))
+    expect_value_error(
+        lambda: review_reward_memory_candidate(candidate, review("retire"))
+    )
+
+    cli_accept = run_cli(
+        "reward-memory",
+        "candidate-review",
+        "--case",
+        "issue-fix-verified-contributor",
+        "--decision",
+        "accept",
+    )
+    assert cli_accept["status"] == "active"
+    assert cli_accept["adapter"]["shared_candidate"]["status"] == "review_ready"
+    cli_retire = run_cli(
+        "reward-memory",
+        "candidate-review",
+        "--decision",
+        "retire",
+    )
+    assert cli_retire["status"] == "retired"
+    assert cli_retire["external_writes_performed"] is False
+
+    assert adapter["provider_write_performed"] is False
+    assert adapter["external_writes_performed"] is False
+    assert adapter["raw_content_captured"] is False
+    print("reward-memory-candidate-review-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -287,7 +287,7 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
     },
     {
         "id": "reward-memory",
-        "title": "Reward-memory architecture, corpus health, and routing",
+        "title": "Reward-memory architecture, corpus health, and candidate review",
         "status": "foundation",
         "real_world_anchor": (
             "typed feedback memory, provider-owned corpus health, and pilot/meta delegation"
@@ -319,6 +319,11 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "purpose": "Exercise deterministic project, surface, freshness, index, retrieval, readback, and application health states.",
                 "write_boundary": "public fixture classification only; no memory, index, receipt, state, or external write",
             },
+            {
+                "command": "loopx reward-memory candidate-review --case issue-fix-verified-contributor --decision accept --format json",
+                "purpose": "Exercise the Stage-2 shared candidate/review seam through the mapping-only Issue Fix adapter.",
+                "write_boundary": "stateless decision output only; persistence stays with the declared corpus owner and this command performs no provider or external write",
+            },
         ],
         "implemented_protocols": [
             {
@@ -341,10 +346,26 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "module": "loopx.capabilities.reward_memory.health",
                 "doc": "docs/reference/protocols/reward-memory-corpus-registry-v0.md",
             },
+            {
+                "schema_version": "reward_memory_candidate_v0",
+                "module": "loopx.capabilities.reward_memory.candidate_review",
+                "doc": "docs/reference/protocols/reward-memory-architecture-v0.md",
+            },
+            {
+                "schema_version": "reward_memory_candidate_review_v0",
+                "module": "loopx.capabilities.reward_memory.candidate_review",
+                "doc": "docs/reference/protocols/reward-memory-architecture-v0.md",
+            },
+            {
+                "schema_version": "issue_fix_reward_memory_candidate_adapter_v0",
+                "module": "loopx.capabilities.reward_memory.candidate_review",
+                "doc": "docs/reference/protocols/reward-memory-architecture-v0.md",
+            },
         ],
         "smokes": [
             "python3 examples/reward-memory-architecture-smoke.py",
             "python3 examples/reward-memory-corpus-registry-smoke.py",
+            "python3 examples/reward-memory-candidate-review-smoke.py",
         ],
         "docs": [
             "docs/reference/protocols/reward-memory-architecture-v0.md",
@@ -360,11 +381,13 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
             "Corpus presence, index presence, retrieval success, readback, and applied receipts are distinct health states.",
             "Project or surface mismatch fails closed before provider availability can influence application.",
             "Stages 0-1 write no corpus, candidate, provider memory, evaluation result, or external artifact.",
+            "Stage 2 returns inspectable candidate/review decisions only; accept or retire still requires the caller to use the corpus owner's declared write authority and verify readback.",
+            "The Issue Fix Stage-2 adapter maps compact domain evidence into the shared core and owns no parallel lifecycle, store, scheduler, or recall path.",
         ],
         "next_real_step": (
-            "Implement one thin Stage-2 candidate and activation-decision seam over "
-            "existing LoopX/OpenViking evidence, with Issue Fix as the first adapter; "
-            "do not add a second store, scheduler, or automatic recall."
+            "Add opt-in Stage-3 recall and reasoning-mediated application over the "
+            "same candidate/review core; preserve provider ownership and do not add "
+            "a second store, scheduler, or automatic cross-module recall."
         ),
     },
     {

--- a/loopx/capabilities/reward_memory/__init__.py
+++ b/loopx/capabilities/reward_memory/__init__.py
@@ -5,6 +5,12 @@ from .architecture import (
     build_reward_memory_route_packet,
     pr_3237_regression_observation,
 )
+from .candidate_review import (
+    build_issue_fix_reward_memory_candidate,
+    build_reward_memory_candidate,
+    issue_fix_verified_contributor_candidate_fixture,
+    review_reward_memory_candidate,
+)
 from .health import (
     build_reward_memory_corpus_health_packet,
     reward_memory_health_case,
@@ -17,11 +23,15 @@ from .registry import (
 
 __all__ = [
     "build_reward_memory_architecture_packet",
+    "build_issue_fix_reward_memory_candidate",
+    "build_reward_memory_candidate",
     "build_reward_memory_corpus_health_packet",
     "build_reward_memory_corpus_registry_packet",
     "build_reward_memory_route_packet",
     "normalize_reward_memory_corpus",
+    "issue_fix_verified_contributor_candidate_fixture",
     "pr_3237_regression_observation",
     "reward_memory_health_case",
+    "review_reward_memory_candidate",
     "semantic_preference_inventory_to_reward_corpora",
 ]

--- a/loopx/capabilities/reward_memory/architecture.py
+++ b/loopx/capabilities/reward_memory/architecture.py
@@ -358,6 +358,20 @@ def build_reward_memory_architecture_packet() -> dict[str, Any]:
                 "role": "provider_storage_index_retrieval_and_session_memory",
                 "reuse_before_new_infrastructure": True,
             },
+            "candidate_review": {
+                "status": "implemented_stateless_stage_2_seam",
+                "candidate_schema": "reward_memory_candidate_v0",
+                "review_schema": "reward_memory_candidate_review_v0",
+                "review_decisions": [
+                    "accept",
+                    "edit",
+                    "reject",
+                    "retire",
+                    "no_write",
+                ],
+                "persistence_owner": "declared_corpus_write_authority",
+                "provider_write_performed_by_seam": False,
+            },
         },
         "provider_alignment": {"openviking": _openviking_alignment()},
         "pilot_meta_delegation": {
@@ -392,7 +406,8 @@ def build_reward_memory_architecture_packet() -> dict[str, Any]:
             "stage_0": "classification_precedence_and_delegation_only",
             "stage_1": "corpus_registry_ownership_and_retrieval_health",
             "stage_2": (
-                "thin_candidate_and_review_seam_no_second_store_scheduler_or_recall"
+                "implemented_thin_candidate_and_review_seam_no_second_store_"
+                "scheduler_or_recall"
             ),
             "stage_3": "reasoning_mediated_cross_module_recall_and_application",
             "stage_4": "evaluation_harness_and_release_gate",

--- a/loopx/capabilities/reward_memory/candidate_review.py
+++ b/loopx/capabilities/reward_memory/candidate_review.py
@@ -1,0 +1,480 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from ...control_plane.runtime.public_safety import public_safe_compact_text
+
+
+REWARD_MEMORY_CANDIDATE_SCHEMA_VERSION = "reward_memory_candidate_v0"
+REWARD_MEMORY_REVIEW_SCHEMA_VERSION = "reward_memory_candidate_review_v0"
+ISSUE_FIX_REWARD_MEMORY_ADAPTER_SCHEMA_VERSION = (
+    "issue_fix_reward_memory_candidate_adapter_v0"
+)
+
+TARGET_CLASS_IDS = {
+    "hard_policy",
+    "soft_preference",
+    "procedural_experience",
+}
+REVIEW_DECISIONS = {"accept", "edit", "reject", "retire", "no_write"}
+CONFIDENCE_LEVELS = {"low", "medium", "high"}
+SOURCE_FRESHNESS_STATES = {"current", "stale", "unknown"}
+CONFLICT_STATES = {"clear", "unresolved"}
+ELIGIBLE_POLICY_ACTOR_ROLES = {
+    "verified_repository_core_contributor",
+    "verified_project_owner_or_operator",
+}
+TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/#-]{0,199}$")
+SURFACE_RE = re.compile(r"^[a-z][a-z0-9_-]*(?:\.[a-z][a-z0-9_-]*)+$")
+MAX_SURFACES = 12
+MAX_ACTION_SCOPES = 12
+
+
+def _token(value: object, label: str) -> str:
+    result = str(value or "").strip()
+    if not TOKEN_RE.fullmatch(result):
+        raise ValueError(f"{label} must be a compact public-safe token")
+    return result
+
+
+def _optional_token(value: object, label: str) -> str | None:
+    if value in (None, ""):
+        return None
+    return _token(value, label)
+
+
+def _compact(value: object, label: str, *, limit: int) -> str:
+    result = public_safe_compact_text(value, limit=limit)
+    if not result:
+        raise ValueError(f"{label} must be compact and public-safe")
+    return result
+
+
+def _boolean(mapping: Mapping[str, Any], key: str) -> bool:
+    value = mapping.get(key)
+    if not isinstance(value, bool):
+        raise ValueError(f"{key} must be a boolean")
+    return value
+
+
+def _tokens(value: object, label: str, *, maximum: int) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise ValueError(f"{label} must be a bounded token list")
+    if len(value) > maximum:
+        raise ValueError(f"{label} must contain at most {maximum} items")
+    result = sorted({_token(item, label) for item in value})
+    if len(result) != len(value):
+        raise ValueError(f"{label} must not contain duplicates")
+    return result
+
+
+def _scope(raw: object) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise ValueError("scope must be an object")
+    surfaces = _tokens(
+        raw.get("surface_ids") or [],
+        "scope.surface_ids",
+        maximum=MAX_SURFACES,
+    )
+    if not surfaces or any(not SURFACE_RE.fullmatch(item) for item in surfaces):
+        raise ValueError("scope.surface_ids must contain module-qualified tokens")
+    return {
+        "workspace_ref": _token(raw.get("workspace_ref"), "scope.workspace_ref"),
+        "project_ref": _token(raw.get("project_ref"), "scope.project_ref"),
+        "surface_ids": surfaces,
+        "revision_ref": _optional_token(raw.get("revision_ref"), "scope.revision_ref"),
+    }
+
+
+def _source(raw: object) -> dict[str, str]:
+    if not isinstance(raw, Mapping):
+        raise ValueError("source must be an object")
+    return {
+        "source_kind": _token(raw.get("source_kind"), "source.source_kind"),
+        "source_ref": _compact(raw.get("source_ref"), "source.source_ref", limit=240),
+        "actor_ref": _token(raw.get("actor_ref"), "source.actor_ref"),
+        "actor_role": _token(raw.get("actor_role"), "source.actor_role"),
+    }
+
+
+def _reasoning(raw: object) -> dict[str, str]:
+    if not isinstance(raw, Mapping):
+        raise ValueError("reasoning must be an object")
+    confidence = str(raw.get("confidence") or "").strip()
+    if confidence not in CONFIDENCE_LEVELS:
+        raise ValueError("reasoning.confidence must be low, medium, or high")
+    return {
+        "summary": _compact(raw.get("summary"), "reasoning.summary", limit=500),
+        "confidence": confidence,
+    }
+
+
+def _guard_context(raw: object) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise ValueError("guard_context must be an object")
+    source_freshness = str(raw.get("source_freshness") or "").strip()
+    conflict_state = str(raw.get("conflict_state") or "").strip()
+    if source_freshness not in SOURCE_FRESHNESS_STATES:
+        raise ValueError("guard_context.source_freshness is invalid")
+    if conflict_state not in CONFLICT_STATES:
+        raise ValueError("guard_context.conflict_state is invalid")
+    return {
+        "source_freshness": source_freshness,
+        "conflict_state": conflict_state,
+        "current_artifact_verified": _boolean(raw, "current_artifact_verified"),
+    }
+
+
+def _authority_checkpoint(raw: object) -> dict[str, Any]:
+    if raw is None:
+        return {
+            "verified": False,
+            "source_ref": None,
+            "actor_ref": None,
+            "actor_role": None,
+            "project_ref": None,
+            "action_scopes": [],
+        }
+    if not isinstance(raw, Mapping):
+        raise ValueError("authority_checkpoint must be an object")
+    verified = _boolean(raw, "verified")
+    return {
+        "verified": verified,
+        "source_ref": _optional_token(
+            raw.get("source_ref"), "authority_checkpoint.source_ref"
+        ),
+        "actor_ref": _optional_token(
+            raw.get("actor_ref"), "authority_checkpoint.actor_ref"
+        ),
+        "actor_role": _optional_token(
+            raw.get("actor_role"), "authority_checkpoint.actor_role"
+        ),
+        "project_ref": _optional_token(
+            raw.get("project_ref"), "authority_checkpoint.project_ref"
+        ),
+        "action_scopes": _tokens(
+            raw.get("action_scopes") or [],
+            "authority_checkpoint.action_scopes",
+            maximum=MAX_ACTION_SCOPES,
+        ),
+    }
+
+
+def _candidate_ref(candidate: Mapping[str, Any]) -> str:
+    identity = {
+        key: candidate[key]
+        for key in (
+            "target_class",
+            "content_summary",
+            "source",
+            "scope",
+            "guard_context",
+            "requested_action_scopes",
+        )
+    }
+    digest = hashlib.sha256(
+        json.dumps(identity, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    ).hexdigest()[:20]
+    return f"candidate:{digest}"
+
+
+def _guard(
+    candidate: Mapping[str, Any], checkpoint: Mapping[str, Any]
+) -> dict[str, Any]:
+    reasons: list[str] = []
+    requested = set(candidate["requested_action_scopes"])
+    target_class = candidate["target_class"]
+    guard_context = candidate["guard_context"]
+    if guard_context["source_freshness"] != "current":
+        reasons.append("source_freshness_not_current")
+    if guard_context["conflict_state"] != "clear":
+        reasons.append("unresolved_higher_authority_conflict")
+    if (
+        target_class == "procedural_experience"
+        and guard_context["current_artifact_verified"] is not True
+    ):
+        reasons.append("procedural_experience_current_artifact_unverified")
+    if target_class != "hard_policy" and requested:
+        reasons.append("advisory_class_requested_action_authority")
+    if target_class == "hard_policy":
+        source = candidate["source"]
+        scope = candidate["scope"]
+        verified_scopes = set(checkpoint["action_scopes"])
+        if not requested:
+            reasons.append("hard_policy_missing_action_scope")
+        if checkpoint["verified"] is not True or not checkpoint["source_ref"]:
+            reasons.append("authority_checkpoint_unverified")
+        if checkpoint["actor_ref"] != source["actor_ref"]:
+            reasons.append("authority_actor_mismatch")
+        if checkpoint["actor_role"] != source["actor_role"]:
+            reasons.append("authority_actor_role_mismatch")
+        if source["actor_role"] not in ELIGIBLE_POLICY_ACTOR_ROLES:
+            reasons.append("actor_role_cannot_derive_hard_policy")
+        if checkpoint["project_ref"] != scope["project_ref"]:
+            reasons.append("authority_project_mismatch")
+        if requested - verified_scopes:
+            reasons.append("requested_action_scope_exceeds_verified_authority")
+    return {
+        "passed": not reasons,
+        "reason_codes": reasons,
+        "rule": (
+            "model_proposes_meaning_deterministic_guards_verify_scope_privacy_"
+            "and_no_authority_expansion"
+        ),
+        "semantic_reasoning_preserved": True,
+    }
+
+
+def build_reward_memory_candidate(
+    proposal: Mapping[str, Any],
+    *,
+    authority_checkpoint: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build one inspectable candidate without persisting memory or raw evidence."""
+
+    if _boolean(proposal, "raw_content_captured"):
+        raise ValueError("reward-memory candidates must not capture raw content")
+    target_class = str(proposal.get("target_class") or "").strip()
+    if target_class not in TARGET_CLASS_IDS:
+        raise ValueError("target_class must be a durable reusable memory class")
+    candidate: dict[str, Any] = {
+        "schema_version": REWARD_MEMORY_CANDIDATE_SCHEMA_VERSION,
+        "target_class": target_class,
+        "content_summary": _compact(
+            proposal.get("content_summary"), "content_summary", limit=500
+        ),
+        "source": _source(proposal.get("source")),
+        "scope": _scope(proposal.get("scope")),
+        "reasoning": _reasoning(proposal.get("reasoning")),
+        "guard_context": _guard_context(proposal.get("guard_context")),
+        "requested_action_scopes": _tokens(
+            proposal.get("requested_action_scopes") or [],
+            "requested_action_scopes",
+            maximum=MAX_ACTION_SCOPES,
+        ),
+        "lifecycle": {"state": "candidate", "supersedes_refs": []},
+        "privacy": {"raw_content_captured": False},
+    }
+    candidate["candidate_ref"] = _candidate_ref(candidate)
+    checkpoint = _authority_checkpoint(authority_checkpoint)
+    guard = _guard(candidate, checkpoint)
+    return {
+        "ok": True,
+        "schema_version": REWARD_MEMORY_CANDIDATE_SCHEMA_VERSION,
+        "status": "review_ready" if guard["passed"] else "guard_blocked",
+        "candidate": candidate,
+        "authority_checkpoint": checkpoint,
+        "guard": guard,
+        "available_review_decisions": sorted(REVIEW_DECISIONS),
+        "candidate_persisted": False,
+        "provider_write_performed": False,
+        "external_writes_performed": False,
+        "raw_content_captured": False,
+    }
+
+
+def _target(candidate_or_review: Mapping[str, Any]) -> tuple[dict[str, Any], bool]:
+    schema = candidate_or_review.get("schema_version")
+    if schema == REWARD_MEMORY_CANDIDATE_SCHEMA_VERSION:
+        candidate = candidate_or_review.get("candidate")
+        guard = candidate_or_review.get("guard")
+        if not isinstance(candidate, Mapping) or not isinstance(guard, Mapping):
+            raise ValueError("candidate packet is incomplete")
+        return dict(candidate), guard.get("passed") is True
+    if schema == REWARD_MEMORY_REVIEW_SCHEMA_VERSION:
+        record = candidate_or_review.get("record")
+        if not isinstance(record, Mapping):
+            raise ValueError("review packet does not contain a record")
+        return dict(record), candidate_or_review.get("guard_passed") is True
+    raise ValueError("review target must be a candidate or review packet")
+
+
+def review_reward_memory_candidate(
+    candidate_or_review: Mapping[str, Any],
+    review: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Apply one review decision while leaving persistence to the corpus owner."""
+
+    record, guard_passed = _target(candidate_or_review)
+    decision = str(review.get("decision") or "").strip()
+    if decision not in REVIEW_DECISIONS:
+        raise ValueError("decision must be accept, edit, reject, retire, or no_write")
+    reviewer_ref = _token(review.get("reviewer_ref"), "review.reviewer_ref")
+    review_ref = _token(review.get("review_ref"), "review.review_ref")
+    reasoning_summary = _compact(
+        review.get("reasoning_summary"), "review.reasoning_summary", limit=500
+    )
+    lifecycle = record.get("lifecycle")
+    state = lifecycle.get("state") if isinstance(lifecycle, Mapping) else None
+    supersedes_refs = (
+        list(lifecycle.get("supersedes_refs") or [])
+        if isinstance(lifecycle, Mapping)
+        else []
+    )
+    if decision == "retire" and state != "active":
+        raise ValueError("retire requires an active reviewed record")
+    if decision != "retire" and state != "candidate":
+        raise ValueError("accept, edit, reject, and no_write require a candidate")
+
+    effective_decision = decision
+    status = "reviewed"
+    if not guard_passed and decision in {"accept", "edit"}:
+        effective_decision = "no_write"
+        status = "guard_blocked"
+    elif decision == "accept":
+        record["lifecycle"] = {
+            "state": "active",
+            "supersedes_refs": supersedes_refs,
+        }
+        status = "active"
+    elif decision == "edit":
+        old_ref = str(record.get("candidate_ref") or "")
+        record["content_summary"] = _compact(
+            review.get("edited_content_summary"),
+            "review.edited_content_summary",
+            limit=500,
+        )
+        record["candidate_ref"] = _candidate_ref(record)
+        record["lifecycle"] = {
+            "state": "candidate",
+            "supersedes_refs": [old_ref],
+        }
+        status = "review_ready"
+    elif decision == "reject":
+        record["lifecycle"] = {
+            "state": "retired",
+            "supersedes_refs": supersedes_refs,
+            "retired_reason": "rejected_in_review",
+        }
+        status = "rejected"
+    elif decision == "retire":
+        record["lifecycle"] = {
+            "state": "retired",
+            "supersedes_refs": supersedes_refs,
+            "retired_reason": "reviewed_retirement",
+        }
+        status = "retired"
+    else:
+        record["lifecycle"] = {
+            "state": "retired",
+            "supersedes_refs": supersedes_refs,
+            "retired_reason": "no_write_rationale",
+        }
+        status = "no_write" if status != "guard_blocked" else status
+
+    persistence_needed = effective_decision in {"accept", "retire"}
+    return {
+        "ok": True,
+        "schema_version": REWARD_MEMORY_REVIEW_SCHEMA_VERSION,
+        "status": status,
+        "requested_decision": decision,
+        "effective_decision": effective_decision,
+        "guard_passed": guard_passed,
+        "review": {
+            "reviewer_ref": reviewer_ref,
+            "review_ref": review_ref,
+            "reasoning_summary": reasoning_summary,
+        },
+        "record": record,
+        "persistence_next_step": (
+            "caller_uses_declared_corpus_write_authority_then_readback"
+            if persistence_needed
+            else "none"
+        ),
+        "grants_new_action_authority": False,
+        "provider_write_performed": False,
+        "external_writes_performed": False,
+        "raw_content_captured": False,
+    }
+
+
+def build_issue_fix_reward_memory_candidate(
+    event: Mapping[str, Any],
+    *,
+    authority_checkpoint: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Map compact Issue Fix evidence into the shared candidate contract."""
+
+    issue_ref = _compact(event.get("issue_ref"), "issue_ref", limit=160)
+    proposal = {
+        "target_class": event.get("target_class"),
+        "content_summary": event.get("content_summary"),
+        "source": event.get("source"),
+        "scope": {
+            "workspace_ref": event.get("workspace_ref"),
+            "project_ref": event.get("repository_ref"),
+            "surface_ids": [event.get("surface_id")],
+            "revision_ref": event.get("revision_ref"),
+        },
+        "reasoning": event.get("reasoning"),
+        "guard_context": event.get("guard_context"),
+        "requested_action_scopes": event.get("requested_action_scopes") or [],
+        "raw_content_captured": event.get("raw_content_captured"),
+    }
+    candidate = build_reward_memory_candidate(
+        proposal,
+        authority_checkpoint=authority_checkpoint,
+    )
+    return {
+        "ok": True,
+        "schema_version": ISSUE_FIX_REWARD_MEMORY_ADAPTER_SCHEMA_VERSION,
+        "issue_ref": issue_ref,
+        "surface_id": candidate["candidate"]["scope"]["surface_ids"][0],
+        "shared_candidate": candidate,
+        "adapter_role": "field_mapping_only_shared_core_owns_semantics_and_lifecycle",
+        "fresh_execution_context_source": "existing_loopx_control_plane",
+        "provider_write_performed": False,
+        "external_writes_performed": False,
+        "raw_content_captured": False,
+    }
+
+
+def issue_fix_verified_contributor_candidate_fixture() -> dict[str, Any]:
+    """Return one public Issue Fix adapter fixture for CLI and smoke coverage."""
+
+    return build_issue_fix_reward_memory_candidate(
+        {
+            "issue_ref": "github:example/repository#42",
+            "workspace_ref": "workspace:example",
+            "repository_ref": "repository:example",
+            "surface_id": "issue_fix.patch_planning",
+            "revision_ref": "revision:abc123",
+            "target_class": "hard_policy",
+            "content_summary": (
+                "Keep focused fixes within the affected module unless broader "
+                "evidence is present."
+            ),
+            "source": {
+                "source_kind": "maintainer_correction",
+                "source_ref": "github:example/repository#42:comment:1",
+                "actor_ref": "github:user:maintainer",
+                "actor_role": "verified_repository_core_contributor",
+            },
+            "reasoning": {
+                "summary": (
+                    "The correction consistently constrains issue-fix scope; "
+                    "it does not grant repository write authority."
+                ),
+                "confidence": "high",
+            },
+            "guard_context": {
+                "source_freshness": "current",
+                "conflict_state": "clear",
+                "current_artifact_verified": True,
+            },
+            "requested_action_scopes": ["issue_fix:scope_selection"],
+            "raw_content_captured": False,
+        },
+        authority_checkpoint={
+            "verified": True,
+            "source_ref": "repository:authority-map",
+            "actor_ref": "github:user:maintainer",
+            "actor_role": "verified_repository_core_contributor",
+            "project_ref": "repository:example",
+            "action_scopes": ["issue_fix:scope_selection"],
+        },
+    )

--- a/loopx/capabilities/reward_memory/cli.py
+++ b/loopx/capabilities/reward_memory/cli.py
@@ -8,6 +8,10 @@ from .architecture import (
     build_reward_memory_route_packet,
     pr_3237_regression_observation,
 )
+from .candidate_review import (
+    issue_fix_verified_contributor_candidate_fixture,
+    review_reward_memory_candidate,
+)
 from .health import (
     build_reward_memory_corpus_health_packet,
     reward_memory_health_case,
@@ -17,7 +21,13 @@ from .registry import build_reward_memory_corpus_registry_packet
 
 def _render(payload: dict[str, object]) -> str:
     lines = ["# Reward Memory", ""]
-    for key in ("status", "decision", "health_state", "case_ref"):
+    for key in (
+        "status",
+        "decision",
+        "effective_decision",
+        "health_state",
+        "case_ref",
+    ):
         if key in payload:
             lines.append(f"- {key}: `{payload[key]}`")
     classes = payload.get("memory_classes")
@@ -75,6 +85,24 @@ def register_reward_memory_commands(
         help="Use a compact public health fixture.",
     )
 
+    candidate = sub.add_parser(
+        "candidate-review",
+        help="Exercise the stateless Stage-2 candidate and review seam.",
+    )
+    add_subcommand_format(candidate)
+    candidate.add_argument(
+        "--case",
+        choices=["issue-fix-verified-contributor"],
+        default="issue-fix-verified-contributor",
+        help="Use a compact public Issue Fix adapter fixture.",
+    )
+    candidate.add_argument(
+        "--decision",
+        choices=["accept", "edit", "reject", "retire", "no_write"],
+        default="accept",
+        help="Apply one review decision without persisting provider state.",
+    )
+
     route = sub.add_parser(
         "route-check",
         help="Route a compact issue-fix observation to pilot, meta, or evidence hold.",
@@ -125,6 +153,31 @@ def handle_reward_memory_command(
         elif args.reward_memory_command == "health-check":
             corpus, observation = reward_memory_health_case(args.case)
             payload = build_reward_memory_corpus_health_packet(corpus, observation)
+        elif args.reward_memory_command == "candidate-review":
+            adapter = issue_fix_verified_contributor_candidate_fixture()
+            candidate = adapter["shared_candidate"]
+            review = {
+                "decision": args.decision,
+                "reviewer_ref": "github:user:maintainer",
+                "review_ref": f"review:fixture:{args.decision}",
+                "reasoning_summary": "The compact evidence and scope were reviewed.",
+            }
+            if args.decision == "edit":
+                review["edited_content_summary"] = (
+                    "Keep focused fixes within the affected module unless "
+                    "current evidence requires a broader surface."
+                )
+            if args.decision == "retire":
+                candidate = review_reward_memory_candidate(
+                    candidate,
+                    review
+                    | {
+                        "decision": "accept",
+                        "review_ref": "review:fixture:accept-before-retire",
+                    },
+                )
+            payload = review_reward_memory_candidate(candidate, review)
+            payload["adapter"] = adapter
         else:
             observation = (
                 pr_3237_regression_observation()


### PR DESCRIPTION
## Summary

- add a provider-neutral Stage-2 candidate/review contract with accept, edit, reject, retire, and no-write decisions
- keep model reasoning responsible for candidate meaning while deterministic guards enforce scope, freshness, conflicts, current-artifact proof, and no authority expansion
- add a mapping-only Issue Fix adapter that reuses existing LoopX fresh context and leaves persistence to declared corpus owners
- update the English/Chinese architecture contract and capability catalog

## Validation

- `python3 examples/reward-memory-architecture-smoke.py`
- `python3 examples/reward-memory-corpus-registry-smoke.py`
- `python3 examples/reward-memory-candidate-review-smoke.py`
- `pytest -q` (299 passed, 2 skipped)
- `ruff check` and `ruff format --check` on changed Python surfaces
- `loopx check` (0 errors, 0 warnings)
- standard premerge canary: 13/13 passed, 0 failures, 0 warnings, 0 manual holds

## Boundary

No provider write, external write, scheduler, second store, automatic recall, raw chat, local state, credentials, or private corpus is included.