### PR TITLE
test(quota): preserve monitor-poll scheduler context parity

### DIFF
--- a/examples/control_plane/monitor-poll-writeback-smoke.py
+++ b/examples/control_plane/monitor-poll-writeback-smoke.py
@@ -795,28 +795,80 @@ def assert_cli_help_names_capability_sensitive_commands() -> None:
         assert command in option_help, (command, option_help)
 
 
+def cli_monitor_poll_scheduler_hints(registry_path: Path, *scheduler_args: str) -> tuple[dict, dict]:
+    payload = run_cli(
+        registry_path,
+        "quota",
+        "monitor-poll",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        *scheduler_args,
+        "--todo-id",
+        TODO_ID,
+        "--result-hash",
+        "old",
+    )
+    return payload["before"]["scheduler_hint"], payload["after"]["scheduler_hint"]
+
+
 def assert_cli_monitor_poll_preserves_codex_app_scheduler_context() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-monitor-poll-codex-app-") as tmp:
-        registry_path, _state_file = write_fixture(Path(tmp))
-        payload = run_cli(
-            registry_path,
-            "quota",
-            "monitor-poll",
-            "--goal-id",
-            GOAL_ID,
-            "--agent-id",
-            AGENT_ID,
-            "--codex-app",
-            "--todo-id",
-            TODO_ID,
-            "--result-hash",
-            "old",
-        )
+        hints = cli_monitor_poll_scheduler_hints(write_fixture(Path(tmp))[0], "--codex-app")
+        for scheduler_hint in hints:
+            assert scheduler_hint["codex_app"]["applicability"] == "applicable", scheduler_hint
+            assert scheduler_hint["action"] != "repair_scheduler_execution_context", scheduler_hint
 
-        for decision in (payload["before"], payload["after"]):
-            scheduler_hint = decision["scheduler_hint"]
-            assert scheduler_hint["codex_app"]["applicability"] == "applicable", decision
-            assert scheduler_hint["action"] != "repair_scheduler_execution_context", decision
+
+def assert_cli_monitor_poll_preserves_outer_controller_scheduler_context() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-monitor-poll-outer-controller-") as tmp:
+        hints = cli_monitor_poll_scheduler_hints(
+            write_fixture(Path(tmp))[0], "--runtime-profile", "outer_controller"
+        )
+        for scheduler_hint in hints:
+            execution_context = scheduler_hint["execution_context"]
+            execution_phase = scheduler_hint["execution_phase"]
+            assert scheduler_hint["action"] != "repair_scheduler_execution_context", scheduler_hint
+            assert scheduler_hint["codex_app"]["applicability"] == "not_applicable", scheduler_hint
+            assert "stateful_backoff" not in scheduler_hint["codex_app"], scheduler_hint
+            assert (
+                execution_context["host_surface"],
+                execution_context["scheduler_owner"],
+                execution_context["execution_mode"],
+                execution_context["valid"],
+            ) == ("generic_cli", "outer_controller", "isolated_headless", True), scheduler_hint
+            assert execution_phase["disposition"] == "outer_controller_owned", scheduler_hint
+            assert execution_phase["completed"] is True, scheduler_hint
+            assert execution_phase["apply_needed"] is False, scheduler_hint
+            assert execution_phase["ack_needed"] is False, scheduler_hint
+
+
+def assert_cli_monitor_poll_invalid_scheduler_context_fails_closed() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-monitor-poll-invalid-context-") as tmp:
+        hints = cli_monitor_poll_scheduler_hints(
+            write_fixture(Path(tmp))[0],
+            "--host-surface",
+            "generic_cli",
+            "--scheduler-owner",
+            "outer_controller",
+            "--execution-mode",
+            "interactive",
+        )
+        for scheduler_hint in hints:
+            execution_context = scheduler_hint["execution_context"]
+            execution_phase = scheduler_hint["execution_phase"]
+            assert scheduler_hint["action"] == "repair_scheduler_execution_context", scheduler_hint
+            assert scheduler_hint["codex_app"]["applicability"] == "blocked_invalid_context", scheduler_hint
+            assert "stateful_backoff" not in scheduler_hint["codex_app"], scheduler_hint
+            assert execution_context["valid"] is False, scheduler_hint
+            assert execution_context["errors"] == [
+                "outer_controller requires execution_mode=isolated_headless"
+            ], scheduler_hint
+            assert execution_phase["disposition"] == "contract_error", scheduler_hint
+            assert execution_phase["completed"] is False, scheduler_hint
+            assert execution_phase["apply_needed"] is False, scheduler_hint
+            assert execution_phase["ack_needed"] is False, scheduler_hint
 
 
 def assert_writeback_helper_preview_contract() -> None:
@@ -933,6 +985,8 @@ def main() -> int:
     assert_cli_help_names_capability_sensitive_commands()
     assert_cli_monitor_poll_uses_should_run_lookback()
     assert_cli_monitor_poll_preserves_codex_app_scheduler_context()
+    assert_cli_monitor_poll_preserves_outer_controller_scheduler_context()
+    assert_cli_monitor_poll_invalid_scheduler_context_fails_closed()
     assert_writeback_helper_preview_contract()
     assert_unchanged_writeback()
     assert_interleaved_monitor_stalls_replan_blocked_benchmark()

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -2341,25 +2341,25 @@ def record_quota_monitor_poll(
     next_due_at: str | None = None,
     next_agent_todo: str | None = None,
     next_user_todo: str | None = None,
-    next_claimed_by: str | None = None, scheduler_execution_context: Mapping[str, Any] | SchedulerExecutionContextResolution | None = None, operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
+    next_claimed_by: str | None = None,
+    scheduler_execution_context: Mapping[str, Any] | SchedulerExecutionContextResolution | None = None,
+    operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     safe_goal_id = _validate_goal_id_path_segment(str(goal_id or ""))
-    before = build_quota_should_run(
-        status_payload,
-        goal_id=safe_goal_id,
-        agent_id=agent_id,
-        available_capabilities=available_capabilities, scheduler_execution_context=scheduler_execution_context, operator_inbox_urgency_projector=operator_inbox_urgency_projector,
-    )
+    def should_run(current_status: dict[str, Any]) -> dict[str, Any]:
+        return build_quota_should_run(current_status,
+            goal_id=safe_goal_id,
+            agent_id=agent_id,
+            available_capabilities=available_capabilities,
+            scheduler_execution_context=scheduler_execution_context,
+            operator_inbox_urgency_projector=operator_inbox_urgency_projector,
+        )
+    before = should_run(status_payload)
     return record_quota_monitor_poll_for_decision(
         before,
         status_payload,
         goal_id=safe_goal_id,
-        after_decision=lambda after_status: build_quota_should_run(
-            after_status,
-            goal_id=safe_goal_id,
-            agent_id=agent_id,
-            available_capabilities=available_capabilities, scheduler_execution_context=scheduler_execution_context, operator_inbox_urgency_projector=operator_inbox_urgency_projector,
-        ),
+        after_decision=should_run,
         registry_path=registry_path,
         execute=execute,
         source=source,


### PR DESCRIPTION
## Summary
- normalize `record_quota_monitor_poll` scheduler-context parameters and construct one shared should-run callback for both before/after decisions
- add real CLI parity coverage for the generic outer-controller profile
- prove invalid outer-controller context fails closed in both decisions without Codex App apply/ACK state

## Validation
- `python examples/control_plane/monitor-poll-writeback-smoke.py`
- `pytest -q tests/control_plane/test_scheduler_execution_context.py` (76 passed)
- `ruff check loopx/quota.py examples/control_plane/monitor-poll-writeback-smoke.py`
- `loopx canary premerge --from-git-diff` (18/18 selected checks passed; public boundary passed)
- full `pytest -q`: 786 passed, 2 skipped, 1 unrelated failure in `test_turn_launcher_requires_an_independent_validator`; the same failure reproduces on detached `origin/main` at `1ce4b5b9` because the local runner profile supplies a validator

## Boundary
No scheduler schema, CLI option, cadence policy, benchmark scoring, runner behavior, credentials, private state, or raw benchmark evidence is changed.