### PR TITLE
refactor(content-ops): own social browser connector profile

### DIFF
--- a/docs/capabilities/content-ops/README.md
+++ b/docs/capabilities/content-ops/README.md
@@ -49,3 +49,15 @@ turning LoopX into a raw platform archive or untracked publisher. Even when an
 owner grants broad posting discretion, the agent should still record the exact
 body, account/channel, source map, timing, and stop condition before an external
 post.
+
+## Social Browser Provider
+
+`content-ops` owns the built-in `social_browser_x` provider because public
+social observation, source promotion, draft preparation, and publish gates are
+content outcomes. The provider supplies one shared source profile, install
+check, and metadata-only connector trial. The `value-connectors` CLI remains a
+compatibility facade and delegates those packets without changing their output.
+
+The provider does not open a browser, read a timeline, or publish. A real
+browser session remains owner-controlled, and every external write still needs
+the exact account, body, media/link plan, source references, and stop condition.

--- a/docs/capabilities/value-connectors/README.md
+++ b/docs/capabilities/value-connectors/README.md
@@ -79,9 +79,11 @@ call planning, but it does not own new user outcomes. Each profile declares the
 outcome capability that serves callers; implementations move there one proven
 profile at a time while these CLI commands stay stable.
 
-The first completed migration is the public GitHub probe and reply monitor.
-Their implementation and protocol ownership now live under `issue-fix`; the
-existing `loopx value-connectors ...` commands delegate to that provider.
+The first completed migrations are the public GitHub probe/reply monitor and
+the `social_browser_x` profile. GitHub implementation and protocol ownership
+live under `issue-fix`; the social source, install, and content-ops trial
+contracts live under `content-ops`. Existing `loopx value-connectors ...`
+commands delegate to those providers.
 
 ## Connector Profiles
 
@@ -90,7 +92,7 @@ existing `loopx value-connectors ...` commands delegate to that provider.
 | `github_public_channel` | `issue-fix` | migrated | yes | none |
 | `github_public_reply_monitor` | `issue-fix` | migrated | yes | none |
 | `content_ops_public_handle` | `content-ops` | native | public-handle observation | none |
-| `social_browser_x` | `content-ops` | mapped | install-check, public-handle packet, and gated plan | exact profile/post/reply gate required |
+| `social_browser_x` | `content-ops` | migrated | install-check, public-handle packet, and gated plan | exact profile/post/reply gate required |
 | `finance_market_snapshot` | `finance-value-discovery` | mapped | plan, user prompt surface, and [no-credential probe packet](finance-market-snapshot-probe.md) | account, private portfolio, trading, and paid-data gates required |
 | `agent_reach_ops_source_map` | `content-ops` | mapped | `loopx value-connectors source-map --connector agent_reach_ops_source_map --format json`; [profile note](agent-reach-ops-source-map.md) | publish/audit record required for every external write |
 | `botmail_identity` | `content-ops` | mapped | install-check only | exact send gate required |

--- a/docs/reference/protocols/value-connector-plan-v0.md
+++ b/docs/reference/protocols/value-connector-plan-v0.md
@@ -3,9 +3,10 @@
 Status: public-safe connector planning and starter runtime contract v0.
 
 `loopx value-connectors` is a compatibility CLI and protocol facade. Generic
-planning, install checks, and source mapping remain here. The public GitHub
-probe and reply-monitor implementations are owned by `issue-fix` and are still
-invoked through the commands below so existing callers do not change.
+planning and the stable command surface remain here. Public GitHub probes are
+owned by `issue-fix`; the `social_browser_x` source, install, and connector-trial
+contracts are owned by `content-ops`. Existing callers still invoke the commands
+below while the facade delegates to those providers.
 
 `value_connector_plan_v0` is a compact contract for external-value connector
 calls. It sits before real connector execution so LoopX can separate useful
@@ -81,6 +82,7 @@ loopx value-connectors plan \
 | `connector_approval_gate_v0` | Exact-call approval gate for account setup, external writes, sends, publishing, or private expansion. |
 | `github_public_channel_probe_packet_v0` | Starter connector output for public GitHub issue/PR/discussion metadata. |
 | `github_public_reply_monitor_packet_v0` | Starter connector output for public maintainer reply detection after a LoopX comment. |
+| `content_ops_social_browser_x_provider_v0` | Content-ops-owned source, install, and metadata-only trial contract behind the compatibility facade. |
 | `finance_market_snapshot_profile_v0` | Candidate profile for quote/fund/news/announcement pulls with source, freshness, uncertainty, and no-investment-advice gates. |
 | `finance_market_snapshot_probe_packet_v0` | No-credential public-source probe packet for Eastmoney/Futu/GitHub OSS source readiness, gates, and fallback decisions. |
 | `value_connector_install_check_packet_v0` | Local install/use checklist for connector starters. |

--- a/examples/value-connectors-github-public-probe-smoke.py
+++ b/examples/value-connectors-github-public-probe-smoke.py
@@ -125,6 +125,11 @@ def main() -> int:
     )
     assert profiles["content_ops_public_handle"]["provider_binding_state"] == "native"
     assert profiles["social_browser_x"]["outcome_capability_id"] == "content-ops"
+    assert profiles["social_browser_x"]["provider_binding_state"] == "migrated"
+    assert (
+        profiles["social_browser_x"]["provider_module"]
+        == "loopx.capabilities.content_ops.social_browser_x"
+    )
     assert profiles["agent_reach_ops_source_map"]["outcome_capability_id"] == "content-ops"
     assert (
         profiles["finance_market_snapshot"]["outcome_capability_id"]
@@ -141,7 +146,7 @@ def main() -> int:
     assert source_map["projection"]["compatibility_facade"] is True
     assert source_map["projection"]["new_profile_ownership_allowed"] is False
     assert source_map["projection"]["mapped_profile_count"] == 8
-    assert source_map["projection"]["migrated_profile_count"] == 3
+    assert source_map["projection"]["migrated_profile_count"] == 4
     assert source_map["generic_evidence_card_schema"]["operation"] == "read", source_map
     assert "loopx value-connectors plan" in source_map["agent_prompt"], source_map
     assert_public_safe(source_map)

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -596,6 +596,11 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "module": "loopx.capabilities.content_ops.surface",
                 "doc": "docs/reference/protocols/content-ops-surface-v0.md",
             },
+            {
+                "schema_version": "content_ops_social_browser_x_provider_v0",
+                "module": "loopx.capabilities.content_ops.social_browser_x",
+                "doc": "docs/capabilities/content-ops/README.md",
+            },
         ],
         "smokes": [
             "python3 examples/content-ops-exploration-plan-smoke.py",

--- a/loopx/capabilities/content_ops/social_browser_x.py
+++ b/loopx/capabilities/content_ops/social_browser_x.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import shutil
+from typing import Any
+
+
+CONTENT_OPS_SOCIAL_BROWSER_X_PROVIDER_SCHEMA_VERSION = (
+    "content_ops_social_browser_x_provider_v0"
+)
+SOCIAL_BROWSER_X_CONNECTOR_ID = "social_browser_x"
+SOCIAL_BROWSER_X_PROVIDER_MODULE = "loopx.capabilities.content_ops.social_browser_x"
+
+
+def build_social_browser_x_provider_packet() -> dict[str, Any]:
+    return {
+        "ok": True,
+        "schema_version": CONTENT_OPS_SOCIAL_BROWSER_X_PROVIDER_SCHEMA_VERSION,
+        "connector_id": SOCIAL_BROWSER_X_CONNECTOR_ID,
+        "outcome_capability_id": "content-ops",
+        "provider_module": SOCIAL_BROWSER_X_PROVIDER_MODULE,
+        "source_profile": {
+            "connector_id": SOCIAL_BROWSER_X_CONNECTOR_ID,
+            "status": "profile_ready_when_browser_available",
+            "route_type": "browser-backed public/social channel",
+            "boundary": "logged_in_read",
+            "safe_uses": [
+                "read public or account-visible X metadata through an owner-approved browser profile",
+                "prepare source-mapped drafts for LoopX posts or replies",
+                "monitor published posts after an audited publish record exists",
+            ],
+            "commands": [
+                "loopx content-ops observe-public-handle --url https://x.com/<handle> --source-item-id <stable-source-id> --no-fetch --format json",
+                "loopx value-connectors plan --connector-id social_browser_x --connector-kind browser_social_channel --channel 'X public post via browser' --stage external_write_request --target-ref '<exact post>' --target-url https://x.com/<handle> --external-write-requested --money-metric '<demand metric>' --success-metric '<success metric>' --kill-condition '<stop condition>' --format json",
+            ],
+            "evidence_schema": (
+                "x_draft_packet_v0 or content_ops_public_handle_observation_packet_v0"
+            ),
+            "maturity_hint": (
+                "Use repeated public signals and concrete workflow-owner replies; "
+                "avoid platform drama as proof."
+            ),
+            "write_gate": (
+                "exact account, final body, media/link plan, timing, source refs, "
+                "and stop condition required"
+            ),
+            "stop_conditions": [
+                "active account identity is unclear",
+                "source requires private DMs, private lists, or hidden timeline expansion",
+                "post/reply/media upload would execute without an audit record",
+            ],
+        },
+        "install_check": {
+            "connector_id": SOCIAL_BROWSER_X_CONNECTOR_ID,
+            "status": "ready" if shutil.which("ego-browser") else "needs_ego_browser",
+            "install": [
+                "Install ego lite / ego-browser and log in to X in the user-owned browser profile.",
+                "Use LoopX to plan X account setup, research, draft, publish, and reply-monitor calls before browser execution.",
+                "loopx content-ops observe-public-handle --url https://x.com/loopxops --source-item-id source_x_loopx_public_handle --no-fetch --format json",
+                "loopx value-connectors plan --connector-id social_browser_x --connector-kind browser_social_channel --channel 'X public post via ego-browser' --stage external_write_request --target-ref 'one approved LoopX post' --target-url https://x.com/loopxops --external-write-requested --money-metric 'qualified workflow owner asks for LoopX setup help' --success-metric 'one audit, demo, or setup request' --kill-condition 'spam hiding, account-health degradation, or no workflow owner signal' --format json",
+            ],
+            "optional_tools": [
+                {
+                    "tool": "ego-browser",
+                    "installed": shutil.which("ego-browser") is not None,
+                    "needed_for": (
+                        "logged-in browser research, profile maintenance, uploads, "
+                        "approved posts, and reply monitoring"
+                    ),
+                    "install_hint": (
+                        "Install ego lite, then confirm `ego-browser nodejs` can "
+                        "open the target site."
+                    ),
+                }
+            ],
+            "external_write_capability": True,
+            "write_gate": (
+                "exact account identity, body, image, link, mentions, and stop "
+                "condition required before any X write"
+            ),
+        },
+        "connector_trial": {
+            "schema_version": "connector_trial_v0",
+            "trial_id": "trial_x_ego_lite_browser",
+            "surface": "x_public_feed",
+            "tool_hint": "ego-lite browser",
+            "access_mode": "public_metadata_only",
+            "source_status": "public",
+            "freshness": "unknown",
+            "allowed_use": "metadata_only",
+            "trial_state": "ready_for_metadata_trial",
+            "proposed_source_item_id": "source_x_public_signal_001",
+            "terms_note": (
+                "public/terms-aware signal intake; no login, posting, or raw "
+                "timeline capture in LoopX state"
+            ),
+            "promotion_target": "source_item_v0",
+            "requires_user_gate": False,
+            "external_write_allowed": False,
+        },
+        "truth_contract": {
+            "compatibility_facade_may_delegate": True,
+            "external_reads_performed": False,
+            "external_writes_performed": False,
+            "autopublish_allowed": False,
+            "raw_platform_data_recorded": False,
+        },
+    }

--- a/loopx/capabilities/content_ops/surface.py
+++ b/loopx/capabilities/content_ops/surface.py
@@ -13,14 +13,15 @@ from .connector_packets import (
     source_item_and_trial_from_private_gate_packet,
     source_item_and_trial_from_public_packet,
 )
+from .social_browser_x import build_social_browser_x_provider_packet
 from .markdown import (
-    render_content_ops_chatview_report_markdown,
-    render_content_ops_exploration_plan_markdown,
-    render_content_ops_packet_aggregation_markdown,
-    render_content_ops_preview_markdown,
-    render_content_ops_private_connector_gate_markdown,
-    render_content_ops_public_handle_observation_markdown,
-    render_content_ops_walkthrough_artifact_markdown,
+    render_content_ops_chatview_report_markdown as render_content_ops_chatview_report_markdown,
+    render_content_ops_exploration_plan_markdown as render_content_ops_exploration_plan_markdown,
+    render_content_ops_packet_aggregation_markdown as render_content_ops_packet_aggregation_markdown,
+    render_content_ops_preview_markdown as render_content_ops_preview_markdown,
+    render_content_ops_private_connector_gate_markdown as render_content_ops_private_connector_gate_markdown,
+    render_content_ops_public_handle_observation_markdown as render_content_ops_public_handle_observation_markdown,
+    render_content_ops_walkthrough_artifact_markdown as render_content_ops_walkthrough_artifact_markdown,
 )
 from .schemas import (
     ANGLE_CANDIDATE_SCHEMA_VERSION,
@@ -496,22 +497,7 @@ def build_content_ops_surface_fixture(
         }
     ]
     connector_trials = [
-        {
-            "schema_version": CONNECTOR_TRIAL_SCHEMA_VERSION,
-            "trial_id": "trial_x_ego_lite_browser",
-            "surface": "x_public_feed",
-            "tool_hint": "ego-lite browser",
-            "access_mode": "public_metadata_only",
-            "source_status": "public",
-            "freshness": "unknown",
-            "allowed_use": "metadata_only",
-            "trial_state": "ready_for_metadata_trial",
-            "proposed_source_item_id": "source_x_public_signal_001",
-            "terms_note": "public/terms-aware signal intake; no login, posting, or raw timeline capture in LoopX state",
-            "promotion_target": "source_item_v0",
-            "requires_user_gate": False,
-            "external_write_allowed": False,
-        },
+        build_social_browser_x_provider_packet()["connector_trial"],
         {
             "schema_version": CONNECTOR_TRIAL_SCHEMA_VERSION,
             "trial_id": "trial_wechat_chatlog_alpha",

--- a/loopx/capabilities/value_connectors/install_check.py
+++ b/loopx/capabilities/value_connectors/install_check.py
@@ -4,6 +4,8 @@ import shutil
 from collections.abc import Mapping
 from typing import Any
 
+from ..content_ops.social_browser_x import build_social_browser_x_provider_packet
+
 
 VALUE_CONNECTOR_INSTALL_CHECK_PACKET_SCHEMA_VERSION = (
     "value_connector_install_check_packet_v0"
@@ -90,26 +92,7 @@ def build_value_connector_install_check_packet(
             "external_write_capability": True,
             "write_gate": "channel rules, account identity, exact message, and value metric required",
         },
-        {
-            "connector_id": "social_browser_x",
-            "status": "ready" if shutil.which("ego-browser") else "needs_ego_browser",
-            "install": [
-                "Install ego lite / ego-browser and log in to X in the user-owned browser profile.",
-                "Use LoopX to plan X account setup, research, draft, publish, and reply-monitor calls before browser execution.",
-                "loopx content-ops observe-public-handle --url https://x.com/loopxops --source-item-id source_x_loopx_public_handle --no-fetch --format json",
-                "loopx value-connectors plan --connector-id social_browser_x --connector-kind browser_social_channel --channel 'X public post via ego-browser' --stage external_write_request --target-ref 'one approved LoopX post' --target-url https://x.com/loopxops --external-write-requested --money-metric 'qualified workflow owner asks for LoopX setup help' --success-metric 'one audit, demo, or setup request' --kill-condition 'spam hiding, account-health degradation, or no workflow owner signal' --format json",
-            ],
-            "optional_tools": [
-                {
-                    "tool": "ego-browser",
-                    "installed": shutil.which("ego-browser") is not None,
-                    "needed_for": "logged-in browser research, profile maintenance, uploads, approved posts, and reply monitoring",
-                    "install_hint": "Install ego lite, then confirm `ego-browser nodejs` can open the target site.",
-                }
-            ],
-            "external_write_capability": True,
-            "write_gate": "exact account identity, body, image, link, mentions, and stop condition required before any X write",
-        },
+        build_social_browser_x_provider_packet()["install_check"],
     ]
     selected = [
         item

--- a/loopx/capabilities/value_connectors/source_map.py
+++ b/loopx/capabilities/value_connectors/source_map.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
+from ..content_ops.social_browser_x import (
+    SOCIAL_BROWSER_X_PROVIDER_MODULE,
+    build_social_browser_x_provider_packet,
+)
+
 
 VALUE_CONNECTOR_SOURCE_MAP_PACKET_SCHEMA_VERSION = "value_connector_source_map_packet_v0"
 VALUE_CONNECTOR_SOURCE_PROFILE_SCHEMA_VERSION = "value_connector_source_profile_v0"
@@ -37,8 +42,8 @@ OUTCOME_PROVIDER_BINDINGS: dict[str, dict[str, str | None]] = {
     },
     "social_browser_x": {
         "outcome_capability_id": "content-ops",
-        "provider_binding_state": "mapped",
-        "provider_module": None,
+        "provider_binding_state": "migrated",
+        "provider_module": SOCIAL_BROWSER_X_PROVIDER_MODULE,
     },
     "agent_reach_ops_source_map": {
         "outcome_capability_id": "content-ops",
@@ -111,6 +116,7 @@ def _source_profile(
 
 
 def _source_profiles() -> list[dict[str, Any]]:
+    social_browser_x = build_social_browser_x_provider_packet()
     return [
         _source_profile(
             connector_id="github_public_channel",
@@ -177,29 +183,7 @@ def _source_profiles() -> list[dict[str, Any]]:
                 "the next step would scrape private timeline material",
             ],
         ),
-        _source_profile(
-            connector_id="social_browser_x",
-            status="profile_ready_when_browser_available",
-            route_type="browser-backed public/social channel",
-            boundary="logged_in_read",
-            safe_uses=[
-                "read public or account-visible X metadata through an owner-approved browser profile",
-                "prepare source-mapped drafts for LoopX posts or replies",
-                "monitor published posts after an audited publish record exists",
-            ],
-            commands=[
-                "loopx content-ops observe-public-handle --url https://x.com/<handle> --source-item-id <stable-source-id> --no-fetch --format json",
-                "loopx value-connectors plan --connector-id social_browser_x --connector-kind browser_social_channel --channel 'X public post via browser' --stage external_write_request --target-ref '<exact post>' --target-url https://x.com/<handle> --external-write-requested --money-metric '<demand metric>' --success-metric '<success metric>' --kill-condition '<stop condition>' --format json",
-            ],
-            evidence_schema="x_draft_packet_v0 or content_ops_public_handle_observation_packet_v0",
-            maturity_hint="Use repeated public signals and concrete workflow-owner replies; avoid platform drama as proof.",
-            write_gate="exact account, final body, media/link plan, timing, source refs, and stop condition required",
-            stop_conditions=[
-                "active account identity is unclear",
-                "source requires private DMs, private lists, or hidden timeline expansion",
-                "post/reply/media upload would execute without an audit record",
-            ],
-        ),
+        _source_profile(**social_browser_x["source_profile"]),
         _source_profile(
             connector_id="agent_reach_ops_source_map",
             status="field_derived_pattern",

--- a/tests/capabilities/test_value_connector_social_profile.py
+++ b/tests/capabilities/test_value_connector_social_profile.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from loopx.capabilities.content_ops.social_browser_x import (
+    CONTENT_OPS_SOCIAL_BROWSER_X_PROVIDER_SCHEMA_VERSION,
+    SOCIAL_BROWSER_X_PROVIDER_MODULE,
+    build_social_browser_x_provider_packet,
+)
+from loopx.capabilities.content_ops.surface import build_content_ops_preview_packet
+from loopx.capabilities.catalog import BUILTIN_CAPABILITIES
+from loopx.capabilities.value_connectors.install_check import (
+    build_value_connector_install_check_packet,
+)
+from loopx.capabilities.value_connectors.source_map import (
+    build_value_connector_source_map_packet,
+)
+
+
+def test_social_browser_x_provider_owns_the_shared_contract() -> None:
+    provider = build_social_browser_x_provider_packet()
+
+    assert provider["ok"] is True
+    assert (
+        provider["schema_version"]
+        == CONTENT_OPS_SOCIAL_BROWSER_X_PROVIDER_SCHEMA_VERSION
+    )
+    assert provider["connector_id"] == "social_browser_x"
+    assert provider["outcome_capability_id"] == "content-ops"
+    assert provider["provider_module"] == SOCIAL_BROWSER_X_PROVIDER_MODULE
+    assert provider["truth_contract"] == {
+        "compatibility_facade_may_delegate": True,
+        "external_reads_performed": False,
+        "external_writes_performed": False,
+        "autopublish_allowed": False,
+        "raw_platform_data_recorded": False,
+    }
+
+
+def test_value_connector_facade_delegates_social_profile_contract() -> None:
+    provider = build_social_browser_x_provider_packet()
+    source_map = build_value_connector_source_map_packet(connector="social_browser_x")
+    install = build_value_connector_install_check_packet(connector="social_browser_x")
+
+    assert source_map["source_profiles"][0] == {
+        "schema_version": "value_connector_source_profile_v0",
+        **provider["source_profile"],
+        "external_reads_allowed": True,
+        "external_writes_allowed": False,
+        "outcome_capability_id": "content-ops",
+        "provider_binding_state": "migrated",
+        "provider_module": SOCIAL_BROWSER_X_PROVIDER_MODULE,
+    }
+    assert source_map["projection"]["migrated_profile_count"] == 1
+    assert install["checks"] == [provider["install_check"]]
+
+
+def test_content_ops_preview_uses_owned_social_connector_trial() -> None:
+    provider = build_social_browser_x_provider_packet()
+    preview = build_content_ops_preview_packet()
+    trials = {item["trial_id"]: item for item in preview["surface"]["connector_trials"]}
+
+    assert trials["trial_x_ego_lite_browser"] == provider["connector_trial"]
+
+
+def test_content_ops_catalog_declares_social_provider() -> None:
+    content_ops = next(
+        capability
+        for capability in BUILTIN_CAPABILITIES
+        if capability["id"] == "content-ops"
+    )
+    protocols = {
+        item["schema_version"]: item for item in content_ops["implemented_protocols"]
+    }
+
+    assert protocols[CONTENT_OPS_SOCIAL_BROWSER_X_PROVIDER_SCHEMA_VERSION] == {
+        "schema_version": CONTENT_OPS_SOCIAL_BROWSER_X_PROVIDER_SCHEMA_VERSION,
+        "module": SOCIAL_BROWSER_X_PROVIDER_MODULE,
+        "doc": "docs/capabilities/content-ops/README.md",
+    }


### PR DESCRIPTION
## Summary

- Move the shared `social_browser_x` source profile, install check, and metadata-only connector trial into the declared `content-ops` outcome capability.
- Keep `loopx value-connectors` as a compatibility facade and delegate existing packets without changing stable caller output.
- Declare the provider in the capability catalog and document the ownership boundary.

## Placement rationale

`social_browser_x` is the highest-evidence mapped profile with a real active caller: content-ops already renders its connector trial and owns public-handle observation, source promotion, drafting, publish gates, and post-write audit. The finance, agent-reach, botmail, and community profiles remain candidate or gated facade rows and are intentionally not migrated here.

## Change classification

- Core product code: provider module plus catalog, content-ops, source-map, and install-check delegation.
- Core documentation: content-ops ownership and compatibility-facade contract.
- Durable validation: focused provider/delegation tests and migrated-profile smoke assertions.
- Excluded: local baselines, runtime state, credentials, raw logs, and private evidence.

## Compatibility evidence

Base/head qualification confirms:

- install-check packet: identical
- value-connector plan packet: identical
- content-ops preview packet: identical
- source-map packet: only `provider_binding_state`, `provider_module`, and the selected migrated-profile count change

The facade remains because existing CLI callers still depend on it.

## Validation

- `loopx canary premerge --from-git-diff --tier standard`: 18/18 selected checks passed, 4/4 direct checks passed, public-boundary scan passed
- `pytest -q tests/capabilities`: 61 passed
- focused provider/delegation tests: 4 passed
- value-connectors and content-ops focused smokes: passed
- capability registry and placement smokes: passed
- Ruff, `py_compile`, and `git diff --check`: passed

## Review hold

This changes runtime ownership and compatibility delegation. Please perform an independent review of the exact head before merge; the implementation agent will not self-merge it.