### PR TITLE
fix(quota): preserve monitor poll scheduler context

### DIFF
--- a/examples/control_plane/monitor-poll-writeback-smoke.py
+++ b/examples/control_plane/monitor-poll-writeback-smoke.py
@@ -795,6 +795,30 @@ def assert_cli_help_names_capability_sensitive_commands() -> None:
         assert command in option_help, (command, option_help)
 
 
+def assert_cli_monitor_poll_preserves_codex_app_scheduler_context() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-monitor-poll-codex-app-") as tmp:
+        registry_path, _state_file = write_fixture(Path(tmp))
+        payload = run_cli(
+            registry_path,
+            "quota",
+            "monitor-poll",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--codex-app",
+            "--todo-id",
+            TODO_ID,
+            "--result-hash",
+            "old",
+        )
+
+        for decision in (payload["before"], payload["after"]):
+            scheduler_hint = decision["scheduler_hint"]
+            assert scheduler_hint["codex_app"]["applicability"] == "applicable", decision
+            assert scheduler_hint["action"] != "repair_scheduler_execution_context", decision
+
+
 def assert_writeback_helper_preview_contract() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-monitor-poll-helper-parity-") as tmp:
         registry_path, _state_file = write_fixture(Path(tmp))
@@ -861,6 +885,11 @@ def assert_cli_monitor_poll_uses_should_run_lookback() -> None:
         next_agent_todo=None,
         next_user_todo=None,
         next_claimed_by=None,
+        codex_app=True,
+        runtime_profile=None,
+        host_surface=None,
+        scheduler_owner=None,
+        execution_mode=None,
         surface="codex_app",
         state_key="scheduler_hint.codex_app.stateful_backoff",
         applied_rrule=None,
@@ -892,12 +921,18 @@ def assert_cli_monitor_poll_uses_should_run_lookback() -> None:
     assert rc == 0, rc
     assert seen["limit"] == AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, seen
     assert seen["record_kwargs"]["available_capabilities"] == ["network"], seen
+    scheduler_context = seen["record_kwargs"]["scheduler_execution_context"]
+    assert scheduler_context.ok is True, scheduler_context
+    assert scheduler_context.context.host_surface.value == "codex_app", scheduler_context
+    assert scheduler_context.context.scheduler_owner.value == "host_automation", scheduler_context
+    assert scheduler_context.context.execution_mode.value == "hosted_automation", scheduler_context
     assert seen["payload"] == {"ok": True, "mode": "monitor-poll", "dry_run": True, "appended": False}, seen
 
 
 def main() -> int:
     assert_cli_help_names_capability_sensitive_commands()
     assert_cli_monitor_poll_uses_should_run_lookback()
+    assert_cli_monitor_poll_preserves_codex_app_scheduler_context()
     assert_writeback_helper_preview_contract()
     assert_unchanged_writeback()
     assert_interleaved_monitor_stalls_replan_blocked_benchmark()

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -325,6 +325,7 @@ def handle_quota_command(
         scheduler_context = None
         if args.quota_command in {
             "should-run",
+            "monitor-poll",
             "scheduler-ack",
             "scheduler-ack-current",
             "scheduler-fail-current",
@@ -368,6 +369,7 @@ def handle_quota_command(
                 next_agent_todo=args.next_agent_todo,
                 next_user_todo=args.next_user_todo,
                 next_claimed_by=args.next_claimed_by,
+                scheduler_execution_context=scheduler_context,
             )
         elif args.quota_command in {"scheduler-ack", "scheduler-ack-current"}:
             if not args.goal_id:

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -2340,14 +2340,14 @@ def record_quota_monitor_poll(
     next_due_at: str | None = None,
     next_agent_todo: str | None = None,
     next_user_todo: str | None = None,
-    next_claimed_by: str | None = None,
+    next_claimed_by: str | None = None, scheduler_execution_context: Mapping[str, Any] | SchedulerExecutionContextResolution | None = None,
 ) -> dict[str, Any]:
     safe_goal_id = _validate_goal_id_path_segment(str(goal_id or ""))
     before = build_quota_should_run(
         status_payload,
         goal_id=safe_goal_id,
         agent_id=agent_id,
-        available_capabilities=available_capabilities,
+        available_capabilities=available_capabilities, scheduler_execution_context=scheduler_execution_context,
     )
     return record_quota_monitor_poll_for_decision(
         before,
@@ -2357,7 +2357,7 @@ def record_quota_monitor_poll(
             after_status,
             goal_id=safe_goal_id,
             agent_id=agent_id,
-            available_capabilities=available_capabilities,
+            available_capabilities=available_capabilities, scheduler_execution_context=scheduler_execution_context,
         ),
         registry_path=registry_path,
         execute=execute,


### PR DESCRIPTION
## Summary
- include quota monitor-poll in the shared scheduler runtime-context parser
- preserve the resolved context across both pre-write and post-write should-run decisions
- add a real CLI regression proving --codex-app stays applicable before and after monitor writeback

## Validation
- monitor-poll-writeback smoke passed under Python 3.12
- quota-spend-agent-identity smoke passed
- heartbeat-quota-flow smoke passed
- standard diff-based premerge passed: 18/18 selected checks, no warnings or manual holds, public-boundary clean
- changed CLI/smoke Ruff checks and Python compile passed
- full pytest: 752 passed, 2 skipped, 1 inherited SkillsBench launcher failure; the exact failing test reproduces on clean origin/main under the same host environment
- optional control-plane-integrated canary also reproduces its unrelated stale multi-agent todo --agent-id failure on clean origin/main

## Scope
No scheduler cadence policy, quota spending, todo semantics, private state, credentials, benchmark task behavior, or external actions changed.