### PR TITLE
Stabilize issue-fix lifecycle smoke write checks

### DIFF
--- a/examples/issue-fix-pr-lifecycle-smoke.py
+++ b/examples/issue-fix-pr-lifecycle-smoke.py
@@ -562,10 +562,15 @@ def main() -> int:
         assert material_result["status"] == "updated", material_result
         assert material_result["write_performed"] is True, material_result
         assert failing["domain_state_projection"]["write_performed"] is True, failing
-        assert ledger.stat().st_ino != first_inode
         material_rows = [
             json.loads(line) for line in ledger.read_text(encoding="utf-8").splitlines()
         ]
+        assert material_rows[0]["observation_fingerprint"] == failing[
+            "observation_fingerprint"
+        ], material_rows
+        assert material_rows[0]["observation_fingerprint"] != quiet[
+            "observation_fingerprint"
+        ], material_rows
         assert material_rows[0]["first_push_ci"] == quiet["first_push_ci"], (
             material_rows
         )


### PR DESCRIPTION
## Summary
- replace the filesystem-dependent inode inequality assertion in the issue-fix PR lifecycle smoke
- prove material persistence through the stored observation fingerprint while retaining the existing no-write inode check for unchanged input

## Motivation
Full Public Smokes run 29322689645 failed intermittently because an atomic replacement may immediately reuse the prior inode. The production write path and later main runs were healthy; the smoke assertion was stronger than the public behavior contract.

## Validation
- `python3 examples/issue-fix-pr-lifecycle-smoke.py`
- 24 concurrent repeat runs of `examples/issue-fix-pr-lifecycle-smoke.py` (24/24 passed)
- `python3 -m py_compile examples/issue-fix-pr-lifecycle-smoke.py`
- `loopx canary premerge --from-git-diff` (standard gate, 6/6 selected checks passed, no manual holds)
- `git diff --check` and `git diff --cached --check`
- public/private boundary scan passed through premerge canary

## Scope
Test-only change. No runtime behavior, benchmark semantics, permissions, private state, local artifacts, or generated logs are included.