### PR TITLE
Refactor goal-frontier replan into ordered rules

### DIFF
--- a/examples/canary/catalog-planner-smoke.py
+++ b/examples/canary/catalog-planner-smoke.py
@@ -251,6 +251,26 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     assert state_machine_profile["deep_checks_available"] is True, state_machine_profile
     assert state_machine_profile["deep_checks_included"] is False, state_machine_profile
 
+    frontier_rule_payload = build_catalog_canary_plan(
+        changed_files=[
+            "loopx/control_plane/goals/goal_frontier_replan_rules.py",
+        ],
+        surfaces=["ordered goal frontier replan policy"],
+        max_checks_per_profile=5,
+    )
+    frontier_rule_profiles = {
+        profile["id"]: profile for profile in frontier_rule_payload["domain_profiles"]
+    }
+    assert "goal-frontier-replan-rules" in frontier_rule_profiles, frontier_rule_payload
+    frontier_rule_commands = [
+        check["command"]
+        for check in frontier_rule_profiles["goal-frontier-replan-rules"]["checks"]
+    ]
+    assert (
+        "python3 examples/control_plane/goal-frontier-replan-rules-smoke.py"
+        in frontier_rule_commands
+    ), frontier_rule_profiles["goal-frontier-replan-rules"]
+
     state_machine_deep_payload = build_catalog_canary_plan(
         changed_files=["examples/control_plane/control-plane-integrated-canary-smoke.py"],
         surfaces=[

--- a/examples/control_plane/goal-frontier-replan-rules-smoke.py
+++ b/examples/control_plane/goal-frontier-replan-rules-smoke.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Smoke-test ordered goal-frontier replan rules through quota routing."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.scheduler.execution_context import (  # noqa: E402
+    GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT,
+)
+from loopx.control_plane.testing.quota_fixtures import (  # noqa: E402
+    quota_status_payload,
+    quota_todo_item,
+    quota_todo_summary,
+)
+from loopx.quota import build_quota_should_run  # noqa: E402
+
+
+GOAL_ID = "goal-frontier-rule-smoke"
+CURRENT_AGENT = "codex-current"
+PEER_AGENT = "codex-peer"
+
+
+def vision_run() -> dict:
+    return {
+        "classification": "goal_frontier_rule_smoke",
+        "generated_at": "2026-07-18T00:00:00+00:00",
+        "agent_id": CURRENT_AGENT,
+        "progress_scope": "agent_lane",
+        "agent_vision": {
+            "schema_version": "goal_vision_replan_contract_v0",
+            "agent_id": CURRENT_AGENT,
+            "state": "active",
+            "vision_patch": {
+                "acceptance_summary": "Current agent must keep advancing its own stage.",
+                "replan_trigger_summary": "No runnable work satisfies the current stage.",
+                "advancement_policy": "repeat_until_closed",
+            },
+        },
+    }
+
+
+def advancement(todo_id: str, claimed_by: str, *, index: int) -> dict:
+    return quota_todo_item(
+        todo_id=todo_id,
+        index=index,
+        text=f"[P1] Advance {todo_id}.",
+        claimed_by=claimed_by,
+    )
+
+
+def monitor() -> dict:
+    return quota_todo_item(
+        todo_id="todo_monitor",
+        text="[P1] Monitor a material transition.",
+        claimed_by=CURRENT_AGENT,
+        task_class="continuous_monitor",
+        action_kind="monitor",
+        cadence="15m",
+        next_due_at="2999-01-01T00:00:00+00:00",
+        target_key="goal-frontier-rule-smoke",
+    )
+
+
+def quota(items: list[dict], *, include_vision: bool = True) -> dict:
+    agent_todos = quota_todo_summary(
+        items,
+        role="agent",
+        claim_scope_agent_id=CURRENT_AGENT,
+    )
+    payload = quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        recommended_action="Continue the current agent stage.",
+        agent_todos=agent_todos,
+        coordination={
+            "agent_model": "peer_v1",
+            "registered_agents": [CURRENT_AGENT, PEER_AGENT],
+        },
+        latest_runs=[vision_run()] if include_vision else [],
+    )
+    return build_quota_should_run(
+        payload,
+        goal_id=GOAL_ID,
+        agent_id=CURRENT_AGENT,
+        scheduler_execution_context=GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT,
+    )
+
+
+def main() -> None:
+    peer_only = quota([advancement("todo_peer", PEER_AGENT, index=1)])
+    assert peer_only["decision"] == "autonomous_replan_required", peer_only
+    assert peer_only["goal_frontier_projection"]["replan_required"] is True
+    assert peer_only["autonomous_replan_obligation"]["agent_id"] == CURRENT_AGENT
+
+    own_frontier = quota(
+        [
+            advancement("todo_peer", PEER_AGENT, index=1),
+            advancement("todo_current", CURRENT_AGENT, index=2),
+        ]
+    )
+    assert own_frontier["decision"] == "run", own_frontier
+    assert own_frontier["selected_todo"]["todo_id"] == "todo_current"
+    assert own_frontier["goal_frontier_projection"]["replan_required"] is False
+
+    monitor_only = quota([monitor()], include_vision=False)
+    assert monitor_only["decision"] == "autonomous_replan_required", monitor_only
+    trigger = monitor_only["autonomous_replan_obligation"]["triggers"][0]
+    assert trigger["kind"] == "frontier_exhausted_monitor_lane", trigger
+    print("goal-frontier-replan-rules-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/canary/qualification_profiles.py
+++ b/loopx/canary/qualification_profiles.py
@@ -99,6 +99,42 @@ CONTROL_PLANE_QUALIFICATION_PROFILES: tuple[dict[str, Any], ...] = (
         ],
     },
     {
+        "id": "goal-frontier-replan-rules",
+        "title": "Goal-frontier replan rule ordering",
+        "quality_risk": "high",
+        "purpose": (
+            "Qualify ordered goal-frontier replan precedence independently from "
+            "payload rendering and broader scheduler composition."
+        ),
+        "catalog_families": [
+            "Work Routing",
+            "Planning Governance",
+            "State And Boundary",
+        ],
+        "trigger_hints": (
+            "goal frontier replan",
+            "goal_frontier_replan_rules",
+            "loopx/control_plane/goals/goal_frontier.py",
+            "loopx/control_plane/goals/goal_frontier_replan_rules.py",
+            "goal-frontier-replan-rules-smoke.py",
+        ),
+        "checks": [
+            {
+                "command": "python3 examples/control_plane/goal-frontier-replan-rules-smoke.py",
+                "tier": "default",
+                "reason": (
+                    "guards ordered replan precedence, peer-lane isolation, and "
+                    "monitor-frontier exhaustion through quota routing"
+                ),
+            },
+            {
+                "command": "python3 examples/control_plane/quota-replan-decision-plane-smoke.py",
+                "tier": "deep",
+                "reason": "covers the wider replan decision plane and peer ownership contract",
+            },
+        ],
+    },
+    {
         "id": "scheduler-ack-route",
         "title": "Scheduler ACK state and route binding",
         "quality_risk": "high",

--- a/loopx/canary/quality_surface_catalog.py
+++ b/loopx/canary/quality_surface_catalog.py
@@ -129,6 +129,49 @@ QUALITY_SURFACE_CATALOG: tuple[dict[str, Any], ...] = (
         },
     },
     {
+        "surface_id": "goal-frontier-replan",
+        "title": "Goal-frontier replan obligation and precedence",
+        "risk": "high",
+        "canary_profile_id": "goal-frontier-replan-rules",
+        "owner_paths": [
+            "loopx/control_plane/goals/goal_frontier.py",
+            "loopx/control_plane/goals/goal_frontier_replan_rules.py",
+            "loopx/control_plane/work_items/autonomous_replan_ack.py",
+        ],
+        "semantic_oracle": {
+            "source_kind": "specification",
+            "refs": [
+                "docs/reference/protocols/goal-vision-replan-contract-v0.md"
+            ],
+            "independence_rationale": (
+                "The goal-vision contract defines when an agent-local frontier is "
+                "exhausted, blocked, or already advancing before the ordered rule "
+                "selector and quota projection are exercised."
+            ),
+        },
+        "layers": {
+            "unit_contract": _covered(
+                "tests/control_plane/test_goal_frontier_replan_rules.py",
+                "tests/control_plane/test_goal_vision_succession.py",
+                "tests/control_plane/test_goal_vision_blocked_successor.py",
+            ),
+            "durable_smoke": _covered(
+                "examples/control_plane/goal-frontier-replan-rules-smoke.py",
+                "examples/control_plane/quota-replan-decision-plane-smoke.py",
+            ),
+            "catalog_canary": _covered("goal-frontier-replan-rules"),
+            "host_upgrade": _not_applicable(
+                "Host continuity does not decide whether an agent-local goal frontier requires replanning."
+            ),
+            "model_behavior": _not_applicable(
+                "Replan precedence is a deterministic control-plane invariant, not a model judgment."
+            ),
+            "release_gate": _covered(
+                "loopx canary premerge --profile goal-frontier-replan-rules"
+            ),
+        },
+    },
+    {
         "surface_id": "agent-facing-cli-output",
         "title": "Agent-facing guided projection and output budgets",
         "risk": "high",

--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -18,6 +18,11 @@ from ..work_items.autonomous_replan_obligation import (
     build_autonomous_replan_obligation_payload,
 )
 from ..work_items.repair_delta import repair_delta_kinds_have_frontier_delta
+from .goal_frontier_replan_rules import (
+    GoalFrontierReplanFacts,
+    GoalFrontierReplanRule,
+    select_goal_frontier_replan_rule,
+)
 from .goal_vision_policy import goal_vision_repeats_advancement_until_closed
 from .goal_vision_state import (
     goal_vision_state_is_closed,
@@ -1167,11 +1172,6 @@ def derive_goal_frontier_replan_obligation_from_summaries(
     monitor/vision semantics in its scheduler path.
     """
 
-    if autonomous_replan_is_required(existing_replan_obligation):
-        return None
-    if _blocking_handoff_gate_count(agent_todo_summary, agent_id=agent_id) > 0:
-        return None
-
     user_counts = _summary_task_counts(user_todo_summary)
     agent_counts = _summary_task_counts(agent_todo_summary)
     frontier_counts = _frontier_advancement_counts(
@@ -1190,11 +1190,6 @@ def derive_goal_frontier_replan_obligation_from_summaries(
         item.get("kind") == VISION_SUCCESSOR_GAP_TRIGGER
         for item in compact_acceptance_gaps
     )
-    if (
-        _ready_deferred_successor_count(agent_todo_summary, agent_id=agent_id) > 0
-        and not successor_vision_required
-    ):
-        return None
     acceptance_allows_watch_lane_continuation = bool(
         compact_acceptance_gaps
         and not any(
@@ -1210,17 +1205,56 @@ def derive_goal_frontier_replan_obligation_from_summaries(
             delta_kind="watch_lane_continuation",
         )
     )
-    if user_counts.get("open", 0) > 0:
-        return None
     succession_gap_items = _succession_gap_items(
         agent_todo_summary,
         agent_id=agent_id,
     )
-    if (
-        succession_gap_items
-        and agent_counts.get("advancement", 0) == 0
-        and total_frontier_advancement == 0
-    ):
+    long_chain_trigger = _long_todo_chain_trigger(
+        agent_todo_summary=agent_todo_summary,
+        agent_counts=agent_counts,
+        frontier_counts=frontier_counts,
+        agent_id=agent_id,
+    )
+    replan_rule = select_goal_frontier_replan_rule(
+        GoalFrontierReplanFacts(
+            existing_replan_required=autonomous_replan_is_required(
+                existing_replan_obligation
+            ),
+            blocking_handoff_gate_count=_blocking_handoff_gate_count(
+                agent_todo_summary,
+                agent_id=agent_id,
+            ),
+            ready_deferred_successor_count=_ready_deferred_successor_count(
+                agent_todo_summary,
+                agent_id=agent_id,
+            ),
+            successor_vision_required=successor_vision_required,
+            user_open_count=user_counts.get("open", 0),
+            succession_gap_count=len(succession_gap_items),
+            agent_advancement_count=agent_counts.get("advancement", 0),
+            total_frontier_advancement=total_frontier_advancement,
+            acceptance_gap_count=len(compact_acceptance_gaps),
+            selectable_frontier_advancement=selectable_frontier_advancement,
+            acceptance_allows_watch_lane_continuation=(
+                acceptance_allows_watch_lane_continuation
+            ),
+            long_todo_chain_triggered=long_chain_trigger is not None,
+            long_todo_chain_acknowledged=autonomous_replan_ack_has_frontier_delta(
+                latest_replan_ack
+            ),
+            watch_lane_continuation_acknowledged=(
+                _autonomous_replan_ack_has_delta_kind(
+                    latest_replan_ack,
+                    delta_kind="watch_lane_continuation",
+                )
+            ),
+            monitor_only_lane=_is_monitor_only_lane(work_lane_contract),
+            monitor_count=agent_counts.get("monitor", 0),
+        )
+    )
+    if not replan_rule.derives_obligation:
+        return None
+    if replan_rule.rule is GoalFrontierReplanRule.TODO_SUCCESSION_GAP:
         triggers = [
             {
                 "kind": TODO_SUCCESSION_GAP_TRIGGER,
@@ -1267,18 +1301,7 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                 "the next advancement todo, or record explicit no-follow-up"
             ),
         )
-    if (
-        compact_acceptance_gaps
-        and (
-            successor_vision_required
-            or (
-                # Another peer's claimed work cannot satisfy this agent's
-                # scoped vision or checkpoint acceptance gap.
-                selectable_frontier_advancement == 0
-            )
-        )
-        and not acceptance_allows_watch_lane_continuation
-    ):
+    if replan_rule.rule is GoalFrontierReplanRule.VISION_ACCEPTANCE_GAP:
         return build_autonomous_replan_obligation_payload(
             schema_version=AUTONOMOUS_REPLAN_OBLIGATION_SCHEMA_VERSION,
             agent_id=agent_id,
@@ -1324,15 +1347,8 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                 "record no-follow-up"
             ),
         )
-    long_chain_trigger = _long_todo_chain_trigger(
-        agent_todo_summary=agent_todo_summary,
-        agent_counts=agent_counts,
-        frontier_counts=frontier_counts,
-        agent_id=agent_id,
-    )
-    if long_chain_trigger and not autonomous_replan_ack_has_frontier_delta(
-        latest_replan_ack
-    ):
+    if replan_rule.rule is GoalFrontierReplanRule.LONG_TODO_CHAIN:
+        assert long_chain_trigger is not None
         return build_autonomous_replan_obligation_payload(
             schema_version=AUTONOMOUS_REPLAN_OBLIGATION_SCHEMA_VERSION,
             agent_id=agent_id,
@@ -1379,21 +1395,7 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                 "is weak, group/prune work, and write a concrete todo or vision delta"
             ),
         )
-    # Empty monitor-only frontiers require an explicit watch continuation.
-    # Generic vision, next-action, or no-followup writebacks can close other
-    # replan obligations, but they do not prove that an active goal intended
-    # to stop generating advancement work.
-    if _autonomous_replan_ack_has_delta_kind(
-        latest_replan_ack,
-        delta_kind="watch_lane_continuation",
-    ):
-        return None
-    if not _is_monitor_only_lane(work_lane_contract):
-        return None
-    if agent_counts.get("monitor", 0) <= 0:
-        return None
-    if agent_counts.get("advancement", 0) > 0 or total_frontier_advancement > 0:
-        return None
+    assert replan_rule.rule is GoalFrontierReplanRule.MONITOR_FRONTIER_EXHAUSTED
     future_schedule_present = _monitor_only_lane_has_future_schedule(agent_todo_summary)
 
     return build_autonomous_replan_obligation_payload(

--- a/loopx/control_plane/goals/goal_frontier_replan_rules.py
+++ b/loopx/control_plane/goals/goal_frontier_replan_rules.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+GOAL_FRONTIER_REPLAN_RULE_DECISION_SCHEMA_VERSION = (
+    "goal_frontier_replan_rule_decision_v0"
+)
+
+
+class GoalFrontierReplanRule(str, Enum):
+    EXISTING_OBLIGATION = "existing_obligation"
+    BLOCKING_HANDOFF_GATE = "blocking_handoff_gate"
+    READY_DEFERRED_SUCCESSOR = "ready_deferred_successor"
+    OPEN_USER_TODO = "open_user_todo"
+    TODO_SUCCESSION_GAP = "todo_succession_gap"
+    VISION_ACCEPTANCE_GAP = "vision_acceptance_gap"
+    LONG_TODO_CHAIN = "long_todo_chain"
+    LONG_TODO_CHAIN_ACKNOWLEDGED = "long_todo_chain_acknowledged"
+    WATCH_LANE_CONTINUATION_ACKNOWLEDGED = "watch_lane_continuation_acknowledged"
+    NOT_MONITOR_ONLY = "not_monitor_only"
+    NO_OPEN_MONITOR = "no_open_monitor"
+    ADVANCEMENT_REMAINS = "advancement_remains"
+    MONITOR_FRONTIER_EXHAUSTED = "monitor_frontier_exhausted"
+
+
+GOAL_FRONTIER_REPLAN_RULE_ORDER = tuple(GoalFrontierReplanRule)
+
+
+@dataclass(frozen=True)
+class GoalFrontierReplanFacts:
+    existing_replan_required: bool = False
+    blocking_handoff_gate_count: int = 0
+    ready_deferred_successor_count: int = 0
+    successor_vision_required: bool = False
+    user_open_count: int = 0
+    succession_gap_count: int = 0
+    agent_advancement_count: int = 0
+    total_frontier_advancement: int = 0
+    acceptance_gap_count: int = 0
+    selectable_frontier_advancement: int = 0
+    acceptance_allows_watch_lane_continuation: bool = False
+    long_todo_chain_triggered: bool = False
+    long_todo_chain_acknowledged: bool = False
+    watch_lane_continuation_acknowledged: bool = False
+    monitor_only_lane: bool = False
+    monitor_count: int = 0
+
+
+@dataclass(frozen=True)
+class GoalFrontierReplanRuleDecision:
+    rule: GoalFrontierReplanRule
+    derives_obligation: bool
+    reason: str
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": GOAL_FRONTIER_REPLAN_RULE_DECISION_SCHEMA_VERSION,
+            "rule": self.rule.value,
+            "rule_index": GOAL_FRONTIER_REPLAN_RULE_ORDER.index(self.rule),
+            "derives_obligation": self.derives_obligation,
+            "reason": self.reason,
+        }
+
+
+def select_goal_frontier_replan_rule(
+    facts: GoalFrontierReplanFacts,
+) -> GoalFrontierReplanRuleDecision:
+    """Select the first matching goal-frontier rule in policy order."""
+
+    ordered_rules = (
+        (
+            GoalFrontierReplanRule.EXISTING_OBLIGATION,
+            facts.existing_replan_required,
+            False,
+            "an existing scoped obligation remains authoritative",
+        ),
+        (
+            GoalFrontierReplanRule.BLOCKING_HANDOFF_GATE,
+            facts.blocking_handoff_gate_count > 0,
+            False,
+            "a blocking handoff gate owns the next transition",
+        ),
+        (
+            GoalFrontierReplanRule.READY_DEFERRED_SUCCESSOR,
+            facts.ready_deferred_successor_count > 0
+            and not facts.successor_vision_required,
+            False,
+            "a deferred successor is already runnable",
+        ),
+        (
+            GoalFrontierReplanRule.OPEN_USER_TODO,
+            facts.user_open_count > 0,
+            False,
+            "open user work owns the frontier",
+        ),
+        (
+            GoalFrontierReplanRule.TODO_SUCCESSION_GAP,
+            facts.succession_gap_count > 0
+            and facts.agent_advancement_count == 0
+            and facts.total_frontier_advancement == 0,
+            True,
+            "completed advancement work lacks a successor or no-followup rationale",
+        ),
+        (
+            GoalFrontierReplanRule.VISION_ACCEPTANCE_GAP,
+            facts.acceptance_gap_count > 0
+            and (
+                facts.successor_vision_required
+                or facts.selectable_frontier_advancement == 0
+            )
+            and not facts.acceptance_allows_watch_lane_continuation,
+            True,
+            "the scoped vision gap has no satisfying runnable frontier",
+        ),
+        (
+            GoalFrontierReplanRule.LONG_TODO_CHAIN,
+            facts.long_todo_chain_triggered
+            and not facts.long_todo_chain_acknowledged,
+            True,
+            "the selectable todo chain crossed the bounded replan threshold",
+        ),
+        (
+            GoalFrontierReplanRule.LONG_TODO_CHAIN_ACKNOWLEDGED,
+            facts.long_todo_chain_triggered and facts.long_todo_chain_acknowledged,
+            False,
+            "a frontier-delta acknowledgement covers the long todo chain",
+        ),
+        (
+            GoalFrontierReplanRule.WATCH_LANE_CONTINUATION_ACKNOWLEDGED,
+            facts.watch_lane_continuation_acknowledged,
+            False,
+            "an explicit watch-lane continuation covers the empty frontier",
+        ),
+        (
+            GoalFrontierReplanRule.NOT_MONITOR_ONLY,
+            not facts.monitor_only_lane,
+            False,
+            "the selected lane is not monitor-only",
+        ),
+        (
+            GoalFrontierReplanRule.NO_OPEN_MONITOR,
+            facts.monitor_count <= 0,
+            False,
+            "no open monitor remains",
+        ),
+        (
+            GoalFrontierReplanRule.ADVANCEMENT_REMAINS,
+            facts.agent_advancement_count > 0
+            or facts.total_frontier_advancement > 0,
+            False,
+            "advancement work remains on the frontier",
+        ),
+        (
+            GoalFrontierReplanRule.MONITOR_FRONTIER_EXHAUSTED,
+            True,
+            True,
+            "only monitor work remains on an empty advancement frontier",
+        ),
+    )
+    for rule, matches, derives_obligation, reason in ordered_rules:
+        if matches:
+            return GoalFrontierReplanRuleDecision(
+                rule=rule,
+                derives_obligation=derives_obligation,
+                reason=reason,
+            )
+    raise AssertionError("goal-frontier replan rules must have a terminal rule")

--- a/tests/control_plane/test_goal_frontier_replan_rules.py
+++ b/tests/control_plane/test_goal_frontier_replan_rules.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from loopx.control_plane.goals.goal_frontier import (
+    derive_goal_frontier_replan_obligation_from_summaries,
+)
+from loopx.control_plane.goals.goal_frontier_replan_rules import (
+    GOAL_FRONTIER_REPLAN_RULE_ORDER,
+    GoalFrontierReplanFacts,
+    GoalFrontierReplanRule,
+    select_goal_frontier_replan_rule,
+)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected_rule", "derives_obligation"),
+    [
+        (
+            {"existing_replan_required": True, "blocking_handoff_gate_count": 1},
+            GoalFrontierReplanRule.EXISTING_OBLIGATION,
+            False,
+        ),
+        (
+            {"blocking_handoff_gate_count": 1, "acceptance_gap_count": 1},
+            GoalFrontierReplanRule.BLOCKING_HANDOFF_GATE,
+            False,
+        ),
+        (
+            {"ready_deferred_successor_count": 1},
+            GoalFrontierReplanRule.READY_DEFERRED_SUCCESSOR,
+            False,
+        ),
+        (
+            {"user_open_count": 1, "acceptance_gap_count": 1},
+            GoalFrontierReplanRule.OPEN_USER_TODO,
+            False,
+        ),
+        (
+            {"succession_gap_count": 1, "acceptance_gap_count": 1},
+            GoalFrontierReplanRule.TODO_SUCCESSION_GAP,
+            True,
+        ),
+        (
+            {"acceptance_gap_count": 1},
+            GoalFrontierReplanRule.VISION_ACCEPTANCE_GAP,
+            True,
+        ),
+        (
+            {
+                "long_todo_chain_triggered": True,
+                "selectable_frontier_advancement": 15,
+            },
+            GoalFrontierReplanRule.LONG_TODO_CHAIN,
+            True,
+        ),
+        (
+            {
+                "long_todo_chain_triggered": True,
+                "long_todo_chain_acknowledged": True,
+                "selectable_frontier_advancement": 15,
+            },
+            GoalFrontierReplanRule.LONG_TODO_CHAIN_ACKNOWLEDGED,
+            False,
+        ),
+        (
+            {
+                "watch_lane_continuation_acknowledged": True,
+                "monitor_only_lane": True,
+                "monitor_count": 1,
+            },
+            GoalFrontierReplanRule.WATCH_LANE_CONTINUATION_ACKNOWLEDGED,
+            False,
+        ),
+        ({}, GoalFrontierReplanRule.NOT_MONITOR_ONLY, False),
+        (
+            {"monitor_only_lane": True},
+            GoalFrontierReplanRule.NO_OPEN_MONITOR,
+            False,
+        ),
+        (
+            {
+                "monitor_only_lane": True,
+                "monitor_count": 1,
+                "agent_advancement_count": 1,
+                "total_frontier_advancement": 1,
+            },
+            GoalFrontierReplanRule.ADVANCEMENT_REMAINS,
+            False,
+        ),
+        (
+            {"monitor_only_lane": True, "monitor_count": 1},
+            GoalFrontierReplanRule.MONITOR_FRONTIER_EXHAUSTED,
+            True,
+        ),
+    ],
+)
+def test_goal_frontier_replan_decision_table(
+    overrides: dict[str, object],
+    expected_rule: GoalFrontierReplanRule,
+    derives_obligation: bool,
+) -> None:
+    facts = replace(GoalFrontierReplanFacts(), **overrides)
+
+    decision = select_goal_frontier_replan_rule(facts)
+
+    assert decision.rule is expected_rule
+    assert decision.derives_obligation is derives_obligation
+    assert decision.to_payload()["rule_index"] == GOAL_FRONTIER_REPLAN_RULE_ORDER.index(
+        expected_rule
+    )
+
+
+def _repeat_vision_gap() -> list[dict[str, object]]:
+    return [
+        {
+            "kind": "vision_acceptance_gap",
+            "acceptance_summary": "This agent must keep advancing its own stage.",
+            "replan_trigger_summary": "No runnable work satisfies this agent's stage.",
+            "advancement_policy": "repeat_until_closed",
+        }
+    ]
+
+
+def _advancement(todo_id: str, claimed_by: str) -> dict[str, object]:
+    return {
+        "todo_id": todo_id,
+        "status": "open",
+        "task_class": "advancement_task",
+        "claimed_by": claimed_by,
+    }
+
+
+@pytest.mark.parametrize("other_agent_count", [1, 2, 8])
+def test_other_agent_backlog_size_cannot_satisfy_scoped_vision_gap(
+    other_agent_count: int,
+) -> None:
+    other_items = [
+        _advancement(f"todo_peer_{index}", f"peer-{index}")
+        for index in range(other_agent_count)
+    ]
+
+    obligation = derive_goal_frontier_replan_obligation_from_summaries(
+        user_todo_summary={"open_count": 0},
+        agent_todo_summary={
+            "open_count": other_agent_count,
+            "claimed_advancement_open_count": other_agent_count,
+            "current_agent_claimed_advancement_count": 0,
+            "unclaimed_priority_open_items": [],
+            "executable_backlog_items": [],
+            "claim_scope": {"other_agent_claimed_items": other_items},
+        },
+        work_lane_contract=None,
+        agent_id="current-agent",
+        existing_replan_obligation=None,
+        acceptance_gaps=_repeat_vision_gap(),
+    )
+
+    assert obligation is not None
+    assert obligation["agent_id"] == "current-agent"
+    assert obligation["triggers"][0]["kind"] == "vision_acceptance_gap"
+
+
+def test_current_agent_advancement_satisfies_scoped_vision_frontier() -> None:
+    current_item = _advancement("todo_current", "current-agent")
+
+    obligation = derive_goal_frontier_replan_obligation_from_summaries(
+        user_todo_summary={"open_count": 0},
+        agent_todo_summary={
+            "open_count": 1,
+            "claimed_advancement_open_count": 1,
+            "current_agent_claimed_advancement_count": 1,
+            "unclaimed_priority_open_items": [],
+            "executable_backlog_items": [current_item],
+            "claim_scope": {"other_agent_claimed_items": []},
+        },
+        work_lane_contract={"lane": "advancement_task", "must_attempt_work": True},
+        agent_id="current-agent",
+        existing_replan_obligation=None,
+        acceptance_gaps=_repeat_vision_gap(),
+    )
+
+    assert obligation is None


### PR DESCRIPTION
## Summary
- extract goal-frontier replan precedence into an immutable fact packet and explicit first-match rule selector while retaining existing obligation payload builders
- add decision-table and agent-isolation metamorphic tests plus a quota-routing smoke for peer-only, own-frontier, and monitor-only cases
- register the deterministic rule surface as a high-risk canary profile with an independent semantic oracle and explicit quality-layer classifications

## Validation
- `49 passed`: focused replan, vision succession, blocked-successor, and quality-surface catalog tests
- `loopx canary premerge --from-git-diff --tier standard`: passed, 18/18 selected checks, public-boundary scan clean, no manual holds
- `ruff check` on all changed Python files: passed
- full pytest before final rebase: 772 passed, 2 skipped, 1 failed; the sole SkillsBench independent-validator failure reproduced unchanged on a clean synced main worktree and is unrelated to this diff

## Risk and review
- CLI/public payload shape is unchanged; selection remains deterministic and existing payload construction is reused
- host-upgrade and model-behavior layers are explicitly not applicable because deterministic control-plane precedence must not be delegated to a host or model
- no credentials, private state, local paths, generated logs, or raw benchmark evidence are included
- merge is intentionally left for independent peer review because this refactors high-risk quota/replan behavior.