### PR TITLE
Align SkillsBench setup-only timeout

### DIFF
--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -6209,6 +6209,17 @@ def _effective_build_stall_timeout_sec(args: argparse.Namespace) -> int:
     return _requested_build_stall_timeout_sec(args)
 
 
+def _effective_setup_only_stage_timeout_sec(args: argparse.Namespace) -> int:
+    sandbox_timeout_sec = max(
+        1,
+        int(getattr(args, "sandbox_setup_timeout", 0) or 0),
+    )
+    build_stall_timeout_sec = _effective_build_stall_timeout_sec(args)
+    if build_stall_timeout_sec <= 0:
+        return sandbox_timeout_sec
+    return min(sandbox_timeout_sec, build_stall_timeout_sec)
+
+
 def build_compose_setup_diagnostic(
     compact: dict[str, Any],
     plan: dict[str, Any],
@@ -8800,6 +8811,9 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         "setup_only_public_preflight": bool(
             getattr(args, "setup_only_public_preflight", False)
         ),
+        "setup_only_stage_timeout_sec": (
+            _effective_setup_only_stage_timeout_sec(args)
+        ),
         "setup_only_public_preflight_json": str(setup_only_preflight_path),
         "controller_trace_json": str(controller_trace_path),
         "build_stall_timeout_requested_sec": _requested_build_stall_timeout_sec(args),
@@ -9328,6 +9342,7 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
         "agent_idle_timeout_sec",
         "build_stall_timeout_requested_sec",
         "build_stall_timeout_sec",
+        "setup_only_stage_timeout_sec",
         "local_codex_task_output_quiet_timeout_sec",
     )
     for field in int_fields:
@@ -9346,6 +9361,7 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
         "fail_fast_on_verifier_bootstrap_risk",
         "verifier_bootstrap_fail_fast_defaulted",
         "bootstrap_light_fail_fast_defaulted",
+        "setup_only_public_preflight",
         "global_ledger_sync_enabled",
         "ledger_inherit_enabled",
     ):
@@ -14671,7 +14687,9 @@ async def run_benchflow_case(
                 config=config,
                 task_staging=plan.get("task_staging"),
                 setup_preflight=plan.get("task_setup_preflight"),
-                stage_timeout_sec=float(args.sandbox_setup_timeout),
+                stage_timeout_sec=float(
+                    _effective_setup_only_stage_timeout_sec(args)
+                ),
                 progress_callback=lambda progress: _write_setup_only_public_preflight(
                     plan,
                     progress,

--- a/tests/test_skillsbench_setup_preflight.py
+++ b/tests/test_skillsbench_setup_preflight.py
@@ -18,6 +18,8 @@ from loopx.benchmark_adapters.skillsbench_setup_preflight import (
 )
 from loopx.status import compact_benchmark_run
 from scripts.skillsbench_automation_loop import (
+    _effective_setup_only_stage_timeout_sec,
+    _public_runner_config,
     build_compose_setup_diagnostic,
     build_plan,
     parse_args,
@@ -163,6 +165,41 @@ def test_setup_only_runner_mode_bypasses_formal_round_budget() -> None:
     assert plan["setup_only_public_preflight_json"].endswith(
         "setup_only_preflight.public.json"
     )
+
+
+@pytest.mark.parametrize(
+    ("sandbox_timeout", "build_stall_timeout", "expected"),
+    [
+        (7200, 3600, 3600),
+        (1800, 3600, 1800),
+        (7200, 0, 7200),
+    ],
+)
+def test_setup_only_stage_timeout_matches_scoring_setup_watchdog(
+    sandbox_timeout: int,
+    build_stall_timeout: int,
+    expected: int,
+) -> None:
+    args = parse_args(
+        [
+            "--task-id",
+            "flink-query",
+            "--route",
+            "loopx-goal-start-product-mode",
+            "--setup-only-public-preflight",
+            "--sandbox-setup-timeout",
+            str(sandbox_timeout),
+            "--build-stall-timeout-sec",
+            str(build_stall_timeout),
+        ]
+    )
+
+    assert _effective_setup_only_stage_timeout_sec(args) == expected
+    plan = build_plan(args)
+    assert plan["setup_only_stage_timeout_sec"] == expected
+    public_config = _public_runner_config(plan)
+    assert public_config["setup_only_public_preflight"] is True
+    assert public_config["setup_only_stage_timeout_sec"] == expected
 
 
 def test_launcher_syncs_setup_only_public_artifact() -> None:


### PR DESCRIPTION
## Summary
- make setup-only preflight use the tighter of sandbox setup and build-stall timeouts
- expose the effective setup-only stage timeout in the public runner config
- add parameterized timeout and projection coverage

## Validation
- `pytest tests/test_skillsbench_setup_preflight.py` (32 passed)
- setup-only/setup-stall focused benchmark smoke (22 passed)
- Python compile and diff checks
- LoopX premerge: 4/4 catalog canaries passed; benchmark-sensitive manual hold reviewed under owner-authorized benchmark helper self-merge

No benchmark jobs are launched and scoring, task semantics, upload, submission, and permission behavior are unchanged.