### PR TITLE
refactor: separate reward memory evaluation fixtures

### DIFF
--- a/docs/reference/protocols/reward-memory-architecture-v0.md
+++ b/docs/reference/protocols/reward-memory-architecture-v0.md
@@ -337,6 +337,12 @@ module isolation; supersede/revoke rejection; stale-source rejection;
 multi-person authority matching; gate non-override; verified candidate-ranking
 influence; and protection against a large patch for the PR #3237 edge case.
 
+`evaluation.py` owns case orchestration, assertions, metrics, and the release
+gate. Reusable setup and provider doubles live in `evaluation_fixtures.py` with
+neutral fixture identities; OpenViking appears there only through the explicitly
+named PR #3237 Issue Fix regression fixture. Project identity is fixture data,
+not evaluator policy.
+
 `reward_memory_evaluation_v0` reports task outcome plus exact local runner
 latency, public evidence bytes, model-token count, provider/storage writes,
 false applications, maintainer interruptions, and user gates. Zero model tokens

--- a/docs/reference/protocols/reward-memory-architecture-v0.zh-CN.md
+++ b/docs/reference/protocols/reward-memory-architecture-v0.zh-CN.md
@@ -286,6 +286,11 @@ Runner 会直接执行真实的 candidate、recall、application、Issue Fix ada
 supersede/revoke 拒绝；stale source 拒绝；多人 authority 匹配；gate 不被覆盖；在验证当前
 artifact 后影响 candidate ranking；以及避免为 PR #3237 这类 edge case 生成大 patch。
 
+`evaluation.py` 只负责 case 编排、断言、指标与 release gate。可复用的 setup 和 provider
+double 放在 `evaluation_fixtures.py`，并使用中性的 fixture identity；OpenViking 只出现在
+显式命名的 PR #3237 Issue Fix 回归 fixture 中。项目身份属于 fixture data，不属于
+evaluator policy。
+
 `reward_memory_evaluation_v0` 同时汇报 task outcome、真实本地 runner latency、公共证据
 字节数、model token 数、provider/storage write、false application、maintainer interruption
 与 user gate。model token 为零表示这套确定性 contract suite 没有调用模型，不代表后续

--- a/examples/reward-memory-evaluation-smoke.py
+++ b/examples/reward-memory-evaluation-smoke.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -10,9 +11,20 @@ sys.path.insert(0, str(REPO_ROOT))
 
 
 from loopx.capabilities.reward_memory import run_reward_memory_evaluation  # noqa: E402
+from loopx.capabilities.reward_memory.evaluation_fixtures import (  # noqa: E402
+    generic_compact_restart_fixture,
+    openviking_pr_3237_regression_fixture,
+)
 
 
 def main() -> None:
+    generic_fixture = generic_compact_restart_fixture()
+    assert "openviking" not in json.dumps(
+        generic_fixture["fixture_identity"], sort_keys=True
+    ).lower()
+    regression_fixture = openviking_pr_3237_regression_fixture()
+    assert regression_fixture["case_ref"].endswith("/OpenViking/pull/3237")
+
     packet = run_reward_memory_evaluation()
     assert packet["schema_version"] == "reward_memory_evaluation_v0", packet
     assert packet["status"] == "passed", packet

--- a/loopx/capabilities/reward_memory/evaluation.py
+++ b/loopx/capabilities/reward_memory/evaluation.py
@@ -1,26 +1,18 @@
 from __future__ import annotations
 
-import hashlib
 import json
 import time
-from collections.abc import Callable, Mapping
-from copy import deepcopy
-from dataclasses import dataclass
+from collections.abc import Callable
 from typing import Any
 
-from ..context_providers.base import ContextProviderItem, ContextProviderRetrieval
-from .application import (
-    build_active_reward_memory_record,
-    build_reward_memory_recall_request,
-    execute_reward_memory_recall,
-)
-from .architecture import (
-    build_reward_memory_route_packet,
-    pr_3237_regression_observation,
-)
-from .candidate_review import (
-    build_reward_memory_candidate,
-    review_reward_memory_candidate,
+from .evaluation_fixtures import (
+    generic_compact_restart_fixture,
+    generic_inactive_lifecycle_fixture,
+    generic_issue_fix_application_fixture,
+    generic_multi_person_authority_fixture,
+    generic_scope_isolation_fixture,
+    generic_stale_source_fixture,
+    openviking_pr_3237_regression_fixture,
 )
 
 
@@ -36,202 +28,6 @@ REQUIRED_CASE_IDS = (
     "candidate_ranking_influence",
     "large_edge_case_patch_protection",
 )
-
-_OBSERVED_AT = "2026-07-14T10:00:00+00:00"
-_WORKSPACE = "workspace:reward-memory-eval"
-_PROJECT = "repository:openviking-eval"
-_REVISION = "revision:stage4"
-_SURFACE = "issue_fix.patch_planning"
-_CORPUS_ID = "openviking_issue_fix_policy"
-_SCOPE_REF = "viking://resources/reward-memory/openviking-eval"
-
-
-@dataclass
-class _FixtureProvider:
-    items: tuple[ContextProviderItem, ...]
-    provider_id: str = "fixture_provider"
-    call_count: int = 0
-
-    def retrieve(self, **kwargs: Any) -> ContextProviderRetrieval:
-        self.call_count += 1
-        return ContextProviderRetrieval(
-            provider=self.provider_id,
-            namespace=str(kwargs["namespace"]),
-            status="completed",
-            query_summary=str(kwargs["query_summary"]),
-            observed_at=str(kwargs["observed_at"]),
-            search_performed=True,
-            read_performed=True,
-            items=self.items,
-            requested_limit=int(kwargs["max_results"]),
-        )
-
-    def sync(self, **_kwargs: Any) -> Any:
-        raise AssertionError("the Stage-4 harness must not write provider state")
-
-
-def _corpus() -> dict[str, Any]:
-    return {
-        "corpus_id": _CORPUS_ID,
-        "class_id": "hard_policy",
-        "provider_id": "fixture_provider",
-        "owner_ref": "provider_scope_owner",
-        "source_of_truth": "reviewed_owner_feedback",
-        "read_authority": "module_scoped",
-        "write_authority": "provider_managed",
-        "scope": {
-            "workspace_ref": _WORKSPACE,
-            "project_ref": _PROJECT,
-            "surface_ids": [_SURFACE],
-        },
-        "freshness": {"mode": "revision_bound", "source_revision": _REVISION},
-        "lifecycle": {"state": "active", "supersedes": []},
-        "retrieval": {
-            "index_required": True,
-            "readback_required": True,
-            "application_receipt_required": True,
-        },
-        "maintenance": {
-            "writeback_triggers": ["reviewed_candidate"],
-            "closure_policy": "provider_write_then_revision_verified_read",
-            "retirement_authority": "provider_scope_owner",
-        },
-        "privacy": {"visibility": "private", "raw_content_in_registry": False},
-        "provider_scope_ref_digest": hashlib.sha256(
-            _SCOPE_REF.encode("utf-8")
-        ).hexdigest()[:16],
-    }
-
-
-def _proposal(*, actor_ref: str = "github:user:maintainer") -> dict[str, Any]:
-    return {
-        "target_class": "hard_policy",
-        "content_summary": (
-            "Memory-core changes require relevant effect evidence and must not add "
-            "a disproportionate patch for one narrow edge case."
-        ),
-        "source": {
-            "source_kind": "maintainer_correction",
-            "source_ref": "github:volcengine/OpenViking#reviewed-feedback",
-            "actor_ref": actor_ref,
-            "actor_role": "verified_repository_core_contributor",
-        },
-        "scope": {
-            "workspace_ref": _WORKSPACE,
-            "project_ref": _PROJECT,
-            "surface_ids": [_SURFACE],
-            "revision_ref": _REVISION,
-        },
-        "reasoning": {
-            "summary": "The correction is reusable only at Issue Fix patch planning.",
-            "confidence": "high",
-        },
-        "guard_context": {
-            "source_freshness": "current",
-            "conflict_state": "clear",
-            "current_artifact_verified": True,
-        },
-        "requested_action_scopes": ["issue_fix:scope_selection"],
-        "raw_content_captured": False,
-    }
-
-
-def _authority(*, actor_ref: str = "github:user:maintainer") -> dict[str, Any]:
-    return {
-        "verified": True,
-        "source_ref": "repository:authority-map",
-        "actor_ref": actor_ref,
-        "actor_role": "verified_repository_core_contributor",
-        "project_ref": _PROJECT,
-        "action_scopes": ["issue_fix:scope_selection"],
-    }
-
-
-def _active_record() -> dict[str, Any]:
-    candidate = build_reward_memory_candidate(
-        _proposal(), authority_checkpoint=_authority()
-    )
-    reviewed = review_reward_memory_candidate(
-        candidate,
-        {
-            "decision": "accept",
-            "reviewer_ref": "github:user:maintainer",
-            "review_ref": "review:reward-memory-stage4",
-            "reasoning_summary": "The compact policy and authority scope were reviewed.",
-        },
-    )
-    return build_active_reward_memory_record(
-        reviewed, _corpus(), activated_at=_OBSERVED_AT
-    )
-
-
-def _binding() -> dict[str, Any]:
-    return {
-        "corpus_id": _CORPUS_ID,
-        "provider_id": "fixture_provider",
-        "namespace": "reward_memory",
-        "scope_ref": _SCOPE_REF,
-        "timeout_seconds": 5,
-        "setup_hints": {},
-    }
-
-
-def _checkpoint(*, project_ref: str = _PROJECT, surface_id: str = _SURFACE) -> dict[str, Any]:
-    return {
-        "verified": True,
-        "corpus_id": _CORPUS_ID,
-        "workspace_ref": _WORKSPACE,
-        "project_ref": project_ref,
-        "surface_id": surface_id,
-        "read_authority": "module_scoped",
-        "source_ref": "repository:authority-map",
-    }
-
-
-def _request(
-    *,
-    project_ref: str = _PROJECT,
-    surface_id: str = _SURFACE,
-    revision_ref: str = _REVISION,
-    freshness_revision: str = _REVISION,
-) -> dict[str, Any]:
-    return build_reward_memory_recall_request(
-        _corpus(),
-        {
-            "workspace_ref": _WORKSPACE,
-            "project_ref": project_ref,
-            "surface_id": surface_id,
-            "revision_ref": revision_ref,
-            "mode": "function_boundary",
-            "queries": [
-                {
-                    "query": "What reviewed policy constrains this patch?",
-                    "query_summary": "reviewed Issue Fix scope policy",
-                }
-            ],
-            "limit": 3,
-            "observed_at": _OBSERVED_AT,
-            "freshness_context": {
-                "source_truth_current": True,
-                "source_revision": freshness_revision,
-            },
-            "conflict_state": "clear",
-            "raw_content_captured": False,
-        },
-        read_authority_checkpoint=_checkpoint(
-            project_ref=project_ref, surface_id=surface_id
-        ),
-    )
-
-
-def _provider_item(record: Mapping[str, Any], suffix: str = "active") -> ContextProviderItem:
-    return ContextProviderItem(
-        resource_ref=f"{_SCOPE_REF}/{suffix}.json",
-        summary=str(record["content_summary"]),
-        content=json.dumps(record, ensure_ascii=False, sort_keys=True),
-        score=0.9,
-    )
-
 
 def _evaluate_case(
     case_id: str, check: Callable[[], tuple[bool, int, dict[str, Any]]]
@@ -267,164 +63,85 @@ def _evaluate_case(
 
 
 def _compact_restart_case() -> tuple[bool, int, dict[str, Any]]:
-    encoded = json.dumps(_active_record(), ensure_ascii=False, sort_keys=True)
-    restarted = json.loads(encoded)
-    provider = _FixtureProvider((_provider_item(restarted),))
-    session = execute_reward_memory_recall(
-        _request(), provider_binding=_binding(), provider=provider
-    )
+    fixture = generic_compact_restart_fixture()
     checks = (
-        restarted["schema_version"] == "reward_memory_active_record_v0",
-        session.public_packet["status"] == "completed",
-        session.public_packet["result_readback_verified"] is True,
-        provider.call_count == 1,
+        fixture["record_schema_version"] == "reward_memory_active_record_v0",
+        fixture["recall_status"] == "completed",
+        fixture["readback_verified"] is True,
+        fixture["provider_call_count"] == 1,
     )
     return all(checks), len(checks), {
-        "serialized_bytes": len(encoded.encode("utf-8")),
-        "recall_status": session.public_packet["status"],
-        "readback_verified": session.public_packet["result_readback_verified"],
+        "serialized_bytes": fixture["serialized_bytes"],
+        "recall_status": fixture["recall_status"],
+        "readback_verified": fixture["readback_verified"],
     }
 
 
 def _scope_case() -> tuple[bool, int, dict[str, Any]]:
-    wrong_project = _request(project_ref="repository:other")
-    wrong_surface = _request(surface_id="semantic_preference.selection")
-    provider = _FixtureProvider((_provider_item(_active_record()),))
-    project_session = execute_reward_memory_recall(
-        wrong_project, provider_binding=_binding(), provider=provider
-    )
-    surface_session = execute_reward_memory_recall(
-        wrong_surface, provider_binding=_binding(), provider=provider
-    )
+    fixture = generic_scope_isolation_fixture()
     checks = (
-        project_session.public_packet["status"] == "guard_blocked",
-        "project_scope_mismatch" in wrong_project["guard"]["reason_codes"],
-        surface_session.public_packet["status"] == "guard_blocked",
-        "surface_scope_mismatch" in wrong_surface["guard"]["reason_codes"],
-        provider.call_count == 0,
+        fixture["project_status"] == "guard_blocked",
+        "project_scope_mismatch" in fixture["project_reason_codes"],
+        fixture["surface_status"] == "guard_blocked",
+        "surface_scope_mismatch" in fixture["surface_reason_codes"],
+        fixture["provider_call_count"] == 0,
     )
     return all(checks), len(checks), {
-        "project_status": project_session.public_packet["status"],
-        "surface_status": surface_session.public_packet["status"],
-        "provider_call_count": provider.call_count,
-        "false_application_observed": provider.call_count > 0,
+        "project_status": fixture["project_status"],
+        "surface_status": fixture["surface_status"],
+        "provider_call_count": fixture["provider_call_count"],
+        "false_application_observed": fixture["provider_call_count"] > 0,
     }
 
 
 def _inactive_case() -> tuple[bool, int, dict[str, Any]]:
-    superseded = deepcopy(_active_record())
-    superseded["lifecycle"] = {"state": "superseded"}
-    revoked = deepcopy(_active_record())
-    revoked["lifecycle"] = {"state": "revoked"}
-    provider = _FixtureProvider(
-        (_provider_item(superseded, "superseded"), _provider_item(revoked, "revoked"))
-    )
-    session = execute_reward_memory_recall(
-        _request(), provider_binding=_binding(), provider=provider
-    )
+    fixture = generic_inactive_lifecycle_fixture()
     checks = (
-        session.public_packet["status"] == "empty",
-        session.public_packet["result_count"] == 0,
-        session.public_packet["result_readback_verified"] is False,
+        fixture["recall_status"] == "empty",
+        fixture["result_count"] == 0,
+        fixture["readback_verified"] is False,
     )
     return all(checks), len(checks), {
-        "recall_status": session.public_packet["status"],
-        "accepted_result_count": session.public_packet["result_count"],
-        "false_application_observed": session.public_packet["result_count"] > 0,
+        "recall_status": fixture["recall_status"],
+        "accepted_result_count": fixture["result_count"],
+        "false_application_observed": fixture["result_count"] > 0,
     }
 
 
 def _stale_case() -> tuple[bool, int, dict[str, Any]]:
-    request = _request(
-        revision_ref="revision:stale", freshness_revision="revision:stale"
-    )
-    provider = _FixtureProvider((_provider_item(_active_record()),))
-    session = execute_reward_memory_recall(
-        request, provider_binding=_binding(), provider=provider
-    )
-    reasons = request["guard"]["reason_codes"]
+    fixture = generic_stale_source_fixture()
+    reasons = fixture["reason_codes"]
     checks = (
-        session.public_packet["status"] == "guard_blocked",
+        fixture["recall_status"] == "guard_blocked",
         "source_revision_mismatch" in reasons,
         "request_revision_mismatch" in reasons,
-        provider.call_count == 0,
+        fixture["provider_call_count"] == 0,
     )
     return all(checks), len(checks), {
-        "recall_status": session.public_packet["status"],
+        "recall_status": fixture["recall_status"],
         "reason_codes": reasons,
-        "provider_call_count": provider.call_count,
-        "false_application_observed": provider.call_count > 0,
+        "provider_call_count": fixture["provider_call_count"],
+        "false_application_observed": fixture["provider_call_count"] > 0,
     }
 
 
 def _multi_person_case() -> tuple[bool, int, dict[str, Any]]:
-    accepted = build_reward_memory_candidate(
-        _proposal(), authority_checkpoint=_authority()
-    )
-    mismatched = build_reward_memory_candidate(
-        _proposal(), authority_checkpoint=_authority(actor_ref="github:user:other")
-    )
-    reasons = mismatched["guard"]["reason_codes"]
+    fixture = generic_multi_person_authority_fixture()
+    reasons = fixture["reason_codes"]
     checks = (
-        accepted["guard"]["passed"] is True,
-        mismatched["guard"]["passed"] is False,
+        fixture["matching_actor_guard"] is True,
+        fixture["mismatched_actor_guard"] is False,
         "authority_actor_mismatch" in reasons,
     )
     return all(checks), len(checks), {
-        "matching_actor_guard": accepted["guard"]["passed"],
-        "mismatched_actor_guard": mismatched["guard"]["passed"],
+        "matching_actor_guard": fixture["matching_actor_guard"],
+        "mismatched_actor_guard": fixture["mismatched_actor_guard"],
         "reason_codes": reasons,
     }
 
 
-def _issue_fix_application() -> dict[str, Any]:
-    from ..issue_fix.reward_memory import run_issue_fix_patch_planning_reward_memory
-
-    provider = _FixtureProvider((_provider_item(_active_record()),))
-
-    def apply_plan(base: Any, items: Any) -> dict[str, Any]:
-        plan = dict(base)
-        plan["candidates"] = ["focused_fix", "broad_generic_patch"]
-        return {
-            "outcome": "applied",
-            "output": plan,
-            "memory_refs": [items[0].memory_ref],
-            "reasoning_summary": (
-                "Current code verifies the narrow boundary; rank the focused fix first."
-            ),
-            "current_artifact_verified": True,
-        }
-
-    return run_issue_fix_patch_planning_reward_memory(
-        {"candidates": ["broad_generic_patch", "focused_fix"]},
-        corpus=_corpus(),
-        workspace_ref=_WORKSPACE,
-        repository_ref=_PROJECT,
-        revision_ref=_REVISION,
-        queries=[
-            {
-                "query": "What reviewed policy constrains this patch?",
-                "query_summary": "reviewed Issue Fix scope policy",
-            }
-        ],
-        mode="function_boundary",
-        observed_at=_OBSERVED_AT,
-        freshness_context={
-            "source_truth_current": True,
-            "source_revision": _REVISION,
-        },
-        conflict_state="clear",
-        read_authority_checkpoint=_checkpoint(),
-        provider_binding=_binding(),
-        application_id="issue-fix:stage4:ranking",
-        artifact_ref="patch-plan:stage4",
-        apply_memory=apply_plan,
-        provider=provider,
-    )
-
-
 def _gate_case() -> tuple[bool, int, dict[str, Any]]:
-    result = _issue_fix_application()
+    result = generic_issue_fix_application_fixture()
     receipt = result["application"]["receipt"]
     checks = (
         result["application"]["status"] == "applied",
@@ -441,7 +158,7 @@ def _gate_case() -> tuple[bool, int, dict[str, Any]]:
 
 
 def _ranking_case() -> tuple[bool, int, dict[str, Any]]:
-    result = _issue_fix_application()
+    result = generic_issue_fix_application_fixture()
     receipt = result["application"]["receipt"]
     checks = (
         result["patch_plan"]["candidates"][0] == "focused_fix",
@@ -457,7 +174,7 @@ def _ranking_case() -> tuple[bool, int, dict[str, Any]]:
 
 
 def _edge_case() -> tuple[bool, int, dict[str, Any]]:
-    route = build_reward_memory_route_packet(pr_3237_regression_observation())
+    route = openviking_pr_3237_regression_fixture()
     checks = (
         route["decision"] == "meta_design_gate",
         route["pilot_authorized"] is False,
@@ -490,7 +207,10 @@ _CASE_CHECKS: dict[str, Callable[[], tuple[bool, int, dict[str, Any]]]] = {
 def run_reward_memory_evaluation() -> dict[str, Any]:
     """Run the bounded Stage-4 contract suite and emit a compact release gate."""
 
-    cases = [_evaluate_case(case_id, _CASE_CHECKS[case_id]) for case_id in REQUIRED_CASE_IDS]
+    cases = [
+        _evaluate_case(case_id, _CASE_CHECKS[case_id])
+        for case_id in REQUIRED_CASE_IDS
+    ]
     failed = [case["case_id"] for case in cases if not case["passed"]]
     metrics = {
         "case_count": len(cases),

--- a/loopx/capabilities/reward_memory/evaluation_fixtures.py
+++ b/loopx/capabilities/reward_memory/evaluation_fixtures.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any
+
+from ..context_providers.base import ContextProviderItem, ContextProviderRetrieval
+from .application import (
+    build_active_reward_memory_record,
+    build_reward_memory_recall_request,
+    execute_reward_memory_recall,
+)
+from .architecture import (
+    build_reward_memory_route_packet,
+    pr_3237_regression_observation,
+)
+from .candidate_review import (
+    build_reward_memory_candidate,
+    review_reward_memory_candidate,
+)
+
+
+_OBSERVED_AT = "2026-07-14T10:00:00+00:00"
+_WORKSPACE = "workspace:reward-memory-eval"
+_PROJECT = "repository:fixture-project"
+_REVISION = "revision:stage4"
+_SURFACE = "issue_fix.patch_planning"
+_CORPUS_ID = "reward_memory_policy_scopes"
+_SCOPE_REF = "memory://resources/reward-memory/fixture-project"
+
+
+@dataclass
+class _FixtureProvider:
+    items: tuple[ContextProviderItem, ...]
+    provider_id: str = "fixture_provider"
+    call_count: int = 0
+
+    def retrieve(self, **kwargs: Any) -> ContextProviderRetrieval:
+        self.call_count += 1
+        return ContextProviderRetrieval(
+            provider=self.provider_id,
+            namespace=str(kwargs["namespace"]),
+            status="completed",
+            query_summary=str(kwargs["query_summary"]),
+            observed_at=str(kwargs["observed_at"]),
+            search_performed=True,
+            read_performed=True,
+            items=self.items,
+            requested_limit=int(kwargs["max_results"]),
+        )
+
+    def sync(self, **_kwargs: Any) -> Any:
+        raise AssertionError("the Stage-4 fixture must not write provider state")
+
+
+def _corpus() -> dict[str, Any]:
+    return {
+        "corpus_id": _CORPUS_ID,
+        "class_id": "hard_policy",
+        "provider_id": "fixture_provider",
+        "owner_ref": "provider_scope_owner",
+        "source_of_truth": "reviewed_owner_feedback",
+        "read_authority": "module_scoped",
+        "write_authority": "provider_managed",
+        "scope": {
+            "workspace_ref": _WORKSPACE,
+            "project_ref": _PROJECT,
+            "surface_ids": [_SURFACE],
+        },
+        "freshness": {"mode": "revision_bound", "source_revision": _REVISION},
+        "lifecycle": {"state": "active", "supersedes": []},
+        "retrieval": {
+            "index_required": True,
+            "readback_required": True,
+            "application_receipt_required": True,
+        },
+        "maintenance": {
+            "writeback_triggers": ["reviewed_candidate"],
+            "closure_policy": "provider_write_then_revision_verified_read",
+            "retirement_authority": "provider_scope_owner",
+        },
+        "privacy": {"visibility": "private", "raw_content_in_registry": False},
+        "provider_scope_ref_digest": hashlib.sha256(
+            _SCOPE_REF.encode("utf-8")
+        ).hexdigest()[:16],
+    }
+
+
+def _proposal(*, actor_ref: str = "github:user:maintainer") -> dict[str, Any]:
+    return {
+        "target_class": "hard_policy",
+        "content_summary": (
+            "Memory-core changes require relevant effect evidence and must not add "
+            "a disproportionate patch for one narrow edge case."
+        ),
+        "source": {
+            "source_kind": "maintainer_correction",
+            "source_ref": "github:example/reward-memory#reviewed-feedback",
+            "actor_ref": actor_ref,
+            "actor_role": "verified_repository_core_contributor",
+        },
+        "scope": {
+            "workspace_ref": _WORKSPACE,
+            "project_ref": _PROJECT,
+            "surface_ids": [_SURFACE],
+            "revision_ref": _REVISION,
+        },
+        "reasoning": {
+            "summary": "The correction is reusable only at Issue Fix patch planning.",
+            "confidence": "high",
+        },
+        "guard_context": {
+            "source_freshness": "current",
+            "conflict_state": "clear",
+            "current_artifact_verified": True,
+        },
+        "requested_action_scopes": ["issue_fix:scope_selection"],
+        "raw_content_captured": False,
+    }
+
+
+def _authority(*, actor_ref: str = "github:user:maintainer") -> dict[str, Any]:
+    return {
+        "verified": True,
+        "source_ref": "repository:authority-map",
+        "actor_ref": actor_ref,
+        "actor_role": "verified_repository_core_contributor",
+        "project_ref": _PROJECT,
+        "action_scopes": ["issue_fix:scope_selection"],
+    }
+
+
+def _active_record() -> dict[str, Any]:
+    candidate = build_reward_memory_candidate(
+        _proposal(), authority_checkpoint=_authority()
+    )
+    reviewed = review_reward_memory_candidate(
+        candidate,
+        {
+            "decision": "accept",
+            "reviewer_ref": "github:user:maintainer",
+            "review_ref": "review:reward-memory-stage4",
+            "reasoning_summary": (
+                "The compact policy and authority scope were reviewed."
+            ),
+        },
+    )
+    return build_active_reward_memory_record(
+        reviewed, _corpus(), activated_at=_OBSERVED_AT
+    )
+
+
+def _binding() -> dict[str, Any]:
+    return {
+        "corpus_id": _CORPUS_ID,
+        "provider_id": "fixture_provider",
+        "namespace": "reward_memory",
+        "scope_ref": _SCOPE_REF,
+        "timeout_seconds": 5,
+        "setup_hints": {},
+    }
+
+
+def _checkpoint(
+    *, project_ref: str = _PROJECT, surface_id: str = _SURFACE
+) -> dict[str, Any]:
+    return {
+        "verified": True,
+        "corpus_id": _CORPUS_ID,
+        "workspace_ref": _WORKSPACE,
+        "project_ref": project_ref,
+        "surface_id": surface_id,
+        "read_authority": "module_scoped",
+        "source_ref": "repository:authority-map",
+    }
+
+
+def _request(
+    *,
+    project_ref: str = _PROJECT,
+    surface_id: str = _SURFACE,
+    revision_ref: str = _REVISION,
+    freshness_revision: str = _REVISION,
+) -> dict[str, Any]:
+    return build_reward_memory_recall_request(
+        _corpus(),
+        {
+            "workspace_ref": _WORKSPACE,
+            "project_ref": project_ref,
+            "surface_id": surface_id,
+            "revision_ref": revision_ref,
+            "mode": "function_boundary",
+            "queries": [
+                {
+                    "query": "What reviewed policy constrains this patch?",
+                    "query_summary": "reviewed Issue Fix scope policy",
+                }
+            ],
+            "limit": 3,
+            "observed_at": _OBSERVED_AT,
+            "freshness_context": {
+                "source_truth_current": True,
+                "source_revision": freshness_revision,
+            },
+            "conflict_state": "clear",
+            "raw_content_captured": False,
+        },
+        read_authority_checkpoint=_checkpoint(
+            project_ref=project_ref, surface_id=surface_id
+        ),
+    )
+
+
+def _provider_item(
+    record: Mapping[str, Any], suffix: str = "active"
+) -> ContextProviderItem:
+    return ContextProviderItem(
+        resource_ref=f"{_SCOPE_REF}/{suffix}.json",
+        summary=str(record["content_summary"]),
+        content=json.dumps(record, ensure_ascii=False, sort_keys=True),
+        score=0.9,
+    )
+
+
+def generic_compact_restart_fixture() -> dict[str, Any]:
+    encoded = json.dumps(_active_record(), ensure_ascii=False, sort_keys=True)
+    restarted = json.loads(encoded)
+    provider = _FixtureProvider((_provider_item(restarted),))
+    session = execute_reward_memory_recall(
+        _request(), provider_binding=_binding(), provider=provider
+    )
+    return {
+        "fixture_identity": {
+            "project_ref": _PROJECT,
+            "corpus_id": _CORPUS_ID,
+            "scope_ref": _SCOPE_REF,
+        },
+        "serialized_bytes": len(encoded.encode("utf-8")),
+        "record_schema_version": restarted["schema_version"],
+        "recall_status": session.public_packet["status"],
+        "readback_verified": session.public_packet["result_readback_verified"],
+        "provider_call_count": provider.call_count,
+    }
+
+
+def generic_scope_isolation_fixture() -> dict[str, Any]:
+    wrong_project = _request(project_ref="repository:other")
+    wrong_surface = _request(surface_id="semantic_preference.selection")
+    provider = _FixtureProvider((_provider_item(_active_record()),))
+    project_session = execute_reward_memory_recall(
+        wrong_project, provider_binding=_binding(), provider=provider
+    )
+    surface_session = execute_reward_memory_recall(
+        wrong_surface, provider_binding=_binding(), provider=provider
+    )
+    return {
+        "project_status": project_session.public_packet["status"],
+        "project_reason_codes": wrong_project["guard"]["reason_codes"],
+        "surface_status": surface_session.public_packet["status"],
+        "surface_reason_codes": wrong_surface["guard"]["reason_codes"],
+        "provider_call_count": provider.call_count,
+    }
+
+
+def generic_inactive_lifecycle_fixture() -> dict[str, Any]:
+    superseded = deepcopy(_active_record())
+    superseded["lifecycle"] = {"state": "superseded"}
+    revoked = deepcopy(_active_record())
+    revoked["lifecycle"] = {"state": "revoked"}
+    provider = _FixtureProvider(
+        (_provider_item(superseded, "superseded"), _provider_item(revoked, "revoked"))
+    )
+    session = execute_reward_memory_recall(
+        _request(), provider_binding=_binding(), provider=provider
+    )
+    return {
+        "recall_status": session.public_packet["status"],
+        "result_count": session.public_packet["result_count"],
+        "readback_verified": session.public_packet["result_readback_verified"],
+    }
+
+
+def generic_stale_source_fixture() -> dict[str, Any]:
+    request = _request(
+        revision_ref="revision:stale", freshness_revision="revision:stale"
+    )
+    provider = _FixtureProvider((_provider_item(_active_record()),))
+    session = execute_reward_memory_recall(
+        request, provider_binding=_binding(), provider=provider
+    )
+    return {
+        "recall_status": session.public_packet["status"],
+        "reason_codes": request["guard"]["reason_codes"],
+        "provider_call_count": provider.call_count,
+    }
+
+
+def generic_multi_person_authority_fixture() -> dict[str, Any]:
+    accepted = build_reward_memory_candidate(
+        _proposal(), authority_checkpoint=_authority()
+    )
+    mismatched = build_reward_memory_candidate(
+        _proposal(), authority_checkpoint=_authority(actor_ref="github:user:other")
+    )
+    return {
+        "matching_actor_guard": accepted["guard"]["passed"],
+        "mismatched_actor_guard": mismatched["guard"]["passed"],
+        "reason_codes": mismatched["guard"]["reason_codes"],
+    }
+
+
+def generic_issue_fix_application_fixture() -> dict[str, Any]:
+    from ..issue_fix.reward_memory import run_issue_fix_patch_planning_reward_memory
+
+    provider = _FixtureProvider((_provider_item(_active_record()),))
+
+    def apply_plan(base: Any, items: Any) -> dict[str, Any]:
+        plan = dict(base)
+        plan["candidates"] = ["focused_fix", "broad_generic_patch"]
+        return {
+            "outcome": "applied",
+            "output": plan,
+            "memory_refs": [items[0].memory_ref],
+            "reasoning_summary": (
+                "Current code verifies the narrow boundary; rank the focused fix first."
+            ),
+            "current_artifact_verified": True,
+        }
+
+    return run_issue_fix_patch_planning_reward_memory(
+        {"candidates": ["broad_generic_patch", "focused_fix"]},
+        corpus=_corpus(),
+        workspace_ref=_WORKSPACE,
+        repository_ref=_PROJECT,
+        revision_ref=_REVISION,
+        queries=[
+            {
+                "query": "What reviewed policy constrains this patch?",
+                "query_summary": "reviewed Issue Fix scope policy",
+            }
+        ],
+        mode="function_boundary",
+        observed_at=_OBSERVED_AT,
+        freshness_context={
+            "source_truth_current": True,
+            "source_revision": _REVISION,
+        },
+        conflict_state="clear",
+        read_authority_checkpoint=_checkpoint(),
+        provider_binding=_binding(),
+        application_id="issue-fix:stage4:ranking",
+        artifact_ref="patch-plan:stage4",
+        apply_memory=apply_plan,
+        provider=provider,
+    )
+
+
+def openviking_pr_3237_regression_fixture() -> dict[str, Any]:
+    return build_reward_memory_route_packet(pr_3237_regression_observation())


### PR DESCRIPTION
## Why

Reward Memory Stage 4 mixed evaluator orchestration with scenario-specific fixture identity. That made evaluation.py look project-specific and obscured the reusable boundary.

## What changed

- evaluator now owns case orchestration, assertions, metrics, and the release gate
- a dedicated fixture module owns neutral setup data and scenario execution
- OpenViking PR #3237 remains only as an explicitly named regression fixture
- English and Chinese architecture docs now state this ownership boundary

## Behavior parity

- 8 cases and 31 assertions remain unchanged
- public evidence stays 997 bytes; compact record stays 1262 bytes
- normalized evaluation packet digest is unchanged: 7daba49aba23880d9575b13e6728f18cb358b3084f0b273704b1d0ca6adff4f4
- no API, CLI, schema, provider, or scheduler behavior changes

## Validation

- reward-memory evaluation and all five Reward Memory smoke suites pass
- standard diff-driven premerge: 13 selected checks + 4 direct checks, 0 failures, 0 warnings, 0 manual holds
- LoopX public boundary scan: clean