### PR TITLE
docs(course): avoid legacy hierarchy runtime tokens

### DIFF
--- a/docs/development/control-plane-course/03-work-graph-and-peers.md
+++ b/docs/development/control-plane-course/03-work-graph-and-peers.md
@@ -90,8 +90,8 @@ quota 可以同时返回：
 当前 live runtime model 是 `peer_v1`：
 
 - 所有 registered agents 是平等身份；
-- 没有永久 primary agent；
-- 没有永久 side agent；
+- 没有永久的主执行者；
+- 没有永久的辅助执行者；
 - todo claim 和 continuation policy 决定当前工作归属；
 - task-scoped coordination 不授予 durable authority；
 - 旧 hierarchy 字段只允许存在于 exactly-once migration reader。
@@ -616,7 +616,7 @@ if current_workspace:
 1. Claim 和 lease 的差别是什么？
 2. Required capability 为什么不是权限？
 3. 什么情况下 user gate 应是 global？
-4. 为什么 review 应建模成普通 todo，而不是 primary agent 权力？
+4. 为什么 review 应建模成普通 todo，而不是固定执行者的特权？
 5. Completion 缺少 successor 和 no-followup 时，系统为什么不能终止？
 
 下一讲把这个工作图交给决策内核，逐层拆解 `quota should-run` 如何编译出本轮 interaction contract。

--- a/docs/development/control-plane-course/07-engineering-a-control-plane-rule.md
+++ b/docs/development/control-plane-course/07-engineering-a-control-plane-rule.md
@@ -346,7 +346,7 @@ Branch 完成不自动合并。`selected` 仍要经过普通 todo ownership、va
 
 ## Migration Reader 与 Live Model
 
-用户曾指出配置层不应残留 `primary_agent`、`side_agent_handoff_agent` 等实时概念，同时 migration 逻辑不能删。
+用户曾指出配置层不应残留旧版主/辅层级角色字段，同时 migration 逻辑不能删。
 
 正确分层：
 


### PR DESCRIPTION
## Summary

- reword control-plane course references to legacy hierarchy roles without emitting forbidden runtime tokens
- preserve the peer runtime and exactly-once migration teaching contract
- restore the Full Public peer-agent boundary shard after #2254

## Validation

- `python3 examples/control_plane/peer-agent-hard-cut-boundary-smoke.py`
- `python3 examples/control_plane/peer-agent-runtime-v1-smoke.py`
- `python3 examples/run-smokes.py --suite full-public --offset 200 --limit 100 --timeout-seconds 120 --jobs 4 --json` (100/100)
- `loopx canary premerge --from-git-diff` (13/13, no holds)