### PR TITLE
feat: count evidence-backed issue closes

### DIFF
--- a/docs/capabilities/issue-fix/protocols/issue-fix-metrics-projection-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-metrics-projection-v0.md
@@ -70,7 +70,11 @@ native to feasibility or PR lifecycle rows:
     "loopx_capability_gaps_fixed": 2,
     "memory_retrievals": 4,
     "memory_verified_patch_influence": 1,
-    "memory_stale_results": 1
+    "memory_stale_results": 1,
+    "issue_close_recommendations": 3,
+    "issue_close_requests_published": 2,
+    "issue_closes_observed": 1,
+    "issue_reopens_observed": 0
   }
 }
 ```
@@ -101,8 +105,27 @@ retrieval, verified patch-influence, and stale-result counts. An optional
 `issue_fix_metrics_event_batch_v0` supplies stable event identities for
 first-push CI, human interventions, useful public comments, duplicate external
 writes, and capability-gap `found` / `fixed` / `real_callsite_verified`
-transitions. Events outside the reporting period are ignored, duplicate event
-identities are rejected, and a capability gap is counted once per gap identity.
+transitions. It also accepts four explicit issue-close stages:
+`issue_close_recommended`, `issue_close_request_published`,
+`issue_closed_observed`, and `issue_reopened_observed`. Events outside the
+reporting period are ignored, duplicate event identities are rejected, and a
+capability gap is counted once per gap identity.
+
+Issue-close events require `issue_ref`. Published requests and provider-observed
+close/reopen transitions additionally require a public HTTPS `evidence_url`;
+an internal recommendation does not. The composer folds repeated events into
+one `issue_fix_issue_close_activity_v0` row per issue, retaining only stable event
+identity, stage, timestamp, and public evidence URL. For example:
+
+```json
+{
+  "event_id": "close-request-42",
+  "event_type": "issue_close_request_published",
+  "issue_ref": "issues_42",
+  "occurred_at": "2026-07-12T00:00:00Z",
+  "evidence_url": "https://github.com/owner/repo/issues/42#issuecomment-1"
+}
+```
 
 Without an explicit event batch, the composer reads the existing compact LoopX
 run index and counts only route-changing `operator_gate_*` decisions and
@@ -175,6 +198,18 @@ rather than coercing it to zero.
 - Repository shares use explicit numerators and denominators, so a ratio is
   `not_available` when its denominator is zero or evidence is missing.
 - Open PRs are work in progress, not terminal outcomes.
+- A recommendation is activity, not a close. A published request is an
+  externally visible attempt, not a close. `issue_closes_observed` requires a
+  later provider-observed close event or a later `closed_at` in the current
+  repository snapshot.
+- An attributed close conversion requires a published request at or before the
+  observed close. This is a bounded operational attribution rule, not a causal
+  claim about why a maintainer closed the issue.
+- A later observed reopen is a reversal. The packet reports gross attributed
+  conversions, reopen reversals, and net conversions separately. Each measure
+  counts unique issue refs, so retries and repeated comments cannot inflate it.
+- PR-linked issue closes and close-activity conversions are overlapping views;
+  they must not be added together as independent terminal outcomes.
 
 ## Boundary contract
 
@@ -214,6 +249,12 @@ The metrics packet includes stable `impact_rows` for repository health,
 delivery, quality, autonomy, capability, and memory. Every row keeps its
 baseline, current value, delta, numerator/denominator when applicable, public
 source URL, freshness timestamp, and missing-data reason.
+
+Issue-close delivery has separate rows for recommendations, published requests,
+agent-pursued closes, attributed conversions, reopen reversals, net conversions,
+and conversion rate. The rows stay unavailable when the explicit event batch
+does not cover the reporting period, or when an attempted issue has neither a
+current issue state nor provider-observed close/reopen evidence.
 
 Capability delta is represented by three separate rows: gaps found, gaps
 fixed, and gaps verified on a real callsite. This keeps discovery volume,

--- a/examples/issue-fix-metrics-projection-smoke.py
+++ b/examples/issue-fix-metrics-projection-smoke.py
@@ -70,7 +70,11 @@ def main() -> int:
                     "pull_requests_merged": 2,
                 },
                 "issue_states": [
-                    {"issue_ref": "issues_42", "state": "CLOSED"},
+                    {
+                        "issue_ref": "issues_42",
+                        "state": "CLOSED",
+                        "closed_at": "2026-07-12T00:00:00Z",
+                    },
                     {"issue_ref": "issues_43", "state": "OPEN"},
                     {"issue_ref": "issues_44", "state": "OPEN"},
                 ],
@@ -114,6 +118,82 @@ def main() -> int:
                     "memory_verified_decision_influence": 2,
                     "memory_verified_patch_influence": 1,
                     "memory_stale_results": 1,
+                    "issue_close_recommendations": 3,
+                    "issue_close_requests_published": 2,
+                    "issue_closes_observed": 2,
+                    "issue_reopens_observed": 1,
+                },
+                "issue_close_activity": [
+                    {
+                        "schema_version": "issue_fix_issue_close_activity_v0",
+                        "issue_ref": "issues_42",
+                        "events": [
+                            {
+                                "event_id": "recommend-42",
+                                "event_type": "issue_close_recommended",
+                                "occurred_at": "2026-07-10T00:00:00Z",
+                            },
+                            {
+                                "event_id": "request-42",
+                                "event_type": "issue_close_request_published",
+                                "occurred_at": "2026-07-11T00:00:00Z",
+                                "evidence_url": "https://github.com/public-fixture/widgets/issues/42#issuecomment-1",
+                            },
+                        ],
+                    },
+                    {
+                        "schema_version": "issue_fix_issue_close_activity_v0",
+                        "issue_ref": "issues_43",
+                        "events": [
+                            {
+                                "event_id": "recommend-43",
+                                "event_type": "issue_close_recommended",
+                                "occurred_at": "2026-07-13T00:00:00Z",
+                            },
+                            {
+                                "event_id": "request-43",
+                                "event_type": "issue_close_request_published",
+                                "occurred_at": "2026-07-14T00:00:00Z",
+                                "evidence_url": "https://github.com/public-fixture/widgets/issues/43#issuecomment-2",
+                            },
+                            {
+                                "event_id": "closed-43",
+                                "event_type": "issue_closed_observed",
+                                "occurred_at": "2026-07-15T00:00:00Z",
+                                "evidence_url": "https://github.com/public-fixture/widgets/issues/43",
+                            },
+                            {
+                                "event_id": "reopened-43",
+                                "event_type": "issue_reopened_observed",
+                                "occurred_at": "2026-07-16T00:00:00Z",
+                                "evidence_url": "https://github.com/public-fixture/widgets/issues/43",
+                            },
+                        ],
+                    },
+                    {
+                        "schema_version": "issue_fix_issue_close_activity_v0",
+                        "issue_ref": "issues_44",
+                        "events": [
+                            {
+                                "event_id": "closed-44-before-attempt",
+                                "event_type": "issue_closed_observed",
+                                "occurred_at": "2026-07-16T00:00:00Z",
+                                "evidence_url": "https://github.com/public-fixture/widgets/issues/44",
+                            },
+                            {
+                                "event_id": "recommend-44",
+                                "event_type": "issue_close_recommended",
+                                "occurred_at": "2026-07-17T00:00:00Z",
+                            },
+                        ],
+                    },
+                ],
+                "coverage": {
+                    "issue_close_activity": {
+                        "source": "issue_fix_metrics_event_batch_v0",
+                        "observed_issues": 3,
+                        "complete": True,
+                    }
                 },
             },
         )
@@ -230,6 +310,14 @@ def main() -> int:
         assert output["selected_issues"] == 2, packet
         assert output["merged_pull_requests"] == 1, packet
         assert output["linked_issues_closed"] == 1, packet
+        assert output["issue_close_output"] == {
+            "issue_close_recommendations": 3,
+            "issue_close_requests_published": 2,
+            "issue_closes_observed": 2,
+            "issue_close_conversions": 2,
+            "issue_close_reversals": 1,
+            "net_issue_close_conversions": 1,
+        }, packet
         assert output["pull_requests_refreshed_from_snapshot"] == 2, packet
         assert output["stale_lifecycle_rows_corrected_by_snapshot"] == 0, packet
         assert packet["delta"]["repository"]["open_issues"] == 2, packet
@@ -237,20 +325,32 @@ def main() -> int:
             packet["ratios"]["pilot_share_of_repository_prs_opened"]["value"] == 0.5
         ), packet
         assert len(packet["output_inventory"]["pull_requests"]) == 2, packet
-        assert len(packet["impact_rows"]) == 22, packet
+        assert len(packet["output_inventory"]["issue_close_activity"]) == 3, packet
+        close_by_issue = {
+            item["issue_ref"]: item
+            for item in packet["output_inventory"]["issue_close_activity"]
+        }
+        assert close_by_issue["issues_44"]["actual_close_observed"] is False, packet
+        assert len(packet["impact_rows"]) == 29, packet
         impact_by_id = {row["metric_id"]: row for row in packet["impact_rows"]}
         assert impact_by_id["agent_pull_requests"]["current"] == 2, packet
         assert impact_by_id["repository_open_issues"]["delta"] == 2, packet
         assert impact_by_id["quality_first_push_ci_pass_rate"]["current"] == 0.5
         assert impact_by_id["capability_gaps_found"]["current"] == 2, packet
         assert impact_by_id["capability_gaps_fixed"]["current"] == 1, packet
-        assert (
-            impact_by_id["capability_gaps_real_callsite_verified"]["current"] == 1
-        ), packet
+        assert impact_by_id["capability_gaps_real_callsite_verified"]["current"] == 1, (
+            packet
+        )
         assert impact_by_id["memory_retrievals"]["current"] == 3, packet
-        assert impact_by_id["memory_verified_decision_influence"]["current"] == 2, packet
+        assert impact_by_id["memory_verified_decision_influence"]["current"] == 2, (
+            packet
+        )
         assert impact_by_id["memory_verified_patch_influence"]["current"] == 1, packet
         assert impact_by_id["memory_stale_results"]["current"] == 1, packet
+        assert impact_by_id["agent_issue_close_conversions"]["current"] == 2, packet
+        assert impact_by_id["agent_issue_close_reversals"]["current"] == 1, packet
+        assert impact_by_id["agent_net_issue_close_conversions"]["current"] == 1, packet
+        assert impact_by_id["delivery_issue_close_conversion_rate"]["current"] == 1.0
 
         schema = lark_kanban_schema_payload()
         assert any(view["name"] == "Monthly Impact" for view in schema["views"]), schema
@@ -269,7 +369,7 @@ def main() -> int:
                 execute=False,
             )
         assert sync["ok"] is True, sync
-        assert sync["row_count"] == 22, sync
+        assert sync["row_count"] == 29, sync
         metric_records = {
             record["values"]["Metric"]: record for record in sync["records"]
         }
@@ -324,6 +424,9 @@ def main() -> int:
             "not_available"
         )
         assert partial_rows["memory_stale_results"]["status"] == "not_available"
+        assert partial_rows["agent_issue_close_conversions"]["status"] == (
+            "not_available"
+        )
 
         cli_sync = subprocess.run(
             [
@@ -355,7 +458,7 @@ def main() -> int:
             check=True,
         )
         cli_sync_packet = json.loads(cli_sync.stdout)
-        assert cli_sync_packet["row_count"] == 22, cli_sync_packet
+        assert cli_sync_packet["row_count"] == 29, cli_sync_packet
         serialized = json.dumps(packet, sort_keys=True)
         assert str(root) not in serialized, serialized
         assert packet["external_writes_performed"] is False, packet

--- a/examples/issue-fix-metrics-supplement-smoke.py
+++ b/examples/issue-fix-metrics-supplement-smoke.py
@@ -190,6 +190,45 @@ def main() -> int:
                         "occurred_at": "2026-07-10T00:00:00Z",
                     },
                     {
+                        "event_id": "close-recommend-44-a",
+                        "event_type": "issue_close_recommended",
+                        "issue_ref": "issues_44",
+                        "occurred_at": "2026-07-13T00:00:00Z",
+                    },
+                    {
+                        "event_id": "close-recommend-44-b",
+                        "event_type": "issue_close_recommended",
+                        "issue_ref": "issues_44",
+                        "occurred_at": "2026-07-14T00:00:00Z",
+                    },
+                    {
+                        "event_id": "close-request-44",
+                        "event_type": "issue_close_request_published",
+                        "issue_ref": "issues_44",
+                        "occurred_at": "2026-07-15T00:00:00Z",
+                        "evidence_url": "https://github.com/public-fixture/widgets/issues/44#issuecomment-1",
+                    },
+                    {
+                        "event_id": "closed-44",
+                        "event_type": "issue_closed_observed",
+                        "issue_ref": "issues_44",
+                        "occurred_at": "2026-07-16T00:00:00Z",
+                        "evidence_url": "https://github.com/public-fixture/widgets/issues/44",
+                    },
+                    {
+                        "event_id": "reopened-44",
+                        "event_type": "issue_reopened_observed",
+                        "issue_ref": "issues_44",
+                        "occurred_at": "2026-07-17T00:00:00Z",
+                        "evidence_url": "https://github.com/public-fixture/widgets/issues/44",
+                    },
+                    {
+                        "event_id": "close-recommend-45",
+                        "event_type": "issue_close_recommended",
+                        "issue_ref": "issues_45",
+                        "occurred_at": "2026-07-18T00:00:00Z",
+                    },
+                    {
                         "event_id": "outside-period",
                         "event_type": "human_intervention",
                         "occurred_at": "2026-06-01T00:00:00Z",
@@ -271,6 +310,16 @@ def main() -> int:
         assert counts["memory_verified_patch_influence"] == 1, packet
         assert counts["memory_stale_results"] == 0, packet
         assert counts["useful_public_comments"] == 1, packet
+        assert counts["issue_close_recommendations"] == 2, packet
+        assert counts["issue_close_requests_published"] == 1, packet
+        assert counts["issue_closes_observed"] == 1, packet
+        assert counts["issue_reopens_observed"] == 1, packet
+        assert len(packet["supplement"]["issue_close_activity"]) == 2, packet
+        assert packet["supplement"]["coverage"]["issue_close_activity"] == {
+            "source": "issue_fix_metrics_event_batch_v0",
+            "observed_issues": 2,
+            "complete": True,
+        }, packet
         assert "duplicate_external_writes" not in packet["missing_fields"], packet
         serialized = json.dumps(packet, sort_keys=True)
         assert str(root) not in serialized, serialized
@@ -301,6 +350,10 @@ def main() -> int:
         assert "first_push_ci_total" in incomplete["missing_fields"], incomplete
         assert "first_push_ci_passed" in incomplete["missing_fields"], incomplete
         assert "human_interventions" in incomplete["missing_fields"], incomplete
+        assert "issue_close_recommendations" in incomplete["missing_fields"], incomplete
+        assert "issue_close_requests_published" in incomplete["missing_fields"], (
+            incomplete
+        )
         assert incomplete["supplement"]["coverage"]["human_intervention"] == {
             "source": "loopx_compact_run_index",
             "observed_events": 2,

--- a/loopx/capabilities/issue_fix/metrics_projection.py
+++ b/loopx/capabilities/issue_fix/metrics_projection.py
@@ -29,6 +29,10 @@ _SUPPLEMENT_FIELDS = (
     "useful_public_comments",
     "triage_outcomes",
     "issues_screened",
+    "issue_close_recommendations",
+    "issue_close_requests_published",
+    "issue_closes_observed",
+    "issue_reopens_observed",
     "first_push_ci_passed",
     "first_push_ci_total",
 )
@@ -233,6 +237,231 @@ def _first_push_ci_coverage(value: dict[str, Any] | None) -> dict[str, Any] | No
         "observed_prs": observed,
         "complete": complete,
     }
+
+
+def _issue_close_activity(
+    value: dict[str, Any] | None,
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+    if not isinstance(value, dict):
+        return [], None
+    raw_activity = value.get("issue_close_activity")
+    coverage = value.get("coverage")
+    raw_coverage = (
+        coverage.get("issue_close_activity") if isinstance(coverage, dict) else None
+    )
+    compact_coverage = None
+    if isinstance(raw_coverage, dict):
+        observed_issues = _nonnegative_int(
+            raw_coverage.get("observed_issues"),
+            field="supplement.coverage.issue_close_activity.observed_issues",
+        )
+        compact_coverage = {
+            "source": str(raw_coverage.get("source") or "not_supplied").strip(),
+            "observed_issues": observed_issues,
+            "complete": raw_coverage.get("complete") is True,
+        }
+    if raw_activity is None:
+        return [], compact_coverage
+    if not isinstance(raw_activity, list):
+        raise ValueError("supplement.issue_close_activity must be a list")
+
+    known_types = {
+        "issue_close_recommended",
+        "issue_close_request_published",
+        "issue_closed_observed",
+        "issue_reopened_observed",
+    }
+    seen_issue_refs: set[str] = set()
+    seen_event_ids: set[str] = set()
+    activity: list[dict[str, Any]] = []
+    for row_index, row in enumerate(raw_activity):
+        if not isinstance(row, dict) or row.get("schema_version") != (
+            "issue_fix_issue_close_activity_v0"
+        ):
+            raise ValueError(
+                f"supplement.issue_close_activity[{row_index}] uses an unsupported schema"
+            )
+        issue_ref = str(row.get("issue_ref") or "").strip()
+        events = row.get("events")
+        if (
+            not issue_ref
+            or issue_ref in seen_issue_refs
+            or not isinstance(events, list)
+        ):
+            raise ValueError(
+                "supplement issue close activity requires unique issue_ref values and events"
+            )
+        seen_issue_refs.add(issue_ref)
+        compact_events: list[dict[str, str]] = []
+        for event_index, event in enumerate(events):
+            if not isinstance(event, dict):
+                raise ValueError(
+                    f"issue close activity event {row_index}:{event_index} must be an object"
+                )
+            event_id = str(event.get("event_id") or "").strip()
+            event_type = str(event.get("event_type") or "").strip()
+            occurred_at = _timestamp(
+                event.get("occurred_at"),
+                field=f"issue_close_activity.{issue_ref}.{event_index}.occurred_at",
+            )
+            if (
+                not event_id
+                or event_id in seen_event_ids
+                or event_type not in known_types
+            ):
+                raise ValueError(
+                    "issue close activity requires unique event_id values and known event types"
+                )
+            seen_event_ids.add(event_id)
+            evidence_url = _optional_https_url(
+                event.get("evidence_url"),
+                field=f"issue_close_activity.{issue_ref}.{event_index}.evidence_url",
+            )
+            if event_type != "issue_close_recommended" and evidence_url is None:
+                raise ValueError(f"{event_type} requires an https evidence_url")
+            compact_event = {
+                "event_id": event_id,
+                "event_type": event_type,
+                "occurred_at": occurred_at,
+            }
+            if evidence_url:
+                compact_event["evidence_url"] = evidence_url
+            compact_events.append(compact_event)
+        activity.append(
+            {
+                "schema_version": "issue_fix_issue_close_activity_v0",
+                "issue_ref": issue_ref,
+                "events": sorted(
+                    compact_events,
+                    key=lambda item: (item["occurred_at"], item["event_id"]),
+                ),
+            }
+        )
+    if compact_coverage and compact_coverage["observed_issues"] != len(activity):
+        raise ValueError(
+            "supplement issue close activity coverage must match activity rows"
+        )
+    return sorted(activity, key=lambda item: item["issue_ref"]), compact_coverage
+
+
+def _issue_close_output(
+    activity: list[dict[str, Any]],
+    *,
+    current_issue_states: dict[str, dict[str, Any]],
+) -> tuple[dict[str, int], list[dict[str, Any]]]:
+    inventory: list[dict[str, Any]] = []
+    for row in activity:
+        issue_ref = row["issue_ref"]
+        events = list(row["events"])
+        recommendations = [
+            event
+            for event in events
+            if event["event_type"] == "issue_close_recommended"
+        ]
+        requests = [
+            event
+            for event in events
+            if event["event_type"] == "issue_close_request_published"
+        ]
+        close_events = [
+            event for event in events if event["event_type"] == "issue_closed_observed"
+        ]
+        reopen_events = [
+            event
+            for event in events
+            if event["event_type"] == "issue_reopened_observed"
+        ]
+        attempt_times = [
+            datetime.fromisoformat(event["occurred_at"].replace("Z", "+00:00"))
+            for event in [*recommendations, *requests]
+        ]
+        request_times = [
+            datetime.fromisoformat(event["occurred_at"].replace("Z", "+00:00"))
+            for event in requests
+        ]
+        close_candidates = [
+            (
+                datetime.fromisoformat(event["occurred_at"].replace("Z", "+00:00")),
+                event["occurred_at"],
+                "event_evidence",
+            )
+            for event in close_events
+        ]
+        current_state = current_issue_states.get(issue_ref) or {}
+        if current_state.get("state") == "CLOSED" and current_state.get("closed_at"):
+            closed_at = _timestamp(
+                current_state["closed_at"],
+                field=f"current.issue_states.{issue_ref}.closed_at",
+            )
+            close_candidates.append(
+                (
+                    datetime.fromisoformat(closed_at.replace("Z", "+00:00")),
+                    closed_at,
+                    "repository_current_snapshot",
+                )
+            )
+        first_attempt = min(attempt_times) if attempt_times else None
+        eligible_closes = sorted(
+            candidate
+            for candidate in close_candidates
+            if first_attempt is not None and candidate[0] >= first_attempt
+        )
+        actual_close = eligible_closes[0] if eligible_closes else None
+        latest_close = eligible_closes[-1] if eligible_closes else None
+        attributed = bool(
+            actual_close
+            and any(request_time <= actual_close[0] for request_time in request_times)
+        )
+        reopened = bool(
+            attributed
+            and any(
+                datetime.fromisoformat(event["occurred_at"].replace("Z", "+00:00"))
+                > latest_close[0]
+                for event in reopen_events
+            )
+        )
+        inventory.append(
+            {
+                "schema_version": "issue_fix_issue_close_output_v0",
+                "issue_ref": issue_ref,
+                "close_recommended": bool(recommendations),
+                "close_request_published": bool(requests),
+                "actual_close_observed": actual_close is not None,
+                "actual_close_at": actual_close[1] if actual_close else None,
+                "actual_close_source": actual_close[2] if actual_close else None,
+                "attributed_close_conversion": attributed,
+                "reopened_after_attributed_close": reopened,
+                "current_state": current_state.get("state") or "UNKNOWN",
+                "evidence_urls": sorted(
+                    {
+                        event["evidence_url"]
+                        for event in events
+                        if event.get("evidence_url")
+                    }
+                ),
+            }
+        )
+    counts = {
+        "issue_close_recommendations": sum(
+            item["close_recommended"] for item in inventory
+        ),
+        "issue_close_requests_published": sum(
+            item["close_request_published"] for item in inventory
+        ),
+        "issue_closes_observed": sum(
+            item["actual_close_observed"] for item in inventory
+        ),
+        "issue_close_conversions": sum(
+            item["attributed_close_conversion"] for item in inventory
+        ),
+        "issue_close_reversals": sum(
+            item["reopened_after_attributed_close"] for item in inventory
+        ),
+    }
+    counts["net_issue_close_conversions"] = (
+        counts["issue_close_conversions"] - counts["issue_close_reversals"]
+    )
+    return counts, inventory
 
 
 def _latest_rows(
@@ -504,8 +733,11 @@ def build_issue_fix_metrics_projection(
                 compact[field] = observation[field]
         pr_inventory.append(compact)
 
+    current_issue_state_rows = {
+        item["issue_ref"]: item for item in current.get("issue_states", [])
+    }
     issue_states = {
-        item["issue_ref"]: item["state"] for item in current.get("issue_states", [])
+        issue_ref: item["state"] for issue_ref, item in current_issue_state_rows.items()
     }
     missing_issue_states = sorted(linked_issue_refs - issue_states.keys())
     issues_closed = (
@@ -515,6 +747,47 @@ def build_issue_fix_metrics_projection(
     )
     supplement = _supplement(supplement_input)
     first_push_coverage = _first_push_ci_coverage(supplement_input)
+    issue_close_activity, issue_close_coverage = _issue_close_activity(supplement_input)
+    issue_close_counts, issue_close_inventory = _issue_close_output(
+        issue_close_activity,
+        current_issue_states=current_issue_state_rows,
+    )
+    for field in (
+        "issue_close_recommendations",
+        "issue_close_requests_published",
+    ):
+        if (
+            supplement[field] is not None
+            and supplement[field] != issue_close_counts[field]
+        ):
+            raise ValueError(
+                f"supplement.counts.{field} must match compact issue close activity"
+            )
+    close_activity_complete = bool(
+        issue_close_coverage and issue_close_coverage["complete"] is True
+    )
+    close_outcome_missing_refs = sorted(
+        item["issue_ref"]
+        for item in issue_close_inventory
+        if item["current_state"] == "UNKNOWN" and item["actual_close_observed"] is False
+    )
+    close_outcome_complete = close_activity_complete and not close_outcome_missing_refs
+    reported_issue_close_counts = {
+        field: (
+            value
+            if (
+                close_activity_complete
+                if field
+                in {
+                    "issue_close_recommendations",
+                    "issue_close_requests_published",
+                }
+                else close_outcome_complete
+            )
+            else None
+        )
+        for field, value in issue_close_counts.items()
+    }
     terminal_outcomes = (
         pr_state_counts["MERGED"]
         + (supplement["useful_public_comments"] or 0)
@@ -533,6 +806,12 @@ def build_issue_fix_metrics_projection(
             "captured": len(linked_issue_refs) - len(missing_issue_states),
             "total": len(linked_issue_refs),
             "complete": not missing_issue_states,
+        },
+        "issue_close_output": reported_issue_close_counts,
+        "issue_close_outcome_coverage": {
+            "captured": len(issue_close_inventory) - len(close_outcome_missing_refs),
+            "total": len(issue_close_inventory),
+            "complete": close_outcome_complete,
         },
         "validation_passed": validation_passed,
         "validation_missing": validation_missing,
@@ -553,6 +832,12 @@ def build_issue_fix_metrics_projection(
         "closed_unmerged_pull_requests": 0,
         "linked_issues_closed": 0,
         "linked_issue_state_coverage": {
+            "captured": 0,
+            "total": 0,
+            "complete": True,
+        },
+        "issue_close_output": {field: 0 for field in issue_close_counts},
+        "issue_close_outcome_coverage": {
             "captured": 0,
             "total": 0,
             "complete": True,
@@ -580,6 +865,26 @@ def build_issue_fix_metrics_projection(
             {
                 "code": "fix_pr_validation_not_captured",
                 "impact": "validation pass coverage is incomplete",
+            }
+        )
+    if not close_activity_complete:
+        missing_data.append(
+            {
+                "code": "issue_close_activity_not_captured",
+                "impact": (
+                    "close recommendations, published requests, conversions, and "
+                    "reopen reversals are unavailable"
+                ),
+            }
+        )
+    elif close_outcome_missing_refs:
+        missing_data.append(
+            {
+                "code": "issue_close_outcome_states_not_captured",
+                "impact": (
+                    "close conversions and reopen reversals are unavailable; "
+                    f"{len(close_outcome_missing_refs)} attempted issue states are missing"
+                ),
             }
         )
     for field, impact in (
@@ -613,6 +918,10 @@ def build_issue_fix_metrics_projection(
         ),
         "human_interventions_per_terminal_outcome": _ratio(
             supplement["human_interventions"], terminal_outcomes
+        ),
+        "issue_close_conversion_rate": _ratio(
+            reported_issue_close_counts["issue_close_conversions"],
+            reported_issue_close_counts["issue_close_requests_published"],
         ),
     }
     source_url = current.get("source_url") or baseline.get("source_url")
@@ -725,6 +1034,57 @@ def build_issue_fix_metrics_projection(
             source_url=source_url,
         ),
     ]
+    for metric_id, metric, field in (
+        (
+            "agent_issue_close_recommendations",
+            "Issue close recommendations",
+            "issue_close_recommendations",
+        ),
+        (
+            "agent_issue_close_requests_published",
+            "Published issue close requests",
+            "issue_close_requests_published",
+        ),
+        (
+            "agent_issue_closes_observed",
+            "Agent-pursued issues closed",
+            "issue_closes_observed",
+        ),
+        (
+            "agent_issue_close_conversions",
+            "Attributed issue close conversions",
+            "issue_close_conversions",
+        ),
+        (
+            "agent_issue_close_reversals",
+            "Attributed issue close reopen reversals",
+            "issue_close_reversals",
+        ),
+        (
+            "agent_net_issue_close_conversions",
+            "Net attributed issue close conversions",
+            "net_issue_close_conversions",
+        ),
+    ):
+        value = reported_issue_close_counts[field]
+        impact_rows.append(
+            _impact_row(
+                metric_id=metric_id,
+                metric_group="Delivery",
+                metric=metric,
+                baseline=0,
+                current=value,
+                delta=value,
+                status="available" if value is not None else "not_available",
+                missing_reason=(
+                    None
+                    if value is not None
+                    else "issue close activity or outcome state coverage is incomplete"
+                ),
+                updated_at=updated_at,
+                source_url=source_url,
+            )
+        )
     for metric_id, metric_group, metric, ratio_key in (
         (
             "delivery_share_repository_prs_opened",
@@ -755,6 +1115,12 @@ def build_issue_fix_metrics_projection(
             "Autonomy",
             "Human interventions per terminal outcome",
             "human_interventions_per_terminal_outcome",
+        ),
+        (
+            "delivery_issue_close_conversion_rate",
+            "Delivery",
+            "Attributed close conversions per published close request",
+            "issue_close_conversion_rate",
         ),
     ):
         ratio = ratios[ratio_key]
@@ -870,12 +1236,16 @@ def build_issue_fix_metrics_projection(
             },
             "agent_output": agent_output,
         },
-        "output_inventory": {"pull_requests": pr_inventory},
+        "output_inventory": {
+            "pull_requests": pr_inventory,
+            "issue_close_activity": issue_close_inventory,
+        },
         "impact_rows": impact_rows,
         "ratios": ratios,
         "missing_data": missing_data,
         "supplement_coverage": {
             "first_push_ci": first_push_coverage,
+            "issue_close_activity": issue_close_coverage,
         },
         "source_summary": {
             "feasibility_rows": len(feasibility),
@@ -923,6 +1293,7 @@ def render_issue_fix_metrics_projection_markdown(payload: dict[str, Any]) -> str
         return f"# Issue-fix metrics projection\n\n- Error: {payload.get('error') or 'invalid projection'}"
     current = payload["current"]
     output = current["agent_output"]
+    close_output = output["issue_close_output"]
     repository = current["repository"]
     lines = [
         "# Issue-fix metrics projection",
@@ -933,6 +1304,12 @@ def render_issue_fix_metrics_projection_markdown(payload: dict[str, Any]) -> str
         f"- Pull requests: `{output['pull_requests']}` "
         f"(`{output['merged_pull_requests']}` merged, "
         f"`{output['open_pull_requests']}` open)",
+        "- Issue close recommended / published / closed / attributed / reopened: "
+        f"`{close_output['issue_close_recommendations']}` / "
+        f"`{close_output['issue_close_requests_published']}` / "
+        f"`{close_output['issue_closes_observed']}` / "
+        f"`{close_output['issue_close_conversions']}` / "
+        f"`{close_output['issue_close_reversals']}`",
         f"- Repository open issues / PRs: `{repository['open_issues']}` / "
         f"`{repository['open_pull_requests']}`",
         f"- Missing-data items: `{len(payload['missing_data'])}`",
@@ -948,4 +1325,16 @@ def render_issue_fix_metrics_projection_markdown(payload: dict[str, Any]) -> str
         )
     if not payload["output_inventory"]["pull_requests"]:
         lines.append("- None")
+    close_inventory = payload["output_inventory"].get("issue_close_activity") or []
+    if close_inventory:
+        lines.extend(["", "## Issue close activity", ""])
+        for item in close_inventory:
+            lines.append(
+                f"- `{item['issue_ref']}`: recommended="
+                f"{item['close_recommended']}, published="
+                f"{item['close_request_published']}, closed="
+                f"{item['actual_close_observed']}, attributed="
+                f"{item['attributed_close_conversion']}, reopened="
+                f"{item['reopened_after_attributed_close']}"
+            )
     return "\n".join(lines)

--- a/loopx/capabilities/issue_fix/metrics_supplement.py
+++ b/loopx/capabilities/issue_fix/metrics_supplement.py
@@ -13,7 +13,17 @@ _EVENT_TYPES = {
     "duplicate_external_write",
     "first_push_ci",
     "human_intervention",
+    "issue_close_recommended",
+    "issue_close_request_published",
+    "issue_closed_observed",
+    "issue_reopened_observed",
     "useful_public_comment",
+}
+_ISSUE_CLOSE_EVENT_TYPES = {
+    "issue_close_recommended",
+    "issue_close_request_published",
+    "issue_closed_observed",
+    "issue_reopened_observed",
 }
 _SUPPLEMENT_FIELDS = (
     "human_interventions",
@@ -29,6 +39,10 @@ _SUPPLEMENT_FIELDS = (
     "useful_public_comments",
     "triage_outcomes",
     "issues_screened",
+    "issue_close_recommendations",
+    "issue_close_requests_published",
+    "issue_closes_observed",
+    "issue_reopens_observed",
     "first_push_ci_passed",
     "first_push_ci_total",
 )
@@ -94,6 +108,52 @@ def _events_in_period(
         if period_start <= occurred_at <= period_end:
             events.append(dict(item))
     return events
+
+
+def _issue_close_activity(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Project bounded close evidence without treating activity as success.
+
+    Recommendations may be internal. Published requests and provider-observed
+    state transitions require a public evidence URL so downstream attribution
+    is auditable without retaining raw provider payloads.
+    """
+
+    activity_by_issue: dict[str, list[dict[str, str]]] = {}
+    for index, item in enumerate(events):
+        event_type = str(item.get("event_type") or "").strip()
+        if event_type not in _ISSUE_CLOSE_EVENT_TYPES:
+            continue
+        issue_ref = str(item.get("issue_ref") or "").strip()
+        if not issue_ref:
+            raise ValueError(f"issue close event {index} requires issue_ref")
+        evidence_url = str(item.get("evidence_url") or "").strip()
+        if event_type != "issue_close_recommended" and (
+            not evidence_url.startswith("https://")
+            or any(char.isspace() for char in evidence_url)
+        ):
+            raise ValueError(
+                f"{event_type} for {issue_ref} requires an https evidence_url"
+            )
+        compact = {
+            "event_id": str(item.get("event_id") or "").strip(),
+            "event_type": event_type,
+            "occurred_at": str(item.get("occurred_at") or "").strip(),
+        }
+        if evidence_url:
+            compact["evidence_url"] = evidence_url
+        activity_by_issue.setdefault(issue_ref, []).append(compact)
+
+    return [
+        {
+            "schema_version": "issue_fix_issue_close_activity_v0",
+            "issue_ref": issue_ref,
+            "events": sorted(
+                activity_by_issue[issue_ref],
+                key=lambda item: (item["occurred_at"], item["event_id"]),
+            ),
+        }
+        for issue_ref in sorted(activity_by_issue)
+    ]
 
 
 def _lifecycle_first_push_ci(
@@ -329,6 +389,7 @@ def build_issue_fix_metrics_supplement(
     feasibility = _latest_rows(feasibility_rows, repo=repo, ref_field="issue_ref")
     lifecycles = _latest_rows(pr_lifecycle_rows, repo=repo, ref_field="pr_ref")
     events = _events_in_period(event_batch, period_start=start, period_end=end)
+    issue_close_activity = _issue_close_activity(events)
     history_intervention_ids = _history_human_interventions(
         run_history_rows,
         period_start=start,
@@ -377,6 +438,38 @@ def build_issue_fix_metrics_supplement(
         )
         counts["useful_public_comments"] = sum(
             item.get("event_type") == "useful_public_comment" for item in events
+        )
+        counts.update(
+            {
+                "issue_close_recommendations": sum(
+                    any(
+                        event.get("event_type") == "issue_close_recommended"
+                        for event in item["events"]
+                    )
+                    for item in issue_close_activity
+                ),
+                "issue_close_requests_published": sum(
+                    any(
+                        event.get("event_type") == "issue_close_request_published"
+                        for event in item["events"]
+                    )
+                    for item in issue_close_activity
+                ),
+                "issue_closes_observed": sum(
+                    any(
+                        event.get("event_type") == "issue_closed_observed"
+                        for event in item["events"]
+                    )
+                    for item in issue_close_activity
+                ),
+                "issue_reopens_observed": sum(
+                    any(
+                        event.get("event_type") == "issue_reopened_observed"
+                        for event in item["events"]
+                    )
+                    for item in issue_close_activity
+                ),
+            }
         )
         first_push = [
             item for item in events if item.get("event_type") == "first_push_ci"
@@ -471,6 +564,7 @@ def build_issue_fix_metrics_supplement(
     supplement = {
         "schema_version": SUPPLEMENT_SCHEMA_VERSION,
         "counts": counts,
+        "issue_close_activity": issue_close_activity,
         "coverage": {
             "human_intervention": human_intervention_coverage,
             "capability_gap": capability_gap_coverage,
@@ -478,7 +572,16 @@ def build_issue_fix_metrics_supplement(
                 "eligible_prs": len(first_push_eligible),
                 "observed_prs": len(first_push_statuses),
                 "complete": first_push_complete,
-            }
+            },
+            "issue_close_activity": {
+                "source": (
+                    EVENT_BATCH_SCHEMA_VERSION
+                    if event_batch is not None
+                    else "not_supplied"
+                ),
+                "observed_issues": len(issue_close_activity),
+                "complete": event_batch is not None,
+            },
         },
     }
     return {
@@ -493,6 +596,7 @@ def build_issue_fix_metrics_supplement(
             "feasibility_rows": len(feasibility),
             "pr_lifecycle_rows": len(lifecycles),
             "event_rows": len(events),
+            "issue_close_activity_rows": len(issue_close_activity),
             "run_history_rows": len(run_history_rows),
             "rollout_event_rows": len(rollout_event_rows),
             "repository_memory_inputs": len(repository_memory_results),
@@ -518,6 +622,12 @@ def render_issue_fix_metrics_supplement_markdown(payload: dict[str, Any]) -> str
             f"- repository: `{payload.get('repo')}`",
             f"- issues screened: `{counts.get('issues_screened')}`",
             f"- automatic terminal closeouts: `{counts.get('automatic_terminal_closeouts')}`",
+            f"- issue close recommendations / published requests: "
+            f"`{counts.get('issue_close_recommendations', 'not available')}` / "
+            f"`{counts.get('issue_close_requests_published', 'not available')}`",
+            f"- issue closes / reopens observed: "
+            f"`{counts.get('issue_closes_observed', 'not available')}` / "
+            f"`{counts.get('issue_reopens_observed', 'not available')}`",
             f"- memory retrievals: `{counts.get('memory_retrievals', 'not available')}`",
             f"- missing fields: `{len(payload.get('missing_fields') or [])}`",
         ]

--- a/loopx/capabilities/issue_fix/metrics_supplement_cli.py
+++ b/loopx/capabilities/issue_fix/metrics_supplement_cli.py
@@ -37,7 +37,10 @@ def register_issue_fix_metrics_supplement_command(
     parser.add_argument(
         "--event-json",
         default=None,
-        help="Optional issue_fix_metrics_event_batch_v0 file, inline object, or stdin.",
+        help=(
+            "Optional issue_fix_metrics_event_batch_v0 file, inline object, or "
+            "stdin, including evidence-backed issue close activity."
+        ),
     )
     parser.add_argument(
         "--human-intervention-coverage-start",


### PR DESCRIPTION
## Summary

- extend the existing provider-neutral Issue Fix metrics event batch with four close-activity stages
- fold repeated activity to one auditable row per issue and require public evidence for published requests and observed transitions
- distinguish recommendations, published requests, actual closes, attributed conversions, reopen reversals, and net conversions
- preserve missing-data semantics and avoid counting closes that predate the agent attempt
- project the new metrics through the existing Monthly Impact rows without adding another ledger

## Validation

- scripts/loopx canary premerge --from-git-diff --format json (14/14 passed)
- python3 examples/issue-fix-metrics-supplement-smoke.py
- python3 examples/issue-fix-metrics-projection-smoke.py
- python3 examples/issue-fix-workflow-contract-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- ruff and py_compile on changed Python files

No manual holds.