### PR TITLE
Wire LoopX Turn receipts into typed repair

### DIFF
--- a/examples/skillsbench-typed-repair-smoke.py
+++ b/examples/skillsbench-typed-repair-smoke.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 
+import asyncio
+import json
 import sys
 import tempfile
+import types
 from pathlib import Path
+from unittest.mock import patch
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
@@ -24,6 +28,7 @@ from loopx.control_plane.runtime.goal_start_control_score import (
 )
 from loopx.status import compact_benchmark_run
 from examples.skillsbench_fixtures import write_official_skillsbench_result
+from scripts.skillsbench_automation_loop import _build_blind_loop_user
 
 
 def base_trace() -> dict[str, object]:
@@ -67,6 +72,29 @@ def committed_turn_execution() -> dict[str, object]:
             "quota_spent": True,
         },
     }
+
+
+def write_failed_turn_trace(trace_dir: Path, index: int) -> None:
+    payload = {
+        "schema_version": "skillsbench_host_local_acp_relay_public_trace_v0",
+        "trace_kind": "loopx_turn_execution",
+        "loopx_turn_execution": failed_turn_execution(),
+        "boundary": {
+            key: False
+            for key in (
+                "raw_task_text_recorded",
+                "raw_trajectory_recorded",
+                "raw_stdout_recorded",
+                "raw_stderr_recorded",
+                "credential_values_recorded",
+                "host_paths_recorded",
+                "remote_paths_recorded",
+            )
+        },
+    }
+    (trace_dir / f"turn-{index}.compact.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
 
 
 def test_one_attempt_per_unchanged_frontier_and_reward_blind_prompt() -> None:
@@ -275,6 +303,52 @@ def test_turn_recovery_controller_stops_or_continues_from_receipts() -> None:
     )
 
 
+def test_turn_blind_controller_consumes_recovery_receipts() -> None:
+    trace = {
+        "schema_version": "skillsbench_loopx_controller_trace_v0",
+        "route": "loopx-turn-agent-cli",
+        "round_rewards": [],
+    }
+    fake_user = types.ModuleType("benchflow.sandbox.user")
+    fake_user.BaseUser = type("BaseUser", (), {})
+    fake_user.RoundResult = type("RoundResult", (), {})
+    fake_modules = {
+        "benchflow": types.ModuleType("benchflow"),
+        "benchflow.sandbox": types.ModuleType("benchflow.sandbox"),
+        "benchflow.sandbox.user": fake_user,
+    }
+    round_result = types.SimpleNamespace(
+        rewards={}, n_tool_calls=1, trajectory=[]
+    )
+    with patch.dict(sys.modules, fake_modules):
+        with tempfile.TemporaryDirectory(prefix="turn-recovery-controller-") as tmp:
+            trace_dir = Path(tmp)
+            user = _build_blind_loop_user(
+                route="loopx-turn-agent-cli",
+                max_rounds=8,
+                trace=trace,
+                plan={
+                    "route": "loopx-turn-agent-cli",
+                    "host_local_acp_relay_trace_dir": str(trace_dir),
+                    "runner_prerequisites": {},
+                },
+            )
+            assert asyncio.run(user.run(0, "Fix the workbook.")) is not None
+            write_failed_turn_trace(trace_dir, 1)
+            repair_prompt = asyncio.run(
+                user.run(1, "Fix the workbook.", round_result)
+            )
+            assert "later Turn receipt commits" in repair_prompt, repair_prompt
+            assert trace["product_mode_typed_repair_pending"] is True, trace
+            write_failed_turn_trace(trace_dir, 2)
+            assert asyncio.run(
+                user.run(2, "Fix the workbook.", round_result)
+            ) is None
+            assert trace["product_mode_typed_repair_terminal_reason"] == (
+                "turn_repair_round_without_todo_or_committed_validation_delta"
+            ), trace
+
+
 def test_unchanged_frontier_has_typed_terminal_receipt() -> None:
     trace = base_trace()
     assert begin_skillsbench_typed_repair(
@@ -381,6 +455,7 @@ if __name__ == "__main__":
     test_todo_identity_or_task_validation_delta_allows_continuation()
     test_turn_recovery_requires_todo_or_committed_validation_delta()
     test_turn_recovery_controller_stops_or_continues_from_receipts()
+    test_turn_blind_controller_consumes_recovery_receipts()
     test_unchanged_frontier_has_typed_terminal_receipt()
     test_goal_start_control_score_preserves_typed_repair_fields()
     test_typed_repair_projection_survives_result_compaction()

--- a/loopx/benchmark_adapters/skillsbench_typed_repair.py
+++ b/loopx/benchmark_adapters/skillsbench_typed_repair.py
@@ -509,6 +509,52 @@ def build_skillsbench_typed_repair_prompt(
     )
 
 
+def _increment_trace_counter(trace: dict[str, Any], key: str) -> None:
+    value = trace.get(key)
+    current = value if isinstance(value, int) and not isinstance(value, bool) else 0
+    trace[key] = current + 1
+
+
+def resolve_skillsbench_typed_repair_response(
+    trace: dict[str, Any],
+    *,
+    agent_round: int,
+    max_rounds: int,
+    task_instruction_sent: bool = True,
+    continuation_prompt: str,
+    case_state_path: str,
+    loop_alignment_contract: str = "",
+    persistent_constraint_clause: str,
+) -> tuple[bool, str | None]:
+    """Resolve one controller action into a public prompt or typed stop."""
+
+    decision = advance_skillsbench_typed_repair_controller(
+        trace,
+        agent_round=agent_round,
+        scheduled_round=agent_round + 1,
+        max_rounds=max_rounds,
+        task_instruction_sent=task_instruction_sent,
+    )
+    if not decision:
+        return False, None
+    _increment_trace_counter(trace, "controller_action_decisions")
+    trace["last_decision"] = decision["last_decision"]
+    if decision["action"] == "stop":
+        _increment_trace_counter(trace, "stop_decision_count")
+        return True, None
+    _increment_trace_counter(trace, "followup_prompt_count")
+    if decision["action"] == "continue":
+        return True, continuation_prompt
+    return True, build_skillsbench_typed_repair_prompt(
+        scheduled_round=agent_round + 1,
+        max_rounds=max_rounds,
+        case_state_path=case_state_path,
+        loop_alignment_contract=loop_alignment_contract,
+        persistent_constraint_clause=persistent_constraint_clause,
+        trigger_kind=decision.get("trigger_kind", ""),
+    )
+
+
 def record_skillsbench_typed_repair_terminal(
     trace: dict[str, Any],
     *,

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -134,10 +134,10 @@ from loopx.benchmark_adapters.skillsbench_setup_preflight import (  # noqa: E402
     run_setup_only_public_preflight,
 )
 from loopx.benchmark_adapters.skillsbench_typed_repair import (  # noqa: E402
-    advance_skillsbench_typed_repair_controller,
     begin_skillsbench_typed_repair,
     build_skillsbench_typed_repair_prompt,
     record_skillsbench_typed_repair_terminal,
+    resolve_skillsbench_typed_repair_response,
     skillsbench_projected_open_todo_count,
 )
 from loopx.benchmark_adapters.skillsbench_turn_route import (  # noqa: E402
@@ -12256,6 +12256,7 @@ def _build_blind_loop_user(
     route: str,
     max_rounds: int,
     trace: dict[str, Any],
+    plan: dict[str, Any] | None = None,
 ):
     from benchflow.sandbox.user import BaseUser, RoundResult
 
@@ -12294,6 +12295,23 @@ def _build_blind_loop_user(
                     "stop_after_blind_loop_official_success_observed_without_feedback"
                 )
                 return None
+            if round_result is not None and _is_loopx_turn_agent_cli_route(route):
+                _merge_host_local_acp_relay_trace_summary(plan or {}, trace)
+                handled, response = resolve_skillsbench_typed_repair_response(
+                    trace,
+                    agent_round=round,
+                    max_rounds=max_rounds,
+                    continuation_prompt=build_blind_loop_continuation_prompt(
+                        scheduled_round=round + 1,
+                        max_rounds=max_rounds,
+                        persistent_constraint_clause=self._persistent_constraint_clause,
+                        route=route,
+                    ),
+                    case_state_path=PRODUCT_MODE_CASE_STATE_PATH,
+                    persistent_constraint_clause=self._persistent_constraint_clause,
+                )
+                if handled:
+                    return response
             if round >= max_rounds:
                 _inc_counter(trace, "controller_action_decisions")
                 _inc_counter(trace, "stop_decision_count")
@@ -13000,34 +13018,20 @@ def _build_product_mode_user(
                             scheduled_round=round + 1,
                             task_instruction=instruction,
                         )
-                    repair_decision = advance_skillsbench_typed_repair_controller(
+                    handled, response = resolve_skillsbench_typed_repair_response(
                         trace,
                         agent_round=round,
-                        scheduled_round=round + 1,
                         max_rounds=max_rounds,
                         task_instruction_sent=self._task_instruction_sent,
-                    )
-                    if repair_decision:
-                        _inc_counter(trace, "controller_action_decisions")
-                        trace["last_decision"] = repair_decision["last_decision"]
-                        if repair_decision["action"] == "stop":
-                            _inc_counter(trace, "stop_decision_count")
-                            return None
-                        _inc_counter(trace, "followup_prompt_count")
-                        if repair_decision["action"] == "continue":
-                            return self._scheduled_continuation_prompt(
-                                scheduled_round=round + 1,
-                            )
-                        return build_skillsbench_typed_repair_prompt(
+                        continuation_prompt=self._scheduled_continuation_prompt(
                             scheduled_round=round + 1,
-                            max_rounds=max_rounds,
-                            case_state_path=case_state_path,
-                            loop_alignment_contract=goal_start_loop_alignment_contract(),
-                            persistent_constraint_clause=(
-                                self._persistent_constraint_clause
-                            ),
-                            trigger_kind=repair_decision.get("trigger_kind", ""),
-                        )
+                        ),
+                        case_state_path=case_state_path,
+                        loop_alignment_contract=goal_start_loop_alignment_contract(),
+                        persistent_constraint_clause=self._persistent_constraint_clause,
+                    )
+                    if handled:
+                        return response
                     if (
                         self._task_instruction_sent
                         and product_mode_entry_lifecycle_gate_satisfied()
@@ -14181,7 +14185,7 @@ async def run_benchflow_case(
         controller_user = _build_blind_loop_user(
             route=args.route,
             max_rounds=args.max_rounds,
-            trace=controller_trace,
+            trace=controller_trace, plan=plan,
         )
     elif not setup_only_public_preflight and args.route in PRODUCT_MODE_CONTROLLER_ROUTES:
         controller_trace = _new_controller_trace(args.route, max_rounds=args.max_rounds)


### PR DESCRIPTION
## Summary
- route LoopX Turn public recovery receipts through the existing typed-repair controller
- share response/counter handling with product mode instead of adding a second repair state machine
- add a focused controller integration smoke for repair then typed-stop behavior

## Validation
- `python3 -m py_compile scripts/skillsbench_automation_loop.py loopx/benchmark_adapters/skillsbench_typed_repair.py examples/skillsbench-typed-repair-smoke.py`
- `python3 examples/skillsbench-typed-repair-smoke.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `loopx canary premerge --from-git-diff --tier standard`: 10/10 selected checks passed; expected benchmark-sensitive manual hold remains
- public/private boundary scan: clean

## Scope
No scoring, task semantics, leaderboard/submission behavior, permissions, benchmark launch, raw evidence, private state, credentials, or local paths are changed. The owner has explicitly authorized Turn and benchmark PR self-merge after validation.