### PR TITLE
Add safe Explore source history reconciliation

### DIFF
--- a/loopx/capabilities/explore/result_log.py
+++ b/loopx/capabilities/explore/result_log.py
@@ -473,8 +473,9 @@ def append_explore_result_event(path: Path, event: Mapping[str, Any]) -> dict[st
     validated = validate_explore_result_event(event)
     log_path = path.expanduser()
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    with log_path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(validated, ensure_ascii=False, sort_keys=True) + "\n")
+    with exclusive_file_lock(log_path):
+        with log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(validated, ensure_ascii=False, sort_keys=True) + "\n")
     return {
         "ok": True,
         "schema_version": EXPLORE_RESULT_EVENT_SCHEMA_VERSION,

--- a/loopx/capabilities/explore/result_log.py
+++ b/loopx/capabilities/explore/result_log.py
@@ -20,6 +20,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
+from ...file_lock import exclusive_file_lock
+
 
 EXPLORE_RESULT_EVENT_SCHEMA_VERSION = "loopx_explore_result_event_v0"
 EXPLORE_RESULT_PROJECTION_VERSION = "loopx_explore_result_projection_v0"
@@ -398,22 +400,138 @@ def _base_event(
     return event
 
 
-def append_explore_result_event(path: Path, event: Mapping[str, Any]) -> dict[str, Any]:
-    if event.get("schema_version") != EXPLORE_RESULT_EVENT_SCHEMA_VERSION:
-        raise ValueError(
-            f"explore result event must use schema {EXPLORE_RESULT_EVENT_SCHEMA_VERSION}"
+def validate_explore_result_event(
+    event: Mapping[str, Any],
+    *,
+    expected_goal_id: str | None = None,
+) -> dict[str, Any]:
+    """Return one canonical public-safe Explore event or fail closed.
+
+    Event builders are the schema authority. Rebuilding the event catches
+    unknown fields, invalid ids, unsafe text, forged boundary flags, and stale
+    event ids without maintaining a second field-level validator.
+    """
+
+    payload = dict(event)
+    if payload.get("schema_version") != EXPLORE_RESULT_EVENT_SCHEMA_VERSION:
+        raise ValueError(f"explore result event must use schema {EXPLORE_RESULT_EVENT_SCHEMA_VERSION}")
+    event_kind = str(payload.get("event_kind") or "")
+    if event_kind not in EXPLORE_EVENT_KINDS:
+        raise ValueError(f"unsupported explore result event kind {event_kind!r}")
+    goal_id = _safe_goal_id(payload.get("goal_id"))
+    if expected_goal_id is not None and goal_id != _safe_goal_id(expected_goal_id):
+        raise ValueError("explore result event belongs to a different goal")
+    if payload.get("boundary") != PUBLIC_BOUNDARY:
+        raise ValueError("explore result event must declare the public-safe boundary")
+
+    common = {
+        "goal_id": goal_id,
+        "summary": payload.get("summary"),
+        "agent_id": payload.get("agent_id"),
+        "run_id": payload.get("run_id"),
+        "recorded_at": payload.get("recorded_at"),
+    }
+    if event_kind == EVENT_KIND_NODE:
+        rebuilt = build_explore_node_event(
+            **common,
+            title=payload.get("title"),
+            node_id=payload.get("result_id"),
+            node_kind=payload.get("node_kind"),
+            status=payload.get("status"),
+            blocked_reason=payload.get("blocked_reason"),
+            parent_id=payload.get("parent_id"),
+            evidence_refs=payload.get("evidence_refs"),
+            tags=payload.get("tags"),
+            supersedes=payload.get("supersedes"),
         )
+    elif event_kind == EVENT_KIND_EDGE:
+        rebuilt = build_explore_edge_event(
+            **common,
+            from_node=payload.get("from_node"),
+            to_node=payload.get("to_node"),
+            edge_type=payload.get("edge_type"),
+            confidence=payload.get("confidence"),
+        )
+    else:
+        rebuilt = build_explore_finding_event(
+            **common,
+            title=payload.get("title"),
+            finding_id=payload.get("result_id"),
+            node_id=payload.get("node_id"),
+            status=payload.get("status"),
+            confidence=payload.get("confidence"),
+            evidence_refs=payload.get("evidence_refs"),
+            tags=payload.get("tags"),
+            supersedes=payload.get("supersedes"),
+        )
+    if payload != rebuilt:
+        raise ValueError("explore result event is not canonical or contains unknown fields")
+    return rebuilt
+
+
+def append_explore_result_event(path: Path, event: Mapping[str, Any]) -> dict[str, Any]:
+    validated = validate_explore_result_event(event)
     log_path = path.expanduser()
     log_path.parent.mkdir(parents=True, exist_ok=True)
     with log_path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(dict(event), ensure_ascii=False, sort_keys=True) + "\n")
+        handle.write(json.dumps(validated, ensure_ascii=False, sort_keys=True) + "\n")
     return {
         "ok": True,
         "schema_version": EXPLORE_RESULT_EVENT_SCHEMA_VERSION,
         "path": str(log_path),
-        "event_id": event.get("event_id"),
-        "result_id": event.get("result_id"),
-        "event_kind": event.get("event_kind"),
+        "event_id": validated.get("event_id"),
+        "result_id": validated.get("result_id"),
+        "event_kind": validated.get("event_kind"),
+    }
+
+
+def append_explore_result_events(
+    path: Path,
+    events: Sequence[Mapping[str, Any]],
+    *,
+    expected_goal_id: str,
+) -> dict[str, Any]:
+    """Append a validated batch once by event id under the result-log lock."""
+
+    validated = [validate_explore_result_event(event, expected_goal_id=expected_goal_id) for event in events]
+    requested_ids = [str(event["event_id"]) for event in validated]
+    if len(requested_ids) != len(set(requested_ids)):
+        raise ValueError("Explore result event batch contains duplicate event ids")
+
+    log_path = path.expanduser()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    appended = 0
+    reused = 0
+    with exclusive_file_lock(log_path):
+        existing_by_id: dict[str, dict[str, Any]] = {}
+        if log_path.exists():
+            for line in log_path.read_text(encoding="utf-8").splitlines():
+                try:
+                    current = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(current, dict) and current.get("event_id"):
+                    existing_by_id[str(current["event_id"])] = current
+        pending: list[dict[str, Any]] = []
+        for event in validated:
+            event_id = str(event["event_id"])
+            existing = existing_by_id.get(event_id)
+            if existing is None:
+                pending.append(event)
+                continue
+            if existing != event:
+                raise ValueError(f"conflicting Explore result event id: {event_id}")
+            reused += 1
+        if pending:
+            with log_path.open("a", encoding="utf-8") as handle:
+                handle.write("".join(json.dumps(event, ensure_ascii=False, sort_keys=True) + "\n" for event in pending))
+            appended = len(pending)
+    return {
+        "ok": True,
+        "schema_version": EXPLORE_RESULT_EVENT_SCHEMA_VERSION,
+        "requested_event_count": len(validated),
+        "appended_event_count": appended,
+        "reused_event_count": reused,
     }
 
 
@@ -446,6 +564,34 @@ def load_explore_result_events(
         events.append(payload)
     if limit is not None and limit >= 0:
         events = events[-limit:] if limit else []
+    return events
+
+
+def load_explore_result_events_strict(
+    path: Path,
+    *,
+    goal_id: str,
+) -> list[dict[str, Any]]:
+    """Load a complete result log and reject malformed or unsafe rows."""
+
+    log_path = path.expanduser()
+    if not log_path.exists():
+        return []
+    events: list[dict[str, Any]] = []
+    for line_number, line in enumerate(log_path.read_text(encoding="utf-8").splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            payload = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid Explore result JSON at line {line_number}") from exc
+        if not isinstance(payload, dict):
+            raise ValueError(f"Explore result row {line_number} is not an object")
+        try:
+            events.append(validate_explore_result_event(payload, expected_goal_id=goal_id))
+        except ValueError as exc:
+            raise ValueError(f"invalid Explore result event at line {line_number}: {exc}") from exc
     return events
 
 

--- a/loopx/capabilities/explore/source_history_reconcile.py
+++ b/loopx/capabilities/explore/source_history_reconcile.py
@@ -1,0 +1,255 @@
+"""Reconcile a canonical Explore result source from a public-safe candidate log."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from .result_log import (
+    EVENT_KIND_EDGE,
+    EVENT_KIND_FINDING,
+    EVENT_KIND_NODE,
+    PUBLIC_BOUNDARY,
+    append_explore_result_events,
+    build_explore_result_projection,
+    load_explore_result_events_strict,
+)
+
+
+SCHEMA_VERSION = "loopx_explore_source_history_reconcile_v0"
+_TABLE_BY_EVENT_KIND = {
+    EVENT_KIND_NODE: "nodes",
+    EVENT_KIND_EDGE: "edges",
+    EVENT_KIND_FINDING: "findings",
+}
+_PROJECTION_COLLECTIONS = (
+    ("nodes", "node_id"),
+    ("edges", "edge_id"),
+    ("findings", "finding_id"),
+)
+
+
+def _digest(values: Sequence[str] | set[str]) -> str | None:
+    normalized = sorted(set(values))
+    if not normalized:
+        return None
+    encoded = json.dumps(normalized, ensure_ascii=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:16]
+
+
+def _source_ref_digest(path: Path) -> str:
+    return hashlib.sha256(str(path.expanduser().resolve()).encode("utf-8")).hexdigest()[:16]
+
+
+def _projection_result_keys(projection: Mapping[str, Any], *, goal_id: str) -> set[str]:
+    keys: set[str] = set()
+    for table_key, result_id_key in _PROJECTION_COLLECTIONS:
+        for item in projection.get(table_key) or []:
+            if not isinstance(item, Mapping):
+                continue
+            result_id = str(item.get(result_id_key) or "").strip()
+            if result_id:
+                keys.add(f"{goal_id}:{table_key}:{result_id}")
+    return keys
+
+
+def _projection(events: Sequence[Mapping[str, Any]], *, goal_id: str) -> dict[str, Any]:
+    return build_explore_result_projection(
+        events,
+        goal_id=goal_id,
+        finding_limit=len(events),
+        mermaid_node_limit=max(1, len(events)),
+    )
+
+
+def _by_table(keys: set[str], *, goal_id: str) -> dict[str, int]:
+    prefix = f"{goal_id}:"
+    counts: Counter[str] = Counter()
+    for key in keys:
+        suffix = key.removeprefix(prefix)
+        counts[suffix.split(":", 1)[0]] += 1
+    return dict(sorted(counts.items()))
+
+
+def _latest_by_result_id(
+    events: Sequence[Mapping[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    latest: dict[str, dict[str, Any]] = {}
+    for event in events:
+        result_id = str(event.get("result_id") or "").strip()
+        if result_id:
+            latest[result_id] = dict(event)
+    return latest
+
+
+def _direct_projection_key(event: Mapping[str, Any], *, goal_id: str) -> str:
+    table = _TABLE_BY_EVENT_KIND[str(event["event_kind"])]
+    return f"{goal_id}:{table}:{event['result_id']}"
+
+
+def _materialized_parent_edge_keys(projection: Mapping[str, Any], *, goal_id: str) -> set[str]:
+    return {
+        f"{goal_id}:edges:{edge['edge_id']}"
+        for edge in projection.get("edges") or []
+        if isinstance(edge, Mapping) and edge.get("materialized_from") == "node_parent_id" and edge.get("edge_id")
+    }
+
+
+def reconcile_explore_source_history(
+    *,
+    canonical_log_path: Path,
+    candidate_log_path: Path,
+    goal_id: str,
+    registered_result_keys: Sequence[str] | set[str],
+    execute: bool = False,
+) -> dict[str, Any]:
+    """Recover registered public-safe results without deleting remote rows.
+
+    Only the latest canonical event for a result id absent from the canonical
+    source is eligible. Its direct projection key must already exist in the
+    registered sink baseline. Derived rows that remain absent are classified,
+    never synthesized or deleted by this non-destructive command.
+    """
+
+    canonical_events = load_explore_result_events_strict(canonical_log_path, goal_id=goal_id)
+    candidate_events = load_explore_result_events_strict(candidate_log_path, goal_id=goal_id)
+    registered = {
+        str(key)
+        for key in registered_result_keys
+        if any(str(key).startswith(f"{goal_id}:{table}:") for table in _TABLE_BY_EVENT_KIND.values())
+    }
+    if not registered:
+        raise ValueError("Explore source reconciliation requires a registered sink baseline")
+
+    canonical_projection = _projection(canonical_events, goal_id=goal_id)
+    candidate_projection = _projection(candidate_events, goal_id=goal_id)
+    canonical_keys = _projection_result_keys(canonical_projection, goal_id=goal_id)
+    candidate_keys = _projection_result_keys(candidate_projection, goal_id=goal_id)
+    missing_before = registered - canonical_keys
+
+    canonical_result_ids = {str(event.get("result_id") or "") for event in canonical_events}
+    candidate_latest = _latest_by_result_id(candidate_events)
+    selected_events = [
+        event
+        for result_id, event in candidate_latest.items()
+        if result_id not in canonical_result_ids and _direct_projection_key(event, goal_id=goal_id) in missing_before
+    ]
+    selected_events.sort(
+        key=lambda event: (
+            str(event.get("recorded_at") or ""),
+            str(event.get("event_id") or ""),
+        )
+    )
+
+    planned_events = [*canonical_events, *selected_events]
+    planned_projection = _projection(planned_events, goal_id=goal_id)
+    planned_keys = _projection_result_keys(planned_projection, goal_id=goal_id)
+    newly_projected = planned_keys - canonical_keys
+    unexpected_new = newly_projected - registered
+    if unexpected_new:
+        raise ValueError("candidate history would add projection rows outside the registered baseline")
+
+    recovered = missing_before & planned_keys
+    remaining = registered - planned_keys
+    stale_parent_edges = remaining & _materialized_parent_edge_keys(candidate_projection, goal_id=goal_id)
+    unresolved_orphans = remaining - stale_parent_edges
+    selected_event_ids = {str(event.get("event_id") or "") for event in selected_events}
+
+    writeback = {
+        "performed": False,
+        "requested_event_count": len(selected_events),
+        "appended_event_count": 0,
+        "reused_event_count": 0,
+        "readback_verified": None,
+    }
+    post_keys = canonical_keys
+    if execute and selected_events:
+        append_receipt = append_explore_result_events(
+            canonical_log_path,
+            selected_events,
+            expected_goal_id=goal_id,
+        )
+        post_events = load_explore_result_events_strict(canonical_log_path, goal_id=goal_id)
+        post_event_ids = {str(event.get("event_id") or "") for event in post_events}
+        post_projection = _projection(post_events, goal_id=goal_id)
+        post_keys = _projection_result_keys(post_projection, goal_id=goal_id)
+        readback_verified = bool(
+            selected_event_ids <= post_event_ids
+            and planned_keys <= post_keys
+            and not (registered & planned_keys) - post_keys
+        )
+        if not readback_verified:
+            raise RuntimeError("Explore source reconciliation readback failed")
+        writeback.update(
+            {
+                "performed": True,
+                "appended_event_count": int(append_receipt["appended_event_count"]),
+                "reused_event_count": int(append_receipt["reused_event_count"]),
+                "readback_verified": True,
+            }
+        )
+
+    effective_keys = post_keys if execute else planned_keys
+    effective_remaining = registered - effective_keys
+    if selected_events:
+        status = "reconciled" if execute else "would_reconcile"
+    else:
+        status = "already_reconciled"
+    if effective_remaining:
+        status += "_with_remote_orphans"
+
+    return {
+        "ok": True,
+        "schema_version": SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "execute": bool(execute),
+        "status": status,
+        "source_refs": {
+            "canonical_sha256_16": _source_ref_digest(canonical_log_path),
+            "candidate_sha256_16": _source_ref_digest(candidate_log_path),
+            "raw_paths_returned": False,
+        },
+        "source_counts": {
+            "canonical_event_count": len(canonical_events),
+            "candidate_event_count": len(candidate_events),
+            "candidate_result_count": len(candidate_latest),
+        },
+        "plan": {
+            "selected_event_count": len(selected_events),
+            "selected_event_ids_sha256_16": _digest(selected_event_ids),
+            "latest_event_per_missing_result": True,
+            "raw_history_copied": False,
+        },
+        "projection_reconciliation": {
+            "canonical_result_count": len(canonical_keys),
+            "candidate_result_count": len(candidate_keys),
+            "registered_result_count": len(registered),
+            "missing_before_count": len(missing_before),
+            "missing_before_by_table": _by_table(missing_before, goal_id=goal_id),
+            "recovered_lost_history_count": len(recovered),
+            "recovered_lost_history_by_table": _by_table(recovered, goal_id=goal_id),
+            "recovered_lost_history_sha256_16": _digest(recovered),
+            "remaining_registered_result_count": len(effective_remaining),
+            "remaining_registered_by_table": _by_table(effective_remaining, goal_id=goal_id),
+            "remaining_registered_sha256_16": _digest(effective_remaining),
+            "unexpected_new_result_count": len(unexpected_new),
+        },
+        "classification": {
+            "lost_history_recovered_count": len(recovered),
+            "stale_materialized_parent_edge_count": len(stale_parent_edges),
+            "unresolved_orphan_count": len(unresolved_orphans),
+            "remote_deletion_required": bool(effective_remaining),
+            "remote_deletion_performed": False,
+        },
+        "writeback": writeback,
+        "boundary": {
+            **PUBLIC_BOUNDARY,
+            "candidate_events_strictly_validated": True,
+            "registered_baseline_only": True,
+            "destructive_remote_action_performed": False,
+        },
+    }

--- a/loopx/cli_commands/explore.py
+++ b/loopx/cli_commands/explore.py
@@ -23,6 +23,9 @@ from ..capabilities.explore.result_log import (
 )
 from ..capabilities.explore.harness_gate import GATE_STATE_DISABLED
 from ..capabilities.explore.resource_portfolio import parse_resource_counts
+from ..capabilities.explore.source_history_reconcile import (
+    reconcile_explore_source_history,
+)
 from ..capabilities.explore.todo_branch_plan import (
     build_explore_todo_branch_plan,
     resolve_todo_branch_plan_gate,
@@ -142,6 +145,23 @@ def register_explore_commands(
     add_subcommand_format(presentation)
     presentation.add_argument("--goal-id", required=True)
     _add_projection_limit_args(presentation)
+
+    source_reconcile = sub.add_parser(
+        "source-history-reconcile",
+        help=(
+            "Recover registered public-safe results from another runtime log. "
+            "Preview only unless --execute; never deletes remote rows."
+        ),
+    )
+    add_subcommand_format(source_reconcile)
+    source_reconcile.add_argument("--goal-id", required=True)
+    source_reconcile.add_argument(
+        "--candidate-runtime-root",
+        required=True,
+        help="Runtime root containing the candidate goal result log.",
+    )
+    _add_config_path_arg(source_reconcile)
+    source_reconcile.add_argument("--execute", action="store_true")
 
     graph = sub.add_parser(
         "graph",
@@ -638,6 +658,22 @@ def handle_explore_command(
                 finding_limit_override=-1,
             )
             payload = build_explore_presentation_bundle(projection)
+        elif args.explore_command == "source-history-reconcile":
+            local = read_lark_explore_local_config(config_path)
+            result_records = (
+                local.get("result_records")
+                if isinstance(local.get("result_records"), dict)
+                else {}
+            )
+            payload = reconcile_explore_source_history(
+                canonical_log_path=explore_result_log_path(runtime_root, args.goal_id),
+                candidate_log_path=explore_result_log_path(
+                    Path(args.candidate_runtime_root), args.goal_id
+                ),
+                goal_id=args.goal_id,
+                registered_result_keys=set(result_records),
+                execute=bool(args.execute),
+            )
         elif args.explore_command == "graph":
             projection = _projection_for(args, runtime_root=runtime_root)
             graph_view = build_explore_graph_view(

--- a/tests/test_explore_source_history_reconcile.py
+++ b/tests/test_explore_source_history_reconcile.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from loopx.capabilities.explore.result_log import (
+    append_explore_result_event,
+    build_explore_finding_event,
+    build_explore_node_event,
+    build_explore_result_projection,
+    load_explore_result_events_strict,
+    validate_explore_result_event,
+)
+from loopx.capabilities.explore.source_history_reconcile import (
+    reconcile_explore_source_history,
+)
+
+
+GOAL_ID = "source-history-fixture"
+
+
+def _append(path: Path, *events: dict[str, object]) -> None:
+    for event in events:
+        append_explore_result_event(path, event)
+
+
+def _projection_keys(path: Path) -> set[str]:
+    events = load_explore_result_events_strict(path, goal_id=GOAL_ID)
+    projection = build_explore_result_projection(
+        events,
+        goal_id=GOAL_ID,
+        finding_limit=len(events),
+        mermaid_node_limit=max(1, len(events)),
+    )
+    keys: set[str] = set()
+    for table, id_key in (
+        ("nodes", "node_id"),
+        ("edges", "edge_id"),
+        ("findings", "finding_id"),
+    ):
+        keys.update(f"{GOAL_ID}:{table}:{row[id_key]}" for row in projection[table])
+    return keys
+
+
+def test_event_validation_rejects_unknown_private_fields() -> None:
+    event = build_explore_node_event(
+        goal_id=GOAL_ID,
+        node_id="node_one",
+        title="Public fixture node",
+    )
+    event["raw_transcript"] = "must not cross the boundary"
+
+    with pytest.raises(ValueError, match="not canonical"):
+        validate_explore_result_event(event, expected_goal_id=GOAL_ID)
+
+
+def test_reconcile_recovers_lost_results_and_classifies_stale_parent_edge(
+    tmp_path: Path,
+) -> None:
+    canonical = tmp_path / "canonical.jsonl"
+    candidate = tmp_path / "candidate.jsonl"
+    parent_old = build_explore_node_event(
+        goal_id=GOAL_ID,
+        node_id="parent_old",
+        title="Earlier parent",
+        recorded_at="2026-01-01T00:00:00Z",
+    )
+    parent_new = build_explore_node_event(
+        goal_id=GOAL_ID,
+        node_id="parent_new",
+        title="Current parent",
+        recorded_at="2026-01-01T00:00:01Z",
+    )
+    child_old = build_explore_node_event(
+        goal_id=GOAL_ID,
+        node_id="child",
+        title="Moved child",
+        parent_id="parent_old",
+        recorded_at="2026-01-01T00:00:02Z",
+    )
+    child_new = build_explore_node_event(
+        goal_id=GOAL_ID,
+        node_id="child",
+        title="Moved child",
+        parent_id="parent_new",
+        recorded_at="2026-01-02T00:00:00Z",
+    )
+    lost_node = build_explore_node_event(
+        goal_id=GOAL_ID,
+        node_id="lost_node",
+        title="Public-safe lost node",
+        parent_id="parent_old",
+        recorded_at="2026-01-01T00:00:03Z",
+    )
+    lost_finding = build_explore_finding_event(
+        goal_id=GOAL_ID,
+        finding_id="lost_finding",
+        node_id="lost_node",
+        title="Public-safe lost finding",
+        recorded_at="2026-01-01T00:00:04Z",
+    )
+    _append(canonical, parent_old, parent_new, child_new)
+    _append(
+        candidate,
+        parent_old,
+        parent_new,
+        child_old,
+        lost_node,
+        lost_finding,
+    )
+    registered = _projection_keys(canonical) | _projection_keys(candidate)
+
+    preview = reconcile_explore_source_history(
+        canonical_log_path=canonical,
+        candidate_log_path=candidate,
+        goal_id=GOAL_ID,
+        registered_result_keys=registered,
+    )
+
+    assert preview["status"] == "would_reconcile_with_remote_orphans"
+    assert preview["plan"]["selected_event_count"] == 2
+    assert preview["plan"]["raw_history_copied"] is False
+    assert preview["projection_reconciliation"]["recovered_lost_history_count"] == 3
+    assert preview["projection_reconciliation"]["remaining_registered_result_count"] == 1
+    assert preview["classification"]["stale_materialized_parent_edge_count"] == 1
+    assert preview["classification"]["remote_deletion_performed"] is False
+    assert len(load_explore_result_events_strict(canonical, goal_id=GOAL_ID)) == 3
+
+    executed = reconcile_explore_source_history(
+        canonical_log_path=canonical,
+        candidate_log_path=candidate,
+        goal_id=GOAL_ID,
+        registered_result_keys=registered,
+        execute=True,
+    )
+
+    assert executed["status"] == "reconciled_with_remote_orphans"
+    assert executed["writeback"] == {
+        "performed": True,
+        "requested_event_count": 2,
+        "appended_event_count": 2,
+        "reused_event_count": 0,
+        "readback_verified": True,
+    }
+    assert len(load_explore_result_events_strict(canonical, goal_id=GOAL_ID)) == 5
+
+    repeated = reconcile_explore_source_history(
+        canonical_log_path=canonical,
+        candidate_log_path=candidate,
+        goal_id=GOAL_ID,
+        registered_result_keys=registered,
+        execute=True,
+    )
+
+    assert repeated["status"] == "already_reconciled_with_remote_orphans"
+    assert repeated["plan"]["selected_event_count"] == 0
+    assert repeated["writeback"]["performed"] is False
+    assert len(load_explore_result_events_strict(canonical, goal_id=GOAL_ID)) == 5


### PR DESCRIPTION
## Summary
- add a preview-first `explore source-history-reconcile` command for split-runtime recovery
- strictly rebuild and validate public-safe candidate events before append-only import
- recover only sink-registered missing results, classify remaining stale materialized parent edges, and never delete remote rows
- add idempotent locked batch append and focused regression coverage

## Validation
- `pytest -q tests/test_explore_source_history_reconcile.py tests/control_plane/test_explore_source_runtime_route.py` (7 passed)
- `python examples/explore-result-layer-smoke.py`
- `python examples/lark-explore-source-runtime-route-smoke.py`
- `loopx canary premerge --from-git-diff` (8/8 selected canaries passed; no manual holds)
- real split-runtime preview: 53 registered gaps classified as 47 recoverable lost-history projections and 6 stale materialized parent edges, with zero unexpected new projections

## Boundary
- no runtime logs, registry state, connector configuration, credentials, local paths, or private evidence committed
- command returns only counts and digests for source reconciliation evidence
- remote deletion remains an explicit separate action

## Merge decision
Self-merge authorized by the owner; premerge gate reports `self_merge_allowed=true`.