### PR TITLE
Cool nonblocking user notices after scheduler host failures

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -670,12 +670,15 @@ blocker-push turn. If quota also sets
 `open_todo_notification_policy=repeat_until_resolved`, repeat that notification
 until the todo is done, deferred, or replaced. If a failed host cadence update
 leaves a tighter poll, `user_gate_notification_cooldown_v0` keeps the gate open
-but suppresses duplicate notices outside a bounded reminder window. Otherwise,
-blocker-push cases may still be de-duplicated when the same blocker was already
-surfaced recently. Eligible monitor-only polls with no material transition keep
-the open user todo visible in `user_todo_summary`, but do not force a repeated
-notification, make the turn a user-action gate, or leave the top-level
-`should_run` set for an otherwise quiet no-op.
+but suppresses duplicate notices outside a bounded reminder window.
+The compatibility packet also applies to a non-blocking `user_action` notice
+during `monitor_wait`: the todo remains open and visible, but a failed host
+backoff must not turn the tighter scheduler poll into repeated chat noise.
+Otherwise, blocker-push cases may still be de-duplicated when the same blocker
+was already surfaced recently. Eligible monitor-only polls with no material
+transition keep the open user todo visible in `user_todo_summary`, but do not
+force a repeated notification, make the turn a user-action gate, or leave the
+top-level `should_run` set for an otherwise quiet no-op.
 For every registered goal, `quota should-run` also includes a `todo_write_hint`
 so agent executors know to write newly discovered user/owner work with
 `loopx todo add --role user --task-class user_gate|user_action` instead of

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -71,14 +71,19 @@ def _scheduler_rrule_interval_minutes(value: Any) -> int | None:
 def _user_gate_notification_cooldown(
     *,
     cadence_class: str,
+    notification_pending: bool,
     host_failure_suppressed: bool,
     current_interval_minutes: int,
     effective_host_rrule: str,
     recorded_host_failure: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
-    """Bound repeat gate notices when a failed host update leaves a tight poll."""
+    """Bound repeat user notices when a failed host update leaves a tight poll."""
 
-    if cadence_class != "human_gate" or not host_failure_suppressed:
+    if cadence_class not in {"human_gate", "monitor_wait"}:
+        return None
+    if cadence_class == "monitor_wait" and not notification_pending:
+        return None
+    if not host_failure_suppressed:
         return None
     failed_at = parse_scheduler_timestamp((recorded_host_failure or {}).get("failed_at"))
     host_interval = _scheduler_rrule_interval_minutes(effective_host_rrule)
@@ -100,17 +105,36 @@ def _user_gate_notification_cooldown(
         "active": True,
         "notification_due": notification_due,
         "notification_suppressed": not notification_due,
+        "notification_scope": (
+            "blocking_user_gate"
+            if cadence_class == "human_gate"
+            else "nonblocking_user_action"
+        ),
         "policy": "failed_host_update_bounded_reminder_window",
         "cooldown_minutes": target_interval,
         "reminder_window_minutes": host_interval,
         "failed_at": utc_isoformat(failed_at),
         "next_reminder_at": utc_isoformat(next_reminder_at),
         "reason": (
-            "the user gate is still pending, but the failed host cadence update "
+            "the user notice is still pending, but the failed host cadence update "
             "left a tighter poll; suppress duplicate notices outside the bounded "
-            "human-gate reminder window"
+            "user reminder window"
         ),
     }
+
+
+def _interaction_user_notification_pending(payload: dict[str, Any]) -> bool:
+    interaction = payload.get("interaction_contract")
+    if not isinstance(interaction, dict):
+        return False
+    user_channel = interaction.get("user_channel")
+    if not isinstance(user_channel, dict) or user_channel.get("notify") != "NOTIFY":
+        return False
+    return bool(
+        user_channel.get("action_required") is True
+        or user_channel.get("non_blocking") is True
+        or user_channel.get("actions")
+    )
 
 
 def _accepts_stale_monitor_ack_rrule(
@@ -1249,6 +1273,7 @@ def build_scheduler_hint(
         }
         notification_cooldown = _user_gate_notification_cooldown(
             cadence_class=cadence_class,
+            notification_pending=_interaction_user_notification_pending(payload),
             host_failure_suppressed=host_failure_suppressed,
             current_interval_minutes=current_interval,
             effective_host_rrule=effective_host_rrule,

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -122,6 +122,7 @@ def finalize_user_gate_notification_cooldown(payload: dict[str, Any]) -> None:
         payload["pending_user_action"] = bool(
             payload.get("requires_user_action")
             or user_channel_action_todo_actions(payload.get("user_todo_summary"))
+            or user_channel_notice_todo_actions(payload.get("user_todo_summary"))
         )
         payload["requires_user_action"] = False
     payload["interaction_contract"] = build_interaction_contract(payload)
@@ -774,11 +775,13 @@ def _build_interaction_user_channel(
     )
     channel: dict[str, Any] = {
         "action_required": user_required,
-        "notify": "NOTIFY"
-        if user_required or non_blocking_notice
-        else "DONT_NOTIFY"
-        if _user_gate_notification_suppressed(payload)
-        else heartbeat_recommendation.get("notify", "DONT_NOTIFY"),
+        "notify": (
+            "DONT_NOTIFY"
+            if _user_gate_notification_suppressed(payload)
+            else "NOTIFY"
+            if user_required or non_blocking_notice
+            else heartbeat_recommendation.get("notify", "DONT_NOTIFY")
+        ),
     }
     if actions:
         channel["max_items"] = 3

--- a/tests/control_plane/test_nonblocking_user_action_notification_cooldown.py
+++ b/tests/control_plane/test_nonblocking_user_action_notification_cooldown.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from loopx.control_plane.scheduler import scheduler_hint as scheduler_hint_module
+from loopx.control_plane.scheduler.scheduler_hint import build_scheduler_hint
+from loopx.control_plane.scheduler.state import SCHEDULER_STATE_SCHEMA_VERSION
+from loopx.control_plane.work_items.interaction_contract import (
+    finalize_user_gate_notification_cooldown,
+)
+
+
+FIXTURE = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "control_plane"
+    / "nonblocking_user_action_notification_cooldown_v0.json"
+)
+AGENT_SCOPE_ACTIONS = {
+    "agent_scope_exhausted",
+    "agent_scope_wait",
+    "reassignment_required",
+    "successor_replan_required",
+}
+
+
+def _payload(replay: dict) -> dict:
+    user_todo = dict(replay["user_todo"])
+    return {
+        "goal_id": replay["goal_id"],
+        "agent_identity": {"agent_id": replay["agent_id"]},
+        "state": "eligible",
+        "should_run": False,
+        "effective_action": "monitor_quiet_skip",
+        "normal_delivery_allowed": False,
+        "recovery_delivery_allowed": False,
+        "self_repair_allowed": False,
+        "recommended_action": "Wait quietly for material monitor evidence.",
+        "heartbeat_recommendation": {
+            "recommended_mode": "monitor_quiet_until_material_transition",
+            "notify": "DONT_NOTIFY",
+            "spend_policy": "no spend while the monitor target is unchanged",
+        },
+        "execution_obligation": {
+            "must_attempt_work": False,
+            "spend_policy": "do not spend",
+        },
+        "automation_liveness": {
+            "automation_action": "keep_active_quiet",
+            "spend_policy": "no quota spend for unchanged monitor-only polls",
+        },
+        "user_todo_summary": {
+            "first_open_items": [user_todo],
+            "user_action_items": [user_todo],
+        },
+        "interaction_contract": {
+            "schema_version": "loopx_interaction_contract_v0",
+            "mode": "monitor_quiet_skip",
+            "user_channel": {
+                "action_required": False,
+                "notify": "NOTIFY",
+                "non_blocking": True,
+                "actions": [user_todo["text"]],
+            },
+            "agent_channel": {
+                "must_attempt": False,
+                "delivery_allowed": False,
+                "quiet_noop_allowed": True,
+            },
+        },
+    }
+
+
+def _host_failure_state(first_hint: dict, replay: dict, *, now: datetime) -> dict:
+    stateful = first_hint["codex_app"]["stateful_backoff"]
+    scheduler = replay["scheduler"]
+    failed_at = now - timedelta(minutes=scheduler["failure_age_minutes"])
+    return {
+        "schema_version": SCHEDULER_STATE_SCHEMA_VERSION,
+        "goal_id": replay["goal_id"],
+        "agent_id": replay["agent_id"],
+        "surface": "codex_app",
+        "state_key": stateful["state_key"],
+        "reset_token": stateful["reset_token"],
+        "identity_signature": stateful["identity_signature"],
+        "progression_index": stateful["progression_index"],
+        "progression_minutes": first_hint["codex_app"][
+            "example_progression_minutes"
+        ],
+        "last_applied_rrule": "",
+        "updated_at": now.isoformat(),
+        "host_update_failure": {
+            "schema_version": "scheduler_host_update_failure_v0",
+            "target_rrule": scheduler["recommended_rrule"],
+            "observed_host_rrule": scheduler["observed_host_rrule"],
+            "failure_kind": "host_tool_failure",
+            "failure_count": 1,
+            "failed_at": failed_at.isoformat(),
+        },
+    }
+
+
+def _replay_hint(payload: dict, replay: dict) -> dict:
+    now = datetime.fromisoformat(replay["observed_at"])
+    first = build_scheduler_hint(
+        payload,
+        agent_scope_frontier_actions=AGENT_SCOPE_ACTIONS,
+        codex_app_current_rrule=replay["scheduler"]["observed_host_rrule"],
+    )
+    return build_scheduler_hint(
+        payload,
+        agent_scope_frontier_actions=AGENT_SCOPE_ACTIONS,
+        codex_app_scheduler_state=_host_failure_state(first, replay, now=now),
+        codex_app_current_rrule=replay["scheduler"]["observed_host_rrule"],
+    )
+
+
+def test_public_safe_replay_cools_nonblocking_notice_without_closing_todo(
+    monkeypatch,
+) -> None:
+    replay = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    now = datetime.fromisoformat(replay["observed_at"])
+    monkeypatch.setattr(scheduler_hint_module, "now_utc", lambda: now)
+    payload = _payload(replay)
+    hint = _replay_hint(payload, replay)
+    payload["scheduler_hint"] = hint
+
+    finalize_user_gate_notification_cooldown(payload)
+
+    expected = replay["expected"]
+    cooldown = payload["user_gate_notification_cooldown"]
+    assert hint["cadence_class"] == expected["cadence_class"]
+    assert cooldown["notification_scope"] == expected["notification_scope"]
+    assert cooldown["notification_suppressed"] is expected[
+        "notification_suppressed"
+    ]
+    assert payload["pending_user_action"] is expected["pending_user_action"]
+    assert payload["interaction_contract"]["mode"] == expected["interaction_mode"]
+    assert payload["interaction_contract"]["user_channel"]["notify"] == expected[
+        "user_notify"
+    ]
+    assert payload["user_todo_summary"]["first_open_items"][0]["status"] == expected[
+        "todo_status"
+    ]
+
+
+def test_monitor_wait_without_user_notice_does_not_create_notification_cooldown(
+    monkeypatch,
+) -> None:
+    replay = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    now = datetime.fromisoformat(replay["observed_at"])
+    monkeypatch.setattr(scheduler_hint_module, "now_utc", lambda: now)
+    payload = _payload(replay)
+    payload.pop("user_todo_summary")
+    payload["interaction_contract"]["user_channel"] = {
+        "action_required": False,
+        "notify": "DONT_NOTIFY",
+    }
+
+    hint = _replay_hint(payload, replay)
+
+    assert "user_gate_notification_cooldown" not in hint

--- a/tests/fixtures/control_plane/nonblocking_user_action_notification_cooldown_v0.json
+++ b/tests/fixtures/control_plane/nonblocking_user_action_notification_cooldown_v0.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "public_safe_notification_cooldown_replay_v0",
+  "goal_id": "notification-cooldown-replay",
+  "agent_id": "replay-agent",
+  "observed_at": "2026-07-16T07:47:17+00:00",
+  "user_todo": {
+    "todo_id": "todo_restore_runner",
+    "status": "open",
+    "task_class": "user_action",
+    "text": "[P1-user] Restore the benchmark runner substrate."
+  },
+  "scheduler": {
+    "recommended_rrule": "FREQ=MINUTELY;INTERVAL=15",
+    "observed_host_rrule": "FREQ=MINUTELY;INTERVAL=3",
+    "failure_age_minutes": 1
+  },
+  "expected": {
+    "cadence_class": "monitor_wait",
+    "notification_scope": "nonblocking_user_action",
+    "notification_suppressed": true,
+    "interaction_mode": "user_gate_cooldown_wait",
+    "user_notify": "DONT_NOTIFY",
+    "pending_user_action": true,
+    "todo_status": "open"
+  }
+}


### PR DESCRIPTION
## Summary

- extend the failed-host cadence notification cooldown to `monitor_wait` only when the interaction contract has a pending user notice
- let the cooldown suppress the current nonblocking notification without closing or hiding the underlying user todo
- add a public-safe compact replay plus focused negative coverage and document the compatibility behavior

## Validation

- `22 passed`: focused cooldown, scheduler arbitration, and public-safe replay tests
- `quota-scheduler-state-ack-smoke.py` passed
- `ruff check` passed for changed Python surfaces
- `loopx canary premerge --from-git-diff` passed: 18 selected checks, zero failures or warnings
- targeted `mypy` is not a usable gate yet: it reports 201 existing cross-module errors outside this change

## Review note

This changes scheduler/interaction runtime precedence, so it is intentionally left for owner review rather than self-merged.