### PR TITLE
test(quality): qualify peer-agent model routing

### DIFF
--- a/docs/development/testing-and-quality.md
+++ b/docs/development/testing-and-quality.md
@@ -270,18 +270,19 @@ for the actor and promotion contract.
 与 mismatch code。普通贡献者当前不需要一个公开的 live-provider CLI。
 
 The regular live suite is
-`actual_default_model_behavior_portfolio_v0`: seven one-arm scenarios, two
-attempts each, and at most 14 provider calls. It checks normal onboarding,
-agent identity and goal selection, selected todo, final human gate, healthy
-continuation, and projection repair. Each scenario has an independent semantic
-oracle; every repeat must pass, hard actor errors are not retried, and pair mode
-is reserved for temporary sensitive differentials or explicit outcome claims.
+`actual_default_model_behavior_portfolio_v0`: nine one-arm scenarios, two
+attempts each, and at most 18 provider calls. It checks normal onboarding,
+agent identity and goal selection, selected todo, peer identity routing,
+same-agent continuation, final human gate, healthy continuation, and projection
+repair. Each scenario has an independent semantic oracle; every repeat must
+pass, hard actor errors are not retried, and pair mode is reserved for temporary
+sensitive differentials or explicit outcome claims.
 
-常规 live suite 是 `actual_default_model_behavior_portfolio_v0`：7 个 one-arm
-场景，每个重复 2 次，最多 14 次模型调用。它覆盖正常接入、agent 身份与 goal 选择、
-selected todo、最终 human gate、健康继续和 projection repair。每个场景都有独立语义
-oracle，所有重复都必须通过；actor 硬错误不自动重试，pair 只用于临时敏感差分或明确的
-结果提升声明。
+常规 live suite 是 `actual_default_model_behavior_portfolio_v0`：9 个 one-arm
+场景，每个重复 2 次，最多 18 次模型调用。它覆盖正常接入、agent 身份与 goal 选择、
+selected todo、peer 身份路由、same-agent 续接、最终 human gate、健康继续和 projection
+repair。每个场景都有独立语义 oracle，所有重复都必须通过；actor 硬错误不自动重试，
+pair 只用于临时敏感差分或明确的结果提升声明。
 
 For onboarding packets, the suite uses the shipped guided packet builder and
 redacts only local absolute path surfaces before provider transport. The
@@ -329,7 +330,7 @@ results from an earlier commit cannot qualify a later tag.
 | `full_public` | Fleet receipt is ready with no failure or timeout / 全量集群 ready 且无失败或超时 |
 | `install_upgrade_host` | Install, upgrade, and host routes all passed / 安装、升级与 host 路径均通过 |
 | `public_boundary` | Zero public/private violations / 零公开私有边界违规 |
-| `doubao_actual_default` | The 7-scenario, 2-repeat actual-default one-arm portfolio passed all 14 calls / 7 场景、2 次重复的实际默认 one-arm 共 14 次调用全部通过 |
+| `doubao_actual_default` | The 9-scenario, 2-repeat actual-default one-arm portfolio passed all 18 calls / 9 场景、2 次重复的实际默认 one-arm 共 18 次调用全部通过 |
 
 Alongside repeated source identity and status, each receipt keeps only its
 result schema, result digest, completion time, and bounded counters. Result

--- a/docs/reference/protocols/model-behavior-qualification-v0.md
+++ b/docs/reference/protocols/model-behavior-qualification-v0.md
@@ -229,21 +229,23 @@ stochastic output.
 `actual_default_model_behavior_portfolio_v0` is the regular low-frequency live
 suite. It composes the existing TurnEnvelope and onboarding one-arm actors; it
 does not introduce a third model protocol or retain a retired product arm. Its
-fixed catalog covers seven high-risk decisions:
+fixed catalog covers nine high-risk decisions:
 
 1. the normal guided onboarding packet selects `connect_if_needed`;
 2. an unresolved agent identity selects `select_agent_identity`;
 3. multiple goals select `select_goal` before any mutation;
 4. the current TurnEnvelope preserves the exact selected todo;
-5. a final human gate selects `ask_user` and forbids normal delivery;
-6. a healthy onboarding postcondition selects `continue_validation`;
-7. a missing executable todo with an actionable projection selects
+5. the selected peer identity matches the todo claim in the model-facing route;
+6. `same_agent_non_delivery` keeps the successor with the completing peer;
+7. a final human gate selects `ask_user` and forbids normal delivery;
+8. a healthy onboarding postcondition selects `continue_validation`;
+9. a missing executable todo with an actionable projection selects
    `repair_projection`.
 
 Every scenario declares its own semantic oracle and runs exactly twice. All
 attempts must align. Actor or transport errors are not retried automatically;
 the portfolio fails closed and stops further calls. The maximum regular run is
-therefore 14 provider calls. Pair mode remains available only for temporary
+therefore 18 provider calls. Pair mode remains available only for temporary
 sensitive differentials or explicit stable-versus-candidate outcome claims,
 not as a permanent regular-behavior baseline.
 

--- a/examples/release/exact-release-commit-qualification-smoke.py
+++ b/examples/release/exact-release-commit-qualification-smoke.py
@@ -59,9 +59,9 @@ def summary(qualification_id: str) -> dict[str, object]:
         "doubao_actual_default": {
             "model_id": "doubao-seed-1.6",
             "topology": "actual_default_one_arm",
-            "scenario_count": 7,
+            "scenario_count": 9,
             "repeats_per_scenario": 2,
-            "actor_call_count": 14,
+            "actor_call_count": 18,
             "failure_count": 0,
             "skip_count": 0,
             "qualification_passed": True,

--- a/loopx/canary/quality_surface_catalog.py
+++ b/loopx/canary/quality_surface_catalog.py
@@ -350,12 +350,10 @@ QUALITY_SURFACE_CATALOG: tuple[dict[str, Any], ...] = (
             "host_upgrade": _covered(
                 "examples/project/configure-goal-global-sync-smoke.py"
             ),
-            "model_behavior": _deferred(
-                owner="codex-quality-qualification",
-                rationale=(
-                    "The actual-default one-arm portfolio does not yet exercise peer identity "
-                    "selection and same-agent continuation as a model interpretation scenario."
-                ),
+            "model_behavior": _covered(
+                "actual_default_model_behavior_portfolio_v0",
+                "turn_peer_agent_identity",
+                "turn_same_agent_continuation",
             ),
             "release_gate": _covered("loopx canary premerge --profile peer-agent-runtime"),
         },

--- a/loopx/control_plane/quota/turn_envelope.py
+++ b/loopx/control_plane/quota/turn_envelope.py
@@ -247,6 +247,7 @@ def _selected_todo(
         "task_class",
         "action_kind",
         "task_repository",
+        "continuation_policy",
         "claimed_by",
         "blocks_agent",
         "unblocks_todo_id",
@@ -569,6 +570,10 @@ def _contract_capsule(
 
 
 def _action_projection(payload: Mapping[str, Any]) -> dict[str, Any]:
+    agent_identity = _mapping(payload.get("agent_identity"))
+    agent_id = str(
+        payload.get("agent_id") or agent_identity.get("agent_id") or ""
+    ).strip() or None
     interaction = _mapping(payload.get("interaction_contract"))
     agent_channel = _mapping(interaction.get("agent_channel"))
     cli_channel = _mapping(interaction.get("cli_channel"))
@@ -587,6 +592,7 @@ def _action_projection(payload: Mapping[str, Any]) -> dict[str, Any]:
     user = _user_channel(interaction, payload)
     scheduler = _scheduler(payload)
     return {
+        "agent_id": agent_id,
         "decision": payload.get("decision"),
         "should_run": bool(payload.get("should_run")),
         "effective_action": payload.get("effective_action"),
@@ -618,6 +624,7 @@ def _action_projection(payload: Mapping[str, Any]) -> dict[str, Any]:
 
 def turn_envelope_action_signature_document(envelope: Mapping[str, Any]) -> dict[str, Any]:
     fields = (
+        "agent_id",
         "decision",
         "should_run",
         "effective_action",

--- a/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
+++ b/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
@@ -14,6 +14,7 @@ from .model_behavior_qualification import (
     ModelBehaviorActor,
     _actor_failure_code,
     build_model_behavior_actor_request,
+    model_behavior_semantic_contract_from_packet,
     run_model_behavior_qualification_arm,
 )
 from .onboarding_model_behavior_qualification import (
@@ -70,6 +71,18 @@ _SCENARIOS = (
         "execute",
     ),
     _ScenarioSpec(
+        "turn_peer_agent_identity",
+        "turn",
+        None,
+        "execute",
+    ),
+    _ScenarioSpec(
+        "turn_same_agent_continuation",
+        "turn",
+        None,
+        "execute",
+    ),
+    _ScenarioSpec(
         "turn_human_gate",
         "turn",
         None,
@@ -88,6 +101,7 @@ _SCENARIOS = (
         "repair_projection",
     ),
 )
+ACTUAL_DEFAULT_MODEL_BEHAVIOR_SCENARIO_COUNT = len(_SCENARIOS)
 
 
 def _canonical_json(value: Any) -> str:
@@ -204,6 +218,25 @@ def _scenario_contract(
         "selected_todo_id"
     ):
         raise ValueError("selected-todo scenario requires selected work")
+    if spec.scenario_id in {
+        "turn_peer_agent_identity",
+        "turn_same_agent_continuation",
+    }:
+        peer_route = model_behavior_semantic_contract_from_packet(
+            packet,
+            arm="candidate_packet",
+        )["peer_route"]
+        if not peer_route.get("agent_id"):
+            raise ValueError("peer-agent scenario requires a selected agent identity")
+        if peer_route.get("selected_todo_claimed_by") != peer_route.get("agent_id"):
+            raise ValueError("peer-agent scenario must route work to the selected peer")
+        if spec.scenario_id == "turn_same_agent_continuation":
+            if peer_route.get("continuation_policy") != "same_agent_non_delivery":
+                raise ValueError(
+                    "same-agent scenario requires same_agent_non_delivery"
+                )
+            if peer_route.get("same_agent_continuation") is not True:
+                raise ValueError("same-agent scenario must preserve the completing peer")
     if spec.scenario_id == "turn_human_gate":
         required = {
             "selected_todo_id": None,
@@ -369,9 +402,10 @@ def run_actual_default_model_behavior_portfolio(
         "qualification_id": qualification_id,
         "topology": "actual_default_one_arm",
         "scenario_catalog_digest": _digest(catalog),
-        "scenario_count": len(_SCENARIOS),
+        "scenario_count": ACTUAL_DEFAULT_MODEL_BEHAVIOR_SCENARIO_COUNT,
         "actor_call_budget": (
-            len(_SCENARIOS) * ACTUAL_DEFAULT_MODEL_BEHAVIOR_REPEAT_ATTEMPTS
+            ACTUAL_DEFAULT_MODEL_BEHAVIOR_SCENARIO_COUNT
+            * ACTUAL_DEFAULT_MODEL_BEHAVIOR_REPEAT_ATTEMPTS
         ),
         "actor_call_count": actor_call_count,
         "qualification_passed": passed,

--- a/loopx/control_plane/testing/doubao_model_behavior_actor.py
+++ b/loopx/control_plane/testing/doubao_model_behavior_actor.py
@@ -146,7 +146,7 @@ def _provider_input(request: Mapping[str, Any]) -> dict[str, Any]:
 
 def _semantic_contract_instruction() -> str:
     return """
-When semantic_contract_required=true, include all eight semantic_contract
+When semantic_contract_required=true, include all nine semantic_contract
 fields and normalize them as follows. Never copy schema placeholders.
 - concrete_user_question: first user.actions value, else null.
 - required_reads: candidate packet.required_reads; for a full packet use
@@ -181,6 +181,12 @@ fields and normalize them as follows. Never copy schema placeholders.
   state_action_projection_warning, next_action_projection_warning,
   stale_latest_run_warning, and decision_freshness_warning. Use [] when absent;
   guards are not warnings.
+- peer_route: always include exactly agent_id, selected_todo_claimed_by,
+  continuation_policy, and same_agent_continuation. Read agent_id from the
+  action signature. Read the other values from action.selected_todo, using
+  null when absent. same_agent_continuation is true only when agent_id and
+  selected_todo_claimed_by are equal and continuation_policy is exactly
+  same_agent_non_delivery.
 """
 
 
@@ -204,6 +210,7 @@ these fields and no others:
     "concrete_user_question": null,
     "required_reads": [],
     "gate_or_stop": {},
+    "peer_route": {},
     "write_scope": [],
     "spend_rule": {},
     "scheduler_action": {},

--- a/loopx/control_plane/testing/model_behavior_qualification.py
+++ b/loopx/control_plane/testing/model_behavior_qualification.py
@@ -79,6 +79,7 @@ MODEL_BEHAVIOR_SEMANTIC_CONTRACT_FIELDS = (
     "concrete_user_question",
     "required_reads",
     "gate_or_stop",
+    "peer_route",
     "write_scope",
     "spend_rule",
     "scheduler_action",
@@ -323,6 +324,13 @@ def model_behavior_semantic_contract_from_packet(
     boundary = dict(signature.get("boundary") or {})
     capsule = dict(signature.get("contract_capsule") or {})
     interaction = dict(capsule.get("interaction_contract") or {})
+    action = dict(signature.get("action") or {})
+    selected_todo = dict(action.get("selected_todo") or {})
+    agent_id = str(signature.get("agent_id") or "").strip() or None
+    claimed_by = str(selected_todo.get("claimed_by") or "").strip() or None
+    continuation_policy = (
+        str(selected_todo.get("continuation_policy") or "").strip() or None
+    )
     return {
         "concrete_user_question": user_actions[0] if user_actions else None,
         "required_reads": list(signature.get("required_reads") or []),
@@ -335,6 +343,16 @@ def model_behavior_semantic_contract_from_packet(
             "user_action_required": bool(user.get("action_required")),
             "guards": list(boundary.get("guards") or []),
             "stop_condition": boundary.get("stop_condition"),
+        },
+        "peer_route": {
+            "agent_id": agent_id,
+            "selected_todo_claimed_by": claimed_by,
+            "continuation_policy": continuation_policy,
+            "same_agent_continuation": bool(
+                agent_id
+                and claimed_by == agent_id
+                and continuation_policy == "same_agent_non_delivery"
+            ),
         },
         "write_scope": list(boundary.get("write_scope") or []),
         "spend_rule": dict(signature.get("writeback") or {}),

--- a/loopx/control_plane/testing/release_commit_qualification.py
+++ b/loopx/control_plane/testing/release_commit_qualification.py
@@ -8,6 +8,10 @@ from pathlib import Path
 from typing import Any, Callable, Mapping
 
 from ..runtime.public_safety import public_safe_compact_text
+from .actual_default_model_behavior_portfolio import (
+    ACTUAL_DEFAULT_MODEL_BEHAVIOR_REPEAT_ATTEMPTS,
+    ACTUAL_DEFAULT_MODEL_BEHAVIOR_SCENARIO_COUNT,
+)
 
 
 EXACT_RELEASE_COMMIT_MANIFEST_SCHEMA_VERSION = (
@@ -306,8 +310,8 @@ def _validate_doubao(value: Any) -> tuple[dict[str, Any], list[str]]:
     )
     valid = bool(
         topology == "actual_default_one_arm"
-        and scenario_count == 7
-        and repeats == 2
+        and scenario_count == ACTUAL_DEFAULT_MODEL_BEHAVIOR_SCENARIO_COUNT
+        and repeats == ACTUAL_DEFAULT_MODEL_BEHAVIOR_REPEAT_ATTEMPTS
         and calls == scenario_count * repeats
         and failures == 0
         and skips == 0

--- a/tests/canary/test_quality_surface_catalog.py
+++ b/tests/canary/test_quality_surface_catalog.py
@@ -20,10 +20,7 @@ def test_current_high_risk_surfaces_have_no_catalog_drift() -> None:
     assert audit["drift_count"] == 0
     assert audit["repository_reference_validation"] == "performed"
     assert audit["classified_surface_count"] == audit["high_risk_profile_count"]
-    assert {gap["surface_id"] for gap in audit["gaps"]} == {
-        "peer-agent-runtime"
-    }
-    assert audit["gaps"][0]["layer"] == "model_behavior"
+    assert audit["gaps"] == []
 
 
 def test_packaged_audit_keeps_classification_without_source_checkout() -> None:

--- a/tests/control_plane/test_actual_default_model_behavior_portfolio.py
+++ b/tests/control_plane/test_actual_default_model_behavior_portfolio.py
@@ -121,7 +121,23 @@ def _entry_packets(tmp_path: Path) -> dict[str, dict[str, Any]]:
     }
 
 
-def _turn_source(*, human_gate: bool) -> dict[str, Any]:
+def _turn_source(
+    *,
+    human_gate: bool,
+    agent_id: str = AGENT_ID,
+    continuation_policy: str | None = None,
+) -> dict[str, Any]:
+    selected_todo = None
+    if not human_gate:
+        selected_todo = {
+            "todo_id": "todo_portfolio001",
+            "status": "open",
+            "task_class": "advancement_task",
+            "claimed_by": agent_id,
+            "text": "Implement one bounded public-safe slice.",
+        }
+        if continuation_policy:
+            selected_todo["continuation_policy"] = continuation_policy
     return {
         "ok": True,
         "mode": "should-run",
@@ -137,18 +153,8 @@ def _turn_source(*, human_gate: bool) -> dict[str, Any]:
             if human_gate
             else "Implement one bounded public-safe slice."
         ),
-        "selected_todo": (
-            None
-            if human_gate
-            else {
-                "todo_id": "todo_portfolio001",
-                "status": "open",
-                "task_class": "advancement_task",
-                "claimed_by": AGENT_ID,
-                "text": "Implement one bounded public-safe slice.",
-            }
-        ),
-        "agent_identity": {"agent_id": AGENT_ID},
+        "selected_todo": selected_todo,
+        "agent_identity": {"agent_id": agent_id},
         "interaction_contract": {
             "schema_version": "loopx_interaction_contract_v0",
             "mode": "user_gate" if human_gate else "bounded_delivery",
@@ -192,6 +198,18 @@ def _scenario_packets(tmp_path: Path) -> dict[str, dict[str, Any]]:
     packets.update(
         {
             "turn_selected_todo": build_turn_envelope(_turn_source(human_gate=False)),
+            "turn_peer_agent_identity": build_turn_envelope(
+                _turn_source(
+                    human_gate=False,
+                    agent_id="codex-portfolio-reviewer",
+                )
+            ),
+            "turn_same_agent_continuation": build_turn_envelope(
+                _turn_source(
+                    human_gate=False,
+                    continuation_policy="same_agent_non_delivery",
+                )
+            ),
             "turn_human_gate": build_turn_envelope(_turn_source(human_gate=True)),
             "onboarding_healthy_continue": build_onboarding_postcondition_observation(
                 check_warning_codes=[],
@@ -286,9 +304,9 @@ def test_portfolio_runs_actual_default_one_arm_scenarios_twice(tmp_path: Path) -
         == ACTUAL_DEFAULT_MODEL_BEHAVIOR_PORTFOLIO_SCHEMA_VERSION
     )
     assert result["topology"] == "actual_default_one_arm"
-    assert result["scenario_count"] == 7
-    assert result["actor_call_budget"] == 14
-    assert result["actor_call_count"] == 14
+    assert result["scenario_count"] == 9
+    assert result["actor_call_budget"] == 18
+    assert result["actor_call_count"] == 18
     assert result["qualification_passed"] is True
     assert result["automatic_release_promotion_allowed"] is False
     assert all(item["status"] == "passed" for item in result["scenarios"])
@@ -331,7 +349,7 @@ def test_catalog_declares_independent_bounded_repeat_policy() -> None:
     catalog = actual_default_model_behavior_scenario_catalog()
 
     assert catalog["topology"] == "actual_default_one_arm"
-    assert len(catalog["scenarios"]) == 7
+    assert len(catalog["scenarios"]) == 9
     assert all(
         scenario["repeat_policy"]
         == {
@@ -373,3 +391,41 @@ def test_portfolio_preflights_every_scenario_before_actor_spend(tmp_path: Path) 
         )
 
     assert calls == 0
+
+
+def test_portfolio_oracle_catches_wrong_same_agent_route(tmp_path: Path) -> None:
+    def wrong_actor(request: Mapping[str, Any]) -> dict[str, Any]:
+        result = _turn_actor(request)
+        selected_todo = request["packet"]["action"].get("selected_todo") or {}
+        if selected_todo.get("continuation_policy") == "same_agent_non_delivery":
+            semantics = dict(result["decision"]["semantic_contract"])
+            semantics["peer_route"] = {
+                **semantics["peer_route"],
+                "agent_id": "codex-wrong-peer",
+                "same_agent_continuation": False,
+            }
+            result["decision"] = {
+                **result["decision"],
+                "semantic_contract": semantics,
+            }
+        return result
+
+    result = run_actual_default_model_behavior_portfolio(
+        _scenario_packets(tmp_path),
+        qualification_id="actual-default-portfolio-wrong-peer",
+        turn_actor=wrong_actor,
+        onboarding_actor=_onboarding_actor,
+    )
+
+    scenario = next(
+        item
+        for item in result["scenarios"]
+        if item["scenario_id"] == "turn_same_agent_continuation"
+    )
+    assert result["qualification_passed"] is False
+    assert scenario["status"] == "failed"
+    assert scenario["repeats_completed"] == 2
+    assert scenario["failure_codes"] == [
+        "semantic_contract_incomplete",
+        "semantic_contract_mismatch:peer_route",
+    ]

--- a/tests/control_plane/test_doubao_model_behavior_actor.py
+++ b/tests/control_plane/test_doubao_model_behavior_actor.py
@@ -12,6 +12,7 @@ from loopx.control_plane.testing.doubao_model_behavior_actor import (
     MODEL_BEHAVIOR_PROVIDER_INPUT_SCHEMA_VERSION,
     DoubaoActorTransportError,
     DoubaoModelBehaviorActor,
+    _decision_instruction,
     _provider_input,
 )
 from loopx.control_plane.testing.model_behavior_qualification import (
@@ -70,6 +71,16 @@ def test_provider_input_does_not_select_a_diagnostic_todo() -> None:
         ]
         == "todo_diagnostic001"
     )
+
+
+def test_semantic_instruction_requires_exact_peer_route() -> None:
+    instruction = " ".join(
+        _decision_instruction(semantic_contract_required=True).split()
+    )
+
+    assert "peer_route: always include exactly agent_id" in instruction
+    assert "selected_todo_claimed_by" in instruction
+    assert "same_agent_non_delivery" in instruction
 
 
 def test_direct_actor_uses_canonical_endpoint_without_tools_or_raw_retention() -> None:

--- a/tests/control_plane/test_model_behavior_corpus.py
+++ b/tests/control_plane/test_model_behavior_corpus.py
@@ -141,10 +141,11 @@ def test_corpus_covers_matrix_retained_counterfactual_and_ablation() -> None:
         "explicit_owner_review_required",
     ]
     assert result["coverage"]["graded_semantic_contract"] == [
-        "concrete_user_question",
-        "required_reads",
-        "gate_or_stop",
-        "write_scope",
+            "concrete_user_question",
+            "required_reads",
+            "gate_or_stop",
+            "peer_route",
+            "write_scope",
         "spend_rule",
         "scheduler_action",
         "vision_continuation",

--- a/tests/control_plane/test_model_behavior_qualification.py
+++ b/tests/control_plane/test_model_behavior_qualification.py
@@ -408,6 +408,29 @@ def test_required_semantic_contract_keeps_only_aligned_digests() -> None:
     assert "Implement one bounded" not in encoded
 
 
+def test_semantic_contract_preserves_peer_identity_and_continuation() -> None:
+    full = _full_packet()
+    full["selected_todo"]["continuation_policy"] = "same_agent_non_delivery"
+
+    full_semantics = model_behavior_semantic_contract_from_packet(
+        full,
+        arm="full_packet",
+    )
+    candidate_semantics = model_behavior_semantic_contract_from_packet(
+        build_turn_envelope(full),
+        arm="candidate_packet",
+    )
+
+    expected = {
+        "agent_id": "codex-fixture",
+        "selected_todo_claimed_by": "codex-fixture",
+        "continuation_policy": "same_agent_non_delivery",
+        "same_agent_continuation": True,
+    }
+    assert full_semantics["peer_route"] == expected
+    assert candidate_semantics["peer_route"] == expected
+
+
 def test_same_wrong_semantics_in_both_arms_fail_source_alignment() -> None:
     def wrong_actor(request: Mapping[str, Any]) -> dict[str, Any]:
         semantics = model_behavior_semantic_contract_from_packet(

--- a/tests/control_plane/test_release_commit_qualification.py
+++ b/tests/control_plane/test_release_commit_qualification.py
@@ -60,9 +60,9 @@ def _summary(qualification_id: str, *, commit: str = COMMIT) -> dict[str, object
         "doubao_actual_default": {
             "model_id": "doubao-seed-1.6",
             "topology": "actual_default_one_arm",
-            "scenario_count": 7,
+            "scenario_count": 9,
             "repeats_per_scenario": 2,
-            "actor_call_count": 14,
+            "actor_call_count": 18,
             "failure_count": 0,
             "skip_count": 0,
             "qualification_passed": True,

--- a/tests/test_turn_envelope.py
+++ b/tests/test_turn_envelope.py
@@ -66,6 +66,7 @@ def _full_decision() -> dict[str, object]:
             "status": "open",
             "task_class": "advancement_task",
             "action_kind": "fixture_action",
+            "continuation_policy": "same_agent_non_delivery",
             "claimed_by": "codex-fixture",
             "text": "Implement one bounded public-safe slice",
         },
@@ -241,7 +242,11 @@ def test_turn_envelope_preserves_action_boundary_and_writeback() -> None:
     assert envelope["view"] == "turn_envelope"
     assert envelope["goal_id"] == "fixture-goal"
     assert envelope["agent_id"] == "codex-fixture"
+    assert envelope["action_signature"]["matches"] is True
     assert envelope["action"]["selected_todo"]["todo_id"] == "todo_fixture0001"
+    assert envelope["action"]["selected_todo"]["continuation_policy"] == (
+        "same_agent_non_delivery"
+    )
     assert envelope["action"]["must_attempt"] is True
     assert envelope["user"] == {
         "action_required": False,
@@ -529,6 +534,22 @@ def test_action_signature_detects_semantic_drift() -> None:
 
     envelope = build_turn_envelope(source)
     envelope["execution_policy"]["safe_bypass_allowed"] = True
+
+    assert quota_action_signature_document(
+        source
+    ) != turn_envelope_action_signature_document(envelope)
+
+    envelope = build_turn_envelope(source)
+    envelope["agent_id"] = "codex-other-peer"
+
+    assert quota_action_signature_document(
+        source
+    ) != turn_envelope_action_signature_document(envelope)
+
+    envelope = build_turn_envelope(source)
+    envelope["action"]["selected_todo"]["continuation_policy"] = (
+        "independent_handoff"
+    )
 
     assert quota_action_signature_document(
         source


### PR DESCRIPTION
## Summary

- retain `agent_id` and selected-todo `continuation_policy` in the TurnEnvelope action signature
- add an exact `peer_route` semantic oracle for peer identity and `same_agent_non_delivery`
- extend the actual-default one-arm portfolio from 7 to 9 scenarios and the release receipt from 14 to 18 calls
- close the peer-agent runtime model-behavior catalog gap without adding another actor protocol or a permanent comparison arm

## Validation

- `66` focused pytest cases passed
- Ruff passed on every changed Python path
- exact release-commit qualification smoke passed
- quality-surface catalog smoke passed
- source-current `peer-agent-runtime` smoke profile passed `2/2`
- live Doubao actual-default one-arm qualification passed `18/18`; both new scenarios passed `2/2`, with zero retries, tools, or retained raw provider packets
- source-current premerge canary passed all `18/18` selected checks with zero failures, warnings, or manual holds
- an earlier 120-second promotion-readiness timeout was reclassified by a standalone 91.09-second pass and the final 180-second premerge pass
- public/private boundary scan passed; no credentials, local paths, or generated evidence are included

## Review focus

Please confirm that identity selection and same-agent continuation belong in the model-facing action signature, and that the exact `peer_route` oracle captures the intended control-plane semantics without widening the public packet beyond the shipped hot path. This is intentionally held for owner review because it changes the TurnEnvelope semantic contract and the regular live-model release gate.