### PR TITLE
Fix user-gate scheduler and lane deadlock

### DIFF
--- a/loopx/control_plane/agents/agent_scope.py
+++ b/loopx/control_plane/agents/agent_scope.py
@@ -317,6 +317,11 @@ def _scoped_user_gate_fallback(
         if isinstance(agent_todo_summary.get("monitor_due_items"), list)
         else []
     )
+    ready_deferred_candidates = (
+        agent_todo_summary.get("deferred_resume_candidates")
+        if isinstance(agent_todo_summary.get("deferred_resume_candidates"), list)
+        else []
+    )
 
     # An empty capability projection is authoritative for advancement work.
     # Due monitors are projected separately from advancement candidates and are
@@ -327,7 +332,11 @@ def _scoped_user_gate_fallback(
         else None
     )
     if isinstance(capability_candidates, list):
-        executable_items = [*due_monitor_candidates, *capability_candidates]
+        executable_items = [
+            *due_monitor_candidates,
+            *capability_candidates,
+            *ready_deferred_candidates,
+        ]
     else:
         advancement_items = (
             agent_todo_summary.get("executable_backlog_items")
@@ -336,7 +345,11 @@ def _scoped_user_gate_fallback(
             if isinstance(agent_todo_summary.get("first_executable_items"), list)
             else []
         )
-        executable_items = [*due_monitor_candidates, *advancement_items]
+        executable_items = [
+            *due_monitor_candidates,
+            *advancement_items,
+            *ready_deferred_candidates,
+        ]
     executable_items = [item for item in executable_items if isinstance(item, dict)]
     deduped_executable_items: list[dict[str, Any]] = []
     seen_todo_ids: set[str] = set()
@@ -388,6 +401,11 @@ def _scoped_user_gate_fallback(
     selected_text = str(selected.get("text") or "").strip()
     gate_to_surface = blocking_gate or gates[0]
     selected_item = compact_todo_summary_item(selected, text=selected_text)
+    selected_is_deferred_replan = (
+        todo_item_is_deferred(selected) and selected.get("resume_ready") is True
+    )
+    if selected_is_deferred_replan:
+        selected_item["fallback_kind"] = "deferred_successor_replan"
     selected_relation = _todo_gate_relation(gate_to_surface, selected)
     if selected_relation:
         selected_item["todo_gate_relation"] = selected_relation
@@ -397,7 +415,10 @@ def _scoped_user_gate_fallback(
         "executable fallback remains available"
         if blocking_gate
         else (
-            "an open user_gate blocks a different action scope, but the selected "
+            "an open user_gate blocks a different action scope, but the ready "
+            "deferred successor can be replanned independently"
+            if selected_is_deferred_replan
+            else "an open user_gate blocks a different action scope, but the selected "
             "executable agent todo is non-dependent and safe to advance"
         )
     )
@@ -411,7 +432,11 @@ def _scoped_user_gate_fallback(
         "blocked_agent_items": blocked_items[:3],
         "selected_executable": selected_item,
         "recommended_action": (
-            "Notify the user about the scoped gate; then execute the selected "
+            "Notify the user about the scoped gate; then reopen, supersede, or "
+            "record a no-follow-up rationale for the selected ready deferred "
+            "successor, spending only after validated writeback."
+            if selected_is_deferred_replan
+            else "Notify the user about the scoped gate; then execute the selected "
             "non-gated fallback and spend only after validated writeback."
         ),
     }

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -783,10 +783,18 @@ def build_scheduler_hint(
         if isinstance(interaction_contract.get("user_channel"), dict)
         else {}
     )
+    agent_channel = (
+        interaction_contract.get("agent_channel")
+        if isinstance(interaction_contract.get("agent_channel"), dict)
+        else {}
+    )
     effective_action = str(payload.get("effective_action") or "")
     recommended_mode = str(heartbeat_recommendation.get("recommended_mode") or "")
     must_attempt_work = bool(execution_obligation.get("must_attempt_work"))
     user_required = user_action_required or bool(user_channel.get("action_required"))
+    agent_delivery_during_user_gate = bool(agent_channel.get("must_attempt")) and bool(
+        agent_channel.get("delivery_allowed")
+    )
     automation_action = str(automation_liveness.get("automation_action") or "")
     spend_policy = (
         automation_liveness.get("spend_policy")
@@ -1294,6 +1302,21 @@ def build_scheduler_hint(
             claude_limit=3,
         )
 
+    if user_required and not agent_delivery_during_user_gate:
+        return hint(
+            action="backoff_waiting_for_user",
+            cadence_class="human_gate",
+            reason=(
+                "user/controller action is the next unlock; after surfacing the "
+                "concrete todo or gate, external loops should stop repeating the "
+                "same quiet poll"
+            ),
+            codex_interval=30,
+            codex_max=120,
+            cli_limit=3,
+            claude_limit=3,
+        )
+
     if (
         payload.get("should_run") is True
         or must_attempt_work
@@ -1317,7 +1340,7 @@ def build_scheduler_hint(
             advance_same_identity=False,
         )
 
-    if user_required or recommended_mode in {"ask_operator_gate", "blocker_push_notify"}:
+    if recommended_mode in {"ask_operator_gate", "blocker_push_notify"}:
         return hint(
             action="backoff_waiting_for_user",
             cadence_class="human_gate",

--- a/loopx/control_plane/work_items/primary_action.py
+++ b/loopx/control_plane/work_items/primary_action.py
@@ -70,6 +70,10 @@ def protocol_first_candidate_action(payload: dict[str, Any]) -> str | None:
     )
     text = protocol_action_label(selected.get("text"))
     if text:
+        if selected.get("fallback_kind") == "deferred_successor_replan":
+            todo_id = str(selected.get("todo_id") or "").strip()
+            action = f"replan ready deferred successor {text}"
+            return f"{todo_id}: {action}" if todo_id else action
         return text
 
     work_lane = (

--- a/tests/control_plane/test_user_gate_lane_progress.py
+++ b/tests/control_plane/test_user_gate_lane_progress.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from loopx.control_plane.scheduler.scheduler_hint import build_scheduler_hint
+from loopx.control_plane.testing.quota_fixtures import (
+    quota_status_payload,
+    quota_todo_item,
+    quota_todo_summary,
+)
+from loopx.quota import build_quota_should_run
+
+
+GOAL_ID = "user-gate-lane-progress-fixture"
+AGENT_ID = "codex-main-control"
+
+
+def _status_payload(*, gate_action_kind: str) -> dict:
+    completed = quota_todo_item(
+        todo_id="todo_prerequisite",
+        status="done",
+        text="[P0] Complete the prerequisite.",
+        claimed_by=AGENT_ID,
+    )
+    deferred = quota_todo_item(
+        todo_id="todo_ready_deferred",
+        status="deferred",
+        text="[P1] Continue benchmark treatment refinement.",
+        claimed_by=AGENT_ID,
+        action_kind="refine_benchmark_treatment",
+        resume_when="todo_done:todo_prerequisite",
+        done=True,
+    )
+    agent_todos = quota_todo_summary(
+        [completed, deferred],
+        role="agent",
+        claim_scope_agent_id=AGENT_ID,
+    )
+    gate = quota_todo_item(
+        todo_id="todo_product_doc_gate",
+        role="user",
+        status="open",
+        task_class="user_gate",
+        text="[P2-user] Review the product first screen.",
+        action_kind=gate_action_kind,
+        blocks_agent=AGENT_ID,
+    )
+    return quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        recommended_action="Continue benchmark treatment refinement.",
+        agent_todos=agent_todos,
+        user_todos=quota_todo_summary([gate], role="user"),
+        quota_state="operator_gate",
+        safe_bypass=True,
+        coordination={
+            "agent_model": "peer_v1",
+            "registered_agents": [AGENT_ID],
+        },
+    )
+
+
+def test_unrelated_user_gate_allows_ready_deferred_successor_replan() -> None:
+    payload = build_quota_should_run(
+        _status_payload(gate_action_kind="approve_product_first_screen"),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+
+    fallback = payload["scoped_user_gate_fallback"]
+    selected = fallback["selected_executable"]
+    assert selected["todo_id"] == "todo_ready_deferred"
+    assert selected["fallback_kind"] == "deferred_successor_replan"
+    assert payload["interaction_contract"]["mode"] == "scoped_user_gate_fallback"
+    assert payload["interaction_contract"]["agent_channel"]["must_attempt"] is True
+    assert payload["interaction_contract"]["agent_channel"]["delivery_allowed"] is True
+    assert "replan ready deferred successor" in payload["interaction_contract"][
+        "agent_channel"
+    ]["primary_action"]
+    assert payload["scheduler_hint"]["cadence_class"] == "active_work"
+
+
+def test_blocking_user_gate_backs_off_instead_of_polling_as_active_work() -> None:
+    payload = build_quota_should_run(
+        _status_payload(gate_action_kind="refine_benchmark_treatment"),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+
+    assert "scoped_user_gate_fallback" not in payload
+    assert payload["interaction_contract"]["mode"] == "user_gate"
+    assert payload["interaction_contract"]["agent_channel"]["must_attempt"] is False
+    assert payload["scheduler_hint"]["cadence_class"] == "human_gate"
+    assert payload["scheduler_hint"]["codex_app"]["recommended_interval_minutes"] == 30
+
+    initial_backoff = payload["scheduler_hint"]["codex_app"]["stateful_backoff"]
+    next_hint = build_scheduler_hint(
+        payload,
+        user_action_required=True,
+        codex_app_scheduler_state={
+            "reset_token": initial_backoff["reset_token"],
+            "identity_signature": initial_backoff["identity_signature"],
+            "progression_index": initial_backoff["progression_index"],
+            "last_applied_rrule": initial_backoff["current_rrule"],
+        },
+        codex_app_current_rrule=initial_backoff["current_rrule"],
+    )
+
+    assert next_hint["cadence_class"] == "human_gate"
+    assert next_hint["codex_app"]["recommended_interval_minutes"] == 60
+    assert next_hint["codex_app"]["stateful_backoff"]["progression_index"] == 1
+    assert next_hint["codex_app"]["stateful_backoff"]["apply_needed"] is True
+    assert next_hint["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=60"


### PR DESCRIPTION
## Summary

- allow a resume-ready deferred successor to provide the scoped fallback when an unrelated user gate is open
- project that fallback as an explicit typed replan action instead of leaving the agent lane non-deliverable
- classify a truly blocking user gate as stateful human-gate backoff before active-work scheduler logic
- add focused regressions for unrelated-gate continuation and 30-to-60-minute Codex App cadence progression

## Validation

- `uvx --from pytest pytest -q tests/control_plane/test_user_gate_lane_progress.py tests/control_plane/test_goal_vision_blocked_successor.py` (9 passed)
- `uvx ruff check` on changed Python paths
- four focused agent-scope/quota/scheduler smokes
- `loopx canary premerge --from-git-diff --tier standard` (16 selected checks passed, 0 failures, 0 manual holds)

## Scope and holds

Changed surfaces are limited to agent-scope fallback selection, scheduler hint classification, primary-action projection, and a durable control-plane regression. No scoring, benchmark semantics, permissions, first-screen content, private state, raw logs, trajectories, credentials, or local paths are included. This PR is left for review because it changes generic quota/scheduler behavior.