### PR TITLE
Bound Codex App scheduler backoff

### DIFF
--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -500,7 +500,10 @@ heartbeats should search/use `automation_update` when available, but only when
 RRULE update, run `loopx` with
 `scheduler_hint.codex_app.ack_hint.cli_args`; current payloads use
 `quota scheduler-ack-current` so LoopX re-reads the latest hint and owns the
-progression/reset state. When the desired RRULE is already applied, skip
+progression/reset state. Attempt the host update at most once per hint and
+turn. If it fails or times out, do not retry or ACK in that turn; continue any
+allowed delivery under the observed host cadence and let the next heartbeat
+recompute drift. When the desired RRULE is already applied, skip
 `automation_update`; if `stateful_backoff.ack_needed=true`, run the bound ack
 hint directly, otherwise do nothing. For the uniquely matched current heartbeat,
 `quota should-run` reconciles the installed RRULE with the ACK ledger; a
@@ -509,8 +512,8 @@ hint directly, otherwise do nothing. For the uniquely matched current heartbeat,
 ```text
 Create a heartbeat automation starting at 3 minutes for the current thread;
 then apply `quota should-run.scheduler_hint`: update RRULE only when
-`apply_needed=true`, then ack the applied RRULE with the provided
-`ack_hint.cli_args`.
+`apply_needed=true`, trying once per hint and turn; ack with the provided
+`ack_hint.cli_args` only after the host update succeeds.
 
 Task:
 Advance <GOAL_ID> using <ACTIVE_GOAL_STATE_PATH>. Before any delivery work,

--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -558,7 +558,7 @@ JSON or Markdown decision:
     "action": "backoff_waiting_for_user",
     "codex_app": {
       "recommended_interval_minutes": 30,
-      "example_progression_minutes": [30, 60, 120]
+      "example_progression_minutes": [30, 60]
     },
     "unchanged_poll": {
       "limits": {
@@ -745,8 +745,10 @@ After a successful host RRULE update, the agent records that fact with
 `loopx` plus `codex_app.ack_hint.cli_args`; current payloads use
 `quota scheduler-ack-current` to re-read the latest scheduler hint before LoopX
 advances the per goal/agent scheduler state without spending quota. Human gates
-can move to `[30, 60, 120]` after the
-concrete user todo has been surfaced.
+can move Codex App heartbeats through `[30, 60]` after the concrete user todo
+has been surfaced. LoopX caps the Codex App integration at 60 minutes; coarser
+waits remain available to the local scheduler instead of being emitted as App
+heartbeat RRULEs.
 CLI-produced ACK hints bind that argument vector to the exact registry and
 effective runtime root that produced `quota should-run`. Hosts must execute the
 complete vector; stripping its leading global options can route a
@@ -784,6 +786,10 @@ returns to the current profile's initial interval. This gives hosts a compact
 post-update ack protocol instead of requiring them to own or diff the whole
 quota state. If `apply_needed=false` and `ack_needed=true`, the same command
 records an exact matching host readback without calling `automation_update`.
+If `automation_update` fails or times out, the agent must not ACK. LoopX keeps
+the observed host RRULE authoritative, does not retry the same hint in that
+turn, and retries only on a later eligible heartbeat; it never treats an
+intended cadence as an applied cadence.
 `scheduler-ack` is not a second `should-run`: it confirms the host update or
 matching readback and does not emit a successor RRULE in the same turn. User
 feedback, newly runnable work, reassignment, or material evidence therefore

--- a/examples/control_plane/heartbeat-prompt-smoke.py
+++ b/examples/control_plane/heartbeat-prompt-smoke.py
@@ -728,6 +728,9 @@ def main() -> int:
     assert "codex_app.ack_hint.cli_args" in doc, doc
     assert "quota scheduler-ack-current" in doc, doc
     assert "recommended_rrule" in doc, doc
+    normalized_doc = normalized(doc)
+    assert "Attempt the host update at most once per hint and turn" in normalized_doc, doc
+    assert "do not retry or ACK in that turn" in normalized_doc, doc
     assert "must_attempt_work=true" in doc, doc
     assert "not an execution gate" in normalized(doc), doc
     assert "loopx heartbeat-prompt" in doc, doc
@@ -786,6 +789,9 @@ def main() -> int:
     assert "codex_app.ack_hint.cli_args" in project_skill, project_skill
     assert "quota scheduler-ack-current" in project_skill, project_skill
     assert "recommended_rrule" in project_skill, project_skill
+    normalized_project_skill = normalized(project_skill)
+    assert "Attempt the host update at most once per hint and turn" in normalized_project_skill, project_skill
+    assert "do not retry or ACK in that turn" in normalized_project_skill, project_skill
     assert "must_attempt_work=true" in project_skill, project_skill
     assert "not an execution gate" in normalized(project_skill), project_skill
     assert "mapped_noop_if_unchanged" in project_skill, project_skill

--- a/examples/control_plane/monitor-scheduler-contract-smoke.py
+++ b/examples/control_plane/monitor-scheduler-contract-smoke.py
@@ -350,7 +350,9 @@ def assert_monitor_scheduler_active_window_respects_host_floor() -> None:
     assert context["phase"] == "active_window", context
     assert context["cadence_minutes"] == 3, context
     assert context["host_floor_minutes"] == 15, context
-    assert codex_app["example_progression_minutes"] == [15, 15, 15], scheduler
+    assert codex_app["example_progression_minutes"] == [15], scheduler
+    local_scheduler = scheduler["cold_path_detail"]["local_scheduler"]
+    assert local_scheduler["example_progression_minutes"] == [15, 15, 15], scheduler
     assert codex_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", scheduler
 
 

--- a/examples/control_plane/quota-agent-scoped-user-gate-smoke.py
+++ b/examples/control_plane/quota-agent-scoped-user-gate-smoke.py
@@ -651,8 +651,8 @@ def assert_scoped_gate_rejects_capability_ineligible_only_fallback() -> None:
     assert scheduler["codex_app"]["example_progression_minutes"] == [
         30,
         60,
-        120,
     ], scheduler
+    assert scheduler["codex_app"]["max_interval_minutes"] == 60, scheduler
     assert scheduler["codex_app"]["recommended_interval_minutes"] == 30, scheduler
 
 

--- a/examples/control_plane/quota-plan-smoke.py
+++ b/examples/control_plane/quota-plan-smoke.py
@@ -987,7 +987,7 @@ def assert_heartbeat_recommendation_lifecycle() -> None:
     assert scheduler["action"] == "backoff_until_fresh_evidence", mapped_decision
     assert scheduler["codex_app"]["recommended_interval_minutes"] == 60, mapped_decision
     assert scheduler["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=60", mapped_decision
-    assert scheduler["codex_app"]["example_progression_minutes"] == [60, 120, 240], mapped_decision
+    assert scheduler["codex_app"]["example_progression_minutes"] == [60], mapped_decision
     assert scheduler["unchanged_poll"]["limits"]["codex_cli_tui"] == 3, mapped_decision
     assert scheduler["unchanged_poll"]["final_quota_replan_check_enabled"] is True, mapped_decision
     assert "local_scheduler" not in scheduler, scheduler
@@ -1008,7 +1008,7 @@ def assert_heartbeat_recommendation_lifecycle() -> None:
     profile_snapshot = scheduler_reset_profile_snapshot(scheduler)
     assert profile_snapshot["cadence_class"] == "unchanged_noop", profile_snapshot
     assert profile_snapshot["codex_app_initial_rrule"] == "FREQ=MINUTELY;INTERVAL=60", profile_snapshot
-    assert profile_snapshot["codex_app_max_interval_minutes"] == 240, profile_snapshot
+    assert profile_snapshot["codex_app_max_interval_minutes"] == 60, profile_snapshot
     assert profile_snapshot["unchanged_poll_backoff_multiplier"] == 2, profile_snapshot
     identity_snapshot = {
         key: _nested_value(mapped_decision, key)
@@ -1023,7 +1023,7 @@ def assert_heartbeat_recommendation_lifecycle() -> None:
     assert "heartbeat_stop_if_unchanged: `True`" in mapped_markdown, mapped_markdown
     assert "scheduler_hint: action=backoff_until_fresh_evidence" in mapped_markdown, mapped_markdown
     assert "codex_app_rrule=FREQ=MINUTELY;INTERVAL=60" in mapped_markdown, mapped_markdown
-    assert "codex_app_progression=[60, 120, 240]" in mapped_markdown, mapped_markdown
+    assert "codex_app_progression=[60]" in mapped_markdown, mapped_markdown
     assert "scheduler_reset: initial_interval=60" in mapped_markdown, mapped_markdown
     assert "initial_rrule=FREQ=MINUTELY;INTERVAL=60" in mapped_markdown, mapped_markdown
     assert "reset_generation=" in mapped_markdown, mapped_markdown
@@ -1031,6 +1031,22 @@ def assert_heartbeat_recommendation_lifecycle() -> None:
         "execution_obligation: must_attempt_work=False kind=quiet_noop_if_unchanged notify_is_execution_gate=False"
         in mapped_markdown
     ), mapped_markdown
+
+    mapped_detailed = build_quota_should_run(
+        payload,
+        goal_id="mapped-quiet",
+        include_scheduler_detail=True,
+    )
+    detailed_scheduler = mapped_detailed["scheduler_hint"]
+    local_scheduler = detailed_scheduler["cold_path_detail"]["local_scheduler"]
+    stateful_detail = detailed_scheduler["cold_path_detail"]["stateful_backoff_detail"]
+    assert local_scheduler["example_progression_minutes"] == [60, 120, 240], local_scheduler
+    assert local_scheduler["max_interval_minutes"] == 240, local_scheduler
+    assert stateful_detail["host_max_interval_minutes"] == 60, stateful_detail
+    assert stateful_detail["coarser_wait_fallback"] == "local_scheduler_only", stateful_detail
+    assert stateful_detail["host_update_failure"] == (
+        "no_retry_same_turn_do_not_ack_keep_observed_rrule"
+    ), stateful_detail
 
 
 def assert_goal_boundary_in_should_run() -> None:

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -26,6 +26,7 @@ CODEX_APP_STATEFUL_BACKOFF_SCHEMA_VERSION = "codex_app_stateful_backoff_v0"
 CODEX_APP_SCHEDULER_ACK_HINT_SCHEMA_VERSION = "codex_app_scheduler_ack_hint_v0"
 MONITOR_CADENCE_PATTERN = re.compile(r"^\s*(\d+)\s*([mhd])\s*$", re.IGNORECASE)
 MONITOR_WAIT_PROGRESSION_MINUTES = [15, 30, 60]
+CODEX_APP_MAX_INTERVAL_MINUTES = 60
 DEFAULT_ACK_CAPABILITIES = {"shell", "filesystem_read", "filesystem_write"}
 MONITOR_WAIT_HOST_FLOOR_MINUTES = 15
 MONITOR_WAIT_NEAR_WINDOW_LEAD_MINUTES = 60
@@ -734,11 +735,29 @@ def build_scheduler_hint(
         cadence_context_detail: dict[str, Any] | None = None,
         advance_same_identity: bool = True,
     ) -> dict[str, Any]:
-        cadence_progression = cadence_progression_override or [
+        local_cadence_progression = cadence_progression_override or [
             min(codex_interval * (multiplier**step), codex_max)
             for step in range(3)
         ]
-        codex_initial_interval = cadence_progression[0] if cadence_progression else codex_interval
+        codex_host_max = min(max(1, codex_max), CODEX_APP_MAX_INTERVAL_MINUTES)
+        codex_cadence_progression: list[int] = []
+        for interval in local_cadence_progression:
+            bounded_interval = min(max(1, int(interval)), codex_host_max)
+            if (
+                not codex_cadence_progression
+                or codex_cadence_progression[-1] != bounded_interval
+            ):
+                codex_cadence_progression.append(bounded_interval)
+        codex_initial_interval = (
+            codex_cadence_progression[0]
+            if codex_cadence_progression
+            else min(codex_interval, codex_host_max)
+        )
+        local_initial_interval = (
+            local_cadence_progression[0]
+            if local_cadence_progression
+            else codex_interval
+        )
         final_replan_check = {
             "enabled": cli_limit is not None or claude_limit is not None,
             "trigger": "before_unchanged_poll_after_limit",
@@ -759,8 +778,8 @@ def build_scheduler_hint(
             "cadence_class": cadence_class,
             "codex_app_initial_interval_minutes": codex_initial_interval,
             "codex_app_initial_rrule": codex_rrule,
-            "codex_app_max_interval_minutes": codex_max,
-            "codex_app_progression_minutes": cadence_progression,
+            "codex_app_max_interval_minutes": codex_host_max,
+            "codex_app_progression_minutes": codex_cadence_progression,
             "unchanged_poll_backoff_multiplier": multiplier,
             "local_scheduler_unchanged_poll_limit": cli_limit,
             "claude_code_loop_unchanged_poll_limit": claude_limit,
@@ -812,7 +831,7 @@ def build_scheduler_hint(
             "host_state_key": "scheduler_hint.reset_policy.reset_token",
             "codex_app_initial_interval_minutes": codex_initial_interval,
             "codex_app_initial_rrule": codex_rrule,
-            "local_scheduler_initial_interval_minutes": codex_initial_interval,
+            "local_scheduler_initial_interval_minutes": local_initial_interval,
             "clear_unchanged_poll_state": True,
             "identity_key_count": len(identity_keys),
             "identity_signature": identity_signature,
@@ -832,10 +851,10 @@ def build_scheduler_hint(
             "identity_signature": identity_signature,
         }
         local_scheduler = {
-            "recommended_interval_minutes": codex_initial_interval,
+            "recommended_interval_minutes": local_initial_interval,
             "max_interval_minutes": codex_max,
             "unchanged_poll_backoff_multiplier": multiplier,
-            "example_progression_minutes": cadence_progression,
+            "example_progression_minutes": local_cadence_progression,
             "unchanged_poll_limit": cli_limit,
             "after_limit": "stop_tick_loop" if cli_limit is not None else "continue",
             "final_quota_replan_check": final_replan_check,
@@ -872,10 +891,12 @@ def build_scheduler_hint(
                 except (TypeError, ValueError):
                     applied_index = -1
                 next_index = applied_index + 1 if advance_same_identity else 0
-                current_index = min(max(next_index, 0), len(cadence_progression) - 1)
+                current_index = min(
+                    max(next_index, 0), len(codex_cadence_progression) - 1
+                )
             else:
                 state_status = "reset_required"
-        current_interval = cadence_progression[current_index]
+        current_interval = codex_cadence_progression[current_index]
         current_rrule = rrule_for_minutes(current_interval)
         last_applied_rrule = str(scheduler_state.get("last_applied_rrule") or "").strip()
         observed_host_rrule = normalize_scheduler_rrule(codex_app_current_rrule)
@@ -902,8 +923,11 @@ def build_scheduler_hint(
         )
         ack_needed = apply_needed or host_match_ack_needed
         stateful_backoff_detail = {
-            "progression_minutes": cadence_progression,
+            "progression_minutes": codex_cadence_progression,
             "current_interval_minutes": current_interval,
+            "host_max_interval_minutes": codex_host_max,
+            "coarser_wait_fallback": "local_scheduler_only",
+            "host_update_failure": "no_retry_same_turn_do_not_ack_keep_observed_rrule",
             "ack_required_after_apply": apply_needed,
             "ack_required_from_host_match": host_match_ack_needed,
             "persist": "reset_token|identity_signature|progression_index|last_applied_rrule",
@@ -917,9 +941,9 @@ def build_scheduler_hint(
         }
         codex_app = {
             "recommended_interval_minutes": current_interval,
-            "max_interval_minutes": codex_max,
+            "max_interval_minutes": codex_host_max,
             "unchanged_poll_backoff_multiplier": multiplier,
-            "example_progression_minutes": cadence_progression,
+            "example_progression_minutes": codex_cadence_progression,
             "apply": (
                 "update_automation_cadence_if_possible"
                 if apply_needed

--- a/loopx/heartbeat_prompt.py
+++ b/loopx/heartbeat_prompt.py
@@ -642,9 +642,10 @@ If the result says `should_run=true`:
    `notify=DONT_NOTIFY`; quiet no-op needs `must_attempt_work=false` and no
    `notify_user_on_open_todo=true` blocker-push notification. Use
    `scheduler_hint` for wakeup and unchanged-loop limits. For Codex App:
-   `apply_needed=true` -> update `recommended_rrule`, then run
-   `ack_hint.cli_args`; else `ack_needed=true` -> run that bound ack directly;
-   else skip.
+   `apply_needed=true` -> update `recommended_rrule` once; on success run
+   `ack_hint.cli_args`, but on failure or timeout do not retry or ack in the
+   same turn and continue under the observed host cadence. Else
+   `ack_needed=true` -> run that bound ack directly; else skip.
    LoopX owns reset/progression state. It is scheduling only, not delivery
    permission. Then use
    `heartbeat_recommendation`: `recommended_mode=run_first_read_only_map` means

--- a/skills/loopx-project/SKILL.md
+++ b/skills/loopx-project/SKILL.md
@@ -504,12 +504,15 @@ search/use `automation_update` when available, but only when
 RRULE update, run `loopx` with
 `scheduler_hint.codex_app.ack_hint.cli_args` (normally `quota scheduler-ack-current`,
 which re-reads the latest scheduler hint instead of hand-copying short-lived
-reset tokens). If `apply_needed=false` but `ack_needed=true`, a matching host
+reset tokens). Attempt the host update at most once per hint and turn. If it
+fails or times out, do not retry or ACK in that turn; continue allowed delivery
+under the observed host cadence and let the next heartbeat recompute drift. If
+`apply_needed=false` but `ack_needed=true`, a matching host
 readback already proves the RRULE; skip `automation_update` and run the bound
 ack hint directly. LoopX owns reset/progression state
-and omits `recommended_rrule` when the
-desired RRULE is already applied. Cadence changes, reset-to-initial updates,
-final checks, and self-stop changes do not spend quota. Read
+and omits `recommended_rrule` when the desired RRULE is already applied.
+Cadence changes, reset-to-initial updates, final checks, and self-stop changes
+do not spend quota.
 For a uniquely matched active Codex App heartbeat, `quota should-run`
 automatically reconciles the installed RRULE with LoopX's ACK ledger. Treat
 `stateful_backoff.host_observation.status=drift_detected` as authoritative for


### PR DESCRIPTION
## Summary\n- cap Codex App heartbeat backoff at 60 minutes and deduplicate capped progressions\n- preserve coarser 120/240-minute waits for the local scheduler\n- define a bounded host-update contract: one attempt per hint/turn, ACK only after success, and recompute drift on a later heartbeat\n- update public docs and focused scheduler/prompt smokes\n\n## Validation\n- # Pre-Merge Validation Gate

- status: `passed`
- ok: `true`
- merge_gate_passed: `true`
- self_merge_allowed: `true`
- tier: `standard`
- dry_run: `false`
- changed_files: `9`
- surfaces: `control_plane, docs_project_content, public_boundary, python`
- risk_profiles: `core-control-plane, docs-project-content-ops, canary-runner`
- manual_holds: `0`

Pre-merge validation is a risk-based gate: it runs diff hygiene, changed Python compile checks, catalog-selected canaries, risk-profile smokes, and public/private boundary checks. It reports manual holds for benchmark-sensitive or reviewer-gated surfaces instead of treating local smoke success as self-merge permission.

## Direct Checks
- `diff_check_committed`: `passed` `git diff --check origin/main...HEAD`
- `diff_check_staged`: `passed` `git diff --cached --check`
- `diff_check_unstaged`: `passed` `git diff --check`
- `changed_python_py_compile`: `passed` `python3 -m py_compile examples/control_plane/heartbeat-prompt-smoke.py examples/control_plane/monitor-scheduler-contract-smoke.py examples/control_plane/quota-agent-scoped-user-gate-smoke.py examples/control_plane/quota-plan-smoke.py loopx/control_plane/scheduler/scheduler_hint.py loopx/heartbeat_prompt.py`

## Catalog Canaries
- ok: `true`
- selected_checks: `8`
- executed_checks: `8`
- failures: `0`
- advisory_failures: `0`
- warnings: `0`
- `passed` python3 examples/control_plane/bounded-context-namespace-smoke.py
- `passed` python3 examples/control_plane/control-plane-risk-characterization-smoke.py
- `passed` python3 examples/control_plane/hot-path-interface-budget-smoke.py
- `passed` python3 examples/control_plane/quota-resume-gated-open-todo-smoke.py
- `passed` python3 examples/control_plane/repo-python-line-budget-smoke.py
- `passed` python3 examples/control_plane/peer-agent-continuation-state-machine-smoke.py
- `passed` python3 examples/control_plane/interaction-contract-state-machine-smoke.py
- `passed` python3 examples/control_plane/heartbeat-quota-flow-smoke.py

## Risk Profile Smokes
- ok: `true`
- selected_checks: `8`
- executed_checks: `8`
- failures: `0`
- advisory_failures: `0`
- warnings: `0`
- `passed` python3 examples/canary/catalog-planner-smoke.py
- `passed` python3 examples/canary/catalog-run-e2e-smoke.py
- `passed` python3 examples/canary/premerge-validation-gate-smoke.py
- `passed` python3 examples/canary/pytest-smoke-suite-facade-smoke.py
- `passed` python3 examples/canary/smoke-suite-runner-smoke.py
- `passed` python3 examples/canary/smoke-suite-subdir-discovery-smoke.py
- `passed` python3 examples/cli-control-plane-command-modularization-smoke.py
- `passed` python3 examples/cli-project-lifecycle-command-modularization-smoke.py

## Public Boundary
- ok: `true`
- selected_checks: `1`
- executed_checks: `1`
- failures: `0`
- advisory_failures: `0`
- warnings: `0`
- `passed` loopx check --scan-path docs/heartbeat-automation-prompt.md --scan-path docs/quota-allocation.md --scan-path examples/control_plane/heartbeat-prompt-smoke.py --scan-path examples/control_plane/monitor-scheduler-contract-smoke.py --scan-path examples/control_plane/quota-agent-scoped-user-gate-smoke.py --scan-path examples/control_plane/quota-plan-smoke.py --scan-path loopx/control_plane/scheduler/scheduler_hint.py --scan-path loopx/heartbeat_prompt.py --scan-path skills/loopx-project/SKILL.md (17 selected checks passed; 0 failures; 0 manual holds)\n- scheduler and heartbeat focused smokes (6 passed)\n- ........................................................................ [ 22%]
........................................................................ [ 45%]
........................................................................ [ 67%]
........................................................................ [ 90%]
..........ss....................                                         [100%]
318 passed, 2 skipped in 7.36s (318 passed, 2 skipped)\n- \n- public/private boundary scan passed\n\n## Residual risk\nThe Codex App automation update call can still time out independently of LoopX, including for a 3-minute RRULE. This change does not claim to repair that host service. It prevents unsupported coarse-RRULE churn and ensures a failed host update is never retried or ACKed in the same turn.