### PR TITLE
fix(todo): resume explicitly unblocked work

### DIFF
--- a/examples/control_plane/agent-management-live-status-smoke.py
+++ b/examples/control_plane/agent-management-live-status-smoke.py
@@ -214,6 +214,50 @@ def assert_synthetic_projection() -> None:
     assert "reclaim_url" not in json.dumps(stale_hint, sort_keys=True), stale_hint
 
 
+def assert_event_only_todo_receipts_are_not_runtime_work() -> None:
+    payload = fixture_status_payload()
+    payload["run_history"]["goals"][0]["coordination"]["registered_agents"].append(
+        "agent-event-only"
+    )
+    payload["todo_index"]["items"].extend(
+        [
+            {
+                "goal_id": "fixture-goal",
+                "todo_id": "todo_event_shadow",
+                "role": "agent",
+                "status": "open",
+                "priority": "P0",
+                "title": "todo add recorded for todo_event_shadow",
+                "text": "todo add recorded for todo_event_shadow",
+                "agent_id": "agent-reviewer",
+                "source": "rollout_event_log",
+                "latest_event_kind": "todo_add",
+            },
+            {
+                "goal_id": "fixture-goal",
+                "todo_id": "todo_event_only",
+                "role": "agent",
+                "status": "open",
+                "priority": "P0",
+                "title": "todo add recorded for todo_event_only",
+                "text": "todo add recorded for todo_event_only",
+                "agent_id": "agent-event-only",
+                "source": "rollout_event_log",
+                "latest_event_kind": "todo_add",
+            },
+        ]
+    )
+    projection = build_agent_management_projection(payload)
+    by_agent = {
+        row.get("agent_id"): row
+        for row in projection.get("agents", [])
+        if isinstance(row, dict)
+    }
+    assert by_agent["agent-reviewer"]["current_todo"]["todo_id"] == "todo_live_handoff", by_agent
+    assert by_agent["agent-event-only"]["state"] == "unknown", by_agent
+    assert "current_todo" not in by_agent["agent-event-only"], by_agent
+
+
 def assert_advancement_current_todo_beats_standing_monitor() -> None:
     payload = fixture_status_payload()
     payload["run_history"]["goals"][0]["coordination"]["registered_agents"].append("agent-side")
@@ -463,6 +507,7 @@ def assert_live_projection(args: argparse.Namespace) -> dict[str, Any]:
 def main() -> int:
     args = parse_args()
     assert_synthetic_projection()
+    assert_event_only_todo_receipts_are_not_runtime_work()
     assert_advancement_current_todo_beats_standing_monitor()
     result: dict[str, Any] = {
         "synthetic": "ok",

--- a/examples/control_plane/todo-user-gate-scope-smoke.py
+++ b/examples/control_plane/todo-user-gate-scope-smoke.py
@@ -17,7 +17,7 @@ if str(REPO_ROOT) not in sys.path:
 from loopx.contract import check_contract  # noqa: E402
 from loopx.control_plane.todos.todo_summary import active_state_todo_attention_item  # noqa: E402
 from loopx.quota import build_quota_should_run  # noqa: E402
-from loopx.status import collect_status  # noqa: E402
+from loopx.status import collect_status, parse_active_state_todos  # noqa: E402
 from loopx.todos import add_goal_todo, complete_goal_todo, update_goal_todo  # noqa: E402
 
 
@@ -212,6 +212,81 @@ def main() -> int:
             claimed_by=SIDE_AGENT,
         )
         assert side_agent_todo["claimed_by"] == SIDE_AGENT, side_agent_todo
+
+        blocked_agent_todo = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="Clean up the exact approved duplicate records.",
+            status="blocked",
+            task_class="advancement_task",
+            claimed_by=SIDE_AGENT,
+        )
+        approval = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="user",
+            text="Authorize the exact duplicate cleanup.",
+            task_class="user_action",
+            unblocks_todo_id=blocked_agent_todo["todo_id"],
+        )
+        approval_completed = complete_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=approval["todo_id"],
+            role="user",
+            evidence="user authorized the exact bounded cleanup",
+        )
+        assert approval_completed["unblock_resume"]["state"] == "resumed", approval_completed
+        assert approval_completed["unblock_resume"]["target_todo_id"] == blocked_agent_todo["todo_id"], approval_completed
+        resumed = next(
+            item
+            for item in parse_active_state_todos(state.read_text(encoding="utf-8"))["agent_todos"]["items"]
+            if item["todo_id"] == blocked_agent_todo["todo_id"]
+        )
+        assert resumed["status"] == "open", resumed
+        assert resumed["claimed_by"] == SIDE_AGENT, resumed
+
+        multiply_blocked = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="Run a cleanup that needs two exact user actions.",
+            status="blocked",
+            task_class="advancement_task",
+            claimed_by=SIDE_AGENT,
+        )
+        approvals = [
+            add_goal_todo(
+                registry_path=registry,
+                goal_id=GOAL_ID,
+                role="user",
+                text=f"Authorize bounded cleanup part {part}.",
+                task_class="user_action",
+                unblocks_todo_id=multiply_blocked["todo_id"],
+            )
+            for part in ("one", "two")
+        ]
+        first_approval = complete_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=approvals[0]["todo_id"],
+            role="user",
+            evidence="first exact authorization",
+        )
+        assert first_approval["unblock_resume"]["state"] == "other_user_blockers_active", first_approval
+        assert first_approval["unblock_resume"]["remaining_user_blocker_todo_ids"] == [
+            approvals[1]["todo_id"]
+        ], first_approval
+        second_approval = complete_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=approvals[1]["todo_id"],
+            role="user",
+            evidence="second exact authorization",
+        )
+        assert second_approval["unblock_resume"]["state"] == "resumed", second_approval
+
         status_payload = collect_status(
             registry_path=registry,
             runtime_root_override=str(root / "runtime"),
@@ -219,6 +294,12 @@ def main() -> int:
             limit=1,
             goal_id=GOAL_ID,
         )
+        indexed_target = next(
+            item
+            for item in status_payload["todo_index"]["items"]
+            if item.get("todo_id") == blocked_agent_todo["todo_id"]
+        )
+        assert indexed_target["status"] == "open", indexed_target
         quota_payload = build_quota_should_run(
             status_payload,
             goal_id=GOAL_ID,
@@ -228,6 +309,12 @@ def main() -> int:
         assert isinstance(user_summary, dict), quota_payload
         assert user_summary["user_action_open_count"] == 1, user_summary
         assert user_summary["gate_open_items"] == [], user_summary
+        executable_ids = {
+            item.get("todo_id")
+            for item in quota_payload["agent_todo_summary"]["first_executable_items"]
+        }
+        assert blocked_agent_todo["todo_id"] in executable_ids, quota_payload
+        assert multiply_blocked["todo_id"] in executable_ids, quota_payload
 
         assert_raises_message(
             lambda: add_goal_todo(

--- a/loopx/control_plane/agents/management_projection.py
+++ b/loopx/control_plane/agents/management_projection.py
@@ -245,7 +245,11 @@ def _iter_status_todos(status_payload: dict[str, Any]) -> Iterable[dict[str, Any
 
     todo_index = _as_dict(status_payload.get("todo_index"))
     for todo in _as_list(todo_index.get("items")):
-        if isinstance(todo, dict) and str(todo.get("role") or "") == "agent":
+        if (
+            isinstance(todo, dict)
+            and str(todo.get("role") or "") == "agent"
+            and str(todo.get("source") or "") != "rollout_event_log"
+        ):
             row = dict(todo)
             row.setdefault("source", "todo_index")
             yield row
@@ -541,7 +545,10 @@ def build_agent_management_projection(status_payload: dict[str, Any]) -> dict[st
         "source_summary": {
             "registered_agent_count": len(rows_by_agent),
             "projected_agent_count": len(agents),
-            "todo_source": "status.attention_queue + status.todo_index",
+            "todo_source": (
+                "status.attention_queue + authoritative status.todo_index rows; "
+                "event-only rollout receipts are evidence, not runtime work"
+            ),
         },
         "agents": agents,
     }

--- a/loopx/control_plane/todos/unblock_resume.py
+++ b/loopx/control_plane/todos/unblock_resume.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .active_state_editing import section_bounds, todo_blocks
+from .contract import (
+    TODO_STATUS_OPEN,
+    normalize_todo_id,
+    normalize_todo_status,
+    todo_done_for_status,
+)
+
+
+TODO_UNBLOCK_RESUME_SCHEMA_VERSION = "todo_unblock_resume_v0"
+
+
+def _status(todo: dict[str, Any]) -> str:
+    return normalize_todo_status(todo.get("status")) or TODO_STATUS_OPEN
+
+
+def _find_todo(
+    lines: list[str],
+    *,
+    role: str,
+    todo_id: str,
+) -> dict[str, Any] | None:
+    bounds = section_bounds(lines, role)
+    if not bounds:
+        return None
+    start, end, section = bounds
+    return next(
+        (
+            todo
+            for todo in todo_blocks(
+                lines,
+                start,
+                end,
+                role=role,
+                source_section=section,
+            )
+            if normalize_todo_id(todo.get("todo_id")) == todo_id
+        ),
+        None,
+    )
+
+
+def plan_completed_user_unblock_resume(
+    lines: list[str],
+    *,
+    source_todo_id: str,
+    target_todo_id: str,
+) -> dict[str, Any]:
+    """Plan a safe resume for one explicitly linked blocked advancement todo."""
+
+    receipt: dict[str, Any] = {
+        "schema_version": TODO_UNBLOCK_RESUME_SCHEMA_VERSION,
+        "source_todo_id": source_todo_id,
+        "target_todo_id": target_todo_id,
+        "changed": False,
+    }
+    target = _find_todo(lines, role="agent", todo_id=target_todo_id)
+    if not target:
+        return {**receipt, "state": "target_not_found"}
+    target_status = _status(target)
+    receipt["previous_status"] = target_status
+    receipt["status"] = target_status
+    if target_status != "blocked":
+        return {**receipt, "state": "target_not_blocked"}
+    if str(target.get("task_class") or "") == "blocker":
+        return {**receipt, "state": "explicit_blocker_repair_required"}
+
+    user_bounds = section_bounds(lines, "user")
+    remaining_ids: list[str] = []
+    if user_bounds:
+        start, end, section = user_bounds
+        for candidate in todo_blocks(
+            lines,
+            start,
+            end,
+            role="user",
+            source_section=section,
+        ):
+            candidate_id = normalize_todo_id(candidate.get("todo_id"))
+            if (
+                candidate_id
+                and candidate_id != source_todo_id
+                and not todo_done_for_status(_status(candidate))
+                and normalize_todo_id(candidate.get("unblocks_todo_id")) == target_todo_id
+            ):
+                remaining_ids.append(candidate_id)
+    if remaining_ids:
+        return {
+            **receipt,
+            "state": "other_user_blockers_active",
+            "remaining_user_blocker_todo_ids": sorted(set(remaining_ids)),
+        }
+    return {**receipt, "state": "resume_ready"}

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -76,6 +76,7 @@ from .control_plane.todos.text import (
     inherit_todo_priority,
     normalize_new_todo,
 )
+from .control_plane.todos.unblock_resume import plan_completed_user_unblock_resume
 from .control_plane.todos.write_policy import require_user_gate_scope, require_user_todo_task_class
 
 
@@ -1636,6 +1637,45 @@ def complete_goal_todo(
             successor_todo_ids=normalized_successor_todo_ids if successor_todo_ids is not None else None,
             updated_at=updated_at,
         )
+        unblock_resume = None
+        completion_role = str((completion_todo or {}).get("role") or "")
+        completion_task_class = str((completion_todo or {}).get("task_class") or "")
+        linked_unblocks_todo_id = normalize_todo_id(update_result.get("unblocks_todo_id"))
+        if (
+            completion_role == "user"
+            and completion_task_class in {"user_action", TODO_TASK_CLASS_USER_GATE}
+            and linked_unblocks_todo_id
+        ):
+            unblock_resume = plan_completed_user_unblock_resume(
+                lines,
+                source_todo_id=str(update_result.get("todo_id") or todo_id),
+                target_todo_id=linked_unblocks_todo_id,
+            )
+            if unblock_resume.get("state") == "resume_ready":
+                resumed = apply_todo_update_to_lines(
+                    lines,
+                    todo_id=linked_unblocks_todo_id,
+                    role="agent",
+                    status=TODO_STATUS_OPEN,
+                    reason=(
+                        "authorization satisfied by completed user todo "
+                        f"{update_result.get('todo_id') or todo_id}"
+                    ),
+                    updated_at=updated_at,
+                )
+                unblock_resume.update(
+                    {
+                        "state": "resumed",
+                        "status": resumed.get("status"),
+                        "changed": bool(resumed.get("changed")),
+                        "claimed_by": resumed.get("claimed_by"),
+                    }
+                )
+                unblock_resume = {
+                    key: value
+                    for key, value in unblock_resume.items()
+                    if value not in (None, "", [], {})
+                }
         next_unblocks_todo_id = (
             normalize_todo_id(str(update_result.get("todo_id") or todo_id))
             if next_agent_todo
@@ -1693,7 +1733,12 @@ def complete_goal_todo(
             successor_todo_ids=generated_successor_todo_ids,
         )
         next_changed = any(item.get("added") or item.get("metadata_updated") for item in next_results)
-        changed = bool(update_result["changed"] or next_changed or successor_metadata_updated)
+        changed = bool(
+            update_result["changed"]
+            or next_changed
+            or successor_metadata_updated
+            or (unblock_resume or {}).get("changed")
+        )
         new_text = "\n".join(lines) + ("\n" if original.endswith("\n") else "")
         if changed:
             new_text = replace_updated_at(new_text, updated_at)
@@ -1712,6 +1757,8 @@ def complete_goal_todo(
         "project": str(resolved_project) if resolved_project else None,
         "updated_at": updated_at if changed else None,
     }
+    if unblock_resume:
+        result["unblock_resume"] = unblock_resume
     result["self_merged"] = effective_self_merged
     return result
 


### PR DESCRIPTION
## Summary
- resume an explicitly linked blocked advancement todo when its user action or gate completes
- preserve blocking when another open user todo links to the same target
- keep event-only rollout receipts out of agent current-todo projection
- move resume planning into a bounded control-plane module

## Validation
- focused user-gate lifecycle and agent-management projection smokes
- ruff and changed-file py_compile
- standard LoopX premerge: 17/17 passed, public boundary clean, no manual holds

## Risk judgment
The transition requires an exact unblocks_todo_id, a blocked non-blocker agent target, and no other open user blocker for that target. Claims are preserved. Event-only rows remain available as evidence through todo_index but no longer become runtime work.