### PR TITLE
Keep SkillsBench bootstrap import Python 3.9 safe

### DIFF
--- a/loopx/benchmark_adapters/skillsbench_turn_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_runtime.py
@@ -19,7 +19,7 @@ import uuid
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any
+from typing import Any, Union
 
 from ..benchmark_case_state import benchmark_case_loopx_command_prefix
 from ..control_plane.turn_driver import run_loopx_turn_once
@@ -49,7 +49,7 @@ class SkillsBenchTurnAgentResult:
     progress_evidence: Mapping[str, Any]
 
 
-AgentPromptRunner = Callable[[str], str | SkillsBenchTurnAgentResult]
+AgentPromptRunner = Callable[[str], Union[str, SkillsBenchTurnAgentResult]]
 PublicTraceWriter = Callable[[dict[str, Any]], None]
 TurnObserver = Callable[[dict[str, Any], dict[str, Any]], None]
 

--- a/tests/test_skillsbench_turn_runtime.py
+++ b/tests/test_skillsbench_turn_runtime.py
@@ -5,7 +5,7 @@ import subprocess
 import time
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Union, get_args, get_origin
 
 import pytest
 
@@ -23,6 +23,12 @@ from loopx.benchmark_adapters.skillsbench_turn_route import (
     sync_skillsbench_loopx_turn_trace_into_compact,
 )
 from loopx.control_plane.turn_driver import executor as turn_executor
+
+
+def test_agent_prompt_runner_alias_is_bootstrap_python_39_safe() -> None:
+    return_type = get_args(runtime.AgentPromptRunner)[1]
+
+    assert get_origin(return_type) is Union
 
 
 def _config(tmp_path: Path) -> runtime.SkillsBenchTurnRuntimeConfig:


### PR DESCRIPTION
## Summary
- keep the SkillsBench Turn callback type alias importable by a Python 3.9 bootstrap interpreter
- preserve the declared Python 3.11+ runtime by allowing the existing SkillsBench venv re-exec path to run
- add a focused type-shape regression test

## Validation
- system Python 3.9: `scripts/skillsbench_automation_loop.py --help`
- 30 Turn runtime tests
- 38 Turn launcher and setup-preflight tests
- LoopX premerge: direct checks passed and 6/6 selected canaries passed

No benchmark job was launched. This does not change scoring, task semantics, permission boundaries, upload, or submission behavior.