### PR TITLE
Avoid repeated monitor user-action notices

### DIFF
--- a/examples/control_plane/interaction-contract-state-machine-smoke.py
+++ b/examples/control_plane/interaction-contract-state-machine-smoke.py
@@ -477,16 +477,34 @@ def assert_user_action_is_non_blocking_notice() -> None:
 
 
 def assert_monitor_quiet_skip_is_no_spend() -> None:
-    payload = finalize(
-        base_payload(
-            should_run=False,
-            effective_action="monitor_quiet_skip",
-            work_lane=monitor_quiet_lane(),
-            heartbeat_mode="monitor_quiet_until_material_transition",
-        )
+    payload = base_payload(
+        should_run=False,
+        effective_action="monitor_quiet_skip",
+        work_lane=monitor_quiet_lane(),
+        heartbeat_mode="monitor_quiet_until_material_transition",
     )
+    user_action = {
+        "todo_id": "todo_user_action_pending",
+        "status": "open",
+        "task_class": "user_action",
+        "text": "Review the already surfaced optional repository setting.",
+    }
+    payload["user_todo_summary"] = compact_quota_todo_summary_for_payload(
+        {
+            "first_open_items": [user_action],
+            "user_action_open_count": 1,
+            "user_action_items": [user_action],
+        }
+    )
+    payload = finalize(payload)
     contract = payload["interaction_contract"]
     assert contract["mode"] == "monitor_quiet_skip", payload
+    assert contract["user_channel"]["action_required"] is False, contract
+    assert contract["user_channel"]["notify"] == "DONT_NOTIFY", contract
+    assert contract["user_channel"]["non_blocking"] is True, contract
+    assert contract["user_channel"]["actions"] == [
+        "Review the already surfaced optional repository setting."
+    ], contract
     assert contract["agent_channel"]["must_attempt"] is False, contract
     assert contract["agent_channel"]["quiet_noop_allowed"] is True, contract
     assert contract["cli_channel"]["spend_after_validation"] is False, contract

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -874,6 +874,7 @@ def _build_interaction_user_channel(
     payload: dict[str, Any],
     heartbeat_recommendation: dict[str, Any],
     *,
+    mode: str,
     user_required: bool,
 ) -> dict[str, Any]:
     actions = projected_user_channel_actions(payload, limit=3)
@@ -881,10 +882,15 @@ def _build_interaction_user_channel(
         not user_required
         and user_channel_notice_todo_actions(payload.get("user_todo_summary"), limit=3)
     )
+    unchanged_monitor_notice = bool(
+        non_blocking_notice
+        and mode == "monitor_quiet_skip"
+        and heartbeat_recommendation.get("notify") == "DONT_NOTIFY"
+    )
     channel: dict[str, Any] = {
         "action_required": user_required,
         "notify": "NOTIFY"
-        if user_required or non_blocking_notice
+        if user_required or (non_blocking_notice and not unchanged_monitor_notice)
         else "DONT_NOTIFY"
         if _user_gate_notification_suppressed(payload)
         else heartbeat_recommendation.get("notify", "DONT_NOTIFY"),
@@ -1088,6 +1094,7 @@ def build_interaction_contract(
     user_channel = _build_interaction_user_channel(
         payload,
         heartbeat_recommendation,
+        mode=mode,
         user_required=user_required,
     )
     agent_channel = _build_interaction_agent_channel(


### PR DESCRIPTION
## Summary

- keep non-blocking user actions visible in the interaction payload during unchanged monitor-only polls
- stop overriding an explicit `monitor_quiet_skip` / `DONT_NOTIFY` recommendation with a repeated user notification
- preserve notification behavior for normal delivery and blocking user gates

## Validation

- `python3 examples/control_plane/interaction-contract-state-machine-smoke.py`
- `python3 examples/control_plane/quota-heartbeat-recommendation-state-machine-smoke.py`
- `python3 examples/control_plane/quota-agent-scoped-user-gate-smoke.py`
- `uv run --no-project --with 'pytest>=8,<9' -- python -m pytest -q tests/control_plane/test_scheduler_interaction_arbitration.py` (13 passed)
- `uvx --from 'ruff==0.12.12' ruff check loopx/control_plane/work_items/interaction_contract.py examples/control_plane/interaction-contract-state-machine-smoke.py`
- `loopx canary premerge --from-git-diff --no-progress` (9/9 catalog canaries, 8/8 risk-profile smokes, 1/1 public-boundary check; no failures, warnings, or manual holds)

## Boundary

No credentials, private state, raw benchmark evidence, local paths, or generated logs are included. This PR changes notification projection only; it does not alter todo gating, scheduler cadence, monitor execution, or quota spending.
