### PR TITLE
refactor(scheduler): extract state transition rules

### DIFF
--- a/examples/canary/catalog-planner-smoke.py
+++ b/examples/canary/catalog-planner-smoke.py
@@ -117,6 +117,7 @@ def assert_scheduler_ack_route_profile_keeps_independent_checks() -> None:
     assert [check["command"] for check in profile["checks"]] == [
         "python3 examples/control_plane/quota-scheduler-state-ack-smoke.py",
         "python3 examples/control_plane/quota-scheduler-registry-route-smoke.py",
+        "python3 examples/control_plane/monitor-scheduler-contract-smoke.py",
     ], profile
 
 

--- a/examples/control_plane/quota-scheduler-state-ack-smoke.py
+++ b/examples/control_plane/quota-scheduler-state-ack-smoke.py
@@ -1020,6 +1020,7 @@ def assert_cli_scheduler_failure_circuit_breaker() -> None:
             target_rrule = first_app["recommended_rrule"]
             failure_hint = first_app["failure_hint"]
             assert first_app["stateful_backoff"]["apply_needed"] is True, first
+            assert first_app["no_spend_for_cadence_change"] is True, first
             assert failure_hint["route_binding"]["registry_bound"] is True, first
 
             failure = run_cli(
@@ -1053,6 +1054,7 @@ def assert_cli_scheduler_failure_circuit_breaker() -> None:
             suppressed_app = suppressed["scheduler_hint"]["codex_app"]
             assert suppressed_app["stateful_backoff"]["apply_needed"] is False, suppressed
             assert suppressed_app["stateful_backoff"]["ack_needed"] is False, suppressed
+            assert suppressed_app["no_spend_for_cadence_change"] is True, suppressed
             assert suppressed_app["stateful_backoff"]["state_status"] == (
                 "host_update_failure_suppressed"
             ), suppressed

--- a/loopx/canary/qualification_profiles.py
+++ b/loopx/canary/qualification_profiles.py
@@ -155,9 +155,11 @@ CONTROL_PLANE_QUALIFICATION_PROFILES: tuple[dict[str, Any], ...] = (
             "loopx/control_plane/scheduler/ack.py",
             "loopx/control_plane/scheduler/scheduler_hint.py",
             "loopx/control_plane/scheduler/state.py",
+            "loopx/control_plane/scheduler/state_transition_rules.py",
             "loopx/cli_commands/quota",
             "quota-scheduler-state-ack-smoke.py",
             "quota-scheduler-registry-route-smoke.py",
+            "monitor-scheduler-contract-smoke.py",
         ),
         "checks": [
             {
@@ -169,6 +171,11 @@ CONTROL_PLANE_QUALIFICATION_PROFILES: tuple[dict[str, Any], ...] = (
                 "command": "python3 examples/control_plane/quota-scheduler-registry-route-smoke.py",
                 "tier": "default",
                 "reason": "guards ACK writes on the registry/runtime route that emitted the hint",
+            },
+            {
+                "command": "python3 examples/control_plane/monitor-scheduler-contract-smoke.py",
+                "tier": "default",
+                "reason": "guards multi-monitor cadence selection and current-agent lane independence",
             },
         ],
     },

--- a/loopx/canary/quality_surface_catalog.py
+++ b/loopx/canary/quality_surface_catalog.py
@@ -95,7 +95,9 @@ QUALITY_SURFACE_CATALOG: tuple[dict[str, Any], ...] = (
         "owner_paths": [
             "loopx/control_plane/quota/live_decision.py",
             "loopx/control_plane/scheduler/ack.py",
+            "loopx/control_plane/scheduler/scheduler_hint.py",
             "loopx/control_plane/scheduler/state.py",
+            "loopx/control_plane/scheduler/state_transition_rules.py",
         ],
         "semantic_oracle": {
             "source_kind": "specification",
@@ -111,10 +113,13 @@ QUALITY_SURFACE_CATALOG: tuple[dict[str, Any], ...] = (
                 "tests/test_loopx_turn_driver.py",
                 "tests/control_plane/test_scheduler_ack_decision_table.py",
                 "tests/control_plane/test_scheduler_backoff_convergence.py",
+                "tests/control_plane/test_scheduler_host_failure_cache.py",
+                "tests/control_plane/test_scheduler_state_transition_rules.py",
             ),
             "durable_smoke": _covered(
                 "examples/control_plane/quota-scheduler-state-ack-smoke.py",
                 "examples/control_plane/quota-scheduler-registry-route-smoke.py",
+                "examples/control_plane/monitor-scheduler-contract-smoke.py",
             ),
             "catalog_canary": _covered("scheduler-ack-route"),
             "host_upgrade": _not_applicable(

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -28,6 +28,10 @@ from .state import (
     rrule_for_minutes,
     scheduler_rrule_interval_minutes,
 )
+from .state_transition_rules import (
+    decide_scheduler_cadence_transition,
+    decide_scheduler_host_transition,
+)
 from .time import parse_scheduler_timestamp
 
 
@@ -763,8 +767,6 @@ def build_scheduler_hint(
             "final_quota_replan_check": final_replan_check,
             "no_spend_for_stop": True,
         }
-        current_index = 0
-        state_status = "missing"
         scheduler_state = (
             codex_app_scheduler_state
             if isinstance(codex_app_scheduler_state, dict)
@@ -778,51 +780,20 @@ def build_scheduler_hint(
             ),
             reference_time=scheduler_now,
         )
-        same_identity = False
-        if scheduler_state:
-            same_identity = (
-                scheduler_state.get("reset_token") == reset_token
-                and scheduler_state.get("identity_signature") == identity_signature
-            )
-            if same_identity:
-                state_status = "same_identity"
-                try:
-                    applied_index = int(scheduler_state.get("progression_index"))
-                except (TypeError, ValueError):
-                    applied_index = -1
-                applied_target_rrule = (
-                    rrule_for_minutes(codex_cadence_progression[applied_index])
-                    if 0 <= applied_index < len(codex_cadence_progression)
-                    else ""
-                )
-                current_cadence_acknowledged = (
-                    normalize_scheduler_rrule(
-                        scheduler_state.get("last_applied_rrule")
-                    )
-                    == applied_target_rrule
-                )
-                if all_host_update_failures and not current_cadence_acknowledged:
-                    # A failed current target has not settled, so advancing would
-                    # skip the cadence that the host never applied. Failures for
-                    # other targets do not invalidate a successful current ACK.
-                    next_index = applied_index
-                elif not advance_same_identity:
-                    next_index = 0
-                elif _scheduler_progression_interval_elapsed(
-                    scheduler_state,
-                    current_time=scheduler_now,
-                ):
-                    next_index = applied_index + 1
-                else:
-                    # An ACK settles the current target. A same-turn or early
-                    # reconciliation must verify convergence, not manufacture
-                    # the next backoff target before that cadence has elapsed.
-                    next_index = applied_index
-                current_index = min(
-                    max(next_index, 0), len(codex_cadence_progression) - 1
-                )
-            else:
-                state_status = "reset_required"
+        cadence_decision = decide_scheduler_cadence_transition(
+            codex_cadence_progression,
+            scheduler_state=scheduler_state,
+            reset_token=reset_token,
+            identity_signature=identity_signature,
+            advance_same_identity=advance_same_identity,
+            applied_interval_elapsed=_scheduler_progression_interval_elapsed(
+                scheduler_state,
+                current_time=scheduler_now,
+            ),
+            has_host_update_failures=bool(all_host_update_failures),
+        )
+        current_index = cadence_decision.current_index
+        state_status = cadence_decision.state_status
         current_interval = codex_cadence_progression[current_index]
         current_rrule = rrule_for_minutes(current_interval)
         last_applied_rrule = str(scheduler_state.get("last_applied_rrule") or "").strip()
@@ -853,33 +824,19 @@ def build_scheduler_hint(
                 last_applied_rrule=effective_host_rrule,
                 current_rrule=current_rrule,
             )
-        current_target_has_failure = any(
-            normalize_scheduler_rrule(failure.get("target_rrule"))
-            == current_rrule
-            for failure in all_host_update_failures
+        host_decision = decide_scheduler_host_transition(
+            state_status=state_status,
+            observed_host_rrule=observed_host_rrule,
+            effective_host_rrule=effective_host_rrule,
+            current_rrule=current_rrule,
+            current_rrule_already_applied=current_rrule_already_applied,
+            all_host_update_failures=all_host_update_failures,
+            recorded_host_failure=recorded_host_failure,
         )
-        host_match_ack_needed = (
-            bool(observed_host_rrule)
-            and current_rrule_already_applied
-            and (state_status != "same_identity" or current_target_has_failure)
-        )
-        base_apply_needed = (
-            not current_rrule_already_applied
-            or (state_status != "same_identity" and not host_match_ack_needed)
-        )
-        failed_target_rrule = normalize_scheduler_rrule(
-            (recorded_host_failure or {}).get("target_rrule")
-        )
-        failed_observed_host_rrule = normalize_scheduler_rrule(
-            (recorded_host_failure or {}).get("observed_host_rrule")
-        )
-        host_failure_suppressed = bool(
-            base_apply_needed
-            and failed_target_rrule == current_rrule
-            and failed_observed_host_rrule == effective_host_rrule
-        )
-        apply_needed = base_apply_needed and not host_failure_suppressed
-        ack_needed = apply_needed or host_match_ack_needed
+        apply_needed = host_decision.apply_needed
+        ack_needed = host_decision.ack_needed
+        host_match_ack_needed = host_decision.host_match_ack_needed
+        host_failure_suppressed = host_decision.host_failure_suppressed
         if host_failure_suppressed:
             state_status = "host_update_failure_suppressed"
         stateful_backoff_detail = {

--- a/loopx/control_plane/scheduler/state_transition_rules.py
+++ b/loopx/control_plane/scheduler/state_transition_rules.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from collections.abc import Collection, Mapping, Sequence
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from .state import normalize_scheduler_rrule, rrule_for_minutes
+
+
+class SchedulerCadenceTransition(str, Enum):
+    INITIAL = "initial"
+    IDENTITY_RESET = "identity_reset"
+    RETRY_UNACKNOWLEDGED_FAILURE = "retry_unacknowledged_failure"
+    HOLD_ACTIVE_INITIAL = "hold_active_initial"
+    ADVANCE_AFTER_INTERVAL = "advance_after_interval"
+    HOLD_UNTIL_INTERVAL = "hold_until_interval"
+
+
+@dataclass(frozen=True)
+class SchedulerCadenceDecision:
+    current_index: int
+    state_status: str
+    transition: SchedulerCadenceTransition
+    current_cadence_acknowledged: bool
+
+
+def decide_scheduler_cadence_transition(
+    progression_minutes: Sequence[int],
+    *,
+    scheduler_state: Mapping[str, Any],
+    reset_token: str,
+    identity_signature: str,
+    advance_same_identity: bool,
+    applied_interval_elapsed: bool,
+    has_host_update_failures: bool,
+) -> SchedulerCadenceDecision:
+    """Choose the cadence index without rendering a scheduler hint."""
+
+    if not progression_minutes:
+        raise ValueError("scheduler cadence progression must not be empty")
+    if not scheduler_state:
+        return SchedulerCadenceDecision(
+            current_index=0,
+            state_status="missing",
+            transition=SchedulerCadenceTransition.INITIAL,
+            current_cadence_acknowledged=False,
+        )
+
+    same_identity = (
+        scheduler_state.get("reset_token") == reset_token
+        and scheduler_state.get("identity_signature") == identity_signature
+    )
+    if not same_identity:
+        return SchedulerCadenceDecision(
+            current_index=0,
+            state_status="reset_required",
+            transition=SchedulerCadenceTransition.IDENTITY_RESET,
+            current_cadence_acknowledged=False,
+        )
+
+    try:
+        applied_index = int(scheduler_state.get("progression_index"))
+    except (TypeError, ValueError):
+        applied_index = -1
+    applied_target_rrule = (
+        rrule_for_minutes(progression_minutes[applied_index])
+        if 0 <= applied_index < len(progression_minutes)
+        else ""
+    )
+    current_cadence_acknowledged = (
+        normalize_scheduler_rrule(scheduler_state.get("last_applied_rrule"))
+        == applied_target_rrule
+    )
+
+    if has_host_update_failures and not current_cadence_acknowledged:
+        next_index = applied_index
+        transition = SchedulerCadenceTransition.RETRY_UNACKNOWLEDGED_FAILURE
+    elif not advance_same_identity:
+        next_index = 0
+        transition = SchedulerCadenceTransition.HOLD_ACTIVE_INITIAL
+    elif applied_interval_elapsed:
+        next_index = applied_index + 1
+        transition = SchedulerCadenceTransition.ADVANCE_AFTER_INTERVAL
+    else:
+        next_index = applied_index
+        transition = SchedulerCadenceTransition.HOLD_UNTIL_INTERVAL
+
+    return SchedulerCadenceDecision(
+        current_index=min(max(next_index, 0), len(progression_minutes) - 1),
+        state_status="same_identity",
+        transition=transition,
+        current_cadence_acknowledged=current_cadence_acknowledged,
+    )
+
+
+class SchedulerHostTransition(str, Enum):
+    APPLY_REQUIRED = "apply_required"
+    HOST_MATCH_ACK_REQUIRED = "host_match_ack_required"
+    RECORDED_FAILURE_SUPPRESSED = "recorded_failure_suppressed"
+    SETTLED = "settled"
+
+
+@dataclass(frozen=True)
+class SchedulerHostDecision:
+    transition: SchedulerHostTransition
+    current_target_has_failure: bool
+    repeated_failed_pair: bool
+
+    @property
+    def apply_needed(self) -> bool:
+        return self.transition == SchedulerHostTransition.APPLY_REQUIRED
+
+    @property
+    def host_match_ack_needed(self) -> bool:
+        return self.transition == SchedulerHostTransition.HOST_MATCH_ACK_REQUIRED
+
+    @property
+    def host_failure_suppressed(self) -> bool:
+        return self.transition == SchedulerHostTransition.RECORDED_FAILURE_SUPPRESSED
+
+    @property
+    def ack_needed(self) -> bool:
+        return self.transition in {
+            SchedulerHostTransition.APPLY_REQUIRED,
+            SchedulerHostTransition.HOST_MATCH_ACK_REQUIRED,
+        }
+
+
+def decide_scheduler_host_transition(
+    *,
+    state_status: str,
+    observed_host_rrule: str,
+    effective_host_rrule: str,
+    current_rrule: str,
+    current_rrule_already_applied: bool,
+    all_host_update_failures: Collection[Mapping[str, Any]],
+    recorded_host_failure: Mapping[str, Any] | None,
+) -> SchedulerHostDecision:
+    """Classify the host action from normalized scheduler facts."""
+
+    current_target_has_failure = any(
+        normalize_scheduler_rrule(failure.get("target_rrule")) == current_rrule
+        for failure in all_host_update_failures
+    )
+    failed_target_rrule = normalize_scheduler_rrule(
+        (recorded_host_failure or {}).get("target_rrule")
+    )
+    failed_observed_host_rrule = normalize_scheduler_rrule(
+        (recorded_host_failure or {}).get("observed_host_rrule")
+    )
+    repeated_failed_pair = bool(
+        failed_target_rrule == current_rrule
+        and failed_observed_host_rrule == effective_host_rrule
+    )
+
+    if (
+        observed_host_rrule
+        and current_rrule_already_applied
+        and (state_status != "same_identity" or current_target_has_failure)
+    ):
+        transition = SchedulerHostTransition.HOST_MATCH_ACK_REQUIRED
+    elif current_rrule_already_applied and state_status == "same_identity":
+        transition = SchedulerHostTransition.SETTLED
+    elif repeated_failed_pair:
+        transition = SchedulerHostTransition.RECORDED_FAILURE_SUPPRESSED
+    else:
+        transition = SchedulerHostTransition.APPLY_REQUIRED
+
+    return SchedulerHostDecision(
+        transition=transition,
+        current_target_has_failure=current_target_has_failure,
+        repeated_failed_pair=repeated_failed_pair,
+    )

--- a/tests/control_plane/test_scheduler_state_transition_rules.py
+++ b/tests/control_plane/test_scheduler_state_transition_rules.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import pytest
+
+from loopx.control_plane.scheduler.state import rrule_for_minutes
+from loopx.control_plane.scheduler.state_transition_rules import (
+    SchedulerCadenceTransition,
+    SchedulerHostTransition,
+    decide_scheduler_cadence_transition,
+    decide_scheduler_host_transition,
+)
+
+
+RESET_TOKEN = "reset-token"
+IDENTITY_SIGNATURE = "identity-signature"
+TARGET_15 = rrule_for_minutes(15)
+TARGET_30 = rrule_for_minutes(30)
+HOST_60 = rrule_for_minutes(60)
+
+
+def _scheduler_state(
+    *,
+    progression_index: object = 1,
+    last_applied_rrule: str = TARGET_30,
+    reset_token: str = RESET_TOKEN,
+    identity_signature: str = IDENTITY_SIGNATURE,
+) -> dict:
+    return {
+        "progression_index": progression_index,
+        "last_applied_rrule": last_applied_rrule,
+        "reset_token": reset_token,
+        "identity_signature": identity_signature,
+    }
+
+
+CADENCE_CASES = [
+    {
+        "id": "missing_state_starts_at_initial",
+        "state": {},
+        "expected": (0, "missing", SchedulerCadenceTransition.INITIAL, False),
+    },
+    {
+        "id": "changed_identity_resets_to_initial",
+        "state": _scheduler_state(reset_token="old-token"),
+        "expected": (
+            0,
+            "reset_required",
+            SchedulerCadenceTransition.IDENTITY_RESET,
+            False,
+        ),
+    },
+    {
+        "id": "unacknowledged_failure_retries_current_index",
+        "state": _scheduler_state(last_applied_rrule=TARGET_15),
+        "has_failures": True,
+        "expected": (
+            1,
+            "same_identity",
+            SchedulerCadenceTransition.RETRY_UNACKNOWLEDGED_FAILURE,
+            False,
+        ),
+    },
+    {
+        "id": "acknowledged_failure_can_advance_after_interval",
+        "state": _scheduler_state(),
+        "has_failures": True,
+        "expected": (
+            2,
+            "same_identity",
+            SchedulerCadenceTransition.ADVANCE_AFTER_INTERVAL,
+            True,
+        ),
+    },
+    {
+        "id": "active_work_holds_initial_cadence",
+        "state": _scheduler_state(progression_index=2, last_applied_rrule=HOST_60),
+        "advance": False,
+        "expected": (
+            0,
+            "same_identity",
+            SchedulerCadenceTransition.HOLD_ACTIVE_INITIAL,
+            True,
+        ),
+    },
+    {
+        "id": "settled_cadence_holds_until_interval_elapsed",
+        "state": _scheduler_state(),
+        "elapsed": False,
+        "expected": (
+            1,
+            "same_identity",
+            SchedulerCadenceTransition.HOLD_UNTIL_INTERVAL,
+            True,
+        ),
+    },
+    {
+        "id": "elapsed_terminal_index_stays_capped",
+        "state": _scheduler_state(progression_index=2, last_applied_rrule=HOST_60),
+        "expected": (
+            2,
+            "same_identity",
+            SchedulerCadenceTransition.ADVANCE_AFTER_INTERVAL,
+            True,
+        ),
+    },
+    {
+        "id": "invalid_failed_index_recovers_at_initial",
+        "state": _scheduler_state(
+            progression_index="invalid", last_applied_rrule=TARGET_15
+        ),
+        "has_failures": True,
+        "expected": (
+            0,
+            "same_identity",
+            SchedulerCadenceTransition.RETRY_UNACKNOWLEDGED_FAILURE,
+            False,
+        ),
+    },
+]
+
+
+@pytest.mark.parametrize(
+    "case", CADENCE_CASES, ids=[case["id"] for case in CADENCE_CASES]
+)
+def test_scheduler_cadence_transition_table(case: dict) -> None:
+    decision = decide_scheduler_cadence_transition(
+        [15, 30, 60],
+        scheduler_state=case["state"],
+        reset_token=RESET_TOKEN,
+        identity_signature=IDENTITY_SIGNATURE,
+        advance_same_identity=case.get("advance", True),
+        applied_interval_elapsed=case.get("elapsed", True),
+        has_host_update_failures=case.get("has_failures", False),
+    )
+
+    assert (
+        decision.current_index,
+        decision.state_status,
+        decision.transition,
+        decision.current_cadence_acknowledged,
+    ) == case["expected"]
+
+
+def _failure(*, target: str, host: str) -> dict:
+    return {"target_rrule": target, "observed_host_rrule": host}
+
+
+HOST_CASES = [
+    {
+        "id": "settled_same_identity",
+        "already_applied": True,
+        "expected": SchedulerHostTransition.SETTLED,
+    },
+    {
+        "id": "matching_host_repairs_identity_with_ack",
+        "state_status": "reset_required",
+        "already_applied": True,
+        "expected": SchedulerHostTransition.HOST_MATCH_ACK_REQUIRED,
+    },
+    {
+        "id": "matching_host_acks_current_target_failure",
+        "already_applied": True,
+        "failures": [_failure(target=TARGET_15, host=HOST_60)],
+        "expected": SchedulerHostTransition.HOST_MATCH_ACK_REQUIRED,
+    },
+    {
+        "id": "unrelated_failure_does_not_unsettle_matching_host",
+        "already_applied": True,
+        "failures": [_failure(target=TARGET_30, host=HOST_60)],
+        "expected": SchedulerHostTransition.SETTLED,
+    },
+    {
+        "id": "drift_requires_apply",
+        "observed": HOST_60,
+        "effective": HOST_60,
+        "expected": SchedulerHostTransition.APPLY_REQUIRED,
+    },
+    {
+        "id": "exact_failed_pair_suppresses_repeat",
+        "observed": HOST_60,
+        "effective": HOST_60,
+        "recorded": _failure(target=TARGET_15, host=HOST_60),
+        "expected": SchedulerHostTransition.RECORDED_FAILURE_SUPPRESSED,
+    },
+    {
+        "id": "different_failed_target_does_not_suppress",
+        "observed": HOST_60,
+        "effective": HOST_60,
+        "recorded": _failure(target=TARGET_30, host=HOST_60),
+        "expected": SchedulerHostTransition.APPLY_REQUIRED,
+    },
+    {
+        "id": "changed_host_invalidates_failed_pair",
+        "observed": TARGET_30,
+        "effective": TARGET_30,
+        "recorded": _failure(target=TARGET_15, host=HOST_60),
+        "expected": SchedulerHostTransition.APPLY_REQUIRED,
+    },
+    {
+        "id": "persisted_match_without_host_observation_reapplies_after_reset",
+        "state_status": "reset_required",
+        "observed": "",
+        "effective": TARGET_15,
+        "already_applied": True,
+        "expected": SchedulerHostTransition.APPLY_REQUIRED,
+    },
+]
+
+
+@pytest.mark.parametrize("case", HOST_CASES, ids=[case["id"] for case in HOST_CASES])
+def test_scheduler_host_transition_table(case: dict) -> None:
+    observed = case.get("observed", TARGET_15)
+    decision = decide_scheduler_host_transition(
+        state_status=case.get("state_status", "same_identity"),
+        observed_host_rrule=observed,
+        effective_host_rrule=case.get("effective", observed),
+        current_rrule=TARGET_15,
+        current_rrule_already_applied=case.get("already_applied", False),
+        all_host_update_failures=case.get("failures", []),
+        recorded_host_failure=case.get("recorded"),
+    )
+
+    assert decision.transition == case["expected"]
+    assert decision.apply_needed is (
+        decision.transition == SchedulerHostTransition.APPLY_REQUIRED
+    )
+    assert decision.ack_needed is (
+        decision.transition
+        in {
+            SchedulerHostTransition.APPLY_REQUIRED,
+            SchedulerHostTransition.HOST_MATCH_ACK_REQUIRED,
+        }
+    )
+
+
+def test_unrelated_failure_order_does_not_change_host_transition() -> None:
+    unrelated = [
+        _failure(target=TARGET_30, host=HOST_60),
+        _failure(target=HOST_60, host=TARGET_30),
+    ]
+
+    transitions = {
+        decide_scheduler_host_transition(
+            state_status="same_identity",
+            observed_host_rrule=TARGET_15,
+            effective_host_rrule=TARGET_15,
+            current_rrule=TARGET_15,
+            current_rrule_already_applied=True,
+            all_host_update_failures=failures,
+            recorded_host_failure=failures[-1],
+        ).transition
+        for failures in (unrelated, list(reversed(unrelated)))
+    }
+
+    assert transitions == {SchedulerHostTransition.SETTLED}


### PR DESCRIPTION
## Summary\n\n- extract scheduler cadence selection into a pure, typed transition rule seam\n- extract host apply / ACK-only / repeated-failure suppression / settled decisions from the large hint renderer\n- add decision tables for identity reset, cadence progression, failure recovery, and unrelated-failure invariance\n- route scheduler changes through the ACK/route profile plus the existing multi-monitor contract smoke\n\n## Behavioral boundary\n\nThis is a behavior-preserving refactor. It does not change RRULE values, scheduler hint field names, ACK/failure CLI arguments, quota spend policy, or host update authority.\n\n## Validation\n\n- 43 focused scheduler and quality-surface tests passed\n- quota-scheduler-state-ack smoke passed\n- quota-scheduler-registry-route smoke passed\n- monitor-scheduler-contract smoke passed\n- quality-surface-catalog smoke passed\n- catalog-planner smoke passed\n- pytest smoke-suite facade passed\n- Ruff passed on all changed Python paths\n- LoopX premerge standard gate passed: 18 selected checks, including 9 catalog canaries, 8 risk-profile smokes, and the public-boundary scan\n\n## Review focus\n\nPlease verify that the extracted rule precedence preserves these contracts:\n\n1. matching observed host state may require ACK without another automation update;\n2. an exact failed target/observed-host pair suppresses only that repeated update;\n3. unrelated failure entries do not change the current target decision;\n4. active-work cadence remains pinned to the initial interval while monitor cadence may advance only after the applied interval elapses;\n5. every cadence-only apply, ACK, or suppression path remains no-spend.\n\n## Holds and exclusions\n\n- no manual holds or skipped required checks\n- no credentials, private state, raw logs, local paths, or generated evidence included\n- not self-merged because this refactor touches runtime scheduler behavior and should receive independent review\n