### PR TITLE
test(smoke): follow current host adapter task

### DIFF
--- a/examples/session_runtime/session-runtime-control-plane-adapter-doc-smoke.py
+++ b/examples/session_runtime/session-runtime-control-plane-adapter-doc-smoke.py
@@ -55,7 +55,7 @@ def main() -> int:
         contributor_tasks,
         [
             "GH-C35",
-            "session-runtime control-plane adapter",
+            "provider-neutral external-host adapter",
             "raw transcripts, credentials, billing, permissions",
         ],
         source=CONTRIBUTOR_TASKS,


### PR DESCRIPTION
## Summary
- align the session-runtime documentation smoke with the current `GH-C35` provider-neutral host-adapter wording
- retain the stable task id and raw-data/credential boundary assertions

## Root cause
The contributor board refresh in #2231 intentionally evolved `GH-C35` from a session-runtime-specific design task to a provider-neutral LoopX Turn host adapter. The smoke continued asserting the retired phrase, making Full Public Smokes red despite the current board being correct.

## Validation
- targeted documentation smoke passed
- exact failing Full Public shard 4: 100/100 passed, no failures, timeouts, or warnings
- `loopx canary premerge --from-git-diff`: 4/4 direct and 6/6 selected checks passed; self-merge gate passed
- public/private boundary scan clean