### PR TITLE
Allow direct SkillsBench setup egress

### DIFF
--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -26,6 +26,9 @@ Optional env:
   SKILLSBENCH_LOCAL_CODEX_PROXY_PORT   Local proxy port, default 18180
   SKILLSBENCH_DOCKER_PROXY_HOST        Remote Docker bridge host for benchmark
                                        setup/verifier egress; default auto
+  SKILLSBENCH_BENCHMARK_EGRESS_PROXY_MODE
+                                       Benchmark setup/verifier egress mode:
+                                       require (default), auto, or off
   SKILLSBENCH_DOCKER_API_VERSION       Remote Docker daemon API version passed
                                        to Docker CLI/Compose; default auto
   SKILLSBENCH_ROUTE                    Route, default codex-cli-goal-baseline
@@ -204,6 +207,7 @@ skip_global_ledger_sync="${SKILLSBENCH_SKIP_GLOBAL_LEDGER_SYNC:-0}"
 skip_current_aggregate_update="${SKILLSBENCH_SKIP_CURRENT_AGGREGATE_UPDATE:-0}"
 allow_staged_bootstrap_repair_run="${SKILLSBENCH_ALLOW_STAGED_BOOTSTRAP_REPAIR_RUN:-0}"
 setup_only_public_preflight="${SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT:-0}"
+benchmark_egress_proxy_mode="${SKILLSBENCH_BENCHMARK_EGRESS_PROXY_MODE:-require}"
 product_mode_soft_verify_policy="${SKILLSBENCH_PRODUCT_MODE_SOFT_VERIFY_POLICY:-}"
 remote_command_file_bridge_probe_command="${SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_COMMAND:-}"
 remote_command_file_bridge_solver_command="${SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_SOLVER_COMMAND:-}"
@@ -228,6 +232,12 @@ validate_bool_toggle \
   SKILLSBENCH_ALLOW_STAGED_BOOTSTRAP_REPAIR_RUN "$allow_staged_bootstrap_repair_run"
 validate_bool_toggle \
   SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT "$setup_only_public_preflight"
+if [[ "$benchmark_egress_proxy_mode" != "require" ]] &&
+  [[ "$benchmark_egress_proxy_mode" != "auto" ]] &&
+  [[ "$benchmark_egress_proxy_mode" != "off" ]]; then
+  echo "SKILLSBENCH_BENCHMARK_EGRESS_PROXY_MODE must be require, auto, or off" >&2
+  exit 2
+fi
 validate_bool_toggle \
   SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_AGENT_COMMAND_INSTRUMENTED \
   "$remote_command_file_bridge_agent_command_instrumented"
@@ -509,7 +519,7 @@ remote_command=$(
     --build-stall-timeout-sec "$build_stall_timeout" \
     --codex-api-egress-mode reverse-tunnel \
     --codex-api-reverse-tunnel-proxy "$loopback_proxy_url" \
-    --benchmark-egress-proxy-mode require \
+    --benchmark-egress-proxy-mode "$benchmark_egress_proxy_mode" \
     --host-local-acp-launch \
     --local-codex-bin "$remote_codex_bin" \
     --local-codex-sandbox "$local_codex_sandbox" \
@@ -591,6 +601,7 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'codex_cli_goal_thread_prewarm=%s\n' "$codex_cli_goal_thread_prewarm"
   printf 'allow_staged_bootstrap_repair_run=%s\n' "$allow_staged_bootstrap_repair_run"
   printf 'setup_only_public_preflight=%s\n' "$setup_only_public_preflight"
+  printf 'benchmark_egress_proxy_mode=%s\n' "$benchmark_egress_proxy_mode"
   printf 'product_mode_soft_verify_policy=%s\n' \
     "${product_mode_soft_verify_policy:-runner-default}"
   printf 'remote_command_file_bridge_probe_command_configured=%s\n' \

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -135,3 +135,42 @@ def test_turn_launcher_requires_an_independent_validator(tmp_path: Path) -> None
         "SKILLSBENCH_LOOPX_TURN_VALIDATION_COMMAND is required for "
         "loopx-turn-agent-cli"
     ) in proc.stderr
+
+
+def test_launcher_allows_explicit_direct_benchmark_egress(tmp_path: Path) -> None:
+    env = _base_env(tmp_path)
+    env["SKILLSBENCH_BENCHMARK_EGRESS_PROXY_MODE"] = "off"
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "direct-egress"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+
+    assert "benchmark_egress_proxy_mode=off" in proc.stdout
+    assert "--benchmark-egress-proxy-mode off" in proc.stdout
+
+
+def test_launcher_rejects_invalid_benchmark_egress_mode(tmp_path: Path) -> None:
+    env = _base_env(tmp_path)
+    env["SKILLSBENCH_BENCHMARK_EGRESS_PROXY_MODE"] = "sometimes"
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "direct-egress"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    assert (
+        "SKILLSBENCH_BENCHMARK_EGRESS_PROXY_MODE must be require, auto, or off"
+        in proc.stderr
+    )


### PR DESCRIPTION
## Summary
- add an explicit launcher control for benchmark setup/verifier egress: `require` (default), `auto`, or `off`
- preserve existing forced-proxy behavior unless the operator opts into direct egress
- cover direct mode wiring and invalid values with focused launcher tests

## Validation
- `uv run --python 3.11 --with pytest pytest -q tests/test_skillsbench_turn_launcher.py` (5 passed)
- `XDG_STATE_HOME=<empty-temp> uv run --python 3.11 python examples/skillsbench-benchmark-egress-policy-smoke.py`
- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`
- `uvx ruff check tests/test_skillsbench_turn_launcher.py`
- `loopx canary premerge --from-git-diff`: 4/4 selected catalog canaries passed plus diff/compile checks; benchmark-sensitive manual hold remains

## Boundary
- no benchmark jobs launched by this PR
- no scoring, task semantics, submission, or ledger behavior changed
- no raw logs, trajectories, verifier output, credentials, owner profile values, or local paths included

## Merge decision
Owner previously authorized self-merge for public benchmark helper/runtime changes. This is a narrow launcher compatibility switch with default-preserving behavior and focused validation.