### PR TITLE
feat(pi): add native host adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -856,6 +856,8 @@ contract.
   routing, gate, evidence, projection, and planning patterns.
 - [Codex CLI packaged install](docs/product/codex-cli-packaged-install.md):
   no-clone install/update/start path for Codex CLI users.
+- [pi host integration](docs/product/pi-host-integration.md): opt-in pi package,
+  bounded interactive turns, and non-regression boundaries for existing hosts.
 - [Worker bridge install contract](docs/worker-bridge-install-contract.md):
   runner-agnostic bridge and edge-worker handoff model.
 - [Lark Kanban adapter](docs/lark-kanban-control-plane-adapter.md):

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,9 @@ incident report, or launch draft.
 - [Codex CLI first-run rehearsal](product/codex-cli-first-run-rehearsal.md):
   shortest public route from no-clone install to one-message TUI bootstrap and
   proof-capture fixtures.
+- [pi host integration](product/pi-host-integration.md): opt-in pi package,
+  bounded-turn lifecycle, delivery workspace accounting, and compatibility
+  guarantees for existing agent hosts.
 - [Architecture](architecture.md): core concepts and control-plane shape.
 - [Integration guide](integration.md): how to connect a project to LoopX,
   including public-safe Lark or Feishu reply card payloads.

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -25,6 +25,29 @@ workflow. Use `loopx doctor` from any project folder to inspect the
 resolved command path, symlink target, release snapshot, canary wrapper,
 installed skill delivery-hint state, wrapper script, and Python import health.
 
+## pi Host Integration (Opt-In)
+
+LoopX includes an official pi package under `integrations/pi`. Install it only
+on hosts that use pi:
+
+```bash
+loopx-pi-install
+```
+
+Contributors can run `scripts/install-pi-package.sh` directly from a checkout.
+
+Reload an already open pi session with `/reload`. The package exposes `/loopx`,
+`/loopx-turn`, `/loopx-status`, and the structured `loopx_control` tool. pi is
+modeled as an interactive host: every `/loopx-turn` performs at most one
+quota-gated segment, and the package does not install a timer, heartbeat
+automation, or background scheduler.
+
+The integration is additive. Installing LoopX normally does not install the pi
+package, and installing the pi package does not modify Codex App, Codex IDE,
+Codex CLI, Claude Code, manual-shell, or custom-agent resources. See
+[pi host integration](product/pi-host-integration.md) for lifecycle, workspace,
+vision, and compatibility contracts.
+
 ## Global Skill Policy
 
 LoopX product behavior belongs in installed global Codex skills, not in

--- a/docs/product/pi-host-integration.md
+++ b/docs/product/pi-host-integration.md
@@ -1,0 +1,94 @@
+# pi Host Integration
+
+LoopX supports pi through an opt-in host type and a native pi package. LoopX
+remains the durable control plane; pi remains the visible interactive executor.
+
+## Install
+
+Requirements:
+
+- LoopX 0.2.7 or newer on `PATH`;
+- pi 0.80.10 or newer;
+- Python 3.11 or newer.
+
+From a LoopX checkout or release snapshot:
+
+```bash
+loopx-pi-install
+```
+
+Contributors can run `scripts/install-pi-package.sh` directly from a checkout.
+Run `/reload` in an already open pi session. The installer copies the reviewed
+package into the stable managed path `~/.local/share/loopx/pi-package` and
+delegates to `pi install` with that path. A management marker prevents it from
+replacing an unrelated directory. It does not install a scheduler, timer,
+heartbeat automation, Codex skill, Claude Code adapter, or slash command for
+another host.
+
+Review the package before installation because pi extensions run with the
+user's local permissions.
+
+## Host Contract
+
+The canonical LoopX agent type is `pi`, with aliases `pi-cli` and
+`pi coding agent`. Its host activation surface is
+`pi_interactive_bounded_turns`:
+
+1. `/loopx <goal>` creates or reuses local LoopX state and a ranked todo
+   frontier.
+2. `/loopx-turn` runs exactly one quota-gated bounded segment.
+3. `/loopx-status` refreshes a compact read-only status widget.
+4. `loopx_control` exposes allow-listed structured CLI actions. Mutations remain
+   previews unless `execute=true` is explicit.
+
+pi is an interactive host. LoopX scheduler hints remain data for hosts that own
+schedulers; the pi package does not apply or acknowledge them.
+
+## Accountable Delivery
+
+LoopX 0.2.7 binds a material refresh and quota spend to the Git checkout that
+produced the delivery.
+
+- Use `project` for the connected goal registry.
+- Set `deliveryWorkspace` when implementation occurs in another checkout or
+  worktree.
+- Pass the same `deliveryWorkspace` to `refresh_state` and `spend_slot`.
+- A workspace guard failure must stop accounting until the correct checkout is
+  selected.
+
+Material refreshes also require an agent vision checkpoint. The first material
+refresh writes a bounded baseline with `visionState`, `visionSummary`,
+`visionRoleScope`, `visionAcceptance`, and continuation fields. Later refreshes
+may use `visionUnchangedReason` only when that baseline still matches the active
+acceptance boundary.
+
+## Compatibility Boundary
+
+pi support is additive:
+
+- normal `scripts/install-local.sh` and `scripts/install-from-github.sh`
+  behavior is unchanged;
+- the pi package is installed only by `loopx-pi-install`, the source
+  `scripts/install-pi-package.sh`, or an explicit `pi install`;
+- Codex App keeps heartbeat automation activation;
+- Codex IDE and Codex CLI keep visible `/goal` activation;
+- Claude Code keeps native `/loop` activation;
+- manual and custom agents keep external loop-driver activation;
+- pi-specific TypeScript and skill resources live under `integrations/pi` and
+  are not imported by the Python runtime.
+
+The core regression test locks the existing activation methods while testing
+the new pi branch separately.
+
+## Validation
+
+Run the focused package and host tests:
+
+```bash
+python3 -m pytest -q tests/test_host_loop_activation.py tests/test_pi_host_integration.py tests/control_plane/test_start_goal_compact_projection.py
+python3 examples/control_plane/agent-onboard-host-loop-activation-smoke.py
+loopx-pi-install --dry-run
+```
+
+After local installation, reload pi and use `/loopx-status` before starting a
+real goal.

--- a/examples/codex-cli-packaged-install-smoke.py
+++ b/examples/codex-cli-packaged-install-smoke.py
@@ -41,6 +41,7 @@ def main() -> None:
                 "docs",
                 "man",
                 "examples",
+                "integrations",
                 "README.md",
                 "pyproject.toml",
                 "LICENSE",

--- a/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
+++ b/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
@@ -46,6 +46,7 @@ def main() -> int:
         "codex-ide",
         "codex-cli",
         "claude-code",
+        "pi",
         "manual",
         "other-agent",
     } <= agent_types
@@ -55,16 +56,30 @@ def main() -> int:
     assert agent_type_for_host_surface("chat-box") == "codex-app"
     assert agent_type_for_host_surface("codex-ide") == "codex-ide"
     assert agent_type_for_host_surface("codex-cli-tui") == "codex-cli"
+    assert agent_type_for_host_surface("pi") == "pi"
 
     codex_app = build_host_loop_activation_packet(agent_type="codex-app", goal_id="demo")
     codex_ide = build_host_loop_activation_packet(agent_type="codex-ide", goal_id="demo")
     codex_cli = build_host_loop_activation_packet(agent_type="codex-cli", goal_id="demo")
     claude_code = build_host_loop_activation_packet(agent_type="claude-code", goal_id="demo")
+    pi = build_host_loop_activation_packet(agent_type="pi", goal_id="demo")
     assert codex_app["activation_method"] == "create_or_update_codex_app_automation", codex_app
     assert codex_ide["activation_method"] == "set_visible_goal", codex_ide
     assert codex_ide["host_mutation"]["host_command"] == "/goal <task_body>", codex_ide
     assert codex_cli["host_mutation"]["host_command"] == "/goal <task_body>", codex_cli
     assert claude_code["host_mutation"]["host_command"] == "/loop", claude_code
+    assert pi["host_mutation"]["host_command"] == "/loopx-turn", pi
+    assert pi["activation_method"] == "run_pi_quota_gated_bounded_turns", pi
+
+    pi_onboarding = build_agent_onboarding_packet(
+        project=REPO_ROOT,
+        agent_type="pi",
+        goal_id="pi-demo",
+        agent_id="pi-main",
+    )
+    assert "scheduler" not in pi_onboarding["recommended_start"].lower(), pi_onboarding
+    assert pi_onboarding["commands"]["install_command_facade"] == "loopx-pi-install"
+    assert "--host-surface pi" in pi_onboarding["commands"]["bootstrap_command_pack"]
     gated_activation = build_host_loop_activation_packet(
         agent_type="codex-app",
         goal_id="multi-agent-demo",

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -199,6 +199,10 @@ def main() -> int:
         assert f"- executable: {bin_dir / 'loopx'}" in install.stdout, install.stdout
         assert "- release: " in install.stdout, install.stdout
         assert f"- canary executable: {bin_dir / 'loopx-canary'}" in install.stdout, install.stdout
+        assert (
+            f"- pi package installer: {bin_dir / 'loopx-pi-install'} (opt-in)"
+            in install.stdout
+        ), install.stdout
         assert "- executable compatibility: none" in install.stdout, install.stdout
         assert (
             f"- legacy command disabled: {bin_dir / 'goal-harness.legacy-disabled'}"
@@ -216,13 +220,20 @@ def main() -> int:
         assert f"claude skills: {home / '.claude' / 'skills'}" in install.stdout, install.stdout
 
         wrapper = bin_dir / "loopx"
+        pi_installer = bin_dir / "loopx-pi-install"
         assert wrapper.is_symlink(), wrapper
+        assert pi_installer.is_symlink(), pi_installer
         assert not (bin_dir / "goal-harness").exists()
         assert (bin_dir / "goal-harness.legacy-disabled").is_symlink()
         assert wrapper.resolve() != REPO_ROOT / "scripts" / "loopx", wrapper.resolve()
         assert wrapper.resolve().name == "loopx", wrapper.resolve()
         release_root = wrapper.resolve().parents[1]
+        assert pi_installer.resolve() == release_root / "scripts" / "install-pi-package.sh"
         assert (release_root / "loopx" / "cli.py").is_file(), release_root
+        assert (release_root / "integrations" / "pi" / "package.json").is_file(), release_root
+        assert (
+            release_root / "integrations" / "pi" / "extensions" / "loopx.ts"
+        ).is_file(), release_root
         runtime_package = release_root / "loopx" / "control_plane" / "runtime"
         assert (runtime_package / "run_compaction.py").is_file(), release_root
         assert (runtime_package / "session_runtime.py").is_file(), release_root

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -1,0 +1,48 @@
+# LoopX Pi Adapter
+
+Opt-in pi package for using LoopX as the durable control plane while pi performs
+visible, bounded interactive work.
+
+## Install
+
+From a LoopX checkout or release snapshot:
+
+```bash
+loopx-pi-install
+```
+
+Contributors can run `scripts/install-pi-package.sh` directly from a checkout.
+
+Then run `/reload` in an already open pi session. The script syncs the reviewed
+package into the stable managed path `~/.local/share/loopx/pi-package` before
+registering it, so LoopX release snapshot updates do not create a new pi package
+identity. It refuses to replace an unmarked existing directory. The script does
+not change LoopX's Codex, Claude Code, manual, or custom-agent integrations.
+
+## Resources
+
+- `extensions/loopx.ts`: `/loopx`, `/loopx-turn`, `/loopx-status`, and the
+  structured `loopx_control` tool.
+- `skills/loopx-pi/SKILL.md`: pi-specific lifecycle, quota, todo, vision,
+  writeback, and safety rules.
+
+## Requirements
+
+- pi 0.80.10+
+- LoopX 0.2.7+ on `PATH`
+- Python 3.11+
+
+The adapter is an interactive loop driver. It never installs a scheduler,
+timer, heartbeat automation, or hidden background process. Each `/loopx-turn`
+runs at most one quota-gated work segment.
+
+For delivery in a repository other than the connected goal project, pass
+`deliveryWorkspace` to `refresh_state` and `spend_slot`. Material refreshes must
+also provide a valid agent vision patch, or `visionUnchangedReason` after a
+baseline exists.
+
+## Environment
+
+- `LOOPX_BIN`: override the LoopX executable (default: `loopx`).
+- `LOOPX_PI_AGENT_ID`: override the registered LoopX agent id (default:
+  `pi-main`).

--- a/integrations/pi/extensions/loopx.ts
+++ b/integrations/pi/extensions/loopx.ts
@@ -1,0 +1,634 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { StringEnum } from "@earendil-works/pi-ai";
+import {
+  DEFAULT_MAX_BYTES,
+  DEFAULT_MAX_LINES,
+  formatSize,
+  truncateHead,
+  withFileMutationQueue,
+  type ExtensionAPI,
+} from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+
+const LOOPX_BIN = process.env.LOOPX_BIN || "loopx";
+const DEFAULT_AGENT_ID = process.env.LOOPX_PI_AGENT_ID || "pi-main";
+const DEFAULT_CAPABILITIES = ["shell", "filesystem", "filesystem_write"];
+const TOOL_TIMEOUT_MS = 60_000;
+
+const ACTIONS = [
+  "doctor",
+  "status",
+  "start_goal",
+  "connect",
+  "register_agent",
+  "ready_score",
+  "quota_should_run",
+  "turn_plan",
+  "todo_list",
+  "todo_add",
+  "todo_claim",
+  "todo_complete",
+  "history",
+  "diagnose",
+  "refresh_state",
+  "spend_slot",
+] as const;
+
+const controlParameters = Type.Object({
+  action: StringEnum(ACTIONS),
+  project: Type.Optional(Type.String({ description: "Project directory; defaults to pi's current directory" })),
+  goalId: Type.Optional(Type.String({ description: "Stable LoopX goal id" })),
+  goalText: Type.Optional(Type.String({ description: "Exact long-running goal text" })),
+  agentId: Type.Optional(Type.String({ description: `Registered agent id; defaults to ${DEFAULT_AGENT_ID}` })),
+  todoId: Type.Optional(Type.String({ description: "Structured LoopX todo id" })),
+  text: Type.Optional(Type.String({ description: "Public-safe todo text" })),
+  role: Type.Optional(StringEnum(["agent", "user"] as const)),
+  taskClass: Type.Optional(
+    StringEnum(["advancement_task", "continuous_monitor", "user_gate", "user_action", "blocker"] as const),
+  ),
+  actionKind: Type.Optional(Type.String({ description: "Public-safe action token" })),
+  taskRepository: Type.Optional(
+    Type.String({ description: "Credential-free Git repository identity for an agent todo" }),
+  ),
+  evidence: Type.Optional(Type.String({ description: "Public-safe validation evidence or pointer" })),
+  note: Type.Optional(Type.String({ description: "Public-safe lifecycle note" })),
+  nextAgentTodo: Type.Optional(Type.String({ description: "Public-safe successor agent todo" })),
+  nextAction: Type.Optional(Type.String({ description: "Durable next action for refresh_state" })),
+  classification: Type.Optional(Type.String({ description: "Public-safe refresh classification" })),
+  recommendedAction: Type.Optional(Type.String({ description: "Public-safe recommended action" })),
+  deliveryBatchScale: Type.Optional(
+    StringEnum(["test_only", "single_surface", "multi_surface", "implementation"] as const),
+  ),
+  deliveryOutcome: Type.Optional(
+    StringEnum(["surface_only", "outcome_gap", "outcome_progress", "primary_goal_outcome"] as const),
+  ),
+  deliveryWorkspace: Type.Optional(
+    Type.String({ description: "Git checkout that produced the accountable delivery; defaults to project" }),
+  ),
+  visionState: Type.Optional(Type.String({ description: "Agent vision lifecycle state for refresh_state" })),
+  visionSummary: Type.Optional(Type.String({ description: "Bounded agent vision summary" })),
+  visionRoleScope: Type.Optional(Type.String({ description: "Bounded agent role scope" })),
+  visionAcceptance: Type.Optional(Type.String({ description: "Bounded agent vision acceptance summary" })),
+  visionAdvancementPolicy: Type.Optional(StringEnum(["as_needed", "repeat_until_closed"] as const)),
+  visionReplanTrigger: Type.Optional(Type.String({ description: "Bounded agent vision replan trigger" })),
+  visionLastPatch: Type.Optional(Type.String({ description: "Bounded summary of the latest vision patch" })),
+  visionTodoDelta: Type.Optional(
+    Type.Array(Type.String({ description: "Compact public-safe todo delta" }), { maxItems: 8 }),
+  ),
+  visionUnchangedReason: Type.Optional(
+    Type.String({ description: "Reason an existing agent vision remains unchanged" }),
+  ),
+  noFollowUp: Type.Optional(Type.Boolean({ description: "Record that a completed todo intentionally has no successor" })),
+  execute: Type.Optional(Type.Boolean({ description: "Apply a mutation; false or omitted means preview/read-only" })),
+  limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 100 })),
+});
+
+type ControlParams = {
+  action: (typeof ACTIONS)[number];
+  project?: string;
+  goalId?: string;
+  goalText?: string;
+  agentId?: string;
+  todoId?: string;
+  text?: string;
+  role?: "agent" | "user";
+  taskClass?: "advancement_task" | "continuous_monitor" | "user_gate" | "user_action" | "blocker";
+  actionKind?: string;
+  taskRepository?: string;
+  evidence?: string;
+  note?: string;
+  nextAgentTodo?: string;
+  nextAction?: string;
+  classification?: string;
+  recommendedAction?: string;
+  deliveryBatchScale?: "test_only" | "single_surface" | "multi_surface" | "implementation";
+  deliveryOutcome?: "surface_only" | "outcome_gap" | "outcome_progress" | "primary_goal_outcome";
+  deliveryWorkspace?: string;
+  visionState?: string;
+  visionSummary?: string;
+  visionRoleScope?: string;
+  visionAcceptance?: string;
+  visionAdvancementPolicy?: "as_needed" | "repeat_until_closed";
+  visionReplanTrigger?: string;
+  visionLastPatch?: string;
+  visionTodoDelta?: string[];
+  visionUnchangedReason?: string;
+  noFollowUp?: boolean;
+  execute?: boolean;
+  limit?: number;
+};
+
+type ExecContext = {
+  cwd: string;
+  signal?: AbortSignal;
+};
+
+function required(value: string | undefined, name: string): string {
+  const normalized = value?.trim();
+  if (!normalized) throw new Error(`${name} is required for this LoopX action`);
+  return normalized;
+}
+
+function projectPath(value: string | undefined, cwd: string): string {
+  if (!value?.trim()) return cwd;
+  const expanded = value.startsWith("~/") ? join(homedir(), value.slice(2)) : value;
+  return isAbsolute(expanded) ? resolve(expanded) : resolve(cwd, expanded);
+}
+
+function addCapabilities(args: string[]): void {
+  for (const capability of DEFAULT_CAPABILITIES) {
+    args.push("--available-capability", capability);
+  }
+}
+
+function buildArgs(
+  params: ControlParams,
+  cwd: string,
+): { args: string[]; project: string; commandCwd: string; agentId: string } {
+  const project = projectPath(params.project, cwd);
+  const deliveryWorkspace = projectPath(params.deliveryWorkspace, project);
+  const agentId = params.agentId?.trim() || DEFAULT_AGENT_ID;
+  const limit = String(params.limit ?? 20);
+  const goalId = params.goalId?.trim();
+  let args: string[];
+  let commandCwd = project;
+
+  switch (params.action) {
+    case "doctor":
+      args = ["--format", "json", "doctor", "--deep"];
+      break;
+    case "status":
+      args = ["--format", "json", "status", "--limit", limit];
+      if (goalId) args.push("--goal-id", goalId, "--agent-id", agentId);
+      break;
+    case "start_goal":
+      args = [
+        "--format",
+        "json",
+        "start-goal",
+        "--guided",
+        "--project",
+        project,
+        "--host-surface",
+        "pi",
+        "--agent-id",
+        agentId,
+        "--goal-text",
+        required(params.goalText, "goalText"),
+      ];
+      if (goalId) args.push("--goal-id", goalId);
+      addCapabilities(args);
+      break;
+    case "connect":
+      args = [
+        "--format",
+        "json",
+        "bootstrap",
+        "--project",
+        project,
+        "--objective",
+        required(params.goalText, "goalText"),
+        "--adapter-kind",
+        "read_only_project_map_v0",
+        "--adapter-status",
+        "connected-read-only",
+        "--no-onboarding-scan",
+        "--codex-app-heartbeat",
+        "no",
+      ];
+      if (goalId) args.push("--goal-id", goalId);
+      if (!params.execute) args.push("--dry-run");
+      break;
+    case "register_agent":
+      args = [
+        "--format",
+        "json",
+        "register-agent",
+        "--goal-id",
+        required(goalId, "goalId"),
+        "--agent-id",
+        agentId,
+      ];
+      if (params.execute) args.push("--execute");
+      break;
+    case "ready_score":
+      args = [
+        "--format",
+        "json",
+        "ready-score",
+        "--goal-id",
+        required(goalId, "goalId"),
+        "--agent-id",
+        agentId,
+      ];
+      break;
+    case "quota_should_run":
+      args = [
+        "--format",
+        "json",
+        "quota",
+        "should-run",
+        "--goal-id",
+        required(goalId, "goalId"),
+        "--agent-id",
+        agentId,
+        "--turn-envelope",
+      ];
+      addCapabilities(args);
+      break;
+    case "turn_plan":
+      args = [
+        "--format",
+        "json",
+        "turn",
+        "plan",
+        "--goal-id",
+        required(goalId, "goalId"),
+        "--agent-id",
+        agentId,
+        "--host",
+        "generic-cli",
+        "--execution-mode",
+        "interactive-visible",
+      ];
+      addCapabilities(args);
+      break;
+    case "todo_list":
+      args = ["--format", "json", "todo", "list", "--goal-id", required(goalId, "goalId")];
+      break;
+    case "todo_add":
+      args = [
+        "--format",
+        "json",
+        "todo",
+        "add",
+        "--goal-id",
+        required(goalId, "goalId"),
+        "--role",
+        params.role ?? "agent",
+        "--text",
+        required(params.text, "text"),
+        "--task-class",
+        params.taskClass ?? (params.role === "user" ? "user_gate" : "advancement_task"),
+      ];
+      if (params.actionKind) args.push("--action-kind", params.actionKind);
+      if (params.taskRepository) args.push("--task-repository", params.taskRepository);
+      if (params.role !== "user") args.push("--claimed-by", agentId);
+      if (!params.execute) args.push("--dry-run");
+      break;
+    case "todo_claim":
+      args = [
+        "--format",
+        "json",
+        "todo",
+        "claim",
+        "--goal-id",
+        required(goalId, "goalId"),
+        "--todo-id",
+        required(params.todoId, "todoId"),
+        "--claimed-by",
+        agentId,
+      ];
+      if (!params.execute) args.push("--dry-run");
+      break;
+    case "todo_complete":
+      args = [
+        "--format",
+        "json",
+        "todo",
+        "complete",
+        "--goal-id",
+        required(goalId, "goalId"),
+        "--todo-id",
+        required(params.todoId, "todoId"),
+        "--claimed-by",
+        agentId,
+      ];
+      if (params.evidence) args.push("--evidence", params.evidence);
+      if (params.note) args.push("--note", params.note);
+      if (params.nextAgentTodo) args.push("--next-agent-todo", params.nextAgentTodo);
+      if (params.noFollowUp) args.push("--no-follow-up");
+      if (!params.execute) args.push("--dry-run");
+      break;
+    case "history":
+      args = ["--format", "json", "history", "--goal-id", required(goalId, "goalId"), "--limit", limit];
+      break;
+    case "diagnose":
+      args = [
+        "--format",
+        "json",
+        "diagnose",
+        "--goal-id",
+        required(goalId, "goalId"),
+        "--agent-id",
+        agentId,
+        "--limit",
+        limit,
+      ];
+      addCapabilities(args);
+      break;
+    case "refresh_state":
+      args = [
+        "--format",
+        "json",
+        "refresh-state",
+        "--goal-id",
+        required(goalId, "goalId"),
+        "--project",
+        project,
+        "--agent-id",
+        agentId,
+        "--progress-scope",
+        "goal",
+      ];
+      if (params.classification) args.push("--classification", params.classification);
+      if (params.recommendedAction) args.push("--recommended-action", params.recommendedAction);
+      if (params.nextAction) args.push("--next-action", params.nextAction);
+      if (params.deliveryBatchScale) args.push("--delivery-batch-scale", params.deliveryBatchScale);
+      if (params.deliveryOutcome) args.push("--delivery-outcome", params.deliveryOutcome);
+      if (params.deliveryWorkspace) args.push("--delivery-workspace-path", deliveryWorkspace);
+      if (params.visionState) args.push("--vision-state", params.visionState);
+      if (params.visionSummary) args.push("--vision-summary", params.visionSummary);
+      if (params.visionRoleScope) args.push("--vision-role-scope", params.visionRoleScope);
+      if (params.visionAcceptance) args.push("--vision-acceptance", params.visionAcceptance);
+      if (params.visionAdvancementPolicy) {
+        args.push("--vision-advancement-policy", params.visionAdvancementPolicy);
+      }
+      if (params.visionReplanTrigger) args.push("--vision-replan-trigger", params.visionReplanTrigger);
+      if (params.visionLastPatch) args.push("--vision-last-patch", params.visionLastPatch);
+      for (const delta of params.visionTodoDelta ?? []) args.push("--vision-todo-delta", delta);
+      if (params.visionUnchangedReason) {
+        args.push("--vision-unchanged-reason", params.visionUnchangedReason);
+      }
+      if (!params.execute) args.push("--dry-run");
+      break;
+    case "spend_slot":
+      commandCwd = deliveryWorkspace;
+      args = [
+        "--format",
+        "json",
+        ...(params.deliveryWorkspace ? ["--registry", join(project, ".loopx", "registry.json")] : []),
+        "quota",
+        "spend-slot",
+        "--goal-id",
+        required(goalId, "goalId"),
+        "--agent-id",
+        agentId,
+        "--slots",
+        "1",
+        "--source",
+        "controller",
+        params.execute ? "--execute" : "--dry-run",
+      ];
+      addCapabilities(args);
+      break;
+    default:
+      throw new Error(`Unsupported LoopX action: ${String(params.action)}`);
+  }
+
+  return { args, project, commandCwd, agentId };
+}
+
+async function ensureLocalLoopxExcludes(pi: ExtensionAPI, project: string, signal?: AbortSignal) {
+  const gitPath = await pi.exec("git", ["rev-parse", "--git-path", "info/exclude"], {
+    cwd: project,
+    signal,
+    timeout: 5000,
+  });
+  if (gitPath.code !== 0) {
+    return { updated: false, reason: "not_a_git_repository" };
+  }
+
+  const rawPath = gitPath.stdout.trim();
+  const excludePath = isAbsolute(rawPath) ? rawPath : resolve(project, rawPath);
+  const requiredPatterns = [".loopx/", ".codex/goals/", ".local/"];
+
+  return withFileMutationQueue(excludePath, async () => {
+    let current = "";
+    try {
+      current = await readFile(excludePath, "utf8");
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") throw error;
+    }
+
+    const existing = new Set(
+      current
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean),
+    );
+    const missing = requiredPatterns.filter((pattern) => !existing.has(pattern));
+    if (missing.length === 0) return { updated: false, path: excludePath, added: [] };
+
+    const prefix = current.length === 0 || current.endsWith("\n") ? "" : "\n";
+    const block = `${prefix}# LoopX local state (managed by loopx-pi-adapter)\n${missing.join("\n")}\n`;
+    await mkdir(dirname(excludePath), { recursive: true });
+    await writeFile(excludePath, current + block, "utf8");
+    return { updated: true, path: excludePath, added: missing };
+  });
+}
+
+async function runLoopx(pi: ExtensionAPI, params: ControlParams, ctx: ExecContext) {
+  const plan = buildArgs(params, ctx.cwd);
+  const result = await pi.exec(LOOPX_BIN, plan.args, {
+    cwd: plan.commandCwd,
+    signal: ctx.signal,
+    timeout: TOOL_TIMEOUT_MS,
+  });
+
+  if (result.code !== 0) {
+    const errorText = (result.stderr || result.stdout || "LoopX command failed").trim();
+    throw new Error(errorText.slice(0, 8000));
+  }
+
+  const output = result.stdout.trim() || "{}";
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(output);
+  } catch {
+    parsed = undefined;
+  }
+
+  if (params.action === "connect" && params.execute && parsed && typeof parsed === "object") {
+    const goalId = (parsed as Record<string, unknown>).goal_id;
+    if (typeof goalId === "string" && goalId) {
+      const registration = await pi.exec(
+        LOOPX_BIN,
+        ["--format", "json", "register-agent", "--goal-id", goalId, "--agent-id", plan.agentId, "--execute"],
+        { cwd: plan.project, signal: ctx.signal, timeout: TOOL_TIMEOUT_MS },
+      );
+      if (registration.code !== 0) {
+        const detail = (registration.stderr || registration.stdout || "agent registration failed").trim();
+        throw new Error(`Project connected, but pi agent registration failed: ${detail.slice(0, 4000)}`);
+      }
+      try {
+        (parsed as Record<string, unknown>).pi_agent_registration = JSON.parse(registration.stdout);
+      } catch {
+        (parsed as Record<string, unknown>).pi_agent_registration = registration.stdout.trim();
+      }
+    }
+    (parsed as Record<string, unknown>).pi_local_excludes = await ensureLocalLoopxExcludes(
+      pi,
+      plan.project,
+      ctx.signal,
+    );
+  }
+
+  const rendered = parsed === undefined ? output : JSON.stringify(parsed, null, 2);
+  const truncation = truncateHead(rendered, {
+    maxLines: DEFAULT_MAX_LINES,
+    maxBytes: DEFAULT_MAX_BYTES,
+  });
+  let text = truncation.content;
+  let fullOutputPath: string | undefined;
+
+  if (truncation.truncated) {
+    const dir = await mkdtemp(join(tmpdir(), "loopx-pi-"));
+    fullOutputPath = join(dir, `${params.action}.json`);
+    await writeFile(fullOutputPath, rendered, "utf8");
+    text += `\n\n[LoopX output truncated to ${truncation.outputLines} lines / ${formatSize(truncation.outputBytes)}. Full output: ${fullOutputPath}]`;
+  }
+
+  return {
+    content: [{ type: "text" as const, text }],
+    details: {
+      action: params.action,
+      project: plan.project,
+      commandCwd: plan.commandCwd,
+      agentId: plan.agentId,
+      execute: params.execute === true,
+      truncated: truncation.truncated,
+      fullOutputPath,
+    },
+  };
+}
+
+function statusLines(payload: Record<string, unknown>): string[] {
+  const queue = payload.attention_queue as { item_count?: number; items?: Array<Record<string, unknown>> } | undefined;
+  const lines = [
+    `LoopX | goals ${String(payload.goal_count ?? 0)} | runs ${String(payload.run_count ?? 0)} | attention ${String(queue?.item_count ?? 0)}`,
+  ];
+  for (const item of queue?.items?.slice(0, 5) ?? []) {
+    lines.push(
+      `${String(item.severity ?? "info")} | ${String(item.goal_id ?? "unknown")} | ${String(item.recommended_action ?? item.status ?? "inspect status")}`,
+    );
+  }
+  return lines;
+}
+
+export default function loopxPiAdapter(pi: ExtensionAPI) {
+  pi.registerTool({
+    name: "loopx_control",
+    label: "LoopX Control",
+    description:
+      `Inspect and update LoopX's local long-running-goal control plane through structured actions. ` +
+      `Mutating actions are previews unless execute=true. Output is truncated to ${DEFAULT_MAX_LINES} lines or ${formatSize(DEFAULT_MAX_BYTES)}.`,
+    promptSnippet: "Inspect or update LoopX goals, quota, todos, history, and state writeback",
+    promptGuidelines: [
+      "Use loopx_control instead of constructing raw loopx shell commands when the requested action is supported.",
+      "Before a LoopX work segment, use loopx_control status and quota_should_run; spend a slot only after validated work and refresh_state writeback.",
+      "Do not set execute=true for LoopX mutations unless the user explicitly started a goal or approved the state change.",
+    ],
+    parameters: controlParameters,
+    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+      return runLoopx(pi, params as ControlParams, { cwd: ctx.cwd, signal });
+    },
+  });
+
+  pi.registerCommand("loopx", {
+    description: "Inspect LoopX or start/continue a long-running goal",
+    handler: async (args, ctx) => {
+      if (!ctx.isIdle()) {
+        ctx.ui.notify("Agent is busy; run /loopx after the current turn settles.", "warning");
+        return;
+      }
+      const goalText = args.trim();
+      if (ctx.mode === "print") {
+        try {
+          const commandArgs = goalText
+            ? [
+                "--format",
+                "json",
+                "start-goal",
+                "--guided",
+                "--project",
+                ctx.cwd,
+                "--host-surface",
+                "pi",
+                "--agent-id",
+                DEFAULT_AGENT_ID,
+                "--goal-text",
+                goalText,
+              ]
+            : ["--format", "json", "status", "--limit", "20"];
+          if (goalText) addCapabilities(commandArgs);
+          const result = await pi.exec(LOOPX_BIN, commandArgs, { cwd: ctx.cwd, timeout: TOOL_TIMEOUT_MS });
+          if (result.code !== 0) throw new Error(result.stderr || result.stdout || "LoopX command failed");
+          const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+          if (goalText) {
+            const connection = payload.project_connection as Record<string, unknown> | undefined;
+            const next = payload.recommended_next_step as Record<string, unknown> | undefined;
+            console.log(
+              `LoopX preview | goal ${String(payload.goal_id ?? "unknown")} | connection ${String(connection?.connection_state ?? "unknown")} | next ${String(next?.kind ?? "inspect packet")}`,
+            );
+          } else {
+            console.log(statusLines(payload).join("\n"));
+          }
+        } catch (error) {
+          console.error(error instanceof Error ? error.message : String(error));
+        }
+        return;
+      }
+
+      const request = goalText
+        ? `Start or continue this LoopX goal in the current project: ${goalText}\n\nThis /loopx invocation is explicit user intent to create or reuse local LoopX state. Load the loopx-pi skill, use loopx_control start_goal first, connect only if needed, create a concise ranked todo plan without duplicates, then run the first quota-allowed bounded segment. Do not install a background scheduler.`
+        : "Inspect the current project's LoopX state in read-only mode. Load the loopx-pi skill, use loopx_control status, and report the active goal, user gate, top runnable agent todo, and next safe action. Do not mutate state.";
+      pi.sendUserMessage(request);
+    },
+  });
+
+  pi.registerCommand("loopx-turn", {
+    description: "Run one quota-gated LoopX work segment",
+    handler: async (args, ctx) => {
+      if (!ctx.isIdle()) {
+        ctx.ui.notify("Agent is busy; run /loopx-turn after the current turn settles.", "warning");
+        return;
+      }
+      const goalHint = args.trim();
+      pi.sendUserMessage(
+        `Run exactly one bounded LoopX turn in the current project${goalHint ? ` for goal ${goalHint}` : ""}. ` +
+          "Load the loopx-pi skill. Inspect status and quota first, respect every user/capability gate, claim at most one runnable todo, perform and validate one coherent work segment, then complete/update the todo, refresh state, and spend one slot only when validated delivery was written back. Do not schedule another turn.",
+      );
+    },
+  });
+
+  pi.registerCommand("loopx-status", {
+    description: "Show a compact read-only LoopX status widget",
+    handler: async (_args, ctx) => {
+      try {
+        const result = await pi.exec(LOOPX_BIN, ["--format", "json", "status", "--limit", "20"], {
+          cwd: ctx.cwd,
+          timeout: TOOL_TIMEOUT_MS,
+        });
+        if (result.code !== 0) throw new Error(result.stderr || result.stdout || "LoopX status failed");
+        const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+        ctx.ui.setWidget("loopx-pi-status", statusLines(payload), { placement: "aboveEditor" });
+        ctx.ui.notify("LoopX status refreshed", "info");
+      } catch (error) {
+        ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+      }
+    },
+  });
+
+  pi.on("session_start", async (_event, ctx) => {
+    try {
+      const result = await pi.exec(LOOPX_BIN, ["version"], { cwd: ctx.cwd, timeout: 5000 });
+      if (result.code === 0) ctx.ui.setStatus("loopx-pi", result.stdout.trim());
+    } catch {
+      ctx.ui.setStatus("loopx-pi", "LoopX unavailable");
+    }
+  });
+}

--- a/integrations/pi/package.json
+++ b/integrations/pi/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "loopx-pi-adapter",
+  "version": "0.2.7",
+  "private": true,
+  "description": "Opt-in pi host integration for the LoopX control plane.",
+  "license": "MIT",
+  "keywords": ["pi-package", "loopx"],
+  "pi": {
+    "extensions": ["./extensions/loopx.ts"],
+    "skills": ["./skills"]
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "typebox": "*"
+  }
+}

--- a/integrations/pi/skills/loopx-pi/SKILL.md
+++ b/integrations/pi/skills/loopx-pi/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: loopx-pi
+description: Operate LoopX long-running goals from pi. Use for /loopx, /loopx-turn, persistent project goals, quota-gated work, LoopX todo ownership, state writeback, or handoff across agent sessions.
+compatibility: Requires LoopX 0.2.7+ on PATH and the loopx-pi-adapter extension.
+---
+
+# LoopX In Pi
+
+LoopX is the deterministic local control plane. Pi is the interactive executor. Keep their responsibilities separate:
+
+- LoopX owns durable goal, gate, todo, quota, evidence, and handoff state.
+- Pi performs one bounded work segment using its normal read/bash/edit/write tools.
+- This adapter is a manual interactive loop driver. It does not install timers, heartbeat automation, or a hidden background process.
+
+Use `loopx_control` for supported operations. Do not construct raw `loopx` shell commands unless the structured tool lacks the required action.
+
+## Host Mapping
+
+Treat pi as an external interactive CLI host:
+
+- start-goal host surface: `pi`
+- typed turn-plan host: `generic-cli`
+- execution mode: `interactive-visible`
+- LoopX 0.2.7 quota calls use the goal, agent, capabilities, and bounded turn envelope
+- default registered agent: `pi-main` (override with `LOOPX_PI_AGENT_ID`)
+- available capabilities: `shell`, `filesystem`, `filesystem_write`
+
+These capabilities describe the current runtime; they do not grant repository, network, publish, production, or secret access.
+
+## Delivery Workspace And Vision
+
+LoopX 0.2.7 binds accountable delivery to the Git checkout that produced it.
+
+- When work is delivered in the connected goal project, omit `deliveryWorkspace`.
+- When work is delivered in another checkout or worktree, pass that path as `deliveryWorkspace` to both `refresh_state` and `spend_slot`.
+- For a material refresh, provide a bounded vision patch with `visionState`, `visionSummary`, `visionRoleScope`, `visionAcceptance`, and the relevant continuation fields.
+- Use `visionUnchangedReason` only after an agent vision baseline exists and its acceptance boundary is genuinely unchanged.
+- A workspace or vision guard failure is a blocker to fix, not permission to spend from another directory or omit the checkpoint.
+
+## Read-Only Inspection
+
+For `/loopx` without a goal:
+
+1. Call `loopx_control` with `action=status` and no mutation.
+2. If status is contradictory or unhealthy, call `diagnose` for the selected goal.
+3. Report the active goal, current user gate, highest-priority runnable agent todo, owner/claim, and exactly one next safe action.
+4. Do not connect a project, add todos, refresh state, or spend quota.
+
+## Start Or Continue A Goal
+
+`/loopx <goal text>` is explicit user intent to create or reuse local LoopX state for that goal. It is not permission for external writes, publishing, production actions, destructive git, or background scheduling.
+
+1. Call `start_goal` with the exact goal text. Read `project_connection` and `recommended_next_step`.
+2. If already connected, reuse the existing goal and todos. Never force bootstrap or replace state. Check `registered_agents`; when `pi-main` is absent, preview then execute `register_agent` for the existing goal before claiming work.
+3. If not connected, call `connect` first as a preview (`execute=false`), inspect its paths and goal id, then call it with `execute=true`. The adapter also registers `pi-main` for the new goal.
+4. Confirm `.loopx/`, `.codex/goals/`, and `.local/` are ignored. The adapter writes these patterns to local `.git/info/exclude` after connect and does not modify tracked `.gitignore`. Do not commit generated live state.
+5. Read `todo_list` before planning. Avoid todos that duplicate existing text or intent.
+6. For a broad goal, plan 2-5 concise public-safe todos. For a bounded goal, use only the steps needed to make the approach explicit. Prefix each with `[P0]`, `[P1]`, or `[P2]`; include at least one P0 unless blocked by a user gate.
+7. Preview each `todo_add`, then execute it in exact plan order. Prefer `role=agent`, `taskClass=advancement_task`; use `role=user`, `taskClass=user_gate` only for a concrete owner decision.
+8. Call `refresh_state` with a truthful next action. Then follow the one-turn workflow below.
+
+Do not interpret successful setup as successful project work.
+
+## One Bounded Turn
+
+Use this workflow for `/loopx-turn` and for the first segment after starting a goal:
+
+1. Call `status` focused on the goal and `quota_should_run` with `agentId=pi-main`.
+2. If LoopX says not to run, stop. Report the reason, gate, backoff, and next observable condition. Do not spend quota.
+3. Select at most one runnable agent todo. Respect `claimed_by`, excluded agents, required decision scope, write scope, capabilities, and repository policy.
+4. Preview `todo_claim`, then execute it. If the claim is rejected, re-read status instead of working around ownership.
+5. Perform one coherent work segment with pi's normal tools. Keep changes inside the selected todo and repository scope.
+6. Run targeted validation. A tool call, process launch, generated packet, or unverified edit is not delivery evidence.
+7. On validated progress, preview and execute `todo_complete` with compact public-safe evidence and either a concrete successor (`nextAgentTodo`) or `noFollowUp=true`.
+8. Preview and execute `refresh_state`. Set a truthful classification, delivery scale, delivery outcome, next action, delivery workspace, and required agent vision checkpoint.
+9. Only after validated work and state writeback, preview then execute `spend_slot` once from the accountable delivery workspace.
+10. Stop after this segment. Do not trigger another pi turn automatically.
+
+If work fails or remains incomplete, do not falsely complete the todo or spend quota. Record a truthful refresh classification/outcome when supported, and report the blocker.
+
+## Write Safety
+
+- Mutating `loopx_control` actions default to preview. Inspect preview output before repeating with `execute=true`.
+- Never use force bootstrap, state replacement, destructive reconnect, or global-route replacement through this adapter.
+- Never expose credentials, raw private logs, private URLs, local absolute paths, or benchmark trajectories as public-safe evidence.
+- External comments, PR publication, merge, production action, and private-material access remain explicit user or repository-policy gates.
+- LoopX's local generated state is operational state, not source code. Keep it untracked.
+
+## Recovery
+
+When behavior is surprising:
+
+1. Run `doctor`.
+2. Run goal-scoped `status`, then `diagnose` and `history`.
+3. Compare the active todo, quota decision, latest refresh, and claimed agent.
+4. Do not bypass a contradictory gate. Report the exact contradiction and the smallest repair action.

--- a/loopx/agent_onboarding.py
+++ b/loopx/agent_onboarding.py
@@ -29,6 +29,8 @@ def _surface_install_command(agent_type: str, cli_bin: str) -> str | None:
         return f"{shell_arg(cli_bin)} slash-commands --install --surface codex"
     if agent_type == "claude-code":
         return f"{shell_arg(cli_bin)} slash-commands --install --surface claude-code"
+    if agent_type == "pi":
+        return "loopx-pi-install"
     return None
 
 
@@ -46,6 +48,7 @@ def _bootstrap_pack_command(
         "codex-app": "codex-app",
         "codex-cli": "codex-cli-tui",
         "claude-code": "claude-code",
+        "pi": "pi",
         "manual": "shell",
         "other-agent": "worker-bridge",
     }
@@ -75,6 +78,8 @@ def _start_instruction(agent_type: str) -> str:
         return "Use `$loopx <task>` or select the LoopX skill from `/skills`; after todos are written, set `/goal <task_body>` in the visible TUI."
     if agent_type == "claude-code":
         return "Run `/loopx <task>` to arm LoopX, then run native `/loop`."
+    if agent_type == "pi":
+        return "Run `/loopx <task>`, then use `/loopx-turn` for one visible quota-gated bounded segment at a time."
     if agent_type == "manual":
         return "Use the CLI packet and wire an external scheduler, or run quota/status/todo commands manually."
     return "Use the host's explicit LoopX command facade such as `@loopx <task>` or `$loopx <task>`, then wire its scheduler through this packet."

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -39,6 +39,7 @@ START_GOAL_HOST_SURFACES = (
     "codex-ide",
     "codex-cli-tui",
     "claude-code",
+    "pi",
     "shell",
 )
 
@@ -247,6 +248,7 @@ def build_start_goal_host_surface_selection_packet(
         "codex-ide": "Codex IDE extension; activate its visible goal mode",
         "codex-cli-tui": "terminal Codex TUI with visible /goal support",
         "claude-code": "Claude Code with native /loop",
+        "pi": "pi coding agent with interactive quota-gated bounded turns",
         "shell": "manual shell or an explicitly configured external scheduler",
     }
     choices: list[dict[str, Any]] = []
@@ -268,10 +270,7 @@ def build_start_goal_host_surface_selection_packet(
                 "rerun_command": rerun_command,
             }
         )
-    reason = (
-        "host surface is required because Codex App, Codex IDE, and Codex CLI "
-        "have different continuation contracts"
-    )
+    reason = "host surface is required because supported hosts have different continuation contracts"
     gate = {
         "schema_version": HOST_SURFACE_SELECTION_SCHEMA_VERSION,
         "state": "selection_required",
@@ -605,6 +604,7 @@ def _goal_start_contract(*, goal_text: str | None, connected: bool, agent_type: 
                 "codex-app": "Codex App heartbeat automation",
                 "codex-cli": "visible Codex CLI `/goal <task_body>`",
                 "claude-code": "Claude Code native `/loop` after `/loopx <task>` arms LoopX",
+                "pi": "interactive `/loopx-turn` bounded segments without a background scheduler",
                 "manual": "external scheduler or manual quota/status loop",
                 "other-agent": "custom host loop driver using the returned task body and quota guard",
             },
@@ -616,7 +616,7 @@ def _goal_start_contract(*, goal_text: str | None, connected: bool, agent_type: 
                 "Only recompute onboarding/activation when activation is missing, unknown, stale, "
                 "or the agent type changed; normal ticks should read quota/status/state directly."
             ),
-            "begin_automation_when_quota_allows": True,
+            "begin_automation_when_quota_allows": agent_type != "pi",
             "spend_quota_after_writeback": True,
         },
         "domain_route_hints": {
@@ -683,7 +683,7 @@ Planning rules:
 3. Every new todo starts with `[P0]`, `[P1]`, or `[P2]`; include at least one `[P0]` unless the first useful step is blocked by a user gate.
 4. If several todos share the same priority, their listed order is their relative priority. Preserve that exact order when writing them.
 5. Prefer executable Agent Todo items with `task_class=advancement_task`; use User Todo only for concrete owner decisions or private-material gates.
-6. After writing todos, run `loopx refresh-state --goal-id {goal_id}`, activate the host loop if it is missing, unknown, or stale (Codex App automation, Codex CLI `/goal <task_body>`, Claude Code `/loop`, or a custom host-loop gate), then run its typed `quota_guard` and begin the first allowed bounded segment.
+6. After writing todos, run `loopx refresh-state --goal-id {goal_id}`, activate the host loop if it is missing, unknown, or stale (Codex App automation, Codex CLI `/goal <task_body>`, Claude Code `/loop`, pi `/loopx-turn`, or a custom host-loop gate), then run its typed `quota_guard` and begin the first allowed bounded segment.
 7. If the goal is a GitHub issue/PR fix, first preview `loopx issue-fix workflow-plan --url <github-issue-or-pr-url> --repo-path <approved-repo> --repository-context-json <compact-context.json> --validation-label '<validation command>' --format json`; write only metadata classification plus the feasibility checkpoint. Repository context should pin current repo policy, architecture, change-scope, reproduction, and validation refs; memory and external experts remain advisory until verified against the pinned revision. After a compact public-safe observation, run `loopx issue-fix feasibility --url <github-issue-url> --reproduction-status <state> --scope-class <scope> --repository-context-json <compact-context.json> --goal-id {goal_id} --format json` and write only its selected route successor or no-follow-up. Keep private repro material, body/comment reads, arbitrary external comments, PR creation, merge, publish, destructive git, and production actions as explicit gates. After a PR exists and `external_review_request` or `publish` authority is active, call `loopx issue-fix reviewer-request --url <github-pr-url> --repo-path <approved-repo> --base-ref <base-ref> --execute --format json`; it should try the formal request first and, only on confirmed permission denial, post one reviewer-tagging fallback comment. Do not mark notification complete until the request or fallback comment is visible on the PR. Then call `loopx issue-fix pr-lifecycle --url <github-pr-url> --goal-id {goal_id} --format json`; use `grouped_monitor_projection` for one monitor per nonempty state bucket. Never create one monitor per PR. Keep PR actions one-shot and messages at one PR per message.
 """
 
@@ -1294,6 +1294,24 @@ def build_start_goal_guided_packet(
             "preferred_scope_change": "use configure-goal incremental updates instead of force bootstrap when state already exists",
         },
     }
+    if command_pack.get("agent_type") == "pi":
+        guided_transaction["ordered_steps"] = [
+            step
+            for step in guided_transaction["ordered_steps"]
+            if step.get("id") != "scheduler_ack_when_needed"
+        ]
+        quota_step = next(
+            step
+            for step in guided_transaction["ordered_steps"]
+            if step.get("id") == "quota_guard"
+        )
+        quota_step["purpose"] = (
+            "let LoopX choose the first bounded segment; pi does not apply scheduler hints"
+        )
+        guided_transaction["idempotency_policy"]["host_loop_recheck"] = (
+            "Only recheck the pi package surface when it is missing, unknown, stale, or changed."
+        )
+
     if isinstance(identity_selection_gate, dict):
         guided_transaction["blocked_by"] = "agent_identity_selection"
         guided_transaction["identity_selection_gate"] = identity_selection_gate
@@ -1564,7 +1582,7 @@ Host loop activation is part of setup, not a nice-to-have:
 If the host loop is already proven current, skip the mutation. If it is missing,
 unknown, or stale, use the command above to obtain `task_body` and activate the
 right host loop: Codex App automation, Codex CLI `/goal <task_body>`, Claude
-Code `/loop`, or the custom host-loop gate. If this session cannot mutate that
+Code `/loop`, pi `/loopx-turn`, or the custom host-loop gate. If this session cannot mutate that
 host surface, report the exact gate; do not claim autonomous setup complete.
 Use `{commands.get("goal_start_agent_onboard_recheck", "")}` only when
 activation state is missing/unknown/stale or the agent type changed."""

--- a/loopx/cli_commands/starter_bootstrap.py
+++ b/loopx/cli_commands/starter_bootstrap.py
@@ -73,6 +73,7 @@ def handle_agent_onboard_command(
                 "codex-ide",
                 "codex-cli",
                 "claude-code",
+                "pi",
                 "manual",
                 "other-agent",
             ],

--- a/loopx/cli_commands/starter_bootstrap_registration.py
+++ b/loopx/cli_commands/starter_bootstrap_registration.py
@@ -19,7 +19,7 @@ def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) 
     )
     agent_onboard_parser.add_argument(
         "--agent-type",
-        help="Agent runtime type: codex-app, codex-ide, codex-cli, claude-code, manual, or other-agent.",
+        help="Agent runtime type: codex-app, codex-ide, codex-cli, claude-code, pi, manual, or other-agent.",
     )
     agent_onboard_parser.add_argument(
         "--list-agent-types",
@@ -66,7 +66,7 @@ def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) 
     bootstrap_command_pack_parser.add_argument(
         "--host-surface",
         default="chat-box",
-        choices=["chat-box", "codex-app", "codex-ide", "codex-cli-tui", "claude-code", "shell", "http", "worker-bridge"],
+        choices=["chat-box", "codex-app", "codex-ide", "codex-cli-tui", "claude-code", "pi", "shell", "http", "worker-bridge"],
         help="Host surface where the slash command pack will be exposed.",
     )
     bootstrap_command_pack_parser.add_argument(
@@ -112,7 +112,7 @@ def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) 
     )
     start_goal_parser.add_argument(
         "--host-surface",
-        choices=["chat-box", "codex-app", "codex-ide", "codex-cli-tui", "claude-code", "shell", "http", "worker-bridge"],
+        choices=["chat-box", "codex-app", "codex-ide", "codex-cli-tui", "claude-code", "pi", "shell", "http", "worker-bridge"],
         help=(
             "Exact host surface that will own loop activation after todo writeback. "
             "When omitted, start-goal returns a read-only host selection gate."

--- a/loopx/host_loop_activation.py
+++ b/loopx/host_loop_activation.py
@@ -39,6 +39,7 @@ SUPPORTED_AGENT_TYPES = [
     "codex-ide",
     "codex-cli",
     "claude-code",
+    "pi",
     "manual",
     "other-agent",
 ]
@@ -82,6 +83,12 @@ AGENT_TYPE_CATALOG: dict[str, dict[str, Any]] = {
         "host_loop": "native /loop gated by LoopX",
         "entry": "/loopx <task> then /loop",
         "accepted_inputs": ["claude-code", "claude_code", "claude code", "cc"],
+    },
+    "pi": {
+        "display_name": "pi coding agent",
+        "host_loop": "interactive quota-gated /loopx-turn",
+        "entry": "/loopx <task> then /loopx-turn",
+        "accepted_inputs": ["pi", "pi-cli", "pi coding agent"],
     },
     "manual": {
         "display_name": "Manual shell / external scheduler",
@@ -141,6 +148,7 @@ HOST_SURFACE_TO_AGENT_TYPE = {
     "codex-ide": "codex-ide",
     "codex-cli-tui": "codex-cli",
     "claude-code": "claude-code",
+    "pi": "pi",
     "shell": "manual",
     "http": "other-agent",
     "worker-bridge": "other-agent",
@@ -262,6 +270,7 @@ def _heartbeat_commands(
         "codex-ide": "Codex IDE /goal visible task loop",
         "codex-cli": "Codex CLI /goal visible TUI loop",
         "claude-code": "Claude Code native /loop gated by LoopX",
+        "pi": "pi interactive quota-gated bounded turns",
         "manual": "External scheduler or manual shell LoopX poll",
         "other-agent": "Custom agent host loop gated by LoopX",
     }
@@ -456,6 +465,37 @@ def _claude_code_activation(commands: dict[str, str], cli_bin: str) -> dict[str,
     }
 
 
+def _pi_activation() -> dict[str, Any]:
+    return {
+        "host_surface": "pi_interactive_bounded_turns",
+        "entry_command_hint": "/loopx <task> then /loopx-turn",
+        "activation_method": "run_pi_quota_gated_bounded_turns",
+        "activation_input_command": "/loopx-turn",
+        "setup_command": "loopx-pi-install",
+        "host_mutation": {
+            "owner": "pi interactive CLI",
+            "host_command": "/loopx-turn",
+            "cli_can_mutate_directly": False,
+            "missing_host_tool_gate": (
+                "The LoopX pi package is unavailable; install integrations/pi, "
+                "reload pi, and report that concrete gate instead of falling back "
+                "to another agent's host loop."
+            ),
+        },
+        "activation_steps": [
+            "Install or refresh the opt-in LoopX pi package and reload pi.",
+            "Run `/loopx <task>` to create or reuse the goal and ranked todos.",
+            "Run `/loopx-turn` for one visible quota-gated bounded segment at a time.",
+            "Keep scheduling manual; the pi integration does not install a background loop.",
+        ],
+        "success_criteria": [
+            "pi exposes /loopx, /loopx-turn, /loopx-status, and loopx_control.",
+            "Each delivery turn starts from LoopX status and quota, validates work, writes state, then spends at most one slot.",
+            "No scheduler, timer, or unrelated agent integration is installed or changed.",
+        ],
+    }
+
+
 def _manual_activation(commands: dict[str, str]) -> dict[str, Any]:
     return {
         "host_surface": "external_scheduler_or_manual_shell",
@@ -520,6 +560,8 @@ def build_host_loop_activation_packet(
         surface = _codex_cli_activation(commands)
     elif canonical == "claude-code":
         surface = _claude_code_activation(commands, cli_bin)
+    elif canonical == "pi":
+        surface = _pi_activation()
     else:
         surface = _manual_activation(commands)
         if canonical == "other-agent":

--- a/loopx/release_candidate.py
+++ b/loopx/release_candidate.py
@@ -29,6 +29,10 @@ REPRESENTATIVE_PACKAGE_PATHS = (
     "loopx/cli_commands/quota.py",
     "loopx/cli_commands/status.py",
     "scripts/loopx",
+    "scripts/install-pi-package.sh",
+    "integrations/pi/package.json",
+    "integrations/pi/extensions/loopx.ts",
+    "integrations/pi/skills/loopx-pi/SKILL.md",
 )
 
 

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -432,6 +432,7 @@ copy_path "$repo_root/docs" "$release_tmp/docs"
 copy_path "$repo_root/man" "$release_tmp/man"
 copy_path "$repo_root/examples" "$release_tmp/examples"
 copy_path "$repo_root/apps" "$release_tmp/apps"
+copy_path "$repo_root/integrations" "$release_tmp/integrations"
 copy_path "$repo_root/.github" "$release_tmp/.github"
 copy_path "$repo_root/README.md" "$release_tmp/README.md"
 copy_path "$repo_root/CONTRIBUTOR_TASKS.md" "$release_tmp/CONTRIBUTOR_TASKS.md"
@@ -460,6 +461,9 @@ if ! validate_release_candidate "$release_dir"; then
   exit 1
 fi
 install_symlink "$release_dir/scripts/loopx" "$bin_dir/loopx"
+chmod +x "$release_dir/scripts/install-pi-package.sh"
+install_symlink "$release_dir/scripts/install-pi-package.sh" "$bin_dir/loopx-pi-install"
+pi_installer_line="- pi package installer: $bin_dir/loopx-pi-install (opt-in)"
 verify_default_promotion
 
 canary_line="- canary executable: skipped"
@@ -518,6 +522,7 @@ fi
 
 export PATH="$bin_dir:$PATH"
 "$bin_dir/loopx" doctor >/dev/null
+"$bin_dir/loopx-pi-install" --dry-run >/dev/null
 if [[ "$install_canary" != "0" ]]; then
   "$bin_dir/loopx-canary" doctor >/dev/null
 fi
@@ -608,6 +613,7 @@ loopx installed locally
 - manual root: $man_root
 $man_line
 $canary_line
+$pi_installer_line
 - executable compatibility: none
 $legacy_line
 - profile: $shell_profile

--- a/scripts/install-pi-package.sh
+++ b/scripts/install-pi-package.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+package_source="$repo_root/integrations/pi"
+install_root="${LOOPX_PI_INSTALL_ROOT:-$HOME/.local/share/loopx}"
+package_target="$install_root/pi-package"
+managed_marker="$package_target/.loopx-managed-pi-package"
+pi_bin="${PI_BIN:-pi}"
+
+usage() {
+  printf '%s\n' \
+    'Usage: scripts/install-pi-package.sh [--dry-run]' \
+    '' \
+    "Register the opt-in LoopX pi package in pi's user settings. This command" \
+    'does not install a scheduler or modify resources for any other agent host.'
+}
+
+case "${1:-}" in
+  "") ;;
+  --dry-run)
+    printf 'sync %q -> %q\n' "$package_source" "$package_target"
+    printf '%q install %q\n' "$pi_bin" "$package_target"
+    exit 0
+    ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac
+
+if [[ ! -f "$package_source/package.json" ]]; then
+  echo "loopx pi installer error: package not found: $package_source" >&2
+  exit 1
+fi
+
+if ! command -v "$pi_bin" >/dev/null 2>&1; then
+  echo "loopx pi installer error: pi executable not found: $pi_bin" >&2
+  exit 1
+fi
+
+mkdir -p "$install_root"
+if [[ -e "$package_target" && ! -f "$managed_marker" ]]; then
+  echo "loopx pi installer error: refusing to replace unmanaged path: $package_target" >&2
+  exit 1
+fi
+
+staging="$(mktemp -d "$install_root/.pi-package-stage.XXXXXX")"
+backup=""
+cleanup() {
+  if [[ -n "$staging" && -d "$staging" ]]; then
+    rm -rf "$staging"
+  fi
+}
+trap cleanup EXIT
+
+cp -R "$package_source/." "$staging/"
+touch "$staging/.loopx-managed-pi-package"
+
+if [[ -e "$package_target" ]]; then
+  backup="$install_root/.pi-package-backup.$$"
+  mv "$package_target" "$backup"
+fi
+if ! mv "$staging" "$package_target"; then
+  if [[ -n "$backup" && -e "$backup" ]]; then
+    mv "$backup" "$package_target"
+  fi
+  exit 1
+fi
+staging=""
+
+if ! "$pi_bin" install "$package_target"; then
+  rm -rf "$package_target"
+  if [[ -n "$backup" && -e "$backup" ]]; then
+    mv "$backup" "$package_target"
+  fi
+  exit 1
+fi
+
+if [[ -n "$backup" && -e "$backup" ]]; then
+  rm -rf "$backup"
+fi
+
+echo "loopx pi package registered: $package_target"
+echo "Run /reload in an already open pi session."

--- a/tests/control_plane/test_start_goal_compact_projection.py
+++ b/tests/control_plane/test_start_goal_compact_projection.py
@@ -306,6 +306,7 @@ def test_cli_without_host_returns_read_only_host_selection_gate(
         "codex-ide",
         "codex-cli-tui",
         "claude-code",
+        "pi",
         "shell",
     ]
     ide = next(choice for choice in choices if choice["host_surface"] == "codex-ide")
@@ -339,3 +340,44 @@ def test_codex_ide_uses_visible_goal_and_preserves_compact_parity(
     assert activation["activation_method"] == "set_visible_goal"
     assert activation["host_mutation"]["host_command"] == "/goal <task_body>"
     assert _host_shadow_document(compact) == _host_shadow_document(detailed)
+
+
+def test_pi_guided_packet_keeps_scheduler_steps_out_of_interactive_turns(
+    tmp_path: Path,
+) -> None:
+    project = _write_connected_project(tmp_path)
+    common = {
+        "project": project,
+        "goal_id": GOAL_ID,
+        "agent_id": AGENT_ID,
+        "cli_bin": "loopx",
+        "goal_text": GOAL_TEXT,
+        "available_capabilities": ["filesystem_write"],
+        "include_command_pack_detail": False,
+    }
+
+    pi_packet = build_start_goal_guided_packet(host_surface="pi", **common)
+    codex_packet = build_start_goal_guided_packet(host_surface="codex-app", **common)
+
+    activation = pi_packet["command_pack"]["host_loop_activation"]
+    assert activation["host_surface"] == "pi_interactive_bounded_turns"
+    assert activation["activation_input_command"] == "/loopx-turn"
+    assert (
+        pi_packet["command_pack"]["goal_start_contract"]["activation"][
+            "begin_automation_when_quota_allows"
+        ]
+        is False
+    )
+
+    pi_step_ids = [step["id"] for step in pi_packet["guided_transaction"]["ordered_steps"]]
+    codex_step_ids = [
+        step["id"] for step in codex_packet["guided_transaction"]["ordered_steps"]
+    ]
+    assert "scheduler_ack_when_needed" not in pi_step_ids
+    assert "scheduler_ack_when_needed" in codex_step_ids
+    quota_step = next(
+        step
+        for step in pi_packet["guided_transaction"]["ordered_steps"]
+        if step["id"] == "quota_guard"
+    )
+    assert "does not apply scheduler hints" in quota_step["purpose"]

--- a/tests/test_host_loop_activation.py
+++ b/tests/test_host_loop_activation.py
@@ -92,3 +92,44 @@ def test_ambiguous_codex_requires_app_ide_or_cli_selection() -> None:
         normalize_agent_type("codex")
 
     assert caught.value.suggestions == ["codex-app", "codex-ide", "codex-cli"]
+
+
+def test_pi_is_an_additive_interactive_host_without_a_scheduler() -> None:
+    assert normalize_agent_type("pi coding agent") == "pi"
+    assert agent_type_for_host_surface("pi") == "pi"
+
+    packet = build_host_loop_activation_packet(
+        agent_type="pi",
+        goal_id="fixture-goal",
+        agent_id="pi-main",
+        registered_agents=["pi-main"],
+    )
+
+    assert packet["host_surface"] == "pi_interactive_bounded_turns"
+    assert packet["activation_method"] == "run_pi_quota_gated_bounded_turns"
+    assert packet["host_mutation"]["host_command"] == "/loopx-turn"
+    assert packet["setup_command"] == "loopx-pi-install"
+    assert "scheduler" in str(packet).lower()
+
+
+@pytest.mark.parametrize(
+    ("agent_type", "activation_method"),
+    [
+        ("codex-app", "create_or_update_codex_app_automation"),
+        ("codex-ide", "set_visible_goal"),
+        ("codex-cli", "set_visible_goal"),
+        ("claude-code", "arm_loopx_then_run_native_loop"),
+        ("manual", "external_loop_driver"),
+        ("other-agent", "external_loop_driver"),
+    ],
+)
+def test_existing_agent_activation_routes_remain_unchanged(
+    agent_type: str,
+    activation_method: str,
+) -> None:
+    packet = build_host_loop_activation_packet(
+        agent_type=agent_type,
+        goal_id="fixture-goal",
+    )
+
+    assert packet["activation_method"] == activation_method

--- a/tests/test_pi_host_integration.py
+++ b/tests/test_pi_host_integration.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PI_PACKAGE = REPO_ROOT / "integrations" / "pi"
+
+
+def test_pi_package_manifest_and_resources_are_self_contained() -> None:
+    manifest = json.loads((PI_PACKAGE / "package.json").read_text(encoding="utf-8"))
+
+    assert manifest["name"] == "loopx-pi-adapter"
+    assert manifest["private"] is True
+    assert "pi-package" in manifest["keywords"]
+    assert manifest["pi"] == {
+        "extensions": ["./extensions/loopx.ts"],
+        "skills": ["./skills"],
+    }
+
+    for relative_path in (
+        "extensions/loopx.ts",
+        "skills/loopx-pi/SKILL.md",
+        "README.md",
+    ):
+        assert (PI_PACKAGE / relative_path).is_file(), relative_path
+
+
+def test_pi_extension_covers_loopx_027_writeback_guards() -> None:
+    source = (PI_PACKAGE / "extensions" / "loopx.ts").read_text(encoding="utf-8")
+
+    for required_fragment in (
+        '"--host-surface",\n        "pi"',
+        '"--delivery-workspace-path"',
+        '"--vision-state"',
+        '"--vision-acceptance"',
+        '"--vision-unchanged-reason"',
+        '"--task-repository"',
+        '["--registry", join(project, ".loopx", "registry.json")]',
+        "cwd: plan.commandCwd",
+    ):
+        assert required_fragment in source
+
+    assert "automation_update" not in source
+    assert "scheduler-ack" not in source
+
+
+def test_pi_installer_is_explicit_and_has_a_non_mutating_preview() -> None:
+    installer = REPO_ROOT / "scripts" / "install-pi-package.sh"
+    result = subprocess.run(
+        [str(installer), "--dry-run"],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    assert "pi install" in result.stdout
+    assert "integrations/pi" in result.stdout
+    assert ".local/share/loopx/pi-package" in result.stdout
+    assert not (REPO_ROOT / ".loopx-managed-pi-package").exists()
+
+
+def test_pi_installer_uses_a_stable_managed_copy_and_rolls_back_on_failure(
+    tmp_path: Path,
+) -> None:
+    installer = REPO_ROOT / "scripts" / "install-pi-package.sh"
+    install_root = tmp_path / "loopx-share"
+    capture = tmp_path / "pi-args.txt"
+    fake_pi = tmp_path / "pi-ok"
+    fake_pi.write_text(
+        "#!/usr/bin/env bash\nprintf '%s\\n' \"$@\" > \"$PI_CAPTURE\"\n",
+        encoding="utf-8",
+    )
+    fake_pi.chmod(0o755)
+    env = {
+        **os.environ,
+        "LOOPX_PI_INSTALL_ROOT": str(install_root),
+        "PI_BIN": str(fake_pi),
+        "PI_CAPTURE": str(capture),
+    }
+
+    subprocess.run([str(installer)], cwd=REPO_ROOT, env=env, check=True)
+
+    target = install_root / "pi-package"
+    assert (target / ".loopx-managed-pi-package").is_file()
+    assert json.loads((target / "package.json").read_text(encoding="utf-8"))[
+        "name"
+    ] == "loopx-pi-adapter"
+    assert capture.read_text(encoding="utf-8").splitlines() == [
+        "install",
+        str(target),
+    ]
+
+    sentinel = target / "rollback-sentinel"
+    sentinel.write_text("keep", encoding="utf-8")
+    failing_pi = tmp_path / "pi-fail"
+    failing_pi.write_text("#!/usr/bin/env bash\nexit 9\n", encoding="utf-8")
+    failing_pi.chmod(0o755)
+    failed = subprocess.run(
+        [str(installer)],
+        cwd=REPO_ROOT,
+        env={**env, "PI_BIN": str(failing_pi)},
+        check=False,
+    )
+
+    assert failed.returncode != 0
+    assert sentinel.read_text(encoding="utf-8") == "keep"


### PR DESCRIPTION
## Summary

- add `pi` as a canonical interactive LoopX host
- ship an opt-in pi package with `/loopx`, `/loopx-turn`, `/loopx-status`, and the allow-listed `loopx_control` tool
- include a managed package installer in release snapshots without enabling a scheduler or changing existing host resources
- document delivery-workspace and vision writeback contracts and lock existing host behavior with regression coverage

## Validation

- `python3 -m pytest -q` (`676 passed, 2 skipped`)
- `python3 -m loopx.cli canary premerge --from-git-diff` (`18/18` checks passed, no manual holds)
- focused pi/host tests (`21 passed`)
- install-local, packaged-install, and host activation smokes
- shell syntax, Python compile, diff hygiene, secret scan, and public-boundary scan

## Boundaries

The pi package is opt-in and interactive. It does not install or acknowledge a timer, heartbeat, Codex App cadence, or background scheduler, and it does not modify Codex CLI, Codex IDE, Claude Code, manual, or custom-agent resources.