### PR TITLE
docs: clarify exact host goal starts

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -85,7 +85,7 @@ entry point is different:
 
 | Command family | Host entry | CLI fallback |
 | --- | --- | --- |
-| Project goal start | `/loopx <goal text>` where the host exposes native slash commands; `$loopx <goal text>` or the `LoopX` command skill in Codex surfaces that use explicit skills. | `loopx start-goal --guided --project . --goal-text "<goal text>"` |
+| Project goal start | `/loopx <goal text>` where the host exposes native slash commands; `$loopx <goal text>` or the `LoopX` command skill in Codex surfaces that use explicit skills. | `loopx start-goal --guided --project . --goal-text "<goal text>" --host-surface <exact-host>` |
 | Global manager views | `/loopx-global-summary`, `/loopx-global-gates`, `/loopx-global-todos`, `/loopx-global-risks`. | `loopx slash-commands`, then run the listed global manager command for the view you need. |
 | PR review queue | `/loopx-pr-review`. | `loopx pr-review` |
 
@@ -110,7 +110,8 @@ If a project-local goal command still cannot be invoked through the host, run
 the equivalent guided start preview from the project root:
 
 ```bash
-loopx start-goal --guided --project . --goal-text "<goal text>"
+loopx start-goal --guided --project . --goal-text "<goal text>" \
+  --host-surface codex-cli-tui
 ```
 
 That preserves the `/loopx <goal text>` semantics while keeping mutation under
@@ -121,6 +122,12 @@ integrations that need the lower-level handoff packet can use
 `loopx bootstrap-command-pack --project . --goal-text "<goal text>"`. For global
 manager or PR review commands, use `loopx slash-commands` to print the current
 canonical command list and fallback CLI shapes.
+
+Use `codex-app`, `codex-ide`, or `codex-cli-tui` for the corresponding Codex
+host. If the exact host is not known, omit `--host-surface` once: LoopX returns
+a read-only selection gate with exact rerun commands and does not write project
+state. This prevents an upgrade from silently routing an IDE or terminal start
+to a desktop-app heartbeat.
 
 ## Local State Backup
 

--- a/docs/guides/newcomer-command-path.md
+++ b/docs/guides/newcomer-command-path.md
@@ -39,7 +39,7 @@ matches the surface you already use:
 | Codex App | `$loopx <task text>` or `/skills` -> `loopx` in the project thread | The app heartbeat automation. Let the agent install or refresh the generated LoopX heartbeat body; start at the bootstrap cadence, then follow `quota should-run.scheduler_hint`. |
 | Codex CLI | `codex` from the project root, then paste `loopx codex-cli-bootstrap-message --project .` output | Current verified Codex CLI builds do not load user-installed `/loopx` or `/prompts:loopx` commands. Keep the executor visible, then set the generated `/goal <thin task_body>`. |
 | Claude Code | Install LoopX, then `/loopx <task text>` | The installer registers lightweight slash-command skills. Enable the opt-in adapter only when Claude Code's native `/loop` should be gated by LoopX `should_run`. |
-| Other agent or shell | `loopx start-goal --guided --project . --goal-text "<task text>"` | The guided packet previews the same transaction an agent should execute: inspect or connect state, plan todos, refresh status, activate a host loop, run quota, and ack scheduler hints when needed. If the surface has no runner hook, LoopX can track state but the user drives it manually. |
+| Other agent or shell | `loopx start-goal --guided --project . --goal-text "<task text>" --host-surface <exact-host>` | The guided packet previews the same transaction an agent should execute: inspect or connect state, plan todos, refresh status, activate a host loop, run quota, and ack scheduler hints when needed. If the surface has no runner hook, LoopX can track state but the user drives it manually. |
 
 ## One CLI Quickstart
 
@@ -52,13 +52,17 @@ export PATH="$HOME/.local/bin:$PATH"
 loopx doctor
 loopx slash-commands --install
 loopx bootstrap-command-pack --project .
-loopx start-goal --guided --project . --goal-text "<your first long-running task>"
+loopx start-goal --guided --project . --goal-text "<your first long-running task>" \
+  --host-surface codex-cli-tui
 ```
 
 The command pack checks the host-facing recovery packet. The guided start
 packet is the first task path: paste the generated transaction into Codex,
 Claude Code, or another compatible agent that can run shell commands from the
-project root.
+project root. Replace `codex-cli-tui` with `codex-app`, `codex-ide`,
+`claude-code`, or `shell` when that is the actual host. When the host is
+unclear, omit the flag once and follow the returned read-only selection gate;
+that preview does not write project state.
 
 ## Multi-Project Manager Commands
 

--- a/docs/reference/protocols/codex-app-host-command-registry-v0.md
+++ b/docs/reference/protocols/codex-app-host-command-registry-v0.md
@@ -165,6 +165,13 @@ fields can rerun the advertised command or pass
 `--include-command-pack-detail`. Both modes must produce the same host-action
 projection before a compact default is promoted.
 
+`start-goal` does not guess among Codex App, Codex IDE, and Codex CLI TUI.
+Callers should pass `--host-surface codex-app`, `codex-ide`, or
+`codex-cli-tui` for the exact current host. If the option is omitted, the
+command returns a read-only `host_surface_selection` gate with exact rerun
+commands; it must not connect a project, write todos, activate a host, or spend
+quota.
+
 ## Permission Boundary
 
 Host command parsing does not grant new LoopX authority. It only converts
@@ -199,8 +206,8 @@ loopx slash-commands --install
 loopx agent-onboard --list-agent-types
 loopx agent-onboard --agent-type codex-cli --project .
 loopx bootstrap-command-pack --project .
-loopx start-goal --guided --project . --goal-text "<goal text>"
-loopx --format json start-goal --guided --project . --goal-text "<goal text>" --include-command-pack-detail
+loopx start-goal --guided --project . --goal-text "<goal text>" --host-surface codex-cli-tui
+loopx --format json start-goal --guided --project . --goal-text "<goal text>" --host-surface codex-ide --include-command-pack-detail
 loopx bootstrap-command-pack --project . --goal-text "<goal text>"
 loopx pr-review
 loopx global-summary


### PR DESCRIPTION
## Summary
- document exact `--host-surface` selection for Codex App, IDE, and CLI TUI
- explain that omitting the host returns a read-only selection gate with no project-state writes
- align newcomer, getting-started, and host-command protocol guidance with the repaired #2238 contract

## Validation
- `pytest -q -n auto`: 596 passed, 2 skipped
- focused host/qualification/output-budget tests: 33 passed
- release catalog qualification: 8/8 selected canaries passed; packaged-install smoke exited 0
- live Doubao current-packet one-arm: 2/2 repetitions passed across entry, healthy postcondition, and projection-repair calibration
- real Codex CLI 0.142 TUI accepted `/goal <task>` in an isolated empty directory; interrupted before tool execution
- `loopx canary premerge --from-git-diff`: 12/12 checks passed, no manual holds
- docs governance and focused host-command smokes passed

## Boundary
- documentation only; no runtime behavior or first-screen README changes
- no credentials, local paths, raw model output, private state, or generated logs included
