### PR TITLE
test(canary): scope integrated fixture scans

### DIFF
--- a/examples/control_plane/control-plane-integrated-canary-smoke.py
+++ b/examples/control_plane/control-plane-integrated-canary-smoke.py
@@ -42,7 +42,8 @@ MARKDOWN_CONTINUATION_TITLE = "Continue same-agent markdown continuation through
 MONITOR_TODO_ID = "todo_integrated_due_monitor"
 MONITOR_TARGET_KEY = "integrated-due-monitor-watch"
 VALIDATED_PROGRESS_CLASSIFICATION = "integrated_canary_validated_progress"
-DEFAULT_MAX_SECONDS = 120.0
+DEFAULT_MAX_SECONDS = 60.0
+STATUS_BACKED_COMMANDS = {"quota", "review-packet", "status"}
 
 
 def write_fixture(root: Path) -> tuple[Path, Path, Path]:
@@ -209,8 +210,17 @@ def append_event_todos(event_log: Path) -> None:
 
 
 def run_cli(registry_path: Path, runtime_root: Path, *args: str) -> dict[str, Any]:
+    cli_args = list(args)
+    if (
+        cli_args
+        and cli_args[0] in STATUS_BACKED_COMMANDS
+        and "--scan-root" not in cli_args
+        and "--scan-path" not in cli_args
+    ):
+        # Keep public-boundary validation on the fixture project, not this source checkout.
+        cli_args.extend(["--scan-root", str(registry_path.parent.parent)])
     return run_json_cli(
-        *args,
+        *cli_args,
         registry_path=registry_path,
         runtime_root=runtime_root,
         cwd=REPO_ROOT,


### PR DESCRIPTION
## Summary
- scope status-backed CLI calls in the integrated canary to its temporary fixture project
- retain public-boundary scanning and every state re-projection point while avoiding repeated scans of the LoopX source checkout
- tighten the smoke budget from 120s to 60s after three stable ~13s end-to-end runs

## Validation
- integrated canary: 3/3 passed in 13.01s, 13.08s, and 13.34s
- focused transition parity: 6/6 passed
- `loopx canary premerge --from-git-diff --timeout-seconds 180`: 10/10 selected checks passed, no holds
- full-public sweep: 585/599 passed in the initial jobs=8/60s run; all 14 initial anomalies passed on isolated rerun, including the two installation smokes when serialized under low-disk conditions
- `python3 -m py_compile` and `git diff --check` passed
- public/private boundary scan passed

## Risk
Test-only fixture routing. No production CLI behavior, cache, state transition, or public-boundary rule changes.