### PR TITLE
fix(control-plane): isolate replan stalls by agent

### DIFF
--- a/loopx/control_plane/work_items/autonomous_replan_obligation.py
+++ b/loopx/control_plane/work_items/autonomous_replan_obligation.py
@@ -57,6 +57,44 @@ def _single_public_agent_id(items: list[dict[str, Any]]) -> str | None:
     return next(iter(agent_ids)) if len(agent_ids) == 1 else None
 
 
+def _run_history_agent_id(run: dict[str, Any]) -> str | None:
+    agent_id = str(run.get("agent_id") or "").strip()
+    if agent_id:
+        return agent_id
+    monitor_target = run_history_monitor_target(run)
+    if isinstance(monitor_target, dict):
+        return str(monitor_target.get("agent_id") or "").strip() or None
+    return None
+
+
+def _latest_agent_run_history(
+    latest_runs: list[dict[str, Any]] | None,
+    *,
+    neutral_classifications: set[str],
+) -> list[dict[str, Any]]:
+    """Keep the newest attributable agent lane while preserving goal-level runs."""
+
+    accountable_agent_id = next(
+        (
+            _run_history_agent_id(run)
+            for run in latest_runs or []
+            if isinstance(run, dict)
+            and str(run.get("classification") or "").strip()
+            not in neutral_classifications
+            and _run_history_agent_id(run)
+        ),
+        None,
+    )
+    if not accountable_agent_id:
+        return [run for run in latest_runs or [] if isinstance(run, dict)]
+    return [
+        run
+        for run in latest_runs or []
+        if isinstance(run, dict)
+        and _run_history_agent_id(run) in {None, accountable_agent_id}
+    ]
+
+
 def run_history_monitor_target(run: dict[str, Any]) -> dict[str, Any] | None:
     target = run.get("monitor_target")
     if isinstance(target, dict):
@@ -525,9 +563,14 @@ def autonomous_replan_obligation_from_runs(
     dead_monitor_repeat_schema_version: str,
     periodic_run_threshold: int,
 ) -> dict[str, Any] | None:
+    scoped_latest_runs = _latest_agent_run_history(
+        latest_runs,
+        neutral_classifications=neutral_classifications,
+    )
+
     def periodic_review() -> dict[str, Any] | None:
         return autonomous_replan_periodic_review_from_runs(
-            latest_runs,
+            scoped_latest_runs,
             agent_todos=agent_todos,
             autonomous_replan_ack_recorded=autonomous_replan_ack_recorded,
             neutral_classifications=neutral_classifications,
@@ -537,7 +580,7 @@ def autonomous_replan_obligation_from_runs(
 
     signals: list[dict[str, Any]] = []
     signal_scan_limit = max(autonomous_replan_stall_threshold, dead_monitor_repeat_threshold)
-    for run in latest_runs or []:
+    for run in scoped_latest_runs:
         if not isinstance(run, dict):
             continue
         classification = str(run.get("classification") or "").strip()
@@ -624,7 +667,7 @@ def autonomous_replan_obligation_from_runs(
         if monitor_classifications != {"quota_monitor_poll"}:
             return periodic_review()
         if run_history_monitor_wait_already_acknowledged(
-            latest_runs,
+            scoped_latest_runs,
             signal_count=len(monitor_signals),
             autonomous_replan_ack_recorded=autonomous_replan_ack_recorded,
             neutral_classifications=neutral_classifications,

--- a/tests/control_plane/test_goal_vision_blocked_successor.py
+++ b/tests/control_plane/test_goal_vision_blocked_successor.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from copy import deepcopy
+
 import pytest
 
 from loopx.cli_commands.status import attach_agent_lane_next_actions
@@ -228,6 +230,34 @@ def test_two_identical_blocked_successor_waits_trigger_bounded_replan() -> None:
         "discover_safe_successor",
         "create_successor",
         "record_wait_continuation",
+    ]
+
+
+def test_interleaved_peer_monitor_does_not_reset_blocked_successor_replan() -> None:
+    polls = _blocked_wait_polls()
+    peer_poll = deepcopy(polls[0])
+    peer_poll["agent_id"] = PRIMARY_AGENT
+    peer_identity = {
+        "agent_id": PRIMARY_AGENT,
+        "target_id": "peer-monitor-target",
+        "frontier_identity": "peer-frontier",
+    }
+    peer_poll["monitor_target"].update(peer_identity)
+    peer_poll["monitor_event"]["agent_id"] = PRIMARY_AGENT
+    peer_poll["monitor_event"]["monitor_target"].update(peer_identity)
+
+    replanned = _quota_with_replan_runs(
+        [polls[0], peer_poll, polls[1], _vision_run()]
+    )
+
+    assert replanned["decision"] == "autonomous_replan_required"
+    obligation = replanned["autonomous_replan_obligation"]
+    assert obligation["agent_id"] == AGENT_ID
+    trigger = obligation["triggers"][0]
+    assert trigger["kind"] == "blocked_successor_no_progress_repeat"
+    assert trigger["monitor_target_id"] == polls[0]["monitor_target"]["target_id"]
+    assert trigger["frontier_identity"] == polls[0]["monitor_target"][
+        "frontier_identity"
     ]
 
 


### PR DESCRIPTION
## Summary
- scope autonomous replan run-history windows to the newest attributable agent lane
- preserve unscoped goal-level runs while excluding interleaved peer records
- add a regression for two identical blocked-successor waits separated by another peer monitor

## Why
A multi-agent goal could record two unchanged waits for one agent, but an interleaved peer monitor changed the global two-run window. The detector then saw different monitor targets and skipped the required bounded replan.

## Validation
- `23 passed` across `test_goal_vision_blocked_successor.py` and `test_quota_slot_accounting.py`
- `uvx ruff check` on changed Python files
- `loopx canary premerge --from-git-diff`: 16/16 selected checks passed, 0 manual holds
- replayed the active multi-agent run history and observed the expected agent-owned `autonomous_replan_required` decision

## Boundary
Only public control-plane code and a focused regression test are included. Local state, raw run records, credentials, absolute paths, and private evidence are excluded.