### PR TITLE
fix: keep benchmark running during probe transport loss

### DIFF
--- a/examples/skillsbench-reverse-tunnel-supervisor-smoke.py
+++ b/examples/skillsbench-reverse-tunnel-supervisor-smoke.py
@@ -100,6 +100,7 @@ def _flaky_fake_ssh(
     *,
     first_tunnel_exits: bool,
     probe_delay_sec: float = 0.0,
+    probe_failure_exit_code: int = 42,
 ) -> None:
     generation_path = state_dir / "tunnel-generation"
     probe_count_path = state_dir / "probe-count"
@@ -115,6 +116,7 @@ generation_path = Path({str(generation_path)!r})
 probe_count_path = Path({str(probe_count_path)!r})
 first_tunnel_exits = {first_tunnel_exits!r}
 probe_delay_sec = {probe_delay_sec!r}
+probe_failure_exit_code = {probe_failure_exit_code!r}
 args = sys.argv[1:]
 with log_path.open("a", encoding="utf-8") as handle:
     handle.write(repr(args) + "\\n")
@@ -145,7 +147,7 @@ if "LOOPX_REVERSE_TUNNEL_PROBE" in remote_command:
     if first_tunnel_exits or generation >= 2 or count == 0:
         print("HTTP/1.1 200 Connection Established")
         sys.exit(0)
-    sys.exit(42)
+    sys.exit(probe_failure_exit_code)
 
 if "run-long-skillsbench" in remote_command:
     time.sleep(0.9)
@@ -357,6 +359,63 @@ def test_supervisor_preserves_live_tunnel_and_fails_closed() -> None:
         ssh_log_text = ssh_log.read_text(encoding="utf-8")
         assert ssh_log_text.count("'-R'") == 1, ssh_log_text
         assert "benchmark_remote_public_artifact_collection_v0" not in ssh_log_text
+
+
+def test_supervisor_keeps_running_when_ssh_probe_transport_is_unavailable() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-tunnel-probe-transport-") as tmp:
+        root = Path(tmp)
+        fake_ssh = root / "ssh"
+        ssh_log = root / "ssh.log"
+        _flaky_fake_ssh(
+            fake_ssh,
+            ssh_log,
+            root,
+            first_tunnel_exits=False,
+            probe_failure_exit_code=255,
+        )
+
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--ssh-bin",
+                str(fake_ssh),
+                "--ssh-destination",
+                "opaque-benchmark-host.example",
+                "--remote-command",
+                "run-long-skillsbench --batch-size 6",
+                "--tunnel-ready-timeout-sec",
+                "2",
+                "--probe-interval-sec",
+                "0.05",
+                "--tunnel-health-interval-sec",
+                "0.05",
+                "--tunnel-health-failure-threshold",
+                "2",
+                "--tunnel-reconnect-attempts",
+                "1",
+                "--run-timeout-sec",
+                "5",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 0, proc.stderr or proc.stdout
+        payload = json.loads(proc.stdout)
+        assert payload["ok"] is True, payload
+        assert payload["remote_command_exit_code"] == 0, payload
+        liveness = payload["tunnel_liveness"]
+        assert liveness["state"] == "degraded", liveness
+        assert liveness["health_probe_inconclusive_count"] >= 2, liveness
+        assert liveness["max_consecutive_inconclusive_count"] >= 2, liveness
+        assert liveness["health_probe_failure_count"] == 0, liveness
+        assert liveness["reconnect_attempt_count"] == 0, liveness
+        assert liveness["last_probe_status"] == "ssh_transport_unavailable", liveness
+        ssh_log_text = ssh_log.read_text(encoding="utf-8")
+        assert ssh_log_text.count("'-R'") == 1, ssh_log_text
 
 
 def test_supervisor_timeout_does_not_sync_live_artifacts() -> None:
@@ -782,6 +841,7 @@ if __name__ == "__main__":
     test_supervisor_holds_tunnel_and_redacts_private_command()
     test_supervisor_reconnects_after_tunnel_process_exit()
     test_supervisor_preserves_live_tunnel_and_fails_closed()
+    test_supervisor_keeps_running_when_ssh_probe_transport_is_unavailable()
     test_supervisor_timeout_does_not_sync_live_artifacts()
     test_liveness_probe_cannot_cross_deadline_and_sync_artifacts()
     test_supervisor_syncs_only_compact_public_artifacts()

--- a/scripts/skillsbench_reverse_tunnel_supervisor.py
+++ b/scripts/skillsbench_reverse_tunnel_supervisor.py
@@ -491,6 +491,8 @@ def _run_remote_probe(
         return True, "http_connect_ready"
     if " 407 " in f" {output} ":
         return False, "proxy_auth_required"
+    if proc.returncode == 255:
+        return False, "ssh_transport_unavailable"
     if proc.returncode != 0:
         return False, "probe_exit_nonzero"
     return False, "proxy_connect_rejected"
@@ -559,7 +561,9 @@ def _tunnel_liveness_public_contract(args: argparse.Namespace) -> dict[str, Any]
         "health_probe_attempt_count": 0,
         "health_probe_success_count": 0,
         "health_probe_failure_count": 0,
+        "health_probe_inconclusive_count": 0,
         "max_consecutive_failure_count": 0,
+        "max_consecutive_inconclusive_count": 0,
         "reconnect_attempt_count": 0,
         "reconnect_success_count": 0,
         "reconnect_failure_count": 0,
@@ -1032,6 +1036,7 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
             health_interval = max(0.0, float(args.tunnel_health_interval_sec))
             next_health_probe = time.monotonic() + health_interval
             consecutive_failures = 0
+            consecutive_inconclusive = 0
             if liveness["enabled"]:
                 liveness["state"] = "healthy"
 
@@ -1071,11 +1076,29 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
                         int(liveness["health_probe_success_count"]) + 1
                     )
                     consecutive_failures = 0
+                    consecutive_inconclusive = 0
                     if liveness["state"] != "reconnected":
                         liveness["state"] = "healthy"
                     next_health_probe = time.monotonic() + health_interval
                     continue
 
+                if (
+                    health_status == "ssh_transport_unavailable"
+                    and tunnel_proc.poll() is None
+                ):
+                    liveness["health_probe_inconclusive_count"] = (
+                        int(liveness["health_probe_inconclusive_count"]) + 1
+                    )
+                    consecutive_inconclusive += 1
+                    liveness["max_consecutive_inconclusive_count"] = max(
+                        int(liveness["max_consecutive_inconclusive_count"]),
+                        consecutive_inconclusive,
+                    )
+                    liveness["state"] = "degraded"
+                    next_health_probe = time.monotonic() + health_interval
+                    continue
+
+                consecutive_inconclusive = 0
                 liveness["health_probe_failure_count"] = (
                     int(liveness["health_probe_failure_count"]) + 1
                 )
@@ -1147,6 +1170,7 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
                         )
                         liveness["state"] = "reconnected"
                         consecutive_failures = 0
+                        consecutive_inconclusive = 0
                         recovered = True
                         break
                     liveness["reconnect_failure_count"] = (


### PR DESCRIPTION
## Summary\n- Treat SSH exit 255 during long-run health probes as transport-observation loss, not proof that a live reverse tunnel failed.\n- Keep the remote benchmark process running while recording degraded, inconclusive liveness counters.\n- Preserve fail-closed behavior for confirmed CONNECT failures and tunnel-process exit.\n\n## Validation\n- PASS: python3 examples/skillsbench-reverse-tunnel-supervisor-smoke.py\n- PASS: python3 examples/skillsbench-benchmark-run-smoke.py\n- PASS: python3 -m py_compile on both changed Python files\n- PASS: git diff --check\n- PASS: loopx check\n- PASS: loopx canary premerge automated checks (diff, compile, four catalog canaries, public boundary)\n- BASELINE FAIL: python3 examples/skillsbench-host-local-launch-plan-smoke.py at line 446; reproduced unchanged on origin/main afc887d4.\n\n## Boundaries\n- No benchmark jobs launched; no scoring, task semantics, submission, permission, or credential behavior changed.\n- No private state, raw trajectories/logs, verifier output, credentials, local paths, or generated artifacts included.\n\n## Residual risk\n- OpenSSH exit 255 is intentionally treated as an inconclusive monitor observation during an already-running case. Initial admission preflight still fails closed when SSH is unavailable.