### PR TITLE
release: LoopX v0.2.7

### DIFF
--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.2.6"
+version = "0.2.7"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- bump the package and runtime version from `0.2.6` to `0.2.7`
- bind the release candidate to exact commit `d6e2f8fa` and tree `c28f758f`
- keep release notes and publication outside the tracked source change

## Validation

- pytest: 649 passed, 2 skipped
- Ruff: passed
- mypy: 12 source files passed
- full-public smoke fleet: 599/599 passed, 0 failures, 0 timeouts; smoke-health ready
- release/install/host profiles: 15/15 passed
- risk-based premerge canary: passed, 0 manual holds, self-merge allowed
- public/private boundary: 1,558 files scanned, 0 violations
- live Doubao actual-default one-arm: 9 scenarios x 2 repeats = 18/18 passed
- exact-release reducer: `ready_for_owner_release`, no source mismatches

The first full-public run used a 120-second per-check limit and recorded three
timeouts under parallel load. A complete rerun at the same commit with a
180-second per-check limit passed all 599 checks; no assertion, script, or
inventory item was removed or skipped.

## Boundaries

- no raw model prompts, packets, responses, credentials, logs, or local paths
- no benchmark or long-horizon outcome uplift claim, so no matched outcome pair
- no persisted-state migration
- later `main` changes are intentionally excluded from the tested release commit
