### PR TITLE
Keep peer workspace-guard canary compatible with todo authority

### DIFF
--- a/examples/control_plane/peer-agent-workspace-guard-smoke.py
+++ b/examples/control_plane/peer-agent-workspace-guard-smoke.py
@@ -169,6 +169,8 @@ def set_task_repository(project: Path, runtime: Path, registry_path: Path) -> No
         "agent",
         "--todo-id",
         "todo_workspace_guard",
+        "--agent-id",
+        PEER_ALPHA,
         "--task-repository",
         "https://example.invalid/loopx/task-repo.git",
         registry_path=registry_path,


### PR DESCRIPTION
Summary:
- attribute the workspace-guard todo update to the registered peer agent
- keep the smoke aligned with the multi-agent lifecycle mutation authority contract from #2298

Validation:
- peer-agent-workspace-guard-smoke.py
- peer-agent-runtime-v1-smoke.py
- ruff and Python compile
- loopx check public-boundary scan
- loopx canary premerge --from-git-diff (passed, self-merge allowed)

This is a focused smoke-fixture repair; it does not change product/runtime behavior.