### PR TITLE
fix: update OpenViking public smoke authority binding

### DIFF
--- a/examples/openviking-periodic-report-extension-smoke.py
+++ b/examples/openviking-periodic-report-extension-smoke.py
@@ -15,6 +15,9 @@ from loopx.capabilities.periodic_report import (  # noqa: E402
     build_periodic_report_document,
     build_periodic_report_source_result,
 )
+from loopx.capabilities.periodic_report.extension_envelope import (  # noqa: E402
+    build_openviking_archive_execution_envelope,
+)
 from loopx.extensions.openviking_periodic_report.provider import (  # noqa: E402
     REQUEST_SCHEMA,
     archive_request,
@@ -22,6 +25,9 @@ from loopx.extensions.openviking_periodic_report.provider import (  # noqa: E402
 from loopx.presentation.renderers.periodic_report_markdown import (  # noqa: E402
     render_periodic_report_markdown,
 )
+
+
+EXTENSION_REVISION = "smoke-revision-1"
 
 
 class FakeOpenViking:
@@ -99,7 +105,6 @@ def main() -> None:
     request = {
         "schema_version": REQUEST_SCHEMA,
         "activation_receipt": build_periodic_report_activation(profile),
-        "available_capabilities": ["openviking_context_write"],
         "artifact": artifact,
         "document": document,
         "context": {
@@ -110,9 +115,13 @@ def main() -> None:
         },
         "execute": True,
     }
+    request["execution_envelope"] = build_openviking_archive_execution_envelope(
+        request,
+        extension_revision=EXTENSION_REVISION,
+    )
     client = FakeOpenViking()
-    first = archive_request(request, client=client)
-    replay = archive_request(request, client=client)
+    first = archive_request(request, client=client, extension_revision=EXTENSION_REVISION)
+    replay = archive_request(request, client=client, extension_revision=EXTENSION_REVISION)
     assert first["status"] == replay["status"] == "sent"
     assert first["result_id"] == replay["result_id"]
     assert replay["write_status"] == "already_present"


### PR DESCRIPTION
## Summary

- update the public OpenViking periodic-report smoke to use the merged request-bound execution envelope
- pass the same bound extension revision into provider execution and replay
- remove the obsolete request-side `available_capabilities` field

## Why

After #2391 merged, `main` correctly requires an execution envelope and bound revision before effectful archive writes. The public smoke still used the previous direct-call contract, causing three consecutive Full Public Smokes failures while Python Tests remained green.

## Validation

- targeted full-public runner: 1/1 passed
- focused OpenViking/envelope tests: 20 passed
- direct smoke: passed
- Ruff and `git diff --check`: passed
- LoopX premerge: 2/2 selected checks passed, public boundary clean, no holds
