### PR TITLE
refactor(presentation): own quota markdown rendering

### DIFF
--- a/examples/control_plane/presentation-markdown-primitives-smoke.py
+++ b/examples/control_plane/presentation-markdown-primitives-smoke.py
@@ -11,7 +11,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from loopx.control_plane.quota.markdown import (  # noqa: E402
+from loopx.presentation.renderers.quota_markdown import (  # noqa: E402
     render_quota_markdown,
     render_quota_should_run_markdown,
 )

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -24,7 +24,9 @@ from ..control_plane.quota.live_decision import build_live_quota_should_run_deci
 from ..control_plane.quota.scheduler_ack import (
     record_quota_scheduler_failure_for_decision,
 )
-from ..control_plane.quota.markdown import render_quota_scheduler_failure_markdown
+from ..presentation.renderers.quota_markdown import (
+    render_quota_scheduler_failure_markdown,
+)
 from ..control_plane.scheduler.execution_context import (
     SchedulerExecutionContextResolution,
     SchedulerRuntimeProfile,

--- a/loopx/presentation/renderers/quota_markdown.py
+++ b/loopx/presentation/renderers/quota_markdown.py
@@ -6,9 +6,11 @@ from ...control_plane import control_plane_policy_summary
 from ...execution_profile import execution_profile_summary
 from ...long_task_cadence import long_task_cadence_hint_summary
 from ...orchestration import orchestration_policy_summary
-from ...presentation.markdown import as_dict, as_list, markdown_scalar
-from ..runtime.decision_freshness import DECISION_FRESHNESS_WARNING_ITEM_LIMIT
-from .states import QUOTA_STATE_ORDER
+from ...control_plane.quota.states import QUOTA_STATE_ORDER
+from ...control_plane.runtime.decision_freshness import (
+    DECISION_FRESHNESS_WARNING_ITEM_LIMIT,
+)
+from ..markdown import as_dict, as_list, markdown_scalar
 
 
 def render_quota_markdown(payload: dict[str, Any]) -> str:

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -80,7 +80,7 @@ from .control_plane.quota.recent_runs import (
     goal_latest_runs as _goal_latest_runs,
     recent_external_monitor_observation_unchanged as _recent_external_monitor_observation_unchanged,
 )
-from .control_plane.quota.markdown import (
+from .presentation.renderers.quota_markdown import (
     render_quota_markdown,
     render_quota_scheduler_ack_markdown,
     render_quota_should_run_markdown,

--- a/tests/architecture/test_control_plane_import_boundaries.py
+++ b/tests/architecture/test_control_plane_import_boundaries.py
@@ -25,12 +25,6 @@ FORBIDDEN_DEPENDENCY_PREFIXES = (
     "loopx.cli_commands",
     "loopx.presentation",
 )
-ALLOWED_DEPENDENCY_DEBT = {
-    (
-        "loopx.control_plane.quota.markdown",
-        "loopx.presentation.markdown",
-    ),
-}
 STATUS_FORBIDDEN_DEPENDENCY_PREFIXES = (
     "loopx.benchmark_adapters",
     "loopx.presentation",
@@ -78,11 +72,18 @@ def test_control_plane_does_not_gain_outward_dependencies() -> None:
         )
     }
 
-    unexpected = outward_dependencies - ALLOWED_DEPENDENCY_DEBT
-    assert not unexpected, (
+    assert not outward_dependencies, (
         "control-plane code must not depend on presentation, CLI, capability, or "
-        f"benchmark-adapter layers; unexpected edges: {sorted(unexpected)}"
+        f"benchmark-adapter layers; unexpected edges: {sorted(outward_dependencies)}"
     )
+
+
+def test_quota_markdown_is_owned_by_the_presentation_layer() -> None:
+    legacy_renderer = CONTROL_PLANE_ROOT / "quota" / "markdown.py"
+    imports = _resolved_imports(QUOTA_MODULE)
+
+    assert not legacy_renderer.exists()
+    assert "loopx.presentation.renderers.quota_markdown" in imports
 
 
 def test_status_outward_dependency_debt_only_shrinks() -> None:

--- a/tests/control_plane/test_goal_vision_blocked_successor.py
+++ b/tests/control_plane/test_goal_vision_blocked_successor.py
@@ -7,7 +7,6 @@ from loopx.control_plane.goals.goal_frontier import (
     build_goal_frontier_projection_context_from_status,
 )
 from loopx.control_plane.quota.monitor_poll import build_quota_monitor_poll_event
-from loopx.control_plane.quota.markdown import render_quota_should_run_markdown
 from loopx.control_plane.scheduler.execution_context import (
     GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT,
 )
@@ -20,7 +19,7 @@ from loopx.control_plane.work_items.autonomous_replan_ack import (
     latest_blocked_successor_frontier_identity,
 )
 from loopx.presentation.renderers.status_markdown import render_status_markdown
-from loopx.quota import build_quota_should_run
+from loopx.quota import build_quota_should_run, render_quota_should_run_markdown
 from loopx.state_refresh import build_state_refresh_record
 from loopx.status import autonomous_replan_obligation_from_runs, compact_run
 

--- a/tests/presentation/test_quota_markdown_boundary.py
+++ b/tests/presentation/test_quota_markdown_boundary.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from loopx.presentation.renderers.quota_markdown import (
+    render_quota_markdown as render_quota_markdown_direct,
+    render_quota_scheduler_ack_markdown as render_quota_scheduler_ack_markdown_direct,
+    render_quota_should_run_markdown as render_quota_should_run_markdown_direct,
+)
+from loopx.quota import (
+    render_quota_markdown,
+    render_quota_scheduler_ack_markdown,
+    render_quota_should_run_markdown,
+)
+
+
+def test_public_quota_renderers_are_presentation_exports() -> None:
+    assert render_quota_markdown is render_quota_markdown_direct
+    assert render_quota_should_run_markdown is render_quota_should_run_markdown_direct
+    assert render_quota_scheduler_ack_markdown is render_quota_scheduler_ack_markdown_direct
+
+
+def test_quota_rendering_preserves_the_decision_payload() -> None:
+    payload = {
+        "ok": True,
+        "goal_id": "presentation-boundary",
+        "decision": "run",
+        "should_run": True,
+        "interaction_contract": {
+            "mode": "bounded_delivery",
+            "agent_channel": {"must_attempt": True},
+        },
+        "quota": {"compute": "medium", "slot_minutes": 15},
+    }
+    original = deepcopy(payload)
+
+    markdown = render_quota_should_run_markdown(payload)
+
+    assert "# LoopX Quota Should Run" in markdown
+    assert "- decision: `run`" in markdown
+    assert payload == original


### PR DESCRIPTION
## Summary

- move the 1,280-line quota Markdown renderer from `loopx.control_plane.quota` to `loopx.presentation.renderers`
- preserve the existing `loopx.quota` public renderer exports and CLI output paths
- remove the last allowed control-plane-to-presentation dependency debt and make the ownership boundary executable
- update repo-local imports and add purity/public-export regression coverage

This reduces the strict control-plane maintenance surface by 1,278 physical lines without changing quota decision semantics or JSON contracts.

## Changed surfaces

- runtime/API: renderer module ownership and import routing only
- architecture: control plane may no longer import presentation through an allowlisted exception
- validation: presentation export identity/purity test plus updated behavior smoke imports

## Validation

- `20 passed`: focused architecture, presentation-boundary, and blocked-successor pytest set
- `presentation-markdown-primitives-smoke.py`: passed
- `quota-plan-smoke.py`: passed
- `status-markdown-smoke.py`: passed
- real checkout `quota should-run` JSON path: passed
- changed-scope Ruff check: passed for renderer, CLI, architecture/tests, and smoke
- `loopx canary premerge --from-git-diff --tier standard`: passed; 4 direct checks + 18 selected catalog/risk/boundary checks, 0 failures, 0 warnings, 0 manual holds
- full pytest sweep: 755 passed, 2 skipped, 1 failed; the same `test_turn_launcher_requires_an_independent_validator` failure reproduces unchanged on `origin/main` under this machine's SkillsBench launcher environment
- informational full-public smoke sweep: 207/218 passed; 11 failures are outside the changed surface and report recent agent-id/host-contract fixture drift rather than renderer/import failures

The deterministic architecture/parity/CLI checks are the relevant gate here; no prompt, model policy, or agent-behavior contract changed, so a live model/Doubao evaluation would add noise rather than evidence.

## Risk and exclusions

- no JSON decision fields, quota policy, scheduler policy, todo lifecycle, benchmark behavior, or public first-screen copy changed
- no compatibility wrapper is kept for the internal bounded-context path; repo-local callers moved together, while the documented `loopx.quota` facade remains stable
- private state, credentials, raw logs, generated canary evidence, and local paths are excluded
- this PR is ready for independent review and is not self-merged despite the automated gate reporting no manual hold
