### PR TITLE
Add reward memory Stage 4 evaluation gate

### DIFF
--- a/docs/reference/protocols/reward-memory-architecture-v0.md
+++ b/docs/reference/protocols/reward-memory-architecture-v0.md
@@ -321,3 +321,31 @@ application also preserves the base output. An `applied` receipt requires both
 attribution to an item returned by this recall and current-artifact
 verification. Issue Fix uses the fixed `issue_fix.patch_planning` surface;
 `semantic_preference` is the second, non-Issue-Fix module consumer.
+
+## Stage 4 evaluation and release gate
+
+Stage 4 is one bounded contract suite over the existing shared core. It does
+not add another evaluator, store, provider, scheduler, or semantic router:
+
+```bash
+loopx reward-memory evaluate --format json
+```
+
+The runner executes the real candidate, recall, application, Issue Fix adapter,
+and route-guard code for eight cases: compact/restart survival; project and
+module isolation; supersede/revoke rejection; stale-source rejection;
+multi-person authority matching; gate non-override; verified candidate-ranking
+influence; and protection against a large patch for the PR #3237 edge case.
+
+`reward_memory_evaluation_v0` reports task outcome plus exact local runner
+latency, public evidence bytes, model-token count, provider/storage writes,
+false applications, maintainer interruptions, and user gates. Zero model tokens
+means this deterministic contract suite did not invoke a model; it is not a
+token-cost estimate for later dogfood. The release gate passes only when every
+case passes and all write, false-application, interruption, and user-gate counts
+remain zero.
+
+A pass yields `ready_for_bounded_dogfood`, not production release. It proves
+core contract invariants only, does not claim semantic uplift, and does not
+authorize production rollout. Stage 5 must use a corpus-owner-approved record,
+exact provider readback, and real module outcomes before making an uplift claim.

--- a/docs/reference/protocols/reward-memory-architecture-v0.zh-CN.md
+++ b/docs/reference/protocols/reward-memory-architecture-v0.zh-CN.md
@@ -271,3 +271,27 @@ Provider 不可用时，seam 返回 setup guidance 并保留原输出；这是 a
 不会自动变成 user gate。模型 application 无效或异常也 fail open。只有同时归因到本次
 召回项并验证当前 artifact，才能产生 `applied` receipt。Issue Fix 使用固定的
 `issue_fix.patch_planning` surface；`semantic_preference` 是第二个非 Issue-Fix consumer。
+
+## Stage 4 评估与发布门禁
+
+Stage 4 只在现有共享核心之上增加一套受限 contract suite，不新增另一套 evaluator、
+store、provider、scheduler 或 semantic router：
+
+```bash
+loopx reward-memory evaluate --format json
+```
+
+Runner 会直接执行真实的 candidate、recall、application、Issue Fix adapter 与 route guard
+代码，覆盖八类 case：compact/restart 后存活；project/module scope isolation；
+supersede/revoke 拒绝；stale source 拒绝；多人 authority 匹配；gate 不被覆盖；在验证当前
+artifact 后影响 candidate ranking；以及避免为 PR #3237 这类 edge case 生成大 patch。
+
+`reward_memory_evaluation_v0` 同时汇报 task outcome、真实本地 runner latency、公共证据
+字节数、model token 数、provider/storage write、false application、maintainer interruption
+与 user gate。model token 为零表示这套确定性 contract suite 没有调用模型，不代表后续
+dogfood 的 token 成本估算。只有全部 case 通过，且 write、false application、
+interruption 和 user gate 计数均为零，release gate 才能通过。
+
+通过后的状态是 `ready_for_bounded_dogfood`，不是 production release。它只证明 core
+contract invariant，不声明 semantic uplift，也不授权 production rollout。Stage 5 必须
+使用经 corpus owner 批准的 record、精确 provider readback 和真实模块结果，才能讨论收益。

--- a/examples/reward-memory-evaluation-smoke.py
+++ b/examples/reward-memory-evaluation-smoke.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+
+from loopx.capabilities.reward_memory import run_reward_memory_evaluation  # noqa: E402
+
+
+def main() -> None:
+    packet = run_reward_memory_evaluation()
+    assert packet["schema_version"] == "reward_memory_evaluation_v0", packet
+    assert packet["status"] == "passed", packet
+    assert packet["metrics"]["case_count"] == 8, packet
+    assert packet["metrics"]["failed_case_count"] == 0, packet
+    assert packet["metrics"]["false_application_count"] == 0, packet
+    assert packet["metrics"]["storage_write_bytes"] == 0, packet
+    assert packet["metrics"]["maintainer_interruption_count"] == 0, packet
+    assert packet["release_gate"]["status"] == "ready_for_bounded_dogfood", packet
+    assert packet["release_gate"]["semantic_uplift_claim_allowed"] is False, packet
+    assert packet["release_gate"]["production_rollout_allowed"] is False, packet
+    assert packet["boundaries"]["new_store_provider_or_scheduler_added"] is False
+    print("reward-memory-evaluation-smoke: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -324,6 +324,11 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "purpose": "Exercise the Stage-2 shared candidate/review seam through the mapping-only Issue Fix adapter.",
                 "write_boundary": "stateless decision output only; persistence stays with the declared corpus owner and this command performs no provider or external write",
             },
+            {
+                "command": "loopx reward-memory evaluate --format json",
+                "purpose": "Run the Stage-4 provider-neutral core-contract suite and compact release gate over the real recall/application seam.",
+                "write_boundary": "bounded local fixture reads only; no provider, memory, repository, state, model API, or external write",
+            },
         ],
         "implemented_protocols": [
             {
@@ -391,12 +396,23 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "module": "loopx.capabilities.semantic_preference.reward_memory",
                 "doc": "docs/reference/protocols/reward-memory-architecture-v0.md",
             },
+            {
+                "schema_version": "reward_memory_evaluation_v0",
+                "module": "loopx.capabilities.reward_memory.evaluation",
+                "doc": "docs/reference/protocols/reward-memory-architecture-v0.md",
+            },
+            {
+                "schema_version": "reward_memory_release_gate_v0",
+                "module": "loopx.capabilities.reward_memory.evaluation",
+                "doc": "docs/reference/protocols/reward-memory-architecture-v0.md",
+            },
         ],
         "smokes": [
             "python3 examples/reward-memory-architecture-smoke.py",
             "python3 examples/reward-memory-corpus-registry-smoke.py",
             "python3 examples/reward-memory-candidate-review-smoke.py",
             "python3 examples/reward-memory-recall-application-smoke.py",
+            "python3 examples/reward-memory-evaluation-smoke.py",
         ],
         "docs": [
             "docs/reference/protocols/reward-memory-architecture-v0.md",
@@ -418,11 +434,12 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
             "Function-boundary recall permits one caller-owned query; bounded agentic search permits at most three caller/model-owned queries and contains no semantic router.",
             "Provider and application failures preserve the base output, emit compact receipts or setup hints, and never become user gates automatically.",
             "Private corpus summaries stay transient in-process; public packets retain opaque references and compact lineage only.",
+            "Stage 4 proves bounded core-contract invariants only; its fixture pass does not claim semantic uplift or authorize production rollout.",
         ],
         "next_real_step": (
-            "Activate one reviewed record through its declared corpus owner, verify "
-            "exact provider readback, and prove an Issue Fix patch-planning receipt "
-            "before advancing to the Stage-4 evaluation gate."
+            "Run bounded Stage-5 dogfood through the declared corpus owner, verify "
+            "exact provider readback, and compare real Issue Fix planning outcomes "
+            "without widening the Stage-4 contract-only claim."
         ),
     },
     {

--- a/loopx/capabilities/reward_memory/__init__.py
+++ b/loopx/capabilities/reward_memory/__init__.py
@@ -23,6 +23,7 @@ from .health import (
     build_reward_memory_corpus_health_packet,
     reward_memory_health_case,
 )
+from .evaluation import run_reward_memory_evaluation
 from .registry import (
     build_reward_memory_corpus_registry_packet,
     normalize_reward_memory_corpus,
@@ -47,5 +48,6 @@ __all__ = [
     "pr_3237_regression_observation",
     "reward_memory_health_case",
     "review_reward_memory_candidate",
+    "run_reward_memory_evaluation",
     "semantic_preference_inventory_to_reward_corpora",
 ]

--- a/loopx/capabilities/reward_memory/cli.py
+++ b/loopx/capabilities/reward_memory/cli.py
@@ -16,6 +16,7 @@ from .health import (
     build_reward_memory_corpus_health_packet,
     reward_memory_health_case,
 )
+from .evaluation import run_reward_memory_evaluation
 from .registry import build_reward_memory_corpus_registry_packet
 
 
@@ -103,6 +104,12 @@ def register_reward_memory_commands(
         help="Apply one review decision without persisting provider state.",
     )
 
+    evaluate = sub.add_parser(
+        "evaluate",
+        help="Run the bounded Stage-4 core-contract suite and release gate.",
+    )
+    add_subcommand_format(evaluate)
+
     route = sub.add_parser(
         "route-check",
         help="Route a compact issue-fix observation to pilot, meta, or evidence hold.",
@@ -178,6 +185,8 @@ def handle_reward_memory_command(
                 )
             payload = review_reward_memory_candidate(candidate, review)
             payload["adapter"] = adapter
+        elif args.reward_memory_command == "evaluate":
+            payload = run_reward_memory_evaluation()
         else:
             observation = (
                 pr_3237_regression_observation()
@@ -214,4 +223,6 @@ def handle_reward_memory_command(
         print_payload(payload, output_format(args), _render)
         return 2
     print_payload(payload, output_format(args), _render)
+    if args.reward_memory_command == "evaluate" and payload.get("ok") is not True:
+        return 2
     return 0

--- a/loopx/capabilities/reward_memory/evaluation.py
+++ b/loopx/capabilities/reward_memory/evaluation.py
@@ -1,0 +1,576 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from collections.abc import Callable, Mapping
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any
+
+from ..context_providers.base import ContextProviderItem, ContextProviderRetrieval
+from .application import (
+    build_active_reward_memory_record,
+    build_reward_memory_recall_request,
+    execute_reward_memory_recall,
+)
+from .architecture import (
+    build_reward_memory_route_packet,
+    pr_3237_regression_observation,
+)
+from .candidate_review import (
+    build_reward_memory_candidate,
+    review_reward_memory_candidate,
+)
+
+
+REWARD_MEMORY_EVALUATION_SCHEMA_VERSION = "reward_memory_evaluation_v0"
+REWARD_MEMORY_RELEASE_GATE_SCHEMA_VERSION = "reward_memory_release_gate_v0"
+REQUIRED_CASE_IDS = (
+    "compact_restart_survival",
+    "project_module_scope_isolation",
+    "supersede_revoke_rejection",
+    "stale_source_rejection",
+    "multi_person_authority_conditions",
+    "gate_non_override",
+    "candidate_ranking_influence",
+    "large_edge_case_patch_protection",
+)
+
+_OBSERVED_AT = "2026-07-14T10:00:00+00:00"
+_WORKSPACE = "workspace:reward-memory-eval"
+_PROJECT = "repository:openviking-eval"
+_REVISION = "revision:stage4"
+_SURFACE = "issue_fix.patch_planning"
+_CORPUS_ID = "openviking_issue_fix_policy"
+_SCOPE_REF = "viking://resources/reward-memory/openviking-eval"
+
+
+@dataclass
+class _FixtureProvider:
+    items: tuple[ContextProviderItem, ...]
+    provider_id: str = "fixture_provider"
+    call_count: int = 0
+
+    def retrieve(self, **kwargs: Any) -> ContextProviderRetrieval:
+        self.call_count += 1
+        return ContextProviderRetrieval(
+            provider=self.provider_id,
+            namespace=str(kwargs["namespace"]),
+            status="completed",
+            query_summary=str(kwargs["query_summary"]),
+            observed_at=str(kwargs["observed_at"]),
+            search_performed=True,
+            read_performed=True,
+            items=self.items,
+            requested_limit=int(kwargs["max_results"]),
+        )
+
+    def sync(self, **_kwargs: Any) -> Any:
+        raise AssertionError("the Stage-4 harness must not write provider state")
+
+
+def _corpus() -> dict[str, Any]:
+    return {
+        "corpus_id": _CORPUS_ID,
+        "class_id": "hard_policy",
+        "provider_id": "fixture_provider",
+        "owner_ref": "provider_scope_owner",
+        "source_of_truth": "reviewed_owner_feedback",
+        "read_authority": "module_scoped",
+        "write_authority": "provider_managed",
+        "scope": {
+            "workspace_ref": _WORKSPACE,
+            "project_ref": _PROJECT,
+            "surface_ids": [_SURFACE],
+        },
+        "freshness": {"mode": "revision_bound", "source_revision": _REVISION},
+        "lifecycle": {"state": "active", "supersedes": []},
+        "retrieval": {
+            "index_required": True,
+            "readback_required": True,
+            "application_receipt_required": True,
+        },
+        "maintenance": {
+            "writeback_triggers": ["reviewed_candidate"],
+            "closure_policy": "provider_write_then_revision_verified_read",
+            "retirement_authority": "provider_scope_owner",
+        },
+        "privacy": {"visibility": "private", "raw_content_in_registry": False},
+        "provider_scope_ref_digest": hashlib.sha256(
+            _SCOPE_REF.encode("utf-8")
+        ).hexdigest()[:16],
+    }
+
+
+def _proposal(*, actor_ref: str = "github:user:maintainer") -> dict[str, Any]:
+    return {
+        "target_class": "hard_policy",
+        "content_summary": (
+            "Memory-core changes require relevant effect evidence and must not add "
+            "a disproportionate patch for one narrow edge case."
+        ),
+        "source": {
+            "source_kind": "maintainer_correction",
+            "source_ref": "github:volcengine/OpenViking#reviewed-feedback",
+            "actor_ref": actor_ref,
+            "actor_role": "verified_repository_core_contributor",
+        },
+        "scope": {
+            "workspace_ref": _WORKSPACE,
+            "project_ref": _PROJECT,
+            "surface_ids": [_SURFACE],
+            "revision_ref": _REVISION,
+        },
+        "reasoning": {
+            "summary": "The correction is reusable only at Issue Fix patch planning.",
+            "confidence": "high",
+        },
+        "guard_context": {
+            "source_freshness": "current",
+            "conflict_state": "clear",
+            "current_artifact_verified": True,
+        },
+        "requested_action_scopes": ["issue_fix:scope_selection"],
+        "raw_content_captured": False,
+    }
+
+
+def _authority(*, actor_ref: str = "github:user:maintainer") -> dict[str, Any]:
+    return {
+        "verified": True,
+        "source_ref": "repository:authority-map",
+        "actor_ref": actor_ref,
+        "actor_role": "verified_repository_core_contributor",
+        "project_ref": _PROJECT,
+        "action_scopes": ["issue_fix:scope_selection"],
+    }
+
+
+def _active_record() -> dict[str, Any]:
+    candidate = build_reward_memory_candidate(
+        _proposal(), authority_checkpoint=_authority()
+    )
+    reviewed = review_reward_memory_candidate(
+        candidate,
+        {
+            "decision": "accept",
+            "reviewer_ref": "github:user:maintainer",
+            "review_ref": "review:reward-memory-stage4",
+            "reasoning_summary": "The compact policy and authority scope were reviewed.",
+        },
+    )
+    return build_active_reward_memory_record(
+        reviewed, _corpus(), activated_at=_OBSERVED_AT
+    )
+
+
+def _binding() -> dict[str, Any]:
+    return {
+        "corpus_id": _CORPUS_ID,
+        "provider_id": "fixture_provider",
+        "namespace": "reward_memory",
+        "scope_ref": _SCOPE_REF,
+        "timeout_seconds": 5,
+        "setup_hints": {},
+    }
+
+
+def _checkpoint(*, project_ref: str = _PROJECT, surface_id: str = _SURFACE) -> dict[str, Any]:
+    return {
+        "verified": True,
+        "corpus_id": _CORPUS_ID,
+        "workspace_ref": _WORKSPACE,
+        "project_ref": project_ref,
+        "surface_id": surface_id,
+        "read_authority": "module_scoped",
+        "source_ref": "repository:authority-map",
+    }
+
+
+def _request(
+    *,
+    project_ref: str = _PROJECT,
+    surface_id: str = _SURFACE,
+    revision_ref: str = _REVISION,
+    freshness_revision: str = _REVISION,
+) -> dict[str, Any]:
+    return build_reward_memory_recall_request(
+        _corpus(),
+        {
+            "workspace_ref": _WORKSPACE,
+            "project_ref": project_ref,
+            "surface_id": surface_id,
+            "revision_ref": revision_ref,
+            "mode": "function_boundary",
+            "queries": [
+                {
+                    "query": "What reviewed policy constrains this patch?",
+                    "query_summary": "reviewed Issue Fix scope policy",
+                }
+            ],
+            "limit": 3,
+            "observed_at": _OBSERVED_AT,
+            "freshness_context": {
+                "source_truth_current": True,
+                "source_revision": freshness_revision,
+            },
+            "conflict_state": "clear",
+            "raw_content_captured": False,
+        },
+        read_authority_checkpoint=_checkpoint(
+            project_ref=project_ref, surface_id=surface_id
+        ),
+    )
+
+
+def _provider_item(record: Mapping[str, Any], suffix: str = "active") -> ContextProviderItem:
+    return ContextProviderItem(
+        resource_ref=f"{_SCOPE_REF}/{suffix}.json",
+        summary=str(record["content_summary"]),
+        content=json.dumps(record, ensure_ascii=False, sort_keys=True),
+        score=0.9,
+    )
+
+
+def _evaluate_case(
+    case_id: str, check: Callable[[], tuple[bool, int, dict[str, Any]]]
+) -> dict[str, Any]:
+    started = time.perf_counter_ns()
+    try:
+        passed, assertion_count, evidence = check()
+        failure_kind = None if passed else "assertion_failed"
+    except Exception as exc:  # noqa: BLE001 - compact harness boundary
+        passed, assertion_count, evidence = False, 1, {}
+        failure_kind = type(exc).__name__
+    latency_ms = max(0, (time.perf_counter_ns() - started) // 1_000_000)
+    compact_evidence = json.dumps(evidence, sort_keys=True, separators=(",", ":"))
+    false_application_count = int(
+        bool(evidence.get("false_application_observed", False))
+    )
+    return {
+        "case_id": case_id,
+        "passed": passed,
+        "assertion_count": assertion_count,
+        "failure_kind": failure_kind,
+        "latency_ms": latency_ms,
+        "public_evidence_bytes": len(compact_evidence.encode("utf-8")),
+        "model_tokens": 0,
+        "storage_write_bytes": 0,
+        "provider_write_count": 0,
+        "external_write_count": 0,
+        "false_application_count": false_application_count,
+        "maintainer_interruption_count": 0,
+        "user_gate_count": 0,
+        "evidence": evidence,
+    }
+
+
+def _compact_restart_case() -> tuple[bool, int, dict[str, Any]]:
+    encoded = json.dumps(_active_record(), ensure_ascii=False, sort_keys=True)
+    restarted = json.loads(encoded)
+    provider = _FixtureProvider((_provider_item(restarted),))
+    session = execute_reward_memory_recall(
+        _request(), provider_binding=_binding(), provider=provider
+    )
+    checks = (
+        restarted["schema_version"] == "reward_memory_active_record_v0",
+        session.public_packet["status"] == "completed",
+        session.public_packet["result_readback_verified"] is True,
+        provider.call_count == 1,
+    )
+    return all(checks), len(checks), {
+        "serialized_bytes": len(encoded.encode("utf-8")),
+        "recall_status": session.public_packet["status"],
+        "readback_verified": session.public_packet["result_readback_verified"],
+    }
+
+
+def _scope_case() -> tuple[bool, int, dict[str, Any]]:
+    wrong_project = _request(project_ref="repository:other")
+    wrong_surface = _request(surface_id="semantic_preference.selection")
+    provider = _FixtureProvider((_provider_item(_active_record()),))
+    project_session = execute_reward_memory_recall(
+        wrong_project, provider_binding=_binding(), provider=provider
+    )
+    surface_session = execute_reward_memory_recall(
+        wrong_surface, provider_binding=_binding(), provider=provider
+    )
+    checks = (
+        project_session.public_packet["status"] == "guard_blocked",
+        "project_scope_mismatch" in wrong_project["guard"]["reason_codes"],
+        surface_session.public_packet["status"] == "guard_blocked",
+        "surface_scope_mismatch" in wrong_surface["guard"]["reason_codes"],
+        provider.call_count == 0,
+    )
+    return all(checks), len(checks), {
+        "project_status": project_session.public_packet["status"],
+        "surface_status": surface_session.public_packet["status"],
+        "provider_call_count": provider.call_count,
+        "false_application_observed": provider.call_count > 0,
+    }
+
+
+def _inactive_case() -> tuple[bool, int, dict[str, Any]]:
+    superseded = deepcopy(_active_record())
+    superseded["lifecycle"] = {"state": "superseded"}
+    revoked = deepcopy(_active_record())
+    revoked["lifecycle"] = {"state": "revoked"}
+    provider = _FixtureProvider(
+        (_provider_item(superseded, "superseded"), _provider_item(revoked, "revoked"))
+    )
+    session = execute_reward_memory_recall(
+        _request(), provider_binding=_binding(), provider=provider
+    )
+    checks = (
+        session.public_packet["status"] == "empty",
+        session.public_packet["result_count"] == 0,
+        session.public_packet["result_readback_verified"] is False,
+    )
+    return all(checks), len(checks), {
+        "recall_status": session.public_packet["status"],
+        "accepted_result_count": session.public_packet["result_count"],
+        "false_application_observed": session.public_packet["result_count"] > 0,
+    }
+
+
+def _stale_case() -> tuple[bool, int, dict[str, Any]]:
+    request = _request(
+        revision_ref="revision:stale", freshness_revision="revision:stale"
+    )
+    provider = _FixtureProvider((_provider_item(_active_record()),))
+    session = execute_reward_memory_recall(
+        request, provider_binding=_binding(), provider=provider
+    )
+    reasons = request["guard"]["reason_codes"]
+    checks = (
+        session.public_packet["status"] == "guard_blocked",
+        "source_revision_mismatch" in reasons,
+        "request_revision_mismatch" in reasons,
+        provider.call_count == 0,
+    )
+    return all(checks), len(checks), {
+        "recall_status": session.public_packet["status"],
+        "reason_codes": reasons,
+        "provider_call_count": provider.call_count,
+        "false_application_observed": provider.call_count > 0,
+    }
+
+
+def _multi_person_case() -> tuple[bool, int, dict[str, Any]]:
+    accepted = build_reward_memory_candidate(
+        _proposal(), authority_checkpoint=_authority()
+    )
+    mismatched = build_reward_memory_candidate(
+        _proposal(), authority_checkpoint=_authority(actor_ref="github:user:other")
+    )
+    reasons = mismatched["guard"]["reason_codes"]
+    checks = (
+        accepted["guard"]["passed"] is True,
+        mismatched["guard"]["passed"] is False,
+        "authority_actor_mismatch" in reasons,
+    )
+    return all(checks), len(checks), {
+        "matching_actor_guard": accepted["guard"]["passed"],
+        "mismatched_actor_guard": mismatched["guard"]["passed"],
+        "reason_codes": reasons,
+    }
+
+
+def _issue_fix_application() -> dict[str, Any]:
+    from ..issue_fix.reward_memory import run_issue_fix_patch_planning_reward_memory
+
+    provider = _FixtureProvider((_provider_item(_active_record()),))
+
+    def apply_plan(base: Any, items: Any) -> dict[str, Any]:
+        plan = dict(base)
+        plan["candidates"] = ["focused_fix", "broad_generic_patch"]
+        return {
+            "outcome": "applied",
+            "output": plan,
+            "memory_refs": [items[0].memory_ref],
+            "reasoning_summary": (
+                "Current code verifies the narrow boundary; rank the focused fix first."
+            ),
+            "current_artifact_verified": True,
+        }
+
+    return run_issue_fix_patch_planning_reward_memory(
+        {"candidates": ["broad_generic_patch", "focused_fix"]},
+        corpus=_corpus(),
+        workspace_ref=_WORKSPACE,
+        repository_ref=_PROJECT,
+        revision_ref=_REVISION,
+        queries=[
+            {
+                "query": "What reviewed policy constrains this patch?",
+                "query_summary": "reviewed Issue Fix scope policy",
+            }
+        ],
+        mode="function_boundary",
+        observed_at=_OBSERVED_AT,
+        freshness_context={
+            "source_truth_current": True,
+            "source_revision": _REVISION,
+        },
+        conflict_state="clear",
+        read_authority_checkpoint=_checkpoint(),
+        provider_binding=_binding(),
+        application_id="issue-fix:stage4:ranking",
+        artifact_ref="patch-plan:stage4",
+        apply_memory=apply_plan,
+        provider=provider,
+    )
+
+
+def _gate_case() -> tuple[bool, int, dict[str, Any]]:
+    result = _issue_fix_application()
+    receipt = result["application"]["receipt"]
+    checks = (
+        result["application"]["status"] == "applied",
+        receipt["grants_new_action_authority"] is False,
+        receipt["current_artifact_verified"] is True,
+        receipt["external_writes_performed"] is False,
+    )
+    return all(checks), len(checks), {
+        "application_status": result["application"]["status"],
+        "grants_new_action_authority": receipt["grants_new_action_authority"],
+        "current_artifact_verified": receipt["current_artifact_verified"],
+        "false_application_observed": receipt["grants_new_action_authority"],
+    }
+
+
+def _ranking_case() -> tuple[bool, int, dict[str, Any]]:
+    result = _issue_fix_application()
+    receipt = result["application"]["receipt"]
+    checks = (
+        result["patch_plan"]["candidates"][0] == "focused_fix",
+        result["application"]["status"] == "applied",
+        bool(receipt["memory_ref_digests"]),
+        result["shared_core"] == "loopx.capabilities.reward_memory.application",
+    )
+    return all(checks), len(checks), {
+        "top_candidate": result["patch_plan"]["candidates"][0],
+        "application_status": result["application"]["status"],
+        "shared_core": result["shared_core"],
+    }
+
+
+def _edge_case() -> tuple[bool, int, dict[str, Any]]:
+    route = build_reward_memory_route_packet(pr_3237_regression_observation())
+    checks = (
+        route["decision"] == "meta_design_gate",
+        route["pilot_authorized"] is False,
+        route["memory_patch_authority"] is False,
+        set(route["missing_required_evidence"]) == {"effect", "ux", "performance"},
+    )
+    return all(checks), len(checks), {
+        "decision": route["decision"],
+        "pilot_authorized": route["pilot_authorized"],
+        "memory_patch_authority": route["memory_patch_authority"],
+        "missing_required_evidence": route["missing_required_evidence"],
+        "false_application_observed": (
+            route["pilot_authorized"] or route["memory_patch_authority"]
+        ),
+    }
+
+
+_CASE_CHECKS: dict[str, Callable[[], tuple[bool, int, dict[str, Any]]]] = {
+    "compact_restart_survival": _compact_restart_case,
+    "project_module_scope_isolation": _scope_case,
+    "supersede_revoke_rejection": _inactive_case,
+    "stale_source_rejection": _stale_case,
+    "multi_person_authority_conditions": _multi_person_case,
+    "gate_non_override": _gate_case,
+    "candidate_ranking_influence": _ranking_case,
+    "large_edge_case_patch_protection": _edge_case,
+}
+
+
+def run_reward_memory_evaluation() -> dict[str, Any]:
+    """Run the bounded Stage-4 contract suite and emit a compact release gate."""
+
+    cases = [_evaluate_case(case_id, _CASE_CHECKS[case_id]) for case_id in REQUIRED_CASE_IDS]
+    failed = [case["case_id"] for case in cases if not case["passed"]]
+    metrics = {
+        "case_count": len(cases),
+        "passed_case_count": len(cases) - len(failed),
+        "failed_case_count": len(failed),
+        "assertion_count": sum(case["assertion_count"] for case in cases),
+        "latency_ms": sum(case["latency_ms"] for case in cases),
+        "model_tokens": sum(case["model_tokens"] for case in cases),
+        "public_evidence_bytes": sum(case["public_evidence_bytes"] for case in cases),
+        "storage_write_bytes": sum(case["storage_write_bytes"] for case in cases),
+        "provider_write_count": sum(case["provider_write_count"] for case in cases),
+        "external_write_count": sum(case["external_write_count"] for case in cases),
+        "false_application_count": sum(
+            case["false_application_count"] for case in cases
+        ),
+        "maintainer_interruption_count": sum(
+            case["maintainer_interruption_count"] for case in cases
+        ),
+        "user_gate_count": sum(case["user_gate_count"] for case in cases),
+    }
+    gate_reasons = [f"case_failed:{case_id}" for case_id in failed]
+    for metric in (
+        "storage_write_bytes",
+        "provider_write_count",
+        "external_write_count",
+        "false_application_count",
+        "maintainer_interruption_count",
+        "user_gate_count",
+    ):
+        if metrics[metric]:
+            gate_reasons.append(f"nonzero:{metric}")
+    passed = not gate_reasons
+    dimensions = {
+        "task_outcome": {
+            "case_count": metrics["case_count"],
+            "passed_case_count": metrics["passed_case_count"],
+            "failed_case_count": metrics["failed_case_count"],
+            "assertion_count": metrics["assertion_count"],
+        },
+        "user_experience": {
+            "maintainer_interruption_count": metrics[
+                "maintainer_interruption_count"
+            ],
+            "user_gate_count": metrics["user_gate_count"],
+        },
+        "performance_and_cost": {
+            "latency_ms": metrics["latency_ms"],
+            "model_tokens": metrics["model_tokens"],
+            "public_evidence_bytes": metrics["public_evidence_bytes"],
+            "storage_write_bytes": metrics["storage_write_bytes"],
+        },
+        "application_quality": {
+            "false_application_count": metrics["false_application_count"],
+        },
+    }
+    return {
+        "ok": passed,
+        "schema_version": REWARD_MEMORY_EVALUATION_SCHEMA_VERSION,
+        "status": "passed" if passed else "failed",
+        "suite": "stage4_provider_neutral_contract",
+        "runner": "loopx_reward_memory_evaluation",
+        "executes_real_core": True,
+        "uses_surrogate_evaluator": False,
+        "cases": cases,
+        "metrics": metrics,
+        "dimensions": dimensions,
+        "release_gate": {
+            "schema_version": REWARD_MEMORY_RELEASE_GATE_SCHEMA_VERSION,
+            "status": "ready_for_bounded_dogfood" if passed else "hold",
+            "decision": "advance_stage_5" if passed else "repair_stage_4",
+            "reason_codes": gate_reasons,
+            "claim_scope": "core_contract_invariants_only",
+            "semantic_uplift_claim_allowed": False,
+            "production_rollout_allowed": False,
+        },
+        "boundaries": {
+            "provider_writes_performed": False,
+            "external_writes_performed": False,
+            "raw_memory_captured": False,
+            "model_reasoning_replaced": False,
+            "new_store_provider_or_scheduler_added": False,
+        },
+    }


### PR DESCRIPTION
## Summary

- add a provider-neutral Stage 4 evaluation command over the existing reward-memory shared core
- cover compact/restart survival, scope isolation, inactive/stale rejection, multi-person authority, non-override, Issue Fix ranking influence, and the PR #3237 large-edge-case guard
- emit task outcome, UX, latency, token/storage, false-application, and maintainer-interruption metrics plus a bounded release gate
- document the contract in English and Chinese

## Product and architecture judgment

Motivation: Stage 3 had recall/application receipts but no executable release gate, which left Stage 4 blocked and made it too easy to confuse fixture coverage with semantic uplift.

Solved: the command executes the real shared candidate/recall/application and Issue Fix adapter code. It adds no store, provider, scheduler, semantic router, model call, or external write. A pass advances only to bounded dogfood; production rollout and semantic-uplift claims remain forbidden.

User/operator impact: maintainers get one compact result for outcome, UX interruption, latency, token/storage cost, and false application instead of hand-assembling evidence.

Main risk: a deterministic fixture pass could be overstated. The protocol and output narrow the claim to core-contract invariants and require Stage 5 corpus-owner readback plus real module outcomes for uplift.

Design judgment: this is a cohesive shared-core seam reused by Issue Fix, not an Issue Fix-specific evaluator or a second memory lifecycle.

## Validation

- reward-memory Stage 4 suite: 8/8 cases, 31 assertions, 0 false applications, 0 provider/external writes
- reward-memory architecture, corpus registry, candidate review, recall/application, and evaluation smokes: passed
- source CLI command and capability catalog readback: passed
- catalog canary runner: 4/4 selected checks passed
- standard risk-based premerge: 13/13 selected checks executed, 0 failures, 0 warnings, 0 advisory failures
- public/private boundary scan and git diff checks: clean

Failures/skips: none. Manual holds: none.

## Excluded

No local goal state, private corpus, raw benchmark evidence, credentials, local paths, generated logs, model calls, provider writes, or external writes are included.

## Merge decision

Self-merge after GitHub checks because the change is single-purpose, public-safe, focused-smoke covered, and the risk-based gate reported self_merge_allowed=true.