### PR TITLE
fix: retry transient explore marker readback

### DIFF
--- a/examples/explore-result-layer-smoke.py
+++ b/examples/explore-result-layer-smoke.py
@@ -39,6 +39,7 @@ from loopx.capabilities.explore.worker_branch_plan import (  # noqa: E402
     build_explore_worker_branch_plan,
 )
 from loopx.presentation.sinks.lark import explore_results  # noqa: E402
+from loopx.presentation.sinks.lark import explore_visual_styles  # noqa: E402
 
 # Both exploration planners are deny-by-default behind the per-goal
 # goal_boundary.orchestration.explore_harness gate; every library-level plan
@@ -422,6 +423,74 @@ def check_lark_sync_contract() -> None:
         shared_blob = json.dumps(shared["records"], ensure_ascii=False)
         assert "internal.example.invalid" not in shared_blob, shared_blob
         assert "[private-link-redacted]" in shared_blob, shared_blob
+
+
+def check_visual_marker_readback_retry_contract() -> None:
+    marker = "LoopX delivery smoke-marker"
+    config = explore_results.LarkExploreConfig(
+        **{"base_" + "token": "SMOKE_BASE"},
+        table_ids={"nodes": "tblN", "edges": "tblE", "findings": "tblF"},
+    )
+    calls = 0
+
+    def settling_runner(
+        args: list[str], cwd: Path | None, timeout: float | None
+    ) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return {
+                "returncode": 1,
+                "stdout": json.dumps(
+                    {
+                        "ok": False,
+                        "error": {"code": 2890002, "message": "invalid arg"},
+                    }
+                ),
+                "stderr": "",
+                "timed_out": False,
+            }
+        return {
+            "returncode": 0,
+            "stdout": json.dumps(
+                {"ok": True, "data": {"nodes": [{"text": {"text": marker}}]}}
+            ),
+            "stderr": "",
+            "timed_out": False,
+        }
+
+    original_delays = explore_results._VISUAL_READBACK_RETRY_DELAYS_SECONDS
+    explore_results._VISUAL_READBACK_RETRY_DELAYS_SECONDS = (0.0,)
+    try:
+        settled = explore_results._readback_visual_delivery_marker(
+            config,
+            whiteboard_token="wb_public_fixture",
+            marker=marker,
+            runner=settling_runner,
+        )
+    finally:
+        explore_results._VISUAL_READBACK_RETRY_DELAYS_SECONDS = original_delays
+    assert settled["ok"] is True and settled["verified"] is True, settled
+    assert settled["attempt_count"] == 2, settled
+    assert settled["attempts"][0] == {
+        "attempt": 1,
+        "ok": False,
+        "marker_observed": False,
+        "error_code": 2890002,
+        "retryable": True,
+    }, settled
+    assert settled["retryable"] is False, settled
+
+    summary = explore_visual_styles.summarize_explore_visual_sync(
+        views={"canonical": {"ok": False, "retryable": True}},
+        configured_roles=["canonical"],
+        recommended_roles=["canonical"],
+        execute=True,
+    )
+    assert summary["ok"] is False, summary
+    assert summary["status"] == "publish_failed", summary
+    assert summary["retryable"] is True, summary
+    assert "canonical marker readback" in str(summary["required_action"]), summary
 
 
 def check_lark_setup_and_card() -> None:
@@ -1334,6 +1403,7 @@ def check_cli_surface() -> None:
 def main() -> int:
     check_result_log_contract()
     check_lark_sync_contract()
+    check_visual_marker_readback_retry_contract()
     check_lark_setup_and_card()
     check_todo_branch_prediction_contract()
     check_worker_lane_router_contract()

--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -65,6 +65,11 @@ from .explore_visual_styles import (
     resolve_explore_board_style,
     summarize_explore_visual_sync,
 )
+from .explore_visual_readback import (
+    is_retryable_marker_readback_error,
+    structured_command_error,
+    whiteboard_raw_texts,
+)
 from .message_card import build_lark_markdown_reply_card
 
 LARK_EXPLORE_SCHEMA_VERSION = "loopx_lark_explore_result_board_v0"
@@ -557,32 +562,6 @@ def configure_lark_explore_visual_sink(
     }
 
 
-def _whiteboard_raw_texts(payload: Any) -> list[str]:
-    if not isinstance(payload, Mapping):
-        return []
-    data = payload.get("data")
-    nodes = data.get("nodes") if isinstance(data, Mapping) else None
-    texts: list[str] = []
-    for node in nodes if isinstance(nodes, list) else []:
-        if not isinstance(node, Mapping):
-            continue
-        text_node = node.get("text")
-        if isinstance(text_node, Mapping) and str(text_node.get("text") or "").strip():
-            texts.append(str(text_node.get("text")))
-    return texts
-
-
-def _structured_command_error(result: Mapping[str, Any]) -> Mapping[str, Any]:
-    parsed = result.get("json")
-    if not isinstance(parsed, Mapping):
-        try:
-            parsed = json.loads(str(result.get("stderr") or ""))
-        except (TypeError, json.JSONDecodeError):
-            parsed = None
-    error = parsed.get("error") if isinstance(parsed, Mapping) else None
-    return error if isinstance(error, Mapping) else {}
-
-
 def _readback_visual_delivery_marker(
     config: LarkExploreConfig,
     *,
@@ -609,14 +588,17 @@ def _readback_visual_delivery_marker(
     marker_observed = False
     for attempt_index in range(len(_VISUAL_READBACK_RETRY_DELAYS_SECONDS) + 1):
         result = _run_command(command, execute=True, runner=runner)
-        texts = _whiteboard_raw_texts(result.get("json"))
+        texts = whiteboard_raw_texts(result.get("json"))
         marker_observed = marker in texts
-        error = _structured_command_error(result)
+        error = structured_command_error(result)
         error_code = error.get("code")
         error_message = str(error.get("message") or "")
-        is_applying = error_code == 4003101 and "doc is applying" in error_message
+        is_query_settling = is_retryable_marker_readback_error(
+            error_code=error_code,
+            error_message=error_message,
+        )
         is_marker_pending = bool(result.get("ok")) and not marker_observed
-        is_retryable = is_applying or is_marker_pending
+        is_retryable = is_query_settling or is_marker_pending
         attempts.append(
             {
                 "attempt": attempt_index + 1,
@@ -653,6 +635,9 @@ def _readback_visual_delivery_marker(
         "remote_text_node_count": len(texts),
         "attempt_count": len(attempts),
         "attempts": attempts,
+        "retryable": bool(
+            not marker_observed and attempts and attempts[-1].get("retryable")
+        ),
         "command": command_receipt,
         "error": (
             None
@@ -805,7 +790,7 @@ def sync_explore_visual_to_lark(
                 cwd=config_path.parent,
             )
             publish_attempts = [result]
-            error = _structured_command_error(result)
+            error = structured_command_error(result)
             if (
                 not result.get("ok")
                 and error.get("code") == 2891001
@@ -852,6 +837,12 @@ def sync_explore_visual_to_lark(
     delivery_ok = bool(
         result.get("ok") and (not delivery_marker or readback.get("ok"))
     )
+    retryable = bool(
+        execute
+        and result.get("ok")
+        and delivery_marker
+        and readback.get("retryable")
+    )
     return {
         "ok": delivery_ok,
         "schema_version": LARK_EXPLORE_VISUAL_SYNC_VERSION,
@@ -881,6 +872,12 @@ def sync_explore_visual_to_lark(
         "publish_attempt_count": len(publish_attempts),
         "publish_attempts": publish_attempts,
         "readback": readback,
+        "retryable": retryable,
+        "required_action": (
+            "retry Explore visual sync; post-publish marker readback did not settle"
+            if retryable
+            else None
+        ),
         "error": (
             None
             if delivery_ok
@@ -1022,6 +1019,7 @@ def sync_explore_visuals_to_lark(
             )
             stage_results.append(dict(stage_result, stage=dict(stage)))
         role_ok = all(bool(item.get("ok")) for item in stage_results)
+        role_retryable = any(bool(item.get("retryable")) for item in stage_results)
         role_delivery_material = "|".join(
             str(item.get("delivery_digest") or "") for item in stage_results
         ).encode("utf-8")
@@ -1032,6 +1030,12 @@ def sync_explore_visuals_to_lark(
             ),
             "execute": execute,
             "published": bool(execute and role_ok),
+            "retryable": role_retryable,
+            "required_action": (
+                f"retry Explore visual sync for the {role} marker readback"
+                if role_retryable
+                else None
+            ),
             "view_role": role,
             "board_style": (
                 str(stage_results[0].get("board_style") or "")

--- a/loopx/presentation/sinks/lark/explore_visual_readback.py
+++ b/loopx/presentation/sinks/lark/explore_visual_readback.py
@@ -1,0 +1,44 @@
+"""Small parsing helpers for Explore visual marker readback."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+
+def whiteboard_raw_texts(payload: Any) -> list[str]:
+    if not isinstance(payload, Mapping):
+        return []
+    data = payload.get("data")
+    nodes = data.get("nodes") if isinstance(data, Mapping) else None
+    texts: list[str] = []
+    for node in nodes if isinstance(nodes, list) else []:
+        if not isinstance(node, Mapping):
+            continue
+        text_node = node.get("text")
+        if isinstance(text_node, Mapping) and str(text_node.get("text") or "").strip():
+            texts.append(str(text_node.get("text")))
+    return texts
+
+
+def structured_command_error(result: Mapping[str, Any]) -> Mapping[str, Any]:
+    parsed = result.get("json")
+    if not isinstance(parsed, Mapping):
+        try:
+            parsed = json.loads(str(result.get("stderr") or ""))
+        except (TypeError, json.JSONDecodeError):
+            parsed = None
+    error = parsed.get("error") if isinstance(parsed, Mapping) else None
+    return error if isinstance(error, Mapping) else {}
+
+
+def is_retryable_marker_readback_error(
+    *, error_code: Any, error_message: str
+) -> bool:
+    if error_code == 4003101 and "doc is applying" in error_message:
+        return True
+    # Lark can briefly return ``invalid arg`` from the raw-node query
+    # immediately after accepting a whiteboard overwrite. This helper is
+    # called only by that post-publish marker path, so it does not generalize
+    # every API 2890002 response into a transient error.
+    return error_code == 2890002 and "invalid arg" in error_message

--- a/loopx/presentation/sinks/lark/explore_visual_styles.py
+++ b/loopx/presentation/sinks/lark/explore_visual_styles.py
@@ -84,6 +84,11 @@ def summarize_explore_visual_sync(
     missing_roles = [
         role for role in recommended_roles if role not in configured_roles
     ]
+    retryable_roles = [
+        role
+        for role, view in views.items()
+        if isinstance(view, Mapping) and bool(view.get("retryable"))
+    ]
     configured_views_ok = all(bool(view.get("ok")) for view in views.values())
     ok = configured_views_ok and not missing_roles
     if missing_roles and (not views or configured_views_ok):
@@ -95,15 +100,18 @@ def summarize_explore_visual_sync(
     else:
         status = "published" if execute else "would_publish"
     missing_roles_label = ", ".join(missing_roles)
+    retryable_roles_label = ", ".join(retryable_roles)
     return {
         "ok": ok,
         "status": status,
         "published": bool(execute and ok),
-        "retryable": bool(missing_roles),
+        "retryable": bool(missing_roles or retryable_roles),
         "required_action": (
             f"configure the {missing_roles_label} visual role"
             f"{'s' if len(missing_roles) != 1 else ''} and retry Explore visual sync"
             if missing_roles
+            else f"retry Explore visual sync for the {retryable_roles_label} marker readback"
+            if retryable_roles
             else None
         ),
         "configured_roles": configured_roles,


### PR DESCRIPTION
## Why

A material Explore Graph refresh updated and verified all canonical rows, but one post-publish whiteboard marker query briefly returned Lark API 2890002 invalid arg. LoopX stopped immediately and the aggregate visual receipt incorrectly reported retryable=false.

## What changed

- treat 2890002 invalid arg as bounded-retryable only inside the post-publish raw-node marker readback path
- preserve the existing finite retry delays and do not change general Lark API error semantics
- propagate retryable and required_action from stage to role and top-level visual receipts
- extract the small readback parsing/classification helpers so explore_results.py remains under its 2000-line budget

## Validation

- focused marker retry smoke proves the first 2890002 response retries and the next marker read succeeds
- Explore result, issue-fix projection, executive projection, configure-goal, line-budget, and boundary smokes pass
- standard diff-driven premerge: 4 selected plus 4 direct checks, 0 failures, 0 warnings, 0 holds
- real OpenViking canary: 590/590 rows verified, 0 missing/mismatch/duplicates, canonical 14/14 stages published and marker-verified; several stages required 2-3 bounded readback attempts, including the previously failed Stage 3 path