### PR TITLE
Project capability repair in diagnose

### DIFF
--- a/examples/agent-diagnose-packet-smoke.py
+++ b/examples/agent-diagnose-packet-smoke.py
@@ -407,9 +407,19 @@ def main() -> int:
             "--agent-id",
             "codex-main-control",
         )
-        assert capability_blocked["selected"]["machine_signal"] == "user_or_controller_attention", (
+        capability_blocked_selected = capability_blocked["selected"]
+        assert (
+            capability_blocked_selected["machine_signal"]
+            == "capability_repair_attention"
+        ), capability_blocked
+        capability_blocked_quota = capability_blocked_selected["quota_signals"]
+        assert capability_blocked_quota["capability_repair_allowed"] is True, (
             capability_blocked
         )
+        assert capability_blocked_quota["requires_user_action"] is False, (
+            capability_blocked
+        )
+        assert capability_blocked_quota["action_required"] is False, capability_blocked
 
         capability_ready = run_cli(
             "--registry",

--- a/loopx/diagnose.py
+++ b/loopx/diagnose.py
@@ -171,6 +171,8 @@ def _machine_signal(*, status_payload: dict[str, Any], item: dict[str, Any] | No
     user_summary = _todo_summary(quota, item, role="user")
     if _quota_user_action_required(quota) or _open_count(user_summary) > 0:
         return "user_or_controller_attention"
+    if quota.get("capability_repair_allowed"):
+        return "capability_repair_attention"
     if quota.get("self_repair_allowed"):
         return "self_repair_attention"
     if quota.get("recovery_delivery_allowed"):
@@ -236,6 +238,7 @@ def _compact_quota_signals(quota: dict[str, Any]) -> dict[str, Any]:
         "actionable_by_codex",
         "normal_delivery_allowed",
         "recovery_delivery_allowed",
+        "capability_repair_allowed",
         "self_repair_allowed",
         "safe_bypass_allowed",
         "safe_bypass_kind",


### PR DESCRIPTION
## Summary

- classify agent-owned capability bridge work as capability repair attention in diagnose packets
- preserve capability_repair_allowed in compact quota evidence
- update the diagnosis smoke to assert agent repair without a user gate

## Root cause

PR #2150 changed runtime capabilities such as network from owner-held gates to agent-owned capability bridge repair, but the diagnosis projection and its smoke retained the older user-attention expectation.

## Validation

- focused Ruff checks
- agent diagnose packet smoke
- focused diagnostics pytest: 2 passed
- full-public shard offset 0 limit 100: 100/100 passed
- LoopX standard premerge canary and public-boundary check: passed