### PR TITLE
Route material control-plane events to shared runtimes

### DIFF
--- a/examples/control_plane/shared-runtime-material-projection-smoke.py
+++ b/examples/control_plane/shared-runtime-material-projection-smoke.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Exercise material event projection into a registered shared runtime."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx import dreaming  # noqa: E402
+from loopx import operator_gate as operator_gate_module  # noqa: E402
+from loopx import project_map  # noqa: E402
+from loopx.control_plane.runtime import runtime_projection_route as route_module  # noqa: E402
+from loopx.control_plane.runtime.shared_runtime_material_projection import (  # noqa: E402
+    build_shared_runtime_material_projection,
+    write_shared_runtime_material_projection,
+)
+
+
+GOAL_ID = "shared-material-projection-smoke"
+AGENT_ID = "codex-shared-material-smoke"
+
+
+def write_source(
+    root: Path,
+    *,
+    name: str,
+    runtime: Path,
+    registry_is_global: bool = False,
+) -> tuple[Path, Path, dict]:
+    project = root / name
+    registry = (
+        runtime / "registry.global.json"
+        if registry_is_global
+        else project / ".loopx" / "registry.json"
+    )
+    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(
+        "---\nstatus: active\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n\n"
+        f"# {GOAL_ID}\n\n## Agent Todo\n\n"
+        "- [ ] [P1] Keep material control-plane events visible.\n",
+        encoding="utf-8",
+    )
+    goal = {
+        "id": GOAL_ID,
+        "domain": "shared-material-projection-smoke",
+        "status": "active",
+        "repo": str(project),
+        "state_file": str(state_file.relative_to(project)),
+        "adapter": {
+            "kind": "read_only_project_map_v0",
+            "status": "connected-read-only",
+        },
+        "coordination": {
+            "registered_agents": [AGENT_ID],
+            "agent_model": "peer_v1",
+        },
+        "quota": {"compute": 1.0, "window_hours": 24, "allowed_slots": 5},
+    }
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "registry_role": "global-local" if registry_is_global else "project-local",
+                "common_runtime_root": str(runtime),
+                "goals": [goal],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return project, registry, goal
+
+
+def write_target(runtime: Path, *, source_registry: Path, goal: dict, routed: bool = True) -> Path:
+    registry = runtime / "registry.global.json"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    goals = [{**goal, "source_registry": str(source_registry.resolve())}] if routed else []
+    registry.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "registry_role": "global-local",
+                "common_runtime_root": str(runtime),
+                "goals": goals,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry
+
+
+def read_rows(runtime: Path) -> list[dict]:
+    index = runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
+    if not index.exists():
+        return []
+    return [json.loads(line) for line in index.read_text(encoding="utf-8").splitlines()]
+
+
+def run_cli(registry: Path, runtime: Path, *args: str) -> dict:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "--registry",
+            str(registry),
+            "--runtime-root",
+            str(runtime),
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT), "LOOPX_RUNTIME_ROOT": str(runtime)},
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    return json.loads(result.stdout)
+
+
+def append_dreaming_proposal(runtime: Path) -> str:
+    proposal_id = "dreaming_shared_material_fixture"
+    runs_dir = runtime / "goals" / GOAL_ID / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    row = {
+        "generated_at": "2026-01-01T00:03:00+00:00",
+        "goal_id": GOAL_ID,
+        "classification": "dreaming_refactor_warning",
+        "recommended_action": "PRIVATE_LOCAL_ACTION_MARKER",
+        "summary": "Repeated control-plane evidence suggests one bounded follow-up.",
+        "dreaming": {
+            "schema_version": "dreaming_proposal_v0",
+            "proposal_id": proposal_id,
+            "proposal_type": "refactor_warning",
+            "evidence_window": "last_3_non_neutral_runs",
+        },
+    }
+    with (runs_dir / "index.jsonl").open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(row) + "\n")
+    return proposal_id
+
+
+def record_operator_gate(registry: Path, runtime: Path, *, sync_global: bool) -> dict:
+    return operator_gate_module.record_operator_gate(
+        registry_path=registry,
+        runtime_root_override=str(runtime),
+        goal_id=GOAL_ID,
+        gate="release_review",
+        decision="defer",
+        operator_question="Should this bounded release proceed?",
+        reason_summary="Wait for one more public validation signal.",
+        follow_up="Re-evaluate after the validation signal lands.",
+        agent_command=None,
+        recommended_action="PRIVATE_LOCAL_ACTION_MARKER",
+        recorded_at=None,
+        dry_run=False,
+        sync_global=sync_global,
+    )
+
+
+def assert_public_projection(rows: list[dict], kind: str) -> dict:
+    row = rows[-1]
+    marker = row.get("shared_runtime_material_projection") or {}
+    assert marker.get("projection_kind") == kind, row
+    assert marker.get("raw_artifacts_copied") is False, row
+    assert marker.get("recommended_action_copied") is False, row
+    encoded = json.dumps(row, ensure_ascii=False)
+    assert "recommended_action" not in row, row
+    assert "PRIVATE_LOCAL_ACTION_MARKER" not in encoded, row
+    return row
+
+
+def exercise_split_runtime(root: Path) -> None:
+    source_runtime = root / "split-source-runtime"
+    shared_runtime = root / "split-shared-runtime"
+    project, source_registry, goal = write_source(
+        root,
+        name="split-project",
+        runtime=source_runtime,
+    )
+    shared_registry = write_target(
+        shared_runtime,
+        source_registry=source_registry,
+        goal=goal,
+    )
+    original_runtime = os.environ.get("LOOPX_RUNTIME_ROOT")
+    os.environ["LOOPX_RUNTIME_ROOT"] = str(shared_runtime)
+    try:
+        mapped = project_map.read_only_project_map_run(
+            registry_path=source_registry,
+            runtime_root_override=str(source_runtime),
+            goal_id=GOAL_ID,
+            project=project,
+            state_file=None,
+            classification="read_only_project_map",
+            recommended_action="PRIVATE_LOCAL_ACTION_MARKER",
+            dry_run=False,
+            sync_global=True,
+        )
+        assert mapped["shared_runtime_material_projection"]["status"] == "projected", mapped
+        map_row = assert_public_projection(read_rows(shared_runtime), "read_only_project_map")
+        assert isinstance(map_row.get("project_map"), dict), map_row
+        map_status = run_cli(shared_registry, shared_runtime, "status", "--goal-id", GOAL_ID)
+        assert map_status["run_history"]["goals"][0]["latest_status_run"][
+            "classification"
+        ] == "read_only_project_map"
+
+        gate = record_operator_gate(source_registry, source_runtime, sync_global=True)
+        assert gate["shared_runtime_material_projection"]["readback_verified"] is True, gate
+        gate_row = assert_public_projection(read_rows(shared_runtime), "operator_gate_decision")
+        assert gate_row["operator_gate"]["decision"] == "defer", gate_row
+        gate_status = run_cli(shared_registry, shared_runtime, "status", "--goal-id", GOAL_ID)
+        latest_gate = gate_status["run_history"]["goals"][0]["latest_status_run"]
+        assert latest_gate["classification"] == "operator_gate_deferred", latest_gate
+        assert latest_gate["operator_gate"]["operator_question"], latest_gate
+        gate_quota = run_cli(
+            shared_registry,
+            shared_runtime,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+        )
+        assert gate_quota["state"] == "operator_gate", gate_quota
+
+        proposal_id = append_dreaming_proposal(source_runtime)
+        decision = dreaming.record_dreaming_proposal_decision(
+            registry_path=source_registry,
+            runtime_root_override=str(source_runtime),
+            goal_id=GOAL_ID,
+            proposal_id=proposal_id,
+            decision="defer",
+            reason_summary="Keep this proposal advisory until stronger evidence arrives.",
+            todo_text=None,
+            claimed_by=None,
+            dry_run=False,
+            sync_global=True,
+        )
+        assert decision["shared_runtime_material_projection"]["status"] == "projected", decision
+        dream_row = assert_public_projection(read_rows(shared_runtime), "dreaming_decision")
+        assert dream_row["dreaming_decision"]["decision"] == "defer", dream_row
+        assert dream_row["source_dreaming_proposal"]["proposal_id"] == proposal_id, dream_row
+        dream_status = run_cli(shared_registry, shared_runtime, "status", "--goal-id", GOAL_ID)
+        assert dream_status["run_history"]["goals"][0]["latest_status_run"][
+            "classification"
+        ] == "dreaming_proposal_deferred"
+        assert dream_status["runtime_projection_routes"]["counts"]["healthy"] == 1
+
+        source_row = read_rows(source_runtime)[-1]
+        replay_record, replay_index = build_shared_runtime_material_projection(
+            source_row=source_row,
+            projection_kind="dreaming_decision",
+        )
+        before_replay = len(read_rows(shared_runtime))
+        replay = write_shared_runtime_material_projection(
+            shared_runtime_root=shared_runtime,
+            goal_id=GOAL_ID,
+            record=replay_record,
+            index_record=replay_index,
+            dry_run=False,
+        )
+        assert replay["status"] == "already_current", replay
+        assert len(read_rows(shared_runtime)) == before_replay
+
+        no_sync = record_operator_gate(source_registry, source_runtime, sync_global=False)
+        assert no_sync["shared_runtime_material_projection"]["status"] == "disabled", no_sync
+        assert len(read_rows(shared_runtime)) == before_replay
+    finally:
+        if original_runtime is None:
+            os.environ.pop("LOOPX_RUNTIME_ROOT", None)
+        else:
+            os.environ["LOOPX_RUNTIME_ROOT"] = original_runtime
+
+
+def exercise_route_edges(root: Path) -> None:
+    single_runtime = root / "single-runtime"
+    _, single_registry, _ = write_source(
+        root,
+        name="single-project",
+        runtime=single_runtime,
+        registry_is_global=True,
+    )
+    single = record_operator_gate(single_registry, single_runtime, sync_global=True)
+    assert single["runtime_projection_route"]["status"] == "single_runtime", single
+    assert single["shared_runtime_material_projection"]["status"] == "not_required", single
+    assert len(read_rows(single_runtime)) == 1
+
+    missing_source = root / "missing-source-runtime"
+    missing_target = root / "missing-target-runtime"
+    project, missing_registry, goal = write_source(
+        root,
+        name="missing-project",
+        runtime=missing_source,
+    )
+    write_target(missing_target, source_registry=missing_registry, goal=goal, routed=False)
+    original_runtime = os.environ.get("LOOPX_RUNTIME_ROOT")
+    os.environ["LOOPX_RUNTIME_ROOT"] = str(missing_target)
+    missing = project_map.read_only_project_map_run(
+        registry_path=missing_registry,
+        runtime_root_override=str(missing_source),
+        goal_id=GOAL_ID,
+        project=project,
+        state_file=None,
+        classification="read_only_project_map",
+        recommended_action=None,
+        dry_run=False,
+        sync_global=True,
+    )
+    assert missing["ok"] is False and missing["partial_write"] is True, missing
+    assert missing["shared_runtime_material_projection"]["status"] == "route_missing", missing
+    assert len(read_rows(missing_source)) == 1
+    assert read_rows(missing_target) == []
+
+    ambiguous_source = root / "ambiguous-source-runtime"
+    target_a = root / "ambiguous-target-a"
+    target_b = root / "ambiguous-target-b"
+    _, ambiguous_registry, ambiguous_goal = write_source(
+        root,
+        name="ambiguous-project",
+        runtime=ambiguous_source,
+    )
+    write_target(target_a, source_registry=ambiguous_registry, goal=ambiguous_goal)
+    write_target(target_b, source_registry=ambiguous_registry, goal=ambiguous_goal)
+    os.environ["LOOPX_RUNTIME_ROOT"] = str(target_a)
+    original_default = route_module.DEFAULT_RUNTIME_ROOT
+    route_module.DEFAULT_RUNTIME_ROOT = target_b
+    try:
+        ambiguous = record_operator_gate(
+            ambiguous_registry,
+            ambiguous_source,
+            sync_global=True,
+        )
+    finally:
+        route_module.DEFAULT_RUNTIME_ROOT = original_default
+        if original_runtime is None:
+            os.environ.pop("LOOPX_RUNTIME_ROOT", None)
+        else:
+            os.environ["LOOPX_RUNTIME_ROOT"] = original_runtime
+    assert ambiguous["ok"] is False and ambiguous["partial_write"] is True, ambiguous
+    assert ambiguous["shared_runtime_material_projection"]["status"] == "route_ambiguous"
+    assert len(read_rows(ambiguous_source)) == 1
+    assert read_rows(target_a) == [] and read_rows(target_b) == []
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-shared-material-projection-") as tmp:
+        root = Path(tmp)
+        exercise_split_runtime(root)
+        exercise_route_edges(root)
+    print("shared-runtime-material-projection-smoke passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/control_plane/runtime/runtime_projection_route.py
+++ b/loopx/control_plane/runtime/runtime_projection_route.py
@@ -283,16 +283,16 @@ def _route_projection_is_current(
     goal_id: str,
     route_id: str,
     source_generated_at: Any,
+    marker_field: str,
 ) -> bool:
     rows, _ = load_index(
         target_runtime_root / "goals" / goal_id / "runs" / "index.jsonl"
     )
     return any(
-        isinstance(row.get("shared_runtime_projection"), dict)
-        and row["shared_runtime_projection"].get("runtime_projection_route_id")
+        isinstance(row.get(marker_field), dict)
+        and row[marker_field].get("runtime_projection_route_id")
         == route_id
-        and row["shared_runtime_projection"].get("source_generated_at")
-        == source_generated_at
+        and row[marker_field].get("source_generated_at") == source_generated_at
         for row in rows
     )
 
@@ -393,11 +393,18 @@ def collect_runtime_projection_route_diagnostics(
         )
         if source_row:
             target_text = str(route.get("target_runtime_root") or "").strip()
+            source_route = source_row.get("runtime_projection_route")
+            marker_field = (
+                str(source_route.get("projection_marker_field") or "").strip()
+                if isinstance(source_route, dict)
+                else ""
+            ) or "shared_runtime_projection"
             current = bool(target_text) and _route_projection_is_current(
                 target_runtime_root=Path(target_text),
                 goal_id=current_goal_id,
                 route_id=str(route.get("route_id") or ""),
                 source_generated_at=source_row.get("generated_at"),
+                marker_field=marker_field,
             )
             diagnostic_status = "healthy" if current else "lagging"
         elif route_status == "resolved":

--- a/loopx/control_plane/runtime/shared_runtime_material_projection.py
+++ b/loopx/control_plane/runtime/shared_runtime_material_projection.py
@@ -1,0 +1,332 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from ...global_registry import sync_project_registry_to_global
+from .run_compaction import (
+    compact_operator_gate,
+    compact_operator_gate_resume_contract,
+)
+from .runtime_projection_route import (
+    compact_runtime_projection_route,
+    resolve_runtime_projection_route,
+)
+from .runtime_projection_writer import write_compact_runtime_projection
+
+
+SHARED_RUNTIME_MATERIAL_PROJECTION_SCHEMA_VERSION = (
+    "shared_runtime_material_projection_v0"
+)
+SHARED_RUNTIME_MATERIAL_PROJECTION_MARKER = "shared_runtime_material_projection"
+MATERIAL_PROJECTION_KINDS = {
+    "dreaming_decision",
+    "operator_gate_decision",
+    "read_only_project_map",
+}
+
+
+def prepare_material_projection_route(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    source_runtime_root: Path,
+    sync_global: bool,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Resolve and compact the route before the source event is appended."""
+
+    route = resolve_runtime_projection_route(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        source_runtime_root=source_runtime_root,
+    )
+    compact = compact_runtime_projection_route(route)
+    compact["projection_enabled"] = bool(sync_global)
+    compact["projection_marker_field"] = SHARED_RUNTIME_MATERIAL_PROJECTION_MARKER
+    return route, compact
+
+
+def _compact_dreaming_decision(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    compact = {
+        field: value[field]
+        for field in (
+            "schema_version",
+            "proposal_id",
+            "decision",
+            "reason_summary",
+            "promoted_to_delivery",
+            "promoted_todo_id",
+            "created_todo_id",
+            "todo_added",
+            "delivery_spend_allowed",
+            "quota_spent",
+        )
+        if field in value
+    }
+    return compact or None
+
+
+def _compact_source_dreaming_proposal(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    compact = {
+        field: value[field]
+        for field in (
+            "generated_at",
+            "classification",
+            "proposal_id",
+            "proposal_type",
+            "evidence_window",
+            "summary",
+        )
+        if field in value
+    }
+    return compact or None
+
+
+def build_shared_runtime_material_projection(
+    *,
+    source_row: dict[str, Any],
+    projection_kind: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Build one compact, allowlisted shared-runtime event projection."""
+
+    if projection_kind not in MATERIAL_PROJECTION_KINDS:
+        raise ValueError(
+            "projection_kind must be one of: "
+            + ", ".join(sorted(MATERIAL_PROJECTION_KINDS))
+        )
+
+    route = (
+        source_row.get("runtime_projection_route")
+        if isinstance(source_row.get("runtime_projection_route"), dict)
+        else {}
+    )
+    marker: dict[str, Any] = {
+        "schema_version": SHARED_RUNTIME_MATERIAL_PROJECTION_SCHEMA_VERSION,
+        "projection_kind": projection_kind,
+        "source_generated_at": source_row.get("generated_at"),
+        "raw_artifacts_copied": False,
+        "recommended_action_copied": False,
+    }
+    if route.get("route_id"):
+        marker["runtime_projection_route_id"] = route["route_id"]
+
+    projection: dict[str, Any] = {
+        field: source_row[field]
+        for field in (
+            "generated_at",
+            "goal_id",
+            "classification",
+            "health_check",
+            "delivery_batch_scale",
+            "delivery_outcome",
+        )
+        if field in source_row
+    }
+    if projection_kind == "operator_gate_decision":
+        operator_gate = compact_operator_gate(source_row.get("operator_gate"))
+        if operator_gate:
+            projection["operator_gate"] = operator_gate
+        resume_contract = compact_operator_gate_resume_contract(
+            source_row.get("operator_gate_resume_contract")
+        )
+        if resume_contract:
+            resume_contract.pop("resulting_action", None)
+            projection["operator_gate_resume_contract"] = resume_contract
+    elif projection_kind == "read_only_project_map":
+        project_map = source_row.get("project_map")
+        if isinstance(project_map, dict):
+            projection["project_map"] = dict(project_map)
+    else:
+        dreaming_decision = _compact_dreaming_decision(
+            source_row.get("dreaming_decision")
+        )
+        if dreaming_decision:
+            projection["dreaming_decision"] = dreaming_decision
+        source_proposal = _compact_source_dreaming_proposal(
+            source_row.get("source_dreaming_proposal")
+        )
+        if source_proposal:
+            projection["source_dreaming_proposal"] = source_proposal
+
+    projection[SHARED_RUNTIME_MATERIAL_PROJECTION_MARKER] = marker
+    marker["source_projection_sha256_16"] = hashlib.sha256(
+        json.dumps(projection, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    ).hexdigest()[:16]
+    index_record = dict(projection)
+    return projection, index_record
+
+
+def _render_projection_markdown(record: dict[str, Any]) -> str:
+    marker = record.get(SHARED_RUNTIME_MATERIAL_PROJECTION_MARKER) or {}
+    return "\n".join(
+        [
+            "# LoopX Shared Runtime Material Projection",
+            "",
+            f"- goal_id: `{record.get('goal_id')}`",
+            f"- classification: `{record.get('classification')}`",
+            f"- generated_at: `{record.get('generated_at')}`",
+            f"- projection_kind: `{marker.get('projection_kind')}`",
+            f"- raw_artifacts_copied: `{marker.get('raw_artifacts_copied')}`",
+            f"- recommended_action_copied: `{marker.get('recommended_action_copied')}`",
+            f"- runtime_projection_route_id: `{marker.get('runtime_projection_route_id')}`",
+        ]
+    )
+
+
+def write_shared_runtime_material_projection(
+    *,
+    shared_runtime_root: Path,
+    goal_id: str,
+    record: dict[str, Any],
+    index_record: dict[str, Any],
+    dry_run: bool,
+) -> dict[str, Any]:
+    result = write_compact_runtime_projection(
+        target_runtime_root=shared_runtime_root,
+        goal_id=goal_id,
+        record=record,
+        index_record=index_record,
+        marker_field=SHARED_RUNTIME_MATERIAL_PROJECTION_MARKER,
+        identity_fields=(
+            "source_generated_at",
+            "source_projection_sha256_16",
+        ),
+        markdown_renderer=_render_projection_markdown,
+        dry_run=dry_run,
+    )
+    marker = record[SHARED_RUNTIME_MATERIAL_PROJECTION_MARKER]
+    result.update(
+        {
+            "shared_runtime_root": str(shared_runtime_root),
+            "projection_kind": marker.get("projection_kind"),
+            "raw_artifacts_copied": False,
+            "recommended_action_copied": False,
+            "source_generated_at": marker.get("source_generated_at"),
+        }
+    )
+    return result
+
+
+def finalize_material_projection(
+    *,
+    registry_path: Path,
+    source_runtime_root: Path,
+    goal_id: str,
+    source_row: dict[str, Any],
+    projection_kind: str,
+    route: dict[str, Any],
+    sync_global: bool,
+    dry_run: bool,
+) -> dict[str, Any]:
+    """Sync the registry and project a source-first material event."""
+
+    disabled_sync = {
+        "enabled": False,
+        "global_registry": str(source_runtime_root / "registry.global.json"),
+        "synced_goal_ids": [],
+        "wrote": False,
+    }
+    projection_base = {
+        "dry_run": dry_run,
+        "projection_kind": projection_kind,
+        "raw_artifacts_copied": False,
+        "recommended_action_copied": False,
+    }
+    if not sync_global:
+        return {
+            "ok": True,
+            "partial_write": False,
+            "global_sync": disabled_sync,
+            "shared_runtime_material_projection": {
+                **projection_base,
+                "ok": True,
+                "status": "disabled",
+            },
+        }
+
+    route_status = str(route.get("status") or "missing")
+    if route_status in {"missing", "ambiguous"}:
+        return {
+            "ok": False,
+            "partial_write": not dry_run,
+            "global_sync": {
+                "ok": False,
+                "enabled": False,
+                "wrote": False,
+                "reason": f"runtime projection route is {route_status}",
+                "route_status": route_status,
+            },
+            "shared_runtime_material_projection": {
+                **projection_base,
+                "ok": False,
+                "status": f"route_{route_status}",
+            },
+        }
+
+    target_text = str(route.get("target_runtime_root") or "").strip()
+    target_runtime = Path(target_text) if target_text else source_runtime_root
+    global_sync = sync_project_registry_to_global(
+        registry_path=registry_path,
+        runtime_root_override=str(target_runtime),
+        goal_id=goal_id,
+        dry_run=dry_run,
+    )
+    if route_status == "single_runtime":
+        return {
+            "ok": bool(global_sync.get("ok")),
+            "partial_write": bool(not dry_run and not global_sync.get("ok")),
+            "global_sync": global_sync,
+            "shared_runtime_material_projection": {
+                **projection_base,
+                "ok": bool(global_sync.get("ok")),
+                "status": (
+                    "not_required" if global_sync.get("ok") else "blocked_by_global_sync"
+                ),
+            },
+        }
+
+    if not global_sync.get("ok"):
+        return {
+            "ok": False,
+            "partial_write": not dry_run,
+            "global_sync": global_sync,
+            "shared_runtime_material_projection": {
+                **projection_base,
+                "ok": False,
+                "status": "blocked_by_global_sync",
+                "shared_runtime_root": str(target_runtime),
+            },
+        }
+
+    record, index_record = build_shared_runtime_material_projection(
+        source_row=source_row,
+        projection_kind=projection_kind,
+    )
+    try:
+        projection = write_shared_runtime_material_projection(
+            shared_runtime_root=target_runtime,
+            goal_id=goal_id,
+            record=record,
+            index_record=index_record,
+            dry_run=dry_run,
+        )
+    except OSError as exc:
+        projection = {
+            **projection_base,
+            "ok": False,
+            "status": "write_failed",
+            "shared_runtime_root": str(target_runtime),
+            "error": str(exc),
+        }
+    return {
+        "ok": bool(projection.get("ok")),
+        "partial_write": bool(not dry_run and not projection.get("ok")),
+        "global_sync": global_sync,
+        "shared_runtime_material_projection": projection,
+    }

--- a/loopx/dreaming.py
+++ b/loopx/dreaming.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any
 
 from .feedback import validate_local_control_text, validate_public_safe_text
-from .global_registry import sync_project_registry_to_global
 from .history import collect_history, load_registry, write_reserved_run_artifacts
 from .paths import resolve_runtime_root
 from .registry import registry_goals
@@ -18,6 +17,10 @@ from .status import (
 )
 from .state_refresh import now_local
 from .todos import add_goal_todo, update_goal_todo
+from .control_plane.runtime.shared_runtime_material_projection import (
+    finalize_material_projection,
+    prepare_material_projection_route,
+)
 
 
 DREAMING_DRY_RUN_SCHEMA_VERSION = "dreaming_dry_run_proposal_v0"
@@ -426,6 +429,12 @@ def record_dreaming_proposal_decision(
 
     registry = load_registry(registry_path)
     runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    projection_route, compact_projection_route = prepare_material_projection_route(
+        registry_path=registry_path,
+        goal_id=safe_goal_id,
+        source_runtime_root=runtime_root,
+        sync_global=sync_global,
+    )
     history_payload = collect_history(
         registry_path=registry_path,
         runtime_root=runtime_root,
@@ -500,6 +509,7 @@ def record_dreaming_proposal_decision(
         source_proposal=source_proposal,
         decision_payload=decision_payload,
     )
+    record["runtime_projection_route"] = compact_projection_route
 
     runs_dir = runtime_root / "goals" / safe_goal_id / "runs"
     index_record = {
@@ -510,6 +520,7 @@ def record_dreaming_proposal_decision(
         "health_check": record["health_check"],
         "dreaming_decision": decision_payload,
         "source_dreaming_proposal": source_proposal,
+        "runtime_projection_route": compact_projection_route,
     }
     runtime_history_appended = not dry_run
     payload: dict[str, Any] = {
@@ -528,6 +539,7 @@ def record_dreaming_proposal_decision(
         "decision": decision,
         "dreaming_decision": decision_payload,
         "source_dreaming_proposal": source_proposal,
+        "runtime_projection_route": compact_projection_route,
         "todo_result": todo_result,
         "todo_evidence_result": todo_evidence_result,
         "side_effects": {
@@ -561,15 +573,23 @@ def record_dreaming_proposal_decision(
             payload=payload,
             render_markdown=render_dreaming_decision_markdown,
         )
-    if sync_global:
-        payload["global_sync"] = sync_project_registry_to_global(
-            registry_path=registry_path,
-            runtime_root_override=str(runtime_root),
-            goal_id=safe_goal_id,
-            dry_run=dry_run,
-        )
-    else:
-        payload["global_sync"] = {"enabled": False}
+    projection_result = finalize_material_projection(
+        registry_path=registry_path,
+        source_runtime_root=runtime_root,
+        goal_id=safe_goal_id,
+        source_row=index_record,
+        projection_kind="dreaming_decision",
+        route=projection_route,
+        sync_global=sync_global,
+        dry_run=dry_run,
+    )
+    payload["global_sync"] = projection_result["global_sync"]
+    payload["shared_runtime_material_projection"] = projection_result[
+        "shared_runtime_material_projection"
+    ]
+    if not projection_result["ok"]:
+        payload["ok"] = False
+        payload["partial_write"] = projection_result["partial_write"]
     return payload
 
 

--- a/loopx/operator_gate.py
+++ b/loopx/operator_gate.py
@@ -5,12 +5,15 @@ from pathlib import Path
 from typing import Any
 
 from .feedback import validate_local_control_text, validate_public_safe_text
-from .global_registry import sync_project_registry_to_global
 from .history import collect_history, load_registry
 from .paths import resolve_runtime_root
 from .registry import registry_goals
 from .runtime import validate_goal_id_path_segment
 from .state_refresh import now_local, run_file_stem
+from .control_plane.runtime.shared_runtime_material_projection import (
+    finalize_material_projection,
+    prepare_material_projection_route,
+)
 
 
 OPERATOR_GATE_DECISIONS = {"approve", "reject", "defer"}
@@ -311,6 +314,12 @@ def record_operator_gate(
     validate_public_safe_text("reason_summary", reason_summary)
     registry = load_registry(registry_path)
     runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    projection_route, compact_projection_route = prepare_material_projection_route(
+        registry_path=registry_path,
+        goal_id=safe_goal_id,
+        source_runtime_root=runtime_root,
+        sync_global=sync_global,
+    )
     registry_goal = find_registry_goal(registry, safe_goal_id)
     question = operator_question or default_operator_question(safe_goal_id, gate)
     command = agent_command
@@ -350,6 +359,7 @@ def record_operator_gate(
         operator_gate=operator_gate,
     )
     record["operator_gate_resume_contract"] = resume_contract
+    record["runtime_projection_route"] = compact_projection_route
 
     runs_dir = runtime_root / "goals" / safe_goal_id / "runs"
     json_path = runs_dir / f"{stem}.json"
@@ -363,6 +373,7 @@ def record_operator_gate(
         "health_check": record["health_check"],
         "operator_gate": operator_gate,
         "operator_gate_resume_contract": resume_contract,
+        "runtime_projection_route": compact_projection_route,
         "json_path": str(json_path),
         "markdown_path": str(markdown_path),
     }
@@ -380,6 +391,7 @@ def record_operator_gate(
         "json_path": str(json_path),
         "markdown_path": str(markdown_path),
         "index_path": str(index_path),
+        "runtime_projection_route": compact_projection_route,
         **record,
     }
     if not dry_run:
@@ -388,13 +400,21 @@ def record_operator_gate(
         markdown_path.write_text(render_operator_gate_markdown(payload) + "\n", encoding="utf-8")
         with index_path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
-    if sync_global:
-        payload["global_sync"] = sync_project_registry_to_global(
-            registry_path=registry_path,
-            runtime_root_override=str(runtime_root),
-            goal_id=safe_goal_id,
-            dry_run=dry_run,
-        )
-    else:
-        payload["global_sync"] = {"enabled": False}
+    projection_result = finalize_material_projection(
+        registry_path=registry_path,
+        source_runtime_root=runtime_root,
+        goal_id=safe_goal_id,
+        source_row=index_record,
+        projection_kind="operator_gate_decision",
+        route=projection_route,
+        sync_global=sync_global,
+        dry_run=dry_run,
+    )
+    payload["global_sync"] = projection_result["global_sync"]
+    payload["shared_runtime_material_projection"] = projection_result[
+        "shared_runtime_material_projection"
+    ]
+    if not projection_result["ok"]:
+        payload["ok"] = False
+        payload["partial_write"] = projection_result["partial_write"]
     return payload

--- a/loopx/project_map.py
+++ b/loopx/project_map.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from .authority import compact_authority_registry
 from .feedback import validate_local_control_text, validate_public_safe_text
-from .global_registry import sync_project_registry_to_global
 from .history import load_registry
 from .paths import rel_or_abs, resolve_runtime_root
 from .state_refresh import (
@@ -18,6 +17,10 @@ from .state_refresh import (
     run_file_stem,
 )
 from .runtime import validate_goal_id_path_segment
+from .control_plane.runtime.shared_runtime_material_projection import (
+    finalize_material_projection,
+    prepare_material_projection_route,
+)
 
 
 DEFAULT_PROJECT_MAP_CLASSIFICATION = "read_only_project_map"
@@ -462,6 +465,12 @@ def read_only_project_map_run(
     validate_public_safe_text("classification", classification)
     registry = load_registry(registry_path)
     runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    projection_route, compact_projection_route = prepare_material_projection_route(
+        registry_path=registry_path,
+        goal_id=safe_goal_id,
+        source_runtime_root=runtime_root,
+        sync_global=sync_global,
+    )
     registry_goal, resolved_project, resolved_state_file = resolve_goal_state(
         registry=registry,
         goal_id=safe_goal_id,
@@ -512,6 +521,7 @@ def read_only_project_map_run(
         registry_goal=registry_goal,
     )
     record["residual_risks"] = derive_residual_risks(record, opt_in_required=opt_in_required)
+    record["runtime_projection_route"] = compact_projection_route
     project_map = compact_project_map(record)
 
     runs_dir = runtime_root / "goals" / safe_goal_id / "runs"
@@ -527,6 +537,7 @@ def read_only_project_map_run(
         "health_check": record["health_check"],
         "residual_risks": record["residual_risks"],
         "project_map": project_map,
+        "runtime_projection_route": compact_projection_route,
         "json_path": str(json_path),
         "markdown_path": str(markdown_path),
     }
@@ -549,6 +560,7 @@ def read_only_project_map_run(
         "markdown_path": str(markdown_path),
         "index_path": str(index_path),
         "project_map": project_map,
+        "runtime_projection_route": compact_projection_route,
         **record,
     }
     if not dry_run:
@@ -557,18 +569,21 @@ def read_only_project_map_run(
         markdown_path.write_text(render_read_only_project_map_markdown(payload) + "\n", encoding="utf-8")
         with index_path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
-    if sync_global:
-        payload["global_sync"] = sync_project_registry_to_global(
-            registry_path=registry_path,
-            runtime_root_override=str(runtime_root),
-            goal_id=safe_goal_id,
-            dry_run=dry_run,
-        )
-    else:
-        payload["global_sync"] = {
-            "enabled": False,
-            "global_registry": str(runtime_root / "registry.global.json"),
-            "synced_goal_ids": [],
-            "wrote": False,
-        }
+    projection_result = finalize_material_projection(
+        registry_path=registry_path,
+        source_runtime_root=runtime_root,
+        goal_id=safe_goal_id,
+        source_row=index_record,
+        projection_kind="read_only_project_map",
+        route=projection_route,
+        sync_global=sync_global,
+        dry_run=dry_run,
+    )
+    payload["global_sync"] = projection_result["global_sync"]
+    payload["shared_runtime_material_projection"] = projection_result[
+        "shared_runtime_material_projection"
+    ]
+    if not projection_result["ok"]:
+        payload["ok"] = False
+        payload["partial_write"] = projection_result["partial_write"]
     return payload

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -1005,6 +1005,7 @@ def refresh_state_run(
         record["vision_checkpoint"] = vision_checkpoint
     compact_route = compact_runtime_projection_route(runtime_projection_route)
     compact_route["projection_enabled"] = bool(sync_global)
+    compact_route["projection_marker_field"] = "shared_runtime_projection"
     record["runtime_projection_route"] = compact_route
 
     runs_dir = runtime_root / "goals" / safe_goal_id / "runs"


### PR DESCRIPTION
## Summary
- project operator-gate decisions, dreaming decisions, and read-only project maps into their registry-declared shared runtime
- preserve source-first writes, single-runtime compatibility, `--no-global-sync`, route failure semantics, compact allowlists, and idempotent readback
- make route diagnostics validate the marker declared by each source projection
- add split-runtime parity coverage for shared status/quota plus single, missing, ambiguous, disabled, and replay cases

## Validation
- `loopx canary premerge --from-git-diff` (17/17, no failures or manual holds)
- `uv run --extra test pytest -q` (318 passed, 2 skipped)
- `python3 examples/control_plane/shared-runtime-material-projection-smoke.py`
- `python3 examples/control_plane/refresh-state-shared-runtime-projection-smoke.py`
- `uvx ruff check ...` on all changed Python files

## Boundary
- shared rows copy no raw artifacts, top-level `recommended_action`, local paths, credentials, or benchmark payloads
- the compact operator resume projection also omits the `resulting_action` alias