### PR TITLE
Discover the owner-local SkillsBench runner profile

### DIFF
--- a/examples/skillsbench-runner-profile-smoke.py
+++ b/examples/skillsbench-runner-profile-smoke.py
@@ -13,6 +13,7 @@ from loopx.benchmark_adapters.skillsbench_runner_profile import (
     SKILLSBENCH_RUNNER_PROFILE_SCHEMA_VERSION,
     SkillsBenchRunnerProfileError,
     capture_skillsbench_runner_profile,
+    default_skillsbench_runner_profile_path,
     load_skillsbench_runner_profile,
     skillsbench_runner_profile_shell_exports,
     skillsbench_runner_profile_summary,
@@ -72,6 +73,12 @@ def main() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-runner-profile-") as value:
         root = Path(value)
         profile_path = root / "private" / "runner-profile.json"
+        default_profile_path = default_skillsbench_runner_profile_path(
+            {"XDG_STATE_HOME": str(root / "state")}
+        )
+        assert default_profile_path == (
+            root / "state" / "loopx" / "skillsbench" / "runner-profile.json"
+        )
         source_environment = _environment()
         _expect_error(
             "required_runner_environment_missing",
@@ -147,13 +154,15 @@ def main() -> None:
         }
         launch_environment.update(
             {
-                "SKILLSBENCH_RUNNER_PROFILE": str(profile_path),
                 "SKILLSBENCH_ROUTE": "loopx-turn-agent-cli",
                 "SKILLSBENCH_RUN_STAMP": "runnerprofile-smoke",
                 "SKILLSBENCH_DOCKER_PROXY_HOST": "docker-proxy.example.invalid",
                 "SKILLSBENCH_DOCKER_API_VERSION": "1.43",
+                "XDG_STATE_HOME": str(root / "state"),
             }
         )
+        default_profile_path.parent.mkdir(parents=True)
+        shutil.copy2(profile_path, default_profile_path)
         completed = subprocess.run(
             [
                 "bash",

--- a/loopx/benchmark_adapters/skillsbench_runner_profile.py
+++ b/loopx/benchmark_adapters/skillsbench_runner_profile.py
@@ -12,6 +12,9 @@ from typing import Any
 
 
 SKILLSBENCH_RUNNER_PROFILE_SCHEMA_VERSION = "skillsbench_runner_profile_v0"
+SKILLSBENCH_RUNNER_PROFILE_RELATIVE_PATH = Path(
+    "loopx/skillsbench/runner-profile.json"
+)
 REQUIRED_RUNNER_ENV = (
     "SKILLSBENCH_SSH_DESTINATION",
     "SKILLSBENCH_REMOTE_ROOT",
@@ -36,6 +39,23 @@ class SkillsBenchRunnerProfileError(ValueError):
     def __init__(self, code: str) -> None:
         super().__init__(code)
         self.code = code
+
+
+def default_skillsbench_runner_profile_path(
+    environment: Mapping[str, str] | None = None,
+) -> Path:
+    source = environment if environment is not None else os.environ
+    state_home = str(source.get("XDG_STATE_HOME") or "")
+    if state_home:
+        root = Path(state_home).expanduser()
+    else:
+        home = str(source.get("HOME") or "")
+        if not home:
+            raise SkillsBenchRunnerProfileError("profile_default_path_unavailable")
+        root = Path(home).expanduser() / ".local" / "state"
+    if not root.is_absolute():
+        raise SkillsBenchRunnerProfileError("profile_default_path_invalid")
+    return root / SKILLSBENCH_RUNNER_PROFILE_RELATIVE_PATH
 
 
 def _profile_file(path: Path) -> Path:
@@ -165,9 +185,11 @@ def _parser() -> argparse.ArgumentParser:
     commands = parser.add_subparsers(dest="command", required=True)
     for name in ("export-shell", "inspect"):
         command = commands.add_parser(name)
-        command.add_argument("--profile", type=Path, required=True)
+        command.add_argument("--profile", type=Path)
+        if name == "export-shell":
+            command.add_argument("--if-present", action="store_true")
     capture = commands.add_parser("capture")
-    capture.add_argument("--profile", type=Path, required=True)
+    capture.add_argument("--profile", type=Path)
     capture.add_argument("--force", action="store_true")
     return parser
 
@@ -175,20 +197,29 @@ def _parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     try:
+        profile_path = args.profile or default_skillsbench_runner_profile_path()
         if args.command == "capture":
             summary = capture_skillsbench_runner_profile(
-                args.profile,
+                profile_path,
                 force=args.force,
             )
             print(json.dumps(summary, sort_keys=True))
             return 0
-        profile = load_skillsbench_runner_profile(args.profile)
+        if (
+            args.command == "export-shell"
+            and args.if_present
+            and not profile_path.exists()
+            and not profile_path.is_symlink()
+        ):
+            return 0
+        profile = load_skillsbench_runner_profile(profile_path)
         if args.command == "inspect":
             print(json.dumps(skillsbench_runner_profile_summary(profile), sort_keys=True))
             return 0
         exports = skillsbench_runner_profile_shell_exports(profile)
         if exports:
             print(exports)
+        print("export SKILLSBENCH_RUNNER_PROFILE_DISCOVERED=1")
         return 0
     except SkillsBenchRunnerProfileError as error:
         print(

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -18,7 +18,10 @@ Required env:
 Optional env:
   SKILLSBENCH_RUNNER_PROFILE           Owner-only local JSON profile captured
                                        by skillsbench_runner_profile; explicit
-                                       env values override profile values
+                                       env values override profile values. If
+                                       unset, the owner-local default is used
+                                       when present. Capture the default with:
+                                       python3 -m loopx.benchmark_adapters.skillsbench_runner_profile capture
   SKILLSBENCH_LOCAL_CODEX_PROXY_HOST   Local proxy host, default 127.0.0.1
   SKILLSBENCH_LOCAL_CODEX_PROXY_PORT   Local proxy port, default 18180
   SKILLSBENCH_DOCKER_PROXY_HOST        Remote Docker bridge host for benchmark
@@ -130,19 +133,28 @@ remote_proxy_port="${3:-${SKILLSBENCH_REMOTE_CODEX_PROXY_PORT:-18180}}"
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 runner_profile="${SKILLSBENCH_RUNNER_PROFILE:-}"
 runner_profile_loaded=false
+runner_profile_args=(export-shell)
+unset SKILLSBENCH_RUNNER_PROFILE_DISCOVERED
 if [[ -n "$runner_profile" ]]; then
-  if ! runner_profile_exports="$(
-    PYTHONPATH="${repo_root}${PYTHONPATH:+:${PYTHONPATH}}" \
-      python3 -m loopx.benchmark_adapters.skillsbench_runner_profile \
-      export-shell --profile "$runner_profile"
-  )"; then
-    exit 2
-  fi
+  runner_profile_args+=(--profile "$runner_profile")
+else
+  runner_profile_args+=(--if-present)
+fi
+if ! runner_profile_exports="$(
+  PYTHONPATH="${repo_root}${PYTHONPATH:+:${PYTHONPATH}}" \
+    python3 -m loopx.benchmark_adapters.skillsbench_runner_profile \
+    "${runner_profile_args[@]}"
+)"; then
+  exit 2
+fi
+if [[ -n "$runner_profile_exports" ]]; then
   # The helper emits only whitelisted variable names with shlex-quoted values.
   eval "$runner_profile_exports"
-  unset runner_profile_exports
+fi
+if [[ "${SKILLSBENCH_RUNNER_PROFILE_DISCOVERED:-}" == "1" ]]; then
   runner_profile_loaded=true
 fi
+unset runner_profile_exports SKILLSBENCH_RUNNER_PROFILE_DISCOVERED
 
 required_env=(
   SKILLSBENCH_SSH_DESTINATION


### PR DESCRIPTION
## Summary
- give the owner-only SkillsBench runner profile a stable XDG-state default location
- let the existing launcher discover that profile when no explicit path is supplied
- keep explicit environment and explicit profile overrides intact, and preserve fail-closed symlink/permission checks

## Product judgment
PR #2230 persisted profile values but left the profile locator in process-local environment, so a later heartbeat could still lose the runner. This follow-up closes that exact resume gap without adding Turn protocol fields or automatic secret capture. A trusted runner session explicitly runs `capture` once; subsequent launcher calls discover the owner-local profile.

## Validation
- Python compile
- launcher `bash -n`
- runner-profile smoke, including default discovery and redaction
- full SkillsBench runner smoke, including no-profile fallback
- standard LoopX premerge canary: all direct and 7 selected checks passed
- public/private boundary scan clean

No benchmark job, scoring, task semantics, submission, permission boundary, or automatic credential persistence changed. `shellcheck` remains unavailable locally.