### PR TITLE
fix(extensions): run bundled providers as modules

### DIFF
--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -82,9 +82,10 @@ root; it does not contain provider output or credentials.
 `disable` is reversible, but `enable` never trusts an earlier readiness result:
 it reruns the configured doctor and changes the enabled bit only after that
 probe succeeds. A successful doctor binds readiness to both the active manifest
-revision and the resolved executable identity. Missing or replaced executables
-fail closed until a new executed doctor succeeds; a failed executed doctor
-clears the stale proof without switching revisions.
+revision and the resolved runtime identity. Missing or replaced executables,
+interpreters, or Python module sources fail closed until a new executed doctor
+succeeds; a failed executed doctor clears the stale proof without switching
+revisions.
 
 An enabled implementation is resolved by capability id, versioned protocol,
 declared permission, current revision, and current doctor proof. Domain config
@@ -190,7 +191,7 @@ permissions = ["read_status", "read_todos", "external_write"]
 
 [runtime]
 protocol = "lark_kanban_provider_v0"
-entrypoint = "loopx-lark-kanban"
+python_module = "loopx.extensions.lark.provider"
 doctor_args = ["--doctor"]
 required_permissions = ["read_status", "read_todos"]
 timeout_seconds = 30
@@ -225,6 +226,15 @@ Runtime-required permissions must be a subset of the provider's declared
 permissions. Declaring either does not grant authority: existing LoopX goal
 boundaries, user gates, and external-write authorization still decide whether
 an operation may execute.
+
+Every executable runtime declares exactly one launch target. Use `entrypoint`
+for a separately installed executable such as the OpenViking provider. Use
+`python_module` for a provider shipped in the LoopX Python package. Module
+providers run as `<current-loopx-python> -m <module>` and their doctor proof is
+bound to both that interpreter and the resolved module source. This lets a
+clean source checkout and a local LoopX release activate bundled providers
+without separately installing a console script; catalog discovery remains
+declarative and does not import the module.
 
 ## Scope Boundaries
 

--- a/examples/lark-extension-activation-smoke.py
+++ b/examples/lark-extension-activation-smoke.py
@@ -173,7 +173,7 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-extension-") as raw_temp:
     assert active["extension_activation"] == {
         "schema_version": "loopx_extension_activation_v0",
         "extension_id": "loopx-lark",
-        "provider_version": "1.3.0",
+        "provider_version": "1.3.1",
         "revision": installed["revision"],
         "enabled": True,
         "doctor_verified": True,
@@ -267,7 +267,7 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-extension-") as raw_temp:
     upgraded_manifest = temp / "loopx-lark-v1.4.toml"
     upgraded_manifest.write_text(
         bundled_manifest.read_text(encoding="utf-8").replace(
-            'version = "1.3.0"',
+            'version = "1.3.1"',
             'version = "1.4.0"',
             1,
         ),

--- a/loopx/extensions/lark/extension.toml
+++ b/loopx/extensions/lark/extension.toml
@@ -1,6 +1,6 @@
 schema_version = "loopx_extension_manifest_v0"
 id = "loopx-lark"
-version = "1.3.0"
+version = "1.3.1"
 requires_loopx_api = ">=1,<2"
 permissions = [
   "lark.inbox.read",
@@ -13,7 +13,7 @@ permissions = [
 
 [runtime]
 protocol = "lark_extension_lifecycle_v0"
-entrypoint = "loopx-lark-provider"
+python_module = "loopx.extensions.lark.provider"
 args = []
 doctor_args = ["--doctor"]
 required_permissions = []

--- a/loopx/extensions/manifest.py
+++ b/loopx/extensions/manifest.py
@@ -11,6 +11,7 @@ EXTENSION_MANIFEST_SCHEMA_VERSION = "loopx_extension_manifest_v0"
 LOOPX_EXTENSION_API_VERSION = 1
 _API_CLAUSE = re.compile(r"^(>=|<=|==|>|<)?\s*(\d+)$")
 _PROTOCOL_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}_v\d+$")
+_PYTHON_MODULE_RE = re.compile(r"^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*$")
 
 
 def _required_string(record: Mapping[str, Any], key: str, *, context: str) -> str:
@@ -46,9 +47,28 @@ def _runtime_contract(
         raise ValueError(
             f"{runtime_context} protocol must be a versioned lower-snake token"
         )
-    entrypoint = _required_string(value, "entrypoint", context=runtime_context)
-    if "\x00" in entrypoint:
-        raise ValueError(f"{runtime_context} entrypoint contains an invalid byte")
+    entrypoint_raw = value.get("entrypoint")
+    python_module_raw = value.get("python_module")
+    if (entrypoint_raw is None) == (python_module_raw is None):
+        raise ValueError(
+            f"{runtime_context} requires exactly one of `entrypoint` or `python_module`"
+        )
+    entrypoint: str | None = None
+    python_module: str | None = None
+    if entrypoint_raw is not None:
+        entrypoint = _required_string(value, "entrypoint", context=runtime_context)
+        if "\x00" in entrypoint:
+            raise ValueError(f"{runtime_context} entrypoint contains an invalid byte")
+    else:
+        python_module = _required_string(
+            value,
+            "python_module",
+            context=runtime_context,
+        )
+        if not _PYTHON_MODULE_RE.fullmatch(python_module):
+            raise ValueError(
+                f"{runtime_context} python_module must be a dotted Python module name"
+            )
     args = _string_list(value, "args", context=runtime_context)
     doctor_args = _string_list(value, "doctor_args", context=runtime_context)
     required_permissions = _string_list(
@@ -66,14 +86,17 @@ def _runtime_contract(
         raise ValueError(
             f"{runtime_context} timeout_seconds must be an integer from 1 to 120"
         )
-    return {
+    runtime = {
         "protocol": protocol,
-        "entrypoint": entrypoint,
         "args": args,
         "doctor_args": doctor_args,
         "required_permissions": required_permissions,
         "timeout_seconds": timeout_seconds,
     }
+    runtime["entrypoint" if entrypoint is not None else "python_module"] = (
+        entrypoint if entrypoint is not None else python_module
+    )
+    return runtime
 
 
 def _require_compatible_loopx_api(requirement: str, *, context: str) -> None:

--- a/loopx/extensions/readiness.py
+++ b/loopx/extensions/readiness.py
@@ -1,15 +1,24 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import dataclass
 import hashlib
+import importlib.util
 import json
 from pathlib import Path
 import shutil
 import subprocess
+import sys
 from typing import Any
 
 
 EXTENSION_DOCTOR_SCHEMA_VERSION = "loopx_extension_doctor_v0"
+
+
+@dataclass(frozen=True)
+class ResolvedRuntimeEntrypoint:
+    argv_prefix: tuple[str, ...]
+    identity: str
 
 
 def extension_runtime(manifest: Mapping[str, Any]) -> Mapping[str, Any]:
@@ -19,21 +28,14 @@ def extension_runtime(manifest: Mapping[str, Any]) -> Mapping[str, Any]:
     return runtime
 
 
-def resolved_entrypoint_identity(command: str) -> tuple[Path, str] | None:
-    if "/" in command or "\\" in command:
-        path = Path(command).expanduser()
-    else:
-        resolved = shutil.which(command)
-        if resolved is None:
-            return None
-        path = Path(resolved)
+def _file_identity(path: Path, *, executable: bool) -> tuple[Path, str] | None:
     try:
         path = path.resolve(strict=True)
         stat = path.stat()
-        if not path.is_file() or stat.st_mode & 0o111 == 0:
+        if not path.is_file() or (executable and stat.st_mode & 0o111 == 0):
             return None
-        with path.open("rb") as executable:
-            content_digest = hashlib.file_digest(executable, "sha256").hexdigest()
+        with path.open("rb") as file:
+            content_digest = hashlib.file_digest(file, "sha256").hexdigest()
     except OSError:
         return None
     identity = {
@@ -48,14 +50,65 @@ def resolved_entrypoint_identity(command: str) -> tuple[Path, str] | None:
     return path, hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
 
+def resolved_entrypoint_identity(command: str) -> tuple[Path, str] | None:
+    if "/" in command or "\\" in command:
+        path = Path(command).expanduser()
+    else:
+        resolved = shutil.which(command)
+        if resolved is None:
+            return None
+        path = Path(resolved)
+    return _file_identity(path, executable=True)
+
+
+def resolve_runtime_entrypoint(
+    runtime: Mapping[str, Any],
+) -> ResolvedRuntimeEntrypoint | None:
+    python_module = runtime.get("python_module")
+    if python_module is None:
+        resolved = resolved_entrypoint_identity(str(runtime["entrypoint"]))
+        if resolved is None:
+            return None
+        return ResolvedRuntimeEntrypoint(
+            argv_prefix=(str(resolved[0]),),
+            identity=resolved[1],
+        )
+
+    interpreter_path = Path(sys.executable).expanduser()
+    interpreter = _file_identity(interpreter_path, executable=True)
+    try:
+        spec = importlib.util.find_spec(str(python_module))
+    except (ImportError, AttributeError, ValueError):
+        spec = None
+    if interpreter is None or spec is None or not spec.origin:
+        return None
+    module = _file_identity(Path(spec.origin), executable=False)
+    if module is None:
+        return None
+    identity_payload = {
+        "kind": "python_module",
+        "interpreter_identity": interpreter[1],
+        "module": str(python_module),
+        "module_identity": module[1],
+    }
+    serialized = json.dumps(
+        identity_payload,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return ResolvedRuntimeEntrypoint(
+        argv_prefix=(str(interpreter_path), "-m", str(python_module)),
+        identity=hashlib.sha256(serialized.encode("utf-8")).hexdigest(),
+    )
+
+
 def extension_doctor(
     manifest: Mapping[str, Any],
     *,
     execute: bool = False,
 ) -> dict[str, Any]:
     runtime = extension_runtime(manifest)
-    entrypoint = str(runtime["entrypoint"])
-    identity_before = resolved_entrypoint_identity(entrypoint)
+    identity_before = resolve_runtime_entrypoint(runtime)
     available = identity_before is not None
     doctor_args = [str(value) for value in runtime.get("doctor_args") or []]
     status = "ready" if available else "entrypoint_missing"
@@ -69,7 +122,7 @@ def extension_doctor(
         status = "probe_required"
     elif available:
         argv = [
-            str(identity_before[0]),
+            *identity_before.argv_prefix,
             *[str(value) for value in runtime.get("args") or []],
             *doctor_args,
         ]
@@ -90,8 +143,11 @@ def extension_doctor(
             available = False
             failure_kind = failure_kind or "probe_nonzero_exit"
         else:
-            identity_after = resolved_entrypoint_identity(entrypoint)
-            if identity_after is None or identity_after[1] != identity_before[1]:
+            identity_after = resolve_runtime_entrypoint(runtime)
+            if (
+                identity_after is None
+                or identity_after.identity != identity_before.identity
+            ):
                 status = "provider_unavailable"
                 available = False
                 failure_kind = "entrypoint_changed_during_probe"
@@ -106,7 +162,7 @@ def extension_doctor(
         "status": status,
         "available": available,
         "verified": verified,
-        "entrypoint_identity": identity_before[1] if verified else None,
+        "entrypoint_identity": identity_before.identity if verified else None,
         "failure_kind": failure_kind,
         "external_writes_performed": False,
     }

--- a/loopx/extensions/runtime.py
+++ b/loopx/extensions/runtime.py
@@ -13,9 +13,10 @@ from ..file_lock import exclusive_file_lock
 from .manifest import load_extension_manifest
 from .readiness import (
     EXTENSION_DOCTOR_SCHEMA_VERSION,
+    ResolvedRuntimeEntrypoint,
     extension_doctor,
     extension_runtime,
-    resolved_entrypoint_identity,
+    resolve_runtime_entrypoint,
 )
 
 
@@ -448,7 +449,9 @@ def doctor_installed_extension(
     return doctor
 
 
-def _verified_entrypoint(entry: Mapping[str, Any]) -> Path | None:
+def _verified_entrypoint(
+    entry: Mapping[str, Any],
+) -> ResolvedRuntimeEntrypoint | None:
     active_revision = str(entry.get("active_revision") or "")
     if entry.get("doctor_verified_revision") != active_revision:
         return None
@@ -460,19 +463,19 @@ def _verified_entrypoint(entry: Mapping[str, Any]) -> Path | None:
     if not isinstance(manifest, Mapping):
         return None
     runtime = _runtime(manifest)
-    identity = resolved_entrypoint_identity(str(runtime["entrypoint"]))
-    if identity is None or identity[1] != entry.get(
+    identity = resolve_runtime_entrypoint(runtime)
+    if identity is None or identity.identity != entry.get(
         "doctor_verified_entrypoint_identity"
     ):
         return None
-    return identity[0]
+    return identity
 
 
 def _resolved_active_extension(
     extension_id: str,
     *,
     state_file: str | Path,
-) -> tuple[str, Path, Mapping[str, Any]]:
+) -> tuple[str, ResolvedRuntimeEntrypoint, Mapping[str, Any]]:
     state = _read_state(Path(state_file).expanduser())
     entry = state["extensions"].get(extension_id)
     if not isinstance(entry, dict):
@@ -569,16 +572,15 @@ def resolve_extension_binding(
             f"extension `{extension_id}` does not implement `{capability_id}` "
             f"with protocol `{protocol}`"
         )
-    resolved_entrypoint = str(verified_entrypoint)
     return {
         "schema_version": EXTENSION_BINDING_SCHEMA_VERSION,
         "extension_id": extension_id,
         "provider_version": provider.get("version"),
         "revision": active_revision,
         "protocol": protocol,
-        "argv": [resolved_entrypoint, *(runtime.get("args") or [])],
+        "argv": [*verified_entrypoint.argv_prefix, *(runtime.get("args") or [])],
         "doctor_argv": [
-            resolved_entrypoint,
+            *verified_entrypoint.argv_prefix,
             *(runtime.get("args") or []),
             *(runtime.get("doctor_args") or []),
         ],

--- a/tests/extensions/test_extension_runtime.py
+++ b/tests/extensions/test_extension_runtime.py
@@ -4,6 +4,7 @@ import argparse
 import ast
 from collections.abc import Callable
 import json
+import os
 from pathlib import Path
 import subprocess
 import sys
@@ -84,6 +85,110 @@ protocol = "semantic_preference_provider_v0"
         encoding="utf-8",
     )
     return path
+
+
+def _python_module_manifest(path: Path, *, module_name: str) -> Path:
+    path.write_text(
+        """\
+schema_version = "loopx_extension_manifest_v0"
+id = "test-lark-module-extension"
+version = "1.0.0"
+requires_loopx_api = ">=1,<2"
+permissions = ["semantic_preference.read"]
+
+[runtime]
+protocol = "semantic_preference_provider_v0"
+python_module = "{module_name}"
+doctor_args = ["--doctor"]
+required_permissions = ["semantic_preference.read"]
+timeout_seconds = 5
+
+[[implements]]
+capability_id = "semantic-preference"
+protocol = "semantic_preference_provider_v0"
+""".format(module_name=module_name),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_python_module_runtime_uses_current_interpreter_without_console_script(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_name = "test_loopx_extension_provider"
+    module_path = tmp_path / f"{module_name}.py"
+    module_path.write_text(
+        "import sys\nraise SystemExit(0 if '--doctor' in sys.argv else 2)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    python_path = os.environ.get("PYTHONPATH")
+    monkeypatch.setenv(
+        "PYTHONPATH",
+        os.pathsep.join(part for part in [str(tmp_path), python_path] if part),
+    )
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    manifest = _python_module_manifest(
+        tmp_path / "extension.toml",
+        module_name=module_name,
+    )
+    state_file = tmp_path / "extensions.json"
+
+    installed = install_extension(manifest, state_file=state_file, execute=True)
+    assert installed["doctor"]["verified"] is True
+    binding = resolve_extension_binding(
+        "test-lark-module-extension",
+        state_file=state_file,
+        capability_id="semantic-preference",
+        protocol="semantic_preference_provider_v0",
+        permission="semantic_preference.read",
+    )
+
+    assert binding["argv"] == [
+        sys.executable,
+        "-m",
+        module_name,
+    ]
+    assert binding["doctor_argv"] == [*binding["argv"], "--doctor"]
+
+    module_path.write_text(
+        module_path.read_text(encoding="utf-8") + "# replaced\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="doctor readiness is stale"):
+        resolve_extension_activation(
+            "test-lark-module-extension",
+            state_file=state_file,
+        )
+
+
+@pytest.mark.parametrize(
+    "runtime_target",
+    [
+        "",
+        'entrypoint = "provider"\npython_module = "provider.module"',
+        'python_module = "not-a-module"',
+    ],
+)
+def test_runtime_requires_one_valid_launch_target(
+    tmp_path: Path,
+    runtime_target: str,
+) -> None:
+    manifest = _python_module_manifest(
+        tmp_path / "extension.toml",
+        module_name="loopx.extensions.lark.provider",
+    )
+    manifest.write_text(
+        manifest.read_text(encoding="utf-8").replace(
+            'python_module = "loopx.extensions.lark.provider"',
+            runtime_target,
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="exactly one|dotted Python module"):
+        install_extension(manifest, state_file=tmp_path / "extensions.json")
 
 
 def test_install_disable_upgrade_and_rollback_preserve_verified_binding(


### PR DESCRIPTION
## Summary
- allow extension manifests to declare exactly one of an external `entrypoint` or a packaged `python_module`
- bind module readiness to the current LoopX interpreter and resolved module source, while preserving venv launch identity
- migrate bundled `loopx-lark` to its packaged module so clean source/release installs do not depend on an independently installed console script
- document and cover the launch contract, including stale proof rejection after module replacement

## Motivation
Full Public run 29657414843 failed Lark, Explore, and issue-fix smokes because a clean GitHub checkout had no `loopx-lark-provider` console script. Local environments masked this through an already installed script on PATH.

## Validation
- `pytest -q tests/extensions` (19 passed)
- clean-PATH replay: `explore-feishu-singleflight-smoke.py`, `issue-fix-reviewer-request-smoke.py`, `lark-extension-activation-smoke.py`
- clean-PATH extension registry, OpenViking runtime, and placement-doc smokes
- temporary wheel/venv install from `/tmp`, with PATH excluding provider console scripts
- Ruff check on touched Python files
- `loopx canary premerge --from-git-diff --tier standard` (gate passed; 13 selected checks; no failures, warnings, skips, or manual holds; self-merge allowed)
- public/private boundary scan clean for all 7 changed paths

## Scope and risk
External executable manifests remain backward compatible. The only bundled migration is `loopx-lark`; provider permissions and activation gates are unchanged. No credentials, private state, raw run artifacts, local paths, or generated logs are included. The two unrelated Full Public roots (todo actor-attribution fixtures and project-adoption scheduler context) remain separate LoopX todos.