### PR TITLE
fix(issue-fix): support Python 3.9 reviewer drain imports

### DIFF
--- a/loopx/capabilities/issue_fix/reviewer_notification_drain.py
+++ b/loopx/capabilities/issue_fix/reviewer_notification_drain.py
@@ -29,7 +29,7 @@ ISSUE_FIX_REVIEWER_NOTIFICATION_DRAIN_SCHEMA_VERSION = (
     "issue_fix_reviewer_notification_drain_v0"
 )
 MetadataLoader = Callable[..., tuple[Optional[dict[str, Any]], Optional[str]]]
-SemanticHistoryMatcher = Callable[[str, Mapping[str, Any]], bool | None]
+SemanticHistoryMatcher = Callable[[str, Mapping[str, Any]], Optional[bool]]
 
 
 def _row_with_live_lifecycle_facts(


### PR DESCRIPTION
## Summary
- make the grouped reviewer notification drain importable on Python 3.9
- preserve the existing optional semantic-history matcher contract

## Validation
- `PYTHONPATH=. /usr/bin/python3 -c "from loopx.capabilities.issue_fix.reviewer_notification_drain import SemanticHistoryMatcher"`
- `LOOPX_PYTHON=/usr/bin/python3 scripts/loopx --format json doctor --deep`
- `PYTHONPATH=. /usr/bin/python3 examples/issue-fix-reviewer-notification-drain-postwrite-smoke.py`
- `PYTHONPATH=. /usr/bin/python3 examples/issue-fix-reviewer-request-smoke.py`
- `LOOPX_PYTHON=/usr/bin/python3 scripts/loopx canary premerge --from-git-diff` (5/5 selected canaries passed)

## Boundary
- one runtime type-alias compatibility edit
- no local state, credentials, logs, generated artifacts, or private material included