### PR TITLE
fix(quota): replan exhausted scoped vision frontiers

### DIFF
--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -84,6 +84,20 @@ def primary_claimed_advancement() -> dict:
     }
 
 
+def primary_excluded_unclaimed_advancement() -> dict:
+    item = primary_claimed_advancement()
+    item.pop("claimed_by")
+    item["excluded_agents"] = [SIDE_AGENT]
+    return item
+
+
+def primary_owned_lifecycle_monitor() -> dict:
+    item = monitor_item()
+    item["claimed_by"] = PRIMARY_AGENT
+    item["excluded_agents"] = [SIDE_AGENT]
+    return item
+
+
 def side_agent_claimed_advancement(
     *,
     index: int = 2,
@@ -1011,6 +1025,40 @@ def assert_repeat_advancement_vision_beats_watch_lane_continuation_ack() -> None
     ), guard
 
 
+def assert_repeat_advancement_vision_replans_past_peer_only_work() -> None:
+    guard = build_quota_should_run(
+        status_payload(
+            [
+                primary_owned_lifecycle_monitor(),
+                primary_excluded_unclaimed_advancement(),
+            ],
+            replan_obligation=None,
+            latest_runs=[
+                agent_vision_acceptance_only_run(
+                    advancement_policy="repeat_until_closed"
+                ),
+            ],
+        ),
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+
+    assert guard["decision"] == "autonomous_replan_required", guard
+    assert guard["effective_action"] == "autonomous_replan_required", guard
+    frontier = guard["goal_frontier_projection"]["remaining_advancement_frontier"]
+    assert frontier["current_agent_claimed_advancement_count"] == 0, guard
+    assert frontier["unclaimed_advancement_count"] == 0, guard
+    assert guard["agent_todo_summary"]["claim_scope"]["executor_excluded_self_count"] == 2, guard
+    monitors = guard["agent_todo_summary"]["claimed_monitor_open_items"]
+    assert monitors[0]["todo_id"] == "todo_monitor_wait", guard
+    route_hint = guard["goal_route_hint"]
+    assert route_hint["counts"]["unclaimed_advancement_count"] == 0, guard
+    assert "unclaimed_next_actions" not in route_hint, guard
+    action = guard["autonomous_replan_obligation"]["todo_actions"][0]
+    assert action["action"] == "add", guard
+    assert "next runnable" in action["text"], guard
+
+
 def assert_repeat_advancement_vision_accepts_runnable_successor() -> None:
     guard = build_quota_should_run(
         status_payload(
@@ -1528,6 +1576,7 @@ def main() -> None:
     assert_open_agent_vision_uses_watch_lane_continuation_ack()
     assert_due_monitor_runs_under_watched_open_agent_vision()
     assert_repeat_advancement_vision_beats_watch_lane_continuation_ack()
+    assert_repeat_advancement_vision_replans_past_peer_only_work()
     assert_repeat_advancement_vision_accepts_runnable_successor()
     assert_non_watch_replan_ack_does_not_suppress_open_agent_vision()
     assert_open_agent_vision_with_runnable_frontier_uses_neutral_gap_trigger()

--- a/loopx/control_plane/agents/agent_scope.py
+++ b/loopx/control_plane/agents/agent_scope.py
@@ -529,6 +529,18 @@ def _count_advancement_items(items: Any, *, claimed_by: str | None = None) -> in
     return agent_scope_count_advancement_items(items, claimed_by=claimed_by)
 
 
+def _selectable_unclaimed_advancement_count(
+    agent_todo_summary: dict[str, Any],
+) -> int:
+    executable_items = agent_todo_summary.get("executable_backlog_items")
+    source_items = (
+        executable_items
+        if isinstance(executable_items, list)
+        else agent_todo_summary.get("unclaimed_priority_open_items")
+    )
+    return _count_advancement_items(source_items, claimed_by="__unclaimed__")
+
+
 def _first_compact_todo_id(items: Any) -> str | None:
     if not isinstance(items, list):
         return None
@@ -738,10 +750,7 @@ def _agent_lane_frontier_hint(
         agent_todo_summary.get("current_agent_claimed_advancement_count") or 0
     )
     current_monitor_count = int(agent_todo_summary.get("current_agent_claimed_monitor_count") or 0)
-    unclaimed_count = _count_advancement_items(
-        agent_todo_summary.get("unclaimed_priority_open_items"),
-        claimed_by="__unclaimed__",
-    )
+    unclaimed_count = _selectable_unclaimed_advancement_count(agent_todo_summary)
     lane = str(work_lane_contract.get("lane") or "") if isinstance(work_lane_contract, dict) else ""
     if current_advancement_count == 0 and unclaimed_count == 0 and current_monitor_count > 0:
         return build_hint(
@@ -1075,19 +1084,16 @@ def _agent_scope_no_candidate_frontier(
             claimed_by=agent_id,
         ),
     )
-    unclaimed_count = _count_advancement_items(
-        agent_todo_summary.get("unclaimed_priority_open_items"),
-        claimed_by="__unclaimed__",
-    )
+    unclaimed_count = _selectable_unclaimed_advancement_count(agent_todo_summary)
     executable_items = agent_todo_summary.get("executable_backlog_items")
     if isinstance(executable_items, list):
         current_agent_count = max(
             current_agent_count,
             _count_advancement_items(executable_items, claimed_by=agent_id),
         )
-        unclaimed_count = max(
-            unclaimed_count,
-            _count_advancement_items(executable_items, claimed_by="__unclaimed__"),
+        unclaimed_count = _count_advancement_items(
+            executable_items,
+            claimed_by="__unclaimed__",
         )
     if current_agent_count > 0 or unclaimed_count > 0:
         return None

--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -900,14 +900,7 @@ def _frontier_advancement_counts(
         if isinstance(agent_todo_summary, dict)
         else 0
     )
-    unclaimed_advancement_count = (
-        _count_advancement_items(
-            agent_todo_summary.get("unclaimed_priority_open_items"),
-            claimed_by="__unclaimed__",
-        )
-        if isinstance(agent_todo_summary, dict)
-        else 0
-    )
+    unclaimed_advancement_count = 0
     other_agent_claimed_items: Any = None
     if isinstance(agent_todo_summary, dict):
         executable_items = agent_todo_summary.get("executable_backlog_items")
@@ -917,9 +910,17 @@ def _frontier_advancement_counts(
                     current_agent_advancement_count,
                     _count_advancement_items(executable_items, claimed_by=agent_id),
                 )
-            unclaimed_advancement_count = max(
-                unclaimed_advancement_count,
-                _count_advancement_items(executable_items, claimed_by="__unclaimed__"),
+            unclaimed_advancement_count = _count_advancement_items(
+                executable_items,
+                claimed_by="__unclaimed__",
+            )
+        else:
+            # The unclaimed visibility lane is diagnostic and may contain work
+            # that excludes this agent. Prefer the scoped executable lane when
+            # available; retain this fallback for legacy summaries only.
+            unclaimed_advancement_count = _count_advancement_items(
+                agent_todo_summary.get("unclaimed_priority_open_items"),
+                claimed_by="__unclaimed__",
             )
         claim_scope = (
             agent_todo_summary.get("claim_scope")
@@ -1270,10 +1271,9 @@ def derive_goal_frontier_replan_obligation_from_summaries(
         and (
             successor_vision_required
             or (
-                agent_counts.get("advancement", 0) == 0
                 # Another peer's claimed work cannot satisfy this agent's
                 # scoped vision or checkpoint acceptance gap.
-                and selectable_frontier_advancement == 0
+                selectable_frontier_advancement == 0
             )
         )
         and not acceptance_allows_watch_lane_continuation

--- a/loopx/control_plane/work_items/goal_route_hint.py
+++ b/loopx/control_plane/work_items/goal_route_hint.py
@@ -219,15 +219,21 @@ def build_goal_route_hint(
             agent_id=agent_id,
             claim="other",
         )
+    executable_items = agent_summary.get("executable_backlog_items")
+    unclaimed_source = (
+        executable_items
+        if isinstance(executable_items, list)
+        else agent_summary.get("unclaimed_priority_open_items")
+    )
     unclaimed_actions = _todo_items(
-        agent_summary.get("unclaimed_priority_open_items"),
+        unclaimed_source,
         agent_id=agent_id,
         claim="unclaimed",
     )
     blocking_handoff_gates = _blocking_handoff_gates(agent_summary, agent_id=agent_id)
     current_count = _int_count(agent_summary.get("current_agent_claimed_advancement_count"))
     unclaimed_count = _count_advancement_items(
-        agent_summary.get("unclaimed_priority_open_items"),
+        unclaimed_source,
         agent_id=agent_id,
         claim="unclaimed",
     )

--- a/tests/control_plane/test_goal_vision_succession.py
+++ b/tests/control_plane/test_goal_vision_succession.py
@@ -110,3 +110,36 @@ def test_user_gate_still_precedes_successor_vision_replan() -> None:
     )
 
     assert obligation is None
+
+
+def test_other_agent_work_does_not_satisfy_scoped_repeat_vision() -> None:
+    active_vision = vision("vision_active")
+    active_vision["vision_patch"]["advancement_policy"] = "repeat_until_closed"
+    gaps = acceptance_gaps_from_agent_vision(active_vision, goal_status="active")
+    other_agent_todo = {
+        "todo_id": "todo_other_agent",
+        "status": "open",
+        "task_class": "advancement_task",
+        "claimed_by": "fixture-other-agent",
+    }
+
+    obligation = derive_goal_frontier_replan_obligation_from_summaries(
+        user_todo_summary={"open_count": 0},
+        agent_todo_summary={
+            "open_count": 1,
+            "claimed_advancement_open_count": 1,
+            "current_agent_claimed_advancement_count": 0,
+            "unclaimed_priority_open_items": [],
+            "executable_backlog_items": [],
+            "claim_scope": {"other_agent_claimed_items": [other_agent_todo]},
+        },
+        work_lane_contract=None,
+        agent_id=AGENT_ID,
+        existing_replan_obligation=None,
+        acceptance_gaps=gaps,
+    )
+
+    assert obligation is not None
+    assert obligation["agent_id"] == AGENT_ID
+    assert obligation["triggers"][0]["kind"] == "vision_acceptance_gap"
+    assert obligation["todo_actions"][0]["action"] == "add"


### PR DESCRIPTION
## Summary

- count unclaimed advancement from the agent-scoped executable lane, not the diagnostic visibility lane
- let `repeat_until_closed` vision gaps replan when this agent has no runnable successor, even when peer/excluded work remains
- keep exact blocked/deferred successor wait policy and peer-owned lifecycle monitors intact

## Product / architecture judgment

The regression let non-empty durable Next Action prose or an unclaimed todo that explicitly excluded the current agent suppress an agent-scoped vision replan. The fix keeps visibility lanes diagnostic and makes all execution/frontier consumers prefer the scoped executable lane, with a legacy fallback for older summaries. This is a reusable projection contract rather than an OpenViking-specific rule.

## Validation

- `python3 examples/control_plane/quota-replan-decision-plane-smoke.py`
- `python3 examples/control_plane/agent-scope-projection-characterization-smoke.py`
- `python3 examples/control_plane/todo-claim-visibility-lanes-smoke.py`
- `python3 examples/control_plane/work-lane-contract-smoke.py`
- `uv run --extra test pytest -q tests/control_plane/test_goal_vision_blocked_successor.py tests/control_plane/test_goal_vision_succession.py tests/test_turn_envelope.py` (45 passed)
- focused `ruff check` (passed)
- `loopx --format json canary premerge --from-git-diff` (`ok=true`)

## Boundary

No project/private state, credentials, raw trajectories, permission changes, or production actions.