### PR TITLE
fix(control-plane): wait on exact blocked vision successors

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -382,6 +382,16 @@ todo in `capability_gate.runnable_candidates` or `agent_lane_next_action`; it
 may continue with a lower-priority executable fallback when the interaction
 contract allows safe scoped fallback work.
 
+If an active per-agent vision has no other selectable advancement and its
+existing current-agent or unclaimed successor is blocked by an exact supported
+`resume_when`, quota projects `vision_wait_state.state=waiting` and
+`agent_scope_wait` instead of deriving another autonomous vision replan. The
+wait payload preserves the todo id, condition, and automatic-resume contract.
+Once `resume_ready=true`, the wait disappears and ordinary open-todo or
+deferred-successor selection runs again. Missing vision checkpoints, closed
+stage succession, unsupported conditions, and continuous-monitor-as-gate
+repairs remain fail-closed and are not hidden by this wait path.
+
 For completed handoff gates, record that rationale structurally as
 `no_followup=true`; status projects the gate as `cleared_no_followup` instead
 of waking the blocked agent with `successor_replan_required`.

--- a/docs/reference/protocols/goal-vision-replan-contract-v0.md
+++ b/docs/reference/protocols/goal-vision-replan-contract-v0.md
@@ -256,6 +256,24 @@ choose the explicit terminal lane semantics `retired`, `superseded`, or
 vision. This keeps stage completion from silently terminating a long-horizon
 goal.
 
+### Exact blocked-successor wait
+
+An open agent vision does not need another replan when the lane already has an
+exact current-agent or unclaimed advancement successor whose supported
+`resume_when` condition is projected as `resume_ready=false`. When there is no
+other selectable advancement, quota/status expose
+`goal_vision_wait_state_v0` with the waiting todo id, `resume_when`, compact
+`resume_condition`, and `automatic_resume=true`. The ordinary
+`vision_acceptance_gap` is deferred while that read model is active, so the
+agent can remain quiet instead of inventing duplicate successor work.
+
+This is a read model, not a stored vision or todo lifecycle state. When the
+condition becomes ready, normal open-todo or deferred-successor routing resumes
+automatically and the active vision remains available for acceptance auditing.
+It cannot suppress `vision_checkpoint_missing`, `vision_successor_required`, a
+resume condition that lacks exact projected evidence, or the dedicated repair
+for an advancement todo incorrectly gated by a standing continuous monitor.
+
 ## Replan Triggers
 
 A replan trigger is goal-level and should be evaluated before lane-local quiet

--- a/loopx/control_plane/agents/agent_scope.py
+++ b/loopx/control_plane/agents/agent_scope.py
@@ -28,6 +28,7 @@ from ..todos.contract import (
     normalize_todo_task_class,
 )
 from ..todos.handoff_gate import HandoffGateState
+from ..todos.deferred_resume import todo_summary_blocked_successor_items
 from ..todos.projection import (
     todo_item_claimed_by_agent_or_unclaimed,
     todo_item_excludes_agent,
@@ -669,6 +670,17 @@ def _agent_lane_frontier_hint(
         AgentScopeFrontierAction.AGENT_SCOPE_WAIT,
         AgentScopeFrontierAction.REASSIGNMENT_REQUIRED,
     }:
+        blocked_successor_todo_id = _first_compact_todo_id(
+            frontier.get("blocked_successor_wait_candidates")
+        )
+        if blocked_successor_todo_id:
+            return build_hint(
+                AgentLaneFrontierHintDecision.QUIET_NOOP_BLOCKER,
+                source="agent_scope_frontier",
+                reason_code="blocked_successor_resume_pending",
+                target_todo_id=blocked_successor_todo_id,
+                quiet_noop_allowed=True,
+            )
         blocker_todo_id = _first_compact_todo_id(frontier.get("blocking_handoff_gates"))
         if not blocker_todo_id:
             blocker_todo_id = _first_compact_todo_id(frontier.get("other_agent_claimed_items"))
@@ -1123,6 +1135,47 @@ def _agent_scope_no_candidate_frontier(
                 "deferred_resume_candidate_count": len(deferred_resume_candidates),
             },
             extra_fields={"deferred_resume_candidates": deferred_resume_candidates[:3]},
+        )
+
+    blocked_successor_wait_candidates = todo_summary_blocked_successor_items(
+        agent_todo_summary,
+        agent_id=agent_id,
+    )
+    if blocked_successor_wait_candidates:
+        first_candidate = blocked_successor_wait_candidates[0]
+        candidate_todo_id = (
+            str(first_candidate.get("todo_id") or "").strip() or "<todo_id>"
+        )
+        resume_when = str(first_candidate.get("resume_when") or "").strip()
+        return build_agent_scope_frontier_payload(
+            agent_id=agent_id,
+            action=AgentScopeFrontierAction.AGENT_SCOPE_WAIT,
+            quiet_noop_allowed=True,
+            spend_policy=(
+                "no quota spend while an exact successor resume condition is pending"
+            ),
+            reason=(
+                f"current {agent_label} {agent_id} has exact blocked successor "
+                f"{candidate_todo_id} waiting on {resume_when}; another successor "
+                "replan would duplicate the existing route"
+            ),
+            recommended_action=(
+                f"Keep {agent_id} active but quiet until {resume_when} becomes ready; "
+                "then resume ordinary todo/deferred-successor routing automatically."
+            ),
+            requires_replan=False,
+            candidate_counts={
+                "current_agent_claimed_advancement_count": current_agent_count,
+                "unclaimed_advancement_count": unclaimed_count,
+                "blocked_successor_wait_count": len(
+                    blocked_successor_wait_candidates
+                ),
+            },
+            extra_fields={
+                "blocked_successor_wait_candidates": (
+                    blocked_successor_wait_candidates[:3]
+                ),
+            },
         )
 
     route_continuation_replan_candidates = _agent_scope_route_continuation_replan_candidates(

--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -22,6 +22,7 @@ from .goal_vision_state import (
     goal_vision_state_is_closed,
     goal_vision_state_requires_successor,
 )
+from .goal_vision_wait import build_goal_vision_wait_state
 
 
 GOAL_FRONTIER_PROJECTION_SCHEMA_VERSION = "goal_frontier_projection_v0"
@@ -1175,6 +1176,10 @@ def derive_goal_frontier_replan_obligation_from_summaries(
         agent_id=agent_id,
     )
     total_frontier_advancement = sum(frontier_counts.values())
+    selectable_frontier_advancement = (
+        frontier_counts["current_agent_claimed_advancement_count"]
+        + frontier_counts["unclaimed_advancement_count"]
+    )
     compact_acceptance_gaps = [
         item for item in (acceptance_gaps or []) if isinstance(item, dict)
     ]
@@ -1265,7 +1270,9 @@ def derive_goal_frontier_replan_obligation_from_summaries(
             successor_vision_required
             or (
                 agent_counts.get("advancement", 0) == 0
-                and total_frontier_advancement == 0
+                # Another peer's claimed work cannot satisfy this agent's
+                # scoped vision or checkpoint acceptance gap.
+                and selectable_frontier_advancement == 0
             )
         )
         and not acceptance_allows_watch_lane_continuation
@@ -1444,6 +1451,7 @@ def build_goal_frontier_projection_from_summaries(
     work_lane_contract: dict[str, Any] | None,
     replan_obligation: dict[str, Any] | None,
     acceptance_gaps: list[dict[str, Any]] | None = None,
+    vision_wait_state: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     user_counts = _summary_task_counts(user_todo_summary)
     agent_counts = _summary_task_counts(agent_todo_summary)
@@ -1472,6 +1480,7 @@ def build_goal_frontier_projection_from_summaries(
         monitor_only_lane=monitor_only_lane,
         replan_obligation=replan_obligation,
         acceptance_gaps=acceptance_gaps,
+        vision_wait_state=vision_wait_state,
         deferred_successors=_deferred_successors(
             agent_todo_summary,
             agent_id=agent_id,
@@ -1534,13 +1543,27 @@ def build_goal_frontier_projection_context_from_status(
         goal_id=goal_id,
         agent_id=agent_id,
     )
-    acceptance_gaps = (
+    source_acceptance_gaps = (
         acceptance_gaps_from_agent_vision(
             latest_agent_vision,
             goal_status=goal_status,
         )
         + acceptance_gaps_from_vision_checkpoint(latest_missing_vision_checkpoint)
     )
+    frontier_counts = _frontier_advancement_counts(
+        agent_todo_summary=agent_todo_summary,
+        agent_id=agent_id,
+    )
+    vision_wait_state = build_goal_vision_wait_state(
+        agent_todo_summary=agent_todo_summary,
+        agent_id=agent_id,
+        acceptance_gaps=source_acceptance_gaps,
+        selectable_advancement_count=(
+            frontier_counts["current_agent_claimed_advancement_count"]
+            + frontier_counts["unclaimed_advancement_count"]
+        ),
+    )
+    acceptance_gaps = [] if vision_wait_state else source_acceptance_gaps
     projected_replan_ack = projected_autonomous_replan_ack_for_agent(
         item,
         project_asset,
@@ -1583,6 +1606,7 @@ def build_goal_frontier_projection_context_from_status(
         work_lane_contract=work_lane_contract,
         replan_obligation=replan_obligation,
         acceptance_gaps=acceptance_gaps,
+        vision_wait_state=vision_wait_state,
     )
     return {
         "schema_version": "goal_frontier_projection_context_v0",
@@ -1590,6 +1614,7 @@ def build_goal_frontier_projection_context_from_status(
         "replan_scope": replan_scope,
         "goal_frontier_projection": goal_frontier_projection,
         "acceptance_gaps": acceptance_gaps,
+        "vision_wait_state": vision_wait_state,
         "latest_replan_ack": latest_agent_replan_ack,
         "projected_replan_ack": projected_replan_ack,
     }
@@ -1664,6 +1689,7 @@ def build_goal_frontier_projection(
     replan_obligation: dict[str, Any] | None,
     acceptance_gaps: list[dict[str, Any]] | None = None,
     deferred_successors: dict[str, Any] | None = None,
+    vision_wait_state: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     replan_required = autonomous_replan_is_required(replan_obligation)
     blockers: list[str] = []
@@ -1677,6 +1703,8 @@ def build_goal_frontier_projection(
         blockers.append("other_agent_claimed_advancement")
     if replan_required:
         blockers.append("autonomous_replan_obligation")
+    if isinstance(vision_wait_state, dict):
+        blockers.append("vision_blocked_successor_wait")
 
     compact_acceptance_gaps = [
         item for item in (acceptance_gaps or []) if isinstance(item, dict)
@@ -1721,6 +1749,8 @@ def build_goal_frontier_projection(
     }
     if vision_continuation_audit:
         projection["vision_continuation_audit"] = vision_continuation_audit
+    if isinstance(vision_wait_state, dict):
+        projection["vision_wait_state"] = vision_wait_state
     if replan_required and isinstance(replan_obligation, dict):
         projection["autonomous_replan_decision"] = build_autonomous_replan_decision(
             replan_obligation

--- a/loopx/control_plane/goals/goal_vision_wait.py
+++ b/loopx/control_plane/goals/goal_vision_wait.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..todos.contract import normalize_todo_id
+from ..todos.deferred_resume import todo_summary_blocked_successor_items
+
+
+GOAL_VISION_WAIT_STATE_SCHEMA_VERSION = "goal_vision_wait_state_v0"
+VISION_ACCEPTANCE_GAP_KIND = "vision_acceptance_gap"
+
+
+def _compact_resume_condition(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    compact = {
+        key: value.get(key)
+        for key in (
+            "schema_version",
+            "resume_when",
+            "satisfied",
+            "kind",
+            "target",
+            "target_todo_id",
+            "target_status",
+            "target_archive_state",
+            "target_source_section",
+            "target_task_class",
+            "target_claimed_by",
+            "capability",
+            "provider",
+        )
+        if value.get(key) is not None
+    }
+    compact["satisfied"] = False
+    return compact
+
+
+def build_goal_vision_wait_state(
+    *,
+    agent_todo_summary: dict[str, Any] | None,
+    agent_id: str | None,
+    acceptance_gaps: list[dict[str, Any]] | None,
+    selectable_advancement_count: int,
+) -> dict[str, Any] | None:
+    """Project a temporary vision wait over an exact blocked successor.
+
+    This is deliberately a read model, not a new todo or vision lifecycle
+    state. It may defer only ordinary open-vision acceptance gaps. Missing
+    checkpoints and closed-stage successor requirements remain strict.
+    """
+
+    gaps = [gap for gap in (acceptance_gaps or []) if isinstance(gap, dict)]
+    if not gaps or any(gap.get("kind") != VISION_ACCEPTANCE_GAP_KIND for gap in gaps):
+        return None
+    if selectable_advancement_count > 0:
+        return None
+    candidates = todo_summary_blocked_successor_items(
+        agent_todo_summary or {},
+        agent_id=agent_id,
+    )
+    if not candidates:
+        return None
+
+    selected = candidates[0]
+    waiting_todo_ids = [
+        todo_id
+        for todo_id in (normalize_todo_id(item.get("todo_id")) for item in candidates[:5])
+        if todo_id
+    ]
+    selected_todo_id = normalize_todo_id(selected.get("todo_id"))
+    payload: dict[str, Any] = {
+        "schema_version": GOAL_VISION_WAIT_STATE_SCHEMA_VERSION,
+        "state": "waiting",
+        "reason_code": "exact_blocked_successor",
+        "agent_id": agent_id,
+        "waiting_todo_count": len(candidates),
+        "waiting_todo_ids": waiting_todo_ids,
+        "selected_todo_id": selected_todo_id,
+        "selected_todo_status": selected.get("status"),
+        "selected_todo_priority": selected.get("priority"),
+        "selected_todo_claimed_by": selected.get("claimed_by"),
+        "resume_when": selected.get("resume_when"),
+        "resume_condition": _compact_resume_condition(selected.get("resume_condition")),
+        "deferred_acceptance_gap_count": len(gaps),
+        "deferred_acceptance_gap_kinds": [VISION_ACCEPTANCE_GAP_KIND],
+        "automatic_resume": True,
+        "resume_behavior": (
+            "when resume_ready becomes true, restore ordinary open-todo or "
+            "deferred-successor routing without closing the active vision"
+        ),
+    }
+    return {key: value for key, value in payload.items() if value is not None}

--- a/loopx/control_plane/quota/markdown.py
+++ b/loopx/control_plane/quota/markdown.py
@@ -302,6 +302,15 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
                     f"done={vision_gap_judge.get('done')} "
                     f"decision={vision_gap_judge.get('decision')}"
                 )
+        vision_wait_state = as_dict(goal_frontier.get("vision_wait_state"))
+        if vision_wait_state:
+            lines.append(
+                "- vision_wait_state: "
+                f"state={vision_wait_state.get('state')} "
+                f"todo_id={vision_wait_state.get('selected_todo_id')} "
+                f"resume_when={vision_wait_state.get('resume_when')} "
+                f"automatic_resume={vision_wait_state.get('automatic_resume')}"
+            )
     task_orchestration = as_dict(payload.get("task_orchestration_contract"))
     if task_orchestration:
         peer_lanes = as_list(task_orchestration.get("eligible_peer_lanes"))

--- a/loopx/control_plane/todos/deferred_resume.py
+++ b/loopx/control_plane/todos/deferred_resume.py
@@ -299,6 +299,59 @@ def todo_summary_monitor_blocked_resume_items(
     return sorted(_dedupe_todo_items(candidates), key=todo_projection_sort_key)
 
 
+def todo_summary_blocked_successor_items(
+    value: dict[str, Any],
+    *,
+    agent_id: str | None,
+) -> list[dict[str, Any]]:
+    """Return exact non-monitor successor waits selectable by one agent lane.
+
+    Open resume-gated todos and deferred todos share the same wait contract.
+    A standing continuous monitor is deliberately excluded because it has a
+    dedicated gate-repair route: an endless monitor must not become a hidden
+    ``todo_done`` prerequisite for ordinary advancement.
+    """
+
+    if not isinstance(value, dict) or not agent_id:
+        return []
+    candidates = [
+        *todo_summary_resume_blocked_items(value),
+        *[
+            item
+            for item in todo_summary_deferred_items(value, "deferred_items")
+            if item.get("resume_ready") is False
+        ],
+    ]
+    selected: list[dict[str, Any]] = []
+    for item in _dedupe_todo_items(candidates):
+        if _todo_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
+            continue
+        if todo_item_excludes_agent(item, agent_id=agent_id):
+            continue
+        claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
+        if claimed_by and claimed_by != agent_id:
+            continue
+        resume_when = normalize_todo_resume_when(item.get("resume_when"))
+        condition = (
+            item.get("resume_condition")
+            if isinstance(item.get("resume_condition"), dict)
+            else {}
+        )
+        if not resume_when or condition.get("satisfied") is not False:
+            continue
+        target_task_class = normalize_todo_task_class(
+            condition.get("target_task_class"),
+            text="",
+        )
+        if target_task_class == TODO_TASK_CLASS_MONITOR:
+            continue
+        compact = dict(item)
+        compact["resume_when"] = resume_when
+        compact["resume_ready"] = False
+        selected.append(compact)
+    return sorted(_dedupe_todo_items(selected), key=todo_projection_sort_key)
+
+
 def _agent_claim_filtered_deferred_items(
     items: list[dict[str, Any]],
     *,

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -822,6 +822,28 @@ def _attach_interaction_vision_continuation_audit(
         }
 
 
+def _attach_interaction_vision_wait_state(
+    contract: dict[str, Any],
+    payload: dict[str, Any],
+) -> None:
+    vision_wait_state = (
+        payload.get("vision_wait_state")
+        if isinstance(payload.get("vision_wait_state"), dict)
+        else {}
+    )
+    if vision_wait_state.get("state") != "waiting":
+        return
+    contract["agent_channel"]["vision_wait_state"] = vision_wait_state
+    contract["cli_channel"]["vision_wait_state"] = {
+        "state": "waiting",
+        "reason_code": vision_wait_state.get("reason_code"),
+        "selected_todo_id": vision_wait_state.get("selected_todo_id"),
+        "resume_when": vision_wait_state.get("resume_when"),
+        "automatic_resume": vision_wait_state.get("automatic_resume") is True,
+        "spend_policy": "no spend while the exact resume condition is pending",
+    }
+
+
 def _interaction_fallback_policy_required(payload: dict[str, Any], *, mode: str) -> bool:
     return mode in {
         "user_gate",
@@ -894,6 +916,7 @@ def build_interaction_contract(payload: dict[str, Any]) -> dict[str, Any]:
     }
     _attach_interaction_required_reads(contract, required_reads)
     _attach_interaction_vision_continuation_audit(contract, payload)
+    _attach_interaction_vision_wait_state(contract, payload)
     if _interaction_fallback_policy_required(payload, mode=mode):
         contract["fallback_policy"] = {"do_not_cancel_on_block": True}
     return contract

--- a/loopx/presentation/renderers/status_markdown.py
+++ b/loopx/presentation/renderers/status_markdown.py
@@ -1199,6 +1199,15 @@ def _append_project_asset_agent_lane_markdown(
                 f"done={vision_gap_judge.get('done')} "
                 f"decision={markdown_scalar(vision_gap_judge.get('decision') or '')}"
             )
+    vision_wait_state = as_dict(goal_frontier.get("vision_wait_state"))
+    if vision_wait_state:
+        lines.append(
+            "    - vision_wait_state: "
+            f"state={markdown_scalar(vision_wait_state.get('state') or '')} "
+            f"todo_id={markdown_scalar(vision_wait_state.get('selected_todo_id') or '')} "
+            f"resume_when={markdown_scalar(vision_wait_state.get('resume_when') or '')} "
+            f"automatic_resume={vision_wait_state.get('automatic_resume')}"
+        )
 
 
 def _append_project_asset_runtime_policy_markdown(

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -1934,12 +1934,10 @@ def build_quota_should_run(
             "todo_write_hint": build_todo_write_hint(safe_goal_id),
         }
         payload = attach_task_orchestration_payload(payload, task_orchestration_contract)
-        autonomous_replan_decision = goal_frontier_projection.get("autonomous_replan_decision")
-        if isinstance(autonomous_replan_decision, dict):
-            payload["autonomous_replan_decision"] = autonomous_replan_decision
-        vision_continuation_audit = goal_frontier_projection.get("vision_continuation_audit")
-        if isinstance(vision_continuation_audit, dict):
-            payload["vision_continuation_audit"] = vision_continuation_audit
+        for key in ("autonomous_replan_decision", "vision_continuation_audit",
+                    "vision_wait_state"):
+            if isinstance(value := goal_frontier_projection.get(key), dict):
+                payload[key] = value
         if replan_scope.get("required"):
             payload["autonomous_replan_scope"] = replan_scope
         if agent_identity:

--- a/tests/control_plane/test_goal_vision_blocked_successor.py
+++ b/tests/control_plane/test_goal_vision_blocked_successor.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import pytest
+
+from loopx.cli_commands.status import attach_agent_lane_next_actions
+from loopx.control_plane.goals.goal_frontier import (
+    build_goal_frontier_projection_context_from_status,
+)
+from loopx.control_plane.quota.markdown import render_quota_should_run_markdown
+from loopx.control_plane.testing.quota_fixtures import (
+    quota_status_payload,
+    quota_todo_item,
+    quota_todo_summary,
+)
+from loopx.presentation.renderers.status_markdown import render_status_markdown
+from loopx.quota import build_quota_should_run
+
+
+GOAL_ID = "vision-blocked-successor-fixture"
+AGENT_ID = "codex-side-agent"
+PRIMARY_AGENT = "codex-primary-agent"
+BLOCKER_ID = "todo_exact_blocker"
+WAITING_ID = "todo_waiting_successor"
+
+
+def _vision_run(
+    *,
+    state: str = "vision_drift_detected",
+    missing_checkpoint: bool = False,
+) -> dict:
+    run = {
+        "classification": "vision_blocked_successor_fixture",
+        "generated_at": "2026-07-16T00:00:00+00:00",
+        "agent_id": AGENT_ID,
+        "progress_scope": "agent_lane",
+        "agent_vision": {
+            "schema_version": "goal_vision_replan_contract_v0",
+            "agent_id": AGENT_ID,
+            "state": state,
+            "vision_patch": {
+                "acceptance_summary": "Deliver the exact successor after its prerequisite clears.",
+                "replan_trigger_summary": "The successor acceptance remains open.",
+                "advancement_policy": "repeat_until_closed",
+            },
+        },
+    }
+    if missing_checkpoint:
+        run["vision_checkpoint"] = {
+            "schema_version": "vision_checkpoint_v0",
+            "agent_id": AGENT_ID,
+            "required": True,
+            "satisfied": False,
+            "decision": "missing_required",
+            "triggers": [{"kind": "material_delivery_outcome"}],
+        }
+    return run
+
+
+def _status_payload(
+    *,
+    blocker_status: str = "open",
+    waiting_status: str = "open",
+    blocker_task_class: str = "advancement_task",
+    vision_state: str = "vision_drift_detected",
+    missing_checkpoint: bool = False,
+) -> dict:
+    blocker = quota_todo_item(
+        todo_id=BLOCKER_ID,
+        index=1,
+        text="[P0] Complete the exact prerequisite.",
+        status=blocker_status,
+        task_class=blocker_task_class,
+        claimed_by=PRIMARY_AGENT,
+        successor_todo_ids=[WAITING_ID],
+    )
+    waiting = quota_todo_item(
+        todo_id=WAITING_ID,
+        index=2,
+        text="[P0] Resume the exact successor.",
+        status=waiting_status,
+        claimed_by=AGENT_ID,
+        resume_when=f"todo_done:{BLOCKER_ID}",
+    )
+    agent_todos = quota_todo_summary([blocker, waiting], role="agent")
+    return quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        recommended_action="Resume the exact successor after its prerequisite clears.",
+        agent_todos=agent_todos,
+        coordination={
+            "agent_model": "peer_v1",
+            "registered_agents": [PRIMARY_AGENT, AGENT_ID],
+        },
+        latest_runs=[
+            _vision_run(
+                state=vision_state,
+                missing_checkpoint=missing_checkpoint,
+            )
+        ],
+    )
+
+
+def _quota(payload: dict) -> dict:
+    return build_quota_should_run(payload, goal_id=GOAL_ID, agent_id=AGENT_ID)
+
+
+@pytest.mark.parametrize("waiting_status", ["open", "deferred"])
+def test_exact_blocked_successor_defers_only_open_vision_gap(
+    waiting_status: str,
+) -> None:
+    guard = _quota(_status_payload(waiting_status=waiting_status))
+
+    assert guard["decision"] == "agent_scope_wait"
+    assert guard["should_run"] is False
+    assert guard["normal_delivery_allowed"] is False
+    assert guard.get("autonomous_replan_obligation") is None
+    frontier = guard["goal_frontier_projection"]
+    assert frontier["acceptance_gaps"] == []
+    assert frontier["replan_required"] is False
+    assert "vision_blocked_successor_wait" in frontier["autonomy_blockers"]
+    wait = frontier["vision_wait_state"]
+    assert wait["schema_version"] == "goal_vision_wait_state_v0"
+    assert wait["selected_todo_id"] == WAITING_ID
+    assert wait["selected_todo_status"] == waiting_status
+    assert wait["resume_when"] == f"todo_done:{BLOCKER_ID}"
+    assert wait["resume_condition"]["target_todo_id"] == BLOCKER_ID
+    assert wait["resume_condition"]["satisfied"] is False
+    assert wait["deferred_acceptance_gap_count"] == 1
+    assert wait["automatic_resume"] is True
+    assert guard["vision_wait_state"] == wait
+    assert guard["agent_scope_frontier"]["action"] == "agent_scope_wait"
+    assert guard["agent_scope_frontier"].get("requires_replan") is not True
+    assert guard["agent_scope_frontier"]["blocked_successor_wait_candidates"][0][
+        "todo_id"
+    ] == WAITING_ID
+    assert guard["agent_lane_frontier_hint"]["reason_code"] == (
+        "blocked_successor_resume_pending"
+    )
+    assert guard["interaction_contract"]["agent_channel"]["vision_wait_state"] == wait
+    cli_wait = guard["interaction_contract"]["cli_channel"]["vision_wait_state"]
+    assert cli_wait["selected_todo_id"] == WAITING_ID
+    assert cli_wait["automatic_resume"] is True
+    assert "vision_continuation_audit" not in guard
+
+    markdown = render_quota_should_run_markdown(guard)
+    assert (
+        "vision_wait_state: state=waiting "
+        f"todo_id={WAITING_ID} resume_when=todo_done:{BLOCKER_ID} "
+        "automatic_resume=True"
+    ) in markdown
+
+
+def test_status_projects_exact_blocker_and_resume_contract() -> None:
+    payload = _status_payload(waiting_status="deferred")
+    attach_agent_lane_next_actions(payload, agent_id=AGENT_ID)
+
+    item = payload["attention_queue"]["items"][0]
+    wait = item["goal_frontier_projection"]["vision_wait_state"]
+    assert wait["selected_todo_id"] == WAITING_ID
+    assert item["project_asset"]["goal_frontier_projection"]["vision_wait_state"] == wait
+    markdown = render_status_markdown(payload)
+    assert (
+        "vision_wait_state: state=waiting "
+        f"todo_id={WAITING_ID} resume_when=todo_done:{BLOCKER_ID} "
+        "automatic_resume=True"
+    ) in markdown
+
+
+def test_cleared_blocker_restores_normal_open_successor_routing() -> None:
+    guard = _quota(_status_payload(blocker_status="done"))
+
+    assert guard["decision"] == "run"
+    assert guard["normal_delivery_allowed"] is True
+    assert guard["selected_todo"]["todo_id"] == WAITING_ID
+    assert guard["agent_lane_next_action"]["resume_ready"] is True
+    assert "vision_wait_state" not in guard
+    assert "vision_wait_state" not in guard["goal_frontier_projection"]
+    assert guard["goal_frontier_projection"]["acceptance_gaps"][0]["kind"] == (
+        "vision_acceptance_gap"
+    )
+    assert guard["vision_continuation_audit"]["required"] is True
+
+
+def test_missing_checkpoint_is_not_hidden_by_blocked_successor() -> None:
+    guard = _quota(_status_payload(missing_checkpoint=True))
+
+    assert guard["decision"] == "autonomous_replan_required"
+    assert "vision_wait_state" not in guard
+    gap_kinds = {
+        gap["kind"] for gap in guard["goal_frontier_projection"]["acceptance_gaps"]
+    }
+    assert "vision_checkpoint_missing" in gap_kinds
+    assert guard["vision_continuation_audit"]["required"] is True
+
+
+def test_closed_stage_successor_gap_is_not_hidden_by_blocked_successor() -> None:
+    payload = _status_payload(vision_state="vision_closed")
+    item = payload["attention_queue"]["items"][0]
+    context = build_goal_frontier_projection_context_from_status(
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        status_payload=payload,
+        item=item,
+        project_asset=item["project_asset"],
+        user_todo_summary=item["user_todos"],
+        agent_todo_summary=item["agent_todos"],
+        work_lane_contract={"lane": "advancement_task", "must_attempt_work": True},
+        neutral_replan_ack_classifications=set(),
+        registered_agent_ids=[PRIMARY_AGENT, AGENT_ID],
+        goal_status="active",
+    )
+
+    frontier = context["goal_frontier_projection"]
+    assert "vision_wait_state" not in frontier
+    assert frontier["replan_required"] is True
+    assert {
+        gap["kind"] for gap in frontier["acceptance_gaps"]
+    } == {"vision_successor_required"}
+
+
+def test_standing_monitor_prerequisite_keeps_dedicated_repair_route() -> None:
+    guard = _quota(
+        _status_payload(
+            blocker_task_class="continuous_monitor",
+            vision_state="retired",
+        )
+    )
+
+    assert guard["decision"] == "run"
+    assert "vision_wait_state" not in guard
+    assert guard["work_lane_contract"]["obligation"] == (
+        "repair_resume_gate_or_close_standing_monitor"
+    )
+    assert "resume_blocked_by_open_monitor" in guard["work_lane_contract"][
+        "reason_codes"
+    ]
+    assert guard["selected_todo"]["todo_id"] == WAITING_ID


### PR DESCRIPTION
## Summary
- project a temporary `goal_vision_wait_state_v0` when an active agent vision already has an exact blocked/deferred successor
- keep strict checkpoint, closed-stage succession, and standing-monitor repair semantics fail-closed
- restore ordinary routing automatically when `resume_ready=true` and expose the wait through quota/status/interaction channels

## Product / architecture judgment
This fixes repeated autonomous-replan churn without inventing a second persisted lifecycle. The wait is a reusable read model derived from existing todo `resume_when` evidence. Other peers' claimed work no longer masks this agent's vision/checkpoint gaps. Main risk is hot-path routing compatibility; focused regressions plus the standard risk canary cover it.

## Validation
- `pytest -q`: 443 passed, 2 skipped
- 21 focused goal-vision tests passed
- 5 focused quota/status/agent-scope/work-lane smokes passed
- `loopx canary premerge --from-git-diff --format json`: 17/17 passed, public boundary clean, no manual holds, self-merge allowed
- `git diff --check`: passed

## Boundary
No private state, raw logs, credentials, local paths, benchmark scoring, permission, or production behavior changes.