### PR TITLE
feat(agents): project bounded material handoffs

### DIFF
--- a/docs/reference/protocols/agent-management-projection-v0.md
+++ b/docs/reference/protocols/agent-management-projection-v0.md
@@ -33,6 +33,8 @@ The projection is derived from:
 - quota `agent_lane_next_action`, `interaction_contract`, and scheduler hints;
 - compact run history and the agent-scoped evidence ledger;
 - task graph, handoff, and review-packet projections when present.
+- optional prebuilt `agent_material_frontier_v0` packets on the cold-path
+  `agent_material_frontiers` input.
 
 The projection is stale after any lifecycle event until recomputed. Consumers
 must tolerate missing fields and fall back to existing status/review-packet
@@ -106,6 +108,8 @@ Optional fields:
 - `scheduler_state`;
 - `workspace_ref`;
 - `handoff_refs`;
+- `handoff_note`;
+- `material_frontier`;
 - `stale_claim_hint`;
 - `blocked_on`;
 - `recent_events`;
@@ -155,7 +159,8 @@ model.
 ## Handoff Notes
 
 Inter-agent handoff should appear as a typed note attached to existing todo,
-history, and evidence refs:
+history, and evidence refs. Rows without material context retain the existing
+`handoff_note_v0` shape:
 
 ```json
 {
@@ -183,6 +188,46 @@ introducing a second task model.
 The projection may show the latest handoff note in the agent row, but the note
 does not create a chat stream, dispatcher queue, approval mechanism, or runtime
 task separate from the source todo.
+
+When the cold path also receives a full `agent_material_frontier_v0` for the
+same agent, the management projection may enrich the typed note as
+`handoff_note_v1`:
+
+```json
+{
+  "schema_version": "handoff_note_v1",
+  "handoff_id": "handoff_123",
+  "todo_id": "todo_abc",
+  "from_agent": "codex-builder",
+  "to_agent": "codex-reviewer",
+  "material_frontier_summary": {
+    "required_count": 5,
+    "current_count": 1,
+    "stale_count": 1,
+    "missing_count": 0,
+    "inaccessible_count": 1,
+    "required_unread_count": 2
+  },
+  "material_ref_count": 5,
+  "material_refs": [
+    {
+      "material_id": "runtime-contract",
+      "relation": "required",
+      "purpose": "review the current contract"
+    }
+  ],
+  "material_refs_truncated": true
+}
+```
+
+`material_frontier` on the agent row uses the same bounded summary/ref shape
+with `schema_version=agent_material_handoff_projection_v0`. At most four refs
+are exposed. The projection never forwards receipts,
+observed or required revisions, boundary availability, gate state, permissions,
+authority ownership, or source bodies. A successor rebuilds its own frontier
+from current goal authority and its own agent-scoped requirements and receipts.
+The optional cold-path input does not create an agent row, claim, or task by
+itself.
 
 ## Stale Claim Hint
 

--- a/docs/reference/protocols/agent-material-frontier-v0.md
+++ b/docs/reference/protocols/agent-material-frontier-v0.md
@@ -102,18 +102,42 @@ stable id, outcome, and timestamp fails closed.
 
 ## Handoff Semantics
 
-A successor may receive the same required material ids through handoff, then
-rebuild its own frontier from goal authority. The predecessor's receipt does
-not make the successor current, and the handoff does not transfer source
-permissions or authority ownership.
+A successor may receive a bounded set of material refs through handoff, then
+rebuild its own complete frontier from goal authority plus its profile, todo,
+and vision requirements. The predecessor's receipt does not make the successor
+current, and the handoff does not transfer source permissions or authority
+ownership.
 
 This supports durable handoff without introducing a dispatcher or an
 agent-owned material cache.
 
+The bounded handoff projection emits:
+
+- `schema_version=agent_material_handoff_projection_v0`;
+- the six frontier summary counts;
+- `material_ref_count` and `material_refs_truncated`;
+- at most four refs containing only `material_id`, `relation`, and optional
+  public-safe `purpose`.
+
+It deliberately omits observed and required revisions, receipt refs,
+boundaries, gate status, authority metadata, and available permissions. The
+bounded refs are context, not a complete material manifest. A successor uses
+its own profile, todo, vision, and handoff requirements to rebuild the full
+frontier against current goal authority.
+
+When a typed `handoff_note_v0` and a full frontier are both present, the agent
+read-model layer may emit `handoff_note_v1` by attaching
+`material_frontier_summary` and the bounded refs. The legacy todo handoff
+producer remains unchanged for rows without a frontier.
+
 ## Current Delivery Boundary
 
-The current implementation is a pure cold-path read model. It intentionally
-does not add:
+The implementation includes the pure frontier builder, a bounded material
+handoff projector, and an optional agent-management cold-path consumer. The
+consumer reads prebuilt packets from `status.agent_material_frontiers`; it does
+not load canonical authority or material bodies by itself.
+
+The implementation intentionally does not add:
 
 - profile/todo material-requirement authoring commands;
 - a material body cache;
@@ -121,10 +145,6 @@ does not add:
 - automatic authorization or gate creation;
 - a cross-agent dispatcher;
 - an MA- or runtime-specific field.
-
-Later integrations may attach the bounded summary and up to a few refs to
-agent-management or handoff projections. Those integrations must continue to
-resolve revisions and boundaries from goal authority.
 
 ## Acceptance Checks
 

--- a/examples/control_plane/agent-material-handoff-projection-smoke.py
+++ b/examples/control_plane/agent-material-handoff-projection-smoke.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Smoke-test bounded material handoff and agent-management projection."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.agents.management_projection import (  # noqa: E402
+    build_agent_management_projection,
+)
+from loopx.control_plane.agents.material_frontier import (  # noqa: E402
+    build_agent_material_frontier,
+)
+from loopx.control_plane.agents.material_handoff import (  # noqa: E402
+    MAX_MATERIAL_HANDOFF_REFS,
+    build_material_handoff_note_v1,
+    project_material_frontier_for_handoff,
+)
+
+
+GOAL_ID = "material-handoff-fixture"
+SOURCE_AGENT = "agent-builder"
+SUCCESSOR_AGENT = "agent-reviewer"
+SOURCE_TODO = "todo_material_source"
+SUCCESSOR_TODO = "todo_material_successor"
+
+
+def authority_registry() -> dict:
+    materials = {
+        "design-current": {
+            "id": "design-current",
+            "revision": "rev-2",
+            "freshness": "current",
+            "boundary": "public_safe",
+            "gate_status": "registered",
+        },
+        "design-unread": {
+            "id": "design-unread",
+            "revision": "rev-1",
+            "freshness": "current",
+            "boundary": "public",
+            "gate_status": "registered",
+        },
+        "private-runbook": {
+            "id": "private-runbook",
+            "revision": "rev-1",
+            "freshness": "current",
+            "boundary": "private_redacted",
+            "gate_status": "registered",
+        },
+        "stale-review": {
+            "id": "stale-review",
+            "revision": "rev-3",
+            "freshness": "stale",
+            "boundary": "public",
+            "gate_status": "registered",
+        },
+    }
+    return {"project_materials": materials, "topic_authority": {}}
+
+
+def material_refs() -> list[dict[str, str]]:
+    return [
+        {
+            "material_id": "design-current",
+            "relation": "required",
+            "purpose": "implement the current contract",
+        },
+        {"material_id": "design-unread", "relation": "reviewer"},
+        {"material_id": "private-runbook", "relation": "required"},
+        {"material_id": "stale-review", "relation": "reviewer"},
+        {"material_id": "missing-source", "relation": "required"},
+    ]
+
+
+def source_receipt() -> dict:
+    return {
+        "schema_version": "material_usage_receipt_v0",
+        "receipt_id": "receipt_source_current",
+        "goal_id": GOAL_ID,
+        "agent_id": SOURCE_AGENT,
+        "todo_id": SOURCE_TODO,
+        "material_id": "design-current",
+        "observed_revision": "rev-2",
+        "outcome": "used",
+        "recorded_at": "2026-07-19T00:00:00Z",
+    }
+
+
+def source_frontier() -> dict:
+    return build_agent_material_frontier(
+        goal_id=GOAL_ID,
+        agent_id=SOURCE_AGENT,
+        authority_registry=authority_registry(),
+        todos={"todo_id": SOURCE_TODO, "material_refs": material_refs()},
+        receipts=[source_receipt()],
+        available_boundaries=["private_redacted"],
+        generated_at="2026-07-19T00:01:00Z",
+    )
+
+
+def legacy_handoff_note() -> dict:
+    return {
+        "schema_version": "handoff_note_v0",
+        "handoff_id": "handoff_material_successor",
+        "todo_id": SUCCESSOR_TODO,
+        "goal_id": GOAL_ID,
+        "from_agent": SOURCE_AGENT,
+        "to_agent": SUCCESSOR_AGENT,
+        "intent": "independent_review",
+        "summary": "Review the bounded implementation evidence.",
+        "evidence_refs": [f"todo:{SOURCE_TODO}:evidence"],
+    }
+
+
+def assert_bounded_handoff() -> dict:
+    frontier = source_frontier()
+    compact = project_material_frontier_for_handoff(frontier)
+    assert compact["schema_version"] == "agent_material_handoff_projection_v0", compact
+    assert compact["material_ref_count"] == 5, compact
+    assert len(compact["material_refs"]) == MAX_MATERIAL_HANDOFF_REFS, compact
+    assert compact["material_refs_truncated"] is True, compact
+    assert compact["summary"] == frontier["summary"], (compact, frontier)
+
+    note = build_material_handoff_note_v1(legacy_handoff_note(), frontier)
+    assert note["schema_version"] == "handoff_note_v1", note
+    assert note["material_refs"] == compact["material_refs"], note
+    rendered = json.dumps(note, sort_keys=True)
+    for forbidden in (
+        "receipt_source_current",
+        "receipt_ref",
+        "observed_revision",
+        "required_revision",
+        "boundary",
+        "gate_status",
+        "authority_registry",
+        "available_boundaries",
+    ):
+        assert forbidden not in rendered, (forbidden, note)
+    return note
+
+
+def assert_successor_rebuilds_frontier(note: dict) -> dict:
+    successor = build_agent_material_frontier(
+        goal_id=GOAL_ID,
+        agent_id=SUCCESSOR_AGENT,
+        authority_registry=authority_registry(),
+        todos={"todo_id": SUCCESSOR_TODO, "material_refs": material_refs()},
+        handoffs=[note],
+        receipts=[source_receipt()],
+        generated_at="2026-07-19T00:02:00Z",
+    )
+    items = {item["material_id"]: item for item in successor["items"]}
+    assert successor["summary"]["required_count"] == 5, successor
+    assert items["design-current"]["state"] == "required_unread", successor
+    assert items["private-runbook"]["state"] == "inaccessible", successor
+    assert items["missing-source"]["state"] == "missing", successor
+    assert all("receipt_ref" not in item for item in successor["items"]), successor
+    return successor
+
+
+def assert_agent_management_cold_path(successor: dict) -> None:
+    payload = {
+        "goal_filter": GOAL_ID,
+        "run_history": {
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "coordination": {"registered_agents": [SUCCESSOR_AGENT]},
+                }
+            ]
+        },
+        "todo_index": {
+            "items": [
+                {
+                    "role": "agent",
+                    "todo_id": SUCCESSOR_TODO,
+                    "goal_id": GOAL_ID,
+                    "status": "open",
+                    "task_class": "advancement_task",
+                    "action_kind": "independent_review",
+                    "claimed_by": SUCCESSOR_AGENT,
+                    "text": "Review the material-aware handoff.",
+                    "handoff_note": legacy_handoff_note(),
+                }
+            ]
+        },
+        "agent_material_frontiers": [successor],
+    }
+    projection = build_agent_management_projection(payload)
+    row = projection["agents"][0]
+    assert row["agent_id"] == SUCCESSOR_AGENT, row
+    assert (
+        row["material_frontier"]["schema_version"]
+        == "agent_material_handoff_projection_v0"
+    ), row
+    assert row["material_frontier"]["summary"] == successor["summary"], row
+    assert row["handoff_note"]["schema_version"] == "handoff_note_v1", row
+    assert row["handoff_note"]["material_refs"] == row["material_frontier"]["material_refs"], row
+
+    payload.pop("agent_material_frontiers")
+    legacy = build_agent_management_projection(payload)["agents"][0]
+    assert "material_frontier" not in legacy, legacy
+    assert "handoff_note" not in legacy, legacy
+
+
+def main() -> int:
+    note = assert_bounded_handoff()
+    successor = assert_successor_rebuilds_frontier(note)
+    assert_agent_management_cold_path(successor)
+    print("agent-material-handoff-projection-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/control_plane/agents/management_projection.py
+++ b/loopx/control_plane/agents/management_projection.py
@@ -6,6 +6,11 @@ from ..runtime.public_safety import public_safe_compact_text
 from ..runtime.time import now_utc, now_utc_iso, parse_timestamp
 from ..todos.contract import normalize_todo_claimed_by, normalize_todo_id
 from ..todos.summary_item import TODO_SUMMARY_SOURCE_KEYS
+from .material_frontier import AGENT_MATERIAL_FRONTIER_SCHEMA_VERSION
+from .material_handoff import (
+    build_material_handoff_note_v1,
+    project_material_frontier_for_handoff,
+)
 
 
 AGENT_MANAGEMENT_PROJECTION_SCHEMA_VERSION = "agent_management_projection_v0"
@@ -182,6 +187,25 @@ def _registered_agents(status_payload: dict[str, Any]) -> dict[str, dict[str, An
             if goal_id and goal_id not in row["_goal_ids"]:
                 row["_goal_ids"].append(goal_id)
     return rows
+
+
+def _agent_material_frontiers(status_payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    raw_frontiers = status_payload.get("agent_material_frontiers")
+    if isinstance(raw_frontiers, dict):
+        candidates = list(raw_frontiers.values())
+    else:
+        candidates = _as_list(raw_frontiers)
+
+    frontiers: dict[str, dict[str, Any]] = {}
+    for raw in candidates:
+        if not isinstance(raw, dict):
+            continue
+        if str(raw.get("schema_version") or "") != AGENT_MATERIAL_FRONTIER_SCHEMA_VERSION:
+            continue
+        agent_id = normalize_todo_claimed_by(raw.get("agent_id"))
+        if agent_id:
+            frontiers[agent_id] = raw
+    return frontiers
 
 
 def _iter_todo_group_items(
@@ -455,6 +479,7 @@ def build_agent_management_projection(status_payload: dict[str, Any]) -> dict[st
     """
 
     rows_by_agent = _registered_agents(status_payload)
+    material_frontiers = _agent_material_frontiers(status_payload)
     seen_todos: set[tuple[str, str, str, str]] = set()
     for todo in _iter_status_todos(status_payload):
         agent_id = _todo_agent_id(todo)
@@ -512,6 +537,17 @@ def build_agent_management_projection(status_payload: dict[str, Any]) -> dict[st
             "handoff_refs": handoff_refs[:MAX_REFS],
             "goal_ids": _as_list(raw_row.get("_goal_ids"))[:MAX_REFS],
         }
+        material_frontier = material_frontiers.get(agent_id)
+        if material_frontier:
+            agent_row["material_frontier"] = project_material_frontier_for_handoff(
+                material_frontier
+            )
+            handoff_note = _as_dict(current.get("handoff_note")) if current else {}
+            if handoff_note:
+                agent_row["handoff_note"] = build_material_handoff_note_v1(
+                    handoff_note,
+                    material_frontier,
+                )
         workspace_ref = _workspace_ref_from_todo(current)
         if workspace_ref:
             agent_row["workspace_ref"] = workspace_ref
@@ -531,6 +567,17 @@ def build_agent_management_projection(status_payload: dict[str, Any]) -> dict[st
             break
 
     goal_filter = _compact(status_payload.get("goal_filter"), limit=180)
+    source_summary: dict[str, Any] = {
+        "registered_agent_count": len(rows_by_agent),
+        "projected_agent_count": len(agents),
+        "todo_source": (
+            "status.attention_queue + authoritative status.todo_index rows; "
+            "event-only rollout receipts are evidence, not runtime work"
+        ),
+    }
+    if material_frontiers:
+        source_summary["material_frontier_count"] = len(material_frontiers)
+
     projection: dict[str, Any] = {
         "schema_version": AGENT_MANAGEMENT_PROJECTION_SCHEMA_VERSION,
         "mode": AGENT_MANAGEMENT_MODE,
@@ -542,14 +589,7 @@ def build_agent_management_projection(status_payload: dict[str, Any]) -> dict[st
             "introduces_task_runtime": False,
             "write_api": False,
         },
-        "source_summary": {
-            "registered_agent_count": len(rows_by_agent),
-            "projected_agent_count": len(agents),
-            "todo_source": (
-                "status.attention_queue + authoritative status.todo_index rows; "
-                "event-only rollout receipts are evidence, not runtime work"
-            ),
-        },
+        "source_summary": source_summary,
         "agents": agents,
     }
     return {

--- a/loopx/control_plane/agents/material_handoff.py
+++ b/loopx/control_plane/agents/material_handoff.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ..runtime.public_safety import public_safe_compact_text
+from .material_frontier import AGENT_MATERIAL_FRONTIER_SCHEMA_VERSION
+
+
+MATERIAL_HANDOFF_NOTE_SCHEMA_VERSION = "handoff_note_v1"
+MATERIAL_HANDOFF_PROJECTION_SCHEMA_VERSION = "agent_material_handoff_projection_v0"
+MAX_MATERIAL_HANDOFF_REFS = 4
+
+_FRONTIER_STATES = {
+    "current",
+    "inaccessible",
+    "missing",
+    "required_unread",
+    "stale",
+}
+_HANDOFF_NOTE_FIELDS = (
+    "handoff_id",
+    "todo_id",
+    "goal_id",
+    "from_agent",
+    "to_agent",
+    "intent",
+    "summary",
+    "evidence_refs",
+    "unresolved_decisions",
+    "blocked_on",
+    "suggested_next_action",
+    "source",
+    "successor_todo_ids",
+    "unblocks_todo_id",
+    "excluded_agents",
+)
+
+
+def _safe_text(value: Any, *, field: str, limit: int = 220) -> str | None:
+    text = " ".join(str(value or "").strip().split())
+    if not text:
+        return None
+    if len(text) > limit:
+        raise ValueError(f"{field} must be at most {limit} characters")
+    if public_safe_compact_text(text, limit=limit) != text:
+        raise ValueError(f"{field} must be public-safe")
+    return text
+
+
+def _required_text(value: Any, *, field: str, limit: int = 220) -> str:
+    text = _safe_text(value, field=field, limit=limit)
+    if not text:
+        raise ValueError(f"{field} is required")
+    return text
+
+
+def project_material_frontier_for_handoff(
+    frontier: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Reduce a full frontier to bounded requirement refs and state counts."""
+
+    if str(frontier.get("schema_version") or "") != AGENT_MATERIAL_FRONTIER_SCHEMA_VERSION:
+        raise ValueError(
+            "material handoff requires an agent_material_frontier_v0 packet"
+        )
+    raw_items = frontier.get("items")
+    if not isinstance(raw_items, list) or any(
+        not isinstance(item, Mapping) for item in raw_items
+    ):
+        raise ValueError("agent material frontier items must be a list of objects")
+
+    counts = {state: 0 for state in _FRONTIER_STATES}
+    material_refs: list[dict[str, str]] = []
+    seen_ids: set[str] = set()
+    for raw_item in raw_items:
+        material_id = _required_text(
+            raw_item.get("material_id"),
+            field="material handoff material_id",
+            limit=180,
+        )
+        if material_id in seen_ids:
+            continue
+        seen_ids.add(material_id)
+        state = _required_text(
+            raw_item.get("state"),
+            field=f"material handoff state for {material_id}",
+            limit=40,
+        )
+        if state not in _FRONTIER_STATES:
+            raise ValueError(f"unsupported material frontier state: {state}")
+        counts[state] += 1
+
+        if len(material_refs) >= MAX_MATERIAL_HANDOFF_REFS:
+            continue
+        material_ref: dict[str, str] = {"material_id": material_id}
+        relation = _safe_text(
+            raw_item.get("relation"),
+            field=f"material handoff relation for {material_id}",
+            limit=80,
+        )
+        purpose = _safe_text(
+            raw_item.get("purpose"),
+            field=f"material handoff purpose for {material_id}",
+            limit=220,
+        )
+        if relation:
+            material_ref["relation"] = relation
+        if purpose:
+            material_ref["purpose"] = purpose
+        material_refs.append(material_ref)
+
+    summary = {
+        "required_count": len(seen_ids),
+        "current_count": counts["current"],
+        "stale_count": counts["stale"],
+        "missing_count": counts["missing"],
+        "inaccessible_count": counts["inaccessible"],
+        "required_unread_count": counts["required_unread"],
+    }
+    return {
+        "schema_version": MATERIAL_HANDOFF_PROJECTION_SCHEMA_VERSION,
+        "summary": summary,
+        "material_ref_count": len(seen_ids),
+        "material_refs": material_refs,
+        "material_refs_truncated": len(seen_ids) > len(material_refs),
+    }
+
+
+def build_material_handoff_note_v1(
+    handoff_note: Mapping[str, Any],
+    frontier: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Attach a bounded frontier projection to an existing typed handoff note."""
+
+    if str(handoff_note.get("schema_version") or "") not in {
+        "handoff_note_v0",
+        MATERIAL_HANDOFF_NOTE_SCHEMA_VERSION,
+    }:
+        raise ValueError("material handoff requires a typed handoff_note_v0 or v1")
+    projection = project_material_frontier_for_handoff(frontier)
+    payload = {
+        key: handoff_note[key]
+        for key in _HANDOFF_NOTE_FIELDS
+        if handoff_note.get(key) not in (None, "", [], {})
+    }
+    payload.update(
+        {
+            "schema_version": MATERIAL_HANDOFF_NOTE_SCHEMA_VERSION,
+            "material_frontier_summary": projection["summary"],
+            "material_ref_count": projection["material_ref_count"],
+            "material_refs": projection["material_refs"],
+            "material_refs_truncated": projection["material_refs_truncated"],
+        }
+    )
+    return payload


### PR DESCRIPTION
## Summary

- add `agent_material_handoff_projection_v0`, reducing a full frontier to six summary counts and at most four `{material_id, relation, purpose}` refs
- enrich an existing typed handoff as `handoff_note_v1` without changing the legacy todo handoff producer
- let `agent_management_projection_v0` consume optional prebuilt `status.agent_material_frontiers` packets on its cold path
- prove a successor rebuilds from current goal authority and its own requirements instead of inheriting predecessor receipts, permissions, or authority

## Boundary

This does not add material authoring, receipt writing, source-body caching, permission transfer, dispatcher/runtime behavior, or a new task identity. Without `agent_material_frontiers`, agent-management output remains unchanged.

## Validation

- focused material handoff, existing material frontier, live agent-management, and management protocol smokes: passed
- full pytest in an isolated HOME: 752 passed, 2 skipped
- Ruff and changed-file compile: passed
- new module isolated mypy: passed
- standard premerge: 18/18 passed (9 catalog, 8 risk-profile, 1 public-boundary), 0 warnings, 0 manual holds

A direct mypy invocation through the existing management module still reports the same 10 baseline errors on clean `origin/main`; the changed module introduces no additional mypy finding.

## Merge hold

This is a control-plane protocol extension and should receive independent review before merge.