### PR TITLE
release: require opt-in activation guidance

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -515,6 +515,11 @@ Every public release note or update note should also answer:
 - Which commands, docs, or smokes prove the claim?
 - Are there compatibility or migration notes for existing local state?
 - Which surfaces are still experimental or intentionally excluded?
+- For every new or materially changed experimental, default-off, or opt-in
+  capability, include an **Optional capability activation** entry in both
+  languages: name its scope, read-only preview, exact enable and disable
+  commands, prerequisites or safety gates, and canonical docs. If no persistent
+  switch exists, say that opt-in is per command or preset instead.
 - Did the public/private scan run on the changed docs, examples, and workflow
   files?
 - Did full `pytest`, focused release/install contracts, risk-based canary, and

--- a/examples/release/release-readiness-doc-smoke.py
+++ b/examples/release/release-readiness-doc-smoke.py
@@ -77,9 +77,12 @@ def main() -> None:
         "/loopx-global-summary",
         "benchmark runner behavior, scoring, upload",
         "## Release Note Checklist",
+        "Optional capability activation",
+        "If no persistent switch exists",
         "public/private scan",
         "## 中文摘要",
-        "avoid overfitting the release to one feature area",
+        "Bilingual releases must preserve these same group boundaries",
+        "mirrors the English group structure and material claims",
     ]:
         assert_contains(doc, required, "release-readiness doc")
 


### PR DESCRIPTION
## Summary
- require every new or materially changed experimental/default-off capability to document scope, preview, enable, disable, safety gates, and canonical docs in both release languages
- distinguish persistent switches from per-command and preset opt-in
- repair a stale release-doc assertion so it checks the current stronger bilingual grouping contract
- update the existing [v0.2.6 release](https://github.com/huangruiteng/loopx/releases/tag/v0.2.6) with activation and shutdown instructions for LoopX Turn, Reward Memory, Explore Graph/Harness, subagents, and advanced fixers

## Validation
- `python3 examples/release/release-readiness-doc-smoke.py`
- `python3 examples/release/release-version-contract-smoke.py`
- `python3 examples/release/codex-cli-no-clone-release-verification-smoke.py`
- `python3 examples/docs-governance-smoke.py`
- `python3 -m py_compile examples/release/release-readiness-doc-smoke.py`
- focused `loopx check` public-boundary scan: 0 errors
- `git diff --check`
- v0.2.6 release API readback confirmed both language sections and all five activation routes

## Validation note
`loopx canary premerge --from-git-diff` reached the existing `install-local-smoke.py` branch but the host command session terminated without a pass/fail receipt. It is not reported as passed. The explicit release-contract set above covers this docs/smoke-only change; no runtime or installer behavior changed.

## Boundary
Only durable public release guidance and its focused smoke are committed. No credentials, private state, local paths, raw model evidence, or generated logs are included.