### PR TITLE
Add first-class OpenCode host support

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ Choose your surface:
   pasteable gate.
 - **Claude Code**: best when Claude Code's native `/loop` should drive each tick.
   Install the opt-in adapter, run `/loopx <task>`, then `/loop`.
+- **OpenCode**: install the static command facade with the normal command
+  installer. For recurring quota-gated goals, explicitly run `loopx
+  slash-commands --install --surface opencode --with-goal-bridge`, restart
+  OpenCode, then run `/loopx <task>`.
 - **Manual shell / other agents**: best when you want LoopX state without a
   supported runtime bridge. Install from the no-clone installer, then run
   `loopx doctor` and `loopx bootstrap`.
@@ -192,8 +196,10 @@ Choose your surface:
 Command registration is host-specific, but the state path is not. Codex
 surfaces may expose LoopX through `$loopx` or `/skills` command facades before
 native `/loopx` exists; Claude Code can expose `/loopx <task>` after its opt-in
-adapter is installed. If a host command is missing, run `loopx slash-commands`
-for the current catalog or start the same agent-safe path from a shell with
+adapter is installed; OpenCode can expose `/loopx <task>` through its static
+command facade, while its executable goal bridge remains explicit opt-in. If a
+host command is missing, run `loopx slash-commands` for the current catalog or
+start the same agent-safe path from a shell with
 `loopx start-goal --guided --project . --goal-text "<task>"`. Host and plugin
 integrations that need the lower-level handoff packet can still use
 `loopx bootstrap-command-pack --project . --goal-text "<task>"`. Full routing and

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -123,8 +123,8 @@ integrations that need the lower-level handoff packet can use
 manager or PR review commands, use `loopx slash-commands` to print the current
 canonical command list and fallback CLI shapes.
 
-Use `codex-app`, `codex-ide-plugin`, or `codex-cli-tui` for the corresponding
-Codex host. Select `codex-ide-plugin` only when LoopX is running through the
+Use `codex-app`, `codex-ide-plugin`, `codex-cli-tui`, or `opencode` for the
+corresponding host. Select `codex-ide-plugin` only when LoopX is running through the
 installed IDE plugin; using Codex beside an editor does not make the host an IDE
 plugin. If the exact host is not known, omit `--host-surface` once: LoopX
 returns a read-only selection gate with exact rerun commands and does not write

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -79,6 +79,10 @@ can discover user-installed skills:
 - Claude Code: lightweight user skills under `~/.claude/skills/loopx*`, so the
   command family can appear as Claude Code slash commands without enabling the
   opt-in MCP/hook adapter.
+- OpenCode: static command files under `~/.config/opencode/commands/` expose
+  native `/loopx` slash commands after restart. The executable goal bridge
+  (timer-based idle continuation gated by LoopX quota) requires an explicit
+  `--with-goal-bridge` install.
 
 The command family is the same across surfaces, even when the host-specific
 entry point is different:

--- a/docs/guides/newcomer-command-path.md
+++ b/docs/guides/newcomer-command-path.md
@@ -39,6 +39,7 @@ matches the surface you already use:
 | Codex App | `$loopx <task text>` or `/skills` -> `loopx` in the project thread | The app heartbeat automation. Let the agent install or refresh the generated LoopX heartbeat body; start at the bootstrap cadence, then follow `quota should-run.scheduler_hint`. |
 | Codex CLI | `codex` from the project root, then paste `loopx codex-cli-bootstrap-message --project .` output | Current verified Codex CLI builds do not load user-installed `/loopx` or `/prompts:loopx` commands. Keep the executor visible, then set the generated `/goal <thin task_body>`. |
 | Claude Code | Install LoopX, then `/loopx <task text>` | The installer registers lightweight slash-command skills. Enable the opt-in adapter only when Claude Code's native `/loop` should be gated by LoopX `should_run`. |
+| OpenCode | Install the OpenCode surface, then `/loopx <task text>` | The bridge writes commands, plugin, runtime, and pinned dependencies. After todos are written, call `loopx_goal_activate` to bind the quota-gated goal loop. |
 | Other agent or shell | `loopx start-goal --guided --project . --goal-text "<task text>" --host-surface <exact-host>` | The guided packet previews the same transaction an agent should execute: inspect or connect state, plan todos, refresh status, activate a host loop, run quota, and ack scheduler hints when needed. If the surface has no runner hook, LoopX can track state but the user drives it manually. |
 
 ## One CLI Quickstart

--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -105,7 +105,7 @@ path, and canary route rather than as a user-facing release baseline.
 - `v0.1.8` on 2026-07-04 16:53 +08:00: deterministic host-loop activation
   release at the matching `v0.1.8` tag. This release gives new agent hosts an explicit
   `agent-onboard` contract for choosing `codex-app`, `codex-cli`,
-  `claude-code`, `manual`, or `other-agent`, rejects ambiguous inputs such as
+  `claude-code`, `opencode`, `manual`, or `other-agent`, rejects ambiguous inputs such as
   `codex`, and makes `/loopx <task>` activate or gate the correct host loop
   after todo writeback.
 - `v0.1.9` on 2026-07-05 21:45 +08:00: real auto-research and agent-scoped

--- a/docs/reference/protocols/agent-scoped-evidence-ledger-v0.md
+++ b/docs/reference/protocols/agent-scoped-evidence-ledger-v0.md
@@ -122,7 +122,7 @@ Supported filters:
 The command must fail closed on missing `goal_id` or `agent_id`. A vague
 surface value such as `codex` should not silently fall into `other-agent`
 semantics; callers should pass a registered agent id and, when needed, a
-separate host surface such as `codex-app`, `codex-cli`, or `claude-code`.
+separate host surface such as `codex-app`, `codex-cli`, `opencode`, or `claude-code`.
 
 ## Scoping Rules
 

--- a/docs/reference/protocols/codex-app-host-command-registry-v0.md
+++ b/docs/reference/protocols/codex-app-host-command-registry-v0.md
@@ -80,7 +80,7 @@ Example registry entry:
 
 Hosts that do not know their exact runtime type should first call
 `loopx agent-onboard --list-agent-types`, then pass a canonical value such as
-`codex-app`, `codex-cli`, or `claude-code`. Ambiguous values such as `codex`
+`codex-app`, `codex-cli`, `opencode`, or `claude-code`. Ambiguous values such as `codex`
 are invalid because Codex App heartbeat automation and Codex CLI `/goal` have
 different activation procedures.
 
@@ -165,9 +165,9 @@ fields can rerun the advertised command or pass
 `--include-command-pack-detail`. Both modes must produce the same host-action
 projection before a compact default is promoted.
 
-`start-goal` does not guess among Codex App, the Codex IDE plugin, and Codex CLI
-TUI. Callers should pass `--host-surface codex-app`,
-`codex-ide-plugin`, or `codex-cli-tui` for the exact current host.
+`start-goal` does not guess among Codex App, the Codex IDE plugin, Codex CLI
+TUI, or OpenCode. Callers should pass `--host-surface codex-app`,
+`codex-ide-plugin`, `codex-cli-tui`, or `opencode` for the exact current host.
 `codex-ide-plugin` means the installed IDE plugin host, not any Codex session
 used alongside an editor. The legacy `codex-ide` value remains accepted as a
 compatibility alias but is not offered by the selection gate. If the option is

--- a/docs/reference/protocols/loopx-goal-command-v0.md
+++ b/docs/reference/protocols/loopx-goal-command-v0.md
@@ -25,6 +25,9 @@ When the user provides text after `/loopx`, the host should:
      generated `heartbeat-prompt` task body.
    - `codex-cli`: set the visible Codex CLI TUI to `/goal <task_body>`.
    - `claude-code`: arm LoopX with `/loopx <task>`, then run native `/loop`.
+   - `opencode`: call `loopx_goal_activate` from the installed LoopX OpenCode
+     bridge; the bridge gates idle continuation and timer wakes through
+     `quota should-run` and completes only on validated terminal no-follow-up.
    - `manual` / `other-agent`: wire the external loop driver described by
      `loopx agent-onboard`.
 7. If the host cannot mutate that surface, report the exact pasteable gate

--- a/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
+++ b/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
@@ -46,6 +46,7 @@ def main() -> int:
         "codex-ide-plugin",
         "codex-cli",
         "claude-code",
+        "opencode",
         "manual",
         "other-agent",
     } <= agent_types
@@ -56,16 +57,21 @@ def main() -> int:
     assert agent_type_for_host_surface("codex-ide-plugin") == "codex-ide-plugin"
     assert agent_type_for_host_surface("codex-ide") == "codex-ide-plugin"
     assert agent_type_for_host_surface("codex-cli-tui") == "codex-cli"
+    assert agent_type_for_host_surface("opencode") == "opencode"
 
     codex_app = build_host_loop_activation_packet(agent_type="codex-app", goal_id="demo")
     codex_ide = build_host_loop_activation_packet(agent_type="codex-ide-plugin", goal_id="demo")
     codex_cli = build_host_loop_activation_packet(agent_type="codex-cli", goal_id="demo")
     claude_code = build_host_loop_activation_packet(agent_type="claude-code", goal_id="demo")
+    opencode = build_host_loop_activation_packet(agent_type="opencode", goal_id="demo")
     assert codex_app["activation_method"] == "create_or_update_codex_app_automation", codex_app
     assert codex_ide["activation_method"] == "set_visible_goal", codex_ide
     assert codex_ide["host_mutation"]["host_command"] == "/goal <task_body>", codex_ide
     assert codex_cli["host_mutation"]["host_command"] == "/goal <task_body>", codex_cli
     assert claude_code["host_mutation"]["host_command"] == "/loop", claude_code
+    assert opencode["activation_method"] == "activate_loopx_opencode_goal_bridge", opencode
+    assert opencode["host_mutation"]["host_tool"] == "loopx_goal_activate", opencode
+    assert "--runtime-profile generic_cli" in opencode["commands"]["heartbeat_prompt"], opencode
     gated_activation = build_host_loop_activation_packet(
         agent_type="codex-app",
         goal_id="multi-agent-demo",
@@ -270,6 +276,21 @@ def main() -> int:
         assert "--host-surface codex-ide-plugin" in ide_bootstrap, ide_onboarding
         assert "worker-bridge" not in ide_bootstrap, ide_onboarding
         assert "visible IDE plugin" in ide_onboarding["recommended_start"], ide_onboarding
+
+        opencode_onboarding = build_agent_onboarding_packet(
+            project=project,
+            agent_type="opencode",
+            goal_id="multi-agent-goal",
+            agent_id="codex-product-capability",
+            cli_bin=cli_bin,
+        )
+        assert "--host-surface opencode" in opencode_onboarding["commands"]["bootstrap_command_pack"]
+        assert opencode_onboarding["commands"]["install_command_facade"].endswith(
+            "--surface opencode"
+        )
+        assert opencode_onboarding["host_loop_activation"]["host_mutation"]["host_tool"] == (
+            "loopx_goal_activate"
+        )
 
     return 0
 

--- a/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
+++ b/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
@@ -286,7 +286,7 @@ def main() -> int:
         )
         assert "--host-surface opencode" in opencode_onboarding["commands"]["bootstrap_command_pack"]
         assert opencode_onboarding["commands"]["install_command_facade"].endswith(
-            "--surface opencode"
+            "--surface opencode --with-goal-bridge"
         )
         assert opencode_onboarding["host_loop_activation"]["host_mutation"]["host_tool"] == (
             "loopx_goal_activate"

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -732,6 +732,29 @@ def main() -> int:
         assert "age_hours=" in stale_install.stderr, stale_install.stderr
         assert "non-blocking" in stale_install.stderr, stale_install.stderr
 
+        blocked_opencode_root = home / ".config" / "opencode-blocked"
+        blocked_opencode_root.mkdir(parents=True)
+        (blocked_opencode_root / "opencode.jsonc").write_text(
+            "{ invalid\n",
+            encoding="utf-8",
+        )
+        blocked_opencode_install = run_install(
+            {
+                **env,
+                "LOOPX_INSTALL_OPENCODE": "1",
+                "OPENCODE_CONFIG_DIR": str(blocked_opencode_root),
+            },
+            "install-smoke-opencode-blocked",
+        )
+        assert (
+            "loopx OpenCode bridge: install attempted; run manually:"
+            in blocked_opencode_install.stdout
+        ), blocked_opencode_install.stdout
+        assert (blocked_opencode_root / "commands" / "loopx.md").is_file()
+        assert not (blocked_opencode_root / "plugins" / "loopx-goal.js").exists()
+        assert not (blocked_opencode_root / "loopx" / "goal-bridge-runtime.mjs").exists()
+        assert not (blocked_opencode_root / "package.json").exists()
+
         opencode_install = run_install(
             {**env, "LOOPX_INSTALL_OPENCODE": "1"},
             "install-smoke-opencode",

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -182,6 +182,7 @@ def main() -> int:
             **os.environ,
             "HOME": str(home),
             "CODEX_HOME": str(codex_home),
+            "OPENCODE_CONFIG_DIR": str(home / ".config" / "opencode"),
             "LOOPX_BIN_DIR": str(bin_dir),
             "LOOPX_SHELL_PROFILE": str(profile),
             "LOOPX_INSTALL_SKILL": "1",
@@ -215,6 +216,8 @@ def main() -> int:
         assert f"- skill: {codex_home / 'skills' / 'loopx-self-repair'}" in install.stdout, install.stdout
         assert f"codex skills: {codex_home / 'skills'}" in install.stdout, install.stdout
         assert f"claude skills: {home / '.claude' / 'skills'}" in install.stdout, install.stdout
+        assert "loopx OpenCode bridge: skipped (opt-in" in install.stdout, install.stdout
+        assert not (home / ".config" / "opencode").exists()
 
         wrapper = bin_dir / "loopx"
         assert wrapper.is_symlink(), wrapper
@@ -724,6 +727,17 @@ def main() -> int:
         assert "promotion-readiness evidence is stale" in stale_install.stderr, stale_install.stderr
         assert "age_hours=" in stale_install.stderr, stale_install.stderr
         assert "non-blocking" in stale_install.stderr, stale_install.stderr
+
+        opencode_install = run_install(
+            {**env, "LOOPX_INSTALL_OPENCODE": "1"},
+            "install-smoke-opencode",
+        )
+        opencode_root = home / ".config" / "opencode"
+        assert "loopx OpenCode bridge:" in opencode_install.stdout, opencode_install.stdout
+        assert (opencode_root / "commands" / "loopx.md").is_file()
+        assert (opencode_root / "plugins" / "loopx-goal.js").is_file()
+        assert (opencode_root / "loopx" / "goal-bridge-runtime.mjs").is_file()
+        assert (opencode_root / "package.json").is_file()
 
     print("install-local-smoke ok")
     return 0

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -217,7 +217,11 @@ def main() -> int:
         assert f"codex skills: {codex_home / 'skills'}" in install.stdout, install.stdout
         assert f"claude skills: {home / '.claude' / 'skills'}" in install.stdout, install.stdout
         assert "loopx OpenCode bridge: skipped (opt-in" in install.stdout, install.stdout
-        assert not (home / ".config" / "opencode").exists()
+        opencode_root = home / ".config" / "opencode"
+        assert (opencode_root / "commands" / "loopx.md").is_file()
+        assert not (opencode_root / "plugins" / "loopx-goal.js").exists()
+        assert not (opencode_root / "loopx" / "goal-bridge-runtime.mjs").exists()
+        assert not (opencode_root / "package.json").exists()
 
         wrapper = bin_dir / "loopx"
         assert wrapper.is_symlink(), wrapper
@@ -732,7 +736,6 @@ def main() -> int:
             {**env, "LOOPX_INSTALL_OPENCODE": "1"},
             "install-smoke-opencode",
         )
-        opencode_root = home / ".config" / "opencode"
         assert "loopx OpenCode bridge:" in opencode_install.stdout, opencode_install.stdout
         assert (opencode_root / "commands" / "loopx.md").is_file()
         assert (opencode_root / "plugins" / "loopx-goal.js").is_file()

--- a/examples/slash-command-install-smoke.py
+++ b/examples/slash-command-install-smoke.py
@@ -14,14 +14,14 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
-def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+def run_cli(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, "-m", "loopx.cli", *args],
         cwd=REPO_ROOT,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        check=True,
+        check=check,
     )
 
 
@@ -362,6 +362,32 @@ def main() -> int:
         assert (bridge_home / "plugins" / "loopx-goal.js").is_file(), bridge
         assert (bridge_home / "loopx" / "goal-bridge-runtime.mjs").is_file(), bridge
         assert (bridge_home / "package.json").is_file(), bridge
+
+        blocked_bridge_home = root / "opencode-bridge-blocked"
+        blocked_bridge_home.mkdir()
+        (blocked_bridge_home / "opencode.jsonc").write_text(
+            "{ invalid\n",
+            encoding="utf-8",
+        )
+        blocked_bridge_result = run_cli(
+            "--format",
+            "json",
+            "slash-commands",
+            "--install",
+            "--surface",
+            "opencode",
+            "--with-goal-bridge",
+            "--opencode-home",
+            str(blocked_bridge_home),
+            check=False,
+        )
+        assert blocked_bridge_result.returncode == 1, blocked_bridge_result
+        blocked_bridge = json.loads(blocked_bridge_result.stdout)
+        assert blocked_bridge["ok"] is False, blocked_bridge
+        assert not (blocked_bridge_home / "commands" / "loopx.md").exists(), blocked_bridge
+        assert not (blocked_bridge_home / "plugins" / "loopx-goal.js").exists(), blocked_bridge
+        assert not (blocked_bridge_home / "loopx" / "goal-bridge-runtime.mjs").exists(), blocked_bridge
+        assert not (blocked_bridge_home / "package.json").exists(), blocked_bridge
 
     print("slash-command-install-smoke ok")
     return 0

--- a/examples/slash-command-install-smoke.py
+++ b/examples/slash-command-install-smoke.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -37,6 +38,8 @@ def main() -> int:
         root = Path(tmp)
         codex_home = root / ".codex"
         claude_home = root / ".claude"
+        opencode_home = root / ".opencode"
+        os.environ["OPENCODE_CONFIG_DIR"] = str(opencode_home)
 
         dry = json.loads(
             run_cli(
@@ -57,6 +60,7 @@ def main() -> int:
         assert dry["summary"]["status_counts"]["unsupported_host_surface"] >= 1, dry
         assert not (codex_home / "prompts").exists(), dry
         assert not (claude_home / "skills").exists(), dry
+        assert not opencode_home.exists(), dry
         assert dry["summary"]["codex_prompt_dir"] is None, dry
 
         payload = json.loads(
@@ -76,6 +80,8 @@ def main() -> int:
         assert payload["summary"]["codex_prompt_dir"] is None, payload
         assert payload["summary"]["codex_skill_dir"] == str(codex_home / "skills"), payload
         assert payload["summary"]["claude_skill_dir"] == str(claude_home / "skills"), payload
+        assert payload["summary"]["opencode_command_dir"] == str(opencode_home / "commands"), payload
+        assert payload["summary"]["opencode_plugin_path"] is None, payload
         assert payload["summary"]["status_counts"]["created"] >= 20, payload
         assert payload["summary"]["status_counts"]["unsupported_host_surface"] >= 1, payload
         assert "skipped_user_file" not in payload["summary"]["status_counts"], payload
@@ -336,6 +342,26 @@ def main() -> int:
             ).stdout
         )
         assert uninstall_again["summary"]["status_counts"]["absent"] >= 20, uninstall_again
+
+        bridge_home = root / "opencode-bridge"
+        bridge = json.loads(
+            run_cli(
+                "--format",
+                "json",
+                "slash-commands",
+                "--install",
+                "--surface",
+                "opencode",
+                "--with-goal-bridge",
+                "--opencode-home",
+                str(bridge_home),
+            ).stdout
+        )
+        assert bridge["with_goal_bridge"] is True, bridge
+        assert (bridge_home / "commands" / "loopx.md").is_file(), bridge
+        assert (bridge_home / "plugins" / "loopx-goal.js").is_file(), bridge
+        assert (bridge_home / "loopx" / "goal-bridge-runtime.mjs").is_file(), bridge
+        assert (bridge_home / "package.json").is_file(), bridge
 
     print("slash-command-install-smoke ok")
     return 0

--- a/loopx/agent_onboarding.py
+++ b/loopx/agent_onboarding.py
@@ -28,7 +28,10 @@ def _surface_install_command(agent_type: str, cli_bin: str) -> str | None:
     if agent_type == "claude-code":
         return f"{shell_arg(cli_bin)} slash-commands --install --surface claude-code"
     if agent_type == "opencode":
-        return f"{shell_arg(cli_bin)} slash-commands --install --surface opencode"
+        return (
+            f"{shell_arg(cli_bin)} slash-commands --install --surface opencode "
+            "--with-goal-bridge"
+        )
     return None
 
 
@@ -167,10 +170,6 @@ def build_agent_onboarding_packet(
                 if selected_agent_id
                 else ""
             )
-        )
-    if canonical_agent_type == "opencode":
-        commands["opencode_bridge_preflight"] = (
-            f"{shell_arg(cli_bin)} slash-commands --install --surface opencode"
         )
     return {
         "ok": True,

--- a/loopx/agent_onboarding.py
+++ b/loopx/agent_onboarding.py
@@ -27,6 +27,8 @@ def _surface_install_command(agent_type: str, cli_bin: str) -> str | None:
         return f"{shell_arg(cli_bin)} slash-commands --install --surface codex"
     if agent_type == "claude-code":
         return f"{shell_arg(cli_bin)} slash-commands --install --surface claude-code"
+    if agent_type == "opencode":
+        return f"{shell_arg(cli_bin)} slash-commands --install --surface opencode"
     return None
 
 
@@ -45,6 +47,7 @@ def _bootstrap_pack_command(
         "codex-ide-plugin": "codex-ide-plugin",
         "codex-cli": "codex-cli-tui",
         "claude-code": "claude-code",
+        "opencode": "opencode",
         "manual": "shell",
         "other-agent": "worker-bridge",
     }
@@ -76,6 +79,8 @@ def _start_instruction(agent_type: str) -> str:
         return "Use `$loopx <task>` or select the LoopX skill from `/skills`; after todos are written, set `/goal <task_body>` in the visible TUI."
     if agent_type == "claude-code":
         return "Run `/loopx <task>` to arm LoopX, then run native `/loop`."
+    if agent_type == "opencode":
+        return "Run `/loopx <task>`; after todo writeback, call `loopx_goal_activate` with the generated heartbeat task body."
     if agent_type == "manual":
         return "Use the CLI packet and wire an external scheduler, or run quota/status/todo commands manually."
     return "Use the host's explicit LoopX command facade such as `@loopx <task>` or `$loopx <task>`, then wire its scheduler through this packet."

--- a/loopx/agent_onboarding.py
+++ b/loopx/agent_onboarding.py
@@ -168,6 +168,10 @@ def build_agent_onboarding_packet(
                 else ""
             )
         )
+    if canonical_agent_type == "opencode":
+        commands["opencode_bridge_preflight"] = (
+            f"{shell_arg(cli_bin)} slash-commands --install --surface opencode"
+        )
     return {
         "ok": True,
         "schema_version": SCHEMA_VERSION,

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -39,6 +39,7 @@ START_GOAL_HOST_SURFACES = (
     "codex-ide-plugin",
     "codex-cli-tui",
     "claude-code",
+    "opencode",
     "shell",
 )
 
@@ -247,6 +248,7 @@ def build_start_goal_host_surface_selection_packet(
         "codex-ide-plugin": "Codex IDE plugin; activate its visible goal mode",
         "codex-cli-tui": "terminal Codex TUI with visible /goal support",
         "claude-code": "Claude Code with native /loop",
+        "opencode": "OpenCode with the LoopX goal bridge and quota-gated heartbeat",
         "shell": "manual shell or an explicitly configured external scheduler",
     }
     choices: list[dict[str, Any]] = []

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -248,7 +248,7 @@ def build_start_goal_host_surface_selection_packet(
         "codex-ide-plugin": "Codex IDE plugin; activate its visible goal mode",
         "codex-cli-tui": "terminal Codex TUI with visible /goal support",
         "claude-code": "Claude Code with native /loop",
-        "opencode": "OpenCode with the LoopX goal bridge and quota-gated heartbeat",
+        "opencode": "OpenCode LoopX goal bridge",
         "shell": "manual shell or an explicitly configured external scheduler",
     }
     choices: list[dict[str, Any]] = []
@@ -607,7 +607,7 @@ def _goal_start_contract(*, goal_text: str | None, connected: bool, agent_type: 
                 "codex-app": "Codex App heartbeat automation",
                 "codex-cli": "visible Codex CLI `/goal <task_body>`",
                 "claude-code": "Claude Code native `/loop` after `/loopx <task>` arms LoopX",
-                "opencode": "OpenCode `loopx_goal_activate` bridge gated by LoopX quota",
+                "opencode": "OpenCode `loopx_goal_activate`",
                 "manual": "external scheduler or manual quota/status loop",
                 "other-agent": "custom host loop driver using the returned task body and quota guard",
             },
@@ -686,7 +686,7 @@ Planning rules:
 3. Every new todo starts with `[P0]`, `[P1]`, or `[P2]`; include at least one `[P0]` unless the first useful step is blocked by a user gate.
 4. If several todos share the same priority, their listed order is their relative priority. Preserve that exact order when writing them.
 5. Prefer executable Agent Todo items with `task_class=advancement_task`; use User Todo only for concrete owner decisions or private-material gates.
-6. After writing todos, run `loopx refresh-state --goal-id {goal_id}`, activate the host loop if it is missing, unknown, or stale (Codex App automation, Codex CLI `/goal <task_body>`, Claude Code `/loop`, OpenCode `loopx_goal_activate`, or a custom host-loop gate), then run its typed `quota_guard` and begin the first allowed bounded segment.
+6. After writing todos, run `loopx refresh-state --goal-id {goal_id}`, activate the host loop if it is missing, unknown, or stale (Codex App automation, Codex CLI `/goal <task_body>`, Claude Code `/loop`, OpenCode bridge, or a custom host-loop gate), then run its typed `quota_guard` and begin the first allowed bounded segment.
 7. If the goal is a GitHub issue/PR fix, first preview `loopx issue-fix workflow-plan --url <github-issue-or-pr-url> --repo-path <approved-repo> --repository-context-json <compact-context.json> --validation-label '<validation command>' --format json`; write only metadata classification plus the feasibility checkpoint. Repository context should pin current repo policy, architecture, change-scope, reproduction, and validation refs; memory and external experts remain advisory until verified against the pinned revision. After a compact public-safe observation, run `loopx issue-fix feasibility --url <github-issue-url> --reproduction-status <state> --scope-class <scope> --repository-context-json <compact-context.json> --goal-id {goal_id} --format json` and write only its selected route successor or no-follow-up. Keep private repro material, body/comment reads, arbitrary external comments, PR creation, merge, publish, destructive git, and production actions as explicit gates. After a PR exists and `external_review_request` or `publish` authority is active, call `loopx issue-fix reviewer-request --url <github-pr-url> --repo-path <approved-repo> --base-ref <base-ref> --execute --format json`; it should try the formal request first and, only on confirmed permission denial, post one reviewer-tagging fallback comment. Do not mark notification complete until the request or fallback comment is visible on the PR. Then call `loopx issue-fix pr-lifecycle --url <github-pr-url> --goal-id {goal_id} --format json`; use `grouped_monitor_projection` for one monitor per nonempty state bucket. Never create one monitor per PR. Keep PR actions one-shot and messages at one PR per message.
 """
 
@@ -1567,7 +1567,7 @@ Host loop activation is part of setup, not a nice-to-have:
 If the host loop is already proven current, skip the mutation. If it is missing,
 unknown, or stale, use the command above to obtain `task_body` and activate the
 right host loop: Codex App automation, Codex CLI `/goal <task_body>`, Claude
-Code `/loop`, OpenCode `loopx_goal_activate`, or the custom host-loop gate.
+Code `/loop`, OpenCode bridge, or the custom host-loop gate.
 If this session cannot mutate that
 host surface, report the exact gate; do not claim autonomous setup complete.
 Use `{commands.get("goal_start_agent_onboard_recheck", "")}` only when

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -607,6 +607,7 @@ def _goal_start_contract(*, goal_text: str | None, connected: bool, agent_type: 
                 "codex-app": "Codex App heartbeat automation",
                 "codex-cli": "visible Codex CLI `/goal <task_body>`",
                 "claude-code": "Claude Code native `/loop` after `/loopx <task>` arms LoopX",
+                "opencode": "OpenCode `loopx_goal_activate` bridge gated by LoopX quota",
                 "manual": "external scheduler or manual quota/status loop",
                 "other-agent": "custom host loop driver using the returned task body and quota guard",
             },
@@ -685,7 +686,7 @@ Planning rules:
 3. Every new todo starts with `[P0]`, `[P1]`, or `[P2]`; include at least one `[P0]` unless the first useful step is blocked by a user gate.
 4. If several todos share the same priority, their listed order is their relative priority. Preserve that exact order when writing them.
 5. Prefer executable Agent Todo items with `task_class=advancement_task`; use User Todo only for concrete owner decisions or private-material gates.
-6. After writing todos, run `loopx refresh-state --goal-id {goal_id}`, activate the host loop if it is missing, unknown, or stale (Codex App automation, Codex CLI `/goal <task_body>`, Claude Code `/loop`, or a custom host-loop gate), then run its typed `quota_guard` and begin the first allowed bounded segment.
+6. After writing todos, run `loopx refresh-state --goal-id {goal_id}`, activate the host loop if it is missing, unknown, or stale (Codex App automation, Codex CLI `/goal <task_body>`, Claude Code `/loop`, OpenCode `loopx_goal_activate`, or a custom host-loop gate), then run its typed `quota_guard` and begin the first allowed bounded segment.
 7. If the goal is a GitHub issue/PR fix, first preview `loopx issue-fix workflow-plan --url <github-issue-or-pr-url> --repo-path <approved-repo> --repository-context-json <compact-context.json> --validation-label '<validation command>' --format json`; write only metadata classification plus the feasibility checkpoint. Repository context should pin current repo policy, architecture, change-scope, reproduction, and validation refs; memory and external experts remain advisory until verified against the pinned revision. After a compact public-safe observation, run `loopx issue-fix feasibility --url <github-issue-url> --reproduction-status <state> --scope-class <scope> --repository-context-json <compact-context.json> --goal-id {goal_id} --format json` and write only its selected route successor or no-follow-up. Keep private repro material, body/comment reads, arbitrary external comments, PR creation, merge, publish, destructive git, and production actions as explicit gates. After a PR exists and `external_review_request` or `publish` authority is active, call `loopx issue-fix reviewer-request --url <github-pr-url> --repo-path <approved-repo> --base-ref <base-ref> --execute --format json`; it should try the formal request first and, only on confirmed permission denial, post one reviewer-tagging fallback comment. Do not mark notification complete until the request or fallback comment is visible on the PR. Then call `loopx issue-fix pr-lifecycle --url <github-pr-url> --goal-id {goal_id} --format json`; use `grouped_monitor_projection` for one monitor per nonempty state bucket. Never create one monitor per PR. Keep PR actions one-shot and messages at one PR per message.
 """
 
@@ -1566,7 +1567,8 @@ Host loop activation is part of setup, not a nice-to-have:
 If the host loop is already proven current, skip the mutation. If it is missing,
 unknown, or stale, use the command above to obtain `task_body` and activate the
 right host loop: Codex App automation, Codex CLI `/goal <task_body>`, Claude
-Code `/loop`, or the custom host-loop gate. If this session cannot mutate that
+Code `/loop`, OpenCode `loopx_goal_activate`, or the custom host-loop gate.
+If this session cannot mutate that
 host surface, report the exact gate; do not claim autonomous setup complete.
 Use `{commands.get("goal_start_agent_onboard_recheck", "")}` only when
 activation state is missing/unknown/stale or the agent type changed."""

--- a/loopx/cli_commands/slash_commands.py
+++ b/loopx/cli_commands/slash_commands.py
@@ -50,10 +50,10 @@ def register_slash_commands_command(
     parser.add_argument(
         "--surface",
         action="append",
-        choices=["all", "codex", "codex-cli", "codex-app", "codex-ide-plugin", "codex-ide", "claude-code"],
+        choices=["all", "codex", "codex-cli", "codex-app", "codex-ide-plugin", "codex-ide", "claude-code", "opencode"],
         help=(
             "Host surface to install. Repeatable. Defaults to all "
-            "(Codex explicit skills plus Claude Code skills)."
+            "(Codex explicit skills, Claude Code skills, and OpenCode commands/bridge)."
         ),
     )
     parser.add_argument(
@@ -63,6 +63,10 @@ def register_slash_commands_command(
     parser.add_argument(
         "--claude-home",
         help="Claude Code home for skill installation. Defaults to CLAUDE_HOME or ~/.claude.",
+    )
+    parser.add_argument(
+        "--opencode-home",
+        help="OpenCode config directory. Defaults to OPENCODE_CONFIG_DIR or ~/.config/opencode.",
     )
     parser.add_argument(
         "--dry-run",
@@ -88,6 +92,7 @@ def handle_slash_commands_command(
             include_legacy_aliases=not bool(args.no_legacy_aliases),
             codex_home=args.codex_home,
             claude_home=args.claude_home,
+            opencode_home=args.opencode_home,
         )
         print_payload(payload, output_format(args), render_slash_command_install_markdown)
         return 0

--- a/loopx/cli_commands/slash_commands.py
+++ b/loopx/cli_commands/slash_commands.py
@@ -52,8 +52,9 @@ def register_slash_commands_command(
         action="append",
         choices=["all", "codex", "codex-cli", "codex-app", "codex-ide-plugin", "codex-ide", "claude-code", "opencode"],
         help=(
-            "Host surface to install. Repeatable. Defaults to all "
-            "(Codex explicit skills, Claude Code skills, and OpenCode commands/bridge)."
+            "Host surface to install. Repeatable. Defaults to all standard surfaces "
+            "(Codex explicit skills and Claude Code skills); OpenCode requires "
+            "--surface opencode."
         ),
     )
     parser.add_argument(

--- a/loopx/cli_commands/slash_commands.py
+++ b/loopx/cli_commands/slash_commands.py
@@ -104,7 +104,7 @@ def handle_slash_commands_command(
             opencode_home=args.opencode_home,
         )
         print_payload(payload, output_format(args), render_slash_command_install_markdown)
-        return 0
+        return 0 if payload.get("ok") is True else 1
     payload = build_slash_command_catalog(
         cli_bin=args.cli_bin,
         include_legacy_aliases=not bool(args.no_legacy_aliases),

--- a/loopx/cli_commands/slash_commands.py
+++ b/loopx/cli_commands/slash_commands.py
@@ -52,9 +52,16 @@ def register_slash_commands_command(
         action="append",
         choices=["all", "codex", "codex-cli", "codex-app", "codex-ide-plugin", "codex-ide", "claude-code", "opencode"],
         help=(
-            "Host surface to install. Repeatable. Defaults to all standard surfaces "
-            "(Codex explicit skills and Claude Code skills); OpenCode requires "
-            "--surface opencode."
+            "Host surface to install. Repeatable. Defaults to static command facades "
+            "for Codex, Claude Code, and OpenCode."
+        ),
+    )
+    parser.add_argument(
+        "--with-goal-bridge",
+        action="store_true",
+        help=(
+            "Also install or uninstall the executable OpenCode goal bridge. Requires "
+            "an effective OpenCode surface and explicit opt-in."
         ),
     )
     parser.add_argument(
@@ -88,6 +95,7 @@ def handle_slash_commands_command(
         payload = install_slash_commands(
             execute=bool((args.install or args.uninstall) and not args.dry_run),
             uninstall=bool(args.uninstall),
+            with_goal_bridge=bool(args.with_goal_bridge),
             surfaces=args.surface,
             cli_bin=args.cli_bin,
             include_legacy_aliases=not bool(args.no_legacy_aliases),

--- a/loopx/cli_commands/starter_bootstrap_registration.py
+++ b/loopx/cli_commands/starter_bootstrap_registration.py
@@ -19,7 +19,7 @@ def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) 
     )
     agent_onboard_parser.add_argument(
         "--agent-type",
-        help="Agent runtime type: codex-app, codex-ide-plugin, codex-cli, claude-code, manual, or other-agent.",
+        help="Agent runtime type: codex-app, codex-ide-plugin, codex-cli, claude-code, opencode, manual, or other-agent.",
     )
     agent_onboard_parser.add_argument(
         "--list-agent-types",
@@ -66,7 +66,7 @@ def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) 
     bootstrap_command_pack_parser.add_argument(
         "--host-surface",
         default="chat-box",
-        choices=["chat-box", "codex-app", "codex-ide-plugin", "codex-ide", "codex-cli-tui", "claude-code", "shell", "http", "worker-bridge"],
+        choices=["chat-box", "codex-app", "codex-ide-plugin", "codex-ide", "codex-cli-tui", "claude-code", "opencode", "shell", "http", "worker-bridge"],
         help="Host surface where the slash command pack will be exposed.",
     )
     bootstrap_command_pack_parser.add_argument(
@@ -112,7 +112,7 @@ def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) 
     )
     start_goal_parser.add_argument(
         "--host-surface",
-        choices=["chat-box", "codex-app", "codex-ide-plugin", "codex-ide", "codex-cli-tui", "claude-code", "shell", "http", "worker-bridge"],
+        choices=["chat-box", "codex-app", "codex-ide-plugin", "codex-ide", "codex-cli-tui", "claude-code", "opencode", "shell", "http", "worker-bridge"],
         help=(
             "Exact host surface that will own loop activation after todo writeback. "
             "When omitted, start-goal returns a read-only host selection gate."

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -95,6 +95,10 @@ COMMAND_GROUPS: list[dict[str, object]] = [
                 "purpose": "Use installed slash skills for `/loopx`; enable the adapter only when native `/loop` should be gated by LoopX.",
             },
             {
+                "command": "OpenCode goal bridge",
+                "purpose": "Install the LoopX OpenCode surface, then use `loopx_goal_activate` to bind the quota-gated bridge.",
+            },
+            {
                 "command": "Other agent or shell",
                 "purpose": "Use a CLI, task, automation, heartbeat, or scheduler hook; otherwise drive LoopX manually.",
             },
@@ -250,6 +254,7 @@ def render_concise_help(program: str = "loopx") -> str:
             "  Codex App      use /loopx <goal>; let the app set the heartbeat automation.",
             "  Codex CLI      keep visible TUI; run loopx codex-cli-bootstrap-message.",
             "  Claude Code    use installed /loopx skills; adapter only for gated native /loop.",
+            "  OpenCode       install the LoopX surface, then use loopx_goal_activate.",
             "  Other agents   need a CLI/task/automation/loop hook, or run LoopX manually.",
             "",
             "Global options: --registry PATH   --runtime-root PATH   --format markdown|json",

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -96,7 +96,7 @@ COMMAND_GROUPS: list[dict[str, object]] = [
             },
             {
                 "command": "OpenCode goal bridge",
-                "purpose": "Install the LoopX OpenCode surface, then use `loopx_goal_activate` to bind the quota-gated bridge.",
+                "purpose": "Opt into `--with-goal-bridge`, then use `loopx_goal_activate` to bind the quota-gated bridge.",
             },
             {
                 "command": "Other agent or shell",
@@ -254,7 +254,7 @@ def render_concise_help(program: str = "loopx") -> str:
             "  Codex App      use /loopx <goal>; let the app set the heartbeat automation.",
             "  Codex CLI      keep visible TUI; run loopx codex-cli-bootstrap-message.",
             "  Claude Code    use installed /loopx skills; adapter only for gated native /loop.",
-            "  OpenCode       install the LoopX surface, then use loopx_goal_activate.",
+            "  OpenCode       opt into the goal bridge, then use loopx_goal_activate.",
             "  Other agents   need a CLI/task/automation/loop hook, or run LoopX manually.",
             "",
             "Global options: --registry PATH   --runtime-root PATH   --format markdown|json",

--- a/loopx/host_loop_activation.py
+++ b/loopx/host_loop_activation.py
@@ -28,6 +28,7 @@ def scheduler_command_binding_for_agent_type(
         "codex-cli": SchedulerRuntimeProfile.CODEX_CLI_VISIBLE,
         "codex-ide-plugin": SchedulerRuntimeProfile.CODEX_CLI_VISIBLE,
         "claude-code": SchedulerRuntimeProfile.CLAUDE_CODE_VISIBLE,
+        "opencode": SchedulerRuntimeProfile.GENERIC_CLI_AGENT_LOOP,
     }.get(canonical)
     if runtime_profile is not None:
         return {"runtime_profile": runtime_profile.value}
@@ -39,6 +40,7 @@ SUPPORTED_AGENT_TYPES = [
     "codex-ide-plugin",
     "codex-cli",
     "claude-code",
+    "opencode",
     "manual",
     "other-agent",
 ]
@@ -87,6 +89,12 @@ AGENT_TYPE_CATALOG: dict[str, dict[str, Any]] = {
         "host_loop": "native /loop gated by LoopX",
         "entry": "/loopx <task> then /loop",
         "accepted_inputs": ["claude-code", "claude_code", "claude code", "cc"],
+    },
+    "opencode": {
+        "display_name": "OpenCode",
+        "host_loop": "visible OpenCode goal plugin gated by LoopX",
+        "entry": "/loopx <task> with the LoopX OpenCode bridge installed",
+        "accepted_inputs": ["opencode", "open-code", "open_code", "open code"],
     },
     "manual": {
         "display_name": "Manual shell / external scheduler",
@@ -147,6 +155,7 @@ HOST_SURFACE_TO_AGENT_TYPE = {
     "codex-ide": "codex-ide-plugin",
     "codex-cli-tui": "codex-cli",
     "claude-code": "claude-code",
+    "opencode": "opencode",
     "shell": "manual",
     "http": "other-agent",
     "worker-bridge": "other-agent",
@@ -269,6 +278,7 @@ def _heartbeat_commands(
         "codex-ide-plugin": "Codex IDE plugin /goal visible task loop",
         "codex-cli": "Codex CLI /goal visible TUI loop",
         "claude-code": "Claude Code native /loop gated by LoopX",
+        "opencode": "OpenCode visible goal loop gated by LoopX",
         "manual": "External scheduler or manual shell LoopX poll",
         "other-agent": "Custom agent host loop gated by LoopX",
     }
@@ -463,6 +473,43 @@ def _claude_code_activation(commands: dict[str, str], cli_bin: str) -> dict[str,
     }
 
 
+def _opencode_activation(commands: dict[str, str], cli_bin: str) -> dict[str, Any]:
+    return {
+        "host_surface": "opencode_visible_goal_mode",
+        "entry_command_hint": "/loopx <task>",
+        "activation_method": "activate_loopx_opencode_goal_bridge",
+        "activation_input_command": commands["heartbeat_prompt_json"],
+        "setup_command": f"{cli_bin} slash-commands --install --surface opencode",
+        "host_mutation": {
+            "owner": "OpenCode LoopX goal bridge",
+            "host_tool": "loopx_goal_activate",
+            "tool_argument_mapping": {
+                "goalId": "heartbeat_prompt.goal_id",
+                "objective": "heartbeat_prompt.task_body",
+                "agentId": "heartbeat_prompt.agent_id when present",
+                "registryPath": "explicit registry path when present",
+                "availableCapabilities": "declared host capabilities when present",
+            },
+            "cli_can_mutate_directly": False,
+            "missing_host_tool_gate": (
+                "The LoopX OpenCode bridge or loopx_goal_activate tool is unavailable; "
+                "install the OpenCode surface and restart OpenCode before claiming "
+                "autonomous heartbeat support."
+            ),
+        },
+        "activation_steps": [
+            "Install or refresh the LoopX OpenCode surface when needed.",
+            "Run the heartbeat-prompt JSON command after project state and todos are written.",
+            "Call loopx_goal_activate with goalId from goal_id, objective from task_body, and optional agentId, registryPath, or availableCapabilities when those values are present.",
+            "Let the bridge gate every idle continuation and timer wake through LoopX quota should-run.",
+        ],
+        "success_criteria": [
+            "The visible OpenCode session has a LoopX-backed goal bound through loopx_goal_activate.",
+            "Quiet waits make no model call, active work auto-continues, and validated terminal no-follow-up stops the goal.",
+        ],
+    }
+
+
 def _manual_activation(commands: dict[str, str]) -> dict[str, Any]:
     return {
         "host_surface": "external_scheduler_or_manual_shell",
@@ -527,6 +574,8 @@ def build_host_loop_activation_packet(
         surface = _codex_cli_activation(commands)
     elif canonical == "claude-code":
         surface = _claude_code_activation(commands, cli_bin)
+    elif canonical == "opencode":
+        surface = _opencode_activation(commands, cli_bin)
     else:
         surface = _manual_activation(commands)
         if canonical == "other-agent":

--- a/loopx/host_loop_activation.py
+++ b/loopx/host_loop_activation.py
@@ -479,7 +479,9 @@ def _opencode_activation(commands: dict[str, str], cli_bin: str) -> dict[str, An
         "entry_command_hint": "/loopx <task>",
         "activation_method": "activate_loopx_opencode_goal_bridge",
         "activation_input_command": commands["heartbeat_prompt_json"],
-        "setup_command": f"{cli_bin} slash-commands --install --surface opencode",
+        "setup_command": (
+            f"{cli_bin} slash-commands --install --surface opencode --with-goal-bridge"
+        ),
         "host_mutation": {
             "owner": "OpenCode LoopX goal bridge",
             "host_tool": "loopx_goal_activate",

--- a/loopx/opencode_goal_mode/README.md
+++ b/loopx/opencode_goal_mode/README.md
@@ -1,0 +1,65 @@
+# LoopX OpenCode adapter
+
+LoopX uses OpenCode's visible session as the executor and keeps scheduling truth
+in `loopx quota should-run`. The adapter wraps `opencode-goal-plugin@0.6.5`
+instead of loading that package directly, so every idle continuation and timer
+wake passes through the LoopX quota contract first.
+
+## Install
+
+```bash
+loopx slash-commands --install --surface opencode
+```
+
+The installer writes:
+
+- `~/.config/opencode/commands/loopx*.md` for the LoopX command family;
+- `~/.config/opencode/plugins/loopx-goal.js` for the local bridge;
+- `~/.config/opencode/loopx/goal-bridge-runtime.mjs` for the tested runtime;
+- pinned bridge dependencies in `~/.config/opencode/package.json`.
+
+Remove any direct `opencode-goal-plugin` entry from `opencode.json` or
+`opencode.jsonc` before installation. Loading the npm plugin and the LoopX local
+bridge together would create two independent goal runtimes, so installation
+fails closed while that conflict exists. Restart OpenCode after installation.
+
+## Goal start
+
+Run `/loopx <task>` in OpenCode. After LoopX has planned and written todos, the
+agent uses the returned host activation packet to call `loopx_goal_activate`
+with `goalId` from the packet's goal id and `objective` from its heartbeat task
+body. Pass `agentId`, `registryPath`, and `availableCapabilities` when those
+optional values are present.
+
+The bridge then applies this lifecycle:
+
+1. `scheduler_hint.action=run_now` or `should_run=true`: allow one OpenCode goal
+   continuation.
+2. Quiet wait or user gate: make no model call and schedule a bounded local
+   recheck using LoopX's unchanged-poll cadence.
+3. Repeated unchanged decisions: apply the advertised progression and final
+   replan limit without spending quota.
+4. Validated `terminal_no_followup`: submit completion through the goal plugin;
+   the custom auditor reruns LoopX quota and rejects any earlier completion.
+5. User message, denied permission, or session error: pause automatic resume
+   until the user explicitly resumes the goal.
+
+The bridge also suppresses OpenCode 1.18's reflected `$ARGUMENTS` chat event for
+the just-executed `/goal` command. Without that compatibility guard, the
+underlying plugin interprets its own command payload as a new user intervention
+and pauses a newly created goal before the first continuation.
+
+Bindings are private per-session JSON files under
+`$LOOPX_OPENCODE_STATE_DIR`, or under
+`$XDG_STATE_HOME/loopx/opencode` by default, and are written with mode `0600`.
+OpenCode's one-shot `opencode run` process cannot own timers after it exits; use
+the visible TUI or a persistent OpenCode server for recurring goal operation.
+
+## Uninstall
+
+```bash
+loopx slash-commands --uninstall --surface opencode
+```
+
+Uninstall removes only LoopX-managed command and bridge files. It preserves
+`package.json` dependencies because user-owned local plugins may share them.

--- a/loopx/opencode_goal_mode/README.md
+++ b/loopx/opencode_goal_mode/README.md
@@ -1,69 +1,71 @@
 # LoopX OpenCode adapter
 
-LoopX uses OpenCode's visible session as the executor and keeps scheduling truth
-in `loopx quota should-run`. The adapter wraps `opencode-goal-plugin@0.6.5`
-instead of loading that package directly, so every idle continuation and timer
-wake passes through the LoopX quota contract first.
+LoopX exposes two separate OpenCode layers: a static command facade and an
+optional executable goal bridge. Ordinary command installation never activates
+the runtime bridge.
 
 ## Install
 
+The default `all` surface installs only static files under
+`~/.config/opencode/commands/`:
+
 ```bash
-loopx slash-commands --install --surface opencode
+loopx slash-commands --install
 ```
 
-The installer writes:
+Enable the goal bridge explicitly:
 
-- `~/.config/opencode/commands/loopx*.md` for the LoopX command family;
-- `~/.config/opencode/plugins/loopx-goal.js` for the local bridge;
-- `~/.config/opencode/loopx/goal-bridge-runtime.mjs` for the tested runtime;
+```bash
+loopx slash-commands --install --surface opencode --with-goal-bridge
+```
+
+Before writing any OpenCode file, bridge installation validates
+`opencode.json`, `opencode.jsonc`, and `package.json`. It fails closed if a
+config is invalid or directly registers `opencode-goal-plugin`, because loading
+that plugin beside the LoopX wrapper would start two independent goal runtimes.
+
+After preflight succeeds, the installer writes the command facade plus:
+
+- `~/.config/opencode/plugins/loopx-goal.js`;
+- `~/.config/opencode/loopx/goal-bridge-runtime.mjs`;
 - pinned bridge dependencies in `~/.config/opencode/package.json`.
 
-OpenCode runs `bun install` for config-directory dependencies at startup, so
-the LoopX installer does not invoke a package manager. Restart OpenCode after
-installation so it installs the pinned dependencies and loads the bridge.
+OpenCode runs `bun install` for config-directory dependencies at startup.
+Restart OpenCode after bridge installation so it installs those dependencies
+and loads the local plugin.
 
-Remove any direct `opencode-goal-plugin` entry from `opencode.json` or
-`opencode.jsonc` before installation. Loading the npm plugin and the LoopX local
-bridge together would create two independent goal runtimes, so installation
-fails closed while that conflict exists.
+## Runtime
 
-## Goal start
+Run `/loopx <task>`, then activate the returned host packet through
+`loopx_goal_activate`. The runtime flow is:
 
-Run `/loopx <task>` in OpenCode. After LoopX has planned and written todos, the
-agent uses the returned host activation packet to call `loopx_goal_activate`
-with `goalId` from the packet's goal id and `objective` from its heartbeat task
-body. Pass `agentId`, `registryPath`, and `availableCapabilities` when those
-optional values are present.
-
-The bridge then applies this lifecycle:
-
-1. `scheduler_hint.action=run_now` or `should_run=true`: allow one OpenCode goal
-   continuation.
-2. Quiet wait or user gate: make no model call and schedule a bounded local
-   recheck using LoopX's unchanged-poll cadence.
-3. Repeated unchanged decisions: apply the advertised progression and final
-   replan limit without spending quota.
-4. Validated `terminal_no_followup`: submit completion through the goal plugin;
-   the custom auditor reruns LoopX quota and rejects any earlier completion.
-5. User message, denied permission, or session error: pause automatic resume
-   until the user explicitly resumes the goal.
-
-The bridge also suppresses OpenCode 1.18's reflected `$ARGUMENTS` chat event for
-the just-executed `/goal` command. Without that compatibility guard, the
-underlying plugin interprets its own command payload as a new user intervention
-and pauses a newly created goal before the first continuation.
+```text
+OpenCode idle event -> loopx quota should-run
+  -> run_now: continue once
+  -> wait: schedule a bounded local recheck without a model call
+  -> pause: remain stopped for user, permission, or session intervention
+  -> terminal_no_followup: submit completion and revalidate it in the auditor
+```
 
 Bindings are private per-session JSON files under
-`$LOOPX_OPENCODE_STATE_DIR`, or under
-`$XDG_STATE_HOME/loopx/opencode` by default, and are written with mode `0600`.
-OpenCode's one-shot `opencode run` process cannot own timers after it exits; use
-the visible TUI or a persistent OpenCode server for recurring goal operation.
+`$LOOPX_OPENCODE_STATE_DIR`, or `$XDG_STATE_HOME/loopx/opencode` by default,
+and use mode `0600`. OpenCode's one-shot `opencode run` process cannot own
+timers after exit; recurring operation requires the visible TUI or a persistent
+OpenCode server.
 
 ## Uninstall
+
+Remove only the static command facade:
 
 ```bash
 loopx slash-commands --uninstall --surface opencode
 ```
 
-Uninstall removes only LoopX-managed command and bridge files. It preserves
-`package.json` dependencies because user-owned local plugins may share them.
+Remove the static facade and LoopX-managed bridge files:
+
+```bash
+loopx slash-commands --uninstall --surface opencode --with-goal-bridge
+```
+
+Bridge uninstall preserves `package.json` dependencies because user-owned
+local plugins may share them.

--- a/loopx/opencode_goal_mode/README.md
+++ b/loopx/opencode_goal_mode/README.md
@@ -18,10 +18,14 @@ The installer writes:
 - `~/.config/opencode/loopx/goal-bridge-runtime.mjs` for the tested runtime;
 - pinned bridge dependencies in `~/.config/opencode/package.json`.
 
+OpenCode runs `bun install` for config-directory dependencies at startup, so
+the LoopX installer does not invoke a package manager. Restart OpenCode after
+installation so it installs the pinned dependencies and loads the bridge.
+
 Remove any direct `opencode-goal-plugin` entry from `opencode.json` or
 `opencode.jsonc` before installation. Loading the npm plugin and the LoopX local
 bridge together would create two independent goal runtimes, so installation
-fails closed while that conflict exists. Restart OpenCode after installation.
+fails closed while that conflict exists.
 
 ## Goal start
 

--- a/loopx/opencode_goal_mode/__init__.py
+++ b/loopx/opencode_goal_mode/__init__.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from importlib import resources
+
+
+def plugin_source() -> str:
+    return resources.files(__package__).joinpath("loopx-goal.js").read_text(encoding="utf-8")
+
+
+def runtime_source() -> str:
+    return resources.files(__package__).joinpath("goal-bridge-runtime.mjs").read_text(
+        encoding="utf-8"
+    )

--- a/loopx/opencode_goal_mode/goal-bridge-runtime.mjs
+++ b/loopx/opencode_goal_mode/goal-bridge-runtime.mjs
@@ -1,0 +1,662 @@
+// <!-- loopx-managed-slash-command:v1 command=/goal surface=opencode-runtime -->
+import { execFile as execFileCallback } from "node:child_process"
+import { promises as fs } from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { promisify } from "node:util"
+
+
+const execFile = promisify(execFileCallback)
+const BRIDGE_SCHEMA_VERSION = "loopx_opencode_goal_bridge_v0"
+const TERMINAL_STATE_SCHEMA_VERSION = "goal_terminal_state_v0"
+const SOURCE_COMPLETENESS_SCHEMA_VERSION = "goal_terminal_source_completeness_v0"
+const DEFAULT_RETRY_MINUTES = 3
+const LOOPX_GOAL_LIMITS = {
+  maxTurns: 10000,
+  maxDurationMs: 30 * 24 * 60 * 60 * 1000,
+  maxTokens: 1_000_000_000,
+}
+
+
+function sessionIDFromEvent(event) {
+  return (
+    event?.properties?.sessionID ||
+    event?.properties?.info?.sessionID ||
+    event?.data?.sessionID ||
+    event?.data?.info?.sessionID ||
+    null
+  )
+}
+
+
+function isIdleEvent(event) {
+  return (
+    event?.type === "session.idle" ||
+    (event?.type === "session.status" && event?.properties?.status?.type === "idle")
+  )
+}
+
+
+function shouldPauseForHostEvent(event) {
+  if (event?.type === "session.error") return true
+  if (event?.type !== "permission.replied") return false
+  const reply = String(
+    event?.properties?.reply ??
+      event?.properties?.response ??
+      event?.data?.reply ??
+      event?.data?.response ??
+      "",
+  )
+  return /^(?:reject(?:ed)?|deny|denied)$/i.test(reply)
+}
+
+
+function textFromParts(parts) {
+  return (parts || [])
+    .filter((part) => part?.type === "text" && !part?.ignored)
+    .map((part) => part.text || "")
+    .join("\n")
+    .trim()
+}
+
+
+function parseToolResult(value) {
+  if (typeof value !== "string") return null
+  try {
+    return JSON.parse(value)
+  } catch {
+    return null
+  }
+}
+
+
+function toolResultSucceeded(value) {
+  const parsed = parseToolResult(value)
+  return parsed?.ok === true || (typeof value === "string" && /^Goal (?:cleared|completed)/i.test(value))
+}
+
+
+function toolResultHasError(value, error) {
+  const parsed = parseToolResult(value)
+  return parsed?.ok === false && parsed?.error === error
+}
+
+
+function sanitizedSessionID(sessionID) {
+  const value = String(sessionID || "").replace(/[^A-Za-z0-9_-]/g, "_")
+  if (!value) throw new Error("OpenCode session id is required")
+  return value.slice(0, 160)
+}
+
+
+function defaultStateRoot() {
+  if (process.env.LOOPX_OPENCODE_STATE_DIR) {
+    return path.resolve(process.env.LOOPX_OPENCODE_STATE_DIR)
+  }
+  const xdgState = process.env.XDG_STATE_HOME || path.join(os.homedir(), ".local", "state")
+  return path.join(xdgState, "loopx", "opencode")
+}
+
+
+export function createFileBindingStore({ root = defaultStateRoot() } = {}) {
+  const target = (sessionID) => path.join(root, `${sanitizedSessionID(sessionID)}.json`)
+  return {
+    async read(sessionID) {
+      try {
+        const payload = JSON.parse(await fs.readFile(target(sessionID), "utf8"))
+        if (payload?.schemaVersion !== BRIDGE_SCHEMA_VERSION || payload?.sessionID !== sessionID) {
+          throw new Error("invalid LoopX OpenCode binding")
+        }
+        return payload
+      } catch (error) {
+        if (error?.code === "ENOENT") return null
+        throw error
+      }
+    },
+    async write(sessionID, binding) {
+      await fs.mkdir(root, { recursive: true, mode: 0o700 })
+      const destination = target(sessionID)
+      const temporary = `${destination}.${process.pid}.${Date.now()}.tmp`
+      const payload = {
+        schemaVersion: BRIDGE_SCHEMA_VERSION,
+        sessionID,
+        ...binding,
+        updatedAt: new Date().toISOString(),
+      }
+      await fs.writeFile(temporary, `${JSON.stringify(payload, null, 2)}\n`, {
+        encoding: "utf8",
+        mode: 0o600,
+      })
+      await fs.rename(temporary, destination)
+      await fs.chmod(destination, 0o600)
+      return payload
+    },
+    async remove(sessionID) {
+      try {
+        await fs.unlink(target(sessionID))
+      } catch (error) {
+        if (error?.code !== "ENOENT") throw error
+      }
+    },
+  }
+}
+
+
+export async function probeLoopxQuota(binding, { directory, execFileImpl = execFile } = {}) {
+  const args = []
+  if (binding.registryPath) args.push("--registry", binding.registryPath)
+  args.push(
+    "--format",
+    "json",
+    "quota",
+    "should-run",
+    "--goal-id",
+    binding.goalId,
+    "--runtime-profile",
+    "generic_cli",
+    "--include-scheduler-detail",
+  )
+  if (binding.agentId) args.push("--agent-id", binding.agentId)
+  for (const capability of binding.availableCapabilities || []) {
+    args.push("--available-capability", capability)
+  }
+  const { stdout } = await execFileImpl(process.env.LOOPX_BIN || "loopx", args, {
+    cwd: binding.directory || directory,
+    timeout: 20_000,
+    maxBuffer: 4 * 1024 * 1024,
+  })
+  const decision = JSON.parse(stdout || "{}")
+  if (!decision || typeof decision !== "object" || Array.isArray(decision)) {
+    throw new Error("loopx quota should-run returned a non-object payload")
+  }
+  return decision
+}
+
+
+export function isTerminalNoFollowup(decision) {
+  const frontier = decision?.goal_frontier_projection
+  const terminal = frontier?.terminal_state
+  const completeness = frontier?.source_completeness
+  return Boolean(
+    decision?.should_run === false &&
+      decision?.effective_action === "terminal_no_followup" &&
+      terminal?.schema_version === TERMINAL_STATE_SCHEMA_VERSION &&
+      terminal?.kind === "no_followup" &&
+      terminal?.derived === true &&
+      terminal?.source === "validated_goal_closure" &&
+      completeness?.schema_version === SOURCE_COMPLETENESS_SCHEMA_VERSION &&
+      completeness?.user_todos === "valid" &&
+      completeness?.agent_todos === "valid",
+  )
+}
+
+
+function shouldRunNow(decision) {
+  return decision?.scheduler_hint?.action === "run_now" || decision?.should_run === true
+}
+
+
+function waitPlan(decision, binding) {
+  const local = decision?.scheduler_hint?.unchanged_poll?.local_scheduler
+  if (!local || local === "stop") return { stop: true }
+  const token = decision?.scheduler_hint?.reset_policy?.reset_token || ""
+  const sameIdentity = token && token === binding.schedulerToken
+  const unchangedPolls = sameIdentity ? Number(binding.unchangedPolls || 0) : 0
+  const limit = Number.isInteger(local.unchanged_poll_limit) ? local.unchanged_poll_limit : null
+  if (limit !== null && unchangedPolls >= limit) return { stop: true }
+  const progression = Array.isArray(local.example_progression_minutes)
+    ? local.example_progression_minutes.filter((value) => Number(value) > 0)
+    : []
+  const fallback = Number(local.recommended_interval_minutes || DEFAULT_RETRY_MINUTES)
+  const minutes = progression.length
+    ? Number(progression[Math.min(unchangedPolls, progression.length - 1)])
+    : fallback
+  return {
+    stop: false,
+    minutes: Number.isFinite(minutes) && minutes > 0 ? minutes : DEFAULT_RETRY_MINUTES,
+    schedulerToken: token,
+    unchangedPolls: unchangedPolls + 1,
+  }
+}
+
+
+function toolContext(context, sessionID) {
+  return {
+    sessionID,
+    directory: context.directory,
+    worktree: context.worktree,
+  }
+}
+
+
+async function executeTool(definition, args, context) {
+  if (!definition || typeof definition.execute !== "function") {
+    throw new Error("required opencode-goal-plugin tool is unavailable")
+  }
+  return definition.execute(args, context)
+}
+
+
+function commandKind(argumentsText) {
+  const normalized = String(argumentsText || "").trim().toLowerCase()
+  if (!normalized || normalized === "status" || normalized === "history" || normalized === "list") {
+    return "inspect"
+  }
+  if (["clear", "stop", "off", "reset", "none", "cancel"].includes(normalized)) return "clear"
+  if (normalized === "resume") return "resume"
+  if (normalized === "pause") return "pause"
+  if (normalized.startsWith("edit ")) return "edit"
+  return "replace"
+}
+
+
+export function createLoopxGoalPlugin({
+  GoalPlugin,
+  tool,
+  bindingStore = createFileBindingStore(),
+  quotaProbe = probeLoopxQuota,
+  setTimer = setTimeout,
+  clearTimer = clearTimeout,
+} = {}) {
+  if (typeof GoalPlugin !== "function") throw new Error("GoalPlugin factory is required")
+  if (typeof tool !== "function" || !tool.schema) throw new Error("OpenCode tool helper is required")
+
+  return async function LoopXGoalPlugin(context) {
+    const timers = new Map()
+    const evaluations = new Map()
+    const pendingGoalCommands = new Map()
+    const initializedSessions = new Set()
+
+    const log = async (level, message, extra = {}) => {
+      try {
+        await context.client?.app?.log?.({
+          body: { service: "loopx-opencode-goal", level, message, extra },
+        })
+      } catch {
+        // Logging must never change the continuation policy.
+      }
+    }
+
+    const cancelScheduled = (sessionID) => {
+      const timer = timers.get(sessionID)
+      if (timer !== undefined) clearTimer(timer)
+      timers.delete(sessionID)
+    }
+
+    const readBinding = async (sessionID) => bindingStore.read(sessionID)
+    const updateBinding = async (sessionID, changes) => {
+      const current = await readBinding(sessionID)
+      if (!current) return null
+      return bindingStore.write(sessionID, { ...current, ...changes })
+    }
+
+    const auditor = async ({ sessionID }) => {
+      const binding = await readBinding(sessionID)
+      if (!binding) return { approved: true }
+      try {
+        const decision = await quotaProbe(binding, { directory: context.directory })
+        return isTerminalNoFollowup(decision)
+          ? { approved: true }
+          : {
+              approved: false,
+              reason: "LoopX has not derived terminal no-follow-up from a complete empty frontier.",
+            }
+      } catch (error) {
+        return {
+          approved: false,
+          reason: `LoopX terminal audit unavailable: ${error?.message || String(error)}`,
+        }
+      }
+    }
+
+    const base = await GoalPlugin(context, { auditor })
+    const baseTools = base.tool || {}
+    const baseGoalSet = baseTools.goal_set
+    const baseGoalResume = baseTools.goal_resume
+    const baseGoalComplete = baseTools.goal_complete
+    const baseEvent = base.event
+    const baseChatMessage = base["chat.message"]
+    const baseCommand = base["command.execute.before"]
+
+    const completeTerminalGoal = async (sessionID, binding, decision) => {
+      try {
+        const reason = String(decision?.reason || "LoopX validated an empty terminal frontier.")
+        const result = await executeTool(
+          baseGoalComplete,
+          {
+            summary: "LoopX validated terminal no-follow-up.",
+            criteria: [
+              {
+                criterion: "LoopX reports validated goal closure with no remaining follow-up.",
+                evidence: [reason],
+              },
+            ],
+          },
+          toolContext(context, sessionID),
+        )
+        if (toolResultSucceeded(result) || toolResultHasError(result, "no_active_goal")) {
+          await bindingStore.remove(sessionID)
+          cancelScheduled(sessionID)
+          await log("info", "LoopX terminal frontier completed the OpenCode goal", {
+            goalId: binding.goalId,
+            sessionID,
+          })
+          return
+        }
+        await log("warn", "OpenCode goal completion was rejected after LoopX terminal state", {
+          goalId: binding.goalId,
+          sessionID,
+        })
+      } catch (error) {
+        await log("error", "OpenCode goal completion failed", {
+          goalId: binding.goalId,
+          sessionID,
+          error: error?.message || String(error),
+        })
+      }
+    }
+
+    const scheduleEvaluation = (sessionID, minutes) => {
+      cancelScheduled(sessionID)
+      const timer = setTimer(async () => {
+        timers.delete(sessionID)
+        try {
+          await evaluateIdle(sessionID, {
+            event: { type: "session.idle", properties: { sessionID } },
+          })
+        } catch (error) {
+          await log("error", "Scheduled LoopX quota evaluation failed closed", {
+            sessionID,
+            error: error?.message || String(error),
+          })
+        }
+      }, Math.max(1, minutes) * 60_000)
+      if (typeof timer?.unref === "function") timer.unref()
+      timers.set(sessionID, timer)
+    }
+
+    const evaluateIdleOnce = async (sessionID, input) => {
+      let binding
+      try {
+        binding = await readBinding(sessionID)
+      } catch (error) {
+        cancelScheduled(sessionID)
+        await log("error", "Invalid LoopX OpenCode binding; continuation failed closed", {
+          sessionID,
+          error: error?.message || String(error),
+        })
+        return
+      }
+      if (!binding) {
+        await baseEvent?.(input)
+        return
+      }
+      if (binding.autoResume === false) {
+        cancelScheduled(sessionID)
+        return
+      }
+
+      let decision
+      try {
+        decision = await quotaProbe(binding, { directory: context.directory })
+      } catch (error) {
+        await log("warn", "LoopX quota probe failed closed; scheduling a bounded retry", {
+          goalId: binding.goalId,
+          sessionID,
+          error: error?.message || String(error),
+        })
+        scheduleEvaluation(sessionID, DEFAULT_RETRY_MINUTES)
+        return
+      }
+
+      const currentBinding = await readBinding(sessionID)
+      if (
+        !currentBinding ||
+        currentBinding.autoResume === false ||
+        currentBinding.goalId !== binding.goalId
+      ) {
+        cancelScheduled(sessionID)
+        return
+      }
+      binding = currentBinding
+
+      if (isTerminalNoFollowup(decision)) {
+        await completeTerminalGoal(sessionID, binding, decision)
+        return
+      }
+
+      if (shouldRunNow(decision)) {
+        cancelScheduled(sessionID)
+        await bindingStore.write(sessionID, {
+          ...binding,
+          schedulerToken: "",
+          unchangedPolls: 0,
+        })
+        if (!initializedSessions.has(sessionID)) {
+          initializedSessions.add(sessionID)
+          try {
+            await executeTool(baseGoalResume, {}, toolContext(context, sessionID))
+          } catch (error) {
+            await log("warn", "OpenCode goal resume probe failed before continuation", {
+              goalId: binding.goalId,
+              sessionID,
+              error: error?.message || String(error),
+            })
+          }
+        }
+        await baseEvent?.(input)
+        return
+      }
+
+      const wait = waitPlan(decision, binding)
+      if (wait.stop) {
+        cancelScheduled(sessionID)
+        await log("info", "LoopX unchanged-poll limit stopped the OpenCode timer", {
+          goalId: binding.goalId,
+          sessionID,
+        })
+        return
+      }
+      await bindingStore.write(sessionID, {
+        ...binding,
+        schedulerToken: wait.schedulerToken,
+        unchangedPolls: wait.unchangedPolls,
+      })
+      scheduleEvaluation(sessionID, wait.minutes)
+    }
+
+    const evaluateIdle = (sessionID, input) => {
+      const existing = evaluations.get(sessionID)
+      if (existing) return existing
+      const evaluation = evaluateIdleOnce(sessionID, input).finally(() => {
+        if (evaluations.get(sessionID) === evaluation) evaluations.delete(sessionID)
+      })
+      evaluations.set(sessionID, evaluation)
+      return evaluation
+    }
+
+    const activateTool = tool({
+      description:
+        "Activate a LoopX-backed OpenCode goal after LoopX start-goal has written todos and produced a heartbeat task_body.",
+      args: {
+        goalId: tool.schema.string(),
+        objective: tool.schema.string(),
+        agentId: tool.schema.string().optional(),
+        registryPath: tool.schema.string().optional(),
+        availableCapabilities: tool.schema.array(tool.schema.string()).optional(),
+      },
+      async execute(args, toolCtx) {
+        const sessionID = toolCtx?.sessionID || toolCtx?.session_id || toolCtx?.session?.id
+        if (!sessionID) {
+          return JSON.stringify({
+            version: 1,
+            operation: "loopx_activate",
+            ok: false,
+            error: "missing_session",
+            message: "No OpenCode session id is available.",
+          })
+        }
+        const result = await executeTool(
+          baseGoalSet,
+          {
+            objective: args.objective,
+            successCriteria:
+              "LoopX derives terminal no-follow-up from complete todo sources and an empty frontier.",
+            constraints:
+              "Run every continuation through LoopX quota should-run and do not self-declare terminal closure.",
+            ...LOOPX_GOAL_LIMITS,
+          },
+          toolCtx,
+        )
+        if (!toolResultSucceeded(result)) return result
+        const binding = await bindingStore.write(sessionID, {
+          directory: context.directory,
+          goalId: String(args.goalId),
+          agentId: args.agentId ? String(args.agentId) : "",
+          registryPath: args.registryPath ? String(args.registryPath) : "",
+          availableCapabilities: Array.isArray(args.availableCapabilities)
+            ? args.availableCapabilities.map(String)
+            : [],
+          autoResume: true,
+          schedulerToken: "",
+          unchangedPolls: 0,
+        })
+        initializedSessions.add(sessionID)
+        cancelScheduled(sessionID)
+        return JSON.stringify({
+          version: 1,
+          operation: "loopx_activate",
+          ok: true,
+          message: "LoopX-backed OpenCode goal activated.",
+          data: { goalId: binding.goalId, sessionID },
+        })
+      },
+    })
+
+    const tools = { ...baseTools, loopx_goal_activate: activateTool }
+
+    const wrapTool = (name, after) => {
+      const original = tools[name]
+      if (!original || typeof original.execute !== "function") return
+      tools[name] = {
+        ...original,
+        execute: async (args, toolCtx) => {
+          const result = await original.execute(args, toolCtx)
+          const sessionID = toolCtx?.sessionID || toolCtx?.session_id || toolCtx?.session?.id
+          if (sessionID) await after(sessionID, args || {}, result)
+          return result
+        },
+      }
+    }
+
+    for (const name of ["goal_set", "set_goal"]) {
+      wrapTool(name, async (sessionID, _args, result) => {
+        if (toolResultSucceeded(result)) await bindingStore.remove(sessionID)
+      })
+    }
+    for (const name of ["goal_complete", "clear_goal"]) {
+      wrapTool(name, async (sessionID, _args, result) => {
+        if (toolResultSucceeded(result)) {
+          await bindingStore.remove(sessionID)
+          cancelScheduled(sessionID)
+        }
+      })
+    }
+    wrapTool("goal_resume", async (sessionID, _args, result) => {
+      if (toolResultSucceeded(result)) {
+        await updateBinding(sessionID, { autoResume: true })
+        initializedSessions.add(sessionID)
+      }
+    })
+    for (const name of ["goal_pause", "goal_block"]) {
+      wrapTool(name, async (sessionID, _args, result) => {
+        if (toolResultSucceeded(result)) {
+          await updateBinding(sessionID, { autoResume: false })
+          cancelScheduled(sessionID)
+        }
+      })
+    }
+
+    return {
+      ...base,
+      tool: tools,
+      config: async (config) => {
+        if (config && typeof config === "object") {
+          config.command ||= {}
+          config.command.goal ||= {
+            description: "Set a session-scoped goal and auto-continue until complete.",
+            template: "$ARGUMENTS",
+            agent: "build",
+          }
+        }
+        await base.config?.(config)
+      },
+      "command.execute.before": async (input, output) => {
+        await baseCommand?.(input, output)
+        if (input?.command !== "goal" || !input?.sessionID) return
+        const sessionID = input.sessionID
+        const args = String(input.arguments || "").trim()
+        pendingGoalCommands.set(sessionID, { args, recordedAt: Date.now() })
+        const kind = commandKind(args)
+        if (kind === "clear" || kind === "replace") {
+          await bindingStore.remove(sessionID)
+          cancelScheduled(sessionID)
+        } else if (kind === "resume") {
+          await updateBinding(sessionID, { autoResume: true })
+          initializedSessions.add(sessionID)
+        } else if (kind === "pause") {
+          await updateBinding(sessionID, { autoResume: false })
+          cancelScheduled(sessionID)
+        }
+      },
+      "chat.message": async (input, output) => {
+        const sessionID = input?.sessionID
+        if (!sessionID) {
+          await baseChatMessage?.(input, output)
+          return
+        }
+        const pending = pendingGoalCommands.get(sessionID)
+        if (pending) {
+          pendingGoalCommands.delete(sessionID)
+          const reflected = textFromParts(output?.parts)
+          if (Date.now() - pending.recordedAt < 10_000 && reflected === pending.args) {
+            return
+          }
+        }
+        const text = textFromParts(output?.parts)
+        if (text === "/goal" || text.startsWith("/goal ")) {
+          await baseChatMessage?.(input, output)
+          return
+        }
+        const binding = await readBinding(sessionID)
+        if (binding) {
+          await bindingStore.write(sessionID, { ...binding, autoResume: false })
+          cancelScheduled(sessionID)
+        }
+        await baseChatMessage?.(input, output)
+      },
+      event: async (input) => {
+        const event = input?.event
+        const sessionID = sessionIDFromEvent(event)
+        if (!isIdleEvent(event)) {
+          if (sessionID && event?.type === "session.deleted") {
+            await bindingStore.remove(sessionID)
+            cancelScheduled(sessionID)
+          } else if (sessionID && shouldPauseForHostEvent(event)) {
+            await updateBinding(sessionID, { autoResume: false })
+            cancelScheduled(sessionID)
+          }
+          await baseEvent?.(input)
+          return
+        }
+        if (sessionID) await evaluateIdle(sessionID, input)
+      },
+      dispose: async () => {
+        for (const timer of timers.values()) clearTimer(timer)
+        timers.clear()
+        evaluations.clear()
+        await base.dispose?.()
+      },
+    }
+  }
+}

--- a/loopx/opencode_goal_mode/goal-bridge-runtime.mjs
+++ b/loopx/opencode_goal_mode/goal-bridge-runtime.mjs
@@ -266,6 +266,7 @@ export function createLoopxGoalPlugin({
     const evaluations = new Map()
     const pendingGoalCommands = new Map()
     const initializedSessions = new Set()
+    let disposed = false
 
     const log = async (level, message, extra = {}) => {
       try {
@@ -357,9 +358,11 @@ export function createLoopxGoalPlugin({
     }
 
     const scheduleEvaluation = (sessionID, minutes) => {
+      if (disposed) return
       cancelScheduled(sessionID)
       const timer = setTimer(async () => {
         timers.delete(sessionID)
+        if (disposed) return
         try {
           await evaluateIdle(sessionID, {
             event: { type: "session.idle", properties: { sessionID } },
@@ -376,6 +379,7 @@ export function createLoopxGoalPlugin({
     }
 
     const evaluateIdleOnce = async (sessionID, input) => {
+      if (disposed) return
       let binding
       try {
         binding = await readBinding(sessionID)
@@ -408,6 +412,7 @@ export function createLoopxGoalPlugin({
         scheduleEvaluation(sessionID, DEFAULT_RETRY_MINUTES)
         return
       }
+      if (disposed) return
 
       const currentBinding = await readBinding(sessionID)
       if (
@@ -444,6 +449,7 @@ export function createLoopxGoalPlugin({
             })
           }
         }
+        if (disposed) return
         await baseEvent?.(input)
         return
       }
@@ -466,6 +472,7 @@ export function createLoopxGoalPlugin({
     }
 
     const evaluateIdle = (sessionID, input) => {
+      if (disposed) return Promise.resolve()
       const existing = evaluations.get(sessionID)
       if (existing) return existing
       const evaluation = evaluateIdleOnce(sessionID, input).finally(() => {
@@ -652,6 +659,7 @@ export function createLoopxGoalPlugin({
         if (sessionID) await evaluateIdle(sessionID, input)
       },
       dispose: async () => {
+        disposed = true
         for (const timer of timers.values()) clearTimer(timer)
         timers.clear()
         evaluations.clear()

--- a/loopx/opencode_goal_mode/loopx-goal.js
+++ b/loopx/opencode_goal_mode/loopx-goal.js
@@ -1,0 +1,8 @@
+// <!-- loopx-managed-slash-command:v1 command=/goal surface=opencode-plugin -->
+import { tool } from "@opencode-ai/plugin"
+import { GoalPlugin } from "opencode-goal-plugin"
+
+import { createLoopxGoalPlugin } from "../loopx/goal-bridge-runtime.mjs"
+
+
+export const LoopXGoalPlugin = createLoopxGoalPlugin({ GoalPlugin, tool })

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -425,7 +425,7 @@ def _normalize_surfaces(surfaces: list[str] | None) -> list[str]:
     normalized: list[str] = []
     for surface in requested:
         if surface == "all":
-            candidates = ["codex", "claude-code"]
+            candidates = ["codex", "claude-code", "opencode"]
         elif surface == "codex":
             candidates = ["codex"]
         elif surface in {"codex-app", "codex-ide-plugin", "codex-ide", "codex-cli"}:
@@ -442,6 +442,7 @@ def install_slash_commands(
     *,
     execute: bool,
     uninstall: bool = False,
+    with_goal_bridge: bool = False,
     surfaces: list[str] | None = None,
     cli_bin: str = "loopx",
     include_legacy_aliases: bool = True,
@@ -455,6 +456,20 @@ def install_slash_commands(
     claude_root = _claude_home(claude_home)
     opencode_root = _opencode_home(opencode_home)
     installed: list[dict[str, Any]] = []
+
+    if with_goal_bridge and "opencode" not in effective_surfaces:
+        installed.append(
+            {
+                "surface": "opencode",
+                "host_surfaces": ["opencode"],
+                "mechanism": "opencode_goal_bridge",
+                "command": "/goal",
+                "path": None,
+                "status": "blocked_goal_bridge_requires_opencode_surface",
+                "invoke_as": [],
+                "reason": "Select --surface opencode when using --with-goal-bridge.",
+            }
+        )
 
     if "codex" in effective_surfaces:
         prompt_dir = codex_root / "prompts"
@@ -639,60 +654,12 @@ def install_slash_commands(
 
     if "opencode" in effective_surfaces:
         commands_dir = opencode_root / "commands"
-        for spec in specs:
-            path = commands_dir / f"{spec['name']}.md"
-            status = (
-                _retire_status(path, execute=execute)
-                if uninstall
-                else _target_status(
-                    path,
-                    _opencode_command_body(spec),
-                    execute=execute,
-                )
-            )
-            installed.append(
-                {
-                    "surface": "opencode",
-                    "host_surfaces": ["opencode"],
-                    "mechanism": "opencode_commands",
-                    "command": spec["command"],
-                    "path": str(path),
-                    "status": status,
-                    "invoke_as": [str(spec["command"])],
-                }
-            )
-
         plugin_path = opencode_root / "plugins" / "loopx-goal.js"
         runtime_path = opencode_root / "loopx" / "goal-bridge-runtime.mjs"
         package_path = opencode_root / "package.json"
-        if uninstall:
-            for mechanism, path in (
-                ("opencode_goal_bridge", plugin_path),
-                ("opencode_goal_bridge_runtime", runtime_path),
-            ):
-                installed.append(
-                    {
-                        "surface": "opencode",
-                        "host_surfaces": ["opencode"],
-                        "mechanism": mechanism,
-                        "command": "/goal",
-                        "path": str(path),
-                        "status": _retire_status(path, execute=execute),
-                        "invoke_as": ["/goal", "loopx_goal_activate"],
-                    }
-                )
-            installed.append(
-                {
-                    "surface": "opencode",
-                    "host_surfaces": ["opencode"],
-                    "mechanism": "opencode_goal_dependencies",
-                    "command": "/goal",
-                    "path": str(package_path),
-                    "status": "preserved_shared_dependencies",
-                    "invoke_as": [],
-                }
-            )
-        else:
+
+        bridge_preflight_blocked = False
+        if with_goal_bridge and not uninstall:
             conflicts, invalid_configs = _opencode_direct_goal_plugin_conflicts(opencode_root)
             if invalid_configs:
                 installed.append(
@@ -711,6 +678,7 @@ def install_slash_commands(
                         "invalid_configs": invalid_configs,
                     }
                 )
+                bridge_preflight_blocked = True
             elif conflicts:
                 installed.append(
                     {
@@ -727,6 +695,55 @@ def install_slash_commands(
                             "the pinned plugin and both must not be loaded independently."
                         ),
                         "conflicts": conflicts,
+                    }
+                )
+                bridge_preflight_blocked = True
+            else:
+                package_status = _target_package_dependencies(
+                    package_path,
+                    OPENCODE_GOAL_DEPENDENCIES,
+                    execute=False,
+                )
+                if package_status == "blocked_invalid_user_package_json":
+                    installed.append(
+                        {
+                            "surface": "opencode",
+                            "host_surfaces": ["opencode"],
+                            "mechanism": "opencode_goal_dependencies",
+                            "command": "/goal",
+                            "path": str(package_path),
+                            "status": package_status,
+                            "invoke_as": [],
+                        }
+                    )
+                    bridge_preflight_blocked = True
+
+        if with_goal_bridge and not bridge_preflight_blocked:
+            if uninstall:
+                for mechanism, path in (
+                    ("opencode_goal_bridge", plugin_path),
+                    ("opencode_goal_bridge_runtime", runtime_path),
+                ):
+                    installed.append(
+                        {
+                            "surface": "opencode",
+                            "host_surfaces": ["opencode"],
+                            "mechanism": mechanism,
+                            "command": "/goal",
+                            "path": str(path),
+                            "status": _retire_status(path, execute=execute),
+                            "invoke_as": ["/goal", "loopx_goal_activate"],
+                        }
+                    )
+                installed.append(
+                    {
+                        "surface": "opencode",
+                        "host_surfaces": ["opencode"],
+                        "mechanism": "opencode_goal_dependencies",
+                        "command": "/goal",
+                        "path": str(package_path),
+                        "status": "preserved_shared_dependencies",
+                        "invoke_as": [],
                     }
                 )
             else:
@@ -747,17 +764,7 @@ def install_slash_commands(
                     }
                 )
                 if package_status == "blocked_invalid_user_package_json":
-                    installed.append(
-                        {
-                            "surface": "opencode",
-                            "host_surfaces": ["opencode"],
-                            "mechanism": "opencode_goal_bridge",
-                            "command": "/goal",
-                            "path": str(plugin_path),
-                            "status": package_status,
-                            "invoke_as": [],
-                        }
-                    )
+                    bridge_preflight_blocked = True
                 else:
                     for mechanism, path, content in (
                         ("opencode_goal_bridge_runtime", runtime_path, runtime_source()),
@@ -775,6 +782,30 @@ def install_slash_commands(
                             }
                         )
 
+        if not bridge_preflight_blocked:
+            for spec in specs:
+                path = commands_dir / f"{spec['name']}.md"
+                status = (
+                    _retire_status(path, execute=execute)
+                    if uninstall
+                    else _target_status(
+                        path,
+                        _opencode_command_body(spec),
+                        execute=execute,
+                    )
+                )
+                installed.append(
+                    {
+                        "surface": "opencode",
+                        "host_surfaces": ["opencode"],
+                        "mechanism": "opencode_commands",
+                        "command": spec["command"],
+                        "path": str(path),
+                        "status": status,
+                        "invoke_as": [str(spec["command"])],
+                    }
+                )
+
     status_counts: dict[str, int] = {}
     for item in installed:
         status = str(item["status"])
@@ -785,6 +816,7 @@ def install_slash_commands(
         "schema_version": SCHEMA_VERSION,
         "operation": "uninstall" if uninstall else "install",
         "execute": execute,
+        "with_goal_bridge": with_goal_bridge,
         "requested_surfaces": surfaces or ["all"],
         "effective_surfaces": effective_surfaces,
         "catalog_schema_version": build_slash_command_catalog(
@@ -796,8 +828,8 @@ def install_slash_commands(
             "codex_skill_dir": str(codex_root / "skills") if "codex" in effective_surfaces else None,
             "claude_skill_dir": str(claude_root / "skills") if "claude-code" in effective_surfaces else None,
             "opencode_command_dir": str(opencode_root / "commands") if "opencode" in effective_surfaces else None,
-            "opencode_plugin_path": str(opencode_root / "plugins" / "loopx-goal.js") if "opencode" in effective_surfaces else None,
-            "opencode_package_path": str(opencode_root / "package.json") if "opencode" in effective_surfaces else None,
+            "opencode_plugin_path": str(opencode_root / "plugins" / "loopx-goal.js") if "opencode" in effective_surfaces and with_goal_bridge else None,
+            "opencode_package_path": str(opencode_root / "package.json") if "opencode" in effective_surfaces and with_goal_bridge else None,
             "status_counts": status_counts,
             "skip_policy": (
                 "Uninstall removes only LoopX-managed files; user files without a LoopX managed marker are preserved"
@@ -810,8 +842,9 @@ def install_slash_commands(
             "Codex does not currently support user-defined native top-level slash commands; use explicit skill invocation through `$loopx` or `/skills`.",
             "Explicit LoopX command-facade skills use agents/openai.yaml policy allow_implicit_invocation=false and remain distinct from richer workflow skills such as loopx-project.",
             "Claude Code discovers user skills from CLAUDE_HOME/skills and exposes each skill name as a slash command.",
-            "OpenCode is opt-in through --surface opencode; it discovers commands and local plugins from its config directory, installs package.json dependencies with Bun at startup, and requires the LoopX bridge to replace any direct goal-plugin registration.",
-            "OpenCode uninstall preserves package.json dependencies because they may be shared by user-owned local plugins.",
+            "The default all surface installs only OpenCode's static command facade; the executable goal bridge requires --with-goal-bridge.",
+            "The OpenCode goal bridge uses Bun-managed config-directory dependencies and must replace any direct goal-plugin registration.",
+            "OpenCode bridge uninstall preserves package.json dependencies because they may be shared by user-owned local plugins.",
             "Uninstall is fail-closed: it retires only files carrying the LoopX managed marker and leaves user-owned files in place.",
         ],
     }

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 from typing import Any
 
+from .opencode_goal_mode import plugin_source, runtime_source
 from .slash_commands import build_slash_command_catalog
 
 
@@ -18,6 +20,10 @@ EXISTING_LOOPX_CAPABILITY_SKILL_SIGNATURES = (
     "# LoopX PR Review",
     "Run `loopx pr-review` first",
 )
+OPENCODE_GOAL_DEPENDENCIES = {
+    "@opencode-ai/plugin": ">=1.17.15 <2",
+    "opencode-goal-plugin": "0.6.5",
+}
 
 
 def _managed_marker(*, command: str, surface: str) -> str:
@@ -76,6 +82,31 @@ def _openai_skill_metadata(*, command: str, display_name: str, short_description
     )
 
 
+def _opencode_command_body(spec: dict[str, Any]) -> str:
+    return "\n\n".join(
+        [
+            _front_matter(
+                fields={
+                    "description": str(spec["description"]),
+                    "agent": "build",
+                }
+            ),
+            _managed_marker(command=str(spec["command"]), surface="opencode-command"),
+            f"Treat this as the LoopX `{spec['command']}` OpenCode command.",
+            (
+                "The exact current host is OpenCode. For goal start, pass "
+                "`--host-surface opencode` and use `loopx_goal_activate` from the "
+                "returned host-loop activation packet."
+            ),
+            "\n".join(str(item) for item in spec["instructions"]),
+            (
+                "Keep public/private boundaries intact and do not perform external "
+                "writes unless the active LoopX state or owner explicitly authorizes them."
+            ),
+        ]
+    ) + "\n"
+
+
 def _command_prompt_specs(*, cli_bin: str, include_legacy_aliases: bool) -> list[dict[str, Any]]:
     specs: list[dict[str, Any]] = [
         {
@@ -85,14 +116,14 @@ def _command_prompt_specs(*, cli_bin: str, include_legacy_aliases: bool) -> list
             "argument_hint": "[task text]",
             "instructions": [
                 "Visible command arguments: `$ARGUMENTS`.",
-                "Before start-goal, identify the exact current host: use `codex-app` for the desktop app, `codex-ide-plugin` only for the IDE plugin, or `codex-cli-tui` for the terminal TUI.",
+                "Before start-goal, identify the exact current host: use `codex-app` for the desktop app, `codex-ide-plugin` only for the IDE plugin, `codex-cli-tui` for the terminal TUI, or `opencode` for OpenCode.",
                 f"If arguments are present, preserve them as the task text and run `{cli_bin} start-goal --guided --project . --goal-text \"$ARGUMENTS\" --host-surface <exact-current-host>` before planning work. If the host is unclear, omit the flag once and follow the returned host-surface selection gate.",
                 f"If that packet exposes a goal-selection gate, rerun one exact choice before any mutation. When the user asks to create or become a new peer/meta/supervisor agent, do not reuse an existing registered identity: choose a new public-safe agent id, preview then apply `{cli_bin} register-agent --goal-id <selected-goal-id> --agent-id <new-agent-id> --execute`, and rerun start-goal with explicit `--goal-id` and `--agent-id` before todo writeback.",
                 f"If arguments are empty, inspect `{cli_bin} bootstrap-command-pack --project .`, `{cli_bin} status`, and `{cli_bin} slash-commands` before changing files.",
-                f"Use `{cli_bin} agent-onboard --list-agent-types` when the host runtime is unclear; pass an exact type such as `codex-app`, `codex-ide-plugin`, `codex-cli`, or `claude-code`, never ambiguous `codex`.",
+                f"Use `{cli_bin} agent-onboard --list-agent-types` when the host runtime is unclear; pass an exact type such as `codex-app`, `codex-ide-plugin`, `codex-cli`, `claude-code`, or `opencode`, never ambiguous `codex`.",
                 f"Do not configure optional features during first-run. Only when the task needs bounded child agents or Explore, inspect `{cli_bin} configure-goal --goal-id <resolved-goal-id>` and its `configuration_catalog`; preview before explicit apply and never auto-enable a feature merely because it exists.",
                 "When project work is started, plan ordered P0/P1/P2 todos, write them through LoopX todo state, refresh state, activate the host loop if missing/stale, run quota, and complete one bounded delivery segment through validation plus LoopX writeback or an exact blocker; do not return merely after setup, planning, or claim.",
-                "Host loop activation means Codex App heartbeat automation, Codex IDE plugin or CLI visible `/goal <task_body>`, Claude Code native `/loop`, or a custom host-loop gate from `loopx agent-onboard`.",
+                "Host loop activation means Codex App heartbeat automation, Codex IDE plugin or CLI visible `/goal <task_body>`, Claude Code native `/loop`, OpenCode `loopx_goal_activate`, or a custom host-loop gate from `loopx agent-onboard`.",
                 "If this session cannot mutate the host loop surface, surface the exact pasteable gate instead of saying LoopX is autonomously connected.",
             ],
         },
@@ -228,12 +259,173 @@ def _claude_home(value: str | None = None) -> Path:
     return Path(raw).expanduser()
 
 
+def _opencode_home(value: str | None = None) -> Path:
+    raw = value or os.environ.get("OPENCODE_CONFIG_DIR")
+    if not raw:
+        config_home = os.environ.get("XDG_CONFIG_HOME") or str(Path.home() / ".config")
+        raw = str(Path(config_home) / "opencode")
+    return Path(raw).expanduser()
+
+
+def _strip_jsonc_comments(content: str) -> str:
+    output: list[str] = []
+    index = 0
+    in_string = False
+    escaped = False
+    while index < len(content):
+        char = content[index]
+        next_char = content[index + 1] if index + 1 < len(content) else ""
+        if in_string:
+            output.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            index += 1
+            continue
+        if char == '"':
+            in_string = True
+            output.append(char)
+            index += 1
+            continue
+        if char == "/" and next_char == "/":
+            output.extend((" ", " "))
+            index += 2
+            while index < len(content) and content[index] not in "\r\n":
+                output.append(" ")
+                index += 1
+            continue
+        if char == "/" and next_char == "*":
+            output.extend((" ", " "))
+            index += 2
+            while index < len(content):
+                if index + 1 < len(content) and content[index : index + 2] == "*/":
+                    output.extend((" ", " "))
+                    index += 2
+                    break
+                output.append("\n" if content[index] == "\n" else " ")
+                index += 1
+            continue
+        output.append(char)
+        index += 1
+    return "".join(output)
+
+
+def _strip_jsonc_trailing_commas(content: str) -> str:
+    output: list[str] = []
+    index = 0
+    in_string = False
+    escaped = False
+    while index < len(content):
+        char = content[index]
+        if in_string:
+            output.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            index += 1
+            continue
+        if char == '"':
+            in_string = True
+            output.append(char)
+            index += 1
+            continue
+        if char == ",":
+            lookahead = index + 1
+            while lookahead < len(content) and content[lookahead].isspace():
+                lookahead += 1
+            if lookahead < len(content) and content[lookahead] in "]}":
+                index += 1
+                continue
+        output.append(char)
+        index += 1
+    return "".join(output)
+
+
+def _opencode_direct_goal_plugin_conflicts(root: Path) -> tuple[list[str], list[str]]:
+    conflicts: list[str] = []
+    invalid: list[str] = []
+    goal_plugins = {
+        "opencode-goal-plugin",
+        "@heimoshuiyu/opencode-goal-plugin",
+        "@prevalentware/opencode-goal-plugin",
+    }
+    for name in ("opencode.json", "opencode.jsonc"):
+        path = root / name
+        if not path.exists():
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+            if path.suffix == ".jsonc":
+                content = _strip_jsonc_trailing_commas(_strip_jsonc_comments(content))
+            payload = json.loads(content)
+        except (json.JSONDecodeError, OSError):
+            invalid.append(str(path))
+            continue
+        if not isinstance(payload, dict):
+            invalid.append(str(path))
+            continue
+        plugins = payload.get("plugin") or []
+        if isinstance(plugins, str):
+            plugins = [plugins]
+        if not isinstance(plugins, list):
+            invalid.append(str(path))
+            continue
+        if any(
+            str(plugin) == package or str(plugin).startswith(f"{package}@")
+            for plugin in plugins
+            for package in goal_plugins
+        ):
+            conflicts.append(str(path))
+    return conflicts, invalid
+
+
+def _target_package_dependencies(
+    path: Path,
+    dependencies: dict[str, str],
+    *,
+    execute: bool,
+) -> str:
+    if path.exists():
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return "blocked_invalid_user_package_json"
+        if not isinstance(payload, dict):
+            return "blocked_invalid_user_package_json"
+        current = payload.get("dependencies")
+        if current is None:
+            current = {}
+        if not isinstance(current, dict):
+            return "blocked_invalid_user_package_json"
+        wanted = {**current, **dependencies}
+        if wanted == current:
+            return "unchanged"
+        payload["dependencies"] = wanted
+        status = "updated" if execute else "would_update"
+    else:
+        payload = {"private": True, "dependencies": dependencies}
+        status = "created" if execute else "would_create"
+    if execute:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(payload, indent=2) + "\n",
+            encoding="utf-8",
+        )
+    return status
+
+
 def _normalize_surfaces(surfaces: list[str] | None) -> list[str]:
     requested = surfaces or ["all"]
     normalized: list[str] = []
     for surface in requested:
         if surface == "all":
-            candidates = ["codex", "claude-code"]
+            candidates = ["codex", "claude-code", "opencode"]
         elif surface == "codex":
             candidates = ["codex"]
         elif surface in {"codex-app", "codex-ide-plugin", "codex-ide", "codex-cli"}:
@@ -255,11 +447,13 @@ def install_slash_commands(
     include_legacy_aliases: bool = True,
     codex_home: str | None = None,
     claude_home: str | None = None,
+    opencode_home: str | None = None,
 ) -> dict[str, Any]:
     specs = _command_prompt_specs(cli_bin=cli_bin, include_legacy_aliases=include_legacy_aliases)
     effective_surfaces = _normalize_surfaces(surfaces)
     codex_root = _codex_home(codex_home)
     claude_root = _claude_home(claude_home)
+    opencode_root = _opencode_home(opencode_home)
     installed: list[dict[str, Any]] = []
 
     if "codex" in effective_surfaces:
@@ -443,13 +637,151 @@ def install_slash_commands(
                 }
             )
 
+    if "opencode" in effective_surfaces:
+        commands_dir = opencode_root / "commands"
+        for spec in specs:
+            path = commands_dir / f"{spec['name']}.md"
+            status = (
+                _retire_status(path, execute=execute)
+                if uninstall
+                else _target_status(
+                    path,
+                    _opencode_command_body(spec),
+                    execute=execute,
+                )
+            )
+            installed.append(
+                {
+                    "surface": "opencode",
+                    "host_surfaces": ["opencode"],
+                    "mechanism": "opencode_commands",
+                    "command": spec["command"],
+                    "path": str(path),
+                    "status": status,
+                    "invoke_as": [str(spec["command"])],
+                }
+            )
+
+        plugin_path = opencode_root / "plugins" / "loopx-goal.js"
+        runtime_path = opencode_root / "loopx" / "goal-bridge-runtime.mjs"
+        package_path = opencode_root / "package.json"
+        if uninstall:
+            for mechanism, path in (
+                ("opencode_goal_bridge", plugin_path),
+                ("opencode_goal_bridge_runtime", runtime_path),
+            ):
+                installed.append(
+                    {
+                        "surface": "opencode",
+                        "host_surfaces": ["opencode"],
+                        "mechanism": mechanism,
+                        "command": "/goal",
+                        "path": str(path),
+                        "status": _retire_status(path, execute=execute),
+                        "invoke_as": ["/goal", "loopx_goal_activate"],
+                    }
+                )
+            installed.append(
+                {
+                    "surface": "opencode",
+                    "host_surfaces": ["opencode"],
+                    "mechanism": "opencode_goal_dependencies",
+                    "command": "/goal",
+                    "path": str(package_path),
+                    "status": "preserved_shared_dependencies",
+                    "invoke_as": [],
+                }
+            )
+        else:
+            conflicts, invalid_configs = _opencode_direct_goal_plugin_conflicts(opencode_root)
+            if invalid_configs:
+                installed.append(
+                    {
+                        "surface": "opencode",
+                        "host_surfaces": ["opencode"],
+                        "mechanism": "opencode_goal_bridge",
+                        "command": "/goal",
+                        "path": str(plugin_path),
+                        "status": "blocked_invalid_opencode_config",
+                        "invoke_as": [],
+                        "reason": (
+                            "Repair the listed OpenCode JSON/JSONC config before installing "
+                            "the bridge so direct plugin conflicts can be checked safely."
+                        ),
+                        "invalid_configs": invalid_configs,
+                    }
+                )
+            elif conflicts:
+                installed.append(
+                    {
+                        "surface": "opencode",
+                        "host_surfaces": ["opencode"],
+                        "mechanism": "opencode_goal_bridge",
+                        "command": "/goal",
+                        "path": str(plugin_path),
+                        "status": "blocked_conflicting_direct_plugin",
+                        "invoke_as": [],
+                        "reason": (
+                            "Remove direct goal-plugin registration from the listed "
+                            "OpenCode config, then rerun installation. The bridge imports "
+                            "the pinned plugin and both must not be loaded independently."
+                        ),
+                        "conflicts": conflicts,
+                    }
+                )
+            else:
+                package_status = _target_package_dependencies(
+                    package_path,
+                    OPENCODE_GOAL_DEPENDENCIES,
+                    execute=execute,
+                )
+                installed.append(
+                    {
+                        "surface": "opencode",
+                        "host_surfaces": ["opencode"],
+                        "mechanism": "opencode_goal_dependencies",
+                        "command": "/goal",
+                        "path": str(package_path),
+                        "status": package_status,
+                        "invoke_as": [],
+                    }
+                )
+                if package_status == "blocked_invalid_user_package_json":
+                    installed.append(
+                        {
+                            "surface": "opencode",
+                            "host_surfaces": ["opencode"],
+                            "mechanism": "opencode_goal_bridge",
+                            "command": "/goal",
+                            "path": str(plugin_path),
+                            "status": package_status,
+                            "invoke_as": [],
+                        }
+                    )
+                else:
+                    for mechanism, path, content in (
+                        ("opencode_goal_bridge_runtime", runtime_path, runtime_source()),
+                        ("opencode_goal_bridge", plugin_path, plugin_source()),
+                    ):
+                        installed.append(
+                            {
+                                "surface": "opencode",
+                                "host_surfaces": ["opencode"],
+                                "mechanism": mechanism,
+                                "command": "/goal",
+                                "path": str(path),
+                                "status": _target_status(path, content, execute=execute),
+                                "invoke_as": ["/goal", "loopx_goal_activate"],
+                            }
+                        )
+
     status_counts: dict[str, int] = {}
     for item in installed:
         status = str(item["status"])
         status_counts[status] = status_counts.get(status, 0) + 1
 
     return {
-        "ok": True,
+        "ok": not any(status.startswith("blocked_") for status in status_counts),
         "schema_version": SCHEMA_VERSION,
         "operation": "uninstall" if uninstall else "install",
         "execute": execute,
@@ -463,6 +795,9 @@ def install_slash_commands(
             "codex_prompt_dir": None,
             "codex_skill_dir": str(codex_root / "skills") if "codex" in effective_surfaces else None,
             "claude_skill_dir": str(claude_root / "skills") if "claude-code" in effective_surfaces else None,
+            "opencode_command_dir": str(opencode_root / "commands") if "opencode" in effective_surfaces else None,
+            "opencode_plugin_path": str(opencode_root / "plugins" / "loopx-goal.js") if "opencode" in effective_surfaces else None,
+            "opencode_package_path": str(opencode_root / "package.json") if "opencode" in effective_surfaces else None,
             "status_counts": status_counts,
             "skip_policy": (
                 "Uninstall removes only LoopX-managed files; user files without a LoopX managed marker are preserved"
@@ -475,6 +810,8 @@ def install_slash_commands(
             "Codex does not currently support user-defined native top-level slash commands; use explicit skill invocation through `$loopx` or `/skills`.",
             "Explicit LoopX command-facade skills use agents/openai.yaml policy allow_implicit_invocation=false and remain distinct from richer workflow skills such as loopx-project.",
             "Claude Code discovers user skills from CLAUDE_HOME/skills and exposes each skill name as a slash command.",
+            "OpenCode discovers commands and local plugins from its config directory; the LoopX bridge imports opencode-goal-plugin@0.6.5 and must replace any direct goal-plugin registration.",
+            "OpenCode uninstall preserves package.json dependencies because they may be shared by user-owned local plugins.",
             "Uninstall is fail-closed: it retires only files carrying the LoopX managed marker and leaves user-owned files in place.",
         ],
     }
@@ -493,12 +830,18 @@ def render_slash_command_install_markdown(payload: dict[str, Any]) -> str:
     codex_prompt_dir = payload.get("summary", {}).get("codex_prompt_dir")
     codex_skill_dir = payload.get("summary", {}).get("codex_skill_dir")
     claude_skill_dir = payload.get("summary", {}).get("claude_skill_dir")
+    opencode_command_dir = payload.get("summary", {}).get("opencode_command_dir")
+    opencode_plugin_path = payload.get("summary", {}).get("opencode_plugin_path")
     if codex_prompt_dir:
         lines.append(f"- codex prompts: `{codex_prompt_dir}`")
     if codex_skill_dir:
         lines.append(f"- codex skills: `{codex_skill_dir}`")
     if claude_skill_dir:
         lines.append(f"- claude skills: `{claude_skill_dir}`")
+    if opencode_command_dir:
+        lines.append(f"- opencode commands: `{opencode_command_dir}`")
+    if opencode_plugin_path:
+        lines.append(f"- opencode bridge: `{opencode_plugin_path}`")
     counts = payload.get("summary", {}).get("status_counts") or {}
     if isinstance(counts, dict) and counts:
         count_text = ", ".join(f"{key}={value}" for key, value in sorted(counts.items()))

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -425,7 +425,7 @@ def _normalize_surfaces(surfaces: list[str] | None) -> list[str]:
     normalized: list[str] = []
     for surface in requested:
         if surface == "all":
-            candidates = ["codex", "claude-code", "opencode"]
+            candidates = ["codex", "claude-code"]
         elif surface == "codex":
             candidates = ["codex"]
         elif surface in {"codex-app", "codex-ide-plugin", "codex-ide", "codex-cli"}:
@@ -810,7 +810,7 @@ def install_slash_commands(
             "Codex does not currently support user-defined native top-level slash commands; use explicit skill invocation through `$loopx` or `/skills`.",
             "Explicit LoopX command-facade skills use agents/openai.yaml policy allow_implicit_invocation=false and remain distinct from richer workflow skills such as loopx-project.",
             "Claude Code discovers user skills from CLAUDE_HOME/skills and exposes each skill name as a slash command.",
-            "OpenCode discovers commands and local plugins from its config directory; the LoopX bridge imports opencode-goal-plugin@0.6.5 and must replace any direct goal-plugin registration.",
+            "OpenCode is opt-in through --surface opencode; it discovers commands and local plugins from its config directory, installs package.json dependencies with Bun at startup, and requires the LoopX bridge to replace any direct goal-plugin registration.",
             "OpenCode uninstall preserves package.json dependencies because they may be shared by user-owned local plugins.",
             "Uninstall is fail-closed: it retires only files carrying the LoopX managed marker and leaves user-owned files in place.",
         ],

--- a/loopx/slash_commands.py
+++ b/loopx/slash_commands.py
@@ -67,6 +67,7 @@ def build_slash_command_catalog(
                     "codex-app": "create/update Codex App heartbeat automation from heartbeat-prompt task_body",
                     "codex-cli": "set visible Codex CLI TUI `/goal <task_body>`",
                     "claude-code": "arm LoopX with `/loopx <task>`, then run native `/loop`",
+                    "opencode": "call `loopx_goal_activate` so the OpenCode bridge gates idle continuation and timers through LoopX",
                     "manual": "wire an external scheduler or run quota/status manually",
                     "other-agent": "use the custom host loop driver declared by `loopx agent-onboard`",
                 },

--- a/loopx/slash_commands.py
+++ b/loopx/slash_commands.py
@@ -67,7 +67,7 @@ def build_slash_command_catalog(
                     "codex-app": "create/update Codex App heartbeat automation from heartbeat-prompt task_body",
                     "codex-cli": "set visible Codex CLI TUI `/goal <task_body>`",
                     "claude-code": "arm LoopX with `/loopx <task>`, then run native `/loop`",
-                    "opencode": "call `loopx_goal_activate` so the OpenCode bridge gates idle continuation and timers through LoopX",
+                    "opencode": "call `loopx_goal_activate`",
                     "manual": "wire an external scheduler or run quota/status manually",
                     "other-agent": "use the custom host loop driver declared by `loopx agent-onboard`",
                 },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ include = ["loopx*"]
 "loopx.capabilities.auto_research" = ["worker_skill/SKILL.md"]
 "loopx.extensions.lark" = ["extension.toml"]
 "loopx.extensions.openviking_semantic_preference" = ["extension.toml"]
+"loopx.opencode_goal_mode" = ["*.js", "*.mjs", "README.md"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -632,19 +632,19 @@ if [[ "$install_claude" != "0" && -f "$claude_installer" ]]; then
   fi
 fi
 
-# loopx OpenCode goal bridge: OPT-IN, OFF by default — the normal loopx install
-# does not install OpenCode commands, bridge plugin, runtime, or pinned
-# dependencies. Enable with LOOPX_INSTALL_OPENCODE=1. The bridge wraps
+# loopx OpenCode goal bridge: OPT-IN, OFF by default. Static OpenCode commands
+# remain part of the ordinary slash-command install; this flag additionally
+# provisions the plugin, runtime, and pinned dependencies. The bridge wraps
 # opencode-goal-plugin@0.6.5 and gates idle continuation plus timer wakes
 # through LoopX quota should-run. Install manually with:
-#   loopx slash-commands --install --surface opencode
+#   loopx slash-commands --install --surface opencode --with-goal-bridge
 install_opencode="${LOOPX_INSTALL_OPENCODE:-0}"
-opencode_line="- loopx OpenCode bridge: skipped (opt-in; LOOPX_INSTALL_OPENCODE=1, or run: loopx slash-commands --install --surface opencode)"
+opencode_line="- loopx OpenCode bridge: skipped (opt-in; LOOPX_INSTALL_OPENCODE=1, or run: loopx slash-commands --install --surface opencode --with-goal-bridge)"
 if [[ "$install_opencode" != "0" ]]; then
-  if "$bin_dir/loopx" slash-commands --install --surface opencode >/dev/null 2>&1; then
+  if "$bin_dir/loopx" slash-commands --install --surface opencode --with-goal-bridge >/dev/null 2>&1; then
     opencode_line="- loopx OpenCode bridge: ~/.config/opencode (commands, plugin, runtime, pinned deps; restart OpenCode after install)"
   else
-    opencode_line="- loopx OpenCode bridge: install attempted; run manually: loopx slash-commands --install --surface opencode"
+    opencode_line="- loopx OpenCode bridge: install attempted; run manually: loopx slash-commands --install --surface opencode --with-goal-bridge"
   fi
 fi
 

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -17,6 +17,7 @@ Common environment variables:
   LOOPX_INSTALL_CANARY=0           Skip the loopx-canary executable.
   LOOPX_INSTALL_SKILL=0            Skip packaged Codex workflow skills.
   LOOPX_INSTALL_SLASH_COMMANDS=0   Skip Codex and Claude command skills.
+  LOOPX_INSTALL_OPENCODE=0         Install the OpenCode goal bridge surface.
   CODEX_HOME=/path                 Override the Codex home directory.
 EOF
 }
@@ -631,6 +632,22 @@ if [[ "$install_claude" != "0" && -f "$claude_installer" ]]; then
   fi
 fi
 
+# loopx OpenCode goal bridge: OPT-IN, OFF by default — the normal loopx install
+# does not install OpenCode commands, bridge plugin, runtime, or pinned
+# dependencies. Enable with LOOPX_INSTALL_OPENCODE=1. The bridge wraps
+# opencode-goal-plugin@0.6.5 and gates idle continuation plus timer wakes
+# through LoopX quota should-run. Install manually with:
+#   loopx slash-commands --install --surface opencode
+install_opencode="${LOOPX_INSTALL_OPENCODE:-0}"
+opencode_line="- loopx OpenCode bridge: skipped (opt-in; LOOPX_INSTALL_OPENCODE=1, or run: loopx slash-commands --install --surface opencode)"
+if [[ "$install_opencode" != "0" ]]; then
+  if "$bin_dir/loopx" slash-commands --install --surface opencode >/dev/null 2>&1; then
+    opencode_line="- loopx OpenCode bridge: ~/.config/opencode (commands, plugin, runtime, pinned deps; restart OpenCode after install)"
+  else
+    opencode_line="- loopx OpenCode bridge: install attempted; run manually: loopx slash-commands --install --surface opencode"
+  fi
+fi
+
 cat <<EOF
 loopx installed locally
 - executable: $bin_dir/loopx
@@ -645,6 +662,7 @@ $legacy_line
 $skill_line
 $slash_line
 $claude_line
+$opencode_line
 
 Current shell can use it with:
   export PATH="$bin_dir:\$PATH"

--- a/tests/control_plane/test_start_goal_compact_projection.py
+++ b/tests/control_plane/test_start_goal_compact_projection.py
@@ -306,6 +306,7 @@ def test_cli_without_host_returns_read_only_host_selection_gate(
         "codex-ide-plugin",
         "codex-cli-tui",
         "claude-code",
+        "opencode",
         "shell",
     ]
     ide = next(choice for choice in choices if choice["host_surface"] == "codex-ide-plugin")

--- a/tests/opencode_goal_bridge_runtime.test.mjs
+++ b/tests/opencode_goal_bridge_runtime.test.mjs
@@ -1,0 +1,240 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { createLoopxGoalPlugin } from "../loopx/opencode_goal_mode/goal-bridge-runtime.mjs"
+
+
+function fakeTool(spec) {
+  return spec
+}
+const optional = () => ({ optional })
+fakeTool.schema = {
+  string: optional,
+  number: optional,
+  array: () => ({ optional }),
+  object: () => ({}),
+  enum: () => ({}),
+}
+
+
+function memoryBindingStore() {
+  const bindings = new Map()
+  return {
+    bindings,
+    async read(sessionID) {
+      return bindings.get(sessionID) || null
+    },
+    async write(sessionID, binding) {
+      const value = { schemaVersion: "loopx_opencode_goal_bridge_v0", sessionID, ...binding }
+      bindings.set(sessionID, value)
+      return value
+    },
+    async remove(sessionID) {
+      bindings.delete(sessionID)
+    },
+  }
+}
+
+
+function terminalDecision() {
+  return {
+    should_run: false,
+    effective_action: "terminal_no_followup",
+    reason: "validated closure",
+    goal_frontier_projection: {
+      terminal_state: {
+        schema_version: "goal_terminal_state_v0",
+        kind: "no_followup",
+        derived: true,
+        source: "validated_goal_closure",
+      },
+      source_completeness: {
+        schema_version: "goal_terminal_source_completeness_v0",
+        user_todos: "valid",
+        agent_todos: "valid",
+      },
+    },
+  }
+}
+
+
+function harness(initialDecision) {
+  const store = memoryBindingStore()
+  const calls = { chat: 0, event: 0, complete: 0, quota: 0, resume: 0 }
+  const scheduled = []
+  let decision = initialDecision
+  const GoalPlugin = async (_context, options) => ({
+    config: async () => {},
+    "command.execute.before": async () => {},
+    "chat.message": async () => {
+      calls.chat += 1
+    },
+    event: async () => {
+      calls.event += 1
+    },
+    tool: {
+      goal_set: fakeTool({
+        args: {},
+        execute: async () => JSON.stringify({ version: 1, operation: "set", ok: true }),
+      }),
+      goal_resume: fakeTool({
+        args: {},
+        execute: async () => {
+          calls.resume += 1
+          return JSON.stringify({ version: 1, operation: "resume", ok: true })
+        },
+      }),
+      goal_complete: fakeTool({
+        args: {},
+        execute: async (_args, context) => {
+          calls.complete += 1
+          const verdict = await options.auditor({ sessionID: context.sessionID })
+          return JSON.stringify({
+            version: 1,
+            operation: "complete",
+            ok: verdict.approved,
+            ...(verdict.approved ? {} : { error: "completion_rejected" }),
+          })
+        },
+      }),
+    },
+    dispose: async () => {},
+  })
+  const plugin = createLoopxGoalPlugin({
+    GoalPlugin,
+    tool: fakeTool,
+    bindingStore: store,
+    quotaProbe: async () => {
+      calls.quota += 1
+      return decision
+    },
+    setTimer: (callback, delay) => {
+      const timer = { callback, delay, unref() {} }
+      scheduled.push(timer)
+      return timer
+    },
+    clearTimer: () => {},
+  })
+  return {
+    calls,
+    plugin,
+    scheduled,
+    store,
+    setDecision(value) {
+      decision = value
+    },
+  }
+}
+
+
+test("suppresses the OpenCode 1.18 command reflection that pauses a new goal", async () => {
+  const fixture = harness({ should_run: true, scheduler_hint: { action: "run_now" } })
+  const hooks = await fixture.plugin({ directory: "/workspace", client: {} })
+  await hooks["command.execute.before"](
+    { command: "goal", sessionID: "session-command", arguments: "ship the task" },
+    { parts: [] },
+  )
+  await hooks["chat.message"](
+    { sessionID: "session-command" },
+    { parts: [{ type: "text", text: "ship the task" }] },
+  )
+  assert.equal(fixture.calls.chat, 0)
+})
+
+
+test("gates active and quiet idle turns through LoopX quota", async () => {
+  const fixture = harness({ should_run: true, scheduler_hint: { action: "run_now" } })
+  const hooks = await fixture.plugin({ directory: "/workspace", client: {} })
+  await hooks.tool.loopx_goal_activate.execute(
+    { goalId: "goal-1", objective: "LoopX task body" },
+    { sessionID: "session-idle" },
+  )
+  await hooks.event({ event: { type: "session.idle", properties: { sessionID: "session-idle" } } })
+  assert.equal(fixture.calls.event, 1)
+
+  fixture.setDecision({
+    should_run: false,
+    scheduler_hint: {
+      action: "backoff_waiting_for_user",
+      reset_policy: { reset_token: "wait-1" },
+      unchanged_poll: {
+        local_scheduler: {
+          recommended_interval_minutes: 3,
+          example_progression_minutes: [3, 6, 12],
+          unchanged_poll_limit: 3,
+        },
+      },
+    },
+  })
+  await hooks.event({ event: { type: "session.idle", properties: { sessionID: "session-idle" } } })
+  assert.equal(fixture.calls.event, 1)
+  assert.equal(fixture.scheduled.at(-1).delay, 180_000)
+})
+
+
+test("coalesces concurrent idle events into one quota decision", async () => {
+  let releaseDecision
+  const pendingDecision = new Promise((resolve) => {
+    releaseDecision = resolve
+  })
+  const fixture = harness(pendingDecision)
+  const hooks = await fixture.plugin({ directory: "/workspace", client: {} })
+  await hooks.tool.loopx_goal_activate.execute(
+    { goalId: "goal-concurrent", objective: "LoopX task body" },
+    { sessionID: "session-concurrent" },
+  )
+  const first = hooks.event({
+    event: { type: "session.idle", properties: { sessionID: "session-concurrent" } },
+  })
+  const second = hooks.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "session-concurrent", status: { type: "idle" } },
+    },
+  })
+  releaseDecision({ should_run: true, scheduler_hint: { action: "run_now" } })
+  await Promise.all([first, second])
+  assert.equal(fixture.calls.quota, 1)
+  assert.equal(fixture.calls.event, 1)
+})
+
+
+test("does not continue when the user intervenes during a quota probe", async () => {
+  let releaseDecision
+  const pendingDecision = new Promise((resolve) => {
+    releaseDecision = resolve
+  })
+  const fixture = harness(pendingDecision)
+  const hooks = await fixture.plugin({ directory: "/workspace", client: {} })
+  await hooks.tool.loopx_goal_activate.execute(
+    { goalId: "goal-intervention", objective: "LoopX task body" },
+    { sessionID: "session-intervention" },
+  )
+  const idle = hooks.event({
+    event: { type: "session.idle", properties: { sessionID: "session-intervention" } },
+  })
+  await hooks["chat.message"](
+    { sessionID: "session-intervention" },
+    { parts: [{ type: "text", text: "change direction" }] },
+  )
+  releaseDecision({ should_run: true, scheduler_hint: { action: "run_now" } })
+  await idle
+  assert.equal(fixture.calls.event, 0)
+  assert.equal((await fixture.store.read("session-intervention")).autoResume, false)
+})
+
+
+test("completes only after LoopX validates terminal no-follow-up", async () => {
+  const fixture = harness(terminalDecision())
+  const hooks = await fixture.plugin({ directory: "/workspace", client: {} })
+  await hooks.tool.loopx_goal_activate.execute(
+    { goalId: "goal-terminal", objective: "LoopX task body" },
+    { sessionID: "session-terminal" },
+  )
+  await hooks.event({
+    event: { type: "session.idle", properties: { sessionID: "session-terminal" } },
+  })
+  assert.equal(fixture.calls.complete, 1)
+  assert.equal(await fixture.store.read("session-terminal"), null)
+  assert.equal(fixture.calls.event, 0)
+})

--- a/tests/opencode_goal_bridge_runtime.test.mjs
+++ b/tests/opencode_goal_bridge_runtime.test.mjs
@@ -60,7 +60,7 @@ function terminalDecision() {
 
 function harness(initialDecision) {
   const store = memoryBindingStore()
-  const calls = { chat: 0, event: 0, complete: 0, quota: 0, resume: 0 }
+  const calls = { chat: 0, event: 0, complete: 0, dispose: 0, quota: 0, resume: 0 }
   const scheduled = []
   let decision = initialDecision
   const GoalPlugin = async (_context, options) => ({
@@ -98,7 +98,9 @@ function harness(initialDecision) {
         },
       }),
     },
-    dispose: async () => {},
+    dispose: async () => {
+      calls.dispose += 1
+    },
   })
   const plugin = createLoopxGoalPlugin({
     GoalPlugin,
@@ -106,14 +108,17 @@ function harness(initialDecision) {
     bindingStore: store,
     quotaProbe: async () => {
       calls.quota += 1
+      if (decision instanceof Error) throw decision
       return decision
     },
     setTimer: (callback, delay) => {
-      const timer = { callback, delay, unref() {} }
+      const timer = { callback, cleared: false, delay, unref() {} }
       scheduled.push(timer)
       return timer
     },
-    clearTimer: () => {},
+    clearTimer: (timer) => {
+      timer.cleared = true
+    },
   })
   return {
     calls,
@@ -169,6 +174,148 @@ test("gates active and quiet idle turns through LoopX quota", async () => {
   await hooks.event({ event: { type: "session.idle", properties: { sessionID: "session-idle" } } })
   assert.equal(fixture.calls.event, 1)
   assert.equal(fixture.scheduled.at(-1).delay, 180_000)
+})
+
+
+test("fails closed and schedules a bounded retry after a quota network timeout", async () => {
+  const fixture = harness(new Error("network timeout"))
+  const hooks = await fixture.plugin({ directory: "/workspace", client: {} })
+  await hooks.tool.loopx_goal_activate.execute(
+    { goalId: "goal-timeout", objective: "LoopX task body" },
+    { sessionID: "session-timeout" },
+  )
+
+  await hooks.event({
+    event: { type: "session.idle", properties: { sessionID: "session-timeout" } },
+  })
+
+  assert.equal(fixture.calls.quota, 1)
+  assert.equal(fixture.calls.event, 0)
+  assert.equal(fixture.scheduled.length, 1)
+  assert.equal(fixture.scheduled[0].delay, 180_000)
+  assert.equal(fixture.scheduled[0].cleared, false)
+})
+
+
+test("fails closed when the session binding cannot be read", async () => {
+  const fixture = harness({ should_run: true, scheduler_hint: { action: "run_now" } })
+  const hooks = await fixture.plugin({ directory: "/workspace", client: {} })
+  await hooks.tool.loopx_goal_activate.execute(
+    { goalId: "goal-binding-error", objective: "LoopX task body" },
+    { sessionID: "session-binding-error" },
+  )
+  fixture.store.read = async () => {
+    const error = new Error("binding filesystem unavailable")
+    error.code = "EACCES"
+    throw error
+  }
+
+  await hooks.event({
+    event: { type: "session.idle", properties: { sessionID: "session-binding-error" } },
+  })
+
+  assert.equal(fixture.calls.quota, 0)
+  assert.equal(fixture.calls.event, 0)
+  assert.equal(fixture.scheduled.length, 0)
+  assert.equal(fixture.store.bindings.has("session-binding-error"), true)
+})
+
+
+test("keeps scheduled quota timers isolated between sessions", async () => {
+  const fixture = harness({
+    should_run: false,
+    scheduler_hint: {
+      action: "backoff_waiting_for_user",
+      reset_policy: { reset_token: "wait-multi" },
+      unchanged_poll: {
+        local_scheduler: {
+          recommended_interval_minutes: 3,
+          unchanged_poll_limit: 3,
+        },
+      },
+    },
+  })
+  const hooks = await fixture.plugin({ directory: "/workspace", client: {} })
+  for (const sessionID of ["session-a", "session-b"]) {
+    await hooks.tool.loopx_goal_activate.execute(
+      { goalId: `goal-${sessionID}`, objective: "LoopX task body" },
+      { sessionID },
+    )
+    await hooks.event({ event: { type: "session.idle", properties: { sessionID } } })
+  }
+
+  assert.equal(fixture.scheduled.length, 2)
+  assert.equal(fixture.scheduled[0].cleared, false)
+  assert.equal(fixture.scheduled[1].cleared, false)
+
+  fixture.setDecision({ should_run: true, scheduler_hint: { action: "run_now" } })
+  await hooks.event({
+    event: { type: "session.idle", properties: { sessionID: "session-a" } },
+  })
+
+  assert.equal(fixture.scheduled[0].cleared, true)
+  assert.equal(fixture.scheduled[1].cleared, false)
+  assert.equal(fixture.calls.event, 1)
+})
+
+
+test("disposal clears every active session timer before disposing the base plugin", async () => {
+  const fixture = harness({
+    should_run: false,
+    scheduler_hint: {
+      action: "backoff_waiting_for_user",
+      reset_policy: { reset_token: "wait-dispose" },
+      unchanged_poll: {
+        local_scheduler: {
+          recommended_interval_minutes: 3,
+          unchanged_poll_limit: 3,
+        },
+      },
+    },
+  })
+  const hooks = await fixture.plugin({ directory: "/workspace", client: {} })
+  for (const sessionID of ["session-dispose-a", "session-dispose-b"]) {
+    await hooks.tool.loopx_goal_activate.execute(
+      { goalId: `goal-${sessionID}`, objective: "LoopX task body" },
+      { sessionID },
+    )
+    await hooks.event({ event: { type: "session.idle", properties: { sessionID } } })
+  }
+
+  await hooks.dispose()
+
+  assert.equal(fixture.scheduled.length, 2)
+  assert.equal(fixture.scheduled.every((timer) => timer.cleared), true)
+  assert.equal(fixture.calls.dispose, 1)
+})
+
+
+test("disposal prevents an in-flight quota decision from continuing the session", async () => {
+  let releaseDecision
+  const pendingDecision = new Promise((resolve) => {
+    releaseDecision = resolve
+  })
+  const fixture = harness(pendingDecision)
+  const hooks = await fixture.plugin({ directory: "/workspace", client: {} })
+  await hooks.tool.loopx_goal_activate.execute(
+    { goalId: "goal-dispose-in-flight", objective: "LoopX task body" },
+    { sessionID: "session-dispose-in-flight" },
+  )
+  const idle = hooks.event({
+    event: { type: "session.idle", properties: { sessionID: "session-dispose-in-flight" } },
+  })
+  for (let index = 0; index < 5 && fixture.calls.quota === 0; index += 1) {
+    await Promise.resolve()
+  }
+  assert.equal(fixture.calls.quota, 1)
+
+  await hooks.dispose()
+  releaseDecision({ should_run: true, scheduler_hint: { action: "run_now" } })
+  await idle
+
+  assert.equal(fixture.calls.event, 0)
+  assert.equal(fixture.scheduled.length, 0)
+  assert.equal(fixture.calls.dispose, 1)
 })
 
 

--- a/tests/test_host_loop_activation.py
+++ b/tests/test_host_loop_activation.py
@@ -106,7 +106,9 @@ def test_opencode_activation_uses_bridge_tool_and_generic_cli_quota() -> None:
     assert packet["host_surface"] == "opencode_visible_goal_mode"
     assert packet["activation_method"] == "activate_loopx_opencode_goal_bridge"
     assert packet["host_mutation"]["host_tool"] == "loopx_goal_activate"
-    assert packet["setup_command"].endswith("--surface opencode")
+    assert packet["setup_command"].endswith(
+        "--surface opencode --with-goal-bridge"
+    )
     assert "--runtime-profile generic_cli" in packet["commands"]["heartbeat_prompt"]
 
 

--- a/tests/test_host_loop_activation.py
+++ b/tests/test_host_loop_activation.py
@@ -20,6 +20,8 @@ def test_codex_ide_plugin_is_an_exact_host_type_with_visible_goal_activation() -
     assert agent_type_for_host_surface("codex-ide") == "codex-ide-plugin"
     assert agent_type_for_host_surface("codex-app") == "codex-app"
     assert agent_type_for_host_surface("codex-cli-tui") == "codex-cli"
+    assert normalize_agent_type("Open Code") == "opencode"
+    assert agent_type_for_host_surface("opencode") == "opencode"
 
     packet = build_host_loop_activation_packet(
         agent_type="codex-ide-plugin",
@@ -49,6 +51,7 @@ def test_codex_ide_plugin_is_an_exact_host_type_with_visible_goal_activation() -
         ("codex-cli", "codex_cli"),
         ("codex-ide-plugin", "codex_cli"),
         ("claude-code", "claude_code"),
+        ("opencode", "generic_cli"),
     ),
 )
 def test_first_class_hosts_bind_one_runtime_profile(
@@ -90,6 +93,21 @@ def test_codex_app_thin_prompt_embeds_profile_only_in_quota_command() -> None:
     assert "compact_prompt_command" not in prompt
     assert "brief_prompt_command" not in prompt
     assert prompt["interface_budget"]["within_budget"] is True
+
+
+def test_opencode_activation_uses_bridge_tool_and_generic_cli_quota() -> None:
+    packet = build_host_loop_activation_packet(
+        agent_type="opencode",
+        goal_id="fixture-goal",
+        agent_id="opencode-fixture",
+        registered_agents=["opencode-fixture"],
+    )
+
+    assert packet["host_surface"] == "opencode_visible_goal_mode"
+    assert packet["activation_method"] == "activate_loopx_opencode_goal_bridge"
+    assert packet["host_mutation"]["host_tool"] == "loopx_goal_activate"
+    assert packet["setup_command"].endswith("--surface opencode")
+    assert "--runtime-profile generic_cli" in packet["commands"]["heartbeat_prompt"]
 
 
 def test_ambiguous_codex_requires_app_ide_or_cli_selection() -> None:

--- a/tests/test_opencode_goal_bridge.py
+++ b/tests/test_opencode_goal_bridge.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def test_opencode_goal_bridge_runtime_contract() -> None:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("Node.js is required for the OpenCode bridge runtime contract")
+    test_file = Path(__file__).with_name("opencode_goal_bridge_runtime.test.mjs")
+    subprocess.run([node, "--test", str(test_file)], check=True)

--- a/tests/test_slash_command_install.py
+++ b/tests/test_slash_command_install.py
@@ -102,3 +102,81 @@ def test_codex_install_retires_managed_metadata_beside_user_owned_skill(
     assert _row(payload, "retired_codex_command_metadata")["status"] == (
         "retired_managed_file"
     )
+
+
+def test_opencode_install_writes_commands_bridge_and_pinned_dependencies(
+    tmp_path: Path,
+) -> None:
+    opencode_home = tmp_path / "opencode"
+
+    payload = install_slash_commands(
+        execute=True,
+        surfaces=["opencode"],
+        codex_home=str(tmp_path / "codex"),
+        claude_home=str(tmp_path / "claude"),
+        opencode_home=str(opencode_home),
+    )
+
+    assert payload["ok"] is True
+    command = opencode_home / "commands" / "loopx.md"
+    plugin = opencode_home / "plugins" / "loopx-goal.js"
+    runtime = opencode_home / "loopx" / "goal-bridge-runtime.mjs"
+    package = opencode_home / "package.json"
+    assert "--host-surface opencode" in command.read_text(encoding="utf-8")
+    assert "createLoopxGoalPlugin" in plugin.read_text(encoding="utf-8")
+    runtime_text = runtime.read_text(encoding="utf-8")
+    assert "quota" in runtime_text
+    assert "terminal_no_followup" in runtime_text
+    package_text = package.read_text(encoding="utf-8")
+    assert '"opencode-goal-plugin": "0.6.5"' in package_text
+    assert '"@opencode-ai/plugin": ">=1.17.15 <2"' in package_text
+    assert _row(payload, "opencode_goal_bridge")["status"] == "created"
+
+
+def test_opencode_install_fails_closed_for_direct_goal_plugin_registration(
+    tmp_path: Path,
+) -> None:
+    opencode_home = tmp_path / "opencode"
+    opencode_home.mkdir()
+    (opencode_home / "opencode.jsonc").write_text(
+        '{"plugin": ["opencode-goal-plugin"]}\n',
+        encoding="utf-8",
+    )
+
+    payload = install_slash_commands(
+        execute=True,
+        surfaces=["opencode"],
+        codex_home=str(tmp_path / "codex"),
+        claude_home=str(tmp_path / "claude"),
+        opencode_home=str(opencode_home),
+    )
+
+    assert payload["ok"] is False
+    assert _row(payload, "opencode_goal_bridge")["status"] == (
+        "blocked_conflicting_direct_plugin"
+    )
+    assert not (opencode_home / "plugins" / "loopx-goal.js").exists()
+
+
+def test_opencode_install_ignores_commented_jsonc_goal_plugin(
+    tmp_path: Path,
+) -> None:
+    opencode_home = tmp_path / "opencode"
+    opencode_home.mkdir()
+    (opencode_home / "opencode.jsonc").write_text(
+        """{
+  // \"plugin\": [\"opencode-goal-plugin\"],
+  \"plugin\": [],
+}
+""",
+        encoding="utf-8",
+    )
+
+    payload = install_slash_commands(
+        execute=True,
+        surfaces=["opencode"],
+        opencode_home=str(opencode_home),
+    )
+
+    assert payload["ok"] is True
+    assert (opencode_home / "plugins" / "loopx-goal.js").exists()

--- a/tests/test_slash_command_install.py
+++ b/tests/test_slash_command_install.py
@@ -111,6 +111,7 @@ def test_opencode_install_writes_commands_bridge_and_pinned_dependencies(
 
     payload = install_slash_commands(
         execute=True,
+        with_goal_bridge=True,
         surfaces=["opencode"],
         codex_home=str(tmp_path / "codex"),
         claude_home=str(tmp_path / "claude"),
@@ -133,7 +134,9 @@ def test_opencode_install_writes_commands_bridge_and_pinned_dependencies(
     assert _row(payload, "opencode_goal_bridge")["status"] == "created"
 
 
-def test_default_and_all_surfaces_keep_opencode_opt_in(tmp_path: Path) -> None:
+def test_default_and_all_surfaces_install_only_static_opencode_commands(
+    tmp_path: Path,
+) -> None:
     for surfaces in (None, ["all"]):
         opencode_home = tmp_path / ("default" if surfaces is None else "all")
         payload = install_slash_commands(
@@ -144,8 +147,64 @@ def test_default_and_all_surfaces_keep_opencode_opt_in(tmp_path: Path) -> None:
             opencode_home=str(opencode_home),
         )
 
-        assert payload["effective_surfaces"] == ["codex", "claude-code"]
-        assert not opencode_home.exists()
+        assert payload["effective_surfaces"] == ["codex", "claude-code", "opencode"]
+        assert payload["with_goal_bridge"] is False
+        assert (opencode_home / "commands" / "loopx.md").exists()
+        assert not (opencode_home / "plugins" / "loopx-goal.js").exists()
+        assert not (opencode_home / "loopx" / "goal-bridge-runtime.mjs").exists()
+        assert not (opencode_home / "package.json").exists()
+
+
+def test_opencode_static_uninstall_preserves_installed_bridge(tmp_path: Path) -> None:
+    opencode_home = tmp_path / "opencode"
+    install_slash_commands(
+        execute=True,
+        with_goal_bridge=True,
+        surfaces=["opencode"],
+        opencode_home=str(opencode_home),
+    )
+
+    payload = install_slash_commands(
+        execute=True,
+        uninstall=True,
+        surfaces=["opencode"],
+        opencode_home=str(opencode_home),
+    )
+
+    assert payload["ok"] is True
+    assert not (opencode_home / "commands" / "loopx.md").exists()
+    assert (opencode_home / "plugins" / "loopx-goal.js").exists()
+    assert (opencode_home / "loopx" / "goal-bridge-runtime.mjs").exists()
+    assert (opencode_home / "package.json").exists()
+
+
+def test_opencode_bridge_uninstall_retires_managed_files_and_keeps_package(
+    tmp_path: Path,
+) -> None:
+    opencode_home = tmp_path / "opencode"
+    install_slash_commands(
+        execute=True,
+        with_goal_bridge=True,
+        surfaces=["opencode"],
+        opencode_home=str(opencode_home),
+    )
+
+    payload = install_slash_commands(
+        execute=True,
+        uninstall=True,
+        with_goal_bridge=True,
+        surfaces=["opencode"],
+        opencode_home=str(opencode_home),
+    )
+
+    assert payload["ok"] is True
+    assert not (opencode_home / "commands" / "loopx.md").exists()
+    assert not (opencode_home / "plugins" / "loopx-goal.js").exists()
+    assert not (opencode_home / "loopx" / "goal-bridge-runtime.mjs").exists()
+    assert (opencode_home / "package.json").exists()
+    assert _row(payload, "opencode_goal_dependencies")["status"] == (
+        "preserved_shared_dependencies"
+    )
 
 
 def test_opencode_install_fails_closed_for_direct_goal_plugin_registration(
@@ -160,6 +219,7 @@ def test_opencode_install_fails_closed_for_direct_goal_plugin_registration(
 
     payload = install_slash_commands(
         execute=True,
+        with_goal_bridge=True,
         surfaces=["opencode"],
         codex_home=str(tmp_path / "codex"),
         claude_home=str(tmp_path / "claude"),
@@ -170,7 +230,71 @@ def test_opencode_install_fails_closed_for_direct_goal_plugin_registration(
     assert _row(payload, "opencode_goal_bridge")["status"] == (
         "blocked_conflicting_direct_plugin"
     )
+    assert not (opencode_home / "commands" / "loopx.md").exists()
     assert not (opencode_home / "plugins" / "loopx-goal.js").exists()
+
+
+def test_opencode_bridge_preflight_blocks_all_writes_for_invalid_config(
+    tmp_path: Path,
+) -> None:
+    opencode_home = tmp_path / "opencode"
+    opencode_home.mkdir()
+    (opencode_home / "opencode.jsonc").write_text("{ invalid\n", encoding="utf-8")
+
+    payload = install_slash_commands(
+        execute=True,
+        with_goal_bridge=True,
+        surfaces=["opencode"],
+        opencode_home=str(opencode_home),
+    )
+
+    assert payload["ok"] is False
+    assert _row(payload, "opencode_goal_bridge")["status"] == (
+        "blocked_invalid_opencode_config"
+    )
+    assert not (opencode_home / "commands" / "loopx.md").exists()
+    assert not (opencode_home / "plugins" / "loopx-goal.js").exists()
+    assert not (opencode_home / "package.json").exists()
+
+
+def test_goal_bridge_requires_an_effective_opencode_surface(tmp_path: Path) -> None:
+    payload = install_slash_commands(
+        execute=True,
+        with_goal_bridge=True,
+        surfaces=["codex"],
+        codex_home=str(tmp_path / "codex"),
+        opencode_home=str(tmp_path / "opencode"),
+    )
+
+    assert payload["ok"] is False
+    assert _row(payload, "opencode_goal_bridge")["status"] == (
+        "blocked_goal_bridge_requires_opencode_surface"
+    )
+    assert not (tmp_path / "opencode").exists()
+
+
+def test_opencode_bridge_preflight_blocks_all_writes_for_invalid_package(
+    tmp_path: Path,
+) -> None:
+    opencode_home = tmp_path / "opencode"
+    opencode_home.mkdir()
+    package = opencode_home / "package.json"
+    package.write_text("[]\n", encoding="utf-8")
+
+    payload = install_slash_commands(
+        execute=True,
+        with_goal_bridge=True,
+        surfaces=["opencode"],
+        opencode_home=str(opencode_home),
+    )
+
+    assert payload["ok"] is False
+    assert _row(payload, "opencode_goal_dependencies")["status"] == (
+        "blocked_invalid_user_package_json"
+    )
+    assert not (opencode_home / "commands" / "loopx.md").exists()
+    assert not (opencode_home / "plugins" / "loopx-goal.js").exists()
+    assert package.read_text(encoding="utf-8") == "[]\n"
 
 
 def test_opencode_install_ignores_commented_jsonc_goal_plugin(
@@ -189,6 +313,7 @@ def test_opencode_install_ignores_commented_jsonc_goal_plugin(
 
     payload = install_slash_commands(
         execute=True,
+        with_goal_bridge=True,
         surfaces=["opencode"],
         opencode_home=str(opencode_home),
     )

--- a/tests/test_slash_command_install.py
+++ b/tests/test_slash_command_install.py
@@ -133,6 +133,21 @@ def test_opencode_install_writes_commands_bridge_and_pinned_dependencies(
     assert _row(payload, "opencode_goal_bridge")["status"] == "created"
 
 
+def test_default_and_all_surfaces_keep_opencode_opt_in(tmp_path: Path) -> None:
+    for surfaces in (None, ["all"]):
+        opencode_home = tmp_path / ("default" if surfaces is None else "all")
+        payload = install_slash_commands(
+            execute=True,
+            surfaces=surfaces,
+            codex_home=str(tmp_path / "codex"),
+            claude_home=str(tmp_path / "claude"),
+            opencode_home=str(opencode_home),
+        )
+
+        assert payload["effective_surfaces"] == ["codex", "claude-code"]
+        assert not opencode_home.exists()
+
+
 def test_opencode_install_fails_closed_for_direct_goal_plugin_registration(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- register OpenCode as a first-class LoopX host surface across onboarding, guided start, command catalogs, and scheduler profile selection
- install static OpenCode command facades through the default `all` surface while keeping the executable goal bridge, runtime, and dependencies behind explicit `--with-goal-bridge` opt-in
- preflight OpenCode config and package state before any OpenCode write, then provision bridge files before command files so blocked bridge installs cannot leave commands pointing at a missing runtime
- gate idle continuation, timer wakes, disposal, and validated terminal completion through `loopx quota should-run`
- document exact install/uninstall boundaries in the adapter README and add OpenCode to the repository Quick Start

## Validation

- `python3 -m pytest -q`: 900 passed, 2 skipped
- `node --test tests/opencode_goal_bridge_runtime.test.mjs`: 10 passed
- `python3 examples/slash-command-install-smoke.py`: passed
- `python3 examples/install-local-smoke.py`: passed
- CLI output base/head differential and budget regression smokes: passed
- changed-file Ruff checks: passed
- `python3 -m loopx.cli canary premerge --from-git-diff --tier standard`: passed, 18 selected checks, public boundary clean, 0 manual holds

## Install boundary

Default and `--surface all` installs write only static OpenCode command files. Enable or remove the executable bridge explicitly with:

```bash
loopx slash-commands --install --surface opencode --with-goal-bridge
loopx slash-commands --uninstall --surface opencode --with-goal-bridge
```

Bridge uninstall preserves shared `package.json` dependencies. A static-only uninstall omits `--with-goal-bridge` and leaves bridge files untouched.

## Runtime notes

- The global OpenCode config must not also register a goal plugin directly; preflight detects JSON/JSONC conflicts and fails closed before writes.
- OpenCode installs config-directory dependencies with Bun at startup, so restart OpenCode after bridge installation.
- `opencode run` is one-shot and cannot own timers after process exit; recurring operation uses the visible TUI or persistent OpenCode server.
- This changes runtime and installer behavior, so it remains open for normal review.