### PR TITLE
Keep /loopx and loopx-project distinct in Codex

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -69,12 +69,12 @@ Success looks like this:
 The installer also registers the LoopX command family for host surfaces that
 can discover user-installed skills:
 
-- Codex CLI / IDE / App: explicit LoopX command-facade skills under
-  `~/.codex/skills/loopx*`. Codex does not currently support user-defined
-  native top-level `/loopx` slash commands, so invoke these through `$loopx` or
-  `/skills`. Only these command facades include `agents/openai.yaml` with
-  `allow_implicit_invocation: false`; richer workflow skills such as
-  `loopx-project` and `loopx-pr-review` keep their normal implicit behavior.
+- Codex CLI / IDE / App: the project-local `/loopx` fallback is handled by the
+  `loopx-project` workflow skill shown as `LoopX` in `/skills`; other command
+  facades remain under `~/.codex/skills/loopx*`. Upgrades retire the older
+  LoopX-managed `$loopx` facade. Command facades set
+  `allow_implicit_invocation: false`; workflow skills such as `loopx-project`
+  and `loopx-pr-review` keep their normal implicit behavior.
 - Claude Code: lightweight user skills under `~/.claude/skills/loopx*`, so the
   command family can appear as Claude Code slash commands without enabling the
   opt-in MCP/hook adapter.
@@ -84,7 +84,7 @@ entry point is different:
 
 | Command family | Host entry | CLI fallback |
 | --- | --- | --- |
-| Project goal start | `/loopx <goal text>` where the host exposes native slash commands; `$loopx <goal text>` or the `loopx` skill in Codex surfaces that use explicit skills. | `loopx start-goal --guided --project . --goal-text "<goal text>"` |
+| Project goal start | `/loopx <goal text>` where the host exposes native slash commands; the `LoopX` workflow skill in Codex `/skills` otherwise. | `loopx start-goal --guided --project . --goal-text "<goal text>"` |
 | Global manager views | `/loopx-global-summary`, `/loopx-global-gates`, `/loopx-global-todos`, `/loopx-global-risks`. | `loopx slash-commands`, then run the listed global manager command for the view you need. |
 | PR review queue | `/loopx-pr-review`. | `loopx pr-review` |
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -72,7 +72,7 @@ can discover user-installed skills:
 - Codex CLI / IDE / App: explicit LoopX command-facade skills under
   `~/.codex/skills/loopx*`. Codex does not currently support user-defined
   native top-level `/loopx` slash commands, so invoke the project command
-  through `$loopx` or `/skills`. The `LoopX /loopx` command facade and
+  through `$loopx` or `/skills`. The primary `LoopX` command facade and
   `LoopX Project` workflow skill are separate entries: command facades set
   `allow_implicit_invocation: false`, while richer workflow skills such as
   `loopx-project` and `loopx-pr-review` keep their normal implicit behavior.
@@ -85,7 +85,7 @@ entry point is different:
 
 | Command family | Host entry | CLI fallback |
 | --- | --- | --- |
-| Project goal start | `/loopx <goal text>` where the host exposes native slash commands; `$loopx <goal text>` or the `LoopX /loopx` command skill in Codex surfaces that use explicit skills. | `loopx start-goal --guided --project . --goal-text "<goal text>"` |
+| Project goal start | `/loopx <goal text>` where the host exposes native slash commands; `$loopx <goal text>` or the `LoopX` command skill in Codex surfaces that use explicit skills. | `loopx start-goal --guided --project . --goal-text "<goal text>"` |
 | Global manager views | `/loopx-global-summary`, `/loopx-global-gates`, `/loopx-global-todos`, `/loopx-global-risks`. | `loopx slash-commands`, then run the listed global manager command for the view you need. |
 | PR review queue | `/loopx-pr-review`. | `loopx pr-review` |
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -69,12 +69,13 @@ Success looks like this:
 The installer also registers the LoopX command family for host surfaces that
 can discover user-installed skills:
 
-- Codex CLI / IDE / App: the project-local `/loopx` fallback is handled by the
-  `loopx-project` workflow skill shown as `LoopX` in `/skills`; other command
-  facades remain under `~/.codex/skills/loopx*`. Upgrades retire the older
-  LoopX-managed `$loopx` facade. Command facades set
-  `allow_implicit_invocation: false`; workflow skills such as `loopx-project`
-  and `loopx-pr-review` keep their normal implicit behavior.
+- Codex CLI / IDE / App: explicit LoopX command-facade skills under
+  `~/.codex/skills/loopx*`. Codex does not currently support user-defined
+  native top-level `/loopx` slash commands, so invoke the project command
+  through `$loopx` or `/skills`. The `LoopX /loopx` command facade and
+  `LoopX Project` workflow skill are separate entries: command facades set
+  `allow_implicit_invocation: false`, while richer workflow skills such as
+  `loopx-project` and `loopx-pr-review` keep their normal implicit behavior.
 - Claude Code: lightweight user skills under `~/.claude/skills/loopx*`, so the
   command family can appear as Claude Code slash commands without enabling the
   opt-in MCP/hook adapter.
@@ -84,7 +85,7 @@ entry point is different:
 
 | Command family | Host entry | CLI fallback |
 | --- | --- | --- |
-| Project goal start | `/loopx <goal text>` where the host exposes native slash commands; the `LoopX` workflow skill in Codex `/skills` otherwise. | `loopx start-goal --guided --project . --goal-text "<goal text>"` |
+| Project goal start | `/loopx <goal text>` where the host exposes native slash commands; `$loopx <goal text>` or the `LoopX /loopx` command skill in Codex surfaces that use explicit skills. | `loopx start-goal --guided --project . --goal-text "<goal text>"` |
 | Global manager views | `/loopx-global-summary`, `/loopx-global-gates`, `/loopx-global-todos`, `/loopx-global-risks`. | `loopx slash-commands`, then run the listed global manager command for the view you need. |
 | PR review queue | `/loopx-pr-review`. | `loopx pr-review` |
 

--- a/docs/product/codex-cli-packaged-install.md
+++ b/docs/product/codex-cli-packaged-install.md
@@ -29,8 +29,10 @@ snapshot under `~/.local/share/loopx/releases/`, installs the
 skills under `~/.codex/skills`. It also refreshes the lightweight slash-command
 facades:
 
-- `~/.codex/skills/loopx*/SKILL.md` for explicit Codex command-facade
-  invocation through `$loopx` or `/skills`;
+- `~/.codex/skills/loopx-project/SKILL.md` for the Codex project-command
+  fallback shown as `LoopX` in `/skills`;
+- `~/.codex/skills/loopx*/SKILL.md` for the remaining explicit Codex command
+  facades, while upgrades retire the older managed `$loopx` facade;
 - `~/.claude/skills/loopx*/SKILL.md` for Claude Code slash-command discovery.
 
 Current verified Codex CLI builds still reject user-installed `/loopx` and

--- a/docs/product/codex-cli-packaged-install.md
+++ b/docs/product/codex-cli-packaged-install.md
@@ -29,10 +29,10 @@ snapshot under `~/.local/share/loopx/releases/`, installs the
 skills under `~/.codex/skills`. It also refreshes the lightweight slash-command
 facades:
 
-- `~/.codex/skills/loopx-project/SKILL.md` for the Codex project-command
-  fallback shown as `LoopX` in `/skills`;
-- `~/.codex/skills/loopx*/SKILL.md` for the remaining explicit Codex command
-  facades, while upgrades retire the older managed `$loopx` facade;
+- `~/.codex/skills/loopx*/SKILL.md` for explicit Codex command-facade
+  invocation through `$loopx` or `/skills`;
+- `~/.codex/skills/loopx-project/SKILL.md` for the distinct project workflow
+  skill shown as `LoopX Project` in `/skills`;
 - `~/.claude/skills/loopx*/SKILL.md` for Claude Code slash-command discovery.
 
 Current verified Codex CLI builds still reject user-installed `/loopx` and

--- a/docs/reference/protocols/codex-app-host-command-registry-v0.md
+++ b/docs/reference/protocols/codex-app-host-command-registry-v0.md
@@ -219,9 +219,9 @@ Until every host exposes a native command registry, LoopX installs slash-command
 facades into the user-level discovery locations that current hosts already
 support:
 
-- `~/.codex/skills/loopx-project/SKILL.md` for the Codex project command
-  fallback shown as `LoopX` in `/skills`; other `loopx*` command facades cover
-  manager commands, while upgrades retire the older managed `$loopx` facade;
+- `~/.codex/skills/loopx*/SKILL.md` for explicit Codex command-facade
+  invocation through `$loopx` or `/skills`; the `LoopX /loopx` command facade
+  remains distinct from the `LoopX Project` workflow skill;
 - `~/.claude/skills/loopx*/SKILL.md` for Claude Code skill-based slash
   commands.
 

--- a/docs/reference/protocols/codex-app-host-command-registry-v0.md
+++ b/docs/reference/protocols/codex-app-host-command-registry-v0.md
@@ -220,7 +220,7 @@ facades into the user-level discovery locations that current hosts already
 support:
 
 - `~/.codex/skills/loopx*/SKILL.md` for explicit Codex command-facade
-  invocation through `$loopx` or `/skills`; the `LoopX /loopx` command facade
+  invocation through `$loopx` or `/skills`; the primary `LoopX` command facade
   remains distinct from the `LoopX Project` workflow skill;
 - `~/.claude/skills/loopx*/SKILL.md` for Claude Code skill-based slash
   commands.

--- a/docs/reference/protocols/codex-app-host-command-registry-v0.md
+++ b/docs/reference/protocols/codex-app-host-command-registry-v0.md
@@ -219,8 +219,9 @@ Until every host exposes a native command registry, LoopX installs slash-command
 facades into the user-level discovery locations that current hosts already
 support:
 
-- `~/.codex/skills/loopx*/SKILL.md` for explicit Codex command-facade
-  invocation through `$loopx` or `/skills`;
+- `~/.codex/skills/loopx-project/SKILL.md` for the Codex project command
+  fallback shown as `LoopX` in `/skills`; other `loopx*` command facades cover
+  manager commands, while upgrades retire the older managed `$loopx` facade;
 - `~/.claude/skills/loopx*/SKILL.md` for Claude Code skill-based slash
   commands.
 

--- a/examples/canary/canary-promotion-no-write-contract-smoke.py
+++ b/examples/canary/canary-promotion-no-write-contract-smoke.py
@@ -30,6 +30,8 @@ def main() -> int:
     dashboard_source = DASHBOARD_DEMO_SMOKE.read_text(encoding="utf-8")
 
     assert_contains(canary_source, "--no-write-evidence", "canary no-write flag")
+    assert_contains(canary_source, "--goal-id", "canary refresh-state goal id flag")
+    assert_contains(canary_source, "DEFAULT_READINESS_GOAL_ID", "canary default writeback goal")
     assert_contains(canary_source, "--agent-id", "canary refresh-state agent id flag")
     assert_contains(canary_source, "DEFAULT_READINESS_AGENT_ID", "canary default writeback agent")
     assert_contains(canary_source, "DEFAULT_READINESS_AGENT_LANE", "canary default writeback lane")

--- a/examples/canary/canary-promotion-readiness-smoke.py
+++ b/examples/canary/canary-promotion-readiness-smoke.py
@@ -26,7 +26,7 @@ COMMON_NODE_PATHS = [
     "/opt/homebrew/bin",
     "/usr/local/bin",
 ]
-READINESS_GOAL_ID = "loopx-meta"
+DEFAULT_READINESS_GOAL_ID = "loopx-meta"
 DEFAULT_READINESS_AGENT_ID = "codex-product-capability"
 DEFAULT_READINESS_AGENT_LANE = "product_capability_catalog_canary"
 READINESS_CLASSIFICATION = "canary_promotion_readiness_smoke_group"
@@ -72,6 +72,14 @@ def parse_args() -> argparse.Namespace:
         help="Run checks only; do not append the promotion-readiness evidence event.",
     )
     parser.add_argument(
+        "--goal-id",
+        default=os.environ.get("LOOPX_GOAL_ID") or DEFAULT_READINESS_GOAL_ID,
+        help=(
+            "Registered goal id used for the readiness evidence writeback. "
+            "Defaults to LOOPX_GOAL_ID or loopx-meta."
+        ),
+    )
+    parser.add_argument(
         "--agent-id",
         default=os.environ.get("LOOPX_AGENT_ID") or DEFAULT_READINESS_AGENT_ID,
         help=(
@@ -109,6 +117,7 @@ def write_readiness_evidence(
     env: dict[str, str],
     *,
     dashboard_skipped: bool,
+    goal_id: str | None = None,
     agent_id: str | None = None,
     agent_lane: str | None = None,
 ) -> None:
@@ -120,6 +129,9 @@ def write_readiness_evidence(
     resolved_agent_id = (
         agent_id or os.environ.get("LOOPX_AGENT_ID") or DEFAULT_READINESS_AGENT_ID
     ).strip()
+    resolved_goal_id = (
+        goal_id or os.environ.get("LOOPX_GOAL_ID") or DEFAULT_READINESS_GOAL_ID
+    ).strip()
     resolved_agent_lane = (
         agent_lane or os.environ.get("LOOPX_AGENT_LANE") or DEFAULT_READINESS_AGENT_LANE
     ).strip()
@@ -129,7 +141,7 @@ def write_readiness_evidence(
         "loopx.cli",
         "refresh-state",
         "--goal-id",
-        READINESS_GOAL_ID,
+        resolved_goal_id,
         "--classification",
         READINESS_CLASSIFICATION,
         "--recommended-action",
@@ -217,6 +229,7 @@ def main() -> int:
         write_readiness_evidence(
             env,
             dashboard_skipped=dashboard_plan["status"] == "skip",
+            goal_id=args.goal_id,
             agent_id=args.agent_id,
             agent_lane=args.agent_lane,
         )

--- a/examples/canary/canary-promotion-readiness-writeback-smoke.py
+++ b/examples/canary/canary-promotion-readiness-writeback-smoke.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 INSTALL_SCRIPT = REPO_ROOT / "scripts" / "install-local.sh"
-GOAL_ID = "loopx-meta"
+GOAL_ID = "loopx-product"
 
 
 def load_canary_smoke_module():
@@ -159,7 +159,11 @@ def main() -> int:
         assert "promotion-readiness evidence is missing" in preflight_install.stderr, preflight_install.stderr
         assert "non-blocking" in preflight_install.stderr, preflight_install.stderr
 
-        module.write_readiness_evidence(env, dashboard_skipped=False)
+        module.write_readiness_evidence(
+            env,
+            dashboard_skipped=False,
+            goal_id=GOAL_ID,
+        )
 
         index_path = runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
         assert index_path.is_file(), index_path
@@ -202,7 +206,7 @@ def main() -> int:
         global_registry = runtime / "registry.global.json"
         assert global_registry.is_file(), global_registry
         global_payload = json.loads(global_registry.read_text(encoding="utf-8"))
-        assert global_payload["common_runtime_root"] == str(runtime), global_payload
+        assert Path(global_payload["common_runtime_root"]).resolve() == runtime.resolve(), global_payload
         assert any(goal.get("id") == GOAL_ID for goal in global_payload.get("goals") or []), global_payload
 
         ready_gate = run_promotion_gate(env, runtime)

--- a/examples/cli-help-manpage-smoke.py
+++ b/examples/cli-help-manpage-smoke.py
@@ -94,6 +94,40 @@ def assert_installer_manpage_surface() -> None:
             "SHELL": "/bin/zsh",
         }
 
+        help_result = subprocess.run(
+            [str(script), "--help"],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+        assert help_result.returncode == 0, help_result
+        assert "Usage: install-local.sh [--help]" in help_result.stdout, help_result.stdout
+        assert "positional arguments are not supported" in help_result.stdout, help_result.stdout
+        assert help_result.stderr == "", help_result.stderr
+        assert not bin_dir.exists(), bin_dir
+        assert not man_root.exists(), man_root
+        assert not profile.exists(), profile
+        assert not Path(env["CODEX_HOME"]).exists(), env["CODEX_HOME"]
+        assert not Path(env["LOOPX_RELEASES_DIR"]).exists(), env["LOOPX_RELEASES_DIR"]
+
+        unknown_result = subprocess.run(
+            [str(script), "--unknown"],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+        assert unknown_result.returncode == 2, unknown_result
+        assert unknown_result.stdout == "", unknown_result.stdout
+        assert "loopx installer error: unknown argument: --unknown" in unknown_result.stderr
+        assert "Usage: install-local.sh [--help]" in unknown_result.stderr
+        assert not bin_dir.exists(), bin_dir
+        assert not man_root.exists(), man_root
+        assert not profile.exists(), profile
+        assert not Path(env["CODEX_HOME"]).exists(), env["CODEX_HOME"]
+        assert not Path(env["LOOPX_RELEASES_DIR"]).exists(), env["LOOPX_RELEASES_DIR"]
+
         install = subprocess.run(
             [str(script)],
             cwd=REPO_ROOT,

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -338,6 +338,10 @@ def main() -> int:
         )
         doc_registry_skill = codex_home / "skills" / "loopx-doc-registry" / "SKILL.md"
         doc_registry_text = " ".join(doc_registry_skill.read_text(encoding="utf-8").split())
+        doc_registry_metadata = doc_registry_skill.parent / "agents" / "openai.yaml"
+        doc_registry_metadata_text = doc_registry_metadata.read_text(encoding="utf-8")
+        assert 'display_name: "LoopX Doc Registry"' in doc_registry_metadata_text
+        assert 'display_name: "Loopx' not in doc_registry_metadata_text
         for phrase in (
             "Use even when the user does not mention LoopX or doc registry",
             "use `.loopx/registry.json` as the project-local doc registry",

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -316,11 +316,17 @@ def main() -> int:
         assert not auto_research_skill.exists(), auto_research_skill
         loopx_prompt = codex_home / "prompts" / "loopx.md"
         assert not loopx_prompt.exists(), loopx_prompt
-        assert not (codex_home / "skills" / "loopx" / "SKILL.md").exists()
-        assert not (codex_home / "skills" / "loopx" / "agents" / "openai.yaml").exists()
+        loopx_command_skill = codex_home / "skills" / "loopx" / "SKILL.md"
+        loopx_command_skill_text = loopx_command_skill.read_text(encoding="utf-8")
+        assert "surface=codex-skills" in loopx_command_skill_text, loopx_command_skill_text
+        loopx_openai_metadata = loopx_command_skill.parent / "agents" / "openai.yaml"
+        loopx_openai_metadata_text = loopx_openai_metadata.read_text(encoding="utf-8")
+        assert 'display_name: "LoopX /loopx"' in loopx_openai_metadata_text, loopx_openai_metadata_text
+        assert "allow_implicit_invocation: false" in loopx_openai_metadata_text, loopx_openai_metadata_text
         loopx_project_metadata = codex_home / "skills" / "loopx-project" / "agents" / "openai.yaml"
         loopx_project_metadata_text = loopx_project_metadata.read_text(encoding="utf-8")
-        assert 'display_name: "LoopX"' in loopx_project_metadata_text, loopx_project_metadata_text
+        assert 'display_name: "LoopX Project"' in loopx_project_metadata_text, loopx_project_metadata_text
+        assert 'display_name: "LoopX /loopx"' not in loopx_project_metadata_text, loopx_project_metadata_text
         claude_loopx_skill = home / ".claude" / "skills" / "loopx" / "SKILL.md"
         claude_loopx_skill_text = claude_loopx_skill.read_text(encoding="utf-8")
         assert "surface=claude-skills" in claude_loopx_skill_text, claude_loopx_skill_text

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -305,6 +305,13 @@ def main() -> int:
             "Do not use this skill to approve",
         ):
             assert phrase in pr_review_text, phrase
+        pr_review_metadata = pr_review_skill.parent / "agents" / "openai.yaml"
+        pr_review_metadata_text = pr_review_metadata.read_text(encoding="utf-8")
+        assert (
+            'short_description: "Guide AgentLoop through LoopX PR review queues"'
+            in pr_review_metadata_text
+        ), pr_review_metadata_text
+        assert "Guide agentloop" not in pr_review_metadata_text, pr_review_metadata_text
         auto_research_skill = codex_home / "skills" / "loopx-auto-research" / "SKILL.md"
         assert not auto_research_skill.exists(), auto_research_skill
         loopx_prompt = codex_home / "prompts" / "loopx.md"

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -164,6 +164,18 @@ def main() -> int:
         stale_canary_target.mkdir()
         (bin_dir / "loopx-canary").symlink_to(stale_canary_target)
         codex_home = home / ".codex"
+        stale_command_skill = codex_home / "skills" / "loopx" / "SKILL.md"
+        stale_command_skill.parent.mkdir(parents=True)
+        stale_command_skill.write_text(
+            "<!-- loopx-managed-slash-command:v1 command=/loopx surface=codex-skills -->\n",
+            encoding="utf-8",
+        )
+        stale_command_metadata = stale_command_skill.parent / "agents" / "openai.yaml"
+        stale_command_metadata.parent.mkdir(parents=True)
+        stale_command_metadata.write_text(
+            "# <!-- loopx-managed-slash-command:v1 command=/loopx surface=codex-skill-metadata -->\n",
+            encoding="utf-8",
+        )
         profile = home / ".zshrc"
         assert_release_snapshot_source_fallback(root)
         env = {
@@ -297,12 +309,11 @@ def main() -> int:
         assert not auto_research_skill.exists(), auto_research_skill
         loopx_prompt = codex_home / "prompts" / "loopx.md"
         assert not loopx_prompt.exists(), loopx_prompt
-        loopx_command_skill = codex_home / "skills" / "loopx" / "SKILL.md"
-        loopx_command_skill_text = loopx_command_skill.read_text(encoding="utf-8")
-        assert "surface=codex-skills" in loopx_command_skill_text, loopx_command_skill_text
-        loopx_openai_metadata = codex_home / "skills" / "loopx" / "agents" / "openai.yaml"
-        loopx_openai_metadata_text = loopx_openai_metadata.read_text(encoding="utf-8")
-        assert "allow_implicit_invocation: false" in loopx_openai_metadata_text, loopx_openai_metadata_text
+        assert not (codex_home / "skills" / "loopx" / "SKILL.md").exists()
+        assert not (codex_home / "skills" / "loopx" / "agents" / "openai.yaml").exists()
+        loopx_project_metadata = codex_home / "skills" / "loopx-project" / "agents" / "openai.yaml"
+        loopx_project_metadata_text = loopx_project_metadata.read_text(encoding="utf-8")
+        assert 'display_name: "LoopX"' in loopx_project_metadata_text, loopx_project_metadata_text
         claude_loopx_skill = home / ".claude" / "skills" / "loopx" / "SKILL.md"
         claude_loopx_skill_text = claude_loopx_skill.read_text(encoding="utf-8")
         assert "surface=claude-skills" in claude_loopx_skill_text, claude_loopx_skill_text

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -321,12 +321,13 @@ def main() -> int:
         assert "surface=codex-skills" in loopx_command_skill_text, loopx_command_skill_text
         loopx_openai_metadata = loopx_command_skill.parent / "agents" / "openai.yaml"
         loopx_openai_metadata_text = loopx_openai_metadata.read_text(encoding="utf-8")
-        assert 'display_name: "LoopX /loopx"' in loopx_openai_metadata_text, loopx_openai_metadata_text
+        assert 'display_name: "LoopX"' in loopx_openai_metadata_text, loopx_openai_metadata_text
+        assert 'display_name: "LoopX /loopx"' not in loopx_openai_metadata_text, loopx_openai_metadata_text
         assert "allow_implicit_invocation: false" in loopx_openai_metadata_text, loopx_openai_metadata_text
         loopx_project_metadata = codex_home / "skills" / "loopx-project" / "agents" / "openai.yaml"
         loopx_project_metadata_text = loopx_project_metadata.read_text(encoding="utf-8")
         assert 'display_name: "LoopX Project"' in loopx_project_metadata_text, loopx_project_metadata_text
-        assert 'display_name: "LoopX /loopx"' not in loopx_project_metadata_text, loopx_project_metadata_text
+        assert 'display_name: "LoopX"' not in loopx_project_metadata_text, loopx_project_metadata_text
         claude_loopx_skill = home / ".claude" / "skills" / "loopx" / "SKILL.md"
         claude_loopx_skill_text = claude_loopx_skill.read_text(encoding="utf-8")
         assert "surface=claude-skills" in claude_loopx_skill_text, claude_loopx_skill_text

--- a/examples/slash-command-install-smoke.py
+++ b/examples/slash-command-install-smoke.py
@@ -79,20 +79,20 @@ def main() -> int:
         assert payload["summary"]["status_counts"]["created"] >= 20, payload
         assert payload["summary"]["status_counts"]["unsupported_host_surface"] >= 1, payload
         assert "skipped_user_file" not in payload["summary"]["status_counts"], payload
-        codex_skill_rows = [
+        retired_codex_project_rows = [
             item
             for item in payload["installed"]
-            if item.get("mechanism") == "codex_explicit_skills" and item.get("command") == "/loopx"
+            if item.get("mechanism") == "retired_codex_project_command_facade"
         ]
-        assert codex_skill_rows, payload
-        assert codex_skill_rows[0]["invoke_as"] == ["$loopx", "/skills"], codex_skill_rows
-        assert "/loopx" not in codex_skill_rows[0]["invoke_as"], codex_skill_rows
-        codex_metadata_rows = [
+        assert retired_codex_project_rows, payload
+        assert retired_codex_project_rows[0]["status"] == "absent", retired_codex_project_rows
+        retired_codex_project_metadata_rows = [
             item
             for item in payload["installed"]
-            if item.get("mechanism") == "codex_skill_openai_metadata" and item.get("command") == "/loopx"
+            if item.get("mechanism") == "retired_codex_project_command_metadata"
         ]
-        assert codex_metadata_rows, payload
+        assert retired_codex_project_metadata_rows, payload
+        assert retired_codex_project_metadata_rows[0]["status"] == "absent", retired_codex_project_metadata_rows
         codex_cli_rows = [
             item
             for item in payload["installed"]
@@ -102,23 +102,11 @@ def main() -> int:
         assert codex_cli_rows[0]["status"] == "unsupported_host_surface", codex_cli_rows
         assert codex_cli_rows[0]["native_registry_supported"] is False, codex_cli_rows
         assert codex_cli_rows[0]["failure_policy"] == "fail_closed_to_explicit_skill", codex_cli_rows
-        assert "$loopx" in codex_cli_rows[0]["fallback"], codex_cli_rows
+        assert "`LoopX` workflow skill in `/skills`" in codex_cli_rows[0]["fallback"], codex_cli_rows
+        assert "$loopx" not in codex_cli_rows[0]["fallback"], codex_cli_rows
 
-        codex_skill = codex_home / "skills" / "loopx" / "SKILL.md"
-        codex_skill_text = codex_skill.read_text(encoding="utf-8")
-        assert "name: \"loopx\"" in codex_skill_text
-        assert "surface=codex-skills" in codex_skill_text
-        assert "LoopX `/loopx`" in codex_skill_text
-        assert "start-goal --guided --project . --goal-text" in codex_skill_text
-        assert "bootstrap-command-pack --project . --goal-text" not in codex_skill_text
-        assert "new peer/meta/supervisor agent" in codex_skill_text
-        assert "register-agent --goal-id <selected-goal-id>" in codex_skill_text
-        assert "Do not configure optional features during first-run" in codex_skill_text
-        assert "configure-goal --goal-id <resolved-goal-id>" in codex_skill_text
-        codex_metadata = codex_home / "skills" / "loopx" / "agents" / "openai.yaml"
-        codex_metadata_text = codex_metadata.read_text(encoding="utf-8")
-        assert "allow_implicit_invocation: false" in codex_metadata_text
-        assert "loopx-managed-slash-command:v1 command=/loopx surface=codex-skill-metadata" in codex_metadata_text
+        assert not (codex_home / "skills" / "loopx" / "SKILL.md").exists()
+        assert not (codex_home / "skills" / "loopx" / "agents" / "openai.yaml").exists()
 
         assert not (codex_home / "prompts" / "loopx-pr-review.md").exists()
 
@@ -193,7 +181,7 @@ def main() -> int:
         assert "codex skills:" in markdown, markdown
         assert "claude skills:" in markdown, markdown
         assert "Skipped user-owned files:" in markdown, markdown
-        assert "$loopx" in markdown and "command-facade skills" in markdown, markdown
+        assert "older managed $loopx command facade" in markdown, markdown
 
         codex_only = json.loads(
             run_cli(
@@ -220,7 +208,7 @@ def main() -> int:
         legacy_skill = legacy_codex_home / "skills" / "loopx" / "SKILL.md"
         legacy_skill.parent.mkdir(parents=True)
         legacy_skill.write_text(
-            "# Legacy LoopX\n\nloopx goal-mode setup (NOT Claude Code's built-in /goal)\n",
+            "<!-- loopx-managed-slash-command:v1 command=/loopx surface=codex-skills -->\n",
             encoding="utf-8",
         )
         legacy_install = json.loads(
@@ -237,8 +225,29 @@ def main() -> int:
                 str(legacy_claude_home),
             ).stdout
         )
-        assert statuses_for(legacy_install, legacy_skill) == ["upgraded_legacy_managed"], legacy_install
-        assert "loopx-managed-slash-command:v1 command=/loopx surface=codex-skills" in legacy_skill.read_text(encoding="utf-8")
+        assert statuses_for(legacy_install, legacy_skill) == ["retired_managed_file"], legacy_install
+        assert not legacy_skill.exists(), legacy_install
+
+        user_codex_home = root / "user-codex"
+        user_skill = user_codex_home / "skills" / "loopx" / "SKILL.md"
+        user_skill.parent.mkdir(parents=True)
+        user_skill.write_text("# user-owned loopx skill\n", encoding="utf-8")
+        user_install = json.loads(
+            run_cli(
+                "--format",
+                "json",
+                "slash-commands",
+                "--install",
+                "--surface",
+                "codex",
+                "--codex-home",
+                str(user_codex_home),
+                "--claude-home",
+                str(root / "user-claude"),
+            ).stdout
+        )
+        assert statuses_for(user_install, user_skill) == ["skipped_user_file"], user_install
+        assert user_skill.read_text(encoding="utf-8") == "# user-owned loopx skill\n"
 
         uninstall_codex_home = root / "uninstall-codex"
         uninstall_claude_home = root / "uninstall-claude"

--- a/examples/slash-command-install-smoke.py
+++ b/examples/slash-command-install-smoke.py
@@ -79,20 +79,20 @@ def main() -> int:
         assert payload["summary"]["status_counts"]["created"] >= 20, payload
         assert payload["summary"]["status_counts"]["unsupported_host_surface"] >= 1, payload
         assert "skipped_user_file" not in payload["summary"]["status_counts"], payload
-        retired_codex_project_rows = [
+        codex_skill_rows = [
             item
             for item in payload["installed"]
-            if item.get("mechanism") == "retired_codex_project_command_facade"
+            if item.get("mechanism") == "codex_explicit_skills" and item.get("command") == "/loopx"
         ]
-        assert retired_codex_project_rows, payload
-        assert retired_codex_project_rows[0]["status"] == "absent", retired_codex_project_rows
-        retired_codex_project_metadata_rows = [
+        assert codex_skill_rows, payload
+        assert codex_skill_rows[0]["invoke_as"] == ["$loopx", "/skills"], codex_skill_rows
+        assert "/loopx" not in codex_skill_rows[0]["invoke_as"], codex_skill_rows
+        codex_metadata_rows = [
             item
             for item in payload["installed"]
-            if item.get("mechanism") == "retired_codex_project_command_metadata"
+            if item.get("mechanism") == "codex_skill_openai_metadata" and item.get("command") == "/loopx"
         ]
-        assert retired_codex_project_metadata_rows, payload
-        assert retired_codex_project_metadata_rows[0]["status"] == "absent", retired_codex_project_metadata_rows
+        assert codex_metadata_rows, payload
         codex_cli_rows = [
             item
             for item in payload["installed"]
@@ -102,11 +102,19 @@ def main() -> int:
         assert codex_cli_rows[0]["status"] == "unsupported_host_surface", codex_cli_rows
         assert codex_cli_rows[0]["native_registry_supported"] is False, codex_cli_rows
         assert codex_cli_rows[0]["failure_policy"] == "fail_closed_to_explicit_skill", codex_cli_rows
-        assert "`LoopX` workflow skill in `/skills`" in codex_cli_rows[0]["fallback"], codex_cli_rows
-        assert "$loopx" not in codex_cli_rows[0]["fallback"], codex_cli_rows
+        assert "$loopx" in codex_cli_rows[0]["fallback"], codex_cli_rows
 
-        assert not (codex_home / "skills" / "loopx" / "SKILL.md").exists()
-        assert not (codex_home / "skills" / "loopx" / "agents" / "openai.yaml").exists()
+        codex_skill = codex_home / "skills" / "loopx" / "SKILL.md"
+        codex_skill_text = codex_skill.read_text(encoding="utf-8")
+        assert 'name: "loopx"' in codex_skill_text
+        assert "surface=codex-skills" in codex_skill_text
+        assert "LoopX `/loopx`" in codex_skill_text
+        assert "start-goal --guided --project . --goal-text" in codex_skill_text
+        codex_metadata = codex_home / "skills" / "loopx" / "agents" / "openai.yaml"
+        codex_metadata_text = codex_metadata.read_text(encoding="utf-8")
+        assert 'display_name: "LoopX /loopx"' in codex_metadata_text
+        assert "allow_implicit_invocation: false" in codex_metadata_text
+        assert "loopx-managed-slash-command:v1 command=/loopx surface=codex-skill-metadata" in codex_metadata_text
 
         assert not (codex_home / "prompts" / "loopx-pr-review.md").exists()
 
@@ -181,7 +189,7 @@ def main() -> int:
         assert "codex skills:" in markdown, markdown
         assert "claude skills:" in markdown, markdown
         assert "Skipped user-owned files:" in markdown, markdown
-        assert "older managed $loopx command facade" in markdown, markdown
+        assert "$loopx" in markdown and "command-facade skills" in markdown, markdown
 
         codex_only = json.loads(
             run_cli(
@@ -225,8 +233,8 @@ def main() -> int:
                 str(legacy_claude_home),
             ).stdout
         )
-        assert statuses_for(legacy_install, legacy_skill) == ["retired_managed_file"], legacy_install
-        assert not legacy_skill.exists(), legacy_install
+        assert statuses_for(legacy_install, legacy_skill) == ["updated"], legacy_install
+        assert "loopx-managed-slash-command:v1 command=/loopx surface=codex-skills" in legacy_skill.read_text(encoding="utf-8")
 
         user_codex_home = root / "user-codex"
         user_skill = user_codex_home / "skills" / "loopx" / "SKILL.md"

--- a/examples/slash-command-install-smoke.py
+++ b/examples/slash-command-install-smoke.py
@@ -112,7 +112,8 @@ def main() -> int:
         assert "start-goal --guided --project . --goal-text" in codex_skill_text
         codex_metadata = codex_home / "skills" / "loopx" / "agents" / "openai.yaml"
         codex_metadata_text = codex_metadata.read_text(encoding="utf-8")
-        assert 'display_name: "LoopX /loopx"' in codex_metadata_text
+        assert 'display_name: "LoopX"' in codex_metadata_text
+        assert 'display_name: "LoopX /loopx"' not in codex_metadata_text
         assert "allow_implicit_invocation: false" in codex_metadata_text
         assert "loopx-managed-slash-command:v1 command=/loopx surface=codex-skill-metadata" in codex_metadata_text
 

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -297,6 +297,23 @@ def install_slash_commands(
         for spec in specs:
             skill_path = skill_dir / str(spec["name"]) / "SKILL.md"
             metadata_path = skill_path.parent / "agents" / "openai.yaml"
+            if spec["command"] == "/loopx":
+                for path, mechanism in (
+                    (skill_path, "retired_codex_project_command_facade"),
+                    (metadata_path, "retired_codex_project_command_metadata"),
+                ):
+                    installed.append(
+                        {
+                            "surface": "codex",
+                            "host_surfaces": ["codex-cli", "codex-ide", "codex-app"],
+                            "mechanism": mechanism,
+                            "command": spec["command"],
+                            "path": str(path),
+                            "status": _retire_status(path, execute=execute),
+                            "invoke_as": [],
+                        }
+                    )
+                continue
             if uninstall:
                 skill_status = _retire_status(skill_path, execute=execute)
                 installed.append(
@@ -377,6 +394,19 @@ def install_slash_commands(
                         }
                     )
         for spec in specs:
+            if spec["command"] == "/loopx":
+                fallback = (
+                    "Use the `LoopX` workflow skill in `/skills`; for the visible TUI loop, "
+                    "run `loopx codex-cli-bootstrap-message --project .`, paste the setup "
+                    "message, then set `/goal <thin task_body>`."
+                )
+            else:
+                fallback = (
+                    f"Use `${spec['name']}` or `/skills` to explicitly invoke the LoopX "
+                    "command skill; for the visible TUI loop, run "
+                    "`loopx codex-cli-bootstrap-message --project .`, paste the setup "
+                    "message, then set `/goal <thin task_body>`."
+                )
             installed.append(
                 {
                     "surface": "codex",
@@ -392,7 +422,7 @@ def install_slash_commands(
                     ),
                     "native_registry_supported": False,
                     "failure_policy": "fail_closed_to_explicit_skill",
-                    "fallback": "Use `$loopx` or `/skills` to explicitly invoke the LoopX skill; for the visible TUI loop, run `loopx codex-cli-bootstrap-message --project .`, paste the setup message, then set `/goal <thin task_body>`.",
+                    "fallback": fallback,
                 }
             )
 
@@ -463,8 +493,8 @@ def install_slash_commands(
         },
         "installed": installed,
         "notes": [
-            "Codex does not currently support user-defined native top-level slash commands; use explicit skill invocation through `$loopx` or `/skills`.",
-            "Only explicit LoopX command-facade skills are installed with agents/openai.yaml policy allow_implicit_invocation=false; richer workflow skills stay implicit.",
+            "Codex routes the project-local /loopx fallback through the LoopX workflow skill; upgrades retire the older managed $loopx command facade.",
+            "Other explicit LoopX command-facade skills are installed with agents/openai.yaml policy allow_implicit_invocation=false; richer workflow skills stay implicit.",
             "Claude Code discovers user skills from CLAUDE_HOME/skills and exposes each skill name as a slash command.",
             "Uninstall is fail-closed: it retires only files carrying the LoopX managed marker and leaves user-owned files in place.",
         ],

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -297,23 +297,6 @@ def install_slash_commands(
         for spec in specs:
             skill_path = skill_dir / str(spec["name"]) / "SKILL.md"
             metadata_path = skill_path.parent / "agents" / "openai.yaml"
-            if spec["command"] == "/loopx":
-                for path, mechanism in (
-                    (skill_path, "retired_codex_project_command_facade"),
-                    (metadata_path, "retired_codex_project_command_metadata"),
-                ):
-                    installed.append(
-                        {
-                            "surface": "codex",
-                            "host_surfaces": ["codex-cli", "codex-ide", "codex-app"],
-                            "mechanism": mechanism,
-                            "command": spec["command"],
-                            "path": str(path),
-                            "status": _retire_status(path, execute=execute),
-                            "invoke_as": [],
-                        }
-                    )
-                continue
             if uninstall:
                 skill_status = _retire_status(skill_path, execute=execute)
                 installed.append(
@@ -394,19 +377,6 @@ def install_slash_commands(
                         }
                     )
         for spec in specs:
-            if spec["command"] == "/loopx":
-                fallback = (
-                    "Use the `LoopX` workflow skill in `/skills`; for the visible TUI loop, "
-                    "run `loopx codex-cli-bootstrap-message --project .`, paste the setup "
-                    "message, then set `/goal <thin task_body>`."
-                )
-            else:
-                fallback = (
-                    f"Use `${spec['name']}` or `/skills` to explicitly invoke the LoopX "
-                    "command skill; for the visible TUI loop, run "
-                    "`loopx codex-cli-bootstrap-message --project .`, paste the setup "
-                    "message, then set `/goal <thin task_body>`."
-                )
             installed.append(
                 {
                     "surface": "codex",
@@ -422,7 +392,12 @@ def install_slash_commands(
                     ),
                     "native_registry_supported": False,
                     "failure_policy": "fail_closed_to_explicit_skill",
-                    "fallback": fallback,
+                    "fallback": (
+                        f"Use `${spec['name']}` or `/skills` to explicitly invoke the LoopX "
+                        "command skill; for the visible TUI loop, run "
+                        "`loopx codex-cli-bootstrap-message --project .`, paste the setup "
+                        "message, then set `/goal <thin task_body>`."
+                    ),
                 }
             )
 
@@ -493,8 +468,8 @@ def install_slash_commands(
         },
         "installed": installed,
         "notes": [
-            "Codex routes the project-local /loopx fallback through the LoopX workflow skill; upgrades retire the older managed $loopx command facade.",
-            "Other explicit LoopX command-facade skills are installed with agents/openai.yaml policy allow_implicit_invocation=false; richer workflow skills stay implicit.",
+            "Codex does not currently support user-defined native top-level slash commands; use explicit skill invocation through `$loopx` or `/skills`.",
+            "Explicit LoopX command-facade skills use agents/openai.yaml policy allow_implicit_invocation=false and remain distinct from richer workflow skills such as loopx-project.",
             "Claude Code discovers user skills from CLAUDE_HOME/skills and exposes each skill name as a slash command.",
             "Uninstall is fail-closed: it retires only files carrying the LoopX managed marker and leaves user-owned files in place.",
         ],

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -345,9 +345,12 @@ def install_slash_commands(
                 }
             )
             if skill_status not in {"skipped_user_file", "preserved_existing_loopx_skill"}:
+                display_name = (
+                    "LoopX" if spec["command"] == "/loopx" else f"LoopX {spec['command']}"
+                )
                 metadata = _openai_skill_metadata(
                     command=str(spec["command"]),
-                    display_name=f"LoopX {spec['command']}",
+                    display_name=display_name,
                     short_description=str(spec["description"]),
                 )
                 metadata_status = _target_status(metadata_path, metadata, execute=execute)

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -1,6 +1,44 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+  cat <<'EOF'
+Usage: install-local.sh [--help]
+
+Install LoopX from the current checkout. Installation behavior is configured
+through environment variables; positional arguments are not supported.
+
+Options:
+  -h, --help  Show this help and exit.
+
+Common environment variables:
+  LOOPX_PROMOTE_DEFAULT=1          Promote this checkout as the default loopx.
+  LOOPX_INSTALL_CANARY=0           Skip the loopx-canary executable.
+  LOOPX_INSTALL_SKILL=0            Skip packaged Codex workflow skills.
+  LOOPX_INSTALL_SLASH_COMMANDS=0   Skip Codex and Claude command skills.
+  CODEX_HOME=/path                 Override the Codex home directory.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    if [[ "$#" -ne 1 ]]; then
+      echo "loopx installer error: --help does not accept additional arguments" >&2
+      usage >&2
+      exit 2
+    fi
+    usage
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "loopx installer error: unknown argument: $1" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/.." && pwd)"
 

--- a/skills/loopx-doc-registry/agents/openai.yaml
+++ b/skills/loopx-doc-registry/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "LoopX Doc Registry"
+  short_description: "Register durable project materials in LoopX"
+  default_prompt: "Use the LoopX doc registry workflow to register or retrieve durable project materials from the authoritative project state."

--- a/skills/loopx-pr-review/agents/openai.yaml
+++ b/skills/loopx-pr-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "LoopX PR Review"
-  short_description: "Guide agentloop through LoopX PR review queues"
+  short_description: "Guide AgentLoop through LoopX PR review queues"
   default_prompt: "Use /loopx-pr-review to fetch the PR queue, preserve the full packet contract, read selected PR evidence, and produce five-block reviews."

--- a/skills/loopx-project/agents/openai.yaml
+++ b/skills/loopx-project/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "LoopX"
+  short_description: "Connect projects and advance LoopX goals"
+  default_prompt: "Use the LoopX project workflow to inspect or advance the current project goal from authoritative LoopX state."

--- a/skills/loopx-project/agents/openai.yaml
+++ b/skills/loopx-project/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "LoopX"
+  display_name: "LoopX Project"
   short_description: "Connect projects and advance LoopX goals"
   default_prompt: "Use the LoopX project workflow to inspect or advance the current project goal from authoritative LoopX state."

--- a/tests/test_packaged_skill_metadata.py
+++ b/tests/test_packaged_skill_metadata.py
@@ -1,0 +1,20 @@
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_packaged_loopx_skills_use_canonical_brand_display_names() -> None:
+    skill_dirs = sorted((REPO_ROOT / "skills").glob("loopx-*"))
+    assert skill_dirs
+
+    for skill_dir in skill_dirs:
+        metadata_path = skill_dir / "agents" / "openai.yaml"
+        assert metadata_path.is_file(), f"{skill_dir.name} must declare an explicit display name"
+        metadata = metadata_path.read_text(encoding="utf-8")
+        match = re.search(r'^\s*display_name:\s*"([^"]+)"\s*$', metadata, re.MULTILINE)
+        assert match, f"{metadata_path} must declare interface.display_name"
+        display_name = match.group(1)
+        assert display_name == "LoopX" or display_name.startswith("LoopX "), display_name
+        assert not display_name.startswith("Loopx"), display_name

--- a/tests/test_slash_command_install.py
+++ b/tests/test_slash_command_install.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+
+from loopx.slash_command_install import install_slash_commands
+
+
+MANAGED_SKILL = "<!-- loopx-managed-slash-command:v1 command=/loopx surface=codex-skills -->\n"
+MANAGED_METADATA = (
+    "# <!-- loopx-managed-slash-command:v1 command=/loopx "
+    "surface=codex-skill-metadata -->\n"
+)
+
+
+def _row(payload: dict[str, object], mechanism: str) -> dict[str, object]:
+    installed = payload["installed"]
+    assert isinstance(installed, list)
+    return next(item for item in installed if item.get("mechanism") == mechanism)
+
+
+def _loopx_paths(codex_home: Path) -> tuple[Path, Path]:
+    skill = codex_home / "skills" / "loopx" / "SKILL.md"
+    return skill, skill.parent / "agents" / "openai.yaml"
+
+
+def test_codex_install_retires_managed_loopx_facade(tmp_path: Path) -> None:
+    codex_home = tmp_path / "codex"
+    skill, metadata = _loopx_paths(codex_home)
+    skill.parent.mkdir(parents=True)
+    skill.write_text(MANAGED_SKILL, encoding="utf-8")
+    metadata.parent.mkdir(parents=True)
+    metadata.write_text(MANAGED_METADATA, encoding="utf-8")
+
+    payload = install_slash_commands(
+        execute=True,
+        surfaces=["codex"],
+        codex_home=str(codex_home),
+        claude_home=str(tmp_path / "claude"),
+    )
+
+    assert not skill.exists()
+    assert not metadata.exists()
+    assert _row(payload, "retired_codex_project_command_facade")["status"] == (
+        "retired_managed_file"
+    )
+    assert _row(payload, "retired_codex_project_command_metadata")["status"] == (
+        "retired_managed_file"
+    )
+    fallback = next(
+        item["fallback"]
+        for item in payload["installed"]
+        if item.get("mechanism") == "unsupported_native_slash_registry"
+        and item.get("command") == "/loopx"
+    )
+    assert "$loopx" not in fallback
+    assert "`LoopX` workflow skill in `/skills`" in fallback
+
+
+def test_codex_install_preserves_user_owned_loopx_facade(tmp_path: Path) -> None:
+    codex_home = tmp_path / "codex"
+    skill, metadata = _loopx_paths(codex_home)
+    skill.parent.mkdir(parents=True)
+    skill.write_text("# user-owned loopx skill\n", encoding="utf-8")
+    metadata.parent.mkdir(parents=True)
+    metadata.write_text("# user-owned metadata\n", encoding="utf-8")
+
+    payload = install_slash_commands(
+        execute=True,
+        surfaces=["codex"],
+        codex_home=str(codex_home),
+        claude_home=str(tmp_path / "claude"),
+    )
+
+    assert skill.read_text(encoding="utf-8") == "# user-owned loopx skill\n"
+    assert metadata.read_text(encoding="utf-8") == "# user-owned metadata\n"
+    assert _row(payload, "retired_codex_project_command_facade")["status"] == (
+        "skipped_user_file"
+    )
+    assert _row(payload, "retired_codex_project_command_metadata")["status"] == (
+        "skipped_user_file"
+    )

--- a/tests/test_slash_command_install.py
+++ b/tests/test_slash_command_install.py
@@ -40,7 +40,8 @@ def test_codex_install_upgrades_managed_loopx_facade(tmp_path: Path) -> None:
         encoding="utf-8"
     )
     metadata_text = metadata.read_text(encoding="utf-8")
-    assert 'display_name: "LoopX /loopx"' in metadata_text
+    assert 'display_name: "LoopX"' in metadata_text
+    assert 'display_name: "LoopX /loopx"' not in metadata_text
     assert "allow_implicit_invocation: false" in metadata_text
     assert _row(payload, "codex_explicit_skills")["status"] == "updated"
     assert _row(payload, "codex_skill_openai_metadata")["status"] == "updated"

--- a/tests/test_slash_command_install.py
+++ b/tests/test_slash_command_install.py
@@ -21,7 +21,7 @@ def _loopx_paths(codex_home: Path) -> tuple[Path, Path]:
     return skill, skill.parent / "agents" / "openai.yaml"
 
 
-def test_codex_install_retires_managed_loopx_facade(tmp_path: Path) -> None:
+def test_codex_install_upgrades_managed_loopx_facade(tmp_path: Path) -> None:
     codex_home = tmp_path / "codex"
     skill, metadata = _loopx_paths(codex_home)
     skill.parent.mkdir(parents=True)
@@ -36,22 +36,21 @@ def test_codex_install_retires_managed_loopx_facade(tmp_path: Path) -> None:
         claude_home=str(tmp_path / "claude"),
     )
 
-    assert not skill.exists()
-    assert not metadata.exists()
-    assert _row(payload, "retired_codex_project_command_facade")["status"] == (
-        "retired_managed_file"
+    assert "Treat this as the LoopX `/loopx` explicit LoopX command skill." in skill.read_text(
+        encoding="utf-8"
     )
-    assert _row(payload, "retired_codex_project_command_metadata")["status"] == (
-        "retired_managed_file"
-    )
+    metadata_text = metadata.read_text(encoding="utf-8")
+    assert 'display_name: "LoopX /loopx"' in metadata_text
+    assert "allow_implicit_invocation: false" in metadata_text
+    assert _row(payload, "codex_explicit_skills")["status"] == "updated"
+    assert _row(payload, "codex_skill_openai_metadata")["status"] == "updated"
     fallback = next(
         item["fallback"]
         for item in payload["installed"]
         if item.get("mechanism") == "unsupported_native_slash_registry"
         and item.get("command") == "/loopx"
     )
-    assert "$loopx" not in fallback
-    assert "`LoopX` workflow skill in `/skills`" in fallback
+    assert "$loopx" in fallback
 
 
 def test_codex_install_preserves_user_owned_loopx_facade(tmp_path: Path) -> None:
@@ -71,9 +70,4 @@ def test_codex_install_preserves_user_owned_loopx_facade(tmp_path: Path) -> None
 
     assert skill.read_text(encoding="utf-8") == "# user-owned loopx skill\n"
     assert metadata.read_text(encoding="utf-8") == "# user-owned metadata\n"
-    assert _row(payload, "retired_codex_project_command_facade")["status"] == (
-        "skipped_user_file"
-    )
-    assert _row(payload, "retired_codex_project_command_metadata")["status"] == (
-        "skipped_user_file"
-    )
+    assert _row(payload, "codex_explicit_skills")["status"] == "skipped_user_file"


### PR DESCRIPTION
## What changed

- keep the managed Codex `$loopx` command facade and upgrade it in place
- make the core command facade the uniquely named `LoopX` entry
- keep the separate project workflow as `LoopX Project` with implicit invocation enabled by default
- give the doc-registry workflow the explicit display name `LoopX Doc Registry`
- require every packaged `loopx-*` workflow skill to declare canonical `LoopX` branding
- preserve same-name user-owned skills and keep the Claude Code `/loopx` path unchanged
- document and test the distinct-skill identity contract across fresh and upgrade installs

## Root cause

Three independent concerns had been conflated:

1. The explicit `/loopx` command facade is the primary user entry and must remain distinct from `loopx-project`.
2. The primary command needs the exact display name `LoopX` so it is the leading discovery match.
3. `loopx-doc-registry` had no OpenAI UI metadata, so overwrite installs fell back to a slug-derived `Loopx Doc Registry` label.

The fix makes each capability explicit and treats exact `LoopX` branding as a packaged-skill invariant.

## User impact

After upgrade, Codex discovery has stable names and roles:

- `LoopX` for explicit project-command invocation through `$loopx` or `/skills`
- `LoopX Project` for the implicitly discoverable project workflow
- `LoopX Doc Registry` for durable project-material registration

Only LoopX-managed command files are upgraded. Same-name user-owned files remain untouched.

## Validation

- focused unit contracts: 3 passed
- full Python suite: 502 passed, 2 skipped
- `examples/slash-command-install-smoke.py`: passed
- `examples/install-local-smoke.py`: passed
- standard diff-selected premerge gate: passed
  - 9 catalog canaries
  - 8 risk-profile smokes
  - public/private boundary scan
  - 0 failures, 0 warnings, 0 manual holds
- real clean-snapshot overwrite install: passed
  - installed readback: `LoopX`, `LoopX Project`, `LoopX Doc Registry`
  - the primary `LoopX` command has `allow_implicit_invocation: false`
  - `loopx doctor` reported a fresh, clean release snapshot from commit `bbb68edc`

The coverage exercises fresh install, managed-file upgrade, user-owned preservation, primary-entry naming, metadata identity separation, canonical branding, packaged install, CLI output, and public-boundary behavior.