### PR TITLE
fix(extensions): gate issue-fix Lark provider use

### DIFF
--- a/examples/issue-fix-reviewer-request-smoke.py
+++ b/examples/issue-fix-reviewer-request-smoke.py
@@ -54,6 +54,11 @@ from loopx.domain_packs.issue_fix import (  # noqa: E402
     persist_issue_fix_reviewer_notification_state,
     upsert_issue_fix_pr_lifecycle_ledger_jsonl,
 )
+from loopx.extensions.bundled import bundled_extension_manifest  # noqa: E402
+from loopx.extensions.runtime import (  # noqa: E402
+    default_extension_state_file,
+    install_extension,
+)
 
 
 PRIVATE_PATTERNS = (
@@ -950,32 +955,39 @@ def main() -> int:
         }
         notification_sinks_path = path / "notification-sinks.json"
         write(notification_sinks_path, json.dumps(cli_sinks_input))
+        runtime_root = path / ".runtime"
+        install_extension(
+            bundled_extension_manifest("loopx-lark"),
+            state_file=default_extension_state_file(runtime_root),
+            execute=True,
+        )
+        loopx_cli = [
+            sys.executable, "-m", "loopx.cli", "--runtime-root",
+            str(runtime_root), "--format", "json",
+        ]
+        reviewer_cli_args = [
+            *loopx_cli,
+            "issue-fix",
+            "reviewer-request",
+            "--url",
+            "https://github.com/owner/repo/pull/42",
+            "--repo-path",
+            str(path),
+            "--base-ref",
+            "main",
+            "--changed-file",
+            "src/map_only.py",
+            "--exclude-reviewer",
+            "@fallback-owner",
+            "--reviewer-sources-json",
+            str(reviewer_sources_path),
+            "--metadata-json",
+            str(metadata_path),
+            "--notification-sinks-json",
+            str(notification_sinks_path),
+        ]
         cli = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "loopx.cli",
-                "--format",
-                "json",
-                "issue-fix",
-                "reviewer-request",
-                "--url",
-                "https://github.com/owner/repo/pull/42",
-                "--repo-path",
-                str(path),
-                "--base-ref",
-                "main",
-                "--changed-file",
-                "src/map_only.py",
-                "--exclude-reviewer",
-                "@fallback-owner",
-                "--reviewer-sources-json",
-                str(reviewer_sources_path),
-                "--metadata-json",
-                str(metadata_path),
-                "--notification-sinks-json",
-                str(notification_sinks_path),
-            ],
+            reviewer_cli_args,
             cwd=ROOT,
             text=True,
             stdout=subprocess.PIPE,
@@ -987,6 +999,11 @@ def main() -> int:
         assert cli_packet["reviewer_source_count"] == 1
         assert cli_packet["external_writes_performed"] is False
         assert cli_packet["secondary_notification_status"] == "preview_ready"
+        assert cli_packet["extension_activation"]["required_permissions"] == [
+            "lark.inbox.read",
+            "lark.inbox.write",
+            "lark.reply.send",
+        ]
         assert (
             cli_packet["secondary_notifications"]["results"][0][
                 "private_destination_captured"
@@ -1139,13 +1156,9 @@ def main() -> int:
         upsert_issue_fix_pr_lifecycle_ledger_jsonl(legacy_request_lifecycle_path, legacy_request_row)
         goal_default_cli = subprocess.run(
             [
-                sys.executable,
-                "-m",
-                "loopx.cli",
+                *loopx_cli,
                 "--registry",
                 str(registry),
-                "--format",
-                "json",
                 "issue-fix",
                 "reviewer-request",
                 "--url",
@@ -1309,13 +1322,9 @@ def main() -> int:
         )
         invalid_execute_cli = subprocess.run(
             [
-                sys.executable,
-                "-m",
-                "loopx.cli",
+                *loopx_cli,
                 "--registry",
                 str(registry),
-                "--format",
-                "json",
                 "issue-fix",
                 "reviewer-request",
                 "--url",
@@ -1348,11 +1357,7 @@ def main() -> int:
         )
         project_registry_cli = subprocess.run(
             [
-                sys.executable,
-                "-m",
-                "loopx.cli",
-                "--format",
-                "json",
+                *loopx_cli,
                 "issue-fix",
                 "reviewer-request",
                 "--url",
@@ -1458,13 +1463,9 @@ def main() -> int:
         assert stored_lifecycle["maintainer_correction_body_captured"] is False
         explicit_scoped_cli = subprocess.run(
             [
-                sys.executable,
-                "-m",
-                "loopx.cli",
+                *loopx_cli,
                 "--registry",
                 str(registry),
-                "--format",
-                "json",
                 "issue-fix",
                 "reviewer-request",
                 "--url",

--- a/examples/lark-extension-activation-smoke.py
+++ b/examples/lark-extension-activation-smoke.py
@@ -56,6 +56,25 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-extension-") as raw_temp:
         ),
         encoding="utf-8",
     )
+    reviewer_config = project / ".loopx" / "config" / "reviewer-notifications.json"
+    reviewer_config.write_text(
+        json.dumps(
+            {
+                "schema_version": "issue_fix_reviewer_notification_sinks_input_v0",
+                "feedback_inbox_config": ".loopx/config/lark-event-inbox.json",
+                "sinks": [
+                    {
+                        "sink_kind": "lark_chat",
+                        "reader_profile": "fixture-reader",
+                        "reader_identity": "user",
+                        "sender_profile": "fixture-bot",
+                        "sender_identity": "bot",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
     registry = project / ".loopx" / "registry.json"
     registry.write_text(
         json.dumps(
@@ -68,7 +87,15 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-extension-") as raw_temp:
                             "lark_event_inbox": {
                                 "enabled": True,
                                 "config_path": ".loopx/config/lark-event-inbox.json",
-                            }
+                            },
+                            "issue_fix": {
+                                "reviewer_notification": {
+                                    "enabled": True,
+                                    "config_path": (
+                                        ".loopx/config/reviewer-notifications.json"
+                                    ),
+                                }
+                            },
                         },
                     }
                 ]
@@ -82,6 +109,12 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-extension-") as raw_temp:
         "--goal-id",
         "lark-extension-fixture",
     )
+    reviewer_drain_args = (
+        "issue-fix",
+        "reviewer-feedback-inbox",
+        "--goal-id",
+        "lark-extension-fixture",
+    )
 
     missing = run_cli(
         registry,
@@ -90,6 +123,13 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-extension-") as raw_temp:
         expected_returncode=1,
     )
     assert "not installed" in str(missing["error"]), missing
+    reviewer_missing = run_cli(
+        registry,
+        runtime_root,
+        *reviewer_drain_args,
+        expected_returncode=1,
+    )
+    assert "not installed" in str(reviewer_missing["error"]), reviewer_missing
 
     installed = run_cli(
         registry,
@@ -111,6 +151,16 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-extension-") as raw_temp:
         "doctor_verified": True,
         "required_permissions": ["lark.inbox.read"],
     }, active
+    reviewer_active = run_cli(registry, runtime_root, *reviewer_drain_args)
+    assert reviewer_active["configured_reviewer_group"] is True, reviewer_active
+    assert reviewer_active["extension_activation"] == {
+        **active["extension_activation"],
+        "required_permissions": [
+            "lark.inbox.read",
+            "lark.inbox.write",
+            "lark.reply.send",
+        ],
+    }, reviewer_active
 
     disabled = run_cli(
         registry,
@@ -128,6 +178,13 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-extension-") as raw_temp:
         expected_returncode=1,
     )
     assert "is disabled" in str(blocked["error"]), blocked
+    reviewer_blocked = run_cli(
+        registry,
+        runtime_root,
+        *reviewer_drain_args,
+        expected_returncode=1,
+    )
+    assert "is disabled" in str(reviewer_blocked["error"]), reviewer_blocked
 
     enabled = run_cli(
         registry,
@@ -161,6 +218,11 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-extension-") as raw_temp:
     assert upgraded["previous_revision"] == installed["revision"], upgraded
     after_upgrade = run_cli(registry, runtime_root, *drain_args)
     assert after_upgrade["extension_activation"]["revision"] == upgraded["revision"]
+    reviewer_after_upgrade = run_cli(registry, runtime_root, *reviewer_drain_args)
+    assert (
+        reviewer_after_upgrade["extension_activation"]["revision"]
+        == upgraded["revision"]
+    )
 
     rolled_back = run_cli(
         registry,

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -60,6 +60,7 @@ from .pr_lifecycle import (
     validate_issue_fix_pr_lifecycle_monitor_packet,
 )
 from .pr_lifecycle_rollout import append_pr_merge_rollout_event
+from .provider_hooks import ReviewerInboxHooksFactory
 from . import pr_gate_reconcile_cli
 from .reviewer_cli import (
     REVIEWER_COMMANDS,
@@ -871,6 +872,7 @@ def handle_issue_fix_command(
     *,
     registry_path: Path | None = None,
     runtime_root_arg: str | None = None,
+    reviewer_inbox_hooks_factory: ReviewerInboxHooksFactory | None = None,
     output_format: FormatSelector,
     print_payload: PrintPayload,
 ) -> int:
@@ -882,6 +884,7 @@ def handle_issue_fix_command(
             registry_path=registry_path,
             generated_at=generated_at,
             delivery_observed_at=invocation_at,
+            reviewer_inbox_hooks_factory=reviewer_inbox_hooks_factory,
         )
         if reviewer_result is not None:
             payload, renderer = reviewer_result

--- a/loopx/capabilities/issue_fix/provider_hooks.py
+++ b/loopx/capabilities/issue_fix/provider_hooks.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+InboxOperation = Callable[..., dict[str, Any]]
+InboxContainsText = Callable[..., bool]
+
+
+@dataclass(frozen=True)
+class ReviewerInboxHooks:
+    """Provider-neutral operations used by issue-fix reviewer workflows."""
+
+    inspect: InboxOperation
+    acknowledge: InboxOperation
+    contains_text: InboxContainsText
+    activation: Mapping[str, object]
+
+
+ReviewerInboxHooksFactory = Callable[[], ReviewerInboxHooks]

--- a/loopx/capabilities/issue_fix/reviewer_cli.py
+++ b/loopx/capabilities/issue_fix/reviewer_cli.py
@@ -11,11 +11,6 @@ from ...domain_packs.issue_fix import (
     persist_issue_fix_reviewer_notification_state,
     upsert_issue_fix_pr_lifecycle_ledger_jsonl,
 )
-from ...extensions.lark.event_inbox import (
-    acknowledge_lark_event_inbox,
-    inspect_lark_event_inbox,
-    lark_event_inbox_contains_text,
-)
 from ..reward_memory.experiment import (
     resolve_reward_memory_experiment,
     resolve_reward_memory_surface_config,
@@ -23,6 +18,7 @@ from ..reward_memory.experiment import (
 from .cli_input import load_json_object, load_jsonl_row
 from .metadata_preview import normalise_github_issue_reference
 from .pr_lifecycle import build_issue_fix_pr_lifecycle_monitor_packet
+from .provider_hooks import ReviewerInboxHooks, ReviewerInboxHooksFactory
 from .reviewer_notification import (
     load_goal_reviewer_notification_sinks_input,
     reviewer_notification_legacy_queue_from_state,
@@ -407,7 +403,29 @@ def handle_issue_fix_reviewer_command(
     registry_path: Path | None,
     generated_at: str,
     delivery_observed_at: str,
+    reviewer_inbox_hooks_factory: ReviewerInboxHooksFactory | None = None,
 ) -> tuple[dict[str, Any], Renderer] | None:
+    reviewer_inbox_hooks: ReviewerInboxHooks | None = None
+
+    def require_reviewer_inbox_hooks() -> ReviewerInboxHooks:
+        nonlocal reviewer_inbox_hooks
+        if reviewer_inbox_hooks is None:
+            if reviewer_inbox_hooks_factory is None:
+                raise ValueError(
+                    "configured reviewer feedback inbox requires an enabled provider"
+                )
+            reviewer_inbox_hooks = reviewer_inbox_hooks_factory()
+        return reviewer_inbox_hooks
+
+    def lark_sink_configured(value: Mapping[str, Any] | None) -> bool:
+        return bool(
+            value
+            and any(
+                isinstance(sink, Mapping) and sink.get("sink_kind") == "lark_chat"
+                for sink in (value.get("sinks") or [])
+            )
+        )
+
     if args.issue_fix_command == "reviewer-plan":
         payload = build_issue_fix_reviewer_recommendation_packet(
             repo_path=args.repo_path,
@@ -443,13 +461,7 @@ def handle_issue_fix_reviewer_command(
             goal=goal,
             project=requested_project,
         )
-        lark_group_configured = bool(
-            sinks_input
-            and any(
-                isinstance(sink, dict) and sink.get("sink_kind") == "lark_chat"
-                for sink in (sinks_input.get("sinks") or [])
-            )
-        )
+        lark_group_configured = lark_sink_configured(sinks_input)
         if not lark_group_configured:
             payload = {
                 "ok": True,
@@ -462,19 +474,20 @@ def handle_issue_fix_reviewer_command(
                 "external_reads_performed": False,
             }
         else:
+            inbox_hooks = require_reviewer_inbox_hooks()
             config_ref = str(
                 sinks_input.get("feedback_inbox_config")
                 or ".loopx/config/lark/event-inbox.json"
             )
             if args.message_id:
-                payload = acknowledge_lark_event_inbox(
+                payload = inbox_hooks.acknowledge(
                     project=requested_project,
                     config_path=config_ref,
                     message_ids=args.message_id,
                     execute=args.execute,
                 )
             else:
-                payload = inspect_lark_event_inbox(
+                payload = inbox_hooks.inspect(
                     project=requested_project,
                     config_path=config_ref,
                     limit=args.limit,
@@ -484,6 +497,7 @@ def handle_issue_fix_reviewer_command(
                 "mode": "issue-fix-reviewer-feedback-inbox",
                 "configured_reviewer_group": True,
                 "source": "goal_default_lark_event_inbox",
+                "extension_activation": dict(inbox_hooks.activation),
             }
         return payload, render_issue_fix_reviewer_feedback_inbox_markdown
 
@@ -518,12 +532,10 @@ def handle_issue_fix_reviewer_command(
                 project=requested_project,
                 goal_id=args.goal_id,
             )
-            lark_group_configured = any(
-                isinstance(sink, Mapping) and sink.get("sink_kind") == "lark_chat"
-                for sink in (sinks_input.get("sinks") or [])
-            )
+            lark_group_configured = lark_sink_configured(sinks_input)
             semantic_history_matcher = None
             if lark_group_configured:
+                inbox_hooks = require_reviewer_inbox_hooks()
                 default_config_ref = str(
                     sinks_input.get("feedback_inbox_config")
                     or ".loopx/config/lark/event-inbox.json"
@@ -543,7 +555,7 @@ def handle_issue_fix_reviewer_command(
                     ).strip()
                     if not sink_config_ref and lark_sink_count != 1:
                         return None
-                    return lark_event_inbox_contains_text(
+                    return inbox_hooks.contains_text(
                         project=requested_project,
                         config_path=sink_config_ref or default_config_ref,
                         text=permalink,
@@ -557,6 +569,8 @@ def handle_issue_fix_reviewer_command(
                 limit=args.limit,
                 semantic_history_matcher=semantic_history_matcher,
             )
+            if lark_group_configured:
+                payload["extension_activation"] = dict(inbox_hooks.activation)
             payload["notification_source"] = "goal_default"
         return payload, render_issue_fix_reviewer_notification_drain_markdown
 
@@ -658,18 +672,17 @@ def handle_issue_fix_reviewer_command(
                 existing_queued_receipts = reviewer_notification_queue_from_state(
                     notification_lifecycle_packet
                 )
-                lark_group_configured = any(
-                    isinstance(sink, Mapping)
-                    and sink.get("sink_kind") == "lark_chat"
-                    for sink in (notification_sinks_input.get("sinks") or [])
+                lark_group_configured = lark_sink_configured(
+                    notification_sinks_input
                 )
                 if lark_group_configured:
+                    inbox_hooks = require_reviewer_inbox_hooks()
                     config_ref = str(
                         notification_sinks_input.get("feedback_inbox_config")
                         or ".loopx/config/lark/event-inbox.json"
                     )
                     try:
-                        history_match = lark_event_inbox_contains_text(
+                        history_match = inbox_hooks.contains_text(
                             project=requested_project,
                             config_path=config_ref,
                             text=str(reference["permalink"]),
@@ -750,6 +763,8 @@ def handle_issue_fix_reviewer_command(
                             "config": experiment_config,
                             "observed_at": generated_at,
                         }
+    if lark_sink_configured(notification_sinks_input):
+        require_reviewer_inbox_hooks()
     payload = build_issue_fix_reviewer_request_packet(
         repo_path=args.repo_path,
         url=args.url,
@@ -786,6 +801,8 @@ def handle_issue_fix_reviewer_command(
         notification_lifecycle_materialized
     )
     payload["secondary_notification_semantic_history_status"] = semantic_history_status
+    if reviewer_inbox_hooks is not None:
+        payload["extension_activation"] = dict(reviewer_inbox_hooks.activation)
     if legacy_queue_blocker is not None:
         payload["secondary_notification_blocker"] = legacy_queue_blocker
     payload["secondary_notification_receipts_persisted"] = False

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -82,6 +82,7 @@ from .cli_commands import (
     register_explore_commands,
     register_history_command,
     register_lark_inbox_commands,
+    build_lark_issue_fix_reviewer_inbox_hooks,
     register_lark_kanban_commands,
     register_ml_experiment_commands,
     register_multi_agent_commands,
@@ -416,6 +417,11 @@ def main(argv: list[str] | None = None) -> int:
             args,
             registry_path=registry_path,
             runtime_root_arg=args.runtime_root,
+            reviewer_inbox_hooks_factory=(
+                lambda: build_lark_issue_fix_reviewer_inbox_hooks(
+                    runtime_root_arg=args.runtime_root
+                )
+            ),
             output_format=output_format,
             print_payload=print_payload,
         )

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -87,7 +87,11 @@ from .dreaming import handle_dreaming_command, register_dreaming_commands
 from .evidence_log import handle_evidence_log_command, register_evidence_log_command
 from .explore import handle_explore_command, register_explore_commands
 from .history import handle_history_command, register_history_command
-from .lark_inbox import handle_lark_inbox_command, register_lark_inbox_commands
+from .lark_inbox import (
+    build_lark_issue_fix_reviewer_inbox_hooks,
+    handle_lark_inbox_command,
+    register_lark_inbox_commands,
+)
 from .lark_kanban import handle_lark_kanban_command, register_lark_kanban_commands
 from .ml_experiment import handle_ml_experiment_command, register_ml_experiment_commands
 from .multi_agent import handle_multi_agent_command, register_multi_agent_commands

--- a/loopx/cli_commands/lark_inbox.py
+++ b/loopx/cli_commands/lark_inbox.py
@@ -17,6 +17,7 @@ from ..extensions.lark.event_inbox import (
     acknowledge_lark_event_inbox,
     ingest_lark_event_inbox,
     inspect_lark_event_inbox,
+    lark_event_inbox_contains_text,
 )
 from ..extensions.lark.inbox_reply import reply_lark_event_inbox
 from ..extensions.lark.event_collector import (
@@ -29,6 +30,7 @@ from ..extensions.runtime import (
     default_extension_state_file,
     resolve_extension_activation,
 )
+from ..capabilities.issue_fix.provider_hooks import ReviewerInboxHooks
 from ..control_plane.runtime.goal_project_route import resolve_goal_project_route
 
 
@@ -182,6 +184,26 @@ def _resolve_lark_activation(
         LARK_EXTENSION_ID,
         state_file=default_extension_state_file(runtime_root_arg),
         required_permissions=_required_extension_permissions(command),
+    )
+
+
+def build_lark_issue_fix_reviewer_inbox_hooks(
+    *, runtime_root_arg: str | None
+) -> ReviewerInboxHooks:
+    activation = resolve_extension_activation(
+        LARK_EXTENSION_ID,
+        state_file=default_extension_state_file(runtime_root_arg),
+        required_permissions=(
+            LARK_INBOX_READ_PERMISSION,
+            LARK_INBOX_WRITE_PERMISSION,
+            LARK_REPLY_PERMISSION,
+        ),
+    )
+    return ReviewerInboxHooks(
+        inspect=inspect_lark_event_inbox,
+        acknowledge=acknowledge_lark_event_inbox,
+        contains_text=lark_event_inbox_contains_text,
+        activation=activation,
     )
 
 

--- a/tests/architecture/test_control_plane_import_boundaries.py
+++ b/tests/architecture/test_control_plane_import_boundaries.py
@@ -10,6 +10,9 @@ CONTROL_PLANE_ROOT = PACKAGE_ROOT / "control_plane"
 STATUS_MODULE = PACKAGE_ROOT / "status.py"
 QUOTA_MODULE = PACKAGE_ROOT / "quota.py"
 LARK_INBOX_CLI_MODULE = PACKAGE_ROOT / "cli_commands" / "lark_inbox.py"
+ISSUE_FIX_REVIEWER_CLI_MODULE = (
+    PACKAGE_ROOT / "capabilities" / "issue_fix" / "reviewer_cli.py"
+)
 LARK_EXTENSION_ROOT = PACKAGE_ROOT / "extensions" / "lark"
 LEGACY_LARK_CAPABILITY_ROOT = PACKAGE_ROOT / "capabilities" / "lark"
 FORBIDDEN_DEPENDENCY_PREFIXES = (
@@ -141,3 +144,14 @@ def test_lark_inbox_provider_is_owned_by_the_extension_layer() -> None:
     } <= imports
     assert (LARK_EXTENSION_ROOT / "extension.toml").is_file()
     assert (LARK_EXTENSION_ROOT / "provider.py").is_file()
+
+
+def test_issue_fix_reviewer_uses_provider_neutral_inbox_hooks() -> None:
+    imports = _resolved_imports(ISSUE_FIX_REVIEWER_CLI_MODULE)
+
+    assert not any(
+        dependency == "loopx.extensions.lark"
+        or dependency.startswith("loopx.extensions.lark.")
+        for dependency in imports
+    )
+    assert "loopx.capabilities.issue_fix.provider_hooks" in imports


### PR DESCRIPTION
## Summary
- remove the issue-fix reviewer CLI's direct dependency on the bundled Lark inbox implementation
- inject provider-neutral inbox hooks only after resolving the installed, enabled, doctor-verified `loopx-lark` activation
- fail closed for explicit and goal-default Lark reviewer sinks, with activation evidence and disable/upgrade regressions

## Validation
- `loopx canary premerge --from-git-diff --tier standard` (10/10 selected checks; 4/4 direct checks; 0 failures; 0 manual holds)
- full `pytest`: 752 passed, 2 skipped (isolated `XDG_STATE_HOME`)
- `examples/issue-fix-reviewer-request-smoke.py`
- `examples/lark-extension-activation-smoke.py`
- architecture import-boundary tests: 5 passed

## Scope
This closes the issue-fix activation bypass. Extraction of the remaining default Lark notification adapter, presentation sinks, and full dispatch stays in the existing LoopX todo.
