### PR TITLE
fix(lark): verify normalized mention replies

### DIFF
--- a/docs/capabilities/lark-event-inbox.md
+++ b/docs/capabilities/lark-event-inbox.md
@@ -235,6 +235,13 @@ the same configured profile. Ordinary chatter remains a no-reply path;
 enabling this capability does not grant reviewer-notification or other
 outbound authority.
 
+For text replies containing Lark `<at user_id="...">...</at>` mentions, provider
+readback may replace the markup with tokens such as `@_user_1`. Verification
+therefore compares the normalized visible-text template and requires every
+mention token to resolve to the identity requested at send time. A missing,
+extra, or differently resolved mention remains `sent_unverified`; display-name
+or raw-markup similarity alone is not accepted.
+
 ## Bounded history reconciliation
 
 Real-time event subscriptions do not backfill messages sent before a collector

--- a/examples/lark-event-inbox-smoke.py
+++ b/examples/lark-event-inbox-smoke.py
@@ -293,10 +293,86 @@ def main() -> None:
             for call in calls
         ), calls
         assert any("+messages-reply" in call for call in calls), calls
+        reply_call = next(call for call in calls if "+messages-reply" in call)
+        assert reply_call[reply_call.index("--message-id") + 1] == "om_review_2"
+        assert "--reply-in-thread" in reply_call
         assert all(
             "--as" in call and call[call.index("--as") + 1] == "bot"
             for call in calls[1:]
         ), calls
+
+        def mention_runner(*, readback_open_id: str):
+            def run(args):
+                if args[3:6] == ["auth", "status", "--verify"]:
+                    return successful_runner(args)
+                if args[3:6] == ["im", "chats", "get"]:
+                    return {"returncode": 0, "stdout": "{}", "stderr": ""}
+                if "+messages-reply" in args:
+                    return {
+                        "returncode": 0,
+                        "stdout": json.dumps({"message_id": "om_reply_mention"}),
+                        "stderr": "",
+                    }
+                if "+messages-mget" in args:
+                    return {
+                        "returncode": 0,
+                        "stdout": json.dumps(
+                            {
+                                "items": [
+                                    {
+                                        "message_id": "om_reply_mention",
+                                        "body": {
+                                            "content": json.dumps(
+                                                {"text": "@_user_1 已记录并修正。"},
+                                                ensure_ascii=False,
+                                            )
+                                        },
+                                        "mentions": [
+                                            {
+                                                "key": "@_user_1",
+                                                "id": {
+                                                    "open_id": readback_open_id,
+                                                    "user_id": "fixture-user-id",
+                                                },
+                                                "name": "Reviewer",
+                                            }
+                                        ],
+                                    }
+                                ]
+                            },
+                            ensure_ascii=False,
+                        ),
+                        "stderr": "",
+                    }
+                raise AssertionError(args)
+
+            return run
+
+        mention_reply = (
+            '<at user_id="ou_reviewer_fixture">Reviewer</at> 已记录并修正。'
+        )
+        normalized_mention = reply_lark_event_inbox(
+            project=project,
+            config_path=config,
+            message_id="om_review_2",
+            text=mention_reply,
+            execute=True,
+            runner=mention_runner(readback_open_id="ou_reviewer_fixture"),
+        )
+        assert normalized_mention["status"] == "sent_verified", normalized_mention
+
+        wrong_mention = reply_lark_event_inbox(
+            project=project,
+            config_path=config,
+            message_id="om_review_2",
+            text=mention_reply,
+            execute=True,
+            runner=mention_runner(readback_open_id="ou_different_fixture"),
+        )
+        assert wrong_mention["status"] == "sent_unverified", wrong_mention
+        assert wrong_mention["blocker"] == "lark_inbox_reply_not_verified", (
+            wrong_mention
+        )
 
         membership_calls: list[list[str]] = []
 

--- a/loopx/capabilities/lark/inbox_reply.py
+++ b/loopx/capabilities/lark/inbox_reply.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import subprocess
 from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
@@ -15,6 +16,13 @@ from .event_inbox import (
 
 
 CommandRunner = Callable[[Sequence[str]], Mapping[str, Any]]
+
+AT_MENTION_PATTERN = re.compile(
+    r'<at\s+(?P<kind>user_id|open_id|union_id)="(?P<identity>[^"<>]+)">'
+    r"(?P<name>.*?)</at>",
+    re.IGNORECASE,
+)
+MENTION_ID_KEYS = ("open_id", "user_id", "union_id")
 
 
 def _default_runner(args: Sequence[str]) -> Mapping[str, Any]:
@@ -62,6 +70,110 @@ def _message_id(value: Any) -> str | None:
             None,
         )
     return None
+
+
+def _message(value: Any, message_id: str) -> Mapping[str, Any] | None:
+    if isinstance(value, Mapping):
+        if str(value.get("message_id") or "") == message_id:
+            return value
+        return next(
+            (found for child in value.values() if (found := _message(child, message_id))),
+            None,
+        )
+    if isinstance(value, list):
+        return next(
+            (found for child in value if (found := _message(child, message_id))),
+            None,
+        )
+    return None
+
+
+def _content_text(value: Any) -> str:
+    if isinstance(value, Mapping):
+        text = value.get("text")
+        if isinstance(text, str):
+            return text
+        content = value.get("content")
+        if content is not None:
+            return _content_text(content)
+        return ""
+    if not isinstance(value, str):
+        return ""
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError:
+        return value
+    return _content_text(decoded) if isinstance(decoded, Mapping) else value
+
+
+def _message_text(message: Mapping[str, Any]) -> str:
+    body = message.get("body")
+    if isinstance(body, Mapping):
+        text = _content_text(body)
+        if text:
+            return text
+    return _content_text(message.get("content"))
+
+
+def _mention_identities(mention: Mapping[str, Any]) -> set[str]:
+    identities = {
+        str(mention.get(key) or "").strip()
+        for key in MENTION_ID_KEYS
+        if str(mention.get(key) or "").strip()
+    }
+    mention_id = mention.get("id")
+    if isinstance(mention_id, Mapping):
+        identities.update(
+            str(mention_id.get(key) or "").strip()
+            for key in MENTION_ID_KEYS
+            if str(mention_id.get(key) or "").strip()
+        )
+    elif isinstance(mention_id, str) and mention_id.strip():
+        identities.add(mention_id.strip())
+    return identities
+
+
+def _canonical_expected_text(text: str) -> tuple[str, dict[str, str]]:
+    identity_tokens: dict[str, str] = {}
+
+    def replace(match: re.Match[str]) -> str:
+        identity = match.group("identity").strip()
+        token = identity_tokens.setdefault(
+            identity, f"\x1fmention:{len(identity_tokens)}\x1f"
+        )
+        return token
+
+    return " ".join(AT_MENTION_PATTERN.sub(replace, text).split()), identity_tokens
+
+
+def _readback_matches_reply(
+    *, reply_text: str, message: Mapping[str, Any]
+) -> bool:
+    expected_text, identity_tokens = _canonical_expected_text(reply_text)
+    actual_text = _message_text(message)
+    if not actual_text:
+        return False
+    if not identity_tokens:
+        return " ".join(actual_text.split()) == expected_text
+
+    mentions = message.get("mentions")
+    if not isinstance(mentions, list):
+        return False
+    matched_identities: set[str] = set()
+    for mention in mentions:
+        if not isinstance(mention, Mapping):
+            return False
+        key = str(mention.get("key") or "")
+        matches = _mention_identities(mention).intersection(identity_tokens)
+        if not key or len(matches) != 1:
+            return False
+        identity = next(iter(matches))
+        actual_text = actual_text.replace(key, identity_tokens[identity])
+        matched_identities.add(identity)
+    return (
+        matched_identities == set(identity_tokens)
+        and " ".join(actual_text.split()) == expected_text
+    )
 
 
 def _result(
@@ -263,13 +375,15 @@ def reply_lark_event_inbox(
             "json",
         ],
     )
-    readback_text = json.dumps(
-        _json_object(readback.get("stdout")), ensure_ascii=False, sort_keys=True
-    )
+    readback_payload = _json_object(readback.get("stdout"))
+    readback_message = _message(readback_payload, reply_message_id)
     verified = bool(
         readback.get("returncode") == 0
-        and reply_message_id in readback_text
-        and reply_text in readback_text
+        and readback_message is not None
+        and _readback_matches_reply(
+            reply_text=reply_text,
+            message=readback_message,
+        )
     )
     return _result(
         status="sent_verified" if verified else "sent_unverified",


### PR DESCRIPTION
## Summary

- verify inbox replies against the exact read-back message instead of a payload-wide raw substring
- canonicalize Lark `<at user_id="...">` markup against provider `@_user_N` tokens only when `mentions[].id` resolves to the requested identity
- keep mismatched, missing, or extra mentions fail-closed and document the contract

## Product and architecture judgment

The provider preserves mention identity structurally while normalizing its text representation, so raw-markup equality creates false `sent_unverified` results after successful sends. This change keeps the generic inbox reply seam provider-aware but project-neutral: visible-text shape and resolved identities form the verification contract, while idempotency and source-thread binding remain unchanged. The main residual risk is future provider payload variants; unknown or incomplete variants intentionally remain unverified.

## Validation

- `python3 examples/lark-event-inbox-smoke.py`
- `python3 examples/lark-event-collector-lifecycle-smoke.py`
- `uv run --extra test ruff check loopx/capabilities/lark/inbox_reply.py examples/lark-event-inbox-smoke.py`
- `loopx check --scan-path loopx/capabilities/lark/inbox_reply.py --scan-path examples/lark-event-inbox-smoke.py --scan-path docs/capabilities/lark-event-inbox.md`
- `loopx --format json canary premerge --from-git-diff` (10/10 selected checks passed; self-merge allowed)

## Boundary

No private messages, identities, local paths, credentials, raw provider payloads, or generated local artifacts are included. The smoke uses public synthetic identifiers only.