### PR TITLE
Add controlled SkillsBench pip build fallback

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -6113,6 +6113,7 @@ def test_skillsbench_docker_task_staging_adds_pip_bootstrap_patch() -> None:
         assert metadata["dockerfile_pip_index_host"] == DEFAULT_DOCKER_PIP_INDEX_HOST, (
             metadata
         )
+        assert metadata["dockerfile_pip_build_mode"] == "isolated", metadata
         assert metadata["original_task_mutated"] is False, metadata
         assert dockerfile.read_text(encoding="utf-8") == original_text
         staged_text = (staged_path / "environment" / "Dockerfile").read_text(
@@ -6128,6 +6129,7 @@ def test_skillsbench_docker_task_staging_adds_pip_bootstrap_patch() -> None:
             staged_text
         ), staged_text
         assert "PIP_RETRIES=10" in staged_text, staged_text
+        assert "PIP_NO_BUILD_ISOLATION" not in staged_text, staged_text
         assert staged_text.index(DOCKER_PIP_BOOTSTRAP_BEGIN) < staged_text.index(
             "pip3 install"
         ), staged_text
@@ -6150,6 +6152,22 @@ def test_skillsbench_docker_task_staging_adds_pip_bootstrap_patch() -> None:
             f"ARG LOOPX_SKILLSBENCH_PIP_INDEX_URL={PRIMARY_DOCKER_PIP_INDEX_URL}"
             in primary_text
         ), primary_text
+
+        no_isolation_path, no_isolation_metadata = stage_task_for_sandbox(
+            task_path=task,
+            jobs_dir=root / "jobs",
+            job_name="adaptive-cruise-control-no-isolation",
+            sandbox="docker",
+            include_task_skills=False,
+            docker_pip_build_mode="no-isolation",
+        )
+        no_isolation_text = (
+            no_isolation_path / "environment" / "Dockerfile"
+        ).read_text(encoding="utf-8")
+        assert no_isolation_metadata["dockerfile_pip_build_mode"] == (
+            "no-isolation"
+        ), no_isolation_metadata
+        assert "PIP_NO_BUILD_ISOLATION=1" in no_isolation_text, no_isolation_text
 
 
 def test_skillsbench_docker_pip_bootstrap_skips_python_heredoc_imports() -> None:

--- a/loopx/benchmark_adapters/skillsbench_setup_preflight.py
+++ b/loopx/benchmark_adapters/skillsbench_setup_preflight.py
@@ -55,6 +55,7 @@ _PUBLIC_TASK_STAGING_STRING_FIELDS = (
     "dockerfile_ubuntu_apt_mirror_host",
     "dockerfile_debian_apt_mirror_host",
     "dockerfile_pip_index_host",
+    "dockerfile_pip_build_mode",
     "dockerfile_uv_bootstrap_version",
     "dockerfile_uv_bootstrap_mirror_host",
     "dockerfile_apache_archive_mirror_host",
@@ -62,6 +63,7 @@ _PUBLIC_TASK_STAGING_STRING_FIELDS = (
     "verifier_uv_bootstrap_version",
     "verifier_uv_bootstrap_mirror_host",
 )
+_COMPOSE_EXCEPTION_FINGERPRINT_TEXT_LIMIT = 64 * 1024
 
 
 class SkillsBenchComposeCommandFailure(RuntimeError):
@@ -85,6 +87,27 @@ def skillsbench_compose_typed_fingerprint(
     return dict(exc.fingerprint)
 
 
+def _compose_exception_fingerprint_text(exc: Exception) -> str:
+    """Collect producer-owned output only long enough to derive a fingerprint."""
+
+    parts: list[str] = []
+    remaining = _COMPOSE_EXCEPTION_FINGERPRINT_TEXT_LIMIT
+    for value in (
+        str(exc),
+        getattr(exc, "stderr", None),
+        getattr(exc, "stdout", None),
+        getattr(exc, "output", None),
+    ):
+        if isinstance(value, bytes):
+            value = value.decode("utf-8", errors="replace")
+        if not isinstance(value, str) or not value or remaining <= 0:
+            continue
+        part = value[:remaining]
+        parts.append(part)
+        remaining -= len(part) + 1
+    return "\n".join(parts)
+
+
 def install_skillsbench_compose_typed_cause_boundary(
     environment: Any,
 ) -> Callable[[], None] | None:
@@ -100,7 +123,9 @@ def install_skillsbench_compose_typed_cause_boundary(
         except SkillsBenchComposeCommandFailure:
             raise
         except Exception as exc:
-            fingerprint = skillsbench_runner_error_fingerprint(str(exc))
+            fingerprint = skillsbench_runner_error_fingerprint(
+                _compose_exception_fingerprint_text(exc)
+            )
             raise SkillsBenchComposeCommandFailure(fingerprint) from None
 
     try:

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -33,6 +33,8 @@ Optional env:
                                        to Docker CLI/Compose; default auto
   SKILLSBENCH_DOCKER_PIP_INDEX_MODE    Staged Dockerfile pip index: mirror
                                        (default) or primary
+  SKILLSBENCH_DOCKER_PIP_BUILD_MODE    Staged Dockerfile pip build mode:
+                                       isolated (default) or no-isolation
   SKILLSBENCH_ROUTE                    Route, default codex-cli-goal-baseline
   SKILLSBENCH_MODEL                    Model, default gpt-5.5
   SKILLSBENCH_REASONING_EFFORT         Reasoning effort, default xhigh
@@ -214,6 +216,7 @@ allow_staged_bootstrap_repair_run="${SKILLSBENCH_ALLOW_STAGED_BOOTSTRAP_REPAIR_R
 setup_only_public_preflight="${SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT:-0}"
 benchmark_egress_proxy_mode="${SKILLSBENCH_BENCHMARK_EGRESS_PROXY_MODE:-require}"
 docker_pip_index_mode="${SKILLSBENCH_DOCKER_PIP_INDEX_MODE:-mirror}"
+docker_pip_build_mode="${SKILLSBENCH_DOCKER_PIP_BUILD_MODE:-isolated}"
 product_mode_soft_verify_policy="${SKILLSBENCH_PRODUCT_MODE_SOFT_VERIFY_POLICY:-}"
 remote_command_file_bridge_probe_command="${SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_COMMAND:-}"
 remote_command_file_bridge_solver_command="${SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_SOLVER_COMMAND:-}"
@@ -247,6 +250,11 @@ fi
 if [[ "$docker_pip_index_mode" != "mirror" ]] &&
   [[ "$docker_pip_index_mode" != "primary" ]]; then
   echo "SKILLSBENCH_DOCKER_PIP_INDEX_MODE must be mirror or primary" >&2
+  exit 2
+fi
+if [[ "$docker_pip_build_mode" != "isolated" ]] &&
+  [[ "$docker_pip_build_mode" != "no-isolation" ]]; then
+  echo "SKILLSBENCH_DOCKER_PIP_BUILD_MODE must be isolated or no-isolation" >&2
   exit 2
 fi
 validate_bool_toggle \
@@ -539,6 +547,7 @@ remote_command=$(
     --codex-api-reverse-tunnel-proxy "$loopback_proxy_url" \
     --benchmark-egress-proxy-mode "$benchmark_egress_proxy_mode" \
     --docker-pip-index-mode "$docker_pip_index_mode" \
+    --docker-pip-build-mode "$docker_pip_build_mode" \
     --host-local-acp-launch \
     --local-codex-bin "$remote_codex_bin" \
     --local-codex-sandbox "$local_codex_sandbox" \
@@ -625,6 +634,7 @@ if [[ "$dry_run" == "true" ]]; then
     "$public_artifact_sync_interval"
   printf 'benchmark_egress_proxy_mode=%s\n' "$benchmark_egress_proxy_mode"
   printf 'docker_pip_index_mode=%s\n' "$docker_pip_index_mode"
+  printf 'docker_pip_build_mode=%s\n' "$docker_pip_build_mode"
   printf 'product_mode_soft_verify_policy=%s\n' \
     "${product_mode_soft_verify_policy:-runner-default}"
   printf 'remote_command_file_bridge_probe_command_configured=%s\n' \

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -436,6 +436,8 @@ DOCKER_PIP_INDEX_MODES = {
     "mirror": (DEFAULT_DOCKER_PIP_INDEX_URL, DEFAULT_DOCKER_PIP_INDEX_HOST),
     "primary": (PRIMARY_DOCKER_PIP_INDEX_URL, PRIMARY_DOCKER_PIP_INDEX_HOST),
 }
+DEFAULT_DOCKER_PIP_BUILD_MODE = "isolated"
+DOCKER_PIP_BUILD_MODES = ("isolated", "no-isolation")
 DOCKER_HOST_CPU_ENV = "LOOPX_SKILLSBENCH_DOCKER_CPUS"
 SANDBOX_PATH_RE = re.compile(r"/(?:app|root|workspace|tmp)/[A-Za-z0-9_./-]+")
 LOOPX_CLI_RE = re.compile(r"(?:^|\s|/)loopx(?:\s|$)")
@@ -7751,20 +7753,33 @@ def _docker_pip_index(mode: str) -> tuple[str, str]:
         raise ValueError(f"unsupported Docker pip index mode: {mode}") from exc
 
 
+def _docker_pip_build_mode(mode: str) -> str:
+    if mode not in DOCKER_PIP_BUILD_MODES:
+        raise ValueError(f"unsupported Docker pip build mode: {mode}")
+    return mode
+
+
 def patch_dockerfile_pip_bootstrap(
     dockerfile: Path,
     *,
     index_url: str = DEFAULT_DOCKER_PIP_INDEX_URL,
+    build_mode: str = DEFAULT_DOCKER_PIP_BUILD_MODE,
 ) -> bool:
     """Add public-safe pip retry/index defaults to staged Dockerfiles."""
 
     if not dockerfile_needs_pip_bootstrap_patch(dockerfile):
         return False
+    build_mode = _docker_pip_build_mode(build_mode)
     original = dockerfile.read_text(encoding="utf-8")
     text = _strip_marker_block(
         original,
         DOCKER_PIP_BOOTSTRAP_BEGIN,
         DOCKER_PIP_BOOTSTRAP_END,
+    )
+    build_mode_env = (
+        "    PIP_NO_BUILD_ISOLATION=1 \\\n"
+        if build_mode == "no-isolation"
+        else ""
     )
     block = (
         f"{DOCKER_PIP_BOOTSTRAP_BEGIN}\n"
@@ -7772,6 +7787,7 @@ def patch_dockerfile_pip_bootstrap(
         "ENV PIP_INDEX_URL=${LOOPX_SKILLSBENCH_PIP_INDEX_URL} \\\n"
         "    PIP_DEFAULT_TIMEOUT=120 \\\n"
         "    PIP_RETRIES=10 \\\n"
+        f"{build_mode_env}"
         "    PIP_DISABLE_PIP_VERSION_CHECK=1\n"
         f"{DOCKER_PIP_BOOTSTRAP_END}"
     )
@@ -8000,6 +8016,7 @@ def stage_task_for_sandbox(
     include_task_skills: bool = True,
     benchmark_egress_proxy_env: Mapping[str, str] | None = None,
     docker_pip_index_mode: str = DEFAULT_DOCKER_PIP_INDEX_MODE,
+    docker_pip_build_mode: str = DEFAULT_DOCKER_PIP_BUILD_MODE,
     docker_gcr_mirror_prefix: str = "",
     verifier_dependency_cache_enabled: bool = False,
     loopx_case_runtime_required: bool = False,
@@ -8010,6 +8027,7 @@ def stage_task_for_sandbox(
     docker_pip_index_url, docker_pip_index_host = _docker_pip_index(
         docker_pip_index_mode
     )
+    docker_pip_build_mode = _docker_pip_build_mode(docker_pip_build_mode)
     metadata: dict[str, Any] = {
         "schema_version": "skillsbench_task_staging_v0",
         "original_task_name": task_path.name,
@@ -8194,6 +8212,7 @@ def stage_task_for_sandbox(
     )
     if needs_pip_bootstrap_patch:
         metadata["dockerfile_pip_index_host"] = docker_pip_index_host
+        metadata["dockerfile_pip_build_mode"] = docker_pip_build_mode
     metadata["dockerfile_gcr_mirror_patch_required"] = needs_gcr_mirror_patch
     metadata["dockerfile_elan_toolchain_retry_patch_required"] = (
         needs_elan_toolchain_retry_patch
@@ -8353,6 +8372,7 @@ def stage_task_for_sandbox(
     pip_bootstrap_patched = patch_dockerfile_pip_bootstrap(
         staged_path / "environment" / "Dockerfile",
         index_url=docker_pip_index_url,
+        build_mode=docker_pip_build_mode,
     )
     venv_pip_invocation_patched = dockerfile_runtime.patch_venv_pip_invocations(
         staged_path / "environment" / "Dockerfile"
@@ -8431,6 +8451,9 @@ def stage_task_for_sandbox(
             ),
             "dockerfile_pip_index_host": (
                 docker_pip_index_host if pip_bootstrap_patched else ""
+            ),
+            "dockerfile_pip_build_mode": (
+                docker_pip_build_mode if pip_bootstrap_patched else ""
             ),
             "dockerfile_gcr_mirror_patch_applied": gcr_mirror_patched,
             "dockerfile_gcr_mirror_raw_prefix_recorded": False,
@@ -8546,6 +8569,9 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
     task_id = args.task_id
     route = args.route
     _, docker_pip_index_host = _docker_pip_index(args.docker_pip_index_mode)
+    docker_pip_build_mode = _docker_pip_build_mode(
+        getattr(args, "docker_pip_build_mode", DEFAULT_DOCKER_PIP_BUILD_MODE)
+    )
     route_slug = route.replace("-", "_")
     intermediate_soft_verify_policy = product_mode_soft_verify_policy_for_route(
         route,
@@ -8776,6 +8802,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         "run_group_id": str(args.run_group_id or ""),
         "sandbox": args.sandbox,
         "docker_pip_index_mode": args.docker_pip_index_mode,
+        "docker_pip_build_mode": docker_pip_build_mode,
         "max_rounds": args.max_rounds,
         "independent_goal_retry": {
             "schema_version": "skillsbench_independent_goal_retry_config_v0",
@@ -9355,6 +9382,7 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
         "app_server_goal_prompt_style",
         "sandbox",
         "docker_pip_index_mode",
+        "docker_pip_build_mode",
         "run_group_id",
         "job_name",
         "rollout_name",
@@ -13763,6 +13791,7 @@ async def run_benchflow_case(
         include_task_skills=bool(args.include_task_skills),
         benchmark_egress_proxy_env=_benchmark_egress_proxy_env(args),
         docker_pip_index_mode=args.docker_pip_index_mode,
+        docker_pip_build_mode=args.docker_pip_build_mode,
         docker_gcr_mirror_prefix=args.docker_gcr_mirror_prefix,
         verifier_dependency_cache_enabled=(
             verifier_dependency_cache_policy_enabled
@@ -16617,6 +16646,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "Public package index used by the staged Dockerfile pip bootstrap "
             "repair. mirror preserves the default; primary provides a bounded "
             "fallback after a typed mirror-network setup failure."
+        ),
+    )
+    parser.add_argument(
+        "--docker-pip-build-mode",
+        choices=DOCKER_PIP_BUILD_MODES,
+        default=DEFAULT_DOCKER_PIP_BUILD_MODE,
+        help=(
+            "Build-isolation policy used by the staged Dockerfile pip bootstrap. "
+            "isolated preserves the default; no-isolation is a bounded fallback "
+            "after a typed build-dependency subprocess failure."
         ),
     )
     parser.add_argument(

--- a/tests/test_skillsbench_setup_preflight.py
+++ b/tests/test_skillsbench_setup_preflight.py
@@ -79,6 +79,7 @@ def run_preflight() -> dict[str, Any]:
                 "dockerfile_debian_apt_mirror_host": "mirror.example",
                 "dockerfile_debian_apt_mirror_raw_url_recorded": False,
                 "dockerfile_pip_bootstrap_patch_applied": True,
+                "dockerfile_pip_build_mode": "no-isolation",
                 "unrelated": "/private/should-not-project",
             },
             setup_preflight={
@@ -114,6 +115,7 @@ def test_setup_only_preflight_stops_before_agent_and_verifier() -> None:
         "dockerfile_debian_apt_mirror_host": "mirror.example",
         "dockerfile_debian_apt_mirror_raw_url_recorded": False,
         "dockerfile_pip_bootstrap_patch_applied": True,
+        "dockerfile_pip_build_mode": "no-isolation",
     }
     assert FakeRollout.events == ["create", "setup", "start", "cleanup"]
     serialized = json.dumps(result, sort_keys=True)
@@ -182,6 +184,23 @@ def test_primary_pip_index_mode_is_publicly_attributable() -> None:
 
     assert plan["docker_pip_index_mode"] == "primary"
     assert public_config["docker_pip_index_mode"] == "primary"
+
+
+def test_no_isolation_pip_build_mode_is_publicly_attributable() -> None:
+    args = parse_args(
+        [
+            "--task-id",
+            "flink-query",
+            "--docker-pip-build-mode",
+            "no-isolation",
+        ]
+    )
+
+    plan = build_plan(args)
+    public_config = _public_runner_config(plan)
+
+    assert plan["docker_pip_build_mode"] == "no-isolation"
+    assert public_config["docker_pip_build_mode"] == "no-isolation"
 
 
 @pytest.mark.parametrize(
@@ -359,6 +378,43 @@ def test_compose_producer_emits_only_bounded_typed_cause() -> None:
     with pytest.raises(RuntimeError, match="Docker compose command failed"):
         asyncio.run(invoke())
     assert environment.command_attempts == 4
+
+
+def test_compose_producer_fingerprints_exception_output_without_recording_it() -> None:
+    raw_stderr = (
+        "private build output: pip subprocess to install build dependencies "
+        "did not run successfully at /private/job"
+    )
+
+    class ComposeFailure(RuntimeError):
+        def __init__(self) -> None:
+            super().__init__("docker compose build returned exit status 1")
+            self.stderr = raw_stderr
+
+    class FakeComposeEnvironment:
+        async def _run_docker_compose_build(self) -> None:
+            raise ComposeFailure()
+
+    environment = FakeComposeEnvironment()
+    restore = install_skillsbench_compose_typed_cause_boundary(environment)
+    assert restore is not None
+
+    async def invoke() -> None:
+        await environment._run_docker_compose_build()
+
+    with pytest.raises(SkillsBenchComposeCommandFailure) as error:
+        asyncio.run(invoke())
+
+    typed = error.value
+    serialized = json.dumps(typed.fingerprint, sort_keys=True)
+    assert typed.fingerprint["pip_failure_subtype"] == (
+        "build_dependency_subprocess_failed"
+    )
+    assert "pip_bootstrap_failure" in typed.fingerprint["matched_patterns"]
+    assert "pip_build_failure" in typed.fingerprint["failure_reason_codes"]
+    assert raw_stderr not in serialized
+    assert "/private/job" not in serialized
+    assert raw_stderr not in str(typed)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -245,6 +245,45 @@ def test_launcher_rejects_unbounded_pip_index_mode(tmp_path: Path) -> None:
     )
 
 
+def test_launcher_wires_bounded_no_isolation_pip_build_mode(tmp_path: Path) -> None:
+    env = _base_env(tmp_path)
+    env["SKILLSBENCH_DOCKER_PIP_BUILD_MODE"] = "no-isolation"
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "pip-build-mode"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+
+    assert "docker_pip_build_mode=no-isolation" in proc.stdout
+    assert "--docker-pip-build-mode no-isolation" in proc.stdout
+
+
+def test_launcher_rejects_unbounded_pip_build_mode(tmp_path: Path) -> None:
+    env = _base_env(tmp_path)
+    env["SKILLSBENCH_DOCKER_PIP_BUILD_MODE"] = "arbitrary-flags"
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "invalid-pip-build"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    assert (
+        "SKILLSBENCH_DOCKER_PIP_BUILD_MODE must be isolated or no-isolation"
+        in proc.stderr
+    )
+
+
 def test_setup_only_launcher_enables_incremental_public_artifact_sync(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- fingerprint exception-carried compose output at the producer boundary without retaining raw stdout, stderr, paths, or command text
- add a bounded `isolated` / `no-isolation` pip build mode for staged SkillsBench Dockerfiles, with the existing isolated behavior as the default
- expose the selected mode through public-safe staging and runner configuration, and wire the existing launcher environment contract

## Product and architecture judgment

The remaining setup failures could not be classified when the exception message omitted subprocess output, and typed build-dependency failures had no reversible compatibility mode. This keeps both behaviors inside the existing SkillsBench setup adapter: producer output is reduced immediately to the established fingerprint schema, while the fallback is a fixed enum rather than arbitrary pip flags. It does not change scoring, task semantics, verifier behavior, submissions, or the default build path.

## Validation

- `48 passed` across focused setup-preflight and launcher tests
- `skillsbench-failure-attribution-smoke: ok`
- `skillsbench-benchmark-run-smoke: ok`
- Python compile and shell syntax checks passed
- premerge canary: all 6 selected catalog canaries passed
- premerge public-boundary scan passed
- diff hygiene passed

## Holds and residual risk

- Premerge reports the standard `benchmark_sensitive` manual hold; there were no automated failures.
- `no-isolation` is opt-in and may still fail when a task image lacks its required build backend. The producer-side fingerprint then preserves a bounded typed cause for the next repair decision.
- No benchmark job, agent execution, verifier execution, upload, or submission is included in this PR.
- Raw benchmark evidence, private state, credentials, local paths, and generated logs are excluded.
