### PR TITLE
Deduplicate cumulative SkillsBench relay snapshots

### DIFF
--- a/examples/skillsbench-agent-operation-snapshot-smoke.py
+++ b/examples/skillsbench-agent-operation-snapshot-smoke.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Prove cumulative relay snapshots do not inflate SkillsBench counters."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
+    CodexExecConfig,
+    SkillsBenchLocalAcpRelay,
+)
+from scripts.skillsbench_automation_loop import (  # noqa: E402
+    _merge_host_local_acp_relay_trace_summary,
+)
+
+
+def append_operation(records: list[dict[str, object]]) -> None:
+    records.extend(
+        (
+            {
+                "operation": "exec",
+                "record_phase": "start",
+                "operation_observed": True,
+                "task_facing_operation": True,
+            },
+            {
+                "operation": "exec",
+                "record_phase": "complete",
+                "returncode": 0,
+                "task_facing_operation": True,
+            },
+        )
+    )
+
+
+def write_summary(path: Path, records: list[dict[str, object]]) -> None:
+    path.write_text(
+        "".join(json.dumps(record) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+
+def merge_trace(trace_dir: Path) -> dict[str, object]:
+    plan = {
+        "host_local_acp_relay_trace_dir": str(trace_dir),
+        "runner_prerequisites": {
+            "remote_command_file_bridge_agent_operation_trace_required": True,
+        },
+    }
+    trace: dict[str, object] = {
+        "schema_version": "skillsbench_loopx_controller_trace_v0",
+        "route": "loopx-goal-start-product-mode",
+        "trace_publicness": "public_counts_only_no_task_text_no_verifier_output",
+    }
+    _merge_host_local_acp_relay_trace_summary(plan, trace)
+    return trace
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-agent-snapshots-") as tmp:
+        root = Path(tmp)
+        trace_dir = root / "traces"
+        summary_path = root / "bridge-summary.jsonl"
+        relay = SkillsBenchLocalAcpRelay(
+            CodexExecConfig(
+                route="loopx-goal-start-product-mode",
+                worker_public_trace_dir=str(trace_dir),
+            )
+        )
+
+        records: list[dict[str, object]] = []
+        for _ in range(2):
+            append_operation(records)
+            write_summary(summary_path, records)
+            relay._publish_remote_bridge_agent_operations_trace(
+                bridge_summary_path=summary_path,
+            )
+
+        payloads = [
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in sorted(trace_dir.glob("*.compact.json"))
+        ]
+        snapshots = [
+            payload["remote_command_file_bridge_agent_operations"]
+            for payload in payloads
+        ]
+        assert len(snapshots) == 2, snapshots
+        assert len({snapshot["snapshot_id"] for snapshot in snapshots}) == 1
+        assert sorted(snapshot["snapshot_index"] for snapshot in snapshots) == [1, 2]
+
+        trace = merge_trace(trace_dir)
+        assert trace["remote_command_file_bridge_agent_operation_trace_count"] == 2
+        assert trace["remote_command_file_bridge_agent_superseded_snapshot_count"] == 1
+        assert trace["remote_command_file_bridge_agent_request_count"] == 2, trace
+        assert trace["remote_command_file_bridge_agent_success_count"] == 2, trace
+        assert trace["remote_command_file_bridge_agent_operation_counts"] == {
+            "exec": 2,
+        }, trace
+
+        independent_summary_path = root / "independent-summary.jsonl"
+        write_summary(independent_summary_path, records[:2])
+        relay._publish_remote_bridge_agent_operations_trace(
+            bridge_summary_path=independent_summary_path,
+        )
+        trace = merge_trace(trace_dir)
+        assert trace["remote_command_file_bridge_agent_operation_trace_count"] == 3
+        assert trace["remote_command_file_bridge_agent_superseded_snapshot_count"] == 1
+        assert trace["remote_command_file_bridge_agent_request_count"] == 3, trace
+        assert trace["remote_command_file_bridge_agent_success_count"] == 3, trace
+        assert trace["remote_command_file_bridge_agent_operation_counts"] == {
+            "exec": 3,
+        }, trace
+
+    print("skillsbench-agent-operation-snapshot-smoke: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -471,6 +471,8 @@ class SkillsBenchLocalAcpRelay:
         self._sessions: dict[str, dict[str, Any]] = {}
         self._published_lifecycle_stages: set[str] = set()
         self._workflow_checkpoint_count = 0
+        self._bridge_summary_snapshot_ids: dict[str, str] = {}
+        self._bridge_summary_snapshot_indexes: dict[str, int] = {}
 
     def serve(self, stdin: TextIO = sys.stdin, stdout: TextIO = sys.stdout) -> int:
         for line in stdin:
@@ -2633,6 +2635,15 @@ raise SystemExit(proc.returncode)
                     )
                 )
         inflight_operation_count = max(0, starts - completions)
+        snapshot_key = str(bridge_summary_path)
+        snapshot_id = self._bridge_summary_snapshot_ids.setdefault(
+            snapshot_key,
+            f"bridge-{uuid.uuid4().hex[:12]}",
+        )
+        snapshot_index = (
+            self._bridge_summary_snapshot_indexes.get(snapshot_key, 0) + 1
+        )
+        self._bridge_summary_snapshot_indexes[snapshot_key] = snapshot_index
         trace = {
             "schema_version": "skillsbench_host_local_acp_relay_public_trace_v0",
             "ok": True,
@@ -2644,6 +2655,9 @@ raise SystemExit(proc.returncode)
                 "schema_version": (
                     "skillsbench_remote_command_file_bridge_agent_operations_v0"
                 ),
+                "snapshot_id": snapshot_id,
+                "snapshot_index": snapshot_index,
+                "snapshot_semantics": "cumulative",
                 "request_count": request_count,
                 "success_count": success_count,
                 "failure_count": failure_count,

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -10307,6 +10307,7 @@ def _merge_host_local_acp_relay_trace_summary(
     codex_cli_goal_stages: list[str] = []
     codex_cli_goal_reasoning_efforts: list[str] = []
     raw_material_recorded = False
+    payloads: list[dict[str, Any]] = []
     for path in files:
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
@@ -10319,10 +10320,56 @@ def _merge_host_local_acp_relay_trace_summary(
             != "skillsbench_host_local_acp_relay_public_trace_v0"
         ):
             continue
+        payloads.append(payload)
+
+    latest_agent_snapshot_indexes: dict[str, tuple[int, int]] = {}
+    for payload_index, payload in enumerate(payloads):
+        if payload.get("trace_kind") != "remote_command_file_bridge_agent_operations":
+            continue
+        agent_ops = payload.get("remote_command_file_bridge_agent_operations")
+        if not isinstance(agent_ops, dict):
+            continue
+        snapshot_id = agent_ops.get("snapshot_id")
+        snapshot_index = agent_ops.get("snapshot_index")
+        if (
+            agent_ops.get("snapshot_semantics") != "cumulative"
+            or not isinstance(snapshot_id, str)
+            or not snapshot_id
+            or len(snapshot_id) > 128
+            or not isinstance(snapshot_index, int)
+            or isinstance(snapshot_index, bool)
+            or snapshot_index < 1
+        ):
+            continue
+        current = latest_agent_snapshot_indexes.get(snapshot_id)
+        if current is None or snapshot_index >= current[0]:
+            latest_agent_snapshot_indexes[snapshot_id] = (
+                snapshot_index,
+                payload_index,
+            )
+
+    superseded_agent_snapshot_count = 0
+    for payload_index, payload in enumerate(payloads):
         boundary = (
             payload.get("boundary")
             if isinstance(payload.get("boundary"), dict)
             else {}
+        )
+        raw_material_recorded = raw_material_recorded or any(
+            boundary.get(field) is True
+            for field in (
+                "raw_command_recorded",
+                "raw_stdout_recorded",
+                "raw_stderr_recorded",
+                "raw_task_text_recorded",
+                "raw_logs_recorded",
+                "raw_trajectory_recorded",
+                "credential_values_recorded",
+                "host_paths_recorded",
+                "remote_paths_recorded",
+                "upload_performed",
+                "submit_performed",
+            )
         )
         trace_kind = payload.get("trace_kind")
         if trace_kind == "remote_command_file_bridge_solver_consumption":
@@ -10376,6 +10423,17 @@ def _merge_host_local_acp_relay_trace_summary(
             raw_material_recorded = raw_material_recorded or (
                 agent_ops.get("raw_material_recorded") is True
             )
+            snapshot_id = agent_ops.get("snapshot_id")
+            snapshot_index = agent_ops.get("snapshot_index")
+            if (
+                agent_ops.get("snapshot_semantics") == "cumulative"
+                and isinstance(snapshot_id, str)
+                and snapshot_id in latest_agent_snapshot_indexes
+                and latest_agent_snapshot_indexes[snapshot_id]
+                != (snapshot_index, payload_index)
+            ):
+                superseded_agent_snapshot_count += 1
+                continue
             count_fields = {
                 "request_count": "request",
                 "success_count": "success",
@@ -10560,22 +10618,6 @@ def _merge_host_local_acp_relay_trace_summary(
             )
         else:
             continue
-        raw_material_recorded = raw_material_recorded or any(
-            boundary.get(field) is True
-            for field in (
-                "raw_command_recorded",
-                "raw_stdout_recorded",
-                "raw_stderr_recorded",
-                "raw_task_text_recorded",
-                "raw_logs_recorded",
-                "raw_trajectory_recorded",
-                "credential_values_recorded",
-                "host_paths_recorded",
-                "remote_paths_recorded",
-                "upload_performed",
-                "submit_performed",
-            )
-        )
     consumed_by_solver = solver_trace_count > 0 and probe_ready_count > 0
     agent_bridge_failure_category = ""
     for category, count in sorted(agent_bridge_failure_category_counts.items()):
@@ -10624,6 +10666,9 @@ def _merge_host_local_acp_relay_trace_summary(
     )
     trace["remote_command_file_bridge_agent_operation_trace_present"] = (
         agent_bridge_trace_count > 0
+    )
+    trace["remote_command_file_bridge_agent_superseded_snapshot_count"] = (
+        superseded_agent_snapshot_count
     )
     prerequisites = plan.setdefault("runner_prerequisites", {})
     agent_trace_required = (


### PR DESCRIPTION
## Summary
- label cumulative bridge-operation snapshots with a stable public-safe id and monotonic index
- reduce each cumulative snapshot stream from its latest snapshot while preserving additive counts across independent streams
- add a focused public smoke proving 1 -> 2 cumulative snapshots reduce to 2 and an independent 1 still sums to 3

## Validation
- focused snapshot smoke: passed
- full SkillsBench benchmark-run smoke: passed
- repository Python line-budget smoke: passed
- canary catalog planner smoke: passed
- changed-file Python compile: passed
- public boundary scan: clean for all three changed files
- standard premerge canary: all direct, catalog, and public-boundary checks passed; expected benchmark-sensitive manual hold remains for maintainer review

No benchmark job, upload, submission, scoring change, task semantic change, or permission change is included.