### PR TITLE
release: LoopX v0.2.9

### DIFF
--- a/examples/bootstrap-command-pack-smoke.py
+++ b/examples/bootstrap-command-pack-smoke.py
@@ -416,6 +416,8 @@ def test_start_goal_guided_requires_explicit_goal_for_multi_goal_project() -> No
             assert "--goal-text 'Add a new meta agent without reusing an old lane'" in choice[
                 "rerun_command"
             ], choice
+        commands = payload["command_pack"]["commands"]
+        assert set(commands) == {"doctor", "status", "goal_selection_choices"}, commands
         assert payload["safety_contract"]["writes_registry"] is False, payload
         assert payload["safety_contract"]["creates_heartbeat"] is False, payload
         assert_packet_summary_refs(

--- a/examples/release-wrapper-import-isolation-smoke.py
+++ b/examples/release-wrapper-import-isolation-smoke.py
@@ -29,6 +29,7 @@ def main() -> int:
         wrapper.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(REPO_ROOT / "scripts" / "loopx", wrapper)
         wrapper.chmod(0o755)
+        _write(release / ".loopx-python", f"{sys.executable}\n")
 
         _write(release / "loopx" / "__init__.py", "")
         _write(

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.8"
+__version__ = "0.2.9"

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -1058,10 +1058,6 @@ def _build_multi_goal_start_selection_packet(
             "doctor": f"{shell_arg(cli_bin)} doctor",
             "status": _project_command(resolved_project, f"{shell_arg(cli_bin)} status"),
             "goal_selection_choices": choices,
-            "goal_start_connect_if_needed": None,
-            "goal_start_refresh_state": None,
-            "goal_start_host_loop_activation": None,
-            "goal_start_quota_should_run": None,
         },
         "safety_contract": {
             "runs_bootstrap": False,

--- a/loopx/control_plane/testing/model_behavior_qualification.py
+++ b/loopx/control_plane/testing/model_behavior_qualification.py
@@ -500,9 +500,10 @@ def normalize_model_behavior_actor_result(
         ),
         "reason_codes": _reason_codes(decision.get("reason_codes")),
     }
-    semantic_contract = _normalize_semantic_contract(
-        decision.get("semantic_contract"),
-        required=semantic_contract_required,
+    semantic_contract = (
+        _normalize_semantic_contract(decision.get("semantic_contract"), required=True)
+        if semantic_contract_required
+        else None
     )
     if semantic_contract is not None:
         normalized_decision["semantic_contract"] = semantic_contract

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.2.8"
+version = "0.2.9"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/control_plane/test_actual_default_model_behavior_portfolio.py
+++ b/tests/control_plane/test_actual_default_model_behavior_portfolio.py
@@ -328,6 +328,14 @@ def _onboarding_actor(request: Mapping[str, Any]) -> dict[str, Any]:
 def test_live_packet_builder_uses_production_blocking_gate_plan(tmp_path: Path) -> None:
     packets = build_actual_default_model_behavior_scenario_packets(tmp_path)
 
+    selection_commands = packets["onboarding_goal_selection_gate"]["command_pack"][
+        "commands"
+    ]
+    assert set(selection_commands) == {
+        "doctor",
+        "status",
+        "goal_selection_choices",
+    }
     gate = packets["turn_human_gate"]
     assert gate["mode"] == "should-run"
     gate_signature = quota_action_signature_document(gate)

--- a/tests/control_plane/test_doubao_model_behavior_actor.py
+++ b/tests/control_plane/test_doubao_model_behavior_actor.py
@@ -174,6 +174,39 @@ def test_direct_actor_uses_canonical_endpoint_without_tools_or_raw_retention() -
     assert "fixture-key" not in json.dumps(result, sort_keys=True)
 
 
+def test_optional_semantic_contract_does_not_grade_auxiliary_model_output() -> None:
+    decision = _decision()
+    decision["semantic_contract"] = {"partial": "ungraded"}
+
+    result = normalize_model_behavior_actor_result(
+        {
+            "schema_version": "model_behavior_actor_result_v0",
+            "actor_ref": f"ark:{DOUBAO_2_1_PRO_MODEL}",
+            "decision": decision,
+            "tool_calls": [],
+        },
+        semantic_contract_required=False,
+    )
+
+    assert "semantic_contract" not in result["decision"]
+
+
+def test_required_semantic_contract_remains_strict() -> None:
+    decision = _decision()
+    decision["semantic_contract"] = {"partial": "invalid"}
+
+    with pytest.raises(ValueError, match="unknown semantic contract field"):
+        normalize_model_behavior_actor_result(
+            {
+                "schema_version": "model_behavior_actor_result_v0",
+                "actor_ref": f"ark:{DOUBAO_2_1_PRO_MODEL}",
+                "decision": decision,
+                "tool_calls": [],
+            },
+            semantic_contract_required=True,
+        )
+
+
 def test_environment_factory_fails_closed_without_injected_key() -> None:
     with pytest.raises(RuntimeError, match="ARK_API_KEY is not injected"):
         DoubaoModelBehaviorActor.from_environment(environ={})


### PR DESCRIPTION
## Summary

### State Kernel & Control Plane

- Tighten agent-scoped scheduler, monitor, replan, path-delta, and quota decisions so one lane cannot consume or suppress another lane's frontier ([#2350](https://github.com/huangruiteng/loopx/pull/2350), [#2358](https://github.com/huangruiteng/loopx/pull/2358), [#2363](https://github.com/huangruiteng/loopx/pull/2363), [#2371](https://github.com/huangruiteng/loopx/pull/2371), [#2377](https://github.com/huangruiteng/loopx/pull/2377), [#2381](https://github.com/huangruiteng/loopx/pull/2381)).

### Capabilities & Workflows

- Add first-class OpenCode host support, a Turn-backed host selector, and reusable periodic HTML reports without changing the default Codex App automation path ([#2364](https://github.com/huangruiteng/loopx/pull/2364), [#2365](https://github.com/huangruiteng/loopx/pull/2365), [#2368](https://github.com/huangruiteng/loopx/pull/2368)). Optional host selection remains per Turn command/preset; see the host-mode and periodic-report command help for preview and prerequisites.

### Quality & Testing

- Restore the default regression contract suite, improve SkillsBench setup diagnostics, and retain scheduler ACK parity coverage ([#2375](https://github.com/huangruiteng/loopx/pull/2375), [#2379](https://github.com/huangruiteng/loopx/pull/2379), [#2380](https://github.com/huangruiteng/loopx/pull/2380)).
- Keep goal-selection packets free of unavailable command placeholders and grade only requested semantic-contract output in live model qualification. This closes two qualification false negatives without expanding the Codex App heartbeat prompt or weakening route, action, write, spend, or user-gate checks.

### Benchmarks & Integrations

- Keep benchmark setup failures attributable without launching jobs or changing scoring, submission, or leaderboard behavior ([#2379](https://github.com/huangruiteng/loopx/pull/2379)).

### Documentation & Compatibility

- Persist the supported Python runtime across self-update, derive update smoke launchers from fixture homes, and refresh contributor/peer boundary guidance ([#2369](https://github.com/huangruiteng/loopx/pull/2369), [#2370](https://github.com/huangruiteng/loopx/pull/2370), [#2373](https://github.com/huangruiteng/loopx/pull/2373), [#2374](https://github.com/huangruiteng/loopx/pull/2374)). Package version and tag advance to `0.2.9` / `v0.2.9`; no persisted LoopX state migration is required.

## 中文摘要

### 状态内核与控制面

- Scheduler、monitor、replan、path delta 与 quota 的判定进一步按 agent lane 隔离，避免一个 agent 消费或压制另一个 agent 的 frontier（[#2350](https://github.com/huangruiteng/loopx/pull/2350)、[#2358](https://github.com/huangruiteng/loopx/pull/2358)、[#2363](https://github.com/huangruiteng/loopx/pull/2363)、[#2371](https://github.com/huangruiteng/loopx/pull/2371)、[#2377](https://github.com/huangruiteng/loopx/pull/2377)、[#2381](https://github.com/huangruiteng/loopx/pull/2381)）。

### 能力与工作流

- 新增 OpenCode host、Turn host selector 与可复用 periodic HTML report，同时不改变 Codex App automation 默认路径（[#2364](https://github.com/huangruiteng/loopx/pull/2364)、[#2365](https://github.com/huangruiteng/loopx/pull/2365)、[#2368](https://github.com/huangruiteng/loopx/pull/2368)）。host 选择仍按命令或 preset 显式 opt-in。

### 质量与测试

- 恢复默认 regression contract suite，改善 SkillsBench setup 诊断，并保留 scheduler ACK parity 覆盖（[#2375](https://github.com/huangruiteng/loopx/pull/2375)、[#2379](https://github.com/huangruiteng/loopx/pull/2379)、[#2380](https://github.com/huangruiteng/loopx/pull/2380)）。
- goal-selection packet 不再投影当前不可执行的空 command 占位；live model qualification 只评分明确要求的 semantic contract。该修复没有扩张 Codex App heartbeat prompt，也没有放松 route、action、write、spend 或 user-gate 校验。

### 基准与集成

- benchmark setup 失败现在更易归因；本次 release 不启动 benchmark job，也不修改 scoring、submission 或 leaderboard 行为（[#2379](https://github.com/huangruiteng/loopx/pull/2379)）。

### 文档与兼容性

- self-update 会复用已支持的 Python runtime，update smoke 从 fixture home 派生 launcher，并刷新 contributor 与 peer boundary 文档（[#2369](https://github.com/huangruiteng/loopx/pull/2369)、[#2370](https://github.com/huangruiteng/loopx/pull/2370)、[#2373](https://github.com/huangruiteng/loopx/pull/2373)、[#2374](https://github.com/huangruiteng/loopx/pull/2374)）。版本升级为 `0.2.9` / `v0.2.9`，无需迁移已有 LoopX state。

## Validation

Exact candidate `0fceaa9865cf419a3d6bee745f93aa134f242f85` passed the complete release gate:

- pytest: 918 passed, 2 skipped; 45.83% coverage
- workflow-scoped Ruff: 0 violations; strict mypy: 0 errors across 12 files; CLI output-budget smoke passed
- risk premerge: 18/18 selected checks, 0 failures, 0 warnings, 0 manual holds; self-merge allowed
- install/upgrade/host release profile: 16/16 passed, 0 failures/timeouts/warnings
- public boundary: 1,014 files scanned, 0 errors/warnings
- Full Public Smokes: 7/7 shard receipts, 613/613 checks passed, 0 failures/timeouts, [`ready=true`](https://github.com/huangruiteng/loopx/actions/runs/29714865190)
- live Doubao actual-default portfolio: 12 scenarios x 2 repeats, 24/24 calls passed, no automatic retries, no raw model response or packet retention
- exact-commit reducer: `ready_for_owner_release`, 8/8 required qualification lanes source-aligned, 0 missing qualifications or source mismatches

The dashboard browser subcheck was skipped because local npm dependencies were absent; the release-promotion smoke ran with its documented no-browser path and passed. A preliminary live qualification exposed two qualification-boundary defects and failed closed before this final exact-SHA run; both were repaired with focused regressions. An initial bare-repository Ruff command also scanned paths outside the workflow contract and reported existing out-of-scope findings; the exact workflow pathspec passed with 0 violations.

No benchmark or long-horizon outcome uplift claim is made, so the matched outcome baseline is not required.

## Update

```bash
loopx update --check
loopx update --execute
loopx doctor
```

[Full changelog](https://github.com/huangruiteng/loopx/compare/v0.2.8...v0.2.9)
