### PR TITLE
Wire LoopX Turn runner bridge and validator

### DIFF
--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -43,6 +43,20 @@ Optional env:
                                        Optional product-mode intermediate
                                        verifier policy: every-round or
                                        final-only; unset preserves runner default
+  SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_COMMAND
+                                       Private task-free bridge probe command
+  SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_SOLVER_COMMAND
+                                       Private scored-workspace bridge command
+  SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_AGENT_COMMAND
+                                       Optional private agent bridge command;
+                                       defaults to the relay-generated wrapper
+  SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_AGENT_COMMAND_INSTRUMENTED
+                                       Set to 1 only when the explicit agent
+                                       command emits the public-safe operation
+                                       trace contract; default 0
+  SKILLSBENCH_LOOPX_TURN_VALIDATION_COMMAND
+                                       Independent scored-workspace validator
+                                       required by loopx-turn-agent-cli
   SKILLSBENCH_BUILD_STALL_TIMEOUT_SEC  Setup stall timeout, default 3600;
                                        0 disables cap
   SKILLSBENCH_RUN_TIMEOUT_SEC          Supervisor timeout, default 28800
@@ -154,6 +168,11 @@ skip_current_aggregate_update="${SKILLSBENCH_SKIP_CURRENT_AGGREGATE_UPDATE:-0}"
 allow_staged_bootstrap_repair_run="${SKILLSBENCH_ALLOW_STAGED_BOOTSTRAP_REPAIR_RUN:-0}"
 setup_only_public_preflight="${SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT:-0}"
 product_mode_soft_verify_policy="${SKILLSBENCH_PRODUCT_MODE_SOFT_VERIFY_POLICY:-}"
+remote_command_file_bridge_probe_command="${SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_COMMAND:-}"
+remote_command_file_bridge_solver_command="${SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_SOLVER_COMMAND:-}"
+remote_command_file_bridge_agent_command="${SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_AGENT_COMMAND:-}"
+remote_command_file_bridge_agent_command_instrumented="${SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_AGENT_COMMAND_INSTRUMENTED:-0}"
+loopx_turn_validation_command="${SKILLSBENCH_LOOPX_TURN_VALIDATION_COMMAND:-}"
 validate_bool_toggle() {
   local env_name="$1"
   local value="$2"
@@ -169,6 +188,14 @@ validate_bool_toggle \
   SKILLSBENCH_ALLOW_STAGED_BOOTSTRAP_REPAIR_RUN "$allow_staged_bootstrap_repair_run"
 validate_bool_toggle \
   SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT "$setup_only_public_preflight"
+validate_bool_toggle \
+  SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_AGENT_COMMAND_INSTRUMENTED \
+  "$remote_command_file_bridge_agent_command_instrumented"
+if [[ "$remote_command_file_bridge_agent_command_instrumented" == "1" ]] &&
+  [[ -z "$remote_command_file_bridge_agent_command" ]]; then
+  echo "SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_AGENT_COMMAND_INSTRUMENTED requires SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_AGENT_COMMAND" >&2
+  exit 2
+fi
 if [[ -n "$product_mode_soft_verify_policy" ]] &&
   [[ "$product_mode_soft_verify_policy" != "every-round" ]] &&
   [[ "$product_mode_soft_verify_policy" != "final-only" ]]; then
@@ -207,6 +234,11 @@ fi
 goal_id="${SKILLSBENCH_GOAL_ID:-loopx-meta}"
 local_run_ledger="${SKILLSBENCH_LOCAL_RUN_LEDGER_PATH:-.local/goals/${goal_id}/skillsbench-ledgers/live-standard-run-ledger.json}"
 route="${SKILLSBENCH_ROUTE:-codex-cli-goal-baseline}"
+if [[ "$route" == "loopx-turn-agent-cli" ]] &&
+  [[ -z "$loopx_turn_validation_command" ]]; then
+  echo "SKILLSBENCH_LOOPX_TURN_VALIDATION_COMMAND is required for loopx-turn-agent-cli" >&2
+  exit 2
+fi
 model="${SKILLSBENCH_MODEL:-gpt-5.5}"
 reasoning_effort="${SKILLSBENCH_REASONING_EFFORT:-xhigh}"
 build_stall_timeout="${SKILLSBENCH_BUILD_STALL_TIMEOUT_SEC:-3600}"
@@ -320,6 +352,33 @@ fi
 if [[ -n "$product_mode_soft_verify_policy" ]]; then
   extra_runner_args+=(
     --product-mode-soft-verify-policy "$product_mode_soft_verify_policy"
+  )
+fi
+if [[ -n "$remote_command_file_bridge_probe_command" ]]; then
+  extra_runner_args+=(
+    --remote-command-file-bridge-probe-command
+    "$remote_command_file_bridge_probe_command"
+  )
+fi
+if [[ -n "$remote_command_file_bridge_solver_command" ]]; then
+  extra_runner_args+=(
+    --remote-command-file-bridge-solver-command
+    "$remote_command_file_bridge_solver_command"
+  )
+fi
+if [[ -n "$remote_command_file_bridge_agent_command" ]]; then
+  extra_runner_args+=(
+    --remote-command-file-bridge-agent-command
+    "$remote_command_file_bridge_agent_command"
+  )
+fi
+if [[ "$remote_command_file_bridge_agent_command_instrumented" == "1" ]]; then
+  extra_runner_args+=(--remote-command-file-bridge-agent-command-instrumented)
+fi
+if [[ -n "$loopx_turn_validation_command" ]]; then
+  extra_runner_args+=(
+    --loopx-turn-validation-command
+    "$loopx_turn_validation_command"
   )
 fi
 if [[ -n "${SKILLSBENCH_REGISTRY:-}" ]]; then
@@ -464,16 +523,48 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'setup_only_public_preflight=%s\n' "$setup_only_public_preflight"
   printf 'product_mode_soft_verify_policy=%s\n' \
     "${product_mode_soft_verify_policy:-runner-default}"
+  printf 'remote_command_file_bridge_probe_command_configured=%s\n' \
+    "$([[ -n "$remote_command_file_bridge_probe_command" ]] && echo 1 || echo 0)"
+  printf 'remote_command_file_bridge_solver_command_configured=%s\n' \
+    "$([[ -n "$remote_command_file_bridge_solver_command" ]] && echo 1 || echo 0)"
+  printf 'remote_command_file_bridge_agent_command_configured=%s\n' \
+    "$([[ -n "$remote_command_file_bridge_agent_command" ]] && echo 1 || echo 0)"
+  printf 'remote_command_file_bridge_agent_command_instrumented=%s\n' \
+    "$remote_command_file_bridge_agent_command_instrumented"
+  printf 'loopx_turn_validation_command_configured=%s\n' \
+    "$([[ -n "$loopx_turn_validation_command" ]] && echo 1 || echo 0)"
   printf 'skip_global_ledger_sync=%s\n' "$skip_global_ledger_sync"
   printf 'skip_current_aggregate_update=%s\n' "$skip_current_aggregate_update"
   printf 'local_run_ledger=%s\n' "$local_run_ledger"
   if [[ -n "${standard_aggregate:-}" ]]; then
     printf 'standard_aggregate=%s\n' "$standard_aggregate"
   fi
-  printf 'remote_command=%s\n' "$remote_command"
-  printf 'supervisor_command='
-  printf '%q ' "${supervisor_cmd[@]}"
-  printf '\n'
+  if [[ -n "$remote_command_file_bridge_probe_command" ]] ||
+    [[ -n "$remote_command_file_bridge_solver_command" ]] ||
+    [[ -n "$remote_command_file_bridge_agent_command" ]] ||
+    [[ -n "$loopx_turn_validation_command" ]]; then
+    printf 'private_runner_command_values_redacted=true\n'
+    printf 'private_runner_arg_names='
+    [[ -n "$remote_command_file_bridge_probe_command" ]] &&
+      printf '%s ' --remote-command-file-bridge-probe-command
+    [[ -n "$remote_command_file_bridge_solver_command" ]] &&
+      printf '%s ' --remote-command-file-bridge-solver-command
+    [[ -n "$remote_command_file_bridge_agent_command" ]] &&
+      printf '%s ' --remote-command-file-bridge-agent-command
+    [[ "$remote_command_file_bridge_agent_command_instrumented" == "1" ]] &&
+      printf '%s ' --remote-command-file-bridge-agent-command-instrumented
+    [[ -n "$loopx_turn_validation_command" ]] &&
+      printf '%s ' --loopx-turn-validation-command
+    printf '\n'
+    printf 'remote_command=<redacted-private-runner-command-values>\n'
+    printf 'supervisor_command=<redacted-private-runner-command-values>\n'
+  else
+    printf 'private_runner_command_values_redacted=false\n'
+    printf 'remote_command=%s\n' "$remote_command"
+    printf 'supervisor_command='
+    printf '%q ' "${supervisor_cmd[@]}"
+    printf '\n'
+  fi
   exit 0
 fi
 

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LAUNCHER = REPO_ROOT / "scripts" / "skillsbench-launch-goal-xhigh.sh"
+
+
+def _base_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "SKILLSBENCH_SSH_DESTINATION": "example.invalid",
+            "SKILLSBENCH_REMOTE_ROOT": "/remote/loopx",
+            "SKILLSBENCH_ROOT": "/remote/skillsbench",
+            "SKILLSBENCH_EXPECTED_LOOPX_GIT_HEAD": "abc1234",
+            "SKILLSBENCH_DOCKER_PROXY_HOST": "host.docker.internal",
+            "SKILLSBENCH_DOCKER_API_VERSION": "1.43",
+            "SKILLSBENCH_RUN_STAMP": "20260716T000000CST",
+        }
+    )
+    return env
+
+
+def test_turn_launcher_wires_private_commands_without_echoing_values() -> None:
+    env = _base_env()
+    private_values = {
+        "SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_COMMAND": (
+            "private-probe-command sentinel-probe"
+        ),
+        "SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_SOLVER_COMMAND": (
+            "private-solver-command sentinel-solver"
+        ),
+        "SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_AGENT_COMMAND": (
+            "private-agent-command sentinel-agent"
+        ),
+        "SKILLSBENCH_LOOPX_TURN_VALIDATION_COMMAND": (
+            "private-validator-command sentinel-validator"
+        ),
+    }
+    env.update(private_values)
+    env.update(
+        {
+            "SKILLSBENCH_ROUTE": "loopx-turn-agent-cli",
+            "SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_AGENT_COMMAND_INSTRUMENTED": (
+                "1"
+            ),
+        }
+    )
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "turn-wiring"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+
+    output = proc.stdout
+    assert "remote_command_file_bridge_probe_command_configured=1" in output
+    assert "remote_command_file_bridge_solver_command_configured=1" in output
+    assert "remote_command_file_bridge_agent_command_configured=1" in output
+    assert "remote_command_file_bridge_agent_command_instrumented=1" in output
+    assert "loopx_turn_validation_command_configured=1" in output
+    assert "private_runner_command_values_redacted=true" in output
+    for arg_name in (
+        "--remote-command-file-bridge-probe-command",
+        "--remote-command-file-bridge-solver-command",
+        "--remote-command-file-bridge-agent-command",
+        "--remote-command-file-bridge-agent-command-instrumented",
+        "--loopx-turn-validation-command",
+    ):
+        assert arg_name in output
+    for private_value in private_values.values():
+        assert private_value not in output
+    assert "sentinel-" not in output
+
+
+def test_instrumented_agent_bridge_requires_an_explicit_agent_command() -> None:
+    env = _base_env()
+    env["SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_AGENT_COMMAND_INSTRUMENTED"] = "1"
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "turn-wiring"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    assert (
+        "SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_AGENT_COMMAND_INSTRUMENTED requires "
+        "SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_AGENT_COMMAND"
+    ) in proc.stderr
+
+
+def test_turn_launcher_requires_an_independent_validator() -> None:
+    env = _base_env()
+    env["SKILLSBENCH_ROUTE"] = "loopx-turn-agent-cli"
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "turn-wiring"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    assert (
+        "SKILLSBENCH_LOOPX_TURN_VALIDATION_COMMAND is required for "
+        "loopx-turn-agent-cli"
+    ) in proc.stderr


### PR DESCRIPTION
## Summary
- pass private bridge probe, solver, and optional agent commands through the canonical SkillsBench launcher
- pass the independent LoopX Turn validator and fail closed locally when it is missing
- redact private command values from launcher dry-run output while retaining configuration diagnostics

## Validation
- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`
- focused launcher tests (3 direct test functions; system Python lacks pytest)
- `python3 examples/skillsbench-loopx-turn-agent-cli-smoke.py`
- `python3 examples/skillsbench-benchmark-egress-policy-smoke.py`
- `loopx canary premerge --from-git-diff` (all selected checks passed; benchmark-sensitive manual hold reviewed under the owner's standing authorization for Turn/benchmark PR self-merge)

## Boundary
- no private command values, runner paths, credentials, raw task text, logs, trajectories, verifier output, uploads, or submissions are committed
- no benchmark scoring, task semantics, leaderboard, submission, or permission behavior changes
