### PR TITLE
fix(todo): point agent authors to --claimed-by

### DIFF
--- a/examples/cli-control-plane-command-modularization-smoke.py
+++ b/examples/cli-control-plane-command-modularization-smoke.py
@@ -79,6 +79,16 @@ def assert_help_surfaces() -> None:
         "exact linked user_gate decision_scope",
         "todo complete controller override help",
     )
+    assert_contains(
+        complete_help.stdout,
+        "todo add intentionally does not accept this option",
+        "todo agent-id help",
+    )
+    assert_contains(
+        complete_help.stdout,
+        "use --claimed-by to assign execution",
+        "todo agent-id recovery help",
+    )
 
     quota_help = run_cli("quota", "--help")
     assert quota_help.returncode == 0, quota_help.stderr

--- a/examples/control_plane/todo-suggestion-prompt-smoke.py
+++ b/examples/control_plane/todo-suggestion-prompt-smoke.py
@@ -186,12 +186,11 @@ def main() -> int:
         assert rejected.returncode == 1, rejected.stdout
         error_payload = json.loads(rejected.stdout)
         assert error_payload["error"].startswith(
-            "todo add does not support --agent-id;"
+            "todo add does not support --agent-id for agent todos;"
         ), error_payload
         error = error_payload["error"]
-        assert "todo list/suggest" in error, error_payload
-        assert "user-todo authoring" in error, error_payload
-        assert "lifecycle actor attribution only" in error, error_payload
+        assert "use --claimed-by <registered-agent>" in error, error_payload
+        assert "omit both options to leave the todo unclaimed" in error, error_payload
 
     print("todo-suggestion-prompt-smoke: ok")
     return 0

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -410,7 +410,9 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
             "claim/update/complete/supersede, attribute the "
             "lifecycle actor; registered multi-agent goals require it unless an "
             "exact linked user_gate decision_scope supplies the typed owner/controller "
-            "override. For list/suggest, select the project agent lane."
+            "override. For list/suggest, select the project agent lane. Agent todo "
+            "add intentionally does not accept this option; use --claimed-by to "
+            "assign execution, or omit both options to leave the todo unclaimed."
         ),
     )
     todo_parser.add_argument(

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -107,6 +107,13 @@ def validate_shared_todo_options(args: argparse.Namespace) -> None:
         and not agent_id_allowed_for_read
         and not agent_id_allowed_for_lifecycle
     ):
+        if args.todo_command == "add" and args.role == "agent":
+            raise ValueError(
+                "todo add does not support --agent-id for agent todos; omit "
+                "--agent-id and use --claimed-by <registered-agent> only when "
+                "assigning execution, or omit both options to leave the todo "
+                "unclaimed."
+            )
         raise ValueError(
             f"todo {args.todo_command} does not support --agent-id; --agent-id "
             "scopes todo list/suggest, user-todo authoring, and lifecycle actor "


### PR DESCRIPTION
## Summary

- keep todo lifecycle authority unchanged: agent todo creation still rejects `--agent-id`
- point agent todo authors to `--claimed-by` for execution assignment, or to an unclaimed todo
- cover the help text and structured rejection payload with focused existing smokes

## Issue Or Task

- Closes # N/A (bounded CLI self-repair)
- Contributor task ID: N/A

## Validation

- [x] `python3 -m py_compile` on the four changed Python files
- [x] `uvx --from "ruff>=0.12,<1" ruff check` on the four changed Python files
- [x] `python3 examples/control_plane/todo-suggestion-prompt-smoke.py`
- [x] `python3 examples/cli-control-plane-command-modularization-smoke.py`
- [x] `loopx canary premerge --from-git-diff` (18/18 selected checks passed)
- [x] public boundary scan clean for all four changed files

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.

## Residual Risk

- This intentionally does not introduce command-specific argparse subparsers; the shared union help remains, but the supported alternative is now explicit before and after a rejected invocation.
