### PR TITLE
docs: codify semantic-first test design

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,11 @@ section, or abstraction, pass a scope-fit review:
   benchmark-specific builder, arm constants, or wide field-level smoke. Do not
   split so narrowly that reviewers must reconstruct one logical behavior from
   several dependent PRs.
+- Design tests from semantics, not observed output. Independently review the
+  intended invariant and legal or illegal transitions before testing the
+  implementation. Never derive expected results from the implementation under
+  test or its current output; characterization fixtures are non-authoritative,
+  and contradictions require rule repair plus negative or mutation coverage.
 - Characterize before moving code. For status, quota, review-packet, scheduler,
   monitor, and handoff behavior, add or extend parity fixtures first, then
   extract the proven rule or cohesive rule group.

--- a/docs/development/testing-and-quality.md
+++ b/docs/development/testing-and-quality.md
@@ -29,6 +29,18 @@ that names the broken rule.
 这些层次互补：模型通过不能覆盖确定性合同失败；大规模 smoke 也不能代替明确指出
 错误规则的聚焦回归测试。
 
+Tests first judge whether the state and rule are correct, then whether the
+implementation conforms. Expected outcomes come from an independently reviewed
+invariant, never the implementation under test or its current output.
+Characterization fixtures document legacy behavior but do not authorize it;
+contradictions require rule repair and negative or mutation coverage, not a
+refreshed golden.
+
+测试先判断状态和规则是否正确，再验证实现是否符合。预期结果必须来自独立审阅的
+不变量，不能由被测实现或当前输出生成。Characterization fixture 只记录历史
+行为，不授予其正确性；发现矛盾时应修复规则并增加反例或 mutation 覆盖，不得刷新
+golden 来让测试通过。
+
 ## Pull-Request Baseline / PR 基线
 
 Install the test dependencies once:


### PR DESCRIPTION
## Summary
- make semantic correctness authoritative over observed output in `AGENTS.md`
- generalize the independently reviewed oracle rule in the bilingual quality guide
- mark characterization fixtures as non-authoritative and require negative or mutation coverage for contradictions

## Validation
- `python3 examples/docs-governance-smoke.py`
- `loopx canary premerge --from-git-diff` (9/9 selected checks passed; 8 risk-profile smokes plus public-boundary scan)
- `loopx check --scan-path AGENTS.md --scan-path docs/development/testing-and-quality.md` (0 errors; one unrelated OpenViking history-index warning)
- `git diff --check`

## Boundary
Only durable public documentation is included. No credentials, private state, local paths, raw model evidence, or generated logs are committed.