### PR TITLE
Add native Codex CLI LoopX Turn host

### DIFF
--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -9,7 +9,9 @@ from ..control_plane.turn_driver import (
     LOOPX_TURN_EXECUTION_SCHEMA_VERSION,
     LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION,
     build_loopx_turn_plan,
+    codex_cli_session_binding,
     load_loopx_turn_plan_from_journal,
+    run_codex_cli_host,
     run_loopx_turn_once,
 )
 from ..control_plane.quota.live_decision import build_live_quota_should_run_decision
@@ -20,6 +22,7 @@ from ..control_plane.runtime.status_projection_cache import (
 from ..quota import spend_quota_slot
 from ..state_refresh import refresh_state_run
 from ..status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, collect_status
+from ..todos import update_goal_todo
 
 
 PrintPayload = Callable[
@@ -78,17 +81,33 @@ def register_turn_commands(
     _add_turn_decision_arguments(
         run_once,
         default_host="generic-cli",
-        host_choices=["generic-cli"],
+        host_choices=["codex-cli", "generic-cli"],
         execution_mode_choices=["isolated-headless"],
         default_execution_mode="isolated-headless",
     )
     run_once.add_argument("--project", required=True)
     run_once.add_argument(
         "--host-command-json",
-        required=True,
-        help="JSON argv array for the explicit host process; shell parsing is never used.",
+        help="JSON argv array for generic-cli; shell parsing is never used.",
+    )
+    run_once.add_argument(
+        "--codex-bin",
+        default="codex",
+        help="Codex CLI executable used by the built-in codex-cli host.",
+    )
+    run_once.add_argument("--codex-model")
+    run_once.add_argument(
+        "--codex-sandbox",
+        choices=["read-only", "workspace-write"],
+        default="read-only",
+        help="Sandbox for a new Codex CLI session; resume preserves its original session policy.",
     )
     run_once.add_argument("--timeout-seconds", type=float, default=120.0)
+    run_once.add_argument(
+        "--retry-failed-turn",
+        action="store_true",
+        help="Retry a failed transaction from its last side-effect-safe phase.",
+    )
     run_once.add_argument(
         "--resume-turn-key",
         help="Resume the exact journaled transaction without recomputing its plan.",
@@ -241,8 +260,11 @@ def handle_turn_command(
                 "schema_version": LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION,
                 **resume_identity,
             }
+        turn_envelope = build_turn_envelope(decision)
+        if args.turn_command == "run-once" and args.host == "codex-cli" and not supplied_resume_fields:
+            session_binding = codex_cli_session_binding(runtime_root, turn_envelope)
         payload = build_loopx_turn_plan(
-            build_turn_envelope(decision),
+            turn_envelope,
             host=args.host,
             execution_mode=args.execution_mode,
             session_binding=session_binding,
@@ -274,14 +296,43 @@ def handle_turn_command(
                     raise ValueError(
                         "LoopX Turn resume journal belongs to another agent"
                     )
-            raw_argv = json.loads(args.host_command_json)
-            if not isinstance(raw_argv, list) or not all(
-                isinstance(item, str) for item in raw_argv
-            ):
-                raise ValueError("--host-command-json must be a JSON string array")
             project = Path(args.project).expanduser().resolve()
+            planned_host = payload.get("host") if isinstance(payload.get("host"), dict) else {}
+            if planned_host.get("kind") != args.host:
+                raise ValueError("--host must match the journaled LoopX Turn plan")
+            if args.host == "generic-cli":
+                if not args.host_command_json:
+                    raise ValueError("generic-cli requires --host-command-json")
+                raw_argv = json.loads(args.host_command_json)
+                if not isinstance(raw_argv, list) or not all(
+                    isinstance(item, str) for item in raw_argv
+                ):
+                    raise ValueError("--host-command-json must be a JSON string array")
+            else:
+                if args.host_command_json:
+                    raise ValueError("codex-cli does not accept --host-command-json")
+                raw_argv = None
+            envelope = payload.get("turn_envelope") if isinstance(payload.get("turn_envelope"), dict) else {}
+            action = envelope.get("action") if isinstance(envelope.get("action"), dict) else {}
+            selected_todo = action.get("selected_todo") if isinstance(action.get("selected_todo"), dict) else {}
 
             def writeback(result: dict[str, object]) -> dict[str, object]:
+                result_kind = str(result.get("result_kind") or "")
+                if result_kind in {"repair_required", "replan_required"}:
+                    todo_id = str(selected_todo.get("todo_id") or "")
+                    if not todo_id:
+                        raise ValueError(f"{result_kind} requires one selected todo for typed writeback")
+                    update_goal_todo(
+                        registry_path=registry_path,
+                        goal_id=args.goal_id,
+                        todo_id=todo_id,
+                        role="agent",
+                        note=str(result.get("summary") or result["classification"]),
+                        evidence=f"LoopX Turn {result_kind}: {result['next_action']}",
+                        agent_id=args.agent_id,
+                        project=project,
+                        dry_run=False,
+                    )
                 return refresh_state_run(
                     registry_path=registry_path,
                     runtime_root_override=runtime_root_arg,
@@ -295,6 +346,7 @@ def handle_turn_command(
                     delivery_outcome=str(result["delivery_outcome"]),
                     agent_id=args.agent_id,
                     progress_scope="goal",
+                    autonomous_replan_recorded=result_kind == "replan_required",
                     vision_unchanged_reason=str(result["vision_unchanged_reason"]),
                     dry_run=False,
                     sync_global=not bool(args.no_global_sync),
@@ -352,14 +404,31 @@ def handle_turn_command(
                     ),
                 }
 
+            host_runner = None
+            if args.host == "codex-cli":
+                def run_built_in_host(request: dict[str, object]) -> dict[str, object]:
+                    return run_codex_cli_host(
+                        request,
+                        runtime_root=runtime_root,
+                        project=project,
+                        codex_bin=args.codex_bin,
+                        sandbox=args.codex_sandbox,
+                        model=args.codex_model,
+                        timeout_seconds=max(1.0, args.timeout_seconds - 5.0),
+                    )
+
+                host_runner = run_built_in_host
+
             payload = run_loopx_turn_once(
                 payload,
                 host_argv=raw_argv,
+                host_runner=host_runner,
                 project=project,
                 runtime_root=runtime_root,
                 goal_id=args.goal_id,
                 timeout_seconds=args.timeout_seconds,
                 execute=bool(args.execute),
+                retry_failed=bool(args.retry_failed_turn),
                 writeback=writeback if args.execute else None,
                 spend=spend if args.execute else None,
                 scheduler=scheduler if args.execute else None,

--- a/loopx/control_plane/turn_driver/__init__.py
+++ b/loopx/control_plane/turn_driver/__init__.py
@@ -5,6 +5,13 @@ from .driver import (
     LoopXTurnRoute,
     build_loopx_turn_plan,
 )
+from .codex_cli import (
+    CODEX_CLI_SESSION_SCHEMA_VERSION,
+    codex_cli_result_schema,
+    codex_cli_session_binding,
+    load_codex_cli_session,
+    run_codex_cli_host,
+)
 from .executor import (
     LOOPX_TURN_EXECUTION_SCHEMA_VERSION,
     LOOPX_TURN_HOST_REQUEST_SCHEMA_VERSION,
@@ -23,6 +30,7 @@ from .transaction import (
 
 __all__ = [
     "LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION",
+    "CODEX_CLI_SESSION_SCHEMA_VERSION",
     "LOOPX_TURN_RESULT_SCHEMA_VERSION",
     "LOOPX_TURN_EXECUTION_SCHEMA_VERSION",
     "LOOPX_TURN_HOST_REQUEST_SCHEMA_VERSION",
@@ -32,8 +40,12 @@ __all__ = [
     "build_loopx_turn_host_request",
     "build_loopx_turn_transaction_plan",
     "load_loopx_turn_plan_from_journal",
+    "load_codex_cli_session",
     "normalize_host_argv",
     "run_loopx_turn_once",
+    "run_codex_cli_host",
+    "codex_cli_result_schema",
+    "codex_cli_session_binding",
     "validate_loopx_turn_host_result",
     "validate_loopx_turn_receipt",
 ]

--- a/loopx/control_plane/turn_driver/codex_cli.py
+++ b/loopx/control_plane/turn_driver/codex_cli.py
@@ -1,0 +1,428 @@
+"""Native Codex CLI host for one governed LoopX Turn."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import signal
+import subprocess
+import tempfile
+import threading
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from ...runtime import validate_goal_id_path_segment
+from .executor import BuiltInHostError, LOOPX_TURN_HOST_REQUEST_SCHEMA_VERSION
+from .transaction import LOOPX_TURN_RESULT_SCHEMA_VERSION, TRANSACTION_PHASES
+
+
+CODEX_CLI_SESSION_SCHEMA_VERSION = "loopx_codex_cli_session_v0"
+CODEX_CLI_RESULT_KINDS = (
+    "validated_progress",
+    "repair_required",
+    "replan_required",
+    "user_action_required",
+    "wait",
+)
+CODEX_CLI_SANDBOXES = ("read-only", "workspace-write")
+SESSION_ID_MAX_CHARS = 256
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _lineage(request: Mapping[str, Any]) -> dict[str, str]:
+    envelope = _mapping(request.get("turn_envelope"))
+    action = _mapping(envelope.get("action"))
+    todo = _mapping(action.get("selected_todo"))
+    lineage = {
+        "goal_id": str(envelope.get("goal_id") or "").strip(),
+        "agent_id": str(envelope.get("agent_id") or "").strip(),
+        "todo_id": str(todo.get("todo_id") or "").strip(),
+    }
+    if not all(lineage.values()):
+        raise ValueError("Codex CLI host request has incomplete turn lineage")
+    lineage["goal_id"] = validate_goal_id_path_segment(lineage["goal_id"])
+    return lineage
+
+
+def _session_path(runtime_root: Path, lineage: Mapping[str, str]) -> Path:
+    digest = hashlib.sha256(
+        json.dumps(
+            dict(lineage),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    return (
+        runtime_root
+        / "goals"
+        / validate_goal_id_path_segment(lineage["goal_id"])
+        / "turn-sessions"
+        / f"{digest}.json"
+    )
+
+
+def _valid_session_id(value: Any) -> str | None:
+    session_id = str(value or "").strip()
+    if not session_id or len(session_id) > SESSION_ID_MAX_CHARS:
+        return None
+    if any(character in session_id for character in ("\x00", "\r", "\n")):
+        return None
+    return session_id
+
+
+def load_codex_cli_session(
+    runtime_root: Path,
+    *,
+    lineage: Mapping[str, str],
+) -> dict[str, Any] | None:
+    path = _session_path(runtime_root, lineage)
+    if not path.exists():
+        return None
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(value, dict):
+        return None
+    if value.get("schema_version") != CODEX_CLI_SESSION_SCHEMA_VERSION:
+        return None
+    if any(value.get(field) != lineage[field] for field in lineage):
+        return None
+    session_id = _valid_session_id(value.get("session_id"))
+    if not session_id:
+        return None
+    return {**value, "session_id": session_id}
+
+
+def codex_cli_session_binding(
+    runtime_root: Path,
+    turn_envelope: Mapping[str, Any],
+) -> dict[str, str] | None:
+    request = {"turn_envelope": dict(turn_envelope)}
+    lineage = _lineage(request)
+    if load_codex_cli_session(runtime_root, lineage=lineage) is None:
+        return None
+    return {
+        "schema_version": "loopx_turn_session_binding_v0",
+        **lineage,
+    }
+
+
+def _store_codex_cli_session(
+    runtime_root: Path,
+    *,
+    lineage: Mapping[str, str],
+    session_id: str,
+) -> None:
+    normalized_session_id = _valid_session_id(session_id)
+    if not normalized_session_id:
+        raise ValueError("Codex CLI returned an invalid session id")
+    path = _session_path(runtime_root, lineage)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", dir=path.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(
+                {
+                    "schema_version": CODEX_CLI_SESSION_SCHEMA_VERSION,
+                    **lineage,
+                    "host": "codex-cli",
+                    "session_id": normalized_session_id,
+                },
+                handle,
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+            )
+            handle.write("\n")
+        os.replace(temporary, path)
+        path.chmod(0o600)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def codex_cli_result_schema() -> dict[str, Any]:
+    properties: dict[str, Any] = {
+        "schema_version": {
+            "type": "string",
+            "enum": [LOOPX_TURN_RESULT_SCHEMA_VERSION],
+        },
+        "turn_key": {"type": "string"},
+        "result_kind": {"type": "string", "enum": list(CODEX_CLI_RESULT_KINDS)},
+        "completed_phases": {
+            "type": "array",
+            "items": {"type": "string", "enum": list(TRANSACTION_PHASES[:2])},
+            "minItems": 2,
+            "maxItems": 2,
+        },
+        "classification": {"type": "string"},
+        "recommended_action": {"type": "string"},
+        "next_action": {"type": "string"},
+        "delivery_batch_scale": {
+            "type": "string",
+            "enum": [
+                "",
+                "test_only",
+                "single_surface",
+                "multi_surface",
+                "implementation",
+            ],
+        },
+        "delivery_outcome": {
+            "type": "string",
+            "enum": [
+                "",
+                "surface_only",
+                "outcome_gap",
+                "outcome_progress",
+                "primary_goal_outcome",
+            ],
+        },
+        "vision_unchanged_reason": {"type": "string"},
+        "summary": {"type": "string"},
+    }
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": list(properties),
+        "additionalProperties": False,
+    }
+
+
+def _prompt(request: Mapping[str, Any]) -> str:
+    request_json = json.dumps(
+        request, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    )
+    return "\n".join(
+        [
+            "Execute exactly one bounded LoopX Turn in the current workspace.",
+            "Use the TurnEnvelope as the source of truth. Perform work only when its contract allows it.",
+            "Do not write LoopX state, spend quota, or apply scheduler changes; the adapter owns those effects.",
+            "Return only the schema-constrained result. For validated_progress, repair_required, or replan_required, fill every material field with public-safe evidence.",
+            "For user_action_required or wait, leave material-only fields empty and explain the stop in summary.",
+            'completed_phases must be exactly ["host_execute","typed_result"], and turn_key must match the request.',
+            "Turn request:",
+            request_json,
+        ]
+    )
+
+
+def _event_session_id(event: Mapping[str, Any]) -> str | None:
+    if event.get("type") not in {"thread.started", "thread_started"}:
+        return None
+    for candidate in (
+        event.get("thread_id"),
+        event.get("threadId"),
+        event.get("session_id"),
+        _mapping(event.get("thread")).get("id"),
+    ):
+        session_id = _valid_session_id(candidate)
+        if session_id:
+            return session_id
+    return None
+
+
+def _stderr_failure_category(line: str) -> str | None:
+    text = line.lower()
+    if "requires a newer version of codex" in text:
+        return "model_requires_newer_codex"
+    if "invalid_json_schema" in text or ("output schema" in text and "invalid" in text):
+        return "output_schema_rejected"
+    if any(
+        marker in text
+        for marker in ("unauthorized", "authentication failed", "login required")
+    ):
+        return "auth_failed"
+    if any(
+        marker in text
+        for marker in ("rate limit", "too many requests", "quota exceeded")
+    ):
+        return "rate_limited"
+    if "session" in text and "not found" in text:
+        return "session_missing"
+    return None
+
+
+def _terminate_process(proc: subprocess.Popen[str]) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+    except (OSError, ProcessLookupError):
+        proc.terminate()
+    try:
+        proc.wait(timeout=3)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except (OSError, ProcessLookupError):
+            proc.kill()
+
+
+def _codex_command(
+    *,
+    codex_bin: str,
+    project: Path,
+    schema_path: Path,
+    output_path: Path,
+    sandbox: str,
+    model: str | None,
+    session_id: str | None,
+) -> list[str]:
+    if session_id:
+        command = [
+            codex_bin,
+            "exec",
+            "resume",
+            "--skip-git-repo-check",
+            "--output-schema",
+            str(schema_path),
+            "--output-last-message",
+            str(output_path),
+            "--json",
+        ]
+    else:
+        command = [
+            codex_bin,
+            "exec",
+            "--skip-git-repo-check",
+            "--sandbox",
+            sandbox,
+            "-C",
+            str(project),
+            "--output-schema",
+            str(schema_path),
+            "--output-last-message",
+            str(output_path),
+            "--json",
+        ]
+    if model:
+        command.extend(["--model", model])
+    if session_id:
+        command.append(session_id)
+    command.append("-")
+    return command
+
+
+def run_codex_cli_host(
+    request: Mapping[str, Any],
+    *,
+    runtime_root: Path,
+    project: Path,
+    codex_bin: str = "codex",
+    sandbox: str = "read-only",
+    model: str | None = None,
+    timeout_seconds: float = 115.0,
+) -> dict[str, Any]:
+    if request.get("schema_version") != LOOPX_TURN_HOST_REQUEST_SCHEMA_VERSION:
+        raise ValueError("unsupported LoopX Turn host request schema")
+    if sandbox not in CODEX_CLI_SANDBOXES:
+        raise ValueError("Codex CLI sandbox must be read-only or workspace-write")
+    resolved = shutil.which(codex_bin) if os.path.sep not in codex_bin else codex_bin
+    if not resolved or not Path(resolved).exists():
+        raise ValueError("Codex CLI executable is unavailable")
+    lineage = _lineage(request)
+    binding = load_codex_cli_session(runtime_root, lineage=lineage)
+    planned_session = _mapping(request.get("session"))
+    planned_action = str(planned_session.get("action") or "")
+    if planned_action == "resume" and binding is None:
+        raise RuntimeError("Codex CLI resume binding disappeared after planning")
+    if planned_action == "start_new" and binding is not None:
+        raise RuntimeError("Codex CLI session binding changed after planning")
+    if planned_action not in {"resume", "start_new"}:
+        raise ValueError("Codex CLI host request has no executable session action")
+    session_id = str(binding.get("session_id")) if binding else None
+
+    with tempfile.TemporaryDirectory(prefix="loopx-turn-codex-") as directory:
+        temporary = Path(directory)
+        schema_path = temporary / "result-schema.json"
+        output_path = temporary / "last-message.json"
+        schema_path.write_text(
+            json.dumps(
+                codex_cli_result_schema(), ensure_ascii=False, separators=(",", ":")
+            ),
+            encoding="utf-8",
+        )
+        command = _codex_command(
+            codex_bin=str(resolved),
+            project=project,
+            schema_path=schema_path,
+            output_path=output_path,
+            sandbox=sandbox,
+            model=model,
+            session_id=session_id,
+        )
+        proc = subprocess.Popen(
+            command,
+            cwd=project,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        )
+        observed_session: list[str] = []
+        failure_categories: list[str] = []
+
+        def discard_events() -> None:
+            assert proc.stdout is not None
+            for line in proc.stdout:
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(event, dict):
+                    candidate = _event_session_id(event)
+                    if candidate and not observed_session:
+                        observed_session.append(candidate)
+
+        reader = threading.Thread(target=discard_events, daemon=True)
+
+        def discard_stderr() -> None:
+            assert proc.stderr is not None
+            for line in proc.stderr:
+                category = _stderr_failure_category(line)
+                if category and not failure_categories:
+                    failure_categories.append(category)
+
+        stderr_reader = threading.Thread(target=discard_stderr, daemon=True)
+        reader.start()
+        stderr_reader.start()
+        assert proc.stdin is not None
+        try:
+            proc.stdin.write(_prompt(request))
+            proc.stdin.close()
+            returncode = proc.wait(timeout=max(1.0, timeout_seconds))
+        except subprocess.TimeoutExpired as exc:
+            _terminate_process(proc)
+            raise BuiltInHostError("codex_cli_timeout") from exc
+        finally:
+            reader.join(timeout=2)
+            stderr_reader.join(timeout=2)
+        if observed_session:
+            _store_codex_cli_session(
+                runtime_root,
+                lineage=lineage,
+                session_id=observed_session[0],
+            )
+        if returncode != 0:
+            category = failure_categories[0] if failure_categories else "exit_nonzero"
+            raise BuiltInHostError(f"codex_cli_{category}")
+        try:
+            result = json.loads(output_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise BuiltInHostError("codex_cli_final_result_missing") from exc
+        if not isinstance(result, dict):
+            raise BuiltInHostError("codex_cli_final_result_not_object")
+        return result

--- a/loopx/control_plane/turn_driver/executor.py
+++ b/loopx/control_plane/turn_driver/executor.py
@@ -57,6 +57,15 @@ HOST_RESULT_FIELDS = {
 Writeback = Callable[[dict[str, Any]], dict[str, Any]]
 Spend = Callable[[], dict[str, Any]]
 Scheduler = Callable[[dict[str, Any]], dict[str, Any]]
+HostRunner = Callable[[Mapping[str, Any]], dict[str, Any]]
+
+
+class BuiltInHostError(RuntimeError):
+    """A public-safe built-in host failure classification."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
 
 
 def normalize_host_argv(value: Sequence[str]) -> list[str]:
@@ -330,6 +339,25 @@ def _run_host(
     return {"ok": True, "value": value, "returncode": 0}
 
 
+def _run_host_runner(
+    request: Mapping[str, Any],
+    *,
+    runner: HostRunner,
+) -> dict[str, Any]:
+    try:
+        value = runner(request)
+    except BuiltInHostError as exc:
+        return {"ok": False, "reason": exc.reason, "returncode": None}
+    except Exception as exc:
+        return {"ok": False, "reason": type(exc).__name__, "returncode": None}
+    if not isinstance(value, dict):
+        return {"ok": False, "reason": "built-in host result must be one JSON object"}
+    encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    if len(encoded) > HOST_RESULT_MAX_BYTES:
+        return {"ok": False, "reason": "built-in host result exceeded the result budget"}
+    return {"ok": True, "value": value, "returncode": 0}
+
+
 def _compact_callback(payload: Mapping[str, Any]) -> dict[str, Any]:
     return {
         key: payload.get(key)
@@ -374,19 +402,27 @@ def _execution_payload(
 def run_loopx_turn_once(
     plan: Mapping[str, Any],
     *,
-    host_argv: Sequence[str],
+    host_argv: Sequence[str] | None = None,
+    host_runner: HostRunner | None = None,
     project: Path,
     runtime_root: Path,
     goal_id: str,
     timeout_seconds: float,
     execute: bool,
+    retry_failed: bool = False,
     writeback: Writeback | None = None,
     spend: Spend | None = None,
     scheduler: Scheduler | None = None,
 ) -> dict[str, Any]:
-    argv = normalize_host_argv(host_argv)
+    if host_runner is not None and host_argv is not None:
+        raise ValueError("run-once accepts either host_argv or host_runner, not both")
+    if host_runner is None:
+        argv = normalize_host_argv(host_argv or [])
+        host_projection = {"executable": Path(argv[0]).name, "argv_count": len(argv)}
+    else:
+        argv = None
+        host_projection = {"executable": "built-in", "kind": "codex-cli"}
     request = build_loopx_turn_host_request(plan)
-    host_projection = {"executable": Path(argv[0]).name, "argv_count": len(argv)}
     empty_effects = {
         "host_invoked": False,
         "state_written": False,
@@ -416,11 +452,10 @@ def run_loopx_turn_once(
     journal_path = turn_journal_path(runtime_root, goal_id=goal_id, turn_key=turn_key)
     with exclusive_file_lock(journal_path):
         journal = _load_journal(journal_path)
-        if journal and journal.get("status") in {
-            "committed",
-            "stopped",
-            "failed",
-        }:
+        if journal and (
+            journal.get("status") in {"committed", "stopped"}
+            or journal.get("status") == "failed" and not retry_failed
+        ):
             return _execution_payload(
                 plan,
                 journal,
@@ -428,6 +463,16 @@ def run_loopx_turn_once(
                 replayed=True,
                 effects=empty_effects,
             )
+        if journal and journal.get("status") == "failed":
+            receipt = journal.get("receipt") if isinstance(journal.get("receipt"), dict) else {}
+            if receipt.get("failed_phase") == "validation":
+                journal.pop("host_result", None)
+                journal.pop("result_kind", None)
+                journal["completed_phases"] = []
+            journal.pop("reason", None)
+            journal.pop("receipt", None)
+            journal["status"] = "in_progress"
+            _write_journal(journal_path, journal)
         if journal is None:
             journal = {
                 "schema_version": LOOPX_TURN_JOURNAL_SCHEMA_VERSION,
@@ -444,11 +489,15 @@ def run_loopx_turn_once(
         completed_phases = list(journal.get("completed_phases") or [])
         result = journal.get("host_result") if isinstance(journal.get("host_result"), dict) else None
         if "typed_result" not in completed_phases:
-            host_observation = _run_host(
-                request,
-                argv=argv,
-                project=project,
-                timeout_seconds=timeout_seconds,
+            host_observation = (
+                _run_host_runner(request, runner=host_runner)
+                if host_runner is not None
+                else _run_host(
+                    request,
+                    argv=argv or [],
+                    project=project,
+                    timeout_seconds=timeout_seconds,
+                )
             )
             effects["host_invoked"] = True
             if not host_observation.get("ok"):

--- a/tests/test_loopx_turn_codex_cli.py
+++ b/tests/test_loopx_turn_codex_cli.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+import pytest
+
+from loopx.control_plane.turn_driver.codex_cli import (
+    CODEX_CLI_SESSION_SCHEMA_VERSION,
+    codex_cli_result_schema,
+    codex_cli_session_binding,
+    load_codex_cli_session,
+    run_codex_cli_host,
+)
+
+
+def _request(
+    *,
+    turn_key: str = "sha256:" + "a" * 64,
+    session_action: str = "start_new",
+) -> dict[str, object]:
+    return {
+        "schema_version": "loopx_turn_host_request_v0",
+        "turn_key": turn_key,
+        "route": "ready_for_host",
+        "session": {
+            "schema_version": "loopx_turn_session_binding_v0",
+            "action": session_action,
+        },
+        "turn_envelope": {
+            "schema_version": "loopx_turn_envelope_v0",
+            "goal_id": "fixture-goal",
+            "agent_id": "codex-fixture",
+            "action": {
+                "selected_todo": {
+                    "todo_id": "todo_fixture0001",
+                    "text": "Advance one public fixture",
+                }
+            },
+        },
+        "result_contract": {
+            "schema_version": "loopx_turn_result_v0",
+            "completed_phases": ["host_execute", "typed_result"],
+        },
+    }
+
+
+def _fake_codex(tmp_path: Path) -> tuple[Path, Path]:
+    executable = tmp_path / "fake-codex"
+    log_path = tmp_path / "codex-argv.jsonl"
+    executable.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import re
+import sys
+
+args = sys.argv[1:]
+prompt = sys.stdin.read()
+log = pathlib.Path(os.environ["FAKE_CODEX_LOG"])
+with log.open("a", encoding="utf-8") as handle:
+    handle.write(json.dumps(args) + "\\n")
+turn_key = re.search(r'"turn_key":"([^"]+)"', prompt).group(1)
+print(json.dumps({
+    "type": "thread.started",
+    "thread_id": "session-fixture-0001",
+    "raw_trajectory": "must-not-persist",
+    "private_material": "must-not-persist"
+}), flush=True)
+if os.environ.get("FAKE_CODEX_FAIL") == "1":
+    if os.environ.get("FAKE_CODEX_FAILURE_CATEGORY") == "model":
+        print("This model requires a newer version of Codex.", file=sys.stderr)
+    raise SystemExit(9)
+output_path = pathlib.Path(args[args.index("--output-last-message") + 1])
+output_path.write_text(json.dumps({
+    "schema_version": "loopx_turn_result_v0",
+    "turn_key": turn_key,
+    "result_kind": "validated_progress",
+    "completed_phases": ["host_execute", "typed_result"],
+    "classification": "fixture_progress",
+    "recommended_action": "Continue the public fixture",
+    "next_action": "Run the next public fixture check",
+    "delivery_batch_scale": "implementation",
+    "delivery_outcome": "outcome_progress",
+    "vision_unchanged_reason": "The fixture objective remains unchanged.",
+    "summary": "One public fixture advanced."
+}), encoding="utf-8")
+""",
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+    return executable, log_path
+
+
+def test_codex_cli_result_schema_requires_only_bounded_contract_fields() -> None:
+    schema = codex_cli_result_schema()
+
+    assert schema["additionalProperties"] is False
+    assert set(schema["required"]) == set(schema["properties"])
+    assert "raw_trajectory" not in schema["properties"]
+    assert "stdout" not in schema["properties"]
+
+
+def test_codex_cli_host_starts_then_resumes_opaque_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable, log_path = _fake_codex(tmp_path)
+    monkeypatch.setenv("FAKE_CODEX_LOG", str(log_path))
+    runtime_root = tmp_path / "runtime"
+    project = tmp_path / "project"
+    project.mkdir()
+    first_request = _request()
+
+    first = run_codex_cli_host(
+        first_request,
+        runtime_root=runtime_root,
+        project=project,
+        codex_bin=str(executable),
+        timeout_seconds=5,
+    )
+    with pytest.raises(RuntimeError, match="binding changed after planning"):
+        run_codex_cli_host(
+            _request(turn_key="sha256:" + "c" * 64),
+            runtime_root=runtime_root,
+            project=project,
+            codex_bin=str(executable),
+            timeout_seconds=5,
+        )
+    second_request = _request(
+        turn_key="sha256:" + "b" * 64,
+        session_action="resume",
+    )
+    second = run_codex_cli_host(
+        second_request,
+        runtime_root=runtime_root,
+        project=project,
+        codex_bin=str(executable),
+        timeout_seconds=5,
+    )
+
+    assert first["turn_key"] == first_request["turn_key"]
+    assert second["turn_key"] == second_request["turn_key"]
+    argv_rows = [
+        json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert "resume" not in argv_rows[0]
+    assert "resume" in argv_rows[1]
+    assert "session-fixture-0001" in argv_rows[1]
+
+    envelope = first_request["turn_envelope"]
+    assert isinstance(envelope, dict)
+    binding = codex_cli_session_binding(runtime_root, envelope)
+    assert binding == {
+        "schema_version": "loopx_turn_session_binding_v0",
+        "goal_id": "fixture-goal",
+        "agent_id": "codex-fixture",
+        "todo_id": "todo_fixture0001",
+    }
+    lineage = {key: binding[key] for key in ("goal_id", "agent_id", "todo_id")}
+    session = load_codex_cli_session(runtime_root, lineage=lineage)
+    assert session is not None
+    assert session["schema_version"] == CODEX_CLI_SESSION_SCHEMA_VERSION
+    assert set(session) == {
+        "schema_version",
+        "goal_id",
+        "agent_id",
+        "todo_id",
+        "host",
+        "session_id",
+    }
+    session_paths = list(runtime_root.glob("goals/*/turn-sessions/*.json"))
+    assert len(session_paths) == 1
+    assert stat.S_IMODE(session_paths[0].stat().st_mode) == 0o600
+    persisted = session_paths[0].read_text(encoding="utf-8")
+    assert "raw_trajectory" not in persisted
+    assert "private_material" not in persisted
+
+
+def test_codex_cli_host_preserves_session_after_failed_turn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable, log_path = _fake_codex(tmp_path)
+    monkeypatch.setenv("FAKE_CODEX_LOG", str(log_path))
+    monkeypatch.setenv("FAKE_CODEX_FAIL", "1")
+    runtime_root = tmp_path / "runtime"
+    project = tmp_path / "project"
+    project.mkdir()
+    request = _request()
+
+    with pytest.raises(RuntimeError, match="codex_cli_exit_nonzero"):
+        run_codex_cli_host(
+            request,
+            runtime_root=runtime_root,
+            project=project,
+            codex_bin=str(executable),
+            timeout_seconds=5,
+        )
+
+    envelope = request["turn_envelope"]
+    assert isinstance(envelope, dict)
+    assert codex_cli_session_binding(runtime_root, envelope) is not None
+
+
+def test_codex_cli_host_classifies_failure_without_persisting_stderr(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable, log_path = _fake_codex(tmp_path)
+    monkeypatch.setenv("FAKE_CODEX_LOG", str(log_path))
+    monkeypatch.setenv("FAKE_CODEX_FAIL", "1")
+    monkeypatch.setenv("FAKE_CODEX_FAILURE_CATEGORY", "model")
+    runtime_root = tmp_path / "runtime"
+    project = tmp_path / "project"
+    project.mkdir()
+
+    with pytest.raises(
+        RuntimeError,
+        match="codex_cli_model_requires_newer_codex",
+    ):
+        run_codex_cli_host(
+            _request(),
+            runtime_root=runtime_root,
+            project=project,
+            codex_bin=str(executable),
+            timeout_seconds=5,
+        )
+
+    persisted = "\n".join(
+        path.read_text(encoding="utf-8") for path in runtime_root.rglob("*.json")
+    )
+    assert "requires a newer version" not in persisted

--- a/tests/test_loopx_turn_driver.py
+++ b/tests/test_loopx_turn_driver.py
@@ -574,3 +574,73 @@ json.dump({
         "fixture_progress",
         "quota_slot_spent",
     ]
+
+
+@pytest.mark.parametrize(
+    "result_kind", ["validated_progress", "repair_required", "replan_required"]
+)
+def test_turn_run_once_cli_uses_built_in_codex_host_and_typed_writeback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    result_kind: str,
+) -> None:
+    project, runtime, registry = _write_live_fixture(tmp_path)
+
+    def fake_codex_host(request: dict[str, object], **_kwargs: object) -> dict[str, object]:
+        return {
+            "schema_version": "loopx_turn_result_v0",
+            "turn_key": request["turn_key"],
+            "result_kind": result_kind,
+            "completed_phases": ["host_execute", "typed_result"],
+            "classification": f"fixture_{result_kind}",
+            "recommended_action": "Apply the typed follow-up",
+            "next_action": "Run one revised public fixture check",
+            "delivery_batch_scale": "implementation",
+            "delivery_outcome": "outcome_progress",
+            "vision_unchanged_reason": "The fixture objective remains unchanged.",
+            "summary": "One public fixture advanced.",
+        }
+
+    monkeypatch.setattr("loopx.cli_commands.turn.run_codex_cli_host", fake_codex_host)
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(
+            [
+                "--registry",
+                str(registry),
+                "--runtime-root",
+                str(runtime),
+                "--format",
+                "json",
+                "turn",
+                "run-once",
+                "--goal-id",
+                "loopx-turn-fixture",
+                "--agent-id",
+                "codex-fixture",
+                "--host",
+                "codex-cli",
+                "--project",
+                str(project),
+                "--scan-root",
+                str(project),
+                "--no-global-sync",
+                "--execute",
+            ]
+        )
+
+    payload = json.loads(output.getvalue())
+    assert exit_code == 0, payload
+    assert payload["host"] == {"executable": "built-in", "kind": "codex-cli"}
+    assert payload["effects"]["state_written"] is True
+    assert payload["effects"]["quota_spent"] is True
+    state = (
+        project
+        / ".codex"
+        / "goals"
+        / "loopx-turn-fixture"
+        / "ACTIVE_GOAL_STATE.md"
+    ).read_text(encoding="utf-8")
+    assert "Run one revised public fixture check" in state
+    if result_kind != "validated_progress":
+        assert f"LoopX%20Turn%20{result_kind}" in state

--- a/tests/test_loopx_turn_executor.py
+++ b/tests/test_loopx_turn_executor.py
@@ -13,6 +13,7 @@ from loopx.control_plane.turn_driver import (
     run_loopx_turn_once,
     validate_loopx_turn_host_result,
 )
+from loopx.control_plane.turn_driver.executor import BuiltInHostError
 
 
 def _plan() -> dict[str, object]:
@@ -134,6 +135,63 @@ def test_run_once_preview_has_no_host_or_journal_effects(tmp_path: Path) -> None
         "scheduler_acknowledged": False,
     }
     assert not (tmp_path / "runtime").exists()
+
+
+def test_run_once_rejects_oversized_built_in_host_result(tmp_path: Path) -> None:
+    plan = _plan()
+    calls = {"writeback": 0, "spend": 0, "scheduler": 0}
+    writeback, spend, scheduler = _callbacks(calls)
+    oversized = _host_result(plan)
+    oversized["summary"] = "x" * 13_000
+
+    payload = run_loopx_turn_once(
+        plan,
+        host_runner=lambda _request: oversized,
+        project=tmp_path,
+        runtime_root=tmp_path / "runtime",
+        goal_id="fixture-goal",
+        timeout_seconds=5,
+        execute=True,
+        writeback=writeback,
+        spend=spend,
+        scheduler=scheduler,
+    )
+
+    assert payload["ok"] is False
+    assert payload["reason"] == "built-in host result exceeded the result budget"
+    assert calls == {"writeback": 0, "spend": 0, "scheduler": 0}
+
+
+def test_run_once_explicitly_retries_failed_host_without_duplicate_effects(tmp_path: Path) -> None:
+    plan = _plan()
+    calls = {"host": 0, "writeback": 0, "spend": 0, "scheduler": 0}
+    writeback, spend, scheduler = _callbacks(calls)
+
+    def host(_request: dict[str, object]) -> dict[str, object]:
+        calls["host"] += 1
+        if calls["host"] == 1:
+            raise BuiltInHostError("codex_cli_model_requires_newer_codex")
+        return _host_result(plan)
+
+    kwargs = {
+        "host_runner": host,
+        "project": tmp_path,
+        "runtime_root": tmp_path / "runtime",
+        "goal_id": "fixture-goal",
+        "timeout_seconds": 5,
+        "execute": True,
+        "writeback": writeback,
+        "spend": spend,
+        "scheduler": scheduler,
+    }
+    failed = run_loopx_turn_once(plan, **kwargs)
+    replayed = run_loopx_turn_once(plan, **kwargs)
+    recovered = run_loopx_turn_once(plan, retry_failed=True, **kwargs)
+
+    assert failed["reason"] == "codex_cli_model_requires_newer_codex"
+    assert replayed["replayed"] is True
+    assert recovered["status"] == "committed"
+    assert calls == {"host": 2, "writeback": 1, "spend": 1, "scheduler": 1}
 
 
 def test_run_once_commits_once_and_replays_without_duplicate_effects(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a built-in `codex-cli` host for one governed LoopX Turn
- keep opaque Codex session ids in a private, lineage-keyed local store while persisting only bounded typed results
- support explicit side-effect-safe retries after typed host failures and repair/replan todo writeback

## Validation
- 54 focused pytest cases
- Codex CLI automation driver audit smoke
- Ruff and changed-file compile checks
- `loopx canary premerge --from-git-diff --tier standard`: 12/12 selected checks passed, no warnings or manual holds
- disposable local start/resume E2E confirmed one durable writeback, one quota spend, scheduler handoff, and idempotent replay

## Boundaries
- no benchmark jobs, scoring, task semantics, permissions, or submission behavior changed
- no raw trajectory, stderr, credentials, session payload, local path, or private runtime state is committed
