### PR TITLE
Project capability resolution ownership

### DIFF
--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -681,8 +681,21 @@ precedence for the interaction decision, so a local bridge repair cannot hide
 the concrete user action. Runtime capability gaps do not enter
 `owner_missing`: the agent observes or repairs the launcher bridge and then
 truthfully declares the capability available. Once an owner-held capability is
-provided through its concrete gate, the user gate disappears and any remaining
-bridge repair returns to the agent lane.
+provided and its concrete gate is resolved, any remaining bridge repair returns
+to the agent lane.
+
+The same resolution information must survive when a non-dependent fallback is
+runnable. `resolution_bindings` groups each missing capability with its owner
+and exact `blocked_todo_ids`. The interaction CLI channel projects idempotent
+todo writes: owner-held gaps become scoped `user_gate` todos linked with
+`unblocks_todo_id`; repairable gaps become agent advancement todos whose
+`target_capabilities` name the bridge being materialized. The user channel is
+notified for the owner-held gap while the agent channel continues an unrelated
+runnable todo. Unsupported gaps remain explicit but do not invent user work.
+
+These todos record responsibility and lineage, not capability truth. A launcher
+must verify the real callsite and declare `--available-capability` again for the
+current preflight and spend; todo completion alone never grants a capability.
 
 Launchers that really have an extra capability should pass it to both
 `quota should-run` and `quota spend-slot` with `--available-capability`, so the

--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -331,6 +331,20 @@ candidate is missing a capability, the gate returns
 `credentials`/`production_access`, or
 `action=skip` for unsupported capability classes.
 
+Blocked candidates retain typed `resolution_bindings` even when another todo is
+runnable. Each binding names the capability, its resolution owner, and the
+exact `blocked_todo_ids`. The interaction contract turns an owner-held binding
+into an idempotent scoped `user_gate` write linked by `unblocks_todo_id`, while
+an agent-repairable binding becomes an idempotent advancement todo with the
+capability in `target_capabilities`. The user gate does not block unrelated
+runnable todos. `quota should-run` remains read-only; the agent or host executes
+the projected todo write before normal writeback.
+
+Completing a repair or owner todo is not proof that the runtime capability is
+available. The current host must still verify the real callsite and pass the
+capability through `--available-capability` on both preflight and spend. This
+keeps capability truth session-scoped and prevents stale persistent grants.
+
 Runtime capability absence is not permission authority. A missing `network`
 declaration therefore remains in the agent repair lane: the agent should
 observe or repair the launcher/runtime bridge, truthfully pass

--- a/examples/capability-gate-smoke.py
+++ b/examples/capability-gate-smoke.py
@@ -16,6 +16,7 @@ from loopx.quota import build_quota_should_run, build_quota_slot_preview  # noqa
 
 
 GOAL_ID = "capability-gate-goal"
+AGENT_ID = "codex-main-control"
 
 
 def todo(
@@ -50,6 +51,7 @@ def status_payload(
     items: list[dict[str, Any]],
     *,
     available_capabilities: list[str] | None = None,
+    registered_agent: str | None = None,
 ) -> dict[str, Any]:
     summary = {
         "schema_version": "todo_summary_v0",
@@ -72,6 +74,16 @@ def status_payload(
         "state": "eligible",
         "reason": "fixture eligible quota",
     }
+    coordination: dict[str, Any] = {
+        "available_capabilities": available_capabilities or [],
+    }
+    if registered_agent:
+        coordination.update(
+            {
+                "agent_model": "peer_v1",
+                "registered_agents": [registered_agent],
+            }
+        )
     return {
         "ok": True,
         "attention_queue": {
@@ -82,9 +94,7 @@ def status_payload(
                     "waiting_on": "codex",
                     "severity": "info",
                     "source": "project_asset",
-                    "coordination": {
-                        "available_capabilities": available_capabilities or [],
-                    },
+                    "coordination": coordination,
                     "quota": quota,
                     "project_asset": {
                         "next_action": items[0]["text"] if items else "",
@@ -98,9 +108,7 @@ def status_payload(
                 {
                     "id": GOAL_ID,
                     "registry_member": True,
-                    "coordination": {
-                        "available_capabilities": available_capabilities or [],
-                    },
+                    "coordination": coordination,
                     "quota": quota,
                     "latest_runs": [],
                 }
@@ -163,6 +171,13 @@ def main() -> int:
         for item in p0_fallback["capability_gate"]["runnable_candidates"]
     ] == ["todo_capability_2", "todo_capability_5"], p0_fallback
     assert p0_fallback["capability_gate"]["blocked_candidates"][0]["todo_id"] == "todo_capability_1", p0_fallback
+    assert p0_fallback["capability_gate"]["repair_missing"] == ["benchmark_runner"], p0_fallback
+    assert any(
+        "--action-kind materialize_capability" in action
+        and "--target-capability benchmark_runner" in action
+        and "--unblocks-todo-id todo_capability_1" in action
+        for action in p0_fallback["interaction_contract"]["cli_channel"]["next_cli_actions"]
+    ), p0_fallback
     assert p0_fallback["recommended_action"] == p0_validate["text"], p0_fallback
     assert "choose one of 2 capability-runnable todo(s)" in p0_fallback["protocol_action_packet"]["summary"], p0_fallback
 
@@ -212,6 +227,10 @@ def main() -> int:
         item["todo_id"]
         for item in repair_candidate["capability_gate"]["blocked_candidates"]
     ] == ["todo_capability_1"], repair_candidate
+    assert not any(
+        "--action-kind materialize_capability" in action
+        for action in repair_candidate["interaction_contract"]["cli_channel"]["next_cli_actions"]
+    ), repair_candidate
 
     benchmark_ready = build_quota_should_run(
         status_payload([p0_benchmark, p0_validate, p1_docs]),
@@ -301,9 +320,53 @@ def main() -> int:
     assert owner_gate["capability_gate"]["action"] == "ask_owner", owner_gate
     assert owner_gate["interaction_contract"]["user_channel"]["action_required"] is True, owner_gate
     assert owner_gate["interaction_contract"]["user_channel"]["actions"] == [
-        "provide or authorize the missing owner-held capability: credentials"
+        "provide or authorize the missing owner-held capability: credentials "
+        "for todo_capability_9"
     ], owner_gate
+    assert any(
+        "--task-class user_gate" in action
+        and "--action-kind provide_capability" in action
+        and "--target-capability credentials" in action
+        and "--unblocks-todo-id todo_capability_9" in action
+        for action in owner_gate["interaction_contract"]["cli_channel"]["next_cli_actions"]
+    ), owner_gate
     assert owner_gate["heartbeat_recommendation"]["notify"] == "NOTIFY", owner_gate
+
+    owner_with_fallback = build_quota_should_run(
+        status_payload(
+            [credentials_todo, p1_docs],
+            registered_agent=AGENT_ID,
+        ),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        available_capabilities=["shell", "filesystem_write"],
+    )
+    assert owner_with_fallback["should_run"] is True, owner_with_fallback
+    assert owner_with_fallback["normal_delivery_allowed"] is True, owner_with_fallback
+    assert owner_with_fallback["requires_user_action"] is True, owner_with_fallback
+    assert owner_with_fallback["capability_gate"]["action"] == "run", owner_with_fallback
+    assert owner_with_fallback["capability_gate"]["owner_missing"] == [
+        "credentials"
+    ], owner_with_fallback
+    assert owner_with_fallback["interaction_contract"]["mode"] == (
+        "bounded_delivery_with_user_notice"
+    ), owner_with_fallback
+    assert owner_with_fallback["interaction_contract"]["agent_channel"][
+        "must_attempt"
+    ] is True, owner_with_fallback
+    assert owner_with_fallback["interaction_contract"]["user_channel"]["actions"] == [
+        "provide or authorize the missing owner-held capability: credentials "
+        "for todo_capability_9"
+    ], owner_with_fallback
+    assert any(
+        "--task-class user_gate" in action
+        and "--target-capability credentials" in action
+        and f"--blocks-agent {AGENT_ID}" in action
+        and "--unblocks-todo-id todo_capability_9" in action
+        for action in owner_with_fallback["interaction_contract"]["cli_channel"][
+            "next_cli_actions"
+        ]
+    ), owner_with_fallback
 
     mixed_capability_todo = todo(
         8,

--- a/examples/control_plane/capability-gate-projection-smoke.py
+++ b/examples/control_plane/capability-gate-projection-smoke.py
@@ -204,7 +204,58 @@ def assert_gate_prefers_active_next_and_exposes_blocked_fallback() -> None:
         "todo_needs_network"
     ], gate
     assert gate["blocked_missing"] == ["network"], gate
+    assert gate["repair_missing"] == ["network"], gate
+    assert gate["resolution_bindings"] == [
+        {
+            "owner": "agent",
+            "action": "repair_bridge",
+            "capability": "network",
+            "priority": "P0",
+            "primary_blocked_todo_id": "todo_needs_network",
+            "blocked_todo_ids": ["todo_needs_network"],
+        }
+    ], gate
     assert gate["available"] == ["shell", "filesystem_read", "filesystem_write"], gate
+
+
+def assert_runnable_fallback_preserves_owner_resolution() -> None:
+    blocked = todo(
+        "todo_needs_credentials",
+        1,
+        "P0",
+        claimed_by=AGENT_ID,
+        required_capabilities=["credentials"],
+    )
+    runnable = todo(
+        "todo_local_docs",
+        2,
+        "P1",
+        claimed_by=AGENT_ID,
+        required_capabilities=["shell"],
+    )
+    gate = build_capability_gate(
+        {"executable_backlog_items": [blocked, runnable]},
+        available_capabilities=["shell"],
+        agent_identity={"agent_id": AGENT_ID, "agent_model": "peer_v1"},
+    )
+    assert gate is not None
+    assert gate["action"] == "run", gate
+    assert gate["owner_missing"] == ["credentials"], gate
+    assert gate["owner_action"] == (
+        "provide or authorize the missing owner-held capability: credentials "
+        "for todo_needs_credentials"
+    ), gate
+    assert gate["resolution_bindings"] == [
+        {
+            "owner": "user",
+            "action": "provide_or_authorize",
+            "capability": "credentials",
+            "priority": "P0",
+            "primary_blocked_todo_id": "todo_needs_credentials",
+            "blocked_todo_ids": ["todo_needs_credentials"],
+        }
+    ], gate
+    assert gate["runnable_candidates"][0]["todo_id"] == "todo_local_docs", gate
 
 
 def assert_target_capability_creates_repair_hint_not_hard_block() -> None:
@@ -279,7 +330,8 @@ def assert_all_blocked_owner_capability_stops_delivery() -> None:
     assert gate["owner_missing"] == ["credentials"], gate
     assert gate["repair_missing"] == [], gate
     assert gate["owner_action"] == (
-        "provide or authorize the missing owner-held capability: credentials"
+        "provide or authorize the missing owner-held capability: credentials "
+        "for todo_credentials"
     ), gate
 
 
@@ -299,6 +351,7 @@ def main() -> int:
     assert_current_agent_candidate_order_contract()
     assert_stale_active_next_does_not_override_ready_p0()
     assert_gate_prefers_active_next_and_exposes_blocked_fallback()
+    assert_runnable_fallback_preserves_owner_resolution()
     assert_target_capability_creates_repair_hint_not_hard_block()
     assert_all_blocked_runtime_capability_routes_to_agent_repair()
     assert_all_blocked_owner_capability_stops_delivery()

--- a/loopx/control_plane/agents/capability_gate.py
+++ b/loopx/control_plane/agents/capability_gate.py
@@ -105,6 +105,81 @@ def _capability_resolution(missing: list[str]) -> dict[str, Any]:
     }
 
 
+def _capability_priority(value: Any) -> str:
+    priority = str(value or "").strip().upper()
+    for prefix in ("P0", "P1", "P2"):
+        if priority.startswith(prefix):
+            return prefix
+    return "P1"
+
+
+def _blocked_capability_resolution_bindings(
+    blocked: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    bindings: dict[tuple[str, str], dict[str, Any]] = {}
+    for item in blocked:
+        todo_id = str(item.get("todo_id") or "").strip()
+        for capability in normalize_required_capabilities(
+            item.get("missing_capabilities")
+        ):
+            action = _capability_missing_action([capability])
+            if action == "ask_owner":
+                owner = "user"
+                resolution_action = "provide_or_authorize"
+            elif action == "repair_bridge":
+                owner = "agent"
+                resolution_action = "repair_bridge"
+            else:
+                owner = "capability_gate"
+                resolution_action = "unsupported"
+            key = (owner, capability)
+            binding = bindings.get(key)
+            if binding is None:
+                binding = {
+                    "owner": owner,
+                    "action": resolution_action,
+                    "capability": capability,
+                    "priority": _capability_priority(item.get("priority")),
+                    "primary_blocked_todo_id": todo_id or None,
+                    "blocked_todo_ids": [],
+                }
+                bindings[key] = binding
+            if todo_id and todo_id not in binding["blocked_todo_ids"]:
+                binding["blocked_todo_ids"].append(todo_id)
+    return list(bindings.values())
+
+
+def _binding_capabilities(
+    bindings: list[dict[str, Any]],
+    *,
+    owner: str,
+) -> list[str]:
+    result: list[str] = []
+    for binding in bindings:
+        if binding.get("owner") != owner:
+            continue
+        capability = str(binding.get("capability") or "").strip()
+        if capability and capability not in result:
+            result.append(capability)
+    return result
+
+
+def _owner_capability_action(bindings: list[dict[str, Any]]) -> str | None:
+    actions: list[str] = []
+    for binding in bindings:
+        if binding.get("owner") != "user":
+            continue
+        capability = str(binding.get("capability") or "").strip()
+        todo_id = str(binding.get("primary_blocked_todo_id") or "").strip()
+        if capability:
+            actions.append(f"{capability} for {todo_id}" if todo_id else capability)
+    if not actions:
+        return None
+    return "provide or authorize the missing owner-held capability: " + ", ".join(
+        actions
+    )
+
+
 def available_capabilities_with_defaults(value: Any) -> list[str]:
     capabilities = list(DEFAULT_AVAILABLE_CAPABILITIES)
     for capability in normalize_required_capabilities(value):
@@ -347,6 +422,15 @@ def build_capability_gate(
             for capability in item.get("missing_capabilities") or []:
                 if capability not in blocked_missing:
                     blocked_missing.append(str(capability))
+        resolution_bindings = _blocked_capability_resolution_bindings(blocked)
+        owner_missing = _binding_capabilities(resolution_bindings, owner="user")
+        for capability in _binding_capabilities(resolution_bindings, owner="agent"):
+            if capability not in repair_missing:
+                repair_missing.append(capability)
+        unsupported_missing = _binding_capabilities(
+            resolution_bindings,
+            owner="capability_gate",
+        )
         return {
             "schema_version": CAPABILITY_GATE_SCHEMA_VERSION,
             "source": source,
@@ -361,11 +445,15 @@ def build_capability_gate(
             "runnable_candidates": runnable,
             "blocked_candidates": blocked,
             "blocked_missing": blocked_missing,
+            "owner_missing": owner_missing,
             "repair_missing": repair_missing,
+            "unsupported_missing": unsupported_missing,
+            "resolution_bindings": resolution_bindings,
             "repair_candidate_count": sum(
                 1 for item in runnable if item.get("capability_repair_mode") is True
             ),
             "reason": "capability gate projected runnable candidate set; agent chooses the actual todo",
+            "owner_action": _owner_capability_action(resolution_bindings),
         }
 
     missing_all: list[str] = []
@@ -378,6 +466,7 @@ def build_capability_gate(
             if capability not in missing_all:
                 missing_all.append(str(capability))
     resolution = _capability_resolution(missing_all)
+    resolution_bindings = _blocked_capability_resolution_bindings(blocked)
     action = str(resolution["action"])
     owner_missing = list(resolution["owner_missing"])
     repair_missing = list(resolution["repair_missing"])
@@ -393,21 +482,12 @@ def build_capability_gate(
         "repair_missing": repair_missing,
         "unsupported_missing": resolution["unsupported_missing"],
         "resolution_steps": resolution["resolution_steps"],
+        "resolution_bindings": resolution_bindings,
         "selection_policy": "no_runnable_candidate",
         "runnable_count": 0,
         "runnable_candidates": [],
         "blocked_candidates": blocked,
         "blocks_delivery": True,
         "reason": "all visible executable todo candidates require unavailable capabilities",
-        "owner_action": (
-            "provide or authorize the missing owner-held capability: "
-            + ", ".join(owner_missing)
-            + (
-                "; after that, the agent can repair: " + ", ".join(repair_missing)
-                if repair_missing
-                else ""
-            )
-        )
-        if action == "ask_owner"
-        else None,
+        "owner_action": _owner_capability_action(resolution_bindings),
     }

--- a/loopx/control_plane/todos/write_hint.py
+++ b/loopx/control_plane/todos/write_hint.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 
 def build_todo_write_hint(goal_id: str) -> dict[str, str]:
     return {
@@ -18,3 +20,64 @@ def build_todo_write_hint(goal_id: str) -> dict[str, str]:
         ),
         "section": "User Todo / Owner Review Reading Queue",
     }
+
+
+def build_capability_resolution_writeback_actions(
+    capability_gate: Any,
+    *,
+    goal_id: str,
+    agent_id: str | None,
+    limit: int = 3,
+) -> list[str]:
+    if not isinstance(capability_gate, dict):
+        return []
+    bindings = capability_gate.get("resolution_bindings")
+    if not isinstance(bindings, list):
+        return []
+    targeted_capabilities = {
+        str(capability)
+        for candidate in capability_gate.get("runnable_candidates") or []
+        if isinstance(candidate, dict)
+        for capability in candidate.get("target_capabilities") or []
+        if str(capability).strip()
+    }
+    actions: list[str] = []
+    agent = agent_id or "<registered-agent>"
+    for binding in bindings:
+        if not isinstance(binding, dict):
+            continue
+        owner = str(binding.get("owner") or "").strip()
+        capability = str(binding.get("capability") or "").strip()
+        todo_id = str(binding.get("primary_blocked_todo_id") or "").strip()
+        priority = str(binding.get("priority") or "P1").strip().upper()
+        if not capability or not todo_id:
+            continue
+        if priority not in {"P0", "P1", "P2"}:
+            priority = "P1"
+        if owner == "user":
+            text = (
+                f"[{priority}-user] Provide or authorize capability {capability} "
+                f"required by {todo_id}."
+            )
+            actions.append(
+                f"loopx todo add --goal-id {goal_id} --role user "
+                "--task-class user_gate --action-kind provide_capability "
+                f"--target-capability {capability} --blocks-agent {agent} "
+                f"--unblocks-todo-id {todo_id} --text '{text}'"
+            )
+        elif owner == "agent" and capability not in targeted_capabilities:
+            text = (
+                f"[{priority}] Observe or materialize and real-callsite verify "
+                f"capability {capability} required by {todo_id}."
+            )
+            claimed_arg = f" --claimed-by {agent_id}" if agent_id else ""
+            actions.append(
+                f"loopx todo add --goal-id {goal_id} --role agent "
+                "--task-class advancement_task --action-kind materialize_capability "
+                "--required-capability shell "
+                f"--target-capability {capability}{claimed_arg} "
+                f"--unblocks-todo-id {todo_id} --text '{text}'"
+            )
+        if len(actions) >= limit:
+            break
+    return actions

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -11,6 +11,7 @@ from ..goals.goal_vision_wait import exact_blocked_successor_wait_state
 from ..todos.contract import TODO_TASK_CLASS_MONITOR, TODO_TASK_CLASS_USER_ACTION
 from ..todos.projection import todo_item_task_class
 from ..todos.user_gate import open_todo_count
+from ..todos.write_hint import build_capability_resolution_writeback_actions
 from .primary_action import (
     build_primary_action_projection,
     protocol_action_label as _protocol_action_label,
@@ -109,6 +110,18 @@ def _user_gate_notification_suppressed(payload: dict[str, Any]) -> bool:
     return isinstance(cooldown, dict) and cooldown.get("notification_suppressed") is True
 
 
+def _capability_resolution_user_actions(payload: dict[str, Any]) -> list[str]:
+    capability_gate = (
+        payload.get("capability_gate")
+        if isinstance(payload.get("capability_gate"), dict)
+        else {}
+    )
+    if not capability_gate.get("owner_missing"):
+        return []
+    owner_action = protocol_action_text(capability_gate.get("owner_action"))
+    return [owner_action] if owner_action else []
+
+
 def finalize_user_gate_notification_cooldown(payload: dict[str, Any]) -> None:
     scheduler_hint = payload.get("scheduler_hint")
     cooldown = (
@@ -145,14 +158,19 @@ def projected_user_channel_actions(
         payload.get("user_todo_summary"),
         limit=limit,
     )
-    if notices or not user_channel_action_required(payload):
+    if notices:
         return notices
+    capability_actions = _capability_resolution_user_actions(payload)
+    if capability_actions:
+        return capability_actions[:limit]
+    if not user_channel_action_required(payload):
+        return []
     capability_gate = (
         payload.get("capability_gate")
         if isinstance(payload.get("capability_gate"), dict)
         else {}
     )
-    if capability_gate.get("action") == "ask_owner":
+    if capability_gate.get("owner_missing"):
         owner_action = protocol_action_text(capability_gate.get("owner_action"))
         if owner_action:
             return [owner_action]
@@ -412,6 +430,15 @@ def interaction_next_cli_actions(payload: dict[str, Any], *, mode: str) -> list[
         if agent_identity.get("agent_id")
         else ""
     )
+    capability_resolution_actions = build_capability_resolution_writeback_actions(
+        payload.get("capability_gate"),
+        goal_id=goal_id,
+        agent_id=(
+            str(agent_identity.get("agent_id"))
+            if agent_identity.get("agent_id")
+            else None
+        ),
+    )
     if mode == "terminal_no_followup":
         return ["no quota spend until explicit goal resume or newly projected work"]
     if mode == "automation_prompt_upgrade":
@@ -550,11 +577,15 @@ def interaction_next_cli_actions(payload: dict[str, Any], *, mode: str) -> list[
         "bounded_delivery_with_user_notice",
     }:
         return [
+            *capability_resolution_actions,
             f"loopx refresh-state --goal-id {goal_id} --classification <validated_progress>{agent_arg}",
             f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{agent_arg}",
         ]
     if mode in {"user_gate", "user_todo_blocker_push", "user_action_required"}:
-        return ["no quota spend for blocker-push/gate-notification"]
+        return [
+            *capability_resolution_actions,
+            "no quota spend for blocker-push/gate-notification",
+        ]
     return ["no quota spend without validated transition/blocker writeback"]
 
 

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -1926,7 +1926,7 @@ def build_quota_should_run(
             payload["work_lane_contract"] = payload_work_lane_contract
         if capability_gate:
             payload["capability_gate"] = capability_gate
-            if capability_gate.get("action") == "ask_owner":
+            if capability_gate.get("owner_missing"):
                 payload["notify_user_on_capability_gate"] = True
         if capability_monitor_fallback:
             payload["capability_monitor_fallback"] = capability_monitor_fallback


### PR DESCRIPTION
## Summary
- Preserve per-todo capability resolution bindings even when an unrelated fallback is runnable.
- Project owner-held gaps as scoped user gates and agent-repairable gaps as target-capability advancement todos.
- Keep runtime capability truth session-scoped and continue unrelated runnable work.

## Validation
- python3 examples/control_plane/capability-gate-projection-smoke.py
- python3 examples/capability-gate-smoke.py
- python3 examples/control_plane/monitor-scheduler-contract-smoke.py
- python3 examples/interaction-pattern-catalog-smoke.py
- python3 examples/control_plane/quota-contract-smoke.py
- Real public-safe loopx-meta compact replay
- loopx canary premerge --from-git-diff --tier standard: 9 catalog canaries, 8 risk-profile smokes, and the boundary scan all passed

## Review focus
- Owner classification is intentionally narrow: credentials and production_access require user action.
- Repairable launcher capabilities stay in the agent lane.
- Unsupported capabilities remain explicit and do not invent user work.
- Todo completion does not grant a runtime capability; launchers must re-declare verified availability.