### PR TITLE
fix(smoke): follow benchmark read model move

### DIFF
--- a/examples/control_plane/run-compaction-readmodel-smoke.py
+++ b/examples/control_plane/run-compaction-readmodel-smoke.py
@@ -12,7 +12,7 @@ if str(ROOT) not in sys.path:
 from loopx import status as status_module  # noqa: E402
 from loopx.control_plane.goals import goal_frontier as goal_frontier_read_model  # noqa: E402
 from loopx.control_plane.goals.goal_vision import compact_goal_vision_packet  # noqa: E402
-from loopx.control_plane.runtime import (  # noqa: E402
+from loopx.benchmarks.read_models import (  # noqa: E402
     benchmark_comparison as benchmark_comparison_read_model,
 )
 from loopx.control_plane.runtime import (  # noqa: E402


### PR DESCRIPTION
## Summary

- update run-compaction-readmodel-smoke.py to import benchmark_comparison from its post-#2446 owner, loopx.benchmarks.read_models
- restore the exact-main Full Public shard 2 smoke without changing runtime or benchmark behavior

## Validation

- python3 examples/control_plane/run-compaction-readmodel-smoke.py
- python3 examples/run-smokes.py --suite full-public --script examples/control_plane/run-compaction-readmodel-smoke.py --json (1/1 passed)
- uvx --from pytest>=8,<9 pytest -q tests/architecture/test_control_plane_import_boundaries.py (13 passed)
- loopx --format json canary premerge --from-git-diff --no-progress (passed; no manual holds)
- git diff --check

## Boundaries

- no benchmark jobs launched
- no credentials, private state, local paths, generated logs, or unrelated files included
- residual risk is limited to the moved public import path; runtime semantics are unchanged

Fixes the non-benchmark smoke regression observed in Full Public run 29923513713.
