### PR TITLE
Cover apt transport in each Docker stage

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -5752,6 +5752,42 @@ def test_skillsbench_docker_task_staging_supports_proxy_compatible_apt() -> None
         assert dockerfile_runtime.UBUNTU_APT_MIRROR_BEGIN not in staged_text
 
 
+def test_skillsbench_apt_transport_covers_each_apt_stage() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-apt-stage-coverage-") as tmp:
+        root = Path(tmp)
+        task = root / "tasks" / "apt-stage-probe"
+        dockerfile = task / "environment" / "Dockerfile"
+        dockerfile.parent.mkdir(parents=True)
+        original_text = (
+            "FROM ubuntu:24.04 AS build\n\n"
+            "RUN echo build-only\n\n"
+            "FROM ubuntu:24.04 AS runtime\n\n"
+            "RUN apt-get update && apt-get install -y curl\n"
+        )
+        dockerfile.write_text(original_text, encoding="utf-8")
+        (task / "task.toml").write_text("version = \"1.1\"\n", encoding="utf-8")
+
+        staged_path, metadata = stage_task_for_sandbox(
+            task_path=task,
+            jobs_dir=root / "jobs",
+            job_name="apt-stage-probe",
+            sandbox="docker",
+            docker_apt_source_mode="primary",
+            docker_apt_transport_mode="proxy-compatible",
+        )
+
+        assert metadata["apt_retry_patch_applied"] is True, metadata
+        assert dockerfile.read_text(encoding="utf-8") == original_text
+        staged_text = (staged_path / "environment" / "Dockerfile").read_text(
+            encoding="utf-8"
+        )
+        assert staged_text.count(DOCKER_APT_RETRY_BEGIN) == 1, staged_text
+        runtime_stage = staged_text.index("FROM ubuntu:24.04 AS runtime")
+        transport_config = staged_text.rindex('Acquire::ForceIPv4 "true";')
+        apt_update = staged_text.index("RUN apt-get update")
+        assert runtime_stage < transport_config < apt_update, staged_text
+
+
 def test_skillsbench_no_skill_route_removes_staged_task_skills() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-no-skill-stage-") as tmp:
         root = Path(tmp)
@@ -14902,6 +14938,7 @@ if __name__ == "__main__":
     test_skillsbench_docker_task_staging_adds_debian_apt_mirror_patch()
     test_skillsbench_docker_task_staging_can_keep_primary_apt_sources()
     test_skillsbench_docker_task_staging_supports_proxy_compatible_apt()
+    test_skillsbench_apt_transport_covers_each_apt_stage()
     test_skillsbench_no_skill_route_removes_staged_task_skills()
     test_skillsbench_docker_task_staging_adds_apt_retry_patch()
     test_skillsbench_docker_task_staging_apt_retry_is_nonroot_safe()

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -7733,7 +7733,7 @@ def patch_dockerfile_apt_retry(
     *,
     transport_mode: str = DEFAULT_DOCKER_APT_TRANSPORT_MODE,
 ) -> bool:
-    """Add public-safe apt retry/no-cache defaults to staged Dockerfiles."""
+    """Add public-safe apt retry/no-cache defaults to apt-using stages."""
 
     if not dockerfile_needs_apt_retry_patch(dockerfile):
         return False
@@ -7768,16 +7768,43 @@ def patch_dockerfile_apt_retry(
         "    fi\n"
         f"{DOCKER_APT_RETRY_END}"
     )
-    patched_lines: list[str] = []
-    inserted = False
-    for line in text.splitlines():
-        patched_lines.append(line)
-        stripped = line.strip()
-        if stripped.startswith("FROM ") and not inserted:
-            patched_lines.extend(["", *block.splitlines(), ""])
-            inserted = True
-    if not inserted:
-        patched_lines = [*block.splitlines(), "", *text.splitlines()]
+    lines = text.splitlines()
+    stage_starts: list[int] = []
+    heredoc_delimiter: str | None = None
+    for index, line in enumerate(lines):
+        if heredoc_delimiter is not None:
+            if line.strip() == heredoc_delimiter:
+                heredoc_delimiter = None
+            continue
+        heredoc_delimiter = dockerfile_runtime.dockerfile_heredoc_delimiter(line)
+        if _is_dockerfile_from_instruction(line.strip()):
+            stage_starts.append(index)
+
+    if not stage_starts:
+        patched_lines = [*block.splitlines(), "", *lines]
+    else:
+        patched_lines = lines[: stage_starts[0]]
+        for position, start in enumerate(stage_starts):
+            end = (
+                stage_starts[position + 1]
+                if position + 1 < len(stage_starts)
+                else len(lines)
+            )
+            stage_lines = lines[start:end]
+            from_line = stage_lines[0].strip().lower()
+            stage_uses_apt = bool(
+                re.search(
+                    r"\bapt(?:-get)?\s+update\b",
+                    "\n".join(stage_lines),
+                    flags=re.IGNORECASE,
+                )
+            )
+            if stage_uses_apt and " scratch" not in from_line:
+                patched_lines.extend(
+                    [stage_lines[0], "", *block.splitlines(), "", *stage_lines[1:]]
+                )
+            else:
+                patched_lines.extend(stage_lines)
     patched = "\n".join(patched_lines).rstrip() + "\n"
     if patched == dockerfile.read_text(encoding="utf-8"):
         return False

--- a/tests/test_skillsbench_setup_preflight.py
+++ b/tests/test_skillsbench_setup_preflight.py
@@ -290,6 +290,41 @@ def test_proxy_compatible_apt_transport_is_public_and_bounded() -> None:
         assert "LOOPX_SKILLSBENCH_UBUNTU_APT_MIRROR" not in staged_text
 
 
+def test_proxy_compatible_apt_transport_covers_each_apt_stage() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-apt-stages-pytest-") as tmp:
+        root = Path(tmp)
+        task = root / "tasks" / "apt-stage-probe"
+        dockerfile = task / "environment" / "Dockerfile"
+        dockerfile.parent.mkdir(parents=True)
+        dockerfile.write_text(
+            "FROM ubuntu:24.04 AS build\n\n"
+            "RUN echo build-only\n\n"
+            "FROM ubuntu:24.04 AS runtime\n\n"
+            "RUN apt-get update && apt-get install -y curl\n",
+            encoding="utf-8",
+        )
+        (task / "task.toml").write_text("version = \"1.1\"\n", encoding="utf-8")
+
+        staged_path, metadata = stage_task_for_sandbox(
+            task_path=task,
+            jobs_dir=root / "jobs",
+            job_name="apt-stage-probe",
+            sandbox="docker",
+            docker_apt_source_mode="primary",
+            docker_apt_transport_mode="proxy-compatible",
+        )
+
+        assert metadata["apt_retry_patch_applied"] is True
+        staged_text = (staged_path / "environment" / "Dockerfile").read_text(
+            encoding="utf-8"
+        )
+        assert staged_text.count(DOCKER_APT_RETRY_BEGIN) == 1
+        runtime_stage = staged_text.index("FROM ubuntu:24.04 AS runtime")
+        transport_config = staged_text.rindex('Acquire::ForceIPv4 "true";')
+        apt_update = staged_text.index("RUN apt-get update")
+        assert runtime_stage < transport_config < apt_update
+
+
 def test_no_isolation_pip_build_mode_is_publicly_attributable() -> None:
     args = parse_args(
         [


### PR DESCRIPTION
## Summary

- inject the bounded apt retry/transport block into the Docker stage that actually runs `apt update`
- preserve heredoc-aware `FROM` parsing and skip unrelated stages
- add focused and durable multi-stage regression coverage

## Validation

- `python -m pytest -q tests/test_skillsbench_setup_preflight.py tests/test_skillsbench_turn_launcher.py` (56 passed)
- `python examples/skillsbench-benchmark-run-smoke.py`
- `python examples/skillsbench-failure-attribution-smoke.py`
- `loopx canary premerge --from-git-diff --no-progress` (7/7 selected checks passed; public boundary clean; benchmark-sensitive manual hold covered by owner self-merge authorization)