### PR TITLE
Add SkillsBench setup-only public preflight

### DIFF
--- a/loopx/benchmark_adapters/skillsbench_codex_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_codex_runtime.py
@@ -160,6 +160,7 @@ def preflight_required(args: Any) -> bool:
         getattr(args, "host_local_acp_launch", False)
         and not getattr(args, "local_acp_relay_command", None)
         and not getattr(args, "reduce_only", False)
+        and not getattr(args, "setup_only_public_preflight", False)
     )
 
 

--- a/loopx/benchmark_adapters/skillsbench_failure_signals.py
+++ b/loopx/benchmark_adapters/skillsbench_failure_signals.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 
 
 _SETUP_ATTRIBUTION_FINGERPRINT_PATTERNS = {
@@ -91,6 +92,29 @@ def skillsbench_failure_dependency_classes(error_text: str) -> list[str]:
     ]
 
 
+def skillsbench_setup_failure_category(
+    fingerprint: Mapping[str, object],
+) -> str:
+    """Map a public failure fingerprint to its most specific setup category."""
+
+    matched_patterns = fingerprint.get("matched_patterns")
+    if not isinstance(matched_patterns, list):
+        return "skillsbench_docker_compose_setup_failure"
+    matched = {
+        str(item)
+        for item in matched_patterns
+        if isinstance(item, str)
+    }
+    return next(
+        (
+            attribution
+            for pattern, attribution in _FINGERPRINT_SETUP_ATTRIBUTIONS
+            if pattern in matched
+        ),
+        "skillsbench_docker_compose_setup_failure",
+    )
+
+
 def reconcile_skillsbench_setup_attribution(
     benchmark_run: dict[str, object],
 ) -> bool:
@@ -112,14 +136,7 @@ def reconcile_skillsbench_setup_attribution(
     if required_pattern in matched:
         return False
 
-    replacement = next(
-        (
-            attribution
-            for pattern, attribution in _FINGERPRINT_SETUP_ATTRIBUTIONS
-            if pattern in matched
-        ),
-        "skillsbench_docker_compose_setup_failure",
-    )
+    replacement = skillsbench_setup_failure_category(fingerprint)
     benchmark_run["score_failure_attribution"] = replacement
     for field in ("first_blocker", "repeat_blocked_by"):
         if benchmark_run.get(field) == current:

--- a/loopx/benchmark_adapters/skillsbench_setup_preflight.py
+++ b/loopx/benchmark_adapters/skillsbench_setup_preflight.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from typing import Any
+
+from .skillsbench_failure_signals import (
+    skillsbench_runner_error_fingerprint,
+    skillsbench_setup_failure_category,
+)
+
+
+SCHEMA_VERSION = "skillsbench_setup_only_public_preflight_v0"
+_PATCH_SUFFIX = "_patch_applied"
+
+
+def _patch_hits(task_staging: Mapping[str, Any] | None) -> list[str]:
+    staging = task_staging or {}
+    return sorted(
+        key.removesuffix(_PATCH_SUFFIX)
+        for key, value in staging.items()
+        if isinstance(key, str) and key.endswith(_PATCH_SUFFIX) and value is True
+    )
+
+
+def _exit_category(exc: Exception, matched_patterns: set[str]) -> str:
+    if (
+        isinstance(exc, (asyncio.TimeoutError, TimeoutError))
+        or "timeout" in matched_patterns
+    ):
+        return "timeout"
+    if isinstance(exc, PermissionError) or "permission_denied" in matched_patterns:
+        return "permission_denied"
+    if {
+        "docker_daemon_unavailable",
+        "docker_api_version_mismatch",
+        "docker_compose_plugin_unavailable",
+    } & matched_patterns:
+        return "runtime_unavailable"
+    if {
+        "docker_compose_command_failed",
+        "image_build",
+        "apt_failure",
+        "pip_bootstrap_failure",
+        "volume_mount_failure",
+    } & matched_patterns:
+        return "setup_command_failed"
+    if isinstance(exc, FileNotFoundError) or "missing_file" in matched_patterns:
+        return "missing_input"
+    return "exception"
+
+
+def _base_result(
+    *,
+    task_staging: Mapping[str, Any] | None,
+    setup_preflight: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    setup = setup_preflight or {}
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "running",
+        "stage": "rollout_create",
+        "job_root_materialized": False,
+        "environment_object_materialized": False,
+        "environment_started": False,
+        "agent_install_invoked": False,
+        "agent_execution_invoked": False,
+        "verifier_invoked": False,
+        "dependency_classes": [],
+        "failure_category": "none",
+        "exit_category": "pending",
+        "patch_hits": _patch_hits(task_staging),
+        "apt_setup_risk_detected": setup.get("apt_setup_risk_detected") is True,
+        "dockerfile_pip_install_risk_detected": (
+            setup.get("dockerfile_pip_install_risk_detected") is True
+        ),
+        "verifier_bootstrap_risk_detected": (
+            setup.get("verifier_bootstrap_risk_detected") is True
+        ),
+        "cleanup_status": "not_started",
+        "raw_error_recorded": False,
+        "raw_logs_read": False,
+        "raw_logs_recorded": False,
+        "raw_task_text_read": False,
+        "raw_trajectory_read": False,
+        "raw_verifier_output_read": False,
+        "host_paths_recorded": False,
+        "secret_values_recorded": False,
+    }
+
+
+async def run_setup_only_public_preflight(
+    *,
+    rollout_type: Any,
+    config: Any,
+    task_staging: Mapping[str, Any] | None = None,
+    setup_preflight: Mapping[str, Any] | None = None,
+    stage_timeout_sec: float,
+    cleanup_timeout_sec: float = 30.0,
+) -> dict[str, Any]:
+    """Materialize a BenchFlow environment without installing or running an agent."""
+
+    result = _base_result(
+        task_staging=task_staging,
+        setup_preflight=setup_preflight,
+    )
+    stage_timeout_sec = max(1.0, stage_timeout_sec)
+    cleanup_timeout_sec = max(1.0, cleanup_timeout_sec)
+    rollout: Any | None = None
+    failed = False
+    try:
+        rollout = await asyncio.wait_for(
+            rollout_type.create(config),
+            timeout=stage_timeout_sec,
+        )
+        result["stage"] = "rollout_setup"
+        await asyncio.wait_for(rollout.setup(), timeout=stage_timeout_sec)
+        result["job_root_materialized"] = (
+            getattr(rollout, "_rollout_dir", None) is not None
+        )
+        result["environment_object_materialized"] = (
+            getattr(rollout, "env", None) is not None
+        )
+
+        result["stage"] = "environment_start"
+        await asyncio.wait_for(rollout.start(), timeout=stage_timeout_sec)
+        result["environment_started"] = True
+        result["status"] = "passed"
+        result["stage"] = "environment_ready_before_agent"
+        result["exit_category"] = "passed"
+    except Exception as exc:
+        failed = True
+        if rollout is not None:
+            result["job_root_materialized"] = (
+                getattr(rollout, "_rollout_dir", None) is not None
+            )
+            result["environment_object_materialized"] = (
+                getattr(rollout, "env", None) is not None
+            )
+        fingerprint = skillsbench_runner_error_fingerprint(str(exc))
+        matched_patterns = {
+            str(item)
+            for item in fingerprint.get("matched_patterns", [])
+            if isinstance(item, str)
+        }
+        result["status"] = "failed"
+        result["failure_stage"] = result["stage"]
+        result["failure_category"] = skillsbench_setup_failure_category(fingerprint)
+        result["exit_category"] = _exit_category(exc, matched_patterns)
+        result["dependency_classes"] = [
+            str(item)
+            for item in fingerprint.get("failure_line_dependency_classes", [])
+            if isinstance(item, str)
+        ]
+        result["fingerprint_patterns"] = sorted(matched_patterns)
+        result["fingerprint_confidence"] = str(
+            fingerprint.get("fingerprint_confidence")
+            or "coarse_public_safe_pattern_match"
+        )
+    finally:
+        if rollout is not None:
+            try:
+                await asyncio.wait_for(
+                    rollout.cleanup(),
+                    timeout=cleanup_timeout_sec,
+                )
+                result["cleanup_status"] = "completed"
+            except Exception:
+                result["cleanup_status"] = "failed"
+                if not failed:
+                    result["status"] = "failed"
+                    result["failure_stage"] = "cleanup"
+                    result["failure_category"] = "skillsbench_setup_cleanup_failure"
+                    result["exit_category"] = "cleanup_failed"
+        else:
+            result["cleanup_status"] = "not_required"
+    return result

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -35,6 +35,10 @@ Optional env:
                                        Set to 1 to let the runner stage an
                                        isolated task copy and apply its
                                        public-safe setup bootstrap repairs
+  SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT
+                                       Set to 1 to stop after real job-root and
+                                       environment materialization, before any
+                                       agent or verifier lifecycle
   SKILLSBENCH_BUILD_STALL_TIMEOUT_SEC  Setup stall timeout, default 3600;
                                        0 disables cap
   SKILLSBENCH_RUN_TIMEOUT_SEC          Supervisor timeout, default 28800
@@ -144,6 +148,7 @@ fi
 skip_global_ledger_sync="${SKILLSBENCH_SKIP_GLOBAL_LEDGER_SYNC:-0}"
 skip_current_aggregate_update="${SKILLSBENCH_SKIP_CURRENT_AGGREGATE_UPDATE:-0}"
 allow_staged_bootstrap_repair_run="${SKILLSBENCH_ALLOW_STAGED_BOOTSTRAP_REPAIR_RUN:-0}"
+setup_only_public_preflight="${SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT:-0}"
 validate_bool_toggle() {
   local env_name="$1"
   local value="$2"
@@ -157,11 +162,13 @@ validate_bool_toggle \
   SKILLSBENCH_SKIP_CURRENT_AGGREGATE_UPDATE "$skip_current_aggregate_update"
 validate_bool_toggle \
   SKILLSBENCH_ALLOW_STAGED_BOOTSTRAP_REPAIR_RUN "$allow_staged_bootstrap_repair_run"
+validate_bool_toggle \
+  SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT "$setup_only_public_preflight"
 remote_codex_bin_mode="path_lookup"
 if [[ -n "${SKILLSBENCH_REMOTE_CODEX_BIN:-}" ]]; then
   remote_codex_bin_mode="explicit"
 fi
-if [[ "$dry_run" == "false" ]]; then
+if [[ "$dry_run" == "false" && "$setup_only_public_preflight" != "1" ]]; then
   if [[ "$remote_codex_bin" == */* ]]; then
     printf -v remote_codex_probe \
       'test -x %q && %q --version >/dev/null 2>&1' \
@@ -296,6 +303,9 @@ fi
 if [[ "$allow_staged_bootstrap_repair_run" == "1" ]]; then
   extra_runner_args+=(--allow-staged-bootstrap-repair-run)
 fi
+if [[ "$setup_only_public_preflight" == "1" ]]; then
+  extra_runner_args+=(--setup-only-public-preflight)
+fi
 if [[ -n "${SKILLSBENCH_REGISTRY:-}" ]]; then
   extra_runner_args+=(--registry "$SKILLSBENCH_REGISTRY")
 fi
@@ -388,30 +398,35 @@ supervisor_cmd=(
   --remote-command "$remote_command"
   --remote-public-artifact-root "${SKILLSBENCH_REMOTE_ROOT}/.local/private-benchmark-jobs"
   --remote-public-artifact-glob "${job_name}*/runner_prerequisites.public.json"
+  --remote-public-artifact-glob "${job_name}*/setup_only_preflight.public.json"
   --remote-public-artifact-glob "${job_name}*/loopx_controller_trace.public.json"
   --remote-public-artifact-glob "${job_name}*/runner_config.public.json"
   --remote-public-artifact-glob "${job_name}*/*/benchmark_run.compact.json"
   --remote-public-artifact-glob "${job_name}*/host_local_acp_relay_traces/*.compact.json"
   --local-public-artifact-dir "$public_dir"
-  --local-run-ledger-path "$local_run_ledger"
-  --local-run-group-id "$run_group"
-  --local-ledger-catchup-root "$public_root"
-  --local-ledger-catchup-run-group-contains "$ledger_catchup_group"
   --private-log-path "${private_dir}/remote-command.log"
   --public-output-path "${public_dir}/supervisor.public.json"
 )
 
-if [[ "$dry_run" == "false" && ! -f "$local_run_ledger" && -n "${SKILLSBENCH_LOCAL_RUN_LEDGER_SEED:-}" ]]; then
-  mkdir -p "$(dirname "$local_run_ledger")"
-  cp "$SKILLSBENCH_LOCAL_RUN_LEDGER_SEED" "$local_run_ledger"
-fi
-if [[ -n "${SKILLSBENCH_CANONICAL_CASE_IDS_FILE:-}" ]]; then
-  standard_aggregate="${SKILLSBENCH_STANDARD_AGGREGATE_PATH:-$(dirname "$local_run_ledger")/standard-current-aggregate.json}"
+if [[ "$setup_only_public_preflight" != "1" ]]; then
   supervisor_cmd+=(
-    --local-current-aggregate-path "$standard_aggregate"
-    --local-canonical-case-ids-file "$SKILLSBENCH_CANONICAL_CASE_IDS_FILE"
-    --local-target-lane-id codex-cli-goal-xhigh
+    --local-run-ledger-path "$local_run_ledger"
+    --local-run-group-id "$run_group"
+    --local-ledger-catchup-root "$public_root"
+    --local-ledger-catchup-run-group-contains "$ledger_catchup_group"
   )
+  if [[ "$dry_run" == "false" && ! -f "$local_run_ledger" && -n "${SKILLSBENCH_LOCAL_RUN_LEDGER_SEED:-}" ]]; then
+    mkdir -p "$(dirname "$local_run_ledger")"
+    cp "$SKILLSBENCH_LOCAL_RUN_LEDGER_SEED" "$local_run_ledger"
+  fi
+  if [[ -n "${SKILLSBENCH_CANONICAL_CASE_IDS_FILE:-}" ]]; then
+    standard_aggregate="${SKILLSBENCH_STANDARD_AGGREGATE_PATH:-$(dirname "$local_run_ledger")/standard-current-aggregate.json}"
+    supervisor_cmd+=(
+      --local-current-aggregate-path "$standard_aggregate"
+      --local-canonical-case-ids-file "$SKILLSBENCH_CANONICAL_CASE_IDS_FILE"
+      --local-target-lane-id codex-cli-goal-xhigh
+    )
+  fi
 fi
 
 if [[ "$dry_run" == "true" ]]; then
@@ -430,6 +445,7 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'local_codex_sandbox=%s\n' "$local_codex_sandbox"
   printf 'codex_cli_goal_thread_prewarm=%s\n' "$codex_cli_goal_thread_prewarm"
   printf 'allow_staged_bootstrap_repair_run=%s\n' "$allow_staged_bootstrap_repair_run"
+  printf 'setup_only_public_preflight=%s\n' "$setup_only_public_preflight"
   printf 'skip_global_ledger_sync=%s\n' "$skip_global_ledger_sync"
   printf 'skip_current_aggregate_update=%s\n' "$skip_current_aggregate_update"
   printf 'local_run_ledger=%s\n' "$local_run_ledger"
@@ -481,4 +497,5 @@ remote_codex_bin_mode=${remote_codex_bin_mode}
 local_codex_sandbox=${local_codex_sandbox}
 codex_cli_goal_thread_prewarm=${codex_cli_goal_thread_prewarm}
 allow_staged_bootstrap_repair_run=${allow_staged_bootstrap_repair_run}
+setup_only_public_preflight=${setup_only_public_preflight}
 EOF

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -140,6 +140,9 @@ from loopx.benchmark_adapters.skillsbench_remote_bridge import (  # noqa: E402
     run_skillsbench_remote_command_file_bridge_probe,
     skillsbench_remote_command_file_bridge_command_is_fixture_probe,
 )
+from loopx.benchmark_adapters.skillsbench_setup_preflight import (  # noqa: E402
+    run_setup_only_public_preflight,
+)
 from loopx.benchmark_core import (  # noqa: E402
     build_benchmark_launch_observable_handle,
     canonical_lifecycle,
@@ -1139,6 +1142,8 @@ def _effective_local_codex_task_output_quiet_timeout_sec(
 
 
 def _codex_api_egress_preflight_required(args: argparse.Namespace) -> bool:
+    if bool(getattr(args, "setup_only_public_preflight", False)):
+        return False
     if not bool(getattr(args, "host_local_acp_launch", False)):
         return False
     requested = _codex_api_egress_requested_mode(args)
@@ -1995,6 +2000,8 @@ def _host_local_acp_codex_exec_preflight_should_run(
 ) -> bool:
     """Return whether the host-local Codex exec path must be probed first."""
 
+    if bool(getattr(args, "setup_only_public_preflight", False)):
+        return False
     route = str(getattr(args, "route", "") or "")
     if bool(getattr(args, "host_local_acp_launch", False)) and route in {
         CODEX_APP_SERVER_GOAL_BASELINE_ROUTE,
@@ -8083,6 +8090,9 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
     jobs_dir = Path(args.jobs_dir).expanduser()
     result_path = jobs_dir / job_name / rollout_name / "result.json"
     compact_path = jobs_dir / job_name / rollout_name / "benchmark_run.compact.json"
+    setup_only_preflight_path = (
+        jobs_dir / job_name / "setup_only_preflight.public.json"
+    )
     controller_trace_path = jobs_dir / job_name / "loopx_controller_trace.public.json"
     app_server_goal_worker_trace_dir = (
         jobs_dir / job_name / "app_server_goal_worker_traces"
@@ -8344,6 +8354,10 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         "rollout_name": rollout_name,
         "result_json": str(result_path),
         "compact_benchmark_run_json": str(compact_path),
+        "setup_only_public_preflight": bool(
+            getattr(args, "setup_only_public_preflight", False)
+        ),
+        "setup_only_public_preflight_json": str(setup_only_preflight_path),
         "controller_trace_json": str(controller_trace_path),
         "build_stall_timeout_requested_sec": _requested_build_stall_timeout_sec(args),
         "build_stall_timeout_sec": _effective_build_stall_timeout_sec(args),
@@ -9230,7 +9244,24 @@ def _write_public_runner_config(plan: dict[str, Any]) -> Path | None:
 async def run_benchflow_case_with_private_output(
     args: argparse.Namespace,
     plan: dict[str, Any],
-) -> Path:
+) -> Path | dict[str, Any]:
+    if getattr(args, "setup_only_public_preflight", False):
+        plan["runner_output_capture"] = {
+            "schema_version": "skillsbench_runner_output_capture_v0",
+            "enabled": False,
+            "stdout_stderr_redirected": True,
+            "output_policy": "discard",
+            "raw_output_public": False,
+            "private_log_created": False,
+            "private_log_path_public": False,
+        }
+        with open(os.devnull, "w", encoding="utf-8") as stream:
+            with redirect_stdout(stream), redirect_stderr(stream):
+                with _benchmark_egress_proxy_env_applied(args, plan=plan):
+                    _write_public_runner_config(plan)
+                    _write_public_runner_prerequisites(plan)
+                    return await run_benchflow_case(args, plan)
+
     log_path = _private_runner_output_log_path(plan)
     log_path.parent.mkdir(parents=True, exist_ok=True)
     plan["runner_output_capture"] = {
@@ -13193,7 +13224,10 @@ def _build_product_mode_user(
     return ProductModeUser()
 
 
-async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> Path:
+async def run_benchflow_case(
+    args: argparse.Namespace,
+    plan: dict[str, Any],
+) -> Path | dict[str, Any]:
     prerequisites = plan.setdefault("runner_prerequisites", {})
     prerequisites["benchflow_run_stage"] = "entered"
     source_fingerprint = plan.get("loopx_runner_source_fingerprint")
@@ -13929,10 +13963,13 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
             await run_codex_acp_launch_preflight(env)
         return result
 
+    setup_only_public_preflight = bool(
+        getattr(args, "setup_only_public_preflight", False)
+    )
     controller_user = None
     controller_trace: dict[str, Any] | None = None
     product_mode_case_payload: dict[str, Any] | None = None
-    if _is_loopx_product_mode_route(args.route):
+    if not setup_only_public_preflight and _is_loopx_product_mode_route(args.route):
         product_mode_case_payload = benchmark_case_loopx_install_payload(
             benchmark_id="skillsbench",
             case_id=args.task_id,
@@ -13942,7 +13979,7 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
             case_loopx_source_path=_loopx_case_source_path_for_container(args),
             goal_start_product_mode=_is_goal_start_product_mode_route(args.route),
         )
-    if args.route in {
+    if not setup_only_public_preflight and args.route in {
         CODEX_ACP_BLIND_LOOP_BASELINE_ROUTE,
         LOOPX_BLIND_LOOP_TREATMENT_ROUTE,
         LOOPX_PROMPT_POLLING_TEST_ROUTE,
@@ -13954,7 +13991,7 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
             trace=controller_trace,
             treatment_prompt_style=args.treatment_prompt_style,
         )
-    elif args.route in PRODUCT_MODE_CONTROLLER_ROUTES:
+    elif not setup_only_public_preflight and args.route in PRODUCT_MODE_CONTROLLER_ROUTES:
         controller_trace = _new_controller_trace(args.route, max_rounds=args.max_rounds)
         controller_user = _build_product_mode_user(
             route=args.route,
@@ -13963,10 +14000,13 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
             plan=plan,
             case_payload=product_mode_case_payload,
         )
-    elif args.route == CODEX_CLI_GOAL_BASELINE_ROUTE:
+    elif not setup_only_public_preflight and args.route == CODEX_CLI_GOAL_BASELINE_ROUTE:
         controller_trace = _new_controller_trace(args.route, max_rounds=args.max_rounds)
         controller_trace["last_decision"] = "host_codex_cli_tui_goal_worker_selected"
-    elif args.route == CODEX_APP_SERVER_GOAL_BASELINE_ROUTE:
+    elif (
+        not setup_only_public_preflight
+        and args.route == CODEX_APP_SERVER_GOAL_BASELINE_ROUTE
+    ):
         controller_trace = _new_controller_trace(args.route, max_rounds=args.max_rounds)
         _apply_app_server_goal_round_semantics_to_controller_trace(
             controller_trace,
@@ -13996,12 +14036,14 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
 
     pre_agent_hooks = (
         []
-        if args.host_local_acp_launch
+        if setup_only_public_preflight
+        or args.host_local_acp_launch
         or args.require_preinstalled_benchflow_agent_runtime
         else [ensure_codex_acp_runtime_deps]
     )
     if _is_loopx_product_mode_route(args.route) and not args.host_local_acp_launch:
-        pre_agent_hooks.append(seed_product_mode_case_state)
+        if not setup_only_public_preflight:
+            pre_agent_hooks.append(seed_product_mode_case_state)
 
     agent_env: dict[str, str] = {}
     if runtime_mounts:
@@ -14138,11 +14180,25 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
             and original_rollout_planes_class_connect_acp is not None
         ):
             rollout_planes_class.connect_acp = connect_host_local_acp_method
+    setup_only_result: dict[str, Any] | None = None
     try:
-        await run_benchflow_with_setup_stall_watchdog()
-        result_path = discover_benchflow_result_path(plan)
-        if result_path.exists():
-            _merge_final_result_round_reward(controller_trace, result_path)
+        if setup_only_public_preflight:
+            setup_only_result = await run_setup_only_public_preflight(
+                rollout_type=Rollout,
+                config=config,
+                task_staging=plan.get("task_staging"),
+                setup_preflight=plan.get("task_setup_preflight"),
+                stage_timeout_sec=float(args.sandbox_setup_timeout),
+            )
+            plan["setup_only_public_preflight_result"] = setup_only_result
+            prerequisites["benchflow_run_stage"] = str(
+                setup_only_result.get("stage") or "setup_only_preflight_complete"
+            )
+        else:
+            await run_benchflow_with_setup_stall_watchdog()
+            result_path = discover_benchflow_result_path(plan)
+            if result_path.exists():
+                _merge_final_result_round_reward(controller_trace, result_path)
     finally:
         Rollout.install_agent = original_install_agent
         Rollout._run_user_loop = original_user_loop
@@ -14181,6 +14237,8 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
         _merge_app_server_goal_worker_trace_summary(plan, controller_trace)
         _merge_host_local_acp_relay_trace_summary(plan, controller_trace)
         _write_controller_trace(plan, controller_trace)
+    if setup_only_result is not None:
+        return setup_only_result
     if result_path is None:
         result_path = discover_benchflow_result_path(plan)
     if not result_path.exists():
@@ -15765,6 +15823,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Print launch plan without importing BenchFlow or running a task.",
     )
     parser.add_argument(
+        "--setup-only-public-preflight",
+        action="store_true",
+        help=(
+            "Materialize the BenchFlow job root and environment, then stop "
+            "before agent install, agent execution, and verification. Emit only "
+            "a compact public-safe setup classification."
+        ),
+    )
+    parser.add_argument(
         "--reduce-only",
         action="store_true",
         help="Reduce an existing result.json for the selected job without rerunning the task.",
@@ -16140,6 +16207,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     apt_fail_fast_explicit = "--fail-fast-on-apt-risk" in raw_argv
     verifier_fail_fast_explicit = "--fail-fast-on-verifier-bootstrap-risk" in raw_argv
     args = parser.parse_args(raw_argv)
+    if args.setup_only_public_preflight and (args.plan_only or args.reduce_only):
+        parser.error(
+            "--setup-only-public-preflight is incompatible with --plan-only "
+            "and --reduce-only"
+        )
+    if args.setup_only_public_preflight and (args.append_history or args.update_ledger):
+        parser.error(
+            "--setup-only-public-preflight does not append history or update ledgers"
+        )
     default_ledger = (
         PUBLIC_BENCHMARK_RUN_LEDGER if args.publish_public_ledger else DEFAULT_LEDGER
     )
@@ -16188,6 +16264,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     if args.independent_goal_retries < 1:
         parser.error("--independent-goal-retries must be >= 1")
     if args.independent_goal_retries > 1:
+        if args.setup_only_public_preflight:
+            parser.error(
+                "--setup-only-public-preflight does not use independent goal retries"
+            )
         if args.route not in INDEPENDENT_GOAL_RETRY_ROUTES:
             parser.error(
                 "--independent-goal-retries currently applies only to "
@@ -16204,6 +16284,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         args.route in PRODUCT_MODE_CONTROLLER_ROUTES
         and not args.plan_only
         and not args.reduce_only
+        and not args.setup_only_public_preflight
         and args.max_rounds < PRODUCT_MODE_MIN_FORMAL_MAX_ROUNDS
     ):
         parser.error(
@@ -16269,6 +16350,7 @@ async def _async_main_with_observable_handle(
     )
     if (
         getattr(args, "require_preinstalled_benchflow_agent_runtime", False)
+        and not args.setup_only_public_preflight
         and runtime_layer.get("ready") is not True
     ):
         prerequisites = plan.setdefault("runner_prerequisites", {})
@@ -16382,6 +16464,7 @@ async def _async_main_with_observable_handle(
     if (
         _codex_api_egress_preflight_required(args)
         and not args.reduce_only
+        and not args.setup_only_public_preflight
     ):
         try:
             _run_codex_api_egress_preflight(args, plan)
@@ -16400,6 +16483,7 @@ async def _async_main_with_observable_handle(
         _host_local_acp_codex_exec_preflight_should_run(args)
         and args.host_local_acp_launch
         and not args.reduce_only
+        and not args.setup_only_public_preflight
     ):
         _run_host_local_acp_codex_exec_preflight(args, plan)
 
@@ -16417,10 +16501,43 @@ async def _async_main_with_observable_handle(
         _merge_final_result_round_reward(controller_trace, result_path)
         _write_controller_trace(plan, controller_trace)
     else:
-        result_path = await asyncio.wait_for(
+        case_result = await asyncio.wait_for(
             run_benchflow_case_with_private_output(args, plan),
             timeout=args.outer_timeout_sec,
         )
+        if args.setup_only_public_preflight:
+            if not isinstance(case_result, dict):
+                raise TypeError("setup-only preflight returned a non-object result")
+            preflight_path = Path(plan["setup_only_public_preflight_json"])
+            preflight_path.parent.mkdir(parents=True, exist_ok=True)
+            preflight_path.write_text(
+                json.dumps(
+                    case_result,
+                    indent=2,
+                    sort_keys=True,
+                    default=_json_default,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            _write_public_runner_config(plan)
+            _write_public_runner_prerequisites(plan)
+            passed = case_result.get("status") == "passed"
+            return {
+                "ok": passed,
+                "setup_only_public_preflight": True,
+                "task_id": str(args.task_id),
+                "route": str(args.route),
+                "run_group_id": str(args.run_group_id or ""),
+                "job_name": str(plan.get("job_name") or ""),
+                "preflight": case_result,
+                "setup_only_public_preflight_json": preflight_path.name,
+                "compact_closeout_recorded": True,
+                "runner_returncode": 0 if passed else 1,
+            }
+        if not isinstance(case_result, Path):
+            raise TypeError("SkillsBench case returned a non-path result")
+        result_path = case_result
     compact = reduce_result(args, result_path, plan)
     compact_path = Path(plan["compact_benchmark_run_json"])
     compact_path.parent.mkdir(parents=True, exist_ok=True)
@@ -16583,7 +16700,7 @@ async def async_batch_main(
                         case_start_wait_sec,
                     )
                 payload = await async_main(case_args, plan=case_plan)
-                payload["runner_returncode"] = 0
+                payload.setdefault("runner_returncode", 0)
                 return case_start_pacer.annotate_payload(payload, case_start_wait_sec)
             except Exception as exc:
                 payload, returncode = _build_runner_exception_closeout_payload(
@@ -16869,6 +16986,7 @@ def main(argv: list[str] | None = None) -> int:
         args.route == CODEX_APP_SERVER_GOAL_BASELINE_ROUTE
         and not args.plan_only
         and not args.reduce_only
+        and not args.setup_only_public_preflight
         and not args.allow_deprecated_app_server_goal_route
     ):
         payload = {
@@ -16895,6 +17013,7 @@ def main(argv: list[str] | None = None) -> int:
         args.route == CODEX_CLI_GOAL_BASELINE_ROUTE
         and not args.plan_only
         and not args.reduce_only
+        and not args.setup_only_public_preflight
     ):
         bridge_ready = bool(
             args.remote_command_file_bridge_ready
@@ -16946,6 +17065,7 @@ def main(argv: list[str] | None = None) -> int:
         args.route == CODEX_APP_SERVER_GOAL_BASELINE_ROUTE
         and not args.plan_only
         and not args.reduce_only
+        and not args.setup_only_public_preflight
     ):
         bridge_ready = bool(
             args.remote_command_file_bridge_ready
@@ -17015,6 +17135,7 @@ def main(argv: list[str] | None = None) -> int:
         and not args.local_driver_worker_handshake_preflight
         and not args.plan_only
         and not args.reduce_only
+        and not args.setup_only_public_preflight
     ):
         payload = {
             "ok": False,
@@ -17051,6 +17172,7 @@ def main(argv: list[str] | None = None) -> int:
         and product_host_local_bridge_fixture_solver
         and not args.local_driver_worker_handshake_preflight
         and not args.plan_only
+        and not args.setup_only_public_preflight
     ):
         payload = {
             "ok": False,
@@ -17094,6 +17216,7 @@ def main(argv: list[str] | None = None) -> int:
         )
         and not args.local_driver_worker_handshake_preflight
         and not args.plan_only
+        and not args.setup_only_public_preflight
     ):
         payload = {
             "ok": False,

--- a/tests/test_skillsbench_setup_preflight.py
+++ b/tests/test_skillsbench_setup_preflight.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from loopx.benchmark_adapters.skillsbench_codex_runtime import preflight_required
+from loopx.benchmark_adapters.skillsbench_setup_preflight import (
+    run_setup_only_public_preflight,
+)
+from scripts.skillsbench_automation_loop import build_plan, parse_args
+
+
+class FakeRollout:
+    failure_stage = ""
+    failure: Exception | None = None
+    events: list[str] = []
+
+    def __init__(self) -> None:
+        self._rollout_dir: object | None = None
+        self.env: object | None = None
+
+    @classmethod
+    async def create(cls, _config: Any) -> "FakeRollout":
+        cls.events.append("create")
+        if cls.failure_stage == "rollout_create" and cls.failure is not None:
+            raise cls.failure
+        return cls()
+
+    async def setup(self) -> None:
+        self.events.append("setup")
+        if self.failure_stage == "rollout_setup" and self.failure is not None:
+            raise self.failure
+        self._rollout_dir = object()
+        self.env = object()
+
+    async def start(self) -> None:
+        self.events.append("start")
+        if self.failure_stage == "environment_start" and self.failure is not None:
+            raise self.failure
+
+    async def cleanup(self) -> None:
+        self.events.append("cleanup")
+        if self.failure_stage == "cleanup" and self.failure is not None:
+            raise self.failure
+
+
+@pytest.fixture(autouse=True)
+def reset_fake_rollout() -> None:
+    FakeRollout.failure_stage = ""
+    FakeRollout.failure = None
+    FakeRollout.events = []
+
+
+def run_preflight() -> dict[str, Any]:
+    return asyncio.run(
+        run_setup_only_public_preflight(
+            rollout_type=FakeRollout,
+            config=object(),
+            task_staging={
+                "apt_retry_patch_applied": True,
+                "dockerfile_pip_bootstrap_patch_applied": True,
+                "unrelated": "/private/should-not-project",
+            },
+            setup_preflight={
+                "apt_setup_risk_detected": True,
+                "dockerfile_pip_install_risk_detected": True,
+                "verifier_bootstrap_risk_detected": False,
+            },
+            stage_timeout_sec=1,
+        )
+    )
+
+
+def test_setup_only_preflight_stops_before_agent_and_verifier() -> None:
+    result = run_preflight()
+
+    assert result["status"] == "passed"
+    assert result["stage"] == "environment_ready_before_agent"
+    assert result["job_root_materialized"] is True
+    assert result["environment_object_materialized"] is True
+    assert result["environment_started"] is True
+    assert result["agent_install_invoked"] is False
+    assert result["agent_execution_invoked"] is False
+    assert result["verifier_invoked"] is False
+    assert result["patch_hits"] == [
+        "apt_retry",
+        "dockerfile_pip_bootstrap",
+    ]
+    assert FakeRollout.events == ["create", "setup", "start", "cleanup"]
+    serialized = json.dumps(result, sort_keys=True)
+    assert "/private/" not in serialized
+    assert "should-not-project" not in serialized
+
+
+def test_setup_only_runner_mode_bypasses_formal_round_budget() -> None:
+    args = parse_args(
+        [
+            "--task-id",
+            "flink-query",
+            "--route",
+            "loopx-goal-start-product-mode",
+            "--setup-only-public-preflight",
+            "--max-rounds",
+            "1",
+        ]
+    )
+
+    plan = build_plan(args)
+    assert args.setup_only_public_preflight is True
+    assert plan["setup_only_public_preflight"] is True
+    assert plan["setup_only_public_preflight_json"].endswith(
+        "setup_only_preflight.public.json"
+    )
+
+
+def test_launcher_syncs_setup_only_public_artifact() -> None:
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "scripts"
+        / "skillsbench-launch-goal-xhigh.sh"
+    ).read_text(encoding="utf-8")
+
+    assert (
+        '--remote-public-artifact-glob "${job_name}*/setup_only_preflight.public.json"'
+        in source
+    )
+    closeout_guard = 'if [[ "$setup_only_public_preflight" != "1" ]]; then'
+    assert closeout_guard in source
+    assert source.index(closeout_guard) < source.index("--local-run-ledger-path")
+
+
+def test_setup_only_mode_does_not_require_host_codex_preflight() -> None:
+    args = parse_args(
+        [
+            "--task-id",
+            "flink-query",
+            "--route",
+            "loopx-goal-start-product-mode",
+            "--setup-only-public-preflight",
+            "--host-local-acp-launch",
+        ]
+    )
+
+    assert preflight_required(args) is False
+    plan = build_plan(args)
+    assert plan["codex_api_egress_preflight"]["status"] == "not_required"
+
+
+@pytest.mark.parametrize(
+    ("message", "category", "dependency_classes"),
+    [
+        (
+            "Docker compose command failed. ERROR: failed to solve: process "
+            "/bin/sh -c apt-get update did not complete successfully: "
+            "failed to fetch package index",
+            "skillsbench_docker_compose_apt_repository_failure",
+            ["system_package"],
+        ),
+        (
+            "Docker compose command failed. ERROR: failed to solve: process "
+            "/bin/sh -c pip3 install numpy did not complete successfully: "
+            "max retries exceeded for pypi.org",
+            "skillsbench_docker_compose_pip_bootstrap_failure",
+            ["python_package"],
+        ),
+        (
+            "Docker compose command failed: invalid mount config for type "
+            "bind: bind source path does not exist",
+            "skillsbench_docker_compose_volume_mount_failure",
+            [],
+        ),
+    ],
+)
+def test_setup_only_preflight_classifies_public_setup_failures(
+    message: str,
+    category: str,
+    dependency_classes: list[str],
+) -> None:
+    FakeRollout.failure_stage = "environment_start"
+    FakeRollout.failure = RuntimeError(message)
+
+    result = run_preflight()
+
+    assert result["status"] == "failed"
+    assert result["failure_stage"] == "environment_start"
+    assert result["failure_category"] == category
+    assert result["dependency_classes"] == dependency_classes
+    assert result["exit_category"] == "setup_command_failed"
+    assert result["cleanup_status"] == "completed"
+    serialized = json.dumps(result, sort_keys=True)
+    assert message not in serialized
+    assert result["raw_error_recorded"] is False
+    assert result["raw_logs_read"] is False
+
+
+def test_setup_only_preflight_reports_cleanup_failure_without_raw_error() -> None:
+    FakeRollout.failure_stage = "cleanup"
+    FakeRollout.failure = RuntimeError("secret cleanup detail /private/job")
+
+    result = run_preflight()
+
+    assert result["status"] == "failed"
+    assert result["failure_stage"] == "cleanup"
+    assert result["failure_category"] == "skillsbench_setup_cleanup_failure"
+    assert result["exit_category"] == "cleanup_failed"
+    assert result["cleanup_status"] == "failed"
+    assert "secret cleanup detail" not in json.dumps(result, sort_keys=True)


### PR DESCRIPTION
## Summary
- add a real BenchFlow setup-only preflight that materializes the job root and environment, then stops before agent install, agent execution, and verification
- emit only normalized setup stages, dependency classes, patch hits, exit categories, and explicit public/private boundary flags
- expose the mode through the SkillsBench launcher and sync its public artifact without requiring benchmark compact or ledger closeout

## Validation
- focused setup-only tests and existing Codex preflight tests
- SkillsBench runner, attribution, setup-timeout, source, egress, task-source, and host-launch smokes
- LoopX standard premerge canary: all automated checks passed; expected benchmark-sensitive maintainer hold remains
- live setup-only validation classified financial-modeling-qa as pip bootstrap failure and flink-query as apt repository failure; both stopped before agent/verifier and cleaned up

## Boundaries
- no scoring, task semantics, leaderboard, submission, permission, or benchmark launch behavior changes
- no raw task text, logs, trajectories, verifier output, credentials, or host paths are projected