### PR TITLE
Fix deferred successor resume clearing

### DIFF
--- a/examples/control_plane/todo-deferred-capacity-cli-smoke.py
+++ b/examples/control_plane/todo-deferred-capacity-cli-smoke.py
@@ -143,7 +143,79 @@ def assert_deferred_add_and_capacity_resume() -> None:
                 todo_id
             ], ready
             assert ready["execution_obligation"]["contract"] == "deferred_resume_projection", ready
+            next_action = ready["interaction_contract"]["cli_channel"]["next_cli_actions"][0]
+            assert "--clear-resume-when" in next_action, ready
         assert state_file.read_text(encoding="utf-8") == state_before_polls
+
+        conflicting = run_cli_error(
+            registry_path,
+            "todo",
+            "update",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            todo_id,
+            "--agent-id",
+            ACTOR_AGENT_ID,
+            "--resume-when",
+            CAPACITY_RESUME,
+            "--clear-resume-when",
+        )
+        assert (
+            "either --resume-when or --clear-resume-when" in conflicting["error"]
+        ), conflicting
+
+        still_deferred = run_cli_error(
+            registry_path,
+            "todo",
+            "update",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            todo_id,
+            "--agent-id",
+            ACTOR_AGENT_ID,
+            "--clear-resume-when",
+        )
+        assert (
+            "transition to deferred requires --resume-when" in still_deferred["error"]
+        ), still_deferred
+
+        reopened = run_cli(
+            registry_path,
+            "todo",
+            "update",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            todo_id,
+            "--agent-id",
+            ACTOR_AGENT_ID,
+            "--status",
+            "open",
+            "--clear-resume-when",
+            "--note",
+            "capacity condition was satisfied",
+        )
+        assert (
+            reopened["status"] == "open" and reopened["resume_when"] is None
+        ), reopened
+        item = next(item for item in parsed_items(state_file) if item["todo_id"] == todo_id)
+        assert item["status"] == "open" and item.get("resume_when") is None, item
+
+        runnable = run_cli(
+            registry_path,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            ACTOR_AGENT_ID,
+            "--available-capability",
+            "short_pool",
+        )
+        assert runnable["effective_action"] == "normal_run", runnable
+        assert runnable["selected_todo"]["todo_id"] == todo_id, runnable
 
 
 def assert_open_to_deferred_update() -> None:

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -293,6 +293,14 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
     todo_parser.add_argument(
+        "--clear-resume-when",
+        action="store_true",
+        help=(
+            "For todo update, remove the existing resume condition after its "
+            "successor replan has made the todo runnable."
+        ),
+    )
+    todo_parser.add_argument(
         "--monitor-target-key",
         dest="monitor_target_key",
         help=(
@@ -676,6 +684,7 @@ def handle_todo_command(
                 args.unblocks_todo_id,
                 args.successor_todo_ids,
                 args.resume_when,
+                args.clear_resume_when,
                 args.no_follow_up,
                 args.monitor_target_key,
                 args.cadence,
@@ -742,6 +751,7 @@ def handle_todo_command(
                 unblocks_todo_id=args.unblocks_todo_id,
                 successor_todo_ids=args.successor_todo_ids,
                 resume_when=args.resume_when,
+                clear_resume_when=bool(args.clear_resume_when),
                 no_followup=True if args.no_follow_up else None,
                 monitor_metadata={
                     "target_key": args.monitor_target_key,

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -38,6 +38,7 @@ TODO_OPTION_FIELDS = (
     ("--unblocks-todo-id", "unblocks_todo_id"),
     ("--successor-todo-id", "successor_todo_ids"),
     ("--resume-when", "resume_when"),
+    ("--clear-resume-when", "clear_resume_when"),
     ("--monitor-target-key", "monitor_target_key"),
     ("--cadence", "cadence"),
     ("--next-due-at", "next_due_at"),
@@ -127,6 +128,12 @@ def validate_shared_todo_options(args: argparse.Namespace) -> None:
     if args.clear_global_gate and not clear_global_gate_allowed:
         raise ValueError(
             "--clear-global-gate is supported only by todo update for user_gate items"
+        )
+    if args.clear_resume_when and args.todo_command != "update":
+        raise ValueError("--clear-resume-when is supported only by todo update")
+    if args.clear_resume_when and args.resume_when:
+        raise ValueError(
+            "todo update accepts either --resume-when or --clear-resume-when, not both"
         )
     if (
         args.todo_command not in {"suggest", "capture-followups"}

--- a/loopx/control_plane/todos/line_update.py
+++ b/loopx/control_plane/todos/line_update.py
@@ -94,6 +94,7 @@ def apply_todo_update_to_lines(
     unblocks_todo_id: str | None = None,
     successor_todo_ids: list[str] | None = None,
     resume_when: str | None = None,
+    clear_resume_when: bool = False,
     no_followup: bool | None = None,
     monitor_metadata: dict[str, Any] | None = None,
     clear_claim: bool = False,
@@ -101,6 +102,10 @@ def apply_todo_update_to_lines(
     updated_at: str,
 ) -> dict[str, Any]:
     normalized_resume_when = require_supported_todo_resume_when(resume_when)
+    if normalized_resume_when and clear_resume_when:
+        raise ValueError(
+            "todo update accepts either resume_when or clear_resume_when, not both"
+        )
     normalized_todo_id = normalize_todo_id(todo_id)
     if not normalized_todo_id:
         raise ValueError(
@@ -139,6 +144,8 @@ def apply_todo_update_to_lines(
     if status and not normalized_status:
         raise ValueError("todo status must be one of: open, done, blocked, deferred")
     target_status = normalized_status or str(block.get("status") or TODO_STATUS_OPEN)
+    if target_status == "deferred" and clear_resume_when:
+        raise ValueError("cannot clear resume_when while todo status remains deferred")
     if claim_only and target_status != TODO_STATUS_OPEN:
         raise ValueError(
             f"todo claim requires status=open; todo_id {normalized_todo_id!r} "
@@ -218,7 +225,9 @@ def apply_todo_update_to_lines(
         updates["unblocks_todo_id"] = unblocks_todo_id
     if successor_todo_ids is not None:
         updates["successor_todo_ids"] = successor_todo_ids
-    if normalized_resume_when:
+    if clear_resume_when:
+        updates["resume_when"] = None
+    elif normalized_resume_when:
         updates["resume_when"] = normalized_resume_when
     if no_followup is not None:
         updates["no_followup"] = no_followup

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -620,7 +620,11 @@ def interaction_next_cli_actions(
         first_candidate = candidates[0] if candidates and isinstance(candidates[0], dict) else {}
         todo_id = str(first_candidate.get("todo_id") or "<todo_id>")
         return [
-            f"loopx todo update --goal-id {goal_id} --todo-id {todo_id}{lifecycle_actor_args} --status open --note '<public-safe successor replan reason>'",
+            (
+                f"loopx todo update --goal-id {goal_id} --todo-id {todo_id}"
+                f"{lifecycle_actor_args} --status open --clear-resume-when "
+                "--note '<public-safe successor replan reason>'"
+            ),
             f"loopx refresh-state --goal-id {goal_id} --classification successor_replan_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress{scoped_cli_args}",
             f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{scoped_cli_args}",
         ]

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -1078,6 +1078,7 @@ def update_goal_todo(
     unblocks_todo_id: str | None = None,
     successor_todo_ids: list[str] | None = None,
     resume_when: str | None = None,
+    clear_resume_when: bool = False,
     no_followup: bool | None = None,
     monitor_metadata: dict[str, Any] | None = None,
     clear_claim: bool = False,
@@ -1094,6 +1095,10 @@ def update_goal_todo(
         raise ValueError("todo update accepts either blocks_agent or clear_blocks_agent, not both")
     if bound_agent and goal_bound:
         raise ValueError("todo update accepts either bound_agent or goal_bound, not both")
+    if resume_when and clear_resume_when:
+        raise ValueError(
+            "todo update accepts either resume_when or clear_resume_when, not both"
+        )
     resolved_project, resolved_state_file = resolve_todo_state_path(
         registry_path=registry_path,
         goal_id=goal_id,
@@ -1165,7 +1170,7 @@ def update_goal_todo(
                 bound_agent, goal_bound,
                 excluded_agents, clear_excluded_agents, global_gate,
                 clear_global_gate, unblocks_todo_id, successor_todo_ids,
-                resume_when, no_followup,
+                resume_when, clear_resume_when, no_followup,
             ),
             monitor_metadata=monitor_metadata,
         )
@@ -1292,10 +1297,13 @@ def update_goal_todo(
         if successor_todo_ids and not normalized_successor_todo_ids:
             raise ValueError("successor_todo_ids must contain public todo_<letters-digits-underscore-hyphen> tokens")
         normalized_resume_when = require_supported_todo_resume_when(resume_when)
-        effective_resume_when = normalized_resume_when or normalize_supported_todo_resume_when(
-            existing_block.get("resume_when")
+        effective_resume_when = (
+            None
+            if clear_resume_when
+            else normalized_resume_when
+            or normalize_supported_todo_resume_when(existing_block.get("resume_when"))
         )
-        if status and target_status == TODO_STATUS_DEFERRED and not effective_resume_when:
+        if target_status == TODO_STATUS_DEFERRED and not effective_resume_when:
             raise ValueError("transition to deferred requires --resume-when with a supported condition")
         normalized_monitor_metadata = require_monitor_metadata_scope(
             monitor_metadata=monitor_metadata,
@@ -1340,6 +1348,7 @@ def update_goal_todo(
             unblocks_todo_id=normalized_unblocks_todo_id,
             successor_todo_ids=normalized_successor_todo_ids if successor_todo_ids is not None else None,
             resume_when=normalized_resume_when,
+            clear_resume_when=clear_resume_when,
             no_followup=no_followup,
             monitor_metadata=normalized_monitor_metadata,
             clear_claim=clear_claim,


### PR DESCRIPTION
## Summary

- add an explicit `todo update --clear-resume-when` transition
- make generated successor-replan actions clear the consumed resume condition when reopening work
- fail closed when callers try to clear a condition while the todo remains deferred
- extend the durable capacity-resume CLI smoke through the next runnable quota decision

## Validation

- `examples/control_plane/todo-deferred-capacity-cli-smoke.py`
- `examples/control_plane/interaction-contract-state-machine-smoke.py`
- focused pytest: 20 passed
- `ruff check` on all changed Python files
- `loopx canary premerge --from-git-diff`: passed 18/18, public boundary clean, no manual holds, self-merge allowed

No benchmark jobs were launched and no scoring, verifier, permission, or scheduler behavior changed.