### PR TITLE
fix(quota): bind guards to selected todo

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1196,6 +1196,11 @@ an independent worktree/branch, and require rerunning `quota should-run` with
 the same `--agent-id` before repository edits. This preflight does not spend
 quota; `quota spend-slot` should fail closed until the guard is rerun from the
 independent worktree.
+Workspace and boundary guards must bind to the final work-lane `selected_todo`
+after due-monitor, capability-fallback, and scoped-gate routing. They must not
+inherit repository or write-scope semantics from an unrelated first executable
+backlog item; in particular, a selected read-only continuous monitor stays
+monitor work even when a separate repository repair is also runnable.
 If the selected todo declares `task_repository`, the guard should also project
 that credential-free identity with
 `workspace_guard.repository_source=selected_todo.task_repository`; otherwise

--- a/examples/control_plane/peer-agent-workspace-guard-smoke.py
+++ b/examples/control_plane/peer-agent-workspace-guard-smoke.py
@@ -16,6 +16,7 @@ GOAL_ID = "workspace-guard-canary"
 PEER_ALPHA = "codex-alpha"
 PEER_BETA = "codex-beta"
 TASK_REPOSITORY = "git:example.invalid/loopx/task-repo"
+PROJECT_REPOSITORY = "git:example.invalid/loopx/project-repo"
 
 
 def run_git(cwd: Path, *args: str) -> None:
@@ -67,6 +68,13 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path, Path, Path, Path]:
     project.mkdir(parents=True)
     (project / "README.md").write_text("# Workspace Guard Canary\n", encoding="utf-8")
     run_git(project, "init", "--initial-branch", "main")
+    run_git(
+        project,
+        "remote",
+        "add",
+        "origin",
+        "https://example.invalid/loopx/project-repo.git",
+    )
     run_git(project, "add", "README.md")
     run_git(
         project,
@@ -261,6 +269,44 @@ def main() -> None:
         assert goal_worktree_guarded["workspace_guard"]["task_repository"] == (
             TASK_REPOSITORY
         ), goal_worktree_guarded
+
+        registry = json.loads(registry_path.read_text(encoding="utf-8"))
+        registry["goals"][0].pop("workspace_guard_policy", None)
+        registry_path.write_text(
+            json.dumps(registry, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        state_path = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+        state_path.write_text(
+            "---\nstatus: active\nowner_mode: goal\n"
+            'objective: "Exercise selected-todo workspace routing."\n'
+            "updated_at: 2026-01-01T00:00:00+00:00\n---\n\n"
+            "# Selected Todo Workspace Guard Canary\n\n## Agent Todo\n\n"
+            "- [ ] [P0] Monitor one due repository lifecycle without repository writes.\n"
+            f"  <!-- loopx:todo todo_id=todo_due_monitor status=open "
+            f"task_class=continuous_monitor action_kind=monitor_repository_lifecycle "
+            f"task_repository={PROJECT_REPOSITORY} claimed_by={PEER_ALPHA} "
+            "target_key=repository-lifecycle cadence=30m "
+            "next_due_at=2020-01-01T00:00:00+00:00 "
+            "expires_at=2099-01-01T00:00:00+00:00 -->\n"
+            "- [ ] [P1] Repair a separate repository-writing control-plane task.\n"
+            f"  <!-- loopx:todo todo_id=todo_unrelated_repair status=open "
+            f"task_class=advancement_task action_kind=repair_workspace_route "
+            f"task_repository={TASK_REPOSITORY} required_write_scopes=loopx/** "
+            f"claimed_by={PEER_ALPHA} -->\n",
+            encoding="utf-8",
+        )
+
+        monitor_selected = should_run(project, project, runtime, registry_path)
+        assert monitor_selected["decision"] == "run", monitor_selected
+        assert "workspace_guard" not in monitor_selected, monitor_selected
+        assert "boundary_projection_gap" not in monitor_selected, monitor_selected
+        assert monitor_selected["selected_todo"]["todo_id"] == (
+            "todo_due_monitor"
+        ), monitor_selected
+        assert monitor_selected["selected_todo"]["task_repository"] == (
+            PROJECT_REPOSITORY
+        ), monitor_selected
 
 
 if __name__ == "__main__":

--- a/loopx/control_plane/agents/workspace_guard.py
+++ b/loopx/control_plane/agents/workspace_guard.py
@@ -242,16 +242,23 @@ def _peer_candidate_items(agent_todo_summary: dict[str, Any] | None) -> list[dic
 def _peer_work_requires_isolated_workspace(
     workspace_guard_policy: dict[str, Any],
     agent_todo_summary: dict[str, Any] | None,
+    *,
+    selected_todo: dict[str, Any] | None = None,
 ) -> bool:
     explicit = workspace_guard_policy.get("peer_independent_worktree_required")
     if explicit is not None:
         return explicit is True
-    candidates = _peer_candidate_items(agent_todo_summary)
-    if not candidates:
+    candidate = (
+        selected_todo
+        if isinstance(selected_todo, dict) and selected_todo
+        else next(iter(_peer_candidate_items(agent_todo_summary)), None)
+    )
+    if not isinstance(candidate, dict):
         return False
-    candidate = candidates[0]
     if candidate.get("required_write_scopes"):
         return True
+    if str(candidate.get("task_class") or "").strip().lower() == "continuous_monitor":
+        return False
     action_kind = str(candidate.get("action_kind") or "").strip().lower()
     return action_kind in PEER_WRITE_ACTION_KINDS or action_kind.startswith(
         tuple(f"{prefix}_" for prefix in PEER_WRITE_ACTION_KINDS)
@@ -263,6 +270,7 @@ def build_agent_workspace_guard(
     agent_identity: dict[str, Any] | None,
     *,
     agent_todo_summary: dict[str, Any] | None = None,
+    selected_todo: dict[str, Any] | None = None,
     current_path: Path | None = None,
 ) -> dict[str, Any] | None:
     if not isinstance(agent_identity, dict):
@@ -277,11 +285,15 @@ def build_agent_workspace_guard(
     if not _peer_work_requires_isolated_workspace(
         workspace_guard_policy,
         agent_todo_summary,
+        selected_todo=selected_todo,
     ):
         return None
     current_path = current_path or Path.cwd()
-    candidates = _peer_candidate_items(agent_todo_summary)
-    candidate = candidates[0] if candidates else {}
+    candidate = (
+        selected_todo
+        if isinstance(selected_todo, dict) and selected_todo
+        else next(iter(_peer_candidate_items(agent_todo_summary)), {})
+    )
     task_repository = normalize_todo_task_repository(candidate.get("task_repository"))
     current_workspace = ""
     repository_source = "goal.repo"

--- a/loopx/control_plane/quota/projection_repair.py
+++ b/loopx/control_plane/quota/projection_repair.py
@@ -149,11 +149,14 @@ def build_boundary_projection_repair_hint(
     *,
     candidate_should_run: bool,
     capability_gate: dict[str, Any] | None = None,
+    selected_todo: dict[str, Any] | None = None,
 ) -> dict[str, Any] | None:
     if not candidate_should_run or not isinstance(agent_todo_summary, dict):
         return None
     candidate_items: list[dict[str, Any]] = []
-    if isinstance(capability_gate, dict):
+    if isinstance(selected_todo, dict) and selected_todo:
+        candidate_items.append(selected_todo)
+    elif isinstance(capability_gate, dict):
         if capability_gate.get("action") != "run":
             return None
         runnable_candidates = capability_gate.get("runnable_candidates")
@@ -161,7 +164,7 @@ def build_boundary_projection_repair_hint(
             candidate_items.extend(
                 item for item in runnable_candidates if isinstance(item, dict)
             )
-    if not candidate_items:
+    if not candidate_items and not selected_todo:
         for key in ("first_executable_items", "first_open_items"):
             value = agent_todo_summary.get(key)
             if isinstance(value, list):

--- a/loopx/control_plane/quota/selected_todo_projection.py
+++ b/loopx/control_plane/quota/selected_todo_projection.py
@@ -15,6 +15,7 @@ SELECTED_TODO_COMPACT_FIELDS = (
     "task_class",
     "action_kind",
     "task_repository",
+    "required_write_scopes",
     "claimed_by",
     "blocks_agent",
     "excluded_agents",

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -1354,11 +1354,7 @@ def build_quota_should_run(
             recovery_allowed = False
             reason = str(quota["reason"])
         goal_boundary = _goal_boundary(registry_goal or item, item=item, agent_id=normalize_todo_claimed_by((agent_identity or {}).get("agent_id")), lark_event_inbox_urgency_projector=_project_lark_event_inbox_urgency)
-        workspace_guard = build_agent_workspace_guard(
-            item,
-            agent_identity,
-            agent_todo_summary=agent_todo_summary,
-        )
+        workspace_guard = None
         automation_prompt_upgrade = _automation_prompt_upgrade(
             item,
             goal_id=safe_goal_id,
@@ -1411,9 +1407,15 @@ def build_quota_should_run(
             scoped_user_gate_fallback, current_contract=work_lane_contract) or work_lane_contract
         work_lane_contract = lark_inbox_reply_due_work_lane_contract(goal_boundary, current_contract=work_lane_contract)
         inbox_reply_due = work_lane_contract_is_lark_inbox_reply_due(work_lane_contract)
+        work_lane_selected_todo = _selected_todo_projection(
+            agent_lane_next_action=None, work_lane_contract=work_lane_contract)
         if inbox_reply_due:
             task_orchestration_contract = capability_gate = capability_monitor_contract = None
             capability_monitor_fallback = scoped_user_gate_fallback = workspace_guard = None
+        else:
+            workspace_guard = build_agent_workspace_guard(
+                item, agent_identity, agent_todo_summary=agent_todo_summary,
+                selected_todo=work_lane_selected_todo)
         agent_frontier_id = (
             normalize_todo_claimed_by(agent_identity.get("agent_id"))
             if isinstance(agent_identity, dict)
@@ -1468,7 +1470,7 @@ def build_quota_should_run(
             candidate_should_run=bool(
                 normal_delivery_allowed or recovery_allowed or self_repair_allowed
             ),
-            capability_gate=capability_gate,
+            capability_gate=capability_gate, selected_todo=work_lane_selected_todo,
         )
         if boundary_projection_repair:
             stall_self_repair = boundary_projection_repair


### PR DESCRIPTION
## Summary

- bind workspace isolation to the final work-lane selected todo after due-monitor and capability routing
- bind boundary projection repair to the same selected todo instead of an unrelated executable backlog item
- keep derived workspace isolation off read-only continuous monitors unless an explicit policy or write scope requires it
- add a real CLI regression fixture where a due monitor coexists with a cross-repository repair

## Validation

- `python3 examples/control_plane/peer-agent-workspace-guard-smoke.py`
- workspace, boundary, monitor, work-lane, spend-causality, peer-runtime, review-packet, and projection smokes passed
- `11 passed` in `tests/control_plane/test_quota_slot_accounting.py`
- premerge catalog checks, Python compilation, diff checks, CLI output budget, and repository line budget passed
- Ruff passed on touched focused modules; `loopx/quota.py` retains the pre-existing `origin/main` F401 baseline and has no new non-F401 findings

## Boundary

Public generic control-plane code, contract docs, and durable smoke only. No project state, runtime receipts, local paths, credentials, raw logs, or private artifacts are included.