### PR TITLE
Require a review Turn after validated content change

### DIFF
--- a/docs/reference/protocols/loopx-turn-v0.md
+++ b/docs/reference/protocols/loopx-turn-v0.md
@@ -244,8 +244,11 @@ Adapters that lack a separate terminal signal may declare a bounded `fixed-n`
 terminal policy. Under that policy, each successful independent validator call
 proves progress, while only a successful final configured Turn satisfies the
 sequence terminal postcondition. The default `validator` policy continues to
-interpret exit code `0` as terminal completion. The policy is explicit in
-public-safe runner prerequisites and never changes benchmark scoring.
+interpret exit code `0` as per-Turn terminal completion. Within a bounded
+multi-Turn sequence, a successful Turn that also proves a durable content
+change receives one further blinded review Turn before sequence termination;
+the next successful no-change Turn may terminate early. The policy is explicit
+in public-safe runner prerequisites and never changes benchmark scoring.
 
 ## Turn Input
 

--- a/loopx/benchmark_adapters/skillsbench_turn_route.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_route.py
@@ -124,8 +124,9 @@ def add_skillsbench_loopx_turn_arguments(parser: Any) -> None:
         default="validator",
         help=(
             "How a successful per-Turn validator closes a bounded sequence. "
-            "validator trusts exit 0 as terminal; fixed-n treats successful "
-            "steps as progress until the configured final Turn; stability "
+            "validator trusts exit 0 as terminal unless the Turn also proves "
+            "a durable content change that requires one bounded review; fixed-n "
+            "treats successful steps as progress until the configured final Turn; stability "
             "continues after exit-code progress or a verified write and stops "
             "after a no-change review whose completion postcondition passes."
         ),
@@ -313,6 +314,7 @@ def _public_validation(value: Any) -> dict[str, Any]:
         "raw_verifier_output_recorded",
         "validated_progress",
         "terminal_complete",
+        "sequence_terminal_complete",
         "sequence_baseline_configured",
         "stability_progress_detected",
         "stability_completion_checked",
@@ -519,7 +521,13 @@ def _aggregate_validations(validations: list[dict[str, Any]]) -> dict[str, Any]:
             and all(item.get("validated_progress") is True for item in validations)
         ),
         "terminal_complete": any(
-            item.get("terminal_complete") is True for item in validations
+            (
+                item.get("sequence_terminal_complete")
+                if isinstance(item.get("sequence_terminal_complete"), bool)
+                else item.get("terminal_complete")
+            )
+            is True
+            for item in validations
         ),
         "turn_count": len(validations),
         "successful_task_file_write_count": sum(

--- a/loopx/benchmark_adapters/skillsbench_turn_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_runtime.py
@@ -743,9 +743,22 @@ def run_skillsbench_loopx_turn_sequence(
         validation["turn_index"] = turn_index
         validation["turn_sequence_ref"] = turn_sequence_ref
         records.append((execution, validation))
+        verified_content_progress = bool(
+            validation.get("progress_evidence_kind")
+            == "verified_task_content_change"
+        )
+        sequence_terminal_complete = bool(
+            validation.get("terminal_complete") is True
+            and not (
+                config.terminal_policy == "validator"
+                and turn_index < config.max_turns
+                and verified_content_progress
+            )
+        )
+        validation["sequence_terminal_complete"] = sequence_terminal_complete
         if execution.get("status") != "committed":
             stop_reason = "turn_not_committed"
-        elif validation.get("terminal_complete") is True:
+        elif sequence_terminal_complete:
             stop_reason = "terminal_complete"
         elif validation.get("validated_progress") is not True:
             stop_reason = "no_validated_progress"

--- a/tests/test_skillsbench_turn_runtime.py
+++ b/tests/test_skillsbench_turn_runtime.py
@@ -652,6 +652,7 @@ def test_adaptive_sequence_commits_progress_then_terminal_turns(
 
     assert len(records) == 2
     assert sequence["status"] == "terminal_complete"
+    assert sequence["official_feedback_blinded"] is True
     assert sequence["turn_count"] == 2
     assert len(set(plan_instance_ids)) == 2
     assert plan_instance_ids[0].endswith("turn-001")
@@ -667,6 +668,61 @@ def test_adaptive_sequence_commits_progress_then_terminal_turns(
     assert records[1][1]["terminal_complete"] is True
     assert records[1][1]["sequence_stop_reason"] == "terminal_complete"
     assert len(observed) == 2
+
+
+def test_adaptive_sequence_reviews_verified_content_after_validator_success(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    progress_kinds = iter(
+        ["verified_task_content_change", "scored_workspace_command"]
+    )
+    prompts: list[str] = []
+
+    def fake_turn(**kwargs: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+        prompts.append(kwargs["prompt"])
+        return (
+            {"status": "committed"},
+            {
+                "status": "passed",
+                "validated_progress": True,
+                "terminal_complete": True,
+                "progress_evidence_kind": next(progress_kinds),
+            },
+        )
+
+    monkeypatch.setattr(runtime, "run_skillsbench_loopx_turn", fake_turn)
+
+    records, sequence = runtime.run_skillsbench_loopx_turn_sequence(
+        prompt="original task prompt",
+        agent_runner=lambda _prompt: "done",
+        config=runtime.SkillsBenchTurnRuntimeConfig(
+            **{**_config(tmp_path).__dict__, "max_turns": 4}
+        ),
+    )
+
+    assert len(records) == 2
+    assert sequence["status"] == "terminal_complete"
+    assert sequence["official_feedback_blinded"] is True
+    assert prompts[0] == "original task prompt"
+    assert "Continue the same task" in prompts[1]
+    assert records[0][1]["terminal_complete"] is True
+    assert records[0][1]["sequence_terminal_complete"] is False
+    assert records[0][1]["sequence_stop_reason"] == "continue"
+    assert records[1][1]["sequence_terminal_complete"] is True
+    assert records[1][1]["sequence_stop_reason"] == "terminal_complete"
+    first_trace = runtime.build_skillsbench_loopx_turn_trace(
+        route="loopx-turn-agent-cli",
+        benchmark_id="synthetic-benchmark",
+        task_id="synthetic-task",
+        execution=records[0][0],
+        scored_workspace_validation=records[0][1],
+    )
+    summary = SkillsBenchTurnTraceSummary()
+    summary.merge(first_trace, first_trace["boundary"])
+    controller_trace: dict[str, Any] = {}
+    summary.apply(controller_trace)
+    assert controller_trace["scored_workspace_validation"]["terminal_complete"] is False
 
 
 def test_stability_sequence_repeats_repairs_then_stops_after_no_change(


### PR DESCRIPTION
## Summary
- separate per-Turn validator completion from bounded sequence termination
- continue one blinded review Turn when a successful Turn also proves a durable content change
- project the sequence-level terminal signal through public-safe trace aggregation

## Validation
- `uv run --no-project --with pytest --python 3.11 pytest -q tests/test_skillsbench_turn_runtime.py tests/test_skillsbench_turn_launcher.py` (40 passed)
- `uv run --no-project --python 3.11 python examples/skillsbench-loopx-turn-agent-cli-smoke.py`
- Ruff on changed Python surfaces
- `loopx check` on the four changed public files (0 errors, 0 warnings)
- `loopx canary premerge --from-git-diff` completed without command failures

## Boundaries
The focused regression proves `max_turns=4` commits a second Turn after validator success plus verified content change, while official feedback remains blinded. No scoring, task semantics, benchmark launch, upload, submission, raw task material, trajectories, credentials, or local paths are changed or included.

## Hold
Premerge classifies the diff as `benchmark_sensitive`; the explicit maintainer-review hold remains and self-merge is not requested.