### PR TITLE
fix(agents): isolate material frontiers by goal

### DIFF
--- a/docs/reference/protocols/agent-management-projection-v0.md
+++ b/docs/reference/protocols/agent-management-projection-v0.md
@@ -229,6 +229,12 @@ from current goal authority and its own agent-scoped requirements and receipts.
 The optional cold-path input does not create an agent row, claim, or task by
 itself.
 
+The cold-path join is scoped by `(goal_id, agent_id)`, not agent identity alone.
+An explicit status goal filter takes precedence, followed by the current todo's
+goal and then a single unambiguous row goal. When a multi-goal agent row has no
+unique goal context, LoopX omits the material enrichment instead of selecting a
+frontier by input order.
+
 ## Stale Claim Hint
 
 `stale_claim_hint` is an observability warning, not an automatic reclaim rule.

--- a/examples/control_plane/agent-material-handoff-projection-smoke.py
+++ b/examples/control_plane/agent-material-handoff-projection-smoke.py
@@ -25,6 +25,7 @@ from loopx.control_plane.agents.material_handoff import (  # noqa: E402
 
 
 GOAL_ID = "material-handoff-fixture"
+OTHER_GOAL_ID = "other-material-handoff-fixture"
 SOURCE_AGENT = "agent-builder"
 SUCCESSOR_AGENT = "agent-reviewer"
 SOURCE_TODO = "todo_material_source"
@@ -165,34 +166,69 @@ def assert_successor_rebuilds_frontier(note: dict) -> dict:
     return successor
 
 
-def assert_agent_management_cold_path(successor: dict) -> None:
+def other_goal_frontier() -> dict:
+    return build_agent_material_frontier(
+        goal_id=OTHER_GOAL_ID,
+        agent_id=SUCCESSOR_AGENT,
+        authority_registry={"project_materials": {}},
+        todos={
+            "todo_id": "todo_other_goal",
+            "material_refs": [
+                {
+                    "material_id": "other-goal-only",
+                    "relation": "required",
+                }
+            ],
+        },
+        generated_at="2026-07-19T00:03:00Z",
+    )
+
+
+def management_payload(
+    *,
+    frontiers: list[dict],
+    goal_filter: str | None = GOAL_ID,
+    goal_ids: list[str] | None = None,
+    include_todo: bool = True,
+) -> dict:
     payload = {
-        "goal_filter": GOAL_ID,
         "run_history": {
             "goals": [
                 {
-                    "id": GOAL_ID,
+                    "id": goal_id,
                     "coordination": {"registered_agents": [SUCCESSOR_AGENT]},
                 }
+                for goal_id in (goal_ids or [GOAL_ID])
             ]
         },
         "todo_index": {
-            "items": [
-                {
-                    "role": "agent",
-                    "todo_id": SUCCESSOR_TODO,
-                    "goal_id": GOAL_ID,
-                    "status": "open",
-                    "task_class": "advancement_task",
-                    "action_kind": "independent_review",
-                    "claimed_by": SUCCESSOR_AGENT,
-                    "text": "Review the material-aware handoff.",
-                    "handoff_note": legacy_handoff_note(),
-                }
-            ]
+            "items": (
+                [
+                    {
+                        "role": "agent",
+                        "todo_id": SUCCESSOR_TODO,
+                        "goal_id": GOAL_ID,
+                        "status": "open",
+                        "task_class": "advancement_task",
+                        "action_kind": "independent_review",
+                        "claimed_by": SUCCESSOR_AGENT,
+                        "text": "Review the material-aware handoff.",
+                        "handoff_note": legacy_handoff_note(),
+                    }
+                ]
+                if include_todo
+                else []
+            )
         },
-        "agent_material_frontiers": [successor],
+        "agent_material_frontiers": frontiers,
     }
+    if goal_filter:
+        payload["goal_filter"] = goal_filter
+    return payload
+
+
+def assert_agent_management_cold_path(successor: dict) -> None:
+    payload = management_payload(frontiers=[successor])
     projection = build_agent_management_projection(payload)
     row = projection["agents"][0]
     assert row["agent_id"] == SUCCESSOR_AGENT, row
@@ -203,6 +239,41 @@ def assert_agent_management_cold_path(successor: dict) -> None:
     assert row["material_frontier"]["summary"] == successor["summary"], row
     assert row["handoff_note"]["schema_version"] == "handoff_note_v1", row
     assert row["handoff_note"]["material_refs"] == row["material_frontier"]["material_refs"], row
+
+    other = other_goal_frontier()
+    exact = build_agent_management_projection(
+        management_payload(frontiers=[successor, other])
+    )["agents"][0]
+    exact_material_ids = {
+        ref["material_id"] for ref in exact["material_frontier"]["material_refs"]
+    }
+    assert "design-current" in exact_material_ids, exact
+    assert "other-goal-only" not in exact_material_ids, exact
+
+    cross_goal = build_agent_management_projection(
+        management_payload(frontiers=[other])
+    )["agents"][0]
+    assert "material_frontier" not in cross_goal, cross_goal
+    assert "handoff_note" not in cross_goal, cross_goal
+
+    current_todo = build_agent_management_projection(
+        management_payload(
+            frontiers=[other, successor],
+            goal_filter=None,
+            goal_ids=[GOAL_ID, OTHER_GOAL_ID],
+        )
+    )["agents"][0]
+    assert current_todo["material_frontier"]["summary"] == successor["summary"], current_todo
+
+    ambiguous = build_agent_management_projection(
+        management_payload(
+            frontiers=[successor, other],
+            goal_filter=None,
+            goal_ids=[GOAL_ID, OTHER_GOAL_ID],
+            include_todo=False,
+        )
+    )["agents"][0]
+    assert "material_frontier" not in ambiguous, ambiguous
 
     payload.pop("agent_material_frontiers")
     legacy = build_agent_management_projection(payload)["agents"][0]

--- a/loopx/control_plane/agents/management_projection.py
+++ b/loopx/control_plane/agents/management_projection.py
@@ -189,23 +189,55 @@ def _registered_agents(status_payload: dict[str, Any]) -> dict[str, dict[str, An
     return rows
 
 
-def _agent_material_frontiers(status_payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+def _agent_material_frontiers(
+    status_payload: dict[str, Any],
+) -> dict[tuple[str, str], dict[str, Any]]:
     raw_frontiers = status_payload.get("agent_material_frontiers")
     if isinstance(raw_frontiers, dict):
         candidates = list(raw_frontiers.values())
     else:
         candidates = _as_list(raw_frontiers)
 
-    frontiers: dict[str, dict[str, Any]] = {}
+    frontiers: dict[tuple[str, str], dict[str, Any]] = {}
     for raw in candidates:
         if not isinstance(raw, dict):
             continue
         if str(raw.get("schema_version") or "") != AGENT_MATERIAL_FRONTIER_SCHEMA_VERSION:
             continue
+        goal_id = _compact(raw.get("goal_id"), limit=180)
         agent_id = normalize_todo_claimed_by(raw.get("agent_id"))
-        if agent_id:
-            frontiers[agent_id] = raw
+        if goal_id and agent_id:
+            frontiers[(goal_id, agent_id)] = raw
     return frontiers
+
+
+def _agent_material_frontier_key(
+    *,
+    raw_row: dict[str, Any],
+    current: dict[str, Any] | None,
+    agent_id: str,
+    goal_filter: str | None,
+) -> tuple[str, str] | None:
+    row_goal_ids: list[str] = []
+    for raw_goal_id in _as_list(raw_row.get("_goal_ids")):
+        row_goal_id = _compact(raw_goal_id, limit=180)
+        if row_goal_id and row_goal_id not in row_goal_ids:
+            row_goal_ids.append(row_goal_id)
+    current_goal_id = _compact(current.get("goal_id"), limit=180) if current else None
+
+    if goal_filter:
+        if current_goal_id and current_goal_id != goal_filter:
+            return None
+        if row_goal_ids and goal_filter not in row_goal_ids:
+            return None
+        return (goal_filter, agent_id)
+    if current_goal_id:
+        if row_goal_ids and current_goal_id not in row_goal_ids:
+            return None
+        return (current_goal_id, agent_id)
+    if len(row_goal_ids) == 1:
+        return (row_goal_ids[0], agent_id)
+    return None
 
 
 def _iter_todo_group_items(
@@ -480,6 +512,7 @@ def build_agent_management_projection(status_payload: dict[str, Any]) -> dict[st
 
     rows_by_agent = _registered_agents(status_payload)
     material_frontiers = _agent_material_frontiers(status_payload)
+    goal_filter = _compact(status_payload.get("goal_filter"), limit=180)
     seen_todos: set[tuple[str, str, str, str]] = set()
     for todo in _iter_status_todos(status_payload):
         agent_id = _todo_agent_id(todo)
@@ -537,7 +570,17 @@ def build_agent_management_projection(status_payload: dict[str, Any]) -> dict[st
             "handoff_refs": handoff_refs[:MAX_REFS],
             "goal_ids": _as_list(raw_row.get("_goal_ids"))[:MAX_REFS],
         }
-        material_frontier = material_frontiers.get(agent_id)
+        material_frontier_key = _agent_material_frontier_key(
+            raw_row=raw_row,
+            current=current,
+            agent_id=agent_id,
+            goal_filter=goal_filter,
+        )
+        material_frontier = (
+            material_frontiers.get(material_frontier_key)
+            if material_frontier_key
+            else None
+        )
         if material_frontier:
             agent_row["material_frontier"] = project_material_frontier_for_handoff(
                 material_frontier
@@ -566,7 +609,6 @@ def build_agent_management_projection(status_payload: dict[str, Any]) -> dict[st
         if len(agents) >= MAX_AGENT_ROWS:
             break
 
-    goal_filter = _compact(status_payload.get("goal_filter"), limit=180)
     source_summary: dict[str, Any] = {
         "registered_agent_count": len(rows_by_agent),
         "projected_agent_count": len(agents),


### PR DESCRIPTION
## Summary

- key prebuilt agent material frontiers by `(goal_id, agent_id)` instead of agent identity alone
- resolve the cold-path join from an explicit goal filter, the current todo goal, or one unambiguous row goal; omit enrichment when a multi-goal row cannot be resolved safely
- extend the durable handoff smoke with cross-goal, same-agent/multi-frontier, current-todo, and ambiguous-row regressions, and document the goal-isolation rule

## Validation

- `git diff --check`
- Ruff on both changed Python files
- adjacent frontier, handoff, live-management, projection-contract, and status-collection smokes
- isolated-HOME full suite: `791 passed, 2 skipped`
- `loopx canary premerge --from-git-diff`: 18/18 passed, including 9 catalog canaries, 8 risk-profile smokes, and the public/private boundary scan
- focused mypy remains non-green with the same 10 pre-existing errors documented during #2313 review; the changed join adds no new reported line

The first premerge attempt exposed an environment issue: nested `scripts/loopx` selected macOS `/usr/bin/python3` 3.9 and correctly failed the Python 3.11+ runtime guard. Re-running with `LOOPX_PYTHON` bound to the validated Python 3.13 venv passed the complete peer-runtime smoke and the full premerge gate.

## Boundary

Only public control-plane code, its durable smoke, and the protocol reference are included. No local state, raw material bodies, receipts, permissions, private paths, credentials, or generated logs are committed.

## Residual risk

The management projection still aggregates one agent row across goals. This change deliberately does not redesign that read model; it only makes optional material enrichment fail closed unless the row has a unique goal context.
