### PR TITLE
Fail closed on stale Lark Kanban schemas

### DIFF
--- a/examples/lark-kanban-control-plane-smoke.py
+++ b/examples/lark-kanban-control-plane-smoke.py
@@ -299,6 +299,17 @@ def run_cli(*extra_args: str) -> dict[str, object]:
     return json.loads(result.stdout)
 
 
+def ready_field_list_result() -> dict[str, object]:
+    return {
+        "returncode": 0,
+        "stdout": json.dumps(
+            {"ok": True, "data": {"fields": lark_kanban_schema_payload()["fields"]}}
+        ),
+        "stderr": "",
+        "timed_out": False,
+    }
+
+
 def main() -> int:
     credential_boundary_smoke()
     global existing_setup_view_list_count
@@ -642,6 +653,8 @@ def main() -> int:
 
         def todo_upsert_runner(args: list[str], cwd: Path | None, timeout: float | None) -> dict[str, object]:
             todo_sync_calls.append(args)
+            if "+field-list" in args:
+                return ready_field_list_result()
             if "+record-list" in args:
                 return {
                     "returncode": 0,
@@ -938,6 +951,8 @@ def main() -> int:
 
         def projection_upsert_runner(args: list[str], cwd: Path | None, timeout: float | None) -> dict[str, object]:
             projection_calls.append(args)
+            if "+field-list" in args:
+                return ready_field_list_result()
             if "+record-list" in args:
                 return {
                     "returncode": 0,

--- a/loopx/cli_commands/lark_kanban.py
+++ b/loopx/cli_commands/lark_kanban.py
@@ -475,6 +475,8 @@ def handle_lark_kanban_command(
                 execute=bool(args.execute),
             )
             try:
+                if not payload.get("ok"):
+                    raise RuntimeError("primary Lark Kanban todo sync did not complete")
                 explore_sync = sync_issue_fix_explore_on_material_change(
                     registry_path=registry_path,
                     goal_id=args.goal_id,
@@ -556,6 +558,7 @@ def handle_lark_kanban_command(
                 payload["ok"] = False
                 payload["issue_fix_explore_projection"] = {
                     "ok": False,
+                    "status": "skipped" if payload.get("error") else "failed",
                     "error": str(exc),
                 }
             payload = compact_lark_kanban_sync_receipt(

--- a/loopx/extensions/lark/presentation/kanban.py
+++ b/loopx/extensions/lark/presentation/kanban.py
@@ -39,6 +39,7 @@ from .record_io import (
     build_record_delete_command,
     lark_record_rows,
     record_list_is_complete,
+    todo_record_list_is_authoritative,
     todo_record_entries,
 )
 from .sync_receipt import (
@@ -1695,6 +1696,83 @@ def _view_configuration_commands(
     return issue_fix_surface.view_configuration_commands(cli_bin=cli_bin, identity=identity, base_token=base_token, table_id=table_id, view_ids=view_ids, worker_view_name=DEFAULT_STATUS_QUEUE_VIEW, todo_statuses=[STATUS_TODO, STATUS_CLAIMED], user_gate_status=STATUS_USER_GATE, operator_card_fields=OPERATOR_CARD_FIELDS)
 
 
+def _lark_kanban_schema_check(parsed: Any) -> dict[str, Any]:
+    definitions = lark_kanban_field_definitions()
+    missing = issue_fix_surface.missing_field_definitions(parsed, definitions)
+    migrations = issue_fix_surface.field_definition_migrations(parsed, definitions)
+    missing_names = [str(item.get("name") or "") for item in missing]
+    incompatible_names = [str(item.get("name") or "") for item in migrations]
+    migration_required = bool(missing_names or incompatible_names)
+    return {
+        "ok": not migration_required,
+        "status": "stale" if migration_required else "ready",
+        "expected_field_count": len(definitions),
+        "observed_field_count": len(issue_fix_surface.extract_field_names(parsed)),
+        "missing_fields": missing_names,
+        "incompatible_fields": incompatible_names,
+        "migration_required": migration_required,
+        "remediation_command": (
+            "loopx lark-kanban setup --execute" if migration_required else None
+        ),
+    }
+
+
+def _inspect_lark_kanban_schema(
+    config: LarkKanbanConfig,
+    *,
+    commands: list[dict[str, Any]],
+    runner: CommandRunner,
+) -> dict[str, Any]:
+    field_list = _run_command(
+        [
+            config.cli_bin,
+            "base",
+            "+field-list",
+            "--as",
+            config.identity,
+            "--base-token",
+            config.base_token,
+            "--table-id",
+            config.table_id,
+            "--format",
+            "json",
+            "--limit",
+            "200",
+        ],
+        execute=True,
+        runner=runner,
+    )
+    commands.append(field_list)
+    if not field_list.get("ok"):
+        return {
+            "ok": False,
+            "status": "unavailable",
+            "migration_required": None,
+            "missing_fields": [],
+            "incompatible_fields": [],
+            "remediation_command": "loopx lark-kanban doctor --require-board",
+            "error": _command_error(field_list),
+        }
+    return _lark_kanban_schema_check(field_list.get("json"))
+
+
+def _schema_check_error(schema_check: dict[str, Any]) -> str:
+    if schema_check.get("status") == "stale":
+        missing = ", ".join(schema_check.get("missing_fields") or []) or "none"
+        incompatible = (
+            ", ".join(schema_check.get("incompatible_fields") or []) or "none"
+        )
+        return (
+            "Lark Kanban schema is stale "
+            f"(missing: {missing}; incompatible: {incompatible}); run "
+            f"`{schema_check['remediation_command']}` before sync"
+        )
+    return (
+        "Lark Kanban schema could not be inspected before sync: "
+        f"{schema_check.get('error') or 'unknown error'}"
+    )
+
+
 def lark_kanban_doctor(
     *,
     config_path: Path,
@@ -1706,6 +1784,7 @@ def lark_kanban_doctor(
 ) -> dict[str, Any]:
     commands: list[dict[str, Any]] = []
     issues: list[dict[str, str]] = []
+    schema_check: dict[str, Any] | None = None
     preflight = _lark_kanban_preflight(cli_bin=cli_bin, identity=identity, runner=runner)
     commands.extend(preflight["commands"])
     for warning in preflight["warnings"]:
@@ -1754,6 +1833,19 @@ def lark_kanban_doctor(
             commands.append(result)
             if not result.get("ok"):
                 issues.append({"severity": "error", "message": _command_error(result)})
+        if not any(issue["severity"] == "error" for issue in issues):
+            schema_check = _inspect_lark_kanban_schema(
+                board_config,
+                commands=commands,
+                runner=runner,
+            )
+            if not schema_check.get("ok"):
+                issues.append(
+                    {
+                        "severity": "error",
+                        "message": _schema_check_error(schema_check),
+                    }
+                )
 
     return {
         "ok": not any(issue["severity"] == "error" for issue in issues),
@@ -1761,6 +1853,7 @@ def lark_kanban_doctor(
         "config_path": str(config_path),
         "identity": identity,
         "issues": issues,
+        "schema_check": schema_check,
         "config": config_payload,
         "commands": commands,
     }
@@ -1933,6 +2026,32 @@ def sync_loopx_projection_to_lark_kanban(
     )
 
     commands: list[dict[str, Any]] = []
+    schema_check: dict[str, Any] | None = None
+    if execute:
+        schema_check = _inspect_lark_kanban_schema(
+            config,
+            commands=commands,
+            runner=runner,
+        )
+        if not schema_check.get("ok"):
+            return {
+                "ok": False,
+                "schema_version": LARK_KANBAN_SYNC_PROJECTION_VERSION,
+                "execute": execute,
+                "goal_id": resolved_goal_id,
+                "agent_id": agent_id,
+                "source_id": resolved_source_id,
+                "sink_visibility": sink_visibility,
+                "public_safe_redaction": public_safe,
+                "projection_schema_version": projection.get("schema_version"),
+                "row_count": len(rows),
+                "records": [],
+                "commands": commands,
+                "warnings": warnings,
+                "config_path": str(config_path) if config_path else None,
+                "schema_check": schema_check,
+                "error": _schema_check_error(schema_check),
+            }
     local, record_map, remote_records, remote_list_complete = _load_lark_todo_record_map(
         config,
         config_path=config_path,
@@ -2040,6 +2159,7 @@ def sync_loopx_projection_to_lark_kanban(
         "sink_visibility": sink_visibility,
         "public_safe_redaction": public_safe,
         "projection_schema_version": projection.get("schema_version"),
+        "schema_check": schema_check,
         "row_count": len(rows),
         "source_reconcile": {
             **reconcile_plan,
@@ -2126,6 +2246,39 @@ def sync_loopx_todos_to_lark_kanban(
     ]
 
     commands: list[dict[str, Any]] = []
+    schema_check: dict[str, Any] | None = None
+    if execute:
+        schema_check = _inspect_lark_kanban_schema(
+            config,
+            commands=commands,
+            runner=runner,
+        )
+        if not schema_check.get("ok"):
+            return {
+                "ok": False,
+                "schema_version": "loopx_lark_kanban_sync_todos_v0",
+                "execute": execute,
+                "goal_id": goal_id,
+                "agent_id": agent_id,
+                "base_token": config.base_token,
+                "table_id": config.table_id,
+                "view_id": config.view_id,
+                "project": str(resolved_project) if resolved_project else None,
+                "state_file": str(resolved_state_file),
+                "todo_count": len(todos),
+                "issue_fix_outcome_count": len(outcome_rows),
+                "limit_policy": {
+                    "todo_rows": limit,
+                    "issue_fix_outcomes": "complete_source_projection",
+                },
+                "issue_fix_source_counts": outcome_projection.get("source_counts"),
+                "warnings": outcome_warnings,
+                "records": [],
+                "commands": commands,
+                "config_path": str(config_path) if config_path else None,
+                "schema_check": schema_check,
+                "error": _schema_check_error(schema_check),
+            }
     local, record_map, _, _ = _load_lark_todo_record_map(
         config,
         config_path=config_path,
@@ -2224,6 +2377,7 @@ def sync_loopx_todos_to_lark_kanban(
             "todo_rows": limit, "issue_fix_outcomes": "complete_source_projection",
         },
         "issue_fix_source_counts": outcome_projection.get("source_counts"),
+        "schema_check": schema_check,
         "warnings": outcome_warnings,
         "records": results,
         "commands": commands,
@@ -2253,10 +2407,17 @@ def _load_lark_todo_record_map(
     remote_records: list[dict[str, str]] = []
     remote_complete = False
     if list_result.get("ok"):
-        remote_records = todo_record_entries(list_result.get("json"))
+        parsed_records = list_result.get("json")
+        remote_records = todo_record_entries(parsed_records)
         remote_by_key: dict[str, list[str]] = {}
         for item in remote_records:
             remote_by_key.setdefault(item["key"], []).append(item["record_id"])
+        if todo_record_list_is_authoritative(parsed_records):
+            record_map = {
+                key: record_id
+                for key, record_id in record_map.items()
+                if record_id in remote_by_key.get(key, [])
+            }
         for key, record_ids in remote_by_key.items():
             preferred_record_id = record_map.get(key)
             record_map[key] = (
@@ -2264,7 +2425,7 @@ def _load_lark_todo_record_map(
                 if preferred_record_id in record_ids
                 else sorted(record_ids)[0]
             )
-        remote_complete = record_list_is_complete(list_result.get("json"))
+        remote_complete = record_list_is_complete(parsed_records)
     return local, record_map, remote_records, remote_complete
 
 

--- a/loopx/extensions/lark/presentation/record_io.py
+++ b/loopx/extensions/lark/presentation/record_io.py
@@ -54,6 +54,26 @@ def record_list_is_complete(parsed: Any) -> bool:
     )
 
 
+def todo_record_list_is_authoritative(parsed: Any) -> bool:
+    if not record_list_is_complete(parsed) or not isinstance(parsed, dict):
+        return False
+    data = parsed.get("data") if isinstance(parsed.get("data"), dict) else parsed
+    if not isinstance(data, dict):
+        return False
+    fields = data.get("fields")
+    rows = data.get("data")
+    record_ids = data.get("record_id_list")
+    return (
+        isinstance(fields, list)
+        and {"LoopX Goal ID", "LoopX Todo ID"}.issubset(
+            {str(field) for field in fields}
+        )
+        and isinstance(rows, list)
+        and isinstance(record_ids, list)
+        and len(record_ids) == len(rows)
+    )
+
+
 def build_record_delete_command(
     config: RecordTarget,
     *,

--- a/tests/extensions/test_lark_kanban_schema_preflight.py
+++ b/tests/extensions/test_lark_kanban_schema_preflight.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from loopx.extensions.lark.presentation.kanban import (
+    LarkKanbanConfig,
+    lark_kanban_doctor,
+    lark_kanban_schema_payload,
+    read_lark_kanban_local_config,
+    save_lark_kanban_board_config,
+    sync_loopx_projection_to_lark_kanban,
+    write_lark_kanban_local_config,
+)
+
+
+def _result(payload: object) -> dict[str, object]:
+    return {
+        "returncode": 0,
+        "stdout": json.dumps(payload),
+        "stderr": "",
+        "timed_out": False,
+    }
+
+
+def _stale_schema_runner(
+    calls: list[list[str]],
+):
+    def run(
+        args: list[str], cwd: Path | None, timeout: float | None
+    ) -> dict[str, object]:
+        calls.append(args)
+        if args == ["lark-cli", "--version"]:
+            return _result({"version": "1.0.56"})
+        if args == ["lark-cli", "auth", "status"]:
+            return _result(
+                {"ok": True, "identities": {"user": {"available": True}}}
+            )
+        if args[-1:] == ["--help"]:
+            return _result({"ok": True})
+        if "+field-list" in args:
+            return _result(
+                {
+                    "ok": True,
+                    "data": {
+                        "fields": [
+                            {"id": "fld_task", "name": "Task", "type": "text"},
+                            {
+                                "id": "fld_status",
+                                "name": "Status",
+                                "type": "select",
+                            },
+                        ]
+                    },
+                }
+            )
+        return _result({"ok": True})
+
+    return run
+
+
+def test_doctor_reports_stale_schema_with_migration_command(tmp_path: Path) -> None:
+    config_path = tmp_path / "lark-kanban.json"
+    save_lark_kanban_board_config(
+        config_path,
+        base_token="base_public_fixture",
+        table_id="tbl_public_fixture",
+        cli_bin="lark-cli",
+        identity="user",
+    )
+    calls: list[list[str]] = []
+
+    payload = lark_kanban_doctor(
+        config_path=config_path,
+        runner=_stale_schema_runner(calls),
+    )
+
+    assert payload["ok"] is False
+    assert payload["schema_check"]["status"] == "stale"
+    assert "Work Item Type" in payload["schema_check"]["missing_fields"]
+    assert payload["schema_check"]["remediation_command"] == (
+        "loopx lark-kanban setup --execute"
+    )
+    assert any("setup --execute" in issue["message"] for issue in payload["issues"])
+    assert sum("+field-list" in args for args in calls) == 1
+
+
+def test_execute_sync_stops_before_writes_when_schema_is_stale() -> None:
+    calls: list[list[str]] = []
+    config = LarkKanbanConfig(
+        base_token="base_public_fixture",
+        table_id="tbl_public_fixture",
+        cli_bin="lark-cli",
+        identity="user",
+    )
+
+    payload = sync_loopx_projection_to_lark_kanban(
+        config,
+        projection={
+            "schema_version": "goal_channel_projection_v0",
+            "goal_id": "goal_public_fixture",
+            "source_id": "source-public-fixture",
+            "agent_todos": [
+                {
+                    "todo_id": "todo_public_fixture",
+                    "title": "Repair the public fixture",
+                    "status": "open",
+                    "task_class": "advancement_task",
+                }
+            ],
+        },
+        execute=True,
+        runner=_stale_schema_runner(calls),
+    )
+
+    assert payload["ok"] is False
+    assert payload["schema_check"]["status"] == "stale"
+    assert "setup --execute" in payload["error"]
+    assert payload["records"] == []
+    assert len(calls) == 1
+    assert "+field-list" in calls[0]
+    assert not any("+record-upsert" in args for args in calls)
+
+
+def test_complete_remote_list_replaces_stale_local_record_id(tmp_path: Path) -> None:
+    config_path = tmp_path / "lark-kanban.json"
+    config = LarkKanbanConfig(
+        base_token="base_public_fixture",
+        table_id="tbl_public_fixture",
+        cli_bin="lark-cli",
+        identity="user",
+    )
+    save_lark_kanban_board_config(
+        config_path,
+        base_token=config.base_token,
+        table_id=config.table_id,
+        cli_bin=config.cli_bin,
+        identity=config.identity,
+    )
+    local = read_lark_kanban_local_config(config_path)
+    record_key = (
+        "goal_public_fixture:"
+        "projection:source-public-fixture:agent_todo:todo_public_fixture"
+    )
+    local["todo_records"] = {record_key: "rec_stale_fixture"}
+    write_lark_kanban_local_config(config_path, local)
+    calls: list[list[str]] = []
+
+    def runner(
+        args: list[str], cwd: Path | None, timeout: float | None
+    ) -> dict[str, object]:
+        calls.append(args)
+        if "+field-list" in args:
+            return _result(
+                {
+                    "ok": True,
+                    "data": {"fields": lark_kanban_schema_payload()["fields"]},
+                }
+            )
+        if "+record-list" in args:
+            return _result(
+                {
+                    "ok": True,
+                    "data": {
+                        "fields": ["LoopX Goal ID", "LoopX Todo ID"],
+                        "data": [["goal_public_fixture", "todo_different_fixture"]],
+                        "record_id_list": ["rec_stale_fixture"],
+                        "has_more": False,
+                    },
+                }
+            )
+        if "+record-upsert" in args:
+            assert "--record-id" not in args
+            return _result({"ok": True, "data": {"record_id": "rec_fresh_fixture"}})
+        raise AssertionError(args)
+
+    payload = sync_loopx_projection_to_lark_kanban(
+        config,
+        projection={
+            "schema_version": "goal_channel_projection_v0",
+            "goal_id": "goal_public_fixture",
+            "source_id": "source-public-fixture",
+            "agent_todos": [
+                {
+                    "todo_id": "todo_public_fixture",
+                    "title": "Repair the public fixture",
+                    "status": "open",
+                    "task_class": "advancement_task",
+                }
+            ],
+        },
+        config_path=config_path,
+        execute=True,
+        runner=runner,
+    )
+
+    assert payload["ok"] is True
+    assert payload["records"][0]["record_id"] == "rec_fresh_fixture"
+    persisted = read_lark_kanban_local_config(config_path)["todo_records"]
+    assert persisted[record_key] == "rec_fresh_fixture"
+    assert persisted["goal_public_fixture:todo_different_fixture"] == (
+        "rec_stale_fixture"
+    )
+    assert sum("+record-upsert" in args for args in calls) == 1


### PR DESCRIPTION
## Summary
- make `lark-kanban doctor` compare the live table fields with the current LoopX schema and return a concrete `setup --execute` migration command
- preflight execute-mode todo/projection syncs so stale or unreadable schemas fail before any record or follow-on Explore writes
- trust cached record IDs only when a complete remote list confirms the exact logical-key/record-ID pair
- add focused stale-schema and stale-record-map tests while keeping the existing end-to-end smoke current

## Validation
- `pytest -q tests/extensions/test_lark_kanban_schema_preflight.py` (3 passed)
- `python examples/lark-kanban-control-plane-smoke.py`
- `ruff check` on all changed Python files
- `loopx canary premerge --from-git-diff` (17 selected checks passed, 0 failures, 0 warnings)
- public/private boundary scan clean for all 5 changed files
- owner-only live migration, scoped sync, and complete record-ID readback passed; no external identifiers or output were committed

## Holds and scope
- no skipped checks or manual holds
- does not change Lark credentials, permission boundaries, projection semantics, or public evidence policy
- historical duplicate-row deletion remains explicit reconciliation work; normal sync does not delete remote rows