### PR TITLE
Validate non-file SkillsBench Turn progress

### DIFF
--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -32,6 +32,7 @@ from loopx.benchmark_adapters.skillsbench_remote_bridge import (
     run_skillsbench_remote_command_file_bridge_probe,
 )
 from loopx.benchmark_adapters.skillsbench_turn_runtime import (
+    SkillsBenchTurnAgentResult,
     run_skillsbench_loopx_turn_relay,
 )
 from loopx.benchmark_adapters.skillsbench_bridge_summary import (
@@ -39,6 +40,7 @@ from loopx.benchmark_adapters.skillsbench_bridge_summary import (
     bridge_summary_has_meaningful_agent_progress as _bridge_summary_has_meaningful_agent_progress,
     bridge_summary_has_successful_task_file_write as _bridge_summary_has_successful_task_file_write,
     bridge_summary_has_successful_task_operation as _bridge_summary_has_successful_task_operation,
+    bridge_summary_task_progress_receipt as _bridge_summary_task_progress_receipt,
     bridge_operation_record_interrupted as _bridge_operation_record_interrupted,
     prompt_requires_meaningful_bridge_progress as _prompt_requires_meaningful_bridge_progress,
 )
@@ -468,6 +470,7 @@ class SkillsBenchLocalAcpRelay:
         self._workflow_checkpoint_count = 0
         self._bridge_summary_snapshot_ids: dict[str, str] = {}
         self._bridge_summary_snapshot_indexes: dict[str, int] = {}
+        self._latest_loopx_turn_agent_progress_receipt: dict[str, Any] = {}
 
     def serve(self, stdin: TextIO = sys.stdin, stdout: TextIO = sys.stdout) -> int:
         for line in stdin:
@@ -605,13 +608,12 @@ class SkillsBenchLocalAcpRelay:
                     prompt=prompt_text,
                     session_id=session_id,
                     relay_config=self._config,
-                    agent_runner=lambda turn_prompt: self._run_codex(
+                    agent_runner=lambda turn_prompt: self._run_loopx_turn_agent_prompt(
                         turn_prompt,
                         session=session,
                         session_id=session_id,
                         stdout=stdout,
-                        _bypass_loopx_turn=True,
-                        _turn_deadline=sequence_deadline,
+                        turn_deadline=sequence_deadline,
                     ),
                     trace_writer=self._write_worker_public_trace,
                 )
@@ -1059,7 +1061,34 @@ class SkillsBenchLocalAcpRelay:
                 self._publish_remote_bridge_agent_operations_trace(
                     bridge_summary_path=bridge_summary_path,
                 )
+                if _bypass_loopx_turn and self._config.loopx_turn_agent_cli:
+                    self._latest_loopx_turn_agent_progress_receipt = (
+                        _bridge_summary_task_progress_receipt(bridge_summary_path)
+                    )
             return response or "local codex returned an empty final message"
+
+    def _run_loopx_turn_agent_prompt(
+        self,
+        prompt_text: str,
+        *,
+        session: dict[str, Any],
+        session_id: str,
+        stdout: TextIO,
+        turn_deadline: float,
+    ) -> SkillsBenchTurnAgentResult:
+        self._latest_loopx_turn_agent_progress_receipt = {}
+        response = self._run_codex(
+            prompt_text,
+            session=session,
+            session_id=session_id,
+            stdout=stdout,
+            _bypass_loopx_turn=True,
+            _turn_deadline=turn_deadline,
+        )
+        return SkillsBenchTurnAgentResult(
+            response_text=response,
+            progress_evidence=dict(self._latest_loopx_turn_agent_progress_receipt),
+        )
 
     def _run_codex_cli_goal_worker(
         self,
@@ -2517,6 +2546,30 @@ record["task_facing_operation"] = bool(
         or (operation == "exec" and loopx_invocations == 0)
     )
 )
+request_path = payload.get("path") if isinstance(payload, dict) else ""
+durable_task_write = bool(
+    operation == "write_file"
+    and isinstance(request_path, str)
+    and request_path.startswith(("/app/", "/root/"))
+    and not request_path.startswith(
+        (
+            "/app/.loopx/",
+            "/app/.codex/",
+            "/app/.git/",
+            "/app/.cache/",
+            "/app/node_modules/",
+            "/root/.loopx/",
+            "/root/.codex/",
+            "/root/.cache/",
+            "/root/.local/",
+        )
+    )
+)
+record["durable_task_write"] = durable_task_write
+if durable_task_write:
+    record["durable_task_write_root"] = (
+        "app" if request_path.startswith("/app/") else "root"
+    )
 record["bridge_probe_operation"] = bridge_probe_operation
 record["operation_observed"] = True
 
@@ -2541,8 +2594,26 @@ proc = subprocess.run(
 )
 complete_record = dict(record)
 complete_record["record_phase"] = "complete"
-complete_record["returncode"] = int(proc.returncode)
-complete_record["success"] = proc.returncode == 0
+try:
+    bridge_response = json.loads(proc.stdout or "")
+except Exception:
+    bridge_response = {{}}
+response_ok = bridge_response.get("ok") if isinstance(bridge_response, dict) else None
+response_exit_code = (
+    bridge_response.get("exit_code") if isinstance(bridge_response, dict) else None
+)
+if isinstance(response_ok, bool):
+    operation_returncode = (
+        response_exit_code
+        if isinstance(response_exit_code, int) and not isinstance(response_exit_code, bool)
+        else 0 if response_ok else 1
+    )
+    operation_success = bool(response_ok and operation_returncode == 0)
+else:
+    operation_returncode = int(proc.returncode)
+    operation_success = proc.returncode == 0
+complete_record["returncode"] = operation_returncode
+complete_record["success"] = operation_success
 complete_record["stdout_bytes"] = len((proc.stdout or "").encode("utf-8"))
 complete_record["stderr_bytes"] = len((proc.stderr or "").encode("utf-8"))
 attach_successful_todo_add_id(complete_record, subcommands, proc.stdout or "")
@@ -2560,6 +2631,8 @@ if proc.returncode != 0:
         complete_record["failure_category"] = "bridge_ssh_unavailable"
     else:
         complete_record["failure_category"] = "bridge_command_failed"
+elif not operation_success:
+    complete_record["failure_category"] = "bridge_operation_failed"
 append_record(complete_record)
 sys.stdout.write(proc.stdout)
 sys.stderr.write(proc.stderr)

--- a/loopx/benchmark_adapters/skillsbench_bridge_summary.py
+++ b/loopx/benchmark_adapters/skillsbench_bridge_summary.py
@@ -107,6 +107,68 @@ def bridge_summary_has_successful_task_operation(
     return False
 
 
+def bridge_summary_task_progress_receipt(path: Path | None) -> dict[str, Any]:
+    """Reduce one agent invocation to bounded task-facing progress counts."""
+
+    receipt: dict[str, Any] = {
+        "schema_version": "skillsbench_bridge_task_progress_receipt_v0",
+        "status": "no_verified_task_mutation",
+        "task_facing_operation_count": 0,
+        "task_facing_success_count": 0,
+        "successful_task_file_write_count": 0,
+        "raw_material_recorded": False,
+    }
+    if path is None or not path.exists():
+        return receipt
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return receipt
+    for line in lines:
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(record, dict):
+            continue
+        receipt["raw_material_recorded"] = receipt["raw_material_recorded"] or any(
+            record.get(field) is True
+            for field in (
+                "raw_request_recorded",
+                "raw_stdout_recorded",
+                "raw_stderr_recorded",
+                "raw_task_text_recorded",
+                "credential_values_recorded",
+                "host_paths_recorded",
+                "remote_paths_recorded",
+            )
+        )
+        phase = str(record.get("record_phase") or "").strip().lower()
+        if phase != "complete" or bridge_operation_record_interrupted(record):
+            continue
+        if record.get("task_facing_operation") is not True:
+            continue
+        receipt["task_facing_operation_count"] += 1
+        success = record.get("success")
+        successful = (
+            success if isinstance(success, bool) else record.get("returncode") == 0
+        )
+        if not successful:
+            continue
+        receipt["task_facing_success_count"] += 1
+        if (
+            record.get("operation") == "write_file"
+            and record.get("durable_task_write") is True
+        ):
+            receipt["successful_task_file_write_count"] += 1
+    if (
+        receipt["successful_task_file_write_count"] > 0
+        and receipt["raw_material_recorded"] is False
+    ):
+        receipt["status"] = "verified_task_file_write"
+    return receipt
+
+
 def bridge_operation_record_interrupted(record: dict[str, Any]) -> bool:
     rc = record.get("returncode")
     if isinstance(rc, int) and not isinstance(rc, bool) and rc < 0:

--- a/loopx/benchmark_adapters/skillsbench_turn_route.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_route.py
@@ -279,6 +279,7 @@ def _public_validation(value: Any) -> dict[str, Any]:
             "baseline_contract",
             "sequence_stop_reason",
             "terminal_policy",
+            "progress_evidence_kind",
         )
         if (label := _public_label(value.get(key), limit=120))
     }
@@ -300,6 +301,9 @@ def _public_validation(value: Any) -> dict[str, Any]:
     turn_index = value.get("turn_index")
     if isinstance(turn_index, int) and not isinstance(turn_index, bool):
         validation["turn_index"] = max(1, turn_index)
+    write_count = value.get("successful_task_file_write_count")
+    if isinstance(write_count, int) and not isinstance(write_count, bool):
+        validation["successful_task_file_write_count"] = max(0, write_count)
     return validation
 
 
@@ -422,7 +426,21 @@ def _aggregate_validations(validations: list[dict[str, Any]]) -> dict[str, Any]:
             item.get("terminal_complete") is True for item in validations
         ),
         "turn_count": len(validations),
+        "successful_task_file_write_count": sum(
+            max(0, int(item.get("successful_task_file_write_count") or 0))
+            for item in validations
+            if not isinstance(item.get("successful_task_file_write_count"), bool)
+        ),
     }
+    progress_evidence_kinds = {
+        str(item.get("progress_evidence_kind") or "")
+        for item in validations
+        if item.get("progress_evidence_kind")
+    }
+    if len(progress_evidence_kinds) == 1:
+        aggregate["progress_evidence_kind"] = progress_evidence_kinds.pop()
+    elif progress_evidence_kinds:
+        aggregate["progress_evidence_kind"] = "mixed"
     if len(terminal_policies) == 1:
         aggregate["terminal_policy"] = terminal_policies.pop()
     if validations and validations[-1].get("sequence_stop_reason"):

--- a/loopx/benchmark_adapters/skillsbench_turn_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_runtime.py
@@ -38,7 +38,13 @@ SKILLSBENCH_BRIDGE_OPERATION_SCHEMA_VERSION = (
 SKILLSBENCH_TURN_BASELINE_ENV = "LOOPX_TURN_BASELINE_FILE"
 SKILLSBENCH_LOOPX_TURN_TERMINAL_POLICIES = frozenset({"validator", "fixed-n"})
 
-AgentPromptRunner = Callable[[str], str]
+@dataclass(frozen=True)
+class SkillsBenchTurnAgentResult:
+    response_text: str
+    progress_evidence: Mapping[str, Any]
+
+
+AgentPromptRunner = Callable[[str], str | SkillsBenchTurnAgentResult]
 PublicTraceWriter = Callable[[dict[str, Any]], None]
 TurnObserver = Callable[[dict[str, Any], dict[str, Any]], None]
 
@@ -270,6 +276,25 @@ def _host_result(request: Mapping[str, Any], response: str) -> dict[str, Any]:
     }
 
 
+def _agent_result(value: str | SkillsBenchTurnAgentResult) -> tuple[str, dict[str, Any]]:
+    if isinstance(value, SkillsBenchTurnAgentResult):
+        return value.response_text, dict(value.progress_evidence)
+    return str(value), {}
+
+
+def _verified_bridge_write_progress(value: Mapping[str, Any]) -> bool:
+    count = value.get("successful_task_file_write_count")
+    return bool(
+        value.get("schema_version")
+        == "skillsbench_bridge_task_progress_receipt_v0"
+        and value.get("status") == "verified_task_file_write"
+        and isinstance(count, int)
+        and not isinstance(count, bool)
+        and count > 0
+        and value.get("raw_material_recorded") is False
+    )
+
+
 def _turn_baseline_path(request: Mapping[str, Any]) -> str:
     turn_key = str(request.get("turn_key") or "")
     digest = hashlib.sha256(turn_key.encode("utf-8")).hexdigest()[:24]
@@ -350,12 +375,14 @@ def run_skillsbench_loopx_turn(
     validation_baseline = _validation_baseline(bridge, config)
     prefix = _case_cli_prefix(config)
     baseline_path = ""
+    agent_progress_evidence: dict[str, Any] = {}
 
     def host_runner(request: Mapping[str, Any]) -> dict[str, Any]:
-        nonlocal baseline_path
+        nonlocal agent_progress_evidence, baseline_path
         baseline_path = _turn_baseline_path(request)
         bridge.exec(f"umask 077; : > {shlex.quote(baseline_path)}")
-        return _host_result(request, agent_runner(prompt))
+        response, agent_progress_evidence = _agent_result(agent_runner(prompt))
+        return _host_result(request, response)
 
     def validator(
         _plan: Mapping[str, Any],
@@ -391,6 +418,23 @@ def run_skillsbench_loopx_turn(
         exit_code = validation_result.get("exit_code")
         validation_succeeded = exit_code in {0, config.progress_exit_code}
         if not validation_succeeded:
+            if _verified_bridge_write_progress(agent_progress_evidence):
+                effective_step_kind = sequence_step_kind
+                if effective_step_kind == "validator":
+                    effective_step_kind = "progress"
+                if effective_step_kind == "terminal":
+                    return {
+                        "status": "passed",
+                        "validator_kind": "skillsbench_bridge_write_progress",
+                        "summary": "independent task-facing bridge write validated progress",
+                        "exit_code": 0,
+                    }
+                return {
+                    "status": "progress",
+                    "validator_kind": "skillsbench_bridge_write_progress",
+                    "summary": "independent task-facing bridge write validated progress",
+                    "exit_code": config.progress_exit_code,
+                }
             return {
                 "status": "failed",
                 "validator_kind": "skillsbench_scored_workspace_command",
@@ -491,11 +535,22 @@ def run_skillsbench_loopx_turn(
     validation_passed = validation_status in {"passed", "progress"}
     terminal_complete = validation_status == "passed"
     validated_progress = validation_status in {"passed", "progress"}
+    bridge_write_progress = bool(
+        transaction_validation.get("validator_kind")
+        == "skillsbench_bridge_write_progress"
+        and _verified_bridge_write_progress(agent_progress_evidence)
+    )
+    write_count = agent_progress_evidence.get("successful_task_file_write_count")
+    if not isinstance(write_count, int) or isinstance(write_count, bool):
+        write_count = 0
     scored_validation = {
         "schema_version": "skillsbench_scored_workspace_validation_v0",
         "status": ("passed" if validation_passed else "failed"),
         "independent": True,
-        "validator_kind": "skillsbench_scored_workspace_command",
+        "validator_kind": str(
+            transaction_validation.get("validator_kind")
+            or "skillsbench_scored_workspace_command"
+        ),
         "pre_agent_postcondition_checked": True,
         "pre_agent_postcondition_status": validation_baseline["status"],
         "post_agent_postcondition_status": (
@@ -508,7 +563,15 @@ def run_skillsbench_loopx_turn(
         "validated_progress": validated_progress,
         "terminal_complete": terminal_complete,
         "terminal_policy": config.terminal_policy,
-        "baseline_contract": "task_declared_independent_postcondition",
+        "baseline_contract": (
+            "task_declared_independent_postcondition_or_verified_bridge_write"
+        ),
+        "progress_evidence_kind": (
+            "verified_task_file_write"
+            if bridge_write_progress
+            else "scored_workspace_command"
+        ),
+        "successful_task_file_write_count": max(0, write_count),
         "oracle_feedback_used": False,
         "meaningful_operation_count": bridge.meaningful_operation_count,
         "raw_validator_output_recorded": False,

--- a/tests/test_skillsbench_turn_runtime.py
+++ b/tests/test_skillsbench_turn_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -9,6 +10,7 @@ from typing import Any
 import pytest
 
 from loopx.benchmark_adapters import skillsbench_acp_relay as acp_relay
+from loopx.benchmark_adapters import skillsbench_bridge_summary as bridge_summary
 from loopx.benchmark_adapters import skillsbench_turn_runtime as runtime
 from loopx.benchmark_adapters.skillsbench_acp_relay import (
     CodexExecConfig,
@@ -60,6 +62,220 @@ def test_nonzero_validation_probe_does_not_return_private_output(
     assert result["exit_code"] == 17
     assert set(result) == {"ok", "exit_code", "elapsed_ms"}
     assert "private" not in json.dumps(result)
+
+
+def test_bridge_progress_receipt_requires_successful_task_file_write(
+    tmp_path: Path,
+) -> None:
+    summary_path = tmp_path / "bridge-summary.jsonl"
+    records = [
+        {
+            "record_phase": "complete",
+            "operation": "read_file",
+            "task_facing_operation": True,
+            "success": True,
+        },
+        {
+            "record_phase": "complete",
+            "operation": "write_file",
+            "task_facing_operation": True,
+            "durable_task_write": True,
+            "success": False,
+            "returncode": 1,
+        },
+        {
+            "record_phase": "start",
+            "operation": "write_file",
+            "task_facing_operation": True,
+        },
+        {
+            "record_phase": "complete",
+            "operation": "write_file",
+            "task_facing_operation": True,
+            "durable_task_write": False,
+            "success": True,
+            "returncode": 0,
+        },
+        {
+            "record_phase": "complete",
+            "operation": "write_file",
+            "task_facing_operation": True,
+            "durable_task_write": True,
+            "success": True,
+            "returncode": 0,
+        },
+    ]
+    summary_path.write_text(
+        "\n".join(json.dumps(record) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+    receipt = bridge_summary.bridge_summary_task_progress_receipt(summary_path)
+
+    assert receipt == {
+        "schema_version": "skillsbench_bridge_task_progress_receipt_v0",
+        "status": "verified_task_file_write",
+        "task_facing_operation_count": 4,
+        "task_facing_success_count": 3,
+        "successful_task_file_write_count": 1,
+        "raw_material_recorded": False,
+    }
+
+
+def test_instrumented_bridge_emits_durable_root_without_raw_path(
+    tmp_path: Path,
+) -> None:
+    fake_bridge = tmp_path / "fake-bridge"
+    fake_bridge.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, sys\n"
+        "request = json.loads(sys.stdin.read())\n"
+        "ok = not str(request.get('path', '')).endswith('failed.txt')\n"
+        "print(json.dumps({'ok': ok, 'exit_code': 0}))\n",
+        encoding="utf-8",
+    )
+    fake_bridge.chmod(0o755)
+    relay = SkillsBenchLocalAcpRelay(
+        CodexExecConfig(remote_command_file_bridge_command=str(fake_bridge))
+    )
+    summary_path = tmp_path / "bridge-summary.jsonl"
+    wrapper = relay._write_instrumented_bridge_wrapper(
+        tmp_path=tmp_path,
+        summary_path=summary_path,
+    )
+    requests = [
+        {
+            "operation": "write_file",
+            "path": "/root/task-output.txt",
+            "content": "private task output",
+        },
+        {
+            "operation": "write_file",
+            "path": "/tmp/temporary-note.txt",
+            "content": "temporary private note",
+        },
+        {
+            "operation": "write_file",
+            "path": "/root/failed.txt",
+            "content": "failed private output",
+        },
+    ]
+    for request in requests:
+        subprocess.run(
+            [str(wrapper)],
+            input=json.dumps(request),
+            text=True,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+    receipt = bridge_summary.bridge_summary_task_progress_receipt(summary_path)
+    summary_text = summary_path.read_text(encoding="utf-8")
+
+    assert receipt["successful_task_file_write_count"] == 1
+    assert receipt["status"] == "verified_task_file_write"
+    assert '"durable_task_write_root": "root"' in summary_text
+    assert "/root/task-output.txt" not in summary_text
+    assert "/tmp/temporary-note.txt" not in summary_text
+    assert "/root/failed.txt" not in summary_text
+    assert "private task output" not in summary_text
+    assert "temporary private note" not in summary_text
+    assert "failed private output" not in summary_text
+    assert '"failure_category": "bridge_operation_failed"' in summary_text
+
+
+@pytest.mark.parametrize(
+    ("write_count", "raw_material_recorded", "expected_status"),
+    [
+        (1, False, "committed"),
+        (0, False, "failed"),
+        (1, True, "failed"),
+    ],
+)
+def test_bridge_write_progress_can_commit_when_workspace_command_cannot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    write_count: int,
+    raw_material_recorded: bool,
+    expected_status: str,
+) -> None:
+    class NonFileProgressBridge:
+        def __init__(self, _config: Any) -> None:
+            self.meaningful_operation_count = 0
+
+        def exec(
+            self,
+            _command: str,
+            *,
+            meaningful: bool = False,
+            allow_nonzero: bool = False,
+        ) -> dict[str, Any]:
+            if allow_nonzero:
+                if meaningful:
+                    self.meaningful_operation_count += 1
+                return {"ok": False, "exit_code": 3, "elapsed_ms": 1}
+            return {"ok": True, "exit_code": 0, "stdout": "", "elapsed_ms": 1}
+
+    def fake_turn_once(
+        plan: dict[str, Any],
+        *,
+        host_runner: Any,
+        task_validator: Any,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        result = host_runner({"turn_key": "synthetic-turn"})
+        validation = dict(task_validator(plan, result))
+        return {
+            "status": (
+                "committed"
+                if validation.get("status") in {"progress", "passed"}
+                else "failed"
+            ),
+            "validation": validation,
+        }
+
+    monkeypatch.setattr(runtime, "SkillsBenchTurnBridge", NonFileProgressBridge)
+    monkeypatch.setattr(runtime, "_turn_plan", lambda *_args, **_kwargs: {"ok": True})
+    monkeypatch.setattr(runtime, "run_loopx_turn_once", fake_turn_once)
+    evidence = {
+        "schema_version": "skillsbench_bridge_task_progress_receipt_v0",
+        "status": (
+            "verified_task_file_write"
+            if write_count and not raw_material_recorded
+            else "no_verified_task_mutation"
+        ),
+        "task_facing_operation_count": 4,
+        "task_facing_success_count": 4,
+        "successful_task_file_write_count": write_count,
+        "raw_material_recorded": raw_material_recorded,
+    }
+
+    execution, validation = runtime.run_skillsbench_loopx_turn(
+        prompt="synthetic prompt",
+        agent_runner=lambda _prompt: runtime.SkillsBenchTurnAgentResult(
+            response_text="done",
+            progress_evidence=evidence,
+        ),
+        config=runtime.SkillsBenchTurnRuntimeConfig(
+            **{
+                **_config(tmp_path).__dict__,
+                "terminal_policy": "fixed-n",
+            }
+        ),
+        sequence_step_kind="progress",
+    )
+
+    assert execution["status"] == expected_status
+    if expected_status == "committed":
+        assert validation["status"] == "passed"
+        assert validation["post_agent_postcondition_status"] == "progress_validated"
+        assert validation["validator_kind"] == "skillsbench_bridge_write_progress"
+        assert validation["progress_evidence_kind"] == "verified_task_file_write"
+        assert validation["successful_task_file_write_count"] == 1
+    else:
+        assert validation["status"] == "failed"
+        assert validation["post_agent_postcondition_status"] == "unsatisfied"
 
 
 def test_satisfied_pre_agent_postcondition_runs_but_does_not_claim_readiness(


### PR DESCRIPTION
## Summary

- add a bounded public-safe task-progress receipt for SkillsBench command/file bridge invocations
- let LoopX Turn use a verified durable task-file write as non-terminal progress when the benchmark's scored-workspace validation command cannot express intermediate state
- preserve explicit command validation as the strongest signal and reject failed, temporary, control-plane, or raw-material-bearing write evidence
- parse typed bridge operation results so transport success cannot mask an operation-level failure

## Motivation

Some long-horizon benchmark cases make real task-facing progress through the command/file bridge without exposing a benchmark-neutral intermediate postcondition to the scored-workspace validator. Treating every such turn as failed prevents a fixed-N or adaptive Turn sequence from continuing even though the agent durably changed the task workspace.

This change keeps the validator boundary independent of official reward or verifier feedback. It records only bounded counts and coarse root labels; raw paths, task content, command output, trajectories, and credentials remain excluded.

## Validation

- `51 passed` across the focused Turn runtime, setup preflight, benchmark projection, and post-run debug tests
- changed Python files compile successfully
- `skillsbench-benchmark-run-smoke: ok`
- `skillsbench-failure-attribution-smoke: ok`
- `git diff --check`: passed
- standard premerge canary: all direct checks and all 6 selected catalog checks passed

The premerge gate reports the expected `benchmark_sensitive` manual hold. There were no command or smoke failures. The owner has explicitly authorized self-merge for this bounded benchmark runtime batch after maintainer review and validation.

## Boundary

- no benchmark scoring, task semantics, upload, submission, or permission behavior changes
- no official verifier or reward feedback is exposed to the agent
- no private state, raw benchmark evidence, credentials, local paths, or generated logs are included
- formatting/lint tools were unavailable in the repository environment; compile, focused tests, diff hygiene, smokes, and canaries cover the changed surface
