### PR TITLE
Gate SkillsBench LoopX Turn benchmark fidelity

### DIFF
--- a/examples/benchmark-loopx-turn-fidelity-smoke.py
+++ b/examples/benchmark-loopx-turn-fidelity-smoke.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Smoke-test strict LoopX Turn benchmark treatment and pair fidelity."""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.benchmark_core import (  # noqa: E402
+    build_loopx_turn_benchmark_fidelity_check,
+    build_loopx_turn_goal_matched_pair_check,
+)
+
+
+def _attempt_accounting() -> dict[str, bool]:
+    return {
+        "launcher_attempt_countable": True,
+        "case_attempt_countable": True,
+        "solver_attempt_countable": True,
+        "verifier_attempt_countable": True,
+        "official_score_attempt_countable": True,
+    }
+
+
+def _common() -> dict[str, object]:
+    return {
+        "benchmark_id": "skillsbench@1.1",
+        "case_id": "public-fixture-case",
+        "agent_model": "gpt-fixture",
+        "reasoning_effort": "xhigh",
+        "max_rounds_budget": 5,
+        "official_feedback_blinded": True,
+        "reward_feedback_forwarded": False,
+        "loopx_runner_source_fingerprint": {
+            "fingerprint": "sha256:public-fixture-runner"
+        },
+        **_attempt_accounting(),
+    }
+
+
+def _baseline() -> dict[str, object]:
+    return {
+        **_common(),
+        "route": "codex-cli-goal-baseline",
+        "official_score": 0.0,
+    }
+
+
+def _treatment() -> dict[str, object]:
+    return {
+        **_common(),
+        "route": "loopx-turn-agent-cli",
+        "official_score": 1.0,
+        "loopx_turn_executions": [
+            {
+                "schema_version": "loopx_turn_execution_v0",
+                "mode": "run_once",
+                "status": "committed",
+                "result_kind": "validated_progress",
+                "execution_mode": "isolated-headless",
+                "host": {"executable": "built-in", "kind": "codex-cli"},
+                "validation": {"status": "passed"},
+                "receipt": {"status": "committed"},
+                "effects": {
+                    "host_invoked": True,
+                    "state_written": True,
+                    "quota_spent": True,
+                    "scheduler_acknowledged": False,
+                },
+                "quota_slot_spend_count": 1,
+            },
+        ],
+        "scored_workspace_validation": {
+            "status": "passed",
+            "independent": True,
+            "oracle_feedback_used": False,
+            "meaningful_operation_count": 2,
+        },
+        "public_boundary": {
+            "raw_task_text_recorded": False,
+            "raw_verifier_output_recorded": False,
+            "raw_agent_trajectory_recorded": False,
+            "raw_host_output_recorded": False,
+            "credentials_recorded": False,
+            "local_paths_recorded": False,
+        },
+    }
+
+
+def test_real_turn_pair_is_countable_without_claiming_advantage() -> None:
+    treatment = _treatment()
+    executions = treatment["loopx_turn_executions"]
+    assert isinstance(executions, list)
+    executions.append(copy.deepcopy(executions[0]))
+    fidelity = build_loopx_turn_benchmark_fidelity_check(treatment)
+    assert fidelity["turn_treatment_fidelity_allowed"] is True, fidelity
+    assert fidelity["turn_count"] == 2, fidelity
+
+    pair = build_loopx_turn_goal_matched_pair_check(
+        baseline_run=_baseline(),
+        treatment_run=treatment,
+    )
+    assert pair["matched_pair_countable"] is True, pair
+    assert pair["effect_analysis_allowed"] is True, pair
+    assert pair["advantage_claim_allowed"] is False, pair
+    assert pair["official_scores"]["delta"] == 1.0, pair
+
+
+def test_old_product_mode_cannot_impersonate_turn() -> None:
+    treatment = _treatment()
+    treatment["route"] = "loopx-goal-start-product-mode"
+    fidelity = build_loopx_turn_benchmark_fidelity_check(treatment)
+    assert fidelity["turn_treatment_fidelity_allowed"] is False, fidelity
+    assert "canonical_turn_route" in fidelity["missing_evidence"], fidelity
+
+
+def test_missing_validator_or_duplicate_spend_is_not_countable() -> None:
+    treatment = _treatment()
+    executions = treatment["loopx_turn_executions"]
+    assert isinstance(executions, list)
+    execution = executions[0]
+    assert isinstance(execution, dict)
+    execution["validation"] = {"status": "failed"}
+    execution["quota_slot_spend_count"] = 2
+    executions.append("invalid-turn-entry")
+    fidelity = build_loopx_turn_benchmark_fidelity_check(treatment)
+    assert fidelity["turn_treatment_fidelity_allowed"] is False, fidelity
+    assert "turn_execution_items_valid" in fidelity["missing_evidence"]
+    assert "independent_turn_validation_passed" in fidelity["missing_evidence"]
+    assert "exactly_one_quota_spend_per_turn" in fidelity["missing_evidence"]
+
+
+def test_setup_or_parity_mismatch_blocks_effect_analysis() -> None:
+    treatment = _treatment()
+    treatment["case_id"] = "different-case"
+    treatment["loopx_runner_source_fingerprint"] = {
+        "fingerprint": "sha256:different-runner"
+    }
+    treatment["official_score_attempt_countable"] = False
+    pair = build_loopx_turn_goal_matched_pair_check(
+        baseline_run=_baseline(),
+        treatment_run=treatment,
+    )
+    assert pair["matched_pair_countable"] is False, pair
+    assert "treatment_not_official_countable" in pair["blockers"], pair
+    assert "case_id_mismatch_or_missing" in pair["blockers"], pair
+    assert "runner_source_fingerprint_mismatch_or_missing" in pair["blockers"], pair
+    assert pair["official_scores"]["delta"] is None, pair
+
+
+def test_oracle_or_raw_evidence_leak_blocks_turn_fidelity() -> None:
+    treatment = copy.deepcopy(_treatment())
+    treatment["reward_feedback_forwarded"] = True
+    boundary = treatment["public_boundary"]
+    assert isinstance(boundary, dict)
+    boundary["raw_host_output_recorded"] = True
+    fidelity = build_loopx_turn_benchmark_fidelity_check(treatment)
+    assert fidelity["turn_treatment_fidelity_allowed"] is False, fidelity
+    assert "official_feedback_blinded" in fidelity["missing_evidence"], fidelity
+    assert "raw_host_output_absent" in fidelity["safety_failures"], fidelity
+
+
+def test_public_ledger_old_treatments_do_not_impersonate_turn() -> None:
+    ledger_path = (
+        REPO_ROOT
+        / "docs"
+        / "research"
+        / "long-horizon-agent-benchmarks"
+        / "benchmark-run-ledger.json"
+    )
+    ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
+    old_routes = {
+        "loopx-product-mode",
+        "loopx-goal-start-product-mode",
+        "loopx-blind-loop-treatment",
+        "loopx-prompt-polling-test",
+    }
+    old_treatments: list[dict[str, object]] = []
+    for benchmark in ledger.get("benchmarks", {}).values():
+        for case in benchmark.get("cases", {}).values():
+            for run in case.get("runs", []):
+                route = str(run.get("route") or "")
+                arm = str(run.get("arm_id") or "")
+                if route in old_routes or "loopx" in arm.lower():
+                    old_treatments.append(run)
+
+    assert old_treatments, "public ledger should retain historical LoopX controls"
+    for run in old_treatments:
+        fidelity = build_loopx_turn_benchmark_fidelity_check(run)
+        assert fidelity["turn_treatment_fidelity_allowed"] is False, fidelity
+        assert "canonical_turn_route" in fidelity["missing_evidence"], fidelity
+
+
+def main() -> int:
+    test_real_turn_pair_is_countable_without_claiming_advantage()
+    test_old_product_mode_cannot_impersonate_turn()
+    test_missing_validator_or_duplicate_spend_is_not_countable()
+    test_setup_or_parity_mismatch_blocks_effect_analysis()
+    test_oracle_or_raw_evidence_leak_blocks_turn_fidelity()
+    test_public_ledger_old_treatments_do_not_impersonate_turn()
+    print("benchmark LoopX Turn fidelity smoke: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/benchmark_core/__init__.py
+++ b/loopx/benchmark_core/__init__.py
@@ -119,6 +119,12 @@ from .split_control import (
     build_split_control_remote_executor_readiness,
     build_split_control_remote_executor_runner_batch,
 )
+from .turn_fidelity import (
+    LOOPX_TURN_BENCHMARK_FIDELITY_SCHEMA_VERSION,
+    LOOPX_TURN_MATCHED_PAIR_SCHEMA_VERSION,
+    build_loopx_turn_benchmark_fidelity_check,
+    build_loopx_turn_goal_matched_pair_check,
+)
 
 __all__ = [
     "AdapterClassification",
@@ -156,6 +162,8 @@ __all__ = [
     "build_blind_loop_initial_prompt",
     "build_product_mode_main_table_comparison_contract",
     "build_codex_app_parity_posthoc_check",
+    "build_loopx_turn_benchmark_fidelity_check",
+    "build_loopx_turn_goal_matched_pair_check",
     "build_run_permission_policy",
     "build_benchmark_route_profile",
     "build_split_control_remote_executor_execution_seam",
@@ -177,6 +185,8 @@ __all__ = [
     "DEFAULT_SPLIT_CONTROL_BENCHMARK_IDS",
     "LEGACY_NONPRODUCT_PROMPT_POLLING_ROUTES",
     "LOOPX_PACKET_ONLY_OBSERVATION_ROUTE",
+    "LOOPX_TURN_BENCHMARK_FIDELITY_SCHEMA_VERSION",
+    "LOOPX_TURN_MATCHED_PAIR_SCHEMA_VERSION",
     "IngestResult",
     "filter_public_benchmark_artifact_paths",
     "materialize_public_benchmark_artifacts",

--- a/loopx/benchmark_core/turn_fidelity.py
+++ b/loopx/benchmark_core/turn_fidelity.py
@@ -1,0 +1,325 @@
+"""Compact fidelity gates for SkillsBench Goal versus LoopX Turn pairs."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Callable, Mapping
+from typing import Any
+
+
+LOOPX_TURN_BENCHMARK_FIDELITY_SCHEMA_VERSION = (
+    "skillsbench_loopx_turn_benchmark_fidelity_v0"
+)
+LOOPX_TURN_MATCHED_PAIR_SCHEMA_VERSION = (
+    "skillsbench_loopx_turn_goal_matched_pair_v0"
+)
+LOOPX_TURN_AGENT_CLI_ROUTE = "loopx-turn-agent-cli"
+CODEX_CLI_GOAL_BASELINE_ROUTE = "codex-cli-goal-baseline"
+COUNTABLE_ATTEMPT_FIELDS = (
+    "launcher_attempt_countable",
+    "case_attempt_countable",
+    "solver_attempt_countable",
+    "verifier_attempt_countable",
+    "official_score_attempt_countable",
+)
+
+
+def _safe_label(value: object, *, limit: int = 120) -> str:
+    text = str(value or "").strip()
+    text = re.sub(r"[^A-Za-z0-9@._:/+= -]+", "_", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text[:limit]
+
+
+def _as_mapping(value: object) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _positive_int(value: object) -> int:
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        return value
+    return 0
+
+
+def _finite_score(value: object) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(float(value))
+    )
+
+
+def _public_fingerprint(run: Mapping[str, Any]) -> str:
+    fingerprint = _as_mapping(run.get("loopx_runner_source_fingerprint"))
+    for value in (
+        fingerprint.get("fingerprint"),
+        fingerprint.get("source_fingerprint"),
+        run.get("runner_source_fingerprint"),
+    ):
+        label = _safe_label(value, limit=160)
+        if label:
+            return label
+    return ""
+
+
+def _reasoning_effort(run: Mapping[str, Any]) -> str:
+    config = _as_mapping(run.get("loopx_runner_config"))
+    return _safe_label(
+        run.get("reasoning_effort") or config.get("reasoning_effort"),
+        limit=40,
+    )
+
+
+def _round_budget(run: Mapping[str, Any]) -> int:
+    contract = _as_mapping(run.get("benchmark_loop_contract"))
+    for value in (run.get("max_rounds_budget"), contract.get("max_rounds_budget")):
+        parsed = _positive_int(value)
+        if parsed:
+            return parsed
+    return 0
+
+
+def _attempts_countable(run: Mapping[str, Any]) -> tuple[bool, list[str]]:
+    missing = [field for field in COUNTABLE_ATTEMPT_FIELDS if run.get(field) is not True]
+    if not _finite_score(run.get("official_score")):
+        missing.append("official_score")
+    return not missing, missing
+
+
+def _safe_boundary(run: Mapping[str, Any]) -> dict[str, bool]:
+    boundary = _as_mapping(run.get("public_boundary"))
+    interaction = _as_mapping(run.get("interaction_counters"))
+    return {
+        "raw_task_text_absent": boundary.get("raw_task_text_recorded") is False
+        and interaction.get("raw_task_text_recorded") is not True,
+        "raw_verifier_output_absent": boundary.get("raw_verifier_output_recorded")
+        is False
+        and interaction.get("raw_verifier_output_recorded") is not True,
+        "raw_agent_trajectory_absent": boundary.get("raw_agent_trajectory_recorded")
+        is False
+        and interaction.get("raw_agent_trajectory_recorded") is not True,
+        "raw_host_output_absent": boundary.get("raw_host_output_recorded") is False,
+        "credentials_absent": boundary.get("credentials_recorded") is False,
+        "local_paths_absent": boundary.get("local_paths_recorded") is False,
+    }
+
+
+def _turn_executions(
+    run: Mapping[str, Any],
+) -> tuple[list[Mapping[str, Any]], bool]:
+    executions = run.get("loopx_turn_executions")
+    if isinstance(executions, list):
+        valid = bool(executions) and all(
+            isinstance(item, Mapping) for item in executions
+        )
+        return [item for item in executions if isinstance(item, Mapping)], valid
+    execution = run.get("loopx_turn_execution")
+    if isinstance(execution, Mapping):
+        return [execution], True
+    return [], False
+
+
+def build_loopx_turn_benchmark_fidelity_check(
+    benchmark_run: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Require real Turn transaction evidence before treating a run as Turn."""
+
+    route = _safe_label(benchmark_run.get("route"), limit=120)
+    executions, execution_items_valid = _turn_executions(benchmark_run)
+
+    def all_turns(predicate: Callable[[Mapping[str, Any]], bool]) -> bool:
+        return bool(executions) and all(predicate(execution) for execution in executions)
+
+    scored_validation = _as_mapping(
+        benchmark_run.get("scored_workspace_validation")
+    )
+    safety_checks = _safe_boundary(benchmark_run)
+    evidence_checks = {
+        "canonical_turn_route": route == LOOPX_TURN_AGENT_CLI_ROUTE,
+        "one_or_more_turns": bool(executions),
+        "turn_execution_items_valid": execution_items_valid,
+        "turn_execution_schema": all_turns(
+            lambda execution: execution.get("schema_version")
+            == "loopx_turn_execution_v0"
+        ),
+        "run_once_committed": all_turns(
+            lambda execution: execution.get("mode") == "run_once"
+            and execution.get("status") == "committed"
+        ),
+        "validated_material_result": all_turns(
+            lambda execution: execution.get("result_kind")
+            in {"validated_progress", "validated_completion"}
+        ),
+        "independent_turn_validation_passed": all_turns(
+            lambda execution: _as_mapping(execution.get("validation")).get("status")
+            == "passed"
+        ),
+        "turn_receipt_committed": all_turns(
+            lambda execution: _as_mapping(execution.get("receipt")).get("status")
+            == "committed"
+        ),
+        "agent_cli_host_observed": all_turns(
+            lambda execution: _as_mapping(execution.get("host")).get("kind")
+            in {"codex-cli", "generic-cli"}
+        ),
+        "isolated_headless_execution": all_turns(
+            lambda execution: execution.get("execution_mode")
+            == "isolated-headless"
+        ),
+        "host_invoked": all_turns(
+            lambda execution: _as_mapping(execution.get("effects")).get(
+                "host_invoked"
+            )
+            is True
+        ),
+        "durable_state_written": all_turns(
+            lambda execution: _as_mapping(execution.get("effects")).get(
+                "state_written"
+            )
+            is True
+        ),
+        "exactly_one_quota_spend_per_turn": all_turns(
+            lambda execution: _as_mapping(execution.get("effects")).get(
+                "quota_spent"
+            )
+            is True
+            and _positive_int(execution.get("quota_slot_spend_count")) == 1
+        ),
+        "scored_workspace_validation_passed": (
+            scored_validation.get("status") == "passed"
+            and scored_validation.get("independent") is True
+            and scored_validation.get("oracle_feedback_used") is False
+        ),
+        "scored_workspace_bridge_observed": (
+            _positive_int(scored_validation.get("meaningful_operation_count")) > 0
+        ),
+        "official_feedback_blinded": (
+            benchmark_run.get("official_feedback_blinded") is True
+            and benchmark_run.get("reward_feedback_forwarded") is False
+        ),
+    }
+    missing_evidence = [key for key, value in evidence_checks.items() if not value]
+    safety_failures = [key for key, value in safety_checks.items() if not value]
+    fidelity_allowed = not missing_evidence and not safety_failures
+    return {
+        "schema_version": LOOPX_TURN_BENCHMARK_FIDELITY_SCHEMA_VERSION,
+        "benchmark_id": _safe_label(benchmark_run.get("benchmark_id"), limit=80),
+        "case_id": _safe_label(benchmark_run.get("case_id"), limit=120),
+        "route": route,
+        "turn_count": len(executions),
+        "turn_treatment_fidelity_allowed": fidelity_allowed,
+        "claim_level": (
+            "real_loopx_turn_treatment"
+            if fidelity_allowed
+            else "not_countable_as_loopx_turn_treatment"
+        ),
+        "evidence_checks": evidence_checks,
+        "safety_checks": safety_checks,
+        "missing_evidence": missing_evidence,
+        "safety_failures": safety_failures,
+        "read_boundary": {
+            "compact_benchmark_run_only": True,
+            "raw_task_text_read": False,
+            "raw_logs_read": False,
+            "raw_trajectory_read": False,
+            "verifier_output_read": False,
+            "credentials_read": False,
+        },
+    }
+
+
+def build_loopx_turn_goal_matched_pair_check(
+    *,
+    baseline_run: Mapping[str, Any],
+    treatment_run: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Gate effect analysis on a matched, official, countable Goal/Turn pair."""
+
+    blockers: list[str] = []
+    baseline_route = _safe_label(baseline_run.get("route"), limit=120)
+    if baseline_route != CODEX_CLI_GOAL_BASELINE_ROUTE:
+        blockers.append("baseline_not_codex_cli_goal")
+
+    baseline_countable, baseline_missing = _attempts_countable(baseline_run)
+    treatment_countable, treatment_missing = _attempts_countable(treatment_run)
+    if not baseline_countable:
+        blockers.append("baseline_not_official_countable")
+    if not treatment_countable:
+        blockers.append("treatment_not_official_countable")
+
+    fidelity = build_loopx_turn_benchmark_fidelity_check(treatment_run)
+    if fidelity.get("turn_treatment_fidelity_allowed") is not True:
+        blockers.append("treatment_not_real_loopx_turn")
+
+    parity_fields = {
+        "benchmark_id": (
+            _safe_label(baseline_run.get("benchmark_id"), limit=80),
+            _safe_label(treatment_run.get("benchmark_id"), limit=80),
+        ),
+        "case_id": (
+            _safe_label(baseline_run.get("case_id"), limit=120),
+            _safe_label(treatment_run.get("case_id"), limit=120),
+        ),
+        "agent_model": (
+            _safe_label(baseline_run.get("agent_model"), limit=80),
+            _safe_label(treatment_run.get("agent_model"), limit=80),
+        ),
+        "reasoning_effort": (
+            _reasoning_effort(baseline_run),
+            _reasoning_effort(treatment_run),
+        ),
+        "max_rounds_budget": (
+            _round_budget(baseline_run),
+            _round_budget(treatment_run),
+        ),
+        "runner_source_fingerprint": (
+            _public_fingerprint(baseline_run),
+            _public_fingerprint(treatment_run),
+        ),
+    }
+    parity_checks: dict[str, bool] = {}
+    for field, values in parity_fields.items():
+        left, right = values
+        matched = bool(left) and left == right
+        parity_checks[field] = matched
+        if not matched:
+            blockers.append(f"{field}_mismatch_or_missing")
+
+    if baseline_run.get("official_feedback_blinded") is not True:
+        blockers.append("baseline_official_feedback_not_blinded")
+    if baseline_run.get("reward_feedback_forwarded") is not False:
+        blockers.append("baseline_reward_feedback_forwarding_not_disabled")
+
+    comparison_allowed = not blockers
+    baseline_score = baseline_run.get("official_score")
+    treatment_score = treatment_run.get("official_score")
+    return {
+        "schema_version": LOOPX_TURN_MATCHED_PAIR_SCHEMA_VERSION,
+        "matched_pair_countable": comparison_allowed,
+        "effect_analysis_allowed": comparison_allowed,
+        "advantage_claim_allowed": False,
+        "claim_policy": (
+            "analyze_compact_outcome_and_lifecycle_without_advantage_claim"
+            if comparison_allowed
+            else "repair_runner_setup_or_fidelity_before_comparison"
+        ),
+        "blockers": blockers,
+        "attempt_accounting": {
+            "baseline_countable": baseline_countable,
+            "baseline_missing": baseline_missing,
+            "treatment_countable": treatment_countable,
+            "treatment_missing": treatment_missing,
+        },
+        "parity_checks": parity_checks,
+        "treatment_fidelity": fidelity,
+        "official_scores": {
+            "baseline": baseline_score if _finite_score(baseline_score) else None,
+            "treatment": treatment_score if _finite_score(treatment_score) else None,
+            "delta": (
+                float(treatment_score) - float(baseline_score)
+                if comparison_allowed
+                else None
+            ),
+        },
+    }


### PR DESCRIPTION
## Summary

- add a compact benchmark fidelity gate that only recognizes committed `loopx turn run-once` transactions with independent scored-workspace validation
- require blinded official feedback, public-safe evidence boundaries, durable writeback, and exactly one quota spend per Turn
- gate Goal/Turn effect analysis on a canonical Codex CLI Goal baseline, official countability, matched case/model/config/fingerprint, and real Turn treatment evidence
- replay the public benchmark ledger so historical LoopX product-mode and polling controls cannot be relabeled as Turn

This PR defines a reusable benchmark seam and does not launch jobs, change benchmark scoring or task semantics, or modify an existing runner. The executable SkillsBench relay remains follow-up work.

## Validation

- `python examples/benchmark-loopx-turn-fidelity-smoke.py`
- `python examples/benchmark-codex-app-parity-posthoc-smoke.py`
- focused Turn and benchmark pytest suite: 58 passed
  - one pre-existing 0.1-second timeout test was flaky on the first full run (57 passed, 1 failed); the isolated rerun and subsequent full rerun passed
- `ruff check` on changed Python surfaces
- Python compile checks and `git diff --check`
- `loopx canary premerge --from-git-diff --tier standard`: all selected checks and public-boundary scans passed; the expected benchmark-sensitive manual hold remains for maintainer judgment

## Boundary

No raw task text, trajectories, logs, verifier output, credentials, local paths, generated artifacts, or private state are included.