### PR TITLE
Fix secondary reviewer candidate fallback

### DIFF
--- a/examples/issue-fix-reviewer-request-smoke.py
+++ b/examples/issue-fix-reviewer-request-smoke.py
@@ -282,6 +282,30 @@ def assert_public_safe(packet: dict[str, Any]) -> None:
     assert packet["commit_emails_captured"] is False
 
 
+def fake_notification_adapter(**kwargs: Any) -> dict[str, Any]:
+    assert kwargs["execute"] is False
+    return {
+        "ok": True,
+        "schema_version": "issue_fix_reviewer_notification_sink_result_v0",
+        "sink_kind": "fixture_channel",
+        "status": "preview_ready",
+        "reviewer_handles": list(kwargs["reviewer_handles"]),
+        "resolved_reviewer_count": len(kwargs["reviewer_handles"]),
+        "idempotency_key": None,
+        "identity_scope": "project_dedicated",
+        "external_write_authority_asserted": False,
+        "external_write_performed": False,
+        "verification_performed": False,
+        "notification_verified": False,
+        "bot_identity_verified": False,
+        "reader_identity_verified": False,
+        "private_destination_captured": False,
+        "private_member_ids_captured": False,
+        "private_bot_profile_captured": False,
+        "raw_provider_payload_captured": False,
+    }
+
+
 def main() -> int:
     path = Path(tempfile.mkdtemp(prefix="loopx-reviewer-request-"))
     try:
@@ -369,6 +393,78 @@ def main() -> int:
         assert with_secondary["secondary_notifications"]["receipts"]
         assert len(combined.lark_calls) == 3
         assert_public_safe(with_secondary)
+
+        fallback_sink_input = json.loads(json.dumps(sinks_input))
+        fallback_sink_input["sinks"][0]["reviewer_identities"] = {
+            "@history-owner": {
+                "member_id": "ou_private_member",
+                "display_name": "History Owner",
+            }
+        }
+        fallback_combined = FakeCombinedRunner(
+            FakeGitHubRunner(before=metadata(requested=["service-owner"]))
+        )
+        secondary_fallback = build_issue_fix_reviewer_request_packet(
+            repo_path=path,
+            url="https://github.com/owner/repo/pull/42",
+            base_ref="main",
+            notification_sinks_input=fallback_sink_input,
+            execute=True,
+            runner=fallback_combined,
+        )
+        assert secondary_fallback["ok"] is True, secondary_fallback
+        assert secondary_fallback["selected_reviewers"] == []
+        assert secondary_fallback["notified_reviewers"] == ["@service-owner"]
+        assert secondary_fallback["secondary_notification_primary_targets"] == [
+            "@service-owner"
+        ]
+        assert secondary_fallback["secondary_notification_candidate_pool"][:2] == [
+            "@service-owner",
+            "@history-owner",
+        ], secondary_fallback
+        assert secondary_fallback["secondary_notification_targets"] == [
+            "@history-owner"
+        ]
+        assert secondary_fallback["secondary_notification_fallback_used"] is True
+        assert secondary_fallback["secondary_notification_status"] == "sent_verified"
+        assert secondary_fallback["secondary_notification_verified"] is True
+        assert fallback_combined.github.edits == 0
+        assert len(fallback_combined.lark_calls) == 3
+        assert_public_safe(secondary_fallback)
+
+        provider_neutral_fallback = build_issue_fix_reviewer_request_packet(
+            repo_path=path,
+            url="https://github.com/owner/repo/pull/42",
+            base_ref="main",
+            notification_sinks_input={
+                "schema_version": "issue_fix_reviewer_notification_sinks_input_v0",
+                "receipts": [],
+                "sinks": [
+                    {
+                        "sink_kind": "fixture_channel",
+                        "reviewer_identities": {
+                            "@history-owner": {"identity": "fixture"}
+                        },
+                    }
+                ],
+            },
+            notification_sink_adapters={
+                "fixture_channel": fake_notification_adapter
+            },
+            provider_payload=metadata(requested=["service-owner"]),
+        )
+        assert provider_neutral_fallback["ok"] is True, provider_neutral_fallback
+        assert provider_neutral_fallback["secondary_notification_targets"] == [
+            "@history-owner"
+        ]
+        assert provider_neutral_fallback["secondary_notification_fallback_used"] is True
+        assert provider_neutral_fallback["secondary_notification_status"] == (
+            "preview_ready"
+        )
+        assert provider_neutral_fallback["secondary_notifications"]["results"][0][
+            "sink_kind"
+        ] == "fixture_channel"
+        assert_public_safe(provider_neutral_fallback)
 
         reviewed_combined = FakeCombinedRunner(
             FakeGitHubRunner(before=metadata(reviewed=["service-owner"]))

--- a/loopx/capabilities/issue_fix/reviewer_request.py
+++ b/loopx/capabilities/issue_fix/reviewer_request.py
@@ -10,6 +10,7 @@ from typing import Any
 from ...control_plane.runtime.public_safety import public_safe_compact_text
 from .metadata_preview import normalise_github_issue_reference
 from .reviewer_notification import (
+    NotificationSinkAdapter,
     build_issue_fix_reviewer_notification_sinks_result,
 )
 from .reviewer_recommendation import build_issue_fix_reviewer_recommendation_packet
@@ -81,6 +82,73 @@ def _normalise_login(value: Any) -> str | None:
 def _is_automated_reviewer_handle(value: Any) -> bool:
     handle = _normalise_login(value)
     return bool(handle and REVIEWER_BOT_HANDLE_PATTERN.search(handle.lstrip("@")))
+
+
+def _secondary_notification_targets(
+    *,
+    primary_handles: Sequence[str],
+    candidates: Sequence[Any],
+    sinks_input: Mapping[str, Any],
+) -> tuple[list[str], list[str]]:
+    """Choose sink-resolvable reviewers without changing GitHub coverage.
+
+    The primary handles are reviewers already covered on GitHub or selected for
+    a new GitHub request.  Ranked recommendation candidates are fallback-only:
+    they are used when every configured secondary sink declares an identity for
+    the candidate.  Sink adapters still perform the authoritative provider and
+    membership verification before sending.
+    """
+
+    primary = list(
+        dict.fromkeys(
+            handle
+            for value in primary_handles
+            if (handle := _normalise_login(value)) is not None
+        )
+    )[:3]
+    if not primary:
+        return [], []
+
+    pool = list(primary)
+    for candidate in candidates:
+        if (
+            not isinstance(candidate, Mapping)
+            or candidate.get("requestable") is not True
+        ):
+            continue
+        handle = _normalise_login(candidate.get("reviewer_handle"))
+        if handle and not _is_automated_reviewer_handle(handle) and handle not in pool:
+            pool.append(handle)
+
+    raw_sinks = sinks_input.get("sinks")
+    sinks = raw_sinks if isinstance(raw_sinks, list) else []
+    identity_maps: list[dict[str, Any]] = []
+    for sink in sinks:
+        if not isinstance(sink, Mapping):
+            return primary, pool
+        raw_identities = sink.get("reviewer_identities")
+        if not isinstance(raw_identities, Mapping):
+            return primary, pool
+        identity_maps.append(
+            {
+                handle: value
+                for raw_handle, value in raw_identities.items()
+                if (handle := _normalise_login(raw_handle)) is not None
+            }
+        )
+    if not identity_maps:
+        return primary, pool
+
+    target_count = len(primary)
+    resolved = [
+        handle
+        for handle in pool
+        if all(
+            isinstance(identities.get(handle), Mapping)
+            for identities in identity_maps
+        )
+    ][:target_count]
+    return (resolved or primary), pool
 
 
 def _is_mention_cluster_separator(value: str) -> bool:
@@ -401,6 +469,7 @@ def build_issue_fix_reviewer_request_packet(
     resolved_identities: Mapping[str, Any] | None = None,
     reviewer_sources_input: Mapping[str, Any] | None = None,
     notification_sinks_input: Mapping[str, Any] | None = None,
+    notification_sink_adapters: Mapping[str, NotificationSinkAdapter] | None = None,
     provider_payload: Mapping[str, Any] | None = None,
     execute: bool = False,
     generated_at: str | None = "2026-07-10T00:00:00Z",
@@ -821,7 +890,7 @@ def build_issue_fix_reviewer_request_packet(
     packet["secondary_notification_verified"] = False
     if notification_sinks_input:
         notification_targets = list(packet.get("selected_reviewers") or [])
-        if execute and packet.get("notified_reviewers"):
+        if packet.get("notified_reviewers"):
             notification_targets = list(packet.get("notified_reviewers") or [])
         if execute:
             completed_reviewers = set(packet.get("existing_reviewed_by") or [])
@@ -830,6 +899,23 @@ def build_issue_fix_reviewer_request_packet(
                 for handle in notification_targets
                 if handle not in completed_reviewers
             ]
+        primary_notification_targets = list(notification_targets)
+        notification_targets, notification_candidate_pool = (
+            _secondary_notification_targets(
+                primary_handles=primary_notification_targets,
+                candidates=candidates,
+                sinks_input=notification_sinks_input,
+            )
+        )
+        packet["secondary_notification_primary_targets"] = (
+            primary_notification_targets
+        )
+        packet["secondary_notification_candidate_pool"] = notification_candidate_pool
+        packet["secondary_notification_targets"] = notification_targets
+        packet["secondary_notification_fallback_used"] = bool(
+            notification_targets
+            and notification_targets != primary_notification_targets
+        )
         if notification_targets:
             secondary = build_issue_fix_reviewer_notification_sinks_result(
                 repo=repo,
@@ -842,6 +928,7 @@ def build_issue_fix_reviewer_request_packet(
                 sinks_input=notification_sinks_input,
                 execute=execute,
                 runner=runner,
+                sink_adapters=notification_sink_adapters,
             )
             packet["secondary_notifications"] = secondary
             packet["secondary_notification_status"] = secondary.get("status")


### PR DESCRIPTION
## Summary

- keep GitHub reviewer coverage independent from secondary notification routing
- when the GitHub-covered reviewer lacks a configured sink identity, continue through ranked requestable candidates and select the first sink-resolvable reviewer
- retain adapter-side identity verification, idempotency, receipts, and post-send readback

## Validation

- `python3 examples/issue-fix-reviewer-request-smoke.py`
- `python3 examples/issue-fix-reviewer-notification-sink-smoke.py`
- `loopx canary premerge --from-git-diff` (9/9 selected checks passed)
- public/private boundary scan clean

## Scope

Two public files only: the reviewer-request runtime and its focused smoke. The regression covers both a Lark fixture and a provider-neutral fake sink. No credentials, local state, raw provider payloads, or private identities are committed.

## Residual risk

Fallback candidates are used only for secondary notification; this change does not alter or expand the existing GitHub review request.