### PR TITLE
Compact guided start-goal output without dropping host actions

### DIFF
--- a/docs/reference/protocols/codex-app-host-command-registry-v0.md
+++ b/docs/reference/protocols/codex-app-host-command-registry-v0.md
@@ -155,6 +155,16 @@ The packet may be rendered to the agent prompt, passed to a tool call, or used
 to run the CLI directly. It must not contain raw transcripts, credentials,
 private document bodies, or local absolute paths in user-visible output.
 
+`loopx start-goal --guided` defaults to a compact command-pack projection. The
+hot path keeps the ordered transaction, planning contract, safety contract,
+goal and agent identity, action commands, host activation contract, and an
+executable cold-path command. It does not nest the complete bootstrap message,
+slash-command discovery catalog, or repeated connection and next-step
+diagnostics a second time. Consumers that genuinely need those lower-level
+fields can rerun the advertised command or pass
+`--include-command-pack-detail`. Both modes must produce the same host-action
+projection before a compact default is promoted.
+
 ## Permission Boundary
 
 Host command parsing does not grant new LoopX authority. It only converts
@@ -190,6 +200,7 @@ loopx agent-onboard --list-agent-types
 loopx agent-onboard --agent-type codex-cli --project .
 loopx bootstrap-command-pack --project .
 loopx start-goal --guided --project . --goal-text "<goal text>"
+loopx --format json start-goal --guided --project . --goal-text "<goal text>" --include-command-pack-detail
 loopx bootstrap-command-pack --project . --goal-text "<goal text>"
 loopx pr-review
 loopx global-summary

--- a/docs/reference/protocols/model-behavior-qualification-v0.md
+++ b/docs/reference/protocols/model-behavior-qualification-v0.md
@@ -171,6 +171,13 @@ the currently shipped default `start-goal --guided` packet. The qualification
 does not retain a retired full-detail implementation as a second product
 contract.
 
+The regular Doubao onboarding profile rejects packets with
+`command_pack_detail_included=true` before any provider call. The explicit
+`--include-command-pack-detail` recovery path remains a supported diagnostic
+contract, but its restoration and semantic parity are covered only by
+deterministic tests. It is not a regular Doubao scenario, corpus member, or
+repetition arm.
+
 The closed loop checks three decisions:
 
 1. the entry turn must select `connect_if_needed` from the actual default
@@ -202,10 +209,11 @@ receipt digests. Packets, observations, model responses, local paths, and
 credentials are not retained. It always sets
 `automatic_release_promotion_allowed=false`.
 
-For a sensitive behavior-changing pull request, maintainers may additionally
-run a temporary base/candidate differential evaluation. That comparison is PR
-evidence, not a merged API, fixture, or permanent test arm. Once the candidate
-becomes the default, the one-arm qualification follows the new actual packet;
+For a sensitive behavior-changing pull request, the one-arm qualification runs
+against the candidate checkout's actual default packet. A separate generic
+packet-ablation tool may still be used for targeted diagnosis, but the
+full-detail recovery path must not become its baseline arm. Once the candidate
+becomes the default, the same one-arm qualification follows that packet;
 changing the independent behavior invariants remains an explicit reviewable
 contract change.
 
@@ -220,7 +228,9 @@ stochastic output.
 
 This contract is one gate in a larger promotion process. Turning a candidate
 packet into the default requires deterministic state-matrix parity, a complete
-field-classification ledger, repeated paired model runs over representative and
-counterfactual states, zero safety drift, bounded behavioral drift, and explicit
-owner review. Missing provider access, an unknown schema, or incomplete
+field-classification ledger, repeated model evidence using the profile's
+declared topology, zero safety drift, bounded behavioral drift, and explicit
+owner review. The onboarding profile uses the actual-default one arm; generic
+packet projection evaluation may use paired or counterfactual cases. Missing
+provider access, an unknown schema, or incomplete
 evidence keeps the full packet as the default.

--- a/examples/bootstrap-command-pack-smoke.py
+++ b/examples/bootstrap-command-pack-smoke.py
@@ -35,6 +35,7 @@ def assert_packet_summary_refs(
     payload: dict[str, object],
     *,
     packet_kind: str,
+    compact_projection_default: bool = False,
 ) -> dict[str, object]:
     summary = payload["packet_summary"]
     assert isinstance(summary, dict)
@@ -43,8 +44,8 @@ def assert_packet_summary_refs(
     compatibility = summary["compatibility"]
     assert isinstance(compatibility, dict)
     assert compatibility == {
-        "legacy_fields_retained": True,
-        "compact_projection_default": False,
+        "legacy_fields_retained": not compact_projection_default,
+        "compact_projection_default": compact_projection_default,
         "removal_gate": "explicit_host_shadow_parity",
     }
     detail_refs = summary["detail_refs"]
@@ -278,7 +279,11 @@ def test_start_goal_guided_previews_transaction_without_mutation() -> None:
         assert payload["guided"] is True
         assert payload["goal_text"] == "Connect this repo and start an auto research lane"
         assert payload["goal_id"] == "guided-goal"
-        summary = assert_packet_summary_refs(payload, packet_kind="guided_start_goal")
+        summary = assert_packet_summary_refs(
+            payload,
+            packet_kind="guided_start_goal",
+            compact_projection_default=True,
+        )
         assert summary["objective"] == "Connect this repo and start an auto research lane"
         assert summary["next_step_kind"] == "goal_plan_write_and_activate"
         detail_refs = summary["detail_refs"]
@@ -328,6 +333,9 @@ def test_start_goal_guided_previews_transaction_without_mutation() -> None:
         command_pack = payload["command_pack"]
         assert isinstance(command_pack, dict)
         assert command_pack["schema_version"] == "loopx_bootstrap_command_pack_v0"
+        assert command_pack["projection_schema_version"] == "loopx_guided_command_pack_projection_v0"
+        assert command_pack["projection_mode"] == "guided_start_compatibility"
+        assert "--include-command-pack-detail" in str(command_pack["detail_command"])
         assert command_pack["goal_start_contract"]["planner"]["required_before_todo_write"] is True
         assert not (project / ".loopx").exists()
         assert not (project / ".codex").exists()
@@ -396,7 +404,11 @@ def test_start_goal_guided_requires_explicit_goal_for_multi_goal_project() -> No
             ], choice
         assert payload["safety_contract"]["writes_registry"] is False, payload
         assert payload["safety_contract"]["creates_heartbeat"] is False, payload
-        assert_packet_summary_refs(payload, packet_kind="guided_start_goal")
+        assert_packet_summary_refs(
+            payload,
+            packet_kind="guided_start_goal",
+            compact_projection_default=True,
+        )
 
 
 def test_connected_project_reuses_existing_state() -> None:

--- a/examples/control_plane/cli-output-probe-runner.py
+++ b/examples/control_plane/cli-output-probe-runner.py
@@ -152,7 +152,11 @@ def _variant_rows(
             output_format=output_format,
         )
         for variant_id, command in commands.items():
-            variant = probe.CLI_OUTPUT_MODE_VARIANT_BY_ID[variant_id]
+            variant = probe.CLI_OUTPUT_MODE_VARIANT_BY_ID.get(variant_id)
+            if variant is None:
+                # The shared candidate fixture may name a mode introduced after
+                # the detached base. Candidate-only rows are qualified later.
+                continue
             if output_format not in variant.output_formats:
                 continue
             exit_code, text = probe._invoke_cli(command)

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -25,6 +25,9 @@ GOAL_START_SCHEMA_VERSION = "loopx_goal_start_command_v0"
 GUIDED_START_SCHEMA_VERSION = "loopx_start_goal_guided_v0"
 PACKET_SUMMARY_SCHEMA_VERSION = "loopx_start_goal_packet_summary_v0"
 PACKET_MEASUREMENT_SCHEMA_VERSION = "loopx_packet_duplication_measurement_v0"
+GUIDED_COMMAND_PACK_PROJECTION_SCHEMA_VERSION = (
+    "loopx_guided_command_pack_projection_v0"
+)
 
 
 def _iter_string_leaves(
@@ -118,6 +121,8 @@ def _build_packet_summary(
     *,
     packet_kind: str,
     detail_refs: dict[str, str],
+    legacy_fields_retained: bool = True,
+    compact_projection_default: bool = False,
 ) -> dict[str, Any]:
     next_step = payload.get("recommended_next_step")
     next_step = next_step if isinstance(next_step, dict) else {}
@@ -135,8 +140,8 @@ def _build_packet_summary(
             for name, pointer in detail_refs.items()
         },
         "compatibility": {
-            "legacy_fields_retained": True,
-            "compact_projection_default": False,
+            "legacy_fields_retained": legacy_fields_retained,
+            "compact_projection_default": compact_projection_default,
             "removal_gate": "explicit_host_shadow_parity",
         },
         "duplication_measurement": _measure_packet_duplication(
@@ -146,6 +151,68 @@ def _build_packet_summary(
             else None,
         ),
     }
+
+
+def _start_goal_detail_command(
+    *,
+    project: str,
+    goal_id: str | None,
+    agent_id: str | None,
+    cli_bin: str,
+    host_surface: str,
+    goal_text: str,
+    available_capabilities: list[str] | None,
+) -> str:
+    return (
+        f"{shell_arg(cli_bin)} --format json start-goal --guided "
+        f"--project {shell_arg(project)}"
+        + (f" --goal-id {shell_arg(goal_id)}" if goal_id else "")
+        + (f" --agent-id {shell_arg(agent_id)}" if agent_id else "")
+        + f" --host-surface {shell_arg(host_surface)}"
+        + render_available_capability_args(available_capabilities)
+        + f" --goal-text {shell_arg(goal_text)}"
+        + " --include-command-pack-detail"
+    )
+
+
+def _guided_command_pack_projection(
+    command_pack: dict[str, Any],
+    *,
+    detail_command: str,
+) -> dict[str, Any]:
+    """Keep the guided hot path actionable without nesting the full host packet."""
+
+    projection: dict[str, Any] = {
+        "ok": command_pack.get("ok"),
+        "schema_version": command_pack.get("schema_version"),
+        "projection_schema_version": GUIDED_COMMAND_PACK_PROJECTION_SCHEMA_VERSION,
+        "projection_mode": "guided_start_compatibility",
+        "read_only": command_pack.get("read_only"),
+        "project": command_pack.get("project"),
+        "goal_id": command_pack.get("goal_id"),
+        "agent_id": command_pack.get("agent_id"),
+        "host_surface": command_pack.get("host_surface"),
+        "goal_text": command_pack.get("goal_text"),
+        "goal_start_contract": command_pack.get("goal_start_contract"),
+        "commands": command_pack.get("commands"),
+        "host_loop_activation": command_pack.get("host_loop_activation"),
+        "safety_contract": command_pack.get("safety_contract"),
+        "detail_command": detail_command,
+    }
+    projection["packet_summary"] = _build_packet_summary(
+        projection,
+        packet_kind="bootstrap_command_pack_projection",
+        detail_refs={
+            "goal_start_contract": "#/goal_start_contract",
+            "commands": "#/commands",
+            "host_loop_activation": "#/host_loop_activation",
+            "safety_contract": "#/safety_contract",
+            "full_command_pack": "#/detail_command",
+        },
+        legacy_fields_retained=False,
+        compact_projection_default=True,
+    )
+    return projection
 
 
 def _resolve_project(project: Path) -> Path:
@@ -749,6 +816,7 @@ def _build_multi_goal_start_selection_packet(
     host_surface: str,
     goal_text: str,
     available_capabilities: list[str] | None,
+    include_command_pack_detail: bool,
 ) -> dict[str, Any] | None:
     inspection = inspect_bootstrap_connection(project)
     registry_path = Path(str(inspection.get("registry") or ""))
@@ -917,6 +985,23 @@ def _build_multi_goal_start_selection_packet(
             "preferred_scope_change": "use configure-goal incremental updates instead of force bootstrap when state already exists",
         },
     }
+    detail_command = _start_goal_detail_command(
+        project=resolved_project,
+        goal_id=None,
+        agent_id=agent_id,
+        cli_bin=cli_bin,
+        host_surface=host_surface,
+        goal_text=normalized_goal_text,
+        available_capabilities=available_capabilities,
+    )
+    selected_command_pack = (
+        command_pack
+        if include_command_pack_detail
+        else _guided_command_pack_projection(
+            command_pack,
+            detail_command=detail_command,
+        )
+    )
     payload: dict[str, Any] = {
         "ok": True,
         "schema_version": GUIDED_START_SCHEMA_VERSION,
@@ -931,7 +1016,8 @@ def _build_multi_goal_start_selection_packet(
         "goal_selection_gate": goal_selection_gate,
         "recommended_next_step": recommended_next_step,
         "guided_transaction": guided_transaction,
-        "command_pack": command_pack,
+        "command_pack": selected_command_pack,
+        "command_pack_detail_included": include_command_pack_detail,
         "safety_contract": {
             "writes_registry": False,
             "writes_state_file": False,
@@ -951,10 +1037,12 @@ def _build_multi_goal_start_selection_packet(
             "goal_selection_gate": "#/goal_selection_gate",
             "recommended_next_step": "#/recommended_next_step",
             "guided_transaction": "#/guided_transaction",
-            "commands": "#/command_pack/commands",
+            "commands": "#/guided_transaction/ordered_steps",
             "safety_contract": "#/safety_contract",
             "compatibility_message": "#/message",
         },
+        legacy_fields_retained=include_command_pack_detail,
+        compact_projection_default=not include_command_pack_detail,
     )
     return payload
 
@@ -968,6 +1056,7 @@ def build_start_goal_guided_packet(
     host_surface: str,
     goal_text: str,
     available_capabilities: list[str] | None = None,
+    include_command_pack_detail: bool = False,
 ) -> dict[str, Any]:
     if goal_id is None:
         selection_packet = _build_multi_goal_start_selection_packet(
@@ -977,6 +1066,7 @@ def build_start_goal_guided_packet(
             host_surface=host_surface,
             goal_text=goal_text,
             available_capabilities=available_capabilities,
+            include_command_pack_detail=include_command_pack_detail,
         )
         if selection_packet is not None:
             return selection_packet
@@ -1083,6 +1173,23 @@ def build_start_goal_guided_packet(
                 "purpose": "select one registered agent lane before generating heartbeat or quota commands",
             },
         )
+    detail_command = _start_goal_detail_command(
+        project=str(command_pack.get("project") or project),
+        goal_id=str(command_pack.get("goal_id") or "") or None,
+        agent_id=str(command_pack.get("agent_id") or "") or None,
+        cli_bin=cli_bin,
+        host_surface=host_surface,
+        goal_text=str(command_pack.get("goal_text") or goal_text),
+        available_capabilities=available_capabilities,
+    )
+    selected_command_pack = (
+        command_pack
+        if include_command_pack_detail
+        else _guided_command_pack_projection(
+            command_pack,
+            detail_command=detail_command,
+        )
+    )
     payload = {
         "ok": True,
         "schema_version": GUIDED_START_SCHEMA_VERSION,
@@ -1096,7 +1203,8 @@ def build_start_goal_guided_packet(
         "project_connection": command_pack.get("project_connection"),
         "recommended_next_step": command_pack.get("recommended_next_step"),
         "guided_transaction": guided_transaction,
-        "command_pack": command_pack,
+        "command_pack": selected_command_pack,
+        "command_pack_detail_included": include_command_pack_detail,
         "safety_contract": {
             "writes_registry": False,
             "writes_state_file": False,
@@ -1115,10 +1223,12 @@ def build_start_goal_guided_packet(
             "project_connection": "#/project_connection",
             "recommended_next_step": "#/recommended_next_step",
             "guided_transaction": "#/guided_transaction",
-            "commands": "#/command_pack/commands",
+            "commands": "#/guided_transaction/ordered_steps",
             "safety_contract": "#/safety_contract",
             "compatibility_message": "#/message",
         },
+        legacy_fields_retained=include_command_pack_detail,
+        compact_projection_default=not include_command_pack_detail,
     )
     return payload
 

--- a/loopx/cli_commands/starter_bootstrap.py
+++ b/loopx/cli_commands/starter_bootstrap.py
@@ -129,6 +129,7 @@ def handle_start_goal_command(
         host_surface=args.host_surface,
         goal_text=args.goal_text,
         available_capabilities=args.available_capabilities,
+        include_command_pack_detail=bool(args.include_command_pack_detail),
     )
     print_payload(payload, args.format, render_start_goal_guided_markdown)
     return 0

--- a/loopx/cli_commands/starter_bootstrap_registration.py
+++ b/loopx/cli_commands/starter_bootstrap_registration.py
@@ -127,6 +127,14 @@ def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) 
         required=True,
         help="Exact goal text to plan before todo writeback.",
     )
+    start_goal_parser.add_argument(
+        "--include-command-pack-detail",
+        action="store_true",
+        help=(
+            "Include the complete nested bootstrap command pack. The default guided "
+            "projection keeps the actionable transaction and advertises this cold path."
+        ),
+    )
 
     prompt_parser = subparsers.add_parser(
         "new-project-prompt",

--- a/loopx/control_plane/testing/cli_output_budget.py
+++ b/loopx/control_plane/testing/cli_output_budget.py
@@ -72,7 +72,7 @@ CLI_OUTPUT_BUDGET_SPECS: tuple[CliOutputBudgetSpec, ...] = (
         owner="goal bootstrap",
         consumer_action="plan a goal start before any mutation",
         qualification_policy="baseline_and_growth",
-        cold_path="packet_summary detail_refs and bootstrap-command-pack",
+        cold_path="--include-command-pack-detail and bootstrap-command-pack",
         semantic_json_keys=(
             "guided_transaction",
             "command_pack",
@@ -81,14 +81,14 @@ CLI_OUTPUT_BUDGET_SPECS: tuple[CliOutputBudgetSpec, ...] = (
         ),
         markdown_anchor="# Guided Start Goal",
         max_chars={
-            "small": {"json": 64_000, "markdown": 3_200},
-            "crowded": {"json": 64_000, "markdown": 3_200},
-            "multi_agent": {"json": 64_000, "markdown": 3_200},
+            "small": {"json": 40_000, "markdown": 3_200},
+            "crowded": {"json": 40_000, "markdown": 3_200},
+            "multi_agent": {"json": 40_000, "markdown": 3_200},
         },
         max_lines={
-            "small": {"json": 650, "markdown": 55},
-            "crowded": {"json": 650, "markdown": 55},
-            "multi_agent": {"json": 650, "markdown": 55},
+            "small": {"json": 450, "markdown": 55},
+            "crowded": {"json": 450, "markdown": 55},
+            "multi_agent": {"json": 450, "markdown": 55},
         },
         scale_axis="todo_count",
         max_json_growth_chars_per_unit=8,
@@ -335,6 +335,21 @@ CLI_OUTPUT_BUDGET_BY_ID = {spec.surface_id: spec for spec in CLI_OUTPUT_BUDGET_S
 # characterization. This prevents a compact default from hiding unbounded
 # growth in the exact diagnostic mode an agent uses during repair.
 CLI_OUTPUT_MODE_VARIANT_SPECS: tuple[CliOutputModeVariantSpec, ...] = (
+    CliOutputModeVariantSpec(
+        variant_id="start_goal_guided_command_pack_detail",
+        parent_surface_id="start_goal_guided",
+        command="start-goal --guided --include-command-pack-detail",
+        output_formats=("json", "markdown"),
+        semantic_json_keys=(
+            "guided_transaction",
+            "command_pack",
+            "safety_contract",
+            "packet_summary",
+        ),
+        markdown_anchor="# Guided Start Goal",
+        max_chars={"json": 64_000, "markdown": 3_200},
+        max_lines={"json": 650, "markdown": 55},
+    ),
     CliOutputModeVariantSpec(
         variant_id="bootstrap_command_pack_message_only",
         parent_surface_id="bootstrap_command_pack",

--- a/loopx/control_plane/testing/onboarding_model_behavior_qualification.py
+++ b/loopx/control_plane/testing/onboarding_model_behavior_qualification.py
@@ -94,6 +94,14 @@ def _digest(value: Any) -> str:
     return "sha256:" + sha256(_canonical_json(value).encode("utf-8")).hexdigest()
 
 
+def _validate_actual_default_projection(packet: Mapping[str, Any]) -> None:
+    if packet.get("command_pack_detail_included") is True:
+        raise OnboardingActualBehaviorValidationError(
+            "regular onboarding model qualification excludes explicit "
+            "command-pack detail; validate cold-path restoration deterministically"
+        )
+
+
 def _mapping(value: Any, *, field: str) -> dict[str, Any]:
     if not isinstance(value, Mapping):
         raise ValueError(f"{field} must be an object")
@@ -519,6 +527,7 @@ def run_onboarding_actual_behavior_qualification(
     transition_runner: Callable[[], Mapping[str, Any]],
     repair_observation: Mapping[str, Any],
 ) -> dict[str, Any]:
+    _validate_actual_default_projection(actual_packet)
     entry_contract = onboarding_entry_semantic_contract(actual_packet)
     entry_violations = onboarding_entry_contract_violations(entry_contract)
     if entry_violations:

--- a/tests/control_plane/test_cli_output_budget.py
+++ b/tests/control_plane/test_cli_output_budget.py
@@ -378,6 +378,21 @@ def _mode_variant_commands(
         "Public CLI output qualification.",
     ]
     return {
+        "start_goal_guided_command_pack_detail": [
+            "--format",
+            output_format,
+            "start-goal",
+            "--guided",
+            "--project",
+            str(project),
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_IDS[0],
+            "--goal-text",
+            GOAL_TEXT,
+            "--include-command-pack-detail",
+        ],
         "bootstrap_command_pack_message_only": [
             "--format",
             output_format,
@@ -513,6 +528,7 @@ def test_manifest_covers_the_declared_agent_facing_surface_set() -> None:
     assert {row["surface_id"] for row in manifest["surfaces"]} == expected
     assert all(spec.owner and spec.consumer_action and spec.cold_path for spec in CLI_OUTPUT_BUDGET_SPECS)
     expected_variants = {
+        "start_goal_guided_command_pack_detail",
         "bootstrap_command_pack_message_only",
         "quota_should_run_scheduler_detail",
         "quota_should_run_turn_envelope",
@@ -583,8 +599,8 @@ def test_collection_growth_and_bootstrap_duplication_are_explicit(tmp_path: Path
     bootstrap_payload = small["bootstrap_command_pack"]["json"]["payload"]
     start_duplication = start_payload["packet_summary"]["duplication_measurement"]
     bootstrap_duplication = bootstrap_payload["packet_summary"]["duplication_measurement"]
-    assert start_duplication["objective_content"]["duplicate_occurrences"] <= 15
-    assert start_duplication["command_content"]["duplicate_occurrences"] <= 17
+    assert start_duplication["objective_content"]["duplicate_occurrences"] <= 11
+    assert start_duplication["command_content"]["duplicate_occurrences"] <= 13
     assert bootstrap_duplication["objective_content"]["duplicate_occurrences"] <= 8
     assert bootstrap_duplication["command_content"]["duplicate_occurrences"] <= 9
     assert start_duplication["objective_content"]["duplicate_occurrences"] > 0

--- a/tests/control_plane/test_onboarding_model_behavior_qualification.py
+++ b/tests/control_plane/test_onboarding_model_behavior_qualification.py
@@ -53,6 +53,7 @@ TRANSACTION = {
 def _actual_entry_packet() -> dict[str, Any]:
     return {
         "schema_version": "loopx_start_goal_guided_v0",
+        "command_pack_detail_included": False,
         "goal_id": "fixture-goal",
         "agent_id": "codex-fixture",
         "guided_transaction": TRANSACTION,
@@ -181,6 +182,38 @@ def test_independent_oracle_rejects_command_loss_before_model_or_transition() ->
         )
 
     assert tuple(COMMANDS) == ONBOARDING_REQUIRED_CONNECT_COMMAND_IDS
+    assert calls == 0
+    assert transitions == 0
+
+
+def test_regular_qualification_rejects_explicit_cold_path_before_model() -> None:
+    calls = 0
+    transitions = 0
+    packet = _actual_entry_packet()
+    packet["command_pack_detail_included"] = True
+
+    def actor(_: Mapping[str, Any]) -> Mapping[str, Any]:
+        nonlocal calls
+        calls += 1
+        return {}
+
+    def transition() -> Mapping[str, Any]:
+        nonlocal transitions
+        transitions += 1
+        return _healthy_observation()
+
+    with pytest.raises(
+        OnboardingActualBehaviorValidationError,
+        match="excludes explicit command-pack detail",
+    ):
+        run_onboarding_actual_behavior_qualification(
+            packet,
+            qualification_id="onboarding-cold-path-excluded-001",
+            actor=actor,
+            transition_runner=transition,
+            repair_observation=_projection_gap_observation(),
+        )
+
     assert calls == 0
     assert transitions == 0
 

--- a/tests/control_plane/test_start_goal_compact_projection.py
+++ b/tests/control_plane/test_start_goal_compact_projection.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import shlex
+from pathlib import Path
+from typing import Any
+
+from loopx.bootstrap_command_pack import (
+    GUIDED_COMMAND_PACK_PROJECTION_SCHEMA_VERSION,
+    build_start_goal_guided_packet,
+)
+from loopx.cli import main as cli_main
+
+
+GOAL_ID = "guided-projection-goal"
+AGENT_ID = "codex-guided-projection"
+GOAL_TEXT = "Ship a bounded public issue triage workflow."
+
+
+def _write_connected_project(root: Path) -> Path:
+    project = root / "project"
+    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text("# Active Goal State\n", encoding="utf-8")
+    registry = project / ".loopx" / "registry.json"
+    registry.parent.mkdir(parents=True)
+    registry.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": str(state_file.relative_to(project)),
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": [AGENT_ID],
+                        },
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return project
+
+
+def _build(project: Path, *, include_detail: bool) -> dict[str, Any]:
+    return build_start_goal_guided_packet(
+        project=project,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        cli_bin="loopx",
+        host_surface="codex-app",
+        goal_text=GOAL_TEXT,
+        available_capabilities=["network"],
+        include_command_pack_detail=include_detail,
+    )
+
+
+def _host_shadow_document(payload: dict[str, Any]) -> dict[str, Any]:
+    command_pack = payload["command_pack"]
+    transaction = payload["guided_transaction"]
+    return {
+        "schema_version": payload["schema_version"],
+        "project": payload["project"],
+        "goal_id": payload["goal_id"],
+        "agent_id": payload["agent_id"],
+        "host_surface": payload["host_surface"],
+        "goal_text": payload["goal_text"],
+        "recommended_next_step": payload["recommended_next_step"],
+        "ordered_steps": transaction["ordered_steps"],
+        "idempotency_policy": transaction["idempotency_policy"],
+        "preserve_todos_policy": transaction["preserve_todos_policy"],
+        "goal_start_contract": command_pack["goal_start_contract"],
+        "commands": command_pack["commands"],
+        "host_loop_activation": command_pack["host_loop_activation"],
+        "safety_contract": payload["safety_contract"],
+    }
+
+
+def _resolve_pointer(payload: Any, pointer: str) -> Any:
+    assert pointer.startswith("#/")
+    current = payload
+    for escaped_part in pointer[2:].split("/"):
+        part = escaped_part.replace("~1", "/").replace("~0", "~")
+        current = current[int(part)] if isinstance(current, list) else current[part]
+    return current
+
+
+def _invoke_detail_command(command: str) -> dict[str, Any]:
+    argv = shlex.split(command)
+    assert argv[0] == "loopx"
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(argv[1:])
+    assert exit_code == 0
+    payload = json.loads(output.getvalue())
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_default_projection_preserves_host_actions_and_json_anchors(
+    tmp_path: Path,
+) -> None:
+    project = _write_connected_project(tmp_path)
+    compact = _build(project, include_detail=False)
+    detailed = _build(project, include_detail=True)
+
+    assert set(compact) == set(detailed)
+    assert _host_shadow_document(compact) == _host_shadow_document(detailed)
+    assert compact["command_pack_detail_included"] is False
+    assert detailed["command_pack_detail_included"] is True
+
+    projection = compact["command_pack"]
+    assert projection["schema_version"] == "loopx_bootstrap_command_pack_v0"
+    assert (
+        projection["projection_schema_version"]
+        == GUIDED_COMMAND_PACK_PROJECTION_SCHEMA_VERSION
+    )
+    assert projection["projection_mode"] == "guided_start_compatibility"
+    assert projection["commands"] == detailed["command_pack"]["commands"]
+    assert (
+        projection["host_loop_activation"]
+        == detailed["command_pack"]["host_loop_activation"]
+    )
+    assert "message" not in projection
+    assert "available_slash_commands" not in projection
+    assert (
+        projection["goal_start_contract"]
+        == detailed["command_pack"]["goal_start_contract"]
+    )
+    assert projection["safety_contract"] == detailed["command_pack"]["safety_contract"]
+
+    compatibility = compact["packet_summary"]["compatibility"]
+    assert compatibility == {
+        "legacy_fields_retained": False,
+        "compact_projection_default": True,
+        "removal_gate": "explicit_host_shadow_parity",
+    }
+    for ref in compact["packet_summary"]["detail_refs"].values():
+        _resolve_pointer(compact, ref["json_pointer"])
+    for ref in projection["packet_summary"]["detail_refs"].values():
+        _resolve_pointer(projection, ref["json_pointer"])
+
+
+def test_explicit_cold_path_restores_the_complete_command_pack(tmp_path: Path) -> None:
+    project = _write_connected_project(tmp_path)
+    compact = _build(project, include_detail=False)
+    restored = _invoke_detail_command(compact["command_pack"]["detail_command"])
+
+    assert restored["command_pack_detail_included"] is True
+    assert "commands" in restored["command_pack"]
+    assert "message" in restored["command_pack"]
+    assert "host_loop_activation" in restored["command_pack"]
+    assert "available_slash_commands" in restored["command_pack"]
+    assert _host_shadow_document(restored) == _host_shadow_document(compact)
+    assert restored["packet_summary"]["compatibility"] == {
+        "legacy_fields_retained": True,
+        "compact_projection_default": False,
+        "removal_gate": "explicit_host_shadow_parity",
+    }
+
+
+def test_projection_materially_reduces_repetition_without_hiding_measurement(
+    tmp_path: Path,
+) -> None:
+    project = _write_connected_project(tmp_path)
+    compact = _build(project, include_detail=False)
+    detailed = _build(project, include_detail=True)
+    compact_json = json.dumps(compact, ensure_ascii=False, sort_keys=True)
+    detailed_json = json.dumps(detailed, ensure_ascii=False, sort_keys=True)
+
+    assert len(compact_json) <= int(len(detailed_json) * 0.65)
+    compact_duplication = compact["packet_summary"]["duplication_measurement"]
+    detailed_duplication = detailed["packet_summary"]["duplication_measurement"]
+    assert compact_duplication["objective_content"]["duplicate_occurrences"] <= 11
+    assert compact_duplication["command_content"]["duplicate_occurrences"] <= 13
+    assert (
+        compact_duplication["objective_content"]["duplicate_occurrences"]
+        < (detailed_duplication["objective_content"]["duplicate_occurrences"])
+    )
+    assert (
+        compact_duplication["command_content"]["duplicate_occurrences"]
+        < (detailed_duplication["command_content"]["duplicate_occurrences"])
+    )
+
+
+def test_projection_preserves_agent_identity_gate_actions(tmp_path: Path) -> None:
+    project = _write_connected_project(tmp_path)
+    registry_path = project / ".loopx" / "registry.json"
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    registry["goals"][0]["coordination"]["registered_agents"].append(
+        "codex-guided-reviewer"
+    )
+    registry_path.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
+
+    common = {
+        "project": project,
+        "goal_id": GOAL_ID,
+        "agent_id": None,
+        "cli_bin": "loopx",
+        "host_surface": "codex-app",
+        "goal_text": GOAL_TEXT,
+        "available_capabilities": ["network"],
+    }
+    compact = build_start_goal_guided_packet(
+        **common,
+        include_command_pack_detail=False,
+    )
+    detailed = build_start_goal_guided_packet(
+        **common,
+        include_command_pack_detail=True,
+    )
+
+    assert compact["guided_transaction"]["blocked_by"] == "agent_identity_selection"
+    assert _host_shadow_document(compact) == _host_shadow_document(detailed)
+
+
+def test_projection_preserves_multi_goal_selection_actions(tmp_path: Path) -> None:
+    project = _write_connected_project(tmp_path)
+    registry_path = project / ".loopx" / "registry.json"
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    second_goal_id = "guided-projection-second-goal"
+    second_state = (
+        project / ".codex" / "goals" / second_goal_id / "ACTIVE_GOAL_STATE.md"
+    )
+    second_state.parent.mkdir(parents=True)
+    second_state.write_text("# Second Active Goal State\n", encoding="utf-8")
+    registry["goals"].append(
+        {
+            "id": second_goal_id,
+            "status": "active",
+            "repo": str(project),
+            "state_file": str(second_state.relative_to(project)),
+            "coordination": {
+                "agent_model": "peer_v1",
+                "registered_agents": ["codex-guided-second"],
+            },
+        }
+    )
+    registry_path.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
+
+    common = {
+        "project": project,
+        "goal_id": None,
+        "agent_id": None,
+        "cli_bin": "loopx",
+        "host_surface": "codex-app",
+        "goal_text": GOAL_TEXT,
+        "available_capabilities": ["network"],
+    }
+    compact = build_start_goal_guided_packet(
+        **common,
+        include_command_pack_detail=False,
+    )
+    detailed = build_start_goal_guided_packet(
+        **common,
+        include_command_pack_detail=True,
+    )
+
+    assert compact["guided_transaction"]["blocked_by"] == "goal_selection"
+    assert [step["id"] for step in compact["guided_transaction"]["ordered_steps"]] == [
+        "inspect_connection",
+        "select_goal",
+    ]
+    assert _host_shadow_document(compact) == _host_shadow_document(detailed)


### PR DESCRIPTION
## Summary

- compact the default `start-goal --guided` nested command pack into a compatibility projection
- retain the ordered transaction, planning and safety contracts, action commands, identity gates, and host-loop activation in the hot path
- move only repeated bootstrap prose, slash discovery, and duplicate connection/next-step diagnostics behind `--include-command-pack-detail`
- characterize the default projection in the CLI output budget and preserve deterministic hot/cold semantic parity
- keep the explicit full-detail recovery contract out of regular Doubao qualification

## Qualification topology

The merged onboarding behavior contract from #2168 is the source of truth:

- regular Doubao qualification has one arm: the checkout's actual default packet
- `command_pack_detail_included=true` fails before any provider or transition call
- cold-path restoration and semantic parity remain deterministic tests only
- generic packet ablation may be used separately for diagnosis, but full detail is not a baseline arm or retained model-test fixture

## Live model evidence

The candidate's actual `default_guided` packet was exercised for normal single-agent onboarding, the agent-identity gate, and the multi-goal selection gate. Each scenario repeated twice, for 6 candidate-default calls. All six decisions matched the expected route and were repeat-stable.

The additional `full_detail` calls in the earlier diagnostic receipt are historical ablation evidence only. They are not counted as regular qualification or promotion evidence.

Separately, #2168 established the independent actual-default onboarding oracle with 6/6 Doubao one-arm decisions across `connect_if_needed`, `continue_validation`, and `repair_projection`. The final follow-up commit on this PR changes only the qualification guard, tests, and protocol wording; it does not alter the candidate default packet exercised by the earlier six calls.

No raw prompt, response, credential, local path, generated log, or transition workspace is retained.

## Validation

- rebased onto current `main` through #2172 without conflict
- 18 focused onboarding, Doubao-adapter, compact-projection, and CLI-budget tests passed
- Ruff, Python compile, and diff hygiene passed
- `loopx canary premerge --from-git-diff`: 17/17 selected checks passed, 0 failures, 0 warnings, 0 manual holds
- public/private boundary scan: all 12 changed files clean
- deterministic rejection test proves explicit full detail causes 0 actor calls and 0 transition calls
- GitHub `pytest` passed on the rebased head

## Merge decision

Owner explicitly authorized self-merge in the current turn. The remaining branch-protection review requirement will be bypassed only for this authorized merge after the validation above.