### PR TITLE
Refactor quota event Markdown ownership

### DIFF
--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -16,11 +16,13 @@ from ..status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, collect_status
 from ..upgrade import resolve_codex_app_automation_rrule
 from ..control_plane.quota.turn_envelope import build_turn_envelope
 from ..control_plane.quota.live_decision import build_live_quota_should_run_decision
-from ..control_plane.quota.monitor_poll import render_quota_monitor_poll_markdown
 from ..control_plane.quota.scheduler_ack import (
     record_quota_scheduler_failure_for_decision,
 )
-from ..control_plane.quota.slot_accounting import render_quota_slot_preview_markdown
+from ..presentation.renderers.quota_event_markdown import (
+    render_quota_monitor_poll_markdown,
+    render_quota_slot_preview_markdown,
+)
 from ..presentation.renderers.quota_markdown import (
     render_quota_markdown,
     render_quota_scheduler_ack_markdown,

--- a/loopx/control_plane/quota/monitor_poll.py
+++ b/loopx/control_plane/quota/monitor_poll.py
@@ -277,6 +277,7 @@ def record_quota_monitor_poll_for_decision(
     *,
     goal_id: str,
     after_decision: Callable[[dict[str, Any]], dict[str, Any]],
+    render_markdown: Callable[[dict[str, Any]], str],
     registry_path: Path | None = None,
     execute: bool = False,
     source: str = DEFAULT_SLOT_SPEND_SOURCE,
@@ -428,7 +429,7 @@ def record_quota_monitor_poll_for_decision(
     after_status = deepcopy(status_payload)
     if execute:
         json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-        markdown_path.write_text(render_quota_monitor_poll_markdown(record) + "\n", encoding="utf-8")
+        markdown_path.write_text(render_markdown(record) + "\n", encoding="utf-8")
         with index_path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
         run_history = after_status.get("run_history") if isinstance(after_status.get("run_history"), dict) else {}
@@ -477,54 +478,3 @@ def record_quota_monitor_poll_for_decision(
             f"{goal_id} effective_action={before.get('effective_action')}"
         ),
     }
-
-
-def render_quota_monitor_poll_markdown(payload: dict[str, Any]) -> str:
-    if payload.get("ok") is False:
-        return "\n".join(
-            [
-                "# LoopX Quota Monitor Poll",
-                "",
-                "- ok: `False`",
-                f"- mode: `{payload.get('mode') or 'monitor-poll'}`",
-                f"- goal_id: `{payload.get('goal_id') or ''}`",
-                f"- appended: `{bool(payload.get('appended'))}`",
-                f"- registry_mutated: `{bool(payload.get('registry_mutated'))}`",
-                f"- agent_id: `{payload.get('agent_id') or ''}`",
-                f"- source: `{payload.get('source') or ''}`",
-                f"- todo_id: `{payload.get('todo_id') or ''}`",
-                f"- target_key: `{payload.get('target_key') or ''}`",
-                f"- material_change: `{bool(payload.get('material_change'))}`",
-                f"- reason: {payload.get('reason') or 'monitor-poll rejected'}",
-            ]
-        )
-    event = payload.get("monitor_event") if isinstance(payload.get("monitor_event"), dict) else {}
-    before = event.get("before") if isinstance(event.get("before"), dict) else {}
-    todo_writeback = event.get("todo_writeback") if isinstance(event.get("todo_writeback"), dict) else {}
-    lines = [
-        "# LoopX Quota Monitor Poll",
-        "",
-        f"- goal_id: `{payload.get('goal_id')}`",
-        f"- classification: `{payload.get('classification')}`",
-        f"- agent_id: `{payload.get('agent_id') or event.get('agent_id') or ''}`",
-        f"- source: `{event.get('source')}`",
-        f"- effective_action: `{before.get('effective_action')}`",
-        f"- monitor_target: `{(event.get('monitor_target') or {}).get('target_id') if isinstance(event.get('monitor_target'), dict) else ''}`",
-        f"- todo_id: `{event.get('todo_id') or ''}`",
-        f"- target_key: `{event.get('target_key') or ''}`",
-        f"- material_change: `{event.get('material_change')}`",
-        f"- should_run: `{before.get('should_run')}`",
-        f"- self_repair_allowed: `{before.get('self_repair_allowed')}`",
-        f"- state: `{before.get('state')}`",
-        f"- health_check: {payload.get('health_check')}",
-        f"- reason: {event.get('reason_summary')}",
-    ]
-    if todo_writeback:
-        lines.append(
-            "- todo_writeback: "
-            f"dry_run={todo_writeback.get('dry_run')} "
-            f"consecutive_no_change={todo_writeback.get('consecutive_no_change')} "
-            f"last_checked_at={todo_writeback.get('last_checked_at')} "
-            f"next_due_at={todo_writeback.get('next_due_at')}"
-        )
-    return "\n".join(lines)

--- a/loopx/control_plane/quota/slot_accounting.py
+++ b/loopx/control_plane/quota/slot_accounting.py
@@ -668,6 +668,7 @@ def record_quota_slot_void_from_preview(
     status_payload: dict[str, Any],
     *,
     goal_id: str,
+    render_markdown: Callable[[dict[str, Any]], str],
     execute: bool = False,
     source: str = DEFAULT_SLOT_SPEND_SOURCE,
     reason_summary: str | None = None,
@@ -727,7 +728,7 @@ def record_quota_slot_void_from_preview(
         payload["after"] = record["quota_event"]["after"]
     if execute:
         json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-        markdown_path.write_text(render_quota_slot_preview_markdown(payload) + "\n", encoding="utf-8")
+        markdown_path.write_text(render_markdown(payload) + "\n", encoding="utf-8")
         with index_path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
     return payload
@@ -739,6 +740,7 @@ def record_quota_slot_spend_from_preview(
     *,
     goal_id: str,
     self_repair_spend_actions: set[str] | frozenset[str],
+    render_markdown: Callable[[dict[str, Any]], str],
     execute: bool = False,
     source: str = DEFAULT_SLOT_SPEND_SOURCE,
 ) -> dict[str, Any]:
@@ -798,53 +800,7 @@ def record_quota_slot_spend_from_preview(
         payload["after"] = record["quota_event"]["after"]
     if execute:
         json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-        markdown_path.write_text(render_quota_slot_preview_markdown(payload) + "\n", encoding="utf-8")
+        markdown_path.write_text(render_markdown(payload) + "\n", encoding="utf-8")
         with index_path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
     return payload
-
-
-def render_quota_slot_preview_markdown(payload: dict[str, Any]) -> str:
-    before = payload.get("before") if isinstance(payload.get("before"), dict) else {}
-    after = payload.get("after") if isinstance(payload.get("after"), dict) else {}
-    before_quota = before.get("quota") if isinstance(before.get("quota"), dict) else before
-    after_quota = after.get("quota") if isinstance(after.get("quota"), dict) else after
-    lines = [
-        "# LoopX Quota Slot Preview",
-        "",
-        f"- ok: `{payload.get('ok')}`",
-        f"- dry_run: `{payload.get('dry_run')}`",
-        f"- goal_id: `{payload.get('goal_id')}`",
-        f"- classification: `{payload.get('classification') or QUOTA_SLOT_SPENT_CLASSIFICATION}`",
-        f"- agent_id: `{payload.get('agent_id') or ''}`",
-        f"- slots: `{payload.get('slots')}`",
-        f"- appended: `{payload.get('appended')}`",
-        f"- registry_mutated: `{payload.get('registry_mutated')}`",
-        f"- would_throttle: `{payload.get('would_throttle')}`",
-    ]
-    if payload.get("json_path"):
-        lines.append(f"- json_path: `{payload.get('json_path')}`")
-    if payload.get("index_path"):
-        lines.append(f"- index_path: `{payload.get('index_path')}`")
-    if payload.get("reason"):
-        lines.append(f"- reason: {payload.get('reason')}")
-    if before:
-        lines.append(
-            "- before: "
-            f"state={before.get('state')} "
-            f"should_run={before.get('should_run')} "
-            f"slots={before_quota.get('spent_slots')}/{before_quota.get('allowed_slots')}"
-        )
-    if after:
-        lines.append(
-            "- after: "
-            f"state={after.get('state')} "
-            f"should_run={after.get('should_run')} "
-            f"slots={after_quota.get('spent_slots')}/{after_quota.get('allowed_slots')}"
-        )
-        summary = after.get("plan_summary") if isinstance(after.get("plan_summary"), dict) else {}
-        if summary:
-            lines.append(f"- after_plan_next_automatic_turn: {summary.get('next_automatic_turn') or 'none'}")
-    if payload.get("rolling_window_note"):
-        lines.append(f"- rolling_window_note: {payload.get('rolling_window_note')}")
-    return "\n".join(lines)

--- a/loopx/presentation/renderers/quota_event_markdown.py
+++ b/loopx/presentation/renderers/quota_event_markdown.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ...control_plane.quota.slot_accounting import QUOTA_SLOT_SPENT_CLASSIFICATION
+from ..markdown import as_dict
+
+
+def render_quota_monitor_poll_markdown(payload: dict[str, Any]) -> str:
+    if payload.get("ok") is False:
+        return "\n".join(
+            [
+                "# LoopX Quota Monitor Poll",
+                "",
+                "- ok: `False`",
+                f"- mode: `{payload.get('mode') or 'monitor-poll'}`",
+                f"- goal_id: `{payload.get('goal_id') or ''}`",
+                f"- appended: `{bool(payload.get('appended'))}`",
+                f"- registry_mutated: `{bool(payload.get('registry_mutated'))}`",
+                f"- agent_id: `{payload.get('agent_id') or ''}`",
+                f"- source: `{payload.get('source') or ''}`",
+                f"- todo_id: `{payload.get('todo_id') or ''}`",
+                f"- target_key: `{payload.get('target_key') or ''}`",
+                f"- material_change: `{bool(payload.get('material_change'))}`",
+                f"- reason: {payload.get('reason') or 'monitor-poll rejected'}",
+            ]
+        )
+    event = as_dict(payload.get("monitor_event"))
+    before = as_dict(event.get("before"))
+    todo_writeback = as_dict(event.get("todo_writeback"))
+    monitor_target = as_dict(event.get("monitor_target"))
+    lines = [
+        "# LoopX Quota Monitor Poll",
+        "",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- classification: `{payload.get('classification')}`",
+        f"- agent_id: `{payload.get('agent_id') or event.get('agent_id') or ''}`",
+        f"- source: `{event.get('source')}`",
+        f"- effective_action: `{before.get('effective_action')}`",
+        f"- monitor_target: `{monitor_target.get('target_id')}`",
+        f"- todo_id: `{event.get('todo_id') or ''}`",
+        f"- target_key: `{event.get('target_key') or ''}`",
+        f"- material_change: `{event.get('material_change')}`",
+        f"- should_run: `{before.get('should_run')}`",
+        f"- self_repair_allowed: `{before.get('self_repair_allowed')}`",
+        f"- state: `{before.get('state')}`",
+        f"- health_check: {payload.get('health_check')}",
+        f"- reason: {event.get('reason_summary')}",
+    ]
+    if todo_writeback:
+        lines.append(
+            "- todo_writeback: "
+            f"dry_run={todo_writeback.get('dry_run')} "
+            f"consecutive_no_change={todo_writeback.get('consecutive_no_change')} "
+            f"last_checked_at={todo_writeback.get('last_checked_at')} "
+            f"next_due_at={todo_writeback.get('next_due_at')}"
+        )
+    return "\n".join(lines)
+
+
+def render_quota_slot_preview_markdown(payload: dict[str, Any]) -> str:
+    before = as_dict(payload.get("before"))
+    after = as_dict(payload.get("after"))
+    before_quota = (
+        as_dict(before.get("quota"))
+        if isinstance(before.get("quota"), dict)
+        else before
+    )
+    after_quota = (
+        as_dict(after.get("quota"))
+        if isinstance(after.get("quota"), dict)
+        else after
+    )
+    lines = [
+        "# LoopX Quota Slot Preview",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- dry_run: `{payload.get('dry_run')}`",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- classification: `{payload.get('classification') or QUOTA_SLOT_SPENT_CLASSIFICATION}`",
+        f"- agent_id: `{payload.get('agent_id') or ''}`",
+        f"- slots: `{payload.get('slots')}`",
+        f"- appended: `{payload.get('appended')}`",
+        f"- registry_mutated: `{payload.get('registry_mutated')}`",
+        f"- would_throttle: `{payload.get('would_throttle')}`",
+    ]
+    if payload.get("json_path"):
+        lines.append(f"- json_path: `{payload.get('json_path')}`")
+    if payload.get("index_path"):
+        lines.append(f"- index_path: `{payload.get('index_path')}`")
+    if payload.get("reason"):
+        lines.append(f"- reason: {payload.get('reason')}")
+    if before:
+        lines.append(
+            "- before: "
+            f"state={before.get('state')} "
+            f"should_run={before.get('should_run')} "
+            f"slots={before_quota.get('spent_slots')}/{before_quota.get('allowed_slots')}"
+        )
+    if after:
+        lines.append(
+            "- after: "
+            f"state={after.get('state')} "
+            f"should_run={after.get('should_run')} "
+            f"slots={after_quota.get('spent_slots')}/{after_quota.get('allowed_slots')}"
+        )
+        summary = as_dict(after.get("plan_summary"))
+        if summary:
+            lines.append(
+                f"- after_plan_next_automatic_turn: {summary.get('next_automatic_turn') or 'none'}"
+            )
+    if payload.get("rolling_window_note"):
+        lines.append(f"- rolling_window_note: {payload.get('rolling_window_note')}")
+    return "\n".join(lines)

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -75,11 +75,8 @@ from .control_plane.quota.recent_runs import (
     goal_latest_runs as _goal_latest_runs,
     recent_external_monitor_observation_unchanged as _recent_external_monitor_observation_unchanged,
 )
-from .presentation.renderers.quota_markdown import (
-    render_quota_markdown as render_quota_markdown,
-    render_quota_scheduler_ack_markdown as render_quota_scheduler_ack_markdown,
-    render_quota_should_run_markdown as render_quota_should_run_markdown,
-)
+from .presentation.renderers.quota_event_markdown import render_quota_monitor_poll_markdown as _render_quota_monitor_poll_markdown, render_quota_slot_preview_markdown as _render_quota_slot_preview_markdown, render_quota_slot_preview_markdown as render_quota_slot_preview_markdown
+from .presentation.renderers.quota_markdown import render_quota_markdown as render_quota_markdown, render_quota_scheduler_ack_markdown as render_quota_scheduler_ack_markdown, render_quota_should_run_markdown as render_quota_should_run_markdown
 from .control_plane.quota.scheduler_ack import (
     QUOTA_SCHEDULER_ACK_CLASSIFICATION,
     record_quota_scheduler_ack_for_decision,
@@ -109,7 +106,6 @@ from .control_plane.quota.slot_accounting import (
     load_quota_event_from_run,
     record_quota_slot_spend_from_preview,
     record_quota_slot_void_from_preview,
-    render_quota_slot_preview_markdown as render_quota_slot_preview_markdown,
 )
 from .control_plane.quota.spend_sources import (
     DEFAULT_SLOT_SPEND_SOURCE,
@@ -191,7 +187,7 @@ _PUBLIC_COMPAT_REEXPORTS = {
     "render_quota_scheduler_ack_markdown": "loopx.presentation.renderers.quota_markdown",
     "render_quota_should_run_markdown": "loopx.presentation.renderers.quota_markdown",
     "build_quota_slot_void_event": "loopx.control_plane.quota.slot_accounting",
-    "render_quota_slot_preview_markdown": "loopx.control_plane.quota.slot_accounting",
+    "render_quota_slot_preview_markdown": "loopx.presentation.renderers.quota_event_markdown",
 }
 
 
@@ -2354,6 +2350,7 @@ def record_quota_monitor_poll(
         before,
         status_payload,
         goal_id=safe_goal_id,
+        render_markdown=_render_quota_monitor_poll_markdown,
         after_decision=lambda after_status: build_quota_should_run(
             after_status,
             goal_id=safe_goal_id,
@@ -2418,6 +2415,7 @@ def void_quota_slot(
         preview,
         status_payload,
         goal_id=safe_goal_id,
+        render_markdown=_render_quota_slot_preview_markdown,
         execute=execute,
         source=source,
         reason_summary=reason_summary,
@@ -2450,6 +2448,7 @@ def spend_quota_slot(
         status_payload,
         goal_id=safe_goal_id,
         self_repair_spend_actions=SELF_REPAIR_SPEND_ACTIONS,
+        render_markdown=_render_quota_slot_preview_markdown,
         execute=execute,
         source=source,
     )

--- a/tests/architecture/test_control_plane_import_boundaries.py
+++ b/tests/architecture/test_control_plane_import_boundaries.py
@@ -108,6 +108,15 @@ def _top_level_imported_names(path: Path) -> set[str]:
     }
 
 
+def _top_level_function_names(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    return {
+        node.name
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
 def _top_level_import_bindings(path: Path) -> dict[str, str]:
     module_name = _module_name(path)
     package_name = module_name.rpartition(".")[0]
@@ -189,9 +198,24 @@ def test_control_plane_does_not_gain_outward_dependencies() -> None:
 def test_quota_markdown_is_owned_by_the_presentation_layer() -> None:
     legacy_renderer = CONTROL_PLANE_ROOT / "quota" / "markdown.py"
     imports = _resolved_imports(QUOTA_MODULE)
+    cli_imports = _resolved_from_imports(QUOTA_CLI_MODULE)
+    presentation_renderers = cli_imports.get(
+        "loopx.presentation.renderers.quota_event_markdown", set()
+    )
 
     assert not legacy_renderer.exists()
     assert "loopx.presentation.renderers.quota_markdown" in imports
+    assert {
+        "render_quota_monitor_poll_markdown",
+        "render_quota_slot_preview_markdown",
+    } <= presentation_renderers
+    assert "loopx.presentation.renderers.quota_event_markdown" in imports
+    assert "render_quota_monitor_poll_markdown" not in _top_level_function_names(
+        CONTROL_PLANE_ROOT / "quota" / "monitor_poll.py"
+    )
+    assert "render_quota_slot_preview_markdown" not in _top_level_function_names(
+        CONTROL_PLANE_ROOT / "quota" / "slot_accounting.py"
+    )
 
 
 def test_internal_consumers_bypass_status_and_quota_reexport_routes() -> None:

--- a/tests/presentation/test_quota_markdown_renderers.py
+++ b/tests/presentation/test_quota_markdown_renderers.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from loopx.presentation.renderers.quota_event_markdown import (
+    render_quota_monitor_poll_markdown,
+    render_quota_slot_preview_markdown,
+)
+
+
+def test_monitor_poll_renderer_preserves_rejection_context() -> None:
+    markdown = render_quota_monitor_poll_markdown(
+        {
+            "ok": False,
+            "mode": "monitor-poll",
+            "goal_id": "quality-goal",
+            "agent_id": "codex-quality",
+            "todo_id": "todo_monitor",
+            "target_key": "release-watch",
+            "material_change": False,
+            "reason": "monitor target is not due",
+        }
+    )
+
+    assert markdown.startswith("# LoopX Quota Monitor Poll")
+    assert "- ok: `False`" in markdown
+    assert "- agent_id: `codex-quality`" in markdown
+    assert "- todo_id: `todo_monitor`" in markdown
+    assert "- target_key: `release-watch`" in markdown
+    assert "- reason: monitor target is not due" in markdown
+
+
+def test_monitor_poll_renderer_preserves_decision_and_writeback_context() -> None:
+    markdown = render_quota_monitor_poll_markdown(
+        {
+            "goal_id": "quality-goal",
+            "classification": "quota_monitor_poll",
+            "health_check": "monitor observation recorded",
+            "monitor_event": {
+                "agent_id": "codex-quality",
+                "source": "heartbeat",
+                "monitor_target": {"target_id": "release-watch"},
+                "todo_id": "todo_monitor",
+                "target_key": "release-watch",
+                "material_change": True,
+                "reason_summary": "new release observed",
+                "before": {
+                    "effective_action": "monitor_quiet_skip",
+                    "should_run": False,
+                    "self_repair_allowed": False,
+                    "state": "eligible",
+                },
+                "todo_writeback": {
+                    "dry_run": False,
+                    "consecutive_no_change": 0,
+                    "last_checked_at": "2026-07-19T00:00:00Z",
+                    "next_due_at": "2026-07-20T00:00:00Z",
+                },
+            },
+        }
+    )
+
+    assert "- effective_action: `monitor_quiet_skip`" in markdown
+    assert "- monitor_target: `release-watch`" in markdown
+    assert "- material_change: `True`" in markdown
+    assert "consecutive_no_change=0" in markdown
+    assert "- reason: new release observed" in markdown
+
+
+def test_slot_renderer_preserves_accounting_transition_context() -> None:
+    markdown = render_quota_slot_preview_markdown(
+        {
+            "ok": True,
+            "dry_run": False,
+            "goal_id": "quality-goal",
+            "classification": "quota_slot_spent",
+            "agent_id": "codex-quality",
+            "slots": 1,
+            "appended": True,
+            "registry_mutated": False,
+            "would_throttle": False,
+            "json_path": "/runtime/run.json",
+            "index_path": "/runtime/index.jsonl",
+            "before": {
+                "state": "eligible",
+                "should_run": True,
+                "quota": {"spent_slots": 4, "allowed_slots": 10},
+            },
+            "after": {
+                "state": "eligible",
+                "should_run": True,
+                "quota": {"spent_slots": 5, "allowed_slots": 10},
+                "plan_summary": {"next_automatic_turn": "quality-goal"},
+            },
+            "rolling_window_note": "older events may expire",
+        }
+    )
+
+    assert markdown.startswith("# LoopX Quota Slot Preview")
+    assert "- before: state=eligible should_run=True slots=4/10" in markdown
+    assert "- after: state=eligible should_run=True slots=5/10" in markdown
+    assert "- after_plan_next_automatic_turn: quality-goal" in markdown
+    assert "- rolling_window_note: older events may expire" in markdown


### PR DESCRIPTION
## Summary
- move monitor-poll and slot-accounting Markdown renderers from control-plane modules into a focused presentation module
- inject renderers at the quota facade boundary so control-plane persistence retains inward-only dependencies
- route CLI rendering directly through presentation while preserving the audited `loopx.quota` compatibility export

## Validation
- `26 passed`: presentation renderer semantics, control-plane import boundaries, and slot accounting
- `ruff check`: all seven changed Python files
- exact base/head Markdown parity across monitor failure/success and slot-accounting payloads
- focused quota monitor/spend smokes
- `loopx canary premerge --from-git-diff --no-progress`: passed (9 catalog canaries, 8 risk-profile smokes, no manual holds)

## Review focus
- verify renderer injection does not invert the control-plane dependency boundary
- verify CLI imports presentation directly and `loopx.quota.render_quota_slot_preview_markdown` remains identity-compatible
- verify semantic assertions cover operator-relevant monitor and accounting context without snapshotting incidental text