### PR TITLE
refactor(scheduler): isolate ACK decision boundary

### DIFF
--- a/docs/development/control-plane-course/05-host-scheduler-and-heartbeat.md
+++ b/docs/development/control-plane-course/05-host-scheduler-and-heartbeat.md
@@ -374,7 +374,7 @@ base_identity_keys = [
 
 ### 3. ACK 校验的是当前 hint，不接受任意 host 回报
 
-`build_scheduler_ack_plan` 逐层比对 state identity：
+`scheduler/ack.py` 中的 `build_scheduler_ack_plan` 逐层比对 state identity：
 
 ```python
 if not agent_id:
@@ -454,8 +454,8 @@ App tick
 
 ### 断点建议
 
-- `build_scheduler_hint:774`：观察非法 execution context 如何 fail closed；
-- `build_scheduler_ack_plan:410`：依次改错 state key、reset token、identity signature；
+- `scheduler_hint.py:457`：观察非法 execution context 如何 fail closed；
+- `scheduler/ack.py:120`：依次改错 state key、reset token、identity signature；
 - `write_monitor_poll_todo_state:98`：比较 hash 相同、hash 变化、显式 material change；
 - host adapter：确认只有 host 层真正调用 automation update。
 

--- a/examples/control_plane/quota-scheduler-state-ack-smoke.py
+++ b/examples/control_plane/quota-scheduler-state-ack-smoke.py
@@ -23,9 +23,11 @@ from loopx.control_plane.testing.canary_harness import (  # noqa: E402
     run_json_cli_result,
 )
 from loopx.control_plane.scheduler import scheduler_hint as scheduler_hint_module  # noqa: E402
-from loopx.control_plane.scheduler.scheduler_hint import (  # noqa: E402
+from loopx.control_plane.scheduler.ack import (  # noqa: E402
     build_codex_app_scheduler_ack_event,
     build_scheduler_ack_plan,
+)
+from loopx.control_plane.scheduler.scheduler_hint import (  # noqa: E402
     build_scheduler_hint,
 )
 from loopx.control_plane.scheduler.state import (  # noqa: E402

--- a/loopx/control_plane/quota/scheduler_ack.py
+++ b/loopx/control_plane/quota/scheduler_ack.py
@@ -5,10 +5,9 @@ from typing import Any
 
 from .decision_summary import compact_quota_decision, quota_decision_agent_id
 from ..runtime.time import now_local_iso
-from ..scheduler.scheduler_hint import (
+from ..scheduler.ack import (
     build_codex_app_scheduler_ack_event,
     build_scheduler_ack_plan,
-    normalize_scheduler_rrule,
     scheduler_backoff_packet,
 )
 from ..scheduler.state import (
@@ -18,6 +17,7 @@ from ..scheduler.state import (
     build_scheduler_state,
     merge_scheduler_host_update_failure,
     normalize_scheduler_host_update_failures,
+    normalize_scheduler_rrule,
     retained_scheduler_host_update_failures,
     scheduler_state_path,
     write_scheduler_state,

--- a/loopx/control_plane/scheduler/ack.py
+++ b/loopx/control_plane/scheduler/ack.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..work_items.delivery_outcome import DeliveryOutcome
+from .state import (
+    CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
+    CODEX_APP_SURFACE,
+    build_scheduler_state,
+    normalize_scheduler_host_update_failures,
+    normalize_scheduler_rrule,
+    retained_scheduler_host_update_failures,
+    scheduler_rrule_interval_minutes,
+)
+
+
+SCHEDULER_ACK_STALE_HINT_TOLERANCE_MINUTES = 2
+
+
+def _accepts_stale_monitor_ack_rrule(
+    scheduler_hint: dict[str, Any],
+    stateful_backoff: dict[str, Any],
+    *,
+    applied_rrule: str,
+    expected_rrule: str,
+    reset_token: str | None,
+    identity_signature: str | None,
+) -> bool:
+    if str(scheduler_hint.get("cadence_class") or "") != "monitor_wait":
+        return False
+    safe_reset_token = str(reset_token or "").strip()
+    safe_identity_signature = str(identity_signature or "").strip()
+    if not safe_reset_token or not safe_identity_signature:
+        return False
+    if safe_reset_token != str(stateful_backoff.get("reset_token") or ""):
+        return False
+    if safe_identity_signature != str(stateful_backoff.get("identity_signature") or ""):
+        return False
+    applied_minutes = scheduler_rrule_interval_minutes(applied_rrule)
+    expected_minutes = scheduler_rrule_interval_minutes(expected_rrule)
+    if applied_minutes is None or expected_minutes is None:
+        return False
+    if applied_minutes < expected_minutes:
+        return False
+    return (
+        applied_minutes - expected_minutes <= SCHEDULER_ACK_STALE_HINT_TOLERANCE_MINUTES
+    )
+
+
+def _scheduler_ack_rrule_acceptance(
+    scheduler_hint: dict[str, Any],
+    codex_app: dict[str, Any],
+    stateful_backoff: dict[str, Any],
+    *,
+    applied_rrule: str,
+    reset_token: str | None,
+    identity_signature: str | None,
+) -> dict[str, Any]:
+    expected_rrule = normalize_scheduler_rrule(
+        codex_app.get("recommended_rrule") or stateful_backoff.get("current_rrule")
+    )
+    if not expected_rrule:
+        return {
+            "ok": False,
+            "reason": "quota scheduler-ack has no current recommended_rrule to acknowledge",
+            "expected_rrule": "",
+        }
+    if applied_rrule == expected_rrule:
+        return {
+            "ok": True,
+            "applied_rrule": applied_rrule,
+            "expected_rrule": expected_rrule,
+        }
+    if _accepts_stale_monitor_ack_rrule(
+        scheduler_hint,
+        stateful_backoff,
+        applied_rrule=applied_rrule,
+        expected_rrule=expected_rrule,
+        reset_token=reset_token,
+        identity_signature=identity_signature,
+    ):
+        return {
+            "ok": True,
+            "applied_rrule": applied_rrule,
+            "expected_rrule": expected_rrule,
+            "stale_hint_accepted": True,
+            "stale_hint_tolerance_minutes": SCHEDULER_ACK_STALE_HINT_TOLERANCE_MINUTES,
+        }
+    return {
+        "ok": False,
+        "reason": (
+            f"quota scheduler-ack applied_rrule {applied_rrule!r} "
+            f"does not match expected {expected_rrule!r}"
+        ),
+        "expected_rrule": expected_rrule,
+    }
+
+
+def scheduler_backoff_packet(
+    decision: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    scheduler_hint = (
+        decision.get("scheduler_hint")
+        if isinstance(decision.get("scheduler_hint"), dict)
+        else {}
+    )
+    codex_app = (
+        scheduler_hint.get("codex_app")
+        if isinstance(scheduler_hint.get("codex_app"), dict)
+        else {}
+    )
+    stateful_backoff = (
+        codex_app.get("stateful_backoff")
+        if isinstance(codex_app.get("stateful_backoff"), dict)
+        else {}
+    )
+    return scheduler_hint, codex_app, stateful_backoff
+
+
+def build_scheduler_ack_plan(
+    before: dict[str, Any],
+    *,
+    agent_id: str | None,
+    state_key: str = CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
+    applied_rrule: str | None = None,
+    reset_token: str | None = None,
+    identity_signature: str | None = None,
+) -> dict[str, Any]:
+    safe_agent_id = str(agent_id or "").strip()
+    scheduler_hint, codex_app, stateful_backoff = scheduler_backoff_packet(before)
+    if not safe_agent_id:
+        return {
+            "ok": False,
+            "reason": "`loopx quota scheduler-ack` requires --agent-id",
+        }
+    if not stateful_backoff:
+        return {
+            "ok": False,
+            "reason": "current quota decision has no Codex App stateful scheduler packet",
+        }
+    if str(stateful_backoff.get("state_key") or "") != state_key:
+        return {
+            "ok": False,
+            "reason": "--state-key does not match scheduler_hint.codex_app.stateful_backoff.state_key",
+        }
+    if reset_token and str(reset_token).strip() != str(
+        stateful_backoff.get("reset_token") or ""
+    ):
+        return {
+            "ok": False,
+            "reason": "--reset-token does not match the current scheduler hint",
+        }
+    if identity_signature and str(identity_signature).strip() != str(
+        stateful_backoff.get("identity_signature") or ""
+    ):
+        return {
+            "ok": False,
+            "reason": "--identity-signature does not match the current scheduler hint",
+        }
+    safe_applied_rrule = normalize_scheduler_rrule(applied_rrule)
+    apply_needed = stateful_backoff.get("apply_needed") is True
+    ack_needed = stateful_backoff.get("ack_needed") is True
+    if not apply_needed and not ack_needed:
+        return {
+            "ok": True,
+            "already_applied": True,
+            "applied_rrule": safe_applied_rrule,
+        }
+    if not safe_applied_rrule:
+        return {
+            "ok": False,
+            "reason": "`loopx quota scheduler-ack` requires --applied-rrule when an ack is needed",
+        }
+    acceptance = _scheduler_ack_rrule_acceptance(
+        scheduler_hint,
+        codex_app,
+        stateful_backoff,
+        applied_rrule=safe_applied_rrule,
+        reset_token=reset_token,
+        identity_signature=identity_signature,
+    )
+    if not acceptance.get("ok"):
+        return {
+            "ok": False,
+            "reason": str(
+                acceptance.get("reason") or "scheduler ack RRULE validation failed"
+            ),
+        }
+    result = {
+        "ok": True,
+        "already_applied": False,
+        "applied_rrule": acceptance["applied_rrule"],
+        "expected_rrule": acceptance["expected_rrule"],
+    }
+    if ack_needed and not apply_needed:
+        result["host_match_ack"] = True
+    if acceptance.get("stale_hint_accepted"):
+        result["stale_hint_accepted"] = True
+        result["stale_hint_tolerance_minutes"] = acceptance.get(
+            "stale_hint_tolerance_minutes"
+        )
+    return result
+
+
+def _int_number(value: Any, *, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def build_codex_app_scheduler_ack_event(
+    before: dict[str, Any],
+    *,
+    agent_id: str | None,
+    applied_rrule: str,
+    classification: str = "quota_scheduler_ack",
+    surface: str = CODEX_APP_SURFACE,
+    state_key: str = CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
+    reset_token: str | None = None,
+    identity_signature: str | None = None,
+    generated_at: str | None = None,
+    reason_summary: str | None = None,
+    compact_before: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    safe_agent_id = str(agent_id or "").strip()
+    if not safe_agent_id:
+        raise ValueError("quota scheduler-ack requires a scoped --agent-id")
+    scheduler_hint, codex_app, stateful_backoff = scheduler_backoff_packet(before)
+    if not stateful_backoff:
+        raise ValueError(
+            "quota scheduler-ack requires scheduler_hint.codex_app.stateful_backoff"
+        )
+    if str(stateful_backoff.get("state_key") or "") != state_key:
+        raise ValueError(
+            "quota scheduler-ack state_key does not match current quota scheduler hint"
+        )
+    if (
+        stateful_backoff.get("apply_needed") is not True
+        and stateful_backoff.get("ack_needed") is not True
+    ):
+        raise ValueError(
+            "quota scheduler-ack is not needed because the current RRULE is already applied"
+        )
+    safe_applied_rrule = normalize_scheduler_rrule(applied_rrule)
+    acceptance = _scheduler_ack_rrule_acceptance(
+        scheduler_hint,
+        codex_app,
+        stateful_backoff,
+        applied_rrule=safe_applied_rrule,
+        reset_token=reset_token,
+        identity_signature=identity_signature,
+    )
+    if not acceptance.get("ok"):
+        raise ValueError(
+            str(acceptance.get("reason") or "scheduler ack RRULE validation failed")
+        )
+    expected_rrule = acceptance["expected_rrule"]
+    acknowledged_rrule = acceptance["applied_rrule"]
+    codex_progression = (
+        codex_app.get("example_progression_minutes")
+        if isinstance(codex_app.get("example_progression_minutes"), list)
+        else []
+    )
+    progression_minutes = (
+        stateful_backoff.get("progression_minutes")
+        if isinstance(stateful_backoff.get("progression_minutes"), list)
+        else codex_progression
+    )
+    progression_index = max(
+        0, _int_number(stateful_backoff.get("progression_index"), default=0)
+    )
+    safe_generated_at = generated_at or ""
+    retained_host_update_failures = [
+        failure
+        for failure in retained_scheduler_host_update_failures(
+            normalize_scheduler_host_update_failures(
+                stateful_backoff.get("host_update_failures"),
+                legacy_failure=stateful_backoff.get("host_update_failure"),
+            ),
+            reference_time=safe_generated_at,
+            observed_host_rrule=acknowledged_rrule,
+        )
+        if normalize_scheduler_rrule(failure.get("target_rrule")) != acknowledged_rrule
+    ]
+    scheduler_state = build_scheduler_state(
+        goal_id=before.get("goal_id"),
+        agent_id=safe_agent_id,
+        surface=surface,
+        state_key=state_key,
+        reset_token=stateful_backoff.get("reset_token"),
+        identity_signature=stateful_backoff.get("identity_signature"),
+        progression_index=progression_index,
+        progression_minutes=progression_minutes,
+        last_applied_rrule=acknowledged_rrule,
+        updated_at=safe_generated_at,
+        source=classification,
+        host_update_failure=(
+            retained_host_update_failures[-1] if retained_host_update_failures else None
+        ),
+        host_update_failures=retained_host_update_failures or None,
+    )
+    reason = str(reason_summary or "").strip() or (
+        f"acknowledged Codex App scheduler RRULE {acknowledged_rrule}; no quota spend"
+    )
+    scheduler_ack_event = {
+        "event_type": classification,
+        "surface": surface,
+        "state_key": state_key,
+        "applied_rrule": acknowledged_rrule,
+        "before": compact_before if isinstance(compact_before, dict) else before,
+        "scheduler_state": scheduler_state,
+    }
+    if acceptance.get("stale_hint_accepted"):
+        scheduler_ack_event["expected_rrule"] = expected_rrule
+        scheduler_ack_event["stale_hint_accepted"] = True
+        scheduler_ack_event["stale_hint_tolerance_minutes"] = acceptance.get(
+            "stale_hint_tolerance_minutes"
+        )
+    return {
+        "generated_at": safe_generated_at,
+        "goal_id": before.get("goal_id"),
+        "classification": classification,
+        "agent_id": safe_agent_id,
+        "recommended_action": reason,
+        "health_check": "scheduler ack state updated; no quota spend",
+        "delivery_outcome": DeliveryOutcome.SURFACE_ONLY.value,
+        "scheduler_ack_event": scheduler_ack_event,
+    }

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from ..runtime.time import now_utc, utc_isoformat
-from ..work_items.delivery_outcome import DeliveryOutcome
+from . import ack as scheduler_ack
 from .arbitration import (
     SchedulerDisposition,
     build_scheduler_arbitration,
@@ -22,11 +22,11 @@ from .execution_context import (
 from .state import (
     CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
     CODEX_APP_SURFACE,
-    build_scheduler_state,
     normalize_scheduler_host_update_failures,
     normalize_scheduler_rrule,
     retained_scheduler_host_update_failures,
     rrule_for_minutes,
+    scheduler_rrule_interval_minutes,
 )
 from .time import parse_scheduler_timestamp
 
@@ -44,7 +44,6 @@ CODEX_APP_MAX_INTERVAL_MINUTES = 60
 DEFAULT_ACK_CAPABILITIES = {"shell", "filesystem_read", "filesystem_write"}
 MONITOR_WAIT_HOST_FLOOR_MINUTES = 15
 MONITOR_WAIT_NEAR_WINDOW_LEAD_MINUTES = 60
-SCHEDULER_ACK_STALE_HINT_TOLERANCE_MINUTES = 2
 MONITOR_WAIT_PHASE_RANK = {
     "active_window": 0,
     "near_window": 1,
@@ -52,21 +51,9 @@ MONITOR_WAIT_PHASE_RANK = {
     "far_window": 3,
 }
 
-
-def _scheduler_rrule_interval_minutes(value: Any) -> int | None:
-    text = normalize_scheduler_rrule(value)
-    parts: dict[str, str] = {}
-    for part in text.split(";"):
-        key, separator, raw_value = part.partition("=")
-        if separator:
-            parts[key.strip().upper()] = raw_value.strip()
-    if parts.get("FREQ", "").upper() != "MINUTELY":
-        return None
-    try:
-        interval = int(parts.get("INTERVAL", ""))
-    except ValueError:
-        return None
-    return interval if interval > 0 else None
+build_codex_app_scheduler_ack_event = scheduler_ack.build_codex_app_scheduler_ack_event
+build_scheduler_ack_plan = scheduler_ack.build_scheduler_ack_plan
+scheduler_backoff_packet = scheduler_ack.scheduler_backoff_packet
 
 
 def _scheduler_progression_interval_elapsed(
@@ -77,7 +64,7 @@ def _scheduler_progression_interval_elapsed(
     """Advance only after the applied host cadence has had one real interval."""
 
     updated_at = parse_scheduler_timestamp(scheduler_state.get("updated_at"))
-    applied_interval = _scheduler_rrule_interval_minutes(
+    applied_interval = scheduler_rrule_interval_minutes(
         scheduler_state.get("last_applied_rrule")
     )
     if updated_at is None or applied_interval is None:
@@ -100,7 +87,7 @@ def _user_gate_notification_cooldown(
     if cadence_class != "human_gate" or not host_failure_suppressed:
         return None
     failed_at = parse_scheduler_timestamp((recorded_host_failure or {}).get("failed_at"))
-    host_interval = _scheduler_rrule_interval_minutes(effective_host_rrule)
+    host_interval = scheduler_rrule_interval_minutes(effective_host_rrule)
     target_interval = max(1, int(current_interval_minutes))
     if failed_at is None or host_interval is None or host_interval >= target_interval:
         return None
@@ -132,37 +119,6 @@ def _user_gate_notification_cooldown(
     }
 
 
-def _accepts_stale_monitor_ack_rrule(
-    scheduler_hint: dict[str, Any],
-    stateful_backoff: dict[str, Any],
-    *,
-    applied_rrule: str,
-    expected_rrule: str,
-    reset_token: str | None,
-    identity_signature: str | None,
-) -> bool:
-    if str(scheduler_hint.get("cadence_class") or "") != "monitor_wait":
-        return False
-    safe_reset_token = str(reset_token or "").strip()
-    safe_identity_signature = str(identity_signature or "").strip()
-    if not safe_reset_token or not safe_identity_signature:
-        return False
-    if safe_reset_token != str(stateful_backoff.get("reset_token") or ""):
-        return False
-    if safe_identity_signature != str(stateful_backoff.get("identity_signature") or ""):
-        return False
-    applied_minutes = _scheduler_rrule_interval_minutes(applied_rrule)
-    expected_minutes = _scheduler_rrule_interval_minutes(expected_rrule)
-    if applied_minutes is None or expected_minutes is None:
-        return False
-    if applied_minutes < expected_minutes:
-        return False
-    return (
-        applied_minutes - expected_minutes
-        <= SCHEDULER_ACK_STALE_HINT_TOLERANCE_MINUTES
-    )
-
-
 def _monitor_rrule_applied_within_stale_tolerance(
     *,
     cadence_class: str,
@@ -171,86 +127,16 @@ def _monitor_rrule_applied_within_stale_tolerance(
 ) -> bool:
     if cadence_class != "monitor_wait":
         return False
-    applied_minutes = _scheduler_rrule_interval_minutes(last_applied_rrule)
-    current_minutes = _scheduler_rrule_interval_minutes(current_rrule)
+    applied_minutes = scheduler_rrule_interval_minutes(last_applied_rrule)
+    current_minutes = scheduler_rrule_interval_minutes(current_rrule)
     if applied_minutes is None or current_minutes is None:
         return False
     if applied_minutes < current_minutes:
         return False
     return (
         applied_minutes - current_minutes
-        <= SCHEDULER_ACK_STALE_HINT_TOLERANCE_MINUTES
+        <= scheduler_ack.SCHEDULER_ACK_STALE_HINT_TOLERANCE_MINUTES
     )
-
-
-def _scheduler_ack_rrule_acceptance(
-    scheduler_hint: dict[str, Any],
-    codex_app: dict[str, Any],
-    stateful_backoff: dict[str, Any],
-    *,
-    applied_rrule: str,
-    reset_token: str | None,
-    identity_signature: str | None,
-) -> dict[str, Any]:
-    expected_rrule = normalize_scheduler_rrule(
-        codex_app.get("recommended_rrule") or stateful_backoff.get("current_rrule")
-    )
-    if not expected_rrule:
-        return {
-            "ok": False,
-            "reason": "quota scheduler-ack has no current recommended_rrule to acknowledge",
-            "expected_rrule": "",
-        }
-    if applied_rrule == expected_rrule:
-        return {
-            "ok": True,
-            "applied_rrule": applied_rrule,
-            "expected_rrule": expected_rrule,
-        }
-    if _accepts_stale_monitor_ack_rrule(
-        scheduler_hint,
-        stateful_backoff,
-        applied_rrule=applied_rrule,
-        expected_rrule=expected_rrule,
-        reset_token=reset_token,
-        identity_signature=identity_signature,
-    ):
-        return {
-            "ok": True,
-            "applied_rrule": applied_rrule,
-            "expected_rrule": expected_rrule,
-            "stale_hint_accepted": True,
-            "stale_hint_tolerance_minutes": SCHEDULER_ACK_STALE_HINT_TOLERANCE_MINUTES,
-        }
-    return {
-        "ok": False,
-        "reason": (
-            f"quota scheduler-ack applied_rrule {applied_rrule!r} "
-            f"does not match expected {expected_rrule!r}"
-        ),
-        "expected_rrule": expected_rrule,
-    }
-
-
-def scheduler_backoff_packet(
-    decision: dict[str, Any],
-) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
-    scheduler_hint = (
-        decision.get("scheduler_hint")
-        if isinstance(decision.get("scheduler_hint"), dict)
-        else {}
-    )
-    codex_app = (
-        scheduler_hint.get("codex_app")
-        if isinstance(scheduler_hint.get("codex_app"), dict)
-        else {}
-    )
-    stateful_backoff = (
-        codex_app.get("stateful_backoff")
-        if isinstance(codex_app.get("stateful_backoff"), dict)
-        else {}
-    )
-    return scheduler_hint, codex_app, stateful_backoff
 
 
 def build_codex_app_scheduler_ack_hint(
@@ -384,95 +270,6 @@ def build_codex_app_scheduler_failure_hint(
         "schema_version": CODEX_APP_SCHEDULER_FAILURE_HINT_SCHEMA_VERSION,
         "cli_args": cli_args,
     }
-
-
-def build_scheduler_ack_plan(
-    before: dict[str, Any],
-    *,
-    agent_id: str | None,
-    state_key: str = CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
-    applied_rrule: str | None = None,
-    reset_token: str | None = None,
-    identity_signature: str | None = None,
-) -> dict[str, Any]:
-    safe_agent_id = str(agent_id or "").strip()
-    scheduler_hint, codex_app, stateful_backoff = scheduler_backoff_packet(before)
-    if not safe_agent_id:
-        return {
-            "ok": False,
-            "reason": "`loopx quota scheduler-ack` requires --agent-id",
-        }
-    if not stateful_backoff:
-        return {
-            "ok": False,
-            "reason": "current quota decision has no Codex App stateful scheduler packet",
-        }
-    if str(stateful_backoff.get("state_key") or "") != state_key:
-        return {
-            "ok": False,
-            "reason": "--state-key does not match scheduler_hint.codex_app.stateful_backoff.state_key",
-        }
-    if reset_token and str(reset_token).strip() != str(stateful_backoff.get("reset_token") or ""):
-        return {
-            "ok": False,
-            "reason": "--reset-token does not match the current scheduler hint",
-        }
-    if (
-        identity_signature
-        and str(identity_signature).strip() != str(stateful_backoff.get("identity_signature") or "")
-    ):
-        return {
-            "ok": False,
-            "reason": "--identity-signature does not match the current scheduler hint",
-        }
-    safe_applied_rrule = normalize_scheduler_rrule(applied_rrule)
-    apply_needed = stateful_backoff.get("apply_needed") is True
-    ack_needed = stateful_backoff.get("ack_needed") is True
-    if not apply_needed and not ack_needed:
-        return {
-            "ok": True,
-            "already_applied": True,
-            "applied_rrule": safe_applied_rrule,
-        }
-    if not safe_applied_rrule:
-        return {
-            "ok": False,
-            "reason": "`loopx quota scheduler-ack` requires --applied-rrule when an ack is needed",
-        }
-    acceptance = _scheduler_ack_rrule_acceptance(
-        scheduler_hint,
-        codex_app,
-        stateful_backoff,
-        applied_rrule=safe_applied_rrule,
-        reset_token=reset_token,
-        identity_signature=identity_signature,
-    )
-    if not acceptance.get("ok"):
-        return {
-            "ok": False,
-            "reason": str(acceptance.get("reason") or "scheduler ack RRULE validation failed"),
-        }
-    result = {
-        "ok": True,
-        "already_applied": False,
-        "applied_rrule": acceptance["applied_rrule"],
-        "expected_rrule": acceptance["expected_rrule"],
-    }
-    if ack_needed and not apply_needed:
-        result["host_match_ack"] = True
-    if acceptance.get("stale_hint_accepted"):
-        result["stale_hint_accepted"] = True
-        result["stale_hint_tolerance_minutes"] = acceptance.get(
-            "stale_hint_tolerance_minutes"
-        )
-    return result
-
-
-def _int_number(value: Any, *, default: int) -> int:
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return default
 
 
 def _parse_monitor_timestamp(value: Any) -> datetime | None:
@@ -654,119 +451,6 @@ def _monitor_wait_cadence_plan(payload: dict[str, Any]) -> dict[str, Any] | None
         "base_progression_minutes": MONITOR_WAIT_PROGRESSION_MINUTES,
         "candidate_count": len(plans),
         "expired_monitor_count": expired_count,
-    }
-
-
-def build_codex_app_scheduler_ack_event(
-    before: dict[str, Any],
-    *,
-    agent_id: str | None,
-    applied_rrule: str,
-    classification: str = "quota_scheduler_ack",
-    surface: str = CODEX_APP_SURFACE,
-    state_key: str = CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
-    reset_token: str | None = None,
-    identity_signature: str | None = None,
-    generated_at: str | None = None,
-    reason_summary: str | None = None,
-    compact_before: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    safe_agent_id = str(agent_id or "").strip()
-    if not safe_agent_id:
-        raise ValueError("quota scheduler-ack requires a scoped --agent-id")
-    scheduler_hint, codex_app, stateful_backoff = scheduler_backoff_packet(before)
-    if not stateful_backoff:
-        raise ValueError("quota scheduler-ack requires scheduler_hint.codex_app.stateful_backoff")
-    if str(stateful_backoff.get("state_key") or "") != state_key:
-        raise ValueError("quota scheduler-ack state_key does not match current quota scheduler hint")
-    if (
-        stateful_backoff.get("apply_needed") is not True
-        and stateful_backoff.get("ack_needed") is not True
-    ):
-        raise ValueError("quota scheduler-ack is not needed because the current RRULE is already applied")
-    safe_applied_rrule = normalize_scheduler_rrule(applied_rrule)
-    acceptance = _scheduler_ack_rrule_acceptance(
-        scheduler_hint,
-        codex_app,
-        stateful_backoff,
-        applied_rrule=safe_applied_rrule,
-        reset_token=reset_token,
-        identity_signature=identity_signature,
-    )
-    if not acceptance.get("ok"):
-        raise ValueError(str(acceptance.get("reason") or "scheduler ack RRULE validation failed"))
-    expected_rrule = acceptance["expected_rrule"]
-    acknowledged_rrule = acceptance["applied_rrule"]
-    codex_progression = (
-        codex_app.get("example_progression_minutes")
-        if isinstance(codex_app.get("example_progression_minutes"), list)
-        else []
-    )
-    progression_minutes = (
-        stateful_backoff.get("progression_minutes")
-        if isinstance(stateful_backoff.get("progression_minutes"), list)
-        else codex_progression
-    )
-    progression_index = max(0, _int_number(stateful_backoff.get("progression_index"), default=0))
-    safe_generated_at = generated_at or ""
-    retained_host_update_failures = [
-        failure
-        for failure in retained_scheduler_host_update_failures(
-            normalize_scheduler_host_update_failures(
-                stateful_backoff.get("host_update_failures"),
-                legacy_failure=stateful_backoff.get("host_update_failure"),
-            ),
-            reference_time=safe_generated_at,
-            observed_host_rrule=acknowledged_rrule,
-        )
-        if normalize_scheduler_rrule(failure.get("target_rrule"))
-        != acknowledged_rrule
-    ]
-    scheduler_state = build_scheduler_state(
-        goal_id=before.get("goal_id"),
-        agent_id=safe_agent_id,
-        surface=surface,
-        state_key=state_key,
-        reset_token=stateful_backoff.get("reset_token"),
-        identity_signature=stateful_backoff.get("identity_signature"),
-        progression_index=progression_index,
-        progression_minutes=progression_minutes,
-        last_applied_rrule=acknowledged_rrule,
-        updated_at=safe_generated_at,
-        source=classification,
-        host_update_failure=(
-            retained_host_update_failures[-1]
-            if retained_host_update_failures
-            else None
-        ),
-        host_update_failures=retained_host_update_failures or None,
-    )
-    reason = str(reason_summary or "").strip() or (
-        f"acknowledged Codex App scheduler RRULE {acknowledged_rrule}; no quota spend"
-    )
-    scheduler_ack_event = {
-        "event_type": classification,
-        "surface": surface,
-        "state_key": state_key,
-        "applied_rrule": acknowledged_rrule,
-        "before": compact_before if isinstance(compact_before, dict) else before,
-        "scheduler_state": scheduler_state,
-    }
-    if acceptance.get("stale_hint_accepted"):
-        scheduler_ack_event["expected_rrule"] = expected_rrule
-        scheduler_ack_event["stale_hint_accepted"] = True
-        scheduler_ack_event["stale_hint_tolerance_minutes"] = acceptance.get(
-            "stale_hint_tolerance_minutes"
-        )
-    return {
-        "generated_at": safe_generated_at,
-        "goal_id": before.get("goal_id"),
-        "classification": classification,
-        "agent_id": safe_agent_id,
-        "recommended_action": reason,
-        "health_check": "scheduler ack state updated; no quota spend",
-        "delivery_outcome": DeliveryOutcome.SURFACE_ONLY.value,
-        "scheduler_ack_event": scheduler_ack_event,
     }
 
 

--- a/loopx/control_plane/scheduler/state.py
+++ b/loopx/control_plane/scheduler/state.py
@@ -29,6 +29,22 @@ def normalize_scheduler_rrule(value: Any) -> str:
     return text
 
 
+def scheduler_rrule_interval_minutes(value: Any) -> int | None:
+    text = normalize_scheduler_rrule(value)
+    parts: dict[str, str] = {}
+    for part in text.split(";"):
+        key, separator, raw_value = part.partition("=")
+        if separator:
+            parts[key.strip().upper()] = raw_value.strip()
+    if parts.get("FREQ", "").upper() != "MINUTELY":
+        return None
+    try:
+        interval = int(parts.get("INTERVAL", ""))
+    except ValueError:
+        return None
+    return interval if interval > 0 else None
+
+
 def _safe_segment(value: str) -> str:
     safe = re.sub(r"[^0-9A-Za-z_.-]+", "-", str(value or "").strip()).strip("-._")
     return safe or "default"

--- a/tests/control_plane/test_scheduler_ack_decision_table.py
+++ b/tests/control_plane/test_scheduler_ack_decision_table.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import pytest
+
+from loopx.control_plane.scheduler.ack import build_scheduler_ack_plan
+from loopx.control_plane.scheduler.state import (
+    CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
+)
+
+
+AGENT_ID = "codex-scheduler-ack-table"
+EXPECTED_RRULE = "FREQ=MINUTELY;INTERVAL=30"
+RESET_TOKEN = "reset-token"
+IDENTITY_SIGNATURE = "identity-signature"
+STALE_WITHIN = "FREQ=MINUTELY;INTERVAL=31"
+
+
+def _decision(*, cadence_class: str = "active_work") -> dict:
+    return {
+        "scheduler_hint": {
+            "cadence_class": cadence_class,
+            "codex_app": {
+                "recommended_rrule": EXPECTED_RRULE,
+                "stateful_backoff": {
+                    "state_key": CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
+                    "current_rrule": EXPECTED_RRULE,
+                    "apply_needed": True,
+                    "ack_needed": False,
+                    "reset_token": RESET_TOKEN,
+                    "identity_signature": IDENTITY_SIGNATURE,
+                },
+            },
+        }
+    }
+
+
+ACK_DECISION_CASES = [
+    {
+        "id": "exact_apply_ack",
+        "rrule": EXPECTED_RRULE,
+        "expected": {"ok": True, "already_applied": False},
+    },
+    {
+        "id": "exact_host_match_ack",
+        "rrule": EXPECTED_RRULE,
+        "apply": False,
+        "ack": True,
+        "expected": {"ok": True, "host_match_ack": True},
+    },
+    {
+        "id": "monitor_stale_hint_within_tolerance",
+        "cadence": "monitor_wait",
+        "rrule": STALE_WITHIN,
+        "proof": True,
+        "expected": {"ok": True, "stale_hint_accepted": True},
+    },
+    {
+        "id": "monitor_stale_hint_below_current",
+        "cadence": "monitor_wait",
+        "rrule": "FREQ=MINUTELY;INTERVAL=29",
+        "proof": True,
+        "expected": {"ok": False},
+    },
+    {
+        "id": "monitor_stale_hint_outside_tolerance",
+        "cadence": "monitor_wait",
+        "rrule": "FREQ=MINUTELY;INTERVAL=33",
+        "proof": True,
+        "expected": {"ok": False},
+    },
+    {
+        "id": "monitor_stale_hint_without_identity_proof",
+        "cadence": "monitor_wait",
+        "rrule": STALE_WITHIN,
+        "expected": {"ok": False},
+    },
+    {
+        "id": "non_monitor_never_accepts_stale_hint",
+        "rrule": STALE_WITHIN,
+        "proof": True,
+        "expected": {"ok": False},
+    },
+    {
+        "id": "missing_rrule_while_ack_required",
+        "rrule": None,
+        "expected": {"ok": False},
+    },
+    {
+        "id": "steady_state_needs_no_ack",
+        "rrule": None,
+        "apply": False,
+        "expected": {"ok": True, "already_applied": True},
+    },
+]
+
+
+@pytest.mark.parametrize(
+    "case",
+    ACK_DECISION_CASES,
+    ids=[case["id"] for case in ACK_DECISION_CASES],
+)
+def test_scheduler_ack_decision_table(case: dict) -> None:
+    decision = _decision(cadence_class=case.get("cadence", "active_work"))
+    stateful_backoff = decision["scheduler_hint"]["codex_app"]["stateful_backoff"]
+    stateful_backoff["apply_needed"] = case.get("apply", True)
+    stateful_backoff["ack_needed"] = case.get("ack", False)
+
+    result = build_scheduler_ack_plan(
+        decision,
+        agent_id=AGENT_ID,
+        applied_rrule=case["rrule"],
+        reset_token=RESET_TOKEN if case.get("proof") else None,
+        identity_signature=IDENTITY_SIGNATURE if case.get("proof") else None,
+    )
+
+    expected = case["expected"]
+    assert {key: result.get(key) for key in expected} == expected
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_reason_fragment"),
+    [
+        ("missing_agent", "--agent-id"),
+        ("wrong_state_key", "--state-key"),
+        ("wrong_reset_token", "--reset-token"),
+        ("wrong_identity_signature", "--identity-signature"),
+    ],
+)
+def test_scheduler_ack_scope_proof_rejects_mutations(
+    mutation: str,
+    expected_reason_fragment: str,
+) -> None:
+    decision = _decision()
+    kwargs = {
+        "agent_id": AGENT_ID,
+        "state_key": CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
+        "applied_rrule": EXPECTED_RRULE,
+        "reset_token": RESET_TOKEN,
+        "identity_signature": IDENTITY_SIGNATURE,
+    }
+    if mutation == "missing_agent":
+        kwargs["agent_id"] = None
+    elif mutation == "wrong_state_key":
+        kwargs["state_key"] = "scheduler.wrong.state"
+    elif mutation == "wrong_reset_token":
+        kwargs["reset_token"] = "wrong-reset"
+    elif mutation == "wrong_identity_signature":
+        kwargs["identity_signature"] = "wrong-identity"
+
+    result = build_scheduler_ack_plan(decision, **kwargs)
+
+    assert result["ok"] is False
+    assert expected_reason_fragment in result["reason"]

--- a/tests/control_plane/test_scheduler_backoff_convergence.py
+++ b/tests/control_plane/test_scheduler_backoff_convergence.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 
 from loopx.control_plane.scheduler import scheduler_hint as scheduler_hint_module
-from loopx.control_plane.scheduler.scheduler_hint import (
-    build_codex_app_scheduler_ack_event,
-    build_scheduler_hint,
-)
+from loopx.control_plane.scheduler.ack import build_codex_app_scheduler_ack_event
+from loopx.control_plane.scheduler.scheduler_hint import build_scheduler_hint
 
 
 GOAL_ID = "scheduler-backoff-convergence"

--- a/tests/control_plane/test_scheduler_host_failure_cache.py
+++ b/tests/control_plane/test_scheduler_host_failure_cache.py
@@ -7,10 +7,8 @@ from pathlib import Path
 from loopx.control_plane.quota.scheduler_ack import (
     record_quota_scheduler_failure_for_decision,
 )
-from loopx.control_plane.scheduler.scheduler_hint import (
-    build_codex_app_scheduler_ack_event,
-    build_scheduler_hint,
-)
+from loopx.control_plane.scheduler.ack import build_codex_app_scheduler_ack_event
+from loopx.control_plane.scheduler.scheduler_hint import build_scheduler_hint
 from loopx.control_plane.scheduler.state import (
     CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
     CODEX_APP_SURFACE,


### PR DESCRIPTION
## Summary
- add a semantic scheduler ACK decision table covering exact apply, host-match ACK, scoped stale-monitor tolerance, steady state, and identity-proof rejection
- move ACK planning and event writeback from the 1,506-line scheduler hint projector into `control_plane/scheduler/ack.py`
- keep existing scheduler-hint imports compatible while routing product call sites to the bounded ACK context
- update the developer course source locations

## Why this hotspot
`scheduler_hint.py` was both one of the largest control-plane modules and tied for the highest change frequency in the latest 500 commits. Recent fixes repeatedly touched ACK settlement, stale hints, host-failure retention, and runtime ownership. This batch moves only the ACK rule group; cadence and monitor planning remain unchanged.

## Validation
- `uv run pytest -q`: 629 passed, 2 skipped
- focused ACK/unit tests: 19 passed
- `examples/control_plane/quota-scheduler-state-ack-smoke.py`: passed
- `uv run ruff check tests loopx/canary loopx/control_plane loopx/domain_packs loopx/presentation`: passed
- `uv run mypy`: passed
- `loopx canary premerge --from-git-diff`: 18/18 checks passed, public-boundary clean

## Review hold
This is intended as a behavior-preserving runtime refactor, but scheduler ACK is a sensitive control-plane surface. Please review the decision table and the compatibility export before merge; no self-merge is requested.