### PR TITLE
fix(doctor): preserve install source ref on upgrade

### DIFF
--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -5,6 +5,7 @@ from enum import Enum
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -23,11 +24,6 @@ PROMOTION_READINESS_CLASSIFICATIONS = {
 PROMOTION_READINESS_FRESHNESS_HOURS = 24
 INSTALL_FRESHNESS_STALE_HOURS = 168
 NO_CLONE_INSTALL_URL = "https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh"
-NO_CLONE_UPGRADE_COMMAND = (
-    f"curl -fsSL {NO_CLONE_INSTALL_URL} | bash\n"
-    'export PATH="$HOME/.local/bin:$PATH"\n'
-    "loopx doctor"
-)
 RELEASE_ID_TIMESTAMP_RE = re.compile(r"^\d{8}T\d{6}Z$")
 REQUIRED_INSTALLED_SKILL_PHRASES = {
     "loopx-project": (
@@ -63,6 +59,20 @@ class GitRevisionRelation(str, Enum):
     INSTALLED_BEHIND = "installed_behind"
     DIVERGED = "diverged"
     UNKNOWN = "unknown"
+
+
+def no_clone_upgrade_command(source_ref: Any = None) -> str:
+    ref = str(source_ref or "").strip()
+    installer = f"curl -fsSL {NO_CLONE_INSTALL_URL}"
+    if ref and ref != "stable":
+        installer = f"{installer} | env LOOPX_REF={shlex.quote(ref)} bash"
+    else:
+        installer = f"{installer} | bash"
+    return (
+        f"{installer}\n"
+        'export PATH="$HOME/.local/bin:$PATH"\n'
+        "loopx doctor"
+    )
 
 
 def user_local_bin() -> Path:
@@ -365,7 +375,6 @@ def build_install_freshness(
         reason = "current command is not a timestamped release snapshot"
         requires_upgrade = False
 
-    contributor_upgrade_command = f"{repo_root / 'scripts' / 'install-local.sh'}\nloopx doctor"
     manifest = release_manifest if isinstance(release_manifest, dict) else {}
     manifest_body = manifest.get("manifest") if isinstance(manifest.get("manifest"), dict) else {}
     manifest_package = (
@@ -386,6 +395,8 @@ def build_install_freshness(
     manifest_source = (
         manifest_body.get("source") if isinstance(manifest_body.get("source"), dict) else {}
     )
+    upgrade_command = no_clone_upgrade_command(manifest_source.get("ref"))
+    contributor_upgrade_command = f"{repo_root / 'scripts' / 'install-local.sh'}\nloopx doctor"
     manifest_source_git_commit = manifest_source.get("git_commit")
     manifest_source_revision = (
         manifest_source_git_commit
@@ -442,8 +453,8 @@ def build_install_freshness(
         "stale_after_hours": INSTALL_FRESHNESS_STALE_HOURS,
         "release_id": release_id,
         "release_age_hours": age_hours,
-        "upgrade_command": NO_CLONE_UPGRADE_COMMAND,
-        "no_clone_upgrade_command": NO_CLONE_UPGRADE_COMMAND,
+        "upgrade_command": upgrade_command,
+        "no_clone_upgrade_command": upgrade_command,
         "contributor_upgrade_command": contributor_upgrade_command,
         "doctor_after_upgrade": "loopx doctor",
         "release_manifest_available": manifest.get("available"),

--- a/tests/test_doctor_install_freshness.py
+++ b/tests/test_doctor_install_freshness.py
@@ -37,6 +37,7 @@ def _freshness(
     revision_relation: str,
     freshness_commit: str | None = None,
     freshness_relation: str | None = None,
+    source_ref: str | None = None,
 ) -> dict[str, object]:
     return build_install_freshness(
         command_path=tmp_path / "loopx",
@@ -47,7 +48,10 @@ def _freshness(
             "available": True,
             "manifest": {
                 "package": {"version": __version__},
-                "source": {"git_commit": installed_commit},
+                "source": {
+                    "git_commit": installed_commit,
+                    "ref": source_ref,
+                },
             },
         },
         comparison_source={
@@ -146,6 +150,44 @@ def test_trusted_main_ref_stales_older_default_release(tmp_path: Path) -> None:
     assert freshness["status"] == "stale"
     assert freshness["requires_upgrade"] is True
     assert "is behind loopx/loopx@main" in str(freshness["reason"])
+
+
+def test_main_channel_upgrade_command_preserves_source_ref(tmp_path: Path) -> None:
+    current = "a" * 40
+    freshness = _freshness(
+        tmp_path,
+        installed_commit=current,
+        comparison_commit=current,
+        revision_relation="same",
+        freshness_commit=current,
+        freshness_relation="same",
+        source_ref="main",
+    )
+
+    command = str(freshness["no_clone_upgrade_command"])
+    assert (
+        "curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/"
+        "scripts/install-from-github.sh | env LOOPX_REF=main bash"
+    ) in command
+    assert freshness["upgrade_command"] == command
+
+
+def test_stable_channel_upgrade_command_keeps_public_default(tmp_path: Path) -> None:
+    current = "a" * 40
+    freshness = _freshness(
+        tmp_path,
+        installed_commit=current,
+        comparison_commit=current,
+        revision_relation="same",
+        freshness_commit=current,
+        freshness_relation="same",
+        source_ref="stable",
+    )
+
+    command = str(freshness["no_clone_upgrade_command"])
+    assert "LOOPX_REF=" not in command
+    assert "scripts/install-from-github.sh | bash" in command
+    assert freshness["upgrade_command"] == command
 
 
 def test_unknown_canary_relation_does_not_stale_current_default_release(tmp_path: Path) -> None:


### PR DESCRIPTION
## Root cause

`loopx doctor` compares an installed release against the manifest source ref, but its no-clone upgrade command was constant. For a stale `main`-channel install, running the suggested command invoked the installer without `LOOPX_REF`, so the installer correctly fell back to its public `stable` default instead of updating the channel doctor had diagnosed.

## Change

- Build the doctor upgrade command from `release_manifest.manifest.source.ref`.
- Pass non-stable refs to the installer as `env LOOPX_REF=<quoted-ref> bash`.
- Keep the existing public stable command unchanged.
- Cover both main-channel preservation and stable-default behavior.

## Validation

- `pytest -q tests/test_doctor_install_freshness.py`: 7 passed
- full `pytest -q` in an isolated HOME: 754 passed, 2 skipped
- Ruff on changed Python files: passed
- `loopx canary premerge --from-git-diff`: passed; 4/4 catalog checks, 0 warnings, 0 manual holds
- public/private scan: clean; no credentials, private state, raw logs, or local paths added

## Merge hold

Runtime install/doctor behavior should receive independent review before merge; this PR is not self-merged.