### PR TITLE
Fix refresh-state shared runtime projection

### DIFF
--- a/examples/control_plane/refresh-state-shared-runtime-projection-smoke.py
+++ b/examples/control_plane/refresh-state-shared-runtime-projection-smoke.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Keep project-local refresh-state visible to its registered shared runtime."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.runtime.shared_runtime_refresh_projection import (  # noqa: E402
+    build_shared_runtime_projection,
+    write_shared_runtime_projection,
+)
+
+
+AGENT_ID = "codex-shared-runtime-smoke"
+GOAL_ID = "refresh-state-shared-runtime-smoke"
+VISION_ACCEPTANCE = "Shared quota reads the newest project-local agent vision."
+
+
+def run_cli(*args: str, cwd: Path, shared_runtime: Path) -> dict:
+    result = subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--format", "json", *args],
+        cwd=cwd,
+        check=False,
+        text=True,
+        capture_output=True,
+        env={
+            **os.environ,
+            "PYTHONPATH": str(REPO_ROOT),
+            "LOOPX_RUNTIME_ROOT": str(shared_runtime),
+        },
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict), payload
+    return payload
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
+    project = root / "project"
+    project_runtime = project / ".loopx" / "runtime"
+    shared_runtime = root / "shared-runtime"
+    source_registry = project / ".loopx" / "registry.json"
+    shared_registry = shared_runtime / "registry.global.json"
+    state_file = project / ".loopx" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(
+        "---\nstatus: active\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n\n"
+        f"# {GOAL_ID}\n\n## Agent Todo\n\n"
+        "- [ ] [P1] Verify the shared-runtime refresh projection.\n",
+        encoding="utf-8",
+    )
+    goal = {
+        "id": GOAL_ID,
+        "domain": "refresh-state-shared-runtime-smoke",
+        "status": "active",
+        "repo": str(project),
+        "state_file": str(state_file.relative_to(project)),
+        "adapter": {"kind": "fixture", "status": "connected-read-only"},
+        "coordination": {
+            "registered_agents": [AGENT_ID],
+            "agent_model": "peer_v1",
+        },
+        "quota": {"compute": 1.0, "window_hours": 24},
+    }
+    source_registry.parent.mkdir(parents=True, exist_ok=True)
+    source_registry.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "common_runtime_root": str(project_runtime),
+                "goals": [goal],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    shared_registry.parent.mkdir(parents=True)
+    shared_registry.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "registry_role": "global-local",
+                "common_runtime_root": str(shared_runtime),
+                "goals": [
+                    {
+                        **goal,
+                        "source_registry": str(source_registry.resolve()),
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return project, project_runtime, source_registry, shared_registry
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-refresh-shared-runtime-") as tmp:
+        project, project_runtime, source_registry, shared_registry = write_fixture(
+            Path(tmp)
+        )
+        shared_runtime = shared_registry.parent
+        refresh = run_cli(
+            "--registry",
+            str(source_registry),
+            "refresh-state",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--progress-scope",
+            "agent_lane",
+            "--classification",
+            "shared_runtime_projection_verified",
+            "--recommended-action",
+            "Inspect PRIVATE_LOCAL_ACTION_MARKER in the source runtime only.",
+            "--delivery-batch-scale",
+            "implementation",
+            "--delivery-outcome",
+            "outcome_progress",
+            "--vision-state",
+            "active",
+            "--vision-summary",
+            "Project-local material refresh should remain visible globally.",
+            "--vision-acceptance",
+            VISION_ACCEPTANCE,
+            "--suppress-external-sinks",
+            cwd=project,
+            shared_runtime=shared_runtime,
+        )
+
+        assert Path(refresh["runtime_root"]).resolve() == project_runtime.resolve()
+        assert Path(refresh["global_sync"]["global_registry"]).resolve() == shared_registry.resolve()
+        projection = refresh["shared_runtime_projection"]
+        assert projection["ok"] is True, projection
+        assert projection["status"] == "projected", projection
+        assert projection["raw_artifacts_copied"] is False, projection
+        assert projection["recommended_action_copied"] is False, projection
+        assert not (project_runtime / "registry.global.json").exists()
+
+        shared_index = shared_runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
+        rows = [json.loads(line) for line in shared_index.read_text().splitlines()]
+        latest = rows[-1]
+        assert latest["classification"] == "shared_runtime_projection_verified"
+        assert latest["agent_vision"]["vision_patch"]["acceptance_summary"] == VISION_ACCEPTANCE
+        shared_record = Path(latest["json_path"]).read_text(encoding="utf-8")
+        assert "PRIVATE_LOCAL_ACTION_MARKER" not in shared_record
+        assert str(project) not in shared_record
+
+        source_record = json.loads(Path(refresh["json_path"]).read_text(encoding="utf-8"))
+        replay_record, replay_index = build_shared_runtime_projection(record=source_record)
+        replay = write_shared_runtime_projection(
+            shared_runtime_root=shared_runtime,
+            goal_id=GOAL_ID,
+            record=replay_record,
+            index_record=replay_index,
+            dry_run=False,
+        )
+        assert replay["status"] == "already_current", replay
+        assert len(shared_index.read_text().splitlines()) == len(rows)
+
+        source_record["state"]["frontmatter"]["updated_at"] = str(project)
+        boundary_record, _ = build_shared_runtime_projection(record=source_record)
+        assert boundary_record["state"]["frontmatter"]["updated_at"] is None
+        assert str(project) not in json.dumps(boundary_record)
+
+        quota = run_cli(
+            "--registry",
+            str(shared_registry),
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--available-capability",
+            "shell",
+            cwd=project,
+            shared_runtime=shared_runtime,
+        )
+        audit = quota["interaction_contract"]["agent_channel"][
+            "vision_continuation_audit"
+        ]
+        assert audit["acceptance_gaps"][0]["acceptance_summary"] == VISION_ACCEPTANCE
+
+    print("refresh-state shared-runtime projection smoke passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/control_plane/refresh-state-write-correctness-smoke.py
+++ b/examples/control_plane/refresh-state-write-correctness-smoke.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import runpy
 import sys
 import tempfile
 from pathlib import Path
@@ -139,6 +140,10 @@ def main() -> None:
     finally:
         state_refresh.now_local = original_now_local
 
+    runpy.run_path(
+        str(Path(__file__).with_name("refresh-state-shared-runtime-projection-smoke.py")),
+        run_name="__main__",
+    )
     print("refresh-state-write-correctness-smoke ok")
 
 

--- a/loopx/control_plane/runtime/shared_runtime_refresh_projection.py
+++ b/loopx/control_plane/runtime/shared_runtime_refresh_projection.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from ...file_lock import exclusive_file_lock
+from ...history import load_index, load_registry, reserve_unique_run_paths
+from ...paths import DEFAULT_RUNTIME_ROOT, global_registry_path
+from ...registry import registry_goals
+from ..goals.goal_vision import compact_goal_vision_packet
+from .time import now_local_iso
+
+
+SHARED_RUNTIME_PROJECTION_SCHEMA_VERSION = "shared_runtime_refresh_projection_v0"
+ISO_LIKE_TIMESTAMP_RE = re.compile(r"[0-9TZ:+.\-]{10,64}")
+
+
+def registered_shared_runtime_root(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    source_runtime_root: Path,
+) -> Path | None:
+    """Find the shared runtime that registered this exact source registry route."""
+
+    candidate_roots: list[Path] = []
+    configured_root = str(os.environ.get("LOOPX_RUNTIME_ROOT") or "").strip()
+    if configured_root:
+        candidate_roots.append(Path(configured_root).expanduser())
+    candidate_roots.append(DEFAULT_RUNTIME_ROOT)
+
+    source_path = registry_path.expanduser().resolve()
+    seen: set[Path] = set()
+    for candidate_root in candidate_roots:
+        resolved_root = candidate_root.resolve()
+        if resolved_root in seen or resolved_root == source_runtime_root.resolve():
+            continue
+        seen.add(resolved_root)
+        candidate_registry = global_registry_path(resolved_root)
+        if not candidate_registry.exists() or candidate_registry.resolve() == source_path:
+            continue
+        shared_registry = load_registry(candidate_registry)
+        for goal in registry_goals(shared_registry):
+            if str(goal.get("id") or "") != goal_id:
+                continue
+            registered_source = str(goal.get("source_registry") or "").strip()
+            if not registered_source:
+                continue
+            registered_path = Path(registered_source).expanduser()
+            if not registered_path.is_absolute():
+                registered_path = candidate_registry.parent / registered_path
+            if registered_path.resolve() == source_path:
+                return resolved_root
+    return None
+
+
+def build_shared_runtime_projection(
+    *,
+    record: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Build the compact allowlisted record consumed by shared status/quota."""
+
+    state = record.get("state") if isinstance(record.get("state"), dict) else {}
+    frontmatter = (
+        state.get("frontmatter") if isinstance(state.get("frontmatter"), dict) else {}
+    )
+    updated_at = str(frontmatter.get("updated_at") or "").strip()
+    if not ISO_LIKE_TIMESTAMP_RE.fullmatch(updated_at):
+        updated_at = ""
+    marker = {
+        "schema_version": SHARED_RUNTIME_PROJECTION_SCHEMA_VERSION,
+        "source": "refresh_state",
+        "source_generated_at": record.get("generated_at"),
+        "raw_artifacts_copied": False,
+        "recommended_action_copied": False,
+    }
+    projection: dict[str, Any] = {
+        "generated_at": record.get("generated_at"),
+        "goal_id": record.get("goal_id"),
+        "classification": record.get("classification"),
+        "health_check": "project-local refresh projected to registered shared runtime",
+        "state": {
+            "sha256_16": state.get("sha256_16"),
+            "frontmatter": {"updated_at": updated_at or None},
+        },
+        "shared_runtime_projection": marker,
+    }
+    compact_vision = compact_goal_vision_packet(record.get("agent_vision"))
+    if compact_vision:
+        projection["agent_vision"] = compact_vision
+    for field in (
+        "delivery_batch_scale",
+        "delivery_outcome",
+        "progress_scope",
+        "agent_id",
+        "agent_lane",
+        "vision_checkpoint",
+    ):
+        if field in record:
+            projection[field] = record[field]
+
+    ack = (
+        record.get("autonomous_replan_ack")
+        if isinstance(record.get("autonomous_replan_ack"), dict)
+        else {}
+    )
+    if ack:
+        compact_ack = {
+            field: ack[field]
+            for field in ("schema_version", "recorded", "source", "requested")
+            if field in ack
+        }
+        delta = ack.get("delta_contract") if isinstance(ack.get("delta_contract"), dict) else {}
+        if delta:
+            compact_ack["delta_contract"] = {
+                field: delta[field]
+                for field in (
+                    "schema_version",
+                    "required",
+                    "delta_present",
+                    "delta_kinds",
+                    "accepted_without_delta",
+                )
+                if field in delta
+            }
+        projection["autonomous_replan_ack"] = compact_ack
+
+    marker["source_projection_sha256_16"] = hashlib.sha256(
+        json.dumps(projection, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    ).hexdigest()[:16]
+    projected_index = {
+        key: projection[key]
+        for key in (
+            "generated_at",
+            "goal_id",
+            "classification",
+            "health_check",
+            "state",
+            "delivery_batch_scale",
+            "delivery_outcome",
+            "progress_scope",
+            "agent_id",
+            "agent_lane",
+            "autonomous_replan_ack",
+            "agent_vision",
+            "vision_checkpoint",
+            "shared_runtime_projection",
+        )
+        if key in projection
+    }
+    return projection, projected_index
+
+
+def _render_projection_markdown(record: dict[str, Any]) -> str:
+    marker = record.get("shared_runtime_projection") or {}
+    return "\n".join(
+        [
+            "# LoopX Shared Runtime Refresh Projection",
+            "",
+            f"- goal_id: `{record.get('goal_id')}`",
+            f"- classification: `{record.get('classification')}`",
+            f"- generated_at: `{record.get('generated_at')}`",
+            f"- agent_id: `{record.get('agent_id')}`",
+            f"- raw_artifacts_copied: `{marker.get('raw_artifacts_copied')}`",
+            f"- recommended_action_copied: `{marker.get('recommended_action_copied')}`",
+        ]
+    )
+
+
+def write_shared_runtime_projection(
+    *,
+    shared_runtime_root: Path,
+    goal_id: str,
+    record: dict[str, Any],
+    index_record: dict[str, Any],
+    dry_run: bool,
+) -> dict[str, Any]:
+    marker = record["shared_runtime_projection"]
+    result: dict[str, Any] = {
+        "ok": True,
+        "status": "would_project" if dry_run else "projected",
+        "dry_run": dry_run,
+        "shared_runtime_root": str(shared_runtime_root),
+        "raw_artifacts_copied": False,
+        "recommended_action_copied": False,
+        "source_generated_at": marker.get("source_generated_at"),
+    }
+    if dry_run:
+        return result
+
+    runs_dir = shared_runtime_root / "goals" / goal_id / "runs"
+    index_path = runs_dir / "index.jsonl"
+    with exclusive_file_lock(index_path):
+        existing, _ = load_index(index_path)
+        if any(
+            isinstance(item.get("shared_runtime_projection"), dict)
+            and item["shared_runtime_projection"].get("source_generated_at")
+            == marker.get("source_generated_at")
+            and item["shared_runtime_projection"].get("source_projection_sha256_16")
+            == marker.get("source_projection_sha256_16")
+            for item in existing
+        ):
+            result["status"] = "already_current"
+            result["index_path"] = str(index_path)
+            return result
+        json_path, markdown_path = reserve_unique_run_paths(
+            runs_dir, str(record.get("generated_at") or now_local_iso())
+        )
+        index_record["json_path"] = str(json_path)
+        index_record["markdown_path"] = str(markdown_path)
+        json_path.write_text(
+            json.dumps(record, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        markdown_path.write_text(
+            _render_projection_markdown(record) + "\n",
+            encoding="utf-8",
+        )
+        with index_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(index_record, ensure_ascii=False) + "\n")
+    result.update(
+        {
+            "json_path": str(json_path),
+            "markdown_path": str(markdown_path),
+            "index_path": str(index_path),
+        }
+    )
+    return result

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -7,11 +7,22 @@ from pathlib import Path
 from typing import Any
 
 from .control_plane.runtime.time import now_local_iso
-from .control_plane.work_items.delivery_batch_scale import DELIVERY_BATCH_SCALE_CHOICES, require_delivery_batch_scale
-from .control_plane.work_items.delivery_outcome import DELIVERY_OUTCOME_CHOICES, require_delivery_outcome
+from .control_plane.work_items.delivery_batch_scale import (
+    DELIVERY_BATCH_SCALE_CHOICES as DELIVERY_BATCH_SCALE_CHOICES,
+    require_delivery_batch_scale,
+)
+from .control_plane.work_items.delivery_outcome import (
+    DELIVERY_OUTCOME_CHOICES as DELIVERY_OUTCOME_CHOICES,
+    require_delivery_outcome,
+)
 from .control_plane.work_items.repair_delta import (
-    REPAIR_DELTA_KIND_CHOICES,
+    REPAIR_DELTA_KIND_CHOICES as REPAIR_DELTA_KIND_CHOICES,
     normalize_repair_delta_kinds,
+)
+from .control_plane.runtime.shared_runtime_refresh_projection import (
+    build_shared_runtime_projection,
+    registered_shared_runtime_root,
+    write_shared_runtime_projection,
 )
 from .feedback import validate_local_control_text, validate_public_safe_text
 from .file_lock import exclusive_file_lock
@@ -807,6 +818,15 @@ def refresh_state_run(
     normalized_repair_delta_kinds = normalize_repair_delta_kinds(repair_delta_kinds)
     registry = load_registry(registry_path)
     runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    shared_runtime_root = (
+        registered_shared_runtime_root(
+            registry_path=registry_path,
+            goal_id=safe_goal_id,
+            source_runtime_root=runtime_root,
+        )
+        if sync_global
+        else None
+    )
     registry_goal, resolved_project, resolved_state_file = resolve_goal_state(
         registry=registry,
         goal_id=safe_goal_id,
@@ -1059,6 +1079,8 @@ def refresh_state_run(
             expected_write_scopes.insert(0, "active_state")
         if sync_global:
             expected_write_scopes.append("global_registry")
+        if shared_runtime_root:
+            expected_write_scopes.append("shared_runtime_projection")
         patch_parts = [f"append refresh-state run classification={classification}"]
         if active_state_next_action_update:
             if active_state_next_action_update.get("would_update"):
@@ -1067,6 +1089,8 @@ def refresh_state_run(
                 patch_parts.append("preserve active-state Next Action")
         if sync_global:
             patch_parts.append("sync public-safe registry projection")
+        if shared_runtime_root:
+            patch_parts.append("project compact refresh to registered shared runtime")
         payload["local_state_write_correctness"] = build_local_state_write_correctness_dry_run_packet(
             goal_id=safe_goal_id,
             writer_id=normalized_agent_id or "loopx.refresh-state",
@@ -1077,6 +1101,9 @@ def refresh_state_run(
                 "run_history_ref": "runtime.goal.runs",
                 "index_ref": "runtime.goal.runs.index",
                 "global_registry_ref": "runtime.registry.global" if sync_global else None,
+                "shared_runtime_projection_ref": (
+                    "shared_runtime.goal.runs.index" if shared_runtime_root else None
+                ),
             },
             patch_summary="; ".join(patch_parts),
             expected_write_scopes=expected_write_scopes,
@@ -1100,15 +1127,65 @@ def refresh_state_run(
     if sync_global:
         payload["global_sync"] = sync_project_registry_to_global(
             registry_path=registry_path,
-            runtime_root_override=str(runtime_root),
+            runtime_root_override=str(shared_runtime_root or runtime_root),
             goal_id=safe_goal_id,
             dry_run=dry_run,
         )
+        if shared_runtime_root and payload["global_sync"].get("ok"):
+            projection_record, projection_index = build_shared_runtime_projection(
+                record=record,
+            )
+            try:
+                payload["shared_runtime_projection"] = write_shared_runtime_projection(
+                    shared_runtime_root=shared_runtime_root,
+                    goal_id=safe_goal_id,
+                    record=projection_record,
+                    index_record=projection_index,
+                    dry_run=dry_run,
+                )
+            except OSError as exc:
+                payload["ok"] = False
+                payload["partial_write"] = not dry_run
+                payload["shared_runtime_projection"] = {
+                    "ok": False,
+                    "status": "write_failed",
+                    "dry_run": dry_run,
+                    "shared_runtime_root": str(shared_runtime_root),
+                    "raw_artifacts_copied": False,
+                    "recommended_action_copied": False,
+                    "error": str(exc),
+                }
+        elif shared_runtime_root:
+            payload["ok"] = False
+            payload["partial_write"] = not dry_run
+            payload["shared_runtime_projection"] = {
+                "ok": False,
+                "status": "blocked_by_global_sync",
+                "dry_run": dry_run,
+                "shared_runtime_root": str(shared_runtime_root),
+                "raw_artifacts_copied": False,
+                "recommended_action_copied": False,
+            }
+        else:
+            payload["shared_runtime_projection"] = {
+                "ok": True,
+                "status": "not_required",
+                "dry_run": dry_run,
+                "raw_artifacts_copied": False,
+                "recommended_action_copied": False,
+            }
     else:
         payload["global_sync"] = {
             "enabled": False,
             "global_registry": str(runtime_root / "registry.global.json"),
             "synced_goal_ids": [],
             "wrote": False,
+        }
+        payload["shared_runtime_projection"] = {
+            "ok": True,
+            "status": "disabled",
+            "dry_run": dry_run,
+            "raw_artifacts_copied": False,
+            "recommended_action_copied": False,
         }
     return payload


### PR DESCRIPTION
Summary:
- route project-local refresh-state global sync back to the shared registry that registered the source route
- append an idempotent allowlisted shared run projection for quota/status agent context
- keep local recommended actions, raw state, and raw artifact paths out of the shared projection
- add a CLI regression covering shared quota readback, privacy boundaries, and retry idempotency

Validation:
- standard LoopX premerge canary: 17/17 passed, no manual holds
- ruff on changed Python files
- focused refresh-state write correctness and shared-runtime projection smokes