### PR TITLE
Add typed SkillsBench pip setup diagnostics

### DIFF
--- a/loopx/benchmark_adapters/skillsbench_failure_signals.py
+++ b/loopx/benchmark_adapters/skillsbench_failure_signals.py
@@ -461,6 +461,52 @@ def skillsbench_pip_bootstrap_failure_evidence(error_text: str) -> bool:
     )
 
 
+def skillsbench_pip_bootstrap_failure_subtype(error_text: str) -> str:
+    """Reduce a pip bootstrap failure to a bounded public-safe subtype."""
+
+    text = error_text.lower()
+    if not skillsbench_pip_bootstrap_failure_evidence(text):
+        return "none"
+    if (
+        "no matching distribution found" in text
+        or "could not find a version that satisfies the requirement" in text
+    ):
+        return "no_matching_distribution"
+    if (
+        "failed building wheel" in text
+        or "failed to build installable wheels" in text
+    ):
+        return "wheel_build_failed"
+    if "pip subprocess to install build dependencies did not run successfully" in text:
+        return "build_dependency_subprocess_failed"
+    if "could not install packages due to an oserror" in text:
+        return "package_install_os_error"
+
+    package_hosts = (
+        "files.pythonhosted.org",
+        "pypi.org",
+        "pypi.tuna.tsinghua.edu.cn",
+    )
+    network_failures = (
+        "read timed out",
+        "connection timed out",
+        "connection reset",
+        "temporary failure in name resolution",
+        "max retries exceeded",
+    )
+    if any(
+        any(host in line for host in package_hosts)
+        and any(marker in line for marker in network_failures)
+        for line in text.splitlines()
+    ):
+        return "package_index_network_failure"
+    if "subprocess-exited-with-error" in text:
+        return "package_build_subprocess_failed"
+    if "pip._vendor." in text:
+        return "pip_internal_error"
+    return "command_failed_unclassified"
+
+
 def skillsbench_error_len_bucket(text: str) -> str:
     size = len(text)
     if size <= 0:
@@ -542,6 +588,7 @@ def skillsbench_runner_error_fingerprint(error_text: str) -> dict[str, object]:
         "error_len_bucket": skillsbench_error_len_bucket(text),
         "line_count": len(text.splitlines()) if text else 0,
         "matched_patterns": matched,
+        "pip_failure_subtype": skillsbench_pip_bootstrap_failure_subtype(text),
         "failure_line_dependency_classes": skillsbench_failure_dependency_classes(text),
         **terminal_signals,
         "has_host_paths": bool(re.search(r"/Users/|/private/|/var/folders/", text)),

--- a/loopx/benchmark_adapters/skillsbench_setup_preflight.py
+++ b/loopx/benchmark_adapters/skillsbench_setup_preflight.py
@@ -189,6 +189,7 @@ def _base_result(
         "failure_reason_codes": [],
         "terminal_failure_reason_codes": [],
         "apt_failure_subtype": "none",
+        "pip_failure_subtype": "none",
         "dependency_endpoints": [],
         "terminal_dependency_endpoints": [],
         "retryability": "unknown",
@@ -313,6 +314,9 @@ async def run_setup_only_public_preflight(
         ]
         result["apt_failure_subtype"] = str(
             fingerprint.get("apt_failure_subtype") or "none"
+        )
+        result["pip_failure_subtype"] = str(
+            fingerprint.get("pip_failure_subtype") or "none"
         )
         result["dependency_endpoints"] = [
             str(item)

--- a/tests/test_skillsbench_setup_preflight.py
+++ b/tests/test_skillsbench_setup_preflight.py
@@ -174,7 +174,7 @@ def test_setup_only_mode_does_not_require_host_codex_preflight() -> None:
 
 
 @pytest.mark.parametrize(
-    ("message", "category", "dependency_classes"),
+    ("message", "category", "dependency_classes", "pip_failure_subtype"),
     [
         (
             "Docker compose command failed. ERROR: failed to solve: process "
@@ -182,6 +182,7 @@ def test_setup_only_mode_does_not_require_host_codex_preflight() -> None:
             "failed to fetch package index",
             "skillsbench_docker_compose_apt_repository_failure",
             ["system_package"],
+            "none",
         ),
         (
             "Docker compose command failed. ERROR: failed to solve: process "
@@ -189,12 +190,14 @@ def test_setup_only_mode_does_not_require_host_codex_preflight() -> None:
             "max retries exceeded for pypi.org",
             "skillsbench_docker_compose_pip_bootstrap_failure",
             ["python_package"],
+            "package_index_network_failure",
         ),
         (
             "Docker compose command failed: invalid mount config for type "
             "bind: bind source path does not exist",
             "skillsbench_docker_compose_volume_mount_failure",
             [],
+            "none",
         ),
     ],
 )
@@ -202,6 +205,7 @@ def test_setup_only_preflight_classifies_public_setup_failures(
     message: str,
     category: str,
     dependency_classes: list[str],
+    pip_failure_subtype: str,
 ) -> None:
     FakeRollout.failure_stage = "environment_start"
     FakeRollout.failure = RuntimeError(message)
@@ -212,6 +216,7 @@ def test_setup_only_preflight_classifies_public_setup_failures(
     assert result["failure_stage"] == "environment_start"
     assert result["failure_category"] == category
     assert result["dependency_classes"] == dependency_classes
+    assert result["pip_failure_subtype"] == pip_failure_subtype
     assert result["exit_category"] == "setup_command_failed"
     assert result["cleanup_status"] == "completed"
     serialized = json.dumps(result, sort_keys=True)
@@ -275,6 +280,39 @@ def test_compose_producer_emits_only_bounded_typed_cause() -> None:
     with pytest.raises(RuntimeError, match="Docker compose command failed"):
         asyncio.run(invoke())
     assert environment.command_attempts == 4
+
+
+@pytest.mark.parametrize(
+    ("message", "subtype"),
+    [
+        (
+            "Docker compose command failed: pip install demo failed: "
+            "No matching distribution found for demo==99",
+            "no_matching_distribution",
+        ),
+        (
+            "Docker compose command failed: pip install demo failed: "
+            "Failed building wheel for demo",
+            "wheel_build_failed",
+        ),
+        (
+            "Docker compose command failed: pip install demo returned a non-zero code",
+            "command_failed_unclassified",
+        ),
+    ],
+)
+def test_setup_only_preflight_projects_bounded_pip_failure_subtype(
+    message: str,
+    subtype: str,
+) -> None:
+    FakeRollout.failure_stage = "environment_start"
+    FakeRollout.failure = RuntimeError(message)
+
+    result = run_preflight()
+
+    assert result["pip_failure_subtype"] == subtype
+    serialized = json.dumps(result, sort_keys=True)
+    assert message not in serialized
 
 
 def test_setup_only_preflight_consumes_compose_producer_typed_cause() -> None:


### PR DESCRIPTION
## Summary
- classify SkillsBench pip bootstrap failures into bounded public-safe subtypes
- project the subtype through setup-only receipts without retaining raw errors
- cover network, unavailable distribution, wheel-build, and unclassified command failures

## Validation
- `pytest -q tests/test_skillsbench_setup_preflight.py` (27 passed)
- `pytest -q tests/test_skillsbench_turn_runtime.py` (14 passed)
- `python examples/skillsbench-failure-attribution-smoke.py`
- `python examples/skillsbench-benchmark-run-smoke.py`
- `loopx canary premerge --from-git-diff` (all direct and 6 selected catalog checks passed; benchmark-sensitive manual hold acknowledged)

## Boundaries
No scoring, task semantics, runner execution, upload, submission, permission, or launch behavior changes. No raw benchmark logs, task text, trajectories, verifier output, credentials, private paths, or generated artifacts are included.