### PR TITLE
test(smoke): bootstrap SkillsBench profile import

### DIFF
--- a/examples/skillsbench-runner-profile-smoke.py
+++ b/examples/skillsbench-runner-profile-smoke.py
@@ -6,8 +6,14 @@ import os
 import shutil
 import stat
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.benchmark_adapters.skillsbench_runner_profile import (
     SKILLSBENCH_RUNNER_PROFILE_SCHEMA_VERSION,
@@ -20,7 +26,6 @@ from loopx.benchmark_adapters.skillsbench_runner_profile import (
 )
 
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
 LAUNCHER = REPO_ROOT / "scripts" / "skillsbench-launch-goal-xhigh.sh"
 PROFILE_MODULE = (
     REPO_ROOT


### PR DESCRIPTION
## Summary
- bootstrap the repository root before importing `loopx` in the SkillsBench runner-profile smoke
- restore the Full Public Smokes CI contract without changing benchmark behavior

## Validation
- `python3 examples/skillsbench-runner-profile-smoke.py`
- Full Public shard 5: 95/95 passed, no failures, timeouts, or warnings
- `loopx canary premerge --from-git-diff`: all 4 direct checks and 5 selected canaries/boundary checks passed
- public/private boundary scan clean

## Risk
The premerge classifier flags the filename as benchmark-sensitive. This patch only changes test import bootstrapping, does not launch jobs, and does not alter scoring, runner behavior, evidence semantics, or permissions.