### PR TITLE
fix(lark): route verified replies to the configured bot

### DIFF
--- a/docs/capabilities/lark-event-inbox.md
+++ b/docs/capabilities/lark-event-inbox.md
@@ -16,21 +16,26 @@ Lark event stream
 The collector is host infrastructure. LoopX can validate a local-private
 collector config, preview or explicitly install a macOS `launchd` / Linux
 `systemd` user service, and report supervisor plus event-bus health. The
-installed service runs `lark-cli --profile <configured-profile> event consume`
-directly with a bounded timeout,
+installed service runs a small LoopX collector runtime around
+`lark-cli --profile <configured-profile> event consume` with a bounded timeout,
 so stdin EOF under a supervisor cannot terminate an otherwise unbounded
 consumer. When the official npm package exposes a Node wrapper, LoopX records
 absolute paths for both Node and the wrapper so launchd does not depend on an
-interactive-shell PATH. It filters before persistence and writes one compact event per Lark
-`event_id`/`message_id`. The agent does not need to keep a websocket open.
+interactive-shell PATH. It filters before persistence and writes one compact
+event per Lark `event_id`/`message_id`. Direct mentions are persisted
+immediately. For a message without a direct mention, the runtime reads back the
+current message and its direct parent, then marks it actionable only when the
+parent sender is the app id of the configured profile. A reply to a person,
+another app, or an unverifiable parent remains captured but does not wake the
+agent. The agent does not need to keep a websocket open.
 
 Use `addressed_only` only when direct bot mentions are the entire feedback
-contract. Lark's real-time `im.message.receive_v1` projection does not expose a
-thread id, so it cannot recognize later replies in a bot-started thread. A
-review or collaboration inbox that must learn from the whole discussion should
-use `configured_chat_all`: the host collector filters by its local-private chat
-id, persists every message from that chat, and lets the domain binding group or
-ignore messages during durable writeback.
+contract. A review or collaboration inbox that accepts non-mention replies to
+bot messages should use `configured_chat_all`: the host collector filters by
+its local-private chat id, persists every message from that chat, and verifies
+the reply relation through message readback before scheduling a reply. Full-chat
+capture is not full-chat activation; unrelated conversation remains available
+to domain interpretation without being treated as addressed to the bot.
 
 ## Local-private configuration
 
@@ -114,10 +119,11 @@ output never returns the chat id, local paths, generated jq, or credentials.
 An enabled collector must bind an explicit non-default Lark CLI profile. When
 `profile` is omitted, LoopX may reuse the enabled inbox reply
 `sender_profile`; when both are present they must match. The generated service
-places `--profile` before `event consume`, so collection and optional replies
-cannot silently use different app identities. Public plan/status packets expose
-only whether a profile is bound and where the binding came from, never its
-value.
+passes the profile-bound collector config to the LoopX runtime, which places
+`--profile` before both `event consume` and message readback calls. Collection,
+reply-target verification, and optional replies therefore cannot silently use
+different app identities. Public plan/status packets expose only whether a
+profile is bound and where the binding came from, never its value.
 
 ```bash
 loopx lark-inbox collector-plan \
@@ -142,8 +148,10 @@ loopx lark-inbox collector-status \
   --probe-event-bus
 ```
 
-Missing `lark-cli` produces a non-blocking install hint. Missing scopes or bot
-configuration still belong to `lark-cli`; LoopX does not authenticate a bot,
+Missing `lark-cli` produces a non-blocking install hint. Reply-target
+verification also requires the configured bot to read messages in the selected
+chat. Missing scopes or bot configuration still belong to `lark-cli`; LoopX
+does not authenticate a bot,
 copy app credentials, or silently install packages. Service installation is a
 local host write and therefore requires explicit `--execute`. Status separates
 `healthy` from `real_event_evidence_present`: a running subscriber can be
@@ -167,10 +175,12 @@ loopx configure-goal \
 The configuration catalog exposes this optional capability on demand. Quota
 projects `enabled`, `config_pointer_registered`, a public-safe command, and a
 content-free urgency summary; it never projects the private path, message ids,
-senders, or message bodies. The summary includes pending/direct-question/direct-
-mention counts and the oldest pending age. A configured direct reply becomes a
-high-priority `lark_event_inbox` work lane before ordinary monitor or advancement
-work. Generated heartbeat bodies run the actual goal-boundary `drain_command`;
+senders, or message bodies. The summary includes
+pending/direct-question/direct-mention/verified-bot-reply counts and the oldest
+pending age. A configured direct mention or verified reply to a message authored
+by the configured bot becomes a high-priority `lark_event_inbox` work lane
+before ordinary monitor or advancement work. Generated heartbeat bodies run the
+actual goal-boundary `drain_command`;
 `loopx lark-inbox drain --goal-id <goal-id> --project .`
 resolves the ignored config from the goal registry. A disabled or empty inbox
 is a quiet zero-spend path, so projects without Lark keep the default behavior.
@@ -193,14 +203,16 @@ Drain is read-only and returns bounded local-private message content. A message
 must be acknowledged only after its effect is written back. Duplicate event
 files collapse by `message_id`; repeated acknowledgement is idempotent.
 
-Urgency classification stays local: explicit configured bot-name/LoopX mentions
-and bounded question signals produce counts only. The agent still drains and
-interprets the source event before deciding the durable effect or reply; the
+Urgency classification stays local: explicit `@` mentions of the configured
+bot/LoopX, bounded question signals on addressed events, and provider-verified
+direct replies to the configured bot produce counts only. A question elsewhere in the
+group or a reply to a human does not become `reply_due`. The agent still drains
+and interprets the source event before deciding the durable effect or reply; the
 summary is a scheduling signal, not semantic authority.
 
-For a direct question or explicit bot mention, write the requested durable
-effect first, preview one concise source-thread reply, execute it, require
-readback, and only then ACK:
+For a direct question, explicit bot mention, or verified reply to the configured
+bot, write the requested durable effect first, preview one concise source-thread
+reply, execute it, require readback, and only then ACK:
 
 ```bash
 loopx lark-inbox reply \

--- a/examples/control_plane/lark-inbox-priority-smoke.py
+++ b/examples/control_plane/lark-inbox-priority-smoke.py
@@ -121,6 +121,7 @@ def main() -> None:
         assert lane["obligation"] == "drain_lark_inbox_reply_due", lane
         assert lane["priority_preemption"] is True, lane
         assert lane["direct_question_count"] == 1, lane
+        assert lane["reply_to_bot_count"] == 0, lane
         assert lane["pending_count"] == 1, lane
         assert decision["execution_obligation"]["contract_obligation"] == lane["obligation"]
         assert "durable effect" in decision["recommended_action"], decision
@@ -131,11 +132,42 @@ def main() -> None:
         markdown = render_quota_should_run_markdown(decision)
         assert "lane=lark_event_inbox" in markdown, markdown
         assert "questions=1" in markdown, markdown
+        assert "bot_replies=0" in markdown, markdown
 
         acknowledge_lark_event_inbox(
             project=project,
             config_path=config,
             message_ids=["om_direct_question"],
+            execute=True,
+        )
+        (inbox / "om_verified_bot_reply.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "lark_event_inbox_event_v0",
+                    "event_id": "evt-verified-bot-reply",
+                    "message_id": "om_verified_bot_reply",
+                    "parent_id": "om_bot_parent",
+                    "create_time": "2026-07-15T00:01:00Z",
+                    "content": "不带 at 的直接回复",
+                    "reply_context_verified": True,
+                    "reply_to_bot": True,
+                }
+            ),
+            encoding="utf-8",
+        )
+        reply_decision = build_quota_should_run(
+            status_payload(project), goal_id=GOAL_ID
+        )
+        reply_lane = reply_decision["work_lane_contract"]
+        assert reply_decision["effective_action"] == "lark_inbox_reply_due", (
+            reply_decision
+        )
+        assert reply_lane["reply_to_bot_count"] == 1, reply_lane
+        assert reply_lane["direct_question_count"] == 0, reply_lane
+        acknowledge_lark_event_inbox(
+            project=project,
+            config_path=config,
+            message_ids=["om_verified_bot_reply"],
             execute=True,
         )
         after_ack = build_quota_should_run(status_payload(project), goal_id=GOAL_ID)

--- a/examples/lark-event-collector-lifecycle-smoke.py
+++ b/examples/lark-event-collector-lifecycle-smoke.py
@@ -18,6 +18,14 @@ from loopx.capabilities.lark.event_collector import (  # noqa: E402
     install_lark_event_collector,
     plan_lark_event_collector,
 )
+from loopx.capabilities.lark.event_collector_runtime import (  # noqa: E402
+    enrich_lark_event_reply_context,
+    lark_event_requires_reply_context_lookup,
+    run_lark_event_collector,
+)
+from loopx.capabilities.lark.event_inbox import (  # noqa: E402
+    project_lark_event_inbox_urgency,
+)
 
 
 def completed(argv: list[str], returncode: int = 0) -> subprocess.CompletedProcess[str]:
@@ -130,14 +138,92 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-collector-") as raw:
         assert str(node) in plist_text, plist_text
         assert str(lark_cli) in plist_text, plist_text
         service_argv = plistlib.loads(plist.read_bytes())["ProgramArguments"]
-        assert service_argv[:6] == [
-            str(node),
-            str(lark_cli),
-            "--profile",
-            "project-review-bot",
-            "event",
-            "consume",
-        ], service_argv
+        assert Path(service_argv[0]).name == "loopx", service_argv
+        assert service_argv[1:3] == ["lark-inbox", "collector-run"], service_argv
+        assert service_argv[service_argv.index("--lark-cli-executable") + 1] == str(
+            lark_cli
+        ), service_argv
+        assert service_argv[service_argv.index("--node-executable") + 1] == str(
+            node
+        ), service_argv
+        assert "event" not in service_argv and "consume" not in service_argv, service_argv
+
+        direct_event = {
+            "message_id": "om_direct_fixture",
+            "content": "@Project Review Bot 请处理这个问题",
+        }
+        assert not lark_event_requires_reply_context_lookup(
+            direct_event,
+            bot_display_name="Project Review Bot",
+        )
+        assert lark_event_requires_reply_context_lookup(
+            {"message_id": "om_plain_fixture", "content": "普通群聊消息"},
+            bot_display_name="Project Review Bot",
+        )
+
+        messages = {
+            "om_reply_fixture": {
+                "message_id": "om_reply_fixture",
+                "parent_id": "om_bot_parent",
+                "root_id": "om_bot_parent",
+                "chat_id": "oc_private_fixture_chat",
+                "sender": {"sender_type": "user", "id": "ou_fixture_user"},
+            },
+            "om_bot_parent": {
+                "message_id": "om_bot_parent",
+                "chat_id": "oc_private_fixture_chat",
+                "sender": {"sender_type": "app", "id": "cli_fixture_app"},
+            },
+            "om_human_reply": {
+                "message_id": "om_human_reply",
+                "parent_id": "om_human_parent",
+                "chat_id": "oc_private_fixture_chat",
+                "sender": {"sender_type": "user", "id": "ou_fixture_user"},
+            },
+            "om_human_parent": {
+                "message_id": "om_human_parent",
+                "chat_id": "oc_private_fixture_chat",
+                "sender": {"sender_type": "user", "id": "ou_fixture_other"},
+            },
+        }
+        lookup_calls: list[list[str]] = []
+
+        def lookup_runner(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+            lookup_calls.append(list(argv))
+            message_id = argv[argv.index("--message-ids") + 1]
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                stdout=json.dumps({"items": [messages[message_id]]}),
+                stderr="",
+            )
+
+        bot_reply = enrich_lark_event_reply_context(
+            {"message_id": "om_reply_fixture", "content": "继续"},
+            runner=lookup_runner,
+            command_prefix=["lark-cli"],
+            profile="project-review-bot",
+            profile_app_id="cli_fixture_app",
+            configured_chat_id="oc_private_fixture_chat",
+            sleeper=lambda _: None,
+        )
+        assert bot_reply["reply_context_verified"] is True, bot_reply
+        assert bot_reply["reply_to_bot"] is True, bot_reply
+        human_reply = enrich_lark_event_reply_context(
+            {"message_id": "om_human_reply", "content": "继续"},
+            runner=lookup_runner,
+            command_prefix=["lark-cli"],
+            profile="project-review-bot",
+            profile_app_id="cli_fixture_app",
+            configured_chat_id="oc_private_fixture_chat",
+            sleeper=lambda _: None,
+        )
+        assert human_reply["reply_context_verified"] is True, human_reply
+        assert human_reply["reply_to_bot"] is False, human_reply
+        assert all(
+            call[:3] == ["lark-cli", "--profile", "project-review-bot"]
+            for call in lookup_calls
+        ), lookup_calls
 
         inbox = project / ".loopx" / "inbox" / "team-feedback"
         inbox.mkdir(parents=True)
@@ -168,6 +254,85 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-collector-") as raw:
         assert "project-review-bot" not in json.dumps(status), status
         assert status["local_paths_returned"] is False, status
         assert status["chat_id_returned"] is False, status
+
+        runtime_cli = bin_dir / "runtime-lark-cli"
+        runtime_cli.write_text(
+            """#!/usr/bin/env python3
+import json
+import sys
+
+args = sys.argv[1:]
+messages = {
+    "om_runtime_ordinary": {
+        "message_id": "om_runtime_ordinary",
+        "chat_id": "oc_private_fixture_chat",
+        "sender": {"sender_type": "user", "id": "ou_fixture_user"},
+    },
+    "om_runtime_reply": {
+        "message_id": "om_runtime_reply",
+        "parent_id": "om_runtime_bot_parent",
+        "chat_id": "oc_private_fixture_chat",
+        "sender": {"sender_type": "user", "id": "ou_fixture_user"},
+    },
+    "om_runtime_bot_parent": {
+        "message_id": "om_runtime_bot_parent",
+        "chat_id": "oc_private_fixture_chat",
+        "sender": {"sender_type": "app", "id": "cli_fixture_app"},
+    },
+}
+if "event" in args and "consume" in args:
+    events = [
+        {
+            "schema_version": "lark_event_inbox_event_v0",
+            "event_id": "evt-runtime-direct",
+            "message_id": "om_runtime_direct",
+            "create_time": "2026-07-16T00:00:00Z",
+            "content": "@Project Review Bot 能处理吗？",
+        },
+        {
+            "schema_version": "lark_event_inbox_event_v0",
+            "event_id": "evt-runtime-ordinary",
+            "message_id": "om_runtime_ordinary",
+            "create_time": "2026-07-16T00:01:00Z",
+            "content": "Project Review Bot 群里的普通问题为什么会这样？",
+        },
+        {
+            "schema_version": "lark_event_inbox_event_v0",
+            "event_id": "evt-runtime-reply",
+            "message_id": "om_runtime_reply",
+            "create_time": "2026-07-16T00:02:00Z",
+            "content": "这是不带 at 的回复",
+        },
+    ]
+    for event in events:
+        print(json.dumps(event), flush=True)
+elif "whoami" in args:
+    print(json.dumps({"appId": "cli_fixture_app"}))
+elif "+messages-mget" in args:
+    message_id = args[args.index("--message-ids") + 1]
+    print(json.dumps({"items": [messages[message_id]]}))
+else:
+    raise SystemExit(2)
+""",
+            encoding="utf-8",
+        )
+        runtime_cli.chmod(0o755)
+        runtime_result = run_lark_event_collector(
+            project=project,
+            config_path=collector_config,
+            lark_cli_executable=str(runtime_cli),
+        )
+        assert runtime_result["ok"] is True, runtime_result
+        assert runtime_result["captured_count"] == 3, runtime_result
+        assert runtime_result["reply_context_verified_count"] == 2, runtime_result
+        assert runtime_result["reply_to_bot_count"] == 1, runtime_result
+        runtime_urgency = project_lark_event_inbox_urgency(
+            project=project,
+            config_path=inbox_config,
+        )
+        assert runtime_urgency["direct_question_count"] == 1, runtime_urgency
+        assert runtime_urgency["reply_to_bot_count"] == 1, runtime_urgency
+        assert runtime_urgency["attention_required_count"] == 2, runtime_urgency
 
         unsupported = json.loads(collector_config.read_text())
         unsupported["event_key"] = "im.message.reaction.created_v1"

--- a/examples/lark-event-inbox-smoke.py
+++ b/examples/lark-event-inbox-smoke.py
@@ -175,7 +175,27 @@ def main() -> None:
                 "event_id": "evt-ordinary-chat",
                 "message_id": "om_ordinary_chat",
                 "create_time": "2026-07-12T10:03:00Z",
-                "content": "ordinary project discussion without a bot mention",
+                "content": "Project Review Bot 这个普通项目问题为什么会这样？",
+            },
+            {
+                "schema_version": "lark_event_inbox_event_v0",
+                "event_id": "evt-reply-to-bot",
+                "message_id": "om_reply_to_bot",
+                "parent_id": "om_bot_parent",
+                "create_time": "2026-07-12T10:04:00Z",
+                "content": "收到，继续按这个方向处理",
+                "reply_context_verified": True,
+                "reply_to_bot": True,
+            },
+            {
+                "schema_version": "lark_event_inbox_event_v0",
+                "event_id": "evt-reply-to-human",
+                "message_id": "om_reply_to_human",
+                "parent_id": "om_human_parent",
+                "create_time": "2026-07-12T10:05:00Z",
+                "content": "这是回复群成员，不是回复机器人",
+                "reply_context_verified": True,
+                "reply_to_bot": False,
             },
         ]
         ingest_lark_event_inbox(
@@ -189,10 +209,11 @@ def main() -> None:
             config_path=config,
             now=datetime(2026, 7, 12, 10, 12, tzinfo=timezone.utc),
         )
-        assert urgency["pending_count"] == 2, urgency
+        assert urgency["pending_count"] == 4, urgency
         assert urgency["direct_question_count"] == 1, urgency
         assert urgency["direct_mention_count"] == 0, urgency
-        assert urgency["attention_required_count"] == 1, urgency
+        assert urgency["reply_to_bot_count"] == 1, urgency
+        assert urgency["attention_required_count"] == 2, urgency
         assert urgency["reply_due"] is True, urgency
         assert urgency["oldest_pending_age_seconds"] == 600, urgency
         assert urgency["local_private_content_returned"] is False, urgency
@@ -200,7 +221,12 @@ def main() -> None:
         acknowledge_lark_event_inbox(
             project=project,
             config_path=config,
-            message_ids=["om_direct_question", "om_ordinary_chat"],
+            message_ids=[
+                "om_direct_question",
+                "om_ordinary_chat",
+                "om_reply_to_bot",
+                "om_reply_to_human",
+            ],
             execute=True,
         )
 

--- a/loopx/capabilities/lark/event_collector.py
+++ b/loopx/capabilities/lark/event_collector.py
@@ -189,25 +189,28 @@ def _executable_prefix(executable: str) -> list[str]:
 
 
 def _collector_argv(config: Mapping[str, Any], executable: str) -> list[str]:
-    inbox_path = Path(config["inbox"]["inbox_path"])
-    relative_inbox = inbox_path.relative_to(Path(config["project"]))
     prefix = _executable_prefix(executable)
-    if config.get("profile"):
-        prefix.extend(["--profile", str(config["profile"])])
-    return [
-        *prefix,
-        "event",
-        "consume",
-        str(config["event_key"]),
-        "--as",
-        str(config["identity"]),
-        "--timeout",
-        str(config["consume_timeout"]),
-        "--jq",
-        _jq_projection(str(config["chat_id"])),
-        "--output-dir",
-        relative_inbox.as_posix(),
+    repo_root = Path(__file__).resolve().parents[3]
+    discovered = shutil.which("loopx")
+    loopx_executable = (
+        Path(discovered) if discovered else repo_root / "scripts" / "loopx"
+    )
+    if not loopx_executable.is_file():
+        raise ValueError("loopx executable is unavailable for collector runtime")
+    argv = [
+        str(loopx_executable),
+        "lark-inbox",
+        "collector-run",
+        "--project",
+        str(config["project"]),
+        "--config",
+        str(config["config_path"]),
+        "--lark-cli-executable",
+        executable,
     ]
+    if len(prefix) == 2:
+        argv.extend(["--node-executable", prefix[0]])
+    return argv
 
 
 def _service_file(config: Mapping[str, Any]) -> Path:

--- a/loopx/capabilities/lark/event_collector_runtime.py
+++ b/loopx/capabilities/lark/event_collector_runtime.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import json
+import re
+import signal
+import subprocess
+import time
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from .event_collector import (
+    _executable_prefix,
+    _jq_projection,
+    load_lark_event_collector_config,
+)
+from .event_inbox import (
+    MESSAGE_ID_PATTERN,
+    _event_attention_kind,
+    ingest_lark_event_inbox,
+)
+
+
+APP_ID_PATTERN = re.compile(r"cli_[A-Za-z0-9_-]+")
+CommandRunner = Callable[..., subprocess.CompletedProcess[str]]
+Sleeper = Callable[[float], None]
+
+
+def _run_json(runner: CommandRunner, argv: Sequence[str]) -> object:
+    result = runner(
+        list(argv),
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        return {}
+    try:
+        return json.loads(result.stdout)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+
+
+def _find_string_by_key(value: object, keys: set[str]) -> str | None:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            if str(key) in keys and isinstance(child, str) and child.strip():
+                return child.strip()
+        for child in value.values():
+            if found := _find_string_by_key(child, keys):
+                return found
+    elif isinstance(value, list):
+        for child in value:
+            if found := _find_string_by_key(child, keys):
+                return found
+    return None
+
+
+def _profile_app_id(
+    *,
+    runner: CommandRunner,
+    command_prefix: Sequence[str],
+    profile: str,
+) -> str | None:
+    payload = _run_json(
+        runner,
+        [*command_prefix, "--profile", profile, "whoami", "--as", "bot"],
+    )
+    app_id = _find_string_by_key(payload, {"appId", "app_id"})
+    return app_id if app_id and APP_ID_PATTERN.fullmatch(app_id) else None
+
+
+def _find_message(value: object, message_id: str) -> Mapping[str, Any] | None:
+    if isinstance(value, Mapping):
+        if str(value.get("message_id") or "") == message_id:
+            return value
+        for child in value.values():
+            if found := _find_message(child, message_id):
+                return found
+    elif isinstance(value, list):
+        for child in value:
+            if found := _find_message(child, message_id):
+                return found
+    return None
+
+
+def _read_message(
+    *,
+    runner: CommandRunner,
+    command_prefix: Sequence[str],
+    profile: str,
+    message_id: str,
+    attempts: int,
+    sleeper: Sleeper,
+) -> Mapping[str, Any] | None:
+    for attempt in range(max(1, attempts)):
+        payload = _run_json(
+            runner,
+            [
+                *command_prefix,
+                "--profile",
+                profile,
+                "im",
+                "+messages-mget",
+                "--message-ids",
+                message_id,
+                "--as",
+                "bot",
+                "--no-reactions",
+                "--format",
+                "json",
+            ],
+        )
+        if message := _find_message(payload, message_id):
+            return message
+        if attempt + 1 < max(1, attempts):
+            sleeper(0.5 * (attempt + 1))
+    return None
+
+
+def _sender_identity(message: Mapping[str, Any]) -> tuple[str, str]:
+    sender = message.get("sender")
+    sender = sender if isinstance(sender, Mapping) else {}
+    sender_type = str(
+        sender.get("sender_type") or message.get("sender_type") or ""
+    ).strip()
+    sender_id = str(
+        sender.get("id")
+        or sender.get("sender_id")
+        or message.get("sender_id")
+        or ""
+    ).strip()
+    return sender_type, sender_id
+
+
+def enrich_lark_event_reply_context(
+    event: Mapping[str, Any],
+    *,
+    runner: CommandRunner,
+    command_prefix: Sequence[str],
+    profile: str,
+    profile_app_id: str,
+    configured_chat_id: str,
+    attempts: int = 3,
+    sleeper: Sleeper = time.sleep,
+) -> dict[str, Any]:
+    """Verify whether an event structurally replies to this profile's bot."""
+
+    enriched = dict(event)
+    enriched["reply_context_verified"] = False
+    enriched["reply_to_bot"] = False
+    message_id = str(event.get("message_id") or "").strip()
+    if not MESSAGE_ID_PATTERN.fullmatch(message_id):
+        return enriched
+    current = _read_message(
+        runner=runner,
+        command_prefix=command_prefix,
+        profile=profile,
+        message_id=message_id,
+        attempts=attempts,
+        sleeper=sleeper,
+    )
+    if current is None or str(current.get("chat_id") or "") != configured_chat_id:
+        return enriched
+
+    parent_id = str(current.get("parent_id") or "").strip()
+    root_id = str(current.get("root_id") or "").strip()
+    if MESSAGE_ID_PATTERN.fullmatch(root_id):
+        enriched["root_id"] = root_id
+    if not MESSAGE_ID_PATTERN.fullmatch(parent_id):
+        enriched["reply_context_verified"] = True
+        return enriched
+    enriched["parent_id"] = parent_id
+
+    parent = _read_message(
+        runner=runner,
+        command_prefix=command_prefix,
+        profile=profile,
+        message_id=parent_id,
+        attempts=attempts,
+        sleeper=sleeper,
+    )
+    if parent is None or str(parent.get("chat_id") or "") != configured_chat_id:
+        return enriched
+    current_sender_type, _ = _sender_identity(current)
+    parent_sender_type, parent_sender_id = _sender_identity(parent)
+    enriched["reply_context_verified"] = True
+    enriched["reply_to_bot"] = bool(
+        current_sender_type == "user"
+        and parent_sender_type == "app"
+        and parent_sender_id == profile_app_id
+    )
+    return enriched
+
+
+def _consume_argv(
+    config: Mapping[str, Any], command_prefix: Sequence[str]
+) -> list[str]:
+    return [
+        *command_prefix,
+        "--profile",
+        str(config["profile"]),
+        "event",
+        "consume",
+        str(config["event_key"]),
+        "--as",
+        str(config["identity"]),
+        "--timeout",
+        str(config["consume_timeout"]),
+        "--jq",
+        _jq_projection(str(config["chat_id"])),
+        "--quiet",
+    ]
+
+
+def lark_event_requires_reply_context_lookup(
+    event: Mapping[str, Any], *, bot_display_name: str
+) -> bool:
+    """Direct mentions are actionable without a provider readback."""
+
+    direct_attention = _event_attention_kind(
+        event,
+        bot_display_name=bot_display_name,
+        capture_scope="configured_chat_all",
+    )
+    return direct_attention not in {"direct_question", "direct_mention"}
+
+
+def run_lark_event_collector(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    lark_cli_executable: str,
+    node_executable: str | None = None,
+    runner: CommandRunner = subprocess.run,
+) -> dict[str, Any]:
+    config = load_lark_event_collector_config(
+        project=project,
+        config_path=config_path,
+    )
+    command_prefix = (
+        [node_executable, lark_cli_executable]
+        if node_executable
+        else _executable_prefix(lark_cli_executable)
+    )
+    process = subprocess.Popen(
+        _consume_argv(config, command_prefix),
+        stdout=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    previous_handlers: dict[signal.Signals, Any] = {}
+
+    def forward_signal(signum: int, _: object) -> None:
+        if process.poll() is None:
+            process.send_signal(signum)
+
+    for signum in (signal.SIGTERM, signal.SIGINT):
+        previous_handlers[signum] = signal.signal(signum, forward_signal)
+    captured_count = 0
+    verified_count = 0
+    reply_to_bot_count = 0
+    profile_app_id: str | None = None
+    profile_identity_checked = False
+    try:
+        assert process.stdout is not None
+        for line in process.stdout:
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(payload, Mapping):
+                continue
+            needs_reply_lookup = lark_event_requires_reply_context_lookup(
+                payload,
+                bot_display_name=str(
+                    config["inbox"]["reply"].get("bot_display_name") or ""
+                ),
+            )
+            if not needs_reply_lookup:
+                enriched = {
+                    **payload,
+                    "reply_context_verified": False,
+                    "reply_to_bot": False,
+                }
+            else:
+                if not profile_identity_checked:
+                    profile_app_id = _profile_app_id(
+                        runner=runner,
+                        command_prefix=command_prefix,
+                        profile=str(config["profile"]),
+                    )
+                    profile_identity_checked = True
+                enriched = (
+                    enrich_lark_event_reply_context(
+                        payload,
+                        runner=runner,
+                        command_prefix=command_prefix,
+                        profile=str(config["profile"]),
+                        profile_app_id=profile_app_id,
+                        configured_chat_id=str(config["chat_id"]),
+                    )
+                    if profile_app_id is not None
+                    else {
+                        **payload,
+                        "reply_context_verified": False,
+                        "reply_to_bot": False,
+                    }
+                )
+            result = ingest_lark_event_inbox(
+                project=config["project"],
+                config_path=config["event_inbox_config_ref"],
+                events=[{"schema_version": "lark_event_inbox_event_v0", **enriched}],
+                execute=True,
+            )
+            if int(result.get("accepted_count") or 0) == 0:
+                continue
+            captured_count += 1
+            verified_count += int(enriched.get("reply_context_verified") is True)
+            reply_to_bot_count += int(enriched.get("reply_to_bot") is True)
+        returncode = process.wait()
+    finally:
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)
+    return {
+        "ok": returncode == 0,
+        "schema_version": "lark_event_collector_run_v0",
+        "status": "completed" if returncode == 0 else "consumer_failed",
+        "captured_count": captured_count,
+        "reply_context_verified_count": verified_count,
+        "reply_to_bot_count": reply_to_bot_count,
+        "profile_identity_checked": profile_identity_checked,
+        "profile_identity_verified": profile_app_id is not None,
+        "private_content_returned": False,
+    }

--- a/loopx/capabilities/lark/event_inbox.py
+++ b/loopx/capabilities/lark/event_inbox.py
@@ -135,12 +135,26 @@ def _event_from_payload(payload: object) -> dict[str, Any] | None:
     content = " ".join(str(payload.get("content") or "").split())[:1200]
     if not content:
         return None
-    return {
+    event = {
         "event_id": event_id,
         "message_id": message_id,
         "create_time": str(payload.get("create_time") or "")[:40],
         "content": content,
     }
+    parent_id = str(payload.get("parent_id") or "").strip()
+    root_id = str(payload.get("root_id") or "").strip()
+    if MESSAGE_ID_PATTERN.fullmatch(parent_id):
+        event["parent_id"] = parent_id
+    if MESSAGE_ID_PATTERN.fullmatch(root_id):
+        event["root_id"] = root_id
+    reply_context_verified = payload.get("reply_context_verified") is True
+    event["reply_context_verified"] = reply_context_verified
+    event["reply_to_bot"] = bool(
+        reply_context_verified
+        and "parent_id" in event
+        and payload.get("reply_to_bot") is True
+    )
+    return event
 
 
 def _event_from_file(path: Path) -> dict[str, Any] | None:
@@ -199,9 +213,14 @@ def _event_attention_kind(
     content = " ".join(str(event.get("content") or "").split())
     if not content:
         return None
+    if (
+        event.get("reply_context_verified") is True
+        and event.get("reply_to_bot") is True
+    ):
+        return "reply_to_bot"
     folded = content.casefold()
     bot_name = " ".join(str(bot_display_name or "").split()).casefold()
-    explicit_bot_mention = bool(bot_name and bot_name in folded)
+    explicit_bot_mention = bool(bot_name and "@" in content and bot_name in folded)
     generic_loopx_mention = "@" in content and "loopx" in folded
     addressed = bool(
         capture_scope == "addressed_only"
@@ -233,6 +252,7 @@ def project_lark_event_inbox_urgency(
             "pending_count": 0,
             "direct_question_count": 0,
             "direct_mention_count": 0,
+            "reply_to_bot_count": 0,
             "attention_required_count": 0,
             "reply_due": False,
             "local_private_content_returned": False,
@@ -248,7 +268,10 @@ def project_lark_event_inbox_urgency(
     ]
     direct_question_count = kinds.count("direct_question")
     direct_mention_count = kinds.count("direct_mention")
-    attention_required_count = direct_question_count + direct_mention_count
+    reply_to_bot_count = kinds.count("reply_to_bot")
+    attention_required_count = (
+        direct_question_count + direct_mention_count + reply_to_bot_count
+    )
     parsed_times = [
         parsed
         for event in pending
@@ -266,6 +289,7 @@ def project_lark_event_inbox_urgency(
         "pending_count": len(pending),
         "direct_question_count": direct_question_count,
         "direct_mention_count": direct_mention_count,
+        "reply_to_bot_count": reply_to_bot_count,
         "attention_required_count": attention_required_count,
         "oldest_pending_at": oldest.isoformat() if oldest else None,
         "oldest_pending_age_seconds": oldest_age_seconds,

--- a/loopx/cli_commands/lark_inbox.py
+++ b/loopx/cli_commands/lark_inbox.py
@@ -17,6 +17,7 @@ from ..capabilities.lark.event_collector import (
     install_lark_event_collector,
     plan_lark_event_collector,
 )
+from ..capabilities.lark.event_collector_runtime import run_lark_event_collector
 from ..registry import read_json, registry_goals
 
 
@@ -126,6 +127,12 @@ def register_lark_inbox_commands(
     collector_status.add_argument("--project", default=".")
     collector_status.add_argument("--config", required=True)
     collector_status.add_argument("--probe-event-bus", action="store_true")
+    collector_run = sub.add_parser("collector-run", help=argparse.SUPPRESS)
+    add_subcommand_format(collector_run)
+    collector_run.add_argument("--project", required=True)
+    collector_run.add_argument("--config", required=True)
+    collector_run.add_argument("--lark-cli-executable", required=True)
+    collector_run.add_argument("--node-executable")
 
 
 def _read_stdin_events() -> list[object]:
@@ -229,6 +236,13 @@ def handle_lark_inbox_command(
                 project=args.project,
                 config_path=args.config,
                 execute=args.execute,
+            )
+        elif args.lark_inbox_command == "collector-run":
+            payload = run_lark_event_collector(
+                project=args.project,
+                config_path=args.config,
+                lark_cli_executable=args.lark_cli_executable,
+                node_executable=args.node_executable,
             )
         else:
             payload = inspect_lark_event_collector(

--- a/loopx/control_plane/quota/markdown.py
+++ b/loopx/control_plane/quota/markdown.py
@@ -652,6 +652,7 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
                 f"pending={work_lane_contract.get('pending_count')} "
                 f"questions={work_lane_contract.get('direct_question_count')} "
                 f"mentions={work_lane_contract.get('direct_mention_count')} "
+                f"bot_replies={work_lane_contract.get('reply_to_bot_count')} "
                 f"oldest_age_seconds={work_lane_contract.get('oldest_pending_age_seconds')}"
             )
         if work_lane_contract.get("action"):
@@ -1211,6 +1212,7 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
                 f"pending={urgency.get('pending_count')} "
                 f"questions={urgency.get('direct_question_count')} "
                 f"mentions={urgency.get('direct_mention_count')} "
+                f"bot_replies={urgency.get('reply_to_bot_count')} "
                 f"reply_due={urgency.get('reply_due')} "
                 f"oldest_age_seconds={urgency.get('oldest_pending_age_seconds')}"
             )

--- a/loopx/control_plane/work_items/work_lane.py
+++ b/loopx/control_plane/work_items/work_lane.py
@@ -149,7 +149,10 @@ def lark_inbox_reply_due_work_lane_contract(
         "obligation": WORK_LANE_LARK_INBOX_REPLY_DUE_OBLIGATION,
         "must_attempt_work": True,
         "priority_preemption": True,
-        "reason_codes": ["lark_inbox_reply_due", "direct_question_or_mention"],
+        "reason_codes": [
+            "lark_inbox_reply_due",
+            "direct_question_mention_or_bot_reply",
+        ],
         "pending_count": max(0, int(urgency.get("pending_count") or 0)),
         "direct_question_count": max(
             0, int(urgency.get("direct_question_count") or 0)
@@ -157,12 +160,16 @@ def lark_inbox_reply_due_work_lane_contract(
         "direct_mention_count": max(
             0, int(urgency.get("direct_mention_count") or 0)
         ),
+        "reply_to_bot_count": max(
+            0, int(urgency.get("reply_to_bot_count") or 0)
+        ),
         "oldest_pending_age_seconds": urgency.get("oldest_pending_age_seconds"),
         "drain_command": inbox.get("drain_command"),
         "monitor_policy": "durable_effect_then_one_verified_reply_then_ack",
         "action": (
             "drain the configured Lark inbox before ordinary work; translate the "
-            "direct question or mention into a durable effect, send exactly one "
+            "direct question, mention, or verified bot reply into a durable effect, "
+            "send exactly one "
             "source-thread reply with idempotency and readback, then ACK"
         ),
     }

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -1484,7 +1484,10 @@ def build_quota_should_run(
         elif inbox_reply_due:
             should_run, normal_delivery_allowed = True, True
             recovery_allowed = self_repair_allowed = capability_repair_allowed = workspace_repair_allowed = False
-            effective_action, reason = "lark_inbox_reply_due", "a direct Lark question or bot mention is pending reply"
+            effective_action, reason = "lark_inbox_reply_due", (
+                "a direct Lark question, bot mention, or verified reply to the bot "
+                "is pending reply"
+            )
         effective_action, reason = task_orchestration_effective_action(
             task_orchestration_contract,
             should_run=should_run,


### PR DESCRIPTION
## Summary
- route a non-mention Lark message only after verifying its direct parent was authored by the app bound to the configured profile
- keep direct @ mentions on the immediate event path and keep unrelated chat, human replies, other-app replies, and unverifiable parents non-triggering
- preserve full-chat capture while projecting verified bot replies into inbox urgency and the Lark work lane

## Validation
- `python3 examples/lark-event-collector-lifecycle-smoke.py`
- `python3 examples/lark-event-inbox-smoke.py`
- `python3 examples/control_plane/lark-inbox-priority-smoke.py`
- `python3 examples/control_plane/quota-contract-smoke.py`
- `python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `loopx canary premerge --from-git-diff --tier standard`: 18 selected checks, 0 failures, 0 warnings, 0 manual holds
- public-boundary scan: clean across all 11 changed files
- `ruff` was not available in the local environment; changed Python files passed `py_compile`, focused smokes, repository line-budget checks, and the standard premerge gate

## Boundary
- no credentials, local config, chat ids, message bodies, raw provider payloads, or private state are committed
- no live Lark messages are sent and no production action is performed by this PR