### PR TITLE
Stabilize monitor due scheduler buckets

### DIFF
--- a/examples/control_plane/monitor-scheduler-contract-smoke.py
+++ b/examples/control_plane/monitor-scheduler-contract-smoke.py
@@ -288,7 +288,7 @@ def assert_monitor_scheduler_near_window_caps_without_breaking_floor() -> None:
     assert context["phase"] == "near_window", context
     assert context["host_floor_minutes"] == 15, context
     assert context["cap_minutes"] == 37, context
-    assert codex_app["example_progression_minutes"] == [15, 30, 37], scheduler
+    assert codex_app["example_progression_minutes"] == [15, 30], scheduler
 
 
 def assert_monitor_scheduler_near_window_reset_identity_is_stable() -> None:
@@ -302,29 +302,46 @@ def assert_monitor_scheduler_near_window_reset_identity_is_stable() -> None:
         target_key="near-window-stable-watch",
     )
     first = guard_for([item], include_scheduler_detail=True)
-    later = guard_for(
+    same_bucket = guard_for(
         [item],
         include_scheduler_detail=True,
-        now=FROZEN_NOW + timedelta(minutes=10),
+        now=FROZEN_NOW + timedelta(minutes=1),
+    )
+    next_bucket = guard_for(
+        [item],
+        include_scheduler_detail=True,
+        now=FROZEN_NOW + timedelta(minutes=8),
     )
     first_scheduler = first["scheduler_hint"]
-    later_scheduler = later["scheduler_hint"]
+    same_bucket_scheduler = same_bucket["scheduler_hint"]
+    next_bucket_scheduler = next_bucket["scheduler_hint"]
     first_context = first_scheduler["cold_path_detail"]["cadence_context"]
-    later_context = later_scheduler["cold_path_detail"]["cadence_context"]
+    same_bucket_context = same_bucket_scheduler["cold_path_detail"]["cadence_context"]
+    next_bucket_context = next_bucket_scheduler["cold_path_detail"]["cadence_context"]
     assert first_context["phase"] == "near_window", first_context
-    assert later_context["phase"] == "near_window", later_context
+    assert same_bucket_context["phase"] == "near_window", same_bucket_context
+    assert next_bucket_context["phase"] == "near_window", next_bucket_context
     assert first_context["cap_minutes"] == 37, first_context
-    assert later_context["cap_minutes"] == 27, later_context
-    assert first_scheduler["reset_policy"]["reset_token"] == later_scheduler["reset_policy"]["reset_token"], (
+    assert same_bucket_context["cap_minutes"] == 36, same_bucket_context
+    assert next_bucket_context["cap_minutes"] == 29, next_bucket_context
+    assert first_scheduler["codex_app"]["example_progression_minutes"] == [15, 30], first_scheduler
+    assert same_bucket_scheduler["codex_app"]["example_progression_minutes"] == [15, 30], (
+        same_bucket_scheduler
+    )
+    assert next_bucket_scheduler["codex_app"]["example_progression_minutes"] == [15], (
+        next_bucket_scheduler
+    )
+    assert first_scheduler["reset_policy"]["reset_token"] == same_bucket_scheduler[
+        "reset_policy"
+    ]["reset_token"], (
         first_scheduler,
-        later_scheduler,
+        same_bucket_scheduler,
     )
     assert first_scheduler["cold_path_detail"]["reset_policy_detail"][
         "reset_profile_signature"
-    ] == later_scheduler["cold_path_detail"]["reset_policy_detail"]["reset_profile_signature"], later_scheduler
-    assert first_scheduler["codex_app"]["example_progression_minutes"] != later_scheduler["codex_app"][
-        "example_progression_minutes"
-    ], later_scheduler
+    ] == same_bucket_scheduler["cold_path_detail"]["reset_policy_detail"][
+        "reset_profile_signature"
+    ], same_bucket_scheduler
 
 
 def assert_monitor_scheduler_active_window_respects_host_floor() -> None:
@@ -352,7 +369,7 @@ def assert_monitor_scheduler_active_window_respects_host_floor() -> None:
     assert context["host_floor_minutes"] == 15, context
     assert codex_app["example_progression_minutes"] == [15], scheduler
     local_scheduler = scheduler["cold_path_detail"]["local_scheduler"]
-    assert local_scheduler["example_progression_minutes"] == [15, 15, 15], scheduler
+    assert local_scheduler["example_progression_minutes"] == [15], scheduler
     assert codex_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", scheduler
 
 

--- a/examples/control_plane/quota-scheduler-state-ack-smoke.py
+++ b/examples/control_plane/quota-scheduler-state-ack-smoke.py
@@ -553,70 +553,70 @@ def assert_normal_run_ack_preserves_runtime_capabilities() -> None:
         assert cli_args[capability_index - 1] == "--available-capability", ack_hint
 
 
-def assert_monitor_wait_stale_ack_hint_is_accepted() -> None:
+def assert_monitor_wait_fixed_due_bucket_does_not_churn() -> None:
     base = monitor_window_payload(minutes_until_due=59)
     first = build_hint_at(base, now=FROZEN_NOW)
     second = build_hint_at(base, now=FROZEN_NOW, scheduler_state=state_from(first))
-    previous_state = state_from(second)
-
-    stale_hint_source = build_hint_at(
-        base,
-        now=FROZEN_NOW,
-        scheduler_state=previous_state,
-    )
-    stale_app = stale_hint_source["codex_app"]
-    stale_ack_args = stale_app["ack_hint"]["args"]
-    assert stale_hint_source["cadence_class"] == "monitor_wait", stale_hint_source
-    assert stale_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=59", stale_hint_source
-
-    current_hint = build_hint_at(
+    applied_state = state_from(second)
+    steady = build_hint_at(
         base,
         now=FROZEN_NOW + timedelta(minutes=1),
-        scheduler_state=previous_state,
+        scheduler_state=applied_state,
+        codex_app_current_rrule="FREQ=MINUTELY;INTERVAL=30",
+    )
+    steady_app = steady["codex_app"]
+    assert first["codex_app"]["example_progression_minutes"] == [15, 30], first
+    assert second["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=30", second
+    assert steady_app["example_progression_minutes"] == [15, 30], steady
+    assert steady_app["stateful_backoff"]["current_rrule"] == (
+        "FREQ=MINUTELY;INTERVAL=30"
+    ), steady
+    assert steady_app["stateful_backoff"]["apply_needed"] is False, steady
+    assert steady_app["stateful_backoff"]["ack_needed"] is False, steady
+    assert steady_app["host_action"] == "none", steady
+    assert "recommended_rrule" not in steady_app, steady
+
+
+def assert_monitor_wait_stale_ack_hint_is_accepted() -> None:
+    base = monitor_window_payload(minutes_until_due=59)
+    first = build_hint_at(base, now=FROZEN_NOW)
+    current_hint = build_hint_at(
+        base,
+        now=FROZEN_NOW,
+        scheduler_state=state_from(first),
     )
     current_app = current_hint["codex_app"]
-    assert current_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=58", current_hint
-    assert (
-        current_app["stateful_backoff"]["reset_token"]
-        == stale_ack_args["reset_token"]
-    ), current_hint
-    assert (
-        current_app["stateful_backoff"]["identity_signature"]
-        == stale_ack_args["identity_signature"]
-    ), current_hint
+    ack_args = current_app["ack_hint"]["args"]
+    assert current_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=30", current_hint
 
     plan = build_scheduler_ack_plan(
         {"scheduler_hint": current_hint},
-        agent_id=stale_ack_args["agent_id"],
-        state_key=stale_ack_args["state_key"],
-        applied_rrule=stale_ack_args["applied_rrule"],
-        reset_token=stale_ack_args["reset_token"],
-        identity_signature=stale_ack_args["identity_signature"],
+        agent_id=ack_args["agent_id"],
+        state_key=ack_args["state_key"],
+        applied_rrule="FREQ=MINUTELY;INTERVAL=31",
+        reset_token=ack_args["reset_token"],
+        identity_signature=ack_args["identity_signature"],
     )
     assert plan == {
         "ok": True,
         "already_applied": False,
-        "applied_rrule": "FREQ=MINUTELY;INTERVAL=59",
-        "expected_rrule": "FREQ=MINUTELY;INTERVAL=58",
+        "applied_rrule": "FREQ=MINUTELY;INTERVAL=31",
+        "expected_rrule": "FREQ=MINUTELY;INTERVAL=30",
         "stale_hint_accepted": True,
         "stale_hint_tolerance_minutes": 2,
     }, plan
 
     event = build_codex_app_scheduler_ack_event(
         {"goal_id": "scheduler-state-ack-smoke", "scheduler_hint": current_hint},
-        agent_id=stale_ack_args["agent_id"],
-        applied_rrule=stale_ack_args["applied_rrule"],
-        reset_token=stale_ack_args["reset_token"],
-        identity_signature=stale_ack_args["identity_signature"],
+        agent_id=ack_args["agent_id"],
+        applied_rrule="FREQ=MINUTELY;INTERVAL=31",
+        reset_token=ack_args["reset_token"],
+        identity_signature=ack_args["identity_signature"],
     )
     ack_event = event["scheduler_ack_event"]
-    assert ack_event["applied_rrule"] == "FREQ=MINUTELY;INTERVAL=59", event
-    assert ack_event["expected_rrule"] == "FREQ=MINUTELY;INTERVAL=58", event
+    assert ack_event["applied_rrule"] == "FREQ=MINUTELY;INTERVAL=31", event
+    assert ack_event["expected_rrule"] == "FREQ=MINUTELY;INTERVAL=30", event
     assert ack_event["stale_hint_accepted"] is True, event
-    assert (
-        ack_event["scheduler_state"]["last_applied_rrule"]
-        == "FREQ=MINUTELY;INTERVAL=59"
-    ), event
     quiet_after_stale_ack = build_hint_at(
         base,
         now=FROZEN_NOW + timedelta(minutes=1),
@@ -625,42 +625,24 @@ def assert_monitor_wait_stale_ack_hint_is_accepted() -> None:
     quiet_app = quiet_after_stale_ack["codex_app"]
     assert quiet_app["stateful_backoff"]["apply_needed"] is False, quiet_after_stale_ack
     assert quiet_app["host_action"] == "none", quiet_after_stale_ack
-    assert "recommended_rrule" not in quiet_app, quiet_after_stale_ack
 
     observed_stale_host = build_hint_at(
         base,
         now=FROZEN_NOW + timedelta(minutes=1),
         scheduler_state=ack_event["scheduler_state"],
-        codex_app_current_rrule="FREQ=MINUTELY;INTERVAL=59",
+        codex_app_current_rrule="FREQ=MINUTELY;INTERVAL=31",
     )
     observed_app = observed_stale_host["codex_app"]
     assert observed_app["stateful_backoff"]["apply_needed"] is True, observed_stale_host
-    assert observed_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=58", observed_stale_host
-    assert (
-        observed_app["stateful_backoff"]["host_observation"]["status"]
-        == "drift_detected"
-    ), observed_stale_host
-
-    outside_state_tolerance = build_hint_at(
-        base,
-        now=FROZEN_NOW + timedelta(minutes=3),
-        scheduler_state=ack_event["scheduler_state"],
-    )
-    outside_app = outside_state_tolerance["codex_app"]
-    assert outside_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=56", (
-        outside_state_tolerance
-    )
-    assert outside_app["stateful_backoff"]["apply_needed"] is True, (
-        outside_state_tolerance
-    )
+    assert observed_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=30", observed_stale_host
 
     outside_tolerance = build_scheduler_ack_plan(
         {"scheduler_hint": current_hint},
-        agent_id=stale_ack_args["agent_id"],
-        state_key=stale_ack_args["state_key"],
-        applied_rrule="FREQ=MINUTELY;INTERVAL=61",
-        reset_token=stale_ack_args["reset_token"],
-        identity_signature=stale_ack_args["identity_signature"],
+        agent_id=ack_args["agent_id"],
+        state_key=ack_args["state_key"],
+        applied_rrule="FREQ=MINUTELY;INTERVAL=33",
+        reset_token=ack_args["reset_token"],
+        identity_signature=ack_args["identity_signature"],
     )
     assert outside_tolerance["ok"] is False, outside_tolerance
     assert "does not match expected" in outside_tolerance["reason"], outside_tolerance
@@ -1464,6 +1446,7 @@ def main() -> int:
     assert_active_work_keeps_initial_cadence()
     assert_scheduler_ack_plan_validation()
     assert_normal_run_ack_preserves_runtime_capabilities()
+    assert_monitor_wait_fixed_due_bucket_does_not_churn()
     assert_monitor_wait_stale_ack_hint_is_accepted()
     assert_scheduler_state_scope_validation()
     assert_cli_scheduler_ack_progression()

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -506,10 +506,13 @@ def _minutes_until(value: datetime, current_time: datetime) -> int:
 def _cap_monitor_progression(*, cap_minutes: int, host_floor_minutes: int) -> list[int]:
     safe_cap = max(1, int(cap_minutes))
     safe_floor = max(1, int(host_floor_minutes))
-    return [
-        max(safe_floor, min(interval, safe_cap))
+    # Keep host RRULEs on stable buckets; the exact due horizon still gates routing.
+    progression = [
+        max(safe_floor, interval)
         for interval in MONITOR_WAIT_PROGRESSION_MINUTES
+        if interval <= safe_cap
     ]
+    return progression or [safe_floor]
 
 
 def _monitor_wait_item_plan(


### PR DESCRIPTION
## Summary
- keep Codex App monitor RRULE recommendations on stable 15/30/60-minute buckets below the exact due horizon
- preserve exact `next_due_at` routing, candidate ordering, active-work reset, and stale-ACK protection
- add focused regressions proving a fixed due time no longer causes minute-by-minute host update/ACK churn and bucket boundaries still tighten cadence

## Product / architecture judgment
The bug was a split between stable scheduler identity and an unstable progression profile: the last progression entry copied the wall-clock countdown. Keeping exact due time in routing while quantizing only the host cadence is the smallest reusable fix; it avoids adding state or special-casing OpenViking. The main compatibility risk is earlier polling inside a due window, bounded by the existing 15/30/60 progression.

## Validation
- `uv run python examples/control_plane/monitor-scheduler-contract-smoke.py`
- `uv run python examples/control_plane/quota-scheduler-state-ack-smoke.py`
- `uv run --extra test python -m pytest -q -n 2` (323 passed, 2 skipped)
- targeted Ruff check on all three changed Python files
- `uv run python examples/control_plane/repo-python-line-budget-smoke.py`
- `loopx canary premerge --from-git-diff` (17/17 passed, 0 holds, self-merge allowed)
- `git diff --check` and public/private boundary scan

## Excluded
- generated `uv.lock` and all local/private LoopX state were excluded.