### PR TITLE
refactor(benchmark): separate read models from control plane

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -10,6 +10,9 @@ packets and dated route notes still live under
 `docs/research/long-horizon-agent-benchmarks/`, but reusable runner behavior
 belongs in `loopx/`, `examples/`, and this guide.
 
+For package ownership and dependency direction, see
+[`reference/benchmark-architecture.md`](reference/benchmark-architecture.md).
+
 ## Product Shape
 
 The benchmark workflow has four layers:
@@ -36,7 +39,7 @@ without seeing credentials, raw logs, raw trajectories, or local machine paths.
 From a fresh checkout:
 
 ```bash
-python3 -m py_compile loopx/*.py loopx/benchmark_core/*.py
+python3 -m py_compile loopx/*.py loopx/benchmark_core/*.py loopx/benchmarks/read_models/*.py
 python3 examples/benchmark-split-control-remote-executor-smoke.py
 loopx benchmark --help
 ```

--- a/docs/reference/benchmark-architecture.md
+++ b/docs/reference/benchmark-architecture.md
@@ -1,0 +1,57 @@
+# Benchmark Architecture
+
+Benchmark support ships as part of LoopX, but it is not part of the generic
+control-plane kernel. The package boundary follows ownership:
+
+```text
+loopx/
+  control_plane/          generic goal, todo, quota, scheduler, and turn rules
+  benchmarks/             benchmark-owned projections and qualification logic
+    read_models/          public-safe result, comparison, and debug projections
+    qualification/        benchmark-specific release qualification
+  benchmark_core/         shared harness contracts (stable legacy import path)
+  benchmark_adapters/     benchmark-family providers (stable legacy import path)
+  benchmark.py            compatibility facade and unextracted legacy behavior
+```
+
+## Why Not A Repository-Root `benchmark/` Package?
+
+LoopX publishes only `loopx*` from `pyproject.toml`. A sibling Python package
+would therefore be omitted from the distribution unless packaging and release
+ownership were split. It would also create a second product namespace for code
+whose CLI, state, history, and version lifecycle are still owned by LoopX.
+
+The useful separation is one level lower: `loopx.benchmarks` is a sibling of
+`loopx.control_plane`. This keeps one installable product while preventing the
+generic control plane from becoming the home for benchmark-specific reducers,
+comparison policy, and suite diagnostics.
+
+## Placement Rule
+
+| Code owns | Place it in |
+| --- | --- |
+| Goal, todo, quota, scheduler, transaction, or public-safety rules used without benchmarks | `loopx/control_plane/` |
+| Adapter-neutral benchmark lifecycle, launch, observation, or artifact contracts | `loopx/benchmark_core/` |
+| Public-safe benchmark result, comparison, ledger, or diagnostic projections | `loopx/benchmarks/read_models/` |
+| Benchmark-specific release qualification from compact outcomes | `loopx/benchmarks/qualification/` |
+| A named benchmark family's runner, verifier, image, route, or task convention | `loopx/benchmark_adapters/` |
+| CLI parsing and rendering for `loopx benchmark ...` | `loopx/cli_commands/benchmark_*.py` |
+| Optional runner distributed on its own lifecycle | a co-located `extensions/<extension-id>/` package or a separate repository |
+
+`loopx.benchmark_core` and `loopx.benchmark_adapters` are established import
+surfaces. Renaming them is a compatibility migration, not a directory cleanup;
+do it only with explicit aliases, deprecation coverage, and a release window.
+New benchmark-owned read models use `loopx.benchmarks` now, and no new
+benchmark-specific module should be added under `loopx.control_plane.runtime`.
+
+## Dependency Direction
+
+The control plane defines generic execution and safety contracts. Benchmark
+code may consume those contracts. Status, history, and CLI composition may
+consume both domains. A benchmark adapter must not redefine quota, todo,
+scheduler, or transaction truth, and the control-plane runtime must not import
+benchmark-specific read models.
+
+This is a product boundary, not an isolation claim: benchmark execution still
+uses LoopX state and receipts, and it remains covered by the same release and
+public-evidence policies.

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-core-adapter-contract-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-core-adapter-contract-v0.md
@@ -49,6 +49,7 @@ surfaces into smaller modules:
 | Module | Owns | Must Not Own |
 | --- | --- | --- |
 | `loopx.benchmark_core` | adapter-neutral lifecycle, round summaries, artifact/source boundary policy, JSON/number IO reducers | benchmark-specific launchers or scoring quirks |
+| `loopx.benchmarks.read_models` | public-safe benchmark result, comparison, ledger, lifecycle, and diagnostic projections | generic control-plane runtime rules or benchmark-family launch behavior |
 | `loopx.benchmark_adapters.skillsbench` | SkillsBench routes, arm semantics, job names, public-safe setup failure attribution | Terminal-Bench/ALE/AgentIssue behavior |
 | `loopx.benchmark_adapters.terminal_bench` | Terminal-Bench public constants, runner modes, CLI-bridge/access-packet labels, private-runner launch/materialization/readiness helpers, Harbor result reducers, timeout and compact validation policy constants | ALE/SkillsBench/AgentIssue behavior |
 | `loopx.benchmark_adapters.agents_last_exam` | ALE public constants, case-state path, local runner/source readiness, launch-packet, validation-gate, CUA/Codex-route, task-material and result-report helpers | Terminal-Bench/SkillsBench/AgentIssue behavior or raw ALE task material |

--- a/examples/benchmark-experiment-report-template-smoke.py
+++ b/examples/benchmark-experiment-report-template-smoke.py
@@ -13,7 +13,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from loopx.control_plane.runtime.benchmark_comparison import (  # noqa: E402
+from loopx.benchmarks.read_models.benchmark_comparison import (  # noqa: E402
     benchmark_comparison_decision_note,
 )
 

--- a/examples/benchmark-run-v0-append-cli-smoke.py
+++ b/examples/benchmark-run-v0-append-cli-smoke.py
@@ -15,7 +15,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from loopx.control_plane.runtime.benchmark_comparison import (  # noqa: E402
+from loopx.benchmarks.read_models.benchmark_comparison import (  # noqa: E402
     benchmark_comparison_decision_note,
     compact_benchmark_comparison,
 )

--- a/examples/benchmark-run-v0-status-projection-smoke.py
+++ b/examples/benchmark-run-v0-status-projection-smoke.py
@@ -18,7 +18,7 @@ if str(REPO_ROOT) not in sys.path:
 from loopx.review_packet import build_review_packet  # noqa: E402
 from loopx.presentation.renderers.status_markdown import render_status_markdown  # noqa: E402
 from loopx.status import collect_status, compact_benchmark_run  # noqa: E402
-from loopx.control_plane.runtime.benchmark_projection import (  # noqa: E402
+from loopx.benchmarks.read_models.benchmark_projection import (  # noqa: E402
     compact_benchmark_run_core,
 )
 from loopx.worker_bridge import build_worker_bridge_outcome  # noqa: E402

--- a/examples/skillsbench-typed-repair-smoke.py
+++ b/examples/skillsbench-typed-repair-smoke.py
@@ -22,7 +22,7 @@ from loopx.benchmark_adapters.skillsbench_typed_repair import (
     skillsbench_turn_recovery_checkpoint,
 )
 from loopx.benchmark import build_skillsbench_benchflow_result_benchmark_run
-from loopx.control_plane.runtime.goal_start_control_score import (
+from loopx.benchmarks.read_models.goal_start_control_score import (
     build_goal_start_product_mode_control_score,
     compact_goal_start_product_mode_control_score,
 )

--- a/loopx/benchmark_adapters/skillsbench_signals.py
+++ b/loopx/benchmark_adapters/skillsbench_signals.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..control_plane.runtime.benchmark_projection import (
+from ..benchmarks.read_models.benchmark_projection import (
     build_benchmark_solution_quality_signals,
 )
 

--- a/loopx/benchmarks/__init__.py
+++ b/loopx/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmark domain code shipped with LoopX."""

--- a/loopx/benchmarks/qualification/__init__.py
+++ b/loopx/benchmarks/qualification/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmark release qualification contracts."""

--- a/loopx/benchmarks/qualification/release_outcome_baseline.py
+++ b/loopx/benchmarks/qualification/release_outcome_baseline.py
@@ -5,8 +5,8 @@ from collections import Counter
 from statistics import fmean
 from typing import Any, Iterable, Mapping
 
-from ..runtime.benchmark_result import compact_benchmark_result
-from ..runtime.public_safety import public_safe_compact_text
+from ..read_models.benchmark_result import compact_benchmark_result
+from ...control_plane.runtime.public_safety import public_safe_compact_text
 
 
 RELEASE_OUTCOME_PAIR_MANIFEST_SCHEMA_VERSION = "release_outcome_pair_manifest_v0"

--- a/loopx/benchmarks/read_models/__init__.py
+++ b/loopx/benchmarks/read_models/__init__.py
@@ -1,0 +1,1 @@
+"""Public-safe benchmark projections and qualification read models."""

--- a/loopx/benchmarks/read_models/benchmark_attempt_accounting.py
+++ b/loopx/benchmarks/read_models/benchmark_attempt_accounting.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from .public_safety import public_safe_compact_text
+from ...control_plane.runtime.public_safety import public_safe_compact_text
 
 
 def compact_benchmark_attempt_accounting(value: Any) -> dict[str, Any]:

--- a/loopx/benchmarks/read_models/benchmark_comparison.py
+++ b/loopx/benchmarks/read_models/benchmark_comparison.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from .public_safety import public_safe_compact_list, public_safe_compact_text
+from ...control_plane.runtime.public_safety import (
+    public_safe_compact_list,
+    public_safe_compact_text,
+)
 
 BENCHMARK_COMPARISON_SCHEMA_VERSION = "benchmark_comparison_v0"
 BENCHMARK_COMPARISON_DECISION_SCHEMA_VERSION = "benchmark_comparison_decision_note_v0"

--- a/loopx/benchmarks/read_models/benchmark_event_timeline.py
+++ b/loopx/benchmarks/read_models/benchmark_event_timeline.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from .public_safety import public_safe_compact_list, public_safe_compact_text
+from ...control_plane.runtime.public_safety import (
+    public_safe_compact_list,
+    public_safe_compact_text,
+)
 
 
 MAX_BENCHMARK_EVENT_LABELS = 5

--- a/loopx/benchmarks/read_models/benchmark_experiment_report.py
+++ b/loopx/benchmarks/read_models/benchmark_experiment_report.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from .benchmark_attempt_accounting import compact_benchmark_attempt_accounting
-from .public_safety import (
+from ...control_plane.runtime.public_safety import (
     compact_numeric_map,
     public_safe_compact_list,
     public_safe_compact_text,

--- a/loopx/benchmarks/read_models/benchmark_learning_ledger.py
+++ b/loopx/benchmarks/read_models/benchmark_learning_ledger.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from typing import Any
 
 from .benchmark_comparison import compact_comparison_delta
-from .public_safety import public_safe_compact_list, public_safe_compact_text
+from ...control_plane.runtime.public_safety import (
+    public_safe_compact_list,
+    public_safe_compact_text,
+)
 
 BENCHMARK_LEARNING_LEDGER_SCHEMA_VERSION = "benchmark_learning_ledger_v0"
 MAX_BENCHMARK_LEARNING_LEDGER_LIST_ITEMS = 5

--- a/loopx/benchmarks/read_models/benchmark_lifecycle_contracts.py
+++ b/loopx/benchmarks/read_models/benchmark_lifecycle_contracts.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from .public_safety import public_safe_compact_list, public_safe_compact_text
+from ...control_plane.runtime.public_safety import (
+    public_safe_compact_list,
+    public_safe_compact_text,
+)
 
 
 MAX_BENCHMARK_LIFECYCLE_LIST_ITEMS = 5

--- a/loopx/benchmarks/read_models/benchmark_projection.py
+++ b/loopx/benchmarks/read_models/benchmark_projection.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from .public_safety import (
+from ...control_plane.runtime.public_safety import (
     compact_numeric_map,
     public_safe_compact_list,
     public_safe_compact_text,

--- a/loopx/benchmarks/read_models/benchmark_result.py
+++ b/loopx/benchmarks/read_models/benchmark_result.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from .public_safety import (
+from ...control_plane.runtime.public_safety import (
     compact_numeric_map,
     public_safe_compact_list,
     public_safe_compact_text,

--- a/loopx/benchmarks/read_models/benchmark_run_metrics.py
+++ b/loopx/benchmarks/read_models/benchmark_run_metrics.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from .public_safety import compact_numeric_map, public_safe_compact_text
+from ...control_plane.runtime.public_safety import (
+    compact_numeric_map,
+    public_safe_compact_text,
+)
 
 
 def compact_benchmark_round_reward_trace(value: Any) -> dict[str, Any]:

--- a/loopx/benchmarks/read_models/goal_start_control_score.py
+++ b/loopx/benchmarks/read_models/goal_start_control_score.py
@@ -7,7 +7,7 @@ from loopx.benchmark_case_state import (
     BENCHMARK_CASE_LOOPX_GOAL_START_TODO_TEXTS,
 )
 
-from .public_safety import (
+from ...control_plane.runtime.public_safety import (
     LOOPX_COMMAND_RECORD_TODO_ID_PATTERN,
     compact_loopx_command_records,
     public_safe_compact_list,

--- a/loopx/benchmarks/read_models/skillsbench_post_run_debug.py
+++ b/loopx/benchmarks/read_models/skillsbench_post_run_debug.py
@@ -8,11 +8,11 @@ from .benchmark_event_timeline import (
 from .benchmark_projection import (
     build_benchmark_solution_quality_signals,
 )
-from .public_safety import (
+from ...control_plane.runtime.public_safety import (
     public_safe_compact_list,
     public_safe_compact_text,
 )
-from ..turn_driver.transaction import (
+from ...control_plane.turn_driver.transaction import (
     loopx_turn_execution_committed,
     loopx_turn_execution_has_durable_effects,
 )

--- a/loopx/canary/maintainability_ratchet.py
+++ b/loopx/canary/maintainability_ratchet.py
@@ -54,18 +54,6 @@ _OVERSIZED_DECISION_RETIREMENT_PLANS = {
     "loopx.control_plane.quota.heartbeat_recommendation:build_heartbeat_recommendation": (
         "Move recommendation modes into ordered policy rules with one projection assembler."
     ),
-    "loopx.control_plane.runtime.benchmark_comparison:benchmark_comparison_decision_note": (
-        "Extract comparison evidence rules from decision-note presentation assembly."
-    ),
-    "loopx.control_plane.runtime.benchmark_experiment_report:compact_benchmark_experiment_report": (
-        "Split experiment evidence normalization from compact report projection."
-    ),
-    "loopx.control_plane.runtime.goal_start_control_score:build_goal_start_product_mode_control_score": (
-        "Extract score dimensions into independently testable rule evaluators."
-    ),
-    "loopx.control_plane.runtime.skillsbench_post_run_debug:build_skillsbench_post_run_debug_gate": (
-        "Separate debug evidence classification from the final gate projection."
-    ),
     "loopx.control_plane.todos.contract:parse_todo_metadata_line": (
         "Replace branch-heavy field parsing with the canonical todo field schema."
     ),
@@ -97,22 +85,6 @@ _OVERSIZED_DECISION_METRIC_CEILINGS = {
     "loopx.control_plane.quota.heartbeat_recommendation:build_heartbeat_recommendation": {
         "statements": 63,
         "decision_points": 64,
-    },
-    "loopx.control_plane.runtime.benchmark_comparison:benchmark_comparison_decision_note": {
-        "statements": 97,
-        "decision_points": 45,
-    },
-    "loopx.control_plane.runtime.benchmark_experiment_report:compact_benchmark_experiment_report": {
-        "statements": 100,
-        "decision_points": 49,
-    },
-    "loopx.control_plane.runtime.goal_start_control_score:build_goal_start_product_mode_control_score": {
-        "statements": 109,
-        "decision_points": 81,
-    },
-    "loopx.control_plane.runtime.skillsbench_post_run_debug:build_skillsbench_post_run_debug_gate": {
-        "statements": 113,
-        "decision_points": 97,
     },
     "loopx.control_plane.todos.contract:parse_todo_metadata_line": {
         "statements": 119,

--- a/loopx/canary/quality_surface_catalog.py
+++ b/loopx/canary/quality_surface_catalog.py
@@ -238,7 +238,7 @@ QUALITY_SURFACE_CATALOG: tuple[dict[str, Any], ...] = (
         "layers": {
             "unit_contract": _covered(
                 "tests/control_plane/test_release_commit_qualification.py",
-                "tests/control_plane/test_release_outcome_baseline.py",
+                "tests/benchmarks/qualification/test_release_outcome_baseline.py",
                 "tests/test_doctor_install_freshness.py",
             ),
             "durable_smoke": _covered(
@@ -348,7 +348,7 @@ QUALITY_SURFACE_CATALOG: tuple[dict[str, Any], ...] = (
         },
         "layers": {
             "unit_contract": _covered(
-                "tests/control_plane/test_goal_start_control_score.py",
+                "tests/benchmarks/read_models/test_goal_start_control_score.py",
                 "tests/control_plane/test_start_goal_compact_projection.py",
                 "tests/control_plane/test_onboarding_model_behavior_qualification.py",
             ),

--- a/loopx/cli_commands/benchmark_release_outcome.py
+++ b/loopx/cli_commands/benchmark_release_outcome.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from ..control_plane.testing.release_outcome_baseline import (
+from ..benchmarks.qualification.release_outcome_baseline import (
     RELEASE_OUTCOME_BASELINE_SCHEMA_VERSION,
     build_release_outcome_baseline,
 )

--- a/loopx/cli_commands/benchmark_review_lifecycle.py
+++ b/loopx/cli_commands/benchmark_review_lifecycle.py
@@ -22,13 +22,13 @@ from ..benchmark_adapters.terminal_bench import (
     TERMINAL_BENCH_MANAGED_CODEX_LOOPX_KWARGS,
     agent_kwargs_from_invocation,
 )
-from ..control_plane.runtime.benchmark_comparison import (
+from ..benchmarks.read_models.benchmark_comparison import (
     compact_benchmark_comparison,
 )
-from ..control_plane.runtime.benchmark_learning_ledger import (
+from ..benchmarks.read_models.benchmark_learning_ledger import (
     compact_benchmark_learning_ledger,
 )
-from ..control_plane.runtime.benchmark_result import compact_benchmark_result
+from ..benchmarks.read_models.benchmark_result import compact_benchmark_result
 from ..control_plane.work_items.delivery_batch_scale import DELIVERY_BATCH_SCALE_CHOICES
 from ..control_plane.work_items.delivery_outcome import DELIVERY_OUTCOME_CHOICES
 from ..global_registry import sync_project_registry_to_global

--- a/loopx/cli_commands/history.py
+++ b/loopx/cli_commands/history.py
@@ -9,16 +9,16 @@ from pathlib import Path
 from ..benchmark_adapters.agents_last_exam import (
     build_agents_last_exam_result_benchmark_report,
 )
-from ..control_plane.runtime.benchmark_comparison import (
+from ..benchmarks.read_models.benchmark_comparison import (
     compact_benchmark_comparison,
 )
-from ..control_plane.runtime.benchmark_experiment_report import (
+from ..benchmarks.read_models.benchmark_experiment_report import (
     compact_benchmark_experiment_report,
 )
-from ..control_plane.runtime.benchmark_learning_ledger import (
+from ..benchmarks.read_models.benchmark_learning_ledger import (
     compact_benchmark_learning_ledger,
 )
-from ..control_plane.runtime.benchmark_result import compact_benchmark_result
+from ..benchmarks.read_models.benchmark_result import compact_benchmark_result
 from ..control_plane.work_items.delivery_batch_scale import DELIVERY_BATCH_SCALE_CHOICES
 from ..control_plane.work_items.delivery_outcome import DELIVERY_OUTCOME_CHOICES
 from ..control_plane.runtime.trajectory_hygiene import build_trajectory_hygiene_summary

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -165,40 +165,40 @@ from .control_plane.runtime.run_compaction import (
     compact_operator_gate_resume_contract,
     compact_run_base as _compact_run_base_read_model,
 )
-from .control_plane.runtime.benchmark_projection import (
+from .benchmarks.read_models.benchmark_projection import (
     benchmark_run_source as _benchmark_run_source_read_model,
     build_benchmark_solution_quality_signals,
     compact_benchmark_run_core as _compact_benchmark_run_core_read_model,
 )
-from .control_plane.runtime.benchmark_event_timeline import (
+from .benchmarks.read_models.benchmark_event_timeline import (
     compact_benchmark_case_event_timeline,
 )
-from .control_plane.runtime.benchmark_comparison import (
+from .benchmarks.read_models.benchmark_comparison import (
     benchmark_comparison_decision_note as _benchmark_comparison_decision_note_read_model,
     compact_benchmark_comparison as _compact_benchmark_comparison_read_model,
 )
-from .control_plane.runtime.benchmark_attempt_accounting import (
+from .benchmarks.read_models.benchmark_attempt_accounting import (
     compact_benchmark_attempt_accounting as _compact_benchmark_attempt_accounting,
 )
-from .control_plane.runtime.benchmark_experiment_report import (
+from .benchmarks.read_models.benchmark_experiment_report import (
     benchmark_experiment_report_readiness_note,
     benchmark_experiment_report_replay_decision,
     compact_benchmark_experiment_report,
 )
-from .control_plane.runtime.benchmark_learning_ledger import (
+from .benchmarks.read_models.benchmark_learning_ledger import (
     compact_benchmark_learning_ledger,
 )
-from .control_plane.runtime.benchmark_result import compact_benchmark_result
-from .control_plane.runtime.benchmark_lifecycle_contracts import (
+from .benchmarks.read_models.benchmark_result import compact_benchmark_result
+from .benchmarks.read_models.benchmark_lifecycle_contracts import (
     compact_app_server_goal_round_semantics as _compact_app_server_goal_round_semantics,
     compact_native_goal_worker_contract as _compact_native_goal_worker_contract,
     compact_product_mode_lifecycle_contract as _compact_product_mode_lifecycle_contract,
 )
-from .control_plane.runtime.benchmark_run_metrics import (
+from .benchmarks.read_models.benchmark_run_metrics import (
     compact_benchmark_overhead_attribution_counters as _compact_benchmark_overhead_attribution_counters,
     compact_benchmark_round_reward_trace as _compact_benchmark_round_reward_trace,
 )
-from .control_plane.runtime.goal_start_control_score import (
+from .benchmarks.read_models.goal_start_control_score import (
     compact_goal_start_product_mode_control_score,
 )
 from .control_plane.runtime.public_safety import (
@@ -257,7 +257,7 @@ from .control_plane.runtime.session_runtime import (
     compact_session_runtime_projection_from_run,
     legacy_runtime_goal_attention as _legacy_runtime_goal_attention_read_model,
 )
-from .control_plane.runtime.skillsbench_post_run_debug import (
+from .benchmarks.read_models.skillsbench_post_run_debug import (
     build_skillsbench_post_run_debug_gate,
 )
 from .control_plane.agents.subagent_activity import (

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -175,7 +175,7 @@ from loopx.benchmark_trajectory import (
     normalized_loopx_cli_call,
     summarize_public_acp_trajectory,
 )
-from loopx.control_plane.runtime.goal_start_control_score import (
+from loopx.benchmarks.read_models.goal_start_control_score import (
     build_goal_start_product_mode_control_score,
     goal_start_public_command_records as _goal_start_public_command_records,
     goal_start_public_text_list as _goal_start_public_text_list,
@@ -14761,7 +14761,7 @@ def reduce_result(
     from loopx.benchmark import (
         build_skillsbench_benchflow_result_benchmark_run,
     )
-    from loopx.control_plane.runtime.skillsbench_post_run_debug import (
+    from loopx.benchmarks.read_models.skillsbench_post_run_debug import (
         build_skillsbench_post_run_debug_gate,
     )
     from loopx.status import compact_benchmark_run
@@ -15630,7 +15630,7 @@ def build_runner_failure_compact(
         skillsbench_runner_error_attribution,
         skillsbench_runner_error_fingerprint,
     )
-    from loopx.control_plane.runtime.skillsbench_post_run_debug import (
+    from loopx.benchmarks.read_models.skillsbench_post_run_debug import (
         build_skillsbench_post_run_debug_gate,
     )
     from loopx.status import compact_benchmark_run

--- a/tests/architecture/test_control_plane_import_boundaries.py
+++ b/tests/architecture/test_control_plane_import_boundaries.py
@@ -10,6 +10,7 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 PACKAGE_ROOT = REPOSITORY_ROOT / "loopx"
 SCRIPTS_ROOT = REPOSITORY_ROOT / "scripts"
 CONTROL_PLANE_ROOT = PACKAGE_ROOT / "control_plane"
+BENCHMARK_READ_MODELS_ROOT = PACKAGE_ROOT / "benchmarks" / "read_models"
 STATUS_MODULE = PACKAGE_ROOT / "status.py"
 QUOTA_MODULE = PACKAGE_ROOT / "quota.py"
 PUBLIC_CONTRACT_ROOTS = (
@@ -192,6 +193,26 @@ def test_control_plane_does_not_gain_outward_dependencies() -> None:
     assert not outward_dependencies, (
         "control-plane code must not depend on presentation, CLI, capability, or "
         f"benchmark-adapter layers; unexpected edges: {sorted(outward_dependencies)}"
+    )
+
+
+def test_benchmark_read_models_stay_out_of_control_plane_runtime() -> None:
+    runtime_root = CONTROL_PLANE_ROOT / "runtime"
+    misplaced = sorted(
+        str(path.relative_to(PACKAGE_ROOT))
+        for path in (
+            *runtime_root.glob("benchmark_*.py"),
+            *runtime_root.glob("skillsbench_*.py"),
+        )
+    )
+
+    assert BENCHMARK_READ_MODELS_ROOT.is_dir()
+    assert (BENCHMARK_READ_MODELS_ROOT / "benchmark_projection.py").is_file()
+    assert (BENCHMARK_READ_MODELS_ROOT / "goal_start_control_score.py").is_file()
+    assert not (runtime_root / "goal_start_control_score.py").exists()
+    assert not misplaced, (
+        "benchmark-specific read models belong to loopx.benchmarks.read_models, "
+        f"not the generic control-plane runtime: {misplaced}"
     )
 
 

--- a/tests/benchmarks/qualification/test_release_outcome_baseline.py
+++ b/tests/benchmarks/qualification/test_release_outcome_baseline.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from loopx.control_plane.testing.release_outcome_baseline import (
+from loopx.benchmarks.qualification.release_outcome_baseline import (
     build_release_outcome_baseline,
 )
 

--- a/tests/benchmarks/read_models/test_benchmark_comparison.py
+++ b/tests/benchmarks/read_models/test_benchmark_comparison.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from loopx.control_plane.runtime.benchmark_comparison import (
+from loopx.benchmarks.read_models.benchmark_comparison import (
     benchmark_comparison_decision_note,
     compact_benchmark_comparison,
 )

--- a/tests/benchmarks/read_models/test_benchmark_event_timeline.py
+++ b/tests/benchmarks/read_models/test_benchmark_event_timeline.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from loopx.control_plane.runtime.benchmark_event_timeline import (
+from loopx.benchmarks.read_models.benchmark_event_timeline import (
     compact_benchmark_case_event_timeline,
 )
 

--- a/tests/benchmarks/read_models/test_benchmark_experiment_report.py
+++ b/tests/benchmarks/read_models/test_benchmark_experiment_report.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from loopx import status
-from loopx.control_plane.runtime.benchmark_attempt_accounting import (
+from loopx.benchmarks.read_models.benchmark_attempt_accounting import (
     compact_benchmark_attempt_accounting,
 )
-from loopx.control_plane.runtime.benchmark_experiment_report import (
+from loopx.benchmarks.read_models.benchmark_experiment_report import (
     benchmark_experiment_report_readiness_note,
     benchmark_experiment_report_replay_decision,
     compact_benchmark_experiment_report,

--- a/tests/benchmarks/read_models/test_benchmark_learning_ledger.py
+++ b/tests/benchmarks/read_models/test_benchmark_learning_ledger.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from loopx import status
-from loopx.control_plane.runtime.benchmark_learning_ledger import (
+from loopx.benchmarks.read_models.benchmark_learning_ledger import (
     compact_benchmark_learning_ledger,
 )
 

--- a/tests/benchmarks/read_models/test_benchmark_lifecycle_contracts.py
+++ b/tests/benchmarks/read_models/test_benchmark_lifecycle_contracts.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from loopx.control_plane.runtime.benchmark_lifecycle_contracts import (
+from loopx.benchmarks.read_models.benchmark_lifecycle_contracts import (
     compact_app_server_goal_round_semantics,
     compact_native_goal_worker_contract,
     compact_product_mode_lifecycle_contract,

--- a/tests/benchmarks/read_models/test_benchmark_projection.py
+++ b/tests/benchmarks/read_models/test_benchmark_projection.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from loopx.benchmark_adapters.skillsbench_signals import (
     build_skillsbench_solution_quality_signals,
 )
-from loopx.control_plane.runtime.benchmark_projection import (
+from loopx.benchmarks.read_models.benchmark_projection import (
     build_benchmark_solution_quality_signals,
 )
 

--- a/tests/benchmarks/read_models/test_benchmark_result.py
+++ b/tests/benchmarks/read_models/test_benchmark_result.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from loopx import status
-from loopx.control_plane.runtime.benchmark_result import compact_benchmark_result
+from loopx.benchmarks.read_models.benchmark_result import compact_benchmark_result
 
 
 def test_status_preserves_benchmark_result_import() -> None:

--- a/tests/benchmarks/read_models/test_benchmark_run_metrics.py
+++ b/tests/benchmarks/read_models/test_benchmark_run_metrics.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from loopx.control_plane.runtime.benchmark_run_metrics import (
+from loopx.benchmarks.read_models.benchmark_run_metrics import (
     compact_benchmark_overhead_attribution_counters,
     compact_benchmark_round_reward_trace,
 )

--- a/tests/benchmarks/read_models/test_goal_start_control_score.py
+++ b/tests/benchmarks/read_models/test_goal_start_control_score.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 
-from loopx.control_plane.runtime.goal_start_control_score import (
+from loopx.benchmarks.read_models.goal_start_control_score import (
     compact_goal_start_product_mode_control_score,
 )
 

--- a/tests/benchmarks/read_models/test_skillsbench_post_run_debug.py
+++ b/tests/benchmarks/read_models/test_skillsbench_post_run_debug.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from loopx import status
-from loopx.control_plane.runtime.skillsbench_post_run_debug import (
+from loopx.benchmarks.read_models.skillsbench_post_run_debug import (
     build_skillsbench_post_run_debug_gate,
 )
 


### PR DESCRIPTION
## Summary

- establish `loopx/benchmarks` as the benchmark-owned domain beside `loopx/control_plane`
- move public-safe benchmark read models, SkillsBench debug projection, goal-start score, and release-outcome qualification out of the generic control plane
- preserve `loopx.status`, CLI behavior, persisted schemas, scoring/task semantics, and the established `loopx.benchmark_core` / `loopx.benchmark_adapters` import surfaces
- add an architecture guard and a concise placement guide; a repository-root Python `benchmark/` package is intentionally rejected because the wheel publishes only `loopx*`

## Validation

- `68 passed`: architecture, benchmark read-model/qualification, release qualification, maintainability, and quality catalog tests
- `benchmark-run-v0-status-projection-smoke.py`
- `benchmark-run-v0-append-cli-smoke.py`
- `benchmark-experiment-report-template-smoke.py`
- `skillsbench-typed-repair-smoke.py`
- wheel build succeeded and contains every new `loopx/benchmarks/read_models` and `qualification` module
- LoopX standard premerge: changed-file compile and diff checks passed; 9 catalog canaries, 8 risk-profile smokes, and the public/private boundary scan passed
- public scan found no private paths, internal links, credentials, or local state

## Holds and residual risk

- premerge reports the expected `benchmark_sensitive` manual-review hold; this PR does not self-merge
- full suite result: 1078 passed, 2 skipped, 1 unrelated environment failure. `test_generated_starter_installs_and_runs_through_managed_lifecycle` failed while nested `venv` creation under uv Python 3.13 could not load `libpython3.13.dylib`; focused extension behavior was not changed
- no benchmark jobs were launched and no scoring, verifier, runner, task, upload, or permission semantics changed