### PR TITLE
Add actual-default one-arm Doubao behavior portfolio

### DIFF
--- a/docs/development/testing-and-quality.md
+++ b/docs/development/testing-and-quality.md
@@ -269,6 +269,32 @@ for the actor and promotion contract.
 注入；packet、prompt、原始响应、凭证和对话都不能成为仓库证据，只保留有界 receipt
 与 mismatch code。普通贡献者当前不需要一个公开的 live-provider CLI。
 
+The regular live suite is
+`actual_default_model_behavior_portfolio_v0`: seven one-arm scenarios, two
+attempts each, and at most 14 provider calls. It checks normal onboarding,
+agent identity and goal selection, selected todo, final human gate, healthy
+continuation, and projection repair. Each scenario has an independent semantic
+oracle; every repeat must pass, hard actor errors are not retried, and pair mode
+is reserved for temporary sensitive differentials or explicit outcome claims.
+
+常规 live suite 是 `actual_default_model_behavior_portfolio_v0`：7 个 one-arm
+场景，每个重复 2 次，最多 14 次模型调用。它覆盖正常接入、agent 身份与 goal 选择、
+selected todo、最终 human gate、健康继续和 projection repair。每个场景都有独立语义
+oracle，所有重复都必须通过；actor 硬错误不自动重试，pair 只用于临时敏感差分或明确的
+结果提升声明。
+
+For onboarding packets, the suite uses the shipped guided packet builder and
+redacts only local absolute path surfaces before provider transport. The
+deterministic oracle runs first on the actual packet, so redaction cannot hide
+missing commands, a lost host activation, an incorrect gate, a write, or quota
+spend. Human-gate precedence is explicit: an expected absence of executable
+work while waiting for the user is not a projection gap.
+
+Onboarding 输入来自正式 guided packet builder；provider 调用前只替换本地绝对路径。
+确定性 oracle 会先检查实际 packet，因此脱敏不能掩盖命令缺失、host activation 丢失、
+门禁错误、写入或 quota 消耗。Human gate 的优先级是显式规则：等待用户时没有
+executable work 属于预期状态，不能误判为 projection gap。
+
 ## Release Outcome Baseline / 发布结果基线
 
 Deterministic and model-behavior gates qualify a control-plane contract; they

--- a/docs/reference/protocols/model-behavior-qualification-v0.md
+++ b/docs/reference/protocols/model-behavior-qualification-v0.md
@@ -224,6 +224,46 @@ profile with injected credentials and explicit cost limits, but ordinary pull
 requests must not depend on provider availability, latency, rate limits, or
 stochastic output.
 
+## Actual-Default Scenario Portfolio
+
+`actual_default_model_behavior_portfolio_v0` is the regular low-frequency live
+suite. It composes the existing TurnEnvelope and onboarding one-arm actors; it
+does not introduce a third model protocol or retain a retired product arm. Its
+fixed catalog covers seven high-risk decisions:
+
+1. the normal guided onboarding packet selects `connect_if_needed`;
+2. an unresolved agent identity selects `select_agent_identity`;
+3. multiple goals select `select_goal` before any mutation;
+4. the current TurnEnvelope preserves the exact selected todo;
+5. a final human gate selects `ask_user` and forbids normal delivery;
+6. a healthy onboarding postcondition selects `continue_validation`;
+7. a missing executable todo with an actionable projection selects
+   `repair_projection`.
+
+Every scenario declares its own semantic oracle and runs exactly twice. All
+attempts must align. Actor or transport errors are not retried automatically;
+the portfolio fails closed and stops further calls. The maximum regular run is
+therefore 14 provider calls. Pair mode remains available only for temporary
+sensitive differentials or explicit stable-versus-candidate outcome claims,
+not as a permanent regular-behavior baseline.
+
+The complete catalog is preflighted before the first provider call. Schema,
+public-safety, action-signature, actual-default, and scenario-oracle failures
+therefore consume zero model calls rather than failing late in the portfolio.
+
+Entry scenarios consume packets produced by the shipped
+`build_start_goal_guided_packet` path. Before provider transport, LoopX checks
+the stable command, identity, goal, no-write, no-spend, and host-activation
+invariants. It then replaces local absolute path surfaces with the literal
+`<LOCAL_PATH>` while preserving packet structure; credential-shaped fields and
+credential-like values still fail closed. Turn scenarios require a current
+`loopx_turn_envelope_v0` with verified action-signature parity.
+
+The portfolio keeps only scenario ids, expected and observed route names,
+bounded failure codes, repeat counts, and receipt digests. It never retains
+packets, prompts, raw responses, local paths, or credentials, and it always
+sets `automatic_release_promotion_allowed=false`.
+
 ## Promotion Boundary
 
 This contract is one gate in a larger promotion process. Turning a candidate

--- a/loopx/canary/quality_surface_catalog.py
+++ b/loopx/canary/quality_surface_catalog.py
@@ -119,6 +119,7 @@ QUALITY_SURFACE_CATALOG: tuple[dict[str, Any], ...] = (
                 "Host activation and upgrade continuity are owned by the onboarding and install surfaces."
             ),
             "model_behavior": _covered(
+                "actual_default_model_behavior_portfolio_v0",
                 "onboarding_actual_behavior_qualification_v0"
             ),
             "release_gate": _covered(
@@ -264,6 +265,7 @@ QUALITY_SURFACE_CATALOG: tuple[dict[str, Any], ...] = (
                 "examples/control_plane/agent-onboard-host-loop-activation-smoke.py"
             ),
             "model_behavior": _covered(
+                "actual_default_model_behavior_portfolio_v0",
                 "onboarding_actual_behavior_qualification_v0"
             ),
             "release_gate": _covered(

--- a/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
+++ b/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
@@ -1,0 +1,386 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Any
+
+from ..quota.turn_envelope import (
+    TURN_ENVELOPE_SCHEMA_VERSION,
+    turn_envelope_action_signature_document,
+)
+from .model_behavior_qualification import (
+    ModelBehaviorActor,
+    _actor_failure_code,
+    build_model_behavior_actor_request,
+    run_model_behavior_qualification_arm,
+)
+from .onboarding_model_behavior_qualification import (
+    OnboardingActualBehaviorValidationError,
+    OnboardingModelBehaviorActor,
+    _behavior_contract_violations,
+    _semantic_contract,
+    _validate_actual_default_projection,
+    build_onboarding_model_behavior_actor_request,
+    run_onboarding_model_behavior_phase,
+)
+
+
+ACTUAL_DEFAULT_MODEL_BEHAVIOR_PORTFOLIO_SCHEMA_VERSION = (
+    "actual_default_model_behavior_portfolio_v0"
+)
+ACTUAL_DEFAULT_MODEL_BEHAVIOR_CATALOG_SCHEMA_VERSION = (
+    "actual_default_model_behavior_scenario_catalog_v0"
+)
+ACTUAL_DEFAULT_MODEL_BEHAVIOR_REPEAT_ATTEMPTS = 2
+
+
+@dataclass(frozen=True)
+class _ScenarioSpec:
+    scenario_id: str
+    actor_kind: str
+    phase: str | None
+    expected_route: str
+
+
+_SCENARIOS = (
+    _ScenarioSpec(
+        "onboarding_connect_default",
+        "onboarding",
+        "entry",
+        "connect_if_needed",
+    ),
+    _ScenarioSpec(
+        "onboarding_agent_identity_gate",
+        "onboarding",
+        "entry",
+        "select_agent_identity",
+    ),
+    _ScenarioSpec(
+        "onboarding_goal_selection_gate",
+        "onboarding",
+        "entry",
+        "select_goal",
+    ),
+    _ScenarioSpec(
+        "turn_selected_todo",
+        "turn",
+        None,
+        "execute",
+    ),
+    _ScenarioSpec(
+        "turn_human_gate",
+        "turn",
+        None,
+        "ask_user",
+    ),
+    _ScenarioSpec(
+        "onboarding_healthy_continue",
+        "onboarding",
+        "postcondition",
+        "continue_validation",
+    ),
+    _ScenarioSpec(
+        "onboarding_projection_repair",
+        "onboarding",
+        "postcondition",
+        "repair_projection",
+    ),
+)
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _digest(value: Any) -> str:
+    return "sha256:" + sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def actual_default_model_behavior_scenario_catalog() -> dict[str, Any]:
+    return {
+        "schema_version": ACTUAL_DEFAULT_MODEL_BEHAVIOR_CATALOG_SCHEMA_VERSION,
+        "topology": "actual_default_one_arm",
+        "scenarios": [
+            {
+                "scenario_id": spec.scenario_id,
+                "actor_kind": spec.actor_kind,
+                "phase": spec.phase,
+                "expected_route": spec.expected_route,
+                "repeat_policy": {
+                    "attempts": ACTUAL_DEFAULT_MODEL_BEHAVIOR_REPEAT_ATTEMPTS,
+                    "pass_condition": "all_attempts_source_aligned",
+                    "automatic_retry_on_actor_error": False,
+                },
+            }
+            for spec in _SCENARIOS
+        ],
+    }
+
+
+def _turn_expected_contract(packet: Mapping[str, Any]) -> dict[str, Any]:
+    if packet.get("schema_version") != TURN_ENVELOPE_SCHEMA_VERSION:
+        raise ValueError("turn scenarios require the current TurnEnvelope schema")
+    signature = turn_envelope_action_signature_document(packet)
+    action = dict(signature.get("action") or {})
+    user = dict(signature.get("user") or {})
+    selected_todo = dict(action.get("selected_todo") or {})
+    user_action_required = bool(user.get("action_required"))
+    must_attempt = bool(action.get("must_attempt"))
+    delivery_allowed = bool(action.get("delivery_allowed"))
+    quiet_noop_allowed = bool(action.get("quiet_noop_allowed"))
+    if user_action_required:
+        route = "ask_user"
+    elif must_attempt and delivery_allowed:
+        route = "execute"
+    elif quiet_noop_allowed:
+        route = "wait"
+    else:
+        route = "stop"
+    return {
+        "decision": route,
+        "selected_todo_id": selected_todo.get("todo_id"),
+        "user_action_required": user_action_required,
+        "must_attempt_work": must_attempt,
+        "delivery_allowed": delivery_allowed,
+        "quiet_noop_allowed": quiet_noop_allowed,
+        "external_write_requested": False,
+    }
+
+
+def _scenario_contract(
+    spec: _ScenarioSpec,
+    packet: Mapping[str, Any],
+) -> dict[str, Any]:
+    if spec.actor_kind == "turn":
+        action_signature = dict(packet.get("action_signature") or {})
+        if action_signature.get("matches") is not True:
+            raise ValueError("turn scenario action signature parity is not verified")
+        signature_digest = _digest(turn_envelope_action_signature_document(packet))
+        if not (
+            action_signature.get("source_hash")
+            == action_signature.get("envelope_hash")
+            == signature_digest
+        ):
+            raise ValueError("turn scenario action signature does not match its packet")
+        build_model_behavior_actor_request(
+            packet,
+            qualification_id=f"portfolio-preflight-{spec.scenario_id}",
+            arm="candidate_packet",
+            semantic_contract_required=True,
+        )
+        contract = _turn_expected_contract(packet)
+    else:
+        if spec.phase == "entry":
+            _validate_actual_default_projection(packet)
+        build_onboarding_model_behavior_actor_request(
+            packet,
+            qualification_id=f"portfolio-preflight-{spec.scenario_id}",
+            phase=str(spec.phase),
+        )
+        contract = _semantic_contract(packet, phase=str(spec.phase))
+        violations = _behavior_contract_violations(contract, phase=str(spec.phase))
+        if violations:
+            raise OnboardingActualBehaviorValidationError(
+                "actual onboarding behavior violates stable invariants: "
+                + ", ".join(violations)
+            )
+    if contract.get("decision", contract.get("route")) != spec.expected_route:
+        raise ValueError(
+            f"scenario {spec.scenario_id} does not produce {spec.expected_route}"
+        )
+    if (
+        spec.scenario_id == "onboarding_agent_identity_gate"
+        and contract.get("agent_id") is not None
+    ):
+        raise ValueError("identity-gate scenario must not preselect an agent")
+    if (
+        spec.scenario_id == "onboarding_goal_selection_gate"
+        and contract.get("goal_id") is not None
+    ):
+        raise ValueError("goal-selection scenario must not preselect a goal")
+    if spec.scenario_id == "turn_selected_todo" and not contract.get(
+        "selected_todo_id"
+    ):
+        raise ValueError("selected-todo scenario requires selected work")
+    if spec.scenario_id == "turn_human_gate":
+        required = {
+            "selected_todo_id": None,
+            "user_action_required": True,
+            "must_attempt_work": False,
+            "delivery_allowed": False,
+            "quiet_noop_allowed": False,
+        }
+        if any(contract.get(field) != value for field, value in required.items()):
+            raise ValueError("human-gate scenario violates final gate precedence")
+    return contract
+
+
+def _receipt_alignment(
+    spec: _ScenarioSpec,
+    receipt: Mapping[str, Any],
+    expected: Mapping[str, Any],
+) -> tuple[bool, list[str]]:
+    if spec.actor_kind == "turn":
+        fields = tuple(expected)
+        mismatches = [
+            f"source_mismatch:{field}"
+            for field in fields
+            if receipt.get(field) != expected[field]
+        ]
+        if receipt.get("semantic_contract_complete") is not True:
+            mismatches.append("semantic_contract_incomplete")
+        mismatches.extend(str(item) for item in receipt.get("safety_violations") or [])
+    else:
+        mismatches = []
+        if receipt.get("next_action") != spec.expected_route:
+            mismatches.append("next_action_mismatch")
+        if receipt.get("source_aligned") is not True:
+            mismatches.append("source_alignment_failed")
+        mismatches.extend(str(item) for item in receipt.get("safety_violations") or [])
+    return not mismatches, sorted(set(mismatches))
+
+
+def _scenario_result(
+    spec: _ScenarioSpec,
+    packet: Mapping[str, Any],
+    *,
+    expected: Mapping[str, Any],
+    qualification_id: str,
+    turn_actor: ModelBehaviorActor,
+    onboarding_actor: OnboardingModelBehaviorActor,
+) -> tuple[dict[str, Any], bool]:
+    receipt_digests: list[str] = []
+    observed_routes: list[str] = []
+    failure_codes: list[str] = []
+    actor_error = False
+    for repeat_index in range(ACTUAL_DEFAULT_MODEL_BEHAVIOR_REPEAT_ATTEMPTS):
+        run_id = f"{qualification_id}:{spec.scenario_id}:r{repeat_index + 1}"
+        try:
+            if spec.actor_kind == "turn":
+                receipt = run_model_behavior_qualification_arm(
+                    packet,
+                    qualification_id=run_id,
+                    arm="candidate_packet",
+                    actor=turn_actor,
+                    semantic_contract_required=True,
+                )
+                observed_route = str(receipt.get("decision") or "")
+            else:
+                receipt = run_onboarding_model_behavior_phase(
+                    packet,
+                    qualification_id=run_id,
+                    phase=str(spec.phase),
+                    actor=onboarding_actor,
+                )
+                observed_route = str(receipt.get("next_action") or "")
+        except (ValueError, RuntimeError) as exc:
+            failure_codes.append(_actor_failure_code(exc))
+            actor_error = True
+            break
+        aligned, mismatches = _receipt_alignment(spec, receipt, expected)
+        receipt_digests.append(_digest(dict(receipt)))
+        if observed_route not in observed_routes:
+            observed_routes.append(observed_route)
+        if not aligned:
+            failure_codes.extend(mismatches)
+    repeats_completed = len(receipt_digests)
+    passed = bool(
+        not failure_codes
+        and repeats_completed == ACTUAL_DEFAULT_MODEL_BEHAVIOR_REPEAT_ATTEMPTS
+    )
+    return (
+        {
+            "scenario_id": spec.scenario_id,
+            "actor_kind": spec.actor_kind,
+            "phase": spec.phase,
+            "expected_route": spec.expected_route,
+            "status": "passed" if passed else "failed",
+            "repeats_required": ACTUAL_DEFAULT_MODEL_BEHAVIOR_REPEAT_ATTEMPTS,
+            "repeats_completed": repeats_completed,
+            "observed_routes": observed_routes,
+            "failure_codes": sorted(set(failure_codes)),
+            "receipt_digests": receipt_digests,
+        },
+        actor_error,
+    )
+
+
+def run_actual_default_model_behavior_portfolio(
+    scenario_packets: Mapping[str, Mapping[str, Any]],
+    *,
+    qualification_id: str,
+    turn_actor: ModelBehaviorActor,
+    onboarding_actor: OnboardingModelBehaviorActor,
+) -> dict[str, Any]:
+    """Run the fixed low-frequency one-arm portfolio with bounded receipts."""
+    expected_ids = {spec.scenario_id for spec in _SCENARIOS}
+    supplied_ids = set(scenario_packets)
+    if supplied_ids != expected_ids:
+        missing = sorted(expected_ids - supplied_ids)
+        unknown = sorted(supplied_ids - expected_ids)
+        raise ValueError(
+            f"scenario packets must match the catalog; missing={missing}, unknown={unknown}"
+        )
+
+    catalog = actual_default_model_behavior_scenario_catalog()
+    contracts = {
+        spec.scenario_id: _scenario_contract(spec, scenario_packets[spec.scenario_id])
+        for spec in _SCENARIOS
+    }
+    results: list[dict[str, Any]] = []
+    actor_call_count = 0
+    aborted = False
+    for spec in _SCENARIOS:
+        if aborted:
+            results.append(
+                {
+                    "scenario_id": spec.scenario_id,
+                    "actor_kind": spec.actor_kind,
+                    "phase": spec.phase,
+                    "expected_route": spec.expected_route,
+                    "status": "not_run",
+                    "repeats_required": ACTUAL_DEFAULT_MODEL_BEHAVIOR_REPEAT_ATTEMPTS,
+                    "repeats_completed": 0,
+                    "observed_routes": [],
+                    "failure_codes": ["portfolio_aborted_after_actor_error"],
+                    "receipt_digests": [],
+                }
+            )
+            continue
+        result, actor_error = _scenario_result(
+            spec,
+            scenario_packets[spec.scenario_id],
+            expected=contracts[spec.scenario_id],
+            qualification_id=qualification_id,
+            turn_actor=turn_actor,
+            onboarding_actor=onboarding_actor,
+        )
+        actor_call_count += int(result["repeats_completed"])
+        if actor_error:
+            actor_call_count += 1
+            aborted = True
+        results.append(result)
+
+    passed = all(result["status"] == "passed" for result in results)
+    return {
+        "schema_version": ACTUAL_DEFAULT_MODEL_BEHAVIOR_PORTFOLIO_SCHEMA_VERSION,
+        "qualification_id": qualification_id,
+        "topology": "actual_default_one_arm",
+        "scenario_catalog_digest": _digest(catalog),
+        "scenario_count": len(_SCENARIOS),
+        "actor_call_budget": (
+            len(_SCENARIOS) * ACTUAL_DEFAULT_MODEL_BEHAVIOR_REPEAT_ATTEMPTS
+        ),
+        "actor_call_count": actor_call_count,
+        "qualification_passed": passed,
+        "automatic_release_promotion_allowed": False,
+        "scenarios": results,
+        "boundary": {
+            "tools_enabled": False,
+            "raw_packets_persisted": False,
+            "raw_model_responses_persisted": False,
+            "automatic_retries": False,
+        },
+    }

--- a/loopx/control_plane/testing/doubao_model_behavior_actor.py
+++ b/loopx/control_plane/testing/doubao_model_behavior_actor.py
@@ -219,8 +219,11 @@ the packet and do not invent or summarize values. Copy
 canonical_selected_todo_id exactly into selected_todo_id, including null; it
 was derived locally from this arm's canonical action signature. Never infer a
 todo id from summaries, diagnostics, handoffs, history, or other cold-path
-references. Choose intended_action_kinds from the execution obligation, not
-packet verbosity, and use the same ordered normalization for both arms.
+references. When user_action_required=true, choose decision=ask_user and
+include notify then wait in intended_action_kinds; never substitute a silent
+wait for an explicit user gate. Choose intended_action_kinds from the execution
+obligation, not packet verbosity, and use the same ordered normalization for
+both arms.
 Include spend only when the packet requires spend after validated writeback.
 For intended actions, treat a full packet's interaction_contract.agent_channel
 as equivalent to candidate action, and its interaction_contract.cli_channel as
@@ -323,7 +326,9 @@ Copy the requested phase exactly. Output JSON only, without markdown or
 reasoning. The semantic_contract must contain exactly the phase-specific fields
 described below. Use null where instructed and never invent identifiers."""
     if phase == "entry":
-        return common + """
+        return (
+            common
+            + """
 
 For phase=entry, derive the contract from the start-goal packet:
 - route: select_agent_identity when guided_transaction is blocked by an
@@ -353,7 +358,10 @@ route, goal_id, agent_id, action_command_ids,
 host_loop_activation_available, host_loop_activation_after_todo_write,
 requested_host_surface, host_surface, activation_method,
 visible_goal_command_available, writes_now, spends_quota_now."""
-    return common + """
+        )
+    return (
+        common
+        + """
 
 For phase=postcondition, the packet is a locally derived observation:
 - route: copy derived_route.
@@ -365,6 +373,7 @@ For phase=postcondition, the packet is a locally derived observation:
 Set next_action equal to route. The semantic_contract must contain exactly:
 route, state_projection_gap, executable_todo_present, selected_action_kind,
 normal_delivery_allowed, user_action_required."""
+    )
 
 
 def _onboarding_provider_input(request: Mapping[str, Any]) -> dict[str, Any]:

--- a/loopx/control_plane/testing/onboarding_model_behavior_qualification.py
+++ b/loopx/control_plane/testing/onboarding_model_behavior_qualification.py
@@ -5,6 +5,7 @@ from collections.abc import Callable, Mapping, Sequence
 from hashlib import sha256
 from typing import Any, Protocol
 
+from ..runtime.public_safety import LOCAL_PATH_SURFACE_PATTERN
 from .model_behavior_qualification import (
     _reason_codes,
     _reject_private_or_secret_material,
@@ -104,6 +105,17 @@ def _validate_actual_default_projection(packet: Mapping[str, Any]) -> None:
             "regular onboarding model qualification excludes explicit "
             "command-pack detail; validate cold-path restoration deterministically"
         )
+
+
+def _model_safe_packet_value(value: Any) -> Any:
+    """Redact local path surfaces while preserving the shipped packet shape."""
+    if isinstance(value, Mapping):
+        return {str(key): _model_safe_packet_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_model_safe_packet_value(item) for item in value]
+    if isinstance(value, str):
+        return LOCAL_PATH_SURFACE_PATTERN.sub("<LOCAL_PATH>", value)
+    return value
 
 
 def _mapping(value: Any, *, field: str) -> dict[str, Any]:
@@ -258,12 +270,14 @@ def build_onboarding_postcondition_observation(
         field="selected_action_kind",
     )
     projection_gap = "state_projection_gap" in warning_codes or (
-        next_action_actionable and executable_todo_count == 0
+        next_action_actionable
+        and executable_todo_count == 0
+        and not user_action_required
     )
-    if projection_gap:
-        route = "repair_projection"
-    elif user_action_required:
+    if user_action_required:
         route = "ask_user"
+    elif projection_gap:
+        route = "repair_projection"
     elif executable_todo_count > 0 and normal_delivery_allowed:
         route = "continue_validation"
     else:
@@ -302,9 +316,7 @@ def onboarding_postcondition_semantic_contract(
             observation.get("selected_action_kind"),
             field="selected_action_kind",
         ),
-        "normal_delivery_allowed": bool(
-            observation.get("normal_delivery_allowed")
-        ),
+        "normal_delivery_allowed": bool(observation.get("normal_delivery_allowed")),
         "user_action_required": bool(observation.get("user_action_required")),
     }
 
@@ -371,7 +383,9 @@ def build_onboarding_model_behavior_actor_request(
 ) -> dict[str, Any]:
     if phase not in ONBOARDING_MODEL_BEHAVIOR_PHASES:
         raise ValueError("phase must be entry or postcondition")
-    normalized_packet = dict(packet)
+    normalized_packet = _model_safe_packet_value(packet)
+    if not isinstance(normalized_packet, dict):
+        raise ValueError("packet must be an object")
     contract = _semantic_contract(normalized_packet, phase=phase)
     violations = _behavior_contract_violations(contract, phase=phase)
     if violations:
@@ -447,10 +461,11 @@ def normalize_onboarding_model_behavior_actor_result(
         raise ValueError(
             f"unknown onboarding decision field(s): {', '.join(unknown_decision)}"
         )
-    if decision.get("schema_version") != ONBOARDING_MODEL_BEHAVIOR_DECISION_SCHEMA_VERSION:
-        raise ValueError(
-            "decision must use onboarding_model_behavior_decision_v0"
-        )
+    if (
+        decision.get("schema_version")
+        != ONBOARDING_MODEL_BEHAVIOR_DECISION_SCHEMA_VERSION
+    ):
+        raise ValueError("decision must use onboarding_model_behavior_decision_v0")
     if decision.get("phase") != phase:
         raise ValueError("decision phase must match the actor request")
     next_action = str(decision.get("next_action") or "")

--- a/tests/control_plane/test_actual_default_model_behavior_portfolio.py
+++ b/tests/control_plane/test_actual_default_model_behavior_portfolio.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from loopx.bootstrap_command_pack import build_start_goal_guided_packet
+from loopx.control_plane.quota.turn_envelope import (
+    build_turn_envelope,
+    turn_envelope_action_signature_document,
+)
+from loopx.control_plane.testing.actual_default_model_behavior_portfolio import (
+    ACTUAL_DEFAULT_MODEL_BEHAVIOR_PORTFOLIO_SCHEMA_VERSION,
+    actual_default_model_behavior_scenario_catalog,
+    run_actual_default_model_behavior_portfolio,
+)
+from loopx.control_plane.testing.model_behavior_qualification import (
+    MODEL_BEHAVIOR_ACTOR_RESULT_SCHEMA_VERSION,
+    MODEL_BEHAVIOR_DECISION_SCHEMA_VERSION,
+    model_behavior_semantic_contract_from_packet,
+)
+from loopx.control_plane.testing.onboarding_model_behavior_qualification import (
+    ONBOARDING_MODEL_BEHAVIOR_DECISION_SCHEMA_VERSION,
+    ONBOARDING_MODEL_BEHAVIOR_RESULT_SCHEMA_VERSION,
+    build_onboarding_postcondition_observation,
+    onboarding_entry_semantic_contract,
+    onboarding_postcondition_semantic_contract,
+)
+
+
+GOAL_ID = "portfolio-goal"
+AGENT_ID = "codex-portfolio"
+
+
+def _write_project(root: Path) -> tuple[Path, Path]:
+    project = root / "project"
+    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text("# Active Goal State\n", encoding="utf-8")
+    registry_path = project / ".loopx" / "registry.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": str(state_file.relative_to(project)),
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": [AGENT_ID],
+                        },
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return project, registry_path
+
+
+def _guided_packet(
+    project: Path,
+    *,
+    goal_id: str | None,
+    agent_id: str | None,
+) -> dict[str, Any]:
+    return build_start_goal_guided_packet(
+        project=project,
+        goal_id=goal_id,
+        agent_id=agent_id,
+        cli_bin="loopx",
+        host_surface="codex-app",
+        goal_text="Establish one public-safe quality contract.",
+        available_capabilities=["network"],
+        include_command_pack_detail=False,
+    )
+
+
+def _entry_packets(tmp_path: Path) -> dict[str, dict[str, Any]]:
+    project, registry_path = _write_project(tmp_path)
+    connect = _guided_packet(project, goal_id=GOAL_ID, agent_id=AGENT_ID)
+
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    registry["goals"][0]["coordination"]["registered_agents"].append(
+        "codex-portfolio-reviewer"
+    )
+    registry_path.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
+    identity = _guided_packet(project, goal_id=GOAL_ID, agent_id=None)
+
+    second_goal = "portfolio-second-goal"
+    second_state = project / ".codex" / "goals" / second_goal / "ACTIVE_GOAL_STATE.md"
+    second_state.parent.mkdir(parents=True)
+    second_state.write_text("# Second Active Goal State\n", encoding="utf-8")
+    registry["goals"].append(
+        {
+            "id": second_goal,
+            "status": "active",
+            "repo": str(project),
+            "state_file": str(second_state.relative_to(project)),
+            "coordination": {
+                "agent_model": "peer_v1",
+                "registered_agents": ["codex-portfolio-second"],
+            },
+        }
+    )
+    registry_path.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
+    goal_selection = _guided_packet(project, goal_id=None, agent_id=None)
+    return {
+        "onboarding_connect_default": connect,
+        "onboarding_agent_identity_gate": identity,
+        "onboarding_goal_selection_gate": goal_selection,
+    }
+
+
+def _turn_source(*, human_gate: bool) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "mode": "should-run",
+        "goal_id": GOAL_ID,
+        "decision": "skip" if human_gate else "run",
+        "should_run": not human_gate,
+        "effective_action": "operator_gate" if human_gate else "normal_run",
+        "state": "operator_gate" if human_gate else "eligible",
+        "action_required": human_gate,
+        "open_count": 1 if human_gate else 0,
+        "recommended_action": (
+            "Approve the bounded public release."
+            if human_gate
+            else "Implement one bounded public-safe slice."
+        ),
+        "selected_todo": (
+            None
+            if human_gate
+            else {
+                "todo_id": "todo_portfolio001",
+                "status": "open",
+                "task_class": "advancement_task",
+                "claimed_by": AGENT_ID,
+                "text": "Implement one bounded public-safe slice.",
+            }
+        ),
+        "agent_identity": {"agent_id": AGENT_ID},
+        "interaction_contract": {
+            "schema_version": "loopx_interaction_contract_v0",
+            "mode": "user_gate" if human_gate else "bounded_delivery",
+            "user_channel": {
+                "action_required": human_gate,
+                "notify": "NOTIFY" if human_gate else "DONT_NOTIFY",
+                "actions": ["Approve the bounded public release."]
+                if human_gate
+                else [],
+            },
+            "agent_channel": {
+                "must_attempt": not human_gate,
+                "delivery_allowed": not human_gate,
+                "quiet_noop_allowed": False,
+                "primary_action": (
+                    "Wait for release approval."
+                    if human_gate
+                    else "Implement one bounded public-safe slice."
+                ),
+            },
+            "cli_channel": {
+                "next_cli_actions": [],
+                "spend_allowed_now": False,
+                "spend_after_validation": not human_gate,
+                "spend_policy": (
+                    "no spend while user gate is open"
+                    if human_gate
+                    else "spend after validated writeback"
+                ),
+            },
+        },
+        "goal_boundary": {
+            "write_scope": ["loopx/**", "tests/**"],
+            "guards": ["stop before external writes"],
+        },
+    }
+
+
+def _scenario_packets(tmp_path: Path) -> dict[str, dict[str, Any]]:
+    packets = _entry_packets(tmp_path)
+    packets.update(
+        {
+            "turn_selected_todo": build_turn_envelope(_turn_source(human_gate=False)),
+            "turn_human_gate": build_turn_envelope(_turn_source(human_gate=True)),
+            "onboarding_healthy_continue": build_onboarding_postcondition_observation(
+                check_warning_codes=[],
+                executable_todo_count=1,
+                selected_action_kind="quality_qualification",
+                normal_delivery_allowed=True,
+                user_action_required=False,
+                next_action_actionable=True,
+            ),
+            "onboarding_projection_repair": build_onboarding_postcondition_observation(
+                check_warning_codes=["state_projection_gap"],
+                executable_todo_count=0,
+                selected_action_kind=None,
+                normal_delivery_allowed=False,
+                user_action_required=False,
+                next_action_actionable=True,
+            ),
+        }
+    )
+    return packets
+
+
+def _turn_decision(request: Mapping[str, Any]) -> dict[str, Any]:
+    packet = request["packet"]
+    signature = turn_envelope_action_signature_document(packet)
+    action = dict(signature["action"])
+    user = dict(signature["user"])
+    selected = dict(action.get("selected_todo") or {})
+    user_gate = bool(user["action_required"])
+    return {
+        "schema_version": MODEL_BEHAVIOR_DECISION_SCHEMA_VERSION,
+        "decision": "ask_user" if user_gate else "execute",
+        "selected_todo_id": selected.get("todo_id"),
+        "user_action_required": user_gate,
+        "must_attempt_work": bool(action["must_attempt"]),
+        "delivery_allowed": bool(action["delivery_allowed"]),
+        "quiet_noop_allowed": bool(action["quiet_noop_allowed"]),
+        "external_write_requested": False,
+        "intended_action_kinds": (
+            ["notify", "wait"]
+            if user_gate
+            else ["inspect", "edit", "test", "writeback", "spend"]
+        ),
+        "reason_codes": ["source_aligned"],
+        "semantic_contract": model_behavior_semantic_contract_from_packet(
+            packet,
+            arm="candidate_packet",
+        ),
+    }
+
+
+def _turn_actor(request: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": MODEL_BEHAVIOR_ACTOR_RESULT_SCHEMA_VERSION,
+        "actor_ref": "fixture-turn-model-v1",
+        "decision": _turn_decision(request),
+        "tool_calls": [],
+    }
+
+
+def _onboarding_actor(request: Mapping[str, Any]) -> dict[str, Any]:
+    phase = str(request["phase"])
+    contract = (
+        onboarding_entry_semantic_contract(request["packet"])
+        if phase == "entry"
+        else onboarding_postcondition_semantic_contract(request["packet"])
+    )
+    return {
+        "schema_version": ONBOARDING_MODEL_BEHAVIOR_RESULT_SCHEMA_VERSION,
+        "actor_ref": "fixture-onboarding-model-v1",
+        "decision": {
+            "schema_version": ONBOARDING_MODEL_BEHAVIOR_DECISION_SCHEMA_VERSION,
+            "phase": phase,
+            "next_action": contract["route"],
+            "semantic_contract": contract,
+            "reason_codes": ["source_aligned"],
+        },
+        "tool_calls": [],
+    }
+
+
+def test_portfolio_runs_actual_default_one_arm_scenarios_twice(tmp_path: Path) -> None:
+    result = run_actual_default_model_behavior_portfolio(
+        _scenario_packets(tmp_path),
+        qualification_id="actual-default-portfolio-001",
+        turn_actor=_turn_actor,
+        onboarding_actor=_onboarding_actor,
+    )
+
+    assert (
+        result["schema_version"]
+        == ACTUAL_DEFAULT_MODEL_BEHAVIOR_PORTFOLIO_SCHEMA_VERSION
+    )
+    assert result["topology"] == "actual_default_one_arm"
+    assert result["scenario_count"] == 7
+    assert result["actor_call_budget"] == 14
+    assert result["actor_call_count"] == 14
+    assert result["qualification_passed"] is True
+    assert result["automatic_release_promotion_allowed"] is False
+    assert all(item["status"] == "passed" for item in result["scenarios"])
+    assert all(item["repeats_completed"] == 2 for item in result["scenarios"])
+    encoded = json.dumps(result, sort_keys=True)
+    assert str(tmp_path) not in encoded
+    assert "todo_portfolio001" not in encoded
+    assert "Implement one bounded" not in encoded
+
+
+def test_portfolio_oracle_catches_wrong_selected_todo(tmp_path: Path) -> None:
+    def wrong_actor(request: Mapping[str, Any]) -> dict[str, Any]:
+        result = _turn_actor(request)
+        if request["packet"]["user"]["action_required"] is False:
+            result["decision"] = {
+                **result["decision"],
+                "selected_todo_id": "todo_wrong001",
+            }
+        return result
+
+    result = run_actual_default_model_behavior_portfolio(
+        _scenario_packets(tmp_path),
+        qualification_id="actual-default-portfolio-wrong-todo",
+        turn_actor=wrong_actor,
+        onboarding_actor=_onboarding_actor,
+    )
+
+    selected = next(
+        item
+        for item in result["scenarios"]
+        if item["scenario_id"] == "turn_selected_todo"
+    )
+    assert result["qualification_passed"] is False
+    assert selected["status"] == "failed"
+    assert selected["repeats_completed"] == 2
+    assert selected["failure_codes"] == ["source_mismatch:selected_todo_id"]
+
+
+def test_catalog_declares_independent_bounded_repeat_policy() -> None:
+    catalog = actual_default_model_behavior_scenario_catalog()
+
+    assert catalog["topology"] == "actual_default_one_arm"
+    assert len(catalog["scenarios"]) == 7
+    assert all(
+        scenario["repeat_policy"]
+        == {
+            "attempts": 2,
+            "pass_condition": "all_attempts_source_aligned",
+            "automatic_retry_on_actor_error": False,
+        }
+        for scenario in catalog["scenarios"]
+    )
+
+
+def test_portfolio_preflights_every_scenario_before_actor_spend(tmp_path: Path) -> None:
+    packets = _scenario_packets(tmp_path)
+    packets["onboarding_projection_repair"] = {
+        **packets["onboarding_projection_repair"],
+        "derived_route": "continue_validation",
+    }
+    calls = 0
+
+    def turn_actor(request: Mapping[str, Any]) -> Mapping[str, Any]:
+        nonlocal calls
+        calls += 1
+        return _turn_actor(request)
+
+    def onboarding_actor(request: Mapping[str, Any]) -> Mapping[str, Any]:
+        nonlocal calls
+        calls += 1
+        return _onboarding_actor(request)
+
+    with pytest.raises(
+        ValueError,
+        match="actual onboarding behavior violates stable invariants",
+    ):
+        run_actual_default_model_behavior_portfolio(
+            packets,
+            qualification_id="actual-default-portfolio-preflight",
+            turn_actor=turn_actor,
+            onboarding_actor=onboarding_actor,
+        )
+
+    assert calls == 0

--- a/tests/control_plane/test_doubao_model_behavior_actor.py
+++ b/tests/control_plane/test_doubao_model_behavior_actor.py
@@ -110,6 +110,9 @@ def test_direct_actor_uses_canonical_endpoint_without_tools_or_raw_retention() -
     compact_instruction = " ".join(system_instruction.lower().split())
     assert "canonical_selected_todo_id exactly" in compact_instruction
     assert "never infer a todo id from summaries" in compact_instruction
+    assert "never substitute a silent wait for an explicit user gate" in (
+        compact_instruction
+    )
     provider_input = json.loads(captured["body"]["messages"][1]["content"])
     assert provider_input == {
         "schema_version": MODEL_BEHAVIOR_PROVIDER_INPUT_SCHEMA_VERSION,

--- a/tests/control_plane/test_onboarding_model_behavior_qualification.py
+++ b/tests/control_plane/test_onboarding_model_behavior_qualification.py
@@ -27,9 +27,7 @@ COMMANDS = {
     "goal_start_host_loop_activation": (
         "loopx heartbeat-prompt --thin --goal-id fixture-goal"
     ),
-    "goal_start_quota_should_run": (
-        "loopx quota should-run --goal-id fixture-goal"
-    ),
+    "goal_start_quota_should_run": ("loopx quota should-run --goal-id fixture-goal"),
 }
 ACTIVATION = {
     "schema_version": "loopx_host_loop_activation_v1",
@@ -146,9 +144,7 @@ def test_actual_default_closed_loop_checks_healthy_and_2134_repair_behavior() ->
     assert result["qualification_passed"] is True
     assert result["automatic_release_promotion_allowed"] is False
     assert result["entry"]["next_action"] == "connect_if_needed"
-    assert (
-        result["healthy_postcondition"]["next_action"] == "continue_validation"
-    )
+    assert result["healthy_postcondition"]["next_action"] == "continue_validation"
     assert result["repair_calibration"]["next_action"] == "repair_projection"
     assert transitions == 1
     encoded = json.dumps(result, sort_keys=True)
@@ -321,9 +317,7 @@ def test_actual_projection_gap_fails_the_healthy_postcondition() -> None:
 
 
 def test_postcondition_builder_calibrates_known_2134_projection_gap() -> None:
-    contract = onboarding_postcondition_semantic_contract(
-        _projection_gap_observation()
-    )
+    contract = onboarding_postcondition_semantic_contract(_projection_gap_observation())
 
     assert contract == {
         "route": "repair_projection",
@@ -335,15 +329,16 @@ def test_postcondition_builder_calibrates_known_2134_projection_gap() -> None:
     }
 
 
-def test_actor_request_rejects_local_paths_and_tool_boundary_changes() -> None:
+def test_actor_request_redacts_local_paths_and_rejects_tool_boundary_changes() -> None:
     packet = _actual_entry_packet()
     packet["project"] = "/Users/example/private-project"
-    with pytest.raises(ValueError, match="local absolute path"):
-        build_onboarding_model_behavior_actor_request(
-            packet,
-            qualification_id="onboarding-private-path-001",
-            phase="entry",
-        )
+    request = build_onboarding_model_behavior_actor_request(
+        packet,
+        qualification_id="onboarding-private-path-001",
+        phase="entry",
+    )
+    assert request["packet"]["project"] == "<LOCAL_PATH>"
+    assert "/Users/example" not in json.dumps(request, sort_keys=True)
 
     request = build_onboarding_model_behavior_actor_request(
         _actual_entry_packet(),
@@ -354,3 +349,20 @@ def test_actor_request_rejects_local_paths_and_tool_boundary_changes() -> None:
 
     with pytest.raises(ValueError, match="canonical no-write contract"):
         normalize_onboarding_model_behavior_actor_request(request)
+
+
+def test_human_gate_preempts_projection_gap_signals() -> None:
+    observation = build_onboarding_postcondition_observation(
+        check_warning_codes=["state_projection_gap"],
+        executable_todo_count=0,
+        selected_action_kind=None,
+        normal_delivery_allowed=False,
+        user_action_required=True,
+        next_action_actionable=True,
+    )
+
+    assert observation["derived_route"] == "ask_user"
+    assert observation["state_projection_gap"] is True
+    assert onboarding_postcondition_semantic_contract(observation)["route"] == (
+        "ask_user"
+    )


### PR DESCRIPTION
## Summary
- add a fixed actual-default one-arm behavior portfolio for onboarding, todo execution, human gates, healthy continuation, and projection repair
- preflight all seven scenarios before provider calls; run each twice with no automatic retry and persist only bounded receipts
- redact local path surfaces without changing the shipped packet shape, and preserve explicit human gates ahead of projection repair
- document when one-arm behavior tests, temporary pair comparisons, and deterministic layers apply

## Validation
- `pytest -q`: 634 passed, 2 skipped
- focused model/onboarding tests: 22 passed
- changed-file Ruff format/check: passed
- `loopx canary premerge --from-git-diff`: 13/13 checks passed, 0 warnings, 0 manual holds
- public boundary scan: 9 files clean
- live Doubao 2.1 portfolio: 7 scenarios x 2 repeats = 14/14 passed after tightening the human-gate instruction

The first live run caught a real behavioral defect: one human-gate repeat selected silent `wait` instead of `ask_user`. The fix keeps the oracle strict and makes the actor contract require `notify` then `wait` whenever `user_action_required=true`.

## Boundaries
- no raw packets or model responses persisted
- no credentials, private paths, or local run artifacts committed
- no automatic release promotion; the result remains reviewer evidence
- repository-wide Ruff currently has pre-existing unrelated failures, so this PR gates Ruff on changed files