### PR TITLE
fix(history): preserve concurrent run artifact identity

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -466,6 +466,24 @@ consecutive public stalled monitor records with the same target feed
 watch-lane expiry, concrete blocker, todo supersede, or successor runnable todo
 instead of another quiet skip.
 
+Execute-mode quota monitor/spend/void writers reserve each JSON/Markdown pair
+atomically and lock the compact index append, so concurrent processes with the
+same timestamp retain distinct artifact identities. For historical collisions,
+inspect before repair:
+
+```bash
+loopx history --goal-id <GOAL_ID> inspect-index-duplicates
+loopx history --goal-id <GOAL_ID> repair-index-duplicates          # preview
+loopx history --goal-id <GOAL_ID> repair-index-duplicates --execute
+```
+
+The repair path only rebuilds a collision automatically when every row is a
+`quota_monitor_poll` and the compact index proves distinct todo/target event
+identities. It creates one public-safe artifact pair per event, preserves every
+index row and leaves the original shared artifacts in place. Ambiguous artifact
+identity collisions remain blocked for reviewed merge semantics; they are
+never deleted by this command.
+
 After that bounded replan slice is acknowledged by a compact state run carrying
 `autonomous_replan_ack_v0` and `repair_delta_contract_v0` with
 `delta_present=true`, later empty monitor polls for the same acknowledged wait

--- a/examples/history-index-duplicate-inspection-smoke.py
+++ b/examples/history-index-duplicate-inspection-smoke.py
@@ -148,6 +148,29 @@ def write_index_fixture(root: Path, goal_id: str, duplicate_kind: str) -> None:
             },
             {**base, "classification": "state_refreshed"},
         ]
+    elif duplicate_kind == "distinct_monitor_event_collision":
+        rows = [
+            {
+                **base,
+                "classification": "quota_monitor_poll",
+                "todo_id": "todo-monitor-a",
+                "target_key": "monitor:fixture:a",
+                "monitor_target": {
+                    "target_id": "fixture-a",
+                    "target_kind": "external_evidence",
+                },
+            },
+            {
+                **base,
+                "classification": "quota_monitor_poll",
+                "todo_id": "todo-monitor-b",
+                "target_key": "monitor:fixture:b",
+                "monitor_target": {
+                    "target_id": "fixture-b",
+                    "target_kind": "external_evidence",
+                },
+            },
+        ]
     else:
         raise ValueError(duplicate_kind)
     (runs_dir / "index.jsonl").write_text(
@@ -173,6 +196,7 @@ def write_registry(root: Path) -> Path:
         ("structured-artifact-goal", "structured_artifact_collision"),
         ("structured-bundle-goal", "structured_artifact_bundle"),
         ("artifact-collision-goal", "artifact_identity_collision"),
+        ("monitor-collision-goal", "distinct_monitor_event_collision"),
     ):
         state_file = project / ".codex" / "goals" / goal_id / "ACTIVE_GOAL_STATE.md"
         state_file.parent.mkdir(parents=True, exist_ok=True)
@@ -234,8 +258,8 @@ def main() -> None:
             registry_path, "history", "inspect-index-duplicates", "--limit", "10"
         )
         assert payload["ok"] is True, payload
-        assert payload["duplicate_group_count"] == 7, payload
-        assert payload["duplicate_row_count"] == 8, payload
+        assert payload["duplicate_group_count"] == 8, payload
+        assert payload["duplicate_row_count"] == 9, payload
         by_goal = {group["goal_id"]: group for group in payload["groups"]}
         assert by_goal["reward-overlay-goal"]["duplicate_kind"] == "reward_overlay", (
             payload
@@ -278,6 +302,11 @@ def main() -> None:
             "benchmark_run_v0",
             "state_refreshed",
         ], payload
+        assert (
+            by_goal["monitor-collision-goal"]["action"]
+            == "rebuild_distinct_monitor_event_artifacts"
+        ), payload
+        assert by_goal["monitor-collision-goal"]["repairable"] is True, payload
         assert payload["groups"][0]["severity"] == "warning", payload
 
         repair_preview = run_cli(
@@ -292,6 +321,8 @@ def main() -> None:
             repair_preview
         )
         assert repair_preview["unrepaired_group_count"] == 2, repair_preview
+        assert repair_preview["planned_rebuild_artifact_count"] == 2, repair_preview
+        assert repair_preview["rebuilt_artifact_count"] == 0, repair_preview
         repair_actions = {
             group["goal_id"]: group["action"] for group in repair_preview["groups"]
         }
@@ -319,6 +350,10 @@ def main() -> None:
             repair_actions["artifact-collision-goal"]
             == "blocked_artifact_identity_collision"
         ), repair_preview
+        assert (
+            repair_actions["monitor-collision-goal"]
+            == "rebuild_distinct_monitor_event_artifacts"
+        ), repair_preview
 
         repair_execute = run_cli(
             registry_path,
@@ -332,6 +367,8 @@ def main() -> None:
         assert repair_execute["dry_run"] is False, repair_execute
         assert repair_execute["repaired"] is True, repair_execute
         assert repair_execute["removed_row_count"] == 2, repair_execute
+        assert repair_execute["planned_rebuild_artifact_count"] == 2, repair_execute
+        assert repair_execute["rebuilt_artifact_count"] == 2, repair_execute
 
         after_repair = run_cli(
             registry_path, "history", "inspect-index-duplicates", "--limit", "10"
@@ -360,6 +397,34 @@ def main() -> None:
             after_by_goal["artifact-collision-goal"]["duplicate_kind"]
             == "artifact_identity_collision"
         ), after_repair
+        assert "monitor-collision-goal" not in after_by_goal, after_repair
+
+        monitor_runs_dir = (
+            Path(registry_path).parents[2]
+            / "runtime"
+            / "goals"
+            / "monitor-collision-goal"
+            / "runs"
+        )
+        monitor_rows = [
+            json.loads(line)
+            for line in (monitor_runs_dir / "index.jsonl")
+            .read_text(encoding="utf-8")
+            .splitlines()
+            if line.strip()
+        ]
+        assert len(monitor_rows) == 2, monitor_rows
+        assert {row["todo_id"] for row in monitor_rows} == {
+            "todo-monitor-a",
+            "todo-monitor-b",
+        }, monitor_rows
+        assert len({row["json_path"] for row in monitor_rows}) == 2, monitor_rows
+        assert all(Path(row["json_path"]).exists() for row in monitor_rows), monitor_rows
+        assert all(Path(row["markdown_path"]).exists() for row in monitor_rows), (
+            monitor_rows
+        )
+        assert (monitor_runs_dir / "run.json").exists(), monitor_rows
+        assert (monitor_runs_dir / "run.md").exists(), monitor_rows
 
         filtered = run_cli(
             registry_path,

--- a/loopx/control_plane/quota/monitor_poll.py
+++ b/loopx/control_plane/quota/monitor_poll.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from copy import deepcopy
-import json
 from pathlib import Path
 from typing import Any
 
 from .decision_summary import compact_quota_decision, quota_decision_agent_id
 from .spend_sources import DEFAULT_SLOT_SPEND_SOURCE, VALID_SLOT_SPEND_SOURCES
 from ..runtime.time import now_local_iso
-from ..runtime.run_artifacts import run_file_stem, unique_run_artifact_paths
+from ..runtime.run_artifacts import (
+    run_file_stem,
+    unique_run_artifact_paths,
+    write_unique_run_artifacts,
+)
 from ..scheduler.monitor_poll_policy import (
     allows_no_spend_blocked_successor_wait_poll,
     allows_due_monitor_poll,
@@ -422,11 +425,14 @@ def record_quota_monitor_poll_for_decision(
 
     after_status = deepcopy(status_payload)
     if execute:
-        runs_dir.mkdir(parents=True, exist_ok=True)
-        json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-        markdown_path.write_text(render_quota_monitor_poll_markdown(record) + "\n", encoding="utf-8")
-        with index_path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
+        json_path, markdown_path, index_path = write_unique_run_artifacts(
+            runs_dir=runs_dir,
+            stem=stem,
+            suffix="quota-monitor-poll",
+            record=record,
+            markdown=render_quota_monitor_poll_markdown(record),
+            index_record=index_record,
+        )
         run_history = after_status.get("run_history") if isinstance(after_status.get("run_history"), dict) else {}
         for goal in run_history.get("goals") if isinstance(run_history.get("goals"), list) else []:
             if isinstance(goal, dict) and str(goal.get("id") or "") == goal_id:

--- a/loopx/control_plane/quota/slot_accounting.py
+++ b/loopx/control_plane/quota/slot_accounting.py
@@ -10,7 +10,11 @@ from .monitor_poll import QUOTA_MONITOR_POLL_CLASSIFICATION
 from .scheduler_ack import QUOTA_SCHEDULER_ACK_CLASSIFICATION
 from .spend_sources import DEFAULT_SLOT_SPEND_SOURCE, VALID_SLOT_SPEND_SOURCES
 from ..runtime.time import now_local_iso
-from ..runtime.run_artifacts import run_file_stem, unique_run_artifact_paths
+from ..runtime.run_artifacts import (
+    run_file_stem,
+    unique_run_artifact_paths,
+    write_unique_run_artifacts,
+)
 from ..agents.workspace_guard import (
     build_delivery_workspace_guard,
     delivery_workspace_repository,
@@ -721,11 +725,17 @@ def record_quota_slot_void_from_preview(
         payload["before"] = record["quota_event"]["before"]
         payload["after"] = record["quota_event"]["after"]
     if execute:
-        runs_dir.mkdir(parents=True, exist_ok=True)
-        json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-        markdown_path.write_text(render_quota_slot_preview_markdown(payload) + "\n", encoding="utf-8")
-        with index_path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
+        json_path, markdown_path, index_path = write_unique_run_artifacts(
+            runs_dir=runs_dir,
+            stem=stem,
+            suffix="quota-slot-voided",
+            record=record,
+            markdown=render_quota_slot_preview_markdown(payload),
+            index_record=index_record,
+        )
+        payload["json_path"] = str(json_path)
+        payload["markdown_path"] = str(markdown_path)
+        payload["index_path"] = str(index_path)
     return payload
 
 
@@ -792,11 +802,17 @@ def record_quota_slot_spend_from_preview(
         payload["before"] = record["quota_event"]["before"]
         payload["after"] = record["quota_event"]["after"]
     if execute:
-        runs_dir.mkdir(parents=True, exist_ok=True)
-        json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-        markdown_path.write_text(render_quota_slot_preview_markdown(payload) + "\n", encoding="utf-8")
-        with index_path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
+        json_path, markdown_path, index_path = write_unique_run_artifacts(
+            runs_dir=runs_dir,
+            stem=stem,
+            suffix="quota-slot-spent",
+            record=record,
+            markdown=render_quota_slot_preview_markdown(payload),
+            index_record=index_record,
+        )
+        payload["json_path"] = str(json_path)
+        payload["markdown_path"] = str(markdown_path)
+        payload["index_path"] = str(index_path)
     return payload
 
 

--- a/loopx/control_plane/runtime/run_artifacts.py
+++ b/loopx/control_plane/runtime/run_artifacts.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import json
+import os
 import re
 from pathlib import Path
+from typing import Any
+
+from ...file_lock import exclusive_file_lock
 
 
 def run_file_stem(generated_at: str) -> str:
@@ -20,3 +25,78 @@ def unique_run_artifact_paths(runs_dir: Path, stem: str, suffix: str) -> tuple[P
         if not candidate.exists() and not markdown_candidate.exists():
             return candidate, markdown_candidate
         index += 1
+
+
+def reserve_unique_run_artifact_paths(
+    runs_dir: Path,
+    stem: str,
+    suffix: str,
+) -> tuple[Path, Path]:
+    """Atomically reserve one JSON/Markdown artifact pair.
+
+    Dry-run callers should keep using :func:`unique_run_artifact_paths`. Execute
+    callers use this reservation so concurrent writers cannot both select and
+    truncate the same run artifacts.
+    """
+
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    index = 1
+    while True:
+        actual_suffix = suffix if index == 1 else f"{suffix}-{index}"
+        json_path = runs_dir / f"{stem}-{actual_suffix}.json"
+        markdown_path = runs_dir / f"{stem}-{actual_suffix}.md"
+        try:
+            json_fd = os.open(json_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError:
+            index += 1
+            continue
+        try:
+            markdown_fd = os.open(
+                markdown_path,
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+            )
+        except FileExistsError:
+            os.close(json_fd)
+            json_path.unlink(missing_ok=True)
+            index += 1
+            continue
+        os.close(json_fd)
+        os.close(markdown_fd)
+        return json_path, markdown_path
+
+
+def write_unique_run_artifacts(
+    *,
+    runs_dir: Path,
+    stem: str,
+    suffix: str,
+    record: dict[str, Any],
+    markdown: str,
+    index_record: dict[str, Any],
+) -> tuple[Path, Path, Path]:
+    """Reserve, write, and index one run without sharing artifact identity."""
+
+    json_path, markdown_path = reserve_unique_run_artifact_paths(
+        runs_dir,
+        stem,
+        suffix,
+    )
+    index_path = runs_dir / "index.jsonl"
+    index_record["json_path"] = str(json_path)
+    index_record["markdown_path"] = str(markdown_path)
+    try:
+        json_path.write_text(
+            json.dumps(record, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        markdown_path.write_text(markdown.rstrip("\n") + "\n", encoding="utf-8")
+        with exclusive_file_lock(index_path):
+            with index_path.open("a", encoding="utf-8") as index_file:
+                index_file.write(json.dumps(index_record, ensure_ascii=False) + "\n")
+    except Exception:
+        # No index row refers to the pair until the final append. Remove a
+        # failed reservation instead of leaving it looking like a valid run.
+        json_path.unlink(missing_ok=True)
+        markdown_path.unlink(missing_ok=True)
+        raise
+    return json_path, markdown_path, index_path

--- a/loopx/control_plane/runtime/run_index_duplicates.py
+++ b/loopx/control_plane/runtime/run_index_duplicates.py
@@ -19,6 +19,7 @@ REWARD_OVERLAY_IDENTITY_KEYS = (
     "json_path",
     "markdown_path",
 )
+QUOTA_MONITOR_POLL_CLASSIFICATION = "quota_monitor_poll"
 
 
 def index_identity(record: dict[str, Any]) -> tuple[str, str, str]:
@@ -111,6 +112,32 @@ def is_structured_artifact_bundle(records: list[dict[str, Any]]) -> bool:
     return len(payload_fingerprints) == len(records)
 
 
+def monitor_event_identity(record: dict[str, Any]) -> tuple[str, str] | None:
+    """Return the compact public identity retained by monitor index rows."""
+
+    if str(record.get("classification") or "") != QUOTA_MONITOR_POLL_CLASSIFICATION:
+        return None
+    todo_id = str(record.get("todo_id") or "").strip()
+    target_key = str(record.get("target_key") or "").strip()
+    if not (todo_id or target_key):
+        return None
+    return todo_id, target_key
+
+
+def is_rebuildable_distinct_monitor_event_collision(
+    records: list[dict[str, Any]],
+) -> bool:
+    """Recognize overwritten artifacts whose distinct events survive in index rows."""
+
+    identities = [monitor_event_identity(record) for record in records]
+    return (
+        len(records) > 1
+        and not any(isinstance(record.get("human_reward"), dict) for record in records)
+        and all(identity is not None for identity in identities)
+        and len(set(identities)) == len(records)
+    )
+
+
 def classify_index_duplicate_records(records: list[dict[str, Any]]) -> dict[str, Any]:
     normalized_keys = {
         _normalized_key(_normalized_index_record(record)) for record in records
@@ -156,6 +183,22 @@ def classify_index_duplicate_records(records: list[dict[str, Any]]) -> dict[str,
             "action": "keep_structured_artifact_row",
             "repairable": True,
             "reason": "one row carries the compact structured artifact payload and siblings only repeat the artifact identity",
+        }
+
+    if is_rebuildable_distinct_monitor_event_collision(records):
+        return {
+            "duplicate_kind": "artifact_identity_collision",
+            "severity": "warning",
+            "repair_hint": (
+                "rebuild one compact artifact pair per distinct monitor event; "
+                "preserve every index row and the original shared artifacts"
+            ),
+            "action": "rebuild_distinct_monitor_event_artifacts",
+            "repairable": True,
+            "reason": (
+                "all collided rows are quota monitor events with distinct retained "
+                "todo/target identities"
+            ),
         }
 
     return {

--- a/loopx/history.py
+++ b/loopx/history.py
@@ -3,22 +3,25 @@ from __future__ import annotations
 import json
 import os
 import re
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any, Callable
 
 from .authority import goal_authority_registry_summary
 from .control_plane import compact_control_plane_policy
-from .control_plane.runtime.time import now_local_iso
 from .control_plane.runtime.run_index_duplicates import (
     classify_index_duplicate_records,
     duplicate_repair_decision,
     index_identity,
 )
+from .control_plane.runtime.run_artifacts import reserve_unique_run_artifact_paths
+from .control_plane.runtime.time import now_local_iso
 from .control_plane.work_items.delivery_batch_scale import require_delivery_batch_scale
 from .control_plane.work_items.delivery_outcome import require_delivery_outcome
 from .doctor import PROMOTION_READINESS_CLASSIFICATIONS
 from .execution_profile import compact_execution_profile
 from .explore_graph import compact_explore_graph_policy
+from .file_lock import exclusive_file_lock
 from .paths import registry_project_root, resolve_runtime_root
 from .presentation.markdown import (
     markdown_code,
@@ -934,6 +937,8 @@ def inspect_index_duplicates(
                     "health_checks": health_checks,
                     "reward_overlay_rows": reward_records,
                     "repair_hint": duplicate_classification.get("repair_hint"),
+                    "action": duplicate_classification.get("action"),
+                    "repairable": duplicate_classification.get("repairable"),
                 }
             )
 
@@ -961,6 +966,84 @@ def inspect_index_duplicates(
     }
 
 
+def _rebuild_monitor_event_artifact(
+    *,
+    runs_dir: Path,
+    source_line_number: int,
+    source_record: dict[str, Any],
+) -> tuple[dict[str, Any], Path, Path]:
+    generated_at = str(source_record.get("generated_at") or now_local())
+    source_identity = {
+        "generated_at": source_record.get("generated_at"),
+        "json_path": source_record.get("json_path"),
+        "markdown_path": source_record.get("markdown_path"),
+    }
+    rebuild = {
+        "schema_version": "run_artifact_rebuild_v0",
+        "source_identity": source_identity,
+        "source_line_number": source_line_number,
+        "preserved_original_artifacts": True,
+    }
+    record = {
+        key: source_record[key]
+        for key in (
+            "generated_at",
+            "goal_id",
+            "classification",
+            "recommended_action",
+            "health_check",
+            "delivery_outcome",
+            "monitor_target",
+            "agent_id",
+        )
+        if key in source_record
+    }
+    record["monitor_event"] = {
+        "event_type": QUOTA_MONITOR_POLL_CLASSIFICATION,
+        "todo_id": source_record.get("todo_id"),
+        "target_key": source_record.get("target_key"),
+        "material_change": source_record.get("material_change") is True,
+        "recovered_from_index": True,
+    }
+    record["artifact_rebuild"] = rebuild
+    json_path, markdown_path = reserve_unique_run_artifact_paths(
+        runs_dir,
+        run_file_stem(generated_at),
+        "quota-monitor-poll-rebuilt",
+    )
+    try:
+        json_path.write_text(
+            json.dumps(record, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        markdown_path.write_text(
+            "\n".join(
+                [
+                    "# LoopX Rebuilt Monitor Run Artifact",
+                    "",
+                    f"- goal_id: `{source_record.get('goal_id') or ''}`",
+                    f"- generated_at: `{generated_at}`",
+                    f"- todo_id: `{source_record.get('todo_id') or ''}`",
+                    f"- target_key: `{source_record.get('target_key') or ''}`",
+                    f"- source_index_line: `{source_line_number}`",
+                    "- original_artifacts_preserved: `True`",
+                    "- recovered_from: compact public-safe index row",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    except Exception:
+        json_path.unlink(missing_ok=True)
+        markdown_path.unlink(missing_ok=True)
+        raise
+    rebuilt_index_record = dict(source_record)
+    rebuilt_index_record["json_path"] = str(json_path)
+    rebuilt_index_record["markdown_path"] = str(markdown_path)
+    rebuilt_index_record["artifact_rebuild"] = rebuild
+    return rebuilt_index_record, json_path, markdown_path
+
+
 def repair_index_duplicates(
     *,
     registry_path: Path,
@@ -980,6 +1063,8 @@ def repair_index_duplicates(
     removed_row_count = 0
     preserved_reward_overlay_rows = 0
     preserved_structured_artifact_bundle_rows = 0
+    planned_rebuild_artifact_count = 0
+    rebuilt_artifact_count = 0
     unrepaired_group_count = 0
     groups: list[dict[str, Any]] = []
 
@@ -989,68 +1074,103 @@ def repair_index_duplicates(
         if not index_path.exists():
             continue
 
-        raw_lines = index_path.read_text(encoding="utf-8").splitlines()
-        grouped: dict[tuple[str, str, str], list[tuple[int, dict[str, Any]]]] = {}
-        for line_number, line in enumerate(raw_lines, start=1):
-            if not line.strip():
-                continue
-            raw_index_records += 1
-            try:
-                item = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if not isinstance(item, dict):
-                continue
-            grouped.setdefault(index_identity(item), []).append((line_number, item))
+        lock = exclusive_file_lock(index_path) if execute else nullcontext()
+        with lock:
+            raw_lines = index_path.read_text(encoding="utf-8").splitlines()
+            grouped: dict[tuple[str, str, str], list[tuple[int, dict[str, Any]]]] = {}
+            for line_number, line in enumerate(raw_lines, start=1):
+                if not line.strip():
+                    continue
+                raw_index_records += 1
+                try:
+                    item = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(item, dict):
+                    continue
+                grouped.setdefault(index_identity(item), []).append((line_number, item))
 
-        remove_lines: set[int] = set()
-        for records in grouped.values():
-            if len(records) <= 1:
-                continue
-            decision = duplicate_repair_decision(records)
-            removed_lines = list(decision.get("removed_line_numbers") or [])
-            if decision.get("action") == "preserve_reward_overlay":
-                preserved_reward_overlay_rows += len(records) - 1
-            elif decision.get("action") == "preserve_structured_artifact_bundle":
-                preserved_structured_artifact_bundle_rows += len(records) - 1
-            elif decision.get("repairable"):
-                remove_lines.update(int(line_number) for line_number in removed_lines)
-                removed_row_count += len(removed_lines)
-            else:
-                unrepaired_group_count += 1
+            remove_lines: set[int] = set()
+            rebuilt_lines: dict[int, dict[str, Any]] = {}
+            for records in grouped.values():
+                if len(records) <= 1:
+                    continue
+                decision = duplicate_repair_decision(records)
+                action = decision.get("action")
+                removed_lines = list(decision.get("removed_line_numbers") or [])
+                rebuilt_paths: list[dict[str, str]] = []
+                if action == "preserve_reward_overlay":
+                    preserved_reward_overlay_rows += len(records) - 1
+                elif action == "preserve_structured_artifact_bundle":
+                    preserved_structured_artifact_bundle_rows += len(records) - 1
+                elif action == "rebuild_distinct_monitor_event_artifacts":
+                    planned_rebuild_artifact_count += len(records)
+                    if execute:
+                        for line_number, source_record in records:
+                            rebuilt, rebuilt_json, rebuilt_markdown = (
+                                _rebuild_monitor_event_artifact(
+                                    runs_dir=index_path.parent,
+                                    source_line_number=line_number,
+                                    source_record=source_record,
+                                )
+                            )
+                            rebuilt_lines[line_number] = rebuilt
+                            rebuilt_paths.append(
+                                {
+                                    "json_path": str(rebuilt_json),
+                                    "markdown_path": str(rebuilt_markdown),
+                                }
+                            )
+                            rebuilt_artifact_count += 1
+                elif decision.get("repairable"):
+                    remove_lines.update(int(line_number) for line_number in removed_lines)
+                    removed_row_count += len(removed_lines)
+                else:
+                    unrepaired_group_count += 1
 
-            first_record = records[0][1]
-            groups.append(
-                {
-                    "goal_id": current_goal_id,
-                    "index_path": str(index_path),
-                    "generated_at": first_record.get("generated_at"),
-                    "json_path": first_record.get("json_path"),
-                    "markdown_path": first_record.get("markdown_path"),
-                    "action": decision.get("action"),
-                    "repairable": decision.get("repairable"),
-                    "line_numbers": decision.get("line_numbers"),
-                    "kept_line_numbers": decision.get("kept_line_numbers"),
-                    "removed_line_numbers": removed_lines,
-                    "reason": decision.get("reason"),
-                }
-            )
+                first_record = records[0][1]
+                groups.append(
+                    {
+                        "goal_id": current_goal_id,
+                        "index_path": str(index_path),
+                        "generated_at": first_record.get("generated_at"),
+                        "json_path": first_record.get("json_path"),
+                        "markdown_path": first_record.get("markdown_path"),
+                        "action": action,
+                        "repairable": decision.get("repairable"),
+                        "line_numbers": decision.get("line_numbers"),
+                        "kept_line_numbers": decision.get("kept_line_numbers"),
+                        "removed_line_numbers": removed_lines,
+                        "planned_rebuild_artifacts": (
+                            len(records)
+                            if action == "rebuild_distinct_monitor_event_artifacts"
+                            else 0
+                        ),
+                        "rebuilt_paths": rebuilt_paths,
+                        "reason": decision.get("reason"),
+                    }
+                )
 
-        if execute and remove_lines:
-            rewritten = [
-                line
-                for line_number, line in enumerate(raw_lines, start=1)
-                if line_number not in remove_lines
-            ]
-            tmp_path = index_path.with_suffix(index_path.suffix + ".tmp")
-            tmp_path.write_text("".join(line + "\n" for line in rewritten), encoding="utf-8")
-            tmp_path.replace(index_path)
+            if execute and (remove_lines or rebuilt_lines):
+                rewritten: list[str] = []
+                for line_number, line in enumerate(raw_lines, start=1):
+                    if line_number in remove_lines:
+                        continue
+                    if line_number in rebuilt_lines:
+                        line = json.dumps(rebuilt_lines[line_number], ensure_ascii=False)
+                    rewritten.append(line)
+                tmp_path = index_path.with_suffix(index_path.suffix + ".tmp")
+                tmp_path.write_text(
+                    "".join(line + "\n" for line in rewritten),
+                    encoding="utf-8",
+                )
+                tmp_path.replace(index_path)
 
     limited_groups = groups[: max(0, limit)]
     return {
         "ok": True,
         "dry_run": not execute,
-        "repaired": bool(execute and removed_row_count),
+        "repaired": bool(execute and (removed_row_count or rebuilt_artifact_count)),
         "registry": str(registry_path),
         "runtime_root": str(runtime_root),
         "goal_filter": goal_id,
@@ -1059,6 +1179,8 @@ def repair_index_duplicates(
         "removed_row_count": removed_row_count,
         "preserved_reward_overlay_rows": preserved_reward_overlay_rows,
         "preserved_structured_artifact_bundle_rows": preserved_structured_artifact_bundle_rows,
+        "planned_rebuild_artifact_count": planned_rebuild_artifact_count,
+        "rebuilt_artifact_count": rebuilt_artifact_count,
         "unrepaired_group_count": unrepaired_group_count,
         "groups": limited_groups,
         "truncated": len(groups) > len(limited_groups),
@@ -1083,6 +1205,8 @@ def render_index_duplicate_repair_markdown(payload: dict[str, Any]) -> str:
         f"- removed_rows: `{payload.get('removed_row_count')}`",
         f"- preserved_reward_overlay_rows: `{payload.get('preserved_reward_overlay_rows')}`",
         f"- preserved_structured_artifact_bundle_rows: `{payload.get('preserved_structured_artifact_bundle_rows')}`",
+        f"- planned_rebuild_artifacts: `{payload.get('planned_rebuild_artifact_count')}`",
+        f"- rebuilt_artifacts: `{payload.get('rebuilt_artifact_count')}`",
         f"- unrepaired_groups: `{payload.get('unrepaired_group_count')}`",
         f"- truncated: `{payload.get('truncated')}`",
         "",

--- a/tests/control_plane/test_run_artifact_concurrency.py
+++ b/tests/control_plane/test_run_artifact_concurrency.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import multiprocessing
+from pathlib import Path
+
+from loopx.control_plane.runtime.run_artifacts import write_unique_run_artifacts
+
+
+def _write_same_timestamp_monitor_artifact(runs_dir: str, worker_id: int) -> None:
+    record = {
+        "generated_at": "2026-07-17T00:00:00+08:00",
+        "goal_id": "fixture-goal",
+        "classification": "quota_monitor_poll",
+        "monitor_event": {
+            "todo_id": f"todo-{worker_id}",
+            "target_key": f"monitor:fixture:{worker_id}",
+        },
+    }
+    index_record = {
+        "generated_at": record["generated_at"],
+        "goal_id": record["goal_id"],
+        "classification": record["classification"],
+        "todo_id": record["monitor_event"]["todo_id"],
+        "target_key": record["monitor_event"]["target_key"],
+    }
+    write_unique_run_artifacts(
+        runs_dir=Path(runs_dir),
+        stem="2026-07-17T00-00-00-08-00",
+        suffix="quota-monitor-poll",
+        record=record,
+        markdown=f"# Monitor {worker_id}",
+        index_record=index_record,
+    )
+
+
+def test_same_timestamp_multi_process_monitor_artifacts_keep_distinct_identity(
+    tmp_path: Path,
+) -> None:
+    runs_dir = tmp_path / "runs"
+    context = multiprocessing.get_context("spawn")
+    processes = [
+        context.Process(
+            target=_write_same_timestamp_monitor_artifact,
+            args=(str(runs_dir), worker_id),
+        )
+        for worker_id in range(6)
+    ]
+
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=20)
+        assert process.exitcode == 0
+
+    rows = [
+        json.loads(line)
+        for line in (runs_dir / "index.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(rows) == 6
+    assert len({row["json_path"] for row in rows}) == 6
+    assert len({row["markdown_path"] for row in rows}) == 6
+    assert {row["todo_id"] for row in rows} == {
+        f"todo-{worker_id}" for worker_id in range(6)
+    }
+    for row in rows:
+        json_payload = json.loads(Path(row["json_path"]).read_text(encoding="utf-8"))
+        assert json_payload["monitor_event"]["todo_id"] == row["todo_id"]
+        assert Path(row["markdown_path"]).exists()


### PR DESCRIPTION
## Summary

- atomically reserve quota monitor/spend/void artifact pairs and serialize index appends
- rebuild only proven-distinct historical monitor collisions while preserving every event row and original artifact
- document the repair contract and cover same-timestamp multi-process writers

## Validation

- tests/control_plane: 281 passed
- focused multiprocessing and history migration tests passed
- LoopX premerge canary: 18/18 checks passed
- public boundary scan: clean

## Migration readback

The OpenViking shared runtime preview found three safe legacy collision groups. Six compact event artifacts were rebuilt with zero index-row deletion; all new and original artifacts passed readback.