### PR TITLE
Test agent-facing CLI output budgets

### DIFF
--- a/docs/interface-budget-contract.md
+++ b/docs/interface-budget-contract.md
@@ -13,12 +13,40 @@ and size/count budgets.
 | `quota_should_run_json` | quota guard | decide whether the selected goal may spend compute | `status`, `history`, or active state | `json_chars <= 12550` | `nested_keys <= 322` | `top_level_keys <= 50` |
 | `dashboard_status_json` | operator dashboard | render first-screen operator state | `history`, run artifacts, or project-local adapter output | `json_chars <= 18200` | `nested_keys <= 260` | `top_level_keys <= 25` |
 
-These budgets are intentionally about the machine payloads, not the full
-archival facts. When a surface needs more detail, put that detail behind a
-queryable cold-path command or a linked run-history artifact instead of making
-the recurring heartbeat prompt carry it. `nested_keys` counts dictionary keys
-through three payload levels and samples at most 20 list items per level; it is a
-hot-path structure budget, not an archival record-size budget.
+These four budgets measure compact in-memory machine payloads. They do not
+measure the exact text written to stdout: JSON indentation, compatibility
+projections, repeated commands, and Markdown wrappers can make emitted output
+materially larger. The emitted-output qualification matrix below measures that
+separate boundary through the real CLI entry point.
+
+| Emitted Surface | Default Qualification | Scale / Limit Contract | Cold Path |
+| --- | --- | --- | --- |
+| `start-goal --guided` | baseline and growth | small, crowded, and multi-agent goals; objective/command duplication | `packet_summary.detail_refs` and `bootstrap-command-pack` |
+| `bootstrap-command-pack` | baseline and growth | small, crowded, and multi-agent goals; objective/command duplication | `--message-only` and `packet_summary.detail_refs` |
+| `quota should-run` | absolute hot path | todo-count growth plus semantic anchors | `status`, `history`, active state, `--include-scheduler-detail` |
+| `status --goal-id` | absolute hot path | todo-count growth; task graph excluded by default | `--include-task-graph`, `history`, run artifacts |
+| `diagnose --goal-id` | explicit-limit cold path | `--limit 5` fixture matrix | status plus goal-specific quota/todo reads |
+| `review-packet --handoff-only` | absolute hot path | todo-count growth plus handoff semantic anchors | full `review-packet`, run artifacts |
+| `heartbeat-prompt --thin` | absolute hot path | agent scope and multi-agent fixture matrix | `--compact`, `--full` |
+| `todo list` | baseline and growth | todo-count growth and agent filtering semantics | role/status filters, direct todo-id lifecycle commands |
+| `history --limit 5` | explicit-limit cold path | returned-run bound | individual run JSON/Markdown artifacts |
+| `evidence-log --thin --limit 5` | explicit-limit cold path | returned-evidence bound | referenced run-history and rollout-event artifacts |
+
+The canonical emitted-output inventory and current characterization ceilings
+live in `loopx.control_plane.testing.cli_output_budget`. Those ceilings are
+regression baselines, not target sizes: preserving a large current value makes
+unreviewed growth fail while a later optimization lowers the ceiling. Tests
+also record UTF-8 bytes, line count, JSON parseability, pretty-print overhead,
+semantic anchors, collection-growth slope, and bootstrap duplication. Every
+declared agent-facing surface must name an owner, consumer action, and cold-path
+fallback.
+
+Both budget layers are intentionally about projections, not the full archival
+facts. When a surface needs more detail, put that detail behind a queryable
+cold-path command or a linked run-history artifact instead of making the
+recurring heartbeat prompt carry it. `nested_keys` counts dictionary keys
+through three payload levels and samples at most 20 list items per level; it is
+a hot-path structure budget, not an archival record-size budget.
 
 Restraint rules for new fields:
 
@@ -41,6 +69,7 @@ structured fields remain `interaction_contract.user_channel` and
 Regression entrypoints:
 
 ```bash
+pytest -q tests/control_plane/test_cli_output_budget.py
 python3 examples/control_plane/hot-path-interface-budget-smoke.py
 python3 examples/control_plane/status-quota-perf-budget-smoke.py
 ```

--- a/docs/interface-budget-contract.md
+++ b/docs/interface-budget-contract.md
@@ -41,6 +41,13 @@ semantic anchors, collection-growth slope, and bootstrap duplication. Every
 declared agent-facing surface must name an owner, consumer action, and cold-path
 fallback.
 
+The same matrix characterizes explicit mode switches instead of assuming that
+the default command represents them. Covered variants are
+`bootstrap-command-pack --message-only`, quota scheduler detail and
+TurnEnvelope output, status task-graph detail, the full review packet, and the
+brief/compact/full heartbeat prompt modes. These remain opt-in cold paths, but
+their exact stdout size and semantic anchors are regression contracts too.
+
 Both budget layers are intentionally about projections, not the full archival
 facts. When a surface needs more detail, put that detail behind a queryable
 cold-path command or a linked run-history artifact instead of making the

--- a/loopx/control_plane/testing/cli_output_budget.py
+++ b/loopx/control_plane/testing/cli_output_budget.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Literal
+
+
+CLI_OUTPUT_BUDGET_SCHEMA_VERSION = "loopx_cli_output_budget_v0"
+CLI_OUTPUT_MEASUREMENT_SCHEMA_VERSION = "loopx_cli_output_measurement_v0"
+
+OutputFormat = Literal["json", "markdown"]
+QualificationPolicy = Literal[
+    "absolute_hot_path",
+    "baseline_and_growth",
+    "explicit_limit_cold_path",
+]
+
+
+@dataclass(frozen=True)
+class CliOutputBudgetSpec:
+    surface_id: str
+    command: str
+    owner: str
+    consumer_action: str
+    qualification_policy: QualificationPolicy
+    cold_path: str
+    semantic_json_keys: tuple[str, ...]
+    markdown_anchor: str
+    max_chars: dict[str, dict[OutputFormat, int]]
+    max_lines: dict[str, dict[OutputFormat, int]]
+    scale_axis: str | None = None
+    max_json_growth_chars_per_unit: int | None = None
+
+
+# These ceilings characterize the emitted CLI text on public fixtures. They are
+# deliberately separate from compact in-memory payload budgets. Baseline-only
+# ceilings freeze current debt so later optimization can lower them safely.
+CLI_OUTPUT_BUDGET_SPECS: tuple[CliOutputBudgetSpec, ...] = (
+    CliOutputBudgetSpec(
+        surface_id="start_goal_guided",
+        command="start-goal --guided",
+        owner="goal bootstrap",
+        consumer_action="plan a goal start before any mutation",
+        qualification_policy="baseline_and_growth",
+        cold_path="packet_summary detail_refs and bootstrap-command-pack",
+        semantic_json_keys=("guided_transaction", "command_pack", "safety_contract", "packet_summary"),
+        markdown_anchor="# Guided Start Goal",
+        max_chars={
+            "small": {"json": 64_000, "markdown": 3_200},
+            "crowded": {"json": 64_000, "markdown": 3_200},
+            "multi_agent": {"json": 64_000, "markdown": 3_200},
+        },
+        max_lines={
+            "small": {"json": 650, "markdown": 55},
+            "crowded": {"json": 650, "markdown": 55},
+            "multi_agent": {"json": 650, "markdown": 55},
+        },
+        scale_axis="todo_count",
+        max_json_growth_chars_per_unit=8,
+    ),
+    CliOutputBudgetSpec(
+        surface_id="bootstrap_command_pack",
+        command="bootstrap-command-pack",
+        owner="slash-command bootstrap",
+        consumer_action="connect and activate one host loop",
+        qualification_policy="baseline_and_growth",
+        cold_path="message-only projection and packet_summary detail_refs",
+        semantic_json_keys=("commands", "goal_start_contract", "host_loop_activation", "packet_summary"),
+        markdown_anchor="# /loopx Bootstrap Command Pack",
+        max_chars={
+            "small": {"json": 45_000, "markdown": 14_500},
+            "crowded": {"json": 45_000, "markdown": 14_500},
+            "multi_agent": {"json": 45_000, "markdown": 14_500},
+        },
+        max_lines={
+            "small": {"json": 470, "markdown": 240},
+            "crowded": {"json": 470, "markdown": 240},
+            "multi_agent": {"json": 470, "markdown": 240},
+        },
+        scale_axis="todo_count",
+        max_json_growth_chars_per_unit=8,
+    ),
+    CliOutputBudgetSpec(
+        surface_id="quota_should_run",
+        command="quota should-run",
+        owner="quota guard",
+        consumer_action="decide whether one agent may run",
+        qualification_policy="absolute_hot_path",
+        cold_path="status, history, active state, and --include-scheduler-detail",
+        semantic_json_keys=("interaction_contract", "scheduler_hint", "selected_todo"),
+        markdown_anchor="# LoopX Quota Should Run",
+        max_chars={
+            "small": {"json": 26_000, "markdown": 6_700},
+            "crowded": {"json": 40_000, "markdown": 7_800},
+            "multi_agent": {"json": 36_000, "markdown": 7_000},
+        },
+        max_lines={
+            "small": {"json": 720, "markdown": 72},
+            "crowded": {"json": 1_050, "markdown": 78},
+            "multi_agent": {"json": 1_000, "markdown": 75},
+        },
+        scale_axis="todo_count",
+        max_json_growth_chars_per_unit=400,
+    ),
+    CliOutputBudgetSpec(
+        surface_id="status",
+        command="status --goal-id",
+        owner="operator and agent status",
+        consumer_action="locate the current goal and attention state",
+        qualification_policy="absolute_hot_path",
+        cold_path="--include-task-graph, history, and run artifacts",
+        semantic_json_keys=("status_contract", "attention_queue", "todo_index"),
+        markdown_anchor="# LoopX Status",
+        max_chars={
+            "small": {"json": 42_000, "markdown": 7_000},
+            "crowded": {"json": 70_000, "markdown": 7_800},
+            "multi_agent": {"json": 70_000, "markdown": 7_800},
+        },
+        max_lines={
+            "small": {"json": 1_120, "markdown": 85},
+            "crowded": {"json": 1_850, "markdown": 90},
+            "multi_agent": {"json": 1_850, "markdown": 90},
+        },
+        scale_axis="todo_count",
+        max_json_growth_chars_per_unit=750,
+    ),
+    CliOutputBudgetSpec(
+        surface_id="diagnose",
+        command="diagnose --goal-id",
+        owner="agent self-repair",
+        consumer_action="explain whether and why one goal can advance",
+        qualification_policy="explicit_limit_cold_path",
+        cold_path="status plus goal-specific quota and todo reads",
+        semantic_json_keys=("agent_must_reason", "selected", "goals", "status_summary"),
+        markdown_anchor="# LoopX Diagnosis Packet",
+        max_chars={
+            "small": {"json": 21_000, "markdown": 4_300},
+            "crowded": {"json": 34_000, "markdown": 4_500},
+            "multi_agent": {"json": 21_000, "markdown": 4_300},
+        },
+        max_lines={
+            "small": {"json": 470, "markdown": 72},
+            "crowded": {"json": 720, "markdown": 72},
+            "multi_agent": {"json": 480, "markdown": 72},
+        },
+        scale_axis="todo_count",
+        max_json_growth_chars_per_unit=360,
+    ),
+    CliOutputBudgetSpec(
+        surface_id="review_packet_handoff_only",
+        command="review-packet --handoff-only",
+        owner="project-agent handoff",
+        consumer_action="forward the smallest sufficient work packet",
+        qualification_policy="absolute_hot_path",
+        cold_path="full review-packet and run-history artifacts",
+        semantic_json_keys=("project_agent_handoff", "handoff_interface_budget", "within_budget"),
+        markdown_anchor="quota should-run",
+        max_chars={
+            "small": {"json": 4_500, "markdown": 1_400},
+            "crowded": {"json": 5_100, "markdown": 1_700},
+            "multi_agent": {"json": 5_100, "markdown": 1_700},
+        },
+        max_lines={
+            "small": {"json": 48, "markdown": 18},
+            "crowded": {"json": 48, "markdown": 20},
+            "multi_agent": {"json": 48, "markdown": 20},
+        },
+        scale_axis="todo_count",
+        max_json_growth_chars_per_unit=20,
+    ),
+    CliOutputBudgetSpec(
+        surface_id="heartbeat_prompt_thin",
+        command="heartbeat-prompt --thin",
+        owner="heartbeat automation",
+        consumer_action="wake and route one bounded turn",
+        qualification_policy="absolute_hot_path",
+        cold_path="heartbeat-prompt --compact or --full",
+        semantic_json_keys=("task_body", "quota_guard_command", "interface_budget"),
+        markdown_anchor="# Heartbeat Automation Prompt",
+        max_chars={
+            "small": {"json": 6_000, "markdown": 5_100},
+            "crowded": {"json": 6_000, "markdown": 5_100},
+            "multi_agent": {"json": 6_000, "markdown": 5_100},
+        },
+        max_lines={
+            "small": {"json": 58, "markdown": 72},
+            "crowded": {"json": 58, "markdown": 72},
+            "multi_agent": {"json": 58, "markdown": 72},
+        },
+        scale_axis="todo_count",
+        max_json_growth_chars_per_unit=4,
+    ),
+    CliOutputBudgetSpec(
+        surface_id="todo_list",
+        command="todo list",
+        owner="todo control plane",
+        consumer_action="select and inspect current work items",
+        qualification_policy="baseline_and_growth",
+        cold_path="role/status filters and direct todo-id lifecycle commands",
+        semantic_json_keys=("todos", "agent_todos", "filter_semantics"),
+        markdown_anchor="# LoopX Todo List",
+        max_chars={
+            "small": {"json": 7_500, "markdown": 1_000},
+            "crowded": {"json": 82_000, "markdown": 8_500},
+            "multi_agent": {"json": 30_000, "markdown": 2_200},
+        },
+        max_lines={
+            "small": {"json": 220, "markdown": 28},
+            "crowded": {"json": 2_300, "markdown": 70},
+            "multi_agent": {"json": 850, "markdown": 38},
+        },
+        scale_axis="todo_count",
+        max_json_growth_chars_per_unit=2_050,
+    ),
+    CliOutputBudgetSpec(
+        surface_id="history_limited",
+        command="history --limit 5",
+        owner="run-history read model",
+        consumer_action="inspect bounded recent progress",
+        qualification_policy="explicit_limit_cold_path",
+        cold_path="individual run JSON/Markdown artifacts",
+        semantic_json_keys=("goals", "runs", "run_count"),
+        markdown_anchor="# LoopX Run History",
+        max_chars={
+            "small": {"json": 5_800, "markdown": 900},
+            "crowded": {"json": 12_500, "markdown": 1_500},
+            "multi_agent": {"json": 12_500, "markdown": 1_500},
+        },
+        max_lines={
+            "small": {"json": 160, "markdown": 22},
+            "crowded": {"json": 280, "markdown": 28},
+            "multi_agent": {"json": 290, "markdown": 28},
+        },
+        scale_axis="returned_run_count",
+        max_json_growth_chars_per_unit=1_600,
+    ),
+    CliOutputBudgetSpec(
+        surface_id="evidence_log_thin",
+        command="evidence-log --thin --limit 5",
+        owner="agent-scoped evidence ledger",
+        consumer_action="read bounded public-safe evidence for replan",
+        qualification_policy="explicit_limit_cold_path",
+        cold_path="referenced run-history and rollout-event artifacts",
+        semantic_json_keys=("ledger", "truncated", "other_agent_frontier"),
+        markdown_anchor="# LoopX Evidence Log",
+        max_chars={
+            "small": {"json": 2_900, "markdown": 800},
+            "crowded": {"json": 3_500, "markdown": 1_100},
+            "multi_agent": {"json": 4_300, "markdown": 1_200},
+        },
+        max_lines={
+            "small": {"json": 100, "markdown": 26},
+            "crowded": {"json": 120, "markdown": 30},
+            "multi_agent": {"json": 140, "markdown": 34},
+        },
+        scale_axis="returned_evidence_count",
+        max_json_growth_chars_per_unit=800,
+    ),
+)
+
+
+CLI_OUTPUT_BUDGET_BY_ID = {spec.surface_id: spec for spec in CLI_OUTPUT_BUDGET_SPECS}
+
+
+def measure_cli_output(
+    text: str,
+    *,
+    output_format: OutputFormat,
+) -> dict[str, Any]:
+    payload: dict[str, Any] | None = None
+    compact_payload_chars: int | None = None
+    if output_format == "json":
+        decoded = json.loads(text)
+        if not isinstance(decoded, dict):
+            raise ValueError("agent-facing CLI JSON output must be an object")
+        payload = decoded
+        compact_payload_chars = len(
+            json.dumps(
+                decoded,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+        )
+    return {
+        "schema_version": CLI_OUTPUT_MEASUREMENT_SCHEMA_VERSION,
+        "format": output_format,
+        "chars": len(text),
+        "utf8_bytes": len(text.encode("utf-8")),
+        "lines": len(text.splitlines()),
+        "json_parseable": payload is not None,
+        "top_level_keys": len(payload or {}),
+        "compact_payload_chars": compact_payload_chars,
+        "pretty_print_overhead_chars": (
+            len(text) - compact_payload_chars
+            if compact_payload_chars is not None
+            else None
+        ),
+        "payload": payload,
+    }
+
+
+def assert_cli_output_baseline(
+    spec: CliOutputBudgetSpec,
+    *,
+    scenario: str,
+    output_format: OutputFormat,
+    text: str,
+    measurement: dict[str, Any],
+) -> None:
+    max_chars = spec.max_chars[scenario][output_format]
+    max_lines = spec.max_lines[scenario][output_format]
+    if int(measurement["chars"]) > max_chars:
+        raise AssertionError(
+            f"{spec.surface_id}/{scenario}/{output_format} emitted "
+            f"{measurement['chars']} chars; baseline ceiling is {max_chars}"
+        )
+    if int(measurement["lines"]) > max_lines:
+        raise AssertionError(
+            f"{spec.surface_id}/{scenario}/{output_format} emitted "
+            f"{measurement['lines']} lines; baseline ceiling is {max_lines}"
+        )
+    if output_format == "markdown" and spec.markdown_anchor not in text:
+        raise AssertionError(
+            f"{spec.surface_id} markdown lost semantic anchor {spec.markdown_anchor!r}"
+        )
+    if output_format == "json":
+        payload = measurement.get("payload")
+        if not isinstance(payload, dict):
+            raise AssertionError(f"{spec.surface_id} did not emit a JSON object")
+        missing = [key for key in spec.semantic_json_keys if key not in payload]
+        if missing:
+            raise AssertionError(
+                f"{spec.surface_id} JSON lost semantic key(s): {', '.join(missing)}"
+            )
+
+
+def public_manifest() -> dict[str, Any]:
+    return {
+        "schema_version": CLI_OUTPUT_BUDGET_SCHEMA_VERSION,
+        "surface_count": len(CLI_OUTPUT_BUDGET_SPECS),
+        "surfaces": [
+            {
+                "surface_id": spec.surface_id,
+                "command": spec.command,
+                "owner": spec.owner,
+                "consumer_action": spec.consumer_action,
+                "qualification_policy": spec.qualification_policy,
+                "cold_path": spec.cold_path,
+                "formats": ["json", "markdown"],
+                "scenarios": sorted(spec.max_chars),
+                "scale_axis": spec.scale_axis,
+            }
+            for spec in CLI_OUTPUT_BUDGET_SPECS
+        ],
+    }

--- a/loopx/control_plane/testing/cli_output_budget.py
+++ b/loopx/control_plane/testing/cli_output_budget.py
@@ -32,6 +32,18 @@ class CliOutputBudgetSpec:
     max_json_growth_chars_per_unit: int | None = None
 
 
+@dataclass(frozen=True)
+class CliOutputModeVariantSpec:
+    variant_id: str
+    parent_surface_id: str
+    command: str
+    output_formats: tuple[OutputFormat, ...]
+    semantic_json_keys: tuple[str, ...]
+    markdown_anchor: str
+    max_chars: dict[OutputFormat, int]
+    max_lines: dict[OutputFormat, int]
+
+
 # These ceilings characterize the emitted CLI text on public fixtures. They are
 # deliberately separate from compact in-memory payload budgets. Baseline-only
 # ceilings freeze current debt so later optimization can lower them safely.
@@ -262,6 +274,98 @@ CLI_OUTPUT_BUDGET_SPECS: tuple[CliOutputBudgetSpec, ...] = (
 CLI_OUTPUT_BUDGET_BY_ID = {spec.surface_id: spec for spec in CLI_OUTPUT_BUDGET_SPECS}
 
 
+# Explicit variants are opt-in cold paths, but they still need real stdout
+# characterization. This prevents a compact default from hiding unbounded
+# growth in the exact diagnostic mode an agent uses during repair.
+CLI_OUTPUT_MODE_VARIANT_SPECS: tuple[CliOutputModeVariantSpec, ...] = (
+    CliOutputModeVariantSpec(
+        variant_id="bootstrap_command_pack_message_only",
+        parent_surface_id="bootstrap_command_pack",
+        command="bootstrap-command-pack --message-only",
+        output_formats=("markdown",),
+        semantic_json_keys=(),
+        markdown_anchor="Handle `/loopx`",
+        max_chars={"markdown": 9_500},
+        max_lines={"markdown": 135},
+    ),
+    CliOutputModeVariantSpec(
+        variant_id="quota_should_run_scheduler_detail",
+        parent_surface_id="quota_should_run",
+        command="quota should-run --include-scheduler-detail",
+        output_formats=("json", "markdown"),
+        semantic_json_keys=("interaction_contract", "scheduler_hint", "selected_todo"),
+        markdown_anchor="# LoopX Quota Should Run",
+        max_chars={"json": 31_000, "markdown": 6_700},
+        max_lines={"json": 820, "markdown": 72},
+    ),
+    CliOutputModeVariantSpec(
+        variant_id="quota_should_run_turn_envelope",
+        parent_surface_id="quota_should_run",
+        command="quota should-run --turn-envelope",
+        output_formats=("json", "markdown"),
+        semantic_json_keys=("schema_version", "contract_capsule", "action_signature"),
+        markdown_anchor="# LoopX Turn Envelope",
+        max_chars={"json": 9_000, "markdown": 650},
+        max_lines={"json": 250, "markdown": 20},
+    ),
+    CliOutputModeVariantSpec(
+        variant_id="status_task_graph_detail",
+        parent_surface_id="status",
+        command="status --include-task-graph",
+        output_formats=("json", "markdown"),
+        semantic_json_keys=("status_contract", "attention_queue", "todo_index"),
+        markdown_anchor="# LoopX Status",
+        max_chars={"json": 47_000, "markdown": 7_000},
+        max_lines={"json": 1_250, "markdown": 85},
+    ),
+    CliOutputModeVariantSpec(
+        variant_id="review_packet_full",
+        parent_surface_id="review_packet_handoff_only",
+        command="review-packet",
+        output_formats=("json", "markdown"),
+        semantic_json_keys=("goal_id", "project_agent_handoff", "handoff_interface_budget"),
+        markdown_anchor="LoopX Review Packet",
+        max_chars={"json": 11_000, "markdown": 2_000},
+        max_lines={"json": 220, "markdown": 35},
+    ),
+    CliOutputModeVariantSpec(
+        variant_id="heartbeat_prompt_brief",
+        parent_surface_id="heartbeat_prompt_thin",
+        command="heartbeat-prompt --brief",
+        output_formats=("json", "markdown"),
+        semantic_json_keys=("task_body", "quota_guard_command", "interface_budget"),
+        markdown_anchor="# Heartbeat Automation Prompt",
+        max_chars={"json": 8_500, "markdown": 7_500},
+        max_lines={"json": 58, "markdown": 115},
+    ),
+    CliOutputModeVariantSpec(
+        variant_id="heartbeat_prompt_compact",
+        parent_surface_id="heartbeat_prompt_thin",
+        command="heartbeat-prompt --compact",
+        output_formats=("json", "markdown"),
+        semantic_json_keys=("task_body", "quota_guard_command", "interface_budget"),
+        markdown_anchor="# Heartbeat Automation Prompt",
+        max_chars={"json": 11_500, "markdown": 10_500},
+        max_lines={"json": 58, "markdown": 155},
+    ),
+    CliOutputModeVariantSpec(
+        variant_id="heartbeat_prompt_full",
+        parent_surface_id="heartbeat_prompt_thin",
+        command="heartbeat-prompt --full",
+        output_formats=("json", "markdown"),
+        semantic_json_keys=("task_body", "quota_guard_command", "interface_budget"),
+        markdown_anchor="# Heartbeat Automation Prompt",
+        max_chars={"json": 19_000, "markdown": 18_000},
+        max_lines={"json": 58, "markdown": 280},
+    ),
+)
+
+
+CLI_OUTPUT_MODE_VARIANT_BY_ID = {
+    spec.variant_id: spec for spec in CLI_OUTPUT_MODE_VARIANT_SPECS
+}
+
+
 def measure_cli_output(
     text: str,
     *,
@@ -335,10 +439,49 @@ def assert_cli_output_baseline(
             )
 
 
+def assert_cli_output_mode_variant(
+    spec: CliOutputModeVariantSpec,
+    *,
+    output_format: OutputFormat,
+    text: str,
+    measurement: dict[str, Any],
+) -> None:
+    if output_format not in spec.output_formats:
+        raise AssertionError(
+            f"{spec.variant_id} does not declare {output_format} qualification"
+        )
+    if int(measurement["chars"]) > spec.max_chars[output_format]:
+        raise AssertionError(
+            f"{spec.variant_id}/{output_format} emitted {measurement['chars']} chars; "
+            f"variant ceiling is {spec.max_chars[output_format]}"
+        )
+    if int(measurement["lines"]) > spec.max_lines[output_format]:
+        raise AssertionError(
+            f"{spec.variant_id}/{output_format} emitted {measurement['lines']} lines; "
+            f"variant ceiling is {spec.max_lines[output_format]}"
+        )
+    if output_format == "markdown":
+        if spec.markdown_anchor not in text:
+            raise AssertionError(
+                f"{spec.variant_id} markdown lost semantic anchor "
+                f"{spec.markdown_anchor!r}"
+            )
+        return
+    payload = measurement.get("payload")
+    if not isinstance(payload, dict):
+        raise AssertionError(f"{spec.variant_id} did not emit a JSON object")
+    missing = [key for key in spec.semantic_json_keys if key not in payload]
+    if missing:
+        raise AssertionError(
+            f"{spec.variant_id} JSON lost semantic key(s): {', '.join(missing)}"
+        )
+
+
 def public_manifest() -> dict[str, Any]:
     return {
         "schema_version": CLI_OUTPUT_BUDGET_SCHEMA_VERSION,
         "surface_count": len(CLI_OUTPUT_BUDGET_SPECS),
+        "mode_variant_count": len(CLI_OUTPUT_MODE_VARIANT_SPECS),
         "surfaces": [
             {
                 "surface_id": spec.surface_id,
@@ -352,5 +495,15 @@ def public_manifest() -> dict[str, Any]:
                 "scale_axis": spec.scale_axis,
             }
             for spec in CLI_OUTPUT_BUDGET_SPECS
+        ],
+        "mode_variants": [
+            {
+                "variant_id": spec.variant_id,
+                "parent_surface_id": spec.parent_surface_id,
+                "command": spec.command,
+                "qualification_policy": "explicit_opt_in_cold_path",
+                "formats": list(spec.output_formats),
+            }
+            for spec in CLI_OUTPUT_MODE_VARIANT_SPECS
         ],
     }

--- a/tests/control_plane/test_cli_output_budget.py
+++ b/tests/control_plane/test_cli_output_budget.py
@@ -1,0 +1,402 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from loopx.cli import main as cli_main
+from loopx.control_plane.testing.cli_output_budget import (
+    CLI_OUTPUT_BUDGET_BY_ID,
+    CLI_OUTPUT_BUDGET_SPECS,
+    assert_cli_output_baseline,
+    measure_cli_output,
+    public_manifest,
+)
+from loopx.rollout_event_log import rollout_event_log_path
+
+
+GOAL_ID = "cli-output-budget-goal"
+AGENT_IDS = ("codex-alpha", "codex-beta", "codex-gamma")
+GOAL_TEXT = "Qualify agent-facing CLI output budgets before changing production output."
+
+
+@dataclass(frozen=True)
+class Scenario:
+    name: str
+    todo_count: int
+    agent_count: int
+    run_count: int
+
+
+SCENARIOS = (
+    Scenario("small", todo_count=1, agent_count=1, run_count=1),
+    Scenario("crowded", todo_count=36, agent_count=1, run_count=12),
+    Scenario("multi_agent", todo_count=18, agent_count=3, run_count=12),
+)
+
+
+def _write_fixture(root: Path, scenario: Scenario) -> tuple[Path, Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_relative = Path(".codex") / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    state_file = project / state_relative
+    state_file.parent.mkdir(parents=True)
+    agents = AGENT_IDS[: scenario.agent_count]
+    lines = [
+        "---",
+        "status: active",
+        "updated_at: 2026-01-01T00:00:00+00:00",
+        "---",
+        "",
+        "# CLI Output Budget Fixture",
+        "",
+        "## Agent Todo",
+        "",
+    ]
+    for index in range(scenario.todo_count):
+        agent_id = agents[index % len(agents)]
+        priority = f"P{index % 3}"
+        lines.extend(
+            [
+                f"- [ ] [{priority}] Validate public fixture lane {index:02d} without reading archival detail.",
+                (
+                    "  <!-- loopx:todo "
+                    f"todo_id=todo_fixture_{index:03d} status=open "
+                    "task_class=advancement_task "
+                    f"action_kind=fixture_{index % 4} claimed_by={agent_id} "
+                    f"priority={priority} -->"
+                ),
+            ]
+        )
+    state_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    registry_path = project / ".loopx" / "registry.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "cli-output-budget-fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": str(state_relative),
+                        "adapter": {
+                            "kind": "fixture_connected_delivery_v0",
+                            "status": "connected-delivery",
+                        },
+                        "quota": {"compute": 1.0, "window_hours": 24},
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": list(agents),
+                            "agent_profiles": {
+                                agent_id: {
+                                    "schema_version": "agent_profile_v1",
+                                    "profile_role": "fixture",
+                                    "scope": "public qualification",
+                                }
+                                for agent_id in agents
+                            },
+                            "write_scope": ["docs/**"],
+                        },
+                    }
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    _write_run_history(runtime, agents=agents, run_count=scenario.run_count)
+    _write_rollout_event(runtime, agent_id=agents[0])
+    return project, runtime, registry_path, state_file
+
+
+def _write_run_history(runtime: Path, *, agents: tuple[str, ...], run_count: int) -> None:
+    runs_dir = runtime / "goals" / GOAL_ID / "runs"
+    runs_dir.mkdir(parents=True)
+    index_rows = []
+    for index in range(run_count):
+        json_path = runs_dir / f"fixture-run-{index:02d}.json"
+        markdown_path = json_path.with_suffix(".md")
+        record = {
+            "generated_at": f"2026-01-01T00:{index:02d}:00+00:00",
+            "goal_id": GOAL_ID,
+            "classification": "fixture_progress",
+            "recommended_action": f"Continue fixture step {index}.",
+            "health_check": "public fixture healthy",
+            "agent_id": agents[index % len(agents)],
+            "progress_scope": "agent_lane",
+        }
+        json_path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+        markdown_path.write_text("# Public fixture run\n", encoding="utf-8")
+        index_rows.append(
+            {
+                **record,
+                "json_path": str(json_path),
+                "markdown_path": str(markdown_path),
+            }
+        )
+    (runs_dir / "index.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in index_rows),
+        encoding="utf-8",
+    )
+
+
+def _write_rollout_event(runtime: Path, *, agent_id: str) -> None:
+    path = rollout_event_log_path(runtime, GOAL_ID)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "loopx_rollout_event_v0",
+                "event_id": "fixture-event",
+                "event_kind": "todo_updated",
+                "recorded_at": "2026-01-01T01:00:00Z",
+                "goal_id": GOAL_ID,
+                "agent_id": agent_id,
+                "todo_id": "todo_fixture_000",
+                "status": "appended",
+                "summary": "Public fixture evidence.",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _invoke_cli(args: list[str]) -> tuple[int, str]:
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(args)
+    return exit_code, output.getvalue()
+
+
+def _surface_commands(
+    *,
+    project: Path,
+    runtime: Path,
+    registry_path: Path,
+    state_file: Path,
+    output_format: str,
+) -> dict[str, list[str]]:
+    common = [
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime),
+        "--format",
+        output_format,
+    ]
+    return {
+        "start_goal_guided": [
+            "--format",
+            output_format,
+            "start-goal",
+            "--guided",
+            "--project",
+            str(project),
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_IDS[0],
+            "--goal-text",
+            GOAL_TEXT,
+        ],
+        "bootstrap_command_pack": [
+            "--format",
+            output_format,
+            "bootstrap-command-pack",
+            "--project",
+            str(project),
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_IDS[0],
+            "--goal-text",
+            GOAL_TEXT,
+        ],
+        "quota_should_run": common
+        + [
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_IDS[0],
+            "--scan-root",
+            str(project),
+        ],
+        "status": common
+        + [
+            "status",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_IDS[0],
+            "--scan-root",
+            str(project),
+            "--limit",
+            "5",
+        ],
+        "diagnose": common
+        + [
+            "diagnose",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_IDS[0],
+            "--scan-root",
+            str(project),
+            "--limit",
+            "5",
+        ],
+        "review_packet_handoff_only": common
+        + [
+            "review-packet",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_IDS[0],
+            "--handoff-only",
+            "--scan-root",
+            str(project),
+            "--limit",
+            "5",
+        ],
+        "heartbeat_prompt_thin": common
+        + [
+            "heartbeat-prompt",
+            "--thin",
+            "--goal-id",
+            GOAL_ID,
+            "--active-state",
+            str(state_file),
+            "--agent-id",
+            AGENT_IDS[0],
+            "--agent-scope",
+            "Public CLI output qualification.",
+        ],
+        "todo_list": common
+        + ["todo", "list", "--goal-id", GOAL_ID, "--agent-id", AGENT_IDS[0]],
+        "history_limited": common
+        + ["history", "--goal-id", GOAL_ID, "--limit", "5"],
+        "evidence_log_thin": common
+        + [
+            "evidence-log",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_IDS[0],
+            "--limit",
+            "5",
+            "--history-limit",
+            "10",
+            "--rollout-limit",
+            "20",
+            "--thin",
+        ],
+    }
+
+
+def _measure_scenario(root: Path, scenario: Scenario) -> dict[str, dict[str, dict]]:
+    project, runtime, registry_path, state_file = _write_fixture(root, scenario)
+    results: dict[str, dict[str, dict]] = {}
+    for output_format in ("json", "markdown"):
+        commands = _surface_commands(
+            project=project,
+            runtime=runtime,
+            registry_path=registry_path,
+            state_file=state_file,
+            output_format=output_format,
+        )
+        for surface_id, command in commands.items():
+            exit_code, text = _invoke_cli(command)
+            assert exit_code == 0, (surface_id, output_format, text)
+            measurement = measure_cli_output(text, output_format=output_format)  # type: ignore[arg-type]
+            spec = CLI_OUTPUT_BUDGET_BY_ID[surface_id]
+            assert_cli_output_baseline(
+                spec,
+                scenario=scenario.name,
+                output_format=output_format,  # type: ignore[arg-type]
+                text=text,
+                measurement=measurement,
+            )
+            results.setdefault(surface_id, {})[output_format] = measurement
+    return results
+
+
+def test_manifest_covers_the_declared_agent_facing_surface_set() -> None:
+    expected = {
+        "start_goal_guided",
+        "bootstrap_command_pack",
+        "quota_should_run",
+        "status",
+        "diagnose",
+        "review_packet_handoff_only",
+        "heartbeat_prompt_thin",
+        "todo_list",
+        "history_limited",
+        "evidence_log_thin",
+    }
+    manifest = public_manifest()
+    assert set(CLI_OUTPUT_BUDGET_BY_ID) == expected
+    assert manifest["surface_count"] == len(expected)
+    assert {row["surface_id"] for row in manifest["surfaces"]} == expected
+    assert all(spec.owner and spec.consumer_action and spec.cold_path for spec in CLI_OUTPUT_BUDGET_SPECS)
+
+
+@pytest.mark.parametrize("scenario", SCENARIOS, ids=lambda scenario: scenario.name)
+def test_real_cli_output_stays_inside_the_characterized_baseline(
+    tmp_path: Path,
+    scenario: Scenario,
+) -> None:
+    results = _measure_scenario(tmp_path, scenario)
+    for formats in results.values():
+        assert formats["json"]["json_parseable"] is True
+        assert formats["json"]["pretty_print_overhead_chars"] > 0
+        assert formats["markdown"]["json_parseable"] is False
+
+
+def test_collection_growth_and_bootstrap_duplication_are_explicit(tmp_path: Path) -> None:
+    small = _measure_scenario(tmp_path / "small", SCENARIOS[0])
+    crowded = _measure_scenario(tmp_path / "crowded", SCENARIOS[1])
+    added_todos = SCENARIOS[1].todo_count - SCENARIOS[0].todo_count
+    added_runs = SCENARIOS[1].run_count - SCENARIOS[0].run_count
+    for spec in CLI_OUTPUT_BUDGET_SPECS:
+        if spec.max_json_growth_chars_per_unit is None:
+            continue
+        units = (
+            added_runs
+            if spec.scale_axis in {"returned_run_count", "returned_evidence_count"}
+            else added_todos
+        )
+        growth = (
+            crowded[spec.surface_id]["json"]["chars"]
+            - small[spec.surface_id]["json"]["chars"]
+        )
+        assert growth <= spec.max_json_growth_chars_per_unit * units, (
+            spec.surface_id,
+            growth,
+            units,
+        )
+
+    start_payload = small["start_goal_guided"]["json"]["payload"]
+    bootstrap_payload = small["bootstrap_command_pack"]["json"]["payload"]
+    start_duplication = start_payload["packet_summary"]["duplication_measurement"]
+    bootstrap_duplication = bootstrap_payload["packet_summary"]["duplication_measurement"]
+    assert start_duplication["objective_content"]["duplicate_occurrences"] <= 15
+    assert start_duplication["command_content"]["duplicate_occurrences"] <= 17
+    assert bootstrap_duplication["objective_content"]["duplicate_occurrences"] <= 8
+    assert bootstrap_duplication["command_content"]["duplicate_occurrences"] <= 9
+    assert start_duplication["objective_content"]["duplicate_occurrences"] > 0
+    assert bootstrap_duplication["objective_content"]["duplicate_occurrences"] > 0

--- a/tests/control_plane/test_cli_output_budget.py
+++ b/tests/control_plane/test_cli_output_budget.py
@@ -12,7 +12,10 @@ from loopx.cli import main as cli_main
 from loopx.control_plane.testing.cli_output_budget import (
     CLI_OUTPUT_BUDGET_BY_ID,
     CLI_OUTPUT_BUDGET_SPECS,
+    CLI_OUTPUT_MODE_VARIANT_BY_ID,
+    CLI_OUTPUT_MODE_VARIANT_SPECS,
     assert_cli_output_baseline,
+    assert_cli_output_mode_variant,
     measure_cli_output,
     public_manifest,
 )
@@ -335,6 +338,102 @@ def _measure_scenario(root: Path, scenario: Scenario) -> dict[str, dict[str, dic
     return results
 
 
+def _mode_variant_commands(
+    *,
+    project: Path,
+    runtime: Path,
+    registry_path: Path,
+    state_file: Path,
+    output_format: str,
+) -> dict[str, list[str]]:
+    common = [
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime),
+        "--format",
+        output_format,
+    ]
+    heartbeat = [
+        "--goal-id",
+        GOAL_ID,
+        "--active-state",
+        str(state_file),
+        "--agent-id",
+        AGENT_IDS[0],
+        "--agent-scope",
+        "Public CLI output qualification.",
+    ]
+    return {
+        "bootstrap_command_pack_message_only": [
+            "--format",
+            output_format,
+            "bootstrap-command-pack",
+            "--project",
+            str(project),
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_IDS[0],
+            "--goal-text",
+            GOAL_TEXT,
+            "--message-only",
+        ],
+        "quota_should_run_scheduler_detail": common
+        + [
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_IDS[0],
+            "--scan-root",
+            str(project),
+            "--include-scheduler-detail",
+        ],
+        "quota_should_run_turn_envelope": common
+        + [
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_IDS[0],
+            "--scan-root",
+            str(project),
+            "--turn-envelope",
+        ],
+        "status_task_graph_detail": common
+        + [
+            "status",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_IDS[0],
+            "--scan-root",
+            str(project),
+            "--limit",
+            "5",
+            "--include-task-graph",
+        ],
+        "review_packet_full": common
+        + [
+            "review-packet",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_IDS[0],
+            "--scan-root",
+            str(project),
+            "--limit",
+            "5",
+        ],
+        "heartbeat_prompt_brief": common + ["heartbeat-prompt", "--brief", *heartbeat],
+        "heartbeat_prompt_compact": common + ["heartbeat-prompt", "--compact", *heartbeat],
+        "heartbeat_prompt_full": common + ["heartbeat-prompt", "--full", *heartbeat],
+    }
+
+
 def test_manifest_covers_the_declared_agent_facing_surface_set() -> None:
     expected = {
         "start_goal_guided",
@@ -353,6 +452,22 @@ def test_manifest_covers_the_declared_agent_facing_surface_set() -> None:
     assert manifest["surface_count"] == len(expected)
     assert {row["surface_id"] for row in manifest["surfaces"]} == expected
     assert all(spec.owner and spec.consumer_action and spec.cold_path for spec in CLI_OUTPUT_BUDGET_SPECS)
+    expected_variants = {
+        "bootstrap_command_pack_message_only",
+        "quota_should_run_scheduler_detail",
+        "quota_should_run_turn_envelope",
+        "status_task_graph_detail",
+        "review_packet_full",
+        "heartbeat_prompt_brief",
+        "heartbeat_prompt_compact",
+        "heartbeat_prompt_full",
+    }
+    assert set(CLI_OUTPUT_MODE_VARIANT_BY_ID) == expected_variants
+    assert manifest["mode_variant_count"] == len(expected_variants)
+    assert {row["variant_id"] for row in manifest["mode_variants"]} == expected_variants
+    assert all(
+        spec.parent_surface_id in expected for spec in CLI_OUTPUT_MODE_VARIANT_SPECS
+    )
 
 
 @pytest.mark.parametrize("scenario", SCENARIOS, ids=lambda scenario: scenario.name)
@@ -400,3 +515,28 @@ def test_collection_growth_and_bootstrap_duplication_are_explicit(tmp_path: Path
     assert bootstrap_duplication["command_content"]["duplicate_occurrences"] <= 9
     assert start_duplication["objective_content"]["duplicate_occurrences"] > 0
     assert bootstrap_duplication["objective_content"]["duplicate_occurrences"] > 0
+
+
+def test_explicit_compact_and_detail_modes_are_characterized(tmp_path: Path) -> None:
+    project, runtime, registry_path, state_file = _write_fixture(tmp_path, SCENARIOS[0])
+    for output_format in ("json", "markdown"):
+        commands = _mode_variant_commands(
+            project=project,
+            runtime=runtime,
+            registry_path=registry_path,
+            state_file=state_file,
+            output_format=output_format,
+        )
+        for variant_id, command in commands.items():
+            spec = CLI_OUTPUT_MODE_VARIANT_BY_ID[variant_id]
+            if output_format not in spec.output_formats:
+                continue
+            exit_code, text = _invoke_cli(command)
+            assert exit_code == 0, (variant_id, output_format, text)
+            measurement = measure_cli_output(text, output_format=output_format)  # type: ignore[arg-type]
+            assert_cli_output_mode_variant(
+                spec,
+                output_format=output_format,  # type: ignore[arg-type]
+                text=text,
+                measurement=measurement,
+            )


### PR DESCRIPTION
## Summary
- add a canonical inventory for 10 default agent-facing CLI output surfaces and 8 explicit compact/detail mode variants
- measure exact emitted JSON/Markdown chars, UTF-8 bytes, lines, parseability, semantic anchors, growth, and bootstrap duplication
- exercise small, crowded, and multi-agent public fixtures through the real CLI entry point
- document the difference between compact payload budgets and actual stdout baselines

## Scope
This PR is characterization-only. It does not compact or otherwise change production CLI output. Large current ceilings are explicit regression baselines to be lowered by a later optimization PR.

## Validation
- `pytest -q tests/control_plane/test_cli_output_budget.py` (6 passed)
- `python3 examples/control_plane/hot-path-interface-budget-smoke.py`
- `python3 examples/bootstrap-command-pack-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `python3 -m ruff check loopx/control_plane/testing/cli_output_budget.py tests/control_plane/test_cli_output_budget.py`
- `loopx canary premerge --from-git-diff` (10 selected, 0 failed, no manual holds)
- public/private boundary scan clean

## Follow-up
Canary selection currently reaches the generic Python/control-plane checks but not this new matrix directly. A separate planned change will wire the output-surface manifest into canary/CI selection without mixing production compaction into this baseline PR.
