### PR TITLE
fix(explore): reconcile bounded visual readback

### DIFF
--- a/docs/capabilities/explore/README.md
+++ b/docs/capabilities/explore/README.md
@@ -312,6 +312,10 @@ one never enables the other:
   zero-write operation. A configured row sink is complete only after a
   row/result-id readback verifies the projection. A failed sync or readback
   does not advance its digest, so the next material refresh retries it.
+  Visual sinks also preflight their deterministic delivery marker: an existing
+  marker reconciles the prior write without publishing again, while a bounded
+  readback timeout stops further calls in that stage batch and leaves a
+  retryable receipt instead of blindly repeating remote writes.
 - `spawn_policy.explore_harness.enabled` controls only the read-only branch
   planners described below. It does not create, update, or publish a graph.
 

--- a/examples/explore-result-layer-smoke.py
+++ b/examples/explore-result-layer-smoke.py
@@ -475,9 +475,33 @@ def check_visual_marker_readback_retry_contract() -> None:
         "ok": False,
         "marker_observed": False,
         "error_code": 2890002,
+        "timed_out": False,
         "retryable": True,
     }, settled
     assert settled["retryable"] is False, settled
+
+    observed_timeouts: list[float | None] = []
+
+    def timeout_runner(
+        args: list[str], cwd: Path | None, timeout: float | None
+    ) -> dict[str, object]:
+        observed_timeouts.append(timeout)
+        raise subprocess.TimeoutExpired(args, timeout)
+
+    timed_out = explore_visual_readback.readback_visual_delivery_marker(
+        cli_bin=config.cli_bin,
+        identity=config.identity,
+        whiteboard_token="wb_timeout_fixture",
+        marker=marker,
+        runner=timeout_runner,
+        retry_delays=(),
+    )
+    assert observed_timeouts == [
+        explore_visual_readback.VISUAL_READBACK_COMMAND_TIMEOUT_SECONDS
+    ], observed_timeouts
+    assert timed_out["ok"] is False and timed_out["retryable"] is True, timed_out
+    assert timed_out["host_wait_exhausted"] is True, timed_out
+    assert timed_out["command"]["timed_out"] is True, timed_out
 
     stage_markers = {
         "wb_stage_1": "LoopX delivery stage-1",
@@ -543,6 +567,66 @@ def check_visual_marker_readback_retry_contract() -> None:
     assert all(
         result["readback"]["attempt_count"] == 2 for result in stage_results
     ), stage_results
+
+    timeout_stage_calls: list[str] = []
+
+    def batch_timeout_runner(
+        args: list[str], cwd: Path | None, timeout: float | None
+    ) -> dict[str, object]:
+        token = args[args.index("--whiteboard-token") + 1]
+        timeout_stage_calls.append(token)
+        if token == "wb_stage_2":
+            raise subprocess.TimeoutExpired(args, timeout)
+        expected_marker = stage_markers.get(
+            token,
+            f"LoopX delivery stage-{token.rsplit('_', 1)[-1]}",
+        )
+        return {
+            "returncode": 0,
+            "stdout": json.dumps(
+                {
+                    "ok": True,
+                    "data": {"nodes": [{"text": {"text": expected_marker}}]},
+                }
+            ),
+            "stderr": "",
+            "timed_out": False,
+        }
+
+    timed_stage_results = []
+    timed_stage_targets = []
+    for index in range(1, 4):
+        token = f"wb_stage_{index}"
+        expected_marker = stage_markers.get(token, f"LoopX delivery stage-{index}")
+        result = {
+            "ok": False,
+            "status": "publish_unverified",
+            "published": False,
+            "command": {"ok": True},
+            "readback": {
+                "ok": False,
+                "expected_marker": expected_marker,
+                "retryable": True,
+                "attempts": [],
+            },
+            "retryable": True,
+        }
+        timed_stage_results.append(result)
+        timed_stage_targets.append((result, token))
+
+    explore_visual_readback.settle_visual_stage_readbacks(
+        cli_bin=config.cli_bin,
+        identity=config.identity,
+        stage_targets=timed_stage_targets,
+        runner=batch_timeout_runner,
+        retry_delays=(0.0,),
+    )
+    assert timeout_stage_calls == ["wb_stage_1", "wb_stage_2"], timeout_stage_calls
+    assert timed_stage_results[0]["ok"] is True, timed_stage_results
+    assert timed_stage_results[1]["readback"]["host_wait_exhausted"] is True
+    assert timed_stage_results[2]["readback"]["source"] == (
+        "batch_host_wait_exhausted"
+    )
 
     summary = explore_visual_styles.summarize_explore_visual_sync(
         views={"canonical": {"ok": False, "retryable": True}},

--- a/examples/explore-visual-cross-role-integrity-smoke.py
+++ b/examples/explore-visual-cross-role-integrity-smoke.py
@@ -86,6 +86,7 @@ def main() -> int:
             "ok": False,
             "status": "publish_unverified",
             "published": False,
+            "external_write_performed": True,
             "retryable": True,
             "delivery_digest": view_key,
             "board_style": "semantic_lane_columns",

--- a/loopx/presentation/sinks/lark/explore_results.py
+++ b/loopx/presentation/sinks/lark/explore_results.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Mapping
@@ -68,9 +67,9 @@ from .explore_visual_integrity import (
     finalize_visual_role_results,
 )
 from .explore_visual_readback import (
-    readback_visual_delivery_marker,
+    defer_visual_stage_after_host_timeout,
+    publish_visual_with_readback,
     settle_visual_stage_readbacks,
-    structured_command_error,
 )
 from .explore_visual_styles import (
     board_source_with_delivery_marker,
@@ -696,81 +695,23 @@ def sync_explore_visual_to_lark(
         "--format",
         "json",
     ]
-    if not execute:
-        result = _run_command(command, execute=False, runner=runner)
-        publish_attempts = [result]
-    else:
-        config_path.parent.mkdir(parents=True, exist_ok=True)
-        source_path = config_path.parent / source_name
-        source_path.write_text(published_source, encoding="utf-8")
-        try:
-            result = _run_command(
-                command,
-                execute=True,
-                runner=runner,
-                cwd=config_path.parent,
-            )
-            publish_attempts = [result]
-            error = structured_command_error(result)
-            if (
-                not result.get("ok")
-                and error.get("code") == 2891001
-                and "not iterable" in str(error.get("message") or "")
-            ):
-                retry_command = list(command)
-                token_index = retry_command.index("--idempotent-token") + 1
-                retry_material = (
-                    f"{retry_command[token_index]}:{time.time_ns()}".encode("utf-8")
-                )
-                retry_command[token_index] = (
-                    "loopx-retry-" + hashlib.sha256(retry_material).hexdigest()[:32]
-                )
-                result = _run_command(
-                    retry_command,
-                    execute=True,
-                    runner=runner,
-                    cwd=config_path.parent,
-                )
-                publish_attempts.append(result)
-        finally:
-            source_path.unlink(missing_ok=True)
-    readback_deferred = bool(
-        execute and result.get("ok") and delivery_marker and defer_readback
+    delivery = publish_visual_with_readback(
+        cli_bin=config.cli_bin,
+        identity=config.identity,
+        whiteboard_token=whiteboard_token,
+        marker=delivery_marker,
+        command=command,
+        published_source=published_source,
+        source_path=config_path.parent / source_name,
+        execute=execute,
+        runner=runner,
+        defer_readback=defer_readback,
     )
-    readback: dict[str, Any] = {
-        "ok": not readback_deferred,
-        "schema_version": "loopx_lark_explore_visual_readback_v0",
-        "performed": False,
-        "verified": False,
-        "source": (
-            "not_required"
-            if not delivery_marker
-            else "deferred_to_batch"
-            if readback_deferred
-            else "would_query_whiteboard_raw_nodes"
-        ),
-        "expected_marker": delivery_marker,
-        "observed_marker": None,
-        "retryable": readback_deferred,
-        "error": None,
-    }
-    if execute and result.get("ok") and delivery_marker and not defer_readback:
-        readback = readback_visual_delivery_marker(
-            cli_bin=config.cli_bin,
-            identity=config.identity,
-            whiteboard_token=whiteboard_token,
-            marker=delivery_marker,
-            runner=runner,
-        )
-    delivery_ok = bool(
-        result.get("ok") and (not delivery_marker or readback.get("ok"))
-    )
-    retryable = bool(
-        execute
-        and result.get("ok")
-        and delivery_marker
-        and readback.get("retryable")
-    )
+    result = delivery["command"]
+    readback = delivery["readback"]
+    delivery_ok = bool(delivery["ok"])
+    retryable = bool(delivery["retryable"])
+    publish_attempts = delivery["publish_attempts"]
     return {
         "ok": delivery_ok,
         "schema_version": LARK_EXPLORE_VISUAL_SYNC_VERSION,
@@ -785,6 +726,9 @@ def sync_explore_visual_to_lark(
         ),
         "execute": execute,
         "published": bool(execute and delivery_ok),
+        "external_write_performed": delivery["external_write_performed"],
+        "reconciled_existing_delivery": delivery["reconciled_existing_delivery"],
+        "prepublish_readback": delivery["prepublish_readback"],
         "semantic_digest": semantic_digest,
         "delivery_digest": delivery_digest,
         "source_digest": source_digest,
@@ -851,6 +795,7 @@ def sync_explore_visuals_to_lark(
         return conflict
     results: dict[str, Any] = {}
     stage_readback_targets: list[tuple[dict[str, Any], str]] = []
+    readback_host_wait_exhausted = False
     for role in requested_roles:
         if role not in active_roles:
             results[role] = {
@@ -950,15 +895,23 @@ def sync_explore_visuals_to_lark(
                 semantic_digest=role_bundle["source_digest"],
                 display_projection=stage_projection,
                 view_key=f"{role}_stage_{stage_index:02d}",
-                execute=execute,
+                execute=bool(execute and not readback_host_wait_exhausted),
                 runner=runner,
-                defer_readback=execute,
+                defer_readback=bool(execute and not readback_host_wait_exhausted),
             )
+            if execute and readback_host_wait_exhausted:
+                defer_visual_stage_after_host_timeout(stage_result)
             stage_result = dict(stage_result, stage=dict(stage))
             stage_results.append(stage_result)
+            prepublish_readback = stage_result.get("prepublish_readback")
+            if isinstance(prepublish_readback, Mapping) and prepublish_readback.get(
+                "host_wait_exhausted"
+            ):
+                readback_host_wait_exhausted = True
             if (
                 execute
                 and stage_result.get("retryable")
+                and stage_result.get("external_write_performed")
                 and str(stage_sink.get("whiteboard_token") or "").strip()
             ):
                 stage_readback_targets.append(
@@ -1002,6 +955,18 @@ def sync_explore_visuals_to_lark(
             "stages": stage_results,
             "section_commands": section_commands,
             "reconciliation": reconciliation,
+            "reconciled_stage_count": sum(
+                bool(item.get("reconciled_existing_delivery"))
+                for item in stage_results
+            ),
+            "updated_stage_count": sum(
+                bool(item.get("external_write_performed")) for item in stage_results
+            ),
+            "readback_host_wait_exhausted": any(
+                bool((item.get("readback") or {}).get("host_wait_exhausted"))
+                for item in stage_results
+                if isinstance(item.get("readback"), Mapping)
+            ),
         }
     if stage_readback_targets:
         settle_visual_stage_readbacks(
@@ -1025,6 +990,11 @@ def sync_explore_visuals_to_lark(
         "source_revision": bundle["source_revision"],
         "recommended_roles": active_roles,
         "views": results,
+        "readback_host_wait_exhausted": any(
+            bool(view.get("readback_host_wait_exhausted"))
+            for view in results.values()
+            if isinstance(view, Mapping)
+        ),
     }
 
 

--- a/loopx/presentation/sinks/lark/explore_visual_readback.py
+++ b/loopx/presentation/sinks/lark/explore_visual_readback.py
@@ -1,15 +1,18 @@
-"""Small parsing helpers for Explore visual marker readback."""
+"""Explore visual marker readback and idempotent delivery reconciliation."""
 
 from __future__ import annotations
 
+import hashlib
 import json
 import time
+from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from .kanban import CommandRunner, _command_error, _run_command
 
 
 VISUAL_READBACK_RETRY_DELAYS_SECONDS = (0.25, 0.5, 1.0, 2.0, 4.0)
+VISUAL_READBACK_COMMAND_TIMEOUT_SECONDS = 10.0
 
 
 def whiteboard_raw_texts(payload: Any) -> list[str]:
@@ -58,6 +61,7 @@ def readback_visual_delivery_marker(
     marker: str,
     runner: CommandRunner,
     retry_delays: Sequence[float] | None = None,
+    command_timeout_seconds: float | None = VISUAL_READBACK_COMMAND_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
     command = [
         cli_bin,
@@ -82,25 +86,38 @@ def readback_visual_delivery_marker(
         else retry_delays
     )
     for attempt_index in range(len(effective_retry_delays) + 1):
-        result = _run_command(command, execute=True, runner=runner)
+        result = _run_command(
+            command,
+            execute=True,
+            runner=runner,
+            timeout_seconds=command_timeout_seconds,
+        )
         texts = whiteboard_raw_texts(result.get("json"))
         marker_observed = marker in texts
         error = structured_command_error(result)
         error_code = error.get("code")
-        is_retryable = is_retryable_marker_readback_error(
-            error_code=error_code,
-            error_message=str(error.get("message") or ""),
-        ) or bool(result.get("ok") and not marker_observed)
+        is_retryable = (
+            bool(result.get("timed_out"))
+            or is_retryable_marker_readback_error(
+                error_code=error_code,
+                error_message=str(error.get("message") or ""),
+            )
+            or bool(result.get("ok") and not marker_observed)
+        )
         attempts.append(
             {
                 "attempt": attempt_index + 1,
                 "ok": bool(result.get("ok")),
                 "marker_observed": marker_observed,
                 "error_code": error_code,
+                "timed_out": bool(result.get("timed_out")),
                 "retryable": is_retryable,
             }
         )
-        if marker_observed or not is_retryable:
+        # A host timeout already consumed the bounded wait for this batch.
+        # Retrying here would multiply that wait by the visibility schedule
+        # and can again stall the whole refresh.
+        if marker_observed or result.get("timed_out") or not is_retryable:
             break
         if attempt_index < len(effective_retry_delays):
             time.sleep(effective_retry_delays[attempt_index])
@@ -130,6 +147,7 @@ def readback_visual_delivery_marker(
         "retryable": bool(
             not marker_observed and attempts and attempts[-1].get("retryable")
         ),
+        "host_wait_exhausted": bool(result.get("timed_out")),
         "command": command_receipt,
         "error": (
             None
@@ -138,6 +156,145 @@ def readback_visual_delivery_marker(
             if not result.get("ok")
             else "remote whiteboard raw nodes do not contain the expected delivery marker"
         ),
+    }
+
+
+def publish_visual_with_readback(
+    *,
+    cli_bin: str,
+    identity: str,
+    whiteboard_token: str,
+    marker: str,
+    command: list[str],
+    published_source: str,
+    source_path: Path,
+    execute: bool,
+    runner: CommandRunner,
+    defer_readback: bool,
+) -> dict[str, Any]:
+    """Reconcile a deterministic marker, publish once, then verify delivery."""
+
+    prepublish_readback = None
+    reconciled_existing_delivery = False
+    prepublish_readback_blocked = False
+    if execute:
+        prepublish_readback = readback_visual_delivery_marker(
+            cli_bin=cli_bin,
+            identity=identity,
+            whiteboard_token=whiteboard_token,
+            marker=marker,
+            runner=runner,
+            retry_delays=(),
+        )
+        prepublish_command = prepublish_readback.get("command")
+        prepublish_command = (
+            prepublish_command if isinstance(prepublish_command, Mapping) else {}
+        )
+        reconciled_existing_delivery = bool(prepublish_readback.get("verified"))
+        prepublish_readback_blocked = bool(
+            not reconciled_existing_delivery and not prepublish_command.get("ok")
+        )
+    if not execute:
+        result = _run_command(command, execute=False, runner=runner)
+        publish_attempts = [result]
+    elif reconciled_existing_delivery or prepublish_readback_blocked:
+        result = _run_command(command, execute=False, runner=runner)
+        publish_attempts = []
+    else:
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_text(published_source, encoding="utf-8")
+        try:
+            result = _run_command(
+                command,
+                execute=True,
+                runner=runner,
+                cwd=source_path.parent,
+            )
+            publish_attempts = [result]
+            error = structured_command_error(result)
+            if (
+                not result.get("ok")
+                and error.get("code") == 2891001
+                and "not iterable" in str(error.get("message") or "")
+            ):
+                retry_command = list(command)
+                token_index = retry_command.index("--idempotent-token") + 1
+                retry_material = (
+                    f"{retry_command[token_index]}:{time.time_ns()}".encode("utf-8")
+                )
+                retry_command[token_index] = (
+                    "loopx-retry-" + hashlib.sha256(retry_material).hexdigest()[:32]
+                )
+                result = _run_command(
+                    retry_command,
+                    execute=True,
+                    runner=runner,
+                    cwd=source_path.parent,
+                )
+                publish_attempts.append(result)
+        finally:
+            source_path.unlink(missing_ok=True)
+    readback_deferred = bool(
+        execute
+        and not reconciled_existing_delivery
+        and not prepublish_readback_blocked
+        and result.get("ok")
+        and marker
+        and defer_readback
+    )
+    readback: dict[str, Any] = dict(prepublish_readback or {}) if (
+        reconciled_existing_delivery or prepublish_readback_blocked
+    ) else {
+        "ok": not readback_deferred,
+        "schema_version": "loopx_lark_explore_visual_readback_v0",
+        "performed": False,
+        "verified": False,
+        "source": (
+            "not_required"
+            if not marker
+            else "deferred_to_batch"
+            if readback_deferred
+            else "would_query_whiteboard_raw_nodes"
+        ),
+        "expected_marker": marker,
+        "observed_marker": None,
+        "retryable": readback_deferred,
+        "error": None,
+    }
+    if (
+        execute
+        and not reconciled_existing_delivery
+        and not prepublish_readback_blocked
+        and result.get("ok")
+        and marker
+        and not defer_readback
+    ):
+        readback = readback_visual_delivery_marker(
+            cli_bin=cli_bin,
+            identity=identity,
+            whiteboard_token=whiteboard_token,
+            marker=marker,
+            runner=runner,
+        )
+    delivery_ok = bool(
+        not prepublish_readback_blocked
+        and result.get("ok")
+        and (not marker or readback.get("ok"))
+    )
+    retryable = bool(
+        execute and result.get("ok") and marker and readback.get("retryable")
+    )
+    return {
+        "ok": delivery_ok,
+        "retryable": retryable,
+        "command": result,
+        "publish_attempts": publish_attempts,
+        "readback": readback,
+        "external_write_performed": any(
+            bool(item.get("executed")) for item in publish_attempts
+        ),
+        "reconciled_existing_delivery": reconciled_existing_delivery,
+        "prepublish_readback": prepublish_readback,
     }
 
 
@@ -184,6 +341,42 @@ def _apply_stage_readback(
     )
 
 
+def defer_visual_stage_after_host_timeout(stage_result: dict[str, Any]) -> None:
+    """Leave a retryable receipt without issuing another remote stage call."""
+
+    readback = stage_result.get("readback")
+    readback = readback if isinstance(readback, Mapping) else {}
+    error = (
+        "visual marker readback deferred after the bounded batch host wait "
+        "was exhausted"
+    )
+    stage_result.update(
+        {
+            "ok": False,
+            "status": "readback_deferred_after_timeout",
+            "execute": True,
+            "published": False,
+            "external_write_performed": False,
+            "retryable": True,
+            "required_action": (
+                "reconcile Explore visual markers after the bounded host "
+                "readback timeout; do not repeat the full publish"
+            ),
+            "readback": {
+                **readback,
+                "ok": False,
+                "performed": False,
+                "verified": False,
+                "source": "batch_host_wait_exhausted",
+                "retryable": True,
+                "host_wait_exhausted": True,
+                "error": error,
+            },
+            "error": error,
+        }
+    )
+
+
 def settle_visual_stage_readbacks(
     *,
     cli_bin: str,
@@ -191,6 +384,7 @@ def settle_visual_stage_readbacks(
     stage_targets: Sequence[tuple[dict[str, Any], str]],
     runner: CommandRunner,
     retry_delays: Sequence[float] | None = None,
+    command_timeout_seconds: float | None = VISUAL_READBACK_COMMAND_TIMEOUT_SECONDS,
 ) -> None:
     """Verify every published stage within one shared settling window."""
 
@@ -202,7 +396,7 @@ def settle_visual_stage_readbacks(
     pending = list(stage_targets)
     for attempt_index in range(len(effective_retry_delays) + 1):
         next_pending: list[tuple[dict[str, Any], str]] = []
-        for stage_result, whiteboard_token in pending:
+        for target_index, (stage_result, whiteboard_token) in enumerate(pending):
             previous = stage_result.get("readback")
             previous = previous if isinstance(previous, Mapping) else {}
             readback = readback_visual_delivery_marker(
@@ -212,11 +406,45 @@ def settle_visual_stage_readbacks(
                 marker=str(previous.get("expected_marker") or ""),
                 runner=runner,
                 retry_delays=(),
+                command_timeout_seconds=command_timeout_seconds,
             )
             merged = _merge_readback_attempts(previous, readback)
             _apply_stage_readback(stage_result, merged)
             if merged.get("retryable"):
                 next_pending.append((stage_result, whiteboard_token))
+            if merged.get("host_wait_exhausted"):
+                for deferred_result, deferred_token in pending[target_index + 1 :]:
+                    deferred_previous = deferred_result.get("readback")
+                    deferred_previous = (
+                        deferred_previous
+                        if isinstance(deferred_previous, Mapping)
+                        else {}
+                    )
+                    deferred = _merge_readback_attempts(
+                        deferred_previous,
+                        {
+                            "ok": False,
+                            "schema_version": "loopx_lark_explore_visual_readback_v0",
+                            "performed": False,
+                            "verified": False,
+                            "source": "batch_host_wait_exhausted",
+                            "expected_marker": str(
+                                deferred_previous.get("expected_marker") or ""
+                            ),
+                            "observed_marker": None,
+                            "remote_text_node_count": 0,
+                            "attempts": [],
+                            "retryable": True,
+                            "host_wait_exhausted": True,
+                            "error": (
+                                "visual marker readback deferred after the bounded "
+                                "batch host wait was exhausted"
+                            ),
+                        },
+                    )
+                    _apply_stage_readback(deferred_result, deferred)
+                    next_pending.append((deferred_result, deferred_token))
+                return
         pending = next_pending
         if not pending:
             break

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
 
 import pytest
 
@@ -993,7 +994,7 @@ def test_stage_svg_visual_publish_preserves_lane_source_and_remote_marker(
         runner=runner,
     )
 
-    assert len(calls) == 2
+    assert len(calls) == 3
     assert synced["ok"] is True
     assert synced["board_style"] == "semantic_lane_columns"
     assert synced["renderer"] == "stage_svg"
@@ -1057,13 +1058,105 @@ def test_mermaid_visual_publish_reads_back_remote_delivery_marker(tmp_path) -> N
         runner=runner,
     )
 
-    assert len(calls) == 2
+    assert len(calls) == 3
     assert synced["ok"] is True
     assert synced["status"] == "published"
     assert synced["published"] is True
     assert synced["readback"]["performed"] is True
     assert synced["readback"]["verified"] is True
     assert synced["readback"]["observed_marker"] == published_marker
+
+
+def test_visual_publish_reconciles_existing_marker_without_duplicate_update(
+    tmp_path,
+) -> None:
+    projection = _complex_projection()
+    config = LarkExploreConfig(base_token="PUBLIC_FIXTURE_BASE")
+    bundle = build_explore_presentation_bundle(projection)
+    sink = {
+        "whiteboard_token": "wb_executive_fixture",
+        "view_role": "executive",
+        "renderer": "mermaid",
+    }
+    preview = sync_explore_visual_to_lark(
+        config,
+        projection=projection,
+        visual_sink=sink,
+        config_path=tmp_path / "lark-explore.json",
+        semantic_digest=bundle["source_digest"],
+        display_projection=bundle["executive"],
+        view_key="executive",
+    )
+    marker = preview["readback"]["expected_marker"]
+    calls: list[list[str]] = []
+
+    def runner(args, _cwd, timeout):
+        calls.append(args)
+        assert timeout == 10.0
+        assert "+query" in args, args
+        return {
+            "returncode": 0,
+            "stdout": json.dumps(
+                {"ok": True, "data": {"nodes": [{"text": {"text": marker}}]}}
+            ),
+            "stderr": "",
+        }
+
+    synced = sync_explore_visual_to_lark(
+        config,
+        projection=projection,
+        visual_sink=sink,
+        config_path=tmp_path / "lark-explore.json",
+        semantic_digest=bundle["source_digest"],
+        display_projection=bundle["executive"],
+        view_key="executive",
+        execute=True,
+        runner=runner,
+    )
+
+    assert len(calls) == 1
+    assert synced["ok"] is True
+    assert synced["published"] is True
+    assert synced["reconciled_existing_delivery"] is True
+    assert synced["external_write_performed"] is False
+    assert synced["publish_attempt_count"] == 0
+
+
+def test_visual_publish_timeout_blocks_update_without_repeating_host_wait(
+    tmp_path,
+) -> None:
+    projection = _complex_projection()
+    config = LarkExploreConfig(base_token="PUBLIC_FIXTURE_BASE")
+    bundle = build_explore_presentation_bundle(projection)
+    observed_timeouts: list[float | None] = []
+
+    def runner(args, _cwd, timeout):
+        assert "+query" in args, args
+        observed_timeouts.append(timeout)
+        raise subprocess.TimeoutExpired(args, timeout)
+
+    synced = sync_explore_visual_to_lark(
+        config,
+        projection=projection,
+        visual_sink={
+            "whiteboard_token": "wb_executive_fixture",
+            "view_role": "executive",
+            "renderer": "mermaid",
+        },
+        config_path=tmp_path / "lark-explore.json",
+        semantic_digest=bundle["source_digest"],
+        display_projection=bundle["executive"],
+        view_key="executive",
+        execute=True,
+        runner=runner,
+    )
+
+    assert observed_timeouts == [10.0]
+    assert synced["ok"] is False
+    assert synced["external_write_performed"] is False
+    assert synced["publish_attempt_count"] == 0
+    assert synced["prepublish_readback"]["host_wait_exhausted"] is True
+    assert synced["prepublish_readback"]["attempt_count"] == 1
 
 
 def test_mermaid_visual_publish_retries_idempotency_replay_error(tmp_path) -> None:
@@ -1145,7 +1238,7 @@ def test_mermaid_visual_readback_retries_lark_doc_applying(
     query_count = 0
     delays: list[float] = []
     monkeypatch.setattr(
-        "loopx.presentation.sinks.lark.explore_results.time.sleep",
+        "loopx.presentation.sinks.lark.explore_visual_readback.time.sleep",
         delays.append,
     )
 
@@ -1169,7 +1262,7 @@ def test_mermaid_visual_readback_retries_lark_doc_applying(
                         "message": "doc is applying; doc data is not ready",
                     },
                 }
-                if query_count == 1
+                if query_count == 2
                 else {
                     "ok": True,
                     "data": {"nodes": [{"text": {"text": published_marker}}]},
@@ -1216,7 +1309,7 @@ def test_mermaid_visual_readback_retries_until_remote_marker_is_visible(
     query_count = 0
     delays: list[float] = []
     monkeypatch.setattr(
-        "loopx.presentation.sinks.lark.explore_results.time.sleep",
+        "loopx.presentation.sinks.lark.explore_visual_readback.time.sleep",
         delays.append,
     )
 
@@ -1240,7 +1333,7 @@ def test_mermaid_visual_readback_retries_until_remote_marker_is_visible(
                             "text": {
                                 "text": (
                                     "stale visual"
-                                    if query_count == 1
+                                    if query_count <= 2
                                     else published_marker
                                 )
                             }
@@ -1286,7 +1379,7 @@ def test_mermaid_visual_publish_fails_closed_when_remote_marker_is_missing(
     config = LarkExploreConfig(base_token="PUBLIC_FIXTURE_BASE")
     bundle = build_explore_presentation_bundle(projection)
     monkeypatch.setattr(
-        "loopx.presentation.sinks.lark.explore_results.time.sleep",
+        "loopx.presentation.sinks.lark.explore_visual_readback.time.sleep",
         lambda _delay: None,
     )
 
@@ -1404,7 +1497,9 @@ def test_visual_sync_creates_one_document_section_and_board_per_missing_stage(
             token = args[args.index("--whiteboard-token") + 1]
             payload = {
                 "ok": True,
-                "data": {"nodes": [{"text": {"text": published_markers[token]}}]},
+                "data": {
+                    "nodes": [{"text": {"text": published_markers.get(token, "")}}]
+                },
             }
         return {
             "returncode": 0,
@@ -1525,7 +1620,9 @@ def test_stage_document_recreates_configured_board_missing_from_document(
             token = args[args.index("--whiteboard-token") + 1]
             payload = {
                 "ok": True,
-                "data": {"nodes": [{"text": {"text": published_markers[token]}}]},
+                "data": {
+                    "nodes": [{"text": {"text": published_markers.get(token, "")}}]
+                },
             }
         return {
             "returncode": 0,
@@ -1662,7 +1759,9 @@ def test_stage_document_reconciliation_removes_all_stale_duplicate_sections(
             token = args[args.index("--whiteboard-token") + 1]
             payload = {
                 "ok": True,
-                "data": {"nodes": [{"text": {"text": published_markers[token]}}]},
+                "data": {
+                    "nodes": [{"text": {"text": published_markers.get(token, "")}}]
+                },
             }
         return {
             "returncode": 0,


### PR DESCRIPTION
## Summary
- bound each visual marker query and stop the remaining stage batch after a host timeout
- reconcile the deterministic delivery marker before publishing, so interrupted runs do not repeat remote writes
- move publish/readback transaction ownership into the visual readback module and document the retryable receipt contract

## Validation
-  (37 passed)
- 
- 
- 
- {
  "ok": true,
  "schema_version": "loopx_premerge_validation_gate_v0",
  "repo_root": "/private/tmp/loopx-explore-visual-readback-20260717",
  "base_ref": "origin/main",
  "tier": "standard",
  "dry_run": false,
  "executes_checks": true,
  "writes_evidence": false,
  "creates_runtime_contract": false,
  "changed_files": [
    "docs/capabilities/explore/README.md",
    "examples/explore-result-layer-smoke.py",
    "examples/explore-visual-cross-role-integrity-smoke.py",
    "loopx/presentation/sinks/lark/explore_results.py",
    "loopx/presentation/sinks/lark/explore_visual_readback.py",
    "tests/test_explore_presentation_views.py"
  ],
  "classification": {
    "changed_files": [
      "docs/capabilities/explore/README.md",
      "examples/explore-result-layer-smoke.py",
      "examples/explore-visual-cross-role-integrity-smoke.py",
      "loopx/presentation/sinks/lark/explore_results.py",
      "loopx/presentation/sinks/lark/explore_visual_readback.py",
      "tests/test_explore_presentation_views.py"
    ],
    "changed_file_count": 6,
    "python_files": [
      "examples/explore-result-layer-smoke.py",
      "examples/explore-visual-cross-role-integrity-smoke.py",
      "loopx/presentation/sinks/lark/explore_results.py",
      "loopx/presentation/sinks/lark/explore_visual_readback.py",
      "tests/test_explore_presentation_views.py"
    ],
    "surfaces": [
      "docs_project_content",
      "public_boundary",
      "python"
    ],
    "risk_profiles": [
      "docs-project-content-ops"
    ],
    "manual_holds": [],
    "public_boundary_scan_recommended": true
  },
  "direct_checks": [
    {
      "id": "diff_check_committed",
      "kind": "direct_command",
      "argv": [
        "git",
        "diff",
        "--check",
        "origin/main...HEAD"
      ],
      "display_argv": [
        "git",
        "diff",
        "--check",
        "origin/main...HEAD"
      ],
      "command": "git diff --check origin/main...HEAD",
      "reason": "checks committed PR diff whitespace/conflict-marker hygiene",
      "status": "passed",
      "ok": true,
      "check_index": 1,
      "check_count": 3,
      "returncode": 0,
      "duration_seconds": 0.02,
      "stdout_tail": "",
      "stderr_tail": ""
    },
    {
      "id": "diff_check_staged",
      "kind": "direct_command",
      "argv": [
        "git",
        "diff",
        "--cached",
        "--check"
      ],
      "display_argv": [
        "git",
        "diff",
        "--cached",
        "--check"
      ],
      "command": "git diff --cached --check",
      "reason": "checks staged changes not yet committed",
      "status": "passed",
      "ok": true,
      "check_index": 2,
      "check_count": 3,
      "returncode": 0,
      "duration_seconds": 0.016,
      "stdout_tail": "",
      "stderr_tail": ""
    },
    {
      "id": "diff_check_unstaged",
      "kind": "direct_command",
      "argv": [
        "git",
        "diff",
        "--check"
      ],
      "display_argv": [
        "git",
        "diff",
        "--check"
      ],
      "command": "git diff --check",
      "reason": "checks unstaged changes not yet committed",
      "status": "passed",
      "ok": true,
      "check_index": 3,
      "check_count": 3,
      "returncode": 0,
      "duration_seconds": 0.016,
      "stdout_tail": "",
      "stderr_tail": ""
    },
    {
      "id": "changed_python_py_compile",
      "kind": "direct_command",
      "argv": [
        "/Library/Developer/CommandLineTools/usr/bin/python3",
        "-m",
        "py_compile",
        "examples/explore-result-layer-smoke.py",
        "examples/explore-visual-cross-role-integrity-smoke.py",
        "loopx/presentation/sinks/lark/explore_results.py",
        "loopx/presentation/sinks/lark/explore_visual_readback.py",
        "tests/test_explore_presentation_views.py"
      ],
      "display_argv": [
        "python3",
        "-m",
        "py_compile",
        "examples/explore-result-layer-smoke.py",
        "examples/explore-visual-cross-role-integrity-smoke.py",
        "loopx/presentation/sinks/lark/explore_results.py",
        "loopx/presentation/sinks/lark/explore_visual_readback.py",
        "tests/test_explore_presentation_views.py"
      ],
      "command": "python3 -m py_compile examples/explore-result-layer-smoke.py examples/explore-visual-cross-role-integrity-smoke.py loopx/presentation/sinks/lark/explore_results.py loopx/presentation/sinks/lark/explore_visual_readback.py tests/test_explore_presentation_views.py",
      "reason": "compiles changed Python files that still exist in the worktree",
      "status": "passed",
      "ok": true,
      "check_index": 1,
      "check_count": 1,
      "returncode": 0,
      "duration_seconds": 0.09,
      "stdout_tail": "",
      "stderr_tail": ""
    }
  ],
  "catalog_run": {
    "ok": true,
    "schema_version": "canary_smoke_suite_run_v0",
    "suite": "catalog-plan",
    "repo_root": "/private/tmp/loopx-explore-visual-readback-20260717",
    "dry_run": false,
    "executes_checks": true,
    "writes_evidence": false,
    "creates_runtime_contract": false,
    "timeout_seconds": 120.0,
    "fail_fast": false,
    "parallel_jobs": 1,
    "effective_parallel_jobs": 1,
    "serial_check_count": 0,
    "side_effect_guard": {
      "schema_version": "canary_smoke_suite_side_effect_guard_v0",
      "tracked_side_effects_allowed": false,
      "enforced": true,
      "enforcement_reason": "tracked_side_effect_guard_active",
      "clean_start": true,
      "tracked_before": [],
      "tracked_side_effects": [],
      "auto_restored": false,
      "git_status_ok": true,
      "git_status_final_ok": true,
      "tracked_after": []
    },
    "offset": 0,
    "limit": 9,
    "matched_check_count": 10,
    "selected_check_count": 9,
    "executed_check_count": 9,
    "failure_count": 0,
    "git_required_skip_count": 0,
    "timeout_count": 0,
    "tracked_side_effect_failure_count": 0,
    "unsafe_command_count": 0,
    "warning_count": 0,
    "warnings": [],
    "selection_inputs": {
      "suite": "catalog-plan",
      "modules": [],
      "exclude_modules": [],
      "scripts": [],
      "changed_files": [
        "docs/capabilities/explore/README.md",
        "examples/explore-result-layer-smoke.py",
        "examples/explore-visual-cross-role-integrity-smoke.py",
        "loopx/presentation/sinks/lark/explore_results.py",
        "loopx/presentation/sinks/lark/explore_visual_readback.py",
        "tests/test_explore_presentation_views.py"
      ],
      "surfaces": [],
      "families": [],
      "profiles": [],
      "smoke_profiles": [],
      "catalog_profiles": [],
      "profile_expansions": [],
      "include_deep_checks": false,
      "max_checks_per_family": 3,
      "max_checks_per_profile": 4,
      "offset": 0,
      "limit": 9,
      "parallel_jobs": 1,
      "effective_parallel_jobs": 1,
      "serial_check_count": 0
    },
    "catalog_plan": {
      "schema_version": "catalog_canary_plan_v0",
      "planned_check_count": 10,
      "profiles": [],
      "domain_profiles": [
        {
          "schema_version": "catalog_canary_domain_profile_v0",
          "id": "repo-architecture-budget",
          "title": "Repository architecture budget",
          "purpose": "Keep Python source files below a default line budget, with explicit legacy allowlist entries for oversized modules that need staged refactors.",
          "catalog_families": [
            "Planning Governance",
            "State And Boundary"
          ],
          "trigger_hints": [
            "architecture",
            "architecture budget",
            "file length",
            "line budget",
            "large file",
            "mega-file",
            "refactor",
            "quota.py",
            "status.py",
            "terminal_bench.py",
            "skillsbench",
            "loopx/",
            "examples/",
            "scripts/"
          ],
          "checks": [
            {
              "command": "python3 examples/control_plane/repo-python-line-budget-smoke.py",
              "tier": "default",
              "reason": "fails when a Python source file grows beyond the default limit or its current legacy allowlist budget"
            }
          ],
          "deep_checks_available": false,
          "deep_checks_included": false,
          "selection_reasons": [
            "selector matches `loopx/`",
            "selector matches `examples/`"
          ]
        },
        {
          "schema_version": "catalog_canary_domain_profile_v0",
          "id": "product-entry-workflows",
          "title": "Product entry workflows",
          "purpose": "Check user-facing product entry routes for issue-fix, content-ops, update notes, and cross-runtime demo surfaces without reading private sources.",
          "catalog_families": [
            "Human Decision",
            "Evidence Lifecycle",
            "State And Boundary",
            "Work Routing"
          ],
          "trigger_hints": [
            "product-entry",
            "product entry",
            "issue-fix",
            "issue fix",
            "content-ops",
            "content ops",
            "update-note",
            "update note",
            "update-notes",
            "update notes",
            "cross-runtime",
            "impl-review",
            "claude implements",
            "codex reviews",
            "README.md",
            "docs/product/cross-runtime-impl-review-demo.md",
            "docs/capabilities/issue-fix",
            "docs/capabilities/content-ops",
            "docs/update-notes",
            "loopx/capabilities/issue_fix",
            "loopx/capabilities/content_ops",
            "loopx/cli_commands/issue_fix",
            "loopx/cli_commands/content_ops",
            "scripts/update_notes_release_job.py"
          ],
          "checks": [
            {
              "command": "python3 examples/issue-fix-workflow-contract-smoke.py",
              "tier": "default",
              "reason": "guards the public issue-fix workflow contract, gated metadata preview, and todo writeback preview"
            },
            {
              "command": "python3 examples/issue-fix-repository-context-smoke.py",
              "tier": "default",
              "reason": "guards provenance-aware repository context, advisory experts, and feasibility domain-state integration"
            },
            {
              "command": "python3 examples/issue-fix-feasibility-smoke.py",
              "tier": "default",
              "reason": "guards single-route feasibility decisions and compact issue_fix domain-state writeback"
            },
            {
              "command": "python3 examples/issue-fix-pr-lifecycle-smoke.py",
              "tier": "default",
              "reason": "guards PR lifecycle transitions, terminal-state precedence, and issue_fix domain-state writeback"
            }
          ],
          "deep_checks_available": true,
          "deep_checks_included": false,
          "selection_reasons": [
            "selector matches `README.md`"
          ]
        },
        {
          "schema_version": "catalog_canary_domain_profile_v0",
          "id": "frontstage-rollout",
          "title": "Frontstage rollout projection",
          "purpose": "Check public frontstage/showcase projection data before visual browser smokes.",
          "catalog_families": [
            "State And Boundary",
            "Evidence Lifecycle",
            "Human Decision"
          ],
          "trigger_hints": [
            "frontstage",
            "showcase",
            "rollout",
            "dashboard",
            "visual"
          ],
          "checks": [
            {
              "command": "python3 examples/frontstage-rollout-projections-fixture-smoke.py",
              "tier": "default",
              "reason": "checks reusable frontstage rollout projection fixtures"
            },
            {
              "command": "python3 examples/showcase-animation-prototype-smoke.py",
              "tier": "default",
              "reason": "guards showcase animation projection data without a browser"
            }
          ],
          "deep_checks_available": true,
          "deep_checks_included": false,
          "selection_reasons": [
            "selector matches `visual`"
          ]
        },
        {
          "schema_version": "catalog_canary_domain_profile_v0",
          "id": "explore-harness",
          "title": "Explore Harness configuration and runtime",
          "purpose": "Check the deny-by-default goal boundary, planner agreement, resumable runtime state, and per-item failure isolation.",
          "catalog_families": [
            "Work Routing",
            "State And Boundary",
            "Evidence Lifecycle"
          ],
          "trigger_hints": [
            "explore harness",
            "explore-harness",
            "harness_runtime",
            "harness_checkpoint",
            "explore_harness",
            "loopx/capabilities/explore",
            "docs/capabilities/explore",
            "examples/explore-configure-goal-smoke.py",
            "examples/explore-harness-runtime-resume-smoke.py"
          ],
          "checks": [
            {
              "command": "python3 examples/explore-configure-goal-smoke.py",
              "tier": "default",
              "reason": "guards configure-goal opt-in and quota/planner boundary agreement"
            },
            {
              "command": "python3 examples/explore-harness-runtime-resume-smoke.py",
              "tier": "default",
              "reason": "guards validated resume state, novelty/variant restoration, and item failure isolation"
            },
            {
              "command": "python3 examples/explore-worker-plan-gate-smoke.py",
              "tier": "default",
              "reason": "guards profile pinning, analysis-only planning, and lane-width authority"
            }
          ],
          "deep_checks_available": true,
          "deep_checks_included": false,
          "selection_reasons": [
            "selector matches `docs/capabilities/explore`"
          ]
        }
      ]
    },
    "selected_checks": [
      {
        "source": "domain_profile",
        "profile_id": "repo-architecture-budget",
        "profile_title": "Repository architecture budget",
        "tier": "default",
        "command": "python3 examples/control_plane/repo-python-line-budget-smoke.py",
        "reason": "fails when a Python source file grows beyond the default limit or its current legacy allowlist budget",
        "normalized": {
          "ok": true,
          "command": "python3 examples/control_plane/repo-python-line-budget-smoke.py",
          "argv": [
            "/Library/Developer/CommandLineTools/usr/bin/python3",
            "/private/tmp/loopx-explore-visual-readback-20260717/examples/control_plane/repo-python-line-budget-smoke.py"
          ],
          "display_argv": [
            "python3",
            "examples/control_plane/repo-python-line-budget-smoke.py"
          ],
          "injected_args": [],
          "script": "examples/control_plane/repo-python-line-budget-smoke.py"
        },
        "check_index": 1,
        "check_count": 9,
        "status": "passed",
        "ok": true,
        "returncode": 0,
        "duration_seconds": 0.58,
        "stdout_tail": "repo-python-line-budget-smoke: ok (1280 tracked Python files, default_max=2000, legacy_budgets=19, changed_python_files=5, existing_over_budget=0, strict=False)\n",
        "stderr_tail": ""
      },
      {
        "source": "domain_profile",
        "profile_id": "product-entry-workflows",
        "profile_title": "Product entry workflows",
        "tier": "default",
        "command": "python3 examples/issue-fix-workflow-contract-smoke.py",
        "reason": "guards the public issue-fix workflow contract, gated metadata preview, and todo writeback preview",
        "normalized": {
          "ok": true,
          "command": "python3 examples/issue-fix-workflow-contract-smoke.py",
          "argv": [
            "/Library/Developer/CommandLineTools/usr/bin/python3",
            "/private/tmp/loopx-explore-visual-readback-20260717/examples/issue-fix-workflow-contract-smoke.py"
          ],
          "display_argv": [
            "python3",
            "examples/issue-fix-workflow-contract-smoke.py"
          ],
          "injected_args": [],
          "script": "examples/issue-fix-workflow-contract-smoke.py"
        },
        "check_index": 2,
        "check_count": 9,
        "status": "passed",
        "ok": true,
        "returncode": 0,
        "duration_seconds": 0.127,
        "stdout_tail": "issue-fix-workflow-contract-smoke: ok\n",
        "stderr_tail": ""
      },
      {
        "source": "domain_profile",
        "profile_id": "product-entry-workflows",
        "profile_title": "Product entry workflows",
        "tier": "default",
        "command": "python3 examples/issue-fix-repository-context-smoke.py",
        "reason": "guards provenance-aware repository context, advisory experts, and feasibility domain-state integration",
        "normalized": {
          "ok": true,
          "command": "python3 examples/issue-fix-repository-context-smoke.py",
          "argv": [
            "/Library/Developer/CommandLineTools/usr/bin/python3",
            "/private/tmp/loopx-explore-visual-readback-20260717/examples/issue-fix-repository-context-smoke.py"
          ],
          "display_argv": [
            "python3",
            "examples/issue-fix-repository-context-smoke.py"
          ],
          "injected_args": [],
          "script": "examples/issue-fix-repository-context-smoke.py"
        },
        "check_index": 3,
        "check_count": 9,
        "status": "passed",
        "ok": true,
        "returncode": 0,
        "duration_seconds": 0.571,
        "stdout_tail": "issue-fix-repository-context-smoke: ok\n",
        "stderr_tail": ""
      },
      {
        "source": "domain_profile",
        "profile_id": "product-entry-workflows",
        "profile_title": "Product entry workflows",
        "tier": "default",
        "command": "python3 examples/issue-fix-feasibility-smoke.py",
        "reason": "guards single-route feasibility decisions and compact issue_fix domain-state writeback",
        "normalized": {
          "ok": true,
          "command": "python3 examples/issue-fix-feasibility-smoke.py",
          "argv": [
            "/Library/Developer/CommandLineTools/usr/bin/python3",
            "/private/tmp/loopx-explore-visual-readback-20260717/examples/issue-fix-feasibility-smoke.py"
          ],
          "display_argv": [
            "python3",
            "examples/issue-fix-feasibility-smoke.py"
          ],
          "injected_args": [],
          "script": "examples/issue-fix-feasibility-smoke.py"
        },
        "check_index": 4,
        "check_count": 9,
        "status": "passed",
        "ok": true,
        "returncode": 0,
        "duration_seconds": 1.261,
        "stdout_tail": "issue-fix-feasibility-smoke: ok\n",
        "stderr_tail": ""
      },
      {
        "source": "domain_profile",
        "profile_id": "product-entry-workflows",
        "profile_title": "Product entry workflows",
        "tier": "default",
        "command": "python3 examples/issue-fix-pr-lifecycle-smoke.py",
        "reason": "guards PR lifecycle transitions, terminal-state precedence, and issue_fix domain-state writeback",
        "normalized": {
          "ok": true,
          "command": "python3 examples/issue-fix-pr-lifecycle-smoke.py",
          "argv": [
            "/Library/Developer/CommandLineTools/usr/bin/python3",
            "/private/tmp/loopx-explore-visual-readback-20260717/examples/issue-fix-pr-lifecycle-smoke.py"
          ],
          "display_argv": [
            "python3",
            "examples/issue-fix-pr-lifecycle-smoke.py"
          ],
          "injected_args": [],
          "script": "examples/issue-fix-pr-lifecycle-smoke.py"
        },
        "check_index": 5,
        "check_count": 9,
        "status": "passed",
        "ok": true,
        "returncode": 0,
        "duration_seconds": 5.055,
        "stdout_tail": "issue-fix-pr-lifecycle-smoke: ok\n",
        "stderr_tail": ""
      },
      {
        "source": "domain_profile",
        "profile_id": "frontstage-rollout",
        "profile_title": "Frontstage rollout projection",
        "tier": "default",
        "command": "python3 examples/frontstage-rollout-projections-fixture-smoke.py",
        "reason": "checks reusable frontstage rollout projection fixtures",
        "normalized": {
          "ok": true,
          "command": "python3 examples/frontstage-rollout-projections-fixture-smoke.py",
          "argv": [
            "/Library/Developer/CommandLineTools/usr/bin/python3",
            "/private/tmp/loopx-explore-visual-readback-20260717/examples/frontstage-rollout-projections-fixture-smoke.py"
          ],
          "display_argv": [
            "python3",
            "examples/frontstage-rollout-projections-fixture-smoke.py"
          ],
          "injected_args": [],
          "script": "examples/frontstage-rollout-projections-fixture-smoke.py"
        },
        "check_index": 6,
        "check_count": 9,
        "status": "passed",
        "ok": true,
        "returncode": 0,
        "duration_seconds": 0.066,
        "stdout_tail": "frontstage-rollout-projections fixture smoke ok\n",
        "stderr_tail": ""
      },
      {
        "source": "domain_profile",
        "profile_id": "frontstage-rollout",
        "profile_title": "Frontstage rollout projection",
        "tier": "default",
        "command": "python3 examples/showcase-animation-prototype-smoke.py",
        "reason": "guards showcase animation projection data without a browser",
        "normalized": {
          "ok": true,
          "command": "python3 examples/showcase-animation-prototype-smoke.py",
          "argv": [
            "/Library/Developer/CommandLineTools/usr/bin/python3",
            "/private/tmp/loopx-explore-visual-readback-20260717/examples/showcase-animation-prototype-smoke.py"
          ],
          "display_argv": [
            "python3",
            "examples/showcase-animation-prototype-smoke.py"
          ],
          "injected_args": [],
          "script": "examples/showcase-animation-prototype-smoke.py"
        },
        "check_index": 7,
        "check_count": 9,
        "status": "passed",
        "ok": true,
        "returncode": 0,
        "duration_seconds": 0.112,
        "stdout_tail": "showcase-animation-prototype-smoke ok\n",
        "stderr_tail": ""
      },
      {
        "source": "domain_profile",
        "profile_id": "explore-harness",
        "profile_title": "Explore Harness configuration and runtime",
        "tier": "default",
        "command": "python3 examples/explore-configure-goal-smoke.py",
        "reason": "guards configure-goal opt-in and quota/planner boundary agreement",
        "normalized": {
          "ok": true,
          "command": "python3 examples/explore-configure-goal-smoke.py",
          "argv": [
            "/Library/Developer/CommandLineTools/usr/bin/python3",
            "/private/tmp/loopx-explore-visual-readback-20260717/examples/explore-configure-goal-smoke.py"
          ],
          "display_argv": [
            "python3",
            "examples/explore-configure-goal-smoke.py"
          ],
          "injected_args": [],
          "script": "examples/explore-configure-goal-smoke.py"
        },
        "check_index": 8,
        "check_count": 9,
        "status": "passed",
        "ok": true,
        "returncode": 0,
        "duration_seconds": 12.275,
        "stdout_tail": "explore-configure-goal-smoke ok\n",
        "stderr_tail": ""
      },
      {
        "source": "domain_profile",
        "profile_id": "explore-harness",
        "profile_title": "Explore Harness configuration and runtime",
        "tier": "default",
        "command": "python3 examples/explore-harness-runtime-resume-smoke.py",
        "reason": "guards validated resume state, novelty/variant restoration, and item failure isolation",
        "normalized": {
          "ok": true,
          "command": "python3 examples/explore-harness-runtime-resume-smoke.py",
          "argv": [
            "/Library/Developer/CommandLineTools/usr/bin/python3",
            "/private/tmp/loopx-explore-visual-readback-20260717/examples/explore-harness-runtime-resume-smoke.py"
          ],
          "display_argv": [
            "python3",
            "examples/explore-harness-runtime-resume-smoke.py"
          ],
          "injected_args": [],
          "script": "examples/explore-harness-runtime-resume-smoke.py"
        },
        "check_index": 9,
        "check_count": 9,
        "status": "passed",
        "ok": true,
        "returncode": 0,
        "duration_seconds": 0.359,
        "stdout_tail": "explore-harness-runtime-resume-smoke ok\n",
        "stderr_tail": ""
      }
    ],
    "failures": [],
    "git_required_skips": [],
    "note": "Smoke-suite run executes repository-local public smoke scripts with shell-free argv, per-check timeouts, and continue-on-failure reporting. Use --suite full-public for a full sweep, --module/--script for local development, recognized --profile values for named smoke-suite profiles, or catalog selectors such as --profile for canary-plan modules. Use --offset with --limit to sweep large profiles in stable windows."
  },
  "risk_profile_run": {
    "ok": true,
    "schema_version": "canary_smoke_suite_run_v0",
    "suite": "full-public",
    "repo_root": "/private/tmp/loopx-explore-visual-readback-20260717",
    "dry_run": false,
    "executes_checks": true,
    "writes_evidence": false,
    "creates_runtime_contract": false,
    "timeout_seconds": 120.0,
    "fail_fast": false,
    "parallel_jobs": 1,
    "effective_parallel_jobs": 1,
    "serial_check_count": 0,
    "side_effect_guard": {
      "schema_version": "canary_smoke_suite_side_effect_guard_v0",
      "tracked_side_effects_allowed": false,
      "enforced": true,
      "enforcement_reason": "tracked_side_effect_guard_active",
      "clean_start": true,
      "tracked_before": [],
      "tracked_side_effects": [],
      "auto_restored": false,
      "git_status_ok": true,
      "git_status_final_ok": true,
      "tracked_after": []
    },
    "offset": 0,
    "limit": 8,
    "matched_check_count": 66,
    "selected_check_count": 8,
    "executed_check_count": 8,
    "failure_count": 0,
    "git_required_skip_count": 0,
    "timeout_count": 0,
    "tracked_side_effect_failure_count": 0,
    "unsafe_command_count": 0,
    "warning_count": 0,
    "warnings": [],
    "selection_inputs": {
      "suite": "full-public",
      "modules": [
        "content",
        "content-ops",
        "content_ops",
        "docs",
        "project",
        "update-note",
        "update_notes"
      ],
      "exclude_modules": [
        "agentissue-bench",
        "agents-last-exam",
        "benchmark",
        "skillsbench",
        "swe-marathon",
        "terminal-bench"
      ],
      "scripts": [],
      "changed_files": [],
      "surfaces": [],
      "families": [],
      "profiles": [
        "docs-project-content-ops"
      ],
      "smoke_profiles": [
        "docs-project-content-ops"
      ],
      "catalog_profiles": [],
      "profile_expansions": [
        {
          "profile": "docs-project-content-ops",
          "suite": "full-public",
          "modules": [
            "content",
            "content-ops",
            "content_ops",
            "docs",
            "project",
            "update-note",
            "update_notes"
          ],
          "exclude_modules": [
            "agentissue-bench",
            "agents-last-exam",
            "benchmark",
            "skillsbench",
            "swe-marathon",
            "terminal-bench"
          ],
          "description": "Docs, project lifecycle, and content/update-note operations checks."
        }
      ],
      "include_deep_checks": false,
      "max_checks_per_family": 3,
      "max_checks_per_profile": 3,
      "offset": 0,
      "limit": 8,
      "parallel_jobs": 1,
      "effective_parallel_jobs": 1,
      "serial_check_count": 0
    },
    "catalog_plan": null,
    "selected_checks": [
      {
        "source": "suite",
        "profile_id": "smoke-suite",
        "profile_title": "Smoke suite",
        "tier": "default",
        "command": "python3 examples/cli-project-lifecycle-command-modularization-smoke.py",
        "reason": "tracked public smoke script",
        "normalized": {
          "ok": true,
          "command": "python3 examples/cli-project-lifecycle-command-modularization-smoke.py",
          "argv": [
            "/Library/Developer/CommandLineTools/usr/bin/python3",
            "/private/tmp/loopx-explore-visual-readback-20260717/examples/cli-project-lifecycle-command-modularization-smoke.py"
          ],
          "display_argv": [
            "python3",
            "examples/cli-project-lifecycle-command-modularization-smoke.py"
          ],
          "injected_args": [],
          "script": "examples/cli-project-lifecycle-command-modularization-smoke.py"
        },
        "check_index": 1,
        "check_count": 8,
        "status": "passed",
        "ok": true,
        "returncode": 0,
        "duration_seconds": 4.571,
        "stdout_tail": "cli-project-lifecycle-command-modularization-smoke: ok\n",
        "stderr_tail": ""
      },
      {
        "source": "suite",
        "profile_id": "smoke-suite",
        "profile_title": "Smoke suite",
        "tier": "default",
        "command": "python3 examples/content-ops-chatview-report-smoke.py",
        "reason": "tracked public smoke script",
        "normalized": {
          "ok": true,
          "command": "python3 examples/content-ops-chatview-report-smoke.py",
          "argv": [
            "/Library/Developer/CommandLineTools/usr/bin/python3",
            "/private/tmp/loopx-explore-visual-readback-20260717/examples/content-ops-chatview-report-smoke.py"
          ],
          "display_argv": [
            "python3",
            "examples/content-ops-chatview-report-smoke.py"
          ],
          "injected_args": [],
          "script": "examples/content-ops-chatview-report-smoke.py"
        },
        "check_index": 2,
        "check_count": 8,
        "status": "passed",
        "ok": true,
        "returncode": 0,
        "duration_seconds": 2.892,
        "stdout_tail": "content-ops-chatview-report-smoke: ok\n",
        "stderr_tail": ""
      },
      {
        "source": "suite",
        "profile_id": "smoke-suite",
        "profile_title": "Smoke suite",
        "tier": "default",
        "command": "python3 examples/content-ops-exploration-plan-smoke.py",
        "reason": "tracked public smoke script",
        "normalized": {
          "ok": true,
          "command": "python3 examples/content-ops-exploration-plan-smoke.py",
          "argv": [
            "/Library/Developer/CommandLineTools/usr/bin/python3",
            "/private/tmp/loopx-explore-visual-readback-20260717/examples/content-ops-exploration-plan-smoke.py"
          ],
          "display_argv": [
            "python3",
            "examples/content-ops-exploration-plan-smoke.py"
          ],
          "injected_args": [],
          "script": "examples/content-ops-exploration-plan-smoke.py"
        },
        "check_index": 3,
        "check_count": 8,
        "status": "passed",
        "ok": true,
        "returncode": 0,
        "duration_seconds": 1.765,
        "stdout_tail": "content-ops-exploration-plan-smoke: ok\n",
        "stderr_tail": ""
      },
      {
        "source": "suite",
        "profile_id": "smoke-suite",
        "profile_title": "Smoke suite",
        "tier": "default",
        "command": "python3 examples/content-ops-issue-fix-intake-smoke.py",
        "reason": "tracked public smoke script",
        "normalized": {
          "ok": true,
          "command": "python3 examples/content-ops-issue-fix-intake-smoke.py",
          "argv": [
            "/Library/Developer/CommandLineTools/usr/bin/python3",
            "/private/tmp/loopx-explore-visual-readback-20260717/examples/content-ops-issue-fix-intake-smoke.py"
          ],
          "display_argv": [
            "python3",
            "examples/content-ops-issue-fix-intake-smoke.py"
          ],
          "injected_args": [],
          "script": "examples/content-ops-issue-fix-intake-smoke.py"
        },
        "check_index": 4,
        "check_count": 8,
        "status": "passed",
        "ok": true,
        "returncode": 0,
        "duration_seconds": 1.786,
        "stdout_tail": "content-ops-issue-fix-intake-smoke: ok\n",
        "stderr_tail": ""
      },
      {
        "source": "suite",
        "profile_id": "smoke-suite",
        "profile_title": "Smoke suite",
        "tier": "default",
        "command": "python3 examples/content-ops-issue-fix-metadata-preview-smoke.py",
        "reason": "tracked public smoke script",
        "normalized": {
          "ok": true,
          "command": "python3 examples/content-ops-issue-fix-metadata-preview-smoke.py",
          "argv": [
            "/Library/Developer/CommandLineTools/usr/bin/python3",
            "/private/tmp/loopx-explore-visual-readback-20260717/examples/content-ops-issue-fix-metadata-preview-smoke.py"
          ],
          "display_argv": [
            "python3",
            "examples/content-ops-issue-fix-metadata-preview-smoke.py"
          ],
          "injected_args": [],
          "script": "examples/content-ops-issue-fix-metadata-preview-smoke.py"
        },
        "check_index": 5,
        "check_count": 8,
        "status": "passed",
        "ok": true,
        "returncode": 0,
        "duration_seconds": 4.703,
        "stdout_tail": "content-ops-issue-fix-metadata-preview-smoke: ok\n",
        "stderr_tail": ""
      },
      {
        "source": "suite",
        "profile_id": "smoke-suite",
        "profile_title": "Smoke suite",
        "tier": "default",
        "command": "python3 examples/content-ops-packet-aggregation-smoke.py",
        "reason": "tracked public smoke script",
        "normalized": {
          "ok": true,
          "command": "python3 examples/content-ops-packet-aggregation-smoke.py",
          "argv": [
            "/Library/Developer/CommandLineTools/usr/bin/python3",
            "/private/tmp/loopx-explore-visual-readback-20260717/examples/content-ops-packet-aggregation-smoke.py"
          ],
          "display_argv": [
            "python3",
            "examples/content-ops-packet-aggregation-smoke.py"
          ],
          "injected_args": [],
          "script": "examples/content-ops-packet-aggregation-smoke.py"
        },
        "check_index": 6,
        "check_count": 8,
        "status": "passed",
        "ok": true,
        "returncode": 0,
        "duration_seconds": 2.726,
        "stdout_tail": "content-ops-packet-aggregation-smoke: ok\n",
        "stderr_tail": ""
      },
      {
        "source": "suite",
        "profile_id": "smoke-suite",
        "profile_title": "Smoke suite",
        "tier": "default",
        "command": "python3 examples/content-ops-preview-cli-smoke.py",
        "reason": "tracked public smoke script",
        "normalized": {
          "ok": true,
          "command": "python3 examples/content-ops-preview-cli-smoke.py",
          "argv": [
            "/Library/Developer/CommandLineTools/usr/bin/python3",
            "/private/tmp/loopx-explore-visual-readback-20260717/examples/content-ops-preview-cli-smoke.py"
          ],
          "display_argv": [
            "python3",
            "examples/content-ops-preview-cli-smoke.py"
          ],
          "injected_args": [],
          "script": "examples/content-ops-preview-cli-smoke.py"
        },
        "check_index": 7,
        "check_count": 8,
        "status": "passed",
        "ok": true,
        "returncode": 0,
        "duration_seconds": 1.2,
        "stdout_tail": "content-ops-preview-cli-smoke: ok\n",
        "stderr_tail": ""
      },
      {
        "source": "suite",
        "profile_id": "smoke-suite",
        "profile_title": "Smoke suite",
        "tier": "default",
        "command": "python3 examples/content-ops-private-connector-gate-smoke.py",
        "reason": "tracked public smoke script",
        "normalized": {
          "ok": true,
          "command": "python3 examples/content-ops-private-connector-gate-smoke.py",
          "argv": [
            "/Library/Developer/CommandLineTools/usr/bin/python3",
            "/private/tmp/loopx-explore-visual-readback-20260717/examples/content-ops-private-connector-gate-smoke.py"
          ],
          "display_argv": [
            "python3",
            "examples/content-ops-private-connector-gate-smoke.py"
          ],
          "injected_args": [],
          "script": "examples/content-ops-private-connector-gate-smoke.py"
        },
        "check_index": 8,
        "check_count": 8,
        "status": "passed",
        "ok": true,
        "returncode": 0,
        "duration_seconds": 1.657,
        "stdout_tail": "content-ops-private-connector-gate-smoke: ok\n",
        "stderr_tail": ""
      }
    ],
    "failures": [],
    "git_required_skips": [],
    "note": "Smoke-suite run executes repository-local public smoke scripts with shell-free argv, per-check timeouts, and continue-on-failure reporting. Use --suite full-public for a full sweep, --module/--script for local development, recognized --profile values for named smoke-suite profiles, or catalog selectors such as --profile for canary-plan modules. Use --offset with --limit to sweep large profiles in stable windows."
  },
  "boundary_run": {
    "ok": true,
    "schema_version": "canary_smoke_suite_run_v0",
    "suite": "premerge-public-boundary",
    "repo_root": "/private/tmp/loopx-explore-visual-readback-20260717",
    "dry_run": false,
    "executes_checks": true,
    "writes_evidence": false,
    "creates_runtime_contract": false,
    "timeout_seconds": 120.0,
    "fail_fast": false,
    "side_effect_guard": {},
    "offset": 0,
    "limit": 1,
    "matched_check_count": 1,
    "selected_check_count": 1,
    "executed_check_count": 1,
    "failure_count": 0,
    "git_required_skip_count": 0,
    "timeout_count": 0,
    "tracked_side_effect_failure_count": 0,
    "unsafe_command_count": 0,
    "warning_count": 0,
    "warnings": [],
    "selection_inputs": {
      "suite": "premerge-public-boundary",
      "changed_files": [
        "docs/capabilities/explore/README.md",
        "examples/explore-result-layer-smoke.py",
        "examples/explore-visual-cross-role-integrity-smoke.py",
        "loopx/presentation/sinks/lark/explore_results.py",
        "loopx/presentation/sinks/lark/explore_visual_readback.py",
        "tests/test_explore_presentation_views.py"
      ],
      "scan_paths": [
        "docs/capabilities/explore/README.md",
        "examples/explore-result-layer-smoke.py",
        "examples/explore-visual-cross-role-integrity-smoke.py",
        "loopx/presentation/sinks/lark/explore_results.py",
        "loopx/presentation/sinks/lark/explore_visual_readback.py",
        "tests/test_explore_presentation_views.py"
      ]
    },
    "catalog_plan": null,
    "selected_checks": [
      {
        "source": "premerge_public_boundary",
        "tier": "default",
        "command": "loopx check --scan-path docs/capabilities/explore/README.md --scan-path examples/explore-result-layer-smoke.py --scan-path examples/explore-visual-cross-role-integrity-smoke.py --scan-path loopx/presentation/sinks/lark/explore_results.py --scan-path loopx/presentation/sinks/lark/explore_visual_readback.py --scan-path tests/test_explore_presentation_views.py",
        "reason": "scans changed public-boundary files for private material",
        "normalized": {
          "ok": true,
          "display_argv": [
            "loopx",
            "check",
            "--scan-path",
            "docs/capabilities/explore/README.md",
            "--scan-path",
            "examples/explore-result-layer-smoke.py",
            "--scan-path",
            "examples/explore-visual-cross-role-integrity-smoke.py",
            "--scan-path",
            "loopx/presentation/sinks/lark/explore_results.py",
            "--scan-path",
            "loopx/presentation/sinks/lark/explore_visual_readback.py",
            "--scan-path",
            "tests/test_explore_presentation_views.py"
          ]
        },
        "status": "passed",
        "ok": true,
        "duration_seconds": 0.028,
        "stdout_tail": "public boundary scan clean: 6 files",
        "stderr_tail": "",
        "boundary": {
          "scanned_files": 6,
          "skipped_private_state_files": [],
          "allowed_hits": [],
          "hit_count": 0
        }
      }
    ],
    "failures": [],
    "git_required_skips": [],
    "note": "Premerge public-boundary validation scans the changed public files directly. The full fresh-directory contract smoke remains available through the canary catalog/profile suites."
  },
  "validation_summary": {
    "schema_version": "premerge_validation_summary_v0",
    "direct_check_count": 4,
    "direct_failure_count": 0,
    "selected_check_count": 18,
    "executed_check_count": 18,
    "failure_count": 0,
    "warning_count": 0,
    "advisory_failure_count": 0,
    "direct_commands": [
      "git diff --check origin/main...HEAD",
      "git diff --cached --check",
      "git diff --check",
      "python3 -m py_compile examples/explore-result-layer-smoke.py examples/explore-visual-cross-role-integrity-smoke.py loopx/presentation/sinks/lark/explore_results.py loopx/presentation/sinks/lark/explore_visual_readback.py tests/test_explore_presentation_views.py"
    ],
    "selected_commands": [
      "python3 examples/control_plane/repo-python-line-budget-smoke.py",
      "python3 examples/issue-fix-workflow-contract-smoke.py",
      "python3 examples/issue-fix-repository-context-smoke.py",
      "python3 examples/issue-fix-feasibility-smoke.py",
      "python3 examples/issue-fix-pr-lifecycle-smoke.py",
      "python3 examples/frontstage-rollout-projections-fixture-smoke.py",
      "python3 examples/showcase-animation-prototype-smoke.py",
      "python3 examples/explore-configure-goal-smoke.py",
      "python3 examples/explore-harness-runtime-resume-smoke.py",
      "python3 examples/cli-project-lifecycle-command-modularization-smoke.py",
      "python3 examples/content-ops-chatview-report-smoke.py",
      "python3 examples/content-ops-exploration-plan-smoke.py",
      "python3 examples/content-ops-issue-fix-intake-smoke.py",
      "python3 examples/content-ops-issue-fix-metadata-preview-smoke.py",
      "python3 examples/content-ops-packet-aggregation-smoke.py",
      "python3 examples/content-ops-preview-cli-smoke.py",
      "python3 examples/content-ops-private-connector-gate-smoke.py",
      "loopx check --scan-path docs/capabilities/explore/README.md --scan-path examples/explore-result-layer-smoke.py --scan-path examples/explore-visual-cross-role-integrity-smoke.py --scan-path loopx/presentation/sinks/lark/explore_results.py --scan-path loopx/presentation/sinks/lark/explore_visual_readback.py --scan-path tests/test_explore_presentation_views.py"
    ],
    "all_commands": [
      "git diff --check origin/main...HEAD",
      "git diff --cached --check",
      "git diff --check",
      "python3 -m py_compile examples/explore-result-layer-smoke.py examples/explore-visual-cross-role-integrity-smoke.py loopx/presentation/sinks/lark/explore_results.py loopx/presentation/sinks/lark/explore_visual_readback.py tests/test_explore_presentation_views.py",
      "python3 examples/control_plane/repo-python-line-budget-smoke.py",
      "python3 examples/issue-fix-workflow-contract-smoke.py",
      "python3 examples/issue-fix-repository-context-smoke.py",
      "python3 examples/issue-fix-feasibility-smoke.py",
      "python3 examples/issue-fix-pr-lifecycle-smoke.py",
      "python3 examples/frontstage-rollout-projections-fixture-smoke.py",
      "python3 examples/showcase-animation-prototype-smoke.py",
      "python3 examples/explore-configure-goal-smoke.py",
      "python3 examples/explore-harness-runtime-resume-smoke.py",
      "python3 examples/cli-project-lifecycle-command-modularization-smoke.py",
      "python3 examples/content-ops-chatview-report-smoke.py",
      "python3 examples/content-ops-exploration-plan-smoke.py",
      "python3 examples/content-ops-issue-fix-intake-smoke.py",
      "python3 examples/content-ops-issue-fix-metadata-preview-smoke.py",
      "python3 examples/content-ops-packet-aggregation-smoke.py",
      "python3 examples/content-ops-preview-cli-smoke.py",
      "python3 examples/content-ops-private-connector-gate-smoke.py",
      "loopx check --scan-path docs/capabilities/explore/README.md --scan-path examples/explore-result-layer-smoke.py --scan-path examples/explore-visual-cross-role-integrity-smoke.py --scan-path loopx/presentation/sinks/lark/explore_results.py --scan-path loopx/presentation/sinks/lark/explore_visual_readback.py --scan-path tests/test_explore_presentation_views.py"
    ],
    "failed_commands": [],
    "runs": {
      "catalog_run": {
        "ok": true,
        "selected_check_count": 9,
        "executed_check_count": 9,
        "failure_count": 0,
        "warning_count": 0,
        "advisory_failure_count": 0,
        "selected_commands": [
          "python3 examples/control_plane/repo-python-line-budget-smoke.py",
          "python3 examples/issue-fix-workflow-contract-smoke.py",
          "python3 examples/issue-fix-repository-context-smoke.py",
          "python3 examples/issue-fix-feasibility-smoke.py",
          "python3 examples/issue-fix-pr-lifecycle-smoke.py",
          "python3 examples/frontstage-rollout-projections-fixture-smoke.py",
          "python3 examples/showcase-animation-prototype-smoke.py",
          "python3 examples/explore-configure-goal-smoke.py",
          "python3 examples/explore-harness-runtime-resume-smoke.py"
        ],
        "failed_commands": []
      },
      "risk_profile_run": {
        "ok": true,
        "selected_check_count": 8,
        "executed_check_count": 8,
        "failure_count": 0,
        "warning_count": 0,
        "advisory_failure_count": 0,
        "selected_commands": [
          "python3 examples/cli-project-lifecycle-command-modularization-smoke.py",
          "python3 examples/content-ops-chatview-report-smoke.py",
          "python3 examples/content-ops-exploration-plan-smoke.py",
          "python3 examples/content-ops-issue-fix-intake-smoke.py",
          "python3 examples/content-ops-issue-fix-metadata-preview-smoke.py",
          "python3 examples/content-ops-packet-aggregation-smoke.py",
          "python3 examples/content-ops-preview-cli-smoke.py",
          "python3 examples/content-ops-private-connector-gate-smoke.py"
        ],
        "failed_commands": []
      },
      "boundary_run": {
        "ok": true,
        "selected_check_count": 1,
        "executed_check_count": 1,
        "failure_count": 0,
        "warning_count": 0,
        "advisory_failure_count": 0,
        "selected_commands": [
          "loopx check --scan-path docs/capabilities/explore/README.md --scan-path examples/explore-result-layer-smoke.py --scan-path examples/explore-visual-cross-role-integrity-smoke.py --scan-path loopx/presentation/sinks/lark/explore_results.py --scan-path loopx/presentation/sinks/lark/explore_visual_readback.py --scan-path tests/test_explore_presentation_views.py"
        ],
        "failed_commands": []
      }
    }
  },
  "gate": {
    "status": "passed",
    "merge_gate_passed": true,
    "self_merge_allowed": true,
    "direct_failure_count": 0,
    "run_failure_count": 0,
    "manual_hold_count": 0
  },
  "recommended_pr_comment_fields": [
    "changed_surfaces",
    "direct_checks",
    "catalog_canaries",
    "risk_profile_smokes",
    "public_private_boundary",
    "failures_or_skips",
    "manual_holds",
    "merge_decision"
  ],
  "note": "Pre-merge validation is a risk-based gate: it runs diff hygiene, changed Python compile checks, catalog-selected canaries, risk-profile smokes, and public/private boundary checks. It reports manual holds for benchmark-sensitive or reviewer-gated surfaces instead of treating local smoke success as self-merge permission.",
  "selector_sources": {
    "git_diff": {
      "ok": true,
      "base_ref": "origin/main",
      "repo_root": "/private/tmp/loopx-explore-visual-readback-20260717",
      "changed_files": [
        "docs/capabilities/explore/README.md",
        "examples/explore-result-layer-smoke.py",
        "examples/explore-visual-cross-role-integrity-smoke.py",
        "loopx/presentation/sinks/lark/explore_results.py",
        "loopx/presentation/sinks/lark/explore_visual_readback.py",
        "tests/test_explore_presentation_views.py"
      ],
      "changed_file_count": 6,
      "successful_sources": [
        "base",
        "staged",
        "unstaged",
        "untracked"
      ],
      "warnings": []
    }
  }
} (18/18 selected checks passed; public boundary clean; self-merge allowed)

## Boundary
- no credentials, private state, local paths, raw evidence, or production actions
- generated local  excluded
- residual risk: remote host availability still requires a later retry, now represented by a bounded receipt without blind republish