### PR TITLE
Fix registry-relative runtime paths from independent worktrees

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1580,11 +1580,11 @@ It mirrors the compact run index, but strips local artifact paths. UIs should
 show artifact availability with `json_exists` and `markdown_exists` instead of
 linking directly to local files.
 
-Relative `common_runtime_root` values, relative `--runtime-root` overrides, and
-relative run-index artifact paths are resolved against the project root that
-owns the selected registry, not the caller's current working directory. This
-keeps `status`, `quota should-run`, and `history` stable when they are invoked
-from an independent worktree.
+On the `status`, `quota should-run`, and `history` read paths, relative
+`common_runtime_root` values, relative `--runtime-root` overrides, and relative
+run-index artifact paths are resolved against the project root that owns the
+selected registry, not the caller's current working directory. This keeps
+those read surfaces stable when they are invoked from an independent worktree.
 
 Goal shape:
 

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1580,6 +1580,12 @@ It mirrors the compact run index, but strips local artifact paths. UIs should
 show artifact availability with `json_exists` and `markdown_exists` instead of
 linking directly to local files.
 
+Relative `common_runtime_root` values, relative `--runtime-root` overrides, and
+relative run-index artifact paths are resolved against the project root that
+owns the selected registry, not the caller's current working directory. This
+keeps `status`, `quota should-run`, and `history` stable when they are invoked
+from an independent worktree.
+
 Goal shape:
 
 ```json

--- a/examples/control_plane/status-collection-readmodel-smoke.py
+++ b/examples/control_plane/status-collection-readmodel-smoke.py
@@ -124,9 +124,15 @@ def assert_context_orchestration() -> None:
     def load_registry(path: Path) -> dict[str, Any]:
         return record("load_registry", {"common_runtime_root": str(runtime_root), "path": str(path)})
 
-    def resolve_runtime_root(registry: dict[str, Any], override: str | None) -> Path:
+    def resolve_runtime_root(
+        registry: dict[str, Any],
+        override: str | None,
+        *,
+        registry_path: Path | None = None,
+    ) -> Path:
         assert registry["common_runtime_root"] == str(runtime_root), registry
         assert override == "runtime-override", override
+        assert registry_path == Path("registry.json"), registry_path
         return runtime_root
 
     def collect_history(**kwargs: Any) -> dict[str, Any]:

--- a/loopx/cli_commands/history.py
+++ b/loopx/cli_commands/history.py
@@ -169,7 +169,11 @@ def handle_history_command(
             if not args.goal_id:
                 raise ValueError("history trajectory-hygiene requires --goal-id")
             registry = load_registry(registry_path)
-            runtime_root = resolve_runtime_root(registry, runtime_root_arg)
+            runtime_root = resolve_runtime_root(
+                registry,
+                runtime_root_arg,
+                registry_path=registry_path,
+            )
             history = collect_history(
                 registry_path=registry_path,
                 runtime_root=runtime_root,
@@ -200,7 +204,11 @@ def handle_history_command(
             )
         except Exception as exc:
             registry = load_registry(registry_path)
-            runtime_root = resolve_runtime_root(registry, runtime_root_arg)
+            runtime_root = resolve_runtime_root(
+                registry,
+                runtime_root_arg,
+                registry_path=registry_path,
+            )
             payload = {
                 "ok": False,
                 "registry": str(registry_path),
@@ -222,7 +230,11 @@ def handle_history_command(
             )
         except Exception as exc:
             registry = load_registry(registry_path)
-            runtime_root = resolve_runtime_root(registry, runtime_root_arg)
+            runtime_root = resolve_runtime_root(
+                registry,
+                runtime_root_arg,
+                registry_path=registry_path,
+            )
             payload = {
                 "ok": False,
                 "dry_run": not bool(args.execute),
@@ -697,7 +709,11 @@ def handle_history_command(
 
     try:
         registry = load_registry(registry_path)
-        runtime_root = resolve_runtime_root(registry, runtime_root_arg)
+        runtime_root = resolve_runtime_root(
+            registry,
+            runtime_root_arg,
+            registry_path=registry_path,
+        )
         payload = collect_history(
             registry_path=registry_path,
             runtime_root=runtime_root,

--- a/loopx/contract.py
+++ b/loopx/contract.py
@@ -650,7 +650,11 @@ def check_contract(
     errors.extend(user_gate_scope_errors)
     warnings.extend(_active_state_projection_gap_warnings(registry))
 
-    runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    runtime_root = resolve_runtime_root(
+        registry,
+        runtime_root_override,
+        registry_path=registry_path,
+    )
     if runtime_root == DEFAULT_RUNTIME_ROOT or runtime_root.exists():
         checks.append(f"runtime root resolved: {runtime_root}")
     else:

--- a/loopx/control_plane/runtime/status_projection_cache.py
+++ b/loopx/control_plane/runtime/status_projection_cache.py
@@ -32,7 +32,11 @@ def resolve_status_projection_cache_runtime_root(
     runtime_root_override: str | None,
 ) -> Path:
     registry = load_registry(registry_path)
-    return resolve_runtime_root(registry, runtime_root_override)
+    return resolve_runtime_root(
+        registry,
+        runtime_root_override,
+        registry_path=registry_path,
+    )
 
 
 def status_projection_cache_dir(runtime_root: Path) -> Path:

--- a/loopx/control_plane/status_collection.py
+++ b/loopx/control_plane/status_collection.py
@@ -43,7 +43,11 @@ def collect_status(
     control_plane_limit = max(display_limit, context.status_control_plane_context_limit)
     goal_filter = str(goal_id or "").strip() or None
     registry = context.load_registry(registry_path)
-    runtime_root = context.resolve_runtime_root(registry, runtime_root_override)
+    runtime_root = context.resolve_runtime_root(
+        registry,
+        runtime_root_override,
+        registry_path=registry_path,
+    )
     global_registry = context.collect_global_registry_health(
         registry_path=registry_path,
         runtime_root=runtime_root,
@@ -59,7 +63,7 @@ def collect_status(
     )
     contract = context.check_contract(
         registry_path=registry_path,
-        runtime_root_override=runtime_root_override,
+        runtime_root_override=str(runtime_root),
         scan_roots=scan_roots,
         limit=limit,
     )

--- a/loopx/history.py
+++ b/loopx/history.py
@@ -19,7 +19,7 @@ from .control_plane.work_items.delivery_outcome import require_delivery_outcome
 from .doctor import PROMOTION_READINESS_CLASSIFICATIONS
 from .execution_profile import compact_execution_profile
 from .explore_graph import compact_explore_graph_policy
-from .paths import resolve_runtime_root
+from .paths import registry_project_root, resolve_runtime_root
 from .presentation.markdown import (
     markdown_code,
     markdown_table_row,
@@ -166,7 +166,21 @@ def discover_goal_ids(
     return sorted(ids)
 
 
-def load_index(path: Path) -> tuple[list[dict[str, Any]], int]:
+def _indexed_artifact_exists(value: Any, *, artifact_root: Path | None) -> bool:
+    text = str(value or "").strip()
+    if not text:
+        return False
+    path = Path(text).expanduser()
+    if not path.is_absolute() and artifact_root is not None:
+        path = artifact_root / path
+    return path.exists()
+
+
+def load_index(
+    path: Path,
+    *,
+    artifact_root: Path | None = None,
+) -> tuple[list[dict[str, Any]], int]:
     if not path.exists():
         return [], 0
 
@@ -191,10 +205,14 @@ def load_index(path: Path) -> tuple[list[dict[str, Any]], int]:
                 str(item.get("markdown_path") or ""),
             )
             item = dict(item)
-            json_path = Path(str(item.get("json_path") or ""))
-            markdown_path = Path(str(item.get("markdown_path") or ""))
-            item["json_exists"] = json_path.exists() if str(json_path) else False
-            item["markdown_exists"] = markdown_path.exists() if str(markdown_path) else False
+            item["json_exists"] = _indexed_artifact_exists(
+                item.get("json_path"),
+                artifact_root=artifact_root,
+            )
+            item["markdown_exists"] = _indexed_artifact_exists(
+                item.get("markdown_path"),
+                artifact_root=artifact_root,
+            )
             if key in positions:
                 records[positions[key]].update(item)
             else:
@@ -222,7 +240,11 @@ def append_benchmark_run(
     delivery_outcome = _normalize_optional_delivery_outcome(delivery_outcome)
 
     registry = load_registry(registry_path)
-    runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    runtime_root = resolve_runtime_root(
+        registry,
+        runtime_root_override,
+        registry_path=registry_path,
+    )
     generated_at = now_local()
     action = recommended_action or "inspect benchmark_run_v0 summary and continue passive benchmark work"
     health_check = "benchmark_run_v0 compact event public-safe"
@@ -300,7 +322,11 @@ def append_benchmark_result(
     delivery_outcome = _normalize_optional_delivery_outcome(delivery_outcome)
 
     registry = load_registry(registry_path)
-    runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    runtime_root = resolve_runtime_root(
+        registry,
+        runtime_root_override,
+        registry_path=registry_path,
+    )
     generated_at = now_local()
     action = recommended_action or "inspect benchmark_result_v0 summary and continue benchmark comparison work"
     health_check = "benchmark_result_v0 compact event public-safe"
@@ -378,7 +404,11 @@ def append_benchmark_comparison(
     delivery_outcome = _normalize_optional_delivery_outcome(delivery_outcome)
 
     registry = load_registry(registry_path)
-    runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    runtime_root = resolve_runtime_root(
+        registry,
+        runtime_root_override,
+        registry_path=registry_path,
+    )
     generated_at = now_local()
     action = recommended_action or "inspect benchmark_comparison_v0 deltas and continue benchmark analysis"
     health_check = "benchmark_comparison_v0 compact event public-safe"
@@ -456,7 +486,11 @@ def append_benchmark_learning_ledger(
     delivery_outcome = _normalize_optional_delivery_outcome(delivery_outcome)
 
     registry = load_registry(registry_path)
-    runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    runtime_root = resolve_runtime_root(
+        registry,
+        runtime_root_override,
+        registry_path=registry_path,
+    )
     generated_at = now_local()
     action = recommended_action or "route benchmark follow-up from benchmark_learning_ledger_v0"
     health_check = "benchmark_learning_ledger_v0 compact event public-safe"
@@ -534,7 +568,11 @@ def append_benchmark_experiment_report(
     delivery_outcome = _normalize_optional_delivery_outcome(delivery_outcome)
 
     registry = load_registry(registry_path)
-    runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    runtime_root = resolve_runtime_root(
+        registry,
+        runtime_root_override,
+        registry_path=registry_path,
+    )
     generated_at = now_local()
     action = recommended_action or "inspect benchmark_experiment_report_v0 summary and continue report consumer work"
     health_check = "benchmark_experiment_report_v0 compact event public-safe"
@@ -612,7 +650,11 @@ def append_active_user_assisted_pilot(
     delivery_outcome = _normalize_optional_delivery_outcome(delivery_outcome)
 
     registry = load_registry(registry_path)
-    runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    runtime_root = resolve_runtime_root(
+        registry,
+        runtime_root_override,
+        registry_path=registry_path,
+    )
     generated_at = now_local()
     action = recommended_action or "inspect active_user_assisted_pilot_v0 summary and decide assisted treatment next step"
     health_check = "active_user_assisted_pilot_v0 compact event public-safe"
@@ -749,7 +791,10 @@ def collect_history(
         include_runtime_goals=include_runtime_goals,
     ):
         index_path = runtime_root / "goals" / current_goal_id / "runs" / "index.jsonl"
-        runs, raw_count = load_index(index_path)
+        runs, raw_count = load_index(
+            index_path,
+            artifact_root=registry_project_root(registry_path),
+        )
         runs = [
             run
             for _, run in sorted(
@@ -821,7 +866,11 @@ def inspect_index_duplicates(
     limit: int,
 ) -> dict[str, Any]:
     registry = load_registry(registry_path)
-    runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    runtime_root = resolve_runtime_root(
+        registry,
+        runtime_root_override,
+        registry_path=registry_path,
+    )
     groups: list[dict[str, Any]] = []
     checked_goal_count = 0
     raw_index_records = 0
@@ -868,8 +917,14 @@ def inspect_index_duplicates(
                     "generated_at": generated_at,
                     "json_path": json_path,
                     "markdown_path": markdown_path,
-                    "json_exists": Path(json_path).exists() if json_path else False,
-                    "markdown_exists": Path(markdown_path).exists() if markdown_path else False,
+                    "json_exists": _indexed_artifact_exists(
+                        json_path,
+                        artifact_root=registry_project_root(registry_path),
+                    ),
+                    "markdown_exists": _indexed_artifact_exists(
+                        markdown_path,
+                        artifact_root=registry_project_root(registry_path),
+                    ),
                     "line_numbers": [line_number for line_number, _ in records],
                     "raw_rows": len(records),
                     "duplicate_rows": len(records) - 1,
@@ -915,7 +970,11 @@ def repair_index_duplicates(
     execute: bool,
 ) -> dict[str, Any]:
     registry = load_registry(registry_path)
-    runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    runtime_root = resolve_runtime_root(
+        registry,
+        runtime_root_override,
+        registry_path=registry_path,
+    )
     checked_goal_count = 0
     raw_index_records = 0
     removed_row_count = 0

--- a/loopx/paths.py
+++ b/loopx/paths.py
@@ -20,11 +20,36 @@ def global_registry_path(runtime_root: Path = DEFAULT_RUNTIME_ROOT) -> Path:
     return runtime_root / GLOBAL_REGISTRY_FILENAME
 
 
-def resolve_runtime_root(registry: dict[str, object], override: str | None = None) -> Path:
-    if override:
-        return Path(override).expanduser()
-    value = registry.get("common_runtime_root") if isinstance(registry, dict) else None
-    return Path(str(value)).expanduser() if value else DEFAULT_RUNTIME_ROOT
+def registry_project_root(registry_path: Path) -> Path:
+    """Return the project root that owns a registry path.
+
+    Project registries conventionally live at ``<project>/.loopx/registry.json``.
+    Standalone fixtures and global registries live directly under their owning
+    root.  Keeping this rule here prevents relative runtime paths from silently
+    depending on the caller's current working directory.
+    """
+
+    expanded = registry_path.expanduser().resolve()
+    parent = expanded.parent
+    return parent.parent if parent.name == ".loopx" else parent
+
+
+def resolve_runtime_root(
+    registry: dict[str, object],
+    override: str | None = None,
+    *,
+    registry_path: Path | None = None,
+) -> Path:
+    value = override
+    if not value:
+        value = registry.get("common_runtime_root") if isinstance(registry, dict) else None
+    if not value:
+        return DEFAULT_RUNTIME_ROOT
+
+    runtime_root = Path(str(value)).expanduser()
+    if runtime_root.is_absolute() or registry_path is None:
+        return runtime_root
+    return registry_project_root(registry_path) / runtime_root
 
 
 def rel_or_abs(path: Path, root: Path) -> str:

--- a/tests/control_plane/test_registry_relative_runtime_resolution.py
+++ b/tests/control_plane/test_registry_relative_runtime_resolution.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+from examples.control_plane.quota_plan_fixtures import write_cli_fixture
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _make_runtime_paths_project_relative(
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    project: Path,
+) -> Path:
+    target_runtime = project / ".loopx" / "runtime"
+    runtime_root.rename(target_runtime)
+
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    registry["common_runtime_root"] = ".loopx/runtime"
+    registry_path.write_text(
+        json.dumps(registry, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    for index_path in target_runtime.glob("goals/*/runs/index.jsonl"):
+        rows = []
+        for line in index_path.read_text(encoding="utf-8").splitlines():
+            row = json.loads(line)
+            for field in ("json_path", "markdown_path"):
+                raw_path = Path(str(row[field]))
+                moved_path = target_runtime / raw_path.relative_to(runtime_root)
+                row[field] = str(moved_path.relative_to(project))
+            rows.append(json.dumps(row, ensure_ascii=False))
+        index_path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+    return target_runtime
+
+
+def _run_cli(*args: str, cwd: Path) -> dict:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        value for value in (str(REPO_ROOT), env.get("PYTHONPATH", "")) if value
+    )
+    result = subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=cwd,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_history_and_quota_anchor_relative_runtime_to_registry_project(
+    tmp_path: Path,
+) -> None:
+    registry_path, runtime_root, project = write_cli_fixture(tmp_path / "fixture")
+    target_runtime = _make_runtime_paths_project_relative(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        project=project,
+    )
+    independent_worktree = tmp_path / "independent-worktree"
+    independent_worktree.mkdir()
+
+    history = _run_cli(
+        "--format",
+        "json",
+        "--registry",
+        str(registry_path),
+        "history",
+        "--goal-id",
+        "half-speed",
+        "--limit",
+        "1",
+        cwd=independent_worktree,
+    )
+
+    assert Path(history["runtime_root"]) == target_runtime
+    assert history["run_count"] == 1
+    latest = history["goals"][0]["latest_status_run"]
+    assert latest["json_exists"] is True
+    assert latest["markdown_exists"] is True
+
+    decision = _run_cli(
+        "--format",
+        "json",
+        "--registry",
+        str(registry_path),
+        "quota",
+        "should-run",
+        "--goal-id",
+        "half-speed",
+        "--scan-path",
+        str(project),
+        cwd=independent_worktree,
+    )
+
+    assert decision["should_run"] is True
+    assert decision["normal_delivery_allowed"] is True
+    assert decision["decision"] == "run"


### PR DESCRIPTION
## Summary

- anchor relative `common_runtime_root` and relative `--runtime-root` values to the project that owns the selected registry on status/quota/history read paths
- resolve relative run-index artifact availability against that same project root
- keep status/contract/cache/history consumers on one canonical runtime binding
- add an independent-worktree CLI regression covering both `history` artifact readback and runnable `quota should-run`
- document the registry-relative read-path contract

## Product / architecture

This fixes a control-plane identity seam rather than special-casing OpenViking or issue #3274. A registry is the authority for its runtime namespace, so changing the caller's cwd must not change which run index or artifacts status/quota trust. The new optional `registry_path` anchor preserves existing absolute-path behavior and keeps callers without registry context backward compatible.

## Validation

- `pytest -q`: 436 passed, 2 skipped
- focused registry-relative runtime and source-route tests: 6 passed
- Ruff on touched Python files: passed
- real OpenViking #3274 independent worktree: 742 runs discovered; latest JSON/Markdown read back as present
- risk-based `loopx canary premerge --from-git-diff --tier standard`: passed, 17/17 selected checks, no warnings or manual holds
- `git diff --check`: passed

## Boundary / exclusions

- no project runtime, active goal state, credentials, raw logs, or private material included
- no OpenViking product code changed
- residual risk is limited to status/quota/history callers that intentionally relied on a relative runtime path being cwd-relative while also supplying a registry path; the documented read-path contract now makes registry ownership authoritative
