### PR TITLE
Keep full findings in issue-fix Explore sync

### DIFF
--- a/examples/issue-fix-explore-projection-smoke.py
+++ b/examples/issue-fix-explore-projection-smoke.py
@@ -25,6 +25,11 @@ from loopx.capabilities.issue_fix.pr_lifecycle import (  # noqa: E402
 from loopx.capabilities.explore.activation import (  # noqa: E402
     sync_explore_graph_after_material_refresh,
 )
+from loopx.capabilities.explore.result_log import (  # noqa: E402
+    append_explore_result_event,
+    build_explore_finding_event,
+    explore_result_log_path,
+)
 from loopx.domain_packs.issue_fix import (  # noqa: E402
     default_issue_fix_domain_state_ledger_path,
     default_issue_fix_feasibility_ledger_path,
@@ -216,6 +221,23 @@ def main() -> None:
         )
         assert unrelated["applicable"] is False, unrelated
         assert unrelated["material_event_count"] == 0, unrelated
+        unrelated_log = explore_result_log_path(runtime, "unrelated-goal")
+        for index in range(205):
+            append_explore_result_event(
+                unrelated_log,
+                build_explore_finding_event(
+                    goal_id="unrelated-goal",
+                    finding_id=f"finding_{index}",
+                    title=f"Public fixture finding {index}",
+                ),
+            )
+        full_findings = project_issue_fix_explore_graph(
+            registry_path=registry,
+            goal_id="unrelated-goal",
+            project=project,
+        )
+        assert full_findings["counts"]["finding_count"] == 205, full_findings
+        assert len(full_findings["projection"]["findings"]) == 205, full_findings
         upsert_issue_fix_feasibility_ledger_jsonl(
             default_issue_fix_feasibility_ledger_path(project=project, goal_id=goal_id),
             feasibility_packet(),

--- a/loopx/capabilities/issue_fix/explore_projection.py
+++ b/loopx/capabilities/issue_fix/explore_projection.py
@@ -674,7 +674,11 @@ def project_issue_fix_explore_graph(
         for event in material_events:
             append_explore_result_event(result_log, event)
     projected_events = [*existing_events, *material_events]
-    projection = build_explore_result_projection(projected_events, goal_id=goal_id)
+    projection = build_explore_result_projection(
+        projected_events,
+        goal_id=goal_id,
+        finding_limit=len(projected_events),
+    )
     digest = _semantic_projection_digest(projection)
     return {
         "ok": True,


### PR DESCRIPTION
## Summary
- build the automatic issue-fix Explore projection with the complete finding set
- keep the default bounded finding limit for ordinary display callers
- add a public smoke proving more than 200 findings survive the issue-fix sync projection

## Motivation
The source coverage guard compared a registered append-only sink baseline against an intentionally truncated 200-finding display projection. A healthy canonical source could therefore be misreported as missing rows after source reconciliation.

## Validation
- `python3 examples/issue-fix-explore-projection-smoke.py`
- `loopx canary premerge --from-git-diff`: 6/6 selected checks passed, including public-boundary validation; no warnings or manual holds; `self_merge_allowed=true`

## Boundary
Only generic public fixture data is added. No runtime state, private evidence, credentials, connector values, or local paths are included.

## Merge decision
Self-merge authorized by the owner after GitHub pytest passes.