### PR TITLE
Add provider-neutral review batch contract

### DIFF
--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -26,6 +26,7 @@ Current contracts:
 - [auto_research_role_profile_v0](auto-research-role-profile-v0.md)
 - [global_manager_command_v0](global-manager-command-v0.md)
 - [pr_review_command_v0](pr-review-command-v0.md)
+- [review_batch_v0](review-batch-v0.md)
 - [event_sourced_state_contract_v0](event-sourced-state-contract-v0.md)
 - [active_state_structured_projection_v0](active-state-structured-projection-v0.md)
 - [local_state_write_correctness_v0](local-state-write-correctness-v0.md)

--- a/docs/reference/protocols/review-batch-v0.md
+++ b/docs/reference/protocols/review-batch-v0.md
@@ -1,0 +1,77 @@
+# Provider-neutral review batch v0
+
+`review_batch_v0` is a cold-path composition contract for bounded human review.
+It turns already-normalized candidate packets into one deterministic decision
+surface. Candidate collection, repository APIs, chat APIs, scoring policy, and
+external delivery remain adopter responsibilities.
+
+Use it when several sources need one stable sort/limit, an exact decision
+digest, and compact delivery receipts:
+
+```bash
+loopx review-batch compose --request-json request.json --format json
+loopx review-batch bind-decisions \
+  --batch-json batch.json \
+  --decisions-json decisions.json \
+  --format json
+```
+
+Both commands are local and effect-free. They do not fetch candidates, publish
+comments, update documents, send chat messages, or infer external authority.
+
+## Composition request
+
+A `review_batch_request_v0` contains:
+
+- `batch_id` and `generated_at`;
+- `policy.soft_limit`, `policy.hard_limit`, an ordered list of stable priority
+  reason codes, and the adopter's allowed decision values;
+- typed `candidate_sources[]`, each with `source_id`, `source_kind`, and
+  normalized `candidates[]`;
+- optional compact `sink_receipts[]` produced by an external adapter.
+
+Each candidate provides a stable id and source reference, a bounded summary,
+priority tier and registered reason codes, compact evidence state/references,
+and either a proposed action or a compact draft. The core sorts candidates by
+tier, configured reason order, and stable candidate id; it applies the hard
+limit before the soft report limit.
+
+The core rejects raw content, logs, transcripts, credentials, secret/token
+fields, and local-private paths. Adopters must normalize those inputs before
+calling the command.
+
+## Digest and decision binding
+
+Every selected candidate receives a digest over its normalized identity,
+evidence, priority, and proposal. The batch digest binds the exact ordered list
+of candidate digests to the policy. `review_batch_decisions_v0` must repeat the
+batch digest and each decided candidate's digest. `bind-decisions` rejects
+stale, unknown, duplicated, or policy-invalid decisions and emits a compact
+`review_batch_decision_receipt_v0` without executing them.
+
+## Delivery receipts
+
+Sink delivery runs outside the core. A receipt is provider-neutral:
+
+- `sink_id` and `sink_kind`;
+- `status`: `preview`, `sent`, `failed`, or `skipped`;
+- optional `idempotency_key` and `receipt_ref`;
+- `readback_verified`.
+
+`sent` is accepted only when idempotency, a receipt reference, and verified
+readback are all present. The core stores no provider response body.
+
+## Adopter boundary
+
+An adopter may source pull requests, issue-comment drafts, documents, or other
+reviewable items, but those names and policies do not enter this core. It owns:
+
+- candidate adapters and freshness checks;
+- domain-specific risk scoring mapped to registered reason codes;
+- document/chat rendering and delivery;
+- authority checks before any external effect;
+- applying only decisions whose exact digests were bound successfully.
+
+This keeps a daily maintainer report, a content review queue, and an operations
+decision brief on the same small contract without hard-coding one provider or
+project into LoopX.

--- a/docs/reference/protocols/review-batch-v0.md
+++ b/docs/reference/protocols/review-batch-v0.md
@@ -46,7 +46,8 @@ Every selected candidate receives a digest over its normalized identity,
 evidence, priority, and proposal. The batch digest binds the exact ordered list
 of candidate digests to the policy. `review_batch_decisions_v0` must repeat the
 batch digest and each decided candidate's digest. `bind-decisions` rejects
-stale, unknown, duplicated, or policy-invalid decisions and emits a compact
+stale, tampered, unknown, duplicated, or policy-invalid decisions by
+recomputing both digest layers, then emits a compact
 `review_batch_decision_receipt_v0` without executing them.
 
 ## Delivery receipts

--- a/loopx/capabilities/review_batch/__init__.py
+++ b/loopx/capabilities/review_batch/__init__.py
@@ -1,0 +1,11 @@
+"""Provider-neutral review-batch composition and decision binding."""
+
+from .core import (
+    build_review_batch,
+    bind_review_batch_decisions,
+)
+
+__all__ = [
+    "bind_review_batch_decisions",
+    "build_review_batch",
+]

--- a/loopx/capabilities/review_batch/cli.py
+++ b/loopx/capabilities/review_batch/cli.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from .core import bind_review_batch_decisions, build_review_batch
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+FormatSelector = Callable[..., str]
+AddFormat = Callable[[argparse.ArgumentParser], None]
+
+
+def _load_json_object(path_text: str) -> dict[str, Any]:
+    if path_text == "-":
+        payload = json.loads(sys.stdin.read())
+    else:
+        payload = json.loads(Path(path_text).expanduser().read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path_text} must contain a JSON object")
+    return payload
+
+
+def register_review_batch_commands(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: AddFormat,
+) -> None:
+    parser = subparsers.add_parser(
+        "review-batch",
+        help="Compose provider-neutral bounded review batches and bind exact decisions.",
+    )
+    commands = parser.add_subparsers(dest="review_batch_command", required=True)
+    compose = commands.add_parser(
+        "compose",
+        help="Compose a deterministic review_batch_v0 packet from typed candidate sources.",
+    )
+    add_subcommand_format(compose)
+    compose.add_argument(
+        "--request-json",
+        required=True,
+        help="Path to a review_batch_request_v0 object; use '-' for stdin.",
+    )
+    bind = commands.add_parser(
+        "bind-decisions",
+        help="Bind maintainer decisions to exact batch and candidate digests without effects.",
+    )
+    add_subcommand_format(bind)
+    bind.add_argument("--batch-json", required=True, help="Path to review_batch_v0 JSON.")
+    bind.add_argument(
+        "--decisions-json",
+        required=True,
+        help="Path to review_batch_decisions_v0 JSON.",
+    )
+
+
+def _render_candidate(candidate: dict[str, Any]) -> list[str]:
+    reasons = candidate.get("priority_reasons")
+    reason_text = ", ".join(
+        str(item.get("code")) for item in reasons or [] if isinstance(item, dict)
+    )
+    proposal = candidate.get("proposal") if isinstance(candidate.get("proposal"), dict) else {}
+    action = proposal.get("action") or proposal.get("draft") or "n/a"
+    return [
+        f"### {candidate.get('candidate_id')}: {candidate.get('title')}",
+        "",
+        f"- priority: tier {candidate.get('priority_tier')} ({reason_text})",
+        f"- evidence: `{candidate.get('evidence_status')}`",
+        f"- proposed: {action}",
+        f"- decision_digest: `{candidate.get('decision_digest')}`",
+        "",
+    ]
+
+
+def render_review_batch_markdown(payload: dict[str, object]) -> str:
+    if not payload.get("ok"):
+        return f"# Review Batch Error\n\n- error: {payload.get('error')}\n"
+    lines = [
+        f"# Review Batch `{payload.get('batch_id')}`",
+        "",
+        f"- schema: `{payload.get('schema_version')}`",
+        f"- decision_digest: `{payload.get('decision_digest')}`",
+        f"- candidate_counts: `{json.dumps(payload.get('candidate_counts'), ensure_ascii=False, sort_keys=True)}`",
+        "",
+    ]
+    for candidate in payload.get("candidates") or []:
+        if isinstance(candidate, dict):
+            lines.extend(_render_candidate(candidate))
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_review_batch_decision_markdown(payload: dict[str, object]) -> str:
+    if not payload.get("ok"):
+        return f"# Review Batch Decision Error\n\n- error: {payload.get('error')}\n"
+    lines = [
+        f"# Review Batch Decisions `{payload.get('batch_id')}`",
+        "",
+        f"- receipt_id: `{payload.get('receipt_id')}`",
+        f"- decision_digest: `{payload.get('decision_digest')}`",
+        "",
+    ]
+    for decision in payload.get("decisions") or []:
+        if isinstance(decision, dict):
+            lines.append(
+                f"- `{decision.get('candidate_id')}`: `{decision.get('decision')}` "
+                f"(`{decision.get('candidate_decision_digest')}`)"
+            )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def handle_review_batch_command(
+    args: argparse.Namespace,
+    *,
+    output_format: FormatSelector,
+    print_payload: PrintPayload,
+) -> int | None:
+    if args.command != "review-batch":
+        return None
+    renderer = render_review_batch_markdown
+    try:
+        if args.review_batch_command == "compose":
+            payload = build_review_batch(_load_json_object(args.request_json))
+        else:
+            payload = bind_review_batch_decisions(
+                _load_json_object(args.batch_json),
+                _load_json_object(args.decisions_json),
+            )
+            renderer = render_review_batch_decision_markdown
+    except Exception as exc:
+        payload = {
+            "ok": False,
+            "schema_version": "review_batch_error_v0",
+            "command": args.review_batch_command,
+            "error": str(exc),
+        }
+    print_payload(payload, output_format(args), renderer)
+    return 0 if payload.get("ok") else 1

--- a/loopx/capabilities/review_batch/core.py
+++ b/loopx/capabilities/review_batch/core.py
@@ -85,6 +85,31 @@ def _digest(value: object, *, prefix: str) -> str:
     return f"{prefix}_{hashlib.sha256(encoded).hexdigest()[:24]}"
 
 
+def _candidate_decision_digest(candidate: Mapping[str, Any]) -> str:
+    digest_input = {
+        key: value
+        for key, value in candidate.items()
+        if key != "decision_digest" and value is not None
+    }
+    return _digest(digest_input, prefix="candidate")
+
+
+def _batch_decision_digest(
+    *,
+    batch_id: str,
+    policy: Mapping[str, Any],
+    candidate_decision_digests: list[str],
+) -> str:
+    return _digest(
+        {
+            "batch_id": batch_id,
+            "policy": dict(policy),
+            "candidate_decision_digests": candidate_decision_digests,
+        },
+        prefix="batch",
+    )
+
+
 def _normalize_policy(raw: object) -> dict[str, Any]:
     policy = _object(raw, "policy")
     soft_limit = int(policy.get("soft_limit", 8))
@@ -203,8 +228,7 @@ def _normalize_candidate(
             candidate.get("observed_at"), f"{label}.observed_at", maximum=80
         ),
     }
-    digest_input = {key: value for key, value in normalized.items() if value is not None}
-    normalized["decision_digest"] = _digest(digest_input, prefix="candidate")
+    normalized["decision_digest"] = _candidate_decision_digest(normalized)
     return normalized
 
 
@@ -306,13 +330,10 @@ def build_review_batch(request: Mapping[str, Any]) -> dict[str, Any]:
     )
     bounded = ordered[: policy["hard_limit"]]
     selected = bounded[: policy["soft_limit"]]
-    decision_digest = _digest(
-        {
-            "batch_id": batch_id,
-            "policy": policy,
-            "candidate_decision_digests": [item["decision_digest"] for item in selected],
-        },
-        prefix="batch",
+    decision_digest = _batch_decision_digest(
+        batch_id=batch_id,
+        policy=policy,
+        candidate_decision_digests=[item["decision_digest"] for item in selected],
     )
     return {
         "ok": True,
@@ -352,20 +373,50 @@ def bind_review_batch_decisions(
         raise ValueError(f"batch must use {BATCH_SCHEMA}")
     if decision_payload.get("schema_version") != DECISIONS_SCHEMA:
         raise ValueError(f"decisions must use {DECISIONS_SCHEMA}")
+    _reject_raw_keys(batch_payload, "batch")
     _reject_raw_keys(decision_payload, "decisions")
+    batch_id = _token(batch_payload.get("batch_id"), "batch.batch_id")
+    if batch_payload.get("batch_id") != batch_id:
+        raise ValueError("batch.batch_id must be normalized")
+    raw_policy = _object(batch_payload.get("policy"), "batch.policy")
+    policy = _normalize_policy(raw_policy)
+    if raw_policy != policy:
+        raise ValueError("batch.policy must be normalized")
+    candidates = _list(batch_payload.get("candidates"), "batch.candidates")
+    candidate_by_id: dict[str, dict[str, Any]] = {}
+    candidate_digests: list[str] = []
+    for index, value in enumerate(candidates):
+        label = f"batch.candidates[{index}]"
+        candidate = _object(value, label)
+        candidate_id = _token(candidate.get("candidate_id"), f"{label}.candidate_id")
+        if candidate.get("candidate_id") != candidate_id:
+            raise ValueError(f"{label}.candidate_id must be normalized")
+        if candidate_id in candidate_by_id:
+            raise ValueError(f"duplicate batch candidate_id {candidate_id!r}")
+        supplied_candidate_digest = _text(
+            candidate.get("decision_digest"), f"{label}.decision_digest"
+        )
+        expected_candidate_digest = _candidate_decision_digest(candidate)
+        if supplied_candidate_digest != expected_candidate_digest:
+            raise ValueError(
+                f"batch candidate digest does not match candidate {candidate_id!r}"
+            )
+        candidate_by_id[candidate_id] = candidate
+        candidate_digests.append(supplied_candidate_digest)
     expected_batch_digest = _text(batch_payload.get("decision_digest"), "batch.decision_digest")
+    recomputed_batch_digest = _batch_decision_digest(
+        batch_id=batch_id,
+        policy=policy,
+        candidate_decision_digests=candidate_digests,
+    )
+    if expected_batch_digest != recomputed_batch_digest:
+        raise ValueError("batch decision digest does not match the exact review batch")
     supplied_batch_digest = _text(
         decision_payload.get("decision_digest"), "decisions.decision_digest"
     )
     if supplied_batch_digest != expected_batch_digest:
         raise ValueError("decision batch digest does not match the exact review batch")
-    policy = _object(batch_payload.get("policy"), "batch.policy")
-    allowed = set(_list(policy.get("decision_values"), "batch.policy.decision_values"))
-    candidate_by_id = {
-        str(item["candidate_id"]): item
-        for item in _list(batch_payload.get("candidates"), "batch.candidates")
-        if isinstance(item, Mapping) and item.get("candidate_id")
-    }
+    allowed = set(policy["decision_values"])
     bound: list[dict[str, Any]] = []
     seen: set[str] = set()
     for index, value in enumerate(_list(decision_payload.get("decisions"), "decisions.decisions")):

--- a/loopx/capabilities/review_batch/core.py
+++ b/loopx/capabilities/review_batch/core.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from typing import Any
+
+
+REQUEST_SCHEMA = "review_batch_request_v0"
+BATCH_SCHEMA = "review_batch_v0"
+DECISIONS_SCHEMA = "review_batch_decisions_v0"
+DECISION_RECEIPT_SCHEMA = "review_batch_decision_receipt_v0"
+
+_TOKEN_RE = re.compile(r"^[a-z][a-z0-9_.-]{0,127}$")
+_FORBIDDEN_RAW_KEYS = {
+    "credential",
+    "credentials",
+    "private_path",
+    "raw_body",
+    "raw_content",
+    "raw_log",
+    "raw_logs",
+    "raw_message",
+    "raw_transcript",
+    "secret",
+    "token",
+}
+_RECEIPT_STATUSES = {"preview", "sent", "failed", "skipped"}
+
+
+def _object(value: object, label: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be an object")
+    return {str(key): item for key, item in value.items()}
+
+
+def _list(value: object, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValueError(f"{label} must be a list")
+    return list(value)
+
+
+def _text(value: object, label: str, *, maximum: int = 1000) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{label} is required")
+    if len(text) > maximum:
+        raise ValueError(f"{label} exceeds {maximum} characters")
+    return text
+
+
+def _optional_text(value: object, label: str, *, maximum: int = 1000) -> str | None:
+    if value is None:
+        return None
+    return _text(value, label, maximum=maximum)
+
+
+def _token(value: object, label: str) -> str:
+    token = _text(value, label, maximum=128).lower()
+    if not _TOKEN_RE.fullmatch(token):
+        raise ValueError(f"{label} must be a lower-snake-like public token")
+    return token
+
+
+def _reject_raw_keys(value: object, label: str) -> None:
+    if isinstance(value, Mapping):
+        for raw_key, item in value.items():
+            key = str(raw_key).strip().lower()
+            if key in _FORBIDDEN_RAW_KEYS:
+                raise ValueError(f"{label} contains forbidden raw/private field {raw_key!r}")
+            _reject_raw_keys(item, f"{label}.{raw_key}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            _reject_raw_keys(item, f"{label}[{index}]")
+
+
+def _digest(value: object, *, prefix: str) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return f"{prefix}_{hashlib.sha256(encoded).hexdigest()[:24]}"
+
+
+def _normalize_policy(raw: object) -> dict[str, Any]:
+    policy = _object(raw, "policy")
+    soft_limit = int(policy.get("soft_limit", 8))
+    hard_limit = int(policy.get("hard_limit", max(soft_limit, 10)))
+    if not 1 <= soft_limit <= hard_limit <= 50:
+        raise ValueError("policy limits must satisfy 1 <= soft_limit <= hard_limit <= 50")
+    reason_order = [
+        _token(value, f"policy.priority_reason_order[{index}]")
+        for index, value in enumerate(
+            _list(policy.get("priority_reason_order"), "policy.priority_reason_order")
+        )
+    ]
+    if not reason_order:
+        raise ValueError("policy.priority_reason_order must not be empty")
+    if len(reason_order) != len(set(reason_order)):
+        raise ValueError("policy.priority_reason_order must contain unique codes")
+    decision_values = [
+        _token(value, f"policy.decision_values[{index}]")
+        for index, value in enumerate(
+            _list(
+                policy.get("decision_values", ["approve", "revise", "hold", "skip"]),
+                "policy.decision_values",
+            )
+        )
+    ]
+    if not decision_values or len(decision_values) != len(set(decision_values)):
+        raise ValueError("policy.decision_values must contain unique values")
+    return {
+        "soft_limit": soft_limit,
+        "hard_limit": hard_limit,
+        "priority_reason_order": reason_order,
+        "decision_values": decision_values,
+    }
+
+
+def _normalize_priority_reasons(
+    raw: object,
+    *,
+    candidate_label: str,
+    reason_order: list[str],
+) -> list[dict[str, str]]:
+    reasons: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for index, value in enumerate(_list(raw, f"{candidate_label}.priority_reasons")):
+        if isinstance(value, str):
+            code = _token(value, f"{candidate_label}.priority_reasons[{index}]")
+            detail = code.replace("_", " ")
+        else:
+            item = _object(value, f"{candidate_label}.priority_reasons[{index}]")
+            code = _token(item.get("code"), f"{candidate_label}.priority_reasons[{index}].code")
+            detail = _text(
+                item.get("detail"),
+                f"{candidate_label}.priority_reasons[{index}].detail",
+                maximum=400,
+            )
+        if code not in reason_order:
+            raise ValueError(
+                f"{candidate_label}.priority_reasons contains unregistered code {code!r}"
+            )
+        if code not in seen:
+            reasons.append({"code": code, "detail": detail})
+            seen.add(code)
+    if not reasons:
+        raise ValueError(f"{candidate_label}.priority_reasons must not be empty")
+    reasons.sort(key=lambda item: reason_order.index(item["code"]))
+    return reasons
+
+
+def _normalize_candidate(
+    raw: object,
+    *,
+    source_id: str,
+    source_kind: str,
+    source_index: int,
+    candidate_index: int,
+    policy: dict[str, Any],
+) -> dict[str, Any]:
+    label = f"candidate_sources[{source_index}].candidates[{candidate_index}]"
+    candidate = _object(raw, label)
+    _reject_raw_keys(candidate, label)
+    candidate_id = _token(candidate.get("candidate_id"), f"{label}.candidate_id")
+    priority_tier = int(candidate.get("priority_tier", 1))
+    if not 0 <= priority_tier <= 9:
+        raise ValueError(f"{label}.priority_tier must be between 0 and 9")
+    reasons = _normalize_priority_reasons(
+        candidate.get("priority_reasons"),
+        candidate_label=label,
+        reason_order=policy["priority_reason_order"],
+    )
+    proposal = _object(candidate.get("proposal"), f"{label}.proposal")
+    action = _optional_text(proposal.get("action"), f"{label}.proposal.action", maximum=600)
+    draft = _optional_text(proposal.get("draft"), f"{label}.proposal.draft", maximum=2000)
+    if not action and not draft:
+        raise ValueError(f"{label}.proposal requires action or draft")
+    evidence_refs = [
+        _text(value, f"{label}.evidence_refs[{index}]", maximum=500)
+        for index, value in enumerate(_list(candidate.get("evidence_refs", []), f"{label}.evidence_refs"))
+    ]
+    normalized = {
+        "candidate_id": candidate_id,
+        "source": {
+            "source_id": source_id,
+            "source_kind": source_kind,
+            "source_ref": _text(candidate.get("source_ref"), f"{label}.source_ref", maximum=500),
+        },
+        "title": _text(candidate.get("title"), f"{label}.title", maximum=300),
+        "summary": _text(candidate.get("summary"), f"{label}.summary", maximum=1200),
+        "priority_tier": priority_tier,
+        "priority_reasons": reasons,
+        "evidence_status": _token(
+            candidate.get("evidence_status"), f"{label}.evidence_status"
+        ),
+        "evidence_refs": evidence_refs,
+        "proposal": {key: value for key, value in (("action", action), ("draft", draft)) if value},
+        "observed_at": _optional_text(
+            candidate.get("observed_at"), f"{label}.observed_at", maximum=80
+        ),
+    }
+    digest_input = {key: value for key, value in normalized.items() if value is not None}
+    normalized["decision_digest"] = _digest(digest_input, prefix="candidate")
+    return normalized
+
+
+def _candidate_sort_key(candidate: dict[str, Any], reason_order: list[str]) -> tuple[Any, ...]:
+    reason_ranks = tuple(
+        reason_order.index(str(item["code"])) for item in candidate["priority_reasons"]
+    )
+    return (
+        int(candidate["priority_tier"]),
+        reason_ranks,
+        str(candidate["candidate_id"]),
+    )
+
+
+def _normalize_sink_receipts(raw: object) -> list[dict[str, Any]]:
+    receipts: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, value in enumerate(_list(raw, "sink_receipts")):
+        label = f"sink_receipts[{index}]"
+        item = _object(value, label)
+        _reject_raw_keys(item, label)
+        sink_id = _token(item.get("sink_id"), f"{label}.sink_id")
+        if sink_id in seen:
+            raise ValueError(f"duplicate sink_id {sink_id!r}")
+        seen.add(sink_id)
+        status = _token(item.get("status"), f"{label}.status")
+        if status not in _RECEIPT_STATUSES:
+            raise ValueError(f"{label}.status is invalid")
+        receipt = {
+            "sink_id": sink_id,
+            "sink_kind": _token(item.get("sink_kind"), f"{label}.sink_kind"),
+            "status": status,
+            "idempotency_key": _optional_text(
+                item.get("idempotency_key"), f"{label}.idempotency_key", maximum=300
+            ),
+            "receipt_ref": _optional_text(
+                item.get("receipt_ref"), f"{label}.receipt_ref", maximum=500
+            ),
+            "readback_verified": bool(item.get("readback_verified", False)),
+        }
+        if status == "sent" and not (
+            receipt["idempotency_key"]
+            and receipt["receipt_ref"]
+            and receipt["readback_verified"]
+        ):
+            raise ValueError(
+                f"{label} sent receipts require idempotency_key, receipt_ref, and readback_verified=true"
+            )
+        receipts.append(receipt)
+    return receipts
+
+
+def build_review_batch(request: Mapping[str, Any]) -> dict[str, Any]:
+    """Compose one deterministic, provider-neutral review batch."""
+
+    payload = _object(request, "request")
+    if payload.get("schema_version") != REQUEST_SCHEMA:
+        raise ValueError(f"request must use {REQUEST_SCHEMA}")
+    _reject_raw_keys(payload, "request")
+    batch_id = _token(payload.get("batch_id"), "batch_id")
+    policy = _normalize_policy(payload.get("policy"))
+    sources = _list(payload.get("candidate_sources"), "candidate_sources")
+    if not sources:
+        raise ValueError("candidate_sources must not be empty")
+    normalized_candidates: list[dict[str, Any]] = []
+    source_summary: list[dict[str, Any]] = []
+    seen_sources: set[str] = set()
+    seen_candidates: set[str] = set()
+    for source_index, raw_source in enumerate(sources):
+        label = f"candidate_sources[{source_index}]"
+        source = _object(raw_source, label)
+        source_id = _token(source.get("source_id"), f"{label}.source_id")
+        source_kind = _token(source.get("source_kind"), f"{label}.source_kind")
+        if source_id in seen_sources:
+            raise ValueError(f"duplicate source_id {source_id!r}")
+        seen_sources.add(source_id)
+        candidates = _list(source.get("candidates"), f"{label}.candidates")
+        source_summary.append(
+            {"source_id": source_id, "source_kind": source_kind, "candidate_count": len(candidates)}
+        )
+        for candidate_index, raw_candidate in enumerate(candidates):
+            candidate = _normalize_candidate(
+                raw_candidate,
+                source_id=source_id,
+                source_kind=source_kind,
+                source_index=source_index,
+                candidate_index=candidate_index,
+                policy=policy,
+            )
+            candidate_id = str(candidate["candidate_id"])
+            if candidate_id in seen_candidates:
+                raise ValueError(f"duplicate candidate_id {candidate_id!r}")
+            seen_candidates.add(candidate_id)
+            normalized_candidates.append(candidate)
+
+    ordered = sorted(
+        normalized_candidates,
+        key=lambda candidate: _candidate_sort_key(candidate, policy["priority_reason_order"]),
+    )
+    bounded = ordered[: policy["hard_limit"]]
+    selected = bounded[: policy["soft_limit"]]
+    decision_digest = _digest(
+        {
+            "batch_id": batch_id,
+            "policy": policy,
+            "candidate_decision_digests": [item["decision_digest"] for item in selected],
+        },
+        prefix="batch",
+    )
+    return {
+        "ok": True,
+        "schema_version": BATCH_SCHEMA,
+        "batch_id": batch_id,
+        "generated_at": _text(payload.get("generated_at"), "generated_at", maximum=80),
+        "policy": policy,
+        "source_summary": source_summary,
+        "candidate_counts": {
+            "input": len(ordered),
+            "within_hard_limit": len(bounded),
+            "selected": len(selected),
+            "overflow": max(0, len(ordered) - len(selected)),
+        },
+        "candidates": selected,
+        "decision_digest": decision_digest,
+        "sink_receipts": _normalize_sink_receipts(payload.get("sink_receipts", [])),
+        "boundary": {
+            "provider_neutral": True,
+            "raw_content_persisted": False,
+            "external_writes_performed": False,
+            "candidate_adapters_execute_outside_core": True,
+            "sink_delivery_executes_outside_core": True,
+        },
+    }
+
+
+def bind_review_batch_decisions(
+    batch: Mapping[str, Any],
+    decisions: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Validate decisions against exact batch and candidate digests without effects."""
+
+    batch_payload = _object(batch, "batch")
+    decision_payload = _object(decisions, "decisions")
+    if batch_payload.get("schema_version") != BATCH_SCHEMA:
+        raise ValueError(f"batch must use {BATCH_SCHEMA}")
+    if decision_payload.get("schema_version") != DECISIONS_SCHEMA:
+        raise ValueError(f"decisions must use {DECISIONS_SCHEMA}")
+    _reject_raw_keys(decision_payload, "decisions")
+    expected_batch_digest = _text(batch_payload.get("decision_digest"), "batch.decision_digest")
+    supplied_batch_digest = _text(
+        decision_payload.get("decision_digest"), "decisions.decision_digest"
+    )
+    if supplied_batch_digest != expected_batch_digest:
+        raise ValueError("decision batch digest does not match the exact review batch")
+    policy = _object(batch_payload.get("policy"), "batch.policy")
+    allowed = set(_list(policy.get("decision_values"), "batch.policy.decision_values"))
+    candidate_by_id = {
+        str(item["candidate_id"]): item
+        for item in _list(batch_payload.get("candidates"), "batch.candidates")
+        if isinstance(item, Mapping) and item.get("candidate_id")
+    }
+    bound: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, value in enumerate(_list(decision_payload.get("decisions"), "decisions.decisions")):
+        label = f"decisions.decisions[{index}]"
+        item = _object(value, label)
+        candidate_id = _token(item.get("candidate_id"), f"{label}.candidate_id")
+        if candidate_id in seen:
+            raise ValueError(f"duplicate decision for {candidate_id!r}")
+        seen.add(candidate_id)
+        candidate = candidate_by_id.get(candidate_id)
+        if candidate is None:
+            raise ValueError(f"decision references unknown candidate {candidate_id!r}")
+        supplied_candidate_digest = _text(
+            item.get("candidate_decision_digest"), f"{label}.candidate_decision_digest"
+        )
+        if supplied_candidate_digest != candidate.get("decision_digest"):
+            raise ValueError(f"decision digest does not match candidate {candidate_id!r}")
+        decision = _token(item.get("decision"), f"{label}.decision")
+        if decision not in allowed:
+            raise ValueError(f"decision {decision!r} is not allowed by the batch policy")
+        bound.append(
+            {
+                "candidate_id": candidate_id,
+                "candidate_decision_digest": supplied_candidate_digest,
+                "decision": decision,
+                "note": _optional_text(item.get("note"), f"{label}.note", maximum=600),
+            }
+        )
+    receipt_input = {
+        "batch_id": batch_payload.get("batch_id"),
+        "decision_digest": expected_batch_digest,
+        "decisions": bound,
+    }
+    return {
+        "ok": True,
+        "schema_version": DECISION_RECEIPT_SCHEMA,
+        **receipt_input,
+        "receipt_id": _digest(receipt_input, prefix="decision_receipt"),
+        "boundary": {
+            "exact_digest_binding": True,
+            "external_writes_performed": False,
+            "raw_content_persisted": False,
+        },
+    }

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -18,6 +18,10 @@ from .capabilities.reward_memory.cli import (
     handle_reward_memory_command,
     register_reward_memory_commands,
 )
+from .capabilities.review_batch.cli import (
+    handle_review_batch_command,
+    register_review_batch_commands,
+)
 from .capabilities.semantic_preference.cli import (
     handle_semantic_preference_command,
     register_semantic_preference_commands,
@@ -184,6 +188,8 @@ def main(argv: list[str] | None = None) -> int:
     register_issue_fix_commands(sub, add_subcommand_format)
 
     register_reward_memory_commands(sub, add_subcommand_format)
+
+    register_review_batch_commands(sub, add_subcommand_format)
 
     register_semantic_preference_commands(sub, add_subcommand_format)
 
@@ -384,6 +390,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     if reward_memory_result is not None:
         return reward_memory_result
+
+    review_batch_result = handle_review_batch_command(
+        args,
+        output_format=output_format,
+        print_payload=print_payload,
+    )
+    if review_batch_result is not None:
+        return review_batch_result
 
     semantic_preference_result = handle_semantic_preference_command(
         args,

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -154,6 +154,10 @@ COMMAND_GROUPS: list[dict[str, object]] = [
                 "purpose": "Record the exploration topology (nodes, edges, findings) and project it to a Feishu/Lark result board.",
             },
             {"command": "loopx issue-fix", "purpose": "Build public-safe issue or PR fix workflow packets."},
+            {
+                "command": "loopx review-batch",
+                "purpose": "Compose provider-neutral bounded review packets and bind exact decisions.",
+            },
             {"command": "loopx auto-research", "purpose": "Project public-safe research frontiers."},
             {"command": "loopx multi-agent", "purpose": "Launch visible role-scoped Codex TUI agents."},
             {"command": "loopx canary", "purpose": "Plan or run catalog-informed smoke profiles."},

--- a/tests/capabilities/test_review_batch.py
+++ b/tests/capabilities/test_review_batch.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+
+from loopx.capabilities.review_batch import (
+    bind_review_batch_decisions,
+    build_review_batch,
+)
+from loopx.cli import main
+
+
+def _request() -> dict[str, object]:
+    return {
+        "schema_version": "review_batch_request_v0",
+        "batch_id": "maintainer_daily_001",
+        "generated_at": "2026-07-15T10:00:00Z",
+        "policy": {
+            "soft_limit": 2,
+            "hard_limit": 3,
+            "priority_reason_order": [
+                "correctness_risk",
+                "user_impact",
+                "evidence_ready",
+            ],
+            "decision_values": ["approve", "revise", "hold", "skip"],
+        },
+        "candidate_sources": [
+            {
+                "source_id": "change_queue",
+                "source_kind": "change_request",
+                "candidates": [
+                    {
+                        "candidate_id": "change_2",
+                        "source_ref": "public:change/2",
+                        "title": "Small verified correction",
+                        "summary": "A bounded change with focused evidence.",
+                        "priority_tier": 1,
+                        "priority_reasons": [
+                            {"code": "evidence_ready", "detail": "Focused checks passed."}
+                        ],
+                        "evidence_status": "verified",
+                        "evidence_refs": ["public:check/2"],
+                        "proposal": {"action": "Route to human review."},
+                    },
+                    {
+                        "candidate_id": "change_1",
+                        "source_ref": "public:change/1",
+                        "title": "Correctness risk",
+                        "summary": "A behavior change with a known correctness concern.",
+                        "priority_tier": 0,
+                        "priority_reasons": [
+                            {
+                                "code": "correctness_risk",
+                                "detail": "Current evidence exposes a correctness gap.",
+                            }
+                        ],
+                        "evidence_status": "needs_revision",
+                        "evidence_refs": ["public:review/1"],
+                        "proposal": {"draft": "Please address the focused blocker."},
+                    },
+                ],
+            },
+            {
+                "source_id": "question_queue",
+                "source_kind": "response_draft",
+                "candidates": [
+                    {
+                        "candidate_id": "question_1",
+                        "source_ref": "public:question/1",
+                        "title": "Evidence request",
+                        "summary": "A response draft that asks for missing evidence.",
+                        "priority_tier": 1,
+                        "priority_reasons": [
+                            {"code": "user_impact", "detail": "The report is user-visible."}
+                        ],
+                        "evidence_status": "missing_evidence",
+                        "evidence_refs": [],
+                        "proposal": {"action": "Request bounded diagnostics."},
+                    }
+                ],
+            },
+        ],
+        "sink_receipts": [
+            {
+                "sink_id": "owner_document",
+                "sink_kind": "managed_document",
+                "status": "preview",
+                "readback_verified": False,
+            }
+        ],
+    }
+
+
+def test_review_batch_is_bounded_deterministic_and_provider_neutral() -> None:
+    request = _request()
+    first = build_review_batch(request)
+    reversed_request = copy.deepcopy(request)
+    reversed_request["candidate_sources"] = list(
+        reversed(reversed_request["candidate_sources"])
+    )
+    for source in reversed_request["candidate_sources"]:
+        source["candidates"] = list(reversed(source["candidates"]))
+    second = build_review_batch(reversed_request)
+
+    assert first["schema_version"] == "review_batch_v0"
+    assert [item["candidate_id"] for item in first["candidates"]] == [
+        "change_1",
+        "question_1",
+    ]
+    assert first["candidate_counts"] == {
+        "input": 3,
+        "within_hard_limit": 3,
+        "selected": 2,
+        "overflow": 1,
+    }
+    assert first["decision_digest"] == second["decision_digest"]
+    assert first["boundary"] == {
+        "provider_neutral": True,
+        "raw_content_persisted": False,
+        "external_writes_performed": False,
+        "candidate_adapters_execute_outside_core": True,
+        "sink_delivery_executes_outside_core": True,
+    }
+    encoded = json.dumps(first, sort_keys=True)
+    assert "github" not in encoded.lower()
+    assert "lark" not in encoded.lower()
+    assert "openviking" not in encoded.lower()
+
+
+def test_sent_sink_receipt_requires_idempotency_and_readback() -> None:
+    request = _request()
+    request["sink_receipts"] = [
+        {
+            "sink_id": "owner_document",
+            "sink_kind": "managed_document",
+            "status": "sent",
+            "receipt_ref": "public:receipt/1",
+            "readback_verified": True,
+        }
+    ]
+    with pytest.raises(ValueError, match="sent receipts require idempotency_key"):
+        build_review_batch(request)
+
+
+def test_raw_content_and_unregistered_reason_are_rejected() -> None:
+    raw_request = _request()
+    raw_request["candidate_sources"][0]["candidates"][0]["raw_body"] = "do not persist"
+    with pytest.raises(ValueError, match="forbidden raw/private field"):
+        build_review_batch(raw_request)
+
+    reason_request = _request()
+    reason_request["candidate_sources"][0]["candidates"][0]["priority_reasons"] = [
+        "provider_specific_magic"
+    ]
+    with pytest.raises(ValueError, match="unregistered code"):
+        build_review_batch(reason_request)
+
+
+def test_bind_decisions_requires_exact_batch_and_candidate_digests() -> None:
+    batch = build_review_batch(_request())
+    candidate = batch["candidates"][0]
+    decisions = {
+        "schema_version": "review_batch_decisions_v0",
+        "decision_digest": batch["decision_digest"],
+        "decisions": [
+            {
+                "candidate_id": candidate["candidate_id"],
+                "candidate_decision_digest": candidate["decision_digest"],
+                "decision": "revise",
+                "note": "Keep the current blocker focused.",
+            }
+        ],
+    }
+    receipt = bind_review_batch_decisions(batch, decisions)
+
+    assert receipt["schema_version"] == "review_batch_decision_receipt_v0"
+    assert receipt["boundary"]["exact_digest_binding"] is True
+    assert receipt["boundary"]["external_writes_performed"] is False
+
+    stale = copy.deepcopy(decisions)
+    stale["decisions"][0]["candidate_decision_digest"] = "candidate_stale"
+    with pytest.raises(ValueError, match="does not match candidate"):
+        bind_review_batch_decisions(batch, stale)
+
+    raw_decision = copy.deepcopy(decisions)
+    raw_decision["decisions"][0]["raw_message"] = "do not persist"
+    with pytest.raises(ValueError, match="forbidden raw/private field"):
+        bind_review_batch_decisions(batch, raw_decision)
+
+
+def test_review_batch_cli_composes_json(tmp_path, capsys) -> None:
+    request_path = tmp_path / "request.json"
+    request_path.write_text(json.dumps(_request()), encoding="utf-8")
+
+    assert main(["--format", "json", "review-batch", "compose", "--request-json", str(request_path)]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["schema_version"] == "review_batch_v0"
+    assert payload["candidate_counts"]["selected"] == 2

--- a/tests/capabilities/test_review_batch.py
+++ b/tests/capabilities/test_review_batch.py
@@ -191,6 +191,36 @@ def test_bind_decisions_requires_exact_batch_and_candidate_digests() -> None:
         bind_review_batch_decisions(batch, raw_decision)
 
 
+def test_bind_decisions_recomputes_batch_and_candidate_integrity() -> None:
+    batch = build_review_batch(_request())
+    candidate = batch["candidates"][0]
+    decisions = {
+        "schema_version": "review_batch_decisions_v0",
+        "decision_digest": batch["decision_digest"],
+        "decisions": [
+            {
+                "candidate_id": candidate["candidate_id"],
+                "candidate_decision_digest": candidate["decision_digest"],
+                "decision": "approve",
+            }
+        ],
+    }
+
+    tampered_candidate = copy.deepcopy(batch)
+    tampered_candidate["candidates"][0]["proposal"] = {
+        "action": "A different action inserted after composition."
+    }
+    with pytest.raises(ValueError, match="batch candidate digest does not match"):
+        bind_review_batch_decisions(tampered_candidate, decisions)
+
+    tampered_policy = copy.deepcopy(batch)
+    tampered_policy["policy"]["decision_values"].append("delete")
+    tampered_decisions = copy.deepcopy(decisions)
+    tampered_decisions["decisions"][0]["decision"] = "delete"
+    with pytest.raises(ValueError, match="batch decision digest does not match"):
+        bind_review_batch_decisions(tampered_policy, tampered_decisions)
+
+
 def test_review_batch_cli_composes_json(tmp_path, capsys) -> None:
     request_path = tmp_path / "request.json"
     request_path.write_text(json.dumps(_request()), encoding="utf-8")


### PR DESCRIPTION
## Summary

- Add the provider-neutral `review_batch_v0` composition and exact decision-binding contract.
- Expose effect-free `review-batch compose` and `review-batch bind-decisions` CLI commands.
- Document adopter boundaries, bounded sorting, digest binding, and sink receipt requirements.

## Issue Or Task

- Closes #
- Contributor task ID: `todo_fbc622297df2`

## Validation

- [ ] `python3 -m py_compile loopx/*.py`
- [ ] `loopx check --scan-root .`
- [x] Other: `ruff` passed; 11 focused tests passed; standard premerge gate passed 16/16 selected canaries plus 4/4 direct checks and changed-file public-boundary scan.

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
