### PR TITLE
Add provider-aware capability and extension registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,32 @@ Treat code volume as a cost, especially during refactors. A good LoopX change
 should make the next change easier to localize, test, and revert; it should not
 turn a design possibility into unused production structure.
 
+## Capability And Extension Placement
+
+Before adding an ability, decide its capability owner and provider boundary;
+do not choose a directory from the feature name alone:
+
+- extend `loopx/capabilities/<capability>/` when the change belongs to an
+  existing product contract and shares that built-in capability's lifecycle;
+- create a new built-in capability only when LoopX core must ship it by
+  default and it has a stable caller contract, real entrypoint, and focused
+  validation;
+- put generic manifest, registration, compatibility, and lifecycle mechanics
+  in `loopx/extensions/`;
+- put an independently versioned or optional provider in
+  `extensions/<extension-id>/` when it is co-located, or in its own package or
+  repository when it is distributed separately;
+- when a provider introduces a new product contract, register the capability
+  contract and implement it through the extension rather than choosing only
+  one side;
+- keep private helpers in the nearest owning module. A helper is not a new
+  capability or extension merely because several files are involved.
+
+Record the placement rationale before editing: capability id, provider id,
+whether the provider is built-in or extension-delivered, and why the nearest
+existing owner is or is not sufficient. See `docs/extensions.md` for the full
+decision guide.
+
 Before adding a new module, builder, protocol field, CLI option, fixture, smoke
 section, or abstraction, pass a scope-fit review:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,10 @@ turn a design possibility into unused production structure.
 Before adding an ability, decide its capability owner and provider boundary;
 do not choose a directory from the feature name alone:
 
+- name public capabilities after caller outcomes, not delivery mechanisms. A
+  proposed `connector`, `provider`, `adapter`, or `sink` capability needs an
+  independently useful caller contract; otherwise make it an extension
+  provider or an internal part of the outcome capability it serves;
 - extend `loopx/capabilities/<capability>/` when the change belongs to an
   existing product contract and shares that built-in capability's lifecycle;
 - create a new built-in capability only when LoopX core must ship it by

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,6 +57,11 @@ generic compact benchmark fields; its shipped schema remains compatible. Hiding
 an adapter dependency inside a function or dynamic import does not count as
 architectural separation.
 
+Capabilities and extensions are also orthogonal: a capability is a product
+contract, while an extension is an independently managed provider that may
+offer one or more capabilities. The provider-aware registration and manifest
+boundary is documented in [extensions.md](extensions.md).
+
 LoopX should still absorb field-tested project-control mechanisms such
 as authority registries, current-belief TODOs, managed external-source
 manifests, experiment boards, validation surface maps, and gated handoff

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,0 +1,97 @@
+# Extensions And Capabilities
+
+Capabilities and extensions are independent dimensions in LoopX:
+
+- a **capability** describes what LoopX can do and the product contract exposed
+  to callers;
+- an **extension** is a delivery unit that can provide one or more capabilities
+  and has its own installation, enablement, disablement, and upgrade lifecycle.
+
+Built-in capabilities and extension-provided capabilities share one registry.
+Implementation directories do not become capabilities merely because they live
+under `loopx/capabilities/`; registration is explicit.
+
+```text
+LoopX Core
+|-- capability contracts
+|-- built-in capability registrations
+`-- extension runtime
+      |-- extension A -- provides capabilities
+      |-- extension B -- provides capabilities
+      `-- extension C -- provides capabilities
+```
+
+## Registration Model
+
+Every registered capability declares three provider-facing fields:
+
+- `origin`: `builtin` or `extension`;
+- `visibility`: `public` or `internal`;
+- `provider_id`: `loopx-core` or the extension manifest id.
+
+The built-in catalog remains the default source. Explicitly enabled extension
+manifests are validated and appended in caller order. Duplicate capability or
+provider ids fail closed. Internal registrations remain available to the
+registry but are omitted from the public catalog.
+
+The initial runtime does not scan arbitrary directories and does not import
+extension Python code while reading the catalog. A caller enables a manifest
+for one catalog operation explicitly:
+
+```bash
+loopx capability list \
+  --extension-manifest /path/to/extension.toml \
+  --format json
+
+loopx capability show lark-kanban \
+  --extension-manifest /path/to/extension.toml \
+  --format json
+```
+
+This explicit read path establishes the registration contract without
+prematurely defining an installer, package repository, or global activation
+store. Those lifecycle surfaces can later provide the same validated manifest
+paths to the registry.
+
+## Manifest Contract
+
+An extension manifest is declarative TOML. `[[provides]]` records carry enough
+metadata to enter the capability catalog without loading provider code.
+The v0 runtime exposes integer extension API version `1` and accepts bounded
+integer constraints such as `>=1,<2`; incompatible manifests fail closed.
+
+```toml
+schema_version = "loopx_extension_manifest_v0"
+id = "loopx-lark"
+version = "1.0.0"
+requires_loopx_api = ">=1,<2"
+permissions = ["read_status", "read_todos", "external_write"]
+
+[[provides]]
+id = "lark-kanban"
+kind = "projection_sink"
+title = "Lark Kanban projection"
+status = "active"
+visibility = "public"
+real_world_anchor = "operator-facing Lark Base projection"
+user_value = "Project public-safe LoopX status and todo rows into Lark."
+entry_command = "loopx lark-kanban sync"
+next_real_step = "Validate one explicitly enabled owner-approved sink."
+```
+
+`permissions` are declared provider metadata in this stage. Declaring a
+permission does not grant it: existing LoopX goal boundaries, user gates, and
+external-write authorization still decide whether an operation may execute.
+
+## Scope Boundaries
+
+This first stage intentionally does not:
+
+- rename or move existing capability implementation directories;
+- infer capabilities from Python packages;
+- install, enable, disable, or upgrade extension packages;
+- import an extension entrypoint during catalog discovery;
+- let manifest permissions bypass LoopX control-plane authority.
+
+These omissions keep the registry useful now while leaving package and
+lifecycle policy to a later, evidence-backed call site.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -53,6 +53,61 @@ prematurely defining an installer, package repository, or global activation
 store. Those lifecycle surfaces can later provide the same validated manifest
 paths to the registry.
 
+## Placement Decision For Agents
+
+Before creating a directory, LoopX or an executing agent must answer these
+questions in order:
+
+1. **What caller-visible contract is being added or changed?** If an existing
+   capability already owns that contract, add the implementation to
+   `loopx/capabilities/<existing-capability>/` instead of creating a sibling.
+2. **Must LoopX core always ship and maintain the implementation?** If yes, it
+   may be a built-in capability. A new built-in needs a stable id, a real
+   entrypoint or protocol call site, focused validation, and catalog
+   registration.
+3. **Does the implementation need independent installation, enablement,
+   disablement, upgrade, dependencies, credentials, or provider ownership?**
+   If yes, it is an extension provider. The capability remains the contract;
+   the extension manifest declares that it provides the contract.
+4. **Is this only registration or lifecycle machinery shared by all
+   extensions?** Put that mechanism in `loopx/extensions/`, not in a provider
+   package.
+5. **Is this only an internal helper?** Put it in the nearest module that owns
+   its change reason. Do not register a capability or create an extension.
+
+Use this placement map after answering the questions:
+
+| Change | Placement |
+| --- | --- |
+| Existing built-in capability behavior | `loopx/capabilities/<capability-id>/` |
+| Built-in catalog and registration contract | `loopx/capabilities/catalog.py` or `registry.py` |
+| Generic extension runtime | `loopx/extensions/` |
+| Co-located optional provider | `extensions/<extension-id>/` |
+| Separately distributed provider | provider-owned package or repository |
+| Internal implementation helper | nearest owning module |
+
+Some work belongs on both axes. For example, a finance-discovery provider can
+live in `extensions/finance-value-discovery/` while providing the existing
+`value-connectors` contract. Register a separate `finance-value-discovery`
+capability only when callers need a distinct stable contract that
+`value-connectors` cannot express. The extension directory owns delivery and
+lifecycle; capability registration owns the caller-visible promise.
+
+Before editing, record a compact rationale in the active todo or plan:
+
+```text
+capability_id: <existing-or-new-contract>
+provider_id: loopx-core | <extension-id>
+origin: builtin | extension
+placement: <target-directory-or-package>
+reason: <why the nearest existing owner is or is not sufficient>
+```
+
+Do not create a new capability directory merely because no current directory
+has the feature name. Do not create an extension merely because an external
+service is involved: a built-in connector can still belong to an existing
+capability when it shares the core release and lifecycle.
+
 ## Manifest Contract
 
 An extension manifest is declarative TOML. `[[provides]]` records carry enough

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -58,7 +58,11 @@ paths to the registry.
 Before creating a directory, LoopX or an executing agent must answer these
 questions in order:
 
-1. **What caller-visible contract is being added or changed?** If an existing
+1. **What user outcome and caller-visible contract is being added or changed?**
+   Capability ids describe outcomes, not transports. Names such as
+   `connector`, `provider`, `adapter`, or `sink` usually describe an extension
+   or internal mechanism unless callers use and validate that mechanism as an
+   independent product contract. If an existing
    capability already owns that contract, add the implementation to
    `loopx/capabilities/<existing-capability>/` instead of creating a sibling.
 2. **Must LoopX core always ship and maintain the implementation?** If yes, it
@@ -86,12 +90,19 @@ Use this placement map after answering the questions:
 | Separately distributed provider | provider-owned package or repository |
 | Internal implementation helper | nearest owning module |
 
-Some work belongs on both axes. For example, a finance-discovery provider can
-live in `extensions/finance-value-discovery/` while providing the existing
-`value-connectors` contract. Register a separate `finance-value-discovery`
-capability only when callers need a distinct stable contract that
-`value-connectors` cannot express. The extension directory owns delivery and
-lifecycle; capability registration owns the caller-visible promise.
+Some work belongs on both axes. Finance research should expose the outcome
+capability `finance-value-discovery`; public-market, filing, and news sources
+can be extension providers of that capability. Shared connector intent,
+permission, and approval logic is internal runtime machinery, not another
+public capability. The extension directory owns delivery and lifecycle;
+capability registration owns the caller-visible promise.
+
+`value-connectors` is an existing compatibility CLI and protocol surface. Do
+not use it as the public capability owner for new work. Migrate each profile to
+the outcome capability it serves, such as `finance-value-discovery`,
+`issue-fix`, or `content-ops`, before retiring the compatibility surface. This
+keeps the migration behavior-preserving instead of replacing one broad bucket
+with another broad bucket.
 
 Before editing, record a compact rationale in the active todo or plan:
 

--- a/examples/capability-extension-placement-doc-smoke.py
+++ b/examples/capability-extension-placement-doc-smoke.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+AGENTS = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+GUIDE = (ROOT / "docs" / "extensions.md").read_text(encoding="utf-8")
+
+for anchor in (
+    "## Capability And Extension Placement",
+    "loopx/capabilities/<capability>/",
+    "loopx/extensions/",
+    "extensions/<extension-id>/",
+    "capability id, provider id",
+):
+    assert anchor in AGENTS, anchor
+
+for anchor in (
+    "## Placement Decision For Agents",
+    "What caller-visible contract is being added or changed?",
+    "Does the implementation need independent installation",
+    "Some work belongs on both axes.",
+    "capability_id: <existing-or-new-contract>",
+    "reason: <why the nearest existing owner is or is not sufficient>",
+):
+    assert anchor in GUIDE, anchor
+
+print("capability-extension-placement-doc-smoke: ok")

--- a/examples/capability-extension-placement-doc-smoke.py
+++ b/examples/capability-extension-placement-doc-smoke.py
@@ -14,14 +14,17 @@ for anchor in (
     "loopx/extensions/",
     "extensions/<extension-id>/",
     "capability id, provider id",
+    "name public capabilities after caller outcomes",
 ):
     assert anchor in AGENTS, anchor
 
 for anchor in (
     "## Placement Decision For Agents",
-    "What caller-visible contract is being added or changed?",
+    "What user outcome and caller-visible contract is being added or changed?",
     "Does the implementation need independent installation",
     "Some work belongs on both axes.",
+    "`value-connectors` is an existing compatibility CLI",
+    "Migrate each profile to",
     "capability_id: <existing-or-new-contract>",
     "reason: <why the nearest existing owner is or is not sufficient>",
 ):

--- a/examples/capability-extension-registry-smoke.py
+++ b/examples/capability-extension-registry-smoke.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_cli(*args: str) -> dict[str, object]:
+    result = subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--format", "json", *args],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+with tempfile.TemporaryDirectory(prefix="loopx-extension-registry-") as raw_temp:
+    manifest = Path(raw_temp) / "extension.toml"
+    manifest.write_text(
+        """\
+schema_version = "loopx_extension_manifest_v0"
+id = "example-extension"
+version = "1.0.0"
+requires_loopx_api = ">=1,<2"
+permissions = ["read_status"]
+
+[[provides]]
+id = "example-report"
+kind = "projection_sink"
+title = "Example report"
+status = "active"
+visibility = "public"
+real_world_anchor = "public smoke fixture"
+user_value = "Prove explicit extension composition."
+entry_command = "example-extension report"
+next_real_step = "Keep explicit enablement bounded."
+""",
+        encoding="utf-8",
+    )
+
+    baseline = run_cli("capability", "list")
+    assert [item["id"] for item in baseline["capabilities"]] == [
+        "issue-fix",
+        "semantic-preference",
+        "reward-memory",
+        "content-ops",
+        "value-connectors",
+    ]
+    assert all(item["provider_id"] == "loopx-core" for item in baseline["capabilities"])
+
+    composed = run_cli(
+        "capability",
+        "list",
+        "--extension-manifest",
+        str(manifest),
+    )
+    assert composed["capabilities"][-1]["id"] == "example-report"
+    assert composed["capabilities"][-1]["origin"] == "extension"
+    assert composed["providers"][-1]["id"] == "example-extension"
+
+    detail = run_cli(
+        "capability",
+        "show",
+        "example-report",
+        "--extension-manifest",
+        str(manifest),
+    )
+    assert detail["capability"]["capability_kind"] == "projection_sink"
+    assert detail["capability"]["provider_id"] == "example-extension"
+
+print("capability-extension-registry-smoke: ok")

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -1,16 +1,23 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
+from pathlib import Path
 from typing import Any
+
+from .registry import CapabilityRegistry
+from ..extensions.manifest import load_extension_manifest
 
 
 CAPABILITY_CATALOG_SCHEMA_VERSION = "loopx_capability_catalog_v0"
 CAPABILITY_DETAIL_SCHEMA_VERSION = "loopx_capability_detail_v0"
 
 
-CAPABILITIES: tuple[dict[str, Any], ...] = (
+BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
     {
         "id": "issue-fix",
+        "origin": "builtin",
+        "visibility": "public",
+        "provider_id": "loopx-core",
         "title": "Repo issue-fix loop",
         "status": "active-preview",
         "real_world_anchor": "open-source issue/PR solver",
@@ -210,6 +217,9 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
     },
     {
         "id": "semantic-preference",
+        "origin": "builtin",
+        "visibility": "public",
+        "provider_id": "loopx-core",
         "title": "Optional semantic preference hook",
         "status": "active-preview",
         "real_world_anchor": "provider-neutral preference recall before domain work",
@@ -287,6 +297,9 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
     },
     {
         "id": "reward-memory",
+        "origin": "builtin",
+        "visibility": "public",
+        "provider_id": "loopx-core",
         "title": "Reward-memory candidate, recall, and application foundation",
         "status": "active-preview",
         "real_world_anchor": (
@@ -484,6 +497,9 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
     },
     {
         "id": "content-ops",
+        "origin": "builtin",
+        "visibility": "public",
+        "provider_id": "loopx-core",
         "title": "Creator/content operations loop",
         "status": "active-preview",
         "real_world_anchor": "self-media operations and public/private source intake",
@@ -569,6 +585,9 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
     },
     {
         "id": "value-connectors",
+        "origin": "builtin",
+        "visibility": "public",
+        "provider_id": "loopx-core",
         "title": "External value connector starters",
         "status": "active-preview",
         "real_world_anchor": "external channel intake for revenue, cost, demand, and connector reuse",
@@ -667,12 +686,18 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
     },
 )
 
+# Preserve the original import surface while routing all reads through the registry.
+CAPABILITIES = BUILTIN_CAPABILITIES
+
 
 def _summary(record: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "id": record["id"],
         "title": record["title"],
         "status": record["status"],
+        "origin": record["origin"],
+        "visibility": record["visibility"],
+        "provider_id": record["provider_id"],
         "real_world_anchor": record["real_world_anchor"],
         "entry_command": record["entry_command"],
         "implemented_protocol_count": len(record.get("implemented_protocols") or []),
@@ -681,30 +706,66 @@ def _summary(record: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
-def capability_ids() -> list[str]:
-    return [str(record["id"]) for record in CAPABILITIES]
+def build_capability_registry(
+    extension_manifest_paths: Iterable[str | Path] = (),
+) -> CapabilityRegistry:
+    registry = CapabilityRegistry()
+    registry.register_provider(
+        {
+            "id": "loopx-core",
+            "origin": "builtin",
+            "enabled": True,
+        }
+    )
+    for record in BUILTIN_CAPABILITIES:
+        registry.register_capability(record)
+    for manifest_path in extension_manifest_paths:
+        manifest = load_extension_manifest(manifest_path)
+        registry.register_provider(manifest["provider"])
+        for record in manifest["capabilities"]:
+            registry.register_capability(record)
+    return registry
 
 
-def get_capability(capability_id: str) -> dict[str, Any]:
-    wanted = str(capability_id or "").strip()
-    for record in CAPABILITIES:
-        if record["id"] == wanted:
-            return dict(record)
-    raise ValueError(
-        f"unknown capability `{wanted}`; expected one of {capability_ids()}"
+def capability_ids(
+    extension_manifest_paths: Iterable[str | Path] = (),
+    *,
+    include_internal: bool = False,
+) -> list[str]:
+    return build_capability_registry(extension_manifest_paths).capability_ids(
+        include_internal=include_internal
     )
 
 
-def build_capability_catalog_packet() -> dict[str, Any]:
+def get_capability(
+    capability_id: str,
+    extension_manifest_paths: Iterable[str | Path] = (),
+    *,
+    include_internal: bool = False,
+) -> dict[str, Any]:
+    return build_capability_registry(extension_manifest_paths).get(
+        capability_id,
+        include_internal=include_internal,
+    )
+
+
+def build_capability_catalog_packet(
+    extension_manifest_paths: Iterable[str | Path] = (),
+) -> dict[str, Any]:
+    registry = build_capability_registry(extension_manifest_paths)
     return {
         "ok": True,
         "schema_version": CAPABILITY_CATALOG_SCHEMA_VERSION,
-        "capabilities": [_summary(record) for record in CAPABILITIES],
+        "capabilities": [_summary(record) for record in registry.records()],
+        "providers": registry.providers(),
     }
 
 
-def build_capability_detail_packet(capability_id: str) -> dict[str, Any]:
-    record = get_capability(capability_id)
+def build_capability_detail_packet(
+    capability_id: str,
+    extension_manifest_paths: Iterable[str | Path] = (),
+) -> dict[str, Any]:
+    record = get_capability(capability_id, extension_manifest_paths)
     return {
         "ok": True,
         "schema_version": CAPABILITY_DETAIL_SCHEMA_VERSION,
@@ -722,6 +783,8 @@ def render_capability_catalog_markdown(payload: dict[str, Any]) -> str:
                 f"## {item.get('id')}: {item.get('title')}",
                 "",
                 f"- status: `{item.get('status')}`",
+                f"- provider: `{item.get('provider_id')}` ({item.get('origin')})",
+                f"- visibility: `{item.get('visibility')}`",
                 f"- anchor: {item.get('real_world_anchor')}",
                 f"- entry: `{item.get('entry_command')}`",
                 f"- implemented_protocol_count: `{item.get('implemented_protocol_count')}`",
@@ -742,6 +805,8 @@ def render_capability_detail_markdown(payload: dict[str, Any]) -> str:
         "",
         f"- id: `{record.get('id')}`",
         f"- status: `{record.get('status')}`",
+        f"- provider: `{record.get('provider_id')}` ({record.get('origin')})",
+        f"- visibility: `{record.get('visibility')}`",
         f"- anchor: {record.get('real_world_anchor')}",
         f"- value: {record.get('user_value')}",
         f"- entry: `{record.get('entry_command')}`",

--- a/loopx/capabilities/registry.py
+++ b/loopx/capabilities/registry.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+from typing import Any
+
+
+CAPABILITY_ORIGINS = frozenset({"builtin", "extension"})
+CAPABILITY_VISIBILITIES = frozenset({"public", "internal"})
+REQUIRED_CAPABILITY_FIELDS = (
+    "id",
+    "title",
+    "status",
+    "user_value",
+    "next_real_step",
+)
+REQUIRED_PUBLIC_CAPABILITY_FIELDS = ("real_world_anchor", "entry_command")
+
+
+def _required_string(record: Mapping[str, Any], key: str, *, context: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{context} requires non-empty string `{key}`")
+    return value.strip()
+
+
+class CapabilityRegistry:
+    """Compose capability records from built-in and enabled extension providers."""
+
+    def __init__(self) -> None:
+        self._providers: dict[str, dict[str, Any]] = {}
+        self._records: dict[str, dict[str, Any]] = {}
+
+    def register_provider(self, provider: Mapping[str, Any]) -> None:
+        provider_id = _required_string(provider, "id", context="provider")
+        origin = _required_string(
+            provider, "origin", context=f"provider `{provider_id}`"
+        )
+        if origin not in CAPABILITY_ORIGINS:
+            raise ValueError(
+                f"provider `{provider_id}` has unsupported origin `{origin}`; "
+                f"expected one of {sorted(CAPABILITY_ORIGINS)}"
+            )
+        if provider_id in self._providers:
+            raise ValueError(f"duplicate capability provider `{provider_id}`")
+        normalized = deepcopy(dict(provider))
+        normalized["id"] = provider_id
+        normalized["origin"] = origin
+        normalized["enabled"] = bool(provider.get("enabled", True))
+        self._providers[provider_id] = normalized
+
+    def register_capability(self, record: Mapping[str, Any]) -> None:
+        capability_id = _required_string(record, "id", context="capability")
+        context = f"capability `{capability_id}`"
+        for key in REQUIRED_CAPABILITY_FIELDS:
+            _required_string(record, key, context=context)
+
+        origin = _required_string(record, "origin", context=context)
+        if origin not in CAPABILITY_ORIGINS:
+            raise ValueError(
+                f"{context} has unsupported origin `{origin}`; "
+                f"expected one of {sorted(CAPABILITY_ORIGINS)}"
+            )
+        visibility = _required_string(record, "visibility", context=context)
+        if visibility not in CAPABILITY_VISIBILITIES:
+            raise ValueError(
+                f"{context} has unsupported visibility `{visibility}`; "
+                f"expected one of {sorted(CAPABILITY_VISIBILITIES)}"
+            )
+        if visibility == "public":
+            for key in REQUIRED_PUBLIC_CAPABILITY_FIELDS:
+                _required_string(record, key, context=context)
+        provider_id = _required_string(record, "provider_id", context=context)
+        provider = self._providers.get(provider_id)
+        if provider is None:
+            raise ValueError(f"{context} references unknown provider `{provider_id}`")
+        if provider["origin"] != origin:
+            raise ValueError(
+                f"{context} origin `{origin}` does not match provider "
+                f"`{provider_id}` origin `{provider['origin']}`"
+            )
+        if capability_id in self._records:
+            previous = self._records[capability_id]
+            raise ValueError(
+                f"duplicate capability `{capability_id}` from providers "
+                f"`{previous['provider_id']}` and `{provider_id}`"
+            )
+
+        normalized = deepcopy(dict(record))
+        normalized["id"] = capability_id
+        normalized["origin"] = origin
+        normalized["visibility"] = visibility
+        normalized["provider_id"] = provider_id
+        self._records[capability_id] = normalized
+
+    def capability_ids(self, *, include_internal: bool = False) -> list[str]:
+        return [
+            capability_id
+            for capability_id, record in self._records.items()
+            if include_internal or record["visibility"] == "public"
+        ]
+
+    def get(
+        self,
+        capability_id: str,
+        *,
+        include_internal: bool = False,
+    ) -> dict[str, Any]:
+        wanted = str(capability_id or "").strip()
+        record = self._records.get(wanted)
+        if record is None or (
+            record["visibility"] == "internal" and not include_internal
+        ):
+            raise ValueError(
+                f"unknown capability `{wanted}`; expected one of "
+                f"{self.capability_ids(include_internal=include_internal)}"
+            )
+        return deepcopy(record)
+
+    def records(self, *, include_internal: bool = False) -> list[dict[str, Any]]:
+        return [
+            deepcopy(record)
+            for record in self._records.values()
+            if include_internal or record["visibility"] == "public"
+        ]
+
+    def providers(self) -> list[dict[str, Any]]:
+        return [deepcopy(provider) for provider in self._providers.values()]

--- a/loopx/cli_commands/capability.py
+++ b/loopx/cli_commands/capability.py
@@ -6,7 +6,6 @@ from collections.abc import Callable
 from ..capabilities.catalog import (
     build_capability_catalog_packet,
     build_capability_detail_packet,
-    capability_ids,
     render_capability_catalog_markdown,
     render_capability_detail_markdown,
 )
@@ -18,6 +17,19 @@ PrintPayload = Callable[
 ]
 FormatSelector = Callable[..., str]
 AddFormat = Callable[[argparse.ArgumentParser], None]
+
+
+def _add_extension_manifest_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--extension-manifest",
+        action="append",
+        default=[],
+        help=(
+            "Explicitly enable one declarative extension manifest for this "
+            "catalog read. Repeat for multiple manifests."
+        ),
+    )
+    parser.set_defaults(capability_operation_parser=parser)
 
 
 def register_capability_commands(
@@ -37,6 +49,7 @@ def register_capability_commands(
         help="List implemented product capability paths.",
     )
     add_subcommand_format(list_parser)
+    _add_extension_manifest_argument(list_parser)
     show_parser = capability_sub.add_parser(
         "show",
         help="Show CLI, protocol, smoke, and boundary details for a capability.",
@@ -44,9 +57,9 @@ def register_capability_commands(
     add_subcommand_format(show_parser)
     show_parser.add_argument(
         "capability_id",
-        choices=capability_ids(),
         help="Capability id to inspect.",
     )
+    _add_extension_manifest_argument(show_parser)
 
 
 def handle_capability_command(
@@ -57,13 +70,20 @@ def handle_capability_command(
 ) -> int | None:
     if args.command != "capability":
         return None
-    if args.capability_command == "list":
-        payload = build_capability_catalog_packet()
-        renderer = render_capability_catalog_markdown
-    elif args.capability_command == "show":
-        payload = build_capability_detail_packet(args.capability_id)
-        renderer = render_capability_detail_markdown
-    else:
-        raise ValueError("capability requires `list` or `show`")
+    manifest_paths = tuple(args.extension_manifest)
+    try:
+        if args.capability_command == "list":
+            payload = build_capability_catalog_packet(manifest_paths)
+            renderer = render_capability_catalog_markdown
+        elif args.capability_command == "show":
+            payload = build_capability_detail_packet(
+                args.capability_id,
+                manifest_paths,
+            )
+            renderer = render_capability_detail_markdown
+        else:
+            raise ValueError("capability requires `list` or `show`")
+    except ValueError as exc:
+        args.capability_operation_parser.error(str(exc))
     print_payload(payload, output_format(args), renderer)
     return 0

--- a/loopx/extensions/__init__.py
+++ b/loopx/extensions/__init__.py
@@ -1,0 +1,1 @@
+"""Extension manifests and lifecycle-facing registration helpers."""

--- a/loopx/extensions/manifest.py
+++ b/loopx/extensions/manifest.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+import re
+import tomllib
+from typing import Any
+
+
+EXTENSION_MANIFEST_SCHEMA_VERSION = "loopx_extension_manifest_v0"
+LOOPX_EXTENSION_API_VERSION = 1
+_API_CLAUSE = re.compile(r"^(>=|<=|==|>|<)?\s*(\d+)$")
+
+
+def _required_string(record: Mapping[str, Any], key: str, *, context: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{context} requires non-empty string `{key}`")
+    return value.strip()
+
+
+def _string_list(record: Mapping[str, Any], key: str, *, context: str) -> list[str]:
+    value = record.get(key, [])
+    if not isinstance(value, list) or any(
+        not isinstance(item, str) or not item.strip() for item in value
+    ):
+        raise ValueError(f"{context} requires `{key}` to be an array of strings")
+    return [item.strip() for item in value]
+
+
+def _require_compatible_loopx_api(requirement: str, *, context: str) -> None:
+    clauses = [clause.strip() for clause in requirement.split(",")]
+    if not clauses or any(not clause for clause in clauses):
+        raise ValueError(f"{context} has invalid `requires_loopx_api` `{requirement}`")
+    comparisons = {
+        ">=": lambda wanted: LOOPX_EXTENSION_API_VERSION >= wanted,
+        "<=": lambda wanted: LOOPX_EXTENSION_API_VERSION <= wanted,
+        "==": lambda wanted: LOOPX_EXTENSION_API_VERSION == wanted,
+        ">": lambda wanted: LOOPX_EXTENSION_API_VERSION > wanted,
+        "<": lambda wanted: LOOPX_EXTENSION_API_VERSION < wanted,
+    }
+    for clause in clauses:
+        match = _API_CLAUSE.fullmatch(clause)
+        if match is None:
+            raise ValueError(
+                f"{context} has invalid `requires_loopx_api` clause `{clause}`; "
+                "expected integer constraints such as `>=1,<2`"
+            )
+        operator = match.group(1) or "=="
+        wanted = int(match.group(2))
+        if not comparisons[operator](wanted):
+            raise ValueError(
+                f"{context} requires LoopX extension API `{requirement}`, "
+                f"but this runtime provides `{LOOPX_EXTENSION_API_VERSION}`"
+            )
+
+
+def load_extension_manifest(path: str | Path) -> dict[str, Any]:
+    """Read one declarative manifest without importing extension code."""
+
+    manifest_path = Path(path).expanduser()
+    try:
+        raw = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise ValueError(
+            f"cannot read extension manifest `{manifest_path}`: {exc}"
+        ) from exc
+    if not isinstance(raw, Mapping):
+        raise ValueError(
+            f"extension manifest `{manifest_path}` must contain a TOML table"
+        )
+
+    context = f"extension manifest `{manifest_path}`"
+    schema_version = _required_string(raw, "schema_version", context=context)
+    if schema_version != EXTENSION_MANIFEST_SCHEMA_VERSION:
+        raise ValueError(
+            f"{context} has unsupported schema_version `{schema_version}`; "
+            f"expected `{EXTENSION_MANIFEST_SCHEMA_VERSION}`"
+        )
+    extension_id = _required_string(raw, "id", context=context)
+    version = _required_string(raw, "version", context=context)
+    requires_loopx_api = _required_string(raw, "requires_loopx_api", context=context)
+    _require_compatible_loopx_api(requires_loopx_api, context=context)
+    permissions = _string_list(raw, "permissions", context=context)
+    provided = raw.get("provides")
+    if not isinstance(provided, list) or not provided:
+        raise ValueError(f"{context} requires at least one `[[provides]]` table")
+
+    capabilities: list[dict[str, Any]] = []
+    for index, item in enumerate(provided):
+        item_context = f"{context} provides[{index}]"
+        if not isinstance(item, Mapping):
+            raise ValueError(f"{item_context} must be a TOML table")
+        capability = dict(item)
+        capability["id"] = _required_string(item, "id", context=item_context)
+        capability["capability_kind"] = _required_string(
+            item,
+            "kind",
+            context=item_context,
+        )
+        capability["origin"] = "extension"
+        capability["visibility"] = str(item.get("visibility", "public")).strip()
+        capability["provider_id"] = extension_id
+        capability["provider_version"] = version
+        capabilities.append(capability)
+
+    return {
+        "provider": {
+            "id": extension_id,
+            "origin": "extension",
+            "enabled": True,
+            "version": version,
+            "requires_loopx_api": requires_loopx_api,
+            "permissions": permissions,
+        },
+        "capabilities": capabilities,
+    }

--- a/tests/capabilities/test_capability_extension_registry.py
+++ b/tests/capabilities/test_capability_extension_registry.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from loopx.capabilities.catalog import (
+    build_capability_catalog_packet,
+    build_capability_detail_packet,
+    build_capability_registry,
+)
+from loopx.cli import main
+
+
+BUILTIN_IDS = [
+    "issue-fix",
+    "semantic-preference",
+    "reward-memory",
+    "content-ops",
+    "value-connectors",
+]
+
+
+def _write_manifest(path: Path, *, capability_id: str = "sample-report") -> Path:
+    path.write_text(
+        f'''\
+schema_version = "loopx_extension_manifest_v0"
+id = "sample-extension"
+version = "1.2.3"
+requires_loopx_api = ">=1,<2"
+permissions = ["read_status"]
+runtime_entrypoint = "module.that.must.not.be.imported"
+
+[[provides]]
+id = "{capability_id}"
+kind = "projection_sink"
+title = "Sample report"
+status = "active"
+visibility = "public"
+real_world_anchor = "deterministic extension fixture"
+user_value = "Prove provider-aware capability composition."
+entry_command = "sample-extension report"
+next_real_step = "Keep the fixture bounded."
+
+[[provides]]
+id = "sample-internal-helper"
+kind = "provider_helper"
+title = "Sample internal helper"
+status = "internal"
+visibility = "internal"
+real_world_anchor = "extension implementation detail"
+user_value = "Remain hidden from the public catalog."
+entry_command = ""
+next_real_step = "Remain internal."
+''',
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_builtin_catalog_preserves_order_and_marks_provider() -> None:
+    packet = build_capability_catalog_packet()
+
+    assert packet["schema_version"] == "loopx_capability_catalog_v0"
+    assert [item["id"] for item in packet["capabilities"]] == BUILTIN_IDS
+    for item in packet["capabilities"]:
+        assert item["origin"] == "builtin"
+        assert item["visibility"] == "public"
+        assert item["provider_id"] == "loopx-core"
+    assert packet["providers"] == [
+        {"id": "loopx-core", "origin": "builtin", "enabled": True}
+    ]
+
+
+def test_enabled_manifest_composes_public_capability_without_importing_code(
+    tmp_path: Path,
+) -> None:
+    manifest = _write_manifest(tmp_path / "extension.toml")
+
+    packet = build_capability_catalog_packet([manifest])
+    assert [item["id"] for item in packet["capabilities"]] == [
+        *BUILTIN_IDS,
+        "sample-report",
+    ]
+    extension = packet["capabilities"][-1]
+    assert extension["origin"] == "extension"
+    assert extension["visibility"] == "public"
+    assert extension["provider_id"] == "sample-extension"
+    assert packet["providers"][-1] == {
+        "id": "sample-extension",
+        "origin": "extension",
+        "enabled": True,
+        "version": "1.2.3",
+        "requires_loopx_api": ">=1,<2",
+        "permissions": ["read_status"],
+    }
+
+    detail = build_capability_detail_packet("sample-report", [manifest])
+    assert detail["capability"]["capability_kind"] == "projection_sink"
+    assert detail["capability"]["provider_version"] == "1.2.3"
+
+
+def test_internal_capability_is_registered_but_not_publicly_listed(
+    tmp_path: Path,
+) -> None:
+    manifest = _write_manifest(tmp_path / "extension.toml")
+    registry = build_capability_registry([manifest])
+
+    assert "sample-internal-helper" not in registry.capability_ids()
+    assert "sample-internal-helper" in registry.capability_ids(include_internal=True)
+    assert (
+        registry.get("sample-internal-helper", include_internal=True)["visibility"]
+        == "internal"
+    )
+
+
+def test_duplicate_capability_fails_closed(tmp_path: Path) -> None:
+    manifest = _write_manifest(
+        tmp_path / "extension.toml",
+        capability_id="value-connectors",
+    )
+
+    with pytest.raises(ValueError, match="duplicate capability `value-connectors`"):
+        build_capability_catalog_packet([manifest])
+
+
+def test_incompatible_extension_api_fails_closed(tmp_path: Path) -> None:
+    manifest = _write_manifest(tmp_path / "extension.toml")
+    manifest.write_text(
+        manifest.read_text(encoding="utf-8").replace(
+            'requires_loopx_api = ">=1,<2"',
+            'requires_loopx_api = ">=2,<3"',
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="requires LoopX extension API"):
+        build_capability_catalog_packet([manifest])
+
+
+def test_cli_lists_and_shows_explicit_extension_manifest(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    manifest = _write_manifest(tmp_path / "extension.toml")
+
+    assert (
+        main(
+            [
+                "--format",
+                "json",
+                "capability",
+                "list",
+                "--extension-manifest",
+                str(manifest),
+            ]
+        )
+        == 0
+    )
+    listed = json.loads(capsys.readouterr().out)
+    assert listed["capabilities"][-1]["id"] == "sample-report"
+
+    assert (
+        main(
+            [
+                "--format",
+                "json",
+                "capability",
+                "show",
+                "sample-report",
+                "--extension-manifest",
+                str(manifest),
+            ]
+        )
+        == 0
+    )
+    shown = json.loads(capsys.readouterr().out)
+    assert shown["capability"]["provider_id"] == "sample-extension"
+
+
+def test_cli_rejects_unknown_capability_without_traceback(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["capability", "show", "not-registered"])
+
+    assert exc_info.value.code == 2
+    assert "unknown capability `not-registered`" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- keep capability contracts distinct from extension delivery lifecycle
- compose the existing built-in catalog with explicitly enabled TOML extension manifests
- expose origin, visibility, and provider identity while preserving existing capability order and v0 CLI fields
- fail closed on duplicate ids, incompatible extension API ranges, malformed manifests, and internal-only public reads
- document the boundary without moving existing capability directories or adding an installer

## Validation

- `510 passed, 2 skipped`
- `python3 examples/capability-extension-registry-smoke.py`
- changed-file Ruff check and format check
- wheel build/install readback includes `loopx.capabilities.registry` and `loopx.extensions.manifest`
- `loopx canary premerge --from-git-diff --tier standard`: 13/13 selected checks passed, 0 warnings
- public/private boundary scan: 9 changed files clean

## Holds

- No manual holds from premerge canary.
- Runtime/API change: requesting independent review; no self-merge.