### PR TITLE
Make successor routing metadata atomic

### DIFF
--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -473,7 +473,11 @@ loopx todo complete \
 Without `--self-merged`, no implicit review route is created. For independent
 review, use `--next-action-kind review --next-continuation-policy
 independent_handoff`; add `--next-excluded-agent <author>` only when the review
-must remain open to multiple peers while excluding the author.
+must remain open to multiple peers while excluding the author. When that
+successor belongs to a specific repository or needs execution capabilities,
+set `--next-task-repository <git:host/path>` and repeat
+`--next-required-capability <capability>` in the same completion command. The
+successor is then fully routable before its executor exclusions take effect.
 
 Use `todo update` for lower-level, non-terminal status changes:
 

--- a/examples/control_plane/todo-lifecycle-cli-smoke.py
+++ b/examples/control_plane/todo-lifecycle-cli-smoke.py
@@ -40,6 +40,10 @@ from todo_lifecycle_fixtures import (  # noqa: E402
 )
 
 
+SUCCESSOR_REPOSITORY = "git:github.com/huangruiteng/loopx"
+SUCCESSOR_CAPABILITIES = ["network", "external_evidence_poll"]
+
+
 def assert_peer_monitor_no_followup() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-peer-monitor-no-followup-") as tmp:
         registry_path, state_file = write_fixture(Path(tmp))
@@ -458,6 +462,27 @@ def main() -> int:
         assert side_review_added["added"] is True, side_review_added
         side_review_todo_id = side_review_added["todo_id"]
 
+        missing_successor = run_cli_error(
+            registry_path,
+            "todo",
+            "complete",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            side_review_todo_id,
+            "--claimed-by",
+            "codex-side-bypass",
+            "--agent-id",
+            "codex-side-bypass",
+            "--evidence",
+            "side-worktree-contract-diff",
+            "--next-task-repository",
+            SUCCESSOR_REPOSITORY,
+        )
+        assert "--next-task-repository requires --next-agent-todo" in (
+            missing_successor["error"]
+        ), missing_successor
+
         side_review_claim_error = run_cli_error(
             registry_path,
             "todo",
@@ -509,12 +534,24 @@ def main() -> int:
             "codex-side-bypass",
             "--next-action-kind",
             "review",
+            "--next-task-repository",
+            SUCCESSOR_REPOSITORY,
+            "--next-required-capability",
+            "network",
+            "--next-required-capability",
+            "external_evidence_poll",
         )
         assert side_completed["changed"] is True, side_completed
         review_todo_id = side_completed["next_todos"][0]["todo_id"]
         assert side_completed["next_todos"][0]["claimed_by"] == "codex-main-control", side_completed
         assert side_completed["next_todos"][0]["blocks_agent"] is None, side_completed
         assert side_completed["next_todos"][0]["excluded_agents"] == ["codex-side-bypass"], side_completed
+        assert side_completed["next_todos"][0]["task_repository"] == (
+            SUCCESSOR_REPOSITORY
+        ), side_completed
+        assert side_completed["next_todos"][0]["required_capabilities"] == (
+            SUCCESSOR_CAPABILITIES
+        ), side_completed
         assert side_completed["next_todos"][0]["unblocks_todo_id"] == side_review_todo_id, side_completed
         assert side_completed["successor_todo_ids"] == [review_todo_id], side_completed
         items = parsed_items(state_file)
@@ -530,6 +567,8 @@ def main() -> int:
         assert review_item["action_kind"] == "review", review_item
         assert review_item.get("blocks_agent") is None, review_item
         assert review_item["excluded_agents"] == ["codex-side-bypass"], review_item
+        assert review_item["task_repository"] == SUCCESSOR_REPOSITORY, review_item
+        assert review_item["required_capabilities"] == SUCCESSOR_CAPABILITIES, review_item
         assert review_item["unblocks_todo_id"] == side_review_todo_id, review_item
         assert review_item.get("updated_at"), review_item
         assert side_completed["next_todos"][0].get("updated_at") == review_item["updated_at"], side_completed

--- a/examples/control_plane/todo-list-event-projection-smoke.py
+++ b/examples/control_plane/todo-list-event-projection-smoke.py
@@ -31,6 +31,10 @@ GATE_TODO_ID = "todo_markdown_gate_done"
 DEPENDENT_TODO_ID = "todo_event_dependent"
 EVENT_GATE_TODO_ID = "todo_event_non_delivery_gate"
 EVENT_SUCCESSOR_TODO_ID = "todo_event_same_agent_successor"
+EVENT_ATOMIC_SOURCE_TODO_ID = "todo_event_atomic_handoff_source"
+EVENT_ATOMIC_SUCCESSOR_TEXT = "Independently review the event-projected delivery"
+SUCCESSOR_REPOSITORY = "git:github.com/huangruiteng/loopx"
+SUCCESSOR_CAPABILITIES = ["network", "external_evidence_poll"]
 
 
 def write_fixture(root: Path) -> tuple[Path, Path, Path]:
@@ -240,6 +244,21 @@ def main() -> int:
                 },
             )
         )
+        store.append(
+            event(
+                "evt-atomic-handoff-source",
+                TODO_ADDED,
+                EVENT_ATOMIC_SOURCE_TODO_ID,
+                {
+                    "role": "agent",
+                    "priority": "P1",
+                    "title": "Deliver an event-projected implementation",
+                    "task_class": "advancement_task",
+                    "action_kind": "implement",
+                    "claimed_by": SIDE_AGENT,
+                },
+            )
+        )
         completed = run_cli(
             registry_path,
             "todo",
@@ -261,6 +280,59 @@ def main() -> int:
         )
         assert completed["linked_successor_id"] == EVENT_SUCCESSOR_TODO_ID, completed
         assert completed["self_merged"] is False, completed
+
+        atomic_handoff = run_cli(
+            registry_path,
+            "todo",
+            "complete",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--todo-id",
+            EVENT_ATOMIC_SOURCE_TODO_ID,
+            "--agent-id",
+            SIDE_AGENT,
+            "--claimed-by",
+            SIDE_AGENT,
+            "--evidence",
+            "public-safe event-projected implementation evidence",
+            "--next-agent-todo",
+            EVENT_ATOMIC_SUCCESSOR_TEXT,
+            "--next-claimed-by",
+            PRIMARY_AGENT,
+            "--next-action-kind",
+            "review",
+            "--next-task-repository",
+            SUCCESSOR_REPOSITORY,
+            "--next-required-capability",
+            "network",
+            "--next-required-capability",
+            "external_evidence_poll",
+            "--next-excluded-agent",
+            SIDE_AGENT,
+        )
+        atomic_successor = atomic_handoff["next_todos"][0]
+        assert atomic_successor["claimed_by"] == PRIMARY_AGENT, atomic_handoff
+        assert atomic_successor["excluded_agents"] == [SIDE_AGENT], atomic_handoff
+        assert atomic_successor["task_repository"] == SUCCESSOR_REPOSITORY, atomic_handoff
+        assert atomic_successor["required_capabilities"] == SUCCESSOR_CAPABILITIES, (
+            atomic_handoff
+        )
+        projected_atomic = run_cli(
+            registry_path,
+            "todo",
+            "list",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            atomic_successor["todo_id"],
+        )
+        atomic_item = projected_atomic["todos"][0]
+        assert atomic_item["claimed_by"] == PRIMARY_AGENT, atomic_item
+        assert atomic_item["excluded_agents"] == [SIDE_AGENT], atomic_item
+        assert atomic_item["task_repository"] == SUCCESSOR_REPOSITORY, atomic_item
+        assert atomic_item["required_capabilities"] == SUCCESSOR_CAPABILITIES, atomic_item
 
         event_log.unlink()
         fallback = run_cli(registry_path, "todo", "list", "--goal-id", GOAL_ID, "--role", "agent")

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -358,6 +358,22 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
     )
     todo_parser.add_argument("--next-action-kind", help="Action kind for --next-agent-todo.")
     todo_parser.add_argument(
+        "--next-task-repository",
+        help=(
+            "Credential-free Git repository identity for --next-agent-todo, such as "
+            "git:github.com/owner/repo."
+        ),
+    )
+    todo_parser.add_argument(
+        "--next-required-capability",
+        dest="next_required_capabilities",
+        action="append",
+        help=(
+            "Execution capability required by --next-agent-todo. Repeat for multiple "
+            "capabilities."
+        ),
+    )
+    todo_parser.add_argument(
         "--next-continuation-policy",
         choices=sorted(TODO_CONTINUATION_POLICY_VALUES),
         help="Continuation policy for --next-agent-todo.",
@@ -474,6 +490,10 @@ def handle_todo_command(
                 )
             if args.next_claimed_by:
                 raise ValueError("todo add does not support --next-claimed-by")
+            if args.next_task_repository:
+                raise ValueError("todo add does not support --next-task-repository")
+            if args.next_required_capabilities:
+                raise ValueError("todo add does not support --next-required-capability")
             if args.next_continuation_policy:
                 raise ValueError("todo add does not support --next-continuation-policy")
             if args.next_excluded_agents:
@@ -571,6 +591,8 @@ def handle_todo_command(
                     ("--next-claimed-by", args.next_claimed_by),
                     ("--next-task-class", args.next_task_class),
                     ("--next-action-kind", args.next_action_kind),
+                    ("--next-task-repository", args.next_task_repository),
+                    ("--next-required-capability", args.next_required_capabilities),
                     ("--next-continuation-policy", args.next_continuation_policy),
                     ("--next-excluded-agent", args.next_excluded_agents),
                     ("--self-merged", args.self_merged),
@@ -655,6 +677,10 @@ def handle_todo_command(
                 raise ValueError("todo update does not support --follow-up; use `todo capture-followups`")
             if args.next_claimed_by:
                 raise ValueError("todo update does not support --next-claimed-by")
+            if args.next_task_repository:
+                raise ValueError("todo update does not support --next-task-repository")
+            if args.next_required_capabilities:
+                raise ValueError("todo update does not support --next-required-capability")
             if args.next_continuation_policy:
                 raise ValueError("todo update does not support --next-continuation-policy")
             if args.next_excluded_agents:
@@ -742,6 +768,12 @@ def handle_todo_command(
                 raise ValueError(
                     "--next-continuation-policy requires --next-agent-todo"
                 )
+            if args.next_task_repository and not args.next_agent_todo:
+                raise ValueError("--next-task-repository requires --next-agent-todo")
+            if args.next_required_capabilities and not args.next_agent_todo:
+                raise ValueError(
+                    "--next-required-capability requires --next-agent-todo"
+                )
             if args.next_excluded_agents and not args.next_agent_todo:
                 raise ValueError("--next-excluded-agent requires --next-agent-todo")
             payload = complete_goal_todo(
@@ -761,6 +793,8 @@ def handle_todo_command(
                 next_claimed_by=args.next_claimed_by,
                 next_task_class=args.next_task_class,
                 next_action_kind=args.next_action_kind,
+                next_task_repository=args.next_task_repository,
+                next_required_capabilities=args.next_required_capabilities,
                 next_continuation_policy=args.next_continuation_policy,
                 next_excluded_agents=args.next_excluded_agents,
                 self_merged=bool(args.self_merged),
@@ -803,6 +837,12 @@ def handle_todo_command(
                 raise ValueError(
                     "--next-continuation-policy requires --next-agent-todo"
                 )
+            if args.next_task_repository and not args.next_agent_todo:
+                raise ValueError("--next-task-repository requires --next-agent-todo")
+            if args.next_required_capabilities and not args.next_agent_todo:
+                raise ValueError(
+                    "--next-required-capability requires --next-agent-todo"
+                )
             if args.next_excluded_agents and not args.next_agent_todo:
                 raise ValueError("--next-excluded-agent requires --next-agent-todo")
             if args.blocks_agent or args.clear_blocks_agent or args.excluded_agents or args.clear_excluded_agents or args.global_gate or args.clear_global_gate or args.unblocks_todo_id or args.resume_when:
@@ -822,6 +862,8 @@ def handle_todo_command(
                 next_claimed_by=args.next_claimed_by,
                 next_task_class=args.next_task_class,
                 next_action_kind=args.next_action_kind,
+                next_task_repository=args.next_task_repository,
+                next_required_capabilities=args.next_required_capabilities,
                 next_continuation_policy=args.next_continuation_policy,
                 next_excluded_agents=args.next_excluded_agents,
                 agent_id=args.agent_id,
@@ -841,6 +883,10 @@ def handle_todo_command(
                 raise ValueError("todo archive-completed does not support executor exclusions")
             if args.next_claimed_by:
                 raise ValueError("todo archive-completed does not support --next-claimed-by")
+            if args.next_task_repository or args.next_required_capabilities:
+                raise ValueError(
+                    "todo archive-completed does not support successor routing metadata"
+                )
             if args.self_merged:
                 raise ValueError("todo archive-completed does not support --self-merged")
             if args.no_follow_up:

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -49,6 +49,8 @@ TODO_OPTION_FIELDS = (
     ("--next-claimed-by", "next_claimed_by"),
     ("--next-task-class", "next_task_class"),
     ("--next-action-kind", "next_action_kind"),
+    ("--next-task-repository", "next_task_repository"),
+    ("--next-required-capability", "next_required_capabilities"),
     ("--next-continuation-policy", "next_continuation_policy"),
     ("--next-excluded-agent", "next_excluded_agents"),
     ("--self-merged", "self_merged"),

--- a/loopx/control_plane/todos/event_writeback.py
+++ b/loopx/control_plane/todos/event_writeback.py
@@ -25,11 +25,13 @@ from .contract import (
     TODO_STATUS_OPEN,
     build_todo_id,
     merge_todo_id_lists,
+    normalize_required_capabilities,
     normalize_todo_claimed_by,
     normalize_todo_bound_agent,
     normalize_todo_continuation_policy,
     normalize_todo_excluded_agents,
     normalize_todo_id,
+    normalize_todo_task_repository,
     todo_done_for_status,
 )
 from .text import (
@@ -143,6 +145,8 @@ def _append_event_projected_successor(
     fields: dict[str, Any],
     task_class: str | None,
     action_kind: str | None,
+    task_repository: str | None,
+    required_capabilities: list[str] | None,
     continuation_policy: str | None,
     claimed_by: str | None,
     dry_run: bool,
@@ -175,6 +179,23 @@ def _append_event_projected_successor(
         payload["task_class"] = task_class
     if action_kind:
         payload["action_kind"] = action_kind
+    normalized_task_repository = normalize_todo_task_repository(task_repository)
+    if task_repository and not normalized_task_repository:
+        raise ValueError(
+            "todo task_repository must be a credential-free Git remote or canonical "
+            "git:<host>/<path> identity"
+        )
+    if normalized_task_repository:
+        payload["task_repository"] = normalized_task_repository
+    normalized_required_capabilities = normalize_required_capabilities(
+        required_capabilities
+    )
+    if required_capabilities and not normalized_required_capabilities:
+        raise ValueError(
+            "required_capabilities must contain public-safe capability tokens"
+        )
+    if normalized_required_capabilities:
+        payload["required_capabilities"] = normalized_required_capabilities
     normalized_continuation_policy = normalize_todo_continuation_policy(
         continuation_policy
     )
@@ -247,6 +268,8 @@ def _append_event_projected_successor(
         "todo_id": todo_id,
         "task_class": task_class,
         "action_kind": action_kind,
+        "task_repository": normalized_task_repository,
+        "required_capabilities": normalized_required_capabilities,
         "continuation_policy": effective_continuation_policy,
         "claimed_by": claimed_by,
         "bound_agent": bound_agent,
@@ -274,6 +297,8 @@ def complete_event_projected_goal_todo(
     next_claimed_by: str | None,
     next_task_class: str | None,
     next_action_kind: str | None,
+    next_task_repository: str | None,
+    next_required_capabilities: list[str] | None,
     next_continuation_policy: str | None,
     self_merged: bool,
     next_excluded_agents: list[str],
@@ -312,6 +337,8 @@ def complete_event_projected_goal_todo(
                 fields=context["fields"],
                 task_class=next_task_class or "advancement_task",
                 action_kind=next_action_kind,
+                task_repository=next_task_repository,
+                required_capabilities=next_required_capabilities,
                 continuation_policy=next_continuation_policy,
                 claimed_by=next_claimed_by,
                 excluded_agents=next_excluded_agents,
@@ -330,6 +357,8 @@ def complete_event_projected_goal_todo(
                 fields=context["fields"],
                 task_class="user_gate",
                 action_kind="gate",
+                task_repository=None,
+                required_capabilities=None,
                 continuation_policy=None,
                 claimed_by=None,
                 bound_agent=next_user_blocks_agent,

--- a/loopx/event_sourced_state.py
+++ b/loopx/event_sourced_state.py
@@ -19,6 +19,7 @@ from .control_plane.todos.contract import (
     build_todo_id,
     format_todo_metadata_line,
     normalize_explicit_todo_task_class,
+    normalize_required_capabilities,
     normalize_required_write_scopes,
     normalize_removed_todo_continuation_policy,
     normalize_todo_action_kind,
@@ -32,6 +33,7 @@ from .control_plane.todos.contract import (
     normalize_todo_id,
     normalize_todo_id_list,
     normalize_todo_status,
+    normalize_todo_task_repository,
     parse_todo_metadata_line,
     todo_done_for_status,
     todo_marker_for_status,
@@ -270,6 +272,9 @@ def backfill_todo_events_from_markdown(
         }
         task_class = normalize_explicit_todo_task_class(record.get("task_class"))
         action_kind = normalize_todo_action_kind(record.get("action_kind"))
+        task_repository = normalize_todo_task_repository(
+            record.get("task_repository")
+        )
         continuation_policy = normalize_todo_continuation_policy(
             record.get("continuation_policy")
         )
@@ -278,6 +283,9 @@ def backfill_todo_events_from_markdown(
         )
         required_write_scopes = normalize_required_write_scopes(
             record.get("required_write_scopes")
+        )
+        required_capabilities = normalize_required_capabilities(
+            record.get("required_capabilities")
         )
         blocks_agent = normalize_todo_blocks_agent(record.get("blocks_agent"))
         bound_agent = normalize_todo_bound_agent(record.get("bound_agent"))
@@ -288,12 +296,16 @@ def backfill_todo_events_from_markdown(
             payload["task_class"] = task_class
         if action_kind:
             payload["action_kind"] = action_kind
+        if task_repository:
+            payload["task_repository"] = task_repository
         if continuation_policy:
             payload["continuation_policy"] = continuation_policy
         if removed_continuation_policy:
             payload["removed_continuation_policy"] = removed_continuation_policy
         if required_write_scopes:
             payload["required_write_scopes"] = required_write_scopes
+        if required_capabilities:
+            payload["required_capabilities"] = required_capabilities
         if blocks_agent:
             payload["blocks_agent"] = blocks_agent
         if bound_agent:
@@ -580,6 +592,7 @@ def _todo_from_added_event(event: dict[str, Any]) -> dict[str, Any]:
     )
     task_class = normalize_explicit_todo_task_class(payload.get("task_class"))
     action_kind = normalize_todo_action_kind(payload.get("action_kind"))
+    task_repository = normalize_todo_task_repository(payload.get("task_repository"))
     continuation_policy = normalize_todo_continuation_policy(
         payload.get("continuation_policy")
     )
@@ -589,6 +602,9 @@ def _todo_from_added_event(event: dict[str, Any]) -> dict[str, Any]:
     )
     required_write_scopes = normalize_required_write_scopes(
         payload.get("required_write_scopes")
+    )
+    required_capabilities = normalize_required_capabilities(
+        payload.get("required_capabilities")
     )
     blocks_agent = normalize_todo_blocks_agent(payload.get("blocks_agent"))
     bound_agent = normalize_todo_bound_agent(payload.get("bound_agent"))
@@ -614,12 +630,16 @@ def _todo_from_added_event(event: dict[str, Any]) -> dict[str, Any]:
         todo["task_class"] = task_class
     if action_kind:
         todo["action_kind"] = action_kind
+    if task_repository:
+        todo["task_repository"] = task_repository
     if removed_continuation_policy:
         todo["removed_continuation_policy"] = removed_continuation_policy
     elif continuation_policy:
         todo["continuation_policy"] = continuation_policy
     if required_write_scopes:
         todo["required_write_scopes"] = required_write_scopes
+    if required_capabilities:
+        todo["required_capabilities"] = required_capabilities
     if blocks_agent:
         todo["blocks_agent"] = blocks_agent
     if bound_agent:
@@ -680,6 +700,16 @@ def _update_todo_from_event(todo: dict[str, Any], event: dict[str, Any]) -> None
         )
         if required_write_scopes:
             todo["required_write_scopes"] = required_write_scopes
+        task_repository = normalize_todo_task_repository(
+            payload.get("task_repository")
+        )
+        if task_repository:
+            todo["task_repository"] = task_repository
+        required_capabilities = normalize_required_capabilities(
+            payload.get("required_capabilities")
+        )
+        if required_capabilities:
+            todo["required_capabilities"] = required_capabilities
         blocks_agent = normalize_todo_blocks_agent(payload.get("blocks_agent"))
         if blocks_agent:
             todo["blocks_agent"] = blocks_agent
@@ -831,9 +861,11 @@ def render_todo_markdown(item: dict[str, Any]) -> list[str]:
         status=status,
         task_class=item.get("task_class"),
         action_kind=item.get("action_kind"),
+        task_repository=item.get("task_repository"),
         continuation_policy=item.get("continuation_policy"),
         removed_continuation_policy=item.get("removed_continuation_policy"),
         required_write_scopes=item.get("required_write_scopes"),
+        required_capabilities=item.get("required_capabilities"),
         claimed_by=item.get("claimed_by"),
         bound_agent=item.get("bound_agent"),
         goal_bound=item.get("goal_bound"),

--- a/loopx/state_projection.py
+++ b/loopx/state_projection.py
@@ -25,6 +25,7 @@ from .control_plane.todos.contract import (
     normalize_todo_required_decision_scopes,
     normalize_todo_resume_when,
     normalize_todo_status,
+    normalize_todo_task_repository,
     normalize_todo_task_class,
     parse_todo_metadata_line,
     todo_done_for_status,
@@ -83,6 +84,7 @@ NEXT_ACTION_USER_WAIT_PATTERN = re.compile(
 )
 TODO_METADATA_KEYS = (
     "action_kind",
+    "task_repository",
     "continuation_policy",
     "required_write_scopes",
     "required_capabilities",
@@ -510,6 +512,9 @@ def _normalize_structured_todo_item(
         normalized["title"] = title
     if action_kind:
         normalized["action_kind"] = action_kind
+    task_repository = normalize_todo_task_repository(item.get("task_repository"))
+    if task_repository:
+        normalized["task_repository"] = task_repository
     continuation_policy = normalize_todo_continuation_policy(
         item.get("continuation_policy")
     )

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -1384,6 +1384,8 @@ def complete_goal_todo(
     next_claimed_by: str | None = None,
     next_task_class: str | None = None,
     next_action_kind: str | None = None,
+    next_task_repository: str | None = None,
+    next_required_capabilities: list[str] | None = None,
     next_continuation_policy: str | None = None,
     next_excluded_agents: list[str] | None = None,
     self_merged: bool = False,
@@ -1392,6 +1394,10 @@ def complete_goal_todo(
     state_file: Path | None = None,
     dry_run: bool = False,
 ) -> dict[str, Any]:
+    if next_task_repository and not next_agent_todo:
+        raise ValueError("--next-task-repository requires --next-agent-todo")
+    if next_required_capabilities and not next_agent_todo:
+        raise ValueError("--next-required-capability requires --next-agent-todo")
     resolved_project, resolved_state_file = resolve_todo_state_path(
         registry_path=registry_path,
         goal_id=goal_id,
@@ -1526,6 +1532,8 @@ def complete_goal_todo(
                     next_claimed_by=effective_next_claimed_by,
                     next_task_class=next_task_class,
                     next_action_kind=next_action_kind,
+                    next_task_repository=next_task_repository,
+                    next_required_capabilities=next_required_capabilities,
                     next_continuation_policy=next_continuation_policy,
                     self_merged=effective_self_merged,
                     next_excluded_agents=effective_next_excluded_agents,
@@ -1586,6 +1594,8 @@ def complete_goal_todo(
                     ),
                     task_class=next_task_class or "advancement_task",
                     action_kind=next_action_kind,
+                    task_repository=next_task_repository,
+                    required_capabilities=next_required_capabilities,
                     continuation_policy=next_continuation_policy,
                     claimed_by=effective_next_claimed_by,
                     excluded_agents=effective_next_excluded_agents,
@@ -1666,6 +1676,8 @@ def supersede_goal_todo(
     next_claimed_by: str | None = None,
     next_task_class: str | None = None,
     next_action_kind: str | None = None,
+    next_task_repository: str | None = None,
+    next_required_capabilities: list[str] | None = None,
     next_continuation_policy: str | None = None,
     next_excluded_agents: list[str] | None = None,
     agent_id: str | None = None, authority_reason: str | None = None,
@@ -1673,6 +1685,10 @@ def supersede_goal_todo(
     state_file: Path | None = None,
     dry_run: bool = False,
 ) -> dict[str, Any]:
+    if next_task_repository and not next_agent_todo:
+        raise ValueError("--next-task-repository requires --next-agent-todo")
+    if next_required_capabilities and not next_agent_todo:
+        raise ValueError("--next-required-capability requires --next-agent-todo")
     resolved_project, resolved_state_file = resolve_todo_state_path(
         registry_path=registry_path,
         goal_id=goal_id,
@@ -1772,6 +1788,8 @@ def supersede_goal_todo(
                     ),
                     task_class=next_task_class or "advancement_task",
                     action_kind=next_action_kind,
+                    task_repository=next_task_repository,
+                    required_capabilities=next_required_capabilities,
                     continuation_policy=next_continuation_policy,
                     claimed_by=effective_next_claimed_by,
                     excluded_agents=effective_next_excluded_agents,


### PR DESCRIPTION
## Summary
- let `todo complete/supersede --next-agent-todo` carry successor `task_repository` and repeatable `required_capabilities` in the same mutation
- preserve those fields across materialized state, event writeback, replay, backfill, and structured projection
- document and regress the excluded-implementer to independent-review handoff

## Validation
- focused materialized lifecycle smoke: passed
- focused event projection/replay smoke: passed
- Ruff on touched Python: passed
- isolated-HOME full pytest: 791 passed, 2 skipped
- `loopx canary premerge --from-git-diff --tier standard`: 18/18 passed, 0 warnings, 0 manual holds
- public/private boundary scan: clean

The first non-isolated full-suite run inherited an owner-local SkillsBench runner profile and failed one validator-absence expectation; rerunning that test and the full suite with an isolated HOME passed. No benchmark launch, scoring, permission, scheduler, or merge-authority behavior changes.