### PR TITLE
feat(extensions): activate bundled Lark provider

### DIFF
--- a/docs/capabilities/lark-event-inbox.md
+++ b/docs/capabilities/lark-event-inbox.md
@@ -37,6 +37,28 @@ the reply relation through message readback before scheduling a reply. Full-chat
 capture is not full-chat activation; unrelated conversation remains available
 to domain interpretation without being treated as addressed to the bot.
 
+## Activate the provider
+
+Install and explicitly activate the bundled provider once in the LoopX runtime
+used by the project:
+
+```bash
+loopx extension install --bundled loopx-lark --execute --format json
+```
+
+Configured `lark-inbox` commands fail closed when `loopx-lark` is absent,
+disabled, or no longer matches its doctor-verified revision. Each operation
+also requires its manifest permission: inbox read/write, reply send, or
+collector management. `extension upgrade` and `extension rollback` probe the
+candidate revision before switching it. A goal with no Lark inbox pointer still
+returns the existing quiet disabled drain projection and does not require the
+extension, so projects that do not use Lark remain unaffected.
+
+The collector service is a separate host lifecycle. Disabling or switching the
+extension blocks its next `collector-run` start but does not signal a process
+that is already consuming events. Stop or restart the configured launchd or
+systemd user service when disabling, upgrading, or rolling back the provider.
+
 ## Local-private configuration
 
 The inbox is opt-in. Create a local-private generic Lark inbox config:
@@ -124,6 +146,9 @@ passes the profile-bound collector config to the LoopX runtime, which places
 reply-target verification, and optional replies therefore cannot silently use
 different app identities. Public plan/status packets expose only whether a
 profile is bound and where the binding came from, never its value.
+When the CLI uses a custom `--runtime-root`, the generated service records that
+same root before `lark-inbox collector-run`; a supervisor restart therefore
+resolves the same extension activation state that was validated at install.
 
 ```bash
 loopx lark-inbox collector-plan \

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -67,6 +67,9 @@ loopx extension list --format json
 loopx extension doctor openviking-semantic-preference --execute --format json
 loopx extension disable openviking-semantic-preference --execute --format json
 loopx extension enable openviking-semantic-preference --execute --format json
+
+# Activate the bundled Lark lifecycle provider before using lark-inbox.
+loopx extension install --bundled loopx-lark --execute --format json
 ```
 
 For a separately distributed provider, pass `--manifest <extension.toml>`.
@@ -87,6 +90,16 @@ An enabled implementation is resolved by capability id, versioned protocol,
 declared permission, current revision, and current doctor proof. Domain config
 may add bounded provider arguments, but cannot replace the manifest entrypoint,
 timeout, protocol, or permission contract.
+
+Compatibility delegates use the same revision-bound readiness rule. Every
+configured `loopx lark-inbox` operation resolves the enabled `loopx-lark`
+provider, its current doctor proof, and the permission needed by that operation
+before entering the in-process provider code. Disabling the extension therefore
+blocks new collector starts, drain, ingest, reply, and acknowledge operations;
+upgrade and rollback affect new invocations without changing project
+configuration. Extension lifecycle commands do not terminate an already
+running host-managed collector process; stop or restart that supervisor service
+separately when changing the active provider revision.
 
 ## Placement Decision For Agents
 
@@ -226,8 +239,11 @@ provider-neutral read models, while provider packages own collection, transport,
 credentials, and external effects. For example, quota reads
 `operator_inbox_urgency_v0`. Lark inbox collection, reply transport, and
 provider-owned configuration live under `loopx/extensions/lark/`; the existing
-`loopx lark-inbox` command remains a direct compatibility delegate while the
-activation protocol is introduced in a separate, behavior-preserving slice.
+`loopx lark-inbox` command remains a direct compatibility delegate, but it now
+requires an installed, enabled, doctor-verified `loopx-lark` revision with the
+operation's declared permission. The provider subprocess currently implements
+doctor only; command execution remains in-process until the transport protocol
+is migrated.
 The former `loopx.capabilities.lark` provider imports are intentionally removed
 instead of kept as wrappers. Presentation sinks remain in their current owner
 until their broader CLI and projection parity surface is characterized.

--- a/examples/capability-extension-registry-smoke.py
+++ b/examples/capability-extension-registry-smoke.py
@@ -76,4 +76,15 @@ next_real_step = "Keep explicit enablement bounded."
     assert detail["capability"]["capability_kind"] == "projection_sink"
     assert detail["capability"]["provider_id"] == "example-extension"
 
+    lark_manifest = ROOT / "loopx" / "extensions" / "lark" / "extension.toml"
+    lark = run_cli(
+        "capability",
+        "show",
+        "lark-event-inbox",
+        "--extension-manifest",
+        str(lark_manifest),
+    )
+    assert lark["capability"]["origin"] == "extension", lark
+    assert lark["capability"]["provider_id"] == "loopx-lark", lark
+
 print("capability-extension-registry-smoke: ok")

--- a/examples/lark-event-collector-lifecycle-smoke.py
+++ b/examples/lark-event-collector-lifecycle-smoke.py
@@ -92,6 +92,28 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-collector-") as raw:
     previous_path = os.environ.get("PATH")
     os.environ["HOME"] = str(home)
     os.environ["PATH"] = f"{bin_dir}:{previous_path or ''}"
+    runtime_root = temp / "runtime"
+    installed_extension = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--runtime-root",
+            str(runtime_root),
+            "--format",
+            "json",
+            "extension",
+            "install",
+            "--bundled",
+            "loopx-lark",
+            "--execute",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert installed_extension.returncode == 0, installed_extension.stderr
     calls: list[list[str]] = []
 
     def runner(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
@@ -103,7 +125,11 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-collector-") as raw:
         return completed(argv)
 
     try:
-        plan = plan_lark_event_collector(project=project, config_path=collector_config)
+        plan = plan_lark_event_collector(
+            project=project,
+            config_path=collector_config,
+            runtime_root=runtime_root,
+        )
         assert plan["status"] == "install_ready", plan
         assert plan["thread_complete"] is True, plan
         assert plan["profile_bound"] is True, plan
@@ -115,6 +141,7 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-collector-") as raw:
         preview = install_lark_event_collector(
             project=project,
             config_path=collector_config,
+            runtime_root=runtime_root,
             runner=runner,
         )
         assert preview["status"] == "preview_ready", preview
@@ -126,6 +153,7 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-collector-") as raw:
         installed = install_lark_event_collector(
             project=project,
             config_path=collector_config,
+            runtime_root=runtime_root,
             execute=True,
             runner=runner,
         )
@@ -139,7 +167,11 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-collector-") as raw:
         assert str(lark_cli) in plist_text, plist_text
         service_argv = plistlib.loads(plist.read_bytes())["ProgramArguments"]
         assert Path(service_argv[0]).name == "loopx", service_argv
-        assert service_argv[1:3] == ["lark-inbox", "collector-run"], service_argv
+        assert service_argv[1:3] == [
+            "--runtime-root",
+            str(runtime_root.resolve()),
+        ], service_argv
+        assert service_argv[3:5] == ["lark-inbox", "collector-run"], service_argv
         assert service_argv[service_argv.index("--lark-cli-executable") + 1] == str(
             lark_cli
         ), service_argv
@@ -242,6 +274,7 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-collector-") as raw:
         status = inspect_lark_event_collector(
             project=project,
             config_path=collector_config,
+            runtime_root=runtime_root,
             probe_event_bus=True,
             runner=runner,
         )
@@ -417,6 +450,8 @@ else:
                 "loopx.cli",
                 "--format",
                 "json",
+                "--runtime-root",
+                str(runtime_root),
                 "lark-inbox",
                 "collector-plan",
                 "--project",

--- a/examples/lark-event-inbox-smoke.py
+++ b/examples/lark-event-inbox-smoke.py
@@ -450,6 +450,30 @@ def main() -> None:
             ),
             encoding="utf-8",
         )
+        runtime_root = project / "runtime"
+        installed_extension = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--registry",
+                str(registry),
+                "--runtime-root",
+                str(runtime_root),
+                "--format",
+                "json",
+                "extension",
+                "install",
+                "--bundled",
+                "loopx-lark",
+                "--execute",
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert installed_extension.returncode == 0, installed_extension.stderr
         discovered = subprocess.run(
             [
                 sys.executable,
@@ -457,6 +481,8 @@ def main() -> None:
                 "loopx.cli",
                 "--registry",
                 str(registry),
+                "--runtime-root",
+                str(runtime_root),
                 "--format",
                 "json",
                 "lark-inbox",
@@ -510,6 +536,8 @@ def main() -> None:
                 "loopx.cli",
                 "--registry",
                 str(shared_registry),
+                "--runtime-root",
+                str(runtime_root),
                 "--format",
                 "json",
                 "lark-inbox",
@@ -535,6 +563,8 @@ def main() -> None:
                 "loopx.cli",
                 "--registry",
                 str(registry),
+                "--runtime-root",
+                str(runtime_root),
                 "--format",
                 "json",
                 "lark-inbox",

--- a/examples/lark-extension-activation-smoke.py
+++ b/examples/lark-extension-activation-smoke.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_cli(
+    registry: Path,
+    runtime_root: Path,
+    *args: str,
+    expected_returncode: int = 0,
+) -> dict[str, object]:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry),
+            "--runtime-root",
+            str(runtime_root),
+            "--format",
+            "json",
+            *args,
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == expected_returncode, completed
+    return json.loads(completed.stdout)
+
+
+with tempfile.TemporaryDirectory(prefix="loopx-lark-extension-") as raw_temp:
+    temp = Path(raw_temp)
+    project = temp / "project"
+    runtime_root = temp / "runtime"
+    project.mkdir()
+    config = project / ".loopx" / "config" / "lark-event-inbox.json"
+    config.parent.mkdir(parents=True)
+    config.write_text(
+        json.dumps(
+            {
+                "schema_version": "lark_event_inbox_config_v0",
+                "enabled": True,
+                "inbox_dir": ".loopx/inbox/lark-feedback",
+            }
+        ),
+        encoding="utf-8",
+    )
+    registry = project / ".loopx" / "registry.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "goals": [
+                    {
+                        "id": "lark-extension-fixture",
+                        "repo": str(project),
+                        "control_plane": {
+                            "lark_event_inbox": {
+                                "enabled": True,
+                                "config_path": ".loopx/config/lark-event-inbox.json",
+                            }
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    drain_args = (
+        "lark-inbox",
+        "drain",
+        "--goal-id",
+        "lark-extension-fixture",
+    )
+
+    missing = run_cli(
+        registry,
+        runtime_root,
+        *drain_args,
+        expected_returncode=1,
+    )
+    assert "not installed" in str(missing["error"]), missing
+
+    installed = run_cli(
+        registry,
+        runtime_root,
+        "extension",
+        "install",
+        "--bundled",
+        "loopx-lark",
+        "--execute",
+    )
+    assert installed["doctor"]["verified"] is True, installed
+    active = run_cli(registry, runtime_root, *drain_args)
+    assert active["extension_activation"] == {
+        "schema_version": "loopx_extension_activation_v0",
+        "extension_id": "loopx-lark",
+        "provider_version": "1.0.0",
+        "revision": installed["revision"],
+        "enabled": True,
+        "doctor_verified": True,
+        "required_permissions": ["lark.inbox.read"],
+    }, active
+
+    disabled = run_cli(
+        registry,
+        runtime_root,
+        "extension",
+        "disable",
+        "loopx-lark",
+        "--execute",
+    )
+    assert disabled["enabled"] is False, disabled
+    blocked = run_cli(
+        registry,
+        runtime_root,
+        *drain_args,
+        expected_returncode=1,
+    )
+    assert "is disabled" in str(blocked["error"]), blocked
+
+    enabled = run_cli(
+        registry,
+        runtime_root,
+        "extension",
+        "enable",
+        "loopx-lark",
+        "--execute",
+    )
+    assert enabled["doctor"]["verified"] is True, enabled
+
+    bundled_manifest = ROOT / "loopx" / "extensions" / "lark" / "extension.toml"
+    upgraded_manifest = temp / "loopx-lark-v1.1.toml"
+    upgraded_manifest.write_text(
+        bundled_manifest.read_text(encoding="utf-8").replace(
+            'version = "1.0.0"',
+            'version = "1.1.0"',
+            1,
+        ),
+        encoding="utf-8",
+    )
+    upgraded = run_cli(
+        registry,
+        runtime_root,
+        "extension",
+        "upgrade",
+        "--manifest",
+        str(upgraded_manifest),
+        "--execute",
+    )
+    assert upgraded["previous_revision"] == installed["revision"], upgraded
+    after_upgrade = run_cli(registry, runtime_root, *drain_args)
+    assert after_upgrade["extension_activation"]["revision"] == upgraded["revision"]
+
+    rolled_back = run_cli(
+        registry,
+        runtime_root,
+        "extension",
+        "rollback",
+        "loopx-lark",
+        "--execute",
+    )
+    assert rolled_back["revision"] == installed["revision"], rolled_back
+    after_rollback = run_cli(registry, runtime_root, *drain_args)
+    assert (
+        after_rollback["extension_activation"]["revision"] == installed["revision"]
+    ), after_rollback
+
+    doctor = run_cli(
+        registry,
+        runtime_root,
+        "extension",
+        "doctor",
+        "loopx-lark",
+        "--execute",
+    )
+    assert doctor["verified"] is True, doctor
+
+print("lark-extension-activation-smoke: ok")

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -498,6 +498,7 @@ def main(argv: list[str] | None = None) -> int:
     lark_inbox_result = handle_lark_inbox_command(
         args,
         registry_path=registry_path,
+        runtime_root_arg=args.runtime_root,
         output_format=output_format,
         print_payload=print_payload,
     )

--- a/loopx/cli_commands/lark_inbox.py
+++ b/loopx/cli_commands/lark_inbox.py
@@ -6,6 +6,13 @@ import sys
 from pathlib import Path
 from typing import Callable
 
+from ..extensions.lark import (
+    LARK_COLLECTOR_PERMISSION,
+    LARK_EXTENSION_ID,
+    LARK_INBOX_READ_PERMISSION,
+    LARK_INBOX_WRITE_PERMISSION,
+    LARK_REPLY_PERMISSION,
+)
 from ..extensions.lark.event_inbox import (
     acknowledge_lark_event_inbox,
     ingest_lark_event_inbox,
@@ -18,6 +25,10 @@ from ..extensions.lark.event_collector import (
     plan_lark_event_collector,
 )
 from ..extensions.lark.event_collector_runtime import run_lark_event_collector
+from ..extensions.runtime import (
+    default_extension_state_file,
+    resolve_extension_activation,
+)
 from ..control_plane.runtime.goal_project_route import resolve_goal_project_route
 
 
@@ -152,6 +163,41 @@ def _read_stdin_events() -> list[object]:
     raise ValueError("lark inbox ingest input must be an event object or event array")
 
 
+def _required_extension_permissions(command: str) -> tuple[str, ...]:
+    if command == "drain":
+        return (LARK_INBOX_READ_PERMISSION,)
+    if command in {"ack", "ingest"}:
+        return (LARK_INBOX_WRITE_PERMISSION,)
+    if command == "reply":
+        return (LARK_REPLY_PERMISSION,)
+    return (LARK_COLLECTOR_PERMISSION,)
+
+
+def _resolve_lark_activation(
+    command: str,
+    *,
+    runtime_root_arg: str | None,
+) -> dict[str, object]:
+    return resolve_extension_activation(
+        LARK_EXTENSION_ID,
+        state_file=default_extension_state_file(runtime_root_arg),
+        required_permissions=_required_extension_permissions(command),
+    )
+
+
+def _disabled_inbox_projection() -> dict[str, object]:
+    return {
+        "ok": True,
+        "schema_version": "lark_event_inbox_projection_v0",
+        "enabled": False,
+        "configured": False,
+        "pending_count": 0,
+        "items": [],
+        "local_private_content_returned": False,
+        "external_reads_performed": False,
+    }
+
+
 def _render(payload: dict[str, object]) -> str:
     lines = [
         "# Lark Event Inbox",
@@ -171,36 +217,37 @@ def handle_lark_inbox_command(
     args: argparse.Namespace,
     *,
     registry_path: Path,
+    runtime_root_arg: str | None,
     output_format: Callable[..., str],
     print_payload: Callable,
 ) -> int | None:
     if args.command != "lark-inbox":
         return None
+    activation: dict[str, object] | None = None
     try:
-        if args.lark_inbox_command == "drain":
+        inbox_commands = {"drain", "ack", "reply", "ingest"}
+        project: Path | None = None
+        config_path: str | None = None
+        if args.lark_inbox_command in inbox_commands:
             project, config_path = _inbox_context(args, registry_path)
             if config_path is None:
-                payload = {
-                    "ok": True,
-                    "schema_version": "lark_event_inbox_projection_v0",
-                    "enabled": False,
-                    "configured": False,
-                    "pending_count": 0,
-                    "items": [],
-                    "local_private_content_returned": False,
-                    "external_reads_performed": False,
-                }
+                if args.lark_inbox_command != "drain":
+                    raise ValueError("goal does not configure a Lark event inbox")
+                payload = _disabled_inbox_projection()
                 print_payload(payload, output_format(args), _render)
                 return 0
+
+        activation = _resolve_lark_activation(
+            args.lark_inbox_command,
+            runtime_root_arg=runtime_root_arg,
+        )
+        if args.lark_inbox_command == "drain":
             payload = inspect_lark_event_inbox(
                 project=project,
                 config_path=config_path,
                 limit=args.limit,
             )
         elif args.lark_inbox_command == "ack":
-            project, config_path = _inbox_context(args, registry_path)
-            if config_path is None:
-                raise ValueError("goal does not configure a Lark event inbox")
             payload = acknowledge_lark_event_inbox(
                 project=project,
                 config_path=config_path,
@@ -208,9 +255,6 @@ def handle_lark_inbox_command(
                 execute=args.execute,
             )
         elif args.lark_inbox_command == "reply":
-            project, config_path = _inbox_context(args, registry_path)
-            if config_path is None:
-                raise ValueError("goal does not configure a Lark event inbox")
             payload = reply_lark_event_inbox(
                 project=project,
                 config_path=config_path,
@@ -219,9 +263,6 @@ def handle_lark_inbox_command(
                 execute=args.execute,
             )
         elif args.lark_inbox_command == "ingest":
-            project, config_path = _inbox_context(args, registry_path)
-            if config_path is None:
-                raise ValueError("goal does not configure a Lark event inbox")
             payload = ingest_lark_event_inbox(
                 project=project,
                 config_path=config_path,
@@ -232,11 +273,13 @@ def handle_lark_inbox_command(
             payload = plan_lark_event_collector(
                 project=args.project,
                 config_path=args.config,
+                runtime_root=runtime_root_arg,
             )
         elif args.lark_inbox_command == "collector-install":
             payload = install_lark_event_collector(
                 project=args.project,
                 config_path=args.config,
+                runtime_root=runtime_root_arg,
                 execute=args.execute,
             )
         elif args.lark_inbox_command == "collector-run":
@@ -250,6 +293,7 @@ def handle_lark_inbox_command(
             payload = inspect_lark_event_collector(
                 project=args.project,
                 config_path=args.config,
+                runtime_root=runtime_root_arg,
                 probe_event_bus=args.probe_event_bus,
             )
     except (OSError, ValueError, json.JSONDecodeError) as exc:
@@ -258,5 +302,7 @@ def handle_lark_inbox_command(
             "schema_version": "lark_event_inbox_error_v0",
             "error": str(exc),
         }
+    if activation is not None and payload.get("ok"):
+        payload["extension_activation"] = activation
     print_payload(payload, output_format(args), _render)
     return 0 if payload.get("ok") else 1

--- a/loopx/extensions/bundled.py
+++ b/loopx/extensions/bundled.py
@@ -4,17 +4,22 @@ from importlib import resources
 from pathlib import Path
 
 
-BUNDLED_EXTENSION_IDS = ("openviking-semantic-preference",)
+BUNDLED_EXTENSION_PACKAGES = {
+    "loopx-lark": "loopx.extensions.lark",
+    "openviking-semantic-preference": (
+        "loopx.extensions.openviking_semantic_preference"
+    ),
+}
+BUNDLED_EXTENSION_IDS = tuple(BUNDLED_EXTENSION_PACKAGES)
 
 
 def bundled_extension_manifest(extension_id: str) -> Path:
     wanted = str(extension_id or "").strip()
-    if wanted != "openviking-semantic-preference":
+    package = BUNDLED_EXTENSION_PACKAGES.get(wanted)
+    if package is None:
         raise ValueError(
             f"unknown bundled extension `{wanted}`; expected one of "
             f"{list(BUNDLED_EXTENSION_IDS)}"
         )
-    manifest = resources.files(
-        "loopx.extensions.openviking_semantic_preference"
-    ).joinpath("extension.toml")
+    manifest = resources.files(package).joinpath("extension.toml")
     return Path(str(manifest))

--- a/loopx/extensions/lark/__init__.py
+++ b/loopx/extensions/lark/__init__.py
@@ -1,1 +1,7 @@
 """Lark provider implementation owned by the extension layer."""
+
+LARK_EXTENSION_ID = "loopx-lark"
+LARK_INBOX_READ_PERMISSION = "lark.inbox.read"
+LARK_INBOX_WRITE_PERMISSION = "lark.inbox.write"
+LARK_REPLY_PERMISSION = "lark.reply.send"
+LARK_COLLECTOR_PERMISSION = "lark.collector.manage"

--- a/loopx/extensions/lark/event_collector.py
+++ b/loopx/extensions/lark/event_collector.py
@@ -188,7 +188,12 @@ def _executable_prefix(executable: str) -> list[str]:
     return [executable]
 
 
-def _collector_argv(config: Mapping[str, Any], executable: str) -> list[str]:
+def _collector_argv(
+    config: Mapping[str, Any],
+    executable: str,
+    *,
+    runtime_root: str | Path | None = None,
+) -> list[str]:
     prefix = _executable_prefix(executable)
     repo_root = Path(__file__).resolve().parents[3]
     discovered = shutil.which("loopx")
@@ -197,17 +202,21 @@ def _collector_argv(config: Mapping[str, Any], executable: str) -> list[str]:
     )
     if not loopx_executable.is_file():
         raise ValueError("loopx executable is unavailable for collector runtime")
-    argv = [
-        str(loopx_executable),
-        "lark-inbox",
-        "collector-run",
-        "--project",
-        str(config["project"]),
-        "--config",
-        str(config["config_path"]),
-        "--lark-cli-executable",
-        executable,
-    ]
+    argv = [str(loopx_executable)]
+    if runtime_root is not None:
+        argv.extend(["--runtime-root", str(Path(runtime_root).expanduser().resolve())])
+    argv.extend(
+        [
+            "lark-inbox",
+            "collector-run",
+            "--project",
+            str(config["project"]),
+            "--config",
+            str(config["config_path"]),
+            "--lark-cli-executable",
+            executable,
+        ]
+    )
     if len(prefix) == 2:
         argv.extend(["--node-executable", prefix[0]])
     return argv
@@ -247,9 +256,17 @@ def _service_payload(config: Mapping[str, Any], argv: Sequence[str]) -> bytes:
     ).encode()
 
 
-def _plan(config: Mapping[str, Any]) -> tuple[dict[str, Any], list[str], bytes]:
+def _plan(
+    config: Mapping[str, Any],
+    *,
+    runtime_root: str | Path | None = None,
+) -> tuple[dict[str, Any], list[str], bytes]:
     executable = shutil.which(str(config["lark_cli_bin"]))
-    argv = _collector_argv(config, executable or str(config["lark_cli_bin"]))
+    argv = _collector_argv(
+        config,
+        executable or str(config["lark_cli_bin"]),
+        runtime_root=runtime_root,
+    )
     service_payload = _service_payload(config, argv)
     return (
         {
@@ -284,10 +301,13 @@ def _plan(config: Mapping[str, Any]) -> tuple[dict[str, Any], list[str], bytes]:
 
 
 def plan_lark_event_collector(
-    *, project: str | Path, config_path: str | Path
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    runtime_root: str | Path | None = None,
 ) -> dict[str, Any]:
     config = load_lark_event_collector_config(project=project, config_path=config_path)
-    plan, _, _ = _plan(config)
+    plan, _, _ = _plan(config, runtime_root=runtime_root)
     return plan
 
 
@@ -307,11 +327,12 @@ def install_lark_event_collector(
     *,
     project: str | Path,
     config_path: str | Path,
+    runtime_root: str | Path | None = None,
     execute: bool = False,
     runner: Runner = subprocess.run,
 ) -> dict[str, Any]:
     config = load_lark_event_collector_config(project=project, config_path=config_path)
-    plan, _, _ = _plan(config)
+    plan, _, _ = _plan(config, runtime_root=runtime_root)
     if not config["enabled"]:
         raise ValueError("cannot install a disabled lark collector")
     if not plan["lark_cli_available"]:
@@ -326,7 +347,7 @@ def install_lark_event_collector(
             "execute": execute,
             "install_hint": "Upgrade lark-cli to a version with event consume support.",
         }
-    argv = _collector_argv(config, str(executable))
+    argv = _collector_argv(config, str(executable), runtime_root=runtime_root)
     service_payload = _service_payload(config, argv)
     if not execute:
         return {
@@ -379,11 +400,12 @@ def inspect_lark_event_collector(
     *,
     project: str | Path,
     config_path: str | Path,
+    runtime_root: str | Path | None = None,
     probe_event_bus: bool = False,
     runner: Runner = subprocess.run,
 ) -> dict[str, Any]:
     config = load_lark_event_collector_config(project=project, config_path=config_path)
-    plan, _, _ = _plan(config)
+    plan, _, _ = _plan(config, runtime_root=runtime_root)
     service_path = _service_file(config)
     if config["supervisor"] == "launchd":
         observed = _run(

--- a/loopx/extensions/lark/extension.toml
+++ b/loopx/extensions/lark/extension.toml
@@ -1,0 +1,29 @@
+schema_version = "loopx_extension_manifest_v0"
+id = "loopx-lark"
+version = "1.0.0"
+requires_loopx_api = ">=1,<2"
+permissions = [
+  "lark.inbox.read",
+  "lark.inbox.write",
+  "lark.reply.send",
+  "lark.collector.manage",
+]
+
+[runtime]
+protocol = "lark_extension_lifecycle_v0"
+entrypoint = "loopx-lark-provider"
+args = []
+doctor_args = ["--doctor"]
+required_permissions = []
+timeout_seconds = 30
+
+[[provides]]
+id = "lark-event-inbox"
+kind = "event_inbox"
+title = "Lark event inbox"
+status = "active-preview"
+visibility = "public"
+real_world_anchor = "host-collected project feedback from a configured Lark chat"
+user_value = "Collect, inspect, reply to, and acknowledge bounded Lark feedback without making chat the control-plane source of truth."
+entry_command = "loopx lark-inbox drain --goal-id <goal-id>"
+next_real_step = "Install and explicitly enable the bundled provider before configuring a project inbox."

--- a/loopx/extensions/lark/provider.py
+++ b/loopx/extensions/lark/provider.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import argparse
+from importlib import import_module
+import sys
+from collections.abc import Sequence
+
+
+REQUIRED_EXPORTS = {
+    "loopx.extensions.lark.event_collector": (
+        "inspect_lark_event_collector",
+        "install_lark_event_collector",
+        "plan_lark_event_collector",
+    ),
+    "loopx.extensions.lark.event_collector_runtime": ("run_lark_event_collector",),
+    "loopx.extensions.lark.event_inbox": (
+        "acknowledge_lark_event_inbox",
+        "ingest_lark_event_inbox",
+        "inspect_lark_event_inbox",
+    ),
+    "loopx.extensions.lark.inbox_reply": ("reply_lark_event_inbox",),
+}
+
+
+def doctor_lark_provider() -> None:
+    for module_name, exports in REQUIRED_EXPORTS.items():
+        module = import_module(module_name)
+        missing = [
+            name for name in exports if not callable(getattr(module, name, None))
+        ]
+        if missing:
+            raise RuntimeError(
+                f"Lark provider module `{module_name}` is missing exports {missing}"
+            )
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="LoopX Lark extension provider.")
+    parser.add_argument("--doctor", action="store_true")
+    args = parser.parse_args(argv)
+    if not args.doctor:
+        raise ValueError(
+            "the Lark subprocess protocol is not active; use the LoopX compatibility CLI"
+        )
+    doctor_lark_provider()
+    return 0
+
+
+def main() -> int:
+    try:
+        return run()
+    except Exception as exc:
+        print(f"LoopX Lark provider failed: {type(exc).__name__}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/extensions/runtime.py
+++ b/loopx/extensions/runtime.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from contextlib import nullcontext
 from copy import deepcopy
 import hashlib
@@ -22,6 +22,7 @@ from .readiness import (
 EXTENSION_STATE_SCHEMA_VERSION = "loopx_extension_state_v0"
 EXTENSION_OPERATION_SCHEMA_VERSION = "loopx_extension_operation_v0"
 EXTENSION_BINDING_SCHEMA_VERSION = "loopx_extension_runtime_binding_v0"
+EXTENSION_ACTIVATION_SCHEMA_VERSION = "loopx_extension_activation_v0"
 MAX_REVISIONS = 5
 
 
@@ -467,14 +468,11 @@ def _verified_entrypoint(entry: Mapping[str, Any]) -> Path | None:
     return identity[0]
 
 
-def resolve_extension_binding(
+def _resolved_active_extension(
     extension_id: str,
     *,
     state_file: str | Path,
-    capability_id: str,
-    protocol: str,
-    permission: str,
-) -> dict[str, Any]:
+) -> tuple[str, Path, Mapping[str, Any]]:
     state = _read_state(Path(state_file).expanduser())
     entry = state["extensions"].get(extension_id)
     if not isinstance(entry, dict):
@@ -489,6 +487,62 @@ def resolve_extension_binding(
     manifest = snapshot.get("manifest")
     if not isinstance(manifest, Mapping):
         raise ValueError("extension active manifest is invalid")
+    return active_revision, verified_entrypoint, manifest
+
+
+def resolve_extension_activation(
+    extension_id: str,
+    *,
+    state_file: str | Path,
+    required_permissions: Sequence[str] = (),
+) -> dict[str, Any]:
+    """Resolve one enabled, revision-bound extension compatibility delegate."""
+
+    active_revision, _, manifest = _resolved_active_extension(
+        extension_id,
+        state_file=state_file,
+    )
+    provider = manifest.get("provider")
+    if not isinstance(provider, Mapping):
+        raise ValueError("extension active manifest is incomplete")
+    declared_permissions = {
+        str(permission)
+        for permission in provider.get("permissions") or []
+        if str(permission).strip()
+    }
+    required = {
+        str(permission).strip()
+        for permission in required_permissions
+        if str(permission).strip()
+    }
+    missing = sorted(required - declared_permissions)
+    if missing:
+        raise ValueError(
+            f"extension `{extension_id}` does not declare permissions {missing}"
+        )
+    return {
+        "schema_version": EXTENSION_ACTIVATION_SCHEMA_VERSION,
+        "extension_id": extension_id,
+        "provider_version": provider.get("version"),
+        "revision": active_revision,
+        "enabled": True,
+        "doctor_verified": True,
+        "required_permissions": sorted(required),
+    }
+
+
+def resolve_extension_binding(
+    extension_id: str,
+    *,
+    state_file: str | Path,
+    capability_id: str,
+    protocol: str,
+    permission: str,
+) -> dict[str, Any]:
+    active_revision, verified_entrypoint, manifest = _resolved_active_extension(
+        extension_id,
+        state_file=state_file,
+    )
     provider = manifest.get("provider")
     runtime = _runtime(manifest)
     implementations = manifest.get("implementations")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ test = [
 
 [project.scripts]
 loopx = "loopx.cli:main"
+loopx-lark-provider = "loopx.extensions.lark.provider:main"
 loopx-openviking-semantic-preference = "loopx.extensions.openviking_semantic_preference.provider:main"
 
 [tool.setuptools.packages.find]
@@ -30,6 +31,7 @@ include = ["loopx*"]
 
 [tool.setuptools.package-data]
 "loopx.capabilities.auto_research" = ["worker_skill/SKILL.md"]
+"loopx.extensions.lark" = ["extension.toml"]
 "loopx.extensions.openviking_semantic_preference" = ["extension.toml"]
 
 [tool.mypy]

--- a/tests/architecture/test_control_plane_import_boundaries.py
+++ b/tests/architecture/test_control_plane_import_boundaries.py
@@ -10,6 +10,7 @@ CONTROL_PLANE_ROOT = PACKAGE_ROOT / "control_plane"
 STATUS_MODULE = PACKAGE_ROOT / "status.py"
 QUOTA_MODULE = PACKAGE_ROOT / "quota.py"
 LARK_INBOX_CLI_MODULE = PACKAGE_ROOT / "cli_commands" / "lark_inbox.py"
+LARK_EXTENSION_ROOT = PACKAGE_ROOT / "extensions" / "lark"
 LEGACY_LARK_CAPABILITY_ROOT = PACKAGE_ROOT / "capabilities" / "lark"
 FORBIDDEN_DEPENDENCY_PREFIXES = (
     "loopx.benchmark_adapters",
@@ -136,4 +137,7 @@ def test_lark_inbox_provider_is_owned_by_the_extension_layer() -> None:
         "loopx.extensions.lark.event_collector_runtime",
         "loopx.extensions.lark.event_inbox",
         "loopx.extensions.lark.inbox_reply",
+        "loopx.extensions.runtime",
     } <= imports
+    assert (LARK_EXTENSION_ROOT / "extension.toml").is_file()
+    assert (LARK_EXTENSION_ROOT / "provider.py").is_file()

--- a/tests/extensions/test_extension_runtime.py
+++ b/tests/extensions/test_extension_runtime.py
@@ -22,6 +22,7 @@ from loopx.extensions.runtime import (
     enable_extension,
     extension_status,
     install_extension,
+    resolve_extension_activation,
     resolve_extension_binding,
     rollback_extension,
 )
@@ -101,6 +102,26 @@ def test_install_disable_upgrade_and_rollback_preserve_verified_binding(
 
     installed = install_extension(v1, state_file=state_file, execute=True)
     assert installed["changed"] is True
+    activation = resolve_extension_activation(
+        "test-semantic-extension",
+        state_file=state_file,
+        required_permissions=["semantic_preference.read"],
+    )
+    assert activation == {
+        "schema_version": "loopx_extension_activation_v0",
+        "extension_id": "test-semantic-extension",
+        "provider_version": "1.0.0",
+        "revision": installed["revision"],
+        "enabled": True,
+        "doctor_verified": True,
+        "required_permissions": ["semantic_preference.read"],
+    }
+    with pytest.raises(ValueError, match="does not declare permissions"):
+        resolve_extension_activation(
+            "test-semantic-extension",
+            state_file=state_file,
+            required_permissions=["semantic_preference.write"],
+        )
     binding = resolve_extension_binding(
         "test-semantic-extension",
         state_file=state_file,
@@ -117,6 +138,11 @@ def test_install_disable_upgrade_and_rollback_preserve_verified_binding(
         execute=True,
     )
     assert disabled["changed"] is True
+    with pytest.raises(ValueError, match="is disabled"):
+        resolve_extension_activation(
+            "test-semantic-extension",
+            state_file=state_file,
+        )
     with pytest.raises(ValueError, match="is disabled"):
         resolve_extension_binding(
             "test-semantic-extension",
@@ -326,6 +352,11 @@ def test_binding_rejects_missing_or_replaced_entrypoint(
     assert extension_status(state_file=state_file)["extensions"][0][
         "doctor_verified"
     ] is False
+    with pytest.raises(ValueError, match="doctor readiness is stale"):
+        resolve_extension_activation(
+            "test-semantic-extension",
+            state_file=state_file,
+        )
     with pytest.raises(ValueError, match="doctor readiness is stale"):
         resolve_extension_binding(
             "test-semantic-extension",


### PR DESCRIPTION
## Summary

- add a bundled `loopx-lark` manifest and doctor entrypoint
- require configured `lark-inbox` operations to resolve an enabled, revision-bound, permission-declared provider
- preserve the current in-process CLI delegate while making disable, upgrade, rollback, and custom runtime-root behavior effective
- compose `lark-event-inbox` into the capability registry through the extension manifest

## Product and architecture

This is the executable activation slice after moving Lark provider code under `loopx/extensions/lark`. It deliberately does not add a speculative subprocess dispatch protocol: the provider subprocess is doctor-only, and `loopx lark-inbox` remains the compatibility delegate. The generic resolver shares installed/enabled/revision/doctor validation with implementation binding, so lifecycle rules have one source of truth. Declared permissions gate entry into provider behavior but do not grant any new LoopX or external-write authority.

The remaining migration is intentionally explicit: issue-fix direct imports and Lark presentation sinks are not claimed as complete here.

## Validation

- `pytest -q`: 750 passed, 2 skipped
- `canary smoke-suite --profile extension-runtime`: 7/7 passed
- `canary premerge --from-git-diff --tier standard`: 16/16 selected checks passed, 0 warnings, 0 manual holds
- focused extension/runtime/architecture tests: 17 passed
- wheel inspection: bundled manifest and provider included
- `loopx check`: public boundary clean
- Ruff and compile checks passed
