### PR TITLE
Fix LoopX Turn session recovery eligibility

### DIFF
--- a/docs/reference/protocols/loopx-turn-v0.md
+++ b/docs/reference/protocols/loopx-turn-v0.md
@@ -78,6 +78,69 @@ Turn request/result objects and that CLI's prompt, session, and output model.
 Raw transcript text, process exit zero, and the host's own completion claim are
 never sufficient validation.
 
+### Five Questions For Any Agent CLI
+
+Before wiring Trae CLI, Codex CLI, or another host, answer these five questions:
+
+1. **How does it run unattended?** Choose an explicit non-interactive command
+   and workspace. If the CLI is interactive-only, it is not an
+   `isolated-headless` adapter yet.
+2. **How does it return one typed result?** Prefer a native output schema or a
+   dedicated result file. Do not scrape arbitrary conversation text as the
+   completion contract.
+3. **What is its resume handle?** Keep the opaque handle in local adapter
+   state, keyed by `(goal_id, agent_id, todo_id)`. Never put it in LoopX state
+   or public evidence.
+4. **Which failures may resume?** A bounded timeout or lost transport may
+   preserve an observed session. A rejected startup contract, incompatible
+   host version, or missing session invalidates it so the next Turn starts
+   cleanly.
+5. **What proves the work independently?** Name a command that checks the real
+   repository, artifact, service readback, document revision, or other
+   postcondition without trusting the agent CLI's own claim.
+
+This yields one reusable integration shape:
+
+```text
+TurnEnvelope
+    -> host adapter -> agent CLI -> typed candidate result
+    -> independent validator -> pass | repair | replan
+    -> LoopX writeback -> one durable transition and one quota spend
+```
+
+A thin adapter can be implemented with this host-neutral algorithm:
+
+```text
+request = read_one_json(stdin)
+todo = request.turn_envelope.action.selected_todo
+session = load_local_session(goal_id, agent_id, todo.todo_id)
+prompt = render_bounded_prompt(todo, request.result_contract, temporary_result_path)
+invoke_agent_cli(prompt, workspace, session, explicit_timeout)
+candidate = read_and_shape_temporary_result(temporary_result_path)
+write_one_json(stdout, candidate with request.turn_key)
+```
+
+`render_bounded_prompt` should tell the agent CLI to work only on the selected
+todo and write its candidate result to a dedicated temporary path. The adapter
+must reject a missing or malformed result instead of guessing from prose. It may
+discard raw conversation output after extracting the host's opaque session
+handle. LoopX then passes the candidate to a separate validator; the adapter
+does not call the work complete itself.
+
+For a CLI with native structured output and resume support, the adapter is
+mostly field mapping. For a CLI such as a Trae installation whose selected
+command only returns conversational text, the wrapper must first establish a
+dedicated typed result channel; passing `trae chat` directly as the adapter is
+not sufficient. Check the installed CLI's help and pin the qualified command
+shape because flags and headless behavior may vary by version.
+
+For a coding collaboration, the validator may run focused tests and inspect the
+expected git diff. For operations, it may read back the declared resource
+state. For data work, it may check a schema and bounded quality assertions. For
+documents or knowledge maintenance, it may verify the target revision and
+required sections. These are different validators over the same Turn
+orchestration contract; they do not require different control loops.
+
 ## Authority Boundary
 
 | Concern | Authority |
@@ -109,9 +172,10 @@ One driver tick has exactly these ordered phases:
 4. **Prepare**: preserve the selected todo identity, claim or lease when the
    contract requires it, and satisfy the workspace guard before any repository
    write.
-5. **Execute**: resume the declared host session when possible, or create a new
-   session only when the execution mode permits it. Give the host the thin task
-   body plus the current envelope, and request one bounded work segment.
+5. **Execute**: resume the declared host session only when the adapter marked
+   it eligible, or create a new session when the execution mode permits it.
+   Give the host the thin task body plus the current envelope, and request one
+   bounded work segment.
 6. **Validate**: classify the host result and validate the claimed artifact or
    state transition. Host process exit zero is not validation.
 7. **Write back**: update or complete the current todo, create a repair or
@@ -218,6 +282,20 @@ state with a concrete projected action.
 | `validation_failed` | Preserve compact negative evidence and choose repair or replan. |
 | `writeback_failed` | Retry idempotent writeback; never spend first. |
 | `scheduler_apply_failed` | Preserve completed writeback, record cadence failure, and retry scheduler control without a delivery spend. |
+
+Session recovery is fail-closed:
+
+| Host observation | Session disposition | Next Turn |
+| --- | --- | --- |
+| Typed result returned | Keep the opaque session eligible. | Resume when the same todo remains selected. |
+| Timeout or transport loss after a session was observed | Keep it eligible, but do not infer progress. | Retry the side-effect-safe host phase. |
+| Incompatible host version or rejected startup/output contract | Invalidate it. | Start a fresh session after repair. |
+| Host reports the session is missing | Invalidate it. | Start a fresh session if policy still allows execution. |
+| Failure before any session was observed | Store nothing. | Re-decide, then start fresh only if allowed. |
+
+Session eligibility is recovery metadata, not evidence that work happened. It
+never bypasses a fresh Turn decision, task lease, independent validation, or
+writeback ordering.
 
 ## Adapter Requirements
 

--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -86,7 +86,9 @@ def register_turn_commands(
             "A Trae, Codex, or other conversational CLI normally needs a thin "
             "adapter: read one typed request from stdin and emit one typed result "
             "to stdout. The validation command receives that normalized result "
-            "on stdin and must independently check the real postcondition."
+            "on stdin and must independently check the real postcondition. Only "
+            "eligible interrupted sessions resume; terminal startup or missing-session "
+            "failures start a fresh host session on the next Turn."
         ),
     )
     add_subcommand_format(run_once)

--- a/loopx/control_plane/turn_driver/codex_cli.py
+++ b/loopx/control_plane/turn_driver/codex_cli.py
@@ -23,7 +23,7 @@ from .executor import (
 from .transaction import LOOPX_TURN_RESULT_SCHEMA_VERSION, TRANSACTION_PHASES
 
 
-CODEX_CLI_SESSION_SCHEMA_VERSION = "loopx_codex_cli_session_v0"
+CODEX_CLI_SESSION_SCHEMA_VERSION = "loopx_codex_cli_session_v1"
 CODEX_CLI_RESULT_KINDS = (
     "validated_progress",
     "repair_required",
@@ -33,6 +33,13 @@ CODEX_CLI_RESULT_KINDS = (
 )
 CODEX_CLI_SANDBOXES = ("read-only", "workspace-write")
 SESSION_ID_MAX_CHARS = 256
+SESSION_INVALIDATING_FAILURE_CATEGORIES = frozenset(
+    {
+        "model_requires_newer_codex",
+        "output_schema_rejected",
+        "session_missing",
+    }
+)
 
 
 def _mapping(value: Any) -> dict[str, Any]:
@@ -154,6 +161,14 @@ def _store_codex_cli_session(
         path.chmod(0o600)
     finally:
         temporary.unlink(missing_ok=True)
+
+
+def _discard_codex_cli_session(
+    runtime_root: Path,
+    *,
+    lineage: Mapping[str, str],
+) -> None:
+    _session_path(runtime_root, lineage).unlink(missing_ok=True)
 
 
 def codex_cli_result_schema() -> dict[str, Any]:
@@ -417,24 +432,37 @@ def run_codex_cli_host(
         reader.start()
         stderr_reader.start()
         assert proc.stdin is not None
+        timed_out = False
         try:
             proc.stdin.write(_prompt(request))
             proc.stdin.close()
             returncode = proc.wait(timeout=max(1.0, timeout_seconds))
-        except subprocess.TimeoutExpired as exc:
+        except subprocess.TimeoutExpired:
             _terminate_process(proc)
-            raise BuiltInHostError("codex_cli_timeout") from exc
+            timed_out = True
+            returncode = proc.returncode
         finally:
             reader.join(timeout=2)
             stderr_reader.join(timeout=2)
+        if timed_out:
+            if observed_session:
+                _store_codex_cli_session(
+                    runtime_root,
+                    lineage=lineage,
+                    session_id=observed_session[0],
+                )
+            raise BuiltInHostError("codex_cli_timeout")
+        category = failure_categories[0] if failure_categories else "exit_nonzero"
+        if returncode != 0 and category in SESSION_INVALIDATING_FAILURE_CATEGORIES:
+            _discard_codex_cli_session(runtime_root, lineage=lineage)
         if observed_session:
-            _store_codex_cli_session(
-                runtime_root,
-                lineage=lineage,
-                session_id=observed_session[0],
-            )
+            if returncode == 0 or category not in SESSION_INVALIDATING_FAILURE_CATEGORIES:
+                _store_codex_cli_session(
+                    runtime_root,
+                    lineage=lineage,
+                    session_id=observed_session[0],
+                )
         if returncode != 0:
-            category = failure_categories[0] if failure_categories else "exit_nonzero"
             raise BuiltInHostError(f"codex_cli_{category}")
         try:
             result = json.loads(output_path.read_text(encoding="utf-8"))

--- a/tests/test_loopx_turn_codex_cli.py
+++ b/tests/test_loopx_turn_codex_cli.py
@@ -56,6 +56,7 @@ import os
 import pathlib
 import re
 import sys
+import time
 
 args = sys.argv[1:]
 prompt = sys.stdin.read()
@@ -72,7 +73,11 @@ print(json.dumps({
 if os.environ.get("FAKE_CODEX_FAIL") == "1":
     if os.environ.get("FAKE_CODEX_FAILURE_CATEGORY") == "model":
         print("This model requires a newer version of Codex.", file=sys.stderr)
+    if os.environ.get("FAKE_CODEX_FAILURE_CATEGORY") == "session":
+        print("Session not found.", file=sys.stderr)
     raise SystemExit(9)
+if os.environ.get("FAKE_CODEX_SLEEP"):
+    time.sleep(float(os.environ["FAKE_CODEX_SLEEP"]))
 output_path = pathlib.Path(args[args.index("--output-last-message") + 1])
 output_path.write_text(json.dumps({
     "schema_version": "loopx_turn_result_v0",
@@ -195,6 +200,33 @@ def test_codex_cli_host_starts_then_resumes_opaque_session(
     assert "private_material" not in persisted
 
 
+def test_codex_cli_host_ignores_legacy_session_eligibility(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable, log_path = _fake_codex(tmp_path)
+    monkeypatch.setenv("FAKE_CODEX_LOG", str(log_path))
+    runtime_root = tmp_path / "runtime"
+    project = tmp_path / "project"
+    project.mkdir()
+    request = _request()
+    run_codex_cli_host(
+        request,
+        runtime_root=runtime_root,
+        project=project,
+        codex_bin=str(executable),
+        timeout_seconds=5,
+    )
+    session_path = next(runtime_root.glob("goals/*/turn-sessions/*.json"))
+    legacy = json.loads(session_path.read_text(encoding="utf-8"))
+    legacy["schema_version"] = "loopx_codex_cli_session_v0"
+    session_path.write_text(json.dumps(legacy), encoding="utf-8")
+
+    envelope = request["turn_envelope"]
+    assert isinstance(envelope, dict)
+    assert codex_cli_session_binding(runtime_root, envelope) is None
+
+
 def test_codex_cli_host_preserves_session_after_failed_turn(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -214,6 +246,32 @@ def test_codex_cli_host_preserves_session_after_failed_turn(
             project=project,
             codex_bin=str(executable),
             timeout_seconds=5,
+        )
+
+    envelope = request["turn_envelope"]
+    assert isinstance(envelope, dict)
+    assert codex_cli_session_binding(runtime_root, envelope) is not None
+
+
+def test_codex_cli_host_preserves_observed_session_after_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable, log_path = _fake_codex(tmp_path)
+    monkeypatch.setenv("FAKE_CODEX_LOG", str(log_path))
+    monkeypatch.setenv("FAKE_CODEX_SLEEP", "2")
+    runtime_root = tmp_path / "runtime"
+    project = tmp_path / "project"
+    project.mkdir()
+    request = _request()
+
+    with pytest.raises(RuntimeError, match="codex_cli_timeout"):
+        run_codex_cli_host(
+            request,
+            runtime_root=runtime_root,
+            project=project,
+            codex_bin=str(executable),
+            timeout_seconds=0.1,
         )
 
     envelope = request["turn_envelope"]
@@ -249,3 +307,58 @@ def test_codex_cli_host_classifies_failure_without_persisting_stderr(
         path.read_text(encoding="utf-8") for path in runtime_root.rglob("*.json")
     )
     assert "requires a newer version" not in persisted
+    envelope = _request()["turn_envelope"]
+    assert isinstance(envelope, dict)
+    assert codex_cli_session_binding(runtime_root, envelope) is None
+
+    monkeypatch.delenv("FAKE_CODEX_FAIL")
+    monkeypatch.delenv("FAKE_CODEX_FAILURE_CATEGORY")
+    recovered = run_codex_cli_host(
+        _request(turn_key="sha256:" + "d" * 64),
+        runtime_root=runtime_root,
+        project=project,
+        codex_bin=str(executable),
+        timeout_seconds=5,
+    )
+    assert recovered["result_kind"] == "validated_progress"
+    argv_rows = [
+        json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert "resume" not in argv_rows[1]
+
+
+def test_codex_cli_host_discards_missing_resume_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable, log_path = _fake_codex(tmp_path)
+    monkeypatch.setenv("FAKE_CODEX_LOG", str(log_path))
+    runtime_root = tmp_path / "runtime"
+    project = tmp_path / "project"
+    project.mkdir()
+    first_request = _request()
+    run_codex_cli_host(
+        first_request,
+        runtime_root=runtime_root,
+        project=project,
+        codex_bin=str(executable),
+        timeout_seconds=5,
+    )
+
+    monkeypatch.setenv("FAKE_CODEX_FAIL", "1")
+    monkeypatch.setenv("FAKE_CODEX_FAILURE_CATEGORY", "session")
+    with pytest.raises(RuntimeError, match="codex_cli_session_missing"):
+        run_codex_cli_host(
+            _request(
+                turn_key="sha256:" + "f" * 64,
+                session_action="resume",
+            ),
+            runtime_root=runtime_root,
+            project=project,
+            codex_bin=str(executable),
+            timeout_seconds=5,
+        )
+
+    envelope = first_request["turn_envelope"]
+    assert isinstance(envelope, dict)
+    assert codex_cli_session_binding(runtime_root, envelope) is None


### PR DESCRIPTION
## Summary
- preserve observed Codex sessions across bounded timeouts and generic resumable failures
- invalidate incompatible-version, rejected-output-contract, and missing-session records; ignore legacy eligibility records
- explain a host-neutral Trae/Codex adapter recipe and fail-closed session recovery

## Validation
- `76 passed` across the focused LoopX Turn pytest set
- ruff and Python compile checks passed
- `loopx check` public-boundary scan passed
- standard `loopx canary premerge --from-git-diff`: 13 selected, 0 failures, 0 manual holds

## Real-host evidence
- current bundled Codex CLI returned a typed result on a fresh minimal lineage
- terminal failed-start lineage no longer becomes eligible to resume
- repository-sized real-host runs remain explicitly bounded and fail closed with no state write or quota spend; long-duration qualification continues after merge