### PR TITLE
fix(update): qualify installed runtime activation

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -52,6 +52,31 @@ Before promoting a stable install/update recommendation, maintainers must move
 the public `stable` ref to the release commit that passed this gate. Do not
 claim stable-channel readiness while `stable` is missing or stale.
 
+## Merged Is Not Runtime-Active
+
+A post-merge check proves behavior on the tested source commit. It does not
+prove that an installed LoopX runtime contains that commit. This distinction
+matters when a fix reaches `main` after the latest named release: package
+versions may still match while the installed source commit is behind.
+
+Use `loopx update --check --ref main` for maintainer qualification. Its
+`runtime_activation_qualification` result compares the release-manifest source
+commit with the trusted source lineage reported by `loopx doctor`:
+
+- `runtime_active` means the installed commit is the target commit or contains it;
+- `release_or_install_successor_required` means the installed commit is behind
+  or diverged, so a release/install successor must remain explicit;
+- `activation_qualification_required` means commit lineage is unavailable or
+  belongs to a different `repo/ref`; the runtime-active claim must fail closed
+  until identity is refreshed.
+
+Closing a PR monitor after latest-`main` validation is valid, but the closeout
+must not say the fix is active in the installed runtime unless this receipt is
+`runtime_active`. Publishing a release remains a separate maintainer action.
+When the qualification command itself runs from newer source code, pass a local
+snapshot from the older installed CLI with `--installed-doctor-json`; this
+option is read-only and accepted only by `update --check`.
+
 ## Named Version Contract
 
 LoopX v0.x is distributed from GitHub, but each stable promotion still needs a

--- a/examples/loopx-update-smoke.py
+++ b/examples/loopx-update-smoke.py
@@ -28,6 +28,10 @@ from loopx.self_update import (  # noqa: E402
 )
 
 
+INSTALLED_COMMIT = "1" * 40
+TARGET_COMMIT = "2" * 40
+
+
 def fake_doctor_payload() -> dict[str, object]:
     return {
         "path": {
@@ -47,6 +51,12 @@ def fake_doctor_payload() -> dict[str, object]:
             "manifest_package_version": __version__,
             "manifest_package_version_tag": release_version_tag(),
             "manifest_package_version_matches_runtime": True,
+            "manifest_source_repo": "example/loopx",
+            "manifest_source_ref": "stable",
+            "manifest_source_git_commit": INSTALLED_COMMIT,
+            "freshness_source_label": "example/loopx@main",
+            "freshness_source_git_commit": TARGET_COMMIT,
+            "manifest_source_freshness_relation": "installed_behind",
         },
         "release_manifest": {
             "available": True,
@@ -59,6 +69,7 @@ def fake_doctor_payload() -> dict[str, object]:
                     "ref": "stable",
                     "archive_url": "https://codeload.github.com/example/loopx/tar.gz/stable",
                     "archive_sha256": "abc123",
+                    "git_commit": INSTALLED_COMMIT,
                 },
                 "package": {
                     "name": "loopx",
@@ -87,6 +98,12 @@ def fake_fresh_doctor_payload() -> dict[str, object]:
         "manifest_package_version": __version__,
         "manifest_package_version_tag": release_version_tag(),
         "manifest_package_version_matches_runtime": True,
+        "manifest_source_repo": "example/loopx",
+        "manifest_source_ref": "stable",
+        "manifest_source_git_commit": INSTALLED_COMMIT,
+        "freshness_source_label": "example/loopx@main",
+        "freshness_source_git_commit": INSTALLED_COMMIT,
+        "manifest_source_freshness_relation": "same",
     }
     return payload
 

--- a/loopx/cli_commands/support_control.py
+++ b/loopx/cli_commands/support_control.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Callable
+import json
 from pathlib import Path
 
 from ..agent_registry import (
@@ -281,6 +282,13 @@ def register_support_control_commands(
     update_parser.add_argument(
         "--archive-url",
         help="Explicit tarball URL passed to the installer as LOOPX_ARCHIVE_URL.",
+    )
+    update_parser.add_argument(
+        "--installed-doctor-json",
+        help=(
+            "Local JSON output from the installed `loopx --format json doctor`; "
+            "valid only with --check for source-versus-installed qualification."
+        ),
     )
     update_parser.add_argument(
         "--timeout-seconds",
@@ -563,16 +571,29 @@ def handle_support_control_command(
 
     if args.command == "update":
         try:
+            if args.installed_doctor_json and not args.check:
+                raise ValueError("--installed-doctor-json requires update --check")
             if args.rollback:
                 payload = build_rollback_plan(release_id=args.rollback)
                 payload = execute_rollback_plan(payload, timeout_seconds=args.timeout_seconds)
             else:
+                doctor_payload = None
+                if args.installed_doctor_json:
+                    doctor_path = Path(args.installed_doctor_json).expanduser()
+                    loaded_doctor = json.loads(doctor_path.read_text(encoding="utf-8"))
+                    if not isinstance(loaded_doctor, dict):
+                        raise ValueError("--installed-doctor-json must contain a JSON object")
+                    doctor_payload = loaded_doctor
                 payload = build_update_plan(
                     repo=args.repo,
                     ref=args.ref,
                     archive_url=args.archive_url,
                     check_only=args.check,
                     execute=args.execute,
+                    doctor_payload=doctor_payload,
+                )
+                payload["installed_doctor_source"] = (
+                    "explicit_json" if doctor_payload is not None else "current_runtime"
                 )
                 if args.execute:
                     payload = execute_update_plan(payload, timeout_seconds=args.timeout_seconds)

--- a/loopx/self_update.py
+++ b/loopx/self_update.py
@@ -17,6 +17,9 @@ DEFAULT_UPDATE_REPO = "huangruiteng/loopx"
 DEFAULT_UPDATE_REF = "stable"
 ROLLBACK_PREVIOUS_ALIAS = "previous"
 SOURCE_VERSION_CHECK_SCHEMA_VERSION = "loopx_source_version_check_v0"
+RUNTIME_ACTIVATION_QUALIFICATION_SCHEMA_VERSION = (
+    "loopx_runtime_activation_qualification_v0"
+)
 SOURCE_VERSION_CHECK_TIMEOUT_SECONDS = 3
 SOURCE_VERSION_READ_LIMIT_BYTES = 64 * 1024
 PERSISTED_PYTHON_FILENAME = ".loopx-python"
@@ -167,6 +170,93 @@ def _source_version_check(source: dict[str, Any]) -> dict[str, Any]:
         "version": version,
         "version_tag": f"v{version}",
         "source_url": source_url,
+    }
+
+
+def _runtime_activation_qualification(
+    *,
+    install_freshness: dict[str, Any],
+    source: dict[str, Any],
+) -> dict[str, Any]:
+    installed_commit = install_freshness.get("manifest_source_git_commit")
+    target_commit = install_freshness.get("freshness_source_git_commit")
+    revision_relation = install_freshness.get("manifest_source_freshness_relation")
+    qualified_repo = install_freshness.get("manifest_source_repo")
+    qualified_ref = install_freshness.get("manifest_source_ref")
+    selected_repo = source.get("repo")
+    selected_ref = source.get("ref")
+    package_matches_runtime = install_freshness.get(
+        "manifest_package_version_matches_runtime"
+    )
+    requires_upgrade = install_freshness.get("requires_upgrade")
+    has_commit_pair = all(
+        isinstance(commit, str) and bool(commit)
+        for commit in (installed_commit, target_commit)
+    )
+    source_identity_matches = all(
+        isinstance(value, str) and bool(value)
+        for value in (qualified_repo, qualified_ref, selected_repo, selected_ref)
+    ) and (
+        str(qualified_repo).removesuffix(".git").lower()
+        == str(selected_repo).removesuffix(".git").lower()
+        and str(qualified_ref).removeprefix("refs/heads/")
+        == str(selected_ref).removeprefix("refs/heads/")
+    )
+
+    if package_matches_runtime is False:
+        decision = "release_or_install_successor_required"
+        runtime_active: bool | None = False
+        successor_kind = "release_or_install"
+        reason = "release manifest package version does not match the active runtime"
+    elif not source_identity_matches:
+        decision = "activation_qualification_required"
+        runtime_active = None
+        successor_kind = "activation_qualification"
+        reason = "trusted source lineage does not identify the selected update source"
+    elif has_commit_pair and (
+        installed_commit == target_commit or revision_relation == "installed_ahead"
+    ):
+        decision = "runtime_active"
+        runtime_active = True
+        successor_kind = None
+        reason = "installed source contains the trusted target source commit"
+    elif has_commit_pair and revision_relation in {"installed_behind", "diverged"}:
+        decision = "release_or_install_successor_required"
+        runtime_active = False
+        successor_kind = "release_or_install"
+        reason = "installed source does not contain the trusted target source commit"
+    else:
+        decision = "activation_qualification_required"
+        runtime_active = None
+        successor_kind = "activation_qualification"
+        reason = "trusted installed-versus-target source lineage is unavailable"
+
+    return {
+        "schema_version": RUNTIME_ACTIVATION_QUALIFICATION_SCHEMA_VERSION,
+        "decision": decision,
+        "runtime_active": runtime_active,
+        "installed_release_id": install_freshness.get("release_id"),
+        "installed_version": install_freshness.get("current_version"),
+        "installed_source_commit": installed_commit,
+        "target_source_label": install_freshness.get("freshness_source_label"),
+        "target_source_commit": target_commit,
+        "revision_relation": revision_relation,
+        "qualified_source": {
+            "repo": qualified_repo,
+            "ref": qualified_ref,
+        },
+        "source_identity_matches": source_identity_matches,
+        "package_version_matches_runtime": package_matches_runtime,
+        "requires_upgrade": requires_upgrade,
+        "selected_source": {
+            "repo": selected_repo,
+            "ref": selected_ref,
+        },
+        "successor": {
+            "required": runtime_active is not True,
+            "kind": successor_kind,
+        },
+        "reason": reason,
     }
 
 
@@ -350,17 +440,26 @@ def build_update_plan(
             if isinstance(current_version, str) and current_version
             else None
         )
+    runtime_activation = _runtime_activation_qualification(
+        install_freshness=install_freshness,
+        source=source,
+    )
     if execute:
         recommended_action = "review execution result and post-update doctor output"
+    elif (
+        check_only
+        and runtime_activation.get("decision")
+        == "release_or_install_successor_required"
+    ):
+        recommended_action = (
+            "installed runtime does not contain the trusted target source; "
+            "project a release/install successor, then run `loopx update --dry-run`"
+        )
     elif check_only and source_version_check.get("matches_current") is False:
         recommended_action = (
             f"source version v{source_version} differs from installed version "
             f"v{current_version}; run `loopx update --dry-run`, then `loopx update --execute`"
         )
-    elif check_only and source_version_check.get("matches_current") is True and requires_upgrade is False:
-        recommended_action = "installed version matches the selected source; no update needed"
-    elif check_only and requires_upgrade is True:
-        recommended_action = "run `loopx update --dry-run` to review the source and rollback plan"
     elif check_only and source_version_check.get("status") == "unavailable":
         recommended_action = (
             "local install health is known, but the selected source version could not be checked; "
@@ -371,6 +470,18 @@ def build_update_plan(
             "local install health is known, but source version comparison was skipped; "
             "run `loopx update --dry-run` to review the source"
         )
+    elif (
+        check_only
+        and runtime_activation.get("decision") == "activation_qualification_required"
+    ):
+        recommended_action = (
+            "installed runtime activation is not proven; refresh trusted source lineage "
+            "before claiming the merged behavior is active"
+        )
+    elif check_only and source_version_check.get("matches_current") is True and requires_upgrade is False:
+        recommended_action = "installed version and trusted source lineage match; no update needed"
+    elif check_only and requires_upgrade is True:
+        recommended_action = "run `loopx update --dry-run` to review the source and rollback plan"
     elif requires_upgrade is False:
         recommended_action = (
             "no update needed; use `loopx update --dry-run` or "
@@ -389,6 +500,7 @@ def build_update_plan(
         "execute_requested": execute,
         "source": source,
         "source_version_check": source_version_check,
+        "runtime_activation_qualification": runtime_activation,
         "current": {
             "loopx_command": path.get("loopx"),
             "loopx_realpath": path.get("loopx_realpath"),
@@ -575,6 +687,11 @@ def render_update_plan_markdown(payload: dict[str, Any]) -> str:
         if isinstance(payload.get("source_version_check"), dict)
         else {}
     )
+    runtime_activation = (
+        payload.get("runtime_activation_qualification")
+        if isinstance(payload.get("runtime_activation_qualification"), dict)
+        else {}
+    )
     current = payload.get("current") if isinstance(payload.get("current"), dict) else {}
     plan = payload.get("plan") if isinstance(payload.get("plan"), dict) else {}
     backup = plan.get("backup") if isinstance(plan.get("backup"), dict) else {}
@@ -590,6 +707,12 @@ def render_update_plan_markdown(payload: dict[str, Any]) -> str:
         f"- Source version tag: `{source_version_check.get('version_tag')}`",
         f"- Source version matches current: `{source_version_check.get('matches_current')}`",
         f"- Source version check reason: `{source_version_check.get('reason')}`",
+        f"- Runtime activation decision: `{runtime_activation.get('decision')}`",
+        f"- Runtime active: `{runtime_activation.get('runtime_active')}`",
+        f"- Installed source commit: `{runtime_activation.get('installed_source_commit')}`",
+        f"- Target source commit: `{runtime_activation.get('target_source_commit')}`",
+        f"- Source revision relation: `{runtime_activation.get('revision_relation')}`",
+        f"- Runtime activation reason: `{runtime_activation.get('reason')}`",
         f"- Current version: `{current.get('current_version')}`",
         f"- Current version tag: `{current.get('current_version_tag')}`",
         f"- Manifest package version: `{current.get('manifest_package_version')}`",

--- a/tests/test_self_update_runtime_activation.py
+++ b/tests/test_self_update_runtime_activation.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+from unittest import mock
+
+from loopx import __version__
+from loopx.self_update import build_update_plan
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALLED_COMMIT = "1" * 40
+TARGET_COMMIT = "2" * 40
+
+
+class FakeVersionResponse:
+    def __init__(self) -> None:
+        self.body = f'__version__ = "{__version__}"\n'.encode()
+
+    def __enter__(self) -> FakeVersionResponse:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self, limit: int) -> bytes:
+        return self.body[:limit]
+
+
+def doctor_payload(
+    *,
+    installed_commit: str | None = INSTALLED_COMMIT,
+    target_commit: str | None = TARGET_COMMIT,
+    relation: str = "installed_behind",
+    source_ref: str = "main",
+) -> dict[str, object]:
+    return {
+        "path": {
+            "loopx": "/home/user/.local/bin/loopx",
+            "loopx_realpath": "/home/user/.local/share/loopx/releases/fixture/scripts/loopx",
+        },
+        "package": {
+            "release_root": "/home/user/.local/share/loopx/releases/fixture",
+        },
+        "install_freshness": {
+            "status": "stale" if relation == "installed_behind" else "fresh",
+            "requires_upgrade": relation == "installed_behind",
+            "current_version": __version__,
+            "release_id": "fixture",
+            "manifest_package_version": __version__,
+            "manifest_package_version_matches_runtime": True,
+            "manifest_source_repo": "example/loopx",
+            "manifest_source_ref": source_ref,
+            "manifest_source_git_commit": installed_commit,
+            "freshness_source_label": f"example/loopx@{source_ref}",
+            "freshness_source_git_commit": target_commit,
+            "manifest_source_freshness_relation": relation,
+        },
+        "release_manifest": {
+            "available": True,
+            "manifest": {
+                "source": {
+                    "repo": "example/loopx",
+                    "ref": source_ref,
+                    "git_commit": installed_commit,
+                }
+            },
+        },
+    }
+
+
+def build_check(doctor: dict[str, object], *, ref: str = "main") -> dict[str, object]:
+    with mock.patch("loopx.self_update.urlopen", return_value=FakeVersionResponse()):
+        return build_update_plan(
+            repo="example/loopx",
+            ref=ref,
+            check_only=True,
+            doctor_payload=doctor,
+        )
+
+
+def test_same_version_older_commit_requires_release_or_install_successor() -> None:
+    payload = build_check(doctor_payload())
+
+    assert payload["source_version_check"]["matches_current"] is True
+    activation = payload["runtime_activation_qualification"]
+    assert activation["decision"] == "release_or_install_successor_required"
+    assert activation["runtime_active"] is False
+    assert activation["installed_source_commit"] == INSTALLED_COMMIT
+    assert activation["target_source_commit"] == TARGET_COMMIT
+    assert activation["successor"] == {
+        "required": True,
+        "kind": "release_or_install",
+    }
+    assert "project a release/install successor" in payload["recommended_action"]
+
+
+def test_equal_commit_proves_runtime_active() -> None:
+    payload = build_check(
+        doctor_payload(target_commit=INSTALLED_COMMIT, relation="same")
+    )
+
+    activation = payload["runtime_activation_qualification"]
+    assert activation["decision"] == "runtime_active"
+    assert activation["runtime_active"] is True
+    assert activation["source_identity_matches"] is True
+    assert activation["successor"] == {"required": False, "kind": None}
+
+
+def test_missing_commit_lineage_never_proves_runtime_active() -> None:
+    payload = build_check(doctor_payload(target_commit=None, relation="same"))
+
+    activation = payload["runtime_activation_qualification"]
+    assert activation["decision"] == "activation_qualification_required"
+    assert activation["runtime_active"] is None
+    assert activation["successor"] == {
+        "required": True,
+        "kind": "activation_qualification",
+    }
+
+
+def test_different_selected_source_never_reuses_unrelated_lineage() -> None:
+    payload = build_check(
+        doctor_payload(target_commit=INSTALLED_COMMIT, relation="same", source_ref="stable"),
+        ref="main",
+    )
+
+    activation = payload["runtime_activation_qualification"]
+    assert activation["decision"] == "activation_qualification_required"
+    assert activation["runtime_active"] is None
+    assert activation["source_identity_matches"] is False
+    assert activation["qualified_source"]["ref"] == "stable"
+    assert activation["selected_source"]["ref"] == "main"
+
+
+def test_cli_check_qualifies_explicit_installed_doctor_snapshot(tmp_path: Path) -> None:
+    doctor_path = tmp_path / "installed-doctor.json"
+    doctor_path.write_text(json.dumps(doctor_payload()), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "update",
+            "--format",
+            "json",
+            "--check",
+            "--repo",
+            "example/loopx",
+            "--ref",
+            "main",
+            "--archive-url",
+            "https://example.invalid/loopx.tar.gz",
+            "--installed-doctor-json",
+            str(doctor_path),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    payload = json.loads(result.stdout)
+    assert payload["installed_doctor_source"] == "explicit_json"
+    activation = payload["runtime_activation_qualification"]
+    assert activation["decision"] == "release_or_install_successor_required"
+    assert activation["installed_source_commit"] == INSTALLED_COMMIT
+    assert activation["target_source_commit"] == TARGET_COMMIT
+
+
+def test_cli_rejects_installed_doctor_snapshot_outside_check(tmp_path: Path) -> None:
+    doctor_path = tmp_path / "installed-doctor.json"
+    doctor_path.write_text(json.dumps(doctor_payload()), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "update",
+            "--format",
+            "json",
+            "--dry-run",
+            "--installed-doctor-json",
+            str(doctor_path),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1, (result.stdout, result.stderr)
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["error"] == "--installed-doctor-json requires update --check"


### PR DESCRIPTION
## Summary

- add a machine-readable `runtime_activation_qualification` receipt to `loopx update --check`
- distinguish source validation from installed runtime activation by version, commit lineage, and selected `repo/ref`
- accept an explicit installed `loopx doctor` JSON snapshot for read-only cross-version qualification
- document that merge validation does not prove an installed runtime contains the fix

## Root cause

Post-merge validation proved behavior at the latest source commit, while the active installed CLI could still point to an older release. Package versions can also match across several commits, so semver alone cannot establish that merged behavior is runtime-active.

The new receipt fails closed unless the installed manifest identity matches the selected source and the installed commit equals or contains the trusted target commit. Older, diverged, missing, or unrelated lineage projects an explicit release/install or qualification successor.

## Validation

- `uv run ruff check loopx/self_update.py loopx/cli_commands/support_control.py examples/loopx-update-smoke.py tests/test_self_update_runtime_activation.py`
- `uv run --extra test pytest -q tests/test_self_update_runtime_activation.py tests/test_doctor_install_freshness.py` (13 passed)
- update, support-control modularization, subcommand-format, and release-version smokes passed
- real installed-doctor/new-source qualification returned `release_or_install_successor_required` for installed v0.2.8 at `7fb421c5` behind trusted main `1944c02f`
- `loopx canary premerge --from-git-diff`: 18/18 passed, 0 failures, 0 warnings, 0 manual holds
- public/private boundary scan clean

## Boundary and merge decision

- no release was published and no install was mutated
- local untracked `uv.lock` was excluded from the commit and PR
- no credentials, private state, raw logs, trajectories, verifier output, or local paths are included
- runtime/update behavior changed, so this PR is left for independent review rather than self-merged
