### PR TITLE
Fix batched Explore visual marker readback

### DIFF
--- a/examples/explore-result-layer-smoke.py
+++ b/examples/explore-result-layer-smoke.py
@@ -39,6 +39,7 @@ from loopx.capabilities.explore.worker_branch_plan import (  # noqa: E402
     build_explore_worker_branch_plan,
 )
 from loopx.presentation.sinks.lark import explore_results  # noqa: E402
+from loopx.presentation.sinks.lark import explore_visual_readback  # noqa: E402
 from loopx.presentation.sinks.lark import explore_visual_styles  # noqa: E402
 
 # Both exploration planners are deny-by-default behind the per-goal
@@ -459,17 +460,14 @@ def check_visual_marker_readback_retry_contract() -> None:
             "timed_out": False,
         }
 
-    original_delays = explore_results._VISUAL_READBACK_RETRY_DELAYS_SECONDS
-    explore_results._VISUAL_READBACK_RETRY_DELAYS_SECONDS = (0.0,)
-    try:
-        settled = explore_results._readback_visual_delivery_marker(
-            config,
-            whiteboard_token="wb_public_fixture",
-            marker=marker,
-            runner=settling_runner,
-        )
-    finally:
-        explore_results._VISUAL_READBACK_RETRY_DELAYS_SECONDS = original_delays
+    settled = explore_visual_readback.readback_visual_delivery_marker(
+        cli_bin=config.cli_bin,
+        identity=config.identity,
+        whiteboard_token="wb_public_fixture",
+        marker=marker,
+        runner=settling_runner,
+        retry_delays=(0.0,),
+    )
     assert settled["ok"] is True and settled["verified"] is True, settled
     assert settled["attempt_count"] == 2, settled
     assert settled["attempts"][0] == {
@@ -480,6 +478,71 @@ def check_visual_marker_readback_retry_contract() -> None:
         "retryable": True,
     }, settled
     assert settled["retryable"] is False, settled
+
+    stage_markers = {
+        "wb_stage_1": "LoopX delivery stage-1",
+        "wb_stage_2": "LoopX delivery stage-2",
+    }
+    stage_calls = {token: 0 for token in stage_markers}
+
+    def batch_settling_runner(
+        args: list[str], cwd: Path | None, timeout: float | None
+    ) -> dict[str, object]:
+        token = args[args.index("--whiteboard-token") + 1]
+        stage_calls[token] += 1
+        marker = stage_markers[token] if stage_calls[token] > 1 else "old marker"
+        return {
+            "returncode": 0,
+            "stdout": json.dumps(
+                {"ok": True, "data": {"nodes": [{"text": {"text": marker}}]}}
+            ),
+            "stderr": "",
+            "timed_out": False,
+        }
+
+    stage_results = []
+    stage_targets = []
+    for token, marker in stage_markers.items():
+        result = {
+            "ok": False,
+            "status": "publish_unverified",
+            "published": False,
+            "command": {"ok": True},
+            "readback": {
+                "ok": False,
+                "performed": False,
+                "verified": False,
+                "source": "deferred_to_batch",
+                "expected_marker": marker,
+                "observed_marker": None,
+                "retryable": True,
+                "attempts": [],
+            },
+            "retryable": True,
+        }
+        stage_results.append(result)
+        stage_targets.append((result, token))
+
+    sleeps: list[float] = []
+    original_sleep = explore_visual_readback.time.sleep
+    explore_visual_readback.time.sleep = sleeps.append
+    try:
+        explore_visual_readback.settle_visual_stage_readbacks(
+            cli_bin=config.cli_bin,
+            identity=config.identity,
+            stage_targets=stage_targets,
+            runner=batch_settling_runner,
+            retry_delays=(0.0,),
+        )
+    finally:
+        explore_visual_readback.time.sleep = original_sleep
+    assert sleeps == [0.0], sleeps
+    assert stage_calls == {"wb_stage_1": 2, "wb_stage_2": 2}, stage_calls
+    assert all(result["ok"] is True for result in stage_results), stage_results
+    assert all(result["published"] is True for result in stage_results), stage_results
+    assert all(
+        result["readback"]["attempt_count"] == 2 for result in stage_results
+    ), stage_results
 
     summary = explore_visual_styles.summarize_explore_visual_sync(
         views={"canonical": {"ok": False, "retryable": True}},

--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -67,9 +67,9 @@ from .explore_visual_styles import (
     summarize_explore_visual_sync,
 )
 from .explore_visual_readback import (
-    is_retryable_marker_readback_error,
+    readback_visual_delivery_marker,
+    settle_visual_stage_readbacks,
     structured_command_error,
-    whiteboard_raw_texts,
 )
 from .message_card import build_lark_markdown_reply_card
 
@@ -85,8 +85,6 @@ DEFAULT_EXPLORE_BASE_NAME = "LoopX Exploration Results"
 SINK_VISIBILITY_OWNER_ONLY = "owner-only"
 SINK_VISIBILITY_SHARED = "shared"
 SINK_VISIBILITIES = {SINK_VISIBILITY_OWNER_ONLY, SINK_VISIBILITY_SHARED}
-
-_VISUAL_READBACK_RETRY_DELAYS_SECONDS = (0.25, 0.5, 1.0, 2.0, 4.0)
 
 TABLE_NODES = "nodes"
 TABLE_EDGES = "edges"
@@ -563,93 +561,6 @@ def configure_lark_explore_visual_sink(
     }
 
 
-def _readback_visual_delivery_marker(
-    config: LarkExploreConfig,
-    *,
-    whiteboard_token: str,
-    marker: str,
-    runner: CommandRunner,
-) -> dict[str, Any]:
-    command = [
-        config.cli_bin,
-        "whiteboard",
-        "+query",
-        "--as",
-        config.identity,
-        "--whiteboard-token",
-        whiteboard_token,
-        "--output_as",
-        "raw",
-        "--format",
-        "json",
-    ]
-    attempts: list[dict[str, Any]] = []
-    result: dict[str, Any] = {}
-    texts: list[str] = []
-    marker_observed = False
-    for attempt_index in range(len(_VISUAL_READBACK_RETRY_DELAYS_SECONDS) + 1):
-        result = _run_command(command, execute=True, runner=runner)
-        texts = whiteboard_raw_texts(result.get("json"))
-        marker_observed = marker in texts
-        error = structured_command_error(result)
-        error_code = error.get("code")
-        error_message = str(error.get("message") or "")
-        is_query_settling = is_retryable_marker_readback_error(
-            error_code=error_code,
-            error_message=error_message,
-        )
-        is_marker_pending = bool(result.get("ok")) and not marker_observed
-        is_retryable = is_query_settling or is_marker_pending
-        attempts.append(
-            {
-                "attempt": attempt_index + 1,
-                "ok": bool(result.get("ok")),
-                "marker_observed": marker_observed,
-                "error_code": error_code,
-                "retryable": is_retryable,
-            }
-        )
-        if marker_observed or not is_retryable:
-            break
-        if attempt_index < len(_VISUAL_READBACK_RETRY_DELAYS_SECONDS):
-            time.sleep(_VISUAL_READBACK_RETRY_DELAYS_SECONDS[attempt_index])
-    command_receipt = {
-        key: result.get(key)
-        for key in (
-            "command",
-            "executed",
-            "ok",
-            "returncode",
-            "timed_out",
-            "stderr",
-        )
-        if result.get(key) not in (None, "")
-    }
-    return {
-        "ok": bool(result.get("ok") and marker_observed),
-        "schema_version": "loopx_lark_explore_visual_readback_v0",
-        "performed": True,
-        "verified": marker_observed,
-        "source": "whiteboard_raw_nodes",
-        "expected_marker": marker,
-        "observed_marker": marker if marker_observed else None,
-        "remote_text_node_count": len(texts),
-        "attempt_count": len(attempts),
-        "attempts": attempts,
-        "retryable": bool(
-            not marker_observed and attempts and attempts[-1].get("retryable")
-        ),
-        "command": command_receipt,
-        "error": (
-            None
-            if result.get("ok") and marker_observed
-            else _command_error(result)
-            if not result.get("ok")
-            else "remote whiteboard raw nodes do not contain the expected delivery marker"
-        ),
-    }
-
-
 def sync_explore_visual_to_lark(
     config: LarkExploreConfig,
     *,
@@ -661,6 +572,7 @@ def sync_explore_visual_to_lark(
     view_key: str | None = None,
     execute: bool = False,
     runner: CommandRunner = default_subprocess_runner,
+    defer_readback: bool = False,
 ) -> dict[str, Any]:
     """Publish a configured whiteboard without conflating it with Base rows."""
 
@@ -814,23 +726,30 @@ def sync_explore_visual_to_lark(
                 publish_attempts.append(result)
         finally:
             source_path.unlink(missing_ok=True)
+    readback_deferred = bool(
+        execute and result.get("ok") and delivery_marker and defer_readback
+    )
     readback: dict[str, Any] = {
-        "ok": True,
+        "ok": not readback_deferred,
         "schema_version": "loopx_lark_explore_visual_readback_v0",
         "performed": False,
         "verified": False,
         "source": (
             "not_required"
             if not delivery_marker
+            else "deferred_to_batch"
+            if readback_deferred
             else "would_query_whiteboard_raw_nodes"
         ),
         "expected_marker": delivery_marker,
         "observed_marker": None,
+        "retryable": readback_deferred,
         "error": None,
     }
-    if execute and result.get("ok") and delivery_marker:
-        readback = _readback_visual_delivery_marker(
-            config,
+    if execute and result.get("ok") and delivery_marker and not defer_readback:
+        readback = readback_visual_delivery_marker(
+            cli_bin=config.cli_bin,
+            identity=config.identity,
             whiteboard_token=whiteboard_token,
             marker=delivery_marker,
             runner=runner,
@@ -977,6 +896,7 @@ def sync_explore_visuals_to_lark(
             }
             continue
         stage_results = []
+        stage_readback_targets: list[tuple[dict[str, Any], str]] = []
         role_nodes = {
             str(node.get("node_id") or ""): node
             for node in role_view.get("nodes") or []
@@ -1017,8 +937,25 @@ def sync_explore_visuals_to_lark(
                 view_key=f"{role}_stage_{stage_index:02d}",
                 execute=execute,
                 runner=runner,
+                defer_readback=execute,
             )
-            stage_results.append(dict(stage_result, stage=dict(stage)))
+            stage_result = dict(stage_result, stage=dict(stage))
+            stage_results.append(stage_result)
+            if (
+                execute
+                and stage_result.get("retryable")
+                and str(stage_sink.get("whiteboard_token") or "").strip()
+            ):
+                stage_readback_targets.append(
+                    (stage_result, str(stage_sink["whiteboard_token"]))
+                )
+        if stage_readback_targets:
+            settle_visual_stage_readbacks(
+                cli_bin=config.cli_bin,
+                identity=config.identity,
+                stage_targets=stage_readback_targets,
+                runner=runner,
+            )
         role_ok = all(bool(item.get("ok")) for item in stage_results)
         role_retryable = any(bool(item.get("retryable")) for item in stage_results)
         role_delivery_material = "|".join(

--- a/loopx/presentation/sinks/lark/explore_visual_readback.py
+++ b/loopx/presentation/sinks/lark/explore_visual_readback.py
@@ -3,7 +3,13 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Mapping
+import time
+from typing import Any, Mapping, Sequence
+
+from .kanban import CommandRunner, _command_error, _run_command
+
+
+VISUAL_READBACK_RETRY_DELAYS_SECONDS = (0.25, 0.5, 1.0, 2.0, 4.0)
 
 
 def whiteboard_raw_texts(payload: Any) -> list[str]:
@@ -42,3 +48,177 @@ def is_retryable_marker_readback_error(
     # called only by that post-publish marker path, so it does not generalize
     # every API 2890002 response into a transient error.
     return error_code == 2890002 and "invalid arg" in error_message
+
+
+def readback_visual_delivery_marker(
+    *,
+    cli_bin: str,
+    identity: str,
+    whiteboard_token: str,
+    marker: str,
+    runner: CommandRunner,
+    retry_delays: Sequence[float] | None = None,
+) -> dict[str, Any]:
+    command = [
+        cli_bin,
+        "whiteboard",
+        "+query",
+        "--as",
+        identity,
+        "--whiteboard-token",
+        whiteboard_token,
+        "--output_as",
+        "raw",
+        "--format",
+        "json",
+    ]
+    attempts: list[dict[str, Any]] = []
+    result: dict[str, Any] = {}
+    texts: list[str] = []
+    marker_observed = False
+    effective_retry_delays = tuple(
+        VISUAL_READBACK_RETRY_DELAYS_SECONDS
+        if retry_delays is None
+        else retry_delays
+    )
+    for attempt_index in range(len(effective_retry_delays) + 1):
+        result = _run_command(command, execute=True, runner=runner)
+        texts = whiteboard_raw_texts(result.get("json"))
+        marker_observed = marker in texts
+        error = structured_command_error(result)
+        error_code = error.get("code")
+        is_retryable = is_retryable_marker_readback_error(
+            error_code=error_code,
+            error_message=str(error.get("message") or ""),
+        ) or bool(result.get("ok") and not marker_observed)
+        attempts.append(
+            {
+                "attempt": attempt_index + 1,
+                "ok": bool(result.get("ok")),
+                "marker_observed": marker_observed,
+                "error_code": error_code,
+                "retryable": is_retryable,
+            }
+        )
+        if marker_observed or not is_retryable:
+            break
+        if attempt_index < len(effective_retry_delays):
+            time.sleep(effective_retry_delays[attempt_index])
+    command_receipt = {
+        key: result.get(key)
+        for key in (
+            "command",
+            "executed",
+            "ok",
+            "returncode",
+            "timed_out",
+            "stderr",
+        )
+        if result.get(key) not in (None, "")
+    }
+    return {
+        "ok": bool(result.get("ok") and marker_observed),
+        "schema_version": "loopx_lark_explore_visual_readback_v0",
+        "performed": True,
+        "verified": marker_observed,
+        "source": "whiteboard_raw_nodes",
+        "expected_marker": marker,
+        "observed_marker": marker if marker_observed else None,
+        "remote_text_node_count": len(texts),
+        "attempt_count": len(attempts),
+        "attempts": attempts,
+        "retryable": bool(
+            not marker_observed and attempts and attempts[-1].get("retryable")
+        ),
+        "command": command_receipt,
+        "error": (
+            None
+            if result.get("ok") and marker_observed
+            else _command_error(result)
+            if not result.get("ok")
+            else "remote whiteboard raw nodes do not contain the expected delivery marker"
+        ),
+    }
+
+
+def _merge_readback_attempts(
+    previous: Mapping[str, Any], current: Mapping[str, Any]
+) -> dict[str, Any]:
+    attempts = [
+        dict(item)
+        for item in previous.get("attempts") or []
+        if isinstance(item, Mapping)
+    ]
+    for item in current.get("attempts") or []:
+        if isinstance(item, Mapping):
+            attempts.append(dict(item, attempt=len(attempts) + 1))
+    merged = dict(current)
+    merged["attempts"] = attempts
+    merged["attempt_count"] = len(attempts)
+    return merged
+
+
+def _apply_stage_readback(
+    stage_result: dict[str, Any], readback: Mapping[str, Any]
+) -> None:
+    command = stage_result.get("command")
+    command_ok = bool(isinstance(command, Mapping) and command.get("ok"))
+    delivery_ok = bool(command_ok and readback.get("ok"))
+    retryable = bool(command_ok and readback.get("retryable"))
+    stage_result.update(
+        {
+            "ok": delivery_ok,
+            "status": "published" if delivery_ok else "publish_unverified",
+            "published": delivery_ok,
+            "readback": dict(readback),
+            "retryable": retryable,
+            "required_action": (
+                "retry Explore visual sync; post-publish marker readback did not settle"
+                if retryable
+                else None
+            ),
+            "error": None
+            if delivery_ok
+            else str(readback.get("error") or "visual marker readback failed"),
+        }
+    )
+
+
+def settle_visual_stage_readbacks(
+    *,
+    cli_bin: str,
+    identity: str,
+    stage_targets: Sequence[tuple[dict[str, Any], str]],
+    runner: CommandRunner,
+    retry_delays: Sequence[float] | None = None,
+) -> None:
+    """Verify every published stage within one shared settling window."""
+
+    effective_retry_delays = tuple(
+        VISUAL_READBACK_RETRY_DELAYS_SECONDS
+        if retry_delays is None
+        else retry_delays
+    )
+    pending = list(stage_targets)
+    for attempt_index in range(len(effective_retry_delays) + 1):
+        next_pending: list[tuple[dict[str, Any], str]] = []
+        for stage_result, whiteboard_token in pending:
+            previous = stage_result.get("readback")
+            previous = previous if isinstance(previous, Mapping) else {}
+            readback = readback_visual_delivery_marker(
+                cli_bin=cli_bin,
+                identity=identity,
+                whiteboard_token=whiteboard_token,
+                marker=str(previous.get("expected_marker") or ""),
+                runner=runner,
+                retry_delays=(),
+            )
+            merged = _merge_readback_attempts(previous, readback)
+            _apply_stage_readback(stage_result, merged)
+            if merged.get("retryable"):
+                next_pending.append((stage_result, whiteboard_token))
+        pending = next_pending
+        if not pending:
+            break
+        if attempt_index < len(effective_retry_delays):
+            time.sleep(effective_retry_delays[attempt_index])


### PR DESCRIPTION
## 动机

Stage-document Explore sinks currently apply the full marker settling delay independently to every whiteboard. A multi-stage material refresh can therefore take minutes and leave a partially published document when interrupted.

## 改动思路

Separate visual marker readback from the main sink and make stage documents use a two-phase delivery: publish every configured stage first, then verify only pending markers within one shared settling window.

## 关键代码或伪代码

```text
publish all stages with deferred readback
pending = every successfully published stage
for delay in shared_settling_window:
    query each pending stage once
    remove stages whose exact delivery marker is observed
    stop when pending is empty
```

## 具体改动

- Move marker query/receipt handling into `explore_visual_readback.py`.
- Allow a single marker query to receive an explicit retry schedule.
- Defer stage-document readback until all stage writes have been attempted.
- Preserve per-stage attempt counts, exact marker receipts, retryability, and failure status.
- Add a regression proving two pending stages share one sleep window instead of sleeping once per stage.

## 修复后复现

Run `python3 examples/explore-result-layer-smoke.py`. The batch fixture makes both stage markers settle on the second query and asserts one shared delay, two attempts per stage, and verified publication for both stages.

## 验证

- `python3 examples/explore-result-layer-smoke.py`
- `python3 examples/issue-fix-explore-projection-smoke.py`
- `python3 examples/explore-executive-projection-contract-smoke.py`
- `python3 examples/explore-todo-result-node-linkage-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `./scripts/loopx canary premerge --from-git-diff` — passed, 4 selected checks, 0 failures, 0 manual holds

## 对主干的风险与未覆盖

The retry schedule and exact marker postcondition are unchanged; only the scope of the wait changes from per-stage to per-batch. Provider latency can still make the batch retryable after the bounded window, but every stage retains an independent readback receipt and no successful query is inferred from write acceptance alone.
