### PR TITLE
Honor process-group termination grace

### DIFF
--- a/loopx/extensions/process_runtime.py
+++ b/loopx/extensions/process_runtime.py
@@ -36,13 +36,16 @@ def _terminate_posix_process_group(process: subprocess.Popen[bytes]) -> None:
     except ProcessLookupError:
         process.wait()
         return
-    _wait_for_process(process, _PROCESS_TERMINATE_GRACE_SECONDS)
+    # Give every group member the full grace window before escalation. On
+    # macOS, signaling a group whose leader is an unreaped zombie can fail with
+    # EPERM, so reap an exited leader only after that window has elapsed.
+    time.sleep(_PROCESS_TERMINATE_GRACE_SECONDS)
+    process.poll()
     try:
         os.killpg(process_group_id, signal.SIGKILL)
     except ProcessLookupError:
         pass
-    if process.poll() is None:
-        process.kill()
+    if process.returncode is None:
         process.wait()
 
 

--- a/tests/extensions/test_process_runtime.py
+++ b/tests/extensions/test_process_runtime.py
@@ -14,14 +14,19 @@ from loopx.extensions.process_runtime import run_capped_process
 @pytest.mark.skipif(os.name != "posix", reason="POSIX process-group regression")
 def test_timeout_terminates_provider_descendants(tmp_path: Path) -> None:
     marker = tmp_path / "descendant-effect"
+    ready_marker = tmp_path / "descendant-ready"
     child_code = (
-        "from pathlib import Path; import time; "
-        "time.sleep(1.2); "
+        "from pathlib import Path; import signal, time; "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        f"Path({str(ready_marker)!r}).write_text('ready', encoding='utf-8'); "
+        "time.sleep(2.5); "
         f"Path({str(marker)!r}).write_text('effect', encoding='utf-8')"
     )
     provider_code = (
-        "import subprocess, sys, time; "
+        "from pathlib import Path; import subprocess, sys, time; "
         f"subprocess.Popen([sys.executable, '-c', {child_code!r}]); "
+        f"ready = Path({str(ready_marker)!r}); "
+        "\nwhile not ready.exists(): time.sleep(0.01)\n"
         "time.sleep(5)"
     )
 
@@ -35,6 +40,38 @@ def test_timeout_terminates_provider_descendants(tmp_path: Path) -> None:
     assert result.failure_kind == "timeout"
     time.sleep(0.5)
     assert not marker.exists()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process-group regression")
+def test_descendant_receives_the_full_termination_grace_period(tmp_path: Path) -> None:
+    marker = tmp_path / "descendant-cleanup"
+    ready_marker = tmp_path / "descendant-ready"
+    child_code = (
+        "from pathlib import Path; import signal, time; "
+        "stopping = [False]; "
+        "signal.signal(signal.SIGTERM, lambda *_: stopping.__setitem__(0, True)); "
+        f"Path({str(ready_marker)!r}).write_text('ready', encoding='utf-8'); "
+        "\nwhile not stopping[0]: time.sleep(0.01)\n"
+        "time.sleep(0.2); "
+        f"Path({str(marker)!r}).write_text('cleaned', encoding='utf-8')"
+    )
+    provider_code = (
+        "from pathlib import Path; import subprocess, sys, time; "
+        f"subprocess.Popen([sys.executable, '-c', {child_code!r}]); "
+        f"ready = Path({str(ready_marker)!r}); "
+        "\nwhile not ready.exists(): time.sleep(0.01)\n"
+        "time.sleep(5)"
+    )
+
+    result = run_capped_process(
+        [sys.executable, "-c", provider_code],
+        stdin=b"{}",
+        timeout_seconds=1,
+        output_limit_bytes=1024,
+    )
+
+    assert result.failure_kind == "timeout"
+    assert marker.read_text(encoding="utf-8") == "cleaned"
 
 
 @pytest.mark.skipif(os.name != "posix", reason="POSIX process-group regression")


### PR DESCRIPTION
## Summary

- give POSIX provider descendants the full bounded SIGTERM grace period before SIGKILL escalation
- reap an exited process-group leader after the grace window to avoid macOS EPERM on escalation
- add deterministic descendant regressions for graceful cleanup and forced termination

## Validation

- focused process-runtime/public-runtime checks: 6 passed
- extension and capability-extension registry checks: 93 passed
- `loopx canary premerge --from-git-diff`: 8/9 selected checks passed; `examples/lark-extension-activation-smoke.py` timed out at the unchanged 120-second canary limit twice

## Hold

Keep this draft until the unrelated Lark activation smoke timeout is understood or the premerge gate passes. No timeout increase is included in this PR.