### PR TITLE
Fail closed on missing Explore visual roles

### DIFF
--- a/docs/capabilities/explore/README.md
+++ b/docs/capabilities/explore/README.md
@@ -743,6 +743,12 @@ projection is rejected before any whiteboard command runs. Legacy grid/SVG
 renderer configuration fails with an explicit migration message instead of
 silently publishing the wrong visual form.
 
+The visual sync is not satisfied when any recommended role is missing from the
+configured sinks. Its top-level receipt stays `published=false`, names the
+missing roles, and returns a retryable configuration action; successful
+per-role diagnostics may still be inspected, but they cannot make the overall
+sink look current or advance its delivery checkpoint.
+
 The text `From Node` / `To Node` columns remain stable public ids for
 automation and review, while the linked-record columns are the Feishu-native
 graph substrate. A Base plugin, relationship-aware view, or Feishu dashboard

--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -63,6 +63,7 @@ from .explore_visual_styles import (
     board_source_with_delivery_marker,
     explore_board_style,
     resolve_explore_board_style,
+    summarize_explore_visual_sync,
 )
 from .message_card import build_lark_markdown_reply_card
 
@@ -916,9 +917,6 @@ def sync_explore_visuals_to_lark(
     active_roles = ["canonical"]
     if bundle["presentation_mode"] == PRESENTATION_MODE_DUAL_VIEW:
         active_roles.append("executive")
-    missing_recommended_roles = [
-        role for role in active_roles if role not in requested_roles
-    ]
     results: dict[str, Any] = {}
     for role in requested_roles:
         if role not in active_roles:
@@ -1055,24 +1053,21 @@ def sync_explore_visuals_to_lark(
             "section_commands": section_commands,
             "reconciliation": reconciliation,
         }
-    ok = all(bool(item.get("ok")) for item in results.values())
-    if not results:
-        status = "not_configured"
-    elif not ok:
-        status = "publish_failed" if execute else "invalid_projection"
-    else:
-        status = "published" if execute else "would_publish"
+    delivery = summarize_explore_visual_sync(
+        views=results,
+        configured_roles=requested_roles,
+        recommended_roles=active_roles,
+        execute=execute,
+    )
     return {
-        "ok": ok,
+        **delivery,
         "schema_version": LARK_EXPLORE_VISUALS_SYNC_VERSION,
-        "status": status,
         "execute": execute,
         "presentation_mode": bundle["presentation_mode"],
         "reason_codes": bundle["reason_codes"],
         "source_digest": bundle["source_digest"],
         "source_revision": bundle["source_revision"],
         "recommended_roles": active_roles,
-        "missing_recommended_roles": missing_recommended_roles,
         "views": results,
     }
 

--- a/loopx/presentation/sinks/lark/explore_visual_styles.py
+++ b/loopx/presentation/sinks/lark/explore_visual_styles.py
@@ -72,6 +72,45 @@ def resolve_explore_board_style(
     return _RENDERER_BOARD_STYLES[renderer]
 
 
+def summarize_explore_visual_sync(
+    *,
+    views: Mapping[str, Mapping[str, Any]],
+    configured_roles: list[str],
+    recommended_roles: list[str],
+    execute: bool,
+) -> dict[str, Any]:
+    """Fail closed when a recommended visual role is not configured."""
+
+    missing_roles = [
+        role for role in recommended_roles if role not in configured_roles
+    ]
+    configured_views_ok = all(bool(view.get("ok")) for view in views.values())
+    ok = configured_views_ok and not missing_roles
+    if missing_roles and (not views or configured_views_ok):
+        status = "sink_unsatisfied"
+    elif not views:
+        status = "not_configured"
+    elif not configured_views_ok:
+        status = "publish_failed" if execute else "invalid_projection"
+    else:
+        status = "published" if execute else "would_publish"
+    missing_roles_label = ", ".join(missing_roles)
+    return {
+        "ok": ok,
+        "status": status,
+        "published": bool(execute and ok),
+        "retryable": bool(missing_roles),
+        "required_action": (
+            f"configure the {missing_roles_label} visual role"
+            f"{'s' if len(missing_roles) != 1 else ''} and retry Explore visual sync"
+            if missing_roles
+            else None
+        ),
+        "configured_roles": configured_roles,
+        "missing_recommended_roles": missing_roles,
+    }
+
+
 def board_source_with_delivery_marker(
     source: str,
     marker: str,

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -663,6 +663,39 @@ def test_visual_configuration_can_create_all_stage_boards_from_docx(tmp_path) ->
     assert sink["stage_whiteboards"] == []
 
 
+def test_canonical_only_visual_sync_fails_closed_without_canonical_sink(
+    tmp_path,
+) -> None:
+    projection = _small_projection()
+
+    def runner(_args, _cwd, _timeout):
+        raise AssertionError("missing recommended role must not publish another view")
+
+    synced = sync_explore_visuals_to_lark(
+        LarkExploreConfig(base_token="PUBLIC_FIXTURE_BASE"),
+        projection=projection,
+        visual_sinks={
+            "executive": {
+                "whiteboard_token": "wb_executive_fixture",
+                "view_role": "executive",
+            }
+        },
+        config_path=tmp_path / "lark-explore.json",
+        execute=True,
+        runner=runner,
+    )
+
+    assert synced["presentation_mode"] == PRESENTATION_MODE_CANONICAL_ONLY
+    assert synced["ok"] is False
+    assert synced["status"] == "sink_unsatisfied"
+    assert synced["published"] is False
+    assert synced["retryable"] is True
+    assert synced["recommended_roles"] == ["canonical"]
+    assert synced["missing_recommended_roles"] == ["canonical"]
+    assert synced["views"]["executive"]["status"] == "not_recommended"
+    assert "configure the canonical visual role" in synced["required_action"]
+
+
 @pytest.mark.parametrize(
     ("board_style", "renderer", "input_format"),
     [
@@ -1326,7 +1359,10 @@ def test_visual_sync_creates_one_document_section_and_board_per_missing_stage(
     )
 
     view = synced["views"]["executive"]
-    assert synced["ok"] is True
+    assert synced["ok"] is False
+    assert synced["status"] == "sink_unsatisfied"
+    assert synced["missing_recommended_roles"] == ["canonical"]
+    assert view["ok"] is True
     assert view["stage_count"] == stage_count
     assert len(view["section_commands"]) == stage_count - 1
     assert all(stage["published"] for stage in view["stages"])
@@ -1451,7 +1487,10 @@ def test_stage_document_recreates_configured_board_missing_from_document(
         assert outline_fetch_count == 2
         return
 
-    assert synced["ok"] is True
+    assert synced["ok"] is False
+    assert synced["status"] == "sink_unsatisfied"
+    assert synced["missing_recommended_roles"] == ["canonical"]
+    assert view["ok"] is True
     assert len(view["section_commands"]) == 1
     assert view["reconciliation"]["missing_remote_stage_indexes"] == [2]
     assert view["reconciliation"]["performed"] is True
@@ -1578,7 +1617,10 @@ def test_stage_document_reconciliation_removes_all_stale_duplicate_sections(
     )
 
     view = synced["views"]["canonical"]
-    assert synced["ok"] is True
+    assert synced["ok"] is False
+    assert synced["status"] == "sink_unsatisfied"
+    assert synced["missing_recommended_roles"] == ["executive"]
+    assert view["ok"] is True
     assert view["reconciliation"] == {
         "required": False,
         "performed": True,


### PR DESCRIPTION
## Summary

- make Explore multi-view sync fail closed when a presentation-recommended role is not configured
- keep per-role receipts available while preventing a partial sink from reporting published or advancing its delivery checkpoint
- document the retryable sink contract and cover canonical-only plus dual-view stage-document cases

## Validation

- 34 presentation-view tests passed
- Explore result-layer smoke passed
- ruff and diff checks passed
- standard pre-merge canary passed: 17 selected checks, 4 direct checks, public-boundary scan, zero warnings and zero holds
- repository Python line-budget smoke passed