### PR TITLE
test(ci): restore deterministic full-public smokes

### DIFF
--- a/.github/workflows/full-public-smokes.yml
+++ b/.github/workflows/full-public-smokes.yml
@@ -59,6 +59,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/examples/bootstrap-command-pack-smoke.py
+++ b/examples/bootstrap-command-pack-smoke.py
@@ -261,7 +261,7 @@ def test_start_goal_guided_previews_transaction_without_mutation() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         project = Path(tmp) / "guided-project"
         project.mkdir()
-        payload = run_json(
+        start_args = (
             "start-goal",
             "--guided",
             "--project",
@@ -273,6 +273,16 @@ def test_start_goal_guided_previews_transaction_without_mutation() -> None:
             "--goal-text",
             "Connect this repo and start an auto research lane",
         )
+        selection = run_json(*start_args)
+        selection_summary = assert_packet_summary_refs(
+            selection,
+            packet_kind="guided_start_host_surface_selection",
+        )
+        assert selection_summary["next_step_kind"] == "select_host_surface"
+        assert selection["guided_transaction"]["blocked_by"] == "host_surface_selection"
+        assert selection["safety_contract"]["writes_registry"] is False
+
+        payload = run_json(*start_args, "--host-surface", "codex-app")
 
         assert payload["schema_version"] == "loopx_start_goal_guided_v0"
         assert payload["read_only"] is True
@@ -377,6 +387,8 @@ def test_start_goal_guided_requires_explicit_goal_for_multi_goal_project() -> No
             "--guided",
             "--project",
             str(project),
+            "--host-surface",
+            "codex-app",
             "--goal-text",
             "Add a new meta agent without reusing an old lane",
         )

--- a/examples/context-provider-service-ownership-smoke.py
+++ b/examples/context-provider-service-ownership-smoke.py
@@ -62,7 +62,9 @@ def main() -> int:
 
         encoded = json.dumps(public, sort_keys=True)
         assert str(receipt) not in encoded
-        assert str(os.getpid()) not in encoded
+        assert "pid" not in public
+        assert all(value != os.getpid() for value in public.values())
+        assert public["process_id_captured"] is False
         assert "public-index-service" not in encoded
 
         write_receipt(receipt, generation="generation-2", pid=os.getpid())

--- a/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
+++ b/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
@@ -41,17 +41,28 @@ def run_cli(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
 def main() -> int:
     catalog = build_agent_type_catalog()
     agent_types = {item["agent_type"] for item in catalog["canonical_agent_types"]}
-    assert {"codex-app", "codex-cli", "claude-code", "manual", "other-agent"} <= agent_types
+    assert {
+        "codex-app",
+        "codex-ide",
+        "codex-cli",
+        "claude-code",
+        "manual",
+        "other-agent",
+    } <= agent_types
     ambiguous = {item["input"]: item["use_one_of"] for item in catalog["ambiguous_inputs"]}
-    assert ambiguous["codex"] == ["codex-app", "codex-cli"], ambiguous
+    assert ambiguous["codex"] == ["codex-app", "codex-ide", "codex-cli"], ambiguous
 
     assert agent_type_for_host_surface("chat-box") == "codex-app"
+    assert agent_type_for_host_surface("codex-ide") == "codex-ide"
     assert agent_type_for_host_surface("codex-cli-tui") == "codex-cli"
 
     codex_app = build_host_loop_activation_packet(agent_type="codex-app", goal_id="demo")
+    codex_ide = build_host_loop_activation_packet(agent_type="codex-ide", goal_id="demo")
     codex_cli = build_host_loop_activation_packet(agent_type="codex-cli", goal_id="demo")
     claude_code = build_host_loop_activation_packet(agent_type="claude-code", goal_id="demo")
     assert codex_app["activation_method"] == "create_or_update_codex_app_automation", codex_app
+    assert codex_ide["activation_method"] == "set_visible_goal", codex_ide
+    assert codex_ide["host_mutation"]["host_command"] == "/goal <task_body>", codex_ide
     assert codex_cli["host_mutation"]["host_command"] == "/goal <task_body>", codex_cli
     assert claude_code["host_mutation"]["host_command"] == "/loop", claude_code
     gated_activation = build_host_loop_activation_packet(
@@ -99,7 +110,11 @@ def main() -> int:
     assert ambiguous_result.returncode == 2, ambiguous_result.stdout
     ambiguous_payload = json.loads(ambiguous_result.stdout)
     assert ambiguous_payload["ok"] is False, ambiguous_payload
-    assert ambiguous_payload["suggestions"] == ["codex-app", "codex-cli"], ambiguous_payload
+    assert ambiguous_payload["suggestions"] == [
+        "codex-app",
+        "codex-ide",
+        "codex-cli",
+    ], ambiguous_payload
 
     with tempfile.TemporaryDirectory(prefix="loopx-agent-onboard-smoke-") as tmp:
         project = Path(tmp) / "project"


### PR DESCRIPTION
## Summary
- cover the read-only host-surface gate before the guided start transaction
- pass an exact Codex App host when exercising goal selection
- include Codex IDE in agent-type catalog, ambiguity, and visible `/goal` activation smoke coverage
- fetch full git history in the Full Public Smokes workflow so base/head differential checks can resolve `origin/main`
- replace a PID substring assertion with structured public-state assertions to avoid opaque-hash collisions

## Validation
- `python3 examples/bootstrap-command-pack-smoke.py`
- `python3 examples/control_plane/agent-onboard-host-loop-activation-smoke.py`
- `python3 examples/control_plane/peer-agent-runtime-v1-smoke.py`
- `python3 examples/context-provider-service-ownership-smoke.py`
- `python3 examples/control_plane/cli-output-base-head-differential-smoke.py`
- `python3 examples/control_plane/cli-output-budget-regression-smoke.py`
- `loopx canary premerge --from-git-diff --tier standard --format json` (passed; merge gate allows self-merge)
- [Full Public Smokes run 29535996794](https://github.com/huangruiteng/loopx/actions/runs/29535996794) passed all 6 shards on final head `eae4286f`

## Boundary
- public smoke and CI determinism only; no runtime behavior changes
- public/private boundary scan clean
- no local state, credentials, benchmark evidence, or generated logs included

Closes the regressions observed in main run 29533555380 and the CI-only defects isolated by branch run 29535524271.