### PR TITLE
Fix SkillsBench pip failure projection

### DIFF
--- a/loopx/status.py
+++ b/loopx/status.py
@@ -1619,6 +1619,38 @@ def _skillsbench_compact_official_score_missing(compact: dict[str, Any]) -> bool
     return not (isinstance(value, (int, float)) and not isinstance(value, bool))
 
 
+def _sync_skillsbench_runner_failure_root_blockers(
+    compact: dict[str, Any],
+) -> None:
+    runner_failure = compact.get("runner_failure")
+    if not isinstance(runner_failure, dict):
+        return
+    if not _skillsbench_compact_official_score_missing(compact):
+        return
+
+    blocker = public_safe_compact_text(
+        compact.get("score_failure_attribution"),
+        limit=140,
+    )
+    if blocker in {None, "none", "score_missing"}:
+        blocker = public_safe_compact_text(
+            runner_failure.get("failure_class"),
+            limit=140,
+        )
+    if not blocker:
+        return
+
+    replaceable = {
+        None,
+        "none",
+        "score_missing",
+        "skillsbench_runner_error",
+    }
+    for field in ("first_blocker", "repeat_blocked_by"):
+        if compact.get(field) in replaceable:
+            compact[field] = blocker
+
+
 def _skillsbench_compact_pre_agent_setup_label(compact: dict[str, Any]) -> str:
     diagnostic = compact.get("compose_setup_diagnostic")
     if not isinstance(diagnostic, dict):
@@ -3350,34 +3382,9 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         setup_preflight=compact.get("task_setup_preflight"),
     )
 
-    runner_failure = compact.get("runner_failure")
-    if (
-        isinstance(runner_failure, dict)
-        and _skillsbench_compact_official_score_missing(compact)
-    ):
-        blocker = public_safe_compact_text(
-            compact.get("score_failure_attribution"),
-            limit=140,
-        )
-        if blocker in {None, "none", "score_missing"}:
-            blocker = public_safe_compact_text(
-                runner_failure.get("failure_class"),
-                limit=140,
-            )
-        if blocker:
-            replaceable_blockers = {
-                None,
-                "none",
-                "score_missing",
-                "skillsbench_runner_error",
-            }
-            if compact.get("first_blocker") in replaceable_blockers:
-                compact["first_blocker"] = blocker
-            if compact.get("repeat_blocked_by") in replaceable_blockers:
-                compact["repeat_blocked_by"] = blocker
+    _sync_skillsbench_runner_failure_root_blockers(compact)
 
-    solution_quality = build_benchmark_solution_quality_signals(compact)
-    if solution_quality:
+    if solution_quality := build_benchmark_solution_quality_signals(compact):
         compact["solution_quality_signals"] = solution_quality
 
     post_run_debug_gate = build_skillsbench_post_run_debug_gate(compact)

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -1526,6 +1526,7 @@ def _compact_benchmark_compose_setup_diagnostic(value: Any) -> dict[str, Any]:
         "runner_error_len_bucket",
         "primary_setup_failure_category",
         "apt_failure_subtype",
+        "pip_failure_subtype",
         "retryability",
         "next_diagnostic_action",
     ):
@@ -1537,6 +1538,7 @@ def _compact_benchmark_compose_setup_diagnostic(value: Any) -> dict[str, Any]:
         "unclassified_compose_failure",
         "docker_daemon_unavailable",
         "apt_repository_failure",
+        "pip_bootstrap_failure",
         "volume_mount_failure",
         "environment_setup_failure",
         "agent_rounds_started",
@@ -3002,6 +3004,7 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
             "error_len_bucket",
             "fingerprint_confidence",
             "apt_failure_subtype",
+            "pip_failure_subtype",
             "retryability",
         ):
             value = public_safe_compact_text(fingerprint.get(field), limit=100)
@@ -3346,6 +3349,32 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         task_staging=compact.get("task_staging"),
         setup_preflight=compact.get("task_setup_preflight"),
     )
+
+    runner_failure = compact.get("runner_failure")
+    if (
+        isinstance(runner_failure, dict)
+        and _skillsbench_compact_official_score_missing(compact)
+    ):
+        blocker = public_safe_compact_text(
+            compact.get("score_failure_attribution"),
+            limit=140,
+        )
+        if blocker in {None, "none", "score_missing"}:
+            blocker = public_safe_compact_text(
+                runner_failure.get("failure_class"),
+                limit=140,
+            )
+        if blocker:
+            replaceable_blockers = {
+                None,
+                "none",
+                "score_missing",
+                "skillsbench_runner_error",
+            }
+            if compact.get("first_blocker") in replaceable_blockers:
+                compact["first_blocker"] = blocker
+            if compact.get("repeat_blocked_by") in replaceable_blockers:
+                compact["repeat_blocked_by"] = blocker
 
     solution_quality = build_benchmark_solution_quality_signals(compact)
     if solution_quality:

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -4930,6 +4930,37 @@ def _apply_host_local_acp_prereq_failure_attribution(
     return True
 
 
+def _sync_specific_runner_failure_root_blockers(
+    compact: dict[str, Any],
+) -> bool:
+    if compact.get("official_score_status") != "missing":
+        return False
+    if not isinstance(compact.get("runner_failure"), dict):
+        return False
+    attribution = compact.get("score_failure_attribution")
+    if not isinstance(attribution, str) or attribution in {
+        "",
+        "none",
+        "score_missing",
+        "skillsbench_runner_error",
+    }:
+        return False
+
+    changed = False
+    replaceable = {
+        None,
+        "",
+        "none",
+        "score_missing",
+        "skillsbench_runner_error",
+    }
+    for field in ("first_blocker", "repeat_blocked_by"):
+        if compact.get(field) in replaceable:
+            compact[field] = attribution
+            changed = True
+    return changed
+
+
 def _apply_native_goal_worker_finish_guard_attribution(
     compact: dict[str, Any],
 ) -> bool:
@@ -6225,6 +6256,9 @@ def build_compose_setup_diagnostic(
     apt_failure_subtype = str(
         fingerprint.get("apt_failure_subtype") or ""
     )[:120]
+    pip_failure_subtype = str(
+        fingerprint.get("pip_failure_subtype") or ""
+    )[:120]
     terminal_failure_dependency_endpoints = [
         str(item)[:120]
         for item in fingerprint.get("terminal_failure_dependency_endpoints", [])
@@ -6294,12 +6328,19 @@ def build_compose_setup_diagnostic(
         or "system_package" in terminal_dependency_classes
         or any(code.startswith("apt_") for code in terminal_failure_reason_codes)
     )
+    pip_bootstrap_failure = (
+        score_failure == "skillsbench_docker_compose_pip_bootstrap_failure"
+        or "skillsbench_docker_compose_pip_bootstrap_failure" in labels
+        or "pip_bootstrap_failure" in matched_patterns
+    )
     volume_mount_failure = (
         score_failure == "skillsbench_docker_compose_volume_mount_failure"
         or "skillsbench_docker_compose_volume_mount_failure" in labels
         or "volume_mount_failure" in matched_patterns
     )
-    if apt_repository_failure:
+    if pip_bootstrap_failure:
+        primary_setup_failure_category = "python_package_bootstrap"
+    elif apt_repository_failure:
         primary_setup_failure_category = "system_package_repository"
     elif volume_mount_failure:
         primary_setup_failure_category = "volume_mount"
@@ -6311,7 +6352,11 @@ def build_compose_setup_diagnostic(
         primary_setup_failure_category = "runner_setup"
     if compose_setup_failure and not agent_rounds_started:
         status = "compose_setup_blocked_before_agent_rounds"
-        if apt_repository_failure:
+        if pip_bootstrap_failure:
+            next_action = (
+                "repair_python_package_bootstrap_before_product_treatment"
+            )
+        elif apt_repository_failure:
             next_action = (
                 "repair_system_package_repository_setup_before_product_treatment"
             )
@@ -6341,9 +6386,11 @@ def build_compose_setup_diagnostic(
         "unclassified_compose_failure": unclassified,
         "docker_daemon_unavailable": docker_daemon_unavailable,
         "apt_repository_failure": apt_repository_failure,
+        "pip_bootstrap_failure": pip_bootstrap_failure,
         "volume_mount_failure": volume_mount_failure,
         "primary_setup_failure_category": primary_setup_failure_category,
         "apt_failure_subtype": apt_failure_subtype,
+        "pip_failure_subtype": pip_failure_subtype,
         "terminal_failure_dependency_classes": terminal_dependency_classes,
         "terminal_failure_reason_codes": terminal_failure_reason_codes,
         "terminal_failure_dependency_endpoints": (
@@ -14738,7 +14785,7 @@ def reduce_result(
         ):
             _exception_type, score_failure_attribution, labels = prereq_failure
             compact["score_failure_attribution"] = score_failure_attribution
-            compact.setdefault("first_blocker", score_failure_attribution)
+            _sync_specific_runner_failure_root_blockers(compact)
             existing_labels = [
                 label
                 for label in compact.get("failure_attribution_labels", [])
@@ -14766,7 +14813,7 @@ def reduce_result(
                 ):
                     label = "skillsbench_host_local_acp_empty_trajectory_after_install"
                     compact["score_failure_attribution"] = label
-                    compact.setdefault("first_blocker", label)
+                    _sync_specific_runner_failure_root_blockers(compact)
                     existing_labels = [
                         item
                         for item in compact.get("failure_attribution_labels", [])
@@ -14810,6 +14857,7 @@ def reduce_result(
     if diagnostic.get("status") != "not_applicable":
         compact["compose_setup_diagnostic"] = diagnostic
         apply_skillsbench_pre_agent_setup_diagnostic_attribution(compact)
+    _sync_specific_runner_failure_root_blockers(compact)
     runner_output_capture = _public_runner_output_capture(plan)
     if runner_output_capture:
         compact["runner_output_capture"] = runner_output_capture

--- a/tests/test_skillsbench_setup_preflight.py
+++ b/tests/test_skillsbench_setup_preflight.py
@@ -584,6 +584,69 @@ def test_compose_diagnostic_ignores_incidental_volume_for_terminal_apt() -> None
     assert message not in json.dumps(reduced, sort_keys=True)
 
 
+def test_compose_diagnostic_projects_mixed_pip_failure_for_replan() -> None:
+    message = (
+        "Docker compose command failed. ERROR: failed to solve: process "
+        "apt-get update && pip3 install numpy did not complete successfully: "
+        "max retries exceeded for pypi.org"
+    )
+    failure_class = "skillsbench_docker_compose_pip_bootstrap_failure"
+    source = {
+        "schema_version": "benchmark_run_v0",
+        "benchmark": "skillsbench",
+        "task_id": "synthetic-mixed-pip-setup",
+        "route": "loopx-turn-agent-cli",
+        "score_failure_attribution": failure_class,
+        "failure_attribution_labels": [
+            failure_class,
+            "skillsbench_docker_compose_setup_failure",
+            "skillsbench_python_package_bootstrap_failure",
+            "skillsbench_environment_setup_error",
+        ],
+        "official_score_status": "missing",
+        "runner_failure": {
+            "schema_version": "skillsbench_runner_failure_v0",
+            "failure_class": failure_class,
+            "raw_error_recorded": False,
+        },
+        "runner_failure_fingerprint": skillsbench_runner_error_fingerprint(message),
+    }
+
+    compact = compact_benchmark_run(source)
+
+    assert compact is not None
+    assert compact["first_blocker"] == failure_class
+    assert compact["repeat_blocked_by"] == failure_class
+    fingerprint = compact["runner_failure_fingerprint"]
+    assert fingerprint["pip_failure_subtype"] == "package_index_network_failure"
+    assert fingerprint["apt_failure_subtype"] == "retry_exhausted"
+
+    diagnostic = build_compose_setup_diagnostic(
+        compact,
+        {"route": "loopx-turn-agent-cli"},
+    )
+    assert diagnostic["pip_bootstrap_failure"] is True
+    assert diagnostic["apt_repository_failure"] is True
+    assert diagnostic["primary_setup_failure_category"] == (
+        "python_package_bootstrap"
+    )
+    assert diagnostic["pip_failure_subtype"] == "package_index_network_failure"
+    assert diagnostic["next_diagnostic_action"] == (
+        "repair_python_package_bootstrap_before_product_treatment"
+    )
+
+    reduced = compact_benchmark_run(
+        {**compact, "compose_setup_diagnostic": diagnostic}
+    )
+    assert reduced is not None
+    reduced_diagnostic = reduced["compose_setup_diagnostic"]
+    assert reduced_diagnostic["pip_bootstrap_failure"] is True
+    assert reduced_diagnostic["pip_failure_subtype"] == (
+        "package_index_network_failure"
+    )
+    assert message not in json.dumps(reduced, sort_keys=True)
+
+
 def test_setup_only_preflight_classifies_ubuntu_mirror_without_raw_url() -> None:
     FakeRollout.failure_stage = "environment_start"
     FakeRollout.failure = RuntimeError(


### PR DESCRIPTION
## Summary

- retain the bounded pip failure subtype and pip bootstrap signal in public SkillsBench compact projections
- prefer Python package bootstrap repair when mixed apt/pip setup evidence has already been attributed to pip
- synchronize the final specific runner attribution into generic root blockers so replan sees the actionable cause

## Validation

- `32 passed`: `tests/test_skillsbench_setup_preflight.py` and `tests/control_plane/test_benchmark_lifecycle_contracts.py`
- `examples/skillsbench-benchmark-run-smoke.py`
- `examples/benchmark-core-adapter-contract-smoke.py`
- `examples/benchmark-artifact-path-filter-smoke.py`
- changed-file `py_compile` and `git diff --check`
- standard LoopX premerge canary: 4/4 direct checks and 17/17 selected canaries passed with no failures or warnings

## Boundary And Merge Note

The premerge gate reports the expected `benchmark_sensitive` manual hold. This change does not alter scoring, task semantics, leaderboard/submission behavior, permissions, or launch benchmark jobs. It contains no raw task text, trajectories, logs, verifier output, credentials, private state, or local paths. The owner explicitly authorized self-merge for this bounded public benchmark helper/runtime repair.
