### PR TITLE
Deepen the PR review explanation contract

### DIFF
--- a/docs/reference/protocols/pr-review-command-v0.md
+++ b/docs/reference/protocols/pr-review-command-v0.md
@@ -155,43 +155,44 @@ absolute paths, private source bodies, or hidden CI artifacts.
   "pull_requests": [
     {
       "number": 773,
+      "head_oid": "0123456789abcdef0123456789abcdef01234567",
       "review_template": {
         "schema_version": "pr_review_five_block_template_v0",
         "purpose": "Empty scaffold only; agentloop fills it after reading PR body and diff.",
         "sections": [
           {
             "label": "动机",
-            "word_hint": "100-200字",
+            "word_hint": "200-350字",
             "content": "",
-            "agent_instruction": "读 PR title/body/diff 后填写：这个 PR 为什么存在，想解决哪个用户或维护者问题；说明触发背景和价值，不要只复述标题。"
+            "agent_instruction": "解释旧行为、具体痛点、受影响的用户或调用方、目标结果与必要性；说明不合并会继续付出什么代价，以及需求来自活跃调用方还是未来设想。"
           },
           {
             "label": "改动思路",
-            "word_hint": "100-200字",
+            "word_hint": "250-450字",
             "content": "",
-            "agent_instruction": "读关键 diff 后填写：作者采用什么路线解决问题，关键设计取舍是什么，不要只复述文件名。"
+            "agent_instruction": "解释所选架构、改动前后的控制流或数据流、所有权边界、关键不变量和替代方案取舍；为不熟悉子系统的读者给出一条正向运行链路。"
           },
           {
             "label": "具体改动",
-            "word_hint": "100-200字",
+            "word_hint": "300-600字",
             "content": "",
-            "agent_instruction": "读 diff 后填写：具体改了哪些模块、协议、命令、文档或测试；保留能支撑 review 决策的细节。"
+            "agent_instruction": "把关键文件和符号映射到行为，覆盖接口、配置或状态、兼容路径、测试与文档；说明各部分如何协作，并给出一个具体输入到输出的例子。"
           },
           {
             "label": "对主干的风险",
-            "word_hint": "100-200字",
+            "word_hint": "250-500字",
             "content": "",
-            "agent_instruction": "读 diff、checks 和 main_regression_analysis 后填写：合入 main 可能破坏什么，哪些验证已覆盖，哪些残余风险还需要关注。"
+            "agent_instruction": "按严重度列出有文件或符号证据的发现，评估爆炸半径、兼容性、权限、默认副作用、失败与回滚、可观测性和缺失覆盖；策略或生命周期改动必须解释一条负向链路。"
           },
           {
             "label": "我的整体评价",
-            "word_hint": "100-200字",
+            "word_hint": "150-300字",
             "content": "",
-            "agent_instruction": "读完整 PR 后填写：approve / request changes / defer / merge after checks；给出结论、理由和必要的后续条件。"
+            "agent_instruction": "权衡价值与复杂度，列出实际检查或运行的验证，注明审阅的 head SHA，并给出精确结论；若阻塞，说明最小修复和复审所需证据。"
           }
         ],
         "review_order": ["docs/guides/newcomer-command-path.md", "docs/README.md"],
-        "output_hint": "Write each of the five sections with concrete evidence and judgment; each section is usually 100-200 Chinese characters, shorter only for genuinely tiny PRs and longer when risk demands it."
+        "output_hint": "Write for a reader unfamiliar with the PR: explain context, architecture, implementation, validation, necessity, and risk with concrete evidence. Follow each section's range as a depth signal, not filler."
       },
       "motivation": "Adds a newcomer command path...",
       "scale": {"changed_files": 3, "additions": 90, "deletions": 4},
@@ -220,9 +221,10 @@ absolute paths, private source bodies, or hidden CI artifacts.
       },
       "risk_notes": [],
       "evidence_commands": [
-        "gh pr view 773 --json title,body,files,commits,statusCheckRollup",
+        "gh pr view 773 --json title,body,files,commits,statusCheckRollup,headRefOid,updatedAt",
         "gh pr diff 773 --name-only",
-        "gh pr diff 773 --patch"
+        "gh pr diff 773 --patch",
+        "gh pr view 773 --json headRefOid,updatedAt"
       ]
     }
   ],
@@ -244,7 +246,13 @@ absolute paths, private source bodies, or hidden CI artifacts.
       "具体改动",
       "对主干的风险",
       "我的整体评价"
-    ]
+    ],
+    "explanation_depth_contract": {
+      "schema_version": "pr_review_explanation_depth_v0",
+      "reader_profile": "A technically curious reader who may not know this PR or subsystem.",
+      "evidence_layers": ["problem", "architecture", "implementation", "validation"],
+      "freshness": "Record and recheck the remote head SHA before the verdict."
+    }
   },
   "boundary": {
     "raw_logs_recorded": false,
@@ -266,10 +274,11 @@ The packet should let a reviewer move through PRs in order:
 4. Read `main_regression_analysis` before filling risk prose. It is the CLI's
    concrete, generated view of potential main regressions, bug risks, and
    focused validation.
-5. Let agentloop fill the blank five-block template:
+5. Follow `agent_response_contract.explanation_depth_contract`, then let
+   agentloop fill the blank five-block template:
    `动机`, `改动思路`, `具体改动`, `对主干的风险`, `我的整体评价`.
-   Each section should usually be 100-200 Chinese characters and include
-   concrete evidence and judgment after reading the selected PR.
+   Use each section's range as a depth signal for a reader unfamiliar with the
+   subsystem, not as filler.
 6. Treat `metadata_risk_hint` only as queue-ordering metadata. It must not be
    copied as the final risk judgement.
 7. Decide `approve`, `request changes`, `defer`, or `merge after checks`.
@@ -313,9 +322,12 @@ A first implementation is acceptable when:
   per-PR deep-read commands after the CLI packet selects a PR;
 - each PR includes `review_template.sections` for `动机`, `改动思路`,
   `具体改动`, `对主干的风险`, and `我的整体评价`;
-- each review template section carries a `100-200字` hint so the final chat
-  review explains evidence and judgment instead of collapsing the whole PR into
-  a single short paragraph;
+- each review template section carries a section-specific depth range, and the
+  packet's explanation-depth contract requires problem, architecture,
+  implementation, validation, necessity, and risk evidence instead of a generic
+  long answer;
+- live packets expose and recheck `headRefOid` so a review verdict is bound to
+  the remote revision actually inspected;
 - template sections must leave `content` empty so agentloop reads the real PR
   before writing the review;
 - `metadata_risk_hint` must be repository-generic and must not special-case

--- a/examples/pr-review-command-smoke.py
+++ b/examples/pr-review-command-smoke.py
@@ -173,7 +173,7 @@ def main() -> int:
     template = first["review_template"]
     assert template["schema_version"] == "pr_review_five_block_template_v0", template
     assert "Empty scaffold only" in template["purpose"], template
-    assert "each section is usually 100-200 Chinese characters" in template["output_hint"], template
+    assert "reader unfamiliar with the PR" in template["output_hint"], template
     labels = [section["label"] for section in template["sections"]]
     assert labels == ["动机", "改动思路", "具体改动", "对主干的风险", "我的整体评价"], template
     for section in template["sections"]:
@@ -181,6 +181,15 @@ def main() -> int:
         assert section["word_hint"], section
         assert section["agent_instruction"], section
         assert "quota.py" not in section["agent_instruction"], section
+    assert [section["word_hint"] for section in template["sections"]] == [
+        "200-350字",
+        "250-450字",
+        "300-600字",
+        "250-500字",
+        "150-300字",
+    ], template
+    assert "headRefOid" in first["evidence_commands"][0], first["evidence_commands"]
+    assert "headRefOid" in first["evidence_commands"][-1], first["evidence_commands"]
     assert template["review_order"][0] == "docs/guides/newcomer-command-path.md", template
     assert first["checks"]["counts"]["success"] == 2, first["checks"]
     assert "public_docs" in first["areas"], first["areas"]
@@ -277,6 +286,14 @@ def main() -> int:
         "对主干的风险",
         "我的整体评价",
     ], response_contract
+    depth = response_contract["explanation_depth_contract"]
+    assert depth["schema_version"] == "pr_review_explanation_depth_v0", depth
+    assert "may not know" in depth["reader_profile"], depth
+    assert len(depth["evidence_layers"]) == 4, depth
+    assert len(depth["necessity_questions"]) == 3, depth
+    assert depth["runtime_walkthroughs"]["positive"], depth
+    assert "authority, permission, or scope bypass" in depth["risk_scan"], depth
+    assert "head SHA" in depth["freshness"], depth
     assert any("Do not stop at the queue/table summary" in item for item in response_contract["instructions"])
     assert any("open, closed, merged, today" in item for item in response_contract["instructions"])
     assert any("drops agent_response_contract" in item or "Do not pipe the JSON packet" in item for item in response_contract["instructions"])
@@ -352,6 +369,8 @@ def main() -> int:
     assert "final answer contract: queue/table is only a preface" in markdown, markdown
     assert "## Agent Output Contract" in markdown, markdown
     assert "Do not stop at the queue/table summary" in markdown, markdown
+    assert "explanation_depth_contract" in markdown, markdown
+    assert "remote head SHA" in markdown, markdown
     assert "Required card headings: `动机`, `改动思路`, `具体改动`, `对主干的风险`, `我的整体评价`" in markdown, markdown
     assert "## Unmerged PRs" in markdown, markdown
     assert "## Merged PRs" in markdown, markdown
@@ -362,11 +381,11 @@ def main() -> int:
     assert "template below is intentionally blank" in markdown, markdown
     assert "- 推荐阅读顺序:" in markdown, markdown
     assert "- 五块模板（留空给 agentloop 填写）:" in markdown, markdown
-    assert "动机（100-200字）" in markdown, markdown
-    assert "改动思路（100-200字）" in markdown, markdown
-    assert "具体改动（100-200字）" in markdown, markdown
-    assert "对主干的风险（100-200字）" in markdown, markdown
-    assert "我的整体评价（100-200字）" in markdown, markdown
+    assert "动机（200-350字）" in markdown, markdown
+    assert "改动思路（250-450字）" in markdown, markdown
+    assert "具体改动（300-600字）" in markdown, markdown
+    assert "对主干的风险（250-500字）" in markdown, markdown
+    assert "我的整体评价（150-300字）" in markdown, markdown
     assert "main regression risk:" not in markdown, markdown
     assert "## Combined Review Sequence" in markdown, markdown
     assert "PR #773" in markdown, markdown

--- a/examples/slash-command-catalog-smoke.py
+++ b/examples/slash-command-catalog-smoke.py
@@ -50,6 +50,7 @@ def main() -> int:
     assert pr_review["agent_contract"]["slash_prefix_dominates_intent"] is True, pr_review
     assert pr_review["agent_contract"]["stats_only_requires_explicit_opt_out"] is True, pr_review
     assert "agent_response_contract" in pr_review["agent_contract"]["authoritative_fields"], pr_review
+    assert "agent_response_contract.explanation_depth_contract" in pr_review["agent_contract"]["authoritative_fields"], pr_review
     assert "review_groups.unmerged" in pr_review["agent_contract"]["authoritative_fields"], pr_review
     assert "review_groups.merged" in pr_review["agent_contract"]["authoritative_fields"], pr_review
     assert "agent_response_contract.required_final_sections" in pr_review["agent_contract"]["authoritative_fields"], pr_review
@@ -69,7 +70,9 @@ def main() -> int:
         "对主干的风险",
         "我的整体评价",
     ], final_contract
-    assert "100-200 Chinese characters" in final_contract["section_length_hint"], final_contract
+    assert "per-section ranges" in final_contract["section_length_hint"], final_contract
+    assert "may not know" in final_contract["reader_profile"], final_contract
+    assert "remote head" in final_contract["freshness_policy"], final_contract
     assert "do not reconstruct" in pr_review["agent_contract"]["manual_gh_policy"], pr_review
     assert "summary-only projection" in pr_review["agent_contract"]["json_projection_policy"], pr_review
     onboarding = payload["onboarding"]

--- a/loopx/pr_review.py
+++ b/loopx/pr_review.py
@@ -202,6 +202,7 @@ def scan_github_pull_requests(
         "reviewDecision",
         "mergeStateStatus",
         "headRefName",
+        "headRefOid",
         "baseRefName",
         "author",
         "updatedAt",
@@ -601,28 +602,28 @@ def _review_template(item: dict[str, Any]) -> dict[str, Any]:
     sections = [
         _section(
             "动机",
-            "100-200字",
-            "读 PR title/body/diff 后填写：这个 PR 为什么存在，想解决哪个用户或维护者问题；说明触发背景和价值，不要只复述标题。",
+            "200-350字",
+            "解释旧行为、具体痛点、受影响的用户或调用方、目标结果与必要性；说明不合并会继续付出什么代价，以及需求来自活跃调用方还是未来设想。",
         ),
         _section(
             "改动思路",
-            "100-200字",
-            "读关键 diff 后填写：作者采用什么路线解决问题，关键设计取舍是什么，不要只复述文件名。",
+            "250-450字",
+            "解释所选架构、改动前后的控制流或数据流、所有权边界、关键不变量和替代方案取舍；为不熟悉子系统的读者给出一条正向运行链路。",
         ),
         _section(
             "具体改动",
-            "100-200字",
-            "读 diff 后填写：具体改了哪些模块、协议、命令、文档或测试；保留能支撑 review 决策的细节。",
+            "300-600字",
+            "把关键文件和符号映射到行为，覆盖接口、配置或状态、兼容路径、测试与文档；说明各部分如何协作，并给出一个具体输入到输出的例子。",
         ),
         _section(
             "对主干的风险",
-            "100-200字",
-            "读 diff、checks 和 main_regression_analysis 后填写：合入 main 可能破坏什么，哪些验证已覆盖，哪些残余风险还需要关注。",
+            "250-500字",
+            "按严重度列出有文件或符号证据的发现，评估爆炸半径、兼容性、权限、默认副作用、失败与回滚、可观测性和缺失覆盖；策略或生命周期改动必须解释一条负向链路。",
         ),
         _section(
             "我的整体评价",
-            "100-200字",
-            "读完整 PR 后填写：approve / request changes / defer / merge after checks；给出结论、理由和必要的后续条件。",
+            "150-300字",
+            "权衡价值与复杂度，列出实际检查或运行的验证，注明审阅的 head SHA，并给出精确结论；若阻塞，说明最小修复和复审所需证据。",
         ),
     ]
     return {
@@ -630,7 +631,7 @@ def _review_template(item: dict[str, Any]) -> dict[str, Any]:
         "purpose": "Empty scaffold only; agentloop fills it after reading PR body and diff.",
         "sections": sections,
         "review_order": _review_order(key_files),
-        "output_hint": "Write each of the five sections with concrete evidence and judgment; each section is usually 100-200 Chinese characters, shorter only for genuinely tiny PRs and longer when risk demands it.",
+        "output_hint": "Write for a reader unfamiliar with the PR: explain context, architecture, implementation, validation, necessity, and risk with concrete evidence. Follow each section's range as a depth signal, not filler.",
     }
 
 
@@ -664,6 +665,37 @@ def _agent_response_contract() -> dict[str, Any]:
             "对主干的风险",
             "我的整体评价",
         ],
+        "explanation_depth_contract": {
+            "schema_version": "pr_review_explanation_depth_v0",
+            "reader_profile": "A technically curious reader who may not know this PR or subsystem.",
+            "verdict_preface": "Lead with one evidence-based merge verdict and the highest-severity reason before the five sections.",
+            "evidence_layers": [
+                "problem: old behavior, concrete pain, affected caller, and before/after scenario",
+                "architecture: entry point, control/data flow, ownership, state, authority, and failure boundary",
+                "implementation: important files and symbols, behavior changes, compatibility plumbing, tests, and docs",
+                "validation: checks and focused reproductions tied to invariants, including untested or environment-blocked cases",
+            ],
+            "necessity_questions": [
+                "What remains broken or expensive without this PR?",
+                "Why is a smaller call-site fix insufficient, or why would it be sufficient?",
+                "Which plausible alternative was rejected and what trade-off was chosen?",
+            ],
+            "runtime_walkthroughs": {
+                "positive": "Trace one user or host action through calls/state to the observable result.",
+                "negative_when": "For selectors, policy, authority, lifecycle, or bridge changes, trace one rejection or failure case.",
+            },
+            "risk_scan": [
+                "false-ready or false-success state",
+                "authority, permission, or scope bypass",
+                "unexpected default-on installation or side effect",
+                "compatibility or persisted-state migration gap",
+                "host-specific assumption presented as host-neutral",
+                "duplicated truth, stale projection, or lifecycle leak",
+                "missing negative test, rollback behavior, or error observability",
+                "scope inflation or speculative abstraction without an active caller",
+            ],
+            "freshness": "Record the remote head SHA before review and query it again before the verdict; restart if it changed.",
+        },
         "instructions": [
             "Run loopx pr-review first and use review_groups as the queue.",
             "Before treating the queue as exhaustive, require result_completeness.complete=true. If it is false and the user asked for all/every PR, rerun with result_completeness.recommended_limit and preserve the new full packet.",
@@ -671,6 +703,8 @@ def _agent_response_contract() -> dict[str, Any]:
             "Do not stop at the queue/table summary when the user invokes /loopx-pr-review.",
             "Do not pipe the JSON packet through jq or another projection that drops agent_response_contract, result_completeness, review_groups, pull_requests[].review_template, or pull_requests[].evidence_commands before planning the final answer.",
             "For each selected PR, run the evidence_commands or equivalent PR body/diff reads before filling the five sections.",
+            "Follow explanation_depth_contract and the per-section instructions; the packet, rather than host-specific skill prose, is the canonical explanation-depth contract.",
+            "Lead with actionable findings, explain repository-specific terms on first use, and distinguish intended behavior from implementation and validation evidence.",
             "Do not fill the five sections from metadata_risk_hint alone; metadata_risk_hint is only queue-ordering context.",
             "Use the installed loopx command or the intended checked-out LoopX worktree; if using python -m loopx.cli from a checkout, first confirm that checkout includes this response contract.",
             "Only treat the request as stats/list-only when the user explicitly opts out of review with wording such as 只统计, 只列出, stats only, list only, 不要 review, or 不用分析; then say that no detailed PR review was performed.",
@@ -835,6 +869,7 @@ def _normalize_pr(pr: dict[str, Any]) -> dict[str, Any]:
         "merge_commit": _redact_text(merge_commit_oid, limit=80) if merge_commit_oid else None,
         "base_ref": _redact_text(pr.get("baseRefName"), limit=80),
         "head_ref": _redact_text(pr.get("headRefName"), limit=120),
+        "head_oid": _redact_text(pr.get("headRefOid"), limit=80),
         "is_draft": bool(pr.get("isDraft")),
         "review_decision": str(pr.get("reviewDecision") or "UNKNOWN"),
         "merge_state": str(pr.get("mergeStateStatus") or pr.get("mergeable") or "UNKNOWN"),
@@ -854,9 +889,10 @@ def _normalize_pr(pr: dict[str, Any]) -> dict[str, Any]:
         "main_regression_analysis": _main_regression_analysis(pr, files),
         "review_goal": "Fill the five-block review template after reading the PR body and diff.",
         "evidence_commands": [
-            f"gh pr view {number} --json title,body,files,commits,statusCheckRollup",
+            f"gh pr view {number} --json title,body,files,commits,statusCheckRollup,headRefOid,updatedAt",
             f"gh pr diff {number} --name-only",
             f"gh pr diff {number} --patch",
+            f"gh pr view {number} --json headRefOid,updatedAt",
         ]
         if number
         else [],
@@ -1124,6 +1160,8 @@ def render_pr_review_markdown(payload: dict[str, Any]) -> str:
         "- Do not stop at the queue/table summary.",
         "- Do not collapse this packet to `.summary` and `.review_sequence` only; preserve `agent_response_contract`, `review_groups`, `pull_requests[].review_template`, and `pull_requests[].evidence_commands`.",
         "- For each selected PR, read PR body/files/diff/checks first, then return one review card.",
+        "- Follow `agent_response_contract.explanation_depth_contract`; explain the PR for a technically curious reader who may not know the subsystem.",
+        "- Bind the verdict to the remote head SHA and recheck it before answering.",
         "- Required card headings: `动机`, `改动思路`, `具体改动`, `对主干的风险`, `我的整体评价`.",
         "- `metadata_risk_hint` is only queue-ordering metadata; do not copy it as the final risk judgment.",
         "",

--- a/loopx/slash_commands.py
+++ b/loopx/slash_commands.py
@@ -134,6 +134,7 @@ def build_slash_command_catalog(
                 "stats_only_requires_explicit_opt_out": True,
                 "authoritative_fields": [
                     "agent_response_contract",
+                    "agent_response_contract.explanation_depth_contract",
                     "review_groups.unmerged",
                     "review_groups.merged",
                     "pull_requests[].review_template",
@@ -164,7 +165,9 @@ def build_slash_command_catalog(
                         "我的整体评价",
                     ],
                     "evidence_before_filling": "Read each selected PR body/files/diff/checks before filling the sections.",
-                    "section_length_hint": "Each section should usually be 100-200 Chinese characters with concrete evidence and judgment.",
+                    "section_length_hint": "Use the per-section ranges in pull_requests[].review_template as depth signals; explain context, architecture, implementation, validation, necessity, and risk without filler.",
+                    "reader_profile": "A technically curious reader who may not know the PR or subsystem.",
+                    "freshness_policy": "Record the remote head before review, recheck it before the verdict, and restart if it changed.",
                 },
                 "manual_gh_policy": (
                     "Use gh only after the CLI packet selects a PR; do not reconstruct "

--- a/skills/loopx-pr-review/SKILL.md
+++ b/skills/loopx-pr-review/SKILL.md
@@ -101,6 +101,18 @@ For each selected PR, read the PR evidence before writing the review. Prefer the
 packet's `evidence_commands`; equivalent targeted `gh pr view`, `gh pr diff
 --name-only`, and `gh pr diff --patch` commands are acceptable when needed.
 
+Treat `agent_response_contract.explanation_depth_contract` and each
+`review_template.sections[].agent_instruction` as the canonical detail policy.
+The skill owns routing and evidence discipline; it must not maintain a second,
+competing explanation checklist. For older packets without the depth contract,
+still explain context, architecture, implementation, validation, necessity, and
+risk for a reader who may not know the subsystem.
+
+Record the remote `headRefOid` before deep review and query it again before the
+verdict. If it changed, review the new head instead of carrying forward stale
+findings. Use a clean read-only worktree at the exact head when local execution
+or line-level evidence is useful, and name the reviewed short SHA in the answer.
+
 Do not fill the five-block review from title, labels, changed-file counts, or
 metadata risk hints alone. `metadata_risk_hint` is only for queue ordering.
 
@@ -109,7 +121,8 @@ first and say which PRs remain. Do not silently replace review with a summary.
 
 ## Output Contract
 
-For each reviewed PR, use exactly these five headings:
+Lead with a one-line evidence-based verdict and highest-severity reason. Then use
+exactly these five headings for each reviewed PR:
 
 1. `动机`
 2. `改动思路`
@@ -119,12 +132,10 @@ For each reviewed PR, use exactly these five headings:
 
 Use the packet's blank `review_template` as the required structure and minimum
 detail signal, not as fake/example content. Fill each section only after reading
-PR body, files, checks, and diff. Each of the five sections should usually be
-100-200 Chinese characters, with concrete evidence and judgment; go shorter
-only for genuinely tiny PRs and longer when risk or diff complexity requires it.
-Avoid title-only summaries such as "improves docs" or "low risk"; explain the
-background, implementation route, reviewer-relevant changes, main-branch risk,
-and final recommendation.
+PR body, files, checks, and diff. Follow the packet's per-section ranges and
+instructions as depth signals rather than padding. Avoid title-only summaries
+such as "improves docs" or "low risk", and distinguish intended behavior from
+what the implementation and validation actually prove.
 
 ## Failure And Fallback
 


### PR DESCRIPTION
## Summary

- make the CLI packet the canonical source for PR explanation depth
- add reader, evidence, necessity, runtime-walkthrough, risk, and remote-head freshness contracts
- keep the installed skill focused on routing and evidence discipline
- use section-specific depth ranges instead of one repeated 100-200 character hint

## Validation

- `python examples/pr-review-command-smoke.py`
- `python examples/slash-command-catalog-smoke.py`
- `python examples/bootstrap-command-pack-smoke.py`
- `loopx canary premerge --from-git-diff` (15 selected, 0 failures)