### PR TITLE
fix: distinguish user gate decision outcomes

### DIFF
--- a/loopx/capabilities/issue_fix/pr_gate_reconcile.py
+++ b/loopx/capabilities/issue_fix/pr_gate_reconcile.py
@@ -114,6 +114,7 @@ def reconcile_issue_fix_pr_gate(
             goal_id=goal_id,
             todo_id=todo_id,
             role="user",
+            decision_outcome="approve" if state == "MERGED" else "cancel",
             note=(
                 f"Public PR lifecycle reached terminal state {state}; "
                 "the merge approval gate is obsolete."

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -180,6 +180,14 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
     todo_parser.add_argument(
+        "--decision-outcome",
+        choices=["approve", "reject", "cancel"],
+        help=(
+            "For todo complete on a user_gate, record the explicit owner decision. "
+            "Only approve consumes authority and resumes linked work."
+        ),
+    )
+    todo_parser.add_argument(
         "--claimed-by",
         help=(
             "For todo add/claim/update/complete, soft-claim the todo for a registered "
@@ -414,6 +422,10 @@ def handle_todo_command(
                 runtime_root_arg=runtime_root_arg,
             )
         elif args.todo_command == "add":
+            if args.decision_outcome:
+                raise ValueError(
+                    "todo add does not accept --decision-outcome; record it on completion"
+                )
             if args.followups:
                 raise ValueError("todo add does not support --follow-up; use `todo capture-followups`")
             if not args.role:
@@ -501,6 +513,7 @@ def handle_todo_command(
                     ("--clear-explore-result-node-refs", args.clear_explore_result_node_refs),
                     ("--decision-scope", args.decision_scope),
                     ("--required-decision-scope", args.required_decision_scopes),
+                    ("--decision-outcome", args.decision_outcome),
                     ("--blocks-agent", args.blocks_agent),
                     ("--clear-blocks-agent", args.clear_blocks_agent),
                     ("--excluded-agent", args.excluded_agents),
@@ -591,6 +604,10 @@ def handle_todo_command(
                 raise ValueError("todo update requires at least one mutable todo field")
             if args.no_follow_up and not (args.note or args.reason or args.evidence):
                 raise ValueError("--no-follow-up requires --note, --reason, or --evidence")
+            if args.decision_outcome:
+                raise ValueError(
+                    "todo update does not accept --decision-outcome; use todo complete"
+                )
             if args.followups:
                 raise ValueError("todo update does not support --follow-up; use `todo capture-followups`")
             if args.next_claimed_by:
@@ -685,6 +702,7 @@ def handle_todo_command(
                 goal_id=args.goal_id,
                 todo_id=args.todo_id,
                 role=args.role,
+                decision_outcome=args.decision_outcome,
                 evidence=args.evidence,
                 note=args.note,
                 no_followup=bool(args.no_follow_up),
@@ -709,6 +727,10 @@ def handle_todo_command(
             if args.explore_result_node_refs or args.clear_explore_result_node_refs:
                 raise ValueError(
                     "todo supersede does not update --explore-result-node-ref; use todo update first"
+                )
+            if args.decision_outcome:
+                raise ValueError(
+                    "todo supersede does not accept --decision-outcome; use todo complete"
                 )
             if args.claimed_by:
                 raise ValueError(
@@ -758,6 +780,10 @@ def handle_todo_command(
                 dry_run=bool(args.dry_run),
             )
         elif args.todo_command == "archive-completed":
+            if args.decision_outcome:
+                raise ValueError(
+                    "todo archive-completed does not support --decision-outcome"
+                )
             if args.claimed_by or args.clear_claim:
                 raise ValueError("todo archive-completed does not support --claimed-by or --clear-claim")
             if args.clear_blocks_agent or args.excluded_agents or args.clear_excluded_agents or args.next_excluded_agents:

--- a/loopx/control_plane/todos/contract.py
+++ b/loopx/control_plane/todos/contract.py
@@ -47,7 +47,8 @@ TODO_METADATA_FIELDS = (
     "todo_id", "status", "task_class", "action_kind", "continuation_policy",
     "task_repository", "required_write_scopes", "required_capabilities", "target_capabilities",
     "explore_result_node_refs",
-    "decision_scope", "required_decision_scopes", "claimed_by", "blocks_agent",
+    "decision_scope", "required_decision_scopes", "decision_outcome",
+    "decision_scope_outcomes", "claimed_by", "blocks_agent",
     "excluded_agents", "global_gate", "unblocks_todo_id", "successor_todo_ids",
     "resume_when", "no_followup", *TODO_MONITOR_METADATA_FIELDS, "note", "evidence",
     "reason", "completed_at", "updated_at", "superseded_by",
@@ -66,6 +67,8 @@ TODO_TASK_CLASS_VALUES = {
     TODO_TASK_CLASS_BLOCKER,
 }
 TODO_DECISION_SCOPE_SCHEMA_VERSION = "decision_scope_v0"
+TODO_DECISION_SCOPE_OUTCOME_SCHEMA_VERSION = "todo_decision_scope_outcome_v0"
+TODO_DECISION_OUTCOME_VALUES = {"approve", "reject", "cancel"}
 TODO_DECISION_SCOPE_KIND_VALUES = {
     "private_read",
     "write_scope",
@@ -515,6 +518,21 @@ def normalize_todo_decision_scope(value: Any) -> dict[str, str] | None:
     return payload
 
 
+def normalize_todo_decision_outcome(value: Any) -> str | None:
+    candidate = compact_todo_text(value).lower()
+    return candidate if candidate in TODO_DECISION_OUTCOME_VALUES else None
+
+
+def require_todo_decision_outcome(value: Any) -> str:
+    outcome = normalize_todo_decision_outcome(value)
+    if not outcome:
+        raise ValueError(
+            "decision_outcome must be one of: "
+            + ", ".join(sorted(TODO_DECISION_OUTCOME_VALUES))
+        )
+    return outcome
+
+
 def require_todo_decision_scope(value: Any) -> dict[str, str]:
     scope = normalize_todo_decision_scope(value)
     if not scope:
@@ -579,6 +597,68 @@ def required_decision_scopes_metadata_value(value: Any) -> str | None:
     return ",".join(
         f"{scope['kind']}:{scope['granularity']}:{scope['scope_key']}"
         for scope in scopes
+    )
+
+
+def normalize_todo_decision_scope_outcomes(value: Any) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    raw_values = list(value) if isinstance(value, (list, tuple, set)) else [value]
+    if isinstance(value, str):
+        raw_values = [item for item in value.split(",") if item]
+    outcomes: list[dict[str, Any]] = []
+    positions: dict[tuple[str, str, str], int] = {}
+    for raw in raw_values:
+        raw_outcome: Any = None
+        raw_scope: Any = None
+        raw_source_todo_id: Any = None
+        if isinstance(raw, dict):
+            raw_outcome = raw.get("outcome")
+            raw_scope = raw.get("decision_scope") or raw.get("scope")
+            raw_source_todo_id = raw.get("source_todo_id")
+        else:
+            parts = str(raw or "").split("|", 2)
+            if len(parts) == 3:
+                raw_outcome, raw_scope, raw_source_todo_id = parts
+        outcome = normalize_todo_decision_outcome(raw_outcome)
+        scope = normalize_todo_decision_scope(raw_scope)
+        source_todo_id = normalize_todo_id(raw_source_todo_id)
+        if not outcome or not scope or not source_todo_id:
+            continue
+        payload = {
+            "schema_version": TODO_DECISION_SCOPE_OUTCOME_SCHEMA_VERSION,
+            "outcome": outcome,
+            "decision_scope": scope,
+            "source_todo_id": source_todo_id,
+        }
+        identity = (scope["kind"], scope["granularity"], scope["scope_key"])
+        if identity in positions:
+            outcomes[positions[identity]] = payload
+        else:
+            positions[identity] = len(outcomes)
+            outcomes.append(payload)
+    return outcomes
+
+
+def decision_scope_outcomes_metadata_value(value: Any) -> str | None:
+    outcomes = normalize_todo_decision_scope_outcomes(value)
+    if not outcomes:
+        return None
+    return ",".join(
+        "|".join(
+            (
+                item["outcome"],
+                ":".join(
+                    (
+                        item["decision_scope"]["kind"],
+                        item["decision_scope"]["granularity"],
+                        item["decision_scope"]["scope_key"],
+                    )
+                ),
+                item["source_todo_id"],
+            )
+        )
+        for item in outcomes
     )
 
 
@@ -718,9 +798,17 @@ def parse_todo_metadata_line(line: str) -> dict[str, Any] | None:
             if decision_scope:
                 metadata["decision_scope"] = decision_scope
         elif key in {"required_decision_scope", "required_decision_scopes"}:
-            scopes = normalize_todo_required_decision_scopes(value)
-            if scopes:
-                metadata["required_decision_scopes"] = scopes
+            decision_scopes = normalize_todo_required_decision_scopes(value)
+            if decision_scopes:
+                metadata["required_decision_scopes"] = decision_scopes
+        elif key == "decision_outcome":
+            outcome = normalize_todo_decision_outcome(value)
+            if outcome:
+                metadata["decision_outcome"] = outcome
+        elif key == "decision_scope_outcomes":
+            outcomes = normalize_todo_decision_scope_outcomes(value)
+            if outcomes:
+                metadata["decision_scope_outcomes"] = outcomes
         elif key == "claimed_by":
             claimed_by = normalize_todo_claimed_by(value)
             if claimed_by:
@@ -781,6 +869,8 @@ def format_todo_metadata_line(
     explore_result_node_refs: Any = None,
     decision_scope: Any = None,
     required_decision_scopes: Any = None,
+    decision_outcome: str | None = None,
+    decision_scope_outcomes: Any = None,
     claimed_by: str | None = None,
     blocks_agent: str | None = None,
     excluded_agents: Any = None,
@@ -911,6 +1001,29 @@ def format_todo_metadata_line(
             "required_decision_scopes="
             f"{encode_metadata_value(normalized_required_decision_scopes)}"
         )
+    normalized_decision_outcome = normalize_todo_decision_outcome(decision_outcome)
+    if decision_outcome and not normalized_decision_outcome:
+        raise ValueError(
+            "decision_outcome must be one of: "
+            + ", ".join(sorted(TODO_DECISION_OUTCOME_VALUES))
+        )
+    if normalized_decision_outcome:
+        fields.append(
+            f"decision_outcome={encode_metadata_value(normalized_decision_outcome)}"
+        )
+    normalized_scope_outcomes = decision_scope_outcomes_metadata_value(
+        decision_scope_outcomes
+    )
+    if decision_scope_outcomes and not normalized_scope_outcomes:
+        raise ValueError(
+            "decision_scope_outcomes must contain outcome, decision_scope, and "
+            "source_todo_id"
+        )
+    if normalized_scope_outcomes:
+        fields.append(
+            "decision_scope_outcomes="
+            f"{encode_metadata_value(normalized_scope_outcomes)}"
+        )
     normalized_claimed_by = normalize_todo_claimed_by(claimed_by)
     if claimed_by and not normalized_claimed_by:
         raise ValueError("claimed_by must be a public-safe agent token such as codex-main-control")
@@ -991,6 +1104,7 @@ def todo_block_metadata(block: dict[str, Any]) -> dict[str, Any]:
         value = block.get(key)
         if value is None:
             continue
+        normalized: Any
         if key == "required_write_scopes":
             normalized = normalize_required_write_scopes(value)
         elif key == "task_repository":
@@ -1009,6 +1123,10 @@ def todo_block_metadata(block: dict[str, Any]) -> dict[str, Any]:
             normalized = normalize_todo_decision_scope(value)
         elif key == "required_decision_scopes":
             normalized = normalize_todo_required_decision_scopes(value)
+        elif key == "decision_outcome":
+            normalized = normalize_todo_decision_outcome(value)
+        elif key == "decision_scope_outcomes":
+            normalized = normalize_todo_decision_scope_outcomes(value)
         elif key == "no_followup":
             normalized = normalize_todo_no_followup(value)
         elif key == "global_gate":
@@ -1083,6 +1201,14 @@ def metadata_line_for_todo_block(
             normalized = require_todo_required_decision_scopes(value)
             if normalized:
                 metadata[key] = normalized
+            else:
+                metadata.pop(key, None)
+        elif key == "decision_outcome":
+            metadata[key] = require_todo_decision_outcome(value)
+        elif key == "decision_scope_outcomes":
+            normalized_scope_outcomes = normalize_todo_decision_scope_outcomes(value)
+            if normalized_scope_outcomes:
+                metadata[key] = normalized_scope_outcomes
             else:
                 metadata.pop(key, None)
         elif key == "no_followup":

--- a/loopx/control_plane/todos/decision_scope.py
+++ b/loopx/control_plane/todos/decision_scope.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from .contract import (
     normalize_todo_decision_scope,
+    normalize_todo_decision_scope_outcomes,
     normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
     normalize_todo_global_gate,
@@ -131,6 +132,7 @@ def build_required_decision_scope_consistency(
     user_actions = [item for item in user_items if not is_user_gate_todo_item(item)]
     errors: list[dict[str, Any]] = []
     checked_scope_count = 0
+    terminal_outcome_count = 0
 
     for agent_item in agent_items:
         claimed_by = normalize_todo_claimed_by(agent_item.get("claimed_by"))
@@ -154,6 +156,33 @@ def build_required_decision_scope_consistency(
                 if _gate_owner_compatible(gate, agent_id=effective_owner)
             ]
             if compatible_gates:
+                continue
+            terminal_outcomes = [
+                item
+                for item in normalize_todo_decision_scope_outcomes(
+                    agent_item.get("decision_scope_outcomes")
+                )
+                if item.get("outcome") in {"reject", "cancel"}
+                and decision_scope_covers(
+                    item.get("decision_scope"),
+                    required_scope,
+                )
+            ]
+            if terminal_outcomes:
+                terminal_outcome_count += 1
+                if str(agent_item.get("status") or "open") != "blocked":
+                    errors.append(
+                        {
+                            "reason_code": "terminal_decision_outcome_target_not_blocked",
+                            "agent_todo_id": normalize_todo_id(
+                                agent_item.get("todo_id")
+                            ),
+                            "required_scope": _scope_identity(required_scope),
+                            "related_user_todo_ids": [
+                                item["source_todo_id"] for item in terminal_outcomes
+                            ],
+                        }
+                    )
                 continue
             matching_actions = [
                 item
@@ -185,6 +214,7 @@ def build_required_decision_scope_consistency(
         "agent_id": normalize_todo_claimed_by(agent_id),
         "checked_agent_todo_count": len(agent_items),
         "checked_required_scope_count": checked_scope_count,
+        "terminal_outcome_count": terminal_outcome_count,
         "errors": errors,
     }
 

--- a/loopx/control_plane/todos/summary_item.py
+++ b/loopx/control_plane/todos/summary_item.py
@@ -4,7 +4,9 @@ from typing import Any
 
 from .contract import (
     normalize_required_write_scopes,
+    normalize_todo_decision_outcome,
     normalize_todo_decision_scope,
+    normalize_todo_decision_scope_outcomes,
     normalize_todo_excluded_agents,
     normalize_todo_id,
     normalize_removed_todo_continuation_policy,
@@ -36,6 +38,8 @@ TODO_SUMMARY_COMPACT_FIELDS = (
     "target_capabilities",
     "decision_scope",
     "required_decision_scopes",
+    "decision_outcome",
+    "decision_scope_outcomes",
     "claimed_by",
     "blocks_agent",
     "excluded_agents",
@@ -122,6 +126,18 @@ def compact_todo_summary_item(
         compact["required_decision_scopes"] = required_decision_scopes
     else:
         compact.pop("required_decision_scopes", None)
+    decision_outcome = normalize_todo_decision_outcome(compact.get("decision_outcome"))
+    if decision_outcome:
+        compact["decision_outcome"] = decision_outcome
+    else:
+        compact.pop("decision_outcome", None)
+    decision_scope_outcomes = normalize_todo_decision_scope_outcomes(
+        compact.get("decision_scope_outcomes")
+    )
+    if decision_scope_outcomes:
+        compact["decision_scope_outcomes"] = decision_scope_outcomes
+    else:
+        compact.pop("decision_scope_outcomes", None)
     excluded_agents = normalize_todo_excluded_agents(compact.get("excluded_agents"))
     if excluded_agents:
         compact["excluded_agents"] = excluded_agents

--- a/loopx/control_plane/todos/todo_summary.py
+++ b/loopx/control_plane/todos/todo_summary.py
@@ -21,7 +21,9 @@ from .contract import (
     normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
     normalize_todo_continuation_policy,
+    normalize_todo_decision_outcome,
     normalize_todo_decision_scope,
+    normalize_todo_decision_scope_outcomes,
     normalize_todo_excluded_agents,
     normalize_todo_global_gate,
     normalize_todo_id,
@@ -339,6 +341,14 @@ def structured_todo_item(
     )
     if required_decision_scopes:
         normalized["required_decision_scopes"] = required_decision_scopes
+    decision_outcome = normalize_todo_decision_outcome(item.get("decision_outcome"))
+    if decision_outcome:
+        normalized["decision_outcome"] = decision_outcome
+    decision_scope_outcomes = normalize_todo_decision_scope_outcomes(
+        item.get("decision_scope_outcomes")
+    )
+    if decision_scope_outcomes:
+        normalized["decision_scope_outcomes"] = decision_scope_outcomes
     claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
     if claimed_by:
         normalized["claimed_by"] = claimed_by
@@ -392,6 +402,8 @@ def compact_todo_item(item: dict[str, Any]) -> dict[str, Any]:
         "explore_result_node_refs",
         "decision_scope",
         "required_decision_scopes",
+        "decision_outcome",
+        "decision_scope_outcomes",
         "claimed_by",
         "blocks_agent",
         "excluded_agents",

--- a/loopx/control_plane/todos/unblock_resume.py
+++ b/loopx/control_plane/todos/unblock_resume.py
@@ -5,11 +5,15 @@ from typing import Any, Callable
 from .active_state_editing import section_bounds, todo_blocks
 from .contract import (
     TODO_STATUS_OPEN,
+    TODO_STATUS_BLOCKED,
     TODO_TASK_CLASS_USER_GATE,
+    normalize_todo_decision_outcome,
     normalize_todo_decision_scope,
+    normalize_todo_decision_scope_outcomes,
     normalize_todo_id,
     normalize_todo_required_decision_scopes,
     normalize_todo_status,
+    require_todo_decision_outcome,
     todo_done_for_status,
 )
 from .decision_scope import decision_scope_covers
@@ -19,6 +23,35 @@ TODO_UNBLOCK_RESUME_SCHEMA_VERSION = "todo_unblock_resume_v0"
 TODO_DECISION_SCOPE_RESOLUTION_SCHEMA_VERSION = (
     "todo_decision_scope_resolution_v0"
 )
+
+
+def require_completion_decision_outcome(
+    completion_todo: dict[str, Any] | None,
+    decision_outcome: str | None,
+    *,
+    materialized: bool,
+) -> str | None:
+    is_user_gate = (
+        str((completion_todo or {}).get("role") or "") == "user"
+        and str((completion_todo or {}).get("task_class") or "")
+        == TODO_TASK_CLASS_USER_GATE
+    )
+    if not is_user_gate:
+        if decision_outcome is not None:
+            raise ValueError(
+                "decision_outcome is only valid when completing a user_gate"
+            )
+        return None
+    if decision_outcome is None:
+        raise ValueError(
+            "user_gate completion requires decision_outcome=approve, reject, or cancel"
+        )
+    if not materialized:
+        raise ValueError(
+            "event-projected user_gate completion must first materialize the gate "
+            "in active state so its decision outcome is durable"
+        )
+    return require_todo_decision_outcome(decision_outcome)
 
 
 def _status(todo: dict[str, Any]) -> str:
@@ -152,6 +185,7 @@ def apply_completed_user_todo_lifecycle(
     completion_todo: dict[str, Any] | None,
     update_result: dict[str, Any],
     fallback_todo_id: str,
+    decision_outcome: str | None,
     updated_at: str,
     apply_update: Callable[..., dict[str, Any]],
 ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
@@ -159,12 +193,14 @@ def apply_completed_user_todo_lifecycle(
 
     completion_role = str((completion_todo or {}).get("role") or "")
     completion_task_class = str((completion_todo or {}).get("task_class") or "")
+    normalized_outcome = normalize_todo_decision_outcome(decision_outcome)
     source_todo_id = str(update_result.get("todo_id") or fallback_todo_id)
     target_todo_id = normalize_todo_id(update_result.get("unblocks_todo_id"))
     decision_scope_resolution = None
     if (
         completion_role == "user"
         and completion_task_class == TODO_TASK_CLASS_USER_GATE
+        and normalized_outcome == "approve"
         and target_todo_id
     ):
         decision_scope_resolution = plan_completed_user_gate_decision_scope_resolution(
@@ -174,6 +210,17 @@ def apply_completed_user_todo_lifecycle(
             decision_scope=(completion_todo or {}).get("decision_scope"),
         )
         if decision_scope_resolution:
+            target = _find_todo(lines, role="agent", todo_id=target_todo_id)
+            remaining_outcomes = [
+                item
+                for item in normalize_todo_decision_scope_outcomes(
+                    (target or {}).get("decision_scope_outcomes")
+                )
+                if not decision_scope_covers(
+                    (completion_todo or {}).get("decision_scope"),
+                    item.get("decision_scope"),
+                )
+            ]
             resolved_target = apply_update(
                 lines,
                 todo_id=target_todo_id,
@@ -181,6 +228,7 @@ def apply_completed_user_todo_lifecycle(
                 required_decision_scopes=decision_scope_resolution[
                     "remaining_required_decision_scopes"
                 ],
+                decision_scope_outcomes=remaining_outcomes,
                 updated_at=updated_at,
             )
             decision_scope_resolution.update(
@@ -192,7 +240,62 @@ def apply_completed_user_todo_lifecycle(
     unblock_resume = None
     if (
         completion_role == "user"
-        and completion_task_class in {"user_action", TODO_TASK_CLASS_USER_GATE}
+        and completion_task_class == TODO_TASK_CLASS_USER_GATE
+        and normalized_outcome in {"reject", "cancel"}
+        and target_todo_id
+    ):
+        target = _find_todo(lines, role="agent", todo_id=target_todo_id)
+        decision_scope = normalize_todo_decision_scope(
+            (completion_todo or {}).get("decision_scope")
+        )
+        target_outcomes = normalize_todo_decision_scope_outcomes(
+            (target or {}).get("decision_scope_outcomes")
+        )
+        if target and decision_scope:
+            target_outcomes.append(
+                {
+                    "outcome": normalized_outcome,
+                    "decision_scope": decision_scope,
+                    "source_todo_id": source_todo_id,
+                }
+            )
+            recorded = apply_update(
+                lines,
+                todo_id=target_todo_id,
+                role="agent",
+                status=TODO_STATUS_BLOCKED,
+                decision_scope_outcomes=target_outcomes,
+                updated_at=updated_at,
+            )
+            unblock_resume = {
+                "schema_version": TODO_UNBLOCK_RESUME_SCHEMA_VERSION,
+                "source_todo_id": source_todo_id,
+                "target_todo_id": target_todo_id,
+                "state": (
+                    "decision_rejected"
+                    if normalized_outcome == "reject"
+                    else "decision_cancelled"
+                ),
+                "status": recorded.get("status"),
+                "changed": bool(recorded.get("changed")),
+            }
+        else:
+            unblock_resume = {
+                "schema_version": TODO_UNBLOCK_RESUME_SCHEMA_VERSION,
+                "source_todo_id": source_todo_id,
+                "target_todo_id": target_todo_id,
+                "state": "target_or_decision_scope_not_found",
+                "changed": False,
+            }
+    elif (
+        completion_role == "user"
+        and (
+            completion_task_class == "user_action"
+            or (
+                completion_task_class == TODO_TASK_CLASS_USER_GATE
+                and normalized_outcome == "approve"
+            )
+        )
         and target_todo_id
     ):
         unblock_resume = plan_completed_user_unblock_resume(

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -37,6 +37,7 @@ from .control_plane.todos.contract import (
     normalize_todo_claimed_by,
     normalize_todo_continuation_policy,
     normalize_todo_decision_scope,
+    normalize_todo_decision_scope_outcomes,
     normalize_todo_excluded_agents,
     normalize_todo_global_gate,
     normalize_todo_id,
@@ -79,7 +80,10 @@ from .control_plane.todos.text import (
     inherit_todo_priority,
     normalize_new_todo,
 )
-from .control_plane.todos.unblock_resume import apply_completed_user_todo_lifecycle
+from .control_plane.todos.unblock_resume import (
+    apply_completed_user_todo_lifecycle,
+    require_completion_decision_outcome,
+)
 from .control_plane.todos.write_policy import require_user_gate_scope, require_user_todo_task_class
 
 
@@ -1069,6 +1073,8 @@ def apply_todo_update_to_lines(
     explore_result_node_refs: list[str] | None = None,
     decision_scope: Any = None,
     required_decision_scopes: Any = None,
+    decision_outcome: str | None = None,
+    decision_scope_outcomes: Any = None,
     claimed_by: str | None = None,
     blocks_agent: str | None = None,
     clear_blocks_agent: bool = False,
@@ -1163,6 +1169,10 @@ def apply_todo_update_to_lines(
         updates["decision_scope"] = decision_scope
     if required_decision_scopes is not None:
         updates["required_decision_scopes"] = required_decision_scopes
+    if decision_outcome is not None:
+        updates["decision_outcome"] = decision_outcome
+    if decision_scope_outcomes is not None:
+        updates["decision_scope_outcomes"] = decision_scope_outcomes
     if clear_claim:
         updates["claimed_by"] = None
     elif claimed_by:
@@ -1230,6 +1240,10 @@ def apply_todo_update_to_lines(
         "decision_scope": normalize_todo_decision_scope(effective_metadata.get("decision_scope")),
         "required_decision_scopes": normalize_todo_required_decision_scopes(
             effective_metadata.get("required_decision_scopes")
+        ),
+        "decision_outcome": effective_metadata.get("decision_outcome"),
+        "decision_scope_outcomes": normalize_todo_decision_scope_outcomes(
+            effective_metadata.get("decision_scope_outcomes")
         ),
         "blocks_agent": normalize_todo_blocks_agent(effective_metadata.get("blocks_agent")),
         "excluded_agents": normalize_todo_excluded_agents(
@@ -1512,6 +1526,7 @@ def complete_goal_todo(
     goal_id: str,
     todo_id: str,
     role: str | None = None,
+    decision_outcome: str | None = None,
     evidence: str | None = None,
     note: str | None = None,
     no_followup: bool = False,
@@ -1560,6 +1575,11 @@ def complete_goal_todo(
                 event_context["project"] = resolved_project
                 completion_todo = dict(event_context["item"])
                 completion_todo["role"] = event_context["role"]
+        effective_decision_outcome = require_completion_decision_outcome(
+            completion_todo,
+            decision_outcome,
+            materialized=bool(completion_match),
+        )
         normalized_successor_todo_ids = normalize_todo_id_list(successor_todo_ids)
         if successor_todo_ids and not normalized_successor_todo_ids:
             raise ValueError("successor_todo_ids must contain public todo_<letters-digits-underscore-hyphen> tokens")
@@ -1644,6 +1664,7 @@ def complete_goal_todo(
             todo_id=todo_id,
             status=TODO_STATUS_DONE,
             role=role,
+            decision_outcome=effective_decision_outcome,
             note=note,
             evidence=evidence,
             claimed_by=effective_claimed_by,
@@ -1658,6 +1679,7 @@ def complete_goal_todo(
                 completion_todo=completion_todo,
                 update_result=update_result,
                 fallback_todo_id=todo_id,
+                decision_outcome=effective_decision_outcome,
                 updated_at=updated_at,
                 apply_update=apply_todo_update_to_lines,
             )
@@ -1748,6 +1770,8 @@ def complete_goal_todo(
         result["unblock_resume"] = unblock_resume
     if decision_scope_resolution:
         result["decision_scope_resolution"] = decision_scope_resolution
+    if effective_decision_outcome:
+        result["decision_outcome"] = effective_decision_outcome
     result["self_merged"] = effective_self_merged
     return result
 

--- a/tests/control_plane/test_todo_decision_scope_cli_validation.py
+++ b/tests/control_plane/test_todo_decision_scope_cli_validation.py
@@ -189,3 +189,129 @@ def test_todo_update_rejects_invalid_decision_scope_tokens_without_data_loss(
                 scope["scope_key"] for scope in readback["todo"][field]
             ] == ["release_route"]
         assert state_file.read_text(encoding="utf-8") == original
+
+
+@pytest.mark.parametrize(
+    ("decision_outcome", "expected_status", "scope_retained"),
+    [
+        ("approve", "open", False),
+        ("reject", "blocked", True),
+        ("cancel", "blocked", True),
+    ],
+)
+def test_todo_complete_cli_applies_explicit_user_gate_outcome(
+    tmp_path: Path,
+    decision_outcome: str,
+    expected_status: str,
+    scope_retained: bool,
+) -> None:
+    registry_path, _state_file = _write_fixture(tmp_path)
+    target = run_json_cli(
+        "todo",
+        "add",
+        "--goal-id",
+        GOAL_ID,
+        "--role",
+        "agent",
+        "--task-class",
+        "advancement_task",
+        "--status",
+        "blocked",
+        "--text",
+        "Read restricted material only after an explicit decision.",
+        "--required-decision-scope",
+        "private_read:project:restricted_material",
+        registry_path=registry_path,
+    )
+    gate = run_json_cli(
+        "todo",
+        "add",
+        "--goal-id",
+        GOAL_ID,
+        "--role",
+        "user",
+        "--task-class",
+        "user_gate",
+        "--text",
+        "Decide whether this agent may read restricted material.",
+        "--decision-scope",
+        "private_read:project:restricted_material",
+        "--unblocks-todo-id",
+        target["todo_id"],
+        registry_path=registry_path,
+    )
+
+    completed = run_json_cli(
+        "todo",
+        "complete",
+        "--goal-id",
+        GOAL_ID,
+        "--todo-id",
+        gate["todo_id"],
+        "--role",
+        "user",
+        "--decision-outcome",
+        decision_outcome,
+        "--evidence",
+        f"owner recorded {decision_outcome}",
+        registry_path=registry_path,
+    )
+
+    assert completed["decision_outcome"] == decision_outcome
+    target_readback = run_json_cli(
+        "todo",
+        "list",
+        "--goal-id",
+        GOAL_ID,
+        "--todo-id",
+        target["todo_id"],
+        registry_path=registry_path,
+    )["todo"]
+    assert target_readback["status"] == expected_status
+    assert bool(target_readback.get("required_decision_scopes")) is scope_retained
+    if decision_outcome == "approve":
+        assert target_readback.get("decision_scope_outcomes", []) == []
+    else:
+        assert target_readback["decision_scope_outcomes"][0]["outcome"] == (
+            decision_outcome
+        )
+
+
+def test_todo_complete_cli_rejects_ambiguous_user_gate_completion(
+    tmp_path: Path,
+) -> None:
+    registry_path, state_file = _write_fixture(tmp_path)
+    gate = run_json_cli(
+        "todo",
+        "add",
+        "--goal-id",
+        GOAL_ID,
+        "--role",
+        "user",
+        "--task-class",
+        "user_gate",
+        "--text",
+        "Decide whether publication is authorized.",
+        "--decision-scope",
+        VALID_SCOPE,
+        registry_path=registry_path,
+    )
+    original = state_file.read_text(encoding="utf-8")
+
+    returncode, payload = run_json_cli_result(
+        "todo",
+        "complete",
+        "--goal-id",
+        GOAL_ID,
+        "--todo-id",
+        gate["todo_id"],
+        "--role",
+        "user",
+        "--evidence",
+        "ambiguous completion",
+        registry_path=registry_path,
+    )
+
+    assert returncode != 0
+    assert "user_gate completion requires decision_outcome" in payload["error"]
+    assert state_file.read_text(encoding="utf-8") == original

--- a/tests/control_plane/test_todo_decision_scope_consistency.py
+++ b/tests/control_plane/test_todo_decision_scope_consistency.py
@@ -184,6 +184,59 @@ def test_complete_source_items_take_precedence_over_hot_path_summary() -> None:
     assert result["errors"][0]["reason_code"] == "dangling_required_decision_scope"
 
 
+@pytest.mark.parametrize("decision_outcome", ["reject", "cancel"])
+def test_terminal_non_approval_is_a_valid_blocked_scope_state(
+    decision_outcome: str,
+) -> None:
+    agent_summary = _agent_summary()
+    agent_item = agent_summary["first_open_items"][0]
+    agent_item["status"] = "blocked"
+    agent_item["decision_scope_outcomes"] = [
+        {
+            "outcome": decision_outcome,
+            "decision_scope": SCOPE,
+            "source_todo_id": "todo_terminal_gate",
+        }
+    ]
+
+    result = build_required_decision_scope_consistency(
+        agent_summary,
+        _user_summary(),
+        agent_id=AGENT_ID,
+    )
+
+    assert result["ok"] is True
+    assert result["terminal_outcome_count"] == 1
+    assert result["errors"] == []
+
+
+def test_terminal_non_approval_cannot_leave_target_executable() -> None:
+    agent_summary = _agent_summary()
+    agent_summary["first_open_items"][0]["decision_scope_outcomes"] = [
+        {
+            "outcome": "reject",
+            "decision_scope": SCOPE,
+            "source_todo_id": "todo_terminal_gate",
+        }
+    ]
+
+    result = build_required_decision_scope_consistency(
+        agent_summary,
+        _user_summary(),
+        agent_id=AGENT_ID,
+    )
+
+    assert result["ok"] is False
+    assert result["errors"] == [
+        {
+            "reason_code": "terminal_decision_outcome_target_not_blocked",
+            "agent_todo_id": "todo_agent_delivery",
+            "required_scope": "direction:action:publish_quality_contract",
+            "related_user_todo_ids": ["todo_terminal_gate"],
+        }
+    ]
+
+
 def test_quota_checks_scope_item_beyond_hot_path_backlog_limit() -> None:
     items = [
         quota_todo_item(

--- a/tests/control_plane/test_todo_decision_scope_lifecycle.py
+++ b/tests/control_plane/test_todo_decision_scope_lifecycle.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from loopx.quota import build_quota_should_run
 from loopx.status import collect_status, parse_active_state_todos
 from loopx.todos import add_goal_todo, complete_goal_todo, supersede_goal_todo
@@ -13,6 +15,7 @@ AGENT_ID = "codex-delivery"
 OTHER_AGENT_ID = "codex-review"
 PUBLISH_SCOPE = "direction:action:publish_release"
 ANNOUNCE_SCOPE = "direction:action:announce_release"
+PRIVATE_READ_SCOPE = "private_read:project:restricted_material"
 
 
 def _write_fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
@@ -74,6 +77,7 @@ def _add_target_and_gate(
     *,
     required_scopes: list[str],
     target_status: str = "open",
+    decision_scope: str = PUBLISH_SCOPE,
 ) -> tuple[dict, dict]:
     target = add_goal_todo(
         registry_path=registry,
@@ -92,7 +96,7 @@ def _add_target_and_gate(
         text="Approve publishing the release artifact.",
         task_class="user_gate",
         blocks_agent=AGENT_ID,
-        decision_scope=PUBLISH_SCOPE,
+        decision_scope=decision_scope,
         unblocks_todo_id=target["todo_id"],
     )
     return target, gate
@@ -112,6 +116,7 @@ def test_completed_gate_consumes_scope_for_already_open_publication(
         goal_id=GOAL_ID,
         todo_id=gate["todo_id"],
         role="user",
+        decision_outcome="approve",
         evidence="owner approved the exact release publication",
     )
 
@@ -168,6 +173,7 @@ def test_completed_gate_consumes_only_covered_scope(tmp_path: Path) -> None:
         goal_id=GOAL_ID,
         todo_id=gate["todo_id"],
         role="user",
+        decision_outcome="approve",
         evidence="owner approved publication only",
     )
 
@@ -208,3 +214,96 @@ def test_superseded_gate_does_not_consume_required_scope(tmp_path: Path) -> None
     assert [
         item["scope_key"] for item in updated_target["required_decision_scopes"]
     ] == ["publish_release"]
+
+
+@pytest.mark.parametrize(
+    ("decision_outcome", "unblock_state"),
+    [
+        ("reject", "decision_rejected"),
+        ("cancel", "decision_cancelled"),
+    ],
+)
+def test_non_approval_gate_outcome_remains_a_durable_block(
+    tmp_path: Path,
+    decision_outcome: str,
+    unblock_state: str,
+) -> None:
+    repo, state, registry = _write_fixture(tmp_path)
+    target, gate = _add_target_and_gate(
+        registry,
+        required_scopes=[PRIVATE_READ_SCOPE],
+        target_status="blocked",
+        decision_scope=PRIVATE_READ_SCOPE,
+    )
+
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=gate["todo_id"],
+        role="user",
+        decision_outcome=decision_outcome,
+        evidence=f"owner recorded {decision_outcome} for the exact private read",
+    )
+
+    assert result["decision_outcome"] == decision_outcome
+    assert "decision_scope_resolution" not in result
+    assert result["unblock_resume"]["state"] == unblock_state
+    updated_target = _todo(state, target["todo_id"])
+    assert updated_target["status"] == "blocked"
+    assert updated_target["required_decision_scopes"][0]["scope_key"] == (
+        "restricted_material"
+    )
+    assert updated_target["decision_scope_outcomes"] == [
+        {
+            "schema_version": "todo_decision_scope_outcome_v0",
+            "outcome": decision_outcome,
+            "decision_scope": {
+                "schema_version": "decision_scope_v0",
+                "kind": "private_read",
+                "granularity": "project",
+                "scope_key": "restricted_material",
+            },
+            "source_todo_id": gate["todo_id"],
+        }
+    ]
+    assert "authorization satisfied" not in str(updated_target.get("reason") or "")
+
+    status = collect_status(
+        registry_path=registry,
+        runtime_root_override=str(tmp_path / "runtime"),
+        scan_roots=[repo],
+        limit=1,
+        goal_id=GOAL_ID,
+    )
+    quota = build_quota_should_run(status, goal_id=GOAL_ID, agent_id=AGENT_ID)
+    assert quota["effective_action"] != "todo_decision_scope_projection_repair"
+    consistency = quota.get("todo_decision_scope_consistency")
+    assert consistency is None or consistency["ok"] is True
+
+
+def test_user_gate_completion_requires_explicit_decision_outcome(
+    tmp_path: Path,
+) -> None:
+    _repo, state, registry = _write_fixture(tmp_path)
+    target, gate = _add_target_and_gate(
+        registry,
+        required_scopes=[PRIVATE_READ_SCOPE],
+        target_status="blocked",
+        decision_scope=PRIVATE_READ_SCOPE,
+    )
+    before = state.read_text(encoding="utf-8")
+
+    with pytest.raises(
+        ValueError,
+        match="user_gate completion requires decision_outcome",
+    ):
+        complete_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=gate["todo_id"],
+            role="user",
+            evidence="ambiguous completion must not grant authority",
+        )
+
+    assert state.read_text(encoding="utf-8") == before
+    assert _todo(state, target["todo_id"])["status"] == "blocked"


### PR DESCRIPTION
## Summary

- Require an explicit `approve`, `reject`, or `cancel` outcome when completing a `user_gate`.
- Let only `approve` consume matching decision scope and resume linked work.
- Persist `reject` and `cancel` as target-side terminal scope outcomes, retain the required scope, and keep the target blocked.
- Map merged PR gates to `approve` and closed-unmerged PR gates to `cancel`.

## State contract

| Outcome | Required scope | Target status | Resume |
| --- | --- | --- | --- |
| `approve` | consumed when covered | open when otherwise eligible | allowed |
| `reject` | retained | blocked | forbidden |
| `cancel` | retained | blocked | forbidden |

## Validation

- Full pytest: 661 passed, 2 skipped.
- Focused decision-scope suite: 25 passed.
- `todo-user-gate-scope-smoke.py`: passed.
- Ruff on all changed Python files: passed.
- `git diff --check`: passed.
- Risk-based premerge canary: 17/17 passed, including state-machine, quota/resume, interaction-contract, line-budget, and CLI modularization checks.
- An initial canary run caught `loopx/todos.py` at 2019 lines; the validation helper was moved into the todo bounded context, and the final file is 1997 lines with the line-budget canary passing.
- Broad mypy is not currently a usable repository gate: it reports 3157 pre-existing errors across 240 files.
- Live Doubao was not run because `ARK_API_KEY` was not injected into the clean candidate process. The actual-default model portfolio covers agent waiting at a pending gate; terminal approve/reject/cancel authority is covered here by deterministic state oracles and real CLI E2E.

## Boundary and review hold

- No credentials, private state, local paths, raw model evidence, or generated logs are included.
- Owner review is required because this changes authorization semantics and intentionally makes ambiguous user-gate completion fail closed.