### PR TITLE
fix(quota): preserve scoped capability envelopes

### DIFF
--- a/docs/state-interaction-model.md
+++ b/docs/state-interaction-model.md
@@ -164,6 +164,13 @@ the single action entrypoint for the current turn. If it carries a
 signal the primary action matched and whether `Next Action` / latest-run drift
 exists; it is not a second action source and does not authorize state sync by
 itself.
+For a registered agent, scoped state and accounting commands in
+`interaction_contract.cli_channel.next_cli_actions` preserve the normalized
+effective `--available-capability` envelope from the same quota decision.
+Capabilities describe observed execution support; they do not grant authority
+or replace user, repository-policy, or production gates. Owner-held authority
+labels such as credentials and production access are excluded from this CLI
+projection.
 Legacy Markdown parsing is even lower authority: it is a deterministic lint for
 unprojected prose in `Next Action`, not a source of gate truth. The hot path
 should not call an LLM to decide whether the user is gated, because that adds

--- a/examples/control_plane/quota-spend-agent-identity-smoke.py
+++ b/examples/control_plane/quota-spend-agent-identity-smoke.py
@@ -89,6 +89,7 @@ def assert_monitor_poll_event_carries_agent_id(agent_id: str) -> None:
 
 
 def assert_monitor_poll_next_cli_action_preserves_agent_id(agent_id: str) -> None:
+    available_capabilities = ["shell", "network", "github_cli"]
     actions = interaction_next_cli_actions(
         {
             "goal_id": "scoped-monitor-goal",
@@ -97,15 +98,24 @@ def assert_monitor_poll_next_cli_action_preserves_agent_id(agent_id: str) -> Non
             },
         },
         mode="monitor_quiet_skip",
+        available_capabilities=available_capabilities,
     )
 
     assert actions == [
-        f"loopx quota monitor-poll --goal-id scoped-monitor-goal --agent-id {agent_id} --execute",
-        f"loopx --format json quota should-run --goal-id scoped-monitor-goal --agent-id {agent_id}",
+        f"loopx quota monitor-poll --goal-id scoped-monitor-goal --agent-id {agent_id} --available-capability shell --available-capability network --available-capability github_cli --execute",
+        f"loopx --format json quota should-run --goal-id scoped-monitor-goal --agent-id {agent_id} --available-capability shell --available-capability network --available-capability github_cli",
     ], actions
 
 
 def assert_interaction_cli_actions_preserve_agent_id(agent_id: str) -> None:
+    available_capabilities = [
+        "shell",
+        "filesystem_write",
+        "benchmark_runner",
+        "credentials",
+        "production_access",
+    ]
+    projected_capabilities = ["shell", "filesystem_write", "benchmark_runner"]
     scoped_payload = {
         "goal_id": "scoped-delivery-goal",
         "agent_identity": {"agent_id": agent_id},
@@ -123,7 +133,11 @@ def assert_interaction_cli_actions_preserve_agent_id(agent_id: str) -> None:
         "successor_replan_required",
     ]
     for mode in command_modes:
-        actions = interaction_next_cli_actions(scoped_payload, mode=mode)
+        actions = interaction_next_cli_actions(
+            scoped_payload,
+            mode=mode,
+            available_capabilities=available_capabilities,
+        )
         state_or_accounting_commands = [
             action
             for action in actions
@@ -136,12 +150,28 @@ def assert_interaction_cli_actions_preserve_agent_id(agent_id: str) -> None:
             f"--agent-id {agent_id}" in action
             for action in state_or_accounting_commands
         ), (mode, actions)
+        assert all(
+            all(
+                f"--available-capability {capability}" in action
+                for capability in projected_capabilities
+            )
+            for action in state_or_accounting_commands
+        ), (mode, actions)
+        assert all(
+            "--available-capability credentials" not in action
+            and "--available-capability production_access" not in action
+            for action in state_or_accounting_commands
+        ), (mode, actions)
 
     unscoped_actions = interaction_next_cli_actions(
         {"goal_id": "unscoped-delivery-goal"},
         mode="bounded_delivery",
+        available_capabilities=available_capabilities,
     )
     assert all("--agent-id" not in action for action in unscoped_actions), unscoped_actions
+    assert all(
+        "--available-capability" not in action for action in unscoped_actions
+    ), unscoped_actions
 
 
 def assert_delivery_completion_spend_preserves_requested_agent_id(agent_id: str) -> None:
@@ -271,6 +301,42 @@ def main() -> int:
         index_path = runtime / "goals" / "near-limit-half" / "runs" / "index.jsonl"
         registry_before = registry_path.read_text(encoding="utf-8")
         index_before = index_path.read_text(encoding="utf-8")
+
+        quota_capabilities = ["network", "benchmark_runner"]
+        scoped_decision, scoped_decision_code = run_quota(
+            root,
+            registry_path,
+            runtime,
+            "should-run",
+            "--goal-id",
+            "near-limit-half",
+            "--agent-id",
+            agent_id,
+            *(
+                arg
+                for capability in quota_capabilities
+                for arg in ("--available-capability", capability)
+            ),
+        )
+        assert scoped_decision_code == 0, scoped_decision
+        assert scoped_decision["interaction_contract"]["mode"] == "bounded_delivery", scoped_decision
+        scoped_actions = scoped_decision["interaction_contract"]["cli_channel"][
+            "next_cli_actions"
+        ]
+        state_or_accounting_actions = [
+            action
+            for action in scoped_actions
+            if "loopx refresh-state" in action or "loopx quota spend-slot" in action
+        ]
+        assert state_or_accounting_actions, scoped_actions
+        assert all(
+            f"--agent-id {agent_id}" in action
+            and all(
+                f"--available-capability {capability}" in action
+                for capability in quota_capabilities
+            )
+            for action in state_or_accounting_actions
+        ), scoped_actions
 
         unscoped_payload, unscoped_code = run_quota(
             root,

--- a/examples/control_plane/refresh-state-agent-lane-scope-smoke.py
+++ b/examples/control_plane/refresh-state-agent-lane-scope-smoke.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -111,6 +112,48 @@ def main() -> None:
         with tempfile.TemporaryDirectory(prefix="loopx-agent-lane-refresh-") as raw_tmp:
             registry_path, runtime, project = write_fixture(Path(raw_tmp))
             state_path = project / f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+
+            cli_preview = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "loopx.cli",
+                    "--registry",
+                    str(registry_path),
+                    "--runtime-root",
+                    str(runtime),
+                    "--format",
+                    "json",
+                    "refresh-state",
+                    "--goal-id",
+                    GOAL_ID,
+                    "--project",
+                    str(project),
+                    "--classification",
+                    "scoped_capability_preview",
+                    "--agent-id",
+                    "codex-side-bypass",
+                    "--available-capability",
+                    "network",
+                    "--available-capability",
+                    "benchmark_runner",
+                    "--available-capability",
+                    "credentials",
+                    "--dry-run",
+                    "--no-global-sync",
+                ],
+                cwd=Path(__file__).resolve().parents[2],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            assert cli_preview.returncode == 0, cli_preview.stderr
+            cli_preview_payload = json.loads(cli_preview.stdout)
+            assert cli_preview_payload["available_capabilities"] == [
+                "network",
+                "benchmark_runner",
+            ], cli_preview_payload
+            assert cli_preview_payload["dry_run"] is True, cli_preview_payload
 
             state_refresh.now_local = lambda: "2026-06-20T00:00:00+00:00"
             primary_payload = state_refresh.refresh_state_run(

--- a/loopx/cli_commands/project_lifecycle.py
+++ b/loopx/cli_commands/project_lifecycle.py
@@ -5,11 +5,14 @@ import json
 from collections.abc import Callable
 from pathlib import Path
 
-from ..control_plane.goals.goal_vision_policy import (
-    GOAL_VISION_ADVANCEMENT_POLICY_CHOICES,
-)
 from ..capabilities.explore.activation import (
     sync_explore_graph_after_material_refresh,
+)
+from ..control_plane.agents.capability_gate import (
+    runtime_capabilities_for_cli_projection,
+)
+from ..control_plane.goals.goal_vision_policy import (
+    GOAL_VISION_ADVANCEMENT_POLICY_CHOICES,
 )
 from ..control_plane.work_items.delivery_batch_scale import (
     DELIVERY_BATCH_SCALE_INPUT_CHOICES,
@@ -233,6 +236,16 @@ def register_project_lifecycle_commands(
         help=(
             "Registered agent id for agent-lane state refreshes. When set, the "
             "refresh is visible in run history but does not replace goal-level status."
+        ),
+    )
+    refresh_state_parser.add_argument(
+        "--available-capability",
+        dest="available_capabilities",
+        action="append",
+        help=(
+            "Preserve one observed public-safe runtime capability from the scoped "
+            "quota decision. Repeatable; this context does not grant authority or "
+            "change refresh-state write scope."
         ),
     )
     refresh_state_parser.add_argument(
@@ -478,6 +491,11 @@ def handle_project_lifecycle_command(
                 "dry_run": bool(args.dry_run),
                 "error": str(exc),
             }
+        projected_capabilities = runtime_capabilities_for_cli_projection(
+            args.available_capabilities
+        )
+        if projected_capabilities:
+            payload["available_capabilities"] = projected_capabilities
         payload["external_sink_delivery_authorized"] = not bool(
             args.suppress_external_sinks
         )

--- a/loopx/control_plane/agents/capability_gate.py
+++ b/loopx/control_plane/agents/capability_gate.py
@@ -38,6 +38,16 @@ CAPABILITY_OWNER_GATE_HINTS = {
 }
 
 
+def runtime_capabilities_for_cli_projection(value: Any) -> list[str]:
+    """Return observed runtime capabilities, never owner-held authority gates."""
+
+    return [
+        capability
+        for capability in normalize_required_capabilities(value)
+        if capability not in CAPABILITY_OWNER_GATE_HINTS
+    ]
+
+
 def _capability_missing_action(missing: list[str]) -> str:
     missing_set = set(missing)
     if not missing_set:

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
+import shlex
 from typing import Any
 
 from ..agents.agent_scope_frontier import (
     AgentScopeFrontierAction,
     agent_scope_frontier_action as _agent_scope_frontier_action,
 )
+from ..agents.capability_gate import runtime_capabilities_for_cli_projection
 from ..goals.goal_frontier import AUTONOMOUS_REPLAN_REQUIRED_MODE
 from ..goals.goal_vision_wait import exact_blocked_successor_wait_state
-from ..todos.contract import TODO_TASK_CLASS_MONITOR, TODO_TASK_CLASS_USER_ACTION
+from ..todos.contract import (
+    TODO_TASK_CLASS_MONITOR,
+    TODO_TASK_CLASS_USER_ACTION,
+)
 from ..todos.projection import todo_item_task_class
 from ..todos.user_gate import open_todo_count
 from ..todos.write_hint import build_capability_resolution_writeback_actions
@@ -122,7 +127,11 @@ def _capability_resolution_user_actions(payload: dict[str, Any]) -> list[str]:
     return [owner_action] if owner_action else []
 
 
-def finalize_user_gate_notification_cooldown(payload: dict[str, Any]) -> None:
+def finalize_user_gate_notification_cooldown(
+    payload: dict[str, Any],
+    *,
+    available_capabilities: Any = None,
+) -> None:
     scheduler_hint = payload.get("scheduler_hint")
     cooldown = (
         scheduler_hint.get("user_gate_notification_cooldown")
@@ -137,7 +146,10 @@ def finalize_user_gate_notification_cooldown(payload: dict[str, Any]) -> None:
             or user_channel_action_todo_actions(payload.get("user_todo_summary"))
         )
         payload["requires_user_action"] = False
-    payload["interaction_contract"] = build_interaction_contract(payload)
+    payload["interaction_contract"] = build_interaction_contract(
+        payload,
+        available_capabilities=available_capabilities,
+    )
     attach_user_action_compat_fields(payload)
 
 
@@ -418,17 +430,38 @@ def _interaction_mode(payload: dict[str, Any]) -> str:
     return "skip"
 
 
-def interaction_next_cli_actions(payload: dict[str, Any], *, mode: str) -> list[str]:
+def _scoped_cli_args(
+    agent_identity: dict[str, Any],
+    *,
+    available_capabilities: Any,
+) -> str:
+    agent_id = str(agent_identity.get("agent_id") or "").strip()
+    if not agent_id:
+        return ""
+    capability_args = "".join(
+        f" --available-capability {shlex.quote(capability)}"
+        for capability in runtime_capabilities_for_cli_projection(
+            available_capabilities
+        )
+    )
+    return f" --agent-id {agent_id}{capability_args}"
+
+
+def interaction_next_cli_actions(
+    payload: dict[str, Any],
+    *,
+    mode: str,
+    available_capabilities: Any = None,
+) -> list[str]:
     goal_id = str(payload.get("goal_id") or "<GOAL_ID>")
     agent_identity = (
         payload.get("agent_identity")
         if isinstance(payload.get("agent_identity"), dict)
         else {}
     )
-    agent_arg = (
-        f" --agent-id {agent_identity.get('agent_id')}"
-        if agent_identity.get("agent_id")
-        else ""
+    scoped_cli_args = _scoped_cli_args(
+        agent_identity,
+        available_capabilities=available_capabilities,
     )
     capability_resolution_actions = build_capability_resolution_writeback_actions(
         payload.get("capability_gate"),
@@ -462,8 +495,8 @@ def interaction_next_cli_actions(payload: dict[str, Any], *, mode: str) -> list[
         ]
     if mode == "monitor_quiet_skip":
         return [
-            f"loopx quota monitor-poll --goal-id {goal_id}{agent_arg} --execute",
-            f"loopx --format json quota should-run --goal-id {goal_id}{agent_arg}",
+            f"loopx quota monitor-poll --goal-id {goal_id}{scoped_cli_args} --execute",
+            f"loopx --format json quota should-run --goal-id {goal_id}{scoped_cli_args}",
         ]
     if mode == AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value:
         agent_scope_frontier = (
@@ -489,8 +522,8 @@ def interaction_next_cli_actions(payload: dict[str, Any], *, mode: str) -> list[
             return [
                 f"loopx todo complete --goal-id {goal_id} --todo-id {monitor_todo_id} --evidence '<validated gate evidence>'",
                 f"loopx todo update --goal-id {goal_id} --todo-id {gated_todo_id} --note '<public-safe gate repair reason>'",
-                f"loopx refresh-state --goal-id {goal_id} --classification standing_monitor_gate_repair_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress{agent_arg}",
-                f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{agent_arg}",
+                f"loopx refresh-state --goal-id {goal_id} --classification standing_monitor_gate_repair_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress{scoped_cli_args}",
+                f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{scoped_cli_args}",
             ]
         route_candidates = (
             agent_scope_frontier.get("route_continuation_replan_candidates")
@@ -500,8 +533,8 @@ def interaction_next_cli_actions(payload: dict[str, Any], *, mode: str) -> list[
         if route_candidates:
             return [
                 f"loopx todo add --goal-id {goal_id} --role agent --text '<public-safe route continuation advancement todo>'",
-                f"loopx refresh-state --goal-id {goal_id} --classification route_continuation_replan_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress{agent_arg}",
-                f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{agent_arg}",
+                f"loopx refresh-state --goal-id {goal_id} --classification route_continuation_replan_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress{scoped_cli_args}",
+                f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{scoped_cli_args}",
             ]
         candidates = (
             agent_scope_frontier.get("deferred_resume_candidates")
@@ -512,42 +545,32 @@ def interaction_next_cli_actions(payload: dict[str, Any], *, mode: str) -> list[
         todo_id = str(first_candidate.get("todo_id") or "<todo_id>")
         return [
             f"loopx todo update --goal-id {goal_id} --todo-id {todo_id} --status open --note '<public-safe successor replan reason>'",
-            f"loopx refresh-state --goal-id {goal_id} --classification successor_replan_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress{agent_arg}",
-            f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{agent_arg}",
+            f"loopx refresh-state --goal-id {goal_id} --classification successor_replan_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress{scoped_cli_args}",
+            f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{scoped_cli_args}",
         ]
     if (
         mode == AgentScopeFrontierAction.AGENT_SCOPE_WAIT.value
         and _blocked_successor_wait_observation_required(payload)
     ):
         return [
-            f"loopx quota monitor-poll --goal-id {goal_id}{agent_arg} --execute",
-            f"loopx --format json quota should-run --goal-id {goal_id}{agent_arg}",
+            f"loopx quota monitor-poll --goal-id {goal_id}{scoped_cli_args} --execute",
+            f"loopx --format json quota should-run --goal-id {goal_id}{scoped_cli_args}",
         ]
     if _agent_scope_frontier_action(mode) is not None:
         return [
             "no quota spend while this agent has no in-scope runnable candidate",
-            f"loopx --format json quota should-run --goal-id {goal_id}{agent_arg}",
+            f"loopx --format json quota should-run --goal-id {goal_id}{scoped_cli_args}",
         ]
     if mode == "external_evidence_observation":
         return [
             "read approved controller/job/marker/writeback surfaces only",
-            f"loopx refresh-state --goal-id {goal_id} --classification <compact_blocker_or_transition>{agent_arg}",
-            f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{agent_arg}",
+            f"loopx refresh-state --goal-id {goal_id} --classification <compact_blocker_or_transition>{scoped_cli_args}",
+            f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{scoped_cli_args}",
         ]
     if mode == "agent_workspace_repair":
-        agent_identity = (
-            payload.get("agent_identity")
-            if isinstance(payload.get("agent_identity"), dict)
-            else {}
-        )
-        agent_arg = (
-            f" --agent-id {agent_identity.get('agent_id')}"
-            if agent_identity.get("agent_id")
-            else ""
-        )
         return [
             "create or switch to an independent git worktree/branch",
-            f"loopx --format json quota should-run --goal-id {goal_id}{agent_arg}",
+            f"loopx --format json quota should-run --goal-id {goal_id}{scoped_cli_args}",
         ]
     if mode == "autonomous_replan":
         lane_action = _protocol_first_candidate_action(payload)
@@ -559,11 +582,11 @@ def interaction_next_cli_actions(payload: dict[str, Any], *, mode: str) -> list[
         )
         return [
             first_action,
-            f"loopx refresh-state --goal-id {goal_id} --classification autonomous_replan_recorded --autonomous-replan-recorded --repair-delta-kind <delta_kind> --delivery-batch-scale <scale> --delivery-outcome <outcome>{agent_arg}",
+            f"loopx refresh-state --goal-id {goal_id} --classification autonomous_replan_recorded --autonomous-replan-recorded --repair-delta-kind <delta_kind> --delivery-batch-scale <scale> --delivery-outcome <outcome>{scoped_cli_args}",
             (
                 "if the replan writeback records an accountable delta such as "
                 "outcome_progress or primary_goal_outcome, run "
-                f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{agent_arg}; "
+                f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{scoped_cli_args}; "
                 "otherwise do not spend for surface_only watch-lane continuation/no-followup"
             ),
         ]
@@ -578,8 +601,8 @@ def interaction_next_cli_actions(payload: dict[str, Any], *, mode: str) -> list[
     }:
         return [
             *capability_resolution_actions,
-            f"loopx refresh-state --goal-id {goal_id} --classification <validated_progress>{agent_arg}",
-            f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{agent_arg}",
+            f"loopx refresh-state --goal-id {goal_id} --classification <validated_progress>{scoped_cli_args}",
+            f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{scoped_cli_args}",
         ]
     if mode in {"user_gate", "user_todo_blocker_push", "user_action_required"}:
         return [
@@ -832,9 +855,14 @@ def _build_interaction_cli_channel(
     *,
     mode: str,
     spend_after_validation: bool,
+    available_capabilities: Any = None,
 ) -> dict[str, Any]:
     return {
-        "next_cli_actions": interaction_next_cli_actions(payload, mode=mode),
+        "next_cli_actions": interaction_next_cli_actions(
+            payload,
+            mode=mode,
+            available_capabilities=available_capabilities,
+        ),
         "spend_allowed_now": False,
         "spend_after_validation": spend_after_validation,
         "spend_policy": _interaction_spend_policy(
@@ -929,7 +957,11 @@ def _interaction_fallback_policy_required(payload: dict[str, Any], *, mode: str)
     } or bool(payload.get("blocked_priority_fallback"))
 
 
-def build_interaction_contract(payload: dict[str, Any]) -> dict[str, Any]:
+def build_interaction_contract(
+    payload: dict[str, Any],
+    *,
+    available_capabilities: Any = None,
+) -> dict[str, Any]:
     execution_obligation = (
         payload.get("execution_obligation")
         if isinstance(payload.get("execution_obligation"), dict)
@@ -991,6 +1023,7 @@ def build_interaction_contract(payload: dict[str, Any]) -> dict[str, Any]:
             heartbeat_recommendation,
             mode=mode,
             spend_after_validation=spend_after_validation,
+            available_capabilities=available_capabilities,
         ),
     }
     _attach_interaction_required_reads(contract, required_reads)

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -2143,7 +2143,10 @@ def build_quota_should_run(
                     "required_reads": required_reads,
                 }
         payload["automation_liveness"] = build_automation_liveness(payload)
-        payload["interaction_contract"] = build_interaction_contract(payload)
+        payload["interaction_contract"] = build_interaction_contract(
+            payload,
+            available_capabilities=effective_available_capabilities,
+        )
         payload["scheduler_hint"] = _scheduler_hint(
             payload,
             include_detail=include_scheduler_detail,
@@ -2161,7 +2164,10 @@ def build_quota_should_run(
             ), codex_app_current_rrule=codex_app_current_rrule,
             scheduler_execution_context=resolved_scheduler_context,
         )
-        finalize_user_gate_notification_cooldown(payload)
+        finalize_user_gate_notification_cooldown(
+            payload,
+            available_capabilities=effective_available_capabilities,
+        )
         payload["protocol_action_packet"] = build_protocol_action_packet(payload)
         return payload
 


### PR DESCRIPTION
## Summary

- preserve normalized observed capabilities on registered-agent refresh, monitor, follow-up quota, and spend commands
- let refresh-state accept and echo the scoped runtime envelope without changing authority or write scope
- exclude credentials and production-access authority labels from generated capability replay
- document the capability-versus-authority boundary

## Validation

- quota-spend-agent-identity-smoke
- refresh-state-agent-lane-scope-smoke
- scheduler interaction arbitration: 13 passed
- ruff on changed focused Python surfaces
- real openviking-goal quota readback and refresh-state dry-run
- LoopX premerge canary: 18/18 checks passed, 0 manual holds
- public boundary scan clean