### PR TITLE
Preserve executable scheduler argv in TurnEnvelope

### DIFF
--- a/examples/control_plane/quota-scheduler-registry-route-smoke.py
+++ b/examples/control_plane/quota-scheduler-registry-route-smoke.py
@@ -94,24 +94,29 @@ def main() -> None:
             GOAL_ID,
             "--agent-id",
             AGENT_ID,
+            "--available-capability",
+            "network",
+            "--available-capability",
+            "external_write",
+            "--codex-app-current-rrule",
+            "FREQ=MINUTELY;INTERVAL=3",
+            "--turn-envelope",
             "--scan-path",
             str(project),
             cwd=project,
         )
-        ack_hint = decision["scheduler_hint"]["codex_app"]["ack_hint"]
-        ack_cli_args = ack_hint["cli_args"]
+        ack_cli_args = decision["scheduler"]["codex_app"]["ack_cli_args"]
         assert ack_cli_args[:4] == [
             "--registry",
             str(global_registry.resolve()),
             "--runtime-root",
             str(global_runtime.resolve()),
-        ], ack_hint
-        assert ack_hint["route_binding"] == {
-            "schema_version": "scheduler_ack_cli_route_v0",
-            "source": "quota_cli_invocation",
-            "registry_bound": True,
-            "runtime_root_bound": True,
-        }, ack_hint
+        ], decision
+        assert ack_cli_args.count("--available-capability") == 2, decision
+        assert "--host-match-observed" in ack_cli_args, decision
+        assert "--reset-token" in ack_cli_args, decision
+        assert "--identity-signature" in ack_cli_args, decision
+        assert ack_cli_args[-1] == "--execute", decision
 
         ack = run_cli(*ack_cli_args, "--scan-path", str(project), cwd=project)
         state_path = Path(ack["scheduler_state_path"])

--- a/loopx/control_plane/quota/turn_envelope.py
+++ b/loopx/control_plane/quota/turn_envelope.py
@@ -15,6 +15,10 @@ from ..work_items.primary_action import protocol_action_text
 
 TURN_ENVELOPE_SCHEMA_VERSION = "loopx_turn_envelope_v0"
 TURN_ENVELOPE_BUDGET_BYTES = 8_192
+EXECUTABLE_CLI_ARGS_MAX_ITEMS = 64
+EXECUTABLE_CLI_ARGS_MAX_ITEM_CHARS = 512
+EXECUTABLE_CLI_ARGS_MAX_TOTAL_CHARS = 2_048
+SCHEDULER_DETAIL_REQUEST = "loopx quota should-run --include-scheduler-detail"
 CONTRACT_CAPSULE_SCHEMA_VERSION = "loopx_contract_capsule_v0"
 ACTION_SIGNATURE_SCHEMA_VERSION = "loopx_action_signature_v0"
 ACTION_SIGNATURE_COVERAGE = "turn_envelope_action_dimensions_v0"
@@ -143,6 +147,32 @@ def _text_list(value: Any, *, limit: int, item_limit: int = 240) -> list[str]:
         result.append(text)
         if len(result) >= limit:
             break
+    return result
+
+
+def _executable_cli_args(value: Any) -> list[str]:
+    """Return one exact CLI argv vector or omit it entirely.
+
+    General compact text lists intentionally deduplicate and truncate. Both
+    behaviors corrupt argv because flags such as ``--available-capability``
+    are repeated and a partial vector is not executable.
+    """
+
+    if not isinstance(value, list) or not value:
+        return []
+    if len(value) > EXECUTABLE_CLI_ARGS_MAX_ITEMS:
+        return []
+    result: list[str] = []
+    total_chars = 0
+    for item in value:
+        if not isinstance(item, str) or not item:
+            return []
+        if len(item) > EXECUTABLE_CLI_ARGS_MAX_ITEM_CHARS:
+            return []
+        total_chars += len(item) + 1
+        if total_chars > EXECUTABLE_CLI_ARGS_MAX_TOTAL_CHARS:
+            return []
+        result.append(item)
     return result
 
 
@@ -331,17 +361,23 @@ def _scheduler(payload: Mapping[str, Any]) -> dict[str, Any]:
                 if failure.get(field) is not None
             }
     ack = _mapping(codex_app.get("ack_hint"))
-    cli_args = _text_list(ack.get("cli_args"), limit=20, item_limit=180)
+    cli_args = _executable_cli_args(ack.get("cli_args"))
     if cli_args:
         app["ack_cli_args"] = cli_args
+    elif ack.get("cli_args"):
+        app["ack_cli_args_detail_ref"] = {
+            "reason": "omitted_to_preserve_executable_argv",
+            "request": SCHEDULER_DETAIL_REQUEST,
+        }
     failure_hint = _mapping(codex_app.get("failure_hint"))
-    failure_cli_args = _text_list(
-        failure_hint.get("cli_args"),
-        limit=20,
-        item_limit=180,
-    )
+    failure_cli_args = _executable_cli_args(failure_hint.get("cli_args"))
     if failure_cli_args:
         app["failure_cli_args"] = failure_cli_args
+    elif failure_hint.get("cli_args"):
+        app["failure_cli_args_detail_ref"] = {
+            "reason": "omitted_to_preserve_executable_argv",
+            "request": SCHEDULER_DETAIL_REQUEST,
+        }
     if app:
         scheduler["codex_app"] = app
     return scheduler

--- a/tests/test_turn_envelope.py
+++ b/tests/test_turn_envelope.py
@@ -305,6 +305,83 @@ def test_turn_envelope_preserves_action_boundary_and_writeback() -> None:
     )
 
 
+def test_turn_envelope_preserves_exact_scheduler_ack_argv() -> None:
+    source = _full_decision()
+    capabilities = [
+        "network",
+        "github",
+        "github_cli",
+        "external_evidence_poll",
+        "external_write",
+        "lark_user",
+        "lark_bot",
+        "browser",
+    ]
+    cli_args = [
+        "--registry",
+        "/tmp/registry.global.json",
+        "--runtime-root",
+        "/tmp/runtime",
+        "quota",
+        "scheduler-ack-current",
+        "--goal-id",
+        "fixture-goal",
+        "--agent-id",
+        "codex-fixture",
+    ]
+    for capability in capabilities:
+        cli_args.extend(["--available-capability", capability])
+    cli_args.extend(
+        [
+            "--surface",
+            "codex_app",
+            "--state-key",
+            "scheduler_hint.codex_app.stateful_backoff",
+            "--applied-rrule",
+            "FREQ=MINUTELY;INTERVAL=3",
+            "--host-match-observed",
+            "--reset-token",
+            "reset-token",
+            "--identity-signature",
+            "identity-signature",
+            "--execute",
+        ]
+    )
+    source["scheduler_hint"]["codex_app"]["ack_hint"]["cli_args"] = cli_args
+
+    envelope = build_turn_envelope(source)
+    compact_args = envelope["scheduler"]["codex_app"]["ack_cli_args"]
+
+    assert compact_args == cli_args
+    assert compact_args.count("--available-capability") == len(capabilities)
+    assert compact_args[-6:] == [
+        "--host-match-observed",
+        "--reset-token",
+        "reset-token",
+        "--identity-signature",
+        "identity-signature",
+        "--execute",
+    ]
+
+
+def test_turn_envelope_omits_oversized_scheduler_argv_instead_of_truncating() -> None:
+    source = _full_decision()
+    source["scheduler_hint"]["codex_app"]["ack_hint"]["cli_args"] = [
+        "quota",
+        "x" * 513,
+        "--execute",
+    ]
+
+    envelope = build_turn_envelope(source)
+    codex_app = envelope["scheduler"]["codex_app"]
+
+    assert "ack_cli_args" not in codex_app
+    assert codex_app["ack_cli_args_detail_ref"] == {
+        "reason": "omitted_to_preserve_executable_argv",
+        "request": "loopx quota should-run --include-scheduler-detail",
+    }
+
+
 def test_turn_envelope_keeps_concrete_user_gate() -> None:
     source = _full_decision()
     source["action_required"] = True


### PR DESCRIPTION
## Summary

- Preserve exact scheduler ACK/failure argv vectors in compact TurnEnvelope packets, including repeated capability flags.
- Omit oversized argv atomically with a cold-path detail reference instead of emitting a truncated command.
- Replay a host-match ACK from the compact packet in the registry-route smoke.

## Issue Or Task

- Closes #
- Contributor task ID: `todo_789dc77ff2ad`

## Validation

- [x] `python3 -m py_compile` on the three touched Python files
- [x] `loopx check` public-boundary validation via premerge canary
- [x] Other: `pytest tests/test_turn_envelope.py` (19 passed); CLI budget and turn-driver tests (22 passed); scheduler compaction, state-ACK, and registry-route smokes; standard premerge canary (14/14, zero holds)

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
