### PR TITLE
Trace pre-agent SkillsBench Turn failures

### DIFF
--- a/examples/skillsbench-loopx-turn-agent-cli-smoke.py
+++ b/examples/skillsbench-loopx-turn-agent-cli-smoke.py
@@ -310,12 +310,8 @@ print(json.dumps({
     "schema_version": "skillsbench_remote_command_file_bridge_operation_response_v0",
     "ok": False,
     "exit_code": 13,
-    "stdout": json.dumps({
-        "ok": False,
-        "mode": "plan",
-        "error": "Permission denied: SENSITIVE_PATH_SENTINEL",
-    }),
-    "stderr": "SENSITIVE_STDERR_SENTINEL",
+    "stdout": "",
+    "stderr": "/bin/sh: /app/.local/bin/loopx: not found SENSITIVE_STDERR_SENTINEL",
     "stdout_truncated": False,
     "stderr_truncated": False,
 }))
@@ -357,7 +353,7 @@ print(json.dumps({
     assert execution.get("status") == "failed", execution
     assert execution.get("receipt", {}).get("failed_phase") == "turn_plan", execution
     assert execution.get("failure") == {
-        "category": "scored_workspace_permission_denied",
+        "category": "case_loopx_cli_missing",
         "exit_code": 13,
     }, execution
     assert execution.get("effects") == {
@@ -370,9 +366,8 @@ print(json.dumps({
     assert validation.get("meaningful_operation_count") == 0, validation
     assert all(value is False for value in boundary.values()), boundary
     public_trace = json.dumps(traces[0], sort_keys=True)
-    assert "SENSITIVE_PATH_SENTINEL" not in public_trace, public_trace
     assert "SENSITIVE_STDERR_SENTINEL" not in public_trace, public_trace
-    assert "loopx_turn_turn_plan_scored_workspace_permission_denied" in response, (
+    assert "loopx_turn_turn_plan_case_loopx_cli_missing" in response, (
         response
     )
     return {

--- a/examples/skillsbench-loopx-turn-agent-cli-smoke.py
+++ b/examples/skillsbench-loopx-turn-agent-cli-smoke.py
@@ -8,6 +8,7 @@ import shlex
 import sys
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 
@@ -22,6 +23,7 @@ from loopx.benchmark_adapters.skillsbench_turn_runtime import (  # noqa: E402
     SkillsBenchTurnRuntimeConfig,
     build_skillsbench_loopx_turn_trace,
     run_skillsbench_loopx_turn,
+    run_skillsbench_loopx_turn_relay,
 )
 from loopx.benchmark_adapters.skillsbench_turn_route import (  # noqa: E402
     sync_skillsbench_loopx_turn_trace_into_compact,
@@ -298,6 +300,90 @@ def _run_recoverable_host_failure(root: Path) -> dict[str, Any]:
     }
 
 
+def _run_turn_plan_failure(root: Path) -> dict[str, Any]:
+    bridge = root / "failing-plan-bridge.py"
+    bridge.write_text(
+        """#!/usr/bin/env python3
+import json
+
+print(json.dumps({
+    "schema_version": "skillsbench_remote_command_file_bridge_operation_response_v0",
+    "ok": False,
+    "exit_code": 13,
+    "stdout": json.dumps({
+        "ok": False,
+        "mode": "plan",
+        "error": "Permission denied: SENSITIVE_PATH_SENTINEL",
+    }),
+    "stderr": "SENSITIVE_STDERR_SENTINEL",
+    "stdout_truncated": False,
+    "stderr_truncated": False,
+}))
+""",
+        encoding="utf-8",
+    )
+    traces: list[dict[str, Any]] = []
+
+    def unexpected_agent_invocation(_prompt: str) -> str:
+        raise AssertionError("Turn plan failure must not invoke the Agent CLI")
+
+    response = run_skillsbench_loopx_turn_relay(
+        prompt="Public fixture prompt.",
+        session_id="turn-plan-failure",
+        relay_config=SimpleNamespace(
+            remote_command_file_bridge_command=(
+                f"{shlex.quote(sys.executable)} {shlex.quote(str(bridge))}"
+            ),
+            loopx_turn_validation_command="unrecorded-validator-command",
+            worker_public_trace_dir=str(root / "public-trace"),
+            loopx_case_goal_id=GOAL_ID,
+            loopx_case_agent_id=AGENT_ID,
+            remote_command_file_bridge_timeout_sec=30.0,
+            timeout_sec=60.0,
+            loopx_case_cli_path="/app/.local/bin/loopx",
+            loopx_case_registry_path="/app/.loopx/registry.json",
+            loopx_case_runtime_root="/app/.loopx/runtime",
+            route=LOOPX_TURN_AGENT_CLI_ROUTE,
+            dataset="skillsbench",
+            task_id="public-smoke-case",
+        ),
+        agent_runner=unexpected_agent_invocation,
+        trace_writer=traces.append,
+    )
+    assert len(traces) == 1, traces
+    execution = traces[0].get("loopx_turn_execution", {})
+    validation = traces[0].get("scored_workspace_validation", {})
+    boundary = traces[0].get("boundary", {})
+    assert execution.get("status") == "failed", execution
+    assert execution.get("receipt", {}).get("failed_phase") == "turn_plan", execution
+    assert execution.get("failure") == {
+        "category": "scored_workspace_permission_denied",
+        "exit_code": 13,
+    }, execution
+    assert execution.get("effects") == {
+        "host_invoked": False,
+        "state_written": False,
+        "quota_spent": False,
+        "scheduler_acknowledged": False,
+    }, execution
+    assert validation.get("status") == "not_attempted", validation
+    assert validation.get("meaningful_operation_count") == 0, validation
+    assert all(value is False for value in boundary.values()), boundary
+    public_trace = json.dumps(traces[0], sort_keys=True)
+    assert "SENSITIVE_PATH_SENTINEL" not in public_trace, public_trace
+    assert "SENSITIVE_STDERR_SENTINEL" not in public_trace, public_trace
+    assert "loopx_turn_turn_plan_scored_workspace_permission_denied" in response, (
+        response
+    )
+    return {
+        "execution_status": execution.get("status"),
+        "failed_phase": execution.get("receipt", {}).get("failed_phase"),
+        "failure_category": execution.get("failure", {}).get("category"),
+        "validator_invoked": validation.get("meaningful_operation_count") != 0,
+        "raw_material_recorded": False,
+    }
+
+
 def main() -> int:
     route_contract = skillsbench_route_contract(LOOPX_TURN_AGENT_CLI_ROUTE)
     assert route_contract.get("product_mode") is True, route_contract
@@ -338,6 +424,10 @@ def main() -> int:
         prefix="skillsbench-loopx-turn-host-failure-"
     ) as value:
         recoverable_host_failure = _run_recoverable_host_failure(Path(value))
+    with tempfile.TemporaryDirectory(
+        prefix="skillsbench-loopx-turn-plan-failure-"
+    ) as value:
+        turn_plan_failure = _run_turn_plan_failure(Path(value))
     with tempfile.TemporaryDirectory(prefix="skillsbench-loopx-turn-missing-") as value:
         paths = _write_fixture(Path(value))
         try:
@@ -365,6 +455,7 @@ def main() -> int:
                 "success": success,
                 "failure": failure,
                 "recoverable_host_failure": recoverable_host_failure,
+                "turn_plan_failure": turn_plan_failure,
                 "missing_validator_failed_closed": True,
                 "model_invoked": False,
                 "remote_job_launched": False,

--- a/loopx/benchmark_adapters/skillsbench_turn_route.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_route.py
@@ -178,6 +178,17 @@ def _public_execution(value: Any) -> dict[str, Any]:
         if public_receipt:
             execution["receipt"] = public_receipt
 
+    failure = value.get("failure")
+    if isinstance(failure, dict):
+        public_failure: dict[str, Any] = {}
+        if category := _public_label(failure.get("category"), limit=120):
+            public_failure["category"] = category
+        exit_code = failure.get("exit_code")
+        if isinstance(exit_code, int) and not isinstance(exit_code, bool):
+            public_failure["exit_code"] = exit_code
+        if public_failure:
+            execution["failure"] = public_failure
+
     effects = value.get("effects")
     if isinstance(effects, dict):
         execution["effects"] = {

--- a/loopx/benchmark_adapters/skillsbench_turn_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_runtime.py
@@ -73,15 +73,20 @@ class SkillsBenchTurnAgentFailure(RuntimeError):
     """A recoverable host Agent CLI failure that must not commit a Turn."""
 
 
-def _loopx_cli_failure_category(stdout: Any) -> str:
+def _loopx_cli_failure_category(stdout: Any, stderr: Any) -> str:
     try:
         payload = json.loads(str(stdout or ""))
     except json.JSONDecodeError:
-        return "scored_workspace_command_failed"
-    if not isinstance(payload, dict):
-        return "scored_workspace_command_failed"
-    error = " ".join(str(payload.get("error") or "").lower().split())
+        payload = {}
+    error = " ".join(
+        f"{payload.get('error') if isinstance(payload, dict) else ''} {stderr or ''}"
+        .lower()
+        .split()
+    )
     classifiers = (
+        (r"/app/\.local/bin/loopx.*not found", "case_loopx_cli_missing"),
+        (r"no module named loopx", "case_loopx_source_missing"),
+        (r"loopx cli requires python", "case_python_runtime_missing"),
         (r"python 3\.11\+ is required", "unsupported_python_runtime"),
         (r"permission denied", "scored_workspace_permission_denied"),
         (r"no such file|not found", "scored_workspace_path_missing"),
@@ -141,7 +146,9 @@ class SkillsBenchTurnBridge:
             exit_code = payload.get("exit_code")
             raise SkillsBenchTurnBridgeError(
                 "scored-workspace command failed",
-                category=_loopx_cli_failure_category(payload.get("stdout")),
+                category=_loopx_cli_failure_category(
+                    payload.get("stdout"), payload.get("stderr")
+                ),
                 exit_code=(
                     exit_code
                     if isinstance(exit_code, int) and not isinstance(exit_code, bool)

--- a/loopx/benchmark_adapters/skillsbench_turn_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_runtime.py
@@ -10,6 +10,7 @@ the Turn executor own writeback and the single quota spend.
 from __future__ import annotations
 
 import json
+import re
 import shlex
 import subprocess
 import time
@@ -54,9 +55,45 @@ class SkillsBenchTurnRuntimeConfig:
 class SkillsBenchTurnBridgeError(RuntimeError):
     """A compact failure raised at the host/scored-workspace boundary."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        stage: str = "bridge_operation",
+        category: str = "bridge_operation_failed",
+        exit_code: int | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.stage = stage
+        self.category = category
+        self.exit_code = exit_code
+
 
 class SkillsBenchTurnAgentFailure(RuntimeError):
     """A recoverable host Agent CLI failure that must not commit a Turn."""
+
+
+def _loopx_cli_failure_category(stdout: Any) -> str:
+    try:
+        payload = json.loads(str(stdout or ""))
+    except json.JSONDecodeError:
+        return "scored_workspace_command_failed"
+    if not isinstance(payload, dict):
+        return "scored_workspace_command_failed"
+    error = " ".join(str(payload.get("error") or "").lower().split())
+    classifiers = (
+        (r"python 3\.11\+ is required", "unsupported_python_runtime"),
+        (r"permission denied", "scored_workspace_permission_denied"),
+        (r"no such file|not found", "scored_workspace_path_missing"),
+        (r"unknown agent|agent .*not registered", "case_agent_not_registered"),
+        (r"goal .*not found|no matching goal", "case_goal_not_found"),
+        (r"public boundary|private material", "case_public_boundary_rejected"),
+        (r"operator inbox|lark", "case_operator_inbox_projection_failed"),
+    )
+    for pattern, category in classifiers:
+        if re.search(pattern, error):
+            return category
+    return "loopx_cli_command_failed"
 
 
 class SkillsBenchTurnBridge:
@@ -88,7 +125,10 @@ class SkillsBenchTurnBridge:
                 "bridge operation did not complete"
             ) from exc
         if proc.returncode != 0:
-            raise SkillsBenchTurnBridgeError("bridge command returned non-zero")
+            raise SkillsBenchTurnBridgeError(
+                "bridge command returned non-zero",
+                exit_code=proc.returncode,
+            )
         try:
             payload = json.loads(proc.stdout)
         except json.JSONDecodeError as exc:
@@ -98,7 +138,16 @@ class SkillsBenchTurnBridge:
         if payload.get("schema_version") != SKILLSBENCH_BRIDGE_OPERATION_SCHEMA_VERSION:
             raise SkillsBenchTurnBridgeError("bridge operation schema was unsupported")
         if payload.get("ok") is not True or payload.get("exit_code") != 0:
-            raise SkillsBenchTurnBridgeError("scored-workspace command failed")
+            exit_code = payload.get("exit_code")
+            raise SkillsBenchTurnBridgeError(
+                "scored-workspace command failed",
+                category=_loopx_cli_failure_category(payload.get("stdout")),
+                exit_code=(
+                    exit_code
+                    if isinstance(exit_code, int) and not isinstance(exit_code, bool)
+                    else None
+                ),
+            )
         if payload.get("stdout_truncated") is True:
             raise SkillsBenchTurnBridgeError("scored-workspace stdout was truncated")
         if meaningful:
@@ -140,9 +189,21 @@ def _turn_plan(
         "--host generic-cli --execution-mode isolated-headless "
         "--include-transaction-detail --scan-root /app --limit 5"
     )
-    payload = bridge.loopx_json(command)
+    try:
+        payload = bridge.loopx_json(command)
+    except SkillsBenchTurnBridgeError as exc:
+        raise SkillsBenchTurnBridgeError(
+            str(exc),
+            stage="turn_plan",
+            category=exc.category,
+            exit_code=exc.exit_code,
+        ) from exc
     if payload.get("ok") is not True:
-        raise SkillsBenchTurnBridgeError("LoopX Turn plan was not executable")
+        raise SkillsBenchTurnBridgeError(
+            "LoopX Turn plan was not executable",
+            stage="turn_plan",
+            category="loopx_turn_plan_not_executable",
+        )
     return payload
 
 
@@ -335,6 +396,62 @@ def build_skillsbench_loopx_turn_trace(
     }
 
 
+def build_skillsbench_loopx_turn_failure_trace(
+    *,
+    route: str,
+    benchmark_id: str,
+    task_id: str,
+    error: SkillsBenchTurnBridgeError,
+) -> dict[str, Any]:
+    """Build a public-safe receipt when Turn fails before execution exists."""
+
+    failure: dict[str, Any] = {
+        "category": error.category,
+    }
+    if error.exit_code is not None:
+        failure["exit_code"] = error.exit_code
+    execution = {
+        "schema_version": "loopx_turn_execution_v0",
+        "mode": "run_once",
+        "status": "failed",
+        "execution_mode": "isolated-headless",
+        "result_kind": "repair_required",
+        "quota_slot_spend_count": 0,
+        "failure": failure,
+        "receipt": {
+            "status": "failed",
+            "result_kind": "repair_required",
+            "failed_phase": error.stage,
+            "next_phase": error.stage,
+            "completed_phases": [],
+        },
+        "effects": {
+            "host_invoked": False,
+            "state_written": False,
+            "quota_spent": False,
+            "scheduler_acknowledged": False,
+        },
+    }
+    validation = {
+        "schema_version": "skillsbench_scored_workspace_validation_v0",
+        "status": "not_attempted",
+        "independent": True,
+        "validator_kind": "skillsbench_scored_workspace_command",
+        "oracle_feedback_used": False,
+        "meaningful_operation_count": 0,
+        "raw_validator_output_recorded": False,
+        "raw_task_text_recorded": False,
+        "raw_verifier_output_recorded": False,
+    }
+    return build_skillsbench_loopx_turn_trace(
+        route=route,
+        benchmark_id=benchmark_id,
+        task_id=task_id,
+        execution=execution,
+        scored_workspace_validation=validation,
+    )
+
+
 def run_skillsbench_loopx_turn_relay(
     *,
     prompt: str,
@@ -360,26 +477,39 @@ def run_skillsbench_loopx_turn_relay(
         )[:120]
         or "session"
     )
-    execution, scored_validation = run_skillsbench_loopx_turn(
-        prompt=prompt,
-        agent_runner=agent_runner,
-        config=SkillsBenchTurnRuntimeConfig(
-            bridge_command=bridge_command,
-            validation_command=validation_command,
-            goal_id=relay_config.loopx_case_goal_id,
-            agent_id=relay_config.loopx_case_agent_id,
-            runtime_root=Path(trace_root).parent
-            / ".loopx-turn-runtime"
-            / runtime_session,
-            bridge_timeout_seconds=max(
-                1.0, relay_config.remote_command_file_bridge_timeout_sec
+    try:
+        execution, scored_validation = run_skillsbench_loopx_turn(
+            prompt=prompt,
+            agent_runner=agent_runner,
+            config=SkillsBenchTurnRuntimeConfig(
+                bridge_command=bridge_command,
+                validation_command=validation_command,
+                goal_id=relay_config.loopx_case_goal_id,
+                agent_id=relay_config.loopx_case_agent_id,
+                runtime_root=Path(trace_root).parent
+                / ".loopx-turn-runtime"
+                / runtime_session,
+                bridge_timeout_seconds=max(
+                    1.0, relay_config.remote_command_file_bridge_timeout_sec
+                ),
+                agent_timeout_seconds=max(1.0, float(relay_config.timeout_sec)),
+                case_cli_path=relay_config.loopx_case_cli_path,
+                case_registry_path=relay_config.loopx_case_registry_path,
+                case_runtime_root=relay_config.loopx_case_runtime_root,
             ),
-            agent_timeout_seconds=max(1.0, float(relay_config.timeout_sec)),
-            case_cli_path=relay_config.loopx_case_cli_path,
-            case_registry_path=relay_config.loopx_case_registry_path,
-            case_runtime_root=relay_config.loopx_case_runtime_root,
-        ),
-    )
+        )
+    except SkillsBenchTurnBridgeError as exc:
+        trace_writer(
+            build_skillsbench_loopx_turn_failure_trace(
+                route=relay_config.route,
+                benchmark_id=relay_config.dataset,
+                task_id=relay_config.task_id,
+                error=exc,
+            )
+        )
+        return recoverable_codex_turn_failure_message(
+            f"loopx_turn_{exc.stage}_{exc.category}"
+        )
     trace_writer(
         build_skillsbench_loopx_turn_trace(
             route=relay_config.route,


### PR DESCRIPTION
## Summary
- emit a compact Turn receipt when the scored-workspace bridge fails before Agent execution
- preserve failure stage/category/exit code while excluding command, stdout, stderr, task text, paths, and credentials
- project the failure into benchmark compact evidence and cover it in the existing focused Turn smoke

## Validation
- `examples/skillsbench-loopx-turn-agent-cli-smoke.py` passed: committed path, validation failure, host failure, and pre-agent `turn_plan` failure
- `examples/skillsbench-typed-repair-smoke.py` passed
- `python3 -m py_compile` passed for all changed Python files
- `loopx canary premerge --from-git-diff`: 7/7 selected checks passed, including public-boundary scan; gate remains `manual_review_required` because benchmark-sensitive surfaces require maintainer review

## Boundary
No benchmark jobs, task text, trajectories, verifier output, credentials, uploads, submissions, scoring changes, or task-semantic changes are included.

## Merge
Not self-merging; benchmark-sensitive manual hold is preserved.