### PR TITLE
Add resumable LoopX Turn run-once execution

### DIFF
--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -1,18 +1,24 @@
 from __future__ import annotations
 
 import argparse
+import json
 from collections.abc import Callable
 from pathlib import Path
 
 from ..control_plane.turn_driver import (
+    LOOPX_TURN_EXECUTION_SCHEMA_VERSION,
     LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION,
     build_loopx_turn_plan,
+    load_loopx_turn_plan_from_journal,
+    run_loopx_turn_once,
 )
 from ..control_plane.quota.live_decision import build_live_quota_should_run_decision
 from ..control_plane.quota.turn_envelope import build_turn_envelope
 from ..control_plane.runtime.status_projection_cache import (
     resolve_status_projection_cache_runtime_root,
 )
+from ..quota import spend_quota_slot
+from ..state_refresh import refresh_state_run
 from ..status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, collect_status
 
 
@@ -34,7 +40,7 @@ def register_turn_commands(
 ) -> None:
     parser = subparsers.add_parser(
         "turn",
-        help="Plan one governed external-host turn from a live LoopX decision.",
+        help="Plan or run one governed external-host turn from a live LoopX decision.",
     )
     command_sub = parser.add_subparsers(dest="turn_command", required=True)
     plan = command_sub.add_parser(
@@ -42,35 +48,7 @@ def register_turn_commands(
         help="Build one typed read-only host decision without launching or writing.",
     )
     add_subcommand_format(plan)
-    plan.add_argument("--goal-id", required=True)
-    plan.add_argument("--agent-id", required=True)
-    plan.add_argument(
-        "--host",
-        choices=["codex-cli", "claude-code", "generic-cli"],
-        default="codex-cli",
-    )
-    plan.add_argument(
-        "--execution-mode",
-        choices=["interactive-visible", "isolated-headless"],
-        default="interactive-visible",
-    )
-    plan.add_argument(
-        "--resume-goal-id",
-        help="Goal identity bound to an available opaque host session.",
-    )
-    plan.add_argument(
-        "--resume-agent-id",
-        help="Agent identity bound to an available opaque host session.",
-    )
-    plan.add_argument(
-        "--resume-todo-id",
-        help="Todo identity bound to an available opaque host session.",
-    )
-    plan.add_argument(
-        "--available-capability",
-        dest="available_capabilities",
-        action="append",
-    )
+    _add_turn_decision_arguments(plan, default_host="codex-cli")
     plan.add_argument(
         "--include-transaction-detail",
         action="store_true",
@@ -88,6 +66,89 @@ def register_turn_commands(
         help="Specific public file or directory to scan. Repeatable.",
     )
     plan.add_argument("--limit", type=int, default=5)
+
+    run_once = command_sub.add_parser(
+        "run-once",
+        help=(
+            "Run one explicit isolated generic host command and commit only a "
+            "validated public-safe result."
+        ),
+    )
+    add_subcommand_format(run_once)
+    _add_turn_decision_arguments(
+        run_once,
+        default_host="generic-cli",
+        host_choices=["generic-cli"],
+        execution_mode_choices=["isolated-headless"],
+        default_execution_mode="isolated-headless",
+    )
+    run_once.add_argument("--project", required=True)
+    run_once.add_argument(
+        "--host-command-json",
+        required=True,
+        help="JSON argv array for the explicit host process; shell parsing is never used.",
+    )
+    run_once.add_argument("--timeout-seconds", type=float, default=120.0)
+    run_once.add_argument(
+        "--resume-turn-key",
+        help="Resume the exact journaled transaction without recomputing its plan.",
+    )
+    run_once.add_argument(
+        "--no-global-sync",
+        action="store_true",
+        help="Keep disposable fixture writeback out of the shared global registry.",
+    )
+    run_once.add_argument(
+        "--execute",
+        action="store_true",
+        help="Invoke the host and commit validated writeback/quota effects.",
+    )
+    run_once.add_argument(
+        "--scan-root",
+        default=_default_public_scan_root(),
+        help="Public files to scan for obvious private material.",
+    )
+    run_once.add_argument("--scan-path", action="append", default=[])
+    run_once.add_argument("--limit", type=int, default=5)
+
+
+def _add_turn_decision_arguments(
+    parser: argparse.ArgumentParser,
+    *,
+    default_host: str,
+    host_choices: list[str] | None = None,
+    execution_mode_choices: list[str] | None = None,
+    default_execution_mode: str = "interactive-visible",
+) -> None:
+    parser.add_argument("--goal-id", required=True)
+    parser.add_argument("--agent-id", required=True)
+    parser.add_argument(
+        "--host",
+        choices=host_choices or ["codex-cli", "claude-code", "generic-cli"],
+        default=default_host,
+    )
+    parser.add_argument(
+        "--execution-mode",
+        choices=execution_mode_choices or ["interactive-visible", "isolated-headless"],
+        default=default_execution_mode,
+    )
+    parser.add_argument(
+        "--resume-goal-id",
+        help="Goal identity bound to an available opaque host session.",
+    )
+    parser.add_argument(
+        "--resume-agent-id",
+        help="Agent identity bound to an available opaque host session.",
+    )
+    parser.add_argument(
+        "--resume-todo-id",
+        help="Todo identity bound to an available opaque host session.",
+    )
+    parser.add_argument(
+        "--available-capability",
+        dest="available_capabilities",
+        action="append",
+    )
 
 
 def _render_loopx_turn_plan_markdown(payload: dict[str, object]) -> str:
@@ -108,6 +169,22 @@ def _render_loopx_turn_plan_markdown(payload: dict[str, object]) -> str:
     )
 
 
+def _render_loopx_turn_execution_markdown(payload: dict[str, object]) -> str:
+    effects = payload.get("effects") if isinstance(payload.get("effects"), dict) else {}
+    receipt = payload.get("receipt") if isinstance(payload.get("receipt"), dict) else {}
+    return "\n".join(
+        [
+            "# LoopX Turn Run Once",
+            f"- status: {payload.get('status')}",
+            f"- result_kind: {payload.get('result_kind')}",
+            f"- next_phase: {receipt.get('next_phase')}",
+            f"- host_invoked: {effects.get('host_invoked')}",
+            f"- state_written: {effects.get('state_written')}",
+            f"- quota_spent: {effects.get('quota_spent')}",
+        ]
+    )
+
+
 def handle_turn_command(
     args: argparse.Namespace,
     *,
@@ -119,8 +196,6 @@ def handle_turn_command(
     if args.command != "turn":
         return None
     try:
-        if args.turn_command != "plan":
-            raise ValueError("turn requires the `plan` subcommand")
         scan_roots = [Path(item).expanduser() for item in args.scan_path]
         if not scan_roots:
             scan_roots = [Path(args.scan_root).expanduser()]
@@ -172,17 +247,134 @@ def handle_turn_command(
             execution_mode=args.execution_mode,
             session_binding=session_binding,
         )
-        if not args.include_transaction_detail:
-            payload.pop("session", None)
-            payload.pop("transaction", None)
-            boundary = payload.get("boundary")
-            if isinstance(boundary, dict):
-                boundary.pop("opaque_session_handle_omitted", None)
+        if args.turn_command == "plan":
+            if not args.include_transaction_detail:
+                payload.pop("session", None)
+                payload.pop("transaction", None)
+                boundary = payload.get("boundary")
+                if isinstance(boundary, dict):
+                    boundary.pop("opaque_session_handle_omitted", None)
+        elif args.turn_command == "run-once":
+            if args.resume_turn_key:
+                if supplied_resume_fields:
+                    raise ValueError(
+                        "--resume-turn-key cannot be combined with host session identity flags"
+                    )
+                payload = load_loopx_turn_plan_from_journal(
+                    runtime_root,
+                    goal_id=args.goal_id,
+                    turn_key=args.resume_turn_key,
+                )
+                envelope = (
+                    payload.get("turn_envelope")
+                    if isinstance(payload.get("turn_envelope"), dict)
+                    else {}
+                )
+                if envelope.get("agent_id") != args.agent_id:
+                    raise ValueError(
+                        "LoopX Turn resume journal belongs to another agent"
+                    )
+            raw_argv = json.loads(args.host_command_json)
+            if not isinstance(raw_argv, list) or not all(
+                isinstance(item, str) for item in raw_argv
+            ):
+                raise ValueError("--host-command-json must be a JSON string array")
+            project = Path(args.project).expanduser().resolve()
+
+            def writeback(result: dict[str, object]) -> dict[str, object]:
+                return refresh_state_run(
+                    registry_path=registry_path,
+                    runtime_root_override=runtime_root_arg,
+                    goal_id=args.goal_id,
+                    project=project,
+                    state_file=None,
+                    classification=str(result["classification"]),
+                    recommended_action=str(result["recommended_action"]),
+                    next_action=str(result["next_action"]),
+                    delivery_batch_scale=str(result["delivery_batch_scale"]),
+                    delivery_outcome=str(result["delivery_outcome"]),
+                    agent_id=args.agent_id,
+                    progress_scope="goal",
+                    vision_unchanged_reason=str(result["vision_unchanged_reason"]),
+                    dry_run=False,
+                    sync_global=not bool(args.no_global_sync),
+                )
+
+            def current_status() -> dict[str, object]:
+                return collect_status(
+                    registry_path=registry_path,
+                    runtime_root_override=runtime_root_arg,
+                    scan_roots=scan_roots,
+                    limit=max(max(0, args.limit), AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK),
+                )
+
+            def spend() -> dict[str, object]:
+                return spend_quota_slot(
+                    current_status(),
+                    goal_id=args.goal_id,
+                    slots=1,
+                    execute=True,
+                    source="adapter",
+                    agent_id=args.agent_id,
+                    available_capabilities=args.available_capabilities,
+                )
+
+            def scheduler(_spend_payload: dict[str, object]) -> dict[str, object]:
+                latest = build_live_quota_should_run_decision(
+                    current_status(),
+                    goal_id=args.goal_id,
+                    agent_id=args.agent_id,
+                    available_capabilities=args.available_capabilities,
+                    include_scheduler_detail=False,
+                    codex_app_current_rrule=None,
+                    registry_path=registry_path,
+                    runtime_root=runtime_root,
+                    route_source="loopx_turn_run_once",
+                )
+                hint = latest.get("scheduler_hint") if isinstance(latest.get("scheduler_hint"), dict) else {}
+                codex_app = hint.get("codex_app") if isinstance(hint.get("codex_app"), dict) else {}
+                backoff = codex_app.get("stateful_backoff") if isinstance(codex_app.get("stateful_backoff"), dict) else {}
+                apply_needed = backoff.get("apply_needed") is True
+                return {
+                    "disposition": "host_action_required" if apply_needed else "not_required",
+                    "completed": not apply_needed,
+                    "acknowledged": False,
+                    "apply_needed": apply_needed,
+                    **(
+                        {
+                            "recommended_interval_minutes": codex_app.get(
+                                "recommended_interval_minutes"
+                            ),
+                            "ack_hint": codex_app.get("ack_hint"),
+                        }
+                        if apply_needed
+                        else {}
+                    ),
+                }
+
+            payload = run_loopx_turn_once(
+                payload,
+                host_argv=raw_argv,
+                project=project,
+                runtime_root=runtime_root,
+                goal_id=args.goal_id,
+                timeout_seconds=args.timeout_seconds,
+                execute=bool(args.execute),
+                writeback=writeback if args.execute else None,
+                spend=spend if args.execute else None,
+                scheduler=scheduler if args.execute else None,
+            )
+        else:
+            raise ValueError("turn requires the `plan` or `run-once` subcommand")
     except Exception as exc:
         payload = {
             "ok": False,
-            "schema_version": "loopx_turn_plan_v0",
-            "mode": "plan",
+            "schema_version": (
+                LOOPX_TURN_EXECUTION_SCHEMA_VERSION
+                if args.turn_command == "run-once"
+                else "loopx_turn_plan_v0"
+            ),
+            "mode": "run_once" if args.turn_command == "run-once" else "plan",
             "error": str(exc),
             "effects": {
                 "host_invoked": False,
@@ -191,5 +383,10 @@ def handle_turn_command(
                 "quota_spent": False,
             },
         }
-    print_payload(payload, output_format(args), _render_loopx_turn_plan_markdown)
+    renderer = (
+        _render_loopx_turn_execution_markdown
+        if args.turn_command == "run-once"
+        else _render_loopx_turn_plan_markdown
+    )
+    print_payload(payload, output_format(args), renderer)
     return 0 if payload.get("ok") else 1

--- a/loopx/control_plane/testing/cli_output_budget.py
+++ b/loopx/control_plane/testing/cli_output_budget.py
@@ -149,8 +149,8 @@ CLI_OUTPUT_BUDGET_SPECS: tuple[CliOutputBudgetSpec, ...] = (
         consumer_action="route one live LoopX decision without host or state side effects",
         qualification_policy="absolute_hot_path",
         cold_path=(
-            "--include-transaction-detail, TurnEnvelope detail_ref commands, "
-            "and full quota should-run decision"
+            "--include-transaction-detail, turn run-once, TurnEnvelope detail_ref "
+            "commands, and full quota should-run decision"
         ),
         semantic_json_keys=("route", "turn_envelope", "effects", "boundary"),
         markdown_anchor="# LoopX Turn Plan",
@@ -381,6 +381,16 @@ CLI_OUTPUT_MODE_VARIANT_SPECS: tuple[CliOutputModeVariantSpec, ...] = (
         markdown_anchor=None,
         max_chars={"json": 13_000},
         max_lines={"json": 360},
+    ),
+    CliOutputModeVariantSpec(
+        variant_id="loopx_turn_run_once_preview",
+        parent_surface_id="loopx_turn_plan",
+        command="turn run-once",
+        output_formats=("json", "markdown"),
+        semantic_json_keys=("status", "host", "effects", "resume_turn_key"),
+        markdown_anchor="# LoopX Turn Run Once",
+        max_chars={"json": 3_000, "markdown": 350},
+        max_lines={"json": 90, "markdown": 12},
     ),
     CliOutputModeVariantSpec(
         variant_id="status_task_graph_detail",

--- a/loopx/control_plane/turn_driver/__init__.py
+++ b/loopx/control_plane/turn_driver/__init__.py
@@ -5,6 +5,15 @@ from .driver import (
     LoopXTurnRoute,
     build_loopx_turn_plan,
 )
+from .executor import (
+    LOOPX_TURN_EXECUTION_SCHEMA_VERSION,
+    LOOPX_TURN_HOST_REQUEST_SCHEMA_VERSION,
+    build_loopx_turn_host_request,
+    load_loopx_turn_plan_from_journal,
+    normalize_host_argv,
+    run_loopx_turn_once,
+    validate_loopx_turn_host_result,
+)
 from .transaction import (
     LOOPX_TURN_RESULT_SCHEMA_VERSION,
     LoopXTurnResultKind,
@@ -15,9 +24,16 @@ from .transaction import (
 __all__ = [
     "LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION",
     "LOOPX_TURN_RESULT_SCHEMA_VERSION",
+    "LOOPX_TURN_EXECUTION_SCHEMA_VERSION",
+    "LOOPX_TURN_HOST_REQUEST_SCHEMA_VERSION",
     "LoopXTurnRoute",
     "LoopXTurnResultKind",
     "build_loopx_turn_plan",
+    "build_loopx_turn_host_request",
     "build_loopx_turn_transaction_plan",
+    "load_loopx_turn_plan_from_journal",
+    "normalize_host_argv",
+    "run_loopx_turn_once",
+    "validate_loopx_turn_host_result",
     "validate_loopx_turn_receipt",
 ]

--- a/loopx/control_plane/turn_driver/executor.py
+++ b/loopx/control_plane/turn_driver/executor.py
@@ -1,0 +1,600 @@
+"""One bounded LoopX Turn host execution with resumable local receipts."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import tempfile
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from ...authority import validate_public_safe_text
+from ...file_lock import exclusive_file_lock
+from ..work_items.delivery_batch_scale import require_delivery_batch_scale
+from ..work_items.delivery_outcome import require_delivery_outcome
+from .transaction import (
+    LOOPX_TURN_RESULT_SCHEMA_VERSION,
+    TRANSACTION_PHASES,
+    LoopXTurnResultKind,
+    validate_loopx_turn_receipt,
+)
+
+
+LOOPX_TURN_HOST_REQUEST_SCHEMA_VERSION = "loopx_turn_host_request_v0"
+LOOPX_TURN_EXECUTION_SCHEMA_VERSION = "loopx_turn_execution_v0"
+LOOPX_TURN_JOURNAL_SCHEMA_VERSION = "loopx_turn_journal_v0"
+HOST_RESULT_MAX_BYTES = 12_000
+HOST_ARG_MAX_COUNT = 32
+HOST_ARG_MAX_CHARS = 1_024
+TURN_KEY_RE = re.compile(r"^sha256:(?P<digest>[0-9a-f]{64})$")
+
+MATERIAL_HOST_RESULT_KINDS = {
+    LoopXTurnResultKind.VALIDATED_PROGRESS,
+    LoopXTurnResultKind.REPAIR_REQUIRED,
+    LoopXTurnResultKind.REPLAN_REQUIRED,
+}
+STOP_HOST_RESULT_KINDS = {
+    LoopXTurnResultKind.USER_ACTION_REQUIRED,
+    LoopXTurnResultKind.WAIT,
+}
+HOST_RESULT_FIELDS = {
+    "schema_version",
+    "turn_key",
+    "result_kind",
+    "completed_phases",
+    "classification",
+    "recommended_action",
+    "next_action",
+    "delivery_batch_scale",
+    "delivery_outcome",
+    "vision_unchanged_reason",
+    "summary",
+}
+
+Writeback = Callable[[dict[str, Any]], dict[str, Any]]
+Spend = Callable[[], dict[str, Any]]
+Scheduler = Callable[[dict[str, Any]], dict[str, Any]]
+
+
+def normalize_host_argv(value: Sequence[str]) -> list[str]:
+    argv = [str(item) for item in value]
+    if not argv:
+        raise ValueError("host command must contain at least one argv item")
+    if len(argv) > HOST_ARG_MAX_COUNT:
+        raise ValueError(f"host command exceeds {HOST_ARG_MAX_COUNT} argv items")
+    for item in argv:
+        if not item or "\x00" in item or len(item) > HOST_ARG_MAX_CHARS:
+            raise ValueError("host command contains an empty, NUL, or oversized argv item")
+    return argv
+
+
+def build_loopx_turn_host_request(plan: Mapping[str, Any]) -> dict[str, Any]:
+    transaction = plan.get("transaction") if isinstance(plan.get("transaction"), dict) else {}
+    turn_key = str(transaction.get("turn_key") or "")
+    if not TURN_KEY_RE.fullmatch(turn_key):
+        raise ValueError("LoopX Turn plan has no valid transaction turn_key")
+    route = plan.get("route") if isinstance(plan.get("route"), dict) else {}
+    if route.get("would_invoke_host") is not True:
+        raise ValueError("LoopX Turn route is not host executable")
+    return {
+        "schema_version": LOOPX_TURN_HOST_REQUEST_SCHEMA_VERSION,
+        "turn_key": turn_key,
+        "route": route.get("kind"),
+        "session": plan.get("session"),
+        "turn_envelope": plan.get("turn_envelope"),
+        "result_contract": {
+            "schema_version": LOOPX_TURN_RESULT_SCHEMA_VERSION,
+            "completed_phases": list(TRANSACTION_PHASES[:2]),
+            "stdout": "one public-safe JSON object",
+        },
+    }
+
+
+def _bounded_public_text(
+    result: Mapping[str, Any],
+    field: str,
+    *,
+    limit: int,
+    required: bool,
+    errors: list[str],
+) -> str | None:
+    text = str(result.get(field) or "").strip()
+    if required and not text:
+        errors.append(f"{field} is required")
+        return None
+    if not text:
+        return None
+    if len(text) > limit:
+        errors.append(f"{field} exceeds {limit} characters")
+        return None
+    try:
+        validate_public_safe_text(f"host_result.{field}", text)
+    except ValueError as exc:
+        errors.append(str(exc))
+        return None
+    return text
+
+
+def validate_loopx_turn_host_result(
+    plan: Mapping[str, Any],
+    value: Mapping[str, Any],
+) -> dict[str, Any]:
+    result = dict(value)
+    errors: list[str] = []
+    unknown = sorted(set(result) - HOST_RESULT_FIELDS)
+    if unknown:
+        errors.append("unsupported host result fields: " + ", ".join(unknown))
+    if result.get("schema_version") != LOOPX_TURN_RESULT_SCHEMA_VERSION:
+        errors.append("unsupported host result schema_version")
+
+    transaction = plan.get("transaction") if isinstance(plan.get("transaction"), dict) else {}
+    turn_key = str(transaction.get("turn_key") or "")
+    if not turn_key or str(result.get("turn_key") or "") != turn_key:
+        errors.append("host result turn_key does not match the transaction plan")
+
+    try:
+        kind = LoopXTurnResultKind(str(result.get("result_kind") or ""))
+    except ValueError:
+        kind = None
+        errors.append("unsupported host result kind")
+    if kind is LoopXTurnResultKind.VALIDATED_COMPLETION:
+        errors.append("validated_completion requires a todo lifecycle adapter")
+    if kind not in MATERIAL_HOST_RESULT_KINDS | STOP_HOST_RESULT_KINDS:
+        if kind is not LoopXTurnResultKind.VALIDATED_COMPLETION:
+            errors.append("host result kind is not accepted by run-once")
+
+    phases = result.get("completed_phases")
+    if phases != list(TRANSACTION_PHASES[:2]):
+        errors.append("host result completed_phases must be host_execute, typed_result")
+
+    material = kind in MATERIAL_HOST_RESULT_KINDS
+    normalized = {
+        "schema_version": LOOPX_TURN_RESULT_SCHEMA_VERSION,
+        "turn_key": turn_key,
+        "result_kind": kind.value if kind else None,
+        "completed_phases": list(TRANSACTION_PHASES[:2]),
+    }
+    for field, limit in (
+        ("classification", 120),
+        ("recommended_action", 1_200),
+        ("next_action", 1_200),
+        ("vision_unchanged_reason", 240),
+        ("summary", 400),
+    ):
+        text = _bounded_public_text(
+            result,
+            field,
+            limit=limit,
+            required=material and field != "summary",
+            errors=errors,
+        )
+        if text:
+            normalized[field] = text
+    if material:
+        try:
+            normalized["delivery_batch_scale"] = require_delivery_batch_scale(
+                result.get("delivery_batch_scale")
+            ).value
+        except ValueError as exc:
+            errors.append(str(exc))
+        try:
+            normalized["delivery_outcome"] = require_delivery_outcome(
+                result.get("delivery_outcome")
+            ).value
+        except ValueError as exc:
+            errors.append(str(exc))
+    return {
+        "ok": not errors,
+        "result": normalized,
+        "errors": errors,
+    }
+
+
+def turn_journal_path(runtime_root: Path, *, goal_id: str, turn_key: str) -> Path:
+    match = TURN_KEY_RE.fullmatch(turn_key)
+    if not match:
+        raise ValueError("turn_key must be a sha256 digest")
+    return runtime_root / "goals" / goal_id / "turns" / f"{match.group('digest')}.json"
+
+
+def _write_journal(path: Path, journal: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(journal, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _load_journal(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict) or value.get("schema_version") != LOOPX_TURN_JOURNAL_SCHEMA_VERSION:
+        raise ValueError("LoopX Turn journal has an unsupported schema")
+    return value
+
+
+def load_loopx_turn_plan_from_journal(
+    runtime_root: Path,
+    *,
+    goal_id: str,
+    turn_key: str,
+) -> dict[str, Any]:
+    path = turn_journal_path(runtime_root, goal_id=goal_id, turn_key=turn_key)
+    with exclusive_file_lock(path):
+        journal = _load_journal(path)
+    if journal is None:
+        raise ValueError("LoopX Turn resume journal does not exist")
+    plan = journal.get("plan")
+    if not isinstance(plan, dict):
+        raise ValueError("LoopX Turn resume journal does not contain a plan")
+    transaction = plan.get("transaction") if isinstance(plan.get("transaction"), dict) else {}
+    if transaction.get("turn_key") != turn_key or journal.get("turn_key") != turn_key:
+        raise ValueError("LoopX Turn resume journal has mismatched turn lineage")
+    envelope = plan.get("turn_envelope") if isinstance(plan.get("turn_envelope"), dict) else {}
+    if envelope.get("goal_id") != goal_id or journal.get("goal_id") != goal_id:
+        raise ValueError("LoopX Turn resume journal belongs to another goal")
+    return dict(plan)
+
+
+def _receipt(
+    plan: Mapping[str, Any],
+    result: Mapping[str, Any],
+    *,
+    completed_phases: Sequence[str],
+    failure_kind: LoopXTurnResultKind | None = None,
+    failed_phase: str | None = None,
+) -> dict[str, Any]:
+    payload = {
+        "schema_version": LOOPX_TURN_RESULT_SCHEMA_VERSION,
+        "turn_key": result.get("turn_key"),
+        "result_kind": (
+            failure_kind.value if failure_kind else result.get("result_kind")
+        ),
+        "completed_phases": list(completed_phases),
+        "failed_phase": failed_phase,
+    }
+    return validate_loopx_turn_receipt(
+        plan.get("transaction") if isinstance(plan.get("transaction"), dict) else {},
+        payload,
+    )
+
+
+def _host_failure(
+    plan: Mapping[str, Any],
+    *,
+    kind: LoopXTurnResultKind,
+    completed_phases: Sequence[str],
+    failed_phase: str,
+    reason: str,
+) -> dict[str, Any]:
+    transaction = plan.get("transaction") if isinstance(plan.get("transaction"), dict) else {}
+    result = {"turn_key": transaction.get("turn_key"), "result_kind": kind.value}
+    return {
+        "ok": False,
+        "reason": reason,
+        "receipt": _receipt(
+            plan,
+            result,
+            completed_phases=completed_phases,
+            failure_kind=kind,
+            failed_phase=failed_phase,
+        ),
+    }
+
+
+def _run_host(
+    request: Mapping[str, Any],
+    *,
+    argv: Sequence[str],
+    project: Path,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    try:
+        completed = subprocess.run(
+            list(argv),
+            cwd=project,
+            input=json.dumps(request, ensure_ascii=False, separators=(",", ":")),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=max(1.0, timeout_seconds),
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"ok": False, "reason": type(exc).__name__, "returncode": None}
+    if completed.returncode != 0:
+        return {
+            "ok": False,
+            "reason": "host command returned non-zero",
+            "returncode": completed.returncode,
+            "stderr_chars": len(completed.stderr),
+        }
+    encoded = completed.stdout.encode("utf-8")
+    if len(encoded) > HOST_RESULT_MAX_BYTES:
+        return {"ok": False, "reason": "host stdout exceeded the result budget", "returncode": 0}
+    try:
+        value = json.loads(completed.stdout)
+    except json.JSONDecodeError:
+        return {"ok": False, "reason": "host stdout is not one JSON value", "returncode": 0}
+    if not isinstance(value, dict):
+        return {"ok": False, "reason": "host stdout must be one JSON object", "returncode": 0}
+    return {"ok": True, "value": value, "returncode": 0}
+
+
+def _compact_callback(payload: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        key: payload.get(key)
+        for key in ("ok", "appended", "classification", "generated_at", "slots", "reason")
+        if key in payload
+    }
+
+
+def _execution_payload(
+    plan: Mapping[str, Any],
+    journal: Mapping[str, Any],
+    *,
+    execute: bool,
+    replayed: bool,
+    effects: Mapping[str, bool],
+) -> dict[str, Any]:
+    transaction = plan.get("transaction") if isinstance(plan.get("transaction"), dict) else {}
+    turn_key = str(transaction.get("turn_key") or "")
+    return {
+        "ok": journal.get("status") in {
+            "preview",
+            "committed",
+            "stopped",
+            "scheduler_action_required",
+        },
+        "schema_version": LOOPX_TURN_EXECUTION_SCHEMA_VERSION,
+        "mode": "run_once",
+        "dry_run": not execute,
+        "replayed": replayed,
+        "resume_turn_key": turn_key,
+        "journal_ref": f"turn:{turn_key.removeprefix('sha256:')[:16]}",
+        "status": journal.get("status"),
+        "host": journal.get("host"),
+        "result_kind": journal.get("result_kind"),
+        "receipt": journal.get("receipt"),
+        "scheduler": journal.get("scheduler"),
+        "effects": dict(effects),
+        **({"reason": journal.get("reason")} if journal.get("reason") else {}),
+    }
+
+
+def run_loopx_turn_once(
+    plan: Mapping[str, Any],
+    *,
+    host_argv: Sequence[str],
+    project: Path,
+    runtime_root: Path,
+    goal_id: str,
+    timeout_seconds: float,
+    execute: bool,
+    writeback: Writeback | None = None,
+    spend: Spend | None = None,
+    scheduler: Scheduler | None = None,
+) -> dict[str, Any]:
+    argv = normalize_host_argv(host_argv)
+    request = build_loopx_turn_host_request(plan)
+    host_projection = {"executable": Path(argv[0]).name, "argv_count": len(argv)}
+    empty_effects = {
+        "host_invoked": False,
+        "state_written": False,
+        "quota_spent": False,
+        "scheduler_acknowledged": False,
+    }
+    if not execute:
+        preview = {
+            "schema_version": LOOPX_TURN_JOURNAL_SCHEMA_VERSION,
+            "status": "preview",
+            "host": host_projection,
+            "result_kind": None,
+            "receipt": None,
+            "scheduler": {"disposition": "not_evaluated"},
+        }
+        return _execution_payload(
+            plan,
+            preview,
+            execute=False,
+            replayed=False,
+            effects=empty_effects,
+        )
+    if writeback is None or spend is None or scheduler is None:
+        raise ValueError("executing run-once requires writeback, spend, and scheduler callbacks")
+
+    turn_key = str(request["turn_key"])
+    journal_path = turn_journal_path(runtime_root, goal_id=goal_id, turn_key=turn_key)
+    with exclusive_file_lock(journal_path):
+        journal = _load_journal(journal_path)
+        if journal and journal.get("status") in {
+            "committed",
+            "stopped",
+            "failed",
+        }:
+            return _execution_payload(
+                plan,
+                journal,
+                execute=True,
+                replayed=True,
+                effects=empty_effects,
+            )
+        if journal is None:
+            journal = {
+                "schema_version": LOOPX_TURN_JOURNAL_SCHEMA_VERSION,
+                "turn_key": turn_key,
+                "goal_id": goal_id,
+                "status": "in_progress",
+                "host": host_projection,
+                "completed_phases": [],
+                "plan": dict(plan),
+            }
+            _write_journal(journal_path, journal)
+
+        effects = dict(empty_effects)
+        completed_phases = list(journal.get("completed_phases") or [])
+        result = journal.get("host_result") if isinstance(journal.get("host_result"), dict) else None
+        if "typed_result" not in completed_phases:
+            host_observation = _run_host(
+                request,
+                argv=argv,
+                project=project,
+                timeout_seconds=timeout_seconds,
+            )
+            effects["host_invoked"] = True
+            if not host_observation.get("ok"):
+                failure = _host_failure(
+                    plan,
+                    kind=LoopXTurnResultKind.HOST_FAILURE,
+                    completed_phases=[],
+                    failed_phase="host_execute",
+                    reason=str(host_observation.get("reason") or "host execution failed"),
+                )
+                journal.update(
+                    status="failed",
+                    reason=failure["reason"],
+                    receipt=failure["receipt"],
+                    completed_phases=[],
+                )
+                _write_journal(journal_path, journal)
+                return _execution_payload(plan, journal, execute=True, replayed=False, effects=effects)
+            result = dict(host_observation["value"])
+            completed_phases = list(TRANSACTION_PHASES[:2])
+
+        validation = validate_loopx_turn_host_result(plan, result or {})
+        if not validation.get("ok"):
+            failure = _host_failure(
+                plan,
+                kind=LoopXTurnResultKind.VALIDATION_FAILED,
+                completed_phases=list(TRANSACTION_PHASES[:2]),
+                failed_phase="validation",
+                reason="; ".join(validation.get("errors") or ["host result validation failed"]),
+            )
+            journal.update(
+                status="failed",
+                reason=failure["reason"],
+                receipt=failure["receipt"],
+                completed_phases=list(TRANSACTION_PHASES[:2]),
+            )
+            _write_journal(journal_path, journal)
+            return _execution_payload(plan, journal, execute=True, replayed=False, effects=effects)
+        result = dict(validation["result"])
+        if len(completed_phases) < 3:
+            completed_phases = list(TRANSACTION_PHASES[:3])
+        journal.update(
+            host_result=result,
+            result_kind=result.get("result_kind"),
+            completed_phases=completed_phases,
+        )
+        _write_journal(journal_path, journal)
+
+        kind = LoopXTurnResultKind(str(result["result_kind"]))
+        if kind in STOP_HOST_RESULT_KINDS:
+            journal.update(
+                status="stopped",
+                receipt=_receipt(plan, result, completed_phases=completed_phases),
+                scheduler={"disposition": "not_applicable"},
+            )
+            _write_journal(journal_path, journal)
+            return _execution_payload(plan, journal, execute=True, replayed=False, effects=effects)
+
+        if "durable_writeback" not in completed_phases:
+            writeback_payload = writeback(result)
+            if not writeback_payload.get("ok") or not writeback_payload.get("appended"):
+                failure = _host_failure(
+                    plan,
+                    kind=LoopXTurnResultKind.WRITEBACK_FAILED,
+                    completed_phases=completed_phases,
+                    failed_phase="durable_writeback",
+                    reason=str(
+                        writeback_payload.get("error")
+                        or writeback_payload.get("reason")
+                        or "writeback failed"
+                    ),
+                )
+                journal.update(
+                    status="failed",
+                    reason=failure["reason"],
+                    receipt=failure["receipt"],
+                )
+                _write_journal(journal_path, journal)
+                return _execution_payload(
+                    plan,
+                    journal,
+                    execute=True,
+                    replayed=False,
+                    effects=effects,
+                )
+            effects["state_written"] = True
+            completed_phases = list(TRANSACTION_PHASES[:4])
+            journal.update(
+                completed_phases=completed_phases,
+                writeback=_compact_callback(writeback_payload),
+            )
+            _write_journal(journal_path, journal)
+
+        if "quota_spend" not in completed_phases:
+            spend_payload = spend()
+            if not spend_payload.get("ok") or not spend_payload.get("appended"):
+                failure = _host_failure(
+                    plan,
+                    kind=LoopXTurnResultKind.QUOTA_SPEND_FAILED,
+                    completed_phases=completed_phases,
+                    failed_phase="quota_spend",
+                    reason=str(spend_payload.get("reason") or "quota spend failed"),
+                )
+                journal.update(
+                    status="failed",
+                    reason=failure["reason"],
+                    receipt=failure["receipt"],
+                )
+                _write_journal(journal_path, journal)
+                return _execution_payload(
+                    plan,
+                    journal,
+                    execute=True,
+                    replayed=False,
+                    effects=effects,
+                )
+            effects["quota_spent"] = True
+            completed_phases = list(TRANSACTION_PHASES[:5])
+            journal.update(
+                completed_phases=completed_phases,
+                quota_spend=_compact_callback(spend_payload),
+            )
+            _write_journal(journal_path, journal)
+        else:
+            spend_payload = (
+                dict(journal["quota_spend"])
+                if isinstance(journal.get("quota_spend"), dict)
+                else {"ok": True, "appended": True}
+            )
+
+        scheduler_payload = scheduler(spend_payload)
+        journal["scheduler"] = scheduler_payload
+        if scheduler_payload.get("completed") is not True:
+            journal.update(
+                status="scheduler_action_required",
+                receipt=_receipt(plan, result, completed_phases=completed_phases),
+            )
+            _write_journal(journal_path, journal)
+            return _execution_payload(plan, journal, execute=True, replayed=False, effects=effects)
+
+        completed_phases = list(TRANSACTION_PHASES)
+        effects["scheduler_acknowledged"] = bool(scheduler_payload.get("acknowledged"))
+        journal.update(
+            status="committed",
+            completed_phases=completed_phases,
+            receipt=_receipt(plan, result, completed_phases=completed_phases),
+        )
+        _write_journal(journal_path, journal)
+        return _execution_payload(plan, journal, execute=True, replayed=False, effects=effects)

--- a/loopx/control_plane/turn_driver/transaction.py
+++ b/loopx/control_plane/turn_driver/transaction.py
@@ -34,6 +34,7 @@ class LoopXTurnResultKind(str, Enum):
     HOST_FAILURE = "host_failure"
     VALIDATION_FAILED = "validation_failed"
     WRITEBACK_FAILED = "writeback_failed"
+    QUOTA_SPEND_FAILED = "quota_spend_failed"
 
 
 MATERIAL_RESULT_KINDS = {
@@ -48,6 +49,7 @@ NO_SPEND_RESULT_KINDS = {
     LoopXTurnResultKind.HOST_FAILURE,
     LoopXTurnResultKind.VALIDATION_FAILED,
     LoopXTurnResultKind.WRITEBACK_FAILED,
+    LoopXTurnResultKind.QUOTA_SPEND_FAILED,
 }
 STOP_RESULT_KINDS = {
     LoopXTurnResultKind.USER_ACTION_REQUIRED,
@@ -57,6 +59,7 @@ FAILURE_PHASES = {
     LoopXTurnResultKind.HOST_FAILURE: "host_execute",
     LoopXTurnResultKind.VALIDATION_FAILED: "validation",
     LoopXTurnResultKind.WRITEBACK_FAILED: "durable_writeback",
+    LoopXTurnResultKind.QUOTA_SPEND_FAILED: "quota_spend",
 }
 
 

--- a/tests/control_plane/test_cli_output_budget.py
+++ b/tests/control_plane/test_cli_output_budget.py
@@ -428,6 +428,22 @@ def _mode_variant_commands(
             str(project),
             "--include-transaction-detail",
         ],
+        "loopx_turn_run_once_preview": common
+        + [
+            "turn",
+            "run-once",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_IDS[0],
+            "--project",
+            str(project),
+            "--host-command-json",
+            '["python3","-c","raise SystemExit(9)"]',
+            "--scan-root",
+            str(project),
+            "--no-global-sync",
+        ],
         "status_task_graph_detail": common
         + [
             "status",
@@ -501,6 +517,7 @@ def test_manifest_covers_the_declared_agent_facing_surface_set() -> None:
         "quota_should_run_scheduler_detail",
         "quota_should_run_turn_envelope",
         "loopx_turn_plan_transaction_detail",
+        "loopx_turn_run_once_preview",
         "status_task_graph_detail",
         "review_packet_full",
         "heartbeat_prompt_brief",

--- a/tests/test_loopx_turn_driver.py
+++ b/tests/test_loopx_turn_driver.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import io
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -448,3 +449,128 @@ def test_turn_cli_requires_complete_resume_identity(tmp_path: Path) -> None:
     assert exit_code == 1
     assert payload["ok"] is False
     assert "requires --resume-goal-id" in payload["error"]
+
+
+def test_turn_run_once_cli_commits_validated_result_and_one_quota_slot(
+    tmp_path: Path,
+) -> None:
+    project, runtime, registry = _write_live_fixture(tmp_path)
+    host_script = """
+import json
+import sys
+request = json.load(sys.stdin)
+json.dump({
+    "schema_version": "loopx_turn_result_v0",
+    "turn_key": request["turn_key"],
+    "result_kind": "validated_progress",
+    "completed_phases": ["host_execute", "typed_result"],
+    "classification": "fixture_progress",
+    "recommended_action": "Continue the public fixture",
+    "next_action": "Run the next public fixture check",
+    "delivery_batch_scale": "implementation",
+    "delivery_outcome": "outcome_progress",
+    "vision_unchanged_reason": "The fixture objective remains unchanged.",
+    "summary": "One public fixture advanced."
+}, sys.stdout)
+"""
+    output = io.StringIO()
+
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(
+            [
+                "--registry",
+                str(registry),
+                "--runtime-root",
+                str(runtime),
+                "--format",
+                "json",
+                "turn",
+                "run-once",
+                "--goal-id",
+                "loopx-turn-fixture",
+                "--agent-id",
+                "codex-fixture",
+                "--project",
+                str(project),
+                "--host-command-json",
+                json.dumps([sys.executable, "-c", host_script]),
+                "--scan-root",
+                str(project),
+                "--no-global-sync",
+                "--execute",
+            ]
+        )
+
+    payload = json.loads(output.getvalue())
+    assert exit_code == 0, payload
+    assert payload["status"] == "scheduler_action_required"
+    assert payload["receipt"]["status"] == "validated"
+    assert payload["receipt"]["next_phase"] == "scheduler_apply"
+    assert payload["resume_turn_key"].startswith("sha256:")
+    assert payload["effects"] == {
+        "host_invoked": True,
+        "state_written": True,
+        "quota_spent": True,
+        "scheduler_acknowledged": False,
+    }
+    state_path = (
+        project
+        / ".codex"
+        / "goals"
+        / "loopx-turn-fixture"
+        / "ACTIVE_GOAL_STATE.md"
+    )
+    assert "Run the next public fixture check" in state_path.read_text(encoding="utf-8")
+    index_path = runtime / "goals" / "loopx-turn-fixture" / "runs" / "index.jsonl"
+    rows = [json.loads(line) for line in index_path.read_text(encoding="utf-8").splitlines()]
+    assert [row["classification"] for row in rows] == [
+        "fixture_progress",
+        "quota_slot_spent",
+    ]
+
+    resumed_output = io.StringIO()
+    with contextlib.redirect_stdout(resumed_output):
+        resumed_exit_code = cli_main(
+            [
+                "--registry",
+                str(registry),
+                "--runtime-root",
+                str(runtime),
+                "--format",
+                "json",
+                "turn",
+                "run-once",
+                "--goal-id",
+                "loopx-turn-fixture",
+                "--agent-id",
+                "codex-fixture",
+                "--project",
+                str(project),
+                "--host-command-json",
+                json.dumps([sys.executable, "-c", host_script]),
+                "--scan-root",
+                str(project),
+                "--no-global-sync",
+                "--resume-turn-key",
+                payload["resume_turn_key"],
+                "--execute",
+            ]
+        )
+
+    resumed = json.loads(resumed_output.getvalue())
+    assert resumed_exit_code == 0, resumed
+    assert resumed["status"] == "scheduler_action_required"
+    assert resumed["effects"] == {
+        "host_invoked": False,
+        "state_written": False,
+        "quota_spent": False,
+        "scheduler_acknowledged": False,
+    }
+    replayed_rows = [
+        json.loads(line)
+        for line in index_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert [row["classification"] for row in replayed_rows] == [
+        "fixture_progress",
+        "quota_slot_spent",
+    ]

--- a/tests/test_loopx_turn_executor.py
+++ b/tests/test_loopx_turn_executor.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from loopx.control_plane.turn_driver import (
+    LOOPX_TURN_RESULT_SCHEMA_VERSION,
+    build_loopx_turn_plan,
+    load_loopx_turn_plan_from_journal,
+    run_loopx_turn_once,
+    validate_loopx_turn_host_result,
+)
+
+
+def _plan() -> dict[str, object]:
+    return build_loopx_turn_plan(
+        {
+            "ok": True,
+            "schema_version": "loopx_turn_envelope_v0",
+            "goal_id": "fixture-goal",
+            "agent_id": "codex-fixture",
+            "should_run": True,
+            "effective_action": "normal_run",
+            "action": {
+                "must_attempt": True,
+                "delivery_allowed": True,
+                "quiet_noop_allowed": False,
+                "selected_todo": {
+                    "todo_id": "todo_fixture0001",
+                    "text": "Advance one public fixture",
+                },
+            },
+            "user": {"action_required": False, "open_count": 0, "notify": "DONT_NOTIFY"},
+            "writeback": {"spend_after_validation": True},
+            "scheduler": {"action": "run_now"},
+            "action_signature": {
+                "matches": True,
+                "source_hash": "sha256:fixture",
+                "envelope_hash": "sha256:fixture",
+            },
+            "compaction": {"within_budget": True},
+        },
+        host="generic-cli",
+        execution_mode="isolated-headless",
+    )
+
+
+def _host_result(plan: dict[str, object], *, kind: str = "validated_progress") -> dict[str, object]:
+    transaction = plan["transaction"]
+    assert isinstance(transaction, dict)
+    result: dict[str, object] = {
+        "schema_version": LOOPX_TURN_RESULT_SCHEMA_VERSION,
+        "turn_key": transaction["turn_key"],
+        "result_kind": kind,
+        "completed_phases": ["host_execute", "typed_result"],
+    }
+    if kind == "validated_progress":
+        result.update(
+            classification="fixture_progress",
+            recommended_action="Continue the public fixture",
+            next_action="Run the next public fixture check",
+            delivery_batch_scale="implementation",
+            delivery_outcome="outcome_progress",
+            vision_unchanged_reason="The fixture objective is unchanged after validated progress.",
+            summary="One public fixture advanced.",
+        )
+    return result
+
+
+def _host_argv(result_path: Path, count_path: Path) -> list[str]:
+    script = """
+import json
+import pathlib
+import sys
+request = json.load(sys.stdin)
+result = json.loads(pathlib.Path(sys.argv[1]).read_text())
+result["turn_key"] = request["turn_key"]
+count = pathlib.Path(sys.argv[2])
+count.write_text(str(int(count.read_text()) + 1 if count.exists() else 1))
+json.dump(result, sys.stdout)
+"""
+    return [sys.executable, "-c", script, str(result_path), str(count_path)]
+
+
+def _callbacks(calls: dict[str, int]):
+    def writeback(_result: dict[str, object]) -> dict[str, object]:
+        calls["writeback"] += 1
+        return {"ok": True, "appended": True, "classification": "fixture_progress"}
+
+    def spend() -> dict[str, object]:
+        calls["spend"] += 1
+        return {"ok": True, "appended": True, "slots": 1}
+
+    def scheduler(_spend: dict[str, object]) -> dict[str, object]:
+        calls["scheduler"] += 1
+        return {"completed": True, "acknowledged": False, "disposition": "not_required"}
+
+    return writeback, spend, scheduler
+
+
+def test_host_result_requires_bounded_public_material_fields() -> None:
+    plan = _plan()
+    result = _host_result(plan)
+    result["raw_trajectory"] = "not allowed"
+
+    validation = validate_loopx_turn_host_result(plan, result)
+
+    assert validation["ok"] is False
+    assert "unsupported host result fields" in " ".join(validation["errors"])
+
+
+def test_run_once_preview_has_no_host_or_journal_effects(tmp_path: Path) -> None:
+    plan = _plan()
+
+    payload = run_loopx_turn_once(
+        plan,
+        host_argv=[sys.executable, "-c", "raise SystemExit(9)"],
+        project=tmp_path,
+        runtime_root=tmp_path / "runtime",
+        goal_id="fixture-goal",
+        timeout_seconds=5,
+        execute=False,
+    )
+
+    assert payload["ok"] is True
+    assert payload["status"] == "preview"
+    assert payload["effects"] == {
+        "host_invoked": False,
+        "state_written": False,
+        "quota_spent": False,
+        "scheduler_acknowledged": False,
+    }
+    assert not (tmp_path / "runtime").exists()
+
+
+def test_run_once_commits_once_and_replays_without_duplicate_effects(tmp_path: Path) -> None:
+    plan = _plan()
+    result_path = tmp_path / "result.json"
+    result_path.write_text(json.dumps(_host_result(plan)), encoding="utf-8")
+    count_path = tmp_path / "host-count"
+    calls = {"writeback": 0, "spend": 0, "scheduler": 0}
+    writeback, spend, scheduler = _callbacks(calls)
+    kwargs = {
+        "host_argv": _host_argv(result_path, count_path),
+        "project": tmp_path,
+        "runtime_root": tmp_path / "runtime",
+        "goal_id": "fixture-goal",
+        "timeout_seconds": 5,
+        "execute": True,
+        "writeback": writeback,
+        "spend": spend,
+        "scheduler": scheduler,
+    }
+
+    first = run_loopx_turn_once(plan, **kwargs)
+    replay = run_loopx_turn_once(plan, **kwargs)
+
+    assert first["ok"] is True
+    assert first["status"] == "committed"
+    assert first["receipt"]["status"] == "committed"
+    assert first["effects"]["host_invoked"] is True
+    assert first["effects"]["state_written"] is True
+    assert first["effects"]["quota_spent"] is True
+    assert replay["replayed"] is True
+    assert not any(replay["effects"].values())
+    assert count_path.read_text(encoding="utf-8") == "1"
+    assert calls == {"writeback": 1, "spend": 1, "scheduler": 1}
+
+
+def test_run_once_recovers_after_process_exit_before_writeback(tmp_path: Path) -> None:
+    plan = _plan()
+    result_path = tmp_path / "result.json"
+    result_path.write_text(json.dumps(_host_result(plan)), encoding="utf-8")
+    count_path = tmp_path / "host-count"
+    calls = {"writeback": 0, "spend": 0, "scheduler": 0}
+    healthy_writeback, spend, scheduler = _callbacks(calls)
+
+    def interrupted_writeback(_result: dict[str, object]) -> dict[str, object]:
+        raise SystemExit(7)
+
+    common = {
+        "host_argv": _host_argv(result_path, count_path),
+        "project": tmp_path,
+        "runtime_root": tmp_path / "runtime",
+        "goal_id": "fixture-goal",
+        "timeout_seconds": 5,
+        "execute": True,
+        "spend": spend,
+        "scheduler": scheduler,
+    }
+    with pytest.raises(SystemExit):
+        run_loopx_turn_once(plan, writeback=interrupted_writeback, **common)
+
+    recovered = run_loopx_turn_once(plan, writeback=healthy_writeback, **common)
+
+    assert recovered["status"] == "committed"
+    assert count_path.read_text(encoding="utf-8") == "1"
+    assert calls == {"writeback": 1, "spend": 1, "scheduler": 1}
+
+
+def test_run_once_resumes_after_writeback_without_duplicate_effects(tmp_path: Path) -> None:
+    plan = _plan()
+    result_path = tmp_path / "result.json"
+    result_path.write_text(json.dumps(_host_result(plan)), encoding="utf-8")
+    count_path = tmp_path / "host-count"
+    calls = {"writeback": 0, "spend": 0, "scheduler": 0}
+    writeback, healthy_spend, scheduler = _callbacks(calls)
+
+    def interrupted_spend() -> dict[str, object]:
+        raise SystemExit(8)
+
+    common = {
+        "host_argv": _host_argv(result_path, count_path),
+        "project": tmp_path,
+        "runtime_root": tmp_path / "runtime",
+        "goal_id": "fixture-goal",
+        "timeout_seconds": 5,
+        "execute": True,
+        "writeback": writeback,
+        "scheduler": scheduler,
+    }
+    with pytest.raises(SystemExit):
+        run_loopx_turn_once(plan, spend=interrupted_spend, **common)
+
+    transaction = plan["transaction"]
+    assert isinstance(transaction, dict)
+    resumed_plan = load_loopx_turn_plan_from_journal(
+        tmp_path / "runtime",
+        goal_id="fixture-goal",
+        turn_key=str(transaction["turn_key"]),
+    )
+    recovered = run_loopx_turn_once(resumed_plan, spend=healthy_spend, **common)
+
+    assert recovered["status"] == "committed"
+    assert count_path.read_text(encoding="utf-8") == "1"
+    assert calls == {"writeback": 1, "spend": 1, "scheduler": 1}
+
+
+def test_run_once_stops_without_writeback_or_spend(tmp_path: Path) -> None:
+    plan = _plan()
+    result_path = tmp_path / "result.json"
+    result_path.write_text(json.dumps(_host_result(plan, kind="wait")), encoding="utf-8")
+    calls = {"writeback": 0, "spend": 0, "scheduler": 0}
+    writeback, spend, scheduler = _callbacks(calls)
+
+    payload = run_loopx_turn_once(
+        plan,
+        host_argv=_host_argv(result_path, tmp_path / "host-count"),
+        project=tmp_path,
+        runtime_root=tmp_path / "runtime",
+        goal_id="fixture-goal",
+        timeout_seconds=5,
+        execute=True,
+        writeback=writeback,
+        spend=spend,
+        scheduler=scheduler,
+    )
+
+    assert payload["ok"] is True
+    assert payload["status"] == "stopped"
+    assert payload["receipt"]["status"] == "stopped"
+    assert calls == {"writeback": 0, "spend": 0, "scheduler": 0}
+
+
+def test_run_once_projects_scheduler_action_without_false_ack(tmp_path: Path) -> None:
+    plan = _plan()
+    result_path = tmp_path / "result.json"
+    result_path.write_text(json.dumps(_host_result(plan)), encoding="utf-8")
+    calls = {"writeback": 0, "spend": 0, "scheduler": 0}
+    writeback, spend, _scheduler = _callbacks(calls)
+
+    def scheduler(_spend: dict[str, object]) -> dict[str, object]:
+        calls["scheduler"] += 1
+        return {"completed": False, "apply_needed": True, "disposition": "host_action_required"}
+
+    payload = run_loopx_turn_once(
+        plan,
+        host_argv=_host_argv(result_path, tmp_path / "host-count"),
+        project=tmp_path,
+        runtime_root=tmp_path / "runtime",
+        goal_id="fixture-goal",
+        timeout_seconds=5,
+        execute=True,
+        writeback=writeback,
+        spend=spend,
+        scheduler=scheduler,
+    )
+
+    assert payload["ok"] is True
+    assert payload["status"] == "scheduler_action_required"
+    assert payload["receipt"]["next_phase"] == "scheduler_apply"
+    assert payload["effects"]["scheduler_acknowledged"] is False
+
+
+def test_run_once_resumes_scheduler_without_repeating_committed_effects(
+    tmp_path: Path,
+) -> None:
+    plan = _plan()
+    result_path = tmp_path / "result.json"
+    result_path.write_text(json.dumps(_host_result(plan)), encoding="utf-8")
+    count_path = tmp_path / "host-count"
+    calls = {"writeback": 0, "spend": 0, "scheduler": 0}
+    writeback, spend, _scheduler = _callbacks(calls)
+
+    def scheduler(_spend: dict[str, object]) -> dict[str, object]:
+        calls["scheduler"] += 1
+        if calls["scheduler"] == 1:
+            return {
+                "completed": False,
+                "apply_needed": True,
+                "disposition": "host_action_required",
+            }
+        return {
+            "completed": True,
+            "acknowledged": True,
+            "disposition": "applied_and_acknowledged",
+        }
+
+    kwargs = {
+        "host_argv": _host_argv(result_path, count_path),
+        "project": tmp_path,
+        "runtime_root": tmp_path / "runtime",
+        "goal_id": "fixture-goal",
+        "timeout_seconds": 5,
+        "execute": True,
+        "writeback": writeback,
+        "spend": spend,
+        "scheduler": scheduler,
+    }
+    first = run_loopx_turn_once(plan, **kwargs)
+    resumed = run_loopx_turn_once(plan, **kwargs)
+
+    assert first["status"] == "scheduler_action_required"
+    assert resumed["status"] == "committed"
+    assert resumed["effects"]["scheduler_acknowledged"] is True
+    assert count_path.read_text(encoding="utf-8") == "1"
+    assert calls == {"writeback": 1, "spend": 1, "scheduler": 2}

--- a/tests/test_loopx_turn_transaction.py
+++ b/tests/test_loopx_turn_transaction.py
@@ -135,6 +135,16 @@ def test_receipt_rejects_turn_lineage_drift() -> None:
             ["host_execute", "typed_result", "validation"],
             "durable_writeback",
         ),
+        (
+            LoopXTurnResultKind.QUOTA_SPEND_FAILED,
+            [
+                "host_execute",
+                "typed_result",
+                "validation",
+                "durable_writeback",
+            ],
+            "quota_spend",
+        ),
     ],
 )
 def test_typed_failure_stops_at_its_declared_phase(


### PR DESCRIPTION
## Summary
- add an explicit generic-host `loopx turn run-once` execution boundary
- validate one public-safe typed result before state writeback and quota spend
- persist phase journals with explicit resume keys so host, writeback, and spend are not repeated after interruption
- surface scheduler apply requirements without claiming an ACK
- characterize preview output and add CLI/recovery regression coverage

## Validation
- 73 focused Turn, envelope, quota-accounting, and CLI-output tests passed
- Ruff and Python compile checks passed on changed surfaces
- `loopx check` reported a clean public boundary for all candidate files
- standard premerge canary passed 12 selected checks with no failures or manual holds

## Safety and scope
- no benchmark job was launched and benchmark scoring or task semantics are unchanged
- no shell parsing, raw trajectories, stderr bodies, credentials, or local state are persisted
- this stage is generic-host only; a direct Codex CLI adapter and todo lifecycle completion remain follow-up work