### PR TITLE
fix(update): reuse persisted release Python

### DIFF
--- a/examples/claude-install-optin-smoke.py
+++ b/examples/claude-install-optin-smoke.py
@@ -50,6 +50,7 @@ def main() -> int:
             "LOOPX_INSTALL_CANARY": "0",
             "LOOPX_INSTALL_SKILL": "0",
             "LOOPX_PROMOTE_DEFAULT": "1",
+            "LOOPX_PYTHON": sys.executable,
             "PATH": os.environ.get("PATH", ""),
             "SHELL": "/bin/zsh",
         }
@@ -73,7 +74,8 @@ def main() -> int:
 
     with tempfile.TemporaryDirectory(prefix="loopx-proj-") as d:
         proj, other_home = Path(d) / "proj", Path(d) / "home"
-        proj.mkdir(); other_home.mkdir()
+        proj.mkdir()
+        other_home.mkdir()
         env = {**os.environ, "HOME": str(other_home)}  # prove it doesn't touch ~/.claude
         # dry-run writes nothing
         r = _install_py(["--scope", "project", "--project", str(proj), "--skip-mcp", "--dry-run"], env=env)

--- a/examples/codex-cli-packaged-install-smoke.py
+++ b/examples/codex-cli-packaged-install-smoke.py
@@ -32,7 +32,18 @@ def main() -> None:
         tmp = Path(td)
         archive = tmp / "loopx.tar.gz"
         home = tmp / "home"
+        fake_bin = tmp / "fake-bin"
+        unexpected_python_marker = tmp / "unexpected-python3"
         home.mkdir()
+        fake_bin.mkdir()
+        fake_python = fake_bin / "python3"
+        fake_python.write_text(
+            "#!/usr/bin/env bash\n"
+            f"touch {unexpected_python_marker!s}\n"
+            "exit 86\n",
+            encoding="utf-8",
+        )
+        fake_python.chmod(0o755)
 
         with tarfile.open(archive, "w:gz") as tar:
             for name in (
@@ -59,9 +70,11 @@ def main() -> None:
                 "LOOPX_ARCHIVE_URL": f"file://{archive}",
                 "LOOPX_INSTALL_CANARY": "0",
                 "LOOPX_PYTHON": sys.executable,
+                "PATH": f"{fake_bin}:{env.get('PATH', '')}",
             }
         )
         subprocess.run(["bash", str(script)], check=True, env=env, cwd=tmp)
+        assert not unexpected_python_marker.exists(), unexpected_python_marker
 
         installed = home / ".local" / "bin" / "loopx"
         assert installed.exists(), installed

--- a/examples/loopx-update-smoke.py
+++ b/examples/loopx-update-smoke.py
@@ -17,12 +17,13 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from loopx import __version__  # noqa: E402
 from loopx.release_manifest import release_version_tag  # noqa: E402
-from loopx.self_update import (
+from loopx.self_update import (  # noqa: E402
     DEFAULT_UPDATE_REF,
     _installer_env_for_source,
     build_rollback_plan,
     build_update_plan,
     execute_rollback_plan,
+    execute_update_plan,
     render_update_plan_markdown,
 )
 
@@ -194,6 +195,87 @@ def test_explicit_archive_url_reaches_installer() -> None:
     assert "LOOPX_ARCHIVE_URL=https://example.invalid/loopx.tar.gz" in payload["plan"]["install_command"], payload
     installer_env = _installer_env_for_source(payload["source"], base_env={})
     assert installer_env["LOOPX_ARCHIVE_URL"] == "https://example.invalid/loopx.tar.gz", installer_env
+
+
+def test_active_release_python_reaches_installer() -> None:
+    with TemporaryDirectory() as tmpdir:
+        release_root = Path(tmpdir) / "release"
+        release_root.mkdir()
+        (release_root / ".loopx-python").write_text(f"{sys.executable}\n", encoding="utf-8")
+        source = {"repo": "example/loopx", "ref": "stable"}
+
+        inherited = _installer_env_for_source(
+            source,
+            base_env={},
+            current_release_root=release_root,
+        )
+        assert inherited["LOOPX_PYTHON"] == sys.executable, inherited
+
+        explicit = _installer_env_for_source(
+            source,
+            base_env={"LOOPX_PYTHON": "/explicit/python"},
+            current_release_root=release_root,
+        )
+        assert explicit["LOOPX_PYTHON"] == "/explicit/python", explicit
+
+
+def test_active_release_python_marker_fails_closed() -> None:
+    with TemporaryDirectory() as tmpdir:
+        release_root = Path(tmpdir) / "release"
+        release_root.mkdir()
+        source = {"repo": "example/loopx", "ref": "stable"}
+        try:
+            _installer_env_for_source(
+                source,
+                base_env={},
+                current_release_root=release_root,
+            )
+        except ValueError as exc:
+            assert "missing its persisted Python runtime" in str(exc), exc
+        else:
+            raise AssertionError("missing release Python marker must fail closed")
+
+        (release_root / ".loopx-python").write_text("\n", encoding="utf-8")
+        try:
+            _installer_env_for_source(
+                source,
+                base_env={},
+                current_release_root=release_root,
+            )
+        except ValueError as exc:
+            assert "empty persisted Python runtime" in str(exc), exc
+        else:
+            raise AssertionError("empty release Python marker must fail closed")
+
+
+def test_execute_update_uses_persisted_release_python() -> None:
+    with TemporaryDirectory() as tmpdir:
+        release_root = Path(tmpdir) / "release"
+        release_root.mkdir()
+        missing_python = str(release_root / "missing-python")
+        (release_root / ".loopx-python").write_text(f"{missing_python}\n", encoding="utf-8")
+        payload = build_update_plan(
+            execute=True,
+            doctor_payload=fake_doctor_payload_for_release(release_root),
+        )
+        failed = subprocess.CompletedProcess(
+            args=[],
+            returncode=2,
+            stdout="",
+            stderr="loopx installer error: Python executable not found",
+        )
+        with mock.patch.dict(os.environ, {}, clear=True), mock.patch(
+            "loopx.self_update.subprocess.run",
+            side_effect=[failed, failed],
+        ) as run:
+            result = execute_update_plan(payload)
+
+        assert result["ok"] is False, result
+        assert run.call_count == 2, run.call_args_list
+        install_env = run.call_args_list[0].kwargs["env"]
+        doctor_env = run.call_args_list[1].kwargs["env"]
+        assert install_env["LOOPX_PYTHON"] == missing_python, install_env
+        assert doctor_env["LOOPX_PYTHON"] == missing_python, doctor_env
 
 
 def test_fresh_check_is_noop_recommendation() -> None:
@@ -380,6 +462,9 @@ def main() -> int:
     test_module_plan()
     test_default_source_uses_stable_ref()
     test_explicit_archive_url_reaches_installer()
+    test_active_release_python_reaches_installer()
+    test_active_release_python_marker_fails_closed()
+    test_execute_update_uses_persisted_release_python()
     test_fresh_check_is_noop_recommendation()
     test_check_compares_selected_source_version()
     test_check_degrades_when_source_version_is_unavailable()

--- a/loopx/self_update.py
+++ b/loopx/self_update.py
@@ -19,6 +19,7 @@ ROLLBACK_PREVIOUS_ALIAS = "previous"
 SOURCE_VERSION_CHECK_SCHEMA_VERSION = "loopx_source_version_check_v0"
 SOURCE_VERSION_CHECK_TIMEOUT_SECONDS = 3
 SOURCE_VERSION_READ_LIMIT_BYTES = 64 * 1024
+PERSISTED_PYTHON_FILENAME = ".loopx-python"
 _PACKAGE_VERSION_PATTERN = re.compile(r'^__version__\s*=\s*"([^"]+)"$', re.MULTILINE)
 
 
@@ -71,8 +72,24 @@ def _installer_env_for_source(
     source: dict[str, Any],
     *,
     base_env: dict[str, str] | None = None,
+    current_release_root: str | Path | None = None,
 ) -> dict[str, str]:
-    env = dict(base_env or os.environ)
+    env = dict(os.environ if base_env is None else base_env)
+    if not env.get("LOOPX_PYTHON") and current_release_root is not None:
+        marker = Path(current_release_root) / PERSISTED_PYTHON_FILENAME
+        try:
+            persisted_python = marker.read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            raise ValueError(
+                "active LoopX release snapshot is missing its persisted Python runtime; "
+                "set LOOPX_PYTHON to a Python 3.11+ executable before retrying"
+            ) from exc
+        if not persisted_python:
+            raise ValueError(
+                "active LoopX release snapshot has an empty persisted Python runtime; "
+                "set LOOPX_PYTHON to a Python 3.11+ executable before retrying"
+            )
+        env["LOOPX_PYTHON"] = persisted_python
     env["LOOPX_REPO"] = str(source.get("repo") or DEFAULT_UPDATE_REPO)
     env["LOOPX_REF"] = str(source.get("ref") or DEFAULT_UPDATE_REF)
     if source.get("channel") == "github_archive_url_override" and source.get("archive_url"):
@@ -406,7 +423,15 @@ def build_update_plan(
 def execute_update_plan(payload: dict[str, Any], *, timeout_seconds: int = 600) -> dict[str, Any]:
     source = payload.get("source") if isinstance(payload.get("source"), dict) else {}
     installer_url = str(source.get("installer_url") or NO_CLONE_INSTALL_URL)
-    env = _installer_env_for_source(source)
+    plan = payload.get("plan") if isinstance(payload.get("plan"), dict) else {}
+    backup = plan.get("backup") if isinstance(plan.get("backup"), dict) else {}
+    current_release_root = backup.get("current_release_root")
+    env = _installer_env_for_source(
+        source,
+        current_release_root=(
+            current_release_root if isinstance(current_release_root, str) else None
+        ),
+    )
     install_result = subprocess.run(
         ["bash", "-lc", f"curl -fsSL {shlex.quote(installer_url)} | bash"],
         text=True,

--- a/scripts/install-from-github.sh
+++ b/scripts/install-from-github.sh
@@ -5,6 +5,7 @@ repo="${LOOPX_REPO:-huangruiteng/loopx}"
 ref="${LOOPX_REF:-stable}"
 archive_url_override="${LOOPX_ARCHIVE_URL:-}"
 archive_url="$archive_url_override"
+python_bin="${LOOPX_PYTHON:-python3}"
 export LOOPX_REPO="$repo"
 export LOOPX_REF="$ref"
 
@@ -17,7 +18,7 @@ need() {
 
 need curl
 need tar
-need python3
+need "$python_bin"
 
 if [[ -n "${LOOPX_RESOLVED_SOURCE_GIT_COMMIT:-}" \
   && ! "$LOOPX_RESOLVED_SOURCE_GIT_COMMIT" =~ ^[0-9a-fA-F]{40}$ ]]; then
@@ -30,7 +31,7 @@ if [[ -z "$archive_url" ]]; then
     echo "loopx installer error: LOOPX_REPO must use GitHub owner/name syntax" >&2
     exit 2
   fi
-  commit_api_url="$(python3 - "$repo" "$ref" <<'PY'
+  commit_api_url="$("$python_bin" - "$repo" "$ref" <<'PY'
 from urllib.parse import quote
 import sys
 
@@ -46,7 +47,7 @@ PY
     -H 'Accept: application/vnd.github+json' \
     -H 'User-Agent: LoopX-installer' \
     "$commit_api_url")"
-  resolved_commit="$(LOOPX_COMMIT_JSON="$commit_json" python3 - <<'PY'
+  resolved_commit="$(LOOPX_COMMIT_JSON="$commit_json" "$python_bin" - <<'PY'
 import json
 import os
 
@@ -74,7 +75,7 @@ mkdir -p "$extract_dir"
 
 echo "loopx installer: downloading $archive_url" >&2
 curl -fsSL "$archive_url" -o "$archive_path"
-archive_sha256="$(python3 - "$archive_path" <<'PY'
+archive_sha256="$("$python_bin" - "$archive_path" <<'PY'
 from pathlib import Path
 import hashlib
 import sys


### PR DESCRIPTION
## Summary
- reuse the active release snapshot .loopx-python runtime for loopx update --execute when LOOPX_PYTHON is not explicitly set
- preserve explicit overrides and fail closed when the persisted marker is missing, empty, or names an unusable interpreter
- make the no-clone GitHub installer use the selected LOOPX_PYTHON for all helper Python calls

## Validation
- loopx canary premerge --from-git-diff: 13/13 passed, no warnings or manual holds
- Ruff passed on all changed Python files
- canonical mypy passed for 12 source files
- real temporary-home update execution passed with PATH python3 at 3.9, no explicit override, and a persisted Python 3.11 runtime carried into the next release snapshot

## Boundary
- public/private scan passed for all 5 changed files
- no credentials, private state, local paths, or generated logs are included