### PR TITLE
Keep stability evidence outside Turn receipts

### DIFF
--- a/loopx/benchmark_adapters/skillsbench_turn_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_runtime.py
@@ -413,6 +413,7 @@ def run_skillsbench_loopx_turn(
     prefix = _case_cli_prefix(config)
     baseline_path = ""
     agent_progress_evidence: dict[str, Any] = {}
+    stability_validation_evidence: dict[str, bool] = {}
 
     def host_runner(request: Mapping[str, Any]) -> dict[str, Any]:
         nonlocal agent_progress_evidence, baseline_path
@@ -425,6 +426,7 @@ def run_skillsbench_loopx_turn(
         _plan: Mapping[str, Any],
         _result: Mapping[str, Any],
     ) -> Mapping[str, Any]:
+        nonlocal stability_validation_evidence
         if not baseline_path:
             return {
                 "status": "failed",
@@ -467,7 +469,7 @@ def run_skillsbench_loopx_turn(
                 exit_code == config.progress_exit_code
                 or _verified_bridge_write_progress(agent_progress_evidence)
             )
-            stability_evidence = {
+            stability_validation_evidence = {
                 "stability_progress_detected": progress_detected,
                 "stability_completion_satisfied": completion_satisfied,
                 "stability_completion_checked": True,
@@ -478,7 +480,6 @@ def run_skillsbench_loopx_turn(
                     "validator_kind": "skillsbench_stability_postcondition",
                     "summary": "independent completion postcondition passed at the Turn limit",
                     "exit_code": 0,
-                    **stability_evidence,
                 }
             if progress_detected:
                 return {
@@ -486,7 +487,6 @@ def run_skillsbench_loopx_turn(
                     "validator_kind": "skillsbench_stability_postcondition",
                     "summary": "independent task progress requires another review Turn",
                     "exit_code": config.progress_exit_code,
-                    **stability_evidence,
                 }
             if completion_satisfied:
                 return {
@@ -494,7 +494,6 @@ def run_skillsbench_loopx_turn(
                     "validator_kind": "skillsbench_stability_postcondition",
                     "summary": "no new repair was needed and the completion postcondition passed",
                     "exit_code": 0,
-                    **stability_evidence,
                 }
             return {
                 "status": "failed",
@@ -502,7 +501,6 @@ def run_skillsbench_loopx_turn(
                 "summary": "neither independent progress nor completion was validated",
                 "recovery_kind": "repair_required",
                 "exit_code": completion_result.get("exit_code"),
-                **stability_evidence,
             }
         validation_succeeded = exit_code in {0, config.progress_exit_code}
         if not validation_succeeded:
@@ -649,13 +647,13 @@ def run_skillsbench_loopx_turn(
         "terminal_policy": config.terminal_policy,
         "sequence_baseline_configured": bool(config.sequence_baseline_path),
         "stability_progress_detected": bool(
-            transaction_validation.get("stability_progress_detected") is True
+            stability_validation_evidence.get("stability_progress_detected") is True
         ),
         "stability_completion_checked": bool(
-            transaction_validation.get("stability_completion_checked") is True
+            stability_validation_evidence.get("stability_completion_checked") is True
         ),
         "stability_completion_satisfied": bool(
-            transaction_validation.get("stability_completion_satisfied") is True
+            stability_validation_evidence.get("stability_completion_satisfied") is True
         ),
         "baseline_contract": (
             "task_declared_independent_postcondition_or_verified_bridge_write"

--- a/tests/test_skillsbench_turn_runtime.py
+++ b/tests/test_skillsbench_turn_runtime.py
@@ -22,6 +22,7 @@ from loopx.benchmark_adapters.skillsbench_turn_route import (
     skillsbench_loopx_turn_runner_prerequisites,
     sync_skillsbench_loopx_turn_trace_into_compact,
 )
+from loopx.control_plane.turn_driver import executor as turn_executor
 
 
 def _config(tmp_path: Path) -> runtime.SkillsBenchTurnRuntimeConfig:
@@ -112,7 +113,11 @@ def _install_sequence_runtime(
         **_kwargs: Any,
     ) -> dict[str, Any]:
         result = host_runner({"turn_key": plan["turn_key"]})
-        validation = dict(task_validator(plan, result))
+        validation = turn_executor._run_task_validator(
+            plan,
+            result,
+            validator=task_validator,
+        )
         assert validation["status"] in {"progress", "passed"}
         writeback_payload = writeback(result)
         spend_payload = spend()
@@ -687,6 +692,10 @@ def test_stability_sequence_repeats_repairs_then_stops_after_no_change(
     )
     assert all(record[1]["sequence_baseline_configured"] is True for record in records)
     assert sequence_baseline_paths[0] not in json.dumps(records, sort_keys=True)
+    assert all(
+        not any(key.startswith("stability_") for key in execution["validation"])
+        for execution, _validation in records
+    )
     readiness = runtime.build_skillsbench_benchmark_runner_readiness(
         execution=records[-1][0],
         scored_workspace_validation=records[-1][1],


### PR DESCRIPTION
## Summary

- keep stability diagnostics in the SkillsBench adapter instead of returning them as core Turn validator receipt fields
- preserve compact `stability_*` evidence after core receipt normalization
- make the sequence fixture run callbacks through the real core validator schema

## Validation

- focused runtime suite: 27 passed
- Turn runtime, driver, and launcher suite: 66 passed
- Ruff check, Python compile, and diff checks passed
- public SkillsBench LoopX Turn smoke passed
- premerge direct checks: 4/4 passed
- catalog canaries: 6/6 passed

## Boundary and review

- fixes the public-compact real-callsite failure observed in the stability pilot; no private runner output was used
- no scoring, task semantics, permission, upload, submission, or benchmark launch behavior changes
- no raw task text, trajectories, verifier output, credentials, local paths, or generated logs included
- premerge reports only the expected benchmark-sensitive manual hold; owner authorization permits self-review and admin merge for this narrow benchmark runtime fix
