### PR TITLE
test(update): derive launcher from fixture home

### DIFF
--- a/examples/loopx-update-smoke.py
+++ b/examples/loopx-update-smoke.py
@@ -91,10 +91,10 @@ def fake_fresh_doctor_payload() -> dict[str, object]:
     return payload
 
 
-def fake_doctor_payload_for_release(release_root: Path) -> dict[str, object]:
+def fake_doctor_payload_for_release(release_root: Path, *, home: Path) -> dict[str, object]:
     return {
         "path": {
-            "loopx": str(release_root.parents[4] / ".local" / "bin" / "loopx"),
+            "loopx": str(home / ".local" / "bin" / "loopx"),
             "loopx_realpath": str(release_root / "scripts" / "loopx"),
         },
         "package": {
@@ -250,13 +250,14 @@ def test_active_release_python_marker_fails_closed() -> None:
 
 def test_execute_update_uses_persisted_release_python() -> None:
     with TemporaryDirectory() as tmpdir:
-        release_root = Path(tmpdir) / "release"
+        home = Path(tmpdir)
+        release_root = home / "release"
         release_root.mkdir()
         missing_python = str(release_root / "missing-python")
         (release_root / ".loopx-python").write_text(f"{missing_python}\n", encoding="utf-8")
         payload = build_update_plan(
             execute=True,
-            doctor_payload=fake_doctor_payload_for_release(release_root),
+            doctor_payload=fake_doctor_payload_for_release(release_root, home=home),
         )
         failed = subprocess.CompletedProcess(
             args=[],
@@ -359,7 +360,7 @@ def test_rollback_previous_executes_with_temp_home() -> None:
         current_release = write_fixture_release(home, "20260622T170342Z")
         payload = build_rollback_plan(
             release_id="previous",
-            doctor_payload=fake_doctor_payload_for_release(current_release),
+            doctor_payload=fake_doctor_payload_for_release(current_release, home=home),
             home=home,
         )
         assert payload["ok"] is True, payload
@@ -383,7 +384,7 @@ def test_rollback_restores_previous_when_doctor_fails() -> None:
         loopx_bin.symlink_to(current_release / "scripts" / "loopx")
         payload = build_rollback_plan(
             release_id=bad_release.name,
-            doctor_payload=fake_doctor_payload_for_release(current_release),
+            doctor_payload=fake_doctor_payload_for_release(current_release, home=home),
             home=home,
         )
         assert payload["ok"] is True, payload


### PR DESCRIPTION
## Summary
- remove the update smoke fixture's fixed `release_root.parents[4]` HOME inference
- pass each test's explicit fixture HOME into the fake doctor payload
- preserve all #2369 production behavior and persisted-release-Python assertions

## Validation
- `/private/tmp/loopx-full-public-boundary-board-20260720/.venv/bin/python examples/loopx-update-smoke.py`
- Full Public shard 4: `examples/run-smokes.py --suite full-public --offset 400 --limit 100 --timeout-seconds 120 --jobs 4 --json` (100/100 passed)
- `loopx canary premerge --from-git-diff` (self-merge allowed, no holds)
- `uvx ruff check examples/loopx-update-smoke.py`
- `git diff --cached --check`

## Environment note
- the macOS system Python 3.9 run reached the CLI subtest but cannot import `tomllib`; the same complete smoke passed under Python 3.13, while CI uses Python 3.11

## Boundary
- durable public validation fixture only
- no runtime/update behavior, credentials, private state, local paths, raw logs, or generated artifacts changed