### PR TITLE
Fix scoped user gates in goal-channel status

### DIFF
--- a/examples/project/goal-channel-projection-smoke.py
+++ b/examples/project/goal-channel-projection-smoke.py
@@ -164,6 +164,7 @@ def test_user_gate_projection() -> None:
                 "title": "Approve the bounded delivery packet.",
                 "status": "open",
                 "priority": "P0",
+                "task_class": "user_gate",
             }
         ],
     }
@@ -180,6 +181,30 @@ def test_user_gate_projection() -> None:
     assert payload["open_gates"][0]["kind"] == "user_channel", payload
     assert payload["open_gates"][0]["status"] == "action_required", payload
     assert_no_raw_values(payload)
+
+
+def test_user_gate_projection_without_interaction_contract() -> None:
+    status_item = sample_status_item()
+    status_item["project_asset"]["user_todos"] = {
+        "open_count": 1,
+        "first_open_items": [
+            {
+                "todo_id": "todo_user_2",
+                "title": "Approve the scoped cleanup.",
+                "status": "open",
+                "task_class": "user_gate",
+            }
+        ],
+    }
+    payload = build_goal_channel_projection(
+        goal_id="demo-goal",
+        status_item=status_item,
+        quota_payload={"status": "active_state_user_gate"},
+        run_history_goal=sample_run_history_goal(),
+    )
+    assert payload["decision_frame"]["user_action_required"] is True, payload
+    assert payload["open_gates"][0]["kind"] == "user_todo", payload
+    assert payload["open_gates"][0]["blocks"] == ["todo_user_2"], payload
 
 
 def test_raw_private_material_is_warned_not_copied() -> None:
@@ -226,6 +251,7 @@ def test_raw_private_material_is_warned_not_copied() -> None:
 def main() -> int:
     test_basic_projection()
     test_user_gate_projection()
+    test_user_gate_projection_without_interaction_contract()
     test_raw_private_material_is_warned_not_copied()
     print("goal-channel-projection-smoke: ok")
     return 0

--- a/examples/project/goal-channel-status-export-smoke.py
+++ b/examples/project/goal-channel-status-export-smoke.py
@@ -114,6 +114,9 @@ def main() -> int:
     assert projection["truth_contract"]["projection_is_writable"] is False, projection
     assert projection["truth_contract"]["event_ledger_is_source_of_truth"] is True, projection
     assert projection["user_todos"][0]["todo_id"] == "todo_user_gate", projection
+    assert projection["decision_frame"]["user_action_required"] is True, projection
+    assert projection["open_gates"][0]["kind"] == "user_todo", projection
+    assert projection["open_gates"][0]["blocks"] == ["todo_user_gate"], projection
     assert projection["agent_todos"][0]["claimed_by"] == "codex-side-bypass", projection
     assert projection["active_leases"][0]["owner_agent"] == "codex-side-bypass", projection
     assert projection["recent_events"][0]["classification"] == "validated_progress", projection

--- a/loopx/control_plane/goals/goal_channel_projection.py
+++ b/loopx/control_plane/goals/goal_channel_projection.py
@@ -187,6 +187,15 @@ def _compact_todos(project_asset: Mapping[str, Any], role: str) -> list[dict[str
     return compact
 
 
+def _user_gate_todos(user_todos: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        dict(todo)
+        for todo in user_todos
+        if todo.get("task_class") == "user_gate"
+        and todo.get("status") not in {"done", "closed", "resolved"}
+    ]
+
+
 def _open_gates(
     *,
     quota_payload: Mapping[str, Any],
@@ -194,6 +203,7 @@ def _open_gates(
     user_todos: Sequence[Mapping[str, Any]],
 ) -> list[dict[str, Any]]:
     gates: list[dict[str, Any]] = []
+    user_gate_todos = _user_gate_todos(user_todos)
     raw_gates = project_asset.get("open_gates")
     if isinstance(raw_gates, list):
         for gate in raw_gates:
@@ -219,15 +229,24 @@ def _open_gates(
         if isinstance(interaction, Mapping) and isinstance(interaction.get("user_channel"), Mapping)
         else {}
     )
-    if user_channel.get("action_required") is True and not gates:
+    if (user_channel.get("action_required") is True or user_gate_todos) and not gates:
+        blocking_todos = user_gate_todos or list(user_todos)
         gates.append(
             {
-                "gate_id": "interaction_contract_user_channel",
-                "kind": "user_channel",
+                "gate_id": (
+                    "interaction_contract_user_channel"
+                    if user_channel.get("action_required") is True
+                    else "project_asset_user_gate_todos"
+                ),
+                "kind": (
+                    "user_channel"
+                    if user_channel.get("action_required") is True
+                    else "user_todo"
+                ),
                 "status": "action_required",
                 "blocks": [
                     str(todo.get("todo_id") or todo.get("title") or "user_todo")
-                    for todo in user_todos
+                    for todo in blocking_todos
                 ],
             }
         )
@@ -378,6 +397,7 @@ def build_goal_channel_projection(
         if isinstance(interaction, Mapping) and isinstance(interaction.get("agent_channel"), Mapping)
         else {}
     )
+    user_gate_todos = _user_gate_todos(user_todos)
 
     projection = {
         "schema_version": GOAL_CHANNEL_PROJECTION_SCHEMA_VERSION,
@@ -414,7 +434,9 @@ def build_goal_channel_projection(
             limit=260,
         ),
         "decision_frame": {
-            "user_action_required": bool(user_channel.get("action_required")),
+            "user_action_required": bool(
+                user_channel.get("action_required") or user_gate_todos
+            ),
             "agent_action_required": bool(agent_channel.get("must_attempt")),
             "quiet_noop_allowed": bool(agent_channel.get("quiet_noop_allowed")),
         },


### PR DESCRIPTION
## Summary

- Infer `user_action_required` from open projected `user_gate` todos when status attachment has no embedded interaction contract.
- Emit a compact `open_gates` entry that names only the blocking user-gate todos.
- Add direct and status-export regression coverage for the observed projection path.

## Issue Or Task

- Closes #
- Contributor task ID: `todo_a8a6b7eccee0`

## Validation

- [x] `python3 -m py_compile loopx/*.py`
- [x] `loopx check --scan-root .`
- [x] `python3 examples/project/goal-channel-projection-smoke.py`
- [x] `python3 examples/project/goal-channel-status-export-smoke.py`

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.