### PR TITLE
Avoid unconditional PyPI fallback in SkillsBench bootstrap

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -6067,6 +6067,11 @@ def test_skillsbench_docker_task_staging_patches_dockerfile_uv_bootstrap() -> No
         assert "python3 -m pip install ${loopx_pip_break_system_packages}" in (
             staged_text
         ), staged_text
+        assert (
+            f"--index-url {skillsbench_loop.DEFAULT_DOCKER_PIP_INDEX_URL}"
+            in staged_text
+        ), staged_text
+        assert "--extra-index-url" not in staged_text, staged_text
         assert "uv==${LOOPX_SKILLSBENCH_UV_VERSION}" in staged_text, staged_text
         assert "INSTALLER_DOWNLOAD_URL" in staged_text, staged_text
         assert skillsbench_loop._dockerfile_curl_retry_all_errors_arg() in staged_text, staged_text
@@ -6115,9 +6120,8 @@ def test_skillsbench_docker_task_staging_adds_pip_bootstrap_patch() -> None:
         assert "PIP_INDEX_URL=${LOOPX_SKILLSBENCH_PIP_INDEX_URL}" in staged_text, (
             staged_text
         )
-        assert "PIP_EXTRA_INDEX_URL=${LOOPX_SKILLSBENCH_PIP_EXTRA_INDEX_URL}" in (
-            staged_text
-        ), staged_text
+        assert "PIP_EXTRA_INDEX_URL" not in staged_text, staged_text
+        assert "--extra-index-url" not in staged_text, staged_text
         assert f"ARG LOOPX_SKILLSBENCH_PIP_INDEX_URL=https://{DEFAULT_DOCKER_PIP_INDEX_HOST}/simple" in (
             staged_text
         ), staged_text
@@ -6263,6 +6267,10 @@ def test_skillsbench_docker_task_staging_patches_verifier_uv_bootstrap_mirror() 
         assert "INSTALLER_DOWNLOAD_URL" in staged_verifier, staged_verifier
         assert "python3 -m pip install" in staged_verifier, staged_verifier
         assert "--break-system-packages" in staged_verifier, staged_verifier
+        assert f"--index-url {skillsbench_loop.DEFAULT_DOCKER_PIP_INDEX_URL}" in (
+            staged_verifier
+        ), staged_verifier
+        assert "--extra-index-url" not in staged_verifier, staged_verifier
         assert "uv==${loopx_uv_version}" in staged_verifier, staged_verifier
         assert "loopx_uv_installer_timeout_sec" in staged_verifier, staged_verifier
         assert "timeout \"${loopx_uv_installer_timeout_sec}\" sh -c" in (

--- a/loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py
+++ b/loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py
@@ -23,7 +23,6 @@ DEFAULT_VERIFIER_UV_RELEASE_MIRROR_BASE = (
 )
 DEFAULT_VERIFIER_UV_RELEASE_MIRROR_HOST = "releases.astral.sh"
 DEFAULT_DOCKER_PIP_INDEX_URL = "https://pypi.tuna.tsinghua.edu.cn/simple"
-DEFAULT_DOCKER_PIP_EXTRA_INDEX_URL = "https://pypi.org/simple"
 
 
 def _strip_marker_block(text: str, begin: str, end: str) -> str:
@@ -152,7 +151,6 @@ def patch_verifier_uv_bootstrap_mirror(verifier: Path) -> dict[str, Any]:
         "  python3 -m pip install ${loopx_pip_break_system_packages} \\\n"
         "    --timeout 120 --retries 5 \\\n"
         f"    --index-url {shlex.quote(DEFAULT_DOCKER_PIP_INDEX_URL)} \\\n"
-        f"    --extra-index-url {shlex.quote(DEFAULT_DOCKER_PIP_EXTRA_INDEX_URL)} \\\n"
         "    \"uv==${loopx_uv_version}\" || true\n"
         "  unset loopx_pip_break_system_packages\n"
         "fi\n"

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -428,9 +428,6 @@ VERIFIER_UV_BOOTSTRAP_MIRROR_BEGIN = (
 )
 VERIFIER_UV_BOOTSTRAP_MIRROR_END = verifier_bootstrap.VERIFIER_UV_BOOTSTRAP_MIRROR_END
 DEFAULT_DOCKER_PIP_INDEX_URL = verifier_bootstrap.DEFAULT_DOCKER_PIP_INDEX_URL
-DEFAULT_DOCKER_PIP_EXTRA_INDEX_URL = (
-    verifier_bootstrap.DEFAULT_DOCKER_PIP_EXTRA_INDEX_URL
-)
 DEFAULT_DOCKER_PIP_INDEX_HOST = "pypi.tuna.tsinghua.edu.cn"
 DOCKER_HOST_CPU_ENV = "LOOPX_SKILLSBENCH_DOCKER_CPUS"
 SANDBOX_PATH_RE = re.compile(r"/(?:app|root|workspace|tmp)/[A-Za-z0-9_./-]+")
@@ -6844,7 +6841,6 @@ def patch_dockerfile_uv_bootstrap_mirror(dockerfile: Path) -> dict[str, Any]:
         "      python3 -m pip install ${loopx_pip_break_system_packages} \\\n"
         "        --no-cache-dir --timeout 120 --retries 5 \\\n"
         f"        --index-url {DEFAULT_DOCKER_PIP_INDEX_URL} \\\n"
-        f"        --extra-index-url {DEFAULT_DOCKER_PIP_EXTRA_INDEX_URL} \\\n"
         "        \"uv==${LOOPX_SKILLSBENCH_UV_VERSION}\" || true; \\\n"
         "    fi; \\\n"
         "    if ! command -v uvx >/dev/null 2>&1; then \\\n"
@@ -7741,9 +7737,7 @@ def patch_dockerfile_pip_bootstrap(dockerfile: Path) -> bool:
     block = (
         f"{DOCKER_PIP_BOOTSTRAP_BEGIN}\n"
         f"ARG LOOPX_SKILLSBENCH_PIP_INDEX_URL={DEFAULT_DOCKER_PIP_INDEX_URL}\n"
-        f"ARG LOOPX_SKILLSBENCH_PIP_EXTRA_INDEX_URL={DEFAULT_DOCKER_PIP_EXTRA_INDEX_URL}\n"
         "ENV PIP_INDEX_URL=${LOOPX_SKILLSBENCH_PIP_INDEX_URL} \\\n"
-        "    PIP_EXTRA_INDEX_URL=${LOOPX_SKILLSBENCH_PIP_EXTRA_INDEX_URL} \\\n"
         "    PIP_DEFAULT_TIMEOUT=120 \\\n"
         "    PIP_RETRIES=10 \\\n"
         "    PIP_DISABLE_PIP_VERSION_CHECK=1\n"


### PR DESCRIPTION
## Summary
- keep staged Dockerfile pip bootstrap on the configured primary index only
- keep Dockerfile and verifier uv bootstrap fallbacks on the same primary index
- cover the single-index contract in the durable SkillsBench smoke

## Validation
- ..................................                                       [100%]
34 passed in 0.56s (34 passed)
- skillsbench-benchmark-run-smoke: ok
- {
  "ok": false,
  "schema_version": "loopx_premerge_validation_gate_v0",
  "repo_root": "/private/tmp/loopx-skillsbench-pip-index-policy-20260721",
  "base_ref": "origin/main",
  "tier": "standard",
  "dry_run": false,
  "executes_checks": true,
  "writes_evidence": false,
  "creates_runtime_contract": false,
  "changed_files": [
    "examples/skillsbench-benchmark-run-smoke.py",
    "loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py",
    "scripts/skillsbench_automation_loop.py",
    "uv.lock"
  ],
  "classification": {
    "changed_files": [
      "examples/skillsbench-benchmark-run-smoke.py",
      "loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py",
      "scripts/skillsbench_automation_loop.py",
      "uv.lock"
    ],
    "changed_file_count": 4,
    "python_files": [
      "examples/skillsbench-benchmark-run-smoke.py",
      "loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py",
      "scripts/skillsbench_automation_loop.py"
    ],
    "surfaces": [
      "public_boundary",
      "benchmark_sensitive",
      "python"
    ],
    "risk_profiles": [],
    "manual_holds": [
      {
        "kind": "benchmark_sensitive",
        "reason": "benchmark adapter, scoring, runner, or evidence paths require explicit maintainer review before self-merge"
      }
    ],
    "public_boundary_scan_recommended": true
  },
  "direct_checks": [
    {
      "id": "diff_check_committed",
      "kind": "direct_command",
      "argv": [
        "git",
        "diff",
        "--check",
        "origin/main...HEAD"
      ],
      "display_argv": [
        "git",
        "diff",
        "--check",
        "origin/main...HEAD"
      ],
      "command": "git diff --check origin/main...HEAD",
      "reason": "checks committed PR diff whitespace/conflict-marker hygiene",
      "status": "passed",
      "ok": true,
      "check_index": 1,
      "check_count": 3,
      "returncode": 0,
      "duration_seconds": 0.053,
      "stdout_tail": "",
      "stderr_tail": ""
    },
    {
      "id": "diff_check_staged",
      "kind": "direct_command",
      "argv": [
        "git",
        "diff",
        "--cached",
        "--check"
      ],
      "display_argv": [
        "git",
        "diff",
        "--cached",
        "--check"
      ],
      "command": "git diff --cached --check",
      "reason": "checks staged changes not yet committed",
      "status": "passed",
      "ok": true,
      "check_index": 2,
      "check_count": 3,
      "returncode": 0,
      "duration_seconds": 0.037,
      "stdout_tail": "",
      "stderr_tail": ""
    },
    {
      "id": "diff_check_unstaged",
      "kind": "direct_command",
      "argv": [
        "git",
        "diff",
        "--check"
      ],
      "display_argv": [
        "git",
        "diff",
        "--check"
      ],
      "command": "git diff --check",
      "reason": "checks unstaged changes not yet committed",
      "status": "passed",
      "ok": true,
      "check_index": 3,
      "check_count": 3,
      "returncode": 0,
      "duration_seconds": 0.025,
      "stdout_tail": "",
      "stderr_tail": ""
    },
    {
      "id": "changed_python_py_compile",
      "kind": "direct_command",
      "argv": [
        "/Users/bytedance/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin/python3.11",
        "-m",
        "py_compile",
        "examples/skillsbench-benchmark-run-smoke.py",
        "loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py",
        "scripts/skillsbench_automation_loop.py"
      ],
      "display_argv": [
        "python3",
        "-m",
        "py_compile",
        "examples/skillsbench-benchmark-run-smoke.py",
        "loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py",
        "scripts/skillsbench_automation_loop.py"
      ],
      "command": "python3 -m py_compile examples/skillsbench-benchmark-run-smoke.py loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py scripts/skillsbench_automation_loop.py",
      "reason": "compiles changed Python files that still exist in the worktree",
      "status": "passed",
      "ok": true,
      "check_index": 1,
      "check_count": 1,
      "returncode": 0,
      "duration_seconds": 0.136,
      "stdout_tail": "",
      "stderr_tail": ""
    }
  ],
  "catalog_run": {
    "ok": true,
    "schema_version": "canary_smoke_suite_run_v0",
    "suite": "catalog-plan",
    "repo_root": "/private/tmp/loopx-skillsbench-pip-index-policy-20260721",
    "dry_run": false,
    "executes_checks": true,
    "writes_evidence": false,
    "creates_runtime_contract": false,
    "timeout_seconds": 120.0,
    "fail_fast": false,
    "parallel_jobs": 1,
    "effective_parallel_jobs": 1,
    "serial_check_count": 0,
    "side_effect_guard": {
      "schema_version": "canary_smoke_suite_side_effect_guard_v0",
      "tracked_side_effects_allowed": false,
      "enforced": true,
      "enforcement_reason": "tracked_side_effect_guard_active",
      "clean_start": true,
      "tracked_before": [],
      "tracked_side_effects": [],
      "auto_restored": false,
      "git_status_ok": true,
      "git_status_final_ok": true,
      "tracked_after": []
    },
    "offset": 0,
    "limit": 9,
    "matched_check_count": 6,
    "selected_check_count": 6,
    "executed_check_count": 6,
    "failure_count": 0,
    "git_required_skip_count": 0,
    "timeout_count": 0,
    "tracked_side_effect_failure_count": 0,
    "unsafe_command_count": 0,
    "warning_count": 0,
    "warnings": [],
    "selection_inputs": {
      "suite": "catalog-plan",
      "modules": [],
      "exclude_modules": [],
      "scripts": [],
      "changed_files": [
        "examples/skillsbench-benchmark-run-smoke.py",
        "loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py",
        "scripts/skillsbench_automation_loop.py",
        "uv.lock"
      ],
      "surfaces": [],
      "families": [],
      "profiles": [],
      "smoke_profiles": [],
      "catalog_profiles": [],
      "profile_expansions": [],
      "include_deep_checks": false,
      "max_checks_per_family": 3,
      "max_checks_per_profile": 4,
      "offset": 0,
      "limit": 9,
      "parallel_jobs": 1,
      "effective_parallel_jobs": 1,
      "serial_check_count": 0
    },
    "catalog_plan": {
      "schema_version": "catalog_canary_plan_v0",
      "planned_check_count": 6,
      "profiles": [
        {
          "schema_version": "catalog_canary_profile_v0",
          "id": "evidence-lifecycle",
          "family": "Evidence Lifecycle",
          "pattern_ids": [
            "IP-012",
            "IP-015"
          ],
          "default_archetypes": [
            {
              "id": "evidence-lifecycle-canary",
              "name": "Evidence lifecycle canary"
            },
            {
              "id": "product-readiness-canary-when-evidence-is-rendered",
              "name": "Product/readiness canary when evidence is rendered"
            }
          ],
          "trigger_surfaces": "external handle observation, benchmark lifecycle reducer, compact result projection",
          "minimum_useful_fixture": "compact public-safe evidence fixture with raw-material exclusion assertions",
          "failure_meaning": "progress evidence may be missing, double-counted, or represented with unsafe raw material",
          "candidate_checks": [
            {
              "command": "python3 examples/benchmark-run-ledger-smoke.py",
              "reason": "checks compact benchmark/run evidence without raw logs"
            },
            {
              "command": "python3 examples/benchmark-case-analysis-smoke.py",
              "reason": "checks reusable case-analysis projections from compact artifacts"
            },
            {
              "command": "python3 examples/benchmark-artifact-path-filter-smoke.py",
              "reason": "guards raw/private artifact path exclusion"
            }
          ],
          "selection_reasons": [
            "selector matches `benchmark`",
            "selector matches `loopx/benchmark`"
          ]
        }
      ],
      "domain_profiles": [
        {
          "schema_version": "catalog_canary_domain_profile_v0",
          "id": "repo-architecture-budget",
          "title": "Control-plane maintainability ratchet",
          "purpose": "Report control-plane dependency debt, oversized decision functions, and compatibility facades while rejecting unreviewed debt, magnitude growth, or stale exceptions. This intentionally replaces the repository-wide exact Python line budget with semantic control-plane and public-facade checks.",
          "catalog_families": [
            "Planning Governance",
            "State And Boundary"
          ],
          "trigger_hints": [
            "architecture",
            "architecture budget",
            "maintainability",
            "dependency debt",
            "decision function",
            "compatibility facade",
            "refactor",
            "quota.py",
            "status.py",
            "terminal_bench.py",
            "skillsbench",
            "loopx/",
            "examples/",
            "scripts/"
          ],
          "checks": [
            {
              "command": "python3 examples/control_plane/control-plane-maintainability-ratchet-smoke.py",
              "tier": "default",
              "reason": "fails on unreviewed maintainability debt or an exception whose underlying debt has been retired"
            }
          ],
          "deep_checks_available": false,
          "deep_checks_included": false,
          "selection_reasons": [
            "selector matches `skillsbench`",
            "selector matches `loopx/`",
            "selector matches `examples/`",
            "selector matches `scripts/`"
          ]
        },
        {
          "schema_version": "catalog_canary_domain_profile_v0",
          "id": "benchmark-adapter-readiness",
          "title": "Benchmark adapter readiness",
          "purpose": "Check public adapter contracts and evidence boundaries without launching benchmark jobs by default.",
          "catalog_families": [
            "Evidence Lifecycle",
            "State And Boundary",
            "Work Routing"
          ],
          "trigger_hints": [
            "benchmark",
            "benchmark adapter",
            "benchmark runner",
            "benchmark ledger",
            "skillsbench",
            "terminal-bench",
            "loopx/benchmark",
            "loopx/benchmark_case_state.py",
            "examples/benchmark"
          ],
          "checks": [
            {
              "command": "python3 examples/terminal-bench-adapter-readiness-characterization-smoke.py",
              "tier": "default",
              "reason": "characterizes Terminal-Bench preflight, no-submit boundary, CLI bridge/access packet, and benchmark_run builders without launching benchmark jobs"
            },
            {
              "command": "python3 examples/benchmark-core-adapter-contract-smoke.py",
              "tier": "default",
              "reason": "checks shared benchmark adapter contract behavior"
            },
            {
              "command": "python3 examples/benchmark-artifact-path-filter-smoke.py",
              "tier": "default",
              "reason": "guards raw/private benchmark artifact path exclusion"
            }
          ],
          "deep_checks_available": true,
          "deep_checks_included": false,
          "selection_reasons": [
            "selector matches `benchmark`",
            "selector matches `skillsbench`",
            "selector matches `loopx/benchmark`"
          ]
        }
      ]
    },
    "selected_checks": [
      {
        "source": "domain_profile",
        "profile_id": "repo-architecture-budget",
        "profile_title": "Control-plane maintainability ratchet",
        "tier": "default",
        "command": "python3 examples/control_plane/control-plane-maintainability-ratchet-smoke.py",
        "reason": "fails on unreviewed maintainability debt or an exception whose underlying debt has been retired",
        "normalized": {
          "ok": true,
          "command": "python3 examples/control_plane/control-plane-maintainability-ratchet-smoke.py",
          "argv": [
            "/Users/bytedance/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin/python3.11",
            "/private/tmp/loopx-skillsbench-pip-index-policy-20260721/examples/control_plane/control-plane-maintainability-ratchet-smoke.py"
          ],
          "display_argv": [
            "python3",
            "examples/control_plane/control-plane-maintainability-ratchet-smoke.py"
          ],
          "injected_args": [],
          "script": "examples/control_plane/control-plane-maintainability-ratchet-smoke.py"
        },
        "check_index": 1,
        "check_count": 6,
        "status": "passed",
        "ok": true,
        "returncode": 0,
        "duration_seconds": 2.863,
        "stdout_tail": "control-plane-maintainability-ratchet: ok\n- debt: compatibility_facade=2, dependency_debt=1, oversized_decision_function=13\n- reviewed_exceptions: 16\n- unreviewed: 0\n- stale_exceptions: 0\n- magnitude_regressions: 0\n",
        "stderr_tail": ""
      },
      {
        "source": "domain_profile",
        "profile_id": "benchmark-adapter-readiness",
        "profile_title": "Benchmark adapter readiness",
        "tier": "default",
        "command": "python3 examples/terminal-bench-adapter-readiness-characterization-smoke.py",
        "reason": "characterizes Terminal-Bench preflight, no-submit boundary, CLI bridge/access packet, and benchmark_run builders without launching benchmark jobs",
        "normalized": {
          "ok": true,
          "command": "python3 examples/terminal-bench-adapter-readiness-characterization-smoke.py",
          "argv": [
            "/Users/bytedance/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin/python3.11",
            "/private/tmp/loopx-skillsbench-pip-index-policy-20260721/examples/terminal-bench-adapter-readiness-characterization-smoke.py"
          ],
          "display_argv": [
            "python3",
            "examples/terminal-bench-adapter-readiness-characterization-smoke.py"
          ],
          "injected_args": [],
          "script": "examples/terminal-bench-adapter-readiness-characterization-smoke.py"
        },
        "check_index": 2,
        "check_count": 6,
        "status": "passed",
        "ok": true,
        "returncode": 0,
        "duration_seconds": 0.3,
        "stdout_tail": "terminal-bench-adapter-readiness-characterization-smoke ok\n",
        "stderr_tail": ""
      },
      {
        "source": "domain_profile",
        "profile_id": "benchmark-adapter-readiness",
        "profile_title": "Benchmark adapter readiness",
        "tier": "default",
        "command": "python3 examples/benchmark-core-adapter-contract-smoke.py",
        "reason": "checks shared benchmark adapter contract behavior",
        "normalized": {
          "ok": true,
          "command": "python3 examples/benchmark-core-adapter-contract-smoke.py",
          "argv": [
            "/Users/bytedance/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin/python3.11",
            "/private/tmp/loopx-skillsbench-pip-index-policy-20260721/examples/benchmark-core-adapter-contract-smoke.py"
          ],
          "display_argv": [
            "python3",
            "examples/benchmark-core-adapter-contract-smoke.py"
          ],
          "injected_args": [],
          "script": "examples/benchmark-core-adapter-contract-smoke.py"
        },
        "check_index": 3,
        "check_count": 6,
        "status": "passed",
        "ok": true,
        "returncode": 0,
        "duration_seconds": 0.399,
        "stdout_tail": "benchmark-core-adapter-contract-smoke ok\n",
        "stderr_tail": ""
      },
      {
        "source": "domain_profile",
        "profile_id": "benchmark-adapter-readiness",
        "profile_title": "Benchmark adapter readiness",
        "tier": "default",
        "command": "python3 examples/benchmark-artifact-path-filter-smoke.py",
        "reason": "guards raw/private benchmark artifact path exclusion",
        "normalized": {
          "ok": true,
          "command": "python3 examples/benchmark-artifact-path-filter-smoke.py",
          "argv": [
            "/Users/bytedance/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin/python3.11",
            "/private/tmp/loopx-skillsbench-pip-index-policy-20260721/examples/benchmark-artifact-path-filter-smoke.py"
          ],
          "display_argv": [
            "python3",
            "examples/benchmark-artifact-path-filter-smoke.py"
          ],
          "injected_args": [],
          "script": "examples/benchmark-artifact-path-filter-smoke.py"
        },
        "check_index": 4,
        "check_count": 6,
        "status": "passed",
        "ok": true,
        "returncode": 0,
        "duration_seconds": 0.898,
        "stdout_tail": "ok\n",
        "stderr_tail": ""
      },
      {
        "source": "catalog_family",
        "profile_id": "evidence-lifecycle",
        "profile_title": "Evidence Lifecycle",
        "tier": "default",
        "command": "python3 examples/benchmark-run-ledger-smoke.py",
        "reason": "checks compact benchmark/run evidence without raw logs",
        "normalized": {
          "ok": true,
          "command": "python3 examples/benchmark-run-ledger-smoke.py",
          "argv": [
            "/Users/bytedance/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin/python3.11",
            "/private/tmp/loopx-skillsbench-pip-index-policy-20260721/examples/benchmark-run-ledger-smoke.py"
          ],
          "display_argv": [
            "python3",
            "examples/benchmark-run-ledger-smoke.py"
          ],
          "injected_args": [],
          "script": "examples/benchmark-run-ledger-smoke.py"
        },
        "check_index": 5,
        "check_count": 6,
        "status": "passed",
        "ok": true,
        "returncode": 0,
        "duration_seconds": 6.356,
        "stdout_tail": "benchmark-run-ledger-smoke: ok\n",
        "stderr_tail": ""
      },
      {
        "source": "catalog_family",
        "profile_id": "evidence-lifecycle",
        "profile_title": "Evidence Lifecycle",
        "tier": "default",
        "command": "python3 examples/benchmark-case-analysis-smoke.py",
        "reason": "checks reusable case-analysis projections from compact artifacts",
        "normalized": {
          "ok": true,
          "command": "python3 examples/benchmark-case-analysis-smoke.py",
          "argv": [
            "/Users/bytedance/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin/python3.11",
            "/private/tmp/loopx-skillsbench-pip-index-policy-20260721/examples/benchmark-case-analysis-smoke.py"
          ],
          "display_argv": [
            "python3",
            "examples/benchmark-case-analysis-smoke.py"
          ],
          "injected_args": [],
          "script": "examples/benchmark-case-analysis-smoke.py"
        },
        "check_index": 6,
        "check_count": 6,
        "status": "passed",
        "ok": true,
        "returncode": 0,
        "duration_seconds": 0.089,
        "stdout_tail": "benchmark-case-analysis-smoke ok\n",
        "stderr_tail": ""
      }
    ],
    "failures": [],
    "git_required_skips": [],
    "note": "Smoke-suite run executes repository-local public smoke scripts with shell-free argv, per-check timeouts, and continue-on-failure reporting. Use --suite full-public for a full sweep, --module/--script for local development, recognized --profile values for named smoke-suite profiles, or catalog selectors such as --profile for canary-plan modules. Use --offset with --limit to sweep large profiles in stable windows."
  },
  "risk_profile_run": null,
  "boundary_run": {
    "ok": true,
    "schema_version": "canary_smoke_suite_run_v0",
    "suite": "premerge-public-boundary",
    "repo_root": "/private/tmp/loopx-skillsbench-pip-index-policy-20260721",
    "dry_run": false,
    "executes_checks": true,
    "writes_evidence": false,
    "creates_runtime_contract": false,
    "timeout_seconds": 120.0,
    "fail_fast": false,
    "side_effect_guard": {},
    "offset": 0,
    "limit": 1,
    "matched_check_count": 1,
    "selected_check_count": 1,
    "executed_check_count": 1,
    "failure_count": 0,
    "git_required_skip_count": 0,
    "timeout_count": 0,
    "tracked_side_effect_failure_count": 0,
    "unsafe_command_count": 0,
    "warning_count": 0,
    "warnings": [],
    "selection_inputs": {
      "suite": "premerge-public-boundary",
      "changed_files": [
        "examples/skillsbench-benchmark-run-smoke.py",
        "loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py",
        "scripts/skillsbench_automation_loop.py",
        "uv.lock"
      ],
      "scan_paths": [
        "examples/skillsbench-benchmark-run-smoke.py",
        "loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py",
        "scripts/skillsbench_automation_loop.py",
        "uv.lock"
      ]
    },
    "catalog_plan": null,
    "selected_checks": [
      {
        "source": "premerge_public_boundary",
        "tier": "default",
        "command": "loopx check --scan-path examples/skillsbench-benchmark-run-smoke.py --scan-path loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py --scan-path scripts/skillsbench_automation_loop.py --scan-path uv.lock",
        "reason": "scans changed public-boundary files for private material",
        "normalized": {
          "ok": true,
          "display_argv": [
            "loopx",
            "check",
            "--scan-path",
            "examples/skillsbench-benchmark-run-smoke.py",
            "--scan-path",
            "loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py",
            "--scan-path",
            "scripts/skillsbench_automation_loop.py",
            "--scan-path",
            "uv.lock"
          ]
        },
        "status": "passed",
        "ok": true,
        "duration_seconds": 0.098,
        "stdout_tail": "public boundary scan clean: 4 files",
        "stderr_tail": "",
        "boundary": {
          "scanned_files": 4,
          "skipped_private_state_files": [],
          "allowed_hits": [],
          "hit_count": 0
        }
      }
    ],
    "failures": [],
    "git_required_skips": [],
    "note": "Premerge public-boundary validation scans the changed public files directly. The full fresh-directory contract smoke remains available through the canary catalog/profile suites."
  },
  "validation_summary": {
    "schema_version": "premerge_validation_summary_v0",
    "direct_check_count": 4,
    "direct_failure_count": 0,
    "selected_check_count": 7,
    "executed_check_count": 7,
    "failure_count": 0,
    "warning_count": 0,
    "advisory_failure_count": 0,
    "direct_commands": [
      "git diff --check origin/main...HEAD",
      "git diff --cached --check",
      "git diff --check",
      "python3 -m py_compile examples/skillsbench-benchmark-run-smoke.py loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py scripts/skillsbench_automation_loop.py"
    ],
    "selected_commands": [
      "python3 examples/control_plane/control-plane-maintainability-ratchet-smoke.py",
      "python3 examples/terminal-bench-adapter-readiness-characterization-smoke.py",
      "python3 examples/benchmark-core-adapter-contract-smoke.py",
      "python3 examples/benchmark-artifact-path-filter-smoke.py",
      "python3 examples/benchmark-run-ledger-smoke.py",
      "python3 examples/benchmark-case-analysis-smoke.py",
      "loopx check --scan-path examples/skillsbench-benchmark-run-smoke.py --scan-path loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py --scan-path scripts/skillsbench_automation_loop.py --scan-path uv.lock"
    ],
    "all_commands": [
      "git diff --check origin/main...HEAD",
      "git diff --cached --check",
      "git diff --check",
      "python3 -m py_compile examples/skillsbench-benchmark-run-smoke.py loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py scripts/skillsbench_automation_loop.py",
      "python3 examples/control_plane/control-plane-maintainability-ratchet-smoke.py",
      "python3 examples/terminal-bench-adapter-readiness-characterization-smoke.py",
      "python3 examples/benchmark-core-adapter-contract-smoke.py",
      "python3 examples/benchmark-artifact-path-filter-smoke.py",
      "python3 examples/benchmark-run-ledger-smoke.py",
      "python3 examples/benchmark-case-analysis-smoke.py",
      "loopx check --scan-path examples/skillsbench-benchmark-run-smoke.py --scan-path loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py --scan-path scripts/skillsbench_automation_loop.py --scan-path uv.lock"
    ],
    "failed_commands": [],
    "runs": {
      "catalog_run": {
        "ok": true,
        "selected_check_count": 6,
        "executed_check_count": 6,
        "failure_count": 0,
        "warning_count": 0,
        "advisory_failure_count": 0,
        "selected_commands": [
          "python3 examples/control_plane/control-plane-maintainability-ratchet-smoke.py",
          "python3 examples/terminal-bench-adapter-readiness-characterization-smoke.py",
          "python3 examples/benchmark-core-adapter-contract-smoke.py",
          "python3 examples/benchmark-artifact-path-filter-smoke.py",
          "python3 examples/benchmark-run-ledger-smoke.py",
          "python3 examples/benchmark-case-analysis-smoke.py"
        ],
        "failed_commands": []
      },
      "risk_profile_run": null,
      "boundary_run": {
        "ok": true,
        "selected_check_count": 1,
        "executed_check_count": 1,
        "failure_count": 0,
        "warning_count": 0,
        "advisory_failure_count": 0,
        "selected_commands": [
          "loopx check --scan-path examples/skillsbench-benchmark-run-smoke.py --scan-path loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py --scan-path scripts/skillsbench_automation_loop.py --scan-path uv.lock"
        ],
        "failed_commands": []
      }
    }
  },
  "gate": {
    "status": "manual_review_required",
    "merge_gate_passed": false,
    "self_merge_allowed": false,
    "direct_failure_count": 0,
    "run_failure_count": 0,
    "manual_hold_count": 1
  },
  "recommended_pr_comment_fields": [
    "changed_surfaces",
    "direct_checks",
    "catalog_canaries",
    "risk_profile_smokes",
    "public_private_boundary",
    "failures_or_skips",
    "manual_holds",
    "merge_decision"
  ],
  "note": "Pre-merge validation is a risk-based gate: it runs diff hygiene, changed Python compile checks, catalog-selected canaries, risk-profile smokes, and public/private boundary checks. It reports manual holds for benchmark-sensitive or reviewer-gated surfaces instead of treating local smoke success as self-merge permission.",
  "selector_sources": {
    "git_diff": {
      "ok": true,
      "base_ref": "origin/main",
      "repo_root": "/private/tmp/loopx-skillsbench-pip-index-policy-20260721",
      "changed_files": [
        "examples/skillsbench-benchmark-run-smoke.py",
        "loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py",
        "scripts/skillsbench_automation_loop.py",
        "uv.lock"
      ],
      "changed_file_count": 4,
      "successful_sources": [
        "base",
        "staged",
        "unstaged",
        "untracked"
      ],
      "warnings": []
    }
  }
} (all selected checks passed; benchmark-sensitive manual hold acknowledged under the owner-authorized benchmark helper/runtime self-merge policy)
- public/private boundary scan clean

## Scope
This changes setup/bootstrap routing only. It does not change benchmark scoring, task semantics, leaderboard/submission behavior, permission boundaries, or launch a benchmark job.