### PR TITLE
Refactor internal consumers off status and quota reexports

### DIFF
--- a/loopx/cli_commands/benchmark_review_lifecycle.py
+++ b/loopx/cli_commands/benchmark_review_lifecycle.py
@@ -25,16 +25,15 @@ from ..benchmark_adapters.terminal_bench import (
 from ..control_plane.runtime.benchmark_comparison import (
     compact_benchmark_comparison,
 )
+from ..control_plane.runtime.benchmark_learning_ledger import (
+    compact_benchmark_learning_ledger,
+)
+from ..control_plane.runtime.benchmark_result import compact_benchmark_result
 from ..control_plane.work_items.delivery_batch_scale import DELIVERY_BATCH_SCALE_CHOICES
 from ..control_plane.work_items.delivery_outcome import DELIVERY_OUTCOME_CHOICES
 from ..global_registry import sync_project_registry_to_global
 from ..history import append_benchmark_comparison
-from ..status import (
-    compact_benchmark_learning_ledger,
-    compact_benchmark_result,
-    compact_benchmark_post_launch_materialization,
-    compact_benchmark_run,
-)
+from ..status import compact_benchmark_run
 
 
 PrintPayload = Callable[

--- a/loopx/cli_commands/history.py
+++ b/loopx/cli_commands/history.py
@@ -12,6 +12,13 @@ from ..benchmark_adapters.agents_last_exam import (
 from ..control_plane.runtime.benchmark_comparison import (
     compact_benchmark_comparison,
 )
+from ..control_plane.runtime.benchmark_experiment_report import (
+    compact_benchmark_experiment_report,
+)
+from ..control_plane.runtime.benchmark_learning_ledger import (
+    compact_benchmark_learning_ledger,
+)
+from ..control_plane.runtime.benchmark_result import compact_benchmark_result
 from ..control_plane.work_items.delivery_batch_scale import DELIVERY_BATCH_SCALE_CHOICES
 from ..control_plane.work_items.delivery_outcome import DELIVERY_OUTCOME_CHOICES
 from ..control_plane.runtime.trajectory_hygiene import build_trajectory_hygiene_summary
@@ -45,9 +52,6 @@ from ..presentation.renderers.trajectory_hygiene_markdown import (
 )
 from ..status import (
     compact_active_user_assisted_pilot,
-    compact_benchmark_experiment_report,
-    compact_benchmark_learning_ledger,
-    compact_benchmark_result,
     compact_benchmark_run,
 )
 

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -9,11 +9,6 @@ from ..quota import (
     build_quota_should_run,
     record_quota_monitor_poll,
     record_quota_scheduler_ack,
-    render_quota_markdown,
-    render_quota_monitor_poll_markdown,
-    render_quota_scheduler_ack_markdown,
-    render_quota_should_run_markdown,
-    render_quota_slot_preview_markdown,
     spend_quota_slot,
     void_quota_slot,
 )
@@ -21,11 +16,16 @@ from ..status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, collect_status
 from ..upgrade import resolve_codex_app_automation_rrule
 from ..control_plane.quota.turn_envelope import build_turn_envelope
 from ..control_plane.quota.live_decision import build_live_quota_should_run_decision
+from ..control_plane.quota.monitor_poll import render_quota_monitor_poll_markdown
 from ..control_plane.quota.scheduler_ack import (
     record_quota_scheduler_failure_for_decision,
 )
+from ..control_plane.quota.slot_accounting import render_quota_slot_preview_markdown
 from ..presentation.renderers.quota_markdown import (
+    render_quota_markdown,
+    render_quota_scheduler_ack_markdown,
     render_quota_scheduler_failure_markdown,
+    render_quota_should_run_markdown,
 )
 from ..control_plane.scheduler.execution_context import (
     SchedulerExecutionContextResolution,

--- a/loopx/dreaming.py
+++ b/loopx/dreaming.py
@@ -11,10 +11,10 @@ from .history import collect_history, load_registry, write_reserved_run_artifact
 from .paths import resolve_runtime_root
 from .registry import registry_goals
 from .runtime import validate_goal_id_path_segment
+from .control_plane.runtime.public_safety import public_safe_compact_text
 from .status import (
     DREAMING_ADVISORY_CLASSIFICATIONS,
     STATUS_NEUTRAL_CLASSIFICATIONS,
-    public_safe_compact_text,
 )
 from .state_refresh import now_local
 from .todos import add_goal_todo, update_goal_todo

--- a/loopx/history.py
+++ b/loopx/history.py
@@ -34,12 +34,12 @@ from .presentation.markdown import (
     markdown_table_row,
     markdown_table_separator,
 )
-from .quota import (
-    QUOTA_MONITOR_POLL_CLASSIFICATION,
+from .control_plane.quota.monitor_poll import QUOTA_MONITOR_POLL_CLASSIFICATION
+from .control_plane.quota.slot_accounting import (
     QUOTA_SLOT_SPENT_CLASSIFICATION,
     QUOTA_SLOT_VOIDED_CLASSIFICATION,
-    goal_quota_with_spend_ledger,
 )
+from .quota import goal_quota_with_spend_ledger
 from .registry import read_json, registry_goals
 
 

--- a/loopx/todo_followups.py
+++ b/loopx/todo_followups.py
@@ -6,8 +6,8 @@ from typing import Any
 
 from .file_lock import exclusive_file_lock
 from .state_refresh import now_local
-from .status import normalize_todo_text
 from .control_plane.todos.contract import TODO_TASK_CLASS_ADVANCEMENT
+from .control_plane.todos.todo_summary import normalize_todo_text
 from .todos import (
     TODO_SECTION_HEADINGS,
     add_todo_to_lines,

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -13,10 +13,8 @@ from .state_refresh import now_local, resolve_goal_state
 from .status import (
     MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE,
     active_state_event_projection_fields,
-    compact_todo_group,
-    normalize_todo_text,
-    parse_active_state_todos,
 )
+from .control_plane.todos.active_state_todo_parser import parse_active_state_todos
 from .control_plane.todos.contract import (
     TodoContinuationPolicy,
     TODO_STATUS_DEFERRED,
@@ -78,6 +76,7 @@ from .control_plane.todos.line_update import (
 )
 from .control_plane.todos.monitor_metadata import require_monitor_metadata_scope
 from .control_plane.todos.mutation_authority import authorize_todo_lifecycle_mutation, todo_update_authority_action
+from .control_plane.todos.todo_summary import compact_todo_group, normalize_todo_text
 from .control_plane.todos.succession_warning import build_open_parent_successor_advisory
 from .control_plane.todos.todo_index import MAX_TODO_INDEX_ROLLOUT_EVENTS_PER_GOAL
 from .control_plane.todos.text import (

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -14452,10 +14452,10 @@ def reduce_result(
     from loopx.benchmark import (
         build_skillsbench_benchflow_result_benchmark_run,
     )
-    from loopx.status import (
+    from loopx.control_plane.runtime.skillsbench_post_run_debug import (
         build_skillsbench_post_run_debug_gate,
-        compact_benchmark_run,
     )
+    from loopx.status import compact_benchmark_run
 
     controller_trace = _read_controller_trace(plan)
     _merge_acp_trajectory_summary(plan, controller_trace)
@@ -15320,10 +15320,10 @@ def build_runner_failure_compact(
         skillsbench_runner_error_attribution,
         skillsbench_runner_error_fingerprint,
     )
-    from loopx.status import (
+    from loopx.control_plane.runtime.skillsbench_post_run_debug import (
         build_skillsbench_post_run_debug_gate,
-        compact_benchmark_run,
     )
+    from loopx.status import compact_benchmark_run
 
     plan.setdefault("runner_prerequisites", {})
     _ensure_runner_interruption_prerequisites(plan, exc)

--- a/tests/architecture/test_control_plane_import_boundaries.py
+++ b/tests/architecture/test_control_plane_import_boundaries.py
@@ -5,7 +5,9 @@ from importlib.util import resolve_name
 from pathlib import Path
 
 
-PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "loopx"
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = REPOSITORY_ROOT / "loopx"
+SCRIPTS_ROOT = REPOSITORY_ROOT / "scripts"
 CONTROL_PLANE_ROOT = PACKAGE_ROOT / "control_plane"
 STATUS_MODULE = PACKAGE_ROOT / "status.py"
 QUOTA_MODULE = PACKAGE_ROOT / "quota.py"
@@ -62,6 +64,35 @@ def _resolved_imports(path: Path) -> set[str]:
     return imports
 
 
+def _resolved_from_imports(path: Path) -> dict[str, set[str]]:
+    package_name = ""
+    if path.is_relative_to(PACKAGE_ROOT):
+        module_name = _module_name(path)
+        package_name = module_name if path.name == "__init__.py" else module_name.rpartition(".")[0]
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: dict[str, set[str]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        module = node.module or ""
+        if node.level:
+            if not package_name:
+                continue
+            module = resolve_name("." * node.level + module, package_name)
+        imports.setdefault(module, set()).update(alias.name for alias in node.names)
+    return imports
+
+
+def _top_level_imported_names(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    return {
+        alias.asname or alias.name
+        for node in tree.body
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+
+
 def test_control_plane_does_not_gain_outward_dependencies() -> None:
     outward_dependencies = {
         (_module_name(path), dependency)
@@ -85,6 +116,31 @@ def test_quota_markdown_is_owned_by_the_presentation_layer() -> None:
 
     assert not legacy_renderer.exists()
     assert "loopx.presentation.renderers.quota_markdown" in imports
+
+
+def test_internal_consumers_bypass_status_and_quota_reexport_routes() -> None:
+    facade_reexports = {
+        "loopx.status": _top_level_imported_names(STATUS_MODULE),
+        "loopx.quota": _top_level_imported_names(QUOTA_MODULE),
+    }
+    internal_paths = (
+        path
+        for root in (PACKAGE_ROOT, SCRIPTS_ROOT)
+        for path in root.rglob("*.py")
+        if path not in {STATUS_MODULE, QUOTA_MODULE}
+    )
+    indirect_imports = {
+        (_module_name(path) if path.is_relative_to(PACKAGE_ROOT) else str(path.relative_to(REPOSITORY_ROOT)), facade, name)
+        for path in internal_paths
+        for facade, imported_names in _resolved_from_imports(path).items()
+        if facade in facade_reexports
+        for name in imported_names & facade_reexports[facade]
+    }
+
+    assert not indirect_imports, (
+        "repository-internal consumers must import extracted symbols from their "
+        f"canonical modules instead of status/quota re-export routes: {sorted(indirect_imports)}"
+    )
 
 
 def test_status_outward_dependency_debt_only_shrinks() -> None:


### PR DESCRIPTION
## Summary
- route repository-internal consumers of already-extracted status/quota symbols directly to their canonical bounded modules
- keep facade-owned behavior and public loopx.status / loopx.quota compatibility unchanged
- add an AST import-boundary test that prevents internal code and scripts from reintroducing extracted-symbol facade detours

## Scope
- migrates 16 extracted symbols across quota/history/todo/dreaming/benchmark call sites
- removes one stale unused status import
- does not move implementations, change CLI payload schemas, or prune public facade exports

## Validation
- 36 focused pytest tests passed after rebase
- status-quota-review-packet-parity, CLI history modularization, todo capture-followups, and quota-plan smokes passed under Python 3.12
- full pytest: 759 passed, 2 skipped, 1 failed; the sole SkillsBench independent-validator failure reproduced unchanged on clean latest main
- standard premerge: 9 changed files, 17 selected checks passed, 0 failures/warnings; public/private boundary clean
- py_compile and focused Ruff checks passed; broad Ruff on the legacy SkillsBench runner still reports inherited pre-existing findings

## Review hold
Premerge correctly retained the benchmark-sensitive manual hold because the patch updates internal imports in the SkillsBench runner. This PR is intentionally left for independent review and is not self-merged.

No credentials, private state, local paths, raw benchmark evidence, or generated logs are included.