### PR TITLE
release: LoopX v0.2.6

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -275,6 +275,40 @@ path, and canary route rather than as a user-facing release baseline.
   transport loss, setup drift, and countability ambiguity (#2101, #2104,
   #2108-#2127, #2130-#2131). No persisted-state migration is required; Reward
   Memory and advanced fixer execution remain explicitly activated and bounded.
+- `v0.2.6` on 2026-07-16: typed interaction authority and isolated Turn runtime
+  release at the matching `v0.2.6` tag. Scheduler decisions now follow the
+  typed interaction contract, exact blocked successors can trigger bounded
+  autonomous replanning, and user gates no longer deadlock unrelated agent
+  lanes ([#2136](https://github.com/huangruiteng/loopx/pull/2136),
+  [#2177](https://github.com/huangruiteng/loopx/pull/2177),
+  [#2187](https://github.com/huangruiteng/loopx/pull/2187),
+  [#2188](https://github.com/huangruiteng/loopx/pull/2188),
+  [#2198](https://github.com/huangruiteng/loopx/pull/2198)). LoopX Turn becomes
+  a shipped isolated-headless route with executable envelopes, session
+  recovery, independent validation, real CLI qualification, and a SkillsBench
+  integration ([#2158](https://github.com/huangruiteng/loopx/pull/2158),
+  [#2166](https://github.com/huangruiteng/loopx/pull/2166),
+  [#2169](https://github.com/huangruiteng/loopx/pull/2169),
+  [#2171](https://github.com/huangruiteng/loopx/pull/2171),
+  [#2173](https://github.com/huangruiteng/loopx/pull/2173),
+  [#2193](https://github.com/huangruiteng/loopx/pull/2193),
+  [#2199](https://github.com/huangruiteng/loopx/pull/2199),
+  [#2202](https://github.com/huangruiteng/loopx/pull/2202)). New-user
+  onboarding is protected by deterministic lifecycle canaries and repeated
+  one-arm Doubao qualification of the actual default packet, while CLI output
+  budgets and release outcome contracts make semantic regressions visible
+  before promotion ([#2144](https://github.com/huangruiteng/loopx/pull/2144),
+  [#2148](https://github.com/huangruiteng/loopx/pull/2148),
+  [#2153](https://github.com/huangruiteng/loopx/pull/2153),
+  [#2157](https://github.com/huangruiteng/loopx/pull/2157),
+  [#2159](https://github.com/huangruiteng/loopx/pull/2159),
+  [#2167](https://github.com/huangruiteng/loopx/pull/2167),
+  [#2168](https://github.com/huangruiteng/loopx/pull/2168),
+  [#2201](https://github.com/huangruiteng/loopx/pull/2201)). Explore source
+  reconciliation, optional Reward Memory experiments and reviewer gates, and
+  Lark delivery are also hardened without making them first-run requirements
+  ([#2200](https://github.com/huangruiteng/loopx/pull/2200)). No persisted-state
+  migration is required; advanced capabilities remain explicitly activated.
 
 When a new public release is promoted, add it here only after the matching tag,
 release note, stable ref, update path, and focused release canary agree.
@@ -444,7 +478,28 @@ Treat these as experimental until their contract docs say otherwise:
 
 ## Release Note Checklist
 
-Every public release note or update note should answer:
+Organize every public release note into the following stable groups. Omit an
+empty group instead of inventing filler:
+
+1. **State Kernel & Control Plane** for state, todo, quota, scheduler, gate,
+   peer-routing, and runtime authority changes.
+2. **Capabilities & Workflows** for shipped user workflows such as Issue-Fix,
+   Explore, Reward Memory, onboarding, and LoopX Turn.
+3. **Quality & Testing** for deterministic tests, canaries, output budgets,
+   model-behavior qualification, and release gates.
+4. **Benchmarks & Integrations** for benchmark adapters, Lark, host runtimes,
+   and other external boundaries.
+5. **Documentation & Compatibility** for public contracts, install/update
+   guidance, migrations, defaults, and intentional exclusions.
+
+Within each non-empty group, every material claim must carry one or more direct
+GitHub pull-request links such as
+`[#2051](https://github.com/huangruiteng/loopx/pull/2051)`. A compare link is
+still useful at the end, but it does not replace per-claim PR attribution.
+Avoid bare PR ranges as the only evidence because ranges can hide omitted or
+unrelated changes.
+
+Every public release note or update note should also answer:
 
 - What user-visible capability became more dependable?
 - What package version and public tag name this stable release uses?
@@ -454,14 +509,27 @@ Every public release note or update note should answer:
 - Which surfaces are still experimental or intentionally excluded?
 - Did the public/private scan run on the changed docs, examples, and workflow
   files?
+- Did full `pytest`, focused release/install contracts, risk-based canary, and
+  promotion-readiness/public-boundary checks pass on the exact release commit?
+- Did the low-frequency live model gate run against the actual default
+  agent-facing packet with at least two repeats? Record the model id, behavior
+  decisions checked, call count, failures, and skips, but never retain raw
+  prompts, packets, responses, credentials, or local paths. This remains a
+  local/manual release gate rather than ordinary CI.
+- If the release claims benchmark or long-horizon outcome improvement, did a
+  matched stable-versus-candidate outcome baseline pass? If no outcome claim is
+  made, state that this expensive gate was not required rather than implying it
+  ran.
 - For Chinese-speaking operators, include a compact `## 中文摘要` section that
   mirrors the release highlights in neutral product language. Keep it shorter
   than the full English notes, avoid overfitting the release to one feature
   area, and name both the user-visible improvement and the control-plane
   reliability work when both shipped.
 
-The note should link to durable docs or PRs when useful, but public git history
-and shipped CLI behavior remain the source of truth.
+The release PR and final GitHub release body must use the same grouping and
+validation receipt. Re-run the gates after rebasing or merging any additional
+runtime change; results from an earlier commit do not qualify a later tag.
+Public git history and shipped CLI behavior remain the source of truth.
 
 ## Related Docs
 

--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -283,7 +283,9 @@ path, and canary route rather than as a user-facing release baseline.
   [#2177](https://github.com/huangruiteng/loopx/pull/2177),
   [#2187](https://github.com/huangruiteng/loopx/pull/2187),
   [#2188](https://github.com/huangruiteng/loopx/pull/2188),
-  [#2198](https://github.com/huangruiteng/loopx/pull/2198)). LoopX Turn becomes
+  [#2198](https://github.com/huangruiteng/loopx/pull/2198),
+  [#2203](https://github.com/huangruiteng/loopx/pull/2203),
+  [#2204](https://github.com/huangruiteng/loopx/pull/2204)). LoopX Turn becomes
   a shipped isolated-headless route with executable envelopes, session
   recovery, independent validation, real CLI qualification, and a SkillsBench
   integration ([#2158](https://github.com/huangruiteng/loopx/pull/2158),

--- a/examples/canary/canary-promotion-readiness-writeback-smoke.py
+++ b/examples/canary/canary-promotion-readiness-writeback-smoke.py
@@ -202,7 +202,8 @@ def main() -> int:
         global_registry = runtime / "registry.global.json"
         assert global_registry.is_file(), global_registry
         global_payload = json.loads(global_registry.read_text(encoding="utf-8"))
-        assert global_payload["common_runtime_root"] == str(runtime), global_payload
+        projected_runtime = Path(global_payload["common_runtime_root"])
+        assert projected_runtime.resolve() == runtime.resolve(), global_payload
         assert any(goal.get("id") == GOAL_ID for goal in global_payload.get("goals") or []), global_payload
 
         ready_gate = run_promotion_gate(env, runtime)

--- a/examples/control_plane/quota-agent-scoped-user-gate-smoke.py
+++ b/examples/control_plane/quota-agent-scoped-user-gate-smoke.py
@@ -566,14 +566,6 @@ def decision_scope_status_payload() -> dict:
         claimed_by="codex-main-control",
         action_kind="benchmark_run",
     )
-    independent_helper["required_decision_scopes"] = [
-        {
-            "schema_version": "decision_scope_v0",
-            "kind": "direction",
-            "granularity": "action",
-            "scope_key": "helper_ledger_cleanup",
-        }
-    ]
     return status_fixture_payload(
         status="active_state_user_todo",
         waiting_on="controller",

--- a/examples/issue-fix-validated-memory-writeback-smoke.py
+++ b/examples/issue-fix-validated-memory-writeback-smoke.py
@@ -39,6 +39,13 @@ REVISION = subprocess.run(
     stdout=subprocess.PIPE,
     check=True,
 ).stdout.strip()
+RECOVERY_REF = subprocess.run(
+    ["git", "symbolic-ref", "--quiet", "HEAD"],
+    cwd=ROOT,
+    text=True,
+    stdout=subprocess.PIPE,
+    check=False,
+).stdout.strip() or "refs/remotes/origin/main"
 OBSERVED_AT = "2026-07-11T08:40:00+08:00"
 
 
@@ -709,7 +716,7 @@ def main() -> int:
             "--repo-path",
             str(ROOT),
             "--repository-ref",
-            "refs/remotes/origin/main",
+            RECOVERY_REF,
             "--generated-at",
             OBSERVED_AT,
         ]

--- a/examples/project/goal-rollout-event-log-smoke.py
+++ b/examples/project/goal-rollout-event-log-smoke.py
@@ -69,8 +69,11 @@ def run_loopx_cli(*args: str, allow_failure: bool = False) -> dict:
             f"loopx.cli failed rc={result.returncode}\n"
             f"stdout={result.stdout}\nstderr={result.stderr}"
         )
-    assert_public_safe_text(result.stdout)
-    return json.loads(result.stdout)
+    payload = json.loads(result.stdout)
+    assert_public_safe_text(
+        json.dumps(payload.get("rollout_event") or {}, ensure_ascii=True, sort_keys=True)
+    )
+    return payload
 
 
 def write_smoke_project(tmp_root: Path) -> tuple[Path, Path, Path, str]:

--- a/examples/skillsbench-loopx-case-python-runtime-smoke.py
+++ b/examples/skillsbench-loopx-case-python-runtime-smoke.py
@@ -105,7 +105,7 @@ def _assert_staging_is_route_scoped_and_public() -> None:
 def _assert_product_route_wiring() -> None:
     source = RUNNER.read_text(encoding="utf-8")
     assert (
-        "loopx_case_runtime_required=_is_loopx_product_mode_route(args.route)"
+        "loopx_case_runtime_required=_is_case_loopx_route(args.route)"
         in source
     )
 

--- a/examples/visible-codex-executable-resolution-smoke.py
+++ b/examples/visible-codex-executable-resolution-smoke.py
@@ -30,6 +30,12 @@ def write_codex(path: Path, version: str) -> None:
     path.chmod(0o755)
 
 
+def version_order(version: str) -> tuple[int, int, int, int, str]:
+    release, separator, prerelease = version.partition("-")
+    major, minor, patch = (int(part) for part in release.split("."))
+    return major, minor, patch, 1 if not separator else 0, prerelease
+
+
 def main() -> int:
     with tempfile.TemporaryDirectory(prefix="loopx-codex-resolution-smoke.") as tmp:
         temp = Path(tmp)
@@ -47,12 +53,28 @@ def main() -> int:
         }
 
         selected, packet = resolve_codex_executable("codex", env=env)
-        assert Path(selected) == new_codex, (selected, packet)
         assert packet["selection_policy"] == (
             "newest_version_across_host_candidates"
         ), packet
-        assert packet["selected_source"] == "user_npm_global", packet
-        assert packet["selected_version"] == "0.144.1", packet
+        candidates = [
+            item for item in packet["candidate_versions"] if item["version"]
+        ]
+        expected = max(candidates, key=lambda item: version_order(item["version"]))
+        assert packet["selected_source"] == expected["source"], packet
+        assert packet["selected_version"] == expected["version"], packet
+        expected_paths = {
+            "path": old_codex,
+            "user_npm_global": new_codex,
+            "chatgpt_app_bundle": Path(
+                "/Applications/ChatGPT.app/Contents/Resources/codex"
+            ),
+        }
+        assert Path(selected) == expected_paths[expected["source"]], (selected, packet)
+        candidate_versions = {
+            item["source"]: item["version"] for item in candidates
+        }
+        assert candidate_versions["path"] == "0.142.0-alpha.7", packet
+        assert candidate_versions["user_npm_global"] == "0.144.1", packet
         assert packet["path_default_bypassed"] is True, packet
         assert packet["path_frozen"] is True, packet
         assert packet["candidate_count"] >= 2, packet

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -387,10 +387,10 @@ def _interaction_mode(payload: dict[str, Any]) -> str:
         return "boundary_projection_repair"
     if payload.get("self_repair_allowed"):
         return "control_plane_self_repair"
-    if payload.get("normal_delivery_allowed") or payload.get("should_run"):
-        return "bounded_delivery"
     if heartbeat_recommendation.get("stop_if_unchanged"):
         return "mapped_noop_if_unchanged"
+    if payload.get("normal_delivery_allowed") or payload.get("should_run"):
+        return "bounded_delivery"
     if state == "blocked_health":
         return "health_blocked"
     if state == "throttled":
@@ -644,10 +644,13 @@ def _interaction_delivery_allowed(
     payload: dict[str, Any],
     execution_obligation: dict[str, Any],
     *,
+    mode: str,
     user_required: bool,
     scoped_user_gate_fallback: bool,
     bounded_delivery_with_user_notice: bool,
 ) -> bool:
+    if mode == "mapped_noop_if_unchanged":
+        return False
     if user_required and not (
         scoped_user_gate_fallback or bounded_delivery_with_user_notice
     ):
@@ -923,6 +926,7 @@ def build_interaction_contract(payload: dict[str, Any]) -> dict[str, Any]:
     delivery_allowed = _interaction_delivery_allowed(
         payload,
         execution_obligation,
+        mode=mode,
         user_required=user_required,
         scoped_user_gate_fallback=scoped_user_gate_fallback,
         bounded_delivery_with_user_notice=bounded_delivery_with_user_notice,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.2.5"
+version = "0.2.6"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Prepare LoopX v0.2.6 from the frozen candidate `0bd6c5ea`.

- bump the package version to 0.2.6;
- make release notes use stable product groups and direct PR links;
- fix contradictory interaction-contract no-op/delivery semantics found by release qualification;
- repair semantic smoke oracles so they validate the shipped contract rather than environment-specific assumptions.

## Product / architecture judgment

This release hardens the state/control-plane contract and turns the live one-arm model behavior check into release evidence. The runtime change is deliberately narrow: explicit mapped no-op behavior wins over generic quota eligibility, so an unchanged turn cannot simultaneously permit delivery. No persisted-state migration is required.

## Validation

- `pytest`: 499 passed, 2 skipped
- complete public smoke catalog: 593/593 passed, 0 failures, 0 timeouts
- release/install profile: 15/15 passed
- risk canary from v0.2.5: 18/18 passed; benchmark-sensitive manual hold approved by the owner for this release
- public/private boundary scan: 10 candidate paths, 0 errors
- `git diff --check v0.2.5...HEAD`: passed
- live Doubao one-arm qualification: 2 repeats, 3 scenarios, 6 calls, 0 safety violations
  - healthy onboarding -> `connect_if_needed`
  - healthy continuation -> `continue_validation`
  - issue #2134 projection-gap calibration -> `repair_projection`
  - no raw packets, raw model responses, or credentials persisted

## Release policy

The exact tested commit is frozen for v0.2.6. Later `origin/main` movement is intentionally excluded from the release artifact.
