### PR TITLE
fix: keep CLI manpage in sync with command catalog

### DIFF
--- a/examples/cli-help-manpage-smoke.py
+++ b/examples/cli-help-manpage-smoke.py
@@ -11,6 +11,13 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx import __version__  # noqa: E402
+from loopx.help_surface import COMMAND_GROUPS, render_manpage  # noqa: E402
+
+
 LONG_TAIL_COMMAND = "codex-cli-visible-first-response-capture-plan"
 
 
@@ -66,6 +73,21 @@ def assert_command_reference_surface() -> None:
     assert "codex-cli-bootstrap-message" in result.stdout, result.stdout
     assert "loopx ready-score --goal-id <goal-id>" in result.stdout, result.stdout
     assert result.stderr == "", result.stderr
+
+
+def assert_checked_in_manpage_surface() -> None:
+    manpage = REPO_ROOT / "man" / "loopx.1"
+    assert manpage.read_text(encoding="utf-8") == render_manpage()
+
+
+def assert_catalog_is_present(man_text: str) -> None:
+    assert f'"LoopX {__version__}"' in man_text, man_text
+    for group in COMMAND_GROUPS:
+        for entry in group["commands"]:
+            command = str(entry["command"])
+            purpose = str(entry["purpose"])
+            assert command.replace("-", r"\-") in man_text, command
+            assert purpose.replace("-", r"\-") in man_text, purpose
 
 
 def assert_installer_manpage_surface() -> None:
@@ -157,14 +179,17 @@ def assert_installer_manpage_surface() -> None:
         assert manpage.is_file(), manpage
         with gzip.open(manpage, "rt", encoding="utf-8") as handle:
             man_text = handle.read()
+        assert man_text == render_manpage(), man_text
+        assert_catalog_is_present(man_text)
         compact_man_text = " ".join(man_text.split())
         assert ".TH LOOPX 1" in man_text, man_text
-        assert ".SH LOOP DRIVERS" in man_text, man_text
+        assert ".SH LOOP DRIVER HINTS" in man_text, man_text
         assert "Codex App automation" in man_text, man_text
         assert "loopx commands" in man_text, man_text
-        assert "loopx evidence-log --goal-id" in man_text, man_text
+        assert "loopx extension" in man_text, man_text
+        assert r"loopx evidence\-log \-\-goal\-id" in man_text, man_text
         assert "before replan or handoff" in compact_man_text, man_text
-        assert "loopx COMMAND --help" in man_text, man_text
+        assert r"loopx COMMAND \-\-help" in man_text, man_text
 
         profile_text = profile.read_text(encoding="utf-8")
         assert 'export MANPATH="$HOME/.local/share/man:${MANPATH:-}"' in profile_text, profile_text
@@ -193,6 +218,7 @@ def assert_installer_manpage_surface() -> None:
 def main() -> int:
     assert_default_help_surface()
     assert_command_reference_surface()
+    assert_checked_in_manpage_surface()
     assert_installer_manpage_surface()
     print("cli-help-manpage-smoke ok")
     return 0

--- a/examples/cli-help-manpage-smoke.py
+++ b/examples/cli-help-manpage-smoke.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import argparse
 import gzip
 import os
 import re
 import subprocess
 import sys
 import tempfile
+import tomllib
 from pathlib import Path
 
 
@@ -15,7 +17,13 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx import __version__  # noqa: E402
-from loopx.help_surface import COMMAND_GROUPS, render_manpage  # noqa: E402
+from loopx.cli import build_parser  # noqa: E402
+from loopx.help_surface import (  # noqa: E402
+    COMMAND_GROUPS,
+    MANPAGE_COMMAND_HELP_ONLY,
+    manpage_top_level_commands,
+    render_manpage,
+)
 
 
 LONG_TAIL_COMMAND = "codex-cli-visible-first-response-capture-plan"
@@ -73,6 +81,53 @@ def assert_command_reference_surface() -> None:
     assert "codex-cli-bootstrap-message" in result.stdout, result.stdout
     assert "loopx ready-score --goal-id <goal-id>" in result.stdout, result.stdout
     assert result.stderr == "", result.stderr
+
+
+def assert_top_level_commands_are_explicitly_classified() -> None:
+    parser = build_parser()
+    subparsers = next(
+        action
+        for action in parser._actions
+        if isinstance(action, argparse._SubParsersAction)
+    )
+    parser_commands = frozenset(subparsers.choices)
+    manual_commands = manpage_top_level_commands()
+    assert manual_commands.isdisjoint(MANPAGE_COMMAND_HELP_ONLY)
+    assert parser_commands == manual_commands | MANPAGE_COMMAND_HELP_ONLY, {
+        "unclassified": sorted(
+            parser_commands - manual_commands - MANPAGE_COMMAND_HELP_ONLY
+        ),
+        "stale_manual": sorted(manual_commands - parser_commands),
+        "stale_help_only": sorted(MANPAGE_COMMAND_HELP_ONLY - parser_commands),
+    }
+
+
+def assert_extension_capabilities_stay_out_of_core_manual() -> None:
+    manifest_paths = sorted(REPO_ROOT.glob("loopx/extensions/**/extension.toml"))
+    manifest_paths.extend(sorted(REPO_ROOT.glob("extensions/**/extension.toml")))
+    extension_owned_ids: set[str] = set()
+    for path in manifest_paths:
+        manifest = tomllib.loads(path.read_text(encoding="utf-8"))
+        extension_id = manifest.get("id")
+        if isinstance(extension_id, str):
+            extension_owned_ids.add(extension_id)
+        for capability in manifest.get("provides", []):
+            capability_id = capability.get("id")
+            if isinstance(capability_id, str):
+                extension_owned_ids.add(capability_id)
+
+    # `[[implements]]` ids are intentionally excluded: they name core-owned
+    # capability contracts whose stable core command may belong in the manual.
+    manual_commands = manpage_top_level_commands()
+    assert extension_owned_ids.isdisjoint(manual_commands), {
+        "extension_owned_manual_commands": sorted(
+            extension_owned_ids & manual_commands
+        )
+    }
+    man_text = render_manpage()
+    for extension_owned_id in extension_owned_ids:
+        escaped_id = extension_owned_id.replace("-", r"\-")
+        assert rf"\fBloopx {escaped_id}\fR" not in man_text, extension_owned_id
 
 
 def assert_checked_in_manpage_surface() -> None:
@@ -218,6 +273,8 @@ def assert_installer_manpage_surface() -> None:
 def main() -> int:
     assert_default_help_surface()
     assert_command_reference_surface()
+    assert_top_level_commands_are_explicitly_classified()
+    assert_extension_capabilities_stay_out_of_core_manual()
     assert_checked_in_manpage_surface()
     assert_installer_manpage_surface()
     print("cli-help-manpage-smoke ok")

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -158,13 +158,7 @@ def user_supplied_registry(argv: list[str] | None) -> bool:
     return any(value == "--registry" or value.startswith("--registry=") for value in values)
 
 
-def main(argv: list[str] | None = None) -> int:
-    raw_argv = sys.argv[1:] if argv is None else list(argv)
-    if top_level_help_requested(raw_argv):
-        print(render_concise_help(sys.argv[0] if argv is None else "loopx"), end="")
-        return 0
-    raw_argv = rewrite_auto_research_question_argv(raw_argv)
-
+def build_parser() -> LoopXArgumentParser:
     parser = LoopXArgumentParser(description="LoopX control-plane helper.")
     parser.add_argument("--version", action="version", version=f"loopx {__version__}")
     parser.add_argument("--registry", default=str(default_registry_path()), help="Path to a project-local registry.")
@@ -242,6 +236,17 @@ def main(argv: list[str] | None = None) -> int:
     register_task_lease_command(sub, add_subcommand_format)
     register_quota_command(sub)
 
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    raw_argv = sys.argv[1:] if argv is None else list(argv)
+    if top_level_help_requested(raw_argv):
+        print(render_concise_help(sys.argv[0] if argv is None else "loopx"), end="")
+        return 0
+    raw_argv = rewrite_auto_research_question_argv(raw_argv)
+
+    parser = build_parser()
     args = parser.parse_args(raw_argv)
     registry_path = Path(args.registry).expanduser()
     if (

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from . import __version__
+
 
 GLOBAL_OPTIONS_WITH_VALUE = {"--registry", "--runtime-root", "--format"}
 GLOBAL_OPTIONS_WITH_EQUALS = tuple(f"{option}=" for option in sorted(GLOBAL_OPTIONS_WITH_VALUE))
@@ -307,6 +309,90 @@ def render_command_reference_markdown(payload: dict[str, Any]) -> str:
         [
             "For command-specific flags, run `loopx <command> --help`.",
             "For the manual page, run `man loopx` after installing LoopX.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _roff_text(value: object) -> str:
+    text = str(value).replace("\\", r"\e").replace("-", r"\-")
+    if text.startswith((".", "'")):
+        return rf"\&{text}"
+    return text
+
+
+def render_manpage(*, version: str = __version__) -> str:
+    """Render the CLI manual from the canonical command catalog."""
+
+    lines = [
+        f'.TH LOOPX 1 "" "LoopX {_roff_text(version)}" "User Commands"',
+        ".SH NAME",
+        r"loopx \- control-plane helper for long-running agent work",
+        ".SH SYNOPSIS",
+        ".B loopx",
+        r"[\fB\-\-registry\fR \fIPATH\fR]",
+        r"[\fB\-\-runtime\-root\fR \fIPATH\fR]",
+        r"[\fB\-\-format\fR \fImarkdown|json\fR]",
+        r"\fICOMMAND\fR",
+        r"[\fIARGS\fR]",
+        ".br",
+        ".B loopx",
+        r"\fICOMMAND\fR",
+        r"\fB\-\-help\fR",
+        ".br",
+        ".B loopx commands",
+        ".SH DESCRIPTION",
+        "LoopX keeps long-running agent work moving by preserving goals, todos, gates,",
+        "quota, and evidence between agent turns.",
+        ".PP",
+        "The command sections below are generated from the same canonical catalog used by",
+        r"\fBloopx commands\fR. Command-specific flags remain available through",
+        r"\fBloopx COMMAND \-\-help\fR.",
+    ]
+
+    for group in COMMAND_GROUPS:
+        title = _roff_text(str(group.get("title") or "Commands").upper())
+        lines.append(f".SH {title}")
+        commands = group.get("commands")
+        if not isinstance(commands, list):
+            continue
+        for entry in commands:
+            if not isinstance(entry, dict):
+                continue
+            command = str(entry.get("command") or "").strip()
+            purpose = str(entry.get("purpose") or "").strip()
+            if not command or not purpose:
+                continue
+            lines.extend(
+                [
+                    ".TP",
+                    rf"\fB{_roff_text(command)}\fR",
+                    _roff_text(purpose),
+                ]
+            )
+
+    lines.extend(
+        [
+            ".SH MORE",
+            ".TP",
+            r"\fBloopx COMMAND \-\-help\fR",
+            "Show flags for one command.",
+            ".TP",
+            r"\fBman loopx\fR",
+            "Open this installed manual page.",
+            ".TP",
+            r"\fBdocs/guides/getting\-started.md#command\-reference\fR",
+            "Read the longer operator and contributor guide.",
+            ".SH INSTALL NOTES",
+            "The LoopX local installer writes this manual to",
+            r"\fI$HOME/.local/share/man/man1/loopx.1.gz\fR by default and adds",
+            r"\fI$HOME/.local/share/man\fR to MANPATH in the selected shell profile.",
+            "If the current shell has not reloaded that profile, run:",
+            ".PP",
+            r"\fBMANPATH=\"$HOME/.local/share/man:${MANPATH:\-}\" man loopx\fR",
+            ".SH SEE ALSO",
+            ".BR man (1)",
             "",
         ]
     )

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from . import __version__
@@ -191,6 +192,71 @@ COMMAND_GROUPS: list[dict[str, object]] = [
         ],
     },
 ]
+
+
+# Every top-level parser command must either be represented in COMMAND_GROUPS
+# or be explicitly kept on its command-specific help surface. This makes a new
+# command an intentional manual-visibility decision instead of a silent omission.
+MANPAGE_COMMAND_HELP_ONLY = frozenset(
+    {
+        "archive-runtime",
+        "backup-state",
+        "capability",
+        "codex-cli-bounded-visible-pilot-adapter",
+        "codex-cli-exec-handoff",
+        "codex-cli-local-driver-plan",
+        "codex-cli-local-scheduler-exec",
+        "codex-cli-local-scheduler-tick",
+        "codex-cli-one-message-loop-pilot",
+        "codex-cli-runtime-idle-detector",
+        "codex-cli-session-probe",
+        "codex-cli-visible-driver-plan",
+        "codex-cli-visible-driver-run",
+        "codex-cli-visible-first-response-capture-plan",
+        "codex-cli-visible-local-driver-pilot",
+        "codex-cli-visible-session-proof",
+        "configure-goal",
+        "content-ops",
+        "demo",
+        "dreaming",
+        "global-summary",
+        "import-doc-registry-authority",
+        "lark-inbox",
+        "migrate-state",
+        "ml-experiment",
+        "operator-gate",
+        "pr-review",
+        "promotion-gate",
+        "read-only-map",
+        "refresh-state",
+        "register-authority-source",
+        "registry-boundary",
+        "reward",
+        "reward-memory",
+        "semantic-preference",
+        "serve-status",
+        "uninstall-project",
+        "value-connectors",
+        "version",
+        "worker-bridge",
+    }
+)
+
+
+def manpage_top_level_commands() -> frozenset[str]:
+    commands = {"commands"}
+    for group in COMMAND_GROUPS:
+        entries = group.get("commands")
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            command = str(entry.get("command") or "")
+            commands.update(
+                re.findall(r"(?:^| / )loopx ([a-z0-9][a-z0-9-]*)", command)
+            )
+    return frozenset(commands)
 
 
 def _program_name(program: str) -> str:

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -1,104 +1,203 @@
-.TH LOOPX 1 "2026-07-03" "LoopX 0.1.4" "User Commands"
+.TH LOOPX 1 "" "LoopX 0.2.11" "User Commands"
 .SH NAME
 loopx \- control-plane helper for long-running agent work
 .SH SYNOPSIS
 .B loopx
-[\fB--registry\fR \fIPATH\fR]
-[\fB--runtime-root\fR \fIPATH\fR]
-[\fB--format\fR \fImarkdown|json\fR]
+[\fB\-\-registry\fR \fIPATH\fR]
+[\fB\-\-runtime\-root\fR \fIPATH\fR]
+[\fB\-\-format\fR \fImarkdown|json\fR]
 \fICOMMAND\fR
 [\fIARGS\fR]
 .br
 .B loopx
 \fICOMMAND\fR
-\fB--help\fR
+\fB\-\-help\fR
 .br
 .B loopx commands
 .SH DESCRIPTION
 LoopX keeps long-running agent work moving by preserving goals, todos, gates,
 quota, and evidence between agent turns.
 .PP
-The default command surface is intentionally short. New users should start with
-the agent slash command path, then use the CLI for install checks, status,
-diagnosis, and handoff packets.
+The command sections below are generated from the same canonical catalog used by
+\fBloopx commands\fR. Command-specific flags remain available through
+\fBloopx COMMAND \-\-help\fR.
 .SH START HERE
 .TP
-.B /loopx
+\fB/loopx\fR
 Ask the agent to inspect LoopX status, gates, todos, and next action.
 .TP
-.B /loopx <goal text>
-Start or continue one concrete long-running goal through the agent.
+\fB/loopx <goal text>\fR
+Start or continue one concrete long\-running goal through the agent.
 .TP
-.B loopx doctor
+\fBloopx doctor\fR
 Check install, PATH, release snapshot, skills, and import health.
 .TP
-.B loopx slash-commands --install
-Refresh host slash-command prompt and skill files.
+\fBloopx slash\-commands \-\-install\fR
+Refresh host slash\-command prompt and skill files.
 .TP
-.B loopx start-goal --guided --project . --goal-text "<goal>"
-Preview the shell fallback for the same agent-safe \fB/loopx <goal>\fR path.
-.SH DAILY COMMANDS
+\fBloopx preset list\fR
+Show beginner\-safe and opt\-in advanced loop start packets.
 .TP
-.B loopx status
-Show current goals, gates, attention queue, and next action.
+\fBloopx ready\-score \-\-goal\-id <goal\-id>\fR
+Score install, status, quota, scheduler, todo, and evidence readiness without writing badges.
 .TP
-.B loopx diagnose --goal-id <goal-id>
+\fBloopx start\-goal \-\-guided \-\-project . \-\-goal\-text "<goal>"\fR
+Preview the shell fallback for the same agent\-safe `/loopx <goal>` path.
+.TP
+\fBloopx agent\-onboard \-\-agent\-type codex\-cli \-\-project .\fR
+Generate the exact host\-loop activation packet for one agent runtime.
+.TP
+\fBloopx bootstrap\-command\-pack \-\-project .\fR
+Generate the lower\-level host handoff packet.
+.SH DAILY OPERATOR COMMANDS
+.TP
+\fBloopx status\fR
+Show goals, gates, attention queue, and next action.
+.TP
+\fBloopx diagnose \-\-goal\-id <goal\-id>\fR
 Build a compact evidence packet when behavior is surprising.
 .TP
-.B loopx review-packet --goal-id <goal-id>
-Render a handoff or review packet for operator judgment, including required
-agent-scoped evidence reads when available.
+\fBloopx review\-packet \-\-goal\-id <goal\-id>\fR
+Render a handoff or review packet with any required evidence\-log reads.
 .TP
-.B loopx evidence-log --goal-id <goal-id> --agent-id <agent-id> --thin
-Read the current agent's bounded public-safe evidence ledger before replan or
-handoff. Other agents remain compressed to frontier context.
+\fBloopx evidence\-log \-\-goal\-id <goal\-id> \-\-agent\-id <agent\-id> \-\-thin\fR
+Read the current agent's thin public\-safe ledger before replan or handoff.
 .TP
-.B loopx todo --help
-Show todo add, claim, complete, update, supersede, and archive forms.
+\fBloopx todo \-\-help\fR
+Show todo lifecycle commands.
 .TP
-.B loopx quota should-run
+\fBloopx task\-lease \-\-help\fR
+Acquire, renew, transfer, release, or inspect a hard per\-todo lease.
+.TP
+\fBloopx quota should\-run\fR
 Decide whether the next agent turn should run.
-.SH LOOP DRIVERS
 .TP
-.B Codex App automation
-Use \fB/loopx <goal>\fR and let the app create or refresh the LoopX heartbeat
-automation. Start at the bootstrap cadence, then follow LoopX scheduler hints.
+\fBloopx history \-\-goal\-id <goal\-id>\fR
+Read compact run history.
 .TP
-.B Codex CLI visible goal
-Keep the Codex CLI TUI as the visible executor. Use
-\fBloopx codex-cli-bootstrap-message\fR when a generated setup message is
-needed.
+\fBloopx history trajectory\-hygiene \-\-goal\-id <goal\-id> \-\-limit 100\fR
+Measure controller density and attribution gaps from compact history without reading raw sessions.
+.SH LOOP DRIVER HINTS
 .TP
-.B Claude Code /loop
-Enable the opt-in LoopX adapter, start \fB/loopx <goal>\fR, then use Claude
-Code's native \fB/loop\fR to drive each tick.
+\fBCodex App automation\fR
+Use `/loopx <goal>` and let the app create or refresh the heartbeat automation.
 .TP
-.B Other agents or shell
-Use LoopX only with a CLI, task, automation, heartbeat, or scheduler hook that
-can run the next turn. Without such a hook, run LoopX commands manually.
-.SH MORE COMMANDS
+\fBCodex CLI visible goal\fR
+Stay in the visible TUI; use `loopx codex\-cli\-bootstrap\-message` for setup when needed.
 .TP
-.B loopx commands
-Show the grouped command reference.
+\fBClaude Code /loop\fR
+Use installed slash skills for `/loopx`; enable the adapter only when native `/loop` should be gated by LoopX.
 .TP
-.B loopx COMMAND --help
+\fBOpenCode goal bridge\fR
+Opt into `\-\-with\-goal\-bridge`, then use `loopx_goal_activate` to bind the quota\-gated bridge.
+.TP
+\fBOther agent or shell\fR
+Use a CLI, task, automation, heartbeat, or scheduler hook; otherwise drive LoopX manually.
+.TP
+\fBloopx turn plan \-\-goal\-id <goal\-id> \-\-agent\-id <agent\-id>\fR
+Plan one governed external\-host turn from live LoopX state without launching an agent or writing state.
+.TP
+\fBloopx host\-mode\-plan \-\-goal\-id <goal\-id> \-\-intent <intent> \-\-host\-capability <capability>\fR
+Select a safe host mode (visible, isolated headless Turn, gateway, timer, hybrid) and show the matching Turn/quota preview commands.
+.SH SETUP AND AUTOMATION COMMANDS
+.TP
+\fBloopx bootstrap / loopx connect\fR
+Create or connect project\-local state.
+.TP
+\fBloopx new\-project\-prompt\fR
+Generate a copy\-paste project connection prompt for an agent.
+.TP
+\fBloopx codex\-cli\-bootstrap\-message\fR
+Generate the visible Codex CLI TUI setup message.
+.TP
+\fBloopx codex\-cli\-tui\-bootstrap\-smoke\-bundle\fR
+Generate a transcript\-free Codex CLI first\-run smoke bundle.
+.TP
+\fBloopx codex\-cli\-visible\-attach\-acceptance\fR
+Check public\-safe visible Codex CLI attach evidence.
+.TP
+\fBloopx heartbeat\-prompt\fR
+Generate a guarded heartbeat automation body.
+.TP
+\fBloopx supervisor\-prompt\fR
+Generate the dedicated task body for an opt\-in proposal\-only peer supervisor.
+.TP
+\fBloopx supervisor\-observe\fR
+Read one public\-safe supervisor packet over peer status and evidence.
+.TP
+\fBloopx supervisor\-event\fR
+Preview, append, or read supervisor proposals and host execution receipts.
+.TP
+\fBloopx upgrade\-plan\fR
+Plan default heartbeat upgrade propagation.
+.TP
+\fBloopx update\fR
+Check, dry\-run, or execute the no\-clone update path.
+.SH MAINTAINER AND ADAPTER COMMANDS
+.TP
+\fBloopx check\fR
+Run contract and public/private boundary checks.
+.TP
+\fBloopx registry\fR
+Inspect registered goals and adapters.
+.TP
+\fBloopx sync\-global\fR
+Merge project state into the shared registry.
+.TP
+\fBloopx retire\-global\-goal\fR
+Safely retire explicitly named orphaned global goal routes.
+.TP
+\fBloopx register\-agent\fR
+Register an automation agent.
+.TP
+\fBloopx lark\-kanban\fR
+Project LoopX state into a Feishu/Lark Base board.
+.TP
+\fBloopx presentation\fR
+Package, roll back, and verify provider\-neutral static presentation artifacts.
+.TP
+\fBloopx explore\fR
+Record the exploration topology (nodes, edges, findings) and project it to a Feishu/Lark result board.
+.TP
+\fBloopx extension\fR
+Inspect and manage doctor\-verified subprocess extension activations.
+.TP
+\fBloopx issue\-fix\fR
+Build public\-safe issue or PR fix workflow packets.
+.TP
+\fBloopx review\-batch\fR
+Compose provider\-neutral bounded review packets and bind exact decisions.
+.TP
+\fBloopx periodic\-report\fR
+Resolve a portable weekly profile, evaluate report triggers, and compose provider\-neutral run receipts.
+.TP
+\fBloopx auto\-research\fR
+Project public\-safe research frontiers.
+.TP
+\fBloopx multi\-agent\fR
+Launch visible role\-scoped Codex TUI agents.
+.TP
+\fBloopx canary\fR
+Plan or run catalog\-informed smoke profiles.
+.TP
+\fBloopx benchmark\fR
+Use fixture\-only benchmark runner skeletons by default.
+.SH MORE
+.TP
+\fBloopx COMMAND \-\-help\fR
 Show flags for one command.
 .TP
-.B docs/guides/newcomer-command-path.md
-Explains the minimal product path for new users.
+\fBman loopx\fR
+Open this installed manual page.
 .TP
-.B docs/guides/getting-started.md#command-reference
-Keeps the longer operator and contributor command catalog.
-.TP
-.B loopx bootstrap-command-pack --project .
-Generate the lower-level host handoff packet for host/plugin integration or
-debugging.
+\fBdocs/guides/getting\-started.md#command\-reference\fR
+Read the longer operator and contributor guide.
 .SH INSTALL NOTES
 The LoopX local installer writes this manual to
 \fI$HOME/.local/share/man/man1/loopx.1.gz\fR by default and adds
 \fI$HOME/.local/share/man\fR to MANPATH in the selected shell profile.
 If the current shell has not reloaded that profile, run:
 .PP
-.B MANPATH="$HOME/.local/share/man:${MANPATH:-}" man loopx
+\fBMANPATH=\"$HOME/.local/share/man:${MANPATH:\-}\" man loopx\fR
 .SH SEE ALSO
 .BR man (1)

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -476,6 +476,9 @@ if [[ -d "$release_tmp/apps" ]]; then
     \( -name node_modules -o -name .next -o -name dist -o -name build -o -name coverage \) \
     -type d -prune -exec rm -rf {} +
 fi
+PYTHONPATH="$release_tmp" "${LOOPX_PYTHON:-python3}" \
+  "$release_tmp/scripts/render-manpage.py" \
+  --output "$release_tmp/man/loopx.1"
 (
   cd "$release_tmp"
   PYTHONPATH="$release_tmp" "${LOOPX_PYTHON:-python3}" -m loopx.release_manifest \

--- a/scripts/render-manpage.py
+++ b/scripts/render-manpage.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import difflib
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.help_surface import render_manpage  # noqa: E402
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Render the LoopX manpage from the canonical command catalog."
+    )
+    destination = parser.add_mutually_exclusive_group()
+    destination.add_argument("--output", type=Path, help="write the generated manpage")
+    destination.add_argument(
+        "--check",
+        type=Path,
+        metavar="PATH",
+        help="fail if PATH differs from the generated manpage",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    rendered = render_manpage()
+    if args.check is not None:
+        actual = args.check.read_text(encoding="utf-8") if args.check.is_file() else ""
+        if actual == rendered:
+            return 0
+        diff = difflib.unified_diff(
+            actual.splitlines(keepends=True),
+            rendered.splitlines(keepends=True),
+            fromfile=str(args.check),
+            tofile="generated manpage",
+        )
+        sys.stderr.writelines(diff)
+        return 1
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+        return 0
+    sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- render the checked-in CLI manpage from the canonical command catalog and package version
- regenerate the release-snapshot manpage during local install before writing the release manifest
- require exact parity for both the checked-in and installed manpages, including `loopx extension`
- require every top-level parser command to be explicitly classified as manual-visible or command-help-only
- keep extension ids and extension-owned `[[provides]]` capability ids out of the core manual

## Ownership boundary

The core manual documents stable LoopX CLI entrypoints. It includes the core `loopx extension` lifecycle command, but it does not enumerate installed extension ids or extension-owned capability ids. `[[implements]]` is intentionally different: it supplies an implementation for a core-owned capability, so that capability core command may remain in the manual.

## Root cause

`loopx commands` and `man/loopx.1` were maintained independently, while the installer only compressed the static manpage. A second gap allowed a new top-level parser command to be omitted from the curated command catalog without an explicit visibility decision.

## Validation

- `python3 examples/cli-help-manpage-smoke.py`
- `python3 examples/install-local-smoke.py`
- `python3 scripts/render-manpage.py --check man/loopx.1`
- `ruff check` on changed Python files
- `loopx canary premerge --from-git-diff --tier standard`: 16/16 selected checks passed
- public/private boundary scan: clean across 6 changed files
- failures/skips/manual holds: none

## Merge decision

Ready for review. This PR does not self-merge.