### PR TITLE
Derive agent material frontiers from goal authority

### DIFF
--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -17,6 +17,7 @@ Current contracts:
 - [Action packet router comparison v0](protocol-action-packet-router-comparison-v0.md)
 - [task_graph_projection_v0](task-graph-projection-v0.md)
 - [agent_management_projection_v0](agent-management-projection-v0.md)
+- [agent_material_frontier_v0](agent-material-frontier-v0.md)
 - [todo_detail_cold_path_v0](todo-detail-cold-path-v0.md)
 - [long_horizon_agent_state_protocol_v0](long-horizon-agent-state-protocol-v0.md)
 - [model_behavior_qualification_v0](model-behavior-qualification-v0.md)

--- a/docs/reference/protocols/agent-material-frontier-v0.md
+++ b/docs/reference/protocols/agent-material-frontier-v0.md
@@ -1,0 +1,140 @@
+# agent_material_frontier_v0
+
+`agent_material_frontier_v0` is a read-only, agent-scoped view over
+goal-owned material authority. It answers which registered material refs an
+agent needs, which revision it observed, and whether each ref is current,
+stale, missing, unread, or inaccessible.
+
+The frontier is not a second material registry. Material ids, revisions,
+topics, freshness, boundaries, and gates remain owned by the goal's canonical
+`authority_registry.project_materials` and `topic_authority` maps.
+
+## Inputs
+
+The pure builder accepts six bounded input groups:
+
+- canonical goal authority: material metadata and topic-to-material mappings;
+- agent profile requirements: explicit material refs or default material
+  topics;
+- todo requirements: explicit material refs for current work;
+- an agent vision requirement set;
+- handoff material refs inherited by a successor;
+- `material_usage_receipt_v0` rows for the selected agent and todo.
+
+Requirement precedence is:
+
+```text
+explicit todo or handoff > vision > profile topic default
+```
+
+Multiple bindings for the same material are preserved in `bound_by`. The
+highest-precedence binding selects the relation and purpose, while the current
+revision and boundary are always re-read from goal authority.
+
+## Shape
+
+```json
+{
+  "schema_version": "agent_material_frontier_v0",
+  "goal_id": "example-goal",
+  "agent_id": "agent-reviewer",
+  "generated_at": "2026-07-19T00:00:00Z",
+  "summary": {
+    "required_count": 2,
+    "current_count": 1,
+    "stale_count": 0,
+    "missing_count": 0,
+    "inaccessible_count": 0,
+    "required_unread_count": 1
+  },
+  "items": [],
+  "required_reads": [],
+  "truth_contract": {
+    "authority_is_goal_owned": true,
+    "projection_is_read_only": true,
+    "introduces_task_runtime": false,
+    "grants_cross_agent_authority": false,
+    "evidence_log_implies_material_read": false,
+    "raw_source_body_recorded": false
+  }
+}
+```
+
+Each item may contain:
+
+- `material_id` and authority-derived `topics`;
+- `relation`: `required`, `producer`, `reviewer`, `maintainer`, or `watcher`;
+- `bound_by`: compact `profile`, `todo`, `vision`, or `handoff` refs;
+- `purpose` and `todo_id`;
+- `required_revision` and `observed_revision`;
+- `state`;
+- `boundary` and `gate_status`;
+- a compact `receipt_ref` and `last_verified_at`.
+
+The projection never copies source URLs, document bodies, comments,
+credentials, local absolute paths, or another agent's expanded event stream.
+
+## State Rules
+
+State is derived in this order:
+
+1. The material id is absent from canonical authority: `missing`.
+2. Its boundary or gate is unavailable to the current execution environment:
+   `inaccessible`.
+3. No matching receipt exists for the current agent and todo:
+   `required_unread`.
+4. Authority freshness is stale or the observed revision differs from the
+   authority revision: `stale`.
+5. The observed revision equals the current authority revision: `current`.
+
+A compact authority summary is not enough to derive the frontier. The builder
+fails closed unless canonical `project_materials` are present, so a projected
+count can never be mistaken for an empty authority registry.
+An omitted boundary is also treated as inaccessible rather than implicitly
+public.
+
+Evidence and receipts have different semantics. A run-history or evidence-log
+row may prove that an agent changed or validated an artifact, but it does not
+prove the agent consumed a material revision. Only a matching
+`material_usage_receipt_v0` can move a material from unread or stale to
+current. Receipt-like evidence without the receipt schema, agent, goal, todo,
+stable id, outcome, and timestamp fails closed.
+
+## Handoff Semantics
+
+A successor may receive the same required material ids through handoff, then
+rebuild its own frontier from goal authority. The predecessor's receipt does
+not make the successor current, and the handoff does not transfer source
+permissions or authority ownership.
+
+This supports durable handoff without introducing a dispatcher or an
+agent-owned material cache.
+
+## Current Delivery Boundary
+
+The current implementation is a pure cold-path read model. It intentionally
+does not add:
+
+- profile/todo material-requirement authoring commands;
+- a material body cache;
+- a receipt append command;
+- automatic authorization or gate creation;
+- a cross-agent dispatcher;
+- an MA- or runtime-specific field.
+
+Later integrations may attach the bounded summary and up to a few refs to
+agent-management or handoff projections. Those integrations must continue to
+resolve revisions and boundaries from goal authority.
+
+## Acceptance Checks
+
+A durable fixture should prove:
+
+- profile topics and explicit requirements merge deterministically;
+- todo or handoff requirements override a profile watcher relation;
+- unread, current, stale, missing, and inaccessible states are distinct;
+- an authority revision change makes an older receipt stale;
+- another agent's receipt never satisfies the current agent;
+- a successor gets the same material refs without inherited authority;
+- compact authority summaries fail closed;
+- the emitted packet contains no raw source material or private paths.

--- a/examples/control_plane/agent-material-frontier-smoke.py
+++ b/examples/control_plane/agent-material-frontier-smoke.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Smoke-test the read-only agent material frontier contract."""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.agents.material_frontier import (  # noqa: E402
+    build_agent_material_frontier,
+)
+
+
+GOAL_ID = "material-frontier-fixture"
+AGENT_ID = "agent-builder"
+SUCCESSOR_ID = "agent-reviewer"
+TODO_ID = "todo_material_frontier"
+
+
+def authority_registry() -> dict:
+    return {
+        "project_materials": {
+            "design-contract": {
+                "id": "design-contract",
+                "revision": "rev-2",
+                "freshness": "current",
+                "boundary": "public_safe",
+                "gate_status": "registered",
+                "source_ref_redacted": "registered-public-source",
+            },
+            "private-runbook": {
+                "id": "private-runbook",
+                "revision": "rev-1",
+                "freshness": "current",
+                "boundary": "private_redacted",
+                "gate_status": "registered",
+                "source_ref_redacted": "registered-private-source",
+            },
+            "stale-review": {
+                "id": "stale-review",
+                "revision": "rev-3",
+                "freshness": "stale",
+                "boundary": "public",
+                "gate_status": "registered",
+            },
+        },
+        "topic_authority": {
+            "runtime-design": "design-contract",
+        },
+    }
+
+
+def requirements() -> tuple[dict, dict, dict, dict]:
+    profile = {
+        "agent_id": AGENT_ID,
+        "material_topics": ["runtime-design"],
+    }
+    vision = {
+        "vision_id": "vision_material_frontier",
+        "material_refs": [
+            {
+                "material_id": "design-contract",
+                "relation": "reviewer",
+                "purpose": "review the current contract",
+            }
+        ],
+    }
+    todo = {
+        "todo_id": TODO_ID,
+        "material_refs": [
+            {
+                "material_id": "design-contract",
+                "relation": "required",
+                "purpose": "implement the current revision",
+            },
+            {"material_id": "private-runbook", "relation": "required"},
+            {"material_id": "stale-review", "relation": "reviewer"},
+            {"material_id": "missing-source", "relation": "required"},
+        ],
+        "evidence_refs": ["run:evidence-does-not-prove-a-read"],
+    }
+    handoff = {
+        "schema_version": "handoff_note_v1",
+        "handoff_id": "handoff_material_frontier",
+        "todo_id": TODO_ID,
+        "material_refs": copy.deepcopy(todo["material_refs"]),
+    }
+    return profile, vision, todo, handoff
+
+
+def receipt(
+    *,
+    agent_id: str,
+    material_id: str,
+    observed_revision: str,
+    receipt_id: str,
+) -> dict:
+    return {
+        "schema_version": "material_usage_receipt_v0",
+        "receipt_id": receipt_id,
+        "goal_id": GOAL_ID,
+        "agent_id": agent_id,
+        "todo_id": TODO_ID,
+        "material_id": material_id,
+        "relation": "required",
+        "observed_revision": observed_revision,
+        "outcome": "used",
+        "evidence_ref": f"todo:{TODO_ID}:evidence",
+        "recorded_at": "2026-07-19T00:00:00Z",
+    }
+
+
+def by_material(frontier: dict) -> dict[str, dict]:
+    return {item["material_id"]: item for item in frontier["items"]}
+
+
+def assert_derivation_and_boundaries() -> dict:
+    profile, vision, todo, handoff = requirements()
+    receipts = [
+        receipt(
+            agent_id=AGENT_ID,
+            material_id="design-contract",
+            observed_revision="rev-2",
+            receipt_id="receipt_current",
+        ),
+        receipt(
+            agent_id=AGENT_ID,
+            material_id="stale-review",
+            observed_revision="rev-3",
+            receipt_id="receipt_authority_stale",
+        ),
+        receipt(
+            agent_id=SUCCESSOR_ID,
+            material_id="design-contract",
+            observed_revision="rev-2",
+            receipt_id="receipt_other_agent",
+        ),
+    ]
+    frontier = build_agent_material_frontier(
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        authority_registry=authority_registry(),
+        agent_profile=profile,
+        todos=[todo],
+        vision=vision,
+        handoffs=[handoff],
+        receipts=receipts,
+        generated_at="2026-07-19T00:01:00Z",
+    )
+    items = by_material(frontier)
+    assert frontier["schema_version"] == "agent_material_frontier_v0", frontier
+    assert frontier["summary"] == {
+        "required_count": 4,
+        "current_count": 1,
+        "stale_count": 1,
+        "missing_count": 1,
+        "inaccessible_count": 1,
+        "required_unread_count": 0,
+    }, frontier
+    assert items["design-contract"]["state"] == "current", items
+    assert items["design-contract"]["relation"] == "required", items
+    assert {binding["kind"] for binding in items["design-contract"]["bound_by"]} == {
+        "profile",
+        "vision",
+        "todo",
+        "handoff",
+    }, items
+    assert items["private-runbook"]["state"] == "inaccessible", items
+    assert items["stale-review"]["state"] == "stale", items
+    assert items["missing-source"]["state"] == "missing", items
+    assert "source_ref_redacted" not in json.dumps(frontier, sort_keys=True), frontier
+    assert frontier["truth_contract"] == {
+        "authority_is_goal_owned": True,
+        "projection_is_read_only": True,
+        "introduces_task_runtime": False,
+        "grants_cross_agent_authority": False,
+        "evidence_log_implies_material_read": False,
+        "raw_source_body_recorded": False,
+    }, frontier
+    return frontier
+
+
+def assert_revision_lifecycle() -> None:
+    _, _, todo, _ = requirements()
+    unread = build_agent_material_frontier(
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        authority_registry=authority_registry(),
+        todos={
+            "todo_id": TODO_ID,
+            "material_refs": [todo["material_refs"][0]],
+            "evidence_refs": ["run:still-not-a-receipt"],
+        },
+        receipts=[
+            {
+                "receipt_id": "evidence_shaped_like_receipt",
+                "goal_id": GOAL_ID,
+                "agent_id": AGENT_ID,
+                "todo_id": TODO_ID,
+                "material_id": "design-contract",
+                "observed_revision": "rev-2",
+                "outcome": "used",
+                "recorded_at": "2026-07-19T00:01:30Z",
+            }
+        ],
+        generated_at="2026-07-19T00:02:00Z",
+    )
+    assert by_material(unread)["design-contract"]["state"] == "required_unread", unread
+
+    current_receipt = receipt(
+        agent_id=AGENT_ID,
+        material_id="design-contract",
+        observed_revision="rev-2",
+        receipt_id="receipt_revision_lifecycle",
+    )
+    current = build_agent_material_frontier(
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        authority_registry=authority_registry(),
+        todos={"todo_id": TODO_ID, "material_refs": [todo["material_refs"][0]]},
+        receipts=[current_receipt],
+        generated_at="2026-07-19T00:03:00Z",
+    )
+    assert by_material(current)["design-contract"]["state"] == "current", current
+
+    advanced_authority = authority_registry()
+    advanced_authority["project_materials"]["design-contract"]["revision"] = "rev-3"
+    stale = build_agent_material_frontier(
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        authority_registry=advanced_authority,
+        todos={"todo_id": TODO_ID, "material_refs": [todo["material_refs"][0]]},
+        receipts=[current_receipt],
+        generated_at="2026-07-19T00:04:00Z",
+    )
+    assert by_material(stale)["design-contract"]["state"] == "stale", stale
+
+
+def assert_profile_topic_defaults_to_watcher() -> None:
+    profile, _, _, _ = requirements()
+    frontier = build_agent_material_frontier(
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        authority_registry=authority_registry(),
+        agent_profile=profile,
+        generated_at="2026-07-19T00:04:30Z",
+    )
+    item = by_material(frontier)["design-contract"]
+    assert item["relation"] == "watcher", item
+    assert item["state"] == "required_unread", item
+    assert item["bound_by"] == [{"kind": "profile", "ref": AGENT_ID}], item
+
+
+def assert_handoff_preserves_refs_without_authority_or_receipts() -> None:
+    _, _, todo, handoff = requirements()
+    source = build_agent_material_frontier(
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        authority_registry=authority_registry(),
+        todos=todo,
+        handoffs=handoff,
+        receipts=[
+            receipt(
+                agent_id=AGENT_ID,
+                material_id="design-contract",
+                observed_revision="rev-2",
+                receipt_id="receipt_source_agent",
+            )
+        ],
+        available_boundaries=["private_redacted"],
+        generated_at="2026-07-19T00:05:00Z",
+    )
+    successor = build_agent_material_frontier(
+        goal_id=GOAL_ID,
+        agent_id=SUCCESSOR_ID,
+        authority_registry=authority_registry(),
+        handoffs=handoff,
+        receipts=[],
+        available_boundaries=["private_redacted"],
+        generated_at="2026-07-19T00:06:00Z",
+    )
+    assert set(by_material(source)) == set(by_material(successor)), (source, successor)
+    assert by_material(successor)["design-contract"]["state"] == "required_unread", successor
+    assert by_material(successor)["design-contract"]["required_revision"] == "rev-2", successor
+    assert successor["truth_contract"]["grants_cross_agent_authority"] is False, successor
+
+
+def assert_compact_authority_fails_closed() -> None:
+    try:
+        build_agent_material_frontier(
+            goal_id=GOAL_ID,
+            agent_id=AGENT_ID,
+            authority_registry={"project_material_count": 4},
+            todos={"todo_id": TODO_ID, "material_refs": ["design-contract"]},
+        )
+    except ValueError as exc:
+        assert "canonical authority_registry.project_materials" in str(exc), exc
+    else:
+        raise AssertionError("compact authority summary must not be treated as canonical material truth")
+
+    try:
+        build_agent_material_frontier(
+            goal_id=GOAL_ID,
+            agent_id=AGENT_ID,
+            authority_registry=authority_registry(),
+            agent_profile={
+                "agent_id": AGENT_ID,
+                "material_topics": ["unregistered-topic"],
+            },
+        )
+    except ValueError as exc:
+        assert "material topic is not registered" in str(exc), exc
+    else:
+        raise AssertionError("an unknown profile topic must not produce an empty frontier")
+
+    unknown_boundary = build_agent_material_frontier(
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        authority_registry={
+            "project_materials": {
+                "boundary-unknown": {
+                    "id": "boundary-unknown",
+                    "revision": "rev-1",
+                }
+            },
+            "topic_authority": {},
+        },
+        todos={
+            "todo_id": TODO_ID,
+            "material_refs": ["boundary-unknown"],
+        },
+    )
+    assert by_material(unknown_boundary)["boundary-unknown"]["state"] == "inaccessible"
+
+
+def assert_public_fixture(frontier: dict) -> None:
+    rendered = json.dumps(frontier, ensure_ascii=False, sort_keys=True)
+    for forbidden in (
+        "/Users/",
+        "/private/",
+        "/tmp/",
+        "lark" + "office",
+        "Authorization",
+        "Bearer ",
+        "AK=",
+        "SK=",
+    ):
+        assert forbidden not in rendered, forbidden
+
+
+def main() -> int:
+    frontier = assert_derivation_and_boundaries()
+    assert_revision_lifecycle()
+    assert_profile_topic_defaults_to_watcher()
+    assert_handoff_preserves_refs_without_authority_or_receipts()
+    assert_compact_authority_fails_closed()
+    assert_public_fixture(frontier)
+    print("agent-material-frontier-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/control_plane/agents/material_frontier.py
+++ b/loopx/control_plane/agents/material_frontier.py
@@ -1,0 +1,608 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from datetime import datetime, timezone
+from typing import Any
+
+from ..runtime.public_safety import public_safe_compact_text
+from ..runtime.time import now_utc_iso, parse_timestamp
+
+
+AGENT_MATERIAL_FRONTIER_SCHEMA_VERSION = "agent_material_frontier_v0"
+MATERIAL_USAGE_RECEIPT_SCHEMA_VERSION = "material_usage_receipt_v0"
+
+_PUBLIC_BOUNDARIES = {"public", "public_safe"}
+_BLOCKED_GATE_STATES = {
+    "blocked",
+    "denied",
+    "forbidden",
+    "missing_authority",
+    "owner_gate",
+    "owner_review_required",
+    "private_read_required",
+    "unavailable",
+    "user_gate",
+}
+_STALE_FRESHNESS = {"needs_refresh", "outdated", "stale", "unknown"}
+_RELATIONS = {"required", "producer", "reviewer", "maintainer", "watcher"}
+_RECEIPT_OUTCOMES = {"read", "unavailable", "used", "verified"}
+_RECEIPT_CURRENT_OUTCOMES = {"read", "used", "verified"}
+_REQUIREMENT_FIELDS = (
+    "material_refs",
+    "required_material_refs",
+    "required_materials",
+)
+_TOPIC_FIELDS = (
+    "material_topics",
+    "required_material_topics",
+    "topic_defaults",
+)
+_SOURCE_PRIORITY = {
+    "profile": 10,
+    "vision": 20,
+    "todo": 30,
+    "handoff": 30,
+}
+_STATE_RANK = {
+    "missing": 0,
+    "inaccessible": 1,
+    "stale": 2,
+    "required_unread": 3,
+    "current": 4,
+}
+
+
+def _safe_text(value: Any, *, field: str, limit: int = 180) -> str | None:
+    text = " ".join(str(value or "").strip().split())
+    if not text:
+        return None
+    if len(text) > limit:
+        raise ValueError(f"{field} must be at most {limit} characters")
+    if public_safe_compact_text(text, limit=limit) != text:
+        raise ValueError(f"{field} must be public-safe")
+    return text
+
+
+def _required_text(value: Any, *, field: str, limit: int = 180) -> str:
+    text = _safe_text(value, field=field, limit=limit)
+    if not text:
+        raise ValueError(f"{field} is required")
+    return text
+
+
+def _mapping_list(value: Any) -> list[Mapping[str, Any]]:
+    if isinstance(value, Mapping):
+        return [value]
+    if isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
+        return [item for item in value if isinstance(item, Mapping)]
+    return []
+
+
+def _project_materials(authority_registry: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    if "project_materials" not in authority_registry:
+        raise ValueError(
+            "agent material frontier requires canonical authority_registry.project_materials; "
+            "a compact authority summary is not sufficient"
+        )
+    raw = authority_registry.get("project_materials")
+    if isinstance(raw, Mapping):
+        if any(not isinstance(raw_item, Mapping) for raw_item in raw.values()):
+            raise ValueError("authority_registry.project_materials values must be objects")
+        items = list(raw.items())
+    elif isinstance(raw, list):
+        if any(not isinstance(raw_item, Mapping) for raw_item in raw):
+            raise ValueError("authority_registry.project_materials entries must be objects")
+        items = [
+            (item.get("id") or item.get("source_id"), item)
+            for item in raw
+            if isinstance(item, Mapping)
+        ]
+    else:
+        raise ValueError("authority_registry.project_materials must be a map or list")
+
+    materials: dict[str, dict[str, Any]] = {}
+    for raw_id, raw_item in items:
+        material_id = _required_text(
+            raw_item.get("id") or raw_item.get("source_id") or raw_id,
+            field="authority material_id",
+        )
+        if material_id in materials:
+            raise ValueError(f"duplicate authority material_id: {material_id}")
+        materials[material_id] = dict(raw_item)
+    return materials
+
+
+def _topic_material_ids(value: Any) -> list[str]:
+    raw_items: list[Any]
+    if isinstance(value, list):
+        raw_items = value
+    else:
+        raw_items = [value]
+    material_ids: list[str] = []
+    for raw in raw_items:
+        if isinstance(raw, Mapping):
+            raw = raw.get("material_id") or raw.get("id") or raw.get("source_id")
+        material_id = _safe_text(raw, field="topic material_id")
+        if material_id and material_id not in material_ids:
+            material_ids.append(material_id)
+    return material_ids
+
+
+def _topic_index(authority_registry: Mapping[str, Any]) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
+    raw_topics = authority_registry.get("topic_authority")
+    if not isinstance(raw_topics, Mapping):
+        return {}, {}
+    by_topic: dict[str, list[str]] = {}
+    by_material: dict[str, list[str]] = {}
+    for raw_topic, raw_material in raw_topics.items():
+        topic = _required_text(raw_topic, field="authority topic", limit=120)
+        material_ids = _topic_material_ids(raw_material)
+        if not material_ids:
+            raise ValueError(f"authority topic must reference at least one material: {topic}")
+        by_topic[topic] = material_ids
+        for material_id in material_ids:
+            by_material.setdefault(material_id, []).append(topic)
+    return by_topic, by_material
+
+
+def _requirement_refs(owner: Mapping[str, Any]) -> list[Any]:
+    refs: list[Any] = []
+    for field in _REQUIREMENT_FIELDS:
+        raw = owner.get(field)
+        if isinstance(raw, list):
+            refs.extend(raw)
+        elif raw not in (None, ""):
+            refs.append(raw)
+    return refs
+
+
+def _topic_refs(owner: Mapping[str, Any]) -> list[str]:
+    topics: list[str] = []
+    for field in _TOPIC_FIELDS:
+        raw = owner.get(field)
+        values = raw if isinstance(raw, list) else [raw] if raw not in (None, "") else []
+        for value in values:
+            topic = _safe_text(value, field=f"{field} topic", limit=120)
+            if topic and topic not in topics:
+                topics.append(topic)
+    return topics
+
+
+def _owner_ref(owner: Mapping[str, Any], *, kind: str, agent_id: str) -> str:
+    candidates = {
+        "profile": (owner.get("agent_id"), agent_id),
+        "todo": (owner.get("todo_id"),),
+        "vision": (owner.get("vision_id"), owner.get("state"), agent_id),
+        "handoff": (owner.get("handoff_id"), owner.get("todo_id")),
+    }.get(kind, ())
+    for candidate in candidates:
+        text = _safe_text(candidate, field=f"{kind} ref")
+        if text:
+            return text
+    return f"{kind}:{agent_id}"
+
+
+def _normalize_requirement(
+    raw: Any,
+    *,
+    kind: str,
+    owner: Mapping[str, Any],
+    agent_id: str,
+    default_relation: str,
+    topic: str | None = None,
+) -> dict[str, Any]:
+    payload = dict(raw) if isinstance(raw, Mapping) else {"material_id": raw}
+    material_id = _required_text(
+        payload.get("material_id") or payload.get("id") or payload.get("source_id"),
+        field=f"{kind} material_id",
+    )
+    relation = str(payload.get("relation") or default_relation).strip().lower()
+    if relation not in _RELATIONS:
+        raise ValueError(f"{kind} material relation must be one of {sorted(_RELATIONS)}")
+    todo_id = _safe_text(
+        payload.get("todo_id") or owner.get("todo_id"),
+        field=f"{kind} todo_id",
+    )
+    requirement: dict[str, Any] = {
+        "material_id": material_id,
+        "relation": relation,
+        "bound_by": {
+            "kind": kind,
+            "ref": _owner_ref(owner, kind=kind, agent_id=agent_id),
+        },
+        "purpose": _safe_text(payload.get("purpose"), field=f"{kind} purpose", limit=220),
+        "todo_id": todo_id,
+        "required_revision_hint": _safe_text(
+            payload.get("required_revision"),
+            field=f"{kind} required_revision",
+        ),
+        "topic": topic,
+        "source_priority": _SOURCE_PRIORITY[kind],
+    }
+    return {
+        key: value
+        for key, value in requirement.items()
+        if value not in (None, "", [], {})
+    }
+
+
+def _requirements_from_owner(
+    owner: Mapping[str, Any],
+    *,
+    kind: str,
+    agent_id: str,
+    topic_materials: Mapping[str, list[str]],
+    default_relation: str,
+) -> list[dict[str, Any]]:
+    requirements = [
+        _normalize_requirement(
+            raw,
+            kind=kind,
+            owner=owner,
+            agent_id=agent_id,
+            default_relation=default_relation,
+        )
+        for raw in _requirement_refs(owner)
+    ]
+    for topic in _topic_refs(owner):
+        if topic not in topic_materials:
+            raise ValueError(
+                f"{kind} material topic is not registered in goal authority: {topic}"
+            )
+        for material_id in topic_materials.get(topic, []):
+            requirements.append(
+                _normalize_requirement(
+                    material_id,
+                    kind=kind,
+                    owner=owner,
+                    agent_id=agent_id,
+                    default_relation="watcher" if kind == "profile" else default_relation,
+                    topic=topic,
+                )
+            )
+    return requirements
+
+
+def _collect_requirements(
+    *,
+    agent_id: str,
+    topic_materials: Mapping[str, list[str]],
+    agent_profile: Mapping[str, Any] | None,
+    todos: Iterable[Mapping[str, Any]] | Mapping[str, Any] | None,
+    vision: Mapping[str, Any] | None,
+    handoffs: Iterable[Mapping[str, Any]] | Mapping[str, Any] | None,
+) -> dict[str, dict[str, Any]]:
+    raw_requirements: list[dict[str, Any]] = []
+    if isinstance(agent_profile, Mapping):
+        profile_agent = _safe_text(
+            agent_profile.get("agent_id"),
+            field="profile agent_id",
+        )
+        if profile_agent and profile_agent != agent_id:
+            raise ValueError("agent profile must belong to the selected agent_id")
+        raw_requirements.extend(
+            _requirements_from_owner(
+                agent_profile,
+                kind="profile",
+                agent_id=agent_id,
+                topic_materials=topic_materials,
+                default_relation="watcher",
+            )
+        )
+    if isinstance(vision, Mapping):
+        vision_agent = _safe_text(vision.get("agent_id"), field="vision agent_id")
+        if vision_agent and vision_agent != agent_id:
+            raise ValueError("agent vision must belong to the selected agent_id")
+        raw_requirements.extend(
+            _requirements_from_owner(
+                vision,
+                kind="vision",
+                agent_id=agent_id,
+                topic_materials=topic_materials,
+                default_relation="required",
+            )
+        )
+    for todo in _mapping_list(todos):
+        todo_agent = _safe_text(
+            todo.get("claimed_by") or todo.get("agent_id"),
+            field="todo agent_id",
+        )
+        if todo_agent and todo_agent != agent_id:
+            continue
+        raw_requirements.extend(
+            _requirements_from_owner(
+                todo,
+                kind="todo",
+                agent_id=agent_id,
+                topic_materials=topic_materials,
+                default_relation="required",
+            )
+        )
+    for handoff in _mapping_list(handoffs):
+        handoff_target = _safe_text(handoff.get("to_agent"), field="handoff target")
+        if handoff_target and handoff_target != agent_id:
+            continue
+        raw_requirements.extend(
+            _requirements_from_owner(
+                handoff,
+                kind="handoff",
+                agent_id=agent_id,
+                topic_materials=topic_materials,
+                default_relation="required",
+            )
+        )
+
+    merged: dict[str, dict[str, Any]] = {}
+    for requirement in raw_requirements:
+        material_id = requirement["material_id"]
+        row = merged.setdefault(
+            material_id,
+            {
+                "material_id": material_id,
+                "relation": requirement["relation"],
+                "bound_by": [],
+                "source_priority": -1,
+                "topics": [],
+            },
+        )
+        binding = requirement["bound_by"]
+        if binding not in row["bound_by"]:
+            row["bound_by"].append(binding)
+        topic = requirement.get("topic")
+        if topic and topic not in row["topics"]:
+            row["topics"].append(topic)
+        if requirement["source_priority"] >= row["source_priority"]:
+            row["source_priority"] = requirement["source_priority"]
+            row["relation"] = requirement["relation"]
+            for field in ("purpose", "todo_id", "required_revision_hint"):
+                if requirement.get(field):
+                    row[field] = requirement[field]
+    return merged
+
+
+def _receipt_sort_key(receipt: Mapping[str, Any]) -> tuple[datetime, str]:
+    recorded_at = parse_timestamp(receipt.get("recorded_at"))
+    return (
+        recorded_at or datetime.min.replace(tzinfo=timezone.utc),
+        str(receipt.get("receipt_id") or ""),
+    )
+
+
+def _matching_receipt(
+    receipts: Iterable[Mapping[str, Any]],
+    *,
+    goal_id: str,
+    agent_id: str,
+    material_id: str,
+    todo_id: str | None,
+) -> Mapping[str, Any] | None:
+    matches: list[Mapping[str, Any]] = []
+    for receipt in receipts:
+        if str(receipt.get("schema_version") or "") != MATERIAL_USAGE_RECEIPT_SCHEMA_VERSION:
+            continue
+        if str(receipt.get("goal_id") or "") != goal_id:
+            continue
+        if str(receipt.get("agent_id") or "") != agent_id:
+            continue
+        if str(receipt.get("material_id") or "") != material_id:
+            continue
+        if todo_id and str(receipt.get("todo_id") or "") != todo_id:
+            continue
+        if not _safe_text(receipt.get("receipt_id"), field="receipt_id"):
+            continue
+        outcome = str(receipt.get("outcome") or "").strip().lower()
+        if outcome not in _RECEIPT_OUTCOMES:
+            continue
+        if parse_timestamp(receipt.get("recorded_at")) is None:
+            continue
+        matches.append(receipt)
+    return max(matches, key=_receipt_sort_key) if matches else None
+
+
+def _material_is_accessible(
+    material: Mapping[str, Any],
+    *,
+    available_boundaries: set[str],
+) -> bool:
+    boundary = str(material.get("boundary") or "unknown").strip().lower()
+    gate_status = str(material.get("gate_status") or "").strip().lower()
+    if gate_status in _BLOCKED_GATE_STATES:
+        return False
+    return boundary in _PUBLIC_BOUNDARIES or boundary in available_boundaries
+
+
+def _frontier_state(
+    *,
+    material: Mapping[str, Any] | None,
+    receipt: Mapping[str, Any] | None,
+    required_revision: str | None,
+    available_boundaries: set[str],
+) -> str:
+    if material is None:
+        return "missing"
+    if not _material_is_accessible(material, available_boundaries=available_boundaries):
+        return "inaccessible"
+    if receipt and str(receipt.get("outcome") or "").strip().lower() == "unavailable":
+        return "inaccessible"
+    if receipt is None:
+        return "required_unread"
+    outcome = str(receipt.get("outcome") or "").strip().lower()
+    if outcome not in _RECEIPT_CURRENT_OUTCOMES:
+        return "stale"
+    freshness = str(material.get("freshness") or material.get("status") or "").strip().lower()
+    observed_revision = _safe_text(
+        receipt.get("observed_revision"),
+        field="receipt observed_revision",
+    )
+    if freshness in _STALE_FRESHNESS:
+        return "stale"
+    if required_revision and observed_revision == required_revision:
+        return "current"
+    return "stale"
+
+
+def _required_read(item: Mapping[str, Any]) -> dict[str, Any] | None:
+    state = str(item.get("state") or "")
+    if state == "current":
+        return None
+    reasons = {
+        "missing": "material is not registered in canonical goal authority",
+        "inaccessible": "material boundary or gate does not allow the current read",
+        "stale": "observed revision or authority freshness is stale",
+        "required_unread": "no matching material usage receipt exists",
+    }
+    return {
+        "kind": "material_frontier_item",
+        "material_id": item.get("material_id"),
+        "required_revision": item.get("required_revision"),
+        "state": state,
+        "reason": reasons.get(state, "material requires inspection"),
+    }
+
+
+def build_agent_material_frontier(
+    *,
+    goal_id: str,
+    agent_id: str,
+    authority_registry: Mapping[str, Any],
+    agent_profile: Mapping[str, Any] | None = None,
+    todos: Iterable[Mapping[str, Any]] | Mapping[str, Any] | None = None,
+    vision: Mapping[str, Any] | None = None,
+    handoffs: Iterable[Mapping[str, Any]] | Mapping[str, Any] | None = None,
+    receipts: Iterable[Mapping[str, Any]] | None = None,
+    available_boundaries: Iterable[str] = (),
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    """Derive one agent's material consumption frontier from goal-owned facts.
+
+    The builder is deliberately read-only. Requirements may be attached to an
+    agent profile, todo, vision, or handoff, while revision consumption is
+    proven only by an agent-scoped ``material_usage_receipt_v0`` row.
+    """
+
+    safe_goal_id = _required_text(goal_id, field="goal_id")
+    safe_agent_id = _required_text(agent_id, field="agent_id")
+    safe_generated_at = _safe_text(generated_at, field="generated_at")
+    if safe_generated_at and parse_timestamp(safe_generated_at) is None:
+        raise ValueError("generated_at must be an ISO timestamp")
+    materials = _project_materials(authority_registry)
+    topic_materials, material_topics = _topic_index(authority_registry)
+    requirements = _collect_requirements(
+        agent_id=safe_agent_id,
+        topic_materials=topic_materials,
+        agent_profile=agent_profile,
+        todos=todos,
+        vision=vision,
+        handoffs=handoffs,
+    )
+    safe_boundaries = {
+        boundary.lower()
+        for raw in available_boundaries
+        if (boundary := _safe_text(raw, field="available boundary", limit=80))
+    }
+    receipt_rows = _mapping_list(receipts)
+
+    items: list[dict[str, Any]] = []
+    for material_id, requirement in requirements.items():
+        material = materials.get(material_id)
+        authority_revision = _safe_text(
+            material.get("revision") if material else None,
+            field="authority revision",
+        )
+        required_revision = authority_revision or requirement.get("required_revision_hint")
+        todo_id = requirement.get("todo_id")
+        receipt = _matching_receipt(
+            receipt_rows,
+            goal_id=safe_goal_id,
+            agent_id=safe_agent_id,
+            material_id=material_id,
+            todo_id=todo_id,
+        )
+        state = _frontier_state(
+            material=material,
+            receipt=receipt,
+            required_revision=required_revision,
+            available_boundaries=safe_boundaries,
+        )
+        topics = list(material_topics.get(material_id, []))
+        for topic in requirement.get("topics") or []:
+            if topic not in topics:
+                topics.append(topic)
+        item: dict[str, Any] = {
+            "material_id": material_id,
+            "topics": topics,
+            "relation": requirement["relation"],
+            "bound_by": requirement["bound_by"],
+            "purpose": requirement.get("purpose"),
+            "todo_id": todo_id,
+            "required_revision": required_revision,
+            "observed_revision": _safe_text(
+                receipt.get("observed_revision") if receipt else None,
+                field="receipt observed_revision",
+            ),
+            "state": state,
+            "boundary": _safe_text(
+                material.get("boundary") if material else None,
+                field="material boundary",
+                limit=80,
+            ),
+            "gate_status": _safe_text(
+                material.get("gate_status") if material else None,
+                field="material gate_status",
+                limit=80,
+            ),
+            "receipt_ref": (
+                f"material_receipt:{_required_text(receipt.get('receipt_id'), field='receipt_id')}"
+                if receipt and receipt.get("receipt_id")
+                else None
+            ),
+            "last_verified_at": _safe_text(
+                receipt.get("recorded_at") if receipt else None,
+                field="receipt recorded_at",
+            ),
+            "_source_priority": requirement["source_priority"],
+        }
+        items.append(
+            {
+                key: value
+                for key, value in item.items()
+                if value not in (None, "", [], {})
+            }
+        )
+
+    items.sort(
+        key=lambda item: (
+            -int(item.get("_source_priority") or 0),
+            _STATE_RANK.get(str(item.get("state") or ""), 9),
+            str(item.get("material_id") or ""),
+        )
+    )
+    for item in items:
+        item.pop("_source_priority", None)
+
+    summary = {
+        "required_count": len(items),
+        "current_count": sum(item.get("state") == "current" for item in items),
+        "stale_count": sum(item.get("state") == "stale" for item in items),
+        "missing_count": sum(item.get("state") == "missing" for item in items),
+        "inaccessible_count": sum(item.get("state") == "inaccessible" for item in items),
+        "required_unread_count": sum(item.get("state") == "required_unread" for item in items),
+    }
+    required_reads = [read for item in items if (read := _required_read(item))]
+    return {
+        "schema_version": AGENT_MATERIAL_FRONTIER_SCHEMA_VERSION,
+        "goal_id": safe_goal_id,
+        "agent_id": safe_agent_id,
+        "generated_at": safe_generated_at or now_utc_iso(),
+        "summary": summary,
+        "items": items,
+        "required_reads": required_reads,
+        "truth_contract": {
+            "authority_is_goal_owned": True,
+            "projection_is_read_only": True,
+            "introduces_task_runtime": False,
+            "grants_cross_agent_authority": False,
+            "evidence_log_implies_material_read": False,
+            "raw_source_body_recorded": False,
+        },
+    }


### PR DESCRIPTION
Summary:
- add a pure agent-scoped read model over goal-owned material authority
- derive current, stale, unread, missing, and inaccessible material states from explicit requirements and strict material-usage receipts
- preserve handoff refs without transferring another agent’s receipt or authority
- document the public contract and cover it with a durable smoke

Current boundary:
- no dispatcher, task runtime, material body cache, automatic gate creation, or receipt-writing command
- no MA- or runtime-specific field; later projections may consume the bounded summary and refs

Validation:
- isolated full pytest: 752 passed, 2 skipped
- focused material-frontier smoke, ruff, mypy, and Python compile: passed
- existing authority/project-map/agent-management/public-boundary smokes: passed
- loopx canary premerge --from-git-diff: 18/18 passed, no manual holds, self-merge allowed

The earlier origin/main peer workspace-guard canary drift was repaired separately in #2311 before this validation was rerun.