### PR TITLE
fix(todos): reject invalid decision scopes

### DIFF
--- a/loopx/control_plane/todos/contract.py
+++ b/loopx/control_plane/todos/contract.py
@@ -515,7 +515,21 @@ def normalize_todo_decision_scope(value: Any) -> dict[str, str] | None:
     return payload
 
 
-def normalize_todo_required_decision_scopes(value: Any) -> list[dict[str, str]]:
+def require_todo_decision_scope(value: Any) -> dict[str, str]:
+    scope = normalize_todo_decision_scope(value)
+    if not scope:
+        raise ValueError(
+            "decision_scope must use kind:granularity:scope_key, such as "
+            "private_read:project:authority"
+        )
+    return scope
+
+
+def _normalize_todo_required_decision_scopes(
+    value: Any,
+    *,
+    strict: bool,
+) -> list[dict[str, str]]:
     if value is None:
         return []
     if isinstance(value, (list, tuple, set)):
@@ -527,6 +541,11 @@ def normalize_todo_required_decision_scopes(value: Any) -> list[dict[str, str]]:
     for raw in raw_values:
         scope = normalize_todo_decision_scope(raw)
         if not scope:
+            if strict:
+                raise ValueError(
+                    "required_decision_scopes must contain "
+                    "kind:granularity:scope_key tokens"
+                )
             continue
         identity = (scope["kind"], scope["granularity"], scope["scope_key"])
         if identity in seen:
@@ -536,15 +555,25 @@ def normalize_todo_required_decision_scopes(value: Any) -> list[dict[str, str]]:
     return scopes
 
 
+def normalize_todo_required_decision_scopes(value: Any) -> list[dict[str, str]]:
+    return _normalize_todo_required_decision_scopes(value, strict=False)
+
+
+def require_todo_required_decision_scopes(value: Any) -> list[dict[str, str]]:
+    return _normalize_todo_required_decision_scopes(value, strict=True)
+
+
 def decision_scope_metadata_value(value: Any) -> str | None:
-    scope = normalize_todo_decision_scope(value)
-    if not scope:
+    if value is None:
         return None
+    scope = require_todo_decision_scope(value)
     return f"{scope['kind']}:{scope['granularity']}:{scope['scope_key']}"
 
 
 def required_decision_scopes_metadata_value(value: Any) -> str | None:
-    scopes = normalize_todo_required_decision_scopes(value)
+    if value is None:
+        return None
+    scopes = require_todo_required_decision_scopes(value)
     if not scopes:
         return None
     return ",".join(
@@ -874,13 +903,9 @@ def format_todo_metadata_line(
             f"{encode_metadata_value(','.join(normalized_explore_result_node_refs))}"
         )
     normalized_decision_scope = decision_scope_metadata_value(decision_scope)
-    if decision_scope and not normalized_decision_scope:
-        raise ValueError("decision_scope must use kind:granularity:scope_key, such as private_read:project:authority")
     if normalized_decision_scope:
         fields.append(f"decision_scope={encode_metadata_value(normalized_decision_scope)}")
     normalized_required_decision_scopes = required_decision_scopes_metadata_value(required_decision_scopes)
-    if required_decision_scopes and not normalized_required_decision_scopes:
-        raise ValueError("required_decision_scopes must contain kind:granularity:scope_key tokens")
     if normalized_required_decision_scopes:
         fields.append(
             "required_decision_scopes="
@@ -1053,13 +1078,9 @@ def metadata_line_for_todo_block(
             else:
                 metadata.pop(key, None)
         elif key == "decision_scope":
-            normalized = normalize_todo_decision_scope(value)
-            if normalized:
-                metadata[key] = normalized
-            else:
-                metadata.pop(key, None)
+            metadata[key] = require_todo_decision_scope(value)
         elif key == "required_decision_scopes":
-            normalized = normalize_todo_required_decision_scopes(value)
+            normalized = require_todo_required_decision_scopes(value)
             if normalized:
                 metadata[key] = normalized
             else:

--- a/tests/control_plane/test_todo_decision_scope_cli_validation.py
+++ b/tests/control_plane/test_todo_decision_scope_cli_validation.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from loopx.control_plane.testing.canary_harness import (
+    run_json_cli,
+    run_json_cli_result,
+    write_fixture_registry,
+)
+
+
+GOAL_ID = "decision-scope-cli-validation"
+VALID_SCOPE = "direction:action:release_route"
+INVALID_SCOPE = "not-a-decision-scope"
+
+
+def _write_fixture(tmp_path: Path) -> tuple[Path, Path]:
+    project = tmp_path / "project"
+    runtime = tmp_path / "runtime"
+    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".loopx" / "registry.json"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(
+        "---\n"
+        "status: active\n"
+        "---\n\n"
+        "# Active Goal State\n\n"
+        "## Objective\n\n"
+        "Keep decision-scope writes valid.\n\n"
+        "## Next Action\n\n"
+        "- Validate the next todo write.\n",
+        encoding="utf-8",
+    )
+    write_fixture_registry(
+        project=project,
+        runtime_root=runtime,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        domain="decision-scope-cli-validation",
+        adapter_kind="generic_project_goal_v0",
+    )
+    return registry_path, state_file
+
+
+def _scope_args(flag: str, values: list[str]) -> list[str]:
+    return [part for value in values for part in (flag, value)]
+
+
+@pytest.mark.parametrize(
+    ("role", "task_class", "flag", "values", "error_fragment"),
+    [
+        (
+            "user",
+            "user_gate",
+            "--decision-scope",
+            [INVALID_SCOPE],
+            "decision_scope must use kind:granularity:scope_key",
+        ),
+        (
+            "agent",
+            "advancement_task",
+            "--required-decision-scope",
+            [VALID_SCOPE, INVALID_SCOPE],
+            "required_decision_scopes must contain kind:granularity:scope_key tokens",
+        ),
+    ],
+)
+def test_todo_add_rejects_invalid_decision_scope_tokens_without_writing(
+    tmp_path: Path,
+    role: str,
+    task_class: str,
+    flag: str,
+    values: list[str],
+    error_fragment: str,
+) -> None:
+    registry_path, state_file = _write_fixture(tmp_path)
+    original = state_file.read_text(encoding="utf-8")
+
+    returncode, payload = run_json_cli_result(
+        "todo",
+        "add",
+        "--goal-id",
+        GOAL_ID,
+        "--role",
+        role,
+        "--task-class",
+        task_class,
+        "--text",
+        f"Validate the {role} decision scope.",
+        *_scope_args(flag, values),
+        registry_path=registry_path,
+    )
+
+    assert returncode != 0, payload
+    assert error_fragment in payload["error"], payload
+    readback = run_json_cli(
+        "todo",
+        "list",
+        "--goal-id",
+        GOAL_ID,
+        registry_path=registry_path,
+    )
+    assert readback["todo_count"] == 0, readback
+    assert state_file.read_text(encoding="utf-8") == original
+
+
+def test_todo_update_rejects_invalid_decision_scope_tokens_without_data_loss(
+    tmp_path: Path,
+) -> None:
+    registry_path, state_file = _write_fixture(tmp_path)
+    gate = run_json_cli(
+        "todo",
+        "add",
+        "--goal-id",
+        GOAL_ID,
+        "--role",
+        "user",
+        "--task-class",
+        "user_gate",
+        "--text",
+        "Choose the release route.",
+        "--decision-scope",
+        VALID_SCOPE,
+        registry_path=registry_path,
+    )
+    agent = run_json_cli(
+        "todo",
+        "add",
+        "--goal-id",
+        GOAL_ID,
+        "--role",
+        "agent",
+        "--task-class",
+        "advancement_task",
+        "--text",
+        "Publish through the approved release route.",
+        "--required-decision-scope",
+        VALID_SCOPE,
+        registry_path=registry_path,
+    )
+    original = state_file.read_text(encoding="utf-8")
+
+    cases = [
+        (
+            gate["todo_id"],
+            ["--decision-scope", INVALID_SCOPE],
+            "decision_scope must use kind:granularity:scope_key",
+            "decision_scope",
+        ),
+        (
+            agent["todo_id"],
+            _scope_args(
+                "--required-decision-scope",
+                [VALID_SCOPE, INVALID_SCOPE],
+            ),
+            "required_decision_scopes must contain kind:granularity:scope_key tokens",
+            "required_decision_scopes",
+        ),
+    ]
+    for todo_id, invalid_args, error_fragment, field in cases:
+        returncode, payload = run_json_cli_result(
+            "todo",
+            "update",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            todo_id,
+            *invalid_args,
+            registry_path=registry_path,
+        )
+
+        assert returncode != 0, payload
+        assert error_fragment in payload["error"], payload
+        readback = run_json_cli(
+            "todo",
+            "list",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            todo_id,
+            registry_path=registry_path,
+        )
+        if field == "decision_scope":
+            assert readback["todo"][field]["scope_key"] == "release_route"
+        else:
+            assert [
+                scope["scope_key"] for scope in readback["todo"][field]
+            ] == ["release_route"]
+        assert state_file.read_text(encoding="utf-8") == original


### PR DESCRIPTION
## Summary
- reject invalid `decision_scope` values at the canonical todo metadata write boundary
- reject a `required_decision_scopes` batch when any token is invalid instead of silently keeping only the valid subset
- keep legacy/read normalization tolerant and preserve an explicit empty list as the internal clear operation
- add symmetric CLI add/update negative tests with `todo list` readback proving failed writes neither create todos nor erase valid scopes

## Validation
- red test before implementation: 2 failed, 1 passed
- focused decision-scope suite: 22 passed
- existing `todo-cli-smoke.py`: passed
- premerge gate: 17/17 selected canaries passed, no warnings or manual holds
- full pytest: 644 passed, 2 skipped
- Ruff and diff hygiene passed

## Review focus
- `require_*` helpers are used only by write serialization; tolerant normalizers remain unchanged for legacy state reads
- `required_decision_scopes=[]` still clears resolved scopes during user-gate completion
- invalid update input now fails before persistence and leaves the prior valid metadata intact

## Risk
This intentionally changes control-plane write behavior from partial acceptance/silent deletion to fail closed. It does not migrate or rewrite existing state.