### PR TITLE
Support Debian apt mirror staging for SkillsBench

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -5638,6 +5638,42 @@ def test_skillsbench_docker_task_staging_adds_app_skills_mount() -> None:
         assert f"!{DOCKER_APP_SKILLS_MOUNT_KEEP_FILE}" in staged_dockerignore
 
 
+def test_skillsbench_docker_task_staging_adds_debian_apt_mirror_patch() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-debian-apt-stage-") as tmp:
+        root = Path(tmp)
+        task = root / "tasks" / "debian-apt-probe"
+        dockerfile = task / "environment" / "Dockerfile"
+        dockerfile.parent.mkdir(parents=True)
+        original_text = (
+            "FROM debian:bookworm\n\n"
+            "RUN apt-get update && apt-get install -y --no-install-recommends curl\n"
+        )
+        dockerfile.write_text(original_text, encoding="utf-8")
+        (task / "task.toml").write_text("version = \"1.1\"\n", encoding="utf-8")
+
+        staged_path, metadata = stage_task_for_sandbox(
+            task_path=task,
+            jobs_dir=root / "jobs",
+            job_name="debian-apt-probe",
+            sandbox="docker",
+        )
+
+        assert metadata["staged"] is True, metadata
+        assert metadata["dockerfile_debian_apt_mirror_patch_required"] is True
+        assert metadata["dockerfile_debian_apt_mirror_patch_applied"] is True
+        assert metadata["dockerfile_debian_apt_mirror_host"] == (
+            dockerfile_runtime.DEFAULT_DEBIAN_APT_MIRROR_HOST
+        )
+        assert metadata["dockerfile_debian_apt_mirror_raw_url_recorded"] is False
+        assert metadata["original_task_mutated"] is False, metadata
+        assert dockerfile.read_text(encoding="utf-8") == original_text
+        staged_text = (staged_path / "environment" / "Dockerfile").read_text(
+            encoding="utf-8"
+        )
+        assert dockerfile_runtime.DEBIAN_APT_MIRROR_BEGIN in staged_text
+        assert "LOOPX_SKILLSBENCH_DEBIAN_APT_MIRROR" in staged_text
+
+
 def test_skillsbench_no_skill_route_removes_staged_task_skills() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-no-skill-stage-") as tmp:
         root = Path(tmp)
@@ -14739,6 +14775,7 @@ if __name__ == "__main__":
     test_skillsbench_codex_acp_post_success_trace_recovers_score()
     test_skillsbench_codex_acp_post_success_finalization_route()
     test_skillsbench_docker_task_staging_adds_app_skills_mount()
+    test_skillsbench_docker_task_staging_adds_debian_apt_mirror_patch()
     test_skillsbench_no_skill_route_removes_staged_task_skills()
     test_skillsbench_docker_task_staging_adds_apt_retry_patch()
     test_skillsbench_docker_task_staging_apt_retry_is_nonroot_safe()

--- a/loopx/benchmark_adapters/skillsbench_dockerfile_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_dockerfile_runtime.py
@@ -8,8 +8,15 @@ from pathlib import Path
 VENV_PIP_INVOCATION_MARKER = "# LOOPX_SKILLSBENCH_VENV_PIP_INVOCATION"
 UBUNTU_APT_MIRROR_BEGIN = "# BEGIN LOOPX_SKILLSBENCH_UBUNTU_APT_MIRROR"
 UBUNTU_APT_MIRROR_END = "# END LOOPX_SKILLSBENCH_UBUNTU_APT_MIRROR"
+DEBIAN_APT_MIRROR_BEGIN = "# BEGIN LOOPX_SKILLSBENCH_DEBIAN_APT_MIRROR"
+DEBIAN_APT_MIRROR_END = "# END LOOPX_SKILLSBENCH_DEBIAN_APT_MIRROR"
 DEFAULT_UBUNTU_APT_MIRROR_BASE = "https://repo.huaweicloud.com/ubuntu"
 DEFAULT_UBUNTU_APT_MIRROR_HOST = "repo.huaweicloud.com"
+DEFAULT_DEBIAN_APT_MIRROR_BASE = "https://mirrors.tuna.tsinghua.edu.cn/debian"
+DEFAULT_DEBIAN_SECURITY_MIRROR_BASE = (
+    "https://mirrors.tuna.tsinghua.edu.cn/debian-security"
+)
+DEFAULT_DEBIAN_APT_MIRROR_HOST = "mirrors.tuna.tsinghua.edu.cn"
 _BARE_PIP_INSTALL_RE = re.compile(
     r"(?P<prefix>^\s*(?:RUN\s+)?|(?:&&|\|\||;|\|)\s*)pip3?\s+install\b",
     re.IGNORECASE,
@@ -75,6 +82,23 @@ def needs_ubuntu_apt_mirror_patch(dockerfile: Path) -> bool:
     return _stage_has_apt_update(text.splitlines())
 
 
+def needs_debian_apt_mirror_patch(dockerfile: Path) -> bool:
+    """Return whether a Dockerfile stage runs apt update.
+
+    The staged patch rewrites only Debian source files present in the image, so
+    Ubuntu and other apt-based images are left unchanged by the injected block.
+    """
+
+    if not dockerfile.exists():
+        return False
+    text = _strip_marker_blocks(
+        dockerfile.read_text(encoding="utf-8", errors="replace"),
+        DEBIAN_APT_MIRROR_BEGIN,
+        DEBIAN_APT_MIRROR_END,
+    )
+    return _stage_has_apt_update(text.splitlines())
+
+
 def _ubuntu_apt_mirror_block() -> list[str]:
     return [
         UBUNTU_APT_MIRROR_BEGIN,
@@ -92,6 +116,31 @@ def _ubuntu_apt_mirror_block() -> list[str]:
         "      echo 'loopx Ubuntu apt mirror skipped: apt directory is not writable'; \\",
         "    fi",
         UBUNTU_APT_MIRROR_END,
+    ]
+
+
+def _debian_apt_mirror_block() -> list[str]:
+    return [
+        DEBIAN_APT_MIRROR_BEGIN,
+        f"ARG LOOPX_SKILLSBENCH_DEBIAN_APT_MIRROR={DEFAULT_DEBIAN_APT_MIRROR_BASE}",
+        (
+            "ARG LOOPX_SKILLSBENCH_DEBIAN_SECURITY_MIRROR="
+            f"{DEFAULT_DEBIAN_SECURITY_MIRROR_BASE}"
+        ),
+        "RUN set -eux; \\",
+        "    if [ -d /etc/apt ] && [ -w /etc/apt ]; then \\",
+        "      find /etc/apt -type f \\",
+        "        \\( -name '*.list' -o -name '*.sources' \\) \\",
+        "        -exec sed -i \\",
+        '          -e "s#https\\?://deb.debian.org/debian-security#${LOOPX_SKILLSBENCH_DEBIAN_SECURITY_MIRROR}#g" \\',
+        '          -e "s#https\\?://security.debian.org/debian-security#${LOOPX_SKILLSBENCH_DEBIAN_SECURITY_MIRROR}#g" \\',
+        '          -e "s#https\\?://deb.debian.org/debian#${LOOPX_SKILLSBENCH_DEBIAN_APT_MIRROR}#g" \\',
+        "          {} +; \\",
+        "      if [ -w /var/lib/apt/lists ]; then rm -rf /var/lib/apt/lists/*; fi; \\",
+        "    else \\",
+        "      echo 'loopx Debian apt mirror skipped: apt directory is not writable'; \\",
+        "    fi",
+        DEBIAN_APT_MIRROR_END,
     ]
 
 
@@ -129,6 +178,53 @@ def patch_ubuntu_apt_mirror(dockerfile: Path) -> bool:
         ):
             patched_lines.extend(
                 [stage_lines[0], "", *_ubuntu_apt_mirror_block(), "", *stage_lines[1:]]
+            )
+            applied = True
+        else:
+            patched_lines.extend(stage_lines)
+    if not applied:
+        return False
+    patched = "\n".join(patched_lines).rstrip() + "\n"
+    if patched == original:
+        return False
+    _write_text_atomic(dockerfile, patched)
+    return True
+
+
+def patch_debian_apt_mirror(dockerfile: Path) -> bool:
+    """Add a staged-only Debian apt mirror fallback to apt-using stages."""
+
+    if not dockerfile.exists():
+        return False
+    original = dockerfile.read_text(encoding="utf-8", errors="replace")
+    if DEBIAN_APT_MIRROR_BEGIN in original and DEBIAN_APT_MIRROR_END in original:
+        return False
+    text = _strip_marker_blocks(
+        original,
+        DEBIAN_APT_MIRROR_BEGIN,
+        DEBIAN_APT_MIRROR_END,
+    )
+    lines = text.splitlines()
+    stage_starts = _dockerfile_stage_starts(lines)
+    if not stage_starts:
+        return False
+
+    patched_lines = lines[: stage_starts[0]]
+    applied = False
+    for position, start in enumerate(stage_starts):
+        end = (
+            stage_starts[position + 1]
+            if position + 1 < len(stage_starts)
+            else len(lines)
+        )
+        stage_lines = lines[start:end]
+        from_line = stage_lines[0].strip().lower()
+        if _stage_has_apt_update(stage_lines) and not re.match(
+            r"from(?:\s+--platform=\S+)?\s+scratch(?:\s|$)",
+            from_line,
+        ):
+            patched_lines.extend(
+                [stage_lines[0], "", *_debian_apt_mirror_block(), "", *stage_lines[1:]]
             )
             applied = True
         else:

--- a/loopx/benchmark_adapters/skillsbench_failure_signals.py
+++ b/loopx/benchmark_adapters/skillsbench_failure_signals.py
@@ -107,6 +107,13 @@ _FAILURE_REASON_PATTERNS = (
     ("http_not_found", r"(?:http[^\n]*\s404\b|404 not found)"),
     ("http_server_error", r"(?:http[^\n]*\s5\d\d\b|5\d\d server error)"),
     ("apt_fetch_failed", r"failed to fetch"),
+    ("apt_no_pubkey", r"\bno_pubkey\b"),
+    (
+        "apt_invalid_signature",
+        r"invalid signature|at least one invalid signature was encountered",
+    ),
+    ("apt_unsigned_repository", r"repository .* is not signed"),
+    ("apt_clearsigned_invalid", r"clearsigned file isn.t valid"),
     (
         "apt_signature_or_gpg",
         r"gpg error|no_pubkey|signatures? couldn.t be verified|"
@@ -178,6 +185,10 @@ _DETERMINISTIC_FAILURE_REASONS = {
 }
 
 _APT_FAILURE_SUBTYPE_REASON_PRIORITY = (
+    ("apt_no_pubkey", "missing_public_key"),
+    ("apt_invalid_signature", "invalid_signature"),
+    ("apt_unsigned_repository", "unsigned_repository"),
+    ("apt_clearsigned_invalid", "clearsigned_invalid"),
     ("apt_signature_or_gpg", "signature_or_gpg"),
     ("apt_hash_mismatch", "hash_or_size_mismatch"),
     ("apt_release_expired", "release_metadata"),

--- a/loopx/benchmark_adapters/skillsbench_failure_signals.py
+++ b/loopx/benchmark_adapters/skillsbench_failure_signals.py
@@ -112,12 +112,12 @@ _FAILURE_REASON_PATTERNS = (
         "apt_invalid_signature",
         r"invalid signature|at least one invalid signature was encountered",
     ),
-    ("apt_unsigned_repository", r"repository .* is not signed"),
+    ("apt_unsigned_repository", r"repository(?:\s+\S+)?\s+is not signed"),
     ("apt_clearsigned_invalid", r"clearsigned file isn.t valid"),
     (
         "apt_signature_or_gpg",
         r"gpg error|no_pubkey|signatures? couldn.t be verified|"
-        r"repository .* is not signed|clearsigned file isn.t valid",
+        r"repository(?:\s+\S+)?\s+is not signed|clearsigned file isn.t valid",
     ),
     (
         "apt_hash_mismatch",

--- a/loopx/benchmark_adapters/skillsbench_setup_preflight.py
+++ b/loopx/benchmark_adapters/skillsbench_setup_preflight.py
@@ -13,6 +13,55 @@ from .skillsbench_failure_signals import (
 SCHEMA_VERSION = "skillsbench_setup_only_public_preflight_v0"
 COMPOSE_TYPED_CAUSE_SCHEMA_VERSION = "skillsbench_compose_typed_cause_v0"
 _PATCH_SUFFIX = "_patch_applied"
+_PUBLIC_TASK_STAGING_BOOL_FIELDS = (
+    "staged",
+    "apt_retry_patch_applied",
+    "dockerfile_ubuntu_apt_mirror_patch_required",
+    "dockerfile_ubuntu_apt_mirror_patch_applied",
+    "dockerfile_ubuntu_apt_mirror_raw_url_recorded",
+    "dockerfile_debian_apt_mirror_patch_required",
+    "dockerfile_debian_apt_mirror_patch_applied",
+    "dockerfile_debian_apt_mirror_raw_url_recorded",
+    "dockerfile_pip_bootstrap_patch_required",
+    "dockerfile_pip_bootstrap_patch_applied",
+    "dockerfile_venv_pip_invocation_patch_required",
+    "dockerfile_venv_pip_invocation_patch_applied",
+    "dockerfile_gcr_mirror_patch_required",
+    "dockerfile_gcr_mirror_patch_applied",
+    "dockerfile_gcr_mirror_raw_prefix_recorded",
+    "dockerfile_wget_gpg_key_retry_patch_required",
+    "dockerfile_wget_gpg_key_retry_patch_applied",
+    "dockerfile_network_download_retry_patch_required",
+    "dockerfile_network_download_retry_patch_applied",
+    "dockerfile_uv_bootstrap_mirror_patch_required",
+    "dockerfile_uv_bootstrap_mirror_patch_applied",
+    "dockerfile_apache_archive_mirror_patch_required",
+    "dockerfile_apache_archive_mirror_patch_applied",
+    "dockerfile_apache_archive_raw_url_recorded",
+    "dockerfile_maven_mirror_patch_required",
+    "dockerfile_maven_mirror_patch_applied",
+    "dockerfile_maven_mirror_raw_url_recorded",
+    "benchmark_egress_proxy_dockerfile_env_patch_required",
+    "benchmark_egress_proxy_dockerfile_env_patch_applied",
+    "benchmark_egress_proxy_dockerfile_env_raw_proxy_recorded",
+    "verifier_uv_bootstrap_mirror_patch_required",
+    "verifier_uv_bootstrap_mirror_patch_applied",
+    "verifier_dependency_cache_required",
+    "verifier_dependency_cache_env_patch_applied",
+    "verifier_dependency_cache_raw_path_recorded",
+)
+_PUBLIC_TASK_STAGING_STRING_FIELDS = (
+    "schema_version",
+    "dockerfile_ubuntu_apt_mirror_host",
+    "dockerfile_debian_apt_mirror_host",
+    "dockerfile_pip_index_host",
+    "dockerfile_uv_bootstrap_version",
+    "dockerfile_uv_bootstrap_mirror_host",
+    "dockerfile_apache_archive_mirror_host",
+    "dockerfile_maven_mirror_host",
+    "verifier_uv_bootstrap_version",
+    "verifier_uv_bootstrap_mirror_host",
+)
 
 
 class SkillsBenchComposeCommandFailure(RuntimeError):
@@ -78,6 +127,20 @@ def _patch_hits(task_staging: Mapping[str, Any] | None) -> list[str]:
     )
 
 
+def _public_task_staging(task_staging: Mapping[str, Any] | None) -> dict[str, Any]:
+    staging = task_staging or {}
+    public: dict[str, Any] = {}
+    for field in _PUBLIC_TASK_STAGING_STRING_FIELDS:
+        value = staging.get(field)
+        if isinstance(value, str) and value:
+            public[field] = value[:180]
+    for field in _PUBLIC_TASK_STAGING_BOOL_FIELDS:
+        value = staging.get(field)
+        if isinstance(value, bool):
+            public[field] = value
+    return public
+
+
 def _exit_category(exc: Exception, matched_patterns: set[str]) -> str:
     if (
         isinstance(exc, (asyncio.TimeoutError, TimeoutError))
@@ -135,6 +198,7 @@ def _base_result(
         "compose_typed_cause_boundary_installed": False,
         "compose_typed_cause_boundary_restored": False,
         "patch_hits": _patch_hits(task_staging),
+        "task_staging": _public_task_staging(task_staging),
         "apt_setup_risk_detected": setup.get("apt_setup_risk_detected") is True,
         "dockerfile_pip_install_risk_detected": (
             setup.get("dockerfile_pip_install_risk_detected") is True

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -5785,6 +5785,9 @@ def _public_task_staging(value: Any) -> dict[str, Any]:
         "dockerfile_ubuntu_apt_mirror_patch_required",
         "dockerfile_ubuntu_apt_mirror_patch_applied",
         "dockerfile_ubuntu_apt_mirror_raw_url_recorded",
+        "dockerfile_debian_apt_mirror_patch_required",
+        "dockerfile_debian_apt_mirror_patch_applied",
+        "dockerfile_debian_apt_mirror_raw_url_recorded",
         "dockerfile_pip_install_risk_detected",
         "dockerfile_pip_bootstrap_patch_required",
         "dockerfile_pip_bootstrap_patch_applied",
@@ -5855,6 +5858,7 @@ def _public_task_staging(value: Any) -> dict[str, Any]:
         "dockerfile_apache_archive_mirror_host",
         "dockerfile_maven_mirror_host",
         "dockerfile_ubuntu_apt_mirror_host",
+        "dockerfile_debian_apt_mirror_host",
     ):
         raw = value.get(field)
         if isinstance(raw, str) and raw:
@@ -5943,6 +5947,15 @@ def _discover_prepared_task_staging(plan: dict[str, Any]) -> dict[str, Any]:
             else ""
         ),
         "dockerfile_ubuntu_apt_mirror_raw_url_recorded": False,
+        "dockerfile_debian_apt_mirror_patch_applied": (
+            dockerfile_runtime.DEBIAN_APT_MIRROR_BEGIN in dockerfile_text
+        ),
+        "dockerfile_debian_apt_mirror_host": (
+            dockerfile_runtime.DEFAULT_DEBIAN_APT_MIRROR_HOST
+            if dockerfile_runtime.DEBIAN_APT_MIRROR_BEGIN in dockerfile_text
+            else ""
+        ),
+        "dockerfile_debian_apt_mirror_raw_url_recorded": False,
         "dockerfile_pip_bootstrap_patch_applied": (
             DOCKER_PIP_BOOTSTRAP_BEGIN in dockerfile_text
         ),
@@ -7932,6 +7945,10 @@ def stage_task_for_sandbox(
         "dockerfile_ubuntu_apt_mirror_patch_applied": False,
         "dockerfile_ubuntu_apt_mirror_host": "",
         "dockerfile_ubuntu_apt_mirror_raw_url_recorded": False,
+        "dockerfile_debian_apt_mirror_patch_required": False,
+        "dockerfile_debian_apt_mirror_patch_applied": False,
+        "dockerfile_debian_apt_mirror_host": "",
+        "dockerfile_debian_apt_mirror_raw_url_recorded": False,
         "dockerfile_pip_install_risk_detected": False,
         "dockerfile_pip_bootstrap_patch_required": False,
         "dockerfile_pip_bootstrap_patch_applied": False,
@@ -8013,6 +8030,11 @@ def stage_task_for_sandbox(
             task_path / "environment" / "Dockerfile"
         )
     )
+    needs_debian_apt_mirror_patch = (
+        dockerfile_runtime.needs_debian_apt_mirror_patch(
+            task_path / "environment" / "Dockerfile"
+        )
+    )
     needs_pip_bootstrap_patch = dockerfile_needs_pip_bootstrap_patch(
         task_path / "environment" / "Dockerfile"
     )
@@ -8080,6 +8102,13 @@ def stage_task_for_sandbox(
     if needs_ubuntu_apt_mirror_patch:
         metadata["dockerfile_ubuntu_apt_mirror_host"] = (
             dockerfile_runtime.DEFAULT_UBUNTU_APT_MIRROR_HOST
+        )
+    metadata["dockerfile_debian_apt_mirror_patch_required"] = (
+        needs_debian_apt_mirror_patch
+    )
+    if needs_debian_apt_mirror_patch:
+        metadata["dockerfile_debian_apt_mirror_host"] = (
+            dockerfile_runtime.DEFAULT_DEBIAN_APT_MIRROR_HOST
         )
     metadata["dockerfile_pip_install_risk_detected"] = needs_pip_bootstrap_patch
     metadata["dockerfile_pip_bootstrap_patch_required"] = needs_pip_bootstrap_patch
@@ -8173,6 +8202,7 @@ def stage_task_for_sandbox(
         and not needs_resource_cap
         and not needs_apt_retry_patch
         and not needs_ubuntu_apt_mirror_patch
+        and not needs_debian_apt_mirror_patch
         and not needs_pip_bootstrap_patch
         and not needs_venv_pip_invocation_patch
         and not needs_gcr_mirror_patch
@@ -8240,6 +8270,9 @@ def stage_task_for_sandbox(
     ubuntu_apt_mirror_patched = dockerfile_runtime.patch_ubuntu_apt_mirror(
         staged_path / "environment" / "Dockerfile"
     )
+    debian_apt_mirror_patched = dockerfile_runtime.patch_debian_apt_mirror(
+        staged_path / "environment" / "Dockerfile"
+    )
     pip_bootstrap_patched = patch_dockerfile_pip_bootstrap(
         staged_path / "environment" / "Dockerfile"
     )
@@ -8305,6 +8338,15 @@ def stage_task_for_sandbox(
                 else ""
             ),
             "dockerfile_ubuntu_apt_mirror_raw_url_recorded": False,
+            "dockerfile_debian_apt_mirror_patch_applied": (
+                debian_apt_mirror_patched
+            ),
+            "dockerfile_debian_apt_mirror_host": (
+                dockerfile_runtime.DEFAULT_DEBIAN_APT_MIRROR_HOST
+                if debian_apt_mirror_patched
+                else ""
+            ),
+            "dockerfile_debian_apt_mirror_raw_url_recorded": False,
             "dockerfile_pip_bootstrap_patch_applied": pip_bootstrap_patched,
             "dockerfile_venv_pip_invocation_patch_applied": (
                 venv_pip_invocation_patched

--- a/tests/test_skillsbench_setup_preflight.py
+++ b/tests/test_skillsbench_setup_preflight.py
@@ -72,6 +72,10 @@ def run_preflight() -> dict[str, Any]:
             config=object(),
             task_staging={
                 "apt_retry_patch_applied": True,
+                "dockerfile_debian_apt_mirror_patch_required": True,
+                "dockerfile_debian_apt_mirror_patch_applied": True,
+                "dockerfile_debian_apt_mirror_host": "mirror.example",
+                "dockerfile_debian_apt_mirror_raw_url_recorded": False,
                 "dockerfile_pip_bootstrap_patch_applied": True,
                 "unrelated": "/private/should-not-project",
             },
@@ -98,8 +102,17 @@ def test_setup_only_preflight_stops_before_agent_and_verifier() -> None:
     assert result["verifier_invoked"] is False
     assert result["patch_hits"] == [
         "apt_retry",
+        "dockerfile_debian_apt_mirror",
         "dockerfile_pip_bootstrap",
     ]
+    assert result["task_staging"] == {
+        "apt_retry_patch_applied": True,
+        "dockerfile_debian_apt_mirror_patch_required": True,
+        "dockerfile_debian_apt_mirror_patch_applied": True,
+        "dockerfile_debian_apt_mirror_host": "mirror.example",
+        "dockerfile_debian_apt_mirror_raw_url_recorded": False,
+        "dockerfile_pip_bootstrap_patch_applied": True,
+    }
     assert FakeRollout.events == ["create", "setup", "start", "cleanup"]
     serialized = json.dumps(result, sort_keys=True)
     assert "/private/" not in serialized
@@ -312,9 +325,10 @@ def test_setup_only_preflight_consumes_compose_producer_typed_cause() -> None:
     assert result["failure_category"] == (
         "skillsbench_docker_compose_apt_repository_failure"
     )
-    assert result["apt_failure_subtype"] == "signature_or_gpg"
+    assert result["apt_failure_subtype"] == "unsigned_repository"
     assert result["terminal_failure_reason_codes"] == [
         "apt_fetch_failed",
+        "apt_unsigned_repository",
         "apt_signature_or_gpg",
     ]
     assert result["compose_typed_cause_boundary_installed"] is True
@@ -423,7 +437,17 @@ def test_setup_only_preflight_separates_terminal_reason_and_endpoint() -> None:
         ),
         (
             "apt-get update: GPG error: repository is not signed",
-            "signature_or_gpg",
+            "unsigned_repository",
+            "unknown",
+        ),
+        (
+            "apt-get update: NO_PUBKEY ABC123",
+            "missing_public_key",
+            "unknown",
+        ),
+        (
+            "apt-get update: At least one invalid signature was encountered",
+            "invalid_signature",
             "unknown",
         ),
         (


### PR DESCRIPTION
## Summary
- add staged-only Debian apt mirror patching alongside the existing Ubuntu apt mirror support
- project compact public task-staging fields into setup-only preflight artifacts
- split apt signature/GPG failures into public-safe subtypes such as unsigned repository, missing public key, and invalid signature

## Validation
- py_compile for changed Python modules and smokes
- examples/skillsbench-failure-attribution-smoke.py
- focused Debian apt mirror staging smoke
- examples/skillsbench-benchmark-run-smoke.py
- ECS setup-only public preflight at exact head 75ac122b: patch application is publicly observable; the sampled case still blocks before agent/verifier at apt unsigned-repository setup, with no raw logs/task text/trajectory recorded

## Notes
This does not change benchmark scoring, task semantics, leaderboard/submission behavior, permission boundaries, or launch full benchmark jobs.