### PR TITLE
Qualify SkillsBench Turn runner readiness

### DIFF
--- a/loopx/benchmark_adapters/skillsbench_turn_route.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_route.py
@@ -15,6 +15,13 @@ LOOPX_TURN_PUBLIC_BOUNDARY_FIELDS = (
     "credentials_recorded",
     "local_paths_recorded",
 )
+LOOPX_TURN_RUNNER_READINESS_CHECKS = (
+    "turn_transaction_committed",
+    "pre_agent_postcondition_checked",
+    "pre_agent_postcondition_unsatisfied",
+    "post_agent_postcondition_satisfied",
+    "official_feedback_blinded",
+)
 
 
 def skillsbench_loopx_turn_route_contract() -> dict[str, Any]:
@@ -73,8 +80,11 @@ def add_skillsbench_loopx_turn_arguments(parser: Any) -> None:
         default=None,
         help=(
             "Private scored-workspace postcondition command for the experimental "
-            "LoopX Turn Agent CLI route. The command is executed only through "
-            "the sandbox bridge and is never written to public compact traces."
+            "LoopX Turn Agent CLI route. It must be safe to run before and after "
+            "each agent Turn; the pre-agent result qualifies the validation "
+            "baseline without blocking later Turns whose overall postcondition "
+            "is already satisfied. The command is executed only through the "
+            "sandbox bridge and is never written to public compact traces."
         ),
     )
 
@@ -208,11 +218,19 @@ def _public_validation(value: Any) -> dict[str, Any]:
         return {}
     validation = {
         key: label
-        for key in ("schema_version", "status", "validator_kind")
+        for key in (
+            "schema_version",
+            "status",
+            "validator_kind",
+            "pre_agent_postcondition_status",
+            "post_agent_postcondition_status",
+            "baseline_contract",
+        )
         if (label := _public_label(value.get(key), limit=120))
     }
     for key in (
         "independent",
+        "pre_agent_postcondition_checked",
         "oracle_feedback_used",
         "raw_validator_output_recorded",
         "raw_task_text_recorded",
@@ -224,6 +242,82 @@ def _public_validation(value: Any) -> dict[str, Any]:
     if isinstance(operation_count, int) and not isinstance(operation_count, bool):
         validation["meaningful_operation_count"] = max(0, operation_count)
     return validation
+
+
+def _public_runner_readiness(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    receipt = {
+        key: label
+        for key in ("schema_version", "capability", "status", "evidence_kind")
+        if (label := _public_label(value.get(key), limit=120))
+    }
+    if isinstance(value.get("ready"), bool):
+        receipt["ready"] = value["ready"]
+    checks = value.get("checks")
+    if isinstance(checks, dict):
+        receipt["checks"] = {
+            key: checks[key]
+            for key in LOOPX_TURN_RUNNER_READINESS_CHECKS
+            if isinstance(checks.get(key), bool)
+        }
+    blockers = [
+        blocker
+        for blocker in _public_label_list(value.get("blocker_codes"), limit=80)
+        if blocker in LOOPX_TURN_RUNNER_READINESS_CHECKS
+    ]
+    if blockers:
+        receipt["blocker_codes"] = blockers
+    for key in (
+        "raw_task_text_recorded",
+        "raw_validator_output_recorded",
+        "raw_verifier_output_recorded",
+        "raw_trajectory_recorded",
+        "credential_values_recorded",
+        "local_paths_recorded",
+    ):
+        if isinstance(value.get(key), bool):
+            receipt[key] = value[key]
+    return receipt
+
+
+def _aggregate_runner_readiness(receipts: list[dict[str, Any]]) -> dict[str, Any]:
+    ready_count = sum(item.get("ready") is True for item in receipts)
+    blockers = sorted(
+        {
+            blocker
+            for item in receipts
+            for blocker in item.get("blocker_codes", [])
+            if isinstance(blocker, str) and blocker
+        }
+    )
+    return {
+        "schema_version": "skillsbench_benchmark_runner_readiness_v0",
+        "capability": "benchmark_runner",
+        "status": "ready" if ready_count else "blocked",
+        "ready": ready_count > 0,
+        "proven_turn_count": ready_count,
+        "observed_turn_count": len(receipts),
+        "blocker_codes": [] if ready_count else blockers,
+        "raw_task_text_recorded": any(
+            item.get("raw_task_text_recorded") is True for item in receipts
+        ),
+        "raw_validator_output_recorded": any(
+            item.get("raw_validator_output_recorded") is True for item in receipts
+        ),
+        "raw_verifier_output_recorded": any(
+            item.get("raw_verifier_output_recorded") is True for item in receipts
+        ),
+        "raw_trajectory_recorded": any(
+            item.get("raw_trajectory_recorded") is True for item in receipts
+        ),
+        "credential_values_recorded": any(
+            item.get("credential_values_recorded") is True for item in receipts
+        ),
+        "local_paths_recorded": any(
+            item.get("local_paths_recorded") is True for item in receipts
+        ),
+    }
 
 
 def _aggregate_validations(validations: list[dict[str, Any]]) -> dict[str, Any]:
@@ -263,6 +357,7 @@ def _aggregate_validations(validations: list[dict[str, Any]]) -> dict[str, Any]:
 class SkillsBenchTurnTraceSummary:
     executions: list[dict[str, Any]] = field(default_factory=list)
     validations: list[dict[str, Any]] = field(default_factory=list)
+    readiness_receipts: list[dict[str, Any]] = field(default_factory=list)
     boundary: dict[str, bool] = field(
         default_factory=lambda: dict.fromkeys(LOOPX_TURN_PUBLIC_BOUNDARY_FIELDS, False)
     )
@@ -272,6 +367,10 @@ class SkillsBenchTurnTraceSummary:
             self.executions.append(execution)
         if validation := _public_validation(payload.get("scored_workspace_validation")):
             self.validations.append(validation)
+        if readiness := _public_runner_readiness(
+            payload.get("benchmark_runner_readiness")
+        ):
+            self.readiness_receipts.append(readiness)
         source_fields = {
             "raw_task_text_recorded": ("raw_task_text_recorded",),
             "raw_verifier_output_recorded": ("raw_verifier_output_recorded",),
@@ -288,6 +387,10 @@ class SkillsBenchTurnTraceSummary:
             return
         trace["loopx_turn_executions"] = list(self.executions)
         trace["scored_workspace_validation"] = _aggregate_validations(self.validations)
+        if self.readiness_receipts:
+            trace["benchmark_runner_readiness"] = _aggregate_runner_readiness(
+                self.readiness_receipts
+            )
         trace["loopx_turn_public_boundary"] = dict(self.boundary)
         trace["official_feedback_blinded"] = True
         trace["reward_feedback_forwarded"] = False
@@ -308,6 +411,9 @@ def sync_skillsbench_loopx_turn_trace_into_compact(
     validation = trace.get("scored_workspace_validation")
     if isinstance(validation, dict):
         compact["scored_workspace_validation"] = dict(validation)
+    readiness = trace.get("benchmark_runner_readiness")
+    if isinstance(readiness, dict):
+        compact["benchmark_runner_readiness"] = dict(readiness)
     trace_boundary = trace.get("loopx_turn_public_boundary")
     trace_boundary = trace_boundary if isinstance(trace_boundary, dict) else {}
     boundary = compact.get("public_boundary")

--- a/loopx/benchmark_adapters/skillsbench_turn_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_runtime.py
@@ -79,9 +79,7 @@ def _loopx_cli_failure_category(stdout: Any, stderr: Any) -> str:
     except json.JSONDecodeError:
         payload = {}
     error = " ".join(
-        f"{payload.get('error') if isinstance(payload, dict) else ''} {stderr or ''}"
-        .lower()
-        .split()
+        f"{payload.get('error') if isinstance(payload, dict) else ''} {stderr or ''}".lower().split()
     )
     classifiers = (
         (r"/app/\.local/bin/loopx.*not found", "case_loopx_cli_missing"),
@@ -106,7 +104,13 @@ class SkillsBenchTurnBridge:
         self._config = config
         self.meaningful_operation_count = 0
 
-    def exec(self, command: str, *, meaningful: bool = False) -> dict[str, Any]:
+    def exec(
+        self,
+        command: str,
+        *,
+        meaningful: bool = False,
+        allow_nonzero: bool = False,
+    ) -> dict[str, Any]:
         request = {
             "operation": "exec",
             "cwd": "/app",
@@ -142,8 +146,19 @@ class SkillsBenchTurnBridge:
             raise SkillsBenchTurnBridgeError("bridge response was not an object")
         if payload.get("schema_version") != SKILLSBENCH_BRIDGE_OPERATION_SCHEMA_VERSION:
             raise SkillsBenchTurnBridgeError("bridge operation schema was unsupported")
-        if payload.get("ok") is not True or payload.get("exit_code") != 0:
-            exit_code = payload.get("exit_code")
+        exit_code = payload.get("exit_code")
+        if payload.get("ok") is not True or exit_code != 0:
+            if (
+                allow_nonzero
+                and isinstance(exit_code, int)
+                and not isinstance(exit_code, bool)
+                and exit_code != 0
+            ):
+                return {
+                    "ok": False,
+                    "exit_code": exit_code,
+                    "elapsed_ms": int((time.monotonic() - started) * 1000),
+                }
             raise SkillsBenchTurnBridgeError(
                 "scored-workspace command failed",
                 category=_loopx_cli_failure_category(
@@ -161,6 +176,7 @@ class SkillsBenchTurnBridge:
             self.meaningful_operation_count += 1
         return {
             "ok": True,
+            "exit_code": 0,
             "stdout": str(payload.get("stdout") or ""),
             "elapsed_ms": int((time.monotonic() - started) * 1000),
         }
@@ -245,6 +261,31 @@ def _callback_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+def _validation_baseline(
+    bridge: SkillsBenchTurnBridge,
+    config: SkillsBenchTurnRuntimeConfig,
+) -> dict[str, Any]:
+    """Observe whether the task postcondition is satisfied before agent work."""
+
+    try:
+        result = bridge.exec(config.validation_command, allow_nonzero=True)
+    except SkillsBenchTurnBridgeError as exc:
+        raise SkillsBenchTurnBridgeError(
+            str(exc),
+            stage="validation_baseline",
+            category=exc.category,
+            exit_code=exc.exit_code,
+        ) from exc
+    return {
+        "schema_version": "skillsbench_validation_baseline_v0",
+        "status": "already_satisfied" if result.get("ok") is True else "unsatisfied",
+        "postcondition_kind": "task_declared_independent_command",
+        "exit_code": result.get("exit_code"),
+        "raw_command_recorded": False,
+        "raw_output_recorded": False,
+    }
+
+
 def run_skillsbench_loopx_turn(
     *,
     prompt: str,
@@ -261,6 +302,7 @@ def run_skillsbench_loopx_turn(
         )
     bridge = SkillsBenchTurnBridge(config)
     plan = _turn_plan(bridge, config)
+    validation_baseline = _validation_baseline(bridge, config)
     prefix = _case_cli_prefix(config)
 
     def host_runner(request: Mapping[str, Any]) -> dict[str, Any]:
@@ -356,6 +398,15 @@ def run_skillsbench_loopx_turn(
         ),
         "independent": True,
         "validator_kind": "skillsbench_scored_workspace_command",
+        "pre_agent_postcondition_checked": True,
+        "pre_agent_postcondition_status": validation_baseline["status"],
+        "post_agent_postcondition_status": (
+            "satisfied"
+            if isinstance(execution.get("validation"), dict)
+            and execution["validation"].get("status") == "passed"
+            else "unsatisfied"
+        ),
+        "baseline_contract": "task_declared_independent_postcondition",
         "oracle_feedback_used": False,
         "meaningful_operation_count": bridge.meaningful_operation_count,
         "raw_validator_output_recorded": False,
@@ -363,6 +414,48 @@ def run_skillsbench_loopx_turn(
         "raw_verifier_output_recorded": False,
     }
     return execution, scored_validation
+
+
+def build_skillsbench_benchmark_runner_readiness(
+    *,
+    execution: Mapping[str, Any],
+    scored_workspace_validation: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Reduce a Turn outcome to a compact, public-safe runner capability receipt."""
+
+    checks = {
+        "turn_transaction_committed": execution.get("status") == "committed",
+        "pre_agent_postcondition_checked": (
+            scored_workspace_validation.get("pre_agent_postcondition_checked") is True
+        ),
+        "pre_agent_postcondition_unsatisfied": (
+            scored_workspace_validation.get("pre_agent_postcondition_status")
+            == "unsatisfied"
+        ),
+        "post_agent_postcondition_satisfied": (
+            scored_workspace_validation.get("post_agent_postcondition_status")
+            == "satisfied"
+        ),
+        "official_feedback_blinded": (
+            scored_workspace_validation.get("oracle_feedback_used") is False
+        ),
+    }
+    blockers = [name for name, passed in checks.items() if not passed]
+    return {
+        "schema_version": "skillsbench_benchmark_runner_readiness_v0",
+        "capability": "benchmark_runner",
+        "status": "ready" if not blockers else "blocked",
+        "ready": not blockers,
+        "checks": checks,
+        "blocker_codes": blockers,
+        "evidence_kind": "committed_turn_with_independent_postcondition_baseline",
+        "raw_task_text_recorded": False,
+        "raw_validator_output_recorded": False,
+        "raw_verifier_output_recorded": False,
+        "raw_trajectory_recorded": False,
+        "credential_values_recorded": False,
+        "local_paths_recorded": False,
+    }
 
 
 def build_skillsbench_loopx_turn_trace(
@@ -384,6 +477,10 @@ def build_skillsbench_loopx_turn_trace(
         "task_id": task_id,
         "loopx_turn_execution": dict(execution),
         "scored_workspace_validation": dict(scored_workspace_validation),
+        "benchmark_runner_readiness": build_skillsbench_benchmark_runner_readiness(
+            execution=execution,
+            scored_workspace_validation=scored_workspace_validation,
+        ),
         "official_feedback_blinded": True,
         "reward_feedback_forwarded": False,
         "boundary": {
@@ -444,6 +541,12 @@ def build_skillsbench_loopx_turn_failure_trace(
         "status": "not_attempted",
         "independent": True,
         "validator_kind": "skillsbench_scored_workspace_command",
+        "pre_agent_postcondition_checked": error.stage == "validation_baseline",
+        "pre_agent_postcondition_status": (
+            "check_failed" if error.stage == "validation_baseline" else "not_attempted"
+        ),
+        "post_agent_postcondition_status": "not_attempted",
+        "baseline_contract": "task_declared_independent_postcondition",
         "oracle_feedback_used": False,
         "meaningful_operation_count": 0,
         "raw_validator_output_recorded": False,

--- a/tests/test_skillsbench_turn_runtime.py
+++ b/tests/test_skillsbench_turn_runtime.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from loopx.benchmark_adapters import skillsbench_turn_runtime as runtime
+from loopx.benchmark_adapters.skillsbench_turn_route import (
+    SkillsBenchTurnTraceSummary,
+    sync_skillsbench_loopx_turn_trace_into_compact,
+)
+
+
+def _config(tmp_path: Path) -> runtime.SkillsBenchTurnRuntimeConfig:
+    return runtime.SkillsBenchTurnRuntimeConfig(
+        bridge_command="synthetic-bridge",
+        validation_command="synthetic-postcondition",
+        goal_id="synthetic-goal",
+        agent_id="synthetic-agent",
+        runtime_root=tmp_path,
+    )
+
+
+def test_nonzero_validation_probe_does_not_return_private_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    payload = {
+        "schema_version": runtime.SKILLSBENCH_BRIDGE_OPERATION_SCHEMA_VERSION,
+        "ok": False,
+        "exit_code": 17,
+        "stdout": "private validation output",
+        "stderr": "private validation error",
+    }
+    monkeypatch.setattr(
+        runtime.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(payload),
+            stderr="",
+        ),
+    )
+
+    result = runtime.SkillsBenchTurnBridge(_config(tmp_path)).exec(
+        "synthetic-postcondition",
+        allow_nonzero=True,
+    )
+
+    assert result["ok"] is False
+    assert result["exit_code"] == 17
+    assert set(result) == {"ok", "exit_code", "elapsed_ms"}
+    assert "private" not in json.dumps(result)
+
+
+def test_satisfied_pre_agent_postcondition_runs_but_does_not_claim_readiness(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    agent_calls: list[str] = []
+
+    class BaselineSatisfiedBridge:
+        def __init__(self, _config: Any) -> None:
+            self.meaningful_operation_count = 0
+
+        def exec(
+            self,
+            _command: str,
+            *,
+            meaningful: bool = False,
+            allow_nonzero: bool = False,
+        ) -> dict[str, Any]:
+            if allow_nonzero:
+                return {"ok": True, "exit_code": 0, "elapsed_ms": 1}
+            assert meaningful is True
+            self.meaningful_operation_count += 1
+            return {"ok": True, "exit_code": 0, "stdout": "", "elapsed_ms": 1}
+
+    def fake_turn_once(
+        plan: dict[str, Any],
+        *,
+        host_runner: Any,
+        task_validator: Any,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        result = host_runner({"turn_key": "synthetic-turn"})
+        return {
+            "status": "committed",
+            "validation": dict(task_validator(plan, result)),
+        }
+
+    monkeypatch.setattr(runtime, "SkillsBenchTurnBridge", BaselineSatisfiedBridge)
+    monkeypatch.setattr(runtime, "_turn_plan", lambda *_args: {"ok": True})
+    monkeypatch.setattr(runtime, "run_loopx_turn_once", fake_turn_once)
+
+    execution, validation = runtime.run_skillsbench_loopx_turn(
+        prompt="synthetic prompt",
+        agent_runner=lambda prompt: agent_calls.append(prompt) or "done",
+        config=_config(tmp_path),
+    )
+    receipt = runtime.build_skillsbench_benchmark_runner_readiness(
+        execution=execution,
+        scored_workspace_validation=validation,
+    )
+
+    assert agent_calls == ["synthetic prompt"]
+    assert validation["pre_agent_postcondition_status"] == "already_satisfied"
+    assert receipt["ready"] is False
+    assert "pre_agent_postcondition_unsatisfied" in receipt["blocker_codes"]
+
+
+def test_unsatisfied_baseline_then_satisfied_postcondition_is_runner_ready(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    agent_calls: list[str] = []
+
+    class TransitionBridge:
+        def __init__(self, _config: Any) -> None:
+            self.meaningful_operation_count = 0
+
+        def exec(
+            self,
+            _command: str,
+            *,
+            meaningful: bool = False,
+            allow_nonzero: bool = False,
+        ) -> dict[str, Any]:
+            if allow_nonzero:
+                return {"ok": False, "exit_code": 3, "elapsed_ms": 1}
+            assert meaningful is True
+            self.meaningful_operation_count += 1
+            return {"ok": True, "exit_code": 0, "stdout": "", "elapsed_ms": 1}
+
+    def fake_turn_once(
+        plan: dict[str, Any],
+        *,
+        host_runner: Any,
+        task_validator: Any,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        result = host_runner({"turn_key": "synthetic-turn"})
+        validation = dict(task_validator(plan, result))
+        return {
+            "status": "committed",
+            "validation": validation,
+            "receipt": {"status": "committed"},
+            "effects": {
+                "host_invoked": True,
+                "state_written": True,
+                "quota_spent": True,
+                "scheduler_acknowledged": True,
+            },
+        }
+
+    monkeypatch.setattr(runtime, "SkillsBenchTurnBridge", TransitionBridge)
+    monkeypatch.setattr(
+        runtime,
+        "_turn_plan",
+        lambda *_args: {"ok": True, "turn_key": "synthetic-turn"},
+    )
+    monkeypatch.setattr(runtime, "run_loopx_turn_once", fake_turn_once)
+
+    execution, validation = runtime.run_skillsbench_loopx_turn(
+        prompt="synthetic prompt",
+        agent_runner=lambda prompt: agent_calls.append(prompt) or "done",
+        config=_config(tmp_path),
+    )
+    trace = runtime.build_skillsbench_loopx_turn_trace(
+        route="loopx-turn-agent-cli",
+        benchmark_id="synthetic-benchmark",
+        task_id="synthetic-task",
+        execution=execution,
+        scored_workspace_validation=validation,
+    )
+
+    assert agent_calls == ["synthetic prompt"]
+    assert validation["pre_agent_postcondition_status"] == "unsatisfied"
+    assert validation["post_agent_postcondition_status"] == "satisfied"
+    assert validation["meaningful_operation_count"] == 1
+    assert trace["benchmark_runner_readiness"]["ready"] is True
+    assert trace["benchmark_runner_readiness"]["blocker_codes"] == []
+    assert trace["benchmark_runner_readiness"]["raw_task_text_recorded"] is False
+
+
+@pytest.mark.parametrize(
+    ("execution_status", "baseline_status", "post_status", "blocker"),
+    [
+        ("failed", "unsatisfied", "satisfied", "turn_transaction_committed"),
+        (
+            "committed",
+            "already_satisfied",
+            "satisfied",
+            "pre_agent_postcondition_unsatisfied",
+        ),
+        (
+            "committed",
+            "unsatisfied",
+            "unsatisfied",
+            "post_agent_postcondition_satisfied",
+        ),
+    ],
+)
+def test_runner_readiness_fails_closed_on_partial_evidence(
+    execution_status: str,
+    baseline_status: str,
+    post_status: str,
+    blocker: str,
+) -> None:
+    receipt = runtime.build_skillsbench_benchmark_runner_readiness(
+        execution={"status": execution_status},
+        scored_workspace_validation={
+            "pre_agent_postcondition_checked": True,
+            "pre_agent_postcondition_status": baseline_status,
+            "post_agent_postcondition_status": post_status,
+            "oracle_feedback_used": False,
+        },
+    )
+
+    assert receipt["status"] == "blocked"
+    assert receipt["ready"] is False
+    assert blocker in receipt["blocker_codes"]
+
+
+def test_runner_readiness_survives_public_trace_aggregation() -> None:
+    ready_trace = runtime.build_skillsbench_loopx_turn_trace(
+        route="loopx-turn-agent-cli",
+        benchmark_id="synthetic-benchmark",
+        task_id="synthetic-task",
+        execution={"status": "committed"},
+        scored_workspace_validation={
+            "status": "passed",
+            "validator_kind": "skillsbench_scored_workspace_command",
+            "independent": True,
+            "pre_agent_postcondition_checked": True,
+            "pre_agent_postcondition_status": "unsatisfied",
+            "post_agent_postcondition_status": "satisfied",
+            "baseline_contract": "task_declared_independent_postcondition",
+            "oracle_feedback_used": False,
+        },
+    )
+    already_satisfied_trace = runtime.build_skillsbench_loopx_turn_trace(
+        route="loopx-turn-agent-cli",
+        benchmark_id="synthetic-benchmark",
+        task_id="synthetic-task",
+        execution={"status": "committed"},
+        scored_workspace_validation={
+            "status": "passed",
+            "validator_kind": "skillsbench_scored_workspace_command",
+            "independent": True,
+            "pre_agent_postcondition_checked": True,
+            "pre_agent_postcondition_status": "already_satisfied",
+            "post_agent_postcondition_status": "satisfied",
+            "baseline_contract": "task_declared_independent_postcondition",
+            "oracle_feedback_used": False,
+        },
+    )
+    ready_trace["benchmark_runner_readiness"]["checks"][
+        "private_path_should_not_project"
+    ] = True
+    summary = SkillsBenchTurnTraceSummary()
+    for trace in (ready_trace, already_satisfied_trace):
+        summary.merge(trace, trace["boundary"])
+    assert (
+        "private_path_should_not_project" not in summary.readiness_receipts[0]["checks"]
+    )
+    controller_trace: dict[str, Any] = {}
+    summary.apply(controller_trace)
+    compact: dict[str, Any] = {}
+    sync_skillsbench_loopx_turn_trace_into_compact(compact, controller_trace)
+
+    receipt = compact["benchmark_runner_readiness"]
+    assert receipt["ready"] is True
+    assert receipt["proven_turn_count"] == 1
+    assert receipt["observed_turn_count"] == 2
+    assert receipt["blocker_codes"] == []
+    assert receipt["raw_task_text_recorded"] is False
+    assert (
+        compact["scored_workspace_validation"]["raw_validator_output_recorded"] is False
+    )


### PR DESCRIPTION
## Summary
- observe the task-declared independent postcondition before each SkillsBench Turn without blocking valid multi-Turn continuation
- emit and aggregate a public-safe `benchmark_runner` readiness receipt only when one Turn transitions from an unsatisfied baseline to a satisfied postcondition and commits without official feedback
- keep commands, validator output, task text, trajectories, credentials, and local paths outside public projections
- add focused synthetic transition, partial-evidence, redaction, and multi-Turn aggregation tests

## Validation
- `pytest -q tests/test_skillsbench*.py` (46 passed)
- `python examples/skillsbench-loopx-turn-agent-cli-smoke.py`
- Ruff check and format check on changed files
- `loopx canary premerge --from-git-diff --tier standard` (4 direct checks and 6 selected canaries passed; benchmark-sensitive manual review hold remains)

## Merge decision
Not self-merging: this changes a benchmark adapter/runtime evidence contract and requires explicit maintainer review. No benchmark job was launched and no private/raw evidence was read or recorded.