### PR TITLE
fix(control-plane): clarify task lease release receipts

### DIFF
--- a/examples/control_plane/task-lease-runtime-smoke.py
+++ b/examples/control_plane/task-lease-runtime-smoke.py
@@ -288,6 +288,8 @@ def main() -> int:
             )
         )
         assert released["released"] is True, released
+        assert released["lease"]["status"] == "released", released
+        assert released["lease"]["released_at"] == released["lease"]["updated_at"], released
         assert payload(cli(registry_path, "inspect", "--goal-id", GOAL_ID, "--todo-id", TODO_A))["active"] is False
 
     print("task-lease-runtime-smoke ok")

--- a/loopx/control_plane/work_items/task_lease.py
+++ b/loopx/control_plane/work_items/task_lease.py
@@ -704,12 +704,16 @@ def release_task_lease(
         ):
             raise TaskLeaseError("lease owner or idempotency key mismatch", code="lease_cas_mismatch")
         remove_lease(lease_path)
+        released_lease = dict(lease)
+        released_lease["status"] = "released"
+        released_lease["released_at"] = isoformat(at)
+        released_lease["updated_at"] = isoformat(at)
         return {
             "ok": True,
             "schema_version": TASK_LEASE_SCHEMA_VERSION,
             "action": "release",
             "released": True,
-            "lease": lease,
+            "lease": released_lease,
             "lease_path": str(lease_path),
         }
 

--- a/loopx/control_plane/work_items/task_lease.py
+++ b/loopx/control_plane/work_items/task_lease.py
@@ -288,6 +288,8 @@ def lease_expires_at(lease: dict[str, Any] | None) -> datetime | None:
 def lease_is_active(lease: dict[str, Any] | None, *, at: datetime | None = None) -> bool:
     if not lease or lease.get("schema_version") != TASK_LEASE_SCHEMA_VERSION:
         return False
+    if lease.get("status") != "active":
+        return False
     expires_at = lease_expires_at(lease)
     return bool(expires_at and expires_at > (at or now_utc()))
 

--- a/tests/control_plane/test_task_lease.py
+++ b/tests/control_plane/test_task_lease.py
@@ -197,3 +197,7 @@ def test_task_lease_lifecycle_preserves_idempotency_and_versions(
         expected_version=3,
     )
     assert released["released"] is True
+    assert released["lease"]["status"] == "released"
+    assert released["lease"]["released_at"] == now.isoformat().replace("+00:00", "Z")
+    assert released["lease"]["updated_at"] == released["lease"]["released_at"]
+    assert not Path(str(released["lease_path"])).exists()

--- a/tests/control_plane/test_task_lease.py
+++ b/tests/control_plane/test_task_lease.py
@@ -200,4 +200,5 @@ def test_task_lease_lifecycle_preserves_idempotency_and_versions(
     assert released["lease"]["status"] == "released"
     assert released["lease"]["released_at"] == now.isoformat().replace("+00:00", "Z")
     assert released["lease"]["updated_at"] == released["lease"]["released_at"]
+    assert task_lease.lease_is_active(released["lease"], at=now) is False
     assert not Path(str(released["lease_path"])).exists()


### PR DESCRIPTION
## Summary
- return a terminal `released` lease snapshot after successful task-lease release
- add `released_at` and align `updated_at` with the release transition
- cover both runtime and CLI receipt semantics while preserving inspect-as-source-of-truth

## Validation
- `PYTHONPATH=. uv run --no-project --with pytest python -m pytest tests/control_plane/test_task_lease.py -q` (22 passed)
- `python3 examples/control_plane/task-lease-runtime-smoke.py`
- `loopx canary premerge --from-git-diff` (14/14, public boundary clean)