### PR TITLE
fix(scheduler): settle ACK before backoff progression

### DIFF
--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -507,7 +507,9 @@ no quota, and end the turn without a scheduler ACK. Otherwise call it only when
 RRULE update, run `loopx` with
 `scheduler_hint.codex_app.ack_hint.cli_args`; current payloads use
 `quota scheduler-ack-current` so LoopX re-reads the latest hint and owns the
-progression/reset state. Attempt the host update at most once per hint and
+progression/reset state. The ACK settles that RRULE; an immediate final guard
+may verify the same target but must not be treated as another elapsed poll.
+Attempt the host update at most once per hint and
 turn. If it fails or times out, do not retry or ACK; run
 `scheduler_hint.codex_app.failure_hint.cli_args` once to persist the failed
 target and observed host RRULE without spending quota. Exact repeats are then

--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -815,7 +815,10 @@ the agent must run `codex_app.ack_hint.cli_args`. Current payloads use
 `quota scheduler-ack-current`, so LoopX then persists `reset_token`,
 `identity_signature`, `progression_index`, and
 `last_applied_rrule` under the runtime root. Repeated unchanged identity
-advances through `progression_minutes`; a changed `reset_policy.reset_token`
+advances through `progression_minutes` only after the applied RRULE has had one
+real interval to run. An immediate post-ACK reconciliation therefore verifies
+the settled target instead of manufacturing the next backoff target in the
+same turn. A changed `reset_policy.reset_token`
 returns to the current profile's initial interval. This gives hosts a compact
 post-update ack protocol instead of requiring them to own or diff the whole
 quota state. If `apply_needed=false` and `ack_needed=true`, the same command
@@ -838,7 +841,8 @@ notice is preserved; short host polls are quiet, one host-sized window opens at
 each target cadence, and a changed gate identity or host RRULE bypasses the old
 cooldown. This changes notification delivery only, not the underlying user todo.
 `scheduler-ack` is not a second `should-run`: it confirms the host update or
-matching readback and does not emit a successor RRULE in the same turn. User
+matching readback and does not emit or make immediately due a successor RRULE
+in the same turn. User
 feedback, newly runnable work, reassignment, or material evidence therefore
 restores the automation to the current profile's initial interval before
 backoff resumes.

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1360,7 +1360,9 @@ must run `codex_app.ack_hint.cli_args`;
 current payloads use `quota scheduler-ack-current` so LoopX re-reads the latest
 hint, then persists `reset_token`, `identity_signature`, `progression_index`,
 and `last_applied_rrule` under the runtime root. When the same identity repeats,
-LoopX advances the progression until the max interval; when the reset token
+LoopX advances the progression after the applied interval has elapsed, until
+the max interval. An immediate post-ACK readback remains on the acknowledged
+RRULE so repeated reconciliation converges rather than oscillates. When the reset token
 changes, the next projected RRULE returns to
 `reset_policy.codex_app_initial_rrule`. If the current desired RRULE is already
 applied, `recommended_rrule` is omitted and the host update should be skipped.

--- a/examples/control_plane/quota-scheduler-hint-compaction-smoke.py
+++ b/examples/control_plane/quota-scheduler-hint-compaction-smoke.py
@@ -265,7 +265,7 @@ def assert_compact_scheduler(name: str, source_payload: dict) -> None:
     expected_same_identity_action = (
         "keep_initial_interval_while_active_work"
         if compact["cadence_class"] == "active_work"
-        else "advance_index_after_scheduler_ack"
+        else "advance_index_after_applied_interval_elapsed"
     )
     assert stateful_detail["same_identity_action"] == expected_same_identity_action, (
         name,

--- a/examples/control_plane/quota-scheduler-policy-smoke.py
+++ b/examples/control_plane/quota-scheduler-policy-smoke.py
@@ -75,7 +75,7 @@ def assert_policy_case(
     expected_action: str,
     expected_rrule: str,
     expected_progression: list[int] | None = None,
-    expected_same_identity_action: str = "advance_index_after_scheduler_ack",
+    expected_same_identity_action: str = "advance_index_after_applied_interval_elapsed",
 ) -> None:
     quota_wrapper = _scheduler_hint(deepcopy(base_payload))
     extracted = build_scheduler_hint(

--- a/examples/control_plane/quota-scheduler-state-ack-smoke.py
+++ b/examples/control_plane/quota-scheduler-state-ack-smoke.py
@@ -840,6 +840,7 @@ def assert_cli_scheduler_ack_progression() -> None:
         assert "scheduler_hint" not in ack["before"], ack
         assert ack["after"] is None, ack
         assert ack["post_ack_contract"]["do_not_apply_successor_rrule_from_ack_response"] is True, ack
+        scheduler_state_path = Path(ack["scheduler_state_path"])
 
         second = run_cli(
             root,
@@ -855,10 +856,34 @@ def assert_cli_scheduler_ack_progression() -> None:
         )
         second_app = second["scheduler_hint"]["codex_app"]
         assert second_app["stateful_backoff"]["state_status"] == "same_identity", second
-        assert second_app["recommended_rrule"] != first_rrule, second
-        assert second_app["stateful_backoff"]["apply_needed"] is True, second
+        assert second_app["stateful_backoff"]["current_rrule"] == first_rrule, second
+        assert second_app["stateful_backoff"]["apply_needed"] is False, second
+        assert second_app["host_action"] == "none", second
+        assert "recommended_rrule" not in second_app, second
 
-        current = second
+        def age_applied_interval() -> None:
+            persisted = json.loads(scheduler_state_path.read_text(encoding="utf-8"))
+            persisted["updated_at"] = "2000-01-01T00:00:00+00:00"
+            scheduler_state_path.write_text(
+                json.dumps(persisted, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+
+        age_applied_interval()
+        current = run_cli(
+            root,
+            "quota",
+            "should-run",
+            "--goal-id",
+            "needs-operator",
+            "--agent-id",
+            agent_id,
+            registry_path=registry_path,
+            runtime=runtime,
+            project=project,
+        )
+        assert current["scheduler_hint"]["codex_app"]["recommended_rrule"] != first_rrule, current
+
         while current["scheduler_hint"]["codex_app"]["stateful_backoff"]["apply_needed"]:
             current_app = current["scheduler_hint"]["codex_app"]
             current_rrule = current_app["recommended_rrule"]
@@ -877,6 +902,23 @@ def assert_cli_scheduler_ack_progression() -> None:
                 project=project,
             )
             assert ack["ok"] is True, ack
+            settled = run_cli(
+                root,
+                "quota",
+                "should-run",
+                "--goal-id",
+                "needs-operator",
+                "--agent-id",
+                agent_id,
+                registry_path=registry_path,
+                runtime=runtime,
+                project=project,
+            )
+            settled_app = settled["scheduler_hint"]["codex_app"]
+            assert settled_app["stateful_backoff"]["current_rrule"] == current_rrule, settled
+            assert settled_app["stateful_backoff"]["apply_needed"] is False, settled
+            assert "recommended_rrule" not in settled_app, settled
+            age_applied_interval()
             current = run_cli(
                 root,
                 "quota",
@@ -1152,6 +1194,13 @@ def assert_cli_host_rrule_repairs_false_ack() -> None:
                 project=project,
             )
             assert ack["scheduler_state_mutated"] is True, ack
+            scheduler_state_path = Path(ack["scheduler_state_path"])
+            persisted = json.loads(scheduler_state_path.read_text(encoding="utf-8"))
+            persisted["updated_at"] = "2000-01-01T00:00:00+00:00"
+            scheduler_state_path.write_text(
+                json.dumps(persisted, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
             ledger_only = run_cli(
                 root,
                 "quota",
@@ -1298,6 +1347,33 @@ def assert_cli_host_match_ack_after_ambiguous_update() -> None:
         assert ack["ok"] is True, ack
         assert ack["scheduler_state_mutated"] is True, ack
         assert ack["host_match_ack"] is True, ack
+
+        settled = run_cli(
+            root,
+            "quota",
+            "should-run",
+            "--goal-id",
+            "needs-operator",
+            "--agent-id",
+            agent_id,
+            "--codex-app-current-rrule",
+            first_rrule,
+            registry_path=registry_path,
+            runtime=runtime,
+            project=project,
+        )
+        settled_app = settled["scheduler_hint"]["codex_app"]
+        assert settled_app["stateful_backoff"]["apply_needed"] is False, settled
+        assert "recommended_rrule" not in settled_app, settled
+        assert settled_app["stateful_backoff"]["host_observation"]["status"] == "matches_recommended", settled
+
+        scheduler_state_path = Path(ack["scheduler_state_path"])
+        persisted = json.loads(scheduler_state_path.read_text(encoding="utf-8"))
+        persisted["updated_at"] = "2000-01-01T00:00:00+00:00"
+        scheduler_state_path.write_text(
+            json.dumps(persisted, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
 
         advanced = run_cli(
             root,

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -69,6 +69,24 @@ def _scheduler_rrule_interval_minutes(value: Any) -> int | None:
     return interval if interval > 0 else None
 
 
+def _scheduler_progression_interval_elapsed(
+    scheduler_state: Mapping[str, Any],
+    *,
+    current_time: datetime,
+) -> bool:
+    """Advance only after the applied host cadence has had one real interval."""
+
+    updated_at = parse_scheduler_timestamp(scheduler_state.get("updated_at"))
+    applied_interval = _scheduler_rrule_interval_minutes(
+        scheduler_state.get("last_applied_rrule")
+    )
+    if updated_at is None or applied_interval is None:
+        # Legacy or partial state has no trustworthy settlement clock. Preserve
+        # the historical progression behavior instead of pinning it forever.
+        return True
+    return current_time >= updated_at + timedelta(minutes=applied_interval)
+
+
 def _user_gate_notification_cooldown(
     *,
     cadence_class: str,
@@ -1072,13 +1090,20 @@ def build_scheduler_hint(
                     applied_index = int(scheduler_state.get("progression_index"))
                 except (TypeError, ValueError):
                     applied_index = -1
-                next_index = (
-                    applied_index
-                    if all_host_update_failures
-                    else applied_index + 1
-                    if advance_same_identity
-                    else 0
-                )
+                if all_host_update_failures:
+                    next_index = applied_index
+                elif not advance_same_identity:
+                    next_index = 0
+                elif _scheduler_progression_interval_elapsed(
+                    scheduler_state,
+                    current_time=scheduler_now,
+                ):
+                    next_index = applied_index + 1
+                else:
+                    # An ACK settles the current target. A same-turn or early
+                    # reconciliation must verify convergence, not manufacture
+                    # the next backoff target before that cadence has elapsed.
+                    next_index = applied_index
                 current_index = min(
                     max(next_index, 0), len(codex_cadence_progression) - 1
                 )
@@ -1148,7 +1173,7 @@ def build_scheduler_hint(
             "ack_required_from_host_match": host_match_ack_needed,
             "persist": "reset_token|identity_signature|progression_index|last_applied_rrule|host_update_failures|host_update_failure_compat",
             "same_identity_action": (
-                "advance_index_after_scheduler_ack"
+                "advance_index_after_applied_interval_elapsed"
                 if advance_same_identity
                 else "keep_initial_interval_while_active_work"
             ),

--- a/tests/control_plane/test_scheduler_backoff_convergence.py
+++ b/tests/control_plane/test_scheduler_backoff_convergence.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from loopx.control_plane.scheduler import scheduler_hint as scheduler_hint_module
+from loopx.control_plane.scheduler.scheduler_hint import (
+    build_codex_app_scheduler_ack_event,
+    build_scheduler_hint,
+)
+
+
+GOAL_ID = "scheduler-backoff-convergence"
+AGENT_ID = "codex-fixture"
+HOST_15 = "FREQ=MINUTELY;INTERVAL=15"
+HOST_30 = "FREQ=MINUTELY;INTERVAL=30"
+
+
+def _monitor_decision(*, now: datetime, minutes_until_due: int) -> dict:
+    return {
+        "goal_id": GOAL_ID,
+        "agent_identity": {"agent_id": AGENT_ID},
+        "should_run": False,
+        "effective_action": "monitor_quiet_skip",
+        "recommended_action": "Wait for material monitor evidence.",
+        "heartbeat_recommendation": {
+            "recommended_mode": "monitor_quiet_until_material_transition",
+            "notify": "DONT_NOTIFY",
+        },
+        "interaction_contract": {
+            "schema_version": "loopx_interaction_contract_v0",
+            "mode": "monitor_quiet_skip",
+            "user_channel": {"action_required": False, "notify": "DONT_NOTIFY"},
+            "agent_channel": {
+                "must_attempt": False,
+                "delivery_allowed": False,
+                "quiet_noop_allowed": True,
+            },
+        },
+        "agent_todo_summary": {
+            "current_agent_claimed_monitor_items": [
+                {
+                    "todo_id": "todo_scheduler_convergence",
+                    "task_class": "continuous_monitor",
+                    "target_key": "scheduler-convergence",
+                    "cadence": "3m",
+                    "next_due_at": (
+                        now + timedelta(minutes=minutes_until_due)
+                    ).isoformat(),
+                    "expires_at": (
+                        now + timedelta(minutes=minutes_until_due + 60)
+                    ).isoformat(),
+                }
+            ],
+            "monitor_open_items": [],
+        },
+    }
+
+
+def _hint(
+    monkeypatch,
+    decision: dict,
+    *,
+    now: datetime,
+    scheduler_state: dict | None = None,
+    host_rrule: str | None = None,
+) -> dict:
+    monkeypatch.setattr(scheduler_hint_module, "now_utc", lambda: now)
+    return build_scheduler_hint(
+        decision,
+        codex_app_scheduler_state=scheduler_state,
+        codex_app_current_rrule=host_rrule,
+    )
+
+
+def _ack_state(hint: dict, *, applied_rrule: str, generated_at: datetime) -> dict:
+    event = build_codex_app_scheduler_ack_event(
+        {"goal_id": GOAL_ID, "scheduler_hint": hint},
+        agent_id=AGENT_ID,
+        applied_rrule=applied_rrule,
+        generated_at=generated_at.isoformat(),
+    )
+    return event["scheduler_ack_event"]["scheduler_state"]
+
+
+def test_monitor_ack_settles_before_progression_and_avoids_15_30_15_flip(
+    monkeypatch,
+) -> None:
+    now = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    decision = _monitor_decision(now=now, minutes_until_due=31)
+    first = _hint(monkeypatch, decision, now=now)
+    first_app = first["codex_app"]
+    assert first_app["recommended_rrule"] == HOST_15
+
+    settled_state = _ack_state(first, applied_rrule=HOST_15, generated_at=now)
+    immediate = _hint(
+        monkeypatch,
+        decision,
+        now=now,
+        scheduler_state=settled_state,
+        host_rrule=HOST_15,
+    )
+    immediate_app = immediate["codex_app"]
+    assert immediate_app["stateful_backoff"]["state_status"] == "same_identity"
+    assert immediate_app["stateful_backoff"]["current_rrule"] == HOST_15
+    assert immediate_app["stateful_backoff"]["apply_needed"] is False
+    assert immediate_app["stateful_backoff"]["host_observation"]["status"] == (
+        "matches_recommended"
+    )
+    assert "recommended_rrule" not in immediate_app
+
+    near_due = _hint(
+        monkeypatch,
+        decision,
+        now=now + timedelta(minutes=2),
+        scheduler_state=settled_state,
+        host_rrule=HOST_15,
+    )
+    near_due_app = near_due["codex_app"]
+    assert near_due_app["example_progression_minutes"] == [15]
+    assert near_due_app["stateful_backoff"]["current_rrule"] == HOST_15
+    assert near_due_app["stateful_backoff"]["apply_needed"] is False
+    assert "recommended_rrule" not in near_due_app
+
+
+def test_monitor_progression_advances_after_elapsed_interval_and_then_converges(
+    monkeypatch,
+) -> None:
+    now = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    decision = _monitor_decision(now=now, minutes_until_due=119)
+    first = _hint(monkeypatch, decision, now=now)
+    settled_15 = _ack_state(first, applied_rrule=HOST_15, generated_at=now)
+
+    early = _hint(
+        monkeypatch,
+        decision,
+        now=now + timedelta(minutes=14),
+        scheduler_state=settled_15,
+        host_rrule=HOST_15,
+    )
+    assert early["codex_app"]["stateful_backoff"]["current_rrule"] == HOST_15
+    assert early["codex_app"]["stateful_backoff"]["apply_needed"] is False
+
+    elapsed = now + timedelta(minutes=15)
+    advance = _hint(
+        monkeypatch,
+        decision,
+        now=elapsed,
+        scheduler_state=settled_15,
+        host_rrule=HOST_15,
+    )
+    advance_app = advance["codex_app"]
+    assert advance_app["recommended_rrule"] == HOST_30
+    assert advance_app["stateful_backoff"]["host_observation"]["status"] == (
+        "drift_detected"
+    )
+
+    settled_30 = _ack_state(advance, applied_rrule=HOST_30, generated_at=elapsed)
+    converged = _hint(
+        monkeypatch,
+        decision,
+        now=elapsed,
+        scheduler_state=settled_30,
+        host_rrule=HOST_30,
+    )
+    converged_app = converged["codex_app"]
+    assert converged_app["stateful_backoff"]["current_rrule"] == HOST_30
+    assert converged_app["stateful_backoff"]["apply_needed"] is False
+    assert converged_app["stateful_backoff"]["host_observation"]["status"] == (
+        "matches_recommended"
+    )
+    assert "recommended_rrule" not in converged_app


### PR DESCRIPTION
## Summary

- treat scheduler ACK as settlement of the current host RRULE, not proof that another cadence interval elapsed
- advance unchanged monitor backoff only after one real applied interval, preventing the reproduced 15 -> 30 -> 15 oscillation
- extend focused unit/CLI convergence coverage and document the host contract

## Validation

- `uv run --extra test pytest -q tests/control_plane` (272 passed)
- scheduler state ACK, policy, and hint compaction smokes
- Ruff checks and Python compile checks
- `loopx --format json canary premerge --from-git-diff` (18/18 selected checks passed; public boundary clean; no manual holds)

## Boundary

- no project/private state, credentials, raw gate content, or production actions
- generated local `uv.lock` excluded

## Residual risk

- legacy/partial scheduler state without a trustworthy settlement clock retains historical immediate progression for compatibility; newly ACKed state uses elapsed-time convergence.