### PR TITLE
fix(replan): keep user reminders nonblocking

### DIFF
--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -892,6 +892,20 @@ def _open_todo_count(summary: dict[str, Any] | None) -> int:
     return safe_non_negative_int(summary.get("open_count"))
 
 
+def _blocking_user_open_count(summary: dict[str, Any] | None) -> int:
+    if not isinstance(summary, dict):
+        return 0
+    gate_items = summary.get("gate_open_items")
+    if isinstance(gate_items, list):
+        return sum(
+            1
+            for item in gate_items
+            if isinstance(item, dict) and _todo_item_is_actionable_open(item)
+        )
+    # Legacy or partial summaries without typed gate projection fail closed.
+    return _open_todo_count(summary)
+
+
 def _todo_item_is_actionable_open(item: dict[str, Any]) -> bool:
     if item.get("done") is True:
         return False
@@ -1274,7 +1288,6 @@ def derive_goal_frontier_replan_obligation_from_summaries(
     monitor/vision semantics in its scheduler path.
     """
 
-    user_counts = _summary_task_counts(user_todo_summary)
     agent_counts = _summary_task_counts(agent_todo_summary)
     frontier_counts = _frontier_advancement_counts(
         agent_todo_summary=agent_todo_summary,
@@ -1340,7 +1353,7 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                 agent_id=agent_id,
             ),
             successor_vision_required=successor_vision_required,
-            user_open_count=user_counts.get("open", 0),
+            blocking_user_open_count=_blocking_user_open_count(user_todo_summary),
             succession_gap_count=len(succession_gap_items),
             agent_advancement_count=agent_counts.get("advancement", 0),
             total_frontier_advancement=total_frontier_advancement,

--- a/loopx/control_plane/goals/goal_frontier_replan_rules.py
+++ b/loopx/control_plane/goals/goal_frontier_replan_rules.py
@@ -35,7 +35,7 @@ class GoalFrontierReplanFacts:
     blocking_handoff_gate_count: int = 0
     ready_deferred_successor_count: int = 0
     successor_vision_required: bool = False
-    user_open_count: int = 0
+    blocking_user_open_count: int = 0
     succession_gap_count: int = 0
     agent_advancement_count: int = 0
     total_frontier_advancement: int = 0
@@ -93,9 +93,9 @@ def select_goal_frontier_replan_rule(
         ),
         (
             GoalFrontierReplanRule.OPEN_USER_TODO,
-            facts.user_open_count > 0,
+            facts.blocking_user_open_count > 0,
             False,
-            "open user work owns the frontier",
+            "open blocking user work owns the frontier",
         ),
         (
             GoalFrontierReplanRule.TODO_SUCCESSION_GAP,

--- a/tests/control_plane/test_goal_frontier_replan_rules.py
+++ b/tests/control_plane/test_goal_frontier_replan_rules.py
@@ -34,7 +34,7 @@ from loopx.control_plane.goals.goal_frontier_replan_rules import (
             False,
         ),
         (
-            {"user_open_count": 1, "acceptance_gap_count": 1},
+            {"blocking_user_open_count": 1, "acceptance_gap_count": 1},
             GoalFrontierReplanRule.OPEN_USER_TODO,
             False,
         ),

--- a/tests/control_plane/test_monitor_replan_agent_scope.py
+++ b/tests/control_plane/test_monitor_replan_agent_scope.py
@@ -178,3 +178,112 @@ def test_interleaved_monitors_keep_independent_no_change_streaks() -> None:
     assert guard["agent_todo_summary"]["payload_compaction"]["compacted_lanes"][
         "monitor_open_items"
     ] == {"shown": 2, "total": 3}
+
+
+def _combined_user_frontier_guard(*, user_task_class: str) -> dict:
+    monitor = quota_todo_item(
+        todo_id="todo_stalled_monitor",
+        index=1,
+        title="Watch the release qualification PR.",
+        task_class="continuous_monitor",
+        claimed_by=AGENT_ID,
+        target_key="github-pr-123",
+        consecutive_no_change="2",
+        cadence="30m",
+        next_due_at="2099-01-01T00:00:00+00:00",
+    )
+    blocked_successor = quota_todo_item(
+        todo_id="todo_blocked_release_baseline",
+        index=2,
+        status="deferred",
+        title="Run the release outcome baseline.",
+        task_class="advancement_task",
+        action_kind="release_outcome_baseline_qualification",
+        claimed_by=AGENT_ID,
+        required_capabilities=["benchmark_runner"],
+        resume_when="capacity_available:benchmark_runner",
+    )
+    user_item = quota_todo_item(
+        todo_id="todo_user_frontier",
+        role="user",
+        status="open",
+        title="Review the public-safe qualification evidence.",
+        task_class=user_task_class,
+        blocks_agent=AGENT_ID if user_task_class == "user_gate" else None,
+        bound_agent=AGENT_ID if user_task_class == "user_action" else None,
+    )
+    payload = quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        recommended_action="Wait for material monitor evidence.",
+        agent_todos=quota_todo_summary([monitor, blocked_successor]),
+        user_todos=quota_todo_summary([user_item], role="user"),
+        quota_state="operator_gate" if user_task_class == "user_gate" else "eligible",
+        coordination={
+            "agent_model": "peer_v1",
+            "registered_agents": [AGENT_ID, PEER_AGENT_ID],
+        },
+        latest_runs=[
+            {
+                "classification": "quality_vision_fixture",
+                "generated_at": "2026-07-19T00:00:00+00:00",
+                "agent_id": AGENT_ID,
+                "progress_scope": "agent_lane",
+                "agent_vision": {
+                    "schema_version": "goal_vision_replan_contract_v0",
+                    "agent_id": AGENT_ID,
+                    "state": "vision_active",
+                    "vision_patch": {
+                        "acceptance_summary": (
+                            "Keep release qualification advancing until closed."
+                        ),
+                        "advancement_policy": "repeat_until_closed",
+                        "replan_trigger_summary": (
+                            "Replan after two unchanged monitor observations."
+                        ),
+                    },
+                },
+            }
+        ],
+    )
+    return build_quota_should_run(
+        payload,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        scheduler_execution_context=(
+            GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT
+        ),
+    )
+
+
+def test_nonblocking_user_action_does_not_suppress_stalled_monitor_replan() -> None:
+    guard = _combined_user_frontier_guard(user_task_class="user_action")
+
+    assert guard["decision"] == "autonomous_replan_required"
+    assert guard["goal_frontier_projection"]["vision_wait_state"][
+        "selected_todo_id"
+    ] == "todo_blocked_release_baseline"
+    trigger = guard["autonomous_replan_obligation"]["triggers"][0]
+    assert trigger["kind"] == "monitor_no_change_streak"
+    assert trigger["todo_id"] == "todo_stalled_monitor"
+    assert guard["interaction_contract"]["user_channel"] == {
+        "action_required": False,
+        "notify": "NOTIFY",
+        "max_items": 3,
+        "actions": ["[P0] Review the public-safe qualification evidence."],
+        "non_blocking": True,
+        "reason": (
+            "open non-blocking user action should be surfaced while independent "
+            "agent work continues"
+        ),
+    }
+    assert guard["interaction_contract"]["agent_channel"]["must_attempt"] is True
+
+
+def test_blocking_user_gate_still_precedes_stalled_monitor_replan() -> None:
+    guard = _combined_user_frontier_guard(user_task_class="user_gate")
+
+    assert guard["decision"] == "skip"
+    assert guard["interaction_contract"]["mode"] == "user_gate"
+    assert guard["interaction_contract"]["user_channel"]["action_required"] is True
+    assert guard.get("autonomous_replan_obligation") is None


### PR DESCRIPTION
## Summary
- derive frontier ownership from typed open `user_gate` items instead of every open user todo
- keep legacy or partial summaries fail-closed when typed gate projection is absent
- cover the combined non-blocking user action, stalled monitor, and blocked vision-successor path while preserving blocking gate precedence

## Root cause
`OPEN_USER_TODO` used the summary-wide `open_count`, so a `user_action` reminder marked non-blocking by the interaction contract preempted `MONITOR_NO_CHANGE_STREAK`. After two unchanged polls, quota still returned `monitor_quiet_skip` instead of requiring a bounded replan.

## Validation
- `62 passed`: goal-frontier rules, monitor replan, blocked vision successor, user-gate lane, public-safe replay, and decision-scope consistency
- Ruff and Python compile checks passed
- `loopx canary premerge --from-git-diff`: 17/17 selected checks passed, 0 manual holds
- `git diff --check` passed

## Boundary
No private state, local paths, raw logs, credentials, benchmark task text, or generated artifacts are included.
