### PR TITLE
Fix reviewer notification queue reconciliation

### DIFF
--- a/docs/capabilities/issue-fix/protocols/issue-fix-reviewer-notification-sinks-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-reviewer-notification-sinks-v0.md
@@ -124,7 +124,15 @@ back to that same row. A restart preserves a queued item; a later verified send
 removes the matching queue entry while retaining the stable receipt. Retry
 outside the window returns `already_queued` with the original queue receipt,
 so neither the provider nor local state changes. Retry therefore remains
-idempotent without a second ledger. Goal boundary/status
+idempotent without a second ledger. The live reviewer route is authoritative
+for unsent work: an existing GitHub-covered reviewer may be notified only as
+that same reviewer, never replaced by a different mapped sink identity. Each
+execute reconciliation atomically replaces the PR's unsent queue, cancelling
+stale targets when coverage changes, a review completes, or no current sink
+identity remains. Verified receipts are append-only and are never cancelled by
+this queue replacement. A provider failure before any external write preserves
+the matching current queue entry for retry; an unverified post-write result does
+not requeue and risk a duplicate send. Goal boundary/status
 projections expose only that the capability and pointer are configured; they
 never expose the pointer value or profiles
 (`config_pointer_registered=true`).

--- a/docs/capabilities/issue-fix/protocols/issue-fix-reviewer-request-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-reviewer-request-v0.md
@@ -140,6 +140,8 @@ The packet records:
   private destination, member, or bot-profile fields.
 - whether the sink came from an explicit input or the goal default, and whether
   verified hashed receipts were persisted in existing PR lifecycle state.
+- whether the authoritative execute path reconciled the unsent secondary queue
+  and how many stale entries it cancelled, without exposing destination data.
 
 Successful verified requests emit `issue_fix_reviewer_request_verified` with
 `monitor_continuation`. Confirmed permission denial followed by a verified
@@ -147,7 +149,11 @@ comment emits `issue_fix_reviewer_comment_fallback_verified`. If review is
 already covered by a request, completed review, marked fallback comment, or a
 live comment that explicitly mentions the reviewer and asks for review,
 execution is a quiet, no-write monitor continuation and returns the existing
-comment URL. Semantic comment matching normalizes handle case, requires a
+comment URL. Secondary sinks remain bound to that covered reviewer; an
+unresolved sink identity skips secondary delivery instead of substituting a
+different candidate. Any previously queued, unsent secondary target is
+atomically replaced or cancelled by the current execute reconciliation.
+Semantic comment matching normalizes handle case, requires a
 bounded review-request phrase near the mention, and ignores quoted text, code
 blocks, ordinary discussion, and marker-only metadata. Missing requestable
 identity produces a runnable identity-resolution successor. Closed PRs produce

--- a/examples/issue-fix-reviewer-notification-sink-smoke.py
+++ b/examples/issue-fix-reviewer-notification-sink-smoke.py
@@ -298,6 +298,23 @@ def main() -> int:
     assert queued_retry_runner.calls == []
     assert_public_safe(queued_retry)
 
+    failed_queued_retry_runner = FakeSinkRunner(send_returncode=1)
+    failed_queued_retry = build_issue_fix_reviewer_notification_sinks_result(
+        repo="owner/repo",
+        pr_number=42,
+        pr_url="https://github.com/owner/repo/pull/42",
+        author_handle="@current-author",
+        reviewer_handles=["@service-owner"],
+        sinks_input=queued_retry_config,
+        execute=True,
+        delivery_observed_at="2026-07-10T02:30:00Z",
+        runner=failed_queued_retry_runner,
+    )
+    assert failed_queued_retry["ok"] is False, failed_queued_retry
+    assert failed_queued_retry["external_writes_performed"] is False
+    assert failed_queued_retry["queued_receipts"] == queued["queued_receipts"]
+    assert_public_safe(failed_queued_retry)
+
     inside_window_runner = FakeSinkRunner()
     inside_window = build_issue_fix_reviewer_notification_sinks_result(
         repo="owner/repo",

--- a/examples/issue-fix-reviewer-request-smoke.py
+++ b/examples/issue-fix-reviewer-request-smoke.py
@@ -455,15 +455,37 @@ def main() -> int:
             "@service-owner",
             "@history-owner",
         ], secondary_fallback
-        assert secondary_fallback["secondary_notification_targets"] == [
-            "@history-owner"
-        ]
-        assert secondary_fallback["secondary_notification_fallback_used"] is True
-        assert secondary_fallback["secondary_notification_status"] == "sent_verified"
-        assert secondary_fallback["secondary_notification_verified"] is True
+        assert secondary_fallback["secondary_notification_targets"] == []
+        assert secondary_fallback["secondary_notification_fallback_used"] is False
+        assert secondary_fallback["secondary_notification_status"] == (
+            "skipped_reviewer_unavailable"
+        )
+        assert secondary_fallback["secondary_notification_verified"] is False
         assert fallback_combined.github.edits == 0
-        assert len(fallback_combined.lark_calls) == 3
+        assert fallback_combined.lark_calls == []
         assert_public_safe(secondary_fallback)
+
+        covered_same_runner = FakeCombinedRunner(
+            FakeGitHubRunner(before=metadata(requested=["service-owner"]))
+        )
+        covered_same = build_issue_fix_reviewer_request_packet(
+            repo_path=path,
+            url="https://github.com/owner/repo/pull/42",
+            base_ref="main",
+            notification_sinks_input=sinks_input,
+            execute=True,
+            runner=covered_same_runner,
+        )
+        assert covered_same["ok"] is True, covered_same
+        assert covered_same["selected_reviewers"] == []
+        assert covered_same["secondary_notification_primary_targets"] == [
+            "@service-owner"
+        ]
+        assert covered_same["secondary_notification_targets"] == ["@service-owner"]
+        assert covered_same["secondary_notification_fallback_used"] is False
+        assert covered_same["secondary_notification_status"] == "sent_verified"
+        assert len(covered_same_runner.lark_calls) == 3
+        assert_public_safe(covered_same)
 
         provider_neutral_fallback = build_issue_fix_reviewer_request_packet(
             repo_path=path,
@@ -487,16 +509,12 @@ def main() -> int:
             provider_payload=metadata(requested=["service-owner"]),
         )
         assert provider_neutral_fallback["ok"] is True, provider_neutral_fallback
-        assert provider_neutral_fallback["secondary_notification_targets"] == [
-            "@history-owner"
-        ]
-        assert provider_neutral_fallback["secondary_notification_fallback_used"] is True
+        assert provider_neutral_fallback["secondary_notification_targets"] == []
+        assert provider_neutral_fallback["secondary_notification_fallback_used"] is False
         assert provider_neutral_fallback["secondary_notification_status"] == (
-            "preview_ready"
+            "skipped_reviewer_unavailable"
         )
-        assert provider_neutral_fallback["secondary_notifications"]["results"][0][
-            "sink_kind"
-        ] == "fixture_channel"
+        assert "secondary_notifications" not in provider_neutral_fallback
         assert_public_safe(provider_neutral_fallback)
 
         reviewed_combined = FakeCombinedRunner(
@@ -1368,6 +1386,55 @@ def main() -> int:
         )
         assert queued_key in stored_after_send["reviewer_notification_receipts"]
         assert stored_after_send["reviewer_notification_queue"] == []
+
+        replacement_a = {
+            **queued_receipt,
+            "idempotency_key": "sha256:" + "c" * 64,
+            "reviewer_handles": ["@service-owner"],
+        }
+        replacement_b = {
+            **queued_receipt,
+            "idempotency_key": "sha256:" + "d" * 64,
+            "reviewer_handles": ["@history-owner"],
+        }
+        persist_issue_fix_reviewer_notification_state(
+            lifecycle_path,
+            stored_after_send,
+            receipts=[],
+            queued_receipts=[replacement_a],
+        )
+        stored_with_replacement_a = json.loads(
+            lifecycle_path.read_text(encoding="utf-8").splitlines()[0]
+        )
+        queue_replace = persist_issue_fix_reviewer_notification_state(
+            lifecycle_path,
+            stored_with_replacement_a,
+            receipts=[],
+            queued_receipts=[replacement_b],
+            replace_queued_receipts=True,
+        )
+        assert queue_replace["write_performed"] is True, queue_replace
+        assert queue_replace["queue_reconciliation"]["mode"] == "replace_unsent"
+        assert queue_replace["queue_reconciliation"]["cancelled_count"] == 1
+        stored_with_replacement_b = json.loads(
+            lifecycle_path.read_text(encoding="utf-8").splitlines()[0]
+        )
+        assert reviewer_notification_queue_from_state(stored_with_replacement_b) == [
+            replacement_b
+        ]
+        queue_cancel = persist_issue_fix_reviewer_notification_state(
+            lifecycle_path,
+            stored_with_replacement_b,
+            receipts=[],
+            queued_receipts=[],
+            replace_queued_receipts=True,
+        )
+        assert queue_cancel["write_performed"] is True, queue_cancel
+        assert queue_cancel["queue_reconciliation"]["cancelled_count"] == 1
+        stored_after_cancel = json.loads(
+            lifecycle_path.read_text(encoding="utf-8").splitlines()[0]
+        )
+        assert stored_after_cancel["reviewer_notification_queue"] == []
     finally:
         for attempt in range(10):
             try:

--- a/loopx/capabilities/issue_fix/reviewer_cli.py
+++ b/loopx/capabilities/issue_fix/reviewer_cli.py
@@ -441,6 +441,7 @@ def handle_issue_fix_reviewer_command(
     notification_lifecycle_packet: dict[str, Any] | None = None
     notification_lifecycle_path: Path | None = None
     notification_lifecycle_materialized = False
+    existing_queued_receipts: list[dict[str, Any]] = []
     if args.goal_id:
         goal, requested_project = _load_goal_for_project(
             registry_path=registry_path,
@@ -502,6 +503,9 @@ def handle_issue_fix_reviewer_command(
                     notification_lifecycle_packet
                 ),
             )
+            existing_queued_receipts = reviewer_notification_queue_from_state(
+                notification_lifecycle_packet
+            )
     payload = build_issue_fix_reviewer_request_packet(
         repo_path=args.repo_path,
         url=args.url,
@@ -534,6 +538,8 @@ def handle_issue_fix_reviewer_command(
     )
     payload["secondary_notification_receipts_persisted"] = False
     payload["secondary_notification_queue_persisted"] = False
+    payload["secondary_notification_queue_reconciled"] = False
+    payload["secondary_notification_queue_cancelled_count"] = 0
     payload["secondary_notification_state_persisted"] = False
     secondary = payload.get("secondary_notifications")
     secondary_receipts = secondary.get("receipts") if isinstance(secondary, dict) else []
@@ -555,7 +561,7 @@ def handle_issue_fix_reviewer_command(
         args.execute
         and notification_lifecycle_packet is not None
         and notification_lifecycle_path is not None
-        and (new_receipts or queued_receipts)
+        and (new_receipts or queued_receipts or existing_queued_receipts)
     ):
         try:
             write_result = persist_issue_fix_reviewer_notification_state(
@@ -563,6 +569,7 @@ def handle_issue_fix_reviewer_command(
                 notification_lifecycle_packet,
                 receipts=new_receipts,
                 queued_receipts=queued_receipts,
+                replace_queued_receipts=True,
             )
         except (OSError, ValueError):
             payload["ok"] = False
@@ -607,5 +614,11 @@ def handle_issue_fix_reviewer_command(
             payload["secondary_notification_queue_persisted"] = bool(
                 queued_receipts
             )
+            queue_reconciliation = write_result.get("queue_reconciliation")
+            if isinstance(queue_reconciliation, Mapping):
+                payload["secondary_notification_queue_reconciled"] = True
+                payload["secondary_notification_queue_cancelled_count"] = int(
+                    queue_reconciliation.get("cancelled_count") or 0
+                )
             payload["secondary_notification_state_persisted"] = True
     return payload, render_issue_fix_reviewer_request_markdown

--- a/loopx/capabilities/issue_fix/reviewer_notification.py
+++ b/loopx/capabilities/issue_fix/reviewer_notification.py
@@ -1213,6 +1213,20 @@ def build_issue_fix_reviewer_notification_sinks_result(
             for receipt in [dict(result["queue_receipt"])]
         }.values()
     )
+    queued_receipts_by_result_key = {
+        str(receipt["idempotency_key"]): receipt for receipt in queued_receipts
+    }
+    for result in results:
+        key = str(result.get("idempotency_key") or "")
+        prior = queued_receipts_by_key.get(key)
+        if (
+            prior is not None
+            and result.get("ok") is False
+            and result.get("external_write_performed") is not True
+            and key not in queued_receipts_by_result_key
+        ):
+            queued_receipts.append(dict(prior))
+            queued_receipts_by_result_key[key] = dict(prior)
     statuses = {str(result.get("status")) for result in results}
     if len(statuses) == 1:
         status = statuses.pop()

--- a/loopx/capabilities/issue_fix/reviewer_request.py
+++ b/loopx/capabilities/issue_fix/reviewer_request.py
@@ -89,14 +89,16 @@ def _secondary_notification_targets(
     primary_handles: Sequence[str],
     candidates: Sequence[Any],
     sinks_input: Mapping[str, Any],
+    allow_candidate_fallback: bool = True,
 ) -> tuple[list[str], list[str]]:
     """Choose sink-resolvable reviewers without changing GitHub coverage.
 
     The primary handles are reviewers already covered on GitHub or selected for
-    a new GitHub request.  Ranked recommendation candidates are fallback-only:
-    they are used when every configured secondary sink declares an identity for
-    the candidate.  Sink adapters still perform the authoritative provider and
-    membership verification before sending.
+    a new GitHub request. Ranked recommendation candidates are fallback-only for
+    a newly selected request. Existing GitHub coverage must stay bound to the
+    same reviewer across secondary sinks; an unresolved mapping skips the sink
+    instead of notifying another person. Sink adapters still perform the
+    authoritative provider and membership verification before sending.
     """
 
     primary = list(
@@ -140,6 +142,18 @@ def _secondary_notification_targets(
         return primary, pool
 
     target_count = len(primary)
+    if not allow_candidate_fallback:
+        return (
+            [
+                handle
+                for handle in primary
+                if all(
+                    isinstance(identities.get(handle), Mapping)
+                    for identities in identity_maps
+                )
+            ][:target_count],
+            pool,
+        )
     resolved = [
         handle
         for handle in pool
@@ -906,6 +920,7 @@ def build_issue_fix_reviewer_request_packet(
                 primary_handles=primary_notification_targets,
                 candidates=candidates,
                 sinks_input=notification_sinks_input,
+                allow_candidate_fallback=bool(packet.get("selected_reviewers")),
             )
         )
         packet["secondary_notification_primary_targets"] = (

--- a/loopx/domain_packs/issue_fix.py
+++ b/loopx/domain_packs/issue_fix.py
@@ -359,8 +359,14 @@ def persist_issue_fix_reviewer_notification_state(
     *,
     receipts: list[str],
     queued_receipts: list[dict[str, Any]],
+    replace_queued_receipts: bool = False,
 ) -> dict[str, Any]:
-    """Persist verified receipts and restart-safe queued delivery metadata."""
+    """Persist verified receipts and restart-safe queued delivery metadata.
+
+    The default preserves append-compatible callers. An authoritative reviewer
+    route may replace the unsent queue so stale targets are cancelled when live
+    GitHub coverage changes or the current target becomes unavailable.
+    """
 
     # Rows written before a capture-boundary field was introduced may omit it.
     # Receipt persistence is a metadata-only migration, so make that historical
@@ -391,19 +397,28 @@ def persist_issue_fix_reviewer_notification_state(
             merged_receipts.append(text)
 
     existing_queue = payload.get("reviewer_notification_queue")
-    merged_queue: dict[str, dict[str, Any]] = {}
+    prior_queue: dict[str, dict[str, Any]] = {}
     for value in existing_queue if isinstance(existing_queue, list) else []:
         try:
             queued = _validated_reviewer_notification_queue_receipt(value)
         except ValueError:
             continue
-        merged_queue[str(queued["idempotency_key"])] = queued
+        prior_queue[str(queued["idempotency_key"])] = queued
+    merged_queue = {} if replace_queued_receipts else dict(prior_queue)
     for value in queued_receipts:
         queued = _validated_reviewer_notification_queue_receipt(value)
         merged_queue[str(queued["idempotency_key"])] = queued
     for key in merged_receipts:
         merged_queue.pop(key, None)
     queue = list(merged_queue.values())
+    queue_reconciliation = {
+        "schema_version": "issue_fix_reviewer_notification_queue_reconciliation_v0",
+        "mode": "replace_unsent" if replace_queued_receipts else "merge",
+        "prior_count": len(prior_queue),
+        "requested_count": len(queued_receipts),
+        "result_count": len(queue),
+        "cancelled_count": len(set(prior_queue) - set(merged_queue)),
+    }
 
     prior_receipts = existing_receipts if isinstance(existing_receipts, list) else []
     prior_queue = existing_queue if isinstance(existing_queue, list) else []
@@ -413,10 +428,12 @@ def persist_issue_fix_reviewer_notification_state(
             "write_performed": False,
             "row_count": None,
             "path_recorded": False,
+            "queue_reconciliation": queue_reconciliation,
         }
     payload["reviewer_notification_receipts"] = merged_receipts
     payload["reviewer_notification_queue"] = queue
-    return upsert_issue_fix_pr_lifecycle_ledger_jsonl(ledger_path, payload)
+    result = upsert_issue_fix_pr_lifecycle_ledger_jsonl(ledger_path, payload)
+    return {**result, "queue_reconciliation": queue_reconciliation}
 
 
 def default_issue_fix_domain_state_ledger_path(


### PR DESCRIPTION
## Problem

An already-covered GitHub reviewer could be replaced by a different Lark-mapped candidate, and merge-only persistence left stale unsent reviewer notifications queued after the live route changed.

## Solution

- Bind secondary notifications to the same already-covered GitHub reviewer; skip the sink when that identity cannot resolve.
- Reconcile the unsent queue authoritatively on execute, with explicit replace/cancel evidence.
- Preserve matching queued work after a pre-write provider failure while avoiding duplicate requeue after an unverified external write.
- Document the contract and cover routing, replacement, cancellation, and restart-safe retry behavior.

## Validation

- 435 passed, 2 skipped
- Focused reviewer request, notification sink, and capability guide smokes passed
- Ruff check and git diff check passed
- LoopX premerge canary: 17/17 passed, zero warnings or manual holds, self-merge allowed
- Public-boundary scan clean

## Product judgment

This is a provider-neutral PR-scoped queue contract. It fixes wrong-person notifications and stale retries without expanding the reviewer model or adding a second ledger. Verified receipts stay append-only; only unsent work is replaceable.