### PR TITLE
fix(pr-review): prevent silent queue truncation

### DIFF
--- a/docs/reference/protocols/pr-review-command-v0.md
+++ b/docs/reference/protocols/pr-review-command-v0.md
@@ -43,7 +43,10 @@ command a guided review instead of a statistics table.
 When `--state all` is used, the command must preserve both lifecycle groups.
 The `--limit` value is applied per group so a busy open queue cannot consume the
 whole packet and make `review_groups.merged` empty while merged PRs exist in the
-window. Live GitHub reads should fetch open and closed/merged windows
+window. The default is 100 PRs per selected group. Every packet carries
+`result_completeness`; exhaustive requests must require `complete=true` and
+rerun with its `recommended_limit` when the source scan or packet slice was
+truncated. Live GitHub reads should fetch open and closed/merged windows
 separately before constructing the grouped packet.
 
 The agent response must not stop at a queue table. For `/loopx-pr-review`, the
@@ -85,13 +88,22 @@ absolute paths, private source bodies, or hidden CI artifacts.
     "command": "/loopx-pr-review",
     "cli_command": "loopx pr-review [--repo owner/repo] [--state open|merged|all] [--since ISO]",
     "repository": "owner/repo",
-    "limit": 10,
+    "limit": 100,
     "state_filter": "all",
     "since": "2026-06-28T00:00:00Z",
     "window": {"state_filter": "all", "since": "2026-06-28T00:00:00Z"},
     "source": "github_cli",
     "privacy_mode": "public_safe_github_metadata",
     "dry_run": true
+  },
+  "result_completeness": {
+    "schema_version": "pr_review_result_completeness_v0",
+    "complete": true,
+    "truncated": false,
+    "limit": 100,
+    "source_scan_complete": true,
+    "recommended_limit": null,
+    "rerun_cli_args": []
   },
   "summary": {
     "headline": "8 PR(s) in review window: 3 open, 5 merged; 8 need review attention.",
@@ -283,6 +295,9 @@ A first implementation is acceptable when:
   lifecycle group, and keeps `review_groups.merged` non-empty when merged PRs
   exist in the requested window; `--state open` preserves the old open-only
   review queue;
+- the default limit is 100, and exhaustive requests only proceed when
+  `result_completeness.complete=true`; truncated packets provide a larger
+  `recommended_limit` for the next read;
 - `--since` can bound an overnight or release-window review without relying on
   private chat memory;
 - the response includes review sequence, changed-file scope, status checks,

--- a/examples/pr-review-command-smoke.py
+++ b/examples/pr-review-command-smoke.py
@@ -14,7 +14,11 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
 import loopx.pr_review as pr_review_module
-from loopx.pr_review import _github_search_date
+from loopx.pr_review import (
+    _github_search_date,
+    build_pr_review_packet,
+    load_pr_fixture,
+)
 
 FIXTURE = REPO_ROOT / "examples" / "fixtures" / "pr-review.public.json"
 PR_REVIEW_SKILL = REPO_ROOT / "skills" / "loopx-pr-review" / "SKILL.md"
@@ -136,6 +140,8 @@ def main() -> int:
     assert request["dry_run"] is True, request
     assert request["repository"] == "owner/repo", request
     assert request["state_filter"] == "all", request
+    assert "result_completeness" in request["include"], request
+    assert payload["result_completeness"]["complete"] is True, payload
     assert payload["summary"]["total_pr_count"] == 4, payload["summary"]
     assert payload["summary"]["open_pr_count"] == 3, payload["summary"]
     assert payload["summary"]["merged_pr_count"] == 1, payload["summary"]
@@ -147,6 +153,7 @@ def main() -> int:
     assert groups["merged"]["group_id"] == "merged", groups
     assert groups["unmerged"]["count"] == 3, groups
     assert groups["merged"]["count"] == 1, groups
+    assert groups["merged"]["complete"] is True, groups
     assert 770 not in groups["unmerged"]["pr_numbers"], groups
     assert groups["merged"]["pr_numbers"] == [770], groups
     assert groups["unmerged"]["review_sequence"][0]["number"] == 773, groups
@@ -188,6 +195,66 @@ def main() -> int:
     assert main_risk["post_merge_review"] is False, main_risk
     assert main_risk["potential_regressions"], main_risk
     assert main_risk["bug_risks"], main_risk
+
+    default_payload = json.loads(
+        run_cli("--format", "json", "pr-review", "--fixture", str(FIXTURE)).stdout
+    )
+    assert default_payload["request"]["limit"] == 100, default_payload["request"]
+
+    repository, fixture_prs = load_pr_fixture(FIXTURE)
+    merged_fixture = next(item for item in fixture_prs if item.get("state") == "MERGED")
+    busy_window = []
+    for offset in range(105):
+        item = dict(merged_fixture)
+        item["number"] = 1000 + offset
+        item["url"] = f"https://github.com/owner/repo/pull/{1000 + offset}"
+        busy_window.append(item)
+    truncated = build_pr_review_packet(
+        pull_requests=busy_window,
+        repository=repository,
+        limit=100,
+        source="fixture",
+        state_filter="merged",
+    )
+    completeness = truncated["result_completeness"]
+    assert completeness["complete"] is False, completeness
+    assert completeness["groups"]["merged"] == {
+        "complete": False,
+        "observed_count": 105,
+        "included_count": 100,
+        "truncated": True,
+    }, completeness
+    assert completeness["recommended_limit"] >= 106, completeness
+    assert truncated["review_groups"]["merged"]["truncated"] is True, truncated
+
+    saturated_source = build_pr_review_packet(
+        pull_requests=busy_window[:100],
+        repository=repository,
+        limit=100,
+        source="github_cli",
+        state_filter="merged",
+        source_scan={
+            "schema_version": "pr_review_source_scan_v0",
+            "complete": False,
+            "pull_requests": busy_window[:100],
+            "states": [
+                {
+                    "state": "merged",
+                    "fetch_limit": 100,
+                    "fetched_count": 100,
+                    "included_after_window": 100,
+                    "source_saturated": True,
+                    "source_read_valid": True,
+                }
+            ],
+        },
+    )
+    saturated_completeness = saturated_source["result_completeness"]
+    assert saturated_completeness["complete"] is False, saturated_completeness
+    assert saturated_completeness["source_scan_complete"] is False, saturated_completeness
+    assert saturated_completeness["observed_count_is_lower_bound"] is True, saturated_completeness
+    assert "pull_requests" not in saturated_completeness["source_scan"], saturated_completeness
+    assert saturated_completeness["recommended_limit"] == 200, saturated_completeness
     assert main_risk["verification_focus"], main_risk
     assert "quota.py" not in json.dumps(main_risk), main_risk
     response_contract = payload["agent_response_contract"]
@@ -198,6 +265,7 @@ def main() -> int:
     assert response_contract["queue_table_role"] == "preface_only", response_contract
     assert response_contract["required_packet_fields_to_preserve"] == [
         "agent_response_contract",
+        "result_completeness",
         "review_groups",
         "pull_requests[].review_template",
         "pull_requests[].evidence_commands",

--- a/loopx/cli_commands/pr_review.py
+++ b/loopx/cli_commands/pr_review.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from ..pr_review import (
     build_pr_review_packet,
-    fetch_github_pull_requests,
+    scan_github_pull_requests,
     load_pr_fixture,
     normalize_pr_state_filter,
     render_pr_review_markdown,
@@ -34,7 +34,12 @@ def register_pr_review_command(
         "--repo",
         help="GitHub owner/repo to review. Defaults to the current project's gh repository context.",
     )
-    parser.add_argument("--limit", type=int, default=10, help="Maximum PRs to include.")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        help="Maximum PRs to include per selected lifecycle group.",
+    )
     parser.add_argument(
         "--state",
         choices=("open", "merged", "all"),
@@ -66,14 +71,16 @@ def handle_pr_review_command(
             repository_from_fixture, pull_requests = load_pr_fixture(Path(args.fixture).expanduser())
             repository = repository or repository_from_fixture
             source = "fixture"
+            source_scan = None
         else:
             repository = repository or resolve_current_github_repository()
-            pull_requests = fetch_github_pull_requests(
+            source_scan = scan_github_pull_requests(
                 repo=repository,
-                limit=max(1, args.limit),
+                limit=max(1, args.limit) + 1,
                 state_filter=normalize_pr_state_filter(args.state),
                 since=args.since,
             )
+            pull_requests = source_scan["pull_requests"]
         payload = build_pr_review_packet(
             pull_requests=pull_requests,
             repository=repository,
@@ -81,6 +88,7 @@ def handle_pr_review_command(
             source=source,
             state_filter=normalize_pr_state_filter(args.state),
             since=args.since,
+            source_scan=source_scan,
         )
     except Exception as exc:
         payload = {

--- a/loopx/pr_review.py
+++ b/loopx/pr_review.py
@@ -5,7 +5,7 @@ import re
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 from .control_plane.runtime.time import now_utc_iso
 from .presentation.markdown import as_dict as _as_dict
@@ -169,6 +169,24 @@ def fetch_github_pull_requests(
     state_filter: str = "all",
     since: str | None = None,
 ) -> list[dict[str, Any]]:
+    scan = scan_github_pull_requests(
+        repo=repo,
+        limit=limit,
+        cwd=cwd,
+        state_filter=state_filter,
+        since=since,
+    )
+    return list(scan["pull_requests"])
+
+
+def scan_github_pull_requests(
+    *,
+    repo: str | None,
+    limit: int,
+    cwd: Path | None = None,
+    state_filter: str = "all",
+    since: str | None = None,
+) -> dict[str, Any]:
     repo_args = ["--repo", repo] if repo else []
     normalized_state = normalize_pr_state_filter(state_filter)
     search_args: list[str] = []
@@ -203,6 +221,7 @@ def fetch_github_pull_requests(
 
     detailed: list[dict[str, Any]] = []
     seen_numbers: set[str] = set()
+    state_scans: list[dict[str, Any]] = []
 
     def append_state(state: str) -> None:
         rows = _run_gh_json(
@@ -221,7 +240,18 @@ def fetch_github_pull_requests(
             cwd=cwd,
         )
         if not isinstance(rows, list):
+            state_scans.append(
+                {
+                    "state": state,
+                    "fetch_limit": fetch_limit,
+                    "fetched_count": 0,
+                    "included_after_window": 0,
+                    "source_saturated": False,
+                    "source_read_valid": False,
+                }
+            )
             return
+        included_before = len(detailed)
         for row in rows:
             if not isinstance(row, dict):
                 continue
@@ -233,13 +263,32 @@ def fetch_github_pull_requests(
             if number:
                 seen_numbers.add(number)
             detailed.append(row)
+        state_scans.append(
+            {
+                "state": state,
+                "fetch_limit": fetch_limit,
+                "fetched_count": len(rows),
+                "included_after_window": len(detailed) - included_before,
+                "source_saturated": len(rows) >= fetch_limit,
+                "source_read_valid": True,
+            }
+        )
 
     if normalized_state == "all":
         append_state("open")
         append_state("closed")
     else:
         append_state(normalized_state)
-    return detailed
+    return {
+        "schema_version": "pr_review_source_scan_v0",
+        "complete": all(
+            item["source_read_valid"] is True
+            and item["source_saturated"] is False
+            for item in state_scans
+        ),
+        "pull_requests": detailed,
+        "states": state_scans,
+    }
 
 
 def load_pr_fixture(path: Path) -> tuple[str | None, list[dict[str, Any]]]:
@@ -595,6 +644,7 @@ def _agent_response_contract() -> dict[str, Any]:
         "default_review_scope": "Review PRs in review_groups.unmerged first, then review_groups.merged, bounded by the requested limit.",
         "required_packet_fields_to_preserve": [
             "agent_response_contract",
+            "result_completeness",
             "review_groups",
             "pull_requests[].review_template",
             "pull_requests[].evidence_commands",
@@ -616,9 +666,10 @@ def _agent_response_contract() -> dict[str, Any]:
         ],
         "instructions": [
             "Run loopx pr-review first and use review_groups as the queue.",
+            "Before treating the queue as exhaustive, require result_completeness.complete=true. If it is false and the user asked for all/every PR, rerun with result_completeness.recommended_limit and preserve the new full packet.",
             "When the visible message starts with /loopx-pr-review, treat words such as open, closed, merged, today, or time windows as filters, not as permission to return stats only.",
             "Do not stop at the queue/table summary when the user invokes /loopx-pr-review.",
-            "Do not pipe the JSON packet through jq or another projection that drops agent_response_contract, review_groups, pull_requests[].review_template, or pull_requests[].evidence_commands before planning the final answer.",
+            "Do not pipe the JSON packet through jq or another projection that drops agent_response_contract, result_completeness, review_groups, pull_requests[].review_template, or pull_requests[].evidence_commands before planning the final answer.",
             "For each selected PR, run the evidence_commands or equivalent PR body/diff reads before filling the five sections.",
             "Do not fill the five sections from metadata_risk_hint alone; metadata_risk_hint is only queue-ordering context.",
             "Use the installed loopx command or the intended checked-out LoopX worktree; if using python -m loopx.cli from a checkout, first confirm that checkout includes this response contract.",
@@ -822,6 +873,7 @@ def build_pr_review_packet(
     source: str,
     state_filter: str = "all",
     since: str | None = None,
+    source_scan: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     normalized_state_filter = normalize_pr_state_filter(state_filter)
     normalized_all = [_normalize_pr(item) for item in pull_requests]
@@ -843,6 +895,63 @@ def build_pr_review_packet(
         normalized = normalized_all[:packet_limit]
         unmerged_items = [item for item in normalized if str(item.get("state") or "").upper() != "MERGED"]
         merged_items = [item for item in normalized if str(item.get("state") or "").upper() == "MERGED"]
+    source_scan_complete = (
+        source_scan.get("complete") is True
+        if isinstance(source_scan, Mapping)
+        else True
+    )
+    group_observed_counts = {
+        "unmerged": len(unmerged_all),
+        "merged": len(merged_all),
+    }
+    group_included_counts = {
+        "unmerged": len(unmerged_items),
+        "merged": len(merged_items),
+    }
+    group_completeness = {
+        key: source_scan_complete
+        and group_included_counts[key] == group_observed_counts[key]
+        for key in group_observed_counts
+    }
+    complete = all(group_completeness.values())
+    recommended_limit = None
+    if not complete:
+        recommended_limit = max(
+            packet_limit * 2,
+            max(group_observed_counts.values(), default=0) + 1,
+        )
+    source_scan_summary = None
+    if isinstance(source_scan, Mapping):
+        source_scan_summary = {
+            key: value
+            for key, value in source_scan.items()
+            if key != "pull_requests"
+        }
+    result_completeness = {
+        "schema_version": "pr_review_result_completeness_v0",
+        "complete": complete,
+        "truncated": not complete,
+        "limit": packet_limit,
+        "limit_scope": "per_group" if normalized_state_filter == "all" else "filtered_queue",
+        "source_scan_complete": source_scan_complete,
+        "observed_count_is_lower_bound": not source_scan_complete,
+        "observed_pr_count": len(normalized_all),
+        "included_pr_count": len(normalized),
+        "groups": {
+            key: {
+                "complete": group_completeness[key],
+                "observed_count": group_observed_counts[key],
+                "included_count": group_included_counts[key],
+                "truncated": not group_completeness[key],
+            }
+            for key in ("unmerged", "merged")
+        },
+        "recommended_limit": recommended_limit,
+        "rerun_cli_args": (
+            ["--limit", str(recommended_limit)] if recommended_limit else []
+        ),
+        "source_scan": source_scan_summary,
+    }
     review_sequence = [_review_sequence_entry(item, rank=index) for index, item in enumerate(normalized, start=1)]
     open_review_required = [
         item
@@ -862,6 +971,9 @@ def build_pr_review_packet(
             "title": "Unmerged PRs",
             "intent": "Review before merge: decide approve, request changes, defer, or wait for checks.",
             "count": len(unmerged_items),
+            "complete": group_completeness["unmerged"],
+            "observed_count": group_observed_counts["unmerged"],
+            "truncated": not group_completeness["unmerged"],
             "pr_numbers": [item.get("number") for item in unmerged_items],
             "review_sequence": [
                 _review_sequence_entry(item, rank=index)
@@ -874,6 +986,9 @@ def build_pr_review_packet(
             "title": "Merged PRs",
             "intent": "Post-merge audit: check outcome, regression risk, and follow-up quality without blocking already-merged work.",
             "count": len(merged_items),
+            "complete": group_completeness["merged"],
+            "observed_count": group_observed_counts["merged"],
+            "truncated": not group_completeness["merged"],
             "pr_numbers": [item.get("number") for item in merged_items],
             "review_sequence": [
                 _review_sequence_entry(item, rank=index)
@@ -907,8 +1022,9 @@ def build_pr_review_packet(
             },
             "source": source,
             "include": [
-                "pull_request_list",
-                "review_groups",
+            "pull_request_list",
+            "result_completeness",
+            "review_groups",
                 "review_template",
                 "agent_response_contract",
                 "change_scope",
@@ -935,6 +1051,7 @@ def build_pr_review_packet(
             "source_surfaces": SOURCE_SURFACES,
             "recommended_first_pr": first,
         },
+        "result_completeness": result_completeness,
         "review_sequence": review_sequence,
         "review_groups": review_groups,
         "pull_requests": normalized,
@@ -987,6 +1104,7 @@ def render_pr_review_markdown(payload: dict[str, Any]) -> str:
 
     summary = _as_dict(payload.get("summary"))
     request = _as_dict(payload.get("request"))
+    completeness = _as_dict(payload.get("result_completeness"))
     lines = [
         "# Project PR Review Queue",
         "",
@@ -995,6 +1113,7 @@ def render_pr_review_markdown(payload: dict[str, Any]) -> str:
         f"- state_filter: `{request.get('state_filter') or 'all'}`",
         f"- since: `{request.get('since') or 'not set'}`",
         f"- headline: {summary.get('headline')}",
+        f"- complete: `{completeness.get('complete')}`; truncated=`{completeness.get('truncated')}`; recommended_limit=`{completeness.get('recommended_limit')}`",
         f"- counts: total=`{summary.get('total_pr_count')}`, open=`{summary.get('open_pr_count')}`, merged=`{summary.get('merged_pr_count')}`, review_attention=`{summary.get('review_attention_count')}`, draft=`{summary.get('draft_count')}`",
         "- tool contract: run `loopx pr-review` first and use its `review_groups`; use ad hoc `gh` commands only after selecting a PR from this packet.",
         "- final answer contract: queue/table is only a preface; `/loopx-pr-review` must return filled five-block review cards after reading PR evidence.",

--- a/skills/loopx-pr-review/SKILL.md
+++ b/skills/loopx-pr-review/SKILL.md
@@ -34,8 +34,10 @@ Translate user filters only into these CLI options:
 - `--repo owner/repo` for an explicit repository;
 - `--since ISO` for an explicit time window;
 - `--state open`, `--state merged`, or `--state all` for state filters.
+- `--limit N` when the user explicitly requests a bounded batch.
 
-Default to the current `gh` repository and `--state all`. Treat words like
+Default to the current `gh` repository, `--state all`, and the CLI's normal
+100-PR group limit. Treat words like
 `today`, `open`, `closed`, or `merged` as review-queue filters. They do not
 mean "stats only" unless the user explicitly says `只统计`, `只列出`,
 `stats only`, `list only`, `不要 review`, or `不用分析`.
@@ -45,6 +47,7 @@ mean "stats only" unless the user explicitly says `只统计`, `只列出`,
 Keep these fields in model context from the first CLI packet:
 
 - `agent_response_contract`;
+- `result_completeness`;
 - `review_groups`;
 - `pull_requests[].review_template`;
 - `pull_requests[].evidence_commands`.
@@ -62,6 +65,7 @@ import sys
 p = json.load(open(sys.argv[1]))
 print(json.dumps({
   "agent_response_contract": p.get("agent_response_contract"),
+  "result_completeness": p.get("result_completeness"),
   "review_groups": p.get("review_groups"),
   "pull_requests": [
     {
@@ -76,6 +80,16 @@ print(json.dumps({
 PY
 rm -f "$packet"
 ```
+
+## Require Complete Exhaustive Queues
+
+When the user asks for `all`, `every`, `全部`, `每个`, or an exhaustive time
+window, do not start reviewing until `result_completeness.complete=true`.
+When it is false, rerun the same first command with
+`--limit <result_completeness.recommended_limit>`. Repeat until complete,
+preserving the latest full packet as the queue source of truth. Never infer
+completeness from `summary.total_pr_count`, a count equal to the limit, or the
+absence of a pagination error.
 
 ## Review Flow
 


### PR DESCRIPTION
## Summary
- raise the default PR review group limit from 10 to 100
- add source-scan and result-completeness contracts with machine-readable rerun guidance
- require exhaustive slash-command requests to rerun until `complete=true`

## Validation
- `python3 examples/pr-review-command-smoke.py`
- `python3 -m py_compile loopx/pr_review.py loopx/cli_commands/pr_review.py examples/pr-review-command-smoke.py`
- `loopx --format json canary premerge --from-git-diff` (15/15 selected checks passed)
- live 24-hour merged window: 58 PRs, `result_completeness.complete=true`

## Boundary
- public-boundary scan passed
- no credentials, private state, local paths, or raw logs included