### PR TITLE
Qualify N-Turn resumed Codex CLI flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,19 +487,23 @@ From a repository checkout with Codex CLI logged in, run this disposable,
 non-benchmark example:
 
 ```bash
-python3 examples/loopx-turn-codex-cli-e2e-smoke.py --real-codex-cli
+python3 examples/loopx-turn-codex-cli-e2e-smoke.py \
+  --real-codex-cli \
+  --two-turn-resume
 ```
 
-It creates a temporary goal and workspace, asks Codex CLI to write one marker,
-checks the marker with an independent validator, commits exactly one Turn and
-one quota spend, then replays the same transaction to prove it has no duplicate
-effects. The temporary state is deleted and is never synced to your global
-LoopX registry. Success reports `status=committed`,
-`validation_status=passed`, and `quota_slot_spend_count=1`.
+It creates a temporary goal and workspace, advances one marker through two
+separately validated Turns, and resumes the same opaque Codex CLI session for
+the second interaction. Each Turn commits once and spends once; the example
+then replays the second transaction to prove it has no duplicate effects. The
+temporary state is deleted and is never synced to your global LoopX registry.
+Success reports `status=committed`, `validation_status=passed`,
+`second_status=committed`, `second_validation_status=passed`,
+`session_resumed=true`, and `quota_slot_spend_count=2`.
 
 Run `codex --version` first. If the configured default model requires a newer
 Codex CLI, update Codex or add `--codex-model <qualified-model>`. The
-[one-Turn Codex CLI guide](docs/product/loopx-turn-codex-cli-quickstart.md)
+[Codex CLI Turn guide](docs/product/loopx-turn-codex-cli-quickstart.md)
 shows the command for a connected project and explains the validator boundary.
 
 ### Explore Graph And Harness (Supported, Optional, Default-Off)

--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ the run can claim progress. See
 [Auto-research command path](docs/guides/auto-research-command-path.md) for the
 full stop, attach, retry, and evidence boundary.
 
-### Experimental: Try One Governed Turn Locally
+### Experimental: Try Governed Turns Locally
 
 From a repository checkout with Codex CLI logged in, run this disposable,
 non-benchmark example:
@@ -489,17 +489,17 @@ non-benchmark example:
 ```bash
 python3 examples/loopx-turn-codex-cli-e2e-smoke.py \
   --real-codex-cli \
-  --two-turn-resume
+  --turn-count 3
 ```
 
-It creates a temporary goal and workspace, advances one marker through two
-separately validated Turns, and resumes the same opaque Codex CLI session for
-the second interaction. Each Turn commits once and spends once; the example
-then replays the second transaction to prove it has no duplicate effects. The
-temporary state is deleted and is never synced to your global LoopX registry.
-Success reports `status=committed`, `validation_status=passed`,
-`second_status=committed`, `second_validation_status=passed`,
-`session_resumed=true`, and `quota_slot_spend_count=2`.
+It creates a temporary goal and workspace, advances one marker through N
+separately validated Turns, and keeps one opaque Codex CLI session: the first
+Turn starts it and Turns 2 through N resume it. Each Turn commits once and
+spends once; the example then replays the final transaction to prove it has no
+duplicate effects. The temporary state is deleted and is never synced to your
+global LoopX registry. With `--turn-count 3`, success reports
+`status=committed`, `validation_status=passed`, `committed_turn_count=3`,
+`session_resumed=true`, and `quota_slot_spend_count=3`.
 
 Run `codex --version` first. If the configured default model requires a newer
 Codex CLI, update Codex or add `--codex-model <qualified-model>`. The

--- a/docs/product/loopx-turn-codex-cli-quickstart.md
+++ b/docs/product/loopx-turn-codex-cli-quickstart.md
@@ -58,8 +58,8 @@ The compact JSON result tells the caller what happens next:
 | `result_kind=wait` | No host work should run yet. |
 | `result_kind=user_action_required` | Show the concrete user action and do not invent a substitute. |
 
-A failed or unavailable validator cannot commit or spend. Replaying a committed
-Turn is idempotent: it does not invoke the host, write state, or spend again.
+A failed validator cannot commit or spend; replay invokes nothing. A new logical
+Turn uses a new stable `--turn-instance-id`, while retries reuse that id.
 
 ## Fit Another Runtime
 
@@ -90,7 +90,8 @@ python3 examples/loopx-turn-codex-cli-e2e-smoke.py
 python3 examples/loopx-turn-codex-cli-e2e-smoke.py \
   --real-codex-cli \
   --codex-model <qualified-model>
-python3 examples/loopx-turn-codex-cli-e2e-smoke.py --real-codex-cli --two-turn-resume --codex-model <qualified-model>
+python3 examples/loopx-turn-codex-cli-e2e-smoke.py \
+  --real-codex-cli --turn-count 3 --codex-model <qualified-model>
 ```
 
 The first command is deterministic and model-free. The second makes one real
@@ -99,12 +100,11 @@ one quota spend, and a replay with no side effects. A compact
 `codex_cli_model_requires_newer_codex` result is a host compatibility failure,
 not task progress; it must show zero state writes and zero quota spend.
 
-The third command makes two real calls against one temporary goal and todo. It
-starts an opaque session, then uses `codex exec resume`, validates the next
-marker, and commits separately. Success reports `session_resumed=true` and two
-quota spends. The session id remains private and is never printed or synced.
+The third command makes N real calls against one temporary goal and todo. It
+starts one opaque session, resumes it for Turns 2 through N, and independently
+validates every marker. With `--turn-count 3`, success reports
+`committed_turn_count=3`, `session_resumed=true`, and three quota spends. The
+session id remains private and is never printed or synced.
 
-That is the complete partner-facing path. Read the
-[Codex CLI adapter notes](codex-cli-automation-driver.md) for operational gaps
-or the [LoopX Turn protocol](../reference/protocols/loopx-turn-v0.md) only when
-implementing another host adapter or maintaining the runtime.
+That is the complete partner-facing path. For implementation details, read the
+[adapter notes](codex-cli-automation-driver.md) or the [Turn protocol](../reference/protocols/loopx-turn-v0.md).

--- a/docs/product/loopx-turn-codex-cli-quickstart.md
+++ b/docs/product/loopx-turn-codex-cli-quickstart.md
@@ -22,9 +22,8 @@ isolated project workspace, and an executable validator. The validator receives
 the normalized host result on stdin and exits zero only when the actual artifact
 or state is correct.
 
-Check the local host once with `codex doctor`. If the configured default model
-is newer than the installed Codex CLI supports, update Codex or pass a model
-already qualified for that installation with `--codex-model`.
+Check the local host once with `codex doctor`. If the default model is newer
+than the installed Codex CLI, update Codex or pass `--codex-model`.
 
 ## Run One Turn
 
@@ -77,21 +76,21 @@ state. Host observations such as requested, accepted, running, outcome-ready,
 failed, and resumed map to committed, repair, replan, or wait; they do not
 become new Turn states.
 
-Qualify a new adapter with one real task, a scenario owner, an adapter owner, a
-validator, and a measurable outcome. Add a structured event-reference field
-only after that call site proves the compact result cannot carry the evidence.
+Qualify a new adapter with a real task, scenario owner, adapter owner, validator,
+and measurable outcome. Add an event reference only after that call site proves
+the compact result cannot carry the evidence.
 
 ## Verify The Integration
 
 The repository ships a disposable qualification that keeps raw prompts,
-transcripts, stdout, stderr, credentials, and temporary workspaces out of LoopX
-state:
+transcripts, credentials, and temporary workspaces out of LoopX state:
 
 ```bash
 python3 examples/loopx-turn-codex-cli-e2e-smoke.py
 python3 examples/loopx-turn-codex-cli-e2e-smoke.py \
   --real-codex-cli \
   --codex-model <qualified-model>
+python3 examples/loopx-turn-codex-cli-e2e-smoke.py --real-codex-cli --two-turn-resume --codex-model <qualified-model>
 ```
 
 The first command is deterministic and model-free. The second makes one real
@@ -99,6 +98,11 @@ Codex CLI call and must report `status=committed`, `validation_status=passed`,
 one quota spend, and a replay with no side effects. A compact
 `codex_cli_model_requires_newer_codex` result is a host compatibility failure,
 not task progress; it must show zero state writes and zero quota spend.
+
+The third command makes two real calls against one temporary goal and todo. It
+starts an opaque session, then uses `codex exec resume`, validates the next
+marker, and commits separately. Success reports `session_resumed=true` and two
+quota spends. The session id remains private and is never printed or synced.
 
 That is the complete partner-facing path. Read the
 [Codex CLI adapter notes](codex-cli-automation-driver.md) for operational gaps

--- a/examples/loopx-turn-codex-cli-e2e-smoke.py
+++ b/examples/loopx-turn-codex-cli-e2e-smoke.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Qualify one LoopX Turn transaction with a fake or real Codex CLI host."""
+"""Qualify one or two LoopX Turn transactions with a Codex CLI host."""
 
 from __future__ import annotations
 
@@ -19,13 +19,19 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.cli import main as cli_main  # noqa: E402
+from loopx.control_plane.turn_driver import (  # noqa: E402
+    load_loopx_turn_plan_from_journal,
+)
 
 
 GOAL_ID = "loopx-turn-real-cli-e2e"
 AGENT_ID = "codex-turn-e2e"
 TODO_ID = "todo_turnreale2e01"
 MARKER_NAME = "docs/turn-e2e-marker.txt"
-MARKER_VALUE = "loopx-turn-real-e2e-ok"
+MARKER_VALUES = (
+    "loopx-turn-real-e2e-step-one",
+    "loopx-turn-real-e2e-step-two",
+)
 
 
 def _write_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
@@ -50,8 +56,9 @@ def _write_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
                 "## Agent Todo",
                 "",
                 (
-                    f"- [ ] [P0] Create `{MARKER_NAME}` in the current workspace "
-                    f"with exact content `{MARKER_VALUE}` and report validated progress."
+                    f"- [ ] [P0] Advance `{MARKER_NAME}` by exactly one step per "
+                    f"Turn: missing -> `{MARKER_VALUES[0]}` -> `{MARKER_VALUES[1]}`. "
+                    "Report validated progress after each step."
                 ),
                 (
                     f"  <!-- loopx:todo todo_id={TODO_ID} status=open "
@@ -118,7 +125,9 @@ import sys
 args = sys.argv[1:]
 prompt = sys.stdin.read()
 turn_key = re.search(r'"turn_key":"([^"]+)"', prompt).group(1)
-pathlib.Path({MARKER_NAME!r}).write_text({MARKER_VALUE!r}, encoding="utf-8")
+resumed = "resume" in args
+marker_value = {MARKER_VALUES[1]!r} if resumed else {MARKER_VALUES[0]!r}
+pathlib.Path({MARKER_NAME!r}).write_text(marker_value, encoding="utf-8")
 print(json.dumps({{
     "type": "thread.started",
     "thread_id": "session-fixture-0001",
@@ -144,13 +153,13 @@ output_path.write_text(json.dumps({{
     return executable
 
 
-def _validator_command() -> list[str]:
+def _validator_command(expected_marker: str) -> list[str]:
     program = (
         "import json,pathlib,sys; "
         "json.load(sys.stdin); "
         f"p=pathlib.Path({MARKER_NAME!r}); "
         "raise SystemExit(0 if p.is_file() and "
-        f"p.read_text(encoding='utf-8').strip() == {MARKER_VALUE!r} else 9)"
+        f"p.read_text(encoding='utf-8').strip() == {expected_marker!r} else 9)"
     )
     return [sys.executable, "-c", program]
 
@@ -172,6 +181,7 @@ def _base_argv(
     codex_bin: Path,
     model: str | None,
     timeout_seconds: float,
+    expected_marker: str,
 ) -> list[str]:
     argv = [
         "--registry",
@@ -197,7 +207,7 @@ def _base_argv(
         "--codex-sandbox",
         "workspace-write",
         "--validation-command-json",
-        json.dumps(_validator_command()),
+        json.dumps(_validator_command(expected_marker)),
         "--scan-root",
         str(registry.parent.parent),
         "--no-global-sync",
@@ -220,11 +230,33 @@ def _quota_spend_count(runtime: Path) -> int:
     )
 
 
+def _marker_matches(workspace: Path, expected: str) -> bool:
+    marker = workspace / MARKER_NAME
+    return marker.is_file() and marker.read_text(encoding="utf-8").strip() == expected
+
+
+def _session_action(runtime: Path, turn_key: object) -> str | None:
+    if not isinstance(turn_key, str):
+        return None
+    plan = load_loopx_turn_plan_from_journal(
+        runtime,
+        goal_id=GOAL_ID,
+        turn_key=turn_key,
+    )
+    session = plan.get("session")
+    return str(session.get("action")) if isinstance(session, dict) else None
+
+
 def _summary(
     *,
     real_codex_cli: bool,
+    two_turn_resume: bool,
     first_exit_code: int,
     first: dict[str, Any],
+    first_marker_valid: bool,
+    second_exit_code: int | None,
+    second: dict[str, Any] | None,
+    second_marker_valid: bool | None,
     replay_exit_code: int | None,
     replay: dict[str, Any] | None,
     runtime: Path,
@@ -237,8 +269,12 @@ def _summary(
     return {
         "schema_version": "loopx_turn_real_cli_e2e_v0",
         "real_codex_cli_invoked": real_codex_cli,
+        "two_turn_resume_requested": two_turn_resume,
         "model_explicit": model_explicit,
         "first_exit_code": first_exit_code,
+        "first_session_action": _session_action(
+            runtime, first.get("resume_turn_key")
+        ),
         "status": first.get("status"),
         "reason": first.get("reason"),
         "result_kind": first.get("result_kind"),
@@ -247,10 +283,35 @@ def _summary(
             validation.get("status") if isinstance(validation, dict) else None
         ),
         "effects": effects if isinstance(effects, dict) else {},
-        "marker_valid": (
-            (workspace / MARKER_NAME).is_file()
-            and (workspace / MARKER_NAME).read_text(encoding="utf-8").strip()
-            == MARKER_VALUE
+        "first_marker_valid": first_marker_valid,
+        "second_exit_code": second_exit_code,
+        "second_status": second.get("status") if isinstance(second, dict) else None,
+        "second_receipt_status": (
+            second.get("receipt", {}).get("status")
+            if isinstance(second, dict) and isinstance(second.get("receipt"), dict)
+            else None
+        ),
+        "second_validation_status": (
+            second.get("validation", {}).get("status")
+            if isinstance(second, dict) and isinstance(second.get("validation"), dict)
+            else None
+        ),
+        "second_effects": (
+            second.get("effects") if isinstance(second, dict) else None
+        ),
+        "second_session_action": (
+            _session_action(runtime, second.get("resume_turn_key"))
+            if isinstance(second, dict)
+            else None
+        ),
+        "second_marker_valid": second_marker_valid,
+        "session_resumed": (
+            isinstance(second, dict)
+            and _session_action(runtime, second.get("resume_turn_key")) == "resume"
+        ),
+        "marker_valid": _marker_matches(
+            workspace,
+            MARKER_VALUES[1] if two_turn_resume else MARKER_VALUES[0],
         ),
         "quota_slot_spend_count": _quota_spend_count(runtime),
         "replay_exit_code": replay_exit_code,
@@ -265,11 +326,19 @@ def main() -> int:
     parser.add_argument(
         "--real-codex-cli",
         action="store_true",
-        help="Invoke one real Codex CLI turn instead of the no-model fixture binary.",
+        help="Invoke the real Codex CLI host instead of the no-model fixture binary.",
     )
     parser.add_argument("--codex-bin", type=Path)
     parser.add_argument("--codex-model")
     parser.add_argument("--timeout-seconds", type=float, default=180.0)
+    parser.add_argument(
+        "--two-turn-resume",
+        action="store_true",
+        help=(
+            "Run two separately validated transactions on one opaque Codex CLI "
+            "session, then replay the second transaction idempotently."
+        ),
+    )
     args = parser.parse_args()
 
     with tempfile.TemporaryDirectory(prefix="loopx-turn-real-cli-e2e-") as directory:
@@ -292,19 +361,42 @@ def main() -> int:
             codex_bin=codex_bin,
             model=args.codex_model,
             timeout_seconds=args.timeout_seconds,
+            expected_marker=MARKER_VALUES[0],
         )
         first_exit_code, first = _run_cli([*base, "--execute"])
+        first_marker_valid = _marker_matches(workspace, MARKER_VALUES[0])
+        second_exit_code: int | None = None
+        second: dict[str, Any] | None = None
+        second_marker_valid: bool | None = None
+        if args.two_turn_resume and first_exit_code == 0:
+            second_base = _base_argv(
+                registry=registry,
+                runtime=runtime,
+                workspace=workspace,
+                codex_bin=codex_bin,
+                model=args.codex_model,
+                timeout_seconds=args.timeout_seconds,
+                expected_marker=MARKER_VALUES[1],
+            )
+            second_exit_code, second = _run_cli([*second_base, "--execute"])
+            second_marker_valid = _marker_matches(workspace, MARKER_VALUES[1])
         replay_exit_code: int | None = None
         replay: dict[str, Any] | None = None
-        turn_key = first.get("resume_turn_key")
+        replay_source = second if isinstance(second, dict) else first
+        turn_key = replay_source.get("resume_turn_key")
         if first_exit_code == 0 and isinstance(turn_key, str):
             replay_exit_code, replay = _run_cli(
                 [*base, "--resume-turn-key", turn_key, "--execute"]
             )
         summary = _summary(
             real_codex_cli=bool(args.real_codex_cli),
+            two_turn_resume=bool(args.two_turn_resume),
             first_exit_code=first_exit_code,
             first=first,
+            first_marker_valid=first_marker_valid,
+            second_exit_code=second_exit_code,
+            second=second,
+            second_marker_valid=second_marker_valid,
             replay_exit_code=replay_exit_code,
             replay=replay,
             runtime=runtime,
@@ -325,6 +417,17 @@ def main() -> int:
         "quota_spent": False,
         "scheduler_acknowledged": False,
     }
+    committed_effects = expected_effects
+    two_turn_ok = (
+        summary["second_exit_code"] == 0
+        and summary["second_status"] == "committed"
+        and summary["second_receipt_status"] == "committed"
+        and summary["second_validation_status"] == "passed"
+        and summary["second_effects"] == committed_effects
+        and summary["second_marker_valid"] is True
+        and summary["second_session_action"] == "resume"
+        and summary["session_resumed"] is True
+    ) if args.two_turn_resume else True
     return 0 if (
         summary["first_exit_code"] == 0
         and summary["status"] == "committed"
@@ -332,7 +435,9 @@ def main() -> int:
         and summary["validation_status"] == "passed"
         and summary["effects"] == expected_effects
         and summary["marker_valid"] is True
-        and summary["quota_slot_spend_count"] == 1
+        and summary["first_marker_valid"] is True
+        and summary["quota_slot_spend_count"] == (2 if args.two_turn_resume else 1)
+        and two_turn_ok
         and summary["replay_exit_code"] == 0
         and summary["replay_effects"] == replay_effects
         and summary["loopx_raw_host_output_recorded"] is False

--- a/examples/loopx-turn-codex-cli-e2e-smoke.py
+++ b/examples/loopx-turn-codex-cli-e2e-smoke.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Qualify one or two LoopX Turn transactions with a Codex CLI host."""
+"""Qualify N LoopX Turn transactions with a Codex CLI host."""
 
 from __future__ import annotations
 
@@ -28,13 +28,21 @@ GOAL_ID = "loopx-turn-real-cli-e2e"
 AGENT_ID = "codex-turn-e2e"
 TODO_ID = "todo_turnreale2e01"
 MARKER_NAME = "docs/turn-e2e-marker.txt"
-MARKER_VALUES = (
-    "loopx-turn-real-e2e-step-one",
-    "loopx-turn-real-e2e-step-two",
-)
+MARKER_PREFIX = "loopx-turn-real-e2e-step-"
 
 
-def _write_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("turn count must be at least 1")
+    return parsed
+
+
+def _marker_value(turn_number: int) -> str:
+    return f"{MARKER_PREFIX}{turn_number}"
+
+
+def _write_fixture(root: Path, *, turn_count: int) -> tuple[Path, Path, Path, Path]:
     project = root / "project"
     runtime = root / "runtime"
     workspace = root / "workspace"
@@ -56,9 +64,11 @@ def _write_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
                 "## Agent Todo",
                 "",
                 (
-                    f"- [ ] [P0] Advance `{MARKER_NAME}` by exactly one step per "
-                    f"Turn: missing -> `{MARKER_VALUES[0]}` -> `{MARKER_VALUES[1]}`. "
-                    "Report validated progress after each step."
+                    f"- [ ] [P0] Advance `{MARKER_NAME}` by exactly one numbered "
+                    f"step per Turn: missing -> `{_marker_value(1)}`; step-k -> "
+                    f"step-(k+1). Stop after `{_marker_value(turn_count)}` and report "
+                    "validated progress after each step. Name the completed and next "
+                    "numbered step in the typed result so LoopX can plan the next action."
                 ),
                 (
                     f"  <!-- loopx:todo todo_id={TODO_ID} status=open "
@@ -125,9 +135,15 @@ import sys
 args = sys.argv[1:]
 prompt = sys.stdin.read()
 turn_key = re.search(r'"turn_key":"([^"]+)"', prompt).group(1)
-resumed = "resume" in args
-marker_value = {MARKER_VALUES[1]!r} if resumed else {MARKER_VALUES[0]!r}
-pathlib.Path({MARKER_NAME!r}).write_text(marker_value, encoding="utf-8")
+marker = pathlib.Path({MARKER_NAME!r})
+turn_number = 1
+if marker.is_file():
+    current = marker.read_text(encoding="utf-8").strip()
+    match = re.fullmatch(re.escape({MARKER_PREFIX!r}) + r"([1-9][0-9]*)", current)
+    if match is None:
+        raise SystemExit("unexpected marker value")
+    turn_number = int(match.group(1)) + 1
+marker.write_text({MARKER_PREFIX!r} + str(turn_number), encoding="utf-8")
 print(json.dumps({{
     "type": "thread.started",
     "thread_id": "session-fixture-0001",
@@ -138,13 +154,13 @@ output_path.write_text(json.dumps({{
     "turn_key": turn_key,
     "result_kind": "validated_progress",
     "completed_phases": ["host_execute", "typed_result"],
-    "classification": "real_cli_e2e_fixture_progress",
-    "recommended_action": "Keep the qualified Turn path available.",
-    "next_action": "No follow-up is required for this fixture.",
+    "classification": f"real_cli_e2e_step_{{turn_number}}_progress",
+    "recommended_action": f"Advance the marker to step {{turn_number + 1}}.",
+    "next_action": f"Run the independently validated step {{turn_number + 1}} Turn.",
     "delivery_batch_scale": "single_surface",
     "delivery_outcome": "outcome_progress",
     "vision_unchanged_reason": "The fixture objective remains unchanged.",
-    "summary": "The isolated public marker was created.",
+    "summary": f"The isolated public marker reached step {{turn_number}}.",
 }}), encoding="utf-8")
 """,
         encoding="utf-8",
@@ -182,6 +198,7 @@ def _base_argv(
     model: str | None,
     timeout_seconds: float,
     expected_marker: str,
+    turn_instance_id: str,
 ) -> list[str]:
     argv = [
         "--registry",
@@ -196,6 +213,8 @@ def _base_argv(
         GOAL_ID,
         "--agent-id",
         AGENT_ID,
+        "--turn-instance-id",
+        turn_instance_id,
         "--host",
         "codex-cli",
         "--execution-mode",
@@ -247,72 +266,68 @@ def _session_action(runtime: Path, turn_key: object) -> str | None:
     return str(session.get("action")) if isinstance(session, dict) else None
 
 
+def _turn_summary(
+    *,
+    turn_number: int,
+    exit_code: int,
+    payload: dict[str, Any],
+    marker_valid: bool,
+    runtime: Path,
+) -> dict[str, Any]:
+    validation = payload.get("validation")
+    effects = payload.get("effects")
+    receipt = payload.get("receipt")
+    return {
+        "turn_number": turn_number,
+        "exit_code": exit_code,
+        "session_action": _session_action(runtime, payload.get("resume_turn_key")),
+        "status": payload.get("status"),
+        "reason": payload.get("reason"),
+        "result_kind": payload.get("result_kind"),
+        "receipt_status": receipt.get("status") if isinstance(receipt, dict) else None,
+        "validation_status": (
+            validation.get("status") if isinstance(validation, dict) else None
+        ),
+        "effects": effects if isinstance(effects, dict) else {},
+        "marker_valid": marker_valid,
+    }
+
+
 def _summary(
     *,
     real_codex_cli: bool,
-    two_turn_resume: bool,
-    first_exit_code: int,
-    first: dict[str, Any],
-    first_marker_valid: bool,
-    second_exit_code: int | None,
-    second: dict[str, Any] | None,
-    second_marker_valid: bool | None,
+    turn_count: int,
+    turns: list[dict[str, Any]],
     replay_exit_code: int | None,
     replay: dict[str, Any] | None,
     runtime: Path,
     workspace: Path,
     model_explicit: bool,
 ) -> dict[str, Any]:
-    validation = first.get("validation")
-    effects = first.get("effects")
-    receipt = first.get("receipt")
+    final_turn = turns[-1] if turns else {}
+    session_actions = [turn.get("session_action") for turn in turns]
     return {
-        "schema_version": "loopx_turn_real_cli_e2e_v0",
+        "schema_version": "loopx_turn_real_cli_e2e_v1",
         "real_codex_cli_invoked": real_codex_cli,
-        "two_turn_resume_requested": two_turn_resume,
         "model_explicit": model_explicit,
-        "first_exit_code": first_exit_code,
-        "first_session_action": _session_action(
-            runtime, first.get("resume_turn_key")
+        "requested_turn_count": turn_count,
+        "observed_turn_count": len(turns),
+        "committed_turn_count": sum(
+            turn.get("status") == "committed" for turn in turns
         ),
-        "status": first.get("status"),
-        "reason": first.get("reason"),
-        "result_kind": first.get("result_kind"),
-        "receipt_status": receipt.get("status") if isinstance(receipt, dict) else None,
-        "validation_status": (
-            validation.get("status") if isinstance(validation, dict) else None
-        ),
-        "effects": effects if isinstance(effects, dict) else {},
-        "first_marker_valid": first_marker_valid,
-        "second_exit_code": second_exit_code,
-        "second_status": second.get("status") if isinstance(second, dict) else None,
-        "second_receipt_status": (
-            second.get("receipt", {}).get("status")
-            if isinstance(second, dict) and isinstance(second.get("receipt"), dict)
-            else None
-        ),
-        "second_validation_status": (
-            second.get("validation", {}).get("status")
-            if isinstance(second, dict) and isinstance(second.get("validation"), dict)
-            else None
-        ),
-        "second_effects": (
-            second.get("effects") if isinstance(second, dict) else None
-        ),
-        "second_session_action": (
-            _session_action(runtime, second.get("resume_turn_key"))
-            if isinstance(second, dict)
-            else None
-        ),
-        "second_marker_valid": second_marker_valid,
-        "session_resumed": (
-            isinstance(second, dict)
-            and _session_action(runtime, second.get("resume_turn_key")) == "resume"
-        ),
-        "marker_valid": _marker_matches(
-            workspace,
-            MARKER_VALUES[1] if two_turn_resume else MARKER_VALUES[0],
-        ),
+        "turns": turns,
+        "session_actions": session_actions,
+        "session_resumed": turn_count > 1 and session_actions == [
+            "start_new",
+            *(["resume"] * (turn_count - 1)),
+        ],
+        "status": final_turn.get("status"),
+        "reason": final_turn.get("reason"),
+        "result_kind": final_turn.get("result_kind"),
+        "receipt_status": final_turn.get("receipt_status"),
+        "validation_status": final_turn.get("validation_status"),
+        "effects": final_turn.get("effects", {}),
+        "marker_valid": _marker_matches(workspace, _marker_value(turn_count)),
         "quota_slot_spend_count": _quota_spend_count(runtime),
         "replay_exit_code": replay_exit_code,
         "replay_effects": replay.get("effects") if isinstance(replay, dict) else None,
@@ -332,18 +347,23 @@ def main() -> int:
     parser.add_argument("--codex-model")
     parser.add_argument("--timeout-seconds", type=float, default=180.0)
     parser.add_argument(
-        "--two-turn-resume",
-        action="store_true",
+        "--turn-count",
+        type=_positive_int,
+        default=1,
+        metavar="N",
         help=(
-            "Run two separately validated transactions on one opaque Codex CLI "
-            "session, then replay the second transaction idempotently."
+            "Run N separately validated transactions on one opaque Codex CLI "
+            "session, then replay the final transaction idempotently (default: 1)."
         ),
     )
     args = parser.parse_args()
 
     with tempfile.TemporaryDirectory(prefix="loopx-turn-real-cli-e2e-") as directory:
         root = Path(directory)
-        project, runtime, workspace, registry = _write_fixture(root)
+        project, runtime, workspace, registry = _write_fixture(
+            root,
+            turn_count=args.turn_count,
+        )
         if args.real_codex_cli:
             candidate = args.codex_bin or (
                 Path(found) if (found := shutil.which("codex")) else None
@@ -354,49 +374,52 @@ def main() -> int:
         else:
             codex_bin = _write_fake_codex(root)
 
-        base = _base_argv(
-            registry=registry,
-            runtime=runtime,
-            workspace=workspace,
-            codex_bin=codex_bin,
-            model=args.codex_model,
-            timeout_seconds=args.timeout_seconds,
-            expected_marker=MARKER_VALUES[0],
-        )
-        first_exit_code, first = _run_cli([*base, "--execute"])
-        first_marker_valid = _marker_matches(workspace, MARKER_VALUES[0])
-        second_exit_code: int | None = None
-        second: dict[str, Any] | None = None
-        second_marker_valid: bool | None = None
-        if args.two_turn_resume and first_exit_code == 0:
-            second_base = _base_argv(
+        turns: list[dict[str, Any]] = []
+        turn_payloads: list[dict[str, Any]] = []
+        turn_bases: list[list[str]] = []
+        for turn_number in range(1, args.turn_count + 1):
+            base = _base_argv(
                 registry=registry,
                 runtime=runtime,
                 workspace=workspace,
                 codex_bin=codex_bin,
                 model=args.codex_model,
                 timeout_seconds=args.timeout_seconds,
-                expected_marker=MARKER_VALUES[1],
+                expected_marker=_marker_value(turn_number),
+                turn_instance_id=f"qualification-turn-{turn_number}",
             )
-            second_exit_code, second = _run_cli([*second_base, "--execute"])
-            second_marker_valid = _marker_matches(workspace, MARKER_VALUES[1])
+            exit_code, payload = _run_cli([*base, "--execute"])
+            turns.append(
+                _turn_summary(
+                    turn_number=turn_number,
+                    exit_code=exit_code,
+                    payload=payload,
+                    marker_valid=_marker_matches(
+                        workspace,
+                        _marker_value(turn_number),
+                    ),
+                    runtime=runtime,
+                )
+            )
+            turn_payloads.append(payload)
+            turn_bases.append(base)
+            if exit_code != 0:
+                break
         replay_exit_code: int | None = None
         replay: dict[str, Any] | None = None
-        replay_source = second if isinstance(second, dict) else first
-        turn_key = replay_source.get("resume_turn_key")
-        if first_exit_code == 0 and isinstance(turn_key, str):
+        final_payload = turn_payloads[-1] if turn_payloads else {}
+        turn_key = final_payload.get("resume_turn_key")
+        if turns and turns[-1]["exit_code"] == 0 and isinstance(turn_key, str):
+            replay_base = list(turn_bases[-1])
+            instance_index = replay_base.index("--turn-instance-id")
+            del replay_base[instance_index : instance_index + 2]
             replay_exit_code, replay = _run_cli(
-                [*base, "--resume-turn-key", turn_key, "--execute"]
+                [*replay_base, "--resume-turn-key", turn_key, "--execute"]
             )
         summary = _summary(
             real_codex_cli=bool(args.real_codex_cli),
-            two_turn_resume=bool(args.two_turn_resume),
-            first_exit_code=first_exit_code,
-            first=first,
-            first_marker_valid=first_marker_valid,
-            second_exit_code=second_exit_code,
-            second=second,
-            second_marker_valid=second_marker_valid,
+            turn_count=args.turn_count,
+            turns=turns,
             replay_exit_code=replay_exit_code,
             replay=replay,
             runtime=runtime,
@@ -417,27 +440,33 @@ def main() -> int:
         "quota_spent": False,
         "scheduler_acknowledged": False,
     }
-    committed_effects = expected_effects
-    two_turn_ok = (
-        summary["second_exit_code"] == 0
-        and summary["second_status"] == "committed"
-        and summary["second_receipt_status"] == "committed"
-        and summary["second_validation_status"] == "passed"
-        and summary["second_effects"] == committed_effects
-        and summary["second_marker_valid"] is True
-        and summary["second_session_action"] == "resume"
-        and summary["session_resumed"] is True
-    ) if args.two_turn_resume else True
+    expected_session_actions = [
+        "start_new",
+        *(["resume"] * (args.turn_count - 1)),
+    ]
+    turns_ok = (
+        summary["observed_turn_count"] == args.turn_count
+        and summary["committed_turn_count"] == args.turn_count
+        and summary["session_actions"] == expected_session_actions
+        and all(
+            turn["turn_number"] == index
+            and turn["exit_code"] == 0
+            and turn["status"] == "committed"
+            and turn["receipt_status"] == "committed"
+            and turn["validation_status"] == "passed"
+            and turn["effects"] == expected_effects
+            and turn["marker_valid"] is True
+            for index, turn in enumerate(summary["turns"], start=1)
+        )
+    )
     return 0 if (
-        summary["first_exit_code"] == 0
+        turns_ok
         and summary["status"] == "committed"
         and summary["receipt_status"] == "committed"
         and summary["validation_status"] == "passed"
         and summary["effects"] == expected_effects
         and summary["marker_valid"] is True
-        and summary["first_marker_valid"] is True
-        and summary["quota_slot_spend_count"] == (2 if args.two_turn_resume else 1)
-        and two_turn_ok
+        and summary["quota_slot_spend_count"] == args.turn_count
         and summary["replay_exit_code"] == 0
         and summary["replay_effects"] == replay_effects
         and summary["loopx_raw_host_output_recorded"] is False

--- a/examples/loopx-turn-codex-cli-quickstart-smoke.py
+++ b/examples/loopx-turn-codex-cli-quickstart-smoke.py
@@ -36,7 +36,7 @@ def main() -> int:
         "turn_key",
         "raw event stream",
         "they do not become new Turn states",
-        "a scenario owner",
+        "scenario owner",
         "loopx-turn-codex-cli-e2e-smoke.py",
         "codex_cli_model_requires_newer_codex",
     ]:
@@ -57,10 +57,13 @@ def main() -> int:
     assert f"product/{link}" in docs_index, "docs index link"
     for required in [
         "Try One Governed Turn Locally",
-        "loopx-turn-codex-cli-e2e-smoke.py --real-codex-cli",
+        "--real-codex-cli",
+        "--two-turn-resume",
         "status=committed",
+        "second_status=committed",
         "validation_status=passed",
-        "quota_slot_spend_count=1",
+        "session_resumed=true",
+        "quota_slot_spend_count=2",
     ]:
         assert required in readme, f"README local Turn quickstart: {required}"
 

--- a/examples/loopx-turn-codex-cli-quickstart-smoke.py
+++ b/examples/loopx-turn-codex-cli-quickstart-smoke.py
@@ -56,14 +56,14 @@ def main() -> int:
     assert link in product_index, "product index link"
     assert f"product/{link}" in docs_index, "docs index link"
     for required in [
-        "Try One Governed Turn Locally",
+        "Try Governed Turns Locally",
         "--real-codex-cli",
-        "--two-turn-resume",
+        "--turn-count 3",
         "status=committed",
-        "second_status=committed",
         "validation_status=passed",
         "session_resumed=true",
-        "quota_slot_spend_count=2",
+        "committed_turn_count=3",
+        "quota_slot_spend_count=3",
     ]:
         assert required in readme, f"README local Turn quickstart: {required}"
 

--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -203,6 +203,14 @@ def _add_turn_decision_arguments(
         ),
     )
     parser.add_argument(
+        "--turn-instance-id",
+        help=(
+            "Caller-stable public-safe identity for one logical Turn. Reusing the "
+            "same id replays idempotently; use a new id for a new Turn with the "
+            "same semantic action."
+        ),
+    )
+    parser.add_argument(
         "--resume-goal-id",
         help="Goal identity bound to an available opaque host session.",
     )
@@ -342,6 +350,7 @@ def handle_turn_command(
             execution_mode=args.execution_mode,
             scheduler_owner=args.scheduler_owner,
             session_binding=session_binding,
+            turn_instance_id=args.turn_instance_id,
         )
         if args.turn_command == "plan":
             if not args.include_transaction_detail:
@@ -352,6 +361,10 @@ def handle_turn_command(
                     boundary.pop("opaque_session_handle_omitted", None)
         elif args.turn_command == "run-once":
             if args.resume_turn_key:
+                if args.turn_instance_id:
+                    raise ValueError(
+                        "--resume-turn-key cannot be combined with --turn-instance-id"
+                    )
                 if supplied_resume_fields:
                     raise ValueError(
                         "--resume-turn-key cannot be combined with host session identity flags"

--- a/loopx/control_plane/turn_driver/driver.py
+++ b/loopx/control_plane/turn_driver/driver.py
@@ -152,6 +152,7 @@ def build_loopx_turn_plan(
     execution_mode: str,
     scheduler_owner: str | None = None,
     session_binding: Mapping[str, Any] | None = None,
+    turn_instance_id: str | None = None,
 ) -> dict[str, Any]:
     """Project a TurnEnvelope into a typed, side-effect-free host decision."""
 
@@ -215,6 +216,7 @@ def build_loopx_turn_plan(
             execution_mode=execution_mode,
             scheduler_owner=str(context_projection.get("scheduler_owner") or ""),
             session_action=str(session.get("action") or "none"),
+            turn_instance_id=turn_instance_id,
         ),
         "effects": {
             "host_invoked": False,

--- a/loopx/control_plane/turn_driver/transaction.py
+++ b/loopx/control_plane/turn_driver/transaction.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Mapping
 from enum import Enum
 from hashlib import sha256
@@ -22,6 +23,7 @@ TRANSACTION_PHASES = (
     "scheduler_apply",
     "scheduler_ack",
 )
+TURN_INSTANCE_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,127}")
 
 
 class LoopXTurnResultKind(str, Enum):
@@ -128,17 +130,28 @@ def build_loopx_turn_transaction_plan(
     execution_mode: str,
     session_action: str,
     scheduler_owner: str = "none",
+    turn_instance_id: str | None = None,
 ) -> dict[str, Any]:
-    turn_key = _canonical_hash(
-        {
-            "lineage": dict(lineage),
-            "host": host,
-            "execution_mode": execution_mode,
-            "scheduler_owner": scheduler_owner,
-            "session_action": session_action,
-        }
+    normalized_instance_id = (
+        str(turn_instance_id).strip() if turn_instance_id is not None else None
     )
-    return {
+    if normalized_instance_id is not None and not TURN_INSTANCE_ID_RE.fullmatch(
+        normalized_instance_id
+    ):
+        raise ValueError(
+            "turn_instance_id must be 1-128 public-safe letters, numbers, or ._:-"
+        )
+    identity = {
+        "lineage": dict(lineage),
+        "host": host,
+        "execution_mode": execution_mode,
+        "scheduler_owner": scheduler_owner,
+        "session_action": session_action,
+    }
+    if normalized_instance_id is not None:
+        identity["turn_instance_id"] = normalized_instance_id
+    turn_key = _canonical_hash(identity)
+    plan = {
         "schema_version": LOOPX_TURN_TRANSACTION_PLAN_SCHEMA_VERSION,
         "status": "planned" if planned else "not_applicable",
         "turn_key": turn_key,
@@ -150,6 +163,9 @@ def build_loopx_turn_transaction_plan(
             "next_phase": TRANSACTION_PHASES[0] if planned else None,
         },
     }
+    if normalized_instance_id is not None:
+        plan["turn_instance_id"] = normalized_instance_id
+    return plan
 
 
 def _result_kind(value: Any, errors: list[str]) -> LoopXTurnResultKind | None:

--- a/tests/test_loopx_turn_codex_cli.py
+++ b/tests/test_loopx_turn_codex_cli.py
@@ -366,13 +366,14 @@ def test_codex_cli_host_discards_missing_resume_session(
     assert codex_cli_session_binding(runtime_root, envelope) is None
 
 
-def test_public_e2e_smoke_runs_two_transactions_on_one_session() -> None:
+def test_public_e2e_smoke_runs_n_transactions_on_one_session() -> None:
     root = Path(__file__).resolve().parents[1]
     result = subprocess.run(
         [
             sys.executable,
             str(root / "examples" / "loopx-turn-codex-cli-e2e-smoke.py"),
-            "--two-turn-resume",
+            "--turn-count",
+            "3",
         ],
         cwd=root,
         check=False,
@@ -383,12 +384,15 @@ def test_public_e2e_smoke_runs_two_transactions_on_one_session() -> None:
 
     assert result.returncode == 0, result.stderr or result.stdout
     payload = json.loads(result.stdout)
-    assert payload["first_session_action"] == "start_new"
-    assert payload["second_session_action"] == "resume"
+    assert payload["requested_turn_count"] == 3
+    assert payload["observed_turn_count"] == 3
+    assert payload["committed_turn_count"] == 3
+    assert [turn["turn_number"] for turn in payload["turns"]] == [1, 2, 3]
+    assert payload["session_actions"] == ["start_new", "resume", "resume"]
     assert payload["session_resumed"] is True
-    assert payload["first_marker_valid"] is True
-    assert payload["second_marker_valid"] is True
-    assert payload["quota_slot_spend_count"] == 2
+    assert all(turn["marker_valid"] for turn in payload["turns"])
+    assert payload["marker_valid"] is True
+    assert payload["quota_slot_spend_count"] == 3
     assert payload["replay_effects"] == {
         "host_invoked": False,
         "quota_spent": False,

--- a/tests/test_loopx_turn_codex_cli.py
+++ b/tests/test_loopx_turn_codex_cli.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import stat
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -362,3 +364,34 @@ def test_codex_cli_host_discards_missing_resume_session(
     envelope = first_request["turn_envelope"]
     assert isinstance(envelope, dict)
     assert codex_cli_session_binding(runtime_root, envelope) is None
+
+
+def test_public_e2e_smoke_runs_two_transactions_on_one_session() -> None:
+    root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(root / "examples" / "loopx-turn-codex-cli-e2e-smoke.py"),
+            "--two-turn-resume",
+        ],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["first_session_action"] == "start_new"
+    assert payload["second_session_action"] == "resume"
+    assert payload["session_resumed"] is True
+    assert payload["first_marker_valid"] is True
+    assert payload["second_marker_valid"] is True
+    assert payload["quota_slot_spend_count"] == 2
+    assert payload["replay_effects"] == {
+        "host_invoked": False,
+        "quota_spent": False,
+        "scheduler_acknowledged": False,
+        "state_written": False,
+    }

--- a/tests/test_loopx_turn_driver.py
+++ b/tests/test_loopx_turn_driver.py
@@ -171,6 +171,45 @@ def test_turn_plan_transaction_key_is_stable_and_todo_scoped() -> None:
     assert first["transaction"]["turn_key"] != changed["transaction"]["turn_key"]
 
 
+def test_turn_plan_instance_id_distinguishes_new_turns_from_retries() -> None:
+    first = build_loopx_turn_plan(
+        _envelope(),
+        host="generic-cli",
+        execution_mode="isolated-headless",
+        turn_instance_id="batch-42:turn-1",
+    )
+    retry = build_loopx_turn_plan(
+        _envelope(),
+        host="generic-cli",
+        execution_mode="isolated-headless",
+        turn_instance_id="batch-42:turn-1",
+    )
+    second = build_loopx_turn_plan(
+        _envelope(),
+        host="generic-cli",
+        execution_mode="isolated-headless",
+        turn_instance_id="batch-42:turn-2",
+    )
+
+    assert first["transaction"]["turn_instance_id"] == "batch-42:turn-1"
+    assert first["transaction"]["turn_key"] == retry["transaction"]["turn_key"]
+    assert first["transaction"]["turn_key"] != second["transaction"]["turn_key"]
+
+
+@pytest.mark.parametrize(
+    "instance_id",
+    ["", "contains space", "private/path", "x" * 129],
+)
+def test_turn_plan_rejects_unsafe_instance_id(instance_id: str) -> None:
+    with pytest.raises(ValueError, match="turn_instance_id"):
+        build_loopx_turn_plan(
+            _envelope(),
+            host="generic-cli",
+            execution_mode="isolated-headless",
+            turn_instance_id=instance_id,
+        )
+
+
 @pytest.mark.parametrize(
     ("effective_action", "expected"),
     [


### PR DESCRIPTION
## Summary
- generalize the disposable Codex CLI Turn qualification from a two-step branch to `--turn-count N`
- add an optional caller-stable `--turn-instance-id` so a new logical Turn with the same semantic action gets a distinct transaction key while same-id retries remain idempotent
- independently validate every marker transition, keep one opaque Codex CLI session, spend exactly once per committed Turn, and replay the final journal with zero effects

## Changed surfaces
- Turn transaction identity and `turn plan` / `turn run-once` CLI plumbing
- experimental README and Codex CLI Turn quickstart
- disposable public N-Turn qualification example
- focused transaction, session-resume, quickstart, and N=3 regression coverage

## Validation
- deterministic N=3 qualification: `start_new -> resume -> resume`, 3 validators passed, 3 commits/spends, final replay had zero effects
- deterministic default N=1 qualification passed
- focused Turn tests: 58 passed
- full pytest suite: 918 passed, 2 skipped
- Ruff and Python compile checks passed
- `loopx canary premerge --from-git-diff --tier standard`: 4 direct checks and 17 selected checks passed, 0 failures/warnings
- `loopx check`: 9 changed public files scanned, 0 errors/warnings

## Failures, skips, and holds
- the earlier head qualified two real Codex CLI calls; the current N=3 refinement was validated with the deterministic host and did not spend three additional model calls
- the two full-suite skips are existing environment-dependent skips
- no private state, raw prompts/transcripts, session ids, credentials, benchmark artifacts, generated lockfiles, or temporary paths are included
- hold merge for independent exact-head review; this PR is not self-merged
