### PR TITLE
Document a minimal local LoopX Turn

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,27 @@ Requirements: Python 3.11+, `curl`, `tar`, macOS or Linux shell. Git is only
 needed for contributor clone/canary workflows. The Python package has no
 runtime dependencies outside the standard library.
 
+### Try One Governed Turn Locally
+
+From a repository checkout with Codex CLI logged in, run this disposable,
+non-benchmark example:
+
+```bash
+python3 examples/loopx-turn-codex-cli-e2e-smoke.py --real-codex-cli
+```
+
+It creates a temporary goal and workspace, asks Codex CLI to write one marker,
+checks the marker with an independent validator, commits exactly one Turn and
+one quota spend, then replays the same transaction to prove it has no duplicate
+effects. The temporary state is deleted and is never synced to your global
+LoopX registry. Success reports `status=committed`,
+`validation_status=passed`, and `quota_slot_spend_count=1`.
+
+Run `codex --version` first. If the configured default model requires a newer
+Codex CLI, update Codex or add `--codex-model <qualified-model>`. The
+[one-Turn Codex CLI guide](docs/product/loopx-turn-codex-cli-quickstart.md)
+shows the command for a connected project and explains the validator boundary.
+
 Start agent-first: paste one setup message for the surface you already use,
 then start real work through the LoopX command entry for that host.
 Agents and host integrations can make this deterministic with

--- a/README.md
+++ b/README.md
@@ -165,27 +165,6 @@ Requirements: Python 3.11+, `curl`, `tar`, macOS or Linux shell. Git is only
 needed for contributor clone/canary workflows. The Python package has no
 runtime dependencies outside the standard library.
 
-### Try One Governed Turn Locally
-
-From a repository checkout with Codex CLI logged in, run this disposable,
-non-benchmark example:
-
-```bash
-python3 examples/loopx-turn-codex-cli-e2e-smoke.py --real-codex-cli
-```
-
-It creates a temporary goal and workspace, asks Codex CLI to write one marker,
-checks the marker with an independent validator, commits exactly one Turn and
-one quota spend, then replays the same transaction to prove it has no duplicate
-effects. The temporary state is deleted and is never synced to your global
-LoopX registry. Success reports `status=committed`,
-`validation_status=passed`, and `quota_slot_spend_count=1`.
-
-Run `codex --version` first. If the configured default model requires a newer
-Codex CLI, update Codex or add `--codex-model <qualified-model>`. The
-[one-Turn Codex CLI guide](docs/product/loopx-turn-codex-cli-quickstart.md)
-shows the command for a connected project and explains the validator boundary.
-
 Start agent-first: paste one setup message for the surface you already use,
 then start real work through the LoopX command entry for that host.
 Agents and host integrations can make this deterministic with
@@ -495,6 +474,27 @@ lane-authored evidence still has to be written back through LoopX state before
 the run can claim progress. See
 [Auto-research command path](docs/guides/auto-research-command-path.md) for the
 full stop, attach, retry, and evidence boundary.
+
+### Experimental: Try One Governed Turn Locally
+
+From a repository checkout with Codex CLI logged in, run this disposable,
+non-benchmark example:
+
+```bash
+python3 examples/loopx-turn-codex-cli-e2e-smoke.py --real-codex-cli
+```
+
+It creates a temporary goal and workspace, asks Codex CLI to write one marker,
+checks the marker with an independent validator, commits exactly one Turn and
+one quota spend, then replays the same transaction to prove it has no duplicate
+effects. The temporary state is deleted and is never synced to your global
+LoopX registry. Success reports `status=committed`,
+`validation_status=passed`, and `quota_slot_spend_count=1`.
+
+Run `codex --version` first. If the configured default model requires a newer
+Codex CLI, update Codex or add `--codex-model <qualified-model>`. The
+[one-Turn Codex CLI guide](docs/product/loopx-turn-codex-cli-quickstart.md)
+shows the command for a connected project and explains the validator boundary.
 
 ### Explore Graph And Harness (Supported, Optional, Default-Off)
 

--- a/examples/loopx-turn-codex-cli-e2e-smoke.py
+++ b/examples/loopx-turn-codex-cli-e2e-smoke.py
@@ -24,7 +24,7 @@ from loopx.cli import main as cli_main  # noqa: E402
 GOAL_ID = "loopx-turn-real-cli-e2e"
 AGENT_ID = "codex-turn-e2e"
 TODO_ID = "todo_turnreale2e01"
-MARKER_NAME = "turn-e2e-marker.txt"
+MARKER_NAME = "docs/turn-e2e-marker.txt"
 MARKER_VALUE = "loopx-turn-real-e2e-ok"
 
 
@@ -34,6 +34,7 @@ def _write_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
     workspace = root / "workspace"
     runtime.mkdir(parents=True)
     workspace.mkdir(parents=True)
+    (workspace / "docs").mkdir()
     state = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
     state.parent.mkdir(parents=True)
     state.write_text(

--- a/examples/loopx-turn-codex-cli-quickstart-smoke.py
+++ b/examples/loopx-turn-codex-cli-quickstart-smoke.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 QUICKSTART = REPO_ROOT / "docs" / "product" / "loopx-turn-codex-cli-quickstart.md"
+README = REPO_ROOT / "README.md"
 
 
 def main() -> int:
@@ -17,6 +18,7 @@ def main() -> int:
         encoding="utf-8"
     )
     docs_index = (REPO_ROOT / "docs" / "README.md").read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
 
     assert len(text.splitlines()) <= 110, "quickstart must remain one page"
     for required in [
@@ -53,6 +55,14 @@ def main() -> int:
     link = "loopx-turn-codex-cli-quickstart.md"
     assert link in product_index, "product index link"
     assert f"product/{link}" in docs_index, "docs index link"
+    for required in [
+        "Try One Governed Turn Locally",
+        "loopx-turn-codex-cli-e2e-smoke.py --real-codex-cli",
+        "status=committed",
+        "validation_status=passed",
+        "quota_slot_spend_count=1",
+    ]:
+        assert required in readme, f"README local Turn quickstart: {required}"
 
     print("loopx-turn-codex-cli-quickstart-smoke ok")
     return 0


### PR DESCRIPTION
## Summary

- add a copy-paste, non-benchmark local Turn demo to the README
- keep the disposable marker inside the example goal's declared `docs/**` write boundary
- extend the existing quickstart smoke to protect the README entry and receipt contract

## Validation

- deterministic Turn E2E: committed, validator passed, exactly one quota spend, replay produced no effects
- real Codex CLI Turn E2E: committed with the same receipt invariants
- `tests/test_loopx_turn_codex_cli.py`: 7 passed
- README quickstart smoke: passed
- `git diff --check` and Python compile: passed
- `loopx check` public-boundary scan: passed
- `loopx canary premerge --from-git-diff --tier standard`: passed

## Scope

No production Turn schema, runtime, model, benchmark scoring, permission boundary, or public evidence policy changes. The example continues to use temporary local state, records no raw host output, and does not sync the global registry.