### PR TITLE
fix(history): make concurrent run artifacts collision-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,7 +715,8 @@ loopx history rebuild-index-collisions --goal-id your-project-goal \
 ```
 
 The execute path keeps a pre-rebuild index backup and does not claim that an
-ambiguous legacy artifact belongs to any recovered row.
+ambiguous legacy artifact belongs to any recovered row. A truncated plan is
+not executable; increase `--limit` and review the complete digest first.
 
 Common operator actions:
 

--- a/README.md
+++ b/README.md
@@ -701,6 +701,22 @@ loopx history --goal-id your-project-goal
 loopx quota should-run --goal-id your-project-goal
 ```
 
+Quota/monitor artifacts and generic history appenders use an atomic JSON
+reservation so concurrent writers cannot claim the same JSON/Markdown pair.
+Legacy index identity collisions are never auto-deleted: preview an exact
+rebuild plan, review its rows and digest, then explicitly supply that plan to
+preserve every compact todo/target event under a distinct recovery artifact:
+
+```bash
+loopx --format json history rebuild-index-collisions \
+  --goal-id your-project-goal | jq '.review_plan' > reviewed-plan.json
+loopx history rebuild-index-collisions --goal-id your-project-goal \
+  --review-plan-json reviewed-plan.json --execute
+```
+
+The execute path keeps a pre-rebuild index backup and does not claim that an
+ambiguous legacy artifact belongs to any recovered row.
+
 Common operator actions:
 
 ```bash

--- a/examples/cli-history-command-modularization-smoke.py
+++ b/examples/cli-history-command-modularization-smoke.py
@@ -51,6 +51,7 @@ def main() -> int:
     assert_contains(help_result.stdout, "append-benchmark-run")
     assert_contains(help_result.stdout, "append-agents-last-exam-result-report")
     assert_contains(help_result.stdout, "repair-index-duplicates")
+    assert_contains(help_result.stdout, "rebuild-index-collisions")
     assert_contains(help_result.stdout, "--active-user-pilot-json")
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/examples/history-index-duplicate-inspection-smoke.py
+++ b/examples/history-index-duplicate-inspection-smoke.py
@@ -387,10 +387,13 @@ def main() -> None:
         )
         assert rebuild_preview["dry_run"] is True, rebuild_preview
         assert rebuild_preview["collision_group_count"] == 1, rebuild_preview
+        assert rebuild_preview["total_collision_group_count"] == 1, rebuild_preview
+        assert rebuild_preview["truncated"] is False, rebuild_preview
         assert rebuild_preview["review_required"] is True, rebuild_preview
         assert rebuild_preview["destructive_row_deletion"] is False, rebuild_preview
         review_plan = rebuild_preview["review_plan"]
         assert review_plan["destructive_row_deletion"] is False, review_plan
+        assert review_plan["truncated"] is False, review_plan
         assert len(review_plan["groups"][0]["rows"]) == 2, review_plan
         assert {
             row["event_identity"]["todo_id"]

--- a/examples/history-index-duplicate-inspection-smoke.py
+++ b/examples/history-index-duplicate-inspection-smoke.py
@@ -143,10 +143,18 @@ def write_index_fixture(root: Path, goal_id: str, duplicate_kind: str) -> None:
         rows = [
             {
                 **base,
-                "classification": "benchmark_run_v0",
-                "health_check": "benchmark_run_v0 compact event public-safe",
+                "classification": "quota_monitor_poll",
+                "todo_id": "todo_fixture_a",
+                "target_key": "github-pr-101",
+                "health_check": "due monitor observation unchanged",
             },
-            {**base, "classification": "state_refreshed"},
+            {
+                **base,
+                "classification": "quota_monitor_poll",
+                "todo_id": "todo_fixture_b",
+                "target_key": "github-pr-102",
+                "health_check": "due monitor observation unchanged",
+            },
         ]
     else:
         raise ValueError(duplicate_kind)
@@ -275,8 +283,7 @@ def main() -> None:
             == "artifact_identity_collision"
         ), payload
         assert by_goal["artifact-collision-goal"]["classifications"] == [
-            "benchmark_run_v0",
-            "state_refreshed",
+            "quota_monitor_poll"
         ], payload
         assert payload["groups"][0]["severity"] == "warning", payload
 
@@ -370,6 +377,79 @@ def main() -> None:
         )
         assert filtered["duplicate_group_count"] == 1, filtered
         assert filtered["groups"][0]["duplicate_kind"] == "reward_overlay", filtered
+
+        rebuild_preview = run_cli(
+            registry_path,
+            "history",
+            "rebuild-index-collisions",
+            "--goal-id",
+            "artifact-collision-goal",
+        )
+        assert rebuild_preview["dry_run"] is True, rebuild_preview
+        assert rebuild_preview["collision_group_count"] == 1, rebuild_preview
+        assert rebuild_preview["review_required"] is True, rebuild_preview
+        assert rebuild_preview["destructive_row_deletion"] is False, rebuild_preview
+        review_plan = rebuild_preview["review_plan"]
+        assert review_plan["destructive_row_deletion"] is False, review_plan
+        assert len(review_plan["groups"][0]["rows"]) == 2, review_plan
+        assert {
+            row["event_identity"]["todo_id"]
+            for row in review_plan["groups"][0]["rows"]
+        } == {"todo_fixture_a", "todo_fixture_b"}, review_plan
+        plan_path = Path(raw_tmp) / "reviewed-collision-plan.json"
+        plan_path.write_text(
+            json.dumps(review_plan, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        rebuild_execute = run_cli(
+            registry_path,
+            "history",
+            "rebuild-index-collisions",
+            "--goal-id",
+            "artifact-collision-goal",
+            "--review-plan-json",
+            str(plan_path),
+            "--execute",
+        )
+        assert rebuild_execute["rebuilt"] is True, rebuild_execute
+        assert rebuild_execute["destructive_row_deletion"] is False, rebuild_execute
+        rebuilt_index = rebuild_execute["rebuilt_indexes"][0]
+        assert rebuilt_index["preserved_row_count"] == 2, rebuild_execute
+        assert Path(rebuilt_index["backup_path"]).exists(), rebuild_execute
+        assert all(Path(path).exists() for path in rebuilt_index["recovery_paths"]), (
+            rebuild_execute
+        )
+
+        after_rebuild = run_cli(
+            registry_path,
+            "history",
+            "inspect-index-duplicates",
+            "--goal-id",
+            "artifact-collision-goal",
+        )
+        assert after_rebuild["duplicate_group_count"] == 0, after_rebuild
+        rebuilt_rows = [
+            json.loads(line)
+            for line in (
+                Path(rebuilt_index["index_path"]).read_text(encoding="utf-8").splitlines()
+            )
+            if line.strip()
+        ]
+        assert len(rebuilt_rows) == 2, rebuilt_rows
+        assert {row["classification"] for row in rebuilt_rows} == {
+            "quota_monitor_poll"
+        }, rebuilt_rows
+        assert {row["todo_id"] for row in rebuilt_rows} == {
+            "todo_fixture_a",
+            "todo_fixture_b",
+        }, rebuilt_rows
+        assert {row["target_key"] for row in rebuilt_rows} == {
+            "github-pr-101",
+            "github-pr-102",
+        }, rebuilt_rows
+        assert len({row["json_path"] for row in rebuilt_rows}) == 2, rebuilt_rows
+        assert all(row["artifact_rebuild"]["ambiguous_legacy_artifact_claimed"] is False for row in rebuilt_rows)
 
     print("history-index-duplicate-inspection-smoke ok")
 

--- a/loopx/cli_commands/history.py
+++ b/loopx/cli_commands/history.py
@@ -27,6 +27,7 @@ from ..history import (
     inspect_index_duplicates,
     load_registry,
     repair_index_duplicates,
+    rebuild_index_artifact_collisions,
     render_active_user_assisted_pilot_append_markdown,
     render_benchmark_comparison_append_markdown,
     render_benchmark_experiment_report_append_markdown,
@@ -36,6 +37,7 @@ from ..history import (
     render_history_markdown,
     render_index_duplicate_inspection_markdown,
     render_index_duplicate_repair_markdown,
+    render_index_collision_rebuild_markdown,
 )
 from ..paths import resolve_runtime_root
 from ..presentation.renderers.trajectory_hygiene_markdown import (
@@ -75,13 +77,15 @@ def register_history_command(subparsers: argparse._SubParsersAction) -> None:
             "append-active-user-assisted-pilot",
             "inspect-index-duplicates",
             "repair-index-duplicates",
+            "rebuild-index-collisions",
             "trajectory-hygiene",
         ],
         help=(
             "Append a compact benchmark_run_v0, benchmark_result_v0, benchmark_comparison_v0, "
             "benchmark_learning_ledger_v0, benchmark_experiment_report_v0, ALE compact result report, or "
             "active_user_assisted_pilot_v0 event; inspect duplicate run-index identities; "
-            "repair safe duplicate index rows; or audit compact-history trajectory hygiene."
+            "repair safe duplicate index rows; rebuild reviewed artifact collisions without deleting events; "
+            "or audit compact-history trajectory hygiene."
         ),
     )
     history_parser.add_argument("--goal-id", help="Only show one goal.")
@@ -122,6 +126,13 @@ def register_history_command(subparsers: argparse._SubParsersAction) -> None:
     history_parser.add_argument(
         "--active-user-pilot-json",
         help="Path to an active_user_assisted_pilot_v0 JSON object. Use '-' to read stdin.",
+    )
+    history_parser.add_argument(
+        "--review-plan-json",
+        help=(
+            "For rebuild-index-collisions --execute, a JSON review plan emitted by the dry-run. "
+            "Use '-' to read stdin."
+        ),
     )
     history_parser.add_argument("--classification")
     history_parser.add_argument(
@@ -244,6 +255,48 @@ def handle_history_command(
                 "error": str(exc),
             }
         print_payload(payload, args.format, render_index_duplicate_repair_markdown)
+        return 0 if payload.get("ok") else 1
+
+    if args.history_action == "rebuild-index-collisions":
+        try:
+            if args.dry_run and args.execute:
+                raise ValueError(
+                    "history rebuild-index-collisions accepts either --dry-run or --execute, not both"
+                )
+            reviewed_plan = None
+            if args.review_plan_json:
+                raw_plan = (
+                    sys.stdin.read()
+                    if args.review_plan_json == "-"
+                    else Path(args.review_plan_json).expanduser().read_text(encoding="utf-8")
+                )
+                reviewed_plan = json.loads(raw_plan)
+                if not isinstance(reviewed_plan, dict):
+                    raise ValueError("--review-plan-json must contain a JSON object")
+            payload = rebuild_index_artifact_collisions(
+                registry_path=registry_path,
+                runtime_root_override=runtime_root_arg,
+                goal_id=args.goal_id,
+                limit=args.limit,
+                reviewed_plan=reviewed_plan,
+                execute=bool(args.execute),
+            )
+        except Exception as exc:
+            registry = load_registry(registry_path)
+            runtime_root = resolve_runtime_root(
+                registry,
+                runtime_root_arg,
+                registry_path=registry_path,
+            )
+            payload = {
+                "ok": False,
+                "dry_run": not bool(args.execute),
+                "registry": str(registry_path),
+                "runtime_root": str(runtime_root),
+                "goal_filter": args.goal_id,
+                "error": str(exc),
+            }
+        print_payload(payload, args.format, render_index_collision_rebuild_markdown)
         return 0 if payload.get("ok") else 1
 
     if args.history_action == "append-benchmark-run":

--- a/loopx/control_plane/quota/monitor_poll.py
+++ b/loopx/control_plane/quota/monitor_poll.py
@@ -9,7 +9,11 @@ from typing import Any
 from .decision_summary import compact_quota_decision, quota_decision_agent_id
 from .spend_sources import DEFAULT_SLOT_SPEND_SOURCE, VALID_SLOT_SPEND_SOURCES
 from ..runtime.time import now_local_iso
-from ..runtime.run_artifacts import run_file_stem, unique_run_artifact_paths
+from ..runtime.run_artifacts import (
+    next_run_artifact_paths,
+    reserve_run_artifact_paths,
+    run_file_stem,
+)
 from ..scheduler.monitor_poll_policy import (
     allows_no_spend_blocked_successor_wait_poll,
     allows_due_monitor_poll,
@@ -398,7 +402,8 @@ def record_quota_monitor_poll_for_decision(
     runtime_root = Path(str(raw_runtime_root)).expanduser()
     runs_dir = runtime_root / "goals" / goal_id / "runs"
     stem = run_file_stem(generated_at)
-    json_path, markdown_path = unique_run_artifact_paths(runs_dir, stem, "quota-monitor-poll")
+    path_allocator = reserve_run_artifact_paths if execute else next_run_artifact_paths
+    json_path, markdown_path = path_allocator(runs_dir, stem, "quota-monitor-poll")
     index_path = runs_dir / "index.jsonl"
     index_record = {
         "generated_at": generated_at,
@@ -422,7 +427,6 @@ def record_quota_monitor_poll_for_decision(
 
     after_status = deepcopy(status_payload)
     if execute:
-        runs_dir.mkdir(parents=True, exist_ok=True)
         json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
         markdown_path.write_text(render_quota_monitor_poll_markdown(record) + "\n", encoding="utf-8")
         with index_path.open("a", encoding="utf-8") as f:

--- a/loopx/control_plane/quota/slot_accounting.py
+++ b/loopx/control_plane/quota/slot_accounting.py
@@ -10,7 +10,11 @@ from .monitor_poll import QUOTA_MONITOR_POLL_CLASSIFICATION
 from .scheduler_ack import QUOTA_SCHEDULER_ACK_CLASSIFICATION
 from .spend_sources import DEFAULT_SLOT_SPEND_SOURCE, VALID_SLOT_SPEND_SOURCES
 from ..runtime.time import now_local_iso
-from ..runtime.run_artifacts import run_file_stem, unique_run_artifact_paths
+from ..runtime.run_artifacts import (
+    next_run_artifact_paths,
+    reserve_run_artifact_paths,
+    run_file_stem,
+)
 from ..agents.workspace_guard import (
     build_delivery_workspace_guard,
     delivery_workspace_repository,
@@ -685,7 +689,8 @@ def record_quota_slot_void_from_preview(
     runtime_root = Path(str(raw_runtime_root)).expanduser()
     runs_dir = runtime_root / "goals" / safe_goal_id / "runs"
     stem = run_file_stem(generated_at)
-    json_path, markdown_path = unique_run_artifact_paths(runs_dir, stem, "quota-slot-voided")
+    path_allocator = reserve_run_artifact_paths if execute else next_run_artifact_paths
+    json_path, markdown_path = path_allocator(runs_dir, stem, "quota-slot-voided")
     index_path = runs_dir / "index.jsonl"
     index_record = {
         "generated_at": generated_at,
@@ -721,7 +726,6 @@ def record_quota_slot_void_from_preview(
         payload["before"] = record["quota_event"]["before"]
         payload["after"] = record["quota_event"]["after"]
     if execute:
-        runs_dir.mkdir(parents=True, exist_ok=True)
         json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
         markdown_path.write_text(render_quota_slot_preview_markdown(payload) + "\n", encoding="utf-8")
         with index_path.open("a", encoding="utf-8") as f:
@@ -755,7 +759,8 @@ def record_quota_slot_spend_from_preview(
     runtime_root = Path(str(raw_runtime_root)).expanduser()
     runs_dir = runtime_root / "goals" / safe_goal_id / "runs"
     stem = run_file_stem(generated_at)
-    json_path, markdown_path = unique_run_artifact_paths(runs_dir, stem, "quota-slot-spent")
+    path_allocator = reserve_run_artifact_paths if execute else next_run_artifact_paths
+    json_path, markdown_path = path_allocator(runs_dir, stem, "quota-slot-spent")
     index_path = runs_dir / "index.jsonl"
     index_record = {
         "generated_at": generated_at,
@@ -792,7 +797,6 @@ def record_quota_slot_spend_from_preview(
         payload["before"] = record["quota_event"]["before"]
         payload["after"] = record["quota_event"]["after"]
     if execute:
-        runs_dir.mkdir(parents=True, exist_ok=True)
         json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
         markdown_path.write_text(render_quota_slot_preview_markdown(payload) + "\n", encoding="utf-8")
         with index_path.open("a", encoding="utf-8") as f:

--- a/loopx/control_plane/runtime/run_artifacts.py
+++ b/loopx/control_plane/runtime/run_artifacts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 
@@ -8,15 +9,70 @@ def run_file_stem(generated_at: str) -> str:
     return re.sub(r"[^0-9A-Za-z-]+", "-", generated_at).strip("-")
 
 
-def unique_run_artifact_paths(runs_dir: Path, stem: str, suffix: str) -> tuple[Path, Path]:
-    candidate = runs_dir / f"{stem}-{suffix}.json"
-    markdown_candidate = runs_dir / f"{stem}-{suffix}.md"
-    if not candidate.exists() and not markdown_candidate.exists():
-        return candidate, markdown_candidate
-    index = 2
+def _run_artifact_candidates(
+    runs_dir: Path,
+    stem: str,
+    suffix: str | None,
+    index: int,
+) -> tuple[Path, Path]:
+    base_stem = f"{stem}-{suffix}" if suffix else stem
+    actual_stem = base_stem if index == 1 else f"{base_stem}-{index}"
+    return (
+        runs_dir / f"{actual_stem}.json",
+        runs_dir / f"{actual_stem}.md",
+    )
+
+
+def next_run_artifact_paths(
+    runs_dir: Path,
+    stem: str,
+    suffix: str | None = None,
+) -> tuple[Path, Path]:
+    """Preview the next artifact pair without reserving it."""
+
+    index = 1
     while True:
-        candidate = runs_dir / f"{stem}-{suffix}-{index}.json"
-        markdown_candidate = runs_dir / f"{stem}-{suffix}-{index}.md"
+        candidate, markdown_candidate = _run_artifact_candidates(
+            runs_dir,
+            stem,
+            suffix,
+            index,
+        )
         if not candidate.exists() and not markdown_candidate.exists():
             return candidate, markdown_candidate
         index += 1
+
+
+def reserve_run_artifact_paths(
+    runs_dir: Path,
+    stem: str,
+    suffix: str | None = None,
+) -> tuple[Path, Path]:
+    """Atomically reserve one JSON/Markdown artifact pair across processes.
+
+    The JSON path is the reservation sentinel. Writers must call this only for
+    an executing append, then replace the empty sentinel with the final JSON.
+    A pre-existing Markdown file also excludes the pair so a partial legacy
+    artifact is never overwritten.
+    """
+
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    index = 1
+    while True:
+        candidate, markdown_candidate = _run_artifact_candidates(
+            runs_dir,
+            stem,
+            suffix,
+            index,
+        )
+        if markdown_candidate.exists():
+            index += 1
+            continue
+        try:
+            fd = os.open(candidate, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError:
+            index += 1
+            continue
+        else:
+            os.close(fd)
+            return candidate, markdown_candidate

--- a/loopx/control_plane/runtime/run_index_rebuild.py
+++ b/loopx/control_plane/runtime/run_index_rebuild.py
@@ -95,11 +95,15 @@ def build_collision_rebuild_plan(
     groups: list[dict[str, Any]],
     *,
     goal_filter: str | None,
+    total_collision_group_count: int,
+    truncated: bool,
 ) -> dict[str, Any]:
     plan_body = {
         "schema_version": COLLISION_REBUILD_PLAN_SCHEMA,
         "goal_filter": goal_filter,
         "groups": groups,
+        "total_collision_group_count": total_collision_group_count,
+        "truncated": truncated,
         "destructive_row_deletion": False,
     }
     return {**plan_body, "plan_sha256": _sha256(plan_body)}
@@ -119,6 +123,8 @@ def validate_reviewed_collision_plan(
             "schema_version",
             "goal_filter",
             "groups",
+            "total_collision_group_count",
+            "truncated",
             "destructive_row_deletion",
         )
     }
@@ -131,6 +137,10 @@ def validate_reviewed_collision_plan(
         )
     if reviewed_plan.get("destructive_row_deletion") is not False:
         raise ValueError("review plan must explicitly keep destructive_row_deletion=false")
+    if reviewed_plan.get("truncated") is not False:
+        raise ValueError(
+            "review plan is truncated; increase --limit until truncated=false before execution"
+        )
     return reviewed_digest
 
 

--- a/loopx/control_plane/runtime/run_index_rebuild.py
+++ b/loopx/control_plane/runtime/run_index_rebuild.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from .run_artifacts import run_file_stem
+from .run_index_duplicates import classify_index_duplicate_records, index_identity
+
+
+COLLISION_REBUILD_PLAN_SCHEMA = "artifact_identity_collision_rebuild_plan_v0"
+COLLISION_RECOVERY_ARTIFACT_SCHEMA = "artifact_identity_collision_recovery_v0"
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _sha256(value: Any) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _event_identity(record: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: record.get(key)
+        for key in (
+            "classification",
+            "todo_id",
+            "target_key",
+            "agent_id",
+            "material_change",
+        )
+        if record.get(key) is not None
+    }
+
+
+def read_index_rows(index_path: Path) -> tuple[list[str], list[tuple[int, dict[str, Any]]]]:
+    raw_lines = index_path.read_text(encoding="utf-8").splitlines()
+    rows: list[tuple[int, dict[str, Any]]] = []
+    for line_number, line in enumerate(raw_lines, start=1):
+        if not line.strip():
+            continue
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(item, dict):
+            rows.append((line_number, item))
+    return raw_lines, rows
+
+
+def collision_review_groups(index_path: Path, goal_id: str) -> list[dict[str, Any]]:
+    _, rows = read_index_rows(index_path)
+    grouped: dict[tuple[str, str, str], list[tuple[int, dict[str, Any]]]] = {}
+    for line_number, record in rows:
+        grouped.setdefault(index_identity(record), []).append((line_number, record))
+
+    groups: list[dict[str, Any]] = []
+    for identity, records in grouped.items():
+        if len(records) <= 1:
+            continue
+        classification = classify_index_duplicate_records(
+            [record for _, record in records]
+        )
+        if classification.get("action") != "blocked_artifact_identity_collision":
+            continue
+        generated_at, json_path, markdown_path = identity
+        groups.append(
+            {
+                "goal_id": goal_id,
+                "index_path": str(index_path),
+                "source_identity": {
+                    "generated_at": generated_at,
+                    "json_path": json_path,
+                    "markdown_path": markdown_path,
+                },
+                "line_numbers": [line_number for line_number, _ in records],
+                "rows": [
+                    {
+                        "line_number": line_number,
+                        "row_sha256": _sha256(record),
+                        "event_identity": _event_identity(record),
+                    }
+                    for line_number, record in records
+                ],
+                "rebuild_contract": "preserve_every_row_with_a_distinct_recovery_artifact",
+            }
+        )
+    return groups
+
+
+def build_collision_rebuild_plan(
+    groups: list[dict[str, Any]],
+    *,
+    goal_filter: str | None,
+) -> dict[str, Any]:
+    plan_body = {
+        "schema_version": COLLISION_REBUILD_PLAN_SCHEMA,
+        "goal_filter": goal_filter,
+        "groups": groups,
+        "destructive_row_deletion": False,
+    }
+    return {**plan_body, "plan_sha256": _sha256(plan_body)}
+
+
+def validate_reviewed_collision_plan(
+    reviewed_plan: dict[str, Any],
+    current_plan: dict[str, Any],
+) -> str:
+    if reviewed_plan.get("schema_version") != COLLISION_REBUILD_PLAN_SCHEMA:
+        raise ValueError(
+            f"review plan must have schema_version={COLLISION_REBUILD_PLAN_SCHEMA}"
+        )
+    reviewed_body = {
+        key: reviewed_plan.get(key)
+        for key in (
+            "schema_version",
+            "goal_filter",
+            "groups",
+            "destructive_row_deletion",
+        )
+    }
+    reviewed_digest = _sha256(reviewed_body)
+    if reviewed_plan.get("plan_sha256") != reviewed_digest:
+        raise ValueError("review plan digest does not match its contents")
+    if reviewed_digest != current_plan.get("plan_sha256"):
+        raise ValueError(
+            "review plan is stale or does not match the current collision groups; regenerate and review it"
+        )
+    if reviewed_plan.get("destructive_row_deletion") is not False:
+        raise ValueError("review plan must explicitly keep destructive_row_deletion=false")
+    return reviewed_digest
+
+
+def _write_new_or_verify(path: Path, content: str) -> None:
+    encoded = content.encode("utf-8")
+    try:
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError:
+        if path.read_bytes() != encoded:
+            raise ValueError(f"rebuild artifact already exists with different content: {path}")
+        return
+    with os.fdopen(fd, "wb") as stream:
+        stream.write(encoded)
+
+
+def _recovery_markdown(record: dict[str, Any]) -> str:
+    recovery = record["artifact_rebuild"]
+    event_identity = recovery.get("event_identity") or {}
+    lines = [
+        "# LoopX Recovered Run Index Event",
+        "",
+        f"- schema_version: `{COLLISION_RECOVERY_ARTIFACT_SCHEMA}`",
+        f"- goal_id: `{record.get('goal_id')}`",
+        f"- generated_at: `{record.get('generated_at')}`",
+        f"- classification: `{record.get('classification')}`",
+        f"- source_line_number: `{recovery.get('source_line_number')}`",
+        f"- review_plan_sha256: `{recovery.get('review_plan_sha256')}`",
+        "- recovery: `compact index event preserved; ambiguous legacy artifact not claimed`",
+    ]
+    for key in ("todo_id", "target_key", "agent_id", "material_change"):
+        if key in event_identity:
+            lines.append(f"- {key}: `{event_identity[key]}`")
+    return "\n".join(lines) + "\n"
+
+
+def apply_reviewed_collision_rebuild(
+    current_plan: dict[str, Any],
+    *,
+    plan_sha256: str,
+) -> list[dict[str, Any]]:
+    groups_by_index: dict[str, list[dict[str, Any]]] = {}
+    for group in current_plan.get("groups") or []:
+        groups_by_index.setdefault(str(group.get("index_path") or ""), []).append(group)
+
+    rebuilt_indexes: list[dict[str, Any]] = []
+    digest_prefix = plan_sha256[:16]
+    for raw_index_path, groups in groups_by_index.items():
+        index_path = Path(raw_index_path)
+        raw_lines, parsed_rows = read_index_rows(index_path)
+        rows_by_line = dict(parsed_rows)
+        replacements: dict[int, dict[str, Any]] = {}
+        recovery_paths: list[str] = []
+
+        for group in groups:
+            source_identity = group.get("source_identity") or {}
+            generated_at = str(source_identity.get("generated_at") or "")
+            stem = run_file_stem(generated_at)
+            group_token = _sha256(source_identity)[:8]
+            for ordinal, row_spec in enumerate(group.get("rows") or [], start=1):
+                line_number = int(row_spec["line_number"])
+                source_record = rows_by_line.get(line_number)
+                if source_record is None or _sha256(source_record) != row_spec.get("row_sha256"):
+                    raise ValueError(
+                        f"reviewed collision row changed before rebuild: {index_path}:{line_number}"
+                    )
+                recovery_stem = (
+                    f"{stem}-collision-rebuild-{digest_prefix}-{group_token}-{ordinal}"
+                )
+                json_path = index_path.parent / f"{recovery_stem}.json"
+                markdown_path = index_path.parent / f"{recovery_stem}.md"
+                rebuilt_record = dict(source_record)
+                rebuilt_record["json_path"] = str(json_path)
+                rebuilt_record["markdown_path"] = str(markdown_path)
+                rebuilt_record["artifact_rebuild"] = {
+                    "schema_version": COLLISION_RECOVERY_ARTIFACT_SCHEMA,
+                    "review_plan_sha256": plan_sha256,
+                    "source_identity": source_identity,
+                    "source_line_number": line_number,
+                    "event_identity": row_spec.get("event_identity") or {},
+                    "ambiguous_legacy_artifact_claimed": False,
+                }
+                recovery_payload = {
+                    "schema_version": COLLISION_RECOVERY_ARTIFACT_SCHEMA,
+                    "artifact_rebuild": rebuilt_record["artifact_rebuild"],
+                    "index_record": source_record,
+                }
+                _write_new_or_verify(
+                    json_path,
+                    json.dumps(recovery_payload, ensure_ascii=False, indent=2) + "\n",
+                )
+                _write_new_or_verify(markdown_path, _recovery_markdown(rebuilt_record))
+                replacements[line_number] = rebuilt_record
+                recovery_paths.extend((str(json_path), str(markdown_path)))
+
+        backup_path = index_path.with_name(
+            f"index.pre-collision-rebuild-{digest_prefix}.jsonl"
+        )
+        original_content = "".join(line + "\n" for line in raw_lines)
+        _write_new_or_verify(backup_path, original_content)
+        rebuilt_lines = [
+            json.dumps(replacements[line_number], ensure_ascii=False)
+            if line_number in replacements
+            else line
+            for line_number, line in enumerate(raw_lines, start=1)
+        ]
+        tmp_path = index_path.with_name(f"index.collision-rebuild-{digest_prefix}.tmp")
+        tmp_path.write_text(
+            "".join(line + "\n" for line in rebuilt_lines),
+            encoding="utf-8",
+        )
+        tmp_path.replace(index_path)
+        rebuilt_indexes.append(
+            {
+                "index_path": str(index_path),
+                "backup_path": str(backup_path),
+                "preserved_row_count": len(replacements),
+                "recovery_paths": recovery_paths,
+            }
+        )
+    return rebuilt_indexes

--- a/loopx/history.py
+++ b/loopx/history.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
-import re
 from pathlib import Path
 from typing import Any, Callable
 
@@ -13,6 +11,17 @@ from .control_plane.runtime.run_index_duplicates import (
     classify_index_duplicate_records,
     duplicate_repair_decision,
     index_identity,
+)
+from .control_plane.runtime.run_index_rebuild import (
+    apply_reviewed_collision_rebuild,
+    build_collision_rebuild_plan,
+    collision_review_groups,
+    validate_reviewed_collision_plan,
+)
+from .control_plane.runtime.run_artifacts import (
+    next_run_artifact_paths,
+    reserve_run_artifact_paths,
+    run_file_stem,
 )
 from .control_plane.work_items.delivery_batch_scale import require_delivery_batch_scale
 from .control_plane.work_items.delivery_outcome import require_delivery_outcome
@@ -67,47 +76,13 @@ def _normalize_optional_delivery_batch_scale(value: str | None) -> str | None:
     return require_delivery_batch_scale(value).value if value else None
 
 
-def run_file_stem(generated_at: str) -> str:
-    return re.sub(r"[^0-9A-Za-z-]+", "-", generated_at).strip("-")
-
-
 def unique_run_paths(runs_dir: Path, generated_at: str) -> tuple[Path, Path]:
-    stem = run_file_stem(generated_at)
-    json_path = runs_dir / f"{stem}.json"
-    markdown_path = runs_dir / f"{stem}.md"
-    if not json_path.exists() and not markdown_path.exists():
-        return json_path, markdown_path
-
-    suffix = 2
-    while True:
-        json_path = runs_dir / f"{stem}-{suffix}.json"
-        markdown_path = runs_dir / f"{stem}-{suffix}.md"
-        if not json_path.exists() and not markdown_path.exists():
-            return json_path, markdown_path
-        suffix += 1
+    return next_run_artifact_paths(runs_dir, run_file_stem(generated_at))
 
 
 def reserve_unique_run_paths(runs_dir: Path, generated_at: str) -> tuple[Path, Path]:
     """Atomically reserve a run JSON path for concurrent append writers."""
-
-    runs_dir.mkdir(parents=True, exist_ok=True)
-    stem = run_file_stem(generated_at)
-    suffix = 1
-    while True:
-        actual_stem = stem if suffix == 1 else f"{stem}-{suffix}"
-        json_path = runs_dir / f"{actual_stem}.json"
-        markdown_path = runs_dir / f"{actual_stem}.md"
-        if markdown_path.exists():
-            suffix += 1
-            continue
-        try:
-            fd = os.open(json_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-        except FileExistsError:
-            suffix += 1
-            continue
-        else:
-            os.close(fd)
-            return json_path, markdown_path
+    return reserve_run_artifact_paths(runs_dir, run_file_stem(generated_at))
 
 
 def write_reserved_run_artifacts(
@@ -1064,6 +1039,79 @@ def repair_index_duplicates(
         "truncated": len(groups) > len(limited_groups),
         "limit": limit,
     }
+
+
+def rebuild_index_artifact_collisions(
+    *,
+    registry_path: Path,
+    runtime_root_override: str | None,
+    goal_id: str | None,
+    limit: int,
+    reviewed_plan: dict[str, Any] | None,
+    execute: bool,
+) -> dict[str, Any]:
+    registry = load_registry(registry_path)
+    runtime_root = resolve_runtime_root(
+        registry,
+        runtime_root_override,
+        registry_path=registry_path,
+    )
+    groups: list[dict[str, Any]] = []
+    checked_goal_count = 0
+    for current_goal_id in discover_goal_ids(runtime_root, registry, goal_id):
+        checked_goal_count += 1
+        index_path = runtime_root / "goals" / current_goal_id / "runs" / "index.jsonl"
+        if index_path.exists():
+            groups.extend(collision_review_groups(index_path, current_goal_id))
+
+    groups = groups[: max(0, limit)]
+    current_plan = build_collision_rebuild_plan(groups, goal_filter=goal_id)
+    if execute:
+        if reviewed_plan is None:
+            raise ValueError(
+                "rebuild-index-collisions --execute requires --review-plan-json from a reviewed dry-run"
+            )
+        plan_sha256 = validate_reviewed_collision_plan(reviewed_plan, current_plan)
+        rebuilt_indexes = apply_reviewed_collision_rebuild(
+            current_plan,
+            plan_sha256=plan_sha256,
+        )
+    else:
+        rebuilt_indexes = []
+
+    return {
+        "ok": True,
+        "dry_run": not execute,
+        "rebuilt": bool(execute and rebuilt_indexes),
+        "registry": str(registry_path),
+        "runtime_root": str(runtime_root),
+        "goal_filter": goal_id,
+        "checked_goal_count": checked_goal_count,
+        "collision_group_count": len(groups),
+        "review_required": not execute and bool(groups),
+        "review_plan": current_plan,
+        "rebuilt_indexes": rebuilt_indexes,
+        "destructive_row_deletion": False,
+    }
+
+
+def render_index_collision_rebuild_markdown(payload: dict[str, Any]) -> str:
+    if not payload.get("ok"):
+        return "# LoopX Artifact Collision Rebuild\n\n- ok: `False`\n- error: " + str(payload.get("error"))
+    plan = payload.get("review_plan") or {}
+    return "\n".join(
+        [
+            "# LoopX Artifact Collision Rebuild",
+            "",
+            f"- dry_run: `{payload.get('dry_run')}`",
+            f"- rebuilt: `{payload.get('rebuilt')}`",
+            f"- collision_groups: `{payload.get('collision_group_count')}`",
+            f"- review_required: `{payload.get('review_required')}`",
+            f"- plan_sha256: `{plan.get('plan_sha256')}`",
+            "- destructive_row_deletion: `False`",
+            "- contract: `review the exact plan, then execute with --review-plan-json`",
+        ]
+    )
 
 
 def render_index_duplicate_repair_markdown(payload: dict[str, Any]) -> str:

--- a/loopx/history.py
+++ b/loopx/history.py
@@ -1056,16 +1056,22 @@ def rebuild_index_artifact_collisions(
         runtime_root_override,
         registry_path=registry_path,
     )
-    groups: list[dict[str, Any]] = []
+    all_groups: list[dict[str, Any]] = []
     checked_goal_count = 0
     for current_goal_id in discover_goal_ids(runtime_root, registry, goal_id):
         checked_goal_count += 1
         index_path = runtime_root / "goals" / current_goal_id / "runs" / "index.jsonl"
         if index_path.exists():
-            groups.extend(collision_review_groups(index_path, current_goal_id))
+            all_groups.extend(collision_review_groups(index_path, current_goal_id))
 
-    groups = groups[: max(0, limit)]
-    current_plan = build_collision_rebuild_plan(groups, goal_filter=goal_id)
+    groups = all_groups[: max(0, limit)]
+    truncated = len(groups) < len(all_groups)
+    current_plan = build_collision_rebuild_plan(
+        groups,
+        goal_filter=goal_id,
+        total_collision_group_count=len(all_groups),
+        truncated=truncated,
+    )
     if execute:
         if reviewed_plan is None:
             raise ValueError(
@@ -1088,6 +1094,8 @@ def rebuild_index_artifact_collisions(
         "goal_filter": goal_id,
         "checked_goal_count": checked_goal_count,
         "collision_group_count": len(groups),
+        "total_collision_group_count": len(all_groups),
+        "truncated": truncated,
         "review_required": not execute and bool(groups),
         "review_plan": current_plan,
         "rebuilt_indexes": rebuilt_indexes,
@@ -1106,6 +1114,8 @@ def render_index_collision_rebuild_markdown(payload: dict[str, Any]) -> str:
             f"- dry_run: `{payload.get('dry_run')}`",
             f"- rebuilt: `{payload.get('rebuilt')}`",
             f"- collision_groups: `{payload.get('collision_group_count')}`",
+            f"- total_collision_groups: `{payload.get('total_collision_group_count')}`",
+            f"- truncated: `{payload.get('truncated')}`",
             f"- review_required: `{payload.get('review_required')}`",
             f"- plan_sha256: `{plan.get('plan_sha256')}`",
             "- destructive_row_deletion: `False`",

--- a/tests/control_plane/test_run_artifact_reservation.py
+++ b/tests/control_plane/test_run_artifact_reservation.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import multiprocessing
+from pathlib import Path
+
+from loopx.control_plane.runtime.run_artifacts import reserve_run_artifact_paths
+
+
+def _reserve_same_timestamp(args: tuple[str, str, str]) -> tuple[str, str]:
+    runs_dir, stem, suffix = args
+    json_path, markdown_path = reserve_run_artifact_paths(
+        Path(runs_dir),
+        stem,
+        suffix,
+    )
+    return json_path.name, markdown_path.name
+
+
+def test_run_artifact_reservation_is_atomic_across_processes(tmp_path: Path) -> None:
+    worker_count = 8
+    args = (str(tmp_path), "2026-07-17T07-49-27-08-00", "quota-monitor-poll")
+
+    with multiprocessing.get_context("spawn").Pool(worker_count) as pool:
+        paths = pool.map(_reserve_same_timestamp, [args] * worker_count)
+
+    json_names = {json_name for json_name, _ in paths}
+    markdown_names = {markdown_name for _, markdown_name in paths}
+    assert len(json_names) == worker_count
+    assert len(markdown_names) == worker_count
+    assert {path.name for path in tmp_path.glob("*.json")} == json_names
+    assert all((tmp_path / name).stat().st_size == 0 for name in json_names)


### PR DESCRIPTION
## Summary

- atomically reserve JSON/Markdown run artifact pairs across processes
- use the shared reservation path for quota slot and monitor-poll writes
- add a reviewed collision rebuild command that preserves every compact event, writes distinct recovery artifacts, and backs up the original index
- document the review-plan workflow and cover it with focused regression tests

## Root cause

Quota and monitor writers selected artifact paths with an exists-then-write sequence. Concurrent processes using the same timestamp could therefore select the same pair and create index identity collisions. Existing duplicate repair correctly refused to delete ambiguous collision rows, but it offered no review-bound rebuild path for preserving distinct todo or target events.

## Validation

- `uv run --extra test pytest -q tests/control_plane/test_run_artifact_reservation.py`
- `python3 examples/history-index-duplicate-inspection-smoke.py`
- `python3 examples/contract-reward-overlay-smoke.py`
- `python3 examples/control_plane/monitor-poll-writeback-smoke.py`
- `python3 examples/cli-history-command-modularization-smoke.py`
- `uv run loopx --format json canary premerge --from-git-diff` — 18/18 selected checks passed; zero failures, warnings, skips, or manual holds; public boundary clean

## Boundary and residual risk

- no credentials, private state, raw logs, or local operating context are included
- generated `uv.lock` remains untracked and excluded
- collision rebuild is default-dry-run and requires an exact reviewed plan digest before execution
- rebuild keeps a pre-change index backup and never deletes ambiguous collision rows
