### PR TITLE
Type SkillsBench compose setup failures

### DIFF
--- a/loopx/benchmark_adapters/skillsbench_setup_preflight.py
+++ b/loopx/benchmark_adapters/skillsbench_setup_preflight.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from typing import Any
 
 from .skillsbench_failure_signals import (
@@ -11,7 +11,62 @@ from .skillsbench_failure_signals import (
 
 
 SCHEMA_VERSION = "skillsbench_setup_only_public_preflight_v0"
+COMPOSE_TYPED_CAUSE_SCHEMA_VERSION = "skillsbench_compose_typed_cause_v0"
 _PATCH_SUFFIX = "_patch_applied"
+
+
+class SkillsBenchComposeCommandFailure(RuntimeError):
+    """Carry only a bounded public fingerprint beyond the compose producer."""
+
+    def __init__(self, fingerprint: Mapping[str, object]) -> None:
+        super().__init__(
+            "SkillsBench compose command failed with a bounded typed cause"
+        )
+        self.schema_version = COMPOSE_TYPED_CAUSE_SCHEMA_VERSION
+        self.fingerprint = dict(fingerprint)
+
+
+def skillsbench_compose_typed_fingerprint(
+    exc: Exception,
+) -> dict[str, object] | None:
+    if not isinstance(exc, SkillsBenchComposeCommandFailure):
+        return None
+    if exc.schema_version != COMPOSE_TYPED_CAUSE_SCHEMA_VERSION:
+        return None
+    return dict(exc.fingerprint)
+
+
+def install_skillsbench_compose_typed_cause_boundary(
+    environment: Any,
+) -> Callable[[], None] | None:
+    """Type final build failures without changing BenchFlow's retry loop."""
+
+    original_build = getattr(environment, "_run_docker_compose_build", None)
+    if not callable(original_build):
+        return None
+
+    async def build_with_typed_cause(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return await original_build(*args, **kwargs)
+        except SkillsBenchComposeCommandFailure:
+            raise
+        except Exception as exc:
+            fingerprint = skillsbench_runner_error_fingerprint(str(exc))
+            raise SkillsBenchComposeCommandFailure(fingerprint) from None
+
+    try:
+        setattr(environment, "_run_docker_compose_build", build_with_typed_cause)
+    except (AttributeError, TypeError):
+        return None
+
+    def restore() -> None:
+        if (
+            getattr(environment, "_run_docker_compose_build", None)
+            is build_with_typed_cause
+        ):
+            setattr(environment, "_run_docker_compose_build", original_build)
+
+    return restore
 
 
 def _patch_hits(task_staging: Mapping[str, Any] | None) -> list[str]:
@@ -76,6 +131,9 @@ def _base_result(
         "retryability": "unknown",
         "failure_category": "none",
         "exit_category": "pending",
+        "failure_cause_source": "none",
+        "compose_typed_cause_boundary_installed": False,
+        "compose_typed_cause_boundary_restored": False,
         "patch_hits": _patch_hits(task_staging),
         "apt_setup_risk_detected": setup.get("apt_setup_risk_detected") is True,
         "dockerfile_pip_install_risk_detected": (
@@ -88,6 +146,7 @@ def _base_result(
         "raw_error_recorded": False,
         "raw_logs_read": False,
         "raw_logs_recorded": False,
+        "raw_command_output_recorded": False,
         "raw_task_text_read": False,
         "raw_trajectory_read": False,
         "raw_verifier_output_read": False,
@@ -114,6 +173,7 @@ async def run_setup_only_public_preflight(
     stage_timeout_sec = max(1.0, stage_timeout_sec)
     cleanup_timeout_sec = max(1.0, cleanup_timeout_sec)
     rollout: Any | None = None
+    restore_compose_boundary: Callable[[], None] | None = None
     failed = False
     try:
         rollout = await asyncio.wait_for(
@@ -127,6 +187,13 @@ async def run_setup_only_public_preflight(
         )
         result["environment_object_materialized"] = (
             getattr(rollout, "env", None) is not None
+        )
+
+        restore_compose_boundary = install_skillsbench_compose_typed_cause_boundary(
+            getattr(rollout, "env", None)
+        )
+        result["compose_typed_cause_boundary_installed"] = (
+            restore_compose_boundary is not None
         )
 
         result["stage"] = "environment_start"
@@ -144,7 +211,13 @@ async def run_setup_only_public_preflight(
             result["environment_object_materialized"] = (
                 getattr(rollout, "env", None) is not None
             )
-        fingerprint = skillsbench_runner_error_fingerprint(str(exc))
+        typed_fingerprint = skillsbench_compose_typed_fingerprint(exc)
+        if typed_fingerprint is None:
+            fingerprint = skillsbench_runner_error_fingerprint(str(exc))
+            result["failure_cause_source"] = "exception_text_fingerprint"
+        else:
+            fingerprint = typed_fingerprint
+            result["failure_cause_source"] = "compose_producer_typed_cause"
         matched_patterns = {
             str(item)
             for item in fingerprint.get("matched_patterns", [])
@@ -194,6 +267,9 @@ async def run_setup_only_public_preflight(
             or "coarse_public_safe_pattern_match"
         )
     finally:
+        if restore_compose_boundary is not None:
+            restore_compose_boundary()
+            result["compose_typed_cause_boundary_restored"] = True
         if rollout is not None:
             try:
                 await asyncio.wait_for(

--- a/tests/test_skillsbench_setup_preflight.py
+++ b/tests/test_skillsbench_setup_preflight.py
@@ -12,6 +12,8 @@ from loopx.benchmark_adapters.skillsbench_failure_signals import (
     skillsbench_runner_error_fingerprint,
 )
 from loopx.benchmark_adapters.skillsbench_setup_preflight import (
+    SkillsBenchComposeCommandFailure,
+    install_skillsbench_compose_typed_cause_boundary,
     run_setup_only_public_preflight,
 )
 from loopx.status import compact_benchmark_run
@@ -203,6 +205,126 @@ def test_setup_only_preflight_classifies_public_setup_failures(
     assert message not in serialized
     assert result["raw_error_recorded"] is False
     assert result["raw_logs_read"] is False
+
+
+def test_compose_producer_emits_only_bounded_typed_cause() -> None:
+    raw_failure = (
+        "Docker compose command failed for environment private-case. "
+        "Command: docker compose --project-directory /private/job build. "
+        "Stdout: apt-get update failed to fetch package index: Temporary "
+        "failure resolving 'archive.example.invalid'."
+    )
+
+    class FakeComposeEnvironment:
+        def __init__(self) -> None:
+            self.command_attempts = 0
+            self.build_received_raw_failure = False
+
+        async def _run_docker_compose_command(self) -> None:
+            self.command_attempts += 1
+            raise RuntimeError(raw_failure)
+
+        async def _run_docker_compose_build(self) -> None:
+            for attempt in range(2):
+                try:
+                    await self._run_docker_compose_command()
+                except RuntimeError as exc:
+                    self.build_received_raw_failure = raw_failure in str(exc)
+                    if attempt == 0:
+                        continue
+                    raise
+
+    environment = FakeComposeEnvironment()
+    restore = install_skillsbench_compose_typed_cause_boundary(environment)
+    assert restore is not None
+
+    async def invoke() -> None:
+        await environment._run_docker_compose_build()
+
+    with pytest.raises(SkillsBenchComposeCommandFailure) as error:
+        asyncio.run(invoke())
+
+    typed = error.value
+    serialized = json.dumps(typed.fingerprint, sort_keys=True)
+    assert typed.schema_version == "skillsbench_compose_typed_cause_v0"
+    assert typed.fingerprint["apt_failure_subtype"] == "dns_resolution"
+    assert typed.fingerprint["retryability"] == "retryable"
+    assert typed.fingerprint["has_host_paths"] is True
+    assert typed.fingerprint["has_secret_like_tokens"] is False
+    assert environment.command_attempts == 2
+    assert environment.build_received_raw_failure is True
+    assert raw_failure not in str(typed)
+    assert "/private/job" not in serialized
+    assert "archive.example.invalid" not in serialized
+    assert typed.__cause__ is None
+
+    restore()
+    with pytest.raises(RuntimeError, match="Docker compose command failed"):
+        asyncio.run(invoke())
+    assert environment.command_attempts == 4
+
+
+def test_setup_only_preflight_consumes_compose_producer_typed_cause() -> None:
+    raw_failure = (
+        "Docker compose command failed. apt-get update failed to fetch index: "
+        "GPG error: repository is not signed at /private/job"
+    )
+
+    class FakeComposeEnvironment:
+        async def _run_docker_compose_build(self) -> None:
+            raise RuntimeError(raw_failure)
+
+    class FakeComposeRollout:
+        last_created: "FakeComposeRollout | None" = None
+
+        def __init__(self) -> None:
+            self._rollout_dir: object | None = None
+            self.env: FakeComposeEnvironment | None = None
+
+        @classmethod
+        async def create(cls, _config: Any) -> "FakeComposeRollout":
+            instance = cls()
+            cls.last_created = instance
+            return instance
+
+        async def setup(self) -> None:
+            self._rollout_dir = object()
+            self.env = FakeComposeEnvironment()
+
+        async def start(self) -> None:
+            assert self.env is not None
+            await self.env._run_docker_compose_build()
+
+        async def cleanup(self) -> None:
+            return None
+
+    result = asyncio.run(
+        run_setup_only_public_preflight(
+            rollout_type=FakeComposeRollout,
+            config=object(),
+            stage_timeout_sec=1,
+        )
+    )
+
+    assert result["status"] == "failed"
+    assert result["failure_stage"] == "environment_start"
+    assert result["failure_cause_source"] == "compose_producer_typed_cause"
+    assert result["failure_category"] == (
+        "skillsbench_docker_compose_apt_repository_failure"
+    )
+    assert result["apt_failure_subtype"] == "signature_or_gpg"
+    assert result["terminal_failure_reason_codes"] == [
+        "apt_fetch_failed",
+        "apt_signature_or_gpg",
+    ]
+    assert result["compose_typed_cause_boundary_installed"] is True
+    assert result["compose_typed_cause_boundary_restored"] is True
+    assert result["raw_logs_read"] is False
+    assert result["raw_logs_recorded"] is False
+    assert result["raw_command_output_recorded"] is False
+    serialized = json.dumps(result, sort_keys=True)
+    assert raw_failure not in serialized
+    assert "/private/job" not in serialized
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- install a temporary typed-cause boundary on the setup-only sandbox after Rollout setup
- preserve BenchFlow's canonical Docker build retry loop, then replace only the final build exception with a bounded public fingerprint
- consume that typed fingerprint in the setup-only receipt and restore the original build method before cleanup

## Product and architecture judgment

This is a diagnostic boundary, not a setup repair. It prevents raw compose exception text from crossing the final build producer while retaining existing build, retry, scoring, task, agent, verifier, upload, and submission behavior. The exact setup-only candidate proves that the producer currently exposes only `apt_fetch_failed`, so this PR deliberately does not claim a more specific apt root cause or `environment_ready_before_agent`.

## Validation

- `22 passed`: focused setup-only preflight tests
- `56 passed`: all `tests/test_skillsbench_*.py`
- `skillsbench-benchmark-run-smoke: ok`
- Ruff passed on both changed files
- Python compile and `git diff --check` passed
- `loopx check` passed for both changed files with zero boundary findings
- full suite: `937 passed, 2 skipped, 1 failed`; the remaining failure is the unchanged scheduler host-binding fixture returning its operator-gate status and reproduces independently of this diff
- exact-head ECS setup-only receipt: typed boundary installed/restored, `failure_cause_source=compose_producer_typed_cause`, `apt_failure_subtype=fetch_failed_unclassified`, environment not started, agent install/execution false, verifier false, public artifact sync clean, and remote cleanup left zero matching processes

## Boundary

No raw task text, compose output, logs, trajectory, verifier output, credentials, host paths, uploads, submissions, or generated run artifacts are included in this PR.
