### PR TITLE
Fix fallback scheduler ACK idempotency

### DIFF
--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -1158,10 +1158,15 @@ def build_scheduler_hint(
                 last_applied_rrule=effective_host_rrule,
                 current_rrule=current_rrule,
             )
+        current_target_has_failure = any(
+            normalize_scheduler_rrule(failure.get("target_rrule"))
+            == current_rrule
+            for failure in all_host_update_failures
+        )
         host_match_ack_needed = (
             bool(observed_host_rrule)
             and current_rrule_already_applied
-            and (state_status != "same_identity" or bool(all_host_update_failures))
+            and (state_status != "same_identity" or current_target_has_failure)
         )
         base_apply_needed = (
             not current_rrule_already_applied

--- a/tests/control_plane/test_scheduler_host_failure_cache.py
+++ b/tests/control_plane/test_scheduler_host_failure_cache.py
@@ -243,6 +243,16 @@ def test_fallback_ack_retains_other_failed_target_for_same_host(
         failure["target_rrule"] for failure in fallback_state["host_update_failures"]
     ] == [ACTIVE_3]
 
+    fallback_replay = _with_scheduler_hint(
+        _monitor_decision(),
+        scheduler_state=fallback_state,
+        host_rrule=MONITOR_15,
+    )
+    fallback_replay_app = fallback_replay["scheduler_hint"]["codex_app"]
+    assert fallback_replay_app["stateful_backoff"]["apply_needed"] is False
+    assert fallback_replay_app["stateful_backoff"]["ack_needed"] is False
+    assert fallback_replay_app["host_action"] == "none"
+
     active_replay = _with_scheduler_hint(
         _active_decision(),
         scheduler_state=fallback_state,


### PR DESCRIPTION
## Summary
- require a cached failure for the current RRULE before requesting a matching-host ACK
- retain unrelated failed target pairs without repeatedly ACKing the same fallback cadence
- cover same-fallback replay while preserving current-target failure suppression

## Validation
- `uv run --with pytest pytest -q tests/control_plane/test_scheduler_backoff_convergence.py tests/control_plane/test_scheduler_execution_context.py tests/control_plane/test_scheduler_host_failure_cache.py tests/control_plane/test_scheduler_interaction_arbitration.py tests/test_loopx_turn_driver.py` (106 passed)
- `PYTHONPATH=. python3 -m loopx.cli canary premerge --from-git-diff` (17 selected, 17 passed, 0 manual holds)
- public/private boundary scan clean