### PR TITLE
fix(periodic-report): localize project progress sections

### DIFF
--- a/docs/capabilities/periodic-report/README.md
+++ b/docs/capabilities/periodic-report/README.md
@@ -44,6 +44,13 @@ the audience narrative. This hierarchy is inspired by the validated project
 weekly-report presentation, but it contains no issue, pull-request, or
 Issue Fix policy.
 
+The source request may carry the profile-owned `language` as a BCP-47-like
+tag. The built-in hierarchy currently provides English and Chinese section
+vocabulary (other languages fall back to English), while item facts remain
+owned by the caller. The orchestrator must pass the same language into the
+document editorial input; renderers do not infer or rewrite business section
+semantics. Omitting the field preserves the English default.
+
 There is no issue-fix-specific report capability. Issue Fix, release notes,
 research, operations, and other domains may supply peer source adapters when
 their richer semantics are useful; none is required by the built-in weekly

--- a/loopx/capabilities/periodic_report/project_progress.py
+++ b/loopx/capabilities/periodic_report/project_progress.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from collections.abc import Mapping, Sequence
 from typing import Any
 
@@ -17,15 +18,32 @@ PROJECT_PROGRESS_SOURCE_KIND = "validated_project_progress"
 PROJECT_PROGRESS_ADAPTER_ID = "project_progress_v0"
 
 _SECTION_BY_CONTENT_KIND = {
-    "outcome": ("progress", "Progress and outcomes", 10),
-    "decision": ("progress", "Progress and outcomes", 10),
-    "progress": ("progress", "Progress and outcomes", 10),
-    "capability_change": ("capability_evolution", "Capability evolution", 20),
-    "risk": ("risks", "Risks and blockers", 30),
-    "next_action": ("next_actions", "Next actions", 40),
-    "runtime": ("supporting_evidence", "Supporting evidence", 50),
-    "delivery_receipt": ("supporting_evidence", "Supporting evidence", 50),
+    "outcome": ("progress", 10),
+    "decision": ("progress", 10),
+    "progress": ("progress", 10),
+    "capability_change": ("capability_evolution", 20),
+    "risk": ("risks", 30),
+    "next_action": ("next_actions", 40),
+    "runtime": ("supporting_evidence", 50),
+    "delivery_receipt": ("supporting_evidence", 50),
 }
+_SECTION_TITLES = {
+    "en": {
+        "progress": "Progress and outcomes",
+        "capability_evolution": "Capability evolution",
+        "risks": "Risks and blockers",
+        "next_actions": "Next actions",
+        "supporting_evidence": "Supporting evidence",
+    },
+    "zh": {
+        "progress": "进展与成果",
+        "capability_evolution": "能力演进",
+        "risks": "风险与阻塞",
+        "next_actions": "下一步",
+        "supporting_evidence": "支撑证据",
+    },
+}
+_LANGUAGE_RE = re.compile(r"^[A-Za-z]{2,8}(?:-[A-Za-z0-9]{1,8})*$")
 _SUPPORTING_CONTENT_KINDS = {"runtime", "delivery_receipt"}
 _MAX_PRIMARY_ITEMS = 8
 _MAX_SUPPORTING_ITEMS = 16
@@ -43,10 +61,11 @@ def _sequence(value: object, label: str) -> list[Any]:
     return list(value)
 
 
-def _snapshot_ref(projection: Mapping[str, Any]) -> str:
+def _snapshot_ref(projection: Mapping[str, Any], *, language: str) -> str:
     identity = {
         "goal_id": str(projection.get("goal_id") or "project"),
         "observed_at": str(projection.get("observed_at") or ""),
+        "language": language,
         "items": projection.get("items"),
     }
     encoded = json.dumps(
@@ -56,6 +75,20 @@ def _snapshot_ref(projection: Mapping[str, Any]) -> str:
         separators=(",", ":"),
     ).encode("utf-8")
     return f"loopx-progress:{hashlib.sha256(encoded).hexdigest()[:24]}"
+
+
+def _language(value: object) -> str:
+    language = str(value or "en").strip()
+    if not _LANGUAGE_RE.fullmatch(language):
+        raise ValueError(
+            "project_progress.language must be a BCP-47-like language tag"
+        )
+    return language.lower()
+
+
+def _section_title(section_id: str, *, language: str) -> str:
+    vocabulary = "zh" if language.lower().startswith("zh") else "en"
+    return _SECTION_TITLES[vocabulary][section_id]
 
 
 def build_project_progress_periodic_report_source(
@@ -68,6 +101,7 @@ def build_project_progress_periodic_report_source(
         raise ValueError(
             f"project_progress must use {PROJECT_PROGRESS_PROJECTION_SCHEMA}"
         )
+    language = _language(packet.get("language"))
     raw_items = _sequence(packet.get("items"), "project_progress.items")
     if not raw_items:
         raise ValueError("project_progress.items must not be empty")
@@ -98,12 +132,12 @@ def build_project_progress_periodic_report_source(
         else:
             primary_count += 1
 
-        section_id, title, order = section_spec
+        section_id, order = section_spec
         section = sections.setdefault(
             section_id,
             {
                 "section_id": section_id,
-                "title": title,
+                "title": _section_title(section_id, language=language),
                 "order": order,
                 "items": [],
             },
@@ -132,7 +166,7 @@ def build_project_progress_periodic_report_source(
         status=status,
         observed_at=str(packet.get("observed_at") or ""),
         sections=list(sections.values()),
-        snapshot_ref=_snapshot_ref(packet),
+        snapshot_ref=_snapshot_ref(packet, language=language),
         retryable=retryable,
     )
 

--- a/tests/capabilities/test_periodic_report_project_progress.py
+++ b/tests/capabilities/test_periodic_report_project_progress.py
@@ -16,8 +16,12 @@ from loopx.presentation.renderers.periodic_report_markdown import (
 )
 
 
-def _projection(*, extra_items: list[dict[str, object]] | None = None) -> dict[str, object]:
-    return {
+def _projection(
+    *,
+    extra_items: list[dict[str, object]] | None = None,
+    language: str | None = None,
+) -> dict[str, object]:
+    projection: dict[str, object] = {
         "schema_version": "periodic_report_project_progress_projection_v0",
         "goal_id": "example-project",
         "observed_at": "2026-07-20T08:00:00Z",
@@ -50,6 +54,9 @@ def _projection(*, extra_items: list[dict[str, object]] | None = None) -> dict[s
             *(extra_items or []),
         ],
     }
+    if language is not None:
+        projection["language"] = language
+    return projection
 
 
 def test_project_progress_source_builds_domain_neutral_report_hierarchy() -> None:
@@ -101,6 +108,58 @@ def test_project_progress_source_keeps_runtime_supporting_and_caps_primary_items
     with pytest.raises(ValueError, match="summarize to at most 8"):
         build_project_progress_periodic_report_source(
             _projection(extra_items=extras)
+        )
+
+
+def test_project_progress_source_localizes_its_semantic_sections() -> None:
+    runtime = {
+        "item_id": "runtime",
+        "title": "验证回执",
+        "summary": "聚焦检查已通过。",
+        "content_kind": "runtime",
+        "visibility": "supporting",
+    }
+    english = build_project_progress_periodic_report_source(_projection())
+    chinese = build_project_progress_periodic_report_source(
+        _projection(language="zh-CN", extra_items=[runtime])
+    )
+
+    assert [section["title"] for section in chinese["sections"]] == [
+        "进展与成果",
+        "能力演进",
+        "下一步",
+        "支撑证据",
+    ]
+    assert chinese["snapshot_ref"] != english["snapshot_ref"]
+
+    document = build_periodic_report_document(
+        title="项目周报",
+        generated_at="2026-07-20T08:05:00Z",
+        period_window={
+            "start_at": "2026-07-13T00:00:00Z",
+            "end_at": "2026-07-20T00:00:00Z",
+        },
+        profile={"profile_id": "weekly_progress", "profile_version": "v1"},
+        sources=[chinese],
+        editorial={"language": "zh-CN"},
+    )
+    artifacts = [
+        render_periodic_report_markdown(document),
+        render_periodic_report_html(document),
+    ]
+    for artifact in artifacts:
+        assert "进展与成果" in artifact["content"]
+        assert "能力演进" in artifact["content"]
+        assert "支撑证据" in artifact["content"]
+        assert "Progress and outcomes" not in artifact["content"]
+        assert "Capability evolution" not in artifact["content"]
+        assert "Supporting evidence" not in artifact["content"]
+
+
+def test_project_progress_source_rejects_invalid_language() -> None:
+    with pytest.raises(ValueError, match="BCP-47-like"):
+        build_project_progress_periodic_report_source(
+            _projection(language="zh_CN")
         )
 
 


### PR DESCRIPTION
## Summary

- let the built-in `project_progress` source consume the profile-owned language and emit canonical English or Chinese section headings
- validate BCP-47-like language tags and include normalized language in snapshot identity so localized documents cannot share an ambiguous snapshot reference
- preserve English as the compatibility default; keep renderers, issue-fix adapters, and optional archive extensions unchanged

## Why this boundary

The source adapter owns project-progress semantics, while profiles own locale selection and renderers only present the canonical document. Localizing these headings in the source keeps the behavior reusable for any periodic-report project and avoids making it issue-fix-specific.

## Validation

- `uv run --no-sync ruff check loopx/capabilities/periodic_report/project_progress.py tests/capabilities/test_periodic_report_project_progress.py`
- 79 periodic-report capability, presentation, and extension tests passed before rebasing
- 41 focused periodic-report tests passed after rebasing onto the latest `origin/main`
- `loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard`: 14/14 selected checks passed, 0 warnings, 0 boundary hits
- deterministic local regeneration produced byte-identical repeated artifacts
- first-screen HTML preview approved by the owner

## Risk and compatibility

- omitted language remains English
- `zh` and `zh-*` select the Chinese vocabulary; other valid languages currently fall back to English
- no sink, scheduler, delivery, or OpenViking archive behavior changes

## Excluded from the PR

- local comparison reports and screenshots
- LoopX project state and control-plane evidence
- temporary environments and generated lockfiles
