### PR TITLE
fix: align host-local benchmark plan parity

### DIFF
--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -817,9 +817,9 @@ if out:
                 "launch_plan"
             ]["runner_prerequisites"]
             assert (
-                auto_wiring_prereqs["remote_command_file_bridge_consumption_status"]
-                == "sandbox_bridge_auto_wiring_pending"
-            ), auto_wiring_prereqs
+                auto_wiring_prereqs["remote_command_file_bridge_consumption_status"],
+                auto_wiring_prereqs["container_codex_acp_install_skipped"],
+            ) == ("sandbox_bridge_auto_wiring_pending", True), auto_wiring_prereqs
             source = SCRIPT.read_text(encoding="utf-8")
             assert "_host_local_acp_docker_bridge_command(" in source
             assert 'prerequisites["remote_command_file_bridge_command_configured"] = True' in source

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -8646,7 +8646,11 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             "host_local_acp_codex_exec_preflight_first_blocker": "",
             "container_codex_acp_install_skipped": (
                 True
-                if is_app_server_goal_route or is_codex_cli_goal_route
+                if (
+                    is_app_server_goal_route
+                    or is_codex_cli_goal_route
+                    or args.host_local_acp_launch
+                )
                 else requires_preinstalled_runtime
             ),
             "benchflow_agent_install_skipped_by_runtime_layer": (


### PR DESCRIPTION
## Summary
- report container Codex ACP install as skipped for every host-local ACP plan
- cover both LoopX host-local routes in the durable launch-plan smoke
- keep plan-only matched audits aligned with the runtime behavior already in use

## Validation
- `python3 examples/skillsbench-host-local-launch-plan-smoke.py`
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 examples/skillsbench-runtime-layer-launch-plan-smoke.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-host-local-launch-plan-smoke.py`
- `loopx check` (passes with one unrelated existing duplicate-index warning)
- `loopx canary premerge --from-git-diff` (all automated checks pass; benchmark-sensitive manual hold covered by explicit owner self-merge authorization)

## Boundary
No scoring, task semantics, runner launch behavior, upload/submission behavior, permissions, credentials, raw benchmark evidence, or private paths are changed.