### PR TITLE
Add provider-neutral static presentation delivery contract

### DIFF
--- a/examples/static-site-presentation-smoke.py
+++ b/examples/static-site-presentation-smoke.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Smoke-test provider-neutral static packaging, rollback, and HTTP readback."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import threading
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.presentation.static_site import (  # noqa: E402
+    RECEIPT_FILE,
+    package_static_site,
+    rollback_static_site,
+    verify_static_site_readback,
+)
+
+
+class _QuietHandler(SimpleHTTPRequestHandler):
+    def log_message(self, _format: str, *_args: object) -> None:
+        return None
+
+
+def package(
+    site: Path, output: Path, state: Path, *, revision: str
+) -> dict[str, object]:
+    return package_static_site(
+        site_dir=site,
+        output_dir=output,
+        state_dir=state,
+        site_id="static-presentation-smoke",
+        revision=revision,
+        publisher_kind="local",
+        desktop_visual_check="passed",
+        mobile_visual_check="passed",
+        link_check="passed",
+        execute=True,
+    )
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-static-presentation-") as temp:
+        root = Path(temp)
+        site = root / "site"
+        output = root / "publish"
+        state = root / "state"
+        site.mkdir()
+        (site / "index.html").write_text("<h1>revision one</h1>\n", encoding="utf-8")
+
+        first = package(site, output, state, revision="revision-one")
+        if first["write_performed"] is not True:
+            raise AssertionError(first)
+        repeated = package(site, output, state, revision="equivalent-alias")
+        if (
+            repeated["semantic_noop"] is not True
+            or repeated["active_revision"] != "revision-one"
+        ):
+            raise AssertionError(repeated)
+
+        (site / "index.html").write_text("<h1>revision two</h1>\n", encoding="utf-8")
+        second = package(site, output, state, revision="revision-two")
+        if second["previous_revision"] != "revision-one":
+            raise AssertionError(second)
+        rollback = rollback_static_site(
+            output_dir=output, state_dir=state, execute=True
+        )
+        if rollback["active_revision"] != "revision-one":
+            raise AssertionError(rollback)
+
+        handler = partial(_QuietHandler, directory=str(output))
+        server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            receipt_url = f"http://127.0.0.1:{server.server_port}/{RECEIPT_FILE}"
+            verified = verify_static_site_readback(
+                output_dir=output,
+                state_dir=state,
+                receipt_url=receipt_url,
+                retry_delay_seconds=0,
+                execute=True,
+            )
+        finally:
+            server.shutdown()
+            thread.join(timeout=5)
+            server.server_close()
+        if verified["verified"] is not True or verified["revision"] != "revision-one":
+            raise AssertionError(verified)
+
+    print("static-site-presentation-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -53,6 +53,7 @@ from .cli_commands import (
     handle_ml_experiment_command,
     handle_multi_agent_command,
     handle_preset_command,
+    handle_presentation_command,
     handle_project_lifecycle_command,
     handle_pr_review_command,
     handle_quota_command,
@@ -83,6 +84,7 @@ from .cli_commands import (
     register_ml_experiment_commands,
     register_multi_agent_commands,
     register_preset_commands,
+    register_presentation_commands,
     register_project_lifecycle_commands,
     register_pr_review_command,
     register_quota_command,
@@ -204,6 +206,7 @@ def main(argv: list[str] | None = None) -> int:
     register_multi_agent_commands(sub, add_subcommand_format)
     register_turn_commands(sub, add_subcommand_format)
     register_preset_commands(sub, add_subcommand_format)
+    register_presentation_commands(sub, add_subcommand_format)
     register_ready_score_command(sub, add_subcommand_format)
 
     register_registry_admin_commands(sub)
@@ -373,6 +376,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     if preset_result is not None:
         return preset_result
+
+    presentation_result = handle_presentation_command(
+        args,
+        output_format=output_format,
+        print_payload=print_payload,
+    )
+    if presentation_result is not None:
+        return presentation_result
 
     ready_score_result = handle_ready_score_command(
         args,

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -95,6 +95,7 @@ from .project_lifecycle import (
     register_project_lifecycle_commands,
 )
 from .preset import handle_preset_command, register_preset_commands
+from .presentation import handle_presentation_command, register_presentation_commands
 from .pr_review import handle_pr_review_command, register_pr_review_command
 from .quota import handle_quota_command, register_quota_command
 from .ready_score import handle_ready_score_command, register_ready_score_command
@@ -223,6 +224,7 @@ __all__ = [
     "handle_multi_agent_command",
     "handle_new_project_prompt_command",
     "handle_preset_command",
+    "handle_presentation_command",
     "handle_project_lifecycle_command",
     "handle_pr_review_command",
     "handle_quota_command",
@@ -277,6 +279,7 @@ __all__ = [
     "register_project_lifecycle_commands",
     "register_pr_review_command",
     "register_preset_commands",
+    "register_presentation_commands",
     "register_quota_command",
     "register_ready_score_command",
     "register_registry_admin_commands",

--- a/loopx/cli_commands/presentation.py
+++ b/loopx/cli_commands/presentation.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+from ..presentation.static_site import (
+    StaticSiteContractError,
+    package_static_site,
+    rollback_static_site,
+    verify_static_site_readback,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]], None
+]
+FormatSelector = Callable[..., str]
+AddFormat = Callable[[argparse.ArgumentParser], None]
+
+
+def _render_markdown(payload: dict[str, object]) -> str:
+    lines = ["# LoopX Static Presentation", ""]
+    for key in (
+        "mode",
+        "dry_run",
+        "write_required",
+        "write_performed",
+        "semantic_noop",
+        "active_revision",
+        "previous_revision",
+        "semantic_digest",
+        "receipt_url",
+        "verified",
+        "attempts",
+        "output_dir",
+        "manifest_path",
+        "receipt_path",
+        "state_receipt_log",
+    ):
+        if key in payload:
+            lines.append(f"- **{key}**: `{payload[key]}`")
+    publisher = payload.get("publisher")
+    if isinstance(publisher, dict):
+        lines.extend(
+            [
+                f"- **publisher**: `{publisher.get('kind')}`",
+                f"- **latest_url**: `{publisher.get('latest_url')}`",
+                f"- **revision_url**: `{publisher.get('revision_url')}`",
+            ]
+        )
+    return "\n".join(lines) + "\n"
+
+
+def register_presentation_commands(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: AddFormat,
+) -> None:
+    parser = subparsers.add_parser(
+        "presentation",
+        help="Package and verify provider-neutral static presentation artifacts.",
+    )
+    sub = parser.add_subparsers(dest="presentation_command", required=True)
+
+    package = sub.add_parser(
+        "package",
+        help="Create stable latest/revision artifacts and a deploy receipt from a built site.",
+    )
+    add_subcommand_format(package)
+    package.add_argument(
+        "--site-dir", required=True, help="Already-built public-safe site directory."
+    )
+    package.add_argument(
+        "--output-dir", required=True, help="Local publish artifact directory."
+    )
+    package.add_argument("--state-dir", help="Local deploy receipt state directory.")
+    package.add_argument("--site-id", required=True, help="Stable public-safe site id.")
+    package.add_argument(
+        "--entry-path", default="index.html", help="Relative primary HTML entry."
+    )
+    package.add_argument(
+        "--revision",
+        help="Public-safe immutable revision id; defaults to the content digest.",
+    )
+    package.add_argument(
+        "--publisher",
+        choices=["local", "github-pages"],
+        default="local",
+        help="Optional publisher URL adapter. Local packaging is always available.",
+    )
+    package.add_argument(
+        "--base-url", help="HTTPS deployment root required by github-pages."
+    )
+    package.add_argument(
+        "--desktop-visual-check",
+        required=True,
+        choices=["passed"],
+        help="Receipt from the desktop visual/overflow check.",
+    )
+    package.add_argument(
+        "--mobile-visual-check",
+        required=True,
+        choices=["passed"],
+        help="Receipt from the mobile visual/overflow check.",
+    )
+    package.add_argument(
+        "--link-check",
+        required=True,
+        choices=["passed"],
+        help="Receipt from the generated-link check.",
+    )
+    package.add_argument(
+        "--execute",
+        action="store_true",
+        help="Write the local artifact and receipt state.",
+    )
+
+    rollback = sub.add_parser(
+        "rollback",
+        help="Prepare the latest artifact from a retained previous revision.",
+    )
+    add_subcommand_format(rollback)
+    rollback.add_argument(
+        "--output-dir", required=True, help="Existing local publish artifact directory."
+    )
+    rollback.add_argument("--state-dir", help="Local deploy receipt state directory.")
+    rollback.add_argument(
+        "--revision", help="Target retained revision; defaults to previous_revision."
+    )
+    rollback.add_argument(
+        "--execute",
+        action="store_true",
+        help="Write the rollback artifact and receipt state.",
+    )
+
+    verify = sub.add_parser(
+        "verify-readback",
+        help="Compare a remote HTTP deploy receipt with the local packaged receipt.",
+    )
+    add_subcommand_format(verify)
+    verify.add_argument(
+        "--output-dir", required=True, help="Existing local publish artifact directory."
+    )
+    verify.add_argument("--state-dir", help="Local deploy receipt state directory.")
+    verify.add_argument(
+        "--receipt-url",
+        help="Remote receipt URL; defaults to the publisher latest URL.",
+    )
+    verify.add_argument(
+        "--retries", type=int, default=3, help="Bounded HTTP readback attempts (1-10)."
+    )
+    verify.add_argument(
+        "--retry-delay-seconds",
+        type=float,
+        default=1.0,
+        help="Delay between attempts (0-30 seconds).",
+    )
+    verify.add_argument(
+        "--execute",
+        action="store_true",
+        help="Persist the verified readback receipt locally.",
+    )
+
+
+def handle_presentation_command(
+    args: argparse.Namespace,
+    *,
+    output_format: FormatSelector,
+    print_payload: PrintPayload,
+) -> int | None:
+    if args.command != "presentation":
+        return None
+    try:
+        if args.presentation_command == "package":
+            payload = package_static_site(
+                site_dir=Path(args.site_dir),
+                output_dir=Path(args.output_dir),
+                state_dir=Path(args.state_dir) if args.state_dir else None,
+                site_id=args.site_id,
+                entry_path=args.entry_path,
+                revision=args.revision,
+                publisher_kind=args.publisher,
+                base_url=args.base_url,
+                desktop_visual_check=args.desktop_visual_check,
+                mobile_visual_check=args.mobile_visual_check,
+                link_check=args.link_check,
+                execute=args.execute,
+            )
+        elif args.presentation_command == "rollback":
+            payload = rollback_static_site(
+                output_dir=Path(args.output_dir),
+                state_dir=Path(args.state_dir) if args.state_dir else None,
+                revision=args.revision,
+                execute=args.execute,
+            )
+        elif args.presentation_command == "verify-readback":
+            payload = verify_static_site_readback(
+                output_dir=Path(args.output_dir),
+                state_dir=Path(args.state_dir) if args.state_dir else None,
+                receipt_url=args.receipt_url,
+                retries=args.retries,
+                retry_delay_seconds=args.retry_delay_seconds,
+                execute=args.execute,
+            )
+        else:
+            raise StaticSiteContractError(
+                f"unknown presentation command: {args.presentation_command}"
+            )
+    except StaticSiteContractError as exc:
+        payload = {
+            "ok": False,
+            "mode": args.presentation_command,
+            "error": str(exc),
+        }
+        print_payload(payload, output_format(args), _render_markdown)
+        return 2
+    print_payload(payload, output_format(args), _render_markdown)
+    return 0

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -154,6 +154,10 @@ COMMAND_GROUPS: list[dict[str, object]] = [
             {"command": "loopx register-agent", "purpose": "Register an automation agent."},
             {"command": "loopx lark-kanban", "purpose": "Project LoopX state into a Feishu/Lark Base board."},
             {
+                "command": "loopx presentation",
+                "purpose": "Package, roll back, and verify provider-neutral static presentation artifacts.",
+            },
+            {
                 "command": "loopx explore",
                 "purpose": "Record the exploration topology (nodes, edges, findings) and project it to a Feishu/Lark result board.",
             },

--- a/loopx/presentation/README.md
+++ b/loopx/presentation/README.md
@@ -33,3 +33,40 @@ Only the display side of software-exploration topology belongs here:
 That keeps topology cards, tables, and graph views close to the dashboard
 without turning presentation code into the source of evidence for vision and
 replan.
+
+## Static Site Delivery Contract
+
+`loopx presentation package` turns an already-built, public-safe site directory
+into a provider-neutral publish artifact. The artifact always remains usable
+locally and carries both a stable latest layout and an immutable
+`revisions/<revision>/` snapshot. The command writes a deterministic manifest
+and a deploy receipt into the artifact; identical content and publication
+parameters are a semantic no-op.
+
+Packaging requires caller-supplied `passed` receipts for desktop visual,
+mobile visual, and link checks. LoopX validates the file manifest and common
+public-boundary leaks, but it does not pretend to have run the caller's browser
+suite.
+
+```bash
+loopx --format json presentation package \
+  --site-dir output/site \
+  --output-dir output/publish \
+  --site-id public-frontstage \
+  --revision <public-revision> \
+  --publisher github-pages \
+  --base-url https://example.github.io/project/ \
+  --desktop-visual-check passed \
+  --mobile-visual-check passed \
+  --link-check passed \
+  --execute
+```
+
+`--publisher local` is the default and requires no network configuration.
+`github-pages` is the first optional URL adapter; it only maps the prepared
+artifact to stable latest and revision URLs, so repository credentials and
+Pages enablement stay in the host workflow. After the host deploys the
+artifact, `presentation verify-readback` compares the served deploy receipt
+with the local receipt and persists a compact verification event. Use
+`presentation rollback` to rebuild latest from a retained revision before the
+host republishes the artifact.

--- a/loopx/presentation/static_site.py
+++ b/loopx/presentation/static_site.py
@@ -1,0 +1,691 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import tempfile
+import time
+from collections.abc import Callable, Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote, urljoin, urlparse
+from urllib.request import urlopen
+
+from .public_safety import public_safe_boundary
+
+
+STATIC_SITE_MANIFEST_VERSION = "loopx_static_site_presentation_manifest_v0"
+STATIC_SITE_REVISION_VERSION = "loopx_static_site_presentation_revision_v0"
+STATIC_SITE_RECEIPT_VERSION = "loopx_static_site_deploy_receipt_v0"
+STATIC_SITE_EVENT_VERSION = "loopx_static_site_deploy_event_v0"
+
+MANIFEST_FILE = ".loopx-static-site-manifest.json"
+REVISION_FILE = ".loopx-static-site-revision.json"
+RECEIPT_FILE = ".loopx-static-site-receipt.json"
+RECEIPT_LOG_FILE = "receipts.jsonl"
+REVISION_DIR = "revisions"
+
+_SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+_TEXT_SUFFIXES = {".css", ".html", ".js", ".json", ".md", ".svg", ".txt", ".xml"}
+_PUBLIC_BOUNDARY_PATTERNS = (
+    (
+        "absolute local path",
+        re.compile(r"/(?:Users|home|private|tmp|var)/[^\s`\"'<>]+"),
+    ),
+    ("private key material", re.compile(r"BEGIN (?:RSA |OPENSSH |EC |)PRIVATE KEY")),
+    (
+        "credential assignment",
+        re.compile(
+            r"\b(?:api[_-]?key|auth[_-]?token|access[_-]?token)\s*[:=]", re.IGNORECASE
+        ),
+    ),
+)
+_RESERVED_TOP_LEVEL = {MANIFEST_FILE, RECEIPT_FILE, REVISION_FILE, REVISION_DIR}
+
+
+class StaticSiteContractError(ValueError):
+    """Raised when a static presentation input violates the publish contract."""
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _validate_identifier(value: str, *, label: str) -> str:
+    normalized = str(value or "").strip()
+    if not _SAFE_ID.fullmatch(normalized) or ".." in normalized:
+        raise StaticSiteContractError(
+            f"{label} must be 1-64 public-safe characters: letters, digits, dot, underscore, or hyphen"
+        )
+    return normalized
+
+
+def _validate_entry_path(value: str) -> str:
+    path = Path(str(value or "").strip())
+    if path.is_absolute() or not path.parts or ".." in path.parts:
+        raise StaticSiteContractError(
+            "entry_path must be a relative path inside the site bundle"
+        )
+    return path.as_posix()
+
+
+def _paths_overlap(left: Path, right: Path) -> bool:
+    left_resolved = left.resolve()
+    right_resolved = right.resolve()
+    return (
+        left_resolved == right_resolved
+        or left_resolved in right_resolved.parents
+        or right_resolved in left_resolved.parents
+    )
+
+
+def _scan_public_text(path: Path, relative_path: str) -> None:
+    if path.suffix.lower() not in _TEXT_SUFFIXES or path.stat().st_size > 2_000_000:
+        return
+    text = path.read_text(encoding="utf-8", errors="replace")
+    for label, pattern in _PUBLIC_BOUNDARY_PATTERNS:
+        if pattern.search(text):
+            raise StaticSiteContractError(
+                f"public boundary scan failed for {relative_path}: {label}"
+            )
+
+
+def _collect_site_files(site_dir: Path, *, entry_path: str) -> list[dict[str, object]]:
+    if not site_dir.is_dir():
+        raise StaticSiteContractError(
+            f"site_dir does not exist or is not a directory: {site_dir}"
+        )
+    if not (site_dir / entry_path).is_file():
+        raise StaticSiteContractError(f"site entry is missing: {entry_path}")
+
+    files: list[dict[str, object]] = []
+    for path in sorted(site_dir.rglob("*")):
+        if path.is_symlink():
+            raise StaticSiteContractError(
+                f"site bundle must not contain symlinks: {path.relative_to(site_dir)}"
+            )
+        if not path.is_file():
+            continue
+        relative_path = path.relative_to(site_dir).as_posix()
+        if relative_path.split("/", 1)[0] in _RESERVED_TOP_LEVEL:
+            raise StaticSiteContractError(
+                f"site bundle uses reserved path: {relative_path}"
+            )
+        _scan_public_text(path, relative_path)
+        content = path.read_bytes()
+        files.append(
+            {
+                "path": relative_path,
+                "sha256": hashlib.sha256(content).hexdigest(),
+                "size": len(content),
+            }
+        )
+    if not files:
+        raise StaticSiteContractError("site bundle must contain at least one file")
+    return files
+
+
+def _semantic_digest(files: list[dict[str, object]]) -> str:
+    encoded = json.dumps(
+        files, ensure_ascii=True, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _normalize_base_url(base_url: str | None) -> str:
+    value = str(base_url or "").strip()
+    parsed = urlparse(value)
+    if parsed.scheme != "https" or not parsed.netloc or parsed.query or parsed.fragment:
+        raise StaticSiteContractError(
+            "github-pages publisher requires a clean https --base-url"
+        )
+    return value if value.endswith("/") else f"{value}/"
+
+
+def _publisher_projection(
+    *,
+    publisher_kind: str,
+    base_url: str | None,
+    revision: str,
+) -> dict[str, object]:
+    if publisher_kind == "local":
+        if base_url:
+            raise StaticSiteContractError("local publisher does not accept --base-url")
+        return {
+            "kind": "local",
+            "base_url": None,
+            "latest_url": "./",
+            "revision_url": f"./{REVISION_DIR}/{quote(revision, safe='._-')}/",
+            "http_readback_required": False,
+        }
+    if publisher_kind == "github-pages":
+        normalized = _normalize_base_url(base_url)
+        return {
+            "kind": "github-pages",
+            "base_url": normalized,
+            "latest_url": normalized,
+            "revision_url": urljoin(
+                normalized, f"{REVISION_DIR}/{quote(revision, safe='._-')}/"
+            ),
+            "http_readback_required": True,
+            "deployment_contract": {
+                "artifact_root": ".",
+                "provider_owns_deploy_receipt": True,
+                "loopx_receipt_readback": RECEIPT_FILE,
+            },
+        }
+    raise StaticSiteContractError(f"unsupported publisher kind: {publisher_kind}")
+
+
+def _validation_receipt(
+    *,
+    desktop_visual_check: str,
+    mobile_visual_check: str,
+    link_check: str,
+) -> dict[str, str]:
+    receipt = {
+        "desktop_visual_check": str(desktop_visual_check or "").strip(),
+        "mobile_visual_check": str(mobile_visual_check or "").strip(),
+        "link_check": str(link_check or "").strip(),
+    }
+    failed = [name for name, value in receipt.items() if value != "passed"]
+    if failed:
+        raise StaticSiteContractError(
+            "static presentation packaging requires passed validation receipts: "
+            + ", ".join(failed)
+        )
+    return receipt
+
+
+def _receipt(
+    *,
+    site_id: str,
+    revision: str,
+    semantic_digest: str,
+    entry_path: str,
+    publisher: Mapping[str, object],
+) -> dict[str, object]:
+    return {
+        "schema_version": STATIC_SITE_RECEIPT_VERSION,
+        "site_id": site_id,
+        "revision": revision,
+        "semantic_digest": semantic_digest,
+        "entry_path": entry_path,
+        "publication_state": "prepared",
+        "publisher_kind": publisher["kind"],
+        "latest_url": publisher["latest_url"],
+        "revision_url": publisher["revision_url"],
+        "readback": {
+            "required": publisher["http_readback_required"],
+            "receipt_path": RECEIPT_FILE,
+        },
+    }
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise StaticSiteContractError(
+            f"cannot read static presentation state {path.name}: {exc}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise StaticSiteContractError(
+            f"static presentation state must be a JSON object: {path.name}"
+        )
+    return payload
+
+
+def _write_json(path: Path, payload: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _copy_declared_files(
+    source: Path, target: Path, files: list[dict[str, object]]
+) -> None:
+    for item in files:
+        relative_path = str(item["path"])
+        destination = target / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source / relative_path, destination)
+
+
+def _append_state_event(state_dir: Path, payload: Mapping[str, object]) -> Path:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    log_path = state_dir / RECEIPT_LOG_FILE
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+    return log_path
+
+
+def _default_state_dir(output_dir: Path) -> Path:
+    return output_dir.parent / f".{output_dir.name}.loopx-state"
+
+
+def _replace_output(output_dir: Path, build: Callable[[Path], None]) -> None:
+    output_dir.parent.mkdir(parents=True, exist_ok=True)
+    backup = output_dir.parent / f".{output_dir.name}.loopx-backup"
+    if backup.exists():
+        raise StaticSiteContractError(
+            f"stale static presentation backup requires inspection: {backup}"
+        )
+    with tempfile.TemporaryDirectory(
+        prefix=f".{output_dir.name}.loopx-stage-", dir=output_dir.parent
+    ) as temp_dir:
+        staged = Path(temp_dir) / "publish"
+        staged.mkdir()
+        build(staged)
+        had_output = output_dir.exists()
+        if had_output:
+            os.replace(output_dir, backup)
+        try:
+            os.replace(staged, output_dir)
+        except Exception:
+            if had_output and backup.exists() and not output_dir.exists():
+                os.replace(backup, output_dir)
+            raise
+        if backup.exists():
+            shutil.rmtree(backup)
+
+
+def package_static_site(
+    *,
+    site_dir: Path,
+    output_dir: Path,
+    site_id: str,
+    entry_path: str = "index.html",
+    revision: str | None = None,
+    publisher_kind: str = "local",
+    base_url: str | None = None,
+    state_dir: Path | None = None,
+    desktop_visual_check: str,
+    mobile_visual_check: str,
+    link_check: str,
+    execute: bool = False,
+) -> dict[str, object]:
+    site_dir = site_dir.expanduser().resolve()
+    output_dir = output_dir.expanduser().resolve()
+    if _paths_overlap(site_dir, output_dir):
+        raise StaticSiteContractError(
+            "site_dir and output_dir must be independent directories"
+        )
+
+    site_id = _validate_identifier(site_id, label="site_id")
+    entry_path = _validate_entry_path(entry_path)
+    files = _collect_site_files(site_dir, entry_path=entry_path)
+    semantic_digest = _semantic_digest(files)
+    requested_revision = _validate_identifier(
+        revision or semantic_digest.removeprefix("sha256:")[:16],
+        label="revision",
+    )
+    validation = _validation_receipt(
+        desktop_visual_check=desktop_visual_check,
+        mobile_visual_check=mobile_visual_check,
+        link_check=link_check,
+    )
+    existing = _read_json(output_dir / MANIFEST_FILE)
+
+    exact_semantic_reuse = bool(
+        existing
+        and existing.get("site_id") == site_id
+        and existing.get("semantic_digest") == semantic_digest
+        and existing.get("entry_path") == entry_path
+        and existing.get("files") == files
+        and existing.get("validation") == validation
+    )
+    active_revision = (
+        _validate_identifier(str(existing["active_revision"]), label="active_revision")
+        if exact_semantic_reuse and existing
+        else requested_revision
+    )
+    publisher = _publisher_projection(
+        publisher_kind=publisher_kind,
+        base_url=base_url,
+        revision=active_revision,
+    )
+    previous_revision = None
+    if existing:
+        if exact_semantic_reuse:
+            previous_revision = existing.get("previous_revision")
+        elif existing.get("active_revision") != active_revision:
+            previous_revision = existing.get("active_revision")
+        else:
+            previous_revision = existing.get("previous_revision")
+
+    manifest: dict[str, object] = {
+        "schema_version": STATIC_SITE_MANIFEST_VERSION,
+        "site_id": site_id,
+        "semantic_digest": semantic_digest,
+        "active_revision": active_revision,
+        "previous_revision": previous_revision,
+        "entry_path": entry_path,
+        "latest_entry_path": entry_path,
+        "revision_entry_path": f"{REVISION_DIR}/{active_revision}/{entry_path}",
+        "publisher": publisher,
+        "validation": validation,
+        "files": files,
+        "public_boundary": public_safe_boundary(),
+    }
+    deploy_receipt = _receipt(
+        site_id=site_id,
+        revision=active_revision,
+        semantic_digest=semantic_digest,
+        entry_path=entry_path,
+        publisher=publisher,
+    )
+    revision_metadata: dict[str, object] = {
+        "schema_version": STATIC_SITE_REVISION_VERSION,
+        "site_id": site_id,
+        "revision": active_revision,
+        "semantic_digest": semantic_digest,
+        "entry_path": entry_path,
+        "validation": validation,
+        "files": files,
+    }
+
+    existing_revision = _read_json(
+        output_dir / REVISION_DIR / active_revision / REVISION_FILE
+    )
+    if (
+        existing_revision
+        and existing_revision.get("semantic_digest") != semantic_digest
+    ):
+        raise StaticSiteContractError(
+            f"revision {active_revision} already exists with a different semantic digest"
+        )
+    write_required = not (
+        existing == manifest
+        and existing_revision == revision_metadata
+        and _read_json(output_dir / RECEIPT_FILE) == deploy_receipt
+    )
+    state_path = (
+        state_dir.expanduser().resolve()
+        if state_dir
+        else _default_state_dir(output_dir)
+    )
+
+    if execute and write_required:
+
+        def build(staged: Path) -> None:
+            existing_revisions = output_dir / REVISION_DIR
+            staged_revisions = staged / REVISION_DIR
+            if existing_revisions.is_dir():
+                shutil.copytree(existing_revisions, staged_revisions)
+            else:
+                staged_revisions.mkdir()
+
+            revision_dir = staged_revisions / active_revision
+            if not revision_dir.exists():
+                revision_dir.mkdir()
+                _copy_declared_files(site_dir, revision_dir, files)
+            _write_json(revision_dir / REVISION_FILE, revision_metadata)
+            _write_json(revision_dir / RECEIPT_FILE, deploy_receipt)
+            _copy_declared_files(site_dir, staged, files)
+            _write_json(staged / MANIFEST_FILE, manifest)
+            _write_json(staged / RECEIPT_FILE, deploy_receipt)
+
+        _replace_output(output_dir, build)
+        _append_state_event(
+            state_path,
+            {
+                "schema_version": STATIC_SITE_EVENT_VERSION,
+                "event": "package_prepared",
+                "recorded_at": _utc_now(),
+                "site_id": site_id,
+                "revision": active_revision,
+                "previous_revision": previous_revision,
+                "semantic_digest": semantic_digest,
+                "publisher_kind": publisher_kind,
+                "latest_url": publisher["latest_url"],
+                "revision_url": publisher["revision_url"],
+            },
+        )
+
+    return {
+        "ok": True,
+        "schema_version": STATIC_SITE_MANIFEST_VERSION,
+        "mode": "package",
+        "dry_run": not execute,
+        "write_required": write_required,
+        "write_performed": bool(execute and write_required),
+        "semantic_noop": not write_required,
+        "requested_revision": requested_revision,
+        "active_revision": active_revision,
+        "previous_revision": previous_revision,
+        "semantic_digest": semantic_digest,
+        "publisher": publisher,
+        "output_dir": str(output_dir),
+        "manifest_path": str(output_dir / MANIFEST_FILE),
+        "receipt_path": str(output_dir / RECEIPT_FILE),
+        "state_receipt_log": str(state_path / RECEIPT_LOG_FILE),
+        "validation": validation,
+    }
+
+
+def rollback_static_site(
+    *,
+    output_dir: Path,
+    revision: str | None = None,
+    state_dir: Path | None = None,
+    execute: bool = False,
+) -> dict[str, object]:
+    output_dir = output_dir.expanduser().resolve()
+    manifest = _read_json(output_dir / MANIFEST_FILE)
+    if not manifest or manifest.get("schema_version") != STATIC_SITE_MANIFEST_VERSION:
+        raise StaticSiteContractError(
+            "rollback requires an existing static presentation manifest"
+        )
+    current_revision = _validate_identifier(
+        str(manifest.get("active_revision") or ""), label="active_revision"
+    )
+    target_revision = _validate_identifier(
+        revision or str(manifest.get("previous_revision") or ""),
+        label="rollback revision",
+    )
+    if target_revision == current_revision:
+        raise StaticSiteContractError("rollback target is already active")
+    target_dir = output_dir / REVISION_DIR / target_revision
+    metadata = _read_json(target_dir / REVISION_FILE)
+    if not metadata or metadata.get("schema_version") != STATIC_SITE_REVISION_VERSION:
+        raise StaticSiteContractError(
+            f"rollback revision is missing or invalid: {target_revision}"
+        )
+    files = metadata.get("files")
+    if not isinstance(files, list):
+        raise StaticSiteContractError(
+            "rollback revision does not contain a file manifest"
+        )
+
+    publisher_state = (
+        manifest.get("publisher") if isinstance(manifest.get("publisher"), dict) else {}
+    )
+    publisher = _publisher_projection(
+        publisher_kind=str(publisher_state.get("kind") or "local"),
+        base_url=publisher_state.get("base_url")
+        if isinstance(publisher_state.get("base_url"), str)
+        else None,
+        revision=target_revision,
+    )
+    semantic_digest = str(metadata.get("semantic_digest") or "")
+    entry_path = _validate_entry_path(str(metadata.get("entry_path") or ""))
+    new_manifest = {
+        **manifest,
+        "semantic_digest": semantic_digest,
+        "active_revision": target_revision,
+        "previous_revision": current_revision,
+        "entry_path": entry_path,
+        "latest_entry_path": entry_path,
+        "revision_entry_path": f"{REVISION_DIR}/{target_revision}/{entry_path}",
+        "publisher": publisher,
+        "validation": metadata.get("validation"),
+        "files": files,
+    }
+    deploy_receipt = _receipt(
+        site_id=str(manifest["site_id"]),
+        revision=target_revision,
+        semantic_digest=semantic_digest,
+        entry_path=entry_path,
+        publisher=publisher,
+    )
+    write_required = (
+        manifest != new_manifest
+        or _read_json(output_dir / RECEIPT_FILE) != deploy_receipt
+    )
+    state_path = (
+        state_dir.expanduser().resolve()
+        if state_dir
+        else _default_state_dir(output_dir)
+    )
+
+    if execute and write_required:
+
+        def build(staged: Path) -> None:
+            shutil.copytree(output_dir / REVISION_DIR, staged / REVISION_DIR)
+            _copy_declared_files(target_dir, staged, files)
+            _write_json(staged / MANIFEST_FILE, new_manifest)
+            _write_json(staged / RECEIPT_FILE, deploy_receipt)
+
+        _replace_output(output_dir, build)
+        _append_state_event(
+            state_path,
+            {
+                "schema_version": STATIC_SITE_EVENT_VERSION,
+                "event": "rollback_prepared",
+                "recorded_at": _utc_now(),
+                "site_id": manifest["site_id"],
+                "revision": target_revision,
+                "previous_revision": current_revision,
+                "semantic_digest": semantic_digest,
+                "publisher_kind": publisher["kind"],
+                "latest_url": publisher["latest_url"],
+                "revision_url": publisher["revision_url"],
+            },
+        )
+
+    return {
+        "ok": True,
+        "schema_version": STATIC_SITE_MANIFEST_VERSION,
+        "mode": "rollback",
+        "dry_run": not execute,
+        "write_required": write_required,
+        "write_performed": bool(execute and write_required),
+        "from_revision": current_revision,
+        "active_revision": target_revision,
+        "semantic_digest": semantic_digest,
+        "publisher": publisher,
+        "output_dir": str(output_dir),
+        "manifest_path": str(output_dir / MANIFEST_FILE),
+        "receipt_path": str(output_dir / RECEIPT_FILE),
+        "state_receipt_log": str(state_path / RECEIPT_LOG_FILE),
+    }
+
+
+def verify_static_site_readback(
+    *,
+    output_dir: Path,
+    receipt_url: str | None = None,
+    state_dir: Path | None = None,
+    retries: int = 3,
+    retry_delay_seconds: float = 1.0,
+    execute: bool = False,
+    opener: Callable[..., Any] = urlopen,
+) -> dict[str, object]:
+    output_dir = output_dir.expanduser().resolve()
+    expected = _read_json(output_dir / RECEIPT_FILE)
+    manifest = _read_json(output_dir / MANIFEST_FILE)
+    if not expected or not manifest:
+        raise StaticSiteContractError(
+            "readback verification requires a packaged static presentation"
+        )
+    if retries < 1 or retries > 10:
+        raise StaticSiteContractError("retries must be between 1 and 10")
+    if retry_delay_seconds < 0 or retry_delay_seconds > 30:
+        raise StaticSiteContractError("retry_delay_seconds must be between 0 and 30")
+
+    publisher = (
+        manifest.get("publisher") if isinstance(manifest.get("publisher"), dict) else {}
+    )
+    target_url = str(receipt_url or "").strip()
+    if not target_url:
+        latest_url = str(publisher.get("latest_url") or "")
+        if not latest_url.startswith("https://"):
+            raise StaticSiteContractError(
+                "remote readback requires --receipt-url for a non-HTTP publisher"
+            )
+        target_url = urljoin(latest_url, RECEIPT_FILE)
+    parsed = urlparse(target_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise StaticSiteContractError("receipt_url must be an absolute HTTP(S) URL")
+
+    last_error: Exception | None = None
+    observed: dict[str, Any] | None = None
+    attempts = 0
+    for attempts in range(1, retries + 1):
+        try:
+            with opener(target_url, timeout=10) as response:
+                body = response.read(262_145)
+            if len(body) > 262_144:
+                raise StaticSiteContractError("remote receipt exceeds 256 KiB")
+            candidate = json.loads(body.decode("utf-8"))
+            if not isinstance(candidate, dict):
+                raise StaticSiteContractError("remote receipt must be a JSON object")
+            observed = candidate
+            for field in ("schema_version", "site_id", "revision", "semantic_digest"):
+                if observed.get(field) != expected.get(field):
+                    raise StaticSiteContractError(
+                        f"remote receipt {field} mismatch: expected {expected.get(field)!r}, observed {observed.get(field)!r}"
+                    )
+            break
+        except Exception as exc:  # bounded retry preserves the exact last cause
+            last_error = exc
+            observed = None
+            if attempts < retries:
+                time.sleep(retry_delay_seconds)
+    if observed is None:
+        raise StaticSiteContractError(
+            f"remote receipt readback failed after {attempts} attempt(s): {last_error}"
+        )
+
+    state_path = (
+        state_dir.expanduser().resolve()
+        if state_dir
+        else _default_state_dir(output_dir)
+    )
+    if execute:
+        _append_state_event(
+            state_path,
+            {
+                "schema_version": STATIC_SITE_EVENT_VERSION,
+                "event": "http_readback_verified",
+                "recorded_at": _utc_now(),
+                "site_id": expected["site_id"],
+                "revision": expected["revision"],
+                "semantic_digest": expected["semantic_digest"],
+                "publisher_kind": expected["publisher_kind"],
+                "receipt_url": target_url,
+                "attempts": attempts,
+            },
+        )
+
+    return {
+        "ok": True,
+        "schema_version": STATIC_SITE_RECEIPT_VERSION,
+        "mode": "verify-readback",
+        "dry_run": not execute,
+        "verified": True,
+        "receipt_url": target_url,
+        "attempts": attempts,
+        "site_id": expected["site_id"],
+        "revision": expected["revision"],
+        "semantic_digest": expected["semantic_digest"],
+        "state_receipt_log": str(state_path / RECEIPT_LOG_FILE),
+    }

--- a/tests/test_static_site_presentation.py
+++ b/tests/test_static_site_presentation.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from loopx.cli import main
+from loopx.presentation.static_site import (
+    MANIFEST_FILE,
+    RECEIPT_FILE,
+    RECEIPT_LOG_FILE,
+    REVISION_DIR,
+    REVISION_FILE,
+    StaticSiteContractError,
+    package_static_site,
+    rollback_static_site,
+    verify_static_site_readback,
+)
+
+
+def _site(root: Path, *, body: str = "first") -> Path:
+    site = root / "site"
+    site.mkdir()
+    (site / "index.html").write_text(
+        f"<html><body>{body}</body></html>\n", encoding="utf-8"
+    )
+    (site / "assets").mkdir()
+    (site / "assets" / "app.js").write_text(
+        f"window.payload = {body!r};\n", encoding="utf-8"
+    )
+    return site
+
+
+def _package(
+    site: Path, output: Path, state: Path, **overrides: object
+) -> dict[str, object]:
+    options: dict[str, object] = {
+        "site_dir": site,
+        "output_dir": output,
+        "state_dir": state,
+        "site_id": "public-demo",
+        "entry_path": "index.html",
+        "revision": "rev-a",
+        "publisher_kind": "local",
+        "base_url": None,
+        "desktop_visual_check": "passed",
+        "mobile_visual_check": "passed",
+        "link_check": "passed",
+        "execute": True,
+    }
+    options.update(overrides)
+    return package_static_site(**options)  # type: ignore[arg-type]
+
+
+def test_package_is_semantically_idempotent_and_rollback_restores_previous_revision(
+    tmp_path: Path,
+) -> None:
+    site = _site(tmp_path)
+    output = tmp_path / "publish"
+    state = tmp_path / "state"
+
+    first = _package(site, output, state)
+    assert first["write_performed"] is True
+    assert first["active_revision"] == "rev-a"
+    assert (output / "index.html").read_text(encoding="utf-8").find("first") >= 0
+    assert (output / REVISION_DIR / "rev-a" / REVISION_FILE).is_file()
+    assert (output / RECEIPT_FILE).is_file()
+
+    repeated = _package(site, output, state, revision="rev-alias")
+    assert repeated["semantic_noop"] is True
+    assert repeated["write_performed"] is False
+    assert repeated["active_revision"] == "rev-a"
+    assert not (output / REVISION_DIR / "rev-alias").exists()
+    assert len((state / RECEIPT_LOG_FILE).read_text(encoding="utf-8").splitlines()) == 1
+
+    (site / "index.html").write_text(
+        "<html><body>second</body></html>\n", encoding="utf-8"
+    )
+    second = _package(site, output, state, revision="rev-b")
+    assert second["active_revision"] == "rev-b"
+    assert second["previous_revision"] == "rev-a"
+    assert "second" in (output / "index.html").read_text(encoding="utf-8")
+    assert "first" in (output / REVISION_DIR / "rev-a" / "index.html").read_text(
+        encoding="utf-8"
+    )
+
+    rolled_back = rollback_static_site(output_dir=output, state_dir=state, execute=True)
+    assert rolled_back["active_revision"] == "rev-a"
+    assert rolled_back["from_revision"] == "rev-b"
+    assert "first" in (output / "index.html").read_text(encoding="utf-8")
+    manifest = json.loads((output / MANIFEST_FILE).read_text(encoding="utf-8"))
+    assert manifest["active_revision"] == "rev-a"
+    assert manifest["previous_revision"] == "rev-b"
+    assert len((state / RECEIPT_LOG_FILE).read_text(encoding="utf-8").splitlines()) == 3
+
+
+def test_github_pages_adapter_projects_stable_latest_and_revision_urls(
+    tmp_path: Path,
+) -> None:
+    site = _site(tmp_path)
+    payload = _package(
+        site,
+        tmp_path / "publish",
+        tmp_path / "state",
+        revision="abc123",
+        publisher_kind="github-pages",
+        base_url="https://example.github.io/project",
+        execute=False,
+    )
+
+    publisher = payload["publisher"]
+    assert isinstance(publisher, dict)
+    assert publisher["latest_url"] == "https://example.github.io/project/"
+    assert (
+        publisher["revision_url"]
+        == "https://example.github.io/project/revisions/abc123/"
+    )
+    assert publisher["http_readback_required"] is True
+    assert payload["write_required"] is True
+    assert not (tmp_path / "publish").exists()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("desktop_visual_check", "not-run"),
+        ("mobile_visual_check", "failed"),
+        ("link_check", "unknown"),
+    ],
+)
+def test_package_requires_visual_and_link_validation_receipts(
+    tmp_path: Path,
+    field: str,
+    value: str,
+) -> None:
+    site = _site(tmp_path)
+    with pytest.raises(
+        StaticSiteContractError, match="requires passed validation receipts"
+    ):
+        _package(site, tmp_path / "publish", tmp_path / "state", **{field: value})
+
+
+def test_package_rejects_reserved_paths_symlinks_and_public_boundary_leaks(
+    tmp_path: Path,
+) -> None:
+    site = _site(tmp_path)
+    (site / "notes.txt").write_text(
+        "developer path: /Users/example/private.txt\n", encoding="utf-8"
+    )
+    with pytest.raises(StaticSiteContractError, match="public boundary scan failed"):
+        _package(site, tmp_path / "publish-a", tmp_path / "state-a")
+
+    (site / "notes.txt").unlink()
+    (site / MANIFEST_FILE).write_text("{}\n", encoding="utf-8")
+    with pytest.raises(StaticSiteContractError, match="reserved path"):
+        _package(site, tmp_path / "publish-b", tmp_path / "state-b")
+
+    (site / MANIFEST_FILE).unlink()
+    (site / "linked.html").symlink_to(site / "index.html")
+    with pytest.raises(StaticSiteContractError, match="must not contain symlinks"):
+        _package(site, tmp_path / "publish-c", tmp_path / "state-c")
+
+
+class _Response:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self) -> _Response:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self, _limit: int) -> bytes:
+        return self._body
+
+
+def test_http_readback_retries_then_persists_verified_receipt(tmp_path: Path) -> None:
+    site = _site(tmp_path)
+    output = tmp_path / "publish"
+    state = tmp_path / "state"
+    _package(
+        site,
+        output,
+        state,
+        revision="remote-a",
+        publisher_kind="github-pages",
+        base_url="https://example.github.io/project/",
+    )
+    expected = json.loads((output / RECEIPT_FILE).read_text(encoding="utf-8"))
+    wrong = {**expected, "semantic_digest": "sha256:wrong"}
+    responses = iter([_Response(wrong), _Response(expected)])
+
+    def opener(_url: str, *, timeout: int) -> _Response:
+        assert timeout == 10
+        return next(responses)
+
+    verified = verify_static_site_readback(
+        output_dir=output,
+        state_dir=state,
+        retries=2,
+        retry_delay_seconds=0,
+        execute=True,
+        opener=opener,
+    )
+    assert verified["verified"] is True
+    assert verified["attempts"] == 2
+    events = [
+        json.loads(line)
+        for line in (state / RECEIPT_LOG_FILE).read_text(encoding="utf-8").splitlines()
+    ]
+    assert events[-1]["event"] == "http_readback_verified"
+    assert (
+        events[-1]["receipt_url"]
+        == "https://example.github.io/project/.loopx-static-site-receipt.json"
+    )
+
+
+def test_cli_package_preview_is_read_only_and_exposes_publisher_as_first_class_parameter(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    site = _site(tmp_path)
+    output = tmp_path / "publish"
+    result = main(
+        [
+            "--format",
+            "json",
+            "presentation",
+            "package",
+            "--site-dir",
+            str(site),
+            "--output-dir",
+            str(output),
+            "--site-id",
+            "cli-demo",
+            "--publisher",
+            "github-pages",
+            "--base-url",
+            "https://example.github.io/cli-demo/",
+            "--desktop-visual-check",
+            "passed",
+            "--mobile-visual-check",
+            "passed",
+            "--link-check",
+            "passed",
+        ]
+    )
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["dry_run"] is True
+    assert payload["publisher"]["kind"] == "github-pages"
+    assert output.exists() is False


### PR DESCRIPTION
## Summary

- add first-class `loopx presentation package`, `rollback`, and `verify-readback` commands
- keep a local publish artifact available while projecting optional publisher URLs through a provider-neutral contract; GitHub Pages is the first adapter
- provide deterministic latest and immutable revision layouts, semantic no-op detection, deploy receipts, previous-revision rollback, HTTP receipt readback, and a bounded public-safety scan
- require explicit passed desktop, mobile, and link validation receipts before packaging

## Commit grouping

1. Runtime/API and CLI contract
2. Public documentation, focused unit coverage, and end-to-end smoke

## Validation

- 13 focused tests passed
- `examples/static-site-presentation-smoke.py` passed, including package, semantic retry, rollback, and real local HTTP readback
- CLI help/manpage smoke passed
- Ruff check and format check passed
- Python compile and diff hygiene passed
- standard LoopX premerge canary passed 17 selected checks with zero failures; public-boundary scan passed

## Boundary and residual risk

No credentials, private state, local runtime records, or project-specific OpenViking content are included. The GitHub Pages adapter prepares stable URLs and deploy/readback receipts; the host workflow still owns Pages enablement, credentials, and the actual deploy. This runtime/API PR is intentionally left for independent review and will not be self-reviewed or self-merged by its author.