### PR TITLE
fix(control-plane): repair ambiguous user gate scope

### DIFF
--- a/examples/control_plane/quota-agent-scoped-user-gate-smoke.py
+++ b/examples/control_plane/quota-agent-scoped-user-gate-smoke.py
@@ -42,6 +42,7 @@ def todo_item(
     claimed_by: str | None = None,
     action_kind: str | None = None,
     blocks_agent: str | None = None,
+    global_gate: bool = False,
     cadence: str | None = None,
     next_due_at: str | None = None,
     target_key: str | None = None,
@@ -53,6 +54,7 @@ def todo_item(
             "cadence": cadence,
             "next_due_at": next_due_at,
             "target_key": target_key,
+            "global_gate": True if global_gate else None,
         }.items()
         if value is not None
     }
@@ -119,7 +121,11 @@ def status_fixture_payload(
     )
 
 
-def status_payload(*, blocks_agent: str | None = "codex-product-capability") -> dict:
+def status_payload(
+    *,
+    blocks_agent: str | None = "codex-product-capability",
+    global_gate: bool = False,
+) -> dict:
     user_gate = todo_item(
         todo_id="todo_lark_kanban_gate",
         text="Choose the Lark Kanban target Base before product-capability setup.",
@@ -127,6 +133,7 @@ def status_payload(*, blocks_agent: str | None = "codex-product-capability") -> 
         task_class="user_gate",
         action_kind="lark_kanban_target_decision",
         blocks_agent=blocks_agent,
+        global_gate=global_gate,
     )
     agent_todo = todo_item(
         todo_id="todo_benchmark_driver",
@@ -294,9 +301,32 @@ def assert_target_agent_still_blocks_on_its_user_gate() -> None:
     assert "agent_scoped_user_gate_override" not in payload, payload
 
 
-def assert_unscoped_user_gate_remains_global() -> None:
+def assert_unscoped_user_gate_requires_projection_repair() -> None:
     payload = build_quota_should_run(
         status_payload(blocks_agent=None),
+        goal_id=GOAL_ID,
+        agent_id="codex-main-control",
+    )
+    assert payload["decision"] == "self_repair", payload
+    assert payload["should_run"] is True, payload
+    assert payload["normal_delivery_allowed"] is False, payload
+    assert payload["self_repair_allowed"] is True, payload
+    assert payload["effective_action"] == "todo_decision_scope_projection_repair", payload
+    assert payload["requires_user_action"] is False, payload
+    assert payload["action_required"] is False, payload
+    assert payload["interaction_contract"]["mode"] == "control_plane_self_repair", payload
+    assert payload["interaction_contract"]["user_channel"]["notify"] == "DONT_NOTIFY", payload
+    assert payload["user_todo_summary"]["open_count"] == 1, payload
+    assert payload["open_count"] == 1, payload
+    assert "agent_scoped_user_gate_override" not in payload, payload
+    consistency = payload["todo_decision_scope_consistency"]
+    assert consistency["status"] == "projection_repair_required", consistency
+    assert consistency["errors"][0]["reason_code"] == "multi_agent_user_gate_missing_scope"
+
+
+def assert_explicit_global_gate_blocks_goal() -> None:
+    payload = build_quota_should_run(
+        status_payload(blocks_agent=None, global_gate=True),
         goal_id=GOAL_ID,
         agent_id="codex-main-control",
     )
@@ -306,7 +336,7 @@ def assert_unscoped_user_gate_remains_global() -> None:
     assert payload["interaction_contract"]["mode"] == "user_gate", payload
     assert payload["user_todo_summary"]["open_count"] == 1, payload
     assert payload["open_count"] == 1, payload
-    assert "agent_scoped_user_gate_override" not in payload, payload
+    assert "stall_self_repair" not in payload, payload
 
 
 def unrelated_gate_status_payload() -> dict:
@@ -924,7 +954,8 @@ def main() -> int:
     assert_other_agent_user_gate_does_not_block_current_agent()
     assert_other_agent_user_gate_does_not_notify_non_due_monitor_lane()
     assert_target_agent_still_blocks_on_its_user_gate()
-    assert_unscoped_user_gate_remains_global()
+    assert_unscoped_user_gate_requires_projection_repair()
+    assert_explicit_global_gate_blocks_goal()
     assert_unrelated_user_gate_allows_feishu_fallback()
     assert_exact_todo_gate_only_blocks_target_todo()
     assert_scoped_gate_rejects_capability_ineligible_only_fallback()

--- a/loopx/control_plane/quota/heartbeat_recommendation.py
+++ b/loopx/control_plane/quota/heartbeat_recommendation.py
@@ -181,15 +181,14 @@ def build_heartbeat_recommendation(
         "spend_policy": "do not append quota spend unless a completed bounded progress segment produced substantive progress",
     }
 
-    if state == "operator_gate":
-        return {
-            **base,
-            "recommended_mode": "ask_operator_gate",
-            "notify": "NOTIFY",
-            "spend_policy": "do not append quota spend while asking the operator gate",
-            "reason": "operator gate blocks the gated delivery path",
-        }
-    if stall_self_repair and stall_self_repair.get("allowed"):
+    if (
+        stall_self_repair
+        and stall_self_repair.get("allowed")
+        and (
+            state != "operator_gate"
+            or stall_self_repair.get("trigger") == "user_gate_scope_projection_drift"
+        )
+    ):
         return {
             **base,
             "recommended_mode": stall_self_repair.get("recommended_mode") or "repair_control_plane_stall",
@@ -197,6 +196,14 @@ def build_heartbeat_recommendation(
             "spend_policy": stall_self_repair.get("spend_policy") or base["spend_policy"],
             "reason": stall_self_repair.get("reason") or "control-plane stall requires bounded repair",
             "repair_focus": stall_self_repair.get("repair_focus"),
+        }
+    if state == "operator_gate":
+        return {
+            **base,
+            "recommended_mode": "ask_operator_gate",
+            "notify": "NOTIFY",
+            "spend_policy": "do not append quota spend while asking the operator gate",
+            "reason": "operator gate blocks the gated delivery path",
         }
     if should_run and replan_obligation and replan_obligation.get("required"):
         return {

--- a/loopx/control_plane/quota/stall_repair.py
+++ b/loopx/control_plane/quota/stall_repair.py
@@ -19,6 +19,10 @@ STALL_HEALTH_ITEM_COMPACT_FIELDS = (
     "recommended_action",
 )
 DECISION_SCOPE_REPAIR_TRIGGER = "required_decision_scope_projection_drift"
+USER_GATE_SCOPE_REPAIR_TRIGGER = "user_gate_scope_projection_drift"
+TODO_PROJECTION_REPAIR_TRIGGERS = frozenset(
+    {DECISION_SCOPE_REPAIR_TRIGGER, USER_GATE_SCOPE_REPAIR_TRIGGER}
+)
 
 
 def _compact_health_items(
@@ -54,10 +58,12 @@ def build_quota_stall_self_repair_hint(
     user_todo_source_items: list[dict[str, Any]] | None = None,
     agent_todo_source_items: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any] | None:
+    coordination = item.get("coordination") if isinstance(item.get("coordination"), dict) else {}
     decision_scope_consistency = build_required_decision_scope_consistency(
         agent_todo_summary,
         user_todo_summary,
         agent_id=agent_id,
+        registered_agent_ids=coordination.get("registered_agents"),
         agent_source_items=agent_todo_source_items,
         user_source_items=user_todo_source_items,
     )
@@ -147,22 +153,28 @@ def apply_stall_repair_delivery_guard(
     recovery_allowed: bool,
     reason: str,
 ) -> tuple[bool, bool, str]:
-    if not repair or repair.get("trigger") != DECISION_SCOPE_REPAIR_TRIGGER:
+    if not repair or repair.get("trigger") not in TODO_PROJECTION_REPAIR_TRIGGERS:
         return normal_delivery_allowed, recovery_allowed, reason
     return False, False, str(repair.get("reason") or reason)
 
 
 def stall_repair_blocked_action_scope(repair: dict[str, Any] | None) -> str | None:
-    if not repair or repair.get("trigger") != DECISION_SCOPE_REPAIR_TRIGGER:
+    if not repair or repair.get("trigger") not in TODO_PROJECTION_REPAIR_TRIGGERS:
         return None
     value = str(repair.get("blocked_action_scope") or "").strip()
     return value or None
 
 
 def stall_repair_payload(repair: dict[str, Any] | None) -> dict[str, Any]:
-    if not repair or repair.get("trigger") != DECISION_SCOPE_REPAIR_TRIGGER:
+    if not repair or repair.get("trigger") not in TODO_PROJECTION_REPAIR_TRIGGERS:
         return {}
     consistency = repair.get("consistency")
     if not isinstance(consistency, dict):
         return {}
     return {"todo_decision_scope_consistency": consistency}
+
+
+def stall_repair_suppresses_user_gate_notification(
+    repair: dict[str, Any] | None,
+) -> bool:
+    return bool(repair and repair.get("trigger") == USER_GATE_SCOPE_REPAIR_TRIGGER)

--- a/loopx/control_plane/todos/decision_scope.py
+++ b/loopx/control_plane/todos/decision_scope.py
@@ -113,6 +113,7 @@ def build_required_decision_scope_consistency(
     user_todo_summary: dict[str, Any] | None,
     *,
     agent_id: str | None,
+    registered_agent_ids: list[str] | None = None,
     agent_source_items: list[dict[str, Any]] | None = None,
     user_source_items: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
@@ -133,6 +134,27 @@ def build_required_decision_scope_consistency(
     errors: list[dict[str, Any]] = []
     checked_scope_count = 0
     terminal_outcome_count = 0
+
+    registered_agents = sorted(
+        {
+            normalized
+            for value in registered_agent_ids or []
+            if (normalized := normalize_todo_claimed_by(value))
+        }
+    )
+    if len(registered_agents) > 1:
+        for gate in gates:
+            if normalize_todo_global_gate(gate.get("global_gate")):
+                continue
+            if normalize_todo_blocks_agent(gate.get("blocks_agent")):
+                continue
+            errors.append(
+                {
+                    "reason_code": "multi_agent_user_gate_missing_scope",
+                    "user_todo_id": normalize_todo_id(gate.get("todo_id")),
+                    "registered_agent_ids": registered_agents,
+                }
+            )
 
     for agent_item in agent_items:
         claimed_by = normalize_todo_claimed_by(agent_item.get("claimed_by"))
@@ -224,6 +246,35 @@ def build_required_decision_scope_repair_hint(
 ) -> dict[str, Any] | None:
     if consistency.get("ok") is not False:
         return None
+    errors = consistency.get("errors") if isinstance(consistency.get("errors"), list) else []
+    missing_gate_scope = any(
+        isinstance(error, dict)
+        and error.get("reason_code") == "multi_agent_user_gate_missing_scope"
+        for error in errors
+    )
+    if missing_gate_scope:
+        return {
+            "source": "quota.should-run",
+            "trigger": "user_gate_scope_projection_drift",
+            "recommended_mode": "repair_user_gate_scope_projection",
+            "effective_action": "todo_decision_scope_projection_repair",
+            "blocked_action_scope": "todo_user_gate_scope_projection",
+            "allowed": True,
+            "notify": "DONT_NOTIFY",
+            "reason": (
+                "a multi-agent user_gate lacks blocks_agent or explicit "
+                "global_gate=true, so its blocking authority is ambiguous"
+            ),
+            "repair_focus": (
+                "set blocks_agent to one registered agent, set global_gate=true for "
+                "intentional goal-wide authority, or downgrade the item to user_action"
+            ),
+            "spend_policy": (
+                "spend once only after the gate-scope projection repair is validated "
+                "and written back"
+            ),
+            "consistency": consistency,
+        }
     return {
         "source": "quota.should-run",
         "trigger": "required_decision_scope_projection_drift",

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -104,6 +104,8 @@ def user_channel_notice_todo_actions(summary: Any, *, limit: int = 3) -> list[st
 
 
 def user_channel_action_required(payload: dict[str, Any]) -> bool:
+    if _user_gate_scope_projection_repair_active(payload):
+        return False
     if _user_gate_notification_suppressed(payload):
         return False
     return bool(payload.get("requires_user_action")) or bool(
@@ -114,6 +116,14 @@ def user_channel_action_required(payload: dict[str, Any]) -> bool:
 def _user_gate_notification_suppressed(payload: dict[str, Any]) -> bool:
     cooldown = payload.get("user_gate_notification_cooldown")
     return isinstance(cooldown, dict) and cooldown.get("notification_suppressed") is True
+
+
+def _user_gate_scope_projection_repair_active(payload: dict[str, Any]) -> bool:
+    repair = payload.get("stall_self_repair")
+    return bool(
+        isinstance(repair, dict)
+        and repair.get("trigger") == "user_gate_scope_projection_drift"
+    )
 
 
 def _capability_resolution_user_actions(payload: dict[str, Any]) -> list[str]:
@@ -159,6 +169,8 @@ def projected_user_channel_actions(
     *,
     limit: int = 3,
 ) -> list[str]:
+    if _user_gate_scope_projection_repair_active(payload):
+        return []
     if _user_gate_notification_suppressed(payload):
         return []
     actions = user_channel_action_todo_actions(
@@ -195,7 +207,12 @@ def projected_user_channel_actions(
 
 
 def attach_user_action_compat_fields(payload: dict[str, Any]) -> None:
-    payload["action_required"] = user_channel_action_required(payload)
+    action_required = user_channel_action_required(payload)
+    payload["requires_user_action"] = action_required
+    payload["action_required"] = action_required
+    if _user_gate_scope_projection_repair_active(payload):
+        for key in ("notify_user_on_gate", "gate_prompt", "open_todo_notify_reason"):
+            payload.pop(key, None)
     payload["open_count"] = open_todo_count(payload.get("user_todo_summary"))
 
 

--- a/tests/control_plane/test_todo_decision_scope_consistency.py
+++ b/tests/control_plane/test_todo_decision_scope_consistency.py
@@ -139,6 +139,72 @@ def test_unrelated_gate_has_no_authority_over_independent_agent_todo() -> None:
     assert result["checked_required_scope_count"] == 0
 
 
+def test_multi_agent_unscoped_user_gate_projects_bounded_repair() -> None:
+    unscoped_gate = {
+        "todo_id": "todo_ambiguous_gate",
+        "status": "open",
+        "task_class": "user_gate",
+    }
+
+    result = build_required_decision_scope_consistency(
+        {"first_open_items": []},
+        _user_summary(unscoped_gate),
+        agent_id=AGENT_ID,
+        registered_agent_ids=[AGENT_ID, "codex-other-agent"],
+    )
+    repair = build_required_decision_scope_repair_hint(result)
+
+    assert result["ok"] is False
+    assert result["errors"] == [
+        {
+            "reason_code": "multi_agent_user_gate_missing_scope",
+            "user_todo_id": "todo_ambiguous_gate",
+            "registered_agent_ids": ["codex-other-agent", AGENT_ID],
+        }
+    ]
+    assert repair is not None
+    assert repair["trigger"] == "user_gate_scope_projection_drift"
+    assert repair["effective_action"] == "todo_decision_scope_projection_repair"
+    assert repair["notify"] == "DONT_NOTIFY"
+
+
+def test_explicit_global_gate_is_valid_in_multi_agent_projection() -> None:
+    global_gate = {
+        "todo_id": "todo_explicit_global_gate",
+        "status": "open",
+        "task_class": "user_gate",
+        "global_gate": True,
+    }
+
+    result = build_required_decision_scope_consistency(
+        {"first_open_items": []},
+        _user_summary(global_gate),
+        agent_id=AGENT_ID,
+        registered_agent_ids=[AGENT_ID, "codex-other-agent"],
+    )
+
+    assert result["ok"] is True
+    assert result["errors"] == []
+
+
+def test_single_agent_unscoped_gate_preserves_legacy_scope() -> None:
+    unscoped_gate = {
+        "todo_id": "todo_single_agent_gate",
+        "status": "open",
+        "task_class": "user_gate",
+    }
+
+    result = build_required_decision_scope_consistency(
+        {"first_open_items": []},
+        _user_summary(unscoped_gate),
+        agent_id=AGENT_ID,
+        registered_agent_ids=[AGENT_ID],
+    )
+
+    assert result["ok"] is True
+    assert result["errors"] == []
+
+
 def test_unscoped_diagnostic_uses_claimed_agent_as_effective_owner() -> None:
     other_agent_gate = {
         "todo_id": "todo_other_agent_gate",


### PR DESCRIPTION
## Summary
- treat multi-agent `user_gate` items without `blocks_agent` or explicit `global_gate=true` as projection drift instead of implicit goal-wide authority
- route the malformed state through bounded `todo_decision_scope_projection_repair`, with normal delivery and user notification disabled until validated writeback
- preserve single-agent compatibility and explicit `global_gate=true` goal-wide blocking

## Validation
- `uv run --no-project --with pytest python -m pytest -q` (`664 passed, 2 skipped`)
- `uv run --no-project --with pytest python -m pytest tests/control_plane/test_todo_decision_scope_consistency.py tests/control_plane/test_user_gate_lane_progress.py tests/control_plane/test_scheduler_interaction_arbitration.py -q` (`30 passed`)
- `uv run --no-project python examples/control_plane/quota-agent-scoped-user-gate-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `loopx canary premerge --from-git-diff` (`18/18 passed`, self-merge allowed, no manual holds)

## Review focus
- ambiguous legacy gates cannot acquire global authority
- explicit global gates still block all lanes
- projection repair is quiet and bounded; it cannot leak back into user-channel notification
- `loopx/quota.py` has zero line growth; policy stays in the existing bounded contexts

Owner explicitly authorized self-merge after validation.