### PR TITLE
Route goal-scoped Explore commands to source runtimes

### DIFF
--- a/loopx/cli_commands/explore.py
+++ b/loopx/cli_commands/explore.py
@@ -31,6 +31,10 @@ from ..capabilities.explore.worker_branch_plan import (
     build_explore_worker_branch_plan,
     resolve_explore_harness_gate,
 )
+from ..control_plane.runtime.runtime_projection_route import (
+    compact_goal_source_runtime_route,
+    resolve_goal_source_runtime_route,
+)
 from ..presentation.sinks.lark.explore_results import (
     DEFAULT_EXPLORE_BASE_NAME,
     EXPLORE_TABLE_KEYS,
@@ -563,6 +567,16 @@ def handle_explore_command(
     try:
         registry = load_registry(registry_path)
         runtime_root = resolve_runtime_root(registry, runtime_root_arg)
+        source_runtime_route = None
+        goal_id = str(getattr(args, "goal_id", "") or "")
+        if goal_id:
+            source_runtime_route = resolve_goal_source_runtime_route(
+                registry_path=registry_path,
+                goal_id=goal_id,
+                runtime_root_override=runtime_root_arg,
+                registry=registry,
+            )
+            runtime_root = Path(str(source_runtime_route["source_runtime_root"]))
         config_path = (
             Path(args.config_path).expanduser()
             if getattr(args, "config_path", None)
@@ -890,6 +904,10 @@ def handle_explore_command(
                 payload["card_file"] = str(card_file)
         else:
             raise ValueError(f"unknown explore command: {args.explore_command}")
+        if source_runtime_route is not None:
+            payload["source_runtime_route"] = compact_goal_source_runtime_route(
+                source_runtime_route
+            )
     except Exception as exc:
         payload = {
             "ok": False,

--- a/loopx/control_plane/runtime/runtime_projection_route.py
+++ b/loopx/control_plane/runtime/runtime_projection_route.py
@@ -15,6 +15,7 @@ RUNTIME_PROJECTION_ROUTE_SCHEMA_VERSION = "runtime_projection_route_v0"
 RUNTIME_PROJECTION_ROUTE_DIAGNOSTICS_SCHEMA_VERSION = (
     "runtime_projection_route_diagnostics_v0"
 )
+GOAL_SOURCE_RUNTIME_ROUTE_SCHEMA_VERSION = "goal_source_runtime_route_v0"
 
 
 def _same_path(left: Path, right: Path) -> bool:
@@ -42,6 +43,183 @@ def _resolved_source_registry(goal: dict[str, Any], *, registry_path: Path) -> P
     if not path.is_absolute():
         path = registry_path.parent / path
     return path.resolve()
+
+
+def _registry_runtime_root(
+    registry: dict[str, Any],
+    *,
+    registry_path: Path,
+    goal_id: str,
+) -> Path:
+    runtime_root = resolve_runtime_root(registry, None).expanduser()
+    if not runtime_root.is_absolute():
+        goal = next(
+            (
+                item
+                for item in registry_goals(registry)
+                if str(item.get("id") or "") == goal_id
+            ),
+            None,
+        )
+        repo = Path(str((goal or {}).get("repo") or "")).expanduser()
+        if not repo.is_absolute():
+            repo = (
+                registry_path.parent.parent
+                if registry_path.parent.name == ".loopx"
+                else registry_path.parent
+            )
+        runtime_root = repo / runtime_root
+    return runtime_root.resolve()
+
+
+def _goal_source_route_packet(
+    *,
+    status: str,
+    declaration_source: str,
+    goal_id: str,
+    invoked_registry: Path,
+    source_registry: Path,
+    invoked_runtime: Path,
+    source_runtime: Path,
+) -> dict[str, Any]:
+    return {
+        "schema_version": GOAL_SOURCE_RUNTIME_ROUTE_SCHEMA_VERSION,
+        "status": status,
+        "declaration_source": declaration_source,
+        "goal_id": goal_id,
+        "invoked_registry": str(invoked_registry),
+        "source_registry": str(source_registry),
+        "invoked_runtime_root": str(invoked_runtime),
+        "source_runtime_root": str(source_runtime),
+        "routed_to_source_registry": not _same_path(
+            source_registry,
+            invoked_registry,
+        ),
+    }
+
+
+def resolve_goal_source_runtime_route(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    runtime_root_override: str | None = None,
+    registry: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Resolve goal-scoped writes and reads to the canonical source runtime.
+
+    A global registry is a shared read model. When its goal declares a
+    ``source_registry``, goal-scoped capabilities must use that registry's
+    runtime rather than treating the shared projection as the source of truth.
+    An explicit runtime override remains authoritative for diagnostics and
+    recovery commands.
+    """
+
+    invoked_registry = registry_path.expanduser().resolve()
+    registry_payload = registry if registry is not None else load_registry(invoked_registry)
+    invoked_runtime = _registry_runtime_root(
+        registry_payload,
+        registry_path=invoked_registry,
+        goal_id=goal_id,
+    )
+    if runtime_root_override:
+        runtime_root = Path(runtime_root_override).expanduser().resolve()
+        return _goal_source_route_packet(
+            status="explicit_override",
+            declaration_source="cli.runtime_root_override",
+            goal_id=goal_id,
+            invoked_registry=invoked_registry,
+            source_registry=invoked_registry,
+            invoked_runtime=invoked_runtime,
+            source_runtime=runtime_root,
+        )
+
+    registry_is_global = bool(registry_payload.get("registry_role") == "global-local") or _same_path(
+        invoked_registry,
+        global_registry_path(invoked_runtime),
+    )
+    if not registry_is_global:
+        return _goal_source_route_packet(
+            status="project_registry",
+            declaration_source="invoked_registry.common_runtime_root",
+            goal_id=goal_id,
+            invoked_registry=invoked_registry,
+            source_registry=invoked_registry,
+            invoked_runtime=invoked_runtime,
+            source_runtime=invoked_runtime,
+        )
+
+    goal = next(
+        (
+            item
+            for item in registry_goals(registry_payload)
+            if str(item.get("id") or "") == goal_id
+        ),
+        None,
+    )
+    if goal is None:
+        raise ValueError(
+            f"goal-scoped runtime route requires registered goal {goal_id!r} in the global registry"
+        )
+    source_registry = _resolved_source_registry(goal, registry_path=invoked_registry)
+    if source_registry is None or _same_path(source_registry, invoked_registry):
+        return _goal_source_route_packet(
+            status="global_runtime",
+            declaration_source="global_registry.common_runtime_root",
+            goal_id=goal_id,
+            invoked_registry=invoked_registry,
+            source_registry=invoked_registry,
+            invoked_runtime=invoked_runtime,
+            source_runtime=invoked_runtime,
+        )
+    if not source_registry.exists():
+        raise ValueError(
+            f"goal {goal_id!r} source_registry is missing; refusing to use the shared runtime as source"
+        )
+    try:
+        source_payload = load_registry(source_registry)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            f"goal {goal_id!r} source_registry is unreadable; refusing to use the shared runtime as source"
+        ) from exc
+    if not any(str(item.get("id") or "") == goal_id for item in registry_goals(source_payload)):
+        raise ValueError(
+            f"goal {goal_id!r} is absent from source_registry; refusing to use the shared runtime as source"
+        )
+    source_runtime = _registry_runtime_root(
+        source_payload,
+        registry_path=source_registry,
+        goal_id=goal_id,
+    )
+    return _goal_source_route_packet(
+        status="source_registry",
+        declaration_source="global_registry.goal.source_registry",
+        goal_id=goal_id,
+        invoked_registry=invoked_registry,
+        source_registry=source_registry,
+        invoked_runtime=invoked_runtime,
+        source_runtime=source_runtime,
+    )
+
+
+def compact_goal_source_runtime_route(route: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": GOAL_SOURCE_RUNTIME_ROUTE_SCHEMA_VERSION,
+        "status": route.get("status"),
+        "declaration_source": route.get("declaration_source"),
+        "routed_to_source_registry": bool(route.get("routed_to_source_registry")),
+        "invoked_registry_sha256_16": _path_digest(
+            Path(str(route.get("invoked_registry") or ""))
+        ),
+        "source_registry_sha256_16": _path_digest(
+            Path(str(route.get("source_registry") or ""))
+        ),
+        "invoked_runtime_sha256_16": _path_digest(
+            Path(str(route.get("invoked_runtime_root") or ""))
+        ),
+        "source_runtime_sha256_16": _path_digest(
+            Path(str(route.get("source_runtime_root") or ""))
+        ),
+    }
 
 
 def runtime_projection_candidate_roots(

--- a/tests/control_plane/test_explore_source_runtime_route.py
+++ b/tests/control_plane/test_explore_source_runtime_route.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from loopx.capabilities.explore.result_log import (
+    append_explore_result_event,
+    build_explore_node_event,
+    explore_result_log_path,
+    load_explore_result_events,
+)
+from loopx.cli_commands.explore import handle_explore_command
+from loopx.control_plane.runtime.runtime_projection_route import (
+    resolve_goal_source_runtime_route,
+)
+
+
+GOAL_ID = "split-runtime-fixture"
+
+
+def _write_registry(
+    path: Path,
+    *,
+    runtime_root: str,
+    source_registry: Path | None = None,
+    global_registry: bool = False,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    goal = {"id": GOAL_ID, "status": "active", "repo": str(path.parent.parent)}
+    if source_registry is not None:
+        goal["source_registry"] = str(source_registry)
+    payload = {
+        "schema_version": 1,
+        "common_runtime_root": runtime_root,
+        "goals": [goal],
+    }
+    if global_registry:
+        payload["registry_role"] = "global-local"
+    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+
+def _append_node(runtime_root: Path, *, node_id: str, title: str) -> None:
+    append_explore_result_event(
+        explore_result_log_path(runtime_root, GOAL_ID),
+        build_explore_node_event(
+            goal_id=GOAL_ID,
+            node_id=node_id,
+            title=title,
+            tags=["stage:4"],
+        ),
+    )
+
+
+def _sync_args(config_path: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        command="explore",
+        explore_command="feishu-sync",
+        config_path=str(config_path),
+        goal_id=GOAL_ID,
+        finding_limit=200,
+        mermaid_node_limit=60,
+        base_token=None,
+        table_id_nodes=None,
+        table_id_edges=None,
+        table_id_findings=None,
+        cli_bin=None,
+        identity="user",
+        sink_visibility="owner-only",
+        execute=False,
+    )
+
+
+def test_global_goal_route_uses_source_registry_relative_runtime(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    source_registry = project / ".loopx" / "registry.json"
+    global_registry = tmp_path / "shared" / "registry.global.json"
+    _write_registry(source_registry, runtime_root=".loopx/runtime")
+    _write_registry(
+        global_registry,
+        runtime_root=str(tmp_path / "shared"),
+        source_registry=source_registry,
+        global_registry=True,
+    )
+
+    route = resolve_goal_source_runtime_route(
+        registry_path=global_registry,
+        goal_id=GOAL_ID,
+    )
+
+    assert route["status"] == "source_registry"
+    assert route["routed_to_source_registry"] is True
+    assert Path(route["source_runtime_root"]) == project / ".loopx" / "runtime"
+
+
+def test_feishu_sync_uses_source_rows_and_visual_marker(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    source_registry = project / ".loopx" / "registry.json"
+    source_runtime = project / ".loopx" / "runtime"
+    shared_runtime = tmp_path / "shared"
+    global_registry = shared_runtime / "registry.global.json"
+    _write_registry(source_registry, runtime_root=".loopx/runtime")
+    _write_registry(
+        global_registry,
+        runtime_root=str(shared_runtime),
+        source_registry=source_registry,
+        global_registry=True,
+    )
+    _append_node(shared_runtime, node_id="node_shared_stale", title="Shared stale row")
+    _append_node(source_runtime, node_id="node_source_one", title="Source row one")
+    _append_node(source_runtime, node_id="node_source_two", title="Source row two")
+
+    config_path = tmp_path / "lark-explore.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "loopx_lark_explore_local_config_v0",
+                "board": {
+                    "base_token": "BASE_FIXTURE",
+                    "tables": {
+                        "nodes": "tblNodes",
+                        "edges": "tblEdges",
+                        "findings": "tblFindings",
+                    },
+                    "cli_bin": "lark-cli",
+                    "identity": "user",
+                },
+                "visual_sink": {
+                    "whiteboard_token": "wb_fixture",
+                    "view_role": "canonical",
+                    "projection_mode": "canonical_full",
+                    "board_style": "auto_flow",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    captured: list[dict[str, object]] = []
+
+    result = handle_explore_command(
+        _sync_args(config_path),
+        registry_path=global_registry,
+        runtime_root_arg=None,
+        print_payload=lambda payload, _fmt, _renderer: captured.append(payload),
+        output_format=lambda _args: "json",
+    )
+
+    assert result == 0
+    payload = captured[0]
+    assert payload["row_counts"] == {"nodes": 2, "edges": 0, "findings": 0}
+    assert "node_source_one" in json.dumps(payload["records"])
+    assert "node_shared_stale" not in json.dumps(payload["records"])
+    assert payload["source_runtime_route"]["routed_to_source_registry"] is True
+    visual = payload["visual_sync"]
+    assert visual["graph_counts"]["node_count"] == 2
+    assert visual["source_revision"].startswith("events-2-")
+    assert visual["readback"]["expected_marker"].startswith("LoopX delivery ")
+
+
+def test_global_node_write_appends_only_to_source_runtime(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    source_registry = project / ".loopx" / "registry.json"
+    source_runtime = project / ".loopx" / "runtime"
+    shared_runtime = tmp_path / "shared"
+    global_registry = shared_runtime / "registry.global.json"
+    _write_registry(source_registry, runtime_root=".loopx/runtime")
+    _write_registry(
+        global_registry,
+        runtime_root=str(shared_runtime),
+        source_registry=source_registry,
+        global_registry=True,
+    )
+    captured: list[dict[str, object]] = []
+
+    result = handle_explore_command(
+        argparse.Namespace(
+            command="explore",
+            explore_command="node",
+            goal_id=GOAL_ID,
+            title="Canonical source write",
+            node_id="node_source_write",
+            node_kind="artifact",
+            status="resolved",
+            summary=None,
+            blocked_reason=None,
+            parent_id=None,
+            agent_id="fixture-agent",
+            run_id=None,
+            evidence_ref=[],
+            tag=[],
+            supersedes=None,
+        ),
+        registry_path=global_registry,
+        runtime_root_arg=None,
+        print_payload=lambda payload, _fmt, _renderer: captured.append(payload),
+        output_format=lambda _args: "json",
+    )
+
+    assert result == 0
+    assert captured[0]["source_runtime_route"]["routed_to_source_registry"] is True
+    assert (
+        len(
+            load_explore_result_events(
+                explore_result_log_path(source_runtime, GOAL_ID), goal_id=GOAL_ID
+            )
+        )
+        == 1
+    )
+    assert (
+        load_explore_result_events(
+            explore_result_log_path(shared_runtime, GOAL_ID), goal_id=GOAL_ID
+        )
+        == []
+    )
+
+
+def test_explicit_runtime_override_remains_authoritative(tmp_path: Path) -> None:
+    source_registry = tmp_path / "project" / ".loopx" / "registry.json"
+    global_registry = tmp_path / "shared" / "registry.global.json"
+    override = tmp_path / "diagnostic-runtime"
+    _write_registry(source_registry, runtime_root=".loopx/runtime")
+    _write_registry(
+        global_registry,
+        runtime_root=str(tmp_path / "shared"),
+        source_registry=source_registry,
+        global_registry=True,
+    )
+
+    route = resolve_goal_source_runtime_route(
+        registry_path=global_registry,
+        goal_id=GOAL_ID,
+        runtime_root_override=str(override),
+    )
+
+    assert route["status"] == "explicit_override"
+    assert route["routed_to_source_registry"] is False
+    assert Path(route["source_runtime_root"]) == override
+
+
+def test_missing_source_registry_fails_closed(tmp_path: Path) -> None:
+    global_registry = tmp_path / "shared" / "registry.global.json"
+    _write_registry(
+        global_registry,
+        runtime_root=str(tmp_path / "shared"),
+        source_registry=tmp_path / "missing" / "registry.json",
+        global_registry=True,
+    )
+
+    try:
+        resolve_goal_source_runtime_route(
+            registry_path=global_registry,
+            goal_id=GOAL_ID,
+        )
+    except ValueError as exc:
+        assert "refusing to use the shared runtime as source" in str(exc)
+    else:
+        raise AssertionError("missing source_registry must fail closed")


### PR DESCRIPTION
## Summary
- resolve goal-scoped Explore reads and writes through a global goal source_registry
- resolve relative source runtime roots against the registered project repo
- preserve explicit runtime overrides and fail closed when the declared source is missing or inconsistent
- expose a compact path-digest route receipt without copying local paths

## Validation
- 323 passed, 2 skipped
- focused split-runtime pytest: 5 passed
- architecture import boundaries: 2 passed
- Explore result layer, singleflight, and shared-runtime projection smokes passed
- standard premerge gate: 14/14 selected checks passed; no failures, warnings, or manual holds
- public/private boundary scan clean for all three changed files
- real OpenViking sink: source_registry route selected; Base 643/643 exact readback, zero missing/mismatch/duplicates; canonical 16 stages and executive 5 stages published with no reconciliation drift

## Scope and risk
- changed surfaces: Explore CLI routing, runtime projection route helper, focused regression tests
- no permission, quota, scheduler, benchmark, scoring, or production-action semantics changed
- no private state, local paths, credentials, raw logs, or generated evidence committed
- explicit --runtime-root remains the recovery and diagnostics escape hatch