### PR TITLE
docs(turn): add Codex CLI quickstart

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -138,6 +138,7 @@ incident report, or launch draft.
 
 - [Product vision](product/vision.md)
 - [Release readiness](product/release-readiness.md)
+- [LoopX Turn Codex CLI quickstart](product/loopx-turn-codex-cli-quickstart.md)
 - [Public adoption loop](product/public-adoption-loop.md)
 - [Codex CLI TUI-first loop](product/codex-cli-tui-loop.md)
 - [Reward-style replanning hints](product/reward-style-replanning.md)

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -76,6 +76,9 @@ runtime contract, benchmark route, or launch draft.
   driver planner that keeps TUI bootstrap primary, composes quota/idle/fallback
   checks, validates visible-session proof fixtures, and treats `codex exec` as
   an explicit fallback.
+- [LoopX Turn Codex CLI quickstart](loopx-turn-codex-cli-quickstart.md): the
+  partner-facing isolated-headless path reduced to the built-in Agent CLI
+  adapter, one independent validator, one command, and five typed outcomes.
 - [Codex CLI visible proof capture protocol](codex-cli-visible-proof-capture-protocol.md):
   the opt-in public-safe procedure for turning `resume` / `remote-control`
   signals into evidence, with stop conditions that keep one-message TUI

--- a/docs/product/codex-cli-automation-driver.md
+++ b/docs/product/codex-cli-automation-driver.md
@@ -2,6 +2,11 @@
 
 Status: experimental product route with a shipped isolated-headless driver.
 
+For the partner-facing path, start with
+[Run One LoopX Turn With Codex CLI](loopx-turn-codex-cli-quickstart.md). It
+reduces this maintenance reference to the built-in adapter, one independent
+validator, and one command.
+
 The product goal is one reusable mechanism: LoopX CLI decides what may run,
 Codex CLI performs one bounded agent turn, and LoopX validates and records the
 outcome. It should approach the control-plane behavior available in Codex App

--- a/docs/product/loopx-turn-codex-cli-quickstart.md
+++ b/docs/product/loopx-turn-codex-cli-quickstart.md
@@ -1,0 +1,106 @@
+# Run One LoopX Turn With Codex CLI
+
+Status: experimental `isolated-headless` product path.
+
+LoopX Turn needs only three pieces:
+
+1. **Agent CLI adapter**: the built-in `codex-cli` adapter translates one typed
+   LoopX request into one bounded Codex CLI run and returns one typed result.
+2. **Independent validator**: your command checks the real postcondition. It
+   does not trust the agent's completion claim.
+3. **One Turn command**: LoopX decides, Codex executes, the validator proves,
+   and LoopX commits.
+
+```text
+LoopX decides -> Codex CLI executes -> validator proves -> LoopX commits
+```
+
+## Before You Run
+
+You need a connected LoopX goal, a registered agent with a runnable todo, an
+isolated project workspace, and an executable validator. The validator receives
+the normalized host result on stdin and exits zero only when the actual artifact
+or state is correct.
+
+Check the local host once with `codex doctor`. If the configured default model
+is newer than the installed Codex CLI supports, update Codex or pass a model
+already qualified for that installation with `--codex-model`.
+
+## Run One Turn
+
+For a write-capable coding todo:
+
+```bash
+loopx turn run-once \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --host codex-cli \
+  --project "$PWD" \
+  --codex-sandbox workspace-write \
+  --codex-model <qualified-model> \
+  --validation-command-json '["./verify-postcondition"]' \
+  --execute
+```
+
+The built-in Codex adapter means there is no adapter program to write for this
+path. A different Agent CLI uses the same Turn contract through a thin
+`generic-cli` adapter that reads one JSON request from stdin and writes one JSON
+result to stdout.
+
+## Read The Result
+
+The compact JSON result tells the caller what happens next:
+
+| Signal | Meaning |
+| --- | --- |
+| `status=committed` | Independent validation passed; LoopX wrote the durable result and spent once. |
+| `result_kind=repair_required` | Keep the todo, repair the execution or artifact, then retry. |
+| `result_kind=replan_required` | The current route is no longer valid; write a successor or vision delta. |
+| `result_kind=wait` | No host work should run yet. |
+| `result_kind=user_action_required` | Show the concrete user action and do not invent a substitute. |
+
+A failed or unavailable validator cannot commit or spend. Replaying a committed
+Turn is idempotent: it does not invoke the host, write state, or spend again.
+
+## Fit Another Runtime
+
+Keep the same boundary when the Agent CLI is backed by a managed runtime:
+
+| Runtime owns | LoopX owns |
+| --- | --- |
+| Session, turn, sandbox, raw event stream, platform outcome | Goal, todo, gate, control decision, compact evidence, durable outcome |
+
+The adapter carries the existing `turn_key` as a correlation id, creates or
+resumes the host run, consumes its Event/Outcome API, and emits one existing
+result kind. The validator independently reads tests, a grader, or platform
+state. Host observations such as requested, accepted, running, outcome-ready,
+failed, and resumed map to committed, repair, replan, or wait; they do not
+become new Turn states.
+
+Qualify a new adapter with one real task, a scenario owner, an adapter owner, a
+validator, and a measurable outcome. Add a structured event-reference field
+only after that call site proves the compact result cannot carry the evidence.
+
+## Verify The Integration
+
+The repository ships a disposable qualification that keeps raw prompts,
+transcripts, stdout, stderr, credentials, and temporary workspaces out of LoopX
+state:
+
+```bash
+python3 examples/loopx-turn-codex-cli-e2e-smoke.py
+python3 examples/loopx-turn-codex-cli-e2e-smoke.py \
+  --real-codex-cli \
+  --codex-model <qualified-model>
+```
+
+The first command is deterministic and model-free. The second makes one real
+Codex CLI call and must report `status=committed`, `validation_status=passed`,
+one quota spend, and a replay with no side effects. A compact
+`codex_cli_model_requires_newer_codex` result is a host compatibility failure,
+not task progress; it must show zero state writes and zero quota spend.
+
+That is the complete partner-facing path. Read the
+[Codex CLI adapter notes](codex-cli-automation-driver.md) for operational gaps
+or the [LoopX Turn protocol](../reference/protocols/loopx-turn-v0.md) only when
+implementing another host adapter or maintaining the runtime.

--- a/docs/reference/protocols/loopx-turn-v0.md
+++ b/docs/reference/protocols/loopx-turn-v0.md
@@ -2,6 +2,10 @@
 
 Status: experimental protocol and implementation target.
 
+Integrators using the built-in Codex CLI host should start with the
+[one-Turn quickstart](../../product/loopx-turn-codex-cli-quickstart.md). This
+document is the protocol and maintainer reference, not required onboarding.
+
 `loopx_turn_v0` defines how LoopX can govern one bounded turn executed by an
 external agent-loop host, such as Codex CLI, without turning that host into a
 second control plane. LoopX remains authoritative for goal state, todos,

--- a/examples/loopx-turn-codex-cli-quickstart-smoke.py
+++ b/examples/loopx-turn-codex-cli-quickstart-smoke.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Keep the LoopX Turn partner quickstart small and concept-frozen."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+QUICKSTART = REPO_ROOT / "docs" / "product" / "loopx-turn-codex-cli-quickstart.md"
+
+
+def main() -> int:
+    text = QUICKSTART.read_text(encoding="utf-8")
+    compact_text = " ".join(text.split())
+    product_index = (REPO_ROOT / "docs" / "product" / "README.md").read_text(
+        encoding="utf-8"
+    )
+    docs_index = (REPO_ROOT / "docs" / "README.md").read_text(encoding="utf-8")
+
+    assert len(text.splitlines()) <= 110, "quickstart must remain one page"
+    for required in [
+        "Agent CLI adapter",
+        "Independent validator",
+        "One Turn command",
+        "loopx turn run-once",
+        "--host codex-cli",
+        "--validation-command-json",
+        "status=committed",
+        "result_kind=repair_required",
+        "result_kind=replan_required",
+        "result_kind=wait",
+        "result_kind=user_action_required",
+        "turn_key",
+        "raw event stream",
+        "they do not become new Turn states",
+        "a scenario owner",
+        "loopx-turn-codex-cli-e2e-smoke.py",
+        "codex_cli_model_requires_newer_codex",
+    ]:
+        assert required in compact_text, required
+
+    opening = "\n".join(text.splitlines()[:50])
+    for internal_concept in [
+        "TurnEnvelope",
+        "scheduler hint",
+        "journal",
+        "resume eligibility",
+        "benchmark bridge",
+    ]:
+        assert internal_concept not in opening, internal_concept
+
+    link = "loopx-turn-codex-cli-quickstart.md"
+    assert link in product_index, "product index link"
+    assert f"product/{link}" in docs_index, "docs index link"
+
+    print("loopx-turn-codex-cli-quickstart-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- reduce the partner-facing LoopX Turn path to the built-in Agent CLI adapter, one independent validator, and one command
- document the boundary between a managed agent runtime and LoopX without adding Turn states, schema, or flags
- add a focused smoke that keeps the quickstart compact and concept-frozen

## Validation
- `python3 examples/loopx-turn-codex-cli-quickstart-smoke.py`
- `python3 examples/codex-cli-automation-driver-audit-smoke.py`
- `python3 examples/docs-governance-smoke.py`
- `python3 examples/loopx-turn-codex-cli-e2e-smoke.py`
- `uv run --extra test pytest -q tests/test_loopx_turn_codex_cli.py tests/test_loopx_turn_executor.py tests/test_loopx_turn_driver.py` (45 passed)
- `loopx canary premerge --from-git-diff --tier standard --timeout-seconds 180 --no-progress` (passed; 0 manual holds)