### PR TITLE
fix(onboarding): name the Codex IDE plugin explicitly

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -123,11 +123,14 @@ integrations that need the lower-level handoff packet can use
 manager or PR review commands, use `loopx slash-commands` to print the current
 canonical command list and fallback CLI shapes.
 
-Use `codex-app`, `codex-ide`, or `codex-cli-tui` for the corresponding Codex
-host. If the exact host is not known, omit `--host-surface` once: LoopX returns
-a read-only selection gate with exact rerun commands and does not write project
-state. This prevents an upgrade from silently routing an IDE or terminal start
-to a desktop-app heartbeat.
+Use `codex-app`, `codex-ide-plugin`, or `codex-cli-tui` for the corresponding
+Codex host. Select `codex-ide-plugin` only when LoopX is running through the
+installed IDE plugin; using Codex beside an editor does not make the host an IDE
+plugin. If the exact host is not known, omit `--host-surface` once: LoopX
+returns a read-only selection gate with exact rerun commands and does not write
+project state. The legacy `codex-ide` value remains an accepted compatibility
+alias but is no longer advertised. This prevents an upgrade from silently
+routing an IDE plugin or terminal start to a desktop-app heartbeat.
 
 ## Local State Backup
 

--- a/docs/guides/newcomer-command-path.md
+++ b/docs/guides/newcomer-command-path.md
@@ -59,10 +59,12 @@ loopx start-goal --guided --project . --goal-text "<your first long-running task
 The command pack checks the host-facing recovery packet. The guided start
 packet is the first task path: paste the generated transaction into Codex,
 Claude Code, or another compatible agent that can run shell commands from the
-project root. Replace `codex-cli-tui` with `codex-app`, `codex-ide`,
-`claude-code`, or `shell` when that is the actual host. When the host is
-unclear, omit the flag once and follow the returned read-only selection gate;
-that preview does not write project state.
+project root. Replace `codex-cli-tui` with `codex-app`, `codex-ide-plugin`,
+`claude-code`, or `shell` when that is the actual host. Use
+`codex-ide-plugin` only for the installed IDE plugin, not for another Codex
+surface that happens to be used near an editor. When the host is unclear, omit
+the flag once and follow the returned read-only selection gate; that preview
+does not write project state.
 
 ## Multi-Project Manager Commands
 

--- a/docs/reference/protocols/codex-app-host-command-registry-v0.md
+++ b/docs/reference/protocols/codex-app-host-command-registry-v0.md
@@ -165,12 +165,15 @@ fields can rerun the advertised command or pass
 `--include-command-pack-detail`. Both modes must produce the same host-action
 projection before a compact default is promoted.
 
-`start-goal` does not guess among Codex App, Codex IDE, and Codex CLI TUI.
-Callers should pass `--host-surface codex-app`, `codex-ide`, or
-`codex-cli-tui` for the exact current host. If the option is omitted, the
-command returns a read-only `host_surface_selection` gate with exact rerun
-commands; it must not connect a project, write todos, activate a host, or spend
-quota.
+`start-goal` does not guess among Codex App, the Codex IDE plugin, and Codex CLI
+TUI. Callers should pass `--host-surface codex-app`,
+`codex-ide-plugin`, or `codex-cli-tui` for the exact current host.
+`codex-ide-plugin` means the installed IDE plugin host, not any Codex session
+used alongside an editor. The legacy `codex-ide` value remains accepted as a
+compatibility alias but is not offered by the selection gate. If the option is
+omitted, the command returns a read-only `host_surface_selection` gate with
+exact rerun commands; it must not connect a project, write todos, activate a
+host, or spend quota.
 
 ## Permission Boundary
 
@@ -207,7 +210,7 @@ loopx agent-onboard --list-agent-types
 loopx agent-onboard --agent-type codex-cli --project .
 loopx bootstrap-command-pack --project .
 loopx start-goal --guided --project . --goal-text "<goal text>" --host-surface codex-cli-tui
-loopx --format json start-goal --guided --project . --goal-text "<goal text>" --host-surface codex-ide --include-command-pack-detail
+loopx --format json start-goal --guided --project . --goal-text "<goal text>" --host-surface codex-ide-plugin --include-command-pack-detail
 loopx bootstrap-command-pack --project . --goal-text "<goal text>"
 loopx pr-review
 loopx global-summary

--- a/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
+++ b/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
@@ -43,21 +43,22 @@ def main() -> int:
     agent_types = {item["agent_type"] for item in catalog["canonical_agent_types"]}
     assert {
         "codex-app",
-        "codex-ide",
+        "codex-ide-plugin",
         "codex-cli",
         "claude-code",
         "manual",
         "other-agent",
     } <= agent_types
     ambiguous = {item["input"]: item["use_one_of"] for item in catalog["ambiguous_inputs"]}
-    assert ambiguous["codex"] == ["codex-app", "codex-ide", "codex-cli"], ambiguous
+    assert ambiguous["codex"] == ["codex-app", "codex-ide-plugin", "codex-cli"], ambiguous
 
     assert agent_type_for_host_surface("chat-box") == "codex-app"
-    assert agent_type_for_host_surface("codex-ide") == "codex-ide"
+    assert agent_type_for_host_surface("codex-ide-plugin") == "codex-ide-plugin"
+    assert agent_type_for_host_surface("codex-ide") == "codex-ide-plugin"
     assert agent_type_for_host_surface("codex-cli-tui") == "codex-cli"
 
     codex_app = build_host_loop_activation_packet(agent_type="codex-app", goal_id="demo")
-    codex_ide = build_host_loop_activation_packet(agent_type="codex-ide", goal_id="demo")
+    codex_ide = build_host_loop_activation_packet(agent_type="codex-ide-plugin", goal_id="demo")
     codex_cli = build_host_loop_activation_packet(agent_type="codex-cli", goal_id="demo")
     claude_code = build_host_loop_activation_packet(agent_type="claude-code", goal_id="demo")
     assert codex_app["activation_method"] == "create_or_update_codex_app_automation", codex_app
@@ -112,7 +113,7 @@ def main() -> int:
     assert ambiguous_payload["ok"] is False, ambiguous_payload
     assert ambiguous_payload["suggestions"] == [
         "codex-app",
-        "codex-ide",
+        "codex-ide-plugin",
         "codex-cli",
     ], ambiguous_payload
 
@@ -257,6 +258,18 @@ def main() -> int:
                 key,
                 selected_pack["commands"],
             )
+
+        ide_onboarding = build_agent_onboarding_packet(
+            project=project,
+            agent_type="codex-ide-plugin",
+            goal_id="multi-agent-goal",
+            agent_id="codex-product-capability",
+            cli_bin=cli_bin,
+        )
+        ide_bootstrap = ide_onboarding["commands"]["bootstrap_command_pack"]
+        assert "--host-surface codex-ide-plugin" in ide_bootstrap, ide_onboarding
+        assert "worker-bridge" not in ide_bootstrap, ide_onboarding
+        assert "visible IDE plugin" in ide_onboarding["recommended_start"], ide_onboarding
 
     return 0
 

--- a/loopx/agent_onboarding.py
+++ b/loopx/agent_onboarding.py
@@ -6,8 +6,6 @@ from typing import Any
 from .agent_registry import registered_agent_ids_from_registry
 from .bootstrap_command_pack import inspect_bootstrap_connection
 from .host_loop_activation import (
-    AgentTypeError,
-    build_agent_type_catalog,
     build_host_loop_activation_packet,
     normalize_agent_type,
     render_agent_type_catalog_markdown,
@@ -25,7 +23,7 @@ SCHEMA_VERSION = "loopx_agent_onboarding_v0"
 
 
 def _surface_install_command(agent_type: str, cli_bin: str) -> str | None:
-    if agent_type in {"codex-app", "codex-cli"}:
+    if agent_type in {"codex-app", "codex-ide-plugin", "codex-cli"}:
         return f"{shell_arg(cli_bin)} slash-commands --install --surface codex"
     if agent_type == "claude-code":
         return f"{shell_arg(cli_bin)} slash-commands --install --surface claude-code"
@@ -44,6 +42,7 @@ def _bootstrap_pack_command(
 ) -> str:
     surface_by_type = {
         "codex-app": "codex-app",
+        "codex-ide-plugin": "codex-ide-plugin",
         "codex-cli": "codex-cli-tui",
         "claude-code": "claude-code",
         "manual": "shell",
@@ -71,6 +70,8 @@ def _bootstrap_pack_command(
 def _start_instruction(agent_type: str) -> str:
     if agent_type == "codex-app":
         return "Use `$loopx <task>` or select the LoopX skill from `/skills`; Codex App should then create/update the heartbeat automation."
+    if agent_type == "codex-ide-plugin":
+        return "Use `$loopx <task>` or select the LoopX skill from `/skills`; after todos are written, set `/goal <task_body>` in the visible IDE plugin."
     if agent_type == "codex-cli":
         return "Use `$loopx <task>` or select the LoopX skill from `/skills`; after todos are written, set `/goal <task_body>` in the visible TUI."
     if agent_type == "claude-code":

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -36,7 +36,7 @@ GUIDED_COMMAND_PACK_PROJECTION_SCHEMA_VERSION = (
 HOST_SURFACE_SELECTION_SCHEMA_VERSION = "loopx_host_surface_selection_gate_v0"
 START_GOAL_HOST_SURFACES = (
     "codex-app",
-    "codex-ide",
+    "codex-ide-plugin",
     "codex-cli-tui",
     "claude-code",
     "shell",
@@ -244,7 +244,7 @@ def build_start_goal_host_surface_selection_packet(
     normalized_goal_text = " ".join(goal_text.split())
     host_descriptions = {
         "codex-app": "Codex desktop app with heartbeat automation support",
-        "codex-ide": "Codex IDE extension; activate its visible goal mode",
+        "codex-ide-plugin": "Codex IDE plugin; activate its visible goal mode",
         "codex-cli-tui": "terminal Codex TUI with visible /goal support",
         "claude-code": "Claude Code with native /loop",
         "shell": "manual shell or an explicitly configured external scheduler",
@@ -269,7 +269,7 @@ def build_start_goal_host_surface_selection_packet(
             }
         )
     reason = (
-        "host surface is required because Codex App, Codex IDE, and Codex CLI "
+        "host surface is required because Codex App, the Codex IDE plugin, and Codex CLI "
         "have different continuation contracts"
     )
     gate = {

--- a/loopx/cli_commands/slash_commands.py
+++ b/loopx/cli_commands/slash_commands.py
@@ -50,7 +50,7 @@ def register_slash_commands_command(
     parser.add_argument(
         "--surface",
         action="append",
-        choices=["all", "codex", "codex-cli", "codex-app", "codex-ide", "claude-code"],
+        choices=["all", "codex", "codex-cli", "codex-app", "codex-ide-plugin", "codex-ide", "claude-code"],
         help=(
             "Host surface to install. Repeatable. Defaults to all "
             "(Codex explicit skills plus Claude Code skills)."

--- a/loopx/cli_commands/starter_bootstrap.py
+++ b/loopx/cli_commands/starter_bootstrap.py
@@ -5,11 +5,8 @@ from collections.abc import Callable
 from pathlib import Path
 
 from ..agent_onboarding import (
-    AgentTypeError,
     build_agent_onboarding_packet,
-    build_agent_type_catalog,
     render_agent_onboarding_markdown,
-    render_agent_type_catalog_markdown,
 )
 from ..bootstrap_command_pack import (
     build_start_goal_host_surface_selection_packet,
@@ -17,6 +14,11 @@ from ..bootstrap_command_pack import (
     build_loopx_bootstrap_command_pack,
     render_start_goal_guided_markdown,
     render_loopx_bootstrap_command_pack_markdown,
+)
+from ..host_loop_activation import (
+    AgentTypeError,
+    build_agent_type_catalog,
+    render_agent_type_catalog_markdown,
 )
 from ..project_prompt import (
     build_codex_cli_bootstrap_message,
@@ -70,7 +72,7 @@ def handle_agent_onboard_command(
             reason="--agent-type is required unless --list-agent-types is used",
             suggestions=[
                 "codex-app",
-                "codex-ide",
+                "codex-ide-plugin",
                 "codex-cli",
                 "claude-code",
                 "manual",

--- a/loopx/cli_commands/starter_bootstrap_registration.py
+++ b/loopx/cli_commands/starter_bootstrap_registration.py
@@ -19,7 +19,7 @@ def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) 
     )
     agent_onboard_parser.add_argument(
         "--agent-type",
-        help="Agent runtime type: codex-app, codex-ide, codex-cli, claude-code, manual, or other-agent.",
+        help="Agent runtime type: codex-app, codex-ide-plugin, codex-cli, claude-code, manual, or other-agent.",
     )
     agent_onboard_parser.add_argument(
         "--list-agent-types",
@@ -66,7 +66,7 @@ def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) 
     bootstrap_command_pack_parser.add_argument(
         "--host-surface",
         default="chat-box",
-        choices=["chat-box", "codex-app", "codex-ide", "codex-cli-tui", "claude-code", "shell", "http", "worker-bridge"],
+        choices=["chat-box", "codex-app", "codex-ide-plugin", "codex-ide", "codex-cli-tui", "claude-code", "shell", "http", "worker-bridge"],
         help="Host surface where the slash command pack will be exposed.",
     )
     bootstrap_command_pack_parser.add_argument(
@@ -112,7 +112,7 @@ def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) 
     )
     start_goal_parser.add_argument(
         "--host-surface",
-        choices=["chat-box", "codex-app", "codex-ide", "codex-cli-tui", "claude-code", "shell", "http", "worker-bridge"],
+        choices=["chat-box", "codex-app", "codex-ide-plugin", "codex-ide", "codex-cli-tui", "claude-code", "shell", "http", "worker-bridge"],
         help=(
             "Exact host surface that will own loop activation after todo writeback. "
             "When omitted, start-goal returns a read-only host selection gate."

--- a/loopx/control_plane/testing/onboarding_model_behavior_qualification.py
+++ b/loopx/control_plane/testing/onboarding_model_behavior_qualification.py
@@ -241,7 +241,7 @@ def onboarding_entry_contract_violations(
             violations.append("connect_route_requires_host_loop_activation")
         if contract.get("host_loop_activation_after_todo_write") is not True:
             violations.append("host_loop_must_activate_after_todo_write")
-        if contract.get("requested_host_surface") == "codex-ide":
+        if contract.get("requested_host_surface") in {"codex-ide-plugin", "codex-ide"}:
             if contract.get("host_surface") != "codex_ide_visible_goal_mode":
                 violations.append("codex_ide_requires_ide_goal_surface")
             if contract.get("activation_method") != "set_visible_goal":

--- a/loopx/host_loop_activation.py
+++ b/loopx/host_loop_activation.py
@@ -26,7 +26,7 @@ def scheduler_command_binding_for_agent_type(
     runtime_profile = {
         "codex-app": SchedulerRuntimeProfile.CODEX_APP_HEARTBEAT,
         "codex-cli": SchedulerRuntimeProfile.CODEX_CLI_VISIBLE,
-        "codex-ide": SchedulerRuntimeProfile.CODEX_CLI_VISIBLE,
+        "codex-ide-plugin": SchedulerRuntimeProfile.CODEX_CLI_VISIBLE,
         "claude-code": SchedulerRuntimeProfile.CLAUDE_CODE_VISIBLE,
     }.get(canonical)
     if runtime_profile is not None:
@@ -36,7 +36,7 @@ def scheduler_command_binding_for_agent_type(
 
 SUPPORTED_AGENT_TYPES = [
     "codex-app",
-    "codex-ide",
+    "codex-ide-plugin",
     "codex-cli",
     "claude-code",
     "manual",
@@ -63,14 +63,19 @@ AGENT_TYPE_CATALOG: dict[str, dict[str, Any]] = {
             "codex tui",
         ],
     },
-    "codex-ide": {
-        "display_name": "Codex IDE extension",
-        "host_loop": "visible Codex IDE /goal",
+    "codex-ide-plugin": {
+        "display_name": "Codex IDE plugin",
+        "host_loop": "visible Codex IDE plugin /goal",
         "entry": "$loopx <task> or the explicit LoopX skill from /skills",
         "accepted_inputs": [
+            "codex-ide-plugin",
+            "codex_ide_plugin",
+            "codex ide plugin",
             "codex-ide",
             "codex_ide",
             "codex ide",
+            "codex-ide-extension",
+            "codex ide extension",
             "codex-vscode",
             "codex vscode",
             "vscode-codex",
@@ -98,9 +103,9 @@ AGENT_TYPE_CATALOG: dict[str, dict[str, Any]] = {
 }
 
 AMBIGUOUS_AGENT_TYPE_INPUTS: dict[str, list[str]] = {
-    "codex": ["codex-app", "codex-ide", "codex-cli"],
-    "openai-codex": ["codex-app", "codex-ide", "codex-cli"],
-    "openai codex": ["codex-app", "codex-ide", "codex-cli"],
+    "codex": ["codex-app", "codex-ide-plugin", "codex-cli"],
+    "openai-codex": ["codex-app", "codex-ide-plugin", "codex-cli"],
+    "openai codex": ["codex-app", "codex-ide-plugin", "codex-cli"],
     "cli": ["codex-cli", "manual", "other-agent"],
 }
 
@@ -138,7 +143,8 @@ class AgentTypeError(ValueError):
 HOST_SURFACE_TO_AGENT_TYPE = {
     "codex-app": "codex-app",
     "chat-box": "codex-app",
-    "codex-ide": "codex-ide",
+    "codex-ide-plugin": "codex-ide-plugin",
+    "codex-ide": "codex-ide-plugin",
     "codex-cli-tui": "codex-cli",
     "claude-code": "claude-code",
     "shell": "manual",
@@ -167,7 +173,8 @@ def build_agent_type_catalog() -> dict[str, Any]:
         ],
         "selection_rule": (
             "Agents should pass a canonical agent_type. Ambiguous values such as "
-            "`codex` are rejected because Codex App, Codex IDE, and Codex CLI have different "
+            "`codex` are rejected because Codex App, the Codex IDE plugin, and Codex CLI "
+            "have different "
             "host-loop activation paths."
         ),
     }
@@ -259,7 +266,7 @@ def _heartbeat_commands(
 ) -> dict[str, str]:
     scope_by_type = {
         "codex-app": "Codex App heartbeat automation",
-        "codex-ide": "Codex IDE /goal visible task loop",
+        "codex-ide-plugin": "Codex IDE plugin /goal visible task loop",
         "codex-cli": "Codex CLI /goal visible TUI loop",
         "claude-code": "Claude Code native /loop gated by LoopX",
         "manual": "External scheduler or manual shell LoopX poll",
@@ -423,7 +430,7 @@ def _codex_cli_activation(commands: dict[str, str]) -> dict[str, Any]:
 def _codex_ide_activation(commands: dict[str, str]) -> dict[str, Any]:
     return _codex_goal_activation(
         commands,
-        host_label="Codex IDE composer",
+        host_label="Codex IDE plugin composer",
         host_surface="codex_ide_visible_goal_mode",
     )
 
@@ -514,7 +521,7 @@ def build_host_loop_activation_packet(
     )
     if canonical == "codex-app":
         surface = _codex_app_activation(commands)
-    elif canonical == "codex-ide":
+    elif canonical == "codex-ide-plugin":
         surface = _codex_ide_activation(commands)
     elif canonical == "codex-cli":
         surface = _codex_cli_activation(commands)

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -85,14 +85,14 @@ def _command_prompt_specs(*, cli_bin: str, include_legacy_aliases: bool) -> list
             "argument_hint": "[task text]",
             "instructions": [
                 "Visible command arguments: `$ARGUMENTS`.",
-                "Before start-goal, identify the exact current host: use `codex-app` for the desktop app, `codex-ide` for the IDE extension, or `codex-cli-tui` for the terminal TUI.",
+                "Before start-goal, identify the exact current host: use `codex-app` for the desktop app, `codex-ide-plugin` only for the IDE plugin, or `codex-cli-tui` for the terminal TUI.",
                 f"If arguments are present, preserve them as the task text and run `{cli_bin} start-goal --guided --project . --goal-text \"$ARGUMENTS\" --host-surface <exact-current-host>` before planning work. If the host is unclear, omit the flag once and follow the returned host-surface selection gate.",
                 f"If that packet exposes a goal-selection gate, rerun one exact choice before any mutation. When the user asks to create or become a new peer/meta/supervisor agent, do not reuse an existing registered identity: choose a new public-safe agent id, preview then apply `{cli_bin} register-agent --goal-id <selected-goal-id> --agent-id <new-agent-id> --execute`, and rerun start-goal with explicit `--goal-id` and `--agent-id` before todo writeback.",
                 f"If arguments are empty, inspect `{cli_bin} bootstrap-command-pack --project .`, `{cli_bin} status`, and `{cli_bin} slash-commands` before changing files.",
-                f"Use `{cli_bin} agent-onboard --list-agent-types` when the host runtime is unclear; pass an exact type such as `codex-app`, `codex-ide`, `codex-cli`, or `claude-code`, never ambiguous `codex`.",
+                f"Use `{cli_bin} agent-onboard --list-agent-types` when the host runtime is unclear; pass an exact type such as `codex-app`, `codex-ide-plugin`, `codex-cli`, or `claude-code`, never ambiguous `codex`.",
                 f"Do not configure optional features during first-run. Only when the task needs bounded child agents or Explore, inspect `{cli_bin} configure-goal --goal-id <resolved-goal-id>` and its `configuration_catalog`; preview before explicit apply and never auto-enable a feature merely because it exists.",
                 "When project work is started, plan ordered P0/P1/P2 todos, write them through LoopX todo state, refresh state, activate the host loop if missing/stale, run quota, and complete one bounded delivery segment through validation plus LoopX writeback or an exact blocker; do not return merely after setup, planning, or claim.",
-                "Host loop activation means Codex App heartbeat automation, Codex IDE or CLI visible `/goal <task_body>`, Claude Code native `/loop`, or a custom host-loop gate from `loopx agent-onboard`.",
+                "Host loop activation means Codex App heartbeat automation, Codex IDE plugin or CLI visible `/goal <task_body>`, Claude Code native `/loop`, or a custom host-loop gate from `loopx agent-onboard`.",
                 "If this session cannot mutate the host loop surface, surface the exact pasteable gate instead of saying LoopX is autonomously connected.",
             ],
         },
@@ -236,7 +236,7 @@ def _normalize_surfaces(surfaces: list[str] | None) -> list[str]:
             candidates = ["codex", "claude-code"]
         elif surface == "codex":
             candidates = ["codex"]
-        elif surface in {"codex-app", "codex-ide", "codex-cli"}:
+        elif surface in {"codex-app", "codex-ide-plugin", "codex-ide", "codex-cli"}:
             candidates = ["codex"]
         else:
             candidates = [surface]
@@ -271,7 +271,7 @@ def install_slash_commands(
                 installed.append(
                     {
                         "surface": "codex",
-                        "host_surfaces": ["codex-cli", "codex-ide", "codex-app"],
+                        "host_surfaces": ["codex-cli", "codex-ide-plugin", "codex-app"],
                         "mechanism": "retired_codex_custom_prompt",
                         "command": spec["command"],
                         "path": str(prompt_path),
@@ -285,7 +285,7 @@ def install_slash_commands(
                 installed.append(
                     {
                         "surface": "codex",
-                        "host_surfaces": ["codex-cli", "codex-ide", "codex-app"],
+                        "host_surfaces": ["codex-cli", "codex-ide-plugin", "codex-app"],
                         "mechanism": "retired_codex_custom_prompt",
                         "command": spec["command"],
                         "path": str(prompt_path),
@@ -303,7 +303,7 @@ def install_slash_commands(
                 installed.append(
                     {
                         "surface": "codex",
-                        "host_surfaces": ["codex-cli", "codex-ide", "codex-app"],
+                        "host_surfaces": ["codex-cli", "codex-ide-plugin", "codex-app"],
                         "mechanism": "codex_explicit_skills",
                         "command": spec["command"],
                         "path": str(skill_path),
@@ -315,7 +315,7 @@ def install_slash_commands(
                 installed.append(
                     {
                         "surface": "codex",
-                        "host_surfaces": ["codex-cli", "codex-ide", "codex-app"],
+                        "host_surfaces": ["codex-cli", "codex-ide-plugin", "codex-app"],
                         "mechanism": "codex_skill_openai_metadata",
                         "command": spec["command"],
                         "path": str(metadata_path),
@@ -337,7 +337,7 @@ def install_slash_commands(
             installed.append(
                 {
                     "surface": "codex",
-                    "host_surfaces": ["codex-cli", "codex-ide", "codex-app"],
+                    "host_surfaces": ["codex-cli", "codex-ide-plugin", "codex-app"],
                     "mechanism": "codex_explicit_skills",
                     "command": spec["command"],
                     "path": str(skill_path),
@@ -358,7 +358,7 @@ def install_slash_commands(
                 installed.append(
                     {
                         "surface": "codex",
-                        "host_surfaces": ["codex-cli", "codex-ide", "codex-app"],
+                        "host_surfaces": ["codex-cli", "codex-ide-plugin", "codex-app"],
                         "mechanism": "codex_skill_openai_metadata",
                         "command": spec["command"],
                         "path": str(metadata_path),
@@ -372,7 +372,7 @@ def install_slash_commands(
                     installed.append(
                         {
                             "surface": "codex",
-                            "host_surfaces": ["codex-cli", "codex-ide", "codex-app"],
+                            "host_surfaces": ["codex-cli", "codex-ide-plugin", "codex-app"],
                             "mechanism": "retired_codex_command_metadata",
                             "command": spec["command"],
                             "path": str(metadata_path),

--- a/tests/control_plane/test_onboarding_model_behavior_qualification.py
+++ b/tests/control_plane/test_onboarding_model_behavior_qualification.py
@@ -57,7 +57,7 @@ def _actual_entry_packet() -> dict[str, Any]:
         "command_pack_detail_included": False,
         "goal_id": "fixture-goal",
         "agent_id": "codex-fixture",
-        "host_surface": "codex-ide",
+        "host_surface": "codex-ide-plugin",
         "guided_transaction": TRANSACTION,
         "safety_contract": {
             "writes_registry": False,

--- a/tests/control_plane/test_start_goal_compact_projection.py
+++ b/tests/control_plane/test_start_goal_compact_projection.py
@@ -303,16 +303,16 @@ def test_cli_without_host_returns_read_only_host_selection_gate(
     choices = payload["host_surface_selection_gate"]["choices"]
     assert [choice["host_surface"] for choice in choices] == [
         "codex-app",
-        "codex-ide",
+        "codex-ide-plugin",
         "codex-cli-tui",
         "claude-code",
         "shell",
     ]
-    ide = next(choice for choice in choices if choice["host_surface"] == "codex-ide")
-    assert "--host-surface codex-ide" in ide["rerun_command"]
+    ide = next(choice for choice in choices if choice["host_surface"] == "codex-ide-plugin")
+    assert "--host-surface codex-ide-plugin" in ide["rerun_command"]
 
 
-def test_codex_ide_uses_visible_goal_and_preserves_compact_parity(
+def test_codex_ide_plugin_uses_visible_goal_and_preserves_compact_parity(
     tmp_path: Path,
 ) -> None:
     project = _write_connected_project(tmp_path)
@@ -321,7 +321,7 @@ def test_codex_ide_uses_visible_goal_and_preserves_compact_parity(
         "goal_id": GOAL_ID,
         "agent_id": AGENT_ID,
         "cli_bin": "loopx",
-        "host_surface": "codex-ide",
+        "host_surface": "codex-ide-plugin",
         "goal_text": GOAL_TEXT,
         "available_capabilities": ["network"],
     }
@@ -335,7 +335,17 @@ def test_codex_ide_uses_visible_goal_and_preserves_compact_parity(
     )
 
     activation = compact["command_pack"]["host_loop_activation"]
+    assert detailed["command_pack"]["agent_type"] == "codex-ide-plugin"
     assert activation["host_surface"] == "codex_ide_visible_goal_mode"
     assert activation["activation_method"] == "set_visible_goal"
     assert activation["host_mutation"]["host_command"] == "/goal <task_body>"
     assert _host_shadow_document(compact) == _host_shadow_document(detailed)
+
+    legacy = build_start_goal_guided_packet(
+        **{**common, "host_surface": "codex-ide"},
+        include_command_pack_detail=True,
+    )
+    assert legacy["command_pack"]["agent_type"] == "codex-ide-plugin"
+    assert legacy["command_pack"]["host_loop_activation"]["host_surface"] == (
+        "codex_ide_visible_goal_mode"
+    )

--- a/tests/test_host_loop_activation.py
+++ b/tests/test_host_loop_activation.py
@@ -12,12 +12,17 @@ from loopx.host_loop_activation import (
 )
 
 
-def test_codex_ide_is_an_exact_host_type_with_visible_goal_activation() -> None:
-    assert normalize_agent_type("VSCode Codex") == "codex-ide"
-    assert agent_type_for_host_surface("codex-ide") == "codex-ide"
+def test_codex_ide_plugin_is_an_exact_host_type_with_visible_goal_activation() -> None:
+    assert normalize_agent_type("codex-ide-plugin") == "codex-ide-plugin"
+    assert normalize_agent_type("VSCode Codex") == "codex-ide-plugin"
+    assert normalize_agent_type("codex-ide") == "codex-ide-plugin"
+    assert agent_type_for_host_surface("codex-ide-plugin") == "codex-ide-plugin"
+    assert agent_type_for_host_surface("codex-ide") == "codex-ide-plugin"
+    assert agent_type_for_host_surface("codex-app") == "codex-app"
+    assert agent_type_for_host_surface("codex-cli-tui") == "codex-cli"
 
     packet = build_host_loop_activation_packet(
-        agent_type="codex-ide",
+        agent_type="codex-ide-plugin",
         goal_id="fixture-goal",
         agent_id="codex-fixture",
         registered_agents=["codex-fixture"],
@@ -25,7 +30,7 @@ def test_codex_ide_is_an_exact_host_type_with_visible_goal_activation() -> None:
 
     assert packet["host_surface"] == "codex_ide_visible_goal_mode"
     assert packet["activation_method"] == "set_visible_goal"
-    assert packet["host_mutation"]["owner"] == "Codex IDE composer"
+    assert packet["host_mutation"]["owner"] == "Codex IDE plugin composer"
     assert packet["host_mutation"]["host_command"] == "/goal <task_body>"
     assert "automation_update" not in str(packet)
     assert (
@@ -42,7 +47,7 @@ def test_codex_ide_is_an_exact_host_type_with_visible_goal_activation() -> None:
     (
         ("codex-app", "codex_app_heartbeat"),
         ("codex-cli", "codex_cli"),
-        ("codex-ide", "codex_cli"),
+        ("codex-ide-plugin", "codex_cli"),
         ("claude-code", "claude_code"),
     ),
 )
@@ -91,4 +96,4 @@ def test_ambiguous_codex_requires_app_ide_or_cli_selection() -> None:
     with pytest.raises(AgentTypeError) as caught:
         normalize_agent_type("codex")
 
-    assert caught.value.suggestions == ["codex-app", "codex-ide", "codex-cli"]
+    assert caught.value.suggestions == ["codex-app", "codex-ide-plugin", "codex-cli"]

--- a/tests/test_slash_command_install.py
+++ b/tests/test_slash_command_install.py
@@ -39,8 +39,9 @@ def test_codex_install_upgrades_managed_loopx_facade(tmp_path: Path) -> None:
     skill_text = skill.read_text(encoding="utf-8")
     assert "Treat this as the LoopX `/loopx` explicit LoopX command skill." in skill_text
     assert "--host-surface <exact-current-host>" in skill_text
-    assert "`codex-ide` for the IDE extension" in skill_text
-    assert "Codex IDE or CLI visible `/goal <task_body>`" in skill_text
+    assert "`codex-ide-plugin` only for the IDE plugin" in skill_text
+    assert "Codex IDE plugin or CLI visible `/goal <task_body>`" in skill_text
+    assert "use `codex-ide` for the IDE" not in skill_text
     assert "do not return merely after setup, planning, or claim" in skill_text
     metadata_text = metadata.read_text(encoding="utf-8")
     assert 'display_name: "LoopX"' in metadata_text


### PR DESCRIPTION
## Summary

- make `codex-ide-plugin` the canonical advertised agent and host-surface identity
- keep `codex-ide` as an accepted compatibility alias while preventing Codex App and CLI TUI from being inferred as the IDE plugin
- route IDE plugin onboarding through its visible `/goal` contract instead of the generic `worker-bridge` fallback
- update generated `/loopx` guidance and developer docs to define the host boundary explicitly

## Compatibility

- existing `--host-surface codex-ide` calls remain accepted and normalize to `codex-ide-plugin`
- the internal `codex_ide_visible_goal_mode` activation field is unchanged
- host selection gates and new onboarding packets advertise only `codex-ide-plugin`

## Validation

- `python -m pytest -q`: 713 passed, 2 skipped
- focused host/onboarding/command tests: 28 passed
- onboarding host-loop smoke: passed
- Ruff on changed Python files: passed
- `loopx canary premerge --from-git-diff`: 18 selected checks passed, 0 failures, public-boundary scan clean

## Model behavior

- deterministic onboarding semantic-oracle tests passed with the new canonical identity and legacy alias
- live Doubao one-arm was not run because `ARK_API_KEY` was not injected into the candidate process; no fake-provider result is claimed as live evidence

## Review focus

1. Confirm `codex-ide-plugin` is the right public canonical term.
2. Confirm legacy alias acceptance plus unchanged internal activation schema is sufficient for upgrades.
3. Confirm App, IDE plugin, and CLI TUI remain mutually explicit at `/loopx <goal>` entry.