### PR TITLE
Fix LoopX Turn host result contracts

### DIFF
--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -317,6 +317,8 @@ def handle_turn_command(
             selected_todo = action.get("selected_todo") if isinstance(action.get("selected_todo"), dict) else {}
 
             def writeback(result: dict[str, object]) -> dict[str, object]:
+                # The host workspace is execution context, not state authority.
+                state_project = None
                 result_kind = str(result.get("result_kind") or "")
                 if result_kind in {"repair_required", "replan_required"}:
                     todo_id = str(selected_todo.get("todo_id") or "")
@@ -330,14 +332,14 @@ def handle_turn_command(
                         note=str(result.get("summary") or result["classification"]),
                         evidence=f"LoopX Turn {result_kind}: {result['next_action']}",
                         agent_id=args.agent_id,
-                        project=project,
+                        project=state_project,
                         dry_run=False,
                     )
                 return refresh_state_run(
                     registry_path=registry_path,
                     runtime_root_override=runtime_root_arg,
                     goal_id=args.goal_id,
-                    project=project,
+                    project=state_project,
                     state_file=None,
                     classification=str(result["classification"]),
                     recommended_action=str(result["recommended_action"]),

--- a/loopx/control_plane/turn_driver/codex_cli.py
+++ b/loopx/control_plane/turn_driver/codex_cli.py
@@ -15,7 +15,11 @@ from pathlib import Path
 from typing import Any
 
 from ...runtime import validate_goal_id_path_segment
-from .executor import BuiltInHostError, LOOPX_TURN_HOST_REQUEST_SCHEMA_VERSION
+from .executor import (
+    HOST_RESULT_TEXT_LIMITS,
+    BuiltInHostError,
+    LOOPX_TURN_HOST_REQUEST_SCHEMA_VERSION,
+)
 from .transaction import LOOPX_TURN_RESULT_SCHEMA_VERSION, TRANSACTION_PHASES
 
 
@@ -153,6 +157,7 @@ def _store_codex_cli_session(
 
 
 def codex_cli_result_schema() -> dict[str, Any]:
+    text_limits = dict(HOST_RESULT_TEXT_LIMITS)
     properties: dict[str, Any] = {
         "schema_version": {
             "type": "string",
@@ -166,9 +171,18 @@ def codex_cli_result_schema() -> dict[str, Any]:
             "minItems": 2,
             "maxItems": 2,
         },
-        "classification": {"type": "string"},
-        "recommended_action": {"type": "string"},
-        "next_action": {"type": "string"},
+        "classification": {
+            "type": "string",
+            "maxLength": text_limits["classification"],
+        },
+        "recommended_action": {
+            "type": "string",
+            "maxLength": text_limits["recommended_action"],
+        },
+        "next_action": {
+            "type": "string",
+            "maxLength": text_limits["next_action"],
+        },
         "delivery_batch_scale": {
             "type": "string",
             "enum": [
@@ -189,8 +203,11 @@ def codex_cli_result_schema() -> dict[str, Any]:
                 "primary_goal_outcome",
             ],
         },
-        "vision_unchanged_reason": {"type": "string"},
-        "summary": {"type": "string"},
+        "vision_unchanged_reason": {
+            "type": "string",
+            "maxLength": text_limits["vision_unchanged_reason"],
+        },
+        "summary": {"type": "string", "maxLength": text_limits["summary"]},
     }
     return {
         "type": "object",

--- a/loopx/control_plane/turn_driver/executor.py
+++ b/loopx/control_plane/turn_driver/executor.py
@@ -29,6 +29,13 @@ LOOPX_TURN_JOURNAL_SCHEMA_VERSION = "loopx_turn_journal_v0"
 HOST_RESULT_MAX_BYTES = 12_000
 HOST_ARG_MAX_COUNT = 32
 HOST_ARG_MAX_CHARS = 1_024
+HOST_RESULT_TEXT_LIMITS = (
+    ("classification", 120),
+    ("recommended_action", 1_200),
+    ("next_action", 1_200),
+    ("vision_unchanged_reason", 240),
+    ("summary", 400),
+)
 TURN_KEY_RE = re.compile(r"^sha256:(?P<digest>[0-9a-f]{64})$")
 
 MATERIAL_HOST_RESULT_KINDS = {
@@ -166,13 +173,7 @@ def validate_loopx_turn_host_result(
         "result_kind": kind.value if kind else None,
         "completed_phases": list(TRANSACTION_PHASES[:2]),
     }
-    for field, limit in (
-        ("classification", 120),
-        ("recommended_action", 1_200),
-        ("next_action", 1_200),
-        ("vision_unchanged_reason", 240),
-        ("summary", 400),
-    ):
+    for field, limit in HOST_RESULT_TEXT_LIMITS:
         text = _bounded_public_text(
             result,
             field,

--- a/tests/test_loopx_turn_codex_cli.py
+++ b/tests/test_loopx_turn_codex_cli.py
@@ -101,6 +101,22 @@ def test_codex_cli_result_schema_requires_only_bounded_contract_fields() -> None
     assert set(schema["required"]) == set(schema["properties"])
     assert "raw_trajectory" not in schema["properties"]
     assert "stdout" not in schema["properties"]
+    assert {
+        field: schema["properties"][field]["maxLength"]
+        for field in (
+            "classification",
+            "recommended_action",
+            "next_action",
+            "vision_unchanged_reason",
+            "summary",
+        )
+    } == {
+        "classification": 120,
+        "recommended_action": 1_200,
+        "next_action": 1_200,
+        "vision_unchanged_reason": 240,
+        "summary": 400,
+    }
 
 
 def test_codex_cli_host_starts_then_resumes_opaque_session(

--- a/tests/test_loopx_turn_driver.py
+++ b/tests/test_loopx_turn_driver.py
@@ -455,6 +455,8 @@ def test_turn_run_once_cli_commits_validated_result_and_one_quota_slot(
     tmp_path: Path,
 ) -> None:
     project, runtime, registry = _write_live_fixture(tmp_path)
+    host_project = tmp_path / "isolated-host-workspace"
+    host_project.mkdir()
     host_script = """
 import json
 import sys
@@ -491,7 +493,7 @@ json.dump({
                 "--agent-id",
                 "codex-fixture",
                 "--project",
-                str(project),
+                str(host_project),
                 "--host-command-json",
                 json.dumps([sys.executable, "-c", host_script]),
                 "--scan-root",
@@ -545,7 +547,7 @@ json.dump({
                 "--agent-id",
                 "codex-fixture",
                 "--project",
-                str(project),
+                str(host_project),
                 "--host-command-json",
                 json.dumps([sys.executable, "-c", host_script]),
                 "--scan-root",


### PR DESCRIPTION
## Summary

- keep the Codex CLI output schema aligned with the runtime text limits, so oversized fields are constrained before host execution returns
- treat `--project` as the host execution workspace while resolving LoopX state writes from the registry-authoritative project
- cover both contracts with focused regression tests

## Issue Or Task

- Contributor task ID: `todo_803a4cdf81a1` prerequisite discovered by LoopX Turn SkillsBench dogfood

## Validation

- [x] 69 focused LoopX Turn tests
- [x] Ruff on all five changed Python files
- [x] Python compile checks on all five changed files
- [x] `loopx canary premerge --from-git-diff --tier standard`: 4 direct checks and 12 selected smokes passed
- [x] `loopx check` public boundary scan: 5 changed files clean; one unrelated pre-existing OpenViking index warning

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked task.

## Review Hold

This PR repairs two deterministic failures found by the real CLI dogfood, but it does not claim successful task validation. A typed host result can still make an unsupported completion claim. Follow-up `todo_803a4cdf81a1` adds the independent task/artifact postcondition validator required before material state writeback or quota spend. This PR is intentionally left for owner review rather than self-merged.
