### PR TITLE
Stabilize adaptive Turn completion baselines

### DIFF
--- a/loopx/benchmark_adapters/skillsbench_turn_route.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_route.py
@@ -84,8 +84,11 @@ def add_skillsbench_loopx_turn_arguments(parser: Any) -> None:
             "LoopX Turn Agent CLI route. It must be safe to run before and after "
             "each agent Turn; the pre-agent result qualifies the validation "
             "baseline without blocking later Turns whose overall postcondition "
-            "is already satisfied. The command is executed only through the "
-            "sandbox bridge and is never written to public compact traces."
+            "is already satisfied. Per-Turn progress checks receive "
+            "LOOPX_TURN_BASELINE_FILE; stability completion checks receive "
+            "LOOPX_TURN_SEQUENCE_BASELINE_FILE. The command is executed only "
+            "through the sandbox bridge and is never written to public compact "
+            "traces."
         ),
     )
     parser.add_argument(
@@ -294,6 +297,7 @@ def _public_validation(value: Any) -> dict[str, Any]:
         "raw_verifier_output_recorded",
         "validated_progress",
         "terminal_complete",
+        "sequence_baseline_configured",
         "stability_progress_detected",
         "stability_completion_checked",
         "stability_completion_satisfied",
@@ -451,6 +455,7 @@ def _aggregate_validations(validations: list[dict[str, Any]]) -> dict[str, Any]:
     if validations and validations[-1].get("terminal_policy") == "stability":
         final_validation = validations[-1]
         for key in (
+            "sequence_baseline_configured",
             "stability_progress_detected",
             "stability_completion_checked",
             "stability_completion_satisfied",

--- a/loopx/benchmark_adapters/skillsbench_turn_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_runtime.py
@@ -36,6 +36,7 @@ SKILLSBENCH_BRIDGE_OPERATION_SCHEMA_VERSION = (
     "skillsbench_remote_command_file_bridge_operation_response_v0"
 )
 SKILLSBENCH_TURN_BASELINE_ENV = "LOOPX_TURN_BASELINE_FILE"
+SKILLSBENCH_TURN_SEQUENCE_BASELINE_ENV = "LOOPX_TURN_SEQUENCE_BASELINE_FILE"
 SKILLSBENCH_LOOPX_TURN_TERMINAL_POLICIES = frozenset(
     {"validator", "fixed-n", "stability"}
 )
@@ -77,6 +78,7 @@ class SkillsBenchTurnRuntimeConfig:
     max_turns: int = 1
     progress_exit_code: int = 10
     terminal_policy: str = "validator"
+    sequence_baseline_path: str = ""
     case_cli_path: str = "/app/.local/bin/loopx"
     case_registry_path: str = "/app/.loopx/registry.json"
     case_runtime_root: str = "/app/.loopx/runtime"
@@ -329,7 +331,9 @@ def _validation_baseline(
     """Observe whether the task postcondition is satisfied before agent work."""
 
     try:
-        result = bridge.exec(config.validation_command, allow_nonzero=True)
+        result = bridge.exec(
+            _completion_validation_command(config), allow_nonzero=True
+        )
     except SkillsBenchTurnBridgeError as exc:
         raise SkillsBenchTurnBridgeError(
             str(exc),
@@ -354,6 +358,16 @@ def _validation_baseline(
     }
 
 
+def _completion_validation_command(config: SkillsBenchTurnRuntimeConfig) -> str:
+    if not config.sequence_baseline_path:
+        return config.validation_command
+    return (
+        f"env {SKILLSBENCH_TURN_SEQUENCE_BASELINE_ENV}="
+        f"{shlex.quote(config.sequence_baseline_path)} sh -c "
+        f"{shlex.quote(config.validation_command)}"
+    )
+
+
 def run_skillsbench_loopx_turn(
     *,
     prompt: str,
@@ -376,9 +390,20 @@ def run_skillsbench_loopx_turn(
         raise ValueError(
             "SkillsBench terminal policy must be validator, fixed-n, or stability"
         )
+    if config.terminal_policy == "stability" and not config.sequence_baseline_path:
+        raise ValueError("SkillsBench stability policy requires a sequence baseline")
     if sequence_step_kind not in {"validator", "progress", "terminal"}:
         raise ValueError("SkillsBench sequence step kind was unsupported")
     bridge = SkillsBenchTurnBridge(config)
+    if config.terminal_policy == "stability":
+        sequence_baseline_path = shlex.quote(config.sequence_baseline_path)
+        sequence_baseline_dir = shlex.quote(
+            str(Path(config.sequence_baseline_path).parent)
+        )
+        bridge.exec(
+            f"umask 077; mkdir -p {sequence_baseline_dir}; "
+            f"test -e {sequence_baseline_path} || : > {sequence_baseline_path}"
+        )
     plan = (
         _turn_plan(bridge, config, turn_instance_id=turn_instance_id)
         if turn_instance_id is not None
@@ -431,7 +456,7 @@ def run_skillsbench_loopx_turn(
         if config.terminal_policy == "stability":
             try:
                 completion_result = bridge.exec(
-                    config.validation_command,
+                    _completion_validation_command(config),
                     meaningful=True,
                     allow_nonzero=True,
                 )
@@ -622,6 +647,7 @@ def run_skillsbench_loopx_turn(
         "validated_progress": validated_progress,
         "terminal_complete": terminal_complete,
         "terminal_policy": config.terminal_policy,
+        "sequence_baseline_configured": bool(config.sequence_baseline_path),
         "stability_progress_detected": bool(
             transaction_validation.get("stability_progress_detected") is True
         ),
@@ -665,6 +691,16 @@ def run_skillsbench_loopx_turn_sequence(
             "SkillsBench terminal policy must be validator, fixed-n, or stability"
         )
     sequence_id = uuid.uuid4().hex[:16]
+    sequence_baseline_path = (
+        f"{config.case_runtime_root.rstrip('/')}"
+        f"/benchmark-turn-sequences/{sequence_id}.baseline"
+    )
+    sequence_config = replace(
+        config,
+        sequence_baseline_path=(
+            sequence_baseline_path if config.terminal_policy == "stability" else ""
+        ),
+    )
     deadline = time.monotonic() + max(1.0, config.agent_timeout_seconds)
     records: list[tuple[dict[str, Any], dict[str, Any]]] = []
     stop_reason = "max_turns_reached"
@@ -692,7 +728,9 @@ def run_skillsbench_loopx_turn_sequence(
         execution, validation = run_skillsbench_loopx_turn(
             prompt=turn_prompt,
             agent_runner=agent_runner,
-            config=replace(config, agent_timeout_seconds=remaining_seconds),
+            config=replace(
+                sequence_config, agent_timeout_seconds=remaining_seconds
+            ),
             turn_instance_id=f"{sequence_id}-turn-{turn_index:03d}",
             sequence_step_kind=sequence_step_kind,
         )

--- a/tests/test_skillsbench_turn_runtime.py
+++ b/tests/test_skillsbench_turn_runtime.py
@@ -37,9 +37,11 @@ def _config(tmp_path: Path) -> runtime.SkillsBenchTurnRuntimeConfig:
 def _install_sequence_runtime(
     monkeypatch: pytest.MonkeyPatch,
     validation_runs: list[list[int] | tuple[int, ...]],
-) -> tuple[list[str], dict[str, int]]:
+) -> tuple[list[str], dict[str, int], list[str], list[str]]:
     plan_instance_ids: list[str] = []
     callback_counts = {"writeback": 0, "spend": 0}
+    bridge_commands: list[str] = []
+    sequence_baseline_paths: list[str] = []
 
     class SequenceBridge:
         instance_count = 0
@@ -53,11 +55,12 @@ def _install_sequence_runtime(
 
         def exec(
             self,
-            _command: str,
+            command: str,
             *,
             meaningful: bool = False,
             allow_nonzero: bool = False,
         ) -> dict[str, Any]:
+            bridge_commands.append(command)
             if allow_nonzero:
                 code = self.validation_codes.pop(0)
                 if meaningful:
@@ -95,6 +98,7 @@ def _install_sequence_runtime(
         turn_instance_id: str,
     ) -> dict[str, Any]:
         plan_instance_ids.append(turn_instance_id)
+        sequence_baseline_paths.append(_config.sequence_baseline_path)
         return {"ok": True, "turn_key": turn_instance_id}
 
     def fake_turn_once(
@@ -129,7 +133,12 @@ def _install_sequence_runtime(
     monkeypatch.setattr(runtime, "SkillsBenchTurnBridge", SequenceBridge)
     monkeypatch.setattr(runtime, "_turn_plan", fake_plan)
     monkeypatch.setattr(runtime, "run_loopx_turn_once", fake_turn_once)
-    return plan_instance_ids, callback_counts
+    return (
+        plan_instance_ids,
+        callback_counts,
+        bridge_commands,
+        sequence_baseline_paths,
+    )
 
 
 def test_nonzero_validation_probe_does_not_return_private_output(
@@ -569,9 +578,12 @@ def test_adaptive_sequence_commits_progress_then_terminal_turns(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    plan_instance_ids, callback_counts = _install_sequence_runtime(
-        monkeypatch, [(3, 10), (10, 0)]
-    )
+    (
+        plan_instance_ids,
+        callback_counts,
+        _bridge_commands,
+        sequence_baseline_paths,
+    ) = _install_sequence_runtime(monkeypatch, [(3, 10), (10, 0)])
     agent_prompts: list[str] = []
     observed: list[tuple[dict[str, Any], dict[str, Any]]] = []
 
@@ -595,6 +607,7 @@ def test_adaptive_sequence_commits_progress_then_terminal_turns(
     assert agent_prompts[0] == "original task prompt"
     assert "Continue the same task" in agent_prompts[1]
     assert callback_counts == {"writeback": 2, "spend": 2}
+    assert sequence_baseline_paths == ["", ""]
     assert [item[0]["quota_slot_spend_count"] for item in records] == [1, 1]
     assert records[0][1]["validated_progress"] is True
     assert records[0][1]["terminal_complete"] is False
@@ -613,9 +626,12 @@ def test_stability_sequence_repeats_repairs_then_stops_after_no_change(
         [0, 10, 0],
         [0, 1, 0],
     ]
-    _plan_instance_ids, callback_counts = _install_sequence_runtime(
-        monkeypatch, validation_codes
-    )
+    (
+        _plan_instance_ids,
+        callback_counts,
+        bridge_commands,
+        sequence_baseline_paths,
+    ) = _install_sequence_runtime(monkeypatch, validation_codes)
     agent_prompts: list[str] = []
 
     records, sequence = runtime.run_skillsbench_loopx_turn_sequence(
@@ -633,6 +649,25 @@ def test_stability_sequence_repeats_repairs_then_stops_after_no_change(
     assert sequence["status"] == "terminal_complete"
     assert sequence["turn_count"] == 3
     assert callback_counts == {"writeback": 3, "spend": 3}
+    assert len(set(sequence_baseline_paths)) == 1
+    assert sequence_baseline_paths[0].startswith(
+        "/app/.loopx/runtime/benchmark-turn-sequences/"
+    )
+    assert sequence_baseline_paths[0].endswith(".baseline")
+    assert (
+        sum(
+            f"{runtime.SKILLSBENCH_TURN_BASELINE_ENV}=" in command
+            for command in bridge_commands
+        )
+        == 3
+    )
+    assert (
+        sum(
+            f"{runtime.SKILLSBENCH_TURN_SEQUENCE_BASELINE_ENV}=" in command
+            for command in bridge_commands
+        )
+        == 6
+    )
     assert agent_prompts[0] == "original task prompt"
     assert all(
         "without manufacturing a change" in prompt for prompt in agent_prompts[1:]
@@ -650,6 +685,8 @@ def test_stability_sequence_repeats_repairs_then_stops_after_no_change(
     assert all(
         record[1]["stability_completion_satisfied"] is True for record in records
     )
+    assert all(record[1]["sequence_baseline_configured"] is True for record in records)
+    assert sequence_baseline_paths[0] not in json.dumps(records, sort_keys=True)
     readiness = runtime.build_skillsbench_benchmark_runner_readiness(
         execution=records[-1][0],
         scored_workspace_validation=records[-1][1],
@@ -670,10 +707,25 @@ def test_stability_sequence_repeats_repairs_then_stops_after_no_change(
     aggregate = controller_trace["scored_workspace_validation"]
     assert aggregate["terminal_policy"] == "stability"
     assert aggregate["terminal_complete"] is True
+    assert aggregate["sequence_baseline_configured"] is True
     assert aggregate["stability_completion_satisfied"] is True
     assert aggregate["stability_progress_detected"] is False
     assert aggregate["stability_repair_turn_count"] == 2
     assert controller_trace["benchmark_runner_readiness"]["ready"] is True
+
+
+def test_stability_turn_requires_sequence_baseline(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="requires a sequence baseline"):
+        runtime.run_skillsbench_loopx_turn(
+            prompt="synthetic prompt",
+            agent_runner=lambda _prompt: "done",
+            config=runtime.SkillsBenchTurnRuntimeConfig(
+                **{
+                    **_config(tmp_path).__dict__,
+                    "terminal_policy": "stability",
+                }
+            ),
+        )
 
 
 def test_stability_policy_is_projected_and_launchable() -> None:


### PR DESCRIPTION
## Summary
- create one private sequence-start baseline for stability-policy N-Turn runs
- expose separate per-Turn progress and sequence completion validator contexts
- project only a public-safe configured boolean and keep baseline paths private

## Validation
- 66 Turn runtime/driver/launcher tests passed
- focused runtime suite: 27 passed
- ruff check and py_compile passed
- SkillsBench LoopX Turn public smoke passed
- SkillsBench runner-profile smoke passed
- premerge direct checks: 4/4 passed
- catalog canaries: 6/6 passed

## Boundary and review
- no benchmark job, upload, submission, scoring, or task-semantics change
- no raw task text, trajectories, verifier output, credentials, local paths, or generated logs included
- premerge reports only the expected benchmark-sensitive manual hold; owner authorization permits self-review and admin merge for this narrow benchmark runtime helper change
