### PR TITLE
Retire stale managed metadata beside user-owned skills

### DIFF
--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -365,7 +365,7 @@ def install_slash_commands(
                         "invoke_as": [f"${spec['name']}", "/skills"],
                     }
                 )
-            elif skill_status == "preserved_existing_loopx_skill":
+            elif skill_status in {"skipped_user_file", "preserved_existing_loopx_skill"}:
                 retire_status = _retire_managed_file(metadata_path, execute=execute)
                 if retire_status:
                     installed.append(

--- a/tests/test_slash_command_install.py
+++ b/tests/test_slash_command_install.py
@@ -72,3 +72,29 @@ def test_codex_install_preserves_user_owned_loopx_facade(tmp_path: Path) -> None
     assert skill.read_text(encoding="utf-8") == "# user-owned loopx skill\n"
     assert metadata.read_text(encoding="utf-8") == "# user-owned metadata\n"
     assert _row(payload, "codex_explicit_skills")["status"] == "skipped_user_file"
+    assert _row(payload, "retired_codex_command_metadata")["status"] == "skipped_user_file"
+
+
+def test_codex_install_retires_managed_metadata_beside_user_owned_skill(
+    tmp_path: Path,
+) -> None:
+    codex_home = tmp_path / "codex"
+    skill, metadata = _loopx_paths(codex_home)
+    skill.parent.mkdir(parents=True)
+    skill.write_text("# user-owned loopx skill\n", encoding="utf-8")
+    metadata.parent.mkdir(parents=True)
+    metadata.write_text(MANAGED_METADATA, encoding="utf-8")
+
+    payload = install_slash_commands(
+        execute=True,
+        surfaces=["codex"],
+        codex_home=str(codex_home),
+        claude_home=str(tmp_path / "claude"),
+    )
+
+    assert skill.read_text(encoding="utf-8") == "# user-owned loopx skill\n"
+    assert not metadata.exists()
+    assert _row(payload, "codex_explicit_skills")["status"] == "skipped_user_file"
+    assert _row(payload, "retired_codex_command_metadata")["status"] == (
+        "retired_managed_file"
+    )


### PR DESCRIPTION
## What changed

- apply the existing fail-closed managed-metadata retirement path when a same-name Codex command `SKILL.md` is user-owned
- preserve non-managed metadata unchanged
- add focused ownership contracts for both cases

## Root cause

`skipped_user_file` correctly protected the command `SKILL.md`, but it bypassed all sibling metadata handling. A previously LoopX-managed `agents/openai.yaml` could therefore survive beside an externally owned skill and keep presenting stale LoopX UI identity.

The repair reuses `_retire_managed_file`: only metadata carrying the LoopX managed marker is removed; non-managed metadata remains untouched. Packaged workflow installation behavior is unchanged.

## Validation

- focused unit contract: 3 passed
- `examples/slash-command-install-smoke.py`: passed
- full Python suite: 503 passed, 2 skipped
- standard diff-selected premerge gate: passed
  - changed-Python compile and diff checks passed
  - 4 catalog canaries passed
  - 0 failures, 0 warnings, 0 manual holds
- public/private scan of the two changed paths: clean

No self-merge performed.