### PR TITLE
test(smoke): align full-public contract assertions

### DIFF
--- a/examples/control_plane/quota-plan-smoke.py
+++ b/examples/control_plane/quota-plan-smoke.py
@@ -1044,10 +1044,14 @@ def assert_heartbeat_recommendation_lifecycle() -> None:
     assert local_scheduler["max_interval_minutes"] == 240, local_scheduler
     assert stateful_detail["host_max_interval_minutes"] == 60, stateful_detail
     assert stateful_detail["coarser_wait_fallback"] == "local_scheduler_only", stateful_detail
-    assert "suppress_exact_repeat" in stateful_detail["host_update_failure"], stateful_detail
+    failure_policy = stateful_detail["host_update_failure"]
+    assert "failed_target_and_observed_host_pairs" in failure_policy, stateful_detail
+    assert "suppress_each_exact_repeat" in failure_policy, stateful_detail
     assert stateful_detail["ack_required_after_apply"] is True, stateful_detail
     assert stateful_detail["ack_required_from_host_match"] is False, stateful_detail
-    assert "host_update_failure" in stateful_detail["persist"].split("|"), stateful_detail
+    persisted_fields = stateful_detail["persist"].split("|")
+    assert "host_update_failures" in persisted_fields, stateful_detail
+    assert "host_update_failure_compat" in persisted_fields, stateful_detail
 
 
 def assert_goal_boundary_in_should_run() -> None:

--- a/examples/control_plane/todo-claim-visibility-lanes-smoke.py
+++ b/examples/control_plane/todo-claim-visibility-lanes-smoke.py
@@ -225,7 +225,8 @@ def assert_agent_profile_ranks_only_within_claim_buckets() -> None:
         preferred_todo_ids={"todo_current_avoided"},
         agent_profile=profile,
     )
-    assert active_avoided_key < preferred_key
+    # Profile and explicit priority buckets are resolved before active-next hints.
+    assert preferred_key < active_avoided_key
 
 
 def assert_executor_exclusion_filters_only_the_named_peer() -> None:

--- a/examples/loopx-turn-codex-cli-e2e-smoke.py
+++ b/examples/loopx-turn-codex-cli-e2e-smoke.py
@@ -326,7 +326,8 @@ def main() -> int:
     }
     return 0 if (
         summary["first_exit_code"] == 0
-        and summary["receipt_status"] == "validated"
+        and summary["status"] == "committed"
+        and summary["receipt_status"] == "committed"
         and summary["validation_status"] == "passed"
         and summary["effects"] == expected_effects
         and summary["marker_valid"] is True


### PR DESCRIPTION
## Summary
- align quota scheduler-failure smoke with the bounded target/host pair cache plus compatibility projection
- assert todo visibility ordering after profile and explicit-priority resolution
- assert the committed terminal receipt emitted after Turn validation/writeback/spend

## Root cause
The shipped runtime contracts were correct, but three durable smoke assertions still described earlier contract shapes. Latest `main` Full Public Smokes therefore failed despite the runtime producing the intended state.

## Validation
- changed three smokes and Python compile: passed
- `loopx canary premerge --from-git-diff --tier standard`: 8/8 selected checks passed, no warnings or manual holds; self-merge allowed
- public/private boundary scan: clean
- full-public sweep on the pre-rebase base: 593/593 passed
- final-base high-concurrency sweep: no assertion failures; four 120s local resource-contention timeouts, each passed when rerun serially (`canary-promotion-readiness`, integrated canary, and both install-local smokes)
- latest `main` CI failure reproduces the stale assertions this PR updates