### PR TITLE
Audit status and quota compatibility exports

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,6 +57,20 @@ generic compact benchmark fields; its shipped schema remains compatible. Hiding
 an adapter dependency inside a function or dynamic import does not count as
 architectural separation.
 
+### Status And Quota Facades
+
+`loopx.status` and `loopx.quota` remain compatibility entry points for their
+facade-owned behavior. Imported implementations belong to their canonical
+bounded modules; the only compatibility-only re-exports are the keys in each
+facade's `_PUBLIC_COMPAT_REEXPORTS` map, whose values name the canonical owner.
+
+New repository code must import the canonical owner. A compatibility-only
+entry may remain while a public example, regression, or documented import
+contract consumes it. Zero-consumer, undocumented entries are removed instead
+of becoming permanent accidental API. Removing a retained entry requires an
+explicit migration or deprecation step, and status/quota CLI JSON parity must
+stay characterized independently of the compatibility binding.
+
 Capabilities and extensions are also orthogonal: a capability is a product
 contract, while an extension is an independently managed provider that may
 offer one or more capabilities. The provider-aware registration and manifest

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -22,11 +22,7 @@ from .control_plane.agents.agent_lane_recommendation import (
     selected_recommended_action_from_work_lane,
 )
 from .control_plane.agents.workspace_guard import build_agent_workspace_guard
-from .control_plane.agents.identity import (
-    build_identity_aware_prompt_upgrade,
-    build_quota_agent_identity,
-    quota_registered_agents,
-)
+from .control_plane.agents.identity import build_identity_aware_prompt_upgrade, build_quota_agent_identity
 from .control_plane import compact_control_plane_policy
 from .execution_profile import (
     execution_profile_outcome_floor,
@@ -70,10 +66,9 @@ from .control_plane.quota.decision_summary import (
 )
 from .control_plane.quota.goal_boundary import effective_available_capabilities as _effective_available_capabilities, goal_boundary as _goal_boundary, quota_execution_profile_summary as _quota_execution_profile_summary
 from .control_plane.quota.monitor_poll import (
-    QUOTA_MONITOR_POLL_CLASSIFICATION,
-    build_quota_monitor_poll_event,
+    QUOTA_MONITOR_POLL_CLASSIFICATION as QUOTA_MONITOR_POLL_CLASSIFICATION,
+    build_quota_monitor_poll_event as build_quota_monitor_poll_event,
     record_quota_monitor_poll_for_decision,
-    render_quota_monitor_poll_markdown,
 )
 from .control_plane.quota.recent_runs import (
     build_monitor_debt_arbitration as _build_monitor_debt_arbitration,
@@ -81,13 +76,12 @@ from .control_plane.quota.recent_runs import (
     recent_external_monitor_observation_unchanged as _recent_external_monitor_observation_unchanged,
 )
 from .presentation.renderers.quota_markdown import (
-    render_quota_markdown,
-    render_quota_scheduler_ack_markdown,
-    render_quota_should_run_markdown,
+    render_quota_markdown as render_quota_markdown,
+    render_quota_scheduler_ack_markdown as render_quota_scheduler_ack_markdown,
+    render_quota_should_run_markdown as render_quota_should_run_markdown,
 )
 from .control_plane.quota.scheduler_ack import (
     QUOTA_SCHEDULER_ACK_CLASSIFICATION,
-    build_quota_scheduler_ack_event,
     record_quota_scheduler_ack_for_decision,
 )
 from .control_plane.quota.selected_todo_projection import (
@@ -110,12 +104,12 @@ from .control_plane.quota.slot_accounting import (
     QUOTA_SLOT_VOIDED_CLASSIFICATION,
     build_quota_slot_preview_for_decision,
     build_quota_slot_spend_event as _build_quota_slot_spend_event,
-    build_quota_slot_void_event,
+    build_quota_slot_void_event as build_quota_slot_void_event,
     build_quota_slot_void_preview_for_decision,
     load_quota_event_from_run,
     record_quota_slot_spend_from_preview,
     record_quota_slot_void_from_preview,
-    render_quota_slot_preview_markdown,
+    render_quota_slot_preview_markdown as render_quota_slot_preview_markdown,
 )
 from .control_plane.quota.spend_sources import (
     DEFAULT_SLOT_SPEND_SOURCE,
@@ -157,7 +151,6 @@ from .control_plane.todos.contract import (
     TODO_TASK_CLASS_BLOCKER,
     normalize_todo_claimed_by,
     normalize_todo_status,
-    normalize_todo_task_class,
 )
 from .control_plane.todos.summary_item import (
     compact_todo_summary_item,
@@ -180,7 +173,6 @@ from .control_plane.todos.quota_summary import (
     compact_quota_todo_summary_for_payload,
     select_quota_todo_source_items,
     select_quota_todo_summary,
-    summarize_user_todos_for_quota,
 )
 from .control_plane.todos.user_gate import (
     build_gate_prompt as _build_gate_prompt,
@@ -190,6 +182,17 @@ from .control_plane.todos.user_gate import (
     user_gate_todo_notify_reason as _user_gate_todo_notify_reason,
 )
 from .control_plane.todos.write_hint import build_todo_write_hint
+
+
+_PUBLIC_COMPAT_REEXPORTS = {
+    "QUOTA_MONITOR_POLL_CLASSIFICATION": "loopx.control_plane.quota.monitor_poll",
+    "build_quota_monitor_poll_event": "loopx.control_plane.quota.monitor_poll",
+    "render_quota_markdown": "loopx.presentation.renderers.quota_markdown",
+    "render_quota_scheduler_ack_markdown": "loopx.presentation.renderers.quota_markdown",
+    "render_quota_should_run_markdown": "loopx.presentation.renderers.quota_markdown",
+    "build_quota_slot_void_event": "loopx.control_plane.quota.slot_accounting",
+    "render_quota_slot_preview_markdown": "loopx.control_plane.quota.slot_accounting",
+}
 
 
 DEFAULT_COMPUTE_QUOTA = 1.0

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import hashlib
 from pathlib import Path
 import re
 from typing import Any
@@ -45,20 +44,15 @@ from .history import collect_history, load_registry
 from .history import STATUS_NEUTRAL_CLASSIFICATIONS as HISTORY_STATUS_NEUTRAL_CLASSIFICATIONS
 from .interface_budget import interface_budget_cadence_for_runs
 from .long_task_cadence import build_long_task_cadence_hint
-from .materials import extract_review_materials
 from .operator_gate import DEFAULT_OPERATOR_GATE, default_operator_question, normalize_operator_question
 from .orchestration import compact_orchestration_policy
 from .paths import global_registry_path, resolve_runtime_root
 from .control_plane.work_items.task_graph import (
-    TASK_GRAPH_MAX_USER_GATE_NODES,
-    TASK_GRAPH_PROJECTION_SCHEMA_VERSION,
-    TASK_GRAPH_SOURCE_OF_TRUTH,
     build_task_graph_projection as _build_task_graph_projection_read_model,
 )
 from .control_plane.work_items.project_asset import (
-    PROJECT_ASSET_TODO_PROJECTION_GAP_SCHEMA_VERSION,
-    TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION,
-    TODO_PROJECTION_VIEW_SCHEMA_VERSION,
+    TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION as TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION,
+    TODO_PROJECTION_VIEW_SCHEMA_VERSION as TODO_PROJECTION_VIEW_SCHEMA_VERSION,
     attach_active_state_project_asset_fields as _attach_active_state_project_asset_fields,
     build_project_asset,
     enrich_project_asset as _enrich_project_asset_read_model,
@@ -66,7 +60,7 @@ from .control_plane.work_items.project_asset import (
     project_asset_latest_validation,
     project_asset_quota_state,
     project_asset_quota_summary,
-    project_asset_summary_is_public_safe,
+    project_asset_summary_is_public_safe as project_asset_summary_is_public_safe,
     project_asset_todo_projection_gap,
     project_asset_user_todo_open_count,
 )
@@ -79,8 +73,6 @@ from .control_plane.work_items.autonomous_candidates import (
     MAX_AUTONOMOUS_TODO_CANDIDATES as _MAX_AUTONOMOUS_TODO_CANDIDATES,
     autonomous_backlog_candidates as _autonomous_backlog_candidates_read_model,
     autonomous_monitor_candidates as _autonomous_monitor_candidates_read_model,
-    autonomous_priority_label,
-    autonomous_priority_rank,
 )
 from .control_plane.agents.agent_lane_recommendation import (
     compact_agent_lane_recommendation as _compact_agent_lane_recommendation_read_model,
@@ -93,11 +85,7 @@ from .control_plane.goals.active_state_sections import (
     active_state_sections as _active_state_sections_read_model,
 )
 from .control_plane.goals.active_state_metadata import (
-    AGENT_TODO_HEADER_MARKERS,
-    TODO_ARCHIVE_HEADER_MARKERS,
-    USER_TODO_HEADER_MARKERS,
     parse_state_frontmatter,
-    todo_role_for_heading,
 )
 from .control_plane.goals.active_state_event_projection import (
     active_state_event_projection_fields as _active_state_event_projection_fields_read_model,
@@ -106,8 +94,6 @@ from .control_plane.goals.active_state_event_projection import (
 from .control_plane.todos.active_state_todos import (
     MONITOR_WRITEBACK_CONTRACT_SCHEMA_VERSION as _MONITOR_WRITEBACK_CONTRACT_SCHEMA_VERSION,
     active_state_todo_fields as _active_state_todo_fields_read_model,
-    attach_monitor_writeback_contract,
-    redacted_status_todo_fields,
 )
 from .control_plane.todos.active_state_todo_parser import (
     parse_active_state_todos,
@@ -141,8 +127,6 @@ from .control_plane.work_items.autonomous_replan_obligation import (
     autonomous_replan_obligation_from_runs as _autonomous_replan_obligation_from_runs_read_model,
     autonomous_replan_periodic_review_from_runs as _autonomous_replan_periodic_review_from_runs_read_model,
     build_autonomous_replan_obligation as _build_autonomous_replan_obligation_read_model,
-    normalized_run_history_stall_signature as _normalized_run_history_stall_signature,
-    run_history_monitor_target as _run_history_monitor_target,
     run_history_monitor_wait_already_acknowledged as _run_history_monitor_wait_already_acknowledged_read_model,
     run_history_stall_signal as _run_history_stall_signal_read_model,
 )
@@ -191,7 +175,6 @@ from .control_plane.runtime.benchmark_event_timeline import (
 from .control_plane.runtime.benchmark_comparison import (
     benchmark_comparison_decision_note as _benchmark_comparison_decision_note_read_model,
     compact_benchmark_comparison as _compact_benchmark_comparison_read_model,
-    compact_comparison_delta as _compact_comparison_delta,
 )
 from .control_plane.runtime.benchmark_attempt_accounting import (
     compact_benchmark_attempt_accounting as _compact_benchmark_attempt_accounting,
@@ -248,11 +231,9 @@ from .control_plane.handoff.handoff_runs import (
 )
 from .control_plane.goals.global_registry_shadow import (
     attach_global_registry_shadow_finding,
-    compact_global_registry_shadow_finding,
 )
 from .control_plane.goals.global_registry_health import (
     collect_global_registry_health as _collect_global_registry_health_read_model,
-    global_registry_finding,
 )
 from .control_plane.goals.path_resolution import resolve_goal_local_path, same_path
 from .control_plane.goals.goal_channel import (
@@ -272,9 +253,7 @@ from .control_plane.work_items.lifecycle import (
     run_lifecycle_phase as _run_lifecycle_phase_read_model,
 )
 from .control_plane.runtime.session_runtime import (
-    attach_session_runtime_projection,
     compact_session_runtime_projection_from_run,
-    compact_session_runtime_readonly_projection,
     legacy_runtime_goal_attention as _legacy_runtime_goal_attention_read_model,
 )
 from .control_plane.runtime.skillsbench_post_run_debug import (
@@ -306,46 +285,26 @@ from .control_plane.todos.todo_summary import (
     active_state_todo_attention_item as _active_state_todo_attention_item_read_model,
     active_next_action_todo_ids,
     attach_dependency_blockers,
-    apply_resume_conditions,
-    claimed_visibility_items,
-    compact_active_next_action_todo_item,
-    compact_todo_group,
-    compact_todo_item,
-    dependency_blocker_summary,
-    first_open_todo_item,
+    claimed_visibility_items as claimed_visibility_items,
+    compact_todo_group as compact_todo_group,
+    compact_todo_item as compact_todo_item,
     first_open_todo_text,
     normalize_todo_text,
-    normalized_pr_ref_parts,
     open_todo_items,
-    pr_merged_condition,
     project_asset_todo_summary,
-    rollout_event_pr_refs,
-    structured_todo_item,
     sync_connected_attention_action_from_todos as _sync_connected_attention_action_from_todos_read_model,
-    todo_lane_items,
-    todo_item_expires_at,
+    todo_lane_items as todo_lane_items,
     todo_item_is_actionable_open,
-    todo_item_is_deferred,
-    todo_item_is_due_monitor,
-    todo_item_missing_monitor_schedule,
-    todo_item_next_due_at,
+    todo_item_is_deferred as todo_item_is_deferred,
+    todo_item_is_due_monitor as todo_item_is_due_monitor,
+    todo_item_missing_monitor_schedule as todo_item_missing_monitor_schedule,
+    todo_item_next_due_at as todo_item_next_due_at,
     todo_item_task_class,
-    todo_priority_parts,
-    todo_priority_rank,
-    todo_projection_sort_key,
+    todo_projection_sort_key as todo_projection_sort_key,
 )
 from .control_plane.todos.todo_index import (
     MAX_TODO_INDEX_ITEMS,
     MAX_TODO_INDEX_ROLLOUT_EVENTS_PER_GOAL,
-    TODO_INDEX_ITEM_SCHEMA_VERSION,
-    TODO_INDEX_SCHEMA_VERSION,
-)
-from .control_plane.quota.usage_summary import (
-    USAGE_PROXY_NOTE,
-    blank_usage_goal,
-    is_automation_run,
-    is_progress_signal_run,
-    quota_spend_slots,
 )
 from .promotion_gate import build_promotion_gate
 from .quota import quota_status, quota_with_handoff_outcome_floor
@@ -362,22 +321,31 @@ from .control_plane.todos.contract import (
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_MONITOR,
     TODO_TASK_CLASS_USER_GATE,
-    TODO_TASK_PATTERN,
-    normalize_required_capabilities,
-    normalize_required_write_scopes,
-    normalize_todo_blocks_agent,
-    normalize_todo_claimed_by,
-    normalize_todo_id,
-    normalize_todo_resume_when,
     normalize_todo_status,
-    normalize_todo_task_class,
-    parse_todo_metadata_line,
+    normalize_todo_task_class as normalize_todo_task_class,
     todo_done_for_status,
-    todo_status_from_marker,
 )
 from .control_plane.todos.projection import (
-    todo_item_is_expired_monitor,
+    todo_item_is_expired_monitor as todo_item_is_expired_monitor,
 )
+
+
+_PUBLIC_COMPAT_REEXPORTS = {
+    "TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION": "loopx.control_plane.work_items.project_asset",
+    "TODO_PROJECTION_VIEW_SCHEMA_VERSION": "loopx.control_plane.work_items.project_asset",
+    "project_asset_summary_is_public_safe": "loopx.control_plane.work_items.project_asset",
+    "claimed_visibility_items": "loopx.control_plane.todos.todo_summary",
+    "compact_todo_group": "loopx.control_plane.todos.todo_summary",
+    "compact_todo_item": "loopx.control_plane.todos.todo_summary",
+    "todo_lane_items": "loopx.control_plane.todos.todo_summary",
+    "todo_item_is_deferred": "loopx.control_plane.todos.todo_summary",
+    "todo_item_is_due_monitor": "loopx.control_plane.todos.todo_summary",
+    "todo_item_missing_monitor_schedule": "loopx.control_plane.todos.todo_summary",
+    "todo_item_next_due_at": "loopx.control_plane.todos.todo_summary",
+    "todo_projection_sort_key": "loopx.control_plane.todos.todo_summary",
+    "normalize_todo_task_class": "loopx.control_plane.todos.contract",
+    "todo_item_is_expired_monitor": "loopx.control_plane.todos.projection",
+}
 
 
 CODEX_READY_CLASSIFICATIONS = {

--- a/tests/architecture/test_control_plane_import_boundaries.py
+++ b/tests/architecture/test_control_plane_import_boundaries.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import importlib
 from importlib.util import resolve_name
 from pathlib import Path
 
@@ -11,6 +12,16 @@ SCRIPTS_ROOT = REPOSITORY_ROOT / "scripts"
 CONTROL_PLANE_ROOT = PACKAGE_ROOT / "control_plane"
 STATUS_MODULE = PACKAGE_ROOT / "status.py"
 QUOTA_MODULE = PACKAGE_ROOT / "quota.py"
+PUBLIC_CONTRACT_ROOTS = (
+    REPOSITORY_ROOT / "tests",
+    REPOSITORY_ROOT / "examples",
+    REPOSITORY_ROOT / "scripts",
+    REPOSITORY_ROOT / "regression",
+)
+PUBLIC_COMPAT_FACADES = {
+    "loopx.status": STATUS_MODULE,
+    "loopx.quota": QUOTA_MODULE,
+}
 GOAL_BOUNDARY_MODULE = CONTROL_PLANE_ROOT / "quota" / "goal_boundary.py"
 OPERATOR_INBOX_MODULE = CONTROL_PLANE_ROOT / "work_items" / "operator_inbox.py"
 QUOTA_CLI_MODULE = PACKAGE_ROOT / "cli_commands" / "quota.py"
@@ -97,6 +108,67 @@ def _top_level_imported_names(path: Path) -> set[str]:
     }
 
 
+def _top_level_import_bindings(path: Path) -> dict[str, str]:
+    module_name = _module_name(path)
+    package_name = module_name.rpartition(".")[0]
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    bindings: dict[str, str] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                bindings[alias.asname or alias.name] = alias.name
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if node.level:
+                module = resolve_name("." * node.level + module, package_name)
+            for alias in node.names:
+                bindings[alias.asname or alias.name] = f"{module}.{alias.name}"
+    return bindings
+
+
+def _public_import_only_bindings(path: Path) -> dict[str, str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    loaded_names = {
+        node.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
+    }
+    return {
+        name: target
+        for name, target in _top_level_import_bindings(path).items()
+        if name != "annotations" and not name.startswith("_") and name not in loaded_names
+    }
+
+
+def _public_contract_evidence() -> dict[tuple[str, str], set[str]]:
+    evidence: dict[tuple[str, str], set[str]] = {}
+    for root in PUBLIC_CONTRACT_ROOTS:
+        for path in root.rglob("*.py"):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.ImportFrom):
+                    continue
+                if node.module not in PUBLIC_COMPAT_FACADES:
+                    continue
+                for alias in node.names:
+                    evidence.setdefault((node.module, alias.name), set()).add(
+                        str(path.relative_to(REPOSITORY_ROOT))
+                    )
+    for path in (REPOSITORY_ROOT / "docs").rglob("*.md"):
+        text = path.read_text(encoding="utf-8")
+        for facade_name in PUBLIC_COMPAT_FACADES:
+            facade = importlib.import_module(facade_name)
+            for export_name in facade._PUBLIC_COMPAT_REEXPORTS:
+                if (
+                    f"{facade_name}.{export_name}" in text
+                    or f"from {facade_name} import {export_name}" in text
+                ):
+                    evidence.setdefault((facade_name, export_name), set()).add(
+                        str(path.relative_to(REPOSITORY_ROOT))
+                    )
+    return evidence
+
+
 def test_control_plane_does_not_gain_outward_dependencies() -> None:
     outward_dependencies = {
         (_module_name(path), dependency)
@@ -144,6 +216,38 @@ def test_internal_consumers_bypass_status_and_quota_reexport_routes() -> None:
     assert not indirect_imports, (
         "repository-internal consumers must import extracted symbols from their "
         f"canonical modules instead of status/quota re-export routes: {sorted(indirect_imports)}"
+    )
+
+
+def test_public_facade_import_only_reexports_match_the_audited_allowlist() -> None:
+    for facade_name, source_path in PUBLIC_COMPAT_FACADES.items():
+        facade = importlib.import_module(facade_name)
+        allowlist = getattr(facade, "_PUBLIC_COMPAT_REEXPORTS")
+        import_only_bindings = _public_import_only_bindings(source_path)
+
+        assert import_only_bindings == {
+            export_name: f"{canonical_module}.{export_name}"
+            for export_name, canonical_module in allowlist.items()
+        }
+        for export_name, canonical_module_name in allowlist.items():
+            canonical_module = importlib.import_module(canonical_module_name)
+            assert getattr(facade, export_name) is getattr(
+                canonical_module, export_name
+            )
+
+
+def test_public_facade_compatibility_entries_have_contract_evidence() -> None:
+    evidence = _public_contract_evidence()
+    missing_evidence: list[tuple[str, str]] = []
+    for facade_name in PUBLIC_COMPAT_FACADES:
+        facade = importlib.import_module(facade_name)
+        for export_name in facade._PUBLIC_COMPAT_REEXPORTS:
+            if not evidence.get((facade_name, export_name)):
+                missing_evidence.append((facade_name, export_name))
+
+    assert not missing_evidence, (
+        "import-only compatibility exports need a repository consumer or explicit "
+        f"public documentation; remove stale entries: {missing_evidence}"
     )
 
 

--- a/tests/control_plane/test_cli_output_budget.py
+++ b/tests/control_plane/test_cli_output_budget.py
@@ -606,6 +606,52 @@ def test_real_cli_output_stays_inside_the_characterized_baseline(
             assert formats["markdown"]["json_parseable"] is False
 
 
+def test_status_and_quota_json_ignore_compatibility_reexport_bindings(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    with _stable_budget_fixture_root(tmp_path / "compat") as stable_root:
+        project, runtime, registry_path, state_file = _write_fixture(
+            stable_root,
+            SCENARIOS[0],
+        )
+        commands = _surface_commands(
+            project=project,
+            runtime=runtime,
+            registry_path=registry_path,
+            state_file=state_file,
+            output_format="json",
+        )
+
+        def semantic_receipts() -> dict[str, dict[str, object]]:
+            receipts: dict[str, dict[str, object]] = {}
+            for surface_id in ("status", "quota_should_run"):
+                exit_code, text = _invoke_cli(commands[surface_id])
+                assert exit_code == 0, (surface_id, text)
+                measurement = measure_cli_output(text, output_format="json")
+                payload = measurement["payload"]
+                assert isinstance(payload, dict)
+                receipts[surface_id] = {
+                    "top_level_keys": sorted(payload),
+                    "json_shape_paths": measurement["json_shape_paths"],
+                    "action_signature_sha256": measurement[
+                        "action_signature_sha256"
+                    ],
+                }
+            return receipts
+
+        baseline = semantic_receipts()
+
+        import loopx.quota as quota_facade
+        import loopx.status as status_facade
+
+        for facade in (status_facade, quota_facade):
+            for export_name in facade._PUBLIC_COMPAT_REEXPORTS:
+                monkeypatch.setattr(facade, export_name, object())
+
+        assert semantic_receipts() == baseline
+
+
 def test_collection_growth_and_bootstrap_duplication_are_explicit(tmp_path: Path) -> None:
     small = _measure_scenario(tmp_path / "small", SCENARIOS[0])
     crowded = _measure_scenario(tmp_path / "crowded", SCENARIOS[1])


### PR DESCRIPTION
## Summary

- remove undocumented, zero-consumer import-only reexports from `loopx.status` and `loopx.quota`
- preserve the consumed compatibility surface through audited canonical-owner allowlists (14 status entries, 7 quota entries) with object-identity checks
- document migration/deprecation rules and prove status/quota CLI JSON semantics do not depend on compatibility bindings

## Validation

- focused compatibility and CLI tests: 15 passed
- full CLI output-budget and differential tests: 19 passed
- representative status/quota smokes: passed
- Ruff and `git diff --check`: passed
- `loopx canary premerge --from-git-diff`: 18/18 passed on final rebased head; public-boundary scan clean; no manual holds
- full pytest: 782 passed, 2 skipped, 1 failed. The sole failure is `test_turn_launcher_requires_an_independent_validator`; it reproduces unchanged on a pristine current-main worktree because the local runner profile returns success where the fixture expects a missing-validator error. No changed file participates in that path.

## Review hold

This intentionally contracts accidental public import routes while retaining evidenced compatibility entries. Please independently verify the allowlist/evidence boundary before merge; this PR is not self-merged.