### PR TITLE
Add explicit terminal policies for bounded Turn sequences

### DIFF
--- a/docs/reference/protocols/loopx-turn-v0.md
+++ b/docs/reference/protocols/loopx-turn-v0.md
@@ -240,6 +240,13 @@ adapter to start another Turn, and only under a predeclared maximum, shared
 total time budget, and no-feedback continuation policy. Every other validator
 status fails closed before writeback.
 
+Adapters that lack a separate terminal signal may declare a bounded `fixed-n`
+terminal policy. Under that policy, each successful independent validator call
+proves progress, while only a successful final configured Turn satisfies the
+sequence terminal postcondition. The default `validator` policy continues to
+interpret exit code `0` as terminal completion. The policy is explicit in
+public-safe runner prerequisites and never changes benchmark scoring.
+
 ## Turn Input
 
 The driver input is a small composition of existing contracts:

--- a/examples/skillsbench-loopx-turn-agent-cli-smoke.py
+++ b/examples/skillsbench-loopx-turn-agent-cli-smoke.py
@@ -409,6 +409,8 @@ def main() -> int:
             "4",
             "--loopx-turn-progress-exit-code",
             "10",
+            "--loopx-turn-terminal-policy",
+            "fixed-n",
         ]
     )
     runner_plan = build_plan(runner_args)
@@ -417,6 +419,7 @@ def main() -> int:
     assert "--loopx-turn-validation-command" in launch_command, launch_command
     assert "--loopx-turn-max-turns" in launch_command, launch_command
     assert "--loopx-turn-progress-exit-code" in launch_command, launch_command
+    assert "--loopx-turn-terminal-policy" in launch_command, launch_command
     assert "--loopx-workflow-lifecycle-checkpoint" not in launch_command, launch_command
     prerequisites = runner_plan.get("runner_prerequisites", {})
     assert prerequisites.get("loopx_turn_validation_configured") is True, prerequisites
@@ -427,6 +430,7 @@ def main() -> int:
     assert prerequisites.get("loopx_turn_progress_exit_code_configured") is True, (
         prerequisites
     )
+    assert prerequisites.get("loopx_turn_terminal_policy") == "fixed-n", prerequisites
 
     with tempfile.TemporaryDirectory(prefix="skillsbench-loopx-turn-success-") as value:
         success = _run_success(Path(value))

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -443,6 +443,7 @@ class CodexExecConfig:
     loopx_turn_validation_command: str | None = None
     loopx_turn_max_turns: int = 1
     loopx_turn_progress_exit_code: int = 10
+    loopx_turn_terminal_policy: str = "validator"
     loopx_case_goal_id: str = "skillsbench-case"
     loopx_case_agent_id: str = BENCHMARK_CASE_LOOPX_AGENT_ID
     loopx_case_todo_id: str = BENCHMARK_CASE_LOOPX_TODO_ID

--- a/loopx/benchmark_adapters/skillsbench_turn_route.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_route.py
@@ -106,6 +106,16 @@ def add_skillsbench_loopx_turn_arguments(parser: Any) -> None:
             "Exit 0 means terminal completion; every other code fails closed."
         ),
     )
+    parser.add_argument(
+        "--loopx-turn-terminal-policy",
+        choices=("validator", "fixed-n"),
+        default="validator",
+        help=(
+            "How a successful per-Turn validator closes a bounded sequence. "
+            "validator trusts exit 0 as terminal; fixed-n treats successful "
+            "steps as progress until the configured final Turn."
+        ),
+    )
 
 
 def skillsbench_loopx_turn_runner_prerequisites(
@@ -114,6 +124,7 @@ def skillsbench_loopx_turn_runner_prerequisites(
     *,
     max_turns: Any = 1,
     progress_exit_code: Any = 10,
+    terminal_policy: Any = "validator",
 ) -> dict[str, Any]:
     enabled = route == "loopx-turn-agent-cli"
     return {
@@ -139,6 +150,11 @@ def skillsbench_loopx_turn_runner_prerequisites(
             and isinstance(progress_exit_code, int)
             and not isinstance(progress_exit_code, bool)
             and 1 <= progress_exit_code <= 255
+        ),
+        "loopx_turn_terminal_policy": (
+            terminal_policy
+            if enabled and terminal_policy in {"validator", "fixed-n"}
+            else "not_applicable"
         ),
     }
 
@@ -262,6 +278,7 @@ def _public_validation(value: Any) -> dict[str, Any]:
             "post_agent_postcondition_status",
             "baseline_contract",
             "sequence_stop_reason",
+            "terminal_policy",
         )
         if (label := _public_label(value.get(key), limit=120))
     }
@@ -363,6 +380,11 @@ def _aggregate_runner_readiness(receipts: list[dict[str, Any]]) -> dict[str, Any
 
 
 def _aggregate_validations(validations: list[dict[str, Any]]) -> dict[str, Any]:
+    terminal_policies = {
+        item["terminal_policy"]
+        for item in validations
+        if item.get("terminal_policy") in {"validator", "fixed-n"}
+    }
     aggregate = {
         "schema_version": "skillsbench_scored_workspace_validation_v0",
         "status": (
@@ -401,6 +423,8 @@ def _aggregate_validations(validations: list[dict[str, Any]]) -> dict[str, Any]:
         ),
         "turn_count": len(validations),
     }
+    if len(terminal_policies) == 1:
+        aggregate["terminal_policy"] = terminal_policies.pop()
     if validations and validations[-1].get("sequence_stop_reason"):
         aggregate["sequence_stop_reason"] = validations[-1]["sequence_stop_reason"]
     return aggregate
@@ -545,5 +569,13 @@ def skillsbench_loopx_turn_launch_error(args: Any) -> dict[str, Any] | None:
             "error_type": "SkillsBenchLoopXTurnProgressExitCodeInvalid",
             "reason": "validated progress requires a private exit code from 1 to 255",
             "next_action": "configure --loopx-turn-progress-exit-code from 1 to 255",
+        }
+    terminal_policy = getattr(args, "loopx_turn_terminal_policy", "validator")
+    if terminal_policy not in {"validator", "fixed-n"}:
+        return {
+            **common,
+            "error_type": "SkillsBenchLoopXTurnTerminalPolicyInvalid",
+            "reason": "LoopX Turn terminal policy must be validator or fixed-n",
+            "next_action": "configure --loopx-turn-terminal-policy explicitly",
         }
     return None

--- a/loopx/benchmark_adapters/skillsbench_turn_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_runtime.py
@@ -36,6 +36,7 @@ SKILLSBENCH_BRIDGE_OPERATION_SCHEMA_VERSION = (
     "skillsbench_remote_command_file_bridge_operation_response_v0"
 )
 SKILLSBENCH_TURN_BASELINE_ENV = "LOOPX_TURN_BASELINE_FILE"
+SKILLSBENCH_LOOPX_TURN_TERMINAL_POLICIES = frozenset({"validator", "fixed-n"})
 
 AgentPromptRunner = Callable[[str], str]
 PublicTraceWriter = Callable[[dict[str, Any]], None]
@@ -59,6 +60,7 @@ class SkillsBenchTurnRuntimeConfig:
     agent_timeout_seconds: float = 7200.0
     max_turns: int = 1
     progress_exit_code: int = 10
+    terminal_policy: str = "validator"
     case_cli_path: str = "/app/.local/bin/loopx"
     case_registry_path: str = "/app/.loopx/registry.json"
     case_runtime_root: str = "/app/.loopx/runtime"
@@ -323,6 +325,7 @@ def run_skillsbench_loopx_turn(
     agent_runner: AgentPromptRunner,
     config: SkillsBenchTurnRuntimeConfig,
     turn_instance_id: str | None = None,
+    sequence_step_kind: str = "validator",
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     """Execute one real Turn and return its receipt plus compact validation."""
 
@@ -334,6 +337,10 @@ def run_skillsbench_loopx_turn(
         )
     if not 1 <= config.progress_exit_code <= 255:
         raise ValueError("SkillsBench progress exit code must be between 1 and 255")
+    if config.terminal_policy not in SKILLSBENCH_LOOPX_TURN_TERMINAL_POLICIES:
+        raise ValueError("SkillsBench terminal policy must be validator or fixed-n")
+    if sequence_step_kind not in {"validator", "progress", "terminal"}:
+        raise ValueError("SkillsBench sequence step kind was unsupported")
     bridge = SkillsBenchTurnBridge(config)
     plan = (
         _turn_plan(bridge, config, turn_instance_id=turn_instance_id)
@@ -382,20 +389,26 @@ def run_skillsbench_loopx_turn(
                 "exit_code": 1,
             }
         exit_code = validation_result.get("exit_code")
-        if exit_code == config.progress_exit_code:
-            return {
-                "status": "progress",
-                "validator_kind": "skillsbench_scored_workspace_command",
-                "summary": "independent scored-workspace progress validation passed",
-                "exit_code": exit_code,
-            }
-        if exit_code != 0:
+        validation_succeeded = exit_code in {0, config.progress_exit_code}
+        if not validation_succeeded:
             return {
                 "status": "failed",
                 "validator_kind": "skillsbench_scored_workspace_command",
                 "summary": "independent scored-workspace validation returned non-zero",
                 "recovery_kind": "repair_required",
                 "exit_code": exit_code,
+            }
+        effective_step_kind = sequence_step_kind
+        if effective_step_kind == "validator":
+            effective_step_kind = (
+                "progress" if exit_code == config.progress_exit_code else "terminal"
+            )
+        if effective_step_kind == "progress":
+            return {
+                "status": "progress",
+                "validator_kind": "skillsbench_scored_workspace_command",
+                "summary": "independent scored-workspace progress validation passed",
+                "exit_code": config.progress_exit_code,
             }
         return {
             "status": "passed",
@@ -494,6 +507,7 @@ def run_skillsbench_loopx_turn(
         ),
         "validated_progress": validated_progress,
         "terminal_complete": terminal_complete,
+        "terminal_policy": config.terminal_policy,
         "baseline_contract": "task_declared_independent_postcondition",
         "oracle_feedback_used": False,
         "meaningful_operation_count": bridge.meaningful_operation_count,
@@ -515,6 +529,8 @@ def run_skillsbench_loopx_turn_sequence(
 
     if config.max_turns < 1:
         raise ValueError("SkillsBench LoopX Turn max_turns must be at least 1")
+    if config.terminal_policy not in SKILLSBENCH_LOOPX_TURN_TERMINAL_POLICIES:
+        raise ValueError("SkillsBench terminal policy must be validator or fixed-n")
     sequence_id = uuid.uuid4().hex[:16]
     deadline = time.monotonic() + max(1.0, config.agent_timeout_seconds)
     records: list[tuple[dict[str, Any], dict[str, Any]]] = []
@@ -527,11 +543,17 @@ def run_skillsbench_loopx_turn_sequence(
         turn_prompt = (
             prompt if turn_index == 1 else SKILLSBENCH_LOOPX_TURN_CONTINUATION_PROMPT
         )
+        sequence_step_kind = "validator"
+        if config.terminal_policy == "fixed-n":
+            sequence_step_kind = (
+                "terminal" if turn_index == config.max_turns else "progress"
+            )
         execution, validation = run_skillsbench_loopx_turn(
             prompt=turn_prompt,
             agent_runner=agent_runner,
             config=replace(config, agent_timeout_seconds=remaining_seconds),
             turn_instance_id=f"{sequence_id}-turn-{turn_index:03d}",
+            sequence_step_kind=sequence_step_kind,
         )
         validation["turn_index"] = turn_index
         records.append((execution, validation))
@@ -555,6 +577,7 @@ def run_skillsbench_loopx_turn_sequence(
         "status": stop_reason,
         "turn_count": len(records),
         "max_turns": config.max_turns,
+        "terminal_policy": config.terminal_policy,
         "terminal_complete": stop_reason == "terminal_complete",
         "official_feedback_blinded": True,
         "reward_feedback_forwarded": False,
@@ -728,10 +751,15 @@ def run_skillsbench_loopx_turn_relay(
         raise RuntimeError("LoopX Turn requires a compact public trace directory")
     max_turns = int(getattr(relay_config, "loopx_turn_max_turns", 1))
     progress_exit_code = int(getattr(relay_config, "loopx_turn_progress_exit_code", 10))
+    terminal_policy = str(
+        getattr(relay_config, "loopx_turn_terminal_policy", "validator")
+    )
     if max_turns < 1:
         raise RuntimeError("LoopX Turn max Turns must be at least one")
     if not 1 <= progress_exit_code <= 255:
         raise RuntimeError("LoopX Turn progress exit code must be between 1 and 255")
+    if terminal_policy not in SKILLSBENCH_LOOPX_TURN_TERMINAL_POLICIES:
+        raise RuntimeError("LoopX Turn terminal policy must be validator or fixed-n")
     runtime_session = (
         "".join(
             char if char.isalnum() or char in "_.:-" else "_" for char in session_id
@@ -756,6 +784,7 @@ def run_skillsbench_loopx_turn_relay(
                 agent_timeout_seconds=max(1.0, float(relay_config.timeout_sec)),
                 max_turns=max_turns,
                 progress_exit_code=progress_exit_code,
+                terminal_policy=terminal_policy,
                 case_cli_path=relay_config.loopx_case_cli_path,
                 case_registry_path=relay_config.loopx_case_registry_path,
                 case_runtime_root=relay_config.loopx_case_runtime_root,

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -67,6 +67,8 @@ Optional env:
   SKILLSBENCH_LOOPX_TURN_PROGRESS_EXIT_CODE
                                        Validator code for intermediate progress,
                                        default 10; 0 remains terminal completion
+  SKILLSBENCH_LOOPX_TURN_TERMINAL_POLICY
+                                       validator (default) or fixed-n
   SKILLSBENCH_BUILD_STALL_TIMEOUT_SEC  Setup stall timeout, default 3600;
                                        0 disables cap
   SKILLSBENCH_RUN_TIMEOUT_SEC          Supervisor timeout, default 28800
@@ -210,6 +212,7 @@ remote_command_file_bridge_agent_command_instrumented="${SKILLSBENCH_REMOTE_COMM
 loopx_turn_validation_command="${SKILLSBENCH_LOOPX_TURN_VALIDATION_COMMAND:-}"
 loopx_turn_max_turns="${SKILLSBENCH_LOOPX_TURN_MAX_TURNS:-1}"
 loopx_turn_progress_exit_code="${SKILLSBENCH_LOOPX_TURN_PROGRESS_EXIT_CODE:-10}"
+loopx_turn_terminal_policy="${SKILLSBENCH_LOOPX_TURN_TERMINAL_POLICY:-validator}"
 validate_bool_toggle() {
   local env_name="$1"
   local value="$2"
@@ -284,6 +287,11 @@ if [[ "$route" == "loopx-turn-agent-cli" ]]; then
   if [[ ! "$loopx_turn_progress_exit_code" =~ ^[1-9][0-9]*$ ]] ||
     ((10#$loopx_turn_progress_exit_code > 255)); then
     echo "SKILLSBENCH_LOOPX_TURN_PROGRESS_EXIT_CODE must be between 1 and 255" >&2
+    exit 2
+  fi
+  if [[ "$loopx_turn_terminal_policy" != "validator" ]] &&
+    [[ "$loopx_turn_terminal_policy" != "fixed-n" ]]; then
+    echo "SKILLSBENCH_LOOPX_TURN_TERMINAL_POLICY must be validator or fixed-n" >&2
     exit 2
   fi
 fi
@@ -435,6 +443,8 @@ if [[ "$route" == "loopx-turn-agent-cli" ]]; then
     "$loopx_turn_max_turns"
     --loopx-turn-progress-exit-code
     "$loopx_turn_progress_exit_code"
+    --loopx-turn-terminal-policy
+    "$loopx_turn_terminal_policy"
   )
 fi
 if [[ -n "${SKILLSBENCH_REGISTRY:-}" ]]; then
@@ -594,6 +604,7 @@ if [[ "$dry_run" == "true" ]]; then
     "$([[ -n "$loopx_turn_validation_command" ]] && echo 1 || echo 0)"
   printf 'loopx_turn_max_turns=%s\n' "$loopx_turn_max_turns"
   printf 'loopx_turn_progress_exit_code=%s\n' "$loopx_turn_progress_exit_code"
+  printf 'loopx_turn_terminal_policy=%s\n' "$loopx_turn_terminal_policy"
   printf 'skip_global_ledger_sync=%s\n' "$skip_global_ledger_sync"
   printf 'skip_current_aggregate_update=%s\n' "$skip_current_aggregate_update"
   printf 'local_run_ledger=%s\n' "$local_run_ledger"
@@ -619,6 +630,8 @@ if [[ "$dry_run" == "true" ]]; then
       printf '%s ' --loopx-turn-validation-command
     [[ "$route" == "loopx-turn-agent-cli" ]] &&
       printf '%s ' --loopx-turn-max-turns --loopx-turn-progress-exit-code
+    [[ "$route" == "loopx-turn-agent-cli" ]] &&
+      printf '%s ' --loopx-turn-terminal-policy
     printf '\n'
     printf 'remote_command=<redacted-private-runner-command-values>\n'
     printf 'supervisor_command=<redacted-private-runner-command-values>\n'

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -1070,6 +1070,8 @@ def _host_local_acp_launch_command(
                 str(getattr(args, "loopx_turn_max_turns", 1)),
                 "--loopx-turn-progress-exit-code",
                 str(getattr(args, "loopx_turn_progress_exit_code", 10)),
+                "--loopx-turn-terminal-policy",
+                str(getattr(args, "loopx_turn_terminal_policy", "validator")),
             ]
         )
     if (
@@ -8942,6 +8944,9 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
                 max_turns=getattr(args, "loopx_turn_max_turns", 1),
                 progress_exit_code=getattr(
                     args, "loopx_turn_progress_exit_code", 10
+                ),
+                terminal_policy=getattr(
+                    args, "loopx_turn_terminal_policy", "validator"
                 ),
             ),
             "loopx_product_mode_lifecycle_driver_kind": (

--- a/scripts/skillsbench_local_acp_relay.py
+++ b/scripts/skillsbench_local_acp_relay.py
@@ -247,6 +247,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     )
     parser.add_argument("--loopx-turn-max-turns", type=int, default=1)
     parser.add_argument("--loopx-turn-progress-exit-code", type=int, default=10)
+    parser.add_argument(
+        "--loopx-turn-terminal-policy",
+        choices=("validator", "fixed-n"),
+        default="validator",
+    )
     parser.add_argument("--loopx-case-goal-id", default="skillsbench-case")
     parser.add_argument("--loopx-case-agent-id", default="codex-benchmark-agent")
     parser.add_argument("--loopx-case-todo-id", default=BENCHMARK_CASE_LOOPX_TODO_ID)
@@ -303,6 +308,7 @@ def main(argv: list[str] | None = None) -> int:
             loopx_turn_validation_command=args.loopx_turn_validation_command,
             loopx_turn_max_turns=args.loopx_turn_max_turns,
             loopx_turn_progress_exit_code=args.loopx_turn_progress_exit_code,
+            loopx_turn_terminal_policy=args.loopx_turn_terminal_policy,
             loopx_case_goal_id=args.loopx_case_goal_id,
             loopx_case_agent_id=args.loopx_case_agent_id,
             loopx_case_todo_id=args.loopx_case_todo_id,

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -50,6 +50,7 @@ def test_turn_launcher_wires_private_commands_without_echoing_values(
             "SKILLSBENCH_ROUTE": "loopx-turn-agent-cli",
             "SKILLSBENCH_LOOPX_TURN_MAX_TURNS": "4",
             "SKILLSBENCH_LOOPX_TURN_PROGRESS_EXIT_CODE": "10",
+            "SKILLSBENCH_LOOPX_TURN_TERMINAL_POLICY": "fixed-n",
             "SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_AGENT_COMMAND_INSTRUMENTED": (
                 "1"
             ),
@@ -74,6 +75,7 @@ def test_turn_launcher_wires_private_commands_without_echoing_values(
     assert "loopx_turn_validation_command_configured=1" in output
     assert "loopx_turn_max_turns=4" in output
     assert "loopx_turn_progress_exit_code=10" in output
+    assert "loopx_turn_terminal_policy=fixed-n" in output
     assert "private_runner_command_values_redacted=true" in output
     for arg_name in (
         "--remote-command-file-bridge-probe-command",
@@ -83,6 +85,7 @@ def test_turn_launcher_wires_private_commands_without_echoing_values(
         "--loopx-turn-validation-command",
         "--loopx-turn-max-turns",
         "--loopx-turn-progress-exit-code",
+        "--loopx-turn-terminal-policy",
     ):
         assert arg_name in output
     for private_value in private_values.values():

--- a/tests/test_skillsbench_turn_runtime.py
+++ b/tests/test_skillsbench_turn_runtime.py
@@ -121,6 +121,60 @@ def test_satisfied_pre_agent_postcondition_runs_but_does_not_claim_readiness(
     assert "pre_agent_postcondition_unsatisfied" in receipt["blocker_codes"]
 
 
+def test_fixed_n_maps_accepted_exit_zero_to_nonterminal_progress(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class ProgressBridge:
+        def __init__(self, _config: Any) -> None:
+            self.meaningful_operation_count = 0
+
+        def exec(
+            self,
+            _command: str,
+            *,
+            meaningful: bool = False,
+            allow_nonzero: bool = False,
+        ) -> dict[str, Any]:
+            if allow_nonzero and not meaningful:
+                return {"ok": False, "exit_code": 3, "elapsed_ms": 1}
+            if meaningful:
+                self.meaningful_operation_count += 1
+            return {"ok": True, "exit_code": 0, "stdout": "", "elapsed_ms": 1}
+
+    def fake_turn_once(
+        plan: dict[str, Any],
+        *,
+        host_runner: Any,
+        task_validator: Any,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        result = host_runner({"turn_key": "synthetic-turn"})
+        return {
+            "status": "committed",
+            "validation": dict(task_validator(plan, result)),
+        }
+
+    monkeypatch.setattr(runtime, "SkillsBenchTurnBridge", ProgressBridge)
+    monkeypatch.setattr(runtime, "_turn_plan", lambda *_args: {"ok": True})
+    monkeypatch.setattr(runtime, "run_loopx_turn_once", fake_turn_once)
+
+    execution, validation = runtime.run_skillsbench_loopx_turn(
+        prompt="synthetic progress prompt",
+        agent_runner=lambda _prompt: "done",
+        config=runtime.SkillsBenchTurnRuntimeConfig(
+            **{**_config(tmp_path).__dict__, "terminal_policy": "fixed-n"}
+        ),
+        sequence_step_kind="progress",
+    )
+
+    assert execution["validation"]["status"] == "progress"
+    assert execution["validation"]["exit_code"] == 10
+    assert validation["validated_progress"] is True
+    assert validation["terminal_complete"] is False
+    assert validation["terminal_policy"] == "fixed-n"
+
+
 def test_unsatisfied_baseline_then_satisfied_postcondition_is_runner_ready(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -529,6 +583,45 @@ def test_adaptive_sequence_stops_on_missing_progress_or_fixed_maximum(
     assert sequence["status"] == expected_reason
 
 
+def test_fixed_n_sequence_promotes_only_final_validated_step_to_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    step_kinds: list[str] = []
+
+    def fake_turn(**kwargs: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+        step_kind = kwargs["sequence_step_kind"]
+        step_kinds.append(step_kind)
+        terminal = step_kind == "terminal"
+        return (
+            {"status": "committed"},
+            {
+                "status": "passed",
+                "validated_progress": True,
+                "terminal_complete": terminal,
+            },
+        )
+
+    monkeypatch.setattr(runtime, "run_skillsbench_loopx_turn", fake_turn)
+
+    records, sequence = runtime.run_skillsbench_loopx_turn_sequence(
+        prompt="original task prompt",
+        agent_runner=lambda _prompt: "done",
+        config=runtime.SkillsBenchTurnRuntimeConfig(
+            **{
+                **_config(tmp_path).__dict__,
+                "max_turns": 3,
+                "terminal_policy": "fixed-n",
+            }
+        ),
+    )
+
+    assert step_kinds == ["progress", "progress", "terminal"]
+    assert len(records) == 3
+    assert sequence["status"] == "terminal_complete"
+    assert sequence["terminal_policy"] == "fixed-n"
+
+
 @pytest.mark.parametrize(
     ("execution_status", "baseline_status", "post_status", "blocker"),
     [
@@ -582,6 +675,7 @@ def test_runner_readiness_survives_public_trace_aggregation() -> None:
             "pre_agent_postcondition_status": "unsatisfied",
             "post_agent_postcondition_status": "satisfied",
             "baseline_contract": "task_declared_independent_postcondition",
+            "terminal_policy": "fixed-n",
             "oracle_feedback_used": False,
         },
     )
@@ -598,6 +692,7 @@ def test_runner_readiness_survives_public_trace_aggregation() -> None:
             "pre_agent_postcondition_status": "already_satisfied",
             "post_agent_postcondition_status": "satisfied",
             "baseline_contract": "task_declared_independent_postcondition",
+            "terminal_policy": "fixed-n",
             "oracle_feedback_used": False,
         },
     )
@@ -624,3 +719,4 @@ def test_runner_readiness_survives_public_trace_aggregation() -> None:
     assert (
         compact["scored_workspace_validation"]["raw_validator_output_recorded"] is False
     )
+    assert compact["scored_workspace_validation"]["terminal_policy"] == "fixed-n"


### PR DESCRIPTION
## Summary
- add explicit validator and fixed-n terminal policies for bounded SkillsBench Turn sequences
- preserve the selected policy through relay, runner prerequisites, and compact validation aggregation
- document and test progress-gated fixed-N behavior without changing benchmark scoring

## Validation
- 17 focused pytest tests passed
- durable SkillsBench Turn smoke passed without invoking a model or remote job
- focused Ruff, Python compile, bash syntax, and diff checks passed
- LoopX premerge ran 15 automated checks with 0 failures; public boundary passed
- expected manual hold: benchmark-sensitive adapter paths; owner authorized self-review and self-merge for benchmark code

## Boundary
No raw tasks, trajectories, verifier output, credentials, private paths, or benchmark jobs are included.