### PR TITLE
Honor SkillsBench primary apt source mode

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -14862,6 +14862,7 @@ if __name__ == "__main__":
     test_skillsbench_codex_acp_post_success_finalization_route()
     test_skillsbench_docker_task_staging_adds_app_skills_mount()
     test_skillsbench_docker_task_staging_adds_debian_apt_mirror_patch()
+    test_skillsbench_docker_task_staging_can_keep_primary_apt_sources()
     test_skillsbench_no_skill_route_removes_staged_task_skills()
     test_skillsbench_docker_task_staging_adds_apt_retry_patch()
     test_skillsbench_docker_task_staging_apt_retry_is_nonroot_safe()

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -8388,11 +8388,17 @@ def stage_task_for_sandbox(
     apt_retry_patched = patch_dockerfile_apt_retry(
         staged_path / "environment" / "Dockerfile"
     )
-    ubuntu_apt_mirror_patched = dockerfile_runtime.patch_ubuntu_apt_mirror(
-        staged_path / "environment" / "Dockerfile"
+    ubuntu_apt_mirror_patched = bool(
+        needs_ubuntu_apt_mirror_patch
+        and dockerfile_runtime.patch_ubuntu_apt_mirror(
+            staged_path / "environment" / "Dockerfile"
+        )
     )
-    debian_apt_mirror_patched = dockerfile_runtime.patch_debian_apt_mirror(
-        staged_path / "environment" / "Dockerfile"
+    debian_apt_mirror_patched = bool(
+        needs_debian_apt_mirror_patch
+        and dockerfile_runtime.patch_debian_apt_mirror(
+            staged_path / "environment" / "Dockerfile"
+        )
     )
     pip_bootstrap_patched = patch_dockerfile_pip_bootstrap(
         staged_path / "environment" / "Dockerfile",

--- a/tests/test_skillsbench_setup_preflight.py
+++ b/tests/test_skillsbench_setup_preflight.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -18,11 +19,13 @@ from loopx.benchmark_adapters.skillsbench_setup_preflight import (
 )
 from loopx.status import compact_benchmark_run
 from scripts.skillsbench_automation_loop import (
+    DOCKER_APT_RETRY_BEGIN,
     _effective_setup_only_stage_timeout_sec,
     _public_runner_config,
     build_compose_setup_diagnostic,
     build_plan,
     parse_args,
+    stage_task_for_sandbox,
 )
 
 
@@ -203,6 +206,38 @@ def test_primary_apt_source_mode_is_publicly_attributable() -> None:
 
     assert plan["docker_apt_source_mode"] == "primary"
     assert public_config["docker_apt_source_mode"] == "primary"
+
+
+def test_primary_apt_source_mode_skips_mirror_patches() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-primary-apt-pytest-") as tmp:
+        root = Path(tmp)
+        task = root / "tasks" / "primary-apt-probe"
+        dockerfile = task / "environment" / "Dockerfile"
+        dockerfile.parent.mkdir(parents=True)
+        dockerfile.write_text(
+            "FROM ubuntu:24.04\n\nRUN apt-get update && apt-get install -y curl\n",
+            encoding="utf-8",
+        )
+        (task / "task.toml").write_text("version = \"1.1\"\n", encoding="utf-8")
+
+        staged_path, metadata = stage_task_for_sandbox(
+            task_path=task,
+            jobs_dir=root / "jobs",
+            job_name="primary-apt-probe",
+            sandbox="docker",
+            docker_apt_source_mode="primary",
+        )
+
+        assert metadata["dockerfile_apt_source_mode"] == "primary"
+        assert metadata["apt_retry_patch_applied"] is True
+        assert metadata["dockerfile_ubuntu_apt_mirror_patch_applied"] is False
+        assert metadata["dockerfile_debian_apt_mirror_patch_applied"] is False
+        staged_text = (staged_path / "environment" / "Dockerfile").read_text(
+            encoding="utf-8"
+        )
+        assert DOCKER_APT_RETRY_BEGIN in staged_text
+        assert "LOOPX_SKILLSBENCH_UBUNTU_APT_MIRROR" not in staged_text
+        assert "LOOPX_SKILLSBENCH_DEBIAN_APT_MIRROR" not in staged_text
 
 
 def test_no_isolation_pip_build_mode_is_publicly_attributable() -> None:


### PR DESCRIPTION
## Summary
- gate Ubuntu and Debian mirror patch application on the selected apt source mode
- add a pytest-collected primary-source staging regression
- wire the existing primary-source check into the durable SkillsBench smoke entrypoint

## Validation
- 52 focused pytest cases passed
- `skillsbench-benchmark-run-smoke` passed
- Python compile and diff checks passed
- 6/6 catalog canaries and the public-boundary scan passed

## Self-repair evidence
- an exact-main setup-only receipt showed `dockerfile_apt_source_mode=primary` while both mirror patches were still applied
- the invalid probe was stopped before agent/verifier execution and is not benchmark evidence
- no scoring, task semantics, submission, upload, permission, or verifier-feedback behavior changes
- no raw benchmark evidence, private state, credentials, local paths, or generated logs included