### PR TITLE
fix(todos): resolve approved decision scopes

### DIFF
--- a/docs/product/core-control-plane/state-machine.md
+++ b/docs/product/core-control-plane/state-machine.md
@@ -168,7 +168,8 @@ flowchart TD
   Scope -->|"yes"| Ask["ask concrete user/controller question"]
   Scope -->|"no"| Fallback["keep gate visible; run independent fallback"]
   Scope -->|"ambiguous"| Repair["repair projection or ask controller"]
-  Ask -->|"approve"| Unblock["unblock gated todo"]
+  Ask -->|"approve"| Consume["consume covered required scopes"]
+  Consume --> Unblock["unblock gated todo when otherwise ready"]
   Ask -->|"reject"| Supersede["supersede or compensation todo"]
   Ask -->|"defer"| Defer["deferred resume_when"]
   Fallback --> Write["write fallback evidence"]
@@ -180,7 +181,9 @@ flowchart TD
 | Open gate -> Ask | Concrete payload todo/question, not only "owner gate". |
 | Open gate -> Fallback | Proof that selected fallback is independent of the gate scope. |
 | Open gate -> Repair | Explanation of missing or contradictory scope fields. |
-| Approve/reject/defer | Decision event, todo update, or operator gate record. |
+| Approve | Completed, exactly linked `user_gate`; consume only covered target scopes and preserve the rest. |
+| Reject | Supersede or compensation record; never consume decision authority. |
+| Defer | Decision event with a supported `resume_when`. |
 | Fallback complete | Artifact/blocker/evidence linked to the independent todo. |
 
 This machine is why user and agent channels can intentionally disagree:

--- a/docs/reference/protocols/decision-scope-v0.md
+++ b/docs/reference/protocols/decision-scope-v0.md
@@ -128,6 +128,26 @@ repair proposals. It may suggest a structured decision scope, but it must not
 decide delivery gates, spend policy, write permission, or safe fallback at
 runtime.
 
+## Approval Consumption Lifecycle
+
+`loopx todo complete` resolves authority only for an explicitly linked
+`user_gate`:
+
+1. the completed todo has `task_class=user_gate`, a normalized
+   `decision_scope`, and `unblocks_todo_id=<target>`;
+2. the target is an agent todo whose `required_decision_scopes` contain scopes
+   covered by that gate;
+3. completion removes only the covered requirements and preserves every
+   uncovered scope;
+4. the transition returns a public-safe `todo_decision_scope_resolution_v0`
+   receipt with resolved and remaining scopes.
+
+This consumption also applies when the target todo is already `open`, such as
+publication performed immediately after approval. A completed `user_action`
+may still use the exact unblock relation for compatibility, but it does not
+consume decision authority. `todo supersede` records replacement or rejection;
+it never implies approval and therefore never consumes a required scope.
+
 ## Migration Phases
 
 1. **Contract only:** document this schema and keep current behavior unchanged.
@@ -161,5 +181,7 @@ A decision-scope implementation is acceptable when:
 3. explicit fields outrank title/body regex inference;
 4. ambiguous scope fails closed instead of guessing;
 5. safe fallback continues only when its required scopes are independent; and
-6. legacy regex/LLM assistance remains a cold-path repair signal, not runtime
+6. completing an exactly linked user gate consumes only its covered required
+   scopes while superseding it consumes none; and
+7. legacy regex/LLM assistance remains a cold-path repair signal, not runtime
    gate truth.

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -224,7 +224,8 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
         "--unblocks-todo-id",
         help=(
             "For todo add/update, link this todo to the blocked todo it unblocks, "
-            "for example todo_ab12cd34ef56."
+            "for example todo_ab12cd34ef56. Completing an exactly linked user_gate "
+            "also consumes the target required decision scopes covered by that gate."
         ),
     )
     todo_parser.add_argument(

--- a/loopx/control_plane/todos/unblock_resume.py
+++ b/loopx/control_plane/todos/unblock_resume.py
@@ -1,17 +1,24 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable
 
 from .active_state_editing import section_bounds, todo_blocks
 from .contract import (
     TODO_STATUS_OPEN,
+    TODO_TASK_CLASS_USER_GATE,
+    normalize_todo_decision_scope,
     normalize_todo_id,
+    normalize_todo_required_decision_scopes,
     normalize_todo_status,
     todo_done_for_status,
 )
+from .decision_scope import decision_scope_covers
 
 
 TODO_UNBLOCK_RESUME_SCHEMA_VERSION = "todo_unblock_resume_v0"
+TODO_DECISION_SCOPE_RESOLUTION_SCHEMA_VERSION = (
+    "todo_decision_scope_resolution_v0"
+)
 
 
 def _status(todo: dict[str, Any]) -> str:
@@ -95,3 +102,122 @@ def plan_completed_user_unblock_resume(
             "remaining_user_blocker_todo_ids": sorted(set(remaining_ids)),
         }
     return {**receipt, "state": "resume_ready"}
+
+
+def plan_completed_user_gate_decision_scope_resolution(
+    lines: list[str],
+    *,
+    source_todo_id: str,
+    target_todo_id: str,
+    decision_scope: Any,
+) -> dict[str, Any] | None:
+    """Plan consumption of only the target requirements covered by one approval."""
+
+    normalized_scope = normalize_todo_decision_scope(decision_scope)
+    if not normalized_scope:
+        return None
+    target = _find_todo(lines, role="agent", todo_id=target_todo_id)
+    if not target:
+        return None
+    required_scopes = normalize_todo_required_decision_scopes(
+        target.get("required_decision_scopes")
+    )
+    resolved_scopes = [
+        scope
+        for scope in required_scopes
+        if decision_scope_covers(normalized_scope, scope)
+    ]
+    if not resolved_scopes:
+        return None
+    remaining_scopes = [
+        scope
+        for scope in required_scopes
+        if not decision_scope_covers(normalized_scope, scope)
+    ]
+    return {
+        "schema_version": TODO_DECISION_SCOPE_RESOLUTION_SCHEMA_VERSION,
+        "state": "resolution_ready",
+        "source_todo_id": source_todo_id,
+        "target_todo_id": target_todo_id,
+        "decision_scope": normalized_scope,
+        "resolved_required_decision_scopes": resolved_scopes,
+        "remaining_required_decision_scopes": remaining_scopes,
+        "changed": False,
+    }
+
+
+def apply_completed_user_todo_lifecycle(
+    lines: list[str],
+    *,
+    completion_todo: dict[str, Any] | None,
+    update_result: dict[str, Any],
+    fallback_todo_id: str,
+    updated_at: str,
+    apply_update: Callable[..., dict[str, Any]],
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Apply exact unblock and decision-scope effects after user completion."""
+
+    completion_role = str((completion_todo or {}).get("role") or "")
+    completion_task_class = str((completion_todo or {}).get("task_class") or "")
+    source_todo_id = str(update_result.get("todo_id") or fallback_todo_id)
+    target_todo_id = normalize_todo_id(update_result.get("unblocks_todo_id"))
+    decision_scope_resolution = None
+    if (
+        completion_role == "user"
+        and completion_task_class == TODO_TASK_CLASS_USER_GATE
+        and target_todo_id
+    ):
+        decision_scope_resolution = plan_completed_user_gate_decision_scope_resolution(
+            lines,
+            source_todo_id=source_todo_id,
+            target_todo_id=target_todo_id,
+            decision_scope=(completion_todo or {}).get("decision_scope"),
+        )
+        if decision_scope_resolution:
+            resolved_target = apply_update(
+                lines,
+                todo_id=target_todo_id,
+                role="agent",
+                required_decision_scopes=decision_scope_resolution[
+                    "remaining_required_decision_scopes"
+                ],
+                updated_at=updated_at,
+            )
+            decision_scope_resolution.update(
+                state="resolved",
+                changed=bool(resolved_target.get("changed")),
+                target_status=resolved_target.get("status"),
+            )
+
+    unblock_resume = None
+    if (
+        completion_role == "user"
+        and completion_task_class in {"user_action", TODO_TASK_CLASS_USER_GATE}
+        and target_todo_id
+    ):
+        unblock_resume = plan_completed_user_unblock_resume(
+            lines,
+            source_todo_id=source_todo_id,
+            target_todo_id=target_todo_id,
+        )
+        if unblock_resume.get("state") == "resume_ready":
+            resumed = apply_update(
+                lines,
+                todo_id=target_todo_id,
+                role="agent",
+                status=TODO_STATUS_OPEN,
+                reason=f"authorization satisfied by completed user todo {source_todo_id}",
+                updated_at=updated_at,
+            )
+            unblock_resume.update(
+                state="resumed",
+                status=resumed.get("status"),
+                changed=bool(resumed.get("changed")),
+                claimed_by=resumed.get("claimed_by"),
+            )
+            unblock_resume = {
+                key: value
+                for key, value in unblock_resume.items()
+                if value not in (None, "", [], {})
+            }
+    return unblock_resume, decision_scope_resolution

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -79,7 +79,7 @@ from .control_plane.todos.text import (
     inherit_todo_priority,
     normalize_new_todo,
 )
-from .control_plane.todos.unblock_resume import plan_completed_user_unblock_resume
+from .control_plane.todos.unblock_resume import apply_completed_user_todo_lifecycle
 from .control_plane.todos.write_policy import require_user_gate_scope, require_user_todo_task_class
 
 
@@ -1652,45 +1652,16 @@ def complete_goal_todo(
             successor_todo_ids=normalized_successor_todo_ids if successor_todo_ids is not None else None,
             updated_at=updated_at,
         )
-        unblock_resume = None
-        completion_role = str((completion_todo or {}).get("role") or "")
-        completion_task_class = str((completion_todo or {}).get("task_class") or "")
-        linked_unblocks_todo_id = normalize_todo_id(update_result.get("unblocks_todo_id"))
-        if (
-            completion_role == "user"
-            and completion_task_class in {"user_action", TODO_TASK_CLASS_USER_GATE}
-            and linked_unblocks_todo_id
-        ):
-            unblock_resume = plan_completed_user_unblock_resume(
+        unblock_resume, decision_scope_resolution = (
+            apply_completed_user_todo_lifecycle(
                 lines,
-                source_todo_id=str(update_result.get("todo_id") or todo_id),
-                target_todo_id=linked_unblocks_todo_id,
+                completion_todo=completion_todo,
+                update_result=update_result,
+                fallback_todo_id=todo_id,
+                updated_at=updated_at,
+                apply_update=apply_todo_update_to_lines,
             )
-            if unblock_resume.get("state") == "resume_ready":
-                resumed = apply_todo_update_to_lines(
-                    lines,
-                    todo_id=linked_unblocks_todo_id,
-                    role="agent",
-                    status=TODO_STATUS_OPEN,
-                    reason=(
-                        "authorization satisfied by completed user todo "
-                        f"{update_result.get('todo_id') or todo_id}"
-                    ),
-                    updated_at=updated_at,
-                )
-                unblock_resume.update(
-                    {
-                        "state": "resumed",
-                        "status": resumed.get("status"),
-                        "changed": bool(resumed.get("changed")),
-                        "claimed_by": resumed.get("claimed_by"),
-                    }
-                )
-                unblock_resume = {
-                    key: value
-                    for key, value in unblock_resume.items()
-                    if value not in (None, "", [], {})
-                }
+        )
         next_unblocks_todo_id = (
             normalize_todo_id(str(update_result.get("todo_id") or todo_id))
             if next_agent_todo
@@ -1753,6 +1724,7 @@ def complete_goal_todo(
             or next_changed
             or successor_metadata_updated
             or (unblock_resume or {}).get("changed")
+            or (decision_scope_resolution or {}).get("changed")
         )
         new_text = "\n".join(lines) + ("\n" if original.endswith("\n") else "")
         if changed:
@@ -1774,6 +1746,8 @@ def complete_goal_todo(
     }
     if unblock_resume:
         result["unblock_resume"] = unblock_resume
+    if decision_scope_resolution:
+        result["decision_scope_resolution"] = decision_scope_resolution
     result["self_merged"] = effective_self_merged
     return result
 

--- a/tests/control_plane/test_todo_decision_scope_lifecycle.py
+++ b/tests/control_plane/test_todo_decision_scope_lifecycle.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from loopx.quota import build_quota_should_run
+from loopx.status import collect_status, parse_active_state_todos
+from loopx.todos import add_goal_todo, complete_goal_todo, supersede_goal_todo
+
+
+GOAL_ID = "decision-scope-lifecycle"
+AGENT_ID = "codex-delivery"
+OTHER_AGENT_ID = "codex-review"
+PUBLISH_SCOPE = "direction:action:publish_release"
+ANNOUNCE_SCOPE = "direction:action:announce_release"
+
+
+def _write_fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    state = repo / "ACTIVE_GOAL_STATE.md"
+    state.write_text(
+        "\n".join(
+            [
+                "---",
+                f"goal_id: {GOAL_ID}",
+                "updated_at: 2026-07-16T00:00:00+00:00",
+                "---",
+                "",
+                "## Agent Todo",
+                "",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    registry = tmp_path / "registry.global.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "harness_self_improvement",
+                        "status": "active",
+                        "repo": str(repo),
+                        "state_file": "ACTIVE_GOAL_STATE.md",
+                        "adapter": {"kind": "harness_self_improvement"},
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": [AGENT_ID, OTHER_AGENT_ID],
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    return repo, state, registry
+
+
+def _todo(state: Path, todo_id: str) -> dict:
+    todos = parse_active_state_todos(state.read_text(encoding="utf-8"))
+    return next(
+        item
+        for role in ("agent_todos", "user_todos")
+        for item in todos[role]["items"]
+        if item["todo_id"] == todo_id
+    )
+
+
+def _add_target_and_gate(
+    registry: Path,
+    *,
+    required_scopes: list[str],
+    target_status: str = "open",
+) -> tuple[dict, dict]:
+    target = add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="agent",
+        text="Publish the approved release artifact.",
+        status=target_status,
+        task_class="advancement_task",
+        claimed_by=AGENT_ID,
+        required_decision_scopes=required_scopes,
+    )
+    gate = add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="user",
+        text="Approve publishing the release artifact.",
+        task_class="user_gate",
+        blocks_agent=AGENT_ID,
+        decision_scope=PUBLISH_SCOPE,
+        unblocks_todo_id=target["todo_id"],
+    )
+    return target, gate
+
+
+def test_completed_gate_consumes_scope_for_already_open_publication(
+    tmp_path: Path,
+) -> None:
+    repo, state, registry = _write_fixture(tmp_path)
+    target, gate = _add_target_and_gate(
+        registry,
+        required_scopes=[PUBLISH_SCOPE],
+    )
+
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=gate["todo_id"],
+        role="user",
+        evidence="owner approved the exact release publication",
+    )
+
+    assert result["decision_scope_resolution"] == {
+        "schema_version": "todo_decision_scope_resolution_v0",
+        "state": "resolved",
+        "source_todo_id": gate["todo_id"],
+        "target_todo_id": target["todo_id"],
+        "decision_scope": {
+            "schema_version": "decision_scope_v0",
+            "kind": "direction",
+            "granularity": "action",
+            "scope_key": "publish_release",
+        },
+        "resolved_required_decision_scopes": [
+            {
+                "schema_version": "decision_scope_v0",
+                "kind": "direction",
+                "granularity": "action",
+                "scope_key": "publish_release",
+            }
+        ],
+        "remaining_required_decision_scopes": [],
+        "changed": True,
+        "target_status": "open",
+    }
+    assert result["unblock_resume"]["state"] == "target_not_blocked"
+    updated_target = _todo(state, target["todo_id"])
+    assert updated_target["status"] == "open"
+    assert updated_target.get("required_decision_scopes", []) == []
+
+    status = collect_status(
+        registry_path=registry,
+        runtime_root_override=str(tmp_path / "runtime"),
+        scan_roots=[repo],
+        limit=1,
+        goal_id=GOAL_ID,
+    )
+    quota = build_quota_should_run(status, goal_id=GOAL_ID, agent_id=AGENT_ID)
+    assert quota["effective_action"] != "todo_decision_scope_projection_repair"
+    consistency = quota.get("todo_decision_scope_consistency")
+    assert consistency is None or consistency["ok"] is True
+
+
+def test_completed_gate_consumes_only_covered_scope(tmp_path: Path) -> None:
+    _repo, state, registry = _write_fixture(tmp_path)
+    target, gate = _add_target_and_gate(
+        registry,
+        required_scopes=[PUBLISH_SCOPE, ANNOUNCE_SCOPE],
+    )
+
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=gate["todo_id"],
+        role="user",
+        evidence="owner approved publication only",
+    )
+
+    resolution = result["decision_scope_resolution"]
+    assert [
+        item["scope_key"]
+        for item in resolution["resolved_required_decision_scopes"]
+    ] == ["publish_release"]
+    assert [
+        item["scope_key"]
+        for item in resolution["remaining_required_decision_scopes"]
+    ] == ["announce_release"]
+    updated_target = _todo(state, target["todo_id"])
+    assert [
+        item["scope_key"] for item in updated_target["required_decision_scopes"]
+    ] == ["announce_release"]
+
+
+def test_superseded_gate_does_not_consume_required_scope(tmp_path: Path) -> None:
+    _repo, state, registry = _write_fixture(tmp_path)
+    target, gate = _add_target_and_gate(
+        registry,
+        required_scopes=[PUBLISH_SCOPE],
+        target_status="blocked",
+    )
+
+    result = supersede_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=gate["todo_id"],
+        role="user",
+        reason="approval request replaced without granting authority",
+    )
+
+    assert "decision_scope_resolution" not in result
+    updated_target = _todo(state, target["todo_id"])
+    assert updated_target["status"] == "blocked"
+    assert [
+        item["scope_key"] for item in updated_target["required_decision_scopes"]
+    ] == ["publish_release"]


### PR DESCRIPTION
## Summary

- consume only target required decision scopes covered by a completed, exactly linked user gate
- preserve uncovered scopes and keep supersede non-authoritative
- return a compact resolution receipt and document the lifecycle

## Motivation

After an owner approved an action, the user gate became done but the linked agent todo could retain required_decision_scopes. Quota then treated the already-approved action as a dangling gate, including the case where publication had already returned the target todo to open.

## Product and architecture judgment

This keeps approval consumption on the existing todo complete transition and the exact unblocks_todo_id relation. It does not add another state machine or infer authority from prose. The main compatibility risk is accidental broad consumption, bounded here by normalized scope coverage, exact target linkage, partial-scope preservation, and explicit supersede non-consumption. Lifecycle orchestration is kept outside the large todos.py module.

## Validation

- 12 focused decision-scope tests passed
- existing todo-user-gate-scope smoke passed
- todo Python line-budget smoke passed
- LoopX premerge canary: 18/18 selected checks passed
- public/private boundary scan clean
- canary gate: self_merge_allowed=true