### PR TITLE
fix: record reward memory execution evidence

### DIFF
--- a/examples/reward-memory-recall-application-smoke.py
+++ b/examples/reward-memory-recall-application-smoke.py
@@ -22,6 +22,7 @@ from loopx.capabilities.context_providers.openviking import (  # noqa: E402
     OpenVikingContextProvider,
 )
 from loopx.capabilities.issue_fix.reward_memory import (  # noqa: E402
+    _execution_evidence,
     run_issue_fix_patch_planning_reward_memory,
     run_issue_fix_reviewer_artifact_automatic_reward_memory,
     run_issue_fix_reviewer_artifact_reward_memory,
@@ -402,6 +403,26 @@ def main() -> None:
         "status",
         "search",
         "read",
+    ]
+    incomplete_receipt_evidence = _execution_evidence(
+        {
+            "query_kind": "business_recall",
+            "provider_call_count": 0,
+            "result_readback_verified": True,
+        },
+        {
+            "receipt": {
+                **receipt,
+                "provider_call_count": 0,
+                "query_evidence": [],
+            }
+        },
+    )
+    assert incomplete_receipt_evidence["verified_result"] == "provider_not_called"
+    assert incomplete_receipt_evidence["unknowns"] == [
+        "provider_result_unknown",
+        "query_evidence_unknown",
+        "memory_application_effect_unknown",
     ]
 
     reviewer_surface = "reviewer_artifact.summary"

--- a/examples/reward-memory-recall-application-smoke.py
+++ b/examples/reward-memory-recall-application-smoke.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import subprocess
 import sys
 from collections.abc import Mapping
 from pathlib import Path
@@ -16,6 +17,9 @@ sys.path.insert(0, str(REPO_ROOT))
 from loopx.capabilities.context_providers.base import (  # noqa: E402
     ContextProviderItem,
     ContextProviderRetrieval,
+)
+from loopx.capabilities.context_providers.openviking import (  # noqa: E402
+    OpenVikingContextProvider,
 )
 from loopx.capabilities.issue_fix.reward_memory import (  # noqa: E402
     run_issue_fix_patch_planning_reward_memory,
@@ -76,11 +80,56 @@ class FakeProvider:
         raise AssertionError("Stage-3 recall must not call provider sync")
 
 
-def corpus(*, corpus_id: str, class_id: str, surface: str) -> dict[str, Any]:
+class OpenVikingRewardMemoryRunner:
+    """Exercise the real provider adapter without requiring a live daemon."""
+
+    def __init__(self, *, resource_ref: str, content: str) -> None:
+        self.resource_ref = resource_ref
+        self.content = content
+        self.calls: list[list[str]] = []
+
+    def __call__(
+        self, command: list[str], **_kwargs: Any
+    ) -> subprocess.CompletedProcess[str]:
+        self.calls.append(command)
+        args = command[1:]
+        if args == ["--version"]:
+            stdout = "openviking 0.4.9.dev11\n"
+        elif args[:2] == ["status", "-o"]:
+            stdout = json.dumps({"status": "healthy"})
+        elif args[0] == "search":
+            stdout = json.dumps(
+                {
+                    "result": {
+                        "resources": [
+                            {
+                                "uri": self.resource_ref,
+                                "abstract": "Bounded reviewed reward-memory policy.",
+                                "score": 0.93,
+                            }
+                        ]
+                    }
+                }
+            )
+        elif args[0] == "read":
+            assert args[1] == self.resource_ref
+            stdout = json.dumps({"result": {"content": self.content}})
+        else:
+            raise AssertionError(command)
+        return subprocess.CompletedProcess(command, 0, stdout=stdout)
+
+
+def corpus(
+    *,
+    corpus_id: str,
+    class_id: str,
+    surface: str,
+    provider_id: str = "fake_provider",
+) -> dict[str, Any]:
     return {
         "corpus_id": corpus_id,
         "class_id": class_id,
-        "provider_id": "fake_provider",
+        "provider_id": provider_id,
         "owner_ref": "provider_scope_owner",
         "source_of_truth": "reviewed_owner_feedback",
         "read_authority": "module_scoped",
@@ -180,10 +229,10 @@ def item(active_record: Mapping[str, Any], ref: str) -> ContextProviderItem:
     )
 
 
-def binding(corpus_id: str) -> dict[str, Any]:
+def binding(corpus_id: str, *, provider_id: str = "fake_provider") -> dict[str, Any]:
     return {
         "corpus_id": corpus_id,
-        "provider_id": "fake_provider",
+        "provider_id": provider_id,
         "actor_peer_id": "project-example",
         "namespace": "reward_memory",
         "scope_ref": SCOPE_REF,
@@ -213,6 +262,7 @@ def main() -> None:
         corpus_id="openviking_patch_policy",
         class_id="hard_policy",
         surface=issue_surface,
+        provider_id="openviking",
     )
     peer_scope = "viking://user/example/peers/project-example/memories"
     peer_corpus = issue_corpus | {
@@ -241,7 +291,9 @@ def main() -> None:
         read_authority_checkpoint=checkpoint("openviking_patch_policy", issue_surface),
     )
     for invalid_actor in (None, "project-other"):
-        invalid_binding = binding("openviking_patch_policy") | {
+        invalid_binding = binding(
+            "openviking_patch_policy", provider_id="openviking"
+        ) | {
             "scope_ref": peer_scope,
             "actor_peer_id": invalid_actor,
         }
@@ -270,8 +322,14 @@ def main() -> None:
         activated_at=OBSERVED_AT,
     )
     assert active_issue["provider_write_performed"] is False
-    issue_provider = FakeProvider(
-        (item(active_issue, "viking://resources/reward-memory/example/policy.json"),)
+    issue_resource_ref = "viking://resources/reward-memory/example/policy.json"
+    issue_runner = OpenVikingRewardMemoryRunner(
+        resource_ref=issue_resource_ref,
+        content=json.dumps(active_issue, ensure_ascii=False),
+    )
+    issue_provider = OpenVikingContextProvider(
+        executable="ov-contract",
+        runner=issue_runner,
     )
 
     def apply_plan(base: Any, items: Any) -> dict[str, Any]:
@@ -309,7 +367,7 @@ def main() -> None:
         },
         conflict_state="clear",
         read_authority_checkpoint=checkpoint("openviking_patch_policy", issue_surface),
-        provider_binding=binding("openviking_patch_policy"),
+        provider_binding=binding("openviking_patch_policy", provider_id="openviking"),
         application_id="issue-fix:example:patch-plan",
         artifact_ref="patch-plan:example",
         apply_memory=apply_plan,
@@ -325,7 +383,26 @@ def main() -> None:
     assert receipt["current_artifact_verified"] is True
     assert receipt["result_readback_verified"] is True
     assert len(receipt["memory_ref_digests"]) == 1
+    assert receipt["query_kind"] == "business_recall"
+    assert receipt["provider_call_count"] == 1
+    assert len(receipt["query_evidence"]) == 1
+    evidence = issue_result["execution_evidence"]
+    assert evidence["verified_result"] == "memory_applied"
+    assert evidence["unknowns"] == []
+    minimum = evidence["minimum_evidence"]
+    assert minimum["query_kind"] == "business_recall"
+    assert minimum["provider_call_count"] == 1
+    assert minimum["exact_readback_verified"] is True
+    assert minimum["application_receipt"]["outcome"] == "applied"
+    assert len(minimum["query_evidence"][0]["query_digest"]) == 16
+    assert minimum["query_evidence"][0]["exact_query_exposed"] is False
     assert issue_result["automatic_recall"] is False
+    assert [command[1] for command in issue_runner.calls] == [
+        "--version",
+        "status",
+        "search",
+        "read",
+    ]
 
     reviewer_surface = "reviewer_artifact.summary"
     reviewer_corpus = corpus(
@@ -564,7 +641,7 @@ def main() -> None:
     blocked_provider = FakeProvider(())
     blocked_session = execute_reward_memory_recall(
         blocked_request,
-        provider_binding=binding("openviking_patch_policy"),
+        provider_binding=binding("openviking_patch_policy", provider_id="openviking"),
         provider=blocked_provider,
     )
     assert blocked_session.public_packet["status"] == "guard_blocked"
@@ -587,7 +664,7 @@ def main() -> None:
         },
         conflict_state="clear",
         read_authority_checkpoint=checkpoint("openviking_patch_policy", issue_surface),
-        provider_binding=binding("openviking_patch_policy"),
+        provider_binding=binding("openviking_patch_policy", provider_id="openviking"),
         application_id="issue-fix:example:unavailable",
         apply_memory=apply_plan,
         provider=unavailable_provider,
@@ -597,6 +674,16 @@ def main() -> None:
     assert unavailable_result["recall"]["provider_failure_is_user_gate"] is False
     assert unavailable_result["recall"]["setup_hints"]["configure"]
     assert unavailable_result["application"]["fail_open_preserved_base"] is True
+    unavailable_evidence = unavailable_result["execution_evidence"]
+    assert unavailable_evidence["verified_result"] == (
+        "provider_called_without_verified_recall"
+    )
+    assert unavailable_evidence["unknowns"] == [
+        "exact_recall_readback_unknown",
+        "memory_application_effect_unknown",
+    ]
+    assert unavailable_evidence["minimum_evidence"]["provider_call_count"] == 1
+    assert unavailable_evidence["minimum_evidence"]["exact_readback_verified"] is False
 
     failed_application = apply_reward_memory_recall(
         {"change_scope": "memory_retrieval"},
@@ -623,7 +710,9 @@ def main() -> None:
                     "openviking_patch_policy", issue_surface
                 ),
             ),
-            provider_binding=binding("openviking_patch_policy"),
+            provider_binding=binding(
+                "openviking_patch_policy", provider_id="openviking"
+            ),
             provider=issue_provider,
         ),
         application_id="issue-fix:example:failed-application",

--- a/loopx/capabilities/issue_fix/reward_memory.py
+++ b/loopx/capabilities/issue_fix/reward_memory.py
@@ -43,6 +43,9 @@ ISSUE_FIX_REVIEWER_NOTIFICATION_POLICY_SCHEMA_VERSION = (
     "issue_fix_reviewer_notification_delivery_policy_v0"
 )
 ISSUE_FIX_REWARD_MEMORY_EVENT_SCHEMA_VERSION = "issue_fix_reward_memory_event_v0"
+ISSUE_FIX_REWARD_MEMORY_EXECUTION_EVIDENCE_SCHEMA_VERSION = (
+    "issue_fix_reward_memory_execution_evidence_v0"
+)
 
 _LOCAL_TIME_PATTERN = re.compile(r"(?:[01]\d|2[0-3]):[0-5]\d")
 
@@ -68,6 +71,77 @@ _GUARD_FIELDS = {
     "conflict_state",
     "current_artifact_verified",
 }
+
+
+def _execution_evidence(
+    recall: Mapping[str, Any] | None,
+    application: Mapping[str, Any] | None = None,
+    *,
+    query_kind: str | None = None,
+) -> dict[str, Any]:
+    """Build the minimum evidence needed for conservative outcome reporting."""
+
+    recall_packet = recall if isinstance(recall, Mapping) else {}
+    application_packet = application if isinstance(application, Mapping) else {}
+    receipt_raw = application_packet.get("receipt")
+    receipt = receipt_raw if isinstance(receipt_raw, Mapping) else None
+    provider_call_count = int(recall_packet.get("provider_call_count") or 0)
+    effective_query_kind = str(
+        query_kind or recall_packet.get("query_kind") or "business_recall"
+    )
+    exact_readback_verified = recall_packet.get("result_readback_verified") is True
+    receipt_verified = bool(
+        receipt
+        and receipt.get("schema_version") == "reward_memory_application_receipt_v0"
+        and receipt.get("outcome") == "applied"
+        and receipt.get("result_readback_verified") is True
+        and receipt.get("current_artifact_verified") is True
+        and receipt.get("memory_ref_digests")
+    )
+    if effective_query_kind == "ingest_verification" and exact_readback_verified:
+        verified_result = "ingest_exact_readback_verified"
+    elif effective_query_kind == "ingest_verification" and provider_call_count:
+        verified_result = "ingest_provider_called_without_exact_readback"
+    elif effective_query_kind == "ingest_verification":
+        verified_result = "ingest_provider_not_called"
+    elif receipt_verified:
+        verified_result = "memory_applied"
+    elif exact_readback_verified:
+        verified_result = "memory_recalled_not_applied"
+    elif provider_call_count:
+        verified_result = "provider_called_without_verified_recall"
+    else:
+        verified_result = "provider_not_called"
+
+    unknowns: list[str] = []
+    if provider_call_count == 0:
+        unknowns.append("provider_result_unknown")
+    if not exact_readback_verified:
+        unknowns.append("exact_recall_readback_unknown")
+    if (
+        effective_query_kind == "business_recall"
+        and application is not None
+        and not receipt_verified
+    ):
+        unknowns.append("memory_application_effect_unknown")
+
+    return {
+        "schema_version": ISSUE_FIX_REWARD_MEMORY_EXECUTION_EVIDENCE_SCHEMA_VERSION,
+        "verified_result": verified_result,
+        "unknowns": unknowns,
+        "minimum_evidence": {
+            "query_kind": effective_query_kind,
+            "query_evidence": list(recall_packet.get("query_evidence") or []),
+            "provider_call_count": provider_call_count,
+            "exact_readback_verified": exact_readback_verified,
+            "application_receipt": dict(receipt) if receipt is not None else None,
+        },
+        "claim_policy": (
+            "claim_recalled_only_after_exact_readback_and_claim_applied_only_after_"
+            "verified_application_receipt"
+        ),
+        "raw_content_captured": False,
+    }
 
 
 def _strict_object(
@@ -141,12 +215,17 @@ def ingest_issue_fix_reward_memory_event(
         provider=provider,
     )
     summary = public_safe_compact_text(raw.get("content_summary"), limit=500)
+    readback_raw = result.get("readback")
+    readback = readback_raw if isinstance(readback_raw, Mapping) else None
     return result | {
         "adapter_schema_version": ISSUE_FIX_REWARD_MEMORY_EVENT_SCHEMA_VERSION,
         "issue_ref": public_safe_compact_text(raw.get("issue_ref"), limit=160),
         "event_summary_digest": hashlib.sha256(summary.encode("utf-8")).hexdigest()[
             :16
         ],
+        "execution_evidence": _execution_evidence(
+            readback, query_kind="ingest_verification"
+        ),
         "next_issue_fix_call": "run_issue_fix_patch_planning_reward_memory",
     }
 
@@ -192,6 +271,7 @@ def run_issue_fix_patch_planning_reward_memory(
             "surface_id": ISSUE_FIX_PATCH_PLANNING_SURFACE,
             "revision_ref": revision_ref,
             "mode": mode,
+            "query_kind": "business_recall",
             "queries": queries,
             "limit": limit,
             "observed_at": observed_at,
@@ -216,6 +296,9 @@ def run_issue_fix_patch_planning_reward_memory(
         "patch_plan": dict(output),
         "recall": shared["recall"],
         "application": shared["application"],
+        "execution_evidence": _execution_evidence(
+            shared["recall"], shared["application"]
+        ),
         "shared_core": shared["shared_core"],
         "adapter_role": "field_mapping_only_model_owns_patch_tradeoffs",
         "automatic_recall": False,
@@ -583,9 +666,7 @@ def _reviewer_notification_before_send_applier(
             return {
                 "outcome": "ignored",
                 "output": dict(base),
-                "memory_refs": [
-                    ref for _, refs in policies.values() for ref in refs
-                ],
+                "memory_refs": [ref for _, refs in policies.values() for ref in refs],
                 "reasoning_summary": (
                     "No single active structured reviewer delivery policy was recalled."
                 ),
@@ -644,9 +725,7 @@ def reviewer_notification_before_send_gate(
     ):
         reasons.append("current_artifact_identity_mismatch")
     try:
-        policy = _reviewer_notification_delivery_policy(
-            decision.get("delivery_policy")
-        )
+        policy = _reviewer_notification_delivery_policy(decision.get("delivery_policy"))
     except ValueError:
         policy = None
         reasons.append("delivery_policy_invalid")
@@ -756,9 +835,7 @@ def run_issue_fix_reviewer_notification_automatic_reward_memory(
     )
     result = {
         "ok": True,
-        "schema_version": (
-            ISSUE_FIX_REVIEWER_NOTIFICATION_APPLICATION_SCHEMA_VERSION
-        ),
+        "schema_version": (ISSUE_FIX_REVIEWER_NOTIFICATION_APPLICATION_SCHEMA_VERSION),
         "surface_id": ISSUE_FIX_REVIEWER_NOTIFICATION_SURFACE,
         "decision": dict(output),
         "recall": attempts[-1] if attempts else {"status": automatic["status"]},

--- a/loopx/capabilities/issue_fix/reward_memory.py
+++ b/loopx/capabilities/issue_fix/reward_memory.py
@@ -90,23 +90,43 @@ def _execution_evidence(
         query_kind or recall_packet.get("query_kind") or "business_recall"
     )
     exact_readback_verified = recall_packet.get("result_readback_verified") is True
+    query_evidence_raw = recall_packet.get("query_evidence")
+    query_evidence = (
+        [dict(item) for item in query_evidence_raw if isinstance(item, Mapping)]
+        if isinstance(query_evidence_raw, (list, tuple))
+        else []
+    )
+    query_evidence_verified = bool(query_evidence) and all(
+        len(str(item.get("query_digest") or "")) == 16
+        and bool(str(item.get("query_summary") or "").strip())
+        and item.get("exact_query_exposed") is False
+        for item in query_evidence
+    )
+    provider_recall_verified = bool(
+        provider_call_count > 0 and exact_readback_verified and query_evidence_verified
+    )
     receipt_verified = bool(
         receipt
+        and effective_query_kind == "business_recall"
         and receipt.get("schema_version") == "reward_memory_application_receipt_v0"
+        and receipt.get("query_kind") == "business_recall"
+        and receipt.get("query_evidence") == query_evidence
+        and receipt.get("provider_call_count") == provider_call_count
+        and provider_recall_verified
         and receipt.get("outcome") == "applied"
         and receipt.get("result_readback_verified") is True
         and receipt.get("current_artifact_verified") is True
         and receipt.get("memory_ref_digests")
     )
-    if effective_query_kind == "ingest_verification" and exact_readback_verified:
+    if effective_query_kind == "ingest_verification" and provider_recall_verified:
         verified_result = "ingest_exact_readback_verified"
     elif effective_query_kind == "ingest_verification" and provider_call_count:
-        verified_result = "ingest_provider_called_without_exact_readback"
+        verified_result = "ingest_provider_called_without_verified_readback"
     elif effective_query_kind == "ingest_verification":
         verified_result = "ingest_provider_not_called"
     elif receipt_verified:
         verified_result = "memory_applied"
-    elif exact_readback_verified:
+    elif provider_recall_verified:
         verified_result = "memory_recalled_not_applied"
     elif provider_call_count:
         verified_result = "provider_called_without_verified_recall"
@@ -116,6 +136,8 @@ def _execution_evidence(
     unknowns: list[str] = []
     if provider_call_count == 0:
         unknowns.append("provider_result_unknown")
+    if not query_evidence_verified:
+        unknowns.append("query_evidence_unknown")
     if not exact_readback_verified:
         unknowns.append("exact_recall_readback_unknown")
     if (
@@ -131,14 +153,14 @@ def _execution_evidence(
         "unknowns": unknowns,
         "minimum_evidence": {
             "query_kind": effective_query_kind,
-            "query_evidence": list(recall_packet.get("query_evidence") or []),
+            "query_evidence": query_evidence,
             "provider_call_count": provider_call_count,
             "exact_readback_verified": exact_readback_verified,
             "application_receipt": dict(receipt) if receipt is not None else None,
         },
         "claim_policy": (
-            "claim_recalled_only_after_exact_readback_and_claim_applied_only_after_"
-            "verified_application_receipt"
+            "claim_recalled_only_after_query_provider_call_and_exact_readback_and_"
+            "claim_applied_only_after_matching_verified_application_receipt"
         ),
         "raw_content_captured": False,
     }

--- a/loopx/capabilities/reward_memory/application.py
+++ b/loopx/capabilities/reward_memory/application.py
@@ -29,6 +29,7 @@ REWARD_MEMORY_APPLICATION_RECEIPT_SCHEMA_VERSION = (
 REWARD_MEMORY_APPLICATION_SCHEMA_VERSION = "reward_memory_application_v0"
 
 RECALL_MODES = {"function_boundary", "bounded_agentic_search"}
+RECALL_QUERY_KINDS = {"business_recall", "ingest_verification"}
 APPLICATION_OUTCOMES = {
     "applied",
     "ignored",
@@ -281,6 +282,21 @@ def _queries(raw: object, mode: str) -> list[dict[str, str]]:
     return result
 
 
+def _query_evidence(queries: Sequence[Mapping[str, str]]) -> list[dict[str, Any]]:
+    """Expose bounded query identity without persisting provider query text."""
+
+    return [
+        {
+            "query_digest": hashlib.sha256(item["query"].encode("utf-8")).hexdigest()[
+                :16
+            ],
+            "query_summary": item["query_summary"],
+            "exact_query_exposed": False,
+        }
+        for item in queries
+    ]
+
+
 def build_reward_memory_recall_request(
     corpus: Mapping[str, Any],
     request: Mapping[str, Any],
@@ -307,6 +323,11 @@ def build_reward_memory_recall_request(
         "observed_at": _observed_at(request.get("observed_at")),
         "conflict_state": str(request.get("conflict_state") or "").strip(),
     }
+    query_kind = str(request.get("query_kind") or "business_recall").strip()
+    if query_kind not in RECALL_QUERY_KINDS:
+        raise ValueError("query_kind must be business_recall or ingest_verification")
+    recall_request["query_kind"] = query_kind
+    recall_request["query_evidence"] = _query_evidence(recall_request["queries"])
     limit = recall_request["limit"]
     if (
         isinstance(limit, bool)
@@ -487,6 +508,8 @@ def execute_reward_memory_recall(
         "corpus_id": corpus["corpus_id"],
         "surface_id": request["surface_id"],
         "mode": request["mode"],
+        "query_kind": request["query_kind"],
+        "query_evidence": list(request["query_evidence"]),
         "provider_id": binding["provider_id"],
         "result_count": 0,
         "results": [],
@@ -621,6 +644,8 @@ def _receipt(
         "corpus_id": session.public_packet["corpus_id"],
         "surface_id": session.public_packet["surface_id"],
         "mode": session.public_packet["mode"],
+        "query_kind": str(session.public_packet.get("query_kind") or "business_recall"),
+        "query_evidence": list(session.public_packet.get("query_evidence") or []),
         "outcome": outcome,
         "memory_ref_digests": sorted(
             {
@@ -634,6 +659,9 @@ def _receipt(
         "current_artifact_verified": current_artifact_verified,
         "result_readback_verified": bool(
             session.public_packet.get("result_readback_verified")
+        ),
+        "provider_call_count": int(
+            session.public_packet.get("provider_call_count") or 0
         ),
         "model_reasoning_preserved": True,
         "grants_new_action_authority": False,

--- a/loopx/capabilities/reward_memory/ingestion.py
+++ b/loopx/capabilities/reward_memory/ingestion.py
@@ -440,6 +440,7 @@ def ingest_reward_memory_candidate(
             "surface_id": surface_id,
             "revision_ref": scope.get("revision_ref"),
             "mode": "function_boundary",
+            "query_kind": "ingest_verification",
             "queries": [
                 {
                     "query": f"{candidate_ref} {candidate['content_summary']}",

--- a/tests/capabilities/test_reward_memory_ingestion.py
+++ b/tests/capabilities/test_reward_memory_ingestion.py
@@ -278,6 +278,17 @@ def test_atomic_ingest_writes_reads_back_and_deduplicates() -> None:
     assert first["memory_available_for_recall"] is True
     assert first["external_writes_performed"] is True
     assert first["write"]["write_count"] == 1
+    evidence = first["execution_evidence"]
+    assert evidence["verified_result"] == "ingest_exact_readback_verified"
+    assert evidence["unknowns"] == []
+    minimum = evidence["minimum_evidence"]
+    assert minimum["query_kind"] == "ingest_verification"
+    assert minimum["provider_call_count"] == 1
+    assert minimum["exact_readback_verified"] is True
+    assert minimum["application_receipt"] is None
+    assert len(minimum["query_evidence"]) == 1
+    assert len(minimum["query_evidence"][0]["query_digest"]) == 16
+    assert minimum["query_evidence"][0]["exact_query_exposed"] is False
     assert second["status"] == "activated"
     assert second["candidate_ref"] == first["candidate_ref"]
     assert second["deduplicated"] is True
@@ -303,6 +314,10 @@ def test_dry_run_needs_no_provider_call() -> None:
     assert receipt["status"] == "planned"
     assert receipt["write"]["status"] == "planned"
     assert receipt["memory_available_for_recall"] is False
+    assert receipt["execution_evidence"]["verified_result"] == (
+        "ingest_provider_not_called"
+    )
+    assert receipt["execution_evidence"]["minimum_evidence"]["provider_call_count"] == 0
     assert provider.sync_calls == 0
     assert provider.retrieve_calls == 0
 


### PR DESCRIPTION
## Summary
- distinguish business recall from ingest-verification queries and retain digest-only query evidence
- attach conservative Issue Fix execution evidence with provider-call count, exact readback status, application receipt, and explicit unknowns
- exercise the real OpenViking provider adapter through version/status/search/read in the reward-memory smoke

## Validation
- 32 reward-memory capability tests passed
- reward-memory-recall-application-smoke
- reward-memory-dogfood-smoke
- issue-fix-repository-memory-smoke
- issue-fix-reviewer-notification-sink-smoke
- ruff check and format check
- git diff --check

## Safety
- no exact provider query or provider content is persisted in public evidence
- applied claims require exact readback plus a verified application receipt
- current Open PR file sets were checked and do not overlap