### PR TITLE
Mount canonical LoopX source for Turn cases

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -7135,34 +7135,38 @@ def test_loopx_source_mount_contract_uses_real_cli_source_not_local_installer() 
         source_dir = Path(tmp)
         (source_dir / "loopx").mkdir()
         (source_dir / "loopx" / "cli.py").write_text("# source fixture\n")
-        args = parse_args(
-            [
-                "--route",
-                "loopx-product-mode",
-                "--loopx-source-dir",
-                str(source_dir),
-            ]
-        )
-        contract = _loopx_source_mount_contract(args)
-        assert contract["requested"] is True
-        assert contract["ready"] is True
-        assert contract["status"] == "ready"
+        for route in ("loopx-product-mode", "loopx-turn-agent-cli"):
+            args = parse_args(
+                [
+                    "--route",
+                    route,
+                    "--loopx-source-dir",
+                    str(source_dir),
+                ]
+            )
+            contract = _loopx_source_mount_contract(args)
+            assert contract["requested"] is True, (route, contract)
+            assert contract["ready"] is True, (route, contract)
+            assert contract["status"] == "ready", (route, contract)
 
 
 def test_host_local_product_mode_uses_source_upload_not_docker_bind_mount() -> None:
-    args = parse_args(
-        [
-            "--route",
-            "loopx-product-mode",
-            "--host-local-acp-launch",
-            "--remote-command-file-bridge-ready",
-            "--loopx-source-dir",
-            str(REPO_ROOT),
-        ]
-    )
-    assert _loopx_source_mount_contract(args)["ready"] is True
-    assert _loopx_source_mounts(args) == []
-    assert _loopx_case_source_path_for_container(args) == "/app/.loopx-source"
+    for route in ("loopx-product-mode", "loopx-turn-agent-cli"):
+        args = parse_args(
+            [
+                "--route",
+                route,
+                "--host-local-acp-launch",
+                "--remote-command-file-bridge-ready",
+                "--loopx-source-dir",
+                str(REPO_ROOT),
+            ]
+        )
+        assert _loopx_source_mount_contract(args)["ready"] is True, route
+        assert _loopx_source_mounts(args) == [], route
+        assert _loopx_case_source_path_for_container(args) == (
+            "/app/.loopx-source"
+        ), route
 
 
 def test_host_local_product_mode_auto_bridge_keeps_lifecycle_checkpoint_args() -> None:

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -2501,7 +2501,7 @@ def _loopx_source_mount_contract(args: argparse.Namespace) -> dict[str, Any]:
     source_dir = Path(str(source_arg)).expanduser() if source_arg else None
     disabled = bool(getattr(args, "no_loopx_source_mount", False))
     requested = (
-        _is_loopx_product_mode_route(args.route)
+        _is_case_loopx_route(args.route)
         and args.sandbox == "docker"
         and not disabled
         and source_dir is not None
@@ -15958,9 +15958,9 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     )
     parser.add_argument("--max-verifier-output-chars", type=int, default=0)
     parser.add_argument("--skillsbench-root", default=str(DEFAULT_SKILLSBENCH_ROOT))
-    parser.add_argument("--loopx-source-dir", default=str(REPO_ROOT), help="Local LoopX checkout for product-mode source mount/upload; the path is not recorded.")
+    parser.add_argument("--loopx-source-dir", default=str(REPO_ROOT), help="Local LoopX checkout for case-runtime source mount/upload; the path is not recorded.")
     parser.add_argument("--expected-loopx-git-head", default="", help="Fail before task execution unless runner LoopX checkout HEAD starts with this public commit prefix.")
-    parser.add_argument("--no-loopx-source-mount", action="store_true", help="Disable product-mode LoopX source mount/upload and use the public installer path.")
+    parser.add_argument("--no-loopx-source-mount", action="store_true", help="Disable case-runtime LoopX source mount/upload and use the public installer path.")
     parser.add_argument(
         "--jobs-dir",
         default=str(REPO_ROOT / ".local/private-benchmark-jobs"),


### PR DESCRIPTION
## Summary

- include `loopx-turn-agent-cli` in the existing case-runtime source mount/upload contract
- keep host-local runs on source upload rather than a Docker bind mount
- cover both legacy product mode and Turn in the source-contract smokes

A merged Turn rerun proved the runner source fingerprint was correct but case initialization still had `case_loopx_source_install_requested=false`; the container then fell back to the public installer and failed in `ensure_cli`. Turn is already in `LOOPX_CASE_RUNTIME_ROUTES`, so the source contract should use that canonical set.

## Validation

- `python3 examples/skillsbench-benchmark-run-smoke.py`
- Python compile and repository line-budget smoke
- `loopx canary premerge --from-git-diff --tier standard`: 7/7 checks passed; public boundary scan clean for both files

## Risk and merge hold

The owner has explicitly authorized self-merge for LoopX Turn and benchmark PRs. This does not change scoring, task semantics, submissions, permissions, or launch a benchmark job; it replaces an unreliable installer fallback with the already-defined canonical source upload for a case-runtime route.