### PR TITLE
Fix SkillsBench setup failure diagnostics

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -5148,6 +5148,10 @@ def test_skillsbench_volume_mount_failure_attribution() -> None:
         ], compact
         fingerprint = compact["runner_failure_fingerprint"]
         assert "volume_mount_failure" in fingerprint["matched_patterns"], fingerprint
+        assert fingerprint["terminal_failure_reason_codes"] == [
+            "missing_file"
+        ], fingerprint
+        assert fingerprint["retryability"] == "non_retryable", fingerprint
         plan = {
             "route": "loopx-product-mode",
             "task_id": "suricata-custom-exfil",
@@ -5185,6 +5189,10 @@ def test_skillsbench_volume_mount_failure_attribution() -> None:
         assert reduced is not None
         diagnostic = reduced["compose_setup_diagnostic"]
         assert diagnostic["volume_mount_failure"] is True, diagnostic
+        assert diagnostic["apt_repository_failure"] is False, diagnostic
+        assert diagnostic["primary_setup_failure_category"] == (
+            "volume_mount"
+        ), diagnostic
         assert diagnostic["unclassified_compose_failure"] is False, diagnostic
         assert diagnostic["next_diagnostic_action"] == (
             "repair_task_volume_mount_setup_before_product_treatment"
@@ -5198,6 +5206,12 @@ def test_skillsbench_volume_mount_failure_attribution() -> None:
         )
         ledger_diagnostic = update["entry"]["compose_setup_diagnostic"]
         assert ledger_diagnostic["volume_mount_failure"] is True, ledger_diagnostic
+        assert ledger_diagnostic["primary_setup_failure_category"] == (
+            "volume_mount"
+        ), ledger_diagnostic
+        assert ledger_diagnostic["retryability"] == (
+            "non_retryable"
+        ), ledger_diagnostic
         assert ledger_diagnostic["unclassified_compose_failure"] is False, (
             ledger_diagnostic
         )

--- a/loopx/benchmark_adapters/skillsbench_failure_signals.py
+++ b/loopx/benchmark_adapters/skillsbench_failure_signals.py
@@ -432,7 +432,10 @@ def skillsbench_runner_error_fingerprint(error_text: str) -> dict[str, object]:
             r"network|connection refused|could not connect|read timed out|"
             r"connection timed out|connection reset|max retries exceeded"
         ),
-        "volume_mount_failure": r"mount|volume|bind source path",
+        "volume_mount_failure": (
+            r"invalid mount config|bind source path|mount denied|failed to mount|"
+            r"error while mounting|volume [^\n]*(?:not found|does not exist|invalid)"
+        ),
         "permission_denied": r"permission denied|operation not permitted",
         "missing_file": r"no such file|not found|does not exist",
         "codex_api_egress_failure": (

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -327,6 +327,8 @@ def _compact_compose_setup_diagnostic(value: Any) -> dict[str, Any]:
         "runner_prerequisite_status",
         "task_setup_preflight_status",
         "runner_error_len_bucket",
+        "primary_setup_failure_category",
+        "retryability",
         "next_diagnostic_action",
     ):
         text = _compact_text(value.get(field), limit=140)
@@ -336,6 +338,7 @@ def _compact_compose_setup_diagnostic(value: Any) -> dict[str, Any]:
         "compose_setup_failure",
         "unclassified_compose_failure",
         "docker_daemon_unavailable",
+        "apt_repository_failure",
         "volume_mount_failure",
         "environment_setup_failure",
         "agent_rounds_started",
@@ -376,6 +379,14 @@ def _compact_compose_setup_diagnostic(value: Any) -> dict[str, Any]:
     patterns = _compact_list(value.get("fingerprint_matched_patterns"), limit=8)
     if patterns:
         compact["fingerprint_matched_patterns"] = patterns
+    for field in (
+        "terminal_failure_dependency_classes",
+        "terminal_failure_reason_codes",
+        "terminal_failure_dependency_endpoints",
+    ):
+        values = _compact_list(value.get(field), limit=8)
+        if values:
+            compact[field] = values
     return compact
 
 

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -1524,6 +1524,8 @@ def _compact_benchmark_compose_setup_diagnostic(value: Any) -> dict[str, Any]:
         "task_setup_preflight_status",
         "fingerprint_confidence",
         "runner_error_len_bucket",
+        "primary_setup_failure_category",
+        "retryability",
         "next_diagnostic_action",
     ):
         text = public_safe_compact_text(value.get(field), limit=180)
@@ -1533,6 +1535,7 @@ def _compact_benchmark_compose_setup_diagnostic(value: Any) -> dict[str, Any]:
         "compose_setup_failure",
         "unclassified_compose_failure",
         "docker_daemon_unavailable",
+        "apt_repository_failure",
         "volume_mount_failure",
         "environment_setup_failure",
         "agent_rounds_started",
@@ -1576,6 +1579,17 @@ def _compact_benchmark_compose_setup_diagnostic(value: Any) -> dict[str, Any]:
     )
     if patterns:
         compact["fingerprint_matched_patterns"] = patterns
+    for field in (
+        "terminal_failure_dependency_classes",
+        "terminal_failure_reason_codes",
+        "terminal_failure_dependency_endpoints",
+    ):
+        values = public_safe_compact_list(
+            value.get(field),
+            limit=MAX_BENCHMARK_RUN_LIST_ITEMS * 2,
+        )
+        if values:
+            compact[field] = values
     return compact
 
 
@@ -2986,6 +3000,7 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
             "schema_version",
             "error_len_bucket",
             "fingerprint_confidence",
+            "retryability",
         ):
             value = public_safe_compact_text(fingerprint.get(field), limit=100)
             if value:
@@ -2996,6 +3011,17 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         for field, limit in (
             ("matched_patterns", MAX_BENCHMARK_RUN_LIST_ITEMS * 4),
             ("failure_line_dependency_classes", MAX_BENCHMARK_RUN_LIST_ITEMS * 2),
+            ("failure_reason_codes", MAX_BENCHMARK_RUN_LIST_ITEMS * 2),
+            (
+                "terminal_failure_dependency_classes",
+                MAX_BENCHMARK_RUN_LIST_ITEMS * 2,
+            ),
+            ("terminal_failure_reason_codes", MAX_BENCHMARK_RUN_LIST_ITEMS * 2),
+            ("failure_dependency_endpoints", MAX_BENCHMARK_RUN_LIST_ITEMS * 2),
+            (
+                "terminal_failure_dependency_endpoints",
+                MAX_BENCHMARK_RUN_LIST_ITEMS * 2,
+            ),
         ):
             values = public_safe_compact_list(fingerprint.get(field), limit=limit)
             if values:

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -6183,6 +6183,28 @@ def build_compose_setup_diagnostic(
         if isinstance(compact.get("runner_failure_fingerprint"), dict)
         else {}
     )
+    fingerprint_matched_patterns = [
+        str(item)[:120]
+        for item in fingerprint.get("matched_patterns", [])
+        if isinstance(item, str)
+    ][:10]
+    matched_patterns = set(fingerprint_matched_patterns)
+    terminal_dependency_classes = [
+        str(item)[:120]
+        for item in fingerprint.get("terminal_failure_dependency_classes", [])
+        if isinstance(item, str)
+    ][:10]
+    terminal_failure_reason_codes = [
+        str(item)[:120]
+        for item in fingerprint.get("terminal_failure_reason_codes", [])
+        if isinstance(item, str)
+    ][:10]
+    terminal_failure_dependency_endpoints = [
+        str(item)[:120]
+        for item in fingerprint.get("terminal_failure_dependency_endpoints", [])
+        if isinstance(item, str)
+    ][:10]
+    retryability = str(fingerprint.get("retryability") or "unknown")[:80]
     discovery = (
         compact.get("result_discovery")
         if isinstance(compact.get("result_discovery"), dict)
@@ -6238,24 +6260,36 @@ def build_compose_setup_diagnostic(
     docker_daemon_unavailable = (
         score_failure == "skillsbench_docker_daemon_unavailable"
         or "skillsbench_docker_daemon_unavailable" in labels
-        or "docker_daemon_unavailable" in {
-            str(item)
-            for item in fingerprint.get("matched_patterns", [])
-            if isinstance(item, str)
-        }
+        or "docker_daemon_unavailable" in matched_patterns
+    )
+    apt_repository_failure = (
+        score_failure == "skillsbench_docker_compose_apt_repository_failure"
+        or "skillsbench_docker_compose_apt_repository_failure" in labels
+        or "system_package" in terminal_dependency_classes
+        or any(code.startswith("apt_") for code in terminal_failure_reason_codes)
     )
     volume_mount_failure = (
         score_failure == "skillsbench_docker_compose_volume_mount_failure"
         or "skillsbench_docker_compose_volume_mount_failure" in labels
-        or "volume_mount_failure" in {
-            str(item)
-            for item in fingerprint.get("matched_patterns", [])
-            if isinstance(item, str)
-        }
+        or "volume_mount_failure" in matched_patterns
     )
+    if apt_repository_failure:
+        primary_setup_failure_category = "system_package_repository"
+    elif volume_mount_failure:
+        primary_setup_failure_category = "volume_mount"
+    elif docker_daemon_unavailable:
+        primary_setup_failure_category = "docker_runtime"
+    elif unclassified:
+        primary_setup_failure_category = "unclassified"
+    else:
+        primary_setup_failure_category = "runner_setup"
     if compose_setup_failure and not agent_rounds_started:
         status = "compose_setup_blocked_before_agent_rounds"
-        if volume_mount_failure:
+        if apt_repository_failure:
+            next_action = (
+                "repair_system_package_repository_setup_before_product_treatment"
+            )
+        elif volume_mount_failure:
             next_action = "repair_task_volume_mount_setup_before_product_treatment"
         elif unclassified:
             next_action = "classify_sanitized_compose_setup_category_before_product_treatment"
@@ -6280,7 +6314,15 @@ def build_compose_setup_diagnostic(
         "compose_setup_failure": compose_setup_failure,
         "unclassified_compose_failure": unclassified,
         "docker_daemon_unavailable": docker_daemon_unavailable,
+        "apt_repository_failure": apt_repository_failure,
         "volume_mount_failure": volume_mount_failure,
+        "primary_setup_failure_category": primary_setup_failure_category,
+        "terminal_failure_dependency_classes": terminal_dependency_classes,
+        "terminal_failure_reason_codes": terminal_failure_reason_codes,
+        "terminal_failure_dependency_endpoints": (
+            terminal_failure_dependency_endpoints
+        ),
+        "retryability": retryability,
         "environment_setup_failure": environment_setup_failure,
         "agent_rounds_started": agent_rounds_started,
         "heartbeat_count": heartbeat_count,
@@ -6347,11 +6389,7 @@ def build_compose_setup_diagnostic(
         "resource_cap_applied": (
             isinstance(resource_cap, dict) and resource_cap.get("applied") is True
         ),
-        "fingerprint_matched_patterns": [
-            str(item)[:120]
-            for item in fingerprint.get("matched_patterns", [])
-            if isinstance(item, str)
-        ][:10],
+        "fingerprint_matched_patterns": fingerprint_matched_patterns,
         "fingerprint_confidence": str(
             fingerprint.get("fingerprint_confidence") or ""
         )[:120],

--- a/tests/test_skillsbench_setup_preflight.py
+++ b/tests/test_skillsbench_setup_preflight.py
@@ -8,10 +8,18 @@ from typing import Any
 import pytest
 
 from loopx.benchmark_adapters.skillsbench_codex_runtime import preflight_required
+from loopx.benchmark_adapters.skillsbench_failure_signals import (
+    skillsbench_runner_error_fingerprint,
+)
 from loopx.benchmark_adapters.skillsbench_setup_preflight import (
     run_setup_only_public_preflight,
 )
-from scripts.skillsbench_automation_loop import build_plan, parse_args
+from loopx.status import compact_benchmark_run
+from scripts.skillsbench_automation_loop import (
+    build_compose_setup_diagnostic,
+    build_plan,
+    parse_args,
+)
 
 
 class FakeRollout:
@@ -269,6 +277,68 @@ def test_setup_only_preflight_separates_terminal_reason_and_endpoint() -> None:
     ]
     assert result["terminal_dependency_endpoints"] == ["apache_archive"]
     assert result["raw_error_recorded"] is False
+
+
+def test_compose_diagnostic_ignores_incidental_volume_for_terminal_apt() -> None:
+    message = (
+        "Docker compose command failed while preparing a named volume. "
+        "failed to solve: Dockerfile RUN apt-get update; "
+        "failed to fetch package index"
+    )
+    source = {
+        "schema_version": "benchmark_run_v0",
+        "benchmark": "skillsbench",
+        "task_id": "synthetic-setup",
+        "route": "loopx-turn-agent-cli",
+        "score_failure_attribution": (
+            "skillsbench_docker_compose_apt_repository_failure"
+        ),
+        "failure_attribution_labels": [
+            "skillsbench_docker_compose_apt_repository_failure",
+            "skillsbench_docker_compose_setup_failure",
+            "skillsbench_environment_setup_error",
+        ],
+        "official_score_status": "missing",
+        "runner_failure_fingerprint": skillsbench_runner_error_fingerprint(message),
+    }
+
+    compact = compact_benchmark_run(source)
+
+    assert compact is not None
+    fingerprint = compact["runner_failure_fingerprint"]
+    assert "volume_mount_failure" not in fingerprint["matched_patterns"]
+    assert "apt_failure" in fingerprint["matched_patterns"]
+    assert fingerprint["terminal_failure_dependency_classes"] == [
+        "system_package"
+    ]
+    assert fingerprint["terminal_failure_reason_codes"] == ["apt_fetch_failed"]
+    assert fingerprint["retryability"] == "unknown"
+
+    diagnostic = build_compose_setup_diagnostic(
+        compact,
+        {"route": "loopx-turn-agent-cli"},
+    )
+    assert diagnostic["volume_mount_failure"] is False
+    assert diagnostic["apt_repository_failure"] is True
+    assert diagnostic["primary_setup_failure_category"] == (
+        "system_package_repository"
+    )
+    assert diagnostic["next_diagnostic_action"] == (
+        "repair_system_package_repository_setup_before_product_treatment"
+    )
+
+    reduced = compact_benchmark_run(
+        {**compact, "compose_setup_diagnostic": diagnostic}
+    )
+    assert reduced is not None
+    reduced_diagnostic = reduced["compose_setup_diagnostic"]
+    assert reduced_diagnostic["primary_setup_failure_category"] == (
+        "system_package_repository"
+    )
+    assert reduced_diagnostic["terminal_failure_dependency_classes"] == [
+        "system_package"
+    ]
+    assert message not in json.dumps(reduced, sort_keys=True)
 
 
 def test_setup_only_preflight_classifies_ubuntu_mirror_without_raw_url() -> None:


### PR DESCRIPTION
## Summary
- narrow volume-mount fingerprinting to explicit mount failures instead of any volume/mount wording
- preserve terminal dependency, reason, endpoint, and retryability signals through compact status and ledger projections
- select an explicit primary setup category and actionable system-package repair before agent rounds
- add synthetic and durable APT/volume attribution regressions

## Validation
- `uv run --with pytest pytest -q tests/test_skillsbench_*.py tests/control_plane/test_skillsbench_post_run_debug.py` (`52 passed`)
- `python3 examples/skillsbench-failure-attribution-smoke.py`
- focused APT + volume functions from `examples/skillsbench-benchmark-run-smoke.py`
- `python3 -m py_compile` for all six changed Python files
- `loopx canary premerge --from-git-diff`: 18/18 selected checks passed, including 1/1 public-boundary check; generic benchmark-sensitive manual hold remains
- full monolithic SkillsBench smoke was attempted; it later stopped at an unrelated CLI dry-run subprocess exit, while the affected attribution functions pass independently

## Boundary
No scoring, task semantics, upload/submission, permissions, or agent execution behavior changes. No raw task text, logs, trajectories, verifier output, credentials, local paths, generated ledgers, or `uv.lock` are included.

## Merge rationale
This is a narrow public benchmark setup-diagnostic repair. Explicit maintainer authorization for benchmark self-merge is present; the generic benchmark-sensitive hold is addressed by the validation and public-boundary evidence above.