### PR TITLE
refactor(lark): gate quota urgency through extension

### DIFF
--- a/docs/capabilities/lark-event-inbox.md
+++ b/docs/capabilities/lark-event-inbox.md
@@ -54,6 +54,12 @@ candidate revision before switching it. A goal with no Lark inbox pointer still
 returns the existing quiet disabled drain projection and does not require the
 extension, so projects that do not use Lark remain unaffected.
 
+Quota and Turn planning also resolve `lark.inbox.read` before the extension
+opens the local-private profile/chat config. A missing, disabled, or stale
+extension yields an unavailable urgency projection, does not read that config,
+and cannot schedule a Lark reply lane. The compatibility CLI performs this
+composition internally; agents do not pass a provider, profile, or alias.
+
 The collector service is a separate host lifecycle. Disabling or switching the
 extension blocks its next `collector-run` start but does not signal a process
 that is already consuming events. Stop or restart the configured launchd or

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -101,6 +101,12 @@ configuration. Extension lifecycle commands do not terminate an already
 running host-managed collector process; stop or restart that supervisor service
 separately when changing the active provider revision.
 
+Quota and Turn composition apply the same read gate. They inject the Lark
+extension's urgency projector only after resolving `lark.inbox.read`; provider
+profile/chat schema and private config reads stay in the extension. If the
+extension is missing, disabled, or stale, urgency is unavailable and cannot
+activate a Lark work lane. This adds no agent-facing CLI arguments.
+
 ## Placement Decision For Agents
 
 Before creating a directory, LoopX or an executing agent must answer these
@@ -237,8 +243,10 @@ distribution and service setup to explicit operator-owned workflows.
 Provider migration follows the same direction. Core routing consumes compact
 provider-neutral read models, while provider packages own collection, transport,
 credentials, and external effects. For example, quota reads
-`operator_inbox_urgency_v0`. Lark inbox collection, reply transport, and
-provider-owned configuration live under `loopx/extensions/lark/`; the existing
+`operator_inbox_urgency_v0` through an injected projector. The generic parser
+and read-model contract stay in the control plane; Lark schema, identity,
+destination, collection, reply transport, and provider-owned configuration live
+under `loopx/extensions/lark/`. The existing
 `loopx lark-inbox` command remains a direct compatibility delegate, but it now
 requires an installed, enabled, doctor-verified `loopx-lark` revision with the
 operation's declared permission. The provider subprocess currently implements

--- a/examples/control_plane/lark-inbox-priority-smoke.py
+++ b/examples/control_plane/lark-inbox-priority-smoke.py
@@ -15,11 +15,11 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.extensions.lark.event_inbox import (  # noqa: E402
+    LARK_OPERATOR_INBOX_SOURCE_CONTRACT,
     acknowledge_lark_event_inbox,
     project_lark_event_inbox_urgency,
 )
 from loopx.control_plane.work_items.operator_inbox import (  # noqa: E402
-    LARK_OPERATOR_INBOX_SOURCE_CONTRACT,
     project_operator_inbox_urgency,
 )
 from loopx.control_plane.testing.quota_fixtures import (  # noqa: E402
@@ -148,7 +148,11 @@ def main() -> None:
             encoding="utf-8",
         )
 
-        decision = build_quota_should_run(status_payload(project), goal_id=GOAL_ID)
+        decision = build_quota_should_run(
+            status_payload(project),
+            goal_id=GOAL_ID,
+            operator_inbox_urgency_projector=project_lark_event_inbox_urgency,
+        )
         assert decision["should_run"] is True, decision
         assert decision["effective_action"] == "lark_inbox_reply_due", decision
         assert decision["monitor_debt_arbitration"]["active"] is True, decision
@@ -218,7 +222,9 @@ def main() -> None:
             encoding="utf-8",
         )
         reply_decision = build_quota_should_run(
-            status_payload(project), goal_id=GOAL_ID
+            status_payload(project),
+            goal_id=GOAL_ID,
+            operator_inbox_urgency_projector=project_lark_event_inbox_urgency,
         )
         reply_lane = reply_decision["work_lane_contract"]
         assert reply_decision["effective_action"] == "lark_inbox_reply_due", (
@@ -232,7 +238,11 @@ def main() -> None:
             message_ids=["om_verified_bot_reply"],
             execute=True,
         )
-        after_ack = build_quota_should_run(status_payload(project), goal_id=GOAL_ID)
+        after_ack = build_quota_should_run(
+            status_payload(project),
+            goal_id=GOAL_ID,
+            operator_inbox_urgency_projector=project_lark_event_inbox_urgency,
+        )
         assert after_ack["work_lane_contract"]["lane"] == "advancement_task", after_ack
         assert after_ack["effective_action"] == "normal_run", after_ack
 

--- a/examples/lark-extension-activation-smoke.py
+++ b/examples/lark-extension-activation-smoke.py
@@ -117,6 +117,12 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-extension-") as raw_temp:
     )
     kanban_schema_args = ("lark-kanban", "schema")
     explore_schema_args = ("explore", "schema")
+    quota_args = (
+        "quota",
+        "should-run",
+        "--goal-id",
+        "lark-extension-fixture",
+    )
 
     missing = run_cli(
         registry,
@@ -146,6 +152,12 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-extension-") as raw_temp:
         expected_returncode=1,
     )
     assert "not installed" in str(explore_missing["error"]), explore_missing
+    quota_missing = run_cli(
+        registry, runtime_root, *quota_args, expected_returncode=1
+    )
+    assert quota_missing["goal_boundary"]["capabilities"]["lark_event_inbox"][
+        "urgency"
+    ]["projection_status"] == "unavailable", quota_missing
 
     installed = run_cli(
         registry,
@@ -161,7 +173,7 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-extension-") as raw_temp:
     assert active["extension_activation"] == {
         "schema_version": "loopx_extension_activation_v0",
         "extension_id": "loopx-lark",
-        "provider_version": "1.2.0",
+        "provider_version": "1.3.0",
         "revision": installed["revision"],
         "enabled": True,
         "doctor_verified": True,
@@ -188,6 +200,14 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-extension-") as raw_temp:
         **active["extension_activation"],
         "required_permissions": ["lark.projection_sink.use"],
     }, explore_active
+    quota_active = run_cli(
+        registry, runtime_root, *quota_args, expected_returncode=1
+    )
+    active_urgency = quota_active["goal_boundary"]["capabilities"][
+        "lark_event_inbox"
+    ]["urgency"]
+    assert active_urgency["schema_version"] == "lark_event_inbox_urgency_v0"
+    assert active_urgency.get("projection_status") != "unavailable"
 
     disabled = run_cli(
         registry,
@@ -226,6 +246,12 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-extension-") as raw_temp:
         expected_returncode=1,
     )
     assert "is disabled" in str(explore_blocked["error"]), explore_blocked
+    quota_disabled = run_cli(
+        registry, runtime_root, *quota_args, expected_returncode=1
+    )
+    assert quota_disabled["goal_boundary"]["capabilities"]["lark_event_inbox"][
+        "urgency"
+    ]["projection_status"] == "unavailable", quota_disabled
 
     enabled = run_cli(
         registry,
@@ -238,11 +264,11 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-extension-") as raw_temp:
     assert enabled["doctor"]["verified"] is True, enabled
 
     bundled_manifest = ROOT / "loopx" / "extensions" / "lark" / "extension.toml"
-    upgraded_manifest = temp / "loopx-lark-v1.3.toml"
+    upgraded_manifest = temp / "loopx-lark-v1.4.toml"
     upgraded_manifest.write_text(
         bundled_manifest.read_text(encoding="utf-8").replace(
-            'version = "1.2.0"',
             'version = "1.3.0"',
+            'version = "1.4.0"',
             1,
         ),
         encoding="utf-8",

--- a/loopx/cli_commands/lark_inbox.py
+++ b/loopx/cli_commands/lark_inbox.py
@@ -19,6 +19,7 @@ from ..extensions.lark.event_inbox import (
     ingest_lark_event_inbox,
     inspect_lark_event_inbox,
     lark_event_inbox_contains_text,
+    project_lark_event_inbox_urgency,
 )
 from ..extensions.lark.inbox_reply import reply_lark_event_inbox
 from ..extensions.lark.reviewer_notification import (
@@ -189,6 +190,28 @@ def _resolve_lark_activation(
         state_file=default_extension_state_file(runtime_root_arg),
         required_permissions=_required_extension_permissions(command),
     )
+
+
+def build_lark_operator_inbox_urgency_projector(
+    *, runtime_root_arg: str | Path | None
+) -> Callable[..., dict[str, object]]:
+    """Compose activation proof with the extension-owned private config read."""
+
+    def project(
+        *, project: str | Path, config_path: str | Path
+    ) -> dict[str, object]:
+        _resolve_lark_activation(
+            "drain",
+            runtime_root_arg=(
+                str(runtime_root_arg) if runtime_root_arg is not None else None
+            ),
+        )
+        return project_lark_event_inbox_urgency(
+            project=project,
+            config_path=config_path,
+        )
+
+    return project
 
 
 def build_lark_issue_fix_reviewer_provider_hooks(

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -38,6 +38,7 @@ from ..control_plane.runtime.status_projection_cache import (
     write_status_projection_cache,
 )
 from ..presentation.renderers.turn_envelope_markdown import render_turn_envelope_markdown
+from .lark_inbox import build_lark_operator_inbox_urgency_projector
 
 
 PrintPayload = Callable[
@@ -289,6 +290,11 @@ def handle_quota_command(
             registry_path=registry_path,
             runtime_root_override=runtime_root_arg,
         )
+        operator_inbox_urgency_projector = (
+            build_lark_operator_inbox_urgency_projector(
+                runtime_root_arg=runtime_root,
+            )
+        )
         status_payload = None
         cache_metadata = None
         use_projection_cache = bool(getattr(args, "use_projection_cache", False))
@@ -347,6 +353,7 @@ def handle_quota_command(
                 runtime_root=runtime_root,
                 host_observation_resolver=resolve_codex_app_automation_rrule,
                 scheduler_execution_context=scheduler_context,
+                operator_inbox_urgency_projector=operator_inbox_urgency_projector,
             )
         elif args.quota_command == "monitor-poll":
             if not args.goal_id:
@@ -372,6 +379,7 @@ def handle_quota_command(
                 next_user_todo=args.next_user_todo,
                 next_claimed_by=args.next_claimed_by,
                 scheduler_execution_context=scheduler_context,
+                operator_inbox_urgency_projector=operator_inbox_urgency_projector,
             )
         elif args.quota_command in {"scheduler-ack", "scheduler-ack-current"}:
             if not args.goal_id:
@@ -395,6 +403,7 @@ def handle_quota_command(
                 use_current_hint=bool(args.use_current_hint or args.quota_command == "scheduler-ack-current"),
                 host_match_observed=bool(getattr(args, "host_match_observed", False)),
                 scheduler_execution_context=scheduler_context,
+                operator_inbox_urgency_projector=operator_inbox_urgency_projector,
             )
         elif args.quota_command == "scheduler-fail-current":
             if not args.goal_id:
@@ -418,6 +427,7 @@ def handle_quota_command(
                 available_capabilities=args.available_capabilities,
                 codex_app_current_rrule=observed_rrule,
                 scheduler_execution_context=scheduler_context,
+                operator_inbox_urgency_projector=operator_inbox_urgency_projector,
             )
             payload = record_quota_scheduler_failure_for_decision(
                 failure_decision,
@@ -444,6 +454,7 @@ def handle_quota_command(
                 source=args.source,
                 agent_id=args.agent_id,
                 available_capabilities=args.available_capabilities,
+                operator_inbox_urgency_projector=operator_inbox_urgency_projector,
             )
         elif args.quota_command == "void-slot":
             if not args.goal_id:
@@ -460,6 +471,7 @@ def handle_quota_command(
                 source=args.source,
                 reason_summary=args.reason_summary,
                 agent_id=args.agent_id,
+                operator_inbox_urgency_projector=operator_inbox_urgency_projector,
             )
         else:
             payload = build_quota_plan(status_payload, mode=args.quota_command)

--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -27,6 +27,7 @@ from ..quota import spend_quota_slot
 from ..state_refresh import refresh_state_run
 from ..status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, collect_status
 from ..todos import update_goal_todo
+from .lark_inbox import build_lark_operator_inbox_urgency_projector
 
 
 PrintPayload = Callable[
@@ -279,6 +280,11 @@ def handle_turn_command(
             registry_path=registry_path,
             runtime_root_override=runtime_root_arg,
         )
+        operator_inbox_urgency_projector = (
+            build_lark_operator_inbox_urgency_projector(
+                runtime_root_arg=runtime_root,
+            )
+        )
         status_payload = collect_status(
             registry_path=registry_path,
             runtime_root_override=runtime_root_arg,
@@ -301,6 +307,7 @@ def handle_turn_command(
             runtime_root=runtime_root,
             route_source="loopx_turn_plan",
             scheduler_execution_context=scheduler_context,
+            operator_inbox_urgency_projector=operator_inbox_urgency_projector,
         )
         resume_identity = {
             "goal_id": args.resume_goal_id,
@@ -459,6 +466,7 @@ def handle_turn_command(
                     source="adapter",
                     agent_id=args.agent_id,
                     available_capabilities=args.available_capabilities,
+                    operator_inbox_urgency_projector=operator_inbox_urgency_projector,
                 )
 
             def scheduler(_spend_payload: dict[str, object]) -> dict[str, object]:
@@ -478,6 +486,7 @@ def handle_turn_command(
                     runtime_root=runtime_root,
                     route_source="loopx_turn_run_once",
                     scheduler_execution_context=turn_scheduler_context,
+                    operator_inbox_urgency_projector=operator_inbox_urgency_projector,
                 )
                 hint = latest.get("scheduler_hint") if isinstance(latest.get("scheduler_hint"), dict) else {}
                 phase = hint.get("execution_phase")

--- a/loopx/control_plane/quota/goal_boundary.py
+++ b/loopx/control_plane/quota/goal_boundary.py
@@ -16,7 +16,6 @@ from ..todos.contract import (
     normalize_required_capabilities,
     normalize_required_write_scopes,
 )
-from ..work_items.operator_inbox import LARK_OPERATOR_INBOX_SOURCE_CONTRACT
 
 
 def quota_execution_profile_summary(value: Any) -> dict[str, Any] | None:
@@ -174,11 +173,6 @@ def goal_boundary(
                 urgency = operator_inbox_urgency_projector(
                     project=project,
                     config_path=config_path,
-                    source_contract=LARK_OPERATOR_INBOX_SOURCE_CONTRACT,
-                )
-                urgency["schema_version"] = "lark_event_inbox_urgency_v0"
-                urgency["reply_to_bot_count"] = urgency.pop(
-                    "reply_to_operator_count", 0
                 )
                 inbox_capability["urgency"] = urgency
             except (OSError, ValueError):

--- a/loopx/control_plane/quota/live_decision.py
+++ b/loopx/control_plane/quota/live_decision.py
@@ -68,6 +68,7 @@ def build_live_quota_should_run_decision(
     host_observation_resolver: HostObservationResolver | None = None,
     route_source: str = "quota_cli_invocation",
     scheduler_execution_context: Mapping[str, Any] | SchedulerExecutionContextResolution | None = None,
+    operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Build one live CLI decision while keeping host observation injectable."""
 
@@ -94,6 +95,7 @@ def build_live_quota_should_run_decision(
         include_scheduler_detail=include_scheduler_detail,
         codex_app_current_rrule=observed_rrule,
         scheduler_execution_context=resolved_context,
+        operator_inbox_urgency_projector=operator_inbox_urgency_projector,
     )
     bind_scheduler_followup_cli_routes(
         payload,

--- a/loopx/control_plane/work_items/operator_inbox.py
+++ b/loopx/control_plane/work_items/operator_inbox.py
@@ -31,21 +31,6 @@ class OperatorInboxSourceContract:
     destination_pattern: re.Pattern[str]
 
 
-LARK_OPERATOR_INBOX_SOURCE_CONTRACT = OperatorInboxSourceContract(
-    config_schema_version="lark_event_inbox_config_v0",
-    event_schema_version="lark_event_inbox_event_v0",
-    processed_schema_version="lark_event_inbox_processed_v0",
-    message_id_pattern=re.compile(r"om_[A-Za-z0-9_-]+"),
-    event_id_pattern=re.compile(r"[A-Za-z0-9:_-]{1,200}"),
-    sender_profile_pattern=re.compile(r"[A-Za-z0-9._-]{1,100}"),
-    required_sender_identity="bot",
-    reply_flag_field="reply_to_bot",
-    operator_display_name_field="bot_display_name",
-    destination_field="chat_id",
-    destination_pattern=re.compile(r"oc_[A-Za-z0-9_-]+"),
-)
-
-
 def _safe_inbox_path(project: Path, raw_path: object) -> Path:
     relative = PurePosixPath(str(raw_path or "").strip().replace("\\", "/"))
     if (

--- a/loopx/extensions/lark/event_inbox.py
+++ b/loopx/extensions/lark/event_inbox.py
@@ -7,7 +7,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Mapping, Sequence
 
 from ...control_plane.work_items.operator_inbox import (
-    LARK_OPERATOR_INBOX_SOURCE_CONTRACT,
+    OperatorInboxSourceContract,
     operator_inbox_attention_kind,
     project_operator_inbox_urgency,
 )
@@ -21,6 +21,19 @@ MESSAGE_ID_PATTERN = re.compile(r"om_[A-Za-z0-9_-]+")
 EVENT_ID_PATTERN = re.compile(r"[A-Za-z0-9:_-]{1,200}")
 SAFE_PROFILE_PATTERN = re.compile(r"[A-Za-z0-9._-]{1,100}")
 CHAT_ID_PATTERN = re.compile(r"oc_[A-Za-z0-9_-]+")
+LARK_OPERATOR_INBOX_SOURCE_CONTRACT = OperatorInboxSourceContract(
+    config_schema_version=CONFIG_SCHEMA_VERSION,
+    event_schema_version=EVENT_SCHEMA_VERSION,
+    processed_schema_version=PROCESSED_SCHEMA_VERSION,
+    message_id_pattern=MESSAGE_ID_PATTERN,
+    event_id_pattern=EVENT_ID_PATTERN,
+    sender_profile_pattern=SAFE_PROFILE_PATTERN,
+    required_sender_identity="bot",
+    reply_flag_field="reply_to_bot",
+    operator_display_name_field="bot_display_name",
+    destination_field="chat_id",
+    destination_pattern=CHAT_ID_PATTERN,
+)
 
 
 def _safe_inbox_path(project: str | Path, raw_path: str) -> Path:
@@ -192,7 +205,7 @@ def project_lark_event_inbox_urgency(
     config_path: str | Path,
     now: datetime | None = None,
 ) -> dict[str, Any]:
-    """Compatibility delegate for the provider-neutral urgency projection."""
+    """Bind the generic urgency projector to the extension-owned Lark contract."""
 
     load_lark_event_inbox_config(project=project, config_path=config_path)
     urgency = project_operator_inbox_urgency(

--- a/loopx/extensions/lark/extension.toml
+++ b/loopx/extensions/lark/extension.toml
@@ -1,6 +1,6 @@
 schema_version = "loopx_extension_manifest_v0"
 id = "loopx-lark"
-version = "1.2.0"
+version = "1.3.0"
 requires_loopx_api = ">=1,<2"
 permissions = [
   "lark.inbox.read",

--- a/loopx/extensions/lark/provider.py
+++ b/loopx/extensions/lark/provider.py
@@ -17,6 +17,7 @@ REQUIRED_EXPORTS = {
         "acknowledge_lark_event_inbox",
         "ingest_lark_event_inbox",
         "inspect_lark_event_inbox",
+        "project_lark_event_inbox_urgency",
     ),
     "loopx.extensions.lark.inbox_reply": ("reply_lark_event_inbox",),
     "loopx.extensions.lark.reviewer_notification": (

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -93,7 +93,6 @@ from .control_plane.quota.scheduler_ack import (
 from .control_plane.quota.selected_todo_projection import (
     selected_todo_projection as _selected_todo_projection,
 )
-from .control_plane.work_items.operator_inbox import project_operator_inbox_urgency as _project_operator_inbox_urgency
 from .capabilities.reward_memory.experiment import (
     resolve_reward_memory_experiment_from_status as _resolve_reward_memory_experiment_from_status,
 )
@@ -1207,7 +1206,7 @@ def build_quota_should_run(
     agent_id: str | None = None,
     available_capabilities: Any = None,
     include_scheduler_detail: bool = False, codex_app_current_rrule: Any = None,
-    scheduler_execution_context: Mapping[str, Any] | SchedulerExecutionContextResolution | None = None,
+    scheduler_execution_context: Mapping[str, Any] | SchedulerExecutionContextResolution | None = None, operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     safe_goal_id = str(goal_id or "").strip()
     resolved_scheduler_context = resolve_scheduler_execution_context(
@@ -1316,8 +1315,7 @@ def build_quota_should_run(
             registry_path=(
                 Path(boundary_registry_value) if boundary_registry_value else None
             ),
-            operator_inbox_urgency_projector=_project_operator_inbox_urgency,
-            reward_memory_experiment_status=reward_memory_experiment_status,
+            operator_inbox_urgency_projector=operator_inbox_urgency_projector, reward_memory_experiment_status=reward_memory_experiment_status,
         )
         workspace_guard = None
         automation_prompt_upgrade = _automation_prompt_upgrade(
@@ -2220,14 +2218,14 @@ def build_quota_slot_preview(
     goal_id: str,
     slots: int = 1,
     agent_id: str | None = None,
-    available_capabilities: Any = None,
+    available_capabilities: Any = None, operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     safe_goal_id = str(goal_id or "").strip()
     before = build_quota_should_run(
         status_payload,
         goal_id=safe_goal_id,
         agent_id=agent_id,
-        available_capabilities=available_capabilities,
+        available_capabilities=available_capabilities, operator_inbox_urgency_projector=operator_inbox_urgency_projector,
     )
     return build_quota_slot_preview_for_decision(
         status_payload,
@@ -2239,7 +2237,7 @@ def build_quota_slot_preview(
             after_status,
             goal_id=safe_goal_id,
             agent_id=agent_id,
-            available_capabilities=available_capabilities,
+            available_capabilities=available_capabilities, operator_inbox_urgency_projector=operator_inbox_urgency_projector,
         ),
         quota_status_builder=quota_status,
         self_repair_spend_actions=SELF_REPAIR_SPEND_ACTIONS,
@@ -2278,7 +2276,7 @@ def record_quota_scheduler_ack(
     reset_token: str | None = None,
     identity_signature: str | None = None,
     reason_summary: str | None = None, use_current_hint: bool = False, host_match_observed: bool = False,
-    scheduler_execution_context: Mapping[str, Any] | SchedulerExecutionContextResolution | None = None,
+    scheduler_execution_context: Mapping[str, Any] | SchedulerExecutionContextResolution | None = None, operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     safe_goal_id = _validate_goal_id_path_segment(str(goal_id or ""))
     safe_agent_id = normalize_todo_claimed_by(agent_id)
@@ -2287,7 +2285,7 @@ def record_quota_scheduler_ack(
         goal_id=safe_goal_id,
         agent_id=safe_agent_id,
         available_capabilities=available_capabilities, codex_app_current_rrule=applied_rrule if host_match_observed else None,
-        scheduler_execution_context=scheduler_execution_context,
+        scheduler_execution_context=scheduler_execution_context, operator_inbox_urgency_projector=operator_inbox_urgency_projector,
     )
     raw_runtime_root = status_payload.get("runtime_root")
     if not raw_runtime_root:
@@ -2340,14 +2338,14 @@ def record_quota_monitor_poll(
     next_due_at: str | None = None,
     next_agent_todo: str | None = None,
     next_user_todo: str | None = None,
-    next_claimed_by: str | None = None, scheduler_execution_context: Mapping[str, Any] | SchedulerExecutionContextResolution | None = None,
+    next_claimed_by: str | None = None, scheduler_execution_context: Mapping[str, Any] | SchedulerExecutionContextResolution | None = None, operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     safe_goal_id = _validate_goal_id_path_segment(str(goal_id or ""))
     before = build_quota_should_run(
         status_payload,
         goal_id=safe_goal_id,
         agent_id=agent_id,
-        available_capabilities=available_capabilities, scheduler_execution_context=scheduler_execution_context,
+        available_capabilities=available_capabilities, scheduler_execution_context=scheduler_execution_context, operator_inbox_urgency_projector=operator_inbox_urgency_projector,
     )
     return record_quota_monitor_poll_for_decision(
         before,
@@ -2357,7 +2355,7 @@ def record_quota_monitor_poll(
             after_status,
             goal_id=safe_goal_id,
             agent_id=agent_id,
-            available_capabilities=available_capabilities, scheduler_execution_context=scheduler_execution_context,
+            available_capabilities=available_capabilities, scheduler_execution_context=scheduler_execution_context, operator_inbox_urgency_projector=operator_inbox_urgency_projector,
         ),
         registry_path=registry_path,
         execute=execute,
@@ -2381,10 +2379,10 @@ def build_quota_slot_void_preview(
     *,
     goal_id: str,
     voided_run_generated_at: str,
-    agent_id: str | None = None,
+    agent_id: str | None = None, operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     safe_goal_id = _validate_goal_id_path_segment(str(goal_id or ""))
-    before = build_quota_should_run(status_payload, goal_id=safe_goal_id, agent_id=agent_id)
+    before = build_quota_should_run(status_payload, goal_id=safe_goal_id, agent_id=agent_id, operator_inbox_urgency_projector=operator_inbox_urgency_projector)
     return build_quota_slot_void_preview_for_decision(
         status_payload,
         goal_id=safe_goal_id,
@@ -2401,14 +2399,14 @@ def void_quota_slot(
     execute: bool = False,
     source: str = DEFAULT_SLOT_SPEND_SOURCE,
     reason_summary: str | None = None,
-    agent_id: str | None = None,
+    agent_id: str | None = None, operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     safe_goal_id = _validate_goal_id_path_segment(str(goal_id or ""))
     preview = build_quota_slot_void_preview(
         status_payload,
         goal_id=safe_goal_id,
         voided_run_generated_at=voided_run_generated_at,
-        agent_id=agent_id,
+        agent_id=agent_id, operator_inbox_urgency_projector=operator_inbox_urgency_projector,
     )
     if not preview.get("ok"):
         return preview
@@ -2431,7 +2429,7 @@ def spend_quota_slot(
     execute: bool = False,
     source: str = DEFAULT_SLOT_SPEND_SOURCE,
     agent_id: str | None = None,
-    available_capabilities: Any = None,
+    available_capabilities: Any = None, operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     safe_goal_id = _validate_goal_id_path_segment(str(goal_id or ""))
     preview = build_quota_slot_preview(
@@ -2439,7 +2437,7 @@ def spend_quota_slot(
         goal_id=safe_goal_id,
         slots=slots,
         agent_id=agent_id,
-        available_capabilities=available_capabilities,
+        available_capabilities=available_capabilities, operator_inbox_urgency_projector=operator_inbox_urgency_projector,
     )
     if not preview.get("ok"):
         return preview

--- a/tests/architecture/test_control_plane_import_boundaries.py
+++ b/tests/architecture/test_control_plane_import_boundaries.py
@@ -9,6 +9,10 @@ PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "loopx"
 CONTROL_PLANE_ROOT = PACKAGE_ROOT / "control_plane"
 STATUS_MODULE = PACKAGE_ROOT / "status.py"
 QUOTA_MODULE = PACKAGE_ROOT / "quota.py"
+GOAL_BOUNDARY_MODULE = CONTROL_PLANE_ROOT / "quota" / "goal_boundary.py"
+OPERATOR_INBOX_MODULE = CONTROL_PLANE_ROOT / "work_items" / "operator_inbox.py"
+QUOTA_CLI_MODULE = PACKAGE_ROOT / "cli_commands" / "quota.py"
+TURN_CLI_MODULE = PACKAGE_ROOT / "cli_commands" / "turn.py"
 LARK_INBOX_CLI_MODULE = PACKAGE_ROOT / "cli_commands" / "lark_inbox.py"
 ISSUE_FIX_REVIEWER_CLI_MODULE = (
     PACKAGE_ROOT / "capabilities" / "issue_fix" / "reviewer_cli.py"
@@ -109,11 +113,29 @@ def test_status_outward_dependency_debt_only_shrinks() -> None:
     )
 
 
-def test_quota_operator_inbox_dependency_points_inward() -> None:
-    imports = _resolved_imports(QUOTA_MODULE)
+def test_quota_receives_lark_urgency_only_through_cli_composition() -> None:
+    for module in (QUOTA_MODULE, GOAL_BOUNDARY_MODULE):
+        imports = _resolved_imports(module)
+        assert not any(
+            dependency == "loopx.extensions.lark"
+            or dependency.startswith("loopx.extensions.lark.")
+            for dependency in imports
+        )
 
-    assert "loopx.capabilities.lark.event_inbox" not in imports
-    assert "loopx.control_plane.work_items.operator_inbox" in imports
+    assert "loopx.cli_commands.lark_inbox" in _resolved_imports(QUOTA_CLI_MODULE)
+    assert "loopx.cli_commands.lark_inbox" in _resolved_imports(TURN_CLI_MODULE)
+
+
+def test_lark_operator_inbox_contract_is_extension_owned() -> None:
+    core_source = OPERATOR_INBOX_MODULE.read_text(encoding="utf-8")
+    extension_source = (LARK_EXTENSION_ROOT / "event_inbox.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "LARK_OPERATOR_INBOX_SOURCE_CONTRACT" not in core_source
+    assert "lark_event_inbox_config_v0" not in core_source
+    assert "LARK_OPERATOR_INBOX_SOURCE_CONTRACT" in extension_source
+    assert "OperatorInboxSourceContract" in extension_source
 
 
 def test_lark_inbox_provider_is_owned_by_the_extension_layer() -> None:

--- a/tests/extensions/test_lark_urgency_composition.py
+++ b/tests/extensions/test_lark_urgency_composition.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from loopx.cli_commands import lark_inbox
+from loopx.control_plane.quota.goal_boundary import goal_boundary
+
+
+def _goal(project: Path) -> dict[str, object]:
+    return {
+        "id": "lark-urgency-fixture",
+        "repo": str(project),
+        "control_plane": {
+            "lark_event_inbox": {
+                "enabled": True,
+                "config_path": ".loopx/config/lark/event-inbox.json",
+            }
+        },
+    }
+
+
+def test_lark_urgency_projection_checks_activation_before_private_config(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    events: list[str] = []
+
+    def resolve(command: str, *, runtime_root_arg: str | None) -> dict[str, object]:
+        events.append(f"activate:{command}:{runtime_root_arg}")
+        return {"enabled": True}
+
+    def project(**_kwargs: object) -> dict[str, object]:
+        events.append("project")
+        return {"schema_version": "lark_event_inbox_urgency_v0"}
+
+    monkeypatch.setattr(lark_inbox, "_resolve_lark_activation", resolve)
+    monkeypatch.setattr(lark_inbox, "project_lark_event_inbox_urgency", project)
+
+    projector = lark_inbox.build_lark_operator_inbox_urgency_projector(
+        runtime_root_arg=tmp_path / "runtime"
+    )
+    result = projector(project=tmp_path, config_path="private.json")
+
+    assert result["schema_version"] == "lark_event_inbox_urgency_v0"
+    assert events == [f"activate:drain:{tmp_path / 'runtime'}", "project"]
+
+
+def test_disabled_lark_extension_cannot_schedule_from_private_config(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    projected = False
+
+    def disabled(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise ValueError("extension `loopx-lark` is disabled")
+
+    def project(**_kwargs: object) -> dict[str, object]:
+        nonlocal projected
+        projected = True
+        return {}
+
+    monkeypatch.setattr(lark_inbox, "_resolve_lark_activation", disabled)
+    monkeypatch.setattr(lark_inbox, "project_lark_event_inbox_urgency", project)
+
+    boundary = goal_boundary(
+        _goal(tmp_path),
+        operator_inbox_urgency_projector=(
+            lark_inbox.build_lark_operator_inbox_urgency_projector(
+                runtime_root_arg=tmp_path / "runtime"
+            )
+        ),
+    )
+    urgency = boundary["capabilities"]["lark_event_inbox"]["urgency"]
+
+    assert urgency["projection_status"] == "unavailable"
+    assert urgency["local_private_content_returned"] is False
+    assert projected is False


### PR DESCRIPTION
## Motivation

Finish the Lark extension ownership migration: quota previously read the Lark profile/chat config through a core-owned source contract even when `loopx-lark` was not active. That let provider-private configuration influence scheduling outside the extension lifecycle.

## Changes

- move the concrete Lark inbox source contract into `loopx.extensions.lark`
- inject an activation-gated urgency projector at quota/Turn CLI composition
- require `lark.inbox.read` before opening local-private profile/chat config
- preserve quota, scheduler ACK, monitor, spend, void, and Turn recomputation parity without new agent-facing flags
- bump the bundled Lark provider to 1.3.0 and validate the projector in provider doctor
- add architecture, activation lifecycle, parity, and disabled-extension regression coverage

## Validation

- `pytest -q`: 779 passed, 2 skipped
- `loopx canary premerge --from-git-diff`: 18/18 passed, no warnings or manual holds
- focused Lark activation, inbox priority, inbox lifecycle, collector lifecycle, quota, scheduler, and Turn checks passed
- public/private boundary scan clean for all 16 changed files

No credentials, private state, local paths, or raw provider payloads are included.