### PR TITLE
Fix scheduler ACK host binding

### DIFF
--- a/examples/control_plane/quota-scheduler-state-ack-smoke.py
+++ b/examples/control_plane/quota-scheduler-state-ack-smoke.py
@@ -422,6 +422,7 @@ def assert_scheduler_ack_plan_validation() -> None:
         "applied_rrule": codex_app["recommended_rrule"],
         "reset_token": backoff["reset_token"],
         "identity_signature": backoff["identity_signature"],
+        "host_match_observed": True,
     }, ack_hint
     assert ack_cli_args == [
         "quota",
@@ -433,6 +434,11 @@ def assert_scheduler_ack_plan_validation() -> None:
         "-A",
         "--applied-rrule",
         ack_args["applied_rrule"],
+        "--host-match-observed",
+        "--reset-token",
+        ack_args["reset_token"],
+        "--identity-signature",
+        ack_args["identity_signature"],
         "--execute",
     ], ack_hint
     with_capabilities = active_payload()
@@ -805,8 +811,10 @@ def assert_cli_scheduler_ack_progression() -> None:
             str(runtime.resolve()),
         ], first
         assert first_ack_cli_args[4:6] == ["quota", "scheduler-ack-current"], first
-        assert "--reset-token" not in first_ack_cli_args, first
-        assert "--identity-signature" not in first_ack_cli_args, first
+        assert first_ack_args["host_match_observed"] is True, first
+        assert "--host-match-observed" in first_ack_cli_args, first
+        assert first_ack_args["reset_token"] in first_ack_cli_args, first
+        assert first_ack_args["identity_signature"] in first_ack_cli_args, first
 
         current_hint_preview = run_cli(
             root,
@@ -924,8 +932,10 @@ def assert_cli_scheduler_ack_progression() -> None:
             assert current_ack_args["applied_rrule"] == current_rrule, current
             assert current_ack_args["reset_token"], current
             assert current_ack_args["identity_signature"], current
-            assert "--reset-token" not in current_ack_cli_args, current
-            assert "--identity-signature" not in current_ack_cli_args, current
+            assert current_ack_args["host_match_observed"] is True, current
+            assert "--host-match-observed" in current_ack_cli_args, current
+            assert current_ack_args["reset_token"] in current_ack_cli_args, current
+            assert current_ack_args["identity_signature"] in current_ack_cli_args, current
             ack = run_cli(
                 root,
                 *current_ack_cli_args,

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -222,8 +222,9 @@ def register_quota_command(subparsers: argparse._SubParsersAction) -> None:
         "--host-match-observed",
         action="store_true",
         help=(
-            "A bound scheduler hint observed the applied RRULE on the host, so "
-            "persist its exact reset-token/identity binding without a host write."
+            "A bound scheduler hint has authoritative host proof from a successful "
+            "update or matching readback, so persist its exact reset-token/identity "
+            "binding."
         ),
     )
     quota_parser.add_argument(

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -830,6 +830,10 @@ def build_scheduler_hint(
             effective_host_rrule=effective_host_rrule,
             current_rrule=current_rrule,
             current_rrule_already_applied=current_rrule_already_applied,
+            scheduler_state_acknowledges_current_rrule=(
+                state_status == "same_identity"
+                and normalize_scheduler_rrule(last_applied_rrule) == current_rrule
+            ),
             all_host_update_failures=all_host_update_failures,
             recorded_host_failure=recorded_host_failure,
         )
@@ -955,7 +959,11 @@ def build_scheduler_hint(
                         if apply_needed
                         else "matching_host_rrule_observed"
                     ),
-                    host_match_observed=host_match_ack_needed,
+                    # An ACK hint is executable only after either a successful
+                    # host update or a matching host readback. Carry that proof
+                    # and the originating identity so scheduler-ack-current
+                    # cannot recompute an unbound hint and silently no-op.
+                    host_match_observed=True,
                 )
         scheduler_hint = {
             "schema_version": SCHEDULER_HINT_SCHEMA_VERSION,

--- a/loopx/control_plane/scheduler/state_transition_rules.py
+++ b/loopx/control_plane/scheduler/state_transition_rules.py
@@ -134,6 +134,7 @@ def decide_scheduler_host_transition(
     effective_host_rrule: str,
     current_rrule: str,
     current_rrule_already_applied: bool,
+    scheduler_state_acknowledges_current_rrule: bool,
     all_host_update_failures: Collection[Mapping[str, Any]],
     recorded_host_failure: Mapping[str, Any] | None,
 ) -> SchedulerHostDecision:
@@ -157,7 +158,11 @@ def decide_scheduler_host_transition(
     if (
         observed_host_rrule
         and current_rrule_already_applied
-        and (state_status != "same_identity" or current_target_has_failure)
+        and (
+            not scheduler_state_acknowledges_current_rrule
+            or state_status != "same_identity"
+            or current_target_has_failure
+        )
     ):
         transition = SchedulerHostTransition.HOST_MATCH_ACK_REQUIRED
     elif current_rrule_already_applied and state_status == "same_identity":

--- a/tests/control_plane/test_scheduler_ack_current_host_binding.py
+++ b/tests/control_plane/test_scheduler_ack_current_host_binding.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from examples.control_plane.quota_plan_fixtures import SCOPED_AGENT_ID, write_cli_fixture
+from loopx.control_plane.testing.canary_harness import run_json_cli
+
+
+GOAL_ID = "needs-operator"
+
+
+def _write_heartbeat_rrule(codex_home: Path, rrule: str) -> None:
+    automation_path = codex_home / "automations" / "fixture" / "automation.toml"
+    automation_path.parent.mkdir(parents=True, exist_ok=True)
+    automation_path.write_text(
+        "\n".join(
+            [
+                "version = 1",
+                'id = "fixture"',
+                'kind = "heartbeat"',
+                'name = "Scheduler ACK fixture"',
+                (
+                    'prompt = "Advance `needs-operator` from active state. '
+                    'Agent: `codex-side-bypass`."'
+                ),
+                'status = "ACTIVE"',
+                f'rrule = "{rrule}"',
+                'target_thread_id = "fixture-thread"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _quota(
+    registry_path: Path,
+    runtime_root: Path,
+    project: Path,
+) -> dict:
+    return run_json_cli(
+        "quota",
+        "should-run",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        SCOPED_AGENT_ID,
+        "--codex-app",
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        cwd=project,
+    )
+
+
+def test_scheduler_ack_current_replays_host_binding_after_update(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path, runtime_root, project = write_cli_fixture(
+        tmp_path / "fixture",
+        scoped_agents=True,
+    )
+    codex_home = tmp_path / "codex-home"
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setenv("CODEX_THREAD_ID", "fixture-thread")
+    _write_heartbeat_rrule(codex_home, "FREQ=MINUTELY;INTERVAL=3")
+
+    first = _quota(registry_path, runtime_root, project)
+    app = first["scheduler_hint"]["codex_app"]
+    target_rrule = app["recommended_rrule"]
+    ack_hint = app["ack_hint"]
+    assert app["stateful_backoff"]["apply_needed"] is True
+    assert ack_hint["after"] == "automation_update_rrule_success"
+    assert ack_hint["args"]["host_match_observed"] is True
+
+    # Simulate a successful host update before executing the original ACK hint.
+    _write_heartbeat_rrule(codex_home, target_rrule)
+    ack = run_json_cli(
+        *ack_hint["cli_args"],
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        cwd=project,
+    )
+    assert ack["scheduler_state_mutated"] is True
+    assert ack["already_applied"] is False
+
+    settled = _quota(registry_path, runtime_root, project)
+    settled_app = settled["scheduler_hint"]["codex_app"]
+    assert settled_app["stateful_backoff"]["apply_needed"] is False
+    assert settled_app["stateful_backoff"]["ack_needed"] is False
+    assert settled_app["host_action"] == "none"

--- a/tests/control_plane/test_scheduler_state_transition_rules.py
+++ b/tests/control_plane/test_scheduler_state_transition_rules.py
@@ -158,6 +158,12 @@ HOST_CASES = [
         "expected": SchedulerHostTransition.HOST_MATCH_ACK_REQUIRED,
     },
     {
+        "id": "matching_host_new_progression_requires_ack",
+        "already_applied": True,
+        "persisted": False,
+        "expected": SchedulerHostTransition.HOST_MATCH_ACK_REQUIRED,
+    },
+    {
         "id": "matching_host_acks_current_target_failure",
         "already_applied": True,
         "failures": [_failure(target=TARGET_15, host=HOST_60)],
@@ -216,6 +222,7 @@ def test_scheduler_host_transition_table(case: dict) -> None:
         effective_host_rrule=case.get("effective", observed),
         current_rrule=TARGET_15,
         current_rrule_already_applied=case.get("already_applied", False),
+        scheduler_state_acknowledges_current_rrule=case.get("persisted", True),
         all_host_update_failures=case.get("failures", []),
         recorded_host_failure=case.get("recorded"),
     )
@@ -246,6 +253,7 @@ def test_unrelated_failure_order_does_not_change_host_transition() -> None:
             effective_host_rrule=TARGET_15,
             current_rrule=TARGET_15,
             current_rrule_already_applied=True,
+            scheduler_state_acknowledges_current_rrule=True,
             all_host_update_failures=failures,
             recorded_host_failure=failures[-1],
         ).transition


### PR DESCRIPTION
## Summary
- bind generated scheduler ACK commands to the originating reset token, identity signature, and successful host application/readback proof
- distinguish a host RRULE match from a persisted scheduler ACK so cadence progression cannot settle before ledger writeback
- add a real CLI regression for automation update -> ACK -> final guard settlement

## Root cause
`scheduler-ack-current` could recompute a different or already-settled hint after the host RRULE changed, then return success without persisting the ACK. The next host-aware quota check still reported `ack_needed=true`, causing cadence oscillation. The host transition also conflated host state with persisted ACK state.

## Validation
- Ruff on all changed Python files
- 158 scheduler/interaction tests passed
- `quota-scheduler-state-ack-smoke.py`
- `quota-scheduler-registry-route-smoke.py`
- `monitor-poll-writeback-smoke.py`
- `loopx canary premerge --from-git-diff`: 18/18 selected checks passed, public-boundary scan clean

## Review note
This changes scheduler runtime semantics, so it is intentionally left for independent owner review rather than self-merge.