### PR TITLE
test(control-plane): align public smokes with canonical read models

### DIFF
--- a/examples/control_plane/active-state-metadata-readmodel-smoke.py
+++ b/examples/control_plane/active-state-metadata-readmodel-smoke.py
@@ -38,8 +38,8 @@ malformed
         "普通章节": None,
     }
     for heading, expected in headings.items():
-        assert status_module.todo_role_for_heading(heading) == expected, heading
         assert metadata_read_model.todo_role_for_heading(heading) == expected, heading
+    assert not hasattr(status_module, "todo_role_for_heading")
 
     print("active-state-metadata-readmodel-smoke ok")
 

--- a/examples/control_plane/global-registry-health-readmodel-smoke.py
+++ b/examples/control_plane/global-registry-health-readmodel-smoke.py
@@ -154,7 +154,7 @@ def main() -> None:
             for finding in orphan_findings
         ), orphan_findings
 
-        finding = status_module.global_registry_finding(
+        finding = health_read_model.global_registry_finding(
             kind="fixture",
             severity="info",
             message="fixture finding",
@@ -163,15 +163,9 @@ def main() -> None:
             path=state_file,
             goal_ids=["fresh"],
         )
-        assert finding == health_read_model.global_registry_finding(
-            kind="fixture",
-            severity="info",
-            message="fixture finding",
-            recommended_action="keep parity",
-            goal_id="fresh",
-            path=state_file,
-            goal_ids=["fresh"],
-        )
+        assert finding["kind"] == "fixture", finding
+        assert finding["goal_id"] == "fresh", finding
+        assert not hasattr(status_module, "global_registry_finding")
 
     print("global-registry-health-readmodel-smoke ok")
 

--- a/examples/control_plane/public-safety-readmodel-smoke.py
+++ b/examples/control_plane/public-safety-readmodel-smoke.py
@@ -24,10 +24,7 @@ def assert_status_uses_direct_read_models() -> None:
         status_module._compact_loopx_command_records
         is public_safety_read_model.compact_loopx_command_records
     )
-    assert (
-        status_module.compact_session_runtime_readonly_projection
-        is session_runtime_read_model.compact_session_runtime_readonly_projection
-    )
+    assert not hasattr(status_module, "compact_session_runtime_readonly_projection")
     assert (
         status_module.compact_session_runtime_projection_from_run
         is session_runtime_read_model.compact_session_runtime_projection_from_run
@@ -151,7 +148,7 @@ def assert_session_runtime_defaults() -> None:
         "attention_item": {"kind": "todo", "title": "  Public\nTitle  "},
     }
 
-    compact = status_module.compact_session_runtime_readonly_projection(projection)
+    compact = session_runtime_read_model.compact_session_runtime_readonly_projection(projection)
     assert compact == {
         "schema_version": SESSION_RUNTIME_READONLY_PROJECTION_SCHEMA_VERSION,
         "mode": "read_only",

--- a/examples/control_plane/quota-todo-summary-readmodel-smoke.py
+++ b/examples/control_plane/quota-todo-summary-readmodel-smoke.py
@@ -117,9 +117,9 @@ def assert_agent_scoped_user_gate_and_monitor_state() -> None:
         filter_user_gate_blocks_agent=True,
     )
     assert summary is not None
-    assert summary["open_count"] == 1, summary
+    assert summary["open_count"] == 4, summary
     assert summary["all_open_count"] == 5, summary
-    assert summary["user_action_open_count"] == 4, summary
+    assert summary["user_action_open_count"] == 3, summary
     assert summary["other_agent_scoped_open_count"] == 1, summary
     assert summary["gate_open_items"][0]["todo_id"] == "todo_gate_current", summary
     assert {
@@ -133,8 +133,12 @@ def assert_agent_scoped_user_gate_and_monitor_state() -> None:
         "todo_monitor_due",
         "todo_monitor_gap",
         "todo_refactor_next",
-        "todo_other_agent_next",
     }, summary
+    assert summary["other_agent_bound_user_action_open_count"] == 1, summary
+    assert {
+        item.get("todo_id")
+        for item in summary["other_agent_bound_user_action_items"]
+    } == {"todo_other_agent_next"}, summary
 
     assert summary["monitor_due_count"] == 0, summary
     assert summary["monitor_due_items"] == [], summary

--- a/examples/control_plane/todo-readmodel-boundary-smoke.py
+++ b/examples/control_plane/todo-readmodel-boundary-smoke.py
@@ -17,7 +17,6 @@ from loopx import boundary_authority as boundary_authority_module  # noqa: E402
 from loopx import interface_budget as interface_budget_module  # noqa: E402
 from loopx import quota as quota_module  # noqa: E402
 from loopx.control_plane.goals import active_state_metadata as active_state_metadata_read_model  # noqa: E402
-from loopx.control_plane.goals import global_registry_health as global_registry_health_read_model  # noqa: E402
 from loopx.control_plane.work_items import attention_item as attention_item_read_model  # noqa: E402
 from loopx.control_plane.work_items import autonomous_candidates as autonomous_read_model  # noqa: E402
 from loopx.control_plane.work_items import autonomous_replan_ack as replan_ack_read_model  # noqa: E402
@@ -26,13 +25,10 @@ from loopx.control_plane.goals import path_resolution as path_resolution_read_mo
 from loopx.control_plane.agents import management_projection as management_projection_read_model  # noqa: E402
 from loopx.control_plane.runtime import agent_scoped_evidence_log as evidence_log_read_model  # noqa: E402
 from loopx.control_plane.runtime import run_compaction as run_compaction_read_model  # noqa: E402
-from loopx.control_plane.runtime import session_runtime as session_runtime_read_model  # noqa: E402
 from loopx.control_plane.runtime import status_projection_cache as status_cache_read_model  # noqa: E402
 from loopx.control_plane.runtime import time as runtime_time_read_model  # noqa: E402
 from loopx.control_plane.scheduler import time as scheduler_time_read_model  # noqa: E402
-from loopx.control_plane.quota import usage_summary as usage_summary_read_model  # noqa: E402
 from loopx.control_plane.todos import active_state_todo_parser as active_state_todo_parser_read_model  # noqa: E402
-from loopx.control_plane.todos import active_state_todos as active_state_todos_read_model  # noqa: E402
 from loopx.control_plane.todos import monitor_metadata as monitor_metadata_read_model  # noqa: E402
 from loopx.control_plane.todos import projection as todo_projection_read_model  # noqa: E402
 from loopx.control_plane.todos import todo_summary as todo_read_model  # noqa: E402
@@ -88,26 +84,19 @@ def fixture_todos() -> dict:
     }
 
 
-def assert_direct_status_aliases() -> None:
+def assert_status_compatibility_boundary() -> None:
     assert status_module.parse_state_frontmatter is active_state_metadata_read_model.parse_state_frontmatter
-    assert status_module.todo_role_for_heading is active_state_metadata_read_model.todo_role_for_heading
     assert status_module.same_path is path_resolution_read_model.same_path
     assert status_module.resolve_goal_local_path is path_resolution_read_model.resolve_goal_local_path
     assert status_module.parse_active_state_todos is active_state_todo_parser_read_model.parse_active_state_todos
-    assert status_module.attach_monitor_writeback_contract is active_state_todos_read_model.attach_monitor_writeback_contract
-    assert status_module.redacted_status_todo_fields is active_state_todos_read_model.redacted_status_todo_fields
     assert status_module.todo_item_is_expired_monitor is todo_projection_read_model.todo_item_is_expired_monitor
     assert status_module.open_todo_items is todo_read_model.open_todo_items
     assert status_module.todo_lane_items is todo_read_model.todo_lane_items
     assert status_module.first_open_todo_text is todo_read_model.first_open_todo_text
-    assert status_module.first_open_todo_item is todo_read_model.first_open_todo_item
     assert status_module.project_asset_todo_summary is todo_read_model.project_asset_todo_summary
-    assert status_module.dependency_blocker_summary is todo_read_model.dependency_blocker_summary
     assert status_module.attach_dependency_blockers is todo_read_model.attach_dependency_blockers
     assert status_module.autonomous_replan_ack_recorded is replan_ack_read_model.autonomous_replan_ack_recorded
     assert status_module.compact_autonomous_replan_ack is replan_ack_read_model.compact_autonomous_replan_ack
-    assert status_module.global_registry_finding is global_registry_health_read_model.global_registry_finding
-    assert status_module.attach_session_runtime_projection is session_runtime_read_model.attach_session_runtime_projection
     assert status_module.compact_human_reward is run_compaction_read_model.compact_human_reward
     assert status_module.compact_operator_gate is run_compaction_read_model.compact_operator_gate
     assert status_module.compact_operator_gate_resume_contract is run_compaction_read_model.compact_operator_gate_resume_contract
@@ -122,10 +111,21 @@ def assert_direct_status_aliases() -> None:
     assert quota_module._parse_timestamp is runtime_time_read_model.parse_timestamp
     assert boundary_authority_module._parse_timestamp is runtime_time_read_model.parse_timestamp
     assert interface_budget_module.parse_timestamp is runtime_time_read_model.parse_timestamp
-    assert status_module.quota_spend_slots is usage_summary_read_model.quota_spend_slots
-    assert status_module.is_automation_run is usage_summary_read_model.is_automation_run
-    assert status_module.is_progress_signal_run is usage_summary_read_model.is_progress_signal_run
-    assert status_module.blank_usage_goal is usage_summary_read_model.blank_usage_goal
+    removed_import_only_aliases = {
+        "attach_monitor_writeback_contract",
+        "attach_session_runtime_projection",
+        "blank_usage_goal",
+        "compact_global_registry_shadow_finding",
+        "dependency_blocker_summary",
+        "first_open_todo_item",
+        "global_registry_finding",
+        "is_automation_run",
+        "is_progress_signal_run",
+        "quota_spend_slots",
+        "redacted_status_todo_fields",
+        "todo_role_for_heading",
+    }
+    assert removed_import_only_aliases.isdisjoint(vars(status_module))
 
 
 def assert_wrapper_parity() -> None:
@@ -137,7 +137,7 @@ def assert_wrapper_parity() -> None:
         "monitor_open_items",
     )
     assert status_module.first_open_todo_text(todos) == todo_read_model.first_open_todo_text(todos)
-    assert status_module.first_open_todo_item(todos) == todo_read_model.first_open_todo_item(todos)
+    assert todo_read_model.first_open_todo_item(todos)["index"] == 1
     assert status_module.project_asset_todo_summary(
         todos,
         role="agent",
@@ -185,13 +185,11 @@ def assert_dependency_blocker_parity() -> None:
             },
         },
     ]
-    assert status_module.dependency_blocker_summary(
-        items,
-        current_goal_id="current",
-    ) == todo_read_model.dependency_blocker_summary(
+    summary = todo_read_model.dependency_blocker_summary(
         items,
         current_goal_id="current",
     )
+    assert summary["open_count"] == 1, summary
 
     status_items = deepcopy(items)
     direct_items = deepcopy(items)
@@ -248,9 +246,8 @@ def assert_global_registry_shadow_parity() -> None:
         "message": "registry points at stale projection",
         "recommended_action": "refresh the public-safe state projection",
     }
-    assert status_module.compact_global_registry_shadow_finding(
-        finding
-    ) == global_registry_shadow_read_model.compact_global_registry_shadow_finding(finding)
+    compact = global_registry_shadow_read_model.compact_global_registry_shadow_finding(finding)
+    assert compact["kind"] == "state_shadow", compact
 
     status_item = {"project_asset": {"goal_id": "loopx-meta"}}
     direct_item = deepcopy(status_item)
@@ -348,7 +345,7 @@ def assert_control_plane_has_no_status_reverse_imports() -> None:
 
 
 def main() -> None:
-    assert_direct_status_aliases()
+    assert_status_compatibility_boundary()
     assert_control_plane_has_no_status_reverse_imports()
     assert_wrapper_parity()
     assert_dependency_blocker_parity()

--- a/examples/control_plane/todo-suggestion-prompt-smoke.py
+++ b/examples/control_plane/todo-suggestion-prompt-smoke.py
@@ -188,7 +188,10 @@ def main() -> int:
         assert error_payload["error"].startswith(
             "todo add does not support --agent-id;"
         ), error_payload
-        assert "not lifecycle actor attribution" in error_payload["error"], error_payload
+        error = error_payload["error"]
+        assert "todo list/suggest" in error, error_payload
+        assert "user-todo authoring" in error, error_payload
+        assert "lifecycle actor attribution only" in error, error_payload
 
     print("todo-suggestion-prompt-smoke: ok")
     return 0


### PR DESCRIPTION
## Summary
- make public control-plane smokes call canonical read-model owners instead of removed `loopx.status` import-only aliases
- assert the intentional status compatibility boundary directly
- align agent-scoped user-action and todo CLI error projections with current contracts

## Motivation
The underlying facade and read-model migrations are already on `main`, but six Full Public smokes still encoded the retired compatibility aliases or old projection counts. This focused commit moves those validations to the canonical owners without restoring stale public surfaces.

## Validation
- 6/6 changed focused smokes passed under the repository-isolated runtime
- 12/12 `tests/architecture/test_control_plane_import_boundaries.py` passed
- `loopx check` public-boundary scan clean across all 6 changed files
- `loopx canary premerge --from-git-diff`: 8/8 selected checks passed, 0 warnings, 0 manual holds

Immutable reviewed commit: `9e24ed0eb2686e3dd8eddecb6155f13958e6786d`.
