### PR TITLE
fix(issue-fix): drain grouped reviewer notifications

### DIFF
--- a/docs/capabilities/issue-fix/protocols/issue-fix-reviewer-notification-sinks-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-reviewer-notification-sinks-v0.md
@@ -141,11 +141,30 @@ explicit sink value, then the unrestricted default. When configured, execute
 mode sends only while the current local time is inside the half-open
 `[start, end)` window; overnight windows are supported. Outside the window,
 LoopX performs no provider call and returns `queued_until_window` with a
-compact `issue_fix_reviewer_notification_queue_receipt_v0`. Invalid timezone,
-time, or outside-window policy fails closed. Preview remains read-only and is
-never converted into a queued execution. The execute path uses the trusted
-invocation clock for this decision; the public `--generated-at` artifact field
-cannot move a send into or out of the delivery window.
+compact `issue_fix_reviewer_notification_queue_receipt_v1`. The v1 receipt also
+persists the public-safe summary and whether it came from a verified Reward
+Memory artifact, so a later drain cannot regress a Chinese reviewer summary to
+the raw PR title. Invalid timezone, time, or outside-window policy fails closed.
+Preview remains read-only and is never converted into a queued execution. The
+execute path uses the trusted invocation clock for this decision; the public
+`--generated-at` artifact field cannot move a send into or out of the delivery
+window.
+
+The grouped state monitor drains due receipts with:
+
+```bash
+loopx issue-fix reviewer-notification-drain \
+  --goal-id <goal-id> \
+  --project <project> \
+  --execute \
+  --format json
+```
+
+One bounded invocation scans every queued PR in the review-required state
+bucket; it does not create one continuous monitor per PR. Before each message,
+LoopX refreshes compact live GitHub state and cancels stale queues for closed,
+merged, draft, approved, or already-reviewed PRs. A send remains one PR per
+message and is complete only after semantic readback and receipt persistence.
 
 Profile names, `destination_id`, and `member_id` are execution inputs. They are
 never copied into the result, domain state, todo, Kanban, PR, or public log.

--- a/docs/capabilities/issue-fix/protocols/issue-fix-reviewer-notification-sinks-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-reviewer-notification-sinks-v0.md
@@ -164,7 +164,9 @@ This is a deliberate queue-schema cutover: existing
 `issue_fix_reviewer_notification_queue_receipt_v0` rows must be manually
 migrated to v1 before enabling the grouped drain. The runtime does not retain a
 v0 compatibility reader because a v0 row lacks the persisted Chinese summary
-and therefore cannot satisfy the current reviewer-message contract.
+and therefore cannot satisfy the current reviewer-message contract. A detected
+v0 row fails closed with `reviewer_notification_queue_v1_migration_required`;
+it is never silently treated as an empty queue.
 
 One bounded invocation scans every queued PR in the review-required state
 bucket; it does not create one continuous monitor per PR. Before each message,
@@ -174,7 +176,9 @@ per message (and at most one message per configured sink) and is complete only
 after semantic readback and receipt persistence. If only some queued reviewers
 already reviewed, the drain targets only the remaining reviewers. Temporary CI
 or branch-state changes keep the queue intact, and the drain always reuses the
-timezone and allowed local-time window frozen in the v1 receipt.
+timezone and allowed local-time window frozen in the v1 receipt. A sink removed
+from current configuration cancels only its own stale receipt; other configured
+sinks for that PR continue independently.
 
 Profile names, `destination_id`, and `member_id` are execution inputs. They are
 never copied into the result, domain state, todo, Kanban, PR, or public log.

--- a/docs/capabilities/issue-fix/protocols/issue-fix-reviewer-notification-sinks-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-reviewer-notification-sinks-v0.md
@@ -180,6 +180,14 @@ timezone and allowed local-time window frozen in the v1 receipt. A sink removed
 from current configuration cancels only its own stale receipt; other configured
 sinks for that PR continue independently.
 
+Semantic history dedupe is sink-scoped. A single Lark sink may use the goal-level
+`feedback_inbox_config`; multiple Lark sinks must each declare their own
+`feedback_inbox_config`. If a multi-sink inbox cannot be attributed to one sink,
+the drain fails closed and preserves the queue instead of suppressing another
+chat's delivery. Bounded executions also report `remaining_due_pr_count` and
+return `partial_drain` whenever verified or cancelled work coexists with due
+rows held by a delivery window or left for the next `--limit` batch.
+
 Profile names, `destination_id`, and `member_id` are execution inputs. They are
 never copied into the result, domain state, todo, Kanban, PR, or public log.
 The first contract requires a named, project-dedicated sender profile and expected

--- a/docs/capabilities/issue-fix/protocols/issue-fix-reviewer-notification-sinks-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-reviewer-notification-sinks-v0.md
@@ -160,11 +160,19 @@ loopx issue-fix reviewer-notification-drain \
   --format json
 ```
 
+This is a deliberate queue-schema cutover: existing
+`issue_fix_reviewer_notification_queue_receipt_v0` rows must be manually
+migrated to v1 before enabling the grouped drain. The runtime does not retain a
+v0 compatibility reader because a v0 row lacks the persisted Chinese summary
+and therefore cannot satisfy the current reviewer-message contract.
+
 One bounded invocation scans every queued PR in the review-required state
 bucket; it does not create one continuous monitor per PR. Before each message,
 LoopX refreshes compact live GitHub state and cancels stale queues for closed,
-merged, draft, approved, or already-reviewed PRs. A send remains one PR per
-message and is complete only after semantic readback and receipt persistence.
+merged, draft, approved, or fully-covered reviewer sets. A send remains one PR
+per message (and at most one message per configured sink) and is complete only
+after semantic readback and receipt persistence. If only some queued reviewers
+already reviewed, the drain targets only the remaining reviewers.
 
 Profile names, `destination_id`, and `member_id` are execution inputs. They are
 never copied into the result, domain state, todo, Kanban, PR, or public log.

--- a/docs/capabilities/issue-fix/protocols/issue-fix-reviewer-notification-sinks-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-reviewer-notification-sinks-v0.md
@@ -172,7 +172,9 @@ LoopX refreshes compact live GitHub state and cancels stale queues for closed,
 merged, draft, approved, or fully-covered reviewer sets. A send remains one PR
 per message (and at most one message per configured sink) and is complete only
 after semantic readback and receipt persistence. If only some queued reviewers
-already reviewed, the drain targets only the remaining reviewers.
+already reviewed, the drain targets only the remaining reviewers. Temporary CI
+or branch-state changes keep the queue intact, and the drain always reuses the
+timezone and allowed local-time window frozen in the v1 receipt.
 
 Profile names, `destination_id`, and `member_id` are execution inputs. They are
 never copied into the result, domain state, todo, Kanban, PR, or public log.

--- a/examples/issue-fix-reviewer-notification-drain-postwrite-smoke.py
+++ b/examples/issue-fix-reviewer-notification-drain-postwrite-smoke.py
@@ -8,6 +8,7 @@ import sys
 import tempfile
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -446,6 +447,50 @@ def main() -> int:
             failed_ledger.read_text(encoding="utf-8").splitlines()[0]
         )
         assert failed_stored["reviewer_notification_queue"] == [failed_receipt]
+
+        with patch(
+            "loopx.capabilities.issue_fix.reviewer_notification_drain."
+            "persist_issue_fix_reviewer_notification_state",
+            side_effect=OSError("fixture writeback failure"),
+        ):
+            failed_writeback = drain_issue_fix_reviewer_notification_queue(
+                ledger_path=failed_ledger,
+                sinks_input=sinks_input,
+                execute=True,
+                delivery_observed_at="2026-07-18T01:01:00Z",
+                metadata_loader=failed_metadata_loader,
+                sink_adapters={"lark_chat": scoped_adapter},
+            )
+        assert failed_writeback["status"] == "blocked", failed_writeback
+        assert failed_writeback["external_writes_performed"] is True
+        assert failed_writeback["items"][0]["external_write_performed"] is True
+        assert failed_writeback["remaining_due_pr_count"] == 1
+        assert failed_writeback["has_more_due"] is True
+
+        malformed_row = json.loads(
+            failed_ledger.read_text(encoding="utf-8").splitlines()[0]
+        )
+        malformed_row["reviewer_notification_queue"][0]["not_before"] = (
+            "not-a-timestamp"
+        )
+        failed_ledger.write_text(
+            json.dumps(malformed_row, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        malformed_drain = drain_issue_fix_reviewer_notification_queue(
+            ledger_path=failed_ledger,
+            sinks_input=sinks_input,
+            execute=True,
+            delivery_observed_at="2026-07-18T01:01:00Z",
+        )
+        assert malformed_drain["status"] == "blocked", malformed_drain
+        assert malformed_drain["blocker"] == (
+            "reviewer_notification_queue_not_before_invalid"
+        )
+        assert malformed_drain["invalid_queue_receipt_count"] == 1
+        assert malformed_drain["has_more_due"] is True
+        assert malformed_drain["external_reads_performed"] is False
+        assert malformed_drain["external_writes_performed"] is False
 
         correction_ledger = path / "maintainer-correction-pr-lifecycle.jsonl"
         correction_row = build_issue_fix_pr_lifecycle_monitor_packet(

--- a/examples/issue-fix-reviewer-notification-drain-postwrite-smoke.py
+++ b/examples/issue-fix-reviewer-notification-drain-postwrite-smoke.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Ensure an unverified external write is never retried automatically."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx.capabilities.issue_fix.pr_lifecycle import (  # noqa: E402
+    build_issue_fix_pr_lifecycle_monitor_packet,
+)
+from loopx.capabilities.issue_fix.reviewer_notification import (  # noqa: E402
+    reviewer_notification_idempotency_key,
+)
+from loopx.capabilities.issue_fix.reviewer_notification_drain import (  # noqa: E402
+    drain_issue_fix_reviewer_notification_queue,
+)
+from loopx.domain_packs.issue_fix import (  # noqa: E402
+    persist_issue_fix_reviewer_notification_state,
+    upsert_issue_fix_pr_lifecycle_ledger_jsonl,
+)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-reviewer-postwrite-") as raw_path:
+        path = Path(raw_path)
+        ledger = path / ".loopx/domain-state/drain/pr-lifecycle.jsonl"
+        sink = {
+            "sink_kind": "lark_chat",
+            "sink_instance_key": "fixture-review-lane",
+            "identity_scope": "project_dedicated",
+            "reader_profile": "fixture-reader-profile",
+            "reader_identity": "user",
+            "sender_profile": "fixture-sender-profile",
+            "sender_identity": "bot",
+            "destination_id": "fixture-destination",
+            "reviewer_identities": {
+                "@map-owner": {
+                    "member_id": "fixture-member",
+                    "display_name": "Map Owner",
+                }
+            },
+        }
+        sinks_input = {
+            "schema_version": "issue_fix_reviewer_notification_sinks_input_v0",
+            "receipts": [],
+            "sinks": [sink],
+        }
+        row = build_issue_fix_pr_lifecycle_monitor_packet(
+            url="https://github.com/owner/repo/pull/105",
+            provider_payload={
+                "state": "OPEN",
+                "reviewDecision": "REVIEW_REQUIRED",
+                "mergeStateStatus": "BLOCKED",
+                "statusCheckRollup": [],
+            },
+        )
+        upsert_issue_fix_pr_lifecycle_ledger_jsonl(ledger, row)
+        key = reviewer_notification_idempotency_key(
+            repo="owner/repo",
+            pr_number=105,
+            sink_kind="lark_chat",
+            sink_instance_key=sink["sink_instance_key"],
+            reviewer_handles=["@map-owner"],
+        )
+        persist_issue_fix_reviewer_notification_state(
+            ledger,
+            row,
+            receipts=[],
+            queued_receipts=[
+                {
+                    "schema_version": (
+                        "issue_fix_reviewer_notification_queue_receipt_v1"
+                    ),
+                    "idempotency_key": key,
+                    "sink_kind": "lark_chat",
+                    "reviewer_handles": ["@map-owner"],
+                    "message_summary": "修复发送后验证失败造成重复提醒的问题",
+                    "summary_policy_status": "sink_config",
+                    "queued_at": "2026-07-20T00:00:00Z",
+                    "not_before": "2026-07-20T01:00:00Z",
+                    "timezone": "Asia/Shanghai",
+                    "allowed_local_time": {"start": "09:00", "end": "21:00"},
+                    "status": "queued",
+                }
+            ],
+        )
+
+        def metadata_loader(
+            *, repo: str, number: int
+        ) -> tuple[dict[str, Any], None]:
+            assert (repo, number) == ("owner/repo", 105)
+            return {
+                "author_handle": "@author-e",
+                "reviewed_by": [],
+                "requested_reviewers": ["@map-owner"],
+                "comment_notified_reviewers": [],
+                "state": "OPEN",
+                "review_decision": "REVIEW_REQUIRED",
+                "state_bucket": "review_required",
+                "is_draft": False,
+                "linked_issue_refs": ["#95"],
+            }, None
+
+        def unverified_adapter(**kwargs: Any) -> dict[str, Any]:
+            return {
+                "ok": False,
+                "schema_version": "issue_fix_reviewer_notification_sink_result_v0",
+                "sink_kind": "lark_chat",
+                "status": "sent_unverified",
+                "reviewer_handles": list(kwargs["reviewer_handles"]),
+                "resolved_reviewer_count": len(kwargs["reviewer_handles"]),
+                "idempotency_key": key,
+                "identity_scope": "project_dedicated",
+                "external_write_authority_asserted": True,
+                "external_write_performed": True,
+                "verification_performed": True,
+                "notification_verified": False,
+                "bot_identity_verified": True,
+                "reader_identity_verified": True,
+                "private_destination_captured": False,
+                "private_member_ids_captured": False,
+                "private_bot_profile_captured": False,
+                "raw_provider_payload_captured": False,
+                "blocker": "lark_notification_not_verified",
+            }
+
+        first = drain_issue_fix_reviewer_notification_queue(
+            ledger_path=ledger,
+            sinks_input=sinks_input,
+            execute=True,
+            delivery_observed_at="2026-07-20T01:01:00Z",
+            metadata_loader=metadata_loader,
+            sink_adapters={"lark_chat": unverified_adapter},
+        )
+        assert first["status"] == "blocked", first
+        assert first["external_writes_performed"] is True
+        second = drain_issue_fix_reviewer_notification_queue(
+            ledger_path=ledger,
+            sinks_input=sinks_input,
+            execute=True,
+            delivery_observed_at="2026-07-20T01:02:00Z",
+            metadata_loader=metadata_loader,
+            sink_adapters={"lark_chat": unverified_adapter},
+        )
+        assert second["status"] == "no_due_notifications", second
+
+    print("issue-fix-reviewer-notification-drain-postwrite-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/issue-fix-reviewer-notification-drain-postwrite-smoke.py
+++ b/examples/issue-fix-reviewer-notification-drain-postwrite-smoke.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Ensure an unverified external write is never retried automatically."""
+"""Ensure grouped drain writeback and semantic dedupe are restart safe."""
 
 from __future__ import annotations
 
+import json
 import sys
 import tempfile
 from pathlib import Path
@@ -40,10 +41,11 @@ def main() -> int:
             "reader_identity": "user",
             "sender_profile": "fixture-sender-profile",
             "sender_identity": "bot",
-            "destination_id": "fixture-destination",
+            "bot_display_name": "Fixture Review Bot",
+            "destination_id": "oc_fixture_destination",
             "reviewer_identities": {
                 "@map-owner": {
-                    "member_id": "fixture-member",
+                    "member_id": "ou_fixture_member",
                     "display_name": "Map Owner",
                 }
             },
@@ -151,6 +153,86 @@ def main() -> int:
             sink_adapters={"lark_chat": unverified_adapter},
         )
         assert second["status"] == "no_due_notifications", second
+
+        semantic_ledger = path / "semantic-pr-lifecycle.jsonl"
+        semantic_row = build_issue_fix_pr_lifecycle_monitor_packet(
+            url="https://github.com/owner/repo/pull/106",
+            provider_payload={
+                "state": "OPEN",
+                "reviewDecision": "REVIEW_REQUIRED",
+                "mergeStateStatus": "BLOCKED",
+                "statusCheckRollup": [],
+            },
+        )
+        upsert_issue_fix_pr_lifecycle_ledger_jsonl(semantic_ledger, semantic_row)
+        semantic_key = reviewer_notification_idempotency_key(
+            repo="owner/repo",
+            pr_number=106,
+            sink_kind="lark_chat",
+            sink_instance_key=sink["sink_instance_key"],
+            reviewer_handles=["@map-owner"],
+        )
+        persist_issue_fix_reviewer_notification_state(
+            semantic_ledger,
+            semantic_row,
+            receipts=[],
+            queued_receipts=[
+                {
+                    "schema_version": (
+                        "issue_fix_reviewer_notification_queue_receipt_v1"
+                    ),
+                    "idempotency_key": semantic_key,
+                    "sink_kind": "lark_chat",
+                    "reviewer_handles": ["@map-owner"],
+                    "message_summary": "修复已有群消息被重复发送的问题",
+                    "summary_policy_status": "reward_memory_verified",
+                    "queued_at": "2026-07-17T18:00:00Z",
+                    "not_before": "2026-07-18T01:00:00Z",
+                    "timezone": "Asia/Shanghai",
+                    "allowed_local_time": {"start": "09:00", "end": "21:00"},
+                    "status": "queued",
+                }
+            ],
+        )
+
+        def semantic_metadata_loader(
+            *, repo: str, number: int, runner: Any = None
+        ) -> tuple[dict[str, Any], None]:
+            assert (repo, number) == ("owner/repo", 106)
+            return {
+                "author_handle": "@author-f",
+                "reviewed_by": [],
+                "requested_reviewers": ["@map-owner"],
+                "comment_notified_reviewers": [],
+                "state": "OPEN",
+                "review_decision": "REVIEW_REQUIRED",
+                "state_bucket": "review_required",
+                "is_draft": False,
+                "linked_issue_refs": ["#96"],
+            }, None
+
+        def no_lark_write(_args: list[str]) -> dict[str, Any]:
+            raise AssertionError("semantic inbox dedupe must prevent a Lark write")
+
+        semantic_drain = drain_issue_fix_reviewer_notification_queue(
+            ledger_path=semantic_ledger,
+            sinks_input=sinks_input,
+            execute=True,
+            delivery_observed_at="2026-07-18T01:01:00Z",
+            runner=no_lark_write,
+            metadata_loader=semantic_metadata_loader,
+            semantic_history_matcher=lambda permalink: permalink.endswith(
+                "/pull/106"
+            ),
+        )
+        assert semantic_drain["ok"] is True, semantic_drain
+        assert semantic_drain["external_writes_performed"] is False
+        assert semantic_drain["items"][0]["semantic_history_status"] == "matched"
+        semantic_stored = json.loads(
+            semantic_ledger.read_text(encoding="utf-8").splitlines()[0]
+        )
+        assert semantic_stored["reviewer_notification_queue"] == []
+        assert semantic_key in semantic_stored["reviewer_notification_receipts"]
 
     print("issue-fix-reviewer-notification-drain-postwrite-smoke: ok")
     return 0

--- a/examples/issue-fix-reviewer-notification-drain-postwrite-smoke.py
+++ b/examples/issue-fix-reviewer-notification-drain-postwrite-smoke.py
@@ -431,6 +431,15 @@ def main() -> int:
                 "linked_issue_refs": [],
             }, None
 
+        due_preview = drain_issue_fix_reviewer_notification_queue(
+            ledger_path=failed_ledger,
+            sinks_input=sinks_input,
+            execute=False,
+            delivery_observed_at="2026-07-18T01:01:00Z",
+        )
+        assert due_preview["status"] == "preview_due", due_preview
+        assert due_preview["remaining_due_pr_count"] == 0
+        assert due_preview["has_more_due"] is False
         failed_drain = drain_issue_fix_reviewer_notification_queue(
             ledger_path=failed_ledger,
             sinks_input={
@@ -473,8 +482,37 @@ def main() -> int:
         malformed_row["reviewer_notification_queue"][0]["not_before"] = (
             "not-a-timestamp"
         )
+        healthy_ledger = path / "healthy-due-pr-lifecycle.jsonl"
+        healthy_row = build_issue_fix_pr_lifecycle_monitor_packet(
+            url="https://github.com/owner/repo/pull/114",
+            provider_payload={
+                "state": "OPEN",
+                "reviewDecision": "REVIEW_REQUIRED",
+                "mergeStateStatus": "BLOCKED",
+                "statusCheckRollup": [],
+            },
+        )
+        persist_issue_fix_reviewer_notification_state(
+            healthy_ledger,
+            healthy_row,
+            receipts=[],
+            queued_receipts=[
+                {
+                    **failed_receipt,
+                    "idempotency_key": reviewer_notification_idempotency_key(
+                        repo="owner/repo",
+                        pr_number=114,
+                        sink_kind="lark_chat",
+                        sink_instance_key=sink["sink_instance_key"],
+                        reviewer_handles=["@map-owner"],
+                    ),
+                }
+            ],
+        )
         failed_ledger.write_text(
-            json.dumps(malformed_row, sort_keys=True) + "\n",
+            json.dumps(malformed_row, sort_keys=True)
+            + "\n"
+            + healthy_ledger.read_text(encoding="utf-8"),
             encoding="utf-8",
         )
         malformed_drain = drain_issue_fix_reviewer_notification_queue(
@@ -488,6 +526,8 @@ def main() -> int:
             "reviewer_notification_queue_not_before_invalid"
         )
         assert malformed_drain["invalid_queue_receipt_count"] == 1
+        assert malformed_drain["due_pr_count"] == 1
+        assert malformed_drain["remaining_due_pr_count"] == 2
         assert malformed_drain["has_more_due"] is True
         assert malformed_drain["external_reads_performed"] is False
         assert malformed_drain["external_writes_performed"] is False
@@ -616,6 +656,8 @@ def main() -> int:
         )
         assert preview["status"] == "preview_blocked", preview
         assert preview["blocked_pr_count"] == 1, preview
+        assert preview["remaining_due_pr_count"] == 1, preview
+        assert preview["has_more_due"] is True, preview
         assert reviewer_notification_idempotency_key(
             repo="owner/repo",
             pr_number=108,

--- a/examples/issue-fix-reviewer-notification-drain-postwrite-smoke.py
+++ b/examples/issue-fix-reviewer-notification-drain-postwrite-smoke.py
@@ -198,7 +198,7 @@ def main() -> int:
         def semantic_metadata_loader(
             *, repo: str, number: int, runner: Any = None
         ) -> tuple[dict[str, Any], None]:
-            assert (repo, number) == ("owner/repo", 106)
+            assert repo == "owner/repo" and number in {106, 109}
             return {
                 "author_handle": "@author-f",
                 "reviewed_by": [],
@@ -221,7 +221,7 @@ def main() -> int:
             delivery_observed_at="2026-07-18T01:01:00Z",
             runner=no_lark_write,
             metadata_loader=semantic_metadata_loader,
-            semantic_history_matcher=lambda permalink: permalink.endswith(
+            semantic_history_matcher=lambda permalink, sink: permalink.endswith(
                 "/pull/106"
             ),
         )
@@ -233,6 +233,91 @@ def main() -> int:
         )
         assert semantic_stored["reviewer_notification_queue"] == []
         assert semantic_key in semantic_stored["reviewer_notification_receipts"]
+
+        scoped_ledger = path / "scoped-semantic-pr-lifecycle.jsonl"
+        scoped_row = build_issue_fix_pr_lifecycle_monitor_packet(
+            url="https://github.com/owner/repo/pull/109",
+            provider_payload={
+                "state": "OPEN",
+                "reviewDecision": "REVIEW_REQUIRED",
+                "mergeStateStatus": "BLOCKED",
+                "statusCheckRollup": [],
+            },
+        )
+        upsert_issue_fix_pr_lifecycle_ledger_jsonl(scoped_ledger, scoped_row)
+        second_sink = {**sink, "sink_instance_key": "fixture-review-lane-b"}
+        scoped_queue = [
+            {
+                "schema_version": "issue_fix_reviewer_notification_queue_receipt_v1",
+                "idempotency_key": reviewer_notification_idempotency_key(
+                    repo="owner/repo",
+                    pr_number=109,
+                    sink_kind="lark_chat",
+                    sink_instance_key=current_sink["sink_instance_key"],
+                    reviewer_handles=["@map-owner"],
+                ),
+                "sink_kind": "lark_chat",
+                "reviewer_handles": ["@map-owner"],
+                "message_summary": "仅对已有消息的群做精确去重",
+                "summary_policy_status": "reward_memory_verified",
+                "queued_at": "2026-07-17T18:00:00Z",
+                "not_before": "2026-07-18T01:00:00Z",
+                "timezone": "Asia/Shanghai",
+                "allowed_local_time": {"start": "09:00", "end": "21:00"},
+                "status": "queued",
+            }
+            for current_sink in (sink, second_sink)
+        ]
+        persist_issue_fix_reviewer_notification_state(
+            scoped_ledger,
+            scoped_row,
+            receipts=[],
+            queued_receipts=scoped_queue,
+        )
+        scoped_writes: list[str] = []
+
+        def scoped_adapter(**kwargs: Any) -> dict[str, Any]:
+            instance_key = str(kwargs["sink"]["sink_instance_key"]).strip()
+            key = reviewer_notification_idempotency_key(
+                repo="owner/repo",
+                pr_number=int(kwargs["pr_number"]),
+                sink_kind="lark_chat",
+                sink_instance_key=instance_key,
+                reviewer_handles=["@map-owner"],
+            )
+            already_notified = key in kwargs["receipts"]
+            if not already_notified:
+                scoped_writes.append(instance_key)
+            return {
+                **unverified_adapter(**kwargs),
+                "ok": True,
+                "status": (
+                    "already_notified" if already_notified else "sent_verified"
+                ),
+                "idempotency_key": key,
+                "external_write_performed": not already_notified,
+                "notification_verified": True,
+            }
+
+        scoped_drain = drain_issue_fix_reviewer_notification_queue(
+            ledger_path=scoped_ledger,
+            sinks_input={**sinks_input, "sinks": [sink, second_sink]},
+            execute=True,
+            delivery_observed_at="2026-07-18T01:01:00Z",
+            metadata_loader=semantic_metadata_loader,
+            semantic_history_matcher=lambda permalink, current_sink: (
+                str(current_sink["sink_instance_key"]).strip()
+                == "fixture-review-lane"
+            ),
+            sink_adapters={"lark_chat": scoped_adapter},
+        )
+        assert scoped_drain["status"] == "drained_verified", scoped_drain
+        assert scoped_writes == ["fixture-review-lane-b"], scoped_writes
+        scoped_stored = json.loads(
+            scoped_ledger.read_text(encoding="utf-8").splitlines()[0]
+        )
+        assert scoped_stored["reviewer_notification_queue"] == []
+        assert len(scoped_stored["reviewer_notification_receipts"]) == 2
 
         mixed_ledger = path / "mixed-reviewers-pr-lifecycle.jsonl"
         mixed_row = build_issue_fix_pr_lifecycle_monitor_packet(
@@ -338,6 +423,79 @@ def main() -> int:
         )
         assert preview["status"] == "preview_blocked", preview
         assert preview["blocked_pr_count"] == 1, preview
+        assert reviewer_notification_idempotency_key(
+            repo="owner/repo",
+            pr_number=108,
+            sink_kind=" lark_chat ",
+            sink_instance_key=" fixture-review-lane ",
+            reviewer_handles=["@map-owner"],
+        ) == reviewer_notification_idempotency_key(
+            repo="owner/repo",
+            pr_number=108,
+            sink_kind="lark_chat",
+            sink_instance_key="fixture-review-lane",
+            reviewer_handles=["@map-owner"],
+        )
+
+        limit_ledger = path / "limit-pr-lifecycle.jsonl"
+        for number in (110, 111):
+            limit_row = build_issue_fix_pr_lifecycle_monitor_packet(
+                url=f"https://github.com/owner/repo/pull/{number}",
+                provider_payload={
+                    "state": "OPEN",
+                    "reviewDecision": "REVIEW_REQUIRED",
+                    "mergeStateStatus": "BLOCKED",
+                    "statusCheckRollup": [],
+                },
+            )
+            upsert_issue_fix_pr_lifecycle_ledger_jsonl(limit_ledger, limit_row)
+            persist_issue_fix_reviewer_notification_state(
+                limit_ledger,
+                limit_row,
+                receipts=[],
+                queued_receipts=[
+                    {
+                        **mixed_receipt,
+                        "idempotency_key": reviewer_notification_idempotency_key(
+                            repo="owner/repo",
+                            pr_number=number,
+                            sink_kind="lark_chat",
+                            sink_instance_key=sink["sink_instance_key"],
+                            reviewer_handles=["@map-owner"],
+                        ),
+                        "reviewer_handles": ["@map-owner"],
+                    }
+                ],
+            )
+
+        def limit_metadata_loader(
+            *, repo: str, number: int
+        ) -> tuple[dict[str, Any], None]:
+            assert repo == "owner/repo" and number in {110, 111}
+            return {
+                "author_handle": "@author-h",
+                "reviewed_by": [],
+                "requested_reviewers": ["@map-owner"],
+                "comment_notified_reviewers": [],
+                "state": "OPEN",
+                "review_decision": "REVIEW_REQUIRED",
+                "state_bucket": "review_required",
+                "is_draft": False,
+                "linked_issue_refs": [],
+            }, None
+
+        limit_drain = drain_issue_fix_reviewer_notification_queue(
+            ledger_path=limit_ledger,
+            sinks_input=sinks_input,
+            execute=True,
+            delivery_observed_at="2026-07-18T01:01:00Z",
+            limit=1,
+            metadata_loader=limit_metadata_loader,
+            sink_adapters={"lark_chat": scoped_adapter},
+        )
+        assert limit_drain["status"] == "partial_drain", limit_drain
+        assert limit_drain["remaining_due_pr_count"] == 1, limit_drain
+        assert limit_drain["has_more_due"] is True, limit_drain
 
     print("issue-fix-reviewer-notification-drain-postwrite-smoke: ok")
     return 0

--- a/examples/issue-fix-reviewer-notification-drain-postwrite-smoke.py
+++ b/examples/issue-fix-reviewer-notification-drain-postwrite-smoke.py
@@ -234,6 +234,111 @@ def main() -> int:
         assert semantic_stored["reviewer_notification_queue"] == []
         assert semantic_key in semantic_stored["reviewer_notification_receipts"]
 
+        mixed_ledger = path / "mixed-reviewers-pr-lifecycle.jsonl"
+        mixed_row = build_issue_fix_pr_lifecycle_monitor_packet(
+            url="https://github.com/owner/repo/pull/107",
+            provider_payload={
+                "state": "OPEN",
+                "reviewDecision": "REVIEW_REQUIRED",
+                "mergeStateStatus": "BLOCKED",
+                "statusCheckRollup": [],
+            },
+        )
+        upsert_issue_fix_pr_lifecycle_ledger_jsonl(mixed_ledger, mixed_row)
+        mixed_receipt = {
+            "schema_version": "issue_fix_reviewer_notification_queue_receipt_v1",
+            "idempotency_key": reviewer_notification_idempotency_key(
+                repo="owner/repo",
+                pr_number=107,
+                sink_kind="lark_chat",
+                sink_instance_key=sink["sink_instance_key"],
+                reviewer_handles=["@map-owner", "@removed-owner"],
+            ),
+            "sink_kind": "lark_chat",
+            "reviewer_handles": ["@map-owner", "@removed-owner"],
+            "message_summary": "取消已评审或已移除 reviewer 的过期提醒",
+            "summary_policy_status": "reward_memory_verified",
+            "queued_at": "2026-07-17T18:00:00Z",
+            "not_before": "2026-07-18T01:00:00Z",
+            "timezone": "Asia/Shanghai",
+            "allowed_local_time": {"start": "09:00", "end": "21:00"},
+            "status": "queued",
+        }
+        persist_issue_fix_reviewer_notification_state(
+            mixed_ledger,
+            mixed_row,
+            receipts=[],
+            queued_receipts=[mixed_receipt],
+        )
+
+        def mixed_metadata_loader(
+            *, repo: str, number: int
+        ) -> tuple[dict[str, Any], None]:
+            assert (repo, number) == ("owner/repo", 107)
+            return {
+                "author_handle": "@author-g",
+                "reviewed_by": ["@map-owner"],
+                "requested_reviewers": [],
+                "comment_notified_reviewers": ["@map-owner"],
+                "state": "OPEN",
+                "review_decision": "REVIEW_REQUIRED",
+                "state_bucket": "review_required",
+                "is_draft": False,
+                "linked_issue_refs": [],
+            }, None
+
+        mixed_drain = drain_issue_fix_reviewer_notification_queue(
+            ledger_path=mixed_ledger,
+            sinks_input=sinks_input,
+            execute=True,
+            delivery_observed_at="2026-07-18T01:01:00Z",
+            metadata_loader=mixed_metadata_loader,
+        )
+        assert mixed_drain["status"] == "cancelled_stale", mixed_drain
+        assert mixed_drain["items"][0]["cancellation_reason"] == (
+            "all_queued_reviewers_already_covered_or_inactive"
+        )
+
+        preview_ledger = path / "preview-blocked-pr-lifecycle.jsonl"
+        preview_row = build_issue_fix_pr_lifecycle_monitor_packet(
+            url="https://github.com/owner/repo/pull/108",
+            provider_payload={
+                "state": "OPEN",
+                "reviewDecision": "REVIEW_REQUIRED",
+                "mergeStateStatus": "BLOCKED",
+                "statusCheckRollup": [],
+            },
+        )
+        upsert_issue_fix_pr_lifecycle_ledger_jsonl(preview_ledger, preview_row)
+        preview_key = reviewer_notification_idempotency_key(
+            repo="owner/repo",
+            pr_number=108,
+            sink_kind="lark_chat",
+            sink_instance_key=sink["sink_instance_key"],
+            reviewer_handles=["@map-owner"],
+        )
+        persist_issue_fix_reviewer_notification_state(
+            preview_ledger,
+            preview_row,
+            receipts=[],
+            queued_receipts=[
+                {
+                    **mixed_receipt,
+                    "idempotency_key": preview_key,
+                    "reviewer_handles": ["@map-owner"],
+                    "allowed_local_time": {"start": "09:00", "end": "09:00"},
+                }
+            ],
+        )
+        preview = drain_issue_fix_reviewer_notification_queue(
+            ledger_path=preview_ledger,
+            sinks_input=sinks_input,
+            execute=False,
+            delivery_observed_at="2026-07-18T01:01:00Z",
+        )
+        assert preview["status"] == "preview_blocked", preview
+        assert preview["blocked_pr_count"] == 1, preview
+
     print("issue-fix-reviewer-notification-drain-postwrite-smoke: ok")
     return 0
 

--- a/examples/issue-fix-reviewer-notification-drain-postwrite-smoke.py
+++ b/examples/issue-fix-reviewer-notification-drain-postwrite-smoke.py
@@ -384,6 +384,154 @@ def main() -> int:
             "all_queued_reviewers_already_covered_or_inactive"
         )
 
+        failed_ledger = path / "failed-send-pr-lifecycle.jsonl"
+        failed_row = build_issue_fix_pr_lifecycle_monitor_packet(
+            url="https://github.com/owner/repo/pull/112",
+            provider_payload={
+                "state": "OPEN",
+                "reviewDecision": "REVIEW_REQUIRED",
+                "mergeStateStatus": "BLOCKED",
+                "statusCheckRollup": [],
+            },
+        )
+        upsert_issue_fix_pr_lifecycle_ledger_jsonl(failed_ledger, failed_row)
+        failed_key = reviewer_notification_idempotency_key(
+            repo="owner/repo",
+            pr_number=112,
+            sink_kind="lark_chat",
+            sink_instance_key=sink["sink_instance_key"],
+            reviewer_handles=["@map-owner"],
+        )
+        failed_receipt = {
+            **mixed_receipt,
+            "idempotency_key": failed_key,
+            "reviewer_handles": ["@map-owner"],
+        }
+        persist_issue_fix_reviewer_notification_state(
+            failed_ledger,
+            failed_row,
+            receipts=[],
+            queued_receipts=[failed_receipt],
+        )
+
+        def failed_metadata_loader(
+            *, repo: str, number: int
+        ) -> tuple[dict[str, Any], None]:
+            assert (repo, number) == ("owner/repo", 112)
+            return {
+                "author_handle": "@author-i",
+                "reviewed_by": [],
+                "requested_reviewers": ["@map-owner"],
+                "comment_notified_reviewers": [],
+                "state": "OPEN",
+                "review_decision": "REVIEW_REQUIRED",
+                "state_bucket": "review_required",
+                "is_draft": False,
+                "linked_issue_refs": [],
+            }, None
+
+        failed_drain = drain_issue_fix_reviewer_notification_queue(
+            ledger_path=failed_ledger,
+            sinks_input={
+                **sinks_input,
+                "sinks": [{**sink, "destination_id": "invalid destination"}],
+            },
+            execute=True,
+            delivery_observed_at="2026-07-18T01:01:00Z",
+            metadata_loader=failed_metadata_loader,
+        )
+        assert failed_drain["status"] == "blocked", failed_drain
+        assert failed_drain["external_writes_performed"] is False
+        failed_stored = json.loads(
+            failed_ledger.read_text(encoding="utf-8").splitlines()[0]
+        )
+        assert failed_stored["reviewer_notification_queue"] == [failed_receipt]
+
+        correction_ledger = path / "maintainer-correction-pr-lifecycle.jsonl"
+        correction_row = build_issue_fix_pr_lifecycle_monitor_packet(
+            url="https://github.com/owner/repo/pull/113",
+            provider_payload={
+                "state": "OPEN",
+                "reviewDecision": "REVIEW_REQUIRED",
+                "mergeStateStatus": "BLOCKED",
+                "statusCheckRollup": [],
+            },
+            maintainer_correction_input={
+                "schema_version": "issue_fix_maintainer_correction_input_v0",
+                "correction_kind": "semantic_ambiguity",
+                "source_kind": "maintainer_comment",
+                "source_ref": "https://github.com/owner/repo/pull/113#issuecomment-1",
+                "summary": "需要确认队列失败后是立即重试还是等待下一窗口。",
+                "user_question": "失败发送应立即重试，还是保持到下一发送窗口？",
+            },
+        )
+        upsert_issue_fix_pr_lifecycle_ledger_jsonl(
+            correction_ledger, correction_row
+        )
+        correction_receipt = {
+            **mixed_receipt,
+            "idempotency_key": reviewer_notification_idempotency_key(
+                repo="owner/repo",
+                pr_number=113,
+                sink_kind="lark_chat",
+                sink_instance_key=sink["sink_instance_key"],
+                reviewer_handles=["@map-owner"],
+            ),
+            "reviewer_handles": ["@map-owner"],
+        }
+        persist_issue_fix_reviewer_notification_state(
+            correction_ledger,
+            correction_row,
+            receipts=[],
+            queued_receipts=[correction_receipt],
+        )
+        fresh_lifecycle = build_issue_fix_pr_lifecycle_monitor_packet(
+            url="https://github.com/owner/repo/pull/113",
+            provider_payload={
+                "state": "OPEN",
+                "reviewDecision": "REVIEW_REQUIRED",
+                "mergeStateStatus": "BLOCKED",
+                "statusCheckRollup": [],
+            },
+        )
+
+        def correction_metadata_loader(
+            *, repo: str, number: int
+        ) -> tuple[dict[str, Any], None]:
+            assert (repo, number) == ("owner/repo", 113)
+            return {
+                "author_handle": "@author-j",
+                "reviewed_by": [],
+                "requested_reviewers": ["@map-owner"],
+                "comment_notified_reviewers": [],
+                "state": "OPEN",
+                "review_decision": "REVIEW_REQUIRED",
+                "state_bucket": "review_required",
+                "is_draft": False,
+                "linked_issue_refs": [],
+                "_lifecycle_packet": fresh_lifecycle,
+            }, None
+
+        correction_drain = drain_issue_fix_reviewer_notification_queue(
+            ledger_path=correction_ledger,
+            sinks_input=sinks_input,
+            execute=True,
+            delivery_observed_at="2026-07-18T01:01:00Z",
+            metadata_loader=correction_metadata_loader,
+            sink_adapters={"lark_chat": scoped_adapter},
+        )
+        assert correction_drain["status"] == "drained_verified", correction_drain
+        correction_stored = json.loads(
+            correction_ledger.read_text(encoding="utf-8").splitlines()[0]
+        )
+        assert correction_stored["transition"]["action_kind"] == (
+            "clarify_issue_fix_maintainer_correction"
+        )
+        assert correction_stored["grouped_monitor_projection"] == (
+            correction_row["grouped_monitor_projection"]
+        )
+        assert correction_stored["first_screen"] == correction_row["first_screen"]
+
         preview_ledger = path / "preview-blocked-pr-lifecycle.jsonl"
         preview_row = build_issue_fix_pr_lifecycle_monitor_packet(
             url="https://github.com/owner/repo/pull/108",

--- a/examples/issue-fix-reviewer-request-smoke.py
+++ b/examples/issue-fix-reviewer-request-smoke.py
@@ -1641,10 +1641,62 @@ def main() -> int:
             **goal_sink,
             "sink_instance_key": " openviking-reviewer-group-secondary ",
         }
+        drain_removed_sink = {
+            **goal_sink,
+            "sink_instance_key": "removed-reviewer-lane",
+        }
         drain_goal_config = {
             **goal_config,
             "sinks": [goal_sink, drain_sink_two],
         }
+
+        empty_drain = drain_issue_fix_reviewer_notification_queue(
+            ledger_path=path / ".loopx/domain-state/empty/pr-lifecycle.jsonl",
+            sinks_input=drain_goal_config,
+            execute=True,
+            delivery_observed_at="2026-07-18T01:01:00Z",
+        )
+        assert empty_drain["status"] == "no_due_notifications", empty_drain
+        assert empty_drain["external_reads_performed"] is False
+
+        legacy_ledger = path / ".loopx/domain-state/legacy/pr-lifecycle.jsonl"
+        legacy_row = build_issue_fix_pr_lifecycle_monitor_packet(
+            url="https://github.com/owner/repo/pull/100",
+            provider_payload={
+                "state": "OPEN",
+                "reviewDecision": "REVIEW_REQUIRED",
+                "mergeStateStatus": "BLOCKED",
+                "statusCheckRollup": [],
+            },
+        )
+        legacy_row["reviewer_notification_queue"] = [
+            {
+                "schema_version": (
+                    "issue_fix_reviewer_notification_queue_receipt_v0"
+                ),
+                "idempotency_key": "sha256:" + "e" * 64,
+                "sink_kind": "lark_chat",
+                "reviewer_handles": ["@map-owner"],
+                "queued_at": "2026-07-17T18:00:00Z",
+                "not_before": "2026-07-18T01:00:00Z",
+                "timezone": "Asia/Shanghai",
+                "allowed_local_time": {"start": "09:00", "end": "21:00"},
+                "status": "queued",
+            }
+        ]
+        upsert_issue_fix_pr_lifecycle_ledger_jsonl(legacy_ledger, legacy_row)
+        legacy_drain = drain_issue_fix_reviewer_notification_queue(
+            ledger_path=legacy_ledger,
+            sinks_input=drain_goal_config,
+            execute=True,
+            delivery_observed_at="2026-07-18T01:01:00Z",
+        )
+        assert legacy_drain["status"] == "blocked", legacy_drain
+        assert legacy_drain["blocker"] == (
+            "reviewer_notification_queue_v1_migration_required"
+        )
+        assert legacy_drain["legacy_queue_receipt_count"] == 1
+        assert legacy_drain["external_reads_performed"] is False
 
         def drain_adapter(**kwargs: Any) -> dict[str, Any]:
             assert kwargs["execute"] is True
@@ -1737,7 +1789,7 @@ def main() -> int:
             upsert_issue_fix_pr_lifecycle_ledger_jsonl(drain_ledger, lifecycle_row)
             queue_receipts = []
             sinks = (
-                [goal_sink, drain_sink_two]
+                [goal_sink, drain_sink_two, drain_removed_sink]
                 if number == 101
                 else [goal_sink]
             )
@@ -1791,6 +1843,7 @@ def main() -> int:
         assert drained["due_pr_count"] == 2
         assert drained["verified_pr_count"] == 1
         assert drained["cancelled_pr_count"] == 1
+        assert drained["cancelled_sink_receipt_count"] == 1
         assert drained["not_due_receipt_count"] == 1
         assert drain_calls == [
             {

--- a/examples/issue-fix-reviewer-request-smoke.py
+++ b/examples/issue-fix-reviewer-request-smoke.py
@@ -33,10 +33,14 @@ from loopx.capabilities.issue_fix.cli import (  # noqa: E402
     _materialize_goal_reviewer_notification_lifecycle,
 )
 from loopx.capabilities.issue_fix.reviewer_notification import (  # noqa: E402
+    reviewer_notification_idempotency_key,
     reviewer_notification_queue_from_state,
     reviewer_notification_receipts_from_state,
     with_reviewer_notification_state,
     with_reviewer_notification_receipts,
+)
+from loopx.capabilities.issue_fix.reviewer_notification_drain import (  # noqa: E402
+    drain_issue_fix_reviewer_notification_queue,
 )
 from loopx.capabilities.issue_fix.pr_lifecycle import (  # noqa: E402
     build_issue_fix_pr_lifecycle_monitor_packet,
@@ -144,6 +148,7 @@ def metadata(
         "isDraft": False,
         "reviewRequests": [{"login": login} for login in (requested or [])],
         "reviews": [{"author": {"login": login}} for login in (reviewed or [])],
+        "reviewDecision": "REVIEW_REQUIRED",
         "state": "OPEN",
         "title": "fix: reject file URI for consistency check",
         "url": "https://github.com/owner/repo/pull/42",
@@ -241,9 +246,7 @@ class FakeCombinedRunner:
             self.lark_calls.append(command)
             return {
                 "returncode": 0,
-                "stdout": json.dumps(
-                    {"items": [{"body": {"content": "another PR"}}]}
-                ),
+                "stdout": json.dumps({"items": [{"body": {"content": "another PR"}}]}),
                 "stderr": "",
             }
         if "+messages-send" in command:
@@ -1530,10 +1533,12 @@ def main() -> int:
 
         queued_key = "sha256:" + "b" * 64
         queued_receipt = {
-            "schema_version": "issue_fix_reviewer_notification_queue_receipt_v0",
+            "schema_version": "issue_fix_reviewer_notification_queue_receipt_v1",
             "idempotency_key": queued_key,
             "sink_kind": "lark_chat",
             "reviewer_handles": ["@map-owner"],
+            "message_summary": "修复一致性检查对文件 URI 的错误接受行为",
+            "summary_policy_status": "reward_memory_verified",
             "queued_at": "2026-07-10T14:30:00Z",
             "not_before": "2026-07-11T01:00:00Z",
             "timezone": "Asia/Shanghai",
@@ -1629,6 +1634,141 @@ def main() -> int:
             lifecycle_path.read_text(encoding="utf-8").splitlines()[0]
         )
         assert stored_after_cancel["reviewer_notification_queue"] == []
+
+        drain_ledger = path / ".loopx/domain-state/drain/pr-lifecycle.jsonl"
+        drain_calls: list[dict[str, Any]] = []
+
+        def drain_adapter(**kwargs: Any) -> dict[str, Any]:
+            assert kwargs["execute"] is True
+            assert "修复" in kwargs["pr_title"]
+            key = reviewer_notification_idempotency_key(
+                repo=kwargs["repo"],
+                pr_number=kwargs["pr_number"],
+                sink_kind=kwargs["sink"]["sink_kind"],
+                sink_instance_key=kwargs["sink"]["sink_instance_key"],
+                reviewer_handles=kwargs["reviewer_handles"],
+            )
+            drain_calls.append(
+                {"number": kwargs["pr_number"], "summary": kwargs["pr_title"]}
+            )
+            return {
+                "ok": True,
+                "schema_version": "issue_fix_reviewer_notification_sink_result_v0",
+                "sink_kind": "lark_chat",
+                "status": "sent_verified",
+                "reviewer_handles": list(kwargs["reviewer_handles"]),
+                "resolved_reviewer_count": len(kwargs["reviewer_handles"]),
+                "idempotency_key": key,
+                "identity_scope": "project_dedicated",
+                "external_write_authority_asserted": True,
+                "external_write_performed": True,
+                "verification_performed": True,
+                "notification_verified": True,
+                "bot_identity_verified": True,
+                "reader_identity_verified": True,
+                "private_destination_captured": False,
+                "private_member_ids_captured": False,
+                "private_bot_profile_captured": False,
+                "raw_provider_payload_captured": False,
+            }
+
+        drain_live = {
+            101: {
+                "author_handle": "@author-a",
+                "reviewed_by": [],
+                "state": "OPEN",
+                "review_decision": "REVIEW_REQUIRED",
+                "is_draft": False,
+                "linked_issue_refs": ["#91"],
+            },
+            102: {
+                "author_handle": "@author-b",
+                "reviewed_by": [],
+                "state": "OPEN",
+                "review_decision": "APPROVED",
+                "is_draft": False,
+                "linked_issue_refs": ["#92"],
+            },
+        }
+
+        def drain_metadata_loader(
+            *, repo: str, number: int
+        ) -> tuple[dict[str, Any] | None, str | None]:
+            assert repo == "owner/repo"
+            return dict(drain_live[number]), None
+
+        for number, not_before, summary in (
+            (101, "2026-07-18T01:00:00Z", "修复队列到点后无人消费的问题"),
+            (102, "2026-07-18T01:00:00Z", "修复已批准请求仍重复提醒的问题"),
+            (103, "2026-07-19T01:00:00Z", "修复未来窗口被提前发送的问题"),
+        ):
+            lifecycle_row = build_issue_fix_pr_lifecycle_monitor_packet(
+                url=f"https://github.com/owner/repo/pull/{number}",
+                provider_payload={
+                    "state": "OPEN",
+                    "reviewDecision": "REVIEW_REQUIRED",
+                    "mergeStateStatus": "BLOCKED",
+                    "statusCheckRollup": [],
+                },
+            )
+            upsert_issue_fix_pr_lifecycle_ledger_jsonl(drain_ledger, lifecycle_row)
+            key = reviewer_notification_idempotency_key(
+                repo="owner/repo",
+                pr_number=number,
+                sink_kind="lark_chat",
+                sink_instance_key=goal_sink["sink_instance_key"],
+                reviewer_handles=["@map-owner"],
+            )
+            queue_receipt = {
+                "schema_version": "issue_fix_reviewer_notification_queue_receipt_v1",
+                "idempotency_key": key,
+                "sink_kind": "lark_chat",
+                "reviewer_handles": ["@map-owner"],
+                "message_summary": summary,
+                "summary_policy_status": "reward_memory_verified",
+                "queued_at": "2026-07-17T18:00:00Z",
+                "not_before": not_before,
+                "timezone": "Asia/Shanghai",
+                "allowed_local_time": {"start": "09:00", "end": "21:00"},
+                "status": "queued",
+            }
+            persist_issue_fix_reviewer_notification_state(
+                drain_ledger,
+                lifecycle_row,
+                receipts=[],
+                queued_receipts=[queue_receipt],
+            )
+
+        drained = drain_issue_fix_reviewer_notification_queue(
+            ledger_path=drain_ledger,
+            sinks_input=goal_config,
+            execute=True,
+            delivery_observed_at="2026-07-18T01:01:00Z",
+            metadata_loader=drain_metadata_loader,
+            sink_adapters={"lark_chat": drain_adapter},
+        )
+        assert drained["ok"] is True, drained
+        assert drained["grouping_scope"] == "review_required_state_bucket"
+        assert drained["monitor_granularity"] == "one_monitor_per_state_bucket"
+        assert drained["notification_granularity"] == "one_pr_per_message"
+        assert drained["due_pr_count"] == 2
+        assert drained["verified_pr_count"] == 1
+        assert drained["cancelled_pr_count"] == 1
+        assert drained["not_due_receipt_count"] == 1
+        assert drain_calls == [
+            {"number": 101, "summary": "修复队列到点后无人消费的问题"}
+        ]
+        repeated_drain = drain_issue_fix_reviewer_notification_queue(
+            ledger_path=drain_ledger,
+            sinks_input=goal_config,
+            execute=True,
+            delivery_observed_at="2026-07-18T01:02:00Z",
+            metadata_loader=drain_metadata_loader,
+            sink_adapters={"lark_chat": drain_adapter},
+        )
+        assert repeated_drain["status"] == "no_due_notifications"
+        assert repeated_drain["due_pr_count"] == 0
+        assert len(drain_calls) == 1
     finally:
         for attempt in range(10):
             try:

--- a/examples/issue-fix-reviewer-request-smoke.py
+++ b/examples/issue-fix-reviewer-request-smoke.py
@@ -1116,6 +1116,27 @@ def main() -> int:
                 }
             ),
         )
+        legacy_request_lifecycle_path = default_issue_fix_domain_state_ledger_path(
+            project=path, goal_id=goal_id
+        )
+        legacy_request_row = build_issue_fix_pr_lifecycle_monitor_packet(
+            url="https://github.com/owner/repo/pull/42",
+            provider_payload={"state": "OPEN", "reviewDecision": "REVIEW_REQUIRED"},
+        )
+        legacy_request_row["reviewer_notification_queue"] = [
+            {
+                "schema_version": "issue_fix_reviewer_notification_queue_receipt_v0",
+                "idempotency_key": "sha256:" + "f" * 64,
+                "sink_kind": "lark_chat",
+                "reviewer_handles": ["@map-owner"],
+                "queued_at": "2026-07-17T18:00:00Z",
+                "not_before": "2026-07-18T01:00:00Z",
+                "timezone": "Asia/Shanghai",
+                "allowed_local_time": {"start": "09:00", "end": "21:00"},
+                "status": "queued",
+            }
+        ]
+        upsert_issue_fix_pr_lifecycle_ledger_jsonl(legacy_request_lifecycle_path, legacy_request_row)
         goal_default_cli = subprocess.run(
             [
                 sys.executable,
@@ -1154,7 +1175,14 @@ def main() -> int:
         )
         goal_default_packet = json.loads(goal_default_cli.stdout)
         assert goal_default_packet["secondary_notification_source"] == "goal_default"
-        assert goal_default_packet["secondary_notification_status"] == "preview_ready"
+        assert goal_default_packet["secondary_notification_status"] == "not_configured"
+        assert goal_default_packet["secondary_notification_blocker"] == (
+            "reviewer_notification_queue_v1_migration_required"
+        )
+        assert goal_default_packet["selected_reviewers"] == ["@map-owner"]
+        assert goal_default_packet["ok"] is True
+        assert goal_default_packet["review_request_performed"] is False
+        legacy_request_lifecycle_path.unlink()
         assert_public_safe(goal_default_packet)
 
         reward_application_calls: list[dict[str, Any]] = []

--- a/examples/issue-fix-reviewer-request-smoke.py
+++ b/examples/issue-fix-reviewer-request-smoke.py
@@ -1741,6 +1741,8 @@ def main() -> int:
             101: {
                 "author_handle": "@author-a",
                 "reviewed_by": ["@reviewed-owner"],
+                "requested_reviewers": ["@map-owner"],
+                "comment_notified_reviewers": [],
                 "state": "OPEN",
                 "review_decision": "REVIEW_REQUIRED",
                 "state_bucket": "checks_pending",
@@ -1750,6 +1752,8 @@ def main() -> int:
             102: {
                 "author_handle": "@author-b",
                 "reviewed_by": [],
+                "requested_reviewers": ["@map-owner"],
+                "comment_notified_reviewers": [],
                 "state": "OPEN",
                 "review_decision": "APPROVED",
                 "is_draft": False,
@@ -1758,11 +1762,24 @@ def main() -> int:
             103: {
                 "author_handle": "@author-c",
                 "reviewed_by": [],
+                "requested_reviewers": ["@map-owner"],
+                "comment_notified_reviewers": [],
                 "state": "OPEN",
                 "review_decision": "REVIEW_REQUIRED",
                 "state_bucket": "review_required",
                 "is_draft": False,
                 "linked_issue_refs": ["#93"],
+            },
+            104: {
+                "author_handle": "@author-d",
+                "reviewed_by": [],
+                "requested_reviewers": ["@other-owner"],
+                "comment_notified_reviewers": [],
+                "state": "OPEN",
+                "review_decision": "REVIEW_REQUIRED",
+                "state_bucket": "review_required",
+                "is_draft": False,
+                "linked_issue_refs": ["#94"],
             },
         }
 
@@ -1776,6 +1793,7 @@ def main() -> int:
             (101, "2026-07-18T01:00:00Z", "修复队列到点后无人消费的问题"),
             (102, "2026-07-18T01:00:00Z", "修复已批准请求仍重复提醒的问题"),
             (103, "2026-07-19T01:00:00Z", "修复未来窗口被提前发送的问题"),
+            (104, "2026-07-18T01:00:00Z", "修复 reviewer 换人后误提醒旧人的问题"),
         ):
             lifecycle_row = build_issue_fix_pr_lifecycle_monitor_packet(
                 url=f"https://github.com/owner/repo/pull/{number}",
@@ -1795,7 +1813,7 @@ def main() -> int:
             )
             for sink in sinks:
                 reviewers = (
-                    ["@reviewed-owner", "@map-owner"]
+                    ["@reviewed-owner", "@removed-owner", "@map-owner"]
                     if number == 101
                     else ["@map-owner"]
                 )
@@ -1840,11 +1858,13 @@ def main() -> int:
         assert drained["grouping_scope"] == "review_required_state_bucket"
         assert drained["monitor_granularity"] == "one_monitor_per_state_bucket"
         assert drained["notification_granularity"] == "one_pr_per_message"
-        assert drained["due_pr_count"] == 2
+        assert drained["due_pr_count"] == 3
         assert drained["verified_pr_count"] == 1
-        assert drained["cancelled_pr_count"] == 1
+        assert drained["cancelled_pr_count"] == 2
         assert drained["cancelled_sink_receipt_count"] == 1
         assert drained["not_due_receipt_count"] == 1
+        pr_101 = next(item for item in drained["items"] if item["pr_ref"] == "#101")
+        assert pr_101["inactive_reviewer_handles"] == ["@removed-owner"]
         assert drain_calls == [
             {
                 "number": 101,
@@ -1894,6 +1914,18 @@ def main() -> int:
         assert resumed_drain["verified_pr_count"] == 1
         assert drain_calls[-1]["number"] == 103
         assert len(drain_calls) == 3
+
+        subprocess.run(
+            [
+                sys.executable,
+                str(
+                    ROOT
+                    / "examples/issue-fix-reviewer-notification-drain-postwrite-smoke.py"
+                ),
+            ],
+            cwd=ROOT,
+            check=True,
+        )
     finally:
         for attempt in range(10):
             try:

--- a/examples/issue-fix-reviewer-request-smoke.py
+++ b/examples/issue-fix-reviewer-request-smoke.py
@@ -1637,6 +1637,14 @@ def main() -> int:
 
         drain_ledger = path / ".loopx/domain-state/drain/pr-lifecycle.jsonl"
         drain_calls: list[dict[str, Any]] = []
+        drain_sink_two = {
+            **goal_sink,
+            "sink_instance_key": "openviking-reviewer-group-secondary",
+        }
+        drain_goal_config = {
+            **goal_config,
+            "sinks": [goal_sink, drain_sink_two],
+        }
 
         def drain_adapter(**kwargs: Any) -> dict[str, Any]:
             assert kwargs["execute"] is True
@@ -1649,7 +1657,12 @@ def main() -> int:
                 reviewer_handles=kwargs["reviewer_handles"],
             )
             drain_calls.append(
-                {"number": kwargs["pr_number"], "summary": kwargs["pr_title"]}
+                {
+                    "number": kwargs["pr_number"],
+                    "summary": kwargs["pr_title"],
+                    "sink": kwargs["sink"]["sink_instance_key"],
+                    "reviewers": list(kwargs["reviewer_handles"]),
+                }
             )
             return {
                 "ok": True,
@@ -1675,7 +1688,7 @@ def main() -> int:
         drain_live = {
             101: {
                 "author_handle": "@author-a",
-                "reviewed_by": [],
+                "reviewed_by": ["@reviewed-owner"],
                 "state": "OPEN",
                 "review_decision": "REVIEW_REQUIRED",
                 "is_draft": False,
@@ -1712,36 +1725,50 @@ def main() -> int:
                 },
             )
             upsert_issue_fix_pr_lifecycle_ledger_jsonl(drain_ledger, lifecycle_row)
-            key = reviewer_notification_idempotency_key(
-                repo="owner/repo",
-                pr_number=number,
-                sink_kind="lark_chat",
-                sink_instance_key=goal_sink["sink_instance_key"],
-                reviewer_handles=["@map-owner"],
+            queue_receipts = []
+            sinks = (
+                [goal_sink, drain_sink_two]
+                if number == 101
+                else [goal_sink]
             )
-            queue_receipt = {
-                "schema_version": "issue_fix_reviewer_notification_queue_receipt_v1",
-                "idempotency_key": key,
-                "sink_kind": "lark_chat",
-                "reviewer_handles": ["@map-owner"],
-                "message_summary": summary,
-                "summary_policy_status": "reward_memory_verified",
-                "queued_at": "2026-07-17T18:00:00Z",
-                "not_before": not_before,
-                "timezone": "Asia/Shanghai",
-                "allowed_local_time": {"start": "09:00", "end": "21:00"},
-                "status": "queued",
-            }
+            for sink in sinks:
+                reviewers = (
+                    ["@reviewed-owner", "@map-owner"]
+                    if number == 101
+                    else ["@map-owner"]
+                )
+                key = reviewer_notification_idempotency_key(
+                    repo="owner/repo",
+                    pr_number=number,
+                    sink_kind="lark_chat",
+                    sink_instance_key=sink["sink_instance_key"],
+                    reviewer_handles=reviewers,
+                )
+                queue_receipts.append(
+                    {
+                        "schema_version": "issue_fix_reviewer_notification_queue_receipt_v1",
+                        "idempotency_key": key,
+                        "sink_kind": "lark_chat",
+                        "reviewer_handles": reviewers,
+                        "message_summary": summary,
+                        "summary_policy_status": "reward_memory_verified",
+                        "queued_at": "2026-07-17T18:00:00Z",
+                        "not_before": not_before,
+                        "timezone": "Asia/Shanghai",
+                        "allowed_local_time": {"start": "09:00", "end": "21:00"},
+                        "status": "queued",
+                    }
+                )
             persist_issue_fix_reviewer_notification_state(
                 drain_ledger,
                 lifecycle_row,
                 receipts=[],
-                queued_receipts=[queue_receipt],
+                queued_receipts=queue_receipts,
             )
 
         drained = drain_issue_fix_reviewer_notification_queue(
             ledger_path=drain_ledger,
-            sinks_input=goal_config,
+            sinks_input=drain_goal_config,
             execute=True,
             delivery_observed_at="2026-07-18T01:01:00Z",
             metadata_loader=drain_metadata_loader,
@@ -1756,11 +1783,22 @@ def main() -> int:
         assert drained["cancelled_pr_count"] == 1
         assert drained["not_due_receipt_count"] == 1
         assert drain_calls == [
-            {"number": 101, "summary": "修复队列到点后无人消费的问题"}
-        ]
+            {
+                "number": 101,
+                "summary": "修复队列到点后无人消费的问题",
+                "sink": "fixture-review-lane",
+                "reviewers": ["@map-owner"],
+            },
+            {
+                "number": 101,
+                "summary": "修复队列到点后无人消费的问题",
+                "sink": "openviking-reviewer-group-secondary",
+                "reviewers": ["@map-owner"],
+            },
+        ], drain_calls
         repeated_drain = drain_issue_fix_reviewer_notification_queue(
             ledger_path=drain_ledger,
-            sinks_input=goal_config,
+            sinks_input=drain_goal_config,
             execute=True,
             delivery_observed_at="2026-07-18T01:02:00Z",
             metadata_loader=drain_metadata_loader,
@@ -1768,7 +1806,7 @@ def main() -> int:
         )
         assert repeated_drain["status"] == "no_due_notifications"
         assert repeated_drain["due_pr_count"] == 0
-        assert len(drain_calls) == 1
+        assert len(drain_calls) == 2
     finally:
         for attempt in range(10):
             try:

--- a/examples/issue-fix-reviewer-request-smoke.py
+++ b/examples/issue-fix-reviewer-request-smoke.py
@@ -1756,6 +1756,7 @@ def main() -> int:
                 "comment_notified_reviewers": [],
                 "state": "OPEN",
                 "review_decision": "APPROVED",
+                "state_bucket": "ready_to_merge",
                 "is_draft": False,
                 "linked_issue_refs": ["#92"],
             },
@@ -1784,7 +1785,7 @@ def main() -> int:
         }
 
         def drain_metadata_loader(
-            *, repo: str, number: int
+            *, repo: str, number: int, runner: Any = None
         ) -> tuple[dict[str, Any] | None, str | None]:
             assert repo == "owner/repo"
             return dict(drain_live[number]), None
@@ -1865,6 +1866,21 @@ def main() -> int:
         assert drained["not_due_receipt_count"] == 1
         pr_101 = next(item for item in drained["items"] if item["pr_ref"] == "#101")
         assert pr_101["inactive_reviewer_handles"] == ["@removed-owner"]
+        stored_drain_rows = [
+            json.loads(line)
+            for line in drain_ledger.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        pr_102_row = next(
+            row
+            for row in stored_drain_rows
+            if row["observation"]["pr_ref"] == "pull_102"
+        )
+        assert pr_102_row["observation"]["review_decision"] == "APPROVED"
+        assert (
+            pr_102_row["grouped_monitor_projection"]["state_bucket"]
+            == "ready_to_merge"
+        )
         assert drain_calls == [
             {
                 "number": 101,

--- a/examples/issue-fix-reviewer-request-smoke.py
+++ b/examples/issue-fix-reviewer-request-smoke.py
@@ -1639,7 +1639,7 @@ def main() -> int:
         drain_calls: list[dict[str, Any]] = []
         drain_sink_two = {
             **goal_sink,
-            "sink_instance_key": "openviking-reviewer-group-secondary",
+            "sink_instance_key": " openviking-reviewer-group-secondary ",
         }
         drain_goal_config = {
             **goal_config,
@@ -1691,6 +1691,7 @@ def main() -> int:
                 "reviewed_by": ["@reviewed-owner"],
                 "state": "OPEN",
                 "review_decision": "REVIEW_REQUIRED",
+                "state_bucket": "checks_pending",
                 "is_draft": False,
                 "linked_issue_refs": ["#91"],
             },
@@ -1701,6 +1702,15 @@ def main() -> int:
                 "review_decision": "APPROVED",
                 "is_draft": False,
                 "linked_issue_refs": ["#92"],
+            },
+            103: {
+                "author_handle": "@author-c",
+                "reviewed_by": [],
+                "state": "OPEN",
+                "review_decision": "REVIEW_REQUIRED",
+                "state_bucket": "review_required",
+                "is_draft": False,
+                "linked_issue_refs": ["#93"],
             },
         }
 
@@ -1741,7 +1751,7 @@ def main() -> int:
                     repo="owner/repo",
                     pr_number=number,
                     sink_kind="lark_chat",
-                    sink_instance_key=sink["sink_instance_key"],
+                    sink_instance_key=sink["sink_instance_key"].strip(),
                     reviewer_handles=reviewers,
                 )
                 queue_receipts.append(
@@ -1792,7 +1802,7 @@ def main() -> int:
             {
                 "number": 101,
                 "summary": "修复队列到点后无人消费的问题",
-                "sink": "openviking-reviewer-group-secondary",
+                "sink": " openviking-reviewer-group-secondary ",
                 "reviewers": ["@map-owner"],
             },
         ], drain_calls
@@ -1807,6 +1817,30 @@ def main() -> int:
         assert repeated_drain["status"] == "no_due_notifications"
         assert repeated_drain["due_pr_count"] == 0
         assert len(drain_calls) == 2
+        held_drain = drain_issue_fix_reviewer_notification_queue(
+            ledger_path=drain_ledger,
+            sinks_input=drain_goal_config,
+            execute=True,
+            delivery_observed_at="2026-07-19T15:00:00Z",
+            metadata_loader=drain_metadata_loader,
+            sink_adapters={"lark_chat": drain_adapter},
+        )
+        assert held_drain["status"] == "held_outside_delivery_window", held_drain
+        assert held_drain["held_pr_count"] == 1
+        assert held_drain["external_reads_performed"] is False
+        assert len(drain_calls) == 2
+        resumed_drain = drain_issue_fix_reviewer_notification_queue(
+            ledger_path=drain_ledger,
+            sinks_input=drain_goal_config,
+            execute=True,
+            delivery_observed_at="2026-07-20T01:01:00Z",
+            metadata_loader=drain_metadata_loader,
+            sink_adapters={"lark_chat": drain_adapter},
+        )
+        assert resumed_drain["status"] == "drained_verified", resumed_drain
+        assert resumed_drain["verified_pr_count"] == 1
+        assert drain_calls[-1]["number"] == 103
+        assert len(drain_calls) == 3
     finally:
         for attempt in range(10):
             try:

--- a/examples/issue-fix-reviewer-request-smoke.py
+++ b/examples/issue-fix-reviewer-request-smoke.py
@@ -1881,6 +1881,15 @@ def main() -> int:
             pr_102_row["grouped_monitor_projection"]["state_bucket"]
             == "ready_to_merge"
         )
+        pr_101_row = next(
+            row
+            for row in stored_drain_rows
+            if row["observation"]["pr_ref"] == "pull_101"
+        )
+        assert (
+            pr_101_row["grouped_monitor_projection"]["state_bucket"]
+            == "checks_pending"
+        )
         assert drain_calls == [
             {
                 "number": 101,

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -51,6 +51,11 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "write_boundary": "one formal GitHub review request, or one reviewer-tagging comment only after confirmed permission denial; optional configured secondary sends consume local-private identity/destination data without copying it; no arbitrary comment, push, merge, or publish",
             },
             {
+                "command": "loopx issue-fix reviewer-notification-drain --goal-id <goal-id> --project <project> --execute --format json",
+                "purpose": "Drain one bounded review-required state bucket after live PR verification while preserving one PR per group message.",
+                "write_boundary": "verified configured secondary sends plus compact receipt or stale-queue state writeback; no per-PR continuous monitor, arbitrary comment, push, merge, or publish",
+            },
+            {
                 "command": "loopx issue-fix pr-lifecycle --url <github-pr-url> --goal-id <goal-id> --format json",
                 "purpose": "Project public PR lifecycle state into a successor, monitor continuation, user gate, or no-follow-up transition.",
                 "write_boundary": "writes compact project-local domain state when goal or ledger context is provided; no external comment, PR creation, merge, raw logs, or body/comment capture",
@@ -140,6 +145,11 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
             {
                 "schema_version": "issue_fix_reviewer_notification_sinks_result_v0",
                 "module": "loopx.capabilities.issue_fix.reviewer_notification",
+                "doc": "docs/capabilities/issue-fix/protocols/issue-fix-reviewer-notification-sinks-v0.md",
+            },
+            {
+                "schema_version": "issue_fix_reviewer_notification_drain_v0",
+                "module": "loopx.capabilities.issue_fix.reviewer_notification_drain",
                 "doc": "docs/capabilities/issue-fix/protocols/issue-fix-reviewer-notification-sinks-v0.md",
             },
             {

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -1579,7 +1579,7 @@ def handle_issue_fix_command(
                 "`acceptance-fixture`, `pr-lifecycle`, `pr-gate-reconcile`, `outcome`, `metrics`, "
                 "`metrics-supplement`, "
                 "`repository-snapshot`, `reviewer-plan`, "
-                "`reviewer-request`, "
+                "`reviewer-request`, `reviewer-notification-drain`, "
                 "`repo-branch-fixture`, or `caller-repo-branch`"
             )
     except Exception as exc:

--- a/loopx/capabilities/issue_fix/reviewer_cli.py
+++ b/loopx/capabilities/issue_fix/reviewer_cli.py
@@ -29,6 +29,9 @@ from .reviewer_notification import (
     reviewer_notification_receipts_from_state,
     with_reviewer_notification_state,
 )
+from .reviewer_notification_drain import (
+    drain_issue_fix_reviewer_notification_queue,
+)
 from .reviewer_recommendation import (
     build_issue_fix_reviewer_recommendation_packet,
     render_issue_fix_reviewer_recommendation_markdown,
@@ -44,7 +47,12 @@ AddFormat = Callable[[argparse.ArgumentParser], None]
 AddGeneratedAt = Callable[..., None]
 Renderer = Callable[[dict[str, object]], str]
 REVIEWER_COMMANDS = frozenset(
-    {"reviewer-plan", "reviewer-request", "reviewer-feedback-inbox"}
+    {
+        "reviewer-plan",
+        "reviewer-request",
+        "reviewer-notification-drain",
+        "reviewer-feedback-inbox",
+    }
 )
 
 
@@ -259,6 +267,30 @@ def register_issue_fix_reviewer_commands(
     )
     add_generated_at_arg(reviewer_request_parser, artifact="the request packet")
 
+    reviewer_drain_parser = issue_fix_sub.add_parser(
+        "reviewer-notification-drain",
+        help=(
+            "Drain one bounded batch of due reviewer notifications from the "
+            "grouped review-required state bucket, one PR per message."
+        ),
+    )
+    add_subcommand_format(reviewer_drain_parser)
+    reviewer_drain_parser.add_argument("--goal-id", required=True)
+    reviewer_drain_parser.add_argument("--project")
+    reviewer_drain_parser.add_argument("--limit", type=int, default=20)
+    reviewer_drain_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help=(
+            "Verify live PR state, deliver due messages, and persist semantic "
+            "receipts or stale-queue cancellation."
+        ),
+    )
+    add_generated_at_arg(
+        reviewer_drain_parser,
+        artifact="the grouped reviewer notification drain packet",
+    )
+
     reviewer_feedback_parser = issue_fix_sub.add_parser(
         "reviewer-feedback-inbox",
         help=(
@@ -326,6 +358,8 @@ def reviewer_renderer(command: str | None) -> Renderer:
         return render_issue_fix_reviewer_recommendation_markdown
     if command == "reviewer-feedback-inbox":
         return render_issue_fix_reviewer_feedback_inbox_markdown
+    if command == "reviewer-notification-drain":
+        return render_issue_fix_reviewer_notification_drain_markdown
     return render_issue_fix_reviewer_request_markdown
 
 
@@ -340,6 +374,25 @@ def render_issue_fix_reviewer_feedback_inbox_markdown(
                 f"- enabled: {packet.get('enabled')}",
                 f"- pending_count: {packet.get('pending_count')}",
                 f"- write_performed: {packet.get('write_performed')}",
+            ]
+        ).rstrip()
+        + "\n"
+    )
+
+
+def render_issue_fix_reviewer_notification_drain_markdown(
+    packet: dict[str, object],
+) -> str:
+    return (
+        "\n".join(
+            [
+                "# Issue-fix Reviewer Notification Drain",
+                "",
+                f"- status: {packet.get('status')}",
+                f"- due_pr_count: {packet.get('due_pr_count')}",
+                f"- verified_pr_count: {packet.get('verified_pr_count')}",
+                f"- cancelled_pr_count: {packet.get('cancelled_pr_count')}",
+                f"- blocked_pr_count: {packet.get('blocked_pr_count')}",
             ]
         ).rstrip()
         + "\n"
@@ -431,6 +484,45 @@ def handle_issue_fix_reviewer_command(
                 "source": "goal_default_lark_event_inbox",
             }
         return payload, render_issue_fix_reviewer_feedback_inbox_markdown
+
+    if args.issue_fix_command == "reviewer-notification-drain":
+        goal, requested_project = _load_goal_for_project(
+            registry_path=registry_path,
+            goal_id=args.goal_id,
+            project=args.project,
+        )
+        sinks_input = load_goal_reviewer_notification_sinks_input(
+            goal=goal,
+            project=requested_project,
+        )
+        if sinks_input is None:
+            payload = {
+                "ok": True,
+                "schema_version": "issue_fix_reviewer_notification_drain_v0",
+                "mode": "issue-fix-reviewer-notification-drain",
+                "status": "not_configured",
+                "due_pr_count": 0,
+                "verified_pr_count": 0,
+                "cancelled_pr_count": 0,
+                "blocked_pr_count": 0,
+                "external_reads_performed": False,
+                "external_writes_performed": False,
+                "state_write_performed": False,
+            }
+        else:
+            lifecycle_path = default_issue_fix_domain_state_ledger_path(
+                project=requested_project,
+                goal_id=args.goal_id,
+            )
+            payload = drain_issue_fix_reviewer_notification_queue(
+                ledger_path=lifecycle_path,
+                sinks_input=sinks_input,
+                execute=args.execute,
+                delivery_observed_at=delivery_observed_at,
+                limit=args.limit,
+            )
+            payload["notification_source"] = "goal_default"
+        return payload, render_issue_fix_reviewer_notification_drain_markdown
 
     if args.issue_fix_command != "reviewer-request":
         return None
@@ -536,15 +628,11 @@ def handle_issue_fix_reviewer_command(
                 except (OSError, ValueError):
                     semantic_history_status = "unavailable"
                 else:
-                    semantic_history_status = (
-                        "matched" if history_match else "no_match"
-                    )
+                    semantic_history_status = "matched" if history_match else "no_match"
                     if history_match:
                         notification_sinks_input = {
                             **notification_sinks_input,
-                            "_semantic_history_pr_refs": [
-                                str(reference["permalink"])
-                            ],
+                            "_semantic_history_pr_refs": [str(reference["permalink"])],
                         }
             else:
                 semantic_history_status = "not_applicable"
@@ -644,9 +732,7 @@ def handle_issue_fix_reviewer_command(
     payload["secondary_notification_lifecycle_materialized"] = (
         notification_lifecycle_materialized
     )
-    payload["secondary_notification_semantic_history_status"] = (
-        semantic_history_status
-    )
+    payload["secondary_notification_semantic_history_status"] = semantic_history_status
     payload["secondary_notification_receipts_persisted"] = False
     payload["secondary_notification_queue_persisted"] = False
     payload["secondary_notification_queue_reconciled"] = False

--- a/loopx/capabilities/issue_fix/reviewer_cli.py
+++ b/loopx/capabilities/issue_fix/reviewer_cli.py
@@ -584,6 +584,7 @@ def handle_issue_fix_reviewer_command(
     reviewer_notification_reward_memory: dict[str, Any] | None = None
     reward_memory_experiment_status = "not_configured"
     semantic_history_status = "not_checked"
+    legacy_queue_blocker: str | None = None
     if args.goal_id:
         goal, requested_project = _load_goal_for_project(
             registry_path=registry_path,
@@ -639,45 +640,55 @@ def handle_issue_fix_reviewer_command(
             if reviewer_notification_legacy_queue_from_state(
                 notification_lifecycle_packet
             ):
-                raise ValueError(
+                legacy_queue_blocker = (
                     "reviewer_notification_queue_v1_migration_required"
                 )
-            notification_sinks_input = with_reviewer_notification_state(
-                notification_sinks_input,
-                reviewer_notification_receipts_from_state(
-                    notification_lifecycle_packet
-                ),
-                reviewer_notification_queue_from_state(notification_lifecycle_packet),
-            )
-            existing_queued_receipts = reviewer_notification_queue_from_state(
-                notification_lifecycle_packet
-            )
-            lark_group_configured = any(
-                isinstance(sink, Mapping) and sink.get("sink_kind") == "lark_chat"
-                for sink in (notification_sinks_input.get("sinks") or [])
-            )
-            if lark_group_configured:
-                config_ref = str(
-                    notification_sinks_input.get("feedback_inbox_config")
-                    or ".loopx/config/lark/event-inbox.json"
-                )
-                try:
-                    history_match = lark_event_inbox_contains_text(
-                        project=requested_project,
-                        config_path=config_ref,
-                        text=str(reference["permalink"]),
-                    )
-                except (OSError, ValueError):
-                    semantic_history_status = "unavailable"
-                else:
-                    semantic_history_status = "matched" if history_match else "no_match"
-                    if history_match:
-                        notification_sinks_input = {
-                            **notification_sinks_input,
-                            "_semantic_history_pr_refs": [str(reference["permalink"])],
-                        }
+                notification_sinks_input = None
+                semantic_history_status = "blocked_v1_migration_required"
             else:
-                semantic_history_status = "not_applicable"
+                notification_sinks_input = with_reviewer_notification_state(
+                    notification_sinks_input,
+                    reviewer_notification_receipts_from_state(
+                        notification_lifecycle_packet
+                    ),
+                    reviewer_notification_queue_from_state(
+                        notification_lifecycle_packet
+                    ),
+                )
+                existing_queued_receipts = reviewer_notification_queue_from_state(
+                    notification_lifecycle_packet
+                )
+                lark_group_configured = any(
+                    isinstance(sink, Mapping)
+                    and sink.get("sink_kind") == "lark_chat"
+                    for sink in (notification_sinks_input.get("sinks") or [])
+                )
+                if lark_group_configured:
+                    config_ref = str(
+                        notification_sinks_input.get("feedback_inbox_config")
+                        or ".loopx/config/lark/event-inbox.json"
+                    )
+                    try:
+                        history_match = lark_event_inbox_contains_text(
+                            project=requested_project,
+                            config_path=config_ref,
+                            text=str(reference["permalink"]),
+                        )
+                    except (OSError, ValueError):
+                        semantic_history_status = "unavailable"
+                    else:
+                        semantic_history_status = (
+                            "matched" if history_match else "no_match"
+                        )
+                        if history_match:
+                            notification_sinks_input = {
+                                **notification_sinks_input,
+                                "_semantic_history_pr_refs": [
+                                    str(reference["permalink"])
+                                ],
+                            }
+                else:
+                    semantic_history_status = "not_applicable"
         reward_policy = reward_memory_goal_policy(goal)
         reviewer_artifact_required = bool(notification_sinks_input) and (
             reward_policy["enabled"] is True
@@ -775,6 +786,8 @@ def handle_issue_fix_reviewer_command(
         notification_lifecycle_materialized
     )
     payload["secondary_notification_semantic_history_status"] = semantic_history_status
+    if legacy_queue_blocker is not None:
+        payload["secondary_notification_blocker"] = legacy_queue_blocker
     payload["secondary_notification_receipts_persisted"] = False
     payload["secondary_notification_queue_persisted"] = False
     payload["secondary_notification_queue_reconciled"] = False

--- a/loopx/capabilities/issue_fix/reviewer_cli.py
+++ b/loopx/capabilities/issue_fix/reviewer_cli.py
@@ -25,6 +25,7 @@ from .metadata_preview import normalise_github_issue_reference
 from .pr_lifecycle import build_issue_fix_pr_lifecycle_monitor_packet
 from .reviewer_notification import (
     load_goal_reviewer_notification_sinks_input,
+    reviewer_notification_legacy_queue_from_state,
     reviewer_notification_queue_from_state,
     reviewer_notification_receipts_from_state,
     with_reviewer_notification_state,
@@ -600,6 +601,12 @@ def handle_issue_fix_reviewer_command(
                             "external send"
                         ) from None
                     notification_lifecycle_materialized = True
+            if reviewer_notification_legacy_queue_from_state(
+                notification_lifecycle_packet
+            ):
+                raise ValueError(
+                    "reviewer_notification_queue_v1_migration_required"
+                )
             notification_sinks_input = with_reviewer_notification_state(
                 notification_sinks_input,
                 reviewer_notification_receipts_from_state(

--- a/loopx/capabilities/issue_fix/reviewer_cli.py
+++ b/loopx/capabilities/issue_fix/reviewer_cli.py
@@ -394,6 +394,7 @@ def render_issue_fix_reviewer_notification_drain_markdown(
                 f"- verified_pr_count: {packet.get('verified_pr_count')}",
                 f"- cancelled_pr_count: {packet.get('cancelled_pr_count')}",
                 f"- blocked_pr_count: {packet.get('blocked_pr_count')}",
+                f"- remaining_due_pr_count: {packet.get('remaining_due_pr_count')}",
             ]
         ).rstrip()
         + "\n"
@@ -506,6 +507,8 @@ def handle_issue_fix_reviewer_command(
                 "verified_pr_count": 0,
                 "cancelled_pr_count": 0,
                 "blocked_pr_count": 0,
+                "remaining_due_pr_count": 0,
+                "has_more_due": False,
                 "external_reads_performed": False,
                 "external_writes_performed": False,
                 "state_write_performed": False,
@@ -521,15 +524,28 @@ def handle_issue_fix_reviewer_command(
             )
             semantic_history_matcher = None
             if lark_group_configured:
-                config_ref = str(
+                default_config_ref = str(
                     sinks_input.get("feedback_inbox_config")
                     or ".loopx/config/lark/event-inbox.json"
                 )
+                lark_sink_count = sum(
+                    1
+                    for sink in (sinks_input.get("sinks") or [])
+                    if isinstance(sink, Mapping)
+                    and sink.get("sink_kind") == "lark_chat"
+                )
 
-                def semantic_history_matcher(permalink: str) -> bool:
+                def semantic_history_matcher(
+                    permalink: str, sink: Mapping[str, Any]
+                ) -> bool | None:
+                    sink_config_ref = str(
+                        sink.get("feedback_inbox_config") or ""
+                    ).strip()
+                    if not sink_config_ref and lark_sink_count != 1:
+                        return None
                     return lark_event_inbox_contains_text(
                         project=requested_project,
-                        config_path=config_ref,
+                        config_path=sink_config_ref or default_config_ref,
                         text=permalink,
                     )
 

--- a/loopx/capabilities/issue_fix/reviewer_cli.py
+++ b/loopx/capabilities/issue_fix/reviewer_cli.py
@@ -515,12 +515,31 @@ def handle_issue_fix_reviewer_command(
                 project=requested_project,
                 goal_id=args.goal_id,
             )
+            lark_group_configured = any(
+                isinstance(sink, Mapping) and sink.get("sink_kind") == "lark_chat"
+                for sink in (sinks_input.get("sinks") or [])
+            )
+            semantic_history_matcher = None
+            if lark_group_configured:
+                config_ref = str(
+                    sinks_input.get("feedback_inbox_config")
+                    or ".loopx/config/lark/event-inbox.json"
+                )
+
+                def semantic_history_matcher(permalink: str) -> bool:
+                    return lark_event_inbox_contains_text(
+                        project=requested_project,
+                        config_path=config_ref,
+                        text=permalink,
+                    )
+
             payload = drain_issue_fix_reviewer_notification_queue(
                 ledger_path=lifecycle_path,
                 sinks_input=sinks_input,
                 execute=args.execute,
                 delivery_observed_at=delivery_observed_at,
                 limit=args.limit,
+                semantic_history_matcher=semantic_history_matcher,
             )
             payload["notification_source"] = "goal_default"
         return payload, render_issue_fix_reviewer_notification_drain_markdown

--- a/loopx/capabilities/issue_fix/reviewer_notification.py
+++ b/loopx/capabilities/issue_fix/reviewer_notification.py
@@ -30,6 +30,9 @@ ISSUE_FIX_REVIEWER_NOTIFICATION_SINK_RESULT_SCHEMA_VERSION = (
 ISSUE_FIX_REVIEWER_NOTIFICATION_QUEUE_RECEIPT_SCHEMA_VERSION = (
     "issue_fix_reviewer_notification_queue_receipt_v1"
 )
+ISSUE_FIX_REVIEWER_NOTIFICATION_LEGACY_QUEUE_RECEIPT_SCHEMA_VERSION = (
+    "issue_fix_reviewer_notification_queue_receipt_v0"
+)
 LARK_PERMISSION_PATTERN = re.compile(
     r"(?:missing\s+scope|permission|not\s+in\s+(?:the\s+)?chat|"
     r"lacks?\s+authority|99991672|230027|232033)",
@@ -160,6 +163,30 @@ def reviewer_notification_queue_from_state(
         if (
             value.get("schema_version")
             != ISSUE_FIX_REVIEWER_NOTIFICATION_QUEUE_RECEIPT_SCHEMA_VERSION
+            or not re.fullmatch(r"sha256:[a-f0-9]{64}", key)
+            or key in seen
+        ):
+            continue
+        queue.append(dict(value))
+        seen.add(key)
+    return queue
+
+
+def reviewer_notification_legacy_queue_from_state(
+    packet: Mapping[str, Any] | None,
+) -> list[dict[str, Any]]:
+    """Detect pre-cutover rows without interpreting them as deliverable work."""
+
+    values = packet.get("reviewer_notification_queue") if packet else []
+    queue: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for value in values if isinstance(values, list) else []:
+        if not isinstance(value, Mapping):
+            continue
+        key = str(value.get("idempotency_key") or "")
+        if (
+            value.get("schema_version")
+            != ISSUE_FIX_REVIEWER_NOTIFICATION_LEGACY_QUEUE_RECEIPT_SCHEMA_VERSION
             or not re.fullmatch(r"sha256:[a-f0-9]{64}", key)
             or key in seen
         ):

--- a/loopx/capabilities/issue_fix/reviewer_notification.py
+++ b/loopx/capabilities/issue_fix/reviewer_notification.py
@@ -28,7 +28,7 @@ ISSUE_FIX_REVIEWER_NOTIFICATION_SINK_RESULT_SCHEMA_VERSION = (
     "issue_fix_reviewer_notification_sink_result_v0"
 )
 ISSUE_FIX_REVIEWER_NOTIFICATION_QUEUE_RECEIPT_SCHEMA_VERSION = (
-    "issue_fix_reviewer_notification_queue_receipt_v0"
+    "issue_fix_reviewer_notification_queue_receipt_v1"
 )
 LARK_PERMISSION_PATTERN = re.compile(
     r"(?:missing\s+scope|permission|not\s+in\s+(?:the\s+)?chat|"
@@ -124,9 +124,7 @@ def load_goal_reviewer_notification_sinks_input(
         if sink.get("sink_kind") == "lark_chat" and not (
             SAFE_LOCAL_KEY_PATTERN.fullmatch(str(sink.get("reader_profile") or ""))
             and sink.get("reader_identity") == "user"
-            and SAFE_LOCAL_KEY_PATTERN.fullmatch(
-                str(sink.get("sender_profile") or "")
-            )
+            and SAFE_LOCAL_KEY_PATTERN.fullmatch(str(sink.get("sender_profile") or ""))
             and sink.get("sender_identity") == "bot"
         ):
             raise ValueError(
@@ -181,10 +179,7 @@ def with_reviewer_notification_state(
     )
     for value in sinks_input.get("receipts") or []:
         text = str(value)
-        if (
-            re.fullmatch(r"sha256:[a-f0-9]{64}", text)
-            and text not in merged_receipts
-        ):
+        if re.fullmatch(r"sha256:[a-f0-9]{64}", text) and text not in merged_receipts:
             merged_receipts.append(text)
 
     queue = reviewer_notification_queue_from_state(
@@ -277,6 +272,32 @@ def _idempotency_key(
     return f"sha256:{hashlib.sha256(logical_effect.encode('utf-8')).hexdigest()}"
 
 
+def reviewer_notification_idempotency_key(
+    *,
+    repo: str,
+    pr_number: int,
+    sink_kind: str,
+    sink_instance_key: str,
+    reviewer_handles: Sequence[str],
+) -> str:
+    """Return the public logical-effect key used by queue/drain reconciliation."""
+
+    reviewers = list(
+        dict.fromkeys(
+            handle
+            for value in reviewer_handles
+            if (handle := _normalise_handle(value)) is not None
+        )
+    )[:3]
+    return _idempotency_key(
+        repo=public_safe_compact_text(repo, limit=200),
+        pr_number=int(pr_number),
+        sink_kind=public_safe_compact_text(sink_kind, limit=50),
+        sink_instance_key=str(sink_instance_key),
+        reviewer_handles=reviewers,
+    )
+
+
 def _parse_delivery_observed_at(value: str | None) -> datetime:
     if value is None:
         return datetime.now(timezone.utc)
@@ -325,9 +346,7 @@ def _delivery_window_decision(
     end = time.fromisoformat(end_text)
     current = local.timetz().replace(tzinfo=None)
     allowed = (
-        start <= current < end
-        if start < end
-        else current >= start or current < end
+        start <= current < end if start < end else current >= start or current < end
     )
     decision: dict[str, Any] = {
         "configured": True,
@@ -344,9 +363,7 @@ def _delivery_window_decision(
         if local >= next_start:
             next_start += timedelta(days=1)
         decision["not_before"] = (
-            next_start.astimezone(timezone.utc)
-            .isoformat()
-            .replace("+00:00", "Z")
+            next_start.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
         )
     return decision
 
@@ -358,6 +375,8 @@ def _queued_result(
     sink_kind: str,
     sink_instance_key: str,
     reviewer_handles: Sequence[str],
+    message_summary: str,
+    summary_policy_status: str,
     execute: bool,
     window: Mapping[str, Any],
 ) -> dict[str, Any]:
@@ -393,6 +412,10 @@ def _queued_result(
         "idempotency_key": key,
         "sink_kind": sink_kind,
         "reviewer_handles": list(reviewer_handles),
+        "message_summary": public_safe_compact_text(message_summary, limit=240),
+        "summary_policy_status": public_safe_compact_text(
+            summary_policy_status, limit=80
+        ),
         "queued_at": window["observed_at"],
         "not_before": window["not_before"],
         "timezone": window["timezone"],
@@ -539,9 +562,7 @@ def _lark_result(
     )
     reader_profile = str(sink.get("reader_profile") or "").strip()
     reader_identity = str(sink.get("reader_identity") or "").strip()
-    profile = str(
-        sink.get("sender_profile") or sink.get("bot_profile") or ""
-    ).strip()
+    profile = str(sink.get("sender_profile") or sink.get("bot_profile") or "").strip()
     sender_identity = str(sink.get("sender_identity") or "bot").strip()
     expected_bot_name = public_safe_compact_text(
         sink.get("bot_display_name"),
@@ -775,8 +796,7 @@ def _lark_result(
             semantic_dedupe_status = "configured_chat_no_match"
         else:
             provider_error = " ".join(
-                str(semantic_search.get(field) or "")
-                for field in ("stderr", "stdout")
+                str(semantic_search.get(field) or "") for field in ("stderr", "stdout")
             )
             if LARK_SEARCH_PERMISSION_PATTERN.search(provider_error):
                 semantic_dedupe_status = "permission_fallback"
@@ -857,8 +877,7 @@ def _lark_result(
             sender_members = {"returncode": 1}
         if sender_members.get("returncode") != 0:
             provider_error = " ".join(
-                str(sender_members.get(field) or "")
-                for field in ("stderr", "stdout")
+                str(sender_members.get(field) or "") for field in ("stderr", "stdout")
             )
             return _public_result(
                 sink_kind=sink_kind,
@@ -901,7 +920,9 @@ def _lark_result(
     )
     summary = f"：{pr_title}" if pr_title else ""
     content = json.dumps(
-        {"text": f"{mentions} 请帮忙 review PR #{pr_number}{issue_clause}{summary}。{pr_url}"},
+        {
+            "text": f"{mentions} 请帮忙 review PR #{pr_number}{issue_clause}{summary}。{pr_url}"
+        },
         ensure_ascii=False,
         separators=(",", ":"),
     )
@@ -1083,6 +1104,9 @@ def validate_issue_fix_reviewer_notification_sinks_result(
             or receipt.get("status") != "queued"
             or not public_safe_compact_text(receipt.get("sink_kind"), limit=50)
             or not isinstance(receipt.get("reviewer_handles"), list)
+            or not public_safe_compact_text(receipt.get("message_summary"), limit=240)
+            or receipt.get("summary_policy_status")
+            not in {"reward_memory_verified", "sink_config"}
             or not isinstance(window, Mapping)
             or not LOCAL_TIME_PATTERN.fullmatch(str(window.get("start") or ""))
             or not LOCAL_TIME_PATTERN.fullmatch(str(window.get("end") or ""))
@@ -1142,9 +1166,7 @@ def build_issue_fix_reviewer_notification_sinks_result(
 
     author = _normalise_handle(author_handle)
     title = _humanize_pr_title(pr_title)
-    artifact_gate = reviewer_artifact_notification_gate(
-        reviewer_artifact_application
-    )
+    artifact_gate = reviewer_artifact_notification_gate(reviewer_artifact_application)
     before_send_gate = reviewer_notification_before_send_gate(
         reviewer_notification_policy_application,
         repo=repo,
@@ -1160,8 +1182,7 @@ def build_issue_fix_reviewer_notification_sinks_result(
     if artifact_gate["passed"] is True and not (
         artifact.get("repo") == public_safe_compact_text(repo, limit=200)
         and artifact.get("pr_ref") == f"#{int(pr_number)}"
-        and artifact.get("permalink")
-        == public_safe_compact_text(pr_url, limit=300)
+        and artifact.get("permalink") == public_safe_compact_text(pr_url, limit=300)
     ):
         artifact_gate = {
             **artifact_gate,
@@ -1332,6 +1353,12 @@ def build_issue_fix_reviewer_notification_sinks_result(
                     sink_kind=sink_kind,
                     sink_instance_key=sink_instance_key,
                     reviewer_handles=reviewers,
+                    message_summary=title or "待代码审查",
+                    summary_policy_status=(
+                        "reward_memory_verified"
+                        if artifact_gate["passed"] is True
+                        else "sink_config"
+                    ),
                     execute=execute,
                     window=delivery_window,
                 )

--- a/loopx/capabilities/issue_fix/reviewer_notification.py
+++ b/loopx/capabilities/issue_fix/reviewer_notification.py
@@ -319,8 +319,8 @@ def reviewer_notification_idempotency_key(
     return _idempotency_key(
         repo=public_safe_compact_text(repo, limit=200),
         pr_number=int(pr_number),
-        sink_kind=public_safe_compact_text(sink_kind, limit=50),
-        sink_instance_key=str(sink_instance_key),
+        sink_kind=public_safe_compact_text(sink_kind, limit=50).strip(),
+        sink_instance_key=str(sink_instance_key).strip(),
         reviewer_handles=reviewers,
     )
 

--- a/loopx/capabilities/issue_fix/reviewer_notification.py
+++ b/loopx/capabilities/issue_fix/reviewer_notification.py
@@ -1327,32 +1327,24 @@ def build_issue_fix_reviewer_notification_sinks_result(
     results: list[dict[str, Any]] = []
     for sink in sinks:
         sink_kind = str(sink.get("sink_kind") or "").strip()
+        sink_instance_key = str(sink.get("sink_instance_key") or "").strip()
+        current_key = (
+            _idempotency_key(
+                repo=repo,
+                pr_number=int(pr_number),
+                sink_kind=sink_kind,
+                sink_instance_key=sink_instance_key,
+                reviewer_handles=reviewers,
+            )
+            if sink_kind and SAFE_LOCAL_KEY_PATTERN.fullmatch(sink_instance_key)
+            else None
+        )
         if sink_kind == "lark_chat" and pr_url in semantic_history_pr_refs:
-            sink_instance_key = str(sink.get("sink_instance_key") or "").strip()
-            if SAFE_LOCAL_KEY_PATTERN.fullmatch(sink_instance_key):
-                receipts.add(
-                    _idempotency_key(
-                        repo=repo,
-                        pr_number=int(pr_number),
-                        sink_kind=sink_kind,
-                        sink_instance_key=sink_instance_key,
-                        reviewer_handles=reviewers,
-                    )
-                )
+            if current_key:
+                receipts.add(current_key)
         adapter = adapters.get(sink_kind)
         if adapter and execute and not delivery_window["allowed"]:
-            sink_instance_key = str(sink.get("sink_instance_key") or "").strip()
-            queued_key = (
-                _idempotency_key(
-                    repo=repo,
-                    pr_number=int(pr_number),
-                    sink_kind=sink_kind,
-                    sink_instance_key=sink_instance_key,
-                    reviewer_handles=reviewers,
-                )
-                if SAFE_LOCAL_KEY_PATTERN.fullmatch(sink_instance_key)
-                else None
-            )
+            queued_key = current_key
             if queued_key and queued_key in receipts:
                 result = _public_result(
                     sink_kind=sink_kind,
@@ -1412,6 +1404,8 @@ def build_issue_fix_reviewer_notification_sinks_result(
                 external_write_authority_asserted=execute,
                 blocker="reviewer_notification_sink_unsupported",
             )
+        if result.get("idempotency_key") is None and current_key:
+            result = {**result, "idempotency_key": current_key}
         results.append(result)
 
     successful_receipts = list(

--- a/loopx/capabilities/issue_fix/reviewer_notification_drain.py
+++ b/loopx/capabilities/issue_fix/reviewer_notification_drain.py
@@ -1,0 +1,405 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from ...domain_packs.issue_fix import (
+    persist_issue_fix_reviewer_notification_state,
+)
+from .cli_input import load_jsonl_rows
+from .reviewer_notification import (
+    CommandRunner,
+    NotificationSinkAdapter,
+    build_issue_fix_reviewer_notification_sinks_result,
+    reviewer_notification_idempotency_key,
+    reviewer_notification_queue_from_state,
+    reviewer_notification_receipts_from_state,
+    with_reviewer_notification_state,
+)
+from .reviewer_request import fetch_issue_fix_reviewer_notification_metadata
+
+
+ISSUE_FIX_REVIEWER_NOTIFICATION_DRAIN_SCHEMA_VERSION = (
+    "issue_fix_reviewer_notification_drain_v0"
+)
+MetadataLoader = Callable[..., tuple[Optional[dict[str, Any]], Optional[str]]]
+
+
+def _parse_timestamp(value: str | None) -> datetime:
+    if value is None:
+        return datetime.now(timezone.utc)
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("delivery_observed_at must be an ISO timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError("delivery_observed_at must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def _latest_lifecycle_rows(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    latest: dict[tuple[str, str], dict[str, Any]] = {}
+    for raw in rows:
+        observation = raw.get("observation")
+        if not isinstance(observation, Mapping):
+            continue
+        repo = str(observation.get("repo") or "").strip()
+        pr_ref = str(observation.get("pr_ref") or "").strip()
+        if repo and pr_ref:
+            latest[(repo, pr_ref)] = dict(raw)
+    return list(latest.values())
+
+
+def _queue_due(receipt: Mapping[str, Any], observed_at: datetime) -> bool:
+    try:
+        not_before = _parse_timestamp(str(receipt.get("not_before") or ""))
+    except ValueError:
+        return False
+    return not_before <= observed_at
+
+
+def _matching_sinks(
+    *,
+    sinks_input: Mapping[str, Any],
+    repo: str,
+    number: int,
+    queue: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    queued_keys = {str(receipt.get("idempotency_key") or "") for receipt in queue}
+    matches: list[dict[str, Any]] = []
+    for raw_sink in sinks_input.get("sinks") or []:
+        if not isinstance(raw_sink, Mapping):
+            continue
+        sink = dict(raw_sink)
+        sink_kind = str(sink.get("sink_kind") or "")
+        sink_instance_key = str(sink.get("sink_instance_key") or "")
+        for receipt in queue:
+            reviewers = receipt.get("reviewer_handles")
+            reviewers = reviewers if isinstance(reviewers, list) else []
+            try:
+                key = reviewer_notification_idempotency_key(
+                    repo=repo,
+                    pr_number=number,
+                    sink_kind=sink_kind,
+                    sink_instance_key=sink_instance_key,
+                    reviewer_handles=reviewers,
+                )
+            except (TypeError, ValueError):
+                continue
+            if key in queued_keys and key == receipt.get("idempotency_key"):
+                matches.append(sink)
+                break
+    return matches
+
+
+def drain_issue_fix_reviewer_notification_queue(
+    *,
+    ledger_path: str | Path,
+    sinks_input: Mapping[str, Any],
+    execute: bool = False,
+    delivery_observed_at: str | None = None,
+    limit: int = 20,
+    runner: CommandRunner | None = None,
+    metadata_loader: MetadataLoader = fetch_issue_fix_reviewer_notification_metadata,
+    sink_adapters: Mapping[str, NotificationSinkAdapter] | None = None,
+) -> dict[str, Any]:
+    """Drain one bounded state-group batch while emitting at most one message per PR."""
+
+    if not 1 <= int(limit) <= 100:
+        raise ValueError("reviewer notification drain limit must be between 1 and 100")
+    observed_at = _parse_timestamp(delivery_observed_at)
+    observed_text = observed_at.isoformat().replace("+00:00", "Z")
+    rows = _latest_lifecycle_rows(load_jsonl_rows(Path(ledger_path)))
+    queued_rows: list[tuple[datetime, str, int, dict[str, Any]]] = []
+    queued_count = 0
+    not_due_count = 0
+    for row in rows:
+        queue = reviewer_notification_queue_from_state(row)
+        if not queue:
+            continue
+        queued_count += len(queue)
+        due = [receipt for receipt in queue if _queue_due(receipt, observed_at)]
+        not_due_count += len(queue) - len(due)
+        if not due:
+            continue
+        observation = row.get("observation")
+        observation = observation if isinstance(observation, Mapping) else {}
+        number = observation.get("number")
+        repo = str(observation.get("repo") or "")
+        if not isinstance(number, int) or not repo:
+            continue
+        first_due = min(_parse_timestamp(str(item["not_before"])) for item in due)
+        queued_rows.append((first_due, repo, number, row))
+    queued_rows.sort(key=lambda value: (value[0], value[1], value[2]))
+
+    items: list[dict[str, Any]] = []
+    write_performed = False
+    external_reads = False
+    external_writes = False
+    blocked_count = 0
+    cancelled_count = 0
+    verified_count = 0
+    for _, repo, number, row in queued_rows[: int(limit)]:
+        observation = row.get("observation")
+        observation = observation if isinstance(observation, Mapping) else {}
+        permalink = str(
+            observation.get("permalink") or f"https://github.com/{repo}/pull/{number}"
+        )
+        full_queue = reviewer_notification_queue_from_state(row)
+        due_queue = [
+            receipt for receipt in full_queue if _queue_due(receipt, observed_at)
+        ]
+        future_queue = [
+            receipt for receipt in full_queue if not _queue_due(receipt, observed_at)
+        ]
+        reviewers = list(
+            dict.fromkeys(
+                str(handle)
+                for receipt in due_queue
+                for handle in receipt.get("reviewer_handles") or []
+            )
+        )
+        summaries = list(
+            dict.fromkeys(
+                str(receipt.get("message_summary") or "") for receipt in due_queue
+            )
+        )
+        item: dict[str, Any] = {
+            "repo": repo,
+            "pr_ref": f"#{number}",
+            "permalink": permalink,
+            "reviewer_handles": reviewers,
+            "queued_receipt_count": len(due_queue),
+            "status": "preview_due",
+            "live_state_verified": False,
+            "notification_verified": False,
+            "external_write_performed": False,
+            "queue_write_performed": False,
+        }
+        if len(summaries) != 1 or not summaries[0]:
+            item.update(
+                status="blocked",
+                blocker="reviewer_notification_queue_summary_invalid",
+            )
+            blocked_count += 1
+            items.append(item)
+            continue
+        if len(due_queue) != 1:
+            item.update(
+                status="blocked",
+                blocker="reviewer_notification_queue_granularity_invalid",
+            )
+            blocked_count += 1
+            items.append(item)
+            continue
+        item["message_summary"] = summaries[0]
+        if not execute:
+            items.append(item)
+            continue
+
+        external_reads = True
+        kwargs: dict[str, Any] = {"repo": repo, "number": number}
+        if runner is not None:
+            kwargs["runner"] = runner
+        metadata, metadata_error = metadata_loader(**kwargs)
+        if metadata is None:
+            item.update(
+                status="blocked",
+                blocker=metadata_error or "github_pr_metadata_unavailable",
+            )
+            blocked_count += 1
+            items.append(item)
+            continue
+        live_state = str(metadata.get("state") or "UNKNOWN").upper()
+        live_review_decision = str(metadata.get("review_decision") or "UNKNOWN").upper()
+        live_state_bucket = str(metadata.get("state_bucket") or "unknown")
+        live_reviewed = {str(value) for value in metadata.get("reviewed_by") or []}
+        item.update(
+            live_state=live_state,
+            live_review_decision=live_review_decision,
+            live_state_bucket=live_state_bucket,
+            live_state_verified=True,
+        )
+        if live_state == "UNKNOWN" or live_review_decision == "UNKNOWN":
+            item.update(
+                status="blocked",
+                blocker="github_pr_live_state_incomplete",
+            )
+            blocked_count += 1
+            items.append(item)
+            continue
+        stale_reason = None
+        if live_state != "OPEN":
+            stale_reason = "pr_not_open"
+        elif metadata.get("is_draft") is True:
+            stale_reason = "pr_is_draft"
+        elif live_review_decision != "REVIEW_REQUIRED":
+            stale_reason = "review_no_longer_required"
+        elif live_reviewed.intersection(reviewers):
+            stale_reason = "queued_reviewer_already_reviewed"
+        elif live_state_bucket not in {"review_required", "unknown"}:
+            stale_reason = "pr_left_review_required_bucket"
+        if stale_reason:
+            try:
+                write = persist_issue_fix_reviewer_notification_state(
+                    ledger_path,
+                    row,
+                    receipts=[],
+                    queued_receipts=[],
+                    replace_queued_receipts=True,
+                )
+            except (OSError, ValueError):
+                item.update(
+                    status="blocked",
+                    blocker="reviewer_notification_state_persistence_failed",
+                )
+                blocked_count += 1
+            else:
+                item.update(
+                    status="cancelled_stale",
+                    cancellation_reason=stale_reason,
+                    queue_write_performed=write.get("write_performed") is True,
+                )
+                cancelled_count += 1
+                write_performed = bool(
+                    write_performed or write.get("write_performed") is True
+                )
+            items.append(item)
+            continue
+        author = str(metadata.get("author_handle") or "")
+        if not author or author in reviewers:
+            item.update(
+                status="blocked",
+                blocker=(
+                    "reviewer_notification_author_unavailable"
+                    if not author
+                    else "reviewer_notification_author_exclusion_failed"
+                ),
+            )
+            blocked_count += 1
+            items.append(item)
+            continue
+
+        matching_sinks = _matching_sinks(
+            sinks_input=sinks_input,
+            repo=repo,
+            number=number,
+            queue=due_queue,
+        )
+        if len(matching_sinks) != len(due_queue):
+            item.update(
+                status="blocked",
+                blocker="reviewer_notification_queue_sink_mismatch",
+            )
+            blocked_count += 1
+            items.append(item)
+            continue
+        scoped_input = with_reviewer_notification_state(
+            {**dict(sinks_input), "sinks": matching_sinks},
+            reviewer_notification_receipts_from_state(row),
+            full_queue,
+        )
+        build_kwargs: dict[str, Any] = {
+            "repo": repo,
+            "pr_number": number,
+            "pr_url": permalink,
+            "pr_title": summaries[0],
+            "linked_issue_refs": metadata.get("linked_issue_refs") or [],
+            "author_handle": author,
+            "reviewer_handles": reviewers,
+            "sinks_input": scoped_input,
+            "reviewer_artifact_required": False,
+            "execute": True,
+            "delivery_observed_at": observed_text,
+            "sink_adapters": sink_adapters,
+        }
+        if runner is not None:
+            build_kwargs["runner"] = runner
+        result = build_issue_fix_reviewer_notification_sinks_result(**build_kwargs)
+        result_queue = result.get("queued_receipts")
+        result_queue = result_queue if isinstance(result_queue, list) else []
+        new_queue = [dict(value) for value in future_queue]
+        if result.get("ok") is True:
+            new_queue.extend(
+                dict(value) for value in result_queue if isinstance(value, Mapping)
+            )
+        else:
+            new_queue.extend(dict(value) for value in due_queue)
+        receipts = result.get("receipts")
+        receipts = receipts if isinstance(receipts, list) else []
+        try:
+            write = persist_issue_fix_reviewer_notification_state(
+                ledger_path,
+                row,
+                receipts=[str(value) for value in receipts],
+                queued_receipts=new_queue,
+                replace_queued_receipts=True,
+            )
+        except (OSError, ValueError):
+            item.update(
+                status="blocked",
+                blocker="reviewer_notification_state_persistence_failed",
+            )
+            blocked_count += 1
+        else:
+            item.update(
+                status=str(result.get("status") or "blocked"),
+                notification_verified=result.get("notification_verified") is True,
+                external_write_performed=(
+                    result.get("external_writes_performed") is True
+                ),
+                queue_write_performed=write.get("write_performed") is True,
+            )
+            if result.get("blocker"):
+                item["blocker"] = result["blocker"]
+            if result.get("ok") is not True:
+                blocked_count += 1
+            if result.get("notification_verified") is True:
+                verified_count += 1
+            external_writes = bool(
+                external_writes or result.get("external_writes_performed") is True
+            )
+            write_performed = bool(
+                write_performed or write.get("write_performed") is True
+            )
+        items.append(item)
+
+    if not execute:
+        status = "preview_due" if queued_rows else "no_due_notifications"
+    elif blocked_count:
+        status = "partial_failure" if len(items) > blocked_count else "blocked"
+    elif verified_count:
+        status = "drained_verified"
+    elif cancelled_count:
+        status = "cancelled_stale"
+    else:
+        status = "no_due_notifications"
+    return {
+        "ok": blocked_count == 0,
+        "schema_version": ISSUE_FIX_REVIEWER_NOTIFICATION_DRAIN_SCHEMA_VERSION,
+        "mode": "issue-fix-reviewer-notification-drain",
+        "status": status,
+        "execute": execute,
+        "delivery_observed_at": observed_text,
+        "grouping_scope": "review_required_state_bucket",
+        "monitor_granularity": "one_monitor_per_state_bucket",
+        "notification_granularity": "one_pr_per_message",
+        "queued_receipt_count": queued_count,
+        "due_pr_count": len(queued_rows),
+        "processed_pr_count": len(items),
+        "not_due_receipt_count": not_due_count,
+        "verified_pr_count": verified_count,
+        "cancelled_pr_count": cancelled_count,
+        "blocked_pr_count": blocked_count,
+        "items": items,
+        "external_reads_performed": external_reads,
+        "external_writes_performed": external_writes,
+        "state_write_performed": write_performed,
+        "private_destination_captured": False,
+        "private_member_ids_captured": False,
+        "private_bot_profile_captured": False,
+        "raw_provider_payload_captured": False,
+        "local_paths_captured": False,
+    }

--- a/loopx/capabilities/issue_fix/reviewer_notification_drain.py
+++ b/loopx/capabilities/issue_fix/reviewer_notification_drain.py
@@ -15,6 +15,7 @@ from .reviewer_notification import (
     NotificationSinkAdapter,
     build_issue_fix_reviewer_notification_sinks_result,
     reviewer_notification_idempotency_key,
+    reviewer_notification_legacy_queue_from_state,
     reviewer_notification_queue_from_state,
     reviewer_notification_receipts_from_state,
     with_reviewer_notification_state,
@@ -133,6 +134,41 @@ def _matching_sinks(
     return matches
 
 
+def _matched_queue_keys(
+    *,
+    sinks_input: Mapping[str, Any],
+    repo: str,
+    number: int,
+    queue: Sequence[Mapping[str, Any]],
+) -> set[str]:
+    keys: set[str] = set()
+    for sink in _matching_sinks(
+        sinks_input=sinks_input,
+        repo=repo,
+        number=number,
+        queue=queue,
+    ):
+        sink_kind = str(sink.get("sink_kind") or "").strip()
+        sink_instance_key = str(sink.get("sink_instance_key") or "").strip()
+        for receipt in queue:
+            reviewers = receipt.get("reviewer_handles")
+            reviewers = reviewers if isinstance(reviewers, list) else []
+            try:
+                key = reviewer_notification_idempotency_key(
+                    repo=repo,
+                    pr_number=number,
+                    sink_kind=sink_kind,
+                    sink_instance_key=sink_instance_key,
+                    reviewer_handles=reviewers,
+                )
+            except (TypeError, ValueError):
+                continue
+            if key == receipt.get("idempotency_key"):
+                keys.add(key)
+                break
+    return keys
+
+
 def drain_issue_fix_reviewer_notification_queue(
     *,
     ledger_path: str | Path,
@@ -150,7 +186,43 @@ def drain_issue_fix_reviewer_notification_queue(
         raise ValueError("reviewer notification drain limit must be between 1 and 100")
     observed_at = _parse_timestamp(delivery_observed_at)
     observed_text = observed_at.isoformat().replace("+00:00", "Z")
-    rows = _latest_lifecycle_rows(load_jsonl_rows(Path(ledger_path)))
+    path = Path(ledger_path)
+    rows = _latest_lifecycle_rows(load_jsonl_rows(path) if path.is_file() else [])
+    legacy_queue_count = sum(
+        len(reviewer_notification_legacy_queue_from_state(row)) for row in rows
+    )
+    if legacy_queue_count:
+        return {
+            "ok": False,
+            "schema_version": ISSUE_FIX_REVIEWER_NOTIFICATION_DRAIN_SCHEMA_VERSION,
+            "mode": "issue-fix-reviewer-notification-drain",
+            "status": "blocked",
+            "blocker": "reviewer_notification_queue_v1_migration_required",
+            "execute": execute,
+            "delivery_observed_at": observed_text,
+            "grouping_scope": "review_required_state_bucket",
+            "monitor_granularity": "one_monitor_per_state_bucket",
+            "notification_granularity": "one_pr_per_message",
+            "legacy_queue_receipt_count": legacy_queue_count,
+            "queued_receipt_count": 0,
+            "due_pr_count": 0,
+            "processed_pr_count": 0,
+            "not_due_receipt_count": 0,
+            "verified_pr_count": 0,
+            "cancelled_pr_count": 0,
+            "cancelled_sink_receipt_count": 0,
+            "held_pr_count": 0,
+            "blocked_pr_count": 1,
+            "items": [],
+            "external_reads_performed": False,
+            "external_writes_performed": False,
+            "state_write_performed": False,
+            "private_destination_captured": False,
+            "private_member_ids_captured": False,
+            "private_bot_profile_captured": False,
+            "raw_provider_payload_captured": False,
+            "local_paths_captured": False,
+        }
     queued_rows: list[tuple[datetime, str, int, dict[str, Any]]] = []
     queued_count = 0
     not_due_count = 0
@@ -179,6 +251,7 @@ def drain_issue_fix_reviewer_notification_queue(
     external_writes = False
     blocked_count = 0
     cancelled_count = 0
+    cancelled_sink_receipt_count = 0
     verified_count = 0
     held_count = 0
     for _, repo, number, row in queued_rows[: int(limit)]:
@@ -194,6 +267,29 @@ def drain_issue_fix_reviewer_notification_queue(
         future_queue = [
             receipt for receipt in full_queue if not _queue_due(receipt, observed_at)
         ]
+        original_due_count = len(due_queue)
+        matched_keys = _matched_queue_keys(
+            sinks_input=sinks_input,
+            repo=repo,
+            number=number,
+            queue=due_queue,
+        )
+        unmatched_due_queue = [
+            receipt
+            for receipt in due_queue
+            if str(receipt.get("idempotency_key") or "") not in matched_keys
+        ]
+        due_queue = [
+            receipt
+            for receipt in due_queue
+            if str(receipt.get("idempotency_key") or "") in matched_keys
+        ]
+        matching_sinks = _matching_sinks(
+            sinks_input=sinks_input,
+            repo=repo,
+            number=number,
+            queue=due_queue,
+        )
         reviewers = list(
             dict.fromkeys(
                 str(handle)
@@ -215,13 +311,46 @@ def drain_issue_fix_reviewer_notification_queue(
             "pr_ref": f"#{number}",
             "permalink": permalink,
             "reviewer_handles": reviewers,
-            "queued_receipt_count": len(due_queue),
+            "queued_receipt_count": original_due_count,
             "status": "preview_due",
             "live_state_verified": False,
             "notification_verified": False,
             "external_write_performed": False,
             "queue_write_performed": False,
         }
+        if unmatched_due_queue:
+            item["stale_sink_receipt_count"] = len(unmatched_due_queue)
+            if execute:
+                try:
+                    write = persist_issue_fix_reviewer_notification_state(
+                        ledger_path,
+                        row,
+                        receipts=[],
+                        queued_receipts=[*future_queue, *due_queue],
+                        replace_queued_receipts=True,
+                    )
+                except (OSError, ValueError):
+                    item.update(
+                        status="blocked",
+                        blocker="reviewer_notification_state_persistence_failed",
+                    )
+                    blocked_count += 1
+                    items.append(item)
+                    continue
+                item["queue_write_performed"] = write.get("write_performed") is True
+                write_performed = bool(
+                    write_performed or write.get("write_performed") is True
+                )
+                cancelled_sink_receipt_count += len(unmatched_due_queue)
+                full_queue = [*future_queue, *due_queue]
+        if not due_queue:
+            item["status"] = (
+                "cancelled_stale_sink" if execute else "preview_cancel_stale_sink"
+            )
+            if execute:
+                cancelled_count += 1
+            items.append(item)
+            continue
         if len(summaries) != 1 or not summaries[0]:
             item.update(
                 status="blocked",
@@ -343,20 +472,6 @@ def drain_issue_fix_reviewer_notification_queue(
             items.append(item)
             continue
 
-        matching_sinks = _matching_sinks(
-            sinks_input=sinks_input,
-            repo=repo,
-            number=number,
-            queue=due_queue,
-        )
-        if len(matching_sinks) != len(due_queue):
-            item.update(
-                status="blocked",
-                blocker="reviewer_notification_queue_sink_mismatch",
-            )
-            blocked_count += 1
-            items.append(item)
-            continue
         scoped_input = with_reviewer_notification_state(
             {
                 **dict(sinks_input),
@@ -463,6 +578,7 @@ def drain_issue_fix_reviewer_notification_queue(
         "not_due_receipt_count": not_due_count,
         "verified_pr_count": verified_count,
         "cancelled_pr_count": cancelled_count,
+        "cancelled_sink_receipt_count": cancelled_sink_receipt_count,
         "held_pr_count": held_count,
         "blocked_pr_count": blocked_count,
         "items": items,

--- a/loopx/capabilities/issue_fix/reviewer_notification_drain.py
+++ b/loopx/capabilities/issue_fix/reviewer_notification_drain.py
@@ -138,10 +138,7 @@ def _latest_lifecycle_rows(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, 
 
 
 def _queue_due(receipt: Mapping[str, Any], observed_at: datetime) -> bool:
-    try:
-        not_before = _parse_timestamp(str(receipt.get("not_before") or ""))
-    except ValueError:
-        return False
+    not_before = _parse_timestamp(str(receipt.get("not_before") or ""))
     return not_before <= observed_at
 
 
@@ -344,6 +341,67 @@ def drain_issue_fix_reviewer_notification_queue(
             "remaining_due_pr_count": 0,
             "has_more_due": False,
             "items": [],
+            "external_reads_performed": False,
+            "external_writes_performed": False,
+            "state_write_performed": False,
+            "private_destination_captured": False,
+            "private_member_ids_captured": False,
+            "private_bot_profile_captured": False,
+            "raw_provider_payload_captured": False,
+            "local_paths_captured": False,
+        }
+    invalid_queue_items: list[dict[str, Any]] = []
+    invalid_queue_receipt_count = 0
+    total_queue_receipt_count = 0
+    for row in rows:
+        queue = reviewer_notification_queue_from_state(row)
+        total_queue_receipt_count += len(queue)
+        invalid_count = 0
+        for receipt in queue:
+            try:
+                _parse_timestamp(str(receipt.get("not_before") or ""))
+            except ValueError:
+                invalid_count += 1
+        if not invalid_count:
+            continue
+        invalid_queue_receipt_count += invalid_count
+        observation = row.get("observation")
+        observation = observation if isinstance(observation, Mapping) else {}
+        invalid_queue_items.append(
+            {
+                "repo": str(observation.get("repo") or "unknown"),
+                "pr_ref": str(observation.get("pr_ref") or "unknown"),
+                "status": "blocked",
+                "blocker": "reviewer_notification_queue_not_before_invalid",
+                "invalid_queue_receipt_count": invalid_count,
+                "external_write_performed": False,
+            }
+        )
+    if invalid_queue_receipt_count:
+        return {
+            "ok": False,
+            "schema_version": ISSUE_FIX_REVIEWER_NOTIFICATION_DRAIN_SCHEMA_VERSION,
+            "mode": "issue-fix-reviewer-notification-drain",
+            "status": "blocked",
+            "blocker": "reviewer_notification_queue_not_before_invalid",
+            "execute": execute,
+            "delivery_observed_at": observed_text,
+            "grouping_scope": "review_required_state_bucket",
+            "monitor_granularity": "one_monitor_per_state_bucket",
+            "notification_granularity": "one_pr_per_message",
+            "queued_receipt_count": total_queue_receipt_count,
+            "invalid_queue_receipt_count": invalid_queue_receipt_count,
+            "due_pr_count": 0,
+            "processed_pr_count": len(invalid_queue_items),
+            "not_due_receipt_count": 0,
+            "verified_pr_count": 0,
+            "cancelled_pr_count": 0,
+            "cancelled_sink_receipt_count": 0,
+            "held_pr_count": 0,
+            "blocked_pr_count": len(invalid_queue_items),
+            "remaining_due_pr_count": len(invalid_queue_items),
+            "has_more_due": True,
+            "items": invalid_queue_items,
             "external_reads_performed": False,
             "external_writes_performed": False,
             "state_write_performed": False,
@@ -736,6 +794,8 @@ def drain_issue_fix_reviewer_notification_queue(
         if runner is not None:
             build_kwargs["runner"] = runner
         result = build_issue_fix_reviewer_notification_sinks_result(**build_kwargs)
+        result_external_write = result.get("external_writes_performed") is True
+        external_writes = bool(external_writes or result_external_write)
         result_queue = result.get("queued_receipts")
         result_queue = result_queue if isinstance(result_queue, list) else []
         new_queue = [dict(value) for value in future_queue]
@@ -770,6 +830,7 @@ def drain_issue_fix_reviewer_notification_queue(
             item.update(
                 status="blocked",
                 blocker="reviewer_notification_state_persistence_failed",
+                external_write_performed=result_external_write,
             )
             blocked_count += 1
         else:
@@ -787,16 +848,22 @@ def drain_issue_fix_reviewer_notification_queue(
                 blocked_count += 1
             if result.get("notification_verified") is True:
                 verified_count += 1
-            external_writes = bool(
-                external_writes or result.get("external_writes_performed") is True
-            )
             write_performed = bool(
                 write_performed or write.get("write_performed") is True
             )
         items.append(item)
 
-    unprocessed_due_count = max(0, len(queued_rows) - len(items))
-    remaining_due_pr_count = held_count + unprocessed_due_count
+    final_rows = _latest_lifecycle_rows(
+        load_jsonl_rows(path) if path.is_file() else []
+    )
+    remaining_due_pr_count = sum(
+        1
+        for row in final_rows
+        if any(
+            _queue_due(receipt, observed_at)
+            for receipt in reviewer_notification_queue_from_state(row)
+        )
+    )
     if not execute:
         if blocked_count:
             status = (

--- a/loopx/capabilities/issue_fix/reviewer_notification_drain.py
+++ b/loopx/capabilities/issue_fix/reviewer_notification_drain.py
@@ -169,6 +169,50 @@ def _matched_queue_keys(
     return keys
 
 
+def _retarget_queue_receipts(
+    *,
+    repo: str,
+    number: int,
+    queue: Sequence[Mapping[str, Any]],
+    sinks: Sequence[Mapping[str, Any]],
+    reviewer_handles: Sequence[str],
+) -> list[dict[str, Any]]:
+    retargeted: list[dict[str, Any]] = []
+    for receipt in queue:
+        prior_reviewers = receipt.get("reviewer_handles")
+        prior_reviewers = prior_reviewers if isinstance(prior_reviewers, list) else []
+        matching_sink: Mapping[str, Any] | None = None
+        for sink in sinks:
+            key = reviewer_notification_idempotency_key(
+                repo=repo,
+                pr_number=number,
+                sink_kind=str(sink.get("sink_kind") or "").strip(),
+                sink_instance_key=str(sink.get("sink_instance_key") or "").strip(),
+                reviewer_handles=prior_reviewers,
+            )
+            if key == receipt.get("idempotency_key"):
+                matching_sink = sink
+                break
+        if matching_sink is None:
+            raise ValueError("queued reviewer notification sink is unavailable")
+        retargeted.append(
+            {
+                **dict(receipt),
+                "idempotency_key": reviewer_notification_idempotency_key(
+                    repo=repo,
+                    pr_number=number,
+                    sink_kind=str(matching_sink.get("sink_kind") or "").strip(),
+                    sink_instance_key=str(
+                        matching_sink.get("sink_instance_key") or ""
+                    ).strip(),
+                    reviewer_handles=reviewer_handles,
+                ),
+                "reviewer_handles": list(reviewer_handles),
+            }
+        )
+    return retargeted
+
+
 def drain_issue_fix_reviewer_notification_queue(
     *,
     ledger_path: str | Path,
@@ -403,6 +447,22 @@ def drain_issue_fix_reviewer_notification_queue(
         live_review_decision = str(metadata.get("review_decision") or "UNKNOWN").upper()
         live_state_bucket = str(metadata.get("state_bucket") or "unknown")
         live_reviewed = {str(value) for value in metadata.get("reviewed_by") or []}
+        if not all(
+            field in metadata
+            for field in ("requested_reviewers", "comment_notified_reviewers")
+        ):
+            item.update(
+                status="blocked",
+                blocker="github_pr_live_reviewer_coverage_incomplete",
+            )
+            blocked_count += 1
+            items.append(item)
+            continue
+        live_active_coverage = {
+            str(value)
+            for field in ("requested_reviewers", "comment_notified_reviewers")
+            for value in metadata.get(field) or []
+        }
         item.update(
             live_state=live_state,
             live_review_decision=live_review_decision,
@@ -426,6 +486,8 @@ def drain_issue_fix_reviewer_notification_queue(
             stale_reason = "review_no_longer_required"
         elif reviewers and set(reviewers).issubset(live_reviewed):
             stale_reason = "all_queued_reviewers_already_reviewed"
+        elif reviewers and not set(reviewers).intersection(live_active_coverage):
+            stale_reason = "all_queued_reviewers_no_longer_active"
         if stale_reason:
             try:
                 write = persist_issue_fix_reviewer_notification_state(
@@ -454,10 +516,38 @@ def drain_issue_fix_reviewer_notification_queue(
             items.append(item)
             continue
         covered_reviewers = [reviewer for reviewer in reviewers if reviewer in live_reviewed]
-        reviewers = [reviewer for reviewer in reviewers if reviewer not in live_reviewed]
+        inactive_reviewers = [
+            reviewer
+            for reviewer in reviewers
+            if reviewer not in live_reviewed and reviewer not in live_active_coverage
+        ]
+        reviewers = [
+            reviewer
+            for reviewer in reviewers
+            if reviewer not in live_reviewed and reviewer in live_active_coverage
+        ]
         item["reviewer_handles"] = reviewers
         if covered_reviewers:
             item["covered_reviewer_handles"] = covered_reviewers
+        if inactive_reviewers:
+            item["inactive_reviewer_handles"] = inactive_reviewers
+        try:
+            due_queue = _retarget_queue_receipts(
+                repo=repo,
+                number=number,
+                queue=due_queue,
+                sinks=matching_sinks,
+                reviewer_handles=reviewers,
+            )
+        except ValueError:
+            item.update(
+                status="blocked",
+                blocker="reviewer_notification_queue_sink_mismatch",
+            )
+            blocked_count += 1
+            items.append(item)
+            continue
+        full_queue = [*future_queue, *due_queue]
         author = str(metadata.get("author_handle") or "")
         if not author or author in reviewers:
             item.update(
@@ -505,12 +595,9 @@ def drain_issue_fix_reviewer_notification_queue(
         result_queue = result.get("queued_receipts")
         result_queue = result_queue if isinstance(result_queue, list) else []
         new_queue = [dict(value) for value in future_queue]
-        if result.get("ok") is True:
-            new_queue.extend(
-                dict(value) for value in result_queue if isinstance(value, Mapping)
-            )
-        else:
-            new_queue.extend(dict(value) for value in due_queue)
+        new_queue.extend(
+            dict(value) for value in result_queue if isinstance(value, Mapping)
+        )
         receipts = result.get("receipts")
         receipts = receipts if isinstance(receipts, list) else []
         try:

--- a/loopx/capabilities/issue_fix/reviewer_notification_drain.py
+++ b/loopx/capabilities/issue_fix/reviewer_notification_drain.py
@@ -353,15 +353,26 @@ def drain_issue_fix_reviewer_notification_queue(
     invalid_queue_items: list[dict[str, Any]] = []
     invalid_queue_receipt_count = 0
     total_queue_receipt_count = 0
+    valid_due_pr_count = 0
+    pending_pr_count = 0
+    valid_not_due_receipt_count = 0
     for row in rows:
         queue = reviewer_notification_queue_from_state(row)
         total_queue_receipt_count += len(queue)
         invalid_count = 0
+        has_valid_due = False
         for receipt in queue:
             try:
-                _parse_timestamp(str(receipt.get("not_before") or ""))
+                if _queue_due(receipt, observed_at):
+                    has_valid_due = True
+                else:
+                    valid_not_due_receipt_count += 1
             except ValueError:
                 invalid_count += 1
+        if has_valid_due:
+            valid_due_pr_count += 1
+        if invalid_count or has_valid_due:
+            pending_pr_count += 1
         if not invalid_count:
             continue
         invalid_queue_receipt_count += invalid_count
@@ -391,15 +402,15 @@ def drain_issue_fix_reviewer_notification_queue(
             "notification_granularity": "one_pr_per_message",
             "queued_receipt_count": total_queue_receipt_count,
             "invalid_queue_receipt_count": invalid_queue_receipt_count,
-            "due_pr_count": 0,
+            "due_pr_count": valid_due_pr_count,
             "processed_pr_count": len(invalid_queue_items),
-            "not_due_receipt_count": 0,
+            "not_due_receipt_count": valid_not_due_receipt_count,
             "verified_pr_count": 0,
             "cancelled_pr_count": 0,
             "cancelled_sink_receipt_count": 0,
             "held_pr_count": 0,
             "blocked_pr_count": len(invalid_queue_items),
-            "remaining_due_pr_count": len(invalid_queue_items),
+            "remaining_due_pr_count": pending_pr_count,
             "has_more_due": True,
             "items": invalid_queue_items,
             "external_reads_performed": False,
@@ -853,17 +864,27 @@ def drain_issue_fix_reviewer_notification_queue(
             )
         items.append(item)
 
-    final_rows = _latest_lifecycle_rows(
-        load_jsonl_rows(path) if path.is_file() else []
-    )
-    remaining_due_pr_count = sum(
-        1
-        for row in final_rows
-        if any(
-            _queue_due(receipt, observed_at)
-            for receipt in reviewer_notification_queue_from_state(row)
+    if execute:
+        final_rows = _latest_lifecycle_rows(
+            load_jsonl_rows(path) if path.is_file() else []
         )
-    )
+        remaining_due_pr_count = sum(
+            1
+            for row in final_rows
+            if any(
+                _queue_due(receipt, observed_at)
+                for receipt in reviewer_notification_queue_from_state(row)
+            )
+        )
+    else:
+        unresolved_preview_count = sum(
+            1
+            for item in items
+            if item.get("status") in {"blocked", "held_outside_delivery_window"}
+        )
+        remaining_due_pr_count = (
+            max(0, len(queued_rows) - len(items)) + unresolved_preview_count
+        )
     if not execute:
         if blocked_count:
             status = (

--- a/loopx/capabilities/issue_fix/reviewer_notification_drain.py
+++ b/loopx/capabilities/issue_fix/reviewer_notification_drain.py
@@ -105,7 +105,7 @@ def drain_issue_fix_reviewer_notification_queue(
     metadata_loader: MetadataLoader = fetch_issue_fix_reviewer_notification_metadata,
     sink_adapters: Mapping[str, NotificationSinkAdapter] | None = None,
 ) -> dict[str, Any]:
-    """Drain one bounded state-group batch while emitting at most one message per PR."""
+    """Drain one bounded state-group batch with one PR in each sink message."""
 
     if not 1 <= int(limit) <= 100:
         raise ValueError("reviewer notification drain limit must be between 1 and 100")
@@ -166,6 +166,10 @@ def drain_issue_fix_reviewer_notification_queue(
                 str(receipt.get("message_summary") or "") for receipt in due_queue
             )
         )
+        reviewer_sets = {
+            tuple(str(handle) for handle in receipt.get("reviewer_handles") or [])
+            for receipt in due_queue
+        }
         item: dict[str, Any] = {
             "repo": repo,
             "pr_ref": f"#{number}",
@@ -186,10 +190,10 @@ def drain_issue_fix_reviewer_notification_queue(
             blocked_count += 1
             items.append(item)
             continue
-        if len(due_queue) != 1:
+        if len(reviewer_sets) != 1:
             item.update(
                 status="blocked",
-                blocker="reviewer_notification_queue_granularity_invalid",
+                blocker="reviewer_notification_queue_reviewer_set_mismatch",
             )
             blocked_count += 1
             items.append(item)
@@ -237,8 +241,8 @@ def drain_issue_fix_reviewer_notification_queue(
             stale_reason = "pr_is_draft"
         elif live_review_decision != "REVIEW_REQUIRED":
             stale_reason = "review_no_longer_required"
-        elif live_reviewed.intersection(reviewers):
-            stale_reason = "queued_reviewer_already_reviewed"
+        elif reviewers and set(reviewers).issubset(live_reviewed):
+            stale_reason = "all_queued_reviewers_already_reviewed"
         elif live_state_bucket not in {"review_required", "unknown"}:
             stale_reason = "pr_left_review_required_bucket"
         if stale_reason:
@@ -268,6 +272,11 @@ def drain_issue_fix_reviewer_notification_queue(
                 )
             items.append(item)
             continue
+        covered_reviewers = [reviewer for reviewer in reviewers if reviewer in live_reviewed]
+        reviewers = [reviewer for reviewer in reviewers if reviewer not in live_reviewed]
+        item["reviewer_handles"] = reviewers
+        if covered_reviewers:
+            item["covered_reviewer_handles"] = covered_reviewers
         author = str(metadata.get("author_handle") or "")
         if not author or author in reviewers:
             item.update(

--- a/loopx/capabilities/issue_fix/reviewer_notification_drain.py
+++ b/loopx/capabilities/issue_fix/reviewer_notification_drain.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
-from datetime import datetime, timezone
+from datetime import datetime, time, timezone
 from pathlib import Path
 from typing import Any, Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from ...domain_packs.issue_fix import (
     persist_issue_fix_reviewer_notification_state,
@@ -60,6 +61,44 @@ def _queue_due(receipt: Mapping[str, Any], observed_at: datetime) -> bool:
     return not_before <= observed_at
 
 
+def _queued_delivery_window(
+    queue: Sequence[Mapping[str, Any]], observed_at: datetime
+) -> tuple[dict[str, Any] | None, str | None]:
+    windows: set[tuple[str, str, str]] = set()
+    for receipt in queue:
+        allowed = receipt.get("allowed_local_time")
+        if not isinstance(allowed, Mapping):
+            return None, "reviewer_notification_queue_delivery_window_invalid"
+        windows.add(
+            (
+                str(receipt.get("timezone") or ""),
+                str(allowed.get("start") or ""),
+                str(allowed.get("end") or ""),
+            )
+        )
+    if len(windows) != 1:
+        return None, "reviewer_notification_queue_delivery_window_mismatch"
+    timezone_name, start_text, end_text = windows.pop()
+    try:
+        location = ZoneInfo(timezone_name)
+        start = time.fromisoformat(start_text)
+        end = time.fromisoformat(end_text)
+    except (ValueError, ZoneInfoNotFoundError):
+        return None, "reviewer_notification_queue_delivery_window_invalid"
+    if start == end:
+        return None, "reviewer_notification_queue_delivery_window_invalid"
+    current = observed_at.astimezone(location).timetz().replace(tzinfo=None)
+    allowed_now = (
+        start <= current < end if start < end else current >= start or current < end
+    )
+    return {
+        "timezone": timezone_name,
+        "allowed_local_time": {"start": start_text, "end": end_text},
+        "outside_window": "queue_without_send",
+        "allowed_now": allowed_now,
+    }, None
+
+
 def _matching_sinks(
     *,
     sinks_input: Mapping[str, Any],
@@ -73,8 +112,8 @@ def _matching_sinks(
         if not isinstance(raw_sink, Mapping):
             continue
         sink = dict(raw_sink)
-        sink_kind = str(sink.get("sink_kind") or "")
-        sink_instance_key = str(sink.get("sink_instance_key") or "")
+        sink_kind = str(sink.get("sink_kind") or "").strip()
+        sink_instance_key = str(sink.get("sink_instance_key") or "").strip()
         for receipt in queue:
             reviewers = receipt.get("reviewer_handles")
             reviewers = reviewers if isinstance(reviewers, list) else []
@@ -141,6 +180,7 @@ def drain_issue_fix_reviewer_notification_queue(
     blocked_count = 0
     cancelled_count = 0
     verified_count = 0
+    held_count = 0
     for _, repo, number, row in queued_rows[: int(limit)]:
         observation = row.get("observation")
         observation = observation if isinstance(observation, Mapping) else {}
@@ -198,7 +238,21 @@ def drain_issue_fix_reviewer_notification_queue(
             blocked_count += 1
             items.append(item)
             continue
+        delivery_policy, delivery_policy_error = _queued_delivery_window(
+            due_queue, observed_at
+        )
+        if delivery_policy is None:
+            item.update(status="blocked", blocker=delivery_policy_error)
+            blocked_count += 1
+            items.append(item)
+            continue
         item["message_summary"] = summaries[0]
+        item["queued_delivery_window_honored"] = True
+        if delivery_policy["allowed_now"] is not True:
+            item["status"] = "held_outside_delivery_window"
+            held_count += 1
+            items.append(item)
+            continue
         if not execute:
             items.append(item)
             continue
@@ -243,8 +297,6 @@ def drain_issue_fix_reviewer_notification_queue(
             stale_reason = "review_no_longer_required"
         elif reviewers and set(reviewers).issubset(live_reviewed):
             stale_reason = "all_queued_reviewers_already_reviewed"
-        elif live_state_bucket not in {"review_required", "unknown"}:
-            stale_reason = "pr_left_review_required_bucket"
         if stale_reason:
             try:
                 write = persist_issue_fix_reviewer_notification_state(
@@ -306,7 +358,15 @@ def drain_issue_fix_reviewer_notification_queue(
             items.append(item)
             continue
         scoped_input = with_reviewer_notification_state(
-            {**dict(sinks_input), "sinks": matching_sinks},
+            {
+                **dict(sinks_input),
+                "sinks": matching_sinks,
+                "delivery_policy": {
+                    "timezone": delivery_policy["timezone"],
+                    "allowed_local_time": delivery_policy["allowed_local_time"],
+                    "outside_window": "queue_without_send",
+                },
+            },
             reviewer_notification_receipts_from_state(row),
             full_queue,
         )
@@ -383,6 +443,8 @@ def drain_issue_fix_reviewer_notification_queue(
         status = "drained_verified"
     elif cancelled_count:
         status = "cancelled_stale"
+    elif held_count:
+        status = "held_outside_delivery_window"
     else:
         status = "no_due_notifications"
     return {
@@ -401,6 +463,7 @@ def drain_issue_fix_reviewer_notification_queue(
         "not_due_receipt_count": not_due_count,
         "verified_pr_count": verified_count,
         "cancelled_pr_count": cancelled_count,
+        "held_pr_count": held_count,
         "blocked_pr_count": blocked_count,
         "items": items,
         "external_reads_performed": external_reads,

--- a/loopx/capabilities/issue_fix/reviewer_notification_drain.py
+++ b/loopx/capabilities/issue_fix/reviewer_notification_drain.py
@@ -29,7 +29,7 @@ ISSUE_FIX_REVIEWER_NOTIFICATION_DRAIN_SCHEMA_VERSION = (
     "issue_fix_reviewer_notification_drain_v0"
 )
 MetadataLoader = Callable[..., tuple[Optional[dict[str, Any]], Optional[str]]]
-SemanticHistoryMatcher = Callable[[str], bool]
+SemanticHistoryMatcher = Callable[[str, Mapping[str, Any]], bool | None]
 
 
 def _row_with_live_lifecycle_facts(
@@ -315,6 +315,8 @@ def drain_issue_fix_reviewer_notification_queue(
             "cancelled_sink_receipt_count": 0,
             "held_pr_count": 0,
             "blocked_pr_count": 1,
+            "remaining_due_pr_count": 0,
+            "has_more_due": False,
             "items": [],
             "external_reads_performed": False,
             "external_writes_performed": False,
@@ -491,31 +493,6 @@ def drain_issue_fix_reviewer_notification_queue(
             items.append(item)
             continue
 
-        if semantic_history_matcher is not None:
-            try:
-                semantic_history_match = semantic_history_matcher(permalink)
-            except (OSError, ValueError):
-                semantic_history_status = "unavailable"
-            else:
-                semantic_history_status = (
-                    "matched" if semantic_history_match else "no_match"
-                )
-                if semantic_history_match:
-                    existing_refs = sinks_input.get("_semantic_history_pr_refs")
-                    refs = [
-                        str(value)
-                        for value in (
-                            existing_refs if isinstance(existing_refs, list) else []
-                        )
-                    ]
-                    row_sinks_input = {
-                        **dict(sinks_input),
-                        "_semantic_history_pr_refs": list(
-                            dict.fromkeys([*refs, permalink])
-                        ),
-                    }
-            item["semantic_history_status"] = semantic_history_status
-
         external_reads = True
         kwargs: dict[str, Any] = {"repo": repo, "number": number}
         if runner is not None:
@@ -654,6 +631,52 @@ def drain_issue_fix_reviewer_notification_queue(
             items.append(item)
             continue
 
+        semantic_receipt_keys: list[str] = []
+        if semantic_history_matcher is not None:
+            semantic_statuses: list[str] = []
+            semantic_scope_ambiguous = False
+            for sink in matching_sinks:
+                if str(sink.get("sink_kind") or "").strip() != "lark_chat":
+                    continue
+                try:
+                    semantic_history_match = semantic_history_matcher(permalink, sink)
+                except (OSError, ValueError):
+                    semantic_statuses.append("unavailable")
+                    continue
+                if semantic_history_match is None:
+                    semantic_scope_ambiguous = True
+                    semantic_statuses.append("scope_ambiguous")
+                    continue
+                semantic_statuses.append(
+                    "matched" if semantic_history_match else "no_match"
+                )
+                if semantic_history_match:
+                    semantic_receipt_keys.extend(
+                        _matched_queue_keys(
+                            sinks_input={"sinks": [sink]},
+                            repo=repo,
+                            number=number,
+                            queue=due_queue,
+                        )
+                    )
+            if "matched" in semantic_statuses:
+                semantic_history_status = "matched"
+            elif "scope_ambiguous" in semantic_statuses:
+                semantic_history_status = "scope_ambiguous"
+            elif "unavailable" in semantic_statuses:
+                semantic_history_status = "unavailable"
+            elif semantic_statuses:
+                semantic_history_status = "no_match"
+            item["semantic_history_status"] = semantic_history_status
+            if semantic_scope_ambiguous:
+                item.update(
+                    status="blocked",
+                    blocker="reviewer_notification_semantic_history_scope_ambiguous",
+                )
+                blocked_count += 1
+                items.append(item)
+                continue
+
         scoped_input = with_reviewer_notification_state(
             {
                 **dict(row_sinks_input),
@@ -664,7 +687,10 @@ def drain_issue_fix_reviewer_notification_queue(
                     "outside_window": "queue_without_send",
                 },
             },
-            reviewer_notification_receipts_from_state(row),
+            [
+                *reviewer_notification_receipts_from_state(row),
+                *semantic_receipt_keys,
+            ],
             full_queue,
         )
         build_kwargs: dict[str, Any] = {
@@ -729,6 +755,8 @@ def drain_issue_fix_reviewer_notification_queue(
             )
         items.append(item)
 
+    unprocessed_due_count = max(0, len(queued_rows) - len(items))
+    remaining_due_pr_count = held_count + unprocessed_due_count
     if not execute:
         if blocked_count:
             status = (
@@ -740,6 +768,8 @@ def drain_issue_fix_reviewer_notification_queue(
             status = "preview_due" if queued_rows else "no_due_notifications"
     elif blocked_count:
         status = "partial_failure" if len(items) > blocked_count else "blocked"
+    elif remaining_due_pr_count and (verified_count or cancelled_count):
+        status = "partial_drain"
     elif verified_count:
         status = "drained_verified"
     elif cancelled_count:
@@ -767,6 +797,8 @@ def drain_issue_fix_reviewer_notification_queue(
         "cancelled_sink_receipt_count": cancelled_sink_receipt_count,
         "held_pr_count": held_count,
         "blocked_pr_count": blocked_count,
+        "remaining_due_pr_count": remaining_due_pr_count,
+        "has_more_due": remaining_due_pr_count > 0,
         "items": items,
         "external_reads_performed": external_reads,
         "external_writes_performed": external_writes,

--- a/loopx/capabilities/issue_fix/reviewer_notification_drain.py
+++ b/loopx/capabilities/issue_fix/reviewer_notification_drain.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import json
 from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime, time, timezone
 from pathlib import Path
@@ -27,6 +29,61 @@ ISSUE_FIX_REVIEWER_NOTIFICATION_DRAIN_SCHEMA_VERSION = (
     "issue_fix_reviewer_notification_drain_v0"
 )
 MetadataLoader = Callable[..., tuple[Optional[dict[str, Any]], Optional[str]]]
+SemanticHistoryMatcher = Callable[[str], bool]
+
+
+def _row_with_live_lifecycle_facts(
+    row: Mapping[str, Any], metadata: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Merge freshly verified lifecycle facts without dropping local receipts."""
+
+    updated = dict(row)
+    lifecycle = metadata.get("_lifecycle_packet")
+    if isinstance(lifecycle, Mapping):
+        for key in (
+            "generated_at",
+            "observation",
+            "observation_fingerprint",
+            "transition",
+            "grouped_monitor_projection",
+            "first_screen",
+            "writeback_contract",
+            "evidence",
+        ):
+            if key in lifecycle:
+                value = lifecycle[key]
+                updated[key] = dict(value) if isinstance(value, Mapping) else value
+        return updated
+
+    observation = row.get("observation")
+    fresh_observation = dict(observation) if isinstance(observation, Mapping) else {}
+    fresh_observation.update(
+        state=str(metadata.get("state") or "UNKNOWN").upper(),
+        review_decision=str(
+            metadata.get("review_decision") or "UNKNOWN"
+        ).upper(),
+        is_draft=metadata.get("is_draft") is True,
+    )
+    updated["observation"] = fresh_observation
+    serialized = json.dumps(fresh_observation, sort_keys=True, separators=(",", ":"))
+    updated["observation_fingerprint"] = hashlib.sha256(
+        serialized.encode("utf-8")
+    ).hexdigest()[:16]
+    state_bucket = str(metadata.get("state_bucket") or "unknown")
+    grouped = row.get("grouped_monitor_projection")
+    fresh_grouped = dict(grouped) if isinstance(grouped, Mapping) else {}
+    fresh_grouped["state_bucket"] = state_bucket
+    terminal = state_bucket == "terminal"
+    fresh_grouped["target_key"] = (
+        None if terminal else f"github-pr-state-{state_bucket.replace('_', '-')}"
+    )
+    fresh_grouped["action_kind"] = (
+        None if terminal else f"issue_fix_pr_state_{state_bucket}_monitor"
+    )
+    fresh_grouped["member_operation"] = "remove" if terminal else "upsert"
+    fresh_grouped["materialize_nonempty_bucket_monitor"] = not terminal
+    updated["grouped_monitor_projection"] = fresh_grouped
+    return updated
 
 
 def _parse_timestamp(value: str | None) -> datetime:
@@ -222,6 +279,7 @@ def drain_issue_fix_reviewer_notification_queue(
     limit: int = 20,
     runner: CommandRunner | None = None,
     metadata_loader: MetadataLoader = fetch_issue_fix_reviewer_notification_metadata,
+    semantic_history_matcher: SemanticHistoryMatcher | None = None,
     sink_adapters: Mapping[str, NotificationSinkAdapter] | None = None,
 ) -> dict[str, Any]:
     """Drain one bounded state-group batch with one PR in each sink message."""
@@ -304,6 +362,8 @@ def drain_issue_fix_reviewer_notification_queue(
         permalink = str(
             observation.get("permalink") or f"https://github.com/{repo}/pull/{number}"
         )
+        row_sinks_input = sinks_input
+        semantic_history_status = "not_checked"
         full_queue = reviewer_notification_queue_from_state(row)
         due_queue = [
             receipt for receipt in full_queue if _queue_due(receipt, observed_at)
@@ -313,7 +373,7 @@ def drain_issue_fix_reviewer_notification_queue(
         ]
         original_due_count = len(due_queue)
         matched_keys = _matched_queue_keys(
-            sinks_input=sinks_input,
+            sinks_input=row_sinks_input,
             repo=repo,
             number=number,
             queue=due_queue,
@@ -329,7 +389,7 @@ def drain_issue_fix_reviewer_notification_queue(
             if str(receipt.get("idempotency_key") or "") in matched_keys
         ]
         matching_sinks = _matching_sinks(
-            sinks_input=sinks_input,
+            sinks_input=row_sinks_input,
             repo=repo,
             number=number,
             queue=due_queue,
@@ -361,6 +421,7 @@ def drain_issue_fix_reviewer_notification_queue(
             "notification_verified": False,
             "external_write_performed": False,
             "queue_write_performed": False,
+            "semantic_history_status": semantic_history_status,
         }
         if unmatched_due_queue:
             item["stale_sink_receipt_count"] = len(unmatched_due_queue)
@@ -430,6 +491,31 @@ def drain_issue_fix_reviewer_notification_queue(
             items.append(item)
             continue
 
+        if semantic_history_matcher is not None:
+            try:
+                semantic_history_match = semantic_history_matcher(permalink)
+            except (OSError, ValueError):
+                semantic_history_status = "unavailable"
+            else:
+                semantic_history_status = (
+                    "matched" if semantic_history_match else "no_match"
+                )
+                if semantic_history_match:
+                    existing_refs = sinks_input.get("_semantic_history_pr_refs")
+                    refs = [
+                        str(value)
+                        for value in (
+                            existing_refs if isinstance(existing_refs, list) else []
+                        )
+                    ]
+                    row_sinks_input = {
+                        **dict(sinks_input),
+                        "_semantic_history_pr_refs": list(
+                            dict.fromkeys([*refs, permalink])
+                        ),
+                    }
+            item["semantic_history_status"] = semantic_history_status
+
         external_reads = True
         kwargs: dict[str, Any] = {"repo": repo, "number": number}
         if runner is not None:
@@ -489,10 +575,11 @@ def drain_issue_fix_reviewer_notification_queue(
         elif reviewers and not set(reviewers).intersection(live_active_coverage):
             stale_reason = "all_queued_reviewers_no_longer_active"
         if stale_reason:
+            fresh_row = _row_with_live_lifecycle_facts(row, metadata)
             try:
                 write = persist_issue_fix_reviewer_notification_state(
                     ledger_path,
-                    row,
+                    fresh_row,
                     receipts=[],
                     queued_receipts=[],
                     replace_queued_receipts=True,
@@ -564,7 +651,7 @@ def drain_issue_fix_reviewer_notification_queue(
 
         scoped_input = with_reviewer_notification_state(
             {
-                **dict(sinks_input),
+                **dict(row_sinks_input),
                 "sinks": matching_sinks,
                 "delivery_policy": {
                     "timezone": delivery_policy["timezone"],

--- a/loopx/capabilities/issue_fix/reviewer_notification_drain.py
+++ b/loopx/capabilities/issue_fix/reviewer_notification_drain.py
@@ -529,6 +529,7 @@ def drain_issue_fix_reviewer_notification_queue(
             blocked_count += 1
             items.append(item)
             continue
+        fresh_row = _row_with_live_lifecycle_facts(row, metadata)
         live_state = str(metadata.get("state") or "UNKNOWN").upper()
         live_review_decision = str(metadata.get("review_decision") or "UNKNOWN").upper()
         live_state_bucket = str(metadata.get("state_bucket") or "unknown")
@@ -574,8 +575,12 @@ def drain_issue_fix_reviewer_notification_queue(
             stale_reason = "all_queued_reviewers_already_reviewed"
         elif reviewers and not set(reviewers).intersection(live_active_coverage):
             stale_reason = "all_queued_reviewers_no_longer_active"
+        elif reviewers and not any(
+            reviewer not in live_reviewed and reviewer in live_active_coverage
+            for reviewer in reviewers
+        ):
+            stale_reason = "all_queued_reviewers_already_covered_or_inactive"
         if stale_reason:
-            fresh_row = _row_with_live_lifecycle_facts(row, metadata)
             try:
                 write = persist_issue_fix_reviewer_notification_state(
                     ledger_path,
@@ -690,7 +695,7 @@ def drain_issue_fix_reviewer_notification_queue(
         try:
             write = persist_issue_fix_reviewer_notification_state(
                 ledger_path,
-                row,
+                fresh_row,
                 receipts=[str(value) for value in receipts],
                 queued_receipts=new_queue,
                 replace_queued_receipts=True,
@@ -725,7 +730,14 @@ def drain_issue_fix_reviewer_notification_queue(
         items.append(item)
 
     if not execute:
-        status = "preview_due" if queued_rows else "no_due_notifications"
+        if blocked_count:
+            status = (
+                "preview_partial_failure"
+                if len(items) > blocked_count
+                else "preview_blocked"
+            )
+        else:
+            status = "preview_due" if queued_rows else "no_due_notifications"
     elif blocked_count:
         status = "partial_failure" if len(items) > blocked_count else "blocked"
     elif verified_count:

--- a/loopx/capabilities/issue_fix/reviewer_notification_drain.py
+++ b/loopx/capabilities/issue_fix/reviewer_notification_drain.py
@@ -39,6 +39,28 @@ def _row_with_live_lifecycle_facts(
 
     updated = dict(row)
     lifecycle = metadata.get("_lifecycle_packet")
+    correction = row.get("maintainer_correction")
+    fresh_observation = (
+        lifecycle.get("observation") if isinstance(lifecycle, Mapping) else None
+    )
+    fresh_state = str(
+        (
+            fresh_observation.get("state")
+            if isinstance(fresh_observation, Mapping)
+            else metadata.get("state")
+        )
+        or "UNKNOWN"
+    ).upper()
+    preserve_correction_projection = (
+        isinstance(correction, Mapping)
+        and fresh_state not in {"MERGED", "CLOSED"}
+    )
+    correction_projection_keys = {
+        "transition",
+        "grouped_monitor_projection",
+        "first_screen",
+        "writeback_contract",
+    }
     if isinstance(lifecycle, Mapping):
         for key in (
             "generated_at",
@@ -50,6 +72,8 @@ def _row_with_live_lifecycle_facts(
             "writeback_contract",
             "evidence",
         ):
+            if preserve_correction_projection and key in correction_projection_keys:
+                continue
             if key in lifecycle:
                 value = lifecycle[key]
                 updated[key] = dict(value) if isinstance(value, Mapping) else value
@@ -69,6 +93,8 @@ def _row_with_live_lifecycle_facts(
     updated["observation_fingerprint"] = hashlib.sha256(
         serialized.encode("utf-8")
     ).hexdigest()[:16]
+    if preserve_correction_projection:
+        return updated
     state_bucket = str(metadata.get("state_bucket") or "unknown")
     grouped = row.get("grouped_monitor_projection")
     fresh_grouped = dict(grouped) if isinstance(grouped, Mapping) else {}
@@ -716,6 +742,20 @@ def drain_issue_fix_reviewer_notification_queue(
         new_queue.extend(
             dict(value) for value in result_queue if isinstance(value, Mapping)
         )
+        if (
+            result.get("ok") is not True
+            and result.get("external_writes_performed") is not True
+        ):
+            queued_keys = {
+                str(value.get("idempotency_key") or "")
+                for value in new_queue
+                if isinstance(value, Mapping)
+            }
+            new_queue.extend(
+                dict(value)
+                for value in due_queue
+                if str(value.get("idempotency_key") or "") not in queued_keys
+            )
         receipts = result.get("receipts")
         receipts = receipts if isinstance(receipts, list) else []
         try:

--- a/loopx/capabilities/issue_fix/reviewer_request.py
+++ b/loopx/capabilities/issue_fix/reviewer_request.py
@@ -328,6 +328,9 @@ def _metadata_identities(
         "semantic_comment_notified_reviewers": semantic_comment_notified,
         "reviewer_comment_urls": comment_urls,
         "state": str(payload.get("state") or "UNKNOWN").upper(),
+        "review_decision": str(
+            payload.get("reviewDecision") or payload.get("review_decision") or "UNKNOWN"
+        ).upper(),
         "is_draft": payload.get("isDraft") is True or payload.get("is_draft") is True,
     }
 
@@ -349,7 +352,8 @@ def _fetch_pr_metadata(
                 repo,
                 "--json",
                 "author,closingIssuesReferences,comments,isDraft,reviewRequests,"
-                "reviews,state,title,url",
+                "mergeStateStatus,reviewDecision,reviews,state,statusCheckRollup,"
+                "title,url",
             ]
         )
     except (OSError, subprocess.SubprocessError):
@@ -365,6 +369,31 @@ def _fetch_pr_metadata(
         if isinstance(payload, Mapping)
         else (None, "github_pr_metadata_invalid")
     )
+
+
+def fetch_issue_fix_reviewer_notification_metadata(
+    *,
+    repo: str,
+    number: int,
+    runner: CommandRunner = _default_runner,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Fetch compact live PR facts required before a queued group notification."""
+
+    payload, error = _fetch_pr_metadata(repo=repo, number=number, runner=runner)
+    if payload is None:
+        return None, error
+    identities = _metadata_identities(payload, repo=repo, number=number)
+    from .pr_lifecycle import build_issue_fix_pr_lifecycle_monitor_packet
+
+    lifecycle = build_issue_fix_pr_lifecycle_monitor_packet(
+        url=f"https://github.com/{repo}/pull/{number}",
+        provider_payload=payload,
+        generated_at=None,
+    )
+    grouped = lifecycle.get("grouped_monitor_projection")
+    grouped = grouped if isinstance(grouped, Mapping) else {}
+    identities["state_bucket"] = str(grouped.get("state_bucket") or "unknown")
+    return identities, None
 
 
 def _request_reviewers(
@@ -1030,9 +1059,7 @@ def build_issue_fix_reviewer_request_packet(
                     reviewer_notification_policy_application = None
             packet["reviewer_notification_reward_memory_status"] = (
                 (
-                    reviewer_notification_policy_application.get(
-                        "before_send_gate", {}
-                    )
+                    reviewer_notification_policy_application.get("before_send_gate", {})
                     if reviewer_notification_policy_application
                     else {}
                 ).get("status", "unavailable")

--- a/loopx/capabilities/issue_fix/reviewer_request.py
+++ b/loopx/capabilities/issue_fix/reviewer_request.py
@@ -393,6 +393,10 @@ def fetch_issue_fix_reviewer_notification_metadata(
     grouped = lifecycle.get("grouped_monitor_projection")
     grouped = grouped if isinstance(grouped, Mapping) else {}
     identities["state_bucket"] = str(grouped.get("state_bucket") or "unknown")
+    # The grouped queue drain must persist the same verified lifecycle facts it
+    # used to cancel a stale notification. Keep the full public-safe packet
+    # internal to this adapter instead of reconstructing only a few fields.
+    identities["_lifecycle_packet"] = lifecycle
     return identities, None
 
 

--- a/loopx/domain_packs/issue_fix.py
+++ b/loopx/domain_packs/issue_fix.py
@@ -21,11 +21,9 @@ ISSUE_FIX_FEASIBILITY_LEDGER_FILENAME = "feasibility.jsonl"
 ISSUE_FIX_REPOSITORY_SNAPSHOT_LEDGER_FILENAME = "repository-snapshots.jsonl"
 REVIEWER_NOTIFICATION_RECEIPT_PATTERN = re.compile(r"sha256:[a-f0-9]{64}")
 REVIEWER_NOTIFICATION_QUEUE_RECEIPT_SCHEMA_VERSION = (
-    "issue_fix_reviewer_notification_queue_receipt_v0"
+    "issue_fix_reviewer_notification_queue_receipt_v1"
 )
-REVIEWER_NOTIFICATION_LOCAL_TIME_PATTERN = re.compile(
-    r"(?:[01]\d|2[0-3]):[0-5]\d"
-)
+REVIEWER_NOTIFICATION_LOCAL_TIME_PATTERN = re.compile(r"(?:[01]\d|2[0-3]):[0-5]\d")
 REVIEWER_NOTIFICATION_HANDLE_PATTERN = re.compile(r"@?[A-Za-z0-9_.-]{1,100}")
 
 
@@ -338,6 +336,10 @@ def _validated_reviewer_notification_queue_receipt(
             for handle in reviewers
         )
         or not isinstance(window, dict)
+        or not str(value.get("message_summary") or "").strip()
+        or len(str(value.get("message_summary") or "")) > 240
+        or value.get("summary_policy_status")
+        not in {"reward_memory_verified", "sink_config"}
         or not REVIEWER_NOTIFICATION_LOCAL_TIME_PATTERN.fullmatch(
             str(window.get("start") or "")
         )
@@ -384,9 +386,7 @@ def persist_issue_fix_reviewer_notification_state(
     existing_receipts = payload.get("reviewer_notification_receipts")
     merged_receipts = [
         str(value)
-        for value in (
-            existing_receipts if isinstance(existing_receipts, list) else []
-        )
+        for value in (existing_receipts if isinstance(existing_receipts, list) else [])
         if REVIEWER_NOTIFICATION_RECEIPT_PATTERN.fullmatch(str(value))
     ]
     for receipt in receipts:


### PR DESCRIPTION
## Summary

- add one bounded reviewer-notification drain for the grouped review-required state bucket
- refresh live PR state before each send and cancel stale merged, approved, draft, failing, or already-reviewed entries
- persist queue receipt v1 with the reviewed public summary so delayed delivery retains the Chinese Reward Memory artifact
- keep one PR per group message with semantic dedupe, readback, and durable receipt writeback

## Validation

- LoopX premerge canary: 18/18 selected checks passed, 0 failures
- issue-fix reviewer request smoke passed, including two due PRs in one grouped batch, stale cancellation, a future-window hold, and idempotent rerun
- reviewer notification sink smoke passed
- ruff check passed on all touched Python files
- public/private boundary scan clean

## Boundary

No project/private state, credentials, raw provider payloads, local paths, or generated uv.lock are included. The command consumes the registered local-private sink config without projecting it into output.

## Residual risk

This changes runtime notification behavior and should receive an independent review before merge. Existing v0 queue rows require a one-time project-state migration to v1; no compatibility reader is added.