### PR TITLE
Add adaptive stability policy for benchmark Turns

### DIFF
--- a/loopx/benchmark_adapters/skillsbench_turn_route.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_route.py
@@ -18,7 +18,7 @@ LOOPX_TURN_PUBLIC_BOUNDARY_FIELDS = (
 LOOPX_TURN_RUNNER_READINESS_CHECKS = (
     "turn_transaction_committed",
     "pre_agent_postcondition_checked",
-    "pre_agent_postcondition_unsatisfied",
+    "pre_agent_postcondition_eligible",
     "post_agent_postcondition_satisfied",
     "official_feedback_blinded",
 )
@@ -108,12 +108,14 @@ def add_skillsbench_loopx_turn_arguments(parser: Any) -> None:
     )
     parser.add_argument(
         "--loopx-turn-terminal-policy",
-        choices=("validator", "fixed-n"),
+        choices=("validator", "fixed-n", "stability"),
         default="validator",
         help=(
             "How a successful per-Turn validator closes a bounded sequence. "
             "validator trusts exit 0 as terminal; fixed-n treats successful "
-            "steps as progress until the configured final Turn."
+            "steps as progress until the configured final Turn; stability "
+            "continues after exit-code progress or a verified write and stops "
+            "after a no-change review whose completion postcondition passes."
         ),
     )
 
@@ -153,7 +155,7 @@ def skillsbench_loopx_turn_runner_prerequisites(
         ),
         "loopx_turn_terminal_policy": (
             terminal_policy
-            if enabled and terminal_policy in {"validator", "fixed-n"}
+            if enabled and terminal_policy in {"validator", "fixed-n", "stability"}
             else "not_applicable"
         ),
     }
@@ -292,6 +294,9 @@ def _public_validation(value: Any) -> dict[str, Any]:
         "raw_verifier_output_recorded",
         "validated_progress",
         "terminal_complete",
+        "stability_progress_detected",
+        "stability_completion_checked",
+        "stability_completion_satisfied",
     ):
         if isinstance(value.get(key), bool):
             validation[key] = value[key]
@@ -387,7 +392,7 @@ def _aggregate_validations(validations: list[dict[str, Any]]) -> dict[str, Any]:
     terminal_policies = {
         item["terminal_policy"]
         for item in validations
-        if item.get("terminal_policy") in {"validator", "fixed-n"}
+        if item.get("terminal_policy") in {"validator", "fixed-n", "stability"}
     }
     aggregate = {
         "schema_version": "skillsbench_scored_workspace_validation_v0",
@@ -443,6 +448,18 @@ def _aggregate_validations(validations: list[dict[str, Any]]) -> dict[str, Any]:
         aggregate["progress_evidence_kind"] = "mixed"
     if len(terminal_policies) == 1:
         aggregate["terminal_policy"] = terminal_policies.pop()
+    if validations and validations[-1].get("terminal_policy") == "stability":
+        final_validation = validations[-1]
+        for key in (
+            "stability_progress_detected",
+            "stability_completion_checked",
+            "stability_completion_satisfied",
+        ):
+            if isinstance(final_validation.get(key), bool):
+                aggregate[key] = final_validation[key]
+        aggregate["stability_repair_turn_count"] = sum(
+            item.get("stability_progress_detected") is True for item in validations
+        )
     if validations and validations[-1].get("sequence_stop_reason"):
         aggregate["sequence_stop_reason"] = validations[-1]["sequence_stop_reason"]
     return aggregate
@@ -589,11 +606,13 @@ def skillsbench_loopx_turn_launch_error(args: Any) -> dict[str, Any] | None:
             "next_action": "configure --loopx-turn-progress-exit-code from 1 to 255",
         }
     terminal_policy = getattr(args, "loopx_turn_terminal_policy", "validator")
-    if terminal_policy not in {"validator", "fixed-n"}:
+    if terminal_policy not in {"validator", "fixed-n", "stability"}:
         return {
             **common,
             "error_type": "SkillsBenchLoopXTurnTerminalPolicyInvalid",
-            "reason": "LoopX Turn terminal policy must be validator or fixed-n",
+            "reason": (
+                "LoopX Turn terminal policy must be validator, fixed-n, or stability"
+            ),
             "next_action": "configure --loopx-turn-terminal-policy explicitly",
         }
     return None

--- a/loopx/benchmark_adapters/skillsbench_turn_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_runtime.py
@@ -36,7 +36,10 @@ SKILLSBENCH_BRIDGE_OPERATION_SCHEMA_VERSION = (
     "skillsbench_remote_command_file_bridge_operation_response_v0"
 )
 SKILLSBENCH_TURN_BASELINE_ENV = "LOOPX_TURN_BASELINE_FILE"
-SKILLSBENCH_LOOPX_TURN_TERMINAL_POLICIES = frozenset({"validator", "fixed-n"})
+SKILLSBENCH_LOOPX_TURN_TERMINAL_POLICIES = frozenset(
+    {"validator", "fixed-n", "stability"}
+)
+
 
 @dataclass(frozen=True)
 class SkillsBenchTurnAgentResult:
@@ -52,6 +55,13 @@ SKILLSBENCH_LOOPX_TURN_CONTINUATION_PROMPT = """\
 Continue the same task in this same Codex session. Inspect the current workspace
 state, perform the next bounded task-facing step, and stop. Do not use or request
 official verifier, reward, pass/fail, hidden-test, or gold-answer feedback.
+"""
+SKILLSBENCH_LOOPX_TURN_STABILITY_PROMPT = """\
+Review the current solution against the visible task requirements and inspect the
+durable workspace state. Repair concrete defects and run bounded task-derived
+checks when useful. If no repair is needed, stop without manufacturing a change.
+Do not use or request official verifier, reward, pass/fail, hidden-test, or
+gold-answer feedback.
 """
 
 
@@ -363,7 +373,9 @@ def run_skillsbench_loopx_turn(
     if not 1 <= config.progress_exit_code <= 255:
         raise ValueError("SkillsBench progress exit code must be between 1 and 255")
     if config.terminal_policy not in SKILLSBENCH_LOOPX_TURN_TERMINAL_POLICIES:
-        raise ValueError("SkillsBench terminal policy must be validator or fixed-n")
+        raise ValueError(
+            "SkillsBench terminal policy must be validator, fixed-n, or stability"
+        )
     if sequence_step_kind not in {"validator", "progress", "terminal"}:
         raise ValueError("SkillsBench sequence step kind was unsupported")
     bridge = SkillsBenchTurnBridge(config)
@@ -416,6 +428,57 @@ def run_skillsbench_loopx_turn(
                 "exit_code": 1,
             }
         exit_code = validation_result.get("exit_code")
+        if config.terminal_policy == "stability":
+            try:
+                completion_result = bridge.exec(
+                    config.validation_command,
+                    meaningful=True,
+                    allow_nonzero=True,
+                )
+            except SkillsBenchTurnBridgeError:
+                completion_result = {"ok": False, "exit_code": 1}
+            completion_satisfied = completion_result.get("ok") is True
+            progress_detected = bool(
+                exit_code == config.progress_exit_code
+                or _verified_bridge_write_progress(agent_progress_evidence)
+            )
+            stability_evidence = {
+                "stability_progress_detected": progress_detected,
+                "stability_completion_satisfied": completion_satisfied,
+                "stability_completion_checked": True,
+            }
+            if sequence_step_kind == "terminal" and completion_satisfied:
+                return {
+                    "status": "passed",
+                    "validator_kind": "skillsbench_stability_postcondition",
+                    "summary": "independent completion postcondition passed at the Turn limit",
+                    "exit_code": 0,
+                    **stability_evidence,
+                }
+            if progress_detected:
+                return {
+                    "status": "progress",
+                    "validator_kind": "skillsbench_stability_postcondition",
+                    "summary": "independent task progress requires another review Turn",
+                    "exit_code": config.progress_exit_code,
+                    **stability_evidence,
+                }
+            if completion_satisfied:
+                return {
+                    "status": "passed",
+                    "validator_kind": "skillsbench_stability_postcondition",
+                    "summary": "no new repair was needed and the completion postcondition passed",
+                    "exit_code": 0,
+                    **stability_evidence,
+                }
+            return {
+                "status": "failed",
+                "validator_kind": "skillsbench_stability_postcondition",
+                "summary": "neither independent progress nor completion was validated",
+                "recovery_kind": "repair_required",
+                "exit_code": completion_result.get("exit_code"),
+                **stability_evidence,
+            }
         validation_succeeded = exit_code in {0, config.progress_exit_code}
         if not validation_succeeded:
             if _verified_bridge_write_progress(agent_progress_evidence):
@@ -535,11 +598,7 @@ def run_skillsbench_loopx_turn(
     validation_passed = validation_status in {"passed", "progress"}
     terminal_complete = validation_status == "passed"
     validated_progress = validation_status in {"passed", "progress"}
-    bridge_write_progress = bool(
-        transaction_validation.get("validator_kind")
-        == "skillsbench_bridge_write_progress"
-        and _verified_bridge_write_progress(agent_progress_evidence)
-    )
+    bridge_write_progress = _verified_bridge_write_progress(agent_progress_evidence)
     write_count = agent_progress_evidence.get("successful_task_file_write_count")
     if not isinstance(write_count, int) or isinstance(write_count, bool):
         write_count = 0
@@ -563,6 +622,15 @@ def run_skillsbench_loopx_turn(
         "validated_progress": validated_progress,
         "terminal_complete": terminal_complete,
         "terminal_policy": config.terminal_policy,
+        "stability_progress_detected": bool(
+            transaction_validation.get("stability_progress_detected") is True
+        ),
+        "stability_completion_checked": bool(
+            transaction_validation.get("stability_completion_checked") is True
+        ),
+        "stability_completion_satisfied": bool(
+            transaction_validation.get("stability_completion_satisfied") is True
+        ),
         "baseline_contract": (
             "task_declared_independent_postcondition_or_verified_bridge_write"
         ),
@@ -593,7 +661,9 @@ def run_skillsbench_loopx_turn_sequence(
     if config.max_turns < 1:
         raise ValueError("SkillsBench LoopX Turn max_turns must be at least 1")
     if config.terminal_policy not in SKILLSBENCH_LOOPX_TURN_TERMINAL_POLICIES:
-        raise ValueError("SkillsBench terminal policy must be validator or fixed-n")
+        raise ValueError(
+            "SkillsBench terminal policy must be validator, fixed-n, or stability"
+        )
     sequence_id = uuid.uuid4().hex[:16]
     deadline = time.monotonic() + max(1.0, config.agent_timeout_seconds)
     records: list[tuple[dict[str, Any], dict[str, Any]]] = []
@@ -603,14 +673,22 @@ def run_skillsbench_loopx_turn_sequence(
         if remaining_seconds <= 0:
             stop_reason = "time_budget_exhausted"
             break
-        turn_prompt = (
-            prompt if turn_index == 1 else SKILLSBENCH_LOOPX_TURN_CONTINUATION_PROMPT
-        )
+        if turn_index == 1:
+            turn_prompt = prompt
+        elif config.terminal_policy == "stability":
+            turn_prompt = SKILLSBENCH_LOOPX_TURN_STABILITY_PROMPT
+        else:
+            turn_prompt = SKILLSBENCH_LOOPX_TURN_CONTINUATION_PROMPT
         sequence_step_kind = "validator"
         if config.terminal_policy == "fixed-n":
             sequence_step_kind = (
                 "terminal" if turn_index == config.max_turns else "progress"
             )
+        elif (
+            config.terminal_policy == "stability"
+            and turn_index == config.max_turns
+        ):
+            sequence_step_kind = "terminal"
         execution, validation = run_skillsbench_loopx_turn(
             prompt=turn_prompt,
             agent_runner=agent_runner,
@@ -654,14 +732,22 @@ def build_skillsbench_benchmark_runner_readiness(
 ) -> dict[str, Any]:
     """Reduce a Turn outcome to a compact, public-safe runner capability receipt."""
 
+    pre_agent_unsatisfied = scored_workspace_validation.get(
+        "pre_agent_postcondition_status"
+    ) in {"unsatisfied", "progress_validated"}
+    stability_terminal_review = bool(
+        scored_workspace_validation.get("terminal_policy") == "stability"
+        and scored_workspace_validation.get("terminal_complete") is True
+        and scored_workspace_validation.get("stability_completion_checked") is True
+        and scored_workspace_validation.get("stability_completion_satisfied") is True
+    )
     checks = {
         "turn_transaction_committed": execution.get("status") == "committed",
         "pre_agent_postcondition_checked": (
             scored_workspace_validation.get("pre_agent_postcondition_checked") is True
         ),
-        "pre_agent_postcondition_unsatisfied": (
-            scored_workspace_validation.get("pre_agent_postcondition_status")
-            in {"unsatisfied", "progress_validated"}
+        "pre_agent_postcondition_eligible": (
+            pre_agent_unsatisfied or stability_terminal_review
         ),
         "post_agent_postcondition_satisfied": (
             scored_workspace_validation.get("post_agent_postcondition_status")
@@ -679,7 +765,7 @@ def build_skillsbench_benchmark_runner_readiness(
         "ready": not blockers,
         "checks": checks,
         "blocker_codes": blockers,
-        "evidence_kind": "committed_turn_with_independent_postcondition_baseline",
+        "evidence_kind": "committed_turn_with_independent_postcondition",
         "raw_task_text_recorded": False,
         "raw_validator_output_recorded": False,
         "raw_verifier_output_recorded": False,
@@ -822,7 +908,9 @@ def run_skillsbench_loopx_turn_relay(
     if not 1 <= progress_exit_code <= 255:
         raise RuntimeError("LoopX Turn progress exit code must be between 1 and 255")
     if terminal_policy not in SKILLSBENCH_LOOPX_TURN_TERMINAL_POLICIES:
-        raise RuntimeError("LoopX Turn terminal policy must be validator or fixed-n")
+        raise RuntimeError(
+            "LoopX Turn terminal policy must be validator, fixed-n, or stability"
+        )
     runtime_session = (
         "".join(
             char if char.isalnum() or char in "_.:-" else "_" for char in session_id

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -290,8 +290,9 @@ if [[ "$route" == "loopx-turn-agent-cli" ]]; then
     exit 2
   fi
   if [[ "$loopx_turn_terminal_policy" != "validator" ]] &&
-    [[ "$loopx_turn_terminal_policy" != "fixed-n" ]]; then
-    echo "SKILLSBENCH_LOOPX_TURN_TERMINAL_POLICY must be validator or fixed-n" >&2
+    [[ "$loopx_turn_terminal_policy" != "fixed-n" ]] &&
+    [[ "$loopx_turn_terminal_policy" != "stability" ]]; then
+    echo "SKILLSBENCH_LOOPX_TURN_TERMINAL_POLICY must be validator, fixed-n, or stability" >&2
     exit 2
   fi
 fi

--- a/scripts/skillsbench_local_acp_relay.py
+++ b/scripts/skillsbench_local_acp_relay.py
@@ -249,7 +249,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--loopx-turn-progress-exit-code", type=int, default=10)
     parser.add_argument(
         "--loopx-turn-terminal-policy",
-        choices=("validator", "fixed-n"),
+        choices=("validator", "fixed-n", "stability"),
         default="validator",
     )
     parser.add_argument("--loopx-case-goal-id", default="skillsbench-case")

--- a/tests/test_skillsbench_turn_runtime.py
+++ b/tests/test_skillsbench_turn_runtime.py
@@ -18,6 +18,8 @@ from loopx.benchmark_adapters.skillsbench_acp_relay import (
 )
 from loopx.benchmark_adapters.skillsbench_turn_route import (
     SkillsBenchTurnTraceSummary,
+    skillsbench_loopx_turn_launch_error,
+    skillsbench_loopx_turn_runner_prerequisites,
     sync_skillsbench_loopx_turn_trace_into_compact,
 )
 
@@ -30,6 +32,104 @@ def _config(tmp_path: Path) -> runtime.SkillsBenchTurnRuntimeConfig:
         agent_id="synthetic-agent",
         runtime_root=tmp_path,
     )
+
+
+def _install_sequence_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    validation_runs: list[list[int] | tuple[int, ...]],
+) -> tuple[list[str], dict[str, int]]:
+    plan_instance_ids: list[str] = []
+    callback_counts = {"writeback": 0, "spend": 0}
+
+    class SequenceBridge:
+        instance_count = 0
+
+        def __init__(self, _config: Any) -> None:
+            self.meaningful_operation_count = 0
+            self.validation_codes = list(
+                validation_runs[SequenceBridge.instance_count]
+            )
+            SequenceBridge.instance_count += 1
+
+        def exec(
+            self,
+            _command: str,
+            *,
+            meaningful: bool = False,
+            allow_nonzero: bool = False,
+        ) -> dict[str, Any]:
+            if allow_nonzero:
+                code = self.validation_codes.pop(0)
+                if meaningful:
+                    self.meaningful_operation_count += 1
+                return {
+                    "ok": code == 0,
+                    "exit_code": code,
+                    "elapsed_ms": 1,
+                    **({"stdout": ""} if code == 0 else {}),
+                }
+            return {"ok": True, "exit_code": 0, "stdout": "", "elapsed_ms": 1}
+
+        def loopx_json(self, command: str) -> dict[str, Any]:
+            if "refresh-state" in command:
+                callback_counts["writeback"] += 1
+                return {"ok": True, "appended": True}
+            if "spend-slot" in command:
+                callback_counts["spend"] += 1
+                return {"ok": True, "appended": True, "slots": 1}
+            return {
+                "scheduler_hint": {
+                    "execution_phase": {
+                        "disposition": "outer_controller_owned",
+                        "completed": True,
+                        "acknowledged": False,
+                        "apply_needed": False,
+                    }
+                }
+            }
+
+    def fake_plan(
+        _bridge: Any,
+        _config: Any,
+        *,
+        turn_instance_id: str,
+    ) -> dict[str, Any]:
+        plan_instance_ids.append(turn_instance_id)
+        return {"ok": True, "turn_key": turn_instance_id}
+
+    def fake_turn_once(
+        plan: dict[str, Any],
+        *,
+        host_runner: Any,
+        task_validator: Any,
+        writeback: Any,
+        spend: Any,
+        scheduler: Any,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        result = host_runner({"turn_key": plan["turn_key"]})
+        validation = dict(task_validator(plan, result))
+        assert validation["status"] in {"progress", "passed"}
+        writeback_payload = writeback(result)
+        spend_payload = spend()
+        scheduler(spend_payload)
+        return {
+            "status": "committed",
+            "validation": validation,
+            "quota_slot_spend_count": 1,
+            "receipt": {"status": "committed"},
+            "effects": {
+                "host_invoked": True,
+                "state_written": writeback_payload["appended"],
+                "quota_spent": spend_payload["appended"],
+                "scheduler_acknowledged": False,
+            },
+        }
+
+    monkeypatch.setattr(runtime, "SkillsBenchTurnBridge", SequenceBridge)
+    monkeypatch.setattr(runtime, "_turn_plan", fake_plan)
+    monkeypatch.setattr(runtime, "run_loopx_turn_once", fake_turn_once)
+    return plan_instance_ids, callback_counts
 
 
 def test_nonzero_validation_probe_does_not_return_private_output(
@@ -334,7 +434,7 @@ def test_satisfied_pre_agent_postcondition_runs_but_does_not_claim_readiness(
     assert validation["pre_agent_postcondition_status"] == "already_satisfied"
     assert validation["meaningful_operation_count"] == 1
     assert receipt["ready"] is False
-    assert "pre_agent_postcondition_unsatisfied" in receipt["blocker_codes"]
+    assert "pre_agent_postcondition_eligible" in receipt["blocker_codes"]
 
 
 def test_fixed_n_maps_accepted_exit_zero_to_nonterminal_progress(
@@ -469,100 +569,11 @@ def test_adaptive_sequence_commits_progress_then_terminal_turns(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    validation_pairs = [(3, 10), (10, 0)]
-    plan_instance_ids: list[str] = []
+    plan_instance_ids, callback_counts = _install_sequence_runtime(
+        monkeypatch, [(3, 10), (10, 0)]
+    )
     agent_prompts: list[str] = []
-    callback_counts = {"writeback": 0, "spend": 0}
     observed: list[tuple[dict[str, Any], dict[str, Any]]] = []
-
-    class SequenceBridge:
-        instance_count = 0
-
-        def __init__(self, _config: Any) -> None:
-            self.meaningful_operation_count = 0
-            self.validation_codes = list(
-                validation_pairs[SequenceBridge.instance_count]
-            )
-            SequenceBridge.instance_count += 1
-
-        def exec(
-            self,
-            _command: str,
-            *,
-            meaningful: bool = False,
-            allow_nonzero: bool = False,
-        ) -> dict[str, Any]:
-            if allow_nonzero:
-                code = self.validation_codes.pop(0)
-                if meaningful:
-                    self.meaningful_operation_count += 1
-                return {
-                    "ok": code == 0,
-                    "exit_code": code,
-                    "elapsed_ms": 1,
-                    **({"stdout": ""} if code == 0 else {}),
-                }
-            return {"ok": True, "exit_code": 0, "stdout": "", "elapsed_ms": 1}
-
-        def loopx_json(self, command: str) -> dict[str, Any]:
-            if "refresh-state" in command:
-                callback_counts["writeback"] += 1
-                return {"ok": True, "appended": True}
-            if "spend-slot" in command:
-                callback_counts["spend"] += 1
-                return {"ok": True, "appended": True, "slots": 1}
-            return {
-                "scheduler_hint": {
-                    "execution_phase": {
-                        "disposition": "outer_controller_owned",
-                        "completed": True,
-                        "acknowledged": False,
-                        "apply_needed": False,
-                    }
-                }
-            }
-
-    def fake_plan(
-        _bridge: Any,
-        _config: Any,
-        *,
-        turn_instance_id: str,
-    ) -> dict[str, Any]:
-        plan_instance_ids.append(turn_instance_id)
-        return {"ok": True, "turn_key": f"turn-{len(plan_instance_ids)}"}
-
-    def fake_turn_once(
-        plan: dict[str, Any],
-        *,
-        host_runner: Any,
-        task_validator: Any,
-        writeback: Any,
-        spend: Any,
-        scheduler: Any,
-        **_kwargs: Any,
-    ) -> dict[str, Any]:
-        result = host_runner({"turn_key": plan["turn_key"]})
-        validation = dict(task_validator(plan, result))
-        assert validation["status"] in {"progress", "passed"}
-        writeback_payload = writeback(result)
-        spend_payload = spend()
-        scheduler(spend_payload)
-        return {
-            "status": "committed",
-            "validation": validation,
-            "quota_slot_spend_count": 1,
-            "receipt": {"status": "committed"},
-            "effects": {
-                "host_invoked": True,
-                "state_written": writeback_payload["appended"],
-                "quota_spent": spend_payload["appended"],
-                "scheduler_acknowledged": False,
-            },
-        }
-
-    monkeypatch.setattr(runtime, "SkillsBenchTurnBridge", SequenceBridge)
-    monkeypatch.setattr(runtime, "_turn_plan", fake_plan)
-    monkeypatch.setattr(runtime, "run_loopx_turn_once", fake_turn_once)
 
     records, sequence = runtime.run_skillsbench_loopx_turn_sequence(
         prompt="original task prompt",
@@ -591,6 +602,101 @@ def test_adaptive_sequence_commits_progress_then_terminal_turns(
     assert records[1][1]["terminal_complete"] is True
     assert records[1][1]["sequence_stop_reason"] == "terminal_complete"
     assert len(observed) == 2
+
+
+def test_stability_sequence_repeats_repairs_then_stops_after_no_change(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    validation_codes = [
+        [3, 10, 0],
+        [0, 10, 0],
+        [0, 1, 0],
+    ]
+    _plan_instance_ids, callback_counts = _install_sequence_runtime(
+        monkeypatch, validation_codes
+    )
+    agent_prompts: list[str] = []
+
+    records, sequence = runtime.run_skillsbench_loopx_turn_sequence(
+        prompt="original task prompt",
+        agent_runner=lambda prompt: agent_prompts.append(prompt) or "done",
+        config=runtime.SkillsBenchTurnRuntimeConfig(
+            **{
+                **_config(tmp_path).__dict__,
+                "max_turns": 4,
+                "terminal_policy": "stability",
+            }
+        ),
+    )
+
+    assert sequence["status"] == "terminal_complete"
+    assert sequence["turn_count"] == 3
+    assert callback_counts == {"writeback": 3, "spend": 3}
+    assert agent_prompts[0] == "original task prompt"
+    assert all(
+        "without manufacturing a change" in prompt for prompt in agent_prompts[1:]
+    )
+    assert [record[1]["terminal_complete"] for record in records] == [
+        False,
+        False,
+        True,
+    ]
+    assert [record[1]["stability_progress_detected"] for record in records] == [
+        True,
+        True,
+        False,
+    ]
+    assert all(
+        record[1]["stability_completion_satisfied"] is True for record in records
+    )
+    readiness = runtime.build_skillsbench_benchmark_runner_readiness(
+        execution=records[-1][0],
+        scored_workspace_validation=records[-1][1],
+    )
+    assert readiness["ready"] is True
+    summary = SkillsBenchTurnTraceSummary()
+    for execution, validation in records:
+        trace = runtime.build_skillsbench_loopx_turn_trace(
+            route="loopx-turn-agent-cli",
+            benchmark_id="synthetic-benchmark",
+            task_id="synthetic-task",
+            execution=execution,
+            scored_workspace_validation=validation,
+        )
+        summary.merge(trace, trace["boundary"])
+    controller_trace: dict[str, Any] = {}
+    summary.apply(controller_trace)
+    aggregate = controller_trace["scored_workspace_validation"]
+    assert aggregate["terminal_policy"] == "stability"
+    assert aggregate["terminal_complete"] is True
+    assert aggregate["stability_completion_satisfied"] is True
+    assert aggregate["stability_progress_detected"] is False
+    assert aggregate["stability_repair_turn_count"] == 2
+    assert controller_trace["benchmark_runner_readiness"]["ready"] is True
+
+
+def test_stability_policy_is_projected_and_launchable() -> None:
+    prerequisites = skillsbench_loopx_turn_runner_prerequisites(
+        "loopx-turn-agent-cli",
+        "private-command",
+        max_turns=4,
+        progress_exit_code=10,
+        terminal_policy="stability",
+    )
+    launch_error = skillsbench_loopx_turn_launch_error(
+        SimpleNamespace(
+            route="loopx-turn-agent-cli",
+            host_local_acp_launch=True,
+            loopx_turn_validation_command="private-command",
+            loopx_turn_max_turns=4,
+            loopx_turn_progress_exit_code=10,
+            loopx_turn_terminal_policy="stability",
+        )
+    )
+
+    assert prerequisites["loopx_turn_terminal_policy"] == "stability"
+    assert launch_error is None
 
 
 def test_skillsbench_n_turn_codex_exec_starts_then_resumes_same_thread(
@@ -1171,9 +1277,18 @@ def test_adaptive_sequence_stops_on_missing_progress_or_fixed_maximum(
     assert sequence["status"] == expected_reason
 
 
-def test_fixed_n_sequence_promotes_only_final_validated_step_to_terminal(
+@pytest.mark.parametrize(
+    ("terminal_policy", "expected_step_kinds"),
+    [
+        ("fixed-n", ["progress", "progress", "terminal"]),
+        ("stability", ["validator", "validator", "terminal"]),
+    ],
+)
+def test_sequence_reserves_terminal_step_for_configured_bound(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    terminal_policy: str,
+    expected_step_kinds: list[str],
 ) -> None:
     step_kinds: list[str] = []
 
@@ -1199,15 +1314,15 @@ def test_fixed_n_sequence_promotes_only_final_validated_step_to_terminal(
             **{
                 **_config(tmp_path).__dict__,
                 "max_turns": 3,
-                "terminal_policy": "fixed-n",
+                "terminal_policy": terminal_policy,
             }
         ),
     )
 
-    assert step_kinds == ["progress", "progress", "terminal"]
+    assert step_kinds == expected_step_kinds
     assert len(records) == 3
     assert sequence["status"] == "terminal_complete"
-    assert sequence["terminal_policy"] == "fixed-n"
+    assert sequence["terminal_policy"] == terminal_policy
 
 
 @pytest.mark.parametrize(
@@ -1218,7 +1333,7 @@ def test_fixed_n_sequence_promotes_only_final_validated_step_to_terminal(
             "committed",
             "already_satisfied",
             "satisfied",
-            "pre_agent_postcondition_unsatisfied",
+            "pre_agent_postcondition_eligible",
         ),
         (
             "committed",


### PR DESCRIPTION
## Summary
- add an experimental `stability` terminal policy for bounded N-Turn benchmark runs
- continue after independently detected repairs, then stop after a no-change review whose completion postcondition still passes
- use a review/repair continuation prompt without hard-coding a second step
- project stability evidence through route prerequisites, readiness, and compact reducers

## Validation
- `pytest` Turn/runtime/driver suite: 104 passed
- `ruff check`: passed
- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`: passed
- `examples/skillsbench-loopx-turn-agent-cli-smoke.py`: passed
- premerge direct checks: 4/4 passed
- catalog canaries: 6/6 passed
- expected manual hold: `benchmark_sensitive`

## Boundary and merge rationale
- no benchmark scoring, task semantics, leaderboard, submission, or permission changes
- no benchmark jobs launched by this PR
- no raw task text, trajectories, verifier output, credentials, private state, local paths, or generated logs included
- the only manual hold is the benchmark-sensitive classification; owner authorization permits self-review and admin merge for this bounded benchmark helper/runtime change after checks
