### PR TITLE
Reuse shared harness helpers in todo smokes

### DIFF
--- a/examples/control_plane/todo-cli-smoke.py
+++ b/examples/control_plane/todo-cli-smoke.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-import json
-import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -14,6 +12,11 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from loopx.control_plane.testing.canary_harness import (  # noqa: E402
+    run_json_cli,
+    run_json_cli_result,
+    write_fixture_registry,
+)
 from loopx.status import parse_active_state_todos  # noqa: E402
 from loopx.quota import build_quota_should_run  # noqa: E402
 
@@ -47,77 +50,34 @@ def write_fixture(root: Path, *, register_agents: bool = True) -> tuple[Path, Pa
         "- Choose the next bounded step.\n",
         encoding="utf-8",
     )
-    registry_path.parent.mkdir(parents=True)
-    goal = {
-        "id": GOAL_ID,
-        "domain": "todo-cli-fixture",
-        "status": "active",
-        "repo": str(project),
-        "state_file": ".codex/goals/todo-cli-goal/ACTIVE_GOAL_STATE.md",
-        "adapter": {"kind": "generic_project_goal_v0", "status": "connected"},
-        "authority_sources": [],
-    }
-    if register_agents:
-        goal["coordination"] = {
-            "registered_agents": ["codex-main-control", "codex-side-bypass"],
-            "agent_model": "peer_v1",
-        }
-    registry_path.write_text(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "updated_at": "2026-01-01T00:00:00+00:00",
-                "common_runtime_root": str(runtime),
-                "goals": [goal],
-            },
-            ensure_ascii=False,
-            indent=2,
-        )
-        + "\n",
-        encoding="utf-8",
+    write_fixture_registry(
+        project=project,
+        runtime_root=runtime,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        domain="todo-cli-fixture",
+        adapter_kind="generic_project_goal_v0",
+        registered_agents=("codex-main-control", "codex-side-bypass")
+        if register_agents
+        else None,
+        quota_allowed_slots=None,
     )
     return registry_path, state_file
 
 
 def run_cli(registry_path: Path, *args: str) -> dict:
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "loopx.cli",
-            "--registry",
-            str(registry_path),
-            "--format",
-            "json",
-            *args,
-        ],
-        cwd=REPO_ROOT,
-        check=True,
-        text=True,
-        capture_output=True,
+    return run_json_cli(
+        *args,
+        registry_path=registry_path,
+        include_returncode=False,
     )
-    return json.loads(result.stdout)
 
 
 def run_cli_error(registry_path: Path, *args: str) -> dict:
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "loopx.cli",
-            "--registry",
-            str(registry_path),
-            "--format",
-            "json",
-            *args,
-        ],
-        cwd=REPO_ROOT,
-        check=False,
-        text=True,
-        capture_output=True,
-    )
-    assert result.returncode != 0, result.stdout
-    return json.loads(result.stdout)
+    returncode, payload = run_json_cli_result(*args, registry_path=registry_path)
+    assert returncode != 0, payload
+    payload.pop("_returncode", None)
+    return payload
 
 
 def main() -> int:

--- a/examples/control_plane/todo-list-event-projection-smoke.py
+++ b/examples/control_plane/todo-list-event-projection-smoke.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-import json
-import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -14,6 +12,10 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from loopx.control_plane.testing.canary_harness import (  # noqa: E402
+    run_json_cli,
+    write_fixture_registry,
+)
 from loopx.event_sourced_state import (  # noqa: E402
     AppendOnlyStateEventStore,
     TODO_ADDED,
@@ -55,36 +57,23 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
         f"task_class=advancement_task resume_when=todo_done:{GATE_TODO_ID} -->\n",
         encoding="utf-8",
     )
-    registry_path.parent.mkdir(parents=True)
-    registry_path.write_text(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "updated_at": "2026-01-01T00:00:00+00:00",
-                "common_runtime_root": str(runtime),
-                "goals": [
-                    {
-                        "id": GOAL_ID,
-                        "domain": "todo-list-fixture",
-                        "status": "active",
-                        "repo": str(project),
-                        "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
-                        "state_event_log": f".codex/goals/{GOAL_ID}/events.jsonl",
-                        "adapter": {"kind": "generic_project_goal_v0", "status": "connected"},
-                        "coordination": {
-                            "registered_agents": [PRIMARY_AGENT, SIDE_AGENT],
-                            "agent_model": "peer_v1",
-                            "side_agent_handoff_agent": SIDE_AGENT,
-                        },
-                        "authority_sources": [],
-                    }
-                ],
-            },
-            ensure_ascii=False,
-            indent=2,
-        )
-        + "\n",
-        encoding="utf-8",
+    write_fixture_registry(
+        project=project,
+        runtime_root=runtime,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        domain="todo-list-fixture",
+        adapter_kind="generic_project_goal_v0",
+        state_event_log=f".codex/goals/{GOAL_ID}/events.jsonl",
+        registered_agents=(PRIMARY_AGENT, SIDE_AGENT),
+        quota_allowed_slots=None,
+        extra_goal_fields={
+            "coordination": {
+                "registered_agents": [PRIMARY_AGENT, SIDE_AGENT],
+                "agent_model": "peer_v1",
+                "side_agent_handoff_agent": SIDE_AGENT,
+            }
+        },
     )
     return registry_path, state_file, event_log
 
@@ -102,23 +91,11 @@ def event(event_id: str, event_type: str, todo_id: str, payload: dict) -> dict:
 
 
 def run_cli(registry_path: Path, *args: str) -> dict:
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "loopx.cli",
-            "--registry",
-            str(registry_path),
-            "--format",
-            "json",
-            *args,
-        ],
-        cwd=REPO_ROOT,
-        check=True,
-        text=True,
-        capture_output=True,
+    return run_json_cli(
+        *args,
+        registry_path=registry_path,
+        include_returncode=False,
     )
-    return json.loads(result.stdout)
 
 
 def write_events(event_log: Path) -> None:

--- a/examples/control_plane/todo-write-correctness-smoke.py
+++ b/examples/control_plane/todo-write-correctness-smoke.py
@@ -18,6 +18,10 @@ if str(REPO_ROOT) not in sys.path:
 from loopx.control_plane.runtime.local_state_write_correctness import (  # noqa: E402
     shadow_validate_local_state_write_correctness_packet,
 )
+from loopx.control_plane.testing.canary_harness import (  # noqa: E402
+    run_json_cli,
+    write_fixture_registry,
+)
 
 GOAL_ID = "todo-write-correctness-goal"
 AGENT_ID = "codex-product-capability"
@@ -41,39 +45,26 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
         "  <!-- loopx:todo todo_id=todo_existing status=open task_class=advancement_task -->\n",
         encoding="utf-8",
     )
-    registry_path.parent.mkdir(parents=True)
-    registry_path.write_text(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "updated_at": "2026-01-01T00:00:00+00:00",
-                "common_runtime_root": str(runtime),
-                "goals": [
-                    {
-                        "id": GOAL_ID,
-                        "domain": "todo-write-correctness-fixture",
-                        "status": "active",
-                        "repo": str(project),
-                        "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
-                        "adapter": {"kind": "generic_project_goal_v0", "status": "connected"},
-                        "authority_sources": [],
-                        "coordination": {
-                            "registered_agents": ["codex-main-control", AGENT_ID],
-                            "agent_model": "peer_v1",
-                        },
-                    }
-                ],
-            },
-            ensure_ascii=False,
-            indent=2,
-        )
-        + "\n",
-        encoding="utf-8",
+    write_fixture_registry(
+        project=project,
+        runtime_root=runtime,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        domain="todo-write-correctness-fixture",
+        adapter_kind="generic_project_goal_v0",
+        registered_agents=("codex-main-control", AGENT_ID),
+        quota_allowed_slots=None,
     )
     return registry_path, state_file, project
 
 
 def run_cli(registry_path: Path, *args: str, as_json: bool = True) -> dict | str:
+    if as_json:
+        return run_json_cli(
+            *args,
+            registry_path=registry_path,
+            include_returncode=False,
+        )
     command = [
         sys.executable,
         "-m",
@@ -81,8 +72,6 @@ def run_cli(registry_path: Path, *args: str, as_json: bool = True) -> dict | str
         "--registry",
         str(registry_path),
     ]
-    if as_json:
-        command.extend(["--format", "json"])
     command.extend(args)
     result = subprocess.run(
         command,
@@ -91,7 +80,7 @@ def run_cli(registry_path: Path, *args: str, as_json: bool = True) -> dict | str
         text=True,
         capture_output=True,
     )
-    return json.loads(result.stdout) if as_json else result.stdout
+    return result.stdout
 
 
 def assert_packet(

--- a/loopx/control_plane/testing/canary_harness.py
+++ b/loopx/control_plane/testing/canary_harness.py
@@ -108,17 +108,18 @@ def write_fixture_registry(
     status: str = "active",
     state_file: str | None = None,
     state_event_log: str | None = None,
-    registered_agents: Iterable[str] = (),
+    registered_agents: Iterable[str] | None = (),
     quota_allowed_slots: int | None = 10,
     peer_independent_worktree_required: bool | None = None,
     extra_goal_fields: dict[str, Any] | None = None,
 ) -> Path:
     state_file_value = state_file or default_state_file(goal_id)
-    agents = list(registered_agents)
-    coordination: dict[str, Any] = {
-        "registered_agents": agents,
-        "agent_model": "peer_v1",
-    }
+    coordination: dict[str, Any] | None = None
+    if registered_agents is not None:
+        coordination = {
+            "registered_agents": list(registered_agents),
+            "agent_model": "peer_v1",
+        }
 
     goal: dict[str, Any] = {
         "id": goal_id,
@@ -130,9 +131,10 @@ def write_fixture_registry(
             "kind": adapter_kind,
             "status": adapter_status,
         },
-        "coordination": coordination,
         "authority_sources": [],
     }
+    if coordination is not None:
+        goal["coordination"] = coordination
     if quota_allowed_slots is not None:
         goal["quota"] = {
             "compute": 1.0,


### PR DESCRIPTION
## Summary
- reuse the shipped canary harness for three todo control-plane smoke fixtures and JSON CLI calls
- let fixture registries explicitly omit coordination for legacy identity cases
- remove 72 net lines of duplicated registry and subprocess setup while preserving each smoke contract

## Validation
- `python examples/control_plane/todo-cli-smoke.py`
- `python examples/control_plane/todo-list-event-projection-smoke.py`
- `python examples/control_plane/todo-write-correctness-smoke.py`
- `python -m ruff check` on all four touched files
- `python -m pytest -q` (318 passed, 2 skipped)
- `loopx canary premerge --from-git-diff` (13/13 selected checks passed; no manual holds)
- `git diff --check`

## Boundary
- no runtime behavior, benchmark semantics, private state, credentials, raw evidence, local paths, or generated logs
- cleanup is limited to reusable public test-fixture plumbing and the three affected durable smokes