### PR TITLE
feat(finance): add cross-market crash and repair regimes

### DIFF
--- a/extensions/loopx-finance-value-discovery/README.md
+++ b/extensions/loopx-finance-value-discovery/README.md
@@ -32,6 +32,76 @@ The packet enforces:
 - at most one bounded successor, with no threshold relaxation or continuous
   watch.
 
+The same provider also accepts `finance_market_regime_input_v0` and emits
+`finance_market_regime_packet_v0`. This second mode classifies two different
+questions without turning either into a trade instruction:
+
+- `precrash`: `no_precrash_signal`, `risk_observation`, or
+  `risk_confirmation`;
+- `recovery`: `not_in_drawdown`, `unrepaired`, `repair_observation`,
+  `repair_confirmation`, or `repair_failed`.
+
+The provider remains a pure reducer. A caller computes the frozen point-in-time
+metrics and supplies public source references; the provider validates the exact
+market profile and applies the versioned thresholds. It does not fetch prices,
+access an account, size a position, or execute an automatic risk action.
+
+## Market Regime Rules v0
+
+The U.S. profile uses SPY as the primary series, QQQ and S&P 500 Equal Weight
+relative returns as leadership and participation proxies, HYG as a credit
+proxy, and VIX as the volatility input. Its pre-crash layers are:
+
+1. vulnerability: VIX `<= 20` while the primary index is at or above its
+   200-day average;
+2. leadership or breadth break: QQQ trails by at least 5 percentage points and
+   is below its 50-day average, or equal weight trails by at least 3 percentage
+   points and is below its 50-day average;
+3. credit confirmation: HYG is below its 200-day average with a 20-day return
+   of `<= -1%`;
+4. trend confirmation: the primary index is below its 200-day average and its
+   50-day average has a negative 20-day slope.
+
+The A-share profile uses a CSI 300 ETF as the primary series and CSI 500, CSI
+1000, and ChiNext ETFs as participation proxies. Its distinct layers are:
+
+1. crowding or complacency: the primary series is above its 200-day average
+   with either a 60-day return of `>= 12%` or 20-day turnover at least `1.25x`
+   its 120-day average;
+2. leadership or breadth break: the three participation proxies trail by at
+   least 4 percentage points on average and at least two are below their
+   50-day averages;
+3. turnover or leverage unwind: turnover falls from a `>= 1.25x` peak to
+   `<= 0.9x` while the primary series has a negative 20-day return;
+4. trend confirmation: the primary series is below its 200-day average and its
+   50-day average has a negative 20-day slope.
+
+Two pre-crash layers produce a research observation. Confirmation requires at
+least three layers and must include credit/trend in the U.S. or turnover/trend
+in A shares. Historical blind tests show why the distinction matters. The
+rules failed to retain useful precision in the post-2010 U.S. sample and the
+short A-share ETF sample, so packets explicitly label them
+`research_only_failed_recent_out_of_sample`. They are structured risk-review
+inputs, not validated crash predictors, and confirmation can arrive after a
+decline has begun.
+
+Recovery is evaluated only after the current drawdown episode has reached
+`-15%` in the U.S. or `-18%` in A shares. Eligibility uses the episode's
+anchored trough rather than today's improving drawdown, so a valid repair does
+not disappear as price rebounds. A rebound must persist, reclaim short trends,
+broaden in participation, and show market-specific stress repair. At least two
+layers, including rebound persistence, create an observation. Confirmation
+needs rebound persistence, the short-trend reclaim, at least one participation
+or stress layer, and a total score of at least three. A new low, renewed stress,
+or trend re-loss overrides positive layers as `repair_failed`. A one-day
+rebound can never qualify. Historical recovery results are marked as promising
+but small-sample for the U.S. and insufficient small-sample for A shares.
+
+The ETF and price-based inputs are intentionally described as proxies. HYG is
+not an excess-bond-premium series; ETF turnover is not exchange margin balance;
+and relative returns are not full advance-decline breadth. Those limitations
+remain visible in every packet.
+
 It rejects raw provider bodies, private paths, credentials, account or
 portfolio material, future-dated evidence, unsupported fields, and malformed
 public URLs. It never emits investment advice, a price target, a trade, or an
@@ -92,6 +162,23 @@ loopx extension run loopx-finance-value-discovery \
   --input-json extensions/loopx-finance-value-discovery/examples/paypal-debeta-discovery.json \
   --execute \
   --format json
+```
+
+Classify one frozen market snapshot through the same managed runtime:
+
+```bash
+loopx extension run loopx-finance-value-discovery \
+  --input-json extensions/loopx-finance-value-discovery/examples/us-market-regime-2026-07-20.json \
+  --execute \
+  --format json
+```
+
+For package-level debugging only, the direct command is:
+
+```bash
+loopx-finance-value-discovery market-signals \
+  --input-json extensions/loopx-finance-value-discovery/examples/a-share-market-regime-2026-07-21.json \
+  --format markdown
 ```
 
 The manifest declares no permissions: this workflow is a deterministic reducer

--- a/extensions/loopx-finance-value-discovery/examples/a-share-market-regime-2026-07-21.json
+++ b/extensions/loopx-finance-value-discovery/examples/a-share-market-regime-2026-07-21.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "finance_market_regime_input_v0",
+  "as_of": "2026-07-21",
+  "market": "a_share",
+  "rule_version": "a_share_precrash_repair_rules_v0",
+  "point_in_time_data": true,
+  "lookahead_free": true,
+  "metrics": {
+    "bounce_from_20d_low_pct": 4.3147,
+    "broad_below_sma50_count": 3,
+    "broad_relative_return_20d_pct": -9.6471,
+    "drawdown_from_252d_high_pct": -5.9713,
+    "primary_return_10d_pct": -0.8081,
+    "primary_return_20d_pct": -3.1364,
+    "primary_return_60d_pct": -0.4989,
+    "primary_sma20_slope_10d_pct": -1.2634,
+    "primary_sma50_slope_20d_pct": 0.6295,
+    "primary_vs_sma20_pct": -1.3681,
+    "primary_vs_sma50_pct": -1.9399,
+    "primary_vs_sma200_pct": 1.7908,
+    "recovery_anchor_drawdown_pct": -5.9713,
+    "turnover_20d_vs_120d_ratio": 1.2659,
+    "turnover_ratio_peak_60d": 1.2659
+  },
+  "recovery_failure_flags": [],
+  "source_refs": [
+    {
+      "source_id": "yahoo-a-share-etf-daily",
+      "source_tier": "market_data",
+      "provider_label": "Yahoo Finance public chart data for CSI 300, CSI 500, CSI 1000, and ChiNext ETFs",
+      "observed_at": "2026-07-21"
+    },
+    {
+      "source_id": "sse-margin-summary",
+      "source_tier": "primary",
+      "url": "https://www.sse.com.cn/market/othersdata/margin/sum/",
+      "observed_at": "2026-07-21"
+    }
+  ]
+}

--- a/extensions/loopx-finance-value-discovery/examples/us-market-regime-2026-07-20.json
+++ b/extensions/loopx-finance-value-discovery/examples/us-market-regime-2026-07-20.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": "finance_market_regime_input_v0",
+  "as_of": "2026-07-20",
+  "market": "us",
+  "rule_version": "us_precrash_repair_rules_v0",
+  "point_in_time_data": true,
+  "lookahead_free": true,
+  "metrics": {
+    "bounce_from_20d_low_pct": 1.797,
+    "credit_return_20d_pct": 0.0492,
+    "credit_vs_sma50_pct": 0.3298,
+    "credit_vs_sma200_pct": 1.5161,
+    "drawdown_from_252d_high_pct": -2.0496,
+    "equal_weight_relative_return_20d_pct": 2.1862,
+    "equal_weight_vs_sma50_pct": 1.699,
+    "primary_return_10d_pct": -1.2232,
+    "primary_sma20_slope_10d_pct": 0.6567,
+    "primary_sma50_slope_20d_pct": 2.1453,
+    "primary_vs_sma20_pct": -0.3623,
+    "primary_vs_sma50_pct": -0.1811,
+    "primary_vs_sma200_pct": 6.953,
+    "recovery_anchor_drawdown_pct": -2.0496,
+    "qqq_relative_return_20d_pct": -5.2906,
+    "qqq_vs_sma50_pct": -3.128,
+    "vix_level": 18.65
+  },
+  "recovery_failure_flags": [],
+  "source_refs": [
+    {
+      "source_id": "yahoo-us-etf-daily",
+      "source_tier": "market_data",
+      "provider_label": "Yahoo Finance public chart data for SPY, QQQ, RSP, and HYG",
+      "observed_at": "2026-07-20"
+    },
+    {
+      "source_id": "cboe-vix",
+      "source_tier": "primary",
+      "url": "https://www.cboe.com/tradable-products/vix/",
+      "observed_at": "2026-07-20"
+    }
+  ]
+}

--- a/extensions/loopx-finance-value-discovery/extension.toml
+++ b/extensions/loopx-finance-value-discovery/extension.toml
@@ -1,6 +1,6 @@
 schema_version = "loopx_extension_manifest_v0"
 id = "loopx-finance-value-discovery"
-version = "0.2.0"
+version = "0.3.0"
 requires_loopx_api = ">=1,<2"
 permissions = []
 

--- a/extensions/loopx-finance-value-discovery/pyproject.toml
+++ b/extensions/loopx-finance-value-discovery/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx-finance-value-discovery"
-version = "0.2.0"
-description = "Public-safe finance value-discovery extension for LoopX."
+version = "0.3.0"
+description = "Public-safe value-discovery and market-regime extension for LoopX."
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = ["loopx>=0.2.9"]

--- a/extensions/loopx-finance-value-discovery/src/loopx_finance_value_discovery/__init__.py
+++ b/extensions/loopx-finance-value-discovery/src/loopx_finance_value_discovery/__init__.py
@@ -1,5 +1,12 @@
 """Finance value-discovery extension."""
 
+from .market_regime import (
+    FINANCE_MARKET_REGIME_INPUT_SCHEMA_VERSION,
+    FINANCE_MARKET_REGIME_PACKET_SCHEMA_VERSION,
+    FINANCE_MARKET_REGIME_RULE_VERSION,
+    build_finance_market_regime_packet,
+    render_finance_market_regime_markdown,
+)
 from .reducer import (
     EVIDENCE_AXES,
     FINANCE_VALUE_DISCOVERY_CARD_SCHEMA_VERSION,
@@ -12,10 +19,15 @@ from .reducer import (
 
 __all__ = [
     "EVIDENCE_AXES",
+    "FINANCE_MARKET_REGIME_INPUT_SCHEMA_VERSION",
+    "FINANCE_MARKET_REGIME_PACKET_SCHEMA_VERSION",
+    "FINANCE_MARKET_REGIME_RULE_VERSION",
     "FINANCE_VALUE_DISCOVERY_CARD_SCHEMA_VERSION",
     "FINANCE_VALUE_DISCOVERY_INPUT_SCHEMA_VERSION",
     "FINANCE_VALUE_DISCOVERY_PACKET_SCHEMA_VERSION",
     "FINANCE_VALUE_DISCOVERY_EXTENSION_PROTOCOL",
     "build_finance_value_discovery_packet",
+    "build_finance_market_regime_packet",
     "render_finance_value_discovery_markdown",
+    "render_finance_market_regime_markdown",
 ]

--- a/extensions/loopx-finance-value-discovery/src/loopx_finance_value_discovery/cli.py
+++ b/extensions/loopx-finance-value-discovery/src/loopx_finance_value_discovery/cli.py
@@ -7,6 +7,11 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
+from .market_regime import (
+    FINANCE_MARKET_REGIME_INPUT_SCHEMA_VERSION,
+    build_finance_market_regime_packet,
+    render_finance_market_regime_markdown,
+)
 from .reducer import (
     FINANCE_VALUE_DISCOVERY_ERROR_SCHEMA_VERSION,
     build_finance_value_discovery_packet,
@@ -63,7 +68,25 @@ def _direct_parser() -> argparse.ArgumentParser:
     reduce_parser.add_argument(
         "--format", choices=("json", "markdown"), default="markdown"
     )
+    regime_parser = sub.add_parser(
+        "market-signals",
+        help="Classify market-specific pre-crash and post-drawdown repair signals.",
+    )
+    regime_parser.add_argument(
+        "--input-json",
+        required=True,
+        help="Path to a finance_market_regime_input_v0 object, or '-' for stdin.",
+    )
+    regime_parser.add_argument(
+        "--format", choices=("json", "markdown"), default="markdown"
+    )
     return parser
+
+
+def _build_packet(payload: Mapping[str, Any]) -> dict[str, Any]:
+    if payload.get("schema_version") == FINANCE_MARKET_REGIME_INPUT_SCHEMA_VERSION:
+        return build_finance_market_regime_packet(payload)
+    return build_finance_value_discovery_packet(payload)
 
 
 def run(argv: Sequence[str] | None = None) -> int:
@@ -73,7 +96,7 @@ def run(argv: Sequence[str] | None = None) -> int:
             payload = json.load(sys.stdin)
             if not isinstance(payload, Mapping):
                 raise ValueError("provider input must be a JSON object")
-            packet = build_finance_value_discovery_packet(payload)
+            packet = _build_packet(payload)
         except Exception as exc:
             print(json.dumps(_error_packet(exc), sort_keys=True))
             return 1
@@ -83,15 +106,22 @@ def run(argv: Sequence[str] | None = None) -> int:
     args = _direct_parser().parse_args(arguments)
     if args.doctor:
         return 0
-    if args.command != "reduce":
-        raise ValueError("use --doctor or the reduce command")
+    if args.command not in {"reduce", "market-signals"}:
+        raise ValueError("use --doctor, reduce, or market-signals")
     try:
-        packet = build_finance_value_discovery_packet(_load_json(args.input_json))
+        payload = _load_json(args.input_json)
+        packet = (
+            build_finance_market_regime_packet(payload)
+            if args.command == "market-signals"
+            else build_finance_value_discovery_packet(payload)
+        )
     except Exception as exc:
         print(json.dumps(_error_packet(exc), indent=2, sort_keys=True))
         return 1
     if args.format == "json":
         print(json.dumps(packet, indent=2, sort_keys=True))
+    elif args.command == "market-signals":
+        print(render_finance_market_regime_markdown(packet), end="")
     else:
         print(render_finance_value_discovery_markdown(packet), end="")
     return 0

--- a/extensions/loopx-finance-value-discovery/src/loopx_finance_value_discovery/market_regime.py
+++ b/extensions/loopx-finance-value-discovery/src/loopx_finance_value_discovery/market_regime.py
@@ -1,0 +1,491 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from .reducer import (
+    _iso_date,
+    _public_https_url,
+    _reject_forbidden_material,
+    _text,
+)
+
+
+FINANCE_MARKET_REGIME_INPUT_SCHEMA_VERSION = "finance_market_regime_input_v0"
+FINANCE_MARKET_REGIME_PACKET_SCHEMA_VERSION = "finance_market_regime_packet_v0"
+FINANCE_MARKET_REGIME_RULE_VERSION = {
+    "us": "us_precrash_repair_rules_v0",
+    "a_share": "a_share_precrash_repair_rules_v0",
+}
+
+RECOVERY_FAILURE_FLAGS = {
+    "new_low_after_first_repair",
+    "stress_relapse",
+    "trend_reloss",
+}
+
+COMMON_METRICS = {
+    "bounce_from_20d_low_pct",
+    "drawdown_from_252d_high_pct",
+    "primary_return_10d_pct",
+    "primary_sma20_slope_10d_pct",
+    "primary_sma50_slope_20d_pct",
+    "primary_vs_sma20_pct",
+    "primary_vs_sma50_pct",
+    "primary_vs_sma200_pct",
+    "recovery_anchor_drawdown_pct",
+}
+US_METRICS = COMMON_METRICS | {
+    "credit_return_20d_pct",
+    "credit_vs_sma50_pct",
+    "credit_vs_sma200_pct",
+    "equal_weight_relative_return_20d_pct",
+    "equal_weight_vs_sma50_pct",
+    "qqq_relative_return_20d_pct",
+    "qqq_vs_sma50_pct",
+    "vix_level",
+}
+A_SHARE_METRICS = COMMON_METRICS | {
+    "broad_below_sma50_count",
+    "broad_relative_return_20d_pct",
+    "primary_return_20d_pct",
+    "primary_return_60d_pct",
+    "turnover_20d_vs_120d_ratio",
+    "turnover_ratio_peak_60d",
+}
+
+
+def _number(value: object, *, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field} must be a finite number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{field} must be a finite number")
+    return result
+
+
+def _metrics(value: object, *, market: str) -> dict[str, float]:
+    if not isinstance(value, Mapping):
+        raise ValueError("metrics must be an object")
+    required = US_METRICS if market == "us" else A_SHARE_METRICS
+    if set(value) != required:
+        missing = sorted(required - set(value))
+        extra = sorted(set(value) - required)
+        raise ValueError(
+            f"metrics must match {market} rule profile; missing={missing}, extra={extra}"
+        )
+    result = {
+        name: _number(value[name], field=f"metrics.{name}") for name in sorted(required)
+    }
+    if market == "a_share":
+        count = result["broad_below_sma50_count"]
+        if not count.is_integer() or not 0 <= count <= 3:
+            raise ValueError("metrics.broad_below_sma50_count must be 0, 1, 2, or 3")
+        for name in ("turnover_20d_vs_120d_ratio", "turnover_ratio_peak_60d"):
+            if result[name] < 0:
+                raise ValueError(f"metrics.{name} must be non-negative")
+    if market == "us" and not 0 <= result["vix_level"] <= 200:
+        raise ValueError("metrics.vix_level must be between 0 and 200")
+    return result
+
+
+def _source(value: object, *, index: int, as_of: str) -> dict[str, Any]:
+    field = f"source_refs[{index}]"
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field} must be an object")
+    allowed = {"source_id", "source_tier", "url", "provider_label", "observed_at"}
+    if set(value) - allowed:
+        raise ValueError(f"{field} has unsupported fields")
+    tier = _text(value.get("source_tier"), field=f"{field}.source_tier", limit=32)
+    if tier not in {"primary", "independent", "market_data"}:
+        raise ValueError(f"{field}.source_tier is unsupported")
+    url = value.get("url")
+    provider = value.get("provider_label")
+    if bool(url) == bool(provider):
+        raise ValueError(f"{field} requires exactly one of url or provider_label")
+    observed_at = _iso_date(value.get("observed_at"), field=f"{field}.observed_at")
+    if observed_at[:10] > as_of[:10]:
+        raise ValueError(f"{field}.observed_at must not be after as_of")
+    return {
+        "source_id": _text(
+            value.get("source_id"), field=f"{field}.source_id", limit=96
+        ),
+        "source_tier": tier,
+        "url": _public_https_url(url, field=f"{field}.url") if url else None,
+        "provider_label": _text(provider, field=f"{field}.provider_label", limit=120)
+        if provider
+        else None,
+        "observed_at": observed_at,
+    }
+
+
+def _sources(value: object, *, as_of: str) -> list[dict[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise ValueError("source_refs must be a list")
+    if not 1 <= len(value) <= 12:
+        raise ValueError("source_refs must contain between 1 and 12 items")
+    result = [
+        _source(item, index=index, as_of=as_of) for index, item in enumerate(value)
+    ]
+    ids = [item["source_id"] for item in result]
+    if len(ids) != len(set(ids)):
+        raise ValueError("source_refs must use unique source ids")
+    return result
+
+
+def _failure_flags(value: object) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise ValueError("recovery_failure_flags must be a list")
+    flags = [
+        _text(item, field=f"recovery_failure_flags[{index}]", limit=48)
+        for index, item in enumerate(value)
+    ]
+    if len(flags) != len(set(flags)) or set(flags) - RECOVERY_FAILURE_FLAGS:
+        raise ValueError(
+            "recovery_failure_flags must be unique values from "
+            f"{sorted(RECOVERY_FAILURE_FLAGS)}"
+        )
+    return flags
+
+
+def _layer(layer_id: str, triggered: bool, evidence: str) -> dict[str, Any]:
+    return {"layer_id": layer_id, "triggered": triggered, "evidence": evidence}
+
+
+def _us_layers(
+    metrics: Mapping[str, float],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    precrash = [
+        _layer(
+            "vulnerability",
+            metrics["vix_level"] <= 20 and metrics["primary_vs_sma200_pct"] >= 0,
+            "VIX <= 20 and the primary index is at or above its 200-day average.",
+        ),
+        _layer(
+            "leadership_or_breadth_break",
+            (
+                metrics["qqq_relative_return_20d_pct"] <= -5
+                and metrics["qqq_vs_sma50_pct"] < 0
+            )
+            or (
+                metrics["equal_weight_relative_return_20d_pct"] <= -3
+                and metrics["equal_weight_vs_sma50_pct"] < 0
+            ),
+            "QQQ trails by at least 5pp below its 50-day average, or equal weight trails by at least 3pp below its 50-day average.",
+        ),
+        _layer(
+            "credit_confirmation",
+            metrics["credit_vs_sma200_pct"] < 0
+            and metrics["credit_return_20d_pct"] <= -1,
+            "The high-yield proxy is below its 200-day average and its 20-day return is <= -1%.",
+        ),
+        _layer(
+            "trend_confirmation",
+            metrics["primary_vs_sma200_pct"] < 0
+            and metrics["primary_sma50_slope_20d_pct"] < 0,
+            "The primary index is below its 200-day average and its 50-day average has a negative 20-day slope.",
+        ),
+    ]
+    recovery = [
+        _layer(
+            "rebound_persistence",
+            metrics["primary_vs_sma20_pct"] > 0
+            and metrics["primary_return_10d_pct"] >= 3
+            and metrics["bounce_from_20d_low_pct"] >= 5,
+            "The index is above its 20-day average, up at least 3% in 10 days, and at least 5% above its 20-day low.",
+        ),
+        _layer(
+            "short_trend_reclaim",
+            metrics["primary_vs_sma50_pct"] > 0
+            and metrics["primary_sma20_slope_10d_pct"] > 0,
+            "The index is above its 50-day average and its 20-day average is rising.",
+        ),
+        _layer(
+            "participation_repair",
+            metrics["equal_weight_relative_return_20d_pct"] > 0,
+            "The equal-weight index has outperformed the cap-weighted index over 20 days.",
+        ),
+        _layer(
+            "stress_repair",
+            metrics["credit_vs_sma50_pct"] > 0 and metrics["vix_level"] < 25,
+            "The high-yield proxy is above its 50-day average and VIX is below 25.",
+        ),
+    ]
+    return precrash, recovery
+
+
+def _a_share_layers(
+    metrics: Mapping[str, float],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    precrash = [
+        _layer(
+            "crowding_or_complacency",
+            metrics["primary_vs_sma200_pct"] >= 0
+            and (
+                metrics["primary_return_60d_pct"] >= 12
+                or metrics["turnover_20d_vs_120d_ratio"] >= 1.25
+            ),
+            "The primary index is above its 200-day average with either a >=12% 60-day rise or turnover >=1.25x its 120-day average.",
+        ),
+        _layer(
+            "leadership_or_breadth_break",
+            metrics["broad_relative_return_20d_pct"] <= -4
+            and metrics["broad_below_sma50_count"] >= 2,
+            "The three broad or growth proxies trail the primary index by at least 4pp on average and at least two are below their 50-day averages.",
+        ),
+        _layer(
+            "turnover_or_leverage_unwind",
+            metrics["turnover_ratio_peak_60d"] >= 1.25
+            and metrics["turnover_20d_vs_120d_ratio"] <= 0.9
+            and metrics["primary_return_20d_pct"] < 0,
+            "Turnover has fallen from a >=1.25x 60-day peak to <=0.9x while the primary index has a negative 20-day return.",
+        ),
+        _layer(
+            "trend_confirmation",
+            metrics["primary_vs_sma200_pct"] < 0
+            and metrics["primary_sma50_slope_20d_pct"] < 0,
+            "The primary index is below its 200-day average and its 50-day average has a negative 20-day slope.",
+        ),
+    ]
+    recovery = [
+        _layer(
+            "rebound_persistence",
+            metrics["primary_vs_sma20_pct"] > 0
+            and metrics["primary_return_10d_pct"] >= 5
+            and metrics["bounce_from_20d_low_pct"] >= 8,
+            "The index is above its 20-day average, up at least 5% in 10 days, and at least 8% above its 20-day low.",
+        ),
+        _layer(
+            "short_trend_reclaim",
+            metrics["primary_vs_sma50_pct"] > 0
+            and metrics["primary_sma20_slope_10d_pct"] > 0,
+            "The index is above its 50-day average and its 20-day average is rising.",
+        ),
+        _layer(
+            "participation_repair",
+            metrics["broad_relative_return_20d_pct"] > 0
+            and metrics["broad_below_sma50_count"] <= 1,
+            "Broad and growth proxies outperform over 20 days and no more than one remains below its 50-day average.",
+        ),
+        _layer(
+            "stress_repair",
+            0.8 <= metrics["turnover_20d_vs_120d_ratio"] <= 1.4,
+            "Turnover is between 0.8x and 1.4x its 120-day average, avoiding both dry liquidity and rebound blow-off.",
+        ),
+    ]
+    return precrash, recovery
+
+
+def _state_packet(
+    *,
+    layers: list[dict[str, Any]],
+    confirmed_layer_ids: set[str],
+    observation_required_id: str | None = None,
+) -> dict[str, Any]:
+    triggered = [str(item["layer_id"]) for item in layers if item["triggered"]]
+    clear = [str(item["layer_id"]) for item in layers if not item["triggered"]]
+    score = len(triggered)
+    confirmed = score >= 3 and bool(set(triggered) & confirmed_layer_ids)
+    observed = score >= 2 and (
+        observation_required_id is None or observation_required_id in triggered
+    )
+    return {
+        "score": score,
+        "triggered_layers": triggered,
+        "clear_layers": clear,
+        "supporting_evidence": [
+            item["evidence"] for item in layers if item["triggered"]
+        ],
+        "conflicting_evidence": [
+            item["evidence"] for item in layers if not item["triggered"]
+        ],
+        "observed": observed,
+        "confirmed": confirmed,
+        "layers": layers,
+    }
+
+
+def build_finance_market_regime_packet(payload: Mapping[str, Any]) -> dict[str, Any]:
+    _reject_forbidden_material(payload)
+    allowed = {
+        "schema_version",
+        "as_of",
+        "market",
+        "rule_version",
+        "point_in_time_data",
+        "lookahead_free",
+        "metrics",
+        "recovery_failure_flags",
+        "source_refs",
+    }
+    if set(payload) - allowed:
+        raise ValueError("market-regime input has unsupported fields")
+    if payload.get("schema_version") != FINANCE_MARKET_REGIME_INPUT_SCHEMA_VERSION:
+        raise ValueError(
+            f"schema_version must be {FINANCE_MARKET_REGIME_INPUT_SCHEMA_VERSION}"
+        )
+    as_of = _iso_date(payload.get("as_of"), field="as_of")
+    market = _text(payload.get("market"), field="market", limit=24)
+    if market not in FINANCE_MARKET_REGIME_RULE_VERSION:
+        raise ValueError("market must be us or a_share")
+    expected_rule = FINANCE_MARKET_REGIME_RULE_VERSION[market]
+    if payload.get("rule_version") != expected_rule:
+        raise ValueError(f"rule_version must be {expected_rule}")
+    if payload.get("point_in_time_data") is not True:
+        raise ValueError("point_in_time_data must be true")
+    if payload.get("lookahead_free") is not True:
+        raise ValueError("lookahead_free must be true")
+    metrics = _metrics(payload.get("metrics"), market=market)
+    current_drawdown = metrics["drawdown_from_252d_high_pct"]
+    recovery_anchor = metrics["recovery_anchor_drawdown_pct"]
+    if current_drawdown > 0 or recovery_anchor > current_drawdown:
+        raise ValueError(
+            "recovery_anchor_drawdown_pct must be non-positive and no greater "
+            "than drawdown_from_252d_high_pct"
+        )
+    sources = _sources(payload.get("source_refs"), as_of=as_of)
+    flags = _failure_flags(payload.get("recovery_failure_flags"))
+
+    if market == "us":
+        pre_layers, recovery_layers = _us_layers(metrics)
+        pre_confirmers = {"credit_confirmation", "trend_confirmation"}
+        drawdown_threshold = -15.0
+        proxy_limitations = [
+            "HYG is a tradable credit proxy, not a point-in-time excess bond premium series.",
+            "QQQ and equal-weight relative returns are price proxies for leadership and breadth, not advance-decline counts.",
+        ]
+    else:
+        pre_layers, recovery_layers = _a_share_layers(metrics)
+        pre_confirmers = {"turnover_or_leverage_unwind", "trend_confirmation"}
+        drawdown_threshold = -18.0
+        proxy_limitations = [
+            "ETF turnover is a liquidity proxy and does not replace exchange-published margin balances.",
+            "CSI 500, CSI 1000, and ChiNext ETF relatives approximate participation; they are not full advance-decline breadth.",
+        ]
+
+    precrash = _state_packet(
+        layers=pre_layers,
+        confirmed_layer_ids=pre_confirmers,
+    )
+    if precrash["confirmed"]:
+        precrash_state = "risk_confirmation"
+        precrash_next = "escalate_human_risk_review"
+    elif precrash["observed"]:
+        precrash_state = "risk_observation"
+        precrash_next = "review_risk_assumptions_without_automatic_action"
+    else:
+        precrash_state = "no_precrash_signal"
+        precrash_next = "no_regime_action"
+    precrash["state"] = precrash_state
+    precrash["research_next_action"] = precrash_next
+
+    recovery_eligible = recovery_anchor <= drawdown_threshold
+    recovery = _state_packet(
+        layers=recovery_layers,
+        confirmed_layer_ids={"short_trend_reclaim"},
+        observation_required_id="rebound_persistence",
+    )
+    recovery_triggered = set(recovery["triggered_layers"])
+    recovery["confirmed"] = (
+        recovery["score"] >= 3
+        and "rebound_persistence" in recovery_triggered
+        and "short_trend_reclaim" in recovery_triggered
+        and bool(recovery_triggered & {"participation_repair", "stress_repair"})
+    )
+    recovery["eligible"] = recovery_eligible
+    recovery["eligibility_threshold_pct"] = drawdown_threshold
+    recovery["anchor_drawdown_pct"] = recovery_anchor
+    recovery["current_drawdown_pct"] = metrics["drawdown_from_252d_high_pct"]
+    recovery["failure_flags"] = flags
+    if not recovery_eligible:
+        recovery_state = "not_in_drawdown"
+        recovery_next = "do_not_interpret_normal_strength_as_crash_repair"
+    elif flags:
+        recovery_state = "repair_failed"
+        recovery_next = "invalidate_prior_repair_and_restart_observation"
+    elif recovery["confirmed"]:
+        recovery_state = "repair_confirmation"
+        recovery_next = "falsify_repair_against_new_low_and_stress_relapse"
+    elif recovery["observed"]:
+        recovery_state = "repair_observation"
+        recovery_next = "wait_for_trend_and_participation_confirmation"
+    else:
+        recovery_state = "unrepaired"
+        recovery_next = "wait_for_persistent_rebound"
+    recovery["state"] = recovery_state
+    recovery["research_next_action"] = recovery_next
+
+    return {
+        "ok": True,
+        "schema_version": FINANCE_MARKET_REGIME_PACKET_SCHEMA_VERSION,
+        "mode": "finance-market-regime",
+        "as_of": as_of,
+        "market": market,
+        "rule_version": expected_rule,
+        "metrics": metrics,
+        "precrash": precrash,
+        "recovery": recovery,
+        "source_refs": sources,
+        "data_quality": {
+            "point_in_time_data": True,
+            "lookahead_free": True,
+            "proxy_limitations": proxy_limitations,
+            "precrash_validation_status": "research_only_failed_recent_out_of_sample",
+            "recovery_validation_status": "promising_small_event_sample"
+            if market == "us"
+            else "insufficient_small_event_sample",
+        },
+        "boundary": {
+            "public_sources_only": True,
+            "external_reads_performed": False,
+            "external_writes_performed": False,
+            "investment_advice": False,
+            "position_or_account_accessed": False,
+            "trading_allowed": False,
+            "automatic_risk_action_allowed": False,
+            "human_decision_owner": True,
+        },
+        "truth_contract": {
+            "risk_observation_is_not_crash_prediction": True,
+            "risk_confirmation_may_arrive_after_drawdown_begins": True,
+            "single_day_rebound_is_not_repair": True,
+            "repair_requires_prior_drawdown": True,
+            "repair_eligibility_uses_episode_trough_not_current_drawdown": True,
+            "market_rules_are_not_interchangeable": True,
+            "proxy_limitations_remain_visible": True,
+        },
+    }
+
+
+def render_finance_market_regime_markdown(payload: Mapping[str, Any]) -> str:
+    precrash = (
+        payload.get("precrash") if isinstance(payload.get("precrash"), Mapping) else {}
+    )
+    recovery = (
+        payload.get("recovery") if isinstance(payload.get("recovery"), Mapping) else {}
+    )
+    lines = [
+        "# LoopX Finance Market Regime",
+        "",
+        f"- market: `{payload.get('market')}`",
+        f"- as_of: `{payload.get('as_of')}`",
+        f"- rule_version: `{payload.get('rule_version')}`",
+        f"- precrash_state: `{precrash.get('state')}`",
+        f"- recovery_state: `{recovery.get('state')}`",
+        "- investment_advice: `False`",
+        "",
+        "## Pre-crash evidence",
+        "",
+    ]
+    lines.extend(
+        f"- {item}" for item in precrash.get("supporting_evidence") or ["None"]
+    )
+    lines.extend(["", "## Pre-crash conflicts", ""])
+    lines.extend(
+        f"- {item}" for item in precrash.get("conflicting_evidence") or ["None"]
+    )
+    lines.extend(["", "## Recovery", ""])
+    lines.append(f"- eligible: `{recovery.get('eligible')}`")
+    lines.append(f"- next: `{recovery.get('research_next_action')}`")
+    return "\n".join(lines).rstrip() + "\n"

--- a/tests/extensions/test_finance_value_discovery_extension.py
+++ b/tests/extensions/test_finance_value_discovery_extension.py
@@ -22,9 +22,16 @@ EXTENSION_ROOT = ROOT / "extensions" / "loopx-finance-value-discovery"
 EXTENSION_SRC = EXTENSION_ROOT / "src"
 MANIFEST = EXTENSION_ROOT / "extension.toml"
 EXAMPLE = EXTENSION_ROOT / "examples" / "paypal-debeta-discovery.json"
+US_REGIME_EXAMPLE = EXTENSION_ROOT / "examples" / "us-market-regime-2026-07-20.json"
+A_SHARE_REGIME_EXAMPLE = (
+    EXTENSION_ROOT / "examples" / "a-share-market-regime-2026-07-21.json"
+)
 sys.path.insert(0, str(EXTENSION_SRC))
 
 from loopx_finance_value_discovery.cli import run  # noqa: E402
+from loopx_finance_value_discovery.market_regime import (  # noqa: E402
+    build_finance_market_regime_packet,
+)
 from loopx_finance_value_discovery.reducer import (  # noqa: E402
     EVIDENCE_AXES,
     build_finance_value_discovery_packet,
@@ -33,6 +40,10 @@ from loopx_finance_value_discovery.reducer import (  # noqa: E402
 
 def _example() -> dict[str, object]:
     return json.loads(EXAMPLE.read_text(encoding="utf-8"))
+
+
+def _regime_example(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
 
 
 def _installed_manifest(
@@ -221,6 +232,145 @@ def test_provider_doctor_is_side_effect_free() -> None:
     assert run(["--doctor"]) == 0
 
 
+@pytest.mark.parametrize(
+    ("path", "market", "triggered"),
+    [
+        (
+            US_REGIME_EXAMPLE,
+            "us",
+            {"vulnerability", "leadership_or_breadth_break"},
+        ),
+        (
+            A_SHARE_REGIME_EXAMPLE,
+            "a_share",
+            {"crowding_or_complacency", "leadership_or_breadth_break"},
+        ),
+    ],
+)
+def test_recent_market_examples_are_observations_not_crash_predictions(
+    path: Path,
+    market: str,
+    triggered: set[str],
+) -> None:
+    packet = build_finance_market_regime_packet(_regime_example(path))
+
+    assert packet["market"] == market
+    assert packet["precrash"]["state"] == "risk_observation"
+    assert set(packet["precrash"]["triggered_layers"]) == triggered
+    assert packet["recovery"]["state"] == "not_in_drawdown"
+    assert packet["boundary"]["investment_advice"] is False
+    assert packet["boundary"]["automatic_risk_action_allowed"] is False
+    assert packet["truth_contract"]["market_rules_are_not_interchangeable"] is True
+
+
+def test_repair_requires_prior_drawdown_and_multiple_confirmations() -> None:
+    payload = _regime_example(US_REGIME_EXAMPLE)
+    payload["metrics"].update(
+        {
+            "recovery_anchor_drawdown_pct": -20,
+            "primary_vs_sma20_pct": 3,
+            "primary_return_10d_pct": 4,
+            "bounce_from_20d_low_pct": 7,
+            "primary_vs_sma50_pct": 2,
+            "primary_sma20_slope_10d_pct": 1,
+            "equal_weight_relative_return_20d_pct": 1,
+            "credit_vs_sma50_pct": 1,
+            "vix_level": 20,
+        }
+    )
+
+    confirmed = build_finance_market_regime_packet(payload)
+    assert confirmed["recovery"]["state"] == "repair_confirmation"
+    assert confirmed["recovery"]["score"] == 4
+
+    payload["metrics"]["recovery_anchor_drawdown_pct"] = -10
+    ineligible = build_finance_market_regime_packet(payload)
+    assert ineligible["recovery"]["state"] == "not_in_drawdown"
+
+
+def test_repair_failure_overrides_positive_layers() -> None:
+    payload = _regime_example(US_REGIME_EXAMPLE)
+    payload["metrics"].update(
+        {
+            "recovery_anchor_drawdown_pct": -20,
+            "primary_vs_sma20_pct": 3,
+            "primary_return_10d_pct": 4,
+            "bounce_from_20d_low_pct": 7,
+            "primary_vs_sma50_pct": 2,
+            "primary_sma20_slope_10d_pct": 1,
+            "equal_weight_relative_return_20d_pct": 1,
+            "credit_vs_sma50_pct": 1,
+            "vix_level": 20,
+        }
+    )
+    payload["recovery_failure_flags"] = ["new_low_after_first_repair"]
+
+    packet = build_finance_market_regime_packet(payload)
+    assert packet["recovery"]["state"] == "repair_failed"
+    assert packet["recovery"]["confirmed"] is True
+
+
+def test_repair_confirmation_cannot_precede_persistent_rebound() -> None:
+    payload = _regime_example(A_SHARE_REGIME_EXAMPLE)
+    payload["metrics"].update(
+        {
+            "recovery_anchor_drawdown_pct": -20,
+            "primary_vs_sma20_pct": -1,
+            "primary_return_10d_pct": 1,
+            "bounce_from_20d_low_pct": 3,
+            "primary_vs_sma50_pct": 2,
+            "primary_sma20_slope_10d_pct": 1,
+            "broad_relative_return_20d_pct": 1,
+            "broad_below_sma50_count": 1,
+            "turnover_20d_vs_120d_ratio": 1,
+        }
+    )
+
+    packet = build_finance_market_regime_packet(payload)
+    assert packet["recovery"]["score"] == 3
+    assert packet["recovery"]["observed"] is False
+    assert packet["recovery"]["confirmed"] is False
+    assert packet["recovery"]["state"] == "unrepaired"
+
+
+def test_market_profiles_fail_closed_on_missing_or_cross_market_metrics() -> None:
+    payload = _regime_example(A_SHARE_REGIME_EXAMPLE)
+    payload["metrics"].pop("turnover_ratio_peak_60d")
+    with pytest.raises(ValueError, match="metrics must match a_share rule profile"):
+        build_finance_market_regime_packet(payload)
+
+    payload = _regime_example(A_SHARE_REGIME_EXAMPLE)
+    payload["market"] = "us"
+    payload["rule_version"] = "us_precrash_repair_rules_v0"
+    with pytest.raises(ValueError, match="metrics must match us rule profile"):
+        build_finance_market_regime_packet(payload)
+
+    payload = _regime_example(US_REGIME_EXAMPLE)
+    payload["metrics"]["recovery_anchor_drawdown_pct"] = 1
+    with pytest.raises(ValueError, match="recovery_anchor_drawdown_pct"):
+        build_finance_market_regime_packet(payload)
+
+
+def test_market_signal_direct_command_renders_packet(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert (
+        run(
+            [
+                "market-signals",
+                "--input-json",
+                str(US_REGIME_EXAMPLE),
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    packet = json.loads(capsys.readouterr().out)
+    assert packet["schema_version"] == "finance_market_regime_packet_v0"
+    assert packet["precrash"]["state"] == "risk_observation"
+
+
 def test_standalone_extension_runs_through_verified_runtime(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -249,3 +399,33 @@ def test_standalone_extension_runs_through_verified_runtime(
     packet = receipt["provider_result"]
     assert packet["schema_version"] == "finance_value_discovery_packet_v0"
     assert packet["projection"]["next_targets"] == ["PYPL"]
+
+
+def test_market_regime_runs_through_verified_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _, runtime_root = _installed_manifest(tmp_path, monkeypatch)
+    assert (
+        main(
+            [
+                "--runtime-root",
+                str(runtime_root),
+                "--format",
+                "json",
+                "extension",
+                "run",
+                "loopx-finance-value-discovery",
+                "--input-json",
+                str(A_SHARE_REGIME_EXAMPLE),
+                "--execute",
+            ]
+        )
+        == 0
+    )
+    receipt = json.loads(capsys.readouterr().out)
+    assert receipt["status"] == "succeeded"
+    packet = receipt["provider_result"]
+    assert packet["schema_version"] == "finance_market_regime_packet_v0"
+    assert packet["market"] == "a_share"


### PR DESCRIPTION
## Summary
- add versioned U.S. and A-share pre-crash and post-drawdown repair classifiers to the optional finance extension
- keep collection outside the extension and require frozen point-in-time public metrics
- expose evidence, counterevidence, proxy limitations, validation status, and non-advice boundaries
- add recent public-market examples and managed-runtime coverage

## Research boundary
- pre-crash v0 is explicitly marked `research_only_failed_recent_out_of_sample`; it must not drive automatic risk actions
- recovery confirmation is marked small-sample and requires an anchored prior drawdown, persistent rebound, trend reclaim, and participation or stress repair
- no account access, position sizing, price targets, or trading permissions are added

## Validation
- `ruff check` and `ruff format --check`: passed
- `pytest -q tests/extensions/test_extension_runtime.py tests/extensions/test_finance_value_discovery_extension.py`: 52 passed
- `loopx canary premerge --from-git-diff`: passed, 14 selected checks, 0 failures, 0 manual holds

## Public/private boundary
- changed surfaces are public extension code, public examples, README, and focused tests
- no private planning state, local paths, credentials, raw logs, account data, or portfolio data are included

## Holds
- not self-merging because this adds runtime classification behavior and should receive maintainer review