### PR TITLE
Qualify CLI output with base-head differential

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -53,7 +55,7 @@ jobs:
         run: python -m mypy
 
       - name: Qualify agent-facing CLI output
-        run: python -m pytest -q tests/control_plane/test_cli_output_budget.py
+        run: python examples/control_plane/cli-output-budget-regression-smoke.py
 
       - name: Run fast tests
         run: >-

--- a/docs/interface-budget-contract.md
+++ b/docs/interface-budget-contract.md
@@ -55,6 +55,19 @@ rationale. The canary planner selects the output-budget profile for CLI command,
 help, implementation, fixture, workflow, or budget-contract changes, and PR CI
 runs the matrix as a named step.
 
+The qualification also runs the same public fixture against `origin/main` and
+the candidate checkout. It allows only policy-sized growth for each surface and
+format, rather than treating one global percentage as safe. A smaller candidate
+still fails when it removes a declared semantic key or changes an existing
+`action_signature` semantic contract. Removed observed nested JSON paths or
+Markdown headings are reported as review signals: sensitive output reductions
+must account for them in human review, while an intentional presentation or
+structural refactor does not become a permanent CI red light.
+The receipts contain counts, shape paths, headings, and digests only; they do
+not persist raw CLI output. Candidate-only surfaces are allowed after their
+absolute characterization passes, while removing a qualified base row fails
+closed.
+
 Both budget layers are intentionally about projections, not the full archival
 facts. When a surface needs more detail, put that detail behind a queryable
 cold-path command or a linked run-history artifact instead of making the
@@ -84,6 +97,8 @@ Regression entrypoints:
 
 ```bash
 pytest -q tests/control_plane/test_cli_output_budget.py
+pytest -q tests/control_plane/test_cli_output_differential.py
+python3 examples/control_plane/cli-output-base-head-differential-smoke.py
 python3 examples/control_plane/cli-output-budget-regression-smoke.py
 python3 examples/control_plane/hot-path-interface-budget-smoke.py
 python3 examples/control_plane/status-quota-perf-budget-smoke.py

--- a/examples/control_plane/cli-output-base-head-differential-smoke.py
+++ b/examples/control_plane/cli-output-base-head-differential-smoke.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Compare agent-facing CLI output from one public fixture on base and head."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from loopx.control_plane.testing.cli_output_differential import (
+    compare_cli_output_receipts,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROBE_TEST = REPO_ROOT / "tests" / "control_plane" / "test_cli_output_budget.py"
+PROBE_RUNNER = REPO_ROOT / "examples" / "control_plane" / "cli-output-probe-runner.py"
+SEMANTICS_SOURCE = (
+    REPO_ROOT / "loopx" / "control_plane" / "testing" / "cli_output_semantics.py"
+)
+
+
+def _run(command: list[str], *, cwd: Path, env: dict[str, str] | None = None) -> None:
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=240,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            f"command failed ({completed.returncode}): {' '.join(command)}\n"
+            f"stdout:\n{completed.stdout[-4000:]}\n"
+            f"stderr:\n{completed.stderr[-4000:]}"
+        )
+
+
+def _run_probe(
+    *,
+    source_root: Path,
+    probe_runner: Path,
+    probe_test: Path,
+    semantics_source: Path,
+    fixture_root: Path,
+    receipt_path: Path,
+    cwd: Path,
+) -> None:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(source_root)
+    _run(
+        [
+            sys.executable,
+            str(probe_runner),
+            "--test-source",
+            str(probe_test),
+            "--semantics-source",
+            str(semantics_source),
+            "--fixture-root",
+            str(fixture_root),
+            "--receipt",
+            str(receipt_path),
+        ],
+        cwd=cwd,
+        env=env,
+    )
+
+
+def _load_receipt(path: Path) -> dict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"probe receipt must be an object: {path}")
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--base-ref",
+        default=os.environ.get("LOOPX_CLI_OUTPUT_BASE_REF", "origin/main"),
+    )
+    args = parser.parse_args()
+    if not PROBE_TEST.is_file():
+        raise RuntimeError(f"missing probe source: {PROBE_TEST.relative_to(REPO_ROOT)}")
+    if not PROBE_RUNNER.is_file():
+        raise RuntimeError(
+            f"missing probe runner: {PROBE_RUNNER.relative_to(REPO_ROOT)}"
+        )
+    if not SEMANTICS_SOURCE.is_file():
+        raise RuntimeError(
+            f"missing probe semantics: {SEMANTICS_SOURCE.relative_to(REPO_ROOT)}"
+        )
+
+    with tempfile.TemporaryDirectory(prefix="loopx-cli-output-differential-") as temp:
+        temp_root = Path(temp)
+        base_root = temp_root / "base"
+        probe_test = temp_root / "test_cli_output_probe.py"
+        probe_runner = temp_root / "cli_output_probe_runner.py"
+        semantics_source = temp_root / "cli_output_semantics.py"
+        fixture_root = temp_root / "public-fixture"
+        base_receipt = temp_root / "base-receipt.json"
+        candidate_receipt = temp_root / "candidate-receipt.json"
+        shutil.copy2(PROBE_TEST, probe_test)
+        shutil.copy2(PROBE_RUNNER, probe_runner)
+        shutil.copy2(SEMANTICS_SOURCE, semantics_source)
+
+        _run(
+            ["git", "worktree", "add", "--detach", str(base_root), args.base_ref],
+            cwd=REPO_ROOT,
+        )
+        try:
+            _run_probe(
+                source_root=base_root,
+                probe_runner=probe_runner,
+                probe_test=probe_test,
+                semantics_source=semantics_source,
+                fixture_root=fixture_root,
+                receipt_path=base_receipt,
+                cwd=temp_root,
+            )
+            _run_probe(
+                source_root=REPO_ROOT,
+                probe_runner=probe_runner,
+                probe_test=probe_test,
+                semantics_source=semantics_source,
+                fixture_root=fixture_root,
+                receipt_path=candidate_receipt,
+                cwd=temp_root,
+            )
+        finally:
+            _run(
+                ["git", "worktree", "remove", "--force", str(base_root)],
+                cwd=REPO_ROOT,
+            )
+
+        comparison = compare_cli_output_receipts(
+            _load_receipt(base_receipt),
+            _load_receipt(candidate_receipt),
+        )
+        if not comparison["ok"]:
+            failed = [
+                {"row_id": row["row_id"], "failures": row["failures"]}
+                for row in comparison["rows"]
+                if row["status"] == "failed"
+            ]
+            raise AssertionError(
+                "agent-facing CLI base/head differential failed\n"
+                + json.dumps(failed, ensure_ascii=False, indent=2, sort_keys=True)
+            )
+        if comparison["review_required"]:
+            review_signals = [
+                {"row_id": row["row_id"], "review_signals": row["review_signals"]}
+                for row in comparison["rows"]
+                if row["review_signals"]
+            ]
+            print(
+                "cli-output-base-head-differential review-signals "
+                + json.dumps(review_signals, ensure_ascii=False, sort_keys=True)
+            )
+        print(
+            "cli-output-base-head-differential-smoke ok "
+            f"base={comparison['base_row_count']} "
+            f"candidate={comparison['candidate_row_count']} "
+            f"candidate_only={comparison['candidate_only_row_count']} "
+            f"review_required={comparison['review_row_count']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/control_plane/cli-output-budget-regression-smoke.py
+++ b/examples/control_plane/cli-output-budget-regression-smoke.py
@@ -11,6 +11,12 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TEST_PATH = REPO_ROOT / "tests" / "control_plane" / "test_cli_output_budget.py"
+DIFFERENTIAL_SMOKE = (
+    REPO_ROOT
+    / "examples"
+    / "control_plane"
+    / "cli-output-base-head-differential-smoke.py"
+)
 
 
 def _pytest_command() -> list[str]:
@@ -29,7 +35,9 @@ def _pytest_command() -> list[str]:
 
 def main() -> int:
     if not TEST_PATH.is_file():
-        raise RuntimeError(f"missing CLI output budget test: {TEST_PATH.relative_to(REPO_ROOT)}")
+        raise RuntimeError(
+            f"missing CLI output budget test: {TEST_PATH.relative_to(REPO_ROOT)}"
+        )
     completed = subprocess.run(
         [*_pytest_command(), "-q", str(TEST_PATH.relative_to(REPO_ROOT))],
         cwd=REPO_ROOT,
@@ -42,6 +50,21 @@ def main() -> int:
     if completed.returncode != 0:
         raise AssertionError(
             "agent-facing CLI output qualification failed\n"
+            f"stdout:\n{completed.stdout[-3000:]}\n"
+            f"stderr:\n{completed.stderr[-3000:]}"
+        )
+    completed = subprocess.run(
+        [sys.executable, str(DIFFERENTIAL_SMOKE.relative_to(REPO_ROOT))],
+        cwd=REPO_ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=300,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            "agent-facing CLI base/head differential failed\n"
             f"stdout:\n{completed.stdout[-3000:]}\n"
             f"stderr:\n{completed.stderr[-3000:]}"
         )

--- a/examples/control_plane/cli-output-probe-runner.py
+++ b/examples/control_plane/cli-output-probe-runner.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Emit a public-safe CLI output receipt from the shared qualification fixture."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import shutil
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Callable
+
+
+PROBE_SCHEMA_VERSION = "loopx_cli_output_probe_v0"
+FIXTURE_CONTRACT_VERSION = "loopx_cli_output_public_fixture_v0"
+
+
+def _install_pytest_import_stub() -> None:
+    if importlib.util.find_spec("pytest") is not None:
+        return
+    stub = ModuleType("pytest")
+
+    class Mark:
+        @staticmethod
+        def parametrize(*_args: Any, **_kwargs: Any) -> Callable[..., Any]:
+            return lambda function: function
+
+    stub.mark = Mark()  # type: ignore[attr-defined]
+    sys.modules["pytest"] = stub
+
+
+def _load_module(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load CLI output probe fixture: {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _receipt_row(
+    *,
+    semantics: ModuleType,
+    row_id: str,
+    surface_id: str,
+    scenario: str,
+    output_format: str,
+    qualification_policy: str,
+    semantic_json_keys: tuple[str, ...],
+    markdown_anchor: str,
+    measurement: dict,
+    text: str,
+    variant_id: str | None = None,
+) -> dict:
+    payload = measurement.get("payload")
+    return {
+        "row_id": row_id,
+        "surface_id": surface_id,
+        "variant_id": variant_id,
+        "scenario": scenario,
+        "format": output_format,
+        "qualification_policy": qualification_policy,
+        "chars": measurement["chars"],
+        "utf8_bytes": measurement["utf8_bytes"],
+        "lines": measurement["lines"],
+        "compact_payload_chars": measurement["compact_payload_chars"],
+        "pretty_print_overhead_chars": measurement["pretty_print_overhead_chars"],
+        "semantic_json_keys": list(semantic_json_keys),
+        "json_shape_paths": (
+            semantics.json_shape_paths(payload) if isinstance(payload, dict) else []
+        ),
+        "markdown_headings": semantics.markdown_headings(text),
+        "markdown_anchor": markdown_anchor,
+        "action_signature_sha256": (
+            semantics.action_signature_semantic_sha256(payload)
+            if isinstance(payload, dict)
+            else None
+        ),
+    }
+
+
+def _default_rows(
+    probe: ModuleType,
+    semantics: ModuleType,
+    fixture_root: Path,
+) -> list[dict]:
+    rows: list[dict] = []
+    for scenario in probe.SCENARIOS:
+        project, runtime, registry_path, state_file = probe._write_fixture(
+            fixture_root / scenario.name,
+            scenario,
+        )
+        for output_format in ("json", "markdown"):
+            commands = probe._surface_commands(
+                project=project,
+                runtime=runtime,
+                registry_path=registry_path,
+                state_file=state_file,
+                output_format=output_format,
+            )
+            for surface_id, command in commands.items():
+                exit_code, text = probe._invoke_cli(command)
+                if exit_code != 0:
+                    raise AssertionError(f"{surface_id}/{output_format} failed")
+                measurement = probe.measure_cli_output(
+                    text, output_format=output_format
+                )
+                surface = probe.CLI_OUTPUT_BUDGET_BY_ID[surface_id]
+                probe.assert_cli_output_baseline(
+                    surface,
+                    scenario=scenario.name,
+                    output_format=output_format,
+                    text=text,
+                    measurement=measurement,
+                )
+                rows.append(
+                    _receipt_row(
+                        semantics=semantics,
+                        row_id=f"surface/{surface_id}/{scenario.name}/{output_format}",
+                        surface_id=surface_id,
+                        scenario=scenario.name,
+                        output_format=output_format,
+                        qualification_policy=surface.qualification_policy,
+                        semantic_json_keys=surface.semantic_json_keys,
+                        markdown_anchor=surface.markdown_anchor,
+                        measurement=measurement,
+                        text=text,
+                    )
+                )
+    return rows
+
+
+def _variant_rows(
+    probe: ModuleType,
+    semantics: ModuleType,
+    fixture_root: Path,
+) -> list[dict]:
+    project, runtime, registry_path, state_file = probe._write_fixture(
+        fixture_root / "mode_variants",
+        probe.SCENARIOS[0],
+    )
+    rows: list[dict] = []
+    for output_format in ("json", "markdown"):
+        commands = probe._mode_variant_commands(
+            project=project,
+            runtime=runtime,
+            registry_path=registry_path,
+            state_file=state_file,
+            output_format=output_format,
+        )
+        for variant_id, command in commands.items():
+            variant = probe.CLI_OUTPUT_MODE_VARIANT_BY_ID[variant_id]
+            if output_format not in variant.output_formats:
+                continue
+            exit_code, text = probe._invoke_cli(command)
+            if exit_code != 0:
+                raise AssertionError(f"{variant_id}/{output_format} failed")
+            measurement = probe.measure_cli_output(text, output_format=output_format)
+            probe.assert_cli_output_mode_variant(
+                variant,
+                output_format=output_format,
+                text=text,
+                measurement=measurement,
+            )
+            rows.append(
+                _receipt_row(
+                    semantics=semantics,
+                    row_id=f"variant/{variant_id}/small/{output_format}",
+                    surface_id=variant.parent_surface_id,
+                    variant_id=variant_id,
+                    scenario="small",
+                    output_format=output_format,
+                    qualification_policy="explicit_opt_in_cold_path",
+                    semantic_json_keys=variant.semantic_json_keys,
+                    markdown_anchor=variant.markdown_anchor,
+                    measurement=measurement,
+                    text=text,
+                )
+            )
+    return rows
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--test-source", type=Path, required=True)
+    parser.add_argument("--semantics-source", type=Path, required=True)
+    parser.add_argument("--fixture-root", type=Path, required=True)
+    parser.add_argument("--receipt", type=Path, required=True)
+    args = parser.parse_args()
+    _install_pytest_import_stub()
+    probe = _load_module("loopx_cli_output_probe_fixture", args.test_source)
+    semantics = _load_module("loopx_cli_output_probe_semantics", args.semantics_source)
+    if args.fixture_root.exists():
+        shutil.rmtree(args.fixture_root)
+    args.fixture_root.mkdir(parents=True)
+    rows = [
+        *_default_rows(probe, semantics, args.fixture_root),
+        *_variant_rows(probe, semantics, args.fixture_root),
+    ]
+    args.receipt.parent.mkdir(parents=True, exist_ok=True)
+    args.receipt.write_text(
+        json.dumps(
+            {
+                "schema_version": PROBE_SCHEMA_VERSION,
+                "fixture_contract_version": FIXTURE_CONTRACT_VERSION,
+                "rows": sorted(rows, key=lambda row: row["row_id"]),
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    print(f"cli-output-probe-runner ok rows={len(rows)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/canary/qualification_profiles.py
+++ b/loopx/canary/qualification_profiles.py
@@ -11,7 +11,11 @@ CONTROL_PLANE_QUALIFICATION_PROFILES: tuple[dict[str, Any], ...] = (
             "Run a bounded cross-state-machine canary when interaction, work-lane, "
             "scheduler, frontier, writeback, or quota-spend transitions change together."
         ),
-        "catalog_families": ["Work Routing", "State And Boundary", "Planning Governance"],
+        "catalog_families": [
+            "Work Routing",
+            "State And Boundary",
+            "Planning Governance",
+        ],
         "trigger_hints": (
             "state-machine",
             "state machine",
@@ -87,7 +91,11 @@ CONTROL_PLANE_QUALIFICATION_PROFILES: tuple[dict[str, Any], ...] = (
             "Run exact stdout budgets and fail-closed command classification when "
             "recurring agent-facing CLI surfaces or their qualification contract change."
         ),
-        "catalog_families": ["Work Routing", "State And Boundary", "Planning Governance"],
+        "catalog_families": [
+            "Work Routing",
+            "State And Boundary",
+            "Planning Governance",
+        ],
         "trigger_hints": (
             "agent-facing cli",
             "cli output budget",
@@ -105,6 +113,11 @@ CONTROL_PLANE_QUALIFICATION_PROFILES: tuple[dict[str, Any], ...] = (
             "loopx/evidence_log.py",
             "loopx/control_plane/testing/cli_output_budget.py",
             "tests/control_plane/test_cli_output_budget.py",
+            "tests/control_plane/test_cli_output_differential.py",
+            "loopx/control_plane/testing/cli_output_differential.py",
+            "loopx/control_plane/testing/cli_output_semantics.py",
+            "examples/control_plane/cli-output-probe-runner.py",
+            "examples/control_plane/cli-output-base-head-differential-smoke.py",
             "examples/control_plane/cli-output-budget-regression-smoke.py",
             ".github/workflows/python-tests.yml",
             "docs/interface-budget-contract.md",
@@ -115,7 +128,8 @@ CONTROL_PLANE_QUALIFICATION_PROFILES: tuple[dict[str, Any], ...] = (
                 "tier": "default",
                 "reason": (
                     "invokes the real CLI across declared JSON/Markdown surfaces, modes, "
-                    "fixture scales, semantic anchors, and command classifications"
+                    "fixture scales, semantic anchors, command classifications, and a "
+                    "same-fixture base/head structural and growth differential"
                 ),
             },
             {

--- a/loopx/control_plane/testing/cli_output_budget.py
+++ b/loopx/control_plane/testing/cli_output_budget.py
@@ -4,6 +4,12 @@ import json
 from dataclasses import dataclass
 from typing import Any, Literal
 
+from loopx.control_plane.testing.cli_output_semantics import (
+    action_signature_semantic_sha256,
+    json_shape_paths as collect_json_shape_paths,
+    markdown_headings,
+)
+
 
 CLI_OUTPUT_BUDGET_SCHEMA_VERSION = "loopx_cli_output_budget_v0"
 CLI_OUTPUT_MEASUREMENT_SCHEMA_VERSION = "loopx_cli_output_measurement_v0"
@@ -67,7 +73,12 @@ CLI_OUTPUT_BUDGET_SPECS: tuple[CliOutputBudgetSpec, ...] = (
         consumer_action="plan a goal start before any mutation",
         qualification_policy="baseline_and_growth",
         cold_path="packet_summary detail_refs and bootstrap-command-pack",
-        semantic_json_keys=("guided_transaction", "command_pack", "safety_contract", "packet_summary"),
+        semantic_json_keys=(
+            "guided_transaction",
+            "command_pack",
+            "safety_contract",
+            "packet_summary",
+        ),
         markdown_anchor="# Guided Start Goal",
         max_chars={
             "small": {"json": 64_000, "markdown": 3_200},
@@ -89,7 +100,12 @@ CLI_OUTPUT_BUDGET_SPECS: tuple[CliOutputBudgetSpec, ...] = (
         consumer_action="connect and activate one host loop",
         qualification_policy="baseline_and_growth",
         cold_path="message-only projection and packet_summary detail_refs",
-        semantic_json_keys=("commands", "goal_start_contract", "host_loop_activation", "packet_summary"),
+        semantic_json_keys=(
+            "commands",
+            "goal_start_contract",
+            "host_loop_activation",
+            "packet_summary",
+        ),
         markdown_anchor="# /loopx Bootstrap Command Pack",
         max_chars={
             "small": {"json": 45_000, "markdown": 14_500},
@@ -177,7 +193,11 @@ CLI_OUTPUT_BUDGET_SPECS: tuple[CliOutputBudgetSpec, ...] = (
         consumer_action="forward the smallest sufficient work packet",
         qualification_policy="absolute_hot_path",
         cold_path="full review-packet and run-history artifacts",
-        semantic_json_keys=("project_agent_handoff", "handoff_interface_budget", "within_budget"),
+        semantic_json_keys=(
+            "project_agent_handoff",
+            "handoff_interface_budget",
+            "within_budget",
+        ),
         markdown_anchor="quota should-run",
         max_chars={
             "small": {"json": 4_500, "markdown": 1_400},
@@ -335,7 +355,11 @@ CLI_OUTPUT_MODE_VARIANT_SPECS: tuple[CliOutputModeVariantSpec, ...] = (
         parent_surface_id="review_packet_handoff_only",
         command="review-packet",
         output_formats=("json", "markdown"),
-        semantic_json_keys=("goal_id", "project_agent_handoff", "handoff_interface_budget"),
+        semantic_json_keys=(
+            "goal_id",
+            "project_agent_handoff",
+            "handoff_interface_budget",
+        ),
         markdown_anchor="LoopX Review Packet",
         max_chars={"json": 11_000, "markdown": 2_000},
         max_lines={"json": 220, "markdown": 35},
@@ -494,6 +518,8 @@ def measure_cli_output(
 ) -> dict[str, Any]:
     payload: dict[str, Any] | None = None
     compact_payload_chars: int | None = None
+    json_shape_paths: list[str] = []
+    action_signature_sha256: str | None = None
     if output_format == "json":
         decoded = json.loads(text)
         if not isinstance(decoded, dict):
@@ -507,6 +533,8 @@ def measure_cli_output(
                 separators=(",", ":"),
             )
         )
+        json_shape_paths = collect_json_shape_paths(decoded)
+        action_signature_sha256 = action_signature_semantic_sha256(decoded)
     return {
         "schema_version": CLI_OUTPUT_MEASUREMENT_SCHEMA_VERSION,
         "format": output_format,
@@ -521,6 +549,9 @@ def measure_cli_output(
             if compact_payload_chars is not None
             else None
         ),
+        "json_shape_paths": json_shape_paths,
+        "markdown_headings": markdown_headings(text),
+        "action_signature_sha256": action_signature_sha256,
         "payload": payload,
     }
 

--- a/loopx/control_plane/testing/cli_output_differential.py
+++ b/loopx/control_plane/testing/cli_output_differential.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Literal
+
+
+CLI_OUTPUT_PROBE_SCHEMA_VERSION = "loopx_cli_output_probe_v0"
+CLI_OUTPUT_FIXTURE_CONTRACT_VERSION = "loopx_cli_output_public_fixture_v0"
+CLI_OUTPUT_DIFFERENTIAL_SCHEMA_VERSION = "loopx_cli_output_differential_v0"
+
+Metric = Literal["chars", "utf8_bytes", "lines", "compact_payload_chars"]
+
+
+@dataclass(frozen=True)
+class GrowthAllowance:
+    ratio: float
+    json: dict[Metric, int]
+    markdown: dict[Metric, int]
+
+
+_GROWTH_ALLOWANCE_BY_POLICY: dict[str, GrowthAllowance] = {
+    "absolute_hot_path": GrowthAllowance(
+        ratio=0.005,
+        json={"chars": 64, "utf8_bytes": 128, "lines": 2, "compact_payload_chars": 64},
+        markdown={
+            "chars": 32,
+            "utf8_bytes": 64,
+            "lines": 1,
+            "compact_payload_chars": 0,
+        },
+    ),
+    "baseline_and_growth": GrowthAllowance(
+        ratio=0.005,
+        json={
+            "chars": 128,
+            "utf8_bytes": 256,
+            "lines": 2,
+            "compact_payload_chars": 128,
+        },
+        markdown={
+            "chars": 64,
+            "utf8_bytes": 128,
+            "lines": 1,
+            "compact_payload_chars": 0,
+        },
+    ),
+    "explicit_limit_cold_path": GrowthAllowance(
+        ratio=0.01,
+        json={
+            "chars": 256,
+            "utf8_bytes": 512,
+            "lines": 3,
+            "compact_payload_chars": 256,
+        },
+        markdown={
+            "chars": 128,
+            "utf8_bytes": 256,
+            "lines": 2,
+            "compact_payload_chars": 0,
+        },
+    ),
+    "explicit_opt_in_cold_path": GrowthAllowance(
+        ratio=0.01,
+        json={
+            "chars": 256,
+            "utf8_bytes": 512,
+            "lines": 3,
+            "compact_payload_chars": 256,
+        },
+        markdown={
+            "chars": 128,
+            "utf8_bytes": 256,
+            "lines": 2,
+            "compact_payload_chars": 0,
+        },
+    ),
+}
+
+
+def _rows_by_id(receipt: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    if receipt.get("schema_version") != CLI_OUTPUT_PROBE_SCHEMA_VERSION:
+        raise ValueError("CLI output probe receipt has an unsupported schema_version")
+    if receipt.get("fixture_contract_version") != CLI_OUTPUT_FIXTURE_CONTRACT_VERSION:
+        raise ValueError(
+            "CLI output probe receipt has an unsupported fixture_contract_version"
+        )
+    rows = receipt.get("rows")
+    if not isinstance(rows, list):
+        raise ValueError("CLI output probe receipt rows must be a list")
+    indexed: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        if not isinstance(row, dict) or not isinstance(row.get("row_id"), str):
+            raise ValueError("CLI output probe row must be an object with row_id")
+        row_id = row["row_id"]
+        if row_id in indexed:
+            raise ValueError(f"duplicate CLI output probe row_id: {row_id}")
+        indexed[row_id] = row
+    return indexed
+
+
+def _growth_limit(*, policy: str, output_format: str, metric: Metric, base: int) -> int:
+    allowance = _GROWTH_ALLOWANCE_BY_POLICY.get(policy)
+    if allowance is None:
+        raise ValueError(f"unsupported CLI output qualification policy: {policy}")
+    floors = allowance.json if output_format == "json" else allowance.markdown
+    return max(floors[metric], math.ceil(base * allowance.ratio))
+
+
+def _removed(base: dict[str, Any], candidate: dict[str, Any], field: str) -> list[str]:
+    base_values = {str(value) for value in base.get(field, [])}
+    candidate_values = {str(value) for value in candidate.get(field, [])}
+    return sorted(base_values - candidate_values)
+
+
+def _compare_row(base: dict[str, Any], candidate: dict[str, Any]) -> dict[str, Any]:
+    row_id = str(base["row_id"])
+    failures: list[str] = []
+    review_signals: list[str] = []
+    policy = str(base.get("qualification_policy") or "")
+    output_format = str(base.get("format") or "")
+    if candidate.get("qualification_policy") != policy:
+        failures.append("qualification_policy changed")
+    if candidate.get("format") != output_format:
+        failures.append("format changed")
+
+    deltas: dict[str, int | None] = {}
+    allowances: dict[str, int | None] = {}
+    for metric in ("chars", "utf8_bytes", "lines", "compact_payload_chars"):
+        base_value = base.get(metric)
+        candidate_value = candidate.get(metric)
+        if not isinstance(base_value, int) or not isinstance(candidate_value, int):
+            deltas[metric] = None
+            allowances[metric] = None
+            continue
+        delta = candidate_value - base_value
+        allowance = _growth_limit(
+            policy=policy,
+            output_format=output_format,
+            metric=metric,
+            base=base_value,
+        )
+        deltas[metric] = delta
+        allowances[metric] = allowance
+        if delta > allowance:
+            failures.append(f"{metric} grew by {delta}; allowance is {allowance}")
+
+    for field in ("semantic_json_keys",):
+        missing = _removed(base, candidate, field)
+        if missing:
+            preview = ", ".join(missing[:5])
+            suffix = f" (+{len(missing) - 5} more)" if len(missing) > 5 else ""
+            failures.append(f"{field} removed: {preview}{suffix}")
+
+    for field in ("json_shape_paths", "markdown_headings"):
+        missing = _removed(base, candidate, field)
+        if missing:
+            preview = ", ".join(missing[:5])
+            suffix = f" (+{len(missing) - 5} more)" if len(missing) > 5 else ""
+            review_signals.append(f"{field} removed: {preview}{suffix}")
+
+    base_anchor = base.get("markdown_anchor")
+    if base_anchor and candidate.get("markdown_anchor") != base_anchor:
+        failures.append("markdown_anchor changed")
+    base_signature = base.get("action_signature_sha256")
+    if base_signature and candidate.get("action_signature_sha256") != base_signature:
+        failures.append("action_signature semantic digest changed")
+
+    return {
+        "row_id": row_id,
+        "status": "failed" if failures else "passed",
+        "deltas": deltas,
+        "allowances": allowances,
+        "failures": failures,
+        "review_signals": review_signals,
+    }
+
+
+def compare_cli_output_receipts(
+    base_receipt: dict[str, Any],
+    candidate_receipt: dict[str, Any],
+) -> dict[str, Any]:
+    base_rows = _rows_by_id(base_receipt)
+    candidate_rows = _rows_by_id(candidate_receipt)
+    results: list[dict[str, Any]] = []
+    for row_id in sorted(base_rows.keys() | candidate_rows.keys()):
+        base = base_rows.get(row_id)
+        candidate = candidate_rows.get(row_id)
+        if base is None:
+            results.append(
+                {
+                    "row_id": row_id,
+                    "status": "candidate_only",
+                    "deltas": {},
+                    "allowances": {},
+                    "failures": [],
+                    "review_signals": [],
+                }
+            )
+        elif candidate is None:
+            results.append(
+                {
+                    "row_id": row_id,
+                    "status": "failed",
+                    "deltas": {},
+                    "allowances": {},
+                    "failures": ["qualified base row is missing from candidate"],
+                    "review_signals": [],
+                }
+            )
+        else:
+            results.append(_compare_row(base, candidate))
+
+    failed_rows = [row for row in results if row["status"] == "failed"]
+    review_rows = [row for row in results if row["review_signals"]]
+    return {
+        "schema_version": CLI_OUTPUT_DIFFERENTIAL_SCHEMA_VERSION,
+        "ok": not failed_rows,
+        "base_row_count": len(base_rows),
+        "candidate_row_count": len(candidate_rows),
+        "compared_row_count": len(results),
+        "failed_row_count": len(failed_rows),
+        "review_required": bool(review_rows),
+        "review_row_count": len(review_rows),
+        "candidate_only_row_count": sum(
+            row["status"] == "candidate_only" for row in results
+        ),
+        "rows": results,
+    }

--- a/loopx/control_plane/testing/cli_output_semantics.py
+++ b/loopx/control_plane/testing/cli_output_semantics.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any
+
+
+_MARKDOWN_HEADING = re.compile(r"^#{1,6}\s+.+$")
+
+
+def json_shape_paths(value: Any, *, path: str = "$") -> list[str]:
+    paths = {path}
+    if isinstance(value, dict):
+        for key, child in value.items():
+            paths.update(json_shape_paths(child, path=f"{path}.{key}"))
+    elif isinstance(value, list):
+        list_path = f"{path}[]"
+        paths.add(list_path)
+        for child in value:
+            paths.update(json_shape_paths(child, path=list_path))
+    return sorted(paths)
+
+
+def action_signature_semantic_sha256(value: Any) -> str | None:
+    signatures: list[dict[str, Any]] = []
+
+    def collect(current: Any, *, path: str) -> None:
+        if isinstance(current, dict):
+            for key, child in current.items():
+                child_path = f"{path}.{key}"
+                if key == "action_signature":
+                    normalized = child
+                    if isinstance(child, dict):
+                        normalized = {
+                            "schema_version": child.get("schema_version"),
+                            "coverage": child.get("coverage"),
+                            "matches": child.get("matches"),
+                            "source_envelope_match": (
+                                child.get("source_hash") == child.get("envelope_hash")
+                            ),
+                            "fields": sorted(child),
+                        }
+                    signatures.append({"path": child_path, "value": normalized})
+                collect(child, path=child_path)
+        elif isinstance(current, list):
+            for child in current:
+                collect(child, path=f"{path}[]")
+
+    collect(value, path="$")
+    if not signatures:
+        return None
+    canonical = json.dumps(
+        signatures,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def markdown_headings(text: str) -> list[str]:
+    return [line.strip() for line in text.splitlines() if _MARKDOWN_HEADING.match(line)]

--- a/loopx/control_plane/testing/cli_output_semantics.py
+++ b/loopx/control_plane/testing/cli_output_semantics.py
@@ -36,10 +36,15 @@ def action_signature_semantic_sha256(value: Any) -> str | None:
                             "schema_version": child.get("schema_version"),
                             "coverage": child.get("coverage"),
                             "matches": child.get("matches"),
+                            "source_envelope_hashes_present": (
+                                "source_hash" in child and "envelope_hash" in child
+                            ),
                             "source_envelope_match": (
                                 child.get("source_hash") == child.get("envelope_hash")
                             ),
-                            "fields": sorted(child),
+                            "source_decision_hash_present": (
+                                "source_decision_hash" in child
+                            ),
                         }
                     signatures.append({"path": child_path, "value": normalized})
                 collect(child, path=child_path)

--- a/tests/control_plane/test_cli_output_differential.py
+++ b/tests/control_plane/test_cli_output_differential.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+
+from loopx.control_plane.testing.cli_output_budget import measure_cli_output
+from loopx.control_plane.testing.cli_output_differential import (
+    CLI_OUTPUT_FIXTURE_CONTRACT_VERSION,
+    CLI_OUTPUT_PROBE_SCHEMA_VERSION,
+    compare_cli_output_receipts,
+)
+
+
+def _row(**overrides: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "row_id": "surface/status/small/json",
+        "surface_id": "status",
+        "variant_id": None,
+        "scenario": "small",
+        "format": "json",
+        "qualification_policy": "absolute_hot_path",
+        "chars": 40_000,
+        "utf8_bytes": 40_000,
+        "lines": 1_000,
+        "compact_payload_chars": 20_000,
+        "semantic_json_keys": ["status_contract", "attention_queue"],
+        "json_shape_paths": ["$", "$.status_contract", "$.attention_queue"],
+        "markdown_headings": [],
+        "markdown_anchor": "# LoopX Status",
+        "action_signature_sha256": "semantic-signature",
+    }
+    row.update(overrides)
+    return row
+
+
+def _receipt(*rows: dict[str, object]) -> dict[str, object]:
+    return {
+        "schema_version": CLI_OUTPUT_PROBE_SCHEMA_VERSION,
+        "fixture_contract_version": CLI_OUTPUT_FIXTURE_CONTRACT_VERSION,
+        "rows": list(rows),
+    }
+
+
+def test_measurement_records_semantic_shape_without_runtime_hash_noise() -> None:
+    def payload(runtime_hash: str, source_hash: str) -> str:
+        return json.dumps(
+            {
+                "action": {"todo_id": "todo_fixture"},
+                "action_signature": {
+                    "schema_version": "loopx_action_signature_v0",
+                    "coverage": ["action", "writeback"],
+                    "source_hash": runtime_hash,
+                    "envelope_hash": runtime_hash,
+                    "source_decision_hash": source_hash,
+                    "matches": True,
+                },
+            }
+        )
+
+    first = measure_cli_output(
+        payload("first-runtime", "first-source"), output_format="json"
+    )
+    second = measure_cli_output(
+        payload("second-runtime", "second-source"),
+        output_format="json",
+    )
+    assert "$.action.todo_id" in first["json_shape_paths"]
+    assert first["action_signature_sha256"] == second["action_signature_sha256"]
+
+    markdown = measure_cli_output(
+        "# LoopX Status\n\n## Attention Queue\n",
+        output_format="markdown",
+    )
+    assert markdown["markdown_headings"] == ["# LoopX Status", "## Attention Queue"]
+
+
+def test_unchanged_large_inherited_baseline_passes() -> None:
+    base = _receipt(_row())
+    result = compare_cli_output_receipts(base, copy.deepcopy(base))
+    assert result["ok"] is True
+    assert result["failed_row_count"] == 0
+
+
+def test_growth_above_policy_allowance_fails() -> None:
+    base = _receipt(_row())
+    candidate = _receipt(_row(chars=41_000))
+    result = compare_cli_output_receipts(base, candidate)
+    assert result["ok"] is False
+    assert "chars grew" in result["rows"][0]["failures"][0]
+
+
+def test_shrink_with_semantic_shape_retained_passes() -> None:
+    base = _receipt(_row())
+    candidate = _receipt(
+        _row(chars=20_000, utf8_bytes=20_000, lines=500, compact_payload_chars=10_000)
+    )
+    assert compare_cli_output_receipts(base, candidate)["ok"] is True
+
+
+@pytest.mark.parametrize(
+    ("candidate", "failure_fragment"),
+    [
+        (_row(semantic_json_keys=["status_contract"]), "semantic_json_keys removed"),
+        (
+            _row(action_signature_sha256="changed"),
+            "action_signature semantic digest changed",
+        ),
+    ],
+)
+def test_smaller_candidate_still_fails_when_semantics_are_removed(
+    candidate: dict[str, object],
+    failure_fragment: str,
+) -> None:
+    candidate.update(chars=20_000, utf8_bytes=20_000, lines=500)
+    result = compare_cli_output_receipts(_receipt(_row()), _receipt(candidate))
+    assert result["ok"] is False
+    assert any(failure_fragment in failure for failure in result["rows"][0]["failures"])
+
+
+def test_observed_shape_removal_is_a_review_signal_not_a_permanent_red_light() -> None:
+    candidate = _row(json_shape_paths=["$", "$.status_contract"])
+    candidate.update(chars=20_000, utf8_bytes=20_000, lines=500)
+    result = compare_cli_output_receipts(_receipt(_row()), _receipt(candidate))
+    assert result["ok"] is True
+    assert result["review_required"] is True
+    assert "json_shape_paths removed" in result["rows"][0]["review_signals"][0]
+
+
+def test_markdown_heading_removal_requires_review() -> None:
+    base_row = _row(
+        row_id="surface/status/small/markdown",
+        format="markdown",
+        chars=2_000,
+        utf8_bytes=2_000,
+        lines=30,
+        compact_payload_chars=None,
+        semantic_json_keys=[],
+        json_shape_paths=[],
+        markdown_headings=["# LoopX Status", "## Attention Queue"],
+        action_signature_sha256=None,
+    )
+    candidate = copy.deepcopy(base_row)
+    candidate["markdown_headings"] = ["# LoopX Status"]
+    result = compare_cli_output_receipts(_receipt(base_row), _receipt(candidate))
+    assert result["ok"] is True
+    assert result["review_required"] is True
+    assert "markdown_headings removed" in result["rows"][0]["review_signals"][0]
+
+
+def test_candidate_only_row_is_allowed_but_base_row_removal_fails() -> None:
+    extra = _row(row_id="surface/new/small/json", surface_id="new")
+    candidate_only = compare_cli_output_receipts(_receipt(), _receipt(extra))
+    assert candidate_only["ok"] is True
+    assert candidate_only["candidate_only_row_count"] == 1
+
+    removed = compare_cli_output_receipts(_receipt(_row()), _receipt())
+    assert removed["ok"] is False
+    assert "missing from candidate" in removed["rows"][0]["failures"][0]
+
+
+def test_fixture_contract_mismatch_fails_closed() -> None:
+    candidate = _receipt(_row())
+    candidate["fixture_contract_version"] = "different"
+    with pytest.raises(ValueError, match="fixture_contract_version"):
+        compare_cli_output_receipts(_receipt(_row()), candidate)

--- a/tests/control_plane/test_cli_output_differential.py
+++ b/tests/control_plane/test_cli_output_differential.py
@@ -69,6 +69,20 @@ def test_measurement_records_semantic_shape_without_runtime_hash_noise() -> None
     assert "$.action.todo_id" in first["json_shape_paths"]
     assert first["action_signature_sha256"] == second["action_signature_sha256"]
 
+    with_observability_field = json.loads(payload("third-runtime", "third-source"))
+    with_observability_field["action_signature"]["diagnostic_note"] = "new"
+    third = measure_cli_output(
+        json.dumps(with_observability_field),
+        output_format="json",
+    )
+    assert first["action_signature_sha256"] == third["action_signature_sha256"]
+
+    without_hash_pair = json.loads(payload("fourth-runtime", "fourth-source"))
+    del without_hash_pair["action_signature"]["source_hash"]
+    del without_hash_pair["action_signature"]["envelope_hash"]
+    fourth = measure_cli_output(json.dumps(without_hash_pair), output_format="json")
+    assert first["action_signature_sha256"] != fourth["action_signature_sha256"]
+
     markdown = measure_cli_output(
         "# LoopX Status\n\n## Attention Queue\n",
         output_format="markdown",


### PR DESCRIPTION
## Summary
- run the same public CLI fixture against `origin/main` and the candidate checkout
- hard-fail unreviewed growth, declared semantic-key loss, action-signature contract drift, and removed qualified surfaces
- surface observed JSON-path and Markdown-heading changes as review signals so intentional refactors remain possible
- wire the differential into the existing canary profile and named Python CI qualification step

## Validation
- `uvx --with pytest pytest -q tests/control_plane/test_cli_output_differential.py tests/control_plane/test_cli_output_budget.py` (16 passed)
- `python3 examples/control_plane/cli-output-budget-regression-smoke.py` (75 base / 75 candidate rows, 0 review signals)
- `loopx canary premerge --from-git-diff` (14 checks passed; no failures, warnings, skips, or manual holds)
- `loopx check` public-boundary scan clean

## Scope
Validation infrastructure only. This PR does not reduce or otherwise change production CLI output.