### PR TITLE
Guard the new-user onboarding lifecycle

### DIFF
--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -1243,6 +1243,7 @@ todo and the automation drifts into monitor-only no-ops.
 **Validation**
 
 - `examples/state-projection-gap-smoke.py`
+- `examples/project/onboarding-no-scan-projection-smoke.py`
 - `docs/project-agent-todo-contract.md`
 
 #### IP-006 Checkpointed Scope Mismatch

--- a/examples/canary/catalog-planner-smoke.py
+++ b/examples/canary/catalog-planner-smoke.py
@@ -60,6 +60,7 @@ def assert_profiles_come_from_catalog_matrix() -> None:
         "product-entry-workflows",
         "cross-runtime-impl-review-demo",
         "host-command-entry",
+        "new-user-onboarding-lifecycle",
         "runtime-connector-catalog",
         "frontstage-rollout",
         "auto-research-demo",
@@ -624,6 +625,28 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     assert all(check["tier"] == "default" for check in host_command_profile["checks"])
     assert host_command_profile["deep_checks_available"] is False, host_command_profile
     assert host_command_profile["deep_checks_included"] is False, host_command_profile
+
+    onboarding_payload = build_catalog_canary_plan(
+        changed_files=[
+            "loopx/bootstrap.py",
+            "loopx/bootstrap_command_pack.py",
+            "loopx/contract.py",
+        ],
+        surfaces=[
+            "new user onboarding no-onboarding-scan state projection gap start-goal"
+        ],
+    )
+    onboarding_profiles = {
+        profile["id"]: profile for profile in onboarding_payload["domain_profiles"]
+    }
+    assert "new-user-onboarding-lifecycle" in onboarding_profiles, onboarding_payload
+    onboarding_profile = onboarding_profiles["new-user-onboarding-lifecycle"]
+    assert [check["command"] for check in onboarding_profile["checks"]] == [
+        "python3 examples/project/onboarding-no-scan-projection-smoke.py"
+    ], onboarding_profile
+    assert all(check["tier"] == "default" for check in onboarding_profile["checks"])
+    assert onboarding_profile["deep_checks_available"] is False, onboarding_profile
+    assert onboarding_profile["deep_checks_included"] is False, onboarding_profile
 
     runtime_connector_payload = build_catalog_canary_plan(
         changed_files=["docs/runtime-connector-catalog.md"],

--- a/examples/project/onboarding-no-scan-projection-smoke.py
+++ b/examples/project/onboarding-no-scan-projection-smoke.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 GOAL_ID = "fresh-no-scan-projection"
+DOMAIN_GOAL_ID = "fresh-domain-owned-projection"
 
 
 def run_cli(registry: Path, runtime: Path, *args: str) -> dict:
@@ -36,15 +37,20 @@ def run_cli(registry: Path, runtime: Path, *args: str) -> dict:
     return json.loads(result.stdout)
 
 
+def initialize_project(root: Path, name: str) -> tuple[Path, Path]:
+    project = root / name
+    project.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+    readme = project / "README.md"
+    readme.write_text("# Synthetic LoopX onboarding fixture\n", encoding="utf-8")
+    (project / ".gitignore").write_text(".loopx/\n.codex/\n.local/\n", encoding="utf-8")
+    return project, readme
+
+
 def main() -> int:
     with tempfile.TemporaryDirectory(prefix="loopx-no-scan-projection-") as tmp:
         root = Path(tmp)
-        project = root / "project"
-        project.mkdir()
-        subprocess.run(["git", "init", "-q"], cwd=project, check=True)
-        readme = project / "README.md"
-        readme.write_text("# Synthetic LoopX onboarding fixture\n", encoding="utf-8")
-        (project / ".gitignore").write_text(".loopx/\n.codex/\n.local/\n", encoding="utf-8")
+        project, readme = initialize_project(root, "project")
 
         registry = project / ".loopx" / "registry.json"
         runtime = root / "runtime"
@@ -110,6 +116,54 @@ def main() -> int:
         assert broken_check["ok"] is True, broken_check
         assert broken_check["summary"]["warnings"] == 1, broken_check
         assert any("state_projection_gap" in warning for warning in broken_check["warnings"]), broken_check
+
+        domain_project, domain_readme = initialize_project(root, "domain-project")
+        domain_registry = domain_project / ".loopx" / "registry.json"
+        domain_connected = run_cli(
+            domain_registry,
+            runtime,
+            "connect",
+            "--project",
+            str(domain_project),
+            "--goal-id",
+            DOMAIN_GOAL_ID,
+            "--objective",
+            "Validate domain-owned onboarding routing.",
+            "--domain",
+            "engineering",
+            "--goal-doc",
+            str(domain_readme),
+            "--adapter-kind",
+            "domain_fixture_v0",
+            "--adapter-status",
+            "connected-read-only",
+            "--codex-app-heartbeat",
+            "no",
+            "--no-onboarding-scan",
+            "--no-global-sync",
+        )
+        assert domain_connected["ok"] is True, domain_connected
+
+        domain_state_file = (
+            domain_project
+            / ".codex"
+            / "goals"
+            / DOMAIN_GOAL_ID
+            / "ACTIVE_GOAL_STATE.md"
+        )
+        domain_state_text = domain_state_file.read_text(encoding="utf-8")
+        assert "action_kind=onboarding_connection_validation" not in domain_state_text
+        assert "Initial routing is owned by the connected domain adapter." in domain_state_text
+
+        domain_check = run_cli(
+            domain_registry,
+            runtime,
+            "check",
+            "--scan-path",
+            str(domain_readme),
+        )
+        assert domain_check["ok"] is True, domain_check
+        assert domain_check["summary"]["warnings"] == 0, domain_check
 
     print("onboarding-no-scan-projection-smoke ok")
     return 0

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -994,6 +994,40 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
         ],
     },
     {
+        "id": "new-user-onboarding-lifecycle",
+        "title": "New-user onboarding lifecycle",
+        "purpose": (
+            "Check fresh no-scan connection, structured todo projection, "
+            "state-gap detection, and domain-adapter routing ownership."
+        ),
+        "catalog_families": ["Work Routing", "State And Boundary"],
+        "trigger_hints": (
+            "new user onboarding",
+            "onboarding lifecycle",
+            "no-onboarding-scan",
+            "onboarding_connection_validation",
+            "state projection gap",
+            "start-goal",
+            "loopx/bootstrap.py",
+            "loopx/bootstrap_command_pack.py",
+            "loopx/contract.py",
+            "loopx/state_projection.py",
+            "loopx/cli_commands/bootstrap_connect.py",
+            "loopx/cli_commands/starter_bootstrap.py",
+            "loopx/cli_commands/starter_bootstrap_registration.py",
+        ),
+        "checks": [
+            {
+                "command": "python3 examples/project/onboarding-no-scan-projection-smoke.py",
+                "tier": "default",
+                "reason": (
+                    "guards fresh connection-to-todo parity, state-gap warnings, "
+                    "and domain-adapter routing ownership"
+                ),
+            },
+        ],
+    },
+    {
         "id": "runtime-connector-catalog",
         "title": "Runtime connector catalog",
         "purpose": (


### PR DESCRIPTION
## Summary
- add a dedicated catalog canary profile for new-user onboarding lifecycle changes
- extend the no-scan projection smoke across generic connection, deliberate projection corruption, and domain-adapter ownership
- register the regression under the IP-005 state projection gap validation evidence

## Why
Issue #2134 exposed a gap between a visible onboarding Next Action and the structured todo projection. The regression smoke existed, but edits to bootstrap/start-goal/contract surfaces did not automatically select it. This PR closes that qualification gap without changing runtime behavior.

## Validation
- `python3 examples/project/onboarding-no-scan-projection-smoke.py`
- `python3 examples/canary/catalog-planner-smoke.py`
- `python3 examples/auto-research-worker-loop-smoke.py`
- `python3 -m py_compile examples/project/onboarding-no-scan-projection-smoke.py examples/canary/catalog-planner-smoke.py loopx/canary/planner.py`
- `python3 -m loopx.cli --format json canary premerge --from-git-diff --git-diff-base origin/main --tier standard --timeout-seconds 180 --no-progress`
- `git diff --check origin/main...HEAD`

`ruff` was unavailable in the local Python environment. No credentials, private state, raw model responses, local paths, or generated logs are included.