### PR TITLE
fix(state): avoid technical gate false positives

### DIFF
--- a/examples/state-projection-gap-smoke.py
+++ b/examples/state-projection-gap-smoke.py
@@ -114,6 +114,15 @@ def test_projection_gap_warning() -> dict:
     )
     assert technical_gate_no_gap is None, technical_gate_no_gap
 
+    benchmark_acceptance_no_gap = state_projection_gap_warning(
+        "## Agent Todo\n\n"
+        "- [ ] Run the second matched LoopX Turn versus Codex Goal pair.\n\n"
+        "## Next Action\n\n"
+        "- Run the second matched pair; require both arms to be official and "
+        "verify committed receipts leave the next-case gate open.\n"
+    )
+    assert benchmark_acceptance_no_gap is None, benchmark_acceptance_no_gap
+
     decision_result_input_no_gap = state_projection_gap_warning(
         "## Agent Todo\n\n"
         "- [ ] Build a read-only projection adapter from compact session facts.\n\n"

--- a/loopx/state_projection.py
+++ b/loopx/state_projection.py
@@ -67,7 +67,7 @@ NEXT_ACTION_USER_WAIT_PATTERN = re.compile(
     r"(?i)\b(?:wait(?:ing)? for|await(?:ing)?|blocked by|gated by|"
     r"need(?:s|ed)?|requires?|request(?:s|ed)?|ask(?:ing)? for|pending)"
     r"\b.{0,120}\b(?:owner|user|operator|controller|human|approval|approve|"
-    r"decision|gate|permission|choice)\b|"
+    r"decision|permission|choice)\b|"
     r"\b(?:owner|user|operator|controller|human)\s+"
     r"(?:gate|todo|action|decision|approval|permission|choice)\b|"
     r"\b(?:approval|permission)\s+(?:required|needed|pending)\b|"


### PR DESCRIPTION
## Summary
- stop treating the bare word `gate` after `require` as evidence of a user/owner wait
- preserve explicit actor, approval, permission, and decision wait detection
- cover technical benchmark acceptance text that verifies a next-case gate remains open

## Root cause
The user-wait regex accepted `require ... gate` across a 120-character window. A normal benchmark acceptance statement (`require both arms ... leave the next-case gate open`) was therefore projected as an unrepresented user gate even though the matching Agent Todo already existed.

## Validation
- real active-state readback now returns no `state_projection_gap`
- focused state-projection and quota-plan smokes passed
- Full Public Smokes: 593/593 passed, no warnings, skips, failures, or timeouts
- post-rebase premerge canary: 6/6 selected checks passed; no manual holds; public/private boundary clean