### PR TITLE
Fix SkillsBench LoopX cases without Python

### DIFF
--- a/examples/skillsbench-loopx-case-python-runtime-smoke.py
+++ b/examples/skillsbench-loopx-case-python-runtime-smoke.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Smoke-test route-scoped Python staging for the SkillsBench LoopX CLI."""
+
+from __future__ import annotations
+
+import tempfile
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.skillsbench_automation_loop import (
+    DOCKER_LOOPX_CASE_PYTHON_RUNTIME_BEGIN,
+    _public_task_staging,
+    patch_dockerfile_loopx_case_python_runtime,
+    stage_task_for_sandbox,
+)
+
+
+RUNNER = REPO_ROOT / "scripts" / "skillsbench_automation_loop.py"
+
+
+def _write_task(root: Path, dockerfile_text: str) -> Path:
+    task = root / "task"
+    environment = task / "environment"
+    environment.mkdir(parents=True)
+    (environment / "Dockerfile").write_text(dockerfile_text, encoding="utf-8")
+    (task / "task.toml").write_text("[task]\n", encoding="utf-8")
+    return task
+
+
+def _assert_final_stage_patch_is_idempotent() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-case-python-patch-") as temp:
+        dockerfile = Path(temp) / "Dockerfile"
+        dockerfile.write_text(
+            "FROM alpine:3.20 AS build\n"
+            "RUN echo build\n"
+            "FROM debian:bookworm-slim\n"
+            "RUN echo final\n",
+            encoding="utf-8",
+        )
+        assert patch_dockerfile_loopx_case_python_runtime(dockerfile) is True
+        assert patch_dockerfile_loopx_case_python_runtime(dockerfile) is False
+        text = dockerfile.read_text(encoding="utf-8")
+        assert text.count(DOCKER_LOOPX_CASE_PYTHON_RUNTIME_BEGIN) == 1, text
+        marker = text.index(DOCKER_LOOPX_CASE_PYTHON_RUNTIME_BEGIN)
+        assert marker > text.index("FROM debian:bookworm-slim"), text
+        assert marker < text.index("RUN echo final"), text
+        for package_manager in ("apt-get", "apk", "microdnf", "dnf", "yum"):
+            assert f"command -v {package_manager}" in text, text
+        assert "command -v python3" in text, text
+
+
+def _assert_final_scratch_stage_is_not_mutated() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-case-python-scratch-") as temp:
+        dockerfile = Path(temp) / "Dockerfile"
+        original = "FROM python:3.12 AS build\nFROM scratch\nCOPY --from=build /out /out\n"
+        dockerfile.write_text(original, encoding="utf-8")
+        assert patch_dockerfile_loopx_case_python_runtime(dockerfile) is False
+        assert dockerfile.read_text(encoding="utf-8") == original
+
+
+def _assert_staging_is_route_scoped_and_public() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-case-python-stage-") as temp:
+        root = Path(temp)
+        task = _write_task(root, "FROM debian:bookworm-slim\nRUN echo ready\n")
+        original = (task / "environment" / "Dockerfile").read_text(encoding="utf-8")
+
+        product_task, product_metadata = stage_task_for_sandbox(
+            task_path=task,
+            jobs_dir=root / "jobs",
+            job_name="product",
+            sandbox="docker",
+            loopx_case_runtime_required=True,
+        )
+        product_text = (product_task / "environment" / "Dockerfile").read_text(
+            encoding="utf-8"
+        )
+        assert product_metadata["loopx_case_python_runtime_patch_required"] is True
+        assert product_metadata["loopx_case_python_runtime_patch_applied"] is True
+        assert DOCKER_LOOPX_CASE_PYTHON_RUNTIME_BEGIN in product_text
+        assert (task / "environment" / "Dockerfile").read_text(encoding="utf-8") == original
+
+        baseline_task, baseline_metadata = stage_task_for_sandbox(
+            task_path=task,
+            jobs_dir=root / "jobs",
+            job_name="baseline",
+            sandbox="docker",
+            loopx_case_runtime_required=False,
+        )
+        baseline_text = (baseline_task / "environment" / "Dockerfile").read_text(
+            encoding="utf-8"
+        )
+        assert baseline_metadata["loopx_case_python_runtime_patch_required"] is False
+        assert baseline_metadata["loopx_case_python_runtime_patch_applied"] is False
+        assert DOCKER_LOOPX_CASE_PYTHON_RUNTIME_BEGIN not in baseline_text
+
+        public = _public_task_staging(product_metadata)
+        assert public["loopx_case_python_runtime_patch_required"] is True, public
+        assert public["loopx_case_python_runtime_patch_applied"] is True, public
+
+
+def _assert_product_route_wiring() -> None:
+    source = RUNNER.read_text(encoding="utf-8")
+    assert (
+        "loopx_case_runtime_required=_is_loopx_product_mode_route(args.route)"
+        in source
+    )
+
+
+def main() -> int:
+    _assert_final_stage_patch_is_idempotent()
+    _assert_final_scratch_stage_is_not_mutated()
+    _assert_staging_is_route_scoped_and_public()
+    _assert_product_route_wiring()
+    print("skillsbench-loopx-case-python-runtime-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -333,6 +333,12 @@ DOCKER_CODEX_ACP_RUNTIME_TOOLS_BEGIN = (
 DOCKER_CODEX_ACP_RUNTIME_TOOLS_END = (
     "# END LOOPX_SKILLSBENCH_CODEX_ACP_RUNTIME_TOOLS"
 )
+DOCKER_LOOPX_CASE_PYTHON_RUNTIME_BEGIN = (
+    "# BEGIN LOOPX_SKILLSBENCH_LOOPX_CASE_PYTHON_RUNTIME"
+)
+DOCKER_LOOPX_CASE_PYTHON_RUNTIME_END = (
+    "# END LOOPX_SKILLSBENCH_LOOPX_CASE_PYTHON_RUNTIME"
+)
 DOCKER_PIP_BOOTSTRAP_BEGIN = "# BEGIN LOOPX_SKILLSBENCH_PIP_BOOTSTRAP"
 DOCKER_PIP_BOOTSTRAP_END = "# END LOOPX_SKILLSBENCH_PIP_BOOTSTRAP"
 DOCKER_GCR_MIRROR_BEGIN = "# BEGIN LOOPX_SKILLSBENCH_GCR_MIRROR"
@@ -5645,6 +5651,8 @@ def _public_task_staging(value: Any) -> dict[str, Any]:
         "verifier_bootstrap_risk_preflight_blocked",
         "verifier_bootstrap_fail_fast_defaulted",
         "codex_acp_runtime_tools_patch_applied",
+        "loopx_case_python_runtime_patch_required",
+        "loopx_case_python_runtime_patch_applied",
         "task_skills_removed",
         "original_task_mutated",
     ):
@@ -5806,6 +5814,12 @@ def _discover_prepared_task_staging(plan: dict[str, Any]) -> dict[str, Any]:
         "dockerfile_maven_mirror_raw_url_recorded": False,
         "codex_acp_runtime_tools_patch_applied": (
             DOCKER_CODEX_ACP_RUNTIME_TOOLS_BEGIN in dockerfile_text
+        ),
+        "loopx_case_python_runtime_patch_required": (
+            DOCKER_LOOPX_CASE_PYTHON_RUNTIME_BEGIN in dockerfile_text
+        ),
+        "loopx_case_python_runtime_patch_applied": (
+            DOCKER_LOOPX_CASE_PYTHON_RUNTIME_BEGIN in dockerfile_text
         ),
         "benchmark_egress_proxy_dockerfile_env_patch_applied": (
             DOCKER_BENCHMARK_EGRESS_PROXY_BEGIN in dockerfile_text
@@ -7553,6 +7567,70 @@ def patch_dockerfile_codex_acp_runtime_tools(dockerfile: Path) -> bool:
     return True
 
 
+def patch_dockerfile_loopx_case_python_runtime(dockerfile: Path) -> bool:
+    """Ensure the final task image can execute the case-local LoopX CLI."""
+
+    if not dockerfile.exists():
+        return False
+    original = dockerfile.read_text(encoding="utf-8")
+    text = _strip_marker_block(
+        original,
+        DOCKER_LOOPX_CASE_PYTHON_RUNTIME_BEGIN,
+        DOCKER_LOOPX_CASE_PYTHON_RUNTIME_END,
+    )
+    lines = text.splitlines()
+    from_indexes = [
+        index
+        for index, line in enumerate(lines)
+        if _is_dockerfile_from_instruction(line.strip())
+    ]
+    if not from_indexes:
+        return False
+    final_from_index = from_indexes[-1]
+    if " scratch" in f" {lines[final_from_index].strip().lower()} ":
+        return False
+    block = (
+        f"{DOCKER_LOOPX_CASE_PYTHON_RUNTIME_BEGIN}\n"
+        "RUN set -eux; \\\n"
+        "    if command -v python3 >/dev/null 2>&1 || command -v python >/dev/null 2>&1; then \\\n"
+        "      exit 0; \\\n"
+        "    fi; \\\n"
+        "    if command -v apt-get >/dev/null 2>&1; then \\\n"
+        "      DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=5 update -qq; \\\n"
+        "      DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=5 install -y -qq --no-install-recommends python3; \\\n"
+        "      rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*.deb; \\\n"
+        "    elif command -v apk >/dev/null 2>&1; then \\\n"
+        "      apk add --no-cache python3; \\\n"
+        "    elif command -v microdnf >/dev/null 2>&1; then \\\n"
+        "      microdnf install -y python3; \\\n"
+        "    elif command -v dnf >/dev/null 2>&1; then \\\n"
+        "      dnf -y install python3; \\\n"
+        "    elif command -v yum >/dev/null 2>&1; then \\\n"
+        "      yum install -y python3; \\\n"
+        "    else \\\n"
+        "      echo 'LoopX case lifecycle requires Python in the final benchmark image' >&2; \\\n"
+        "      exit 127; \\\n"
+        "    fi; \\\n"
+        "    command -v python3 >/dev/null 2>&1 || command -v python >/dev/null 2>&1\n"
+        f"{DOCKER_LOOPX_CASE_PYTHON_RUNTIME_END}"
+    )
+    trailing_lines = lines[final_from_index + 1 :]
+    while trailing_lines and not trailing_lines[0].strip():
+        trailing_lines.pop(0)
+    patched_lines = [
+        *lines[: final_from_index + 1],
+        "",
+        *block.splitlines(),
+        "",
+        *trailing_lines,
+    ]
+    patched = "\n".join(patched_lines).rstrip() + "\n"
+    if patched == original:
+        return False
+    _write_text_atomic(dockerfile, patched)
+    return True
+
+
 def dockerfile_references_skills_build_context(dockerfile: Path) -> bool:
     """Return whether the Dockerfile copies the local ``skills`` build context."""
 
@@ -7604,6 +7682,7 @@ def stage_task_for_sandbox(
     benchmark_egress_proxy_env: Mapping[str, str] | None = None,
     docker_gcr_mirror_prefix: str = "",
     verifier_dependency_cache_enabled: bool = False,
+    loopx_case_runtime_required: bool = False,
 ) -> tuple[Path, dict[str, Any]]:
     """Return the task path to run, staging Docker tasks when setup needs it."""
 
@@ -7650,6 +7729,8 @@ def stage_task_for_sandbox(
         "dockerfile_maven_mirror_host": "",
         "dockerfile_maven_mirror_raw_url_recorded": False,
         "codex_acp_runtime_tools_patch_applied": False,
+        "loopx_case_python_runtime_patch_required": False,
+        "loopx_case_python_runtime_patch_applied": False,
         "empty_skills_build_context_required": False,
         "empty_skills_build_context_created": False,
         "verifier_uv_bootstrap_risk_detected": False,
@@ -7753,6 +7834,10 @@ def stage_task_for_sandbox(
         verifier_proxy_exports and (task_path / "environment" / "Dockerfile").exists()
     )
     needs_runtime_tools_patch = (task_path / "environment" / "Dockerfile").exists()
+    needs_loopx_case_python_runtime_patch = bool(
+        loopx_case_runtime_required
+        and (task_path / "environment" / "Dockerfile").exists()
+    )
     metadata["apt_setup_risk_detected"] = needs_apt_retry_patch
     metadata["apt_retry_patch_required"] = needs_apt_retry_patch
     metadata["apt_risk_preflight_blocked"] = False
@@ -7847,6 +7932,9 @@ def stage_task_for_sandbox(
             "verifier_uv_bootstrap_version"
         ]
     metadata["verifier_bootstrap_risk_preflight_blocked"] = False
+    metadata["loopx_case_python_runtime_patch_required"] = (
+        needs_loopx_case_python_runtime_patch
+    )
     if (
         not has_task_skills
         and not needs_resource_cap
@@ -7862,6 +7950,7 @@ def stage_task_for_sandbox(
         and not needs_apache_archive_mirror_patch
         and not needs_maven_mirror_patch
         and not needs_runtime_tools_patch
+        and not needs_loopx_case_python_runtime_patch
         and not needs_verifier_uv_mirror_patch
         and not verifier_script_present
         and not needs_verifier_proxy_env_patch
@@ -7901,6 +7990,13 @@ def stage_task_for_sandbox(
     patched = patch_dockerfile_app_skills_mount(
         staged_path / "environment" / "Dockerfile"
     )
+    loopx_case_python_runtime_patched = False
+    if needs_loopx_case_python_runtime_patch:
+        loopx_case_python_runtime_patched = (
+            patch_dockerfile_loopx_case_python_runtime(
+                staged_path / "environment" / "Dockerfile"
+            )
+        )
     dockerfile_proxy_metadata = patch_dockerfile_benchmark_egress_proxy_env(
         staged_path / "environment" / "Dockerfile",
         proxy_env=benchmark_egress_proxy_env,
@@ -8032,6 +8128,12 @@ def stage_task_for_sandbox(
             ),
             "dockerfile_maven_mirror_raw_url_recorded": False,
             "codex_acp_runtime_tools_patch_applied": runtime_tools_patched,
+            "loopx_case_python_runtime_patch_required": (
+                needs_loopx_case_python_runtime_patch
+            ),
+            "loopx_case_python_runtime_patch_applied": (
+                loopx_case_python_runtime_patched
+            ),
             "empty_skills_build_context_required": empty_skills_context_required,
             "empty_skills_build_context_created": empty_skills_context_created,
             "verifier_script_executable_ready": verifier_script_executable_ready,
@@ -13288,6 +13390,7 @@ async def run_benchflow_case(
         verifier_dependency_cache_enabled=(
             verifier_dependency_cache_policy_enabled
         ),
+        loopx_case_runtime_required=_is_loopx_product_mode_route(args.route),
     )
     plan["task_staging"] = staging_metadata
     plan["effective_task_path"] = str(effective_task_path)


### PR DESCRIPTION
## Summary\n- stage an idempotent Python runtime bootstrap only for the SkillsBench LoopX product-mode route\n- preserve the original benchmark task source by patching only the staged Dockerfile copy\n- cover baseline-route isolation, package-manager variants, final-stage selection, and idempotency with a focused public smoke\n\n## Validation\n- \n- skillsbench-loopx-case-python-runtime-smoke ok\n- skillsbench-goal-start-product-mode-route-smoke ok\n- skillsbench host-local ACP launch plan smoke passed\n- skillsbench-benchmark-run-smoke: ok\n- \n- standard # Pre-Merge Validation Gate

- status: `manual_review_required`
- ok: `false`
- merge_gate_passed: `false`
- self_merge_allowed: `false`
- tier: `standard`
- dry_run: `false`
- changed_files: `2`
- surfaces: `public_boundary, benchmark_sensitive, python`
- risk_profiles: ``
- manual_holds: `1`

Pre-merge validation is a risk-based gate: it runs diff hygiene, changed Python compile checks, catalog-selected canaries, risk-profile smokes, and public/private boundary checks. It reports manual holds for benchmark-sensitive or reviewer-gated surfaces instead of treating local smoke success as self-merge permission.

## Direct Checks
- `diff_check_committed`: `passed` `git diff --check origin/main...HEAD`
- `diff_check_staged`: `passed` `git diff --cached --check`
- `diff_check_unstaged`: `passed` `git diff --check`
- `changed_python_py_compile`: `passed` `python3 -m py_compile examples/skillsbench-loopx-case-python-runtime-smoke.py scripts/skillsbench_automation_loop.py`

## Catalog Canaries
- ok: `true`
- selected_checks: `4`
- executed_checks: `4`
- failures: `0`
- advisory_failures: `0`
- warnings: `0`
- `passed` python3 examples/control_plane/repo-python-line-budget-smoke.py
- `passed` python3 examples/terminal-bench-adapter-readiness-characterization-smoke.py
- `passed` python3 examples/benchmark-core-adapter-contract-smoke.py
- `passed` python3 examples/benchmark-artifact-path-filter-smoke.py

## Public Boundary
- ok: `true`
- selected_checks: `1`
- executed_checks: `1`
- failures: `0`
- advisory_failures: `0`
- warnings: `0`
- `passed` loopx check --scan-path examples/skillsbench-loopx-case-python-runtime-smoke.py --scan-path scripts/skillsbench_automation_loop.py

## Manual Holds
- `benchmark_sensitive`: benchmark adapter, scoring, runner, or evidence paths require explicit maintainer review before self-merge: all direct checks, four catalog canaries, and public-boundary scan passed\n\n## Review Hold\nThe automatic gate reports the expected  manual hold. This change does not alter scoring, task semantics, verifier behavior, leaderboard/submission behavior, permissions, or launch benchmark jobs. Owner authorization for benchmark helper/runtime self-merge is recorded; this PR remains draft until the real setup/formal lifecycle validation is closed out.\n\n## Boundary\nNo raw benchmark task text, trajectories, verifier output, credentials, local paths, or generated run artifacts are included.