### PR TITLE
Record countable Codex Goal baseline contracts

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -1274,7 +1274,14 @@ def _assert_cli_goal_active_timeout_is_public_countability_stage() -> None:
         "failure_attribution_labels": [],
     }
     assert _apply_codex_cli_goal_countability_guard_attribution(compact) is False
-    assert "codex_cli_goal_countability_contract" not in compact
+    contract = compact["codex_cli_goal_countability_contract"]
+    assert contract["countable_baseline"] is True, contract
+    assert contract["countability_source"] == (
+        "official_score_completed_with_task_facing_activity"
+    ), contract
+    assert contract["request_count"] == 4, contract
+    assert contract["task_facing_activity_count"] == 3, contract
+    assert contract["raw_material_recorded"] is False, contract
 
     post_bridge_timeout_trace = dict(completed_attempt_trace)
     post_bridge_timeout_trace.update(
@@ -1468,7 +1475,12 @@ def _assert_cli_goal_active_timeout_is_public_countability_stage() -> None:
         "failure_attribution_labels": ["official_score_zero_case_failure"],
     }
     assert _apply_codex_cli_goal_countability_guard_attribution(compact) is False
-    assert "codex_cli_goal_countability_contract" not in compact
+    contract = compact["codex_cli_goal_countability_contract"]
+    assert contract["countable_baseline"] is True, contract
+    assert contract["countability_source"] == (
+        "official_score_completed_with_task_facing_activity"
+    ), contract
+    assert contract["raw_material_recorded"] is False, contract
 
 
 def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> None:

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -4947,6 +4947,23 @@ def _apply_codex_cli_goal_countability_guard_attribution(
         )
     )
     if not (missing_task_activity or goal_failed):
+        compact["codex_cli_goal_countability_contract"] = {
+            "schema_version": "skillsbench_codex_cli_goal_countability_contract_v0",
+            "required": True,
+            "countable_baseline": True,
+            "countability_source": (
+                "official_score_completed_with_task_facing_activity"
+            ),
+            "failure_category": "",
+            "first_blocker": "",
+            "trace_present": trace_present,
+            "ok_count": ok_count,
+            "goal_stage": goal_stage,
+            "request_count": request_count,
+            "task_facing_activity_count": task_facing_count,
+            "operation_trace_status": operation_trace_status,
+            "raw_material_recorded": False,
+        }
         return False
 
     label = "skillsbench_codex_cli_goal_uncountable_no_task_activity"
@@ -5010,6 +5027,7 @@ def _apply_codex_cli_goal_countability_guard_attribution(
         "schema_version": "skillsbench_codex_cli_goal_countability_contract_v0",
         "required": True,
         "countable_baseline": False,
+        "countability_source": "codex_cli_goal_countability_guard",
         "failure_category": label,
         "first_blocker": label,
         "trace_present": trace_present,


### PR DESCRIPTION
## Summary
- emit a typed public countability contract for successful canonical Codex Goal baseline attempts
- retain the existing fail-closed uncountable attribution and add an explicit source label
- cover countable task-facing traces in the dedicated Codex Goal route smoke

## Validation
- skillsbench-codex-cli-goal-route-smoke ok
- skillsbench-benchmark-run-smoke: ok
- repo-python-line-budget-smoke: ok (1198 tracked Python files, default_max=2000, legacy_budgets=19, changed_python_files=2, existing_over_budget=0, strict=False)
- # Pre-Merge Validation Gate

- status: `manual_review_required`
- ok: `false`
- merge_gate_passed: `false`
- self_merge_allowed: `false`
- tier: `standard`
- dry_run: `false`
- changed_files: `2`
- surfaces: `public_boundary, benchmark_sensitive, python`
- risk_profiles: ``
- manual_holds: `1`

Pre-merge validation is a risk-based gate: it runs diff hygiene, changed Python compile checks, catalog-selected canaries, risk-profile smokes, and public/private boundary checks. It reports manual holds for benchmark-sensitive or reviewer-gated surfaces instead of treating local smoke success as self-merge permission.

## Direct Checks
- `diff_check_committed`: `passed` `git diff --check origin/main...HEAD`
- `diff_check_staged`: `passed` `git diff --cached --check`
- `diff_check_unstaged`: `passed` `git diff --check`
- `changed_python_py_compile`: `passed` `python3 -m py_compile examples/skillsbench-codex-cli-goal-route-smoke.py scripts/skillsbench_automation_loop.py`

## Catalog Canaries
- ok: `true`
- selected_checks: `4`
- executed_checks: `4`
- failures: `0`
- advisory_failures: `0`
- warnings: `0`
- `passed` python3 examples/control_plane/repo-python-line-budget-smoke.py
- `passed` python3 examples/terminal-bench-adapter-readiness-characterization-smoke.py
- `passed` python3 examples/benchmark-core-adapter-contract-smoke.py
- `passed` python3 examples/benchmark-artifact-path-filter-smoke.py

## Public Boundary
- ok: `true`
- selected_checks: `1`
- executed_checks: `1`
- failures: `0`
- advisory_failures: `0`
- warnings: `0`
- `passed` loopx check --scan-path examples/skillsbench-codex-cli-goal-route-smoke.py --scan-path scripts/skillsbench_automation_loop.py

## Manual Holds
- `benchmark_sensitive`: benchmark adapter, scoring, runner, or evidence paths require explicit maintainer review before self-merge (all automated checks passed; expected benchmark-sensitive manual hold remains)
- public/private boundary scan clean

No benchmark jobs were launched. This does not change scoring, task semantics, stopping behavior, submission behavior, or permission boundaries.