### PR TITLE
Retain scheduler failure pairs across unrelated host-match ACKs

### DIFF
--- a/examples/control_plane/quota-scheduler-state-ack-smoke.py
+++ b/examples/control_plane/quota-scheduler-state-ack-smoke.py
@@ -29,6 +29,7 @@ from loopx.control_plane.scheduler.scheduler_hint import (  # noqa: E402
     build_scheduler_hint,
 )
 from loopx.control_plane.scheduler.state import (  # noqa: E402
+    SCHEDULER_HOST_UPDATE_FAILURE_SCHEMA_VERSION,
     SCHEDULER_STATE_SCHEMA_VERSION,
     load_scheduler_state,
     write_scheduler_state,
@@ -529,6 +530,86 @@ def assert_scheduler_ack_plan_validation() -> None:
         "already_applied": True,
         "applied_rrule": "",
     }, already_applied
+
+
+def assert_scheduler_ack_preserves_other_failed_target_for_same_host() -> None:
+    host_rrule = "FREQ=MINUTELY;INTERVAL=15"
+    active_rrule = "FREQ=MINUTELY;INTERVAL=3"
+    active = build_hint_at(
+        active_payload(),
+        now=FROZEN_NOW,
+        codex_app_current_rrule=host_rrule,
+    )
+    failure_state = state_from(active)
+    failure_state["last_applied_rrule"] = host_rrule
+    failure_state["host_update_failures"] = [
+        {
+            "schema_version": SCHEDULER_HOST_UPDATE_FAILURE_SCHEMA_VERSION,
+            "target_rrule": active_rrule,
+            "observed_host_rrule": host_rrule,
+            "failure_kind": "automation_update_failed",
+            "failure_count": 1,
+            "failed_at": FROZEN_NOW.isoformat(),
+        }
+    ]
+
+    monitor = build_hint_at(
+        monitor_payload(),
+        now=FROZEN_NOW + timedelta(minutes=1),
+        scheduler_state=failure_state,
+        codex_app_current_rrule=host_rrule,
+    )
+    monitor_app = monitor["codex_app"]
+    assert monitor_app["stateful_backoff"]["ack_needed"] is True, monitor
+    ack_args = monitor_app["ack_hint"]["args"]
+    ack = build_codex_app_scheduler_ack_event(
+        {"goal_id": "scheduler-state-ack-smoke", "scheduler_hint": monitor},
+        agent_id=ack_args["agent_id"],
+        applied_rrule=host_rrule,
+        reset_token=ack_args["reset_token"],
+        identity_signature=ack_args["identity_signature"],
+        generated_at=(FROZEN_NOW + timedelta(minutes=1)).isoformat(),
+    )
+    acknowledged_state = ack["scheduler_ack_event"]["scheduler_state"]
+    assert acknowledged_state["host_update_failures"] == (
+        failure_state["host_update_failures"]
+    ), ack
+
+    active_again = build_hint_at(
+        active_payload(),
+        now=FROZEN_NOW + timedelta(minutes=2),
+        scheduler_state=acknowledged_state,
+        codex_app_current_rrule=host_rrule,
+    )
+    active_app = active_again["codex_app"]
+    assert active_app["stateful_backoff"]["state_status"] == (
+        "host_update_failure_suppressed"
+    ), active_again
+    assert active_app["stateful_backoff"]["apply_needed"] is False, active_again
+    assert "recommended_rrule" not in active_app, active_again
+    assert "ack_hint" not in active_app, active_again
+    assert "failure_hint" not in active_app, active_again
+
+    changed_host = build_hint_at(
+        active_payload(),
+        now=FROZEN_NOW + timedelta(minutes=3),
+        scheduler_state=acknowledged_state,
+        codex_app_current_rrule=active_rrule,
+    )
+    changed_app = changed_host["codex_app"]
+    assert changed_app["stateful_backoff"]["ack_needed"] is True, changed_host
+    changed_ack_args = changed_app["ack_hint"]["args"]
+    changed_ack = build_codex_app_scheduler_ack_event(
+        {"goal_id": "scheduler-state-ack-smoke", "scheduler_hint": changed_host},
+        agent_id=changed_ack_args["agent_id"],
+        applied_rrule=active_rrule,
+        reset_token=changed_ack_args["reset_token"],
+        identity_signature=changed_ack_args["identity_signature"],
+        generated_at=(FROZEN_NOW + timedelta(minutes=3)).isoformat(),
+    )
+    changed_state = changed_ack["scheduler_ack_event"]["scheduler_state"]
+    assert "host_update_failures" not in changed_state, changed_ack
+    assert "host_update_failure" not in changed_state, changed_ack
 
 
 def assert_normal_run_ack_preserves_runtime_capabilities() -> None:
@@ -1539,6 +1620,7 @@ def main() -> int:
     assert_monitor_wait_ignores_goal_recommended_action_identity_noise()
     assert_active_work_keeps_initial_cadence()
     assert_scheduler_ack_plan_validation()
+    assert_scheduler_ack_preserves_other_failed_target_for_same_host()
     assert_normal_run_ack_preserves_runtime_capabilities()
     assert_monitor_wait_fixed_due_bucket_does_not_churn()
     assert_monitor_wait_stale_ack_hint_is_accepted()

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -709,6 +709,19 @@ def build_codex_app_scheduler_ack_event(
     )
     progression_index = max(0, _int_number(stateful_backoff.get("progression_index"), default=0))
     safe_generated_at = generated_at or ""
+    retained_host_update_failures = [
+        failure
+        for failure in retained_scheduler_host_update_failures(
+            normalize_scheduler_host_update_failures(
+                stateful_backoff.get("host_update_failures"),
+                legacy_failure=stateful_backoff.get("host_update_failure"),
+            ),
+            reference_time=safe_generated_at,
+            observed_host_rrule=acknowledged_rrule,
+        )
+        if normalize_scheduler_rrule(failure.get("target_rrule"))
+        != acknowledged_rrule
+    ]
     scheduler_state = build_scheduler_state(
         goal_id=before.get("goal_id"),
         agent_id=safe_agent_id,
@@ -721,6 +734,7 @@ def build_codex_app_scheduler_ack_event(
         last_applied_rrule=acknowledged_rrule,
         updated_at=safe_generated_at,
         source=classification,
+        host_update_failures=retained_host_update_failures,
     )
     reason = str(reason_summary or "").strip() or (
         f"acknowledged Codex App scheduler RRULE {acknowledged_rrule}; no quota spend"


### PR DESCRIPTION
## Summary
- retain recent scheduler host-update failure pairs when an ACK confirms the same observed host at a different target cadence
- clear a failure pair when its target is acknowledged, the observed host changes, or the entry expires
- add a state-sequence regression covering failed `3 <- 15`, host-match ACK `15`, retry suppression for `3`, and clearing after host convergence

## Validation
- `PYTHONPATH=. python3 examples/control_plane/quota-scheduler-state-ack-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/quota-scheduler-policy-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/monitor-scheduler-contract-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/interaction-scheduler-authority-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/quota-scheduler-hint-compaction-smoke.py`
- `python3 -m compileall -q loopx/control_plane/scheduler/scheduler_hint.py examples/control_plane/quota-scheduler-state-ack-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli --format json canary premerge --from-git-diff` (18 selected checks passed; public-boundary scan clean)

## Review note
This changes core scheduler persisted-state behavior. It intentionally remains review-gated despite the bounded diff and passing canary. No benchmark jobs, private state, raw logs, or host automation updates are included.