### PR TITLE
fix(lark): route goal config and degrade dedupe

### DIFF
--- a/docs/capabilities/issue-fix/protocols/issue-fix-reviewer-notification-sinks-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-reviewer-notification-sinks-v0.md
@@ -104,6 +104,15 @@ binding depends on the machine's active/default Lark profile. The legacy
 `bot_profile` field remains accepted for explicit manual configs, but a
 goal-default config requires both bindings.
 
+Before sending, LoopX deduplicates one PR notification through three bounded
+evidence layers: the durable PR-lifecycle receipt, an exact PR-link match in
+the persisted `configured_chat_all` inbox, and a user-identity search of the
+configured chat. The remote search is an evidence enhancement, not an action
+authority boundary: if that user profile lacks `search:message`, LoopX records
+`permission_fallback` and continues from durable receipt/inbox evidence rather
+than projecting a user gate. A successful remote match is written back as the
+same stable receipt; non-permission provider failures remain fail-closed.
+
 `delivery_policy` is optional and provider-neutral. When configured, execute
 mode sends only while the current local time is inside the half-open
 `[start, end)` window; overnight windows are supported. Outside the window,

--- a/docs/capabilities/lark-event-inbox.md
+++ b/docs/capabilities/lark-event-inbox.md
@@ -173,7 +173,7 @@ loopx configure-goal \
 ```
 
 The configuration catalog exposes this optional capability on demand. Quota
-projects `enabled`, `config_pointer_registered`, a public-safe command, and a
+projects `enabled`, `config_pointer_registered`, a local control command, and a
 content-free urgency summary; it never projects the private path, message ids,
 senders, or message bodies. The summary includes
 pending/direct-question/direct-mention/verified-bot-reply counts and the oldest
@@ -181,8 +181,10 @@ pending age. A configured direct mention or verified reply to a message authored
 by the configured bot becomes a high-priority `lark_event_inbox` work lane
 before ordinary monitor or advancement work. Generated heartbeat bodies run the
 actual goal-boundary `drain_command`;
-`loopx lark-inbox drain --goal-id <goal-id> --project .`
-resolves the ignored config from the goal registry. A disabled or empty inbox
+`loopx --registry <invoked-registry> lark-inbox drain --goal-id <goal-id>`
+follows a shared registry's `source_registry` to the canonical project before
+resolving the ignored config. It therefore remains correct from linked or
+independent worktrees without binding control state to `--project .`. A disabled or empty inbox
 is a quiet zero-spend path, so projects without Lark keep the default behavior.
 
 ## Drain and acknowledge
@@ -262,6 +264,13 @@ Ingest validates ids and schema, deduplicates by `message_id`, writes only to
 the configured local-private inbox, and returns counts rather than message
 content. It does not acknowledge imported messages; the domain agent must still
 write each actionable effect before ACK.
+
+Reviewer notification dedupe uses durable lifecycle receipts first, then exact
+PR-link evidence in the persisted `configured_chat_all` inbox, and finally a
+bounded user-identity search of the configured chat. Missing `search:message`
+permission degrades to the two persisted sources and does not create a user
+gate; other provider read failures remain blockers because absence cannot be
+established safely.
 
 ## Domain bindings
 

--- a/examples/issue-fix-reviewer-notification-sink-smoke.py
+++ b/examples/issue-fix-reviewer-notification-sink-smoke.py
@@ -42,6 +42,8 @@ class FakeSinkRunner:
         reader_verified: bool = True,
         include_member: bool = True,
         member_id: str = "ou_private_member",
+        search_returncode: int = 0,
+        search_hit: bool = False,
     ) -> None:
         self.send_returncode = send_returncode
         self.verify_returncode = verify_returncode
@@ -50,6 +52,8 @@ class FakeSinkRunner:
         self.reader_verified = reader_verified
         self.include_member = include_member
         self.member_id = member_id
+        self.search_returncode = search_returncode
+        self.search_hit = search_hit
         self.calls: list[list[str]] = []
 
     def __call__(self, args: list[str]) -> dict[str, Any]:
@@ -100,6 +104,29 @@ class FakeSinkRunner:
                     }
                 ),
                 "stderr": "",
+            }
+        if "+messages-search" in command:
+            query = command[command.index("--query") + 1]
+            return {
+                "returncode": self.search_returncode,
+                "stdout": (
+                    json.dumps(
+                        {
+                            "items": [
+                                {"body": {"content": query}}
+                                if self.search_hit
+                                else {"body": {"content": "another PR"}}
+                            ]
+                        }
+                    )
+                    if self.search_returncode == 0
+                    else ""
+                ),
+                "stderr": (
+                    "missing scope search:message"
+                    if self.search_returncode
+                    else ""
+                ),
             }
         if "+messages-send" in command:
             return {
@@ -526,7 +553,10 @@ def main() -> int:
     )
     assert explicit["ok"] is True, explicit
     assert explicit["results"][0]["reader_identity_verified"] is True
-    assert len(explicit_runner.calls) == 6, explicit_runner.calls
+    assert len(explicit_runner.calls) == 7, explicit_runner.calls
+    assert explicit["results"][0]["semantic_dedupe_status"] == (
+        "configured_chat_no_match"
+    )
     explicit_send = next(
         call for call in explicit_runner.calls if "+messages-send" in call
     )
@@ -555,6 +585,66 @@ def main() -> int:
         "fixture-sender-profile",
     ]
     assert_public_safe(explicit)
+
+    remote_duplicate_runner = FakeSinkRunner(search_hit=True)
+    remote_duplicate = build_issue_fix_reviewer_notification_sinks_result(
+        repo="owner/repo",
+        pr_number=42,
+        pr_url="https://github.com/owner/repo/pull/42",
+        author_handle="@current-author",
+        reviewer_handles=["@service-owner"],
+        sinks_input=fixture(explicit_profiles=True),
+        execute=True,
+        runner=remote_duplicate_runner,
+    )
+    assert remote_duplicate["status"] == "already_notified", remote_duplicate
+    assert remote_duplicate["results"][0]["semantic_dedupe_status"] == (
+        "configured_chat_match"
+    )
+    assert not any(
+        "+messages-send" in call for call in remote_duplicate_runner.calls
+    )
+
+    permission_fallback_runner = FakeSinkRunner(search_returncode=1)
+    permission_fallback = build_issue_fix_reviewer_notification_sinks_result(
+        repo="owner/repo",
+        pr_number=42,
+        pr_url="https://github.com/owner/repo/pull/42",
+        author_handle="@current-author",
+        reviewer_handles=["@service-owner"],
+        sinks_input=fixture(explicit_profiles=True),
+        execute=True,
+        runner=permission_fallback_runner,
+    )
+    assert permission_fallback["status"] == "sent_verified", permission_fallback
+    assert permission_fallback["results"][0]["semantic_dedupe_status"] == (
+        "permission_fallback"
+    )
+    assert any(
+        "+messages-send" in call for call in permission_fallback_runner.calls
+    )
+
+    inbox_history = fixture(explicit_profiles=True)
+    inbox_history["_semantic_history_pr_refs"] = [
+        "https://github.com/owner/repo/pull/42"
+    ]
+    inbox_history_runner = FakeSinkRunner(search_returncode=1)
+    inbox_duplicate = build_issue_fix_reviewer_notification_sinks_result(
+        repo="owner/repo",
+        pr_number=42,
+        pr_url="https://github.com/owner/repo/pull/42",
+        author_handle="@current-author",
+        reviewer_handles=["@service-owner"],
+        sinks_input=inbox_history,
+        execute=True,
+        runner=inbox_history_runner,
+    )
+    assert inbox_duplicate["status"] == "already_notified", inbox_duplicate
+    assert inbox_duplicate["semantic_history_evidence_applied"] is True
+    assert inbox_duplicate["results"][0]["semantic_dedupe_status"] == (
+        "persisted_evidence_match"
+    )
+    assert inbox_history_runner.calls == []
 
     missing_member = build_issue_fix_reviewer_notification_sinks_result(
         repo="owner/repo",

--- a/examples/issue-fix-reviewer-request-smoke.py
+++ b/examples/issue-fix-reviewer-request-smoke.py
@@ -237,6 +237,15 @@ class FakeCombinedRunner:
                 "stdout": json.dumps({"items": [{"member_id": "ou_private_member"}]}),
                 "stderr": "",
             }
+        if "+messages-search" in command:
+            self.lark_calls.append(command)
+            return {
+                "returncode": 0,
+                "stdout": json.dumps(
+                    {"items": [{"body": {"content": "another PR"}}]}
+                ),
+                "stderr": "",
+            }
         if "+messages-send" in command:
             self.lark_calls.append(command)
             return {
@@ -1403,7 +1412,7 @@ def main() -> int:
             runner=goal_execute_runner,
         )
         assert goal_execute["secondary_notification_status"] == "sent_verified"
-        assert len(goal_execute_runner.lark_calls) == 6
+        assert len(goal_execute_runner.lark_calls) == 7
         receipt = goal_execute["secondary_notifications"]["receipts"][0]
         receipt_write = persist_issue_fix_reviewer_notification_receipts(
             lifecycle_path,

--- a/examples/lark-event-inbox-smoke.py
+++ b/examples/lark-event-inbox-smoke.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -16,6 +17,7 @@ from loopx.capabilities.lark.event_inbox import (  # noqa: E402
     acknowledge_lark_event_inbox,
     ingest_lark_event_inbox,
     inspect_lark_event_inbox,
+    lark_event_inbox_contains_text,
     project_lark_event_inbox_urgency,
 )
 from loopx.capabilities.lark.inbox_reply import reply_lark_event_inbox  # noqa: E402
@@ -75,6 +77,16 @@ def main() -> None:
         )
         pending = inspect_lark_event_inbox(project=project, config_path=config)
         assert pending["thread_complete"] is True, pending
+        assert lark_event_inbox_contains_text(
+            project=project,
+            config_path=config,
+            text="record this feedback",
+        ) is True
+        assert lark_event_inbox_contains_text(
+            project=project,
+            config_path=config,
+            text="https://github.com/owner/repo/pull/404",
+        ) is False
 
         imported = ingest_lark_event_inbox(
             project=project,
@@ -425,6 +437,7 @@ def main() -> None:
                     "goals": [
                         {
                             "id": "lark-inbox-fixture",
+                            "repo": str(project),
                             "control_plane": {
                                 "lark_event_inbox": {
                                     "enabled": True,
@@ -462,6 +475,58 @@ def main() -> None:
         discovered_payload = json.loads(discovered.stdout)
         assert discovered_payload["configured"] is True, discovered_payload
         assert discovered_payload["pending_count"] == 0, discovered_payload
+
+        shared_registry = project / "registry.global.json"
+        shared_registry.write_text(
+            json.dumps(
+                {
+                    "registry_role": "global-local",
+                    "common_runtime_root": str(project / "shared-runtime"),
+                    "goals": [
+                        {
+                            "id": "lark-inbox-fixture",
+                            "repo": str(project),
+                            "source_registry": str(registry),
+                            "control_plane": {
+                                "lark_event_inbox": {
+                                    "enabled": True,
+                                    "config_path": (
+                                        ".loopx/config/lark-event-inbox.json"
+                                    ),
+                                }
+                            },
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        linked_worktree = project / "linked-worktree"
+        linked_worktree.mkdir()
+        routed = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--registry",
+                str(shared_registry),
+                "--format",
+                "json",
+                "lark-inbox",
+                "drain",
+                "--goal-id",
+                "lark-inbox-fixture",
+            ],
+            cwd=linked_worktree,
+            capture_output=True,
+            text=True,
+            check=False,
+            env={**os.environ, "PYTHONPATH": str(ROOT)},
+        )
+        assert routed.returncode == 0, routed.stderr
+        routed_payload = json.loads(routed.stdout)
+        assert routed_payload["configured"] is True, routed_payload
+        assert routed_payload["pending_count"] == 0, routed_payload
 
         reply_preview = subprocess.run(
             [

--- a/examples/project/configure-goal-smoke.py
+++ b/examples/project/configure-goal-smoke.py
@@ -311,7 +311,7 @@ def main() -> int:
             "config_path": ".loopx/config/reward-memory/experiment.json",
             "enabled_agents": ["codex-side-bypass"],
         }, goal
-        boundary = goal_boundary(goal)
+        boundary = goal_boundary(goal, registry_path=registry_path)
         assert boundary["capabilities"]["issue_fix_reviewer_notification"] == {
             "enabled": True,
             "config_pointer_registered": True,
@@ -320,7 +320,8 @@ def main() -> int:
             "enabled": True,
             "config_pointer_registered": True,
             "drain_command": (
-                "loopx lark-inbox drain --goal-id configure-goal-fixture --project ."
+                f"loopx --registry {registry_path} lark-inbox drain "
+                "--goal-id configure-goal-fixture"
             ),
             "urgency": {
                 "schema_version": "lark_event_inbox_urgency_v0",

--- a/loopx/capabilities/issue_fix/reviewer_cli.py
+++ b/loopx/capabilities/issue_fix/reviewer_cli.py
@@ -5,7 +5,6 @@ from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any
 
-from ...agent_registry import load_goal_from_registry
 from ...control_plane.reward_memory import reward_memory_goal_policy
 from ...domain_packs.issue_fix import (
     default_issue_fix_domain_state_ledger_path,
@@ -15,6 +14,7 @@ from ...domain_packs.issue_fix import (
 from ..lark.event_inbox import (
     acknowledge_lark_event_inbox,
     inspect_lark_event_inbox,
+    lark_event_inbox_contains_text,
 )
 from ..reward_memory.experiment import (
     resolve_reward_memory_experiment,
@@ -37,6 +37,7 @@ from .reviewer_request import (
     build_issue_fix_reviewer_request_packet,
     render_issue_fix_reviewer_request_markdown,
 )
+from ...control_plane.runtime.goal_project_route import resolve_goal_project_route
 
 
 AddFormat = Callable[[argparse.ArgumentParser], None]
@@ -244,7 +245,7 @@ def register_issue_fix_reviewer_commands(
     )
     reviewer_request_parser.add_argument(
         "--project",
-        default=".",
+        default=None,
         help="Project root used for goal-default sink config and issue_fix domain state.",
     )
     reviewer_request_parser.add_argument(
@@ -267,7 +268,7 @@ def register_issue_fix_reviewer_commands(
     )
     add_subcommand_format(reviewer_feedback_parser)
     reviewer_feedback_parser.add_argument("--goal-id", required=True)
-    reviewer_feedback_parser.add_argument("--project", default=".")
+    reviewer_feedback_parser.add_argument("--project")
     reviewer_feedback_parser.add_argument("--limit", type=int, default=20)
     reviewer_feedback_parser.add_argument(
         "--message-id",
@@ -290,37 +291,16 @@ def _load_goal_for_project(
     *,
     registry_path: Path | None,
     goal_id: str,
-    project: str | Path,
+    project: str | Path | None,
 ) -> tuple[dict[str, Any], Path]:
-    requested_project = Path(project).expanduser().resolve()
-    project_registry = requested_project / ".loopx" / "registry.json"
-    candidates = [
-        path for path in (registry_path, project_registry) if path is not None
-    ]
-    mismatched_goal = False
-    for candidate in dict.fromkeys(candidates):
-        goal = load_goal_from_registry(candidate, goal_id)
-        if not isinstance(goal, dict):
-            continue
-        goal_repo = str(goal.get("repo") or "").strip()
-        if not goal_repo:
-            raise ValueError(
-                "connected goal repository is required for goal-scoped "
-                "reviewer notification"
-            )
-        if Path(goal_repo).expanduser().resolve() == requested_project:
-            return goal, requested_project
-        mismatched_goal = True
-
-    if mismatched_goal:
-        raise ValueError(
-            "--project must match the connected goal repository for "
-            "goal-scoped reviewer notification"
-        )
-    raise ValueError(
-        "goal-scoped reviewer notification goal was not found in the active "
-        "or project-local registry"
+    if registry_path is None:
+        raise ValueError("goal-scoped reviewer notification requires a registry")
+    goal, requested_project, _ = resolve_goal_project_route(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        project_override=project,
     )
+    return goal, requested_project
 
 
 def _materialize_goal_reviewer_notification_lifecycle(
@@ -474,6 +454,7 @@ def handle_issue_fix_reviewer_command(
     reviewer_artifact_required = False
     reviewer_artifact_reward_memory: dict[str, Any] | None = None
     reward_memory_experiment_status = "not_configured"
+    semantic_history_status = "not_checked"
     if args.goal_id:
         goal, requested_project = _load_goal_for_project(
             registry_path=registry_path,
@@ -536,6 +517,36 @@ def handle_issue_fix_reviewer_command(
             existing_queued_receipts = reviewer_notification_queue_from_state(
                 notification_lifecycle_packet
             )
+            lark_group_configured = any(
+                isinstance(sink, Mapping) and sink.get("sink_kind") == "lark_chat"
+                for sink in (notification_sinks_input.get("sinks") or [])
+            )
+            if lark_group_configured:
+                config_ref = str(
+                    notification_sinks_input.get("feedback_inbox_config")
+                    or ".loopx/config/lark/event-inbox.json"
+                )
+                try:
+                    history_match = lark_event_inbox_contains_text(
+                        project=requested_project,
+                        config_path=config_ref,
+                        text=str(reference["permalink"]),
+                    )
+                except (OSError, ValueError):
+                    semantic_history_status = "unavailable"
+                else:
+                    semantic_history_status = (
+                        "matched" if history_match else "no_match"
+                    )
+                    if history_match:
+                        notification_sinks_input = {
+                            **notification_sinks_input,
+                            "_semantic_history_pr_refs": [
+                                str(reference["permalink"])
+                            ],
+                        }
+            else:
+                semantic_history_status = "not_applicable"
         reward_policy = reward_memory_goal_policy(goal)
         reviewer_artifact_required = bool(notification_sinks_input) and (
             reward_policy["enabled"] is True
@@ -618,6 +629,9 @@ def handle_issue_fix_reviewer_command(
     payload["reward_memory_experiment_status"] = reward_memory_experiment_status
     payload["secondary_notification_lifecycle_materialized"] = (
         notification_lifecycle_materialized
+    )
+    payload["secondary_notification_semantic_history_status"] = (
+        semantic_history_status
     )
     payload["secondary_notification_receipts_persisted"] = False
     payload["secondary_notification_queue_persisted"] = False

--- a/loopx/capabilities/issue_fix/reviewer_notification.py
+++ b/loopx/capabilities/issue_fix/reviewer_notification.py
@@ -32,6 +32,10 @@ LARK_PERMISSION_PATTERN = re.compile(
     r"lacks?\s+authority|99991672|230027|232033)",
     re.IGNORECASE,
 )
+LARK_SEARCH_PERMISSION_PATTERN = re.compile(
+    r"search:message|missing\s+scope[^\n]*(?:message|search)",
+    re.IGNORECASE,
+)
 SAFE_LOCAL_KEY_PATTERN = re.compile(r"[A-Za-z0-9._-]{1,100}")
 LARK_DESTINATION_PATTERN = re.compile(r"oc_[A-Za-z0-9_-]+")
 LARK_MEMBER_PATTERN = re.compile(r"ou_[A-Za-z0-9_-]+")
@@ -423,6 +427,14 @@ def _parse_json_object(value: Any) -> Mapping[str, Any] | None:
     return payload if isinstance(payload, Mapping) else None
 
 
+def _payload_contains_text(value: Any, text: str) -> bool:
+    if isinstance(value, Mapping):
+        return any(_payload_contains_text(child, text) for child in value.values())
+    if isinstance(value, list):
+        return any(_payload_contains_text(child, text) for child in value)
+    return isinstance(value, str) and text in value
+
+
 def _lark_member_ids(value: Any) -> set[str]:
     """Collect exact member ids from a provider response without retaining it."""
 
@@ -458,6 +470,7 @@ def _public_result(
     notification_verified: bool = False,
     bot_identity_verified: bool = False,
     reader_identity_verified: bool = False,
+    semantic_dedupe_status: str | None = None,
     blocker: str | None = None,
 ) -> dict[str, Any]:
     result: dict[str, Any] = {
@@ -482,6 +495,8 @@ def _public_result(
     }
     if blocker:
         result["blocker"] = blocker
+    if semantic_dedupe_status:
+        result["semantic_dedupe_status"] = semantic_dedupe_status
     return result
 
 
@@ -611,6 +626,7 @@ def _lark_result(
             ok=True,
             external_write_authority_asserted=execute,
             notification_verified=True,
+            semantic_dedupe_status="persisted_evidence_match",
         )
     if not execute:
         return _public_result(
@@ -623,6 +639,7 @@ def _lark_result(
         )
 
     reader_verified = False
+    semantic_dedupe_status = "not_configured"
     if explicit_profile_bindings:
         try:
             reader_status = runner(
@@ -701,6 +718,77 @@ def _lark_result(
                     else "reviewer_notification_provider_failed"
                 ),
             )
+
+        try:
+            semantic_search = runner(
+                [
+                    "lark-cli",
+                    "--profile",
+                    reader_profile,
+                    "im",
+                    "+messages-search",
+                    "--chat-id",
+                    destination_id,
+                    "--query",
+                    pr_url,
+                    "--page-size",
+                    "20",
+                    "--as",
+                    "user",
+                    "--no-reactions",
+                    "--format",
+                    "json",
+                ]
+            )
+        except (OSError, subprocess.SubprocessError):
+            semantic_search = {"returncode": 1}
+        semantic_payload = _parse_json_object(semantic_search.get("stdout"))
+        if semantic_search.get("returncode") == 0:
+            if semantic_payload is None:
+                return _public_result(
+                    sink_kind=sink_kind,
+                    reviewer_handles=reviewer_handles,
+                    idempotency_key=key,
+                    status="gate_required",
+                    ok=False,
+                    external_write_authority_asserted=True,
+                    reader_identity_verified=True,
+                    semantic_dedupe_status="provider_failed",
+                    blocker="reviewer_notification_dedupe_readback_failed",
+                )
+            if _payload_contains_text(semantic_payload, pr_url):
+                return _public_result(
+                    sink_kind=sink_kind,
+                    reviewer_handles=reviewer_handles,
+                    idempotency_key=key,
+                    status="already_notified",
+                    ok=True,
+                    external_write_authority_asserted=True,
+                    verification_performed=True,
+                    notification_verified=True,
+                    reader_identity_verified=True,
+                    semantic_dedupe_status="configured_chat_match",
+                )
+            semantic_dedupe_status = "configured_chat_no_match"
+        else:
+            provider_error = " ".join(
+                str(semantic_search.get(field) or "")
+                for field in ("stderr", "stdout")
+            )
+            if LARK_SEARCH_PERMISSION_PATTERN.search(provider_error):
+                semantic_dedupe_status = "permission_fallback"
+            else:
+                return _public_result(
+                    sink_kind=sink_kind,
+                    reviewer_handles=reviewer_handles,
+                    idempotency_key=key,
+                    status="gate_required",
+                    ok=False,
+                    external_write_authority_asserted=True,
+                    reader_identity_verified=True,
+                    semantic_dedupe_status="provider_failed",
+                    blocker="reviewer_notification_dedupe_readback_failed",
+                )
 
     try:
         identity_status = runner(
@@ -924,6 +1012,7 @@ def _lark_result(
         notification_verified=verified,
         bot_identity_verified=True,
         reader_identity_verified=reader_verified,
+        semantic_dedupe_status=semantic_dedupe_status,
         blocker=None if verified else "lark_notification_not_verified",
     )
 
@@ -1137,6 +1226,15 @@ def build_issue_fix_reviewer_notification_sinks_result(
         for value in (raw_receipts if isinstance(raw_receipts, list) else [])
         if re.fullmatch(r"sha256:[a-f0-9]{64}", str(value))
     }
+    semantic_history_pr_refs = {
+        public_safe_compact_text(value, limit=300)
+        for value in (
+            sinks_input.get("_semantic_history_pr_refs")
+            if isinstance(sinks_input.get("_semantic_history_pr_refs"), list)
+            else []
+        )
+        if public_safe_compact_text(value, limit=300)
+    }
     queued_receipts_by_key = {
         str(value["idempotency_key"]): value
         for value in reviewer_notification_queue_from_state(
@@ -1159,6 +1257,18 @@ def build_issue_fix_reviewer_notification_sinks_result(
     results: list[dict[str, Any]] = []
     for sink in sinks:
         sink_kind = str(sink.get("sink_kind") or "").strip()
+        if sink_kind == "lark_chat" and pr_url in semantic_history_pr_refs:
+            sink_instance_key = str(sink.get("sink_instance_key") or "").strip()
+            if SAFE_LOCAL_KEY_PATTERN.fullmatch(sink_instance_key):
+                receipts.add(
+                    _idempotency_key(
+                        repo=repo,
+                        pr_number=int(pr_number),
+                        sink_kind=sink_kind,
+                        sink_instance_key=sink_instance_key,
+                        reviewer_handles=reviewers,
+                    )
+                )
         adapter = adapters.get(sink_kind)
         if adapter and execute and not delivery_window["allowed"]:
             sink_instance_key = str(sink.get("sink_instance_key") or "").strip()
@@ -1281,6 +1391,9 @@ def build_issue_fix_reviewer_notification_sinks_result(
             ),
             "notification_verified": all(
                 result.get("notification_verified") is True for result in results
+            ),
+            "semantic_history_evidence_applied": bool(
+                pr_url in semantic_history_pr_refs
             ),
         }
     )

--- a/loopx/capabilities/lark/event_inbox.py
+++ b/loopx/capabilities/lark/event_inbox.py
@@ -412,6 +412,26 @@ def inspect_lark_event_inbox(
     }
 
 
+def lark_event_inbox_contains_text(
+    *, project: str | Path, config_path: str | Path, text: str
+) -> bool:
+    """Return content-free exact evidence from persisted configured-chat history."""
+
+    needle = " ".join(str(text or "").split())
+    if not needle:
+        raise ValueError("lark inbox history lookup requires non-empty text")
+    config = load_lark_event_inbox_config(project=project, config_path=config_path)
+    if not config["enabled"] or not config["thread_complete"]:
+        return False
+    inbox = config["inbox_path"]
+    return any(
+        needle in str(event.get("content") or "")
+        for path in (inbox.glob("*.json") if inbox.is_dir() else [])
+        if path.name != "processed.json"
+        if (event := _event_from_file(path)) is not None
+    )
+
+
 def acknowledge_lark_event_inbox(
     *,
     project: str | Path,

--- a/loopx/cli_commands/lark_inbox.py
+++ b/loopx/cli_commands/lark_inbox.py
@@ -18,17 +18,10 @@ from ..capabilities.lark.event_collector import (
     plan_lark_event_collector,
 )
 from ..capabilities.lark.event_collector_runtime import run_lark_event_collector
-from ..registry import read_json, registry_goals
+from ..control_plane.runtime.goal_project_route import resolve_goal_project_route
 
 
-def _goal_inbox_config(registry_path: Path, goal_id: str) -> str | None:
-    payload = read_json(registry_path)
-    goal = next(
-        (item for item in registry_goals(payload) if str(item.get("id")) == goal_id),
-        None,
-    )
-    if goal is None:
-        raise ValueError(f"goal_id not found in registry: {goal_id}")
+def _goal_inbox_config(goal: dict[str, object]) -> str | None:
     control_plane = (
         goal.get("control_plane") if isinstance(goal.get("control_plane"), dict) else {}
     )
@@ -42,11 +35,20 @@ def _goal_inbox_config(registry_path: Path, goal_id: str) -> str | None:
     return str(inbox.get("config_path") or "").strip() or None
 
 
-def _inbox_config(args: argparse.Namespace, registry_path: Path) -> str | None:
+def _inbox_context(
+    args: argparse.Namespace, registry_path: Path
+) -> tuple[Path, str | None]:
     if getattr(args, "config", None):
-        return str(args.config)
+        return Path(getattr(args, "project", None) or ".").expanduser(), str(
+            args.config
+        )
     if getattr(args, "goal_id", None):
-        return _goal_inbox_config(registry_path, str(args.goal_id))
+        goal, project, _ = resolve_goal_project_route(
+            registry_path=registry_path,
+            goal_id=str(args.goal_id),
+            project_override=getattr(args, "project", None),
+        )
+        return project, _goal_inbox_config(goal)
     raise ValueError("lark inbox requires --config or --goal-id")
 
 
@@ -64,7 +66,7 @@ def register_lark_inbox_commands(
         help="Return bounded unprocessed local-private events without acknowledging them.",
     )
     add_subcommand_format(drain)
-    drain.add_argument("--project", default=".")
+    drain.add_argument("--project")
     drain.add_argument("--config")
     drain.add_argument("--goal-id")
     drain.add_argument("--limit", type=int, default=20)
@@ -73,7 +75,7 @@ def register_lark_inbox_commands(
         help="Acknowledge events only after their actionable feedback is written back.",
     )
     add_subcommand_format(ack)
-    ack.add_argument("--project", default=".")
+    ack.add_argument("--project")
     ack.add_argument("--config")
     ack.add_argument("--goal-id")
     ack.add_argument("--message-id", action="append", required=True)
@@ -86,7 +88,7 @@ def register_lark_inbox_commands(
         ),
     )
     add_subcommand_format(reply)
-    reply.add_argument("--project", default=".")
+    reply.add_argument("--project")
     reply.add_argument("--config")
     reply.add_argument("--goal-id")
     reply.add_argument("--message-id", required=True)
@@ -100,7 +102,7 @@ def register_lark_inbox_commands(
         ),
     )
     add_subcommand_format(ingest)
-    ingest.add_argument("--project", default=".")
+    ingest.add_argument("--project")
     ingest.add_argument("--config")
     ingest.add_argument("--goal-id")
     ingest.add_argument("--execute", action="store_true")
@@ -176,7 +178,7 @@ def handle_lark_inbox_command(
         return None
     try:
         if args.lark_inbox_command == "drain":
-            config_path = _inbox_config(args, registry_path)
+            project, config_path = _inbox_context(args, registry_path)
             if config_path is None:
                 payload = {
                     "ok": True,
@@ -191,37 +193,37 @@ def handle_lark_inbox_command(
                 print_payload(payload, output_format(args), _render)
                 return 0
             payload = inspect_lark_event_inbox(
-                project=args.project,
+                project=project,
                 config_path=config_path,
                 limit=args.limit,
             )
         elif args.lark_inbox_command == "ack":
-            config_path = _inbox_config(args, registry_path)
+            project, config_path = _inbox_context(args, registry_path)
             if config_path is None:
                 raise ValueError("goal does not configure a Lark event inbox")
             payload = acknowledge_lark_event_inbox(
-                project=args.project,
+                project=project,
                 config_path=config_path,
                 message_ids=args.message_id,
                 execute=args.execute,
             )
         elif args.lark_inbox_command == "reply":
-            config_path = _inbox_config(args, registry_path)
+            project, config_path = _inbox_context(args, registry_path)
             if config_path is None:
                 raise ValueError("goal does not configure a Lark event inbox")
             payload = reply_lark_event_inbox(
-                project=args.project,
+                project=project,
                 config_path=config_path,
                 message_id=args.message_id,
                 text=args.text,
                 execute=args.execute,
             )
         elif args.lark_inbox_command == "ingest":
-            config_path = _inbox_config(args, registry_path)
+            project, config_path = _inbox_context(args, registry_path)
             if config_path is None:
                 raise ValueError("goal does not configure a Lark event inbox")
             payload = ingest_lark_event_inbox(
-                project=args.project,
+                project=project,
                 config_path=config_path,
                 events=_read_stdin_events(),
                 execute=args.execute,

--- a/loopx/control_plane/quota/goal_boundary.py
+++ b/loopx/control_plane/quota/goal_boundary.py
@@ -77,6 +77,7 @@ def goal_boundary(
     item: dict[str, Any] | None = None,
     *,
     agent_id: str | None = None,
+    registry_path: Path | None = None,
     lark_event_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
     reward_memory_experiment_status: Mapping[str, Any] | None = None,
 ) -> dict[str, Any] | None:
@@ -148,17 +149,18 @@ def goal_boundary(
         else {}
     )
     if lark_event_inbox.get("enabled") is True:
-        drain_command = shlex.join(
+        drain_parts = ["loopx"]
+        if registry_path is not None:
+            drain_parts.extend(["--registry", str(registry_path.expanduser())])
+        drain_parts.extend(
             [
-                "loopx",
                 "lark-inbox",
                 "drain",
                 "--goal-id",
                 str(goal.get("id") or ""),
-                "--project",
-                ".",
             ]
         )
+        drain_command = shlex.join(drain_parts)
         inbox_capability: dict[str, Any] = {
             "enabled": True,
             "config_pointer_registered": bool(lark_event_inbox.get("config_path")),

--- a/loopx/control_plane/runtime/goal_project_route.py
+++ b/loopx/control_plane/runtime/goal_project_route.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ...history import load_registry
+from ...paths import registry_project_root
+from ...registry import registry_goals
+from .runtime_projection_route import resolve_goal_source_runtime_route
+
+
+def resolve_goal_project_route(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    project_override: str | Path | None = None,
+) -> tuple[dict[str, Any], Path, dict[str, Any]]:
+    """Resolve a goal-scoped control-plane command to its canonical project.
+
+    Shared registries are read models.  A command invoked from a linked worktree
+    must therefore follow ``goal.source_registry`` before resolving relative,
+    local-private configuration pointers.  An explicit project remains a
+    consistency assertion; it must not silently replace the registered route.
+    """
+
+    route = resolve_goal_source_runtime_route(
+        registry_path=registry_path,
+        goal_id=goal_id,
+    )
+    source_registry = Path(str(route["source_registry"])).expanduser().resolve()
+
+    def load_goal(path: Path) -> tuple[dict[str, Any], dict[str, Any] | None]:
+        payload = load_registry(path)
+        matched = next(
+            (
+                item
+                for item in registry_goals(payload)
+                if str(item.get("id") or "") == goal_id
+            ),
+            None,
+        )
+        return payload, matched if isinstance(matched, dict) else None
+
+    _, goal = load_goal(source_registry)
+    if goal is None and project_override is not None:
+        requested = Path(project_override).expanduser().resolve()
+        project_registry = requested / ".loopx" / "registry.json"
+        if project_registry.is_file() and project_registry.resolve() != source_registry:
+            route = resolve_goal_source_runtime_route(
+                registry_path=project_registry,
+                goal_id=goal_id,
+            )
+            source_registry = Path(str(route["source_registry"])).expanduser().resolve()
+            _, goal = load_goal(source_registry)
+    if not isinstance(goal, dict):
+        raise ValueError(f"goal_id not found in canonical source registry: {goal_id}")
+    raw_repo = str(goal.get("repo") or "").strip()
+    if not raw_repo:
+        raise ValueError("connected goal repository is required")
+    project = Path(raw_repo).expanduser()
+    if not project.is_absolute():
+        project = registry_project_root(source_registry) / project
+    project = project.resolve()
+    if project_override is not None:
+        requested = Path(project_override).expanduser().resolve()
+        if requested != project:
+            raise ValueError(
+                "--project must match the canonical connected goal repository"
+            )
+    return goal, project, route

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -1308,10 +1308,14 @@ def build_quota_should_run(
             goal_id=safe_goal_id,
             agent_id=boundary_agent_id,
         )
+        boundary_registry_value = str(status_payload.get("registry") or "").strip()
         goal_boundary = _goal_boundary(
             registry_goal or item,
             item=item,
             agent_id=boundary_agent_id,
+            registry_path=(
+                Path(boundary_registry_value) if boundary_registry_value else None
+            ),
             lark_event_inbox_urgency_projector=_project_lark_event_inbox_urgency,
             reward_memory_experiment_status=reward_memory_experiment_status,
         )


### PR DESCRIPTION
## Summary

- resolve goal-scoped Lark inbox and reviewer configs through the registry's canonical `source_registry` project instead of the caller worktree
- project registry-bound inbox drain commands without `--project .`, while preserving an explicitly validated project-registry fallback for manual commands
- deduplicate reviewer notifications through durable receipts, persisted configured-chat inbox history, and bounded live chat search
- treat only missing `search:message` as a non-gating fallback; keep other provider read failures fail-closed
- document the route and dedupe contracts

## Product / architecture judgment

The defect was a split control-plane route: quota used shared registry truth while Lark config loading re-bound to the current worktree. The new reusable goal-project route makes the registry/source-registry chain authoritative for goal-scoped local-private config. Reviewer dedupe remains layered and provider-neutral at the lifecycle receipt boundary; Lark search is an optional evidence enhancement, not a new permission authority.

User/operator impact: independent worktrees no longer drain the wrong inbox, repeated PR review notifications can be recognized after local receipt loss, and a reader profile lacking only `search:message` no longer blocks ordinary issue-fix work.

Main risk is notification false-positive/false-negative behavior. Exact canonical PR URLs, bounded configured-chat scope, restart-safe receipts, readback, focused smokes, and fail-closed non-permission errors constrain it.

## Validation

- `python3 examples/lark-event-inbox-smoke.py`
- `python3 examples/issue-fix-reviewer-notification-sink-smoke.py`
- `python3 examples/issue-fix-reviewer-request-smoke.py`
- `python3 examples/project/configure-goal-smoke.py`
- `python3 examples/control_plane/quota-contract-smoke.py`
- `python3 examples/control_plane/heartbeat-prompt-smoke.py`
- `python3 examples/issue-fix-capability-guide-smoke.py`
- focused Ruff and `git diff --check`
- `loopx --format json canary premerge --from-git-diff` — 18/18 passed, public boundary clean, self-merge allowed
