### PR TITLE
fix(quota): preserve delivery attribution across registry checkouts

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -937,6 +937,11 @@ Post-turn accounting protocol:
   account the latest unspent `outcome_progress` delivery run once; a later
   duplicate spend is rejected because the latest run is then the spend event,
   not the delivery run.
+- keep accountable delivery attribution on the worktree that produced it. If
+  `refresh-state` must run from a separate registry checkout, pass
+  `--delivery-workspace-path <delivery-worktree>`; the path is validated locally
+  and omitted from persisted history. Do not point this option at the canonical
+  checkout for peer work.
 - autonomous replans follow the same accountable-outcome rule: spend after a
   concrete successor, blocker, or `outcome_progress`/`primary_goal_outcome`
   writeback, but do not spend for a `surface_only` watch-lane continuation or

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1157,6 +1157,14 @@ when the subcommand supports it. A spend preview that drops the identity may
 correctly show `automation_prompt_upgrade_required` for an unscoped automation,
 but that is an accounting/projection mismatch for the scoped turn, not evidence
 that the earlier peer guard was invalid.
+An accountable `refresh-state` normally records the current checkout as
+`delivery_workspace`. When implementation and validation happened in an
+independent worktree but registry/state projection must run from another
+checkout, pass `--delivery-workspace-path <delivery-worktree>`. LoopX validates
+the referenced checkout against the peer-isolation policy and persists only its
+credential-free repository identity and workspace class, never the local path.
+An explicit canonical checkout is rejected for peer delivery, so this causal
+override cannot turn non-isolated work into an accountable delivery.
 For registered agent-scoped turns, `quota should-run --agent-id` may include
 `agent_lane_next_action.schema_version=agent_lane_next_action_v0`. This is a
 read-only derived pointer to the current agent's selected advancement slice,

--- a/examples/control_plane/quota-spend-workspace-causality-smoke.py
+++ b/examples/control_plane/quota-spend-workspace-causality-smoke.py
@@ -205,6 +205,68 @@ def main() -> None:
             "peer_independent_worktree_required": True,
         }, workspace
 
+        # Registry/state projection may need to run from the canonical source
+        # checkout after implementation and validation happened in the peer
+        # worktree. An explicit causal path preserves the delivery identity
+        # without persisting that local path.
+        split_runtime = root / "split-runtime"
+        with working_directory(delivery):
+            split_refresh = refresh_state_run(
+                registry_path=registry_path,
+                runtime_root_override=str(split_runtime),
+                goal_id=GOAL_ID,
+                project=None,
+                state_file=None,
+                classification="validated_split_runtime_delivery_fixture",
+                recommended_action="complete the current todo",
+                delivery_batch_scale="implementation",
+                delivery_outcome="outcome_progress",
+                delivery_workspace_path=delivery_peer,
+                agent_id=AGENT_ID,
+                progress_scope="agent_lane",
+                dry_run=False,
+                sync_global=False,
+            )
+        split_workspace = split_refresh["delivery_workspace"]
+        assert split_workspace == {
+            **workspace,
+            "repository_source": "refresh_state.delivery_workspace_path",
+        }, split_workspace
+        assert str(delivery_peer) not in json.dumps(split_refresh), split_refresh
+        with working_directory(delivery_peer):
+            split_preview = preview(
+                split_runtime,
+                quota_decision(workspace_repair=True),
+            )
+        assert split_preview["ok"] is True, split_preview
+        assert split_preview["delivery_workspace"] == split_workspace, split_preview
+        assert split_preview["delivery_workspace_validated"] is True, split_preview
+
+        # An explicit canonical path cannot bless a peer delivery. Omitting the
+        # override retains the existing fail-closed recorded-history behavior.
+        with working_directory(delivery):
+            try:
+                refresh_state_run(
+                    registry_path=registry_path,
+                    runtime_root_override=str(root / "invalid-runtime"),
+                    goal_id=GOAL_ID,
+                    project=None,
+                    state_file=None,
+                    classification="invalid_canonical_delivery_fixture",
+                    recommended_action="complete the current todo",
+                    delivery_batch_scale="implementation",
+                    delivery_outcome="outcome_progress",
+                    delivery_workspace_path=delivery,
+                    agent_id=AGENT_ID,
+                    progress_scope="agent_lane",
+                    dry_run=False,
+                    sync_global=False,
+                )
+            except ValueError as exc:
+                assert "independent git worktree" in str(exc), exc
+            else:
+                raise AssertionError("canonical delivery override must fail closed")
+
         # Completing the todo may select work in another repository.  Spending
         # from the original delivery worktree remains valid and attributable.
         with working_directory(delivery_peer):

--- a/loopx/cli_commands/project_lifecycle.py
+++ b/loopx/cli_commands/project_lifecycle.py
@@ -143,6 +143,14 @@ def register_project_lifecycle_commands(
         help="Optional explicit outcome-floor signal for this refresh run.",
     )
     refresh_state_parser.add_argument(
+        "--delivery-workspace-path",
+        help=(
+            "Local git worktree that produced this accountable delivery. Use when "
+            "refresh-state must run from a separate registry checkout; the local "
+            "path is validated but is not persisted."
+        ),
+    )
+    refresh_state_parser.add_argument(
         "--autonomous-replan-recorded",
         action="store_true",
         help=(
@@ -444,6 +452,11 @@ def handle_project_lifecycle_command(
                 next_action=args.next_action,
                 delivery_batch_scale=args.delivery_batch_scale,
                 delivery_outcome=args.delivery_outcome,
+                delivery_workspace_path=(
+                    Path(args.delivery_workspace_path).expanduser()
+                    if args.delivery_workspace_path
+                    else None
+                ),
                 agent_id=args.agent_id,
                 agent_lane=args.agent_lane,
                 progress_scope=args.progress_scope,

--- a/loopx/project_prompt.py
+++ b/loopx/project_prompt.py
@@ -845,6 +845,9 @@ def render_prompt_text(
 
    不要为 quiet `should_run=false` skip、preflight 失败、或纯 dry-run preview 记账；如果
    `should_run=false` 但实际完成了 `safe_bypass_allowed=true` 的 bounded safe-bypass 工作，要记一次账。
+   accountable `refresh-state` 应从实际交付 worktree 运行；若 registry/state 投影只能从另一个
+   checkout 执行，显式加 `--delivery-workspace-path <delivery-worktree>`，不要让 canonical checkout
+   覆盖交付归因。
    不要重复执行。
 12. 最后用中文汇报：
    - changed files；

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -815,6 +815,7 @@ def refresh_state_run(
     next_action: str | None = None,
     delivery_batch_scale: str | None = None,
     delivery_outcome: str | None = None,
+    delivery_workspace_path: Path | None = None,
     agent_id: str | None = None,
     agent_lane: str | None = None,
     progress_scope: str | None = None,
@@ -842,6 +843,12 @@ def refresh_state_run(
     normalized_delivery_outcome = (
         require_delivery_outcome(delivery_outcome).value if delivery_outcome else None
     )
+    if delivery_workspace_path is not None and (
+        normalized_delivery_outcome not in ACCOUNTABLE_DELIVERY_OUTCOMES
+    ):
+        raise ValueError(
+            "--delivery-workspace-path requires an accountable --delivery-outcome"
+        )
     normalized_repair_delta_kinds = normalize_repair_delta_kinds(repair_delta_kinds)
     registry = load_registry(registry_path)
     runtime_root = resolve_runtime_root(registry, runtime_root_override)
@@ -1013,13 +1020,30 @@ def refresh_state_run(
         active_state_next_action_update=active_state_next_action_update,
         repair_delta_kinds=normalized_repair_delta_kinds,
     )
-    delivery_workspace = (
-        capture_delivery_workspace(
+    delivery_workspace = None
+    if normalized_delivery_outcome in ACCOUNTABLE_DELIVERY_OUTCOMES:
+        delivery_workspace = capture_delivery_workspace(
+            current_path=delivery_workspace_path,
             peer_independent_worktree_required=peer_independent_worktree_required,
         )
-        if normalized_delivery_outcome in ACCOUNTABLE_DELIVERY_OUTCOMES
-        else None
-    )
+        if delivery_workspace_path is not None:
+            if delivery_workspace is None:
+                raise ValueError(
+                    "--delivery-workspace-path must identify a git checkout with "
+                    "a credential-free origin repository"
+                )
+            if (
+                peer_independent_worktree_required
+                and delivery_workspace.get("workspace_kind")
+                != "independent_git_worktree"
+            ):
+                raise ValueError(
+                    "--delivery-workspace-path must identify the independent git "
+                    "worktree that produced this peer delivery"
+                )
+            delivery_workspace["repository_source"] = (
+                "refresh_state.delivery_workspace_path"
+            )
     record = build_state_refresh_record(
         goal_id=safe_goal_id,
         state_file=resolved_state_file,


### PR DESCRIPTION
## Summary
- let accountable refresh-state identify the actual delivery worktree when registry projection runs elsewhere
- persist only credential-free repository/worktree identity and reject canonical peer overrides
- teach the agent prompt and quota/status contracts about the causal override

## Validation
- quota-spend-workspace-causality-smoke: passed
- tests/control_plane/test_quota_slot_accounting.py: 11 passed
- ruff check on changed Python: passed
- LoopX premerge canary: 18/18 passed, public-boundary clean, self-merge allowed

## Commit grouping
1. runtime/CLI and agent-facing guidance
2. durable regression smoke and public contracts

## Excluded
- generated local uv.lock remains untracked
- no private state, credentials, raw trajectories, local paths, or production actions

## Residual risk
Callers that project from a different checkout must opt into --delivery-workspace-path; omission intentionally keeps the existing fail-closed canonical attribution.