### PR TITLE
test(scheduler): declare App ownership in cadence smokes

### DIFF
--- a/examples/control_plane/monitor-poll-writeback-smoke.py
+++ b/examples/control_plane/monitor-poll-writeback-smoke.py
@@ -349,6 +349,7 @@ def assert_unchanged_writeback() -> None:
             GOAL_ID,
             "--agent-id",
             AGENT_ID,
+            "--codex-app",
         )
         assert followup["decision"] == "autonomous_replan_required", followup
         assert followup["effective_action"] == "autonomous_replan_required", followup
@@ -479,6 +480,7 @@ def assert_material_transition_followup() -> None:
             GOAL_ID,
             "--agent-id",
             AGENT_ID,
+            "--codex-app",
         )
         assert handoff["ok"] is True, handoff
         assert handoff["decision"] == "run", handoff

--- a/examples/control_plane/monitor-scheduler-contract-smoke.py
+++ b/examples/control_plane/monitor-scheduler-contract-smoke.py
@@ -14,6 +14,9 @@ from loopx.control_plane.testing.quota_fixtures import quota_status_payload  # n
 from loopx.control_plane.scheduler import monitor_todo as monitor_todo_module  # noqa: E402
 from loopx.control_plane.scheduler import scheduler_hint as scheduler_hint_module  # noqa: E402
 from loopx.control_plane.scheduler import time as scheduler_time  # noqa: E402
+from loopx.control_plane.scheduler.execution_context import (  # noqa: E402
+    scheduler_execution_context_for_runtime_profile,
+)
 from loopx.control_plane.runtime import time as runtime_time  # noqa: E402
 from loopx.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
 
@@ -24,6 +27,9 @@ PAST_DUE_AT = "2000-01-01T00:00:00+00:00"
 FUTURE_DUE_AT = "2999-01-01T00:00:00+00:00"
 EXPIRED_AT = "2000-01-01T00:05:00+00:00"
 FROZEN_NOW = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+APP_SCHEDULER_CONTEXT = scheduler_execution_context_for_runtime_profile(
+    "codex_app_heartbeat"
+)
 FRONTIER_REPLAN_ACK_RUNS = [
     {
         "classification": "monitor_scheduler_replan_ack",
@@ -180,6 +186,7 @@ def guard_for(
             agent_id=agent_id,
             available_capabilities=available_capabilities,
             include_scheduler_detail=include_scheduler_detail,
+            scheduler_execution_context=APP_SCHEDULER_CONTEXT,
         )
     finally:
         scheduler_hint_module.now_utc = original_scheduler_now

--- a/examples/control_plane/quota-agent-scoped-user-gate-smoke.py
+++ b/examples/control_plane/quota-agent-scoped-user-gate-smoke.py
@@ -12,6 +12,9 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.control_plane.todos.decision_scope import todo_gate_relation  # noqa: E402
+from loopx.control_plane.scheduler.execution_context import (  # noqa: E402
+    scheduler_execution_context_for_runtime_profile,
+)
 from loopx.control_plane.testing.quota_fixtures import (  # noqa: E402
     quota_status_payload,
     quota_todo_item,
@@ -24,6 +27,9 @@ GOAL_ID = "agent-scoped-user-gate-fixture"
 PRIMARY_AGENT = "codex-main-control"
 PRODUCT_AGENT = "codex-product-capability"
 VALUE_AGENT = "codex-value-explorer"
+APP_SCHEDULER_CONTEXT = scheduler_execution_context_for_runtime_profile(
+    "codex_app_heartbeat"
+)
 
 
 def coordination(*agents: str, primary_agent: str = PRIMARY_AGENT) -> dict:
@@ -676,6 +682,7 @@ def assert_scoped_gate_rejects_capability_ineligible_only_fallback() -> None:
         capability_ineligible_only_fallback_status_payload(),
         goal_id=GOAL_ID,
         agent_id="codex-main-control",
+        scheduler_execution_context=APP_SCHEDULER_CONTEXT,
     )
     capability_gate = payload["capability_gate"]
     assert capability_gate["action"] == "skip", capability_gate
@@ -894,6 +901,7 @@ def assert_agent_without_advancement_candidate_and_only_monitor_work_stays_quiet
         scoped_no_candidate_status_payload(),
         goal_id=GOAL_ID,
         agent_id="codex-product-capability",
+        scheduler_execution_context=APP_SCHEDULER_CONTEXT,
     )
     assert payload["decision"] == "skip", payload
     assert payload["effective_action"] == "monitor_quiet_skip", payload

--- a/examples/control_plane/quota-cleared-blocker-successor-gate-smoke.py
+++ b/examples/control_plane/quota-cleared-blocker-successor-gate-smoke.py
@@ -12,6 +12,9 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.quota import build_quota_should_run  # noqa: E402
+from loopx.control_plane.scheduler.execution_context import (  # noqa: E402
+    scheduler_execution_context_for_runtime_profile,
+)
 from loopx.status import compact_todo_group  # noqa: E402
 from loopx.control_plane.todos.handoff_gate import (  # noqa: E402
     build_todo_handoff_gate_lanes,
@@ -23,6 +26,9 @@ from loopx.control_plane.todos.handoff_gate import (  # noqa: E402
 GOAL_ID = "cleared-blocker-successor-gate-fixture"
 BLOCKED_AGENT = "codex-value-explorer"
 PRIMARY_AGENT = "codex-main-control"
+APP_SCHEDULER_CONTEXT = scheduler_execution_context_for_runtime_profile(
+    "codex_app_heartbeat"
+)
 
 
 def todo_item(
@@ -290,6 +296,7 @@ def assert_cleared_blocker_requires_successor_replan() -> None:
         ),
         goal_id=GOAL_ID,
         agent_id=BLOCKED_AGENT,
+        scheduler_execution_context=APP_SCHEDULER_CONTEXT,
     )
     assert payload["decision"] == "successor_replan_required", payload
     assert payload["should_run"] is True, payload

--- a/examples/control_plane/quota-plan-smoke.py
+++ b/examples/control_plane/quota-plan-smoke.py
@@ -24,6 +24,9 @@ from loopx.quota import (  # noqa: E402
     render_quota_markdown,
     render_quota_should_run_markdown,
 )
+from loopx.control_plane.scheduler.execution_context import (  # noqa: E402
+    scheduler_execution_context_for_runtime_profile,
+)
 
 from quota_plan_fixtures import (  # noqa: E402
     _nested_value,
@@ -44,6 +47,11 @@ from quota_plan_fixtures import (  # noqa: E402
     run_cli_slot_void_execute,
     run_cli_throttled_should_run,
     scheduler_reset_profile_snapshot,
+)
+
+
+APP_SCHEDULER_CONTEXT = scheduler_execution_context_for_runtime_profile(
+    "codex_app_heartbeat"
 )
 
 
@@ -964,7 +972,11 @@ def assert_heartbeat_recommendation_lifecycle() -> None:
         "run_history": {"goals": [first_map_goal, mapped_goal]},
     }
 
-    first_decision = build_quota_should_run(payload, goal_id="first-map")
+    first_decision = build_quota_should_run(
+        payload,
+        goal_id="first-map",
+        scheduler_execution_context=APP_SCHEDULER_CONTEXT,
+    )
     first_rec = first_decision["heartbeat_recommendation"]
 
     assert first_decision["should_run"] is True, first_decision
@@ -973,7 +985,11 @@ def assert_heartbeat_recommendation_lifecycle() -> None:
     assert first_rec["notify"] == "NOTIFY", first_rec
     assert "append exactly one heartbeat spend" in first_rec["spend_policy"], first_rec
 
-    mapped_decision = build_quota_should_run(payload, goal_id="mapped-quiet")
+    mapped_decision = build_quota_should_run(
+        payload,
+        goal_id="mapped-quiet",
+        scheduler_execution_context=APP_SCHEDULER_CONTEXT,
+    )
     mapped_rec = mapped_decision["heartbeat_recommendation"]
     mapped_markdown = render_quota_should_run_markdown(mapped_decision)
 
@@ -1036,6 +1052,7 @@ def assert_heartbeat_recommendation_lifecycle() -> None:
         payload,
         goal_id="mapped-quiet",
         include_scheduler_detail=True,
+        scheduler_execution_context=APP_SCHEDULER_CONTEXT,
     )
     detailed_scheduler = mapped_detailed["scheduler_hint"]
     local_scheduler = detailed_scheduler["cold_path_detail"]["local_scheduler"]

--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -18,6 +18,9 @@ from loopx.quota import (  # noqa: E402
 from loopx.control_plane.goals.goal_frontier import (  # noqa: E402
     build_goal_frontier_projection_context_from_status,
 )
+from loopx.control_plane.scheduler.execution_context import (  # noqa: E402
+    scheduler_execution_context_for_runtime_profile,
+)
 from loopx.control_plane.todos.quota_summary import (  # noqa: E402
     select_quota_todo_summary,
 )
@@ -28,6 +31,9 @@ GOAL_ID = "replan-decision-plane-fixture"
 PRIMARY_AGENT = "codex-main-control"
 SIDE_AGENT = "codex-side-bypass"
 FUTURE_DUE_AT = "2999-01-01T00:00:00+00:00"
+APP_SCHEDULER_CONTEXT = scheduler_execution_context_for_runtime_profile(
+    "codex_app_heartbeat"
+)
 
 
 GLOBAL_REPLAN_OBLIGATION = {
@@ -1353,6 +1359,7 @@ def assert_monitor_schedule_gap_requires_bounded_repair() -> None:
         status_payload([monitor_item(cadence=None, next_due_at=None)], replan_obligation=None),
         goal_id=GOAL_ID,
         agent_id=SIDE_AGENT,
+        scheduler_execution_context=APP_SCHEDULER_CONTEXT,
     )
     assert guard["decision"] == "run", guard
     assert guard["effective_action"] == "normal_run", guard

--- a/examples/control_plane/quota-terminal-no-followup-smoke.py
+++ b/examples/control_plane/quota-terminal-no-followup-smoke.py
@@ -15,12 +15,18 @@ if str(REPO_ROOT) not in sys.path:
 from loopx.control_plane.goals.goal_frontier import (  # noqa: E402
     goal_frontier_is_terminal_no_followup,
 )
+from loopx.control_plane.scheduler.execution_context import (  # noqa: E402
+    scheduler_execution_context_for_runtime_profile,
+)
 from loopx.quota import build_quota_should_run  # noqa: E402
 from loopx.status import compact_todo_group  # noqa: E402
 
 
 GOAL_ID = "terminal-no-followup-fixture"
 AGENT_ID = "codex-main-control"
+APP_SCHEDULER_CONTEXT = scheduler_execution_context_for_runtime_profile(
+    "codex_app_heartbeat"
+)
 
 
 def completed_todos(*, role: str, count: int = 1) -> dict:
@@ -107,6 +113,7 @@ def assert_terminal_guard_stops_recurring_automation() -> None:
         status_payload(),
         goal_id=GOAL_ID,
         agent_id=AGENT_ID,
+        scheduler_execution_context=APP_SCHEDULER_CONTEXT,
     )
     assert guard["status"] == "active", guard
     assert guard["state"] == "terminal_no_followup", guard


### PR DESCRIPTION
## Summary
- migrate scheduler-aware smoke fixtures to the typed Codex App execution context required by #2280
- pass `--codex-app` only on CLI cases that assert App cadence
- keep context-free cases untouched so missing ownership still projects as control-plane repair

## Validation
- `uv run --extra test pytest -q`: 702 passed, 2 skipped
- nine adjacent scheduler/quota smoke surfaces: passed
- `loopx canary premerge --from-git-diff`: 10/10 selected checks passed
- public/private boundary scan: passed

## Scope
Test fixtures only. No runtime, scheduler policy, quota semantics, or fallback behavior changes.