### PR TITLE
Productize runtime projection routes

### DIFF
--- a/examples/control_plane/refresh-state-shared-runtime-projection-smoke.py
+++ b/examples/control_plane/refresh-state-shared-runtime-projection-smoke.py
@@ -19,6 +19,14 @@ from loopx.control_plane.runtime.shared_runtime_refresh_projection import (  # n
     build_shared_runtime_projection,
     write_shared_runtime_projection,
 )
+from loopx.control_plane.runtime import runtime_projection_route as route_module  # noqa: E402
+from loopx.control_plane.runtime.runtime_projection_route import (  # noqa: E402
+    compact_runtime_projection_route,
+    resolve_runtime_projection_route,
+)
+from loopx.presentation.renderers.status_markdown import (  # noqa: E402
+    render_status_markdown,
+)
 
 
 AGENT_ID = "codex-shared-runtime-smoke"
@@ -40,6 +48,25 @@ def run_cli(*args: str, cwd: Path, shared_runtime: Path) -> dict:
         },
     )
     assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict), payload
+    return payload
+
+
+def run_cli_failure(*args: str, cwd: Path, shared_runtime: Path) -> dict:
+    result = subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--format", "json", *args],
+        cwd=cwd,
+        check=False,
+        text=True,
+        capture_output=True,
+        env={
+            **os.environ,
+            "PYTHONPATH": str(REPO_ROOT),
+            "LOOPX_RUNTIME_ROOT": str(shared_runtime),
+        },
+    )
+    assert result.returncode != 0, result.stdout + result.stderr
     payload = json.loads(result.stdout)
     assert isinstance(payload, dict), payload
     return payload
@@ -109,6 +136,81 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
     return project, project_runtime, source_registry, shared_registry
 
 
+def write_route_source(
+    root: Path,
+    *,
+    name: str,
+    source_runtime: Path,
+) -> tuple[Path, str]:
+    goal_id = f"runtime-route-{name}"
+    registry = root / name / "registry.json"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    state_file = registry.parent / "goals" / goal_id / "ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(
+        "---\nstatus: active\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n\n"
+        f"# {goal_id}\n\n## Agent Todo\n\n- [ ] [P1] Verify route behavior.\n",
+        encoding="utf-8",
+    )
+    registry.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "common_runtime_root": str(source_runtime),
+                "goals": [
+                    {
+                        "id": goal_id,
+                        "status": "active",
+                        "repo": str(registry.parent),
+                        "state_file": str(state_file.relative_to(registry.parent)),
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry, goal_id
+
+
+def write_route_target(
+    target_runtime: Path,
+    *,
+    source_registry: Path,
+    goal_id: str,
+    include_route: bool = True,
+) -> None:
+    target_registry = target_runtime / "registry.global.json"
+    target_registry.parent.mkdir(parents=True, exist_ok=True)
+    goals = (
+        [
+            {
+                "id": goal_id,
+                "status": "active",
+                "source_registry": str(source_registry.resolve()),
+            }
+        ]
+        if include_route
+        else []
+    )
+    target_registry.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "registry_role": "global-local",
+                "common_runtime_root": str(target_runtime),
+                "goals": goals,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
 def main() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-refresh-shared-runtime-") as tmp:
         project, project_runtime, source_registry, shared_registry = write_fixture(
@@ -151,6 +253,13 @@ def main() -> None:
         assert projection["status"] == "projected", projection
         assert projection["raw_artifacts_copied"] is False, projection
         assert projection["recommended_action_copied"] is False, projection
+        assert projection["readback_verified"] is True, projection
+        route = refresh["runtime_projection_route"]
+        assert route["schema_version"] == "runtime_projection_route_v0", route
+        assert route["status"] == "resolved", route
+        assert route["projection_required"] is True, route
+        assert route["projection_enabled"] is True, route
+        assert str(project) not in json.dumps(route), route
         assert not (project_runtime / "registry.global.json").exists()
 
         shared_index = shared_runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
@@ -174,10 +283,210 @@ def main() -> None:
         assert replay["status"] == "already_current", replay
         assert len(shared_index.read_text().splitlines()) == len(rows)
 
+        no_sync = run_cli(
+            "--registry",
+            str(source_registry),
+            "refresh-state",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--progress-scope",
+            "agent_lane",
+            "--classification",
+            "shared_runtime_projection_suppressed",
+            "--recommended-action",
+            "Keep this source-local checkpoint out of the shared runtime.",
+            "--no-global-sync",
+            "--suppress-external-sinks",
+            cwd=project,
+            shared_runtime=shared_runtime,
+        )
+        assert no_sync["runtime_projection_route"]["projection_enabled"] is False
+        assert no_sync["global_sync"]["enabled"] is False
+        assert no_sync["shared_runtime_projection"]["status"] == "disabled"
+        assert len(shared_index.read_text().splitlines()) == len(rows)
+
         source_record["state"]["frontmatter"]["updated_at"] = str(project)
         boundary_record, _ = build_shared_runtime_projection(record=source_record)
         assert boundary_record["state"]["frontmatter"]["updated_at"] is None
         assert str(project) not in json.dumps(boundary_record)
+
+        status = run_cli(
+            "--registry",
+            str(source_registry),
+            "status",
+            "--goal-id",
+            GOAL_ID,
+            "--limit",
+            "5",
+            cwd=project,
+            shared_runtime=shared_runtime,
+        )
+        route_diagnostics = status["runtime_projection_routes"]
+        assert route_diagnostics["healthy"] is True, route_diagnostics
+        assert route_diagnostics["counts"]["healthy"] == 1, route_diagnostics
+        assert "runtime_projection_routes: healthy=True" in render_status_markdown(status)
+
+        source_index = project_runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
+        source_rows = [
+            json.loads(line)
+            for line in source_index.read_text(encoding="utf-8").splitlines()
+        ]
+        enabled_route_row = next(
+            row
+            for row in reversed(source_rows)
+            if (row.get("runtime_projection_route") or {}).get("projection_enabled")
+            is True
+        )
+        lagging_row = {
+            **enabled_route_row,
+            "generated_at": "2026-01-01T00:00:01+00:00",
+            "classification": "shared_runtime_projection_lag_fixture",
+        }
+        with source_index.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(lagging_row, ensure_ascii=False) + "\n")
+        lagging_status = run_cli(
+            "--registry",
+            str(source_registry),
+            "status",
+            "--goal-id",
+            GOAL_ID,
+            "--limit",
+            "5",
+            cwd=project,
+            shared_runtime=shared_runtime,
+        )
+        lagging_routes = lagging_status["runtime_projection_routes"]
+        assert lagging_routes["healthy"] is False, lagging_routes
+        assert lagging_routes["counts"]["lagging"] == 1, lagging_routes
+        lagging_markdown = render_status_markdown(lagging_status)
+        assert "## Runtime Projection Route Findings" in lagging_markdown
+        assert "status=lagging" in lagging_markdown
+
+        single_runtime = Path(tmp) / "single-runtime"
+        single_registry, single_goal = write_route_source(
+            Path(tmp),
+            name="single",
+            source_runtime=single_runtime,
+        )
+        write_route_target(
+            single_runtime,
+            source_registry=single_registry,
+            goal_id=single_goal,
+        )
+        single_route = resolve_runtime_projection_route(
+            registry_path=single_registry,
+            goal_id=single_goal,
+            source_runtime_root=single_runtime,
+            candidate_roots=[single_runtime],
+        )
+        assert single_route["status"] == "single_runtime", single_route
+        assert single_route["projection_required"] is False, single_route
+
+        standalone_runtime = Path(tmp) / "standalone-runtime"
+        standalone_registry, standalone_goal = write_route_source(
+            Path(tmp),
+            name="standalone",
+            source_runtime=standalone_runtime,
+        )
+        unrelated_runtime = Path(tmp) / "unrelated-default-runtime"
+        write_route_target(
+            unrelated_runtime,
+            source_registry=standalone_registry,
+            goal_id="unrelated-goal",
+        )
+        original_default_runtime = route_module.DEFAULT_RUNTIME_ROOT
+        route_module.DEFAULT_RUNTIME_ROOT = unrelated_runtime
+        try:
+            standalone_route = resolve_runtime_projection_route(
+                registry_path=standalone_registry,
+                goal_id=standalone_goal,
+                source_runtime_root=standalone_runtime,
+            )
+        finally:
+            route_module.DEFAULT_RUNTIME_ROOT = original_default_runtime
+        assert standalone_route["status"] == "single_runtime", standalone_route
+        assert standalone_route["declaration_source"] == "source_runtime_fallback"
+
+        missing_source_runtime = Path(tmp) / "missing-source-runtime"
+        missing_target_runtime = Path(tmp) / "missing-target-runtime"
+        missing_registry, missing_goal = write_route_source(
+            Path(tmp),
+            name="missing",
+            source_runtime=missing_source_runtime,
+        )
+        write_route_target(
+            missing_target_runtime,
+            source_registry=missing_registry,
+            goal_id=missing_goal,
+            include_route=False,
+        )
+        missing_route = resolve_runtime_projection_route(
+            registry_path=missing_registry,
+            goal_id=missing_goal,
+            source_runtime_root=missing_source_runtime,
+            candidate_roots=[missing_target_runtime],
+        )
+        assert missing_route["status"] == "missing", missing_route
+        (missing_target_runtime / "registry.global.json").write_text(
+            "{invalid-json\n",
+            encoding="utf-8",
+        )
+        unreadable_route = resolve_runtime_projection_route(
+            registry_path=missing_registry,
+            goal_id=missing_goal,
+            source_runtime_root=missing_source_runtime,
+            candidate_roots=[missing_target_runtime],
+        )
+        assert unreadable_route["status"] == "missing", unreadable_route
+        assert unreadable_route["unreadable_target_count"] == 1, unreadable_route
+        missing_refresh = run_cli_failure(
+            "--registry",
+            str(missing_registry),
+            "refresh-state",
+            "--goal-id",
+            missing_goal,
+            "--classification",
+            "runtime_projection_route_missing",
+            "--recommended-action",
+            "Repair the declared runtime projection route before retrying sync.",
+            "--suppress-external-sinks",
+            cwd=missing_registry.parent,
+            shared_runtime=missing_target_runtime,
+        )
+        assert missing_refresh["ok"] is False, missing_refresh
+        assert missing_refresh["runtime_projection_route"]["status"] == "missing"
+        assert missing_refresh["global_sync"]["enabled"] is False
+        assert missing_refresh["shared_runtime_projection"]["status"] == "route_missing"
+        assert not (missing_source_runtime / "registry.global.json").exists()
+
+        ambiguous_source_runtime = Path(tmp) / "ambiguous-source-runtime"
+        ambiguous_registry, ambiguous_goal = write_route_source(
+            Path(tmp),
+            name="ambiguous",
+            source_runtime=ambiguous_source_runtime,
+        )
+        ambiguous_targets = [
+            Path(tmp) / "ambiguous-target-a",
+            Path(tmp) / "ambiguous-target-b",
+        ]
+        for target in ambiguous_targets:
+            write_route_target(
+                target,
+                source_registry=ambiguous_registry,
+                goal_id=ambiguous_goal,
+            )
+        ambiguous_route = resolve_runtime_projection_route(
+            registry_path=ambiguous_registry,
+            goal_id=ambiguous_goal,
+            source_runtime_root=ambiguous_source_runtime,
+            candidate_roots=ambiguous_targets,
+        )
+        assert ambiguous_route["status"] == "ambiguous", ambiguous_route
+        assert ambiguous_route["match_count"] == 2, ambiguous_route
+        compact_ambiguous = compact_runtime_projection_route(ambiguous_route)
+        assert str(Path(tmp)) not in json.dumps(compact_ambiguous), compact_ambiguous
 
         quota = run_cli(
             "--registry",

--- a/loopx/control_plane/runtime/runtime_projection_route.py
+++ b/loopx/control_plane/runtime/runtime_projection_route.py
@@ -1,0 +1,428 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any, Iterable
+
+from ...history import load_index, load_registry
+from ...paths import DEFAULT_RUNTIME_ROOT, global_registry_path, resolve_runtime_root
+from ...registry import registry_goals
+
+
+RUNTIME_PROJECTION_ROUTE_SCHEMA_VERSION = "runtime_projection_route_v0"
+RUNTIME_PROJECTION_ROUTE_DIAGNOSTICS_SCHEMA_VERSION = (
+    "runtime_projection_route_diagnostics_v0"
+)
+
+
+def _same_path(left: Path, right: Path) -> bool:
+    try:
+        return left.expanduser().resolve() == right.expanduser().resolve()
+    except OSError:
+        return str(left.expanduser()) == str(right.expanduser())
+
+
+def _path_digest(path: Path | None) -> str | None:
+    if path is None:
+        return None
+    try:
+        value = str(path.expanduser().resolve())
+    except OSError:
+        value = str(path.expanduser())
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
+
+
+def _resolved_source_registry(goal: dict[str, Any], *, registry_path: Path) -> Path | None:
+    value = str(goal.get("source_registry") or "").strip()
+    if not value:
+        return None
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = registry_path.parent / path
+    return path.resolve()
+
+
+def runtime_projection_candidate_roots(
+    *,
+    source_runtime_root: Path,
+    candidate_roots: Iterable[Path] | None = None,
+) -> list[Path]:
+    roots: list[Path] = []
+    if candidate_roots is None:
+        configured = str(os.environ.get("LOOPX_RUNTIME_ROOT") or "").strip()
+        if configured:
+            roots.append(Path(configured).expanduser())
+        roots.append(DEFAULT_RUNTIME_ROOT)
+    else:
+        roots.extend(Path(root).expanduser() for root in candidate_roots)
+    roots.append(source_runtime_root.expanduser())
+
+    resolved: list[Path] = []
+    for root in roots:
+        candidate = root.resolve()
+        if any(_same_path(candidate, existing) for existing in resolved):
+            continue
+        resolved.append(candidate)
+    return resolved
+
+
+def _route_id(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    source_runtime_root: Path,
+    target_runtime_roots: list[Path],
+) -> str:
+    payload = {
+        "goal_id": goal_id,
+        "source_registry": str(registry_path.resolve()),
+        "source_runtime_root": str(source_runtime_root.resolve()),
+        "target_runtime_roots": sorted(str(root.resolve()) for root in target_runtime_roots),
+    }
+    return hashlib.sha256(
+        json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    ).hexdigest()[:16]
+
+
+def resolve_runtime_projection_route(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    source_runtime_root: Path,
+    candidate_roots: Iterable[Path] | None = None,
+) -> dict[str, Any]:
+    """Resolve the registry-declared route from one source runtime to its read model."""
+
+    source_registry = registry_path.expanduser().resolve()
+    source_runtime = source_runtime_root.expanduser().resolve()
+    provided_roots = (
+        [Path(root).expanduser() for root in candidate_roots]
+        if candidate_roots is not None
+        else None
+    )
+    roots = runtime_projection_candidate_roots(
+        source_runtime_root=source_runtime,
+        candidate_roots=provided_roots,
+    )
+    configured_root_text = str(os.environ.get("LOOPX_RUNTIME_ROOT") or "").strip()
+    explicit_roots = (
+        provided_roots
+        if provided_roots is not None
+        else ([Path(configured_root_text).expanduser()] if configured_root_text else [])
+    )
+    matches: list[dict[str, Any]] = []
+    conflicts: list[dict[str, Any]] = []
+    available_targets: list[Path] = []
+    unreadable_target_count = 0
+    for root in roots:
+        candidate_registry = global_registry_path(root)
+        if not candidate_registry.exists():
+            continue
+        available_targets.append(root)
+        try:
+            target_registry = load_registry(candidate_registry)
+        except (OSError, ValueError, json.JSONDecodeError):
+            unreadable_target_count += 1
+            continue
+        for goal in registry_goals(target_registry):
+            if str(goal.get("id") or "") != goal_id:
+                continue
+            declared_source = _resolved_source_registry(
+                goal,
+                registry_path=candidate_registry,
+            )
+            candidate = {
+                "target_runtime_root": root,
+                "target_registry": candidate_registry.resolve(),
+                "declared_source_registry": declared_source,
+            }
+            if declared_source and _same_path(declared_source, source_registry):
+                matches.append(candidate)
+            else:
+                conflicts.append(candidate)
+
+    unique_matches: list[dict[str, Any]] = []
+    for match in matches:
+        if any(
+            _same_path(match["target_runtime_root"], item["target_runtime_root"])
+            for item in unique_matches
+        ):
+            continue
+        unique_matches.append(match)
+
+    target_roots = [item["target_runtime_root"] for item in unique_matches]
+    source_is_global = _same_path(
+        source_registry,
+        global_registry_path(source_runtime),
+    )
+    if len(unique_matches) > 1:
+        status = "ambiguous"
+        target_runtime = None
+        target_registry = None
+        projection_required = True
+        declaration_source = "multiple_target_registries.goal.source_registry"
+    elif unique_matches:
+        match = unique_matches[0]
+        target_runtime = match["target_runtime_root"]
+        target_registry = match["target_registry"]
+        projection_required = not _same_path(target_runtime, source_runtime)
+        status = "resolved" if projection_required else "single_runtime"
+        declaration_source = "target_registry.goal.source_registry"
+    elif source_is_global:
+        status = "single_runtime"
+        target_runtime = source_runtime
+        target_registry = global_registry_path(source_runtime)
+        projection_required = False
+        declaration_source = "source_registry_is_global_registry"
+        target_roots = [source_runtime]
+    else:
+        external_targets = [
+            root for root in available_targets if not _same_path(root, source_runtime)
+        ]
+        explicit_external_targets = [
+            root
+            for root in external_targets
+            if any(_same_path(root, explicit) for explicit in explicit_roots)
+        ]
+        conflict_targets = [
+            item["target_runtime_root"]
+            for item in conflicts
+            if not _same_path(item["target_runtime_root"], source_runtime)
+        ]
+        missing_targets = explicit_external_targets or conflict_targets
+        if missing_targets:
+            status = "missing"
+            target_runtime = missing_targets[0] if len(missing_targets) == 1 else None
+            target_registry = (
+                global_registry_path(target_runtime) if target_runtime is not None else None
+            )
+            projection_required = True
+            declaration_source = "target_registry_route_missing"
+            target_roots = missing_targets
+        else:
+            status = "single_runtime"
+            target_runtime = source_runtime
+            target_registry = global_registry_path(source_runtime)
+            projection_required = False
+            declaration_source = "source_runtime_fallback"
+            target_roots = [source_runtime]
+
+    route_id = _route_id(
+        registry_path=source_registry,
+        goal_id=goal_id,
+        source_runtime_root=source_runtime,
+        target_runtime_roots=target_roots,
+    )
+    return {
+        "schema_version": RUNTIME_PROJECTION_ROUTE_SCHEMA_VERSION,
+        "route_id": route_id,
+        "goal_id": goal_id,
+        "status": status,
+        "projection_required": projection_required,
+        "declaration_source": declaration_source,
+        "source_registry": str(source_registry),
+        "source_runtime_root": str(source_runtime),
+        "target_runtime_root": str(target_runtime) if target_runtime is not None else None,
+        "target_registry": str(target_registry) if target_registry is not None else None,
+        "candidate_count": len(roots),
+        "match_count": len(unique_matches),
+        "conflict_count": len(conflicts),
+        "unreadable_target_count": unreadable_target_count,
+        "target_runtime_digests": [_path_digest(root) for root in target_roots],
+    }
+
+
+def compact_runtime_projection_route(route: dict[str, Any]) -> dict[str, Any]:
+    source_registry = str(route.get("source_registry") or "").strip()
+    source_runtime = str(route.get("source_runtime_root") or "").strip()
+    target_runtime = str(route.get("target_runtime_root") or "").strip()
+    return {
+        "schema_version": RUNTIME_PROJECTION_ROUTE_SCHEMA_VERSION,
+        "route_id": route.get("route_id"),
+        "status": route.get("status"),
+        "projection_required": bool(route.get("projection_required")),
+        "declaration_source": route.get("declaration_source"),
+        "match_count": int(route.get("match_count") or 0),
+        "conflict_count": int(route.get("conflict_count") or 0),
+        "unreadable_target_count": int(route.get("unreadable_target_count") or 0),
+        "source_registry_sha256_16": _path_digest(Path(source_registry))
+        if source_registry
+        else None,
+        "source_runtime_sha256_16": _path_digest(Path(source_runtime))
+        if source_runtime
+        else None,
+        "target_runtime_sha256_16": _path_digest(Path(target_runtime))
+        if target_runtime
+        else None,
+    }
+
+
+def _latest_route_source_row(
+    *,
+    runtime_root: Path,
+    goal_id: str,
+    route_id: str,
+) -> dict[str, Any] | None:
+    rows, _ = load_index(runtime_root / "goals" / goal_id / "runs" / "index.jsonl")
+    for row in reversed(rows):
+        marker = row.get("runtime_projection_route")
+        if (
+            isinstance(marker, dict)
+            and marker.get("route_id") == route_id
+            and marker.get("projection_enabled") is not False
+        ):
+            return row
+    return None
+
+
+def _route_projection_is_current(
+    *,
+    target_runtime_root: Path,
+    goal_id: str,
+    route_id: str,
+    source_generated_at: Any,
+) -> bool:
+    rows, _ = load_index(
+        target_runtime_root / "goals" / goal_id / "runs" / "index.jsonl"
+    )
+    return any(
+        isinstance(row.get("shared_runtime_projection"), dict)
+        and row["shared_runtime_projection"].get("runtime_projection_route_id")
+        == route_id
+        and row["shared_runtime_projection"].get("source_generated_at")
+        == source_generated_at
+        for row in rows
+    )
+
+
+def _source_routes_for_registry(
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    goal_id: str | None,
+) -> list[tuple[Path, Path, str, str | None]]:
+    registry = load_registry(registry_path)
+    is_global = bool(registry.get("registry_role") == "global-local") or _same_path(
+        registry_path,
+        global_registry_path(runtime_root),
+    )
+    routes: list[tuple[Path, Path, str, str | None]] = []
+    for goal in registry_goals(registry):
+        current_goal_id = str(goal.get("id") or "")
+        if not current_goal_id or (goal_id and current_goal_id != goal_id):
+            continue
+        source_registry = (
+            _resolved_source_registry(goal, registry_path=registry_path)
+            if is_global
+            else registry_path.resolve()
+        )
+        if source_registry is None:
+            continue
+        source_error = None
+        if source_registry.exists():
+            try:
+                source_payload = load_registry(source_registry)
+                source_runtime = resolve_runtime_root(source_payload, None)
+            except (OSError, ValueError, json.JSONDecodeError):
+                source_runtime = runtime_root
+                source_error = "source_registry_unreadable"
+        else:
+            source_runtime = runtime_root
+            source_error = "source_registry_missing"
+        item = (source_registry, source_runtime, current_goal_id, source_error)
+        if item not in routes:
+            routes.append(item)
+    return routes
+
+
+def collect_runtime_projection_route_diagnostics(
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    goal_id: str | None = None,
+) -> dict[str, Any]:
+    items: list[dict[str, Any]] = []
+    source_routes = _source_routes_for_registry(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        goal_id=goal_id,
+    )
+    registry = load_registry(registry_path)
+    registry_is_global = bool(registry.get("registry_role") == "global-local") or _same_path(
+        registry_path,
+        global_registry_path(runtime_root),
+    )
+    for source_registry, source_runtime, current_goal_id, source_error in source_routes:
+        if source_error:
+            items.append(
+                {
+                    "goal_id": current_goal_id,
+                    "status": "missing",
+                    "reason": source_error,
+                }
+            )
+            continue
+        route = resolve_runtime_projection_route(
+            registry_path=source_registry,
+            goal_id=current_goal_id,
+            source_runtime_root=source_runtime,
+            candidate_roots=(
+                [
+                    runtime_root,
+                    *runtime_projection_candidate_roots(
+                        source_runtime_root=source_runtime,
+                    ),
+                ]
+                if registry_is_global
+                else None
+            ),
+        )
+        compact = compact_runtime_projection_route(route)
+        route_status = str(route.get("status") or "missing")
+        diagnostic_status = route_status
+        source_row = (
+            _latest_route_source_row(
+                runtime_root=source_runtime,
+                goal_id=current_goal_id,
+                route_id=str(route.get("route_id") or ""),
+            )
+            if route_status == "resolved"
+            else None
+        )
+        if source_row:
+            target_text = str(route.get("target_runtime_root") or "").strip()
+            current = bool(target_text) and _route_projection_is_current(
+                target_runtime_root=Path(target_text),
+                goal_id=current_goal_id,
+                route_id=str(route.get("route_id") or ""),
+                source_generated_at=source_row.get("generated_at"),
+            )
+            diagnostic_status = "healthy" if current else "lagging"
+        elif route_status == "resolved":
+            diagnostic_status = "ready"
+        items.append(
+            {
+                "goal_id": current_goal_id,
+                "status": diagnostic_status,
+                "route": compact,
+                "source_projection_observed": source_row is not None,
+            }
+        )
+
+    counts = {
+        status: sum(1 for item in items if item.get("status") == status)
+        for status in ("healthy", "ready", "single_runtime", "missing", "ambiguous", "lagging")
+    }
+    return {
+        "schema_version": RUNTIME_PROJECTION_ROUTE_DIAGNOSTICS_SCHEMA_VERSION,
+        "available": bool(items),
+        "goal_count": len(items),
+        "healthy": not any(
+            item.get("status") in {"missing", "ambiguous", "lagging"}
+            for item in items
+        ),
+        "counts": counts,
+        "items": items,
+    }

--- a/loopx/control_plane/runtime/runtime_projection_writer.py
+++ b/loopx/control_plane/runtime/runtime_projection_writer.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Callable
+
+from ...file_lock import exclusive_file_lock
+from ...history import load_index, reserve_unique_run_paths
+from .time import now_local_iso
+
+
+def write_compact_runtime_projection(
+    *,
+    target_runtime_root: Path,
+    goal_id: str,
+    record: dict[str, Any],
+    index_record: dict[str, Any],
+    marker_field: str,
+    identity_fields: tuple[str, ...],
+    markdown_renderer: Callable[[dict[str, Any]], str],
+    dry_run: bool,
+) -> dict[str, Any]:
+    """Idempotently append one compact projection and verify shared readback."""
+
+    marker = record.get(marker_field)
+    if not isinstance(marker, dict):
+        raise ValueError(f"projection record must include object marker {marker_field!r}")
+    identity = tuple(marker.get(field) for field in identity_fields)
+    if not all(identity):
+        raise ValueError(
+            f"projection marker {marker_field!r} is missing identity fields: "
+            + ", ".join(identity_fields)
+        )
+
+    result: dict[str, Any] = {
+        "ok": True,
+        "status": "would_project" if dry_run else "projected",
+        "dry_run": dry_run,
+        "target_runtime_root": str(target_runtime_root),
+        "readback_verified": False if dry_run else None,
+    }
+    if dry_run:
+        return result
+
+    runs_dir = target_runtime_root / "goals" / goal_id / "runs"
+    index_path = runs_dir / "index.jsonl"
+    with exclusive_file_lock(index_path):
+        existing, _ = load_index(index_path)
+        for item in existing:
+            item_marker = item.get(marker_field)
+            if not isinstance(item_marker, dict):
+                continue
+            if tuple(item_marker.get(field) for field in identity_fields) == identity:
+                result.update(
+                    {
+                        "status": "already_current",
+                        "index_path": str(index_path),
+                        "readback_verified": True,
+                    }
+                )
+                return result
+
+        json_path, markdown_path = reserve_unique_run_paths(
+            runs_dir,
+            str(record.get("generated_at") or now_local_iso()),
+        )
+        index_record["json_path"] = str(json_path)
+        index_record["markdown_path"] = str(markdown_path)
+        json_path.write_text(
+            json.dumps(record, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        markdown_path.write_text(
+            markdown_renderer(record) + "\n",
+            encoding="utf-8",
+        )
+        with index_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(index_record, ensure_ascii=False) + "\n")
+
+        rows, _ = load_index(index_path)
+        readback_verified = any(
+            isinstance(item.get(marker_field), dict)
+            and tuple(item[marker_field].get(field) for field in identity_fields)
+            == identity
+            for item in rows
+        )
+        if not readback_verified:
+            raise OSError("runtime projection append did not pass index readback")
+
+    result.update(
+        {
+            "json_path": str(json_path),
+            "markdown_path": str(markdown_path),
+            "index_path": str(index_path),
+            "readback_verified": True,
+        }
+    )
+    return result

--- a/loopx/control_plane/runtime/shared_runtime_refresh_projection.py
+++ b/loopx/control_plane/runtime/shared_runtime_refresh_projection.py
@@ -2,17 +2,15 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import re
 from pathlib import Path
 from typing import Any
 
-from ...file_lock import exclusive_file_lock
-from ...history import load_index, load_registry, reserve_unique_run_paths
-from ...paths import DEFAULT_RUNTIME_ROOT, global_registry_path
-from ...registry import registry_goals
 from ..goals.goal_vision import compact_goal_vision_packet
-from .time import now_local_iso
+from .runtime_projection_route import (
+    resolve_runtime_projection_route,
+)
+from .runtime_projection_writer import write_compact_runtime_projection
 
 
 SHARED_RUNTIME_PROJECTION_SCHEMA_VERSION = "shared_runtime_refresh_projection_v0"
@@ -25,37 +23,17 @@ def registered_shared_runtime_root(
     goal_id: str,
     source_runtime_root: Path,
 ) -> Path | None:
-    """Find the shared runtime that registered this exact source registry route."""
+    """Compatibility wrapper over the first-class runtime projection route."""
 
-    candidate_roots: list[Path] = []
-    configured_root = str(os.environ.get("LOOPX_RUNTIME_ROOT") or "").strip()
-    if configured_root:
-        candidate_roots.append(Path(configured_root).expanduser())
-    candidate_roots.append(DEFAULT_RUNTIME_ROOT)
-
-    source_path = registry_path.expanduser().resolve()
-    seen: set[Path] = set()
-    for candidate_root in candidate_roots:
-        resolved_root = candidate_root.resolve()
-        if resolved_root in seen or resolved_root == source_runtime_root.resolve():
-            continue
-        seen.add(resolved_root)
-        candidate_registry = global_registry_path(resolved_root)
-        if not candidate_registry.exists() or candidate_registry.resolve() == source_path:
-            continue
-        shared_registry = load_registry(candidate_registry)
-        for goal in registry_goals(shared_registry):
-            if str(goal.get("id") or "") != goal_id:
-                continue
-            registered_source = str(goal.get("source_registry") or "").strip()
-            if not registered_source:
-                continue
-            registered_path = Path(registered_source).expanduser()
-            if not registered_path.is_absolute():
-                registered_path = candidate_registry.parent / registered_path
-            if registered_path.resolve() == source_path:
-                return resolved_root
-    return None
+    route = resolve_runtime_projection_route(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        source_runtime_root=source_runtime_root,
+    )
+    if route.get("status") != "resolved":
+        return None
+    target = str(route.get("target_runtime_root") or "").strip()
+    return Path(target) if target else None
 
 
 def build_shared_runtime_projection(
@@ -78,6 +56,13 @@ def build_shared_runtime_projection(
         "raw_artifacts_copied": False,
         "recommended_action_copied": False,
     }
+    route_marker = (
+        record.get("runtime_projection_route")
+        if isinstance(record.get("runtime_projection_route"), dict)
+        else {}
+    )
+    if route_marker.get("route_id"):
+        marker["runtime_projection_route_id"] = route_marker["route_id"]
     projection: dict[str, Any] = {
         "generated_at": record.get("generated_at"),
         "goal_id": record.get("goal_id"),
@@ -167,6 +152,7 @@ def _render_projection_markdown(record: dict[str, Any]) -> str:
             f"- agent_id: `{record.get('agent_id')}`",
             f"- raw_artifacts_copied: `{marker.get('raw_artifacts_copied')}`",
             f"- recommended_action_copied: `{marker.get('recommended_action_copied')}`",
+            f"- runtime_projection_route_id: `{marker.get('runtime_projection_route_id')}`",
         ]
     )
 
@@ -180,53 +166,18 @@ def write_shared_runtime_projection(
     dry_run: bool,
 ) -> dict[str, Any]:
     marker = record["shared_runtime_projection"]
-    result: dict[str, Any] = {
-        "ok": True,
-        "status": "would_project" if dry_run else "projected",
-        "dry_run": dry_run,
-        "shared_runtime_root": str(shared_runtime_root),
-        "raw_artifacts_copied": False,
-        "recommended_action_copied": False,
-        "source_generated_at": marker.get("source_generated_at"),
-    }
-    if dry_run:
-        return result
-
-    runs_dir = shared_runtime_root / "goals" / goal_id / "runs"
-    index_path = runs_dir / "index.jsonl"
-    with exclusive_file_lock(index_path):
-        existing, _ = load_index(index_path)
-        if any(
-            isinstance(item.get("shared_runtime_projection"), dict)
-            and item["shared_runtime_projection"].get("source_generated_at")
-            == marker.get("source_generated_at")
-            and item["shared_runtime_projection"].get("source_projection_sha256_16")
-            == marker.get("source_projection_sha256_16")
-            for item in existing
-        ):
-            result["status"] = "already_current"
-            result["index_path"] = str(index_path)
-            return result
-        json_path, markdown_path = reserve_unique_run_paths(
-            runs_dir, str(record.get("generated_at") or now_local_iso())
-        )
-        index_record["json_path"] = str(json_path)
-        index_record["markdown_path"] = str(markdown_path)
-        json_path.write_text(
-            json.dumps(record, ensure_ascii=False, indent=2) + "\n",
-            encoding="utf-8",
-        )
-        markdown_path.write_text(
-            _render_projection_markdown(record) + "\n",
-            encoding="utf-8",
-        )
-        with index_path.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(index_record, ensure_ascii=False) + "\n")
-    result.update(
-        {
-            "json_path": str(json_path),
-            "markdown_path": str(markdown_path),
-            "index_path": str(index_path),
-        }
+    result = write_compact_runtime_projection(
+        target_runtime_root=shared_runtime_root,
+        goal_id=goal_id,
+        record=record,
+        index_record=index_record,
+        marker_field="shared_runtime_projection",
+        identity_fields=("source_generated_at", "source_projection_sha256_16"),
+        markdown_renderer=_render_projection_markdown,
+        dry_run=dry_run,
     )
+    result["shared_runtime_root"] = str(shared_runtime_root)
+    result["raw_artifacts_copied"] = False
+    result["recommended_action_copied"] = False
+    result["source_generated_at"] = marker.get("source_generated_at")
     return result

--- a/loopx/control_plane/status_collection.py
+++ b/loopx/control_plane/status_collection.py
@@ -4,6 +4,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
+from .runtime.runtime_projection_route import (
+    collect_runtime_projection_route_diagnostics,
+)
+
 
 StatusCallback = Callable[..., Any]
 
@@ -79,6 +83,11 @@ def collect_status(
         registry_path=registry_path,
         runtime_root_override=str(runtime_root),
     )
+    runtime_projection_routes = collect_runtime_projection_route_diagnostics(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        goal_id=goal_filter,
+    )
     payload = {
         "ok": bool(contract.get("ok")) and bool(global_registry.get("ok", True)),
         "registry": str(registry_path),
@@ -100,6 +109,7 @@ def collect_status(
         **runtime_summaries,
         "promotion_gate": promotion_gate,
     }
+    payload["runtime_projection_routes"] = runtime_projection_routes
     agent_management_projection = context.build_agent_management_projection(payload)
     if agent_management_projection.get("agents"):
         payload["agent_management_projection"] = agent_management_projection

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -644,6 +644,10 @@ def latest_promotion_readiness_event(runtime_root: Path, goal_id: str | None = N
 
 
 def collect_doctor(*, deep: bool = False) -> dict[str, Any]:
+    from .control_plane.runtime.runtime_projection_route import (
+        collect_runtime_projection_route_diagnostics,
+    )
+
     loopx_path = resolve_command_path("loopx")
     invocation_path = current_script_invocation_path()
     loopx_canary_path = resolve_command_path("loopx-canary")
@@ -731,6 +735,21 @@ def collect_doctor(*, deep: bool = False) -> dict[str, Any]:
     )
     default_global_registry = global_registry_path(DEFAULT_RUNTIME_ROOT)
     global_registry_writability = probe_registry_write_path(default_global_registry, create_parent=True)
+    runtime_projection_routes = (
+        collect_runtime_projection_route_diagnostics(
+            registry_path=default_global_registry,
+            runtime_root=DEFAULT_RUNTIME_ROOT,
+        )
+        if default_global_registry.exists()
+        else {
+            "schema_version": "runtime_projection_route_diagnostics_v0",
+            "available": False,
+            "goal_count": 0,
+            "healthy": True,
+            "counts": {},
+            "items": [],
+        }
+    )
     deep_validation = None
     if deep:
         from .release_candidate import collect_release_candidate_checks
@@ -847,6 +866,16 @@ def collect_doctor(*, deep: bool = False) -> dict[str, Any]:
             if global_registry_writability.get("ok")
             else str(global_registry_writability.get("error") or default_global_registry),
         },
+        {
+            "id": "runtime_projection_routes_healthy",
+            "required": False,
+            "ok": bool(runtime_projection_routes.get("healthy", True)),
+            "detail": json.dumps(
+                runtime_projection_routes.get("counts") or {},
+                ensure_ascii=False,
+                sort_keys=True,
+            ),
+        },
     ]
     if deep_validation:
         checks.extend(deep_validation["checks"])
@@ -879,6 +908,7 @@ def collect_doctor(*, deep: bool = False) -> dict[str, Any]:
         "release_manifest": release_manifest,
         "release_provenance": release_provenance,
         "global_registry_writability": global_registry_writability,
+        "runtime_projection_routes": runtime_projection_routes,
         "install_freshness": install_freshness,
         "upgrade_hint": install_freshness,
         "skill": {
@@ -917,6 +947,7 @@ def render_doctor_markdown(payload: dict[str, Any]) -> str:
         f"- installed_skill_delivery_hints: `{(payload.get('skill') or {}).get('delivery_hints')}`",
         f"- installed_required_skills: `{','.join(sorted((payload.get('skills') or {}).keys()))}`",
         f"- global_registry_writable: `{(payload.get('global_registry_writability') or {}).get('ok')}`",
+        f"- runtime_projection_routes_healthy: `{(payload.get('runtime_projection_routes') or {}).get('healthy')}`",
         f"- user_local_bin_on_path: `{(payload.get('path') or {}).get('user_local_bin_on_path')}`",
         f"- python: `{(payload.get('python') or {}).get('executable')}`",
         "",

--- a/loopx/presentation/renderers/status_markdown.py
+++ b/loopx/presentation/renderers/status_markdown.py
@@ -128,6 +128,42 @@ def append_global_registry_summary_markdown(
     )
 
 
+def append_runtime_projection_routes_markdown(
+    lines: list[str],
+    diagnostics: dict[str, Any],
+) -> None:
+    if not diagnostics.get("available"):
+        return
+    counts = as_dict(diagnostics.get("counts"))
+    lines.append(
+        "- runtime_projection_routes: "
+        f"healthy={diagnostics.get('healthy')}, "
+        f"single_runtime={counts.get('single_runtime')}, "
+        f"ready={counts.get('ready')}, "
+        f"missing={counts.get('missing')}, "
+        f"ambiguous={counts.get('ambiguous')}, "
+        f"lagging={counts.get('lagging')}"
+    )
+    findings = [
+        item
+        for item in as_list(diagnostics.get("items"))
+        if isinstance(item, dict)
+        and item.get("status") in {"missing", "ambiguous", "lagging"}
+    ]
+    if not findings:
+        return
+    lines.extend(["", "## Runtime Projection Route Findings"])
+    for item in findings:
+        route = as_dict(item.get("route"))
+        lines.append(
+            "- "
+            f"goal={markdown_scalar(item.get('goal_id') or '')} "
+            f"status={markdown_scalar(item.get('status') or '')} "
+            f"reason={markdown_scalar(item.get('reason') or '')} "
+            f"route_id={markdown_scalar(route.get('route_id') or '')}"
+        )
+
+
 def append_global_registry_findings_markdown(
     lines: list[str],
     global_registry: dict[str, Any],
@@ -933,6 +969,12 @@ def render_status_markdown(
         else {}
     )
     append_global_registry_summary_markdown(lines, global_registry)
+    runtime_projection_routes = (
+        payload.get("runtime_projection_routes")
+        if isinstance(payload.get("runtime_projection_routes"), dict)
+        else {}
+    )
+    append_runtime_projection_routes_markdown(lines, runtime_projection_routes)
 
     event_ledger = (
         payload.get("event_ledger_summary")

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -21,8 +21,11 @@ from .control_plane.work_items.repair_delta import (
 )
 from .control_plane.runtime.shared_runtime_refresh_projection import (
     build_shared_runtime_projection,
-    registered_shared_runtime_root,
     write_shared_runtime_projection,
+)
+from .control_plane.runtime.runtime_projection_route import (
+    compact_runtime_projection_route,
+    resolve_runtime_projection_route,
 )
 from .feedback import validate_local_control_text, validate_public_safe_text
 from .file_lock import exclusive_file_lock
@@ -818,13 +821,22 @@ def refresh_state_run(
     normalized_repair_delta_kinds = normalize_repair_delta_kinds(repair_delta_kinds)
     registry = load_registry(registry_path)
     runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    runtime_projection_route = resolve_runtime_projection_route(
+        registry_path=registry_path,
+        goal_id=safe_goal_id,
+        source_runtime_root=runtime_root,
+    )
+    route_status = str(runtime_projection_route.get("status") or "missing")
+    route_target_text = str(
+        runtime_projection_route.get("target_runtime_root") or ""
+    ).strip()
+    route_target_root = Path(route_target_text) if route_target_text else None
     shared_runtime_root = (
-        registered_shared_runtime_root(
-            registry_path=registry_path,
-            goal_id=safe_goal_id,
-            source_runtime_root=runtime_root,
-        )
-        if sync_global
+        route_target_root if sync_global and route_status == "resolved" else None
+    )
+    global_sync_runtime_root = (
+        route_target_root
+        if sync_global and route_status in {"resolved", "single_runtime"}
         else None
     )
     registry_goal, resolved_project, resolved_state_file = resolve_goal_state(
@@ -991,6 +1003,9 @@ def refresh_state_run(
         record["agent_vision"] = agent_vision
     if vision_checkpoint:
         record["vision_checkpoint"] = vision_checkpoint
+    compact_route = compact_runtime_projection_route(runtime_projection_route)
+    compact_route["projection_enabled"] = bool(sync_global)
+    record["runtime_projection_route"] = compact_route
 
     runs_dir = runtime_root / "goals" / safe_goal_id / "runs"
     json_path, markdown_path = unique_run_paths(runs_dir, generated_at)
@@ -1017,6 +1032,7 @@ def refresh_state_run(
             "updated_at": record_frontmatter.get("updated_at"),
         },
     }
+    index_record["runtime_projection_route"] = compact_route
     if normalized_delivery_batch_scale:
         index_record["delivery_batch_scale"] = normalized_delivery_batch_scale
     if normalized_delivery_outcome:
@@ -1077,7 +1093,7 @@ def refresh_state_run(
         expected_write_scopes = ["runtime_history"]
         if active_state_next_action_update and active_state_next_action_update.get("would_update"):
             expected_write_scopes.insert(0, "active_state")
-        if sync_global:
+        if sync_global and route_status in {"resolved", "single_runtime"}:
             expected_write_scopes.append("global_registry")
         if shared_runtime_root:
             expected_write_scopes.append("shared_runtime_projection")
@@ -1087,8 +1103,10 @@ def refresh_state_run(
                 patch_parts.append("preview active-state Next Action update")
             else:
                 patch_parts.append("preserve active-state Next Action")
-        if sync_global:
+        if sync_global and route_status in {"resolved", "single_runtime"}:
             patch_parts.append("sync public-safe registry projection")
+        elif sync_global:
+            patch_parts.append(f"block global sync on {route_status} runtime projection route")
         if shared_runtime_root:
             patch_parts.append("project compact refresh to registered shared runtime")
         payload["local_state_write_correctness"] = build_local_state_write_correctness_dry_run_packet(
@@ -1100,7 +1118,11 @@ def refresh_state_run(
                 "state_file_ref": "registry.goal.state_file",
                 "run_history_ref": "runtime.goal.runs",
                 "index_ref": "runtime.goal.runs.index",
-                "global_registry_ref": "runtime.registry.global" if sync_global else None,
+                "global_registry_ref": (
+                    "runtime.registry.global"
+                    if sync_global and route_status in {"resolved", "single_runtime"}
+                    else None
+                ),
                 "shared_runtime_projection_ref": (
                     "shared_runtime.goal.runs.index" if shared_runtime_root else None
                 ),
@@ -1124,10 +1146,28 @@ def refresh_state_run(
         markdown_path.write_text(render_state_refresh_markdown(payload) + "\n", encoding="utf-8")
         with index_path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
-    if sync_global:
+    if sync_global and route_status in {"missing", "ambiguous"}:
+        payload["ok"] = False
+        payload["partial_write"] = not dry_run
+        payload["global_sync"] = {
+            "ok": False,
+            "enabled": False,
+            "wrote": False,
+            "reason": f"runtime projection route is {route_status}",
+            "route_status": route_status,
+        }
+        payload["shared_runtime_projection"] = {
+            "ok": False,
+            "status": f"route_{route_status}",
+            "dry_run": dry_run,
+            "raw_artifacts_copied": False,
+            "recommended_action_copied": False,
+            "runtime_projection_route_id": compact_route.get("route_id"),
+        }
+    elif sync_global:
         payload["global_sync"] = sync_project_registry_to_global(
             registry_path=registry_path,
-            runtime_root_override=str(shared_runtime_root or runtime_root),
+            runtime_root_override=str(global_sync_runtime_root or runtime_root),
             goal_id=safe_goal_id,
             dry_run=dry_run,
         )


### PR DESCRIPTION
## Summary

- add a registry-declared `runtime_projection_route_v0` resolver for split- and single-runtime goals
- route `refresh-state` through a reusable compact projection writer with idempotent, readback-verified append semantics
- expose missing, ambiguous, ready, healthy, and lagging route diagnostics in `status` and `doctor`
- preserve source-first writes, `--no-global-sync`, allowlisted projection privacy, and single-runtime compatibility

## Validation

- `loopx canary premerge --from-git-diff` (17/17 selected checks passed; no warnings or manual holds)
- `python3 examples/control_plane/refresh-state-shared-runtime-projection-smoke.py`
- `python3 examples/control_plane/refresh-state-write-correctness-smoke.py`
- `python3 examples/control_plane/status-collection-readmodel-smoke.py`
- `python3 examples/control_plane/status-quota-perf-budget-smoke.py`
- `python3 examples/serve-status-global-registry-smoke.py`
- `python3 examples/control_plane/status-global-registry-markdown-smoke.py`
- `uvx ruff check` and changed-file `py_compile`
