### PR TITLE
Add bounded SkillsBench apt transport fallback

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -5714,6 +5714,44 @@ def test_skillsbench_docker_task_staging_can_keep_primary_apt_sources() -> None:
         assert dockerfile_runtime.DEBIAN_APT_MIRROR_BEGIN not in staged_text
 
 
+def test_skillsbench_docker_task_staging_supports_proxy_compatible_apt() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-apt-transport-stage-") as tmp:
+        root = Path(tmp)
+        task = root / "tasks" / "apt-transport-probe"
+        dockerfile = task / "environment" / "Dockerfile"
+        dockerfile.parent.mkdir(parents=True)
+        original_text = (
+            "FROM ubuntu:24.04\n\n"
+            "RUN apt-get update && apt-get install -y --no-install-recommends curl\n"
+        )
+        dockerfile.write_text(original_text, encoding="utf-8")
+        (task / "task.toml").write_text("version = \"1.1\"\n", encoding="utf-8")
+
+        staged_path, metadata = stage_task_for_sandbox(
+            task_path=task,
+            jobs_dir=root / "jobs",
+            job_name="apt-transport-probe",
+            sandbox="docker",
+            docker_apt_source_mode="primary",
+            docker_apt_transport_mode="proxy-compatible",
+        )
+
+        assert metadata["dockerfile_apt_source_mode"] == "primary", metadata
+        assert metadata["dockerfile_apt_transport_mode"] == (
+            "proxy-compatible"
+        ), metadata
+        assert metadata["apt_retry_patch_applied"] is True, metadata
+        assert metadata["original_task_mutated"] is False, metadata
+        assert dockerfile.read_text(encoding="utf-8") == original_text
+        staged_text = (staged_path / "environment" / "Dockerfile").read_text(
+            encoding="utf-8"
+        )
+        assert 'Acquire::http::Pipeline-Depth "0";' in staged_text, staged_text
+        assert 'Acquire::https::Pipeline-Depth "0";' in staged_text, staged_text
+        assert 'Acquire::ForceIPv4 "true";' in staged_text, staged_text
+        assert dockerfile_runtime.UBUNTU_APT_MIRROR_BEGIN not in staged_text
+
+
 def test_skillsbench_no_skill_route_removes_staged_task_skills() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-no-skill-stage-") as tmp:
         root = Path(tmp)
@@ -14863,6 +14901,7 @@ if __name__ == "__main__":
     test_skillsbench_docker_task_staging_adds_app_skills_mount()
     test_skillsbench_docker_task_staging_adds_debian_apt_mirror_patch()
     test_skillsbench_docker_task_staging_can_keep_primary_apt_sources()
+    test_skillsbench_docker_task_staging_supports_proxy_compatible_apt()
     test_skillsbench_no_skill_route_removes_staged_task_skills()
     test_skillsbench_docker_task_staging_adds_apt_retry_patch()
     test_skillsbench_docker_task_staging_apt_retry_is_nonroot_safe()

--- a/loopx/benchmark_adapters/skillsbench_setup_preflight.py
+++ b/loopx/benchmark_adapters/skillsbench_setup_preflight.py
@@ -53,6 +53,7 @@ _PUBLIC_TASK_STAGING_BOOL_FIELDS = (
 _PUBLIC_TASK_STAGING_STRING_FIELDS = (
     "schema_version",
     "dockerfile_apt_source_mode",
+    "dockerfile_apt_transport_mode",
     "dockerfile_ubuntu_apt_mirror_host",
     "dockerfile_debian_apt_mirror_host",
     "dockerfile_pip_index_host",

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -33,6 +33,9 @@ Optional env:
                                        to Docker CLI/Compose; default auto
   SKILLSBENCH_DOCKER_APT_SOURCE_MODE   Staged Dockerfile apt sources: mirror
                                        (default) or primary
+  SKILLSBENCH_DOCKER_APT_TRANSPORT_MODE
+                                       Staged apt transport: default or
+                                       proxy-compatible
   SKILLSBENCH_DOCKER_PIP_INDEX_MODE    Staged Dockerfile pip index: mirror
                                        (default) or primary
   SKILLSBENCH_DOCKER_PIP_BUILD_MODE    Staged Dockerfile pip build mode:
@@ -218,6 +221,7 @@ allow_staged_bootstrap_repair_run="${SKILLSBENCH_ALLOW_STAGED_BOOTSTRAP_REPAIR_R
 setup_only_public_preflight="${SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT:-0}"
 benchmark_egress_proxy_mode="${SKILLSBENCH_BENCHMARK_EGRESS_PROXY_MODE:-require}"
 docker_apt_source_mode="${SKILLSBENCH_DOCKER_APT_SOURCE_MODE:-mirror}"
+docker_apt_transport_mode="${SKILLSBENCH_DOCKER_APT_TRANSPORT_MODE:-default}"
 docker_pip_index_mode="${SKILLSBENCH_DOCKER_PIP_INDEX_MODE:-mirror}"
 docker_pip_build_mode="${SKILLSBENCH_DOCKER_PIP_BUILD_MODE:-isolated}"
 product_mode_soft_verify_policy="${SKILLSBENCH_PRODUCT_MODE_SOFT_VERIFY_POLICY:-}"
@@ -258,6 +262,11 @@ fi
 if [[ "$docker_apt_source_mode" != "mirror" ]] &&
   [[ "$docker_apt_source_mode" != "primary" ]]; then
   echo "SKILLSBENCH_DOCKER_APT_SOURCE_MODE must be mirror or primary" >&2
+  exit 2
+fi
+if [[ "$docker_apt_transport_mode" != "default" ]] &&
+  [[ "$docker_apt_transport_mode" != "proxy-compatible" ]]; then
+  echo "SKILLSBENCH_DOCKER_APT_TRANSPORT_MODE must be default or proxy-compatible" >&2
   exit 2
 fi
 if [[ "$docker_pip_build_mode" != "isolated" ]] &&
@@ -555,6 +564,7 @@ remote_command=$(
     --codex-api-reverse-tunnel-proxy "$loopback_proxy_url" \
     --benchmark-egress-proxy-mode "$benchmark_egress_proxy_mode" \
     --docker-apt-source-mode "$docker_apt_source_mode" \
+    --docker-apt-transport-mode "$docker_apt_transport_mode" \
     --docker-pip-index-mode "$docker_pip_index_mode" \
     --docker-pip-build-mode "$docker_pip_build_mode" \
     --host-local-acp-launch \
@@ -643,6 +653,7 @@ if [[ "$dry_run" == "true" ]]; then
     "$public_artifact_sync_interval"
   printf 'benchmark_egress_proxy_mode=%s\n' "$benchmark_egress_proxy_mode"
   printf 'docker_apt_source_mode=%s\n' "$docker_apt_source_mode"
+  printf 'docker_apt_transport_mode=%s\n' "$docker_apt_transport_mode"
   printf 'docker_pip_index_mode=%s\n' "$docker_pip_index_mode"
   printf 'docker_pip_build_mode=%s\n' "$docker_pip_build_mode"
   printf 'product_mode_soft_verify_policy=%s\n' \

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -438,6 +438,8 @@ DOCKER_PIP_INDEX_MODES = {
 }
 DEFAULT_DOCKER_APT_SOURCE_MODE = "mirror"
 DOCKER_APT_SOURCE_MODES = ("mirror", "primary")
+DEFAULT_DOCKER_APT_TRANSPORT_MODE = "default"
+DOCKER_APT_TRANSPORT_MODES = ("default", "proxy-compatible")
 DEFAULT_DOCKER_PIP_BUILD_MODE = "isolated"
 DOCKER_PIP_BUILD_MODES = ("isolated", "no-isolation")
 DOCKER_HOST_CPU_ENV = "LOOPX_SKILLSBENCH_DOCKER_CPUS"
@@ -5889,6 +5891,7 @@ def _public_task_staging(value: Any) -> dict[str, Any]:
             compact[field] = value[field]
     for field in (
         "dockerfile_apt_source_mode",
+        "dockerfile_apt_transport_mode",
         "dockerfile_pip_index_host",
         "bootstrap_light_blocker_kind",
         "dockerfile_uv_bootstrap_version",
@@ -5948,6 +5951,12 @@ def _discover_prepared_task_staging(plan: dict[str, Any]) -> dict[str, Any]:
             or DEFAULT_DOCKER_APT_SOURCE_MODE
         )
     )
+    docker_apt_transport_mode = _docker_apt_transport_mode(
+        str(
+            plan.get("docker_apt_transport_mode")
+            or DEFAULT_DOCKER_APT_TRANSPORT_MODE
+        )
+    )
     _, docker_pip_index_host = _docker_pip_index(
         str(plan.get("docker_pip_index_mode") or DEFAULT_DOCKER_PIP_INDEX_MODE)
     )
@@ -5989,6 +5998,11 @@ def _discover_prepared_task_staging(plan: dict[str, Any]) -> dict[str, Any]:
         "apt_retry_patch_applied": DOCKER_APT_RETRY_BEGIN in dockerfile_text,
         "dockerfile_apt_source_mode": (
             docker_apt_source_mode if DOCKER_APT_RETRY_BEGIN in dockerfile_text else ""
+        ),
+        "dockerfile_apt_transport_mode": (
+            docker_apt_transport_mode
+            if DOCKER_APT_RETRY_BEGIN in dockerfile_text
+            else ""
         ),
         "dockerfile_ubuntu_apt_mirror_patch_applied": (
             dockerfile_runtime.UBUNTU_APT_MIRROR_BEGIN in dockerfile_text
@@ -7714,15 +7728,27 @@ def patch_dockerfile_benchmark_egress_proxy_env(
     return metadata
 
 
-def patch_dockerfile_apt_retry(dockerfile: Path) -> bool:
+def patch_dockerfile_apt_retry(
+    dockerfile: Path,
+    *,
+    transport_mode: str = DEFAULT_DOCKER_APT_TRANSPORT_MODE,
+) -> bool:
     """Add public-safe apt retry/no-cache defaults to staged Dockerfiles."""
 
     if not dockerfile_needs_apt_retry_patch(dockerfile):
         return False
+    transport_mode = _docker_apt_transport_mode(transport_mode)
     text = _strip_marker_block(
         dockerfile.read_text(encoding="utf-8"),
         DOCKER_APT_RETRY_BEGIN,
         DOCKER_APT_RETRY_END,
+    )
+    proxy_compatible_config = (
+        "        'Acquire::http::Pipeline-Depth \"0\";' \\\n"
+        "        'Acquire::https::Pipeline-Depth \"0\";' \\\n"
+        "        'Acquire::ForceIPv4 \"true\";' \\\n"
+        if transport_mode == "proxy-compatible"
+        else ""
     )
     block = (
         f"{DOCKER_APT_RETRY_BEGIN}\n"
@@ -7733,6 +7759,7 @@ def patch_dockerfile_apt_retry(dockerfile: Path) -> bool:
         "        'Acquire::Retries \"5\";' \\\n"
         "        'Acquire::http::No-Cache \"true\";' \\\n"
         "        'Acquire::https::No-Cache \"true\";' \\\n"
+        f"{proxy_compatible_config}"
         "        'Acquire::Check-Valid-Until \"false\";' \\\n"
         "        > /etc/apt/apt.conf.d/80-loopx-retry; \\\n"
         "      rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*.deb; \\\n"
@@ -7774,6 +7801,12 @@ def _docker_pip_build_mode(mode: str) -> str:
 def _docker_apt_source_mode(mode: str) -> str:
     if mode not in DOCKER_APT_SOURCE_MODES:
         raise ValueError(f"unsupported Docker apt source mode: {mode}")
+    return mode
+
+
+def _docker_apt_transport_mode(mode: str) -> str:
+    if mode not in DOCKER_APT_TRANSPORT_MODES:
+        raise ValueError(f"unsupported Docker apt transport mode: {mode}")
     return mode
 
 
@@ -8034,6 +8067,7 @@ def stage_task_for_sandbox(
     include_task_skills: bool = True,
     benchmark_egress_proxy_env: Mapping[str, str] | None = None,
     docker_apt_source_mode: str = DEFAULT_DOCKER_APT_SOURCE_MODE,
+    docker_apt_transport_mode: str = DEFAULT_DOCKER_APT_TRANSPORT_MODE,
     docker_pip_index_mode: str = DEFAULT_DOCKER_PIP_INDEX_MODE,
     docker_pip_build_mode: str = DEFAULT_DOCKER_PIP_BUILD_MODE,
     docker_gcr_mirror_prefix: str = "",
@@ -8044,6 +8078,9 @@ def stage_task_for_sandbox(
 
     task_path = task_path.expanduser().resolve()
     docker_apt_source_mode = _docker_apt_source_mode(docker_apt_source_mode)
+    docker_apt_transport_mode = _docker_apt_transport_mode(
+        docker_apt_transport_mode
+    )
     docker_pip_index_url, docker_pip_index_host = _docker_pip_index(
         docker_pip_index_mode
     )
@@ -8057,6 +8094,7 @@ def stage_task_for_sandbox(
         "app_skills_mount_patch_applied": False,
         "apt_retry_patch_applied": False,
         "dockerfile_apt_source_mode": "",
+        "dockerfile_apt_transport_mode": "",
         "dockerfile_ubuntu_apt_mirror_patch_required": False,
         "dockerfile_ubuntu_apt_mirror_patch_applied": False,
         "dockerfile_ubuntu_apt_mirror_host": "",
@@ -8216,6 +8254,7 @@ def stage_task_for_sandbox(
     metadata["apt_risk_preflight_blocked"] = False
     if needs_apt_retry_patch:
         metadata["dockerfile_apt_source_mode"] = docker_apt_source_mode
+        metadata["dockerfile_apt_transport_mode"] = docker_apt_transport_mode
     metadata["dockerfile_ubuntu_apt_mirror_patch_required"] = (
         needs_ubuntu_apt_mirror_patch
     )
@@ -8386,7 +8425,8 @@ def stage_task_for_sandbox(
         proxy_env=benchmark_egress_proxy_env,
     )
     apt_retry_patched = patch_dockerfile_apt_retry(
-        staged_path / "environment" / "Dockerfile"
+        staged_path / "environment" / "Dockerfile",
+        transport_mode=docker_apt_transport_mode,
     )
     ubuntu_apt_mirror_patched = bool(
         needs_ubuntu_apt_mirror_patch
@@ -8601,6 +8641,13 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
     route = args.route
     docker_apt_source_mode = _docker_apt_source_mode(
         getattr(args, "docker_apt_source_mode", DEFAULT_DOCKER_APT_SOURCE_MODE)
+    )
+    docker_apt_transport_mode = _docker_apt_transport_mode(
+        getattr(
+            args,
+            "docker_apt_transport_mode",
+            DEFAULT_DOCKER_APT_TRANSPORT_MODE,
+        )
     )
     _, docker_pip_index_host = _docker_pip_index(args.docker_pip_index_mode)
     docker_pip_build_mode = _docker_pip_build_mode(
@@ -8836,6 +8883,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         "run_group_id": str(args.run_group_id or ""),
         "sandbox": args.sandbox,
         "docker_apt_source_mode": docker_apt_source_mode,
+        "docker_apt_transport_mode": docker_apt_transport_mode,
         "docker_pip_index_mode": args.docker_pip_index_mode,
         "docker_pip_build_mode": docker_pip_build_mode,
         "max_rounds": args.max_rounds,
@@ -9417,6 +9465,7 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
         "app_server_goal_prompt_style",
         "sandbox",
         "docker_apt_source_mode",
+        "docker_apt_transport_mode",
         "docker_pip_index_mode",
         "docker_pip_build_mode",
         "run_group_id",
@@ -13829,6 +13878,11 @@ async def run_benchflow_case(
         docker_apt_source_mode=getattr(
             args, "docker_apt_source_mode", DEFAULT_DOCKER_APT_SOURCE_MODE
         ),
+        docker_apt_transport_mode=getattr(
+            args,
+            "docker_apt_transport_mode",
+            DEFAULT_DOCKER_APT_TRANSPORT_MODE,
+        ),
         docker_pip_index_mode=args.docker_pip_index_mode,
         docker_pip_build_mode=args.docker_pip_build_mode,
         docker_gcr_mirror_prefix=args.docker_gcr_mirror_prefix,
@@ -16686,6 +16740,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "preserves the default fixed mirrors; primary keeps the task's "
             "original sources as a bounded fallback after a typed mirror "
             "network failure."
+        ),
+    )
+    parser.add_argument(
+        "--docker-apt-transport-mode",
+        choices=DOCKER_APT_TRANSPORT_MODES,
+        default=DEFAULT_DOCKER_APT_TRANSPORT_MODE,
+        help=(
+            "Apt transport policy used by staged Dockerfile repair. default "
+            "preserves current retry behavior; proxy-compatible additionally "
+            "disables HTTP(S) pipelining and forces IPv4 without recording "
+            "or changing proxy endpoints."
         ),
     )
     parser.add_argument(

--- a/tests/test_skillsbench_setup_preflight.py
+++ b/tests/test_skillsbench_setup_preflight.py
@@ -78,6 +78,7 @@ def run_preflight() -> dict[str, Any]:
             task_staging={
                 "apt_retry_patch_applied": True,
                 "dockerfile_apt_source_mode": "mirror",
+                "dockerfile_apt_transport_mode": "default",
                 "dockerfile_debian_apt_mirror_patch_required": True,
                 "dockerfile_debian_apt_mirror_patch_applied": True,
                 "dockerfile_debian_apt_mirror_host": "mirror.example",
@@ -115,6 +116,7 @@ def test_setup_only_preflight_stops_before_agent_and_verifier() -> None:
     assert result["task_staging"] == {
         "apt_retry_patch_applied": True,
         "dockerfile_apt_source_mode": "mirror",
+        "dockerfile_apt_transport_mode": "default",
         "dockerfile_debian_apt_mirror_patch_required": True,
         "dockerfile_debian_apt_mirror_patch_applied": True,
         "dockerfile_debian_apt_mirror_host": "mirror.example",
@@ -238,6 +240,54 @@ def test_primary_apt_source_mode_skips_mirror_patches() -> None:
         assert DOCKER_APT_RETRY_BEGIN in staged_text
         assert "LOOPX_SKILLSBENCH_UBUNTU_APT_MIRROR" not in staged_text
         assert "LOOPX_SKILLSBENCH_DEBIAN_APT_MIRROR" not in staged_text
+
+
+def test_proxy_compatible_apt_transport_is_public_and_bounded() -> None:
+    args = parse_args(
+        [
+            "--task-id",
+            "flink-query",
+            "--docker-apt-source-mode",
+            "primary",
+            "--docker-apt-transport-mode",
+            "proxy-compatible",
+        ]
+    )
+    plan = build_plan(args)
+    public_config = _public_runner_config(plan)
+
+    assert plan["docker_apt_transport_mode"] == "proxy-compatible"
+    assert public_config["docker_apt_transport_mode"] == "proxy-compatible"
+
+    with tempfile.TemporaryDirectory(prefix="skillsbench-apt-transport-pytest-") as tmp:
+        root = Path(tmp)
+        task = root / "tasks" / "apt-transport-probe"
+        dockerfile = task / "environment" / "Dockerfile"
+        dockerfile.parent.mkdir(parents=True)
+        dockerfile.write_text(
+            "FROM ubuntu:24.04\n\nRUN apt-get update && apt-get install -y curl\n",
+            encoding="utf-8",
+        )
+        (task / "task.toml").write_text("version = \"1.1\"\n", encoding="utf-8")
+
+        staged_path, metadata = stage_task_for_sandbox(
+            task_path=task,
+            jobs_dir=root / "jobs",
+            job_name="apt-transport-probe",
+            sandbox="docker",
+            docker_apt_source_mode="primary",
+            docker_apt_transport_mode="proxy-compatible",
+        )
+
+        assert metadata["dockerfile_apt_source_mode"] == "primary"
+        assert metadata["dockerfile_apt_transport_mode"] == "proxy-compatible"
+        staged_text = (staged_path / "environment" / "Dockerfile").read_text(
+            encoding="utf-8"
+        )
+        assert 'Acquire::http::Pipeline-Depth "0";' in staged_text
+        assert 'Acquire::https::Pipeline-Depth "0";' in staged_text
+        assert 'Acquire::ForceIPv4 "true";' in staged_text
+        assert "LOOPX_SKILLSBENCH_UBUNTU_APT_MIRROR" not in staged_text
 
 
 def test_no_isolation_pip_build_mode_is_publicly_attributable() -> None:

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -243,6 +243,47 @@ def test_launcher_wires_bounded_primary_apt_source_mode(tmp_path: Path) -> None:
     assert "--docker-apt-source-mode primary" in proc.stdout
 
 
+def test_launcher_wires_bounded_proxy_compatible_apt_transport(
+    tmp_path: Path,
+) -> None:
+    env = _base_env(tmp_path)
+    env["SKILLSBENCH_DOCKER_APT_TRANSPORT_MODE"] = "proxy-compatible"
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "proxy-apt"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+
+    assert "docker_apt_transport_mode=proxy-compatible" in proc.stdout
+    assert "--docker-apt-transport-mode proxy-compatible" in proc.stdout
+
+
+def test_launcher_rejects_unbounded_apt_transport_mode(tmp_path: Path) -> None:
+    env = _base_env(tmp_path)
+    env["SKILLSBENCH_DOCKER_APT_TRANSPORT_MODE"] = "private-mode"
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "invalid-transport"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    assert (
+        "SKILLSBENCH_DOCKER_APT_TRANSPORT_MODE must be default or "
+        "proxy-compatible"
+    ) in proc.stderr
+
+
 def test_launcher_rejects_unbounded_apt_source_mode(tmp_path: Path) -> None:
     env = _base_env(tmp_path)
     env["SKILLSBENCH_DOCKER_APT_SOURCE_MODE"] = "private-url"


### PR DESCRIPTION
## Summary
- add a bounded `default|proxy-compatible` apt transport policy for staged SkillsBench Dockerfiles
- keep the selected apt source unchanged while the opt-in mode disables HTTP(S) pipelining and forces IPv4
- project the selected mode through launcher dry-runs, runner config, task staging, and setup-only public receipts

## Validation
- `55 passed` in focused setup-preflight and launcher pytest suites
- `skillsbench-benchmark-run-smoke: ok`
- `skillsbench-failure-attribution-smoke: ok`
- standard premerge: 7/7 selected checks passed; public-boundary scan clean
- default-mode compatibility probe passed

## Boundaries
- no scoring, task semantics, leaderboard, submission, or permission behavior changes
- no benchmark jobs launched by validation
- no raw task text, logs, trajectories, verifier output, credentials, private paths, or generated run artifacts included
- premerge reports the expected `benchmark_sensitive` manual hold; owner authorization permits self-review/self-merge for this bounded benchmark helper/runtime change