### PR TITLE
Preserve Explore visual styles on config updates

### DIFF
--- a/docs/capabilities/explore/README.md
+++ b/docs/capabilities/explore/README.md
@@ -698,6 +698,12 @@ The renderer (`mermaid` or `stage_svg`) is an implementation detail derived
 from `board_style`. Existing local configs that only store `renderer=mermaid`
 remain readable as `auto_flow`.
 
+On first configuration, omitting `--board-style` defaults the new visual role
+to `auto_flow`. On later calls for the same role, omission preserves the stored
+style and its validated renderer. This makes Docx or Evidence Stage token
+maintenance a patch operation instead of an implicit style reset. Pass an
+explicit `--board-style` only when intentionally switching the layout.
+
 A material sync checkpoints `canonical_rows_semantic_digest`
 and `visual_semantic_digest` independently. If whiteboard publication fails
 after Base rows succeed, the next run retries only the visual sink instead of

--- a/examples/explore-result-layer-smoke.py
+++ b/examples/explore-result-layer-smoke.py
@@ -1419,6 +1419,32 @@ def check_cli_surface() -> None:
                 "semantic_lane_columns" if role == "executive" else "auto_flow"
             )
             assert role_config["visual_sink"]["board_style"] == expected_style, role_config
+            expected_renderer = "stage_svg" if role == "executive" else "mermaid"
+            assert role_config["visual_sink"]["renderer"] == expected_renderer, role_config
+
+            updated_role_config = run_cli(
+                "explore",
+                "feishu-visual-configure",
+                "--config-path",
+                str(config_path),
+                "--whiteboard-token",
+                f"wb_{role}_updated_fixture",
+                "--docx-token",
+                f"doc_{role}_updated_fixture",
+                "--stage-whiteboard-token",
+                f"wb_{role}_stage_02_updated_fixture",
+                "--view-role",
+                role,
+                "--projection-mode",
+                mode,
+                "--execute",
+            )
+            assert updated_role_config["visual_sink"]["board_style"] == expected_style, (
+                updated_role_config
+            )
+            assert updated_role_config["visual_sink"]["renderer"] == expected_renderer, (
+                updated_role_config
+            )
         dual_config_sync = run_cli(
             "explore",
             "feishu-sync",

--- a/loopx/cli_commands/explore.py
+++ b/loopx/cli_commands/explore.py
@@ -262,11 +262,11 @@ def register_explore_commands(
     visual.add_argument(
         "--board-style",
         choices=["auto_flow", "semantic_lane_columns"],
-        default="auto_flow",
         help=(
             "Whiteboard layout style. auto_flow uses Mermaid's generic graph "
             "layout; semantic_lane_columns fixes semantic lanes into "
-            "left/right columns while retaining real directed edges."
+            "left/right columns while retaining real directed edges. Omit to "
+            "preserve an existing role's style; new roles default to auto_flow."
         ),
     )
     visual.add_argument(

--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -60,10 +60,9 @@ from .kanban import (
 from .explore_stage_document import ensure_stage_whiteboards
 from .explore_singleflight import singleflight_issue_fix_material_sync
 from .explore_visual_styles import (
-    BOARD_STYLE_AUTO_FLOW,
     board_source_with_delivery_marker,
-    explore_board_style,
     resolve_explore_board_style,
+    resolve_explore_board_style_update,
     summarize_explore_visual_sync,
 )
 from .explore_visual_readback import (
@@ -486,7 +485,7 @@ def configure_lark_explore_visual_sink(
     mermaid_node_limit: int = 100,
     stage_capacity: int = 14,
     stage_whiteboard_tokens: list[str] | None = None,
-    board_style: str = BOARD_STYLE_AUTO_FLOW,
+    board_style: str | None = None,
     view_role: str | None = None,
     execute: bool = False,
 ) -> dict[str, Any]:
@@ -512,7 +511,19 @@ def configure_lark_explore_visual_sink(
         raise ValueError(f"view_role {role} requires projection_mode {expected_mode}")
     if not 10 <= int(stage_capacity) <= 20:
         raise ValueError("stage_capacity must be between 10 and 20")
-    style = explore_board_style(board_style)
+    local = read_lark_explore_local_config(config_path)
+    if not local.get("ok") or not local.get("exists"):
+        raise ValueError("run `loopx explore feishu-setup` before configuring a visual sink")
+    visual_sinks = local.get("visual_sinks")
+    existing_sink = (
+        visual_sinks.get(role)
+        if role and isinstance(visual_sinks, Mapping)
+        else local.get("visual_sink") if not role else None
+    )
+    style = resolve_explore_board_style_update(
+        board_style,
+        existing_sink if isinstance(existing_sink, Mapping) else {},
+    )
     tokens = [
         str(item).strip()
         for item in stage_whiteboard_tokens or []
@@ -522,9 +533,6 @@ def configure_lark_explore_visual_sink(
         tokens = [token]
     elif token and token not in tokens:
         tokens.insert(0, token)
-    local = read_lark_explore_local_config(config_path)
-    if not local.get("ok") or not local.get("exists"):
-        raise ValueError("run `loopx explore feishu-setup` before configuring a visual sink")
     visual_sink = {
         "schema_version": "loopx_lark_explore_visual_sink_config_v0",
         "whiteboard_token": token or None,

--- a/loopx/presentation/sinks/lark/explore_visual_styles.py
+++ b/loopx/presentation/sinks/lark/explore_visual_styles.py
@@ -72,6 +72,19 @@ def resolve_explore_board_style(
     return _RENDERER_BOARD_STYLES[renderer]
 
 
+def resolve_explore_board_style_update(
+    requested_style: str | None,
+    existing_sink: Mapping[str, Any],
+) -> ExploreBoardStyle:
+    """Preserve an existing style when a config update omits the parameter."""
+
+    if requested_style is not None:
+        return explore_board_style(requested_style)
+    if existing_sink:
+        return resolve_explore_board_style(existing_sink)
+    return explore_board_style(BOARD_STYLE_AUTO_FLOW)
+
+
 def summarize_explore_visual_sync(
     *,
     views: Mapping[str, Mapping[str, Any]],

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -609,6 +609,69 @@ def test_visual_configuration_preserves_legacy_and_supports_stage_boards(
     ]
 
 
+def test_visual_configuration_preserves_existing_style_when_omitted(tmp_path) -> None:
+    config_path = tmp_path / "lark-explore.json"
+    write_lark_explore_local_config(
+        config_path,
+        {
+            "board": {
+                "base_token": "PUBLIC_FIXTURE_BASE",
+                "tables": {"nodes": "tblN", "edges": "tblE", "findings": "tblF"},
+            },
+            "visual_sinks": {
+                "canonical": {
+                    "whiteboard_token": "wb_canonical_fixture",
+                    "view_role": "canonical",
+                    "projection_mode": "canonical_full",
+                    "renderer": "mermaid",
+                }
+            },
+        },
+    )
+    configure_lark_explore_visual_sink(
+        config_path=config_path,
+        whiteboard_token="wb_executive_fixture",
+        projection_mode="executive_auto",
+        view_role="executive",
+        board_style="semantic_lane_columns",
+        execute=True,
+    )
+
+    canonical = configure_lark_explore_visual_sink(
+        config_path=config_path,
+        whiteboard_token="wb_canonical_updated",
+        docx_token="doc_canonical_updated",
+        projection_mode="canonical_full",
+        view_role="canonical",
+        execute=True,
+    )["visual_sink"]
+    executive = configure_lark_explore_visual_sink(
+        config_path=config_path,
+        whiteboard_token="wb_executive_updated",
+        docx_token="doc_executive_updated",
+        projection_mode="executive_auto",
+        view_role="executive",
+        stage_whiteboard_tokens=["wb_executive_updated", "wb_stage_02_updated"],
+        execute=True,
+    )["visual_sink"]
+
+    assert canonical["board_style"] == "auto_flow"
+    assert canonical["renderer"] == "mermaid"
+    assert executive["board_style"] == "semantic_lane_columns"
+    assert executive["renderer"] == "stage_svg"
+
+    changed = configure_lark_explore_visual_sink(
+        config_path=config_path,
+        whiteboard_token="wb_executive_updated",
+        projection_mode="executive_auto",
+        view_role="executive",
+        board_style="auto_flow",
+        execute=True,
+    )["visual_sink"]
+    assert changed["board_style"] == "auto_flow"
+    assert changed["renderer"] == "mermaid"
+
+
 def test_visual_configuration_rejects_out_of_range_stage_capacity(tmp_path) -> None:
     config_path = tmp_path / "lark-explore.json"
     write_lark_explore_local_config(


### PR DESCRIPTION
## Summary
- treat an omitted --board-style as preserve-existing for an already configured visual role
- keep auto_flow as the first-configuration default and preserve renderer validation
- cover canonical and executive Docx/stage-token updates plus legacy renderer-only configs
- document patch-style update semantics

## Validation
- .venv/bin/pytest -q: 435 passed, 2 skipped
- .venv/bin/pytest -q tests/test_explore_presentation_views.py: 35 passed
- .venv/bin/python examples/explore-result-layer-smoke.py
- .venv/bin/ruff check on changed Python files
- python3 -m compileall on changed Python files
- git diff --check
- LoopX public/private scan passed; token hits are public fixture identifiers only

## Boundary
No OpenViking core code, private state, local paths, credentials, generated logs, or uv.lock are included.