### PR TITLE
Trace generated SkillsBench todo IDs

### DIFF
--- a/examples/skillsbench-goal-start-product-mode-route-smoke.py
+++ b/examples/skillsbench-goal-start-product-mode-route-smoke.py
@@ -109,6 +109,65 @@ def _assert_bridge_tracks_guided_start_without_task_text() -> None:
     assert completed[1]["loopx_todo_id"] == todo_id
 
 
+def _assert_bridge_tracks_generated_todo_id_without_raw_output() -> None:
+    sys.path.insert(0, str(REPO_ROOT))
+    from loopx.benchmark_adapters.skillsbench_acp_relay import (
+        CodexExecConfig,
+        SkillsBenchLocalAcpRelay,
+    )
+
+    private_stdout = "PRIVATE_STDOUT_SENTINEL do not publish"
+    generated_todo_id = "todo_generated_solver_plan"
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        fake_bridge = temp_path / "fake-bridge.py"
+        fake_bridge.write_text(
+            "import json, sys\n"
+            "request = json.loads(sys.stdin.read() or '{}')\n"
+            f"cli_payload = {{'ok': True, 'todo_id': {generated_todo_id!r}, "
+            f"'detail': {private_stdout!r}}}\n"
+            "print(json.dumps({'ok': True, 'exit_code': 0, "
+            "'stdout': json.dumps(cli_payload), 'stderr': ''}))\n",
+            encoding="utf-8",
+        )
+        summary_path = temp_path / "agent-operations.jsonl"
+        relay = SkillsBenchLocalAcpRelay(
+            CodexExecConfig(
+                remote_command_file_bridge_command=(
+                    f"{shlex.quote(sys.executable)} {shlex.quote(str(fake_bridge))}"
+                )
+            )
+        )
+        wrapper = relay._write_instrumented_bridge_wrapper(
+            tmp_path=temp_path,
+            summary_path=summary_path,
+        )
+        request = {
+            "operation": "exec",
+            "cwd": "/app",
+            "command": (
+                "/app/.local/bin/loopx --format json todo add "
+                "--goal-id skillsbench-case --role agent "
+                "--text 'public safe solver todo'"
+            ),
+        }
+        result = subprocess.run(
+            [str(wrapper)],
+            input=json.dumps(request),
+            text=True,
+            check=True,
+            capture_output=True,
+        )
+        summary_text = summary_path.read_text(encoding="utf-8")
+        records = [json.loads(line) for line in summary_text.splitlines()]
+
+    assert private_stdout in result.stdout, result.stdout
+    assert private_stdout not in summary_text, summary_text
+    completed = [record for record in records if record.get("record_phase") == "complete"]
+    assert completed[-1]["loopx_todo_id"] == generated_todo_id, completed
+    assert completed[-1]["raw_stdout_recorded"] is False, completed
+
+
 def _assert_bridge_rejects_batched_loopx_commands() -> None:
     sys.path.insert(0, str(REPO_ROOT))
     from loopx.benchmark_adapters.skillsbench_acp_relay import (
@@ -858,6 +917,7 @@ def main() -> int:
     _assert_adapter_route_contract_surface()
     _assert_agent_authored_goal_start_bootstrap()
     _assert_bridge_tracks_guided_start_without_task_text()
+    _assert_bridge_tracks_generated_todo_id_without_raw_output()
     _assert_bridge_rejects_batched_loopx_commands()
     _assert_generated_prompt_requires_agent_authored_separate_requests()
     _assert_control_score_surface()

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -41,6 +41,7 @@ from loopx.benchmark_adapters.skillsbench_bridge_summary import (
 )
 from loopx.benchmark_adapters.skillsbench_bridge_guard import (
     LOOPX_COMMAND_INSTRUMENTATION_SOURCE,
+    LOOPX_TODO_OUTPUT_INSTRUMENTATION_SOURCE,
 )
 from loopx.benchmark_adapters.skillsbench_acp_failure_policy import (
     RECOVERABLE_CODEX_TURN_FAILURE_CATEGORIES,
@@ -2334,6 +2335,7 @@ PROBE_OPERATION_LABELS = {{
 PROBE_PATH_LABELS = {{"bridge_probe_marker"}}
 
 {LOOPX_COMMAND_INSTRUMENTATION_SOURCE}
+{LOOPX_TODO_OUTPUT_INSTRUMENTATION_SOURCE}
 
 SAFE_LOOPX_TODO_ID_RE = re.compile(r"^todo_[A-Za-z0-9_-]{{6,80}}$")
 SAFE_LOOPX_GOAL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{{0,120}}$")
@@ -2447,6 +2449,7 @@ complete_record["returncode"] = int(proc.returncode)
 complete_record["success"] = proc.returncode == 0
 complete_record["stdout_bytes"] = len((proc.stdout or "").encode("utf-8"))
 complete_record["stderr_bytes"] = len((proc.stderr or "").encode("utf-8"))
+attach_successful_todo_add_id(complete_record, subcommands, proc.stdout or "")
 if proc.returncode != 0:
     stderr_text = proc.stderr or ""
     if int(proc.returncode) < 0:

--- a/loopx/benchmark_adapters/skillsbench_bridge_guard.py
+++ b/loopx/benchmark_adapters/skillsbench_bridge_guard.py
@@ -152,3 +152,55 @@ def enforce_single_loopx_invocation(count, record, append_record) -> None:
     sys.stderr.write(stderr_text)
     raise SystemExit(2)
 '''.strip()
+
+
+LOOPX_TODO_OUTPUT_INSTRUMENTATION_SOURCE = r'''
+def successful_todo_add_id_from_bridge_stdout(
+    subcommands: list[str],
+    bridge_stdout: str,
+) -> str:
+    if subcommands[:2] != ["todo", "add"]:
+        return ""
+    try:
+        response = json.loads(bridge_stdout or "")
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return ""
+    if not isinstance(response, dict):
+        return ""
+    if response.get("ok") is False or response.get("success") is False:
+        return ""
+    for field in ("exit_code", "returncode"):
+        value = response.get(field)
+        if isinstance(value, int) and not isinstance(value, bool) and value != 0:
+            return ""
+
+    candidates = [response]
+    nested_stdout = response.get("stdout")
+    if isinstance(nested_stdout, str):
+        try:
+            nested_response = json.loads(nested_stdout)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            nested_response = None
+        if isinstance(nested_response, dict):
+            candidates.append(nested_response)
+
+    todo_ids = {
+        str(candidate.get("todo_id") or "")
+        for candidate in candidates
+        if re.fullmatch(
+            r"todo_[A-Za-z0-9_-]{6,80}",
+            str(candidate.get("todo_id") or ""),
+        )
+    }
+    return next(iter(todo_ids)) if len(todo_ids) == 1 else ""
+
+def attach_successful_todo_add_id(record, subcommands, bridge_stdout) -> None:
+    if record.get("returncode") != 0 or record.get("loopx_todo_id"):
+        return
+    todo_id = successful_todo_add_id_from_bridge_stdout(
+        subcommands,
+        bridge_stdout,
+    )
+    if todo_id:
+        record["loopx_todo_id"] = todo_id
+'''.strip()


### PR DESCRIPTION
## Summary
- recover the unique public-safe `todo_id` from successful JSON `todo add` bridge responses
- record only the validated ID in host-local ACP operation traces; raw stdout remains excluded
- cover the double-encoded bridge response and private-output boundary end to end

## Product judgment
Matched `/loopx` benchmark analysis could not reconstruct agent-authored plan order when the CLI generated todo IDs. This change repairs that observability contract without changing benchmark scoring, task semantics, runner behavior, or stop policy. The parser is bounded to successful `todo add` responses and a strict public ID shape.

## Validation
- `python3 examples/skillsbench-goal-start-product-mode-route-smoke.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `python3 -m py_compile loopx/benchmark_adapters/skillsbench_bridge_guard.py loopx/benchmark_adapters/skillsbench_acp_relay.py examples/skillsbench-goal-start-product-mode-route-smoke.py`
- `loopx canary premerge --from-git-diff`: all 6 selected catalog checks and public-boundary check passed; policy reported the expected `benchmark_sensitive` manual hold
- `git diff --check origin/main...HEAD`

## Boundary and merge authorization
No private state, raw benchmark evidence, credentials, local paths, generated logs, uploads, or submissions are included. Owner explicitly authorized self-merging benchmark-related changes; this is a benchmark observation helper only, with no official scoring or task-semantic change.