### PR TITLE
Add incremental SkillsBench setup progress receipts

### DIFF
--- a/examples/skillsbench-reverse-tunnel-supervisor-smoke.py
+++ b/examples/skillsbench-reverse-tunnel-supervisor-smoke.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import base64
 import json
-import os
 import subprocess
 import sys
 import tempfile
@@ -76,6 +75,11 @@ if "benchmark_remote_public_artifact_collection_v0" in remote_command:
             "content_base64": base64.b64encode(compact).decode("ascii"),
         }}],
     }}, sort_keys=True))
+    sys.exit(0)
+
+if "slow-skillsbench" in remote_command:
+    time.sleep(0.5)
+    print('{{"ok": true, "source": "fake_remote_command"}}')
     sys.exit(0)
 
 if "cat >" in remote_command:
@@ -613,6 +617,78 @@ def test_supervisor_syncs_only_compact_public_artifacts() -> None:
         assert sync["raw_trajectory_read"] is False
 
 
+def test_supervisor_incrementally_syncs_public_artifacts() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-tunnel-live-sync-") as tmp:
+        root = Path(tmp)
+        fake_ssh = root / "ssh"
+        ssh_log = root / "ssh.log"
+        synced_dir = root / "synced"
+        ledger_path = root / "live-ledger.json"
+        aggregate_path = root / "standard-aggregate.json"
+        canonical_ids = root / "canonical-case-ids.txt"
+        canonical_ids.write_text("case-a\n", encoding="utf-8")
+        _fake_ssh(fake_ssh, ssh_log)
+
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--ssh-bin",
+                str(fake_ssh),
+                "--ssh-destination",
+                "opaque-benchmark-host.example",
+                "--remote-forward",
+                "127.0.0.1:18180:127.0.0.1:18180",
+                "--remote-command",
+                "slow-skillsbench",
+                "--remote-public-artifact-root",
+                "/opaque/private/jobs",
+                "--remote-public-artifact-glob",
+                "job/*/benchmark_run.compact.json",
+                "--local-public-artifact-dir",
+                str(synced_dir),
+                "--public-artifact-sync-interval-sec",
+                "0.1",
+                "--local-run-ledger-path",
+                str(ledger_path),
+                "--local-run-group-id",
+                "skillsbench-incremental-sync-smoke",
+                "--local-current-aggregate-path",
+                str(aggregate_path),
+                "--local-canonical-case-ids-file",
+                str(canonical_ids),
+                "--local-target-lane-id",
+                "codex-cli-goal-xhigh",
+                "--tunnel-ready-timeout-sec",
+                "5",
+                "--probe-interval-sec",
+                "0.1",
+                "--run-timeout-sec",
+                "5",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+
+        assert proc.returncode == 0, proc.stderr or proc.stdout
+        payload = json.loads(proc.stdout)
+        incremental = payload["incremental_public_artifact_sync"]
+        assert incremental["enabled"] is True
+        assert incremental["attempt_count"] >= 1
+        assert incremental["success_count"] >= 1
+        assert incremental["failure_count"] == 0
+        assert incremental["raw_paths_recorded"] is False
+        assert incremental["raw_artifacts_recorded"] is False
+        assert payload["public_artifact_sync"]["local_ledger_update"][
+            "upserted_count"
+        ] == 1
+        assert ledger_path.exists()
+        assert aggregate_path.exists()
+
+
 def test_public_artifact_materializer_rejects_private_children() -> None:
     with tempfile.TemporaryDirectory(prefix="benchmark-artifact-boundary-") as tmp:
         content = base64.b64encode(b"{}\n").decode("ascii")
@@ -845,6 +921,7 @@ if __name__ == "__main__":
     test_supervisor_timeout_does_not_sync_live_artifacts()
     test_liveness_probe_cannot_cross_deadline_and_sync_artifacts()
     test_supervisor_syncs_only_compact_public_artifacts()
+    test_supervisor_incrementally_syncs_public_artifacts()
     test_public_artifact_materializer_rejects_private_children()
     test_closeout_requires_compact_when_ledger_is_requested()
     test_supervisor_cleans_remote_failure_without_public_pattern()

--- a/loopx/benchmark_adapters/skillsbench_setup_preflight.py
+++ b/loopx/benchmark_adapters/skillsbench_setup_preflight.py
@@ -220,6 +220,14 @@ def _base_result(
     }
 
 
+def _emit_progress(
+    callback: Callable[[Mapping[str, Any]], None] | None,
+    result: Mapping[str, Any],
+) -> None:
+    if callback is not None:
+        callback(dict(result))
+
+
 async def run_setup_only_public_preflight(
     *,
     rollout_type: Any,
@@ -228,6 +236,7 @@ async def run_setup_only_public_preflight(
     setup_preflight: Mapping[str, Any] | None = None,
     stage_timeout_sec: float,
     cleanup_timeout_sec: float = 30.0,
+    progress_callback: Callable[[Mapping[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
     """Materialize a BenchFlow environment without installing or running an agent."""
 
@@ -240,12 +249,14 @@ async def run_setup_only_public_preflight(
     rollout: Any | None = None
     restore_compose_boundary: Callable[[], None] | None = None
     failed = False
+    _emit_progress(progress_callback, result)
     try:
         rollout = await asyncio.wait_for(
             rollout_type.create(config),
             timeout=stage_timeout_sec,
         )
         result["stage"] = "rollout_setup"
+        _emit_progress(progress_callback, result)
         await asyncio.wait_for(rollout.setup(), timeout=stage_timeout_sec)
         result["job_root_materialized"] = (
             getattr(rollout, "_rollout_dir", None) is not None
@@ -262,6 +273,7 @@ async def run_setup_only_public_preflight(
         )
 
         result["stage"] = "environment_start"
+        _emit_progress(progress_callback, result)
         await asyncio.wait_for(rollout.start(), timeout=stage_timeout_sec)
         result["environment_started"] = True
         result["status"] = "passed"
@@ -354,4 +366,5 @@ async def run_setup_only_public_preflight(
                     result["exit_category"] = "cleanup_failed"
         else:
             result["cleanup_status"] = "not_required"
+        _emit_progress(progress_callback, result)
     return result

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -75,6 +75,9 @@ Optional env:
   SKILLSBENCH_BUILD_STALL_TIMEOUT_SEC  Setup stall timeout, default 3600;
                                        0 disables cap
   SKILLSBENCH_RUN_TIMEOUT_SEC          Supervisor timeout, default 28800
+  SKILLSBENCH_PUBLIC_ARTIFACT_SYNC_INTERVAL_SEC
+                                       Incremental public artifact sync interval;
+                                       defaults to 30 for setup-only and 0 otherwise
   SKILLSBENCH_TUNNEL_PROBE_TIMEOUT_SEC Reverse-tunnel CONNECT probe timeout,
                                        default 20
   SKILLSBENCH_TUNNEL_READY_TIMEOUT_SEC Reverse-tunnel readiness budget,
@@ -310,6 +313,13 @@ model="${SKILLSBENCH_MODEL:-gpt-5.5}"
 reasoning_effort="${SKILLSBENCH_REASONING_EFFORT:-xhigh}"
 build_stall_timeout="${SKILLSBENCH_BUILD_STALL_TIMEOUT_SEC:-3600}"
 run_timeout="${SKILLSBENCH_RUN_TIMEOUT_SEC:-28800}"
+if [[ -n "${SKILLSBENCH_PUBLIC_ARTIFACT_SYNC_INTERVAL_SEC:-}" ]]; then
+  public_artifact_sync_interval="$SKILLSBENCH_PUBLIC_ARTIFACT_SYNC_INTERVAL_SEC"
+elif [[ "$setup_only_public_preflight" == "1" ]]; then
+  public_artifact_sync_interval=30
+else
+  public_artifact_sync_interval=0
+fi
 tunnel_probe_timeout="${SKILLSBENCH_TUNNEL_PROBE_TIMEOUT_SEC:-20}"
 tunnel_ready_timeout="${SKILLSBENCH_TUNNEL_READY_TIMEOUT_SEC:-60}"
 tunnel_health_interval="${SKILLSBENCH_TUNNEL_HEALTH_INTERVAL_SEC:-30}"
@@ -545,6 +555,7 @@ supervisor_cmd=(
   --tunnel-reconnect-attempts "$tunnel_reconnect_attempts"
   --tunnel-reconnect-ready-timeout-sec "$tunnel_ready_timeout"
   --run-timeout-sec "$run_timeout"
+  --public-artifact-sync-interval-sec "$public_artifact_sync_interval"
   --remote-failure-cleanup-pattern "$job_name"
   --remote-failure-cleanup-include-docker
   --remote-command "$remote_command"
@@ -601,6 +612,8 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'codex_cli_goal_thread_prewarm=%s\n' "$codex_cli_goal_thread_prewarm"
   printf 'allow_staged_bootstrap_repair_run=%s\n' "$allow_staged_bootstrap_repair_run"
   printf 'setup_only_public_preflight=%s\n' "$setup_only_public_preflight"
+  printf 'public_artifact_sync_interval_sec=%s\n' \
+    "$public_artifact_sync_interval"
   printf 'benchmark_egress_proxy_mode=%s\n' "$benchmark_egress_proxy_mode"
   printf 'product_mode_soft_verify_policy=%s\n' \
     "${product_mode_soft_verify_policy:-runner-default}"
@@ -696,4 +709,5 @@ local_codex_sandbox=${local_codex_sandbox}
 codex_cli_goal_thread_prewarm=${codex_cli_goal_thread_prewarm}
 allow_staged_bootstrap_repair_run=${allow_staged_bootstrap_repair_run}
 setup_only_public_preflight=${setup_only_public_preflight}
+public_artifact_sync_interval_sec=${public_artifact_sync_interval}
 EOF

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -9698,6 +9698,25 @@ def _write_public_runner_config(plan: dict[str, Any]) -> Path | None:
     return path
 
 
+def _write_setup_only_public_preflight(
+    plan: Mapping[str, Any],
+    result: Mapping[str, Any],
+) -> Path:
+    path = Path(str(plan["setup_only_public_preflight_json"]))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _write_text_atomic(
+        path,
+        json.dumps(
+            dict(result),
+            indent=2,
+            sort_keys=True,
+            default=_json_default,
+        )
+        + "\n",
+    )
+    return path
+
+
 async def run_benchflow_case_with_private_output(
     args: argparse.Namespace,
     plan: dict[str, Any],
@@ -14653,6 +14672,10 @@ async def run_benchflow_case(
                 task_staging=plan.get("task_staging"),
                 setup_preflight=plan.get("task_setup_preflight"),
                 stage_timeout_sec=float(args.sandbox_setup_timeout),
+                progress_callback=lambda progress: _write_setup_only_public_preflight(
+                    plan,
+                    progress,
+                ),
             )
             plan["setup_only_public_preflight_result"] = setup_only_result
             prerequisites["benchflow_run_stage"] = str(
@@ -16999,18 +17022,7 @@ async def _async_main_with_observable_handle(
         if args.setup_only_public_preflight:
             if not isinstance(case_result, dict):
                 raise TypeError("setup-only preflight returned a non-object result")
-            preflight_path = Path(plan["setup_only_public_preflight_json"])
-            preflight_path.parent.mkdir(parents=True, exist_ok=True)
-            preflight_path.write_text(
-                json.dumps(
-                    case_result,
-                    indent=2,
-                    sort_keys=True,
-                    default=_json_default,
-                )
-                + "\n",
-                encoding="utf-8",
-            )
+            preflight_path = _write_setup_only_public_preflight(plan, case_result)
             _write_public_runner_config(plan)
             _write_public_runner_prerequisites(plan)
             passed = case_result.get("status") == "passed"

--- a/scripts/skillsbench_reverse_tunnel_supervisor.py
+++ b/scripts/skillsbench_reverse_tunnel_supervisor.py
@@ -20,6 +20,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -633,7 +634,42 @@ def _public_artifact_sync_contract(args: argparse.Namespace) -> dict[str, Any]:
     )
 
 
-def _sync_remote_public_artifacts(args: argparse.Namespace) -> dict[str, Any]:
+def _incremental_public_artifact_sync_contract(
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    interval_sec = max(0.0, float(args.public_artifact_sync_interval_sec))
+    return {
+        "enabled": interval_sec > 0.0,
+        "interval_sec": interval_sec,
+        "attempt_count": 0,
+        "success_count": 0,
+        "failure_count": 0,
+        "last_status": "not_run",
+        "raw_paths_recorded": False,
+        "raw_artifacts_recorded": False,
+    }
+
+
+def _record_incremental_public_artifact_sync(
+    contract: dict[str, Any],
+    result: Mapping[str, Any],
+) -> None:
+    contract["attempt_count"] = int(contract["attempt_count"]) + 1
+    if result.get("ok") is True:
+        contract["success_count"] = int(contract["success_count"]) + 1
+        contract["last_status"] = "passed"
+    else:
+        contract["failure_count"] = int(contract["failure_count"]) + 1
+        contract["last_status"] = str(result.get("first_blocker") or "sync_failed")[
+            :120
+        ]
+
+
+def _sync_remote_public_artifacts(
+    args: argparse.Namespace,
+    *,
+    include_local_closeout: bool = True,
+) -> dict[str, Any]:
     return closeout_remote_benchmark_batch(
         run_remote_command=lambda command, timeout: _run_remote_shell_command(
             args,
@@ -646,9 +682,11 @@ def _sync_remote_public_artifacts(args: argparse.Namespace) -> dict[str, Any]:
         adapter_kind=args.public_artifact_adapter_kind,
         max_bytes=args.public_artifact_max_bytes,
         sync_timeout_sec=args.public_artifact_sync_timeout_sec,
-        ledger_path=args.local_run_ledger_path,
+        ledger_path=args.local_run_ledger_path if include_local_closeout else "",
         run_group_id=args.local_run_group_id,
-        aggregate_path=args.local_current_aggregate_path,
+        aggregate_path=(
+            args.local_current_aggregate_path if include_local_closeout else ""
+        ),
         canonical_case_ids_file=args.local_canonical_case_ids_file,
         benchmark_id=args.local_benchmark_id,
         target_lane_id=args.local_target_lane_id,
@@ -656,7 +694,9 @@ def _sync_remote_public_artifacts(args: argparse.Namespace) -> dict[str, Any]:
         target_backfill_run_group_contains=list(
             args.local_target_backfill_run_group_contains or []
         ),
-        ledger_catchup_root=args.local_ledger_catchup_root,
+        ledger_catchup_root=(
+            args.local_ledger_catchup_root if include_local_closeout else ""
+        ),
         ledger_catchup_run_group_contains=list(
             args.local_ledger_catchup_run_group_contains or []
         ),
@@ -892,6 +932,9 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         "json_bridge": _json_bridge_public_contract(args),
         "remote_failure_cleanup": _remote_failure_cleanup_public_contract(args),
         "public_artifact_sync": _public_artifact_sync_contract(args),
+        "incremental_public_artifact_sync": (
+            _incremental_public_artifact_sync_contract(args)
+        ),
         "tunnel_liveness": _tunnel_liveness_public_contract(args),
     }
 
@@ -1035,6 +1078,13 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
             run_deadline = time.monotonic() + max(1.0, float(args.run_timeout_sec))
             health_interval = max(0.0, float(args.tunnel_health_interval_sec))
             next_health_probe = time.monotonic() + health_interval
+            incremental_sync = payload["incremental_public_artifact_sync"]
+            incremental_sync_interval = float(incremental_sync["interval_sec"])
+            next_incremental_sync = (
+                time.monotonic() + incremental_sync_interval
+                if incremental_sync["enabled"]
+                else float("inf")
+            )
             consecutive_failures = 0
             consecutive_inconclusive = 0
             if liveness["enabled"]:
@@ -1046,6 +1096,18 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
                     remote_command_timed_out = True
                     _stop_process_group(remote_proc, grace_sec=1.0)
                     break
+                if now >= next_incremental_sync:
+                    _record_incremental_public_artifact_sync(
+                        incremental_sync,
+                        _sync_remote_public_artifacts(
+                            args,
+                            include_local_closeout=False,
+                        ),
+                    )
+                    next_incremental_sync = time.monotonic() + incremental_sync_interval
+                    if remote_proc.poll() is not None:
+                        break
+                    now = time.monotonic()
                 if not liveness["enabled"] or now < next_health_probe:
                     time.sleep(0.1)
                     continue
@@ -1421,6 +1483,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=60.0,
     )
     parser.add_argument(
+        "--public-artifact-sync-interval-sec",
+        type=float,
+        default=0.0,
+        help=(
+            "Optional interval for syncing bounded public artifacts while the "
+            "remote command is still running. Zero disables incremental sync."
+        ),
+    )
+    parser.add_argument(
         "--local-run-ledger-path",
         default="",
         help=(
@@ -1504,6 +1575,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
                 parser.error(
                     "--remote-public-artifact-glob must be relative and bounded"
                 )
+    if (
+        args.public_artifact_sync_interval_sec > 0
+        and not _public_artifact_sync_requested(args)
+    ):
+        parser.error("--public-artifact-sync-interval-sec requires artifact sync")
     if args.local_run_ledger_path and not _public_artifact_sync_requested(args):
         parser.error("--local-run-ledger-path requires artifact sync")
     if args.local_ledger_catchup_root and not args.local_run_ledger_path:

--- a/tests/test_skillsbench_setup_preflight.py
+++ b/tests/test_skillsbench_setup_preflight.py
@@ -119,6 +119,31 @@ def test_setup_only_preflight_stops_before_agent_and_verifier() -> None:
     assert "should-not-project" not in serialized
 
 
+def test_setup_only_preflight_projects_incremental_public_stages() -> None:
+    snapshots: list[dict[str, Any]] = []
+
+    result = asyncio.run(
+        run_setup_only_public_preflight(
+            rollout_type=FakeRollout,
+            config=object(),
+            stage_timeout_sec=1,
+            progress_callback=lambda snapshot: snapshots.append(dict(snapshot)),
+        )
+    )
+
+    assert result["status"] == "passed"
+    assert [snapshot["stage"] for snapshot in snapshots] == [
+        "rollout_create",
+        "rollout_setup",
+        "environment_start",
+        "environment_ready_before_agent",
+    ]
+    assert snapshots[0]["status"] == "running"
+    assert snapshots[-1]["status"] == "passed"
+    assert snapshots[-1]["cleanup_status"] == "completed"
+    assert all(snapshot["raw_logs_recorded"] is False for snapshot in snapshots)
+
+
 def test_setup_only_runner_mode_bypasses_formal_round_budget() -> None:
     args = parse_args(
         [

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -174,3 +174,23 @@ def test_launcher_rejects_invalid_benchmark_egress_mode(tmp_path: Path) -> None:
         "SKILLSBENCH_BENCHMARK_EGRESS_PROXY_MODE must be require, auto, or off"
         in proc.stderr
     )
+
+
+def test_setup_only_launcher_enables_incremental_public_artifact_sync(
+    tmp_path: Path,
+) -> None:
+    env = _base_env(tmp_path)
+    env["SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT"] = "1"
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "setup-progress"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+
+    assert "public_artifact_sync_interval_sec=30" in proc.stdout
+    assert "--public-artifact-sync-interval-sec 30" in proc.stdout


### PR DESCRIPTION
## Summary
- emit public-safe setup-stage snapshots during rollout creation, setup, and environment start
- periodically sync bounded public artifacts during setup-only remote runs
- keep ledger and aggregate closeout final-only

## Validation
- `uv run --no-project --python 3.11 --with pytest python -m pytest -q tests/test_skillsbench_setup_preflight.py tests/test_skillsbench_turn_launcher.py` (35 passed)
- `python3 examples/skillsbench-reverse-tunnel-supervisor-smoke.py`
- `python3 -m py_compile ...` for changed Python files
- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`
- focused Ruff lint passed; broad runner Ruff remains noisy from pre-existing findings
- `loopx canary premerge --from-git-diff`: all checks passed; expected benchmark-sensitive manual hold remains

## Boundary
No benchmark jobs are launched. This does not change scoring, task semantics, submission behavior, or permission boundaries. Incremental sync copies only bounded public artifacts; ledger and aggregate mutation remains in terminal closeout.