### PR TITLE
feat(extensions): unify runtime and capability catalog truth

### DIFF
--- a/docs/capabilities/semantic-preference/README.md
+++ b/docs/capabilities/semantic-preference/README.md
@@ -29,7 +29,6 @@ does not branch on `issue_fix`, `content_ops`, or any other domain name.
   "enabled": true,
   "provider": {
     "id": "local_memory",
-    "extension_id": "semantic-preference-provider",
     "args": ["--project", "."]
   },
   "surfaces": {
@@ -44,10 +43,13 @@ does not branch on `issue_fix`, `content_ops`, or any other domain name.
 }
 ```
 
-`extension_id` resolves only from enabled, doctor-verified local activation
-state. `args` are appended after the manifest-owned entrypoint arguments. The
-manifest owns protocol, permission, timeout, and doctor; config cannot override
-them. `extension_state_file` is an optional local-private override for tests or
+LoopX resolves the installed provider from the `semantic-preference` capability
+and `semantic_preference_provider_v0` protocol in runtime state. `args` are
+appended after the manifest-owned entrypoint arguments. The manifest owns
+protocol, permission, timeout, and doctor; config cannot override them.
+`extension_id` remains an optional compatibility selector when migrating an
+existing config or disambiguating multiple installed implementations.
+`extension_state_file` is an optional local-private override for tests or
 specialized embeddings; the CLI's global `--runtime-root` selects the normal
 isolated runtime. If an activated extension is later disabled or unavailable,
 recall follows the surface's existing `fail_open` or `fail_closed` policy.
@@ -64,7 +66,8 @@ provider object with:
 }
 ```
 
-`argv` and `extension_id` are mutually exclusive.
+`argv` and `extension_id` are mutually exclusive. Omitting both selects the
+unique installed extension implementation from runtime state.
 
 A domain module owns the surface id, query, context keys, and decision about
 how recalled items influence its output. Adding another module is a config

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -29,13 +29,14 @@ Every registered capability declares three provider-facing fields:
 - `visibility`: `public` or `internal`;
 - `provider_id`: `loopx-core` or the extension manifest id.
 
-The built-in catalog remains the default source. Explicitly enabled extension
-manifests are validated and appended in caller order. Duplicate capability or
-provider ids fail closed. Internal registrations remain available to the
-registry but are omitted from the public catalog.
+The built-in catalog remains the default source. Extension manifests declare
+providers and contracts; the extension runtime state is the only source for
+whether each provider is installed, enabled, and doctor-ready. Duplicate
+capability or provider ids fail closed. Internal registrations remain available
+to the registry but are omitted from the public catalog.
 
 Catalog discovery does not scan arbitrary directories or import extension
-Python code. A caller can compose one manifest into a catalog read explicitly:
+Python code. A caller can add a declaration-only manifest to a catalog read:
 
 ```bash
 loopx capability list \
@@ -47,7 +48,10 @@ loopx capability show lark-kanban \
   --format json
 ```
 
-The activation store is separate from catalog composition. `loopx extension`
+The resulting provider reports `declared=true` and
+`installed=enabled=ready=false`. The normal CLI read also composes installed
+providers from `<runtime-root>/extensions/state.json`, so the catalog and
+runtime dispatch see the same active manifest revision. `loopx extension`
 registers an already-installed subprocess entrypoint only after the manifest,
 API, permission, and doctor checks pass. It does not download packages or grant
 new permissions.
@@ -87,10 +91,15 @@ interpreters, or Python module sources fail closed until a new executed doctor
 succeeds; a failed executed doctor clears the stale proof without switching
 revisions.
 
-An enabled implementation is resolved by capability id, versioned protocol,
-declared permission, current revision, and current doctor proof. Domain config
-may add bounded provider arguments, but cannot replace the manifest entrypoint,
-timeout, protocol, or permission contract.
+An enabled implementation is resolved by capability id and versioned protocol,
+then checked against its declared permission, current revision, and current
+doctor proof. Callers do not need to copy an extension id into normal config.
+Disabled or stale implementations remain visible in the catalog but are not
+dispatch candidates. When multiple enabled, doctor-ready extensions implement
+the same capability/protocol pair, resolution fails closed until the caller
+selects the intended provider during migration. Domain config may add bounded
+provider arguments, but cannot replace the manifest entrypoint, timeout,
+protocol, or permission contract.
 
 Compatibility delegates use the same revision-bound readiness rule. Every
 configured `loopx lark-inbox` operation resolves the enabled `loopx-lark`

--- a/examples/capability-extension-registry-smoke.py
+++ b/examples/capability-extension-registry-smoke.py
@@ -11,9 +11,18 @@ import tempfile
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def run_cli(*args: str) -> dict[str, object]:
+def run_cli(runtime_root: Path, *args: str) -> dict[str, object]:
     result = subprocess.run(
-        [sys.executable, "-m", "loopx.cli", "--format", "json", *args],
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--runtime-root",
+            str(runtime_root),
+            "--format",
+            "json",
+            *args,
+        ],
         cwd=ROOT,
         check=True,
         capture_output=True,
@@ -23,6 +32,7 @@ def run_cli(*args: str) -> dict[str, object]:
 
 
 with tempfile.TemporaryDirectory(prefix="loopx-extension-registry-") as raw_temp:
+    runtime_root = Path(raw_temp) / "runtime"
     manifest = Path(raw_temp) / "extension.toml"
     manifest.write_text(
         """\
@@ -46,17 +56,20 @@ next_real_step = "Keep explicit enablement bounded."
         encoding="utf-8",
     )
 
-    baseline = run_cli("capability", "list")
+    baseline = run_cli(runtime_root, "capability", "list")
     assert [item["id"] for item in baseline["capabilities"]] == [
         "issue-fix",
         "semantic-preference",
         "reward-memory",
         "content-ops",
         "value-connectors",
+        "explore",
+        "auto-research",
     ]
     assert all(item["provider_id"] == "loopx-core" for item in baseline["capabilities"])
 
     composed = run_cli(
+        runtime_root,
         "capability",
         "list",
         "--extension-manifest",
@@ -65,8 +78,13 @@ next_real_step = "Keep explicit enablement bounded."
     assert composed["capabilities"][-1]["id"] == "example-report"
     assert composed["capabilities"][-1]["origin"] == "extension"
     assert composed["providers"][-1]["id"] == "example-extension"
+    assert composed["providers"][-1]["declared"] is True
+    assert composed["providers"][-1]["installed"] is False
+    assert composed["providers"][-1]["enabled"] is False
+    assert composed["providers"][-1]["ready"] is False
 
     detail = run_cli(
+        runtime_root,
         "capability",
         "show",
         "example-report",
@@ -75,16 +93,25 @@ next_real_step = "Keep explicit enablement bounded."
     )
     assert detail["capability"]["capability_kind"] == "projection_sink"
     assert detail["capability"]["provider_id"] == "example-extension"
+    assert detail["capability"]["provider_state"]["ready"] is False
 
-    lark_manifest = ROOT / "loopx" / "extensions" / "lark" / "extension.toml"
+    installed = run_cli(
+        runtime_root,
+        "extension",
+        "install",
+        "--bundled",
+        "loopx-lark",
+        "--execute",
+    )
+    assert installed["doctor"]["verified"] is True, installed
     lark = run_cli(
+        runtime_root,
         "capability",
         "show",
         "lark-event-inbox",
-        "--extension-manifest",
-        str(lark_manifest),
     )
     assert lark["capability"]["origin"] == "extension", lark
     assert lark["capability"]["provider_id"] == "loopx-lark", lark
+    assert lark["capability"]["provider_state"]["ready"] is True, lark
 
 print("capability-extension-registry-smoke: ok")

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from .registry import CapabilityRegistry
-from ..extensions.manifest import load_extension_manifest
+from ..extensions.runtime import extension_catalog_entries
 
 
 CAPABILITY_CATALOG_SCHEMA_VERSION = "loopx_capability_catalog_v0"
@@ -697,6 +697,113 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
             "into public triage notes or paid-path discovery; otherwise stop without bumps."
         ),
     },
+    {
+        "id": "explore",
+        "origin": "builtin",
+        "visibility": "public",
+        "provider_id": "loopx-core",
+        "title": "Explore evidence topology",
+        "status": "active-preview",
+        "real_world_anchor": (
+            "goal-scoped questions, hypotheses, experiments, findings, and result projections"
+        ),
+        "user_value": (
+            "Keep exploration outcomes queryable and attributable instead of leaving them "
+            "only in chat or a presentation sink."
+        ),
+        "entry_command": "loopx explore summary --goal-id <goal-id> --format json",
+        "commands": [
+            {
+                "command": "loopx explore finding --goal-id <goal-id> --title <finding> --evidence-ref <ref> --format json",
+                "purpose": "Append one public-safe, attributable finding to the canonical result log.",
+                "write_boundary": "goal-scoped local result log only; no sink or external write",
+            },
+            {
+                "command": "loopx explore summary --goal-id <goal-id> --format json",
+                "purpose": "Fold canonical result events into the bounded operator projection.",
+                "write_boundary": "read-only projection over the goal result log",
+            },
+        ],
+        "implemented_protocols": [
+            {
+                "schema_version": "loopx_explore_result_event_v0",
+                "module": "loopx.capabilities.explore.result_log",
+                "doc": "docs/capabilities/explore/README.md",
+            },
+            {
+                "schema_version": "loopx_explore_result_projection_v0",
+                "module": "loopx.capabilities.explore.result_log",
+                "doc": "docs/capabilities/explore/README.md",
+            },
+        ],
+        "smokes": [
+            "python3 examples/explore-result-layer-smoke.py",
+            "python3 examples/explore-todo-result-node-linkage-smoke.py",
+        ],
+        "docs": ["docs/capabilities/explore/README.md"],
+        "boundaries": [
+            "Canonical result events are the source of truth; Lark and other sinks render projections only.",
+            "Evidence refs must be public-safe relative refs or opaque ids, never credentials, raw private payloads, or local absolute paths.",
+        ],
+        "next_real_step": (
+            "Register findings and terminal outcomes through the result log before refreshing any display sink."
+        ),
+    },
+    {
+        "id": "auto-research",
+        "origin": "builtin",
+        "visibility": "public",
+        "provider_id": "loopx-core",
+        "title": "Decentralized auto-research preset",
+        "status": "experimental",
+        "real_world_anchor": (
+            "one-question research contracts with role-scoped workers, evidence packets, and a visible frontier"
+        ),
+        "user_value": (
+            "Launch a thin multi-agent research recipe while reusing LoopX todo, quota, "
+            "history, evidence, and continuation contracts."
+        ),
+        "entry_command": "loopx auto-research <open-question>",
+        "commands": [
+            {
+                "command": "loopx auto-research <open-question>",
+                "purpose": "Render the fixed one-question contract, bounded plan, and exact start command.",
+                "write_boundary": "stateless contract output only",
+            },
+            {
+                "command": "loopx auto-research start <open-question> --execute",
+                "purpose": "Create an isolated goal and launch visible role-scoped workers through the shared multi-agent runtime.",
+                "write_boundary": "local goal, workspace, and visible launcher state; no publication, benchmark submission, or protected external action",
+            },
+        ],
+        "implemented_protocols": [
+            {
+                "schema_version": "auto_research_user_contract_v0",
+                "module": "loopx.capabilities.auto_research.user_contract",
+                "doc": "docs/guides/auto-research-command-path.md",
+            },
+            {
+                "schema_version": "decentralized_auto_research_projection_v0",
+                "module": "loopx.capabilities.auto_research.research_state",
+                "doc": "docs/reference/protocols/decentralized-auto-research-state-v0.md",
+            },
+        ],
+        "smokes": [
+            "python3 examples/auto-research-user-contract-entry-smoke.py",
+            "python3 examples/auto-research-worker-turn-smoke.py",
+        ],
+        "docs": [
+            "docs/guides/auto-research-command-path.md",
+            "docs/product/decentralized-auto-research-showcase.md",
+        ],
+        "boundaries": [
+            "The preset reuses shared control-plane and multi-agent contracts; it is not a second scheduler or runner.",
+            "Completion and uplift require role-authored evidence and projected outcomes; the launcher does not manufacture research results.",
+        ],
+        "next_real_step": (
+            "Use the one-question entrypoint for bounded research and preserve every promoted or rejected outcome in canonical evidence."
+        ),
+    },
 )
 
 # Preserve the original import surface while routing all reads through the registry.
@@ -711,6 +818,7 @@ def _summary(record: Mapping[str, Any]) -> dict[str, Any]:
         "origin": record["origin"],
         "visibility": record["visibility"],
         "provider_id": record["provider_id"],
+        "provider_state": record["provider_state"],
         "real_world_anchor": record["real_world_anchor"],
         "entry_command": record["entry_command"],
         "implemented_protocol_count": len(record.get("implemented_protocols") or []),
@@ -724,19 +832,26 @@ def _summary(record: Mapping[str, Any]) -> dict[str, Any]:
 
 def build_capability_registry(
     extension_manifest_paths: Iterable[str | Path] = (),
+    *,
+    extension_state_file: str | Path | None = None,
 ) -> CapabilityRegistry:
     registry = CapabilityRegistry()
     registry.register_provider(
         {
             "id": "loopx-core",
             "origin": "builtin",
+            "declared": True,
+            "installed": True,
             "enabled": True,
+            "ready": True,
         }
     )
     for record in BUILTIN_CAPABILITIES:
         registry.register_capability(record)
-    for manifest_path in extension_manifest_paths:
-        manifest = load_extension_manifest(manifest_path)
+    for manifest in extension_catalog_entries(
+        extension_manifest_paths,
+        state_file=extension_state_file,
+    ):
         registry.register_provider(manifest["provider"])
         for record in manifest["capabilities"]:
             registry.register_capability(record)
@@ -749,8 +864,12 @@ def capability_ids(
     extension_manifest_paths: Iterable[str | Path] = (),
     *,
     include_internal: bool = False,
+    extension_state_file: str | Path | None = None,
 ) -> list[str]:
-    return build_capability_registry(extension_manifest_paths).capability_ids(
+    return build_capability_registry(
+        extension_manifest_paths,
+        extension_state_file=extension_state_file,
+    ).capability_ids(
         include_internal=include_internal
     )
 
@@ -760,8 +879,12 @@ def get_capability(
     extension_manifest_paths: Iterable[str | Path] = (),
     *,
     include_internal: bool = False,
+    extension_state_file: str | Path | None = None,
 ) -> dict[str, Any]:
-    return build_capability_registry(extension_manifest_paths).get(
+    return build_capability_registry(
+        extension_manifest_paths,
+        extension_state_file=extension_state_file,
+    ).get(
         capability_id,
         include_internal=include_internal,
     )
@@ -769,8 +892,13 @@ def get_capability(
 
 def build_capability_catalog_packet(
     extension_manifest_paths: Iterable[str | Path] = (),
+    *,
+    extension_state_file: str | Path | None = None,
 ) -> dict[str, Any]:
-    registry = build_capability_registry(extension_manifest_paths)
+    registry = build_capability_registry(
+        extension_manifest_paths,
+        extension_state_file=extension_state_file,
+    )
     return {
         "ok": True,
         "schema_version": CAPABILITY_CATALOG_SCHEMA_VERSION,
@@ -782,8 +910,14 @@ def build_capability_catalog_packet(
 def build_capability_detail_packet(
     capability_id: str,
     extension_manifest_paths: Iterable[str | Path] = (),
+    *,
+    extension_state_file: str | Path | None = None,
 ) -> dict[str, Any]:
-    record = get_capability(capability_id, extension_manifest_paths)
+    record = get_capability(
+        capability_id,
+        extension_manifest_paths,
+        extension_state_file=extension_state_file,
+    )
     return {
         "ok": True,
         "schema_version": CAPABILITY_DETAIL_SCHEMA_VERSION,
@@ -802,6 +936,7 @@ def render_capability_catalog_markdown(payload: dict[str, Any]) -> str:
                 "",
                 f"- status: `{item.get('status')}`",
                 f"- provider: `{item.get('provider_id')}` ({item.get('origin')})",
+                f"- provider_state: `{item.get('provider_state')}`",
                 f"- visibility: `{item.get('visibility')}`",
                 f"- anchor: {item.get('real_world_anchor')}",
                 f"- entry: `{item.get('entry_command')}`",
@@ -825,6 +960,7 @@ def render_capability_detail_markdown(payload: dict[str, Any]) -> str:
         f"- id: `{record.get('id')}`",
         f"- status: `{record.get('status')}`",
         f"- provider: `{record.get('provider_id')}` ({record.get('origin')})",
+        f"- provider_state: `{record.get('provider_state')}`",
         f"- visibility: `{record.get('visibility')}`",
         f"- anchor: {record.get('real_world_anchor')}",
         f"- value: {record.get('user_value')}",

--- a/loopx/capabilities/context_providers/__init__.py
+++ b/loopx/capabilities/context_providers/__init__.py
@@ -8,12 +8,18 @@ from .base import (
     ContextProviderRetrieval,
     ContextProviderSync,
 )
-from .openviking import OpenVikingContextProvider
-from .factory import build_context_provider
+from .factory import build_context_provider, register_context_provider
+from .openviking import (
+    OpenVikingContextProvider,
+    build_openviking_context_provider,
+)
 from .service_ownership import (
     context_provider_service_restarted,
     load_context_provider_service_ownership,
 )
+
+
+register_context_provider("openviking", build_openviking_context_provider)
 
 __all__ = [
     "ContextProviderItem",
@@ -21,6 +27,7 @@ __all__ = [
     "ContextProviderSync",
     "OpenVikingContextProvider",
     "build_context_provider",
+    "register_context_provider",
     "context_provider_service_restarted",
     "load_context_provider_service_ownership",
     "canonical_context_text",

--- a/loopx/capabilities/context_providers/factory.py
+++ b/loopx/capabilities/context_providers/factory.py
@@ -1,20 +1,32 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from typing import Any
 
 from .base import ContextProvider
-from .openviking import OpenVikingContextProvider
+
+
+ContextProviderBuilder = Callable[[Mapping[str, Any]], ContextProvider]
+_CONTEXT_PROVIDER_BUILDERS: dict[str, ContextProviderBuilder] = {}
+
+
+def register_context_provider(
+    provider_id: str,
+    builder: ContextProviderBuilder,
+) -> None:
+    normalized = str(provider_id or "").strip()
+    if not normalized:
+        raise ValueError("context provider id is required")
+    if normalized in _CONTEXT_PROVIDER_BUILDERS:
+        raise ValueError(f"context provider already registered: {normalized}")
+    _CONTEXT_PROVIDER_BUILDERS[normalized] = builder
 
 
 def build_context_provider(config: Mapping[str, Any]) -> ContextProvider:
     """Resolve one configured provider without capability-specific branching."""
 
     provider_id = str(config.get("provider") or "").strip()
-    if provider_id == "openviking":
-        return OpenVikingContextProvider(
-            executable=str(config.get("provider_binary") or "ov"),
-            minimum_version=str(config.get("minimum_provider_version") or "0.4.9"),
-            actor_peer_id=str(config.get("actor_peer_id") or "").strip() or None,
-        )
-    raise ValueError(f"unsupported context provider: {provider_id or '<missing>'}")
+    builder = _CONTEXT_PROVIDER_BUILDERS.get(provider_id)
+    if builder is None:
+        raise ValueError(f"unsupported context provider: {provider_id or '<missing>'}")
+    return builder(config)

--- a/loopx/capabilities/context_providers/openviking.py
+++ b/loopx/capabilities/context_providers/openviking.py
@@ -688,3 +688,15 @@ class OpenVikingContextProvider:
             reconciliation_performed=reconciliation_performed,
             retry_disposition=retry_disposition,
         )
+
+
+def build_openviking_context_provider(
+    config: Mapping[str, Any],
+) -> OpenVikingContextProvider:
+    return OpenVikingContextProvider(
+        executable=str(config.get("provider_binary") or "ov"),
+        minimum_version=str(
+            config.get("minimum_provider_version") or DEFAULT_MINIMUM_VERSION
+        ),
+        actor_peer_id=str(config.get("actor_peer_id") or "").strip() or None,
+    )

--- a/loopx/capabilities/registry.py
+++ b/loopx/capabilities/registry.py
@@ -25,7 +25,7 @@ def _required_string(record: Mapping[str, Any], key: str, *, context: str) -> st
 
 
 class CapabilityRegistry:
-    """Compose capability records from built-in and enabled extension providers."""
+    """Compose capability records and their provider lifecycle truth."""
 
     def __init__(self) -> None:
         self._providers: dict[str, dict[str, Any]] = {}
@@ -47,7 +47,24 @@ class CapabilityRegistry:
         normalized = deepcopy(dict(provider))
         normalized["id"] = provider_id
         normalized["origin"] = origin
-        normalized["enabled"] = bool(provider.get("enabled", True))
+        declared = bool(provider.get("declared", True))
+        installed = bool(provider.get("installed", origin == "builtin"))
+        enabled = bool(provider.get("enabled", installed))
+        ready = bool(provider.get("ready", enabled))
+        if installed and not declared:
+            raise ValueError(f"provider `{provider_id}` cannot be installed but undeclared")
+        if enabled and not installed:
+            raise ValueError(f"provider `{provider_id}` cannot be enabled but uninstalled")
+        if ready and not enabled:
+            raise ValueError(f"provider `{provider_id}` cannot be ready but disabled")
+        normalized.update(
+            {
+                "declared": declared,
+                "installed": installed,
+                "enabled": enabled,
+                "ready": ready,
+            }
+        )
         self._providers[provider_id] = normalized
 
     def register_capability(self, record: Mapping[str, Any]) -> None:
@@ -121,9 +138,23 @@ class CapabilityRegistry:
 
     def _with_implementations(self, record: Mapping[str, Any]) -> dict[str, Any]:
         normalized = deepcopy(dict(record))
+        provider = self._providers[str(record["provider_id"])]
+        normalized["provider_state"] = {
+            key: bool(provider[key])
+            for key in ("declared", "installed", "enabled", "ready")
+        }
         implementations = self._implementations.get(str(record["id"]), [])
         if implementations:
-            normalized["implementation_providers"] = deepcopy(implementations)
+            normalized["implementation_providers"] = [
+                deepcopy(item)
+                | {
+                    "provider_state": {
+                        key: bool(self._providers[str(item["provider_id"])][key])
+                        for key in ("declared", "installed", "enabled", "ready")
+                    }
+                }
+                for item in implementations
+            ]
         return normalized
 
     def capability_ids(self, *, include_internal: bool = False) -> list[str]:

--- a/loopx/capabilities/semantic_preference/contract.py
+++ b/loopx/capabilities/semantic_preference/contract.py
@@ -11,6 +11,8 @@ from typing import Any, Mapping, Sequence
 from ...extensions.runtime import (
     default_extension_state_file,
     doctor_installed_extension,
+    resolve_capability_binding,
+    resolve_capability_extension_id,
     resolve_extension_binding,
 )
 
@@ -144,13 +146,31 @@ def _extension_state_file(
     return Path(value).expanduser()
 
 
+def _uses_extension_provider(provider: Mapping[str, Any]) -> bool:
+    return _extension_id(provider) is not None or provider.get("argv") is None
+
+
+def _resolved_extension_id(
+    provider: Mapping[str, Any],
+    *,
+    runtime_root: str | Path | None = None,
+) -> str:
+    extension_id = _extension_id(provider)
+    if extension_id is not None:
+        return extension_id
+    return resolve_capability_extension_id(
+        state_file=_extension_state_file(provider, runtime_root),
+        capability_id="semantic-preference",
+        protocol=SEMANTIC_PREFERENCE_PROTOCOL,
+    )
+
+
 def _provider_binding(
     provider: Mapping[str, Any],
     *,
     runtime_root: str | Path | None = None,
 ) -> tuple[list[str], int]:
-    extension_id = _extension_id(provider)
-    if extension_id is not None:
+    if _uses_extension_provider(provider):
         if provider.get("probe_argv") is not None:
             raise ValueError("extension providers use the extension doctor")
         if provider.get("timeout_seconds") is not None:
@@ -160,12 +180,22 @@ def _provider_binding(
             label="provider args",
             allow_empty=True,
         )
-        binding = resolve_extension_binding(
-            extension_id,
-            state_file=_extension_state_file(provider, runtime_root),
-            capability_id="semantic-preference",
-            protocol=SEMANTIC_PREFERENCE_PROTOCOL,
-            permission=SEMANTIC_PREFERENCE_PERMISSION,
+        extension_id = _extension_id(provider)
+        binding = (
+            resolve_extension_binding(
+                extension_id,
+                state_file=_extension_state_file(provider, runtime_root),
+                capability_id="semantic-preference",
+                protocol=SEMANTIC_PREFERENCE_PROTOCOL,
+                permission=SEMANTIC_PREFERENCE_PERMISSION,
+            )
+            if extension_id is not None
+            else resolve_capability_binding(
+                state_file=_extension_state_file(provider, runtime_root),
+                capability_id="semantic-preference",
+                protocol=SEMANTIC_PREFERENCE_PROTOCOL,
+                permission=SEMANTIC_PREFERENCE_PERMISSION,
+            )
         )
         return [*[str(value) for value in binding["argv"]], *args], int(
             binding["timeout_seconds"]
@@ -228,12 +258,11 @@ def provider_doctor(
     if not re.fullmatch(r"[a-z][a-z0-9_-]{0,63}", provider_id):
         raise ValueError("provider id must use lower-snake token syntax")
     hints = _setup_hints(provider)
-    extension_id = _extension_id(provider)
-    if extension_id is not None:
+    if _uses_extension_provider(provider):
         if provider.get("probe_argv") is not None:
             raise ValueError("extension providers use the extension doctor")
         doctor = doctor_installed_extension(
-            extension_id,
+            _resolved_extension_id(provider, runtime_root=runtime_root),
             state_file=_extension_state_file(provider, runtime_root),
             execute=execute,
         )
@@ -431,7 +460,7 @@ def recall(
     try:
         argv, timeout = _provider_binding(provider, runtime_root=runtime_root)
     except ValueError:
-        if execute and provider.get("extension_id") is not None:
+        if execute and _uses_extension_provider(provider):
             return _unavailable(surface_id, policy, "extension_binding_unavailable")
         raise
     request = {

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -336,6 +336,7 @@ def main(argv: list[str] | None = None) -> int:
 
     capability_result = handle_capability_command(
         args,
+        runtime_root_arg=args.runtime_root,
         output_format=output_format,
         print_payload=print_payload,
     )

--- a/loopx/cli_commands/capability.py
+++ b/loopx/cli_commands/capability.py
@@ -9,6 +9,7 @@ from ..capabilities.catalog import (
     render_capability_catalog_markdown,
     render_capability_detail_markdown,
 )
+from ..extensions.runtime import default_extension_state_file
 
 
 PrintPayload = Callable[
@@ -25,8 +26,8 @@ def _add_extension_manifest_argument(parser: argparse.ArgumentParser) -> None:
         action="append",
         default=[],
         help=(
-            "Explicitly enable one declarative extension manifest for this "
-            "catalog read. Repeat for multiple manifests."
+            "Declare one extension manifest for this catalog read without "
+            "installing or enabling it. Repeat for multiple manifests."
         ),
     )
     parser.set_defaults(capability_operation_parser=parser)
@@ -65,20 +66,26 @@ def register_capability_commands(
 def handle_capability_command(
     args: argparse.Namespace,
     *,
+    runtime_root_arg: str | None,
     output_format: FormatSelector,
     print_payload: PrintPayload,
 ) -> int | None:
     if args.command != "capability":
         return None
     manifest_paths = tuple(args.extension_manifest)
+    state_file = default_extension_state_file(runtime_root_arg)
     try:
         if args.capability_command == "list":
-            payload = build_capability_catalog_packet(manifest_paths)
+            payload = build_capability_catalog_packet(
+                manifest_paths,
+                extension_state_file=state_file,
+            )
             renderer = render_capability_catalog_markdown
         elif args.capability_command == "show":
             payload = build_capability_detail_packet(
                 args.capability_id,
                 manifest_paths,
+                extension_state_file=state_file,
             )
             renderer = render_capability_detail_markdown
         else:

--- a/loopx/extensions/manifest.py
+++ b/loopx/extensions/manifest.py
@@ -217,7 +217,10 @@ def load_extension_manifest(path: str | Path) -> dict[str, Any]:
         "provider": {
             "id": extension_id,
             "origin": "extension",
-            "enabled": True,
+            "declared": True,
+            "installed": False,
+            "enabled": False,
+            "ready": False,
             "version": version,
             "requires_loopx_api": requires_loopx_api,
             "permissions": permissions,

--- a/loopx/extensions/runtime.py
+++ b/loopx/extensions/runtime.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from contextlib import nullcontext
 from copy import deepcopy
 import hashlib
@@ -471,6 +471,102 @@ def _verified_entrypoint(
     return identity
 
 
+def _active_manifest(entry: Mapping[str, Any]) -> Mapping[str, Any]:
+    active_revision = str(entry.get("active_revision") or "")
+    snapshot = _entry_for_revision(entry, active_revision)
+    manifest = snapshot.get("manifest")
+    if not isinstance(manifest, Mapping):
+        raise ValueError("extension active manifest is invalid")
+    return manifest
+
+
+def extension_catalog_entries(
+    extension_manifest_paths: Iterable[str | Path] = (),
+    *,
+    state_file: str | Path | None = None,
+) -> list[dict[str, Any]]:
+    """Compose declared manifests with installed runtime lifecycle state."""
+
+    manifests: dict[str, Mapping[str, Any]] = {}
+    lifecycle: dict[str, dict[str, Any]] = {}
+    for manifest_path in extension_manifest_paths:
+        manifest = load_extension_manifest(manifest_path)
+        extension_id = str(manifest["provider"]["id"])
+        if extension_id in manifests:
+            raise ValueError(f"duplicate capability provider `{extension_id}`")
+        manifests[extension_id] = manifest
+        lifecycle[extension_id] = {
+            "declared": True,
+            "installed": False,
+            "enabled": False,
+            "ready": False,
+        }
+
+    if state_file is not None:
+        state = _read_state(Path(state_file).expanduser())
+        for extension_id, entry in state["extensions"].items():
+            if not isinstance(entry, Mapping):
+                raise ValueError(f"extension `{extension_id}` runtime entry is invalid")
+            manifest = _active_manifest(entry)
+            provider = manifest.get("provider")
+            if not isinstance(provider, Mapping) or provider.get("id") != extension_id:
+                raise ValueError(f"extension `{extension_id}` active manifest is invalid")
+            manifests[extension_id] = manifest
+            enabled = bool(entry.get("enabled"))
+            lifecycle[extension_id] = {
+                "declared": True,
+                "installed": True,
+                "enabled": enabled,
+                "ready": enabled and _verified_entrypoint(entry) is not None,
+                "active_revision": str(entry.get("active_revision") or ""),
+            }
+
+    entries: list[dict[str, Any]] = []
+    for extension_id, manifest in manifests.items():
+        normalized = deepcopy(dict(manifest))
+        normalized["provider"] = deepcopy(dict(manifest["provider"])) | lifecycle[
+            extension_id
+        ]
+        entries.append(normalized)
+    return entries
+
+
+def resolve_capability_extension_id(
+    *,
+    state_file: str | Path,
+    capability_id: str,
+    protocol: str,
+) -> str:
+    """Resolve one ready extension implementation without caller aliases."""
+
+    matching: list[str] = []
+    for entry in extension_catalog_entries(state_file=state_file):
+        provider = entry.get("provider")
+        if not isinstance(provider, Mapping) or not provider.get("ready"):
+            continue
+        implementations = entry.get("implementations")
+        if not isinstance(implementations, list):
+            continue
+        if any(
+            isinstance(item, Mapping)
+            and item.get("capability_id") == capability_id
+            and item.get("protocol") == protocol
+            for item in implementations
+        ):
+            matching.append(str(entry["provider"]["id"]))
+    if not matching:
+        raise ValueError(
+            f"no enabled, doctor-ready extension implements `{capability_id}` "
+            f"with protocol `{protocol}`"
+        )
+    if len(matching) != 1:
+        raise ValueError(
+            f"multiple enabled, doctor-ready extensions implement `{capability_id}` "
+            f"with protocol `{protocol}`: {matching}"
+        )
+    return matching[0]
+
+
 def _resolved_active_extension(
     extension_id: str,
     *,
@@ -486,10 +582,7 @@ def _resolved_active_extension(
     verified_entrypoint = _verified_entrypoint(entry)
     if verified_entrypoint is None:
         raise ValueError(f"extension `{extension_id}` doctor readiness is stale")
-    snapshot = _entry_for_revision(entry, active_revision)
-    manifest = snapshot.get("manifest")
-    if not isinstance(manifest, Mapping):
-        raise ValueError("extension active manifest is invalid")
+    manifest = _active_manifest(entry)
     return active_revision, verified_entrypoint, manifest
 
 
@@ -586,3 +679,24 @@ def resolve_extension_binding(
         ],
         "timeout_seconds": runtime["timeout_seconds"],
     }
+
+
+def resolve_capability_binding(
+    *,
+    state_file: str | Path,
+    capability_id: str,
+    protocol: str,
+    permission: str,
+) -> dict[str, Any]:
+    extension_id = resolve_capability_extension_id(
+        state_file=state_file,
+        capability_id=capability_id,
+        protocol=protocol,
+    )
+    return resolve_extension_binding(
+        extension_id,
+        state_file=state_file,
+        capability_id=capability_id,
+        protocol=protocol,
+        permission=permission,
+    )

--- a/tests/capabilities/test_capability_extension_registry.py
+++ b/tests/capabilities/test_capability_extension_registry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import sys
 
 import pytest
 
@@ -10,7 +11,16 @@ from loopx.capabilities.catalog import (
     build_capability_detail_packet,
     build_capability_registry,
 )
+from loopx.capabilities.context_providers import (
+    OpenVikingContextProvider,
+    build_context_provider,
+)
 from loopx.cli import main
+from loopx.extensions.runtime import (
+    default_extension_state_file,
+    disable_extension,
+    install_extension,
+)
 
 
 BUILTIN_IDS = [
@@ -19,10 +29,30 @@ BUILTIN_IDS = [
     "reward-memory",
     "content-ops",
     "value-connectors",
+    "explore",
+    "auto-research",
 ]
 
 
-def _write_manifest(path: Path, *, capability_id: str = "sample-report") -> Path:
+def _write_manifest(
+    path: Path,
+    *,
+    capability_id: str = "sample-report",
+    entrypoint: Path | None = None,
+) -> Path:
+    runtime = (
+        ""
+        if entrypoint is None
+        else f'''\
+
+[runtime]
+protocol = "sample_report_provider_v0"
+entrypoint = {json.dumps(str(entrypoint))}
+doctor_args = ["--doctor"]
+required_permissions = []
+timeout_seconds = 5
+'''
+    )
     path.write_text(
         f'''\
 schema_version = "loopx_extension_manifest_v0"
@@ -30,7 +60,7 @@ id = "sample-extension"
 version = "1.2.3"
 requires_loopx_api = ">=1,<2"
 permissions = ["read_status"]
-runtime_entrypoint = "module.that.must.not.be.imported"
+{runtime}
 
 [[provides]]
 id = "{capability_id}"
@@ -69,11 +99,18 @@ def test_builtin_catalog_preserves_order_and_marks_provider() -> None:
         assert item["visibility"] == "public"
         assert item["provider_id"] == "loopx-core"
     assert packet["providers"] == [
-        {"id": "loopx-core", "origin": "builtin", "enabled": True}
+        {
+            "id": "loopx-core",
+            "origin": "builtin",
+            "declared": True,
+            "installed": True,
+            "enabled": True,
+            "ready": True,
+        }
     ]
 
 
-def test_enabled_manifest_composes_public_capability_without_importing_code(
+def test_declared_manifest_composes_public_capability_without_claiming_readiness(
     tmp_path: Path,
 ) -> None:
     manifest = _write_manifest(tmp_path / "extension.toml")
@@ -90,10 +127,19 @@ def test_enabled_manifest_composes_public_capability_without_importing_code(
     assert packet["providers"][-1] == {
         "id": "sample-extension",
         "origin": "extension",
-        "enabled": True,
+        "declared": True,
+        "installed": False,
+        "enabled": False,
+        "ready": False,
         "version": "1.2.3",
         "requires_loopx_api": ">=1,<2",
         "permissions": ["read_status"],
+    }
+    assert extension["provider_state"] == {
+        "declared": True,
+        "installed": False,
+        "enabled": False,
+        "ready": False,
     }
 
     detail = build_capability_detail_packet("sample-report", [manifest])
@@ -144,12 +190,15 @@ def test_cli_lists_and_shows_explicit_extension_manifest(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     manifest = _write_manifest(tmp_path / "extension.toml")
+    runtime_root = tmp_path / "runtime"
 
     assert (
         main(
             [
                 "--format",
                 "json",
+                "--runtime-root",
+                str(runtime_root),
                 "capability",
                 "list",
                 "--extension-manifest",
@@ -166,6 +215,8 @@ def test_cli_lists_and_shows_explicit_extension_manifest(
             [
                 "--format",
                 "json",
+                "--runtime-root",
+                str(runtime_root),
                 "capability",
                 "show",
                 "sample-report",
@@ -177,6 +228,91 @@ def test_cli_lists_and_shows_explicit_extension_manifest(
     )
     shown = json.loads(capsys.readouterr().out)
     assert shown["capability"]["provider_id"] == "sample-extension"
+    assert shown["capability"]["provider_state"]["ready"] is False
+
+
+def test_installed_runtime_is_catalog_truth_and_cli_default(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    provider = tmp_path / "provider"
+    provider.write_text(
+        f"#!{sys.executable}\nimport sys\nraise SystemExit(0)\n",
+        encoding="utf-8",
+    )
+    provider.chmod(0o755)
+    manifest = _write_manifest(
+        tmp_path / "extension.toml",
+        entrypoint=provider,
+    )
+    runtime_root = tmp_path / "runtime"
+    state_file = default_extension_state_file(runtime_root)
+    install_extension(manifest, state_file=state_file, execute=True)
+
+    packet = build_capability_catalog_packet(extension_state_file=state_file)
+    extension = packet["capabilities"][-1]
+    assert extension["id"] == "sample-report"
+    assert extension["provider_state"] == {
+        "declared": True,
+        "installed": True,
+        "enabled": True,
+        "ready": True,
+    }
+
+    assert (
+        main(
+            [
+                "--runtime-root",
+                str(runtime_root),
+                "--format",
+                "json",
+                "capability",
+                "show",
+                "sample-report",
+            ]
+        )
+        == 0
+    )
+    shown = json.loads(capsys.readouterr().out)
+    assert shown["capability"]["provider_state"]["ready"] is True
+
+    disable_extension("sample-extension", state_file=state_file, execute=True)
+    disabled = build_capability_detail_packet(
+        "sample-report",
+        extension_state_file=state_file,
+    )
+    assert disabled["capability"]["provider_state"] == {
+        "declared": True,
+        "installed": True,
+        "enabled": False,
+        "ready": False,
+    }
+
+
+def test_active_explore_and_auto_research_records_point_to_real_smokes() -> None:
+    repository = Path(__file__).resolve().parents[2]
+    for capability_id in ("explore", "auto-research"):
+        record = build_capability_detail_packet(capability_id)["capability"]
+        assert record["provider_state"]["ready"] is True
+        assert record["smokes"]
+        for command in record["smokes"]:
+            prefix = "python3 "
+            assert command.startswith(prefix)
+            assert (repository / command.removeprefix(prefix)).is_file()
+
+
+def test_context_provider_factory_dispatches_through_registered_builder() -> None:
+    provider = build_context_provider(
+        {
+            "provider": "openviking",
+            "provider_binary": "custom-ov",
+            "actor_peer_id": "project-example",
+        }
+    )
+
+    assert isinstance(provider, OpenVikingContextProvider)
+    assert provider.executable == "custom-ov"
+    assert provider.actor_peer_id == "project-example"
 
 
 def test_cli_rejects_unknown_capability_without_traceback(

--- a/tests/extensions/test_extension_runtime.py
+++ b/tests/extensions/test_extension_runtime.py
@@ -11,7 +11,10 @@ import sys
 
 import pytest
 
-from loopx.capabilities.catalog import build_capability_detail_packet
+from loopx.capabilities.catalog import (
+    build_capability_catalog_packet,
+    build_capability_detail_packet,
+)
 from loopx.capabilities.semantic_preference.cli import (
     _register_legacy_openviking_provider_arguments,
 )
@@ -23,6 +26,8 @@ from loopx.extensions.runtime import (
     enable_extension,
     extension_status,
     install_extension,
+    resolve_capability_binding,
+    resolve_capability_extension_id,
     resolve_extension_activation,
     resolve_extension_binding,
     rollback_extension,
@@ -501,6 +506,29 @@ def test_semantic_preference_resolves_enabled_extension(tmp_path: Path) -> None:
     )
     state_file = tmp_path / "extensions.json"
     install_extension(manifest, state_file=state_file, execute=True)
+    assert (
+        resolve_capability_extension_id(
+            state_file=state_file,
+            capability_id="semantic-preference",
+            protocol="semantic_preference_provider_v0",
+        )
+        == "test-semantic-extension"
+    )
+    capability_binding = resolve_capability_binding(
+        state_file=state_file,
+        capability_id="semantic-preference",
+        protocol="semantic_preference_provider_v0",
+        permission="semantic_preference.read",
+    )
+    assert capability_binding["argv"] == [str(provider)]
+    catalog = build_capability_catalog_packet(extension_state_file=state_file)
+    catalog_provider = next(
+        item
+        for item in catalog["providers"]
+        if item["id"] == "test-semantic-extension"
+    )
+    assert catalog_provider["active_revision"] == capability_binding["revision"]
+    assert catalog_provider["ready"] is True
     project = tmp_path / "project"
     project.mkdir()
     config = tmp_path / "semantic-preference.json"
@@ -511,7 +539,6 @@ def test_semantic_preference_resolves_enabled_extension(tmp_path: Path) -> None:
                 "enabled": True,
                 "provider": {
                     "id": "openviking_semantic_preference",
-                    "extension_id": "test-semantic-extension",
                     "extension_state_file": str(state_file),
                     "args": ["--project", str(project)],
                 },
@@ -553,15 +580,56 @@ def test_semantic_preference_resolves_enabled_extension(tmp_path: Path) -> None:
     assert unavailable["status"] == "provider_unavailable"
     assert unavailable["failure_kind"] == "extension_binding_unavailable"
 
-    detail = build_capability_detail_packet("semantic-preference", [manifest])
+    detail = build_capability_detail_packet(
+        "semantic-preference",
+        extension_state_file=state_file,
+    )
     assert detail["capability"]["implementation_providers"] == [
         {
             "capability_id": "semantic-preference",
             "protocol": "semantic_preference_provider_v0",
             "provider_id": "test-semantic-extension",
             "provider_version": "1.0.0",
+            "provider_state": {
+                "declared": True,
+                "installed": True,
+                "enabled": False,
+                "ready": False,
+            },
         }
     ]
+
+
+def test_capability_resolution_ignores_disabled_implementations(
+    tmp_path: Path,
+) -> None:
+    provider = _provider(tmp_path / "provider")
+    state_file = tmp_path / "extensions.json"
+    for extension_id in ("first-provider", "second-provider"):
+        manifest = _manifest(
+            tmp_path / f"{extension_id}.toml",
+            entrypoint=provider,
+            version="1.0.0",
+            extension_id=extension_id,
+        )
+        install_extension(manifest, state_file=state_file, execute=True)
+
+    with pytest.raises(ValueError, match="multiple enabled, doctor-ready"):
+        resolve_capability_extension_id(
+            state_file=state_file,
+            capability_id="semantic-preference",
+            protocol="semantic_preference_provider_v0",
+        )
+
+    disable_extension("first-provider", state_file=state_file, execute=True)
+    assert (
+        resolve_capability_extension_id(
+            state_file=state_file,
+            capability_id="semantic-preference",
+            protocol="semantic_preference_provider_v0",
+        )
+        == "second-provider"
+    )
 
 
 def test_extension_cli_installs_preinstalled_runtime(


### PR DESCRIPTION
## Summary

- derive extension capability lifecycle from installed runtime state instead of declaration-only manifests
- resolve semantic-preference providers by capability/protocol while keeping explicit ids only for migration or disambiguation
- remove hardcoded OpenViking construction from the generic context-provider factory
- register shipped Explore and Auto Research capability outcomes in the public catalog

## Validation

- `791 passed, 2 skipped` with isolated local state
- focused extension/capability tests: `28 passed`
- Ruff and diff hygiene passed
- `loopx canary premerge --from-git-diff`: 18/18 selected checks passed, public boundary clean, no manual holds
