### PR TITLE
release: LoopX v0.2.10

### DIFF
--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.9"
+__version__ = "0.2.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.2.9"
+version = "0.2.10"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Weekly report quick start

LoopX v0.2.10 makes the built-in periodic-report capability usable as an explicit, default-off weekly workflow in the standard Codex App Automation setup.

1. Keep a project-local, ignored `periodic_report_profile_v0` JSON file with `enabled: true`, a weekly RRULE, at least one source binding, and at least one renderer binding.
2. Preview the profile without provider effects:

   ```bash
   loopx periodic-report inspect-profile \
     --profile-json .local/loopx/periodic-report/weekly.json \
     --format json
   ```

   Continue only when the receipt reports `active: true` and `generation_allowed: true`.
3. Create a dedicated Codex App Automation with the same weekly schedule. Its task should read that profile, evaluate due/material-progress triggers, collect only the configured source snapshots, compose the report, and invoke only explicitly configured sinks.
4. To turn the workflow off, pause/delete that Automation or set `enabled: false` in the profile and verify the disabled receipt with the same preview command.

There is intentionally no global persistent `enable` command: opt-in is per project profile and host Automation. Installing or updating LoopX does not modify the generic heartbeat prompt, create a schedule, collect project data, or perform an external write. The canonical profile contract and public examples are in [`docs/capabilities/periodic-report/README.md`](https://github.com/huangruiteng/loopx/blob/main/docs/capabilities/periodic-report/README.md) and [`examples/fixtures/periodic-report-product-profiles.public.json`](https://github.com/huangruiteng/loopx/blob/main/examples/fixtures/periodic-report-product-profiles.public.json).

## Summary

### State Kernel & Control Plane

- Keep owner pause authoritative for monitor-only quota work and make installed-runtime activation explicit after self-update ([#2383](https://github.com/huangruiteng/loopx/pull/2383), [#2384](https://github.com/huangruiteng/loopx/pull/2384)).
- Harden OpenCode goal-bridge lifecycle handling so startup, timeout, stop, and cleanup remain attributable without changing the default Codex App path ([#2389](https://github.com/huangruiteng/loopx/pull/2389)).

### Capabilities & Workflows

- Let projects opt into weekly or material-progress reports with a default-off product profile, then produce readable, complete, localized Markdown and HTML artifacts from typed outcomes, evidence, risks, and next actions ([#2388](https://github.com/huangruiteng/loopx/pull/2388), [#2390](https://github.com/huangruiteng/loopx/pull/2390)).
- Add explicit optional sinks for verified Miaoda HTML publication and durable OpenViking archive storage. Both remain profile-bound and fail closed around provider readiness, authority, size, idempotency, and readback ([#2394](https://github.com/huangruiteng/loopx/pull/2394), [#2395](https://github.com/huangruiteng/loopx/pull/2395)).

### Quality & Testing

- Improve SkillsBench setup-failure attribution without launching benchmark jobs or changing task, scoring, submission, or leaderboard behavior ([#2385](https://github.com/huangruiteng/loopx/pull/2385), [#2387](https://github.com/huangruiteng/loopx/pull/2387)).
- Require release notes to state the user outcome, shipped layer, last-mile boundary, and exact activation/disable path for every default-off or opt-in capability ([#2386](https://github.com/huangruiteng/loopx/pull/2386)).

### Documentation & Compatibility

- Add a control-plane architecture course and clarify the reusable kernel/domain-state boundary for Issue-Fix ([#2392](https://github.com/huangruiteng/loopx/pull/2392), [#2393](https://github.com/huangruiteng/loopx/pull/2393)).
- Package version and tag advance to `0.2.10` / `v0.2.10`. Existing LoopX state needs no migration; periodic reports, external sinks, OpenCode, and benchmark routes remain explicit opt-ins.

## 中文摘要

### 周报开启方式

1. 在项目忽略目录保存一份 `periodic_report_profile_v0`，显式设置 `enabled: true`、周 RRULE、source binding 和 renderer binding。
2. 先运行上面的 `inspect-profile` 命令；只有回执中的 `active` 与 `generation_allowed` 都为 `true` 才继续。
3. 在 Codex App 新建一个与 RRULE 一致的专用 Automation，让它读取该 profile、判断 cadence/material progress、采集配置内的 source snapshot、生成报告，并且只调用显式配置的 sink。
4. 停用时暂停/删除该 Automation，或把 profile 改为 `enabled: false` 后再次预览确认。

当前没有全局持久化的 `enable` 命令，opt-in 属于项目 profile 和 host Automation。安装/升级不会扩张通用 heartbeat prompt，不会自动创建调度，也不会自行执行外部写入。

### 状态内核与控制面

- owner pause 对 monitor-only quota 工作保持优先，self-update 后的 installed-runtime activation 更明确；OpenCode goal bridge 的启动、超时、停止和清理也更可靠（[#2383](https://github.com/huangruiteng/loopx/pull/2383)、[#2384](https://github.com/huangruiteng/loopx/pull/2384)、[#2389](https://github.com/huangruiteng/loopx/pull/2389)）。

### 能力与工作流

- 项目可以通过默认关闭的 profile 显式开启周报/材料进展报告，并把结构化结果、证据、风险和下一步编排成可读的中英文 Markdown/HTML（[#2388](https://github.com/huangruiteng/loopx/pull/2388)、[#2390](https://github.com/huangruiteng/loopx/pull/2390)）。
- 新增可选的 Miaoda HTML 投递和 OpenViking 归档；二者都要求 profile 显式绑定，并对 provider readiness、权限、大小、幂等和 readback 失败关闭（[#2394](https://github.com/huangruiteng/loopx/pull/2394)、[#2395](https://github.com/huangruiteng/loopx/pull/2395)）。

### 质量与测试

- SkillsBench setup 失败更易归因，但不启动 benchmark job，也不改变 task、scoring、submission 或 leaderboard（[#2385](https://github.com/huangruiteng/loopx/pull/2385)、[#2387](https://github.com/huangruiteng/loopx/pull/2387)）。
- release note 现在必须同时交代用户结果、已交付层、最后一公里边界，以及 opt-in 能力的准确开启/停用方式（[#2386](https://github.com/huangruiteng/loopx/pull/2386)）。

### 文档与兼容性

- 新增控制面架构课程，并澄清 Issue-Fix 的通用 kernel 与 domain state 边界（[#2392](https://github.com/huangruiteng/loopx/pull/2392)、[#2393](https://github.com/huangruiteng/loopx/pull/2393)）。
- 版本升级为 `0.2.10` / `v0.2.10`；已有 LoopX state 无需迁移。周报、外部 sink、OpenCode 与 benchmark route 均保持显式 opt-in。

## Validation

Exact candidate `d15339d4efe3f4109916bfc4ddc6558fb324ba3d` passed the complete release gate:

- focused periodic-report tests: 56 passed; profile, lifecycle, HTML, binding, OpenViking, and release-version smokes also passed;
- pytest: 970 passed, 2 skipped; 46.47% coverage in the official Python 3.11 workflow ([run](https://github.com/huangruiteng/loopx/actions/runs/29736352488));
- workflow-scoped Ruff: 0 violations; strict mypy: 0 errors across 12 files; CLI output-budget smoke passed;
- risk premerge: 4 direct checks plus 1 selected catalog canary passed, 0 failures, 0 warnings, 0 manual holds; self-merge allowed;
- install/upgrade/host release profile: 16/16 passed, 0 failures, timeouts, or warnings;
- public boundary: 1,820 files scanned, 0 errors or warnings;
- Full Public Smokes: 7/7 shard receipts, 617/617 checks passed, 0 failures or timeouts, [`ready=true`](https://github.com/huangruiteng/loopx/actions/runs/29736364444);
- live Doubao actual-default portfolio: `doubao-seed-2-1-pro-260628`, 12 scenarios x 2 repeats, 24/24 calls passed, no automatic retries, and no raw model response or packet retention;
- exact-commit reducer: `ready_for_owner_release`, 8/8 required qualification lanes source-aligned, 0 missing qualifications, failures, or source mismatches.

A preliminary Doubao invocation failed closed before any provider call because local pytest-xdist coverage shards made the checkout dirty. After removing those agent-generated untracked files, the exact candidate passed all 24 calls. The local Python 3.13 xdist run also emitted coverage-shard merge warnings; the official Python 3.11 workflow reran the complete command cleanly and supplies the authoritative coverage receipt. The two pytest skips are existing suite skips.

This release makes no benchmark or long-horizon outcome-uplift claim, so a matched outcome baseline is not required. It launches no benchmark job and changes no scoring, submission, leaderboard, permission, or production boundary.

## Update

```bash
loopx update --check
loopx update --execute
loopx doctor
```

[Full changelog](https://github.com/huangruiteng/loopx/compare/v0.2.9...v0.2.10)
