### PR TITLE
Qualify agent-facing CLI output in canary and CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Type-check kernel contracts
         run: python -m mypy
 
+      - name: Qualify agent-facing CLI output
+        run: python -m pytest -q tests/control_plane/test_cli_output_budget.py
+
       - name: Run fast tests
         run: >-
           python -m pytest -q -n 2

--- a/docs/interface-budget-contract.md
+++ b/docs/interface-budget-contract.md
@@ -48,6 +48,13 @@ TurnEnvelope output, status task-graph detail, the full review packet, and the
 brief/compact/full heartbeat prompt modes. These remain opt-in cold paths, but
 their exact stdout size and semantic anchors are regression contracts too.
 
+The start and daily command groups in the public help surface, plus
+`heartbeat-prompt`, are fail-closed inventory inputs. Each command must map to
+a default qualified surface or carry an explicit cold-path exception with a
+rationale. The canary planner selects the output-budget profile for CLI command,
+help, implementation, fixture, workflow, or budget-contract changes, and PR CI
+runs the matrix as a named step.
+
 Both budget layers are intentionally about projections, not the full archival
 facts. When a surface needs more detail, put that detail behind a queryable
 cold-path command or a linked run-history artifact instead of making the
@@ -77,6 +84,7 @@ Regression entrypoints:
 
 ```bash
 pytest -q tests/control_plane/test_cli_output_budget.py
+python3 examples/control_plane/cli-output-budget-regression-smoke.py
 python3 examples/control_plane/hot-path-interface-budget-smoke.py
 python3 examples/control_plane/status-quota-perf-budget-smoke.py
 ```

--- a/examples/canary/catalog-planner-smoke.py
+++ b/examples/canary/catalog-planner-smoke.py
@@ -489,6 +489,23 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     commands = [check["command"] for check in cli_profile["checks"]]
     assert "python3 examples/cli-version-command-modularization-smoke.py" in commands, cli_profile
 
+    output_budget_payload = build_catalog_canary_plan(
+        changed_files=["loopx/cli_commands/status.py", "loopx/help_surface.py"],
+        surfaces=["agent-facing CLI output qualification"],
+    )
+    output_budget_profiles = {
+        profile["id"]: profile
+        for profile in output_budget_payload["domain_profiles"]
+    }
+    assert "agent-facing-cli-output-budget" in output_budget_profiles, output_budget_payload
+    output_budget_checks = [
+        check["command"]
+        for check in output_budget_profiles["agent-facing-cli-output-budget"]["checks"]
+    ]
+    assert output_budget_checks == [
+        "python3 examples/control_plane/cli-output-budget-regression-smoke.py"
+    ], output_budget_profiles["agent-facing-cli-output-budget"]
+
     todo_payload = build_catalog_canary_plan(
         changed_files=["loopx/todos.py", "loopx/control_plane/todos/contract.py"],
         surfaces=["todo lifecycle todo claim todo list"],

--- a/examples/canary/premerge-validation-gate-smoke.py
+++ b/examples/canary/premerge-validation-gate-smoke.py
@@ -121,6 +121,17 @@ def assert_changed_python_gets_compile_check() -> None:
     assert "loopx/canary/premerge.py" in compile_check["display_argv"], payload
 
 
+def assert_agent_facing_cli_change_selects_output_qualification() -> None:
+    payload = build_premerge_validation_gate(
+        changed_files=["loopx/cli_commands/status.py"],
+        execute=False,
+    )
+    catalog_commands = commands_from(payload["catalog_run"])
+    expected = "python3 examples/control_plane/cli-output-budget-regression-smoke.py"
+    assert expected in catalog_commands, payload
+    assert expected in payload["validation_summary"]["selected_commands"], payload
+
+
 def assert_benchmark_sensitive_change_blocks_self_merge() -> None:
     payload = build_premerge_validation_gate(
         changed_files=["loopx/benchmark_adapters/skillsbench.py"],
@@ -353,6 +364,7 @@ def main() -> None:
     assert_quick_public_docs_change_skips_risk_profile_smokes()
     assert_public_boundary_scan_executes_in_process()
     assert_changed_python_gets_compile_check()
+    assert_agent_facing_cli_change_selects_output_qualification()
     assert_benchmark_sensitive_change_blocks_self_merge()
     assert_lark_kanban_change_keeps_surface_without_reviewer_hold()
     assert_cli_json_preview()

--- a/examples/control_plane/cli-output-budget-regression-smoke.py
+++ b/examples/control_plane/cli-output-budget-regression-smoke.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Run the real agent-facing CLI output budget matrix from canary plans."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEST_PATH = REPO_ROOT / "tests" / "control_plane" / "test_cli_output_budget.py"
+
+
+def _pytest_command() -> list[str]:
+    try:
+        import pytest  # noqa: F401
+    except Exception:
+        uvx = shutil.which("uvx")
+        if uvx:
+            return [uvx, "--with", "pytest>=8,<9", "pytest"]
+        raise RuntimeError(
+            "cli-output-budget-regression-smoke requires pytest or uvx; "
+            "qualification fails closed when neither runner is available"
+        ) from None
+    return [sys.executable, "-m", "pytest"]
+
+
+def main() -> int:
+    if not TEST_PATH.is_file():
+        raise RuntimeError(f"missing CLI output budget test: {TEST_PATH.relative_to(REPO_ROOT)}")
+    completed = subprocess.run(
+        [*_pytest_command(), "-q", str(TEST_PATH.relative_to(REPO_ROOT))],
+        cwd=REPO_ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=180,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            "agent-facing CLI output qualification failed\n"
+            f"stdout:\n{completed.stdout[-3000:]}\n"
+            f"stderr:\n{completed.stderr[-3000:]}"
+        )
+    print("cli-output-budget-regression-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -4,6 +4,8 @@ import re
 from pathlib import Path
 from typing import Any
 
+from .qualification_profiles import CONTROL_PLANE_QUALIFICATION_PROFILES
+
 
 CANARY_PROFILE_SCHEMA_VERSION = "catalog_canary_profile_v0"
 CANARY_DOMAIN_PROFILE_SCHEMA_VERSION = "catalog_canary_domain_profile_v0"
@@ -408,82 +410,7 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
             },
         ],
     },
-    {
-        "id": "control-plane-state-machine",
-        "title": "Control-plane state-machine composition",
-        "purpose": (
-            "Run a bounded cross-state-machine canary when interaction, work-lane, "
-            "scheduler, frontier, writeback, or quota-spend transitions change together."
-        ),
-        "catalog_families": ["Work Routing", "State And Boundary", "Planning Governance"],
-        "trigger_hints": (
-            "state-machine",
-            "state machine",
-            "interaction_contract",
-            "work_lane_contract",
-            "scheduler_hint",
-            "goal_frontier",
-            "automation_liveness",
-            "spend-slot",
-            "scheduler-ack",
-            "monitor_target",
-            "monitor_poll_writeback",
-            "interaction_contract.py",
-            "loopx/control_plane/scheduler/monitor_poll_writeback.py",
-            "loopx/control_plane/scheduler/monitor_target.py",
-            "loopx/control_plane/work_items/interaction_contract.py",
-            "loopx/control_plane/work_items/execution_obligation.py",
-            "loopx/control_plane/work_items/goal_route_hint.py",
-            "loopx/control_plane/work_items/outcome_followthrough.py",
-            "loopx/control_plane/work_items/work_lane.py",
-            "loopx/control_plane/runtime/event_store_migration_bridge.py",
-            "control-plane-integrated-canary-smoke.py",
-            "interaction-contract-state-machine-smoke.py",
-            "docs/product/core-control-plane/state-machine.md",
-        ),
-        "checks": [
-            {
-                "command": "python3 examples/control_plane/control-plane-integrated-canary-smoke.py",
-                "tier": "deep",
-                "reason": (
-                    "samples the full event-sourced todo projection, status, quota interaction contract, "
-                    "work-lane contract, scheduler ack, refresh-state, spend-slot, and review-packet handoff path; "
-                    "kept deep because it is a slow end-to-end fixture"
-                ),
-            },
-            {
-                "command": "python3 examples/control_plane/peer-agent-continuation-state-machine-smoke.py",
-                "tier": "default",
-                "reason": (
-                    "guards peer self-merge continuation through successor todo selection, "
-                    "agent-lane refresh, scheduler ack, quota spend, and preserved goal next action"
-                ),
-            },
-            {
-                "command": "python3 examples/control_plane/interaction-contract-state-machine-smoke.py",
-                "tier": "default",
-                "reason": (
-                    "guards interaction/protocol state-machine modes across active work, user notice, "
-                    "monitor quiet, autonomous replan, agent-scope wait, and successor replan"
-                ),
-            },
-            {
-                "command": "python3 examples/control_plane/heartbeat-quota-flow-smoke.py",
-                "tier": "default",
-                "reason": "guards the heartbeat writeback then spend lifecycle that the composition canary executes",
-            },
-            {
-                "command": "python3 examples/control_plane/quota-scheduler-state-ack-smoke.py",
-                "tier": "default",
-                "reason": "guards scheduler_hint stateful ack progression and no-spend cadence transitions",
-            },
-            {
-                "command": "python3 examples/control_plane/work-lane-contract-smoke.py",
-                "tier": "deep",
-                "reason": "covers additional work-lane policy branches outside the integrated active-work path",
-            },
-        ],
-    },
+    *CONTROL_PLANE_QUALIFICATION_PROFILES,
     {
         "id": "status-read-path",
         "title": "Status read-path contract",

--- a/loopx/canary/qualification_profiles.py
+++ b/loopx/canary/qualification_profiles.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+CONTROL_PLANE_QUALIFICATION_PROFILES: tuple[dict[str, Any], ...] = (
+    {
+        "id": "control-plane-state-machine",
+        "title": "Control-plane state-machine composition",
+        "purpose": (
+            "Run a bounded cross-state-machine canary when interaction, work-lane, "
+            "scheduler, frontier, writeback, or quota-spend transitions change together."
+        ),
+        "catalog_families": ["Work Routing", "State And Boundary", "Planning Governance"],
+        "trigger_hints": (
+            "state-machine",
+            "state machine",
+            "interaction_contract",
+            "work_lane_contract",
+            "scheduler_hint",
+            "goal_frontier",
+            "automation_liveness",
+            "spend-slot",
+            "scheduler-ack",
+            "monitor_target",
+            "monitor_poll_writeback",
+            "interaction_contract.py",
+            "loopx/control_plane/scheduler/monitor_poll_writeback.py",
+            "loopx/control_plane/scheduler/monitor_target.py",
+            "loopx/control_plane/work_items/interaction_contract.py",
+            "loopx/control_plane/work_items/execution_obligation.py",
+            "loopx/control_plane/work_items/goal_route_hint.py",
+            "loopx/control_plane/work_items/outcome_followthrough.py",
+            "loopx/control_plane/work_items/work_lane.py",
+            "loopx/control_plane/runtime/event_store_migration_bridge.py",
+            "control-plane-integrated-canary-smoke.py",
+            "interaction-contract-state-machine-smoke.py",
+            "docs/product/core-control-plane/state-machine.md",
+        ),
+        "checks": [
+            {
+                "command": "python3 examples/control_plane/control-plane-integrated-canary-smoke.py",
+                "tier": "deep",
+                "reason": (
+                    "samples the full event-sourced todo projection, status, quota interaction contract, "
+                    "work-lane contract, scheduler ack, refresh-state, spend-slot, and review-packet handoff path; "
+                    "kept deep because it is a slow end-to-end fixture"
+                ),
+            },
+            {
+                "command": "python3 examples/control_plane/peer-agent-continuation-state-machine-smoke.py",
+                "tier": "default",
+                "reason": (
+                    "guards peer self-merge continuation through successor todo selection, "
+                    "agent-lane refresh, scheduler ack, quota spend, and preserved goal next action"
+                ),
+            },
+            {
+                "command": "python3 examples/control_plane/interaction-contract-state-machine-smoke.py",
+                "tier": "default",
+                "reason": (
+                    "guards interaction/protocol state-machine modes across active work, user notice, "
+                    "monitor quiet, autonomous replan, agent-scope wait, and successor replan"
+                ),
+            },
+            {
+                "command": "python3 examples/control_plane/heartbeat-quota-flow-smoke.py",
+                "tier": "default",
+                "reason": "guards the heartbeat writeback then spend lifecycle that the composition canary executes",
+            },
+            {
+                "command": "python3 examples/control_plane/quota-scheduler-state-ack-smoke.py",
+                "tier": "default",
+                "reason": "guards scheduler_hint stateful ack progression and no-spend cadence transitions",
+            },
+            {
+                "command": "python3 examples/control_plane/work-lane-contract-smoke.py",
+                "tier": "deep",
+                "reason": "covers additional work-lane policy branches outside the integrated active-work path",
+            },
+        ],
+    },
+    {
+        "id": "agent-facing-cli-output-budget",
+        "title": "Agent-facing CLI output qualification",
+        "purpose": (
+            "Run exact stdout budgets and fail-closed command classification when "
+            "recurring agent-facing CLI surfaces or their qualification contract change."
+        ),
+        "catalog_families": ["Work Routing", "State And Boundary", "Planning Governance"],
+        "trigger_hints": (
+            "agent-facing cli",
+            "cli output budget",
+            "cli output qualification",
+            "loopx/cli.py",
+            "loopx/help_surface.py",
+            "loopx/cli_commands/",
+            "loopx/project_prompt.py",
+            "loopx/quota.py",
+            "loopx/status.py",
+            "loopx/review_packet.py",
+            "loopx/heartbeat_prompt.py",
+            "loopx/todos.py",
+            "loopx/run_history.py",
+            "loopx/evidence_log.py",
+            "loopx/control_plane/testing/cli_output_budget.py",
+            "tests/control_plane/test_cli_output_budget.py",
+            "examples/control_plane/cli-output-budget-regression-smoke.py",
+            ".github/workflows/python-tests.yml",
+            "docs/interface-budget-contract.md",
+        ),
+        "checks": [
+            {
+                "command": "python3 examples/control_plane/cli-output-budget-regression-smoke.py",
+                "tier": "default",
+                "reason": (
+                    "invokes the real CLI across declared JSON/Markdown surfaces, modes, "
+                    "fixture scales, semantic anchors, and command classifications"
+                ),
+            },
+            {
+                "command": "python3 examples/control_plane/hot-path-interface-budget-smoke.py",
+                "tier": "deep",
+                "reason": "pairs emitted stdout qualification with compact in-memory hot-path budgets",
+            },
+        ],
+    },
+)

--- a/loopx/control_plane/testing/cli_output_budget.py
+++ b/loopx/control_plane/testing/cli_output_budget.py
@@ -14,6 +14,10 @@ QualificationPolicy = Literal[
     "baseline_and_growth",
     "explicit_limit_cold_path",
 ]
+CommandQualification = Literal[
+    "qualified_default",
+    "explicit_cold_path_exception",
+]
 
 
 @dataclass(frozen=True)
@@ -42,6 +46,14 @@ class CliOutputModeVariantSpec:
     markdown_anchor: str
     max_chars: dict[OutputFormat, int]
     max_lines: dict[OutputFormat, int]
+
+
+@dataclass(frozen=True)
+class CliOutputCommandClassification:
+    command_id: str
+    qualification: CommandQualification
+    surface_id: str | None
+    rationale: str
 
 
 # These ceilings characterize the emitted CLI text on public fixtures. They are
@@ -366,6 +378,115 @@ CLI_OUTPUT_MODE_VARIANT_BY_ID = {
 }
 
 
+# The public help surface is the authority for recurring agent-facing commands.
+# Every command in its start/daily groups, plus heartbeat-prompt, must resolve
+# here. Tests fail closed when help adds a command without a budget or a named
+# cold-path exception.
+CLI_OUTPUT_COMMAND_CLASSIFICATIONS: tuple[CliOutputCommandClassification, ...] = (
+    CliOutputCommandClassification(
+        command_id="doctor",
+        qualification="explicit_cold_path_exception",
+        surface_id=None,
+        rationale="installation diagnostic invoked on demand, not a recurring decision payload",
+    ),
+    CliOutputCommandClassification(
+        command_id="slash-commands",
+        qualification="explicit_cold_path_exception",
+        surface_id=None,
+        rationale="installation and discovery command invoked explicitly",
+    ),
+    CliOutputCommandClassification(
+        command_id="preset",
+        qualification="explicit_cold_path_exception",
+        surface_id=None,
+        rationale="configuration discovery command invoked explicitly",
+    ),
+    CliOutputCommandClassification(
+        command_id="ready-score",
+        qualification="explicit_cold_path_exception",
+        surface_id=None,
+        rationale="operator readiness diagnostic invoked explicitly",
+    ),
+    CliOutputCommandClassification(
+        command_id="start-goal",
+        qualification="qualified_default",
+        surface_id="start_goal_guided",
+        rationale="guided goal-start packet is a recurring agent bootstrap surface",
+    ),
+    CliOutputCommandClassification(
+        command_id="agent-onboard",
+        qualification="explicit_cold_path_exception",
+        surface_id=None,
+        rationale="one-time host activation packet with its own activation smokes",
+    ),
+    CliOutputCommandClassification(
+        command_id="bootstrap-command-pack",
+        qualification="qualified_default",
+        surface_id="bootstrap_command_pack",
+        rationale="lower-level host handoff packet is consumed by agent bootstrap",
+    ),
+    CliOutputCommandClassification(
+        command_id="status",
+        qualification="qualified_default",
+        surface_id="status",
+        rationale="first-screen agent and operator status read",
+    ),
+    CliOutputCommandClassification(
+        command_id="diagnose",
+        qualification="qualified_default",
+        surface_id="diagnose",
+        rationale="agent self-repair packet",
+    ),
+    CliOutputCommandClassification(
+        command_id="review-packet",
+        qualification="qualified_default",
+        surface_id="review_packet_handoff_only",
+        rationale="agent handoff and review packet",
+    ),
+    CliOutputCommandClassification(
+        command_id="evidence-log",
+        qualification="qualified_default",
+        surface_id="evidence_log_thin",
+        rationale="bounded evidence read before replan or handoff",
+    ),
+    CliOutputCommandClassification(
+        command_id="todo",
+        qualification="qualified_default",
+        surface_id="todo_list",
+        rationale="agent work-queue read path",
+    ),
+    CliOutputCommandClassification(
+        command_id="task-lease",
+        qualification="explicit_cold_path_exception",
+        surface_id=None,
+        rationale="explicit per-todo lease lifecycle command family",
+    ),
+    CliOutputCommandClassification(
+        command_id="quota",
+        qualification="qualified_default",
+        surface_id="quota_should_run",
+        rationale="recurring next-turn execution guard",
+    ),
+    CliOutputCommandClassification(
+        command_id="history",
+        qualification="qualified_default",
+        surface_id="history_limited",
+        rationale="bounded run-history read path",
+    ),
+    CliOutputCommandClassification(
+        command_id="heartbeat-prompt",
+        qualification="qualified_default",
+        surface_id="heartbeat_prompt_thin",
+        rationale="recurring host automation body",
+    ),
+)
+
+
+CLI_OUTPUT_COMMAND_CLASSIFICATION_BY_ID = {
+    spec.command_id: spec for spec in CLI_OUTPUT_COMMAND_CLASSIFICATIONS
+}
+
+
 def measure_cli_output(
     text: str,
     *,
@@ -482,6 +603,7 @@ def public_manifest() -> dict[str, Any]:
         "schema_version": CLI_OUTPUT_BUDGET_SCHEMA_VERSION,
         "surface_count": len(CLI_OUTPUT_BUDGET_SPECS),
         "mode_variant_count": len(CLI_OUTPUT_MODE_VARIANT_SPECS),
+        "command_classification_count": len(CLI_OUTPUT_COMMAND_CLASSIFICATIONS),
         "surfaces": [
             {
                 "surface_id": spec.surface_id,
@@ -505,5 +627,14 @@ def public_manifest() -> dict[str, Any]:
                 "formats": list(spec.output_formats),
             }
             for spec in CLI_OUTPUT_MODE_VARIANT_SPECS
+        ],
+        "command_classifications": [
+            {
+                "command_id": spec.command_id,
+                "qualification": spec.qualification,
+                "surface_id": spec.surface_id,
+                "rationale": spec.rationale,
+            }
+            for spec in CLI_OUTPUT_COMMAND_CLASSIFICATIONS
         ],
     }

--- a/tests/control_plane/test_cli_output_budget.py
+++ b/tests/control_plane/test_cli_output_budget.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import io
 import json
+import shlex
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -12,6 +13,8 @@ from loopx.cli import main as cli_main
 from loopx.control_plane.testing.cli_output_budget import (
     CLI_OUTPUT_BUDGET_BY_ID,
     CLI_OUTPUT_BUDGET_SPECS,
+    CLI_OUTPUT_COMMAND_CLASSIFICATION_BY_ID,
+    CLI_OUTPUT_COMMAND_CLASSIFICATIONS,
     CLI_OUTPUT_MODE_VARIANT_BY_ID,
     CLI_OUTPUT_MODE_VARIANT_SPECS,
     assert_cli_output_baseline,
@@ -19,6 +22,7 @@ from loopx.control_plane.testing.cli_output_budget import (
     measure_cli_output,
     public_manifest,
 )
+from loopx.help_surface import COMMAND_GROUPS
 from loopx.rollout_event_log import rollout_event_log_path
 
 
@@ -434,6 +438,24 @@ def _mode_variant_commands(
     }
 
 
+def _agent_facing_help_command_ids() -> set[str]:
+    command_ids: set[str] = set()
+    for group in COMMAND_GROUPS:
+        title = str(group.get("title") or "")
+        for row in group.get("commands", []):
+            if not isinstance(row, dict):
+                continue
+            command = str(row.get("command") or "")
+            selected = title in {"Start here", "Daily operator commands"}
+            selected = selected or command == "loopx heartbeat-prompt"
+            if not selected or not command.startswith("loopx "):
+                continue
+            parts = shlex.split(command)
+            assert len(parts) >= 2, command
+            command_ids.add(parts[1])
+    return command_ids
+
+
 def test_manifest_covers_the_declared_agent_facing_surface_set() -> None:
     expected = {
         "start_goal_guided",
@@ -468,6 +490,19 @@ def test_manifest_covers_the_declared_agent_facing_surface_set() -> None:
     assert all(
         spec.parent_surface_id in expected for spec in CLI_OUTPUT_MODE_VARIANT_SPECS
     )
+    help_command_ids = _agent_facing_help_command_ids()
+    assert set(CLI_OUTPUT_COMMAND_CLASSIFICATION_BY_ID) == help_command_ids
+    assert manifest["command_classification_count"] == len(help_command_ids)
+    assert {
+        row["command_id"] for row in manifest["command_classifications"]
+    } == help_command_ids
+    for classification in CLI_OUTPUT_COMMAND_CLASSIFICATIONS:
+        assert classification.rationale
+        if classification.qualification == "qualified_default":
+            assert classification.surface_id in expected
+        else:
+            assert classification.qualification == "explicit_cold_path_exception"
+            assert classification.surface_id is None
 
 
 @pytest.mark.parametrize("scenario", SCENARIOS, ids=lambda scenario: scenario.name)


### PR DESCRIPTION
## Summary
- classify every recurring command in the public start/daily help inventory as either a qualified default output surface or an explicit cold-path exception
- add a fail-closed regression smoke and wire it into changed-surface canary selection without displacing existing control-plane state-machine checks
- expose the qualification as a named PR CI step and document the contract

This does not reduce or otherwise change production CLI output. It establishes the qualification gate that must run before later sensitive output changes.

## Commit grouping
1. output-surface classification, exact matrix test, and durable smoke wrapper
2. canary profile selection plus planner/premerge regression coverage
3. named CI gate and interface-budget documentation

## Validation
- `pytest -q tests/control_plane/test_cli_output_budget.py` (6 passed)
- `python3 examples/control_plane/cli-output-budget-regression-smoke.py`
- `python3 examples/canary/catalog-planner-smoke.py`
- `python3 examples/canary/catalog-run-e2e-smoke.py`
- `python3 examples/canary/premerge-validation-gate-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- Ruff on all changed Python paths
- `loopx canary premerge --from-git-diff`: 17/17 selected checks passed, including public-boundary scan; no manual holds

The first premerge pass caught profile precedence displacing an existing heartbeat/quota check; profile ordering now preserves that check. A second pass caught the 2,000-line planner budget; qualification profile data was extracted into its own bounded module rather than expanding the allowlist.

## Boundary and residual risk
- no credentials, private state, raw trajectories, local paths, or generated logs are included
- base/head same-fixture output differential remains a follow-up; this PR covers fail-closed inventory, canary selection, and PR CI only
