### PR TITLE
Fix SkillsBench N-Turn proof counts

### DIFF
--- a/loopx/benchmark_adapters/skillsbench_turn_route.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_route.py
@@ -17,9 +17,18 @@ LOOPX_TURN_PUBLIC_BOUNDARY_FIELDS = (
 )
 LOOPX_TURN_RUNNER_READINESS_CHECKS = (
     "turn_transaction_committed",
+    "independent_scored_workspace_validation_passed",
     "pre_agent_postcondition_checked",
     "pre_agent_postcondition_eligible",
+    "post_agent_postcondition_validated",
     "post_agent_postcondition_satisfied",
+    "official_feedback_blinded",
+)
+LOOPX_TURN_PROOF_CHECKS = (
+    "turn_transaction_committed",
+    "independent_scored_workspace_validation_passed",
+    "pre_agent_postcondition_checked",
+    "post_agent_postcondition_validated",
     "official_feedback_blinded",
 )
 
@@ -326,6 +335,8 @@ def _public_runner_readiness(value: Any) -> dict[str, Any]:
     }
     if isinstance(value.get("ready"), bool):
         receipt["ready"] = value["ready"]
+    if isinstance(value.get("turn_proven"), bool):
+        receipt["turn_proven"] = value["turn_proven"]
     checks = value.get("checks")
     if isinstance(checks, dict):
         receipt["checks"] = {
@@ -355,6 +366,21 @@ def _public_runner_readiness(value: Any) -> dict[str, Any]:
 
 def _aggregate_runner_readiness(receipts: list[dict[str, Any]]) -> dict[str, Any]:
     ready_count = sum(item.get("ready") is True for item in receipts)
+    committed_count = sum(
+        isinstance(item.get("checks"), dict)
+        and item["checks"].get("turn_transaction_committed") is True
+        for item in receipts
+    )
+    proven_count = sum(
+        item.get("turn_proven") is True
+        or (
+            not isinstance(item.get("turn_proven"), bool)
+            and item.get("ready") is True
+            and isinstance(item.get("checks"), dict)
+            and item["checks"].get("turn_transaction_committed") is True
+        )
+        for item in receipts
+    )
     blockers = sorted(
         {
             blocker
@@ -368,7 +394,9 @@ def _aggregate_runner_readiness(receipts: list[dict[str, Any]]) -> dict[str, Any
         "capability": "benchmark_runner",
         "status": "ready" if ready_count else "blocked",
         "ready": ready_count > 0,
-        "proven_turn_count": ready_count,
+        "runner_ready_turn_count": ready_count,
+        "proven_turn_count": proven_count,
+        "committed_turn_count": committed_count,
         "observed_turn_count": len(receipts),
         "blocker_codes": [] if ready_count else blockers,
         "raw_task_text_recorded": any(

--- a/loopx/benchmark_adapters/skillsbench_turn_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_runtime.py
@@ -27,6 +27,7 @@ from .skillsbench_acp_failure_policy import (
     RECOVERABLE_CODEX_TURN_FAILURE_PREFIX,
     recoverable_codex_turn_failure_message,
 )
+from .skillsbench_turn_route import LOOPX_TURN_PROOF_CHECKS
 
 
 SKILLSBENCH_LOOPX_TURN_TRACE_SCHEMA_VERSION = (
@@ -779,6 +780,10 @@ def build_skillsbench_benchmark_runner_readiness(
     )
     checks = {
         "turn_transaction_committed": execution.get("status") == "committed",
+        "independent_scored_workspace_validation_passed": bool(
+            scored_workspace_validation.get("status") == "passed"
+            and scored_workspace_validation.get("independent") is True
+        ),
         "pre_agent_postcondition_checked": (
             scored_workspace_validation.get("pre_agent_postcondition_checked") is True
         ),
@@ -789,16 +794,22 @@ def build_skillsbench_benchmark_runner_readiness(
             scored_workspace_validation.get("post_agent_postcondition_status")
             == "satisfied"
         ),
+        "post_agent_postcondition_validated": (
+            scored_workspace_validation.get("post_agent_postcondition_status")
+            in {"progress_validated", "satisfied"}
+        ),
         "official_feedback_blinded": (
             scored_workspace_validation.get("oracle_feedback_used") is False
         ),
     }
     blockers = [name for name, passed in checks.items() if not passed]
+    turn_proven = all(checks[name] for name in LOOPX_TURN_PROOF_CHECKS)
     return {
         "schema_version": "skillsbench_benchmark_runner_readiness_v0",
         "capability": "benchmark_runner",
         "status": "ready" if not blockers else "blocked",
         "ready": not blockers,
+        "turn_proven": turn_proven,
         "checks": checks,
         "blocker_codes": blockers,
         "evidence_kind": "committed_turn_with_independent_postcondition",

--- a/tests/test_skillsbench_turn_runtime.py
+++ b/tests/test_skillsbench_turn_runtime.py
@@ -448,6 +448,7 @@ def test_satisfied_pre_agent_postcondition_runs_but_does_not_claim_readiness(
     assert validation["pre_agent_postcondition_status"] == "already_satisfied"
     assert validation["meaningful_operation_count"] == 1
     assert receipt["ready"] is False
+    assert receipt["turn_proven"] is True
     assert "pre_agent_postcondition_eligible" in receipt["blocker_codes"]
 
 
@@ -1425,6 +1426,34 @@ def test_runner_readiness_fails_closed_on_partial_evidence(
     assert blocker in receipt["blocker_codes"]
 
 
+@pytest.mark.parametrize(
+    ("post_status", "independent", "expected_proven"),
+    [
+        ("progress_validated", True, True),
+        ("satisfied", False, False),
+    ],
+)
+def test_runner_readiness_turn_proof_is_independent_from_causal_readiness(
+    post_status: str,
+    independent: bool,
+    expected_proven: bool,
+) -> None:
+    receipt = runtime.build_skillsbench_benchmark_runner_readiness(
+        execution={"status": "committed"},
+        scored_workspace_validation={
+            "status": "passed",
+            "independent": independent,
+            "pre_agent_postcondition_checked": True,
+            "pre_agent_postcondition_status": "unsatisfied",
+            "post_agent_postcondition_status": post_status,
+            "oracle_feedback_used": False,
+        },
+    )
+
+    assert receipt["turn_proven"] is expected_proven
+    assert receipt["ready"] is (expected_proven and post_status == "satisfied")
+
+
 def test_runner_readiness_survives_public_trace_aggregation() -> None:
     ready_trace = runtime.build_skillsbench_loopx_turn_trace(
         route="loopx-turn-agent-cli",
@@ -1476,7 +1505,9 @@ def test_runner_readiness_survives_public_trace_aggregation() -> None:
 
     receipt = compact["benchmark_runner_readiness"]
     assert receipt["ready"] is True
-    assert receipt["proven_turn_count"] == 1
+    assert receipt["runner_ready_turn_count"] == 1
+    assert receipt["proven_turn_count"] == 2
+    assert receipt["committed_turn_count"] == 2
     assert receipt["observed_turn_count"] == 2
     assert receipt["blocker_codes"] == []
     assert receipt["raw_task_text_recorded"] is False


### PR DESCRIPTION
## Summary
- separate per-Turn transaction proof from stricter runner readiness
- report runner-ready, proven, committed, and observed counts for bounded N-Turn SkillsBench runs
- require committed transactions, independent validation, checked baselines, validated progress or completion, and blinded official feedback before a Turn is proven

## Validation
- `tests/test_skillsbench_turn_runtime.py`: 29 passed
- `examples/skillsbench-loopx-turn-agent-cli-smoke.py`: passed
- `examples/skillsbench-benchmark-run-smoke.py`: passed
- Ruff, Python compile, and diff checks passed
- standard premerge canary: all 6 selected checks passed
- `loopx check`: 3 public files, 0 errors/warnings

## Holds
- standard canary reports the categorical `benchmark_sensitive` manual hold
- owner has explicitly authorized self-merge for benchmark helper/runtime changes after validation
- no scoring, task semantics, permission, upload, submission, or reward-feedback behavior changes