### PR TITLE
feat(periodic-report): add default-off product profiles

### DIFF
--- a/docs/capabilities/periodic-report/README.md
+++ b/docs/capabilities/periodic-report/README.md
@@ -6,9 +6,16 @@ presentation, and destinations to profiles and adapters.
 
 | Surface | Value |
 | --- | --- |
-| CLI | `loopx periodic-report evaluate-trigger --request-json <path>` and `compose-run` |
+| CLI | `loopx periodic-report inspect-profile --profile-json <path>`, `evaluate-trigger`, and `compose-run` |
 | Protocol | [`periodic_report_v0`](../../reference/protocols/periodic-report-v0.md) |
-| Smokes | `python3 examples/periodic-report-smoke.py` and `python3 examples/periodic-report-html-smoke.py` |
+| Smokes | `python3 examples/periodic-report-smoke.py`, `periodic-report-profile-smoke.py`, `periodic-report-html-smoke.py`, and `periodic-report-bindings-smoke.py` |
+
+The capability ships with LoopX but is **disabled by default for every
+project**. A project opts in with `periodic_report_profile_v0` and
+`enabled: true`; the profile then names generic trigger policy, source adapter
+bindings, renderer bindings, and required/optional/disabled sink bindings.
+There is no issue-fix-specific report capability: issue-fix, release notes,
+research, operations, and other domains are peers that supply source adapters.
 
 The capability is intentionally effect-free. It first evaluates scheduled or
 material progress facts into a deterministic trigger receipt, then composes a
@@ -37,6 +44,49 @@ idempotency, retry, and receipt contract even when no provider is installed.
 Optional or independently versioned collectors, renderers, archive stores, and
 message transports remain extension providers (or built-in adapters) that
 implement the capability's ports without owning its lifecycle.
+
+Use `inspect-profile` before scheduling a run. It returns a deterministic
+`periodic_report_activation_v0` receipt and never starts a scheduler or invokes
+a provider. An omitted `enabled` field is treated as `false`. When enabled, at
+least one source and one renderer binding are required. An optional archive
+extension can therefore add durable history without making report generation
+or another configured delivery sink depend on that provider.
+
+The public profiles fixture covers a default-disabled project, a cadence-based
+release report with an optional archive extension, and a milestone-only
+research report with an extension-provided source. These are peer product uses;
+none changes the capability identity or core schema.
+
+## Generation and formal delivery
+
+The reusable lifecycle has two independently truthful phases:
+
+1. `build_periodic_report_generation_bundle` freezes one normalized document,
+   one or more rendered artifacts, and a provider-free generation receipt. A
+   missing chat or archive provider cannot invalidate these local artifacts.
+2. A project profile declares sink bindings. LoopX checks the pinned extension
+   version, protocol, capability version, and provider readback before a caller
+   attempts formal delivery. Provider results are then normalized into one
+   delivery receipt with retryable sink ids and exact-readback evidence.
+
+Each sink dependency is profile-owned and explicit:
+
+- `required` fails closed when its provider is missing, incompatible, or not
+  verified;
+- `optional` preserves the generated report and records a degraded or partial
+  formal-delivery outcome;
+- `disabled` performs no provider lookup or write.
+
+This yields three portable operating modes. `portable` generates artifacts
+without providers, `enhanced` adds optional sinks, and `durable` requires one
+or more formal delivery or archive sinks. The public fixture at
+`examples/fixtures/periodic-report-extension-modes.public.json` exercises all
+three without naming a project or relying on a live provider.
+
+`compose-run` remains the compatibility envelope for callers that already have
+both archive and delivery receipts. New profile integrations can use the split
+generation/readiness/delivery receipts so provider-specific policy does not
+leak into the capability core.
 
 ## Built-in renderers
 

--- a/docs/reference/protocols/periodic-report-v0.md
+++ b/docs/reference/protocols/periodic-report-v0.md
@@ -1,5 +1,26 @@
 # Provider-neutral periodic report v0
 
+## Product activation
+
+`periodic_report_profile_v0` is the project opt-in contract. The built-in
+capability is installed but inactive until the profile explicitly sets
+`enabled: true`. Enabled profiles declare:
+
+- provider-neutral trigger policy and an optional host-owned RRULE/timezone;
+- one or more domain source adapter bindings;
+- one or more renderer bindings;
+- zero or more required, optional, or disabled extension sink bindings.
+
+`periodic_report_activation_v0` is the effect-free inspection receipt. It
+records whether generation is allowed, the normalized profile digest, and the
+portable/enhanced/durable extension mode. It performs no source read, schedule
+mutation, provider lookup, rendering, archive write, or message delivery.
+
+Issue-fix has no special standing in either schema. It may register a source
+adapter under the same contract as release, research, operations, or another
+domain. OpenViking is likewise an optional archive/query provider behind a
+sink extension; it does not own trigger, selection, rendering, or delivery.
+
 `periodic_report_v0` is the LoopX control contract for one bounded report run.
 It binds a period window and a profile to typed source snapshots, one rendered
 artifact receipt, archive and delivery receipts, deterministic idempotency,
@@ -24,6 +45,35 @@ loopx periodic-report compose-run \
 The command is local and effect-free. Source collection, rendering, archive
 writes, message delivery, and receipt readback all execute in adapters or
 connectors outside this core.
+
+## Split phase contract
+
+`periodic_report_v0` also exposes a split contract for profiles that must keep
+local report generation independent from provider availability:
+
+- `periodic_report_generation_bundle_v0` contains the normalized document,
+  one to eight artifacts, and a deterministic
+  `periodic_report_generation_receipt_v0`. The receipt declares that no
+  provider or external write was required.
+- `periodic_report_sink_binding_v0` pins a sink id, role, dependency policy,
+  capability id/version, extension id/version, and provider-neutral
+  `periodic_report_sink_v0` protocol.
+- `periodic_report_extension_readiness_v0` verifies those bindings against
+  observed provider receipts. It reports `portable`, `enhanced`, or `durable`
+  delivery mode and never performs a provider call.
+- `periodic_report_delivery_receipt_v0` binds provider sink results back to the
+  generation and readiness receipts. A sent sink is accepted only with an
+  idempotency key, compact receipt reference, and verified exact readback.
+
+The dependency policy is `required`, `optional`, or `disabled`. Required sinks
+block formal delivery when unavailable. Optional sinks degrade without
+invalidating the generation receipt. Disabled sinks are skipped. Provider
+versions, protocols, or capabilities that do not match the profile binding are
+`incompatible`; providers without verified readiness are `unverified`.
+
+The older run request below remains a compatibility full-delivery envelope. It
+still requires archive and delivery receipts, while the split contract makes
+the provider-free generation truth available before those receipts exist.
 
 ## Trigger decision
 

--- a/examples/fixtures/periodic-report-extension-modes.public.json
+++ b/examples/fixtures/periodic-report-extension-modes.public.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "periodic_report_extension_modes_fixture_v0",
+  "profiles": [
+    {
+      "profile_id": "portable_changelog",
+      "description": "Generate normalized Markdown and HTML without any external provider.",
+      "expected_delivery_mode": "portable",
+      "sink_bindings": []
+    },
+    {
+      "profile_id": "enhanced_research",
+      "description": "Keep local artifacts usable when the optional team-chat provider is absent.",
+      "expected_delivery_mode": "enhanced",
+      "sink_bindings": [
+        {
+          "schema_version": "periodic_report_sink_binding_v0",
+          "sink_id": "team_chat_delivery",
+          "sink_kind": "team_chat_message",
+          "sink_role": "delivery",
+          "dependency_policy": "optional",
+          "capability": {
+            "capability_id": "report.message.write",
+            "capability_version": "v0"
+          },
+          "extension": {
+            "extension_id": "team_chat_report_sink",
+            "extension_version": "1.0.0",
+            "protocol": "periodic_report_sink_v0"
+          }
+        }
+      ]
+    },
+    {
+      "profile_id": "durable_maintenance",
+      "description": "Require exact readback from both formal delivery and durable archive providers.",
+      "expected_delivery_mode": "durable",
+      "sink_bindings": [
+        {
+          "schema_version": "periodic_report_sink_binding_v0",
+          "sink_id": "project_resource_archive",
+          "sink_kind": "project_resource",
+          "sink_role": "archive",
+          "dependency_policy": "required",
+          "capability": {
+            "capability_id": "report.archive.write",
+            "capability_version": "v0"
+          },
+          "extension": {
+            "extension_id": "project_resource_report_archive",
+            "extension_version": "1.0.0",
+            "protocol": "periodic_report_sink_v0"
+          }
+        },
+        {
+          "schema_version": "periodic_report_sink_binding_v0",
+          "sink_id": "team_chat_delivery",
+          "sink_kind": "team_chat_message",
+          "sink_role": "delivery",
+          "dependency_policy": "required",
+          "capability": {
+            "capability_id": "report.message.write",
+            "capability_version": "v0"
+          },
+          "extension": {
+            "extension_id": "team_chat_report_sink",
+            "extension_version": "1.0.0",
+            "protocol": "periodic_report_sink_v0"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/examples/fixtures/periodic-report-product-profiles.public.json
+++ b/examples/fixtures/periodic-report-product-profiles.public.json
@@ -1,0 +1,91 @@
+{
+  "schema_version": "periodic_report_product_profiles_fixture_v0",
+  "profiles": [
+    {
+      "schema_version": "periodic_report_profile_v0",
+      "profile_id": "disabled_project",
+      "profile_version": "v1"
+    },
+    {
+      "schema_version": "periodic_report_profile_v0",
+      "enabled": true,
+      "profile_id": "release_summary",
+      "profile_version": "v1",
+      "trigger_policy": {
+        "enabled_kinds": ["cadence_due", "primary_goal_outcome"],
+        "minimum_interval_seconds": 3600
+      },
+      "schedule": {
+        "schema_version": "periodic_report_schedule_v0",
+        "schedule_id": "weekly_window",
+        "rrule": "FREQ=WEEKLY;BYDAY=MO;BYHOUR=9",
+        "timezone": "Asia/Shanghai"
+      },
+      "source_bindings": [
+        {
+          "source_id": "release_state",
+          "source_kind": "validated_outcomes",
+          "adapter_id": "release_state_v0",
+          "provider": {"kind": "builtin"}
+        }
+      ],
+      "renderer_bindings": [
+        {
+          "renderer_id": "markdown",
+          "renderer_kind": "markdown",
+          "adapter_id": "markdown_v0",
+          "provider": {"kind": "builtin"}
+        }
+      ],
+      "sink_bindings": [
+        {
+          "schema_version": "periodic_report_sink_binding_v0",
+          "sink_id": "project_archive",
+          "sink_kind": "project_resource",
+          "sink_role": "archive",
+          "dependency_policy": "optional",
+          "capability": {
+            "capability_id": "report.archive.write",
+            "capability_version": "v0"
+          },
+          "extension": {
+            "extension_id": "project_resource_report_archive",
+            "extension_version": "1.0.0",
+            "protocol": "periodic_report_sink_v0"
+          }
+        }
+      ]
+    },
+    {
+      "schema_version": "periodic_report_profile_v0",
+      "enabled": true,
+      "profile_id": "research_milestones",
+      "profile_version": "v1",
+      "trigger_policy": {
+        "enabled_kinds": ["material_decision", "vision_closed"],
+        "minimum_interval_seconds": 0
+      },
+      "source_bindings": [
+        {
+          "source_id": "research_evidence",
+          "source_kind": "validated_findings",
+          "adapter_id": "research_evidence_v0",
+          "provider": {
+            "kind": "extension",
+            "provider_id": "research_evidence",
+            "provider_version": "1.0.0"
+          }
+        }
+      ],
+      "renderer_bindings": [
+        {
+          "renderer_id": "html",
+          "renderer_kind": "html",
+          "adapter_id": "html_artifact_v0",
+          "provider": {"kind": "builtin"}
+        }
+      ],
+      "sink_bindings": []
+    }
+  ]
+}

--- a/examples/periodic-report-bindings-smoke.py
+++ b/examples/periodic-report-bindings-smoke.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.periodic_report import (  # noqa: E402
+    build_periodic_report_delivery_receipt,
+    build_periodic_report_document,
+    build_periodic_report_extension_readiness,
+    build_periodic_report_generation_bundle,
+    build_periodic_report_source_result,
+)
+from loopx.presentation.renderers.periodic_report_html import (  # noqa: E402
+    render_periodic_report_html,
+)
+from loopx.presentation.renderers.periodic_report_markdown import (  # noqa: E402
+    render_periodic_report_markdown,
+)
+
+
+def _generation() -> dict[str, object]:
+    source = build_periodic_report_source_result(
+        source_id="project_progress",
+        source_kind="validated_outcomes",
+        status="complete",
+        observed_at="2026-07-20T00:40:00Z",
+        sections=[
+            {
+                "section_id": "completed",
+                "title": "Completed",
+                "order": 10,
+                "items": [
+                    {
+                        "item_id": "release_2.4",
+                        "title": "Release 2.4",
+                        "summary": "Published the stable release.",
+                    }
+                ],
+            }
+        ],
+    )
+    document = build_periodic_report_document(
+        title="Project report",
+        generated_at="2026-07-20T01:00:00Z",
+        period_window={
+            "start_at": "2026-07-13T00:00:00Z",
+            "end_at": "2026-07-20T00:00:00Z",
+        },
+        profile={"profile_id": "project", "profile_version": "v1"},
+        sources=[source],
+    )
+    return build_periodic_report_generation_bundle(
+        document=document,
+        artifacts=[
+            render_periodic_report_markdown(document),
+            render_periodic_report_html(document),
+        ],
+    )
+
+
+def main() -> None:
+    fixture_path = (
+        REPO_ROOT
+        / "examples"
+        / "fixtures"
+        / "periodic-report-extension-modes.public.json"
+    )
+    fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+    generation = _generation()["generation_receipt"]
+    modes: dict[str, tuple[str, str]] = {}
+    for profile in fixture["profiles"]:
+        readiness = build_periodic_report_extension_readiness(
+            generation_receipt=generation,
+            sink_bindings=profile["sink_bindings"],
+        )
+        delivery = build_periodic_report_delivery_receipt(
+            generation_receipt=generation,
+            readiness_receipt=readiness,
+        )
+        assert readiness["delivery_mode"] == profile["expected_delivery_mode"]
+        assert readiness["generation_usable"] is True
+        modes[profile["profile_id"]] = (
+            readiness["status"],
+            delivery["status"],
+        )
+
+    assert modes == {
+        "portable_changelog": ("not_required", "not_required"),
+        "enhanced_research": ("degraded", "partial"),
+        "durable_maintenance": ("blocked", "failed"),
+    }
+    print("periodic-report-bindings-smoke: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/periodic-report-profile-smoke.py
+++ b/examples/periodic-report-profile-smoke.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.periodic_report import (  # noqa: E402
+    build_periodic_report_activation,
+)
+
+
+def main() -> None:
+    fixture_path = (
+        REPO_ROOT
+        / "examples"
+        / "fixtures"
+        / "periodic-report-product-profiles.public.json"
+    )
+    fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+    activations = {
+        profile["profile_id"]: build_periodic_report_activation(profile)
+        for profile in fixture["profiles"]
+    }
+
+    assert activations["disabled_project"]["status"] == "disabled"
+    assert activations["release_summary"]["extension_mode"] == "enhanced"
+    assert activations["release_summary"]["optional_extension_count"] == 1
+    assert activations["research_milestones"]["extension_mode"] == "portable"
+    assert all(
+        item["boundary"]["external_writes_performed"] is False
+        for item in activations.values()
+    )
+    serialized = json.dumps(activations, ensure_ascii=False).lower()
+    assert "issue_fix" not in serialized and "pull_request" not in serialized
+    print("periodic-report-profile-smoke: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -537,14 +537,20 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
         "provider_id": "loopx-core",
         "title": "Provider-neutral periodic and progress report runs",
         "status": "active-preview",
+        "default_enabled": False,
         "real_world_anchor": "scheduled and milestone project reports with verified archive and delivery",
         "user_value": (
             "Give projects one deterministic trigger, report run, receipt, "
             "partial-state, and retry contract without hard-coding a domain, "
             "provider, cadence, or destination."
         ),
-        "entry_command": "loopx periodic-report evaluate-trigger --request-json <request.json> --format json",
+        "entry_command": "loopx periodic-report inspect-profile --profile-json <profile.json> --format json",
         "commands": [
+            {
+                "command": "loopx periodic-report inspect-profile --profile-json <profile.json> --format json",
+                "purpose": "Validate explicit project activation plus trigger, source, renderer, and extension sink bindings.",
+                "write_boundary": "local profile inspection only; disabled by default and performs no provider lookup, schedule mutation, or write",
+            },
             {
                 "command": "loopx periodic-report evaluate-trigger --request-json <request.json> --format json",
                 "purpose": "Select, coalesce, cool down, and deduplicate cadence or material progress triggers without provider effects.",
@@ -558,6 +564,16 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
         ],
         "implemented_protocols": [
             {
+                "schema_version": "periodic_report_profile_v0",
+                "module": "loopx.capabilities.periodic_report.profile",
+                "doc": "docs/reference/protocols/periodic-report-v0.md",
+            },
+            {
+                "schema_version": "periodic_report_activation_v0",
+                "module": "loopx.capabilities.periodic_report.profile",
+                "doc": "docs/reference/protocols/periodic-report-v0.md",
+            },
+            {
                 "schema_version": "periodic_report_trigger_decision_v0",
                 "module": "loopx.capabilities.periodic_report.triggers",
                 "doc": "docs/reference/protocols/periodic-report-v0.md",
@@ -567,17 +583,45 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "module": "loopx.capabilities.periodic_report.core",
                 "doc": "docs/reference/protocols/periodic-report-v0.md",
             },
+            {
+                "schema_version": "periodic_report_generation_bundle_v0",
+                "module": "loopx.capabilities.periodic_report.bindings",
+                "doc": "docs/reference/protocols/periodic-report-v0.md",
+            },
+            {
+                "schema_version": "periodic_report_generation_receipt_v0",
+                "module": "loopx.capabilities.periodic_report.bindings",
+                "doc": "docs/reference/protocols/periodic-report-v0.md",
+            },
+            {
+                "schema_version": "periodic_report_sink_binding_v0",
+                "module": "loopx.capabilities.periodic_report.bindings",
+                "doc": "docs/reference/protocols/periodic-report-v0.md",
+            },
+            {
+                "schema_version": "periodic_report_extension_readiness_v0",
+                "module": "loopx.capabilities.periodic_report.bindings",
+                "doc": "docs/reference/protocols/periodic-report-v0.md",
+            },
+            {
+                "schema_version": "periodic_report_delivery_receipt_v0",
+                "module": "loopx.capabilities.periodic_report.bindings",
+                "doc": "docs/reference/protocols/periodic-report-v0.md",
+            },
         ],
         "smokes": [
             "python3 examples/periodic-report-smoke.py",
             "python3 examples/periodic-report-adapters-smoke.py",
             "python3 examples/periodic-report-html-smoke.py",
+            "python3 examples/periodic-report-bindings-smoke.py",
+            "python3 examples/periodic-report-profile-smoke.py",
         ],
         "docs": [
             "docs/capabilities/periodic-report/README.md",
             "docs/reference/protocols/periodic-report-v0.md",
         ],
         "boundaries": [
+            "The built-in capability is installed with LoopX but disabled for every project until a periodic_report_profile_v0 explicitly sets enabled=true.",
             "The core owns material trigger classification, coalescing, cooldown/deduplication, period/profile binding, deterministic identity, receipts, run state, and retry projection.",
             "Profiles own schedule calculation, enabled trigger kinds, minimum interval, timezone, sections, audience, and project policy.",
             "Adapters own domain source collection; renderers and sinks own all provider effects and verified readback.",

--- a/loopx/capabilities/periodic_report/__init__.py
+++ b/loopx/capabilities/periodic_report/__init__.py
@@ -12,18 +12,38 @@ from .archive import (
     build_periodic_report_archive_bundle,
     verify_periodic_report_archive_receipts,
 )
+from .bindings import (
+    build_periodic_report_delivery_receipt,
+    build_periodic_report_extension_readiness,
+    build_periodic_report_generation_bundle,
+    normalize_periodic_report_sink_bindings,
+)
 from .core import build_periodic_report_run
-from .triggers import build_periodic_report_trigger_decision
+from .profile import (
+    build_periodic_report_activation,
+    normalize_periodic_report_profile,
+)
+from .triggers import (
+    build_periodic_report_trigger_decision,
+    normalize_periodic_report_trigger_policy,
+)
 
 __all__ = [
     "PeriodicReportAdapterRegistry",
     "PeriodicReportRendererAdapter",
     "PeriodicReportSinkAdapter",
     "PeriodicReportSourceAdapter",
+    "build_periodic_report_activation",
     "build_periodic_report_document",
+    "build_periodic_report_delivery_receipt",
+    "build_periodic_report_extension_readiness",
+    "build_periodic_report_generation_bundle",
     "build_periodic_report_archive_bundle",
     "build_periodic_report_run",
     "build_periodic_report_source_result",
     "build_periodic_report_trigger_decision",
+    "normalize_periodic_report_profile",
+    "normalize_periodic_report_sink_bindings",
+    "normalize_periodic_report_trigger_policy",
     "verify_periodic_report_archive_receipts",
 ]

--- a/loopx/capabilities/periodic_report/archive.py
+++ b/loopx/capabilities/periodic_report/archive.py
@@ -1,3 +1,10 @@
+"""Compatibility archive packet for existing OpenViking-style resource sinks.
+
+New integrations should declare a provider-neutral archive sink binding and
+keep provider-specific transport in an extension. These helpers remain public
+so existing profiles can migrate without changing their receipt truth.
+"""
+
 from __future__ import annotations
 
 import hashlib

--- a/loopx/capabilities/periodic_report/bindings.py
+++ b/loopx/capabilities/periodic_report/bindings.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 import re
 from collections.abc import Mapping, Sequence
-from typing import Any
+from typing import Any, cast
 
 from .adapters import (
     DOCUMENT_SCHEMA,
@@ -79,8 +79,16 @@ def _boolean(value: object, label: str) -> bool:
 
 
 def _canonical_copy(value: Mapping[str, Any]) -> dict[str, Any]:
-    return json.loads(
-        json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return cast(
+        dict[str, Any],
+        json.loads(
+            json.dumps(
+                value,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+        ),
     )
 
 
@@ -541,12 +549,12 @@ def _readiness_receipt(
     for key, value in expected.items():
         if receipt.get(key) is not value and receipt.get(key) != value:
             raise ValueError(f"readiness_receipt.{key} does not match sink readiness")
-    identity = {
+    readiness_identity = {
         "generation_id": generation["generation_id"],
         "mode": mode,
         "bindings": items,
     }
-    if readiness_id != _identity(identity, prefix="report_readiness"):
+    if readiness_id != _identity(readiness_identity, prefix="report_readiness"):
         raise ValueError("readiness_receipt.readiness_id does not match contents")
     return {
         **receipt,
@@ -574,12 +582,14 @@ def build_periodic_report_delivery_receipt(
         _reject_raw_keys(result, label)
         if result.get("schema_version") != SINK_RESULT_SCHEMA:
             raise ValueError(f"{label} must use {SINK_RESULT_SCHEMA}")
-        identity = (
+        sink_identity = (
             _token(result.get("sink_role"), f"{label}.sink_role"),
             _token(result.get("sink_id"), f"{label}.sink_id"),
         )
-        if identity in results_by_identity:
-            raise ValueError(f"duplicate sink result {identity[0]}:{identity[1]}")
+        if sink_identity in results_by_identity:
+            raise ValueError(
+                f"duplicate sink result {sink_identity[0]}:{sink_identity[1]}"
+            )
         status = _token(result.get("status"), f"{label}.status")
         if status not in _SINK_STATUSES:
             raise ValueError(f"{label}.status is invalid")
@@ -589,17 +599,17 @@ def build_periodic_report_delivery_receipt(
             and result.get("idempotency_key")
         ):
             raise ValueError(f"{label} sent result requires exact readback")
-        results_by_identity[identity] = result
+        results_by_identity[sink_identity] = result
 
     sink_receipts: list[dict[str, Any]] = []
     expected_identities: set[tuple[str, str]] = set()
     for index, raw_item in enumerate(readiness_items):
         item = _mapping(raw_item, f"sink_readiness[{index}]")
-        identity = (str(item.get("sink_role")), str(item.get("sink_id")))
-        expected_identities.add(identity)
+        sink_identity = (str(item.get("sink_role")), str(item.get("sink_id")))
+        expected_identities.add(sink_identity)
         policy = str(item.get("dependency_policy"))
         readiness_status = str(item.get("status"))
-        result = results_by_identity.get(identity)
+        sink_result = results_by_identity.get(sink_identity)
         if policy == "disabled":
             status = "skipped"
             retryable = False
@@ -608,20 +618,20 @@ def build_periodic_report_delivery_receipt(
             status = "failed" if policy == "required" else "skipped"
             retryable = True
             reason = f"extension_{readiness_status}"
-        elif result is None:
+        elif sink_result is None:
             status = "pending"
             retryable = True
             reason = "sink_result_pending"
         else:
-            if result.get("sink_kind") != item.get("sink_kind"):
+            if sink_result.get("sink_kind") != item.get("sink_kind"):
                 raise ValueError("sink result kind does not match readiness binding")
-            status = str(result["status"])
-            retryable = bool(result.get("retryable", status != "sent"))
+            status = str(sink_result["status"])
+            retryable = bool(sink_result.get("retryable", status != "sent"))
             reason = "provider_result"
         receipt = {
-            "sink_id": identity[1],
+            "sink_id": sink_identity[1],
             "sink_kind": item.get("sink_kind"),
-            "sink_role": identity[0],
+            "sink_role": sink_identity[0],
             "dependency_policy": policy,
             "status": status,
             "retryable": retryable,
@@ -629,15 +639,15 @@ def build_periodic_report_delivery_receipt(
             "extension": item.get("extension"),
             "capability": item.get("capability"),
             "readback_verified": bool(
-                result is not None
-                and result.get("status") == "sent"
-                and result.get("readback_verified") is True
+                sink_result is not None
+                and sink_result.get("status") == "sent"
+                and sink_result.get("readback_verified") is True
             ),
         }
-        if result is not None:
+        if sink_result is not None:
             for key in ("idempotency_key", "receipt_ref", "result_id"):
-                if result.get(key):
-                    receipt[key] = result[key]
+                if sink_result.get(key):
+                    receipt[key] = sink_result[key]
         sink_receipts.append(receipt)
     unknown = sorted(set(results_by_identity) - expected_identities)
     if unknown:
@@ -670,7 +680,7 @@ def build_periodic_report_delivery_receipt(
         status = "partial"
     else:
         status = "succeeded"
-    identity = {
+    delivery_identity = {
         "generation_id": generation["generation_id"],
         "readiness_id": readiness.get("readiness_id"),
         "sinks": sink_receipts,
@@ -678,7 +688,7 @@ def build_periodic_report_delivery_receipt(
     return {
         "ok": status in {"not_required", "succeeded", "partial"},
         "schema_version": DELIVERY_RECEIPT_SCHEMA,
-        "delivery_id": _identity(identity, prefix="report_delivery"),
+        "delivery_id": _identity(delivery_identity, prefix="report_delivery"),
         "generation_id": generation["generation_id"],
         "readiness_id": readiness.get("readiness_id"),
         "delivery_mode": readiness.get("delivery_mode"),

--- a/loopx/capabilities/periodic_report/bindings.py
+++ b/loopx/capabilities/periodic_report/bindings.py
@@ -1,0 +1,695 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from .adapters import (
+    DOCUMENT_SCHEMA,
+    SINK_RESULT_SCHEMA,
+    _normalize_artifact_result,
+)
+from .core import _reject_raw_keys
+
+
+GENERATION_BUNDLE_SCHEMA = "periodic_report_generation_bundle_v0"
+GENERATION_RECEIPT_SCHEMA = "periodic_report_generation_receipt_v0"
+SINK_BINDING_SCHEMA = "periodic_report_sink_binding_v0"
+EXTENSION_READINESS_SCHEMA = "periodic_report_extension_readiness_v0"
+DELIVERY_RECEIPT_SCHEMA = "periodic_report_delivery_receipt_v0"
+
+_TOKEN_RE = re.compile(r"^[a-z][a-z0-9_.-]{0,127}$")
+_VERSION_RE = re.compile(r"^[0-9a-z][a-z0-9_.+-]{0,127}$")
+_DEPENDENCY_POLICIES = {"required", "optional", "disabled"}
+_SINK_ROLES = {"archive", "delivery"}
+_PROVIDER_STATUSES = {"ready", "unavailable", "unknown"}
+_SINK_STATUSES = {"pending", "sent", "failed", "skipped", "unknown"}
+_READINESS_ITEM_STATUSES = {
+    "disabled",
+    "incompatible",
+    "missing",
+    "ready",
+    "unavailable",
+    "unknown",
+    "unverified",
+}
+
+
+def _mapping(value: object, label: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be an object")
+    return {str(key): item for key, item in value.items()}
+
+
+def _sequence(value: object, label: str) -> list[Any]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise ValueError(f"{label} must be a list")
+    return list(value)
+
+
+def _text(value: object, label: str, *, maximum: int = 500) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{label} is required")
+    if len(text) > maximum:
+        raise ValueError(f"{label} exceeds {maximum} characters")
+    return text
+
+
+def _token(value: object, label: str) -> str:
+    token = _text(value, label, maximum=128).lower()
+    if not _TOKEN_RE.fullmatch(token):
+        raise ValueError(f"{label} must be a lower-snake-like public token")
+    return token
+
+
+def _version(value: object, label: str) -> str:
+    version = _text(value, label, maximum=128).lower()
+    if not _VERSION_RE.fullmatch(version):
+        raise ValueError(f"{label} must be a public version token")
+    return version
+
+
+def _boolean(value: object, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{label} must be a boolean")
+    return value
+
+
+def _canonical_copy(value: Mapping[str, Any]) -> dict[str, Any]:
+    return json.loads(
+        json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    )
+
+
+def _sha256(value: object) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _identity(value: object, *, prefix: str) -> str:
+    return f"{prefix}_{_sha256(value).split(':', 1)[1][:24]}"
+
+
+def _generation_receipt(raw: object) -> dict[str, Any]:
+    receipt = _mapping(raw, "generation_receipt")
+    _reject_raw_keys(receipt, "generation_receipt")
+    if receipt.get("schema_version") != GENERATION_RECEIPT_SCHEMA:
+        raise ValueError(f"generation_receipt must use {GENERATION_RECEIPT_SCHEMA}")
+    if receipt.get("status") != "succeeded":
+        raise ValueError("generation_receipt must be succeeded before delivery")
+    generation_id = _token(receipt.get("generation_id"), "generation_id")
+    document_digest = _text(
+        receipt.get("document_digest"), "document_digest", maximum=80
+    )
+    if not re.fullmatch(r"sha256:[0-9a-f]{64}", document_digest):
+        raise ValueError("generation_receipt.document_digest must use sha256")
+    artifacts = _sequence(receipt.get("artifact_receipts"), "artifact_receipts")
+    if not artifacts:
+        raise ValueError("generation_receipt.artifact_receipts must not be empty")
+    normalized_artifacts: list[dict[str, str]] = []
+    for index, raw_artifact in enumerate(artifacts):
+        label = f"generation_receipt.artifact_receipts[{index}]"
+        artifact = _mapping(raw_artifact, label)
+        artifact_document_digest = _text(
+            artifact.get("document_digest"), f"{label}.document_digest", maximum=80
+        )
+        if artifact_document_digest != document_digest:
+            raise ValueError(f"{label} belongs to a different document")
+        content_digest = _text(
+            artifact.get("content_digest"), f"{label}.content_digest", maximum=80
+        )
+        if not re.fullmatch(r"sha256:[0-9a-f]{64}", content_digest):
+            raise ValueError(f"{label}.content_digest must use sha256")
+        normalized_artifacts.append(
+            {
+                "artifact_id": _token(
+                    artifact.get("artifact_id"), f"{label}.artifact_id"
+                ),
+                "renderer_id": _token(
+                    artifact.get("renderer_id"), f"{label}.renderer_id"
+                ),
+                "renderer_kind": _token(
+                    artifact.get("renderer_kind"), f"{label}.renderer_kind"
+                ),
+                "artifact_ref": _text(
+                    artifact.get("artifact_ref"), f"{label}.artifact_ref", maximum=500
+                ),
+                "content_digest": content_digest,
+                "document_digest": artifact_document_digest,
+            }
+        )
+    normalized_artifacts.sort(key=lambda item: item["artifact_id"])
+    artifact_ids = [item["artifact_id"] for item in normalized_artifacts]
+    renderer_ids = [item["renderer_id"] for item in normalized_artifacts]
+    if len(artifact_ids) != len(set(artifact_ids)):
+        raise ValueError("generation_receipt contains duplicate artifact_id")
+    if len(renderer_ids) != len(set(renderer_ids)):
+        raise ValueError("generation_receipt contains duplicate renderer_id")
+    if receipt.get("artifact_count") != len(normalized_artifacts):
+        raise ValueError("generation_receipt.artifact_count is invalid")
+    if receipt.get("provider_required") is not False:
+        raise ValueError("generation_receipt.provider_required must be false")
+    if receipt.get("external_writes_performed") is not False:
+        raise ValueError("generation_receipt.external_writes_performed must be false")
+    identity = {
+        "document_digest": document_digest,
+        "artifacts": normalized_artifacts,
+    }
+    if generation_id != _identity(identity, prefix="report_generation"):
+        raise ValueError("generation_receipt.generation_id does not match contents")
+    return {
+        **receipt,
+        "generation_id": generation_id,
+        "artifact_receipts": normalized_artifacts,
+    }
+
+
+def build_periodic_report_generation_bundle(
+    *,
+    document: Mapping[str, Any],
+    artifacts: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Freeze one provider-free normalized document and rendered artifact bundle."""
+
+    normalized_document = _canonical_copy(_mapping(document, "document"))
+    _reject_raw_keys(normalized_document, "document")
+    if normalized_document.get("schema_version") != DOCUMENT_SCHEMA:
+        raise ValueError(f"document must use {DOCUMENT_SCHEMA}")
+    if not 1 <= len(artifacts) <= 8:
+        raise ValueError("artifacts must contain between 1 and 8 items")
+    normalized_artifacts = [
+        _normalize_artifact_result(artifact, expected_document=normalized_document)
+        for artifact in artifacts
+    ]
+    artifact_ids = [str(item["artifact_id"]) for item in normalized_artifacts]
+    renderer_ids = [str(item["renderer_id"]) for item in normalized_artifacts]
+    if len(artifact_ids) != len(set(artifact_ids)):
+        raise ValueError("artifacts contains duplicate artifact_id")
+    if len(renderer_ids) != len(set(renderer_ids)):
+        raise ValueError("artifacts contains duplicate renderer_id")
+    normalized_artifacts.sort(key=lambda item: str(item["artifact_id"]))
+    document_digest = _sha256(normalized_document)
+    artifact_receipts = [
+        {
+            key: artifact[key]
+            for key in (
+                "artifact_id",
+                "renderer_id",
+                "renderer_kind",
+                "artifact_ref",
+                "content_digest",
+                "document_digest",
+            )
+        }
+        for artifact in normalized_artifacts
+    ]
+    identity = {
+        "document_digest": document_digest,
+        "artifacts": artifact_receipts,
+    }
+    receipt = {
+        "schema_version": GENERATION_RECEIPT_SCHEMA,
+        "generation_id": _identity(identity, prefix="report_generation"),
+        "status": "succeeded",
+        "document_digest": document_digest,
+        "artifact_count": len(artifact_receipts),
+        "artifact_receipts": artifact_receipts,
+        "provider_required": False,
+        "external_writes_performed": False,
+    }
+    return {
+        "ok": True,
+        "schema_version": GENERATION_BUNDLE_SCHEMA,
+        "document": normalized_document,
+        "artifacts": normalized_artifacts,
+        "generation_receipt": receipt,
+        "boundary": {
+            "provider_neutral": True,
+            "generation_precedes_delivery": True,
+            "sink_readiness_required_for_generation": False,
+            "external_writes_performed": False,
+        },
+    }
+
+
+def normalize_periodic_report_sink_bindings(
+    raw: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Normalize profile-owned sink dependency and extension bindings."""
+
+    bindings: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for index, raw_item in enumerate(raw):
+        label = f"sink_bindings[{index}]"
+        item = _mapping(raw_item, label)
+        _reject_raw_keys(item, label)
+        if item.get("schema_version", SINK_BINDING_SCHEMA) != SINK_BINDING_SCHEMA:
+            raise ValueError(f"{label} must use {SINK_BINDING_SCHEMA}")
+        sink_id = _token(item.get("sink_id"), f"{label}.sink_id")
+        sink_role = _token(item.get("sink_role"), f"{label}.sink_role")
+        if sink_role not in _SINK_ROLES:
+            raise ValueError(f"{label}.sink_role must be archive or delivery")
+        identity = (sink_role, sink_id)
+        if identity in seen:
+            raise ValueError(f"duplicate sink binding {sink_role}:{sink_id}")
+        seen.add(identity)
+        policy = _token(item.get("dependency_policy"), f"{label}.dependency_policy")
+        if policy not in _DEPENDENCY_POLICIES:
+            raise ValueError(
+                f"{label}.dependency_policy must be required, optional, or disabled"
+            )
+        capability = _mapping(item.get("capability"), f"{label}.capability")
+        extension = _mapping(item.get("extension"), f"{label}.extension")
+        bindings.append(
+            {
+                "schema_version": SINK_BINDING_SCHEMA,
+                "sink_id": sink_id,
+                "sink_kind": _token(item.get("sink_kind"), f"{label}.sink_kind"),
+                "sink_role": sink_role,
+                "dependency_policy": policy,
+                "capability": {
+                    "capability_id": _token(
+                        capability.get("capability_id"),
+                        f"{label}.capability.capability_id",
+                    ),
+                    "capability_version": _version(
+                        capability.get("capability_version"),
+                        f"{label}.capability.capability_version",
+                    ),
+                },
+                "extension": {
+                    "extension_id": _token(
+                        extension.get("extension_id"),
+                        f"{label}.extension.extension_id",
+                    ),
+                    "extension_version": _version(
+                        extension.get("extension_version"),
+                        f"{label}.extension.extension_version",
+                    ),
+                    "protocol": _token(
+                        extension.get("protocol"),
+                        f"{label}.extension.protocol",
+                    ),
+                },
+            }
+        )
+    return sorted(
+        bindings, key=lambda item: (str(item["sink_role"]), str(item["sink_id"]))
+    )
+
+
+def _extension_receipts(raw: Sequence[Mapping[str, Any]]) -> dict[str, dict[str, Any]]:
+    receipts: dict[str, dict[str, Any]] = {}
+    for index, raw_item in enumerate(raw):
+        label = f"extension_receipts[{index}]"
+        item = _mapping(raw_item, label)
+        _reject_raw_keys(item, label)
+        extension_id = _token(item.get("extension_id"), f"{label}.extension_id")
+        if extension_id in receipts:
+            raise ValueError(f"duplicate extension receipt {extension_id!r}")
+        status = _token(item.get("status"), f"{label}.status")
+        if status not in _PROVIDER_STATUSES:
+            raise ValueError(f"{label}.status is invalid")
+        capabilities: list[dict[str, str]] = []
+        for capability_index, raw_capability in enumerate(
+            _sequence(item.get("capabilities", []), f"{label}.capabilities")
+        ):
+            capability = _mapping(
+                raw_capability, f"{label}.capabilities[{capability_index}]"
+            )
+            capabilities.append(
+                {
+                    "capability_id": _token(
+                        capability.get("capability_id"),
+                        f"{label}.capabilities[{capability_index}].capability_id",
+                    ),
+                    "capability_version": _version(
+                        capability.get("capability_version"),
+                        f"{label}.capabilities[{capability_index}].capability_version",
+                    ),
+                }
+            )
+        receipts[extension_id] = {
+            "extension_id": extension_id,
+            "extension_version": _version(
+                item.get("extension_version"), f"{label}.extension_version"
+            ),
+            "protocol": _token(item.get("protocol"), f"{label}.protocol"),
+            "status": status,
+            "readback_verified": _boolean(
+                item.get("readback_verified"), f"{label}.readback_verified"
+            ),
+            "capabilities": sorted(
+                capabilities,
+                key=lambda value: (
+                    value["capability_id"],
+                    value["capability_version"],
+                ),
+            ),
+        }
+    return receipts
+
+
+def _binding_provider_status(
+    binding: Mapping[str, Any],
+    provider: Mapping[str, Any] | None,
+) -> str:
+    policy = str(binding["dependency_policy"])
+    expected_extension = _mapping(binding["extension"], "binding.extension")
+    expected_capability = _mapping(binding["capability"], "binding.capability")
+    if policy == "disabled":
+        return "disabled"
+    if provider is None:
+        return "missing"
+    if (
+        provider["extension_id"] != expected_extension["extension_id"]
+        or provider["extension_version"] != expected_extension["extension_version"]
+        or provider["protocol"] != expected_extension["protocol"]
+        or expected_capability not in provider["capabilities"]
+    ):
+        return "incompatible"
+    if provider["status"] != "ready":
+        return str(provider["status"])
+    if provider["readback_verified"] is not True:
+        return "unverified"
+    return "ready"
+
+
+def build_periodic_report_extension_readiness(
+    *,
+    generation_receipt: Mapping[str, Any],
+    sink_bindings: Sequence[Mapping[str, Any]],
+    extension_receipts: Sequence[Mapping[str, Any]] = (),
+) -> dict[str, Any]:
+    """Assess formal-delivery readiness without invoking a provider."""
+
+    generation = _generation_receipt(generation_receipt)
+    bindings = normalize_periodic_report_sink_bindings(sink_bindings)
+    providers = _extension_receipts(extension_receipts)
+    results: list[dict[str, Any]] = []
+    for binding in bindings:
+        policy = str(binding["dependency_policy"])
+        expected_extension = binding["extension"]
+        provider = providers.get(str(expected_extension["extension_id"]))
+        status = _binding_provider_status(binding, provider)
+        blocks_delivery = policy == "required" and status != "ready"
+        results.append(
+            {
+                **binding,
+                "status": status,
+                "ready": status == "ready",
+                "blocks_delivery": blocks_delivery,
+                "provider_receipt": provider,
+            }
+        )
+    enabled = [
+        result for result in results if result["dependency_policy"] != "disabled"
+    ]
+    required = [
+        result for result in enabled if result["dependency_policy"] == "required"
+    ]
+    optional_degraded = any(
+        result["dependency_policy"] == "optional" and not result["ready"]
+        for result in enabled
+    )
+    blocked = any(result["blocks_delivery"] for result in required)
+    ready_count = sum(bool(result["ready"]) for result in enabled)
+    mode = "portable" if not enabled else ("durable" if required else "enhanced")
+    if not enabled:
+        readiness_status = "not_required"
+    elif blocked:
+        readiness_status = "blocked"
+    elif optional_degraded:
+        readiness_status = "degraded"
+    else:
+        readiness_status = "ready"
+    identity = {
+        "generation_id": generation["generation_id"],
+        "mode": mode,
+        "bindings": results,
+    }
+    return {
+        "ok": True,
+        "schema_version": EXTENSION_READINESS_SCHEMA,
+        "readiness_id": _identity(identity, prefix="report_readiness"),
+        "generation_id": generation["generation_id"],
+        "delivery_mode": mode,
+        "status": readiness_status,
+        "generation_usable": True,
+        "formal_delivery_required": bool(required),
+        "delivery_allowed": bool(ready_count and not blocked),
+        "degraded": optional_degraded,
+        "sink_readiness": results,
+        "readback_verified": all(
+            result["status"] in {"ready", "disabled"} for result in results
+        ),
+        "external_writes_performed": False,
+    }
+
+
+def _readiness_receipt(
+    raw: object,
+    *,
+    generation: Mapping[str, Any],
+) -> dict[str, Any]:
+    receipt = _mapping(raw, "readiness_receipt")
+    _reject_raw_keys(receipt, "readiness_receipt")
+    if receipt.get("schema_version") != EXTENSION_READINESS_SCHEMA:
+        raise ValueError(f"readiness_receipt must use {EXTENSION_READINESS_SCHEMA}")
+    if receipt.get("generation_id") != generation["generation_id"]:
+        raise ValueError("readiness_receipt belongs to a different generation")
+    readiness_id = _token(receipt.get("readiness_id"), "readiness_id")
+    raw_items = _sequence(
+        receipt.get("sink_readiness"), "readiness_receipt.sink_readiness"
+    )
+    items: list[dict[str, Any]] = []
+    identities: set[tuple[str, str]] = set()
+    for index, raw_item in enumerate(raw_items):
+        label = f"readiness_receipt.sink_readiness[{index}]"
+        item = _mapping(raw_item, label)
+        binding = normalize_periodic_report_sink_bindings([item])[0]
+        identity = (str(binding["sink_role"]), str(binding["sink_id"]))
+        if identity in identities:
+            raise ValueError(f"duplicate readiness sink {identity[0]}:{identity[1]}")
+        identities.add(identity)
+        status = _token(item.get("status"), f"{label}.status")
+        if status not in _READINESS_ITEM_STATUSES:
+            raise ValueError(f"{label}.status is invalid")
+        ready = status == "ready"
+        blocks_delivery = binding["dependency_policy"] == "required" and not ready
+        if item.get("ready") is not ready:
+            raise ValueError(f"{label}.ready does not match status")
+        if item.get("blocks_delivery") is not blocks_delivery:
+            raise ValueError(f"{label}.blocks_delivery does not match policy")
+        provider_receipt = item.get("provider_receipt")
+        normalized_provider: dict[str, Any] | None = None
+        if provider_receipt is not None:
+            provider_map = _mapping(provider_receipt, f"{label}.provider_receipt")
+            normalized_provider = next(
+                iter(_extension_receipts([provider_map]).values())
+            )
+        expected_status = _binding_provider_status(binding, normalized_provider)
+        if status != expected_status:
+            raise ValueError(f"{label}.status does not match provider receipt")
+        items.append(
+            {
+                **binding,
+                "status": status,
+                "ready": ready,
+                "blocks_delivery": blocks_delivery,
+                "provider_receipt": normalized_provider,
+            }
+        )
+    items.sort(key=lambda item: (str(item["sink_role"]), str(item["sink_id"])))
+    enabled = [item for item in items if item["dependency_policy"] != "disabled"]
+    required = [item for item in enabled if item["dependency_policy"] == "required"]
+    optional_degraded = any(
+        item["dependency_policy"] == "optional" and not item["ready"]
+        for item in enabled
+    )
+    blocked = any(item["blocks_delivery"] for item in required)
+    ready_count = sum(bool(item["ready"]) for item in enabled)
+    mode = "portable" if not enabled else ("durable" if required else "enhanced")
+    if not enabled:
+        status = "not_required"
+    elif blocked:
+        status = "blocked"
+    elif optional_degraded:
+        status = "degraded"
+    else:
+        status = "ready"
+    expected = {
+        "delivery_mode": mode,
+        "status": status,
+        "generation_usable": True,
+        "formal_delivery_required": bool(required),
+        "delivery_allowed": bool(ready_count and not blocked),
+        "degraded": optional_degraded,
+        "readback_verified": all(
+            item["status"] in {"ready", "disabled"} for item in items
+        ),
+        "external_writes_performed": False,
+    }
+    for key, value in expected.items():
+        if receipt.get(key) is not value and receipt.get(key) != value:
+            raise ValueError(f"readiness_receipt.{key} does not match sink readiness")
+    identity = {
+        "generation_id": generation["generation_id"],
+        "mode": mode,
+        "bindings": items,
+    }
+    if readiness_id != _identity(identity, prefix="report_readiness"):
+        raise ValueError("readiness_receipt.readiness_id does not match contents")
+    return {
+        **receipt,
+        **expected,
+        "readiness_id": readiness_id,
+        "sink_readiness": items,
+    }
+
+
+def build_periodic_report_delivery_receipt(
+    *,
+    generation_receipt: Mapping[str, Any],
+    readiness_receipt: Mapping[str, Any],
+    sink_results: Sequence[Mapping[str, Any]] = (),
+) -> dict[str, Any]:
+    """Normalize provider results against a version-pinned readiness receipt."""
+
+    generation = _generation_receipt(generation_receipt)
+    readiness = _readiness_receipt(readiness_receipt, generation=generation)
+    readiness_items = readiness["sink_readiness"]
+    results_by_identity: dict[tuple[str, str], dict[str, Any]] = {}
+    for index, raw_result in enumerate(sink_results):
+        label = f"sink_results[{index}]"
+        result = _mapping(raw_result, label)
+        _reject_raw_keys(result, label)
+        if result.get("schema_version") != SINK_RESULT_SCHEMA:
+            raise ValueError(f"{label} must use {SINK_RESULT_SCHEMA}")
+        identity = (
+            _token(result.get("sink_role"), f"{label}.sink_role"),
+            _token(result.get("sink_id"), f"{label}.sink_id"),
+        )
+        if identity in results_by_identity:
+            raise ValueError(f"duplicate sink result {identity[0]}:{identity[1]}")
+        status = _token(result.get("status"), f"{label}.status")
+        if status not in _SINK_STATUSES:
+            raise ValueError(f"{label}.status is invalid")
+        if status == "sent" and not (
+            result.get("receipt_ref")
+            and result.get("readback_verified") is True
+            and result.get("idempotency_key")
+        ):
+            raise ValueError(f"{label} sent result requires exact readback")
+        results_by_identity[identity] = result
+
+    sink_receipts: list[dict[str, Any]] = []
+    expected_identities: set[tuple[str, str]] = set()
+    for index, raw_item in enumerate(readiness_items):
+        item = _mapping(raw_item, f"sink_readiness[{index}]")
+        identity = (str(item.get("sink_role")), str(item.get("sink_id")))
+        expected_identities.add(identity)
+        policy = str(item.get("dependency_policy"))
+        readiness_status = str(item.get("status"))
+        result = results_by_identity.get(identity)
+        if policy == "disabled":
+            status = "skipped"
+            retryable = False
+            reason = "dependency_disabled"
+        elif readiness_status != "ready":
+            status = "failed" if policy == "required" else "skipped"
+            retryable = True
+            reason = f"extension_{readiness_status}"
+        elif result is None:
+            status = "pending"
+            retryable = True
+            reason = "sink_result_pending"
+        else:
+            if result.get("sink_kind") != item.get("sink_kind"):
+                raise ValueError("sink result kind does not match readiness binding")
+            status = str(result["status"])
+            retryable = bool(result.get("retryable", status != "sent"))
+            reason = "provider_result"
+        receipt = {
+            "sink_id": identity[1],
+            "sink_kind": item.get("sink_kind"),
+            "sink_role": identity[0],
+            "dependency_policy": policy,
+            "status": status,
+            "retryable": retryable,
+            "reason": reason,
+            "extension": item.get("extension"),
+            "capability": item.get("capability"),
+            "readback_verified": bool(
+                result is not None
+                and result.get("status") == "sent"
+                and result.get("readback_verified") is True
+            ),
+        }
+        if result is not None:
+            for key in ("idempotency_key", "receipt_ref", "result_id"):
+                if result.get(key):
+                    receipt[key] = result[key]
+        sink_receipts.append(receipt)
+    unknown = sorted(set(results_by_identity) - expected_identities)
+    if unknown:
+        raise ValueError(
+            f"sink_results contains unbound sink {unknown[0][0]}:{unknown[0][1]}"
+        )
+
+    enabled = [
+        receipt
+        for receipt in sink_receipts
+        if receipt["dependency_policy"] != "disabled"
+    ]
+    if not enabled:
+        status = "not_required"
+    elif any(
+        receipt["dependency_policy"] == "required" and receipt["status"] != "sent"
+        for receipt in enabled
+    ):
+        if any(receipt["status"] == "pending" for receipt in enabled):
+            status = "pending"
+        elif any(receipt["status"] == "unknown" for receipt in enabled):
+            status = "unknown"
+        else:
+            status = "failed"
+    elif any(receipt["status"] == "pending" for receipt in enabled):
+        status = "pending"
+    elif any(receipt["status"] == "unknown" for receipt in enabled):
+        status = "unknown"
+    elif any(receipt["status"] != "sent" for receipt in enabled):
+        status = "partial"
+    else:
+        status = "succeeded"
+    identity = {
+        "generation_id": generation["generation_id"],
+        "readiness_id": readiness.get("readiness_id"),
+        "sinks": sink_receipts,
+    }
+    return {
+        "ok": status in {"not_required", "succeeded", "partial"},
+        "schema_version": DELIVERY_RECEIPT_SCHEMA,
+        "delivery_id": _identity(identity, prefix="report_delivery"),
+        "generation_id": generation["generation_id"],
+        "readiness_id": readiness.get("readiness_id"),
+        "delivery_mode": readiness.get("delivery_mode"),
+        "status": status,
+        "terminal": status not in {"pending", "unknown"},
+        "generation_usable": True,
+        "sink_receipts": sink_receipts,
+        "retryable_sinks": sorted(
+            receipt["sink_id"]
+            for receipt in sink_receipts
+            if receipt["retryable"] and receipt["status"] != "sent"
+        ),
+        "external_writes_performed": False,
+    }

--- a/loopx/capabilities/periodic_report/cli.py
+++ b/loopx/capabilities/periodic_report/cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from .core import build_periodic_report_run
+from .profile import build_periodic_report_activation
 from .triggers import build_periodic_report_trigger_decision
 
 
@@ -58,11 +59,34 @@ def register_periodic_report_commands(
         required=True,
         help="Path to periodic_report_trigger_request_v0 JSON; use '-' for stdin.",
     )
+    inspect_profile = commands.add_parser(
+        "inspect-profile",
+        help="Validate one default-off project profile without provider effects.",
+    )
+    add_subcommand_format(inspect_profile)
+    inspect_profile.add_argument(
+        "--profile-json",
+        required=True,
+        help="Path to periodic_report_profile_v0 JSON; use '-' for stdin.",
+    )
 
 
 def render_periodic_report_markdown(payload: dict[str, object]) -> str:
     if not payload.get("ok"):
         return f"# Periodic Report Error\n\n- error: {payload.get('error')}\n"
+    if payload.get("schema_version") == "periodic_report_activation_v0":
+        profile = payload.get("profile")
+        normalized_profile = profile if isinstance(profile, dict) else {}
+        return "\n".join(
+            [
+                f"# Periodic Report Profile `{normalized_profile.get('profile_id')}`",
+                "",
+                f"- status: `{payload.get('status')}`",
+                f"- active: `{payload.get('active')}`",
+                f"- extension_mode: `{payload.get('extension_mode')}`",
+                "",
+            ]
+        )
     if payload.get("schema_version") == "periodic_report_trigger_decision_v0":
         return "\n".join(
             [
@@ -101,10 +125,15 @@ def handle_periodic_report_command(
     if args.command != "periodic-report":
         return None
     try:
-        request = _load_json_object(args.request_json)
-        if args.periodic_report_command == "evaluate-trigger":
+        if args.periodic_report_command == "inspect-profile":
+            payload = build_periodic_report_activation(
+                _load_json_object(args.profile_json)
+            )
+        elif args.periodic_report_command == "evaluate-trigger":
+            request = _load_json_object(args.request_json)
             payload = build_periodic_report_trigger_decision(request)
         else:
+            request = _load_json_object(args.request_json)
             payload = build_periodic_report_run(request)
     except Exception as exc:
         payload = {

--- a/loopx/capabilities/periodic_report/profile.py
+++ b/loopx/capabilities/periodic_report/profile.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from .bindings import (
+    _boolean,
+    _mapping,
+    _sequence,
+    _sha256,
+    _text,
+    _token,
+    _version,
+    normalize_periodic_report_sink_bindings,
+)
+from .core import _reject_raw_keys
+from .triggers import normalize_periodic_report_trigger_policy
+
+
+PROFILE_SCHEMA = "periodic_report_profile_v0"
+ACTIVATION_SCHEMA = "periodic_report_activation_v0"
+SOURCE_BINDING_SCHEMA = "periodic_report_source_binding_v0"
+RENDERER_BINDING_SCHEMA = "periodic_report_renderer_binding_v0"
+SCHEDULE_SCHEMA = "periodic_report_schedule_v0"
+
+_PROVIDER_KINDS = {"builtin", "extension"}
+_TIMEZONE_RE = re.compile(r"^[A-Za-z_+-]+(?:/[A-Za-z0-9_+-]+)*$")
+_PROFILE_FIELDS = {
+    "schema_version",
+    "enabled",
+    "profile_id",
+    "profile_version",
+    "trigger_policy",
+    "schedule",
+    "source_bindings",
+    "renderer_bindings",
+    "sink_bindings",
+}
+
+
+def _reject_unknown_fields(
+    value: Mapping[str, Any], *, allowed: set[str], label: str
+) -> None:
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise ValueError(f"{label} contains unsupported fields: {', '.join(unknown)}")
+
+
+def _normalize_adapter_bindings(
+    raw: Sequence[Mapping[str, Any]], *, kind: str
+) -> list[dict[str, Any]]:
+    if kind == "source":
+        schema = SOURCE_BINDING_SCHEMA
+        id_field = "source_id"
+        kind_field = "source_kind"
+    else:
+        schema = RENDERER_BINDING_SCHEMA
+        id_field = "renderer_id"
+        kind_field = "renderer_kind"
+    bindings: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, raw_item in enumerate(raw):
+        label = f"{kind}_bindings[{index}]"
+        item = _mapping(raw_item, label)
+        _reject_raw_keys(item, label)
+        _reject_unknown_fields(
+            item,
+            allowed={
+                "schema_version",
+                id_field,
+                kind_field,
+                "adapter_id",
+                "provider",
+            },
+            label=label,
+        )
+        if item.get("schema_version", schema) != schema:
+            raise ValueError(f"{label} must use {schema}")
+        binding_id = _token(item.get(id_field), f"{label}.{id_field}")
+        if binding_id in seen:
+            raise ValueError(f"duplicate {id_field} {binding_id!r}")
+        seen.add(binding_id)
+        provider = _mapping(
+            item.get("provider", {"kind": "builtin"}), f"{label}.provider"
+        )
+        _reject_unknown_fields(
+            provider,
+            allowed={"kind", "provider_id", "provider_version"},
+            label=f"{label}.provider",
+        )
+        provider_kind = _token(
+            provider.get("kind", "builtin"), f"{label}.provider.kind"
+        )
+        if provider_kind not in _PROVIDER_KINDS:
+            raise ValueError(f"{label}.provider.kind must be builtin or extension")
+        normalized_provider: dict[str, str] = {"kind": provider_kind}
+        if provider_kind == "extension":
+            normalized_provider.update(
+                {
+                    "provider_id": _token(
+                        provider.get("provider_id"),
+                        f"{label}.provider.provider_id",
+                    ),
+                    "provider_version": _version(
+                        provider.get("provider_version"),
+                        f"{label}.provider.provider_version",
+                    ),
+                }
+            )
+        elif provider.get("provider_id") or provider.get("provider_version"):
+            raise ValueError(
+                f"{label}.provider builtin must not declare extension identity"
+            )
+        bindings.append(
+            {
+                "schema_version": schema,
+                id_field: binding_id,
+                kind_field: _token(item.get(kind_field), f"{label}.{kind_field}"),
+                "adapter_id": _token(item.get("adapter_id"), f"{label}.adapter_id"),
+                "provider": normalized_provider,
+            }
+        )
+    return sorted(bindings, key=lambda item: str(item[id_field]))
+
+
+def _normalize_schedule(raw: object) -> dict[str, str] | None:
+    if raw is None:
+        return None
+    schedule = _mapping(raw, "schedule")
+    _reject_raw_keys(schedule, "schedule")
+    _reject_unknown_fields(
+        schedule,
+        allowed={"schema_version", "schedule_id", "rrule", "timezone"},
+        label="schedule",
+    )
+    if schedule.get("schema_version", SCHEDULE_SCHEMA) != SCHEDULE_SCHEMA:
+        raise ValueError(f"schedule must use {SCHEDULE_SCHEMA}")
+    rrule = _text(schedule.get("rrule"), "schedule.rrule", maximum=500).upper()
+    if not rrule.startswith("FREQ="):
+        raise ValueError("schedule.rrule must start with FREQ=")
+    timezone = _text(schedule.get("timezone"), "schedule.timezone", maximum=80)
+    if not _TIMEZONE_RE.fullmatch(timezone):
+        raise ValueError("schedule.timezone must be an IANA-like timezone name")
+    return {
+        "schema_version": SCHEDULE_SCHEMA,
+        "schedule_id": _token(schedule.get("schedule_id"), "schedule.schedule_id"),
+        "rrule": rrule,
+        "timezone": timezone,
+    }
+
+
+def normalize_periodic_report_profile(raw: Mapping[str, Any]) -> dict[str, Any]:
+    """Normalize one default-off, domain-neutral project reporting profile."""
+
+    profile = _mapping(raw, "profile")
+    _reject_raw_keys(profile, "profile")
+    _reject_unknown_fields(profile, allowed=_PROFILE_FIELDS, label="profile")
+    if profile.get("schema_version") != PROFILE_SCHEMA:
+        raise ValueError(f"profile must use {PROFILE_SCHEMA}")
+    enabled = _boolean(profile.get("enabled", False), "profile.enabled")
+    sources = _normalize_adapter_bindings(
+        _sequence(profile.get("source_bindings", []), "profile.source_bindings"),
+        kind="source",
+    )
+    renderers = _normalize_adapter_bindings(
+        _sequence(profile.get("renderer_bindings", []), "profile.renderer_bindings"),
+        kind="renderer",
+    )
+    sinks = normalize_periodic_report_sink_bindings(
+        _sequence(profile.get("sink_bindings", []), "profile.sink_bindings")
+    )
+    if enabled and not sources:
+        raise ValueError("enabled profile requires at least one source binding")
+    if enabled and not renderers:
+        raise ValueError("enabled profile requires at least one renderer binding")
+    normalized: dict[str, Any] = {
+        "schema_version": PROFILE_SCHEMA,
+        "enabled": enabled,
+        "profile_id": _token(profile.get("profile_id"), "profile.profile_id"),
+        "profile_version": _version(
+            profile.get("profile_version"), "profile.profile_version"
+        ),
+        "trigger_policy": normalize_periodic_report_trigger_policy(
+            profile.get("trigger_policy", {})
+        ),
+        "source_bindings": sources,
+        "renderer_bindings": renderers,
+        "sink_bindings": sinks,
+    }
+    schedule = _normalize_schedule(profile.get("schedule"))
+    if schedule is not None:
+        normalized["schedule"] = schedule
+    return normalized
+
+
+def build_periodic_report_activation(raw: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a deterministic activation receipt without invoking adapters."""
+
+    profile = normalize_periodic_report_profile(raw)
+    enabled_sinks = [
+        item
+        for item in profile["sink_bindings"]
+        if item["dependency_policy"] != "disabled"
+    ]
+    required_sinks = [
+        item for item in enabled_sinks if item["dependency_policy"] == "required"
+    ]
+    if not enabled_sinks:
+        mode = "portable"
+    elif required_sinks:
+        mode = "durable"
+    else:
+        mode = "enhanced"
+    return {
+        "ok": True,
+        "schema_version": ACTIVATION_SCHEMA,
+        "status": "enabled" if profile["enabled"] else "disabled",
+        "active": profile["enabled"],
+        "generation_allowed": profile["enabled"],
+        "profile_digest": _sha256(profile),
+        "profile": profile,
+        "extension_mode": mode,
+        "required_extension_count": len(required_sinks),
+        "optional_extension_count": sum(
+            item["dependency_policy"] == "optional" for item in enabled_sinks
+        ),
+        "boundary": {
+            "default_enabled": False,
+            "business_semantics_owned_by_sources": True,
+            "schedule_application_owned_by_host": True,
+            "extension_effects_performed": False,
+            "external_writes_performed": False,
+        },
+    }

--- a/loopx/capabilities/periodic_report/triggers.py
+++ b/loopx/capabilities/periodic_report/triggers.py
@@ -101,6 +101,12 @@ def _normalize_policy(raw: object) -> dict[str, Any]:
     }
 
 
+def normalize_periodic_report_trigger_policy(raw: object) -> dict[str, Any]:
+    """Normalize the trigger portion of a project-owned report profile."""
+
+    return _normalize_policy(raw)
+
+
 def _normalize_last_report(raw: object) -> dict[str, Any] | None:
     if raw is None:
         return None

--- a/tests/capabilities/test_capability_extension_registry.py
+++ b/tests/capabilities/test_capability_extension_registry.py
@@ -44,7 +44,7 @@ def _write_manifest(
     runtime = (
         ""
         if entrypoint is None
-        else f'''\
+        else f"""\
 
 [runtime]
 protocol = "sample_report_provider_v0"
@@ -52,7 +52,7 @@ entrypoint = {json.dumps(str(entrypoint))}
 doctor_args = ["--doctor"]
 required_permissions = []
 timeout_seconds = 5
-'''
+"""
     )
     path.write_text(
         f'''\
@@ -109,6 +109,28 @@ def test_builtin_catalog_preserves_order_and_marks_provider() -> None:
             "ready": True,
         }
     ]
+
+
+def test_periodic_report_catalog_exposes_extension_boundary_contracts() -> None:
+    detail = build_capability_detail_packet("periodic-report")
+    capability = detail["capability"]
+
+    assert capability["default_enabled"] is False
+    assert capability["entry_command"].startswith(
+        "loopx periodic-report inspect-profile"
+    )
+    assert {
+        protocol["schema_version"] for protocol in capability["implemented_protocols"]
+    } >= {
+        "periodic_report_profile_v0",
+        "periodic_report_activation_v0",
+        "periodic_report_generation_bundle_v0",
+        "periodic_report_generation_receipt_v0",
+        "periodic_report_sink_binding_v0",
+        "periodic_report_extension_readiness_v0",
+        "periodic_report_delivery_receipt_v0",
+    }
+    assert "python3 examples/periodic-report-bindings-smoke.py" in capability["smokes"]
 
 
 def test_declared_manifest_composes_public_capability_without_claiming_readiness(

--- a/tests/capabilities/test_periodic_report_bindings.py
+++ b/tests/capabilities/test_periodic_report_bindings.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any
+
+import pytest
+
+from loopx.capabilities.periodic_report import (
+    build_periodic_report_delivery_receipt,
+    build_periodic_report_document,
+    build_periodic_report_extension_readiness,
+    build_periodic_report_generation_bundle,
+    build_periodic_report_source_result,
+)
+from loopx.presentation.renderers.periodic_report_html import (
+    render_periodic_report_html,
+)
+from loopx.presentation.renderers.periodic_report_markdown import (
+    render_periodic_report_markdown,
+)
+
+
+def _document() -> dict[str, Any]:
+    source = build_periodic_report_source_result(
+        source_id="project_progress",
+        source_kind="validated_outcomes",
+        status="complete",
+        observed_at="2026-07-20T00:40:00Z",
+        sections=[
+            {
+                "section_id": "completed",
+                "title": "Completed",
+                "order": 10,
+                "items": [
+                    {
+                        "item_id": "release_2.4",
+                        "title": "Release 2.4",
+                        "summary": "Published the stable release.",
+                        "value_rank": 50,
+                    }
+                ],
+            }
+        ],
+    )
+    return build_periodic_report_document(
+        title="Project report",
+        generated_at="2026-07-20T01:00:00Z",
+        period_window={
+            "start_at": "2026-07-13T00:00:00Z",
+            "end_at": "2026-07-20T00:00:00Z",
+        },
+        profile={"profile_id": "project", "profile_version": "v1"},
+        sources=[source],
+    )
+
+
+def _generation() -> dict[str, Any]:
+    document = _document()
+    return build_periodic_report_generation_bundle(
+        document=document,
+        artifacts=[
+            render_periodic_report_markdown(document),
+            render_periodic_report_html(document),
+        ],
+    )
+
+
+def _binding(*, policy: str = "required") -> dict[str, Any]:
+    return {
+        "schema_version": "periodic_report_sink_binding_v0",
+        "sink_id": "team_chat_delivery",
+        "sink_kind": "team_chat_message",
+        "sink_role": "delivery",
+        "dependency_policy": policy,
+        "capability": {
+            "capability_id": "report.message.write",
+            "capability_version": "v0",
+        },
+        "extension": {
+            "extension_id": "team_chat_report_sink",
+            "extension_version": "1.0.0",
+            "protocol": "periodic_report_sink_v0",
+        },
+    }
+
+
+def _extension_receipt(*, verified: bool = True) -> dict[str, Any]:
+    return {
+        "extension_id": "team_chat_report_sink",
+        "extension_version": "1.0.0",
+        "protocol": "periodic_report_sink_v0",
+        "status": "ready",
+        "readback_verified": verified,
+        "capabilities": [
+            {
+                "capability_id": "report.message.write",
+                "capability_version": "v0",
+            }
+        ],
+    }
+
+
+def _sent_result() -> dict[str, Any]:
+    return {
+        "schema_version": "periodic_report_sink_result_v0",
+        "sink_id": "team_chat_delivery",
+        "sink_kind": "team_chat_message",
+        "sink_role": "delivery",
+        "status": "sent",
+        "idempotency_key": "report-delivery-example",
+        "receipt_ref": "message:example",
+        "result_id": "message-result-example",
+        "readback_verified": True,
+        "retryable": False,
+    }
+
+
+def _readiness_identity(receipt: dict[str, Any]) -> str:
+    identity = {
+        "generation_id": receipt["generation_id"],
+        "mode": receipt["delivery_mode"],
+        "bindings": receipt["sink_readiness"],
+    }
+    encoded = json.dumps(
+        identity,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return f"report_readiness_{hashlib.sha256(encoded).hexdigest()[:24]}"
+
+
+def test_generation_bundle_is_provider_free_and_binds_both_artifacts() -> None:
+    bundle = _generation()
+
+    assert bundle["ok"] is True
+    assert bundle["generation_receipt"]["provider_required"] is False
+    assert bundle["generation_receipt"]["external_writes_performed"] is False
+    assert {artifact["renderer_kind"] for artifact in bundle["artifacts"]} == {
+        "html",
+        "markdown",
+    }
+    assert {artifact["document_digest"] for artifact in bundle["artifacts"]} == {
+        bundle["generation_receipt"]["document_digest"]
+    }
+
+
+def test_portable_generation_needs_no_provider_or_delivery() -> None:
+    generation = _generation()["generation_receipt"]
+    readiness = build_periodic_report_extension_readiness(
+        generation_receipt=generation,
+        sink_bindings=[],
+    )
+    delivery = build_periodic_report_delivery_receipt(
+        generation_receipt=generation,
+        readiness_receipt=readiness,
+    )
+
+    assert readiness["delivery_mode"] == "portable"
+    assert readiness["status"] == "not_required"
+    assert readiness["generation_usable"] is True
+    assert delivery["status"] == "not_required"
+    assert delivery["ok"] is True
+
+
+def test_optional_provider_degrades_without_invalidating_generation() -> None:
+    generation = _generation()["generation_receipt"]
+    readiness = build_periodic_report_extension_readiness(
+        generation_receipt=generation,
+        sink_bindings=[_binding(policy="optional")],
+    )
+    delivery = build_periodic_report_delivery_receipt(
+        generation_receipt=generation,
+        readiness_receipt=readiness,
+    )
+
+    assert readiness["delivery_mode"] == "enhanced"
+    assert readiness["status"] == "degraded"
+    assert readiness["generation_usable"] is True
+    assert readiness["formal_delivery_required"] is False
+    assert delivery["status"] == "partial"
+    assert delivery["retryable_sinks"] == ["team_chat_delivery"]
+
+
+def test_required_provider_fails_closed_until_exact_readback() -> None:
+    generation = _generation()["generation_receipt"]
+    missing = build_periodic_report_extension_readiness(
+        generation_receipt=generation,
+        sink_bindings=[_binding()],
+    )
+    blocked = build_periodic_report_delivery_receipt(
+        generation_receipt=generation,
+        readiness_receipt=missing,
+    )
+    assert missing["delivery_mode"] == "durable"
+    assert missing["status"] == "blocked"
+    assert blocked["status"] == "failed"
+    assert blocked["ok"] is False
+
+    ready = build_periodic_report_extension_readiness(
+        generation_receipt=generation,
+        sink_bindings=[_binding()],
+        extension_receipts=[_extension_receipt()],
+    )
+    delivered = build_periodic_report_delivery_receipt(
+        generation_receipt=generation,
+        readiness_receipt=ready,
+        sink_results=[_sent_result()],
+    )
+    assert ready["status"] == "ready"
+    assert ready["delivery_allowed"] is True
+    assert delivered["status"] == "succeeded"
+    assert delivered["sink_receipts"][0]["readback_verified"] is True
+
+
+def test_mismatched_or_unverified_extension_is_not_ready() -> None:
+    generation = _generation()["generation_receipt"]
+    incompatible = _extension_receipt()
+    incompatible["extension_version"] = "2.0.0"
+
+    version_mismatch = build_periodic_report_extension_readiness(
+        generation_receipt=generation,
+        sink_bindings=[_binding()],
+        extension_receipts=[incompatible],
+    )
+    unverified = build_periodic_report_extension_readiness(
+        generation_receipt=generation,
+        sink_bindings=[_binding()],
+        extension_receipts=[_extension_receipt(verified=False)],
+    )
+
+    assert version_mismatch["sink_readiness"][0]["status"] == "incompatible"
+    assert version_mismatch["status"] == "blocked"
+    assert unverified["sink_readiness"][0]["status"] == "unverified"
+    assert unverified["status"] == "blocked"
+
+
+def test_generation_and_delivery_receipts_reject_tampering() -> None:
+    bundle = _generation()
+    generation = bundle["generation_receipt"]
+    readiness = build_periodic_report_extension_readiness(
+        generation_receipt=generation,
+        sink_bindings=[_binding()],
+        extension_receipts=[_extension_receipt()],
+    )
+
+    other_document = deepcopy(bundle["document"])
+    other_document["title"] = "A different report"
+    with pytest.raises(ValueError, match="does not match document"):
+        build_periodic_report_generation_bundle(
+            document=other_document,
+            artifacts=bundle["artifacts"],
+        )
+
+    tampered_readiness = deepcopy(readiness)
+    tampered_readiness["sink_readiness"][0]["ready"] = False
+    with pytest.raises(ValueError, match="ready does not match"):
+        build_periodic_report_delivery_receipt(
+            generation_receipt=generation,
+            readiness_receipt=tampered_readiness,
+            sink_results=[_sent_result()],
+        )
+
+    forged_readiness = deepcopy(readiness)
+    forged_readiness["sink_readiness"][0]["provider_receipt"] = None
+    forged_readiness["readiness_id"] = _readiness_identity(forged_readiness)
+    with pytest.raises(ValueError, match="status does not match provider receipt"):
+        build_periodic_report_delivery_receipt(
+            generation_receipt=generation,
+            readiness_receipt=forged_readiness,
+            sink_results=[_sent_result()],
+        )
+
+    missing_readback = _sent_result()
+    missing_readback["readback_verified"] = False
+    with pytest.raises(ValueError, match="requires exact readback"):
+        build_periodic_report_delivery_receipt(
+            generation_receipt=generation,
+            readiness_receipt=readiness,
+            sink_results=[missing_readback],
+        )
+
+    unknown_sink = _sent_result()
+    unknown_sink["sink_id"] = "unbound_delivery"
+    with pytest.raises(ValueError, match="unbound sink"):
+        build_periodic_report_delivery_receipt(
+            generation_receipt=generation,
+            readiness_receipt=readiness,
+            sink_results=[unknown_sink],
+        )

--- a/tests/capabilities/test_periodic_report_profile.py
+++ b/tests/capabilities/test_periodic_report_profile.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from loopx.capabilities.periodic_report import build_periodic_report_activation
+from loopx.cli import main
+
+
+def _profile(*, enabled: bool = True) -> dict[str, object]:
+    return {
+        "schema_version": "periodic_report_profile_v0",
+        "enabled": enabled,
+        "profile_id": "release_summary",
+        "profile_version": "v1",
+        "trigger_policy": {
+            "enabled_kinds": ["cadence_due", "primary_goal_outcome"],
+            "minimum_interval_seconds": 3600,
+        },
+        "schedule": {
+            "schema_version": "periodic_report_schedule_v0",
+            "schedule_id": "weekly_window",
+            "rrule": "FREQ=WEEKLY;BYDAY=MO;BYHOUR=9",
+            "timezone": "Asia/Shanghai",
+        },
+        "source_bindings": [
+            {
+                "source_id": "release_state",
+                "source_kind": "validated_outcomes",
+                "adapter_id": "release_state_v0",
+                "provider": {"kind": "builtin"},
+            }
+        ],
+        "renderer_bindings": [
+            {
+                "renderer_id": "markdown",
+                "renderer_kind": "markdown",
+                "adapter_id": "markdown_v0",
+                "provider": {"kind": "builtin"},
+            }
+        ],
+        "sink_bindings": [
+            {
+                "schema_version": "periodic_report_sink_binding_v0",
+                "sink_id": "project_archive",
+                "sink_kind": "project_resource",
+                "sink_role": "archive",
+                "dependency_policy": "optional",
+                "capability": {
+                    "capability_id": "report.archive.write",
+                    "capability_version": "v0",
+                },
+                "extension": {
+                    "extension_id": "project_resource_report_archive",
+                    "extension_version": "1.0.0",
+                    "protocol": "periodic_report_sink_v0",
+                },
+            }
+        ],
+    }
+
+
+def test_profile_is_default_off() -> None:
+    activation = build_periodic_report_activation(
+        {
+            "schema_version": "periodic_report_profile_v0",
+            "profile_id": "project_summary",
+            "profile_version": "v1",
+        }
+    )
+
+    assert activation["status"] == "disabled"
+    assert activation["active"] is False
+    assert activation["generation_allowed"] is False
+    assert activation["boundary"]["default_enabled"] is False
+
+
+def test_enabled_profile_is_domain_neutral_and_archive_is_optional() -> None:
+    activation = build_periodic_report_activation(_profile())
+
+    assert activation["status"] == "enabled"
+    assert activation["extension_mode"] == "enhanced"
+    assert activation["required_extension_count"] == 0
+    assert activation["optional_extension_count"] == 1
+    source = activation["profile"]["source_bindings"][0]
+    assert source["source_kind"] == "validated_outcomes"
+    assert "issue" not in json.dumps(activation).lower()
+    assert activation["boundary"]["extension_effects_performed"] is False
+
+
+def test_enabled_profile_requires_sources_and_renderers() -> None:
+    profile = _profile()
+    profile["source_bindings"] = []
+    with pytest.raises(ValueError, match="at least one source"):
+        build_periodic_report_activation(profile)
+
+    profile = _profile()
+    profile["renderer_bindings"] = []
+    with pytest.raises(ValueError, match="at least one renderer"):
+        build_periodic_report_activation(profile)
+
+
+def test_builtin_adapter_rejects_extension_identity() -> None:
+    profile = _profile()
+    profile["source_bindings"][0]["provider"] = {
+        "kind": "builtin",
+        "provider_id": "unexpected_extension",
+    }
+
+    with pytest.raises(ValueError, match="must not declare extension identity"):
+        build_periodic_report_activation(profile)
+
+
+def test_profile_cli_returns_activation_receipt(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = tmp_path / "profile.json"
+    path.write_text(json.dumps(_profile()), encoding="utf-8")
+
+    assert (
+        main(
+            [
+                "--format",
+                "json",
+                "periodic-report",
+                "inspect-profile",
+                "--profile-json",
+                str(path),
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema_version"] == "periodic_report_activation_v0"
+    assert payload["active"] is True


### PR DESCRIPTION
## Summary

- ship `periodic-report` as a built-in, domain-neutral capability that remains disabled until a project explicitly enables a `periodic_report_profile_v0`
- keep business semantics in generic source adapters, presentation in renderer adapters, and archive/delivery effects behind required, optional, or disabled sink-extension bindings
- split provider-free generation from extension readiness and exact-readback delivery receipts, so an optional archive provider never blocks report generation
- document and smoke-test cadence, milestone, portable, enhanced, and durable profiles without making issue-fix, a weekday, or a provider part of the capability identity

## Issue Or Task

- Contributor task ID: `todo_07c21f06b487`

## Commit Grouping

- `feat(periodic-report): add opt-in profile contract` — runtime activation, extension binding, CLI, and catalog behavior
- `test(periodic-report): cover product activation modes` — public fixtures, protocol docs, focused tests, and smokes

## Validation

- [x] `uvx --from 'pytest>=8,<9' pytest ...` — 57 passed across periodic-report and capability/extension registry tests
- [x] Python 3.13 report smokes — profile, bindings, core, adapters, and HTML all passed
- [x] `ruff check` and `ruff format --check` on changed Python paths
- [x] `loopx check` — 17 public paths, 0 errors, 0 warnings
- [x] `loopx canary premerge --from-git-diff --tier standard` — 17/17 checks executed, 0 failures, 0 warnings
- [x] `git diff --check origin/main...HEAD`

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work.
- [x] I kept the change scoped to the linked LoopX task.
- [x] The capability performs no provider read/write or schedule mutation; live scheduler and provider effects remain host/extension responsibilities.

## Residual Risk

- This PR defines and validates activation and provider contracts; it does not activate a project profile or perform a live provider write. Provider-specific canaries remain separate extension/profile work.
