### PR TITLE
fix(canary): run premerge checks in caller repo

### DIFF
--- a/docs/development/testing-and-quality.md
+++ b/docs/development/testing-and-quality.md
@@ -115,6 +115,15 @@ python examples/control_plane/interaction-scheduler-authority-smoke.py
 loopx canary premerge --from-git-diff
 ```
 
+`premerge` resolves the caller's Git root for diff hygiene, changed-Python
+compilation, and public-boundary scanning, while LoopX's installed canary
+catalog continues to run from its own trusted release root. This also supports
+running the command from another repository or one of its subdirectories.
+
+`premerge` 会把调用方 Git 根目录用于 diff 卫生检查、变更 Python 编译和公开边界扫描；
+LoopX 已安装的 canary catalog 仍从自身可信 release root 运行。因此该命令也可从其他
+仓库或其子目录执行。
+
 The complete public sweep remains explicit and bounded:
 
 ```bash

--- a/examples/canary/premerge-validation-gate-smoke.py
+++ b/examples/canary/premerge-validation-gate-smoke.py
@@ -298,6 +298,98 @@ def assert_installed_wrapper_premerge_redirects_to_checkout() -> None:
     assert Path(payload["repo_root"]).resolve() == REPO_ROOT.resolve(), payload
 
 
+def assert_external_dirty_worktree_uses_caller_repo() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        external_repo = Path(temp_dir)
+        subprocess.run(["git", "init", "-q"], cwd=external_repo, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "smoke@example.com"],
+            cwd=external_repo,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "LoopX Smoke"],
+            cwd=external_repo,
+            check=True,
+        )
+        sample = external_repo / "sample.py"
+        sample.write_text("value = 1\n", encoding="utf-8")
+        subprocess.run(["git", "add", "sample.py"], cwd=external_repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-qm", "initial"],
+            cwd=external_repo,
+            check=True,
+        )
+
+        sample.write_text("value =\n", encoding="utf-8")
+        failed = subprocess.run(
+            [
+                str(REPO_ROOT / "scripts" / "loopx"),
+                "--format",
+                "json",
+                "canary",
+                "premerge",
+                "--from-git-diff",
+                "--git-diff-base",
+                "HEAD",
+                "--tier",
+                "quick",
+                "--no-progress",
+                "--timeout-seconds",
+                "60",
+            ],
+            cwd=external_repo,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert failed.returncode == 1, failed.stderr or failed.stdout
+        failed_payload = json.loads(failed.stdout)
+        assert Path(failed_payload["repo_root"]).resolve() == external_repo.resolve(), failed_payload
+        selector = failed_payload["selector_sources"]["git_diff"]
+        assert Path(selector["repo_root"]).resolve() == external_repo.resolve(), failed_payload
+        compile_check = next(
+            check
+            for check in failed_payload["direct_checks"]
+            if check["id"] == "changed_python_py_compile"
+        )
+        assert compile_check["status"] == "failed", failed_payload
+        assert all(
+            check["status"] == "passed"
+            for check in failed_payload["direct_checks"]
+            if check["id"].startswith("diff_check_")
+        ), failed_payload
+
+        sample.write_text("value = 2\n", encoding="utf-8")
+        passed = subprocess.run(
+            [
+                str(REPO_ROOT / "scripts" / "loopx"),
+                "--format",
+                "json",
+                "canary",
+                "premerge",
+                "--from-git-diff",
+                "--git-diff-base",
+                "HEAD",
+                "--tier",
+                "quick",
+                "--no-progress",
+                "--timeout-seconds",
+                "60",
+            ],
+            cwd=external_repo,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert passed.returncode == 0, passed.stderr or passed.stdout
+        passed_payload = json.loads(passed.stdout)
+        assert passed_payload["gate"]["status"] == "passed", passed_payload
+        assert all(check["ok"] for check in passed_payload["direct_checks"]), passed_payload
+
+
 def assert_inherited_line_budget_red_is_advisory_only() -> None:
     inherited_run = {
         "ok": False,
@@ -371,6 +463,7 @@ def main() -> None:
     assert_cli_premerge_reports_progress_by_default()
     assert_no_changes_does_not_mask_direct_failures()
     assert_installed_wrapper_premerge_redirects_to_checkout()
+    assert_external_dirty_worktree_uses_caller_repo()
     assert_inherited_line_budget_red_is_advisory_only()
     print("premerge-validation-gate-smoke ok")
 

--- a/loopx/canary/premerge.py
+++ b/loopx/canary/premerge.py
@@ -84,6 +84,7 @@ def _synthetic_smoke_suite_run(
     timeout_seconds: float,
     selected_checks: list[dict[str, Any]],
     note: str,
+    repo_root: Path = REPO_ROOT,
 ) -> dict[str, Any]:
     executed_checks = selected_checks if execute else []
     failures = [item for item in selected_checks if item.get("ok") is False]
@@ -91,7 +92,7 @@ def _synthetic_smoke_suite_run(
         "ok": not failures,
         "schema_version": "canary_smoke_suite_run_v0",
         "suite": suite,
-        "repo_root": str(REPO_ROOT),
+        "repo_root": str(repo_root),
         "dry_run": not execute,
         "executes_checks": execute,
         "writes_evidence": False,
@@ -126,6 +127,7 @@ def _empty_smoke_suite_run(
     reason: str,
     execute: bool,
     timeout_seconds: float,
+    repo_root: Path = REPO_ROOT,
 ) -> dict[str, Any]:
     return _synthetic_smoke_suite_run(
         suite=suite,
@@ -133,6 +135,7 @@ def _empty_smoke_suite_run(
         timeout_seconds=timeout_seconds,
         selected_checks=[],
         note=reason,
+        repo_root=repo_root,
     )
 
 
@@ -141,16 +144,17 @@ def _public_boundary_changed_files_run(
     changed_files: list[str],
     execute: bool,
     timeout_seconds: float,
+    repo_root: Path = REPO_ROOT,
 ) -> dict[str, Any]:
     existing_paths = [
-        (REPO_ROOT / path).resolve()
+        (repo_root / path).resolve()
         for path in _dedupe(changed_files)
-        if (REPO_ROOT / path).exists()
+        if (repo_root / path).exists()
     ]
     display_paths: list[str] = []
     for path in existing_paths:
         try:
-            display_paths.append(str(path.relative_to(REPO_ROOT.resolve())))
+            display_paths.append(str(path.relative_to(repo_root.resolve())))
         except ValueError:
             display_paths.append(str(path))
     display_argv = ["loopx", "check"]
@@ -211,6 +215,7 @@ def _public_boundary_changed_files_run(
             "directly. The full fresh-directory contract smoke remains available "
             "through the canary catalog/profile suites."
         ),
+        repo_root=repo_root,
     )
     payload["selection_inputs"] = {
         "suite": "premerge-public-boundary",
@@ -248,11 +253,15 @@ def _dedupe(values: list[str]) -> list[str]:
     return deduped
 
 
-def classify_premerge_surfaces(changed_files: list[str]) -> dict[str, Any]:
+def classify_premerge_surfaces(
+    changed_files: list[str],
+    *,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
     files = _dedupe(changed_files)
     python_files = [
         path for path in files
-        if path.endswith(".py") and (REPO_ROOT / path).exists()
+        if path.endswith(".py") and (repo_root / path).exists()
     ]
     surfaces: list[str] = []
     risk_profiles: list[str] = []
@@ -307,14 +316,14 @@ def classify_premerge_surfaces(changed_files: list[str]) -> dict[str, Any]:
     }
 
 
-def _display_argv(argv: list[str]) -> list[str]:
+def _display_argv(argv: list[str], *, repo_root: Path = REPO_ROOT) -> list[str]:
     displayed = list(argv)
     if displayed and Path(displayed[0]).resolve() == Path(sys.executable).resolve():
         displayed[0] = "python3"
     for index, value in enumerate(displayed[1:], start=1):
         path = Path(value)
         try:
-            displayed[index] = str(path.resolve().relative_to(REPO_ROOT.resolve()))
+            displayed[index] = str(path.resolve().relative_to(repo_root.resolve()))
         except (OSError, ValueError):
             displayed[index] = value
     return displayed
@@ -331,13 +340,15 @@ def _run_gate_check(
     section: str = "direct_checks",
     check_index: int | None = None,
     check_count: int | None = None,
+    repo_root: Path = REPO_ROOT,
 ) -> dict[str, Any]:
+    display_argv = _display_argv(argv, repo_root=repo_root)
     check = {
         "id": check_id,
         "kind": "direct_command",
         "argv": argv,
-        "display_argv": _display_argv(argv),
-        "command": " ".join(_display_argv(argv)),
+        "display_argv": display_argv,
+        "command": " ".join(display_argv),
         "reason": reason,
         "status": "ready",
         "ok": True,
@@ -363,7 +374,7 @@ def _run_gate_check(
     try:
         completed = subprocess.run(
             argv,
-            cwd=REPO_ROOT,
+            cwd=repo_root,
             text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -430,6 +441,7 @@ def _diff_hygiene_checks(
     execute: bool,
     timeout_seconds: float,
     progress_callback: ProgressCallback | None = None,
+    repo_root: Path = REPO_ROOT,
 ) -> list[dict[str, Any]]:
     base = (base_ref or "origin/main").strip() or "origin/main"
     specs = [
@@ -462,6 +474,7 @@ def _diff_hygiene_checks(
                 section="direct_checks",
                 check_index=index,
                 check_count=len(specs),
+                repo_root=repo_root,
             )
         )
     return checks
@@ -473,6 +486,7 @@ def _py_compile_check(
     execute: bool,
     timeout_seconds: float,
     progress_callback: ProgressCallback | None = None,
+    repo_root: Path = REPO_ROOT,
 ) -> dict[str, Any] | None:
     if not python_files:
         return None
@@ -486,6 +500,7 @@ def _py_compile_check(
         section="python_compile",
         check_index=1,
         check_count=1,
+        repo_root=repo_root,
     )
 
 
@@ -690,9 +705,11 @@ def build_premerge_validation_gate(
     fail_fast: bool = False,
     include_deep_checks: bool | None = None,
     progress_callback: ProgressCallback | None = None,
+    repo_root: Path | None = None,
 ) -> dict[str, Any]:
+    target_repo_root = (repo_root or REPO_ROOT).resolve()
     files = _dedupe(list(changed_files or []))
-    classification = classify_premerge_surfaces(files)
+    classification = classify_premerge_surfaces(files, repo_root=target_repo_root)
     limits = _tier_limits(tier)
     include_deep = bool(limits["deep"] if include_deep_checks is None else include_deep_checks)
     if progress_callback and execute:
@@ -712,12 +729,14 @@ def build_premerge_validation_gate(
         execute=execute,
         timeout_seconds=timeout_seconds,
         progress_callback=progress_callback,
+        repo_root=target_repo_root,
     )
     py_compile = _py_compile_check(
         python_files=list(classification["python_files"]),
         execute=execute,
         timeout_seconds=timeout_seconds,
         progress_callback=progress_callback,
+        repo_root=target_repo_root,
     )
     if py_compile is not None:
         direct_checks.append(py_compile)
@@ -766,6 +785,7 @@ def build_premerge_validation_gate(
             ),
             execute=execute,
             timeout_seconds=timeout_seconds,
+            repo_root=target_repo_root,
         )
 
     risk_profiles = list(classification["risk_profiles"])
@@ -820,6 +840,7 @@ def build_premerge_validation_gate(
             changed_files=files,
             execute=execute,
             timeout_seconds=timeout_seconds,
+            repo_root=target_repo_root,
         )
         _emit_section_progress(
             boundary_progress,
@@ -856,7 +877,7 @@ def build_premerge_validation_gate(
     payload = {
         "ok": ok,
         "schema_version": PREMERGE_GATE_SCHEMA_VERSION,
-        "repo_root": str(REPO_ROOT),
+        "repo_root": str(target_repo_root),
         "base_ref": (base_ref or "origin/main").strip() or "origin/main",
         "tier": tier if tier in PREMERGE_TIERS else "standard",
         "dry_run": not execute,

--- a/loopx/cli_commands/canary.py
+++ b/loopx/cli_commands/canary.py
@@ -80,6 +80,20 @@ def _run_git_name_only(repo_root: Path, args: list[str]) -> dict[str, object]:
     }
 
 
+def _resolve_git_repo_root(candidate: Path) -> Path:
+    completed = subprocess.run(
+        ["git", "-C", str(candidate), "rev-parse", "--show-toplevel"],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    resolved = completed.stdout.strip()
+    if completed.returncode == 0 and resolved:
+        return Path(resolved).resolve()
+    return candidate.resolve()
+
+
 def collect_git_diff_changed_files(
     *,
     repo_root: Path,
@@ -130,8 +144,9 @@ def _resolve_canary_changed_files(args: argparse.Namespace) -> tuple[list[str], 
     changed_files = list(args.changed_file or [])
     git_diff_selector = None
     if bool(getattr(args, "from_git_diff", False)):
+        repo_root = _resolve_git_repo_root(Path.cwd())
         git_diff_selector = collect_git_diff_changed_files(
-            repo_root=Path.cwd(),
+            repo_root=repo_root,
             base_ref=str(getattr(args, "git_diff_base", "origin/main") or "origin/main"),
         )
         changed_files.extend(
@@ -615,6 +630,7 @@ def handle_canary_command(
         renderer = render_quality_surface_catalog_audit_markdown
     elif args.canary_command == "premerge":
         changed_files, git_diff_selector = _resolve_canary_changed_files(args)
+        target_repo_root = _resolve_git_repo_root(Path.cwd())
         payload = build_premerge_validation_gate(
             changed_files=changed_files,
             base_ref=str(getattr(args, "git_diff_base", "origin/main") or "origin/main"),
@@ -623,6 +639,7 @@ def handle_canary_command(
             timeout_seconds=float(args.timeout_seconds or 120.0),
             fail_fast=bool(args.fail_fast),
             include_deep_checks=bool(args.include_deep_checks),
+            repo_root=target_repo_root,
             progress_callback=(
                 None
                 if bool(args.no_execute) or bool(args.no_progress)


### PR DESCRIPTION
## Summary

- resolve the caller Git top-level before collecting and validating a premerge diff
- run diff hygiene, changed-Python compilation, and public-boundary scans in that caller repository
- keep LoopX catalog and risk-profile canaries anchored to the trusted installed release root
- add an external dirty-worktree regression smoke and bilingual contract documentation

## Validation

- `uvx ruff check loopx/canary/premerge.py loopx/cli_commands/canary.py examples/canary/premerge-validation-gate-smoke.py`
- `python3 examples/canary/premerge-validation-gate-smoke.py`
- `loopx check --scan-path ...` (9 checks, no warnings)
- `loopx canary premerge --from-git-diff --tier standard` (18/18 selected checks passed; self-merge allowed)
- real external dirty-worktree invocation: caller-root git checks and changed-Python compilation passed; its independent public-boundary policy still reported its own content hit

## Boundary

No local state, credentials, raw project material, or generated artifacts are included.

## Residual risk

The caller root falls back to the current directory outside a Git worktree, preserving explicit changed-file use without introducing a new hard failure.