### PR TITLE
Harden OpenCode goal bridge lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ skills/loopx-social-media/
 .goal-harness/
 .goal-wrapper.local/
 .codex/goals/
+.opencode/goals/
 goals/**/ACTIVE_GOAL_STATE.md
 goals/**/ACTIVE_GOAL_STATE.md.lock
 /runtime/

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -82,7 +82,9 @@ can discover user-installed skills:
 - OpenCode: static command files under `~/.config/opencode/commands/` expose
   native `/loopx` slash commands after restart. The executable goal bridge
   (timer-based idle continuation gated by LoopX quota) requires an explicit
-  `--with-goal-bridge` install.
+  `--with-goal-bridge` install. The wrapped goal runtime keeps private restart
+  state under each project's `.opencode/goals/`; add that directory to project
+  ignore rules before using the persistent bridge.
 
 The command family is the same across surfaces, even when the host-specific
 entry point is different:

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -535,6 +535,7 @@ the connected project `.gitignore` before committing:
 ```gitignore
 .loopx/
 .codex/goals/
+.opencode/goals/
 goals/**/ACTIVE_GOAL_STATE.md
 ```
 

--- a/loopx/opencode_goal_mode/README.md
+++ b/loopx/opencode_goal_mode/README.md
@@ -53,6 +53,11 @@ and use mode `0600`. OpenCode's one-shot `opencode run` process cannot own
 timers after exit; recurring operation requires the visible TUI or a persistent
 OpenCode server.
 
+The wrapped goal plugin also persists private restart state under the active
+project's `.opencode/goals/` directory. Add `.opencode/goals/` to the project
+ignore rules so goal text, checkpoints, and lifecycle state cannot enter a
+public commit.
+
 ## Uninstall
 
 Remove only the static command facade:

--- a/loopx/opencode_goal_mode/goal-bridge-runtime.mjs
+++ b/loopx/opencode_goal_mode/goal-bridge-runtime.mjs
@@ -70,9 +70,12 @@ function parseToolResult(value) {
 }
 
 
-function toolResultSucceeded(value) {
+function toolResultSucceeded(value, legacyPrefixes = []) {
   const parsed = parseToolResult(value)
-  return parsed?.ok === true || (typeof value === "string" && /^Goal (?:cleared|completed)/i.test(value))
+  if (parsed?.ok === true) return true
+  if (typeof value !== "string") return false
+  const normalized = value.toLowerCase()
+  return legacyPrefixes.some((prefix) => normalized.startsWith(prefix.toLowerCase()))
 }
 
 
@@ -265,6 +268,7 @@ export function createLoopxGoalPlugin({
     const timers = new Map()
     const evaluations = new Map()
     const pendingGoalCommands = new Map()
+    // Tracks sessions whose persisted base goal is already active in this process.
     const initializedSessions = new Set()
     let disposed = false
 
@@ -282,6 +286,12 @@ export function createLoopxGoalPlugin({
       const timer = timers.get(sessionID)
       if (timer !== undefined) clearTimer(timer)
       timers.delete(sessionID)
+    }
+
+    const detachBinding = async (sessionID) => {
+      await bindingStore.remove(sessionID)
+      cancelScheduled(sessionID)
+      initializedSessions.delete(sessionID)
     }
 
     const readBinding = async (sessionID) => bindingStore.read(sessionID)
@@ -336,8 +346,7 @@ export function createLoopxGoalPlugin({
           toolContext(context, sessionID),
         )
         if (toolResultSucceeded(result) || toolResultHasError(result, "no_active_goal")) {
-          await bindingStore.remove(sessionID)
-          cancelScheduled(sessionID)
+          await detachBinding(sessionID)
           await log("info", "LoopX terminal frontier completed the OpenCode goal", {
             goalId: binding.goalId,
             sessionID,
@@ -558,15 +567,14 @@ export function createLoopxGoalPlugin({
 
     for (const name of ["goal_set", "set_goal"]) {
       wrapTool(name, async (sessionID, _args, result) => {
-        if (toolResultSucceeded(result)) await bindingStore.remove(sessionID)
+        const legacyPrefixes = name === "set_goal" ? ["New active goal:"] : []
+        if (toolResultSucceeded(result, legacyPrefixes)) await detachBinding(sessionID)
       })
     }
     for (const name of ["goal_complete", "clear_goal"]) {
       wrapTool(name, async (sessionID, _args, result) => {
-        if (toolResultSucceeded(result)) {
-          await bindingStore.remove(sessionID)
-          cancelScheduled(sessionID)
-        }
+        const legacyPrefixes = name === "clear_goal" ? ["Goal cleared."] : []
+        if (toolResultSucceeded(result, legacyPrefixes)) await detachBinding(sessionID)
       })
     }
     wrapTool("goal_resume", async (sessionID, _args, result) => {
@@ -583,6 +591,31 @@ export function createLoopxGoalPlugin({
         }
       })
     }
+    wrapTool("update_goal", async (sessionID, args, result) => {
+      if (
+        !toolResultSucceeded(result, [
+          "Objective updated:",
+          "Goal marked blocked.",
+          "Goal paused.",
+          "Goal resumed with fresh limits.",
+          "Goal marked complete and archived.",
+        ])
+      ) return
+      if (typeof args.objective === "string" && args.objective.trim()) {
+        await detachBinding(sessionID)
+        return
+      }
+      const status = String(args.status || "").trim().toLowerCase()
+      if (status === "complete") {
+        await detachBinding(sessionID)
+      } else if (status === "paused" || status === "blocked") {
+        await updateBinding(sessionID, { autoResume: false })
+        cancelScheduled(sessionID)
+      } else if (status === "resumed") {
+        await updateBinding(sessionID, { autoResume: true })
+        initializedSessions.add(sessionID)
+      }
+    })
 
     return {
       ...base,
@@ -606,8 +639,7 @@ export function createLoopxGoalPlugin({
         pendingGoalCommands.set(sessionID, { args, recordedAt: Date.now() })
         const kind = commandKind(args)
         if (kind === "clear" || kind === "replace") {
-          await bindingStore.remove(sessionID)
-          cancelScheduled(sessionID)
+          await detachBinding(sessionID)
         } else if (kind === "resume") {
           await updateBinding(sessionID, { autoResume: true })
           initializedSessions.add(sessionID)
@@ -647,8 +679,8 @@ export function createLoopxGoalPlugin({
         const sessionID = sessionIDFromEvent(event)
         if (!isIdleEvent(event)) {
           if (sessionID && event?.type === "session.deleted") {
-            await bindingStore.remove(sessionID)
-            cancelScheduled(sessionID)
+            await detachBinding(sessionID)
+            pendingGoalCommands.delete(sessionID)
           } else if (sessionID && shouldPauseForHostEvent(event)) {
             await updateBinding(sessionID, { autoResume: false })
             cancelScheduled(sessionID)
@@ -663,6 +695,8 @@ export function createLoopxGoalPlugin({
         for (const timer of timers.values()) clearTimer(timer)
         timers.clear()
         evaluations.clear()
+        initializedSessions.clear()
+        pendingGoalCommands.clear()
         await base.dispose?.()
       },
     }

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -347,6 +347,18 @@ def _strip_jsonc_trailing_commas(content: str) -> str:
     return "".join(output)
 
 
+def _opencode_plugin_name(plugin: Any) -> str | None:
+    if isinstance(plugin, str):
+        return plugin
+    if (
+        isinstance(plugin, list)
+        and plugin
+        and isinstance(plugin[0], str)
+    ):
+        return plugin[0]
+    return None
+
+
 def _opencode_direct_goal_plugin_conflicts(root: Path) -> tuple[list[str], list[str]]:
     conflicts: list[str] = []
     invalid: list[str] = []
@@ -376,9 +388,14 @@ def _opencode_direct_goal_plugin_conflicts(root: Path) -> tuple[list[str], list[
         if not isinstance(plugins, list):
             invalid.append(str(path))
             continue
-        if any(
-            str(plugin) == package or str(plugin).startswith(f"{package}@")
+        plugin_names = [
+            name
             for plugin in plugins
+            if (name := _opencode_plugin_name(plugin)) is not None
+        ]
+        if any(
+            plugin == package or plugin.startswith(f"{package}@")
+            for plugin in plugin_names
             for package in goal_plugins
         ):
             conflicts.append(str(path))
@@ -657,6 +674,8 @@ def install_slash_commands(
         plugin_path = opencode_root / "plugins" / "loopx-goal.js"
         runtime_path = opencode_root / "loopx" / "goal-bridge-runtime.mjs"
         package_path = opencode_root / "package.json"
+        plugin_content = plugin_source()
+        runtime_content = runtime_source()
 
         bridge_preflight_blocked = False
         if with_goal_bridge and not uninstall:
@@ -699,6 +718,36 @@ def install_slash_commands(
                 )
                 bridge_preflight_blocked = True
             else:
+                user_owned_bridge_paths = [
+                    str(path)
+                    for path, content in (
+                        (plugin_path, plugin_content),
+                        (runtime_path, runtime_content),
+                    )
+                    if _target_status(path, content, execute=False)
+                    == "skipped_user_file"
+                ]
+                if user_owned_bridge_paths:
+                    installed.append(
+                        {
+                            "surface": "opencode",
+                            "host_surfaces": ["opencode"],
+                            "mechanism": "opencode_goal_bridge",
+                            "command": "/goal",
+                            "path": str(plugin_path),
+                            "status": "blocked_user_owned_bridge_file",
+                            "invoke_as": [],
+                            "reason": (
+                                "Move or rename the listed user-owned OpenCode bridge "
+                                "files before installing LoopX so no partial bridge or "
+                                "dependency update is applied."
+                            ),
+                            "conflicts": user_owned_bridge_paths,
+                        }
+                    )
+                    bridge_preflight_blocked = True
+
+            if not bridge_preflight_blocked:
                 package_status = _target_package_dependencies(
                     package_path,
                     OPENCODE_GOAL_DEPENDENCIES,
@@ -767,8 +816,8 @@ def install_slash_commands(
                     bridge_preflight_blocked = True
                 else:
                     for mechanism, path, content in (
-                        ("opencode_goal_bridge_runtime", runtime_path, runtime_source()),
-                        ("opencode_goal_bridge", plugin_path, plugin_source()),
+                        ("opencode_goal_bridge_runtime", runtime_path, runtime_content),
+                        ("opencode_goal_bridge", plugin_path, plugin_content),
                     ):
                         installed.append(
                             {

--- a/tests/opencode_goal_bridge_runtime.test.mjs
+++ b/tests/opencode_goal_bridge_runtime.test.mjs
@@ -84,6 +84,14 @@ function harness(initialDecision) {
           return JSON.stringify({ version: 1, operation: "resume", ok: true })
         },
       }),
+      goal_pause: fakeTool({
+        args: {},
+        execute: async () => JSON.stringify({ version: 1, operation: "pause", ok: true }),
+      }),
+      goal_block: fakeTool({
+        args: {},
+        execute: async () => JSON.stringify({ version: 1, operation: "block", ok: true }),
+      }),
       goal_complete: fakeTool({
         args: {},
         execute: async (_args, context) => {
@@ -96,6 +104,23 @@ function harness(initialDecision) {
             ...(verdict.approved ? {} : { error: "completion_rejected" }),
           })
         },
+      }),
+      set_goal: fakeTool({
+        args: {},
+        execute: async () => "New active goal: replacement task",
+      }),
+      update_goal: fakeTool({
+        args: {},
+        execute: async (args) => {
+          if (args.status === "paused") return "Goal paused."
+          if (args.status === "resumed") return "Goal resumed with fresh limits."
+          if (args.status === "complete") return "Goal marked complete and archived."
+          return `Objective updated: ${args.objective}`
+        },
+      }),
+      clear_goal: fakeTool({
+        args: {},
+        execute: async () => "Goal cleared.",
       }),
     },
     dispose: async () => {
@@ -256,6 +281,140 @@ test("keeps scheduled quota timers isolated between sessions", async () => {
   assert.equal(fixture.scheduled[0].cleared, true)
   assert.equal(fixture.scheduled[1].cleared, false)
   assert.equal(fixture.calls.event, 1)
+})
+
+
+test("replacing the host goal cancels the old LoopX timer and binding", async () => {
+  const fixture = harness({
+    should_run: false,
+    scheduler_hint: {
+      action: "backoff_waiting_for_user",
+      unchanged_poll: {
+        local_scheduler: { recommended_interval_minutes: 3, unchanged_poll_limit: 3 },
+      },
+    },
+  })
+  const hooks = await fixture.plugin({ directory: "/workspace", client: {} })
+  await hooks.tool.loopx_goal_activate.execute(
+    { goalId: "goal-replaced", objective: "LoopX task body" },
+    { sessionID: "session-replaced" },
+  )
+  await hooks.event({
+    event: { type: "session.idle", properties: { sessionID: "session-replaced" } },
+  })
+  assert.equal(fixture.scheduled.length, 1)
+
+  await hooks.tool.goal_set.execute(
+    { objective: "ordinary host goal" },
+    { sessionID: "session-replaced" },
+  )
+
+  assert.equal(fixture.scheduled[0].cleared, true)
+  assert.equal(await fixture.store.read("session-replaced"), null)
+})
+
+
+test("legacy goal replacement and objective edits detach the LoopX binding", async () => {
+  for (const [toolName, args] of [
+    ["set_goal", { objective: "legacy replacement" }],
+    ["update_goal", { objective: "legacy objective edit" }],
+  ]) {
+    const fixture = harness({ should_run: true, scheduler_hint: { action: "run_now" } })
+    const hooks = await fixture.plugin({ directory: "/workspace", client: {} })
+    const sessionID = `session-${toolName}`
+    await hooks.tool.loopx_goal_activate.execute(
+      { goalId: `goal-${toolName}`, objective: "LoopX task body" },
+      { sessionID },
+    )
+
+    await hooks.tool[toolName].execute(args, { sessionID })
+
+    assert.equal(await fixture.store.read(sessionID), null)
+  }
+})
+
+
+test("canonical pause and block tools stop scheduled LoopX continuation", async () => {
+  for (const toolName of ["goal_pause", "goal_block"]) {
+    const fixture = harness({
+      should_run: false,
+      scheduler_hint: {
+        action: "backoff_waiting_for_user",
+        unchanged_poll: {
+          local_scheduler: { recommended_interval_minutes: 3, unchanged_poll_limit: 3 },
+        },
+      },
+    })
+    const hooks = await fixture.plugin({ directory: "/workspace", client: {} })
+    const sessionID = `session-${toolName}`
+    await hooks.tool.loopx_goal_activate.execute(
+      { goalId: `goal-${toolName}`, objective: "LoopX task body" },
+      { sessionID },
+    )
+    await hooks.event({ event: { type: "session.idle", properties: { sessionID } } })
+
+    await hooks.tool[toolName].execute({}, { sessionID })
+
+    assert.equal(fixture.scheduled[0].cleared, true)
+    assert.equal((await fixture.store.read(sessionID)).autoResume, false)
+  }
+})
+
+
+test("canonical resume re-enables quota without a duplicate resume probe", async () => {
+  const fixture = harness({ should_run: true, scheduler_hint: { action: "run_now" } })
+  const hooks = await fixture.plugin({ directory: "/workspace", client: {} })
+  const sessionID = "session-canonical-resume"
+  await hooks.tool.loopx_goal_activate.execute(
+    { goalId: "goal-canonical-resume", objective: "LoopX task body" },
+    { sessionID },
+  )
+  await hooks.tool.goal_pause.execute({}, { sessionID })
+
+  await hooks.tool.goal_resume.execute({}, { sessionID })
+  await hooks.event({ event: { type: "session.idle", properties: { sessionID } } })
+
+  assert.equal((await fixture.store.read(sessionID)).autoResume, true)
+  assert.equal(fixture.calls.resume, 1)
+  assert.equal(fixture.calls.event, 1)
+})
+
+
+test("legacy status updates preserve pause resume and completion semantics", async () => {
+  const fixture = harness({ should_run: true, scheduler_hint: { action: "run_now" } })
+  const hooks = await fixture.plugin({ directory: "/workspace", client: {} })
+  const sessionID = "session-legacy-status"
+  await hooks.tool.loopx_goal_activate.execute(
+    { goalId: "goal-legacy-status", objective: "LoopX task body" },
+    { sessionID },
+  )
+
+  await hooks.tool.update_goal.execute({ status: "paused" }, { sessionID })
+  assert.equal((await fixture.store.read(sessionID)).autoResume, false)
+  await hooks.tool.update_goal.execute({ status: "resumed" }, { sessionID })
+  assert.equal((await fixture.store.read(sessionID)).autoResume, true)
+  await hooks.tool.update_goal.execute({ status: "complete" }, { sessionID })
+  assert.equal(await fixture.store.read(sessionID), null)
+})
+
+
+test("legacy objective edits detach even when combined with a status update", async () => {
+  for (const status of ["paused", "blocked", "resumed"]) {
+    const fixture = harness({ should_run: true, scheduler_hint: { action: "run_now" } })
+    const hooks = await fixture.plugin({ directory: "/workspace", client: {} })
+    const sessionID = `session-objective-${status}`
+    await hooks.tool.loopx_goal_activate.execute(
+      { goalId: `goal-objective-${status}`, objective: "LoopX task body" },
+      { sessionID },
+    )
+
+    await hooks.tool.update_goal.execute(
+      { objective: "new host objective", status },
+      { sessionID },
+    )
+
+    assert.equal(await fixture.store.read(sessionID), null)
+  }
 })
 
 

--- a/tests/opencode_goal_bridge_runtime.test.mjs
+++ b/tests/opencode_goal_bridge_runtime.test.mjs
@@ -112,6 +112,7 @@ function harness(initialDecision) {
       update_goal: fakeTool({
         args: {},
         execute: async (args) => {
+          if (args.status === "blocked") return "Goal marked blocked."
           if (args.status === "paused") return "Goal paused."
           if (args.status === "resumed") return "Goal resumed with fresh limits."
           if (args.status === "complete") return "Goal marked complete and archived."
@@ -390,6 +391,13 @@ test("legacy status updates preserve pause resume and completion semantics", asy
   )
 
   await hooks.tool.update_goal.execute({ status: "paused" }, { sessionID })
+  assert.equal((await fixture.store.read(sessionID)).autoResume, false)
+  await hooks.tool.update_goal.execute({ status: "resumed" }, { sessionID })
+  assert.equal((await fixture.store.read(sessionID)).autoResume, true)
+  await hooks.tool.update_goal.execute(
+    { status: "blocked", blocker: "waiting for external approval" },
+    { sessionID },
+  )
   assert.equal((await fixture.store.read(sessionID)).autoResume, false)
   await hooks.tool.update_goal.execute({ status: "resumed" }, { sessionID })
   assert.equal((await fixture.store.read(sessionID)).autoResume, true)

--- a/tests/test_slash_command_install.py
+++ b/tests/test_slash_command_install.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from loopx.slash_command_install import install_slash_commands
 
 
@@ -232,6 +234,7 @@ def test_opencode_install_fails_closed_for_direct_goal_plugin_registration(
     )
     assert not (opencode_home / "commands" / "loopx.md").exists()
     assert not (opencode_home / "plugins" / "loopx-goal.js").exists()
+    assert not (opencode_home / "package.json").exists()
 
 
 def test_opencode_install_fails_closed_for_tuple_goal_plugin_registration(
@@ -260,13 +263,18 @@ def test_opencode_install_fails_closed_for_tuple_goal_plugin_registration(
     assert not (opencode_home / "package.json").exists()
 
 
+@pytest.mark.parametrize(
+    "relative_path",
+    ["plugins/loopx-goal.js", "loopx/goal-bridge-runtime.mjs"],
+)
 def test_opencode_bridge_preflight_blocks_user_owned_bridge_without_partial_writes(
     tmp_path: Path,
+    relative_path: str,
 ) -> None:
     opencode_home = tmp_path / "opencode"
-    plugin = opencode_home / "plugins" / "loopx-goal.js"
-    plugin.parent.mkdir(parents=True)
-    plugin.write_text("// user-owned plugin\n", encoding="utf-8")
+    user_file = opencode_home / relative_path
+    user_file.parent.mkdir(parents=True)
+    user_file.write_text("// user-owned bridge file\n", encoding="utf-8")
 
     payload = install_slash_commands(
         execute=True,
@@ -278,10 +286,15 @@ def test_opencode_bridge_preflight_blocks_user_owned_bridge_without_partial_writ
     assert payload["ok"] is False
     bridge = _row(payload, "opencode_goal_bridge")
     assert bridge["status"] == "blocked_user_owned_bridge_file"
-    assert bridge["conflicts"] == [str(plugin)]
-    assert plugin.read_text(encoding="utf-8") == "// user-owned plugin\n"
+    assert bridge["conflicts"] == [str(user_file)]
+    assert user_file.read_text(encoding="utf-8") == "// user-owned bridge file\n"
     assert not (opencode_home / "commands" / "loopx.md").exists()
-    assert not (opencode_home / "loopx" / "goal-bridge-runtime.mjs").exists()
+    other_bridge = (
+        opencode_home / "loopx" / "goal-bridge-runtime.mjs"
+        if relative_path == "plugins/loopx-goal.js"
+        else opencode_home / "plugins" / "loopx-goal.js"
+    )
+    assert not other_bridge.exists()
     assert not (opencode_home / "package.json").exists()
 
 

--- a/tests/test_slash_command_install.py
+++ b/tests/test_slash_command_install.py
@@ -234,6 +234,57 @@ def test_opencode_install_fails_closed_for_direct_goal_plugin_registration(
     assert not (opencode_home / "plugins" / "loopx-goal.js").exists()
 
 
+def test_opencode_install_fails_closed_for_tuple_goal_plugin_registration(
+    tmp_path: Path,
+) -> None:
+    opencode_home = tmp_path / "opencode"
+    opencode_home.mkdir()
+    (opencode_home / "opencode.json").write_text(
+        '{"plugin": [["opencode-goal-plugin", {"maxTurns": 20}]]}\n',
+        encoding="utf-8",
+    )
+
+    payload = install_slash_commands(
+        execute=True,
+        with_goal_bridge=True,
+        surfaces=["opencode"],
+        opencode_home=str(opencode_home),
+    )
+
+    assert payload["ok"] is False
+    assert _row(payload, "opencode_goal_bridge")["status"] == (
+        "blocked_conflicting_direct_plugin"
+    )
+    assert not (opencode_home / "commands" / "loopx.md").exists()
+    assert not (opencode_home / "plugins" / "loopx-goal.js").exists()
+    assert not (opencode_home / "package.json").exists()
+
+
+def test_opencode_bridge_preflight_blocks_user_owned_bridge_without_partial_writes(
+    tmp_path: Path,
+) -> None:
+    opencode_home = tmp_path / "opencode"
+    plugin = opencode_home / "plugins" / "loopx-goal.js"
+    plugin.parent.mkdir(parents=True)
+    plugin.write_text("// user-owned plugin\n", encoding="utf-8")
+
+    payload = install_slash_commands(
+        execute=True,
+        with_goal_bridge=True,
+        surfaces=["opencode"],
+        opencode_home=str(opencode_home),
+    )
+
+    assert payload["ok"] is False
+    bridge = _row(payload, "opencode_goal_bridge")
+    assert bridge["status"] == "blocked_user_owned_bridge_file"
+    assert bridge["conflicts"] == [str(plugin)]
+    assert plugin.read_text(encoding="utf-8") == "// user-owned plugin\n"
+    assert not (opencode_home / "commands" / "loopx.md").exists()
+    assert not (opencode_home / "loopx" / "goal-bridge-runtime.mjs").exists()
+    assert not (opencode_home / "package.json").exists()
+
+
 def test_opencode_bridge_preflight_blocks_all_writes_for_invalid_config(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- fail closed before OpenCode bridge writes when direct goal-plugin tuples or user-owned plugin/runtime files conflict
- detach stale LoopX bindings and timers when canonical or legacy host goal tools replace, edit, pause, resume, block, or complete the goal
- cover the legacy blocked transition and both user-owned bridge file locations
- document and ignore private `.opencode/goals/` restart state

## Validation

- `PYTHONPATH="$(pwd)" pytest -q -rs` (953 passed, 2 opt-in smoke-suite skips)
- focused OpenCode Python tests (26 passed)
- `node --test tests/opencode_goal_bridge_runtime.test.mjs` (16 passed)
- `python examples/slash-command-install-smoke.py`
- wheel build plus generated plugin dependency install and import smoke
- `loopx canary premerge --from-git-diff` (17 selected checks passed, no manual holds)
- GitHub `pytest` check

## Scope

The change is limited to the built-in OpenCode bridge provider, its installer, focused tests, and private-state documentation. It does not change LoopX quota semantics or launch external work.