### PR TITLE
Fix issue-fix Explore source runtime resolution

### DIFF
--- a/loopx/capabilities/issue_fix/explore_projection.py
+++ b/loopx/capabilities/issue_fix/explore_projection.py
@@ -641,7 +641,7 @@ def project_issue_fix_explore_graph(
         state_file=state_file,
     )
     registry = load_registry(registry_path)
-    runtime_root = resolve_runtime_root(registry)
+    runtime_root = resolve_runtime_root(registry, registry_path=registry_path)
     result_log = explore_result_log_path(runtime_root, goal_id)
     existing_events = load_explore_result_events(result_log, goal_id=goal_id)
     outcomes_packet = build_issue_fix_outcome_collection_from_domain_state(

--- a/tests/control_plane/test_registry_relative_runtime_resolution.py
+++ b/tests/control_plane/test_registry_relative_runtime_resolution.py
@@ -6,7 +6,17 @@ from pathlib import Path
 import subprocess
 import sys
 
+import pytest
+
 from examples.control_plane.quota_plan_fixtures import write_cli_fixture
+from loopx.capabilities.explore.result_log import (
+    append_explore_result_event,
+    build_explore_node_event,
+    explore_result_log_path,
+)
+from loopx.capabilities.issue_fix.explore_projection import (
+    project_issue_fix_explore_graph,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -105,3 +115,37 @@ def test_history_and_quota_anchor_relative_runtime_to_registry_project(
     assert decision["should_run"] is True
     assert decision["normal_delivery_allowed"] is True
     assert decision["decision"] == "run"
+
+
+def test_issue_fix_explore_projection_anchors_relative_runtime_to_registry_project(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry_path, runtime_root, project = write_cli_fixture(tmp_path / "fixture")
+    target_runtime = _make_runtime_paths_project_relative(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        project=project,
+    )
+    result_log = explore_result_log_path(target_runtime, "half-speed")
+    append_explore_result_event(
+        result_log,
+        build_explore_node_event(
+            goal_id="half-speed",
+            node_id="canonical_source_node",
+            title="Canonical source node",
+        ),
+    )
+    independent_worktree = tmp_path / "independent-worktree"
+    independent_worktree.mkdir()
+    monkeypatch.chdir(independent_worktree)
+
+    projection = project_issue_fix_explore_graph(
+        registry_path=registry_path,
+        goal_id="half-speed",
+    )
+
+    assert projection["material_event_count"] == 0
+    assert {
+        node["node_id"] for node in projection["projection"]["nodes"]
+    } == {"canonical_source_node"}


### PR DESCRIPTION
## Summary

- anchor the Issue Fix Explore projection runtime to the registry that declared a relative `common_runtime_root`
- preserve the canonical Explore result log when sync runs from an independent cross-repository worktree
- add a regression test that changes CWD and proves the canonical source node remains projected

## Validation

- `pytest -q tests/control_plane/test_registry_relative_runtime_resolution.py tests/test_explore_source_history_reconcile.py` (4 passed)
- `python examples/issue-fix-explore-projection-smoke.py`
- `python examples/lark-explore-source-runtime-route-smoke.py`
- `ruff check` on changed files
- `loopx canary premerge --from-git-diff --tier standard` (5/5 selected catalog checks passed; no warnings or manual holds)
- real OpenViking dry-run: projection restored from 159 to the canonical 907 rows and changed from `source_projection_regression_blocked` to `unchanged`, with no external write

## Boundary

No private state, local paths, raw logs, credentials, docs, permissions, destructive cleanup, or external sink data are included. The change reuses the existing registry-relative path contract and does not introduce a new reconciliation state machine.