### PR TITLE
Fix SkillsBench meaningful-operation test doubles

### DIFF
--- a/tests/test_skillsbench_turn_runtime.py
+++ b/tests/test_skillsbench_turn_runtime.py
@@ -75,8 +75,8 @@ def test_satisfied_pre_agent_postcondition_runs_but_does_not_claim_readiness(
         ) -> dict[str, Any]:
             if allow_nonzero:
                 return {"ok": True, "exit_code": 0, "elapsed_ms": 1}
-            assert meaningful is True
-            self.meaningful_operation_count += 1
+            if meaningful:
+                self.meaningful_operation_count += 1
             return {"ok": True, "exit_code": 0, "stdout": "", "elapsed_ms": 1}
 
     def fake_turn_once(
@@ -108,6 +108,7 @@ def test_satisfied_pre_agent_postcondition_runs_but_does_not_claim_readiness(
 
     assert agent_calls == ["synthetic prompt"]
     assert validation["pre_agent_postcondition_status"] == "already_satisfied"
+    assert validation["meaningful_operation_count"] == 1
     assert receipt["ready"] is False
     assert "pre_agent_postcondition_unsatisfied" in receipt["blocker_codes"]
 
@@ -131,8 +132,8 @@ def test_unsatisfied_baseline_then_satisfied_postcondition_is_runner_ready(
         ) -> dict[str, Any]:
             if allow_nonzero:
                 return {"ok": False, "exit_code": 3, "elapsed_ms": 1}
-            assert meaningful is True
-            self.meaningful_operation_count += 1
+            if meaningful:
+                self.meaningful_operation_count += 1
             return {"ok": True, "exit_code": 0, "stdout": "", "elapsed_ms": 1}
 
     def fake_turn_once(


### PR DESCRIPTION
## Summary
- allow the SkillsBench Turn test doubles to execute non-meaningful baseline setup and cleanup
- count only the independent post-agent validation as a meaningful operation
- retain an explicit assertion that exactly one meaningful operation is observed

## Validation
- `uv run --extra test python -m pytest -q -n 2 --cov=loopx --cov-report=term --cov-fail-under=19.6` (888 passed, 2 skipped, 45.38% coverage)
- `uvx ruff check tests/test_skillsbench_turn_runtime.py`
- `loopx canary premerge --from-git-diff` (4/4 catalog canaries passed; no manual holds)