### PR TITLE
Align agent management with runnable todo routing

### DIFF
--- a/apps/presentation/dashboard/src/data/status.ts
+++ b/apps/presentation/dashboard/src/data/status.ts
@@ -164,6 +164,7 @@ export const agentManagementRowSchema = z.object({
   handoff_note: agentManagementHandoffNoteSchema.optional().nullable(),
   workspace_ref: agentManagementWorkspaceRefSchema.optional().nullable(),
   stale_claim_hint: agentManagementStaleClaimHintSchema.optional().nullable(),
+  blocked_on: agentManagementTodoRowSchema.optional().nullable(),
   goal_ids: z.array(z.string()).optional().default([]),
 }).passthrough();
 

--- a/apps/presentation/dashboard/src/views/dashboard-page.tsx
+++ b/apps/presentation/dashboard/src/views/dashboard-page.tsx
@@ -1546,9 +1546,9 @@ function buildAgentManagementRows(
       primaryGoalId,
       quotaHints,
       staleClaimHint,
-      status: claimedTodos.length > 0
-        ? agentManagementStatus(openTodos, claimedTodos)
-        : agentManagementProjectionStatus(projected?.state),
+      status: projected?.state
+        ? agentManagementProjectionStatus(projected.state)
+        : agentManagementStatus(openTodos, claimedTodos),
       workspaceRef,
     };
   }).sort((left, right) => {

--- a/docs/reference/protocols/agent-management-projection-v0.md
+++ b/docs/reference/protocols/agent-management-projection-v0.md
@@ -111,6 +111,12 @@ Optional fields:
 - `recent_events`;
 - `display_tone`.
 
+When runnable advancement work exists alongside blocked maintenance, the
+projection keeps the runnable todo in `current_todo` and may expose the
+highest-priority blocked maintenance todo as a separate `blocked_on`
+`todo_row_v0`. The blocker remains visible without changing todo ownership or
+making the whole peer appear blocked.
+
 ## Todo Row
 
 `todo_row_v0` is the dashboard/review-packet representation of an existing

--- a/examples/control_plane/agent-management-live-status-smoke.py
+++ b/examples/control_plane/agent-management-live-status-smoke.py
@@ -302,6 +302,33 @@ def assert_advancement_current_todo_beats_standing_monitor() -> None:
     assert side_row["current_todo"]["todo_id"] == "todo_side_advancement", side_row
     assert side_row["next_action"] == "Continue projected todo todo_side_advancement.", side_row
 
+    payload["attention_queue"]["items"][-1]["agent_lane_next_action"] = {
+        "index": 0,
+        "done": False,
+        "text": "Repair a stale maintenance blocker.",
+        "schema_version": "agent_lane_next_action_v0",
+        "todo_id": "todo_stale_maintenance_blocker",
+        "role": "agent",
+        "status": "blocked",
+        "priority": "P0",
+        "title": "Repair a stale maintenance blocker.",
+        "task_class": "blocker",
+        "action_kind": "repair_stale_maintenance_blocker",
+        "claimed_by": "agent-side",
+        "agent_id": "agent-side",
+        "selected_by": "current_agent_claimed_todo",
+        "updated_at": "2026-07-04T00:00:00Z",
+    }
+    stale_blocker = build_agent_management_projection(payload)
+    stale_blocker_row = next(
+        row
+        for row in stale_blocker.get("agents", [])
+        if isinstance(row, dict) and row.get("agent_id") == "agent-side"
+    )
+    assert stale_blocker_row["state"] == "running", stale_blocker_row
+    assert stale_blocker_row["current_todo"]["todo_id"] == "todo_side_advancement", stale_blocker_row
+    assert stale_blocker_row["blocked_on"]["todo_id"] == "todo_stale_maintenance_blocker", stale_blocker_row
+
     payload["attention_queue"]["items"][-1].pop("agent_lane_next_action")
     lane_only = build_agent_management_projection(payload)
     lane_only_row = next(

--- a/loopx/control_plane/agents/management_projection.py
+++ b/loopx/control_plane/agents/management_projection.py
@@ -36,6 +36,8 @@ _PRIORITY_RANK = {
     "P1": 1,
     "P2": 2,
 }
+
+
 def _compact(value: Any, *, limit: int = 220) -> str | None:
     return public_safe_compact_text(value, limit=limit)
 
@@ -106,6 +108,14 @@ def _is_agent_lane_next_action(todo: dict[str, Any]) -> bool:
     )
 
 
+def _is_runnable_advancement_todo(todo: dict[str, Any]) -> bool:
+    return (
+        _todo_status(todo) == "open"
+        and todo.get("task_class") != "blocker"
+        and not _is_monitor_todo(todo)
+    )
+
+
 def _current_todo_execution_rank(todo: dict[str, Any]) -> int:
     if todo.get("task_class") == "blocker":
         return 0
@@ -116,9 +126,11 @@ def _current_todo_execution_rank(todo: dict[str, Any]) -> int:
     return 1
 
 
-def _current_todo_sort_key(todo: dict[str, Any]) -> tuple[int, int, int, int, str]:
+def _current_todo_sort_key(todo: dict[str, Any]) -> tuple[int, int, int, int, int, str]:
+    runnable_advancement_rank = 0 if _is_runnable_advancement_todo(todo) else 1
     selected_rank = 0 if _is_agent_lane_next_action(todo) else 1
     return (
+        runnable_advancement_rank,
         selected_rank,
         _current_todo_execution_rank(todo),
         _priority_rank(todo),
@@ -132,6 +144,18 @@ def _select_current_todo(todos: list[dict[str, Any]]) -> dict[str, Any] | None:
     if not open_todos:
         return None
     return sorted(open_todos, key=_current_todo_sort_key)[0]
+
+
+def _select_blocked_todo(todos: list[dict[str, Any]]) -> dict[str, Any] | None:
+    blocked_todos = [
+        todo
+        for todo in todos
+        if not _is_done(todo)
+        and (_todo_status(todo) == "blocked" or todo.get("task_class") == "blocker")
+    ]
+    if not blocked_todos:
+        return None
+    return sorted(blocked_todos, key=_todo_sort_key)[0]
 
 
 def _registered_agents(status_payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
@@ -454,6 +478,7 @@ def build_agent_management_projection(status_payload: dict[str, Any]) -> dict[st
     for agent_id, raw_row in sorted(rows_by_agent.items()):
         all_todos = _as_list(raw_row.get("_todos"))
         current = _select_current_todo(all_todos)
+        blocked = _select_blocked_todo(all_todos)
         todos = sorted(all_todos, key=_todo_sort_key)
         if current:
             current_identity = _todo_identity(current)
@@ -486,6 +511,8 @@ def build_agent_management_projection(status_payload: dict[str, Any]) -> dict[st
         workspace_ref = _workspace_ref_from_todo(current)
         if workspace_ref:
             agent_row["workspace_ref"] = workspace_ref
+        if blocked and (not current or _todo_identity(blocked) != _todo_identity(current)):
+            agent_row["blocked_on"] = _todo_row(blocked)
         stale_claim_hint = _stale_claim_hint(current, agent_id=agent_id)
         if stale_claim_hint:
             agent_row["stale_claim_hint"] = stale_claim_hint


### PR DESCRIPTION
## Summary
- keep runnable advancement work as the projected current todo even when a stale blocked maintenance row is still present
- preserve the highest-priority blocked row separately as blocked_on without changing ownership
- make the dashboard trust the canonical agent-management state and cover the real OpenViking peer scenario

## Validation
- python3 examples/control_plane/agent-management-live-status-smoke.py --goal-id openviking-goal --agent-id codex-openviking-pilot --registry global-registry
- live readback: pilot state=running, current_todo=P0 daily triage, blocked_on=runtime capability repair
- dashboard pnpm build
- dashboard smoke:home-route
- python compileall for changed Python files
- git diff --check