### PR TITLE
Fix missing benchmark score countability

### DIFF
--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -2158,7 +2158,7 @@ def build_benchmark_run_ledger_entry(
             if isinstance(marker.get("attempt_accounting"), dict)
             else {}
         )
-    has_official_bool_score = official_score_bool_fallback_used(benchmark_run)
+    has_official_bool_score = bool_fallback_used
     if attempt_accounting:
         for source_field, entry_field in (
             ("lifecycle_phase", "attempt_lifecycle_phase"),

--- a/loopx/benchmark_ledger_countability.py
+++ b/loopx/benchmark_ledger_countability.py
@@ -126,6 +126,17 @@ def official_score_bool_fallback_allowed(run: dict[str, Any]) -> bool:
     if not _fallback_candidate_present(run):
         return False
 
+    accounting = (
+        run.get("attempt_accounting")
+        if isinstance(run.get("attempt_accounting"), dict)
+        else {}
+    )
+    attempt_countable = run.get("official_score_attempt_countable")
+    if attempt_countable is None:
+        attempt_countable = accounting.get("official_score_attempt_countable")
+    if attempt_countable is False:
+        return False
+
     labels = _fallback_label_values(run)
     if "skillsbench_codex_acp_post_success_finalization" in labels:
         return False

--- a/tests/test_benchmark_ledger_countability.py
+++ b/tests/test_benchmark_ledger_countability.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from loopx.benchmark_ledger import build_benchmark_run_ledger_entry
+
+
+def _skillsbench_bool_only_run(*, status: str, attempt_countable: bool) -> dict:
+    return {
+        "schema_version": "benchmark_run_v0",
+        "benchmark_id": "skillsbench@1.1",
+        "case_id": "fixture-case",
+        "job_name": "skillsbench_fixture_loopx_turn_agent_cli",
+        "mode": "skillsbench_loopx_turn_agent_cli_treatment",
+        "official_score_status": status,
+        "official_task_score": {
+            "kind": "skillsbench_verifier_reward",
+            "passed": False,
+        },
+        "score_failure_attribution": (
+            "verifier_infrastructure_failure"
+            if status == "missing"
+            else "official_score_zero_case_failure"
+        ),
+        "attempt_accounting": {
+            "schema_version": "benchmark_attempt_accounting_v0",
+            "lifecycle_phase": "verifier_scored",
+            "failure_label": (
+                "verifier_infrastructure_failure"
+                if status == "missing"
+                else "official_score_zero_case_failure"
+            ),
+            "failure_class": "verifier_failed" if status == "missing" else "solver_failed",
+            "official_score_attempt_countable": attempt_countable,
+        },
+    }
+
+
+def test_missing_uncountable_score_does_not_fall_back_to_zero() -> None:
+    entry = build_benchmark_run_ledger_entry(
+        _skillsbench_bool_only_run(status="missing", attempt_countable=False)
+    )
+
+    assert entry["score_status"] == "missing"
+    assert "official_score" not in entry
+    assert entry["official_score_bool_fallback_used"] is False
+    assert entry["official_score_attempt_countable"] is False
+    assert entry["official_score_countable"] is False
+    assert entry["official_score_countability_reason"] == "score_missing"
+    assert "countable_score" not in entry
+
+
+def test_completed_countable_bool_only_score_can_still_fall_back_to_zero() -> None:
+    entry = build_benchmark_run_ledger_entry(
+        _skillsbench_bool_only_run(status="completed", attempt_countable=True)
+    )
+
+    assert entry["score_status"] == "failed"
+    assert entry["official_score"] == 0.0
+    assert entry["official_score_bool_fallback_used"] is True
+    assert entry["official_score_attempt_countable"] is True
+    assert entry["official_score_countable"] is True
+    assert entry["countable_score"] == 0.0


### PR DESCRIPTION
## Summary

- honor explicit `official_score_attempt_countable=false` before using a bool-only score fallback
- only let an allowed bool fallback override ledger attempt countability
- cover both the missing-score regression and the valid completed bool-only zero fallback

## Motivation

A compact benchmark result can contain `official_task_score.passed=false` while the official score is missing because verifier infrastructure did not produce a countable score. The ledger previously converted that shape to a countable `0.0`, which could pollute aggregates and matched comparisons.

This change keeps the official benchmark result untouched and tightens only the ledger ingestion contract.

## Validation

- `PYTHONPATH=. uv run --no-project --with pytest python -m pytest -q tests/test_benchmark_ledger_countability.py` (2 passed)
- `PYTHONPATH=. uv run --no-project --with pytest python examples/benchmark-run-ledger-smoke.py` (passed)
- `loopx canary premerge --from-git-diff --format json` (compile and 6 selected canaries passed; benchmark-sensitive manual hold remains)
- public/private boundary scan clean; no raw task text, logs, trajectories, verifier output, credentials, or local paths added

## Risk

Low and localized to benchmark ledger ingestion. Completed countable bool-only scores retain their existing fallback behavior; explicitly uncountable missing scores remain missing and cannot enter aggregate scoring.
