### PR TITLE
Fix runtime route diagnostics status budget

### DIFF
--- a/examples/control_plane/hot-path-interface-budget-smoke.py
+++ b/examples/control_plane/hot-path-interface-budget-smoke.py
@@ -283,6 +283,7 @@ def main() -> int:
         status_items = status_payload["attention_queue"]["items"]
         assert status_items, status_payload
         assert "task_graph_projection" not in status_items[0], status_items[0]
+        assert status_payload["runtime_projection_routes"] == {"healthy": True}
         quota_payload = build_quota_should_run(status_payload, goal_id=GOAL_ID)
         review_packet = build_review_packet(status_payload, goal_id=GOAL_ID, action_kind="codex")
         handoff_payload = review_packet_handoff_only_payload(review_packet)

--- a/examples/control_plane/refresh-state-shared-runtime-projection-smoke.py
+++ b/examples/control_plane/refresh-state-shared-runtime-projection-smoke.py
@@ -24,6 +24,7 @@ from loopx.control_plane.runtime.runtime_projection_route import (  # noqa: E402
     compact_runtime_projection_route,
     resolve_runtime_projection_route,
 )
+from loopx import doctor as doctor_module  # noqa: E402
 from loopx.presentation.renderers.status_markdown import (  # noqa: E402
     render_status_markdown,
 )
@@ -324,8 +325,7 @@ def main() -> None:
             shared_runtime=shared_runtime,
         )
         route_diagnostics = status["runtime_projection_routes"]
-        assert route_diagnostics["healthy"] is True, route_diagnostics
-        assert route_diagnostics["counts"]["healthy"] == 1, route_diagnostics
+        assert route_diagnostics == {"healthy": True}, route_diagnostics
         assert "runtime_projection_routes: healthy=True" in render_status_markdown(status)
 
         source_index = project_runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
@@ -358,11 +358,23 @@ def main() -> None:
             shared_runtime=shared_runtime,
         )
         lagging_routes = lagging_status["runtime_projection_routes"]
-        assert lagging_routes["healthy"] is False, lagging_routes
-        assert lagging_routes["counts"]["lagging"] == 1, lagging_routes
+        assert lagging_routes == {"healthy": False}, lagging_routes
         lagging_markdown = render_status_markdown(lagging_status)
-        assert "## Runtime Projection Route Findings" in lagging_markdown
-        assert "status=lagging" in lagging_markdown
+        assert "runtime_projection_routes: healthy=False" in lagging_markdown
+        assert "details=loopx doctor" in lagging_markdown
+        default_runtime_root = doctor_module.DEFAULT_RUNTIME_ROOT
+        doctor_module.DEFAULT_RUNTIME_ROOT = shared_runtime
+        try:
+            doctor = doctor_module.collect_doctor()
+        finally:
+            doctor_module.DEFAULT_RUNTIME_ROOT = default_runtime_root
+        doctor_routes = doctor["runtime_projection_routes"]
+        assert doctor_routes["healthy"] is False, doctor_routes
+        assert doctor_routes["counts"]["lagging"] == 1, doctor_routes
+        assert any(
+            item.get("goal_id") == GOAL_ID and item.get("status") == "lagging"
+            for item in doctor_routes["items"]
+        ), doctor_routes
 
         single_runtime = Path(tmp) / "single-runtime"
         single_registry, single_goal = write_route_source(

--- a/examples/control_plane/shared-runtime-material-projection-smoke.py
+++ b/examples/control_plane/shared-runtime-material-projection-smoke.py
@@ -264,7 +264,7 @@ def exercise_split_runtime(root: Path) -> None:
         assert dream_status["run_history"]["goals"][0]["latest_status_run"][
             "classification"
         ] == "dreaming_proposal_deferred"
-        assert dream_status["runtime_projection_routes"]["counts"]["healthy"] == 1
+        assert dream_status["runtime_projection_routes"] == {"healthy": True}
 
         source_row = read_rows(source_runtime)[-1]
         replay_record, replay_index = build_shared_runtime_material_projection(

--- a/loopx/control_plane/status_collection.py
+++ b/loopx/control_plane/status_collection.py
@@ -88,6 +88,13 @@ def collect_status(
         runtime_root=runtime_root,
         goal_id=goal_filter,
     )
+    runtime_projection_route_health = {
+        "healthy": (
+            bool(runtime_projection_routes.get("healthy"))
+            if runtime_projection_routes.get("available")
+            else None
+        )
+    }
     payload = {
         "ok": bool(contract.get("ok")) and bool(global_registry.get("ok", True)),
         "registry": str(registry_path),
@@ -109,7 +116,7 @@ def collect_status(
         **runtime_summaries,
         "promotion_gate": promotion_gate,
     }
-    payload["runtime_projection_routes"] = runtime_projection_routes
+    payload["runtime_projection_routes"] = runtime_projection_route_health
     agent_management_projection = context.build_agent_management_projection(payload)
     if agent_management_projection.get("agents"):
         payload["agent_management_projection"] = agent_management_projection

--- a/loopx/presentation/renderers/status_markdown.py
+++ b/loopx/presentation/renderers/status_markdown.py
@@ -132,36 +132,11 @@ def append_runtime_projection_routes_markdown(
     lines: list[str],
     diagnostics: dict[str, Any],
 ) -> None:
-    if not diagnostics.get("available"):
+    healthy = diagnostics.get("healthy")
+    if healthy is None:
         return
-    counts = as_dict(diagnostics.get("counts"))
-    lines.append(
-        "- runtime_projection_routes: "
-        f"healthy={diagnostics.get('healthy')}, "
-        f"single_runtime={counts.get('single_runtime')}, "
-        f"ready={counts.get('ready')}, "
-        f"missing={counts.get('missing')}, "
-        f"ambiguous={counts.get('ambiguous')}, "
-        f"lagging={counts.get('lagging')}"
-    )
-    findings = [
-        item
-        for item in as_list(diagnostics.get("items"))
-        if isinstance(item, dict)
-        and item.get("status") in {"missing", "ambiguous", "lagging"}
-    ]
-    if not findings:
-        return
-    lines.extend(["", "## Runtime Projection Route Findings"])
-    for item in findings:
-        route = as_dict(item.get("route"))
-        lines.append(
-            "- "
-            f"goal={markdown_scalar(item.get('goal_id') or '')} "
-            f"status={markdown_scalar(item.get('status') or '')} "
-            f"reason={markdown_scalar(item.get('reason') or '')} "
-            f"route_id={markdown_scalar(route.get('route_id') or '')}"
-        )
+    suffix = "" if healthy else ", details=loopx doctor"
+    lines.append(f"- runtime_projection_routes: healthy={healthy}{suffix}")
 
 
 def append_global_registry_findings_markdown(


### PR DESCRIPTION
## Summary
- keep dashboard status route diagnostics to a compact `healthy` read model
- retain detailed route counts and findings in `loopx doctor`
- cover healthy, lagging, Markdown guidance, and the hot-path budget

## Motivation
Full runtime projection route diagnostics added roughly 750 bytes to the dashboard status payload and caused the public hot-path interface budget smoke to fail. Status only needs the operator health signal; detailed diagnosis is a cold-path concern.

## Validation
- `python3 examples/control_plane/hot-path-interface-budget-smoke.py`
- `python3 examples/control_plane/refresh-state-shared-runtime-projection-smoke.py`
- `python3 examples/control_plane/shared-runtime-material-projection-smoke.py`
- full-public smoke shard offset 200 / limit 100: 100 passed, 0 failed
- `python3 -m loopx.cli --format json canary premerge --from-git-diff --timeout-seconds 120 --no-progress`: 17 selected checks passed, no warnings or manual holds
- changed-file `py_compile`, `git diff --check`, and public/private boundary scan passed

## Risk
The dashboard status JSON and Markdown intentionally stop embedding per-goal route details. Unhealthy status points operators to `loopx doctor`, whose detailed counts/items remain covered. No runtime routing, state writes, permissions, or benchmark semantics change.