### PR TITLE
fix(extensions): make activation reversible and readiness fail closed

### DIFF
--- a/docs/capabilities/semantic-preference/openviking-project-peer.md
+++ b/docs/capabilities/semantic-preference/openviking-project-peer.md
@@ -118,10 +118,12 @@ before activation. `loopx extension doctor openviking-semantic-preference
 --execute` repeats the read-only `ov status` probe. Hook `args` may still carry
 project-scoping options; they do not alter the manifest-owned doctor.
 
-`loopx semantic-preference openviking-provider` remains a delegating
-compatibility alias. New integrations should use the extension activation and
-`extension_id` binding so disable, upgrade, rollback, API compatibility,
-permission, and doctor state remain inspectable in one lifecycle.
+`loopx semantic-preference openviking-provider` remains a lazy delegating
+compatibility alias: ordinary LoopX CLI startup does not import the provider,
+and the alias loads it only when invoked. New integrations should use the
+extension activation and `extension_id` binding so enable, disable, upgrade,
+rollback, API compatibility, permission, and doctor state remain inspectable in
+one lifecycle.
 
 The consuming function remains the final application boundary. For Issue Fix,
 `build_issue_fix_pr_description()` owns one recall, fail-open preservation,

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -66,6 +66,7 @@ loopx extension install \
 loopx extension list --format json
 loopx extension doctor openviking-semantic-preference --execute --format json
 loopx extension disable openviking-semantic-preference --execute --format json
+loopx extension enable openviking-semantic-preference --execute --format json
 ```
 
 For a separately distributed provider, pass `--manifest <extension.toml>`.
@@ -74,6 +75,13 @@ revision. `rollback` probes the previous revision before switching back. A
 failed probe leaves the current revision untouched. Activation state contains
 validated manifest snapshots and revision ids in the private LoopX runtime
 root; it does not contain provider output or credentials.
+
+`disable` is reversible, but `enable` never trusts an earlier readiness result:
+it reruns the configured doctor and changes the enabled bit only after that
+probe succeeds. A successful doctor binds readiness to both the active manifest
+revision and the resolved executable identity. Missing or replaced executables
+fail closed until a new executed doctor succeeds; a failed executed doctor
+clears the stale proof without switching revisions.
 
 An enabled implementation is resolved by capability id, versioned protocol,
 declared permission, current revision, and current doctor proof. Domain config

--- a/examples/openviking-extension-runtime-smoke.py
+++ b/examples/openviking-extension-runtime-smoke.py
@@ -157,6 +157,31 @@ with tempfile.TemporaryDirectory(prefix="loopx-extension-runtime-") as raw_temp:
     assert unavailable["status"] == "provider_unavailable"
     assert unavailable["failure_kind"] == "extension_binding_unavailable"
 
+    enabled = run_cli(
+        "--runtime-root",
+        str(runtime_root),
+        "extension",
+        "enable",
+        "smoke-semantic-extension",
+        "--execute",
+    )
+    assert enabled["enabled"] is True
+    assert enabled["doctor"]["verified"] is True
+    resumed = run_cli(
+        "--runtime-root",
+        str(runtime_root),
+        "semantic-preference",
+        "recall",
+        "--project",
+        str(project),
+        "--config",
+        str(config),
+        "--surface",
+        "issue_fix.pr_description",
+        "--execute",
+    )
+    assert resumed["items"][0]["summary"] == "provider-v1"
+
     upgraded = run_cli(
         "--runtime-root",
         str(runtime_root),

--- a/loopx/capabilities/issue_fix/repository_memory_provider.py
+++ b/loopx/capabilities/issue_fix/repository_memory_provider.py
@@ -22,9 +22,7 @@ from ..context_providers.base import (
     ContextProviderRetrieval,
     opaque_provider_ref,
 )
-from ...extensions.openviking_semantic_preference.project_peer import (
-    resolve_project_identity,
-)
+from ...repository_identity import resolve_project_identity
 from ...control_plane.runtime.public_safety import public_safe_compact_text
 from .repository_memory import (
     ISSUE_FIX_REPOSITORY_MEMORY_READ_RESULT_SCHEMA_VERSION,

--- a/loopx/capabilities/semantic_preference/cli.py
+++ b/loopx/capabilities/semantic_preference/cli.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Callable
+import importlib
+from pathlib import Path
 
 from .contract import (
     application_receipt,
@@ -9,10 +11,29 @@ from .contract import (
     provider_doctor,
     recall,
 )
-from ...extensions.openviking_semantic_preference.provider import (
-    handle_openviking_provider,
-    register_openviking_provider_arguments,
+
+
+_LEGACY_OPENVIKING_PROVIDER_MODULE = (
+    "loopx.extensions.openviking_semantic_preference.provider"
 )
+
+
+def _register_legacy_openviking_provider_arguments(
+    parser: argparse.ArgumentParser,
+) -> None:
+    # Keep the compatibility parser provider-free; parity is regression-tested.
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--doctor", action="store_true")
+    mode.add_argument("--describe-scope", action="store_true")
+    parser.add_argument("--ov-bin", default="ov")
+    parser.add_argument("--cli-config")
+    parser.add_argument("--project", type=Path, default=Path.cwd())
+    parser.add_argument("--user-space", default="default")
+    parser.add_argument("--loopx-project-id")
+    parser.add_argument("--remote-url")
+    parser.add_argument("--include-global-fallback", action="store_true")
+    parser.add_argument("--max-find-calls", type=int, default=1)
+    parser.add_argument("--timeout-seconds", type=int, default=25)
 
 
 def _render(payload: dict[str, object]) -> str:
@@ -73,9 +94,9 @@ def register_semantic_preference_commands(
 
     provider_parser = commands.add_parser(
         "openviking-provider",
-        help="Run the opt-in OpenViking project-as-peer provider protocol.",
+        help="Delegate to the legacy OpenViking provider CLI when invoked.",
     )
-    register_openviking_provider_arguments(provider_parser)
+    _register_legacy_openviking_provider_arguments(provider_parser)
 
     receipt_parser = commands.add_parser("receipt")
     add_subcommand_format(receipt_parser)
@@ -120,7 +141,8 @@ def handle_semantic_preference_command(
     if args.command != "semantic-preference":
         return None
     if args.semantic_preference_command == "openviking-provider":
-        return handle_openviking_provider(args)
+        provider = importlib.import_module(_LEGACY_OPENVIKING_PROVIDER_MODULE)
+        return provider.handle_openviking_provider(args)
     try:
         if args.semantic_preference_command == "recall":
             payload = recall(

--- a/loopx/cli_commands/extension.py
+++ b/loopx/cli_commands/extension.py
@@ -9,6 +9,7 @@ from ..extensions.runtime import (
     default_extension_state_file,
     disable_extension,
     doctor_installed_extension,
+    enable_extension,
     extension_status,
     install_extension,
     rollback_extension,
@@ -99,7 +100,7 @@ def register_extension_commands(
         _add_manifest_source(operation)
         operation.add_argument("--execute", action="store_true")
 
-    for command in ("disable", "rollback", "doctor"):
+    for command in ("enable", "disable", "rollback", "doctor"):
         operation = commands.add_parser(command)
         _add_common(operation, add_subcommand_format)
         operation.add_argument("extension_id")
@@ -136,6 +137,12 @@ def handle_extension_command(
                 manifest_path,
                 state_file=state_file,
                 operation=args.extension_command,
+                execute=args.execute,
+            )
+        elif args.extension_command == "enable":
+            payload = enable_extension(
+                args.extension_id,
+                state_file=state_file,
                 execute=args.execute,
             )
         elif args.extension_command == "disable":

--- a/loopx/extensions/openviking_semantic_preference/project_peer.py
+++ b/loopx/extensions/openviking_semantic_preference/project_peer.py
@@ -2,53 +2,14 @@ from __future__ import annotations
 
 import hashlib
 import re
-import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
-from ...repository_identity import normalize_repository_identity
+from ...repository_identity import resolve_project_identity
 
 
 PROJECT_PEER_PREFIX = "project-"
-_SAFE_PROJECT_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$")
 _SAFE_USER_SPACE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
-
-
-def _origin_remote(project: Path, git_bin: str) -> str:
-    try:
-        completed = subprocess.run(
-            [git_bin, "-C", str(project), "config", "--get", "remote.origin.url"],
-            capture_output=True,
-            check=False,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        raise ValueError("project origin remote could not be read") from exc
-    if completed.returncode != 0 or not completed.stdout.strip():
-        raise ValueError(
-            "project has no canonical origin remote; provide a stable LoopX project id"
-        )
-    return completed.stdout.strip()
-
-
-def resolve_project_identity(
-    project: str | Path,
-    *,
-    loopx_project_id: str | None = None,
-    remote_url: str | None = None,
-    git_bin: str = "git",
-) -> str:
-    """Resolve a durable project identity without using a checkout path."""
-
-    try:
-        remote = remote_url or _origin_remote(Path(project), git_bin)
-        return normalize_repository_identity(remote)
-    except ValueError:
-        project_id = str(loopx_project_id or "").strip()
-        if not _SAFE_PROJECT_ID.fullmatch(project_id):
-            raise
-        return f"loopx:{project_id}"
 
 
 def project_peer_id(project_identity: str) -> str:

--- a/loopx/extensions/readiness.py
+++ b/loopx/extensions/readiness.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+import hashlib
+import json
+from pathlib import Path
+import shutil
+import subprocess
+from typing import Any
+
+
+EXTENSION_DOCTOR_SCHEMA_VERSION = "loopx_extension_doctor_v0"
+
+
+def extension_runtime(manifest: Mapping[str, Any]) -> Mapping[str, Any]:
+    runtime = manifest.get("runtime")
+    if not isinstance(runtime, Mapping):
+        raise ValueError("extension manifest does not declare an executable runtime")
+    return runtime
+
+
+def resolved_entrypoint_identity(command: str) -> tuple[Path, str] | None:
+    if "/" in command or "\\" in command:
+        path = Path(command).expanduser()
+    else:
+        resolved = shutil.which(command)
+        if resolved is None:
+            return None
+        path = Path(resolved)
+    try:
+        path = path.resolve(strict=True)
+        stat = path.stat()
+        if not path.is_file() or stat.st_mode & 0o111 == 0:
+            return None
+        with path.open("rb") as executable:
+            content_digest = hashlib.file_digest(executable, "sha256").hexdigest()
+    except OSError:
+        return None
+    identity = {
+        "path": str(path),
+        "device": stat.st_dev,
+        "inode": stat.st_ino,
+        "size": stat.st_size,
+        "mtime_ns": stat.st_mtime_ns,
+        "content_sha256": content_digest,
+    }
+    serialized = json.dumps(identity, sort_keys=True, separators=(",", ":"))
+    return path, hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def extension_doctor(
+    manifest: Mapping[str, Any],
+    *,
+    execute: bool = False,
+) -> dict[str, Any]:
+    runtime = extension_runtime(manifest)
+    entrypoint = str(runtime["entrypoint"])
+    identity_before = resolved_entrypoint_identity(entrypoint)
+    available = identity_before is not None
+    doctor_args = [str(value) for value in runtime.get("doctor_args") or []]
+    status = "ready" if available else "entrypoint_missing"
+    verified = False
+    failure_kind = None
+    if not doctor_args:
+        status = "doctor_not_configured"
+        available = False
+        failure_kind = "doctor_not_configured"
+    elif available and not execute:
+        status = "probe_required"
+    elif available:
+        argv = [
+            str(identity_before[0]),
+            *[str(value) for value in runtime.get("args") or []],
+            *doctor_args,
+        ]
+        try:
+            completed = subprocess.run(
+                argv,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=int(runtime["timeout_seconds"]),
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            completed = None
+            failure_kind = "probe_execution_failed"
+        if completed is None or completed.returncode != 0:
+            status = "provider_unavailable"
+            available = False
+            failure_kind = failure_kind or "probe_nonzero_exit"
+        else:
+            identity_after = resolved_entrypoint_identity(entrypoint)
+            if identity_after is None or identity_after[1] != identity_before[1]:
+                status = "provider_unavailable"
+                available = False
+                failure_kind = "entrypoint_changed_during_probe"
+            else:
+                status = "ready"
+                verified = True
+    return {
+        "ok": True,
+        "schema_version": EXTENSION_DOCTOR_SCHEMA_VERSION,
+        "extension_id": manifest["provider"]["id"],
+        "version": manifest["provider"]["version"],
+        "status": status,
+        "available": available,
+        "verified": verified,
+        "entrypoint_identity": identity_before[1] if verified else None,
+        "failure_kind": failure_kind,
+        "external_writes_performed": False,
+    }

--- a/loopx/extensions/runtime.py
+++ b/loopx/extensions/runtime.py
@@ -7,17 +7,20 @@ import hashlib
 import json
 import os
 from pathlib import Path
-import shutil
-import subprocess
 from typing import Any
 
 from ..file_lock import exclusive_file_lock
 from .manifest import load_extension_manifest
+from .readiness import (
+    EXTENSION_DOCTOR_SCHEMA_VERSION,
+    extension_doctor,
+    extension_runtime,
+    resolved_entrypoint_identity,
+)
 
 
 EXTENSION_STATE_SCHEMA_VERSION = "loopx_extension_state_v0"
 EXTENSION_OPERATION_SCHEMA_VERSION = "loopx_extension_operation_v0"
-EXTENSION_DOCTOR_SCHEMA_VERSION = "loopx_extension_doctor_v0"
 EXTENSION_BINDING_SCHEMA_VERSION = "loopx_extension_runtime_binding_v0"
 MAX_REVISIONS = 5
 
@@ -78,73 +81,7 @@ def _revision(manifest: Mapping[str, Any]) -> str:
 
 
 def _runtime(manifest: Mapping[str, Any]) -> Mapping[str, Any]:
-    runtime = manifest.get("runtime")
-    if not isinstance(runtime, Mapping):
-        raise ValueError("extension manifest does not declare an executable runtime")
-    return runtime
-
-
-def _command_available(command: str) -> bool:
-    if "/" in command or "\\" in command:
-        path = Path(command).expanduser()
-        return path.is_file() and path.stat().st_mode & 0o111 != 0
-    return shutil.which(command) is not None
-
-
-def extension_doctor(
-    manifest: Mapping[str, Any],
-    *,
-    execute: bool = False,
-) -> dict[str, Any]:
-    runtime = _runtime(manifest)
-    entrypoint = str(runtime["entrypoint"])
-    available = _command_available(entrypoint)
-    doctor_args = [str(value) for value in runtime.get("doctor_args") or []]
-    status = "ready" if available else "entrypoint_missing"
-    verified = False
-    failure_kind = None
-    if not doctor_args:
-        status = "doctor_not_configured"
-        available = False
-        failure_kind = "doctor_not_configured"
-    elif available and not execute:
-        status = "probe_required"
-    elif available:
-        argv = [
-            entrypoint,
-            *[str(value) for value in runtime.get("args") or []],
-            *doctor_args,
-        ]
-        try:
-            completed = subprocess.run(
-                argv,
-                stdin=subprocess.DEVNULL,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                timeout=int(runtime["timeout_seconds"]),
-                check=False,
-            )
-        except (OSError, subprocess.TimeoutExpired):
-            completed = None
-            failure_kind = "probe_execution_failed"
-        if completed is None or completed.returncode != 0:
-            status = "provider_unavailable"
-            available = False
-            failure_kind = failure_kind or "probe_nonzero_exit"
-        else:
-            status = "ready"
-            verified = True
-    return {
-        "ok": True,
-        "schema_version": EXTENSION_DOCTOR_SCHEMA_VERSION,
-        "extension_id": manifest["provider"]["id"],
-        "version": manifest["provider"]["version"],
-        "status": status,
-        "available": available,
-        "verified": verified,
-        "failure_kind": failure_kind,
-        "external_writes_performed": False,
-    }
+    return extension_runtime(manifest)
 
 
 def _manifest_snapshot(manifest: Mapping[str, Any]) -> dict[str, Any]:
@@ -249,6 +186,9 @@ def install_extension(
                 "active_revision": revision,
                 "rollback_revision": previous_revision,
                 "doctor_verified_revision": revision,
+                "doctor_verified_entrypoint_identity": doctor[
+                    "entrypoint_identity"
+                ],
                 "revisions": revisions,
             }
             _write_state(path, state)
@@ -266,6 +206,73 @@ def install_extension(
         "enabled": True if execute else None,
         "doctor": doctor,
         "rollback_available": previous_revision is not None,
+    }
+
+
+def enable_extension(
+    extension_id: str,
+    *,
+    state_file: str | Path,
+    execute: bool = False,
+) -> dict[str, Any]:
+    path = Path(state_file).expanduser()
+    state = _read_state(path)
+    entry = state["extensions"].get(extension_id)
+    if not isinstance(entry, dict):
+        raise ValueError(f"extension `{extension_id}` is not installed")
+    active_revision = str(entry.get("active_revision") or "")
+    snapshot = _entry_for_revision(entry, active_revision)
+    manifest = snapshot.get("manifest")
+    if not isinstance(manifest, Mapping):
+        raise ValueError("extension active manifest is invalid")
+    already_enabled = bool(entry.get("enabled"))
+    doctor = extension_doctor(manifest, execute=execute)
+    if execute and not doctor["verified"]:
+        with exclusive_file_lock(path):
+            current_state = _read_state(path)
+            current_entry = current_state["extensions"].get(extension_id)
+            if (
+                not isinstance(current_entry, dict)
+                or current_entry.get("active_revision") != active_revision
+                or bool(current_entry.get("enabled")) != already_enabled
+            ):
+                raise ValueError("extension state changed during enable; retry")
+            current_entry.pop("doctor_verified_revision", None)
+            current_entry.pop("doctor_verified_entrypoint_identity", None)
+            _write_state(path, current_state)
+        raise ValueError(
+            f"extension `{extension_id}` enable doctor is not ready: "
+            f"{doctor['status']}"
+        )
+    changed = False
+    if execute:
+        with exclusive_file_lock(path):
+            current_state = _read_state(path)
+            current_entry = current_state["extensions"].get(extension_id)
+            if (
+                not isinstance(current_entry, dict)
+                or current_entry.get("active_revision") != active_revision
+                or bool(current_entry.get("enabled")) != already_enabled
+            ):
+                raise ValueError("extension state changed during enable; retry")
+            current_entry["enabled"] = True
+            current_entry["doctor_verified_revision"] = active_revision
+            current_entry["doctor_verified_entrypoint_identity"] = doctor[
+                "entrypoint_identity"
+            ]
+            _write_state(path, current_state)
+            changed = not already_enabled
+    return {
+        "ok": True,
+        "schema_version": EXTENSION_OPERATION_SCHEMA_VERSION,
+        "operation": "enable",
+        "dry_run": not execute,
+        "changed": changed,
+        "would_change": not already_enabled,
+        "extension_id": extension_id,
+        "enabled": True if execute else already_enabled,
+        "active_revision": active_revision,
+        "doctor": doctor,
     }
 
 
@@ -337,6 +344,9 @@ def rollback_extension(
             current_entry["active_revision"] = target_revision
             current_entry["rollback_revision"] = previous_revision
             current_entry["doctor_verified_revision"] = target_revision
+            current_entry["doctor_verified_entrypoint_identity"] = doctor[
+                "entrypoint_identity"
+            ]
             current_entry["enabled"] = True
             _write_state(path, current_state)
     return {
@@ -377,8 +387,8 @@ def extension_status(
                 "enabled": bool(entry.get("enabled")),
                 "active_revision": entry.get("active_revision"),
                 "rollback_available": bool(entry.get("rollback_revision")),
-                "doctor_verified": entry.get("doctor_verified_revision")
-                == entry.get("active_revision"),
+                "doctor_verified": bool(entry.get("enabled"))
+                and _verified_entrypoint(entry) is not None,
                 "revision_count": len(entry.get("revisions") or []),
             }
             for entry in visible
@@ -392,7 +402,8 @@ def doctor_installed_extension(
     state_file: str | Path,
     execute: bool = False,
 ) -> dict[str, Any]:
-    state = _read_state(Path(state_file).expanduser())
+    path = Path(state_file).expanduser()
+    state = _read_state(path)
     entry = state["extensions"].get(extension_id)
     if not isinstance(entry, dict):
         raise ValueError(f"extension `{extension_id}` is not installed")
@@ -404,6 +415,7 @@ def doctor_installed_extension(
             "status": "disabled",
             "available": False,
             "verified": False,
+            "entrypoint_identity": None,
             "failure_kind": None,
             "external_writes_performed": False,
         }
@@ -412,7 +424,47 @@ def doctor_installed_extension(
     manifest = snapshot.get("manifest")
     if not isinstance(manifest, Mapping):
         raise ValueError("extension active manifest is invalid")
-    return extension_doctor(manifest, execute=execute)
+    doctor = extension_doctor(manifest, execute=execute)
+    if execute:
+        with exclusive_file_lock(path):
+            current_state = _read_state(path)
+            current_entry = current_state["extensions"].get(extension_id)
+            if (
+                not isinstance(current_entry, dict)
+                or current_entry.get("active_revision") != active_revision
+                or not current_entry.get("enabled")
+            ):
+                raise ValueError("extension state changed during doctor; retry")
+            if doctor["verified"]:
+                current_entry["doctor_verified_revision"] = active_revision
+                current_entry["doctor_verified_entrypoint_identity"] = doctor[
+                    "entrypoint_identity"
+                ]
+            else:
+                current_entry.pop("doctor_verified_revision", None)
+                current_entry.pop("doctor_verified_entrypoint_identity", None)
+            _write_state(path, current_state)
+    return doctor
+
+
+def _verified_entrypoint(entry: Mapping[str, Any]) -> Path | None:
+    active_revision = str(entry.get("active_revision") or "")
+    if entry.get("doctor_verified_revision") != active_revision:
+        return None
+    try:
+        snapshot = _entry_for_revision(entry, active_revision)
+    except ValueError:
+        return None
+    manifest = snapshot.get("manifest")
+    if not isinstance(manifest, Mapping):
+        return None
+    runtime = _runtime(manifest)
+    identity = resolved_entrypoint_identity(str(runtime["entrypoint"]))
+    if identity is None or identity[1] != entry.get(
+        "doctor_verified_entrypoint_identity"
+    ):
+        return None
+    return identity[0]
 
 
 def resolve_extension_binding(
@@ -430,7 +482,8 @@ def resolve_extension_binding(
     if not entry.get("enabled"):
         raise ValueError(f"extension `{extension_id}` is disabled")
     active_revision = str(entry.get("active_revision") or "")
-    if entry.get("doctor_verified_revision") != active_revision:
+    verified_entrypoint = _verified_entrypoint(entry)
+    if verified_entrypoint is None:
         raise ValueError(f"extension `{extension_id}` doctor readiness is stale")
     snapshot = _entry_for_revision(entry, active_revision)
     manifest = snapshot.get("manifest")
@@ -462,15 +515,16 @@ def resolve_extension_binding(
             f"extension `{extension_id}` does not implement `{capability_id}` "
             f"with protocol `{protocol}`"
         )
+    resolved_entrypoint = str(verified_entrypoint)
     return {
         "schema_version": EXTENSION_BINDING_SCHEMA_VERSION,
         "extension_id": extension_id,
         "provider_version": provider.get("version"),
         "revision": active_revision,
         "protocol": protocol,
-        "argv": [runtime["entrypoint"], *(runtime.get("args") or [])],
+        "argv": [resolved_entrypoint, *(runtime.get("args") or [])],
         "doctor_argv": [
-            runtime["entrypoint"],
+            resolved_entrypoint,
             *(runtime.get("args") or []),
             *(runtime.get("doctor_args") or []),
         ],

--- a/loopx/repository_identity.py
+++ b/loopx/repository_identity.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import re
+import subprocess
+from pathlib import Path
 from urllib.parse import urlsplit
 
 
@@ -8,6 +10,7 @@ CANONICAL_REPOSITORY_IDENTITY_PATTERN = re.compile(
     r"^git:(?P<host>[a-z0-9.-]+(?::[0-9]{1,5})?)/"
     r"(?P<path>[A-Za-z0-9._~+/-]+)$"
 )
+_SAFE_PROJECT_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$")
 
 
 def normalize_repository_identity(remote_url_or_identity: str) -> str:
@@ -49,6 +52,43 @@ def normalize_repository_identity(remote_url_or_identity: str) -> str:
 
     path = _normalize_repository_path(parsed.path)
     return f"git:{host}/{path}"
+
+
+def _origin_remote(project: Path, git_bin: str) -> str:
+    try:
+        completed = subprocess.run(
+            [git_bin, "-C", str(project), "config", "--get", "remote.origin.url"],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ValueError("project origin remote could not be read") from exc
+    if completed.returncode != 0 or not completed.stdout.strip():
+        raise ValueError(
+            "project has no canonical origin remote; provide a stable LoopX project id"
+        )
+    return completed.stdout.strip()
+
+
+def resolve_project_identity(
+    project: str | Path,
+    *,
+    loopx_project_id: str | None = None,
+    remote_url: str | None = None,
+    git_bin: str = "git",
+) -> str:
+    """Resolve a durable project identity without using a checkout path."""
+
+    try:
+        remote = remote_url or _origin_remote(Path(project), git_bin)
+        return normalize_repository_identity(remote)
+    except ValueError:
+        project_id = str(loopx_project_id or "").strip()
+        if not _SAFE_PROJECT_ID.fullmatch(project_id):
+            raise
+        return f"loopx:{project_id}"
 
 
 def _normalize_repository_path(value: str) -> str:

--- a/tests/extensions/test_extension_runtime.py
+++ b/tests/extensions/test_extension_runtime.py
@@ -1,20 +1,32 @@
 from __future__ import annotations
 
+import argparse
+import ast
+from collections.abc import Callable
 import json
 from pathlib import Path
+import subprocess
 import sys
 
 import pytest
 
 from loopx.capabilities.catalog import build_capability_detail_packet
+from loopx.capabilities.semantic_preference.cli import (
+    _register_legacy_openviking_provider_arguments,
+)
 from loopx.capabilities.semantic_preference.contract import provider_doctor, recall
 from loopx.cli import main
 from loopx.extensions.runtime import (
     disable_extension,
+    doctor_installed_extension,
+    enable_extension,
     extension_status,
     install_extension,
     resolve_extension_binding,
     rollback_extension,
+)
+from loopx.extensions.openviking_semantic_preference.provider import (
+    register_openviking_provider_arguments,
 )
 
 
@@ -114,6 +126,28 @@ def test_install_disable_upgrade_and_rollback_preserve_verified_binding(
             permission="semantic_preference.read",
         )
 
+    enabled = enable_extension(
+        "test-semantic-extension",
+        state_file=state_file,
+        execute=True,
+    )
+    assert enabled["changed"] is True
+    assert enabled["doctor"]["verified"] is True
+    assert resolve_extension_binding(
+        "test-semantic-extension",
+        state_file=state_file,
+        capability_id="semantic-preference",
+        protocol="semantic_preference_provider_v0",
+        permission="semantic_preference.read",
+    )["argv"] == [str(provider)]
+    already_enabled = enable_extension(
+        "test-semantic-extension",
+        state_file=state_file,
+        execute=True,
+    )
+    assert already_enabled["changed"] is False
+    assert already_enabled["doctor"]["verified"] is True
+
     upgraded = install_extension(
         v2,
         state_file=state_file,
@@ -159,6 +193,147 @@ def test_failed_upgrade_keeps_the_active_revision(tmp_path: Path) -> None:
     status = extension_status(state_file=state_file)["extensions"][0]
     assert status["active_revision"] == installed["revision"]
     assert status["revision_count"] == 1
+
+
+def test_failed_enable_remains_disabled_and_clears_old_proof(tmp_path: Path) -> None:
+    provider = _provider(tmp_path / "provider")
+    manifest = _manifest(
+        tmp_path / "extension.toml",
+        entrypoint=provider,
+        version="1.0.0",
+    )
+    state_file = tmp_path / "extensions.json"
+    install_extension(manifest, state_file=state_file, execute=True)
+    disable_extension(
+        "test-semantic-extension",
+        state_file=state_file,
+        execute=True,
+    )
+    _provider(provider, doctor_exit=2)
+
+    with pytest.raises(ValueError, match="enable doctor is not ready"):
+        enable_extension(
+            "test-semantic-extension",
+            state_file=state_file,
+            execute=True,
+        )
+
+    entry = json.loads(state_file.read_text(encoding="utf-8"))["extensions"][
+        "test-semantic-extension"
+    ]
+    assert entry["enabled"] is False
+    assert "doctor_verified_revision" not in entry
+    assert "doctor_verified_entrypoint_identity" not in entry
+
+
+def test_failed_executed_doctor_clears_stale_readiness_proof(
+    tmp_path: Path,
+) -> None:
+    provider = _provider(tmp_path / "provider")
+    manifest = _manifest(
+        tmp_path / "extension.toml",
+        entrypoint=provider,
+        version="1.0.0",
+    )
+    state_file = tmp_path / "extensions.json"
+    install_extension(manifest, state_file=state_file, execute=True)
+    _provider(provider, doctor_exit=2)
+
+    doctor = doctor_installed_extension(
+        "test-semantic-extension",
+        state_file=state_file,
+        execute=True,
+    )
+
+    assert doctor["verified"] is False
+    entry = json.loads(state_file.read_text(encoding="utf-8"))["extensions"][
+        "test-semantic-extension"
+    ]
+    assert "doctor_verified_revision" not in entry
+    assert "doctor_verified_entrypoint_identity" not in entry
+    with pytest.raises(ValueError, match="doctor readiness is stale"):
+        resolve_extension_binding(
+            "test-semantic-extension",
+            state_file=state_file,
+            capability_id="semantic-preference",
+            protocol="semantic_preference_provider_v0",
+            permission="semantic_preference.read",
+        )
+
+
+def test_executed_doctor_rebinds_revision_only_legacy_proof(tmp_path: Path) -> None:
+    provider = _provider(tmp_path / "provider")
+    manifest = _manifest(
+        tmp_path / "extension.toml",
+        entrypoint=provider,
+        version="1.0.0",
+    )
+    state_file = tmp_path / "extensions.json"
+    install_extension(manifest, state_file=state_file, execute=True)
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    entry = state["extensions"]["test-semantic-extension"]
+    entry.pop("doctor_verified_entrypoint_identity")
+    state_file.write_text(json.dumps(state), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="doctor readiness is stale"):
+        resolve_extension_binding(
+            "test-semantic-extension",
+            state_file=state_file,
+            capability_id="semantic-preference",
+            protocol="semantic_preference_provider_v0",
+            permission="semantic_preference.read",
+        )
+    repaired = doctor_installed_extension(
+        "test-semantic-extension",
+        state_file=state_file,
+        execute=True,
+    )
+    assert repaired["verified"] is True
+    assert resolve_extension_binding(
+        "test-semantic-extension",
+        state_file=state_file,
+        capability_id="semantic-preference",
+        protocol="semantic_preference_provider_v0",
+        permission="semantic_preference.read",
+    )["argv"] == [str(provider)]
+
+
+@pytest.mark.parametrize("replacement", ["missing", "changed"])
+def test_binding_rejects_missing_or_replaced_entrypoint(
+    tmp_path: Path,
+    replacement: str,
+) -> None:
+    provider = _provider(tmp_path / "provider")
+    manifest = _manifest(
+        tmp_path / "extension.toml",
+        entrypoint=provider,
+        version="1.0.0",
+    )
+    state_file = tmp_path / "extensions.json"
+    install_extension(manifest, state_file=state_file, execute=True)
+    if replacement == "missing":
+        provider.unlink()
+    else:
+        _provider(provider, doctor_exit=0)
+        provider.write_text(
+            provider.read_text(encoding="utf-8").replace(
+                "Prefer compact validation notes.",
+                "A replaced provider must be re-verified.",
+            ),
+            encoding="utf-8",
+        )
+
+    assert extension_status(state_file=state_file)["extensions"][0][
+        "doctor_verified"
+    ] is False
+    with pytest.raises(ValueError, match="doctor readiness is stale"):
+        resolve_extension_binding(
+            "test-semantic-extension",
+            state_file=state_file,
+            capability_id="semantic-preference",
+            protocol="semantic_preference_provider_v0",
+            permission="semantic_preference.read",
+        )
 
 
 def test_runtime_permission_must_be_declared_by_manifest(tmp_path: Path) -> None:
@@ -299,3 +474,96 @@ def test_extension_cli_installs_preinstalled_runtime(
     )
     listed = json.loads(capsys.readouterr().out)
     assert listed["extensions"][0]["doctor_verified"] is True
+
+    assert (
+        main(
+            [
+                "--runtime-root",
+                str(runtime_root),
+                "--format",
+                "json",
+                "extension",
+                "disable",
+                "test-semantic-extension",
+                "--execute",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    assert (
+        main(
+            [
+                "--runtime-root",
+                str(runtime_root),
+                "--format",
+                "json",
+                "extension",
+                "enable",
+                "test-semantic-extension",
+                "--execute",
+            ]
+        )
+        == 0
+    )
+    enabled = json.loads(capsys.readouterr().out)
+    assert enabled["enabled"] is True
+    assert enabled["doctor"]["verified"] is True
+
+
+def test_core_does_not_import_openviking_provider_implementation() -> None:
+    root = Path(__file__).resolve().parents[2] / "loopx"
+    forbidden: list[str] = []
+    for path in root.rglob("*.py"):
+        relative = path.relative_to(root)
+        if relative.parts[0] == "extensions":
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            module = ""
+            if isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+            elif isinstance(node, ast.Import):
+                module = " ".join(alias.name for alias in node.names)
+            if "openviking_semantic_preference" in module:
+                forbidden.append(str(relative))
+    assert forbidden == []
+
+
+def test_ordinary_cli_import_does_not_load_openviking_provider() -> None:
+    module = "loopx.extensions.openviking_semantic_preference.provider"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            f"import sys; import loopx.cli; assert {module!r} not in sys.modules",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_legacy_openviking_alias_matches_provider_argument_contract() -> None:
+    def options(
+        register: Callable[[argparse.ArgumentParser], None],
+    ) -> list[tuple[object, ...]]:
+        parser = argparse.ArgumentParser(add_help=False)
+        register(parser)
+        return [
+            (
+                tuple(action.option_strings),
+                action.dest,
+                type(action).__name__,
+                action.default,
+                action.nargs,
+                action.const,
+            )
+            for action in parser._actions
+            if action.option_strings
+        ]
+
+    assert options(_register_legacy_openviking_provider_arguments) == options(
+        register_openviking_provider_arguments
+    )


### PR DESCRIPTION
## Summary
- add doctor-gated `loopx extension enable` so disable/enable is reversible without trusting stale proof
- bind readiness to the active revision and resolved executable identity; reject missing/replaced entrypoints and clear proof after failed executed doctor
- move generic repository identity resolution into core and make the legacy OpenViking CLI a lazy compatibility delegate

## Validation
- `pytest -q tests/extensions/test_extension_runtime.py` (13 passed)
- `python examples/openviking-extension-runtime-smoke.py`
- `python examples/openviking-project-peer-provider-smoke.py`
- `python examples/issue-fix-repository-memory-smoke.py`
- `python examples/issue-fix-validated-memory-writeback-smoke.py`
- Ruff on changed Python surfaces
- `loopx canary premerge --from-git-diff` via supported Python 3.12 runtime (18/18, boundary clean, no manual holds)

## Compatibility
Existing revision-only readiness state fails closed and can be rebound by an executed doctor. The legacy `semantic-preference openviking-provider` argument contract remains covered by parity and end-to-end tests.