### PR TITLE
release: prepare LoopX v0.2.5

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -259,6 +259,22 @@ path, and canary route rather than as a user-facing release baseline.
   (#2002, #2005-#2006, #2018-#2021, #2027-#2028, #2032, #2036, #2052-#2061).
   No persisted-state migration is required; Explore and its Lark visual sinks
   remain opt-in.
+- `v0.2.5` on 2026-07-15: reward-memory and cross-runtime reliability release
+  at the matching `v0.2.5` tag. LoopX now ships a provider-neutral Reward
+  Memory path from reviewed corpus and health contracts through candidate
+  review, opt-in recall/application, evaluation, dogfood controls, and explicit
+  actor-peer routing at the Issue-Fix planning boundary (#2076-#2085, #2096,
+  #2100, #2103, #2128). Runtime projection routes become a first-class source
+  of truth for material events, refreshes, and Explore commands across shared
+  runtimes, with source-mirror ambiguity and compact diagnostics repaired
+  (#2091, #2094, #2097, #2099, #2102, #2129). Issue-Fix gains stronger commit
+  evidence, evidence-backed close counts, candidate dedupe, reviewer fallback,
+  and delivery-window queuing (#2071, #2087, #2098, #2105, #2107, #2111).
+  Monitor, scheduler, peer-replan, Lark inbox, Explore readback, and long-running
+  SkillsBench paths are hardened against repeated host failures, scoped gates,
+  transport loss, setup drift, and countability ambiguity (#2101, #2104,
+  #2108-#2127, #2130-#2131). No persisted-state migration is required; Reward
+  Memory and advanced fixer execution remain explicitly activated and bounded.
 
 When a new public release is promoted, add it here only after the matching tag,
 release note, stable ref, update path, and focused release canary agree.

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.2.4"
+version = "0.2.5"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- bump `loopx.__version__` and `pyproject.toml` together from 0.2.4 to 0.2.5
- add the v0.2.5 release-readiness timeline entry
- frame the release around Reward Memory, first-class runtime projection routes, Issue-Fix closure/reviewer reliability, scheduler/monitor hardening, and long-running SkillsBench reliability

## Validation

- full pytest: `323 passed, 2 skipped`
- release version, release readiness, no-clone, fresh-clone, and update smokes passed
- promotion-readiness canary passed with a 1588-file public/private scan; the dashboard browser leg used its documented skip because npm dependencies were absent
- standard premerge canary: 17/17 passed, 0 failures, 0 manual holds

## Boundaries

- changed surfaces are package version metadata and release-readiness documentation only
- no persisted-state migration is required
- Reward Memory and advanced fixer execution remain explicitly activated and bounded
- generated `uv.lock` and local environments are excluded

After merge, the release commit will receive a post-merge promotion canary before `stable`, tag, and GitHub release publication.