### PR TITLE
Prevent repeated SkillsBench goal initialization

### DIFF
--- a/examples/skillsbench-goal-start-product-mode-route-smoke.py
+++ b/examples/skillsbench-goal-start-product-mode-route-smoke.py
@@ -643,6 +643,47 @@ def _assert_control_score_surface() -> None:
     assert compacted_prerequisites["goal_start_planned_todo_count_expected"] == 3
 
 
+def _assert_lifecycle_gates_use_successful_command_records() -> None:
+    sys.path.insert(0, str(REPO_ROOT))
+    from scripts.skillsbench_automation_loop import (
+        _product_mode_agent_lifecycle_gate_satisfied,
+        _product_mode_depth_gate_satisfied,
+    )
+
+    trace = {
+        "remote_command_file_bridge_agent_operation_trace_required": True,
+        "remote_command_file_bridge_agent_successful_loopx_command_records": [
+            {"subcommand": "start-goal"},
+            {"subcommand": "todo add", "todo_id": "todo_public_solver"},
+        ],
+    }
+    assert _product_mode_agent_lifecycle_gate_satisfied(trace) is True, trace
+    assert _product_mode_depth_gate_satisfied(trace) is True, trace
+
+    read_only_trace = {
+        "remote_command_file_bridge_agent_operation_trace_required": True,
+        "remote_command_file_bridge_agent_successful_loopx_command_records": [
+            {"subcommand": "start-goal"},
+        ],
+    }
+    assert (
+        _product_mode_agent_lifecycle_gate_satisfied(read_only_trace) is False
+    ), read_only_trace
+    assert _product_mode_depth_gate_satisfied(read_only_trace) is False, read_only_trace
+
+    todo_read_trace = {
+        "remote_command_file_bridge_agent_operation_trace_required": True,
+        "remote_command_file_bridge_agent_successful_loopx_command_records": [
+            {"subcommand": "start-goal"},
+            {"subcommand": "todo list"},
+        ],
+    }
+    assert (
+        _product_mode_agent_lifecycle_gate_satisfied(todo_read_trace) is False
+    ), todo_read_trace
+    assert _product_mode_depth_gate_satisfied(todo_read_trace) is False, todo_read_trace
+
+
 def _assert_host_local_acp_return_arity_compat() -> None:
     sys.path.insert(0, str(REPO_ROOT))
     from scripts.skillsbench_automation_loop import (
@@ -820,6 +861,7 @@ def main() -> int:
     _assert_bridge_rejects_batched_loopx_commands()
     _assert_generated_prompt_requires_agent_authored_separate_requests()
     _assert_control_score_surface()
+    _assert_lifecycle_gates_use_successful_command_records()
     _assert_host_local_acp_return_arity_compat()
     _assert_app_server_goal_baseline_bridge_contract()
     _assert_verifier_feedback_routes_disabled()

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -11442,6 +11442,9 @@ def _product_mode_no_open_todo_below_passing_reward_applicable(
 
 
 def _product_mode_depth_gate_satisfied(trace: dict[str, Any]) -> bool:
+    if _product_mode_agent_lifecycle_gate_satisfied(trace):
+        return True
+
     def count(*fields: str) -> int:
         values = [
             trace.get(field)
@@ -11503,6 +11506,38 @@ def _product_mode_depth_gate_satisfied(trace: dict[str, Any]) -> bool:
 
 def _product_mode_agent_lifecycle_gate_satisfied(trace: dict[str, Any]) -> bool:
     """Return true only after the solver agent, not only the driver, touched LoopX."""
+
+    # Relay snapshots may expose successful commands before cumulative counters catch up.
+    successful_commands = {
+        record.get("subcommand")
+        for record in _goal_start_public_command_records(
+            trace.get(
+                "remote_command_file_bridge_agent_successful_loopx_command_records"
+            )
+        )
+    }
+    successful_read_observed = bool(
+        successful_commands
+        & {"start-goal", "quota should-run", "status", "diagnose"}
+    )
+    successful_write_observed = bool(
+        successful_commands
+        & {
+            "refresh-state",
+            "quota spend-slot",
+            "todo add",
+            "todo claim",
+            "todo update",
+            "todo complete",
+            "todo supersede",
+            "todo archive-completed",
+        }
+    )
+    successful_lifecycle_observed = bool(
+        successful_read_observed and successful_write_observed
+    )
+    if successful_lifecycle_observed:
+        return True
 
     remote_agent_trace_required = (
         trace.get("remote_command_file_bridge_agent_operation_trace_required") is True


### PR DESCRIPTION
## Summary

- Accept public-safe successful relay command records as lifecycle evidence when cumulative agent counters lag.
- Let solver-agent lifecycle evidence satisfy the product-mode depth gate, preventing declared-done continuations from re-running goal initialization.
- Add a focused regression proving that a successful read plus write satisfies both gates, while read-only `start-goal` does not.

## Changed surfaces

- `scripts/skillsbench_automation_loop.py`: online product-mode lifecycle/depth gating only.
- `examples/skillsbench-goal-start-product-mode-route-smoke.py`: durable regression fixture.

No scoring, task semantics, submission, upload, permission, or leaderboard behavior changes.

## Validation

- `python3 examples/skillsbench-goal-start-product-mode-route-smoke.py`
- `python3 examples/benchmark-loop-protocol-smoke.py`
- `python3 examples/skillsbench-reverse-channel-bridge-smoke.py`
- `python3 examples/skillsbench-acp-recoverable-transport-smoke.py`
- `python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-goal-start-product-mode-route-smoke.py`
- `loopx canary premerge --from-git-diff --tier standard`: 4 direct checks and 5 selected checks passed, with no failures or warnings.
- `loopx check --scan-path ...`: public/private boundary clean.

## Holds and residual risk

- The premerge gate correctly retains the benchmark-sensitive manual review hold, so this PR is not self-merge eligible.
- Whole-file Ruff is not a useful gate for these legacy script/example files: they are outside the configured CI lint paths and currently report pre-existing violations unrelated to this diff.
- A clean-main matched `/goal` versus `/loopx` rerun is still required after review/merge to measure whether duplicate initialization is actually removed and whether task score changes.
