### PR TITLE
fix(todo): allow narrowing accidental global gates

### DIFF
--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -229,6 +229,15 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
     todo_parser.add_argument(
+        "--clear-global-gate",
+        action="store_true",
+        help=(
+            "For todo update on a user_gate, remove global_gate. In a multi-agent "
+            "goal, provide --blocks-agent in the same update so the gate retains "
+            "an explicit lane scope."
+        ),
+    )
+    todo_parser.add_argument(
         "--unblocks-todo-id",
         help=(
             "For todo add/update, link this todo to the blocked todo it unblocks, "
@@ -519,6 +528,7 @@ def handle_todo_command(
                     ("--excluded-agent", args.excluded_agents),
                     ("--clear-excluded-agents", args.clear_excluded_agents),
                     ("--global-gate", args.global_gate),
+                    ("--clear-global-gate", args.clear_global_gate),
                     ("--unblocks-todo-id", args.unblocks_todo_id),
                     ("--successor-todo-id", args.successor_todo_ids),
                     ("--resume-when", args.resume_when),
@@ -591,6 +601,7 @@ def handle_todo_command(
                 args.excluded_agents,
                 args.clear_excluded_agents,
                 args.global_gate,
+                args.clear_global_gate,
                 args.unblocks_todo_id,
                 args.successor_todo_ids,
                 args.resume_when,
@@ -648,6 +659,7 @@ def handle_todo_command(
                 excluded_agents=args.excluded_agents,
                 clear_excluded_agents=bool(args.clear_excluded_agents),
                 global_gate=bool(args.global_gate),
+                clear_global_gate=bool(args.clear_global_gate),
                 agent_id=args.agent_id,
                 unblocks_todo_id=args.unblocks_todo_id,
                 successor_todo_ids=args.successor_todo_ids,
@@ -673,7 +685,7 @@ def handle_todo_command(
                 )
             if args.claimed_by and args.clear_claim:
                 raise ValueError("todo complete accepts either --claimed-by or --clear-claim, not both")
-            if args.task_repository or args.blocks_agent or args.clear_blocks_agent or args.excluded_agents or args.clear_excluded_agents or args.global_gate or args.unblocks_todo_id or args.resume_when:
+            if args.task_repository or args.blocks_agent or args.clear_blocks_agent or args.excluded_agents or args.clear_excluded_agents or args.global_gate or args.clear_global_gate or args.unblocks_todo_id or args.resume_when:
                 raise ValueError("todo complete does not update current todo routing metadata; use todo update first")
             if args.monitor_target_key or args.cadence or args.next_due_at or args.expires_at:
                 raise ValueError("todo complete does not support monitor schedule metadata; use todo update before completion")
@@ -756,7 +768,7 @@ def handle_todo_command(
                 )
             if args.next_excluded_agents and not args.next_agent_todo:
                 raise ValueError("--next-excluded-agent requires --next-agent-todo")
-            if args.blocks_agent or args.clear_blocks_agent or args.excluded_agents or args.clear_excluded_agents or args.global_gate or args.unblocks_todo_id or args.resume_when:
+            if args.blocks_agent or args.clear_blocks_agent or args.excluded_agents or args.clear_excluded_agents or args.global_gate or args.clear_global_gate or args.unblocks_todo_id or args.resume_when:
                 raise ValueError("todo supersede does not update current todo routing metadata; use todo update first")
             if args.successor_todo_ids:
                 raise ValueError("todo supersede does not support --successor-todo-id; use --next-agent-todo or update the source todo before supersede")

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -31,6 +31,7 @@ TODO_OPTION_FIELDS = (
     ("--excluded-agent", "excluded_agents"),
     ("--clear-excluded-agents", "clear_excluded_agents"),
     ("--global-gate", "global_gate"),
+    ("--clear-global-gate", "clear_global_gate"),
     ("--unblocks-todo-id", "unblocks_todo_id"),
     ("--successor-todo-id", "successor_todo_ids"),
     ("--resume-when", "resume_when"),
@@ -78,6 +79,7 @@ def validate_shared_todo_options(args: argparse.Namespace) -> None:
     )
     agent_id_allowed_for_read = args.todo_command == "list"
     global_gate_allowed = args.todo_command in {"add", "update"}
+    clear_global_gate_allowed = args.todo_command == "update"
     if (
         args.todo_command not in {"suggest", "capture-followups"}
         and args.agent_id
@@ -93,6 +95,10 @@ def validate_shared_todo_options(args: argparse.Namespace) -> None:
     if args.global_gate and not global_gate_allowed:
         raise ValueError(
             "--global-gate is supported only by todo add/update for user_gate items"
+        )
+    if args.clear_global_gate and not clear_global_gate_allowed:
+        raise ValueError(
+            "--clear-global-gate is supported only by todo update for user_gate items"
         )
     if (
         args.todo_command not in {"suggest", "capture-followups"}

--- a/loopx/control_plane/todos/write_policy.py
+++ b/loopx/control_plane/todos/write_policy.py
@@ -66,3 +66,25 @@ def require_user_gate_scope(
         "when the gate blocks one lane, or pass --global-gate when it genuinely "
         "blocks every registered agent"
     )
+
+
+def resolve_user_gate_global_gate_update(
+    *,
+    role: str,
+    task_class: str | None,
+    existing_global_gate: bool | None,
+    global_gate: bool,
+    clear_global_gate: bool,
+) -> bool | None:
+    if global_gate and clear_global_gate:
+        raise ValueError(
+            "todo update accepts either global_gate or clear_global_gate, not both"
+        )
+    if (global_gate or clear_global_gate) and not (
+        role == "user" and task_class == TODO_TASK_CLASS_USER_GATE
+    ):
+        field = "clear_global_gate" if clear_global_gate else "global_gate"
+        raise ValueError(f"{field} is only valid for user_gate todos")
+    if clear_global_gate:
+        return None
+    return True if global_gate else existing_global_gate

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -84,7 +84,7 @@ from .control_plane.todos.unblock_resume import (
     apply_completed_user_todo_lifecycle,
     require_completion_decision_outcome,
 )
-from .control_plane.todos.write_policy import require_user_gate_scope, require_user_todo_task_class
+from .control_plane.todos.write_policy import require_user_gate_scope, require_user_todo_task_class, resolve_user_gate_global_gate_update
 
 
 ARCHIVE_COMPLETED_DEFAULT_MAX_ACTIVE_DONE = max(0, MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE - 2)
@@ -1079,7 +1079,7 @@ def apply_todo_update_to_lines(
     blocks_agent: str | None = None,
     clear_blocks_agent: bool = False,
     excluded_agents: list[str] | None = None,
-    global_gate: bool | None = None,
+    global_gate: bool | None = None, clear_global_gate: bool = False,
     unblocks_todo_id: str | None = None,
     successor_todo_ids: list[str] | None = None,
     resume_when: str | None = None,
@@ -1189,7 +1189,9 @@ def apply_todo_update_to_lines(
         updates["blocks_agent"] = None
     if excluded_agents is not None:
         updates["excluded_agents"] = excluded_agents
-    if global_gate is not None:
+    if clear_global_gate:
+        updates["global_gate"] = None
+    elif global_gate is not None:
         updates["global_gate"] = global_gate
     if unblocks_todo_id:
         updates["unblocks_todo_id"] = unblocks_todo_id
@@ -1287,7 +1289,7 @@ def update_goal_todo(
     clear_blocks_agent: bool = False,
     excluded_agents: list[str] | None = None,
     clear_excluded_agents: bool = False,
-    global_gate: bool = False,
+    global_gate: bool = False, clear_global_gate: bool = False,
     agent_id: str | None = None,
     unblocks_todo_id: str | None = None,
     successor_todo_ids: list[str] | None = None,
@@ -1300,11 +1302,6 @@ def update_goal_todo(
     state_file: Path | None = None,
     dry_run: bool = False,
 ) -> dict[str, Any]:
-    if global_gate and (
-        (role is not None and role != "user")
-        or (task_class is not None and task_class != TODO_TASK_CLASS_USER_GATE)
-    ):
-        raise ValueError("global_gate is only valid for user_gate todos")
     if excluded_agents and clear_excluded_agents:
         raise ValueError(
             "todo update accepts either excluded_agents or clear_excluded_agents, not both"
@@ -1409,8 +1406,6 @@ def update_goal_todo(
             )
         existing_blocks_agent = normalize_todo_blocks_agent(existing_block.get("blocks_agent"))
         existing_global_gate = normalize_todo_global_gate(existing_block.get("global_gate"))
-        if global_gate and not (target_role == "user" and target_task_class == TODO_TASK_CLASS_USER_GATE):
-            raise ValueError("global_gate is only valid for user_gate todos")
         target_blocks_agent = None if clear_blocks_agent else effective_blocks_agent or existing_blocks_agent
         if (
             effective_agent_id
@@ -1420,7 +1415,13 @@ def update_goal_todo(
         ):
             target_blocks_agent = effective_agent_id
             effective_blocks_agent = effective_agent_id
-        target_global_gate = True if global_gate else existing_global_gate
+        target_global_gate = resolve_user_gate_global_gate_update(
+            role=target_role,
+            task_class=target_task_class,
+            existing_global_gate=existing_global_gate,
+            global_gate=global_gate,
+            clear_global_gate=clear_global_gate,
+        )
         if target_status != TODO_STATUS_DONE:
             require_user_todo_task_class(
                 role=target_role,
@@ -1477,6 +1478,7 @@ def update_goal_todo(
             clear_blocks_agent=clear_blocks_agent,
             excluded_agents=effective_excluded_agents,
             global_gate=True if global_gate else None,
+            clear_global_gate=clear_global_gate,
             unblocks_todo_id=normalized_unblocks_todo_id,
             successor_todo_ids=normalized_successor_todo_ids if successor_todo_ids is not None else None,
             resume_when=normalized_resume_when,

--- a/tests/control_plane/test_todo_decision_scope_cli_validation.py
+++ b/tests/control_plane/test_todo_decision_scope_cli_validation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -14,6 +15,8 @@ from loopx.control_plane.testing.canary_harness import (
 GOAL_ID = "decision-scope-cli-validation"
 VALID_SCOPE = "direction:action:release_route"
 INVALID_SCOPE = "not-a-decision-scope"
+DELIVERY_AGENT = "codex-delivery"
+OTHER_AGENT = "codex-review"
 
 
 def _write_fixture(tmp_path: Path) -> tuple[Path, Path]:
@@ -46,6 +49,101 @@ def _write_fixture(tmp_path: Path) -> tuple[Path, Path]:
 
 def _scope_args(flag: str, values: list[str]) -> list[str]:
     return [part for value in values for part in (flag, value)]
+
+
+def _register_agents(registry_path: Path) -> None:
+    payload = json.loads(registry_path.read_text(encoding="utf-8"))
+    payload["goals"][0]["coordination"] = {
+        "agent_model": "peer_v1",
+        "registered_agents": [DELIVERY_AGENT, OTHER_AGENT],
+    }
+    registry_path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _add_global_gate(registry_path: Path) -> dict:
+    return run_json_cli(
+        "todo",
+        "add",
+        "--goal-id",
+        GOAL_ID,
+        "--role",
+        "user",
+        "--task-class",
+        "user_gate",
+        "--text",
+        "Approve pausing every agent.",
+        "--global-gate",
+        registry_path=registry_path,
+    )
+
+
+def test_todo_update_can_narrow_global_gate_without_consuming_decision(
+    tmp_path: Path,
+) -> None:
+    registry_path, state_file = _write_fixture(tmp_path)
+    _register_agents(registry_path)
+    gate = _add_global_gate(registry_path)
+
+    updated = run_json_cli(
+        "todo",
+        "update",
+        "--goal-id",
+        GOAL_ID,
+        "--role",
+        "user",
+        "--todo-id",
+        gate["todo_id"],
+        "--clear-global-gate",
+        "--blocks-agent",
+        DELIVERY_AGENT,
+        registry_path=registry_path,
+    )
+
+    assert updated["status"] == "open", updated
+    assert updated["blocks_agent"] == DELIVERY_AGENT, updated
+    assert updated["global_gate"] is None, updated
+    state_text = state_file.read_text(encoding="utf-8")
+    assert f"blocks_agent={DELIVERY_AGENT}" in state_text
+    assert "global_gate=" not in state_text
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "error_fragment"),
+    [
+        ([], "multi-agent user_gate requires an explicit scope"),
+        (
+            ["--global-gate"],
+            "todo update accepts either global_gate or clear_global_gate, not both",
+        ),
+    ],
+)
+def test_todo_update_rejects_unsafe_global_gate_clear_without_data_loss(
+    tmp_path: Path,
+    extra_args: list[str],
+    error_fragment: str,
+) -> None:
+    registry_path, state_file = _write_fixture(tmp_path)
+    _register_agents(registry_path)
+    gate = _add_global_gate(registry_path)
+    original = state_file.read_text(encoding="utf-8")
+
+    returncode, payload = run_json_cli_result(
+        "todo",
+        "update",
+        "--goal-id",
+        GOAL_ID,
+        "--role",
+        "user",
+        "--todo-id",
+        gate["todo_id"],
+        "--clear-global-gate",
+        *extra_args,
+        registry_path=registry_path,
+    )
+
+    assert returncode != 0, payload
+    assert error_fragment in payload["error"], payload
+    assert state_file.read_text(encoding="utf-8") == original
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add an explicit `todo update --clear-global-gate` repair path
- require a replacement agent lane when narrowing a gate in multi-agent goals
- preserve the open user decision while removing accidental global scope
- reject contradictory set-and-clear requests and non-user-gate use

## Validation
- `uv run --extra test pytest -q`: 705 passed, 2 skipped
- focused decision-scope tests: 25 passed
- `todo-user-gate-scope-smoke.py`: passed
- explicit global-gate blocking probe: passed
- repository Python line-budget smoke: passed
- premerge canary: 16/17 selected checks passed; the sole failure is `quota-plan-smoke.py`, independently reproduced on clean `origin/main@17a55360` after #2280 because its fixture lacks the newly required typed scheduler execution context

## Merge hold
This PR is intentionally not self-merged yet. A separate fixture-only baseline repair will restore the premerge gate; this branch will then be updated and the full canary rerun before merge.