### PR TITLE
refactor(todo): extract successor argument registration

### DIFF
--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -23,6 +23,8 @@ from ..todos import (
     update_goal_todo,
 )
 from .todo_argument_validation import (
+    register_todo_linkage_arguments,
+    register_todo_successor_creation_arguments,
     unsupported_todo_options,
     validate_capability_gap_options,
     validate_shared_todo_options,
@@ -266,40 +268,7 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
             "an explicit lane scope."
         ),
     )
-    todo_parser.add_argument(
-        "--unblocks-todo-id",
-        help=(
-            "For todo add/update, link this todo to the blocked todo it unblocks, "
-            "for example todo_ab12cd34ef56. Completing an exactly linked user_gate "
-            "also consumes the target required decision scopes covered by that gate."
-        ),
-    )
-    todo_parser.add_argument(
-        "--successor-todo-id",
-        dest="successor_todo_ids",
-        action="append",
-        help=(
-            "For todo update/complete, link an existing successor todo to the "
-            "current todo. Repeat for multiple successors."
-        ),
-    )
-    todo_parser.add_argument(
-        "--resume-when",
-        help=(
-            "For deferred todo add/update, declare a machine-readable resume condition "
-            "such as todo_done:todo_ab12cd34ef56, pr_merged:#532, or "
-            "capacity_available:short_pool. Capacity keys are resolved from quota "
-            "--available-capability declarations."
-        ),
-    )
-    todo_parser.add_argument(
-        "--clear-resume-when",
-        action="store_true",
-        help=(
-            "For todo update, remove the existing resume condition after its "
-            "successor replan has made the todo runnable."
-        ),
-    )
+    register_todo_linkage_arguments(todo_parser)
     todo_parser.add_argument(
         "--monitor-target-key",
         dest="monitor_target_key",
@@ -344,71 +313,7 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
             "when a completed todo intentionally has no successor."
         ),
     )
-    todo_parser.add_argument("--next-agent-todo", help="For complete/supersede, atomically add or update the next agent todo.")
-    todo_parser.add_argument("--next-user-todo", help="For complete/supersede, atomically add or update the next user todo.")
-    todo_parser.add_argument(
-        "--next-user-task-class",
-        choices=["user_gate", "user_action"],
-        help=(
-            "Task class for --next-user-todo. Defaults to user_gate for backward "
-            "compatibility; use user_action for a visible reminder that must not "
-            "block the bound agent lane."
-        ),
-    )
-    todo_parser.add_argument(
-        "--next-claimed-by",
-        help=(
-            "For complete/supersede with --next-agent-todo, soft-claim the successor "
-            "todo for a registered agent. Independent handoffs remain unclaimed unless "
-            "explicitly assigned, while same-agent non-delivery "
-            "continuations keep the current owner. Use --self-merged with --evidence "
-            "for an eligible same-agent delivery."
-        ),
-    )
-    todo_parser.add_argument(
-        "--self-merged",
-        action="store_true",
-        help=(
-            "For todo complete, record that a small validated change was self-merged; "
-            "requires --evidence."
-        ),
-    )
-    todo_parser.add_argument(
-        "--next-task-class",
-        choices=["advancement_task", "continuous_monitor", "blocker"],
-        help="Task class for --next-agent-todo. Defaults to advancement_task.",
-    )
-    todo_parser.add_argument("--next-action-kind", help="Action kind for --next-agent-todo.")
-    todo_parser.add_argument(
-        "--next-task-repository",
-        help=(
-            "Credential-free Git repository identity for --next-agent-todo, such as "
-            "git:github.com/owner/repo."
-        ),
-    )
-    todo_parser.add_argument(
-        "--next-required-capability",
-        dest="next_required_capabilities",
-        action="append",
-        help=(
-            "Execution capability required by --next-agent-todo. Repeat for multiple "
-            "capabilities."
-        ),
-    )
-    todo_parser.add_argument(
-        "--next-continuation-policy",
-        choices=sorted(TODO_CONTINUATION_POLICY_VALUES),
-        help="Continuation policy for --next-agent-todo.",
-    )
-    todo_parser.add_argument(
-        "--next-excluded-agent",
-        dest="next_excluded_agents",
-        action="append",
-        help=(
-            "For complete/supersede with --next-agent-todo, exclude one registered "
-            "peer from claiming or executing the successor. Repeat for multiple peers."
-        ),
-    )
+    register_todo_successor_creation_arguments(todo_parser)
     todo_parser.add_argument(
         "--max-active-done",
         type=int,

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import argparse
 from collections.abc import Iterable
 
+from ..control_plane.todos.contract import TODO_CONTINUATION_POLICY_VALUES
+
 
 TODO_OPTION_FIELDS = (
     ("--role", "role"),
@@ -63,6 +65,124 @@ TODO_OPTION_FIELDS = (
     ("--state-file", "state_file"),
     ("--execute", "execute"),
 )
+
+
+def register_todo_linkage_arguments(
+    todo_parser: argparse.ArgumentParser,
+) -> None:
+    todo_parser.add_argument(
+        "--unblocks-todo-id",
+        help=(
+            "For todo add/update, link this todo to the blocked todo it unblocks, "
+            "for example todo_ab12cd34ef56. Completing an exactly linked user_gate "
+            "also consumes the target required decision scopes covered by that gate."
+        ),
+    )
+    todo_parser.add_argument(
+        "--successor-todo-id",
+        dest="successor_todo_ids",
+        action="append",
+        help=(
+            "For todo update/complete, link an existing successor todo to the "
+            "current todo. Repeat for multiple successors."
+        ),
+    )
+    todo_parser.add_argument(
+        "--resume-when",
+        help=(
+            "For deferred todo add/update, declare a machine-readable resume condition "
+            "such as todo_done:todo_ab12cd34ef56, pr_merged:#532, or "
+            "capacity_available:short_pool. Capacity keys are resolved from quota "
+            "--available-capability declarations."
+        ),
+    )
+    todo_parser.add_argument(
+        "--clear-resume-when",
+        action="store_true",
+        help=(
+            "For todo update, remove the existing resume condition after its "
+            "successor replan has made the todo runnable."
+        ),
+    )
+
+
+def register_todo_successor_creation_arguments(
+    todo_parser: argparse.ArgumentParser,
+) -> None:
+    todo_parser.add_argument(
+        "--next-agent-todo",
+        help="For complete/supersede, atomically add or update the next agent todo.",
+    )
+    todo_parser.add_argument(
+        "--next-user-todo",
+        help="For complete/supersede, atomically add or update the next user todo.",
+    )
+    todo_parser.add_argument(
+        "--next-user-task-class",
+        choices=["user_gate", "user_action"],
+        help=(
+            "Task class for --next-user-todo. Defaults to user_gate for backward "
+            "compatibility; use user_action for a visible reminder that must not "
+            "block the bound agent lane."
+        ),
+    )
+    todo_parser.add_argument(
+        "--next-claimed-by",
+        help=(
+            "For complete/supersede with --next-agent-todo, soft-claim the successor "
+            "todo for a registered agent. Independent handoffs remain unclaimed unless "
+            "explicitly assigned, while same-agent non-delivery continuations keep the "
+            "current owner. Use --self-merged with --evidence for an eligible same-agent "
+            "delivery."
+        ),
+    )
+    todo_parser.add_argument(
+        "--self-merged",
+        action="store_true",
+        help=(
+            "For todo complete, record that a small validated change was self-merged; "
+            "requires --evidence."
+        ),
+    )
+    todo_parser.add_argument(
+        "--next-task-class",
+        choices=["advancement_task", "continuous_monitor", "blocker"],
+        help="Task class for --next-agent-todo. Defaults to advancement_task.",
+    )
+    todo_parser.add_argument(
+        "--next-action-kind",
+        help="Action kind for --next-agent-todo.",
+    )
+    todo_parser.add_argument(
+        "--next-task-repository",
+        help=(
+            "Credential-free Git repository identity for --next-agent-todo, such as "
+            "git:github.com/owner/repo."
+        ),
+    )
+    todo_parser.add_argument(
+        "--next-required-capability",
+        dest="next_required_capabilities",
+        action="append",
+        help=(
+            "Execution capability required by --next-agent-todo. Repeat for multiple "
+            "capabilities."
+        ),
+    )
+    todo_parser.add_argument(
+        "--next-continuation-policy",
+        choices=sorted(TODO_CONTINUATION_POLICY_VALUES),
+        help="Continuation policy for --next-agent-todo.",
+    )
+    todo_parser.add_argument(
+        "--next-excluded-agent",
+        dest="next_excluded_agents",
+        action="append",
+        help=(
+            "For complete/supersede with --next-agent-todo, exclude one registered "
+            "peer from claiming or executing the successor. Repeat for multiple peers."
+        ),
+    )
 
 
 def unsupported_todo_options(


### PR DESCRIPTION
## Summary
- move todo linkage and deferred-successor argparse registration into the existing argument-validation owner
- keep option order, help text, defaults, and validation behavior unchanged
- reduce `loopx/cli_commands/todo.py` from 1010 to 915 lines, restoring the 1000-line ownership budget on latest `main`

## Validation
- `loopx canary premerge --from-git-diff` (17/17 checks passed; 0 manual holds)
- `python3.11 examples/control_plane/todo-deferred-capacity-cli-smoke.py`
- `python3.11 examples/control_plane/todo-cli-smoke.py`
- `python3.11 examples/control_plane/todo-lifecycle-cli-smoke.py`
- `python3.11 examples/cli-command-module-size-ownership-command-modularization-smoke.py`
- `uvx pytest -q tests/test_cli_argument_diagnostics.py tests/control_plane/test_cli_output_budget.py tests/control_plane/test_todo_mutation_authority.py tests/control_plane/test_todo_decision_scope_cli_validation.py` (32 passed)
- `uvx ruff check loopx/cli_commands/todo.py loopx/cli_commands/todo_argument_validation.py`
- `python3.11 -m py_compile loopx/cli_commands/todo.py loopx/cli_commands/todo_argument_validation.py`
- `git diff --check`

## Notes
- The first deferred-capacity smoke attempt used macOS system Python 3.9 and could not import `tomllib`; it was rerun with the repository Python 3.11 runtime.
- That rerun caught one omitted constant import from the extraction; the import was restored before the complete validation set above.
- No benchmark jobs were launched. The failing Full Public benchmark-only shards remain outside this repair lane.
- Public/private boundary scan found no credentials, local paths, raw logs, or internal material.

## Review focus
Please independently verify parser/help parity for linkage and successor-creation options and confirm the module ownership budget remains enforced.