### PR TITLE
Fix autonomous replan for stalled blocked successors

### DIFF
--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -10,6 +10,7 @@ from ..agents.agent_scope import (
 )
 from ..agents.runtime_model import peer_work_key, select_peer_for_work
 from ..work_items.autonomous_replan_ack import (
+    autonomous_replan_ack_matches_frontier,
     autonomous_replan_ack_matches_agent,
     latest_autonomous_replan_ack_for_projection,
 )
@@ -1573,6 +1574,10 @@ def build_goal_frontier_projection_context_from_status(
     if (
         autonomous_replan_is_required(replan_obligation)
         and autonomous_replan_ack_has_frontier_delta(effective_replan_ack)
+        and autonomous_replan_ack_matches_frontier(
+            effective_replan_ack,
+            replan_obligation,
+        )
         and not acceptance_gaps
     ):
         replan_obligation = None
@@ -1621,13 +1626,16 @@ def build_goal_frontier_projection_context_from_status(
 
 
 def compact_replan_obligation(replan_obligation: dict[str, Any]) -> dict[str, Any]:
-    return {
+    compact = {
         "schema_version": replan_obligation.get("schema_version"),
         "stall_threshold": replan_obligation.get("stall_threshold"),
         "trigger_count": replan_obligation.get("trigger_count"),
         "triggers": replan_obligation.get("triggers") or [],
         "stop_condition": replan_obligation.get("stop_condition"),
     }
+    if replan_obligation.get("frontier_identity"):
+        compact["frontier_identity"] = replan_obligation.get("frontier_identity")
+    return compact
 
 
 def build_autonomous_replan_recommendation(

--- a/loopx/control_plane/goals/goal_vision_wait.py
+++ b/loopx/control_plane/goals/goal_vision_wait.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import json
 from typing import Any
 
 from ..todos.contract import normalize_todo_id
@@ -8,6 +10,54 @@ from ..todos.deferred_resume import todo_summary_blocked_successor_items
 
 GOAL_VISION_WAIT_STATE_SCHEMA_VERSION = "goal_vision_wait_state_v0"
 VISION_ACCEPTANCE_GAP_KIND = "vision_acceptance_gap"
+
+
+def exact_blocked_successor_wait_state(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    candidate = value
+    if value.get("schema_version") != GOAL_VISION_WAIT_STATE_SCHEMA_VERSION:
+        candidate = (
+            value.get("vision_wait_state")
+            if isinstance(value.get("vision_wait_state"), dict)
+            else {}
+        )
+        if not candidate:
+            projection = (
+                value.get("goal_frontier_projection")
+                if isinstance(value.get("goal_frontier_projection"), dict)
+                else {}
+            )
+            candidate = (
+                projection.get("vision_wait_state")
+                if isinstance(projection.get("vision_wait_state"), dict)
+                else {}
+            )
+    if (
+        candidate.get("schema_version") != GOAL_VISION_WAIT_STATE_SCHEMA_VERSION
+        or candidate.get("state") != "waiting"
+        or candidate.get("reason_code") != "exact_blocked_successor"
+        or candidate.get("automatic_resume") is not True
+        or not normalize_todo_id(candidate.get("selected_todo_id"))
+        or not str(candidate.get("resume_when") or "").strip()
+    ):
+        return {}
+    return candidate
+
+
+def exact_blocked_successor_frontier_identity(value: Any) -> str | None:
+    wait = exact_blocked_successor_wait_state(value)
+    if not wait:
+        return None
+    parts = {
+        "agent_id": str(wait.get("agent_id") or "").strip(),
+        "reason_code": "exact_blocked_successor",
+        "selected_todo_id": normalize_todo_id(wait.get("selected_todo_id")),
+        "resume_when": str(wait.get("resume_when") or "").strip(),
+    }
+    return hashlib.sha256(
+        json.dumps(parts, ensure_ascii=True, sort_keys=True).encode("utf-8")
+    ).hexdigest()[:16]
 
 
 def _compact_resume_condition(value: Any) -> dict[str, Any]:

--- a/loopx/control_plane/quota/monitor_poll.py
+++ b/loopx/control_plane/quota/monitor_poll.py
@@ -11,6 +11,7 @@ from .spend_sources import DEFAULT_SLOT_SPEND_SOURCE, VALID_SLOT_SPEND_SOURCES
 from ..runtime.time import now_local_iso
 from ..runtime.run_artifacts import run_file_stem, unique_run_artifact_paths
 from ..scheduler.monitor_poll_policy import (
+    allows_no_spend_blocked_successor_wait_poll,
     allows_due_monitor_poll,
     allows_no_spend_external_monitor_poll,
     work_lane_reason_codes,
@@ -48,6 +49,7 @@ def build_quota_monitor_poll_event(
     if safe_source not in VALID_SLOT_SPEND_SOURCES:
         raise ValueError(f"quota monitor-poll source must be one of: {', '.join(sorted(VALID_SLOT_SPEND_SOURCES))}")
     external_monitor_poll = allows_no_spend_external_monitor_poll(before)
+    blocked_successor_wait_poll = allows_no_spend_blocked_successor_wait_poll(before)
     due_monitor_poll = (
         allows_due_monitor_poll(
             before,
@@ -57,9 +59,15 @@ def build_quota_monitor_poll_event(
         if authorized_due_monitor_poll is None
         else authorized_due_monitor_poll
     )
-    if before.get("effective_action") != "monitor_quiet_skip" and not external_monitor_poll and not due_monitor_poll:
+    if (
+        before.get("effective_action") != "monitor_quiet_skip"
+        and not external_monitor_poll
+        and not due_monitor_poll
+        and not blocked_successor_wait_poll
+    ):
         raise ValueError(
-            "quota monitor-poll requires a monitor_quiet_skip, due monitor todo, or external monitor observation decision"
+            "quota monitor-poll requires a monitor_quiet_skip, due monitor todo, "
+            "external monitor observation, or exact blocked successor wait decision"
         )
     recommendation = (
         before.get("heartbeat_recommendation")
@@ -70,9 +78,16 @@ def build_quota_monitor_poll_event(
         recommendation.get("recommended_mode") != "monitor_quiet_until_material_transition"
         and not external_monitor_poll
         and not due_monitor_poll
+        and not blocked_successor_wait_poll
     ):
-        raise ValueError("quota monitor-poll requires monitor_quiet_until_material_transition mode")
-    if external_monitor_poll:
+        raise ValueError(
+            "quota monitor-poll requires monitor_quiet_until_material_transition "
+            "or exact blocked successor wait mode"
+        )
+    if blocked_successor_wait_poll:
+        monitor_kind = "blocked successor wait"
+        monitor_mode_prefix = "blocked_successor_wait"
+    elif external_monitor_poll:
         monitor_kind = "external monitor"
         monitor_mode_prefix = "external_monitor"
     elif due_monitor_poll:
@@ -87,6 +102,17 @@ def build_quota_monitor_poll_event(
         health_check = (
             f"{monitor_kind} material transition observed; follow-up state updated; "
             "no quota spend by monitor-poll"
+        )
+    elif blocked_successor_wait_poll:
+        monitor_mode = "blocked_successor_wait_without_material_transition"
+        default_reason_summary = (
+            recommendation.get("reason")
+            or before.get("reason")
+            or "exact blocked successor wait produced no material transition"
+        )
+        health_check = (
+            "exact blocked successor wait unchanged; no quota spend; "
+            "bounded replan after two identical frontier observations"
         )
     elif external_monitor_poll:
         monitor_mode = "external_monitor_observed_without_material_transition"
@@ -306,10 +332,11 @@ def record_quota_monitor_poll_for_decision(
         before.get("effective_action") != "monitor_quiet_skip"
         and not allows_no_spend_external_monitor_poll(before)
         and not due_monitor_poll
+        and not allows_no_spend_blocked_successor_wait_poll(before)
     ):
         return failure(
             "monitor-poll requires monitor_quiet_skip, due monitor todo, "
-            "or external monitor observation",
+            "external monitor observation, or exact blocked successor wait",
             include_capability_retry=True,
         )
 

--- a/loopx/control_plane/scheduler/monitor_poll_policy.py
+++ b/loopx/control_plane/scheduler/monitor_poll_policy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from ..goals.goal_vision_wait import exact_blocked_successor_wait_state
 from ..todos.contract import TODO_TASK_CLASS_MONITOR, normalize_todo_id
 from ..todos.projection import todo_item_task_class
 
@@ -14,6 +15,15 @@ EXTERNAL_MONITOR_REASON_CODES = {
     "external_evidence_poll_signal",
 }
 DUE_MONITOR_OBLIGATION = "attempt_due_monitor"
+
+
+def allows_no_spend_blocked_successor_wait_poll(decision: dict[str, Any]) -> bool:
+    return bool(
+        decision.get("effective_action") == "agent_scope_wait"
+        and decision.get("should_run") is False
+        and decision.get("requires_user_action") is not True
+        and exact_blocked_successor_wait_state(decision)
+    )
 
 
 def work_lane_reason_codes(work_lane_contract: dict[str, Any]) -> set[str]:

--- a/loopx/control_plane/scheduler/monitor_target.py
+++ b/loopx/control_plane/scheduler/monitor_target.py
@@ -5,6 +5,7 @@ import json
 import re
 from typing import Any
 
+from ..goals.goal_vision_wait import exact_blocked_successor_frontier_identity
 from ..todos.contract import normalize_todo_claimed_by
 
 QUOTA_MONITOR_TARGET_SCHEMA_VERSION = "quota_monitor_target_v0"
@@ -36,13 +37,16 @@ def build_quota_monitor_target(
         limit=160,
     )
     agent_id = monitor_target_agent_id(decision) or ""
+    frontier_identity = exact_blocked_successor_frontier_identity(decision)
     parts = {
         "goal_id": str(decision.get("goal_id") or ""),
         "agent_id": agent_id,
         "monitor_mode": str(monitor_mode or ""),
         "effective_action": str(decision.get("effective_action") or ""),
-        "action_summary": action_summary,
+        "frontier_identity": frontier_identity or "",
     }
+    if not frontier_identity:
+        parts["action_summary"] = action_summary
     target_id = hashlib.sha256(
         json.dumps(parts, ensure_ascii=True, sort_keys=True).encode("utf-8")
     ).hexdigest()[:16]
@@ -55,4 +59,6 @@ def build_quota_monitor_target(
     }
     if agent_id:
         target["agent_id"] = agent_id
+    if frontier_identity:
+        target["frontier_identity"] = frontier_identity
     return target

--- a/loopx/control_plane/work_items/autonomous_replan_ack.py
+++ b/loopx/control_plane/work_items/autonomous_replan_ack.py
@@ -41,7 +41,47 @@ def compact_autonomous_replan_ack(run: dict[str, Any] | None) -> dict[str, Any] 
     agent_id = str(run.get("agent_id") or "").strip()
     if agent_id:
         result["agent_id"] = agent_id
+    frontier_identity = str(ack.get("frontier_identity") or "").strip()
+    if frontier_identity:
+        result["frontier_identity"] = frontier_identity
     return result
+
+
+def latest_blocked_successor_frontier_identity(
+    latest_runs: list[dict[str, Any]] | None,
+) -> str | None:
+    for run in latest_runs or []:
+        if not isinstance(run, dict):
+            continue
+        classification = str(run.get("classification") or "").strip()
+        if classification != "quota_monitor_poll":
+            return None
+        target = (
+            run.get("monitor_target")
+            if isinstance(run.get("monitor_target"), dict)
+            else {}
+        )
+        if target.get("monitor_mode") != (
+            "blocked_successor_wait_without_material_transition"
+        ):
+            continue
+        frontier_identity = str(target.get("frontier_identity") or "").strip()
+        return frontier_identity or None
+    return None
+
+
+def autonomous_replan_ack_matches_frontier(
+    ack: dict[str, Any] | None,
+    obligation: dict[str, Any] | None,
+) -> bool:
+    if not isinstance(obligation, dict):
+        return True
+    frontier_identity = str(obligation.get("frontier_identity") or "").strip()
+    if not frontier_identity:
+        return True
+    if not isinstance(ack, dict):
+        return False
+    return str(ack.get("frontier_identity") or "").strip() == frontier_identity
 
 
 def autonomous_replan_ack_matches_agent(

--- a/loopx/control_plane/work_items/autonomous_replan_obligation.py
+++ b/loopx/control_plane/work_items/autonomous_replan_obligation.py
@@ -113,7 +113,14 @@ def run_history_stall_signal(
         signal["monitor_target_id"] = str(monitor_target.get("target_id") or "")
         signal["monitor_target"] = {
             key: monitor_target.get(key)
-            for key in ("schema_version", "target_id", "monitor_mode", "effective_action", "agent_id")
+            for key in (
+                "schema_version",
+                "target_id",
+                "monitor_mode",
+                "effective_action",
+                "agent_id",
+                "frontier_identity",
+            )
             if monitor_target.get(key)
         }
     return signal
@@ -241,6 +248,14 @@ def build_autonomous_replan_obligation(
         (item for item in evidence if item.get("kind") == "dead_monitor_repeat"),
         None,
     )
+    blocked_successor_evidence = next(
+        (
+            item
+            for item in evidence
+            if item.get("kind") == "blocked_successor_no_progress_repeat"
+        ),
+        None,
+    )
     first_open: dict[str, Any] = {}
     if isinstance(agent_todos, dict):
         open_items = agent_todos.get("first_open_items")
@@ -263,7 +278,19 @@ def build_autonomous_replan_obligation(
         if first_open.get("priority"):
             action["priority"] = first_open.get("priority")
         todo_actions.append(action)
-    if dead_monitor_evidence:
+    if blocked_successor_evidence:
+        todo_actions.append(
+            {
+                "action": "add",
+                "role": "agent",
+                "priority": "P1",
+                "text": (
+                    "discover and promote one safe in-scope evidence-backed successor; "
+                    "otherwise record watch-lane continuation for this frontier"
+                ),
+            }
+        )
+    elif dead_monitor_evidence:
         todo_actions.append(
             {
                 "action": "add",
@@ -309,7 +336,13 @@ def build_autonomous_replan_obligation(
             }
         )
 
-    if dead_monitor_evidence:
+    if blocked_successor_evidence:
+        recommended_action = (
+            "run a bounded autonomous replan for the exact blocked successor: "
+            "promote one safe in-scope evidence-backed successor when available; "
+            "otherwise record a no-spend wait continuation for this frontier"
+        )
+    elif dead_monitor_evidence:
         recommended_action = (
             "resolve a dead monitor loop: record watch-lane continuation with expiry, "
             "a concrete blocker, todo supersede, or successor runnable todo before "
@@ -338,6 +371,8 @@ def build_autonomous_replan_obligation(
         guidance_actions=(
             ["set_watch_expiry", "write_blocker", "supersede_monitor", "create_successor"]
             if dead_monitor_evidence
+            else ["discover_safe_successor", "create_successor", "record_wait_continuation"]
+            if blocked_successor_evidence
             else ["keep", "split", "add", "retire", "ask_decision"]
         ),
         todo_actions=todo_actions[:3],
@@ -347,6 +382,16 @@ def build_autonomous_replan_obligation(
         ),
         recommended_action=recommended_action,
         agent_id=replan_agent_id,
+        extra_fields=(
+            {
+                "frontier_identity": blocked_successor_evidence.get(
+                    "frontier_identity"
+                )
+            }
+            if blocked_successor_evidence
+            and blocked_successor_evidence.get("frontier_identity")
+            else None
+        ),
     )
     if dead_monitor_evidence:
         result["dead_monitor_detector"] = {
@@ -458,6 +503,48 @@ def autonomous_replan_obligation_from_runs(
     if len(signatures) > 1 and len(classifications) > 1:
         return periodic_review()
     if classifications == {"quota_monitor_poll"}:
+        blocked_successor_signals = signals[:autonomous_replan_stall_threshold]
+        blocked_successor_modes = {
+            str((signal.get("monitor_target") or {}).get("monitor_mode") or "")
+            for signal in blocked_successor_signals
+        }
+        if blocked_successor_modes == {
+            "blocked_successor_wait_without_material_transition"
+        }:
+            monitor_target_ids = {
+                str(signal.get("monitor_target_id") or "")
+                for signal in blocked_successor_signals
+                if signal.get("monitor_target_id")
+            }
+            frontier_identities = {
+                str((signal.get("monitor_target") or {}).get("frontier_identity") or "")
+                for signal in blocked_successor_signals
+                if (signal.get("monitor_target") or {}).get("frontier_identity")
+            }
+            if len(monitor_target_ids) != 1 or len(frontier_identities) != 1:
+                return periodic_review()
+            monitor_target_id = next(iter(monitor_target_ids))
+            frontier_identity = next(iter(frontier_identities))
+            evidence = [
+                {
+                    "kind": "blocked_successor_no_progress_repeat",
+                    "section": "run_history",
+                    "text": (
+                        f"latest {autonomous_replan_stall_threshold} exact blocked "
+                        "successor waits repeated the same frontier without progress"
+                    ),
+                    "run_count": len(blocked_successor_signals),
+                    "threshold": autonomous_replan_stall_threshold,
+                    "monitor_target_id": monitor_target_id,
+                    "frontier_identity": frontier_identity,
+                    "latest_generated_at": signals[0].get("generated_at"),
+                    "agent_id": _single_public_agent_id(blocked_successor_signals),
+                }
+            ]
+            return build_autonomous_replan_obligation(
+                evidence,
+                agent_todos=agent_todos,
+            )
         monitor_signals = signals[:dead_monitor_repeat_threshold]
         if len(monitor_signals) < dead_monitor_repeat_threshold:
             return periodic_review()

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -7,6 +7,7 @@ from ..agents.agent_scope_frontier import (
     agent_scope_frontier_action as _agent_scope_frontier_action,
 )
 from ..goals.goal_frontier import AUTONOMOUS_REPLAN_REQUIRED_MODE
+from ..goals.goal_vision_wait import exact_blocked_successor_wait_state
 from ..todos.contract import TODO_TASK_CLASS_MONITOR, TODO_TASK_CLASS_USER_ACTION
 from ..todos.projection import todo_item_task_class
 from ..todos.user_gate import open_todo_count
@@ -22,6 +23,14 @@ from .primary_action import (
 INTERACTION_CONTRACT_SCHEMA_VERSION = "loopx_interaction_contract_v0"
 PROTOCOL_ACTION_PACKET_SCHEMA_VERSION = "protocol_action_packet_v0"
 PROTOCOL_ACTION_PACKET_LLM_POLICY = "no_api"
+
+
+def _blocked_successor_wait_observation_required(payload: dict[str, Any]) -> bool:
+    return bool(
+        payload.get("effective_action")
+        == AgentScopeFrontierAction.AGENT_SCOPE_WAIT.value
+        and exact_blocked_successor_wait_state(payload)
+    )
 
 
 def _user_todo_item_is_explicitly_non_gating(item: dict[str, Any]) -> bool:
@@ -183,7 +192,12 @@ def protocol_action_packet_fields(payload: dict[str, Any]) -> dict[str, Any]:
         else {}
     )
     requires_user_action = user_channel_action_required(payload)
-    must_attempt_work = bool(execution_obligation.get("must_attempt_work"))
+    blocked_successor_wait_observation = (
+        _blocked_successor_wait_observation_required(payload)
+    )
+    must_attempt_work = bool(execution_obligation.get("must_attempt_work")) or (
+        blocked_successor_wait_observation
+    )
     scoped_user_gate_fallback = isinstance(payload.get("scoped_user_gate_fallback"), dict)
     bounded_delivery_with_user_notice = (
         requires_user_action
@@ -230,6 +244,12 @@ def protocol_action_packet_fields(payload: dict[str, Any]) -> dict[str, Any]:
             if capability_gate.get("action") == "ask_owner"
             and capability_gate.get("owner_action")
             else "wait for user/owner action after surfacing the blocker or gate"
+        )
+    elif blocked_successor_wait_observation:
+        primary_actor = "agent"
+        agent_action_required = True
+        agent_action = (
+            "record one no-spend blocked-successor wait observation, then rerun quota"
         )
     elif must_attempt_work:
         primary_actor = "agent"
@@ -463,6 +483,14 @@ def interaction_next_cli_actions(payload: dict[str, Any], *, mode: str) -> list[
             f"loopx todo update --goal-id {goal_id} --todo-id {todo_id} --status open --note '<public-safe successor replan reason>'",
             f"loopx refresh-state --goal-id {goal_id} --classification successor_replan_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress{agent_arg}",
             f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{agent_arg}",
+        ]
+    if (
+        mode == AgentScopeFrontierAction.AGENT_SCOPE_WAIT.value
+        and _blocked_successor_wait_observation_required(payload)
+    ):
+        return [
+            f"loopx quota monitor-poll --goal-id {goal_id}{agent_arg} --execute",
+            f"loopx --format json quota should-run --goal-id {goal_id}{agent_arg}",
         ]
     if _agent_scope_frontier_action(mode) is not None:
         return [
@@ -718,6 +746,11 @@ def _build_interaction_agent_channel(
         "quiet_noop_allowed": quiet_noop_allowed,
     }
     channel.update(build_primary_action_projection(payload, mode=mode))
+    if _blocked_successor_wait_observation_required(payload):
+        channel["primary_action"] = (
+            "record one no-spend blocked-successor wait observation, rerun quota, "
+            "then replan after the second unchanged frontier"
+        )
     return channel
 
 
@@ -876,6 +909,8 @@ def build_interaction_contract(payload: dict[str, Any]) -> dict[str, Any]:
         scoped_user_gate_fallback=scoped_user_gate_fallback,
         bounded_delivery_with_user_notice=bounded_delivery_with_user_notice,
     )
+    if _blocked_successor_wait_observation_required(payload):
+        must_attempt = True
     delivery_allowed = _interaction_delivery_allowed(
         payload,
         execution_obligation,

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -21,6 +21,9 @@ from .control_plane.work_items.repair_delta import (
     REPAIR_DELTA_KIND_CHOICES as REPAIR_DELTA_KIND_CHOICES,
     normalize_repair_delta_kinds,
 )
+from .control_plane.work_items.autonomous_replan_ack import (
+    latest_blocked_successor_frontier_identity,
+)
 from .control_plane.runtime.shared_runtime_refresh_projection import (
     build_shared_runtime_projection,
     write_shared_runtime_projection,
@@ -549,6 +552,7 @@ def build_state_refresh_record(
     agent_lane: str | None = None,
     autonomous_replan_recorded: bool = False,
     repair_delta_contract: dict[str, Any] | None = None,
+    autonomous_replan_frontier_identity: str | None = None,
     agent_vision: dict[str, Any] | None = None,
     vision_checkpoint: dict[str, Any] | None = None,
     delivery_workspace: dict[str, Any] | None = None,
@@ -604,6 +608,10 @@ def build_state_refresh_record(
         }
         if repair_delta_contract:
             record["autonomous_replan_ack"]["delta_contract"] = repair_delta_contract
+        if autonomous_replan_frontier_identity:
+            record["autonomous_replan_ack"]["frontier_identity"] = (
+                autonomous_replan_frontier_identity
+            )
     if agent_vision:
         record["agent_vision"] = agent_vision
     if vision_checkpoint:
@@ -917,6 +925,7 @@ def refresh_state_run(
         vision_unchanged_reason
     )
     existing_agent_vision: dict[str, Any] | None = None
+    autonomous_replan_frontier_identity: str | None = None
     if normalized_agent_id and normalized_vision_unchanged_reason:
         existing_runs, _ = load_index(
             runtime_root / "goals" / safe_goal_id / "runs" / "index.jsonl"
@@ -933,6 +942,21 @@ def refresh_state_run(
             newest_first_runs,
             goal_id=safe_goal_id,
             agent_id=normalized_agent_id,
+        )
+    if autonomous_replan_recorded:
+        existing_runs, _ = load_index(
+            runtime_root / "goals" / safe_goal_id / "runs" / "index.jsonl"
+        )
+        newest_first_runs = [
+            run
+            for _, run in sorted(
+                enumerate(existing_runs),
+                key=lambda item: (str(item[1].get("generated_at") or ""), item[0]),
+                reverse=True,
+            )
+        ]
+        autonomous_replan_frontier_identity = (
+            latest_blocked_successor_frontier_identity(newest_first_runs)
         )
     generated_at = now_local()
     active_state_next_action_update: dict[str, Any] | None = None
@@ -1012,6 +1036,7 @@ def refresh_state_run(
         agent_lane=normalized_agent_lane or None,
         autonomous_replan_recorded=effective_autonomous_replan_recorded,
         repair_delta_contract=repair_delta_contract,
+        autonomous_replan_frontier_identity=autonomous_replan_frontier_identity,
         agent_vision=agent_vision,
         vision_checkpoint=vision_checkpoint,
         delivery_workspace=delivery_workspace,
@@ -1025,6 +1050,10 @@ def refresh_state_run(
                 "delta_contract": repair_delta_contract,
             }
         record["autonomous_replan_ack"]["requested"] = True
+        if autonomous_replan_frontier_identity:
+            record["autonomous_replan_ack"]["frontier_identity"] = (
+                autonomous_replan_frontier_identity
+            )
         if requested_classification != classification:
             record["autonomous_replan_ack"]["requested_classification"] = requested_classification
             record["autonomous_replan_noop"] = {

--- a/tests/control_plane/test_goal_vision_blocked_successor.py
+++ b/tests/control_plane/test_goal_vision_blocked_successor.py
@@ -6,14 +6,20 @@ from loopx.cli_commands.status import attach_agent_lane_next_actions
 from loopx.control_plane.goals.goal_frontier import (
     build_goal_frontier_projection_context_from_status,
 )
+from loopx.control_plane.quota.monitor_poll import build_quota_monitor_poll_event
 from loopx.control_plane.quota.markdown import render_quota_should_run_markdown
 from loopx.control_plane.testing.quota_fixtures import (
     quota_status_payload,
     quota_todo_item,
     quota_todo_summary,
 )
+from loopx.control_plane.work_items.autonomous_replan_ack import (
+    latest_blocked_successor_frontier_identity,
+)
 from loopx.presentation.renderers.status_markdown import render_status_markdown
 from loopx.quota import build_quota_should_run
+from loopx.state_refresh import build_state_refresh_record
+from loopx.status import autonomous_replan_obligation_from_runs
 
 
 GOAL_ID = "vision-blocked-successor-fixture"
@@ -63,6 +69,7 @@ def _status_payload(
     blocker_task_class: str = "advancement_task",
     vision_state: str = "vision_drift_detected",
     missing_checkpoint: bool = False,
+    latest_runs: list[dict] | None = None,
 ) -> dict:
     blocker = quota_todo_item(
         todo_id=BLOCKER_ID,
@@ -91,7 +98,9 @@ def _status_payload(
             "agent_model": "peer_v1",
             "registered_agents": [PRIMARY_AGENT, AGENT_ID],
         },
-        latest_runs=[
+        latest_runs=latest_runs
+        if latest_runs is not None
+        else [
             _vision_run(
                 state=vision_state,
                 missing_checkpoint=missing_checkpoint,
@@ -102,6 +111,33 @@ def _status_payload(
 
 def _quota(payload: dict) -> dict:
     return build_quota_should_run(payload, goal_id=GOAL_ID, agent_id=AGENT_ID)
+
+
+def _blocked_wait_polls() -> list[dict]:
+    guard = _quota(_status_payload())
+    return [
+        build_quota_monitor_poll_event(
+            guard,
+            generated_at="2026-07-16T00:02:00+00:00",
+        ),
+        build_quota_monitor_poll_event(
+            guard,
+            generated_at="2026-07-16T00:01:00+00:00",
+        ),
+    ]
+
+
+def _quota_with_replan_runs(runs: list[dict]) -> dict:
+    payload = _status_payload(latest_runs=runs)
+    item = payload["attention_queue"]["items"][0]
+    obligation = autonomous_replan_obligation_from_runs(
+        runs,
+        agent_todos=item["agent_todos"],
+    )
+    if obligation:
+        item["autonomous_replan_obligation"] = obligation
+        item["project_asset"]["autonomous_replan_obligation"] = obligation
+    return _quota(payload)
 
 
 @pytest.mark.parametrize("waiting_status", ["open", "deferred"])
@@ -137,6 +173,13 @@ def test_exact_blocked_successor_defers_only_open_vision_gap(
         "blocked_successor_resume_pending"
     )
     assert guard["interaction_contract"]["agent_channel"]["vision_wait_state"] == wait
+    assert guard["interaction_contract"]["agent_channel"]["must_attempt"] is True
+    assert guard["interaction_contract"]["agent_channel"]["delivery_allowed"] is False
+    assert guard["interaction_contract"]["agent_channel"]["quiet_noop_allowed"] is False
+    cli_actions = guard["interaction_contract"]["cli_channel"]["next_cli_actions"]
+    assert "quota monitor-poll" in cli_actions[0]
+    assert "quota should-run" in cli_actions[1]
+    assert "agent_action_required=true" in guard["protocol_action_packet"]["summary"]
     cli_wait = guard["interaction_contract"]["cli_channel"]["vision_wait_state"]
     assert cli_wait["selected_todo_id"] == WAITING_ID
     assert cli_wait["automatic_resume"] is True
@@ -148,6 +191,98 @@ def test_exact_blocked_successor_defers_only_open_vision_gap(
         f"todo_id={WAITING_ID} resume_when=todo_done:{BLOCKER_ID} "
         "automatic_resume=True"
     ) in markdown
+
+
+def test_two_identical_blocked_successor_waits_trigger_bounded_replan() -> None:
+    polls = _blocked_wait_polls()
+    target = polls[0]["monitor_target"]
+    assert target["monitor_mode"] == (
+        "blocked_successor_wait_without_material_transition"
+    )
+    assert target["frontier_identity"]
+    assert polls[1]["monitor_target"]["target_id"] == target["target_id"]
+    assert polls[1]["monitor_target"]["frontier_identity"] == target[
+        "frontier_identity"
+    ]
+
+    guard = _quota_with_replan_runs([*polls, _vision_run()])
+
+    assert guard["decision"] == "autonomous_replan_required"
+    assert guard["should_run"] is True
+    obligation = guard["autonomous_replan_obligation"]
+    assert obligation["stall_threshold"] == 2
+    assert obligation["frontier_identity"] == target["frontier_identity"]
+    assert obligation["triggers"][0]["kind"] == (
+        "blocked_successor_no_progress_repeat"
+    )
+    assert obligation["guidance_actions"] == [
+        "discover_safe_successor",
+        "create_successor",
+        "record_wait_continuation",
+    ]
+
+
+def test_replan_ack_dedupes_only_the_same_blocked_successor_frontier() -> None:
+    polls = _blocked_wait_polls()
+    frontier_identity = polls[0]["monitor_target"]["frontier_identity"]
+    ack = {
+        "classification": "autonomous_replan_recorded",
+        "generated_at": "2026-07-16T00:00:30+00:00",
+        "agent_id": AGENT_ID,
+        "autonomous_replan_ack": {
+            "schema_version": "autonomous_replan_ack_v0",
+            "recorded": True,
+            "source": "fixture",
+            "frontier_identity": frontier_identity,
+            "delta_contract": {
+                "schema_version": "repair_delta_contract_v0",
+                "delta_present": True,
+                "delta_kinds": ["watch_lane_continuation"],
+            },
+        },
+    }
+
+    same_frontier = _quota_with_replan_runs([*polls, ack, _vision_run()])
+    assert same_frontier["decision"] == "agent_scope_wait"
+    assert same_frontier.get("autonomous_replan_obligation") is None
+
+    ack["autonomous_replan_ack"]["frontier_identity"] = "different-frontier"
+    changed_frontier = _quota_with_replan_runs([*polls, ack, _vision_run()])
+    assert changed_frontier["decision"] == "autonomous_replan_required"
+    assert changed_frontier["autonomous_replan_obligation"][
+        "frontier_identity"
+    ] == frontier_identity
+
+
+def test_refresh_ack_preserves_the_observed_blocked_successor_identity(
+    tmp_path,
+) -> None:
+    polls = _blocked_wait_polls()
+    frontier_identity = latest_blocked_successor_frontier_identity(polls)
+    assert frontier_identity == polls[0]["monitor_target"]["frontier_identity"]
+
+    record = build_state_refresh_record(
+        goal_id=GOAL_ID,
+        state_file=tmp_path / "ACTIVE_GOAL_STATE.md",
+        state_text="---\nstatus: active\n---\n\n## Next Action\n\n- Replan.\n",
+        classification="autonomous_replan_recorded",
+        recommended_action="Continue the selected bounded replan slice.",
+        recommended_action_source="explicit_arg",
+        generated_at="2026-07-16T00:03:00+00:00",
+        registry_goal=None,
+        agent_id=AGENT_ID,
+        autonomous_replan_recorded=True,
+        repair_delta_contract={
+            "schema_version": "repair_delta_contract_v0",
+            "delta_present": True,
+            "delta_kinds": ["watch_lane_continuation"],
+        },
+        autonomous_replan_frontier_identity=frontier_identity,
+    )
+
+    assert record["autonomous_replan_ack"]["frontier_identity"] == (
+        frontier_identity
+    )
 
 
 def test_status_projects_exact_blocker_and_resume_contract() -> None:


### PR DESCRIPTION
## Summary

- record exact blocked-successor waits as no-spend frontier observations instead of silent repeated reads
- trigger a bounded autonomous replan after two unchanged observations of the same frontier, while preserving the six-poll threshold for ordinary monitors
- carry the stable frontier identity into replan ACKs so the same frontier is deduplicated and a changed frontier can wake again
- require the interaction contract to execute the observation, without allowing delivery or quota spend

## Validation

- `pytest -q tests/control_plane/test_goal_vision_blocked_successor.py` (10 passed)
- full `pytest -q` (462 passed, 2 skipped)
- `ruff check` on all changed Python files
- `examples/autonomous-replan-obligation-smoke.py`
- `examples/control_plane/quota-replan-decision-plane-smoke.py`
- `examples/control_plane/heartbeat-quota-flow-smoke.py`
- `loopx canary premerge --from-git-diff` (16/16 selected checks passed, no manual holds)

## Review focus

This changes agent-facing control-plane routing and is intentionally held for owner review. Please verify that exact blocked successors enter replan after two unchanged frontier observations, ACK dedupe is identity-scoped, and generic monitor-only lanes still require six identical polls. No credentials, private state, local paths, raw logs, or external production actions are included.