### PR TITLE
Add adaptive N-Turn SkillsBench execution

### DIFF
--- a/docs/reference/protocols/loopx-turn-v0.md
+++ b/docs/reference/protocols/loopx-turn-v0.md
@@ -230,6 +230,16 @@ at `validation_failed`, records a typed `repair_required` or `replan_required`
 recovery disposition, and cannot write state or spend quota. Typed stop results
 do not require task validation because they produce no material writeback.
 
+An independent callback validator may distinguish terminal completion from
+validated intermediate progress. `status=passed` means the declared terminal
+postcondition holds and uses exit code `0`. `status=progress` means a bounded,
+task-facing postcondition is independently proven but the terminal
+postcondition is still open; it uses an explicit non-zero marker. Both statuses
+may commit exactly one Turn and one quota spend. Only `progress` permits a host
+adapter to start another Turn, and only under a predeclared maximum, shared
+total time budget, and no-feedback continuation policy. Every other validator
+status fails closed before writeback.
+
 ## Turn Input
 
 The driver input is a small composition of existing contracts:

--- a/examples/skillsbench-loopx-turn-agent-cli-smoke.py
+++ b/examples/skillsbench-loopx-turn-agent-cli-smoke.py
@@ -405,16 +405,26 @@ def main() -> int:
             "private-bridge-command",
             "--loopx-turn-validation-command",
             "test -f /app/solution.ok",
+            "--loopx-turn-max-turns",
+            "4",
+            "--loopx-turn-progress-exit-code",
+            "10",
         ]
     )
     runner_plan = build_plan(runner_args)
     launch_command = _host_local_acp_launch_command(runner_args, runner_plan)
     assert "--loopx-turn-agent-cli" in launch_command, launch_command
     assert "--loopx-turn-validation-command" in launch_command, launch_command
+    assert "--loopx-turn-max-turns" in launch_command, launch_command
+    assert "--loopx-turn-progress-exit-code" in launch_command, launch_command
     assert "--loopx-workflow-lifecycle-checkpoint" not in launch_command, launch_command
     prerequisites = runner_plan.get("runner_prerequisites", {})
     assert prerequisites.get("loopx_turn_validation_configured") is True, prerequisites
     assert prerequisites.get("loopx_turn_validation_command_recorded") is False, (
+        prerequisites
+    )
+    assert prerequisites.get("loopx_turn_max_turns") == 4, prerequisites
+    assert prerequisites.get("loopx_turn_progress_exit_code_configured") is True, (
         prerequisites
     )
 

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
 import json
 import os
 import re
@@ -90,9 +91,24 @@ from loopx.codex_cli_goal_tui import (
     tmux_submit_enter,
     tmux_type_text_and_submit,
 )
+from loopx.control_plane.turn_driver import codex_cli_session_id_from_jsonl
 
 SAFE_LOOPX_TODO_ID_RE = re.compile(r"^todo_[A-Za-z0-9_-]{6,80}$")
 SAFE_LOOPX_GOAL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,120}$")
+
+
+def _loopx_turn_local_session_root(
+    worker_public_trace_dir: str | None,
+    session_id: str,
+) -> Path | None:
+    if not worker_public_trace_dir:
+        return None
+    session_digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:24]
+    return (
+        Path(worker_public_trace_dir).parent
+        / ".loopx-turn-codex-sessions"
+        / session_digest
+    )
 
 
 def _safe_loopx_todo_id(value: object) -> str:
@@ -425,6 +441,8 @@ class CodexExecConfig:
     loopx_workflow_lifecycle_checkpoint: bool = False
     loopx_turn_agent_cli: bool = False
     loopx_turn_validation_command: str | None = None
+    loopx_turn_max_turns: int = 1
+    loopx_turn_progress_exit_code: int = 10
     loopx_case_goal_id: str = "skillsbench-case"
     loopx_case_agent_id: str = BENCHMARK_CASE_LOOPX_AGENT_ID
     loopx_case_todo_id: str = BENCHMARK_CASE_LOOPX_TODO_ID
@@ -573,23 +591,39 @@ class SkillsBenchLocalAcpRelay:
         session_id: str,
         stdout: TextIO,
         _bypass_loopx_turn: bool = False,
+        _turn_deadline: float | None = None,
     ) -> str:
         if self._config.dry_run_response is not None:
             return self._config.dry_run_response
         if self._config.loopx_turn_agent_cli and not _bypass_loopx_turn:
-            return run_skillsbench_loopx_turn_relay(
-                prompt=prompt_text,
-                session_id=session_id,
-                relay_config=self._config,
-                agent_runner=lambda turn_prompt: self._run_codex(
-                    turn_prompt,
-                    session=session,
-                    session_id=session_id,
-                    stdout=stdout,
-                    _bypass_loopx_turn=True,
-                ),
-                trace_writer=self._write_worker_public_trace,
+            sequence_deadline = time.monotonic() + max(
+                1.0, float(self._config.timeout_sec)
             )
+            try:
+                return run_skillsbench_loopx_turn_relay(
+                    prompt=prompt_text,
+                    session_id=session_id,
+                    relay_config=self._config,
+                    agent_runner=lambda turn_prompt: self._run_codex(
+                        turn_prompt,
+                        session=session,
+                        session_id=session_id,
+                        stdout=stdout,
+                        _bypass_loopx_turn=True,
+                        _turn_deadline=sequence_deadline,
+                    ),
+                    trace_writer=self._write_worker_public_trace,
+                )
+            finally:
+                session.pop("_loopx_turn_codex_thread_id", None)
+                session_root = _loopx_turn_local_session_root(
+                    self._config.worker_public_trace_dir,
+                    session_id,
+                )
+                if session_root is not None:
+                    shutil.rmtree(session_root, ignore_errors=True)
+                    with contextlib.suppress(OSError):
+                        session_root.parent.rmdir()
         if self._config.app_server_goal_worker:
             return self._run_app_server_goal_worker(
                 prompt_text,
@@ -611,6 +645,16 @@ class SkillsBenchLocalAcpRelay:
             stderr_path = tmp_path / "codex-stderr.txt"
             prompt_for_codex = prompt_text
             cwd = _safe_cwd(session.get("cwd"), default=os.getcwd())
+            resumable_loopx_turn = bool(
+                _bypass_loopx_turn
+                and self._config.loopx_turn_agent_cli
+                and self._config.loopx_turn_max_turns > 1
+            )
+            resume_session_id = (
+                str(session.get("_loopx_turn_codex_thread_id") or "")
+                if resumable_loopx_turn
+                else ""
+            )
             bridge_server_proc: subprocess.Popen[str] | None = None
             if self._config.remote_command_file_bridge_command:
                 if _is_bridge_action_preflight_prompt(prompt_text):
@@ -620,7 +664,18 @@ class SkillsBenchLocalAcpRelay:
                 self._publish_remote_bridge_consumption_trace(bridge_probe)
                 if bridge_probe.get("ready") is not True:
                     raise RuntimeError("remote command/file bridge probe failed")
-                local_cwd = tmp_path / "local-codex-cwd"
+                if resumable_loopx_turn:
+                    session_root = _loopx_turn_local_session_root(
+                        self._config.worker_public_trace_dir,
+                        session_id,
+                    )
+                    if session_root is None:
+                        raise RuntimeError(
+                            "resumable LoopX Turn requires a public trace directory"
+                        )
+                    local_cwd = session_root / "cwd"
+                else:
+                    local_cwd = tmp_path / "local-codex-cwd"
                 local_cwd.mkdir(parents=True, exist_ok=True)
                 cwd = str(local_cwd)
                 bridge_summary_path = tmp_path / "remote-bridge-agent-ops.jsonl"
@@ -654,19 +709,32 @@ class SkillsBenchLocalAcpRelay:
                 )
             else:
                 bridge_summary_path = None
-            cmd = [
-                self._config.codex_bin,
-                "exec",
-                "--ephemeral",
-                "--skip-git-repo-check",
-                "--sandbox",
-                self._config.sandbox,
-                "-C",
-                cwd,
-                "--output-last-message",
-                str(output_path),
-                "--json",
-            ]
+            if resume_session_id:
+                cmd = [
+                    self._config.codex_bin,
+                    "exec",
+                    "resume",
+                    "--skip-git-repo-check",
+                    "--output-last-message",
+                    str(output_path),
+                    "--json",
+                ]
+            else:
+                cmd = [self._config.codex_bin, "exec"]
+                if not resumable_loopx_turn:
+                    cmd.append("--ephemeral")
+                cmd.extend(
+                    [
+                        "--skip-git-repo-check",
+                        "--sandbox",
+                        self._config.sandbox,
+                        "-C",
+                        cwd,
+                        "--output-last-message",
+                        str(output_path),
+                        "--json",
+                    ]
+                )
             if self._config.reasoning_effort:
                 cmd.extend(
                     [
@@ -678,6 +746,10 @@ class SkillsBenchLocalAcpRelay:
             model = self._config.model or session.get("model")
             if model:
                 cmd.extend(["--model", str(model)])
+            if resume_session_id:
+                cmd.extend([resume_session_id, "-"])
+            elif resumable_loopx_turn:
+                cmd.append("-")
             codex_stdin_prompt = prompt_for_codex
             stdout_text = ""
             stderr_text = ""
@@ -700,7 +772,18 @@ class SkillsBenchLocalAcpRelay:
                         start_new_session=True,
                     )
                     _write_process_stdin_async(proc, codex_stdin_prompt)
-                    deadline = time.monotonic() + self._config.timeout_sec
+                    remaining_turn_seconds = (
+                        _turn_deadline - time.monotonic()
+                        if _turn_deadline is not None
+                        else float(self._config.timeout_sec)
+                    )
+                    if remaining_turn_seconds <= 0:
+                        self._terminate_codex_process(proc)
+                        return _recoverable_codex_turn_failure_message(
+                            "codex_exec_turn_time_budget_exhausted"
+                        )
+                    effective_timeout_sec = remaining_turn_seconds
+                    deadline = time.monotonic() + effective_timeout_sec
                     first_action_deadline = 0.0
                     if (
                         bridge_summary_path is not None
@@ -855,7 +938,7 @@ class SkillsBenchLocalAcpRelay:
                             self._terminate_codex_process(proc)
                             raise subprocess.TimeoutExpired(
                                 cmd,
-                                self._config.timeout_sec,
+                                effective_timeout_sec,
                             )
                         if now >= next_heartbeat:
                             self._write_worker_heartbeat(
@@ -939,6 +1022,25 @@ class SkillsBenchLocalAcpRelay:
                 if recoverable_turn_failure:
                     return _recoverable_codex_turn_failure_message(category)
                 raise RuntimeError(f"local codex execution failed: {category}")
+            if resumable_loopx_turn and not resume_session_id:
+                observed_session_id = codex_cli_session_id_from_jsonl(stdout_text)
+                if not observed_session_id:
+                    self._publish_codex_exec_failure_trace(
+                        stage="session_start_missing",
+                        returncode=0,
+                        stdout_text=stdout_text,
+                        stderr_text=stderr_text,
+                        final_message_present=output_path.exists(),
+                        final_message_bytes=(
+                            output_path.stat().st_size if output_path.exists() else 0
+                        ),
+                        failure_category="codex_exec_session_missing",
+                        recoverable_turn_failure=True,
+                    )
+                    return _recoverable_codex_turn_failure_message(
+                        "codex_exec_session_missing"
+                    )
+                session["_loopx_turn_codex_thread_id"] = observed_session_id
             try:
                 response = output_path.read_text(encoding="utf-8").strip()
             except OSError as exc:

--- a/loopx/benchmark_adapters/skillsbench_turn_route.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_route.py
@@ -54,9 +54,9 @@ def skillsbench_loopx_turn_route_contract() -> dict[str, Any]:
         "official_score_comparable_to_loopx_treatment": True,
         "first_blocker": "none",
         "next_action": (
-            "run each host Agent CLI prompt through one real case-local LoopX "
-            "Turn transaction, validate a private scored-workspace postcondition "
-            "independently, and emit only compact public-safe receipt evidence"
+            "run each host Agent CLI prompt through a bounded sequence of real "
+            "case-local LoopX Turn transactions, continue only after independent "
+            "progress validation, and emit compact public-safe receipt evidence"
         ),
     }
 
@@ -68,6 +68,7 @@ def skillsbench_loopx_turn_validation_signals() -> list[str]:
         "isolated_headless",
         "independent_scored_workspace_validation",
         "official_feedback_withheld",
+        "bounded_n_turn",
         "fixture_only",
         "no_upload",
         "single_task_planned",
@@ -87,11 +88,32 @@ def add_skillsbench_loopx_turn_arguments(parser: Any) -> None:
             "sandbox bridge and is never written to public compact traces."
         ),
     )
+    parser.add_argument(
+        "--loopx-turn-max-turns",
+        type=int,
+        default=1,
+        help=(
+            "Maximum independently validated Turns for the experimental LoopX "
+            "Turn route. 1 preserves the single-Turn baseline."
+        ),
+    )
+    parser.add_argument(
+        "--loopx-turn-progress-exit-code",
+        type=int,
+        default=10,
+        help=(
+            "Private validator exit code meaning validated intermediate progress. "
+            "Exit 0 means terminal completion; every other code fails closed."
+        ),
+    )
 
 
 def skillsbench_loopx_turn_runner_prerequisites(
     route: str,
     validation_command: Any,
+    *,
+    max_turns: Any = 1,
+    progress_exit_code: Any = 10,
 ) -> dict[str, Any]:
     enabled = route == "loopx-turn-agent-cli"
     return {
@@ -104,6 +126,20 @@ def skillsbench_loopx_turn_runner_prerequisites(
             enabled and str(validation_command or "").strip()
         ),
         "loopx_turn_validation_command_recorded": False,
+        "loopx_turn_max_turns": (
+            max_turns
+            if enabled
+            and isinstance(max_turns, int)
+            and not isinstance(max_turns, bool)
+            and max_turns >= 1
+            else 0
+        ),
+        "loopx_turn_progress_exit_code_configured": bool(
+            enabled
+            and isinstance(progress_exit_code, int)
+            and not isinstance(progress_exit_code, bool)
+            and 1 <= progress_exit_code <= 255
+        ),
     }
 
 
@@ -225,6 +261,7 @@ def _public_validation(value: Any) -> dict[str, Any]:
             "pre_agent_postcondition_status",
             "post_agent_postcondition_status",
             "baseline_contract",
+            "sequence_stop_reason",
         )
         if (label := _public_label(value.get(key), limit=120))
     }
@@ -235,12 +272,17 @@ def _public_validation(value: Any) -> dict[str, Any]:
         "raw_validator_output_recorded",
         "raw_task_text_recorded",
         "raw_verifier_output_recorded",
+        "validated_progress",
+        "terminal_complete",
     ):
         if isinstance(value.get(key), bool):
             validation[key] = value[key]
     operation_count = value.get("meaningful_operation_count")
     if isinstance(operation_count, int) and not isinstance(operation_count, bool):
         validation["meaningful_operation_count"] = max(0, operation_count)
+    turn_index = value.get("turn_index")
+    if isinstance(turn_index, int) and not isinstance(turn_index, bool):
+        validation["turn_index"] = max(1, turn_index)
     return validation
 
 
@@ -321,7 +363,7 @@ def _aggregate_runner_readiness(receipts: list[dict[str, Any]]) -> dict[str, Any
 
 
 def _aggregate_validations(validations: list[dict[str, Any]]) -> dict[str, Any]:
-    return {
+    aggregate = {
         "schema_version": "skillsbench_scored_workspace_validation_v0",
         "status": (
             "passed"
@@ -350,7 +392,18 @@ def _aggregate_validations(validations: list[dict[str, Any]]) -> dict[str, Any]:
         "raw_verifier_output_recorded": any(
             item.get("raw_verifier_output_recorded") is True for item in validations
         ),
+        "validated_progress": bool(
+            validations
+            and all(item.get("validated_progress") is True for item in validations)
+        ),
+        "terminal_complete": any(
+            item.get("terminal_complete") is True for item in validations
+        ),
+        "turn_count": len(validations),
     }
+    if validations and validations[-1].get("sequence_stop_reason"):
+        aggregate["sequence_stop_reason"] = validations[-1]["sequence_stop_reason"]
+    return aggregate
 
 
 @dataclass
@@ -472,5 +525,25 @@ def skillsbench_loopx_turn_launch_error(args: Any) -> dict[str, Any] | None:
             ),
             "next_action": "configure --loopx-turn-validation-command",
             "validation_command_recorded": False,
+        }
+    max_turns = getattr(args, "loopx_turn_max_turns", 1)
+    if not isinstance(max_turns, int) or isinstance(max_turns, bool) or max_turns < 1:
+        return {
+            **common,
+            "error_type": "SkillsBenchLoopXTurnMaxTurnsInvalid",
+            "reason": "LoopX Turn treatment requires max Turns of at least one",
+            "next_action": "configure --loopx-turn-max-turns with a positive integer",
+        }
+    progress_exit_code = getattr(args, "loopx_turn_progress_exit_code", 10)
+    if (
+        not isinstance(progress_exit_code, int)
+        or isinstance(progress_exit_code, bool)
+        or not 1 <= progress_exit_code <= 255
+    ):
+        return {
+            **common,
+            "error_type": "SkillsBenchLoopXTurnProgressExitCodeInvalid",
+            "reason": "validated progress requires a private exit code from 1 to 255",
+            "next_action": "configure --loopx-turn-progress-exit-code from 1 to 255",
         }
     return None

--- a/loopx/benchmark_adapters/skillsbench_turn_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_runtime.py
@@ -15,8 +15,9 @@ import re
 import shlex
 import subprocess
 import time
+import uuid
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
@@ -38,6 +39,13 @@ SKILLSBENCH_TURN_BASELINE_ENV = "LOOPX_TURN_BASELINE_FILE"
 
 AgentPromptRunner = Callable[[str], str]
 PublicTraceWriter = Callable[[dict[str, Any]], None]
+TurnObserver = Callable[[dict[str, Any], dict[str, Any]], None]
+
+SKILLSBENCH_LOOPX_TURN_CONTINUATION_PROMPT = """\
+Continue the same task in this same Codex session. Inspect the current workspace
+state, perform the next bounded task-facing step, and stop. Do not use or request
+official verifier, reward, pass/fail, hidden-test, or gold-answer feedback.
+"""
 
 
 @dataclass(frozen=True)
@@ -49,6 +57,8 @@ class SkillsBenchTurnRuntimeConfig:
     runtime_root: Path
     bridge_timeout_seconds: float = 30.0
     agent_timeout_seconds: float = 7200.0
+    max_turns: int = 1
+    progress_exit_code: int = 10
     case_cli_path: str = "/app/.local/bin/loopx"
     case_registry_path: str = "/app/.loopx/registry.json"
     case_runtime_root: str = "/app/.loopx/runtime"
@@ -156,6 +166,8 @@ class SkillsBenchTurnBridge:
                 and not isinstance(exit_code, bool)
                 and exit_code != 0
             ):
+                if meaningful:
+                    self.meaningful_operation_count += 1
                 return {
                     "ok": False,
                     "exit_code": exit_code,
@@ -205,6 +217,8 @@ def _case_cli_prefix(config: SkillsBenchTurnRuntimeConfig) -> str:
 def _turn_plan(
     bridge: SkillsBenchTurnBridge,
     config: SkillsBenchTurnRuntimeConfig,
+    *,
+    turn_instance_id: str | None = None,
 ) -> dict[str, Any]:
     prefix = _case_cli_prefix(config)
     command = (
@@ -214,6 +228,8 @@ def _turn_plan(
         "--host generic-cli --execution-mode isolated-headless "
         "--include-transaction-detail --scan-root /app --limit 5"
     )
+    if turn_instance_id:
+        command += f" --turn-instance-id {shlex.quote(turn_instance_id)}"
     try:
         payload = bridge.loopx_json(command)
     except SkillsBenchTurnBridgeError as exc:
@@ -284,11 +300,18 @@ def _validation_baseline(
             category=exc.category,
             exit_code=exc.exit_code,
         ) from exc
+    exit_code = result.get("exit_code")
+    if result.get("ok") is True:
+        status = "already_satisfied"
+    elif exit_code == config.progress_exit_code:
+        status = "progress_validated"
+    else:
+        status = "unsatisfied"
     return {
         "schema_version": "skillsbench_validation_baseline_v0",
-        "status": "already_satisfied" if result.get("ok") is True else "unsatisfied",
+        "status": status,
         "postcondition_kind": "task_declared_independent_command",
-        "exit_code": result.get("exit_code"),
+        "exit_code": exit_code,
         "raw_command_recorded": False,
         "raw_output_recorded": False,
     }
@@ -299,6 +322,7 @@ def run_skillsbench_loopx_turn(
     prompt: str,
     agent_runner: AgentPromptRunner,
     config: SkillsBenchTurnRuntimeConfig,
+    turn_instance_id: str | None = None,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     """Execute one real Turn and return its receipt plus compact validation."""
 
@@ -308,8 +332,14 @@ def run_skillsbench_loopx_turn(
         raise ValueError(
             "SkillsBench LoopX Turn requires an independent validation command"
         )
+    if not 1 <= config.progress_exit_code <= 255:
+        raise ValueError("SkillsBench progress exit code must be between 1 and 255")
     bridge = SkillsBenchTurnBridge(config)
-    plan = _turn_plan(bridge, config)
+    plan = (
+        _turn_plan(bridge, config, turn_instance_id=turn_instance_id)
+        if turn_instance_id is not None
+        else _turn_plan(bridge, config)
+    )
     validation_baseline = _validation_baseline(bridge, config)
     prefix = _case_cli_prefix(config)
     baseline_path = ""
@@ -338,7 +368,11 @@ def run_skillsbench_loopx_turn(
             f"{shlex.quote(config.validation_command)}"
         )
         try:
-            bridge.exec(validation_command, meaningful=True)
+            validation_result = bridge.exec(
+                validation_command,
+                meaningful=True,
+                allow_nonzero=True,
+            )
         except SkillsBenchTurnBridgeError:
             return {
                 "status": "failed",
@@ -346,6 +380,22 @@ def run_skillsbench_loopx_turn(
                 "summary": "independent scored-workspace validation returned non-zero",
                 "recovery_kind": "repair_required",
                 "exit_code": 1,
+            }
+        exit_code = validation_result.get("exit_code")
+        if exit_code == config.progress_exit_code:
+            return {
+                "status": "progress",
+                "validator_kind": "skillsbench_scored_workspace_command",
+                "summary": "independent scored-workspace progress validation passed",
+                "exit_code": exit_code,
+            }
+        if exit_code != 0:
+            return {
+                "status": "failed",
+                "validator_kind": "skillsbench_scored_workspace_command",
+                "summary": "independent scored-workspace validation returned non-zero",
+                "recovery_kind": "repair_required",
+                "exit_code": exit_code,
             }
         return {
             "status": "passed",
@@ -420,24 +470,30 @@ def run_skillsbench_loopx_turn(
                 bridge.exec(f"rm -f {shlex.quote(baseline_path)}")
             except SkillsBenchTurnBridgeError:
                 pass
+    transaction_validation = execution.get("validation")
+    transaction_validation = (
+        transaction_validation if isinstance(transaction_validation, dict) else {}
+    )
+    validation_status = transaction_validation.get("status")
+    validation_passed = validation_status in {"passed", "progress"}
+    terminal_complete = validation_status == "passed"
+    validated_progress = validation_status in {"passed", "progress"}
     scored_validation = {
         "schema_version": "skillsbench_scored_workspace_validation_v0",
-        "status": (
-            "passed"
-            if isinstance(execution.get("validation"), dict)
-            and execution["validation"].get("status") == "passed"
-            else "failed"
-        ),
+        "status": ("passed" if validation_passed else "failed"),
         "independent": True,
         "validator_kind": "skillsbench_scored_workspace_command",
         "pre_agent_postcondition_checked": True,
         "pre_agent_postcondition_status": validation_baseline["status"],
         "post_agent_postcondition_status": (
             "satisfied"
-            if isinstance(execution.get("validation"), dict)
-            and execution["validation"].get("status") == "passed"
+            if terminal_complete
+            else "progress_validated"
+            if validated_progress
             else "unsatisfied"
         ),
+        "validated_progress": validated_progress,
+        "terminal_complete": terminal_complete,
         "baseline_contract": "task_declared_independent_postcondition",
         "oracle_feedback_used": False,
         "meaningful_operation_count": bridge.meaningful_operation_count,
@@ -446,6 +502,63 @@ def run_skillsbench_loopx_turn(
         "raw_verifier_output_recorded": False,
     }
     return execution, scored_validation
+
+
+def run_skillsbench_loopx_turn_sequence(
+    *,
+    prompt: str,
+    agent_runner: AgentPromptRunner,
+    config: SkillsBenchTurnRuntimeConfig,
+    turn_observer: TurnObserver | None = None,
+) -> tuple[list[tuple[dict[str, Any], dict[str, Any]]], dict[str, Any]]:
+    """Run up to N independently validated Turns within one total time budget."""
+
+    if config.max_turns < 1:
+        raise ValueError("SkillsBench LoopX Turn max_turns must be at least 1")
+    sequence_id = uuid.uuid4().hex[:16]
+    deadline = time.monotonic() + max(1.0, config.agent_timeout_seconds)
+    records: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    stop_reason = "max_turns_reached"
+    for turn_index in range(1, config.max_turns + 1):
+        remaining_seconds = deadline - time.monotonic()
+        if remaining_seconds <= 0:
+            stop_reason = "time_budget_exhausted"
+            break
+        turn_prompt = (
+            prompt if turn_index == 1 else SKILLSBENCH_LOOPX_TURN_CONTINUATION_PROMPT
+        )
+        execution, validation = run_skillsbench_loopx_turn(
+            prompt=turn_prompt,
+            agent_runner=agent_runner,
+            config=replace(config, agent_timeout_seconds=remaining_seconds),
+            turn_instance_id=f"{sequence_id}-turn-{turn_index:03d}",
+        )
+        validation["turn_index"] = turn_index
+        records.append((execution, validation))
+        if execution.get("status") != "committed":
+            stop_reason = "turn_not_committed"
+        elif validation.get("terminal_complete") is True:
+            stop_reason = "terminal_complete"
+        elif validation.get("validated_progress") is not True:
+            stop_reason = "no_validated_progress"
+        elif turn_index < config.max_turns:
+            stop_reason = "continue"
+        else:
+            stop_reason = "max_turns_reached"
+        validation["sequence_stop_reason"] = stop_reason
+        if turn_observer is not None:
+            turn_observer(execution, validation)
+        if stop_reason != "continue":
+            break
+    return records, {
+        "schema_version": "skillsbench_loopx_turn_sequence_v0",
+        "status": stop_reason,
+        "turn_count": len(records),
+        "max_turns": config.max_turns,
+        "terminal_complete": stop_reason == "terminal_complete",
+        "official_feedback_blinded": True,
+        "reward_feedback_forwarded": False,
+    }
 
 
 def build_skillsbench_benchmark_runner_readiness(
@@ -462,7 +575,7 @@ def build_skillsbench_benchmark_runner_readiness(
         ),
         "pre_agent_postcondition_unsatisfied": (
             scored_workspace_validation.get("pre_agent_postcondition_status")
-            == "unsatisfied"
+            in {"unsatisfied", "progress_validated"}
         ),
         "post_agent_postcondition_satisfied": (
             scored_workspace_validation.get("post_agent_postcondition_status")
@@ -613,6 +726,12 @@ def run_skillsbench_loopx_turn_relay(
         raise RuntimeError("LoopX Turn requires an independent validation command")
     if not trace_root:
         raise RuntimeError("LoopX Turn requires a compact public trace directory")
+    max_turns = int(getattr(relay_config, "loopx_turn_max_turns", 1))
+    progress_exit_code = int(getattr(relay_config, "loopx_turn_progress_exit_code", 10))
+    if max_turns < 1:
+        raise RuntimeError("LoopX Turn max Turns must be at least one")
+    if not 1 <= progress_exit_code <= 255:
+        raise RuntimeError("LoopX Turn progress exit code must be between 1 and 255")
     runtime_session = (
         "".join(
             char if char.isalnum() or char in "_.:-" else "_" for char in session_id
@@ -620,7 +739,7 @@ def run_skillsbench_loopx_turn_relay(
         or "session"
     )
     try:
-        execution, scored_validation = run_skillsbench_loopx_turn(
+        turn_records, sequence = run_skillsbench_loopx_turn_sequence(
             prompt=prompt,
             agent_runner=agent_runner,
             config=SkillsBenchTurnRuntimeConfig(
@@ -635,9 +754,20 @@ def run_skillsbench_loopx_turn_relay(
                     1.0, relay_config.remote_command_file_bridge_timeout_sec
                 ),
                 agent_timeout_seconds=max(1.0, float(relay_config.timeout_sec)),
+                max_turns=max_turns,
+                progress_exit_code=progress_exit_code,
                 case_cli_path=relay_config.loopx_case_cli_path,
                 case_registry_path=relay_config.loopx_case_registry_path,
                 case_runtime_root=relay_config.loopx_case_runtime_root,
+            ),
+            turn_observer=lambda execution, scored_validation: trace_writer(
+                build_skillsbench_loopx_turn_trace(
+                    route=relay_config.route,
+                    benchmark_id=relay_config.dataset,
+                    task_id=relay_config.task_id,
+                    execution=execution,
+                    scored_workspace_validation=scored_validation,
+                )
             ),
         )
     except SkillsBenchTurnBridgeError as exc:
@@ -652,17 +782,16 @@ def run_skillsbench_loopx_turn_relay(
         return recoverable_codex_turn_failure_message(
             f"loopx_turn_{exc.stage}_{exc.category}"
         )
-    trace_writer(
-        build_skillsbench_loopx_turn_trace(
-            route=relay_config.route,
-            benchmark_id=relay_config.dataset,
-            task_id=relay_config.task_id,
-            execution=execution,
-            scored_workspace_validation=scored_validation,
+    if not turn_records:
+        return recoverable_codex_turn_failure_message(
+            "loopx_turn_" + str(sequence.get("status") or "failed")
         )
-    )
+    execution, _scored_validation = turn_records[-1]
     if execution.get("status") != "committed":
         return recoverable_codex_turn_failure_message(
             "loopx_turn_" + str(execution.get("status") or "failed")
         )
-    return "loopx turn committed after independent scored-workspace validation"
+    return (
+        "loopx turn sequence stopped after "
+        f"{len(turn_records)} committed turn(s): {sequence['status']}"
+    )

--- a/loopx/control_plane/turn_driver/__init__.py
+++ b/loopx/control_plane/turn_driver/__init__.py
@@ -7,6 +7,7 @@ from .driver import (
 )
 from .codex_cli import (
     CODEX_CLI_SESSION_SCHEMA_VERSION,
+    codex_cli_session_id_from_jsonl,
     codex_cli_result_schema,
     codex_cli_session_binding,
     load_codex_cli_session,
@@ -51,6 +52,7 @@ __all__ = [
     "loopx_turn_execution_recovery_required",
     "load_loopx_turn_plan_from_journal",
     "load_codex_cli_session",
+    "codex_cli_session_id_from_jsonl",
     "normalize_host_argv",
     "run_loopx_turn_once",
     "run_codex_cli_host",

--- a/loopx/control_plane/turn_driver/codex_cli.py
+++ b/loopx/control_plane/turn_driver/codex_cli.py
@@ -250,7 +250,7 @@ def _prompt(request: Mapping[str, Any]) -> str:
     )
 
 
-def _event_session_id(event: Mapping[str, Any]) -> str | None:
+def codex_cli_event_session_id(event: Mapping[str, Any]) -> str | None:
     if event.get("type") not in {"thread.started", "thread_started"}:
         return None
     for candidate in (
@@ -262,6 +262,20 @@ def _event_session_id(event: Mapping[str, Any]) -> str | None:
         session_id = _valid_session_id(candidate)
         if session_id:
             return session_id
+    return None
+
+
+def codex_cli_session_id_from_jsonl(value: str) -> str | None:
+    """Return the first opaque Codex thread id from an exec JSONL stream."""
+
+    for line in value.splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, Mapping):
+            if session_id := codex_cli_event_session_id(event):
+                return session_id
     return None
 
 
@@ -415,7 +429,7 @@ def run_codex_cli_host(
                 except json.JSONDecodeError:
                     continue
                 if isinstance(event, dict):
-                    candidate = _event_session_id(event)
+                    candidate = codex_cli_event_session_id(event)
                     if candidate and not observed_session:
                         observed_session.append(candidate)
 

--- a/loopx/control_plane/turn_driver/executor.py
+++ b/loopx/control_plane/turn_driver/executor.py
@@ -227,7 +227,14 @@ def _task_validation_receipt(
     exit_code: int | None = None,
 ) -> dict[str, Any]:
     errors: list[str] = []
-    if status not in {"passed", "failed", "inconclusive", "unavailable", "not_required"}:
+    if status not in {
+        "passed",
+        "progress",
+        "failed",
+        "inconclusive",
+        "unavailable",
+        "not_required",
+    }:
         errors.append("unsupported task validation status")
     if not validator_kind or len(validator_kind) > 80:
         errors.append("task validator kind must contain at most 80 characters")
@@ -246,18 +253,20 @@ def _task_validation_receipt(
         errors.append("task validation recovery_kind must be repair_required or replan_required")
     if status in {"failed", "inconclusive", "unavailable"} and recovery_kind is None:
         errors.append("failed task validation requires a typed recovery_kind")
-    if status in {"passed", "not_required"} and recovery_kind is not None:
+    if status in {"passed", "progress", "not_required"} and recovery_kind is not None:
         errors.append("successful task validation cannot declare recovery_kind")
     if exit_code is not None and (not isinstance(exit_code, int) or exit_code < 0):
         errors.append("task validation exit_code must be a non-negative integer")
     if status == "passed" and exit_code not in {None, 0}:
         errors.append("passed task validation cannot declare a non-zero exit_code")
+    if status == "progress" and exit_code in {None, 0}:
+        errors.append("progress task validation requires a non-zero exit_code")
     effective_status = status if not errors else "inconclusive"
     effective_recovery_kind = recovery_kind
     if errors and effective_recovery_kind is None:
         effective_recovery_kind = LoopXTurnResultKind.REPAIR_REQUIRED.value
     return {
-        "ok": not errors and status in {"passed", "not_required"},
+        "ok": not errors and status in {"passed", "progress", "not_required"},
         "schema_version": LOOPX_TURN_TASK_VALIDATION_SCHEMA_VERSION,
         "status": effective_status,
         "validator_kind": validator_kind or "invalid",

--- a/loopx/control_plane/turn_driver/transaction.py
+++ b/loopx/control_plane/turn_driver/transaction.py
@@ -88,7 +88,7 @@ def loopx_turn_execution_committed(execution: Mapping[str, Any]) -> bool:
     return bool(
         execution.get("status") == "committed"
         and receipt.get("status") == "committed"
-        and validation.get("status") == "passed"
+        and validation.get("status") in {"passed", "progress"}
         and effects.get("state_written") is True
         and effects.get("quota_spent") is True
     )

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -63,6 +63,10 @@ Optional env:
   SKILLSBENCH_LOOPX_TURN_VALIDATION_COMMAND
                                        Independent scored-workspace validator
                                        required by loopx-turn-agent-cli
+  SKILLSBENCH_LOOPX_TURN_MAX_TURNS      Maximum validated Turns, default 1
+  SKILLSBENCH_LOOPX_TURN_PROGRESS_EXIT_CODE
+                                       Validator code for intermediate progress,
+                                       default 10; 0 remains terminal completion
   SKILLSBENCH_BUILD_STALL_TIMEOUT_SEC  Setup stall timeout, default 3600;
                                        0 disables cap
   SKILLSBENCH_RUN_TIMEOUT_SEC          Supervisor timeout, default 28800
@@ -204,6 +208,8 @@ remote_command_file_bridge_solver_command="${SKILLSBENCH_REMOTE_COMMAND_FILE_BRI
 remote_command_file_bridge_agent_command="${SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_AGENT_COMMAND:-}"
 remote_command_file_bridge_agent_command_instrumented="${SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_AGENT_COMMAND_INSTRUMENTED:-0}"
 loopx_turn_validation_command="${SKILLSBENCH_LOOPX_TURN_VALIDATION_COMMAND:-}"
+loopx_turn_max_turns="${SKILLSBENCH_LOOPX_TURN_MAX_TURNS:-1}"
+loopx_turn_progress_exit_code="${SKILLSBENCH_LOOPX_TURN_PROGRESS_EXIT_CODE:-10}"
 validate_bool_toggle() {
   local env_name="$1"
   local value="$2"
@@ -269,6 +275,17 @@ if [[ "$route" == "loopx-turn-agent-cli" ]] &&
   [[ -z "$loopx_turn_validation_command" ]]; then
   echo "SKILLSBENCH_LOOPX_TURN_VALIDATION_COMMAND is required for loopx-turn-agent-cli" >&2
   exit 2
+fi
+if [[ "$route" == "loopx-turn-agent-cli" ]]; then
+  if [[ ! "$loopx_turn_max_turns" =~ ^[1-9][0-9]*$ ]]; then
+    echo "SKILLSBENCH_LOOPX_TURN_MAX_TURNS must be a positive integer" >&2
+    exit 2
+  fi
+  if [[ ! "$loopx_turn_progress_exit_code" =~ ^[1-9][0-9]*$ ]] ||
+    ((10#$loopx_turn_progress_exit_code > 255)); then
+    echo "SKILLSBENCH_LOOPX_TURN_PROGRESS_EXIT_CODE must be between 1 and 255" >&2
+    exit 2
+  fi
 fi
 model="${SKILLSBENCH_MODEL:-gpt-5.5}"
 reasoning_effort="${SKILLSBENCH_REASONING_EFFORT:-xhigh}"
@@ -410,6 +427,14 @@ if [[ -n "$loopx_turn_validation_command" ]]; then
   extra_runner_args+=(
     --loopx-turn-validation-command
     "$loopx_turn_validation_command"
+  )
+fi
+if [[ "$route" == "loopx-turn-agent-cli" ]]; then
+  extra_runner_args+=(
+    --loopx-turn-max-turns
+    "$loopx_turn_max_turns"
+    --loopx-turn-progress-exit-code
+    "$loopx_turn_progress_exit_code"
   )
 fi
 if [[ -n "${SKILLSBENCH_REGISTRY:-}" ]]; then
@@ -567,6 +592,8 @@ if [[ "$dry_run" == "true" ]]; then
     "$remote_command_file_bridge_agent_command_instrumented"
   printf 'loopx_turn_validation_command_configured=%s\n' \
     "$([[ -n "$loopx_turn_validation_command" ]] && echo 1 || echo 0)"
+  printf 'loopx_turn_max_turns=%s\n' "$loopx_turn_max_turns"
+  printf 'loopx_turn_progress_exit_code=%s\n' "$loopx_turn_progress_exit_code"
   printf 'skip_global_ledger_sync=%s\n' "$skip_global_ledger_sync"
   printf 'skip_current_aggregate_update=%s\n' "$skip_current_aggregate_update"
   printf 'local_run_ledger=%s\n' "$local_run_ledger"
@@ -590,6 +617,8 @@ if [[ "$dry_run" == "true" ]]; then
       printf '%s ' --remote-command-file-bridge-agent-command-instrumented
     [[ -n "$loopx_turn_validation_command" ]] &&
       printf '%s ' --loopx-turn-validation-command
+    [[ "$route" == "loopx-turn-agent-cli" ]] &&
+      printf '%s ' --loopx-turn-max-turns --loopx-turn-progress-exit-code
     printf '\n'
     printf 'remote_command=<redacted-private-runner-command-values>\n'
     printf 'supervisor_command=<redacted-private-runner-command-values>\n'

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -1064,6 +1064,14 @@ def _host_local_acp_launch_command(
             command.extend(
                 ["--loopx-turn-validation-command", validation_command]
             )
+        command.extend(
+            [
+                "--loopx-turn-max-turns",
+                str(getattr(args, "loopx_turn_max_turns", 1)),
+                "--loopx-turn-progress-exit-code",
+                str(getattr(args, "loopx_turn_progress_exit_code", 10)),
+            ]
+        )
     if (
         _is_loopx_product_mode_route(args.route)
         and not _is_goal_start_product_mode_route(args.route)
@@ -8931,6 +8939,10 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             **skillsbench_loopx_turn_runner_prerequisites(
                 args.route,
                 getattr(args, "loopx_turn_validation_command", None),
+                max_turns=getattr(args, "loopx_turn_max_turns", 1),
+                progress_exit_code=getattr(
+                    args, "loopx_turn_progress_exit_code", 10
+                ),
             ),
             "loopx_product_mode_lifecycle_driver_kind": (
                 BENCHMARK_CASE_LOOPX_ORCHESTRATED_EXECUTION_STYLE

--- a/scripts/skillsbench_local_acp_relay.py
+++ b/scripts/skillsbench_local_acp_relay.py
@@ -245,6 +245,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "Its output is never copied into public traces."
         ),
     )
+    parser.add_argument("--loopx-turn-max-turns", type=int, default=1)
+    parser.add_argument("--loopx-turn-progress-exit-code", type=int, default=10)
     parser.add_argument("--loopx-case-goal-id", default="skillsbench-case")
     parser.add_argument("--loopx-case-agent-id", default="codex-benchmark-agent")
     parser.add_argument("--loopx-case-todo-id", default=BENCHMARK_CASE_LOOPX_TODO_ID)
@@ -299,6 +301,8 @@ def main(argv: list[str] | None = None) -> int:
             ),
             loopx_turn_agent_cli=args.loopx_turn_agent_cli,
             loopx_turn_validation_command=args.loopx_turn_validation_command,
+            loopx_turn_max_turns=args.loopx_turn_max_turns,
+            loopx_turn_progress_exit_code=args.loopx_turn_progress_exit_code,
             loopx_case_goal_id=args.loopx_case_goal_id,
             loopx_case_agent_id=args.loopx_case_agent_id,
             loopx_case_todo_id=args.loopx_case_todo_id,

--- a/tests/test_loopx_turn_driver.py
+++ b/tests/test_loopx_turn_driver.py
@@ -13,6 +13,8 @@ from loopx.control_plane.turn_driver import (
     LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION,
     LoopXTurnRoute,
     build_loopx_turn_plan,
+    loopx_turn_execution_committed,
+    run_loopx_turn_once,
 )
 from loopx.control_plane.quota.live_decision import bind_scheduler_followup_cli_routes
 
@@ -859,6 +861,61 @@ raise SystemExit(0 if artifact.read_text(encoding="utf-8") == "validated" else 7
         "fixture_progress",
         "quota_slot_spent",
     ]
+
+
+def test_turn_run_once_commits_independently_validated_progress(
+    tmp_path: Path,
+) -> None:
+    plan = build_loopx_turn_plan(
+        _envelope(),
+        host="generic-cli",
+        execution_mode="isolated-headless",
+    )
+
+    def host_runner(request: dict[str, object]) -> dict[str, object]:
+        return {
+            "schema_version": "loopx_turn_result_v0",
+            "turn_key": request["turn_key"],
+            "result_kind": "validated_progress",
+            "completed_phases": ["host_execute", "typed_result"],
+            "classification": "fixture_intermediate_progress",
+            "recommended_action": "Continue the fixture",
+            "next_action": "Run the next bounded fixture Turn",
+            "delivery_batch_scale": "single_surface",
+            "delivery_outcome": "outcome_progress",
+            "vision_unchanged_reason": "The fixture objective remains open.",
+            "summary": "One intermediate fixture step passed validation.",
+        }
+
+    execution = run_loopx_turn_once(
+        plan,
+        host_runner=host_runner,
+        project=tmp_path,
+        runtime_root=tmp_path / "runtime",
+        goal_id="fixture-goal",
+        timeout_seconds=10,
+        execute=True,
+        task_validator=lambda _plan, _result: {
+            "status": "progress",
+            "validator_kind": "fixture",
+            "summary": "intermediate fixture progress is independently valid",
+            "exit_code": 10,
+        },
+        writeback=lambda _result: {"ok": True, "appended": True},
+        spend=lambda: {"ok": True, "appended": True, "slots": 1},
+        scheduler=lambda _spend: {
+            "disposition": "outer_controller_owned",
+            "completed": True,
+            "acknowledged": False,
+            "apply_needed": False,
+        },
+    )
+
+    assert execution["status"] == "committed"
+    assert execution["validation"]["status"] == "progress"
+    assert execution["validation"]["exit_code"] == 10
+    assert execution["quota_slot_spend_count"] == 1
+    assert loopx_turn_execution_committed(execution) is True
 
 
 def test_turn_run_once_cli_rejects_unproven_host_claim_before_writeback(

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -48,6 +48,8 @@ def test_turn_launcher_wires_private_commands_without_echoing_values(
     env.update(
         {
             "SKILLSBENCH_ROUTE": "loopx-turn-agent-cli",
+            "SKILLSBENCH_LOOPX_TURN_MAX_TURNS": "4",
+            "SKILLSBENCH_LOOPX_TURN_PROGRESS_EXIT_CODE": "10",
             "SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_AGENT_COMMAND_INSTRUMENTED": (
                 "1"
             ),
@@ -70,6 +72,8 @@ def test_turn_launcher_wires_private_commands_without_echoing_values(
     assert "remote_command_file_bridge_agent_command_configured=1" in output
     assert "remote_command_file_bridge_agent_command_instrumented=1" in output
     assert "loopx_turn_validation_command_configured=1" in output
+    assert "loopx_turn_max_turns=4" in output
+    assert "loopx_turn_progress_exit_code=10" in output
     assert "private_runner_command_values_redacted=true" in output
     for arg_name in (
         "--remote-command-file-bridge-probe-command",
@@ -77,6 +81,8 @@ def test_turn_launcher_wires_private_commands_without_echoing_values(
         "--remote-command-file-bridge-agent-command",
         "--remote-command-file-bridge-agent-command-instrumented",
         "--loopx-turn-validation-command",
+        "--loopx-turn-max-turns",
+        "--loopx-turn-progress-exit-code",
     ):
         assert arg_name in output
     for private_value in private_values.values():

--- a/tests/test_skillsbench_turn_runtime.py
+++ b/tests/test_skillsbench_turn_runtime.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
+from loopx.benchmark_adapters import skillsbench_acp_relay as acp_relay
 from loopx.benchmark_adapters import skillsbench_turn_runtime as runtime
+from loopx.benchmark_adapters.skillsbench_acp_relay import (
+    CodexExecConfig,
+    SkillsBenchLocalAcpRelay,
+)
 from loopx.benchmark_adapters.skillsbench_turn_route import (
     SkillsBenchTurnTraceSummary,
     sync_skillsbench_loopx_turn_trace_into_compact,
@@ -74,6 +80,8 @@ def test_satisfied_pre_agent_postcondition_runs_but_does_not_claim_readiness(
             allow_nonzero: bool = False,
         ) -> dict[str, Any]:
             if allow_nonzero:
+                if meaningful:
+                    self.meaningful_operation_count += 1
                 return {"ok": True, "exit_code": 0, "elapsed_ms": 1}
             if meaningful:
                 self.meaningful_operation_count += 1
@@ -130,7 +138,7 @@ def test_unsatisfied_baseline_then_satisfied_postcondition_is_runner_ready(
             meaningful: bool = False,
             allow_nonzero: bool = False,
         ) -> dict[str, Any]:
-            if allow_nonzero:
+            if allow_nonzero and not meaningful:
                 return {"ok": False, "exit_code": 3, "elapsed_ms": 1}
             if meaningful:
                 self.meaningful_operation_count += 1
@@ -185,6 +193,340 @@ def test_unsatisfied_baseline_then_satisfied_postcondition_is_runner_ready(
     assert trace["benchmark_runner_readiness"]["ready"] is True
     assert trace["benchmark_runner_readiness"]["blocker_codes"] == []
     assert trace["benchmark_runner_readiness"]["raw_task_text_recorded"] is False
+
+
+def test_adaptive_sequence_commits_progress_then_terminal_turns(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    validation_pairs = [(3, 10), (10, 0)]
+    plan_instance_ids: list[str] = []
+    agent_prompts: list[str] = []
+    callback_counts = {"writeback": 0, "spend": 0}
+    observed: list[tuple[dict[str, Any], dict[str, Any]]] = []
+
+    class SequenceBridge:
+        instance_count = 0
+
+        def __init__(self, _config: Any) -> None:
+            self.meaningful_operation_count = 0
+            self.validation_codes = list(
+                validation_pairs[SequenceBridge.instance_count]
+            )
+            SequenceBridge.instance_count += 1
+
+        def exec(
+            self,
+            _command: str,
+            *,
+            meaningful: bool = False,
+            allow_nonzero: bool = False,
+        ) -> dict[str, Any]:
+            if allow_nonzero:
+                code = self.validation_codes.pop(0)
+                if meaningful:
+                    self.meaningful_operation_count += 1
+                return {
+                    "ok": code == 0,
+                    "exit_code": code,
+                    "elapsed_ms": 1,
+                    **({"stdout": ""} if code == 0 else {}),
+                }
+            return {"ok": True, "exit_code": 0, "stdout": "", "elapsed_ms": 1}
+
+        def loopx_json(self, command: str) -> dict[str, Any]:
+            if "refresh-state" in command:
+                callback_counts["writeback"] += 1
+                return {"ok": True, "appended": True}
+            if "spend-slot" in command:
+                callback_counts["spend"] += 1
+                return {"ok": True, "appended": True, "slots": 1}
+            return {
+                "scheduler_hint": {
+                    "execution_phase": {
+                        "disposition": "outer_controller_owned",
+                        "completed": True,
+                        "acknowledged": False,
+                        "apply_needed": False,
+                    }
+                }
+            }
+
+    def fake_plan(
+        _bridge: Any,
+        _config: Any,
+        *,
+        turn_instance_id: str,
+    ) -> dict[str, Any]:
+        plan_instance_ids.append(turn_instance_id)
+        return {"ok": True, "turn_key": f"turn-{len(plan_instance_ids)}"}
+
+    def fake_turn_once(
+        plan: dict[str, Any],
+        *,
+        host_runner: Any,
+        task_validator: Any,
+        writeback: Any,
+        spend: Any,
+        scheduler: Any,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        result = host_runner({"turn_key": plan["turn_key"]})
+        validation = dict(task_validator(plan, result))
+        assert validation["status"] in {"progress", "passed"}
+        writeback_payload = writeback(result)
+        spend_payload = spend()
+        scheduler(spend_payload)
+        return {
+            "status": "committed",
+            "validation": validation,
+            "quota_slot_spend_count": 1,
+            "receipt": {"status": "committed"},
+            "effects": {
+                "host_invoked": True,
+                "state_written": writeback_payload["appended"],
+                "quota_spent": spend_payload["appended"],
+                "scheduler_acknowledged": False,
+            },
+        }
+
+    monkeypatch.setattr(runtime, "SkillsBenchTurnBridge", SequenceBridge)
+    monkeypatch.setattr(runtime, "_turn_plan", fake_plan)
+    monkeypatch.setattr(runtime, "run_loopx_turn_once", fake_turn_once)
+
+    records, sequence = runtime.run_skillsbench_loopx_turn_sequence(
+        prompt="original task prompt",
+        agent_runner=lambda prompt: agent_prompts.append(prompt) or "done",
+        config=runtime.SkillsBenchTurnRuntimeConfig(
+            **{**_config(tmp_path).__dict__, "max_turns": 4}
+        ),
+        turn_observer=lambda execution, validation: observed.append(
+            (execution, validation)
+        ),
+    )
+
+    assert len(records) == 2
+    assert sequence["status"] == "terminal_complete"
+    assert sequence["turn_count"] == 2
+    assert len(set(plan_instance_ids)) == 2
+    assert plan_instance_ids[0].endswith("turn-001")
+    assert plan_instance_ids[1].endswith("turn-002")
+    assert agent_prompts[0] == "original task prompt"
+    assert "Continue the same task" in agent_prompts[1]
+    assert callback_counts == {"writeback": 2, "spend": 2}
+    assert [item[0]["quota_slot_spend_count"] for item in records] == [1, 1]
+    assert records[0][1]["validated_progress"] is True
+    assert records[0][1]["terminal_complete"] is False
+    assert records[0][1]["sequence_stop_reason"] == "continue"
+    assert records[1][1]["terminal_complete"] is True
+    assert records[1][1]["sequence_stop_reason"] == "terminal_complete"
+    assert len(observed) == 2
+
+
+def test_skillsbench_n_turn_codex_exec_starts_then_resumes_same_thread(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    argv_log = tmp_path / "argv.jsonl"
+    fake_codex = tmp_path / "fake-codex"
+    fake_codex.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import sys
+
+with pathlib.Path(os.environ["FAKE_CODEX_ARGV_LOG"]).open("a", encoding="utf-8") as handle:
+    handle.write(json.dumps(sys.argv[1:]) + "\\n")
+output_index = sys.argv.index("--output-last-message") + 1
+pathlib.Path(sys.argv[output_index]).write_text("bounded turn complete", encoding="utf-8")
+print(json.dumps({"type": "thread.started", "thread_id": "thread-fixture-001"}))
+""",
+        encoding="utf-8",
+    )
+    fake_codex.chmod(0o755)
+    monkeypatch.setenv("FAKE_CODEX_ARGV_LOG", str(argv_log))
+    trace_dir = tmp_path / "public-traces"
+    trace_dir.mkdir()
+    relay = SkillsBenchLocalAcpRelay(
+        CodexExecConfig(
+            codex_bin=str(fake_codex),
+            loopx_turn_agent_cli=True,
+            loopx_turn_max_turns=3,
+            remote_command_file_bridge_command="synthetic-bridge",
+            worker_public_trace_dir=str(trace_dir),
+            timeout_sec=30,
+        )
+    )
+    monkeypatch.setattr(
+        relay,
+        "_consume_remote_bridge_for_solver",
+        lambda: {"ready": True},
+    )
+    monkeypatch.setattr(
+        relay,
+        "_publish_remote_bridge_consumption_trace",
+        lambda _probe: None,
+    )
+    monkeypatch.setattr(
+        relay,
+        "_start_json_file_bridge_server",
+        lambda **_kwargs: ("synthetic-agent-bridge", None),
+    )
+    monkeypatch.setattr(
+        relay,
+        "_write_instrumented_bridge_wrapper",
+        lambda **kwargs: kwargs["tmp_path"] / "synthetic-wrapper",
+    )
+    monkeypatch.setattr(
+        relay,
+        "_prompt_with_remote_bridge_packet",
+        lambda prompt, **_kwargs: prompt,
+    )
+    monkeypatch.setattr(
+        relay,
+        "_publish_remote_bridge_agent_operations_trace",
+        lambda **_kwargs: None,
+    )
+    session: dict[str, Any] = {"cwd": str(tmp_path), "model": None}
+    deadline = time.monotonic() + 30
+
+    first = relay._run_codex(
+        "first bounded turn",
+        session=session,
+        session_id="fixture-session",
+        stdout=SimpleNamespace(write=lambda _value: None, flush=lambda: None),
+        _bypass_loopx_turn=True,
+        _turn_deadline=deadline,
+    )
+    second = relay._run_codex(
+        "continue bounded turn",
+        session=session,
+        session_id="fixture-session",
+        stdout=SimpleNamespace(write=lambda _value: None, flush=lambda: None),
+        _bypass_loopx_turn=True,
+        _turn_deadline=deadline,
+    )
+
+    argv_rows = [json.loads(line) for line in argv_log.read_text().splitlines()]
+    assert first == second == "bounded turn complete"
+    assert "--ephemeral" not in argv_rows[0]
+    assert argv_rows[0][:2] == ["exec", "--skip-git-repo-check"]
+    assert argv_rows[1][:3] == ["exec", "resume", "--skip-git-repo-check"]
+    assert "thread-fixture-001" in argv_rows[1]
+    assert session["_loopx_turn_codex_thread_id"] == "thread-fixture-001"
+    private_cwd_root = tmp_path / ".loopx-turn-codex-sessions"
+    assert len(list(private_cwd_root.glob("*/cwd"))) == 1
+
+    session.pop("_loopx_turn_codex_thread_id")
+
+    def fake_turn_relay(**kwargs: Any) -> str:
+        kwargs["agent_runner"]("first bounded turn")
+        kwargs["agent_runner"]("continue bounded turn")
+        return "sequence complete"
+
+    monkeypatch.setattr(acp_relay, "run_skillsbench_loopx_turn_relay", fake_turn_relay)
+    assert (
+        relay._run_codex(
+            "full sequence",
+            session=session,
+            session_id="fixture-session",
+            stdout=SimpleNamespace(write=lambda _value: None, flush=lambda: None),
+        )
+        == "sequence complete"
+    )
+    assert "_loopx_turn_codex_thread_id" not in session
+    assert not private_cwd_root.exists()
+
+
+def test_skillsbench_n_turn_codex_exec_respects_expired_shared_budget(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_codex = tmp_path / "fake-codex"
+    fake_codex.write_text(
+        """#!/usr/bin/env python3
+import pathlib
+import sys
+
+output_index = sys.argv.index("--output-last-message") + 1
+pathlib.Path(sys.argv[output_index]).write_text("late", encoding="utf-8")
+""",
+        encoding="utf-8",
+    )
+    fake_codex.chmod(0o755)
+    trace_dir = tmp_path / "public-traces"
+    trace_dir.mkdir()
+    relay = SkillsBenchLocalAcpRelay(
+        CodexExecConfig(
+            codex_bin=str(fake_codex),
+            loopx_turn_agent_cli=True,
+            loopx_turn_max_turns=2,
+            worker_public_trace_dir=str(trace_dir),
+            timeout_sec=30,
+        )
+    )
+
+    response = relay._run_codex(
+        "late turn",
+        session={"cwd": str(tmp_path), "model": None},
+        session_id="fixture-session",
+        stdout=SimpleNamespace(write=lambda _value: None, flush=lambda: None),
+        _bypass_loopx_turn=True,
+        _turn_deadline=time.monotonic() - 1,
+    )
+
+    assert response.startswith(runtime.RECOVERABLE_CODEX_TURN_FAILURE_PREFIX)
+    assert "time_budget_exhausted" in response
+
+
+@pytest.mark.parametrize(
+    ("validated_progress", "max_turns", "expected_reason", "expected_turns"),
+    [
+        (False, 4, "no_validated_progress", 1),
+        (True, 3, "max_turns_reached", 3),
+    ],
+)
+def test_adaptive_sequence_stops_on_missing_progress_or_fixed_maximum(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    validated_progress: bool,
+    max_turns: int,
+    expected_reason: str,
+    expected_turns: int,
+) -> None:
+    calls = 0
+
+    def fake_turn(**_kwargs: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+        nonlocal calls
+        calls += 1
+        return (
+            {
+                "status": "committed",
+                "quota_slot_spend_count": 1,
+                "receipt": {"status": "committed"},
+                "effects": {"state_written": True, "quota_spent": True},
+            },
+            {
+                "status": "passed" if validated_progress else "failed",
+                "validated_progress": validated_progress,
+                "terminal_complete": False,
+            },
+        )
+
+    monkeypatch.setattr(runtime, "run_skillsbench_loopx_turn", fake_turn)
+
+    records, sequence = runtime.run_skillsbench_loopx_turn_sequence(
+        prompt="original task prompt",
+        agent_runner=lambda _prompt: "done",
+        config=runtime.SkillsBenchTurnRuntimeConfig(
+            **{**_config(tmp_path).__dict__, "max_turns": max_turns}
+        ),
+    )
+
+    assert calls == expected_turns
+    assert len(records) == expected_turns
+    assert sequence["status"] == expected_reason
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- generalize the experimental SkillsBench Turn route from one Turn to a bounded `N`-Turn sequence
- resume the same Codex CLI thread across independently validated Turns under one total time budget
- distinguish terminal completion (`0`) from validated intermediate progress (configured nonzero code), fail closed otherwise
- preserve `max_turns=1` as the single-Turn baseline and emit one compact public-safe trace per Turn

## Validation
- `92 passed` across Turn driver, transaction, Codex CLI, SkillsBench runtime/launcher, and remote preflight tests
- durable `skillsbench-loopx-turn-agent-cli-smoke.py` passed
- `ruff check` passed on changed focused surfaces; changed Python compile and `bash -n` passed
- LoopX premerge: 15 automated checks passed, 0 failures; public boundary passed

## Hold disposition
The generic premerge gate reports the expected benchmark-sensitive manual hold. The repository owner explicitly authorized self-merge of benchmark code in this task. This change does not alter scoring, task semantics, uploads, submissions, or official-feedback blindness, and launches no benchmark job.