### PR TITLE
fix(quota): scope vision wait candidates by agent claim

### DIFF
--- a/loopx/control_plane/todos/deferred_resume.py
+++ b/loopx/control_plane/todos/deferred_resume.py
@@ -309,7 +309,9 @@ def todo_summary_blocked_successor_items(
     Open resume-gated todos and deferred todos share the same wait contract.
     A standing continuous monitor is deliberately excluded because it has a
     dedicated gate-repair route: an endless monitor must not become a hidden
-    ``todo_done`` prerequisite for ordinary advancement.
+    ``todo_done`` prerequisite for ordinary advancement. Current-agent claims
+    outrank unclaimed waits before ordinary priority ordering, matching the
+    agent-scoped open-todo selection contract.
     """
 
     if not isinstance(value, dict) or not agent_id:
@@ -349,7 +351,15 @@ def todo_summary_blocked_successor_items(
         compact["resume_when"] = resume_when
         compact["resume_ready"] = False
         selected.append(compact)
-    return sorted(_dedupe_todo_items(selected), key=todo_projection_sort_key)
+    return sorted(
+        _dedupe_todo_items(selected),
+        key=lambda item: (
+            0
+            if normalize_todo_claimed_by(item.get("claimed_by")) == agent_id
+            else 1,
+            *todo_projection_sort_key(item),
+        ),
+    )
 
 
 def _agent_claim_filtered_deferred_items(

--- a/tests/control_plane/test_goal_vision_blocked_successor.py
+++ b/tests/control_plane/test_goal_vision_blocked_successor.py
@@ -36,6 +36,8 @@ AGENT_ID = "codex-side-agent"
 PRIMARY_AGENT = "codex-primary-agent"
 BLOCKER_ID = "todo_exact_blocker"
 WAITING_ID = "todo_waiting_successor"
+CROSS_DOMAIN_WAITING_ID = "todo_cross_domain_waiting"
+CLAIMED_WAITING_ID = "todo_claimed_waiting"
 
 
 def _vision_run(
@@ -115,6 +117,56 @@ def _status_payload(
                 missing_checkpoint=missing_checkpoint,
             )
         ],
+    )
+
+
+def _cross_domain_wait_status_payload() -> dict:
+    unclaimed = quota_todo_item(
+        todo_id=CROSS_DOMAIN_WAITING_ID,
+        index=1,
+        text="[P1] Resume a benchmark-runner task owned by another lane.",
+        status="deferred",
+        priority="P1",
+        action_kind="benchmark_runner_external_lane",
+        required_capabilities=["benchmark_runner"],
+        resume_when="capacity_available:benchmark_runner",
+    )
+    claimed = quota_todo_item(
+        todo_id=CLAIMED_WAITING_ID,
+        index=2,
+        text="[P2] Resume this agent's release qualification successor.",
+        status="deferred",
+        priority="P2",
+        action_kind="release_outcome_baseline_qualification",
+        claimed_by=AGENT_ID,
+        required_capabilities=["benchmark_runner"],
+        resume_when="capacity_available:benchmark_runner",
+    )
+    agent_todos = quota_todo_summary([unclaimed, claimed], role="agent")
+    return quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        recommended_action="Wait for the current agent's exact successor.",
+        agent_todos=agent_todos,
+        coordination={
+            "agent_model": "peer_v1",
+            "registered_agents": [PRIMARY_AGENT, AGENT_ID],
+            "agent_profiles": {
+                AGENT_ID: {
+                    "schema_version": "agent_profile_v1",
+                    "agent_id": AGENT_ID,
+                    "profile_role": "quality-qualification",
+                    "default_task_classes": [
+                        "advancement_task",
+                        "continuous_monitor",
+                    ],
+                    "vision_requirement": "required",
+                    "preferred_action_kinds": ["release_outcome_baseline_*"],
+                    "avoid_action_kinds": ["benchmark_runner_*"],
+                }
+            },
+        },
+        latest_runs=[_vision_run()],
     )
 
 
@@ -207,6 +259,26 @@ def test_exact_blocked_successor_defers_only_open_vision_gap(
         f"todo_id={WAITING_ID} resume_when=todo_done:{BLOCKER_ID} "
         "automatic_resume=True"
     ) in markdown
+
+
+def test_agent_claimed_wait_outranks_unclaimed_cross_domain_wait() -> None:
+    guard = _quota(_cross_domain_wait_status_payload())
+
+    assert guard["decision"] == "agent_scope_wait"
+    wait = guard["goal_frontier_projection"]["vision_wait_state"]
+    assert wait["selected_todo_id"] == CLAIMED_WAITING_ID
+    assert wait["selected_todo_claimed_by"] == AGENT_ID
+    assert wait["waiting_todo_ids"] == [
+        CLAIMED_WAITING_ID,
+        CROSS_DOMAIN_WAITING_ID,
+    ]
+
+    status_payload = _cross_domain_wait_status_payload()
+    attach_agent_lane_next_actions(status_payload, agent_id=AGENT_ID)
+    item = status_payload["attention_queue"]["items"][0]
+    status_wait = item["goal_frontier_projection"]["vision_wait_state"]
+    assert status_wait["selected_todo_id"] == CLAIMED_WAITING_ID
+    assert status_wait["waiting_todo_ids"] == wait["waiting_todo_ids"]
 
 
 def test_two_identical_blocked_successor_waits_trigger_bounded_replan() -> None:


### PR DESCRIPTION
## Summary

- make blocked-successor vision waits follow the same claim bucket ordering as ordinary agent-scoped todo selection
- keep current-agent claimed waits ahead of unclaimed waits before priority/index sorting
- add an integrated quota/status regression where an unclaimed cross-domain P1 must not outrank the current agent's claimed P2 successor

## Root cause

`todo_summary_blocked_successor_items` filtered out other-agent claims but then globally re-sorted the remaining current-agent and unclaimed candidates by priority. That discarded the lane ownership precedence already used by normal todo selection.

## Validation

- `uv run --extra test pytest -q tests/control_plane/test_goal_vision_blocked_successor.py tests/control_plane/test_goal_frontier_replan_rules.py tests/control_plane/test_monitor_replan_agent_scope.py` (35 passed)
- `uv run --extra test ruff check loopx/control_plane/todos/deferred_resume.py tests/control_plane/test_goal_vision_blocked_successor.py`
- `loopx canary premerge --from-git-diff` (17/17 selected checks passed, 0 manual holds)

No todo lifecycle, capability grant, or cross-agent authority semantics change.