### PR TITLE
Keep LoopX Turn scheduler-reset envelopes within budget

### DIFF
--- a/docs/reference/protocols/turn-envelope-v0.md
+++ b/docs/reference/protocols/turn-envelope-v0.md
@@ -44,6 +44,15 @@ fields, and warning collections stay on the referenced full-decision/status
 cold paths. The envelope has an 8 KiB JSON budget and reports its measured
 source/envelope byte counts.
 
+Hot-path fields may use explicit references when the inline value would only
+repeat another authoritative field. In particular,
+`action.selected_todo.text_ref = action.recommended_action` means the selected
+todo text is already present as the recommended action. Scheduler reset plans
+keep the exact acknowledgement argv inline; the failure argv stays behind
+`failure_cli_args_detail_ref` until the host update actually fails. Consumers
+must follow these references instead of treating the omitted duplicate as
+missing state.
+
 This contract is a projection only. It does not change quota selection, todo
 routing, scheduler state, history writes, or state transitions. Promoting it to
 the default agent view requires separate parity evidence across delivery,

--- a/docs/reference/protocols/turn-envelope-v0.md
+++ b/docs/reference/protocols/turn-envelope-v0.md
@@ -48,10 +48,10 @@ Hot-path fields may use explicit references when the inline value would only
 repeat another authoritative field. In particular,
 `action.selected_todo.text_ref = action.recommended_action` means the selected
 todo text is already present as the recommended action. Scheduler reset plans
-keep the exact acknowledgement argv inline; the failure argv stays behind
-`failure_cli_args_detail_ref` until the host update actually fails. Consumers
-must follow these references instead of treating the omitted duplicate as
-missing state.
+keep the exact acknowledgement argv inline when it satisfies the executable
+argv limits; the failure argv stays behind `failure_cli_args_detail_ref` until
+the host update actually fails. Consumers must follow these references instead
+of treating the omitted duplicate as missing state.
 
 This contract is a projection only. It does not change quota selection, todo
 routing, scheduler state, history writes, or state transitions. Promoting it to

--- a/loopx/control_plane/quota/turn_envelope.py
+++ b/loopx/control_plane/quota/turn_envelope.py
@@ -221,6 +221,8 @@ def _same_action_text(left: Any, right: Any) -> bool:
     right_folded = right_text.casefold()
     if left_folded == right_folded:
         return True
+    # Upstream todo projections may already be ellipsized; require a substantial
+    # shared prefix before treating that compact text as the same action.
     if left_folded.endswith("..."):
         prefix = left_folded[:-3].rstrip()
         return len(prefix) >= 80 and right_folded.startswith(prefix)

--- a/loopx/control_plane/quota/turn_envelope.py
+++ b/loopx/control_plane/quota/turn_envelope.py
@@ -212,7 +212,29 @@ def _compact_fields(
     return compact
 
 
-def _selected_todo(payload: Mapping[str, Any]) -> dict[str, Any] | None:
+def _same_action_text(left: Any, right: Any) -> bool:
+    left_text = _text(left, limit=2_000)
+    right_text = _text(right, limit=2_000)
+    if not left_text or not right_text:
+        return False
+    left_folded = left_text.casefold()
+    right_folded = right_text.casefold()
+    if left_folded == right_folded:
+        return True
+    if left_folded.endswith("..."):
+        prefix = left_folded[:-3].rstrip()
+        return len(prefix) >= 80 and right_folded.startswith(prefix)
+    if right_folded.endswith("..."):
+        prefix = right_folded[:-3].rstrip()
+        return len(prefix) >= 80 and left_folded.startswith(prefix)
+    return False
+
+
+def _selected_todo(
+    payload: Mapping[str, Any],
+    *,
+    recommended_action: str | None,
+) -> dict[str, Any] | None:
     source = _mapping(payload.get("selected_todo"))
     if not source:
         return None
@@ -233,7 +255,9 @@ def _selected_todo(payload: Mapping[str, Any]) -> dict[str, Any] | None:
     )
     compact = {field: source[field] for field in fields if source.get(field) is not None}
     text = _text(source.get("text"), limit=360)
-    if text:
+    if text and _same_action_text(source.get("text"), recommended_action):
+        compact["text_ref"] = "action.recommended_action"
+    elif text:
         compact["text"] = text
     return compact or None
 
@@ -370,12 +394,9 @@ def _scheduler(payload: Mapping[str, Any]) -> dict[str, Any]:
             "request": SCHEDULER_DETAIL_REQUEST,
         }
     failure_hint = _mapping(codex_app.get("failure_hint"))
-    failure_cli_args = _executable_cli_args(failure_hint.get("cli_args"))
-    if failure_cli_args:
-        app["failure_cli_args"] = failure_cli_args
-    elif failure_hint.get("cli_args"):
+    if failure_hint.get("cli_args"):
         app["failure_cli_args_detail_ref"] = {
-            "reason": "omitted_to_preserve_executable_argv",
+            "reason": "cold_path_until_host_update_failure",
             "request": SCHEDULER_DETAIL_REQUEST,
         }
     if app:
@@ -549,13 +570,17 @@ def _action_projection(payload: Mapping[str, Any]) -> dict[str, Any]:
     interaction = _mapping(payload.get("interaction_contract"))
     agent_channel = _mapping(interaction.get("agent_channel"))
     cli_channel = _mapping(interaction.get("cli_channel"))
+    recommended_action = _text(payload.get("recommended_action"), limit=480)
     action = {
-        "recommended_action": _text(payload.get("recommended_action"), limit=480),
+        "recommended_action": recommended_action,
         "primary_action": _text(agent_channel.get("primary_action"), limit=480),
         "must_attempt": bool(agent_channel.get("must_attempt")),
         "delivery_allowed": bool(agent_channel.get("delivery_allowed")),
         "quiet_noop_allowed": bool(agent_channel.get("quiet_noop_allowed")),
-        "selected_todo": _selected_todo(payload),
+        "selected_todo": _selected_todo(
+            payload,
+            recommended_action=recommended_action,
+        ),
     }
     user = _user_channel(interaction, payload)
     scheduler = _scheduler(payload)

--- a/tests/test_turn_envelope.py
+++ b/tests/test_turn_envelope.py
@@ -382,6 +382,121 @@ def test_turn_envelope_omits_oversized_scheduler_argv_instead_of_truncating() ->
     }
 
 
+def test_turn_envelope_stays_actionable_during_scheduler_reset() -> None:
+    source = _full_decision()
+    todo_text = (
+        "[P1] Continue host-neutral Agent CLI orchestration with start and resume, "
+        "typed result, independent validation, repair or replan, exactly-once "
+        "writeback and spend, and one real CLI end-to-end validation."
+    )
+    source["recommended_action"] = todo_text
+    source["selected_todo"]["text"] = todo_text[:160].rstrip() + "..."
+    source["interaction_contract"]["user_channel"] = {
+        "action_required": False,
+        "notify": "NOTIFY",
+        "actions": ["Review an optional public documentation wording update."],
+        "reason": "The optional review does not block the agent work lane.",
+    }
+    source["goal_boundary"].update(
+        {
+            "write_scope": [f"public/surface/{index}/**" for index in range(8)],
+            "guards": [
+                "stop before private material, credentials, destructive git, or "
+                f"unauthorized production action {index}"
+                for index in range(6)
+            ],
+        }
+    )
+    source["execution_profile"] = {
+        "cadence": "bounded_progress_segment",
+        "minimum_scale": "multi_surface_or_implementation",
+        "spend_rule": "spend_only_after_artifact_validation_writeback",
+        "must_include": ["coherent_artifact", "targeted_validation", "state_writeback"],
+    }
+    source["automation_liveness"]["pause_policy"] = (
+        "pause only after a bounded repair or replan path is itself stuck for "
+        "two more eligible turns"
+    )
+    source["vision_continuation_audit"] = {
+        "schema_version": "vision_continuation_audit_v0",
+        "required": True,
+        "decision": "acceptance_gap_open",
+        "selected_todo_is_goal_completion": False,
+        "closeout_allowed_without_evidence": False,
+        "required_before_closeout": [
+            "derive requirements from the active vision and current todo",
+            "name authoritative evidence for each requirement",
+            "run bounded public research when local evidence is missing",
+            "create a successor or replan trigger when acceptance remains unproven",
+        ],
+        "recommended_action": (
+            "audit active vision acceptance before todo closeout and keep the vision "
+            "active with a concrete successor when evidence remains incomplete"
+        ),
+    }
+    capabilities = ["network", "shell", "filesystem_read", "filesystem_write"]
+    ack_cli_args = [
+        "--registry",
+        "registry.json",
+        "--runtime-root",
+        ".runtime",
+        "quota",
+        "scheduler-ack-current",
+        "--goal-id",
+        "fixture-goal",
+        "--agent-id",
+        "codex-fixture",
+    ]
+    for capability in capabilities:
+        ack_cli_args.extend(["--available-capability", capability])
+    ack_cli_args.extend(
+        [
+            "--surface",
+            "codex_app",
+            "--state-key",
+            "scheduler_hint.codex_app.stateful_backoff",
+            "--applied-rrule",
+            "FREQ=MINUTELY;INTERVAL=3",
+            "--execute",
+        ]
+    )
+    failure_cli_args = [
+        *ack_cli_args[:4],
+        "quota",
+        "scheduler-fail-current",
+        *ack_cli_args[6:-4],
+        "--failed-rrule",
+        "FREQ=MINUTELY;INTERVAL=3",
+        "--codex-app-current-rrule",
+        "FREQ=MINUTELY;INTERVAL=3",
+        "--execute",
+    ]
+    codex_app = source["scheduler_hint"]["codex_app"]
+    codex_app["ack_hint"]["cli_args"] = ack_cli_args
+    codex_app["failure_hint"] = {"cli_args": failure_cli_args}
+    source["protocol_action_packet"] = build_protocol_action_packet(source)
+
+    envelope = build_turn_envelope(source)
+    compact_app = envelope["scheduler"]["codex_app"]
+
+    assert envelope["action"]["selected_todo"]["text_ref"] == (
+        "action.recommended_action"
+    )
+    assert "text" not in envelope["action"]["selected_todo"]
+    assert compact_app["ack_cli_args"] == ack_cli_args
+    assert "failure_cli_args" not in compact_app
+    assert compact_app["failure_cli_args_detail_ref"] == {
+        "reason": "cold_path_until_host_update_failure",
+        "request": "loopx quota should-run --include-scheduler-detail",
+    }
+    assert envelope["action_signature"]["matches"] is True
+    assert envelope["compaction"]["within_budget"] is True
+    assert envelope["compaction"]["envelope_json_bytes"] <= TURN_ENVELOPE_BUDGET_BYTES
+    assert envelope["compaction"]["envelope_json_bytes"] >= (
+        TURN_ENVELOPE_BUDGET_BYTES - 1_024
+    )
+
+
 def test_turn_envelope_keeps_concrete_user_gate() -> None:
     source = _full_decision()
     source["action_required"] = True


### PR DESCRIPTION
## Summary
- deduplicate selected todo text when the recommended action already carries it
- keep scheduler failure argv on the explicit cold path while preserving exact ACK argv
- add a pressure regression and document the reference semantics

## Validation
- `pytest -q tests/test_turn_envelope.py tests/test_loopx_turn_driver.py tests/test_loopx_turn_executor.py tests/test_loopx_turn_codex_cli.py tests/test_loopx_turn_transaction.py` (77 passed)
- `ruff check loopx/control_plane/quota/turn_envelope.py tests/test_turn_envelope.py`
- live `loopx turn plan` readback: `ready_for_host`, 7420/8192 bytes
- standard `loopx canary premerge --from-git-diff`: passed, 13 selected checks, 4 direct checks, boundary clean, no holds