### PR TITLE
fix(scheduler): retain failed pairs across fallback ack

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -845,7 +845,10 @@ so active-work and monitor-wait targets cannot overwrite one another while the
 host RRULE remains unchanged. Later heartbeats expose `apply_needed=false` and
 `state_status=host_update_failure_suppressed` for every retained exact pair.
 A changed host observation invalidates failures recorded against the old host,
-and a successful scheduler ACK clears the cache. The legacy
+and a successful scheduler ACK clears only failures whose target is the
+acknowledged RRULE. A fallback ACK therefore preserves failures for other
+targets observed against the same unchanged host, preventing the next turn
+from retrying a known-bad target/host pair. The legacy
 `host_update_failure` scalar remains as the latest compatibility projection;
 new hosts should consume `host_update_failures`. LoopX never treats an intended
 cadence as an applied cadence.

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -709,6 +709,19 @@ def build_codex_app_scheduler_ack_event(
     )
     progression_index = max(0, _int_number(stateful_backoff.get("progression_index"), default=0))
     safe_generated_at = generated_at or ""
+    retained_host_update_failures = [
+        failure
+        for failure in retained_scheduler_host_update_failures(
+            normalize_scheduler_host_update_failures(
+                stateful_backoff.get("host_update_failures"),
+                legacy_failure=stateful_backoff.get("host_update_failure"),
+            ),
+            reference_time=safe_generated_at,
+            observed_host_rrule=acknowledged_rrule,
+        )
+        if normalize_scheduler_rrule(failure.get("target_rrule"))
+        != acknowledged_rrule
+    ]
     scheduler_state = build_scheduler_state(
         goal_id=before.get("goal_id"),
         agent_id=safe_agent_id,
@@ -721,6 +734,12 @@ def build_codex_app_scheduler_ack_event(
         last_applied_rrule=acknowledged_rrule,
         updated_at=safe_generated_at,
         source=classification,
+        host_update_failure=(
+            retained_host_update_failures[-1]
+            if retained_host_update_failures
+            else None
+        ),
+        host_update_failures=retained_host_update_failures or None,
     )
     reason = str(reason_summary or "").strip() or (
         f"acknowledged Codex App scheduler RRULE {acknowledged_rrule}; no quota spend"

--- a/tests/control_plane/test_scheduler_host_failure_cache.py
+++ b/tests/control_plane/test_scheduler_host_failure_cache.py
@@ -83,6 +83,7 @@ def _record_failure(
     *,
     runtime_root: Path,
     generated_at: str,
+    observed_host_rrule: str = HOST_30,
 ) -> dict:
     app = decision["scheduler_hint"]["codex_app"]
     target_rrule = app["recommended_rrule"]
@@ -92,7 +93,7 @@ def _record_failure(
         goal_id=GOAL_ID,
         agent_id=AGENT_ID,
         failed_rrule=target_rrule,
-        observed_host_rrule=HOST_30,
+        observed_host_rrule=observed_host_rrule,
         generated_at=generated_at,
     )
     assert result["ok"] is True
@@ -203,6 +204,59 @@ def test_matching_host_ack_clears_the_failure_cache(tmp_path: Path) -> None:
     scheduler_state = ack["scheduler_ack_event"]["scheduler_state"]
     assert "host_update_failures" not in scheduler_state
     assert "host_update_failure" not in scheduler_state
+
+
+def test_fallback_ack_retains_other_failed_target_for_same_host(
+    tmp_path: Path,
+) -> None:
+    generated_at = datetime.now(timezone.utc)
+    active = _with_scheduler_hint(
+        _active_decision(),
+        scheduler_state=None,
+        host_rrule=MONITOR_15,
+    )
+    failure_state = _record_failure(
+        active,
+        runtime_root=tmp_path,
+        generated_at=generated_at.isoformat(),
+        observed_host_rrule=MONITOR_15,
+    )
+
+    fallback = _with_scheduler_hint(
+        _monitor_decision(),
+        scheduler_state=failure_state,
+        host_rrule=MONITOR_15,
+    )
+    fallback_app = fallback["scheduler_hint"]["codex_app"]
+    assert fallback_app["stateful_backoff"]["current_rrule"] == MONITOR_15
+    assert fallback_app["stateful_backoff"]["apply_needed"] is False
+    assert fallback_app["stateful_backoff"]["ack_needed"] is True
+
+    fallback_ack = build_codex_app_scheduler_ack_event(
+        fallback,
+        agent_id=AGENT_ID,
+        applied_rrule=MONITOR_15,
+        generated_at=(generated_at + timedelta(seconds=1)).isoformat(),
+    )
+    fallback_state = fallback_ack["scheduler_ack_event"]["scheduler_state"]
+    assert [
+        failure["target_rrule"] for failure in fallback_state["host_update_failures"]
+    ] == [ACTIVE_3]
+
+    active_replay = _with_scheduler_hint(
+        _active_decision(),
+        scheduler_state=fallback_state,
+        host_rrule=MONITOR_15,
+    )
+    replay_app = active_replay["scheduler_hint"]["codex_app"]
+    assert replay_app["stateful_backoff"]["apply_needed"] is False
+    assert replay_app["stateful_backoff"]["ack_needed"] is False
+    assert replay_app["stateful_backoff"]["state_status"] == (
+        "host_update_failure_suppressed"
+    )
+    assert replay_app["host_action"] == "none_recorded_host_failure"
+    assert "recommended_rrule" not in replay_app
+    assert "failure_hint" not in replay_app
 
 
 def test_failure_cache_is_bounded_expires_and_reads_legacy_scalar_state() -> None:


### PR DESCRIPTION
## Summary
- retain unexpired failed target/host pairs when a fallback RRULE is acknowledged on the same host
- clear only the acknowledged target pair or failures invalidated by a genuine host observation change
- document and test fail(3m,15m) -> ack(15m) -> active(3m) suppression

## Validation
- 70 focused scheduler/control-plane tests passed
- quota-scheduler-state-ack-smoke passed
- Ruff check and py_compile passed
- LoopX premerge canary passed 18/18 with no failures, skips, warnings, or manual holds
- public/private boundary scan clean

## Excluded
- generated local uv.lock remains untracked and is not part of this PR

## Risk
Narrow scheduler-state transition only; no schema, CLI, permission, or production action changes.