### PR TITLE
Fix runtime handoff artifact fixture

### DIFF
--- a/examples/control_plane/runtime-handoff-status-read-path-smoke.py
+++ b/examples/control_plane/runtime-handoff-status-read-path-smoke.py
@@ -85,8 +85,6 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
             "delivery_batch_scale": "multi_surface",
             "delivery_outcome": "outcome_progress",
             "recommended_action": "Handoff ready.",
-            "json_exists": True,
-            "markdown_exists": True,
         },
         {
             "goal_id": GOAL_ID,
@@ -96,10 +94,18 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
             "delivery_batch_scale": "implementation",
             "delivery_outcome": "outcome_progress",
             "recommended_action": POST_HANDOFF_ACTION,
-            "json_exists": True,
-            "markdown_exists": True,
         },
     ]
+    artifact_dir = project / "artifacts" / GOAL_ID
+    artifact_dir.mkdir(parents=True)
+    for row in run_rows:
+        run_id = row["run_id"]
+        json_path = artifact_dir / f"{run_id}.json"
+        markdown_path = artifact_dir / f"{run_id}.md"
+        row["json_path"] = str(json_path.relative_to(project))
+        row["markdown_path"] = str(markdown_path.relative_to(project))
+        json_path.write_text(json.dumps(row, sort_keys=True) + "\n", encoding="utf-8")
+        markdown_path.write_text(f"# {row['classification']}\n", encoding="utf-8")
     run_index.write_text(
         "".join(json.dumps(row, sort_keys=True) + "\n" for row in run_rows),
         encoding="utf-8",


### PR DESCRIPTION
## Summary
- replace synthetic artifact-existence flags in the runtime handoff read-path smoke with real JSON and Markdown artifacts
- index project-relative artifact paths so the smoke exercises the registry-relative resolution contract introduced by #2176
- preserve fail-closed production behavior for missing run artifacts

## Validation
- `python3 examples/control_plane/runtime-handoff-status-read-path-smoke.py`
- `uv run --with pytest pytest -q tests/control_plane/test_registry_relative_runtime_resolution.py`
- `python3 examples/run-smokes.py --suite full-public --offset 200 --limit 100 --timeout-seconds 120 --jobs 4 --json` (100/100 passed)
- `python3 -m loopx.cli canary premerge --from-git-diff` (9/9 selected checks passed, no manual holds)

## Boundary
Only the durable public smoke fixture is included. No local state, raw run evidence, credentials, or generated logs are committed.
