### PR TITLE
Fix agent vision retention across status history truncation

### DIFF
--- a/examples/control_plane/run-history-agent-context-retention-smoke.py
+++ b/examples/control_plane/run-history-agent-context-retention-smoke.py
@@ -11,11 +11,27 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from loopx.control_plane.goals.goal_frontier import latest_agent_vision_from_status_payload
+from loopx.control_plane.runtime.run_history import build_run_history
 from loopx.history import collect_history
 
 
 GOAL_ID = "agent-context-retention-goal"
 SIDE_AGENT = "codex-side-bypass"
+
+
+def project_run_history(history: dict) -> dict:
+    return build_run_history(
+        history,
+        latest_run=lambda goal: goal.get("latest_status_run"),
+        goal_lifecycle_fields=lambda goal, run: {
+            "lifecycle_phase": "active",
+            "lifecycle_flags": [],
+        },
+        subagent_activity_for_goal=lambda goal: None,
+        compact_run=lambda run: dict(run),
+        quota_status=lambda goal: {},
+        display_limit=3,
+    )
 
 
 def write_fixture(root: Path) -> tuple[Path, Path]:
@@ -145,8 +161,14 @@ def main() -> None:
             run.get("agent_id") == SIDE_AGENT and run.get("agent_vision")
             for run in latest_runs
         ), latest_runs
+        projected_run_history = project_run_history(history)
+        projected_runs = projected_run_history["goals"][0]["latest_runs"]
+        assert any(
+            run.get("agent_id") == SIDE_AGENT and run.get("agent_vision")
+            for run in projected_runs
+        ), projected_runs
         vision = latest_agent_vision_from_status_payload(
-            {"run_history": {"goals": history["goals"]}},
+            {"run_history": projected_run_history},
             goal_id=GOAL_ID,
             agent_id=SIDE_AGENT,
         )
@@ -194,8 +216,14 @@ def main() -> None:
             run.get("agent_id") == SIDE_AGENT and run.get("agent_vision")
             for run in latest_runs
         ), latest_runs
+        projected_run_history = project_run_history(history)
+        projected_runs = projected_run_history["goals"][0]["latest_runs"]
+        assert not any(
+            run.get("agent_id") == SIDE_AGENT and run.get("agent_vision")
+            for run in projected_runs
+        ), projected_runs
         vision = latest_agent_vision_from_status_payload(
-            {"run_history": {"goals": history["goals"]}},
+            {"run_history": projected_run_history},
             goal_id=GOAL_ID,
             agent_id=SIDE_AGENT,
         )

--- a/examples/control_plane/run-history-agent-context-retention-smoke.py
+++ b/examples/control_plane/run-history-agent-context-retention-smoke.py
@@ -19,7 +19,7 @@ GOAL_ID = "agent-context-retention-goal"
 SIDE_AGENT = "codex-side-bypass"
 
 
-def project_run_history(history: dict) -> dict:
+def project_run_history(history: dict, *, display_limit: int = 3) -> dict:
     return build_run_history(
         history,
         latest_run=lambda goal: goal.get("latest_status_run"),
@@ -30,7 +30,7 @@ def project_run_history(history: dict) -> dict:
         subagent_activity_for_goal=lambda goal: None,
         compact_run=lambda run: dict(run),
         quota_status=lambda goal: {},
-        display_limit=3,
+        display_limit=display_limit,
     )
 
 
@@ -112,6 +112,20 @@ def write_fixture(root: Path) -> tuple[Path, Path]:
                     "satisfied": True,
                     "decision": "patched",
                 }
+            if action == "older side":
+                record["autonomous_replan_ack"] = {
+                    "schema_version": "autonomous_replan_ack_v0",
+                    "recorded": True,
+                    "source": "fixture",
+                    "delta_contract": {
+                        "schema_version": "repair_delta_contract_v0",
+                        "required": True,
+                        "delta_present": True,
+                        "delta_kinds": ["runnable_todo_set"],
+                        "auto_evidence": [],
+                        "accepted_without_delta": False,
+                    },
+                }
             handle.write(json.dumps(record, ensure_ascii=False) + "\n")
     return registry_path, runtime
 
@@ -161,12 +175,22 @@ def main() -> None:
             run.get("agent_id") == SIDE_AGENT and run.get("agent_vision")
             for run in latest_runs
         ), latest_runs
+        assert any(
+            run.get("agent_id") == SIDE_AGENT and run.get("autonomous_replan_ack")
+            for run in latest_runs
+        ), latest_runs
+        assert len(latest_runs) == 5, latest_runs
         projected_run_history = project_run_history(history)
         projected_runs = projected_run_history["goals"][0]["latest_runs"]
         assert any(
             run.get("agent_id") == SIDE_AGENT and run.get("agent_vision")
             for run in projected_runs
         ), projected_runs
+        assert any(
+            run.get("agent_id") == SIDE_AGENT and run.get("autonomous_replan_ack")
+            for run in projected_runs
+        ), projected_runs
+        assert len(projected_runs) == 5, projected_runs
         vision = latest_agent_vision_from_status_payload(
             {"run_history": projected_run_history},
             goal_id=GOAL_ID,
@@ -174,6 +198,18 @@ def main() -> None:
         )
         assert vision and vision["agent_id"] == SIDE_AGENT, vision
         assert "global run window" in vision["vision_patch"]["replan_trigger_summary"], vision
+
+        zero_budget_history = collect_history(
+            registry_path=registry_path,
+            runtime_root=runtime,
+            goal_id=GOAL_ID,
+            limit=0,
+        )
+        assert zero_budget_history["goals"][0]["latest_runs"] == [], zero_budget_history
+        zero_budget_projection = project_run_history(history, display_limit=0)
+        assert zero_budget_projection["goals"][0]["latest_runs"] == [], (
+            zero_budget_projection
+        )
     with tempfile.TemporaryDirectory(prefix="loopx-agent-context-retired-") as raw_tmp:
         registry_path, runtime = write_fixture(Path(raw_tmp))
         runs_dir = runtime / "goals" / GOAL_ID / "runs"

--- a/examples/control_plane/run-history-agent-context-retention-smoke.py
+++ b/examples/control_plane/run-history-agent-context-retention-smoke.py
@@ -16,7 +16,9 @@ from loopx.history import collect_history
 
 
 GOAL_ID = "agent-context-retention-goal"
-SIDE_AGENT = "codex-side-bypass"
+COORDINATION_PEER = "codex-coordination-peer"
+PRODUCT_PEER = "codex-product-peer"
+TARGET_PEER = "codex-research-peer"
 
 
 def project_run_history(history: dict, *, display_limit: int = 3) -> dict:
@@ -56,9 +58,9 @@ def write_fixture(root: Path) -> tuple[Path, Path]:
                         "coordination": {
                             "agent_model": "peer_v1",
                             "registered_agents": [
-                                "codex-main-control",
-                                SIDE_AGENT,
-                                "codex-product-capability",
+                                COORDINATION_PEER,
+                                TARGET_PEER,
+                                PRODUCT_PEER,
                             ],
                         },
                     }
@@ -69,15 +71,15 @@ def write_fixture(root: Path) -> tuple[Path, Path]:
         encoding="utf-8",
     )
     runs = [
-        ("2026-07-06T00:06:00+00:00", "codex-main-control", "latest main"),
-        ("2026-07-06T00:05:00+00:00", "codex-product-capability", "latest product"),
-        ("2026-07-06T00:04:00+00:00", "codex-main-control", "second main"),
+        ("2026-07-06T00:06:00+00:00", COORDINATION_PEER, "latest coordination"),
+        ("2026-07-06T00:05:00+00:00", PRODUCT_PEER, "latest product"),
+        ("2026-07-06T00:04:00+00:00", COORDINATION_PEER, "second coordination"),
         (
             "2026-07-06T00:03:00+00:00",
-            SIDE_AGENT,
-            "side vision",
+            TARGET_PEER,
+            "target peer vision",
         ),
-        ("2026-07-06T00:02:00+00:00", SIDE_AGENT, "older side"),
+        ("2026-07-06T00:02:00+00:00", TARGET_PEER, "older target peer"),
     ]
     with (runs_dir / "index.jsonl").open("w", encoding="utf-8") as handle:
         for generated_at, agent_id, action in runs:
@@ -90,29 +92,29 @@ def write_fixture(root: Path) -> tuple[Path, Path]:
                 "json_path": str(runs_dir / f"{generated_at}.json"),
                 "markdown_path": str(runs_dir / f"{generated_at}.md"),
             }
-            if action == "side vision":
+            if action == "target peer vision":
                 record["agent_vision"] = {
                     "schema_version": "goal_vision_replan_contract_v0",
-                    "agent_id": SIDE_AGENT,
+                    "agent_id": TARGET_PEER,
                     "state": "active",
                     "vision_patch": {
                         "acceptance_summary": (
-                            "Keep side-lane auto-research multi-round work runnable."
+                            "Keep the research peer's multi-round work runnable."
                         ),
                         "replan_trigger_summary": (
-                            "Side-lane vision would otherwise fall out of the "
+                            "The research peer's vision would otherwise fall out of the "
                             "global run window."
                         ),
                     },
                 }
                 record["vision_checkpoint"] = {
                     "schema_version": "vision_checkpoint_v0",
-                    "agent_id": SIDE_AGENT,
+                    "agent_id": TARGET_PEER,
                     "required": True,
                     "satisfied": True,
                     "decision": "patched",
                 }
-            if action == "older side":
+            if action == "older target peer":
                 record["autonomous_replan_ack"] = {
                     "schema_version": "autonomous_replan_ack_v0",
                     "recorded": True,
@@ -141,17 +143,17 @@ def main() -> None:
                         "generated_at": "2026-07-06T00:07:00+00:00",
                         "goal_id": GOAL_ID,
                         "classification": "state_refreshed",
-                        "agent_id": SIDE_AGENT,
-                        "recommended_action": "keep side vision unchanged",
-                        "json_path": str(runs_dir / "unchanged-side-vision.json"),
-                        "markdown_path": str(runs_dir / "unchanged-side-vision.md"),
+                        "agent_id": TARGET_PEER,
+                        "recommended_action": "keep peer vision unchanged",
+                        "json_path": str(runs_dir / "unchanged-peer-vision.json"),
+                        "markdown_path": str(runs_dir / "unchanged-peer-vision.md"),
                         "vision_checkpoint": {
                             "schema_version": "vision_checkpoint_v0",
-                            "agent_id": SIDE_AGENT,
+                            "agent_id": TARGET_PEER,
                             "required": True,
                             "satisfied": True,
                             "decision": "unchanged_with_reason",
-                            "unchanged_reason": "The active side vision still applies.",
+                            "unchanged_reason": "The active peer vision still applies.",
                         },
                     },
                     ensure_ascii=False,
@@ -167,36 +169,36 @@ def main() -> None:
         goal = history["goals"][0]
         latest_runs = goal["latest_runs"]
         assert [run["recommended_action"] for run in latest_runs[:3]] == [
-            "keep side vision unchanged",
-            "latest main",
+            "keep peer vision unchanged",
+            "latest coordination",
             "latest product",
         ], latest_runs
         assert any(
-            run.get("agent_id") == SIDE_AGENT and run.get("agent_vision")
+            run.get("agent_id") == TARGET_PEER and run.get("agent_vision")
             for run in latest_runs
         ), latest_runs
         assert any(
-            run.get("agent_id") == SIDE_AGENT and run.get("autonomous_replan_ack")
+            run.get("agent_id") == TARGET_PEER and run.get("autonomous_replan_ack")
             for run in latest_runs
         ), latest_runs
         assert len(latest_runs) == 5, latest_runs
         projected_run_history = project_run_history(history)
         projected_runs = projected_run_history["goals"][0]["latest_runs"]
         assert any(
-            run.get("agent_id") == SIDE_AGENT and run.get("agent_vision")
+            run.get("agent_id") == TARGET_PEER and run.get("agent_vision")
             for run in projected_runs
         ), projected_runs
         assert any(
-            run.get("agent_id") == SIDE_AGENT and run.get("autonomous_replan_ack")
+            run.get("agent_id") == TARGET_PEER and run.get("autonomous_replan_ack")
             for run in projected_runs
         ), projected_runs
         assert len(projected_runs) == 5, projected_runs
         vision = latest_agent_vision_from_status_payload(
             {"run_history": projected_run_history},
             goal_id=GOAL_ID,
-            agent_id=SIDE_AGENT,
+            agent_id=TARGET_PEER,
         )
-        assert vision and vision["agent_id"] == SIDE_AGENT, vision
+        assert vision and vision["agent_id"] == TARGET_PEER, vision
         assert "global run window" in vision["vision_patch"]["replan_trigger_summary"], vision
 
         zero_budget_history = collect_history(
@@ -220,13 +222,13 @@ def main() -> None:
                         "generated_at": "2026-07-06T00:07:00+00:00",
                         "goal_id": GOAL_ID,
                         "classification": "state_refreshed",
-                        "agent_id": SIDE_AGENT,
-                        "recommended_action": "retire side vision",
-                        "json_path": str(runs_dir / "retired-side-vision.json"),
-                        "markdown_path": str(runs_dir / "retired-side-vision.md"),
+                        "agent_id": TARGET_PEER,
+                        "recommended_action": "retire peer vision",
+                        "json_path": str(runs_dir / "retired-peer-vision.json"),
+                        "markdown_path": str(runs_dir / "retired-peer-vision.md"),
                         "vision_checkpoint": {
                             "schema_version": "vision_checkpoint_v0",
-                            "agent_id": SIDE_AGENT,
+                            "agent_id": TARGET_PEER,
                             "required": True,
                             "satisfied": True,
                             "decision": "retired_or_superseded",
@@ -244,24 +246,24 @@ def main() -> None:
         )
         latest_runs = history["goals"][0]["latest_runs"]
         assert [run["recommended_action"] for run in latest_runs[:3]] == [
-            "retire side vision",
-            "latest main",
+            "retire peer vision",
+            "latest coordination",
             "latest product",
         ], latest_runs
         assert not any(
-            run.get("agent_id") == SIDE_AGENT and run.get("agent_vision")
+            run.get("agent_id") == TARGET_PEER and run.get("agent_vision")
             for run in latest_runs
         ), latest_runs
         projected_run_history = project_run_history(history)
         projected_runs = projected_run_history["goals"][0]["latest_runs"]
         assert not any(
-            run.get("agent_id") == SIDE_AGENT and run.get("agent_vision")
+            run.get("agent_id") == TARGET_PEER and run.get("agent_vision")
             for run in projected_runs
         ), projected_runs
         vision = latest_agent_vision_from_status_payload(
             {"run_history": projected_run_history},
             goal_id=GOAL_ID,
-            agent_id=SIDE_AGENT,
+            agent_id=TARGET_PEER,
         )
         assert vision is None, vision
     print("run-history-agent-context-retention-smoke ok")

--- a/loopx/control_plane/runtime/run_context_retention.py
+++ b/loopx/control_plane/runtime/run_context_retention.py
@@ -18,6 +18,8 @@ def latest_runs_with_agent_context(
     """Keep recent runs plus each agent's newest durable context per field."""
 
     bounded = max(0, limit)
+    if bounded == 0:
+        return []
     selected = list(runs[:bounded])
     selected_ids = {id(run) for run in selected}
     retained_context_fields: set[tuple[str, str]] = set()

--- a/loopx/control_plane/runtime/run_context_retention.py
+++ b/loopx/control_plane/runtime/run_context_retention.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+PER_AGENT_CONTEXT_RUN_FIELDS = (
+    "agent_vision",
+    "vision_checkpoint",
+    "autonomous_replan_ack",
+)
+
+
+def latest_runs_with_agent_context(
+    runs: list[dict[str, Any]],
+    *,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Keep recent runs plus each agent's newest durable context per field."""
+
+    bounded = max(0, limit)
+    selected = list(runs[:bounded])
+    selected_ids = {id(run) for run in selected}
+    retained_context_fields: set[tuple[str, str]] = set()
+    retired_agent_visions: set[str] = set()
+
+    for run in runs:
+        agent_id = str(run.get("agent_id") or "").strip()
+        if not agent_id:
+            continue
+        fields_to_retain: list[str] = []
+        checkpoint = (
+            run.get("vision_checkpoint")
+            if isinstance(run.get("vision_checkpoint"), dict)
+            else {}
+        )
+        if (
+            checkpoint.get("satisfied") is True
+            and str(checkpoint.get("decision") or "").strip()
+            == "retired_or_superseded"
+        ):
+            retired_agent_visions.add(agent_id)
+            retained_context_fields.add((agent_id, "agent_vision"))
+
+        for field in PER_AGENT_CONTEXT_RUN_FIELDS:
+            context_key = (agent_id, field)
+            if context_key in retained_context_fields:
+                continue
+            if not isinstance(run.get(field), dict):
+                continue
+            if field == "agent_vision" and agent_id in retired_agent_visions:
+                continue
+            retained_context_fields.add(context_key)
+            fields_to_retain.append(field)
+
+        if fields_to_retain and id(run) not in selected_ids:
+            selected.append(run)
+            selected_ids.add(id(run))
+    return selected

--- a/loopx/control_plane/runtime/run_history.py
+++ b/loopx/control_plane/runtime/run_history.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Callable, Optional
 
 from ...boundary_authority import checkpointed_boundary_authority_summary
+from .run_context_retention import latest_runs_with_agent_context
 
 
 LatestRun = Callable[[dict[str, Any]], Optional[dict[str, Any]]]
@@ -74,7 +75,10 @@ def build_run_history(
             if isinstance(run, dict)
         ]
         if display_limit is not None:
-            latest_runs = latest_runs[:display_limit]
+            latest_runs = latest_runs_with_agent_context(
+                latest_runs,
+                limit=display_limit,
+            )
         goals.append(
             {
                 "id": goal.get("id"),

--- a/loopx/history.py
+++ b/loopx/history.py
@@ -6,7 +6,9 @@ from typing import Any, Callable
 
 from .authority import goal_authority_registry_summary
 from .control_plane import compact_control_plane_policy
-from .control_plane.runtime.time import now_local_iso
+from .control_plane.runtime.run_context_retention import (
+    latest_runs_with_agent_context,
+)
 from .control_plane.runtime.run_index_duplicates import (
     classify_index_duplicate_records,
     duplicate_repair_decision,
@@ -23,6 +25,7 @@ from .control_plane.runtime.run_artifacts import (
     reserve_run_artifact_paths,
     run_file_stem,
 )
+from .control_plane.runtime.time import now_local_iso
 from .control_plane.work_items.delivery_batch_scale import require_delivery_batch_scale
 from .control_plane.work_items.delivery_outcome import require_delivery_outcome
 from .doctor import PROMOTION_READINESS_CLASSIFICATIONS
@@ -56,11 +59,6 @@ REGISTRY_ATTENTION_FIELDS = (
     "operator_question",
     "recommended_action",
     "next_handoff_condition",
-)
-PER_AGENT_CONTEXT_RUN_FIELDS = (
-    "agent_vision",
-    "vision_checkpoint",
-    "autonomous_replan_ack",
 )
 
 
@@ -696,54 +694,6 @@ def latest_status_run(runs: list[dict[str, Any]]) -> dict[str, Any] | None:
             continue
         return run
     return None
-
-
-def latest_runs_with_agent_context(
-    runs: list[dict[str, Any]],
-    *,
-    limit: int,
-) -> list[dict[str, Any]]:
-    """Keep recent runs plus each agent's newest durable context per field."""
-
-    bounded = max(0, limit)
-    selected = list(runs[:bounded])
-    selected_ids = {id(run) for run in selected}
-    retained_context_fields: set[tuple[str, str]] = set()
-    retired_agent_visions: set[str] = set()
-
-    for run in runs:
-        agent_id = str(run.get("agent_id") or "").strip()
-        if not agent_id:
-            continue
-        fields_to_retain: list[str] = []
-        checkpoint = (
-            run.get("vision_checkpoint")
-            if isinstance(run.get("vision_checkpoint"), dict)
-            else {}
-        )
-        if (
-            checkpoint.get("satisfied") is True
-            and str(checkpoint.get("decision") or "").strip()
-            == "retired_or_superseded"
-        ):
-            retired_agent_visions.add(agent_id)
-            retained_context_fields.add((agent_id, "agent_vision"))
-
-        for field in PER_AGENT_CONTEXT_RUN_FIELDS:
-            context_key = (agent_id, field)
-            if context_key in retained_context_fields:
-                continue
-            if not isinstance(run.get(field), dict):
-                continue
-            if field == "agent_vision" and agent_id in retired_agent_visions:
-                continue
-            retained_context_fields.add(context_key)
-            fields_to_retain.append(field)
-
-        if fields_to_retain and id(run) not in selected_ids:
-            selected.append(run)
-            selected_ids.add(id(run))
-    return selected
 
 
 def collect_history(


### PR DESCRIPTION
## Summary

- move per-agent durable run-context retention into a shared runtime read model
- preserve each agent's latest vision, checkpoint, and replan ACK when status applies its display limit
- extend the existing retention smoke through the collect-history -> run-history -> vision lookup path, including retirement semantics

## Validation

- real loopx-meta readback: the installed build reports required_agent_vision_missing, while this branch recovers the persisted 13:58 agent vision from the same registry/runtime
- run-history-agent-context-retention-smoke.py
- run-history-readmodel-smoke.py
- status-neutral-run-window-smoke.py
- standard premerge gate: 16/16 selected checks passed, 0 warnings, 0 manual holds
- changed-file py_compile and diff checks passed
- public/private boundary scan clean for all 4 changed files

## Scope and risk

This changes only status/run-history projection behavior. It does not change todo lifecycle, quota accounting, scheduler behavior, permissions, or benchmark semantics. Display limits remain bounded for ordinary runs; only each agent's newest durable context may survive beyond the recent-run window.

No local state, raw runs, trajectories, private links, credentials, or generated logs are included.
