### PR TITLE
test: align scheduler failure smoke contract

### DIFF
--- a/examples/control_plane/quota-plan-smoke.py
+++ b/examples/control_plane/quota-plan-smoke.py
@@ -1044,9 +1044,10 @@ def assert_heartbeat_recommendation_lifecycle() -> None:
     assert local_scheduler["max_interval_minutes"] == 240, local_scheduler
     assert stateful_detail["host_max_interval_minutes"] == 60, stateful_detail
     assert stateful_detail["coarser_wait_fallback"] == "local_scheduler_only", stateful_detail
-    assert stateful_detail["host_update_failure"] == (
-        "no_retry_same_turn_do_not_ack_keep_observed_rrule"
-    ), stateful_detail
+    assert "suppress_exact_repeat" in stateful_detail["host_update_failure"], stateful_detail
+    assert stateful_detail["ack_required_after_apply"] is True, stateful_detail
+    assert stateful_detail["ack_required_from_host_match"] is False, stateful_detail
+    assert "host_update_failure" in stateful_detail["persist"].split("|"), stateful_detail
 
 
 def assert_goal_boundary_in_should_run() -> None:


### PR DESCRIPTION
## Summary

- update the quota plan smoke for the persisted scheduler host-failure contract introduced in #2117
- assert durable behavior fields instead of the retired turn-local failure string

## Validation

- `python3 examples/control_plane/quota-plan-smoke.py`
- full-public shard offset 200, limit 100
- `loopx canary premerge --from-git-diff` (5/5 selected checks passed; self-merge allowed)
- public/private boundary scan clean

Fixes the Full Public Smokes failure on main run 29380874783.