### PR TITLE
fix(configure): sync authoritative shared runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,13 @@ templates. Use `loopx configure-goal --help` for the complete settings surface.
 Preview changes without `--execute`; do not enable a feature only because it is
 available.
 
+An applied `configure-goal` change also refreshes the registry-declared shared
+read model. Without `--runtime-root`, LoopX resolves the authoritative shared
+runtime from the goal's existing global `source_registry` route; an explicit
+runtime override remains authoritative. JSON and Markdown responses name the
+selected global registry and report exact goal-digest readback, so a project
+runtime and its heartbeat runtime cannot silently diverge.
+
 ### Start With A Useful Loop
 
 Use a preset to see LoopX's value before wiring up a full automation:

--- a/examples/canary/catalog-planner-smoke.py
+++ b/examples/canary/catalog-planner-smoke.py
@@ -713,6 +713,23 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     assert "python3 examples/explore-worker-plan-gate-smoke.py" in explore_commands
     assert explore_profile["deep_checks_available"] is True, explore_profile
 
+    configure_sync_payload = build_catalog_canary_plan(
+        changed_files=["loopx/control_plane/goals/configure_goal_service.py"],
+        surfaces=["configure-goal authoritative shared runtime sync readback"],
+    )
+    configure_sync_profiles = {
+        profile["id"]: profile
+        for profile in configure_sync_payload["domain_profiles"]
+    }
+    configure_sync_profile = configure_sync_profiles["peer-agent-runtime"]
+    configure_sync_commands = [
+        check["command"] for check in configure_sync_profile["checks"]
+    ]
+    assert (
+        "python3 examples/project/configure-goal-global-sync-smoke.py"
+        in configure_sync_commands
+    ), configure_sync_profile
+
 
 def assert_explicit_profile_can_include_deep_checks() -> None:
     payload = build_catalog_canary_plan(

--- a/examples/project/configure-goal-global-sync-smoke.py
+++ b/examples/project/configure-goal-global-sync-smoke.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Guard configure-goal shared-runtime routing and exact readback."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GOAL_ID = "configure-goal-global-sync-fixture"
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def source_goal(project: Path) -> dict:
+    return {
+        "id": GOAL_ID,
+        "status": "active",
+        "domain": "configure-goal-global-sync",
+        "repo": str(project),
+        "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
+        "adapter": {"kind": "generic_project_goal_v0", "status": "connected"},
+        "quota": {"compute": 1, "window_hours": 24},
+        "waiting_on": "codex",
+    }
+
+
+def write_fixture(root: Path) -> tuple[Path, Path]:
+    project = root / "project"
+    source_registry = project / ".loopx" / "registry.json"
+    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text("# Active Goal State\n", encoding="utf-8")
+    goal = source_goal(project)
+    write_json(
+        source_registry,
+        {
+            "schema_version": "0.1",
+            "common_runtime_root": ".loopx/runtime",
+            "goals": [goal],
+        },
+    )
+
+    shared_runtime = root / "shared-runtime"
+    write_json(
+        shared_runtime / "registry.global.json",
+        {
+            "schema_version": "0.1",
+            "registry_role": "global-local",
+            "common_runtime_root": str(shared_runtime),
+            "goals": [
+                {
+                    **goal,
+                    "source_registry": str(source_registry.resolve()),
+                    "synced_at": "2026-01-01T00:00:00+00:00",
+                    "authority_source_count": 0,
+                    "authority_registry": {
+                        "schema_version": "authority_registry_v0",
+                        "entries": [],
+                    },
+                }
+            ],
+        },
+    )
+    return source_registry, shared_runtime
+
+
+def run_cli(
+    source_registry: Path,
+    shared_runtime: Path,
+    *args: str,
+    runtime_root: Path | None = None,
+) -> dict:
+    command = [
+        sys.executable,
+        "-m",
+        "loopx.cli",
+        "--format",
+        "json",
+        "--registry",
+        str(source_registry),
+    ]
+    if runtime_root is not None:
+        command.extend(["--runtime-root", str(runtime_root)])
+    command.extend(args)
+    env = dict(os.environ, LOOPX_RUNTIME_ROOT=str(shared_runtime))
+    completed = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode:
+        raise AssertionError(
+            f"command failed ({completed.returncode}): {' '.join(command)}\n"
+            f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+        )
+    return json.loads(completed.stdout)
+
+
+def only_goal(registry: Path) -> dict:
+    return json.loads(registry.read_text(encoding="utf-8"))["goals"][0]
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-configure-global-sync-") as tmp:
+        root = Path(tmp)
+        source_registry, shared_runtime = write_fixture(root)
+        shared_registry = shared_runtime / "registry.global.json"
+        project_runtime_registry = (
+            source_registry.parent / "runtime" / "registry.global.json"
+        )
+
+        preview = run_cli(
+            source_registry,
+            shared_runtime,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--waiting-on",
+            "external_evidence",
+        )
+        assert preview["global_sync"]["enabled"] is True, preview
+        assert preview["global_sync"]["executed"] is False, preview
+        assert preview["global_sync"]["readback"]["status"] == "not_executed", preview
+        assert preview["global_sync"]["selected_target"]["global_registry"] == str(
+            shared_registry.resolve()
+        ), preview
+
+        applied = run_cli(
+            source_registry,
+            shared_runtime,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--waiting-on",
+            "external_evidence",
+            "--execute",
+        )
+        sync = applied["global_sync"]
+        assert applied["ok"] is True and applied["written"] is True, applied
+        assert sync["target_resolution"]["status"] == "resolved", sync
+        assert sync["selected_target"]["global_registry"] == str(
+            shared_registry.resolve()
+        ), sync
+        assert sync["readback"]["status"] == "verified", sync
+        assert (
+            sync["readback"]["expected_goal_sha256_16"]
+            == sync["readback"]["target_goal_sha256_16"]
+        ), sync
+        assert only_goal(source_registry)["waiting_on"] == "external_evidence"
+        assert only_goal(shared_registry)["waiting_on"] == "external_evidence"
+        assert not project_runtime_registry.exists(), project_runtime_registry
+
+        explicit_runtime = root / "explicit-runtime"
+        explicit = run_cli(
+            source_registry,
+            shared_runtime,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--waiting-on",
+            "controller",
+            "--execute",
+            runtime_root=explicit_runtime,
+        )
+        explicit_sync = explicit["global_sync"]
+        explicit_registry = explicit_runtime / "registry.global.json"
+        assert explicit_sync["target_resolution"]["status"] == "explicit_override"
+        assert explicit_sync["selected_target"]["global_registry"] == str(
+            explicit_registry.resolve()
+        )
+        assert explicit_sync["readback"]["verified"] is True
+        assert only_goal(source_registry)["waiting_on"] == "controller"
+        assert only_goal(explicit_registry)["waiting_on"] == "controller"
+        assert only_goal(shared_registry)["waiting_on"] == "external_evidence"
+
+    print("configure-goal-global-sync-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -1220,10 +1220,17 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
             "loopx/control_plane/agents",
             "loopx/control_plane/todos/completion_policy.py",
             "loopx/control_plane/quota/task_orchestration.py",
+            "loopx/control_plane/goals/configure_goal_service.py",
             "loopx/heartbeat_prompt.py",
             "loopx/configure_goal.py",
+            "examples/project/configure-goal-global-sync-smoke.py",
         ),
         "checks": [
+            {
+                "command": "python3 examples/project/configure-goal-global-sync-smoke.py",
+                "tier": "default",
+                "reason": "guards authoritative split-runtime configure-goal sync, explicit overrides, and exact readback",
+            },
             {
                 "command": "python3 examples/control_plane/peer-agent-runtime-v1-smoke.py",
                 "tier": "default",

--- a/loopx/cli_commands/registry_admin.py
+++ b/loopx/cli_commands/registry_admin.py
@@ -7,6 +7,9 @@ from pathlib import Path
 
 from ..agent_registry import normalize_registered_agents
 from ..configure_goal import configure_goal, render_configure_goal_markdown
+from ..control_plane.goals.configure_goal_service import (
+    configure_goal_with_global_sync,
+)
 from ..global_registry import (
     render_global_goal_retirement_markdown,
     render_global_sync_markdown,
@@ -645,9 +648,10 @@ def handle_registry_admin_command(
                 json.loads(raw_profile)
                 for raw_profile in (args.agent_profile_jsons or [])
             ]
-            payload = configure_goal(
+            payload = configure_goal_with_global_sync(
                 registry_path=registry_path,
                 goal_id=args.goal_id,
+                runtime_root_override=args.runtime_root,
                 quota_compute=args.quota_compute,
                 quota_window_hours=args.quota_window_hours,
                 self_repair_enabled=args.self_repair_enabled,

--- a/loopx/configure_goal.py
+++ b/loopx/configure_goal.py
@@ -1024,10 +1024,10 @@ def render_configure_goal_markdown(payload: dict[str, Any]) -> str:
         )
         lines.extend(
             [
-                f"- global_sync_enabled: \`{global_sync.get('enabled')}\`",
-                f"- global_sync_executed: \`{global_sync.get('executed')}\`",
-                f"- global_sync_target: \`{selected_target.get('global_registry')}\`",
-                f"- global_sync_readback: \`{readback.get('status')}\`",
+                f"- global_sync_enabled: `{global_sync.get('enabled')}`",
+                f"- global_sync_executed: `{global_sync.get('executed')}`",
+                f"- global_sync_target: `{selected_target.get('global_registry')}`",
+                f"- global_sync_readback: `{readback.get('status')}`",
             ]
         )
     if payload.get("control_plane_summary"):

--- a/loopx/configure_goal.py
+++ b/loopx/configure_goal.py
@@ -1010,6 +1010,26 @@ def render_configure_goal_markdown(payload: dict[str, Any]) -> str:
         return "\n".join(lines)
     fields = payload.get("changed_fields") or []
     lines.append(f"- changed_fields: `{', '.join(fields) if fields else 'none'}`")
+    global_sync = payload.get("global_sync")
+    if isinstance(global_sync, dict):
+        selected_target = (
+            global_sync.get("selected_target")
+            if isinstance(global_sync.get("selected_target"), dict)
+            else {}
+        )
+        readback = (
+            global_sync.get("readback")
+            if isinstance(global_sync.get("readback"), dict)
+            else {}
+        )
+        lines.extend(
+            [
+                f"- global_sync_enabled: \`{global_sync.get('enabled')}\`",
+                f"- global_sync_executed: \`{global_sync.get('executed')}\`",
+                f"- global_sync_target: \`{selected_target.get('global_registry')}\`",
+                f"- global_sync_readback: \`{readback.get('status')}\`",
+            ]
+        )
     if payload.get("control_plane_summary"):
         lines.append(f"- control_plane: {payload.get('control_plane_summary')}")
     if payload.get("orchestration_summary"):

--- a/loopx/control_plane/goals/configure_goal_service.py
+++ b/loopx/control_plane/goals/configure_goal_service.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from ...configure_goal import configure_goal
+from ...global_registry import (
+    sanitize_goal_for_global,
+    sync_project_registry_to_global,
+)
+from ...history import load_registry
+from ...paths import global_registry_path, resolve_runtime_root
+from ...registry import registry_goals
+from ...registry_writability import probe_registry_write_path
+from ..runtime.runtime_projection_route import (
+    compact_runtime_projection_route,
+    resolve_runtime_projection_route,
+)
+
+
+CONFIGURE_GOAL_GLOBAL_SYNC_SCHEMA_VERSION = "configure_goal_global_sync_v0"
+CONFIGURE_GOAL_GLOBAL_SYNC_READBACK_SCHEMA_VERSION = (
+    "configure_goal_global_sync_readback_v0"
+)
+
+
+def _same_path(left: Path, right: Path) -> bool:
+    try:
+        return left.expanduser().resolve() == right.expanduser().resolve()
+    except OSError:
+        return str(left.expanduser()) == str(right.expanduser())
+
+
+def _goal(payload: dict[str, Any], goal_id: str) -> dict[str, Any] | None:
+    return next(
+        (
+            item
+            for item in registry_goals(payload)
+            if str(item.get("id") or "") == goal_id
+        ),
+        None,
+    )
+
+
+def _digest(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(value, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    ).hexdigest()[:16]
+
+
+def resolve_configure_goal_sync_target(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    runtime_root_override: str | None,
+) -> dict[str, Any]:
+    source_registry = registry_path.expanduser().resolve()
+    source_payload = load_registry(source_registry)
+    if _goal(source_payload, goal_id) is None:
+        raise ValueError(f"goal id not found in source registry: {goal_id}")
+    source_runtime = (
+        resolve_runtime_root(
+            source_payload,
+            None,
+            registry_path=source_registry,
+        )
+        .expanduser()
+        .resolve()
+    )
+
+    if runtime_root_override:
+        target_runtime = Path(runtime_root_override).expanduser().resolve()
+        route = {
+            "schema_version": "runtime_projection_route_v0",
+            "status": "explicit_override",
+            "projection_required": not _same_path(source_runtime, target_runtime),
+            "declaration_source": "cli.runtime_root_override",
+            "source_registry": str(source_registry),
+            "source_runtime_root": str(source_runtime),
+            "target_runtime_root": str(target_runtime),
+            "target_registry": str(global_registry_path(target_runtime)),
+            "match_count": 1,
+            "source_mirror_match_count": 0,
+            "conflict_count": 0,
+            "unreadable_target_count": 0,
+        }
+    else:
+        route = resolve_runtime_projection_route(
+            registry_path=source_registry,
+            goal_id=goal_id,
+            source_runtime_root=source_runtime,
+        )
+        status = str(route.get("status") or "missing")
+        if status not in {"resolved", "single_runtime"}:
+            raise ValueError(
+                f"configure-goal global sync route is {status}; refusing to write "
+                "the source registry without one authoritative shared runtime"
+            )
+        target_text = str(route.get("target_runtime_root") or "").strip()
+        if not target_text:
+            raise ValueError(
+                "configure-goal global sync route has no target runtime; refusing partial write"
+            )
+        target_runtime = Path(target_text).expanduser().resolve()
+
+    target_registry = global_registry_path(target_runtime).expanduser().resolve()
+    return {
+        "ok": True,
+        "schema_version": CONFIGURE_GOAL_GLOBAL_SYNC_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "status": route.get("status"),
+        "declaration_source": route.get("declaration_source"),
+        "explicit_runtime_override": bool(runtime_root_override),
+        "source_registry": str(source_registry),
+        "source_runtime_root": str(source_runtime),
+        "target_runtime_root": str(target_runtime),
+        "target_global_registry": str(target_registry),
+        "route": compact_runtime_projection_route(route),
+    }
+
+
+def _readback(
+    *,
+    source_registry: Path,
+    target_registry: Path,
+    goal_id: str,
+    sync_payload: dict[str, Any],
+) -> dict[str, Any]:
+    source_payload = load_registry(source_registry)
+    target_payload = load_registry(target_registry)
+    source_goal = _goal(source_payload, goal_id)
+    target_goal = _goal(target_payload, goal_id)
+    synced_at = str(sync_payload.get("updated_at") or "").strip()
+    source_is_target = _same_path(source_registry, target_registry)
+
+    expected_goal = source_goal
+    if source_goal is not None and not source_is_target:
+        expected_goal = sanitize_goal_for_global(
+            source_goal,
+            source_registry=source_registry,
+            synced_at=synced_at,
+        )
+    expected_digest = _digest(expected_goal) if expected_goal is not None else None
+    target_digest = _digest(target_goal) if target_goal is not None else None
+    target_source_registry = str(
+        (target_goal or {}).get("source_registry") or ""
+    ).strip()
+    source_registry_match = bool(
+        target_goal is not None
+        and (
+            source_is_target
+            or (
+                target_source_registry
+                and _same_path(Path(target_source_registry), source_registry)
+            )
+        )
+    )
+    synced_at_match = bool(
+        source_is_target
+        or (
+            target_goal is not None
+            and str(target_goal.get("synced_at") or "") == synced_at
+        )
+    )
+    verified = bool(
+        source_goal is not None
+        and target_goal is not None
+        and expected_digest == target_digest
+        and source_registry_match
+        and synced_at_match
+    )
+    return {
+        "schema_version": CONFIGURE_GOAL_GLOBAL_SYNC_READBACK_SCHEMA_VERSION,
+        "status": "verified" if verified else "mismatch",
+        "verified": verified,
+        "goal_id": goal_id,
+        "target_global_registry": str(target_registry),
+        "goal_present": target_goal is not None,
+        "source_registry_match": source_registry_match,
+        "synced_at_match": synced_at_match,
+        "expected_goal_sha256_16": expected_digest,
+        "target_goal_sha256_16": target_digest,
+    }
+
+
+def _sync_plan(
+    *,
+    changed: bool,
+    target_resolution: dict[str, Any] | None,
+    execute: bool,
+) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "schema_version": CONFIGURE_GOAL_GLOBAL_SYNC_SCHEMA_VERSION,
+        "enabled": bool(changed),
+        "required": bool(changed),
+        "executed": False,
+        "target_resolution": target_resolution,
+        "selected_target": (
+            {
+                "runtime_root": target_resolution.get("target_runtime_root"),
+                "global_registry": target_resolution.get("target_global_registry"),
+                "declaration_source": target_resolution.get("declaration_source"),
+                "explicit_runtime_override": target_resolution.get(
+                    "explicit_runtime_override"
+                ),
+            }
+            if target_resolution
+            else None
+        ),
+        "readback": {
+            "schema_version": CONFIGURE_GOAL_GLOBAL_SYNC_READBACK_SCHEMA_VERSION,
+            "status": "not_required" if not changed else "not_executed",
+            "verified": False,
+        },
+        "reason": (
+            "no configuration change"
+            if not changed
+            else "dry-run preview; source and shared registries are unchanged"
+            if not execute
+            else None
+        ),
+    }
+
+
+def configure_goal_with_global_sync(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    runtime_root_override: str | None,
+    execute: bool,
+    **configure_options: Any,
+) -> dict[str, Any]:
+    """Configure one source goal and keep its authoritative shared read model current."""
+
+    preview = configure_goal(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        execute=False,
+        **configure_options,
+    )
+    changed = bool(preview.get("changed"))
+    target_resolution = (
+        resolve_configure_goal_sync_target(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            runtime_root_override=runtime_root_override,
+        )
+        if changed
+        else None
+    )
+    preview["global_sync"] = _sync_plan(
+        changed=changed,
+        target_resolution=target_resolution,
+        execute=execute,
+    )
+    if not execute:
+        return preview
+
+    if not changed:
+        applied = configure_goal(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            execute=True,
+            **configure_options,
+        )
+        applied["global_sync"] = preview["global_sync"]
+        return applied
+
+    if target_resolution is None:
+        raise RuntimeError("configure-goal sync target was not resolved")
+    target_registry = Path(str(target_resolution["target_global_registry"]))
+    writability = probe_registry_write_path(target_registry, create_parent=True)
+    if not writability.get("ok"):
+        preview.update(
+            {
+                "ok": False,
+                "dry_run": False,
+                "execute": True,
+                "written": False,
+                "error": str(
+                    writability.get("error")
+                    or "authoritative shared registry is not writable"
+                ),
+                "recommended_action": writability.get("recommended_action"),
+            }
+        )
+        preview["global_sync"].update(
+            {
+                "ok": False,
+                "reason": "authoritative shared registry preflight failed",
+                "global_registry_writability": writability,
+            }
+        )
+        return preview
+
+    applied = configure_goal(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        execute=True,
+        **configure_options,
+    )
+    if not applied.get("written"):
+        applied["global_sync"] = _sync_plan(
+            changed=False,
+            target_resolution=target_resolution,
+            execute=True,
+        )
+        return applied
+
+    sync_payload = sync_project_registry_to_global(
+        registry_path=registry_path,
+        runtime_root_override=str(target_resolution["target_runtime_root"]),
+        goal_id=goal_id,
+        dry_run=False,
+    )
+    readback = (
+        _readback(
+            source_registry=registry_path.expanduser().resolve(),
+            target_registry=target_registry,
+            goal_id=goal_id,
+            sync_payload=sync_payload,
+        )
+        if sync_payload.get("ok")
+        else {
+            "schema_version": CONFIGURE_GOAL_GLOBAL_SYNC_READBACK_SCHEMA_VERSION,
+            "status": "not_run",
+            "verified": False,
+        }
+    )
+    sync_ok = bool(sync_payload.get("ok") and readback.get("verified"))
+    applied["global_sync"] = {
+        **_sync_plan(
+            changed=True,
+            target_resolution=target_resolution,
+            execute=True,
+        ),
+        "ok": sync_ok,
+        "executed": True,
+        "sync": sync_payload,
+        "readback": readback,
+        "global_registry_writability": writability,
+    }
+    applied["ok"] = bool(applied.get("ok") and sync_ok)
+    applied["partial_write"] = bool(applied.get("written") and not sync_ok)
+    if not sync_ok:
+        applied["error"] = "configure-goal shared registry readback did not verify"
+        applied["recommended_action"] = (
+            sync_payload.get("recommended_action")
+            or f"rerun loopx sync-global --goal-id {goal_id} after repairing the shared runtime route"
+        )
+    return applied

--- a/loopx/status_server.py
+++ b/loopx/status_server.py
@@ -7,7 +7,9 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
-from .configure_goal import configure_goal
+from .control_plane.goals.configure_goal_service import (
+    configure_goal_with_global_sync,
+)
 from .feedback import append_human_reward, compact_reward
 from .history import load_registry
 from .materials import read_review_material
@@ -407,9 +409,10 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
 
     def _configure_goal_payload(self, body: dict[str, Any], *, apply: bool, execute: bool) -> dict[str, Any]:
         values = self._parse_configure_goal_body(body, apply=apply)
-        return configure_goal(
+        return configure_goal_with_global_sync(
             registry_path=self.server.registry_path,
             goal_id=values["goal_id"],
+            runtime_root_override=self.server.runtime_root_override,
             quota_compute=values["quota_compute"],
             quota_window_hours=values["quota_window_hours"],
             self_repair_enabled=values["self_repair_enabled"],
@@ -458,6 +461,7 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             "feature_summary": payload.get("feature_summary"),
             "heartbeat_prompt_migration": payload.get("heartbeat_prompt_migration"),
             "supervisor_prompt": payload.get("supervisor_prompt"),
+            "global_sync": payload.get("global_sync"),
         }
 
     def _handle_configure_goal_dry_run(self) -> None:


### PR DESCRIPTION
## Summary
- resolve implicit configure-goal sync through the registry-declared authoritative shared runtime
- preserve explicit --runtime-root precedence and expose the selected target plus exact digest readback
- cover CLI and dashboard apply paths with a split-runtime regression and README guidance

## Validation
- LoopX premerge canary: 18/18 selected checks passed
- public boundary scan: clean across 8 changed files
- focused configure-goal, API, planner, and peer-runtime smokes passed

## Boundary
- public repository code, tests, and docs only
- no credentials, private project state, or production actions