### PR TITLE
fix: serialize Explore Feishu sync

### DIFF
--- a/docs/capabilities/explore/README.md
+++ b/docs/capabilities/explore/README.md
@@ -749,6 +749,14 @@ missing roles, and returns a retryable configuration action; successful
 per-role diagnostics may still be inspected, but they cannot make the overall
 sink look current or advance its delivery checkpoint.
 
+Executable sync is singleflight per local board config across both the direct
+`feishu-sync` command and automatic material refresh. An overlapping process
+fails before row, visual, or checkpoint writes with `status=sync_busy`,
+`retryable=true`, and `external_write_performed=false`; dry-runs remain
+concurrent because they cannot mutate the sink. Retry after the active process
+exits instead of allowing two upsert scans to create duplicate Result IDs or
+overwrite each other's local checkpoint snapshot.
+
 The text `From Node` / `To Node` columns remain stable public ids for
 automation and review, while the linked-record columns are the Feishu-native
 graph substrate. A Base plugin, relationship-aware view, or Feishu dashboard

--- a/examples/explore-feishu-singleflight-smoke.py
+++ b/examples/explore-feishu-singleflight-smoke.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Prove overlapping Explore Feishu deliveries fail before remote writes."""
+
+from __future__ import annotations
+
+import argparse
+import multiprocessing
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx.cli_commands import explore as explore_cli  # noqa: E402
+from loopx.presentation.sinks.lark.explore_results import (  # noqa: E402
+    sync_issue_fix_explore_on_material_change,
+)
+from loopx.presentation.sinks.lark.explore_singleflight import (  # noqa: E402
+    explore_feishu_sync_singleflight,
+)
+
+
+def _child_attempt(config_path: str, queue: multiprocessing.Queue) -> None:
+    with explore_feishu_sync_singleflight(
+        config_path=Path(config_path), execute=True
+    ) as acquired:
+        queue.put(acquired)
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-explore-singleflight-") as tmp:
+        root = Path(tmp)
+        config_path = root / ".loopx" / "lark-explore.json"
+        registry_path = root / ".loopx" / "registry.json"
+        config_path.parent.mkdir(parents=True)
+        sentinel = '{"sentinel":"unchanged"}\n'
+        config_path.write_text(sentinel, encoding="utf-8")
+
+        runner_calls: list[list[str]] = []
+
+        def runner(args, cwd=None, timeout=None):
+            runner_calls.append(list(args))
+            raise AssertionError("busy sync must fail before connector calls")
+
+        with explore_feishu_sync_singleflight(
+            config_path=config_path, execute=True
+        ) as acquired:
+            assert acquired is True
+
+            ctx = multiprocessing.get_context("spawn")
+            queue = ctx.Queue()
+            child = ctx.Process(
+                target=_child_attempt,
+                args=(str(config_path), queue),
+            )
+            child.start()
+            child.join(timeout=10)
+            assert child.exitcode == 0, child.exitcode
+            assert queue.get(timeout=2) is False
+
+            with explore_feishu_sync_singleflight(
+                config_path=config_path, execute=False
+            ) as dry_run_acquired:
+                assert dry_run_acquired is True
+
+            material = sync_issue_fix_explore_on_material_change(
+                registry_path=registry_path,
+                goal_id="fixture-goal",
+                execute=True,
+                runner=runner,
+            )
+            assert material["status"] == "sync_busy", material
+            assert material["retryable"] is True, material
+            assert material["external_write_performed"] is False, material
+
+            captured: list[dict[str, object]] = []
+            original_load_registry = explore_cli.load_registry
+            original_resolve_runtime_root = explore_cli.resolve_runtime_root
+            explore_cli.load_registry = lambda _path: {}
+            explore_cli.resolve_runtime_root = lambda _registry, _arg: root
+            try:
+                result = explore_cli.handle_explore_command(
+                    argparse.Namespace(
+                        command="explore",
+                        explore_command="feishu-sync",
+                        config_path=str(config_path),
+                        execute=True,
+                    ),
+                    registry_path=registry_path,
+                    runtime_root_arg=None,
+                    print_payload=lambda payload, _fmt, _renderer: captured.append(
+                        payload
+                    ),
+                    output_format=lambda _args: "json",
+                )
+            finally:
+                explore_cli.load_registry = original_load_registry
+                explore_cli.resolve_runtime_root = original_resolve_runtime_root
+            assert result == 1, result
+            assert captured[0]["status"] == "sync_busy", captured
+            assert captured[0]["visual_sync"]["status"] == (
+                "not_attempted_sync_busy"
+            ), captured
+            assert config_path.read_text(encoding="utf-8") == sentinel
+            assert runner_calls == []
+
+        with explore_feishu_sync_singleflight(
+            config_path=config_path, execute=True
+        ) as acquired_after_release:
+            assert acquired_after_release is True
+
+    print("explore-feishu-singleflight-smoke: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/cli_commands/explore.py
+++ b/loopx/cli_commands/explore.py
@@ -48,6 +48,10 @@ from ..presentation.sinks.lark.explore_results import (
     sync_explore_visuals_to_lark,
     write_lark_explore_local_config,
 )
+from ..presentation.sinks.lark.explore_singleflight import (
+    explore_feishu_sync_busy_packet,
+    explore_feishu_sync_singleflight,
+)
 from ..presentation.explore_views import build_explore_presentation_bundle
 from ..presentation.sinks.lark.kanban import DEFAULT_CLI_BIN
 from ..history import load_registry
@@ -804,42 +808,58 @@ def handle_explore_command(
                 execute=bool(args.execute),
             )
         elif args.explore_command == "feishu-sync":
-            projection = _projection_for(args, runtime_root=runtime_root)
-            target = _target_config(args, config_path=config_path)
-            payload = sync_explore_results_to_lark(
-                target,
-                projection=projection,
+            with explore_feishu_sync_singleflight(
                 config_path=config_path,
-                sink_visibility=args.sink_visibility,
                 execute=bool(args.execute),
-            )
-            local = read_lark_explore_local_config(config_path)
-            visual_sinks = local.get("visual_sinks")
-            if isinstance(visual_sinks, dict) and visual_sinks:
-                visual_projection = _projection_for(
-                    args,
-                    runtime_root=runtime_root,
-                    finding_limit_override=-1,
-                )
-                payload["visual_sync"] = sync_explore_visuals_to_lark(
-                    target,
-                    projection=visual_projection,
-                    visual_sinks=visual_sinks,
-                    config_path=config_path,
-                    execute=bool(args.execute),
-                )
-            else:
-                payload["visual_sync"] = sync_explore_visual_to_lark(
-                    target,
-                    projection=projection,
-                    visual_sink=local.get("visual_sink")
-                    if isinstance(local.get("visual_sink"), dict)
-                    else None,
-                    config_path=config_path,
-                    semantic_digest=explore_visual_semantic_digest(projection),
-                    execute=bool(args.execute),
-                )
-            payload["ok"] = bool(payload.get("ok")) and bool(payload["visual_sync"].get("ok"))
+            ) as acquired:
+                if not acquired:
+                    payload = explore_feishu_sync_busy_packet()
+                    payload["visual_sync"] = {
+                        "ok": False,
+                        "status": "not_attempted_sync_busy",
+                        "execute": True,
+                        "published": False,
+                        "external_write_performed": False,
+                    }
+                else:
+                    projection = _projection_for(args, runtime_root=runtime_root)
+                    target = _target_config(args, config_path=config_path)
+                    payload = sync_explore_results_to_lark(
+                        target,
+                        projection=projection,
+                        config_path=config_path,
+                        sink_visibility=args.sink_visibility,
+                        execute=bool(args.execute),
+                    )
+                    local = read_lark_explore_local_config(config_path)
+                    visual_sinks = local.get("visual_sinks")
+                    if isinstance(visual_sinks, dict) and visual_sinks:
+                        visual_projection = _projection_for(
+                            args,
+                            runtime_root=runtime_root,
+                            finding_limit_override=-1,
+                        )
+                        payload["visual_sync"] = sync_explore_visuals_to_lark(
+                            target,
+                            projection=visual_projection,
+                            visual_sinks=visual_sinks,
+                            config_path=config_path,
+                            execute=bool(args.execute),
+                        )
+                    else:
+                        payload["visual_sync"] = sync_explore_visual_to_lark(
+                            target,
+                            projection=projection,
+                            visual_sink=local.get("visual_sink")
+                            if isinstance(local.get("visual_sink"), dict)
+                            else None,
+                            config_path=config_path,
+                            semantic_digest=explore_visual_semantic_digest(projection),
+                            execute=bool(args.execute),
+                        )
+                    payload["ok"] = bool(payload.get("ok")) and bool(
+                        payload["visual_sync"].get("ok")
+                    )
         elif args.explore_command == "feishu-card":
             projection = _projection_for(args, runtime_root=runtime_root)
             local = read_lark_explore_local_config(config_path)

--- a/loopx/file_lock.py
+++ b/loopx/file_lock.py
@@ -24,3 +24,30 @@ def exclusive_file_lock(path: Path) -> Iterator[Path]:
         finally:
             if fcntl is not None:
                 fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def try_exclusive_file_lock(path: Path) -> Iterator[Path | None]:
+    """Try to hold a sibling lock file without waiting for another process.
+
+    ``None`` means another process already owns the lock.  POSIX ``flock`` is
+    the repository's existing cross-process lock primitive; hosts without it
+    retain the historical single-process behavior instead of inventing a
+    stale lock-file protocol.
+    """
+
+    lock_path = path.with_name(f"{path.name}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a", encoding="utf-8") as lock_file:
+        if fcntl is None:  # pragma: no cover - non-POSIX compatibility path.
+            yield lock_path
+            return
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            yield None
+            return
+        try:
+            yield lock_path
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)

--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -58,6 +58,7 @@ from .kanban import (
     parse_lark_base_url,
 )
 from .explore_stage_document import ensure_stage_whiteboards
+from .explore_singleflight import singleflight_issue_fix_material_sync
 from .explore_visual_styles import (
     BOARD_STYLE_AUTO_FLOW,
     board_source_with_delivery_marker,
@@ -1644,6 +1645,7 @@ def sync_explore_results_to_lark(
     }
 
 
+@singleflight_issue_fix_material_sync(default_lark_explore_config_path)
 def sync_issue_fix_explore_on_material_change(
     *,
     registry_path: Path,
@@ -1918,8 +1920,6 @@ def sync_issue_fix_explore_on_material_change(
         "visual_sync": visual_sync,
         "config_path": str(config_path),
     }
-
-
 def build_explore_card_markdown(projection: Mapping[str, Any]) -> str:
     counts = projection.get("counts") if isinstance(projection.get("counts"), dict) else {}
     by_status = counts.get("nodes_by_status") if isinstance(counts.get("nodes_by_status"), dict) else {}

--- a/loopx/presentation/sinks/lark/explore_singleflight.py
+++ b/loopx/presentation/sinks/lark/explore_singleflight.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from functools import wraps
+from pathlib import Path
+from typing import Any
+
+from ....file_lock import try_exclusive_file_lock
+
+
+@contextmanager
+def explore_feishu_sync_singleflight(
+    *, config_path: Path, execute: bool
+) -> Iterator[bool]:
+    """Fail fast when another process is already delivering this board.
+
+    Dry-runs never contend because they perform no remote or config writes.
+    The lock target is local-private and only the acquired/busy state enters
+    public packets.
+    """
+
+    if not execute:
+        yield True
+        return
+    target = config_path.with_name(f"{config_path.name}.feishu-sync")
+    with try_exclusive_file_lock(target) as lock_path:
+        yield lock_path is not None
+
+
+def explore_feishu_sync_busy_packet(
+    *, schema_version: str = "loopx_lark_explore_sync_v0"
+) -> dict[str, Any]:
+    """Return the compact retryable contract for a rejected overlapping sync."""
+
+    return {
+        "ok": False,
+        "schema_version": schema_version,
+        "status": "sync_busy",
+        "execute": True,
+        "retryable": True,
+        "reason_code": "explore_feishu_sync_in_progress",
+        "external_write_performed": False,
+        "row_readback_verified": False,
+        "required_action": "retry after the active Explore Feishu sync exits",
+        "error": "another Explore Feishu sync is already active for this config",
+    }
+
+
+def singleflight_issue_fix_material_sync(
+    config_path_resolver: Callable[[Path | None], Path],
+) -> Callable[[Callable[..., dict[str, Any]]], Callable[..., dict[str, Any]]]:
+    """Serialize an issue-fix material sync across row, visual, and checkpoint writes."""
+
+    def decorate(
+        function: Callable[..., dict[str, Any]],
+    ) -> Callable[..., dict[str, Any]]:
+        @wraps(function)
+        def wrapped(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            registry_path = kwargs.get("registry_path")
+            if registry_path is None and args:
+                registry_path = args[0]
+            resolved_registry = (
+                Path(registry_path) if registry_path is not None else None
+            )
+            execute = bool(kwargs.get("execute", False))
+            delivery_authorized = bool(
+                kwargs.get("external_sink_delivery_authorized", True)
+            )
+            with explore_feishu_sync_singleflight(
+                config_path=config_path_resolver(resolved_registry),
+                execute=bool(execute and delivery_authorized),
+            ) as acquired:
+                if not acquired:
+                    return explore_feishu_sync_busy_packet(
+                        schema_version="issue_fix_explore_lark_material_sync_v0"
+                    )
+                return function(*args, **kwargs)
+
+        return wrapped
+
+    return decorate


### PR DESCRIPTION
## Summary

- add a per-config nonblocking singleflight lock for direct Explore Feishu sync
- share the same lock with automatic issue-fix material refresh
- return a retryable sync_busy packet before any row, visual, or checkpoint write
- document and smoke-test cross-process contention and lock release

## Validation

- scripts/loopx canary premerge --from-git-diff --format json (17/17 passed)
- python3 examples/explore-feishu-singleflight-smoke.py
- python3 examples/issue-fix-explore-projection-smoke.py
- python3 examples/explore-result-layer-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- uvx ruff check on changed Python files

No manual holds.