### PR TITLE
Make CLI output smokes self-contained

### DIFF
--- a/examples/control_plane/cli-output-base-head-differential-smoke.py
+++ b/examples/control_plane/cli-output-base-head-differential-smoke.py
@@ -12,12 +12,16 @@ import sys
 import tempfile
 from pathlib import Path
 
-from loopx.control_plane.testing.cli_output_differential import (
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.testing.cli_output_differential import (  # noqa: E402
     compare_cli_output_receipts,
 )
 
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
 PROBE_TEST = REPO_ROOT / "tests" / "control_plane" / "test_cli_output_budget.py"
 PROBE_RUNNER = REPO_ROOT / "examples" / "control_plane" / "cli-output-probe-runner.py"
 SEMANTICS_SOURCE = (

--- a/examples/control_plane/cli-output-budget-regression-smoke.py
+++ b/examples/control_plane/cli-output-budget-regression-smoke.py
@@ -3,13 +3,17 @@
 
 from __future__ import annotations
 
-import shutil
+import runpy
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 TEST_PATH = REPO_ROOT / "tests" / "control_plane" / "test_cli_output_budget.py"
 DIFFERENTIAL_SMOKE = (
     REPO_ROOT
@@ -19,18 +23,20 @@ DIFFERENTIAL_SMOKE = (
 )
 
 
-def _pytest_command() -> list[str]:
-    try:
-        import pytest  # noqa: F401
-    except Exception:
-        uvx = shutil.which("uvx")
-        if uvx:
-            return [uvx, "--with", "pytest>=8,<9", "pytest"]
-        raise RuntimeError(
-            "cli-output-budget-regression-smoke requires pytest or uvx; "
-            "qualification fails closed when neither runner is available"
-        ) from None
-    return [sys.executable, "-m", "pytest"]
+def _run_budget_checks() -> None:
+    tests = runpy.run_path(str(TEST_PATH))
+    tests["test_manifest_covers_the_declared_agent_facing_surface_set"]()
+    with tempfile.TemporaryDirectory(prefix="loopx-cli-output-budget-") as temp_dir:
+        root = Path(temp_dir)
+        tests["test_real_cli_output_stays_inside_the_characterized_baseline"](
+            root / "scenarios"
+        )
+        tests["test_collection_growth_and_bootstrap_duplication_are_explicit"](
+            root / "growth"
+        )
+        tests["test_explicit_compact_and_detail_modes_are_characterized"](
+            root / "mode-variants"
+        )
 
 
 def main() -> int:
@@ -38,21 +44,7 @@ def main() -> int:
         raise RuntimeError(
             f"missing CLI output budget test: {TEST_PATH.relative_to(REPO_ROOT)}"
         )
-    completed = subprocess.run(
-        [*_pytest_command(), "-q", str(TEST_PATH.relative_to(REPO_ROOT))],
-        cwd=REPO_ROOT,
-        check=False,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        timeout=180,
-    )
-    if completed.returncode != 0:
-        raise AssertionError(
-            "agent-facing CLI output qualification failed\n"
-            f"stdout:\n{completed.stdout[-3000:]}\n"
-            f"stderr:\n{completed.stderr[-3000:]}"
-        )
+    _run_budget_checks()
     completed = subprocess.run(
         [sys.executable, str(DIFFERENTIAL_SMOKE.relative_to(REPO_ROOT))],
         cwd=REPO_ROOT,

--- a/tests/control_plane/test_cli_output_budget.py
+++ b/tests/control_plane/test_cli_output_budget.py
@@ -7,8 +7,6 @@ import shlex
 from dataclasses import dataclass
 from pathlib import Path
 
-import pytest
-
 from loopx.cli import main as cli_main
 from loopx.control_plane.testing.cli_output_budget import (
     CLI_OUTPUT_BUDGET_BY_ID,
@@ -505,16 +503,15 @@ def test_manifest_covers_the_declared_agent_facing_surface_set() -> None:
             assert classification.surface_id is None
 
 
-@pytest.mark.parametrize("scenario", SCENARIOS, ids=lambda scenario: scenario.name)
 def test_real_cli_output_stays_inside_the_characterized_baseline(
     tmp_path: Path,
-    scenario: Scenario,
 ) -> None:
-    results = _measure_scenario(tmp_path, scenario)
-    for formats in results.values():
-        assert formats["json"]["json_parseable"] is True
-        assert formats["json"]["pretty_print_overhead_chars"] > 0
-        assert formats["markdown"]["json_parseable"] is False
+    for scenario in SCENARIOS:
+        results = _measure_scenario(tmp_path / scenario.name, scenario)
+        for formats in results.values():
+            assert formats["json"]["json_parseable"] is True
+            assert formats["json"]["pretty_print_overhead_chars"] > 0
+            assert formats["markdown"]["json_parseable"] is False
 
 
 def test_collection_growth_and_bootstrap_duplication_are_explicit(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- bootstrap the repository import path before the differential smoke imports LoopX
- execute the existing CLI output budget assertions with the standard library in public smokes
- keep pytest coverage while removing the public smoke dependency on pytest or uvx

## Validation

- focused ruff checks
- 14 focused pytest tests
- both affected smoke scripts in a no-pytest/uvx environment
- full-public shard offset 200 limit 100: 100/100 passed
- LoopX premerge canary standard tier: passed, self-merge allowed
- public/private boundary scan: passed