### PR TITLE
fix(scheduler): scope failure cache during backoff

### DIFF
--- a/examples/control_plane/quota-scheduler-state-ack-smoke.py
+++ b/examples/control_plane/quota-scheduler-state-ack-smoke.py
@@ -34,6 +34,7 @@ from loopx.control_plane.scheduler.scheduler_hint import (  # noqa: E402
     build_scheduler_hint as _build_scheduler_hint,
 )
 from loopx.control_plane.scheduler.state import (  # noqa: E402
+    SCHEDULER_HOST_UPDATE_FAILURE_SCHEMA_VERSION,
     SCHEDULER_STATE_SCHEMA_VERSION,
     load_scheduler_state,
     write_scheduler_state,
@@ -1379,6 +1380,23 @@ def assert_cli_host_match_ack_after_ambiguous_update() -> None:
         assert ack["scheduler_state_mutated"] is True, ack
         assert ack["host_match_ack"] is True, ack
 
+        scheduler_state_path = Path(ack["scheduler_state_path"])
+        persisted = json.loads(scheduler_state_path.read_text(encoding="utf-8"))
+        historical_failure = {
+            "schema_version": SCHEDULER_HOST_UPDATE_FAILURE_SCHEMA_VERSION,
+            "target_rrule": "FREQ=MINUTELY;INTERVAL=3",
+            "observed_host_rrule": first_rrule,
+            "failure_kind": "timeout",
+            "failure_count": 1,
+            "failed_at": datetime.now(timezone.utc).isoformat(),
+        }
+        persisted["host_update_failures"] = [historical_failure]
+        persisted["host_update_failure"] = historical_failure
+        scheduler_state_path.write_text(
+            json.dumps(persisted, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
         settled = run_cli(
             root,
             "quota",
@@ -1397,8 +1415,10 @@ def assert_cli_host_match_ack_after_ambiguous_update() -> None:
         assert settled_app["stateful_backoff"]["apply_needed"] is False, settled
         assert "recommended_rrule" not in settled_app, settled
         assert settled_app["stateful_backoff"]["host_observation"]["status"] == "matches_recommended", settled
+        assert settled_app["stateful_backoff"]["host_update_failures"] == [
+            historical_failure
+        ], settled
 
-        scheduler_state_path = Path(ack["scheduler_state_path"])
         persisted = json.loads(scheduler_state_path.read_text(encoding="utf-8"))
         persisted["updated_at"] = "2000-01-01T00:00:00+00:00"
         scheduler_state_path.write_text(
@@ -1424,6 +1444,9 @@ def assert_cli_host_match_ack_after_ambiguous_update() -> None:
         assert advanced_app["stateful_backoff"]["apply_needed"] is True, advanced
         assert advanced_app["recommended_rrule"] != first_rrule, advanced
         assert advanced_app["host_action"] == "update_current_heartbeat_rrule", advanced
+        assert advanced_app["stateful_backoff"]["host_update_failures"] == [
+            historical_failure
+        ], advanced
 
 
 def assert_cli_ignores_corrupt_scheduler_state() -> None:

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -790,7 +790,21 @@ def build_scheduler_hint(
                     applied_index = int(scheduler_state.get("progression_index"))
                 except (TypeError, ValueError):
                     applied_index = -1
-                if all_host_update_failures:
+                applied_target_rrule = (
+                    rrule_for_minutes(codex_cadence_progression[applied_index])
+                    if 0 <= applied_index < len(codex_cadence_progression)
+                    else ""
+                )
+                current_cadence_acknowledged = (
+                    normalize_scheduler_rrule(
+                        scheduler_state.get("last_applied_rrule")
+                    )
+                    == applied_target_rrule
+                )
+                if all_host_update_failures and not current_cadence_acknowledged:
+                    # A failed current target has not settled, so advancing would
+                    # skip the cadence that the host never applied. Failures for
+                    # other targets do not invalidate a successful current ACK.
                     next_index = applied_index
                 elif not advance_same_identity:
                     next_index = 0

--- a/tests/control_plane/test_user_gate_lane_progress.py
+++ b/tests/control_plane/test_user_gate_lane_progress.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
+from loopx.control_plane.scheduler import scheduler_hint as scheduler_hint_module
+from loopx.control_plane.scheduler.ack import build_codex_app_scheduler_ack_event
 from loopx.control_plane.quota.turn_envelope import build_turn_envelope
 from loopx.control_plane.scheduler.scheduler_hint import build_scheduler_hint
 from loopx.control_plane.scheduler.execution_context import (
     scheduler_execution_context_for_runtime_profile,
+)
+from loopx.control_plane.scheduler.state import (
+    SCHEDULER_HOST_UPDATE_FAILURE_SCHEMA_VERSION,
 )
 from loopx.control_plane.testing.quota_fixtures import (
     quota_status_payload,
@@ -134,3 +141,72 @@ def test_blocking_user_gate_backs_off_instead_of_polling_as_active_work() -> Non
     assert next_hint["codex_app"]["stateful_backoff"]["progression_index"] == 1
     assert next_hint["codex_app"]["stateful_backoff"]["apply_needed"] is True
     assert next_hint["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=60"
+
+
+def test_acked_human_gate_advances_despite_unrelated_historical_host_failure(
+    monkeypatch,
+) -> None:
+    now = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(scheduler_hint_module, "now_utc", lambda: now)
+    payload = build_quota_should_run(
+        _status_payload(gate_action_kind="refine_benchmark_treatment"),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        scheduler_execution_context=APP_CONTEXT,
+    )
+    first_rrule = payload["scheduler_hint"]["codex_app"]["stateful_backoff"][
+        "current_rrule"
+    ]
+    historical_failure = {
+        "schema_version": SCHEDULER_HOST_UPDATE_FAILURE_SCHEMA_VERSION,
+        "target_rrule": "FREQ=MINUTELY;INTERVAL=3",
+        "observed_host_rrule": first_rrule,
+        "failure_kind": "timeout",
+        "failure_count": 1,
+        "failed_at": now.isoformat(),
+    }
+
+    host_matched = build_scheduler_hint(
+        payload,
+        user_action_required=True,
+        codex_app_scheduler_state={
+            "reset_token": "previous-active-work",
+            "identity_signature": "previous-active-work",
+            "progression_index": 0,
+            "progression_minutes": [3, 6, 10],
+            "last_applied_rrule": first_rrule,
+            "updated_at": now.isoformat(),
+            "host_update_failures": [historical_failure],
+        },
+        codex_app_current_rrule=first_rrule,
+        scheduler_execution_context=APP_CONTEXT,
+    )
+    matched_app = host_matched["codex_app"]
+    assert matched_app["stateful_backoff"]["apply_needed"] is False
+    assert matched_app["stateful_backoff"]["ack_needed"] is True
+    assert matched_app["ack_hint"]["after"] == "matching_host_rrule_observed"
+
+    fallback_ack = build_codex_app_scheduler_ack_event(
+        {"goal_id": GOAL_ID, "scheduler_hint": host_matched},
+        agent_id=AGENT_ID,
+        applied_rrule=first_rrule,
+        generated_at=now.isoformat(),
+    )
+    settled_state = fallback_ack["scheduler_ack_event"]["scheduler_state"]
+    assert settled_state["last_applied_rrule"] == first_rrule
+    assert settled_state["host_update_failures"] == [historical_failure]
+
+    elapsed = now + timedelta(minutes=30)
+    monkeypatch.setattr(scheduler_hint_module, "now_utc", lambda: elapsed)
+    next_hint = build_scheduler_hint(
+        payload,
+        user_action_required=True,
+        codex_app_scheduler_state=settled_state,
+        codex_app_current_rrule=first_rrule,
+        scheduler_execution_context=APP_CONTEXT,
+    )
+
+    next_app = next_hint["codex_app"]
+    assert next_app["stateful_backoff"]["progression_index"] == 1
+    assert next_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=60"
+    assert next_app["stateful_backoff"]["apply_needed"] is True


### PR DESCRIPTION
## Summary

- let an acknowledged human-gate cadence advance after its real interval even when the cache retains failures for other targets
- keep an unacknowledged current target pinned, and preserve exact target/observed-host retry suppression
- cover host-match fallback ACK retention and the persisted CLI 30-to-60 progression

## State-model rationale

A historical failure is evidence about one target/observed-host pair. It must block progression only while the cadence at the persisted progression index is still unsettled. A successful ACK of that cadence is stronger, newer evidence; unrelated cached failures remain available for their own exact-pair circuit breaker but no longer pin the index.

## Validation

- `713 passed, 2 skipped` (`.venv/bin/pytest -q`)
- `9 passed` across user-gate progression, host-failure cache, and scheduler convergence tests
- `quota-scheduler-state-ack-smoke ok`
- Ruff and `loopx check` clean on all three changed paths
- `loopx canary premerge --from-git-diff`: direct checks, compile, public boundary, and 14 selected smokes passed; three selected smokes failed on both this branch and clean current `origin/main`:
  - `interaction-contract-state-machine-smoke.py`: fixture lacks the typed scheduler execution context required since #2280
  - `heartbeat-quota-flow-smoke.py`: same missing execution-context baseline
  - `premerge-validation-gate-smoke.py`: current main imports `tomllib` through the installed-wrapper Python 3.9 probe after #2212

Because the risk gate is not green, this runtime PR is intentionally not self-merged.