### PR TITLE
feat: add bounded reward memory dogfood controls

### DIFF
--- a/docs/reference/protocols/reward-memory-architecture-v0.md
+++ b/docs/reference/protocols/reward-memory-architecture-v0.md
@@ -355,3 +355,49 @@ A pass yields `ready_for_bounded_dogfood`, not production release. It proves
 core contract invariants only, does not claim semantic uplift, and does not
 authorize production rollout. Stage 5 must use a corpus-owner-approved record,
 exact provider readback, and real module outcomes before making an uplift claim.
+
+## Stage 5 dogfood receipts and operator controls
+
+Stage 5 adds one thin evidence layer over the Stage 3 application receipt. It
+does not add a store, scheduler, semantic router, automatic recall path, or
+another evaluator. A caller supplies a compact real-module observation whose
+artifact reference matches the application receipt:
+
+```bash
+loopx reward-memory dogfood-evaluate \
+  --input compact-observations.json --format json
+```
+
+`reward_memory_dogfood_receipt_v0` derives `hit`, `miss`, or `refute` from the
+existing application outcome instead of trusting a caller-provided label. A
+hit or refute is invalid unless the selected provider result was read back
+exactly and the current artifact was verified. The receipt retains only opaque
+or hashed memory references, a compact verified outcome summary, latency,
+model-token and provider-call counts, intervention count, and optional compact
+bot feedback. It retains no raw provider content and grants no new action
+authority.
+
+`reward_memory_dogfood_batch_v0` becomes
+`ready_for_bounded_issue_fix_pilot` only when the Stage 4 gate still passes and
+the bounded batch contains at least one Issue Fix result, two distinct LoopX
+domain results, all three hit/miss/refute classes, and both operator controls.
+This is a trial-readiness statement. Semantic-uplift and production-rollout
+claims remain false.
+
+The edit/retire control is similarly narrow:
+
+```bash
+loopx reward-memory operator-control \
+  --input reviewed-record.json --action retire \
+  --control-ref control:example:retire \
+  --reasoning-summary 'Current source truth supersedes this record.' \
+  --format json
+```
+
+An edit checkpoint must match the corpus owner; a retirement checkpoint must
+match `maintenance.retirement_authority`. Both checkpoints are also bound to
+the exact corpus, project, and action. Edit produces a replacement
+candidate linked to the active record. Retire produces a retired decision.
+Neither command writes provider state. The declared corpus owner still performs
+the write and exact readback, so operator control cannot silently become a
+publish, production, or cross-project authority expansion.

--- a/docs/reference/protocols/reward-memory-architecture-v0.zh-CN.md
+++ b/docs/reference/protocols/reward-memory-architecture-v0.zh-CN.md
@@ -300,3 +300,42 @@ interruption 和 user gate 计数均为零，release gate 才能通过。
 通过后的状态是 `ready_for_bounded_dogfood`，不是 production release。它只证明 core
 contract invariant，不声明 semantic uplift，也不授权 production rollout。Stage 5 必须
 使用经 corpus owner 批准的 record、精确 provider readback 和真实模块结果，才能讨论收益。
+
+## Stage 5 dogfood receipt 与 operator control
+
+Stage 5 只在 Stage 3 application receipt 上增加一层薄的证据合同，不新增 store、scheduler、
+语义路由器、automatic recall 或第二套 evaluator。调用方传入紧凑的真实模块 observation，
+其中 artifact reference 必须与 application receipt 一致：
+
+```bash
+loopx reward-memory dogfood-evaluate \
+  --input compact-observations.json --format json
+```
+
+`reward_memory_dogfood_receipt_v0` 根据已有 application outcome 推导 `hit`、`miss` 或
+`refute`，不接受调用方自行声明结果类型。`hit` 或 `refute` 必须同时满足精确 provider
+result readback 与 current-artifact verification。Receipt 只保留 opaque/hashed memory ref、
+紧凑的已验证结果摘要、latency、model token、provider call、intervention count，以及可选的
+紧凑 bot feedback；不保留 raw provider content，也不授予新的 action authority。
+
+只有 Stage 4 gate 仍然通过，并且受限 batch 同时包含至少一个 Issue Fix 结果、两个不同的
+LoopX domain 结果、hit/miss/refute 三类结果，以及 edit/retire 两类 operator control，
+`reward_memory_dogfood_batch_v0` 才会进入 `ready_for_bounded_issue_fix_pilot`。这只是
+试用就绪声明，semantic uplift 与 production rollout 仍然为 false。
+
+Edit/retire control 同样保持克制：
+
+```bash
+loopx reward-memory operator-control \
+  --input reviewed-record.json --action retire \
+  --control-ref control:example:retire \
+  --reasoning-summary 'Current source truth supersedes this record.' \
+  --format json
+```
+
+Edit checkpoint 必须匹配 corpus owner；retire checkpoint 必须匹配
+`maintenance.retirement_authority`；两者还必须绑定到准确的 corpus、project 与 action。
+Edit 生成一个引用旧 active record 的 replacement
+candidate，retire 生成 retired decision。两个命令都不写 provider state；真正的 write 与
+精确 readback 仍由声明的 corpus owner 执行，因此 operator control 不会悄悄扩大成
+publish、production 或跨项目 authority。

--- a/examples/reward-memory-dogfood-smoke.py
+++ b/examples/reward-memory-dogfood-smoke.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+
+from loopx.capabilities.reward_memory import (  # noqa: E402
+    RewardMemoryRecallItem,
+    RewardMemoryRecallSession,
+    apply_reward_memory_recall,
+    build_reward_memory_candidate,
+    build_reward_memory_dogfood_batch,
+    build_reward_memory_dogfood_receipt,
+    build_reward_memory_operator_control,
+    review_reward_memory_candidate,
+    run_reward_memory_evaluation,
+)
+
+
+def corpus() -> dict[str, object]:
+    return {
+        "corpus_id": "dogfood_preferences",
+        "class_id": "soft_preference",
+        "provider_id": "configured_memory_provider",
+        "owner_ref": "owner:dogfood",
+        "source_of_truth": "reviewed_feedback",
+        "read_authority": "module_scoped",
+        "write_authority": "provider_managed",
+        "scope": {
+            "workspace_ref": "workspace:dogfood",
+            "project_ref": "project:dogfood",
+            "surface_ids": ["module.owned_surface"],
+        },
+        "freshness": {"mode": "source_truth_bound"},
+        "lifecycle": {"state": "active", "supersedes": []},
+        "retrieval": {
+            "index_required": True,
+            "readback_required": True,
+            "application_receipt_required": True,
+        },
+        "maintenance": {
+            "writeback_triggers": ["explicit_feedback"],
+            "closure_policy": "owner_write_then_exact_readback",
+            "retirement_authority": "operator:retirement",
+        },
+        "privacy": {"visibility": "private", "raw_content_in_registry": False},
+    }
+
+
+def active_review() -> dict[str, object]:
+    candidate = build_reward_memory_candidate(
+        {
+            "target_class": "soft_preference",
+            "content_summary": (
+                "Prefer a focused change unless current evidence justifies a broader one."
+            ),
+            "source": {
+                "source_kind": "reviewed_feedback",
+                "source_ref": "fixture:dogfood:reviewed",
+                "actor_ref": "operator:fixture",
+                "actor_role": "verified_project_owner_or_operator",
+            },
+            "scope": {
+                "workspace_ref": "workspace:dogfood",
+                "project_ref": "project:dogfood",
+                "surface_ids": ["module.owned_surface"],
+            },
+            "reasoning": {
+                "summary": "The preference is reusable inside one owned module.",
+                "confidence": "high",
+            },
+            "guard_context": {
+                "source_freshness": "current",
+                "conflict_state": "clear",
+                "current_artifact_verified": True,
+            },
+            "requested_action_scopes": [],
+            "raw_content_captured": False,
+        }
+    )
+    return review_reward_memory_candidate(
+        candidate,
+        {
+            "decision": "accept",
+            "reviewer_ref": "operator:fixture",
+            "review_ref": "review:dogfood:accept",
+            "reasoning_summary": "The scoped compact preference is accepted.",
+        },
+    )
+
+
+def session(*, surface_id: str, status: str) -> RewardMemoryRecallSession:
+    items: tuple[RewardMemoryRecallItem, ...] = ()
+    if status == "completed":
+        items = (
+            RewardMemoryRecallItem(
+                memory_ref=f"memory:{surface_id}",
+                candidate_ref=f"candidate:{surface_id}",
+                target_class="soft_preference",
+                content_summary="Transient fixture summary.",
+            ),
+        )
+    return RewardMemoryRecallSession(
+        public_packet={
+            "corpus_id": "dogfood_preferences",
+            "surface_id": surface_id,
+            "mode": "function_boundary",
+            "status": status,
+            "result_readback_verified": status == "completed",
+        },
+        items=items,
+    )
+
+
+def application_receipts() -> list[dict[str, object]]:
+    hit_session = session(surface_id="issue_fix.patch_planning", status="completed")
+    hit = apply_reward_memory_recall(
+        {"candidate": "broad_change"},
+        hit_session,
+        application_id="application:issue-fix",
+        artifact_ref="artifact:issue-fix",
+        apply_memory=lambda base, items: {
+            "outcome": "applied",
+            "output": {"candidate": "focused_change"},
+            "memory_refs": [items[0].memory_ref],
+            "reasoning_summary": "Current code supports the narrower candidate.",
+            "current_artifact_verified": True,
+        },
+    )["receipt"]
+
+    miss = apply_reward_memory_recall(
+        {"layout": "semantic_lanes"},
+        session(surface_id="explore_graph.layout", status="empty"),
+        application_id="application:explore",
+        artifact_ref="artifact:explore",
+    )["receipt"]
+
+    refute_session = session(
+        surface_id="runtime_projection.routing", status="completed"
+    )
+    refute = apply_reward_memory_recall(
+        {"route": "external_runtime"},
+        refute_session,
+        application_id="application:runtime-route",
+        artifact_ref="artifact:runtime-route",
+        apply_memory=lambda base, items: {
+            "outcome": "refuted",
+            "output": base,
+            "memory_refs": [items[0].memory_ref],
+            "reasoning_summary": "Current registry evidence refutes the old route.",
+            "current_artifact_verified": True,
+        },
+    )["receipt"]
+    return [hit, miss, refute]
+
+
+def observation(
+    receipt: dict[str, object],
+    *,
+    family: str,
+    domain_id: str,
+    latency_ms: int,
+    interventions: int,
+) -> dict[str, object]:
+    return {
+        "raw_content_captured": False,
+        "domain_family": family,
+        "domain_id": domain_id,
+        "application_receipt": receipt,
+        "module_outcome": {
+            "artifact_ref": receipt["artifact_ref"],
+            "outcome_verified": True,
+            "summary": f"Verified bounded outcome for {domain_id}.",
+        },
+        "cost": {
+            "latency_ms": latency_ms,
+            "model_tokens": 0,
+            "provider_call_count": int(bool(receipt["result_readback_verified"])),
+        },
+        "intervention": {
+            "count": interventions,
+            "summary": (
+                "One operator correction was required." if interventions else None
+            ),
+        },
+        "bot_feedback": {
+            "captured": family == "issue_fix",
+            "summary": (
+                "The bot can consume the compact verified receipt."
+                if family == "issue_fix"
+                else None
+            ),
+        },
+    }
+
+
+def main() -> None:
+    receipts = application_receipts()
+    observations = [
+        observation(
+            receipts[0],
+            family="issue_fix",
+            domain_id="issue_fix.patch_planning",
+            latency_ms=8,
+            interventions=0,
+        ),
+        observation(
+            receipts[1],
+            family="loopx",
+            domain_id="loopx.explore_graph",
+            latency_ms=2,
+            interventions=0,
+        ),
+        observation(
+            receipts[2],
+            family="loopx",
+            domain_id="loopx.runtime_projection",
+            latency_ms=5,
+            interventions=1,
+        ),
+    ]
+    dogfood = [build_reward_memory_dogfood_receipt(item) for item in observations]
+
+    reviewed = active_review()
+    edited = build_reward_memory_operator_control(
+        reviewed,
+        corpus(),
+        action="edit",
+        operator_checkpoint={
+            "verified": True,
+            "operator_ref": "operator:fixture",
+            "authority_ref": "owner:dogfood",
+            "source_ref": "authority:fixture:edit",
+            "corpus_id": "dogfood_preferences",
+            "project_ref": "project:dogfood",
+            "action": "edit",
+        },
+        control_ref="control:dogfood:edit",
+        reasoning_summary="The owner narrowed the preference.",
+        edited_content_summary="Prefer a focused change after current-artifact verification.",
+    )
+    assert edited["decision"]["status"] == "review_ready", edited
+    retired = build_reward_memory_operator_control(
+        reviewed,
+        corpus(),
+        action="retire",
+        operator_checkpoint={
+            "verified": True,
+            "operator_ref": "operator:fixture",
+            "authority_ref": "operator:retirement",
+            "source_ref": "authority:fixture:retire",
+            "corpus_id": "dogfood_preferences",
+            "project_ref": "project:dogfood",
+            "action": "retire",
+        },
+        control_ref="control:dogfood:retire",
+        reasoning_summary="Current evidence supersedes the preference.",
+    )
+    assert retired["decision"]["status"] == "retired", retired
+    try:
+        build_reward_memory_operator_control(
+            reviewed,
+            corpus(),
+            action="edit",
+            operator_checkpoint={
+                "verified": True,
+                "operator_ref": "operator:fixture",
+                "authority_ref": "owner:dogfood",
+                "source_ref": "authority:fixture:wrong-project",
+                "corpus_id": "dogfood_preferences",
+                "project_ref": "project:other",
+                "action": "edit",
+            },
+            control_ref="control:dogfood:wrong-project",
+            reasoning_summary="This checkpoint belongs to another project.",
+            edited_content_summary="This edit must not be accepted.",
+        )
+    except ValueError as exc:
+        assert "project does not match" in str(exc), exc
+    else:
+        raise AssertionError("cross-project operator authority was accepted")
+
+    packet = build_reward_memory_dogfood_batch(
+        dogfood,
+        [edited["receipt"], retired["receipt"]],
+        evaluation=run_reward_memory_evaluation(),
+    )
+    assert packet["status"] == "ready_for_bounded_issue_fix_pilot", packet
+    assert packet["metrics"]["hit_count"] == 1, packet
+    assert packet["metrics"]["miss_count"] == 1, packet
+    assert packet["metrics"]["refute_count"] == 1, packet
+    assert packet["metrics"]["loopx_domain_count"] == 2, packet
+    assert packet["metrics"]["intervention_count"] == 1, packet
+    assert packet["boundaries"]["production_rollout_allowed"] is False, packet
+    assert packet["boundaries"]["operator_write_performed"] is False, packet
+
+    held = build_reward_memory_dogfood_batch(
+        dogfood[:1],
+        [edited["receipt"]],
+        evaluation=run_reward_memory_evaluation(),
+    )
+    assert held["status"] == "hold", held
+    assert "two_loopx_domains_required" in held["reason_codes"], held
+    assert "operator_control_missing:retire" in held["reason_codes"], held
+
+    with tempfile.TemporaryDirectory() as directory:
+        dogfood_input = Path(directory) / "dogfood.json"
+        dogfood_input.write_text(
+            json.dumps(
+                {
+                    "observations": observations,
+                    "operator_controls": [
+                        edited["receipt"],
+                        retired["receipt"],
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        completed = subprocess.run(
+            [
+                str(REPO_ROOT / "scripts" / "loopx"),
+                "reward-memory",
+                "dogfood-evaluate",
+                "--input",
+                str(dogfood_input),
+                "--format",
+                "json",
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        cli_packet = json.loads(completed.stdout)
+        assert cli_packet["status"] == "ready_for_bounded_issue_fix_pilot"
+
+        control_input = Path(directory) / "control.json"
+        control_input.write_text(
+            json.dumps(
+                {
+                    "reviewed_record": reviewed,
+                    "corpus": corpus(),
+                    "operator_checkpoint": {
+                        "verified": True,
+                        "operator_ref": "operator:fixture",
+                        "authority_ref": "owner:dogfood",
+                        "source_ref": "authority:fixture:edit",
+                        "corpus_id": "dogfood_preferences",
+                        "project_ref": "project:dogfood",
+                        "action": "edit",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        completed = subprocess.run(
+            [
+                str(REPO_ROOT / "scripts" / "loopx"),
+                "reward-memory",
+                "operator-control",
+                "--input",
+                str(control_input),
+                "--action",
+                "edit",
+                "--control-ref",
+                "control:cli:edit",
+                "--reasoning-summary",
+                "The owner narrowed the preference.",
+                "--edited-content-summary",
+                "Prefer a focused current-artifact-verified change.",
+                "--format",
+                "json",
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        control_packet = json.loads(completed.stdout)
+        assert control_packet["status"] == "control_ready"
+    print("reward-memory-dogfood-smoke: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -329,6 +329,16 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "purpose": "Run the Stage-4 provider-neutral core-contract suite and compact release gate over the real recall/application seam.",
                 "write_boundary": "bounded local fixture reads only; no provider, memory, repository, state, model API, or external write",
             },
+            {
+                "command": "loopx reward-memory dogfood-evaluate --input <compact-observations.json> --format json",
+                "purpose": "Bind verified Issue Fix and LoopX module outcomes to compact hit, miss, refute, cost, intervention, and bot-feedback receipts after the Stage-4 gate.",
+                "write_boundary": "reads compact receipts only; no raw provider content, memory write, operator write, automatic recall, or external write",
+            },
+            {
+                "command": "loopx reward-memory operator-control --input <reviewed-record.json> --action edit --control-ref <ref> --reasoning-summary <summary> --edited-content-summary <summary> --format json",
+                "purpose": "Prepare an authority-matched edit or retirement decision for a reviewed active record.",
+                "write_boundary": "returns a control decision and next-step receipt only; the declared corpus owner must perform and exactly read back any provider write",
+            },
         ],
         "implemented_protocols": [
             {
@@ -406,6 +416,21 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "module": "loopx.capabilities.reward_memory.evaluation",
                 "doc": "docs/reference/protocols/reward-memory-architecture-v0.md",
             },
+            {
+                "schema_version": "reward_memory_dogfood_receipt_v0",
+                "module": "loopx.capabilities.reward_memory.dogfood",
+                "doc": "docs/reference/protocols/reward-memory-architecture-v0.md",
+            },
+            {
+                "schema_version": "reward_memory_dogfood_batch_v0",
+                "module": "loopx.capabilities.reward_memory.dogfood",
+                "doc": "docs/reference/protocols/reward-memory-architecture-v0.md",
+            },
+            {
+                "schema_version": "reward_memory_operator_control_v0",
+                "module": "loopx.capabilities.reward_memory.dogfood",
+                "doc": "docs/reference/protocols/reward-memory-architecture-v0.md",
+            },
         ],
         "smokes": [
             "python3 examples/reward-memory-architecture-smoke.py",
@@ -413,6 +438,7 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
             "python3 examples/reward-memory-candidate-review-smoke.py",
             "python3 examples/reward-memory-recall-application-smoke.py",
             "python3 examples/reward-memory-evaluation-smoke.py",
+            "python3 examples/reward-memory-dogfood-smoke.py",
         ],
         "docs": [
             "docs/reference/protocols/reward-memory-architecture-v0.md",
@@ -435,11 +461,13 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
             "Provider and application failures preserve the base output, emit compact receipts or setup hints, and never become user gates automatically.",
             "Private corpus summaries stay transient in-process; public packets retain opaque references and compact lineage only.",
             "Stage 4 proves bounded core-contract invariants only; its fixture pass does not claim semantic uplift or authorize production rollout.",
+            "Stage 5 receipts are derived from Stage-3 application receipts and verified module outcomes; hit or refute requires exact provider readback plus current-artifact verification.",
+            "Stage 5 trial readiness requires Issue Fix, two distinct LoopX domains, hit/miss/refute coverage, and authority-matched edit/retire controls; it still does not authorize production rollout.",
         ],
         "next_real_step": (
-            "Run bounded Stage-5 dogfood through the declared corpus owner, verify "
-            "exact provider readback, and compare real Issue Fix planning outcomes "
-            "without widening the Stage-4 contract-only claim."
+            "Feed one corpus-owner-approved, exactly read-back record through the "
+            "bounded OpenViking Issue Fix pilot and write back compact bot feedback "
+            "without widening the Stage-5 trial-only claim."
         ),
     },
     {

--- a/loopx/capabilities/reward_memory/__init__.py
+++ b/loopx/capabilities/reward_memory/__init__.py
@@ -24,6 +24,11 @@ from .health import (
     reward_memory_health_case,
 )
 from .evaluation import run_reward_memory_evaluation
+from .dogfood import (
+    build_reward_memory_dogfood_batch,
+    build_reward_memory_dogfood_receipt,
+    build_reward_memory_operator_control,
+)
 from .registry import (
     build_reward_memory_corpus_registry_packet,
     normalize_reward_memory_corpus,
@@ -40,6 +45,9 @@ __all__ = [
     "build_reward_memory_candidate",
     "build_reward_memory_corpus_health_packet",
     "build_reward_memory_corpus_registry_packet",
+    "build_reward_memory_dogfood_batch",
+    "build_reward_memory_dogfood_receipt",
+    "build_reward_memory_operator_control",
     "build_reward_memory_route_packet",
     "build_reward_memory_recall_request",
     "execute_reward_memory_recall",

--- a/loopx/capabilities/reward_memory/cli.py
+++ b/loopx/capabilities/reward_memory/cli.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Callable
+import json
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
 
 from .architecture import (
     build_reward_memory_architecture_packet,
@@ -17,6 +19,11 @@ from .health import (
     reward_memory_health_case,
 )
 from .evaluation import run_reward_memory_evaluation
+from .dogfood import (
+    build_reward_memory_dogfood_batch,
+    build_reward_memory_dogfood_receipt,
+    build_reward_memory_operator_control,
+)
 from .registry import build_reward_memory_corpus_registry_packet
 
 
@@ -40,6 +47,17 @@ def _render(payload: dict[str, object]) -> str:
     if isinstance(reasons, list):
         lines.append("- reason_codes: `" + ", ".join(map(str, reasons)) + "`")
     return "\n".join(lines) + "\n"
+
+
+def _load_json_object(path_value: str) -> dict[str, object]:
+    path = Path(path_value).expanduser()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(f"cannot read input JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("input JSON must contain one object")
+    return payload
 
 
 def register_reward_memory_commands(
@@ -109,6 +127,31 @@ def register_reward_memory_commands(
         help="Run the bounded Stage-4 core-contract suite and release gate.",
     )
     add_subcommand_format(evaluate)
+
+    dogfood = sub.add_parser(
+        "dogfood-evaluate",
+        help="Evaluate compact Stage-5 module outcomes after the Stage-4 gate.",
+    )
+    add_subcommand_format(dogfood)
+    dogfood.add_argument(
+        "--input",
+        required=True,
+        help=(
+            "JSON object containing observations and operator_controls; no raw "
+            "provider content is accepted."
+        ),
+    )
+
+    control = sub.add_parser(
+        "operator-control",
+        help="Prepare an authorized Stage-5 edit or retire decision without writing.",
+    )
+    add_subcommand_format(control)
+    control.add_argument("--input", required=True)
+    control.add_argument("--action", choices=["edit", "retire"], required=True)
+    control.add_argument("--control-ref", required=True)
+    control.add_argument("--reasoning-summary", required=True)
+    control.add_argument("--edited-content-summary")
 
     route = sub.add_parser(
         "route-check",
@@ -187,6 +230,45 @@ def handle_reward_memory_command(
             payload["adapter"] = adapter
         elif args.reward_memory_command == "evaluate":
             payload = run_reward_memory_evaluation()
+        elif args.reward_memory_command == "dogfood-evaluate":
+            source = _load_json_object(args.input)
+            observations = source.get("observations")
+            controls = source.get("operator_controls")
+            if not isinstance(observations, Sequence) or isinstance(
+                observations, (str, bytes)
+            ):
+                raise ValueError("observations must be a list")
+            if not isinstance(controls, Sequence) or isinstance(controls, (str, bytes)):
+                raise ValueError("operator_controls must be a list")
+            if any(not isinstance(item, Mapping) for item in observations):
+                raise ValueError("each observation must be an object")
+            if any(not isinstance(item, Mapping) for item in controls):
+                raise ValueError("each operator control must be an object")
+            payload = build_reward_memory_dogfood_batch(
+                [build_reward_memory_dogfood_receipt(item) for item in observations],
+                [dict(item) for item in controls],
+                evaluation=run_reward_memory_evaluation(),
+            )
+        elif args.reward_memory_command == "operator-control":
+            source = _load_json_object(args.input)
+            reviewed_record = source.get("reviewed_record")
+            corpus = source.get("corpus")
+            checkpoint = source.get("operator_checkpoint")
+            if not isinstance(reviewed_record, Mapping):
+                raise ValueError("reviewed_record must be an object")
+            if not isinstance(corpus, Mapping):
+                raise ValueError("corpus must be an object")
+            if not isinstance(checkpoint, Mapping):
+                raise ValueError("operator_checkpoint must be an object")
+            payload = build_reward_memory_operator_control(
+                reviewed_record,
+                corpus,
+                action=args.action,
+                operator_checkpoint=checkpoint,
+                control_ref=args.control_ref,
+                reasoning_summary=args.reasoning_summary,
+                edited_content_summary=args.edited_content_summary,
+            )
         else:
             observation = (
                 pr_3237_regression_observation()
@@ -223,6 +305,8 @@ def handle_reward_memory_command(
         print_payload(payload, output_format(args), _render)
         return 2
     print_payload(payload, output_format(args), _render)
-    if args.reward_memory_command == "evaluate" and payload.get("ok") is not True:
+    if args.reward_memory_command in {"evaluate", "dogfood-evaluate"} and (
+        payload.get("ok") is not True
+    ):
         return 2
     return 0

--- a/loopx/capabilities/reward_memory/dogfood.py
+++ b/loopx/capabilities/reward_memory/dogfood.py
@@ -1,0 +1,574 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from typing import Any
+
+from ...control_plane.runtime.public_safety import public_safe_compact_text
+from .application import REWARD_MEMORY_APPLICATION_RECEIPT_SCHEMA_VERSION
+from .candidate_review import (
+    REWARD_MEMORY_REVIEW_SCHEMA_VERSION,
+    review_reward_memory_candidate,
+)
+from .evaluation import REWARD_MEMORY_EVALUATION_SCHEMA_VERSION
+from .registry import normalize_reward_memory_corpus
+
+
+REWARD_MEMORY_DOGFOOD_RECEIPT_SCHEMA_VERSION = "reward_memory_dogfood_receipt_v0"
+REWARD_MEMORY_DOGFOOD_BATCH_SCHEMA_VERSION = "reward_memory_dogfood_batch_v0"
+REWARD_MEMORY_OPERATOR_CONTROL_SCHEMA_VERSION = "reward_memory_operator_control_v0"
+
+DOGFOOD_OUTCOMES = {"hit", "miss", "refute"}
+DOMAIN_FAMILIES = {"issue_fix", "loopx"}
+OPERATOR_ACTIONS = {"edit", "retire"}
+TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/#-]{0,199}$")
+MAX_RECEIPTS = 24
+MAX_OPERATOR_CONTROLS = 8
+
+
+def _token(value: object, label: str) -> str:
+    result = str(value or "").strip()
+    if not TOKEN_RE.fullmatch(result):
+        raise ValueError(f"{label} must be a compact public-safe token")
+    return result
+
+
+def _compact(value: object, label: str, *, limit: int = 500) -> str:
+    result = public_safe_compact_text(value, limit=limit)
+    if not result:
+        raise ValueError(f"{label} must be compact and public-safe")
+    return result
+
+
+def _boolean(mapping: Mapping[str, Any], key: str) -> bool:
+    value = mapping.get(key)
+    if not isinstance(value, bool):
+        raise ValueError(f"{key} must be a boolean")
+    return value
+
+
+def _counter(mapping: Mapping[str, Any], key: str) -> int:
+    value = mapping.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{key} must be a non-negative integer")
+    return value
+
+
+def _digest(payload: Mapping[str, Any], *, prefix: str) -> str:
+    value = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    ).hexdigest()[:20]
+    return f"{prefix}:{value}"
+
+
+def _dogfood_outcome(application_outcome: object) -> str:
+    outcome = str(application_outcome or "").strip()
+    if outcome == "applied":
+        return "hit"
+    if outcome == "refuted":
+        return "refute"
+    if outcome in {
+        "ignored",
+        "failed",
+        "not_available",
+        "available_not_applied",
+    }:
+        return "miss"
+    raise ValueError("application receipt outcome is invalid")
+
+
+def build_reward_memory_dogfood_receipt(
+    observation: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Bind one real module outcome to an existing compact application receipt."""
+
+    if _boolean(observation, "raw_content_captured"):
+        raise ValueError("dogfood observations must not contain raw content")
+    family = str(observation.get("domain_family") or "").strip()
+    if family not in DOMAIN_FAMILIES:
+        raise ValueError("domain_family must be issue_fix or loopx")
+    domain_id = _token(observation.get("domain_id"), "domain_id")
+    if family == "issue_fix" and not domain_id.startswith("issue_fix."):
+        raise ValueError("issue_fix domain_id must use the issue_fix namespace")
+    if family == "loopx" and not domain_id.startswith("loopx."):
+        raise ValueError("loopx domain_id must use the loopx namespace")
+
+    application = observation.get("application_receipt")
+    if not isinstance(application, Mapping):
+        raise ValueError("application_receipt must be an object")
+    if (
+        application.get("schema_version")
+        != REWARD_MEMORY_APPLICATION_RECEIPT_SCHEMA_VERSION
+    ):
+        raise ValueError("application_receipt must use the Stage-3 receipt schema")
+    application_id = _token(application.get("application_id"), "application_id")
+    artifact_ref = _token(application.get("artifact_ref"), "artifact_ref")
+    surface_id = _token(application.get("surface_id"), "surface_id")
+    outcome = _dogfood_outcome(application.get("outcome"))
+    readback_verified = _boolean(application, "result_readback_verified")
+    current_verified = _boolean(application, "current_artifact_verified")
+    if _boolean(application, "grants_new_action_authority"):
+        raise ValueError("application receipt cannot grant action authority")
+    if _boolean(application, "raw_content_captured"):
+        raise ValueError("application receipt cannot contain raw content")
+    if _boolean(application, "external_writes_performed"):
+        raise ValueError("application receipt cannot perform external writes")
+    if outcome in {"hit", "refute"} and not readback_verified:
+        raise ValueError("hit or refute requires exact provider result readback")
+    if outcome in {"hit", "refute"} and not current_verified:
+        raise ValueError("hit or refute requires current-artifact verification")
+    memory_ref_digests = application.get("memory_ref_digests")
+    if not isinstance(memory_ref_digests, Sequence) or isinstance(
+        memory_ref_digests, (str, bytes)
+    ):
+        raise ValueError("memory_ref_digests must be a list")
+    digests = sorted(
+        {_token(value, "memory_ref_digest") for value in memory_ref_digests}
+    )
+    if len(digests) != len(memory_ref_digests):
+        raise ValueError("memory_ref_digests must not contain duplicates")
+    if outcome in {"hit", "refute"} and not digests:
+        raise ValueError("hit or refute requires attributed memory references")
+
+    module_outcome = observation.get("module_outcome")
+    if not isinstance(module_outcome, Mapping):
+        raise ValueError("module_outcome must be an object")
+    if (
+        _token(module_outcome.get("artifact_ref"), "module_outcome.artifact_ref")
+        != artifact_ref
+    ):
+        raise ValueError("module outcome and application artifact_ref must match")
+    outcome_verified = _boolean(module_outcome, "outcome_verified")
+    if not outcome_verified:
+        raise ValueError("dogfood requires a verified real module outcome")
+    outcome_summary = _compact(
+        module_outcome.get("summary"), "module_outcome.summary", limit=360
+    )
+
+    cost = observation.get("cost")
+    if not isinstance(cost, Mapping):
+        raise ValueError("cost must be an object")
+    compact_cost = {
+        key: _counter(cost, key)
+        for key in ("latency_ms", "model_tokens", "provider_call_count")
+    }
+    intervention = observation.get("intervention")
+    if not isinstance(intervention, Mapping):
+        raise ValueError("intervention must be an object")
+    intervention_count = _counter(intervention, "count")
+    intervention_summary = None
+    if intervention_count:
+        intervention_summary = _compact(
+            intervention.get("summary"), "intervention.summary", limit=240
+        )
+
+    bot_feedback = observation.get("bot_feedback") or {
+        "captured": False,
+        "summary": None,
+    }
+    if not isinstance(bot_feedback, Mapping):
+        raise ValueError("bot_feedback must be an object")
+    feedback_captured = _boolean(bot_feedback, "captured")
+    feedback_summary = None
+    if feedback_captured:
+        feedback_summary = _compact(
+            bot_feedback.get("summary"), "bot_feedback.summary", limit=240
+        )
+
+    identity = {
+        "domain_family": family,
+        "domain_id": domain_id,
+        "application_id": application_id,
+        "artifact_ref": artifact_ref,
+        "surface_id": surface_id,
+        "outcome": outcome,
+    }
+    return {
+        "ok": True,
+        "schema_version": REWARD_MEMORY_DOGFOOD_RECEIPT_SCHEMA_VERSION,
+        "receipt_id": _digest(identity, prefix="dogfood"),
+        "domain_family": family,
+        "domain_id": domain_id,
+        "application_id": application_id,
+        "artifact_ref": artifact_ref,
+        "surface_id": surface_id,
+        "outcome": outcome,
+        "module_outcome": {
+            "verified": True,
+            "summary": outcome_summary,
+        },
+        "memory_ref_digests": digests,
+        "verification": {
+            "result_readback_verified": readback_verified,
+            "current_artifact_verified": current_verified,
+        },
+        "cost": compact_cost,
+        "intervention": {
+            "count": intervention_count,
+            "summary": intervention_summary,
+        },
+        "bot_feedback": {
+            "captured": feedback_captured,
+            "summary": feedback_summary,
+        },
+        "grants_new_action_authority": False,
+        "raw_content_captured": False,
+        "external_writes_performed": False,
+    }
+
+
+def _scope_matches(record: Mapping[str, Any], corpus: Mapping[str, Any]) -> bool:
+    scope = record.get("scope")
+    expected = corpus["scope"]
+    if not isinstance(scope, Mapping):
+        return False
+    base_matches = (
+        scope.get("workspace_ref") == expected["workspace_ref"]
+        and scope.get("project_ref") == expected["project_ref"]
+        and set(scope.get("surface_ids") or []).issubset(set(expected["surface_ids"]))
+    )
+    if not base_matches:
+        return False
+    if corpus["freshness"]["mode"] == "revision_bound":
+        return scope.get("revision_ref") == corpus["freshness"]["source_revision"]
+    return True
+
+
+def build_reward_memory_operator_control(
+    reviewed_record: Mapping[str, Any],
+    corpus: Mapping[str, Any],
+    *,
+    action: str,
+    operator_checkpoint: Mapping[str, Any],
+    control_ref: str,
+    reasoning_summary: str,
+    edited_content_summary: str | None = None,
+) -> dict[str, Any]:
+    """Prepare an authorized edit or retirement without performing a provider write."""
+
+    normalized = normalize_reward_memory_corpus(corpus)
+    if action not in OPERATOR_ACTIONS:
+        raise ValueError("operator action must be edit or retire")
+    if normalized["lifecycle"]["state"] != "active":
+        raise ValueError("operator control corpus must be active")
+    if normalized["write_authority"] == "read_only":
+        raise ValueError("operator control corpus is read-only")
+    if reviewed_record.get("schema_version") != REWARD_MEMORY_REVIEW_SCHEMA_VERSION:
+        raise ValueError("operator control requires an active reviewed record")
+    if (
+        reviewed_record.get("status") != "active"
+        or reviewed_record.get("guard_passed") is not True
+    ):
+        raise ValueError("operator control requires a guard-passed active record")
+    record = reviewed_record.get("record")
+    if not isinstance(record, Mapping):
+        raise ValueError("reviewed record is incomplete")
+    lifecycle = record.get("lifecycle")
+    if not isinstance(lifecycle, Mapping) or lifecycle.get("state") != "active":
+        raise ValueError("operator control target must be active")
+    if record.get("target_class") != normalized["class_id"]:
+        raise ValueError("operator control corpus class does not match")
+    if not _scope_matches(record, normalized):
+        raise ValueError("operator control corpus scope does not match")
+    if not isinstance(operator_checkpoint, Mapping):
+        raise ValueError("operator_checkpoint must be an object")
+    if not _boolean(operator_checkpoint, "verified"):
+        raise ValueError("operator authority checkpoint must be verified")
+    operator_ref = _token(
+        operator_checkpoint.get("operator_ref"), "operator_checkpoint.operator_ref"
+    )
+    authority_ref = _token(
+        operator_checkpoint.get("authority_ref"), "operator_checkpoint.authority_ref"
+    )
+    source_ref = _token(
+        operator_checkpoint.get("source_ref"), "operator_checkpoint.source_ref"
+    )
+    checkpoint_corpus_id = _token(
+        operator_checkpoint.get("corpus_id"), "operator_checkpoint.corpus_id"
+    )
+    checkpoint_project_ref = _token(
+        operator_checkpoint.get("project_ref"), "operator_checkpoint.project_ref"
+    )
+    checkpoint_action = str(operator_checkpoint.get("action") or "").strip()
+    if checkpoint_corpus_id != normalized["corpus_id"]:
+        raise ValueError("operator authority corpus does not match")
+    if checkpoint_project_ref != normalized["scope"]["project_ref"]:
+        raise ValueError("operator authority project does not match")
+    if checkpoint_action != action:
+        raise ValueError("operator authority action does not match")
+    expected_authority = (
+        normalized["owner_ref"]
+        if action == "edit"
+        else normalized["maintenance"]["retirement_authority"]
+    )
+    if authority_ref != expected_authority:
+        raise ValueError("operator authority does not match the corpus declaration")
+
+    target = deepcopy(dict(reviewed_record))
+    if action == "edit":
+        target_record = target["record"]
+        old_ref = _token(target_record.get("candidate_ref"), "candidate_ref")
+        target_record["lifecycle"] = {
+            "state": "candidate",
+            "supersedes_refs": [old_ref],
+        }
+    review = {
+        "decision": action,
+        "reviewer_ref": operator_ref,
+        "review_ref": _token(control_ref, "control_ref"),
+        "reasoning_summary": _compact(
+            reasoning_summary, "reasoning_summary", limit=360
+        ),
+    }
+    if action == "edit":
+        review["edited_content_summary"] = _compact(
+            edited_content_summary, "edited_content_summary", limit=500
+        )
+    decision = review_reward_memory_candidate(target, review)
+    old_candidate_ref = _token(record.get("candidate_ref"), "candidate_ref")
+    new_candidate_ref = _token(
+        decision["record"].get("candidate_ref"), "decision.candidate_ref"
+    )
+    receipt = {
+        "schema_version": REWARD_MEMORY_OPERATOR_CONTROL_SCHEMA_VERSION,
+        "control_ref": review["review_ref"],
+        "action": action,
+        "effective_action": decision["effective_decision"],
+        "operator_ref": operator_ref,
+        "authority_ref": authority_ref,
+        "authority_source_ref": source_ref,
+        "authority_verified": True,
+        "corpus_id": normalized["corpus_id"],
+        "prior_candidate_ref_digest": hashlib.sha256(
+            old_candidate_ref.encode("utf-8")
+        ).hexdigest()[:16],
+        "result_candidate_ref_digest": hashlib.sha256(
+            new_candidate_ref.encode("utf-8")
+        ).hexdigest()[:16],
+        "result_state": decision["record"]["lifecycle"]["state"],
+        "reasoning_summary": review["reasoning_summary"],
+        "provider_write_performed": False,
+        "readback_verified": False,
+        "next_step": (
+            "review_replacement_then_owner_write_and_exact_readback"
+            if action == "edit"
+            else "owner_write_retirement_then_exact_readback"
+        ),
+        "grants_new_action_authority": False,
+        "raw_content_captured": False,
+        "external_writes_performed": False,
+    }
+    return {
+        "ok": True,
+        "schema_version": REWARD_MEMORY_OPERATOR_CONTROL_SCHEMA_VERSION,
+        "status": "control_ready",
+        "decision": decision,
+        "receipt": receipt,
+    }
+
+
+def _validate_control_receipt(raw: object) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise ValueError("operator control receipt must be an object")
+    if raw.get("schema_version") != REWARD_MEMORY_OPERATOR_CONTROL_SCHEMA_VERSION:
+        raise ValueError("operator control receipt schema is invalid")
+    action = str(raw.get("action") or "").strip()
+    if action not in OPERATOR_ACTIONS:
+        raise ValueError("operator control receipt action is invalid")
+    if _boolean(raw, "authority_verified") is not True:
+        raise ValueError("operator control authority must be verified")
+    if _boolean(raw, "provider_write_performed"):
+        raise ValueError("Stage-5 control receipt must precede provider write")
+    if str(raw.get("effective_action") or "").strip() != action:
+        raise ValueError("operator control effective action is invalid")
+    expected_state = "candidate" if action == "edit" else "retired"
+    if str(raw.get("result_state") or "").strip() != expected_state:
+        raise ValueError("operator control result state is invalid")
+    for key in (
+        "control_ref",
+        "operator_ref",
+        "authority_ref",
+        "authority_source_ref",
+        "corpus_id",
+        "prior_candidate_ref_digest",
+        "result_candidate_ref_digest",
+    ):
+        _token(raw.get(key), key)
+    if _boolean(raw, "grants_new_action_authority"):
+        raise ValueError("operator control cannot grant action authority")
+    if _boolean(raw, "raw_content_captured"):
+        raise ValueError("operator control cannot contain raw content")
+    if _boolean(raw, "external_writes_performed"):
+        raise ValueError("operator control cannot perform external writes")
+    return dict(raw)
+
+
+def _validate_dogfood_receipt(raw: object) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise ValueError("dogfood receipt must be an object")
+    if raw.get("schema_version") != REWARD_MEMORY_DOGFOOD_RECEIPT_SCHEMA_VERSION:
+        raise ValueError("dogfood receipt schema is invalid")
+    family = str(raw.get("domain_family") or "").strip()
+    domain_id = _token(raw.get("domain_id"), "domain_id")
+    if family not in DOMAIN_FAMILIES or not domain_id.startswith(f"{family}."):
+        raise ValueError("dogfood receipt domain is invalid")
+    outcome = str(raw.get("outcome") or "").strip()
+    if outcome not in DOGFOOD_OUTCOMES:
+        raise ValueError("dogfood receipt outcome is invalid")
+    for key in ("receipt_id", "application_id", "artifact_ref", "surface_id"):
+        _token(raw.get(key), key)
+    verification = raw.get("verification")
+    if not isinstance(verification, Mapping):
+        raise ValueError("dogfood receipt verification is invalid")
+    readback = _boolean(verification, "result_readback_verified")
+    current = _boolean(verification, "current_artifact_verified")
+    if outcome in {"hit", "refute"} and not (readback and current):
+        raise ValueError("hit or refute receipt is not exactly verified")
+    module_outcome = raw.get("module_outcome")
+    if not isinstance(module_outcome, Mapping) or not _boolean(
+        module_outcome, "verified"
+    ):
+        raise ValueError("dogfood module outcome is not verified")
+    _compact(module_outcome.get("summary"), "module_outcome.summary", limit=360)
+    cost = raw.get("cost")
+    if not isinstance(cost, Mapping):
+        raise ValueError("dogfood receipt cost is invalid")
+    for key in ("latency_ms", "model_tokens", "provider_call_count"):
+        _counter(cost, key)
+    intervention = raw.get("intervention")
+    if not isinstance(intervention, Mapping):
+        raise ValueError("dogfood receipt intervention is invalid")
+    _counter(intervention, "count")
+    feedback = raw.get("bot_feedback")
+    if not isinstance(feedback, Mapping):
+        raise ValueError("dogfood receipt bot_feedback is invalid")
+    _boolean(feedback, "captured")
+    if _boolean(raw, "grants_new_action_authority"):
+        raise ValueError("dogfood receipt cannot grant action authority")
+    if _boolean(raw, "raw_content_captured"):
+        raise ValueError("dogfood receipt cannot contain raw content")
+    if _boolean(raw, "external_writes_performed"):
+        raise ValueError("dogfood receipt cannot perform external writes")
+    return dict(raw)
+
+
+def build_reward_memory_dogfood_batch(
+    receipts: Sequence[Mapping[str, Any]],
+    operator_controls: Sequence[Mapping[str, Any]],
+    *,
+    evaluation: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Evaluate bounded Stage-5 evidence without claiming production uplift."""
+
+    if not isinstance(evaluation, Mapping):
+        raise ValueError("evaluation must be a Stage-4 evaluation packet")
+    if len(receipts) > MAX_RECEIPTS:
+        raise ValueError(f"dogfood batch accepts at most {MAX_RECEIPTS} receipts")
+    if len(operator_controls) > MAX_OPERATOR_CONTROLS:
+        raise ValueError(
+            f"dogfood batch accepts at most {MAX_OPERATOR_CONTROLS} controls"
+        )
+    normalized_receipts = [_validate_dogfood_receipt(item) for item in receipts]
+    controls = [_validate_control_receipt(item) for item in operator_controls]
+    receipt_ids = [item["receipt_id"] for item in normalized_receipts]
+    if len(receipt_ids) != len(set(receipt_ids)):
+        raise ValueError("dogfood batch must not double-count a receipt")
+    control_refs = [item["control_ref"] for item in controls]
+    if len(control_refs) != len(set(control_refs)):
+        raise ValueError("dogfood batch must not double-count an operator control")
+
+    gate_ready = (
+        evaluation.get("schema_version") == REWARD_MEMORY_EVALUATION_SCHEMA_VERSION
+        and evaluation.get("status") == "passed"
+        and isinstance(evaluation.get("release_gate"), Mapping)
+        and evaluation["release_gate"].get("status") == "ready_for_bounded_dogfood"
+    )
+    issue_fix_count = sum(
+        item["domain_family"] == "issue_fix" for item in normalized_receipts
+    )
+    loopx_domains = sorted(
+        {
+            item["domain_id"]
+            for item in normalized_receipts
+            if item["domain_family"] == "loopx"
+        }
+    )
+    outcomes = {item["outcome"] for item in normalized_receipts}
+    actions = {item["action"] for item in controls}
+    reason_codes: list[str] = []
+    if not gate_ready:
+        reason_codes.append("stage4_release_gate_not_ready")
+    if issue_fix_count < 1:
+        reason_codes.append("issue_fix_outcome_missing")
+    if len(loopx_domains) < 2:
+        reason_codes.append("two_loopx_domains_required")
+    for outcome in sorted(DOGFOOD_OUTCOMES - outcomes):
+        reason_codes.append(f"outcome_missing:{outcome}")
+    for action in sorted(OPERATOR_ACTIONS - actions):
+        reason_codes.append(f"operator_control_missing:{action}")
+
+    totals = {
+        "receipt_count": len(normalized_receipts),
+        "issue_fix_receipt_count": issue_fix_count,
+        "loopx_domain_count": len(loopx_domains),
+        "hit_count": sum(item["outcome"] == "hit" for item in normalized_receipts),
+        "miss_count": sum(item["outcome"] == "miss" for item in normalized_receipts),
+        "refute_count": sum(
+            item["outcome"] == "refute" for item in normalized_receipts
+        ),
+        "latency_ms": sum(item["cost"]["latency_ms"] for item in normalized_receipts),
+        "model_tokens": sum(
+            item["cost"]["model_tokens"] for item in normalized_receipts
+        ),
+        "provider_call_count": sum(
+            item["cost"]["provider_call_count"] for item in normalized_receipts
+        ),
+        "intervention_count": sum(
+            item["intervention"]["count"] for item in normalized_receipts
+        ),
+        "bot_feedback_count": sum(
+            item["bot_feedback"]["captured"] for item in normalized_receipts
+        ),
+    }
+    ready = not reason_codes
+    compact_receipts = [
+        {
+            key: item[key]
+            for key in (
+                "receipt_id",
+                "domain_family",
+                "domain_id",
+                "artifact_ref",
+                "surface_id",
+                "outcome",
+                "verification",
+                "cost",
+                "intervention",
+                "bot_feedback",
+            )
+        }
+        for item in normalized_receipts
+    ]
+    return {
+        "ok": ready,
+        "schema_version": REWARD_MEMORY_DOGFOOD_BATCH_SCHEMA_VERSION,
+        "status": "ready_for_bounded_issue_fix_pilot" if ready else "hold",
+        "reason_codes": reason_codes,
+        "stage4_gate_verified": gate_ready,
+        "loopx_domains": loopx_domains,
+        "outcomes": sorted(outcomes),
+        "operator_controls": sorted(actions),
+        "metrics": totals,
+        "receipts": compact_receipts,
+        "boundaries": {
+            "semantic_uplift_claim_allowed": False,
+            "production_rollout_allowed": False,
+            "automatic_recall_enabled": False,
+            "new_store_provider_or_scheduler_added": False,
+            "operator_write_performed": False,
+            "raw_content_captured": False,
+        },
+    }


### PR DESCRIPTION
## Summary
- add a provider-neutral Stage 5 dogfood receipt/batch contract over existing Stage 3 application receipts; derive hit/miss/refute and require exact readback plus current-artifact verification for hit/refute
- require one Issue Fix outcome, two distinct LoopX domains, all three outcome classes, and authority-matched edit/retire controls before reporting bounded pilot readiness
- expose `reward-memory dogfood-evaluate` and `operator-control`, with corpus/project/action-bound checkpoints and no provider or external writes
- document the trial-only boundary in English and Chinese and register the durable smoke/catalog surfaces

## Product / architecture judgment
Motivation: Stage 4 proved contract invariants but did not provide a compact way to compare real cross-module outcomes or exercise operator correction. This change adds only an evidence/control layer over the existing core; it does not add a store, scheduler, semantic router, automatic recall, or evaluator. The approach is reusable across module-owned surfaces while preserving caller/model reasoning. Trial readiness remains distinct from semantic uplift or production rollout.

Main compatibility risk is stricter validation of Stage 5 input packets. The new commands are additive and opt-in; existing Stage 0-4 commands and receipts are unchanged.

## Validation
- `scripts/loopx canary smoke-suite --suite full-public --module reward-memory --format json`: 6/6 passed
- `scripts/loopx canary premerge --from-git-diff --format json`: standard gate passed, 13/13 selected checks, 0 failures/warnings/holds
- `uvx ruff check loopx/capabilities/reward_memory examples/reward-memory-dogfood-smoke.py`: passed
- public/private boundary scan: 7 files clean

## Excluded
No private state, raw provider content, credentials, local paths, generated logs, provider writes, or production actions.