### PR TITLE
test(canary): eliminate nested scheduler smoke execution

### DIFF
--- a/examples/canary/catalog-planner-smoke.py
+++ b/examples/canary/catalog-planner-smoke.py
@@ -49,6 +49,7 @@ def assert_profiles_come_from_catalog_matrix() -> None:
         "control-plane-refactor",
         "repo-architecture-budget",
         "control-plane-state-machine",
+        "scheduler-ack-route",
         "status-read-path",
         "status-projection-cache",
         "review-packet-read-path",
@@ -104,6 +105,19 @@ def assert_plan_selects_minimal_profiles_from_changed_surfaces() -> None:
     ], payload
     assert payload["suggested_checks"][0]["source"] == "domain_profile", payload
     assert payload["executes_checks"] is False, payload
+
+
+def assert_scheduler_ack_route_profile_keeps_independent_checks() -> None:
+    payload = build_catalog_canary_plan(
+        changed_files=["loopx/control_plane/scheduler/ack.py"],
+        surfaces=["scheduler ACK route binding"],
+    )
+    domain_profiles = {profile["id"]: profile for profile in payload["domain_profiles"]}
+    profile = domain_profiles["scheduler-ack-route"]
+    assert [check["command"] for check in profile["checks"]] == [
+        "python3 examples/control_plane/quota-scheduler-state-ack-smoke.py",
+        "python3 examples/control_plane/quota-scheduler-registry-route-smoke.py",
+    ], profile
 
 
 def assert_catalog_documents_selection_rules() -> None:
@@ -1063,6 +1077,7 @@ def main() -> int:
     assert_profiles_come_from_catalog_matrix()
     assert_catalog_documents_selection_rules()
     assert_plan_selects_minimal_profiles_from_changed_surfaces()
+    assert_scheduler_ack_route_profile_keeps_independent_checks()
     assert_pr_release_and_refactor_profiles_select()
     assert_explicit_profile_can_include_deep_checks()
     assert_terminal_bench_adapter_changes_select_readiness_smoke()

--- a/examples/control_plane/quota-scheduler-state-ack-smoke.py
+++ b/examples/control_plane/quota-scheduler-state-ack-smoke.py
@@ -9,7 +9,6 @@ import importlib.util
 import json
 import os
 from pathlib import Path
-import subprocess
 import sys
 import tempfile
 
@@ -1551,11 +1550,6 @@ def main() -> int:
     assert_cli_host_match_ack_after_ambiguous_update()
     assert_cli_ignores_corrupt_scheduler_state()
     assert_cli_scheduler_ack_uses_should_run_lookback()
-    subprocess.run(
-        [sys.executable, str(REPO_ROOT / "examples/control_plane/quota-scheduler-registry-route-smoke.py")],
-        cwd=REPO_ROOT,
-        check=True,
-    )
     print("quota-scheduler-state-ack-smoke ok")
     return 0
 

--- a/loopx/canary/qualification_profiles.py
+++ b/loopx/canary/qualification_profiles.py
@@ -99,6 +99,44 @@ CONTROL_PLANE_QUALIFICATION_PROFILES: tuple[dict[str, Any], ...] = (
         ],
     },
     {
+        "id": "scheduler-ack-route",
+        "title": "Scheduler ACK state and route binding",
+        "quality_risk": "high",
+        "purpose": (
+            "Qualify scheduler ACK state progression and originating registry/runtime "
+            "routing as independent contracts without nested smoke execution."
+        ),
+        "catalog_families": [
+            "Work Routing",
+            "State And Boundary",
+        ],
+        "trigger_hints": (
+            "scheduler-ack",
+            "scheduler ack",
+            "scheduler_hint",
+            "ack_cli_args",
+            "route_binding",
+            "loopx/control_plane/scheduler/ack.py",
+            "loopx/control_plane/scheduler/scheduler_hint.py",
+            "loopx/control_plane/scheduler/state.py",
+            "loopx/cli_commands/quota",
+            "quota-scheduler-state-ack-smoke.py",
+            "quota-scheduler-registry-route-smoke.py",
+        ),
+        "checks": [
+            {
+                "command": "python3 examples/control_plane/quota-scheduler-state-ack-smoke.py",
+                "tier": "default",
+                "reason": "guards scheduler_hint stateful ACK progression and no-spend cadence transitions",
+            },
+            {
+                "command": "python3 examples/control_plane/quota-scheduler-registry-route-smoke.py",
+                "tier": "default",
+                "reason": "guards ACK writes on the registry/runtime route that emitted the hint",
+            },
+        ],
+    },
+    {
         "id": "agent-facing-cli-output-budget",
         "title": "Agent-facing CLI output qualification",
         "quality_risk": "high",

--- a/loopx/canary/quality_surface_catalog.py
+++ b/loopx/canary/quality_surface_catalog.py
@@ -88,6 +88,47 @@ QUALITY_SURFACE_CATALOG: tuple[dict[str, Any], ...] = (
         },
     },
     {
+        "surface_id": "scheduler-ack-route",
+        "title": "Scheduler ACK state and route binding",
+        "risk": "high",
+        "canary_profile_id": "scheduler-ack-route",
+        "owner_paths": [
+            "loopx/control_plane/quota/live_decision.py",
+            "loopx/control_plane/scheduler/ack.py",
+            "loopx/control_plane/scheduler/state.py",
+        ],
+        "semantic_oracle": {
+            "source_kind": "specification",
+            "refs": ["docs/status-data-contract.md"],
+            "independence_rationale": (
+                "The status contract requires ACK arguments to retain the registry and "
+                "effective runtime-root route that emitted the scheduler hint, independently "
+                "of the binding and persistence implementations."
+            ),
+        },
+        "layers": {
+            "unit_contract": _covered(
+                "tests/test_loopx_turn_driver.py",
+                "tests/control_plane/test_scheduler_ack_decision_table.py",
+                "tests/control_plane/test_scheduler_backoff_convergence.py",
+            ),
+            "durable_smoke": _covered(
+                "examples/control_plane/quota-scheduler-state-ack-smoke.py",
+                "examples/control_plane/quota-scheduler-registry-route-smoke.py",
+            ),
+            "catalog_canary": _covered("scheduler-ack-route"),
+            "host_upgrade": _not_applicable(
+                "The host executes bound CLI arguments but does not choose or rewrite their registry route."
+            ),
+            "model_behavior": _not_applicable(
+                "Route binding and ACK state progression are deterministic safety invariants."
+            ),
+            "release_gate": _covered(
+                "loopx canary premerge --profile scheduler-ack-route"
+            ),
+        },
+    },
+    {
         "surface_id": "agent-facing-cli-output",
         "title": "Agent-facing guided projection and output budgets",
         "risk": "high",


### PR DESCRIPTION
## Summary

- Remove the direct subprocess execution of quota-scheduler-registry-route-smoke.py from quota-scheduler-state-ack-smoke.py; full-public now executes each tracked contract once.
- Add a focused scheduler-ack-route qualification profile so state progression and registry/runtime route binding remain independently selectable.
- Classify the new high-risk surface across the quality catalog. Model behavior and host-upgrade layers are explicitly not applicable because route binding is a deterministic CLI safety invariant.

## Why the slow integrated canary is unchanged

The exact-base full-public receipt reports control-plane-integrated-canary-smoke.py at 93.299s. Focused phase characterization showed its cost comes from repeated real CLI state transitions (quota should-run, ACK, spend, monitor, review-packet), not nested smoke execution. It remains a deep end-to-end contract; this PR does not trade that coverage for speed.

## Evidence

- Exact base full-public run: https://github.com/huangruiteng/loopx/actions/runs/29561840183
  - 599/599 passed, 0 failures, 0 timeouts
  - smoke-health ready
  - base nested-execution candidates: 1
- Candidate smoke-health against those complete receipts:
  - ready
  - 599 observations, 0 failures, 0 timeouts
  - nested-execution candidates: 0
- Same-host focused timing:
  - base state-ack wrapper: 29.88s
  - candidate state-ack wrapper: 25.85s
  - saved 4.03s (13.5%) while registry-route remains independently executable
- Focused profile execution:
  - state-ack: passed in 24.87s
  - registry-route: passed in 2.096s
- loopx canary premerge --from-git-diff --tier standard --timeout-seconds 120
  - 18/18 selected checks passed
  - 0 warnings, 0 manual holds
  - public boundary scan clean
  - self-merge allowed
- tests/canary/test_quality_surface_catalog.py + tests/canary/test_smoke_fleet_health.py: 9 passed
- catalog planner, smoke-fleet health, quality-surface catalog, standalone registry-route: passed
- Ruff and changed-file compile: passed

The first premerge run correctly rejected the unclassified high-risk profile. The quality-surface classification was added and the complete gate was rerun successfully.

## Scope and exclusions

Only public canary/profile code and durable validation changed. Downloaded receipts, profiling output, local paths, credentials, and runtime state are excluded.