### PR TITLE
Fix mixed authority registry projections

### DIFF
--- a/examples/project/project-map-smoke.py
+++ b/examples/project/project-map-smoke.py
@@ -55,8 +55,16 @@ def write_planned_registry(root: Path) -> Path:
                         "state_file": state_file,
                         "authority_sources": [{"kind": "doc", "role": "primary", "path": "README.md"}],
                         "authority_registry": {
+                            "declared": True,
+                            "required": True,
                             "path": "docs/meta/DOC_REGISTRY.yaml",
+                            "path_exists": False,
                             "read_status": "read",
+                            "default_entry_count": 99,
+                            "default_entries_checked": 99,
+                            "default_entries_present": 99,
+                            "topic_authority_count": 99,
+                            "project_material_count": 99,
                             "default_entry_docs": [
                                 "docs/TODO.md",
                                 "docs/meta/DOC_REGISTRY.yaml",
@@ -197,6 +205,7 @@ def main() -> int:
         assert "planned_adapter_requires_controller_opt_in" not in after["residual_risks"], after
         assert "do not append real run history or grant write-control" in after["recommended_action"], after
         project_map = after["project_map"]
+        assert project_map["authority_registry_path_exists"] is True, project_map
         assert project_map["authority_registry_default_entry_count"] == 2, project_map
         assert project_map["authority_registry_default_entries_present"] == 2, project_map
         assert project_map["topic_authority_count"] == 1, project_map

--- a/examples/register-authority-source-smoke.py
+++ b/examples/register-authority-source-smoke.py
@@ -50,8 +50,14 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
                         "requires_authority_registry": True,
                         "authority_sources": [],
                         "authority_registry": {
+                            "declared": True,
+                            "required": True,
                             "path": "docs/meta/DOC_REGISTRY.yaml",
+                            "path_exists": True,
                             "read_status": "not_read",
+                            "default_entry_count": 0,
+                            "topic_authority_count": 12,
+                            "project_material_count": 12,
                         },
                         "adapter": {
                             "kind": "fixture_connected_readonly_v0",
@@ -151,6 +157,10 @@ def main() -> int:
         assert dry["entry"]["source_ref_redacted"] is True, dry
         assert dry["entry"]["source_ref_kind"] == "url", dry
         assert dry["entry"]["source_ref_sha256"] == hashlib.sha256(SOURCE_REF.encode("utf-8")).hexdigest(), dry
+        dry_summary = dry["authority_registry_summary"]
+        assert dry_summary["path_exists"] is False, dry_summary
+        assert dry_summary["topic_authority_count"] == 1, dry_summary
+        assert dry_summary["project_material_count"] == 1, dry_summary
         assert registry.read_text(encoding="utf-8") == before, "dry-run must not mutate registry"
 
         written = run_cli(registry, runtime, *registration_args())
@@ -169,6 +179,9 @@ def main() -> int:
         assert material["source_ref_redacted"] is True, material
         assert "source_ref" not in material, material
         assert goal["authority_registry"]["topic_authority"]["product_vision"] == SOURCE_ID, goal
+        assert goal["authority_registry"]["path_exists"] is False, goal
+        assert goal["authority_registry"]["topic_authority_count"] == 1, goal
+        assert goal["authority_registry"]["project_material_count"] == 1, goal
         assert goal["authority_sources"][0]["id"] == SOURCE_ID, goal["authority_sources"]
 
         global_path = Path(written["global_sync"]["global_registry"])

--- a/examples/register-authority-source-smoke.py
+++ b/examples/register-authority-source-smoke.py
@@ -55,8 +55,10 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
                             "path": "docs/meta/DOC_REGISTRY.yaml",
                             "path_exists": True,
                             "read_status": "not_read",
-                            "default_entry_count": 0,
-                            "topic_authority_count": 12,
+                            "default_entry_count": 3,
+                            "default_entries_checked": 3,
+                            "default_entries_present": 2,
+                            "topic_authority_count": 4,
                             "project_material_count": 12,
                         },
                         "adapter": {
@@ -99,7 +101,7 @@ def run_cli(registry: Path, runtime: Path, *args: str) -> dict[str, Any]:
     return payload
 
 
-def registration_args(*, dry_run: bool = False) -> list[str]:
+def registration_args(*, dry_run: bool = False, include_topic: bool = True) -> list[str]:
     args = [
         "register-authority-source",
         "--goal-id",
@@ -124,9 +126,9 @@ def registration_args(*, dry_run: bool = False) -> list[str]:
         "rev-2026-06-07",
         "--conflict-rule",
         "newer owner-approved source wins",
-        "--topic",
-        "product_vision",
     ]
+    if include_topic:
+        args.extend(["--topic", "product_vision"])
     if dry_run:
         args.append("--dry-run")
     return args
@@ -158,7 +160,11 @@ def main() -> int:
         assert dry["entry"]["source_ref_kind"] == "url", dry
         assert dry["entry"]["source_ref_sha256"] == hashlib.sha256(SOURCE_REF.encode("utf-8")).hexdigest(), dry
         dry_summary = dry["authority_registry_summary"]
+        assert dry_summary["required"] is True, dry_summary
         assert dry_summary["path_exists"] is False, dry_summary
+        assert dry_summary["default_entry_count"] == 3, dry_summary
+        assert dry_summary["default_entries_checked"] == 3, dry_summary
+        assert dry_summary["default_entries_present"] == 2, dry_summary
         assert dry_summary["topic_authority_count"] == 1, dry_summary
         assert dry_summary["project_material_count"] == 1, dry_summary
         assert registry.read_text(encoding="utf-8") == before, "dry-run must not mutate registry"
@@ -180,6 +186,9 @@ def main() -> int:
         assert "source_ref" not in material, material
         assert goal["authority_registry"]["topic_authority"]["product_vision"] == SOURCE_ID, goal
         assert goal["authority_registry"]["path_exists"] is False, goal
+        assert goal["authority_registry"]["default_entry_count"] == 3, goal
+        assert goal["authority_registry"]["default_entries_checked"] == 3, goal
+        assert goal["authority_registry"]["default_entries_present"] == 2, goal
         assert goal["authority_registry"]["topic_authority_count"] == 1, goal
         assert goal["authority_registry"]["project_material_count"] == 1, goal
         assert goal["authority_sources"][0]["id"] == SOURCE_ID, goal["authority_sources"]
@@ -194,6 +203,21 @@ def main() -> int:
         assert summary["project_material_count"] == 1, summary
         assert summary["project_material_owner_review_required_count"] == 1, summary
         assert summary["project_material_current_authority_count"] == 1, summary
+
+        partial_registry, partial_runtime, _partial_project = write_fixture(Path(raw_tmp) / "partial")
+        partial = run_cli(
+            partial_registry,
+            partial_runtime,
+            *registration_args(dry_run=True, include_topic=False),
+        )
+        partial_summary = partial["authority_registry_summary"]
+        assert partial_summary["required"] is True, partial_summary
+        assert partial_summary["path_exists"] is False, partial_summary
+        assert partial_summary["default_entry_count"] == 3, partial_summary
+        assert partial_summary["default_entries_checked"] == 3, partial_summary
+        assert partial_summary["default_entries_present"] == 2, partial_summary
+        assert partial_summary["topic_authority_count"] == 4, partial_summary
+        assert partial_summary["project_material_count"] == 1, partial_summary
 
     assert_doc_contract()
     print("register-authority-source-smoke ok")

--- a/loopx/authority.py
+++ b/loopx/authority.py
@@ -48,6 +48,13 @@ AUTHORITY_REGISTRY_SUMMARY_FIELDS = (
     "conflict_risk",
 )
 
+AUTHORITY_REGISTRY_CANONICAL_FIELDS = (
+    "default_entry_docs",
+    "topic_authority",
+    "project_materials",
+    "deprecated_sources",
+)
+
 
 def now_local() -> str:
     return now_local_iso()
@@ -143,6 +150,23 @@ def normalize_topic_authority(value: Any) -> dict[str, Any]:
     if isinstance(value, dict):
         return dict(value)
     return {}
+
+
+def authority_registry_has_canonical_fields(raw: dict[str, Any]) -> bool:
+    """Return whether a registry carries source data richer than a summary."""
+
+    return any(key in raw for key in AUTHORITY_REGISTRY_CANONICAL_FIELDS)
+
+
+def apply_authority_registry_summary(
+    authority_registry: dict[str, Any],
+    summary: dict[str, Any],
+) -> None:
+    """Refresh co-located summary fields without replacing canonical source data."""
+
+    for key in AUTHORITY_REGISTRY_SUMMARY_FIELDS:
+        if key in summary:
+            authority_registry[key] = summary[key]
 
 
 def compact_registered_authority_source(
@@ -416,6 +440,7 @@ def register_authority_source(
     updated_registry["updated_at"] = registered_at
     summary = compact_authority_registry(goal, project=Path(str(goal.get("repo"))).expanduser() if goal.get("repo") else None)
     summary.pop("default_entries", None)
+    apply_authority_registry_summary(authority_registry, summary)
     if not dry_run:
         write_json(registry_path, updated_registry)
 
@@ -565,6 +590,7 @@ def import_doc_registry_authority(
     updated_registry["updated_at"] = registered_at
     summary = compact_authority_registry(goal, project=Path(str(goal.get("repo"))).expanduser() if goal.get("repo") else None)
     summary.pop("default_entries", None)
+    apply_authority_registry_summary(authority_registry, summary)
     if not dry_run:
         write_json(registry_path, updated_registry)
 
@@ -716,7 +742,11 @@ def compact_authority_registry(goal: dict[str, Any] | None, *, project: Path | N
             "default_entries": [],
         }
 
-    compact = authority_registry_from_compact(raw)
+    compact = (
+        None
+        if authority_registry_has_canonical_fields(raw)
+        else authority_registry_from_compact(raw)
+    )
     if compact:
         path_text = _path_text(compact.get("path"))
         resolved_path = _resolve_project_path(project, path_text)
@@ -791,6 +821,4 @@ def authority_registry_from_compact(raw: dict[str, Any]) -> dict[str, Any] | Non
 
 
 def goal_authority_registry_summary(goal: dict[str, Any] | None) -> dict[str, Any]:
-    raw = goal.get("authority_registry") if goal and isinstance(goal.get("authority_registry"), dict) else {}
-    compact = authority_registry_from_compact(raw) if raw else None
-    return compact or authority_registry_summary(goal)
+    return authority_registry_summary(goal)

--- a/loopx/authority.py
+++ b/loopx/authority.py
@@ -708,14 +708,9 @@ def authority_registry_project_material_stats(raw_materials: Any) -> dict[str, i
     return stats
 
 
-def authority_registry_deprecated_count(raw: dict[str, Any]) -> int:
-    for key in ("deprecated_source_count", "deprecated_sources_seen"):
-        value = raw.get(key)
-        if isinstance(value, int):
-            return value
-    deprecated_sources = raw.get("deprecated_sources")
-    if isinstance(deprecated_sources, list):
-        return len(deprecated_sources)
+def authority_registry_deprecated_count(raw_sources: Any) -> int:
+    if isinstance(raw_sources, (dict, list)):
+        return len(raw_sources)
     return 0
 
 
@@ -742,65 +737,13 @@ def compact_authority_registry(goal: dict[str, Any] | None, *, project: Path | N
             "default_entries": [],
         }
 
-    compact = (
-        None
-        if authority_registry_has_canonical_fields(raw)
-        else authority_registry_from_compact(raw)
-    )
-    if compact:
-        path_text = _path_text(compact.get("path"))
-        resolved_path = _resolve_project_path(project, path_text)
-        if resolved_path:
-            compact["path_exists"] = resolved_path.exists()
-        compact["default_entries"] = []
-        return compact
-
     path_text = _path_text(raw.get("path"))
     resolved_path = _resolve_project_path(project, path_text)
-    default_entries = authority_registry_default_entries(raw.get("default_entry_docs"))
-    checked_entries: list[dict[str, Any]] = []
-    present = 0
-    checked = 0
-    for entry_path in default_entries:
-        resolved_entry = _resolve_project_path(project, entry_path)
-        exists = resolved_entry.exists() if resolved_entry else None
-        if exists is not None:
-            checked += 1
-        if exists:
-            present += 1
-        checked_entries.append({"path": entry_path, "exists": exists})
-
-    return {
-        "declared": True,
-        "required": authority_registry_required(goal),
+    summary: dict[str, Any] = {
+        "declared": True if authority_registry_has_canonical_fields(raw) else bool(raw.get("declared")),
+        "required": bool(raw.get("required") or authority_registry_required(goal)),
         "path": path_text,
-        "path_exists": resolved_path.exists() if resolved_path else None,
-        "read_status": raw.get("read_status"),
-        "default_entry_count": len(default_entries),
-        "default_entries_checked": checked,
-        "default_entries_present": present,
-        "topic_authority_count": authority_registry_topic_count(raw.get("topic_authority")),
-        **authority_registry_project_material_stats(raw.get("project_materials")),
-        "deprecated_source_count": authority_registry_deprecated_count(raw),
-        "conflict_risk": str(raw.get("conflict_risk") or "unknown"),
-        "default_entries": checked_entries,
-    }
-
-
-def authority_registry_summary(goal: dict[str, Any] | None) -> dict[str, Any]:
-    compact = compact_authority_registry(goal, project=None)
-    compact.pop("default_entries", None)
-    return compact
-
-
-def authority_registry_from_compact(raw: dict[str, Any]) -> dict[str, Any] | None:
-    if "declared" not in raw or "default_entry_count" not in raw:
-        return None
-    return {
-        "declared": bool(raw.get("declared")),
-        "required": bool(raw.get("required")),
-        "path": raw.get("path"),
-        "path_exists": raw.get("path_exists"),
+        "path_exists": resolved_path.exists() if resolved_path else raw.get("path_exists"),
         "read_status": raw.get("read_status"),
         "default_entry_count": int(raw.get("default_entry_count") or 0),
         "default_entries_checked": int(raw.get("default_entries_checked") or 0),
@@ -815,9 +758,47 @@ def authority_registry_from_compact(raw: dict[str, Any]) -> dict[str, Any] | Non
         "project_material_current_authority_count": int(
             raw.get("project_material_current_authority_count") or 0
         ),
-        "deprecated_source_count": int(raw.get("deprecated_source_count") or 0),
+        "deprecated_source_count": int(
+            raw.get("deprecated_source_count") or raw.get("deprecated_sources_seen") or 0
+        ),
         "conflict_risk": str(raw.get("conflict_risk") or "unknown"),
+        "default_entries": [],
     }
+
+    if "default_entry_docs" in raw:
+        default_entries = authority_registry_default_entries(raw.get("default_entry_docs"))
+        checked_entries: list[dict[str, Any]] = []
+        present = 0
+        checked = 0
+        for entry_path in default_entries:
+            resolved_entry = _resolve_project_path(project, entry_path)
+            exists = resolved_entry.exists() if resolved_entry else None
+            if exists is not None:
+                checked += 1
+            if exists:
+                present += 1
+            checked_entries.append({"path": entry_path, "exists": exists})
+        summary.update(
+            {
+                "default_entry_count": len(default_entries),
+                "default_entries_checked": checked,
+                "default_entries_present": present,
+                "default_entries": checked_entries,
+            }
+        )
+    if "topic_authority" in raw:
+        summary["topic_authority_count"] = authority_registry_topic_count(raw.get("topic_authority"))
+    if "project_materials" in raw:
+        summary.update(authority_registry_project_material_stats(raw.get("project_materials")))
+    if "deprecated_sources" in raw:
+        summary["deprecated_source_count"] = authority_registry_deprecated_count(raw.get("deprecated_sources"))
+    return summary
+
+
+def authority_registry_summary(goal: dict[str, Any] | None) -> dict[str, Any]:
+    compact = compact_authority_registry(goal, project=None)
+    compact.pop("default_entries", None)
+    return compact
 
 
 def goal_authority_registry_summary(goal: dict[str, Any] | None) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- prefer canonical authority maps when rich source data and legacy compact fields coexist
- refresh co-located compact summary fields after authority registration/import
- recompute material/topic counts and path existence in registration and project-map projections

## Validation
- 750 pytest passed, 2 skipped
- register-authority-source, project-map, import-doc-registry-authority, platform-migration-material-registry, and review-packet CLI smokes passed
- LoopX premerge canary passed: 16 selected checks, 0 failures, 0 manual holds
- ruff check and git diff checks passed

## Boundary
- only public runtime code and durable focused smokes are included
- no local LoopX state, internal material, raw logs, credentials, or generated lockfiles are included