### PR TITLE
Plan LoopX Turn resume transactions

### DIFF
--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -4,7 +4,10 @@ import argparse
 from collections.abc import Callable
 from pathlib import Path
 
-from ..control_plane.turn_driver import build_loopx_turn_plan
+from ..control_plane.turn_driver import (
+    LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION,
+    build_loopx_turn_plan,
+)
 from ..control_plane.quota.live_decision import build_live_quota_should_run_decision
 from ..control_plane.quota.turn_envelope import build_turn_envelope
 from ..control_plane.runtime.status_projection_cache import (
@@ -50,6 +53,18 @@ def register_turn_commands(
         "--execution-mode",
         choices=["interactive-visible", "isolated-headless"],
         default="interactive-visible",
+    )
+    plan.add_argument(
+        "--resume-goal-id",
+        help="Goal identity bound to an available opaque host session.",
+    )
+    plan.add_argument(
+        "--resume-agent-id",
+        help="Agent identity bound to an available opaque host session.",
+    )
+    plan.add_argument(
+        "--resume-todo-id",
+        help="Todo identity bound to an available opaque host session.",
     )
     plan.add_argument(
         "--available-capability",
@@ -125,10 +140,32 @@ def handle_turn_command(
             runtime_root=runtime_root,
             route_source="loopx_turn_plan",
         )
+        resume_identity = {
+            "goal_id": args.resume_goal_id,
+            "agent_id": args.resume_agent_id,
+            "todo_id": args.resume_todo_id,
+        }
+        supplied_resume_fields = [
+            field for field, value in resume_identity.items() if value is not None
+        ]
+        if supplied_resume_fields and len(supplied_resume_fields) != len(
+            resume_identity
+        ):
+            raise ValueError(
+                "resume planning requires --resume-goal-id, --resume-agent-id, "
+                "and --resume-todo-id together"
+            )
+        session_binding = None
+        if supplied_resume_fields:
+            session_binding = {
+                "schema_version": LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION,
+                **resume_identity,
+            }
         payload = build_loopx_turn_plan(
             build_turn_envelope(decision),
             host=args.host,
             execution_mode=args.execution_mode,
+            session_binding=session_binding,
         )
     except Exception as exc:
         payload = {

--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -72,6 +72,11 @@ def register_turn_commands(
         action="append",
     )
     plan.add_argument(
+        "--include-transaction-detail",
+        action="store_true",
+        help="Include session binding and transaction receipt planning detail.",
+    )
+    plan.add_argument(
         "--scan-root",
         default=_default_public_scan_root(),
         help="Public files to scan for obvious private material.",
@@ -167,6 +172,12 @@ def handle_turn_command(
             execution_mode=args.execution_mode,
             session_binding=session_binding,
         )
+        if not args.include_transaction_detail:
+            payload.pop("session", None)
+            payload.pop("transaction", None)
+            boundary = payload.get("boundary")
+            if isinstance(boundary, dict):
+                boundary.pop("opaque_session_handle_omitted", None)
     except Exception as exc:
         payload = {
             "ok": False,

--- a/loopx/control_plane/testing/cli_output_budget.py
+++ b/loopx/control_plane/testing/cli_output_budget.py
@@ -148,15 +148,11 @@ CLI_OUTPUT_BUDGET_SPECS: tuple[CliOutputBudgetSpec, ...] = (
         owner="LoopX Turn",
         consumer_action="route one live LoopX decision without host or state side effects",
         qualification_policy="absolute_hot_path",
-        cold_path="TurnEnvelope detail_ref commands and full quota should-run decision",
-        semantic_json_keys=(
-            "route",
-            "session",
-            "transaction",
-            "turn_envelope",
-            "effects",
-            "boundary",
+        cold_path=(
+            "--include-transaction-detail, TurnEnvelope detail_ref commands, "
+            "and full quota should-run decision"
         ),
+        semantic_json_keys=("route", "turn_envelope", "effects", "boundary"),
         markdown_anchor="# LoopX Turn Plan",
         max_chars={
             "small": {"json": 12_000, "markdown": 300},
@@ -368,6 +364,23 @@ CLI_OUTPUT_MODE_VARIANT_SPECS: tuple[CliOutputModeVariantSpec, ...] = (
         markdown_anchor="# LoopX Turn Envelope",
         max_chars={"json": 9_000, "markdown": 650},
         max_lines={"json": 250, "markdown": 20},
+    ),
+    CliOutputModeVariantSpec(
+        variant_id="loopx_turn_plan_transaction_detail",
+        parent_surface_id="loopx_turn_plan",
+        command="turn plan --include-transaction-detail",
+        output_formats=("json",),
+        semantic_json_keys=(
+            "route",
+            "session",
+            "transaction",
+            "turn_envelope",
+            "effects",
+            "boundary",
+        ),
+        markdown_anchor=None,
+        max_chars={"json": 13_000},
+        max_lines={"json": 360},
     ),
     CliOutputModeVariantSpec(
         variant_id="status_task_graph_detail",

--- a/loopx/control_plane/testing/cli_output_budget.py
+++ b/loopx/control_plane/testing/cli_output_budget.py
@@ -149,7 +149,14 @@ CLI_OUTPUT_BUDGET_SPECS: tuple[CliOutputBudgetSpec, ...] = (
         consumer_action="route one live LoopX decision without host or state side effects",
         qualification_policy="absolute_hot_path",
         cold_path="TurnEnvelope detail_ref commands and full quota should-run decision",
-        semantic_json_keys=("route", "turn_envelope", "effects", "boundary"),
+        semantic_json_keys=(
+            "route",
+            "session",
+            "transaction",
+            "turn_envelope",
+            "effects",
+            "boundary",
+        ),
         markdown_anchor="# LoopX Turn Plan",
         max_chars={
             "small": {"json": 12_000, "markdown": 300},

--- a/loopx/control_plane/turn_driver/__init__.py
+++ b/loopx/control_plane/turn_driver/__init__.py
@@ -5,9 +5,19 @@ from .driver import (
     LoopXTurnRoute,
     build_loopx_turn_plan,
 )
+from .transaction import (
+    LOOPX_TURN_RESULT_SCHEMA_VERSION,
+    LoopXTurnResultKind,
+    build_loopx_turn_transaction_plan,
+    validate_loopx_turn_receipt,
+)
 
 __all__ = [
     "LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION",
+    "LOOPX_TURN_RESULT_SCHEMA_VERSION",
     "LoopXTurnRoute",
+    "LoopXTurnResultKind",
     "build_loopx_turn_plan",
+    "build_loopx_turn_transaction_plan",
+    "validate_loopx_turn_receipt",
 ]

--- a/loopx/control_plane/turn_driver/__init__.py
+++ b/loopx/control_plane/turn_driver/__init__.py
@@ -1,5 +1,13 @@
 """LoopX Turn decision planning for external agent-loop hosts."""
 
-from .driver import LoopXTurnRoute, build_loopx_turn_plan
+from .driver import (
+    LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION,
+    LoopXTurnRoute,
+    build_loopx_turn_plan,
+)
 
-__all__ = ["LoopXTurnRoute", "build_loopx_turn_plan"]
+__all__ = [
+    "LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION",
+    "LoopXTurnRoute",
+    "build_loopx_turn_plan",
+]

--- a/loopx/control_plane/turn_driver/driver.py
+++ b/loopx/control_plane/turn_driver/driver.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
-import json
 from collections.abc import Mapping
 from enum import Enum
-from hashlib import sha256
 from typing import Any
+
+from .transaction import build_loopx_turn_transaction_plan
 
 
 LOOPX_TURN_PLAN_SCHEMA_VERSION = "loopx_turn_plan_v0"
 LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION = "loopx_turn_session_binding_v0"
-LOOPX_TURN_TRANSACTION_PLAN_SCHEMA_VERSION = "loopx_turn_transaction_plan_v0"
-LOOPX_TURN_RECEIPT_SCHEMA_VERSION = "loopx_turn_receipt_v0"
 TURN_ENVELOPE_SCHEMA_VERSION = "loopx_turn_envelope_v0"
 SUPPORTED_HOSTS = {"codex-cli", "claude-code", "generic-cli"}
 SUPPORTED_EXECUTION_MODES = {"interactive-visible", "isolated-headless"}
@@ -26,15 +24,6 @@ REPAIR_ACTIONS = {
     "state_projection_repair",
     "workspace_repair",
 }
-TRANSACTION_PHASES = (
-    "host_execute",
-    "typed_result",
-    "validation",
-    "durable_writeback",
-    "quota_spend",
-    "scheduler_apply",
-    "scheduler_ack",
-)
 
 
 class LoopXTurnRoute(str, Enum):
@@ -49,16 +38,6 @@ class LoopXTurnRoute(str, Enum):
 
 def _mapping(value: Any) -> dict[str, Any]:
     return dict(value) if isinstance(value, Mapping) else {}
-
-
-def _canonical_hash(value: Any) -> str:
-    encoded = json.dumps(
-        value,
-        ensure_ascii=False,
-        sort_keys=True,
-        separators=(",", ":"),
-    ).encode("utf-8")
-    return "sha256:" + sha256(encoded).hexdigest()
 
 
 def _typed_route(envelope: Mapping[str, Any]) -> LoopXTurnRoute:
@@ -165,41 +144,6 @@ def _session_plan(
     }, None
 
 
-def _transaction_plan(
-    *,
-    route: LoopXTurnRoute,
-    lineage: Mapping[str, str],
-    host: str,
-    execution_mode: str,
-    session_action: str,
-) -> dict[str, Any]:
-    planned = route in {
-        LoopXTurnRoute.READY_FOR_HOST,
-        LoopXTurnRoute.REPAIR_REQUIRED,
-        LoopXTurnRoute.REPLAN_REQUIRED,
-    }
-    turn_key = _canonical_hash(
-        {
-            "lineage": dict(lineage),
-            "host": host,
-            "execution_mode": execution_mode,
-            "session_action": session_action,
-        }
-    )
-    return {
-        "schema_version": LOOPX_TURN_TRANSACTION_PLAN_SCHEMA_VERSION,
-        "status": "planned" if planned else "not_applicable",
-        "turn_key": turn_key,
-        "phases": list(TRANSACTION_PHASES) if planned else [],
-        "commit_policy": "result<validate<writeback<spend;apply<ack;cadence:no-spend",
-        "receipt_seed": {
-            "schema_version": LOOPX_TURN_RECEIPT_SCHEMA_VERSION,
-            "status": "not_executed",
-            "next_phase": TRANSACTION_PHASES[0] if planned else None,
-        },
-    }
-
-
 def build_loopx_turn_plan(
     turn_envelope: Mapping[str, Any],
     *,
@@ -250,8 +194,8 @@ def build_loopx_turn_plan(
             "selected_todo": selected_todo or None,
         },
         "turn_envelope": envelope,
-        "transaction": _transaction_plan(
-            route=route,
+        "transaction": build_loopx_turn_transaction_plan(
+            planned=would_invoke_host,
             lineage=lineage,
             host=host,
             execution_mode=execution_mode,

--- a/loopx/control_plane/turn_driver/driver.py
+++ b/loopx/control_plane/turn_driver/driver.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
 from enum import Enum
+from hashlib import sha256
 from typing import Any
 
 
 LOOPX_TURN_PLAN_SCHEMA_VERSION = "loopx_turn_plan_v0"
+LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION = "loopx_turn_session_binding_v0"
+LOOPX_TURN_TRANSACTION_PLAN_SCHEMA_VERSION = "loopx_turn_transaction_plan_v0"
+LOOPX_TURN_RECEIPT_SCHEMA_VERSION = "loopx_turn_receipt_v0"
 TURN_ENVELOPE_SCHEMA_VERSION = "loopx_turn_envelope_v0"
 SUPPORTED_HOSTS = {"codex-cli", "claude-code", "generic-cli"}
 SUPPORTED_EXECUTION_MODES = {"interactive-visible", "isolated-headless"}
@@ -21,6 +26,15 @@ REPAIR_ACTIONS = {
     "state_projection_repair",
     "workspace_repair",
 }
+TRANSACTION_PHASES = (
+    "host_execute",
+    "typed_result",
+    "validation",
+    "durable_writeback",
+    "quota_spend",
+    "scheduler_apply",
+    "scheduler_ack",
+)
 
 
 class LoopXTurnRoute(str, Enum):
@@ -35,6 +49,16 @@ class LoopXTurnRoute(str, Enum):
 
 def _mapping(value: Any) -> dict[str, Any]:
     return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _canonical_hash(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return "sha256:" + sha256(encoded).hexdigest()
 
 
 def _typed_route(envelope: Mapping[str, Any]) -> LoopXTurnRoute:
@@ -77,11 +101,111 @@ def _typed_route(envelope: Mapping[str, Any]) -> LoopXTurnRoute:
     return LoopXTurnRoute.BLOCKED
 
 
+def _turn_lineage(envelope: Mapping[str, Any]) -> dict[str, str]:
+    action = _mapping(envelope.get("action"))
+    selected_todo = _mapping(action.get("selected_todo"))
+    signature = _mapping(envelope.get("action_signature"))
+    return {
+        "goal_id": str(envelope.get("goal_id") or ""),
+        "agent_id": str(envelope.get("agent_id") or ""),
+        "todo_id": str(selected_todo.get("todo_id") or ""),
+        "action_hash": str(signature.get("source_hash") or ""),
+    }
+
+
+def _session_plan(
+    *,
+    route: LoopXTurnRoute,
+    lineage: Mapping[str, str],
+    session_binding: Mapping[str, Any] | None,
+) -> tuple[dict[str, Any], str | None]:
+    host_route = route in {
+        LoopXTurnRoute.READY_FOR_HOST,
+        LoopXTurnRoute.REPAIR_REQUIRED,
+        LoopXTurnRoute.REPLAN_REQUIRED,
+    }
+    if not host_route:
+        return {
+            "schema_version": LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION,
+            "action": "none",
+            "binding_status": "not_applicable",
+        }, None
+    if not all(lineage.values()):
+        return {
+            "schema_version": LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION,
+            "action": "reject",
+            "binding_status": "missing_turn_lineage",
+        }, "host-bound routes require goal, agent, todo, and action-hash lineage"
+
+    binding = dict(session_binding or {})
+    if not binding:
+        return {
+            "schema_version": LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION,
+            "action": "start_new",
+        }, None
+    if binding.get("schema_version") != LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION:
+        return {
+            "schema_version": LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION,
+            "action": "reject",
+            "binding_status": "unsupported_schema",
+        }, "unsupported LoopX Turn session binding schema"
+
+    identity_fields = ("goal_id", "agent_id", "todo_id")
+    actual = {field: str(binding.get(field) or "") for field in identity_fields}
+    expected = {field: lineage[field] for field in identity_fields}
+    if actual != expected:
+        return {
+            "schema_version": LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION,
+            "action": "reject",
+            "binding_status": "identity_mismatch",
+        }, "session binding does not match the current goal, agent, and todo"
+    return {
+        "schema_version": LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION,
+        "action": "resume",
+    }, None
+
+
+def _transaction_plan(
+    *,
+    route: LoopXTurnRoute,
+    lineage: Mapping[str, str],
+    host: str,
+    execution_mode: str,
+    session_action: str,
+) -> dict[str, Any]:
+    planned = route in {
+        LoopXTurnRoute.READY_FOR_HOST,
+        LoopXTurnRoute.REPAIR_REQUIRED,
+        LoopXTurnRoute.REPLAN_REQUIRED,
+    }
+    turn_key = _canonical_hash(
+        {
+            "lineage": dict(lineage),
+            "host": host,
+            "execution_mode": execution_mode,
+            "session_action": session_action,
+        }
+    )
+    return {
+        "schema_version": LOOPX_TURN_TRANSACTION_PLAN_SCHEMA_VERSION,
+        "status": "planned" if planned else "not_applicable",
+        "turn_key": turn_key,
+        "phases": list(TRANSACTION_PHASES) if planned else [],
+        "commit_policy": "result<validate<writeback<spend;apply<ack;cadence:no-spend",
+        "receipt_seed": {
+            "schema_version": LOOPX_TURN_RECEIPT_SCHEMA_VERSION,
+            "status": "not_executed",
+            "next_phase": TRANSACTION_PHASES[0] if planned else None,
+        },
+    }
+
+
 def build_loopx_turn_plan(
     turn_envelope: Mapping[str, Any],
     *,
     host: str,
     execution_mode: str,
+    session_binding: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Project a TurnEnvelope into a typed, side-effect-free host decision."""
 
@@ -92,6 +216,14 @@ def build_loopx_turn_plan(
 
     envelope = dict(turn_envelope)
     route = _typed_route(envelope)
+    lineage = _turn_lineage(envelope)
+    session, session_error = _session_plan(
+        route=route,
+        lineage=lineage,
+        session_binding=session_binding,
+    )
+    if session_error:
+        route = LoopXTurnRoute.CONTRACT_ERROR
     action = _mapping(envelope.get("action"))
     selected_todo = _mapping(action.get("selected_todo"))
     would_invoke_host = route in {
@@ -108,6 +240,7 @@ def build_loopx_turn_plan(
             "execution_mode": execution_mode,
             "explicit_isolation": execution_mode == "isolated-headless",
         },
+        "session": session,
         "route": {
             "schema_version": "loopx_turn_route_v0",
             "kind": route.value,
@@ -117,6 +250,13 @@ def build_loopx_turn_plan(
             "selected_todo": selected_todo or None,
         },
         "turn_envelope": envelope,
+        "transaction": _transaction_plan(
+            route=route,
+            lineage=lineage,
+            host=host,
+            execution_mode=execution_mode,
+            session_action=str(session.get("action") or "none"),
+        ),
         "effects": {
             "host_invoked": False,
             "state_written": False,
@@ -127,5 +267,7 @@ def build_loopx_turn_plan(
             "read_only": True,
             "requires_explicit_execute_surface": True,
             "preserves_turn_envelope": True,
+            "opaque_session_handle_omitted": True,
         },
+        **({"error": session_error} if session_error else {}),
     }

--- a/loopx/control_plane/turn_driver/transaction.py
+++ b/loopx/control_plane/turn_driver/transaction.py
@@ -1,0 +1,207 @@
+"""Typed LoopX Turn transaction planning and receipt validation."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from enum import Enum
+from hashlib import sha256
+from typing import Any
+
+
+LOOPX_TURN_TRANSACTION_PLAN_SCHEMA_VERSION = "loopx_turn_transaction_plan_v0"
+LOOPX_TURN_RESULT_SCHEMA_VERSION = "loopx_turn_result_v0"
+LOOPX_TURN_RECEIPT_SCHEMA_VERSION = "loopx_turn_receipt_v0"
+LOOPX_TURN_RECEIPT_VALIDATION_SCHEMA_VERSION = "loopx_turn_receipt_validation_v0"
+TRANSACTION_PHASES = (
+    "host_execute",
+    "typed_result",
+    "validation",
+    "durable_writeback",
+    "quota_spend",
+    "scheduler_apply",
+    "scheduler_ack",
+)
+
+
+class LoopXTurnResultKind(str, Enum):
+    VALIDATED_PROGRESS = "validated_progress"
+    VALIDATED_COMPLETION = "validated_completion"
+    REPAIR_REQUIRED = "repair_required"
+    REPLAN_REQUIRED = "replan_required"
+    USER_ACTION_REQUIRED = "user_action_required"
+    WAIT = "wait"
+    HOST_FAILURE = "host_failure"
+    VALIDATION_FAILED = "validation_failed"
+    WRITEBACK_FAILED = "writeback_failed"
+
+
+MATERIAL_RESULT_KINDS = {
+    LoopXTurnResultKind.VALIDATED_PROGRESS,
+    LoopXTurnResultKind.VALIDATED_COMPLETION,
+    LoopXTurnResultKind.REPAIR_REQUIRED,
+    LoopXTurnResultKind.REPLAN_REQUIRED,
+}
+NO_SPEND_RESULT_KINDS = {
+    LoopXTurnResultKind.USER_ACTION_REQUIRED,
+    LoopXTurnResultKind.WAIT,
+    LoopXTurnResultKind.HOST_FAILURE,
+    LoopXTurnResultKind.VALIDATION_FAILED,
+    LoopXTurnResultKind.WRITEBACK_FAILED,
+}
+STOP_RESULT_KINDS = {
+    LoopXTurnResultKind.USER_ACTION_REQUIRED,
+    LoopXTurnResultKind.WAIT,
+}
+FAILURE_PHASES = {
+    LoopXTurnResultKind.HOST_FAILURE: "host_execute",
+    LoopXTurnResultKind.VALIDATION_FAILED: "validation",
+    LoopXTurnResultKind.WRITEBACK_FAILED: "durable_writeback",
+}
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _canonical_hash(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return "sha256:" + sha256(encoded).hexdigest()
+
+
+def build_loopx_turn_transaction_plan(
+    *,
+    planned: bool,
+    lineage: Mapping[str, str],
+    host: str,
+    execution_mode: str,
+    session_action: str,
+) -> dict[str, Any]:
+    turn_key = _canonical_hash(
+        {
+            "lineage": dict(lineage),
+            "host": host,
+            "execution_mode": execution_mode,
+            "session_action": session_action,
+        }
+    )
+    return {
+        "schema_version": LOOPX_TURN_TRANSACTION_PLAN_SCHEMA_VERSION,
+        "status": "planned" if planned else "not_applicable",
+        "turn_key": turn_key,
+        "phases": list(TRANSACTION_PHASES) if planned else [],
+        "commit_policy": "result<validate<writeback<spend;apply<ack;cadence:no-spend",
+        "receipt_seed": {
+            "schema_version": LOOPX_TURN_RECEIPT_SCHEMA_VERSION,
+            "status": "not_executed",
+            "next_phase": TRANSACTION_PHASES[0] if planned else None,
+        },
+    }
+
+
+def _result_kind(value: Any, errors: list[str]) -> LoopXTurnResultKind | None:
+    try:
+        return LoopXTurnResultKind(str(value or ""))
+    except ValueError:
+        errors.append("unsupported execution result kind")
+        return None
+
+
+def _completed_phases(value: Any, errors: list[str]) -> list[str]:
+    if not isinstance(value, list):
+        errors.append("completed_phases must be a list")
+        return []
+    phases = [str(item) for item in value]
+    expected = list(TRANSACTION_PHASES[: len(phases)])
+    if phases != expected:
+        errors.append("completed_phases must be an ordered transaction prefix")
+    return phases
+
+
+def validate_loopx_turn_receipt(
+    transaction_plan: Mapping[str, Any],
+    execution_result: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Validate one public-safe host result against its transaction plan."""
+
+    plan = _mapping(transaction_plan)
+    result = _mapping(execution_result)
+    errors: list[str] = []
+    if plan.get("schema_version") != LOOPX_TURN_TRANSACTION_PLAN_SCHEMA_VERSION:
+        errors.append("unsupported transaction plan schema")
+    if plan.get("status") != "planned":
+        errors.append("transaction plan is not executable")
+    if result.get("schema_version") != LOOPX_TURN_RESULT_SCHEMA_VERSION:
+        errors.append("unsupported execution result schema")
+
+    turn_key = str(plan.get("turn_key") or "")
+    if not turn_key or str(result.get("turn_key") or "") != turn_key:
+        errors.append("execution result turn_key does not match the transaction plan")
+
+    kind = _result_kind(result.get("result_kind"), errors)
+    completed = _completed_phases(result.get("completed_phases"), errors)
+    failed_phase = str(result.get("failed_phase") or "") or None
+    next_index = min(len(completed), len(TRANSACTION_PHASES))
+    expected_next = (
+        TRANSACTION_PHASES[next_index] if next_index < len(TRANSACTION_PHASES) else None
+    )
+
+    if failed_phase and failed_phase != expected_next:
+        errors.append("failed_phase must be the next uncompleted transaction phase")
+    if failed_phase and kind not in FAILURE_PHASES:
+        errors.append("failed_phase is only valid for a typed failure result")
+    if kind in FAILURE_PHASES and failed_phase != FAILURE_PHASES[kind]:
+        errors.append(f"{kind.value} must declare failed_phase={FAILURE_PHASES[kind]}")
+    if kind in MATERIAL_RESULT_KINDS and "validation" not in completed:
+        errors.append("material result requires completed validation")
+    if kind in NO_SPEND_RESULT_KINDS and "quota_spend" in completed:
+        errors.append(f"{kind.value} cannot spend quota")
+
+    ok = not errors
+    fully_committed = completed == list(TRANSACTION_PHASES)
+    failed = kind in FAILURE_PHASES if kind is not None else False
+    stopped = kind in STOP_RESULT_KINDS if kind is not None else False
+    status = (
+        "invalid"
+        if not ok
+        else "failed"
+        if failed
+        else "stopped"
+        if stopped
+        else "committed"
+        if fully_committed
+        else "validated"
+        if "validation" in completed
+        else "in_progress"
+    )
+    return {
+        "ok": ok,
+        "schema_version": LOOPX_TURN_RECEIPT_VALIDATION_SCHEMA_VERSION,
+        "turn_key": turn_key or None,
+        "result_kind": kind.value if kind is not None else None,
+        "completed_phases": completed,
+        "failed_phase": failed_phase,
+        "status": status,
+        "next_phase": (
+            None
+            if fully_committed or (ok and stopped)
+            else failed_phase or expected_next
+        ),
+        "commit_eligibility": {
+            "writeback": ok
+            and kind in MATERIAL_RESULT_KINDS
+            and "validation" in completed,
+            "quota_spend": (
+                ok
+                and kind in MATERIAL_RESULT_KINDS
+                and "durable_writeback" in completed
+            ),
+            "scheduler_ack": ok and "scheduler_apply" in completed,
+        },
+        "errors": errors,
+    }

--- a/tests/control_plane/test_cli_output_budget.py
+++ b/tests/control_plane/test_cli_output_budget.py
@@ -416,6 +416,18 @@ def _mode_variant_commands(
             str(project),
             "--turn-envelope",
         ],
+        "loopx_turn_plan_transaction_detail": common
+        + [
+            "turn",
+            "plan",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_IDS[0],
+            "--scan-root",
+            str(project),
+            "--include-transaction-detail",
+        ],
         "status_task_graph_detail": common
         + [
             "status",
@@ -488,6 +500,7 @@ def test_manifest_covers_the_declared_agent_facing_surface_set() -> None:
         "bootstrap_command_pack_message_only",
         "quota_should_run_scheduler_detail",
         "quota_should_run_turn_envelope",
+        "loopx_turn_plan_transaction_detail",
         "status_task_graph_detail",
         "review_packet_full",
         "heartbeat_prompt_brief",

--- a/tests/test_loopx_turn_driver.py
+++ b/tests/test_loopx_turn_driver.py
@@ -373,6 +373,7 @@ def test_turn_cli_consumes_live_state_without_writes(
                 "codex-fixture",
                 "--scan-root",
                 str(project),
+                "--include-transaction-detail",
             ]
         )
 
@@ -384,6 +385,37 @@ def test_turn_cli_consumes_live_state_without_writes(
     assert payload["turn_envelope"]["action_signature"]["matches"] is True
     assert payload["effects"]["state_written"] is False
     assert before == after
+
+
+def test_turn_cli_omits_transaction_detail_by_default(tmp_path: Path) -> None:
+    project, runtime, registry = _write_live_fixture(tmp_path)
+    output = io.StringIO()
+
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(
+            [
+                "--registry",
+                str(registry),
+                "--runtime-root",
+                str(runtime),
+                "--format",
+                "json",
+                "turn",
+                "plan",
+                "--goal-id",
+                "loopx-turn-fixture",
+                "--agent-id",
+                "codex-fixture",
+                "--scan-root",
+                str(project),
+            ]
+        )
+
+    payload = json.loads(output.getvalue())
+    assert exit_code == 0
+    assert "session" not in payload
+    assert "transaction" not in payload
+    assert "opaque_session_handle_omitted" not in payload["boundary"]
 
 
 def test_turn_cli_requires_complete_resume_identity(tmp_path: Path) -> None:

--- a/tests/test_loopx_turn_driver.py
+++ b/tests/test_loopx_turn_driver.py
@@ -8,7 +8,11 @@ from pathlib import Path
 import pytest
 
 from loopx.cli import main as cli_main
-from loopx.control_plane.turn_driver import LoopXTurnRoute, build_loopx_turn_plan
+from loopx.control_plane.turn_driver import (
+    LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION,
+    LoopXTurnRoute,
+    build_loopx_turn_plan,
+)
 from loopx.control_plane.quota.live_decision import bind_scheduler_followup_cli_routes
 
 
@@ -66,6 +70,22 @@ def test_turn_plan_projects_ready_route_without_side_effects() -> None:
     assert payload["route"]["kind"] == LoopXTurnRoute.READY_FOR_HOST.value
     assert payload["route"]["would_invoke_host"] is True
     assert payload["route"]["host_invocation_allowed"] is False
+    assert payload["session"] == {
+        "schema_version": LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION,
+        "action": "start_new",
+    }
+    assert payload["transaction"]["status"] == "planned"
+    assert payload["transaction"]["phases"] == [
+        "host_execute",
+        "typed_result",
+        "validation",
+        "durable_writeback",
+        "quota_spend",
+        "scheduler_apply",
+        "scheduler_ack",
+    ]
+    assert payload["transaction"]["receipt_seed"]["status"] == "not_executed"
+    assert payload["transaction"]["receipt_seed"]["next_phase"] == "host_execute"
     assert payload["turn_envelope"] == envelope
     assert payload["effects"] == {
         "host_invoked": False,
@@ -85,6 +105,69 @@ def test_turn_help_omits_legacy_agent_loop_entrypoint() -> None:
     assert exit_code == 0
     assert "agent-loop" not in output.getvalue()
     assert "turn" in output.getvalue()
+
+
+def test_turn_plan_resumes_only_a_matching_session_binding() -> None:
+    payload = build_loopx_turn_plan(
+        _envelope(),
+        host="codex-cli",
+        execution_mode="interactive-visible",
+        session_binding={
+            "schema_version": LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION,
+            "goal_id": "fixture-goal",
+            "agent_id": "codex-fixture",
+            "todo_id": "todo_fixture0001",
+        },
+    )
+
+    assert payload["ok"] is True
+    assert payload["session"]["action"] == "resume"
+    assert payload["boundary"]["opaque_session_handle_omitted"] is True
+
+
+def test_turn_plan_rejects_session_binding_identity_drift() -> None:
+    payload = build_loopx_turn_plan(
+        _envelope(),
+        host="codex-cli",
+        execution_mode="interactive-visible",
+        session_binding={
+            "schema_version": LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION,
+            "goal_id": "another-goal",
+            "agent_id": "codex-fixture",
+            "todo_id": "todo_fixture0001",
+        },
+    )
+
+    assert payload["ok"] is False
+    assert payload["route"]["kind"] == LoopXTurnRoute.CONTRACT_ERROR.value
+    assert payload["route"]["would_invoke_host"] is False
+    assert payload["session"]["action"] == "reject"
+    assert payload["session"]["binding_status"] == "identity_mismatch"
+    assert payload["transaction"]["status"] == "not_applicable"
+    assert payload["effects"]["host_invoked"] is False
+
+
+def test_turn_plan_transaction_key_is_stable_and_todo_scoped() -> None:
+    first = build_loopx_turn_plan(
+        _envelope(),
+        host="generic-cli",
+        execution_mode="isolated-headless",
+    )
+    repeated = build_loopx_turn_plan(
+        _envelope(),
+        host="generic-cli",
+        execution_mode="isolated-headless",
+    )
+    changed_envelope = _envelope()
+    changed_envelope["action"]["selected_todo"]["todo_id"] = "todo_fixture0002"
+    changed = build_loopx_turn_plan(
+        changed_envelope,
+        host="generic-cli",
+        execution_mode="isolated-headless",
+    )
+
+    assert first["transaction"]["turn_key"] == repeated["transaction"]["turn_key"]
+    assert first["transaction"]["turn_key"] != changed["transaction"]["turn_key"]
 
 
 @pytest.mark.parametrize(
@@ -144,6 +227,9 @@ def test_turn_plan_projects_non_run_routes(
 
     assert payload["route"]["kind"] == expected.value
     assert payload["route"]["would_invoke_host"] is False
+    assert payload["session"]["action"] == "none"
+    assert payload["transaction"]["status"] == "not_applicable"
+    assert payload["transaction"]["phases"] == []
 
 
 def test_turn_plan_fails_closed_on_action_signature_drift() -> None:
@@ -180,9 +266,7 @@ def test_scheduler_followup_binding_preserves_turn_lineage(
 ) -> None:
     payload = {
         "scheduler_hint": {
-            "codex_app": {
-                "ack_hint": {"cli_args": ["quota", "scheduler-ack-current"]}
-            }
+            "codex_app": {"ack_hint": {"cli_args": ["quota", "scheduler-ack-current"]}}
         }
     }
 
@@ -237,7 +321,10 @@ def _write_live_fixture(root: Path) -> tuple[Path, Path, Path]:
                         "status": "active",
                         "repo": str(project),
                         "state_file": str(state.relative_to(project)),
-                        "adapter": {"kind": "fixture_v0", "status": "connected-delivery"},
+                        "adapter": {
+                            "kind": "fixture_v0",
+                            "status": "connected-delivery",
+                        },
                         "quota": {"compute": 1.0, "window_hours": 24},
                         "coordination": {
                             "agent_model": "peer_v1",
@@ -293,6 +380,39 @@ def test_turn_cli_consumes_live_state_without_writes(
     after = sorted(path.relative_to(tmp_path) for path in tmp_path.rglob("*"))
     assert exit_code == 0
     assert payload["route"]["kind"] == LoopXTurnRoute.READY_FOR_HOST.value
+    assert payload["session"]["action"] == "start_new"
     assert payload["turn_envelope"]["action_signature"]["matches"] is True
     assert payload["effects"]["state_written"] is False
     assert before == after
+
+
+def test_turn_cli_requires_complete_resume_identity(tmp_path: Path) -> None:
+    project, runtime, registry = _write_live_fixture(tmp_path)
+    output = io.StringIO()
+
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(
+            [
+                "--registry",
+                str(registry),
+                "--runtime-root",
+                str(runtime),
+                "--format",
+                "json",
+                "turn",
+                "plan",
+                "--goal-id",
+                "loopx-turn-fixture",
+                "--agent-id",
+                "codex-fixture",
+                "--resume-goal-id",
+                "loopx-turn-fixture",
+                "--scan-root",
+                str(project),
+            ]
+        )
+
+    payload = json.loads(output.getvalue())
+    assert exit_code == 1
+    assert payload["ok"] is False
+    assert "requires --resume-goal-id" in payload["error"]

--- a/tests/test_loopx_turn_transaction.py
+++ b/tests/test_loopx_turn_transaction.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import pytest
+
+from loopx.control_plane.turn_driver import (
+    LOOPX_TURN_RESULT_SCHEMA_VERSION,
+    LoopXTurnResultKind,
+    build_loopx_turn_transaction_plan,
+    validate_loopx_turn_receipt,
+)
+
+
+def _plan() -> dict[str, object]:
+    return build_loopx_turn_transaction_plan(
+        planned=True,
+        lineage={
+            "goal_id": "fixture-goal",
+            "agent_id": "codex-fixture",
+            "todo_id": "todo_fixture0001",
+            "action_hash": "sha256:fixture",
+        },
+        host="codex-cli",
+        execution_mode="interactive-visible",
+        session_action="resume",
+    )
+
+
+def _result(
+    plan: dict[str, object],
+    *,
+    result_kind: LoopXTurnResultKind = LoopXTurnResultKind.VALIDATED_PROGRESS,
+    completed_phases: list[str] | None = None,
+    failed_phase: str | None = None,
+) -> dict[str, object]:
+    result: dict[str, object] = {
+        "schema_version": LOOPX_TURN_RESULT_SCHEMA_VERSION,
+        "turn_key": plan["turn_key"],
+        "result_kind": result_kind.value,
+        "completed_phases": (
+            completed_phases
+            if completed_phases is not None
+            else ["host_execute", "typed_result", "validation"]
+        ),
+    }
+    if failed_phase:
+        result["failed_phase"] = failed_phase
+    return result
+
+
+def test_validated_result_becomes_writeback_eligible_without_spend() -> None:
+    plan = _plan()
+
+    receipt = validate_loopx_turn_receipt(plan, _result(plan))
+
+    assert receipt["ok"] is True
+    assert receipt["status"] == "validated"
+    assert receipt["next_phase"] == "durable_writeback"
+    assert receipt["commit_eligibility"] == {
+        "writeback": True,
+        "quota_spend": False,
+        "scheduler_ack": False,
+    }
+
+
+def test_fully_committed_result_proves_writeback_spend_and_ack_order() -> None:
+    plan = _plan()
+
+    receipt = validate_loopx_turn_receipt(
+        plan,
+        _result(plan, completed_phases=list(plan["phases"])),
+    )
+
+    assert receipt["ok"] is True
+    assert receipt["status"] == "committed"
+    assert receipt["next_phase"] is None
+    assert receipt["commit_eligibility"] == {
+        "writeback": True,
+        "quota_spend": True,
+        "scheduler_ack": True,
+    }
+
+
+@pytest.mark.parametrize(
+    "completed_phases",
+    [
+        ["host_execute", "typed_result", "durable_writeback"],
+        ["host_execute", "typed_result", "validation", "quota_spend"],
+        [
+            "host_execute",
+            "typed_result",
+            "validation",
+            "durable_writeback",
+            "quota_spend",
+            "scheduler_ack",
+        ],
+    ],
+)
+def test_receipt_rejects_skipped_transaction_phases(
+    completed_phases: list[str],
+) -> None:
+    plan = _plan()
+
+    receipt = validate_loopx_turn_receipt(
+        plan,
+        _result(plan, completed_phases=completed_phases),
+    )
+
+    assert receipt["ok"] is False
+    assert "ordered transaction prefix" in " ".join(receipt["errors"])
+    assert receipt["commit_eligibility"]["quota_spend"] is False
+
+
+def test_receipt_rejects_turn_lineage_drift() -> None:
+    plan = _plan()
+    result = _result(plan)
+    result["turn_key"] = "sha256:another-turn"
+
+    receipt = validate_loopx_turn_receipt(plan, result)
+
+    assert receipt["ok"] is False
+    assert "turn_key" in " ".join(receipt["errors"])
+
+
+@pytest.mark.parametrize(
+    ("kind", "completed", "failed_phase"),
+    [
+        (LoopXTurnResultKind.HOST_FAILURE, [], "host_execute"),
+        (
+            LoopXTurnResultKind.VALIDATION_FAILED,
+            ["host_execute", "typed_result"],
+            "validation",
+        ),
+        (
+            LoopXTurnResultKind.WRITEBACK_FAILED,
+            ["host_execute", "typed_result", "validation"],
+            "durable_writeback",
+        ),
+    ],
+)
+def test_typed_failure_stops_at_its_declared_phase(
+    kind: LoopXTurnResultKind,
+    completed: list[str],
+    failed_phase: str,
+) -> None:
+    plan = _plan()
+
+    receipt = validate_loopx_turn_receipt(
+        plan,
+        _result(
+            plan,
+            result_kind=kind,
+            completed_phases=completed,
+            failed_phase=failed_phase,
+        ),
+    )
+
+    assert receipt["ok"] is True
+    assert receipt["status"] == "failed"
+    assert receipt["next_phase"] == failed_phase
+    assert receipt["commit_eligibility"]["quota_spend"] is False
+
+
+def test_no_spend_result_cannot_claim_a_spent_transaction() -> None:
+    plan = _plan()
+
+    receipt = validate_loopx_turn_receipt(
+        plan,
+        _result(
+            plan,
+            result_kind=LoopXTurnResultKind.WAIT,
+            completed_phases=list(plan["phases"][:5]),
+        ),
+    )
+
+    assert receipt["ok"] is False
+    assert "cannot spend quota" in " ".join(receipt["errors"])
+
+
+def test_wait_result_stops_without_effect_eligibility() -> None:
+    plan = _plan()
+
+    receipt = validate_loopx_turn_receipt(
+        plan,
+        _result(
+            plan,
+            result_kind=LoopXTurnResultKind.WAIT,
+            completed_phases=["host_execute", "typed_result"],
+        ),
+    )
+
+    assert receipt["ok"] is True
+    assert receipt["status"] == "stopped"
+    assert receipt["next_phase"] is None
+    assert receipt["commit_eligibility"] == {
+        "writeback": False,
+        "quota_spend": False,
+        "scheduler_ack": False,
+    }
+
+
+def test_material_result_requires_completed_validation() -> None:
+    plan = _plan()
+
+    receipt = validate_loopx_turn_receipt(
+        plan,
+        _result(plan, completed_phases=["host_execute", "typed_result"]),
+    )
+
+    assert receipt["ok"] is False
+    assert "requires completed validation" in " ".join(receipt["errors"])
+
+
+def test_non_executable_plan_rejects_a_result() -> None:
+    plan = build_loopx_turn_transaction_plan(
+        planned=False,
+        lineage={"goal_id": "fixture", "agent_id": "agent", "todo_id": "todo"},
+        host="codex-cli",
+        execution_mode="interactive-visible",
+        session_action="none",
+    )
+
+    receipt = validate_loopx_turn_receipt(plan, _result(plan))
+
+    assert receipt["ok"] is False
+    assert "not executable" in " ".join(receipt["errors"])


### PR DESCRIPTION
## Summary

- extend read-only `loopx turn plan` with explicit start-vs-resume planning bound to `(goal_id, agent_id, todo_id)`
- fail closed when an opaque session binding does not match the current TurnEnvelope lineage
- emit `loopx_turn_*` plans, results, receipts, and validations with a stable turn key and ordered result/validation/writeback/spend/scheduler phases
- validate typed receipts against schema, turn-key lineage, ordered phase prefixes, declared failure phases, material-result validation, and no-spend result classes
- keep host launch, state writeback, quota spend, and scheduler acknowledgement disabled
- remove the unmerged `agent_loop` package, symbols, schemas, and tests without compatibility aliases

## Stack

- base: #2149 (`codex/agent-loop-shadow-driver`)
- this PR contains only the session-resume and transaction/receipt increment
- merge/rebase this PR after #2149

## Validation

- `python -m pytest -q tests/test_loopx_turn_driver.py tests/test_loopx_turn_transaction.py tests/test_turn_envelope.py tests/control_plane/test_quota_slot_accounting.py tests/control_plane/test_cli_output_budget.py tests/test_cli_argument_diagnostics.py` (66 passed)
- focused Ruff checks passed
- Python compile checks passed
- `python examples/control_plane/cli-output-budget-regression-smoke.py` passed
- `loopx canary premerge --from-git-diff` standard control-plane/Python profile passed
- hot-path output remained within the existing 12,000-character ceiling; the ceiling was not raised
- public/private candidate-path scan clean

## Boundaries and review hold

- no host process or session is opened or mutated
- no session handle is printed or persisted
- receipt validation is pure and does not authorize or perform an effect
- no LoopX state write, scheduler ACK, quota spend, benchmark launch, upload, or submission
- no credentials, local paths, raw benchmark evidence, generated logs, or private state are included
- capability behavior remains review-required despite green canary results
