### PR TITLE
Harden SkillsBench setup dependency recovery

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -87,6 +87,9 @@ from loopx.benchmark_adapters.skillsbench_codex_runtime import (  # noqa: E402
     LOCAL_CODEX_PARTICIPANT_MATERIALIZATION_SCHEMA_VERSION,
     materialize_local_codex_participant,
 )
+from loopx.benchmark_adapters import (  # noqa: E402
+    skillsbench_dockerfile_runtime as dockerfile_runtime,
+)
 from scripts.skillsbench_automation_loop import (  # noqa: E402
     CODEX_ACP_RUNTIME_CONTAINER_BOOTSTRAP_CMD,
     CODEX_ACP_RUNTIME_DEPS_SETUP_CMD,
@@ -5691,6 +5694,18 @@ def test_skillsbench_docker_task_staging_adds_apt_retry_patch() -> None:
         assert metadata["apt_retry_patch_required"] is True, metadata
         assert metadata["apt_risk_preflight_blocked"] is False, metadata
         assert metadata["apt_retry_patch_applied"] is True, metadata
+        assert (
+            metadata["dockerfile_ubuntu_apt_mirror_patch_required"] is True
+        ), metadata
+        assert (
+            metadata["dockerfile_ubuntu_apt_mirror_patch_applied"] is True
+        ), metadata
+        assert metadata["dockerfile_ubuntu_apt_mirror_host"] == (
+            dockerfile_runtime.DEFAULT_UBUNTU_APT_MIRROR_HOST
+        ), metadata
+        assert (
+            metadata["dockerfile_ubuntu_apt_mirror_raw_url_recorded"] is False
+        ), metadata
         assert metadata["codex_acp_runtime_tools_patch_applied"] is True, metadata
         assert metadata["original_task_mutated"] is False, metadata
         assert dockerfile.read_text(encoding="utf-8") == original_text
@@ -5698,6 +5713,10 @@ def test_skillsbench_docker_task_staging_adds_apt_retry_patch() -> None:
             encoding="utf-8"
         )
         assert DOCKER_APT_RETRY_BEGIN in staged_text, staged_text
+        assert dockerfile_runtime.UBUNTU_APT_MIRROR_BEGIN in staged_text, staged_text
+        assert dockerfile_runtime.DEFAULT_UBUNTU_APT_MIRROR_BASE in staged_text
+        assert "archive.ubuntu.com/ubuntu" in staged_text
+        assert "security.ubuntu.com/ubuntu" in staged_text
         assert DOCKER_CODEX_ACP_RUNTIME_TOOLS_BEGIN in staged_text, staged_text
         assert 'Acquire::Retries "5";' in staged_text, staged_text
 

--- a/loopx/benchmark_adapters/skillsbench_dockerfile_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_dockerfile_runtime.py
@@ -44,6 +44,20 @@ def _stage_has_apt_update(lines: list[str]) -> bool:
     )
 
 
+def _dockerfile_stage_starts(lines: list[str]) -> list[int]:
+    starts: list[int] = []
+    heredoc_delimiter: str | None = None
+    for index, line in enumerate(lines):
+        if heredoc_delimiter is not None:
+            if line.strip() == heredoc_delimiter:
+                heredoc_delimiter = None
+            continue
+        heredoc_delimiter = dockerfile_heredoc_delimiter(line)
+        if re.match(r"^\s*FROM\s+", line, re.IGNORECASE):
+            starts.append(index)
+    return starts
+
+
 def needs_ubuntu_apt_mirror_patch(dockerfile: Path) -> bool:
     """Return whether a Dockerfile stage runs apt update.
 
@@ -95,11 +109,7 @@ def patch_ubuntu_apt_mirror(dockerfile: Path) -> bool:
         UBUNTU_APT_MIRROR_END,
     )
     lines = text.splitlines()
-    stage_starts = [
-        index
-        for index, line in enumerate(lines)
-        if re.match(r"^\s*FROM\s+", line, re.IGNORECASE)
-    ]
+    stage_starts = _dockerfile_stage_starts(lines)
     if not stage_starts:
         return False
 

--- a/loopx/benchmark_adapters/skillsbench_dockerfile_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_dockerfile_runtime.py
@@ -6,10 +6,130 @@ import tempfile
 from pathlib import Path
 
 VENV_PIP_INVOCATION_MARKER = "# LOOPX_SKILLSBENCH_VENV_PIP_INVOCATION"
+UBUNTU_APT_MIRROR_BEGIN = "# BEGIN LOOPX_SKILLSBENCH_UBUNTU_APT_MIRROR"
+UBUNTU_APT_MIRROR_END = "# END LOOPX_SKILLSBENCH_UBUNTU_APT_MIRROR"
+DEFAULT_UBUNTU_APT_MIRROR_BASE = "https://repo.huaweicloud.com/ubuntu"
+DEFAULT_UBUNTU_APT_MIRROR_HOST = "repo.huaweicloud.com"
 _BARE_PIP_INSTALL_RE = re.compile(
     r"(?P<prefix>^\s*(?:RUN\s+)?|(?:&&|\|\||;|\|)\s*)pip3?\s+install\b",
     re.IGNORECASE,
 )
+
+
+def _write_text_atomic(path: Path, text: str) -> None:
+    fd, temp_name = tempfile.mkstemp(prefix=path.name, dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(temp_name, path)
+    finally:
+        Path(temp_name).unlink(missing_ok=True)
+
+
+def _strip_marker_blocks(text: str, begin: str, end: str) -> str:
+    pattern = re.compile(
+        rf"^\s*{re.escape(begin)}\n.*?^\s*{re.escape(end)}\n?",
+        re.MULTILINE | re.DOTALL,
+    )
+    return pattern.sub("", text)
+
+
+def _stage_has_apt_update(lines: list[str]) -> bool:
+    return bool(
+        re.search(
+            r"\bapt(?:-get)?\s+update\b",
+            "\n".join(lines),
+            re.IGNORECASE,
+        )
+    )
+
+
+def needs_ubuntu_apt_mirror_patch(dockerfile: Path) -> bool:
+    """Return whether a Dockerfile stage runs apt update.
+
+    The staged patch is adaptive: it rewrites only Ubuntu source files found
+    in the image, so Debian and other apt-based images are left unchanged.
+    """
+
+    if not dockerfile.exists():
+        return False
+    text = _strip_marker_blocks(
+        dockerfile.read_text(encoding="utf-8", errors="replace"),
+        UBUNTU_APT_MIRROR_BEGIN,
+        UBUNTU_APT_MIRROR_END,
+    )
+    return _stage_has_apt_update(text.splitlines())
+
+
+def _ubuntu_apt_mirror_block() -> list[str]:
+    return [
+        UBUNTU_APT_MIRROR_BEGIN,
+        f"ARG LOOPX_SKILLSBENCH_UBUNTU_APT_MIRROR={DEFAULT_UBUNTU_APT_MIRROR_BASE}",
+        "RUN set -eux; \\",
+        "    if [ -d /etc/apt ] && [ -w /etc/apt ]; then \\",
+        "      find /etc/apt -type f \\",
+        "        \\( -name '*.list' -o -name '*.sources' \\) \\",
+        "        -exec sed -i \\",
+        '          -e "s#https\\?://archive.ubuntu.com/ubuntu#${LOOPX_SKILLSBENCH_UBUNTU_APT_MIRROR}#g" \\',
+        '          -e "s#https\\?://security.ubuntu.com/ubuntu#${LOOPX_SKILLSBENCH_UBUNTU_APT_MIRROR}#g" \\',
+        "          {} +; \\",
+        "      if [ -w /var/lib/apt/lists ]; then rm -rf /var/lib/apt/lists/*; fi; \\",
+        "    else \\",
+        "      echo 'loopx Ubuntu apt mirror skipped: apt directory is not writable'; \\",
+        "    fi",
+        UBUNTU_APT_MIRROR_END,
+    ]
+
+
+def patch_ubuntu_apt_mirror(dockerfile: Path) -> bool:
+    """Add a staged-only Ubuntu apt mirror fallback to apt-using stages."""
+
+    if not dockerfile.exists():
+        return False
+    original = dockerfile.read_text(encoding="utf-8", errors="replace")
+    if UBUNTU_APT_MIRROR_BEGIN in original and UBUNTU_APT_MIRROR_END in original:
+        return False
+    text = _strip_marker_blocks(
+        original,
+        UBUNTU_APT_MIRROR_BEGIN,
+        UBUNTU_APT_MIRROR_END,
+    )
+    lines = text.splitlines()
+    stage_starts = [
+        index
+        for index, line in enumerate(lines)
+        if re.match(r"^\s*FROM\s+", line, re.IGNORECASE)
+    ]
+    if not stage_starts:
+        return False
+
+    patched_lines = lines[: stage_starts[0]]
+    applied = False
+    for position, start in enumerate(stage_starts):
+        end = (
+            stage_starts[position + 1]
+            if position + 1 < len(stage_starts)
+            else len(lines)
+        )
+        stage_lines = lines[start:end]
+        from_line = stage_lines[0].strip().lower()
+        if _stage_has_apt_update(stage_lines) and not re.match(
+            r"from(?:\s+--platform=\S+)?\s+scratch(?:\s|$)",
+            from_line,
+        ):
+            patched_lines.extend(
+                [stage_lines[0], "", *_ubuntu_apt_mirror_block(), "", *stage_lines[1:]]
+            )
+            applied = True
+        else:
+            patched_lines.extend(stage_lines)
+    if not applied:
+        return False
+    patched = "\n".join(patched_lines).rstrip() + "\n"
+    if patched == original:
+        return False
+    _write_text_atomic(dockerfile, patched)
+    return True
 
 
 def dockerfile_heredoc_delimiter(line: str) -> str | None:
@@ -65,7 +185,11 @@ def _rewrite_venv_stage_pip_installs(text: str) -> tuple[str, int]:
     rewritten_lines = lines[: stage_starts[0]]
     replaced = 0
     for position, start in enumerate(stage_starts):
-        end = stage_starts[position + 1] if position + 1 < len(stage_starts) else len(lines)
+        end = (
+            stage_starts[position + 1]
+            if position + 1 < len(stage_starts)
+            else len(lines)
+        )
         stage_text = "\n".join(lines[start:end])
         if _stage_activates_venv(stage_text):
             stage_text, stage_replaced = _rewrite_bare_pip_installs(stage_text)
@@ -91,7 +215,11 @@ def patch_venv_pip_invocations(dockerfile: Path) -> bool:
     patched, _ = _rewrite_venv_stage_pip_installs(original)
     lines = patched.splitlines()
     from_index = next(
-        (index for index, line in enumerate(lines) if line.lstrip().upper().startswith("FROM ")),
+        (
+            index
+            for index, line in enumerate(lines)
+            if line.lstrip().upper().startswith("FROM ")
+        ),
         -1,
     )
     lines.insert(from_index + 1, VENV_PIP_INVOCATION_MARKER)

--- a/loopx/benchmark_adapters/skillsbench_failure_signals.py
+++ b/loopx/benchmark_adapters/skillsbench_failure_signals.py
@@ -16,7 +16,10 @@ _SETUP_ATTRIBUTION_FINGERPRINT_PATTERNS = {
 }
 _FINGERPRINT_SETUP_ATTRIBUTIONS = (
     ("docker_api_version_mismatch", "skillsbench_docker_api_version_mismatch"),
-    ("docker_compose_plugin_unavailable", "skillsbench_docker_compose_plugin_unavailable"),
+    (
+        "docker_compose_plugin_unavailable",
+        "skillsbench_docker_compose_plugin_unavailable",
+    ),
     ("docker_daemon_unavailable", "skillsbench_docker_daemon_unavailable"),
     ("port_conflict", "skillsbench_docker_compose_port_conflict"),
     ("pip_bootstrap_failure", "skillsbench_docker_compose_pip_bootstrap_failure"),
@@ -76,20 +79,176 @@ _FAILURE_DEPENDENCY_CLASS_PATTERNS = (
     ("model_artifact", r"huggingface\.co|hf\.co"),
 )
 
+_FAILURE_REASON_PATTERNS = (
+    (
+        "dns_resolution",
+        r"temporary failure in name resolution|name or service not known|"
+        r"could not resolve host",
+    ),
+    (
+        "connection_timeout",
+        r"connection timed out|connect timeout|read timed out|operation timed out",
+    ),
+    ("connection_refused", r"connection refused|could not connect"),
+    ("connection_reset", r"connection reset|remote end closed connection"),
+    ("retry_exhausted", r"max retries exceeded"),
+    (
+        "proxy_connect",
+        r"proxyerror|proxy error|tunnel connection failed|"
+        r"cannot connect to proxy|could not connect to proxy",
+    ),
+    (
+        "tls_or_certificate",
+        r"certificate verify failed|ssl certificate problem|tls handshake|"
+        r"unable to get local issuer certificate",
+    ),
+    ("http_not_found", r"(?:http[^\n]*\s404\b|404 not found)"),
+    ("http_server_error", r"(?:http[^\n]*\s5\d\d\b|5\d\d server error)"),
+    ("apt_fetch_failed", r"failed to fetch"),
+    ("apt_signature_or_gpg", r"gpg error|no_pubkey|signatures? couldn.t be verified"),
+    ("apt_hash_mismatch", r"hash sum mismatch|hashes of expected file"),
+    (
+        "apt_release_expired",
+        r"release file .* is not valid yet|release file .* expired|"
+        r"does not have a release file",
+    ),
+    (
+        "apt_package_unavailable",
+        r"unable to locate package|has no installation candidate|"
+        r"couldn.t find any package",
+    ),
+    (
+        "pip_no_matching_distribution",
+        r"no matching distribution found|"
+        r"could not find a version that satisfies the requirement",
+    ),
+    (
+        "pip_build_failure",
+        r"failed building wheel|failed to build installable wheels|"
+        r"pip subprocess to install build dependencies did not run successfully|"
+        r"subprocess-exited-with-error",
+    ),
+    ("pip_os_error", r"could not install packages due to an oserror"),
+    ("permission_denied", r"permission denied|operation not permitted"),
+    ("missing_file", r"no such file|does not exist"),
+    ("no_space_left", r"no space left on device"),
+)
+
+_FAILURE_DEPENDENCY_ENDPOINT_PATTERNS = (
+    ("debian_repository", r"deb\.debian\.org|security\.debian\.org"),
+    ("ubuntu_repository", r"archive\.ubuntu\.com|security\.ubuntu\.com"),
+    ("ubuntu_repository_mirror", r"repo\.huaweicloud\.com/ubuntu"),
+    ("apache_archive", r"archive\.apache\.org|dlcdn\.apache\.org"),
+    ("maven_central", r"repo1\.maven\.org|repo\.maven\.apache\.org"),
+    ("github_release", r"github\.com/.+/(?:releases|archive)/"),
+    ("pypi_primary", r"pypi\.org|files\.pythonhosted\.org"),
+    ("pypi_mirror", r"pypi\.tuna\.tsinghua\.edu\.cn"),
+    ("docker_registry", r"registry-1\.docker\.io|docker\.io|gcr\.io|ghcr\.io"),
+)
+
+_TRANSIENT_FAILURE_REASONS = {
+    "connection_refused",
+    "connection_reset",
+    "connection_timeout",
+    "dns_resolution",
+    "http_server_error",
+    "proxy_connect",
+    "retry_exhausted",
+}
+_DETERMINISTIC_FAILURE_REASONS = {
+    "apt_package_unavailable",
+    "http_not_found",
+    "missing_file",
+    "no_space_left",
+    "permission_denied",
+    "pip_build_failure",
+    "pip_no_matching_distribution",
+    "pip_os_error",
+    "tls_or_certificate",
+}
+
+
+def _dependency_classes_for_lines(lines: list[str]) -> list[str]:
+    return [
+        label
+        for label, pattern in _FAILURE_DEPENDENCY_CLASS_PATTERNS
+        if any(re.search(pattern, line) for line in lines)
+    ]
+
+
+def _failure_reasons_for_lines(lines: list[str]) -> list[str]:
+    return [
+        label
+        for label, pattern in _FAILURE_REASON_PATTERNS
+        if any(re.search(pattern, line) for line in lines)
+    ]
+
+
+def _dependency_endpoints_for_lines(lines: list[str]) -> list[str]:
+    return [
+        label
+        for label, pattern in _FAILURE_DEPENDENCY_ENDPOINT_PATTERNS
+        if any(re.search(pattern, line) for line in lines)
+    ]
+
+
+def _failure_signal_lines(error_text: str) -> list[str]:
+    return [
+        line.lower()
+        for line in error_text.splitlines()
+        if any(marker in line.lower() for marker in _FAILURE_LINE_MARKERS)
+        or any(
+            re.search(pattern, line.lower()) for _, pattern in _FAILURE_REASON_PATTERNS
+        )
+    ]
+
 
 def skillsbench_failure_dependency_classes(error_text: str) -> list[str]:
     """Classify dependencies named on public-safe failure lines."""
 
-    failure_lines = [
-        line.lower()
-        for line in error_text.splitlines()
-        if any(marker in line.lower() for marker in _FAILURE_LINE_MARKERS)
-    ]
-    return [
-        label
-        for label, pattern in _FAILURE_DEPENDENCY_CLASS_PATTERNS
-        if any(re.search(pattern, line) for line in failure_lines)
-    ]
+    return _dependency_classes_for_lines(_failure_signal_lines(error_text))
+
+
+def skillsbench_terminal_failure_signals(error_text: str) -> dict[str, object]:
+    """Return the last dependency-bearing failure signal without raw text."""
+
+    failure_lines = _failure_signal_lines(error_text)
+    terminal_classes: list[str] = []
+    terminal_reasons: list[str] = []
+    terminal_endpoints: list[str] = []
+    for line in reversed(failure_lines):
+        if not terminal_classes:
+            terminal_classes = _dependency_classes_for_lines([line])
+        if not terminal_reasons:
+            terminal_reasons = _failure_reasons_for_lines([line])
+        if not terminal_endpoints:
+            terminal_endpoints = _dependency_endpoints_for_lines([line])
+        if terminal_classes and terminal_reasons and terminal_endpoints:
+            break
+
+    reasons = _failure_reasons_for_lines(failure_lines)
+    endpoints = _dependency_endpoints_for_lines(failure_lines)
+    reason_set = set(reasons)
+    if reason_set and reason_set <= _TRANSIENT_FAILURE_REASONS:
+        retryability = "retryable"
+    elif reason_set & _DETERMINISTIC_FAILURE_REASONS:
+        retryability = (
+            "mixed" if reason_set & _TRANSIENT_FAILURE_REASONS else "non_retryable"
+        )
+    elif reason_set:
+        retryability = "unknown"
+    else:
+        retryability = "unknown"
+
+    return {
+        "failure_reason_codes": reasons,
+        "terminal_failure_dependency_classes": terminal_classes,
+        "terminal_failure_reason_codes": terminal_reasons,
+        "failure_dependency_endpoints": endpoints,
+        "terminal_failure_dependency_endpoints": terminal_endpoints,
+        "retryability": retryability,
+        "raw_error_recorded": False,
+    }
 
 
 def skillsbench_setup_failure_category(
@@ -100,11 +259,7 @@ def skillsbench_setup_failure_category(
     matched_patterns = fingerprint.get("matched_patterns")
     if not isinstance(matched_patterns, list):
         return "skillsbench_docker_compose_setup_failure"
-    matched = {
-        str(item)
-        for item in matched_patterns
-        if isinstance(item, str)
-    }
+    matched = {str(item) for item in matched_patterns if isinstance(item, str)}
     return next(
         (
             attribution
@@ -128,11 +283,7 @@ def reconcile_skillsbench_setup_attribution(
     matched_patterns = fingerprint.get("matched_patterns")
     if not isinstance(matched_patterns, list):
         return False
-    matched = {
-        str(item)
-        for item in matched_patterns
-        if isinstance(item, str)
-    }
+    matched = {str(item) for item in matched_patterns if isinstance(item, str)}
     if required_pattern in matched:
         return False
 
@@ -236,8 +387,7 @@ def skillsbench_pip_bootstrap_failure_evidence(error_text: str) -> bool:
         " failed",
     )
     return any(
-        pip_command.search(line)
-        and any(marker in line for marker in command_failures)
+        pip_command.search(line) and any(marker in line for marker in command_failures)
         for line in text.splitlines()
     )
 
@@ -313,15 +463,15 @@ def skillsbench_runner_error_fingerprint(error_text: str) -> dict[str, object]:
             pattern_matched = bool(re.search(pattern, lowered))
         if pattern_matched:
             matched.append(label)
+    terminal_signals = skillsbench_terminal_failure_signals(text)
     return {
         "schema_version": "skillsbench_runner_failure_fingerprint_v0",
         "error_present": bool(text),
         "error_len_bucket": skillsbench_error_len_bucket(text),
         "line_count": len(text.splitlines()) if text else 0,
         "matched_patterns": matched,
-        "failure_line_dependency_classes": skillsbench_failure_dependency_classes(
-            text
-        ),
+        "failure_line_dependency_classes": skillsbench_failure_dependency_classes(text),
+        **terminal_signals,
         "has_host_paths": bool(re.search(r"/Users/|/private/|/var/folders/", text)),
         "has_urls": bool(re.search(r"https?://", text)),
         "has_secret_like_tokens": bool(

--- a/loopx/benchmark_adapters/skillsbench_setup_preflight.py
+++ b/loopx/benchmark_adapters/skillsbench_setup_preflight.py
@@ -67,6 +67,12 @@ def _base_result(
         "agent_execution_invoked": False,
         "verifier_invoked": False,
         "dependency_classes": [],
+        "terminal_dependency_classes": [],
+        "failure_reason_codes": [],
+        "terminal_failure_reason_codes": [],
+        "dependency_endpoints": [],
+        "terminal_dependency_endpoints": [],
+        "retryability": "unknown",
         "failure_category": "none",
         "exit_category": "pending",
         "patch_hits": _patch_hits(task_staging),
@@ -152,6 +158,32 @@ async def run_setup_only_public_preflight(
             for item in fingerprint.get("failure_line_dependency_classes", [])
             if isinstance(item, str)
         ]
+        result["terminal_dependency_classes"] = [
+            str(item)
+            for item in fingerprint.get("terminal_failure_dependency_classes", [])
+            if isinstance(item, str)
+        ]
+        result["failure_reason_codes"] = [
+            str(item)
+            for item in fingerprint.get("failure_reason_codes", [])
+            if isinstance(item, str)
+        ]
+        result["terminal_failure_reason_codes"] = [
+            str(item)
+            for item in fingerprint.get("terminal_failure_reason_codes", [])
+            if isinstance(item, str)
+        ]
+        result["dependency_endpoints"] = [
+            str(item)
+            for item in fingerprint.get("failure_dependency_endpoints", [])
+            if isinstance(item, str)
+        ]
+        result["terminal_dependency_endpoints"] = [
+            str(item)
+            for item in fingerprint.get("terminal_failure_dependency_endpoints", [])
+            if isinstance(item, str)
+        ]
+        result["retryability"] = str(fingerprint.get("retryability") or "unknown")
         result["fingerprint_patterns"] = sorted(matched_patterns)
         result["fingerprint_confidence"] = str(
             fingerprint.get("fingerprint_confidence")

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -5601,6 +5601,9 @@ def _public_task_staging(value: Any) -> dict[str, Any]:
         "include_task_skills",
         "apt_setup_risk_detected",
         "apt_retry_patch_required",
+        "dockerfile_ubuntu_apt_mirror_patch_required",
+        "dockerfile_ubuntu_apt_mirror_patch_applied",
+        "dockerfile_ubuntu_apt_mirror_raw_url_recorded",
         "dockerfile_pip_install_risk_detected",
         "dockerfile_pip_bootstrap_patch_required",
         "dockerfile_pip_bootstrap_patch_applied",
@@ -5668,6 +5671,7 @@ def _public_task_staging(value: Any) -> dict[str, Any]:
         "verifier_uv_bootstrap_mirror_host",
         "dockerfile_apache_archive_mirror_host",
         "dockerfile_maven_mirror_host",
+        "dockerfile_ubuntu_apt_mirror_host",
     ):
         raw = value.get(field)
         if isinstance(raw, str) and raw:
@@ -5747,6 +5751,15 @@ def _discover_prepared_task_staging(plan: dict[str, Any]) -> dict[str, Any]:
             DOCKER_APP_SKILLS_MOUNT_BEGIN in dockerfile_text
         ),
         "apt_retry_patch_applied": DOCKER_APT_RETRY_BEGIN in dockerfile_text,
+        "dockerfile_ubuntu_apt_mirror_patch_applied": (
+            dockerfile_runtime.UBUNTU_APT_MIRROR_BEGIN in dockerfile_text
+        ),
+        "dockerfile_ubuntu_apt_mirror_host": (
+            dockerfile_runtime.DEFAULT_UBUNTU_APT_MIRROR_HOST
+            if dockerfile_runtime.UBUNTU_APT_MIRROR_BEGIN in dockerfile_text
+            else ""
+        ),
+        "dockerfile_ubuntu_apt_mirror_raw_url_recorded": False,
         "dockerfile_pip_bootstrap_patch_applied": (
             DOCKER_PIP_BOOTSTRAP_BEGIN in dockerfile_text
         ),
@@ -7615,6 +7628,10 @@ def stage_task_for_sandbox(
         "staged": False,
         "app_skills_mount_patch_applied": False,
         "apt_retry_patch_applied": False,
+        "dockerfile_ubuntu_apt_mirror_patch_required": False,
+        "dockerfile_ubuntu_apt_mirror_patch_applied": False,
+        "dockerfile_ubuntu_apt_mirror_host": "",
+        "dockerfile_ubuntu_apt_mirror_raw_url_recorded": False,
         "dockerfile_pip_install_risk_detected": False,
         "dockerfile_pip_bootstrap_patch_required": False,
         "dockerfile_pip_bootstrap_patch_applied": False,
@@ -7689,6 +7706,11 @@ def stage_task_for_sandbox(
     needs_apt_retry_patch = dockerfile_needs_apt_retry_patch(
         task_path / "environment" / "Dockerfile"
     )
+    needs_ubuntu_apt_mirror_patch = (
+        dockerfile_runtime.needs_ubuntu_apt_mirror_patch(
+            task_path / "environment" / "Dockerfile"
+        )
+    )
     needs_pip_bootstrap_patch = dockerfile_needs_pip_bootstrap_patch(
         task_path / "environment" / "Dockerfile"
     )
@@ -7746,6 +7768,13 @@ def stage_task_for_sandbox(
     metadata["apt_setup_risk_detected"] = needs_apt_retry_patch
     metadata["apt_retry_patch_required"] = needs_apt_retry_patch
     metadata["apt_risk_preflight_blocked"] = False
+    metadata["dockerfile_ubuntu_apt_mirror_patch_required"] = (
+        needs_ubuntu_apt_mirror_patch
+    )
+    if needs_ubuntu_apt_mirror_patch:
+        metadata["dockerfile_ubuntu_apt_mirror_host"] = (
+            dockerfile_runtime.DEFAULT_UBUNTU_APT_MIRROR_HOST
+        )
     metadata["dockerfile_pip_install_risk_detected"] = needs_pip_bootstrap_patch
     metadata["dockerfile_pip_bootstrap_patch_required"] = needs_pip_bootstrap_patch
     metadata["dockerfile_venv_pip_invocation_patch_required"] = (
@@ -7834,6 +7863,7 @@ def stage_task_for_sandbox(
         not has_task_skills
         and not needs_resource_cap
         and not needs_apt_retry_patch
+        and not needs_ubuntu_apt_mirror_patch
         and not needs_pip_bootstrap_patch
         and not needs_venv_pip_invocation_patch
         and not needs_gcr_mirror_patch
@@ -7888,6 +7918,9 @@ def stage_task_for_sandbox(
         proxy_env=benchmark_egress_proxy_env,
     )
     apt_retry_patched = patch_dockerfile_apt_retry(
+        staged_path / "environment" / "Dockerfile"
+    )
+    ubuntu_apt_mirror_patched = dockerfile_runtime.patch_ubuntu_apt_mirror(
         staged_path / "environment" / "Dockerfile"
     )
     pip_bootstrap_patched = patch_dockerfile_pip_bootstrap(
@@ -7946,6 +7979,15 @@ def stage_task_for_sandbox(
             "staged_task_path": str(staged_path),
             "app_skills_mount_patch_applied": patched,
             "apt_retry_patch_applied": apt_retry_patched,
+            "dockerfile_ubuntu_apt_mirror_patch_applied": (
+                ubuntu_apt_mirror_patched
+            ),
+            "dockerfile_ubuntu_apt_mirror_host": (
+                dockerfile_runtime.DEFAULT_UBUNTU_APT_MIRROR_HOST
+                if ubuntu_apt_mirror_patched
+                else ""
+            ),
+            "dockerfile_ubuntu_apt_mirror_raw_url_recorded": False,
             "dockerfile_pip_bootstrap_patch_applied": pip_bootstrap_patched,
             "dockerfile_venv_pip_invocation_patch_applied": (
                 venv_pip_invocation_patched

--- a/tests/test_skillsbench_dockerfile_runtime.py
+++ b/tests/test_skillsbench_dockerfile_runtime.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from loopx.benchmark_adapters import skillsbench_dockerfile_runtime as runtime
+
+
+def _dockerfile(tmp_path: Path, text: str) -> Path:
+    path = tmp_path / "Dockerfile"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_ubuntu_apt_mirror_patch_is_staged_per_apt_stage(tmp_path: Path) -> None:
+    dockerfile = _dockerfile(
+        tmp_path,
+        "FROM alpine:3.20 AS source\n"
+        "RUN echo source\n"
+        "FROM ubuntu:24.04\n"
+        "RUN apt-get update && apt-get install -y curl\n",
+    )
+
+    assert runtime.needs_ubuntu_apt_mirror_patch(dockerfile) is True
+    assert runtime.patch_ubuntu_apt_mirror(dockerfile) is True
+
+    patched = dockerfile.read_text(encoding="utf-8")
+    assert patched.count(runtime.UBUNTU_APT_MIRROR_BEGIN) == 1
+    assert runtime.DEFAULT_UBUNTU_APT_MIRROR_BASE in patched
+    assert "archive.ubuntu.com/ubuntu" in patched
+    assert "security.ubuntu.com/ubuntu" in patched
+    assert runtime.patch_ubuntu_apt_mirror(dockerfile) is False
+
+
+def test_ubuntu_apt_mirror_patch_skips_dockerfiles_without_apt(tmp_path: Path) -> None:
+    dockerfile = _dockerfile(tmp_path, "FROM ubuntu:24.04\nRUN echo ready\n")
+
+    assert runtime.needs_ubuntu_apt_mirror_patch(dockerfile) is False
+    assert runtime.patch_ubuntu_apt_mirror(dockerfile) is False
+    assert runtime.UBUNTU_APT_MIRROR_BEGIN not in dockerfile.read_text(encoding="utf-8")

--- a/tests/test_skillsbench_dockerfile_runtime.py
+++ b/tests/test_skillsbench_dockerfile_runtime.py
@@ -35,3 +35,20 @@ def test_ubuntu_apt_mirror_patch_skips_dockerfiles_without_apt(tmp_path: Path) -
     assert runtime.needs_ubuntu_apt_mirror_patch(dockerfile) is False
     assert runtime.patch_ubuntu_apt_mirror(dockerfile) is False
     assert runtime.UBUNTU_APT_MIRROR_BEGIN not in dockerfile.read_text(encoding="utf-8")
+
+
+def test_ubuntu_apt_mirror_patch_ignores_from_inside_heredoc(tmp_path: Path) -> None:
+    dockerfile = _dockerfile(
+        tmp_path,
+        "FROM ubuntu:24.04\n"
+        "RUN python3 <<'PY'\n"
+        "FROM not-a-docker-stage\n"
+        "PY\n"
+        "RUN apt-get update\n",
+    )
+
+    assert runtime.patch_ubuntu_apt_mirror(dockerfile) is True
+
+    patched = dockerfile.read_text(encoding="utf-8")
+    assert patched.count(runtime.UBUNTU_APT_MIRROR_BEGIN) == 1
+    assert patched.index(runtime.UBUNTU_APT_MIRROR_BEGIN) < patched.index("RUN python3")

--- a/tests/test_skillsbench_setup_preflight.py
+++ b/tests/test_skillsbench_setup_preflight.py
@@ -197,6 +197,93 @@ def test_setup_only_preflight_classifies_public_setup_failures(
     assert result["raw_logs_read"] is False
 
 
+@pytest.mark.parametrize(
+    (
+        "message",
+        "terminal_dependency_classes",
+        "failure_reason_codes",
+        "retryability",
+    ),
+    [
+        (
+            "Docker compose command failed. ERROR: failed to solve: process "
+            "/bin/sh -c apt-get install missing-package did not complete "
+            "successfully: unable to locate package missing-package",
+            ["system_package"],
+            ["apt_package_unavailable"],
+            "non_retryable",
+        ),
+        (
+            "Docker compose command failed. ERROR: failed to solve: process "
+            "/bin/sh -c pip3 install numpy did not complete successfully: "
+            "read timed out for pypi.org; max retries exceeded",
+            ["python_package"],
+            ["connection_timeout", "retry_exhausted"],
+            "retryable",
+        ),
+        (
+            "Docker compose command failed: invalid mount config for type "
+            "bind: bind source path does not exist",
+            [],
+            ["missing_file"],
+            "non_retryable",
+        ),
+    ],
+)
+def test_setup_only_preflight_projects_terminal_failure_signals(
+    message: str,
+    terminal_dependency_classes: list[str],
+    failure_reason_codes: list[str],
+    retryability: str,
+) -> None:
+    FakeRollout.failure_stage = "environment_start"
+    FakeRollout.failure = RuntimeError(message)
+
+    result = run_preflight()
+
+    assert result["terminal_dependency_classes"] == terminal_dependency_classes
+    assert result["failure_reason_codes"] == failure_reason_codes
+    assert result["terminal_failure_reason_codes"] == failure_reason_codes
+    assert result["retryability"] == retryability
+    assert message not in json.dumps(result, sort_keys=True)
+
+
+def test_setup_only_preflight_separates_terminal_reason_and_endpoint() -> None:
+    FakeRollout.failure_stage = "environment_start"
+    FakeRollout.failure = RuntimeError(
+        "failed to fetch https://archive.ubuntu.com/package-index\n"
+        "failed to solve: process /bin/sh -c apt-get update && wget "
+        "https://archive.apache.org/dist/tool.tgz did not complete successfully"
+    )
+
+    result = run_preflight()
+
+    assert result["terminal_dependency_classes"] == [
+        "system_package",
+        "http_download",
+    ]
+    assert result["terminal_failure_reason_codes"] == ["apt_fetch_failed"]
+    assert result["dependency_endpoints"] == [
+        "ubuntu_repository",
+        "apache_archive",
+    ]
+    assert result["terminal_dependency_endpoints"] == ["apache_archive"]
+    assert result["raw_error_recorded"] is False
+
+
+def test_setup_only_preflight_classifies_ubuntu_mirror_without_raw_url() -> None:
+    FakeRollout.failure_stage = "environment_start"
+    FakeRollout.failure = RuntimeError(
+        "failed to fetch https://repo.huaweicloud.com/ubuntu/package-index"
+    )
+
+    result = run_preflight()
+
+    assert result["terminal_dependency_endpoints"] == ["ubuntu_repository_mirror"]
+    assert result["terminal_failure_reason_codes"] == ["apt_fetch_failed"]
+    assert "huaweicloud" not in json.dumps(result, sort_keys=True)
+
+
 def test_setup_only_preflight_reports_cleanup_failure_without_raw_error() -> None:
     FakeRollout.failure_stage = "cleanup"
     FakeRollout.failure = RuntimeError("secret cleanup detail /private/job")


### PR DESCRIPTION
## Summary
- add public-safe setup failure reason, terminal dependency, endpoint, and retryability projection
- add a staged-only adaptive Ubuntu apt mirror fallback for apt-using Dockerfile stages
- preserve the original task and expose only bounded patch metadata
- cover the helper, public preflight projection, and runner staging integration

## Validation
- `uv run --no-project --with pytest pytest -q tests/test_skillsbench_dockerfile_runtime.py tests/test_skillsbench_setup_preflight.py` (15 passed)
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `loopx canary premerge --from-git-diff`: compile, 6 selected canaries, and public-boundary scan passed
- setup-only confirmation: both targeted setup cases reached `environment_ready_before_agent`, cleaned up, and did not invoke agent install, agent execution, or verifier
- public artifact sync completed with raw task, log, trajectory, verifier output, host path, and secret flags false

## Manual hold review
The canary reports the expected `benchmark_sensitive` manual hold. This change is limited to public benchmark setup diagnostics and staged dependency recovery. It does not change scoring, task semantics, leaderboard/submission behavior, permission boundaries, or launch jobs from shipped code. Owner authorization for benchmark self-merge is recorded in the task.

## Exclusions
Private run state, raw benchmark evidence, credentials, local paths, generated logs, and temporary probes are not included.