### PR TITLE
Fix autonomous replan for interleaved monitor stalls

### DIFF
--- a/examples/control_plane/monitor-poll-writeback-smoke.py
+++ b/examples/control_plane/monitor-poll-writeback-smoke.py
@@ -67,9 +67,12 @@ def write_fixture(
     *,
     selected_target_key: str | None = TARGET_KEY,
     include_other_monitor: bool = False,
+    include_blocked_advancement: bool = False,
     include_user_gate: bool = False,
     include_advancement: bool = False,
     primary_monitor_priority: str = "P0",
+    primary_no_change_count: int = 1,
+    other_no_change_count: int = 1,
     monitor_required_capabilities: tuple[str, ...] = (),
 ) -> tuple[Path, Path]:
     project = root / "project"
@@ -100,10 +103,23 @@ def write_fixture(
         "cadence=15m "
         "next_due_at=2026-01-01T00:00:00+00:00 "
         "result_hash=old "
-        "consecutive_no_change=1 "
+        f"consecutive_no_change={other_no_change_count} "
         "material_change=false "
         "-->\n"
         if include_other_monitor
+        else ""
+    )
+    blocked_advancement = (
+        "- [ ] [P1] Run the next official and countable matched benchmark pair.\n"
+        "  <!-- loopx:todo "
+        "todo_id=todo_monitorpollbenchmark "
+        "status=blocked "
+        "task_class=advancement_task "
+        "action_kind=run_matched_benchmark "
+        "required_capabilities=benchmark_runner "
+        f"claimed_by={AGENT_ID} "
+        "-->\n"
+        if include_blocked_advancement
         else ""
     )
     gated_advancement = (
@@ -164,10 +180,11 @@ def write_fixture(
         "cadence=15m "
         "next_due_at=2026-01-01T00:00:00+00:00 "
         "result_hash=old "
-        "consecutive_no_change=1 "
+        f"consecutive_no_change={primary_no_change_count} "
         "material_change=false "
         "-->\n"
         f"{other_monitor}"
+        f"{blocked_advancement}"
         f"{gated_advancement}"
         f"{advancement}"
         f"{user_gate}",
@@ -353,6 +370,57 @@ def assert_unchanged_writeback() -> None:
         assert followup["interaction_contract"]["agent_channel"]["quiet_noop_allowed"] is False, followup
         assert followup["execution_obligation"]["kind"] == "autonomous_replan_required", followup
         assert followup["execution_obligation"]["must_attempt_work"] is True, followup
+
+
+def assert_interleaved_monitor_stalls_replan_blocked_benchmark() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-monitor-poll-real-state-replay-") as tmp:
+        registry_path, _ = write_fixture(
+            Path(tmp),
+            include_other_monitor=True,
+            include_blocked_advancement=True,
+            primary_no_change_count=28,
+            other_no_change_count=28,
+        )
+        quota = run_cli(
+            registry_path,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+        )
+        assert quota["decision"] == "autonomous_replan_required", quota
+        assert quota["effective_action"] == "autonomous_replan_required", quota
+        assert quota["goal_frontier_projection"]["replan_required"] is True, quota
+        obligation = quota["autonomous_replan_obligation"]
+        assert obligation["triggers"][0]["kind"] == "monitor_no_change_streak", obligation
+        assert obligation["triggers"][0]["run_count"] == 28, obligation
+        assert obligation["dead_monitor_detector"]["threshold"] == 2, obligation
+
+
+def assert_stalled_monitor_does_not_preempt_runnable_advancement() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-monitor-poll-runnable-advancement-") as tmp:
+        registry_path, _ = write_fixture(
+            Path(tmp),
+            include_advancement=True,
+            primary_no_change_count=28,
+        )
+        quota = run_cli(
+            registry_path,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--available-capability",
+            "network",
+        )
+        assert quota["decision"] == "run", quota
+        assert quota["effective_action"] == "normal_run", quota
+        assert quota["work_lane_contract"]["lane"] == "advancement_task", quota
+        assert quota.get("autonomous_replan_obligation") is None, quota
 
 
 def assert_material_transition_followup() -> None:
@@ -830,6 +898,8 @@ def main() -> int:
     assert_cli_monitor_poll_uses_should_run_lookback()
     assert_writeback_helper_preview_contract()
     assert_unchanged_writeback()
+    assert_interleaved_monitor_stalls_replan_blocked_benchmark()
+    assert_stalled_monitor_does_not_preempt_runnable_advancement()
     assert_material_transition_followup()
     assert_external_material_transition_receipt_correlation()
     assert_due_monitor_poll_allowed_with_open_user_gate()

--- a/loopx/control_plane/work_items/autonomous_replan_obligation.py
+++ b/loopx/control_plane/work_items/autonomous_replan_obligation.py
@@ -231,6 +231,62 @@ def autonomous_replan_obligation_from_state(
     return build_autonomous_replan_obligation(evidence, agent_todos=agent_todos)
 
 
+def _monitor_no_change_evidence(
+    agent_todos: dict[str, Any] | None,
+    *,
+    threshold: int,
+    schema_version: str,
+) -> dict[str, Any] | None:
+    if not isinstance(agent_todos, dict):
+        return None
+    raw_monitors = agent_todos.get("monitor_open_items")
+    monitors = [item for item in raw_monitors or [] if isinstance(item, dict)]
+    stalled: list[tuple[int, dict[str, Any]]] = []
+    for item in monitors:
+        try:
+            no_change_count = int(str(item.get("consecutive_no_change") or "0"))
+        except ValueError:
+            continue
+        if no_change_count >= threshold:
+            stalled.append((no_change_count, item))
+    if not stalled:
+        return None
+
+    stalled.sort(key=lambda pair: pair[0], reverse=True)
+    no_change_count, monitor = stalled[0]
+    agent_id = str(monitor.get("claimed_by") or "").strip() or None
+    raw_advancements = agent_todos.get("executable_backlog_items")
+    if not isinstance(raw_advancements, list):
+        raw_advancements = agent_todos.get("items")
+    for item in raw_advancements or []:
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("status") or "").strip().lower() != "open":
+            continue
+        if str(item.get("task_class") or "").strip() != "advancement_task":
+            continue
+        claimed_by = str(item.get("claimed_by") or "").strip() or None
+        if not claimed_by or claimed_by == agent_id:
+            return None
+
+    monitor_target_id = str(
+        monitor.get("target_key") or monitor.get("todo_id") or "monitor"
+    ).strip()
+    return {
+        "kind": "monitor_no_change_streak",
+        "schema_version": schema_version,
+        "section": "agent_todos",
+        "text": (
+            f"monitor {monitor_target_id} recorded {no_change_count} "
+            "consecutive unchanged polls without runnable advancement"
+        ),
+        "run_count": no_change_count,
+        "threshold": threshold,
+        "monitor_target_id": monitor_target_id,
+        "agent_id": agent_id,
+    }
+
+
 def build_autonomous_replan_obligation(
     evidence: list[dict[str, Any]],
     *,
@@ -242,10 +298,22 @@ def build_autonomous_replan_obligation(
     dead_monitor_repeat_schema_version: str,
 ) -> dict[str, Any] | None:
     if not evidence:
+        monitor_evidence = _monitor_no_change_evidence(
+            agent_todos,
+            threshold=autonomous_replan_stall_threshold,
+            schema_version=dead_monitor_repeat_schema_version,
+        )
+        if monitor_evidence:
+            evidence = [monitor_evidence]
+    if not evidence:
         return None
 
     dead_monitor_evidence = next(
-        (item for item in evidence if item.get("kind") == "dead_monitor_repeat"),
+        (
+            item
+            for item in evidence
+            if item.get("kind") in {"dead_monitor_repeat", "monitor_no_change_streak"}
+        ),
         None,
     )
     blocked_successor_evidence = next(
@@ -362,7 +430,7 @@ def build_autonomous_replan_obligation(
     result = build_autonomous_replan_obligation_payload(
         schema_version=autonomous_replan_schema_version,
         stall_threshold=(
-            dead_monitor_repeat_threshold
+            int(dead_monitor_evidence.get("threshold") or dead_monitor_repeat_threshold)
             if dead_monitor_evidence
             else autonomous_replan_stall_threshold
         ),


### PR DESCRIPTION
## Summary
- derive stalled-monitor replan evidence from the durable todo counter instead of requiring adjacent run-history records for one target
- preserve runnable advancement priority, so monitor debt does not preempt executable work
- add a public-safe compact replay for two interleaved monitors plus a blocked benchmark advancement

## Root cause
The run-history detector required repeated adjacent polls for the same monitor target. Multiple monitors could interleave indefinitely, while each todo accumulated consecutive_no_change, leaving unfinished blocked advancement projected as a quiet monitor-only lane.

## Validation
- python3 examples/control_plane/monitor-poll-writeback-smoke.py
- python3 examples/control_plane/heartbeat-quota-flow-smoke.py
- python3 examples/control_plane/monitor-scheduler-contract-smoke.py
- python3 examples/control_plane/control-plane-integrated-canary-smoke.py
- python3 examples/control_plane/work-lane-contract-smoke.py
- python3 examples/autonomous-replan-obligation-smoke.py
- python3 examples/control_plane/refresh-state-write-correctness-smoke.py
- loopx canary premerge --from-git-diff --tier standard
- loopx check on both changed files: 0 errors, 0 warnings
- git diff --check origin/main...HEAD

## Boundary
No benchmark jobs, runner behavior, scoring, task semantics, credentials, private state, raw evidence, or scheduler cadence are changed.