### PR TITLE
Expose SkillsBench soft-verify policy in launcher

### DIFF
--- a/examples/skillsbench-benchmark-egress-policy-smoke.py
+++ b/examples/skillsbench-benchmark-egress-policy-smoke.py
@@ -141,6 +141,7 @@ def test_public_launcher_uses_container_reachable_benchmark_proxy() -> None:
             "SKILLSBENCH_LOCAL_CODEX_SANDBOX": "danger-full-access",
             "SKILLSBENCH_CLI_GOAL_THREAD_PREWARM": "1",
             "SKILLSBENCH_ALLOW_STAGED_BOOTSTRAP_REPAIR_RUN": "1",
+            "SKILLSBENCH_PRODUCT_MODE_SOFT_VERIFY_POLICY": "final-only",
             "SKILLSBENCH_RUN_STAMP": "20260709T000000CST",
             "SKILLSBENCH_TUNNEL_PROBE_TIMEOUT_SEC": "19",
             "SKILLSBENCH_TUNNEL_READY_TIMEOUT_SEC": "71",
@@ -183,6 +184,8 @@ def test_public_launcher_uses_container_reachable_benchmark_proxy() -> None:
     assert "--codex-cli-goal-thread-prewarm" in output, output
     assert "allow_staged_bootstrap_repair_run=1" in output, output
     assert "--allow-staged-bootstrap-repair-run" in output, output
+    assert "product_mode_soft_verify_policy=final-only" in output, output
+    assert "--product-mode-soft-verify-policy final-only" in output, output
     assert "remote_codex_bin_mode=explicit" in output, output
     assert "--probe-timeout-sec 19" in output, output
     assert "--tunnel-ready-timeout-sec 71" in output, output
@@ -200,6 +203,37 @@ def test_public_launcher_uses_container_reachable_benchmark_proxy() -> None:
     assert "skip_current_aggregate_update=1" in output, output
     assert "--skip-global-ledger-sync" in output, output
     assert "--skip-current-aggregate-update" in output, output
+
+
+def test_public_launcher_rejects_invalid_product_mode_soft_verify_policy() -> None:
+    env = os.environ.copy()
+    env.update(
+        {
+            "SKILLSBENCH_SSH_DESTINATION": "example.invalid",
+            "SKILLSBENCH_REMOTE_ROOT": "/remote/loopx",
+            "SKILLSBENCH_ROOT": "/remote/skillsbench",
+            "SKILLSBENCH_EXPECTED_LOOPX_GIT_HEAD": "abc1234",
+            "SKILLSBENCH_PRODUCT_MODE_SOFT_VERIFY_POLICY": "sometimes",
+        }
+    )
+    proc = subprocess.run(
+        [
+            str(REPO_ROOT / "scripts" / "skillsbench-launch-goal-xhigh.sh"),
+            "--dry-run",
+            "citation-check",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 2, proc
+    assert (
+        "SKILLSBENCH_PRODUCT_MODE_SOFT_VERIFY_POLICY must be "
+        "every-round or final-only" in proc.stderr
+    ), proc.stderr
 
 
 def test_public_launcher_batches_three_cases_with_closeout_sync() -> None:
@@ -253,6 +287,8 @@ def test_public_launcher_batches_three_cases_with_closeout_sync() -> None:
     assert "--update-ledger" not in output, output
     assert "--codex-cli-goal-thread-prewarm" not in output, output
     assert "--allow-staged-bootstrap-repair-run" not in output, output
+    assert "product_mode_soft_verify_policy=runner-default" in output, output
+    assert "--product-mode-soft-verify-policy" not in output, output
     assert "--local-target-lane-id codex-cli-goal-xhigh" in output, output
     assert "--local-target-run-group-contains" not in output, output
     assert "--local-target-backfill-run-group-contains" not in output, output

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -39,6 +39,10 @@ Optional env:
                                        Set to 1 to stop after real job-root and
                                        environment materialization, before any
                                        agent or verifier lifecycle
+  SKILLSBENCH_PRODUCT_MODE_SOFT_VERIFY_POLICY
+                                       Optional product-mode intermediate
+                                       verifier policy: every-round or
+                                       final-only; unset preserves runner default
   SKILLSBENCH_BUILD_STALL_TIMEOUT_SEC  Setup stall timeout, default 3600;
                                        0 disables cap
   SKILLSBENCH_RUN_TIMEOUT_SEC          Supervisor timeout, default 28800
@@ -149,6 +153,7 @@ skip_global_ledger_sync="${SKILLSBENCH_SKIP_GLOBAL_LEDGER_SYNC:-0}"
 skip_current_aggregate_update="${SKILLSBENCH_SKIP_CURRENT_AGGREGATE_UPDATE:-0}"
 allow_staged_bootstrap_repair_run="${SKILLSBENCH_ALLOW_STAGED_BOOTSTRAP_REPAIR_RUN:-0}"
 setup_only_public_preflight="${SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT:-0}"
+product_mode_soft_verify_policy="${SKILLSBENCH_PRODUCT_MODE_SOFT_VERIFY_POLICY:-}"
 validate_bool_toggle() {
   local env_name="$1"
   local value="$2"
@@ -164,6 +169,12 @@ validate_bool_toggle \
   SKILLSBENCH_ALLOW_STAGED_BOOTSTRAP_REPAIR_RUN "$allow_staged_bootstrap_repair_run"
 validate_bool_toggle \
   SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT "$setup_only_public_preflight"
+if [[ -n "$product_mode_soft_verify_policy" ]] &&
+  [[ "$product_mode_soft_verify_policy" != "every-round" ]] &&
+  [[ "$product_mode_soft_verify_policy" != "final-only" ]]; then
+  echo "SKILLSBENCH_PRODUCT_MODE_SOFT_VERIFY_POLICY must be every-round or final-only" >&2
+  exit 2
+fi
 remote_codex_bin_mode="path_lookup"
 if [[ -n "${SKILLSBENCH_REMOTE_CODEX_BIN:-}" ]]; then
   remote_codex_bin_mode="explicit"
@@ -306,6 +317,11 @@ fi
 if [[ "$setup_only_public_preflight" == "1" ]]; then
   extra_runner_args+=(--setup-only-public-preflight)
 fi
+if [[ -n "$product_mode_soft_verify_policy" ]]; then
+  extra_runner_args+=(
+    --product-mode-soft-verify-policy "$product_mode_soft_verify_policy"
+  )
+fi
 if [[ -n "${SKILLSBENCH_REGISTRY:-}" ]]; then
   extra_runner_args+=(--registry "$SKILLSBENCH_REGISTRY")
 fi
@@ -446,6 +462,8 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'codex_cli_goal_thread_prewarm=%s\n' "$codex_cli_goal_thread_prewarm"
   printf 'allow_staged_bootstrap_repair_run=%s\n' "$allow_staged_bootstrap_repair_run"
   printf 'setup_only_public_preflight=%s\n' "$setup_only_public_preflight"
+  printf 'product_mode_soft_verify_policy=%s\n' \
+    "${product_mode_soft_verify_policy:-runner-default}"
   printf 'skip_global_ledger_sync=%s\n' "$skip_global_ledger_sync"
   printf 'skip_current_aggregate_update=%s\n' "$skip_current_aggregate_update"
   printf 'local_run_ledger=%s\n' "$local_run_ledger"


### PR DESCRIPTION
## Summary
- expose `SKILLSBENCH_PRODUCT_MODE_SOFT_VERIFY_POLICY` in the public SkillsBench launcher
- accept only `every-round` or `final-only` and pass the option only when explicitly configured
- prove the unset path preserves the runner default

## Motivation
Compact/public evidence for a `flink-query` treatment showed two intermediate soft-verifier calls followed by a final verifier infrastructure error, while an earlier baseline reached a countable official result without intermediate soft verification. This adds a narrow diagnostic control for a final-only rerun without changing the default arm or scoring contract.

## Validation
- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`
- `python3 -m py_compile examples/skillsbench-benchmark-egress-policy-smoke.py`
- `python3 examples/skillsbench-benchmark-egress-policy-smoke.py`
- `python3 examples/skillsbench-goal-start-product-mode-route-smoke.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `loopx canary premerge --from-git-diff --tier standard`: 4 direct checks and 7 selected checks passed; generic `benchmark_sensitive` manual hold remains
- public/private boundary scan passed

## Boundary
No benchmark jobs are launched by this PR. No task text, trajectories, verifier output, raw logs, credentials, local paths, or generated benchmark artifacts are included. The default remains `every-round`; `final-only` is opt-in.