### PR TITLE
Fix LoopX Turn audit smoke contract

### DIFF
--- a/examples/codex-cli-automation-driver-audit-smoke.py
+++ b/examples/codex-cli-automation-driver-audit-smoke.py
@@ -16,26 +16,26 @@ def main() -> int:
     index = PRODUCT_INDEX.read_text()
 
     required_contracts = [
-        "one LoopX-generated message",
-        "does not expose a mature native recurring scheduler",
-        "recurrence as a LoopX local-driver concern",
-        "codex resume [SESSION_ID] [PROMPT]",
-        "codex exec",
-        "remote-control",
-        "loopx codex-cli-visible-driver-plan",
-        "loopx codex-cli-exec-handoff",
-        "TUI bootstrap primary",
-        "headless-disabled boundary",
-        "idle guard",
-        "validated writeback",
+        "loopx_turn_v0",
+        "loopx turn diagnose",
+        "loopx turn run-once",
+        "interactive-visible",
+        "isolated-headless",
+        "must never switch",
+        "live `quota should-run --turn-envelope`",
+        "Require a typed result",
+        "Spend once only for validated delivery",
+        "apply and ack scheduler state",
     ]
     for phrase in required_contracts:
         assert phrase in doc, phrase
 
     boundary_terms = [
-        "raw Codex transcripts",
+        "Raw host material stays outside LoopX state",
+        "raw task text",
+        "raw trajectories",
         "credentials",
-        "hidden session files",
+        "local artifact paths",
     ]
     for phrase in boundary_terms:
         assert phrase in doc, phrase


### PR DESCRIPTION
## Summary
- replace obsolete Codex CLI visible-driver prose assertions with the current LoopX Turn contract
- keep the durable execution-mode, typed-result, validation/writeback, scheduler-ack, and privacy boundaries covered
- repair the sole independent Full Public smoke failure observed after the #2134 follow-up

## Validation
- `python3 examples/codex-cli-automation-driver-audit-smoke.py`
- `python3 -m py_compile examples/codex-cli-automation-driver-audit-smoke.py`
- `loopx check --scan-path examples/codex-cli-automation-driver-audit-smoke.py` (candidate path clean; unrelated existing OpenViking index warning remains)
- `loopx canary premerge --from-git-diff --tier standard --format json` (passed; self-merge allowed; no manual holds)

## Scope
One public smoke only. No runtime behavior, benchmark semantics, permissions, raw evidence, credentials, or local state changed.