### PR TITLE
fix(benchmark): upgrade canonical apt sources for proxies

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -5710,6 +5710,10 @@ def test_skillsbench_docker_task_staging_can_keep_primary_apt_sources() -> None:
             encoding="utf-8"
         )
         assert DOCKER_APT_RETRY_BEGIN in staged_text
+        assert (
+            "http://archive.ubuntu.com/ubuntu#https://archive.ubuntu.com/ubuntu"
+            not in staged_text
+        ), staged_text
         assert dockerfile_runtime.UBUNTU_APT_MIRROR_BEGIN not in staged_text
         assert dockerfile_runtime.DEBIAN_APT_MIRROR_BEGIN not in staged_text
 
@@ -5722,6 +5726,7 @@ def test_skillsbench_docker_task_staging_supports_proxy_compatible_apt() -> None
         dockerfile.parent.mkdir(parents=True)
         original_text = (
             "FROM ubuntu:24.04\n\n"
+            "# custom source: http://packages.example.test/repository\n"
             "RUN apt-get update && apt-get install -y --no-install-recommends curl\n"
         )
         dockerfile.write_text(original_text, encoding="utf-8")
@@ -5749,6 +5754,19 @@ def test_skillsbench_docker_task_staging_supports_proxy_compatible_apt() -> None
         assert 'Acquire::http::Pipeline-Depth "0";' in staged_text, staged_text
         assert 'Acquire::https::Pipeline-Depth "0";' in staged_text, staged_text
         assert 'Acquire::ForceIPv4 "true";' in staged_text, staged_text
+        assert (
+            "http://archive.ubuntu.com/ubuntu#https://archive.ubuntu.com/ubuntu"
+            in staged_text
+        ), staged_text
+        assert (
+            "http://security.ubuntu.com/ubuntu#https://security.ubuntu.com/ubuntu"
+            in staged_text
+        ), staged_text
+        assert (
+            "http://deb.debian.org/debian#https://deb.debian.org/debian"
+            in staged_text
+        ), staged_text
+        assert "http://packages.example.test/repository" in staged_text
         assert dockerfile_runtime.UBUNTU_APT_MIRROR_BEGIN not in staged_text
 
 

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -7750,11 +7750,26 @@ def patch_dockerfile_apt_retry(
         if transport_mode == "proxy-compatible"
         else ""
     )
+    proxy_compatible_source_upgrade = (
+        "      find /etc/apt -type f \\\n"
+        "        \\( -name '*.list' -o -name '*.sources' \\) \\\n"
+        "        -exec sed -i \\\n"
+        '          -e "s#http://archive.ubuntu.com/ubuntu#https://archive.ubuntu.com/ubuntu#g" \\\n'
+        '          -e "s#http://security.ubuntu.com/ubuntu#https://security.ubuntu.com/ubuntu#g" \\\n'
+        '          -e "s#http://ports.ubuntu.com/ubuntu-ports#https://ports.ubuntu.com/ubuntu-ports#g" \\\n'
+        '          -e "s#http://deb.debian.org/debian-security#https://deb.debian.org/debian-security#g" \\\n'
+        '          -e "s#http://security.debian.org/debian-security#https://security.debian.org/debian-security#g" \\\n'
+        '          -e "s#http://deb.debian.org/debian#https://deb.debian.org/debian#g" \\\n'
+        "          {} +; \\\n"
+        if transport_mode == "proxy-compatible"
+        else ""
+    )
     block = (
         f"{DOCKER_APT_RETRY_BEGIN}\n"
         "RUN set -eux; \\\n"
         "    if mkdir -p /etc/apt/apt.conf.d 2>/dev/null && "
         "[ -w /etc/apt/apt.conf.d ]; then \\\n"
+        f"{proxy_compatible_source_upgrade}"
         "      printf '%s\\n' \\\n"
         "        'Acquire::Retries \"5\";' \\\n"
         "        'Acquire::http::No-Cache \"true\";' \\\n"

--- a/tests/test_skillsbench_setup_preflight.py
+++ b/tests/test_skillsbench_setup_preflight.py
@@ -238,6 +238,10 @@ def test_primary_apt_source_mode_skips_mirror_patches() -> None:
             encoding="utf-8"
         )
         assert DOCKER_APT_RETRY_BEGIN in staged_text
+        assert (
+            "http://archive.ubuntu.com/ubuntu#https://archive.ubuntu.com/ubuntu"
+            not in staged_text
+        )
         assert "LOOPX_SKILLSBENCH_UBUNTU_APT_MIRROR" not in staged_text
         assert "LOOPX_SKILLSBENCH_DEBIAN_APT_MIRROR" not in staged_text
 
@@ -265,7 +269,9 @@ def test_proxy_compatible_apt_transport_is_public_and_bounded() -> None:
         dockerfile = task / "environment" / "Dockerfile"
         dockerfile.parent.mkdir(parents=True)
         dockerfile.write_text(
-            "FROM ubuntu:24.04\n\nRUN apt-get update && apt-get install -y curl\n",
+            "FROM ubuntu:24.04\n\n"
+            "# custom source: http://packages.example.test/repository\n"
+            "RUN apt-get update && apt-get install -y curl\n",
             encoding="utf-8",
         )
         (task / "task.toml").write_text("version = \"1.1\"\n", encoding="utf-8")
@@ -287,6 +293,19 @@ def test_proxy_compatible_apt_transport_is_public_and_bounded() -> None:
         assert 'Acquire::http::Pipeline-Depth "0";' in staged_text
         assert 'Acquire::https::Pipeline-Depth "0";' in staged_text
         assert 'Acquire::ForceIPv4 "true";' in staged_text
+        assert (
+            "http://archive.ubuntu.com/ubuntu#https://archive.ubuntu.com/ubuntu"
+            in staged_text
+        )
+        assert (
+            "http://security.ubuntu.com/ubuntu#https://security.ubuntu.com/ubuntu"
+            in staged_text
+        )
+        assert (
+            "http://deb.debian.org/debian#https://deb.debian.org/debian"
+            in staged_text
+        )
+        assert "http://packages.example.test/repository" in staged_text
         assert "LOOPX_SKILLSBENCH_UBUNTU_APT_MIRROR" not in staged_text
 
 
@@ -321,8 +340,11 @@ def test_proxy_compatible_apt_transport_covers_each_apt_stage() -> None:
         assert staged_text.count(DOCKER_APT_RETRY_BEGIN) == 1
         runtime_stage = staged_text.index("FROM ubuntu:24.04 AS runtime")
         transport_config = staged_text.rindex('Acquire::ForceIPv4 "true";')
+        source_upgrade = staged_text.rindex(
+            "http://archive.ubuntu.com/ubuntu#https://archive.ubuntu.com/ubuntu"
+        )
         apt_update = staged_text.index("RUN apt-get update")
-        assert runtime_stage < transport_config < apt_update
+        assert runtime_stage < source_upgrade < transport_config < apt_update
 
 
 def test_no_isolation_pip_build_mode_is_publicly_attributable() -> None:


### PR DESCRIPTION
## Summary
- keep SkillsBench apt source mode on primary while upgrading only canonical Ubuntu/Debian HTTP endpoints to same-host HTTPS under proxy-compatible transport
- leave default transport, custom repositories, task sources, scoring, verifier behavior, and retry settings unchanged
- cover positive, negative, multi-stage, and original-task immutability boundaries

## Validation
- 60 focused pytest checks passed
- SkillsBench benchmark-run smoke passed on Python 3.11
- SkillsBench failure-attribution smoke passed
- py_compile and git diff checks passed
- LoopX premerge catalog: 6/6 checks passed
- public/private boundary scan clean for all 3 changed files

## Holds
- LoopX reports the expected benchmark-sensitive manual review hold. Owner has provided standing authorization for self-review and self-merge of bounded benchmark helper/runtime changes. This PR does not launch benchmark jobs or alter scoring, task semantics, submission, leaderboard, or permission boundaries.
- Whole-file Ruff remains non-clean because the existing large runner/smoke files carry baseline lint and formatting debt; this diff does not expand that cleanup scope.