### PR TITLE
release: LoopX v0.2.11

### DIFF
--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.10"
+__version__ = "0.2.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.2.10"
+version = "0.2.11"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- bump `loopx.__version__` and `pyproject.toml` from `0.2.10` to `0.2.11`
- package the built-in in-session weekly report preset merged in #2397

## Product and architecture judgment

This is a release-identity-only PR. The user-facing behavior already landed on `main` in #2397: a provider-neutral `weekly-progress` preset with `weekly` and `weekly-report` aliases, a generic project-progress source shape, and an agent-readable in-session activation packet. The release bump exposes that merged behavior through the stable version contract without adding scheduling authority, provider reads, external writes, credentials, or migration requirements.

## Validation

- version sources agree on `0.2.11`
- source distribution and wheel built successfully
- public/private boundary check passed for both changed files
- `git diff --check` passed
- #2397's merged commit passed its GitHub pytest check and its PR recorded 975 passed, 2 skipped plus focused periodic-report and premerge validation

## Explicitly skipped

Per the owner's instruction for this narrow fast-follow release, this release PR did not rerun pytest, Full Public Smokes, the live Doubao portfolio, or the full release qualification reducer. The release notes must preserve that distinction and must not reuse v0.2.10's exact-commit qualification receipt.

## Merge decision

This two-line release metadata change is single-purpose, public-safe, and self-mergeable after the checks above.
