### PR TITLE
feat(periodic-report): add in-session weekly preset

### DIFF
--- a/docs/capabilities/periodic-report/README.md
+++ b/docs/capabilities/periodic-report/README.md
@@ -6,16 +6,63 @@ presentation, and destinations to profiles and adapters.
 
 | Surface | Value |
 | --- | --- |
-| CLI | `loopx periodic-report inspect-profile --profile-json <path>`, `evaluate-trigger`, `compose-run`, and optional `archive-openviking` |
+| CLI | `loopx periodic-report inspect-profile --preset weekly`, custom `--profile-json <path>`, `evaluate-trigger`, `compose-run`, and optional `archive-openviking` |
 | Protocol | [`periodic_report_v0`](../../reference/protocols/periodic-report-v0.md) |
 | Smokes | `python3 examples/periodic-report-smoke.py`, `periodic-report-profile-smoke.py`, `periodic-report-html-smoke.py`, `periodic-report-bindings-smoke.py`, and `openviking-periodic-report-extension-smoke.py` |
 
-The capability ships with LoopX but is **disabled by default for every
-project**. A project opts in with `periodic_report_profile_v0` and
-`enabled: true`; the profile then names generic trigger policy, source adapter
-bindings, renderer bindings, and required/optional/disabled sink bindings.
-There is no issue-fix-specific report capability: issue-fix, release notes,
-research, operations, and other domains are peers that supply source adapters.
+## Generate this week's report
+
+In an active LoopX or Codex project session, ask the agent to **generate this
+week's project report**. That explicit request opts the current session into
+one provider-free generation. The agent resolves the built-in
+`weekly-progress` profile (short aliases: `weekly` and `weekly-report`),
+collects the current project's public-safe LoopX progress, and renders matching
+Markdown and self-contained HTML artifacts. No project profile file,
+Automation, provider, or external sink is required.
+
+The agent can inspect the exact built-in profile with the effect-free command:
+
+```bash
+loopx periodic-report inspect-profile --preset weekly --format json
+```
+
+The receipt must report both `active: true` and `generation_allowed: true`.
+Its `interaction_contract` also says that the explicit user request is
+sufficient, no project profile file or Automation is required, and external
+writes are not allowed for this mode. Agents should follow that packet instead
+of expanding a generic heartbeat prompt.
+The preset binds the built-in `project_progress_v0` source plus `markdown_v0`
+and `html_artifact_v0`, declares no schedule, and contains no sink bindings.
+The explicit request owns the report window using the active session's local
+calendar context; it does not create a recurring job.
+
+`project_progress_v0` organizes typed facts into a reusable hierarchy:
+progress and outcomes, capability evolution, risks and blockers, next actions,
+and collapsed supporting evidence. It permits at most eight primary items, so
+delivery receipts and runtime validation stay supporting instead of crowding
+the audience narrative. This hierarchy is inspired by the validated project
+weekly-report presentation, but it contains no issue, pull-request, or
+Issue Fix policy.
+
+There is no issue-fix-specific report capability. Issue Fix, release notes,
+research, operations, and other domains may supply peer source adapters when
+their richer semantics are useful; none is required by the built-in weekly
+profile.
+
+## Customize or schedule
+
+The capability remains **inactive for background work and external writes by
+default**. Create a project-owned `periodic_report_profile_v0` only when the
+project needs custom sources, renderers, audience policy, timezone/RRULE, or
+explicit sink bindings. Use Codex App Automation only for an unattended
+recurring report: the host schedule should match that custom profile's RRULE.
+Pausing the Automation or setting the profile to `enabled: false` stops that
+scheduled path.
+
+External delivery and archival are separate opt-ins. Adding a sink binding
+does not grant authority by itself; the selected extension, runtime capability,
+execution decision, and exact readback must still pass their own gates. A
+normal in-session weekly report has no sink and performs no external write.
 
 The capability is intentionally effect-free. It first evaluates scheduled or
 material progress facts into a deterministic trigger receipt, then composes a
@@ -33,11 +80,11 @@ closure, blocker, and manual triggers may bypass that interval. Concurrent
 material facts are coalesced into one report and previously covered trigger
 ids are deduplicated.
 
-Project-specific weekly reports should be layered as profiles and adapters.
+Project-specific scheduled reports should be layered as profiles and adapters.
 For example, a maintenance profile may choose a local timezone and weekly
 cadence, collect repository and discussion signals, render a team card, archive
 the artifact, and deliver it to a configured channel. None of those choices
-becomes an invariant of the shared core.
+becomes an invariant of the shared core or the in-session preset.
 
 This is a built-in capability, not an extension: callers need the trigger,
 idempotency, retry, and receipt contract even when no provider is installed.
@@ -45,17 +92,19 @@ Optional or independently versioned collectors, renderers, archive stores, and
 message transports remain extension providers (or built-in adapters) that
 implement the capability's ports without owning its lifecycle.
 
-Use `inspect-profile` before scheduling a run. It returns a deterministic
-`periodic_report_activation_v0` receipt and never starts a scheduler or invokes
-a provider. An omitted `enabled` field is treated as `false`. When enabled, at
-least one source and one renderer binding are required. An optional archive
-extension can therefore add durable history without making report generation
-or another configured delivery sink depend on that provider.
+`inspect-profile` returns a deterministic `periodic_report_activation_v0`
+receipt and never starts a scheduler or invokes a provider. `--preset weekly`
+resolves the built-in session profile; `--profile-json` validates a custom
+project profile. In a custom profile, an omitted `enabled` field is treated as
+`false`, and enabled profiles require at least one source and one renderer.
+An optional archive extension can therefore add durable history without making
+local report generation or another configured delivery sink depend on it.
 
-The public profiles fixture covers a default-disabled project, a cadence-based
-release report with an optional archive extension, and a milestone-only
-research report with an extension-provided source. These are peer product uses;
-none changes the capability identity or core schema.
+The public profiles fixture covers the built-in portable weekly profile, a
+default-disabled project, a cadence-based release report with an optional
+archive extension, and a milestone-only research report with an
+extension-provided source. These are peer product uses; none changes the
+capability identity or core schema.
 
 ## Generation and formal delivery
 

--- a/docs/reference/protocols/periodic-report-v0.md
+++ b/docs/reference/protocols/periodic-report-v0.md
@@ -2,24 +2,50 @@
 
 ## Product activation
 
-`periodic_report_profile_v0` is the project opt-in contract. The built-in
-capability is installed but inactive until the profile explicitly sets
-`enabled: true`. Enabled profiles declare:
+An explicit request in an active project session, such as "generate this
+week's project report", is sufficient authority for one provider-free local
+generation. LoopX resolves the built-in `weekly-progress` profile (aliases
+`weekly` and `weekly-report`), whose normalized `periodic_report_profile_v0`
+sets `enabled: true`, binds `project_progress_v0`, Markdown, and HTML, and
+declares neither a schedule nor a sink. The profile can be inspected without
+effects:
+
+```bash
+loopx periodic-report inspect-profile --preset weekly --format json
+```
+
+This does not persist project activation, create a scheduler, or grant an
+external write. The current session owns the requested calendar window. When
+the built-in preset is selected, the activation packet includes an
+`interaction_contract` that makes those session-generation defaults explicit;
+the generic heartbeat prompt does not need a report-specific expansion.
+
+A project-owned `periodic_report_profile_v0` is the advanced opt-in contract
+for custom or unattended operation. Enabled custom profiles declare:
 
 - provider-neutral trigger policy and an optional host-owned RRULE/timezone;
 - one or more domain source adapter bindings;
 - one or more renderer bindings;
 - zero or more required, optional, or disabled extension sink bindings.
 
+Use a host Automation only when the report must run unattended on an RRULE.
+The Automation schedule and project profile must agree; ordinary in-session
+generation does not need an Automation. External delivery still requires an
+explicit sink binding and its independent runtime authority/readback checks.
+
 `periodic_report_activation_v0` is the effect-free inspection receipt. It
 records whether generation is allowed, the normalized profile digest, and the
 portable/enhanced/durable extension mode. It performs no source read, schedule
 mutation, provider lookup, rendering, archive write, or message delivery.
 
-Issue-fix has no special standing in either schema. It may register a source
-adapter under the same contract as release, research, operations, or another
-domain. OpenViking is likewise an optional archive/query provider behind a
-sink extension; it does not own trigger, selection, rendering, or delivery.
+`periodic_report_project_progress_projection_v0` is the built-in,
+domain-neutral source input. It groups typed project facts into progress,
+capability evolution, risks, next actions, and supporting evidence, with no
+more than eight primary audience items. Issue Fix has no special standing in
+either schema. It may register a peer source adapter under the same contract as
+release, research, operations, or another domain. OpenViking is likewise an
+optional archive/query provider behind a sink extension; it does not own
+trigger, selection, rendering, or delivery.
 
 `periodic_report_v0` is the LoopX control contract for one bounded report run.
 It binds a period window and a profile to typed source snapshots, one rendered

--- a/examples/fixtures/periodic-report-product-profiles.public.json
+++ b/examples/fixtures/periodic-report-product-profiles.public.json
@@ -9,6 +9,47 @@
     {
       "schema_version": "periodic_report_profile_v0",
       "enabled": true,
+      "profile_id": "weekly_progress",
+      "profile_version": "v1",
+      "trigger_policy": {
+        "enabled_kinds": [
+          "manual",
+          "cadence_due",
+          "primary_goal_outcome",
+          "vision_closed",
+          "material_decision",
+          "material_blocker",
+          "material_recovery"
+        ],
+        "minimum_interval_seconds": 0
+      },
+      "source_bindings": [
+        {
+          "source_id": "project_progress",
+          "source_kind": "validated_project_progress",
+          "adapter_id": "project_progress_v0",
+          "provider": {"kind": "builtin"}
+        }
+      ],
+      "renderer_bindings": [
+        {
+          "renderer_id": "markdown",
+          "renderer_kind": "markdown",
+          "adapter_id": "markdown_v0",
+          "provider": {"kind": "builtin"}
+        },
+        {
+          "renderer_id": "html",
+          "renderer_kind": "html",
+          "adapter_id": "html_artifact_v0",
+          "provider": {"kind": "builtin"}
+        }
+      ],
+      "sink_bindings": []
+    },
+    {
+      "schema_version": "periodic_report_profile_v0",
+      "enabled": true,
       "profile_id": "release_summary",
       "profile_version": "v1",
       "trigger_policy": {

--- a/examples/openviking-periodic-report-extension-smoke.py
+++ b/examples/openviking-periodic-report-extension-smoke.py
@@ -60,7 +60,11 @@ def main() -> None:
             / "periodic-report-product-profiles.public.json"
         ).read_text(encoding="utf-8")
     )
-    profile = profiles["profiles"][1]
+    profile = next(
+        item
+        for item in profiles["profiles"]
+        if item.get("profile_id") == "release_summary"
+    )
     source = build_periodic_report_source_result(
         source_id="release_state",
         source_kind="validated_outcomes",

--- a/examples/periodic-report-profile-smoke.py
+++ b/examples/periodic-report-profile-smoke.py
@@ -11,6 +11,7 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.capabilities.periodic_report import (  # noqa: E402
     build_periodic_report_activation,
+    resolve_periodic_report_profile_preset,
 )
 
 
@@ -28,6 +29,11 @@ def main() -> None:
     }
 
     assert activations["disabled_project"]["status"] == "disabled"
+    assert activations["weekly_progress"]["extension_mode"] == "portable"
+    assert activations["weekly_progress"]["profile"] == (
+        resolve_periodic_report_profile_preset("weekly")
+    )
+    assert len(activations["weekly_progress"]["profile"]["renderer_bindings"]) == 2
     assert activations["release_summary"]["extension_mode"] == "enhanced"
     assert activations["release_summary"]["optional_extension_count"] == 1
     assert activations["research_milestones"]["extension_mode"] == "portable"

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -540,16 +540,21 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
         "default_enabled": False,
         "real_world_anchor": "scheduled and milestone project reports with verified archive and delivery",
         "user_value": (
-            "Give projects one deterministic trigger, report run, receipt, "
-            "partial-state, and retry contract without hard-coding a domain, "
-            "provider, cadence, or destination."
+            "Generate a concise weekly project report from the active session "
+            "with one built-in portable profile, while retaining deterministic "
+            "trigger, receipt, partial-state, and retry contracts for custom runs."
         ),
-        "entry_command": "loopx periodic-report inspect-profile --profile-json <profile.json> --format json",
+        "entry_command": "loopx periodic-report inspect-profile --preset weekly --format json",
         "commands": [
             {
+                "command": "loopx periodic-report inspect-profile --preset weekly --format json",
+                "purpose": "Resolve the built-in domain-neutral weekly profile for an explicitly requested in-session report.",
+                "write_boundary": "local preset inspection only; creates no schedule, persists no activation, declares no sink, and performs no provider lookup or write",
+            },
+            {
                 "command": "loopx periodic-report inspect-profile --profile-json <profile.json> --format json",
-                "purpose": "Validate explicit project activation plus trigger, source, renderer, and extension sink bindings.",
-                "write_boundary": "local profile inspection only; disabled by default and performs no provider lookup, schedule mutation, or write",
+                "purpose": "Validate custom project trigger, source, renderer, schedule, and extension sink bindings.",
+                "write_boundary": "local profile inspection only; performs no provider lookup, schedule mutation, or write",
             },
             {
                 "command": "loopx periodic-report evaluate-trigger --request-json <request.json> --format json",
@@ -576,6 +581,11 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
             {
                 "schema_version": "periodic_report_activation_v0",
                 "module": "loopx.capabilities.periodic_report.profile",
+                "doc": "docs/reference/protocols/periodic-report-v0.md",
+            },
+            {
+                "schema_version": "periodic_report_project_progress_projection_v0",
+                "module": "loopx.capabilities.periodic_report.project_progress",
                 "doc": "docs/reference/protocols/periodic-report-v0.md",
             },
             {
@@ -632,7 +642,8 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
             "docs/reference/protocols/periodic-report-v0.md",
         ],
         "boundaries": [
-            "The built-in capability is installed with LoopX but disabled for every project until a periodic_report_profile_v0 explicitly sets enabled=true.",
+            "An explicit request in an active project session may select the built-in weekly-progress profile for one provider-free local generation; it persists no project activation and creates no schedule or sink.",
+            "Custom, unattended, or externally delivered reports remain disabled until a project profile and host/runtime authority explicitly enable those separate paths.",
             "The core owns material trigger classification, coalescing, cooldown/deduplication, period/profile binding, deterministic identity, receipts, run state, and retry projection.",
             "Profiles own schedule calculation, enabled trigger kinds, minimum interval, timezone, sections, audience, and project policy.",
             "Adapters own domain source collection; renderers and sinks own all provider effects and verified readback.",
@@ -642,8 +653,9 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
             "The optional openviking-periodic-report extension implements only the archive sink; it rejects activation unless the periodic-report profile is enabled, its sink binding matches, and openviking_context_write is observed.",
         ],
         "next_real_step": (
-            "Prove one project-owned profile and exact delivery/archive retry readback "
-            "without adding project semantics or schedule policy to the core."
+            "Exercise the built-in weekly profile in a normal project session, then "
+            "prove one separately configured scheduled delivery without widening its "
+            "authority into the portable path."
         ),
     },
     {

--- a/loopx/capabilities/periodic_report/__init__.py
+++ b/loopx/capabilities/periodic_report/__init__.py
@@ -24,6 +24,18 @@ from .profile import (
     build_periodic_report_activation,
     normalize_periodic_report_profile,
 )
+from .presets import (
+    PERIODIC_REPORT_PROFILE_PRESET_ALIASES,
+    PERIODIC_REPORT_PROFILE_PRESET_IDS,
+    WEEKLY_PROGRESS_PRESET_ID,
+    build_periodic_report_preset_activation,
+    resolve_periodic_report_profile_preset,
+)
+from .project_progress import (
+    PROJECT_PROGRESS_PROJECTION_SCHEMA,
+    build_project_progress_periodic_report_source,
+    project_progress_periodic_report_source_adapter,
+)
 from .triggers import (
     build_periodic_report_trigger_decision,
     normalize_periodic_report_trigger_policy,
@@ -34,12 +46,18 @@ __all__ = [
     "PeriodicReportRendererAdapter",
     "PeriodicReportSinkAdapter",
     "PeriodicReportSourceAdapter",
+    "PERIODIC_REPORT_PROFILE_PRESET_ALIASES",
+    "PERIODIC_REPORT_PROFILE_PRESET_IDS",
+    "PROJECT_PROGRESS_PROJECTION_SCHEMA",
+    "WEEKLY_PROGRESS_PRESET_ID",
     "build_periodic_report_activation",
     "build_periodic_report_document",
     "build_periodic_report_delivery_receipt",
     "build_periodic_report_editorial",
     "build_periodic_report_extension_readiness",
     "build_periodic_report_generation_bundle",
+    "build_periodic_report_preset_activation",
+    "build_project_progress_periodic_report_source",
     "build_periodic_report_archive_bundle",
     "build_periodic_report_run",
     "build_periodic_report_source_result",
@@ -47,5 +65,7 @@ __all__ = [
     "normalize_periodic_report_profile",
     "normalize_periodic_report_sink_bindings",
     "normalize_periodic_report_trigger_policy",
+    "project_progress_periodic_report_source_adapter",
+    "resolve_periodic_report_profile_preset",
     "verify_periodic_report_archive_receipts",
 ]

--- a/loopx/capabilities/periodic_report/cli.py
+++ b/loopx/capabilities/periodic_report/cli.py
@@ -11,6 +11,10 @@ from typing import Any
 
 from .core import build_periodic_report_run
 from .profile import build_periodic_report_activation
+from .presets import (
+    PERIODIC_REPORT_PROFILE_PRESET_ALIASES,
+    build_periodic_report_preset_activation,
+)
 from .triggers import build_periodic_report_trigger_decision
 
 
@@ -63,13 +67,18 @@ def register_periodic_report_commands(
     )
     inspect_profile = commands.add_parser(
         "inspect-profile",
-        help="Validate one default-off project profile without provider effects.",
+        help="Inspect a built-in preset or project profile without provider effects.",
     )
     add_subcommand_format(inspect_profile)
-    inspect_profile.add_argument(
+    profile_source = inspect_profile.add_mutually_exclusive_group(required=True)
+    profile_source.add_argument(
         "--profile-json",
-        required=True,
         help="Path to periodic_report_profile_v0 JSON; use '-' for stdin.",
+    )
+    profile_source.add_argument(
+        "--preset",
+        choices=sorted(PERIODIC_REPORT_PROFILE_PRESET_ALIASES),
+        help="Built-in profile preset or short alias, such as 'weekly'.",
     )
     archive = commands.add_parser(
         "archive-openviking",
@@ -236,8 +245,12 @@ def handle_periodic_report_command(
                 args,
             )
         elif args.periodic_report_command == "inspect-profile":
-            payload = build_periodic_report_activation(
-                _load_json_object(args.profile_json)
+            payload = (
+                build_periodic_report_preset_activation(args.preset)
+                if args.preset
+                else build_periodic_report_activation(
+                    _load_json_object(args.profile_json)
+                )
             )
         elif args.periodic_report_command == "evaluate-trigger":
             request = _load_json_object(args.request_json)

--- a/loopx/capabilities/periodic_report/presets.py
+++ b/loopx/capabilities/periodic_report/presets.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from .profile import (
+    build_periodic_report_activation,
+    normalize_periodic_report_profile,
+)
+from .project_progress import (
+    PROJECT_PROGRESS_ADAPTER_ID,
+    PROJECT_PROGRESS_SOURCE_ID,
+    PROJECT_PROGRESS_SOURCE_KIND,
+)
+
+
+WEEKLY_PROGRESS_PRESET_ID = "weekly-progress"
+PERIODIC_REPORT_PROFILE_PRESET_IDS = (WEEKLY_PROGRESS_PRESET_ID,)
+PERIODIC_REPORT_PROFILE_PRESET_ALIASES = {
+    "weekly": WEEKLY_PROGRESS_PRESET_ID,
+    "weekly-progress": WEEKLY_PROGRESS_PRESET_ID,
+    "weekly-report": WEEKLY_PROGRESS_PRESET_ID,
+}
+
+_WEEKLY_PROGRESS_PROFILE: dict[str, Any] = {
+    "schema_version": "periodic_report_profile_v0",
+    "enabled": True,
+    "profile_id": "weekly_progress",
+    "profile_version": "v1",
+    "trigger_policy": {
+        "enabled_kinds": [
+            "manual",
+            "cadence_due",
+            "primary_goal_outcome",
+            "vision_closed",
+            "material_decision",
+            "material_blocker",
+            "material_recovery",
+        ],
+        "minimum_interval_seconds": 0,
+    },
+    "source_bindings": [
+        {
+            "source_id": PROJECT_PROGRESS_SOURCE_ID,
+            "source_kind": PROJECT_PROGRESS_SOURCE_KIND,
+            "adapter_id": PROJECT_PROGRESS_ADAPTER_ID,
+            "provider": {"kind": "builtin"},
+        }
+    ],
+    "renderer_bindings": [
+        {
+            "renderer_id": "html",
+            "renderer_kind": "html",
+            "adapter_id": "html_artifact_v0",
+            "provider": {"kind": "builtin"},
+        },
+        {
+            "renderer_id": "markdown",
+            "renderer_kind": "markdown",
+            "adapter_id": "markdown_v0",
+            "provider": {"kind": "builtin"},
+        },
+    ],
+    "sink_bindings": [],
+}
+
+
+def resolve_periodic_report_profile_preset(preset_id: str) -> dict[str, Any]:
+    """Resolve a short user-facing alias into one normalized built-in profile."""
+
+    requested = str(preset_id or "").strip().lower().replace("_", "-")
+    canonical = PERIODIC_REPORT_PROFILE_PRESET_ALIASES.get(requested)
+    if canonical != WEEKLY_PROGRESS_PRESET_ID:
+        supported = ", ".join(PERIODIC_REPORT_PROFILE_PRESET_IDS)
+        raise ValueError(
+            f"unknown periodic report profile preset {preset_id!r}; "
+            f"supported presets: {supported}"
+        )
+    return normalize_periodic_report_profile(deepcopy(_WEEKLY_PROGRESS_PROFILE))
+
+
+def build_periodic_report_preset_activation(preset_id: str) -> dict[str, Any]:
+    """Return an agent-readable activation packet for one built-in preset."""
+
+    requested = str(preset_id or "").strip().lower().replace("_", "-")
+    profile = resolve_periodic_report_profile_preset(requested)
+    activation = build_periodic_report_activation(profile)
+    activation["profile_preset"] = {
+        "requested_id": requested,
+        "resolved_id": WEEKLY_PROGRESS_PRESET_ID,
+        "aliases": sorted(PERIODIC_REPORT_PROFILE_PRESET_ALIASES),
+    }
+    activation["interaction_contract"] = {
+        "mode": "in_session_local_preview",
+        "explicit_user_request_sufficient": True,
+        "project_profile_file_required": False,
+        "automation_required": False,
+        "schedule_created": False,
+        "source_scope": "current_project_public_safe_loopx_state",
+        "renderer_adapter_ids": ["markdown_v0", "html_artifact_v0"],
+        "external_write_allowed": False,
+    }
+    return activation

--- a/loopx/capabilities/periodic_report/project_progress.py
+++ b/loopx/capabilities/periodic_report/project_progress.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from .adapters import (
+    PeriodicReportSourceAdapter,
+    build_periodic_report_source_result,
+)
+
+
+PROJECT_PROGRESS_PROJECTION_SCHEMA = "periodic_report_project_progress_projection_v0"
+PROJECT_PROGRESS_SOURCE_ID = "project_progress"
+PROJECT_PROGRESS_SOURCE_KIND = "validated_project_progress"
+PROJECT_PROGRESS_ADAPTER_ID = "project_progress_v0"
+
+_SECTION_BY_CONTENT_KIND = {
+    "outcome": ("progress", "Progress and outcomes", 10),
+    "decision": ("progress", "Progress and outcomes", 10),
+    "progress": ("progress", "Progress and outcomes", 10),
+    "capability_change": ("capability_evolution", "Capability evolution", 20),
+    "risk": ("risks", "Risks and blockers", 30),
+    "next_action": ("next_actions", "Next actions", 40),
+    "runtime": ("supporting_evidence", "Supporting evidence", 50),
+    "delivery_receipt": ("supporting_evidence", "Supporting evidence", 50),
+}
+_SUPPORTING_CONTENT_KINDS = {"runtime", "delivery_receipt"}
+_MAX_PRIMARY_ITEMS = 8
+_MAX_SUPPORTING_ITEMS = 16
+
+
+def _mapping(value: object, label: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be an object")
+    return {str(key): item for key, item in value.items()}
+
+
+def _sequence(value: object, label: str) -> list[Any]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise ValueError(f"{label} must be a list")
+    return list(value)
+
+
+def _snapshot_ref(projection: Mapping[str, Any]) -> str:
+    identity = {
+        "goal_id": str(projection.get("goal_id") or "project"),
+        "observed_at": str(projection.get("observed_at") or ""),
+        "items": projection.get("items"),
+    }
+    encoded = json.dumps(
+        identity,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return f"loopx-progress:{hashlib.sha256(encoded).hexdigest()[:24]}"
+
+
+def build_project_progress_periodic_report_source(
+    projection: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Normalize concise, domain-neutral project progress into report sections."""
+
+    packet = _mapping(projection, "project_progress")
+    if packet.get("schema_version") != PROJECT_PROGRESS_PROJECTION_SCHEMA:
+        raise ValueError(
+            f"project_progress must use {PROJECT_PROGRESS_PROJECTION_SCHEMA}"
+        )
+    raw_items = _sequence(packet.get("items"), "project_progress.items")
+    if not raw_items:
+        raise ValueError("project_progress.items must not be empty")
+
+    sections: dict[str, dict[str, Any]] = {}
+    seen_item_ids: set[str] = set()
+    primary_count = 0
+    supporting_count = 0
+    for index, raw_item in enumerate(raw_items):
+        label = f"project_progress.items[{index}]"
+        item = _mapping(raw_item, label)
+        item_id = str(item.get("item_id") or "").strip().lower()
+        if not item_id:
+            raise ValueError(f"{label}.item_id is required")
+        if item_id in seen_item_ids:
+            raise ValueError(f"duplicate project progress item_id {item_id!r}")
+        seen_item_ids.add(item_id)
+
+        content_kind = str(item.get("content_kind") or "").strip().lower()
+        section_spec = _SECTION_BY_CONTENT_KIND.get(content_kind)
+        if section_spec is None:
+            raise ValueError(f"{label}.content_kind is invalid")
+        visibility = str(item.get("visibility") or "primary").strip().lower()
+        if content_kind in _SUPPORTING_CONTENT_KINDS:
+            supporting_count += 1
+        elif visibility == "supporting":
+            supporting_count += 1
+        else:
+            primary_count += 1
+
+        section_id, title, order = section_spec
+        section = sections.setdefault(
+            section_id,
+            {
+                "section_id": section_id,
+                "title": title,
+                "order": order,
+                "items": [],
+            },
+        )
+        section["items"].append(item)
+
+    if primary_count > _MAX_PRIMARY_ITEMS:
+        raise ValueError(
+            f"project_progress contains {primary_count} primary items; "
+            f"summarize to at most {_MAX_PRIMARY_ITEMS}"
+        )
+    if supporting_count > _MAX_SUPPORTING_ITEMS:
+        raise ValueError(
+            f"project_progress contains {supporting_count} supporting items; "
+            f"keep at most {_MAX_SUPPORTING_ITEMS}"
+        )
+
+    warnings = _sequence(packet.get("warnings", []), "project_progress.warnings")
+    retryable = packet.get("retryable", bool(warnings))
+    if not isinstance(retryable, bool):
+        raise ValueError("project_progress.retryable must be a boolean")
+    status = str(packet.get("status") or ("partial" if warnings else "complete"))
+    return build_periodic_report_source_result(
+        source_id=PROJECT_PROGRESS_SOURCE_ID,
+        source_kind=PROJECT_PROGRESS_SOURCE_KIND,
+        status=status,
+        observed_at=str(packet.get("observed_at") or ""),
+        sections=list(sections.values()),
+        snapshot_ref=_snapshot_ref(packet),
+        retryable=retryable,
+    )
+
+
+def project_progress_periodic_report_source_adapter() -> PeriodicReportSourceAdapter:
+    return PeriodicReportSourceAdapter(
+        source_id=PROJECT_PROGRESS_SOURCE_ID,
+        source_kind=PROJECT_PROGRESS_SOURCE_KIND,
+        collect=build_project_progress_periodic_report_source,
+    )

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -180,7 +180,7 @@ COMMAND_GROUPS: list[dict[str, object]] = [
             },
             {
                 "command": "loopx periodic-report",
-                "purpose": "Evaluate report triggers and compose deterministic provider-neutral run receipts.",
+                "purpose": "Resolve a portable weekly profile, evaluate report triggers, and compose provider-neutral run receipts.",
             },
             {"command": "loopx auto-research", "purpose": "Project public-safe research frontiers."},
             {"command": "loopx multi-agent", "purpose": "Launch visible role-scoped Codex TUI agents."},

--- a/tests/capabilities/test_periodic_report_profile.py
+++ b/tests/capabilities/test_periodic_report_profile.py
@@ -5,7 +5,10 @@ from pathlib import Path
 
 import pytest
 
-from loopx.capabilities.periodic_report import build_periodic_report_activation
+from loopx.capabilities.periodic_report import (
+    build_periodic_report_activation,
+    resolve_periodic_report_profile_preset,
+)
 from loopx.cli import main
 
 
@@ -90,6 +93,33 @@ def test_enabled_profile_is_domain_neutral_and_archive_is_optional() -> None:
     assert activation["boundary"]["extension_effects_performed"] is False
 
 
+def test_weekly_preset_is_portable_domain_neutral_and_aliasable() -> None:
+    canonical = resolve_periodic_report_profile_preset("weekly-progress")
+    alias = resolve_periodic_report_profile_preset("weekly")
+    activation = build_periodic_report_activation(alias)
+
+    assert alias == canonical
+    assert activation["active"] is True
+    assert activation["generation_allowed"] is True
+    assert activation["extension_mode"] == "portable"
+    assert "schedule" not in activation["profile"]
+    assert activation["profile"]["sink_bindings"] == []
+    assert activation["profile"]["source_bindings"] == [
+        {
+            "schema_version": "periodic_report_source_binding_v0",
+            "source_id": "project_progress",
+            "source_kind": "validated_project_progress",
+            "adapter_id": "project_progress_v0",
+            "provider": {"kind": "builtin"},
+        }
+    ]
+    assert {
+        item["adapter_id"] for item in activation["profile"]["renderer_bindings"]
+    } == {"markdown_v0", "html_artifact_v0"}
+    serialized = json.dumps(activation, ensure_ascii=False).lower()
+    assert "issue_fix" not in serialized and "pull_request" not in serialized
+
+
 def test_enabled_profile_requires_sources_and_renderers() -> None:
     profile = _profile()
     profile["source_bindings"] = []
@@ -135,3 +165,36 @@ def test_profile_cli_returns_activation_receipt(
     payload = json.loads(capsys.readouterr().out)
     assert payload["schema_version"] == "periodic_report_activation_v0"
     assert payload["active"] is True
+
+
+def test_profile_cli_accepts_short_weekly_alias(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert (
+        main(
+            [
+                "--format",
+                "json",
+                "periodic-report",
+                "inspect-profile",
+                "--preset",
+                "weekly",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["profile"]["profile_id"] == "weekly_progress"
+    assert payload["active"] is True
+    assert payload["profile_preset"]["resolved_id"] == "weekly-progress"
+    assert payload["interaction_contract"] == {
+        "mode": "in_session_local_preview",
+        "explicit_user_request_sufficient": True,
+        "project_profile_file_required": False,
+        "automation_required": False,
+        "schedule_created": False,
+        "source_scope": "current_project_public_safe_loopx_state",
+        "renderer_adapter_ids": ["markdown_v0", "html_artifact_v0"],
+        "external_write_allowed": False,
+    }
+    assert payload["boundary"]["external_writes_performed"] is False

--- a/tests/capabilities/test_periodic_report_project_progress.py
+++ b/tests/capabilities/test_periodic_report_project_progress.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import pytest
+
+from loopx.capabilities.periodic_report import (
+    build_periodic_report_document,
+    build_periodic_report_generation_bundle,
+    build_project_progress_periodic_report_source,
+    project_progress_periodic_report_source_adapter,
+)
+from loopx.presentation.renderers.periodic_report_html import (
+    render_periodic_report_html,
+)
+from loopx.presentation.renderers.periodic_report_markdown import (
+    render_periodic_report_markdown,
+)
+
+
+def _projection(*, extra_items: list[dict[str, object]] | None = None) -> dict[str, object]:
+    return {
+        "schema_version": "periodic_report_project_progress_projection_v0",
+        "goal_id": "example-project",
+        "observed_at": "2026-07-20T08:00:00Z",
+        "items": [
+            {
+                "item_id": "delivery",
+                "title": "Shipped the project milestone",
+                "summary": "The validated outcome is available to users.",
+                "content_kind": "outcome",
+                "value_rank": 10,
+            },
+            {
+                "item_id": "capability",
+                "title": "Simplified report activation",
+                "summary": "A working session can use the built-in weekly preset.",
+                "content_kind": "capability_change",
+                "value_rank": 20,
+                "details": [
+                    {"label": "Before", "text": "A custom profile was required."},
+                    {"label": "Now", "text": "The built-in preset is enough."},
+                ],
+            },
+            {
+                "item_id": "next",
+                "title": "Collect the next reporting window",
+                "summary": "Continue from validated project state.",
+                "content_kind": "next_action",
+                "value_rank": 30,
+            },
+            *(extra_items or []),
+        ],
+    }
+
+
+def test_project_progress_source_builds_domain_neutral_report_hierarchy() -> None:
+    result = build_project_progress_periodic_report_source(_projection())
+
+    assert result["source_id"] == "project_progress"
+    assert result["source_kind"] == "validated_project_progress"
+    assert [section["section_id"] for section in result["sections"]] == [
+        "progress",
+        "capability_evolution",
+        "next_actions",
+    ]
+    assert result["item_count"] == 3
+    assert result["status"] == "complete"
+    assert result["boundary"]["external_reads_performed"] is False
+    assert result["boundary"]["external_writes_performed"] is False
+    adapter = project_progress_periodic_report_source_adapter()
+    assert adapter.source_id == "project_progress"
+    assert adapter.collect(_projection())["snapshot_digest"] == result["snapshot_digest"]
+
+
+def test_project_progress_source_keeps_runtime_supporting_and_caps_primary_items() -> None:
+    runtime = {
+        "item_id": "runtime",
+        "title": "Validation receipt",
+        "summary": "Focused checks passed.",
+        "content_kind": "runtime",
+        "visibility": "supporting",
+    }
+    result = build_project_progress_periodic_report_source(
+        _projection(extra_items=[runtime])
+    )
+    supporting = next(
+        section
+        for section in result["sections"]
+        if section["section_id"] == "supporting_evidence"
+    )
+    assert supporting["items"][0]["visibility"] == "supporting"
+
+    extras = [
+        {
+            "item_id": f"extra_{index}",
+            "title": f"Extra outcome {index}",
+            "summary": "A compact validated outcome.",
+            "content_kind": "outcome",
+        }
+        for index in range(6)
+    ]
+    with pytest.raises(ValueError, match="summarize to at most 8"):
+        build_project_progress_periodic_report_source(
+            _projection(extra_items=extras)
+        )
+
+
+def test_project_progress_source_renders_matching_local_artifacts() -> None:
+    source = build_project_progress_periodic_report_source(_projection())
+    document = build_periodic_report_document(
+        title="Weekly project report",
+        generated_at="2026-07-20T08:05:00Z",
+        period_window={
+            "start_at": "2026-07-13T00:00:00Z",
+            "end_at": "2026-07-20T00:00:00Z",
+        },
+        profile={"profile_id": "weekly_progress", "profile_version": "v1"},
+        sources=[source],
+    )
+    bundle = build_periodic_report_generation_bundle(
+        document=document,
+        artifacts=[
+            render_periodic_report_markdown(document),
+            render_periodic_report_html(document),
+        ],
+    )
+
+    assert bundle["generation_receipt"]["provider_required"] is False
+    assert bundle["generation_receipt"]["external_writes_performed"] is False
+    assert {artifact["renderer_kind"] for artifact in bundle["artifacts"]} == {
+        "markdown",
+        "html",
+    }
+    assert all(
+        "Shipped the project milestone" in artifact["content"]
+        for artifact in bundle["artifacts"]
+    )


### PR DESCRIPTION
## Summary

- add a built-in `weekly-progress` profile with `weekly` and `weekly-report` aliases
- add a domain-neutral `project_progress_v0` source hierarchy with an eight-primary-item audience budget
- return an agent-readable in-session interaction contract from preset inspection
- make custom profiles and Codex App Automation advanced paths for custom or unattended schedules
- keep external sinks explicit and provider-free Markdown/HTML generation portable

## Changed surfaces

- periodic-report preset and project-progress source runtime
- `inspect-profile --preset <alias>` CLI contract and capability catalog
- public profile fixture and focused profile/source/renderer regression tests
- OpenViking extension smoke selection by stable profile identity
- periodic-report capability and protocol documentation

## Validation

- `uv run --extra test pytest -q`: 975 passed, 2 skipped
- focused periodic-report/catalog/presentation/extension suite: 85 passed
- Ruff on changed Python surfaces: passed
- six periodic-report public smokes: passed
- `loopx canary premerge --from-git-diff --tier standard`: 18/18 selected checks passed
- public/private boundary scan: clean
- `git diff --check origin/main...HEAD`: passed
- real CLI inspection for `--preset weekly-report`: active and generation allowed, portable mode, no sink, no schedule, external write forbidden

## Failures, skips, and holds

- no validation failures
- the full suite retained two unrelated skips
- no manual holds

## Why this is enough

The change touches a user-facing CLI/profile path, shared report source normalization, fixtures, and public docs. Coverage exercises alias resolution, activation, source hierarchy and item budgets, Markdown/HTML parity, optional OpenViking behavior, catalog exposure, CLI output qualification, public-boundary policy, and the full repository test suite. It does not add scheduling authority, provider reads, external writes, credentials, private paths, or Issue Fix semantics to the built-in profile.

## Merge decision

Maintainer self-merge is appropriate: the owner explicitly authorized self-merge for this capability work, the premerge gate reports `self_merge_allowed: true`, all required checks pass, and there are no manual holds.
