### PR TITLE
Qualify the actual onboarding behavior with Doubao

### DIFF
--- a/docs/reference/protocols/model-behavior-qualification-v0.md
+++ b/docs/reference/protocols/model-behavior-qualification-v0.md
@@ -163,6 +163,41 @@ in manually triggered or low-frequency shadow qualification where cost,
 repetition, corpus selection, and promotion policy are explicit. Only compact
 decision receipts and paired drift results may become durable evidence.
 
+## New-User Onboarding Closed Loop
+
+`onboarding_model_behavior_pair_result_v0` extends the same low-frequency
+boundary to the first new-user transaction. It compares a full-detail
+`start-goal --guided` packet with the default guided projection in two model
+turns:
+
+1. the entry turn must preserve goal and agent selection gates, the
+   `connect_if_needed` route, canonical action-command availability, no-write /
+   no-spend state, and host-loop activation after todo writeback;
+2. an allowlisted local transition runner performs the canonical connection in
+   an isolated fixture; the postcondition turn must distinguish a healthy
+   executable onboarding todo from a `state_projection_gap` repair route.
+
+The model never supplies a shell command to the transition runner. The runner
+is a caller-owned allowlist, executes only after both entry arms align with the
+source contract, and returns the compact
+`onboarding_postcondition_observation_v0` shape. A missing command, missing
+host-loop contract, or different postcondition fails before promotion evidence
+can be produced. This directly calibrates the qualification against the class
+of regression tracked by issue #2134: a visible onboarding Next Action without
+an executable structured todo.
+
+The pair result retains only source-alignment flags, drift field names, and
+receipt digests. Packets, observations, model responses, local paths, and
+credentials are not retained. The result always sets
+`automatic_release_promotion_allowed=false`.
+
+This profile is a local/manual gate for sensitive agent-facing changes and
+release qualification. Deterministic onboarding fixtures and catalog canaries
+remain the normal CI gate. A future trusted scheduled job may invoke the live
+profile with injected credentials and explicit cost limits, but ordinary pull
+requests must not depend on provider availability, latency, rate limits, or
+stochastic output.
+
 ## Promotion Boundary
 
 This contract is one gate in a larger promotion process. Turning a candidate

--- a/docs/reference/protocols/model-behavior-qualification-v0.md
+++ b/docs/reference/protocols/model-behavior-qualification-v0.md
@@ -165,31 +165,49 @@ decision receipts and paired drift results may become durable evidence.
 
 ## New-User Onboarding Closed Loop
 
-`onboarding_model_behavior_pair_result_v0` extends the same low-frequency
-boundary to the first new-user transaction. It compares a full-detail
-`start-goal --guided` packet with the default guided projection in two model
-turns:
+`onboarding_actual_behavior_qualification_v0` extends the same low-frequency
+boundary to the first new-user transaction. Its durable contract has one arm:
+the currently shipped default `start-goal --guided` packet. The qualification
+does not retain a retired full-detail implementation as a second product
+contract.
 
-1. the entry turn must preserve goal and agent selection gates, the
-   `connect_if_needed` route, canonical action-command availability, no-write /
-   no-spend state, and host-loop activation after todo writeback;
+The closed loop checks three decisions:
+
+1. the entry turn must select `connect_if_needed` from the actual default
+   packet;
 2. an allowlisted local transition runner performs the canonical connection in
-   an isolated fixture; the postcondition turn must distinguish a healthy
-   executable onboarding todo from a `state_projection_gap` repair route.
+   an isolated fixture, after which the model must select
+   `continue_validation` for the healthy executable todo;
+3. a known-bad `state_projection_gap` observation calibrates the model's
+   `repair_projection` decision against the regression class tracked by issue
+   #2134: a visible onboarding Next Action without an executable structured
+   todo.
+
+Two checks are deliberately independent. Before any provider call, a stable
+behavior oracle requires the canonical connect, refresh, host-activation, and
+quota commands; goal and agent identity; no write or quota spend during the
+preview; and host-loop activation only after todo writeback. The model then
+has to reproduce the semantic contract derived from the actual packet. This
+separation prevents an implementation and its source-alignment expectation
+from deleting the same behavior and still passing.
 
 The model never supplies a shell command to the transition runner. The runner
-is a caller-owned allowlist, executes only after both entry arms align with the
-source contract, and returns the compact
-`onboarding_postcondition_observation_v0` shape. A missing command, missing
-host-loop contract, or different postcondition fails before promotion evidence
-can be produced. This directly calibrates the qualification against the class
-of regression tracked by issue #2134: a visible onboarding Next Action without
-an executable structured todo.
+is a caller-owned allowlist and returns only the compact
+`onboarding_postcondition_observation_v0` shape. A missing command or host-loop
+contract fails before model invocation; a damaged actual postcondition fails
+the qualification even when the model correctly recognizes the damage.
 
-The pair result retains only source-alignment flags, drift field names, and
+The result retains only source-alignment flags, route names, safety codes, and
 receipt digests. Packets, observations, model responses, local paths, and
-credentials are not retained. The result always sets
+credentials are not retained. It always sets
 `automatic_release_promotion_allowed=false`.
+
+For a sensitive behavior-changing pull request, maintainers may additionally
+run a temporary base/candidate differential evaluation. That comparison is PR
+evidence, not a merged API, fixture, or permanent test arm. Once the candidate
+becomes the default, the one-arm qualification follows the new actual packet;
+changing the independent behavior invariants remains an explicit reviewable
+contract change.
 
 This profile is a local/manual gate for sensitive agent-facing changes and
 release qualification. Deterministic onboarding fixtures and catalog canaries

--- a/docs/reference/protocols/release-outcome-baseline-v0.md
+++ b/docs/reference/protocols/release-outcome-baseline-v0.md
@@ -19,6 +19,13 @@ The third layer measures what happened, not only whether a packet looked
 equivalent. It stays outside ordinary PR smoke because real tasks and model
 calls are slower, cost-bearing, and may depend on gated environments.
 
+The second layer follows the same CI boundary. Live provider calls are a
+low-frequency local/manual release gate for sensitive agent-facing changes,
+not a required status check on ordinary pull requests. CI owns deterministic
+fixtures and catalog canaries; the live gate adds repeated behavioral evidence
+when a maintainer is considering promotion. Provider unavailability yields
+insufficient qualification evidence, not a product-code failure.
+
 ## Pair Manifest
 
 `release_outcome_pair_manifest_v0` contains:

--- a/docs/reference/protocols/release-outcome-baseline-v0.md
+++ b/docs/reference/protocols/release-outcome-baseline-v0.md
@@ -10,8 +10,9 @@ verifier contract, and budget. It never promotes a release automatically.
 LoopX uses three complementary layers:
 
 1. deterministic fixtures and catalog canaries run on normal pull requests;
-2. low-frequency paired model-behavior qualification checks whether an agent
-   interprets two control-plane projections equivalently;
+2. low-frequency model-behavior qualification checks whether an agent
+   interprets the shipped control-plane behavior correctly; sensitive packet
+   changes may add a temporary base/candidate differential run;
 3. release outcome baselines compare completed long-running attempts on a small
    representative case set.
 
@@ -19,12 +20,15 @@ The third layer measures what happened, not only whether a packet looked
 equivalent. It stays outside ordinary PR smoke because real tasks and model
 calls are slower, cost-bearing, and may depend on gated environments.
 
-The second layer follows the same CI boundary. Live provider calls are a
-low-frequency local/manual release gate for sensitive agent-facing changes,
-not a required status check on ordinary pull requests. CI owns deterministic
-fixtures and catalog canaries; the live gate adds repeated behavioral evidence
-when a maintainer is considering promotion. Provider unavailability yields
-insufficient qualification evidence, not a product-code failure.
+The second layer follows the same CI boundary. Its durable onboarding contract
+runs the current actual default path against an independent semantic oracle,
+then checks the healthy postcondition and known-bad repair calibration. Live
+provider calls are a low-frequency local/manual release gate for sensitive
+agent-facing changes, not a required status check on ordinary pull requests.
+CI owns deterministic fixtures and catalog canaries; the live gate adds
+repeated behavioral evidence when a maintainer is considering promotion.
+Provider unavailability yields insufficient qualification evidence, not a
+product-code failure.
 
 ## Pair Manifest
 

--- a/loopx/control_plane/testing/doubao_model_behavior_actor.py
+++ b/loopx/control_plane/testing/doubao_model_behavior_actor.py
@@ -17,6 +17,10 @@ from .model_behavior_qualification import (
     ModelBehaviorActor,
     normalize_model_behavior_actor_request,
 )
+from .onboarding_model_behavior_qualification import (
+    ONBOARDING_MODEL_BEHAVIOR_RESULT_SCHEMA_VERSION,
+    normalize_onboarding_model_behavior_actor_request,
+)
 
 
 DOUBAO_2_1_PRO_MODEL = "doubao-seed-2-1-pro-260628"
@@ -249,6 +253,123 @@ def _provider_decision(response: Mapping[str, Any]) -> Mapping[str, Any]:
     return decision
 
 
+def _invoke_provider_decision(
+    *,
+    api_key: str,
+    model: str,
+    timeout_seconds: float,
+    transport: DoubaoActorTransport,
+    system_instruction: str,
+    provider_input: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    body = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system_instruction},
+            {
+                "role": "user",
+                "content": json.dumps(
+                    dict(provider_input),
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+            },
+        ],
+        "response_format": {"type": "json_object"},
+        "thinking": {"type": "disabled"},
+        "temperature": 0,
+        "max_tokens": _MAX_DECISION_TOKENS,
+        "stream": False,
+    }
+    try:
+        response = transport(
+            endpoint=DOUBAO_CHAT_COMPLETIONS_ENDPOINT,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            body=json.dumps(
+                body,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8"),
+            timeout_seconds=timeout_seconds,
+        )
+    except DoubaoActorTransportError:
+        raise
+    except Exception:
+        raise DoubaoActorTransportError(
+            "Doubao actor provider transport failed",
+            error_code="provider_transport_failed",
+        ) from None
+    return _provider_decision(response)
+
+
+def _onboarding_decision_instruction(phase: str) -> str:
+    common = """You are a LoopX new-user onboarding decision simulator.
+Use only the qualification packet supplied by the user. Do not call tools,
+execute commands, or request external writes. Return exactly one JSON object
+with these top-level fields and no others:
+{
+  "schema_version": "onboarding_model_behavior_decision_v0",
+  "phase": "entry|postcondition",
+  "next_action": "phase-specific route",
+  "semantic_contract": {},
+  "reason_codes": ["compact_public_safe_token"]
+}
+Copy the requested phase exactly. Output JSON only, without markdown or
+reasoning. The semantic_contract must contain exactly the phase-specific fields
+described below. Use null where instructed and never invent identifiers."""
+    if phase == "entry":
+        return common + """
+
+For phase=entry, derive the contract from the start-goal packet:
+- route: select_agent_identity when guided_transaction is blocked by an
+  identity gate; select_goal when blocked by a goal-selection gate;
+  connect_if_needed when ordered_steps contains that id; otherwise stop.
+- goal_id: copy the top-level goal_id, including null.
+- agent_id: copy top-level agent_id, falling back to
+  host_loop_activation.agent_id or command_pack.host_loop_activation.agent_id;
+  otherwise null.
+- action_command_ids: in this exact order, include each key whose value is a
+  non-empty string in top-level commands or command_pack.commands:
+  goal_start_connect_if_needed, goal_start_refresh_state,
+  goal_start_host_loop_activation, goal_start_quota_should_run.
+- host_loop_activation_available: true when top-level host_loop_activation or
+  command_pack.host_loop_activation is a non-empty object.
+- host_loop_activation_after_todo_write: copy
+  activation_required_after_todo_write from that activation object, else false.
+- writes_now and spends_quota_now: copy the corresponding booleans from
+  guided_transaction, defaulting to false.
+Set next_action equal to route. The semantic_contract must contain exactly:
+route, goal_id, agent_id, action_command_ids,
+host_loop_activation_available, host_loop_activation_after_todo_write,
+writes_now, spends_quota_now."""
+    return common + """
+
+For phase=postcondition, the packet is a locally derived observation:
+- route: copy derived_route.
+- state_projection_gap: copy the boolean field.
+- executable_todo_present: true exactly when executable_todo_count is greater
+  than zero.
+- selected_action_kind: copy the field, including null.
+- normal_delivery_allowed and user_action_required: copy both booleans.
+Set next_action equal to route. The semantic_contract must contain exactly:
+route, state_projection_gap, executable_todo_present, selected_action_kind,
+normal_delivery_allowed, user_action_required."""
+
+
+def _onboarding_provider_input(request: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": "onboarding_model_behavior_provider_input_v0",
+        "arm": request["arm"],
+        "phase": request["phase"],
+        "packet": request["packet"],
+    }
+
+
 class DoubaoModelBehaviorActor(ModelBehaviorActor):
     """Direct Ark actor for low-frequency, no-tool behavior qualification."""
 
@@ -297,58 +418,86 @@ class DoubaoModelBehaviorActor(ModelBehaviorActor):
 
     def __call__(self, request: Mapping[str, Any]) -> Mapping[str, Any]:
         canonical_request = normalize_model_behavior_actor_request(request)
-        body = {
-            "model": self._model,
-            "messages": [
-                {
-                    "role": "system",
-                    "content": _decision_instruction(
-                        semantic_contract_required=bool(
-                            canonical_request["semantic_contract_required"]
-                        )
-                    ),
-                },
-                {
-                    "role": "user",
-                    "content": json.dumps(
-                        _provider_input(canonical_request),
-                        ensure_ascii=False,
-                        sort_keys=True,
-                        separators=(",", ":"),
-                    ),
-                },
-            ],
-            "response_format": {"type": "json_object"},
-            "thinking": {"type": "disabled"},
-            "temperature": 0,
-            "max_tokens": _MAX_DECISION_TOKENS,
-            "stream": False,
-        }
-        try:
-            response = self._transport(
-                endpoint=DOUBAO_CHAT_COMPLETIONS_ENDPOINT,
-                headers={
-                    "Authorization": f"Bearer {self._api_key}",
-                    "Content-Type": "application/json",
-                },
-                body=json.dumps(
-                    body,
-                    ensure_ascii=False,
-                    sort_keys=True,
-                    separators=(",", ":"),
-                ).encode("utf-8"),
-                timeout_seconds=self._timeout_seconds,
-            )
-        except DoubaoActorTransportError:
-            raise
-        except Exception:
-            raise DoubaoActorTransportError(
-                "Doubao actor provider transport failed",
-                error_code="provider_transport_failed",
-            ) from None
+        decision = _invoke_provider_decision(
+            api_key=self._api_key,
+            model=self._model,
+            timeout_seconds=self._timeout_seconds,
+            transport=self._transport,
+            system_instruction=_decision_instruction(
+                semantic_contract_required=bool(
+                    canonical_request["semantic_contract_required"]
+                )
+            ),
+            provider_input=_provider_input(canonical_request),
+        )
         return {
             "schema_version": MODEL_BEHAVIOR_ACTOR_RESULT_SCHEMA_VERSION,
             "actor_ref": f"ark:{self._model}",
-            "decision": dict(_provider_decision(response)),
+            "decision": dict(decision),
+            "tool_calls": [],
+        }
+
+
+class DoubaoOnboardingModelBehaviorActor:
+    """Direct Ark actor for low-frequency onboarding closed-loop qualification."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str = DOUBAO_2_1_PRO_MODEL,
+        timeout_seconds: float = 90.0,
+        transport: DoubaoActorTransport = _direct_ark_transport,
+    ) -> None:
+        if not api_key.strip():
+            raise RuntimeError("Doubao actor requires a runtime-injected API key")
+        if model not in _ALLOWED_MODELS:
+            raise ValueError(
+                "Doubao actor model must be an allowlisted Doubao 2.1 model"
+            )
+        if timeout_seconds <= 0 or timeout_seconds > 300:
+            raise ValueError("Doubao actor timeout must be between 0 and 300 seconds")
+        self._api_key = api_key
+        self._model = model
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    @classmethod
+    def from_environment(
+        cls,
+        *,
+        environ: Mapping[str, str] | None = None,
+        transport: DoubaoActorTransport = _direct_ark_transport,
+        timeout_seconds: float = 90.0,
+    ) -> DoubaoOnboardingModelBehaviorActor:
+        values = os.environ if environ is None else environ
+        api_key = values.get(ARK_API_KEY_ENV, "")
+        if not api_key.strip():
+            raise RuntimeError(
+                "ARK_API_KEY is not injected; live Doubao qualification is unavailable"
+            )
+        model = values.get(DOUBAO_MODEL_ENV, DOUBAO_2_1_PRO_MODEL)
+        return cls(
+            api_key=api_key,
+            model=model,
+            timeout_seconds=timeout_seconds,
+            transport=transport,
+        )
+
+    def __call__(self, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        canonical_request = normalize_onboarding_model_behavior_actor_request(request)
+        phase = str(canonical_request["phase"])
+        decision = _invoke_provider_decision(
+            api_key=self._api_key,
+            model=self._model,
+            timeout_seconds=self._timeout_seconds,
+            transport=self._transport,
+            system_instruction=_onboarding_decision_instruction(phase),
+            provider_input=_onboarding_provider_input(canonical_request),
+        )
+        return {
+            "schema_version": ONBOARDING_MODEL_BEHAVIOR_RESULT_SCHEMA_VERSION,
+            "actor_ref": f"ark:{self._model}",
+            "decision": dict(decision),
             "tool_calls": [],
         }

--- a/loopx/control_plane/testing/doubao_model_behavior_actor.py
+++ b/loopx/control_plane/testing/doubao_model_behavior_actor.py
@@ -364,7 +364,6 @@ normal_delivery_allowed, user_action_required."""
 def _onboarding_provider_input(request: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "schema_version": "onboarding_model_behavior_provider_input_v0",
-        "arm": request["arm"],
         "phase": request["phase"],
         "packet": request["packet"],
     }

--- a/loopx/control_plane/testing/onboarding_model_behavior_qualification.py
+++ b/loopx/control_plane/testing/onboarding_model_behavior_qualification.py
@@ -1,0 +1,539 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping, Sequence
+from hashlib import sha256
+from typing import Any, Protocol
+
+from .model_behavior_qualification import (
+    _reason_codes,
+    _reject_private_or_secret_material,
+    _token,
+)
+
+
+ONBOARDING_MODEL_BEHAVIOR_REQUEST_SCHEMA_VERSION = (
+    "onboarding_model_behavior_actor_request_v0"
+)
+ONBOARDING_MODEL_BEHAVIOR_RESULT_SCHEMA_VERSION = (
+    "onboarding_model_behavior_actor_result_v0"
+)
+ONBOARDING_MODEL_BEHAVIOR_DECISION_SCHEMA_VERSION = (
+    "onboarding_model_behavior_decision_v0"
+)
+ONBOARDING_MODEL_BEHAVIOR_RECEIPT_SCHEMA_VERSION = (
+    "onboarding_model_behavior_receipt_v0"
+)
+ONBOARDING_MODEL_BEHAVIOR_PAIR_SCHEMA_VERSION = (
+    "onboarding_model_behavior_pair_result_v0"
+)
+ONBOARDING_POSTCONDITION_SCHEMA_VERSION = "onboarding_postcondition_observation_v0"
+START_GOAL_PACKET_SCHEMA_VERSION = "loopx_start_goal_guided_v0"
+
+ONBOARDING_MODEL_BEHAVIOR_ARMS = ("full_detail", "guided_default")
+ONBOARDING_MODEL_BEHAVIOR_PHASES = ("entry", "postcondition")
+
+_ENTRY_CONTRACT_FIELDS = (
+    "route",
+    "goal_id",
+    "agent_id",
+    "action_command_ids",
+    "host_loop_activation_available",
+    "host_loop_activation_after_todo_write",
+    "writes_now",
+    "spends_quota_now",
+)
+_POSTCONDITION_CONTRACT_FIELDS = (
+    "route",
+    "state_projection_gap",
+    "executable_todo_present",
+    "selected_action_kind",
+    "normal_delivery_allowed",
+    "user_action_required",
+)
+_DECISION_FIELDS = {
+    "schema_version",
+    "phase",
+    "next_action",
+    "semantic_contract",
+    "reason_codes",
+}
+_RESULT_FIELDS = {"schema_version", "actor_ref", "decision", "tool_calls"}
+_ENTRY_ROUTES = {
+    "connect_if_needed",
+    "select_agent_identity",
+    "select_goal",
+    "stop",
+}
+_POSTCONDITION_ROUTES = {
+    "continue_validation",
+    "repair_projection",
+    "ask_user",
+    "stop",
+}
+
+
+class OnboardingModelBehaviorActor(Protocol):
+    def __call__(self, request: Mapping[str, Any]) -> Mapping[str, Any]: ...
+
+
+class OnboardingModelBehaviorPairValidationError(ValueError):
+    """The paired onboarding inputs diverged before live actor execution."""
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _digest(value: Any) -> str:
+    return "sha256:" + sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _mapping(value: Any, *, field: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field} must be an object")
+    return dict(value)
+
+
+def _nullable_token(value: Any, *, field: str) -> str | None:
+    if value is None:
+        return None
+    return _token(value, field=field)
+
+
+def _entry_route(packet: Mapping[str, Any]) -> str:
+    transaction = _mapping(packet.get("guided_transaction"), field="guided_transaction")
+    blocked_by = str(transaction.get("blocked_by") or "")
+    if blocked_by == "agent_identity_selection" or transaction.get(
+        "identity_selection_gate"
+    ):
+        return "select_agent_identity"
+    if blocked_by == "goal_selection" or transaction.get("goal_selection_gate"):
+        return "select_goal"
+    step_ids = [
+        str(step.get("id") or "")
+        for step in transaction.get("ordered_steps") or []
+        if isinstance(step, Mapping)
+    ]
+    if "connect_if_needed" in step_ids:
+        return "connect_if_needed"
+    return "stop"
+
+
+def _command_pack_value(packet: Mapping[str, Any], field: str) -> Any:
+    value = packet.get(field)
+    if value is not None:
+        return value
+    command_pack = packet.get("command_pack")
+    if isinstance(command_pack, Mapping):
+        return command_pack.get(field)
+    return None
+
+
+def onboarding_entry_semantic_contract(
+    packet: Mapping[str, Any],
+) -> dict[str, Any]:
+    if packet.get("schema_version") != START_GOAL_PACKET_SCHEMA_VERSION:
+        raise ValueError("entry packet must use loopx_start_goal_guided_v0")
+    transaction = _mapping(packet.get("guided_transaction"), field="guided_transaction")
+    commands = _mapping(_command_pack_value(packet, "commands"), field="commands")
+    activation = _mapping(
+        _command_pack_value(packet, "host_loop_activation"),
+        field="host_loop_activation",
+    )
+    canonical_command_ids = (
+        "goal_start_connect_if_needed",
+        "goal_start_refresh_state",
+        "goal_start_host_loop_activation",
+        "goal_start_quota_should_run",
+    )
+    command_ids = [
+        command_id
+        for command_id in canonical_command_ids
+        if isinstance(commands.get(command_id), str) and commands[command_id].strip()
+    ]
+    return {
+        "route": _entry_route(packet),
+        "goal_id": _nullable_token(packet.get("goal_id"), field="goal_id"),
+        "agent_id": _nullable_token(
+            packet.get("agent_id") or activation.get("agent_id"),
+            field="agent_id",
+        ),
+        "action_command_ids": command_ids,
+        "host_loop_activation_available": bool(activation),
+        "host_loop_activation_after_todo_write": bool(
+            activation.get("activation_required_after_todo_write")
+        ),
+        "writes_now": bool(transaction.get("writes_now")),
+        "spends_quota_now": bool(transaction.get("spends_quota_now")),
+    }
+
+
+def build_onboarding_postcondition_observation(
+    *,
+    check_warning_codes: Sequence[str],
+    executable_todo_count: int,
+    selected_action_kind: str | None,
+    normal_delivery_allowed: bool,
+    user_action_required: bool,
+    next_action_actionable: bool,
+) -> dict[str, Any]:
+    if executable_todo_count < 0:
+        raise ValueError("executable_todo_count must be non-negative")
+    warning_codes = [
+        _token(code, field="check_warning_codes[]") for code in check_warning_codes
+    ]
+    selected_kind = _nullable_token(
+        selected_action_kind,
+        field="selected_action_kind",
+    )
+    projection_gap = "state_projection_gap" in warning_codes or (
+        next_action_actionable and executable_todo_count == 0
+    )
+    if projection_gap:
+        route = "repair_projection"
+    elif user_action_required:
+        route = "ask_user"
+    elif executable_todo_count > 0 and normal_delivery_allowed:
+        route = "continue_validation"
+    else:
+        route = "stop"
+    return {
+        "schema_version": ONBOARDING_POSTCONDITION_SCHEMA_VERSION,
+        "check_warning_codes": warning_codes,
+        "executable_todo_count": executable_todo_count,
+        "selected_action_kind": selected_kind,
+        "normal_delivery_allowed": normal_delivery_allowed,
+        "user_action_required": user_action_required,
+        "next_action_actionable": next_action_actionable,
+        "derived_route": route,
+        "state_projection_gap": projection_gap,
+    }
+
+
+def onboarding_postcondition_semantic_contract(
+    observation: Mapping[str, Any],
+) -> dict[str, Any]:
+    if observation.get("schema_version") != ONBOARDING_POSTCONDITION_SCHEMA_VERSION:
+        raise ValueError(
+            "postcondition packet must use onboarding_postcondition_observation_v0"
+        )
+    count = observation.get("executable_todo_count")
+    if not isinstance(count, int) or count < 0:
+        raise ValueError("postcondition executable_todo_count must be non-negative")
+    route = str(observation.get("derived_route") or "")
+    if route not in _POSTCONDITION_ROUTES:
+        raise ValueError("postcondition derived_route is invalid")
+    return {
+        "route": route,
+        "state_projection_gap": bool(observation.get("state_projection_gap")),
+        "executable_todo_present": count > 0,
+        "selected_action_kind": _nullable_token(
+            observation.get("selected_action_kind"),
+            field="selected_action_kind",
+        ),
+        "normal_delivery_allowed": bool(
+            observation.get("normal_delivery_allowed")
+        ),
+        "user_action_required": bool(observation.get("user_action_required")),
+    }
+
+
+def _semantic_contract(
+    packet: Mapping[str, Any],
+    *,
+    phase: str,
+) -> dict[str, Any]:
+    if phase == "entry":
+        return onboarding_entry_semantic_contract(packet)
+    if phase == "postcondition":
+        return onboarding_postcondition_semantic_contract(packet)
+    raise ValueError("phase must be entry or postcondition")
+
+
+def build_onboarding_model_behavior_actor_request(
+    packet: Mapping[str, Any],
+    *,
+    qualification_id: str,
+    arm: str,
+    phase: str,
+) -> dict[str, Any]:
+    if arm not in ONBOARDING_MODEL_BEHAVIOR_ARMS:
+        raise ValueError("arm must be full_detail or guided_default")
+    if phase not in ONBOARDING_MODEL_BEHAVIOR_PHASES:
+        raise ValueError("phase must be entry or postcondition")
+    normalized_packet = dict(packet)
+    _semantic_contract(normalized_packet, phase=phase)
+    _reject_private_or_secret_material(normalized_packet)
+    return {
+        "schema_version": ONBOARDING_MODEL_BEHAVIOR_REQUEST_SCHEMA_VERSION,
+        "qualification_id": _token(qualification_id, field="qualification_id"),
+        "arm": arm,
+        "phase": phase,
+        "packet": normalized_packet,
+        "sandbox": {
+            "schema_version": "model_behavior_no_write_sandbox_v0",
+            "tools_enabled": False,
+            "filesystem_writes_allowed": False,
+            "external_writes_allowed": False,
+            "provider_network_only": True,
+        },
+        "response_contract": {
+            "schema_version": ONBOARDING_MODEL_BEHAVIOR_DECISION_SCHEMA_VERSION,
+            "format": "json_object",
+            "reject_unknown_fields": True,
+            "semantic_contract_fields": list(
+                _ENTRY_CONTRACT_FIELDS
+                if phase == "entry"
+                else _POSTCONDITION_CONTRACT_FIELDS
+            ),
+        },
+    }
+
+
+def normalize_onboarding_model_behavior_actor_request(
+    raw: Mapping[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise ValueError("actor request must be an object")
+    if raw.get("schema_version") != ONBOARDING_MODEL_BEHAVIOR_REQUEST_SCHEMA_VERSION:
+        raise ValueError(
+            "actor request must use onboarding_model_behavior_actor_request_v0"
+        )
+    packet = _mapping(raw.get("packet"), field="packet")
+    canonical = build_onboarding_model_behavior_actor_request(
+        packet,
+        qualification_id=str(raw.get("qualification_id") or ""),
+        arm=str(raw.get("arm") or ""),
+        phase=str(raw.get("phase") or ""),
+    )
+    if dict(raw) != canonical:
+        raise ValueError("actor request does not match the canonical no-write contract")
+    return canonical
+
+
+def normalize_onboarding_model_behavior_actor_result(
+    raw: Mapping[str, Any],
+    *,
+    phase: str,
+) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise ValueError("actor result must be an object")
+    unknown = sorted(set(raw) - _RESULT_FIELDS)
+    if unknown:
+        raise ValueError(f"unknown actor result field(s): {', '.join(unknown)}")
+    if raw.get("schema_version") != ONBOARDING_MODEL_BEHAVIOR_RESULT_SCHEMA_VERSION:
+        raise ValueError(
+            "actor result must use onboarding_model_behavior_actor_result_v0"
+        )
+    if raw.get("tool_calls") != []:
+        raise ValueError("onboarding qualification forbids all tool calls")
+    decision = _mapping(raw.get("decision"), field="decision")
+    unknown_decision = sorted(set(decision) - _DECISION_FIELDS)
+    if unknown_decision:
+        raise ValueError(
+            f"unknown onboarding decision field(s): {', '.join(unknown_decision)}"
+        )
+    if decision.get("schema_version") != ONBOARDING_MODEL_BEHAVIOR_DECISION_SCHEMA_VERSION:
+        raise ValueError(
+            "decision must use onboarding_model_behavior_decision_v0"
+        )
+    if decision.get("phase") != phase:
+        raise ValueError("decision phase must match the actor request")
+    next_action = str(decision.get("next_action") or "")
+    allowed_actions = _ENTRY_ROUTES if phase == "entry" else _POSTCONDITION_ROUTES
+    if next_action not in allowed_actions:
+        raise ValueError("decision next_action is invalid for this phase")
+    contract = _mapping(decision.get("semantic_contract"), field="semantic_contract")
+    contract_fields = (
+        _ENTRY_CONTRACT_FIELDS if phase == "entry" else _POSTCONDITION_CONTRACT_FIELDS
+    )
+    if set(contract) != set(contract_fields):
+        raise ValueError("decision semantic_contract fields do not match the phase")
+    _reject_private_or_secret_material(contract, path="decision.semantic_contract")
+    return {
+        "schema_version": ONBOARDING_MODEL_BEHAVIOR_RESULT_SCHEMA_VERSION,
+        "actor_ref": _token(raw.get("actor_ref"), field="actor_ref"),
+        "decision": {
+            "schema_version": ONBOARDING_MODEL_BEHAVIOR_DECISION_SCHEMA_VERSION,
+            "phase": phase,
+            "next_action": next_action,
+            "semantic_contract": {
+                field: json.loads(_canonical_json(contract[field]))
+                for field in contract_fields
+            },
+            "reason_codes": _reason_codes(decision.get("reason_codes")),
+        },
+        "tool_calls": [],
+    }
+
+
+def run_onboarding_model_behavior_arm(
+    packet: Mapping[str, Any],
+    *,
+    qualification_id: str,
+    arm: str,
+    phase: str,
+    actor: OnboardingModelBehaviorActor,
+) -> dict[str, Any]:
+    request = build_onboarding_model_behavior_actor_request(
+        packet,
+        qualification_id=qualification_id,
+        arm=arm,
+        phase=phase,
+    )
+    result = normalize_onboarding_model_behavior_actor_result(
+        actor(request),
+        phase=phase,
+    )
+    decision = dict(result["decision"])
+    expected = _semantic_contract(request["packet"], phase=phase)
+    actual = dict(decision["semantic_contract"])
+    alignment = {field: actual[field] == expected[field] for field in expected}
+    violations = [
+        f"semantic_contract_mismatch:{field}"
+        for field, matches in alignment.items()
+        if not matches
+    ]
+    if decision["next_action"] != expected["route"]:
+        violations.append("next_action_mismatch")
+    return {
+        "schema_version": ONBOARDING_MODEL_BEHAVIOR_RECEIPT_SCHEMA_VERSION,
+        "qualification_id": request["qualification_id"],
+        "arm": arm,
+        "phase": phase,
+        "actor_ref": result["actor_ref"],
+        "packet_digest": _digest(request["packet"]),
+        "decision_digest": _digest(decision),
+        "next_action": decision["next_action"],
+        "source_aligned": not violations,
+        "semantic_contract_complete": all(alignment.values()),
+        "semantic_contract_alignment": alignment,
+        "semantic_contract_digests": {
+            field: _digest(actual[field]) for field in actual
+        },
+        "safety_violations": violations,
+        "boundary": {
+            "tools_enabled": False,
+            "tool_call_count": 0,
+            "filesystem_writes_allowed": False,
+            "external_writes_allowed": False,
+            "raw_packet_persisted": False,
+            "raw_model_response_persisted": False,
+        },
+    }
+
+
+def _compare_phase_receipts(
+    receipts: Mapping[str, Mapping[str, Any]],
+) -> dict[str, Any]:
+    full = receipts["full_detail"]
+    guided = receipts["guided_default"]
+    fields = ("next_action", "semantic_contract_digests")
+    drift = {
+        field: {
+            "full_detail": full.get(field),
+            "guided_default": guided.get(field),
+        }
+        for field in fields
+        if full.get(field) != guided.get(field)
+    }
+    return {
+        "equivalent": not drift,
+        "drift": drift,
+        "source_aligned": all(
+            receipt.get("source_aligned") is True for receipt in receipts.values()
+        ),
+        "receipt_digests": {
+            arm: _digest(dict(receipt)) for arm, receipt in receipts.items()
+        },
+    }
+
+
+def run_onboarding_closed_loop_pair(
+    full_detail_packet: Mapping[str, Any],
+    guided_default_packet: Mapping[str, Any],
+    *,
+    qualification_id: str,
+    actor: OnboardingModelBehaviorActor,
+    transition_runner: Callable[[str], Mapping[str, Any]],
+    arm_order: Sequence[str] = ONBOARDING_MODEL_BEHAVIOR_ARMS,
+) -> dict[str, Any]:
+    if tuple(sorted(arm_order)) != tuple(sorted(ONBOARDING_MODEL_BEHAVIOR_ARMS)):
+        raise ValueError("arm_order must contain full_detail and guided_default once")
+    packets = {
+        "full_detail": dict(full_detail_packet),
+        "guided_default": dict(guided_default_packet),
+    }
+    entry_contracts = {
+        arm: onboarding_entry_semantic_contract(packet)
+        for arm, packet in packets.items()
+    }
+    if entry_contracts["full_detail"] != entry_contracts["guided_default"]:
+        raise OnboardingModelBehaviorPairValidationError(
+            "paired onboarding entry packets are not semantically equivalent"
+        )
+    if entry_contracts["full_detail"]["route"] != "connect_if_needed":
+        raise OnboardingModelBehaviorPairValidationError(
+            "closed-loop qualification requires the connect_if_needed route"
+        )
+
+    entry_receipts = {
+        arm: run_onboarding_model_behavior_arm(
+            packets[arm],
+            qualification_id=qualification_id,
+            arm=arm,
+            phase="entry",
+            actor=actor,
+        )
+        for arm in arm_order
+    }
+    entry_comparison = _compare_phase_receipts(entry_receipts)
+    if not entry_comparison["source_aligned"]:
+        return {
+            "schema_version": ONBOARDING_MODEL_BEHAVIOR_PAIR_SCHEMA_VERSION,
+            "qualification_id": qualification_id,
+            "closed_loop_complete": False,
+            "qualification_passed": False,
+            "automatic_release_promotion_allowed": False,
+            "entry": entry_comparison,
+            "postcondition": None,
+            "failure_code": "entry_source_alignment_failed",
+        }
+
+    observations = {arm: dict(transition_runner(arm)) for arm in arm_order}
+    post_contracts = {
+        arm: onboarding_postcondition_semantic_contract(observation)
+        for arm, observation in observations.items()
+    }
+    if post_contracts["full_detail"] != post_contracts["guided_default"]:
+        raise OnboardingModelBehaviorPairValidationError(
+            "paired transition runners produced different postconditions"
+        )
+    post_receipts = {
+        arm: run_onboarding_model_behavior_arm(
+            observations[arm],
+            qualification_id=qualification_id,
+            arm=arm,
+            phase="postcondition",
+            actor=actor,
+        )
+        for arm in arm_order
+    }
+    post_comparison = _compare_phase_receipts(post_receipts)
+    passed = bool(
+        entry_comparison["equivalent"]
+        and entry_comparison["source_aligned"]
+        and post_comparison["equivalent"]
+        and post_comparison["source_aligned"]
+    )
+    return {
+        "schema_version": ONBOARDING_MODEL_BEHAVIOR_PAIR_SCHEMA_VERSION,
+        "qualification_id": qualification_id,
+        "closed_loop_complete": True,
+        "qualification_passed": passed,
+        "automatic_release_promotion_allowed": False,
+        "entry": entry_comparison,
+        "postcondition": post_comparison,
+        "failure_code": None if passed else "behavior_drift_or_source_misalignment",
+    }

--- a/loopx/control_plane/testing/onboarding_model_behavior_qualification.py
+++ b/loopx/control_plane/testing/onboarding_model_behavior_qualification.py
@@ -24,14 +24,19 @@ ONBOARDING_MODEL_BEHAVIOR_DECISION_SCHEMA_VERSION = (
 ONBOARDING_MODEL_BEHAVIOR_RECEIPT_SCHEMA_VERSION = (
     "onboarding_model_behavior_receipt_v0"
 )
-ONBOARDING_MODEL_BEHAVIOR_PAIR_SCHEMA_VERSION = (
-    "onboarding_model_behavior_pair_result_v0"
+ONBOARDING_ACTUAL_BEHAVIOR_QUALIFICATION_SCHEMA_VERSION = (
+    "onboarding_actual_behavior_qualification_v0"
 )
 ONBOARDING_POSTCONDITION_SCHEMA_VERSION = "onboarding_postcondition_observation_v0"
 START_GOAL_PACKET_SCHEMA_VERSION = "loopx_start_goal_guided_v0"
 
-ONBOARDING_MODEL_BEHAVIOR_ARMS = ("full_detail", "guided_default")
 ONBOARDING_MODEL_BEHAVIOR_PHASES = ("entry", "postcondition")
+ONBOARDING_REQUIRED_CONNECT_COMMAND_IDS = (
+    "goal_start_connect_if_needed",
+    "goal_start_refresh_state",
+    "goal_start_host_loop_activation",
+    "goal_start_quota_should_run",
+)
 
 _ENTRY_CONTRACT_FIELDS = (
     "route",
@@ -77,8 +82,8 @@ class OnboardingModelBehaviorActor(Protocol):
     def __call__(self, request: Mapping[str, Any]) -> Mapping[str, Any]: ...
 
 
-class OnboardingModelBehaviorPairValidationError(ValueError):
-    """The paired onboarding inputs diverged before live actor execution."""
+class OnboardingActualBehaviorValidationError(ValueError):
+    """The actual onboarding input violates a stable behavior invariant."""
 
 
 def _canonical_json(value: Any) -> str:
@@ -93,6 +98,12 @@ def _mapping(value: Any, *, field: str) -> dict[str, Any]:
     if not isinstance(value, Mapping):
         raise ValueError(f"{field} must be an object")
     return dict(value)
+
+
+def _optional_mapping(value: Any, *, field: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    return _mapping(value, field=field)
 
 
 def _nullable_token(value: Any, *, field: str) -> str | None:
@@ -136,20 +147,16 @@ def onboarding_entry_semantic_contract(
     if packet.get("schema_version") != START_GOAL_PACKET_SCHEMA_VERSION:
         raise ValueError("entry packet must use loopx_start_goal_guided_v0")
     transaction = _mapping(packet.get("guided_transaction"), field="guided_transaction")
-    commands = _mapping(_command_pack_value(packet, "commands"), field="commands")
-    activation = _mapping(
+    commands = _optional_mapping(
+        _command_pack_value(packet, "commands"), field="commands"
+    )
+    activation = _optional_mapping(
         _command_pack_value(packet, "host_loop_activation"),
         field="host_loop_activation",
     )
-    canonical_command_ids = (
-        "goal_start_connect_if_needed",
-        "goal_start_refresh_state",
-        "goal_start_host_loop_activation",
-        "goal_start_quota_should_run",
-    )
     command_ids = [
         command_id
-        for command_id in canonical_command_ids
+        for command_id in ONBOARDING_REQUIRED_CONNECT_COMMAND_IDS
         if isinstance(commands.get(command_id), str) and commands[command_id].strip()
     ]
     return {
@@ -167,6 +174,35 @@ def onboarding_entry_semantic_contract(
         "writes_now": bool(transaction.get("writes_now")),
         "spends_quota_now": bool(transaction.get("spends_quota_now")),
     }
+
+
+def onboarding_entry_contract_violations(
+    contract: Mapping[str, Any],
+) -> list[str]:
+    """Validate stable onboarding behavior without deriving it from the packet."""
+    violations: list[str] = []
+    route = str(contract.get("route") or "")
+    if route not in _ENTRY_ROUTES:
+        violations.append("entry_route_invalid")
+    if contract.get("writes_now") is not False:
+        violations.append("entry_must_not_write")
+    if contract.get("spends_quota_now") is not False:
+        violations.append("entry_must_not_spend_quota")
+    if route == "connect_if_needed":
+        if contract.get("goal_id") is None:
+            violations.append("connect_route_requires_goal_id")
+        if contract.get("agent_id") is None:
+            violations.append("connect_route_requires_agent_id")
+        if (
+            tuple(contract.get("action_command_ids") or ())
+            != ONBOARDING_REQUIRED_CONNECT_COMMAND_IDS
+        ):
+            violations.append("connect_route_missing_required_commands")
+        if contract.get("host_loop_activation_available") is not True:
+            violations.append("connect_route_requires_host_loop_activation")
+        if contract.get("host_loop_activation_after_todo_write") is not True:
+            violations.append("host_loop_must_activate_after_todo_write")
+    return violations
 
 
 def build_onboarding_postcondition_observation(
@@ -239,6 +275,38 @@ def onboarding_postcondition_semantic_contract(
     }
 
 
+def onboarding_postcondition_contract_violations(
+    contract: Mapping[str, Any],
+) -> list[str]:
+    """Check route invariants independently from the observation reducer."""
+    violations: list[str] = []
+    route = str(contract.get("route") or "")
+    if route not in _POSTCONDITION_ROUTES:
+        return ["postcondition_route_invalid"]
+    if route == "continue_validation":
+        if contract.get("state_projection_gap") is not False:
+            violations.append("continue_route_forbids_projection_gap")
+        if contract.get("executable_todo_present") is not True:
+            violations.append("continue_route_requires_executable_todo")
+        if contract.get("normal_delivery_allowed") is not True:
+            violations.append("continue_route_requires_delivery")
+        if contract.get("user_action_required") is not False:
+            violations.append("continue_route_forbids_user_gate")
+    elif route == "repair_projection":
+        if contract.get("state_projection_gap") is not True:
+            violations.append("repair_route_requires_projection_gap")
+        if contract.get("executable_todo_present") is not False:
+            violations.append("repair_route_forbids_executable_todo")
+        if contract.get("normal_delivery_allowed") is not False:
+            violations.append("repair_route_forbids_normal_delivery")
+    elif route == "ask_user":
+        if contract.get("user_action_required") is not True:
+            violations.append("ask_user_route_requires_user_gate")
+    elif contract.get("normal_delivery_allowed") is True:
+        violations.append("stop_route_forbids_normal_delivery")
+    return violations
+
+
 def _semantic_contract(
     packet: Mapping[str, Any],
     *,
@@ -251,24 +319,36 @@ def _semantic_contract(
     raise ValueError("phase must be entry or postcondition")
 
 
+def _behavior_contract_violations(
+    contract: Mapping[str, Any],
+    *,
+    phase: str,
+) -> list[str]:
+    if phase == "entry":
+        return onboarding_entry_contract_violations(contract)
+    return onboarding_postcondition_contract_violations(contract)
+
+
 def build_onboarding_model_behavior_actor_request(
     packet: Mapping[str, Any],
     *,
     qualification_id: str,
-    arm: str,
     phase: str,
 ) -> dict[str, Any]:
-    if arm not in ONBOARDING_MODEL_BEHAVIOR_ARMS:
-        raise ValueError("arm must be full_detail or guided_default")
     if phase not in ONBOARDING_MODEL_BEHAVIOR_PHASES:
         raise ValueError("phase must be entry or postcondition")
     normalized_packet = dict(packet)
-    _semantic_contract(normalized_packet, phase=phase)
+    contract = _semantic_contract(normalized_packet, phase=phase)
+    violations = _behavior_contract_violations(contract, phase=phase)
+    if violations:
+        raise OnboardingActualBehaviorValidationError(
+            "actual onboarding behavior violates stable invariants: "
+            + ", ".join(violations)
+        )
     _reject_private_or_secret_material(normalized_packet)
     return {
         "schema_version": ONBOARDING_MODEL_BEHAVIOR_REQUEST_SCHEMA_VERSION,
         "qualification_id": _token(qualification_id, field="qualification_id"),
-        "arm": arm,
         "phase": phase,
         "packet": normalized_packet,
         "sandbox": {
@@ -304,7 +384,6 @@ def normalize_onboarding_model_behavior_actor_request(
     canonical = build_onboarding_model_behavior_actor_request(
         packet,
         qualification_id=str(raw.get("qualification_id") or ""),
-        arm=str(raw.get("arm") or ""),
         phase=str(raw.get("phase") or ""),
     )
     if dict(raw) != canonical:
@@ -368,18 +447,16 @@ def normalize_onboarding_model_behavior_actor_result(
     }
 
 
-def run_onboarding_model_behavior_arm(
+def run_onboarding_model_behavior_phase(
     packet: Mapping[str, Any],
     *,
     qualification_id: str,
-    arm: str,
     phase: str,
     actor: OnboardingModelBehaviorActor,
 ) -> dict[str, Any]:
     request = build_onboarding_model_behavior_actor_request(
         packet,
         qualification_id=qualification_id,
-        arm=arm,
         phase=phase,
     )
     result = normalize_onboarding_model_behavior_actor_result(
@@ -400,13 +477,13 @@ def run_onboarding_model_behavior_arm(
     return {
         "schema_version": ONBOARDING_MODEL_BEHAVIOR_RECEIPT_SCHEMA_VERSION,
         "qualification_id": request["qualification_id"],
-        "arm": arm,
         "phase": phase,
         "actor_ref": result["actor_ref"],
         "packet_digest": _digest(request["packet"]),
         "decision_digest": _digest(decision),
         "next_action": decision["next_action"],
         "source_aligned": not violations,
+        "behavior_contract_valid": True,
         "semantic_contract_complete": all(alignment.values()),
         "semantic_contract_alignment": alignment,
         "semantic_contract_digests": {
@@ -424,116 +501,92 @@ def run_onboarding_model_behavior_arm(
     }
 
 
-def _compare_phase_receipts(
-    receipts: Mapping[str, Mapping[str, Any]],
-) -> dict[str, Any]:
-    full = receipts["full_detail"]
-    guided = receipts["guided_default"]
-    fields = ("next_action", "semantic_contract_digests")
-    drift = {
-        field: {
-            "full_detail": full.get(field),
-            "guided_default": guided.get(field),
-        }
-        for field in fields
-        if full.get(field) != guided.get(field)
-    }
+def _receipt_summary(receipt: Mapping[str, Any]) -> dict[str, Any]:
     return {
-        "equivalent": not drift,
-        "drift": drift,
-        "source_aligned": all(
-            receipt.get("source_aligned") is True for receipt in receipts.values()
-        ),
-        "receipt_digests": {
-            arm: _digest(dict(receipt)) for arm, receipt in receipts.items()
-        },
+        "next_action": receipt["next_action"],
+        "source_aligned": receipt["source_aligned"],
+        "behavior_contract_valid": receipt["behavior_contract_valid"],
+        "safety_violations": list(receipt["safety_violations"]),
+        "receipt_digest": _digest(dict(receipt)),
     }
 
 
-def run_onboarding_closed_loop_pair(
-    full_detail_packet: Mapping[str, Any],
-    guided_default_packet: Mapping[str, Any],
+def run_onboarding_actual_behavior_qualification(
+    actual_packet: Mapping[str, Any],
     *,
     qualification_id: str,
     actor: OnboardingModelBehaviorActor,
-    transition_runner: Callable[[str], Mapping[str, Any]],
-    arm_order: Sequence[str] = ONBOARDING_MODEL_BEHAVIOR_ARMS,
+    transition_runner: Callable[[], Mapping[str, Any]],
+    repair_observation: Mapping[str, Any],
 ) -> dict[str, Any]:
-    if tuple(sorted(arm_order)) != tuple(sorted(ONBOARDING_MODEL_BEHAVIOR_ARMS)):
-        raise ValueError("arm_order must contain full_detail and guided_default once")
-    packets = {
-        "full_detail": dict(full_detail_packet),
-        "guided_default": dict(guided_default_packet),
-    }
-    entry_contracts = {
-        arm: onboarding_entry_semantic_contract(packet)
-        for arm, packet in packets.items()
-    }
-    if entry_contracts["full_detail"] != entry_contracts["guided_default"]:
-        raise OnboardingModelBehaviorPairValidationError(
-            "paired onboarding entry packets are not semantically equivalent"
+    entry_contract = onboarding_entry_semantic_contract(actual_packet)
+    entry_violations = onboarding_entry_contract_violations(entry_contract)
+    if entry_violations:
+        raise OnboardingActualBehaviorValidationError(
+            "actual onboarding behavior violates stable invariants: "
+            + ", ".join(entry_violations)
         )
-    if entry_contracts["full_detail"]["route"] != "connect_if_needed":
-        raise OnboardingModelBehaviorPairValidationError(
+    if entry_contract["route"] != "connect_if_needed":
+        raise OnboardingActualBehaviorValidationError(
             "closed-loop qualification requires the connect_if_needed route"
         )
 
-    entry_receipts = {
-        arm: run_onboarding_model_behavior_arm(
-            packets[arm],
-            qualification_id=qualification_id,
-            arm=arm,
-            phase="entry",
-            actor=actor,
-        )
-        for arm in arm_order
-    }
-    entry_comparison = _compare_phase_receipts(entry_receipts)
-    if not entry_comparison["source_aligned"]:
+    entry_receipt = run_onboarding_model_behavior_phase(
+        actual_packet,
+        qualification_id=qualification_id,
+        phase="entry",
+        actor=actor,
+    )
+    if entry_receipt["source_aligned"] is not True:
         return {
-            "schema_version": ONBOARDING_MODEL_BEHAVIOR_PAIR_SCHEMA_VERSION,
+            "schema_version": ONBOARDING_ACTUAL_BEHAVIOR_QUALIFICATION_SCHEMA_VERSION,
             "qualification_id": qualification_id,
             "closed_loop_complete": False,
             "qualification_passed": False,
             "automatic_release_promotion_allowed": False,
-            "entry": entry_comparison,
-            "postcondition": None,
+            "entry": _receipt_summary(entry_receipt),
+            "healthy_postcondition": None,
+            "repair_calibration": None,
             "failure_code": "entry_source_alignment_failed",
         }
 
-    observations = {arm: dict(transition_runner(arm)) for arm in arm_order}
-    post_contracts = {
-        arm: onboarding_postcondition_semantic_contract(observation)
-        for arm, observation in observations.items()
-    }
-    if post_contracts["full_detail"] != post_contracts["guided_default"]:
-        raise OnboardingModelBehaviorPairValidationError(
-            "paired transition runners produced different postconditions"
-        )
-    post_receipts = {
-        arm: run_onboarding_model_behavior_arm(
-            observations[arm],
-            qualification_id=qualification_id,
-            arm=arm,
-            phase="postcondition",
-            actor=actor,
-        )
-        for arm in arm_order
-    }
-    post_comparison = _compare_phase_receipts(post_receipts)
-    passed = bool(
-        entry_comparison["equivalent"]
-        and entry_comparison["source_aligned"]
-        and post_comparison["equivalent"]
-        and post_comparison["source_aligned"]
+    healthy_observation = dict(transition_runner())
+    healthy_receipt = run_onboarding_model_behavior_phase(
+        healthy_observation,
+        qualification_id=qualification_id,
+        phase="postcondition",
+        actor=actor,
     )
+    repair_receipt = run_onboarding_model_behavior_phase(
+        repair_observation,
+        qualification_id=qualification_id,
+        phase="postcondition",
+        actor=actor,
+    )
+    healthy_expected = healthy_receipt["next_action"] == "continue_validation"
+    repair_expected = repair_receipt["next_action"] == "repair_projection"
+    passed = bool(
+        healthy_expected
+        and repair_expected
+        and healthy_receipt["source_aligned"]
+        and repair_receipt["source_aligned"]
+    )
+    if not healthy_expected:
+        failure_code = "actual_postcondition_not_healthy"
+    elif not repair_expected:
+        failure_code = "projection_gap_repair_calibration_failed"
+    elif not passed:
+        failure_code = "model_source_alignment_failed"
+    else:
+        failure_code = None
     return {
-        "schema_version": ONBOARDING_MODEL_BEHAVIOR_PAIR_SCHEMA_VERSION,
+        "schema_version": ONBOARDING_ACTUAL_BEHAVIOR_QUALIFICATION_SCHEMA_VERSION,
         "qualification_id": qualification_id,
         "closed_loop_complete": True,
         "qualification_passed": passed,
         "automatic_release_promotion_allowed": False,
-        "entry": entry_comparison,
-        "postcondition": post_comparison,
-        "failure_code": None if passed else "behavior_drift_or_source_misalignment",
+        "entry": _receipt_summary(entry_receipt),
+        "healthy_postcondition": _receipt_summary(healthy_receipt),
+        "repair_calibration": _receipt_summary(repair_receipt),
+        "failure_code": failure_code,
     }

--- a/tests/control_plane/test_doubao_onboarding_model_behavior_actor.py
+++ b/tests/control_plane/test_doubao_onboarding_model_behavior_actor.py
@@ -75,7 +75,6 @@ def test_direct_onboarding_actor_uses_no_tool_provider_boundary() -> None:
     request = build_onboarding_model_behavior_actor_request(
         _packet(),
         qualification_id="onboarding-direct-doubao-001",
-        arm="guided_default",
         phase="entry",
     )
     result = normalize_onboarding_model_behavior_actor_result(
@@ -89,7 +88,7 @@ def test_direct_onboarding_actor_uses_no_tool_provider_boundary() -> None:
     assert captured["body"]["response_format"] == {"type": "json_object"}
     assert "tools" not in captured["body"]
     provider_input = json.loads(captured["body"]["messages"][1]["content"])
-    assert set(provider_input) == {"schema_version", "arm", "phase", "packet"}
+    assert set(provider_input) == {"schema_version", "phase", "packet"}
     assert "qualification_id" not in provider_input
     assert "sandbox" not in provider_input
     assert result["schema_version"] == ONBOARDING_MODEL_BEHAVIOR_RESULT_SCHEMA_VERSION

--- a/tests/control_plane/test_doubao_onboarding_model_behavior_actor.py
+++ b/tests/control_plane/test_doubao_onboarding_model_behavior_actor.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from loopx.control_plane.testing.doubao_model_behavior_actor import (
+    DOUBAO_2_1_PRO_MODEL,
+    DOUBAO_CHAT_COMPLETIONS_ENDPOINT,
+    DoubaoOnboardingModelBehaviorActor,
+)
+from loopx.control_plane.testing.onboarding_model_behavior_qualification import (
+    ONBOARDING_MODEL_BEHAVIOR_DECISION_SCHEMA_VERSION,
+    ONBOARDING_MODEL_BEHAVIOR_RESULT_SCHEMA_VERSION,
+    build_onboarding_model_behavior_actor_request,
+    normalize_onboarding_model_behavior_actor_result,
+    onboarding_entry_semantic_contract,
+)
+
+
+def _packet() -> dict[str, Any]:
+    return {
+        "schema_version": "loopx_start_goal_guided_v0",
+        "goal_id": "fixture-goal",
+        "agent_id": "codex-fixture",
+        "guided_transaction": {
+            "writes_now": False,
+            "spends_quota_now": False,
+            "ordered_steps": [{"id": "connect_if_needed"}],
+        },
+        "commands": {
+            "goal_start_connect_if_needed": "loopx bootstrap --project $PROJECT",
+            "goal_start_refresh_state": "loopx refresh-state --goal-id fixture-goal",
+            "goal_start_host_loop_activation": "loopx heartbeat-prompt --thin",
+            "goal_start_quota_should_run": "loopx quota should-run",
+        },
+        "host_loop_activation": {
+            "agent_id": "codex-fixture",
+            "activation_required_after_todo_write": True,
+        },
+    }
+
+
+def test_direct_onboarding_actor_uses_no_tool_provider_boundary() -> None:
+    captured: dict[str, Any] = {}
+    contract = onboarding_entry_semantic_contract(_packet())
+    decision = {
+        "schema_version": ONBOARDING_MODEL_BEHAVIOR_DECISION_SCHEMA_VERSION,
+        "phase": "entry",
+        "next_action": "connect_if_needed",
+        "semantic_contract": contract,
+        "reason_codes": ["source_aligned"],
+    }
+
+    def transport(
+        *,
+        endpoint: str,
+        headers: Mapping[str, str],
+        body: bytes,
+        timeout_seconds: float,
+    ) -> Mapping[str, Any]:
+        captured.update(
+            endpoint=endpoint,
+            headers=dict(headers),
+            body=json.loads(body),
+            timeout_seconds=timeout_seconds,
+        )
+        return {"choices": [{"message": {"content": json.dumps(decision)}}]}
+
+    actor = DoubaoOnboardingModelBehaviorActor(
+        api_key="fixture-key-not-a-secret",
+        transport=transport,
+        timeout_seconds=18,
+    )
+    request = build_onboarding_model_behavior_actor_request(
+        _packet(),
+        qualification_id="onboarding-direct-doubao-001",
+        arm="guided_default",
+        phase="entry",
+    )
+    result = normalize_onboarding_model_behavior_actor_result(
+        actor(request),
+        phase="entry",
+    )
+
+    assert captured["endpoint"] == DOUBAO_CHAT_COMPLETIONS_ENDPOINT
+    assert captured["body"]["model"] == DOUBAO_2_1_PRO_MODEL
+    assert captured["body"]["thinking"] == {"type": "disabled"}
+    assert captured["body"]["response_format"] == {"type": "json_object"}
+    assert "tools" not in captured["body"]
+    provider_input = json.loads(captured["body"]["messages"][1]["content"])
+    assert set(provider_input) == {"schema_version", "arm", "phase", "packet"}
+    assert "qualification_id" not in provider_input
+    assert "sandbox" not in provider_input
+    assert result["schema_version"] == ONBOARDING_MODEL_BEHAVIOR_RESULT_SCHEMA_VERSION
+    assert result["tool_calls"] == []
+    assert "fixture-key" not in json.dumps(result, sort_keys=True)

--- a/tests/control_plane/test_onboarding_model_behavior_qualification.py
+++ b/tests/control_plane/test_onboarding_model_behavior_qualification.py
@@ -7,15 +7,17 @@ from typing import Any
 import pytest
 
 from loopx.control_plane.testing.onboarding_model_behavior_qualification import (
+    ONBOARDING_ACTUAL_BEHAVIOR_QUALIFICATION_SCHEMA_VERSION,
     ONBOARDING_MODEL_BEHAVIOR_DECISION_SCHEMA_VERSION,
-    ONBOARDING_MODEL_BEHAVIOR_PAIR_SCHEMA_VERSION,
     ONBOARDING_MODEL_BEHAVIOR_RESULT_SCHEMA_VERSION,
-    OnboardingModelBehaviorPairValidationError,
+    ONBOARDING_REQUIRED_CONNECT_COMMAND_IDS,
+    OnboardingActualBehaviorValidationError,
     build_onboarding_model_behavior_actor_request,
     build_onboarding_postcondition_observation,
+    normalize_onboarding_model_behavior_actor_request,
     onboarding_entry_semantic_contract,
     onboarding_postcondition_semantic_contract,
-    run_onboarding_closed_loop_pair,
+    run_onboarding_actual_behavior_qualification,
 )
 
 
@@ -48,8 +50,8 @@ TRANSACTION = {
 }
 
 
-def _entry_packet(*, compact: bool) -> dict[str, Any]:
-    packet: dict[str, Any] = {
+def _actual_entry_packet() -> dict[str, Any]:
+    return {
         "schema_version": "loopx_start_goal_guided_v0",
         "goal_id": "fixture-goal",
         "agent_id": "codex-fixture",
@@ -59,19 +61,12 @@ def _entry_packet(*, compact: bool) -> dict[str, Any]:
             "writes_state_file": False,
             "spends_quota": False,
         },
-    }
-    if compact:
-        packet.update(
-            commands=dict(COMMANDS),
-            host_loop_activation=dict(ACTIVATION),
-        )
-    else:
-        packet["command_pack"] = {
+        "command_pack": {
             "commands": dict(COMMANDS),
             "host_loop_activation": dict(ACTIVATION),
-            "message": "Detailed diagnostic material stays in the cold path.",
-        }
-    return packet
+            "message": "Current default command-pack detail.",
+        },
+    }
 
 
 def _decision_for_request(request: Mapping[str, Any]) -> dict[str, Any]:
@@ -111,35 +106,89 @@ def _healthy_observation() -> dict[str, Any]:
     )
 
 
-def test_closed_loop_pair_checks_entry_and_2134_postcondition_without_raw_retention() -> None:
-    transitions: list[str] = []
-
-    result = run_onboarding_closed_loop_pair(
-        _entry_packet(compact=False),
-        _entry_packet(compact=True),
-        qualification_id="onboarding-2134-healthy-001",
-        actor=_actor,
-        transition_runner=lambda arm: transitions.append(arm) or _healthy_observation(),
-        arm_order=("guided_default", "full_detail"),
+def _projection_gap_observation() -> dict[str, Any]:
+    return build_onboarding_postcondition_observation(
+        check_warning_codes=["state_projection_gap"],
+        executable_todo_count=0,
+        selected_action_kind=None,
+        normal_delivery_allowed=False,
+        user_action_required=False,
+        next_action_actionable=True,
     )
 
-    assert result["schema_version"] == ONBOARDING_MODEL_BEHAVIOR_PAIR_SCHEMA_VERSION
+
+def test_actual_default_closed_loop_checks_healthy_and_2134_repair_behavior() -> None:
+    transitions = 0
+
+    def transition() -> Mapping[str, Any]:
+        nonlocal transitions
+        transitions += 1
+        return _healthy_observation()
+
+    result = run_onboarding_actual_behavior_qualification(
+        _actual_entry_packet(),
+        qualification_id="onboarding-actual-2134-001",
+        actor=_actor,
+        transition_runner=transition,
+        repair_observation=_projection_gap_observation(),
+    )
+
+    assert (
+        result["schema_version"]
+        == ONBOARDING_ACTUAL_BEHAVIOR_QUALIFICATION_SCHEMA_VERSION
+    )
     assert result["closed_loop_complete"] is True
     assert result["qualification_passed"] is True
     assert result["automatic_release_promotion_allowed"] is False
-    assert result["entry"]["equivalent"] is True
-    assert result["postcondition"]["equivalent"] is True
-    assert transitions == ["guided_default", "full_detail"]
+    assert result["entry"]["next_action"] == "connect_if_needed"
+    assert (
+        result["healthy_postcondition"]["next_action"] == "continue_validation"
+    )
+    assert result["repair_calibration"]["next_action"] == "repair_projection"
+    assert transitions == 1
     encoded = json.dumps(result, sort_keys=True)
-    assert "Detailed diagnostic material" not in encoded
+    assert "arm" not in encoded
     assert "onboarding_connection_validation" not in encoded
     assert "$PROJECT" not in encoded
 
 
-def test_pair_rejects_missing_candidate_commands_before_provider_or_transition() -> None:
+def test_independent_oracle_rejects_command_loss_before_model_or_transition() -> None:
     calls = 0
-    candidate = _entry_packet(compact=True)
-    del candidate["commands"]["goal_start_host_loop_activation"]
+    transitions = 0
+    packet = _actual_entry_packet()
+    del packet["command_pack"]["commands"]["goal_start_host_loop_activation"]
+
+    def actor(_: Mapping[str, Any]) -> Mapping[str, Any]:
+        nonlocal calls
+        calls += 1
+        return {}
+
+    def transition() -> Mapping[str, Any]:
+        nonlocal transitions
+        transitions += 1
+        return _healthy_observation()
+
+    with pytest.raises(
+        OnboardingActualBehaviorValidationError,
+        match="connect_route_missing_required_commands",
+    ):
+        run_onboarding_actual_behavior_qualification(
+            packet,
+            qualification_id="onboarding-command-gap-001",
+            actor=actor,
+            transition_runner=transition,
+            repair_observation=_projection_gap_observation(),
+        )
+
+    assert tuple(COMMANDS) == ONBOARDING_REQUIRED_CONNECT_COMMAND_IDS
+    assert calls == 0
+    assert transitions == 0
+
+
+def test_independent_oracle_rejects_host_activation_loss_before_model() -> None:
+    calls = 0
+    packet = _actual_entry_packet()
+    del packet["command_pack"]["host_loop_activation"]
 
     def actor(_: Mapping[str, Any]) -> Mapping[str, Any]:
         nonlocal calls
@@ -147,16 +196,17 @@ def test_pair_rejects_missing_candidate_commands_before_provider_or_transition()
         return {}
 
     with pytest.raises(
-        OnboardingModelBehaviorPairValidationError,
-        match="not semantically equivalent",
+        OnboardingActualBehaviorValidationError,
+        match="connect_route_requires_host_loop_activation",
     ):
-        run_onboarding_closed_loop_pair(
-            _entry_packet(compact=False),
-            candidate,
-            qualification_id="onboarding-command-gap-001",
+        run_onboarding_actual_behavior_qualification(
+            packet,
+            qualification_id="onboarding-activation-gap-001",
             actor=actor,
-            transition_runner=lambda _: _healthy_observation(),
+            transition_runner=_healthy_observation,
+            repair_observation=_projection_gap_observation(),
         )
+
     assert calls == 0
 
 
@@ -169,17 +219,17 @@ def test_entry_source_misalignment_stops_before_allowlisted_transition() -> None
         result["decision"]["next_action"] = "stop"
         return result
 
-    def transition(_: str) -> Mapping[str, Any]:
+    def transition() -> Mapping[str, Any]:
         nonlocal transitions
         transitions += 1
         return _healthy_observation()
 
-    result = run_onboarding_closed_loop_pair(
-        _entry_packet(compact=False),
-        _entry_packet(compact=True),
+    result = run_onboarding_actual_behavior_qualification(
+        _actual_entry_packet(),
         qualification_id="onboarding-stop-before-transition-001",
         actor=wrong_actor,
         transition_runner=transition,
+        repair_observation=_projection_gap_observation(),
     )
 
     assert result["closed_loop_complete"] is False
@@ -188,17 +238,24 @@ def test_entry_source_misalignment_stops_before_allowlisted_transition() -> None
     assert transitions == 0
 
 
-def test_postcondition_builder_calibrates_known_2134_projection_gap() -> None:
-    observation = build_onboarding_postcondition_observation(
-        check_warning_codes=["state_projection_gap"],
-        executable_todo_count=0,
-        selected_action_kind=None,
-        normal_delivery_allowed=False,
-        user_action_required=False,
-        next_action_actionable=True,
+def test_actual_projection_gap_fails_the_healthy_postcondition() -> None:
+    result = run_onboarding_actual_behavior_qualification(
+        _actual_entry_packet(),
+        qualification_id="onboarding-actual-gap-001",
+        actor=_actor,
+        transition_runner=_projection_gap_observation,
+        repair_observation=_projection_gap_observation(),
     )
 
-    contract = onboarding_postcondition_semantic_contract(observation)
+    assert result["closed_loop_complete"] is True
+    assert result["qualification_passed"] is False
+    assert result["failure_code"] == "actual_postcondition_not_healthy"
+
+
+def test_postcondition_builder_calibrates_known_2134_projection_gap() -> None:
+    contract = onboarding_postcondition_semantic_contract(
+        _projection_gap_observation()
+    )
 
     assert contract == {
         "route": "repair_projection",
@@ -211,26 +268,21 @@ def test_postcondition_builder_calibrates_known_2134_projection_gap() -> None:
 
 
 def test_actor_request_rejects_local_paths_and_tool_boundary_changes() -> None:
-    packet = _entry_packet(compact=True)
+    packet = _actual_entry_packet()
     packet["project"] = "/Users/example/private-project"
     with pytest.raises(ValueError, match="local absolute path"):
         build_onboarding_model_behavior_actor_request(
             packet,
             qualification_id="onboarding-private-path-001",
-            arm="guided_default",
             phase="entry",
         )
 
     request = build_onboarding_model_behavior_actor_request(
-        _entry_packet(compact=True),
+        _actual_entry_packet(),
         qualification_id="onboarding-boundary-001",
-        arm="guided_default",
         phase="entry",
     )
     request["sandbox"] = {**request["sandbox"], "tools_enabled": True}
-    from loopx.control_plane.testing.onboarding_model_behavior_qualification import (
-        normalize_onboarding_model_behavior_actor_request,
-    )
 
     with pytest.raises(ValueError, match="canonical no-write contract"):
         normalize_onboarding_model_behavior_actor_request(request)

--- a/tests/control_plane/test_onboarding_model_behavior_qualification.py
+++ b/tests/control_plane/test_onboarding_model_behavior_qualification.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from loopx.control_plane.testing.onboarding_model_behavior_qualification import (
+    ONBOARDING_MODEL_BEHAVIOR_DECISION_SCHEMA_VERSION,
+    ONBOARDING_MODEL_BEHAVIOR_PAIR_SCHEMA_VERSION,
+    ONBOARDING_MODEL_BEHAVIOR_RESULT_SCHEMA_VERSION,
+    OnboardingModelBehaviorPairValidationError,
+    build_onboarding_model_behavior_actor_request,
+    build_onboarding_postcondition_observation,
+    onboarding_entry_semantic_contract,
+    onboarding_postcondition_semantic_contract,
+    run_onboarding_closed_loop_pair,
+)
+
+
+COMMANDS = {
+    "goal_start_connect_if_needed": "cd $PROJECT && loopx bootstrap --project .",
+    "goal_start_refresh_state": "loopx refresh-state --goal-id fixture-goal",
+    "goal_start_host_loop_activation": (
+        "loopx heartbeat-prompt --thin --goal-id fixture-goal"
+    ),
+    "goal_start_quota_should_run": (
+        "loopx quota should-run --goal-id fixture-goal"
+    ),
+}
+ACTIVATION = {
+    "schema_version": "loopx_host_loop_activation_v1",
+    "agent_id": "codex-fixture",
+    "activation_required_after_todo_write": True,
+}
+TRANSACTION = {
+    "schema_version": "loopx_goal_start_transaction_v0",
+    "writes_now": False,
+    "spends_quota_now": False,
+    "ordered_steps": [
+        {"id": "inspect_connection", "kind": "read_only"},
+        {"id": "connect_if_needed", "kind": "conditional_mutation"},
+        {"id": "write_ordered_todos", "kind": "operator_or_agent_actions"},
+        {"id": "activate_host_loop", "kind": "host_loop"},
+        {"id": "quota_guard", "kind": "guard"},
+    ],
+}
+
+
+def _entry_packet(*, compact: bool) -> dict[str, Any]:
+    packet: dict[str, Any] = {
+        "schema_version": "loopx_start_goal_guided_v0",
+        "goal_id": "fixture-goal",
+        "agent_id": "codex-fixture",
+        "guided_transaction": TRANSACTION,
+        "safety_contract": {
+            "writes_registry": False,
+            "writes_state_file": False,
+            "spends_quota": False,
+        },
+    }
+    if compact:
+        packet.update(
+            commands=dict(COMMANDS),
+            host_loop_activation=dict(ACTIVATION),
+        )
+    else:
+        packet["command_pack"] = {
+            "commands": dict(COMMANDS),
+            "host_loop_activation": dict(ACTIVATION),
+            "message": "Detailed diagnostic material stays in the cold path.",
+        }
+    return packet
+
+
+def _decision_for_request(request: Mapping[str, Any]) -> dict[str, Any]:
+    phase = str(request["phase"])
+    if phase == "entry":
+        contract = onboarding_entry_semantic_contract(request["packet"])
+    else:
+        contract = onboarding_postcondition_semantic_contract(request["packet"])
+    return {
+        "schema_version": ONBOARDING_MODEL_BEHAVIOR_DECISION_SCHEMA_VERSION,
+        "phase": phase,
+        "next_action": contract["route"],
+        "semantic_contract": contract,
+        "reason_codes": ["source_aligned"],
+    }
+
+
+def _actor(request: Mapping[str, Any]) -> dict[str, Any]:
+    assert request["sandbox"]["tools_enabled"] is False
+    assert request["sandbox"]["filesystem_writes_allowed"] is False
+    return {
+        "schema_version": ONBOARDING_MODEL_BEHAVIOR_RESULT_SCHEMA_VERSION,
+        "actor_ref": "fixture-model-v1",
+        "decision": _decision_for_request(request),
+        "tool_calls": [],
+    }
+
+
+def _healthy_observation() -> dict[str, Any]:
+    return build_onboarding_postcondition_observation(
+        check_warning_codes=[],
+        executable_todo_count=1,
+        selected_action_kind="onboarding_connection_validation",
+        normal_delivery_allowed=True,
+        user_action_required=False,
+        next_action_actionable=True,
+    )
+
+
+def test_closed_loop_pair_checks_entry_and_2134_postcondition_without_raw_retention() -> None:
+    transitions: list[str] = []
+
+    result = run_onboarding_closed_loop_pair(
+        _entry_packet(compact=False),
+        _entry_packet(compact=True),
+        qualification_id="onboarding-2134-healthy-001",
+        actor=_actor,
+        transition_runner=lambda arm: transitions.append(arm) or _healthy_observation(),
+        arm_order=("guided_default", "full_detail"),
+    )
+
+    assert result["schema_version"] == ONBOARDING_MODEL_BEHAVIOR_PAIR_SCHEMA_VERSION
+    assert result["closed_loop_complete"] is True
+    assert result["qualification_passed"] is True
+    assert result["automatic_release_promotion_allowed"] is False
+    assert result["entry"]["equivalent"] is True
+    assert result["postcondition"]["equivalent"] is True
+    assert transitions == ["guided_default", "full_detail"]
+    encoded = json.dumps(result, sort_keys=True)
+    assert "Detailed diagnostic material" not in encoded
+    assert "onboarding_connection_validation" not in encoded
+    assert "$PROJECT" not in encoded
+
+
+def test_pair_rejects_missing_candidate_commands_before_provider_or_transition() -> None:
+    calls = 0
+    candidate = _entry_packet(compact=True)
+    del candidate["commands"]["goal_start_host_loop_activation"]
+
+    def actor(_: Mapping[str, Any]) -> Mapping[str, Any]:
+        nonlocal calls
+        calls += 1
+        return {}
+
+    with pytest.raises(
+        OnboardingModelBehaviorPairValidationError,
+        match="not semantically equivalent",
+    ):
+        run_onboarding_closed_loop_pair(
+            _entry_packet(compact=False),
+            candidate,
+            qualification_id="onboarding-command-gap-001",
+            actor=actor,
+            transition_runner=lambda _: _healthy_observation(),
+        )
+    assert calls == 0
+
+
+def test_entry_source_misalignment_stops_before_allowlisted_transition() -> None:
+    transitions = 0
+
+    def wrong_actor(request: Mapping[str, Any]) -> Mapping[str, Any]:
+        result = _actor(request)
+        result["decision"] = dict(result["decision"])
+        result["decision"]["next_action"] = "stop"
+        return result
+
+    def transition(_: str) -> Mapping[str, Any]:
+        nonlocal transitions
+        transitions += 1
+        return _healthy_observation()
+
+    result = run_onboarding_closed_loop_pair(
+        _entry_packet(compact=False),
+        _entry_packet(compact=True),
+        qualification_id="onboarding-stop-before-transition-001",
+        actor=wrong_actor,
+        transition_runner=transition,
+    )
+
+    assert result["closed_loop_complete"] is False
+    assert result["qualification_passed"] is False
+    assert result["failure_code"] == "entry_source_alignment_failed"
+    assert transitions == 0
+
+
+def test_postcondition_builder_calibrates_known_2134_projection_gap() -> None:
+    observation = build_onboarding_postcondition_observation(
+        check_warning_codes=["state_projection_gap"],
+        executable_todo_count=0,
+        selected_action_kind=None,
+        normal_delivery_allowed=False,
+        user_action_required=False,
+        next_action_actionable=True,
+    )
+
+    contract = onboarding_postcondition_semantic_contract(observation)
+
+    assert contract == {
+        "route": "repair_projection",
+        "state_projection_gap": True,
+        "executable_todo_present": False,
+        "selected_action_kind": None,
+        "normal_delivery_allowed": False,
+        "user_action_required": False,
+    }
+
+
+def test_actor_request_rejects_local_paths_and_tool_boundary_changes() -> None:
+    packet = _entry_packet(compact=True)
+    packet["project"] = "/Users/example/private-project"
+    with pytest.raises(ValueError, match="local absolute path"):
+        build_onboarding_model_behavior_actor_request(
+            packet,
+            qualification_id="onboarding-private-path-001",
+            arm="guided_default",
+            phase="entry",
+        )
+
+    request = build_onboarding_model_behavior_actor_request(
+        _entry_packet(compact=True),
+        qualification_id="onboarding-boundary-001",
+        arm="guided_default",
+        phase="entry",
+    )
+    request["sandbox"] = {**request["sandbox"], "tools_enabled": True}
+    from loopx.control_plane.testing.onboarding_model_behavior_qualification import (
+        normalize_onboarding_model_behavior_actor_request,
+    )
+
+    with pytest.raises(ValueError, match="canonical no-write contract"):
+        normalize_onboarding_model_behavior_actor_request(request)


### PR DESCRIPTION
## Summary
- qualify the currently shipped default `start-goal --guided` behavior as one durable arm
- validate stable onboarding invariants before any provider call, independently from packet-derived source alignment
- run one caller-owned allowlisted transition, then check the healthy postcondition and the known-bad #2134 repair calibration
- add a direct no-tool Doubao 2.1 actor while keeping live calls outside ordinary CI

## Why one arm
The earlier revision permanently paired `full_detail` and `guided_default`. That would fossilize a retired output shape as a product contract. The merged qualification now follows only the actual default behavior. A sensitive behavior-changing PR may still run base/candidate differential evidence locally, but that comparison is not a merged API, fixture, or permanent test arm.

The independent oracle prevents implementation and test expectations from changing incorrectly together. Before model invocation it requires:
- goal and agent identity on the connect route
- canonical connect, refresh, host-activation, and quota commands
- no write and no quota spend during guided preview
- host-loop activation only after todo writeback

## Relation to #2134
PR #2161/#2162 repaired the runtime projection gap, and PR #2167 made the lifecycle smoke catalog-selectable. This PR adds the slower behavioral layer:
1. model selects `connect_if_needed` from the actual default packet;
2. a caller-owned runner executes real isolated `connect -> read-only-map -> check -> quota/todo` behavior;
3. model selects `continue_validation` for the resulting executable onboarding todo;
4. model selects `repair_projection` for the #2134 calibration state with actionable Next Action but no executable todo.

The model never supplies an executable command.

## Dual-arm audit
Repository-wide review found no other obsolete permanent pair to remove:
- generic packet base/candidate qualification remains a reusable differential and ablation tool; it constructs candidates at run time and does not retain a retired default packet;
- release outcome baseline needs stable-release/candidate pairing to detect regressions;
- Explore and benchmark arms are the experiment and attribution model itself.

The onboarding `full_detail/guided_default` pair was the only pair that encoded a retired output form as a durable behavior contract, and it is removed here.

## Validation
- 40 focused onboarding, model-behavior, corpus, Doubao-adapter, and release-baseline tests passed
- Ruff and Python compile passed
- `loopx canary premerge --from-git-diff`: 17/17 checks passed, no manual holds
- public/private boundary scan passed for all six changed files
- diff hygiene passed

## Doubao 2.1 live qualification
Model: `doubao-seed-2-1-pro-260628`.

Two repetitions, three calls each, using the actual current `start-goal --guided` output and a real isolated transition:
- entry: `connect_if_needed`
- healthy postcondition: `continue_validation`
- #2134 calibration: `repair_projection`

Total: 6 provider calls; both repetitions passed with zero semantic or safety violations.

No raw prompts, packets, model responses, credentials, local paths, generated logs, or transition workspaces are committed or retained. The receipt always sets `automatic_release_promotion_allowed=false`.

## Merge decision
Owner explicitly authorized completing and self-merging this closed-loop mechanism after the one-arm correction and validation.
