### PR TITLE
refactor(capabilities): bind connector profiles to outcome owners

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -450,6 +450,30 @@ sync the management surface, record residual risk, and choose one of:
 One merged PR proves a delivery slice. Repeating the loop on independent issues
 tests whether the system is a durable employee rather than a scripted demo.
 
+## Public GitHub Signal Provider
+
+Issue-fix owns the body-free public GitHub probe and reply-monitor provider in
+`loopx.capabilities.issue_fix.github_public`. Existing CLI callers keep using
+the compatibility commands:
+
+```bash
+loopx value-connectors github-public-probe \
+  --url https://github.com/owner/repo/issues/1 \
+  --fetch-metadata \
+  --format json
+
+loopx value-connectors github-reply-monitor \
+  --issue-url https://github.com/owner/repo/issues/1 \
+  --after-comment-url https://github.com/owner/repo/issues/1#issuecomment-123 \
+  --fetch-metadata \
+  --format json
+```
+
+The CLI name and packet schemas remain stable. Only implementation ownership
+moved: probes and monitor signals now evolve with the issue-to-PR outcome they
+feed, while connector installation and generic approval planning remain in the
+compatibility facade.
+
 ## Implemented Surfaces
 
 | Surface | Command or path | Current responsibility |

--- a/docs/capabilities/value-connectors/README.md
+++ b/docs/capabilities/value-connectors/README.md
@@ -71,17 +71,34 @@ The reply monitor follows the same boundary: it only captures comment author,
 association, timestamp, and URL metadata, then emits either
 `prepare_public_triage_note` or `wait_no_bump`.
 
+## Ownership And Compatibility
+
+`value-connectors` is the compatibility facade for existing connector commands
+and packet schemas. It owns shared install checks, source mapping, and gated
+call planning, but it does not own new user outcomes. Each profile declares the
+outcome capability that serves callers; implementations move there one proven
+profile at a time while these CLI commands stay stable.
+
+The first completed migration is the public GitHub probe and reply monitor.
+Their implementation and protocol ownership now live under `issue-fix`; the
+existing `loopx value-connectors ...` commands delegate to that provider.
+
 ## Connector Profiles
 
-| Connector | Current state | User can run now | External write behavior |
-| --- | --- | --- | --- |
-| `github_public_channel` | implemented starter | yes | none |
-| `github_public_reply_monitor` | implemented starter | yes | none |
-| `social_browser_x` | ego-browser-backed profile | install-check, public-handle packet, and gated plan | exact profile/post/reply gate required |
-| `finance_market_snapshot` | probed candidate profile | plan, user prompt surface, and [no-credential probe packet](finance-market-snapshot-probe.md) | account, private portfolio, trading, and paid-data gates required |
-| `agent_reach_ops_source_map` | field-derived source profile | `loopx value-connectors source-map --connector agent_reach_ops_source_map --format json`; [profile note](agent-reach-ops-source-map.md) | publish/audit record required for every external write |
-| `botmail_identity` | host connector profile | install-check only | exact send gate required |
-| `community_channel` | host/browser connector profile | install-check and plan | exact account/message gate required |
+| Connector | Outcome capability | Binding | User can run now | External write behavior |
+| --- | --- | --- | --- | --- |
+| `github_public_channel` | `issue-fix` | migrated | yes | none |
+| `github_public_reply_monitor` | `issue-fix` | migrated | yes | none |
+| `content_ops_public_handle` | `content-ops` | native | public-handle observation | none |
+| `social_browser_x` | `content-ops` | mapped | install-check, public-handle packet, and gated plan | exact profile/post/reply gate required |
+| `finance_market_snapshot` | `finance-value-discovery` | mapped | plan, user prompt surface, and [no-credential probe packet](finance-market-snapshot-probe.md) | account, private portfolio, trading, and paid-data gates required |
+| `agent_reach_ops_source_map` | `content-ops` | mapped | `loopx value-connectors source-map --connector agent_reach_ops_source_map --format json`; [profile note](agent-reach-ops-source-map.md) | publish/audit record required for every external write |
+| `botmail_identity` | `content-ops` | mapped | install-check only | exact send gate required |
+| `community_channel` | `content-ops` | mapped | install-check and plan | exact account/message gate required |
+
+`migrated` means the implementation module is owned by the outcome capability.
+`native` means the command already lived there. `mapped` records the intended
+owner without pretending that the implementation has moved.
 
 ## Why This Is Not Just A Plan
 

--- a/docs/reference/protocols/value-connector-plan-v0.md
+++ b/docs/reference/protocols/value-connector-plan-v0.md
@@ -2,6 +2,11 @@
 
 Status: public-safe connector planning and starter runtime contract v0.
 
+`loopx value-connectors` is a compatibility CLI and protocol facade. Generic
+planning, install checks, and source mapping remain here. The public GitHub
+probe and reply-monitor implementations are owned by `issue-fix` and are still
+invoked through the commands below so existing callers do not change.
+
 `value_connector_plan_v0` is a compact contract for external-value connector
 calls. It sits before real connector execution so LoopX can separate useful
 business-development work from unsafe automation.

--- a/examples/capability-extension-registry-smoke.py
+++ b/examples/capability-extension-registry-smoke.py
@@ -67,6 +67,44 @@ next_real_step = "Keep explicit enablement bounded."
         "auto-research",
     ]
     assert all(item["provider_id"] == "loopx-core" for item in baseline["capabilities"])
+    value_summary = next(
+        item for item in baseline["capabilities"] if item["id"] == "value-connectors"
+    )
+    assert value_summary["status"] == "compatibility-facade", value_summary
+
+    issue_fix = run_cli(runtime_root, "capability", "show", "issue-fix")["capability"]
+    issue_fix_protocols = {
+        item["schema_version"]: item
+        for item in issue_fix["implemented_protocols"]
+    }
+    assert (
+        issue_fix_protocols["github_public_channel_probe_packet_v0"]["module"]
+        == "loopx.capabilities.issue_fix.github_public"
+    ), issue_fix_protocols
+    assert (
+        issue_fix_protocols["github_public_reply_monitor_packet_v0"]["module"]
+        == "loopx.capabilities.issue_fix.github_public"
+    ), issue_fix_protocols
+
+    value_connectors = run_cli(
+        runtime_root, "capability", "show", "value-connectors"
+    )["capability"]
+    value_protocols = {
+        item["schema_version"]: item
+        for item in value_connectors["implemented_protocols"]
+    }
+    assert "github_public_channel_probe_packet_v0" not in value_protocols
+    assert (
+        value_protocols["value_connector_install_check_packet_v0"]["module"]
+        == "loopx.capabilities.value_connectors.install_check"
+    )
+    github_commands = [
+        item
+        for item in value_connectors["commands"]
+        if "github-" in item["command"]
+    ]
+    assert github_commands
+    assert all(item["compatibility_for"] == "issue-fix" for item in github_commands)
 
     composed = run_cli(
         runtime_root,

--- a/examples/value-connectors-github-public-probe-smoke.py
+++ b/examples/value-connectors-github-public-probe-smoke.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import re
@@ -17,9 +18,11 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from loopx.capabilities.value_connectors.github_public import (  # noqa: E402
+from loopx.capabilities.issue_fix.github_public import (  # noqa: E402
     GITHUB_PUBLIC_CHANNEL_PROBE_PACKET_SCHEMA_VERSION,
     GITHUB_PUBLIC_REPLY_MONITOR_PACKET_SCHEMA_VERSION,
+)
+from loopx.capabilities.value_connectors.install_check import (  # noqa: E402
     VALUE_CONNECTOR_INSTALL_CHECK_PACKET_SCHEMA_VERSION,
 )
 from loopx.capabilities.value_connectors.planner import (  # noqa: E402
@@ -82,6 +85,7 @@ def run_cli(
 
 
 def main() -> int:
+    assert importlib.util.find_spec("loopx.capabilities.value_connectors.github_public") is None
     install = json.loads(
         run_cli(["--format", "json", "value-connectors", "install-check"]).stdout
     )
@@ -110,9 +114,34 @@ def main() -> int:
     assert "social_browser_x" in profile_ids, profile_ids
     assert "agent_reach_ops_source_map" in profile_ids, profile_ids
     assert "finance_market_snapshot" in profile_ids, profile_ids
+    profiles = {
+        item["connector_id"]: item for item in source_map["source_profiles"]
+    }
+    assert profiles["github_public_channel"]["outcome_capability_id"] == "issue-fix"
+    assert profiles["github_public_reply_monitor"]["provider_binding_state"] == "migrated"
+    assert (
+        profiles["github_public_reply_monitor"]["provider_module"]
+        == "loopx.capabilities.issue_fix.github_public"
+    )
+    assert profiles["content_ops_public_handle"]["provider_binding_state"] == "native"
+    assert profiles["social_browser_x"]["outcome_capability_id"] == "content-ops"
+    assert profiles["agent_reach_ops_source_map"]["outcome_capability_id"] == "content-ops"
+    assert (
+        profiles["finance_market_snapshot"]["outcome_capability_id"]
+        == "finance-value-discovery"
+    )
     action_ids = {item["connector_id"] for item in source_map["action_gated_profiles"]}
     assert "botmail_identity" in action_ids, action_ids
     assert "community_channel" in action_ids, action_ids
+    actions = {
+        item["connector_id"]: item for item in source_map["action_gated_profiles"]
+    }
+    assert actions["botmail_identity"]["outcome_capability_id"] == "content-ops"
+    assert actions["community_channel"]["outcome_capability_id"] == "content-ops"
+    assert source_map["projection"]["compatibility_facade"] is True
+    assert source_map["projection"]["new_profile_ownership_allowed"] is False
+    assert source_map["projection"]["mapped_profile_count"] == 8
+    assert source_map["projection"]["migrated_profile_count"] == 3
     assert source_map["generic_evidence_card_schema"]["operation"] == "read", source_map
     assert "loopx value-connectors plan" in source_map["agent_prompt"], source_map
     assert_public_safe(source_map)

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -33,6 +33,16 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "write_boundary": "read-only external metadata; no issue comment, PR, or todo write",
             },
             {
+                "command": "loopx value-connectors github-public-probe --url <github-issue-or-pr-url> --fetch-metadata --format json",
+                "purpose": "Use the compatibility CLI to fetch the issue-fix-owned public GitHub probe packet.",
+                "write_boundary": "public metadata read only; no issue bodies, comments, PRs, account changes, or writes",
+            },
+            {
+                "command": "loopx value-connectors github-reply-monitor --issue-url <github-issue-or-pr-url> --after-comment-url <github-issue-comment-url> --fetch-metadata --format json",
+                "purpose": "Use the compatibility CLI to detect public maintainer replies through the issue-fix provider.",
+                "write_boundary": "public comment metadata read only; no comment bodies, thread bump, or external write",
+            },
+            {
                 "command": "loopx content-ops issue-fix-intake --format json",
                 "purpose": "Project public issue metadata into an issue-fix intake packet.",
                 "write_boundary": "fixture-only; no external read or write",
@@ -89,6 +99,16 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
             },
         ],
         "implemented_protocols": [
+            {
+                "schema_version": "github_public_channel_probe_packet_v0",
+                "module": "loopx.capabilities.issue_fix.github_public",
+                "doc": "docs/reference/protocols/value-connector-plan-v0.md",
+            },
+            {
+                "schema_version": "github_public_reply_monitor_packet_v0",
+                "module": "loopx.capabilities.issue_fix.github_public",
+                "doc": "docs/reference/protocols/value-connector-plan-v0.md",
+            },
             {
                 "schema_version": "github_issue_metadata_preview_v0",
                 "module": "loopx.capabilities.issue_fix.metadata_preview",
@@ -186,6 +206,7 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
             },
         ],
         "smokes": [
+            "python3 examples/value-connectors-github-public-probe-smoke.py",
             "python3 examples/issue-fix-workflow-plan-smoke.py",
             "python3 examples/issue-fix-repository-context-smoke.py",
             "python3 examples/issue-fix-feasibility-smoke.py",
@@ -204,6 +225,7 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
         ],
         "docs": [
             "docs/capabilities/issue-fix/README.md",
+            "docs/reference/protocols/value-connector-plan-v0.md",
             "docs/capabilities/issue-fix/openviking-pilot-handoff.md",
             "docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md",
             "docs/capabilities/issue-fix/protocols/issue-fix-discovered-issue-promotion-v0.md",
@@ -601,13 +623,12 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
         "origin": "builtin",
         "visibility": "public",
         "provider_id": "loopx-core",
-        "title": "External value connector starters",
-        "status": "active-preview",
+        "title": "Value connector compatibility facade",
+        "status": "compatibility-facade",
         "real_world_anchor": "external channel intake for revenue, cost, demand, and connector reuse",
         "user_value": (
-            "Install and run public-safe connector starters that turn external "
-            "channel metadata into LoopX value signals while gating account "
-            "setup, sends, posts, and private reads."
+            "Keep existing connector commands and packet schemas stable while "
+            "each profile moves to the outcome capability that serves callers."
         ),
         "entry_command": "loopx value-connectors source-map --format json",
         "commands": [
@@ -625,16 +646,19 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "command": "loopx value-connectors github-public-probe --url <github-issue-or-pr-url> --format json",
                 "purpose": "Validate a public GitHub channel URL and build a connector call packet.",
                 "write_boundary": "no network read unless --fetch-metadata is provided",
+                "compatibility_for": "issue-fix",
             },
             {
                 "command": "loopx value-connectors github-public-probe --url <github-issue-or-pr-url> --fetch-metadata --format json",
                 "purpose": "Fetch allowlisted public GitHub metadata without body/comment/timeline content.",
                 "write_boundary": "public metadata read only; no comments, PRs, account changes, or writes",
+                "compatibility_for": "issue-fix",
             },
             {
                 "command": "loopx value-connectors github-reply-monitor --issue-url <github-issue-or-pr-url> --after-comment-url <github-issue-comment-url> --fetch-metadata --format json",
                 "purpose": "Detect public maintainer replies after a LoopX comment without capturing comment bodies.",
                 "write_boundary": "public comment metadata read only; no comment bodies, thread bump, or external write",
+                "compatibility_for": "issue-fix",
             },
             {
                 "command": "loopx value-connectors plan --connector-id <id> ... --format json",
@@ -659,18 +683,8 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "doc": "docs/reference/protocols/value-connector-plan-v0.md",
             },
             {
-                "schema_version": "github_public_channel_probe_packet_v0",
-                "module": "loopx.capabilities.value_connectors.github_public",
-                "doc": "docs/reference/protocols/value-connector-plan-v0.md",
-            },
-            {
-                "schema_version": "github_public_reply_monitor_packet_v0",
-                "module": "loopx.capabilities.value_connectors.github_public",
-                "doc": "docs/reference/protocols/value-connector-plan-v0.md",
-            },
-            {
                 "schema_version": "value_connector_install_check_packet_v0",
-                "module": "loopx.capabilities.value_connectors.github_public",
+                "module": "loopx.capabilities.value_connectors.install_check",
                 "doc": "docs/reference/protocols/value-connector-plan-v0.md",
             },
             {
@@ -693,8 +707,8 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
             "Every connector call must include a money, cost, demand, or capability metric plus a kill condition.",
         ],
         "next_real_step": (
-            "Use reply-monitor signals to graduate only explicit maintainer interest "
-            "into public triage notes or paid-path discovery; otherwise stop without bumps."
+            "Move one mapped profile at a time to its declared outcome capability, "
+            "keeping this CLI and its packet schemas stable until callers migrate."
         ),
     },
     {

--- a/loopx/capabilities/issue_fix/github_public.py
+++ b/loopx/capabilities/issue_fix/github_public.py
@@ -20,9 +20,6 @@ GITHUB_PUBLIC_REPLY_MONITOR_PACKET_SCHEMA_VERSION = (
     "github_public_reply_monitor_packet_v0"
 )
 GITHUB_PUBLIC_REPLY_SIGNAL_SCHEMA_VERSION = "github_public_reply_signal_v0"
-VALUE_CONNECTOR_INSTALL_CHECK_PACKET_SCHEMA_VERSION = (
-    "value_connector_install_check_packet_v0"
-)
 
 ALLOWED_GITHUB_REF_TYPES = {"issue", "pull", "discussion"}
 MAINTAINER_ASSOCIATIONS = {"COLLABORATOR", "MEMBER", "OWNER"}
@@ -570,129 +567,6 @@ def build_github_public_channel_probe_packet(
     }
 
 
-def build_value_connector_install_check_packet(
-    *, connector: str = "all"
-) -> dict[str, Any]:
-    checks = [
-        {
-            "connector_id": "github_public_channel",
-            "status": "ready" if shutil.which("python3") else "needs_python3",
-            "install": [
-                "python3 -m pip install -e .",
-                "loopx value-connectors github-public-probe --url https://github.com/owner/repo/issues/1 --format json",
-                "loopx value-connectors github-public-probe --url https://github.com/owner/repo/issues/1 --fetch-metadata --format json",
-                "loopx value-connectors github-reply-monitor --issue-url https://github.com/owner/repo/issues/1 --after-comment-url https://github.com/owner/repo/issues/1#issuecomment-1 --fetch-metadata --format json",
-            ],
-            "optional_tools": [
-                {
-                    "tool": "gh",
-                    "installed": shutil.which("gh") is not None,
-                    "needed_for": "discussion metadata fetch and reply-monitor metadata fetch",
-                    "install_hint": "Install GitHub CLI and run `gh auth login` if discussion metadata is needed.",
-                }
-            ],
-            "external_write_capability": False,
-        },
-        {
-            "connector_id": "agent_reach_ops_source_map",
-            "status": "ready" if shutil.which("agent-reach") else "needs_agent_reach",
-            "install": [
-                "Install Agent-Reach when available, then run `agent-reach doctor --json`.",
-                "Use `loopx value-connectors source-map --connector agent_reach_ops_source_map --format json` before drafting from external signals.",
-                "Keep Agent-Reach routes read-only; use LoopX evidence cards, maturity scores, and publish/audit gates for action.",
-            ],
-            "optional_tools": [
-                {
-                    "tool": "agent-reach",
-                    "installed": shutil.which("agent-reach") is not None,
-                    "needed_for": "source routing across public/read-only external channels",
-                    "install_hint": "Install Agent-Reach in the active agent environment and rerun `agent-reach doctor --json`.",
-                },
-                {
-                    "tool": "gh",
-                    "installed": shutil.which("gh") is not None,
-                    "needed_for": "GitHub-backed source routes and public repository search",
-                    "install_hint": "Install GitHub CLI and authenticate if GitHub source routes are needed.",
-                },
-            ],
-            "external_write_capability": False,
-        },
-        {
-            "connector_id": "finance_market_snapshot",
-            "status": "probed_candidate",
-            "install": [
-                "Use `loopx value-connectors source-map --connector finance_market_snapshot --format json` for the boundary packet.",
-                "Plan finance information pulls as public/reference snapshots, not advice or trading actions.",
-                "Stop for credentials, AK/SK, paid feeds, private portfolio data, or trading intent.",
-            ],
-            "optional_tools": [],
-            "external_write_capability": False,
-        },
-        {
-            "connector_id": "botmail_identity",
-            "status": "host_connector_required",
-            "install": [
-                "Install or enable a host email/Botmail connector.",
-                "Use LoopX only to plan the exact sender, recipient, subject, body, metric, and stop condition before sending.",
-            ],
-            "optional_tools": [],
-            "external_write_capability": True,
-            "write_gate": "exact sender/recipient/subject/body approval required before send",
-        },
-        {
-            "connector_id": "community_channel",
-            "status": "host_or_browser_connector_required",
-            "install": [
-                "Enable a browser or community connector owned by the user.",
-                "Run `loopx value-connectors plan` before signup, posting, or replies.",
-            ],
-            "optional_tools": [],
-            "external_write_capability": True,
-            "write_gate": "channel rules, account identity, exact message, and value metric required",
-        },
-        {
-            "connector_id": "social_browser_x",
-            "status": "ready" if shutil.which("ego-browser") else "needs_ego_browser",
-            "install": [
-                "Install ego lite / ego-browser and log in to X in the user-owned browser profile.",
-                "Use LoopX to plan X account setup, research, draft, publish, and reply-monitor calls before browser execution.",
-                "loopx content-ops observe-public-handle --url https://x.com/loopxops --source-item-id source_x_loopx_public_handle --no-fetch --format json",
-                "loopx value-connectors plan --connector-id social_browser_x --connector-kind browser_social_channel --channel 'X public post via ego-browser' --stage external_write_request --target-ref 'one approved LoopX post' --target-url https://x.com/loopxops --external-write-requested --money-metric 'qualified workflow owner asks for LoopX setup help' --success-metric 'one audit, demo, or setup request' --kill-condition 'spam hiding, account-health degradation, or no workflow owner signal' --format json",
-            ],
-            "optional_tools": [
-                {
-                    "tool": "ego-browser",
-                    "installed": shutil.which("ego-browser") is not None,
-                    "needed_for": "logged-in browser research, profile maintenance, uploads, approved posts, and reply monitoring",
-                    "install_hint": "Install ego lite, then confirm `ego-browser nodejs` can open the target site.",
-                }
-            ],
-            "external_write_capability": True,
-            "write_gate": "exact account identity, body, image, link, mentions, and stop condition required before any X write",
-        },
-    ]
-    selected = [
-        item
-        for item in checks
-        if connector == "all" or item["connector_id"] == connector
-    ]
-    if not selected:
-        raise ValueError("unknown connector install check")
-    return {
-        "ok": True,
-        "schema_version": VALUE_CONNECTOR_INSTALL_CHECK_PACKET_SCHEMA_VERSION,
-        "mode": "value-connector-install-check",
-        "connector": connector,
-        "checks": selected,
-        "truth_contract": {
-            "installation_check_only": True,
-            "external_reads_performed": False,
-            "external_writes_performed": False,
-            "restricted_material_recorded": False,
-        },
-    }
-
-
 def render_github_public_reply_monitor_markdown(payload: dict[str, Any]) -> str:
     ref = payload.get("ref") if isinstance(payload.get("ref"), Mapping) else {}
     validation = payload.get("validation") if isinstance(payload.get("validation"), Mapping) else {}
@@ -745,7 +619,6 @@ def render_github_public_reply_monitor_markdown(payload: dict[str, Any]) -> str:
         lines.extend(["", "## Error", "", str(payload.get("error"))])
     return "\n".join(lines).rstrip() + "\n"
 
-
 def render_github_public_channel_probe_markdown(payload: dict[str, Any]) -> str:
     ref = payload.get("ref") if isinstance(payload.get("ref"), Mapping) else {}
     metadata = payload.get("metadata") if isinstance(payload.get("metadata"), Mapping) else {}
@@ -785,32 +658,4 @@ def render_github_public_channel_probe_markdown(payload: dict[str, Any]) -> str:
     if errors:
         lines.extend(["## Validation Errors", ""])
         lines.extend(f"- {error}" for error in errors)
-    return "\n".join(lines).rstrip() + "\n"
-
-
-def render_value_connector_install_check_markdown(payload: dict[str, Any]) -> str:
-    lines = ["# LoopX Value Connector Install Check", ""]
-    for item in payload.get("checks") or []:
-        if not isinstance(item, Mapping):
-            continue
-        lines.extend(
-            [
-                f"## {item.get('connector_id')}",
-                "",
-                f"- status: `{item.get('status')}`",
-                f"- external_write_capability: `{item.get('external_write_capability')}`",
-            ]
-        )
-        if item.get("write_gate"):
-            lines.append(f"- write_gate: {item.get('write_gate')}")
-        lines.extend(["", "Install / use:"])
-        for command in item.get("install") or []:
-            lines.append(f"- `{command}`")
-        for tool in item.get("optional_tools") or []:
-            if not isinstance(tool, Mapping):
-                continue
-            lines.append(
-                f"- optional `{tool.get('tool')}` installed=`{tool.get('installed')}`: {tool.get('needed_for')}"
-            )
-        lines.append("")
     return "\n".join(lines).rstrip() + "\n"

--- a/loopx/capabilities/value_connectors/cli.py
+++ b/loopx/capabilities/value_connectors/cli.py
@@ -6,12 +6,14 @@ import sys
 from collections.abc import Callable
 from pathlib import Path
 
-from .github_public import (
+from ..issue_fix.github_public import (
     build_github_public_channel_probe_packet,
     build_github_public_reply_monitor_packet,
-    build_value_connector_install_check_packet,
     render_github_public_channel_probe_markdown,
     render_github_public_reply_monitor_markdown,
+)
+from .install_check import (
+    build_value_connector_install_check_packet,
     render_value_connector_install_check_markdown,
 )
 from .planner import (

--- a/loopx/capabilities/value_connectors/install_check.py
+++ b/loopx/capabilities/value_connectors/install_check.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import shutil
+from collections.abc import Mapping
+from typing import Any
+
+
+VALUE_CONNECTOR_INSTALL_CHECK_PACKET_SCHEMA_VERSION = (
+    "value_connector_install_check_packet_v0"
+)
+
+
+def build_value_connector_install_check_packet(
+    *, connector: str = "all"
+) -> dict[str, Any]:
+    checks = [
+        {
+            "connector_id": "github_public_channel",
+            "status": "ready" if shutil.which("python3") else "needs_python3",
+            "install": [
+                "python3 -m pip install -e .",
+                "loopx value-connectors github-public-probe --url https://github.com/owner/repo/issues/1 --format json",
+                "loopx value-connectors github-public-probe --url https://github.com/owner/repo/issues/1 --fetch-metadata --format json",
+                "loopx value-connectors github-reply-monitor --issue-url https://github.com/owner/repo/issues/1 --after-comment-url https://github.com/owner/repo/issues/1#issuecomment-1 --fetch-metadata --format json",
+            ],
+            "optional_tools": [
+                {
+                    "tool": "gh",
+                    "installed": shutil.which("gh") is not None,
+                    "needed_for": "discussion metadata fetch and reply-monitor metadata fetch",
+                    "install_hint": "Install GitHub CLI and run `gh auth login` if discussion metadata is needed.",
+                }
+            ],
+            "external_write_capability": False,
+        },
+        {
+            "connector_id": "agent_reach_ops_source_map",
+            "status": "ready" if shutil.which("agent-reach") else "needs_agent_reach",
+            "install": [
+                "Install Agent-Reach when available, then run `agent-reach doctor --json`.",
+                "Use `loopx value-connectors source-map --connector agent_reach_ops_source_map --format json` before drafting from external signals.",
+                "Keep Agent-Reach routes read-only; use LoopX evidence cards, maturity scores, and publish/audit gates for action.",
+            ],
+            "optional_tools": [
+                {
+                    "tool": "agent-reach",
+                    "installed": shutil.which("agent-reach") is not None,
+                    "needed_for": "source routing across public/read-only external channels",
+                    "install_hint": "Install Agent-Reach in the active agent environment and rerun `agent-reach doctor --json`.",
+                },
+                {
+                    "tool": "gh",
+                    "installed": shutil.which("gh") is not None,
+                    "needed_for": "GitHub-backed source routes and public repository search",
+                    "install_hint": "Install GitHub CLI and authenticate if GitHub source routes are needed.",
+                },
+            ],
+            "external_write_capability": False,
+        },
+        {
+            "connector_id": "finance_market_snapshot",
+            "status": "probed_candidate",
+            "install": [
+                "Use `loopx value-connectors source-map --connector finance_market_snapshot --format json` for the boundary packet.",
+                "Plan finance information pulls as public/reference snapshots, not advice or trading actions.",
+                "Stop for credentials, AK/SK, paid feeds, private portfolio data, or trading intent.",
+            ],
+            "optional_tools": [],
+            "external_write_capability": False,
+        },
+        {
+            "connector_id": "botmail_identity",
+            "status": "host_connector_required",
+            "install": [
+                "Install or enable a host email/Botmail connector.",
+                "Use LoopX only to plan the exact sender, recipient, subject, body, metric, and stop condition before sending.",
+            ],
+            "optional_tools": [],
+            "external_write_capability": True,
+            "write_gate": "exact sender/recipient/subject/body approval required before send",
+        },
+        {
+            "connector_id": "community_channel",
+            "status": "host_or_browser_connector_required",
+            "install": [
+                "Enable a browser or community connector owned by the user.",
+                "Run `loopx value-connectors plan` before signup, posting, or replies.",
+            ],
+            "optional_tools": [],
+            "external_write_capability": True,
+            "write_gate": "channel rules, account identity, exact message, and value metric required",
+        },
+        {
+            "connector_id": "social_browser_x",
+            "status": "ready" if shutil.which("ego-browser") else "needs_ego_browser",
+            "install": [
+                "Install ego lite / ego-browser and log in to X in the user-owned browser profile.",
+                "Use LoopX to plan X account setup, research, draft, publish, and reply-monitor calls before browser execution.",
+                "loopx content-ops observe-public-handle --url https://x.com/loopxops --source-item-id source_x_loopx_public_handle --no-fetch --format json",
+                "loopx value-connectors plan --connector-id social_browser_x --connector-kind browser_social_channel --channel 'X public post via ego-browser' --stage external_write_request --target-ref 'one approved LoopX post' --target-url https://x.com/loopxops --external-write-requested --money-metric 'qualified workflow owner asks for LoopX setup help' --success-metric 'one audit, demo, or setup request' --kill-condition 'spam hiding, account-health degradation, or no workflow owner signal' --format json",
+            ],
+            "optional_tools": [
+                {
+                    "tool": "ego-browser",
+                    "installed": shutil.which("ego-browser") is not None,
+                    "needed_for": "logged-in browser research, profile maintenance, uploads, approved posts, and reply monitoring",
+                    "install_hint": "Install ego lite, then confirm `ego-browser nodejs` can open the target site.",
+                }
+            ],
+            "external_write_capability": True,
+            "write_gate": "exact account identity, body, image, link, mentions, and stop condition required before any X write",
+        },
+    ]
+    selected = [
+        item
+        for item in checks
+        if connector == "all" or item["connector_id"] == connector
+    ]
+    if not selected:
+        raise ValueError("unknown connector install check")
+    return {
+        "ok": True,
+        "schema_version": VALUE_CONNECTOR_INSTALL_CHECK_PACKET_SCHEMA_VERSION,
+        "mode": "value-connector-install-check",
+        "connector": connector,
+        "checks": selected,
+        "truth_contract": {
+            "installation_check_only": True,
+            "external_reads_performed": False,
+            "external_writes_performed": False,
+            "restricted_material_recorded": False,
+        },
+    }
+
+
+def render_value_connector_install_check_markdown(payload: dict[str, Any]) -> str:
+    lines = ["# LoopX Value Connector Install Check", ""]
+    for item in payload.get("checks") or []:
+        if not isinstance(item, Mapping):
+            continue
+        lines.extend(
+            [
+                f"## {item.get('connector_id')}",
+                "",
+                f"- status: `{item.get('status')}`",
+                f"- external_write_capability: `{item.get('external_write_capability')}`",
+            ]
+        )
+        if item.get("write_gate"):
+            lines.append(f"- write_gate: {item.get('write_gate')}")
+        lines.extend(["", "Install / use:"])
+        for command in item.get("install") or []:
+            lines.append(f"- `{command}`")
+        for tool in item.get("optional_tools") or []:
+            if not isinstance(tool, Mapping):
+                continue
+            lines.append(
+                f"- optional `{tool.get('tool')}` installed=`{tool.get('installed')}`: {tool.get('needed_for')}"
+            )
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"

--- a/loopx/capabilities/value_connectors/source_map.py
+++ b/loopx/capabilities/value_connectors/source_map.py
@@ -19,6 +19,56 @@ SOURCE_PROFILE_IDS = {
     "finance_market_snapshot",
 }
 
+OUTCOME_PROVIDER_BINDINGS: dict[str, dict[str, str | None]] = {
+    "github_public_channel": {
+        "outcome_capability_id": "issue-fix",
+        "provider_binding_state": "migrated",
+        "provider_module": "loopx.capabilities.issue_fix.github_public",
+    },
+    "github_public_reply_monitor": {
+        "outcome_capability_id": "issue-fix",
+        "provider_binding_state": "migrated",
+        "provider_module": "loopx.capabilities.issue_fix.github_public",
+    },
+    "content_ops_public_handle": {
+        "outcome_capability_id": "content-ops",
+        "provider_binding_state": "native",
+        "provider_module": "loopx.capabilities.content_ops.surface",
+    },
+    "social_browser_x": {
+        "outcome_capability_id": "content-ops",
+        "provider_binding_state": "mapped",
+        "provider_module": None,
+    },
+    "agent_reach_ops_source_map": {
+        "outcome_capability_id": "content-ops",
+        "provider_binding_state": "mapped",
+        "provider_module": None,
+    },
+    "finance_market_snapshot": {
+        "outcome_capability_id": "finance-value-discovery",
+        "provider_binding_state": "mapped",
+        "provider_module": None,
+    },
+    "botmail_identity": {
+        "outcome_capability_id": "content-ops",
+        "provider_binding_state": "mapped",
+        "provider_module": None,
+    },
+    "community_channel": {
+        "outcome_capability_id": "content-ops",
+        "provider_binding_state": "mapped",
+        "provider_module": None,
+    },
+}
+
+
+def _outcome_provider_binding(connector_id: str) -> dict[str, str | None]:
+    binding = OUTCOME_PROVIDER_BINDINGS.get(connector_id)
+    if binding is None:
+        raise ValueError(f"connector {connector_id!r} has no outcome provider binding")
+    return dict(binding)
+
 
 def _source_profile(
     *,
@@ -56,6 +106,7 @@ def _source_profile(
             "requested action would capture raw private content",
             "requested action would perform an external write without an audit gate",
         ],
+        **_outcome_provider_binding(connector_id),
     }
 
 
@@ -203,6 +254,7 @@ def _action_gated_profiles() -> list[dict[str, Any]]:
             "purpose": "email or botmail identity for replies and outreach",
             "safe_prepare_command": "loopx value-connectors plan --connector-id botmail_identity --connector-kind botmail_identity ... --format json",
             "write_gate": "exact sender, recipient, subject, body, metric, and stop condition required",
+            **_outcome_provider_binding("botmail_identity"),
         },
         {
             "connector_id": "community_channel",
@@ -210,6 +262,7 @@ def _action_gated_profiles() -> list[dict[str, Any]]:
             "purpose": "community reply or post after channel-rule review",
             "safe_prepare_command": "loopx value-connectors plan --connector-id community_channel --connector-kind community_channel ... --format json",
             "write_gate": "exact channel, account identity, message, value metric, and channel-rule fit required",
+            **_outcome_provider_binding("community_channel"),
         },
     ]
 
@@ -263,6 +316,14 @@ def build_value_connector_source_map_packet(*, connector: str = "all") -> dict[s
         "source_profile_count": len(profiles),
         "action_gated_profile_count": len(action_gated),
         "external_write_blocked_by_default": True,
+        "compatibility_facade": True,
+        "new_profile_ownership_allowed": False,
+        "mapped_profile_count": len(profiles) + len(action_gated),
+        "migrated_profile_count": sum(
+            1
+            for profile in [*profiles, *action_gated]
+            if profile.get("provider_binding_state") in {"migrated", "native"}
+        ),
         "read_first_loop": [
             "choose source profile",
             "run only the read/metadata command",
@@ -310,6 +371,8 @@ def render_value_connector_source_map_markdown(payload: dict[str, Any]) -> str:
         f"- external_reads_performed: `{payload.get('external_reads_performed')}`",
         f"- external_writes_performed: `{payload.get('external_writes_performed')}`",
         f"- agent_can_start_without_docs: `{projection.get('agent_can_start_without_docs')}`",
+        f"- compatibility_facade: `{projection.get('compatibility_facade')}`",
+        f"- new_profile_ownership_allowed: `{projection.get('new_profile_ownership_allowed')}`",
         f"- source_profile_count: `{projection.get('source_profile_count')}`",
         f"- action_gated_profile_count: `{projection.get('action_gated_profile_count')}`",
         "",
@@ -328,6 +391,8 @@ def render_value_connector_source_map_markdown(payload: dict[str, Any]) -> str:
                 "",
                 f"- status: `{profile.get('status')}`",
                 f"- boundary: `{profile.get('boundary')}`",
+                f"- outcome_capability_id: `{profile.get('outcome_capability_id')}`",
+                f"- provider_binding_state: `{profile.get('provider_binding_state')}`",
                 f"- evidence_schema: `{profile.get('evidence_schema')}`",
                 f"- maturity_hint: {profile.get('maturity_hint')}",
                 "- commands:",
@@ -347,6 +412,8 @@ def render_value_connector_source_map_markdown(payload: dict[str, Any]) -> str:
             lines.extend(
                 [
                     f"- `{profile.get('connector_id')}`: {profile.get('purpose')}",
+                    f"  - outcome_capability_id: `{profile.get('outcome_capability_id')}`",
+                    f"  - provider_binding_state: `{profile.get('provider_binding_state')}`",
                     f"  - gate: {profile.get('write_gate')}",
                 ]
             )


### PR DESCRIPTION
## Summary

- freeze `value-connectors` as the compatibility CLI/protocol facade and project an explicit outcome owner plus migration state for every GitHub, content, social, Agent-Reach, finance, Botmail, and community profile
- move the proven public GitHub probe/reply-monitor implementation and protocol ownership to `issue-fix`; keep existing CLI commands and packet schemas unchanged
- split generic install checks from the GitHub provider, remove the obsolete internal Python import path, and document the ownership model

## Validation

- `uvx --from ruff==0.12.11 ruff check ...` (changed Python surfaces): passed
- `examples/value-connectors-github-public-probe-smoke.py`: passed
- `examples/capability-extension-registry-smoke.py`: passed
- `examples/capability-extension-placement-doc-smoke.py`: passed
- `loopx canary premerge --from-git-diff`: passed, 4 direct checks plus 18/18 selected checks, public-boundary scan clean, no warnings or manual holds

## Failures / skips

- no final failures or skipped required checks
- two earlier premerge attempts hit host interpreter selection and then exhausted local temporary disk during installer smokes; the supported interpreter was bound, stale test-only temp directories were removed, both installer smokes passed independently, and the exact final HEAD passed the complete gate

## Scope rationale

The facade remains because its CLI and packet schemas are existing caller contracts. This PR migrates only the proven GitHub implementation; other profiles receive explicit owners without speculative provider modules. No old Python import shim is retained because repository callers are migrated and the import path was not a supported public contract.
