### PR TITLE
fix(issue-fix): require PR-description recall before review notification

### DIFF
--- a/examples/issue-fix-pr-description-builder-smoke.py
+++ b/examples/issue-fix-pr-description-builder-smoke.py
@@ -85,6 +85,7 @@ json.dump({
     assert counter.read_text() == "1", "enabled build must call provider once"
     assert applied["description"].startswith("## 动机"), applied
     preference = applied["semantic_preference"]
+    assert preference["recall_executed"] is True, preference
     assert preference["application_status"] == "applied", preference
     assert preference["receipt"]["outcome"] == "applied", preference
     assert preference["corpus_inventory"][0]["corpus_id"] == (
@@ -185,6 +186,7 @@ json.dump({
     )
     assert counter.read_text() == "1", "disabled build must not call provider"
     assert disabled_result["description"] == BASE, disabled_result
+    assert disabled_result["semantic_preference"]["recall_executed"] is True
     assert disabled_result["semantic_preference"]["recall_status"] == "disabled"
 
     def unexpected_recall(*_args, **_kwargs):
@@ -196,6 +198,7 @@ json.dump({
         recall_fn=unexpected_recall,
     )
     assert unconfigured["description"] == BASE, unconfigured
+    assert unconfigured["semantic_preference"]["recall_executed"] is False
 
     failing = temp / "failing.json"
     failing.write_text(
@@ -225,6 +228,7 @@ json.dump({
         ),
     )
     assert unavailable["description"].endswith("Fixes #22\n"), unavailable
+    assert unavailable["semantic_preference"]["recall_executed"] is True
     assert unavailable["fail_open_preserved_base"] is True, unavailable
 
     unattributed = build_issue_fix_pr_description(

--- a/examples/issue-fix-reviewer-request-smoke.py
+++ b/examples/issue-fix-reviewer-request-smoke.py
@@ -139,8 +139,10 @@ def metadata(
     requested: list[str] | None = None,
     comments: list[dict[str, Any]] | None = None,
     reviewed: list[str] | None = None,
+    body: str | None = None,
+    head_ref: str | None = None,
 ) -> dict[str, Any]:
-    return {
+    payload = {
         "author": {"login": "current-author"},
         "closingIssuesReferences": [
             {
@@ -157,6 +159,11 @@ def metadata(
         "title": "fix: reject file URI for consistency check",
         "url": "https://github.com/owner/repo/pull/42",
     }
+    if body is not None:
+        payload["body"] = body
+    if head_ref is not None:
+        payload["headRefOid"] = head_ref
+    return payload
 
 
 class FakeGitHubRunner:
@@ -1968,6 +1975,161 @@ def main() -> int:
         assert resumed_drain["verified_pr_count"] == 1
         assert drain_calls[-1]["number"] == 103
         assert len(drain_calls) == 3
+
+        publication_template = (
+            "## Summary\n\n- Describe the change.\n\n"
+            "## Validation\n\n- [ ] Focused regression passed.\n\n"
+            "## Boundary Checklist\n\n- [ ] No private material included.\n"
+        )
+        publication_body = publication_template.replace(
+            "- [ ] Focused regression passed.",
+            "- [x] Focused regression passed.",
+        )
+        publication_head = "a" * 40
+        write(path / ".github/PULL_REQUEST_TEMPLATE.md", publication_template)
+        write(
+            path / ".loopx/config/semantic-preference.json",
+            json.dumps(
+                {
+                    "schema_version": "semantic_preference_hook_config_v0",
+                    "enabled": True,
+                    "surfaces": {
+                        "issue_fix.pr_description": {
+                            "query": "PR description preferences",
+                            "failure_policy": "fail_open",
+                        }
+                    },
+                }
+            ),
+        )
+        gated_combined = FakeCombinedRunner(
+            FakeGitHubRunner(
+                before=metadata(body=publication_body, head_ref=publication_head)
+            )
+        )
+        missing_publication_evidence = build_issue_fix_reviewer_request_packet(
+            repo_path=path,
+            url="https://github.com/owner/repo/pull/42",
+            base_ref="main",
+            notification_sinks_input=sinks_input,
+            execute=True,
+            runner=gated_combined,
+        )
+        assert missing_publication_evidence["ok"] is False
+        assert missing_publication_evidence["blocker"] == (
+            "pr_description_publication_evidence_required"
+        )
+        assert missing_publication_evidence["selected_reviewers"] == []
+        assert missing_publication_evidence["external_writes_performed"] is False
+        assert missing_publication_evidence["pr_description_publication_gate"][
+            "required_evidence_inputs"
+        ] == ["pr_description_build_json", "pr_description_head_ref"]
+        assert missing_publication_evidence["secondary_notification_status"] == (
+            "skipped_pr_description_publication_blocked"
+        )
+        assert gated_combined.github.edits == 0
+        assert gated_combined.github.comments == 0
+        assert gated_combined.lark_calls == []
+        assert_public_safe(missing_publication_evidence)
+
+        publication_build = {
+            "schema_version": "issue_fix_pr_description_build_v0",
+            "description": publication_body,
+            "semantic_preference": {
+                "surface": "issue_fix.pr_description",
+                "receipt": {
+                    "schema_version": (
+                        "semantic_preference_application_receipt_v0"
+                    ),
+                    "surface": "issue_fix.pr_description",
+                    "application_id": "fixture-pr-42-description",
+                    "outcome": "applied",
+                    "preference_ref_digests": ["0123456789abcdef"],
+                    "artifact_ref": "fixture_pr_42_description",
+                },
+            },
+        }
+        verified_runner = FakeGitHubRunner(
+            before=metadata(body=publication_body, head_ref=publication_head),
+            after=metadata(
+                requested=["service-owner"],
+                body=publication_body,
+                head_ref=publication_head,
+            ),
+        )
+        verified_publication = build_issue_fix_reviewer_request_packet(
+            repo_path=path,
+            url="https://github.com/owner/repo/pull/42",
+            base_ref="main",
+            pr_description_build=publication_build,
+            pr_description_head_ref=publication_head,
+            execute=True,
+            runner=verified_runner,
+        )
+        assert verified_publication["ok"] is True, verified_publication
+        assert verified_publication["pr_description_publication_gate"]["status"] == (
+            "verified"
+        )
+        assert verified_publication["review_request_verified"] is True
+        assert verified_runner.edits == 1
+        assert_public_safe(verified_publication)
+
+        publication_metadata_path = path / "publication-metadata.json"
+        publication_build_path = path / "publication-build.json"
+        write(
+            publication_metadata_path,
+            json.dumps(metadata(body=publication_body, head_ref=publication_head)),
+        )
+        write(publication_build_path, json.dumps(publication_build))
+        publication_cli = subprocess.run(
+            [
+                *loopx_cli,
+                "issue-fix",
+                "reviewer-request",
+                "--url",
+                "https://github.com/owner/repo/pull/42",
+                "--repo-path",
+                str(path),
+                "--base-ref",
+                "main",
+                "--metadata-json",
+                str(publication_metadata_path),
+                "--pr-description-build-json",
+                str(publication_build_path),
+                "--pr-description-head-ref",
+                publication_head,
+            ],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        publication_cli_packet = json.loads(publication_cli.stdout)
+        assert publication_cli_packet["pr_description_publication_gate"]["ok"] is True
+        assert publication_cli_packet["external_writes_performed"] is False
+        assert_public_safe(publication_cli_packet)
+
+        mismatched_build = json.loads(json.dumps(publication_build))
+        mismatched_build["description"] += "\nUnverified mutation.\n"
+        mismatched_runner = FakeGitHubRunner(
+            before=metadata(body=publication_body, head_ref=publication_head)
+        )
+        mismatched_publication = build_issue_fix_reviewer_request_packet(
+            repo_path=path,
+            url="https://github.com/owner/repo/pull/42",
+            base_ref="main",
+            pr_description_build=mismatched_build,
+            pr_description_head_ref=publication_head,
+            execute=True,
+            runner=mismatched_runner,
+        )
+        assert mismatched_publication["ok"] is False
+        assert mismatched_publication["blocker"] == (
+            "pr_description_publication_verification_failed"
+        )
+        assert mismatched_runner.edits == 0
+        assert_public_safe(mismatched_publication)
 
         subprocess.run(
             [

--- a/examples/issue-fix-reviewer-request-smoke.py
+++ b/examples/issue-fix-reviewer-request-smoke.py
@@ -139,10 +139,8 @@ def metadata(
     requested: list[str] | None = None,
     comments: list[dict[str, Any]] | None = None,
     reviewed: list[str] | None = None,
-    body: str | None = None,
-    head_ref: str | None = None,
 ) -> dict[str, Any]:
-    payload = {
+    return {
         "author": {"login": "current-author"},
         "closingIssuesReferences": [
             {
@@ -159,11 +157,6 @@ def metadata(
         "title": "fix: reject file URI for consistency check",
         "url": "https://github.com/owner/repo/pull/42",
     }
-    if body is not None:
-        payload["body"] = body
-    if head_ref is not None:
-        payload["headRefOid"] = head_ref
-    return payload
 
 
 class FakeGitHubRunner:
@@ -1976,37 +1969,8 @@ def main() -> int:
         assert drain_calls[-1]["number"] == 103
         assert len(drain_calls) == 3
 
-        publication_template = (
-            "## Summary\n\n- Describe the change.\n\n"
-            "## Validation\n\n- [ ] Focused regression passed.\n\n"
-            "## Boundary Checklist\n\n- [ ] No private material included.\n"
-        )
-        publication_body = publication_template.replace(
-            "- [ ] Focused regression passed.",
-            "- [x] Focused regression passed.",
-        )
-        publication_head = "a" * 40
-        write(path / ".github/PULL_REQUEST_TEMPLATE.md", publication_template)
-        write(
-            path / ".loopx/config/semantic-preference.json",
-            json.dumps(
-                {
-                    "schema_version": "semantic_preference_hook_config_v0",
-                    "enabled": True,
-                    "surfaces": {
-                        "issue_fix.pr_description": {
-                            "query": "PR description preferences",
-                            "failure_policy": "fail_open",
-                        }
-                    },
-                }
-            ),
-        )
-        gated_combined = FakeCombinedRunner(
-            FakeGitHubRunner(
-                before=metadata(body=publication_body, head_ref=publication_head)
-            )
-        )
+        write(path / ".loopx/config/semantic-preference.json", "{}")
+        gated_combined = FakeCombinedRunner(FakeGitHubRunner(before=metadata()))
         missing_publication_evidence = build_issue_fix_reviewer_request_packet(
             repo_path=path,
             url="https://github.com/owner/repo/pull/42",
@@ -2017,15 +1981,15 @@ def main() -> int:
         )
         assert missing_publication_evidence["ok"] is False
         assert missing_publication_evidence["blocker"] == (
-            "pr_description_publication_evidence_required"
+            "pr_description_recall_evidence_required"
         )
         assert missing_publication_evidence["selected_reviewers"] == []
         assert missing_publication_evidence["external_writes_performed"] is False
         assert missing_publication_evidence["pr_description_publication_gate"][
             "required_evidence_inputs"
-        ] == ["pr_description_build_json", "pr_description_head_ref"]
+        ] == ["pr_description_build_json"]
         assert missing_publication_evidence["secondary_notification_status"] == (
-            "skipped_pr_description_publication_blocked"
+            "skipped_reviewer_unavailable"
         )
         assert gated_combined.github.edits == 0
         assert gated_combined.github.comments == 0
@@ -2034,35 +1998,21 @@ def main() -> int:
 
         publication_build = {
             "schema_version": "issue_fix_pr_description_build_v0",
-            "description": publication_body,
             "semantic_preference": {
                 "surface": "issue_fix.pr_description",
-                "receipt": {
-                    "schema_version": (
-                        "semantic_preference_application_receipt_v0"
-                    ),
-                    "surface": "issue_fix.pr_description",
-                    "application_id": "fixture-pr-42-description",
-                    "outcome": "applied",
-                    "preference_ref_digests": ["0123456789abcdef"],
-                    "artifact_ref": "fixture_pr_42_description",
-                },
+                "recall_executed": True,
+                "recall_status": "completed",
             },
         }
         verified_runner = FakeGitHubRunner(
-            before=metadata(body=publication_body, head_ref=publication_head),
-            after=metadata(
-                requested=["service-owner"],
-                body=publication_body,
-                head_ref=publication_head,
-            ),
+            before=metadata(),
+            after=metadata(requested=["service-owner"]),
         )
         verified_publication = build_issue_fix_reviewer_request_packet(
             repo_path=path,
             url="https://github.com/owner/repo/pull/42",
             base_ref="main",
             pr_description_build=publication_build,
-            pr_description_head_ref=publication_head,
             execute=True,
             runner=verified_runner,
         )
@@ -2073,63 +2023,6 @@ def main() -> int:
         assert verified_publication["review_request_verified"] is True
         assert verified_runner.edits == 1
         assert_public_safe(verified_publication)
-
-        publication_metadata_path = path / "publication-metadata.json"
-        publication_build_path = path / "publication-build.json"
-        write(
-            publication_metadata_path,
-            json.dumps(metadata(body=publication_body, head_ref=publication_head)),
-        )
-        write(publication_build_path, json.dumps(publication_build))
-        publication_cli = subprocess.run(
-            [
-                *loopx_cli,
-                "issue-fix",
-                "reviewer-request",
-                "--url",
-                "https://github.com/owner/repo/pull/42",
-                "--repo-path",
-                str(path),
-                "--base-ref",
-                "main",
-                "--metadata-json",
-                str(publication_metadata_path),
-                "--pr-description-build-json",
-                str(publication_build_path),
-                "--pr-description-head-ref",
-                publication_head,
-            ],
-            cwd=ROOT,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            check=True,
-        )
-        publication_cli_packet = json.loads(publication_cli.stdout)
-        assert publication_cli_packet["pr_description_publication_gate"]["ok"] is True
-        assert publication_cli_packet["external_writes_performed"] is False
-        assert_public_safe(publication_cli_packet)
-
-        mismatched_build = json.loads(json.dumps(publication_build))
-        mismatched_build["description"] += "\nUnverified mutation.\n"
-        mismatched_runner = FakeGitHubRunner(
-            before=metadata(body=publication_body, head_ref=publication_head)
-        )
-        mismatched_publication = build_issue_fix_reviewer_request_packet(
-            repo_path=path,
-            url="https://github.com/owner/repo/pull/42",
-            base_ref="main",
-            pr_description_build=mismatched_build,
-            pr_description_head_ref=publication_head,
-            execute=True,
-            runner=mismatched_runner,
-        )
-        assert mismatched_publication["ok"] is False
-        assert mismatched_publication["blocker"] == (
-            "pr_description_publication_verification_failed"
-        )
-        assert mismatched_runner.edits == 0
-        assert_public_safe(mismatched_publication)
 
         subprocess.run(
             [

--- a/loopx/capabilities/issue_fix/pr_description.py
+++ b/loopx/capabilities/issue_fix/pr_description.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-import json
 import re
 from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
@@ -37,10 +35,6 @@ _CANONICAL_CLOSING_KEYWORD = {
     "resolves": "Resolves",
     "resolved": "Resolves",
 }
-_HEADING_PATTERN = re.compile(r"(?m)^##\s+(.+?)\s*$")
-_CHECKLIST_PATTERN = re.compile(r"(?m)^\s*-\s*\[[ xX]\]\s+(.+?)\s*$")
-_COMMIT_REF_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
-
 PreferenceApplier = Callable[
     [str, Sequence[Mapping[str, Any]]],
     Mapping[str, Any],
@@ -48,187 +42,44 @@ PreferenceApplier = Callable[
 Recall = Callable[..., dict[str, Any]]
 
 
-def _digest(value: str) -> str:
-    return hashlib.sha256(value.encode("utf-8")).hexdigest()
-
-
-def _ordered_contains(actual: Sequence[str], required: Sequence[str]) -> bool:
-    position = 0
-    for item in actual:
-        if position < len(required) and item == required[position]:
-            position += 1
-    return position == len(required)
-
-
-def _semantic_preference_requirement(project: str | Path) -> dict[str, Any]:
-    config_path = (
-        Path(project).expanduser().resolve()
-        / ".loopx/config/semantic-preference.json"
-    )
-    if not config_path.exists():
-        return {"status": "not_configured", "required": False}
-    try:
-        payload = json.loads(config_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return {"status": "invalid", "required": True}
-    if not isinstance(payload, Mapping) or payload.get("schema_version") != (
-        "semantic_preference_hook_config_v0"
-    ):
-        return {"status": "invalid", "required": True}
-    enabled = payload.get("enabled", False)
-    surfaces = payload.get("surfaces", {})
-    if not isinstance(enabled, bool) or not isinstance(surfaces, Mapping):
-        return {"status": "invalid", "required": True}
-    if not enabled:
-        return {"status": "disabled", "required": False}
-    if SURFACE not in surfaces:
-        return {"status": "surface_not_configured", "required": False}
-    if not isinstance(surfaces.get(SURFACE), Mapping):
-        return {"status": "invalid", "required": True}
-    return {"status": "enabled", "required": True}
-
-
 def validate_issue_fix_pr_description_publication(
     *,
     project: str | Path,
-    live_description: str,
-    live_head_ref: str,
     build_packet: Mapping[str, Any] | None = None,
-    expected_head_ref: str | None = None,
 ) -> dict[str, Any]:
-    """Fail closed before PR publication follow-up when evidence is configured.
+    """Require only proof that the PR-description recall path executed."""
 
-    The compact result records only digests and structural counts. Raw PR text,
-    repository templates, semantic preference references, and local paths stay
-    inside this verification boundary.
-    """
+    recall_required = (
+        Path(project).expanduser().resolve()
+        / ".loopx/config/semantic-preference.json"
+    ).exists()
+    preference = (
+        build_packet.get("semantic_preference")
+        if isinstance(build_packet, Mapping)
+        and build_packet.get("schema_version") == BUILD_SCHEMA
+        else None
+    )
+    preference = preference if isinstance(preference, Mapping) else {}
+    recall_executed = preference.get("recall_executed") is True
+    ok = not recall_required or recall_executed
 
-    root = Path(project).expanduser().resolve()
-    requirement = _semantic_preference_requirement(root)
-    errors: list[str] = []
-    if requirement["status"] == "invalid":
-        errors.append("semantic_preference_configuration_invalid")
-
-    template_path = root / ".github/PULL_REQUEST_TEMPLATE.md"
-    template_status = "not_configured"
-    template_verified = True
-    required_headings: list[str] = []
-    required_checklist: list[str] = []
-    matched_heading_count = 0
-    matched_checklist_count = 0
-    if template_path.exists():
-        try:
-            template = template_path.read_text(encoding="utf-8")
-        except OSError:
-            template_status = "unavailable"
-            template_verified = False
-            errors.append("repository_pr_template_unavailable")
-        else:
-            template_status = "configured"
-            required_headings = _HEADING_PATTERN.findall(template)
-            required_checklist = _CHECKLIST_PATTERN.findall(template)
-            live_headings = _HEADING_PATTERN.findall(live_description)
-            live_checklist = _CHECKLIST_PATTERN.findall(live_description)
-            matched_heading_count = sum(
-                heading in live_headings for heading in required_headings
-            )
-            matched_checklist_count = sum(
-                item in live_checklist for item in required_checklist
-            )
-            template_verified = bool(
-                live_description.strip()
-                and _ordered_contains(live_headings, required_headings)
-                and _ordered_contains(live_checklist, required_checklist)
-            )
-            if not template_verified:
-                errors.append("repository_pr_template_not_preserved")
-
-    evidence_required = bool(requirement["required"])
-    evidence_status = "not_required"
-    receipt_outcome: str | None = None
-    receipt_application_digest: str | None = None
-    expected_head_digest: str | None = None
-    live_head_digest = _digest(live_head_ref) if live_head_ref else None
-    if evidence_required:
-        evidence_status = "missing"
-        if not isinstance(build_packet, Mapping):
-            errors.append("pr_description_build_evidence_missing")
-        elif build_packet.get("schema_version") != BUILD_SCHEMA:
-            errors.append("pr_description_build_evidence_invalid")
-        else:
-            evidence_status = "invalid"
-            built_description = build_packet.get("description")
-            preference = build_packet.get("semantic_preference")
-            preference = preference if isinstance(preference, Mapping) else {}
-            receipt = preference.get("receipt")
-            receipt = receipt if isinstance(receipt, Mapping) else {}
-            receipt_outcome = str(receipt.get("outcome") or "") or None
-            application_id = str(receipt.get("application_id") or "")
-            if receipt.get("schema_version") != (
-                "semantic_preference_application_receipt_v0"
-            ) or receipt.get("surface") != SURFACE:
-                errors.append("semantic_preference_receipt_invalid")
-            if receipt_outcome not in {"applied", "ignored"}:
-                errors.append("semantic_preference_receipt_not_applied_or_ignored")
-            if not application_id:
-                errors.append("semantic_preference_receipt_unattributed")
-            else:
-                receipt_application_digest = _digest(application_id)[:16]
-            if not isinstance(built_description, str) or (
-                built_description != live_description
-            ):
-                errors.append("pr_description_live_body_mismatch")
-            if not expected_head_ref or not _COMMIT_REF_PATTERN.fullmatch(
-                expected_head_ref
-            ):
-                errors.append("pr_description_expected_head_ref_missing")
-            else:
-                expected_head_digest = _digest(expected_head_ref.lower())[:16]
-                if not _COMMIT_REF_PATTERN.fullmatch(live_head_ref or "") or (
-                    expected_head_ref.lower() != live_head_ref.lower()
-                ):
-                    errors.append("pr_description_live_head_ref_mismatch")
-            if not errors:
-                evidence_status = "verified"
-
-    blocker = None
-    if errors:
-        blocker = (
-            "pr_description_publication_evidence_required"
-            if any(error.endswith("_missing") for error in errors)
-            else "pr_description_publication_verification_failed"
-        )
     return {
-        "ok": not errors,
+        "ok": ok,
         "schema_version": PUBLICATION_GATE_SCHEMA,
-        "status": "verified" if not errors else "blocked",
-        "blocker": blocker,
-        "semantic_preference_requirement_status": requirement["status"],
-        "semantic_preference_evidence_required": evidence_required,
-        "semantic_preference_evidence_status": evidence_status,
+        "status": (
+            "verified"
+            if recall_executed
+            else "not_required"
+            if ok
+            else "blocked"
+        ),
+        "blocker": None if ok else "pr_description_recall_evidence_required",
+        "recall_required": recall_required,
+        "recall_executed": recall_executed,
+        "recall_status": str(preference.get("recall_status") or "") or None,
         "required_evidence_inputs": (
-            ["pr_description_build_json", "pr_description_head_ref"]
-            if evidence_required
-            else []
+            ["pr_description_build_json"] if recall_required else []
         ),
-        "semantic_preference_receipt_outcome": receipt_outcome,
-        "receipt_application_digest": receipt_application_digest,
-        "template_status": template_status,
-        "template_verified": template_verified,
-        "required_heading_count": len(required_headings),
-        "matched_heading_count": matched_heading_count,
-        "required_checklist_count": len(required_checklist),
-        "matched_checklist_count": matched_checklist_count,
-        "live_description_digest": (
-            _digest(live_description) if live_description else None
-        ),
-        "expected_head_digest": expected_head_digest,
-        "live_head_digest": live_head_digest[:16] if live_head_digest else None,
-        "errors": errors,
-        "raw_description_captured": False,
-        "raw_template_captured": False,
-        "preference_refs_captured": False,
-        "local_paths_captured": False,
     }
 
 
@@ -352,6 +203,7 @@ def _result(
     description: str,
     recall_status: str,
     application_status: str,
+    recall_executed: bool = False,
     recalled_item_count: int = 0,
     applied_preference_count: int = 0,
     receipt: Mapping[str, Any] | None = None,
@@ -372,6 +224,7 @@ def _result(
         "description_changed": description_changed or issue_reference_changed,
         "semantic_preference": {
             "surface": SURFACE,
+            "recall_executed": recall_executed,
             "recall_status": recall_status,
             "application_status": application_status,
             "recalled_item_count": recalled_item_count,
@@ -484,6 +337,7 @@ def build_issue_fix_pr_description(
             description=base_description,
             recall_status=recall_status,
             application_status=recall_status,
+            recall_executed=True,
             fail_open_preserved_base=recall_status == "provider_unavailable",
             issue_reference_policy=issue_reference_policy,
             corpus_inventory=corpus_inventory,
@@ -494,6 +348,7 @@ def build_issue_fix_pr_description(
             description=base_description,
             recall_status=recall_status,
             application_status="available_not_applied",
+            recall_executed=True,
             recalled_item_count=len(items),
             issue_reference_policy=issue_reference_policy,
             corpus_inventory=corpus_inventory,
@@ -527,6 +382,7 @@ def build_issue_fix_pr_description(
             description=base_description,
             recall_status=recall_status,
             application_status="application_failed",
+            recall_executed=True,
             recalled_item_count=len(items),
             receipt=application_receipt(
                 surface=SURFACE,
@@ -545,6 +401,7 @@ def build_issue_fix_pr_description(
         description=description,
         recall_status=recall_status,
         application_status=outcome,
+        recall_executed=True,
         recalled_item_count=len(items),
         applied_preference_count=len(set(applied_refs)),
         receipt=application_receipt(

--- a/loopx/capabilities/issue_fix/pr_description.py
+++ b/loopx/capabilities/issue_fix/pr_description.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
@@ -9,6 +11,7 @@ from ..semantic_preference import application_receipt, recall
 
 
 BUILD_SCHEMA = "issue_fix_pr_description_build_v0"
+PUBLICATION_GATE_SCHEMA = "issue_fix_pr_description_publication_gate_v0"
 SURFACE = "issue_fix.pr_description"
 ISSUE_REFERENCE_BLOCK_SCHEMA = "issue_fix_pr_issue_reference_block_v0"
 
@@ -34,12 +37,199 @@ _CANONICAL_CLOSING_KEYWORD = {
     "resolves": "Resolves",
     "resolved": "Resolves",
 }
+_HEADING_PATTERN = re.compile(r"(?m)^##\s+(.+?)\s*$")
+_CHECKLIST_PATTERN = re.compile(r"(?m)^\s*-\s*\[[ xX]\]\s+(.+?)\s*$")
+_COMMIT_REF_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
 
 PreferenceApplier = Callable[
     [str, Sequence[Mapping[str, Any]]],
     Mapping[str, Any],
 ]
 Recall = Callable[..., dict[str, Any]]
+
+
+def _digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _ordered_contains(actual: Sequence[str], required: Sequence[str]) -> bool:
+    position = 0
+    for item in actual:
+        if position < len(required) and item == required[position]:
+            position += 1
+    return position == len(required)
+
+
+def _semantic_preference_requirement(project: str | Path) -> dict[str, Any]:
+    config_path = (
+        Path(project).expanduser().resolve()
+        / ".loopx/config/semantic-preference.json"
+    )
+    if not config_path.exists():
+        return {"status": "not_configured", "required": False}
+    try:
+        payload = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"status": "invalid", "required": True}
+    if not isinstance(payload, Mapping) or payload.get("schema_version") != (
+        "semantic_preference_hook_config_v0"
+    ):
+        return {"status": "invalid", "required": True}
+    enabled = payload.get("enabled", False)
+    surfaces = payload.get("surfaces", {})
+    if not isinstance(enabled, bool) or not isinstance(surfaces, Mapping):
+        return {"status": "invalid", "required": True}
+    if not enabled:
+        return {"status": "disabled", "required": False}
+    if SURFACE not in surfaces:
+        return {"status": "surface_not_configured", "required": False}
+    if not isinstance(surfaces.get(SURFACE), Mapping):
+        return {"status": "invalid", "required": True}
+    return {"status": "enabled", "required": True}
+
+
+def validate_issue_fix_pr_description_publication(
+    *,
+    project: str | Path,
+    live_description: str,
+    live_head_ref: str,
+    build_packet: Mapping[str, Any] | None = None,
+    expected_head_ref: str | None = None,
+) -> dict[str, Any]:
+    """Fail closed before PR publication follow-up when evidence is configured.
+
+    The compact result records only digests and structural counts. Raw PR text,
+    repository templates, semantic preference references, and local paths stay
+    inside this verification boundary.
+    """
+
+    root = Path(project).expanduser().resolve()
+    requirement = _semantic_preference_requirement(root)
+    errors: list[str] = []
+    if requirement["status"] == "invalid":
+        errors.append("semantic_preference_configuration_invalid")
+
+    template_path = root / ".github/PULL_REQUEST_TEMPLATE.md"
+    template_status = "not_configured"
+    template_verified = True
+    required_headings: list[str] = []
+    required_checklist: list[str] = []
+    matched_heading_count = 0
+    matched_checklist_count = 0
+    if template_path.exists():
+        try:
+            template = template_path.read_text(encoding="utf-8")
+        except OSError:
+            template_status = "unavailable"
+            template_verified = False
+            errors.append("repository_pr_template_unavailable")
+        else:
+            template_status = "configured"
+            required_headings = _HEADING_PATTERN.findall(template)
+            required_checklist = _CHECKLIST_PATTERN.findall(template)
+            live_headings = _HEADING_PATTERN.findall(live_description)
+            live_checklist = _CHECKLIST_PATTERN.findall(live_description)
+            matched_heading_count = sum(
+                heading in live_headings for heading in required_headings
+            )
+            matched_checklist_count = sum(
+                item in live_checklist for item in required_checklist
+            )
+            template_verified = bool(
+                live_description.strip()
+                and _ordered_contains(live_headings, required_headings)
+                and _ordered_contains(live_checklist, required_checklist)
+            )
+            if not template_verified:
+                errors.append("repository_pr_template_not_preserved")
+
+    evidence_required = bool(requirement["required"])
+    evidence_status = "not_required"
+    receipt_outcome: str | None = None
+    receipt_application_digest: str | None = None
+    expected_head_digest: str | None = None
+    live_head_digest = _digest(live_head_ref) if live_head_ref else None
+    if evidence_required:
+        evidence_status = "missing"
+        if not isinstance(build_packet, Mapping):
+            errors.append("pr_description_build_evidence_missing")
+        elif build_packet.get("schema_version") != BUILD_SCHEMA:
+            errors.append("pr_description_build_evidence_invalid")
+        else:
+            evidence_status = "invalid"
+            built_description = build_packet.get("description")
+            preference = build_packet.get("semantic_preference")
+            preference = preference if isinstance(preference, Mapping) else {}
+            receipt = preference.get("receipt")
+            receipt = receipt if isinstance(receipt, Mapping) else {}
+            receipt_outcome = str(receipt.get("outcome") or "") or None
+            application_id = str(receipt.get("application_id") or "")
+            if receipt.get("schema_version") != (
+                "semantic_preference_application_receipt_v0"
+            ) or receipt.get("surface") != SURFACE:
+                errors.append("semantic_preference_receipt_invalid")
+            if receipt_outcome not in {"applied", "ignored"}:
+                errors.append("semantic_preference_receipt_not_applied_or_ignored")
+            if not application_id:
+                errors.append("semantic_preference_receipt_unattributed")
+            else:
+                receipt_application_digest = _digest(application_id)[:16]
+            if not isinstance(built_description, str) or (
+                built_description != live_description
+            ):
+                errors.append("pr_description_live_body_mismatch")
+            if not expected_head_ref or not _COMMIT_REF_PATTERN.fullmatch(
+                expected_head_ref
+            ):
+                errors.append("pr_description_expected_head_ref_missing")
+            else:
+                expected_head_digest = _digest(expected_head_ref.lower())[:16]
+                if not _COMMIT_REF_PATTERN.fullmatch(live_head_ref or "") or (
+                    expected_head_ref.lower() != live_head_ref.lower()
+                ):
+                    errors.append("pr_description_live_head_ref_mismatch")
+            if not errors:
+                evidence_status = "verified"
+
+    blocker = None
+    if errors:
+        blocker = (
+            "pr_description_publication_evidence_required"
+            if any(error.endswith("_missing") for error in errors)
+            else "pr_description_publication_verification_failed"
+        )
+    return {
+        "ok": not errors,
+        "schema_version": PUBLICATION_GATE_SCHEMA,
+        "status": "verified" if not errors else "blocked",
+        "blocker": blocker,
+        "semantic_preference_requirement_status": requirement["status"],
+        "semantic_preference_evidence_required": evidence_required,
+        "semantic_preference_evidence_status": evidence_status,
+        "required_evidence_inputs": (
+            ["pr_description_build_json", "pr_description_head_ref"]
+            if evidence_required
+            else []
+        ),
+        "semantic_preference_receipt_outcome": receipt_outcome,
+        "receipt_application_digest": receipt_application_digest,
+        "template_status": template_status,
+        "template_verified": template_verified,
+        "required_heading_count": len(required_headings),
+        "matched_heading_count": matched_heading_count,
+        "required_checklist_count": len(required_checklist),
+        "matched_checklist_count": matched_checklist_count,
+        "live_description_digest": (
+            _digest(live_description) if live_description else None
+        ),
+        "expected_head_digest": expected_head_digest,
+        "live_head_digest": live_head_digest[:16] if live_head_digest else None,
+        "errors": errors,
+        "raw_description_captured": False,
+        "raw_template_captured": False,
+        "preference_refs_captured": False,
+        "local_paths_captured": False,
+    }
 
 
 def _normalise_issue_references(

--- a/loopx/capabilities/issue_fix/reviewer_cli.py
+++ b/loopx/capabilities/issue_fix/reviewer_cli.py
@@ -216,6 +216,20 @@ def register_issue_fix_reviewer_commands(
         ),
     )
     reviewer_request_parser.add_argument(
+        "--pr-description-build-json",
+        help=(
+            "Compact issue_fix_pr_description_build_v0 JSON used to verify the "
+            "live PR body before reviewer or group notification writes."
+        ),
+    )
+    reviewer_request_parser.add_argument(
+        "--pr-description-head-ref",
+        help=(
+            "Full 40-character head commit used when the PR description was "
+            "built; compared with live GitHub readback."
+        ),
+    )
+    reviewer_request_parser.add_argument(
         "--notification-sinks-json",
         help=(
             "Optional local-private issue_fix_reviewer_notification_sinks_input_v0 "
@@ -801,6 +815,12 @@ def handle_issue_fix_reviewer_command(
         reviewer_artifact_reward_memory=reviewer_artifact_reward_memory,
         reviewer_notification_reward_memory=reviewer_notification_reward_memory,
         reviewer_artifact_required=reviewer_artifact_required,
+        pr_description_build=(
+            load_json_object(args.pr_description_build_json)
+            if getattr(args, "pr_description_build_json", None)
+            else None
+        ),
+        pr_description_head_ref=getattr(args, "pr_description_head_ref", None),
         provider_payload=(
             load_json_object(args.metadata_json) if args.metadata_json else None
         ),

--- a/loopx/capabilities/issue_fix/reviewer_cli.py
+++ b/loopx/capabilities/issue_fix/reviewer_cli.py
@@ -218,15 +218,8 @@ def register_issue_fix_reviewer_commands(
     reviewer_request_parser.add_argument(
         "--pr-description-build-json",
         help=(
-            "Compact issue_fix_pr_description_build_v0 JSON used to verify the "
-            "live PR body before reviewer or group notification writes."
-        ),
-    )
-    reviewer_request_parser.add_argument(
-        "--pr-description-head-ref",
-        help=(
-            "Full 40-character head commit used when the PR description was "
-            "built; compared with live GitHub readback."
+            "Compact issue_fix_pr_description_build_v0 JSON proving the PR "
+            "description recall path executed before notification writes."
         ),
     )
     reviewer_request_parser.add_argument(
@@ -820,7 +813,6 @@ def handle_issue_fix_reviewer_command(
             if getattr(args, "pr_description_build_json", None)
             else None
         ),
-        pr_description_head_ref=getattr(args, "pr_description_head_ref", None),
         provider_payload=(
             load_json_object(args.metadata_json) if args.metadata_json else None
         ),

--- a/loopx/capabilities/issue_fix/reviewer_request.py
+++ b/loopx/capabilities/issue_fix/reviewer_request.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from ...control_plane.runtime.public_safety import public_safe_compact_text
 from .metadata_preview import normalise_github_issue_reference
+from .pr_description import validate_issue_fix_pr_description_publication
 from .reviewer_notification import (
     NotificationSinkAdapter,
     build_issue_fix_reviewer_notification_sinks_result,
@@ -352,8 +353,8 @@ def _fetch_pr_metadata(
                 repo,
                 "--json",
                 "author,closingIssuesReferences,comments,isDraft,reviewRequests,"
-                "mergeStateStatus,reviewDecision,reviews,state,statusCheckRollup,"
-                "title,url",
+                "body,headRefOid,mergeStateStatus,reviewDecision,reviews,state,"
+                "statusCheckRollup,title,url",
             ]
         )
     except (OSError, subprocess.SubprocessError):
@@ -525,6 +526,8 @@ def build_issue_fix_reviewer_request_packet(
     reviewer_artifact_reward_memory: Mapping[str, Any] | None = None,
     reviewer_notification_reward_memory: Mapping[str, Any] | None = None,
     reviewer_artifact_required: bool = False,
+    pr_description_build: Mapping[str, Any] | None = None,
+    pr_description_head_ref: str | None = None,
     provider_payload: Mapping[str, Any] | None = None,
     execute: bool = False,
     generated_at: str | None = "2026-07-10T00:00:00Z",
@@ -562,6 +565,13 @@ def build_issue_fix_reviewer_request_packet(
         )
         external_reads = True
         metadata = fetched or {}
+    publication_gate = validate_issue_fix_pr_description_publication(
+        project=repo_path,
+        live_description=str(metadata.get("body") or ""),
+        live_head_ref=str(metadata.get("headRefOid") or ""),
+        build_packet=pr_description_build,
+        expected_head_ref=pr_description_head_ref,
+    )
     identities = _metadata_identities(metadata, repo=repo, number=number)
     excluded = list(exclude_reviewers)
     if identities["author_handle"]:
@@ -604,7 +614,11 @@ def build_issue_fix_reviewer_request_packet(
     ][:remaining_slots]
     author_exclusion_verified = bool(identities["author_handle"])
     pr_state_verified = identities["state"] in {"OPEN", "CLOSED", "MERGED"}
-    if not author_exclusion_verified or not pr_state_verified:
+    if (
+        not author_exclusion_verified
+        or not pr_state_verified
+        or publication_gate["ok"] is not True
+    ):
         selected = []
 
     existing_notified_reviewers = list(
@@ -633,7 +647,7 @@ def build_issue_fix_reviewer_request_packet(
     )
 
     packet: dict[str, Any] = {
-        "ok": metadata_error is None,
+        "ok": metadata_error is None and publication_gate["ok"] is True,
         "schema_version": ISSUE_FIX_REVIEWER_REQUEST_SCHEMA_VERSION,
         "mode": "issue-fix-reviewer-request",
         "generated_at": generated_at,
@@ -681,6 +695,7 @@ def build_issue_fix_reviewer_request_packet(
             execute and identities["semantic_comment_notified_reviewers"]
         ),
         "reviewer_comment_url": existing_comment_url,
+        "pr_description_publication_gate": publication_gate,
         "private_repo_state_read": True,
         "local_paths_captured": False,
         "raw_provider_payload_captured": False,
@@ -709,6 +724,18 @@ def build_issue_fix_reviewer_request_packet(
                 "without excluding the PR author."
             ),
             material_change=True,
+        )
+    elif publication_gate["ok"] is not True:
+        packet["blocker"] = publication_gate["blocker"]
+        packet["transition"] = _transition(
+            decision="blocker",
+            action_kind="issue_fix_pr_description_publication_evidence",
+            reason=(
+                "Verify the live PR body and head against the repository template "
+                "and an applied-or-ignored semantic preference receipt before "
+                "requesting review or sending a secondary notification."
+            ),
+            material_change=False,
         )
     elif not author_exclusion_verified:
         packet["ok"] = False
@@ -995,7 +1022,12 @@ def build_issue_fix_reviewer_request_packet(
         )
     if reward_memory_error:
         packet["reviewer_artifact_reward_memory_blocker"] = reward_memory_error
-    if notification_sinks_input:
+    if notification_sinks_input and publication_gate["ok"] is not True:
+        packet["secondary_notification_status"] = (
+            "skipped_pr_description_publication_blocked"
+        )
+        packet["secondary_notification_blocker"] = publication_gate["blocker"]
+    elif notification_sinks_input:
         notification_targets = list(packet.get("selected_reviewers") or [])
         if packet.get("notified_reviewers"):
             notification_targets = list(packet.get("notified_reviewers") or [])
@@ -1130,6 +1162,14 @@ def validate_issue_fix_reviewer_request_packet(
         errors.append("raw_git_output_captured must be false")
     if packet.get("commit_emails_captured") is not False:
         errors.append("commit_emails_captured must be false")
+    publication_gate = packet.get("pr_description_publication_gate")
+    if not isinstance(publication_gate, Mapping):
+        errors.append("pr_description_publication_gate must be an object")
+    elif publication_gate.get("ok") is not True:
+        if packet.get("selected_reviewers"):
+            errors.append("blocked PR descriptions must not select reviewers")
+        if packet.get("external_writes_performed") is True:
+            errors.append("blocked PR descriptions must not perform external writes")
     performed = packet.get("review_request_performed") is True
     verified = packet.get("review_request_verified") is True
     requested = packet.get("requested_reviewers")

--- a/loopx/capabilities/issue_fix/reviewer_request.py
+++ b/loopx/capabilities/issue_fix/reviewer_request.py
@@ -353,8 +353,8 @@ def _fetch_pr_metadata(
                 repo,
                 "--json",
                 "author,closingIssuesReferences,comments,isDraft,reviewRequests,"
-                "body,headRefOid,mergeStateStatus,reviewDecision,reviews,state,"
-                "statusCheckRollup,title,url",
+                "mergeStateStatus,reviewDecision,reviews,state,statusCheckRollup,"
+                "title,url",
             ]
         )
     except (OSError, subprocess.SubprocessError):
@@ -527,7 +527,6 @@ def build_issue_fix_reviewer_request_packet(
     reviewer_notification_reward_memory: Mapping[str, Any] | None = None,
     reviewer_artifact_required: bool = False,
     pr_description_build: Mapping[str, Any] | None = None,
-    pr_description_head_ref: str | None = None,
     provider_payload: Mapping[str, Any] | None = None,
     execute: bool = False,
     generated_at: str | None = "2026-07-10T00:00:00Z",
@@ -567,10 +566,7 @@ def build_issue_fix_reviewer_request_packet(
         metadata = fetched or {}
     publication_gate = validate_issue_fix_pr_description_publication(
         project=repo_path,
-        live_description=str(metadata.get("body") or ""),
-        live_head_ref=str(metadata.get("headRefOid") or ""),
         build_packet=pr_description_build,
-        expected_head_ref=pr_description_head_ref,
     )
     identities = _metadata_identities(metadata, repo=repo, number=number)
     excluded = list(exclude_reviewers)
@@ -729,11 +725,10 @@ def build_issue_fix_reviewer_request_packet(
         packet["blocker"] = publication_gate["blocker"]
         packet["transition"] = _transition(
             decision="blocker",
-            action_kind="issue_fix_pr_description_publication_evidence",
+            action_kind="issue_fix_pr_description_recall_evidence",
             reason=(
-                "Verify the live PR body and head against the repository template "
-                "and an applied-or-ignored semantic preference receipt before "
-                "requesting review or sending a secondary notification."
+                "Run the PR-description recall path and pass its compact build "
+                "packet before requesting review or sending a notification."
             ),
             material_change=False,
         )
@@ -1022,12 +1017,7 @@ def build_issue_fix_reviewer_request_packet(
         )
     if reward_memory_error:
         packet["reviewer_artifact_reward_memory_blocker"] = reward_memory_error
-    if notification_sinks_input and publication_gate["ok"] is not True:
-        packet["secondary_notification_status"] = (
-            "skipped_pr_description_publication_blocked"
-        )
-        packet["secondary_notification_blocker"] = publication_gate["blocker"]
-    elif notification_sinks_input:
+    if notification_sinks_input:
         notification_targets = list(packet.get("selected_reviewers") or [])
         if packet.get("notified_reviewers"):
             notification_targets = list(packet.get("notified_reviewers") or [])
@@ -1162,14 +1152,6 @@ def validate_issue_fix_reviewer_request_packet(
         errors.append("raw_git_output_captured must be false")
     if packet.get("commit_emails_captured") is not False:
         errors.append("commit_emails_captured must be false")
-    publication_gate = packet.get("pr_description_publication_gate")
-    if not isinstance(publication_gate, Mapping):
-        errors.append("pr_description_publication_gate must be an object")
-    elif publication_gate.get("ok") is not True:
-        if packet.get("selected_reviewers"):
-            errors.append("blocked PR descriptions must not select reviewers")
-        if packet.get("external_writes_performed") is True:
-            errors.append("blocked PR descriptions must not perform external writes")
     performed = packet.get("review_request_performed") is True
     verified = packet.get("review_request_verified") is True
     requested = packet.get("requested_reviewers")


### PR DESCRIPTION
## Summary

- record whether the PR-description recall path executed
- when semantic-preference config exists, block GitHub and Lark reviewer writes unless the compact build packet reports `recall_executed: true`
- do not validate preference outcome, receipt, PR body, repository template, head SHA, ordering, or digests

## Issue Or Task

- Closes #: N/A
- Contributor task ID: owner-directed issue-fix recall enforcement simplification

## Validation

- [ ] `python3 -m py_compile loopx/*.py`
- [ ] `loopx check --scan-root .`
- [x] Other: `loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard --format json --no-progress` passed 10/10 selected checks, focused PR-description builder and reviewer-request smokes passed, Ruff passed, and the public-boundary scan was clean.

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
