### PR TITLE
Fix fresh no-scan onboarding projection parity

### DIFF
--- a/examples/project/onboarding-no-scan-projection-smoke.py
+++ b/examples/project/onboarding-no-scan-projection-smoke.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Smoke-test fresh no-scan onboarding state and todo projection parity."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GOAL_ID = "fresh-no-scan-projection"
+
+
+def run_cli(registry: Path, runtime: Path, *args: str) -> dict:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry),
+            "--runtime-root",
+            str(runtime),
+            "--format",
+            "json",
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return json.loads(result.stdout)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-no-scan-projection-") as tmp:
+        root = Path(tmp)
+        project = root / "project"
+        project.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+        readme = project / "README.md"
+        readme.write_text("# Synthetic LoopX onboarding fixture\n", encoding="utf-8")
+        (project / ".gitignore").write_text(".loopx/\n.codex/\n.local/\n", encoding="utf-8")
+
+        registry = project / ".loopx" / "registry.json"
+        runtime = root / "runtime"
+        connected = run_cli(
+            registry,
+            runtime,
+            "connect",
+            "--project",
+            str(project),
+            "--goal-id",
+            GOAL_ID,
+            "--objective",
+            "Validate fresh read-only onboarding.",
+            "--domain",
+            "engineering",
+            "--goal-doc",
+            str(readme),
+            "--adapter-kind",
+            "read_only_project_map_v0",
+            "--adapter-status",
+            "connected-read-only",
+            "--codex-app-heartbeat",
+            "no",
+            "--no-onboarding-scan",
+            "--no-global-sync",
+        )
+        assert connected["ok"] is True, connected
+
+        mapped = run_cli(
+            registry,
+            runtime,
+            "read-only-map",
+            "--goal-id",
+            GOAL_ID,
+            "--no-global-sync",
+        )
+        assert mapped["ok"] is True, mapped
+
+        state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+        state_text = state_file.read_text(encoding="utf-8")
+        assert state_text.count("action_kind=onboarding_connection_validation") == 1, state_text
+        assert "## Next Action" in state_text, state_text
+
+        healthy_check = run_cli(registry, runtime, "check", "--scan-path", str(readme))
+        assert healthy_check["ok"] is True, healthy_check
+        assert healthy_check["summary"]["warnings"] == 0, healthy_check
+
+        quota = run_cli(registry, runtime, "quota", "should-run", "--goal-id", GOAL_ID)
+        assert quota["decision"] == "run", quota
+        assert quota["normal_delivery_allowed"] is True, quota
+        assert quota["effective_action"] == "normal_run", quota
+        assert quota.get("state_projection_gap") is None, quota
+
+        broken_lines = [
+            line
+            for line in state_text.splitlines()
+            if "action_kind=onboarding_connection_validation" not in line
+            and not line.startswith("- [ ] [P1] Run `loopx check` against the project registry")
+        ]
+        state_file.write_text("\n".join(broken_lines) + "\n", encoding="utf-8")
+
+        broken_check = run_cli(registry, runtime, "check", "--scan-path", str(readme))
+        assert broken_check["ok"] is True, broken_check
+        assert broken_check["summary"]["warnings"] == 1, broken_check
+        assert any("state_projection_gap" in warning for warning in broken_check["warnings"]), broken_check
+
+    print("onboarding-no-scan-projection-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/bootstrap.py
+++ b/loopx/bootstrap.py
@@ -257,6 +257,17 @@ def onboarding_agent_review_todo_text(
     return text
 
 
+def onboarding_connection_validation_action() -> dict[str, str]:
+    return {
+        "text": (
+            "[P1] Run `loopx check` against the project registry and record the first "
+            "project-specific adapter signal or an explicit no-follow-up rationale."
+        ),
+        "task_class": "advancement_task",
+        "action_kind": "onboarding_connection_validation",
+    }
+
+
 def onboarding_next_action(
     *,
     onboarding_scan: dict[str, Any] | None,
@@ -265,7 +276,7 @@ def onboarding_next_action(
     codex_app_heartbeat: str,
 ) -> str:
     if not onboarding_scan:
-        return "Run `loopx check` against the project registry and decide the first project-specific adapter signal."
+        return onboarding_connection_validation_action()["text"]
     need_heartbeat_choice = codex_app_heartbeat == "ask"
     if not accept_onboarding_agent_todos or not begin_autonomous_advance or need_heartbeat_choice:
         asks: list[str] = []
@@ -315,7 +326,17 @@ def apply_onboarding_todos_to_state(
     codex_app_heartbeat: str,
 ) -> str:
     if not onboarding_scan:
-        return text
+        lines = text.splitlines()
+        action = onboarding_connection_validation_action()
+        add_todo_to_lines(
+            lines,
+            role="agent",
+            text=action["text"],
+            task_class=action["task_class"],
+            action_kind=action["action_kind"],
+            updated_at=updated_at,
+        )
+        return "\n".join(lines) + "\n"
     lines = text.splitlines()
     if accept_onboarding_agent_todos:
         for candidate in onboarding_candidates(onboarding_scan):

--- a/loopx/contract.py
+++ b/loopx/contract.py
@@ -16,6 +16,7 @@ from .control_plane.todos.active_state_editing import COMPLETED_WORK_ARCHIVE_HEA
 from .history import collect_history, load_registry
 from .paths import DEFAULT_RUNTIME_ROOT, rel_or_abs, resolve_runtime_root
 from .registry import inspect_registry, inspect_registry_boundary, registry_goals, resolve_state_file
+from .state_projection import state_projection_gap_warning
 from .control_plane.todos.contract import (
     TODO_STATUS_DEFERRED,
     TODO_STATUS_DONE,
@@ -450,6 +451,31 @@ def _active_state_user_gate_scope_errors(registry: dict[str, Any]) -> tuple[list
     return errors, checked
 
 
+def _active_state_projection_gap_warnings(registry: dict[str, Any]) -> list[str]:
+    warnings: list[str] = []
+    for goal in registry_goals(registry):
+        goal_id = str(goal.get("id") or "")
+        repo_text = str(goal.get("repo") or "").strip()
+        if not repo_text:
+            continue
+        state_file = resolve_state_file(Path(repo_text).expanduser(), goal.get("state_file"))
+        if not state_file or not state_file.exists():
+            continue
+        try:
+            state_text = state_file.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        projection_gap = state_projection_gap_warning(state_text)
+        if not projection_gap:
+            continue
+        target_roles = ",".join(str(role) for role in projection_gap.get("target_roles") or [])
+        warnings.append(
+            f"{goal_id}: active state has a state_projection_gap for {target_roles or 'todo'}; "
+            "expand executable Next Action work into an open Agent Todo or user wait into an open User Todo"
+        )
+    return warnings
+
+
 def _tracked_scan_files(scan_root: Path) -> list[Path]:
     scan_root = scan_root.resolve()
     target = scan_root if scan_root.is_dir() else scan_root.parent
@@ -622,6 +648,7 @@ def check_contract(
     if checked_user_gates:
         checks.append(f"user-gate scopes checked: {checked_user_gates} open multi-agent gates")
     errors.extend(user_gate_scope_errors)
+    warnings.extend(_active_state_projection_gap_warnings(registry))
 
     runtime_root = resolve_runtime_root(registry, runtime_root_override)
     if runtime_root == DEFAULT_RUNTIME_ROOT or runtime_root.exists():


### PR DESCRIPTION
## Summary
- define the no-scan onboarding validation action once and use it for both Next Action and Agent Todo authoring
- make `loopx check` report active-state projection gaps as non-fatal warnings
- add an end-to-end connect -> read-only-map -> check -> quota smoke, including a manually inconsistent fixture

## Validation
- `python3 examples/project/onboarding-no-scan-projection-smoke.py`
- `python3 examples/state-projection-gap-smoke.py`
- `python3 examples/onboarding-connect-candidates-smoke.py`
- `python3 examples/project/bootstrap-force-preserve-todos-smoke.py`
- `python3 examples/control_plane/todo-user-gate-scope-smoke.py`
- `uvx ruff check loopx/bootstrap.py loopx/contract.py examples/project/onboarding-no-scan-projection-smoke.py`
- `loopx canary premerge --from-git-diff` (16/16 passed, no manual holds)

Closes #2134