### PR TITLE
Require stable-release candidate pairing for outcome baselines

### DIFF
--- a/docs/reference/protocols/release-outcome-baseline-v0.md
+++ b/docs/reference/protocols/release-outcome-baseline-v0.md
@@ -23,6 +23,7 @@ calls are slower, cost-bearing, and may depend on gated environments.
 
 `release_outcome_pair_manifest_v0` contains:
 
+- `comparison_kind=stable_release_vs_candidate`;
 - public-safe `baseline_ref` and `candidate_ref` identifiers;
 - an explicit evidence policy;
 - paired compact `benchmark_result_v0` rows.
@@ -34,6 +35,13 @@ all four parity checks:
 - same runner protocol;
 - same verifier contract;
 - same budget.
+
+The baseline and candidate references must be different immutable identities.
+Both arms run the same LoopX product mode; only the stable release and candidate
+revision differ. Native-agent-versus-LoopX uplift experiments, treatment-arm
+comparisons, and two labels pointing to the same revision are rejected. Their
+results may remain useful research evidence, but they are not release
+qualification evidence.
 
 Each result must already be an exact compact `benchmark_result_v0`. Unknown
 fields fail closed instead of being silently copied into the receipt. The
@@ -85,3 +93,17 @@ The command does not read raw task text, trajectories, or verifier output. It
 does not invoke a model, execute a benchmark, mutate a release, or persist local
 paths. Real runners remain responsible for producing compact result rows under
 their own authorization and privacy boundaries.
+
+## Staged Terminal-Bench Profile
+
+The first release profile reuses only the three public task identities from the
+existing official hard-case selection: `fix-code-vulnerability`,
+`modernize-scientific-stack`, and `llm-inference-batching-scheduler`. It does
+not reuse that document's native-agent-versus-LoopX arm semantics.
+
+Run `fix-code-vulnerability` first, twice per arm. Expand to the other two cases
+only after all four parity declarations are true and the pilot has no runner or
+verifier-contract blocker. The final release receipt requires all three cases
+with at least two repetitions per stable-release and candidate arm. A blocked
+pilot remains `insufficient_evidence`; it does not silently lower the case
+floor, replace the task, or block ordinary pull-request iteration.

--- a/loopx/cli_commands/benchmark_release_outcome.py
+++ b/loopx/cli_commands/benchmark_release_outcome.py
@@ -29,6 +29,7 @@ def render_release_outcome_baseline_markdown(payload: dict[str, Any]) -> str:
         "",
         f"- ok: `{payload.get('ok')}`",
         f"- decision: `{payload.get('decision')}`",
+        f"- comparison_kind: `{payload.get('comparison_kind')}`",
         f"- baseline_ref: `{payload.get('baseline_ref')}`",
         f"- candidate_ref: `{payload.get('candidate_ref')}`",
         f"- eligible_for_owner_review: `{payload.get('eligible_for_owner_review')}`",
@@ -65,7 +66,10 @@ def register_benchmark_release_outcome_commands(
     parser.add_argument(
         "--manifest-json",
         required=True,
-        help="Path to a release_outcome_pair_manifest_v0 JSON object.",
+        help=(
+            "Path to a release_outcome_pair_manifest_v0 JSON object comparing "
+            "a stable LoopX release with a distinct candidate revision."
+        ),
     )
     parser.add_argument(
         "--require-owner-review-ready",

--- a/loopx/control_plane/testing/release_outcome_baseline.py
+++ b/loopx/control_plane/testing/release_outcome_baseline.py
@@ -11,10 +11,12 @@ from ..runtime.public_safety import public_safe_compact_text
 
 RELEASE_OUTCOME_PAIR_MANIFEST_SCHEMA_VERSION = "release_outcome_pair_manifest_v0"
 RELEASE_OUTCOME_BASELINE_SCHEMA_VERSION = "release_outcome_baseline_v0"
+RELEASE_OUTCOME_COMPARISON_KIND = "stable_release_vs_candidate"
 
 _TOKEN_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,159}$")
 _MANIFEST_FIELDS = {
     "schema_version",
+    "comparison_kind",
     "baseline_ref",
     "candidate_ref",
     "policy",
@@ -188,6 +190,10 @@ def _normalize_manifest(value: Mapping[str, Any]) -> dict[str, Any]:
         raise ValueError("manifest contains unknown fields")
     if value.get("schema_version") != RELEASE_OUTCOME_PAIR_MANIFEST_SCHEMA_VERSION:
         raise ValueError("manifest must use release_outcome_pair_manifest_v0")
+    if value.get("comparison_kind") != RELEASE_OUTCOME_COMPARISON_KIND:
+        raise ValueError(
+            "manifest.comparison_kind must be stable_release_vs_candidate"
+        )
     raw_pairs = value.get("pairs")
     if not isinstance(raw_pairs, list) or not raw_pairs:
         raise ValueError("manifest.pairs must be a non-empty list")
@@ -204,12 +210,17 @@ def _normalize_manifest(value: Mapping[str, Any]) -> dict[str, Any]:
         if case_id in case_tasks and case_tasks[case_id] != task_id:
             raise ValueError("each case_id must keep the same task_id across repetitions")
         case_tasks[case_id] = task_id
+    baseline_ref = _token(value.get("baseline_ref"), field="manifest.baseline_ref")
+    candidate_ref = _token(
+        value.get("candidate_ref"), field="manifest.candidate_ref"
+    )
+    if baseline_ref == candidate_ref:
+        raise ValueError("manifest baseline_ref and candidate_ref must differ")
     return {
         "schema_version": RELEASE_OUTCOME_PAIR_MANIFEST_SCHEMA_VERSION,
-        "baseline_ref": _token(value.get("baseline_ref"), field="manifest.baseline_ref"),
-        "candidate_ref": _token(
-            value.get("candidate_ref"), field="manifest.candidate_ref"
-        ),
+        "comparison_kind": RELEASE_OUTCOME_COMPARISON_KIND,
+        "baseline_ref": baseline_ref,
+        "candidate_ref": candidate_ref,
         "policy": _normalized_policy(value.get("policy")),
         "pairs": pairs,
     }
@@ -319,6 +330,7 @@ def build_release_outcome_baseline(manifest: Mapping[str, Any]) -> dict[str, Any
 
     return {
         "schema_version": RELEASE_OUTCOME_BASELINE_SCHEMA_VERSION,
+        "comparison_kind": normalized["comparison_kind"],
         "baseline_ref": normalized["baseline_ref"],
         "candidate_ref": normalized["candidate_ref"],
         "decision": decision,

--- a/tests/control_plane/test_release_outcome_baseline.py
+++ b/tests/control_plane/test_release_outcome_baseline.py
@@ -78,6 +78,7 @@ def _manifest(*, case_count: int = 3, repeats: int = 2) -> dict[str, object]:
             )
     return {
         "schema_version": "release_outcome_pair_manifest_v0",
+        "comparison_kind": "stable_release_vs_candidate",
         "baseline_ref": "release:v0.2.5",
         "candidate_ref": "candidate:compact-guided",
         "policy": {
@@ -93,6 +94,7 @@ def _manifest(*, case_count: int = 3, repeats: int = 2) -> dict[str, object]:
 def test_release_outcome_baseline_routes_clean_pair_to_owner_review() -> None:
     receipt = build_release_outcome_baseline(_manifest())
 
+    assert receipt["comparison_kind"] == "stable_release_vs_candidate"
     assert receipt["decision"] == "owner_review_required"
     assert receipt["eligible_for_owner_review"] is True
     assert receipt["automatic_release_promotion_allowed"] is False
@@ -161,6 +163,20 @@ def test_release_outcome_baseline_fails_closed_on_noncompact_or_unpaired_input()
     unstable_case["pairs"][1]["candidate_result"]["task_id"] = "other-task"
     with pytest.raises(ValueError, match="same task_id across repetitions"):
         build_release_outcome_baseline(unstable_case)
+
+
+def test_release_outcome_baseline_rejects_uplift_or_identity_comparisons() -> None:
+    uplift = _manifest()
+    uplift["comparison_kind"] = "native_codex_vs_loopx"
+    with pytest.raises(
+        ValueError, match="comparison_kind must be stable_release_vs_candidate"
+    ):
+        build_release_outcome_baseline(uplift)
+
+    identity = _manifest()
+    identity["candidate_ref"] = identity["baseline_ref"]
+    with pytest.raises(ValueError, match="baseline_ref and candidate_ref must differ"):
+        build_release_outcome_baseline(identity)
 
 
 def test_release_outcome_cli_is_read_only_and_optionally_fails_closed(


### PR DESCRIPTION
## Summary
- require `comparison_kind=stable_release_vs_candidate` for release outcome manifests
- reject uplift-arm manifests and identical baseline/candidate refs
- document a staged three-case Terminal-Bench release profile without reusing native-vs-LoopX arm semantics

## Validation
- `uv run --extra test pytest -q tests/control_plane/test_release_outcome_baseline.py tests/control_plane/test_benchmark_result.py` (9 passed)
- `uv run --extra test ruff check ...`
- `loopx canary premerge --from-git-diff` (17/17 selected checks passed, no manual holds)
- `loopx check` public/private boundary scan clean

No model or benchmark job was launched; scoring, runner behavior, permissions, and release mutation are unchanged.