### PR TITLE
fix(quota): bind spend to accountable delivery workspace

### DIFF
--- a/examples/control_plane/peer-agent-runtime-v1-smoke.py
+++ b/examples/control_plane/peer-agent-runtime-v1-smoke.py
@@ -16,6 +16,7 @@ CHECKS = (
     "examples/control_plane/todo-continuation-policy-smoke.py",
     "examples/control_plane/peer-agent-migration-smoke.py",
     "examples/control_plane/peer-agent-workspace-guard-smoke.py",
+    "examples/control_plane/quota-spend-workspace-causality-smoke.py",
     "examples/control_plane/peer-agent-continuation-state-machine-smoke.py",
     "examples/control_plane/task-orchestration-smoke.py",
     "examples/control_plane/agent-onboard-host-loop-activation-smoke.py",

--- a/examples/control_plane/quota-spend-workspace-causality-smoke.py
+++ b/examples/control_plane/quota-spend-workspace-causality-smoke.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Keep quota spend bound to the repository of its accountable delivery."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.quota.slot_accounting import (  # noqa: E402
+    build_quota_slot_preview_for_decision,
+    build_quota_slot_spend_event,
+)
+from loopx.state_refresh import refresh_state_run  # noqa: E402
+
+
+GOAL_ID = "quota-spend-workspace-causality"
+AGENT_ID = "codex-peer"
+DELIVERY_REPOSITORY = "git:example.invalid/loopx/delivery"
+
+
+def run_git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def create_repository(root: Path, name: str) -> tuple[Path, Path]:
+    canonical = root / name
+    independent = root / f"{name}-peer"
+    canonical.mkdir()
+    (canonical / "README.md").write_text(f"# {name}\n", encoding="utf-8")
+    run_git(canonical, "init", "--initial-branch", "main")
+    run_git(
+        canonical,
+        "remote",
+        "add",
+        "origin",
+        f"https://example.invalid/loopx/{name}.git",
+    )
+    run_git(canonical, "add", "README.md")
+    run_git(
+        canonical,
+        "-c",
+        "user.name=LoopX Canary",
+        "-c",
+        "user.email=loopx-canary@example.invalid",
+        "commit",
+        "-m",
+        "initial fixture",
+    )
+    run_git(canonical, "worktree", "add", "-b", f"{name}-peer", str(independent))
+    return canonical, independent
+
+
+@contextmanager
+def working_directory(path: Path):
+    previous = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+def write_goal_fixture(project: Path, runtime: Path) -> Path:
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_path = project / state_file
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(
+        "---\nstatus: active\nowner_mode: goal\n"
+        'objective: "Exercise quota workspace causality."\n'
+        "updated_at: 2026-01-01T00:00:00+00:00\n---\n\n"
+        "# Quota Workspace Causality\n\n## Agent Todo\n\n"
+        "- [ ] [P1] Deliver from the delivery repository.\n"
+        "  <!-- loopx:todo todo_id=todo_delivery status=open "
+        f"task_class=advancement_task action_kind=repair claimed_by={AGENT_ID} "
+        f"task_repository={DELIVERY_REPOSITORY} -->\n",
+        encoding="utf-8",
+    )
+    registry_path = project / ".loopx" / "registry.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "quota-workspace-fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": state_file,
+                        "adapter": {
+                            "kind": "quota_workspace_fixture_v0",
+                            "status": "connected-read-only",
+                        },
+                        "authority_sources": [],
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": [AGENT_ID, "codex-other"],
+                        },
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path
+
+
+def quota_decision(*, workspace_repair: bool) -> dict:
+    return {
+        "ok": True,
+        "goal_id": GOAL_ID,
+        "should_run": True,
+        "state": "eligible",
+        "effective_action": (
+            "agent_workspace_repair" if workspace_repair else "normal_run"
+        ),
+        "workspace_repair_allowed": workspace_repair,
+        "safe_bypass_allowed": False,
+        "recovery_delivery_allowed": False,
+        "self_repair_allowed": False,
+        "capability_repair_allowed": False,
+        "quota": {
+            "compute": 1.0,
+            "window_hours": 24,
+            "slot_minutes": 1,
+            "allowed_slots": 10,
+            "spent_slots": 0,
+        },
+    }
+
+
+def preview(runtime: Path, before: dict) -> dict:
+    after = {
+        **before,
+        "quota": {**before["quota"], "spent_slots": 1},
+    }
+    return build_quota_slot_preview_for_decision(
+        {"runtime_root": str(runtime)},
+        goal_id=GOAL_ID,
+        before=before,
+        after_decision=lambda _status: after,
+        quota_status_builder=lambda goal, **_kwargs: goal["quota"],
+        self_repair_spend_actions=frozenset(),
+        agent_id=AGENT_ID,
+    )
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-quota-spend-workspace-") as tmp:
+        root = Path(tmp)
+        delivery, delivery_peer = create_repository(root, "delivery")
+        _next, next_peer = create_repository(root, "next")
+        runtime = root / "runtime"
+        registry_path = write_goal_fixture(delivery, runtime)
+
+        with working_directory(delivery_peer):
+            refresh = refresh_state_run(
+                registry_path=registry_path,
+                runtime_root_override=str(runtime),
+                goal_id=GOAL_ID,
+                project=None,
+                state_file=None,
+                classification="validated_delivery_fixture",
+                recommended_action="complete the current todo",
+                delivery_batch_scale="implementation",
+                delivery_outcome="outcome_progress",
+                agent_id=AGENT_ID,
+                progress_scope="agent_lane",
+                dry_run=False,
+                sync_global=False,
+            )
+        workspace = refresh["delivery_workspace"]
+        assert workspace == {
+            "schema_version": "delivery_workspace_v0",
+            "task_repository": DELIVERY_REPOSITORY,
+            "repository_source": "current_git_origin",
+            "workspace_kind": "independent_git_worktree",
+            "peer_independent_worktree_required": True,
+        }, workspace
+
+        # Completing the todo may select work in another repository.  Spending
+        # from the original delivery worktree remains valid and attributable.
+        with working_directory(delivery_peer):
+            causal = preview(runtime, quota_decision(workspace_repair=True))
+        assert causal["ok"] is True, causal
+        assert causal["delivery_completion_spend"] is True, causal
+        assert causal["delivery_workspace_validated"] is True, causal
+        event = build_quota_slot_spend_event(
+            causal,
+            self_repair_spend_actions=frozenset(),
+            source="heartbeat",
+        )
+        assert event["quota_event"]["delivery_workspace"] == workspace, event
+        assert event["quota_event"]["delivery_workspace_validated"] is True, event
+
+        # A worktree matching the next todo but not the accountable delivery
+        # repository must not be allowed to account for that delivery.
+        with working_directory(next_peer):
+            foreign = preview(runtime, quota_decision(workspace_repair=False))
+        assert foreign["ok"] is False, foreign
+        guard = foreign["workspace_guard"]
+        assert guard["current_workspace"] == "foreign_git_worktree", guard
+        assert guard["task_repository"] == DELIVERY_REPOSITORY, guard
+        assert guard["repository_source"] == (
+            "delivery_run.delivery_workspace.task_repository"
+        ), guard
+
+        # The canonical checkout is also not a substitute for the independent
+        # worktree that produced the peer delivery.
+        with working_directory(delivery):
+            canonical = preview(runtime, quota_decision(workspace_repair=True))
+        assert canonical["ok"] is False, canonical
+        assert canonical["workspace_guard"]["current_workspace"] == (
+            "canonical_checkout"
+        ), canonical
+
+        # A peer delivery recorded from a canonical checkout is itself unsafe;
+        # moving to an independent worktree later must not bless that history.
+        index_path = runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
+        recorded_canonical = json.loads(index_path.read_text(encoding="utf-8").strip())
+        recorded_canonical["delivery_workspace"] = {
+            **workspace,
+            "workspace_kind": "canonical_checkout",
+        }
+        index_path.write_text(
+            json.dumps(recorded_canonical) + "\n",
+            encoding="utf-8",
+        )
+        with working_directory(delivery_peer):
+            unsafe_history = preview(runtime, quota_decision(workspace_repair=False))
+        assert unsafe_history["ok"] is False, unsafe_history
+        assert unsafe_history["workspace_guard"]["current_workspace"] == (
+            "delivery_not_recorded_from_independent_worktree"
+        ), unsafe_history
+
+        # Old accountable runs lack the causal snapshot.  Keep the previous
+        # selected-todo workspace repair behavior instead of guessing.
+        legacy = json.loads(index_path.read_text(encoding="utf-8").strip())
+        legacy.pop("delivery_workspace", None)
+        index_path.write_text(json.dumps(legacy) + "\n", encoding="utf-8")
+        with working_directory(delivery_peer):
+            legacy_preview = preview(runtime, quota_decision(workspace_repair=True))
+        assert legacy_preview["ok"] is False, legacy_preview
+        assert legacy_preview["delivery_workspace_validated"] is False, legacy_preview
+        assert "moving to an independent worktree" in legacy_preview["reason"], (
+            legacy_preview
+        )
+
+    print("quota-spend-workspace-causality-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -1212,6 +1212,7 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
             "excluded_agents",
             "task_orchestration_contract",
             "agent_workspace_guard",
+            "loopx/control_plane/quota/slot_accounting.py",
             "loopx/control_plane/agents",
             "loopx/control_plane/todos/completion_policy.py",
             "loopx/control_plane/quota/task_orchestration.py",
@@ -1248,6 +1249,11 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
                 "command": "python3 examples/control_plane/peer-agent-workspace-guard-smoke.py",
                 "tier": "deep",
                 "reason": "guards symmetric write-aware worktree isolation in real git worktrees",
+            },
+            {
+                "command": "python3 examples/control_plane/quota-spend-workspace-causality-smoke.py",
+                "tier": "deep",
+                "reason": "binds post-completion quota spend to the accountable delivery repository without weakening cross-repo isolation",
             },
             {
                 "command": "python3 examples/control_plane/task-orchestration-smoke.py",

--- a/loopx/control_plane/agents/workspace_guard.py
+++ b/loopx/control_plane/agents/workspace_guard.py
@@ -5,9 +5,10 @@ import subprocess
 from typing import Any
 
 from ...repository_identity import normalize_repository_identity
-from ..todos.contract import normalize_todo_task_repository
+from ..todos.contract import normalize_todo_claimed_by, normalize_todo_task_repository
 
 AGENT_WORKSPACE_GUARD_SCHEMA_VERSION = "agent_workspace_guard_v1"
+DELIVERY_WORKSPACE_SCHEMA_VERSION = "delivery_workspace_v0"
 PEER_WRITE_ACTION_KINDS = {
     "fix",
     "implement",
@@ -94,6 +95,134 @@ def _git_repository_identity(path: Path) -> str | None:
         return normalize_repository_identity(remote)
     except ValueError:
         return None
+
+
+def capture_delivery_workspace(
+    current_path: Path | None = None,
+    *,
+    peer_independent_worktree_required: bool = False,
+) -> dict[str, Any] | None:
+    """Capture a compact, credential-free delivery workspace identity.
+
+    The snapshot intentionally excludes local paths and branch names.  It is
+    safe to persist with an accountable run and later binds quota accounting
+    to the repository where that delivery was actually written.
+    """
+
+    path = current_path or Path.cwd()
+    current_root = _git_worktree_root(path)
+    if current_root is None:
+        return None
+    current_common = _git_common_dir(path)
+    current_git_dir = _git_dir(path)
+    task_repository = _git_repository_identity(path)
+    if not task_repository or current_common is None or current_git_dir is None:
+        return None
+    workspace_kind = (
+        "independent_git_worktree"
+        if current_git_dir != current_common
+        else "canonical_checkout"
+    )
+    return {
+        "schema_version": DELIVERY_WORKSPACE_SCHEMA_VERSION,
+        "task_repository": task_repository,
+        "repository_source": "current_git_origin",
+        "workspace_kind": workspace_kind,
+        "peer_independent_worktree_required": bool(
+            peer_independent_worktree_required
+        ),
+    }
+
+
+def delivery_workspace_repository(value: Any) -> str | None:
+    if not isinstance(value, dict):
+        return None
+    if value.get("schema_version") != DELIVERY_WORKSPACE_SCHEMA_VERSION:
+        return None
+    if value.get("workspace_kind") not in {
+        "canonical_checkout",
+        "independent_git_worktree",
+    }:
+        return None
+    if not isinstance(value.get("peer_independent_worktree_required"), bool):
+        return None
+    try:
+        return normalize_todo_task_repository(value.get("task_repository"))
+    except (TypeError, ValueError):
+        return None
+
+
+def build_delivery_workspace_guard(
+    delivery_run: dict[str, Any],
+    *,
+    agent_id: str | None = None,
+    current_path: Path | None = None,
+) -> dict[str, Any] | None:
+    """Validate quota accounting against its accountable delivery workspace.
+
+    Legacy delivery runs without a snapshot return ``None`` so the existing
+    selected-todo workspace guard remains the fail-closed fallback.
+    """
+
+    snapshot = (
+        delivery_run.get("delivery_workspace")
+        if isinstance(delivery_run.get("delivery_workspace"), dict)
+        else {}
+    )
+    task_repository = delivery_workspace_repository(snapshot)
+    if not task_repository:
+        return None
+
+    current = capture_delivery_workspace(current_path)
+    current_repository = str((current or {}).get("task_repository") or "")
+    current_workspace = str((current or {}).get("workspace_kind") or "")
+    recorded_workspace = str(snapshot.get("workspace_kind") or "")
+    peer_independent_worktree_required = bool(
+        snapshot.get("peer_independent_worktree_required")
+    )
+    if not current:
+        current_workspace = "not_git_worktree"
+    elif current_repository != task_repository:
+        current_workspace = "foreign_git_worktree"
+    elif (
+        recorded_workspace == "independent_git_worktree"
+        and current_workspace != "independent_git_worktree"
+    ):
+        current_workspace = "canonical_checkout"
+    elif (
+        peer_independent_worktree_required
+        and recorded_workspace != "independent_git_worktree"
+    ):
+        current_workspace = "delivery_not_recorded_from_independent_worktree"
+    else:
+        return None
+
+    return {
+        "schema_version": AGENT_WORKSPACE_GUARD_SCHEMA_VERSION,
+        "source": "quota.spend_slot.delivery_workspace",
+        "action": "return_to_delivery_worktree",
+        "current_workspace": current_workspace,
+        "required_workspace": (
+            "accountable_delivery_independent_git_worktree"
+            if recorded_workspace == "independent_git_worktree"
+            or peer_independent_worktree_required
+            else "accountable_delivery_git_checkout"
+        ),
+        "blocks_delivery": True,
+        "agent_id": normalize_todo_claimed_by(agent_id),
+        "repository_source": "delivery_run.delivery_workspace.task_repository",
+        "task_repository": task_repository,
+        "delivery_run_generated_at": delivery_run.get("generated_at"),
+        "delivery_run_classification": delivery_run.get("classification"),
+        "reason": (
+            "quota spend workspace does not match the latest unspent accountable "
+            "delivery workspace"
+        ),
+        "required_action": (
+            "run quota spend-slot from the workspace that produced the latest "
+            "unspent accountable delivery"
+        ),
+    }
 
 
 def _peer_candidate_items(agent_todo_summary: dict[str, Any] | None) -> list[dict[str, Any]]:

--- a/loopx/control_plane/quota/slot_accounting.py
+++ b/loopx/control_plane/quota/slot_accounting.py
@@ -11,6 +11,10 @@ from .scheduler_ack import QUOTA_SCHEDULER_ACK_CLASSIFICATION
 from .spend_sources import DEFAULT_SLOT_SPEND_SOURCE, VALID_SLOT_SPEND_SOURCES
 from ..runtime.time import now_local_iso
 from ..runtime.run_artifacts import run_file_stem, unique_run_artifact_paths
+from ..agents.workspace_guard import (
+    build_delivery_workspace_guard,
+    delivery_workspace_repository,
+)
 from ..todos.contract import normalize_todo_claimed_by
 from ..work_items.delivery_outcome import (
     ACCOUNTABLE_DELIVERY_OUTCOMES,
@@ -176,9 +180,57 @@ def build_quota_slot_preview_for_decision(
         before.get("effective_action") == "capability_bridge_repair"
         and before.get("capability_repair_allowed") is True
     )
+    raw_runtime_root = status_payload.get("runtime_root")
+    delivery_completion_run = (
+        _latest_unspent_accountable_delivery_run(
+            Path(str(raw_runtime_root)).expanduser(),
+            safe_goal_id,
+            agent_id=safe_requested_agent_id,
+        )
+        if raw_runtime_root
+        else None
+    )
+    raw_delivery_workspace = (
+        delivery_completion_run.get("delivery_workspace")
+        if isinstance(delivery_completion_run, dict)
+        and isinstance(delivery_completion_run.get("delivery_workspace"), dict)
+        else None
+    )
+    delivery_workspace = (
+        raw_delivery_workspace
+        if delivery_workspace_repository(raw_delivery_workspace)
+        else None
+    )
+    delivery_workspace_guard = (
+        build_delivery_workspace_guard(
+            delivery_completion_run,
+            agent_id=safe_requested_agent_id,
+        )
+        if delivery_completion_run and delivery_workspace
+        else None
+    )
+    if delivery_workspace_guard:
+        return {
+            "ok": False,
+            "mode": "spend-slot",
+            "dry_run": True,
+            "goal_id": safe_goal_id,
+            "slots": safe_slots,
+            "agent_id": safe_requested_agent_id,
+            "appended": False,
+            "registry_mutated": False,
+            "reason": delivery_workspace_guard["reason"],
+            "workspace_guard": delivery_workspace_guard,
+            "delivery_workspace": delivery_workspace,
+            "delivery_workspace_validated": False,
+            "before": before,
+            "after": None,
+        }
+    delivery_workspace_validated = bool(delivery_workspace)
     workspace_repair_no_spend = (
         before.get("effective_action") == "agent_workspace_repair"
         and before.get("workspace_repair_allowed") is True
+        and not delivery_workspace_validated
     )
     if workspace_repair_no_spend:
         return {
@@ -190,6 +242,8 @@ def build_quota_slot_preview_for_decision(
             "agent_id": safe_requested_agent_id,
             "appended": False,
             "registry_mutated": False,
+            "delivery_workspace": delivery_workspace,
+            "delivery_workspace_validated": False,
             "reason": (
                 "agent workspace guard requires moving to an independent "
                 "worktree and rerunning quota should-run before quota spend"
@@ -197,22 +251,16 @@ def build_quota_slot_preview_for_decision(
             "before": before,
             "after": None,
         }
-    raw_runtime_root = status_payload.get("runtime_root")
-    delivery_completion_run = (
-        _latest_unspent_accountable_delivery_run(
-            Path(str(raw_runtime_root)).expanduser(),
-            safe_goal_id,
-            agent_id=safe_requested_agent_id,
-        )
-        if raw_runtime_root
-        else None
-    )
     delivery_completion_spend = (
         delivery_completion_run is not None
         and before.get("ok")
         and (
             not before.get("should_run")
             or before.get("effective_action") == "external_evidence_observe"
+            or (
+                before.get("effective_action") == "agent_workspace_repair"
+                and delivery_workspace_validated
+            )
         )
         and before.get("effective_action") != "automation_prompt_upgrade_required"
         and not safe_bypass_spend
@@ -315,6 +363,8 @@ def build_quota_slot_preview_for_decision(
         "delivery_run_recommended_action": delivery_completion_run.get("recommended_action")
         if delivery_completion_run
         else None,
+        "delivery_workspace": delivery_workspace,
+        "delivery_workspace_validated": delivery_workspace_validated,
     }
 
 
@@ -440,6 +490,10 @@ def build_quota_slot_spend_event(
             "delivery_run_classification": preview.get("delivery_run_classification"),
             "delivery_run_agent_id": preview.get("delivery_run_agent_id"),
             "delivery_run_recommended_action": delivery_run_action or None,
+            "delivery_workspace": preview.get("delivery_workspace"),
+            "delivery_workspace_validated": bool(
+                preview.get("delivery_workspace_validated")
+            ),
             "before": before_compact,
             "after": after_compact,
         },

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -12,9 +12,11 @@ from .control_plane.work_items.delivery_batch_scale import (
     require_delivery_batch_scale,
 )
 from .control_plane.work_items.delivery_outcome import (
+    ACCOUNTABLE_DELIVERY_OUTCOMES,
     DELIVERY_OUTCOME_CHOICES as DELIVERY_OUTCOME_CHOICES,
     require_delivery_outcome,
 )
+from .control_plane.agents.workspace_guard import capture_delivery_workspace
 from .control_plane.work_items.repair_delta import (
     REPAIR_DELTA_KIND_CHOICES as REPAIR_DELTA_KIND_CHOICES,
     normalize_repair_delta_kinds,
@@ -549,6 +551,7 @@ def build_state_refresh_record(
     repair_delta_contract: dict[str, Any] | None = None,
     agent_vision: dict[str, Any] | None = None,
     vision_checkpoint: dict[str, Any] | None = None,
+    delivery_workspace: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     frontmatter = parse_frontmatter(state_text)
     next_action = extract_section_lines(state_text, "Next Action")
@@ -591,6 +594,8 @@ def build_state_refresh_record(
         record["delivery_batch_scale"] = delivery_batch_scale
     if delivery_outcome:
         record["delivery_outcome"] = delivery_outcome
+    if delivery_workspace:
+        record["delivery_workspace"] = delivery_workspace
     if autonomous_replan_recorded:
         record["autonomous_replan_ack"] = {
             "schema_version": "autonomous_replan_ack_v0",
@@ -639,6 +644,17 @@ def render_state_refresh_markdown(payload: dict[str, Any]) -> str:
         lines.append(
             "- external_sink_delivery_authorized: "
             f"`{payload.get('external_sink_delivery_authorized')}`"
+        )
+    delivery_workspace = (
+        payload.get("delivery_workspace")
+        if isinstance(payload.get("delivery_workspace"), dict)
+        else {}
+    )
+    if delivery_workspace:
+        lines.append(
+            "- delivery_workspace: "
+            f"repository={delivery_workspace.get('task_repository')} "
+            f"kind={delivery_workspace.get('workspace_kind')}"
         )
     if payload.get("error"):
         lines.append(f"- error: {payload.get('error')}")
@@ -961,6 +977,13 @@ def refresh_state_run(
         active_state_next_action_update=active_state_next_action_update,
         repair_delta_kinds=normalized_repair_delta_kinds,
     )
+    delivery_workspace = (
+        capture_delivery_workspace(
+            peer_independent_worktree_required=multi_agent_goal,
+        )
+        if normalized_delivery_outcome in ACCOUNTABLE_DELIVERY_OUTCOMES
+        else None
+    )
     record = build_state_refresh_record(
         goal_id=safe_goal_id,
         state_file=resolved_state_file,
@@ -979,6 +1002,7 @@ def refresh_state_run(
         repair_delta_contract=repair_delta_contract,
         agent_vision=agent_vision,
         vision_checkpoint=vision_checkpoint,
+        delivery_workspace=delivery_workspace,
     )
     if autonomous_replan_recorded:
         if "autonomous_replan_ack" not in record:
@@ -1038,6 +1062,8 @@ def refresh_state_run(
         index_record["delivery_batch_scale"] = normalized_delivery_batch_scale
     if normalized_delivery_outcome:
         index_record["delivery_outcome"] = normalized_delivery_outcome
+    if delivery_workspace:
+        index_record["delivery_workspace"] = delivery_workspace
     if autonomous_replan_recorded:
         index_record["autonomous_replan_ack"] = record["autonomous_replan_ack"]
         if requested_classification != classification:


### PR DESCRIPTION
## Summary
- capture a compact, path-free repository/worktree snapshot on accountable state refreshes
- validate quota spend against the delivery run snapshot before considering the newly selected todo workspace
- preserve fail-closed behavior for legacy runs and reject foreign/canonical peer accounting
- add a real-git cross-repository regression to the peer runtime and canary planner

## Commits
1. `fix(quota): bind spend to delivery workspace`
2. `test(quota): cover cross-repo spend causality`

## Validation
- `loopx canary premerge --from-git-diff`: 17/17 checks passed; no warnings or manual holds; self-merge allowed
- focused workspace-causality, workspace-guard, identity, and refresh-state smokes passed
- `loopx check` public-boundary scan: 6 files clean
- `git diff --check` and changed Python compilation passed

## Boundary
No local runtime state, paths, credentials, or private project identifiers are included.

## Residual risk
Legacy accountable runs do not carry a delivery snapshot and intentionally keep the prior fail-closed selected-todo workspace guard.