### PR TITLE
fix: make paused quota authoritative

### DIFF
--- a/loopx/configure_goal.py
+++ b/loopx/configure_goal.py
@@ -151,6 +151,14 @@ def _positive_number(value: float | None, *, field: str) -> float | None:
     return float(value)
 
 
+def _non_negative_number(value: float | None, *, field: str) -> float | None:
+    if value is None:
+        return None
+    if value < 0:
+        raise ValueError(f"{field} must be greater than or equal to 0")
+    return float(value)
+
+
 def _non_negative_int(value: int | None, *, field: str) -> int | None:
     if value is None:
         return None
@@ -541,7 +549,7 @@ def configure_goal(
                 + ", ".join(EXPLORE_HARNESS_PROFILES)
             )
 
-    quota_compute = _positive_number(quota_compute, field="quota_compute")
+    quota_compute = _non_negative_number(quota_compute, field="quota_compute")
     quota_window_hours = _positive_number(quota_window_hours, field="quota_window_hours")
     max_children = _non_negative_int(max_children, field="max_children")
     allowed_domains = _clean_domains(allowed_domains)

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -1411,6 +1411,80 @@ def _apply_agent_monitor_only_precedence(
         payload.pop(key, None)
 
 
+def _apply_paused_quota_precedence(payload: dict[str, Any]) -> None:
+    if str(payload.get("state") or "") != "paused":
+        return
+
+    quota = payload.get("quota") if isinstance(payload.get("quota"), dict) else {}
+    reason = str(
+        quota.get("reason")
+        or "compute quota is 0; automatic agent turns are paused"
+    )
+    payload.update(
+        {
+            "decision": "skip",
+            "should_run": False,
+            "normal_delivery_allowed": False,
+            "recovery_delivery_allowed": False,
+            "self_repair_allowed": False,
+            "capability_repair_allowed": False,
+            "workspace_repair_allowed": False,
+            "effective_action": "quota_skip",
+            "actionable_by_codex": False,
+            "reason": reason,
+            "blocked_action_scope": "all_automatic_agent_turns",
+            "safe_bypass_allowed": False,
+            "safe_bypass_kind": None,
+            "safe_bypass_policy": None,
+            "requires_user_action": False,
+            "recommended_action": (
+                "Resume the goal explicitly before attempting delivery, repair, "
+                "monitoring, or autonomous replan work."
+            ),
+            "heartbeat_recommendation": {
+                "recommended_mode": "quota_paused",
+                "notify": "DONT_NOTIFY",
+                "reason": reason,
+                "spend_policy": "do not append quota spend while the goal is paused",
+            },
+            "execution_obligation": {
+                "must_attempt_work": False,
+                "kind": "quota_paused",
+                "delivery_allowed": False,
+                "notify_is_execution_gate": False,
+                "reason": reason,
+                "spend_policy": "do not append quota spend while the goal is paused",
+            },
+        }
+    )
+    for key in (
+        "agent_command",
+        "agent_lane_frontier_hint",
+        "agent_lane_next_action",
+        "agent_scope_frontier",
+        "autonomous_replan_decision",
+        "autonomous_replan_obligation",
+        "autonomous_replan_scope",
+        "blocked_priority_fallback",
+        "capability_gate",
+        "capability_monitor_fallback",
+        "external_evidence_observation",
+        "goal_route_hint",
+        "notify_user_on_capability_gate",
+        "notify_user_on_gate",
+        "notify_user_on_open_todo",
+        "open_todo_notification_policy",
+        "open_todo_notify_reason",
+        "required_reads",
+        "scoped_user_gate_fallback",
+        "stall_self_repair",
+        "vision_continuation_audit",
+        "vision_wait_state",
+        "workspace_guard",
+    ):
+        payload.pop(key, None)
+
+
 def build_quota_should_run(
     status_payload: dict[str, Any],
     *,
@@ -2352,6 +2426,7 @@ def build_quota_should_run(
             monitor_only=agent_monitor_only,
             inbox_reply_due=inbox_reply_due,
         )
+        _apply_paused_quota_precedence(payload)
         required_reads = _quota_required_reads(payload)
         if required_reads:
             payload["required_reads"] = required_reads

--- a/tests/control_plane/test_quota_paused_precedence.py
+++ b/tests/control_plane/test_quota_paused_precedence.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from loopx.configure_goal import configure_goal
+from loopx.control_plane.scheduler.execution_context import (
+    GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT,
+)
+from loopx.control_plane.testing.quota_fixtures import (
+    quota_status_payload,
+    quota_todo_item,
+)
+from loopx.quota import build_quota_should_run
+
+
+GOAL_ID = "paused-quota-precedence-fixture"
+AGENT_ID = "codex-paused-agent"
+
+
+def _paused_status(*, required_capabilities: list[str] | None = None) -> dict:
+    todo = quota_todo_item(
+        todo_id="todo_paused_delivery",
+        title="Advance paused delivery.",
+        claimed_by=AGENT_ID,
+        required_capabilities=required_capabilities or [],
+    )
+    return quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        recommended_action="Advance the delivery.",
+        agent_todo_items=[todo],
+        quota_state="paused",
+        quota_extra={"compute": 0, "reason": "paused fixture"},
+        coordination={
+            "agent_model": "peer_v1",
+            "registered_agents": [AGENT_ID],
+        },
+    )
+
+
+def _assert_authoritatively_paused(payload: dict) -> None:
+    assert payload["state"] == "paused"
+    assert payload["decision"] == "skip"
+    assert payload["should_run"] is False
+    assert payload["effective_action"] == "quota_skip"
+    assert payload["actionable_by_codex"] is False
+    assert payload["self_repair_allowed"] is False
+    assert payload["capability_repair_allowed"] is False
+    assert payload["workspace_repair_allowed"] is False
+    assert payload["heartbeat_recommendation"]["recommended_mode"] == "quota_paused"
+    assert payload["heartbeat_recommendation"]["notify"] == "DONT_NOTIFY"
+    assert payload["execution_obligation"]["must_attempt_work"] is False
+    assert payload["interaction_contract"]["mode"] == "skip"
+    assert payload["scheduler_hint"]["action"] != "run_now"
+
+
+def test_paused_quota_preempts_capability_bridge_repair() -> None:
+    payload = build_quota_should_run(
+        _paused_status(required_capabilities=["network"]),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        available_capabilities=[],
+        scheduler_execution_context=GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT,
+    )
+
+    _assert_authoritatively_paused(payload)
+    assert "capability_gate" not in payload
+
+
+def test_paused_quota_preempts_workspace_repair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "loopx.quota.build_agent_workspace_guard",
+        lambda *args, **kwargs: {
+            "schema_version": "agent_workspace_guard_v1",
+            "reason": "workspace fixture requires relocation",
+            "required_action": "rerun from the assigned worktree",
+        },
+    )
+
+    payload = build_quota_should_run(
+        _paused_status(),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        scheduler_execution_context=GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT,
+    )
+
+    _assert_authoritatively_paused(payload)
+    assert "workspace_guard" not in payload
+
+
+def test_configure_goal_accepts_zero_compute_as_pause(tmp_path: Path) -> None:
+    registry = tmp_path / "registry.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "repo": str(tmp_path),
+                        "quota": {"compute": 1.0, "window_hours": 24},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = configure_goal(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        quota_compute=0,
+        execute=True,
+    )
+
+    assert result["written"] is True
+    stored = json.loads(registry.read_text(encoding="utf-8"))
+    assert stored["goals"][0]["quota"]["compute"] == 0
+
+
+def test_configure_goal_rejects_negative_compute(tmp_path: Path) -> None:
+    registry = tmp_path / "registry.json"
+    registry.write_text(
+        json.dumps({"goals": [{"id": GOAL_ID, "repo": str(tmp_path)}]}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="greater than or equal to 0"):
+        configure_goal(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            quota_compute=-0.1,
+            execute=False,
+        )


### PR DESCRIPTION
## Summary
- allow `configure-goal --quota-compute 0` as the supported pause configuration
- make paused quota override workspace repair, capability bridge repair, autonomous replan, monitor, inbox, and fallback execution paths
- project a quiet no-spend interaction and scheduler contract while paused

## Validation
- `uv run --extra test pytest -q tests/control_plane/test_quota_paused_precedence.py` (4 passed)
- adjacent control-plane tests (29 passed)
- `uv run loopx canary premerge --from-git-diff` (passed, 17 checks; one unrelated inherited maintainability advisory)
- live readback against three paused goals and four registered agents: all returned `state=paused`, `decision=skip`, `should_run=false`, `effective_action=quota_skip`

## Hold
Draft for maintainer review. No goals are resumed or merged by this PR.