### PR TITLE
Add controlled SkillsBench apt source fallback

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -5676,6 +5676,44 @@ def test_skillsbench_docker_task_staging_adds_debian_apt_mirror_patch() -> None:
         assert "LOOPX_SKILLSBENCH_DEBIAN_APT_MIRROR" in staged_text
 
 
+def test_skillsbench_docker_task_staging_can_keep_primary_apt_sources() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-primary-apt-stage-") as tmp:
+        root = Path(tmp)
+        task = root / "tasks" / "primary-apt-probe"
+        dockerfile = task / "environment" / "Dockerfile"
+        dockerfile.parent.mkdir(parents=True)
+        original_text = (
+            "FROM ubuntu:24.04\n\n"
+            "RUN apt-get update && apt-get install -y --no-install-recommends curl\n"
+        )
+        dockerfile.write_text(original_text, encoding="utf-8")
+        (task / "task.toml").write_text("version = \"1.1\"\n", encoding="utf-8")
+
+        staged_path, metadata = stage_task_for_sandbox(
+            task_path=task,
+            jobs_dir=root / "jobs",
+            job_name="primary-apt-probe",
+            sandbox="docker",
+            docker_apt_source_mode="primary",
+        )
+
+        assert metadata["staged"] is True, metadata
+        assert metadata["dockerfile_apt_source_mode"] == "primary", metadata
+        assert metadata["apt_retry_patch_applied"] is True, metadata
+        assert metadata["dockerfile_ubuntu_apt_mirror_patch_required"] is False
+        assert metadata["dockerfile_ubuntu_apt_mirror_patch_applied"] is False
+        assert metadata["dockerfile_debian_apt_mirror_patch_required"] is False
+        assert metadata["dockerfile_debian_apt_mirror_patch_applied"] is False
+        assert metadata["original_task_mutated"] is False, metadata
+        assert dockerfile.read_text(encoding="utf-8") == original_text
+        staged_text = (staged_path / "environment" / "Dockerfile").read_text(
+            encoding="utf-8"
+        )
+        assert DOCKER_APT_RETRY_BEGIN in staged_text
+        assert dockerfile_runtime.UBUNTU_APT_MIRROR_BEGIN not in staged_text
+        assert dockerfile_runtime.DEBIAN_APT_MIRROR_BEGIN not in staged_text
+
+
 def test_skillsbench_no_skill_route_removes_staged_task_skills() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-no-skill-stage-") as tmp:
         root = Path(tmp)
@@ -5743,6 +5781,7 @@ def test_skillsbench_docker_task_staging_adds_apt_retry_patch() -> None:
         assert metadata["apt_retry_patch_required"] is True, metadata
         assert metadata["apt_risk_preflight_blocked"] is False, metadata
         assert metadata["apt_retry_patch_applied"] is True, metadata
+        assert metadata["dockerfile_apt_source_mode"] == "mirror", metadata
         assert (
             metadata["dockerfile_ubuntu_apt_mirror_patch_required"] is True
         ), metadata

--- a/loopx/benchmark_adapters/skillsbench_setup_preflight.py
+++ b/loopx/benchmark_adapters/skillsbench_setup_preflight.py
@@ -52,6 +52,7 @@ _PUBLIC_TASK_STAGING_BOOL_FIELDS = (
 )
 _PUBLIC_TASK_STAGING_STRING_FIELDS = (
     "schema_version",
+    "dockerfile_apt_source_mode",
     "dockerfile_ubuntu_apt_mirror_host",
     "dockerfile_debian_apt_mirror_host",
     "dockerfile_pip_index_host",

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -31,6 +31,8 @@ Optional env:
                                        require (default), auto, or off
   SKILLSBENCH_DOCKER_API_VERSION       Remote Docker daemon API version passed
                                        to Docker CLI/Compose; default auto
+  SKILLSBENCH_DOCKER_APT_SOURCE_MODE   Staged Dockerfile apt sources: mirror
+                                       (default) or primary
   SKILLSBENCH_DOCKER_PIP_INDEX_MODE    Staged Dockerfile pip index: mirror
                                        (default) or primary
   SKILLSBENCH_DOCKER_PIP_BUILD_MODE    Staged Dockerfile pip build mode:
@@ -215,6 +217,7 @@ skip_current_aggregate_update="${SKILLSBENCH_SKIP_CURRENT_AGGREGATE_UPDATE:-0}"
 allow_staged_bootstrap_repair_run="${SKILLSBENCH_ALLOW_STAGED_BOOTSTRAP_REPAIR_RUN:-0}"
 setup_only_public_preflight="${SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT:-0}"
 benchmark_egress_proxy_mode="${SKILLSBENCH_BENCHMARK_EGRESS_PROXY_MODE:-require}"
+docker_apt_source_mode="${SKILLSBENCH_DOCKER_APT_SOURCE_MODE:-mirror}"
 docker_pip_index_mode="${SKILLSBENCH_DOCKER_PIP_INDEX_MODE:-mirror}"
 docker_pip_build_mode="${SKILLSBENCH_DOCKER_PIP_BUILD_MODE:-isolated}"
 product_mode_soft_verify_policy="${SKILLSBENCH_PRODUCT_MODE_SOFT_VERIFY_POLICY:-}"
@@ -250,6 +253,11 @@ fi
 if [[ "$docker_pip_index_mode" != "mirror" ]] &&
   [[ "$docker_pip_index_mode" != "primary" ]]; then
   echo "SKILLSBENCH_DOCKER_PIP_INDEX_MODE must be mirror or primary" >&2
+  exit 2
+fi
+if [[ "$docker_apt_source_mode" != "mirror" ]] &&
+  [[ "$docker_apt_source_mode" != "primary" ]]; then
+  echo "SKILLSBENCH_DOCKER_APT_SOURCE_MODE must be mirror or primary" >&2
   exit 2
 fi
 if [[ "$docker_pip_build_mode" != "isolated" ]] &&
@@ -546,6 +554,7 @@ remote_command=$(
     --codex-api-egress-mode reverse-tunnel \
     --codex-api-reverse-tunnel-proxy "$loopback_proxy_url" \
     --benchmark-egress-proxy-mode "$benchmark_egress_proxy_mode" \
+    --docker-apt-source-mode "$docker_apt_source_mode" \
     --docker-pip-index-mode "$docker_pip_index_mode" \
     --docker-pip-build-mode "$docker_pip_build_mode" \
     --host-local-acp-launch \
@@ -633,6 +642,7 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'public_artifact_sync_interval_sec=%s\n' \
     "$public_artifact_sync_interval"
   printf 'benchmark_egress_proxy_mode=%s\n' "$benchmark_egress_proxy_mode"
+  printf 'docker_apt_source_mode=%s\n' "$docker_apt_source_mode"
   printf 'docker_pip_index_mode=%s\n' "$docker_pip_index_mode"
   printf 'docker_pip_build_mode=%s\n' "$docker_pip_build_mode"
   printf 'product_mode_soft_verify_policy=%s\n' \

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -436,6 +436,8 @@ DOCKER_PIP_INDEX_MODES = {
     "mirror": (DEFAULT_DOCKER_PIP_INDEX_URL, DEFAULT_DOCKER_PIP_INDEX_HOST),
     "primary": (PRIMARY_DOCKER_PIP_INDEX_URL, PRIMARY_DOCKER_PIP_INDEX_HOST),
 }
+DEFAULT_DOCKER_APT_SOURCE_MODE = "mirror"
+DOCKER_APT_SOURCE_MODES = ("mirror", "primary")
 DEFAULT_DOCKER_PIP_BUILD_MODE = "isolated"
 DOCKER_PIP_BUILD_MODES = ("isolated", "no-isolation")
 DOCKER_HOST_CPU_ENV = "LOOPX_SKILLSBENCH_DOCKER_CPUS"
@@ -5886,6 +5888,7 @@ def _public_task_staging(value: Any) -> dict[str, Any]:
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
     for field in (
+        "dockerfile_apt_source_mode",
         "dockerfile_pip_index_host",
         "bootstrap_light_blocker_kind",
         "dockerfile_uv_bootstrap_version",
@@ -5939,6 +5942,12 @@ def _public_task_staging(value: Any) -> dict[str, Any]:
 
 
 def _discover_prepared_task_staging(plan: dict[str, Any]) -> dict[str, Any]:
+    docker_apt_source_mode = _docker_apt_source_mode(
+        str(
+            plan.get("docker_apt_source_mode")
+            or DEFAULT_DOCKER_APT_SOURCE_MODE
+        )
+    )
     _, docker_pip_index_host = _docker_pip_index(
         str(plan.get("docker_pip_index_mode") or DEFAULT_DOCKER_PIP_INDEX_MODE)
     )
@@ -5978,6 +5987,9 @@ def _discover_prepared_task_staging(plan: dict[str, Any]) -> dict[str, Any]:
             DOCKER_APP_SKILLS_MOUNT_BEGIN in dockerfile_text
         ),
         "apt_retry_patch_applied": DOCKER_APT_RETRY_BEGIN in dockerfile_text,
+        "dockerfile_apt_source_mode": (
+            docker_apt_source_mode if DOCKER_APT_RETRY_BEGIN in dockerfile_text else ""
+        ),
         "dockerfile_ubuntu_apt_mirror_patch_applied": (
             dockerfile_runtime.UBUNTU_APT_MIRROR_BEGIN in dockerfile_text
         ),
@@ -7759,6 +7771,12 @@ def _docker_pip_build_mode(mode: str) -> str:
     return mode
 
 
+def _docker_apt_source_mode(mode: str) -> str:
+    if mode not in DOCKER_APT_SOURCE_MODES:
+        raise ValueError(f"unsupported Docker apt source mode: {mode}")
+    return mode
+
+
 def patch_dockerfile_pip_bootstrap(
     dockerfile: Path,
     *,
@@ -8015,6 +8033,7 @@ def stage_task_for_sandbox(
     sandbox: str,
     include_task_skills: bool = True,
     benchmark_egress_proxy_env: Mapping[str, str] | None = None,
+    docker_apt_source_mode: str = DEFAULT_DOCKER_APT_SOURCE_MODE,
     docker_pip_index_mode: str = DEFAULT_DOCKER_PIP_INDEX_MODE,
     docker_pip_build_mode: str = DEFAULT_DOCKER_PIP_BUILD_MODE,
     docker_gcr_mirror_prefix: str = "",
@@ -8024,6 +8043,7 @@ def stage_task_for_sandbox(
     """Return the task path to run, staging Docker tasks when setup needs it."""
 
     task_path = task_path.expanduser().resolve()
+    docker_apt_source_mode = _docker_apt_source_mode(docker_apt_source_mode)
     docker_pip_index_url, docker_pip_index_host = _docker_pip_index(
         docker_pip_index_mode
     )
@@ -8036,6 +8056,7 @@ def stage_task_for_sandbox(
         "staged": False,
         "app_skills_mount_patch_applied": False,
         "apt_retry_patch_applied": False,
+        "dockerfile_apt_source_mode": "",
         "dockerfile_ubuntu_apt_mirror_patch_required": False,
         "dockerfile_ubuntu_apt_mirror_patch_applied": False,
         "dockerfile_ubuntu_apt_mirror_host": "",
@@ -8121,12 +8142,14 @@ def stage_task_for_sandbox(
         task_path / "environment" / "Dockerfile"
     )
     needs_ubuntu_apt_mirror_patch = (
-        dockerfile_runtime.needs_ubuntu_apt_mirror_patch(
+        docker_apt_source_mode == "mirror"
+        and dockerfile_runtime.needs_ubuntu_apt_mirror_patch(
             task_path / "environment" / "Dockerfile"
         )
     )
     needs_debian_apt_mirror_patch = (
-        dockerfile_runtime.needs_debian_apt_mirror_patch(
+        docker_apt_source_mode == "mirror"
+        and dockerfile_runtime.needs_debian_apt_mirror_patch(
             task_path / "environment" / "Dockerfile"
         )
     )
@@ -8191,6 +8214,8 @@ def stage_task_for_sandbox(
     metadata["apt_setup_risk_detected"] = needs_apt_retry_patch
     metadata["apt_retry_patch_required"] = needs_apt_retry_patch
     metadata["apt_risk_preflight_blocked"] = False
+    if needs_apt_retry_patch:
+        metadata["dockerfile_apt_source_mode"] = docker_apt_source_mode
     metadata["dockerfile_ubuntu_apt_mirror_patch_required"] = (
         needs_ubuntu_apt_mirror_patch
     )
@@ -8568,6 +8593,9 @@ def stage_task_for_sandbox(
 def build_plan(args: argparse.Namespace) -> dict[str, Any]:
     task_id = args.task_id
     route = args.route
+    docker_apt_source_mode = _docker_apt_source_mode(
+        getattr(args, "docker_apt_source_mode", DEFAULT_DOCKER_APT_SOURCE_MODE)
+    )
     _, docker_pip_index_host = _docker_pip_index(args.docker_pip_index_mode)
     docker_pip_build_mode = _docker_pip_build_mode(
         getattr(args, "docker_pip_build_mode", DEFAULT_DOCKER_PIP_BUILD_MODE)
@@ -8801,6 +8829,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         ),
         "run_group_id": str(args.run_group_id or ""),
         "sandbox": args.sandbox,
+        "docker_apt_source_mode": docker_apt_source_mode,
         "docker_pip_index_mode": args.docker_pip_index_mode,
         "docker_pip_build_mode": docker_pip_build_mode,
         "max_rounds": args.max_rounds,
@@ -9381,6 +9410,7 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
         "app_server_reasoning_effort",
         "app_server_goal_prompt_style",
         "sandbox",
+        "docker_apt_source_mode",
         "docker_pip_index_mode",
         "docker_pip_build_mode",
         "run_group_id",
@@ -13790,6 +13820,9 @@ async def run_benchflow_case(
         sandbox=args.sandbox,
         include_task_skills=bool(args.include_task_skills),
         benchmark_egress_proxy_env=_benchmark_egress_proxy_env(args),
+        docker_apt_source_mode=getattr(
+            args, "docker_apt_source_mode", DEFAULT_DOCKER_APT_SOURCE_MODE
+        ),
         docker_pip_index_mode=args.docker_pip_index_mode,
         docker_pip_build_mode=args.docker_pip_build_mode,
         docker_gcr_mirror_prefix=args.docker_gcr_mirror_prefix,
@@ -16636,6 +16669,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help=(
             "Timeout for the benchmark setup/verifier egress proxy preflight. "
             "The probe records no raw proxy URL or raw response output."
+        ),
+    )
+    parser.add_argument(
+        "--docker-apt-source-mode",
+        choices=DOCKER_APT_SOURCE_MODES,
+        default=DEFAULT_DOCKER_APT_SOURCE_MODE,
+        help=(
+            "Apt source policy used by staged Dockerfile repair. mirror "
+            "preserves the default fixed mirrors; primary keeps the task's "
+            "original sources as a bounded fallback after a typed mirror "
+            "network failure."
         ),
     )
     parser.add_argument(

--- a/tests/test_skillsbench_setup_preflight.py
+++ b/tests/test_skillsbench_setup_preflight.py
@@ -74,6 +74,7 @@ def run_preflight() -> dict[str, Any]:
             config=object(),
             task_staging={
                 "apt_retry_patch_applied": True,
+                "dockerfile_apt_source_mode": "mirror",
                 "dockerfile_debian_apt_mirror_patch_required": True,
                 "dockerfile_debian_apt_mirror_patch_applied": True,
                 "dockerfile_debian_apt_mirror_host": "mirror.example",
@@ -110,6 +111,7 @@ def test_setup_only_preflight_stops_before_agent_and_verifier() -> None:
     ]
     assert result["task_staging"] == {
         "apt_retry_patch_applied": True,
+        "dockerfile_apt_source_mode": "mirror",
         "dockerfile_debian_apt_mirror_patch_required": True,
         "dockerfile_debian_apt_mirror_patch_applied": True,
         "dockerfile_debian_apt_mirror_host": "mirror.example",
@@ -184,6 +186,23 @@ def test_primary_pip_index_mode_is_publicly_attributable() -> None:
 
     assert plan["docker_pip_index_mode"] == "primary"
     assert public_config["docker_pip_index_mode"] == "primary"
+
+
+def test_primary_apt_source_mode_is_publicly_attributable() -> None:
+    args = parse_args(
+        [
+            "--task-id",
+            "flink-query",
+            "--docker-apt-source-mode",
+            "primary",
+        ]
+    )
+
+    plan = build_plan(args)
+    public_config = _public_runner_config(plan)
+
+    assert plan["docker_apt_source_mode"] == "primary"
+    assert public_config["docker_apt_source_mode"] == "primary"
 
 
 def test_no_isolation_pip_build_mode_is_publicly_attributable() -> None:

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -225,6 +225,44 @@ def test_launcher_wires_bounded_primary_pip_index_mode(tmp_path: Path) -> None:
     assert "--docker-pip-index-mode primary" in proc.stdout
 
 
+def test_launcher_wires_bounded_primary_apt_source_mode(tmp_path: Path) -> None:
+    env = _base_env(tmp_path)
+    env["SKILLSBENCH_DOCKER_APT_SOURCE_MODE"] = "primary"
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "primary-apt"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+
+    assert "docker_apt_source_mode=primary" in proc.stdout
+    assert "--docker-apt-source-mode primary" in proc.stdout
+
+
+def test_launcher_rejects_unbounded_apt_source_mode(tmp_path: Path) -> None:
+    env = _base_env(tmp_path)
+    env["SKILLSBENCH_DOCKER_APT_SOURCE_MODE"] = "private-url"
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "invalid-apt"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    assert "SKILLSBENCH_DOCKER_APT_SOURCE_MODE must be mirror or primary" in (
+        proc.stderr
+    )
+
+
 def test_launcher_rejects_unbounded_pip_index_mode(tmp_path: Path) -> None:
     env = _base_env(tmp_path)
     env["SKILLSBENCH_DOCKER_PIP_INDEX_MODE"] = "private-url"


### PR DESCRIPTION
## Summary
- add a bounded `mirror|primary` apt source mode for staged SkillsBench Dockerfiles
- keep mirror mode as the default; primary preserves task-owned sources while retaining apt retry hardening
- project the selected mode through runner config and setup-only public receipts

## Validation
- 51 focused pytest cases passed
- `skillsbench-failure-attribution-smoke` passed
- `skillsbench-benchmark-run-smoke` passed
- Python compile, shell syntax, and diff checks passed
- premerge canary: 6/6 catalog canaries and public-boundary scan passed

## Hold / scope
- premerge reports the expected `benchmark_sensitive` manual hold
- owner has explicitly authorized self-merge for bounded benchmark helper/runtime changes
- no scoring, task semantics, submission, upload, or verifier-feedback behavior changes
- no raw benchmark evidence, private state, credentials, local paths, or generated logs included