### PR TITLE
fix(scheduler): scope cadence to runtime owner

### DIFF
--- a/loopx/benchmark_adapters/skillsbench_turn_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_runtime.py
@@ -248,25 +248,23 @@ def run_skillsbench_loopx_turn(
         command = (
             f"{prefix} quota should-run "
             f"--goal-id {shlex.quote(config.goal_id)} "
-            f"--agent-id {shlex.quote(config.agent_id)}"
+            f"--agent-id {shlex.quote(config.agent_id)} "
+            "--host-surface generic_cli "
+            "--scheduler-owner outer_controller "
+            "--execution-mode isolated_headless"
         )
         payload = bridge.loopx_json(command)
         hint = payload.get("scheduler_hint")
         hint = hint if isinstance(hint, dict) else {}
-        codex_app = hint.get("codex_app")
-        codex_app = codex_app if isinstance(codex_app, dict) else {}
-        backoff = codex_app.get("stateful_backoff")
-        backoff = backoff if isinstance(backoff, dict) else {}
-        codex_app_apply_needed = backoff.get("apply_needed") is True
-        # BenchFlow owns the next prompt; a case-local Codex App cadence hint is
-        # observational and must not strand a generic Agent CLI Turn receipt.
-        return {
-            "disposition": "outer_benchmark_controller",
-            "completed": True,
-            "acknowledged": False,
-            "apply_needed": False,
-            "codex_app_apply_needed_observed": codex_app_apply_needed,
-        }
+        phase = hint.get("execution_phase")
+        if not isinstance(phase, dict):
+            return {
+                "disposition": "contract_error",
+                "completed": False,
+                "acknowledged": False,
+                "apply_needed": False,
+            }
+        return dict(phase)
 
     execution = run_loopx_turn_once(
         plan,

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -104,6 +104,21 @@ def register_quota_command(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
     quota_parser.add_argument(
+        "--host-surface",
+        choices=["codex_app", "codex_cli", "generic_cli", "claude_code", "local_scheduler"],
+        help="Host surface that will consume this scheduler projection.",
+    )
+    quota_parser.add_argument(
+        "--scheduler-owner",
+        choices=["host_automation", "agent_cli_loop", "outer_controller", "none"],
+        help="Runtime that owns the next cadence decision.",
+    )
+    quota_parser.add_argument(
+        "--execution-mode",
+        choices=["interactive", "isolated_headless", "hosted_automation"],
+        help="Execution mode paired with --host-surface and --scheduler-owner.",
+    )
+    quota_parser.add_argument(
         "--turn-envelope",
         action="store_true",
         help=(
@@ -248,6 +263,16 @@ def handle_quota_command(
         if args.quota_command == "should-run":
             if not args.goal_id:
                 raise ValueError("`loopx quota should-run` requires --goal-id")
+            scheduler_context = (
+                {
+                    "host_surface": args.host_surface,
+                    "scheduler_owner": args.scheduler_owner,
+                    "execution_mode": args.execution_mode,
+                    "source": "quota_cli_invocation",
+                }
+                if any((args.host_surface, args.scheduler_owner, args.execution_mode))
+                else None
+            )
             payload = build_live_quota_should_run_decision(
                 status_payload,
                 goal_id=args.goal_id,
@@ -258,6 +283,7 @@ def handle_quota_command(
                 registry_path=registry_path,
                 runtime_root=runtime_root,
                 host_observation_resolver=resolve_codex_app_automation_rrule,
+                scheduler_execution_context=scheduler_context,
             )
         elif args.quota_command == "monitor-poll":
             if not args.goal_id:

--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -15,6 +15,9 @@ from ..control_plane.turn_driver import (
     run_codex_cli_host,
     run_loopx_turn_once,
 )
+from ..control_plane.scheduler.execution_context import (
+    scheduler_execution_context_for_turn,
+)
 from ..control_plane.quota.live_decision import build_live_quota_should_run_decision
 from ..control_plane.quota.turn_envelope import build_turn_envelope
 from ..control_plane.runtime.status_projection_cache import (
@@ -191,6 +194,14 @@ def _add_turn_decision_arguments(
         default=default_execution_mode,
     )
     parser.add_argument(
+        "--scheduler-owner",
+        choices=["host_automation", "agent_cli_loop", "outer_controller", "none"],
+        help=(
+            "Cadence owner; defaults to outer_controller for generic-cli and "
+            "agent_cli_loop otherwise."
+        ),
+    )
+    parser.add_argument(
         "--resume-goal-id",
         help="Goal identity bound to an available opaque host session.",
     )
@@ -274,6 +285,11 @@ def handle_turn_command(
             scan_roots=scan_roots,
             limit=max(max(0, args.limit), AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK),
         )
+        scheduler_context = scheduler_execution_context_for_turn(
+            host=args.host,
+            execution_mode=args.execution_mode,
+            scheduler_owner=args.scheduler_owner,
+        )
         decision = build_live_quota_should_run_decision(
             status_payload,
             goal_id=args.goal_id,
@@ -284,6 +300,7 @@ def handle_turn_command(
             registry_path=registry_path,
             runtime_root=runtime_root,
             route_source="loopx_turn_plan",
+            scheduler_execution_context=scheduler_context,
         )
         resume_identity = {
             "goal_id": args.resume_goal_id,
@@ -313,6 +330,7 @@ def handle_turn_command(
             turn_envelope,
             host=args.host,
             execution_mode=args.execution_mode,
+            scheduler_owner=args.scheduler_owner,
             session_binding=session_binding,
         )
         if args.turn_command == "plan":
@@ -441,6 +459,11 @@ def handle_turn_command(
                 )
 
             def scheduler(_spend_payload: dict[str, object]) -> dict[str, object]:
+                turn_scheduler_context = (
+                    payload.get("scheduler_execution_context")
+                    if isinstance(payload.get("scheduler_execution_context"), dict)
+                    else None
+                )
                 latest = build_live_quota_should_run_decision(
                     current_status(),
                     goal_id=args.goal_id,
@@ -451,26 +474,15 @@ def handle_turn_command(
                     registry_path=registry_path,
                     runtime_root=runtime_root,
                     route_source="loopx_turn_run_once",
+                    scheduler_execution_context=turn_scheduler_context,
                 )
                 hint = latest.get("scheduler_hint") if isinstance(latest.get("scheduler_hint"), dict) else {}
-                codex_app = hint.get("codex_app") if isinstance(hint.get("codex_app"), dict) else {}
-                backoff = codex_app.get("stateful_backoff") if isinstance(codex_app.get("stateful_backoff"), dict) else {}
-                apply_needed = backoff.get("apply_needed") is True
-                return {
-                    "disposition": "host_action_required" if apply_needed else "not_required",
-                    "completed": not apply_needed,
+                phase = hint.get("execution_phase")
+                return dict(phase) if isinstance(phase, dict) else {
+                    "disposition": "contract_error",
+                    "completed": False,
                     "acknowledged": False,
-                    "apply_needed": apply_needed,
-                    **(
-                        {
-                            "recommended_interval_minutes": codex_app.get(
-                                "recommended_interval_minutes"
-                            ),
-                            "ack_hint": codex_app.get("ack_hint"),
-                        }
-                        if apply_needed
-                        else {}
-                    ),
+                    "apply_needed": False,
                 }
 
             host_runner = None

--- a/loopx/control_plane/quota/live_decision.py
+++ b/loopx/control_plane/quota/live_decision.py
@@ -5,6 +5,10 @@ from pathlib import Path
 from typing import Any
 
 from ...quota import build_quota_should_run
+from ..scheduler.execution_context import (
+    SchedulerExecutionContextResolution,
+    resolve_scheduler_execution_context,
+)
 
 
 HostObservationResolver = Callable[..., Mapping[str, Any]]
@@ -63,11 +67,22 @@ def build_live_quota_should_run_decision(
     runtime_root: Path,
     host_observation_resolver: HostObservationResolver | None = None,
     route_source: str = "quota_cli_invocation",
+    scheduler_execution_context: Mapping[str, Any] | SchedulerExecutionContextResolution | None = None,
 ) -> dict[str, Any]:
     """Build one live CLI decision while keeping host observation injectable."""
 
+    resolved_context = resolve_scheduler_execution_context(scheduler_execution_context)
+    codex_app_applicable = (
+        resolved_context.ok
+        and resolved_context.context is not None
+        and resolved_context.context.codex_app_applicable
+    )
     observed_rrule = str(codex_app_current_rrule or "").strip()
-    if not observed_rrule and host_observation_resolver is not None:
+    if (
+        codex_app_applicable
+        and not observed_rrule
+        and host_observation_resolver is not None
+    ):
         observation = host_observation_resolver(goal_id=goal_id, agent_id=agent_id)
         if observation.get("available") is True:
             observed_rrule = str(observation.get("rrule") or "")
@@ -78,6 +93,7 @@ def build_live_quota_should_run_decision(
         available_capabilities=available_capabilities,
         include_scheduler_detail=include_scheduler_detail,
         codex_app_current_rrule=observed_rrule,
+        scheduler_execution_context=resolved_context,
     )
     bind_scheduler_followup_cli_routes(
         payload,

--- a/loopx/control_plane/scheduler/execution_context.py
+++ b/loopx/control_plane/scheduler/execution_context.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+SCHEDULER_EXECUTION_CONTEXT_SCHEMA_VERSION = "scheduler_execution_context_v0"
+
+
+class HostSurface(str, Enum):
+    CODEX_APP = "codex_app"
+    CODEX_CLI = "codex_cli"
+    GENERIC_CLI = "generic_cli"
+    CLAUDE_CODE = "claude_code"
+    LOCAL_SCHEDULER = "local_scheduler"
+
+
+class SchedulerOwner(str, Enum):
+    HOST_AUTOMATION = "host_automation"
+    AGENT_CLI_LOOP = "agent_cli_loop"
+    OUTER_CONTROLLER = "outer_controller"
+    NONE = "none"
+
+
+class ExecutionMode(str, Enum):
+    INTERACTIVE = "interactive"
+    ISOLATED_HEADLESS = "isolated_headless"
+    HOSTED_AUTOMATION = "hosted_automation"
+
+
+@dataclass(frozen=True)
+class SchedulerExecutionContext:
+    host_surface: HostSurface
+    scheduler_owner: SchedulerOwner
+    execution_mode: ExecutionMode
+    source: str
+
+    @property
+    def codex_app_applicable(self) -> bool:
+        return (
+            self.host_surface is HostSurface.CODEX_APP
+            and self.scheduler_owner is SchedulerOwner.HOST_AUTOMATION
+            and self.execution_mode is ExecutionMode.HOSTED_AUTOMATION
+        )
+
+    def projection(self) -> dict[str, Any]:
+        return {
+            "schema_version": SCHEDULER_EXECUTION_CONTEXT_SCHEMA_VERSION,
+            "host_surface": self.host_surface.value,
+            "scheduler_owner": self.scheduler_owner.value,
+            "execution_mode": self.execution_mode.value,
+            "source": self.source,
+            "valid": True,
+            "codex_app_applicability": (
+                "applicable" if self.codex_app_applicable else "not_applicable"
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class SchedulerExecutionContextResolution:
+    context: SchedulerExecutionContext | None
+    errors: tuple[str, ...] = ()
+    supplied: Mapping[str, Any] | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.context is not None and not self.errors
+
+    def projection(self) -> dict[str, Any]:
+        if self.context is not None:
+            return self.context.projection()
+        supplied = dict(self.supplied or {})
+        return {
+            "schema_version": SCHEDULER_EXECUTION_CONTEXT_SCHEMA_VERSION,
+            "host_surface": supplied.get("host_surface"),
+            "scheduler_owner": supplied.get("scheduler_owner"),
+            "execution_mode": supplied.get("execution_mode"),
+            "source": supplied.get("source") or "explicit",
+            "valid": False,
+            "codex_app_applicability": "blocked_invalid_context",
+            "errors": list(self.errors),
+        }
+
+
+def _validation_errors(context: SchedulerExecutionContext) -> list[str]:
+    errors: list[str] = []
+    cli_surfaces = {
+        HostSurface.CODEX_CLI,
+        HostSurface.GENERIC_CLI,
+        HostSurface.CLAUDE_CODE,
+    }
+    if context.host_surface is HostSurface.CODEX_APP:
+        if context.scheduler_owner is not SchedulerOwner.HOST_AUTOMATION:
+            errors.append("codex_app requires scheduler_owner=host_automation")
+        if context.execution_mode is not ExecutionMode.HOSTED_AUTOMATION:
+            errors.append("codex_app requires execution_mode=hosted_automation")
+    if context.host_surface is HostSurface.LOCAL_SCHEDULER:
+        if context.scheduler_owner is not SchedulerOwner.HOST_AUTOMATION:
+            errors.append("local_scheduler requires scheduler_owner=host_automation")
+        if context.execution_mode is not ExecutionMode.HOSTED_AUTOMATION:
+            errors.append("local_scheduler requires execution_mode=hosted_automation")
+    if (
+        context.host_surface in cli_surfaces
+        and context.scheduler_owner is SchedulerOwner.HOST_AUTOMATION
+    ):
+        errors.append("CLI host surfaces cannot be owned by host_automation")
+    if context.scheduler_owner is SchedulerOwner.OUTER_CONTROLLER:
+        if context.host_surface not in cli_surfaces:
+            errors.append("outer_controller requires a CLI host surface")
+        if context.execution_mode is not ExecutionMode.ISOLATED_HEADLESS:
+            errors.append("outer_controller requires execution_mode=isolated_headless")
+    if context.scheduler_owner is SchedulerOwner.NONE:
+        if context.host_surface not in cli_surfaces:
+            errors.append("scheduler_owner=none requires a CLI host surface")
+        if context.execution_mode is not ExecutionMode.INTERACTIVE:
+            errors.append("scheduler_owner=none requires execution_mode=interactive")
+    if context.scheduler_owner is SchedulerOwner.AGENT_CLI_LOOP:
+        if context.host_surface not in cli_surfaces:
+            errors.append("agent_cli_loop requires a CLI host surface")
+        if context.execution_mode is ExecutionMode.HOSTED_AUTOMATION:
+            errors.append("agent_cli_loop cannot use execution_mode=hosted_automation")
+    if (
+        context.execution_mode is ExecutionMode.HOSTED_AUTOMATION
+        and context.scheduler_owner is not SchedulerOwner.HOST_AUTOMATION
+    ):
+        errors.append("hosted_automation requires scheduler_owner=host_automation")
+    return errors
+
+
+def resolve_scheduler_execution_context(
+    value: Mapping[str, Any] | SchedulerExecutionContextResolution | None,
+) -> SchedulerExecutionContextResolution:
+    if isinstance(value, SchedulerExecutionContextResolution):
+        return value
+    if value is None:
+        context = SchedulerExecutionContext(
+            host_surface=HostSurface.CODEX_APP,
+            scheduler_owner=SchedulerOwner.HOST_AUTOMATION,
+            execution_mode=ExecutionMode.HOSTED_AUTOMATION,
+            source="compatibility_default",
+        )
+        return SchedulerExecutionContextResolution(context=context)
+
+    supplied = dict(value)
+    missing = [
+        field
+        for field in ("host_surface", "scheduler_owner", "execution_mode")
+        if not str(supplied.get(field) or "").strip()
+    ]
+    errors = [f"missing required field: {field}" for field in missing]
+    try:
+        host_surface = HostSurface(str(supplied.get("host_surface") or ""))
+    except ValueError:
+        host_surface = None
+        if "host_surface" not in missing:
+            errors.append("unsupported host_surface")
+    try:
+        scheduler_owner = SchedulerOwner(str(supplied.get("scheduler_owner") or ""))
+    except ValueError:
+        scheduler_owner = None
+        if "scheduler_owner" not in missing:
+            errors.append("unsupported scheduler_owner")
+    try:
+        execution_mode = ExecutionMode(str(supplied.get("execution_mode") or ""))
+    except ValueError:
+        execution_mode = None
+        if "execution_mode" not in missing:
+            errors.append("unsupported execution_mode")
+    if errors:
+        return SchedulerExecutionContextResolution(
+            context=None,
+            errors=tuple(errors),
+            supplied=supplied,
+        )
+    context = SchedulerExecutionContext(
+        host_surface=host_surface,
+        scheduler_owner=scheduler_owner,
+        execution_mode=execution_mode,
+        source=str(supplied.get("source") or "explicit"),
+    )
+    errors = _validation_errors(context)
+    return SchedulerExecutionContextResolution(
+        context=context if not errors else None,
+        errors=tuple(errors),
+        supplied=supplied,
+    )
+
+
+def scheduler_execution_context_for_turn(
+    *,
+    host: str,
+    execution_mode: str,
+    scheduler_owner: str | None = None,
+) -> SchedulerExecutionContextResolution:
+    host_surface = {
+        "codex-cli": HostSurface.CODEX_CLI.value,
+        "generic-cli": HostSurface.GENERIC_CLI.value,
+        "claude-code": HostSurface.CLAUDE_CODE.value,
+    }.get(host, host)
+    normalized_mode = {
+        "interactive-visible": ExecutionMode.INTERACTIVE.value,
+        "isolated-headless": ExecutionMode.ISOLATED_HEADLESS.value,
+    }.get(execution_mode, execution_mode)
+    owner = scheduler_owner or (
+        SchedulerOwner.OUTER_CONTROLLER.value
+        if host_surface == HostSurface.GENERIC_CLI.value
+        else SchedulerOwner.AGENT_CLI_LOOP.value
+    )
+    return resolve_scheduler_execution_context(
+        {
+            "host_surface": host_surface,
+            "scheduler_owner": owner,
+            "execution_mode": normalized_mode,
+            "source": "loopx_turn",
+        }
+    )
+
+
+def apply_scheduler_execution_context(
+    result: dict[str, Any],
+    resolution: SchedulerExecutionContextResolution,
+) -> dict[str, Any]:
+    """Scope a generic cadence hint to the selected runtime owner."""
+
+    if not resolution.ok or resolution.context is None:
+        raise ValueError("cannot apply an invalid scheduler execution context")
+    context = resolution.context
+    if context.source == "compatibility_default":
+        return result
+
+    result["execution_context"] = resolution.projection()
+    codex_app = (
+        result.get("codex_app") if isinstance(result.get("codex_app"), dict) else {}
+    )
+    if context.codex_app_applicable:
+        codex_app["applicability"] = "applicable"
+        backoff = (
+            codex_app.get("stateful_backoff")
+            if isinstance(codex_app.get("stateful_backoff"), dict)
+            else {}
+        )
+        apply_needed = (
+            backoff.get("apply_needed") is True
+            or codex_app.get("host_action_required") is True
+        )
+        ack_needed = backoff.get("ack_needed") is True
+        result["codex_app"] = codex_app
+        result["execution_phase"] = {
+            "schema_version": "scheduler_execution_phase_v0",
+            "host_surface": context.host_surface.value,
+            "scheduler_owner": context.scheduler_owner.value,
+            "disposition": (
+                "host_action_required" if apply_needed or ack_needed else "not_required"
+            ),
+            "completed": not (apply_needed or ack_needed),
+            "apply_needed": apply_needed,
+            "ack_needed": ack_needed,
+            "acknowledged": False,
+        }
+        return result
+
+    result["codex_app"] = {
+        "applicability": "not_applicable",
+        "reason_code": f"cadence_owned_by_{context.scheduler_owner.value}",
+        "apply": "none",
+        "host_action": "none",
+        "ack_required": False,
+        "no_spend_for_cadence_change": True,
+    }
+    reset_policy = result.get("reset_policy")
+    if isinstance(reset_policy, dict):
+        for key in tuple(reset_policy):
+            if key.startswith("codex_app_"):
+                reset_policy.pop(key, None)
+    cold_path = result.get("cold_path_detail")
+    if isinstance(cold_path, dict):
+        cold_path.pop("stateful_backoff_detail", None)
+        reset_detail = cold_path.get("reset_policy_detail")
+        if isinstance(reset_detail, dict):
+            for key in tuple(reset_detail):
+                if key.startswith("codex_app_"):
+                    reset_detail.pop(key, None)
+    owner = context.scheduler_owner.value
+    result["execution_phase"] = {
+        "schema_version": "scheduler_execution_phase_v0",
+        "host_surface": context.host_surface.value,
+        "scheduler_owner": owner,
+        "disposition": f"{owner}_owned",
+        "completed": True,
+        "apply_needed": False,
+        "ack_needed": False,
+        "acknowledged": False,
+        "completion_reason": (
+            "selected scheduler owner requires no Codex App apply or ACK"
+        ),
+    }
+    return result

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 import math
 import re
-from collections.abc import Collection
+from collections.abc import Collection, Mapping
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -13,6 +13,11 @@ from ..work_items.delivery_outcome import DeliveryOutcome
 from .arbitration import (
     SchedulerDisposition,
     build_scheduler_arbitration,
+)
+from .execution_context import (
+    SchedulerExecutionContextResolution,
+    apply_scheduler_execution_context,
+    resolve_scheduler_execution_context,
 )
 from .state import (
     CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
@@ -754,6 +759,9 @@ def build_scheduler_hint(
     codex_app_scheduler_state: dict[str, Any] | None = None,
     available_capabilities: Any = None,
     codex_app_current_rrule: Any = None,
+    scheduler_execution_context: (
+        Mapping[str, Any] | SchedulerExecutionContextResolution | None
+    ) = None,
 ) -> dict[str, Any]:
     """Project host-runtime cadence/backoff policy from a quota decision.
 
@@ -761,6 +769,52 @@ def build_scheduler_hint(
     classification facts it needs, and it returns the public scheduler contract
     without reading files, mutating state, or depending on the full quota module.
     """
+
+    execution_context = resolve_scheduler_execution_context(
+        scheduler_execution_context
+    )
+    if not execution_context.ok:
+        return {
+            "schema_version": SCHEDULER_HINT_SCHEMA_VERSION,
+            "source": "quota.should-run",
+            "action": "repair_scheduler_execution_context",
+            "cadence_class": "control_plane_repair",
+            "reason_code": "invalid_scheduler_execution_context",
+            "reason": (
+                "scheduler ownership is missing or contradictory; repair the "
+                "typed execution context before applying cadence"
+            ),
+            "spend_policy": "no quota spend for scheduler context repair",
+            "execution_context": execution_context.projection(),
+            "execution_phase": {
+                "schema_version": "scheduler_execution_phase_v0",
+                "disposition": "contract_error",
+                "completed": False,
+                "apply_needed": False,
+                "ack_needed": False,
+                "acknowledged": False,
+            },
+            "codex_app": {
+                "applicability": "blocked_invalid_context",
+                "apply": "none",
+                "host_action": "none",
+                "ack_required": False,
+            },
+            "unchanged_poll": {
+                "local_scheduler": "stop_until_context_repaired",
+                "codex_cli_tui": "stop_until_context_repaired",
+                "claude_code_loop": "stop_until_context_repaired",
+                "final_quota_replan_check_enabled": False,
+                "spend_policy": "no quota spend for scheduler context repair",
+            },
+            "consistency_error": {
+                "source": "scheduler_execution_context",
+                "errors": list(execution_context.errors),
+            },
+        }
+
+    def contextualize(result: dict[str, Any]) -> dict[str, Any]:
+        return apply_scheduler_execution_context(result, execution_context)
 
     heartbeat_recommendation = (
         payload.get("heartbeat_recommendation")
@@ -824,7 +878,7 @@ def build_scheduler_hint(
         return current
 
     if arbitration.disposition == SchedulerDisposition.TERMINAL_STOP:
-        return {
+        return contextualize({
             "schema_version": SCHEDULER_HINT_SCHEMA_VERSION,
             "source": "quota.should-run",
             "action": "stop_until_explicit_resume",
@@ -854,7 +908,7 @@ def build_scheduler_hint(
                 "spend_policy": "no quota spend for terminal loop stop",
             },
             "unchanged_identity_keys": base_identity_keys,
-        }
+        })
 
     def hint(
         *,
@@ -1269,7 +1323,7 @@ def build_scheduler_hint(
             }
             if cadence_context_detail:
                 scheduler_hint["cold_path_detail"]["cadence_context"] = cadence_context_detail
-        return scheduler_hint
+        return contextualize(scheduler_hint)
 
     if arbitration.disposition == SchedulerDisposition.CONSISTENCY_REPAIR:
         result = hint(

--- a/loopx/control_plane/turn_driver/driver.py
+++ b/loopx/control_plane/turn_driver/driver.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from enum import Enum
 from typing import Any
 
+from ..scheduler.execution_context import scheduler_execution_context_for_turn
 from .transaction import build_loopx_turn_transaction_plan
 
 
@@ -149,6 +150,7 @@ def build_loopx_turn_plan(
     *,
     host: str,
     execution_mode: str,
+    scheduler_owner: str | None = None,
     session_binding: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Project a TurnEnvelope into a typed, side-effect-free host decision."""
@@ -158,8 +160,17 @@ def build_loopx_turn_plan(
     if execution_mode not in SUPPORTED_EXECUTION_MODES:
         raise ValueError(f"unsupported LoopX Turn execution mode: {execution_mode}")
 
+    execution_context = scheduler_execution_context_for_turn(
+        host=host,
+        execution_mode=execution_mode,
+        scheduler_owner=scheduler_owner,
+    )
     envelope = dict(turn_envelope)
-    route = _typed_route(envelope)
+    route = (
+        _typed_route(envelope)
+        if execution_context.ok
+        else LoopXTurnRoute.CONTRACT_ERROR
+    )
     lineage = _turn_lineage(envelope)
     session, session_error = _session_plan(
         route=route,
@@ -175,6 +186,7 @@ def build_loopx_turn_plan(
         LoopXTurnRoute.REPAIR_REQUIRED,
         LoopXTurnRoute.REPLAN_REQUIRED,
     }
+    context_projection = execution_context.projection()
     return {
         "ok": route is not LoopXTurnRoute.CONTRACT_ERROR,
         "schema_version": LOOPX_TURN_PLAN_SCHEMA_VERSION,
@@ -182,8 +194,10 @@ def build_loopx_turn_plan(
         "host": {
             "kind": host,
             "execution_mode": execution_mode,
+            "scheduler_owner": context_projection.get("scheduler_owner"),
             "explicit_isolation": execution_mode == "isolated-headless",
         },
+        "scheduler_execution_context": context_projection,
         "session": session,
         "route": {
             "schema_version": "loopx_turn_route_v0",
@@ -199,6 +213,7 @@ def build_loopx_turn_plan(
             lineage=lineage,
             host=host,
             execution_mode=execution_mode,
+            scheduler_owner=str(context_projection.get("scheduler_owner") or ""),
             session_action=str(session.get("action") or "none"),
         ),
         "effects": {
@@ -213,5 +228,9 @@ def build_loopx_turn_plan(
             "preserves_turn_envelope": True,
             "opaque_session_handle_omitted": True,
         },
-        **({"error": session_error} if session_error else {}),
+        **(
+            {"error": session_error or "; ".join(execution_context.errors)}
+            if session_error or not execution_context.ok
+            else {}
+        ),
     }

--- a/loopx/control_plane/turn_driver/transaction.py
+++ b/loopx/control_plane/turn_driver/transaction.py
@@ -84,12 +84,14 @@ def build_loopx_turn_transaction_plan(
     host: str,
     execution_mode: str,
     session_action: str,
+    scheduler_owner: str = "none",
 ) -> dict[str, Any]:
     turn_key = _canonical_hash(
         {
             "lineage": dict(lineage),
             "host": host,
             "execution_mode": execution_mode,
+            "scheduler_owner": scheduler_owner,
             "session_action": session_action,
         }
     )

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -131,6 +132,10 @@ from .control_plane.work_items.goal_route_hint import build_goal_route_hint
 from .control_plane.work_items.capability_monitor_fallback import build_capability_gate_with_monitor_fallback
 from .control_plane.work_items.work_lane import lark_inbox_reply_due_work_lane_contract, scoped_user_gate_due_monitor_contract, work_lane_contract_is_due_monitor_attempt, work_lane_contract_is_lark_inbox_reply_due
 from .control_plane.scheduler.scheduler_hint import build_scheduler_hint
+from .control_plane.scheduler.execution_context import (
+    SchedulerExecutionContextResolution,
+    resolve_scheduler_execution_context,
+)
 from .control_plane.scheduler.external_evidence_observation import build_external_evidence_observation_obligation
 from .control_plane.scheduler.automation_liveness import build_automation_liveness
 from .control_plane.scheduler.state import (
@@ -720,6 +725,7 @@ def _compact_autonomous_candidate_context(
 def _scheduler_hint(
     payload: dict[str, Any], *, include_detail: bool = False,
     codex_app_scheduler_state: dict[str, Any] | None = None, available_capabilities: Any = None, codex_app_current_rrule: Any = None,
+    scheduler_execution_context: Mapping[str, Any] | SchedulerExecutionContextResolution | None = None,
 ) -> dict[str, Any]:
     return build_scheduler_hint(
         payload,
@@ -728,6 +734,7 @@ def _scheduler_hint(
         include_detail=include_detail,
         codex_app_scheduler_state=codex_app_scheduler_state,
         available_capabilities=available_capabilities, codex_app_current_rrule=codex_app_current_rrule,
+        scheduler_execution_context=scheduler_execution_context,
     )
 
 
@@ -1196,8 +1203,12 @@ def build_quota_should_run(
     agent_id: str | None = None,
     available_capabilities: Any = None,
     include_scheduler_detail: bool = False, codex_app_current_rrule: Any = None,
+    scheduler_execution_context: Mapping[str, Any] | SchedulerExecutionContextResolution | None = None,
 ) -> dict[str, Any]:
     safe_goal_id = str(goal_id or "").strip()
+    resolved_scheduler_context = resolve_scheduler_execution_context(
+        scheduler_execution_context
+    )
     registry_goal = _registry_goal_by_id(status_payload).get(safe_goal_id) or {}
     plan = build_quota_plan(status_payload, mode="should-run")
     item = next((candidate for candidate in _quota_plan_items(plan) if candidate.get("goal_id") == safe_goal_id), None)
@@ -2120,11 +2131,18 @@ def build_quota_should_run(
             payload,
             include_detail=include_scheduler_detail,
             available_capabilities=effective_available_capabilities,
-            codex_app_scheduler_state=_load_codex_app_scheduler_state(
-                status_payload,
-                goal_id=safe_goal_id,
-                agent_id=quota_decision_agent_id(payload) or agent_id,
+            codex_app_scheduler_state=(
+                _load_codex_app_scheduler_state(
+                    status_payload,
+                    goal_id=safe_goal_id,
+                    agent_id=quota_decision_agent_id(payload) or agent_id,
+                )
+                if resolved_scheduler_context.ok
+                and resolved_scheduler_context.context is not None
+                and resolved_scheduler_context.context.codex_app_applicable
+                else None
             ), codex_app_current_rrule=codex_app_current_rrule,
+            scheduler_execution_context=resolved_scheduler_context,
         )
         finalize_user_gate_notification_cooldown(payload)
         payload["protocol_action_packet"] = build_protocol_action_packet(payload)

--- a/tests/control_plane/test_scheduler_execution_context.py
+++ b/tests/control_plane/test_scheduler_execution_context.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from itertools import product
+
+import pytest
+
+from loopx.control_plane.scheduler.execution_context import (
+    ExecutionMode,
+    HostSurface,
+    SchedulerOwner,
+    resolve_scheduler_execution_context,
+)
+from loopx.control_plane.scheduler.scheduler_hint import build_scheduler_hint
+
+
+VALID_COMBINATIONS = {
+    ("codex_app", "host_automation", "hosted_automation"),
+    ("local_scheduler", "host_automation", "hosted_automation"),
+    *{
+        (surface, owner, mode)
+        for surface in ("codex_cli", "generic_cli", "claude_code")
+        for owner, mode in (
+            ("agent_cli_loop", "interactive"),
+            ("agent_cli_loop", "isolated_headless"),
+            ("outer_controller", "isolated_headless"),
+            ("none", "interactive"),
+        )
+    },
+}
+
+
+def _active_payload() -> dict:
+    return {
+        "goal_id": "scheduler-context-fixture",
+        "agent_identity": {"agent_id": "codex-fixture"},
+        "should_run": True,
+        "effective_action": "normal_run",
+        "recommended_action": "Advance the public fixture.",
+        "heartbeat_recommendation": {
+            "recommended_mode": "normal_run",
+            "spend_policy": "spend only after validated writeback",
+        },
+        "execution_obligation": {
+            "must_attempt_work": True,
+            "spend_policy": "spend only after validated writeback",
+        },
+        "automation_liveness": {
+            "automation_action": "execute_bounded_work",
+            "spend_policy": "spend only after validated writeback",
+        },
+        "interaction_contract": {
+            "schema_version": "loopx_interaction_contract_v0",
+            "mode": "normal_run",
+            "user_channel": {"action_required": False, "notify": "DONT_NOTIFY"},
+            "agent_channel": {
+                "must_attempt": True,
+                "delivery_allowed": True,
+                "quiet_noop_allowed": False,
+            },
+            "cli_channel": {"next_cli_actions": [], "spend_allowed_now": False},
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("host_surface", "scheduler_owner", "execution_mode"),
+    list(product(HostSurface, SchedulerOwner, ExecutionMode)),
+)
+def test_scheduler_execution_context_decision_table(
+    host_surface: HostSurface,
+    scheduler_owner: SchedulerOwner,
+    execution_mode: ExecutionMode,
+) -> None:
+    values = (
+        host_surface.value,
+        scheduler_owner.value,
+        execution_mode.value,
+    )
+    context = {
+        "host_surface": values[0],
+        "scheduler_owner": values[1],
+        "execution_mode": values[2],
+    }
+
+    resolution = resolve_scheduler_execution_context(context)
+    hint = build_scheduler_hint(
+        _active_payload(),
+        scheduler_execution_context=context,
+    )
+
+    assert resolution.ok is (values in VALID_COMBINATIONS)
+    if values not in VALID_COMBINATIONS:
+        assert hint["execution_phase"]["disposition"] == "contract_error"
+        assert hint["execution_phase"]["completed"] is False
+        assert hint["codex_app"]["applicability"] == "blocked_invalid_context"
+        return
+
+    app_expected = values == (
+        "codex_app",
+        "host_automation",
+        "hosted_automation",
+    )
+    assert hint["codex_app"]["applicability"] == (
+        "applicable" if app_expected else "not_applicable"
+    )
+    assert ("stateful_backoff" in hint["codex_app"]) is app_expected
+    assert hint["execution_phase"]["apply_needed"] is app_expected
+    assert hint["execution_phase"]["completed"] is (not app_expected)
+
+
+def test_partial_scheduler_context_fails_closed_without_app_action() -> None:
+    hint = build_scheduler_hint(
+        _active_payload(),
+        scheduler_execution_context={"host_surface": "generic_cli"},
+    )
+
+    assert hint["action"] == "repair_scheduler_execution_context"
+    assert hint["codex_app"]["applicability"] == "blocked_invalid_context"
+    assert "stateful_backoff" not in hint["codex_app"]
+    assert hint["execution_phase"]["apply_needed"] is False
+
+
+def test_legacy_quota_calls_preserve_codex_app_backoff() -> None:
+    hint = build_scheduler_hint(_active_payload())
+
+    assert "execution_context" not in hint
+    assert "execution_phase" not in hint
+    assert hint["codex_app"]["stateful_backoff"]["apply_needed"] is True

--- a/tests/test_loopx_turn_driver.py
+++ b/tests/test_loopx_turn_driver.py
@@ -191,6 +191,30 @@ def test_turn_plan_projects_typed_recovery_routes(
 
     assert payload["route"]["kind"] == expected.value
     assert payload["host"]["explicit_isolation"] is True
+    assert payload["host"]["scheduler_owner"] == "outer_controller"
+    assert payload["scheduler_execution_context"] == {
+        "schema_version": "scheduler_execution_context_v0",
+        "host_surface": "generic_cli",
+        "scheduler_owner": "outer_controller",
+        "execution_mode": "isolated_headless",
+        "source": "loopx_turn",
+        "valid": True,
+        "codex_app_applicability": "not_applicable",
+    }
+
+
+def test_turn_plan_rejects_contradictory_scheduler_owner() -> None:
+    payload = build_loopx_turn_plan(
+        _envelope(),
+        host="generic-cli",
+        execution_mode="isolated-headless",
+        scheduler_owner="host_automation",
+    )
+
+    assert payload["ok"] is False
+    assert payload["route"]["kind"] == LoopXTurnRoute.CONTRACT_ERROR.value
+    assert payload["route"]["would_invoke_host"] is False
+    assert "cannot be owned by host_automation" in payload["error"]
 
 
 def test_turn_plan_preserves_safe_bypass_when_user_action_is_visible() -> None:
@@ -348,6 +372,50 @@ def _write_live_fixture(root: Path) -> tuple[Path, Path, Path]:
         encoding="utf-8",
     )
     return project, runtime, registry
+
+
+def test_quota_cli_projects_outer_controller_without_codex_app_action(
+    tmp_path: Path,
+) -> None:
+    project, runtime, registry = _write_live_fixture(tmp_path)
+    output = io.StringIO()
+
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(
+            [
+                "--registry",
+                str(registry),
+                "--runtime-root",
+                str(runtime),
+                "--format",
+                "json",
+                "quota",
+                "should-run",
+                "--goal-id",
+                "loopx-turn-fixture",
+                "--agent-id",
+                "codex-fixture",
+                "--host-surface",
+                "generic_cli",
+                "--scheduler-owner",
+                "outer_controller",
+                "--execution-mode",
+                "isolated_headless",
+                "--scan-root",
+                str(project),
+            ]
+        )
+
+    payload = json.loads(output.getvalue())
+    hint = payload["scheduler_hint"]
+    assert exit_code == 0, payload
+    assert hint["execution_context"]["codex_app_applicability"] == "not_applicable"
+    assert hint["codex_app"]["applicability"] == "not_applicable"
+    assert "stateful_backoff" not in hint["codex_app"]
+    assert hint["execution_phase"]["scheduler_owner"] == "outer_controller"
+    assert hint["execution_phase"]["completed"] is True
+    assert hint["execution_phase"]["apply_needed"] is False
+    assert hint["execution_phase"]["ack_needed"] is False
 
 
 def test_turn_cli_consumes_live_state_without_writes(
@@ -517,12 +585,23 @@ raise SystemExit(0 if artifact.read_text(encoding="utf-8") == "validated" else 7
 
     payload = json.loads(output.getvalue())
     assert exit_code == 0, payload
-    assert payload["status"] == "scheduler_action_required"
-    assert payload["receipt"]["status"] == "validated"
-    assert payload["receipt"]["next_phase"] == "scheduler_apply"
+    assert payload["status"] == "committed"
+    assert payload["receipt"]["status"] == "committed"
+    assert payload["receipt"]["next_phase"] is None
     assert payload["validation"]["status"] == "passed"
     assert payload["validation"]["validator_kind"] == "command"
     assert payload["resume_turn_key"].startswith("sha256:")
+    assert payload["scheduler"] == {
+        "schema_version": "scheduler_execution_phase_v0",
+        "host_surface": "generic_cli",
+        "scheduler_owner": "outer_controller",
+        "disposition": "outer_controller_owned",
+        "completed": True,
+        "apply_needed": False,
+        "ack_needed": False,
+        "acknowledged": False,
+        "completion_reason": "selected scheduler owner requires no Codex App apply or ACK",
+    }
     assert payload["effects"] == {
         "host_invoked": True,
         "state_written": True,
@@ -577,7 +656,7 @@ raise SystemExit(0 if artifact.read_text(encoding="utf-8") == "validated" else 7
 
     resumed = json.loads(resumed_output.getvalue())
     assert resumed_exit_code == 0, resumed
-    assert resumed["status"] == "scheduler_action_required"
+    assert resumed["status"] == "committed"
     assert resumed["effects"] == {
         "host_invoked": False,
         "state_written": False,


### PR DESCRIPTION
## Summary

- add a typed host-surface, scheduler-owner, and execution-mode contract
- preserve the legacy Codex App heartbeat default while failing closed on partial or contradictory explicit ownership
- project one execution_phase for Turn consumers and remove the SkillsBench Codex App bypass
- let outer-controller generic CLI Turns commit after validation, writeback, and spend without a fabricated App ACK

## Validation

- 131 focused pytest cases passed
- quota scheduler hint compaction smoke passed
- quota scheduler state ACK smoke passed
- SkillsBench LoopX Turn Agent CLI smoke passed, including two committed replay turns
- loopx canary premerge selected 17 checks; all 17 passed

## Manual hold

The canary marks this benchmark-sensitive because one adapter changes. The adapter now consumes the generic execution_phase contract; scoring, task semantics, launch behavior, and evidence boundaries are unchanged. Maintainer review is required before merge.

Fixes #2197