### PR TITLE
docs: connect course to control-plane authority model

### DIFF
--- a/docs/development/control-plane-course/02-state-substrate.md
+++ b/docs/development/control-plane-course/02-state-substrate.md
@@ -13,6 +13,7 @@
 3. 解释为什么 projection 不能成为写 API。
 4. 沿一次 todo transition 找到它的事实源和 read model。
 5. 判断一个新字段应该属于配置、事件、工作台还是展示层。
+6. 区分 session context、project memory、Domain State 和私有 runtime artifact。
 
 ## Goal 不是聊天线程
 
@@ -31,6 +32,34 @@ Dashboard: 只读观察和路由界面
 
 - 聊天压缩或 session 结束后，长期任务仍可恢复；
 - 多个 peer 可以共享事实，而不共享同一个巨大 transcript。
+
+## Session Context 不是 Project Memory
+
+“状态已经从 session memory 变成 project memory”不是说把聊天记录复制进仓库，
+也不是说 project memory 等于当前机器环境。三者拥有不同事实：
+
+| 表面 | 保存什么 | 可能发生什么 | 能否单独作为 authority |
+| --- | --- | --- | --- |
+| Session context | 当前对话、临时推理、尚未写回的观察 | 被压缩、截断、结束或换模型 | 不能 |
+| Project memory | goal identity、objective/boundary、todo/gate、紧凑 evidence、run lineage | 被 replay、投影或由另一 peer 恢复 | 可以，但必须经过 canonical contract |
+| Environment | 当前 checkout、host capability、外部服务与 fresh source | 在 handoff 之间变化 | 不能，必须重新探测 |
+
+因此恢复公式不是：
+
+```text
+new session = old transcript
+```
+
+而是：
+
+```text
+next decision = replay(project memory) + inspect(fresh environment)
+```
+
+Project memory 的充分性标准是：更换 session 后，新的 peer 仍能从 durable state
+重建同一 objective、authority boundary、open frontier、gate、next probe 和 stop
+condition。它不要求逐字复现旧推理。第 3 讲会把这个要求进一步写成 handoff 的
+不动点检查。
 
 ## 五类状态面
 
@@ -154,6 +183,66 @@ projection_synced
 - 是否有 contract errors、projection gaps 或 repair needs？
 
 Status 不是写入口。Dashboard、Lark kanban、review packet 都应该消费 status 或其他 public-safe projection，而不是反向解析私有源文件再写回。
+
+## Core State、Domain State 与 Runtime Artifact
+
+前面的五类状态面主要解释跨场景生命周期。领域扩展还需要一层紧凑事实，但不能
+因此把 Issue-Fix、Explore 或 ML Experiment 的字段塞进通用 todo/quota 状态机。
+
+| 层 | 代表内容 | 拥有什么 | 明确不拥有什么 |
+| --- | --- | --- | --- |
+| Core State | registry、todo、gate、quota、event、run、vision | 跨领域生命周期与权限边界 | 领域专属结果 schema |
+| Domain State | issue feasibility、PR lifecycle、experiment result、checkpoint | 某个 Capability Pack 的紧凑 read model | quota、gate、claim、permission |
+| Runtime Artifact | raw log、transcript、verifier tail、临时调试文件 | 私有诊断与可复现实验材料 | public control-plane truth |
+
+`loopx/domain_state.py::default_domain_state_file_path` 把领域事实限制在稳定的
+goal/pack 路径中：
+
+```python
+return (
+    Path(project).expanduser()
+    / ".loopx"
+    / "domain-state"
+    / compact_goal_id
+    / compact_pack
+    / compact_filename
+)
+```
+
+`upsert_domain_state_jsonl` 进一步要求稳定 key，并以 lock + temporary file +
+`os.replace` 完成原子 upsert。下面只省略遍历之外的分支，其余行保持源码一致：
+
+```python
+candidate = {**payload, "domain_state_key": key}
+# ...
+if isinstance(row, dict) and row_key == key:
+    if not updated:
+        merged_candidate = (
+            merge_existing_fn(row, candidate)
+            if merge_existing_fn is not None
+            else candidate
+        )
+        if unchanged_fn is not None and unchanged_fn(row, merged_candidate):
+            rows.append(row)
+            unchanged = True
+        else:
+            rows.append(merged_candidate)
+        updated = True
+
+# ...
+os.replace(tmp_name, path)
+```
+
+从这段代码应读出三个边界：
+
+1. Domain State 是 project-local、按 goal 与 pack 分区的事实，不是全局 memory dump。
+2. 稳定 key 和 unchanged 判定用于幂等观察，不代表领域 pack 可以决定下一轮执行。
+3. 返回值显式使用 `path_recorded=False`，public receipt 不应泄露本地路径。
+
+Issue-Fix 与 ML Experiment 的 smoke 分别验证这条通用 seam：
+`examples/issue-fix-feasibility-smoke.py`、
+`tests/test_ml_experiment_volc_packet.py`。如果一个新领域字段会改变 quota、gate、
+claim 或 permission，它很可能属于 Core State 规则，而不是 Domain State。
 
 ## Canonical 与 Projection 的判别法
 

--- a/docs/development/control-plane-course/03-work-graph-and-peers.md
+++ b/docs/development/control-plane-course/03-work-graph-and-peers.md
@@ -123,7 +123,7 @@ Claim 的作用是减少重复劳动，告诉其他 peer 当前谁在推进。
 
 Claim 可以过期、清除、被 completion/supersede 结束。Status 会投影 stale claim 提示。
 
-## Lease：有时间边界的执行占用
+## Lease：显式、可选的执行占用
 
 Task lease 比 claim 更适合需要排他执行或外部资源的工作：
 
@@ -134,7 +134,83 @@ lease: 谁在一段 TTL 内占用这个执行机会或资源
 
 Lease 丢失应 fail closed。一个 worker 不应该在 lease 过期后继续静默执行，再把结果写进 canonical state。
 
-未来 supervisor fork 的 branch lease 更窄：它只授权执行一个 temporary execution branch，不继承 source todo、source quota 或 source durable memory。
+当前 `task_lease_v0` 是显式调用方使用的可选并发原语，支持 TTL、版本 CAS、
+续租、转移、释放和 write-scope 冲突检查。普通 `todo claim`、
+`quota should-run` 和 agent turn 不会自动 acquire task lease。因此：
+
+- `claimed_by` 已经是默认 todo 路由合同；
+- task lease 只在真实并发冲突或排他资源需要时启用；
+- status 中的 `soft_claim` 展示不能反向解释成 hard lease；
+- handoff 不要求先创建 lease，lease 也不证明 handoff 已完成。
+
+实现边界可以直接由调用图证明：`acquire_task_lease()` 的产品调用点位于
+`loopx/cli_commands/task_lease.py`，而不是 todo claim 或 quota pipeline。
+生命周期与幂等合同由 `tests/control_plane/test_task_lease.py` 和
+`examples/control_plane/task-lease-runtime-smoke.py` 看护。
+
+未来 supervisor fork 的 branch lease 更窄：它只授权执行一个 temporary
+execution branch，不继承 source todo、source quota 或 source durable memory。
+
+## Handoff 是恢复协议，不是执行动作
+
+在资格测试里，可以把一次 handoff 建模成“业务无进展”的恢复轮：当前 worker
+停止使用临时上下文，下一 peer 只读取 durable state，并重建同一决策面。
+
+```text
+P = decision-relevant project projection
+H(P, fresh environment) = projection reconstructed by the next peer
+
+no new evidence 时：distance(H(P), P) < epsilon
+```
+
+这里比较的不是逐字 transcript，而是 objective、authority source、validation
+surface、open frontier、gate、claim boundary、next action 与 stop condition。
+连续多次 handoff 仍保持这些字段等价，才说明长期状态不依赖某个 worker 的偶然
+记忆。
+
+生产协议把“可恢复”和“已经开始下一轮”明确分开。
+`loopx/control_plane/work_items/project_asset.py::project_asset_handoff_check_projection`
+先检查 handoff surface：
+
+```python
+checks = {
+    "project_asset_backed": True,
+    "same_source_should_run": bool(
+        quota and next_action and (not item_action or item_action == next_action)
+    ),
+    "codex_ready": waiting_on == "codex" and quota_state == "eligible",
+    "handoff_has_next_action": bool(next_action),
+    "handoff_has_stop_condition": bool(stop_condition),
+    "handoff_sanitized_surface": project_asset_summary_is_public_safe(project_asset),
+}
+```
+
+随后 `loopx/control_plane/handoff/project_handoff.py::project_asset_handoff_state`
+才区分等待与真实后续执行：
+
+```python
+if post_handoff_run:
+    handoff_status = "post_handoff_run_seen"
+elif ready:
+    handoff_status = "ready_waiting_for_run"
+else:
+    handoff_status = "not_ready"
+```
+
+因此收到 handoff packet 后，agent 需要接手工作面，但不会仅凭 packet 自动开始
+业务执行。真正运行仍要重新通过 quota、gate、capability、claim/lease 和
+workspace guard。`ready_waiting_for_run` 正是“状态可恢复，但尚未出现后续工作
+run”的合法状态。
+
+阅读 `examples/project/project-handoff-readmodel-smoke.py` 时重点看两个反例：
+
+1. handoff surface 完整，但没有 post-handoff run，应保持
+   `ready_waiting_for_run`；
+2. status-neutral run 不得冒充业务进展，只有真实后续 work run 才切换到
+   `post_handoff_run_seen`。
+
+连续 N 次 handoff 可以作为低频状态稳定性资格测试，但不是日常执行流程，也不
+能用“漂移分数低”替代任务的 artifact、validation 或 outcome evidence。
 
 ## Capability Gate：能做不等于被授权
 

--- a/docs/development/control-plane-course/06-evidence-refresh-and-self-repair.md
+++ b/docs/development/control-plane-course/06-evidence-refresh-and-self-repair.md
@@ -175,6 +175,56 @@ todo delta
 - 什么证据说明它的 lane 可以关闭？
 - 哪些变化要求 replan？
 
+Vision、Goal 与 Todo 形成一条方向到动作的约束链：
+
+| 层 | 回答的问题 | 不直接做什么 |
+| --- | --- | --- |
+| Vision | 为什么长期工作、向什么标准收敛？ | 不选择本轮 todo，不授予权限 |
+| Goal | 当前阶段要交付什么，边界和 acceptance 是什么？ | 不替代 runnable frontier |
+| Todo | 下一步由谁在什么条件下做什么？ | 不自行改写长期方向 |
+
+```text
+Vision
+  -> Goal boundary / acceptance
+  -> Todo frontier
+  -> bounded delivery + evidence
+  -> acceptance audit
+  -> continue, replan, or vision patch
+```
+
+这条链解释了为什么 Vision 应相对稳定，却不能永久冻结：用户方向变化、验收标准
+被证伪、长期 frontier 耗尽或持续局部最优时，需要一个有明确 delta 的 patch。
+反过来，新增一个 todo 不等于 Vision 已变化。
+
+`loopx/control_plane/goals/goal_vision.py::normalize_goal_vision_packet`
+把这种边界编码成 compact、public-safe、agent-scoped packet：
+
+```python
+if packet_goal_id and packet_goal_id != goal_id:
+    raise ValueError(
+        f"agent_vision goal_id {packet_goal_id!r} does not match {goal_id!r}"
+    )
+
+if agent_id and packet_agent_id and packet_agent_id != agent_id:
+    raise ValueError(
+        f"agent_vision agent_id {packet_agent_id!r} does not match {agent_id!r}"
+    )
+
+if not vision_patch:
+    raise ValueError("agent_vision must include at least one bounded vision field")
+
+if total_usage > GOAL_VISION_TOTAL_LIMIT:
+    raise GoalVisionBudgetError(
+        field="total_agent_vision",
+        used=total_usage,
+        limit=GOAL_VISION_TOTAL_LIMIT,
+    )
+```
+
+这里的 identity check 防止一个 peer 覆盖另一个 lane，budget 防止 Vision 退化成
+第二份 transcript。`examples/project/goal-vision-refresh-state-budget-smoke.py`
+同时验证写入正确性、预算与 repair delta。
+
 当 material refresh 没有 vision patch 或 unchanged reason 时，CLI 会产生 `vision_checkpoint_missing` acceptance gap。Todo 即使完成，也不能直接 terminal。
 
 修复选择有三种：
@@ -184,6 +234,32 @@ todo delta
 3. 用 evidence 关闭或 supersede 该 vision frontier。
 
 不要为了消除 warning 随便写“unchanged”。Reason 必须与本轮 acceptance 事实一致。
+
+## Signal、Anchor 与 Feedback 不直接变成 Todo Truth
+
+长期管理面的输入不只有已有 todo，还包括 issue、PR、review、chat feedback、文档
+变化和外部 monitor。合理的产品链路是：
+
+```text
+signal
+  -> classify and attribute
+  -> select a bounded anchor
+  -> materialize todo / gate / monitor
+  -> deliver and collect evidence
+  -> performance review
+  -> explicit priority, gate, or vision writeback
+```
+
+这个链路是管理面的推理框架，不应被伪装成一套已经独立落地的通用状态机：
+
+- 外部消息到达不等于用户已授权执行；
+- 被认为“有价值”的 signal 不等于已进入 runnable frontier；
+- raw feedback 不直接覆盖 Vision，必须形成明确 source、scope 和 delta；
+- performance review 可以影响下一轮优先级，但仍要通过 todo/gate/vision API 写回。
+
+开发 connector 或 inbox 时，应先把 signal 归一化为 public-safe evidence，再由
+现有 Core State 承接 anchor。第 9 讲的 Lark Event Inbox 展示了这一边界；不要
+为每种外部信号新增一个 quota 分支。
 
 ## Replan 与 Dreaming
 

--- a/docs/development/control-plane-course/09-extension-layer.md
+++ b/docs/development/control-plane-course/09-extension-layer.md
@@ -39,6 +39,64 @@ domain evidence / role defaults / host capability / presentation sink
 registry -> status -> quota -> interaction contract -> todo/evidence -> refresh/spend
 ```
 
+## Kernel、Capability Pack 与 Domain State
+
+扩展层可以用三层架构审查，但三层不是三套 control plane：
+
+| 层 | Owns | Must not own |
+| --- | --- | --- |
+| Kernel | vision、goal、todo、gate、quota、scheduler、evidence、handoff | Issue-Fix/Explore/ML 的专用判断 |
+| Capability Pack | 领域 route、validator、compact adapter、preset | 绕过 Kernel 的 permission 或 lifecycle |
+| Domain State | feasibility、PR lifecycle、experiment result、checkpoint 等紧凑事实 | claim、quota、gate、host effect authority |
+
+这套分层的价值不是目录整齐，而是让领域能力增加事实，不增加第二套权限模型。
+当前 Issue-Fix pack 直接复用通用 Domain State seam：
+
+```python
+from ..domain_state import default_domain_state_file_path, upsert_domain_state_jsonl
+
+def _upsert_issue_fix_payload(ledger_path, payload, *, key, ...):
+    projection = payload.get("domain_state_projection")
+    if not isinstance(projection, dict):
+        raise ValueError("issue-fix payload must include domain_state_projection")
+
+    projection["write_performed"] = True
+    try:
+        result = upsert_domain_state_jsonl(
+            ledger_path,
+            payload,
+            key=key,
+            existing_key_fn=existing_key_fn,
+            unchanged_fn=unchanged_fn,
+            merge_existing_fn=merge_existing_fn,
+        )
+    except Exception:
+        projection["write_performed"] = False
+        raise
+    projection["write_result"] = result
+    return result
+```
+
+ML Experiment 走相同 seam，只替换自己的稳定 key 和 payload validator：
+
+```python
+return upsert_domain_state_jsonl(
+    ledger_path,
+    payload,
+    key=ml_experiment_ledger_key(payload),
+    existing_key_fn=ml_experiment_ledger_key,
+)
+```
+
+这两个调用点给出一条可操作的评审规则：如果新 pack 只需要紧凑领域事实，就复用
+Domain State；如果它需要改变谁可执行、何时 spend、哪个 gate 生效，就必须回到
+Kernel 提出通用规则并接受第 7、8 讲的语义与质量门禁。
+
+同时保留三条数据边界：raw log、凭据和本地路径留在获批的私有 artifact；Domain
+State 只保存可重放的 compact facts；外部 sink 只消费 public-safe projection。
+`examples/issue-fix-feasibility-smoke.py` 与
+`tests/test_ml_experiment_volc_packet.py` 是这条分层的代表性回归入口。
+
 ## 先读 Feature Catalog
 
 不要从 README 猜当前可配置能力。对已注册 goal 运行：


### PR DESCRIPTION
## Summary

- distinguish session context, durable project memory, fresh environment, Domain State, and private runtime artifacts
- separate soft claims, optional task leases, handoff readiness, and actual post-handoff execution
- connect Vision -> Goal -> Todo with bounded signal/anchor/evidence writeback
- teach Kernel, Capability Pack, and Domain State through current Issue-Fix and ML Experiment call sites

The public course generalizes the authority model without embedding private source titles, links, actors, or raw source text. Every code-led explanation is calibrated against the current repository implementation and durable smokes.

## Validation

- `loopx canary premerge --from-git-diff --tier standard --timeout-seconds 180 --no-progress --format json`: passed; 18/18 selected checks, 3/3 direct checks, 0 failures, 0 warnings, 0 manual holds
- `python3 examples/docs-governance-smoke.py`
- `python3 examples/project/project-handoff-readmodel-smoke.py`
- `python3 examples/control_plane/task-lease-runtime-smoke.py`
- `python3 examples/project/goal-vision-refresh-state-budget-smoke.py`
- `python3 examples/issue-fix-feasibility-smoke.py`
- `python3 examples/canary/quality-surface-catalog-smoke.py`
- `uv run --extra test pytest -q tests/test_ml_experiment_volc_packet.py tests/control_plane/test_task_lease.py`: 32 passed
- `git diff --check` and public/private boundary scan passed

## Risk and scope

Docs-only, single-purpose course update. No runtime, CLI output, model packet, permission, release-outcome, or benchmark behavior changes. Doubao qualification was not run because no model-facing behavior changed.