### PR TITLE
refactor(todos): centralize successor option validation

### DIFF
--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -22,7 +22,12 @@ from ..todos import (
     supersede_goal_todo,
     update_goal_todo,
 )
-from .todo_argument_validation import unsupported_todo_options, validate_capability_gap_options, validate_shared_todo_options
+from .todo_argument_validation import (
+    unsupported_todo_options,
+    validate_capability_gap_options,
+    validate_shared_todo_options,
+    validate_successor_routing_options,
+)
 from .todo_event import RolloutEventAppender, append_todo_rollout_event
 
 
@@ -764,18 +769,7 @@ def handle_todo_command(
                 raise ValueError(
                     "todo complete does not update --continuation-policy; use todo update first"
                 )
-            if args.next_continuation_policy and not args.next_agent_todo:
-                raise ValueError(
-                    "--next-continuation-policy requires --next-agent-todo"
-                )
-            if args.next_task_repository and not args.next_agent_todo:
-                raise ValueError("--next-task-repository requires --next-agent-todo")
-            if args.next_required_capabilities and not args.next_agent_todo:
-                raise ValueError(
-                    "--next-required-capability requires --next-agent-todo"
-                )
-            if args.next_excluded_agents and not args.next_agent_todo:
-                raise ValueError("--next-excluded-agent requires --next-agent-todo")
+            validate_successor_routing_options(args)
             payload = complete_goal_todo(
                 registry_path=registry_path,
                 goal_id=args.goal_id,
@@ -833,18 +827,7 @@ def handle_todo_command(
                 raise ValueError(
                     "todo supersede does not update --continuation-policy; use todo update first"
                 )
-            if args.next_continuation_policy and not args.next_agent_todo:
-                raise ValueError(
-                    "--next-continuation-policy requires --next-agent-todo"
-                )
-            if args.next_task_repository and not args.next_agent_todo:
-                raise ValueError("--next-task-repository requires --next-agent-todo")
-            if args.next_required_capabilities and not args.next_agent_todo:
-                raise ValueError(
-                    "--next-required-capability requires --next-agent-todo"
-                )
-            if args.next_excluded_agents and not args.next_agent_todo:
-                raise ValueError("--next-excluded-agent requires --next-agent-todo")
+            validate_successor_routing_options(args)
             if args.blocks_agent or args.clear_blocks_agent or args.excluded_agents or args.clear_excluded_agents or args.global_gate or args.clear_global_gate or args.unblocks_todo_id or args.resume_when:
                 raise ValueError("todo supersede does not update current todo routing metadata; use todo update first")
             if args.successor_todo_ids:

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -152,3 +152,14 @@ def validate_capability_gap_options(args: argparse.Namespace) -> None:
             "fixed and real_callsite_verified capability gaps require "
             "public-safe --evidence"
         )
+
+
+def validate_successor_routing_options(args: argparse.Namespace) -> None:
+    if args.next_continuation_policy and not args.next_agent_todo:
+        raise ValueError("--next-continuation-policy requires --next-agent-todo")
+    if args.next_task_repository and not args.next_agent_todo:
+        raise ValueError("--next-task-repository requires --next-agent-todo")
+    if args.next_required_capabilities and not args.next_agent_todo:
+        raise ValueError("--next-required-capability requires --next-agent-todo")
+    if args.next_excluded_agents and not args.next_agent_todo:
+        raise ValueError("--next-excluded-agent requires --next-agent-todo")


### PR DESCRIPTION
## Summary

- move shared successor-routing argument validation into the existing todo argument-validation owner
- reuse the helper from both complete and supersede paths without changing diagnostics or CLI behavior
- reduce `loopx/cli_commands/todo.py` from 1003 to 986 lines, restoring its ownership budget

## Validation

- `loopx canary premerge --from-git-diff`: 17/17 selected checks passed; no failures, skips, warnings, or manual holds
- `examples/cli-command-module-size-ownership-command-modularization-smoke.py`
- `examples/control_plane/todo-lifecycle-cli-smoke.py`
- `examples/control_plane/todo-list-event-projection-smoke.py`
- `pytest -q tests/control_plane/test_cli_output_budget.py`: 7 passed
- Ruff and public-boundary scan passed

## Boundary

Only the two public CLI implementation modules are changed. No private state, local paths, credentials, generated logs, or benchmark evidence are included.