### PR TITLE
Scope autonomous replans to the causal peer frontier

### DIFF
--- a/examples/control_plane/autonomous-replan-obligation-readmodel-smoke.py
+++ b/examples/control_plane/autonomous-replan-obligation-readmodel-smoke.py
@@ -35,6 +35,7 @@ AGENT_TODOS = {
         {
             "priority": "P2",
             "text": "[P2] Continue canary-gated control-plane read-model cleanup.",
+            "claimed_by": "codex-control-plane",
         }
     ]
 }
@@ -151,6 +152,15 @@ def main() -> int:
     assert regular["stall_threshold"] == AUTONOMOUS_REPLAN_STALL_THRESHOLD, regular
     assert regular["todo_actions"][0]["action"] == "split", regular
     assert regular["todo_actions"][1]["action"] == "add", regular
+    assert regular["agent_id"] == "codex-control-plane", regular
+
+    conflicting_agents = assert_parity(
+        [
+            {"kind": "no_progress_streak", "agent_id": "codex-a"},
+            {"kind": "repeated_action_loop", "agent_id": "codex-b"},
+        ]
+    )
+    assert "agent_id" not in conflicting_agents, conflicting_agents
 
     dead_monitor = assert_parity(
         [
@@ -185,6 +195,7 @@ def main() -> int:
     assert state_wrapper == state_direct, (state_wrapper, state_direct)
     assert state_wrapper is not None, state_wrapper
     assert state_wrapper["trigger_count"] == 3, state_wrapper
+    assert state_wrapper["agent_id"] == "codex-control-plane", state_wrapper
     assert [item["kind"] for item in state_wrapper["triggers"]] == [
         "no_progress_streak",
         "repeated_action_loop",

--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -21,7 +21,7 @@ from loopx.control_plane.goals.goal_frontier import (  # noqa: E402
 from loopx.control_plane.todos.quota_summary import (  # noqa: E402
     select_quota_todo_summary,
 )
-from loopx.status import compact_todo_group  # noqa: E402
+from loopx.status import build_autonomous_replan_obligation, compact_todo_group  # noqa: E402
 
 
 GOAL_ID = "replan-decision-plane-fixture"
@@ -1259,6 +1259,47 @@ def assert_unscoped_peer_replan_has_one_deterministic_owner() -> None:
     ), reversed_guard
 
 
+def assert_state_replan_follows_claimed_frontier_not_monitor_peer() -> None:
+    items = [primary_claimed_advancement(), monitor_item()]
+    agent_todos = compact_todo_group(
+        items,
+        source_section="Agent Todo",
+        role="agent",
+    )
+    obligation = build_autonomous_replan_obligation(
+        [
+            {
+                "kind": "no_progress_streak",
+                "section": "Next Action",
+                "text": "Keep the primary peer's blocked action fail-closed.",
+            }
+        ],
+        agent_todos=agent_todos,
+    )
+    assert obligation is not None, obligation
+    assert obligation["agent_id"] == PRIMARY_AGENT, obligation
+
+    payload = status_payload(items, replan_obligation=obligation)
+    primary_guard = build_quota_should_run(
+        payload,
+        goal_id=GOAL_ID,
+        agent_id=PRIMARY_AGENT,
+    )
+    assert primary_guard["effective_action"] == "autonomous_replan_required", primary_guard
+    assert primary_guard["autonomous_replan_scope"]["scope"] == (
+        "explicit_agent_owner"
+    ), primary_guard
+
+    monitor_guard = build_quota_should_run(
+        payload,
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert monitor_guard.get("autonomous_replan_obligation") is None, monitor_guard
+    assert monitor_guard["effective_action"] == "monitor_quiet_skip", monitor_guard
+    assert monitor_guard["interaction_contract"]["mode"] == "monitor_quiet_skip", monitor_guard
+
+
 def assert_monitor_schedule_gap_requires_bounded_repair() -> None:
     guard = build_quota_should_run(
         status_payload([monitor_item(cadence=None, next_due_at=None)], replan_obligation=None),
@@ -1495,6 +1536,7 @@ def main() -> None:
     assert_satisfied_vision_checkpoint_supersedes_older_missing_but_not_empty_frontier()
     assert_agent_scoped_replan_beats_agent_scope_wait()
     assert_unscoped_peer_replan_has_one_deterministic_owner()
+    assert_state_replan_follows_claimed_frontier_not_monitor_peer()
     assert_monitor_schedule_gap_requires_bounded_repair()
     assert_agent_ack_survives_other_agent_run_and_monitor_poll()
     assert_non_frontier_replan_ack_does_not_clear_monitor_replan()

--- a/loopx/control_plane/work_items/autonomous_replan_obligation.py
+++ b/loopx/control_plane/work_items/autonomous_replan_obligation.py
@@ -48,6 +48,15 @@ def normalized_run_history_stall_signature(value: str) -> str:
     return re.sub(r"\s+", " ", value.strip().lower())
 
 
+def _single_public_agent_id(items: list[dict[str, Any]]) -> str | None:
+    agent_ids = {
+        str(item.get("agent_id") or "").strip()
+        for item in items
+        if isinstance(item, dict) and str(item.get("agent_id") or "").strip()
+    }
+    return next(iter(agent_ids)) if len(agent_ids) == 1 else None
+
+
 def run_history_monitor_target(run: dict[str, Any]) -> dict[str, Any] | None:
     target = run.get("monitor_target")
     if isinstance(target, dict):
@@ -94,6 +103,7 @@ def run_history_stall_signal(
     signal = {
         "classification": classification,
         "generated_at": str(run.get("generated_at") or ""),
+        "agent_id": str(run.get("agent_id") or "").strip() or None,
         "recommended_action": recommended_action,
         "delivery_outcome": delivery_outcome.value if delivery_outcome else None,
         "signature": normalized_run_history_stall_signature(action_or_classification),
@@ -173,6 +183,7 @@ def autonomous_replan_periodic_review_from_runs(
             "threshold": periodic_run_threshold,
             "latest_generated_at": str(durable_runs[0].get("generated_at") or ""),
             "oldest_counted_generated_at": str(durable_runs[-1].get("generated_at") or ""),
+            "agent_id": _single_public_agent_id(durable_runs),
         }
     ]
     return build_autonomous_replan_obligation(evidence, agent_todos=agent_todos)
@@ -235,6 +246,11 @@ def build_autonomous_replan_obligation(
         open_items = agent_todos.get("first_open_items")
         if isinstance(open_items, list) and open_items and isinstance(open_items[0], dict):
             first_open = open_items[0]
+
+    evidence_has_agent_attribution = any("agent_id" in item for item in evidence)
+    replan_agent_id = _single_public_agent_id(evidence)
+    if replan_agent_id is None and not evidence_has_agent_attribution:
+        replan_agent_id = str(first_open.get("claimed_by") or "").strip() or None
 
     todo_actions: list[dict[str, Any]] = []
     first_open_text = public_safe_compact_text(first_open.get("text"), limit=140)
@@ -330,6 +346,7 @@ def build_autonomous_replan_obligation(
             "production actions, or owner-only decisions"
         ),
         recommended_action=recommended_action,
+        agent_id=replan_agent_id,
     )
     if dead_monitor_evidence:
         result["dead_monitor_detector"] = {
@@ -479,6 +496,7 @@ def autonomous_replan_obligation_from_runs(
                 "threshold": dead_monitor_repeat_threshold,
                 "monitor_target_id": monitor_target_id,
                 "latest_generated_at": signals[0].get("generated_at"),
+                "agent_id": _single_public_agent_id(monitor_signals),
             }
         ]
         return build_autonomous_replan_obligation(evidence, agent_todos=agent_todos)
@@ -498,6 +516,7 @@ def autonomous_replan_obligation_from_runs(
             "text": evidence_text,
             "run_count": len(stall_signals),
             "latest_generated_at": stall_signals[0].get("generated_at"),
+            "agent_id": _single_public_agent_id(stall_signals),
         }
     ]
     return build_autonomous_replan_obligation(evidence, agent_todos=agent_todos)


### PR DESCRIPTION
Summary:
- Preserve the unique agent identity on run-history replan evidence.
- When state-authored replan evidence has no explicit actor, bind it to the claimed first agent frontier instead of broadcasting it across registered peers.
- Keep genuinely unscoped or conflicting evidence on the existing deterministic coordination path.

Validation:
- autonomous-replan obligation read-model smoke
- quota replan decision-plane smoke
- heartbeat quota flow, work-lane, and integrated control-plane smokes
- real registry source-CLI parity check for peer isolation
- LoopX standard premerge gate: 17/17 checks passed
- public/private boundary scan: clean

Risk:
The change only adds causal attribution to the existing replan payload. Conflicting explicit agent evidence remains unscoped, and existing deterministic assignment semantics are preserved for truly unowned replans.