### PR TITLE
fix(control-plane): preserve blocked wait replan identity

### DIFF
--- a/loopx/control_plane/runtime/run_compaction.py
+++ b/loopx/control_plane/runtime/run_compaction.py
@@ -64,6 +64,14 @@ VISION_CHECKPOINT_TRIGGER_FIELDS = (
     "kind",
     "delivery_outcome",
 )
+QUOTA_MONITOR_TARGET_COMPACT_FIELDS = (
+    "schema_version",
+    "target_id",
+    "monitor_mode",
+    "effective_action",
+    "agent_id",
+    "frontier_identity",
+)
 RUN_BASE_COMPACT_FIELDS = (
     "generated_at",
     "run_id",
@@ -197,6 +205,25 @@ def compact_vision_checkpoint(checkpoint: Any) -> dict[str, Any] | None:
     return compact or None
 
 
+def compact_quota_monitor_target(run: dict[str, Any]) -> dict[str, Any] | None:
+    if str(run.get("classification") or "") != "quota_monitor_poll":
+        return None
+    target = run.get("monitor_target")
+    if not isinstance(target, dict):
+        event = run.get("monitor_event")
+        target = event.get("monitor_target") if isinstance(event, dict) else None
+    if not isinstance(target, dict):
+        return None
+    if not str(target.get("target_id") or "").strip():
+        return None
+    compact = {
+        field: target[field]
+        for field in QUOTA_MONITOR_TARGET_COMPACT_FIELDS
+        if field in target
+    }
+    return compact or None
+
+
 def compact_run_base(
     run: dict[str, Any],
     *,
@@ -225,6 +252,10 @@ def compact_run_base(
     vision_checkpoint = compact_vision_checkpoint(run.get("vision_checkpoint"))
     if vision_checkpoint:
         compact["vision_checkpoint"] = vision_checkpoint
+
+    monitor_target = compact_quota_monitor_target(run)
+    if monitor_target:
+        compact["monitor_target"] = monitor_target
 
     reward = compact_human_reward(run.get("human_reward"))
     if reward:

--- a/loopx/control_plane/scheduler/monitor_poll_policy.py
+++ b/loopx/control_plane/scheduler/monitor_poll_policy.py
@@ -19,7 +19,7 @@ DUE_MONITOR_OBLIGATION = "attempt_due_monitor"
 
 def allows_no_spend_blocked_successor_wait_poll(decision: dict[str, Any]) -> bool:
     return bool(
-        decision.get("effective_action") == "agent_scope_wait"
+        decision.get("effective_action") in {"agent_scope_wait", "monitor_quiet_skip"}
         and decision.get("should_run") is False
         and decision.get("requires_user_action") is not True
         and exact_blocked_successor_wait_state(decision)

--- a/tests/control_plane/test_goal_vision_blocked_successor.py
+++ b/tests/control_plane/test_goal_vision_blocked_successor.py
@@ -22,7 +22,7 @@ from loopx.control_plane.work_items.autonomous_replan_ack import (
 from loopx.presentation.renderers.status_markdown import render_status_markdown
 from loopx.quota import build_quota_should_run
 from loopx.state_refresh import build_state_refresh_record
-from loopx.status import autonomous_replan_obligation_from_runs
+from loopx.status import autonomous_replan_obligation_from_runs, compact_run
 
 
 GOAL_ID = "vision-blocked-successor-fixture"
@@ -230,6 +230,48 @@ def test_two_identical_blocked_successor_waits_trigger_bounded_replan() -> None:
         "create_successor",
         "record_wait_continuation",
     ]
+
+
+def test_compacted_monitor_quiet_vision_waits_trigger_bounded_replan() -> None:
+    guard = _quota(_status_payload())
+    guard.update(
+        {
+            "decision": "skip",
+            "effective_action": "monitor_quiet_skip",
+            "should_run": False,
+            "normal_delivery_allowed": False,
+        }
+    )
+    polls = [
+        build_quota_monitor_poll_event(
+            guard,
+            generated_at="2026-07-16T00:02:00+00:00",
+        ),
+        build_quota_monitor_poll_event(
+            guard,
+            generated_at="2026-07-16T00:01:00+00:00",
+        ),
+    ]
+
+    assert {
+        poll["monitor_target"]["monitor_mode"]
+        for poll in polls
+    } == {"blocked_successor_wait_without_material_transition"}
+    compacted_polls = [compact_run(poll) for poll in polls]
+    compact_target = compacted_polls[0]["monitor_target"]
+    assert compact_target["target_id"] == polls[0]["monitor_target"]["target_id"]
+    assert compact_target["frontier_identity"] == polls[0]["monitor_target"][
+        "frontier_identity"
+    ]
+    assert "monitor_event" not in compacted_polls[0]
+
+    replanned = _quota_with_replan_runs([*compacted_polls, _vision_run()])
+
+    assert replanned["decision"] == "autonomous_replan_required"
+    assert replanned["should_run"] is True
+    trigger = replanned["autonomous_replan_obligation"]["triggers"][0]
+    assert trigger["kind"] == "blocked_successor_no_progress_repeat"
+    assert trigger["frontier_identity"] == compact_target["frontier_identity"]
 
 
 def test_replan_ack_dedupes_only_the_same_blocked_successor_frontier() -> None:


### PR DESCRIPTION
## Problem

Repeated exact blocked-successor waits were supposed to trigger bounded autonomous replan after two unchanged polls. In the real CLI path, status run compaction dropped monitor_target/frontier_identity, and a monitor-quiet work lane classified the same vision wait as a generic monitor poll. Unit fixtures bypassed both boundaries.

## Change

- preserve only the six public-safe monitor target fields required by replan through status compaction
- classify monitor_quiet_skip plus exact vision_wait_state as a blocked-successor wait
- cover event generation -> status compact_run -> quota replan in one regression

## Product / architecture judgment

This restores an existing goal-level recovery contract without adding a new lifecycle state. The compact projection stays narrow and does not retain monitor payloads or action prose. The main risk is status hot-path growth; the interface-budget canary passed with the added minimal projection.

## Validation

- focused pytest: 26 passed
- full pytest: 751 passed, 2 skipped
- loopx canary premerge --from-git-diff: 17/17 selected checks passed
- git diff checks and changed-file compile passed
- public/private boundary scan: clean

## Merge decision

Ready for maintainer review. Runtime control-plane behavior changed, so this PR is not self-merged without explicit owner approval.