### PR TITLE
Redact SkillsBench dry-run proxy host

### DIFF
--- a/examples/skillsbench-benchmark-egress-policy-smoke.py
+++ b/examples/skillsbench-benchmark-egress-policy-smoke.py
@@ -20,6 +20,15 @@ from loopx.benchmark_adapters import skillsbench_dockerfile_runtime as dockerfil
 from loopx.benchmark_adapters import skillsbench_proxy_runtime as proxy_runtime
 
 
+def _launcher_env_without_profile() -> dict[str, str]:
+    env = os.environ.copy()
+    env.pop("SKILLSBENCH_RUNNER_PROFILE", None)
+    env["XDG_STATE_HOME"] = str(
+        Path(tempfile.gettempdir()) / f"loopx-skillsbench-smoke-{os.getpid()}"
+    )
+    return env
+
+
 def _make_skillsbench_root(root: Path) -> Path:
     skillsbench_root = root / "skillsbench"
     task_dir = skillsbench_root / "tasks" / "citation-check"
@@ -128,7 +137,7 @@ def test_formal_cli_goal_proxy_env_is_forwarded_without_public_url() -> None:
 
 
 def test_public_launcher_uses_container_reachable_benchmark_proxy() -> None:
-    env = os.environ.copy()
+    env = _launcher_env_without_profile()
     env.update(
         {
             "SKILLSBENCH_SSH_DESTINATION": "example.invalid",
@@ -169,7 +178,7 @@ def test_public_launcher_uses_container_reachable_benchmark_proxy() -> None:
         check=True,
     )
     output = proc.stdout
-    assert "docker_proxy_host=host.docker.internal" in output, output
+    assert "docker_proxy_host_recorded=false" in output, output
     assert (
         "LOOPX_SKILLSBENCH_EGRESS_PROXY=http://host.docker.internal:18186"
         in output
@@ -206,7 +215,7 @@ def test_public_launcher_uses_container_reachable_benchmark_proxy() -> None:
 
 
 def test_public_launcher_rejects_invalid_product_mode_soft_verify_policy() -> None:
-    env = os.environ.copy()
+    env = _launcher_env_without_profile()
     env.update(
         {
             "SKILLSBENCH_SSH_DESTINATION": "example.invalid",
@@ -237,7 +246,7 @@ def test_public_launcher_rejects_invalid_product_mode_soft_verify_policy() -> No
 
 
 def test_public_launcher_batches_three_cases_with_closeout_sync() -> None:
-    env = os.environ.copy()
+    env = _launcher_env_without_profile()
     env.update(
         {
             "SKILLSBENCH_SSH_DESTINATION": "example.invalid",
@@ -303,7 +312,7 @@ def test_public_launcher_batches_three_cases_with_closeout_sync() -> None:
 
 
 def test_public_launcher_rejects_aggregate_without_explicit_ledger() -> None:
-    env = os.environ.copy()
+    env = _launcher_env_without_profile()
     env.update(
         {
             "SKILLSBENCH_SSH_DESTINATION": "example.invalid",
@@ -356,7 +365,7 @@ def test_public_launcher_applies_ssh_options_to_remote_discovery() -> None:
             encoding="utf-8",
         )
         fake_ssh.chmod(0o755)
-        env = os.environ.copy()
+        env = _launcher_env_without_profile()
         env.update(
             {
                 "PATH": f"{fake_bin}:{env['PATH']}",
@@ -390,7 +399,7 @@ def test_public_launcher_applies_ssh_options_to_remote_discovery() -> None:
         discovery_calls = ssh_log.read_text(encoding="utf-8").splitlines()
         assert len(discovery_calls) == 3, discovery_calls
         assert all("-o Port=2222" in call for call in discovery_calls), discovery_calls
-        assert "docker_proxy_host=runner-host.example.invalid" in proc.stdout, proc.stdout
+        assert "docker_proxy_host_recorded=false" in proc.stdout, proc.stdout
         assert "docker_proxy_endpoint_mode=rootless_host_interface" in proc.stdout
         assert "docker_api_version=1.43" in proc.stdout, proc.stdout
         assert "DOCKER_API_VERSION=1.43" in proc.stdout, proc.stdout

--- a/examples/skillsbench-runner-profile-smoke.py
+++ b/examples/skillsbench-runner-profile-smoke.py
@@ -188,6 +188,12 @@ def main() -> None:
         assert "runner_profile_loaded=true" in output
         assert "runner_profile_path_recorded=false" in output
         assert "runner_profile_values_recorded=false" in output
+        assert "docker_proxy_host_recorded=false" in output
+        assert launch_environment["SKILLSBENCH_DOCKER_PROXY_HOST"] not in output
+        assert (
+            launch_environment["SKILLSBENCH_DOCKER_PROXY_HOST"]
+            not in completed.stderr
+        )
         assert "private_runner_command_values_redacted=true" in output
         assert "loopx_turn_validation_command_configured=1" in output
         for key, private_value in source_environment.items():

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -601,7 +601,7 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'public_output=%s/supervisor.public.json\n' "$public_dir"
   printf 'private_dir=%s\n' "$private_dir"
   printf 'remote_proxy_port=%s\n' "$remote_proxy_port"
-  printf 'docker_proxy_host=%s\n' "$docker_proxy_host"
+  printf 'docker_proxy_host_recorded=false\n'
   printf 'docker_proxy_endpoint_mode=%s\n' "$docker_proxy_endpoint_mode"
   printf 'docker_api_version=%s\n' "$docker_api_version"
   printf 'remote_codex_bin_mode=%s\n' "$remote_codex_bin_mode"

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -11,6 +11,7 @@ LAUNCHER = REPO_ROOT / "scripts" / "skillsbench-launch-goal-xhigh.sh"
 
 def _base_env(tmp_path: Path) -> dict[str, str]:
     env = os.environ.copy()
+    env.pop("SKILLSBENCH_RUNNER_PROFILE", None)
     env.update(
         {
             "XDG_STATE_HOME": str(tmp_path / "state"),
@@ -76,6 +77,9 @@ def test_turn_launcher_wires_private_commands_without_echoing_values(
     assert "loopx_turn_max_turns=4" in output
     assert "loopx_turn_progress_exit_code=10" in output
     assert "loopx_turn_terminal_policy=fixed-n" in output
+    assert "docker_proxy_host_recorded=false" in output
+    assert "docker_proxy_host=" not in output
+    assert env["SKILLSBENCH_DOCKER_PROXY_HOST"] not in output
     assert "private_runner_command_values_redacted=true" in output
     for arg_name in (
         "--remote-command-file-bridge-probe-command",


### PR DESCRIPTION
## Summary

- stop recording the resolved Docker proxy host in the SkillsBench launcher dry-run summary
- keep the public endpoint-mode signal while preserving real launch behavior
- isolate launcher smokes from owner-local runner profiles and cover the redaction contract directly

## Validation

- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`
- `python3 -m py_compile examples/skillsbench-benchmark-egress-policy-smoke.py examples/skillsbench-runner-profile-smoke.py tests/test_skillsbench_turn_launcher.py`
- `uv run --no-project --python 3.11 --with pytest python -m pytest -q tests/test_skillsbench_turn_launcher.py` (6 passed)
- `uv run --no-project --python 3.11 python examples/skillsbench-benchmark-egress-policy-smoke.py`
- `uv run --no-project --python 3.11 python examples/skillsbench-runner-profile-smoke.py`
- `loopx canary premerge --from-git-diff` (all 7 selected checks passed; manual benchmark-sensitive hold only)

## Risk Review

This narrows a public dry-run projection. It does not change scoring, task semantics, runner execution parameters, permission boundaries, uploads, submissions, or benchmark job launch behavior. The benchmark-sensitive hold is covered by the owner's standing authorization for narrow benchmark helper and public-boundary fixes after focused validation.
