### PR TITLE
refactor(control-plane): invert operator inbox dependency

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,6 +62,13 @@ contract, while an extension is an independently managed provider that may
 offer one or more capabilities. The provider-aware registration and manifest
 boundary is documented in [extensions.md](reference/extensions.md).
 
+Operator-inbox urgency is one such inward contract. Quota consumes the
+content-free `operator_inbox_urgency_v0` read model from the control plane; it
+does not import the Lark provider. The existing Lark config, event files,
+capability key, lane names, and CLI remain compatibility surfaces while the
+provider delegates urgency projection to that contract. Provider files should
+move only after this read-model and work-lane parity remains characterized.
+
 LoopX should still absorb field-tested project-control mechanisms such
 as authority registries, current-belief TODOs, managed external-source
 manifests, experiment boards, validation surface maps, and gated handoff

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -220,3 +220,10 @@ The executable v0 runtime intentionally does not:
 
 These boundaries keep activation reversible and auditable while leaving package
 distribution and service setup to explicit operator-owned workflows.
+
+Provider migration follows the same direction. Core routing consumes compact
+provider-neutral read models, while provider packages own collection, transport,
+credentials, and external effects. For example, quota reads
+`operator_inbox_urgency_v0`; the current Lark inbox API is a compatibility
+delegate and preserves its existing CLI and work-lane output until a later
+provider-file move has independent parity evidence.

--- a/examples/control_plane/lark-inbox-priority-smoke.py
+++ b/examples/control_plane/lark-inbox-priority-smoke.py
@@ -19,6 +19,7 @@ from loopx.capabilities.lark.event_inbox import (  # noqa: E402
     project_lark_event_inbox_urgency,
 )
 from loopx.control_plane.work_items.operator_inbox import (  # noqa: E402
+    LARK_OPERATOR_INBOX_SOURCE_CONTRACT,
     project_operator_inbox_urgency,
 )
 from loopx.control_plane.testing.quota_fixtures import (  # noqa: E402
@@ -134,6 +135,18 @@ def main() -> None:
             ),
             encoding="utf-8",
         )
+        (inbox / "invalid_event.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "lark_event_inbox_event_v0",
+                    "event_id": "invalid event id",
+                    "message_id": "om_invalid_event",
+                    "create_time": "2026-07-15T00:00:01Z",
+                    "content": "@Project Review Bot 这条无效事件不能进入 urgency？",
+                }
+            ),
+            encoding="utf-8",
+        )
 
         decision = build_quota_should_run(status_payload(project), goal_id=GOAL_ID)
         assert decision["should_run"] is True, decision
@@ -147,13 +160,20 @@ def main() -> None:
         assert lane["direct_question_count"] == 1, lane
         assert lane["reply_to_bot_count"] == 0, lane
         assert lane["pending_count"] == 1, lane
-        assert decision["execution_obligation"]["contract_obligation"] == lane["obligation"]
+        assert (
+            decision["execution_obligation"]["contract_obligation"]
+            == lane["obligation"]
+        )
         assert "durable effect" in decision["recommended_action"], decision
-        urgency = decision["goal_boundary"]["capabilities"]["lark_event_inbox"]["urgency"]
+        urgency = decision["goal_boundary"]["capabilities"]["lark_event_inbox"][
+            "urgency"
+        ]
         assert urgency["schema_version"] == "lark_event_inbox_urgency_v0", urgency
         assert urgency["reply_due"] is True, urgency
         assert urgency["local_private_content_returned"] is False, urgency
-        assert "items" not in urgency and "message_id" not in json.dumps(urgency), urgency
+        assert "items" not in urgency and "message_id" not in json.dumps(urgency), (
+            urgency
+        )
         parity_now = datetime(2026, 7, 15, 0, 10, tzinfo=timezone.utc)
         compatibility = project_lark_event_inbox_urgency(
             project=project,
@@ -163,9 +183,7 @@ def main() -> None:
         generic = project_operator_inbox_urgency(
             project=project,
             config_path=config,
-            config_schema_version="lark_event_inbox_config_v0",
-            event_schema_version="lark_event_inbox_event_v0",
-            processed_schema_version="lark_event_inbox_processed_v0",
+            source_contract=LARK_OPERATOR_INBOX_SOURCE_CONTRACT,
             now=parity_now,
         )
         compatibility["schema_version"] = "operator_inbox_urgency_v0"

--- a/examples/control_plane/lark-inbox-priority-smoke.py
+++ b/examples/control_plane/lark-inbox-priority-smoke.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import sys
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -15,6 +16,10 @@ if str(REPO_ROOT) not in sys.path:
 
 from loopx.capabilities.lark.event_inbox import (  # noqa: E402
     acknowledge_lark_event_inbox,
+    project_lark_event_inbox_urgency,
+)
+from loopx.control_plane.work_items.operator_inbox import (  # noqa: E402
+    project_operator_inbox_urgency,
 )
 from loopx.control_plane.testing.quota_fixtures import (  # noqa: E402
     quota_status_payload,
@@ -145,9 +150,29 @@ def main() -> None:
         assert decision["execution_obligation"]["contract_obligation"] == lane["obligation"]
         assert "durable effect" in decision["recommended_action"], decision
         urgency = decision["goal_boundary"]["capabilities"]["lark_event_inbox"]["urgency"]
+        assert urgency["schema_version"] == "lark_event_inbox_urgency_v0", urgency
         assert urgency["reply_due"] is True, urgency
         assert urgency["local_private_content_returned"] is False, urgency
         assert "items" not in urgency and "message_id" not in json.dumps(urgency), urgency
+        parity_now = datetime(2026, 7, 15, 0, 10, tzinfo=timezone.utc)
+        compatibility = project_lark_event_inbox_urgency(
+            project=project,
+            config_path=config,
+            now=parity_now,
+        )
+        generic = project_operator_inbox_urgency(
+            project=project,
+            config_path=config,
+            config_schema_version="lark_event_inbox_config_v0",
+            event_schema_version="lark_event_inbox_event_v0",
+            processed_schema_version="lark_event_inbox_processed_v0",
+            now=parity_now,
+        )
+        compatibility["schema_version"] = "operator_inbox_urgency_v0"
+        compatibility["reply_to_operator_count"] = compatibility.pop(
+            "reply_to_bot_count"
+        )
+        assert compatibility == generic, (compatibility, generic)
         markdown = render_quota_should_run_markdown(decision)
         assert "lane=lark_event_inbox" in markdown, markdown
         assert "questions=1" in markdown, markdown

--- a/loopx/capabilities/lark/event_inbox.py
+++ b/loopx/capabilities/lark/event_inbox.py
@@ -6,6 +6,11 @@ from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any, Mapping, Sequence
 
+from ...control_plane.work_items.operator_inbox import (
+    operator_inbox_attention_kind,
+    project_operator_inbox_urgency,
+)
+
 
 EVENT_SCHEMA_VERSION = "lark_event_inbox_event_v0"
 CONFIG_SCHEMA_VERSION = "lark_event_inbox_config_v0"
@@ -15,9 +20,6 @@ MESSAGE_ID_PATTERN = re.compile(r"om_[A-Za-z0-9_-]+")
 EVENT_ID_PATTERN = re.compile(r"[A-Za-z0-9:_-]{1,200}")
 SAFE_PROFILE_PATTERN = re.compile(r"[A-Za-z0-9._-]{1,100}")
 CHAT_ID_PATTERN = re.compile(r"oc_[A-Za-z0-9_-]+")
-QUESTION_SIGNAL_PATTERN = re.compile(
-    r"[?？]|(?:请问|怎么|怎样|为何|为什么|是不是|是否|能否|可以吗|行吗|结论呢|回复吗)"
-)
 
 
 def _safe_inbox_path(project: str | Path, raw_path: str) -> Path:
@@ -183,25 +185,26 @@ def _pending_events(config: Mapping[str, Any]) -> tuple[list[dict[str, Any]], in
     return pending, len(events), invalid_count
 
 
-def _parse_event_time(value: object) -> datetime | None:
-    raw = str(value or "").strip()
-    if not raw:
-        return None
-    if raw.isdigit():
-        number = int(raw)
-        if number > 10_000_000_000:
-            number //= 1000
-        try:
-            return datetime.fromtimestamp(number, tz=timezone.utc)
-        except (OverflowError, OSError, ValueError):
-            return None
-    try:
-        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
+def project_lark_event_inbox_urgency(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Compatibility delegate for the provider-neutral urgency projection."""
+
+    load_lark_event_inbox_config(project=project, config_path=config_path)
+    urgency = project_operator_inbox_urgency(
+        project=project,
+        config_path=config_path,
+        config_schema_version=CONFIG_SCHEMA_VERSION,
+        event_schema_version=EVENT_SCHEMA_VERSION,
+        processed_schema_version=PROCESSED_SCHEMA_VERSION,
+        now=now,
+    )
+    urgency["schema_version"] = "lark_event_inbox_urgency_v0"
+    urgency["reply_to_bot_count"] = urgency.pop("reply_to_operator_count")
+    return urgency
 
 
 def _event_attention_kind(
@@ -210,94 +213,17 @@ def _event_attention_kind(
     bot_display_name: str,
     capture_scope: str,
 ) -> str | None:
-    content = " ".join(str(event.get("content") or "").split())
-    if not content:
-        return None
-    if (
+    normalized = dict(event)
+    normalized["reply_to_operator"] = bool(
         event.get("reply_context_verified") is True
         and event.get("reply_to_bot") is True
-    ):
-        return "reply_to_bot"
-    folded = content.casefold()
-    bot_name = " ".join(str(bot_display_name or "").split()).casefold()
-    explicit_bot_mention = bool(bot_name and "@" in content and bot_name in folded)
-    generic_loopx_mention = "@" in content and "loopx" in folded
-    addressed = bool(
-        capture_scope == "addressed_only"
-        or explicit_bot_mention
-        or generic_loopx_mention
     )
-    if not addressed:
-        return None
-    if QUESTION_SIGNAL_PATTERN.search(content):
-        return "direct_question"
-    if explicit_bot_mention or generic_loopx_mention:
-        return "direct_mention"
-    return None
-
-
-def project_lark_event_inbox_urgency(
-    *,
-    project: str | Path,
-    config_path: str | Path,
-    now: datetime | None = None,
-) -> dict[str, Any]:
-    """Return a content-free urgency read model for quota/status routing."""
-
-    config = load_lark_event_inbox_config(project=project, config_path=config_path)
-    if not config["enabled"]:
-        return {
-            "schema_version": "lark_event_inbox_urgency_v0",
-            "enabled": False,
-            "pending_count": 0,
-            "direct_question_count": 0,
-            "direct_mention_count": 0,
-            "reply_to_bot_count": 0,
-            "attention_required_count": 0,
-            "reply_due": False,
-            "local_private_content_returned": False,
-        }
-    pending, _, _ = _pending_events(config)
-    kinds = [
-        _event_attention_kind(
-            event,
-            bot_display_name=str(config["reply"].get("bot_display_name") or ""),
-            capture_scope=str(config["capture_scope"]),
-        )
-        for event in pending
-    ]
-    direct_question_count = kinds.count("direct_question")
-    direct_mention_count = kinds.count("direct_mention")
-    reply_to_bot_count = kinds.count("reply_to_bot")
-    attention_required_count = (
-        direct_question_count + direct_mention_count + reply_to_bot_count
+    kind = operator_inbox_attention_kind(
+        normalized,
+        operator_display_name=bot_display_name,
+        capture_scope=capture_scope,
     )
-    parsed_times = [
-        parsed
-        for event in pending
-        if (parsed := _parse_event_time(event.get("create_time"))) is not None
-    ]
-    oldest = min(parsed_times) if parsed_times else None
-    current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
-    oldest_age_seconds = (
-        max(0, int((current - oldest).total_seconds())) if oldest else None
-    )
-    return {
-        "schema_version": "lark_event_inbox_urgency_v0",
-        "enabled": True,
-        "thread_complete": bool(config["thread_complete"]),
-        "pending_count": len(pending),
-        "direct_question_count": direct_question_count,
-        "direct_mention_count": direct_mention_count,
-        "reply_to_bot_count": reply_to_bot_count,
-        "attention_required_count": attention_required_count,
-        "oldest_pending_at": oldest.isoformat() if oldest else None,
-        "oldest_pending_age_seconds": oldest_age_seconds,
-        "reply_due": bool(
-            attention_required_count > 0 and config["reply"].get("enabled") is True
-        ),
-        "local_private_content_returned": False,
-    }
+    return "reply_to_bot" if kind == "reply_to_operator" else kind
 
 
 def ingest_lark_event_inbox(

--- a/loopx/capabilities/lark/event_inbox.py
+++ b/loopx/capabilities/lark/event_inbox.py
@@ -7,6 +7,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Mapping, Sequence
 
 from ...control_plane.work_items.operator_inbox import (
+    LARK_OPERATOR_INBOX_SOURCE_CONTRACT,
     operator_inbox_attention_kind,
     project_operator_inbox_urgency,
 )
@@ -197,9 +198,7 @@ def project_lark_event_inbox_urgency(
     urgency = project_operator_inbox_urgency(
         project=project,
         config_path=config_path,
-        config_schema_version=CONFIG_SCHEMA_VERSION,
-        event_schema_version=EVENT_SCHEMA_VERSION,
-        processed_schema_version=PROCESSED_SCHEMA_VERSION,
+        source_contract=LARK_OPERATOR_INBOX_SOURCE_CONTRACT,
         now=now,
     )
     urgency["schema_version"] = "lark_event_inbox_urgency_v0"

--- a/loopx/control_plane/quota/goal_boundary.py
+++ b/loopx/control_plane/quota/goal_boundary.py
@@ -78,7 +78,7 @@ def goal_boundary(
     *,
     agent_id: str | None = None,
     registry_path: Path | None = None,
-    lark_event_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
+    operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
     reward_memory_experiment_status: Mapping[str, Any] | None = None,
 ) -> dict[str, Any] | None:
     boundary: dict[str, Any] = {}
@@ -168,12 +168,20 @@ def goal_boundary(
         }
         project = Path(str(goal.get("repo") or "")).expanduser()
         config_path = str(lark_event_inbox.get("config_path") or "").strip()
-        if project.is_dir() and config_path and lark_event_inbox_urgency_projector:
+        if project.is_dir() and config_path and operator_inbox_urgency_projector:
             try:
-                inbox_capability["urgency"] = lark_event_inbox_urgency_projector(
+                urgency = operator_inbox_urgency_projector(
                     project=project,
                     config_path=config_path,
+                    config_schema_version="lark_event_inbox_config_v0",
+                    event_schema_version="lark_event_inbox_event_v0",
+                    processed_schema_version="lark_event_inbox_processed_v0",
                 )
+                urgency["schema_version"] = "lark_event_inbox_urgency_v0"
+                urgency["reply_to_bot_count"] = urgency.pop(
+                    "reply_to_operator_count", 0
+                )
+                inbox_capability["urgency"] = urgency
             except (OSError, ValueError):
                 inbox_capability["urgency"] = {
                     "schema_version": "lark_event_inbox_urgency_v0",

--- a/loopx/control_plane/quota/goal_boundary.py
+++ b/loopx/control_plane/quota/goal_boundary.py
@@ -16,6 +16,7 @@ from ..todos.contract import (
     normalize_required_capabilities,
     normalize_required_write_scopes,
 )
+from ..work_items.operator_inbox import LARK_OPERATOR_INBOX_SOURCE_CONTRACT
 
 
 def quota_execution_profile_summary(value: Any) -> dict[str, Any] | None:
@@ -173,9 +174,7 @@ def goal_boundary(
                 urgency = operator_inbox_urgency_projector(
                     project=project,
                     config_path=config_path,
-                    config_schema_version="lark_event_inbox_config_v0",
-                    event_schema_version="lark_event_inbox_event_v0",
-                    processed_schema_version="lark_event_inbox_processed_v0",
+                    source_contract=LARK_OPERATOR_INBOX_SOURCE_CONTRACT,
                 )
                 urgency["schema_version"] = "lark_event_inbox_urgency_v0"
                 urgency["reply_to_bot_count"] = urgency.pop(

--- a/loopx/control_plane/work_items/operator_inbox.py
+++ b/loopx/control_plane/work_items/operator_inbox.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import re
 from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -12,6 +13,36 @@ OPERATOR_INBOX_URGENCY_SCHEMA_VERSION = "operator_inbox_urgency_v0"
 CAPTURE_SCOPES = {"addressed_only", "configured_chat_all"}
 QUESTION_SIGNAL_PATTERN = re.compile(
     r"[?？]|(?:请问|怎么|怎样|为何|为什么|是不是|是否|能否|可以吗|行吗|结论呢|回复吗)"
+)
+
+
+@dataclass(frozen=True)
+class OperatorInboxSourceContract:
+    config_schema_version: str
+    event_schema_version: str
+    processed_schema_version: str
+    message_id_pattern: re.Pattern[str]
+    event_id_pattern: re.Pattern[str]
+    sender_profile_pattern: re.Pattern[str]
+    required_sender_identity: str
+    reply_flag_field: str
+    operator_display_name_field: str
+    destination_field: str
+    destination_pattern: re.Pattern[str]
+
+
+LARK_OPERATOR_INBOX_SOURCE_CONTRACT = OperatorInboxSourceContract(
+    config_schema_version="lark_event_inbox_config_v0",
+    event_schema_version="lark_event_inbox_event_v0",
+    processed_schema_version="lark_event_inbox_processed_v0",
+    message_id_pattern=re.compile(r"om_[A-Za-z0-9_-]+"),
+    event_id_pattern=re.compile(r"[A-Za-z0-9:_-]{1,200}"),
+    sender_profile_pattern=re.compile(r"[A-Za-z0-9._-]{1,100}"),
+    required_sender_identity="bot",
+    reply_flag_field="reply_to_bot",
+    operator_display_name_field="bot_display_name",
+    destination_field="chat_id",
+    destination_pattern=re.compile(r"oc_[A-Za-z0-9_-]+"),
 )
 
 
@@ -42,19 +73,25 @@ def _read_mapping(path: Path) -> Mapping[str, Any]:
 def _pending_events(
     inbox: Path,
     *,
-    event_schema_version: str,
-    processed_schema_version: str,
+    source_contract: OperatorInboxSourceContract,
 ) -> list[dict[str, Any]]:
     processed_path = inbox / "processed.json"
     processed: set[str] = set()
     if processed_path.is_file():
         processed_payload = _read_mapping(processed_path)
-        if processed_payload.get("schema_version") != processed_schema_version:
+        if (
+            processed_payload.get("schema_version")
+            != source_contract.processed_schema_version
+        ):
             raise ValueError("operator inbox processed-state schema is invalid")
         message_ids = processed_payload.get("message_ids")
         if not isinstance(message_ids, list):
             raise ValueError("operator inbox processed message_ids must be a list")
-        processed = {str(value).strip() for value in message_ids if str(value).strip()}
+        processed = {
+            str(value)
+            for value in message_ids
+            if source_contract.message_id_pattern.fullmatch(str(value))
+        }
 
     events: dict[str, dict[str, Any]] = {}
     for path in sorted(inbox.glob("*.json")) if inbox.is_dir() else []:
@@ -65,10 +102,13 @@ def _pending_events(
         except (OSError, ValueError, json.JSONDecodeError):
             continue
         message_id = str(payload.get("message_id") or "").strip()
+        event_id = str(payload.get("event_id") or message_id).strip()
+        parent_id = str(payload.get("parent_id") or "").strip()
         content = " ".join(str(payload.get("content") or "").split())[:1200]
         if (
-            payload.get("schema_version") != event_schema_version
-            or not message_id
+            payload.get("schema_version") != source_contract.event_schema_version
+            or not source_contract.message_id_pattern.fullmatch(message_id)
+            or not source_contract.event_id_pattern.fullmatch(event_id)
             or not content
         ):
             continue
@@ -81,8 +121,8 @@ def _pending_events(
                 "reply_context_verified": payload.get("reply_context_verified") is True,
                 "reply_to_operator": bool(
                     payload.get("reply_context_verified") is True
-                    and str(payload.get("parent_id") or "").strip()
-                    and payload.get("reply_to_bot") is True
+                    and source_contract.message_id_pattern.fullmatch(parent_id)
+                    and payload.get(source_contract.reply_flag_field) is True
                 ),
             },
         )
@@ -143,9 +183,7 @@ def project_operator_inbox_urgency(
     *,
     project: str | Path,
     config_path: str | Path,
-    config_schema_version: str,
-    event_schema_version: str,
-    processed_schema_version: str,
+    source_contract: OperatorInboxSourceContract,
     now: datetime | None = None,
 ) -> dict[str, Any]:
     """Project provider-owned inbox files into a content-free control-plane read model."""
@@ -158,9 +196,34 @@ def project_operator_inbox_urgency(
     except ValueError as exc:
         raise ValueError("operator inbox config must stay inside the project") from exc
     config = _read_mapping(path)
-    if config.get("schema_version") != config_schema_version:
+    if config.get("schema_version") != source_contract.config_schema_version:
         raise ValueError("operator inbox config schema is invalid")
     enabled = config.get("enabled") is True
+    capture_scope = str(config.get("capture_scope") or "addressed_only").strip()
+    if capture_scope not in CAPTURE_SCOPES:
+        raise ValueError("operator inbox capture_scope is invalid")
+    reply = config.get("reply")
+    if reply is not None and not isinstance(reply, Mapping):
+        raise ValueError("operator inbox reply config must be an object")
+    reply = reply if isinstance(reply, Mapping) else {}
+    reply_enabled = reply.get("enabled") is True
+    operator_display_name = " ".join(
+        str(reply.get(source_contract.operator_display_name_field) or "").split()
+    )[:100]
+    sender_profile = str(reply.get("sender_profile") or "").strip()
+    sender_identity = str(reply.get("sender_identity") or "").strip()
+    destination = str(reply.get(source_contract.destination_field) or "").strip()
+    if reply_enabled and (
+        capture_scope != "configured_chat_all"
+        or not source_contract.sender_profile_pattern.fullmatch(sender_profile)
+        or sender_profile.lower() == "default"
+        or sender_identity != source_contract.required_sender_identity
+        or not operator_display_name
+        or not source_contract.destination_pattern.fullmatch(destination)
+    ):
+        raise ValueError(
+            "enabled operator inbox reply does not satisfy its source contract"
+        )
     if not enabled:
         return {
             "schema_version": OPERATOR_INBOX_URGENCY_SCHEMA_VERSION,
@@ -174,26 +237,10 @@ def project_operator_inbox_urgency(
             "local_private_content_returned": False,
         }
 
-    capture_scope = str(config.get("capture_scope") or "addressed_only").strip()
-    if capture_scope not in CAPTURE_SCOPES:
-        raise ValueError("operator inbox capture_scope is invalid")
-    reply = config.get("reply")
-    reply = reply if isinstance(reply, Mapping) else {}
-    reply_enabled = reply.get("enabled") is True
-    operator_display_name = " ".join(
-        str(
-            reply.get("bot_display_name") or reply.get("operator_display_name") or ""
-        ).split()
-    )[:100]
-    if reply_enabled and not operator_display_name:
-        raise ValueError(
-            "enabled operator inbox reply requires an operator display name"
-        )
     inbox = _safe_inbox_path(root, config.get("inbox_dir"))
     pending = _pending_events(
         inbox,
-        event_schema_version=event_schema_version,
-        processed_schema_version=processed_schema_version,
+        source_contract=source_contract,
     )
     kinds = [
         operator_inbox_attention_kind(

--- a/loopx/control_plane/work_items/operator_inbox.py
+++ b/loopx/control_plane/work_items/operator_inbox.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+OPERATOR_INBOX_URGENCY_SCHEMA_VERSION = "operator_inbox_urgency_v0"
+CAPTURE_SCOPES = {"addressed_only", "configured_chat_all"}
+QUESTION_SIGNAL_PATTERN = re.compile(
+    r"[?？]|(?:请问|怎么|怎样|为何|为什么|是不是|是否|能否|可以吗|行吗|结论呢|回复吗)"
+)
+
+
+def _safe_inbox_path(project: Path, raw_path: object) -> Path:
+    relative = PurePosixPath(str(raw_path or "").strip().replace("\\", "/"))
+    if (
+        not relative.parts
+        or relative.is_absolute()
+        or ".." in relative.parts
+        or relative.parts[:2] != (".loopx", "inbox")
+    ):
+        raise ValueError("operator inbox path must stay under .loopx/inbox")
+    resolved = (project / Path(*relative.parts)).resolve()
+    try:
+        resolved.relative_to(project)
+    except ValueError as exc:
+        raise ValueError("operator inbox path escapes the project") from exc
+    return resolved
+
+
+def _read_mapping(path: Path) -> Mapping[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"operator inbox JSON must be an object: {path.name}")
+    return payload
+
+
+def _pending_events(
+    inbox: Path,
+    *,
+    event_schema_version: str,
+    processed_schema_version: str,
+) -> list[dict[str, Any]]:
+    processed_path = inbox / "processed.json"
+    processed: set[str] = set()
+    if processed_path.is_file():
+        processed_payload = _read_mapping(processed_path)
+        if processed_payload.get("schema_version") != processed_schema_version:
+            raise ValueError("operator inbox processed-state schema is invalid")
+        message_ids = processed_payload.get("message_ids")
+        if not isinstance(message_ids, list):
+            raise ValueError("operator inbox processed message_ids must be a list")
+        processed = {str(value).strip() for value in message_ids if str(value).strip()}
+
+    events: dict[str, dict[str, Any]] = {}
+    for path in sorted(inbox.glob("*.json")) if inbox.is_dir() else []:
+        if path.name == "processed.json":
+            continue
+        try:
+            payload = _read_mapping(path)
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
+        message_id = str(payload.get("message_id") or "").strip()
+        content = " ".join(str(payload.get("content") or "").split())[:1200]
+        if (
+            payload.get("schema_version") != event_schema_version
+            or not message_id
+            or not content
+        ):
+            continue
+        events.setdefault(
+            message_id,
+            {
+                "message_id": message_id,
+                "create_time": str(payload.get("create_time") or "")[:40],
+                "content": content,
+                "reply_context_verified": payload.get("reply_context_verified") is True,
+                "reply_to_operator": bool(
+                    payload.get("reply_context_verified") is True
+                    and str(payload.get("parent_id") or "").strip()
+                    and payload.get("reply_to_bot") is True
+                ),
+            },
+        )
+    return [
+        event for message_id, event in events.items() if message_id not in processed
+    ]
+
+
+def _parse_event_time(value: object) -> datetime | None:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    if raw.isdigit():
+        number = int(raw)
+        if number > 10_000_000_000:
+            number //= 1000
+        try:
+            return datetime.fromtimestamp(number, tz=timezone.utc)
+        except (OverflowError, OSError, ValueError):
+            return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def operator_inbox_attention_kind(
+    event: Mapping[str, Any],
+    *,
+    operator_display_name: str,
+    capture_scope: str,
+) -> str | None:
+    if (
+        event.get("reply_context_verified") is True
+        and event.get("reply_to_operator") is True
+    ):
+        return "reply_to_operator"
+    content = str(event.get("content") or "")
+    folded = content.casefold()
+    operator_name = " ".join(operator_display_name.split()).casefold()
+    explicit_mention = bool(
+        operator_name and "@" in content and operator_name in folded
+    )
+    loopx_mention = "@" in content and "loopx" in folded
+    if capture_scope != "addressed_only" and not explicit_mention and not loopx_mention:
+        return None
+    if QUESTION_SIGNAL_PATTERN.search(content):
+        return "direct_question"
+    if explicit_mention or loopx_mention:
+        return "direct_mention"
+    return None
+
+
+def project_operator_inbox_urgency(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    config_schema_version: str,
+    event_schema_version: str,
+    processed_schema_version: str,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Project provider-owned inbox files into a content-free control-plane read model."""
+
+    root = Path(project).expanduser().resolve()
+    path = Path(config_path).expanduser()
+    path = (path if path.is_absolute() else root / path).resolve()
+    try:
+        path.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("operator inbox config must stay inside the project") from exc
+    config = _read_mapping(path)
+    if config.get("schema_version") != config_schema_version:
+        raise ValueError("operator inbox config schema is invalid")
+    enabled = config.get("enabled") is True
+    if not enabled:
+        return {
+            "schema_version": OPERATOR_INBOX_URGENCY_SCHEMA_VERSION,
+            "enabled": False,
+            "pending_count": 0,
+            "direct_question_count": 0,
+            "direct_mention_count": 0,
+            "reply_to_operator_count": 0,
+            "attention_required_count": 0,
+            "reply_due": False,
+            "local_private_content_returned": False,
+        }
+
+    capture_scope = str(config.get("capture_scope") or "addressed_only").strip()
+    if capture_scope not in CAPTURE_SCOPES:
+        raise ValueError("operator inbox capture_scope is invalid")
+    reply = config.get("reply")
+    reply = reply if isinstance(reply, Mapping) else {}
+    reply_enabled = reply.get("enabled") is True
+    operator_display_name = " ".join(
+        str(
+            reply.get("bot_display_name") or reply.get("operator_display_name") or ""
+        ).split()
+    )[:100]
+    if reply_enabled and not operator_display_name:
+        raise ValueError(
+            "enabled operator inbox reply requires an operator display name"
+        )
+    inbox = _safe_inbox_path(root, config.get("inbox_dir"))
+    pending = _pending_events(
+        inbox,
+        event_schema_version=event_schema_version,
+        processed_schema_version=processed_schema_version,
+    )
+    kinds = [
+        operator_inbox_attention_kind(
+            event,
+            operator_display_name=operator_display_name,
+            capture_scope=capture_scope,
+        )
+        for event in pending
+    ]
+    direct_question_count = kinds.count("direct_question")
+    direct_mention_count = kinds.count("direct_mention")
+    reply_to_operator_count = kinds.count("reply_to_operator")
+    attention_required_count = (
+        direct_question_count + direct_mention_count + reply_to_operator_count
+    )
+    parsed_times = [
+        parsed
+        for event in pending
+        if (parsed := _parse_event_time(event.get("create_time"))) is not None
+    ]
+    oldest = min(parsed_times) if parsed_times else None
+    current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    return {
+        "schema_version": OPERATOR_INBOX_URGENCY_SCHEMA_VERSION,
+        "enabled": True,
+        "thread_complete": capture_scope == "configured_chat_all",
+        "pending_count": len(pending),
+        "direct_question_count": direct_question_count,
+        "direct_mention_count": direct_mention_count,
+        "reply_to_operator_count": reply_to_operator_count,
+        "attention_required_count": attention_required_count,
+        "oldest_pending_at": oldest.isoformat() if oldest else None,
+        "oldest_pending_age_seconds": (
+            max(0, int((current - oldest).total_seconds())) if oldest else None
+        ),
+        "reply_due": bool(attention_required_count > 0 and reply_enabled),
+        "local_private_content_returned": False,
+    }

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -93,7 +93,7 @@ from .control_plane.quota.scheduler_ack import (
 from .control_plane.quota.selected_todo_projection import (
     selected_todo_projection as _selected_todo_projection,
 )
-from .capabilities.lark.event_inbox import project_lark_event_inbox_urgency as _project_lark_event_inbox_urgency
+from .control_plane.work_items.operator_inbox import project_operator_inbox_urgency as _project_operator_inbox_urgency
 from .capabilities.reward_memory.experiment import (
     resolve_reward_memory_experiment_from_status as _resolve_reward_memory_experiment_from_status,
 )
@@ -1317,7 +1317,7 @@ def build_quota_should_run(
             registry_path=(
                 Path(boundary_registry_value) if boundary_registry_value else None
             ),
-            lark_event_inbox_urgency_projector=_project_lark_event_inbox_urgency,
+            operator_inbox_urgency_projector=_project_operator_inbox_urgency,
             reward_memory_experiment_status=reward_memory_experiment_status,
         )
         workspace_guard = None

--- a/tests/architecture/test_control_plane_import_boundaries.py
+++ b/tests/architecture/test_control_plane_import_boundaries.py
@@ -8,6 +8,7 @@ from pathlib import Path
 PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "loopx"
 CONTROL_PLANE_ROOT = PACKAGE_ROOT / "control_plane"
 STATUS_MODULE = PACKAGE_ROOT / "status.py"
+QUOTA_MODULE = PACKAGE_ROOT / "quota.py"
 FORBIDDEN_DEPENDENCY_PREFIXES = (
     "loopx.benchmark_adapters",
     "loopx.capabilities",
@@ -95,3 +96,10 @@ def test_status_outward_dependency_debt_only_shrinks() -> None:
         "remove resolved loopx.status edges from STATUS_OUTWARD_DEPENDENCY_DEBT; "
         f"stale entries: {sorted(stale_debt)}"
     )
+
+
+def test_quota_operator_inbox_dependency_points_inward() -> None:
+    imports = _resolved_imports(QUOTA_MODULE)
+
+    assert "loopx.capabilities.lark.event_inbox" not in imports
+    assert "loopx.control_plane.work_items.operator_inbox" in imports


### PR DESCRIPTION
## Summary

- add a provider-neutral operator-inbox urgency read model under the control plane
- make quota depend only on that read model and keep the Lark projector as a temporary compatibility delegate
- preserve Lark urgency/work-lane output and source validation through an explicit source contract
- document the extension boundary and enforce the import direction with an architecture test

## Validation

- `python -m pytest -q` (`748 passed, 2 skipped`)
- focused Lark inbox, collector lifecycle, configure-goal, architecture, and line-budget smokes
- Ruff checks for changed non-hot modules
- `loopx canary premerge --from-git-diff --tier standard --no-progress` (passed; 4 direct checks, 9 catalog canaries, 8 risk-profile smokes, public boundary; zero failures/warnings/manual holds)

## Compatibility

No CLI arguments, registry keys, lane names, or public quota output fields change. The Lark compatibility delegate retains `lark_event_inbox_urgency_v0` and `reply_to_bot_count` while quota imports only the provider-neutral contract.