### PR TITLE
Stop repeated LoopX Turn recovery loops in SkillsBench

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -981,6 +981,18 @@ def test_skillsbench_product_mode_soft_verify_default_is_every_round() -> None:
     )
 
 
+def test_skillsbench_turn_uses_final_only_soft_verify() -> None:
+    args = parse_args(["--route", "loopx-turn-agent-cli"])
+    assert args.product_mode_soft_verify_policy == "every-round"
+    assert (
+        product_mode_soft_verify_policy_for_route(
+            "loopx-turn-agent-cli",
+            args.product_mode_soft_verify_policy,
+        )
+        == "final-only"
+    )
+
+
 def test_reverse_channel_first_action_timeout_stops_codex_process() -> None:
     start = time.monotonic()
     response = _run_codex_payload(
@@ -14628,6 +14640,7 @@ if __name__ == "__main__":
     test_skillsbench_batch_case_cli_filters_internal_aggregate_flag()
     test_skillsbench_formal_product_mode_rejects_tiny_round_budget()
     test_skillsbench_product_mode_soft_verify_default_is_every_round()
+    test_skillsbench_turn_uses_final_only_soft_verify()
     test_reverse_channel_first_action_timeout_stops_codex_process()
     test_reverse_channel_timeout_survives_blocked_stdin_write()
     test_reverse_channel_raw_prompt_does_not_require_bridge_first_action()

--- a/examples/skillsbench-typed-repair-smoke.py
+++ b/examples/skillsbench-typed-repair-smoke.py
@@ -9,11 +9,13 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.benchmark_adapters.skillsbench_typed_repair import (
+    advance_skillsbench_typed_repair_controller,
     begin_skillsbench_typed_repair,
     build_skillsbench_typed_repair_prompt,
     record_skillsbench_typed_repair_terminal,
     resolve_skillsbench_typed_repair,
     skillsbench_projected_open_todo_count,
+    skillsbench_turn_recovery_checkpoint,
 )
 from loopx.benchmark import build_skillsbench_benchflow_result_benchmark_run
 from loopx.control_plane.runtime.goal_start_control_score import (
@@ -34,6 +36,36 @@ def base_trace() -> dict[str, object]:
                 "todo_id": "todo_fixture_primary",
             }
         ],
+    }
+
+
+def failed_turn_execution() -> dict[str, object]:
+    return {
+        "status": "failed",
+        "validation": {
+            "status": "failed",
+            "recovery_kind": "repair_required",
+        },
+        "receipt": {
+            "status": "failed",
+            "failed_phase": "validation",
+        },
+        "effects": {
+            "state_written": False,
+            "quota_spent": False,
+        },
+    }
+
+
+def committed_turn_execution() -> dict[str, object]:
+    return {
+        "status": "committed",
+        "validation": {"status": "passed"},
+        "receipt": {"status": "committed"},
+        "effects": {
+            "state_written": True,
+            "quota_spent": True,
+        },
     }
 
 
@@ -115,6 +147,132 @@ def test_todo_identity_or_task_validation_delta_allows_continuation() -> None:
     assert task_outcome["delta_observed"] is True, task_outcome
     assert task_outcome["task_or_validation_delta"] is True, task_outcome
     assert task_outcome["task_facing_success_delta"] == 1, task_outcome
+
+
+def test_turn_recovery_requires_todo_or_committed_validation_delta() -> None:
+    repeated_failure_trace = base_trace()
+    repeated_failure_trace["loopx_turn_executions"] = [failed_turn_execution()]
+    checkpoint = skillsbench_turn_recovery_checkpoint(repeated_failure_trace)
+    assert checkpoint["repair_required"] is True, checkpoint
+    assert checkpoint["failed_transaction_with_durable_effects"] is False, checkpoint
+    assert checkpoint["recovery_required_count"] == 1, checkpoint
+    assert begin_skillsbench_typed_repair(
+        repeated_failure_trace,
+        trigger_round=2,
+        scheduled_round=3,
+        trigger_kind="turn_transaction_recovery",
+    )
+    repeated_failure_trace[
+        "remote_command_file_bridge_agent_task_facing_success_count"
+    ] = 12
+    repeated_failure_trace["loopx_turn_executions"].append(failed_turn_execution())
+    repeated_outcome = resolve_skillsbench_typed_repair(
+        repeated_failure_trace,
+        agent_round=3,
+    )
+    assert repeated_outcome["task_facing_success_delta"] == 10, repeated_outcome
+    assert repeated_outcome["turn_execution_count_delta"] == 1, repeated_outcome
+    assert repeated_outcome["turn_recovery_required_count_delta"] == 1, (
+        repeated_outcome
+    )
+    assert repeated_outcome["turn_committed_count_delta"] == 0, repeated_outcome
+    assert repeated_outcome["turn_validation_delta"] is False, repeated_outcome
+    assert repeated_outcome["delta_observed"] is False, repeated_outcome
+
+    committed_trace = base_trace()
+    committed_trace["loopx_turn_executions"] = [failed_turn_execution()]
+    assert begin_skillsbench_typed_repair(
+        committed_trace,
+        trigger_round=4,
+        scheduled_round=5,
+        trigger_kind="turn_transaction_recovery",
+    )
+    committed_trace["loopx_turn_executions"].append(committed_turn_execution())
+    committed_outcome = resolve_skillsbench_typed_repair(
+        committed_trace,
+        agent_round=5,
+    )
+    assert committed_outcome["turn_validation_delta"] is True, committed_outcome
+    assert committed_outcome["turn_committed_count_delta"] == 1, committed_outcome
+    assert committed_outcome["delta_observed"] is True, committed_outcome
+
+    prompt = build_skillsbench_typed_repair_prompt(
+        scheduled_round=5,
+        max_rounds=8,
+        case_state_path="/app/.codex/goals/case/ACTIVE_GOAL_STATE.md",
+        loop_alignment_contract="Keep the case todo ledger current. ",
+        trigger_kind="turn_transaction_recovery",
+    )
+    assert "later Turn receipt commits" in prompt, prompt
+    assert "reward" not in prompt.lower(), prompt
+    assert "verifier" not in prompt.lower(), prompt
+
+
+def test_turn_recovery_controller_stops_or_continues_from_receipts() -> None:
+    repeated_failure_trace = base_trace()
+    repeated_failure_trace["loopx_turn_executions"] = [failed_turn_execution()]
+    decision = advance_skillsbench_typed_repair_controller(
+        repeated_failure_trace,
+        agent_round=2,
+        scheduled_round=3,
+        max_rounds=8,
+        task_instruction_sent=True,
+    )
+    assert decision["action"] == "send_repair_prompt", decision
+    repeated_failure_trace[
+        "remote_command_file_bridge_agent_task_facing_success_count"
+    ] = 12
+    repeated_failure_trace["loopx_turn_executions"].append(failed_turn_execution())
+    decision = advance_skillsbench_typed_repair_controller(
+        repeated_failure_trace,
+        agent_round=3,
+        scheduled_round=4,
+        max_rounds=8,
+        task_instruction_sent=True,
+    )
+    assert decision["action"] == "stop", decision
+    assert repeated_failure_trace["product_mode_typed_repair_terminal_reason"] == (
+        "turn_repair_round_without_todo_or_committed_validation_delta"
+    )
+
+    committed_trace = base_trace()
+    committed_trace["loopx_turn_executions"] = [failed_turn_execution()]
+    decision = advance_skillsbench_typed_repair_controller(
+        committed_trace,
+        agent_round=4,
+        scheduled_round=5,
+        max_rounds=8,
+        task_instruction_sent=True,
+    )
+    assert decision["action"] == "send_repair_prompt", decision
+    committed_trace["loopx_turn_executions"].append(committed_turn_execution())
+    decision = advance_skillsbench_typed_repair_controller(
+        committed_trace,
+        agent_round=5,
+        scheduled_round=6,
+        max_rounds=8,
+        task_instruction_sent=True,
+    )
+    assert decision["action"] == "continue", decision
+
+    inconsistent_trace = base_trace()
+    failed_with_effects = failed_turn_execution()
+    failed_with_effects["effects"] = {
+        "state_written": True,
+        "quota_spent": False,
+    }
+    inconsistent_trace["loopx_turn_executions"] = [failed_with_effects]
+    decision = advance_skillsbench_typed_repair_controller(
+        inconsistent_trace,
+        agent_round=6,
+        scheduled_round=7,
+        max_rounds=8,
+        task_instruction_sent=True,
+    )
+    assert decision["action"] == "stop", decision
+    assert inconsistent_trace["product_mode_typed_repair_terminal_reason"] == (
+        "failed_turn_transaction_has_durable_effects"
+    )
 
 
 def test_unchanged_frontier_has_typed_terminal_receipt() -> None:
@@ -221,6 +379,8 @@ if __name__ == "__main__":
     test_one_attempt_per_unchanged_frontier_and_reward_blind_prompt()
     test_open_todo_projection_fails_closed_when_public_history_is_saturated()
     test_todo_identity_or_task_validation_delta_allows_continuation()
+    test_turn_recovery_requires_todo_or_committed_validation_delta()
+    test_turn_recovery_controller_stops_or_continues_from_receipts()
     test_unchanged_frontier_has_typed_terminal_receipt()
     test_goal_start_control_score_preserves_typed_repair_fields()
     test_typed_repair_projection_survives_result_compaction()

--- a/loopx/benchmark_adapters/skillsbench_typed_repair.py
+++ b/loopx/benchmark_adapters/skillsbench_typed_repair.py
@@ -4,6 +4,11 @@ from typing import Any, Mapping
 
 from loopx.control_plane.runtime.public_safety import compact_loopx_command_records
 from loopx.control_plane.runtime.public_safety import public_safe_compact_text
+from loopx.control_plane.turn_driver.transaction import (
+    loopx_turn_execution_committed,
+    loopx_turn_execution_has_durable_effects,
+    loopx_turn_execution_recovery_required,
+)
 
 
 SKILLSBENCH_TYPED_REPAIR_POLICY_ID = "one_typed_repair_per_frontier_v0"
@@ -21,6 +26,7 @@ _TYPED_REPAIR_BOOL_FIELDS = (
     "product_mode_typed_repair_pending",
     "product_mode_typed_repair_todo_identity_observed",
     "product_mode_typed_repair_task_or_validation_delta",
+    "product_mode_typed_repair_turn_validation_delta",
     "product_mode_typed_repair_delta_observed",
     "product_mode_typed_repair_terminal",
     "product_mode_typed_repair_terminal_receipt_consistent",
@@ -31,11 +37,15 @@ _TYPED_REPAIR_COUNT_FIELDS = (
     "product_mode_typed_repair_round_entered_count",
     "product_mode_typed_repair_resolved_round",
     "product_mode_typed_repair_task_facing_success_delta",
+    "product_mode_typed_repair_turn_execution_count_delta",
+    "product_mode_typed_repair_turn_committed_count_delta",
+    "product_mode_typed_repair_turn_recovery_required_count_delta",
     "product_mode_typed_repair_terminal_round",
     "product_mode_typed_repair_open_todo_count_public",
 )
 _TYPED_REPAIR_TEXT_FIELDS = (
     "product_mode_typed_repair_policy_id",
+    "product_mode_typed_repair_trigger_kind",
     "product_mode_typed_repair_terminal_reason",
 )
 
@@ -52,6 +62,64 @@ def _command_records(trace: Mapping[str, Any]) -> list[dict[str, str]]:
         trace.get("remote_command_file_bridge_agent_successful_loopx_command_records"),
         limit=_COMMAND_RECORD_LIMIT,
     )
+
+
+def _turn_executions(trace: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    executions = trace.get("loopx_turn_executions")
+    if not isinstance(executions, list):
+        return []
+    return [item for item in executions if isinstance(item, Mapping)]
+
+
+def _turn_outcome_counts(trace: Mapping[str, Any]) -> dict[str, int]:
+    executions = _turn_executions(trace)
+    return {
+        "execution_count": len(executions),
+        "committed_count": sum(
+            loopx_turn_execution_committed(item) for item in executions
+        ),
+        "recovery_required_count": sum(
+            loopx_turn_execution_recovery_required(item) for item in executions
+        ),
+    }
+
+
+def skillsbench_turn_recovery_checkpoint(
+    trace: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return the public Turn receipt that should steer one typed repair."""
+
+    executions = _turn_executions(trace)
+    latest = executions[-1] if executions else {}
+    recovery_required = bool(
+        latest
+        and loopx_turn_execution_recovery_required(latest)
+        and not loopx_turn_execution_has_durable_effects(latest)
+    )
+    failed_transaction_with_durable_effects = bool(
+        latest
+        and loopx_turn_execution_recovery_required(latest)
+        and loopx_turn_execution_has_durable_effects(latest)
+    )
+    validation = (
+        latest.get("validation")
+        if isinstance(latest.get("validation"), Mapping)
+        else {}
+    )
+    counts = _turn_outcome_counts(trace)
+    return {
+        "schema_version": "skillsbench_turn_recovery_checkpoint_v0",
+        "observed": bool(latest),
+        "repair_required": recovery_required,
+        "failed_transaction_with_durable_effects": (
+            failed_transaction_with_durable_effects
+        ),
+        "recovery_kind": public_safe_compact_text(
+            validation.get("recovery_kind"), limit=80
+        ),
+        **counts,
+        "raw_material_recorded": False,
+    }
 
 
 def compact_skillsbench_typed_repair_counters(
@@ -139,6 +207,7 @@ def capture_skillsbench_typed_repair_frontier(
             and todo_id not in todo_ids
         ):
             todo_ids.append(todo_id)
+    turn_counts = _turn_outcome_counts(trace)
     return {
         "schema_version": SKILLSBENCH_TYPED_REPAIR_SNAPSHOT_SCHEMA_VERSION,
         "successful_command_record_count": len(records),
@@ -148,6 +217,9 @@ def capture_skillsbench_typed_repair_frontier(
         ),
         "todo_identity_count": len(todo_ids),
         "todo_ids": todo_ids[:16],
+        "turn_execution_count": turn_counts["execution_count"],
+        "turn_committed_count": turn_counts["committed_count"],
+        "turn_recovery_required_count": turn_counts["recovery_required_count"],
         "raw_material_recorded": False,
     }
 
@@ -166,6 +238,9 @@ def skillsbench_typed_repair_frontier_signature(
             selected_todo_id[:100] or "no_selected_todo",
             str(_count(snapshot, "successful_command_record_count")),
             str(_count(snapshot, "task_facing_success_count")),
+            str(_count(snapshot, "turn_execution_count")),
+            str(_count(snapshot, "turn_committed_count")),
+            str(_count(snapshot, "turn_recovery_required_count")),
             ",".join(safe_todo_ids) or "no_todo_identity",
         )
     )[:420]
@@ -176,6 +251,7 @@ def begin_skillsbench_typed_repair(
     *,
     trigger_round: int,
     scheduled_round: int,
+    trigger_kind: str = "declared_done_below_passing_reward",
 ) -> bool:
     snapshot = capture_skillsbench_typed_repair_frontier(trace)
     signature = skillsbench_typed_repair_frontier_signature(
@@ -194,6 +270,10 @@ def begin_skillsbench_typed_repair(
     trace["product_mode_typed_repair_pending"] = True
     trace["product_mode_typed_repair_policy_id"] = (
         SKILLSBENCH_TYPED_REPAIR_POLICY_ID
+    )
+    trace["product_mode_typed_repair_trigger_kind"] = (
+        public_safe_compact_text(trigger_kind, limit=120)
+        or "declared_done_below_passing_reward"
     )
     trace["product_mode_typed_repair_trigger_round"] = trigger_round
     trace["product_mode_typed_repair_round_entered"] = scheduled_round
@@ -246,7 +326,28 @@ def resolve_skillsbench_typed_repair(
         - _count(snapshot, "task_facing_success_count"),
     )
     todo_identity_observed = bool(todo_ids)
-    task_or_validation_delta = task_success_delta > 0
+    baseline_turn_count = _count(snapshot, "turn_execution_count")
+    current_turns = _turn_executions(trace)
+    new_turns = (
+        current_turns[baseline_turn_count:]
+        if baseline_turn_count <= len(current_turns)
+        else []
+    )
+    turn_execution_count_delta = len(new_turns)
+    turn_committed_count_delta = sum(
+        loopx_turn_execution_committed(item) for item in new_turns
+    )
+    turn_recovery_required_count_delta = sum(
+        loopx_turn_execution_recovery_required(item) for item in new_turns
+    )
+    turn_validation_delta = turn_committed_count_delta > 0
+    trigger_kind = public_safe_compact_text(
+        trace.get("product_mode_typed_repair_trigger_kind"), limit=120
+    )
+    if trigger_kind == "turn_transaction_recovery":
+        task_or_validation_delta = turn_validation_delta
+    else:
+        task_or_validation_delta = task_success_delta > 0 or turn_validation_delta
     delta_observed = todo_identity_observed or task_or_validation_delta
     outcome = {
         "schema_version": "skillsbench_typed_repair_delta_v0",
@@ -255,6 +356,12 @@ def resolve_skillsbench_typed_repair(
         "todo_ids": todo_ids[:16],
         "task_or_validation_delta": task_or_validation_delta,
         "task_facing_success_delta": task_success_delta,
+        "turn_execution_count_delta": turn_execution_count_delta,
+        "turn_committed_count_delta": turn_committed_count_delta,
+        "turn_recovery_required_count_delta": (
+            turn_recovery_required_count_delta
+        ),
+        "turn_validation_delta": turn_validation_delta,
         "delta_observed": delta_observed,
         "raw_material_recorded": False,
     }
@@ -270,9 +377,104 @@ def resolve_skillsbench_typed_repair(
     trace["product_mode_typed_repair_task_facing_success_delta"] = (
         task_success_delta
     )
+    trace["product_mode_typed_repair_turn_execution_count_delta"] = (
+        turn_execution_count_delta
+    )
+    trace["product_mode_typed_repair_turn_committed_count_delta"] = (
+        turn_committed_count_delta
+    )
+    trace["product_mode_typed_repair_turn_recovery_required_count_delta"] = (
+        turn_recovery_required_count_delta
+    )
+    trace["product_mode_typed_repair_turn_validation_delta"] = turn_validation_delta
     trace["product_mode_typed_repair_delta_observed"] = delta_observed
     trace["product_mode_typed_repair_delta"] = outcome
     return outcome
+
+
+def advance_skillsbench_typed_repair_controller(
+    trace: dict[str, Any],
+    *,
+    agent_round: int,
+    scheduled_round: int,
+    max_rounds: int,
+    task_instruction_sent: bool,
+) -> dict[str, str]:
+    """Advance the typed-repair state machine from public controller evidence."""
+
+    if trace.get("product_mode_typed_repair_pending") is True:
+        trigger_kind = public_safe_compact_text(
+            trace.get("product_mode_typed_repair_trigger_kind"), limit=120
+        )
+        outcome = resolve_skillsbench_typed_repair(trace, agent_round=agent_round)
+        if outcome.get("delta_observed") is not True:
+            reason = (
+                "turn_repair_round_without_todo_or_committed_validation_delta"
+                if trigger_kind == "turn_transaction_recovery"
+                else "repair_round_without_todo_task_or_validation_delta"
+            )
+            record_skillsbench_typed_repair_terminal(
+                trace,
+                agent_round=agent_round,
+                reason=reason,
+            )
+            return {
+                "action": "stop",
+                "last_decision": "stop_after_product_mode_typed_repair_without_delta",
+            }
+        if agent_round >= max_rounds:
+            record_skillsbench_typed_repair_terminal(
+                trace,
+                agent_round=agent_round,
+                reason="repair_delta_observed_at_budget_boundary",
+            )
+            return {
+                "action": "stop",
+                "last_decision": "stop_after_product_mode_typed_repair_budget",
+            }
+        return {
+            "action": "continue",
+            "last_decision": "continue_after_product_mode_typed_repair_delta",
+        }
+
+    if not task_instruction_sent:
+        return {}
+    checkpoint = skillsbench_turn_recovery_checkpoint(trace)
+    trace["product_mode_turn_recovery_checkpoint"] = checkpoint
+    if checkpoint.get("failed_transaction_with_durable_effects") is True:
+        record_skillsbench_typed_repair_terminal(
+            trace,
+            agent_round=agent_round,
+            reason="failed_turn_transaction_has_durable_effects",
+        )
+        return {
+            "action": "stop",
+            "last_decision": "stop_after_failed_turn_transaction_with_durable_effects",
+        }
+    if checkpoint.get("repair_required") is not True:
+        return {}
+    if not begin_skillsbench_typed_repair(
+        trace,
+        trigger_round=agent_round,
+        scheduled_round=scheduled_round,
+        trigger_kind="turn_transaction_recovery",
+    ):
+        record_skillsbench_typed_repair_terminal(
+            trace,
+            agent_round=agent_round,
+            reason="unchanged_turn_recovery_frontier_already_repaired",
+        )
+        return {
+            "action": "stop",
+            "last_decision": "stop_after_repeated_turn_recovery_frontier",
+        }
+    return {
+        "action": "send_repair_prompt",
+        "last_decision": (
+            "send_product_mode_typed_repair_after_turn_validation_failure"
+        ),
+        "trigger_kind": "turn_transaction_recovery",
+    }
 
 
 def build_skillsbench_typed_repair_prompt(
@@ -282,7 +484,15 @@ def build_skillsbench_typed_repair_prompt(
     case_state_path: str,
     loop_alignment_contract: str,
     persistent_constraint_clause: str = "",
+    trigger_kind: str = "declared_done_below_passing_reward",
 ) -> str:
+    turn_recovery_clause = (
+        " The previous public Turn receipt requires recovery. This round counts "
+        "as validation progress only if a later Turn receipt commits, or if a "
+        "new scoped todo identity records a genuinely changed frontier."
+        if trigger_kind == "turn_transaction_recovery"
+        else ""
+    )
     return (
         f"Scheduled typed repair/replan round {scheduled_round} of {max_rounds}. "
         "This checkpoint is selected only from the public LoopX frontier. "
@@ -293,6 +503,7 @@ def build_skillsbench_typed_repair_prompt(
         "The fixed loop may continue only when this round adds a todo identity or "
         "a successful task-facing/validation operation; otherwise the controller "
         "will close the unchanged frontier with a typed terminal receipt. "
+        f"{turn_recovery_clause} "
         f"{loop_alignment_contract}"
         f"{persistent_constraint_clause}"
     )

--- a/loopx/control_plane/runtime/skillsbench_post_run_debug.py
+++ b/loopx/control_plane/runtime/skillsbench_post_run_debug.py
@@ -12,6 +12,10 @@ from .public_safety import (
     public_safe_compact_list,
     public_safe_compact_text,
 )
+from ..turn_driver.transaction import (
+    loopx_turn_execution_committed,
+    loopx_turn_execution_has_durable_effects,
+)
 
 MAX_SKILLSBENCH_DEBUG_LIST_ITEMS = 5
 
@@ -70,13 +74,7 @@ def _skillsbench_turn_transaction_outcome(run: dict[str, Any]) -> dict[str, Any]
         )
         state_written = effects.get("state_written") is True
         quota_spent = effects.get("quota_spent") is True
-        committed = bool(
-            execution.get("status") == "committed"
-            and receipt.get("status") == "committed"
-            and validation.get("status") == "passed"
-            and state_written
-            and quota_spent
-        )
+        committed = loopx_turn_execution_committed(execution)
         validation_failed = bool(
             validation.get("status") == "failed"
             or receipt.get("failed_phase") == "validation"
@@ -93,7 +91,7 @@ def _skillsbench_turn_transaction_outcome(run: dict[str, Any]) -> dict[str, Any]
         state_written_count += int(state_written)
         quota_spent_count += int(quota_spent)
         failed_transaction_with_durable_effect_count += int(
-            validation_failed and (state_written or quota_spent)
+            validation_failed and loopx_turn_execution_has_durable_effects(execution)
         )
 
     execution_count = len(executions)

--- a/loopx/control_plane/turn_driver/__init__.py
+++ b/loopx/control_plane/turn_driver/__init__.py
@@ -27,6 +27,9 @@ from .transaction import (
     LOOPX_TURN_RESULT_SCHEMA_VERSION,
     LoopXTurnResultKind,
     build_loopx_turn_transaction_plan,
+    loopx_turn_execution_committed,
+    loopx_turn_execution_has_durable_effects,
+    loopx_turn_execution_recovery_required,
     validate_loopx_turn_receipt,
 )
 
@@ -43,6 +46,9 @@ __all__ = [
     "build_loopx_turn_host_request",
     "build_loopx_turn_command_validator",
     "build_loopx_turn_transaction_plan",
+    "loopx_turn_execution_committed",
+    "loopx_turn_execution_has_durable_effects",
+    "loopx_turn_execution_recovery_required",
     "load_loopx_turn_plan_from_journal",
     "load_codex_cli_session",
     "normalize_host_argv",

--- a/loopx/control_plane/turn_driver/transaction.py
+++ b/loopx/control_plane/turn_driver/transaction.py
@@ -77,6 +77,49 @@ def _canonical_hash(value: Any) -> str:
     return "sha256:" + sha256(encoded).hexdigest()
 
 
+def loopx_turn_execution_committed(execution: Mapping[str, Any]) -> bool:
+    """Return whether one public execution completed its durable transaction."""
+
+    validation = _mapping(execution.get("validation"))
+    receipt = _mapping(execution.get("receipt"))
+    effects = _mapping(execution.get("effects"))
+    return bool(
+        execution.get("status") == "committed"
+        and receipt.get("status") == "committed"
+        and validation.get("status") == "passed"
+        and effects.get("state_written") is True
+        and effects.get("quota_spent") is True
+    )
+
+
+def loopx_turn_execution_recovery_required(
+    execution: Mapping[str, Any],
+) -> bool:
+    """Return whether a failed public execution requests repair or replan."""
+
+    validation = _mapping(execution.get("validation"))
+    receipt = _mapping(execution.get("receipt"))
+    return bool(
+        validation.get("recovery_kind") in {"repair_required", "replan_required"}
+        and (
+            validation.get("status") == "failed"
+            or receipt.get("failed_phase") == "validation"
+            or execution.get("status") in {"failed", "validation_failed"}
+        )
+    )
+
+
+def loopx_turn_execution_has_durable_effects(
+    execution: Mapping[str, Any],
+) -> bool:
+    """Return whether an execution wrote state or spent quota."""
+
+    effects = _mapping(execution.get("effects"))
+    return bool(
+        effects.get("state_written") is True or effects.get("quota_spent") is True
+    )
+
+
 def build_loopx_turn_transaction_plan(
     *,
     planned: bool,

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -134,10 +134,10 @@ from loopx.benchmark_adapters.skillsbench_setup_preflight import (  # noqa: E402
     run_setup_only_public_preflight,
 )
 from loopx.benchmark_adapters.skillsbench_typed_repair import (  # noqa: E402
+    advance_skillsbench_typed_repair_controller,
     begin_skillsbench_typed_repair,
     build_skillsbench_typed_repair_prompt,
     record_skillsbench_typed_repair_terminal,
-    resolve_skillsbench_typed_repair,
     skillsbench_projected_open_todo_count,
 )
 from loopx.benchmark_adapters.skillsbench_turn_route import (  # noqa: E402
@@ -237,6 +237,11 @@ def product_mode_soft_verify_policy_for_route(
     route: str,
     requested_policy: str,
 ) -> str:
+    if route == LOOPX_TURN_AGENT_CLI_ROUTE:
+        # Turn owns a separate public workspace validator and recovery receipt.
+        # Re-running the private official verifier every round duplicates that
+        # control signal and can exhaust the agent timeout before final scoring.
+        return "final-only"
     if route in PRODUCT_MODE_CONTROLLER_ROUTES:
         return requested_policy
     return "every-round"
@@ -12995,40 +13000,33 @@ def _build_product_mode_user(
                             scheduled_round=round + 1,
                             task_instruction=instruction,
                         )
-                    if trace.get("product_mode_typed_repair_pending") is True:
-                        repair_outcome = resolve_skillsbench_typed_repair(
-                            trace,
-                            agent_round=round,
-                        )
+                    repair_decision = advance_skillsbench_typed_repair_controller(
+                        trace,
+                        agent_round=round,
+                        scheduled_round=round + 1,
+                        max_rounds=max_rounds,
+                        task_instruction_sent=self._task_instruction_sent,
+                    )
+                    if repair_decision:
                         _inc_counter(trace, "controller_action_decisions")
-                        if repair_outcome.get("delta_observed") is not True:
-                            record_skillsbench_typed_repair_terminal(
-                                trace,
-                                agent_round=round,
-                                reason="repair_round_without_todo_task_or_validation_delta",
-                            )
+                        trace["last_decision"] = repair_decision["last_decision"]
+                        if repair_decision["action"] == "stop":
                             _inc_counter(trace, "stop_decision_count")
-                            trace["last_decision"] = (
-                                "stop_after_product_mode_typed_repair_without_delta"
-                            )
-                            return None
-                        if round >= max_rounds:
-                            record_skillsbench_typed_repair_terminal(
-                                trace,
-                                agent_round=round,
-                                reason="repair_delta_observed_at_budget_boundary",
-                            )
-                            _inc_counter(trace, "stop_decision_count")
-                            trace["last_decision"] = (
-                                "stop_after_product_mode_typed_repair_budget"
-                            )
                             return None
                         _inc_counter(trace, "followup_prompt_count")
-                        trace["last_decision"] = (
-                            "continue_after_product_mode_typed_repair_delta"
-                        )
-                        return self._scheduled_continuation_prompt(
+                        if repair_decision["action"] == "continue":
+                            return self._scheduled_continuation_prompt(
+                                scheduled_round=round + 1,
+                            )
+                        return build_skillsbench_typed_repair_prompt(
                             scheduled_round=round + 1,
+                            max_rounds=max_rounds,
+                            case_state_path=case_state_path,
+                            loop_alignment_contract=goal_start_loop_alignment_contract(),
+                            persistent_constraint_clause=(
+                                self._persistent_constraint_clause
+                            ),
+                            trigger_kind=repair_decision.get("trigger_kind", ""),
                         )
                     if (
                         self._task_instruction_sent

--- a/tests/test_loopx_turn_transaction.py
+++ b/tests/test_loopx_turn_transaction.py
@@ -6,6 +6,9 @@ from loopx.control_plane.turn_driver import (
     LOOPX_TURN_RESULT_SCHEMA_VERSION,
     LoopXTurnResultKind,
     build_loopx_turn_transaction_plan,
+    loopx_turn_execution_committed,
+    loopx_turn_execution_has_durable_effects,
+    loopx_turn_execution_recovery_required,
     validate_loopx_turn_receipt,
 )
 
@@ -233,3 +236,31 @@ def test_non_executable_plan_rejects_a_result() -> None:
 
     assert receipt["ok"] is False
     assert "not executable" in " ".join(receipt["errors"])
+
+
+def test_public_execution_outcome_predicates_share_transaction_semantics() -> None:
+    committed = {
+        "status": "committed",
+        "validation": {"status": "passed"},
+        "receipt": {"status": "committed"},
+        "effects": {"state_written": True, "quota_spent": True},
+    }
+    repair = {
+        "status": "failed",
+        "validation": {
+            "status": "failed",
+            "recovery_kind": "repair_required",
+        },
+        "receipt": {"status": "failed", "failed_phase": "validation"},
+        "effects": {"state_written": False, "quota_spent": False},
+    }
+
+    assert loopx_turn_execution_committed(committed) is True
+    assert loopx_turn_execution_recovery_required(committed) is False
+    assert loopx_turn_execution_has_durable_effects(committed) is True
+    assert loopx_turn_execution_committed(repair) is False
+    assert loopx_turn_execution_recovery_required(repair) is True
+    assert loopx_turn_execution_has_durable_effects(repair) is False
+
+    repair["effects"] = {"state_written": True, "quota_spent": False}
+    assert loopx_turn_execution_has_durable_effects(repair) is True


### PR DESCRIPTION
## Summary

- make LoopX Turn use final-only intermediate soft verification because Turn already emits a public workspace-validation receipt
- drive one typed repair from a recovery-required Turn receipt, and stop an unchanged frontier unless a later receipt commits or a new scoped todo is created
- share public Turn transaction outcome predicates with post-run closeout/debug classification

A matched Turn run exposed three recovery-required validation receipts followed by repeated intermediate verifier timeouts, so the official verifier was never attempted. This change makes the public Turn receipt steer recovery and prevents duplicated verifier work from consuming the case timeout.

## Validation

- `python3 examples/skillsbench-typed-repair-smoke.py`
- `python3 examples/skillsbench-post-run-debug-gate-smoke.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- public-safe compact replay of the observed receipt sequence: repair, then terminal stop on another uncommitted receipt
- `loopx canary premerge --from-git-diff --tier standard`: 18/18 checks passed; public boundary scan clean for all 8 changed files

## Risk and merge hold

The canary reports its standard `benchmark_sensitive` manual hold. The owner has explicitly authorized self-merge for LoopX Turn and benchmark PRs. This PR does not change scoring, task semantics, leaderboard/submission behavior, permissions, or launch any benchmark job; it changes controller recovery and validation cadence only. No raw task text, trajectories, verifier output, credentials, local paths, or generated benchmark evidence are included.