### PR TITLE
Restore maintainability ratchet and launcher test isolation

### DIFF
--- a/loopx/canary/maintainability_ratchet.py
+++ b/loopx/canary/maintainability_ratchet.py
@@ -171,9 +171,10 @@ REVIEWED_MAINTAINABILITY_EXCEPTIONS: dict[str, dict[str, Any]] = {
         "Move the bootstrap attribution into the benchmark runtime projection and delete the edge.",
     ),
     "compatibility_facade:loopx.quota": _exception(
-        "The public loopx.quota import surface remains a supported compatibility contract.",
+        "The public loopx.quota import surface remains a supported compatibility contract, "
+        "including presentation-owned quota event renderers.",
         "Keep internal consumers on canonical modules and shrink exports as callers migrate.",
-        metric_ceilings={"package_reexport_count": 95, "source_module_count": 35},
+        metric_ceilings={"package_reexport_count": 95, "source_module_count": 36},
     ),
     "compatibility_facade:loopx.status": _exception(
         "The public loopx.status import surface remains a supported compatibility contract.",

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -9,10 +9,11 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 LAUNCHER = REPO_ROOT / "scripts" / "skillsbench-launch-goal-xhigh.sh"
 
 
-def _base_env() -> dict[str, str]:
+def _base_env(tmp_path: Path) -> dict[str, str]:
     env = os.environ.copy()
     env.update(
         {
+            "XDG_STATE_HOME": str(tmp_path / "state"),
             "SKILLSBENCH_SSH_DESTINATION": "example.invalid",
             "SKILLSBENCH_REMOTE_ROOT": "/remote/loopx",
             "SKILLSBENCH_ROOT": "/remote/skillsbench",
@@ -25,8 +26,10 @@ def _base_env() -> dict[str, str]:
     return env
 
 
-def test_turn_launcher_wires_private_commands_without_echoing_values() -> None:
-    env = _base_env()
+def test_turn_launcher_wires_private_commands_without_echoing_values(
+    tmp_path: Path,
+) -> None:
+    env = _base_env(tmp_path)
     private_values = {
         "SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_COMMAND": (
             "private-probe-command sentinel-probe"
@@ -81,8 +84,10 @@ def test_turn_launcher_wires_private_commands_without_echoing_values() -> None:
     assert "sentinel-" not in output
 
 
-def test_instrumented_agent_bridge_requires_an_explicit_agent_command() -> None:
-    env = _base_env()
+def test_instrumented_agent_bridge_requires_an_explicit_agent_command(
+    tmp_path: Path,
+) -> None:
+    env = _base_env(tmp_path)
     env["SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_AGENT_COMMAND_INSTRUMENTED"] = "1"
 
     proc = subprocess.run(
@@ -102,8 +107,8 @@ def test_instrumented_agent_bridge_requires_an_explicit_agent_command() -> None:
     ) in proc.stderr
 
 
-def test_turn_launcher_requires_an_independent_validator() -> None:
-    env = _base_env()
+def test_turn_launcher_requires_an_independent_validator(tmp_path: Path) -> None:
+    env = _base_env(tmp_path)
     env["SKILLSBENCH_ROUTE"] = "loopx-turn-agent-cli"
 
     proc = subprocess.run(


### PR DESCRIPTION
## Summary
- record the intentional presentation-renderer source used by the supported `loopx.quota` compatibility facade
- keep the package re-export ceiling unchanged while raising only the reviewed source-module ceiling from 35 to 36
- isolate SkillsBench launcher tests from ambient default runner-profile discovery

## Validation
- `799 passed, 2 skipped`
- focused pytest: 25 passed
- `examples/skillsbench-runner-profile-smoke.py`
- `examples/control_plane/control-plane-maintainability-ratchet-smoke.py`
- `loopx canary premerge --from-git-diff --tier standard` (15/15 selected checks passed; no warnings or manual holds)
- Ruff and `git diff --check`

## Boundary
- no runtime behavior, credentials, local paths, private state, benchmark jobs, or generated evidence included
- the launcher test change only supplies an isolated temporary state home
