### PR TITLE
Clarify SkillsBench stability turn policy

### DIFF
--- a/examples/skillsbench-loopx-turn-agent-cli-smoke.py
+++ b/examples/skillsbench-loopx-turn-agent-cli-smoke.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import shlex
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -19,7 +20,15 @@ from loopx.benchmark_adapters.skillsbench import skillsbench_route_contract  # n
 from loopx.benchmark_adapters.skillsbench_acp_failure_policy import (  # noqa: E402
     recoverable_codex_turn_failure_message,
 )
+from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
+    CodexExecConfig,
+    SkillsBenchLocalAcpRelay,
+)
+from loopx.benchmark_adapters.skillsbench_bridge_summary import (  # noqa: E402
+    bridge_summary_task_progress_receipt,
+)
 from loopx.benchmark_adapters.skillsbench_turn_runtime import (  # noqa: E402
+    SkillsBenchTurnAgentResult,
     SkillsBenchTurnRuntimeConfig,
     build_skillsbench_loopx_turn_trace,
     run_skillsbench_loopx_turn,
@@ -126,30 +135,51 @@ def _write_bridge(root: Path, workspace: Path) -> str:
     bridge.write_text(
         f"""#!/usr/bin/env python3
 import json
+import pathlib
 import subprocess
 import sys
 
 request = json.load(sys.stdin)
-command = str(request.get("command") or "").replace("/app", {str(workspace)!r})
-completed = subprocess.run(
-    command,
-    cwd={str(workspace)!r},
-    shell=True,
-    executable="/bin/bash",
-    text=True,
-    stdout=subprocess.PIPE,
-    stderr=subprocess.PIPE,
-    check=False,
-)
-print(json.dumps({{
-    "schema_version": "skillsbench_remote_command_file_bridge_operation_response_v0",
-    "ok": completed.returncode == 0,
-    "exit_code": completed.returncode,
-    "stdout": completed.stdout,
-    "stderr": completed.stderr,
-    "stdout_truncated": False,
-    "stderr_truncated": False,
-}}))
+operation = str(request.get("operation") or "")
+raw_path = str(request.get("path") or "")
+mapped_path = pathlib.Path(raw_path.replace("/app", {str(workspace)!r}, 1))
+if operation == "exec":
+    command = str(request.get("command") or "").replace("/app", {str(workspace)!r})
+    completed = subprocess.run(
+        command,
+        cwd={str(workspace)!r},
+        shell=True,
+        executable="/bin/bash",
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    response = {{
+        "ok": completed.returncode == 0,
+        "exit_code": completed.returncode,
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+        "stdout_truncated": False,
+        "stderr_truncated": False,
+    }}
+elif operation == "read_file" and raw_path.startswith("/app/"):
+    max_bytes = max(1, int(request.get("max_bytes") or 20000))
+    content = mapped_path.read_text(encoding="utf-8")
+    response = {{
+        "ok": True,
+        "exit_code": 0,
+        "content": content[:max_bytes],
+        "content_truncated": len(content) > max_bytes,
+    }}
+elif operation == "write_file" and raw_path.startswith("/app/"):
+    mapped_path.parent.mkdir(parents=True, exist_ok=True)
+    mapped_path.write_text(str(request.get("content") or ""), encoding="utf-8")
+    response = {{"ok": True, "exit_code": 0}}
+else:
+    response = {{"ok": False, "exit_code": 2}}
+response["schema_version"] = "skillsbench_remote_command_file_bridge_operation_response_v0"
+print(json.dumps(response))
 """,
         encoding="utf-8",
     )
@@ -252,6 +282,75 @@ def _run_success(root: Path) -> dict[str, Any]:
         "validation_status": validation.get("status"),
         "fidelity_allowed": fidelity.get("turn_treatment_fidelity_allowed"),
         "compact_turn_count": len(compact.get("loopx_turn_executions", [])),
+    }
+
+
+def _run_content_change_progress(root: Path) -> dict[str, Any]:
+    paths = _write_fixture(root)
+    config = _config(paths, validation_command="false")
+    relay = SkillsBenchLocalAcpRelay(
+        CodexExecConfig(remote_command_file_bridge_command=config.bridge_command)
+    )
+    summary_path = root / "content-change-summary.jsonl"
+    wrapper = relay._write_instrumented_bridge_wrapper(
+        tmp_path=root,
+        summary_path=summary_path,
+    )
+
+    def agent_runner(_prompt: str) -> SkillsBenchTurnAgentResult:
+        subprocess.run(
+            [str(wrapper)],
+            input=json.dumps(
+                {
+                    "operation": "write_file",
+                    "path": "/app/content-change.ok",
+                    "content": "changed\n",
+                }
+            ),
+            text=True,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        return SkillsBenchTurnAgentResult(
+            response_text="agent changed one durable task file",
+            progress_evidence=bridge_summary_task_progress_receipt(summary_path),
+        )
+
+    execution, validation = run_skillsbench_loopx_turn(
+        prompt="Create the requested public content-change marker.",
+        agent_runner=agent_runner,
+        config=config,
+    )
+    effects = execution.get("effects")
+    assert execution.get("status") == "committed", execution
+    assert execution.get("validation", {}).get("status") == "progress", execution
+    assert isinstance(effects, dict) and effects.get("state_written") is True, execution
+    assert isinstance(effects, dict) and effects.get("quota_spent") is True, execution
+    assert validation.get("status") == "passed", validation
+    assert validation.get("terminal_complete") is False, validation
+    assert validation.get("post_agent_postcondition_status") == "progress_validated", (
+        validation
+    )
+    assert validation.get("progress_evidence_kind") == "verified_task_content_change", (
+        validation
+    )
+    assert validation.get("successful_task_file_write_count") == 1, validation
+    assert validation.get("successful_task_file_change_count") == 1, validation
+    assert validation.get("oracle_feedback_used") is False, validation
+    assert validation.get("raw_task_text_recorded") is False, validation
+    assert validation.get("raw_verifier_output_recorded") is False, validation
+    return {
+        "execution_status": execution.get("status"),
+        "receipt_status": execution.get("receipt", {}).get("status"),
+        "transaction_validation_status": execution.get("validation", {}).get(
+            "status"
+        ),
+        "progress_evidence_kind": validation.get("progress_evidence_kind"),
+        "successful_task_file_change_count": validation.get(
+            "successful_task_file_change_count"
+        ),
+        "official_feedback_used": validation.get("oracle_feedback_used"),
     }
 
 
@@ -434,6 +533,10 @@ def main() -> int:
 
     with tempfile.TemporaryDirectory(prefix="skillsbench-loopx-turn-success-") as value:
         success = _run_success(Path(value))
+    with tempfile.TemporaryDirectory(
+        prefix="skillsbench-loopx-turn-content-change-"
+    ) as value:
+        content_change_progress = _run_content_change_progress(Path(value))
     with tempfile.TemporaryDirectory(prefix="skillsbench-loopx-turn-failure-") as value:
         failure = _run_failure(Path(value))
     with tempfile.TemporaryDirectory(
@@ -469,6 +572,7 @@ def main() -> int:
                     "legacy_lifecycle_checkpoint": False,
                 },
                 "success": success,
+                "content_change_progress": content_change_progress,
                 "failure": failure,
                 "recoverable_host_failure": recoverable_host_failure,
                 "turn_plan_failure": turn_plan_failure,

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -2689,6 +2689,7 @@ PROBE_OPERATION_LABELS = {{
     "probe_marker_cleanup",
 }}
 PROBE_PATH_LABELS = {{"bridge_probe_marker"}}
+CONTENT_COMPARE_MAX_BYTES = 200_000
 
 {LOOPX_COMMAND_INSTRUMENTATION_SOURCE}
 {LOOPX_TODO_OUTPUT_INSTRUMENTATION_SOURCE}
@@ -2716,6 +2717,55 @@ def loopx_public_fields(command: str) -> dict[str, str]:
             fields["loopx_goal_id"] = value
         i += 1
     return fields
+
+def private_bridge_probe(request):
+    try:
+        proc = subprocess.run(
+            BRIDGE_COMMAND,
+            input=json.dumps(request, separators=(",", ":")),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=True,
+        )
+    except OSError:
+        return None
+    if proc.returncode != 0:
+        return None
+    try:
+        response = json.loads(proc.stdout or "")
+    except Exception:
+        return None
+    return response if isinstance(response, dict) else None
+
+def durable_write_changes_content(payload, request_path):
+    content = payload.get("content")
+    if not isinstance(content, str):
+        return False
+    existence = private_bridge_probe({{
+        "operation": "exec",
+        "cwd": "/app",
+        "command": "test -e " + shlex.quote(request_path),
+        "timeout_sec": 10,
+    }})
+    if existence is None:
+        return False
+    if existence.get("ok") is not True:
+        return existence.get("exit_code") == 1
+    current = private_bridge_probe({{
+        "operation": "read_file",
+        "path": request_path,
+        "max_bytes": CONTENT_COMPARE_MAX_BYTES,
+        "timeout_sec": 30,
+    }})
+    if current is None or current.get("ok") is not True:
+        return False
+    current_content = current.get("content")
+    if not isinstance(current_content, str):
+        return False
+    if current.get("content_truncated") is True:
+        return not content.startswith(current_content)
+    return current_content != content
 
 raw = sys.stdin.read()
 record: dict[str, object] = {{
@@ -2797,6 +2847,11 @@ durable_task_write = bool(
     )
 )
 record["durable_task_write"] = durable_task_write
+record["durable_task_content_changed"] = bool(
+    durable_task_write
+    and isinstance(payload, dict)
+    and durable_write_changes_content(payload, request_path)
+)
 if durable_task_write:
     record["durable_task_write_root"] = (
         "app" if request_path.startswith("/app/") else "root"

--- a/loopx/benchmark_adapters/skillsbench_bridge_summary.py
+++ b/loopx/benchmark_adapters/skillsbench_bridge_summary.py
@@ -108,7 +108,7 @@ def bridge_summary_has_successful_task_operation(
 
 
 def bridge_summary_task_progress_receipt(path: Path | None) -> dict[str, Any]:
-    """Reduce one agent invocation to bounded task-facing progress counts."""
+    """Reduce one agent invocation to bounded task-facing content changes."""
 
     receipt: dict[str, Any] = {
         "schema_version": "skillsbench_bridge_task_progress_receipt_v0",
@@ -116,6 +116,7 @@ def bridge_summary_task_progress_receipt(path: Path | None) -> dict[str, Any]:
         "task_facing_operation_count": 0,
         "task_facing_success_count": 0,
         "successful_task_file_write_count": 0,
+        "successful_task_file_change_count": 0,
         "raw_material_recorded": False,
     }
     if path is None or not path.exists():
@@ -161,11 +162,13 @@ def bridge_summary_task_progress_receipt(path: Path | None) -> dict[str, Any]:
             and record.get("durable_task_write") is True
         ):
             receipt["successful_task_file_write_count"] += 1
+            if record.get("durable_task_content_changed") is True:
+                receipt["successful_task_file_change_count"] += 1
     if (
-        receipt["successful_task_file_write_count"] > 0
+        receipt["successful_task_file_change_count"] > 0
         and receipt["raw_material_recorded"] is False
     ):
-        receipt["status"] = "verified_task_file_write"
+        receipt["status"] = "verified_task_content_change"
     return receipt
 
 

--- a/loopx/benchmark_adapters/skillsbench_turn_route.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_route.py
@@ -331,6 +331,9 @@ def _public_validation(value: Any) -> dict[str, Any]:
     write_count = value.get("successful_task_file_write_count")
     if isinstance(write_count, int) and not isinstance(write_count, bool):
         validation["successful_task_file_write_count"] = max(0, write_count)
+    change_count = value.get("successful_task_file_change_count")
+    if isinstance(change_count, int) and not isinstance(change_count, bool):
+        validation["successful_task_file_change_count"] = max(0, change_count)
     return validation
 
 
@@ -523,6 +526,11 @@ def _aggregate_validations(validations: list[dict[str, Any]]) -> dict[str, Any]:
             max(0, int(item.get("successful_task_file_write_count") or 0))
             for item in validations
             if not isinstance(item.get("successful_task_file_write_count"), bool)
+        ),
+        "successful_task_file_change_count": sum(
+            max(0, int(item.get("successful_task_file_change_count") or 0))
+            for item in validations
+            if not isinstance(item.get("successful_task_file_change_count"), bool)
         ),
     }
     progress_evidence_kinds = {

--- a/loopx/benchmark_adapters/skillsbench_turn_route.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_route.py
@@ -185,6 +185,13 @@ def _public_label_list(value: Any, *, limit: int) -> list[str]:
     return [label for item in value[:12] if (label := _public_label(item, limit=limit))]
 
 
+def _public_turn_sequence_ref(value: Any) -> str:
+    label = _public_label(value, limit=80)
+    if re.fullmatch(r"sequence:[0-9a-f]{16}", label):
+        return label
+    return ""
+
+
 def _public_execution(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
         return {}
@@ -319,6 +326,8 @@ def _public_validation(value: Any) -> dict[str, Any]:
     turn_index = value.get("turn_index")
     if isinstance(turn_index, int) and not isinstance(turn_index, bool):
         validation["turn_index"] = max(1, turn_index)
+    if sequence_ref := _public_turn_sequence_ref(value.get("turn_sequence_ref")):
+        validation["turn_sequence_ref"] = sequence_ref
     write_count = value.get("successful_task_file_write_count")
     if isinstance(write_count, int) and not isinstance(write_count, bool):
         validation["successful_task_file_write_count"] = max(0, write_count)
@@ -337,6 +346,11 @@ def _public_runner_readiness(value: Any) -> dict[str, Any]:
         receipt["ready"] = value["ready"]
     if isinstance(value.get("turn_proven"), bool):
         receipt["turn_proven"] = value["turn_proven"]
+    if sequence_ref := _public_turn_sequence_ref(value.get("turn_sequence_ref")):
+        receipt["turn_sequence_ref"] = sequence_ref
+    turn_index = value.get("turn_index")
+    if isinstance(turn_index, int) and not isinstance(turn_index, bool):
+        receipt["turn_index"] = max(1, turn_index)
     checks = value.get("checks")
     if isinstance(checks, dict):
         receipt["checks"] = {
@@ -389,7 +403,7 @@ def _aggregate_runner_readiness(receipts: list[dict[str, Any]]) -> dict[str, Any
             if isinstance(blocker, str) and blocker
         }
     )
-    return {
+    aggregate = {
         "schema_version": "skillsbench_benchmark_runner_readiness_v0",
         "capability": "benchmark_runner",
         "status": "ready" if ready_count else "blocked",
@@ -418,6 +432,48 @@ def _aggregate_runner_readiness(receipts: list[dict[str, Any]]) -> dict[str, Any
             item.get("local_paths_recorded") is True for item in receipts
         ),
     }
+    receipts_by_sequence: dict[str, dict[int, list[dict[str, Any]]]] = {}
+    unattributed_turn_count = 0
+    unindexed_sequence_turn_count = 0
+    for item in receipts:
+        sequence_ref = _public_turn_sequence_ref(item.get("turn_sequence_ref"))
+        if not sequence_ref:
+            unattributed_turn_count += 1
+            continue
+        turn_index = item.get("turn_index")
+        if not isinstance(turn_index, int) or isinstance(turn_index, bool):
+            unindexed_sequence_turn_count += 1
+            continue
+        receipts_by_sequence.setdefault(sequence_ref, {}).setdefault(
+            max(1, turn_index), []
+        ).append(item)
+    if receipts_by_sequence:
+        committed_by_sequence = [
+            sum(
+                all(
+                    isinstance(item.get("checks"), dict)
+                    and item["checks"].get("turn_transaction_committed") is True
+                    for item in turn_receipts
+                )
+                for turn_receipts in sequence_receipts.values()
+            )
+            for sequence_receipts in receipts_by_sequence.values()
+        ]
+        aggregate.update(
+            {
+                "turn_sequence_count": len(receipts_by_sequence),
+                "turn_sequence_refs": sorted(receipts_by_sequence)[:12],
+                "max_observed_turn_count_per_sequence": max(
+                    len(sequence_receipts)
+                    for sequence_receipts in receipts_by_sequence.values()
+                ),
+                "max_committed_turn_count_per_sequence": max(committed_by_sequence),
+                "multi_turn_sequence_committed": max(committed_by_sequence) >= 2,
+                "unattributed_turn_count": unattributed_turn_count,
+                "unindexed_sequence_turn_count": unindexed_sequence_turn_count,
+            }
+        )
+    return aggregate
 
 
 def _aggregate_validations(validations: list[dict[str, Any]]) -> dict[str, Any]:

--- a/loopx/benchmark_adapters/skillsbench_turn_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_runtime.py
@@ -295,12 +295,12 @@ def _agent_result(value: str | SkillsBenchTurnAgentResult) -> tuple[str, dict[st
     return str(value), {}
 
 
-def _verified_bridge_write_progress(value: Mapping[str, Any]) -> bool:
-    count = value.get("successful_task_file_write_count")
+def _verified_bridge_content_progress(value: Mapping[str, Any]) -> bool:
+    count = value.get("successful_task_file_change_count")
     return bool(
         value.get("schema_version")
         == "skillsbench_bridge_task_progress_receipt_v0"
-        and value.get("status") == "verified_task_file_write"
+        and value.get("status") == "verified_task_content_change"
         and isinstance(count, int)
         and not isinstance(count, bool)
         and count > 0
@@ -468,7 +468,7 @@ def run_skillsbench_loopx_turn(
             completion_satisfied = completion_result.get("ok") is True
             progress_detected = bool(
                 exit_code == config.progress_exit_code
-                or _verified_bridge_write_progress(agent_progress_evidence)
+                or _verified_bridge_content_progress(agent_progress_evidence)
             )
             stability_validation_evidence = {
                 "stability_progress_detected": progress_detected,
@@ -505,21 +505,21 @@ def run_skillsbench_loopx_turn(
             }
         validation_succeeded = exit_code in {0, config.progress_exit_code}
         if not validation_succeeded:
-            if _verified_bridge_write_progress(agent_progress_evidence):
+            if _verified_bridge_content_progress(agent_progress_evidence):
                 effective_step_kind = sequence_step_kind
                 if effective_step_kind == "validator":
                     effective_step_kind = "progress"
                 if effective_step_kind == "terminal":
                     return {
                         "status": "passed",
-                        "validator_kind": "skillsbench_bridge_write_progress",
-                        "summary": "independent task-facing bridge write validated progress",
+                        "validator_kind": "skillsbench_bridge_content_progress",
+                        "summary": "independent task-facing content change validated progress",
                         "exit_code": 0,
                     }
                 return {
                     "status": "progress",
-                    "validator_kind": "skillsbench_bridge_write_progress",
-                    "summary": "independent task-facing bridge write validated progress",
+                    "validator_kind": "skillsbench_bridge_content_progress",
+                    "summary": "independent task-facing content change validated progress",
                     "exit_code": config.progress_exit_code,
                 }
             return {
@@ -622,10 +622,13 @@ def run_skillsbench_loopx_turn(
     validation_passed = validation_status in {"passed", "progress"}
     terminal_complete = validation_status == "passed"
     validated_progress = validation_status in {"passed", "progress"}
-    bridge_write_progress = _verified_bridge_write_progress(agent_progress_evidence)
+    bridge_content_progress = _verified_bridge_content_progress(agent_progress_evidence)
     write_count = agent_progress_evidence.get("successful_task_file_write_count")
     if not isinstance(write_count, int) or isinstance(write_count, bool):
         write_count = 0
+    change_count = agent_progress_evidence.get("successful_task_file_change_count")
+    if not isinstance(change_count, int) or isinstance(change_count, bool):
+        change_count = 0
     scored_validation = {
         "schema_version": "skillsbench_scored_workspace_validation_v0",
         "status": ("passed" if validation_passed else "failed"),
@@ -657,14 +660,15 @@ def run_skillsbench_loopx_turn(
             stability_validation_evidence.get("stability_completion_satisfied") is True
         ),
         "baseline_contract": (
-            "task_declared_independent_postcondition_or_verified_bridge_write"
+            "task_declared_independent_postcondition_or_verified_content_change"
         ),
         "progress_evidence_kind": (
-            "verified_task_file_write"
-            if bridge_write_progress
+            "verified_task_content_change"
+            if bridge_content_progress
             else "scored_workspace_command"
         ),
         "successful_task_file_write_count": max(0, write_count),
+        "successful_task_file_change_count": max(0, change_count),
         "oracle_feedback_used": False,
         "meaningful_operation_count": bridge.meaningful_operation_count,
         "raw_validator_output_recorded": False,

--- a/loopx/benchmark_adapters/skillsbench_turn_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_runtime.py
@@ -690,6 +690,9 @@ def run_skillsbench_loopx_turn_sequence(
             "SkillsBench terminal policy must be validator, fixed-n, or stability"
         )
     sequence_id = uuid.uuid4().hex[:16]
+    turn_sequence_ref = (
+        "sequence:" + hashlib.sha256(sequence_id.encode("utf-8")).hexdigest()[:16]
+    )
     sequence_baseline_path = (
         f"{config.case_runtime_root.rstrip('/')}"
         f"/benchmark-turn-sequences/{sequence_id}.baseline"
@@ -734,6 +737,7 @@ def run_skillsbench_loopx_turn_sequence(
             sequence_step_kind=sequence_step_kind,
         )
         validation["turn_index"] = turn_index
+        validation["turn_sequence_ref"] = turn_sequence_ref
         records.append((execution, validation))
         if execution.get("status") != "committed":
             stop_reason = "turn_not_committed"
@@ -755,6 +759,7 @@ def run_skillsbench_loopx_turn_sequence(
         "status": stop_reason,
         "turn_count": len(records),
         "max_turns": config.max_turns,
+        "turn_sequence_ref": turn_sequence_ref,
         "terminal_policy": config.terminal_policy,
         "terminal_complete": stop_reason == "terminal_complete",
         "official_feedback_blinded": True,
@@ -804,7 +809,7 @@ def build_skillsbench_benchmark_runner_readiness(
     }
     blockers = [name for name, passed in checks.items() if not passed]
     turn_proven = all(checks[name] for name in LOOPX_TURN_PROOF_CHECKS)
-    return {
+    receipt = {
         "schema_version": "skillsbench_benchmark_runner_readiness_v0",
         "capability": "benchmark_runner",
         "status": "ready" if not blockers else "blocked",
@@ -820,6 +825,15 @@ def build_skillsbench_benchmark_runner_readiness(
         "credential_values_recorded": False,
         "local_paths_recorded": False,
     }
+    turn_sequence_ref = scored_workspace_validation.get("turn_sequence_ref")
+    if isinstance(turn_sequence_ref, str) and re.fullmatch(
+        r"sequence:[0-9a-f]{16}", turn_sequence_ref
+    ):
+        receipt["turn_sequence_ref"] = turn_sequence_ref
+    turn_index = scored_workspace_validation.get("turn_index")
+    if isinstance(turn_index, int) and not isinstance(turn_index, bool):
+        receipt["turn_index"] = max(1, turn_index)
+    return receipt
 
 
 def build_skillsbench_loopx_turn_trace(

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -71,7 +71,7 @@ Optional env:
                                        Validator code for intermediate progress,
                                        default 10; 0 remains terminal completion
   SKILLSBENCH_LOOPX_TURN_TERMINAL_POLICY
-                                       validator (default) or fixed-n
+                                       validator (default), fixed-n, or stability
   SKILLSBENCH_BUILD_STALL_TIMEOUT_SEC  Setup stall timeout, default 3600;
                                        0 disables cap
   SKILLSBENCH_RUN_TIMEOUT_SEC          Supervisor timeout, default 28800

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -97,6 +97,33 @@ def test_turn_launcher_wires_private_commands_without_echoing_values(
     assert "sentinel-" not in output
 
 
+def test_turn_launcher_accepts_stability_policy(tmp_path: Path) -> None:
+    env = _base_env(tmp_path)
+    validator = "private-validator-command sentinel-validator"
+    env.update(
+        {
+            "SKILLSBENCH_ROUTE": "loopx-turn-agent-cli",
+            "SKILLSBENCH_LOOPX_TURN_VALIDATION_COMMAND": validator,
+            "SKILLSBENCH_LOOPX_TURN_MAX_TURNS": "4",
+            "SKILLSBENCH_LOOPX_TURN_TERMINAL_POLICY": "stability",
+        }
+    )
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "stability-wiring"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+
+    assert "loopx_turn_max_turns=4" in proc.stdout
+    assert "loopx_turn_terminal_policy=stability" in proc.stdout
+    assert validator not in proc.stdout
+
+
 def test_instrumented_agent_bridge_requires_an_explicit_agent_command(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_skillsbench_turn_runtime.py
+++ b/tests/test_skillsbench_turn_runtime.py
@@ -184,7 +184,7 @@ def test_nonzero_validation_probe_does_not_return_private_output(
     assert "private" not in json.dumps(result)
 
 
-def test_bridge_progress_receipt_requires_successful_task_file_write(
+def test_bridge_progress_receipt_requires_successful_task_content_change(
     tmp_path: Path,
 ) -> None:
     summary_path = tmp_path / "bridge-summary.jsonl"
@@ -221,6 +221,7 @@ def test_bridge_progress_receipt_requires_successful_task_file_write(
             "operation": "write_file",
             "task_facing_operation": True,
             "durable_task_write": True,
+            "durable_task_content_changed": True,
             "success": True,
             "returncode": 0,
         },
@@ -234,10 +235,11 @@ def test_bridge_progress_receipt_requires_successful_task_file_write(
 
     assert receipt == {
         "schema_version": "skillsbench_bridge_task_progress_receipt_v0",
-        "status": "verified_task_file_write",
+        "status": "verified_task_content_change",
         "task_facing_operation_count": 4,
         "task_facing_success_count": 3,
         "successful_task_file_write_count": 1,
+        "successful_task_file_change_count": 1,
         "raw_material_recorded": False,
     }
 
@@ -246,12 +248,34 @@ def test_instrumented_bridge_emits_durable_root_without_raw_path(
     tmp_path: Path,
 ) -> None:
     fake_bridge = tmp_path / "fake-bridge"
+    bridge_state = tmp_path / "bridge-state.json"
     fake_bridge.write_text(
         "#!/usr/bin/env python3\n"
-        "import json, sys\n"
+        "import json, shlex, sys\n"
+        "from pathlib import Path\n"
+        f"state_path = Path({str(bridge_state)!r})\n"
+        "state = json.loads(state_path.read_text()) if state_path.exists() else {}\n"
         "request = json.loads(sys.stdin.read())\n"
-        "ok = not str(request.get('path', '')).endswith('failed.txt')\n"
-        "print(json.dumps({'ok': ok, 'exit_code': 0}))\n",
+        "operation = request.get('operation')\n"
+        "path = str(request.get('path', ''))\n"
+        "if operation == 'exec':\n"
+        "    tokens = shlex.split(str(request.get('command', '')))\n"
+        "    path = tokens[-1] if len(tokens) >= 3 else ''\n"
+        "    ok = path in state\n"
+        "    response = {'ok': ok, 'exit_code': 0 if ok else 1}\n"
+        "elif operation == 'read_file':\n"
+        "    ok = path in state\n"
+        "    response = {'ok': ok, 'exit_code': 0 if ok else 1, "
+        "'content': state.get(path, ''), 'content_truncated': False}\n"
+        "elif operation == 'write_file':\n"
+        "    ok = not path.endswith('failed.txt')\n"
+        "    if ok:\n"
+        "        state[path] = str(request.get('content', ''))\n"
+        "        state_path.write_text(json.dumps(state))\n"
+        "    response = {'ok': ok, 'exit_code': 0 if ok else 1}\n"
+        "else:\n"
+        "    response = {'ok': True, 'exit_code': 0}\n"
+        "print(json.dumps(response))\n",
         encoding="utf-8",
     )
     fake_bridge.chmod(0o755)
@@ -268,6 +292,16 @@ def test_instrumented_bridge_emits_durable_root_without_raw_path(
             "operation": "write_file",
             "path": "/root/task-output.txt",
             "content": "private task output",
+        },
+        {
+            "operation": "write_file",
+            "path": "/root/task-output.txt",
+            "content": "private task output",
+        },
+        {
+            "operation": "write_file",
+            "path": "/root/task-output.txt",
+            "content": "updated private task output",
         },
         {
             "operation": "write_file",
@@ -293,30 +327,34 @@ def test_instrumented_bridge_emits_durable_root_without_raw_path(
     receipt = bridge_summary.bridge_summary_task_progress_receipt(summary_path)
     summary_text = summary_path.read_text(encoding="utf-8")
 
-    assert receipt["successful_task_file_write_count"] == 1
-    assert receipt["status"] == "verified_task_file_write"
+    assert receipt["successful_task_file_write_count"] == 3
+    assert receipt["successful_task_file_change_count"] == 2
+    assert receipt["status"] == "verified_task_content_change"
     assert '"durable_task_write_root": "root"' in summary_text
     assert "/root/task-output.txt" not in summary_text
     assert "/tmp/temporary-note.txt" not in summary_text
     assert "/root/failed.txt" not in summary_text
     assert "private task output" not in summary_text
+    assert "updated private task output" not in summary_text
     assert "temporary private note" not in summary_text
     assert "failed private output" not in summary_text
     assert '"failure_category": "bridge_operation_failed"' in summary_text
 
 
 @pytest.mark.parametrize(
-    ("write_count", "raw_material_recorded", "expected_status"),
+    ("write_count", "change_count", "raw_material_recorded", "expected_status"),
     [
-        (1, False, "committed"),
-        (0, False, "failed"),
-        (1, True, "failed"),
+        (1, 1, False, "committed"),
+        (1, 0, False, "failed"),
+        (0, 0, False, "failed"),
+        (1, 1, True, "failed"),
     ],
 )
-def test_bridge_write_progress_can_commit_when_workspace_command_cannot(
+def test_bridge_content_progress_can_commit_when_workspace_command_cannot(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     write_count: int,
+    change_count: int,
     raw_material_recorded: bool,
     expected_status: str,
 ) -> None:
@@ -361,13 +399,14 @@ def test_bridge_write_progress_can_commit_when_workspace_command_cannot(
     evidence = {
         "schema_version": "skillsbench_bridge_task_progress_receipt_v0",
         "status": (
-            "verified_task_file_write"
-            if write_count and not raw_material_recorded
+            "verified_task_content_change"
+            if change_count and not raw_material_recorded
             else "no_verified_task_mutation"
         ),
         "task_facing_operation_count": 4,
         "task_facing_success_count": 4,
         "successful_task_file_write_count": write_count,
+        "successful_task_file_change_count": change_count,
         "raw_material_recorded": raw_material_recorded,
     }
 
@@ -390,9 +429,10 @@ def test_bridge_write_progress_can_commit_when_workspace_command_cannot(
     if expected_status == "committed":
         assert validation["status"] == "passed"
         assert validation["post_agent_postcondition_status"] == "progress_validated"
-        assert validation["validator_kind"] == "skillsbench_bridge_write_progress"
-        assert validation["progress_evidence_kind"] == "verified_task_file_write"
+        assert validation["validator_kind"] == "skillsbench_bridge_content_progress"
+        assert validation["progress_evidence_kind"] == "verified_task_content_change"
         assert validation["successful_task_file_write_count"] == 1
+        assert validation["successful_task_file_change_count"] == 1
     else:
         assert validation["status"] == "failed"
         assert validation["post_agent_postcondition_status"] == "unsatisfied"

--- a/tests/test_skillsbench_turn_runtime.py
+++ b/tests/test_skillsbench_turn_runtime.py
@@ -698,6 +698,8 @@ def test_stability_sequence_repeats_repairs_then_stops_after_no_change(
         record[1]["stability_completion_satisfied"] is True for record in records
     )
     assert all(record[1]["sequence_baseline_configured"] is True for record in records)
+    sequence_refs = {record[1]["turn_sequence_ref"] for record in records}
+    assert sequence_refs == {sequence["turn_sequence_ref"]}
     assert sequence_baseline_paths[0] not in json.dumps(records, sort_keys=True)
     assert all(
         not any(key.startswith("stability_") for key in execution["validation"])
@@ -1475,6 +1477,8 @@ def test_runner_readiness_survives_public_trace_aggregation() -> None:
             "post_agent_postcondition_status": "satisfied",
             "baseline_contract": "task_declared_independent_postcondition",
             "terminal_policy": "fixed-n",
+            "turn_sequence_ref": "sequence:aaaaaaaaaaaaaaaa",
+            "turn_index": 1,
             "oracle_feedback_used": False,
         },
     )
@@ -1492,6 +1496,8 @@ def test_runner_readiness_survives_public_trace_aggregation() -> None:
             "post_agent_postcondition_status": "satisfied",
             "baseline_contract": "task_declared_independent_postcondition",
             "terminal_policy": "fixed-n",
+            "turn_sequence_ref": "sequence:aaaaaaaaaaaaaaaa",
+            "turn_index": 2,
             "oracle_feedback_used": False,
         },
     )
@@ -1515,9 +1521,60 @@ def test_runner_readiness_survives_public_trace_aggregation() -> None:
     assert receipt["proven_turn_count"] == 2
     assert receipt["committed_turn_count"] == 2
     assert receipt["observed_turn_count"] == 2
+    assert receipt["turn_sequence_count"] == 1
+    assert receipt["max_observed_turn_count_per_sequence"] == 2
+    assert receipt["max_committed_turn_count_per_sequence"] == 2
+    assert receipt["multi_turn_sequence_committed"] is True
+    assert receipt["unattributed_turn_count"] == 0
+    assert receipt["unindexed_sequence_turn_count"] == 0
     assert receipt["blocker_codes"] == []
     assert receipt["raw_task_text_recorded"] is False
     assert (
         compact["scored_workspace_validation"]["raw_validator_output_recorded"] is False
     )
     assert compact["scored_workspace_validation"]["terminal_policy"] == "fixed-n"
+
+
+def test_runner_readiness_does_not_flatten_commits_across_turn_sequences() -> None:
+    summary = SkillsBenchTurnTraceSummary()
+    for sequence_ref in (
+        "sequence:aaaaaaaaaaaaaaaa",
+        "sequence:bbbbbbbbbbbbbbbb",
+    ):
+        for turn_index, committed in ((1, True), (2, False)):
+            trace = runtime.build_skillsbench_loopx_turn_trace(
+                route="loopx-turn-agent-cli",
+                benchmark_id="synthetic-benchmark",
+                task_id="synthetic-task",
+                execution={"status": "committed" if committed else "failed"},
+                scored_workspace_validation={
+                    "status": "passed" if committed else "failed",
+                    "validator_kind": "skillsbench_stability_postcondition",
+                    "independent": True,
+                    "pre_agent_postcondition_checked": True,
+                    "pre_agent_postcondition_status": "unsatisfied",
+                    "post_agent_postcondition_status": (
+                        "progress_validated" if committed else "unsatisfied"
+                    ),
+                    "baseline_contract": "task_declared_independent_postcondition",
+                    "terminal_policy": "stability",
+                    "turn_sequence_ref": sequence_ref,
+                    "turn_index": turn_index,
+                    "oracle_feedback_used": False,
+                },
+            )
+            summary.merge(trace, trace["boundary"])
+            summary.merge(trace, trace["boundary"])
+
+    controller_trace: dict[str, Any] = {}
+    summary.apply(controller_trace)
+    receipt = controller_trace["benchmark_runner_readiness"]
+
+    assert receipt["observed_turn_count"] == 8
+    assert receipt["committed_turn_count"] == 4
+    assert receipt["turn_sequence_count"] == 2
+    assert receipt["max_observed_turn_count_per_sequence"] == 2
+    assert receipt["max_committed_turn_count_per_sequence"] == 1
+    assert receipt["multi_turn_sequence_committed"] is False
+    assert receipt["unattributed_turn_count"] == 0
+    assert receipt["unindexed_sequence_turn_count"] == 0


### PR DESCRIPTION
## Summary
- document `stability` as a supported LoopX Turn terminal policy in the SkillsBench launcher
- add a dry-run regression proving stability4 is forwarded while the private validator remains redacted

## Validation
- `uv run --no-project --with pytest --python 3.11 pytest -q tests/test_skillsbench_turn_launcher.py` (7 passed)
- targeted Turn runtime/launcher selection (11 passed)
- `examples/skillsbench-loopx-turn-agent-cli-smoke.py`
- `loopx canary premerge --from-git-diff`: 4 catalog checks passed; benchmark-sensitive manual review hold remains

## Boundaries
No scoring, runner behavior, task semantics, uploads, submissions, raw benchmark evidence, credentials, local paths, or generated run artifacts are changed or included.