### PR TITLE
Preserve terminal SkillsBench setup causes

### DIFF
--- a/loopx/benchmark_adapters/skillsbench_failure_signals.py
+++ b/loopx/benchmark_adapters/skillsbench_failure_signals.py
@@ -99,12 +99,33 @@ _FAILURE_REASON_PATTERNS = (
         r"cannot connect to proxy|could not connect to proxy",
     ),
     (
+        "proxy_authentication_required",
+        r"proxy authentication required|(?:http[^\n]*\s407\b)|"
+        r"(?:status code|status:)\s*407\b|\b407\s+status code\b",
+    ),
+    (
         "tls_or_certificate",
         r"certificate verif(?:y|ication) failed|ssl certificate problem|"
         r"tls handshake|could not handshake|"
         r"unable to get local issuer certificate",
     ),
+    (
+        "http_unauthorized",
+        r"(?:http[^\n]*\s401\b)|401 unauthorized|"
+        r"(?:status code|status:)\s*401\b|\b401\s+status code\b",
+    ),
+    (
+        "http_forbidden",
+        r"(?:http[^\n]*\s403\b)|403 forbidden|"
+        r"(?:status code|status:)\s*403\b|\b403\s+status code\b",
+    ),
     ("http_not_found", r"(?:http[^\n]*\s404\b|404 not found)"),
+    (
+        "http_client_error",
+        r"(?:http[^\n]*\s(?!(?:401|403|404|407)\b)4\d\d\b)|"
+        r"(?:status code|status:)\s*(?!(?:401|403|404|407)\b)4\d\d\b|"
+        r"\b(?!(?:401|403|404|407)\b)4\d\d\s+(?:client error|status code)\b",
+    ),
     ("http_server_error", r"(?:http[^\n]*\s5\d\d\b|5\d\d server error)"),
     ("apt_fetch_failed", r"failed to fetch"),
     ("apt_no_pubkey", r"\bno_pubkey\b"),
@@ -180,13 +201,17 @@ _TRANSIENT_FAILURE_REASONS = {
 }
 _DETERMINISTIC_FAILURE_REASONS = {
     "apt_package_unavailable",
+    "http_client_error",
+    "http_forbidden",
     "http_not_found",
+    "http_unauthorized",
     "missing_file",
     "no_space_left",
     "permission_denied",
     "pip_build_failure",
     "pip_no_matching_distribution",
     "pip_os_error",
+    "proxy_authentication_required",
     "tls_or_certificate",
 }
 
@@ -200,9 +225,13 @@ _APT_FAILURE_SUBTYPE_REASON_PRIORITY = (
     ("apt_release_expired", "release_metadata"),
     ("apt_package_unavailable", "package_unavailable"),
     ("dns_resolution", "dns_resolution"),
+    ("proxy_authentication_required", "proxy_authentication_required"),
     ("proxy_connect", "proxy_connect"),
     ("tls_or_certificate", "tls_or_certificate"),
+    ("http_unauthorized", "http_unauthorized"),
+    ("http_forbidden", "http_forbidden"),
     ("http_not_found", "http_not_found"),
+    ("http_client_error", "http_client_error"),
     ("http_server_error", "http_server_error"),
     ("network_unreachable", "network_unreachable"),
     ("connection_timeout", "connection_timeout"),

--- a/loopx/benchmark_adapters/skillsbench_setup_preflight.py
+++ b/loopx/benchmark_adapters/skillsbench_setup_preflight.py
@@ -66,6 +66,7 @@ _PUBLIC_TASK_STAGING_STRING_FIELDS = (
     "verifier_uv_bootstrap_mirror_host",
 )
 _COMPOSE_EXCEPTION_FINGERPRINT_TEXT_LIMIT = 64 * 1024
+_COMPOSE_EXCEPTION_FINGERPRINT_HEAD_LIMIT = 8 * 1024
 
 
 class SkillsBenchComposeCommandFailure(RuntimeError):
@@ -104,7 +105,18 @@ def _compose_exception_fingerprint_text(exc: Exception) -> str:
             value = value.decode("utf-8", errors="replace")
         if not isinstance(value, str) or not value or remaining <= 0:
             continue
-        part = value[:remaining]
+        if len(value) <= remaining:
+            part = value
+        else:
+            head_size = min(
+                _COMPOSE_EXCEPTION_FINGERPRINT_HEAD_LIMIT,
+                max(0, remaining - 1),
+            )
+            tail_size = max(0, remaining - head_size - 1)
+            if tail_size:
+                part = f"{value[:head_size]}\n{value[-tail_size:]}"
+            else:
+                part = value[:remaining]
         parts.append(part)
         remaining -= len(part) + 1
     return "\n".join(parts)

--- a/tests/test_skillsbench_setup_preflight.py
+++ b/tests/test_skillsbench_setup_preflight.py
@@ -556,6 +556,44 @@ def test_compose_producer_fingerprints_exception_output_without_recording_it() -
     assert raw_stderr not in str(typed)
 
 
+def test_compose_producer_preserves_terminal_cause_from_long_build_output() -> None:
+    raw_failure = (
+        "Docker compose command failed. Stdout:\n"
+        + ("# build output without failure detail\n" * 3000)
+        + "apt-get update failed to fetch http://archive.ubuntu.com/index: "
+        "407 Proxy Authentication Required at /private/job\n"
+    )
+
+    class FakeComposeEnvironment:
+        async def _run_docker_compose_build(self) -> None:
+            raise RuntimeError(raw_failure)
+
+    environment = FakeComposeEnvironment()
+    restore = install_skillsbench_compose_typed_cause_boundary(environment)
+    assert restore is not None
+
+    async def invoke() -> None:
+        await environment._run_docker_compose_build()
+
+    with pytest.raises(SkillsBenchComposeCommandFailure) as error:
+        asyncio.run(invoke())
+
+    typed = error.value
+    serialized = json.dumps(typed.fingerprint, sort_keys=True)
+    assert typed.fingerprint["apt_failure_subtype"] == (
+        "proxy_authentication_required"
+    )
+    assert typed.fingerprint["terminal_failure_reason_codes"] == [
+        "proxy_authentication_required",
+        "apt_fetch_failed",
+    ]
+    assert typed.fingerprint["retryability"] == "non_retryable"
+    assert typed.fingerprint["error_len_bucket"] == "2000_plus"
+    assert raw_failure not in serialized
+    assert "/private/job" not in serialized
+    assert "archive.ubuntu.com" not in serialized
+
+
 @pytest.mark.parametrize(
     ("message", "subtype"),
     [
@@ -765,6 +803,21 @@ def test_setup_only_preflight_separates_terminal_reason_and_endpoint() -> None:
         (
             "apt update failed to fetch index: Certificate verification failed",
             "tls_or_certificate",
+            "non_retryable",
+        ),
+        (
+            "apt update failed to fetch index: 407 Proxy Authentication Required",
+            "proxy_authentication_required",
+            "non_retryable",
+        ),
+        (
+            "apt update failed to fetch index: HTTP/1.1 403 Forbidden",
+            "http_forbidden",
+            "non_retryable",
+        ),
+        (
+            "apt update failed to fetch index: 470 status code 470",
+            "http_client_error",
             "non_retryable",
         ),
         (


### PR DESCRIPTION
## Summary
- preserve both the beginning and terminal portion of bounded compose build output so terminal setup causes survive long BuildKit transcripts
- classify apt 401, 403, 407, and remaining 4xx failures through the existing public-safe subtype fields
- cover long-output reduction and common HTTP/proxy statuses without persisting raw command output

## Validation
- focused pytest: 45 passed
- `examples/skillsbench-benchmark-run-smoke.py` under Python 3.11: passed
- `examples/skillsbench-failure-attribution-smoke.py`: passed
- Ruff on changed Python files: passed
- changed-module py_compile: passed
- `loopx canary premerge --from-git-diff --no-progress`: 6/6 catalog canaries passed; only the expected `benchmark_sensitive` maintainer-review hold remained
- Initial integration-smoke invocation with system Python 3.9 exited before assertions because LoopX requires Python 3.11; the same smoke passed under Python 3.11

## Review / merge scope
Owner authorization permits self-review and self-merge for benchmark helper/runtime changes. This PR does not change scoring, task semantics, leaderboard/submission behavior, benchmark launch behavior, or permission boundaries. No raw logs, task text, trajectories, verifier output, credentials, local paths, or generated artifacts are included.