### PR TITLE
Add release outcome baseline qualification

### DIFF
--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -20,6 +20,7 @@ Current contracts:
 - [todo_detail_cold_path_v0](todo-detail-cold-path-v0.md)
 - [long_horizon_agent_state_protocol_v0](long-horizon-agent-state-protocol-v0.md)
 - [model_behavior_qualification_v0](model-behavior-qualification-v0.md)
+- [release_outcome_baseline_v0](release-outcome-baseline-v0.md)
 - [decentralized_auto_research_state_v0](decentralized-auto-research-state-v0.md)
 - [auto_research_lane_contract_v1](auto-research-lane-contract-v1.md)
 - [auto_research_role_state_machine_v0](auto-research-role-state-machine-v0.md)

--- a/docs/reference/protocols/release-outcome-baseline-v0.md
+++ b/docs/reference/protocols/release-outcome-baseline-v0.md
@@ -1,0 +1,87 @@
+# Release Outcome Baseline v0
+
+`release_outcome_baseline_v0` is the review boundary between fast control-plane
+qualification and low-frequency long-running outcome evidence. It compares a
+stable baseline and candidate under matched task semantics, runner protocol,
+verifier contract, and budget. It never promotes a release automatically.
+
+## Validation Layers
+
+LoopX uses three complementary layers:
+
+1. deterministic fixtures and catalog canaries run on normal pull requests;
+2. low-frequency paired model-behavior qualification checks whether an agent
+   interprets two control-plane projections equivalently;
+3. release outcome baselines compare completed long-running attempts on a small
+   representative case set.
+
+The third layer measures what happened, not only whether a packet looked
+equivalent. It stays outside ordinary PR smoke because real tasks and model
+calls are slower, cost-bearing, and may depend on gated environments.
+
+## Pair Manifest
+
+`release_outcome_pair_manifest_v0` contains:
+
+- public-safe `baseline_ref` and `candidate_ref` identifiers;
+- an explicit evidence policy;
+- paired compact `benchmark_result_v0` rows.
+
+Every pair has a stable `case_id` and `repeat_index`. The producer must confirm
+all four parity checks:
+
+- same task semantics;
+- same runner protocol;
+- same verifier contract;
+- same budget.
+
+Each result must already be an exact compact `benchmark_result_v0`. Unknown
+fields fail closed instead of being silently copied into the receipt. The
+result must explicitly report terminal state, verifier pass/fail, erroneous
+write count, human intervention count, stop-policy correctness, wall time, and
+cost. At least two distinct cases and two repetitions per case are required;
+the manifest may demand stronger coverage.
+
+## Metrics And Decisions
+
+The reducer reports both arms and their deltas for:
+
+- completion rate;
+- verifier pass rate;
+- erroneous writes;
+- human interventions;
+- correct stop-policy rate;
+- mean wall time;
+- mean cost.
+
+It produces one of three review decisions:
+
+- `insufficient_evidence`: the representative-case or repetition floor is not
+  met;
+- `hold_regression`: a correctness metric regressed or the declared time/cost
+  ratio was exceeded;
+- `owner_review_required`: the evidence floor is met and no declared regression
+  is present.
+
+`owner_review_required` is not release approval. The receipt always sets
+`automatic_release_promotion_allowed=false`. A maintainer still reviews case
+representativeness, failure attribution, and any qualitative behavior that the
+compact metrics cannot express.
+
+## CLI
+
+The CLI is read-only:
+
+```bash
+loopx --format json benchmark release-outcome-baseline \
+  --manifest-json release-outcome-pairs.json
+```
+
+Add `--require-owner-review-ready` when a scheduled qualification job should
+return non-zero for insufficient evidence or a regression. Without that flag,
+the command remains advisory and does not slow ordinary iteration.
+
+The command does not read raw task text, trajectories, or verifier output. It
+does not invoke a model, execute a benchmark, mutate a release, or persist local
+paths. Real runners remain responsible for producing compact result rows under
+their own authorization and privacy boundaries.

--- a/loopx/cli_commands/benchmark_dispatch.py
+++ b/loopx/cli_commands/benchmark_dispatch.py
@@ -16,6 +16,10 @@ from .benchmark_boundary import (
     handle_benchmark_boundary_command,
     register_benchmark_boundary_commands,
 )
+from .benchmark_release_outcome import (
+    handle_benchmark_release_outcome_command,
+    register_benchmark_release_outcome_commands,
+)
 from .benchmark_review_lifecycle import (
     handle_benchmark_review_lifecycle_command,
     register_benchmark_review_lifecycle_commands,
@@ -54,6 +58,7 @@ def register_benchmark_command_group(
 
     register_agentissue_runner_flow_commands(benchmark_sub, add_subcommand_format)
     register_benchmark_boundary_commands(benchmark_sub, add_subcommand_format)
+    register_benchmark_release_outcome_commands(benchmark_sub, add_subcommand_format)
     register_terminal_bench_adapter_commands(benchmark_sub, add_subcommand_format)
 
     register_agents_last_exam_commands(benchmark_sub, add_subcommand_format)
@@ -88,6 +93,14 @@ def handle_benchmark_command(
     )
     if benchmark_boundary_result is not None:
         return benchmark_boundary_result
+
+    release_outcome_result = handle_benchmark_release_outcome_command(
+        args,
+        print_payload=print_payload,
+        output_format=output_format,
+    )
+    if release_outcome_result is not None:
+        return release_outcome_result
 
     terminal_bench_adapter_result = handle_terminal_bench_adapter_command(
         args,

--- a/loopx/cli_commands/benchmark_release_outcome.py
+++ b/loopx/cli_commands/benchmark_release_outcome.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from ..control_plane.testing.release_outcome_baseline import (
+    RELEASE_OUTCOME_BASELINE_SCHEMA_VERSION,
+    build_release_outcome_baseline,
+)
+from ..control_plane.runtime.public_safety import public_safe_compact_text
+
+
+def _public_error(exc: Exception) -> str:
+    if isinstance(exc, json.JSONDecodeError):
+        return "manifest_invalid_json"
+    if isinstance(exc, OSError):
+        return "manifest_unreadable"
+    if isinstance(exc, ValueError):
+        return public_safe_compact_text(str(exc), limit=220) or "manifest_invalid"
+    return "release_outcome_invalid_input"
+
+
+def render_release_outcome_baseline_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# LoopX Release Outcome Baseline",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- decision: `{payload.get('decision')}`",
+        f"- baseline_ref: `{payload.get('baseline_ref')}`",
+        f"- candidate_ref: `{payload.get('candidate_ref')}`",
+        f"- eligible_for_owner_review: `{payload.get('eligible_for_owner_review')}`",
+        f"- automatic_release_promotion_allowed: `{payload.get('automatic_release_promotion_allowed')}`",
+    ]
+    coverage = payload.get("coverage") if isinstance(payload.get("coverage"), dict) else {}
+    if coverage:
+        lines.extend(
+            [
+                f"- distinct_case_count: `{coverage.get('distinct_case_count')}`",
+                f"- paired_attempt_count: `{coverage.get('paired_attempt_count')}`",
+                f"- evidence_gaps: `{coverage.get('evidence_gaps')}`",
+            ]
+        )
+    if payload.get("regressions") is not None:
+        lines.append(f"- regressions: `{payload.get('regressions')}`")
+    if payload.get("error"):
+        lines.append(f"- error: {payload.get('error')}")
+    return "\n".join(lines) + "\n"
+
+
+def register_benchmark_release_outcome_commands(
+    benchmark_subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    parser = benchmark_subparsers.add_parser(
+        "release-outcome-baseline",
+        help=(
+            "Reduce paired compact benchmark_result_v0 outcomes into a review-only "
+            "release qualification receipt. This never runs a benchmark or model."
+        ),
+    )
+    add_subcommand_format(parser)
+    parser.add_argument(
+        "--manifest-json",
+        required=True,
+        help="Path to a release_outcome_pair_manifest_v0 JSON object.",
+    )
+    parser.add_argument(
+        "--require-owner-review-ready",
+        action="store_true",
+        help="Return non-zero unless the paired evidence is ready for owner review.",
+    )
+
+
+def handle_benchmark_release_outcome_command(
+    args: argparse.Namespace,
+    *,
+    print_payload: Callable[..., None],
+    output_format: Callable[..., str],
+) -> int | None:
+    if args.command != "benchmark" or args.benchmark_command != "release-outcome-baseline":
+        return None
+    try:
+        raw = json.loads(Path(args.manifest_json).expanduser().read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            raise ValueError("--manifest-json must contain a JSON object")
+        payload = build_release_outcome_baseline(raw)
+        payload["ok"] = not args.require_owner_review_ready or payload.get(
+            "eligible_for_owner_review"
+        ) is True
+        if not payload["ok"]:
+            payload["error"] = payload.get("decision") or "release_outcome_not_review_ready"
+    except Exception as exc:
+        payload = {
+            "ok": False,
+            "schema_version": RELEASE_OUTCOME_BASELINE_SCHEMA_VERSION,
+            "decision": "invalid_input",
+            "eligible_for_owner_review": False,
+            "automatic_release_promotion_allowed": False,
+            "error": _public_error(exc),
+            "read_boundary": {
+                "compact_benchmark_results_only": True,
+                "raw_task_text_read": False,
+                "raw_trajectory_read": False,
+                "raw_verifier_output_read": False,
+                "local_paths_recorded": False,
+                "model_api_invoked": False,
+                "benchmark_execution_invoked": False,
+                "release_mutation_invoked": False,
+            },
+        }
+    print_payload(
+        payload,
+        output_format(args),
+        render_release_outcome_baseline_markdown,
+    )
+    return 0 if payload.get("ok") else 1

--- a/loopx/control_plane/runtime/benchmark_result.py
+++ b/loopx/control_plane/runtime/benchmark_result.py
@@ -98,22 +98,29 @@ def compact_benchmark_result(run: dict[str, Any]) -> dict[str, Any] | None:
     if control_score:
         compact["control_plane_score"] = control_score
 
-    counts = compact_numeric_map(
-        source,
-        keys=(
-            "step_count",
-            "wall_time_ms",
-            "validation_pass_count",
-            "validation_fail_count",
-            "changed_file_count",
-            "forbidden_access_count",
-            "stale_state_error_count",
-            "writeback_count",
-            "spend_count",
-            "spend_before_validation_count",
-            "goal_tick_phase_coverage",
-        ),
+    count_fields = (
+        "step_count",
+        "wall_time_ms",
+        "validation_pass_count",
+        "validation_fail_count",
+        "changed_file_count",
+        "forbidden_access_count",
+        "stale_state_error_count",
+        "writeback_count",
+        "erroneous_write_count",
+        "human_intervention_count",
+        "spend_count",
+        "spend_before_validation_count",
+        "goal_tick_phase_coverage",
+        "cost_usd",
     )
+    count_source = (
+        dict(source.get("counts")) if isinstance(source.get("counts"), dict) else {}
+    )
+    for field in count_fields:
+        if field in source:
+            count_source[field] = source[field]
+    counts = compact_numeric_map(count_source, keys=count_fields)
     if counts:
         compact["counts"] = counts
 
@@ -122,6 +129,7 @@ def compact_benchmark_result(run: dict[str, Any]) -> dict[str, Any] | None:
         "archive_hygiene_passed",
         "queue_contract_passed",
         "state_reconstructable",
+        "stop_policy_correct",
     ):
         if isinstance(source.get(field), bool):
             compact[field] = source[field]

--- a/loopx/control_plane/testing/release_outcome_baseline.py
+++ b/loopx/control_plane/testing/release_outcome_baseline.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import re
+from collections import Counter
+from statistics import fmean
+from typing import Any, Iterable, Mapping
+
+from ..runtime.benchmark_result import compact_benchmark_result
+from ..runtime.public_safety import public_safe_compact_text
+
+
+RELEASE_OUTCOME_PAIR_MANIFEST_SCHEMA_VERSION = "release_outcome_pair_manifest_v0"
+RELEASE_OUTCOME_BASELINE_SCHEMA_VERSION = "release_outcome_baseline_v0"
+
+_TOKEN_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,159}$")
+_MANIFEST_FIELDS = {
+    "schema_version",
+    "baseline_ref",
+    "candidate_ref",
+    "policy",
+    "pairs",
+}
+_POLICY_FIELDS = {
+    "min_distinct_cases",
+    "min_repetitions_per_case",
+    "max_wall_time_ratio",
+    "max_cost_ratio",
+}
+_PAIR_FIELDS = {
+    "case_id",
+    "repeat_index",
+    "same_task_semantics",
+    "same_runner_protocol",
+    "same_verifier_contract",
+    "same_budget",
+    "baseline_result",
+    "candidate_result",
+}
+_PUBLIC_TRACE_LABELS = {
+    "public",
+    "public-safe",
+    "compact_public",
+    "public_safe_compact",
+}
+_COMPLETED_TERMINAL_STATES = {"completed", "resolved", "success", "succeeded"}
+_REQUIRED_PARITY_FIELDS = (
+    "same_task_semantics",
+    "same_runner_protocol",
+    "same_verifier_contract",
+    "same_budget",
+)
+
+
+def _token(value: Any, *, field: str) -> str:
+    text = public_safe_compact_text(value, limit=160)
+    if text is None or not _TOKEN_PATTERN.fullmatch(text):
+        raise ValueError(f"{field} must be a compact public-safe token")
+    return text
+
+
+def _bounded_int(
+    value: Any,
+    *,
+    field: str,
+    minimum: int,
+    maximum: int,
+) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"{field} must be an integer")
+    if value < minimum or value > maximum:
+        raise ValueError(f"{field} must be between {minimum} and {maximum}")
+    return value
+
+
+def _positive_ratio(value: Any, *, field: str) -> float:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise ValueError(f"{field} must be numeric")
+    normalized = float(value)
+    if normalized < 1.0 or normalized > 10.0:
+        raise ValueError(f"{field} must be between 1.0 and 10.0")
+    return normalized
+
+
+def _normalized_policy(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError("manifest.policy must be an object")
+    unknown = set(value) - _POLICY_FIELDS
+    if unknown:
+        raise ValueError("manifest.policy contains unknown fields")
+    return {
+        "min_distinct_cases": _bounded_int(
+            value.get("min_distinct_cases"),
+            field="policy.min_distinct_cases",
+            minimum=2,
+            maximum=12,
+        ),
+        "min_repetitions_per_case": _bounded_int(
+            value.get("min_repetitions_per_case"),
+            field="policy.min_repetitions_per_case",
+            minimum=2,
+            maximum=8,
+        ),
+        "max_wall_time_ratio": _positive_ratio(
+            value.get("max_wall_time_ratio"), field="policy.max_wall_time_ratio"
+        ),
+        "max_cost_ratio": _positive_ratio(
+            value.get("max_cost_ratio"), field="policy.max_cost_ratio"
+        ),
+    }
+
+
+def _exact_compact_result(value: Any, *, field: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field} must be a compact benchmark_result_v0 object")
+    source = dict(value)
+    compact = compact_benchmark_result(source)
+    if compact is None or compact != source:
+        raise ValueError(
+            f"{field} must already be an exact compact benchmark_result_v0 object"
+        )
+    trace_publicness = compact.get("trace_publicness")
+    if trace_publicness not in _PUBLIC_TRACE_LABELS:
+        raise ValueError(f"{field}.trace_publicness must declare compact public evidence")
+    official_score = compact.get("official_task_score")
+    if not isinstance(official_score, Mapping) or not isinstance(
+        official_score.get("passed"), bool
+    ):
+        raise ValueError(f"{field}.official_task_score.passed must be explicit")
+    counts = compact.get("counts")
+    if not isinstance(counts, Mapping):
+        raise ValueError(f"{field}.counts must be present")
+    for count_field in ("wall_time_ms", "cost_usd"):
+        count = counts.get(count_field)
+        if (
+            not isinstance(count, (int, float))
+            or isinstance(count, bool)
+            or count < 0
+        ):
+            raise ValueError(f"{field}.counts.{count_field} must be non-negative")
+    for count_field in ("erroneous_write_count", "human_intervention_count"):
+        count = counts.get(count_field)
+        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+            raise ValueError(
+                f"{field}.counts.{count_field} must be a non-negative integer"
+            )
+    if not isinstance(compact.get("stop_policy_correct"), bool):
+        raise ValueError(f"{field}.stop_policy_correct must be explicit")
+    if not compact.get("task_id") or not compact.get("terminal_state"):
+        raise ValueError(f"{field} must include task_id and terminal_state")
+    return compact
+
+
+def _normalize_pair(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError("manifest.pairs[] must be an object")
+    unknown = set(value) - _PAIR_FIELDS
+    if unknown:
+        raise ValueError("manifest.pairs[] contains unknown fields")
+    for field in _REQUIRED_PARITY_FIELDS:
+        if value.get(field) is not True:
+            raise ValueError(f"manifest.pairs[].{field} must be true")
+    baseline = _exact_compact_result(
+        value.get("baseline_result"), field="manifest.pairs[].baseline_result"
+    )
+    candidate = _exact_compact_result(
+        value.get("candidate_result"), field="manifest.pairs[].candidate_result"
+    )
+    if baseline["task_id"] != candidate["task_id"]:
+        raise ValueError("paired results must have the same task_id")
+    return {
+        "case_id": _token(value.get("case_id"), field="manifest.pairs[].case_id"),
+        "repeat_index": _bounded_int(
+            value.get("repeat_index"),
+            field="manifest.pairs[].repeat_index",
+            minimum=1,
+            maximum=32,
+        ),
+        "baseline_result": baseline,
+        "candidate_result": candidate,
+    }
+
+
+def _normalize_manifest(value: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError("manifest must be an object")
+    unknown = set(value) - _MANIFEST_FIELDS
+    if unknown:
+        raise ValueError("manifest contains unknown fields")
+    if value.get("schema_version") != RELEASE_OUTCOME_PAIR_MANIFEST_SCHEMA_VERSION:
+        raise ValueError("manifest must use release_outcome_pair_manifest_v0")
+    raw_pairs = value.get("pairs")
+    if not isinstance(raw_pairs, list) or not raw_pairs:
+        raise ValueError("manifest.pairs must be a non-empty list")
+    if len(raw_pairs) > 96:
+        raise ValueError("manifest.pairs must contain at most 96 paired attempts")
+    pairs = [_normalize_pair(pair) for pair in raw_pairs]
+    identities = [(pair["case_id"], pair["repeat_index"]) for pair in pairs]
+    if len(set(identities)) != len(identities):
+        raise ValueError("manifest contains a duplicate case_id/repeat_index pair")
+    case_tasks: dict[str, str] = {}
+    for pair in pairs:
+        case_id = pair["case_id"]
+        task_id = pair["baseline_result"]["task_id"]
+        if case_id in case_tasks and case_tasks[case_id] != task_id:
+            raise ValueError("each case_id must keep the same task_id across repetitions")
+        case_tasks[case_id] = task_id
+    return {
+        "schema_version": RELEASE_OUTCOME_PAIR_MANIFEST_SCHEMA_VERSION,
+        "baseline_ref": _token(value.get("baseline_ref"), field="manifest.baseline_ref"),
+        "candidate_ref": _token(
+            value.get("candidate_ref"), field="manifest.candidate_ref"
+        ),
+        "policy": _normalized_policy(value.get("policy")),
+        "pairs": pairs,
+    }
+
+
+def _mean(values: Iterable[float]) -> float:
+    return round(fmean(values), 6)
+
+
+def _arm_metrics(results: list[dict[str, Any]]) -> dict[str, Any]:
+    attempt_count = len(results)
+    completed_count = sum(
+        result["terminal_state"] in _COMPLETED_TERMINAL_STATES for result in results
+    )
+    verifier_pass_count = sum(
+        result["official_task_score"]["passed"] is True for result in results
+    )
+    stop_correct_count = sum(result["stop_policy_correct"] is True for result in results)
+    erroneous_write_count = sum(
+        float(result["counts"]["erroneous_write_count"]) for result in results
+    )
+    human_intervention_count = sum(
+        float(result["counts"]["human_intervention_count"]) for result in results
+    )
+    return {
+        "attempt_count": attempt_count,
+        "completed_count": completed_count,
+        "completion_rate": round(completed_count / attempt_count, 6),
+        "verifier_pass_count": verifier_pass_count,
+        "verifier_pass_rate": round(verifier_pass_count / attempt_count, 6),
+        "erroneous_write_count": erroneous_write_count,
+        "human_intervention_count": human_intervention_count,
+        "stop_policy_correct_count": stop_correct_count,
+        "stop_policy_correct_rate": round(stop_correct_count / attempt_count, 6),
+        "mean_wall_time_ms": _mean(
+            float(result["counts"]["wall_time_ms"]) for result in results
+        ),
+        "mean_cost_usd": _mean(
+            float(result["counts"]["cost_usd"]) for result in results
+        ),
+    }
+
+
+def _ratio(candidate: float, baseline: float) -> float | None:
+    if baseline == 0:
+        return 1.0 if candidate == 0 else None
+    return round(candidate / baseline, 6)
+
+
+def build_release_outcome_baseline(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    """Reduce paired compact outcomes into a review-only release receipt."""
+
+    normalized = _normalize_manifest(manifest)
+    pairs = normalized["pairs"]
+    policy = normalized["policy"]
+    case_repetitions = Counter(pair["case_id"] for pair in pairs)
+    baseline_results = [pair["baseline_result"] for pair in pairs]
+    candidate_results = [pair["candidate_result"] for pair in pairs]
+    baseline_metrics = _arm_metrics(baseline_results)
+    candidate_metrics = _arm_metrics(candidate_results)
+
+    deltas = {
+        field: round(candidate_metrics[field] - baseline_metrics[field], 6)
+        for field in (
+            "completion_rate",
+            "verifier_pass_rate",
+            "erroneous_write_count",
+            "human_intervention_count",
+            "stop_policy_correct_rate",
+        )
+    }
+    wall_time_ratio = _ratio(
+        candidate_metrics["mean_wall_time_ms"], baseline_metrics["mean_wall_time_ms"]
+    )
+    cost_ratio = _ratio(
+        candidate_metrics["mean_cost_usd"], baseline_metrics["mean_cost_usd"]
+    )
+    deltas["wall_time_ratio"] = wall_time_ratio
+    deltas["cost_ratio"] = cost_ratio
+
+    evidence_gaps: list[str] = []
+    if len(case_repetitions) < policy["min_distinct_cases"]:
+        evidence_gaps.append("insufficient_distinct_cases")
+    if any(
+        repeat_count < policy["min_repetitions_per_case"]
+        for repeat_count in case_repetitions.values()
+    ):
+        evidence_gaps.append("insufficient_repetitions_per_case")
+
+    regressions: list[str] = []
+    for field in ("completion_rate", "verifier_pass_rate", "stop_policy_correct_rate"):
+        if deltas[field] < 0:
+            regressions.append(field)
+    for field in ("erroneous_write_count", "human_intervention_count"):
+        if deltas[field] > 0:
+            regressions.append(field)
+    if wall_time_ratio is None or wall_time_ratio > policy["max_wall_time_ratio"]:
+        regressions.append("wall_time_ratio")
+    if cost_ratio is None or cost_ratio > policy["max_cost_ratio"]:
+        regressions.append("cost_ratio")
+
+    decision = "owner_review_required"
+    if evidence_gaps:
+        decision = "insufficient_evidence"
+    elif regressions:
+        decision = "hold_regression"
+
+    return {
+        "schema_version": RELEASE_OUTCOME_BASELINE_SCHEMA_VERSION,
+        "baseline_ref": normalized["baseline_ref"],
+        "candidate_ref": normalized["candidate_ref"],
+        "decision": decision,
+        "eligible_for_owner_review": decision == "owner_review_required",
+        "automatic_release_promotion_allowed": False,
+        "coverage": {
+            "distinct_case_count": len(case_repetitions),
+            "paired_attempt_count": len(pairs),
+            "case_repetitions": dict(sorted(case_repetitions.items())),
+            "policy": policy,
+            "evidence_gaps": evidence_gaps,
+        },
+        "baseline": baseline_metrics,
+        "candidate": candidate_metrics,
+        "deltas": deltas,
+        "regressions": regressions,
+        "read_boundary": {
+            "compact_benchmark_results_only": True,
+            "raw_task_text_read": False,
+            "raw_trajectory_read": False,
+            "raw_verifier_output_read": False,
+            "local_paths_recorded": False,
+            "model_api_invoked": False,
+            "benchmark_execution_invoked": False,
+            "release_mutation_invoked": False,
+        },
+    }

--- a/tests/control_plane/test_benchmark_result.py
+++ b/tests/control_plane/test_benchmark_result.py
@@ -40,9 +40,13 @@ def test_compact_benchmark_result_preserves_public_score_contract() -> None:
                 },
                 "step_count": "3",
                 "wall_time_ms": 120,
+                "cost_usd": 0.25,
+                "erroneous_write_count": 0,
+                "human_intervention_count": 1,
                 "validation_pass_count": 2,
                 "open_todo_preserved": True,
                 "state_reconstructable": False,
+                "stop_policy_correct": True,
                 "failure_attribution_labels": [
                     "one",
                     "two",
@@ -76,10 +80,14 @@ def test_compact_benchmark_result_preserves_public_score_contract() -> None:
     assert compact["counts"] == {
         "step_count": 3,
         "wall_time_ms": 120,
+        "cost_usd": 0.25,
+        "erroneous_write_count": 0,
+        "human_intervention_count": 1,
         "validation_pass_count": 2,
     }
     assert compact["open_todo_preserved"] is True
     assert compact["state_reconstructable"] is False
+    assert compact["stop_policy_correct"] is True
     assert compact["failure_attribution_labels"] == [
         "one",
         "two",
@@ -88,6 +96,7 @@ def test_compact_benchmark_result_preserves_public_score_contract() -> None:
         "five",
     ]
     assert "private_detail" not in compact
+    assert compact_benchmark_result(compact) == compact
 
 
 def test_result_accepts_direct_rows_and_rejects_unrelated_payloads() -> None:

--- a/tests/control_plane/test_release_outcome_baseline.py
+++ b/tests/control_plane/test_release_outcome_baseline.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from loopx.control_plane.testing.release_outcome_baseline import (
+    build_release_outcome_baseline,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _result(
+    *,
+    task_id: str,
+    arm: str,
+    passed: bool = True,
+    wall_time_ms: int = 1000,
+    cost_usd: float = 1.0,
+    erroneous_writes: int = 0,
+    interventions: int = 0,
+    stop_correct: bool = True,
+) -> dict[str, object]:
+    return {
+        "schema_version": "benchmark_result_v0",
+        "task_id": task_id,
+        "scenario_id": arm,
+        "terminal_state": "completed" if passed else "failed",
+        "trace_publicness": "compact_public",
+        "official_task_score": {
+            "kind": "verifier_reward",
+            "aggregation": "final",
+            "passed": passed,
+            "value": 1.0 if passed else 0.0,
+        },
+        "counts": {
+            "wall_time_ms": wall_time_ms,
+            "cost_usd": cost_usd,
+            "erroneous_write_count": erroneous_writes,
+            "human_intervention_count": interventions,
+        },
+        "stop_policy_correct": stop_correct,
+    }
+
+
+def _manifest(*, case_count: int = 3, repeats: int = 2) -> dict[str, object]:
+    pairs: list[dict[str, object]] = []
+    for case_index in range(case_count):
+        for repeat_index in range(1, repeats + 1):
+            task_id = f"task-{case_index}"
+            pairs.append(
+                {
+                    "case_id": f"case-{case_index}",
+                    "repeat_index": repeat_index,
+                    "same_task_semantics": True,
+                    "same_runner_protocol": True,
+                    "same_verifier_contract": True,
+                    "same_budget": True,
+                    "baseline_result": _result(
+                        task_id=task_id,
+                        arm="baseline",
+                        wall_time_ms=1000,
+                        cost_usd=1.0,
+                    ),
+                    "candidate_result": _result(
+                        task_id=task_id,
+                        arm="candidate",
+                        wall_time_ms=900,
+                        cost_usd=0.9,
+                    ),
+                }
+            )
+    return {
+        "schema_version": "release_outcome_pair_manifest_v0",
+        "baseline_ref": "release:v0.2.5",
+        "candidate_ref": "candidate:compact-guided",
+        "policy": {
+            "min_distinct_cases": 3,
+            "min_repetitions_per_case": 2,
+            "max_wall_time_ratio": 1.25,
+            "max_cost_ratio": 1.25,
+        },
+        "pairs": pairs,
+    }
+
+
+def test_release_outcome_baseline_routes_clean_pair_to_owner_review() -> None:
+    receipt = build_release_outcome_baseline(_manifest())
+
+    assert receipt["decision"] == "owner_review_required"
+    assert receipt["eligible_for_owner_review"] is True
+    assert receipt["automatic_release_promotion_allowed"] is False
+    assert receipt["coverage"]["distinct_case_count"] == 3
+    assert receipt["coverage"]["paired_attempt_count"] == 6
+    assert receipt["regressions"] == []
+    assert receipt["deltas"]["wall_time_ratio"] == 0.9
+    assert receipt["deltas"]["cost_ratio"] == 0.9
+    assert receipt["read_boundary"]["model_api_invoked"] is False
+    assert receipt["read_boundary"]["benchmark_execution_invoked"] is False
+    assert receipt["read_boundary"]["release_mutation_invoked"] is False
+
+
+def test_release_outcome_baseline_holds_behavior_regressions() -> None:
+    manifest = _manifest()
+    candidate = manifest["pairs"][0]["candidate_result"]
+    candidate["terminal_state"] = "failed"
+    candidate["official_task_score"]["passed"] = False
+    candidate["official_task_score"]["value"] = 0.0
+    candidate["counts"]["erroneous_write_count"] = 1
+    candidate["counts"]["human_intervention_count"] = 1
+    candidate["stop_policy_correct"] = False
+
+    receipt = build_release_outcome_baseline(manifest)
+
+    assert receipt["decision"] == "hold_regression"
+    assert receipt["eligible_for_owner_review"] is False
+    assert set(receipt["regressions"]) >= {
+        "completion_rate",
+        "verifier_pass_rate",
+        "erroneous_write_count",
+        "human_intervention_count",
+        "stop_policy_correct_rate",
+    }
+
+
+def test_release_outcome_baseline_requires_representative_repeats() -> None:
+    receipt = build_release_outcome_baseline(_manifest(case_count=2, repeats=1))
+
+    assert receipt["decision"] == "insufficient_evidence"
+    assert receipt["eligible_for_owner_review"] is False
+    assert receipt["coverage"]["evidence_gaps"] == [
+        "insufficient_distinct_cases",
+        "insufficient_repetitions_per_case",
+    ]
+
+
+def test_release_outcome_baseline_fails_closed_on_noncompact_or_unpaired_input() -> None:
+    noncompact = _manifest()
+    noncompact["pairs"][0]["baseline_result"]["private_detail"] = "must-not-pass"
+    with pytest.raises(ValueError, match="exact compact benchmark_result_v0"):
+        build_release_outcome_baseline(noncompact)
+
+    unpaired = _manifest()
+    unpaired["pairs"][0]["same_budget"] = False
+    with pytest.raises(ValueError, match="same_budget must be true"):
+        build_release_outcome_baseline(unpaired)
+
+    mismatched_task = _manifest()
+    mismatched_task["pairs"][0]["candidate_result"]["task_id"] = "other-task"
+    with pytest.raises(ValueError, match="same task_id"):
+        build_release_outcome_baseline(mismatched_task)
+
+    unstable_case = _manifest()
+    unstable_case["pairs"][1]["baseline_result"]["task_id"] = "other-task"
+    unstable_case["pairs"][1]["candidate_result"]["task_id"] = "other-task"
+    with pytest.raises(ValueError, match="same task_id across repetitions"):
+        build_release_outcome_baseline(unstable_case)
+
+
+def test_release_outcome_cli_is_read_only_and_optionally_fails_closed(
+    tmp_path: Path,
+) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(_manifest()), encoding="utf-8")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "benchmark",
+            "release-outcome-baseline",
+            "--manifest-json",
+            str(manifest_path),
+            "--require-owner-review-ready",
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["decision"] == "owner_review_required"
+    assert payload["read_boundary"]["local_paths_recorded"] is False
+    assert str(tmp_path) not in result.stdout
+
+    insufficient = copy.deepcopy(_manifest())
+    insufficient["pairs"] = insufficient["pairs"][:2]
+    manifest_path.write_text(json.dumps(insufficient), encoding="utf-8")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "benchmark",
+            "release-outcome-baseline",
+            "--manifest-json",
+            str(manifest_path),
+            "--require-owner-review-ready",
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["decision"] == "insufficient_evidence"
+    assert payload["error"] == "insufficient_evidence"
+
+    missing_path = tmp_path / "missing-private-name.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "benchmark",
+            "release-outcome-baseline",
+            "--manifest-json",
+            str(missing_path),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["error"] == "manifest_unreadable"
+    assert str(tmp_path) not in result.stdout


### PR DESCRIPTION
## Summary
- add a read-only `benchmark release-outcome-baseline` reducer for stable base/candidate long-running result pairs
- compare completion, verifier, erroneous writes, human intervention, stop policy, wall time, and cost without executing benchmarks or models
- make compact `benchmark_result_v0` rows idempotent and preserve the added outcome fields
- document the three validation layers and keep promotion owner-reviewed

## Changed surfaces
- benchmark result compact read model
- standalone release outcome qualification module and benchmark CLI registration
- focused contract and CLI tests
- public protocol documentation

## Validation
- `pytest` focused/relevant control-plane set: 20 passed
- Ruff changed Python files: passed
- `loopx canary premerge --from-git-diff --tier standard`: 17 selected/executed, 0 failures, 0 warnings
- public/private boundary scan: clean across all 8 changed files

## Boundaries
- no raw task text, trajectories, verifier output, credentials, local paths, or generated logs are committed
- no model call, benchmark execution, release mutation, scoring change, or ordinary PR smoke requirement is introduced
- `owner_review_required` is evidence readiness, never automatic release approval

## Failures or skips
- no final validation failures or skips
- an early development run exposed non-idempotent compact result counts; the patch now includes a round-trip regression test

## Follow-up
- use the contract in a separate low-frequency run to collect representative repeated real-task pairs; that evidence is intentionally not part of this PR
