### PR TITLE
Include close activity refs in repository snapshots

### DIFF
--- a/docs/capabilities/issue-fix/protocols/issue-fix-metrics-projection-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-metrics-projection-v0.md
@@ -222,11 +222,15 @@ adapters over this packet. They must not become a second source of truth.
 
 `loopx issue-fix repository-snapshot` is the bounded public GitHub collector.
 It reads repository stock/flow plus the current state of issue/PR references
-already present in the goal's issue-fix domain state. The command never retains
-raw provider payloads. With `--retain-material-snapshot`, it writes at most one
-row per day to the existing `issue_fix/repository-snapshots.jsonl` stream and
-skips the write when stock, flow, issue state, PR state, CI, and review are
-unchanged:
+already present in the goal's issue-fix domain state. When `--supplement-json`
+is supplied, the collector also refreshes every deduplicated issue ref in the
+supplement's recommendation, published-request, observed-close, and
+observed-reopen activity. This lets later conversion/reversal projection use a
+complete current-state snapshot without maintaining a second issue list. The
+command never retains raw provider payloads. With
+`--retain-material-snapshot`, it writes at most one row per day to the existing
+`issue_fix/repository-snapshots.jsonl` stream and skips the write when stock,
+flow, issue state, PR state, CI, and review are unchanged:
 
 ```bash
 loopx --format json issue-fix repository-snapshot \
@@ -234,6 +238,7 @@ loopx --format json issue-fix repository-snapshot \
   --project /path/to/connected/project \
   --repo owner/repo \
   --repository-baseline-json baseline.json \
+  --supplement-json metrics-supplement.json \
   --fetch-public-github \
   --retain-material-snapshot
 ```

--- a/examples/issue-fix-repository-snapshot-smoke.py
+++ b/examples/issue-fix-repository-snapshot-smoke.py
@@ -140,6 +140,32 @@ def main() -> int:
                 },
             ],
         )
+        supplement = root / "supplement.json"
+        _write_json(
+            supplement,
+            {
+                "schema_version": "issue_fix_metrics_supplement_v0",
+                "counts": {},
+                "issue_close_activity": [
+                    {
+                        "schema_version": "issue_fix_issue_close_activity_v0",
+                        "issue_ref": "issues_42",
+                        "events": [],
+                    },
+                    {
+                        "schema_version": "issue_fix_issue_close_activity_v0",
+                        "issue_ref": "issues_44",
+                        "events": [],
+                    },
+                    {
+                        "schema_version": "issue_fix_issue_close_activity_v0",
+                        "issue_ref": "issues_45",
+                        "events": [],
+                    },
+                ],
+                "coverage": {},
+            },
+        )
         command = [
             sys.executable,
             "-m",
@@ -156,6 +182,8 @@ def main() -> int:
             "public-fixture/widgets",
             "--repository-baseline-json",
             str(baseline),
+            "--supplement-json",
+            str(supplement),
             "--fetch-public-github",
             "--retain-material-snapshot",
             "--generated-at",
@@ -176,8 +204,20 @@ def main() -> int:
         assert snapshot["open_issues"] == 12, packet
         assert snapshot["open_pull_requests"] == 5, packet
         assert snapshot["flow_since_baseline"]["issues_closed"] == 3, packet
-        assert len(snapshot["issue_states"]) == 2, packet
+        assert [item["issue_ref"] for item in snapshot["issue_states"]] == [
+            "issues_42",
+            "issues_43",
+            "issues_44",
+            "issues_45",
+        ], packet
         assert len(snapshot["pull_request_states"]) == 2, packet
+        assert packet["source_summary"] == {
+            "feasibility_issue_refs": 2,
+            "supplement_issue_refs": 3,
+            "issue_refs_collected": 4,
+            "pr_lifecycle_refs": 2,
+        }, packet
+        assert packet["source_contract"]["reads_metrics_supplement"] is True, packet
         assert packet["retention"]["write_performed"] is True, packet
         assert packet["raw_provider_payload_captured"] is False, packet
         assert packet["credentials_captured"] is False, packet

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -713,6 +713,14 @@ def register_issue_fix_commands(
     snapshot_parser.add_argument("--repo", required=True)
     snapshot_parser.add_argument("--repository-baseline-json", required=True)
     snapshot_parser.add_argument(
+        "--supplement-json",
+        default=None,
+        help=(
+            "Optional public-safe issue_fix_metrics_supplement_v0 whose "
+            "issue-close activity refs must be included in current-state collection."
+        ),
+    )
+    snapshot_parser.add_argument(
         "--fetch-public-github",
         action="store_true",
         help="Explicitly read bounded public repository metadata through gh.",
@@ -1463,6 +1471,17 @@ def handle_issue_fix_command(
         elif args.issue_fix_command == "repository-snapshot":
             if not args.fetch_public_github:
                 raise ValueError("repository-snapshot requires --fetch-public-github")
+            if sum(
+                value == "-"
+                for value in (
+                    args.repository_baseline_json,
+                    args.supplement_json,
+                )
+                if value is not None
+            ) > 1:
+                raise ValueError(
+                    "only one repository-snapshot JSON input may read from stdin"
+                )
             project = Path(args.project).expanduser()
             payload = collect_public_github_repository_snapshot(
                 repo=args.repo,
@@ -1476,6 +1495,11 @@ def handle_issue_fix_command(
                     default_issue_fix_domain_state_ledger_path(
                         project=project, goal_id=args.goal_id
                     )
+                ),
+                metrics_supplement=(
+                    _load_json_object(args.supplement_json)
+                    if args.supplement_json
+                    else None
                 ),
                 generated_at=generated_at,
                 timeout_seconds=args.fetch_timeout_seconds,

--- a/loopx/capabilities/issue_fix/repository_snapshot.py
+++ b/loopx/capabilities/issue_fix/repository_snapshot.py
@@ -8,10 +8,13 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from typing import Any
 
+from .metrics_supplement import SUPPLEMENT_SCHEMA_VERSION
+
 
 SNAPSHOT_SCHEMA_VERSION = "issue_fix_repository_reporting_snapshot_v0"
 COLLECTION_SCHEMA_VERSION = "issue_fix_repository_snapshot_collection_v0"
 RECORD_SCHEMA_VERSION = "issue_fix_repository_snapshot_record_v0"
+ISSUE_CLOSE_ACTIVITY_SCHEMA_VERSION = "issue_fix_issue_close_activity_v0"
 
 _REPO_PATTERN = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 _REF_NUMBER_PATTERN = re.compile(r"(?:issues|pull)_(\d+)")
@@ -80,6 +83,35 @@ def _reference_numbers(
             numbers.add(int(match.group(1)))
     if len(numbers) > 50:
         raise ValueError(f"at most 50 {ref_field} references may be refreshed")
+    return sorted(numbers)
+
+
+def _supplement_issue_reference_numbers(
+    metrics_supplement: dict[str, Any] | None,
+) -> list[int]:
+    if metrics_supplement is None:
+        return []
+    if metrics_supplement.get("schema_version") != SUPPLEMENT_SCHEMA_VERSION:
+        raise ValueError(f"metrics supplement must use {SUPPLEMENT_SCHEMA_VERSION}")
+    raw_activity = metrics_supplement.get("issue_close_activity")
+    if not isinstance(raw_activity, list):
+        raise ValueError("metrics supplement issue_close_activity must be a list")
+
+    numbers: set[int] = set()
+    for index, row in enumerate(raw_activity):
+        if not isinstance(row, dict):
+            raise ValueError(f"issue_close_activity[{index}] must be an object")
+        if row.get("schema_version") != ISSUE_CLOSE_ACTIVITY_SCHEMA_VERSION:
+            raise ValueError(
+                f"issue_close_activity[{index}] must use "
+                f"{ISSUE_CLOSE_ACTIVITY_SCHEMA_VERSION}"
+            )
+        match = re.fullmatch(r"issues_(\d+)", str(row.get("issue_ref") or ""))
+        if match is None:
+            raise ValueError(
+                f"issue_close_activity[{index}].issue_ref must use issues_<number>"
+            )
+        numbers.add(int(match.group(1)))
     return sorted(numbers)
 
 
@@ -294,6 +326,7 @@ def collect_public_github_repository_snapshot(
     baseline_snapshot: dict[str, Any],
     feasibility_rows: list[dict[str, Any]],
     pr_lifecycle_rows: list[dict[str, Any]],
+    metrics_supplement: dict[str, Any] | None = None,
     generated_at: str,
     timeout_seconds: int = 30,
 ) -> dict[str, Any]:
@@ -334,9 +367,17 @@ def collect_public_github_repository_snapshot(
     ):
         raise ValueError("public GitHub stock and flow do not reconcile")
 
-    issue_numbers = _reference_numbers(
+    feasibility_issue_numbers = _reference_numbers(
         feasibility_rows, repo=repo, ref_field="issue_ref"
     )
+    supplement_issue_numbers = _supplement_issue_reference_numbers(
+        metrics_supplement
+    )
+    issue_numbers = sorted(
+        set(feasibility_issue_numbers) | set(supplement_issue_numbers)
+    )
+    if len(issue_numbers) > 50:
+        raise ValueError("at most 50 issue_ref references may be refreshed")
     pr_numbers = _reference_numbers(pr_lifecycle_rows, repo=repo, ref_field="pr_ref")
     with ThreadPoolExecutor(
         max_workers=min(8, max(1, len(issue_numbers) + len(pr_numbers)))
@@ -376,7 +417,14 @@ def collect_public_github_repository_snapshot(
         "source_contract": {
             "provider": "public_github_cli",
             "reads_existing_issue_fix_domain_state": True,
+            "reads_metrics_supplement": metrics_supplement is not None,
             "writes_source_state": False,
+        },
+        "source_summary": {
+            "feasibility_issue_refs": len(feasibility_issue_numbers),
+            "supplement_issue_refs": len(supplement_issue_numbers),
+            "issue_refs_collected": len(issue_numbers),
+            "pr_lifecycle_refs": len(pr_numbers),
         },
         "external_reads_performed": True,
         "external_writes_performed": False,


### PR DESCRIPTION
## Summary

- add an optional `--supplement-json` input to `issue-fix repository-snapshot`
- include deduplicated close recommendation/request/close/reopen issue refs in bounded current-state collection
- expose compact source counts and document the single-source metrics workflow

## Issue Or Task

- Closes #
- Contributor task ID: issue-fix repository snapshot close-activity coverage

## Validation

- [x] `python3 -m py_compile loopx/capabilities/issue_fix/repository_snapshot.py loopx/capabilities/issue_fix/cli.py examples/issue-fix-repository-snapshot-smoke.py`
- [x] `loopx check --scan-path docs/capabilities/issue-fix/protocols/issue-fix-metrics-projection-v0.md --scan-path examples/issue-fix-repository-snapshot-smoke.py --scan-path loopx/capabilities/issue_fix/cli.py --scan-path loopx/capabilities/issue_fix/repository_snapshot.py`
- [x] Other: `python3 examples/issue-fix-repository-snapshot-smoke.py`
- [x] Other: `python3 examples/issue-fix-metrics-supplement-smoke.py`
- [x] Other: `python3 examples/issue-fix-metrics-projection-smoke.py`
- [x] Other: `python3 -m loopx.cli --format json canary premerge --from-git-diff --tier standard --timeout-seconds 120 --no-progress` (17/17 selected checks passed; no warnings or manual holds)
- [ ] Local `pytest` was not run because the system Python lacks the optional pytest dependency; required CI remains authoritative.

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
