### PR TITLE
Restore the default behavior regression suite

### DIFF
--- a/regression/README.md
+++ b/regression/README.md
@@ -11,8 +11,10 @@ run deliberately during release or major control-plane changes.
 
 Run all default contract-only regressions:
 
+Use the same Python 3.11+ runtime selected for LoopX:
+
 ```bash
-python3 regression/run-regressions.py
+"${LOOPX_PYTHON:-python3}" regression/run-regressions.py
 ```
 
 The default suite must stay public-safe and dependency-light: no real Codex CLI,
@@ -35,8 +37,8 @@ python3 regression/blocked-priority-fallback-contract.py
 
 Runs a contract-only projection regression for the human-in-the-loop pattern
 where a higher-priority todo is blocked but a lower-priority fallback is safe.
-It checks that `quota should-run` keeps the blocked item user-visible with
-`notify=NOTIFY`, does not require a new user answer, and still selects the safe
+It checks that `quota should-run` keeps the blocked item structurally visible
+without inventing a user action or notification, and still selects the safe
 fallback as the agent action in the interaction contract and protocol packet.
 
 ```bash
@@ -101,9 +103,10 @@ and a P1 advancement todo is executable, `quota should-run` selects the P1
 backlog item as `recommended_action`, interaction primary action, and protocol
 packet action while keeping the monitor as context. It also checks that the
 payload exposes a state-action projection warning when the visible
-`Next Action` still points at the stale monitor action, and that
-`refresh-state` derives its default recommended action from the first open
-Agent Todo rather than the stale `Next Action`.
+`Next Action` still points at the stale monitor action. The regression keeps
+`refresh-state` ownership separate: without an explicit replacement it
+preserves the authored `Next Action`, while quota remains authoritative for
+the executable action selected in the current turn.
 
 ```bash
 python3 regression/automation-loop-heartbeat-poll-contract.py
@@ -115,6 +118,15 @@ delivery only spends after validated state writeback, repeated monitor polls
 stay quiet and do not spend, compact external-evidence observation remains
 bounded, and projection warnings route stale `Next Action` text behind the
 selected executable todo.
+
+```bash
+python3 regression/interaction-contract-state-machine.py
+```
+
+Runs the canonical interaction-contract state-machine smoke through the
+default regression suite. It keeps user notification, agent delivery, quiet
+monitor, autonomous replan, and quota-spend channels aligned without copying
+the fixture into a second test.
 
 ```bash
 python3 regression/external-evidence-observation-real-codex.py --real-codex

--- a/regression/blocked-priority-fallback-contract.py
+++ b/regression/blocked-priority-fallback-contract.py
@@ -105,10 +105,10 @@ def main() -> int:
     guard = build_quota_should_run(build_status_payload(), goal_id=GOAL_ID)
     assert guard["should_run"] is True, guard
     assert guard["recommended_action"] == FALLBACK_TODO, guard
-    assert guard["heartbeat_recommendation"]["notify"] == "NOTIFY", guard
+    assert guard["heartbeat_recommendation"]["notify"] == "DONT_NOTIFY", guard
 
     fallback = guard["blocked_priority_fallback"]
-    assert fallback["notify_user"] is True, fallback
+    assert fallback["notify_user"] is False, fallback
     assert fallback["requires_user_action"] is False, fallback
     assert fallback["blocked_items"][0]["text"] == BLOCKED_CORE_TODO, fallback
     assert fallback["selected_executable"]["text"] == FALLBACK_TODO, fallback
@@ -116,7 +116,7 @@ def main() -> int:
     interaction = guard["interaction_contract"]
     assert interaction["mode"] == "bounded_delivery", interaction
     assert interaction["user_channel"]["action_required"] is False, interaction
-    assert interaction["user_channel"]["notify"] == "NOTIFY", interaction
+    assert interaction["user_channel"]["notify"] == "DONT_NOTIFY", interaction
     assert interaction["agent_channel"]["must_attempt"] is True, interaction
     assert interaction["agent_channel"]["delivery_allowed"] is True, interaction
     primary_action = interaction["agent_channel"]["primary_action"]
@@ -130,7 +130,7 @@ def main() -> int:
     assert "agent_action=[P1] Continue one safe benchmark attribution cleanup" in packet_summary, packet_summary
 
     markdown = render_quota_should_run_markdown(guard)
-    assert "blocked_priority_fallback: notify_user=True" in markdown, markdown
+    assert "blocked_priority_fallback: notify_user=False" in markdown, markdown
     assert f"blocked_priority_item[1]: {BLOCKED_CORE_TODO}" in markdown, markdown
     assert f"blocked_priority_selected: {FALLBACK_TODO}" in markdown, markdown
     print("blocked-priority-fallback-contract-regression ok")

--- a/regression/interaction-contract-state-machine.py
+++ b/regression/interaction-contract-state-machine.py
@@ -1,10 +1,5 @@
 #!/usr/bin/env python3
-"""Regression wrapper for automation-loop heartbeat poll contracts.
-
-The durable behavior lives in `examples/control_plane/heartbeat-quota-flow-smoke.py`.
-This wrapper makes the default regression suite cover it without duplicating
-fixtures or pulling in real Codex/Docker/model execution.
-"""
+"""Regression wrapper for the interaction contract state machine."""
 
 from __future__ import annotations
 
@@ -14,13 +9,16 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SMOKE_PATH = (
-    REPO_ROOT / "examples" / "control_plane" / "heartbeat-quota-flow-smoke.py"
+    REPO_ROOT
+    / "examples"
+    / "control_plane"
+    / "interaction-contract-state-machine-smoke.py"
 )
 
 
 def main() -> int:
     spec = importlib.util.spec_from_file_location(
-        "heartbeat_quota_flow_smoke",
+        "interaction_contract_state_machine_smoke",
         SMOKE_PATH,
     )
     if spec is None or spec.loader is None:

--- a/regression/quota-executable-backlog-projection.py
+++ b/regression/quota-executable-backlog-projection.py
@@ -168,7 +168,7 @@ def assert_executable_backlog_projection(guard: dict[str, Any]) -> None:
     assert first_open[1]["task_class"] == "advancement_task", guard
 
 
-def assert_refresh_state_prefers_open_agent_todo(
+def assert_refresh_state_preserves_explicit_next_action(
     *,
     registry: Path,
     runtime: Path,
@@ -183,8 +183,8 @@ def assert_refresh_state_prefers_open_agent_todo(
         registry=registry,
         runtime=runtime,
     )
-    assert refresh["recommended_action"] == EXECUTABLE_TODO, refresh
-    assert refresh["recommended_action"] != POLL_ACTION, refresh
+    assert refresh["recommended_action"] == POLL_ACTION, refresh
+    assert refresh["recommended_action_source"] == "active_state_next_action", refresh
 
 
 def assert_latest_run_action_does_not_create_false_projection_gap() -> None:
@@ -221,7 +221,7 @@ def main() -> int:
             runtime=runtime,
         )
         assert_executable_backlog_projection(guard)
-        assert_refresh_state_prefers_open_agent_todo(
+        assert_refresh_state_preserves_explicit_next_action(
             registry=registry,
             runtime=runtime,
         )

--- a/regression/run-regressions.py
+++ b/regression/run-regressions.py
@@ -48,6 +48,10 @@ CONTRACT_ONLY_REGRESSIONS = (
         description="automation heartbeat polls stay bounded, compact, and spend only after writeback",
     ),
     Regression(
+        path="regression/interaction-contract-state-machine.py",
+        description="interaction modes keep user, agent, and spend channels consistent",
+    ),
+    Regression(
         path="regression/external-evidence-observation-real-codex.py",
         description="external evidence waits require observation; launched advancement work stays bounded delivery",
     ),
@@ -63,6 +67,15 @@ CONTRACT_ONLY_REGRESSIONS = (
 
 
 def main() -> int:
+    if sys.version_info < (3, 11):
+        print(
+            "regression suite requires Python 3.11+; "
+            f"selected Python is {sys.version_info.major}.{sys.version_info.minor}. "
+            "Run with the same LOOPX_PYTHON used to install LoopX.",
+            file=sys.stderr,
+        )
+        return 2
+
     failures: list[str] = []
     for regression in CONTRACT_ONLY_REGRESSIONS:
         script = REPO_ROOT / regression.path


### PR DESCRIPTION
## Summary
- repair the heartbeat regression wrapper after the canonical smoke moved
- align stale blocked-fallback and refresh-state assertions with current contracts
- add the canonical interaction state machine to the default regression suite
- fail fast with an actionable message when the suite is launched on Python older than 3.11

## Validation
- default contract-only regression suite: 11/11 passed
- focused wrappers: blocked fallback, heartbeat quota flow, interaction state machine passed
- Python 3.9 fail-fast contract passed
- `loopx canary premerge --from-git-diff`: 18/18 passed, public boundary 1/1, no manual holds
- `py_compile` passed

## Boundaries
- regression tests and contributor docs only
- no product runtime behavior, benchmark launch, scoring, submission, credentials, private state, or raw evidence
- Ruff was unavailable in the validation environment; compile, focused, full-suite, and premerge checks passed