### PR TITLE
test: audit layered quality coverage

### DIFF
--- a/docs/development/testing-and-quality.md
+++ b/docs/development/testing-and-quality.md
@@ -29,6 +29,36 @@ that names the broken rule.
 这些层次互补：模型通过不能覆盖确定性合同失败；大规模 smoke 也不能代替明确指出
 错误规则的聚焦回归测试。
 
+High-risk shipped surfaces are registered in the machine-audited quality
+surface catalog. Each row names an independent semantic oracle and classifies
+every layer as `covered`, `not_applicable` with a reason, or `deferred` with an
+owner. This avoids both silent gaps and meaningless requirements such as using
+a model to judge deterministic scheduler precedence.
+
+高风险交付面需要进入可机器审计的质量 surface catalog。每一行都要指明独立语义
+oracle，并把每一层明确分类为 `covered`、有理由的 `not_applicable`，或有 owner 的
+`deferred`。这样既不会静默漏测，也不会强迫模型去判断确定性的 scheduler 优先级。
+
+```bash
+loopx canary quality-audit
+```
+
+Run it from a source checkout to validate that referenced product, test, and
+documentation paths still exist; packaged installs retain the classification
+audit but report that repository-reference validation is unavailable.
+
+在源码 checkout 中运行时，命令还会验证引用的产品、测试和文档路径仍然存在；打包
+安装仍可审计分类，但会明确报告仓库引用校验不可用。
+
+The audit fails on an unclassified high-risk canary profile, an oracle that
+reuses product source as expected truth, a missing deterministic minimum, or
+an unexplained exception. Valid deferred rows remain visible as backlog gaps
+without pretending that the repository is fully qualified.
+
+如果新增高风险 canary profile 却未分类、oracle 直接复用产品实现作为期望值、缺少
+确定性最小门禁，或例外没有理由，审计会失败。合法的 deferred 行仍作为 backlog
+缺口显式展示，不会伪装成仓库已经完全就绪。
+
 Tests first judge whether the state and rule are correct, then whether the
 implementation conforms. Expected outcomes come from an independently reviewed
 invariant, never the implementation under test or its current output.

--- a/examples/canary/quality-surface-catalog-smoke.py
+++ b/examples/canary/quality-surface-catalog-smoke.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Smoke-test the high-risk quality surface catalog and CLI audit."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.canary.planner import (  # noqa: E402
+    CURRENT_REPO_PROFILES,
+    build_quality_surface_catalog_audit,
+)
+
+
+def main() -> int:
+    audit = build_quality_surface_catalog_audit()
+    assert audit["ok"] is True, audit
+    assert audit["drift_count"] == 0, audit
+    assert audit["classified_surface_count"] == audit["high_risk_profile_count"], audit
+
+    high_risk_ids = {
+        str(profile["id"])
+        for profile in CURRENT_REPO_PROFILES
+        if profile.get("quality_risk") == "high"
+    }
+    classified_ids = {
+        str(surface["canary_profile_id"]) for surface in audit["surfaces"]
+    }
+    assert classified_ids == high_risk_ids, audit
+    assert all(gap.get("owner") and gap.get("rationale") for gap in audit["gaps"]), audit
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "canary",
+            "quality-audit",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    cli_audit = json.loads(completed.stdout)
+    assert cli_audit["schema_version"] == "quality_surface_catalog_audit_v0", cli_audit
+    assert cli_audit["drift_count"] == 0, cli_audit
+    assert cli_audit["executes_checks"] is False, cli_audit
+    print("quality surface catalog smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -5,6 +5,9 @@ from pathlib import Path
 from typing import Any
 
 from .qualification_profiles import CONTROL_PLANE_QUALIFICATION_PROFILES
+from .quality_surface_catalog import (
+    build_quality_surface_catalog_audit as _build_quality_surface_catalog_audit,
+)
 
 
 CANARY_PROFILE_SCHEMA_VERSION = "catalog_canary_profile_v0"
@@ -213,6 +216,7 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
     {
         "id": "release-promotion",
         "title": "Release promotion readiness",
+        "quality_risk": "high",
         "purpose": "Check whether the release/canary promotion path is ready without mutating the install.",
         "catalog_families": ["Work Routing", "Planning Governance", "State And Boundary"],
         "trigger_hints": (
@@ -248,6 +252,7 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
     {
         "id": "install-update",
         "title": "Install and update safety",
+        "quality_risk": "high",
         "purpose": "Check local install, packaged install, update planning, rollback, and uninstall safety before install/update changes ship.",
         "catalog_families": ["State And Boundary", "Work Routing", "Planning Governance"],
         "trigger_hints": (
@@ -702,6 +707,7 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
     {
         "id": "state-write-correctness",
         "title": "State write correctness",
+        "quality_risk": "high",
         "purpose": "Check local state writes, refresh-state, and todo write paths before touching writer internals.",
         "catalog_families": ["State And Boundary", "Planning Governance", "Human Decision"],
         "trigger_hints": ("state write", "refresh-state", "todo write", "idempotency", "revision", "lease"),
@@ -1000,6 +1006,7 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
     {
         "id": "new-user-onboarding-lifecycle",
         "title": "New-user onboarding lifecycle",
+        "quality_risk": "high",
         "purpose": (
             "Check fresh no-scan connection, structured todo projection, "
             "state-gap detection, and domain-adapter routing ownership."
@@ -1202,6 +1209,7 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
     {
         "id": "peer-agent-runtime",
         "title": "Peer agent runtime and migration",
+        "quality_risk": "high",
         "purpose": (
             "Check equal peer identity, deterministic task assignment, task-policy "
             "completion, symmetric workspace isolation, task-scoped coordination, "
@@ -1309,6 +1317,11 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
                 "tier": "deep",
                 "reason": "guards optional pytest/JUnit reporting while keeping canary smoke-suite as source of truth",
             },
+            {
+                "command": "python3 examples/canary/quality-surface-catalog-smoke.py",
+                "tier": "deep",
+                "reason": "guards high-risk surface classification, independent semantic oracles, and explicit quality-layer gaps",
+            },
         ],
     },
     {
@@ -1355,6 +1368,15 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
         ],
     },
 )
+
+
+def build_quality_surface_catalog_audit() -> dict[str, Any]:
+    """Audit quality-layer ownership for every high-risk canary profile."""
+
+    return _build_quality_surface_catalog_audit(
+        CURRENT_REPO_PROFILES,
+        repo_root=REPO_ROOT if (REPO_ROOT / "pyproject.toml").is_file() else None,
+    )
 
 
 def _slug(value: str) -> str:

--- a/loopx/canary/qualification_profiles.py
+++ b/loopx/canary/qualification_profiles.py
@@ -7,6 +7,7 @@ CONTROL_PLANE_QUALIFICATION_PROFILES: tuple[dict[str, Any], ...] = (
     {
         "id": "control-plane-state-machine",
         "title": "Control-plane state-machine composition",
+        "quality_risk": "high",
         "purpose": (
             "Run a bounded cross-state-machine canary when interaction, work-lane, "
             "scheduler, frontier, writeback, or quota-spend transitions change together."
@@ -100,6 +101,7 @@ CONTROL_PLANE_QUALIFICATION_PROFILES: tuple[dict[str, Any], ...] = (
     {
         "id": "agent-facing-cli-output-budget",
         "title": "Agent-facing CLI output qualification",
+        "quality_risk": "high",
         "purpose": (
             "Run exact stdout budgets and fail-closed command classification when "
             "recurring agent-facing CLI surfaces or their qualification contract change."

--- a/loopx/canary/quality_surface_catalog.py
+++ b/loopx/canary/quality_surface_catalog.py
@@ -1,0 +1,647 @@
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+
+QUALITY_SURFACE_CATALOG_SCHEMA_VERSION = "quality_surface_catalog_v0"
+QUALITY_SURFACE_AUDIT_SCHEMA_VERSION = "quality_surface_catalog_audit_v0"
+
+QUALITY_LAYER_IDS = (
+    "unit_contract",
+    "durable_smoke",
+    "catalog_canary",
+    "host_upgrade",
+    "model_behavior",
+    "release_gate",
+)
+DETERMINISTIC_MINIMUM_LAYERS = (
+    "unit_contract",
+    "durable_smoke",
+    "catalog_canary",
+)
+_LAYER_STATUSES = {"covered", "not_applicable", "deferred"}
+_ORACLE_SOURCE_KINDS = {
+    "external_standard",
+    "metamorphic_rule",
+    "reviewed_invariant",
+    "specification",
+}
+
+
+def _covered(*refs: str) -> dict[str, Any]:
+    return {"status": "covered", "refs": list(refs)}
+
+
+def _not_applicable(rationale: str) -> dict[str, Any]:
+    return {"status": "not_applicable", "rationale": rationale}
+
+
+def _deferred(*, owner: str, rationale: str) -> dict[str, Any]:
+    return {"status": "deferred", "owner": owner, "rationale": rationale}
+
+
+QUALITY_SURFACE_CATALOG: tuple[dict[str, Any], ...] = (
+    {
+        "surface_id": "interaction-scheduler-authority",
+        "title": "Interaction contract and scheduler authority",
+        "risk": "high",
+        "canary_profile_id": "control-plane-state-machine",
+        "owner_paths": [
+            "loopx/control_plane/scheduler/arbitration.py",
+            "loopx/control_plane/todos/decision_scope.py",
+            "loopx/control_plane/work_items/interaction_contract.py",
+        ],
+        "semantic_oracle": {
+            "source_kind": "metamorphic_rule",
+            "refs": [
+                "tests/fixtures/control_plane/public_safe_decision_replay_v0.json"
+            ],
+            "independence_rationale": (
+                "Reviewed source facts and precedence invariants define the expected "
+                "decision; lower-level should-run fields are mutated independently of "
+                "the production scheduler."
+            ),
+        },
+        "layers": {
+            "unit_contract": _covered(
+                "tests/control_plane/test_scheduler_interaction_arbitration.py",
+                "tests/control_plane/test_todo_decision_scope_consistency.py",
+                "tests/control_plane/test_public_safe_decision_replay.py",
+            ),
+            "durable_smoke": _covered(
+                "examples/control_plane/interaction-scheduler-authority-smoke.py"
+            ),
+            "catalog_canary": _covered("control-plane-state-machine"),
+            "host_upgrade": _not_applicable(
+                "The precedence rule is host-independent and is exercised before host scheduling."
+            ),
+            "model_behavior": _not_applicable(
+                "A stochastic actor must not decide deterministic scheduler precedence."
+            ),
+            "release_gate": _covered(
+                "loopx canary premerge --profile control-plane-state-machine"
+            ),
+        },
+    },
+    {
+        "surface_id": "agent-facing-cli-output",
+        "title": "Agent-facing guided projection and output budgets",
+        "risk": "high",
+        "canary_profile_id": "agent-facing-cli-output-budget",
+        "owner_paths": [
+            "loopx/bootstrap_command_pack.py",
+            "loopx/control_plane/testing/cli_output_budget.py",
+            "loopx/control_plane/quota/turn_envelope.py",
+        ],
+        "semantic_oracle": {
+            "source_kind": "specification",
+            "refs": ["docs/interface-budget-contract.md"],
+            "independence_rationale": (
+                "The interface contract names required actions and semantic anchors; "
+                "current stdout is measured against that contract rather than copied into a golden."
+            ),
+        },
+        "layers": {
+            "unit_contract": _covered(
+                "tests/control_plane/test_cli_output_budget.py",
+                "tests/control_plane/test_cli_output_differential.py",
+                "tests/control_plane/test_start_goal_compact_projection.py",
+            ),
+            "durable_smoke": _covered(
+                "examples/control_plane/cli-output-budget-regression-smoke.py"
+            ),
+            "catalog_canary": _covered("agent-facing-cli-output-budget"),
+            "host_upgrade": _not_applicable(
+                "Host activation and upgrade continuity are owned by the onboarding and install surfaces."
+            ),
+            "model_behavior": _covered(
+                "onboarding_actual_behavior_qualification_v0"
+            ),
+            "release_gate": _covered(
+                "loopx canary premerge --profile agent-facing-cli-output-budget"
+            ),
+        },
+    },
+    {
+        "surface_id": "release-promotion",
+        "title": "Exact-source release promotion",
+        "risk": "high",
+        "canary_profile_id": "release-promotion",
+        "owner_paths": [
+            "loopx/control_plane/runtime/promotion_readiness.py",
+            "loopx/promotion_gate.py",
+            "loopx/release_manifest.py",
+        ],
+        "semantic_oracle": {
+            "source_kind": "specification",
+            "refs": ["docs/product/release-readiness.md"],
+            "independence_rationale": (
+                "Promotion requirements are declared before a candidate run and bind evidence "
+                "to source identity instead of accepting the latest generated receipt."
+            ),
+        },
+        "layers": {
+            "unit_contract": _covered(
+                "tests/control_plane/test_release_outcome_baseline.py",
+                "tests/test_doctor_install_freshness.py",
+            ),
+            "durable_smoke": _covered(
+                "examples/canary/canary-promotion-readiness-smoke.py"
+            ),
+            "catalog_canary": _covered("release-promotion"),
+            "host_upgrade": _covered(
+                "examples/release/release-version-contract-smoke.py"
+            ),
+            "model_behavior": _not_applicable(
+                "Provider behavior is qualified only when a release changes agent-facing semantics."
+            ),
+            "release_gate": _covered("loopx canary premerge --profile release-promotion"),
+        },
+    },
+    {
+        "surface_id": "install-update-safety",
+        "title": "Install and update safety",
+        "risk": "high",
+        "canary_profile_id": "install-update",
+        "owner_paths": [
+            "loopx/self_update.py",
+            "scripts/install-from-github.sh",
+            "scripts/install-local.sh",
+        ],
+        "semantic_oracle": {
+            "source_kind": "specification",
+            "refs": ["docs/product/codex-cli-packaged-install.md"],
+            "independence_rationale": (
+                "The packaged-install contract defines provenance, rollback, and no-system-mutation "
+                "requirements independently of installer output."
+            ),
+        },
+        "layers": {
+            "unit_contract": _covered(
+                "tests/test_doctor_install_freshness.py",
+                "tests/test_slash_command_install.py",
+            ),
+            "durable_smoke": _covered("examples/install-local-smoke.py"),
+            "catalog_canary": _covered("install-update"),
+            "host_upgrade": _covered("examples/loopx-update-smoke.py"),
+            "model_behavior": _not_applicable(
+                "Installer correctness is deterministic and must not depend on model interpretation."
+            ),
+            "release_gate": _covered("loopx canary premerge --profile install-update"),
+        },
+    },
+    {
+        "surface_id": "state-write-correctness",
+        "title": "State and todo write correctness",
+        "risk": "high",
+        "canary_profile_id": "state-write-correctness",
+        "owner_paths": [
+            "loopx/state_refresh.py",
+            "loopx/todos.py",
+            "loopx/control_plane/runtime",
+        ],
+        "semantic_oracle": {
+            "source_kind": "reviewed_invariant",
+            "refs": ["docs/product/core-control-plane/state-machine.md"],
+            "independence_rationale": (
+                "Lifecycle invariants define legal revisions, ownership, and idempotency before "
+                "writer implementations are exercised."
+            ),
+        },
+        "layers": {
+            "unit_contract": _covered("tests/control_plane/test_task_lease.py"),
+            "durable_smoke": _covered(
+                "examples/control_plane/refresh-state-write-correctness-smoke.py",
+                "examples/control_plane/todo-write-correctness-smoke.py",
+            ),
+            "catalog_canary": _covered("state-write-correctness"),
+            "host_upgrade": _not_applicable(
+                "Host continuity does not change the state writer's atomicity and lifecycle rules."
+            ),
+            "model_behavior": _not_applicable(
+                "State mutation safety is a deterministic contract, not a model judgment."
+            ),
+            "release_gate": _covered(
+                "loopx canary premerge --profile state-write-correctness"
+            ),
+        },
+    },
+    {
+        "surface_id": "new-user-onboarding",
+        "title": "New-user goal start and host activation",
+        "risk": "high",
+        "canary_profile_id": "new-user-onboarding-lifecycle",
+        "owner_paths": [
+            "loopx/agent_onboarding.py",
+            "loopx/bootstrap_command_pack.py",
+            "loopx/host_loop_activation.py",
+        ],
+        "semantic_oracle": {
+            "source_kind": "specification",
+            "refs": [
+                "docs/reference/protocols/model-behavior-qualification-v0.md"
+            ],
+            "independence_rationale": (
+                "The onboarding contract specifies identity, goal selection, command, and host "
+                "activation outcomes before the actual default packet is shown to the actor."
+            ),
+        },
+        "layers": {
+            "unit_contract": _covered(
+                "tests/control_plane/test_goal_start_control_score.py",
+                "tests/control_plane/test_start_goal_compact_projection.py",
+                "tests/control_plane/test_onboarding_model_behavior_qualification.py",
+            ),
+            "durable_smoke": _covered(
+                "examples/project/onboarding-no-scan-projection-smoke.py"
+            ),
+            "catalog_canary": _covered("new-user-onboarding-lifecycle"),
+            "host_upgrade": _covered(
+                "examples/control_plane/agent-onboard-host-loop-activation-smoke.py"
+            ),
+            "model_behavior": _covered(
+                "onboarding_actual_behavior_qualification_v0"
+            ),
+            "release_gate": _covered(
+                "loopx canary premerge --profile new-user-onboarding-lifecycle"
+            ),
+        },
+    },
+    {
+        "surface_id": "peer-agent-runtime",
+        "title": "Peer identity, claims, leases, and continuation",
+        "risk": "high",
+        "canary_profile_id": "peer-agent-runtime",
+        "owner_paths": [
+            "loopx/control_plane/agents",
+            "loopx/control_plane/quota/task_orchestration.py",
+            "loopx/control_plane/todos/completion_policy.py",
+        ],
+        "semantic_oracle": {
+            "source_kind": "specification",
+            "refs": ["docs/reference/protocols/peer-agent-runtime-v1.md"],
+            "independence_rationale": (
+                "The rank-free ownership and continuation protocol defines legal routing before "
+                "the quota and workspace implementations are evaluated."
+            ),
+        },
+        "layers": {
+            "unit_contract": _covered(
+                "tests/control_plane/test_task_lease.py",
+                "tests/control_plane/test_user_gate_lane_progress.py",
+            ),
+            "durable_smoke": _covered(
+                "examples/control_plane/peer-agent-runtime-v1-smoke.py"
+            ),
+            "catalog_canary": _covered("peer-agent-runtime"),
+            "host_upgrade": _covered(
+                "examples/project/configure-goal-global-sync-smoke.py"
+            ),
+            "model_behavior": _deferred(
+                owner="codex-quality-qualification",
+                rationale=(
+                    "The actual-default one-arm portfolio does not yet exercise peer identity "
+                    "selection and same-agent continuation as a model interpretation scenario."
+                ),
+            ),
+            "release_gate": _covered("loopx canary premerge --profile peer-agent-runtime"),
+        },
+    },
+)
+
+
+def _text_list(value: Any) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def _repo_path_ref(value: str) -> str | None:
+    if " " in value or not value.startswith(
+        ("docs/", "examples/", "loopx/", "scripts/", "tests/")
+    ):
+        return None
+    return value.split("#", 1)[0]
+
+
+def build_quality_surface_catalog_audit(
+    domain_profiles: Iterable[Mapping[str, Any]],
+    *,
+    catalog: Iterable[Mapping[str, Any]] = QUALITY_SURFACE_CATALOG,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    profiles = [dict(profile) for profile in domain_profiles]
+    high_risk_profile_ids = sorted(
+        str(profile.get("id") or "")
+        for profile in profiles
+        if profile.get("quality_risk") == "high" and profile.get("id")
+    )
+    entries = [deepcopy(dict(entry)) for entry in catalog]
+    profile_ids = {str(profile.get("id") or "") for profile in profiles}
+    entry_ids = [str(entry.get("surface_id") or "") for entry in entries]
+    entry_profile_ids = [str(entry.get("canary_profile_id") or "") for entry in entries]
+
+    drift: list[dict[str, Any]] = []
+    gaps: list[dict[str, Any]] = []
+    layer_counts: dict[str, Counter[str]] = {
+        layer_id: Counter() for layer_id in QUALITY_LAYER_IDS
+    }
+
+    for surface_id, count in Counter(entry_ids).items():
+        if not surface_id or count > 1:
+            drift.append(
+                {
+                    "code": "duplicate_or_missing_surface_id",
+                    "surface_id": surface_id or None,
+                    "count": count,
+                }
+            )
+    for profile_id, count in Counter(entry_profile_ids).items():
+        if not profile_id or count > 1:
+            drift.append(
+                {
+                    "code": "duplicate_or_missing_canary_profile_id",
+                    "canary_profile_id": profile_id or None,
+                    "count": count,
+                }
+            )
+
+    classified_profile_ids = set(entry_profile_ids)
+    for profile_id in high_risk_profile_ids:
+        if profile_id not in classified_profile_ids:
+            drift.append(
+                {
+                    "code": "unclassified_high_risk_profile",
+                    "canary_profile_id": profile_id,
+                }
+            )
+
+    high_risk_set = set(high_risk_profile_ids)
+    for entry in entries:
+        surface_id = str(entry.get("surface_id") or "")
+        profile_id = str(entry.get("canary_profile_id") or "")
+        if profile_id not in profile_ids:
+            drift.append(
+                {
+                    "code": "unknown_canary_profile",
+                    "surface_id": surface_id,
+                    "canary_profile_id": profile_id,
+                }
+            )
+        elif profile_id not in high_risk_set:
+            drift.append(
+                {
+                    "code": "catalog_profile_not_marked_high_risk",
+                    "surface_id": surface_id,
+                    "canary_profile_id": profile_id,
+                }
+            )
+
+        owner_paths = _text_list(entry.get("owner_paths"))
+        if not owner_paths:
+            drift.append({"code": "missing_owner_paths", "surface_id": surface_id})
+        if repo_root is not None:
+            for owner_path in owner_paths:
+                if not (repo_root / owner_path).exists():
+                    drift.append(
+                        {
+                            "code": "missing_repository_reference",
+                            "surface_id": surface_id,
+                            "ref": owner_path,
+                            "ref_role": "owner_path",
+                        }
+                    )
+
+        oracle = entry.get("semantic_oracle")
+        oracle_map = dict(oracle) if isinstance(oracle, Mapping) else {}
+        oracle_kind = str(oracle_map.get("source_kind") or "")
+        oracle_refs = _text_list(oracle_map.get("refs"))
+        if oracle_kind not in _ORACLE_SOURCE_KINDS:
+            drift.append(
+                {
+                    "code": "invalid_or_implementation_derived_oracle",
+                    "surface_id": surface_id,
+                    "source_kind": oracle_kind or None,
+                }
+            )
+        if not oracle_refs or not str(
+            oracle_map.get("independence_rationale") or ""
+        ).strip():
+            drift.append(
+                {"code": "incomplete_semantic_oracle", "surface_id": surface_id}
+            )
+        overlap = sorted(set(owner_paths) & set(oracle_refs))
+        if overlap:
+            drift.append(
+                {
+                    "code": "circular_oracle_uses_product_source",
+                    "surface_id": surface_id,
+                    "refs": overlap,
+                }
+            )
+        if repo_root is not None:
+            for oracle_ref in oracle_refs:
+                repo_ref = _repo_path_ref(oracle_ref)
+                if repo_ref and not (repo_root / repo_ref).exists():
+                    drift.append(
+                        {
+                            "code": "missing_repository_reference",
+                            "surface_id": surface_id,
+                            "ref": oracle_ref,
+                            "ref_role": "semantic_oracle",
+                        }
+                    )
+
+        raw_layers = entry.get("layers")
+        layers = dict(raw_layers) if isinstance(raw_layers, Mapping) else {}
+        unknown_layers = sorted(set(layers) - set(QUALITY_LAYER_IDS))
+        if unknown_layers:
+            drift.append(
+                {
+                    "code": "unknown_quality_layers",
+                    "surface_id": surface_id,
+                    "layers": unknown_layers,
+                }
+            )
+        evidence_layers: defaultdict[str, list[str]] = defaultdict(list)
+        for layer_id in QUALITY_LAYER_IDS:
+            raw_layer = layers.get(layer_id)
+            layer = dict(raw_layer) if isinstance(raw_layer, Mapping) else {}
+            status = str(layer.get("status") or "")
+            layer_counts[layer_id][status or "missing"] += 1
+            if status not in _LAYER_STATUSES:
+                drift.append(
+                    {
+                        "code": "missing_or_invalid_layer_status",
+                        "surface_id": surface_id,
+                        "layer": layer_id,
+                    }
+                )
+                continue
+            refs = _text_list(layer.get("refs"))
+            rationale = str(layer.get("rationale") or "").strip()
+            owner = str(layer.get("owner") or "").strip()
+            if status == "covered":
+                if not refs:
+                    drift.append(
+                        {
+                            "code": "covered_layer_has_no_evidence",
+                            "surface_id": surface_id,
+                            "layer": layer_id,
+                        }
+                    )
+                for ref in refs:
+                    evidence_layers[ref].append(layer_id)
+                    repo_ref = _repo_path_ref(ref)
+                    if (
+                        repo_root is not None
+                        and repo_ref
+                        and not (repo_root / repo_ref).exists()
+                    ):
+                        drift.append(
+                            {
+                                "code": "missing_repository_reference",
+                                "surface_id": surface_id,
+                                "ref": ref,
+                                "ref_role": layer_id,
+                            }
+                        )
+            elif status == "not_applicable" and not rationale:
+                drift.append(
+                    {
+                        "code": "not_applicable_without_rationale",
+                        "surface_id": surface_id,
+                        "layer": layer_id,
+                    }
+                )
+            elif status == "deferred":
+                if not rationale or not owner:
+                    drift.append(
+                        {
+                            "code": "deferred_without_owner_or_rationale",
+                            "surface_id": surface_id,
+                            "layer": layer_id,
+                        }
+                    )
+                else:
+                    gaps.append(
+                        {
+                            "code": "deferred_quality_layer",
+                            "surface_id": surface_id,
+                            "layer": layer_id,
+                            "owner": owner,
+                            "rationale": rationale,
+                        }
+                    )
+
+        for required_layer in DETERMINISTIC_MINIMUM_LAYERS:
+            required_layer_value = layers.get(required_layer)
+            required_status = (
+                required_layer_value.get("status")
+                if isinstance(required_layer_value, Mapping)
+                else None
+            )
+            if required_status != "covered":
+                drift.append(
+                    {
+                        "code": "high_risk_deterministic_minimum_missing",
+                        "surface_id": surface_id,
+                        "layer": required_layer,
+                    }
+                )
+        canary_layer = layers.get("catalog_canary")
+        canary_refs = (
+            _text_list(canary_layer.get("refs"))
+            if isinstance(canary_layer, Mapping)
+            else []
+        )
+        if profile_id and profile_id not in canary_refs:
+            drift.append(
+                {
+                    "code": "catalog_canary_profile_mismatch",
+                    "surface_id": surface_id,
+                    "canary_profile_id": profile_id,
+                }
+            )
+        for ref, layer_ids in sorted(evidence_layers.items()):
+            if len(layer_ids) > 1:
+                drift.append(
+                    {
+                        "code": "duplicate_evidence_across_layers",
+                        "surface_id": surface_id,
+                        "ref": ref,
+                        "layers": layer_ids,
+                    }
+                )
+
+    normalized_layer_counts = {
+        layer_id: dict(sorted(counts.items()))
+        for layer_id, counts in layer_counts.items()
+    }
+    return {
+        "ok": not drift,
+        "ready": not drift and not gaps,
+        "schema_version": QUALITY_SURFACE_AUDIT_SCHEMA_VERSION,
+        "catalog_schema_version": QUALITY_SURFACE_CATALOG_SCHEMA_VERSION,
+        "dry_run": True,
+        "executes_checks": False,
+        "repository_reference_validation": (
+            "performed" if repo_root is not None else "source_checkout_unavailable"
+        ),
+        "high_risk_profile_count": len(high_risk_profile_ids),
+        "classified_surface_count": len(entries),
+        "drift_count": len(drift),
+        "gap_count": len(gaps),
+        "high_risk_profile_ids": high_risk_profile_ids,
+        "layer_counts": normalized_layer_counts,
+        "drift": drift,
+        "gaps": gaps,
+        "surfaces": entries,
+        "note": (
+            "Every high-risk canary profile must have one independently sourced semantic "
+            "oracle and an explicit classification for every quality layer. Covered, "
+            "not-applicable, and deferred are different states: model and host tests are "
+            "required only when their semantics apply."
+        ),
+    }
+
+
+def render_quality_surface_catalog_audit_markdown(payload: Mapping[str, Any]) -> str:
+    lines = [
+        "# Quality Surface Catalog Audit",
+        "",
+        f"- high_risk_profiles: `{payload.get('high_risk_profile_count')}`",
+        f"- classified_surfaces: `{payload.get('classified_surface_count')}`",
+        f"- drift: `{payload.get('drift_count')}`",
+        f"- deferred_gaps: `{payload.get('gap_count')}`",
+        f"- ready: `{str(bool(payload.get('ready'))).lower()}`",
+        "- repository_reference_validation: "
+        f"`{payload.get('repository_reference_validation')}`",
+        "- dry_run: `true`",
+        "- executes_checks: `false`",
+        "",
+        str(payload.get("note") or ""),
+        "",
+    ]
+    if payload.get("drift"):
+        lines.extend(["## Drift", ""])
+        for item in payload.get("drift", []):
+            if isinstance(item, Mapping):
+                lines.append(
+                    f"- `{item.get('code')}` surface=`{item.get('surface_id')}`"
+                )
+        lines.append("")
+    if payload.get("gaps"):
+        lines.extend(["## Deferred Gaps", ""])
+        for item in payload.get("gaps", []):
+            if isinstance(item, Mapping):
+                lines.append(
+                    f"- `{item.get('surface_id')}` / `{item.get('layer')}`: "
+                    f"{item.get('rationale')} (owner: `{item.get('owner')}`)"
+                )
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"

--- a/loopx/cli_commands/canary.py
+++ b/loopx/cli_commands/canary.py
@@ -10,9 +10,13 @@ from ..canary.planner import (
     build_catalog_canary_coverage_audit,
     build_catalog_canary_plan,
     build_catalog_canary_profiles,
+    build_quality_surface_catalog_audit,
     render_catalog_canary_coverage_audit_markdown,
     render_catalog_canary_plan_markdown,
     render_catalog_canary_profiles_markdown,
+)
+from ..canary.quality_surface_catalog import (
+    render_quality_surface_catalog_audit_markdown,
 )
 from ..canary.premerge import (
     PREMERGE_TIERS,
@@ -436,6 +440,15 @@ def register_canary_commands(
         help="Pattern priority to audit. Defaults to P0 and P1; repeat for multiple priorities.",
     )
 
+    quality_audit_parser = canary_sub.add_parser(
+        "quality-audit",
+        help=(
+            "Audit high-risk shipped surfaces for an independent oracle and explicit "
+            "unit, smoke, canary, host, model, and release-layer classification."
+        ),
+    )
+    add_subcommand_format(quality_audit_parser)
+
     premerge_parser = canary_sub.add_parser(
         "premerge",
         help="Run a risk-based pre-merge validation gate for the current diff.",
@@ -552,6 +565,9 @@ def handle_canary_command(
             priorities=list(args.priority or []) or None,
         )
         renderer = render_catalog_canary_coverage_audit_markdown
+    elif args.canary_command == "quality-audit":
+        payload = build_quality_surface_catalog_audit()
+        renderer = render_quality_surface_catalog_audit_markdown
     elif args.canary_command == "premerge":
         changed_files, git_diff_selector = _resolve_canary_changed_files(args)
         payload = build_premerge_validation_gate(
@@ -573,7 +589,7 @@ def handle_canary_command(
     else:
         raise ValueError(
             "canary requires `profiles`, `plan`, `run`, `smoke-suite`, "
-            "`coverage-audit`, or `premerge`"
+            "`coverage-audit`, `quality-audit`, or `premerge`"
         )
     print_payload(payload, output_format(args), renderer)
     return 0 if payload.get("ok") else 1

--- a/tests/canary/test_quality_surface_catalog.py
+++ b/tests/canary/test_quality_surface_catalog.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+from loopx.canary.planner import CURRENT_REPO_PROFILES
+from loopx.canary.quality_surface_catalog import (
+    QUALITY_SURFACE_CATALOG,
+    build_quality_surface_catalog_audit,
+)
+
+
+def test_current_high_risk_surfaces_have_no_catalog_drift() -> None:
+    audit = build_quality_surface_catalog_audit(
+        CURRENT_REPO_PROFILES,
+        repo_root=Path(__file__).resolve().parents[2],
+    )
+
+    assert audit["ok"] is True
+    assert audit["drift_count"] == 0
+    assert audit["repository_reference_validation"] == "performed"
+    assert audit["classified_surface_count"] == audit["high_risk_profile_count"]
+    assert {gap["surface_id"] for gap in audit["gaps"]} == {
+        "peer-agent-runtime"
+    }
+    assert audit["gaps"][0]["layer"] == "model_behavior"
+
+
+def test_packaged_audit_keeps_classification_without_source_checkout() -> None:
+    audit = build_quality_surface_catalog_audit(CURRENT_REPO_PROFILES)
+
+    assert audit["ok"] is True
+    assert audit["repository_reference_validation"] == "source_checkout_unavailable"
+
+
+def test_unclassified_high_risk_profile_is_drift() -> None:
+    profiles = [*CURRENT_REPO_PROFILES, {"id": "new-risk", "quality_risk": "high"}]
+
+    audit = build_quality_surface_catalog_audit(profiles)
+
+    assert audit["ok"] is False
+    assert {
+        (item["code"], item.get("canary_profile_id")) for item in audit["drift"]
+    } >= {("unclassified_high_risk_profile", "new-risk")}
+
+
+def test_oracle_cannot_reuse_product_source_as_expected_truth() -> None:
+    catalog = deepcopy(QUALITY_SURFACE_CATALOG)
+    catalog[0]["semantic_oracle"]["refs"] = [catalog[0]["owner_paths"][0]]
+
+    audit = build_quality_surface_catalog_audit(
+        CURRENT_REPO_PROFILES,
+        catalog=catalog,
+    )
+
+    assert audit["ok"] is False
+    assert any(
+        item["code"] == "circular_oracle_uses_product_source"
+        for item in audit["drift"]
+    )
+
+
+def test_not_applicable_layer_requires_a_reason_but_is_not_a_gap() -> None:
+    catalog = deepcopy(QUALITY_SURFACE_CATALOG)
+    catalog[0]["layers"]["model_behavior"] = {"status": "not_applicable"}
+
+    invalid = build_quality_surface_catalog_audit(
+        CURRENT_REPO_PROFILES,
+        catalog=catalog,
+    )
+    assert any(
+        item["code"] == "not_applicable_without_rationale"
+        for item in invalid["drift"]
+    )
+
+    catalog[0]["layers"]["model_behavior"]["rationale"] = (
+        "Scheduler precedence is deterministic."
+    )
+    valid = build_quality_surface_catalog_audit(
+        CURRENT_REPO_PROFILES,
+        catalog=catalog,
+    )
+    assert valid["ok"] is True
+    assert not any(
+        gap["surface_id"] == "interaction-scheduler-authority"
+        for gap in valid["gaps"]
+    )
+
+
+def test_same_evidence_cannot_stand_in_for_multiple_layers() -> None:
+    catalog = deepcopy(QUALITY_SURFACE_CATALOG)
+    shared_ref = catalog[0]["layers"]["durable_smoke"]["refs"][0]
+    catalog[0]["layers"]["release_gate"] = {
+        "status": "covered",
+        "refs": [shared_ref],
+    }
+
+    audit = build_quality_surface_catalog_audit(
+        CURRENT_REPO_PROFILES,
+        catalog=catalog,
+    )
+
+    assert any(
+        item["code"] == "duplicate_evidence_across_layers"
+        for item in audit["drift"]
+    )


### PR DESCRIPTION
## Summary

- mark seven existing canary profiles as high-risk shipped surfaces
- add a machine-readable quality catalog and `loopx canary quality-audit`
- fail on unclassified risk, circular or stale semantic oracles, missing deterministic minimums, and unexplained exceptions
- keep host/model layers explicit without forcing them where semantics are deterministic

## Product and architecture judgment

The repository already has unit, smoke, canary, host, model, and release checks, but no independent inventory proves which layer owns each high-risk surface. This PR adds that ownership seam without changing runtime decisions. It currently exposes one deliberate gap: peer-agent identity and same-agent continuation are not yet covered by the actual-default one-arm model portfolio.

## Validation

- `613 passed, 2 skipped`
- `loopx canary premerge --from-git-diff`: passed, 16 catalog/risk checks, no manual holds, self-merge allowed
- `ruff`: passed on changed Python
- focused catalog tests: 6 passed
- public boundary scan: 0 errors, 0 warnings
- isolated mypy for the new catalog module: passed

## Risk

No production control-plane transition, permission, provider call, benchmark scoring, or release promotion behavior changes. The new audit is dry-run and source-checkout path validation degrades explicitly in packaged installs.