### PR TITLE
Fix Explore source config routing

### DIFF
--- a/examples/lark-explore-source-runtime-route-smoke.py
+++ b/examples/lark-explore-source-runtime-route-smoke.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -23,9 +24,15 @@ from loopx.capabilities.explore.result_log import (  # noqa: E402
 from loopx.capabilities.issue_fix.explore_projection import (  # noqa: E402
     ISSUE_FIX_LANE_ID,
 )
+from loopx.capabilities.explore.activation import (  # noqa: E402
+    sync_explore_graph_after_material_refresh,
+)
 from loopx.presentation.sinks.lark.explore_results import (  # noqa: E402
     sync_issue_fix_explore_on_material_change,
     write_lark_explore_local_config,
+)
+from loopx.presentation.sinks.lark.explore_singleflight import (  # noqa: E402
+    explore_feishu_sync_singleflight,
 )
 
 
@@ -43,6 +50,7 @@ def _write_registry(path: Path, *, runtime: Path, project: Path, state: Path) ->
                         "id": GOAL_ID,
                         "repo": str(project),
                         "state_file": str(state),
+                        "explore_graph": {"enabled": True},
                     }
                 ],
             }
@@ -113,7 +121,8 @@ def main() -> None:
         )
         _append_node(shared_runtime, node_id="shared_only", title="Stale shared node")
 
-        config_path = shared_root / "lark-explore.json"
+        config_path = project_loopx / "lark-explore.json"
+        stale_config_path = shared_root / "lark-explore.json"
         baseline_config = {
             "board": {
                 "base_token": "PUBLIC_FIXTURE_BASE",
@@ -135,6 +144,31 @@ def main() -> None:
             },
         }
         write_lark_explore_local_config(config_path, baseline_config)
+        assert not stale_config_path.exists()
+
+        cli_sync = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--format",
+                "json",
+                "--registry",
+                str(shared_registry),
+                "explore",
+                "feishu-sync",
+                "--goal-id",
+                GOAL_ID,
+            ],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        cli_payload = json.loads(cli_sync.stdout)
+        assert Path(cli_payload["config_path"]).resolve() == config_path.resolve(), cli_payload
+        assert cli_payload["source_runtime_route"]["status"] == "source_registry", cli_payload
+        assert not stale_config_path.exists()
 
         routed = sync_issue_fix_explore_on_material_change(
             registry_path=shared_registry,
@@ -154,6 +188,31 @@ def main() -> None:
         assert route["status"] == "source_registry", route
         assert route["routed_to_source_registry"] is True, route
         assert not any("/" in str(value) for value in route.values() if value), route
+        assert Path(routed["config_path"]).resolve() == config_path.resolve(), routed
+        assert not stale_config_path.exists()
+
+        activated = sync_explore_graph_after_material_refresh(
+            registry_path=shared_registry,
+            goal_id=GOAL_ID,
+            project=project,
+            state_file=state,
+            external_sink_delivery_authorized=False,
+        )
+        assert activated["status"] == "external_sink_suppressed", activated
+        assert activated["source_runtime_route"]["status"] == "source_registry", activated
+        assert activated["delivery_postcondition"]["blocks_delivery"] is False, activated
+
+        with explore_feishu_sync_singleflight(config_path=config_path, execute=True):
+            busy = sync_issue_fix_explore_on_material_change(
+                registry_path=shared_registry,
+                goal_id=GOAL_ID,
+                project=project,
+                state_file=state,
+                execute=True,
+            )
+        assert busy["status"] == "sync_busy", busy
+        assert busy["external_write_performed"] is False, busy
+        assert not stale_config_path.exists()
 
         divergent_config = json.loads(config_path.read_text(encoding="utf-8"))
         divergent_config["result_records"][

--- a/loopx/capabilities/explore/activation.py
+++ b/loopx/capabilities/explore/activation.py
@@ -177,6 +177,7 @@ def sync_explore_graph_after_material_refresh(
         "needs_visual_sync": result.get("needs_visual_sync"),
         "row_readback_verified": row_readback_verified,
         "semantic_digest": result.get("semantic_digest"),
+        "source_runtime_route": projection.get("source_runtime_route"),
         "delivery_postcondition": explore_graph_delivery_postcondition(
             enabled=True,
             status=status,

--- a/loopx/cli_commands/explore.py
+++ b/loopx/cli_commands/explore.py
@@ -44,7 +44,6 @@ from ..presentation.sinks.lark.explore_results import (
     LarkExploreConfig,
     build_explore_result_card,
     configure_lark_explore_visual_sink,
-    default_lark_explore_config_path,
     explore_visual_semantic_digest,
     lark_explore_config_from_payload,
     lark_explore_schema_payload,
@@ -56,6 +55,7 @@ from ..presentation.sinks.lark.explore_results import (
     write_lark_explore_local_config,
 )
 from ..presentation.sinks.lark.explore_singleflight import (
+    default_lark_explore_config_path,
     explore_feishu_sync_busy_packet,
     explore_feishu_sync_singleflight,
 )
@@ -600,7 +600,11 @@ def handle_explore_command(
         config_path = (
             Path(args.config_path).expanduser()
             if getattr(args, "config_path", None)
-            else default_lark_explore_config_path(registry_path)
+            else default_lark_explore_config_path(
+                Path(str(source_runtime_route["source_registry"]))
+                if source_runtime_route is not None
+                else registry_path
+            )
         )
         if args.explore_command == "schema":
             payload = lark_explore_schema_payload()

--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -57,22 +57,26 @@ from .kanban import (
     now_lark_datetime,
     parse_lark_base_url,
 )
+from .explore_singleflight import (
+    default_lark_explore_config_path,
+    singleflight_issue_fix_material_sync,
+    source_lark_explore_config_path,
+)
 from .explore_stage_document import ensure_stage_whiteboards
-from .explore_singleflight import singleflight_issue_fix_material_sync
-from .explore_visual_styles import (
-    board_source_with_delivery_marker,
-    resolve_explore_board_style,
-    resolve_explore_board_style_update,
-    summarize_explore_visual_sync,
+from .explore_visual_integrity import (
+    cross_role_stage_token_conflict_delivery,
+    finalize_visual_role_results,
 )
 from .explore_visual_readback import (
     readback_visual_delivery_marker,
     settle_visual_stage_readbacks,
     structured_command_error,
 )
-from .explore_visual_integrity import (
-    cross_role_stage_token_conflict_delivery,
-    finalize_visual_role_results,
+from .explore_visual_styles import (
+    board_source_with_delivery_marker,
+    resolve_explore_board_style,
+    resolve_explore_board_style_update,
+    summarize_explore_visual_sync,
 )
 from .message_card import build_lark_markdown_reply_card
 
@@ -251,14 +255,6 @@ class LarkExploreConfig:
         if not table_id:
             raise ValueError(f"missing table id for {table_key}; run `loopx explore feishu-setup` first")
         return table_id
-
-
-def default_lark_explore_config_path(registry_path: Path | None = None) -> Path:
-    if registry_path is not None:
-        expanded = registry_path.expanduser()
-        if expanded.parent.name == ".loopx":
-            return expanded.parent / "lark-explore.json"
-    return Path.cwd() / ".loopx" / "lark-explore.json"
 
 
 def read_lark_explore_local_config(path: Path) -> dict[str, Any]:
@@ -1600,7 +1596,7 @@ def sync_explore_results_to_lark(
     }
 
 
-@singleflight_issue_fix_material_sync(default_lark_explore_config_path)
+@singleflight_issue_fix_material_sync(source_lark_explore_config_path)
 def sync_issue_fix_explore_on_material_change(
     *,
     registry_path: Path,
@@ -1641,7 +1637,7 @@ def sync_issue_fix_explore_on_material_change(
         execute=execute,
     )
     projection_result["source_runtime_route"] = compact_source_runtime_route
-    config_path = default_lark_explore_config_path(registry_path)
+    config_path = default_lark_explore_config_path(source_registry_path)
     local = read_lark_explore_local_config(config_path)
     config = lark_explore_config_from_payload(local) if local.get("ok") else None
     sync_state = (

--- a/loopx/presentation/sinks/lark/explore_singleflight.py
+++ b/loopx/presentation/sinks/lark/explore_singleflight.py
@@ -9,6 +9,30 @@ from typing import Any
 from ....file_lock import try_exclusive_file_lock
 
 
+def default_lark_explore_config_path(registry_path: Path | None = None) -> Path:
+    if registry_path is not None:
+        expanded = registry_path.expanduser()
+        if expanded.parent.name == ".loopx":
+            return expanded.parent / "lark-explore.json"
+    return Path.cwd() / ".loopx" / "lark-explore.json"
+
+
+def source_lark_explore_config_path(
+    registry_path: Path | None, goal_id: str
+) -> Path:
+    """Resolve the sink config beside the goal's canonical source registry."""
+
+    if registry_path is None or not goal_id:
+        return default_lark_explore_config_path(registry_path)
+    from .explore_source_guard import resolve_explore_source_registry
+
+    source_registry_path, _ = resolve_explore_source_registry(
+        registry_path=registry_path,
+        goal_id=goal_id,
+    )
+    return default_lark_explore_config_path(source_registry_path)
+
+
 @contextmanager
 def explore_feishu_sync_singleflight(
     *, config_path: Path, execute: bool
@@ -48,7 +72,7 @@ def explore_feishu_sync_busy_packet(
 
 
 def singleflight_issue_fix_material_sync(
-    config_path_resolver: Callable[[Path | None], Path],
+    config_path_resolver: Callable[[Path | None, str], Path],
 ) -> Callable[[Callable[..., dict[str, Any]]], Callable[..., dict[str, Any]]]:
     """Serialize an issue-fix material sync across row, visual, and checkpoint writes."""
 
@@ -63,12 +87,13 @@ def singleflight_issue_fix_material_sync(
             resolved_registry = (
                 Path(registry_path) if registry_path is not None else None
             )
+            goal_id = str(kwargs.get("goal_id") or "").strip()
             execute = bool(kwargs.get("execute", False))
             delivery_authorized = bool(
                 kwargs.get("external_sink_delivery_authorized", True)
             )
             with explore_feishu_sync_singleflight(
-                config_path=config_path_resolver(resolved_registry),
+                config_path=config_path_resolver(resolved_registry, goal_id),
                 execute=bool(execute and delivery_authorized),
             ) as acquired:
                 if not acquired:


### PR DESCRIPTION
## Summary
- route the Explore sink config and checkpoint beside the registry-declared source registry
- make automatic refresh and direct Explore CLI calls share the same source route
- serialize source-routed writes with the same singleflight lock and expose compact route diagnostics

## Validation
- `python3 examples/lark-explore-source-runtime-route-smoke.py`
- `python3 examples/issue-fix-explore-projection-smoke.py`
- `python3 examples/explore-feishu-singleflight-smoke.py`
- `loopx canary premerge --from-git-diff --tier standard` (8/8 selected checks passed)
- Ruff and Python compile checks passed
- public/private boundary scan clean

## Scope
No credentials, private state, raw logs, local paths, or generated runtime artifacts are included. The change is limited to Explore source routing, activation diagnostics, and its durable public smoke.