### PR TITLE
Add controlled SkillsBench pip index fallback

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -104,6 +104,8 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     DEFAULT_DOCKER_MAVEN_MIRROR_URL,
     DEFAULT_DOCKER_MAVEN_SETTINGS_PATH,
     DEFAULT_DOCKER_PIP_INDEX_HOST,
+    PRIMARY_DOCKER_PIP_INDEX_HOST,
+    PRIMARY_DOCKER_PIP_INDEX_URL,
     DEFAULT_VERIFIER_UV_RELEASE_MIRROR_HOST,
     DECLARED_DONE_MARKER,
     DOCKER_CODEX_ACP_RUNTIME_TOOLS_BEGIN,
@@ -6129,6 +6131,25 @@ def test_skillsbench_docker_task_staging_adds_pip_bootstrap_patch() -> None:
         assert staged_text.index(DOCKER_PIP_BOOTSTRAP_BEGIN) < staged_text.index(
             "pip3 install"
         ), staged_text
+
+        primary_path, primary_metadata = stage_task_for_sandbox(
+            task_path=task,
+            jobs_dir=root / "jobs",
+            job_name="adaptive-cruise-control-primary-index",
+            sandbox="docker",
+            include_task_skills=False,
+            docker_pip_index_mode="primary",
+        )
+        primary_text = (primary_path / "environment" / "Dockerfile").read_text(
+            encoding="utf-8"
+        )
+        assert primary_metadata["dockerfile_pip_index_host"] == (
+            PRIMARY_DOCKER_PIP_INDEX_HOST
+        ), primary_metadata
+        assert (
+            f"ARG LOOPX_SKILLSBENCH_PIP_INDEX_URL={PRIMARY_DOCKER_PIP_INDEX_URL}"
+            in primary_text
+        ), primary_text
 
 
 def test_skillsbench_docker_pip_bootstrap_skips_python_heredoc_imports() -> None:

--- a/loopx/benchmark_adapters/skillsbench_failure_signals.py
+++ b/loopx/benchmark_adapters/skillsbench_failure_signals.py
@@ -58,7 +58,7 @@ _FAILURE_DEPENDENCY_CLASS_PATTERNS = (
     (
         "python_package",
         r"python\S*\s+-m\s+pip\s+install|pip3?\s+install|pypi\.|"
-        r"pythonhosted\.org",
+        r"pythonhosted\.org|pip\._vendor\.",
     ),
     ("python_uv", r"\buvx?\b|astral\.sh"),
     ("conda_package", r"\bconda\b|\bmamba\b|anaconda\.(?:com|org)"),
@@ -145,6 +145,11 @@ _FAILURE_REASON_PATTERNS = (
         r"subprocess-exited-with-error",
     ),
     ("pip_os_error", r"could not install packages due to an oserror"),
+    (
+        "pip_vendor_network",
+        r"pip\._vendor\.[^\n]*(?:network|connection|retry|timed?\s*out|"
+        r"incompleteread|protocolerror|proxyerror)",
+    ),
     ("permission_denied", r"permission denied|operation not permitted"),
     ("missing_file", r"no such file|does not exist"),
     ("no_space_left", r"no space left on device"),
@@ -170,6 +175,7 @@ _TRANSIENT_FAILURE_REASONS = {
     "http_server_error",
     "network_unreachable",
     "proxy_connect",
+    "pip_vendor_network",
     "retry_exhausted",
 }
 _DETERMINISTIC_FAILURE_REASONS = {
@@ -498,6 +504,20 @@ def skillsbench_pip_bootstrap_failure_subtype(error_text: str) -> str:
         any(host in line for host in package_hosts)
         and any(marker in line for marker in network_failures)
         for line in text.splitlines()
+    ):
+        return "package_index_network_failure"
+    pip_vendor_network_markers = (
+        "network",
+        "connection",
+        "retry",
+        "timed out",
+        "timeout",
+        "incompleteread",
+        "protocolerror",
+        "proxyerror",
+    )
+    if "pip._vendor." in text and any(
+        marker in text for marker in pip_vendor_network_markers
     ):
         return "package_index_network_failure"
     if "subprocess-exited-with-error" in text:

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -31,6 +31,8 @@ Optional env:
                                        require (default), auto, or off
   SKILLSBENCH_DOCKER_API_VERSION       Remote Docker daemon API version passed
                                        to Docker CLI/Compose; default auto
+  SKILLSBENCH_DOCKER_PIP_INDEX_MODE    Staged Dockerfile pip index: mirror
+                                       (default) or primary
   SKILLSBENCH_ROUTE                    Route, default codex-cli-goal-baseline
   SKILLSBENCH_MODEL                    Model, default gpt-5.5
   SKILLSBENCH_REASONING_EFFORT         Reasoning effort, default xhigh
@@ -211,6 +213,7 @@ skip_current_aggregate_update="${SKILLSBENCH_SKIP_CURRENT_AGGREGATE_UPDATE:-0}"
 allow_staged_bootstrap_repair_run="${SKILLSBENCH_ALLOW_STAGED_BOOTSTRAP_REPAIR_RUN:-0}"
 setup_only_public_preflight="${SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT:-0}"
 benchmark_egress_proxy_mode="${SKILLSBENCH_BENCHMARK_EGRESS_PROXY_MODE:-require}"
+docker_pip_index_mode="${SKILLSBENCH_DOCKER_PIP_INDEX_MODE:-mirror}"
 product_mode_soft_verify_policy="${SKILLSBENCH_PRODUCT_MODE_SOFT_VERIFY_POLICY:-}"
 remote_command_file_bridge_probe_command="${SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_COMMAND:-}"
 remote_command_file_bridge_solver_command="${SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_SOLVER_COMMAND:-}"
@@ -239,6 +242,11 @@ if [[ "$benchmark_egress_proxy_mode" != "require" ]] &&
   [[ "$benchmark_egress_proxy_mode" != "auto" ]] &&
   [[ "$benchmark_egress_proxy_mode" != "off" ]]; then
   echo "SKILLSBENCH_BENCHMARK_EGRESS_PROXY_MODE must be require, auto, or off" >&2
+  exit 2
+fi
+if [[ "$docker_pip_index_mode" != "mirror" ]] &&
+  [[ "$docker_pip_index_mode" != "primary" ]]; then
+  echo "SKILLSBENCH_DOCKER_PIP_INDEX_MODE must be mirror or primary" >&2
   exit 2
 fi
 validate_bool_toggle \
@@ -530,6 +538,7 @@ remote_command=$(
     --codex-api-egress-mode reverse-tunnel \
     --codex-api-reverse-tunnel-proxy "$loopback_proxy_url" \
     --benchmark-egress-proxy-mode "$benchmark_egress_proxy_mode" \
+    --docker-pip-index-mode "$docker_pip_index_mode" \
     --host-local-acp-launch \
     --local-codex-bin "$remote_codex_bin" \
     --local-codex-sandbox "$local_codex_sandbox" \
@@ -615,6 +624,7 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'public_artifact_sync_interval_sec=%s\n' \
     "$public_artifact_sync_interval"
   printf 'benchmark_egress_proxy_mode=%s\n' "$benchmark_egress_proxy_mode"
+  printf 'docker_pip_index_mode=%s\n' "$docker_pip_index_mode"
   printf 'product_mode_soft_verify_policy=%s\n' \
     "${product_mode_soft_verify_policy:-runner-default}"
   printf 'remote_command_file_bridge_probe_command_configured=%s\n' \

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -429,6 +429,13 @@ VERIFIER_UV_BOOTSTRAP_MIRROR_BEGIN = (
 VERIFIER_UV_BOOTSTRAP_MIRROR_END = verifier_bootstrap.VERIFIER_UV_BOOTSTRAP_MIRROR_END
 DEFAULT_DOCKER_PIP_INDEX_URL = verifier_bootstrap.DEFAULT_DOCKER_PIP_INDEX_URL
 DEFAULT_DOCKER_PIP_INDEX_HOST = "pypi.tuna.tsinghua.edu.cn"
+PRIMARY_DOCKER_PIP_INDEX_URL = "https://pypi.org/simple"
+PRIMARY_DOCKER_PIP_INDEX_HOST = "pypi.org"
+DEFAULT_DOCKER_PIP_INDEX_MODE = "mirror"
+DOCKER_PIP_INDEX_MODES = {
+    "mirror": (DEFAULT_DOCKER_PIP_INDEX_URL, DEFAULT_DOCKER_PIP_INDEX_HOST),
+    "primary": (PRIMARY_DOCKER_PIP_INDEX_URL, PRIMARY_DOCKER_PIP_INDEX_HOST),
+}
 DOCKER_HOST_CPU_ENV = "LOOPX_SKILLSBENCH_DOCKER_CPUS"
 SANDBOX_PATH_RE = re.compile(r"/(?:app|root|workspace|tmp)/[A-Za-z0-9_./-]+")
 LOOPX_CLI_RE = re.compile(r"(?:^|\s|/)loopx(?:\s|$)")
@@ -5930,6 +5937,9 @@ def _public_task_staging(value: Any) -> dict[str, Any]:
 
 
 def _discover_prepared_task_staging(plan: dict[str, Any]) -> dict[str, Any]:
+    _, docker_pip_index_host = _docker_pip_index(
+        str(plan.get("docker_pip_index_mode") or DEFAULT_DOCKER_PIP_INDEX_MODE)
+    )
     jobs_dir = Path(str(plan.get("jobs_dir") or "")).expanduser()
     job_name = str(plan.get("job_name") or "")
     task_id = str(plan.get("task_id") or "")
@@ -6112,7 +6122,7 @@ def _discover_prepared_task_staging(plan: dict[str, Any]) -> dict[str, Any]:
                 "dockerfile_pip_install_risk_detected": True,
                 "dockerfile_pip_bootstrap_patch_required": True,
                 "dockerfile_pip_bootstrap_patch_applied": True,
-                "dockerfile_pip_index_host": DEFAULT_DOCKER_PIP_INDEX_HOST,
+                "dockerfile_pip_index_host": docker_pip_index_host,
             }
         )
     return discovered
@@ -7734,7 +7744,18 @@ def patch_dockerfile_apt_retry(dockerfile: Path) -> bool:
     return True
 
 
-def patch_dockerfile_pip_bootstrap(dockerfile: Path) -> bool:
+def _docker_pip_index(mode: str) -> tuple[str, str]:
+    try:
+        return DOCKER_PIP_INDEX_MODES[mode]
+    except KeyError as exc:
+        raise ValueError(f"unsupported Docker pip index mode: {mode}") from exc
+
+
+def patch_dockerfile_pip_bootstrap(
+    dockerfile: Path,
+    *,
+    index_url: str = DEFAULT_DOCKER_PIP_INDEX_URL,
+) -> bool:
     """Add public-safe pip retry/index defaults to staged Dockerfiles."""
 
     if not dockerfile_needs_pip_bootstrap_patch(dockerfile):
@@ -7747,7 +7768,7 @@ def patch_dockerfile_pip_bootstrap(dockerfile: Path) -> bool:
     )
     block = (
         f"{DOCKER_PIP_BOOTSTRAP_BEGIN}\n"
-        f"ARG LOOPX_SKILLSBENCH_PIP_INDEX_URL={DEFAULT_DOCKER_PIP_INDEX_URL}\n"
+        f"ARG LOOPX_SKILLSBENCH_PIP_INDEX_URL={index_url}\n"
         "ENV PIP_INDEX_URL=${LOOPX_SKILLSBENCH_PIP_INDEX_URL} \\\n"
         "    PIP_DEFAULT_TIMEOUT=120 \\\n"
         "    PIP_RETRIES=10 \\\n"
@@ -7978,6 +7999,7 @@ def stage_task_for_sandbox(
     sandbox: str,
     include_task_skills: bool = True,
     benchmark_egress_proxy_env: Mapping[str, str] | None = None,
+    docker_pip_index_mode: str = DEFAULT_DOCKER_PIP_INDEX_MODE,
     docker_gcr_mirror_prefix: str = "",
     verifier_dependency_cache_enabled: bool = False,
     loopx_case_runtime_required: bool = False,
@@ -7985,6 +8007,9 @@ def stage_task_for_sandbox(
     """Return the task path to run, staging Docker tasks when setup needs it."""
 
     task_path = task_path.expanduser().resolve()
+    docker_pip_index_url, docker_pip_index_host = _docker_pip_index(
+        docker_pip_index_mode
+    )
     metadata: dict[str, Any] = {
         "schema_version": "skillsbench_task_staging_v0",
         "original_task_name": task_path.name,
@@ -8168,7 +8193,7 @@ def stage_task_for_sandbox(
         needs_venv_pip_invocation_patch
     )
     if needs_pip_bootstrap_patch:
-        metadata["dockerfile_pip_index_host"] = DEFAULT_DOCKER_PIP_INDEX_HOST
+        metadata["dockerfile_pip_index_host"] = docker_pip_index_host
     metadata["dockerfile_gcr_mirror_patch_required"] = needs_gcr_mirror_patch
     metadata["dockerfile_elan_toolchain_retry_patch_required"] = (
         needs_elan_toolchain_retry_patch
@@ -8326,7 +8351,8 @@ def stage_task_for_sandbox(
         staged_path / "environment" / "Dockerfile"
     )
     pip_bootstrap_patched = patch_dockerfile_pip_bootstrap(
-        staged_path / "environment" / "Dockerfile"
+        staged_path / "environment" / "Dockerfile",
+        index_url=docker_pip_index_url,
     )
     venv_pip_invocation_patched = dockerfile_runtime.patch_venv_pip_invocations(
         staged_path / "environment" / "Dockerfile"
@@ -8404,7 +8430,7 @@ def stage_task_for_sandbox(
                 venv_pip_invocation_patched
             ),
             "dockerfile_pip_index_host": (
-                DEFAULT_DOCKER_PIP_INDEX_HOST if pip_bootstrap_patched else ""
+                docker_pip_index_host if pip_bootstrap_patched else ""
             ),
             "dockerfile_gcr_mirror_patch_applied": gcr_mirror_patched,
             "dockerfile_gcr_mirror_raw_prefix_recorded": False,
@@ -8519,6 +8545,7 @@ def stage_task_for_sandbox(
 def build_plan(args: argparse.Namespace) -> dict[str, Any]:
     task_id = args.task_id
     route = args.route
+    _, docker_pip_index_host = _docker_pip_index(args.docker_pip_index_mode)
     route_slug = route.replace("-", "_")
     intermediate_soft_verify_policy = product_mode_soft_verify_policy_for_route(
         route,
@@ -8748,6 +8775,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         ),
         "run_group_id": str(args.run_group_id or ""),
         "sandbox": args.sandbox,
+        "docker_pip_index_mode": args.docker_pip_index_mode,
         "max_rounds": args.max_rounds,
         "independent_goal_retry": {
             "schema_version": "skillsbench_independent_goal_retry_config_v0",
@@ -8860,7 +8888,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             "dockerfile_venv_pip_invocation_patch_required": False,
             "dockerfile_venv_pip_invocation_patch_applied": False,
             "dockerfile_pip_index_host": (
-                DEFAULT_DOCKER_PIP_INDEX_HOST
+                docker_pip_index_host
                 if setup_preflight.get("dockerfile_pip_bootstrap_patch_required")
                 else ""
             ),
@@ -9326,6 +9354,7 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
         "app_server_reasoning_effort",
         "app_server_goal_prompt_style",
         "sandbox",
+        "docker_pip_index_mode",
         "run_group_id",
         "job_name",
         "rollout_name",
@@ -13733,6 +13762,7 @@ async def run_benchflow_case(
         sandbox=args.sandbox,
         include_task_skills=bool(args.include_task_skills),
         benchmark_egress_proxy_env=_benchmark_egress_proxy_env(args),
+        docker_pip_index_mode=args.docker_pip_index_mode,
         docker_gcr_mirror_prefix=args.docker_gcr_mirror_prefix,
         verifier_dependency_cache_enabled=(
             verifier_dependency_cache_policy_enabled
@@ -16577,6 +16607,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help=(
             "Timeout for the benchmark setup/verifier egress proxy preflight. "
             "The probe records no raw proxy URL or raw response output."
+        ),
+    )
+    parser.add_argument(
+        "--docker-pip-index-mode",
+        choices=tuple(DOCKER_PIP_INDEX_MODES),
+        default=DEFAULT_DOCKER_PIP_INDEX_MODE,
+        help=(
+            "Public package index used by the staged Dockerfile pip bootstrap "
+            "repair. mirror preserves the default; primary provides a bounded "
+            "fallback after a typed mirror-network setup failure."
         ),
     )
     parser.add_argument(

--- a/tests/test_skillsbench_setup_preflight.py
+++ b/tests/test_skillsbench_setup_preflight.py
@@ -167,6 +167,23 @@ def test_setup_only_runner_mode_bypasses_formal_round_budget() -> None:
     )
 
 
+def test_primary_pip_index_mode_is_publicly_attributable() -> None:
+    args = parse_args(
+        [
+            "--task-id",
+            "flink-query",
+            "--docker-pip-index-mode",
+            "primary",
+        ]
+    )
+
+    plan = build_plan(args)
+    public_config = _public_runner_config(plan)
+
+    assert plan["docker_pip_index_mode"] == "primary"
+    assert public_config["docker_pip_index_mode"] == "primary"
+
+
 @pytest.mark.parametrize(
     ("sandbox_timeout", "build_stall_timeout", "expected"),
     [
@@ -361,6 +378,11 @@ def test_compose_producer_emits_only_bounded_typed_cause() -> None:
             "Docker compose command failed: pip install demo returned a non-zero code",
             "command_failed_unclassified",
         ),
+        (
+            "Docker compose command failed: pip._vendor.urllib3.ProtocolError: "
+            "connection retry exhausted",
+            "package_index_network_failure",
+        ),
     ],
 )
 def test_setup_only_preflight_projects_bounded_pip_failure_subtype(
@@ -375,6 +397,21 @@ def test_setup_only_preflight_projects_bounded_pip_failure_subtype(
     assert result["pip_failure_subtype"] == subtype
     serialized = json.dumps(result, sort_keys=True)
     assert message not in serialized
+
+
+def test_pip_vendor_network_failure_is_publicly_retryable() -> None:
+    message = (
+        "Docker compose command failed: pip._vendor.urllib3.ProtocolError: "
+        "connection retry exhausted"
+    )
+
+    fingerprint = skillsbench_runner_error_fingerprint(message)
+
+    assert fingerprint["pip_failure_subtype"] == "package_index_network_failure"
+    assert fingerprint["failure_line_dependency_classes"] == ["python_package"]
+    assert fingerprint["terminal_failure_reason_codes"] == ["pip_vendor_network"]
+    assert fingerprint["retryability"] == "retryable"
+    assert message not in json.dumps(fingerprint, sort_keys=True)
 
 
 def test_setup_only_preflight_consumes_compose_producer_typed_cause() -> None:

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -207,6 +207,44 @@ def test_launcher_rejects_invalid_benchmark_egress_mode(tmp_path: Path) -> None:
     )
 
 
+def test_launcher_wires_bounded_primary_pip_index_mode(tmp_path: Path) -> None:
+    env = _base_env(tmp_path)
+    env["SKILLSBENCH_DOCKER_PIP_INDEX_MODE"] = "primary"
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "primary-pip"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+
+    assert "docker_pip_index_mode=primary" in proc.stdout
+    assert "--docker-pip-index-mode primary" in proc.stdout
+
+
+def test_launcher_rejects_unbounded_pip_index_mode(tmp_path: Path) -> None:
+    env = _base_env(tmp_path)
+    env["SKILLSBENCH_DOCKER_PIP_INDEX_MODE"] = "private-url"
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "invalid-pip"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    assert "SKILLSBENCH_DOCKER_PIP_INDEX_MODE must be mirror or primary" in (
+        proc.stderr
+    )
+
+
 def test_setup_only_launcher_enables_incremental_public_artifact_sync(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- classify pip vendor network failures as a bounded retryable setup cause
- add a controlled `mirror` / `primary` pip index mode for staged SkillsBench Dockerfiles
- preserve mirror mode as the default and expose only the selected public mode/host

## Validation

- `44 passed` across focused setup preflight and launcher tests
- `skillsbench-failure-attribution-smoke: ok`
- `skillsbench-benchmark-run-smoke: ok`
- Python compile, shell syntax, and diff checks passed
- LoopX premerge: all 6 catalog canaries and the public-boundary scan passed; the only hold was the expected generic `benchmark_sensitive` maintainer review flag

## Boundaries

- no scoring, task-semantics, leaderboard, submission, or permission change
- no benchmark job launch
- no raw task, trajectory, verifier output, credential, private state, or local path added
