### PR TITLE
Qualify SkillsBench lifecycle with Turn receipts

### DIFF
--- a/examples/skillsbench-post-run-debug-gate-smoke.py
+++ b/examples/skillsbench-post-run-debug-gate-smoke.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import copy
 import sys
 from pathlib import Path
 
@@ -66,8 +67,154 @@ def test_countable_zero_keeps_solution_attribution() -> None:
     assert gate["missing_field_count"] == 0, gate
 
 
+def test_failed_turn_receipts_qualify_direct_lifecycle_success() -> None:
+    turn_execution = {
+        "schema_version": "loopx_turn_execution_v0",
+        "mode": "run_once",
+        "status": "failed",
+        "result_kind": "repair_required",
+        "validation": {
+            "status": "failed",
+            "recovery_kind": "repair_required",
+        },
+        "receipt": {
+            "status": "failed",
+            "failed_phase": "validation",
+        },
+        "effects": {
+            "host_invoked": True,
+            "state_written": False,
+            "quota_spent": False,
+            "scheduler_acknowledged": False,
+        },
+    }
+    compact = {
+        "benchmark_id": "skillsbench@1.1",
+        "product_mode": True,
+        "official_score": 0.0,
+        "official_score_status": "completed",
+        "official_task_score": {
+            "kind": "skillsbench_verifier_reward",
+            "passed": False,
+            "value": 0.0,
+        },
+        "score_failure_attribution": "official_score_zero_case_failure",
+        "failure_attribution_labels": [
+            "skillsbench_runner_error",
+            "official_score_zero_case_failure",
+            "partial_trajectory",
+        ],
+        "product_mode_lifecycle_contract": {
+            "required": True,
+            "satisfied": True,
+            "closeout_satisfied": True,
+            "state_read_count": 8,
+            "state_write_count": 8,
+            "agent_bridge_todo_closeout_count": 1,
+            "agent_bridge_refresh_state_count": 4,
+            "agent_bridge_quota_spend_slot_count": 1,
+        },
+        "loopx_turn_executions": [dict(turn_execution), dict(turn_execution)],
+        "case_event_timeline": {
+            "schema_version": "skillsbench_case_event_timeline_v0",
+            "source": "compact_public_signals",
+            "raw_material_recorded": False,
+            "events": [
+                {
+                    "phase": "goal_init",
+                    "event": "case_goal_state_init",
+                    "status": "satisfied",
+                },
+                {
+                    "phase": "controller",
+                    "event": "controller_decision_loop",
+                    "status": "stopped_after_two_rounds",
+                },
+                {
+                    "phase": "lifecycle",
+                    "event": "orchestrated_loopx_lifecycle",
+                    "status": "satisfied",
+                    "state_read_count": 8,
+                    "state_write_count": 8,
+                },
+                {
+                    "phase": "bridge",
+                    "event": "remote_command_bridge_consumption",
+                    "status": "satisfied",
+                },
+                {
+                    "phase": "activity",
+                    "event": "task_facing_activity",
+                    "status": "satisfied",
+                    "agent_bridge_task_facing_operation_count": 48,
+                },
+                {
+                    "phase": "closeout",
+                    "event": "agent_bridge_closeout",
+                    "status": "satisfied",
+                    "todo_closeout_count": 1,
+                    "refresh_state_count": 4,
+                    "quota_spend_slot_count": 1,
+                },
+                {
+                    "phase": "scoring",
+                    "event": "official_score_closeout",
+                    "status": "completed",
+                    "official_score_passed": False,
+                },
+            ],
+        },
+    }
+
+    gate = build_skillsbench_post_run_debug_gate(compact)
+
+    assert gate["packet_complete"] is True, gate
+    assert gate["case_closeout_complete"] is True, gate
+    assert gate["normal_progress_allowed"] is False, gate
+    assert gate["next_case_gate"] == "blocked_turn_transaction_repair", gate
+    assert gate["attribution_layer"] == "loopx_turn_transaction", gate
+    assert gate["first_blocker"] == "loopx_turn_validation_failed", gate
+    assert gate["loopx_lifecycle"]["direct_lifecycle_satisfied"] is True, gate
+    assert gate["loopx_lifecycle"]["satisfied"] is False, gate
+    assert gate["loopx_lifecycle"]["direct_closeout_status"] == "satisfied", gate
+    assert (
+        gate["loopx_lifecycle"]["closeout_status"]
+        == "turn_transaction_repair_required"
+    ), gate
+    transaction = gate["loopx_turn_transaction"]
+    assert transaction["status"] == "validation_failed", transaction
+    assert transaction["causal_consistency"] == (
+        "validation_failure_effects_not_committed"
+    ), transaction
+    assert transaction["recovery_status"] == "repair_required", transaction
+    assert transaction["execution_count"] == 2, transaction
+    assert transaction["validation_failed_count"] == 2, transaction
+    assert transaction["committed_count"] == 0, transaction
+    assert transaction["state_written_count"] == 0, transaction
+    assert transaction["quota_spent_count"] == 0, transaction
+
+    committed_compact = copy.deepcopy(compact)
+    for execution in committed_compact["loopx_turn_executions"]:
+        execution["status"] = "committed"
+        execution["result_kind"] = "validated_progress"
+        execution["validation"] = {"status": "passed"}
+        execution["receipt"] = {"status": "committed"}
+        execution["effects"]["state_written"] = True
+        execution["effects"]["quota_spent"] = True
+    committed_gate = build_skillsbench_post_run_debug_gate(committed_compact)
+    assert committed_gate["normal_progress_allowed"] is True, committed_gate
+    assert committed_gate["loopx_lifecycle"]["satisfied"] is True, committed_gate
+    assert committed_gate["loopx_lifecycle"]["closeout_status"] == "satisfied", (
+        committed_gate
+    )
+    assert committed_gate["loopx_turn_transaction"]["status"] == "committed", (
+        committed_gate
+    )
+
+
 def main() -> None:
     test_countable_zero_keeps_solution_attribution()
+    test_failed_turn_receipts_qualify_direct_lifecycle_success()
     print("skillsbench-post-run-debug-gate-smoke: ok")
 
 

--- a/loopx/control_plane/runtime/skillsbench_post_run_debug.py
+++ b/loopx/control_plane/runtime/skillsbench_post_run_debug.py
@@ -36,6 +36,115 @@ def _benchmark_positive_int(value: Any) -> int:
     return 0
 
 
+def _skillsbench_turn_transaction_outcome(run: dict[str, Any]) -> dict[str, Any]:
+    executions = run.get("loopx_turn_executions")
+    if not isinstance(executions, list):
+        execution = run.get("loopx_turn_execution")
+        executions = [execution] if isinstance(execution, dict) else []
+    executions = [item for item in executions if isinstance(item, dict)]
+    if not executions:
+        return {}
+
+    committed_count = 0
+    validation_failed_count = 0
+    repair_required_count = 0
+    replan_required_count = 0
+    state_written_count = 0
+    quota_spent_count = 0
+    failed_transaction_with_durable_effect_count = 0
+    for execution in executions:
+        validation = (
+            execution.get("validation")
+            if isinstance(execution.get("validation"), dict)
+            else {}
+        )
+        receipt = (
+            execution.get("receipt")
+            if isinstance(execution.get("receipt"), dict)
+            else {}
+        )
+        effects = (
+            execution.get("effects")
+            if isinstance(execution.get("effects"), dict)
+            else {}
+        )
+        state_written = effects.get("state_written") is True
+        quota_spent = effects.get("quota_spent") is True
+        committed = bool(
+            execution.get("status") == "committed"
+            and receipt.get("status") == "committed"
+            and validation.get("status") == "passed"
+            and state_written
+            and quota_spent
+        )
+        validation_failed = bool(
+            validation.get("status") == "failed"
+            or receipt.get("failed_phase") == "validation"
+            or execution.get("status") == "validation_failed"
+        )
+        recovery_kind = public_safe_compact_text(
+            validation.get("recovery_kind"),
+            limit=80,
+        )
+        committed_count += int(committed)
+        validation_failed_count += int(validation_failed)
+        repair_required_count += int(recovery_kind == "repair_required")
+        replan_required_count += int(recovery_kind == "replan_required")
+        state_written_count += int(state_written)
+        quota_spent_count += int(quota_spent)
+        failed_transaction_with_durable_effect_count += int(
+            validation_failed and (state_written or quota_spent)
+        )
+
+    execution_count = len(executions)
+    if failed_transaction_with_durable_effect_count:
+        status = "inconsistent_failed_transaction_has_durable_effects"
+        causal_consistency = "violated"
+        first_blocker = "failed_turn_transaction_has_durable_effects"
+    elif committed_count == execution_count:
+        status = "committed"
+        causal_consistency = "committed_effects_observed"
+        first_blocker = "none"
+    elif validation_failed_count:
+        status = "validation_failed"
+        causal_consistency = "validation_failure_effects_not_committed"
+        first_blocker = "loopx_turn_validation_failed"
+    else:
+        status = "uncommitted"
+        causal_consistency = "uncommitted_result_requires_recovery"
+        first_blocker = "loopx_turn_uncommitted"
+
+    if repair_required_count:
+        recovery_status = "repair_required"
+    elif replan_required_count:
+        recovery_status = "replan_required"
+    elif committed_count == execution_count:
+        recovery_status = "not_required"
+    else:
+        recovery_status = "missing"
+
+    return {
+        "schema_version": "skillsbench_loopx_turn_transaction_outcome_v0",
+        "observed": True,
+        "status": status,
+        "causal_consistency": causal_consistency,
+        "recovery_status": recovery_status,
+        "progress_blocked": committed_count != execution_count,
+        "first_blocker": first_blocker,
+        "execution_count": execution_count,
+        "committed_count": committed_count,
+        "uncommitted_count": execution_count - committed_count,
+        "validation_failed_count": validation_failed_count,
+        "repair_required_count": repair_required_count,
+        "replan_required_count": replan_required_count,
+        "state_written_count": state_written_count,
+        "quota_spent_count": quota_spent_count,
+        "failed_transaction_with_durable_effect_count": (
+            failed_transaction_with_durable_effect_count
+        ),
+    }
+
+
 def build_skillsbench_post_run_debug_gate(
     run: dict[str, Any],
 ) -> dict[str, Any]:
@@ -170,6 +279,18 @@ def build_skillsbench_post_run_debug_gate(
     effective_lifecycle_satisfied = bool(
         lifecycle_satisfied is True or timeline_lifecycle_satisfied
     )
+    turn_transaction = _skillsbench_turn_transaction_outcome(run)
+    turn_transaction_blocks_progress = bool(
+        turn_transaction.get("progress_blocked") is True
+    )
+    qualified_lifecycle_satisfied = bool(
+        effective_lifecycle_satisfied and not turn_transaction_blocks_progress
+    )
+    qualified_closeout_status = (
+        "turn_transaction_repair_required"
+        if turn_transaction_blocks_progress
+        else closeout_status
+    )
     case_closeout_complete = bool(
         (not missing_fields and official_passed is True and verifier_artifact_success)
         or (
@@ -186,6 +307,15 @@ def build_skillsbench_post_run_debug_gate(
     if missing_fields:
         attribution_layer = "incomplete_public_debug_packet"
         first_blocker = missing_fields[0]
+    elif turn_transaction_blocks_progress:
+        attribution_layer = "loopx_turn_transaction"
+        first_blocker = (
+            public_safe_compact_text(
+                turn_transaction.get("first_blocker"),
+                limit=140,
+            )
+            or "loopx_turn_transaction_repair_required"
+        )
     elif (
         lifecycle_required
         and not verifier_artifact_success
@@ -247,6 +377,9 @@ def build_skillsbench_post_run_debug_gate(
     elif not case_closeout_complete:
         next_case_gate = "blocked_incomplete_case_closeout"
         next_action = "record_or_repair_case_closeout_before_next_case"
+    elif turn_transaction_blocks_progress:
+        next_case_gate = "blocked_turn_transaction_repair"
+        next_action = "repair_loopx_turn_transaction_before_next_matched_case"
     elif attribution_layer == "clean_pass":
         next_case_gate = "open"
         next_action = "upsert_ledger_and_continue_or_compare_pair"
@@ -265,7 +398,11 @@ def build_skillsbench_post_run_debug_gate(
         "packet_complete": packet_complete,
         "case_closeout_complete": case_closeout_complete,
         "next_case_gate": next_case_gate,
-        "normal_progress_allowed": bool(packet_complete and case_closeout_complete),
+        "normal_progress_allowed": bool(
+            packet_complete
+            and case_closeout_complete
+            and not turn_transaction_blocks_progress
+        ),
         "first_blocker": first_blocker,
         "next_action": next_action,
         "attribution_layer": attribution_layer,
@@ -294,8 +431,10 @@ def build_skillsbench_post_run_debug_gate(
         },
         "loopx_lifecycle": {
             "required": lifecycle_required,
-            "satisfied": effective_lifecycle_satisfied,
-            "closeout_status": closeout_status,
+            "satisfied": qualified_lifecycle_satisfied,
+            "direct_lifecycle_satisfied": effective_lifecycle_satisfied,
+            "closeout_status": qualified_closeout_status,
+            "direct_closeout_status": closeout_status,
             "state_read_count": lifecycle_state_read_count,
             "state_write_count": lifecycle_state_write_count,
             "todo_closeout_count": _benchmark_positive_int(
@@ -452,6 +591,8 @@ def build_skillsbench_post_run_debug_gate(
     }
     if solution_quality:
         gate["solution_quality"] = solution_quality
+    if turn_transaction:
+        gate["loopx_turn_transaction"] = turn_transaction
     if labels:
         gate["failure_attribution_labels"] = labels
     if runner_failure:


### PR DESCRIPTION
## Summary
- derive a compact public-safe LoopX Turn transaction outcome from existing receipts, validator status, recovery kind, and durable effects
- keep official case closeout distinct from Turn commit, and block the next matched case when failed receipts would otherwise appear as unqualified lifecycle success
- add a real-state-shaped replay for two validator failures plus a committed control case

## Product and architecture
The reducer previously treated successful direct LoopX CLI reads/writes as sufficient lifecycle success even when every case-local Turn transaction failed validation and wrote no durable effects. This change preserves the countable official result and direct lifecycle evidence, but makes transaction recovery the final next-case gate. It is reducer/closeout plumbing only: no benchmark scoring, task semantics, runner launch, permissions, or submission behavior changes.

## Validation
- `python3 examples/skillsbench-post-run-debug-gate-smoke.py`
- `python3 examples/benchmark-loopx-turn-fidelity-smoke.py`
- `python3 examples/skillsbench-loopx-turn-agent-cli-smoke.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `loopx canary premerge --from-git-diff --tier standard`: 4 direct checks + 9 catalog canaries + 8 risk-profile smokes + public-boundary scan passed; no command failures or skips

## Boundary and hold
- public/private scan clean; no raw task text, trajectories, verifier output, logs, credentials, local paths, or private context
- canary reports its generic `benchmark_sensitive` manual hold. The owner has explicitly authorized benchmark and LoopX Turn PR self-merge; maintainer self-review will still verify the narrow reducer-only scope before admin-bypass merge.
