### PR TITLE
Persist owner-only SkillsBench runner profiles

### DIFF
--- a/examples/skillsbench-runner-profile-smoke.py
+++ b/examples/skillsbench-runner-profile-smoke.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+from loopx.benchmark_adapters.skillsbench_runner_profile import (
+    SKILLSBENCH_RUNNER_PROFILE_SCHEMA_VERSION,
+    SkillsBenchRunnerProfileError,
+    capture_skillsbench_runner_profile,
+    load_skillsbench_runner_profile,
+    skillsbench_runner_profile_shell_exports,
+    skillsbench_runner_profile_summary,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LAUNCHER = REPO_ROOT / "scripts" / "skillsbench-launch-goal-xhigh.sh"
+PROFILE_MODULE = (
+    REPO_ROOT
+    / "loopx"
+    / "benchmark_adapters"
+    / "skillsbench_runner_profile.py"
+)
+
+
+def _environment() -> dict[str, str]:
+    return {
+        "SKILLSBENCH_SSH_DESTINATION": "runner.example.invalid",
+        "SKILLSBENCH_REMOTE_ROOT": "/opaque/source-7d2d9f4a",
+        "SKILLSBENCH_ROOT": "/opaque/benchmark-351d9b72",
+        "SKILLSBENCH_EXPECTED_LOOPX_GIT_HEAD": "a" * 40,
+        "SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_COMMAND": (
+            "private-probe-marker"
+        ),
+        "SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_SOLVER_COMMAND": (
+            "private-solver-marker"
+        ),
+        "SKILLSBENCH_LOOPX_TURN_VALIDATION_COMMAND": (
+            "private-validator-marker"
+        ),
+    }
+
+
+def _expect_error(code: str, callback: object) -> None:
+    try:
+        callback()  # type: ignore[operator]
+    except SkillsBenchRunnerProfileError as error:
+        assert error.code == code, error.code
+    else:
+        raise AssertionError(f"expected runner profile error: {code}")
+
+
+def _copy_launcher_fixture(root: Path) -> Path:
+    launcher = root / "scripts" / LAUNCHER.name
+    launcher.parent.mkdir(parents=True)
+    shutil.copy2(LAUNCHER, launcher)
+    package = root / "loopx" / "benchmark_adapters"
+    package.mkdir(parents=True)
+    (root / "loopx" / "__init__.py").write_text("", encoding="utf-8")
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    shutil.copy2(PROFILE_MODULE, package / PROFILE_MODULE.name)
+    return launcher
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-runner-profile-") as value:
+        root = Path(value)
+        profile_path = root / "private" / "runner-profile.json"
+        source_environment = _environment()
+        _expect_error(
+            "required_runner_environment_missing",
+            lambda: capture_skillsbench_runner_profile(
+                root / "private" / "incomplete.json",
+                environment={},
+            ),
+        )
+        summary = capture_skillsbench_runner_profile(
+            profile_path,
+            environment=source_environment,
+        )
+        assert stat.S_IMODE(profile_path.stat().st_mode) == 0o600
+        assert summary == {
+            "ok": True,
+            "schema_version": SKILLSBENCH_RUNNER_PROFILE_SCHEMA_VERSION,
+            "environment_key_count": len(source_environment),
+            "required_environment_complete": True,
+            "profile_path_recorded": False,
+            "profile_values_recorded": False,
+            "owner_only_permissions_required": True,
+        }
+        loaded = load_skillsbench_runner_profile(profile_path)
+        assert loaded == source_environment
+        assert not set(source_environment.values()) & set(
+            skillsbench_runner_profile_summary(loaded).values()
+        )
+        symlink_path = root / "private" / "runner-profile-link.json"
+        symlink_path.symlink_to(profile_path)
+        _expect_error(
+            "profile_not_regular_file",
+            lambda: load_skillsbench_runner_profile(symlink_path),
+        )
+
+        exports = skillsbench_runner_profile_shell_exports(
+            loaded,
+            current_environment={
+                "SKILLSBENCH_REMOTE_ROOT": "/explicit/source-override"
+            },
+        )
+        assert "SKILLSBENCH_REMOTE_ROOT" not in exports
+        assert "SKILLSBENCH_SSH_DESTINATION" in exports
+
+        profile_path.chmod(0o644)
+        _expect_error(
+            "profile_permissions_not_owner_only",
+            lambda: load_skillsbench_runner_profile(profile_path),
+        )
+        profile_path.chmod(0o600)
+
+        profile_payload = json.loads(profile_path.read_text(encoding="utf-8"))
+        profile_payload["environment"]["SKILLSBENCH_UNKNOWN_PRIVATE_VALUE"] = "x"
+        profile_path.write_text(
+            json.dumps(profile_payload),
+            encoding="utf-8",
+        )
+        profile_path.chmod(0o600)
+        _expect_error(
+            "profile_environment_key_unknown",
+            lambda: load_skillsbench_runner_profile(profile_path),
+        )
+
+        capture_skillsbench_runner_profile(
+            profile_path,
+            environment=source_environment,
+            force=True,
+        )
+        launcher = _copy_launcher_fixture(root / "fixture-repo")
+        launch_environment = {
+            key: value
+            for key, value in os.environ.items()
+            if not key.startswith("SKILLSBENCH_")
+        }
+        launch_environment.update(
+            {
+                "SKILLSBENCH_RUNNER_PROFILE": str(profile_path),
+                "SKILLSBENCH_ROUTE": "loopx-turn-agent-cli",
+                "SKILLSBENCH_RUN_STAMP": "runnerprofile-smoke",
+                "SKILLSBENCH_DOCKER_PROXY_HOST": "docker-proxy.example.invalid",
+                "SKILLSBENCH_DOCKER_API_VERSION": "1.43",
+            }
+        )
+        completed = subprocess.run(
+            [
+                "bash",
+                str(launcher),
+                "--dry-run",
+                "fixture-task",
+                "runner-profile-smoke",
+                "18181",
+            ],
+            cwd=launcher.parents[1],
+            env=launch_environment,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        assert completed.returncode == 0, completed.stderr
+        output = completed.stdout
+        assert "runner_profile_loaded=true" in output
+        assert "runner_profile_path_recorded=false" in output
+        assert "runner_profile_values_recorded=false" in output
+        assert "private_runner_command_values_redacted=true" in output
+        assert "loopx_turn_validation_command_configured=1" in output
+        for key, private_value in source_environment.items():
+            assert private_value not in output, key
+            assert private_value not in completed.stderr, key
+
+    print("skillsbench-runner-profile-smoke: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/benchmark_adapters/skillsbench_runner_profile.py
+++ b/loopx/benchmark_adapters/skillsbench_runner_profile.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import stat
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+
+SKILLSBENCH_RUNNER_PROFILE_SCHEMA_VERSION = "skillsbench_runner_profile_v0"
+REQUIRED_RUNNER_ENV = (
+    "SKILLSBENCH_SSH_DESTINATION",
+    "SKILLSBENCH_REMOTE_ROOT",
+    "SKILLSBENCH_ROOT",
+    "SKILLSBENCH_EXPECTED_LOOPX_GIT_HEAD",
+)
+ALLOWED_RUNNER_ENV = frozenset(
+    {
+        *REQUIRED_RUNNER_ENV,
+        "SKILLSBENCH_REMOTE_CODEX_BIN",
+        "SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_COMMAND",
+        "SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_SOLVER_COMMAND",
+        "SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_AGENT_COMMAND",
+        "SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_AGENT_COMMAND_INSTRUMENTED",
+        "SKILLSBENCH_LOOPX_TURN_VALIDATION_COMMAND",
+        "SKILLSBENCH_SSH_OPTIONS",
+    }
+)
+
+
+class SkillsBenchRunnerProfileError(ValueError):
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+def _profile_file(path: Path) -> Path:
+    try:
+        file_stat = path.lstat()
+    except OSError as error:
+        raise SkillsBenchRunnerProfileError("profile_unreadable") from error
+    if not stat.S_ISREG(file_stat.st_mode):
+        raise SkillsBenchRunnerProfileError("profile_not_regular_file")
+    if file_stat.st_uid != os.getuid():
+        raise SkillsBenchRunnerProfileError("profile_not_owned_by_current_user")
+    if stat.S_IMODE(file_stat.st_mode) & 0o077:
+        raise SkillsBenchRunnerProfileError("profile_permissions_not_owner_only")
+    return path
+
+
+def load_skillsbench_runner_profile(path: Path) -> dict[str, str]:
+    profile_path = _profile_file(path)
+    try:
+        payload = json.loads(profile_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise SkillsBenchRunnerProfileError("profile_json_invalid") from error
+    if not isinstance(payload, Mapping):
+        raise SkillsBenchRunnerProfileError("profile_root_invalid")
+    if payload.get("schema_version") != SKILLSBENCH_RUNNER_PROFILE_SCHEMA_VERSION:
+        raise SkillsBenchRunnerProfileError("profile_schema_unsupported")
+    if set(payload) - {"schema_version", "environment"}:
+        raise SkillsBenchRunnerProfileError("profile_root_key_unknown")
+    environment = payload.get("environment")
+    if not isinstance(environment, Mapping):
+        raise SkillsBenchRunnerProfileError("profile_environment_invalid")
+    unknown = set(environment) - ALLOWED_RUNNER_ENV
+    if unknown:
+        raise SkillsBenchRunnerProfileError("profile_environment_key_unknown")
+
+    normalized: dict[str, str] = {}
+    for key, value in environment.items():
+        if not isinstance(key, str) or not isinstance(value, str) or not value:
+            raise SkillsBenchRunnerProfileError("profile_environment_value_invalid")
+        if "\x00" in value:
+            raise SkillsBenchRunnerProfileError("profile_environment_value_invalid")
+        normalized[key] = value
+    return normalized
+
+
+def skillsbench_runner_profile_shell_exports(
+    profile: Mapping[str, str],
+    *,
+    current_environment: Mapping[str, str] | None = None,
+) -> str:
+    environment = current_environment if current_environment is not None else os.environ
+    lines = []
+    for key in sorted(profile):
+        if environment.get(key):
+            continue
+        lines.append(f"export {key}={shlex.quote(profile[key])}")
+    return "\n".join(lines)
+
+
+def capture_skillsbench_runner_profile(
+    path: Path,
+    *,
+    environment: Mapping[str, str] | None = None,
+    force: bool = False,
+) -> dict[str, Any]:
+    source = environment if environment is not None else os.environ
+    captured = {
+        key: str(source[key])
+        for key in sorted(ALLOWED_RUNNER_ENV)
+        if str(source.get(key) or "")
+    }
+    missing = [key for key in REQUIRED_RUNNER_ENV if key not in captured]
+    if missing:
+        raise SkillsBenchRunnerProfileError("required_runner_environment_missing")
+    if path.exists() and not force:
+        raise SkillsBenchRunnerProfileError("profile_already_exists")
+
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    payload = {
+        "schema_version": SKILLSBENCH_RUNNER_PROFILE_SCHEMA_VERSION,
+        "environment": captured,
+    }
+    try:
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(temporary, path)
+        path.chmod(0o600)
+    except OSError as error:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise SkillsBenchRunnerProfileError("profile_write_failed") from error
+    return skillsbench_runner_profile_summary(captured)
+
+
+def skillsbench_runner_profile_summary(
+    profile: Mapping[str, str],
+) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "schema_version": SKILLSBENCH_RUNNER_PROFILE_SCHEMA_VERSION,
+        "environment_key_count": len(profile),
+        "required_environment_complete": all(
+            profile.get(key) for key in REQUIRED_RUNNER_ENV
+        ),
+        "profile_path_recorded": False,
+        "profile_values_recorded": False,
+        "owner_only_permissions_required": True,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Capture or load an owner-only local SkillsBench runner profile "
+            "without printing private values in public summaries."
+        )
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+    for name in ("export-shell", "inspect"):
+        command = commands.add_parser(name)
+        command.add_argument("--profile", type=Path, required=True)
+    capture = commands.add_parser("capture")
+    capture.add_argument("--profile", type=Path, required=True)
+    capture.add_argument("--force", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "capture":
+            summary = capture_skillsbench_runner_profile(
+                args.profile,
+                force=args.force,
+            )
+            print(json.dumps(summary, sort_keys=True))
+            return 0
+        profile = load_skillsbench_runner_profile(args.profile)
+        if args.command == "inspect":
+            print(json.dumps(skillsbench_runner_profile_summary(profile), sort_keys=True))
+            return 0
+        exports = skillsbench_runner_profile_shell_exports(profile)
+        if exports:
+            print(exports)
+        return 0
+    except SkillsBenchRunnerProfileError as error:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "schema_version": SKILLSBENCH_RUNNER_PROFILE_SCHEMA_VERSION,
+                    "error": error.code,
+                    "profile_path_recorded": False,
+                    "profile_values_recorded": False,
+                },
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -16,6 +16,9 @@ Required env:
   SKILLSBENCH_EXPECTED_LOOPX_GIT_HEAD  Expected LoopX git head in remote root
 
 Optional env:
+  SKILLSBENCH_RUNNER_PROFILE           Owner-only local JSON profile captured
+                                       by skillsbench_runner_profile; explicit
+                                       env values override profile values
   SKILLSBENCH_LOCAL_CODEX_PROXY_HOST   Local proxy host, default 127.0.0.1
   SKILLSBENCH_LOCAL_CODEX_PROXY_PORT   Local proxy port, default 18180
   SKILLSBENCH_DOCKER_PROXY_HOST        Remote Docker bridge host for benchmark
@@ -124,6 +127,23 @@ task_count="${#task_ids[@]}"
 tag="${2:-${SKILLSBENCH_RUN_TAG:-manual}}"
 remote_proxy_port="${3:-${SKILLSBENCH_REMOTE_CODEX_PROXY_PORT:-18180}}"
 
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+runner_profile="${SKILLSBENCH_RUNNER_PROFILE:-}"
+runner_profile_loaded=false
+if [[ -n "$runner_profile" ]]; then
+  if ! runner_profile_exports="$(
+    PYTHONPATH="${repo_root}${PYTHONPATH:+:${PYTHONPATH}}" \
+      python3 -m loopx.benchmark_adapters.skillsbench_runner_profile \
+      export-shell --profile "$runner_profile"
+  )"; then
+    exit 2
+  fi
+  # The helper emits only whitelisted variable names with shlex-quoted values.
+  eval "$runner_profile_exports"
+  unset runner_profile_exports
+  runner_profile_loaded=true
+fi
+
 required_env=(
   SKILLSBENCH_SSH_DESTINATION
   SKILLSBENCH_REMOTE_ROOT
@@ -142,7 +162,6 @@ if [[ -n "${SKILLSBENCH_STANDARD_AGGREGATE_PATH:-}" ]] &&
   exit 2
 fi
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
 ssh_command_options=(-o BatchMode=yes -o ConnectTimeout=10)
@@ -517,6 +536,9 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'docker_proxy_endpoint_mode=%s\n' "$docker_proxy_endpoint_mode"
   printf 'docker_api_version=%s\n' "$docker_api_version"
   printf 'remote_codex_bin_mode=%s\n' "$remote_codex_bin_mode"
+  printf 'runner_profile_loaded=%s\n' "$runner_profile_loaded"
+  printf 'runner_profile_path_recorded=false\n'
+  printf 'runner_profile_values_recorded=false\n'
   printf 'local_codex_sandbox=%s\n' "$local_codex_sandbox"
   printf 'codex_cli_goal_thread_prewarm=%s\n' "$codex_cli_goal_thread_prewarm"
   printf 'allow_staged_bootstrap_repair_run=%s\n' "$allow_staged_bootstrap_repair_run"
@@ -539,7 +561,8 @@ if [[ "$dry_run" == "true" ]]; then
   if [[ -n "${standard_aggregate:-}" ]]; then
     printf 'standard_aggregate=%s\n' "$standard_aggregate"
   fi
-  if [[ -n "$remote_command_file_bridge_probe_command" ]] ||
+  if [[ "$runner_profile_loaded" == "true" ]] ||
+    [[ -n "$remote_command_file_bridge_probe_command" ]] ||
     [[ -n "$remote_command_file_bridge_solver_command" ]] ||
     [[ -n "$remote_command_file_bridge_agent_command" ]] ||
     [[ -n "$loopx_turn_validation_command" ]]; then


### PR DESCRIPTION
## Summary
- add an owner-only, fail-closed local runner profile for durable SkillsBench source/bridge/validator configuration
- let the existing launcher load the profile while preserving explicit environment overrides
- add a public-safe smoke covering permissions, schema boundaries, precedence, redaction, and launcher integration

## Product judgment
This repairs a real resume gap: runner setup previously lived only in one process environment, so a later heartbeat could not recover it. The partner-facing Turn contract remains unchanged; this is an operator-only launcher input, not a new Turn protocol layer.

## Validation
- `python3 -m py_compile loopx/benchmark_adapters/skillsbench_runner_profile.py examples/skillsbench-runner-profile-smoke.py`
- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`
- `PYTHONPATH=. python3 examples/skillsbench-runner-profile-smoke.py`
- `PYTHONPATH=. python3 examples/skillsbench-benchmark-run-smoke.py`
- `PYTHONPATH=. python3 examples/skillsbench-loopx-turn-agent-cli-smoke.py`
- `PYTHONPATH=. python3 examples/skillsbench-runner-source-fingerprint-smoke.py`
- `loopx canary premerge --from-git-diff --tier standard` (all 7 executed checks passed; benchmark-sensitive manual review hold remains)
- public/private boundary scan clean

No benchmark job, scoring, task semantics, submission, or permission boundary changed. `shellcheck` is unavailable locally.