### PR TITLE
fix(control-plane): isolate blocked replan history by agent

### DIFF
--- a/examples/control_plane/autonomous-replan-obligation-readmodel-smoke.py
+++ b/examples/control_plane/autonomous-replan-obligation-readmodel-smoke.py
@@ -16,6 +16,12 @@ from loopx.control_plane.work_items.autonomous_replan_obligation import (  # noq
     build_autonomous_replan_obligation as direct_build_autonomous_replan_obligation,
     build_autonomous_replan_obligation_payload,
 )
+from loopx.control_plane.work_items.project_asset import (  # noqa: E402
+    attach_active_state_project_asset_fields,
+)
+from loopx.control_plane.goals.goal_frontier import (  # noqa: E402
+    select_autonomous_replan_obligation,
+)
 from loopx.status import (  # noqa: E402
     AUTONOMOUS_REPLAN_SECTION_HEADINGS,
     AUTONOMOUS_REPLAN_SCHEMA_VERSION,
@@ -25,6 +31,7 @@ from loopx.status import (  # noqa: E402
     active_state_section_entries,
     active_state_sections,
     autonomous_replan_obligation,
+    autonomous_replan_obligation_from_runs,
     build_autonomous_replan_obligation,
     public_safe_compact_text,
 )
@@ -136,8 +143,74 @@ def direct_state_obligation() -> dict[str, object] | None:
     )
 
 
+def assert_peer_latest_run_does_not_hide_agent_stall() -> None:
+    agent_id = "codex-quality-qualification"
+    peer_id = "codex-main-control"
+    target = {
+        "schema_version": "quota_monitor_target_v0",
+        "target_id": "blocked-successor",
+        "monitor_mode": "blocked_successor_wait_without_material_transition",
+        "effective_action": "monitor_quiet_skip",
+        "agent_id": agent_id,
+        "frontier_identity": "stable-frontier",
+    }
+    latest_runs = [
+        {
+            "classification": "peer_delivery",
+            "generated_at": "2026-07-21T00:03:00+00:00",
+            "agent_id": peer_id,
+            "delivery_outcome": "outcome_progress",
+        },
+        {
+            "classification": "quota_monitor_poll",
+            "generated_at": "2026-07-21T00:02:00+00:00",
+            "agent_id": agent_id,
+            "health_check": "blocked successor wait unchanged; bounded replan after two polls",
+            "monitor_target": target,
+        },
+        {
+            "classification": "quota_monitor_poll",
+            "generated_at": "2026-07-21T00:01:00+00:00",
+            "agent_id": agent_id,
+            "health_check": "blocked successor wait unchanged; bounded replan after two polls",
+            "monitor_target": target,
+        },
+    ]
+
+    obligation = autonomous_replan_obligation_from_runs(
+        latest_runs,
+        agent_todos=None,
+        agent_id=agent_id,
+    )
+    assert obligation is not None, obligation
+    assert obligation["agent_id"] == agent_id, obligation
+    assert obligation["frontier_identity"] == "stable-frontier", obligation
+
+    item = {
+        "agent_todos": AGENT_TODOS,
+        "project_asset": {},
+    }
+    attach_active_state_project_asset_fields(
+        item,
+        latest_runs=latest_runs,
+        autonomous_replan_obligation_from_runs=autonomous_replan_obligation_from_runs,
+    )
+    selected = select_autonomous_replan_obligation(
+        item,
+        item["project_asset"],
+        agent_id=agent_id,
+    )
+    assert selected == obligation, (selected, obligation)
+    assert select_autonomous_replan_obligation(
+        item,
+        item["project_asset"],
+        agent_id=peer_id,
+    ) is None
+
+
 def main() -> int:
     assert_payload_builder_contract()
+    assert_peer_latest_run_does_not_hide_agent_stall()
 
     regular = assert_parity(
         [

--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -209,8 +209,19 @@ def goal_frontier_is_terminal_no_followup(*, projection: dict[str, Any] | None) 
 def select_autonomous_replan_obligation(
     item: dict[str, Any],
     project_asset: dict[str, Any] | None = None,
+    *,
+    agent_id: str | None = None,
 ) -> dict[str, Any] | None:
     project_asset = project_asset if isinstance(project_asset, dict) else {}
+    safe_agent_id = str(agent_id or "").strip()
+    if safe_agent_id:
+        for source in (item, project_asset):
+            obligations = source.get("autonomous_replan_obligations_by_agent")
+            if not isinstance(obligations, dict):
+                continue
+            value = obligations.get(safe_agent_id)
+            if isinstance(value, dict):
+                return value
     value = item.get("autonomous_replan_obligation")
     if isinstance(value, dict):
         return value
@@ -1694,7 +1705,11 @@ def build_goal_frontier_projection_context_from_status(
     per-agent vision gaps, derived replan obligation, and final projection.
     """
 
-    replan_obligation = select_autonomous_replan_obligation(item, project_asset)
+    replan_obligation = select_autonomous_replan_obligation(
+        item,
+        project_asset,
+        agent_id=agent_id,
+    )
     replan_scope = autonomous_replan_scope_decision(
         replan_obligation,
         agent_id=agent_id,

--- a/loopx/control_plane/work_items/autonomous_replan_obligation.py
+++ b/loopx/control_plane/work_items/autonomous_replan_obligation.py
@@ -58,7 +58,7 @@ def _single_public_agent_id(items: list[dict[str, Any]]) -> str | None:
     return next(iter(agent_ids)) if len(agent_ids) == 1 else None
 
 
-def _run_history_agent_id(run: dict[str, Any]) -> str | None:
+def run_history_agent_id(run: dict[str, Any]) -> str | None:
     agent_id = str(run.get("agent_id") or "").strip()
     if agent_id:
         return agent_id
@@ -72,27 +72,30 @@ def _latest_agent_run_history(
     latest_runs: list[dict[str, Any]] | None,
     *,
     neutral_classifications: set[str],
+    agent_id: str | None = None,
 ) -> list[dict[str, Any]]:
     """Keep the newest attributable agent lane while preserving goal-level runs."""
 
-    accountable_agent_id = next(
-        (
-            _run_history_agent_id(run)
-            for run in latest_runs or []
-            if isinstance(run, dict)
-            and str(run.get("classification") or "").strip()
-            not in neutral_classifications
-            and _run_history_agent_id(run)
-        ),
-        None,
-    )
+    accountable_agent_id = str(agent_id or "").strip() or None
+    if accountable_agent_id is None:
+        accountable_agent_id = next(
+            (
+                run_history_agent_id(run)
+                for run in latest_runs or []
+                if isinstance(run, dict)
+                and str(run.get("classification") or "").strip()
+                not in neutral_classifications
+                and run_history_agent_id(run)
+            ),
+            None,
+        )
     if not accountable_agent_id:
         return [run for run in latest_runs or [] if isinstance(run, dict)]
     return [
         run
         for run in latest_runs or []
         if isinstance(run, dict)
-        and _run_history_agent_id(run) in {None, accountable_agent_id}
+        and run_history_agent_id(run) in {None, accountable_agent_id}
     ]
 
 
@@ -552,6 +555,7 @@ def autonomous_replan_obligation_from_runs(
     latest_runs: list[dict[str, Any]] | None,
     *,
     agent_todos: dict[str, Any] | None,
+    agent_id: str | None = None,
     autonomous_replan_ack_recorded: AckRecorded,
     neutral_classifications: set[str],
     progress_outcomes: set[Any],
@@ -567,6 +571,7 @@ def autonomous_replan_obligation_from_runs(
     scoped_latest_runs = _latest_agent_run_history(
         latest_runs,
         neutral_classifications=neutral_classifications,
+        agent_id=agent_id,
     )
 
     def periodic_review() -> dict[str, Any] | None:

--- a/loopx/control_plane/work_items/project_asset.py
+++ b/loopx/control_plane/work_items/project_asset.py
@@ -8,6 +8,7 @@ from ..runtime.public_safety import (
     compact_text as _compact_text,
     public_safe_compact_text as _runtime_public_safe_compact_text,
 )
+from .autonomous_replan_obligation import run_history_agent_id
 
 
 DEFAULT_MONITOR_SIGNAL_WAITING_ON = "monitor_signal"
@@ -302,6 +303,31 @@ def attach_active_state_project_asset_fields(
         else None
     )
     if replan_obligation is None and autonomous_replan_obligation_from_runs is not None:
+        agent_ids = sorted(
+            {
+                agent_id
+                for run in latest_runs or []
+                if isinstance(run, dict)
+                if (agent_id := run_history_agent_id(run)) is not None
+            }
+        )
+        obligations_by_agent = {
+            agent_id: obligation
+            for agent_id in agent_ids
+            if (
+                obligation := autonomous_replan_obligation_from_runs(
+                    latest_runs or [],
+                    # The shared todo summary is goal-scoped here. Quota derives
+                    # todo-based replans later from its agent-filtered summary.
+                    agent_todos=None,
+                    agent_id=agent_id,
+                )
+            )
+        }
+        if obligations_by_agent:
+            item["autonomous_replan_obligations_by_agent"] = obligations_by_agent
+            project_asset["autonomous_replan_obligations_by_agent"] = obligations_by_agent
+            attached["autonomous_replan_obligations_by_agent"] = obligations_by_agent
         replan_obligation = autonomous_replan_obligation_from_runs(
             latest_runs or [],
             agent_todos=item.get("agent_todos") if isinstance(item.get("agent_todos"), dict) else None,

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -3799,10 +3799,12 @@ def autonomous_replan_obligation_from_runs(
     latest_runs: list[dict[str, Any]] | None,
     *,
     agent_todos: dict[str, Any] | None,
+    agent_id: str | None = None,
 ) -> dict[str, Any] | None:
     return _autonomous_replan_obligation_from_runs_read_model(
         latest_runs,
         agent_todos=agent_todos,
+        agent_id=agent_id,
         autonomous_replan_ack_recorded=autonomous_replan_ack_recorded,
         neutral_classifications=AUTONOMOUS_RUN_HISTORY_NEUTRAL_CLASSIFICATIONS,
         progress_outcomes=AUTONOMOUS_RUN_HISTORY_PROGRESS_OUTCOMES,


### PR DESCRIPTION
## Summary
- derive run-history replan obligations for every attributable agent lane instead of letting the newest peer select the lane
- let quota select the current agent's projected obligation while preserving the existing goal-level fallback
- add a public smoke where a newer peer delivery cannot hide two identical blocked-successor waits

## Validation
- `442 passed` in `tests/control_plane`
- focused blocked-successor and monitor-scope tests: `19 passed`
- autonomous replan, project-asset, and quota replan public smokes passed
- ruff passed on changed Python surfaces
- premerge canary: `18/18` selected checks passed, 0 warnings, 0 manual holds
- public/private boundary check passed

## Review note
This fixes a quota routing semantic gap adjacent to #2363, so it is intentionally left for independent review rather than self-merged.