### PR TITLE
fix(install): persist supported Python runtime

### DIFF
--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -281,6 +281,14 @@ def main() -> int:
             text=True,
         )
         assert json.loads(promoted_doctor.stdout)["ok"] is True, promoted_doctor.stdout
+        subprocess.run(
+            [str(wrapper), "canary", "premerge", "--help"],
+            cwd=REPO_ROOT,
+            env=promoted_env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
 
         skill = codex_home / "skills" / "loopx-project" / "SKILL.md"
         assert not skill.parent.is_symlink(), skill.parent

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -186,6 +186,7 @@ def main() -> int:
             "LOOPX_SHELL_PROFILE": str(profile),
             "LOOPX_INSTALL_SKILL": "1",
             "LOOPX_PROMOTE_DEFAULT": "1",
+            "LOOPX_PYTHON": sys.executable,
             "PATH": os.environ.get("PATH", ""),
             "SHELL": "/bin/zsh",
         }
@@ -222,6 +223,8 @@ def main() -> int:
         assert wrapper.resolve() != REPO_ROOT / "scripts" / "loopx", wrapper.resolve()
         assert wrapper.resolve().name == "loopx", wrapper.resolve()
         release_root = wrapper.resolve().parents[1]
+        release_python = release_root / ".loopx-python"
+        assert release_python.read_text(encoding="utf-8").strip() == sys.executable
         assert (release_root / "loopx" / "cli.py").is_file(), release_root
         runtime_package = release_root / "loopx" / "control_plane" / "runtime"
         assert (runtime_package / "run_compaction.py").is_file(), release_root
@@ -257,6 +260,27 @@ def main() -> int:
         assert (bin_dir / "goal-harness-canary.legacy-disabled").is_symlink()
         assert canary_wrapper.resolve() == REPO_ROOT / "scripts" / "loopx", canary_wrapper.resolve()
         assert profile.read_text(encoding="utf-8").count("LoopX local CLI") == 1, profile.read_text()
+
+        unsupported_host_bin = root / "unsupported-host-bin"
+        unsupported_host_bin.mkdir()
+        unsupported_python = unsupported_host_bin / "python3"
+        unsupported_python.write_text("#!/usr/bin/env bash\nexit 86\n", encoding="utf-8")
+        unsupported_python.chmod(0o755)
+        promoted_env = {
+            key: value
+            for key, value in env.items()
+            if key != "LOOPX_PYTHON"
+        }
+        promoted_env["PATH"] = f"{unsupported_host_bin}:{bin_dir}:{promoted_env['PATH']}"
+        promoted_doctor = subprocess.run(
+            ["loopx", "--format", "json", "doctor"],
+            cwd=root,
+            env=promoted_env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert json.loads(promoted_doctor.stdout)["ok"] is True, promoted_doctor.stdout
 
         skill = codex_home / "skills" / "loopx-project" / "SKILL.md"
         assert not skill.parent.is_symlink(), skill.parent

--- a/examples/release/codex-cli-no-clone-release-verification-smoke.py
+++ b/examples/release/codex-cli-no-clone-release-verification-smoke.py
@@ -8,6 +8,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import tarfile
 import tempfile
 from pathlib import Path
@@ -282,6 +283,7 @@ def main() -> None:
                 "LOOPX_SHELL_PROFILE": str(home / ".profile"),
                 "LOOPX_ARCHIVE_URL": f"file://{archive}",
                 "LOOPX_INSTALL_CANARY": "0",
+                "LOOPX_PYTHON": sys.executable,
                 "CODEX_CALLED_MARKER": str(codex_called_marker),
                 "PATH": f"{fake_bin}:{env.get('PATH', '')}",
             }

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -12,6 +12,7 @@ Options:
   -h, --help  Show this help and exit.
 
 Common environment variables:
+  LOOPX_PYTHON=/path/to/python3.11  Use this supported Python for the release.
   LOOPX_PROMOTE_DEFAULT=1          Promote this checkout as the default loopx.
   LOOPX_INSTALL_CANARY=0           Skip the loopx-canary executable.
   LOOPX_INSTALL_SKILL=0            Skip packaged Codex workflow skills.
@@ -60,6 +61,33 @@ install_lock=""
 install_lock_owned=0
 legacy_line=""
 installed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+configure_python_runtime() {
+  local requested="${LOOPX_PYTHON:-python3}"
+  local resolved
+  if ! command -v "$requested" >/dev/null 2>&1; then
+    echo "loopx installer error: Python executable not found: $requested" >&2
+    echo "Set LOOPX_PYTHON to a Python 3.11+ executable." >&2
+    exit 2
+  fi
+  if ! resolved="$("$requested" - <<'PY'
+import sys
+
+if sys.version_info < (3, 11):
+    print(
+        "loopx installer error: Python 3.11+ is required; "
+        f"selected Python is {sys.version_info.major}.{sys.version_info.minor}",
+        file=sys.stderr,
+    )
+    raise SystemExit(2)
+print(sys.executable)
+PY
+)"; then
+    echo "Set LOOPX_PYTHON to a Python 3.11+ executable." >&2
+    exit 2
+  fi
+  export LOOPX_PYTHON="$resolved"
+}
 
 cleanup_install_lock() {
   if [[ -n "$release_tmp" && -d "$release_tmp" ]]; then
@@ -382,6 +410,8 @@ if [[ -z "$shell_profile" ]]; then
   esac
 fi
 
+configure_python_runtime
+
 promote_default=0
 if resolve_default_promotion; then
   promote_default=1
@@ -437,6 +467,7 @@ copy_path "$repo_root/README.md" "$release_tmp/README.md"
 copy_path "$repo_root/CONTRIBUTOR_TASKS.md" "$release_tmp/CONTRIBUTOR_TASKS.md"
 copy_path "$repo_root/LICENSE" "$release_tmp/LICENSE"
 copy_path "$repo_root/pyproject.toml" "$release_tmp/pyproject.toml"
+printf '%s\n' "$LOOPX_PYTHON" >"$release_tmp/.loopx-python"
 find "$release_tmp" -name __pycache__ -type d -prune -exec rm -rf {} +
 find "$release_tmp" -name '*.pyc' -type f -delete
 if [[ -d "$release_tmp/apps" ]]; then

--- a/scripts/loopx
+++ b/scripts/loopx
@@ -49,8 +49,16 @@ if [[ "$loopx_command" == "canary" && "$loopx_subcommand" == "premerge" ]]; then
 fi
 
 python_bin="${LOOPX_PYTHON:-}"
+if [[ -z "$python_bin" && -f "$repo_root/.loopx-python" ]]; then
+  IFS= read -r python_bin <"$repo_root/.loopx-python"
+fi
 if [[ -z "$python_bin" ]]; then
   python_bin="python3"
+fi
+if ! command -v "$python_bin" >/dev/null 2>&1; then
+  echo "loopx runtime error: configured Python executable not found: $python_bin" >&2
+  echo "Set LOOPX_PYTHON to Python 3.11+ and reinstall LoopX." >&2
+  exit 2
 fi
 
 export LOOPX_RELEASE_ROOT="$repo_root"
@@ -59,6 +67,15 @@ exec "$python_bin" -c '
 import os
 import runpy
 import sys
+
+if sys.version_info < (3, 11):
+    print(
+        "loopx runtime error: Python 3.11+ is required; "
+        f"selected Python is {sys.version_info.major}.{sys.version_info.minor}. "
+        "Set LOOPX_PYTHON to Python 3.11+ and reinstall LoopX.",
+        file=sys.stderr,
+    )
+    raise SystemExit(2)
 
 release_root = os.environ["LOOPX_RELEASE_ROOT"]
 cwd = os.getcwd()

--- a/scripts/loopx
+++ b/scripts/loopx
@@ -37,17 +37,6 @@ for arg in "$@"; do
   fi
 done
 
-if [[ "$loopx_command" == "canary" && "$loopx_subcommand" == "premerge" ]]; then
-  checkout_root=""
-  if command -v git >/dev/null 2>&1; then
-    checkout_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
-  fi
-  if [[ -n "$checkout_root" && -f "$checkout_root/loopx/cli.py" && -d "$checkout_root/examples" ]]; then
-    # Pre-merge validation must exercise the checkout under review, not a stale release snapshot.
-    repo_root="$checkout_root"
-  fi
-fi
-
 python_bin="${LOOPX_PYTHON:-}"
 if [[ -z "$python_bin" && -f "$repo_root/.loopx-python" ]]; then
   IFS= read -r python_bin <"$repo_root/.loopx-python"
@@ -59,6 +48,17 @@ if ! command -v "$python_bin" >/dev/null 2>&1; then
   echo "loopx runtime error: configured Python executable not found: $python_bin" >&2
   echo "Set LOOPX_PYTHON to Python 3.11+ and reinstall LoopX." >&2
   exit 2
+fi
+
+if [[ "$loopx_command" == "canary" && "$loopx_subcommand" == "premerge" ]]; then
+  checkout_root=""
+  if command -v git >/dev/null 2>&1; then
+    checkout_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
+  fi
+  if [[ -n "$checkout_root" && -f "$checkout_root/loopx/cli.py" && -d "$checkout_root/examples" ]]; then
+    # Pre-merge validation must exercise the checkout under review, not a stale release snapshot.
+    repo_root="$checkout_root"
+  fi
 fi
 
 export LOOPX_RELEASE_ROOT="$repo_root"


### PR DESCRIPTION
## Summary
- validate one Python 3.11+ interpreter before local installation and persist its executable path in each release snapshot
- make the installed wrapper reuse that interpreter when `LOOPX_PYTHON` is absent, with actionable errors for missing or unsupported runtimes
- cover both local promotion and no-clone release verification with the supported interpreter contract

## Root cause
The installed release was newer than the host's default `python3`, but the wrapper forgot which supported interpreter performed the install. On hosts where `python3` is still 3.9, a promoted LoopX release could therefore fail at import time even though installation had succeeded with Python 3.11+.

## Commit grouping
1. `fix(install): persist supported Python runtime`
2. `test(install): cover promoted Python binding`

## Validation
- `bash -n scripts/install-local.sh scripts/install-from-github.sh scripts/loopx`
- `uv tool run ruff check examples/install-local-smoke.py examples/release/codex-cli-no-clone-release-verification-smoke.py`
- `python examples/install-local-smoke.py`
- `python examples/loopx-update-smoke.py`
- `python examples/release/codex-cli-no-clone-release-verification-smoke.py`
- full pytest: 718 passed, 2 skipped
- `loopx canary premerge --from-git-diff`: 4 direct checks and 18 selected checks passed; public-boundary scan clean

## Failures, skips, and holds
- The first no-clone smoke run failed because that smoke did not pass its supported `sys.executable` into the shell installer; the smoke now models the documented Python 3.11+ contract explicitly and passes.
- The promotion-readiness aggregate reported its existing dashboard dependency skip; no dashboard surface changed.
- No manual holds. No credentials, private state, local paths, raw logs, or generated evidence are included.

## Coverage judgment
The changed surface is the install/release wrapper boundary. The focused installer smoke creates a real promoted snapshot, removes `LOOPX_PYTHON`, places a failing host `python3` first on `PATH`, and verifies the promoted command still runs. The no-clone, packaged install, overwrite, update, uninstall, release qualification, public-entry, and boundary checks cover adjacent behavior and make the risk-based set sufficient for peer review.
