### PR TITLE
fix(control-plane): defer replan until monitor due

### DIFF
--- a/loopx/control_plane/work_items/autonomous_replan_obligation.py
+++ b/loopx/control_plane/work_items/autonomous_replan_obligation.py
@@ -3,6 +3,13 @@ from __future__ import annotations
 import re
 from typing import Any, Callable, Optional, Pattern
 
+from ..runtime.time import parse_timestamp
+from ..todos.contract import normalize_todo_claimed_by, normalize_todo_id
+from ..todos.deferred_resume import (
+    todo_summary_deferred_items,
+    todo_summary_monitor_blocked_resume_items,
+)
+
 
 PublicSafeText = Callable[..., Optional[str]]
 AckRecorded = Callable[[dict[str, Any]], bool]
@@ -327,6 +334,75 @@ def _monitor_no_change_evidence(
         "monitor_target_id": monitor_target_id,
         "agent_id": agent_id,
     }
+
+
+def _future_due_blocking_monitor(
+    agent_todos: dict[str, Any] | None,
+    *,
+    latest_generated_at: str,
+    agent_id: str | None,
+) -> dict[str, str] | None:
+    if not isinstance(agent_todos, dict):
+        return None
+    observed_at = parse_timestamp(latest_generated_at)
+    if observed_at is None:
+        return None
+
+    accountable_agent_id = normalize_todo_claimed_by(agent_id)
+    if not accountable_agent_id:
+        return None
+    raw_monitors = agent_todos.get("monitor_open_items")
+    monitors_by_id: dict[str, dict[str, Any]] = {}
+    for monitor in raw_monitors or []:
+        if not isinstance(monitor, dict):
+            continue
+        monitor_todo_id = normalize_todo_id(monitor.get("todo_id"))
+        claimed_by = normalize_todo_claimed_by(monitor.get("claimed_by"))
+        if not monitor_todo_id:
+            continue
+        if accountable_agent_id and claimed_by and claimed_by != accountable_agent_id:
+            continue
+        monitors_by_id[monitor_todo_id] = monitor
+
+    blocking_monitor_ids: set[str] = set()
+    blocked_items = [
+        *todo_summary_monitor_blocked_resume_items(agent_todos),
+        *todo_summary_deferred_items(agent_todos, "deferred_items"),
+    ]
+    for item in blocked_items:
+        claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
+        if accountable_agent_id and claimed_by and claimed_by != accountable_agent_id:
+            continue
+        condition = (
+            item.get("resume_condition")
+            if isinstance(item.get("resume_condition"), dict)
+            else {}
+        )
+        monitor_todo_id = normalize_todo_id(
+            item.get("blocking_monitor_todo_id")
+            or condition.get("target_todo_id")
+            or condition.get("target")
+        )
+        if monitor_todo_id in monitors_by_id:
+            blocking_monitor_ids.add(monitor_todo_id)
+    if not blocking_monitor_ids:
+        return None
+
+    for monitor_todo_id in blocking_monitor_ids:
+        monitor = monitors_by_id[monitor_todo_id]
+        next_due_at = parse_timestamp(monitor.get("next_due_at"))
+        if next_due_at is None or next_due_at <= observed_at:
+            continue
+        expires_at = parse_timestamp(monitor.get("expires_at"))
+        if expires_at is not None and (
+            expires_at <= observed_at or expires_at <= next_due_at
+        ):
+            continue
+        return {
+            "todo_id": monitor_todo_id,
+            "next_due_at": str(monitor.get("next_due_at") or ""),
+        }
+    return None
 
 
 def _has_runnable_agent_advancement(agent_todos: dict[str, Any] | None) -> bool:
@@ -662,6 +738,13 @@ def autonomous_replan_obligation_from_runs(
         if blocked_successor_modes == {
             "blocked_successor_wait_without_material_transition"
         }:
+            signal_agent_id = _single_public_agent_id(blocked_successor_signals)
+            if _future_due_blocking_monitor(
+                agent_todos,
+                latest_generated_at=str(signals[0].get("generated_at") or ""),
+                agent_id=signal_agent_id or agent_id,
+            ):
+                return periodic_review()
             monitor_target_ids = {
                 str(signal.get("monitor_target_id") or "")
                 for signal in blocked_successor_signals

--- a/tests/control_plane/test_goal_vision_blocked_successor.py
+++ b/tests/control_plane/test_goal_vision_blocked_successor.py
@@ -38,6 +38,8 @@ BLOCKER_ID = "todo_exact_blocker"
 WAITING_ID = "todo_waiting_successor"
 CROSS_DOMAIN_WAITING_ID = "todo_cross_domain_waiting"
 CLAIMED_WAITING_ID = "todo_claimed_waiting"
+MONITOR_ID = "todo_future_monitor"
+MONITOR_BLOCKED_ID = "todo_monitor_blocked_advancement"
 
 
 def _vision_run(
@@ -81,6 +83,7 @@ def _status_payload(
     vision_state: str = "vision_drift_detected",
     missing_checkpoint: bool = False,
     latest_runs: list[dict] | None = None,
+    extra_agent_items: list[dict] | None = None,
 ) -> dict:
     blocker = quota_todo_item(
         todo_id=BLOCKER_ID,
@@ -99,7 +102,10 @@ def _status_payload(
         claimed_by=AGENT_ID,
         resume_when=f"todo_done:{BLOCKER_ID}",
     )
-    agent_todos = quota_todo_summary([blocker, waiting], role="agent")
+    agent_todos = quota_todo_summary(
+        [blocker, waiting, *(extra_agent_items or [])],
+        role="agent",
+    )
     return quota_status_payload(
         goal_id=GOAL_ID,
         status="active",
@@ -195,8 +201,15 @@ def _blocked_wait_polls() -> list[dict]:
     ]
 
 
-def _quota_with_replan_runs(runs: list[dict]) -> dict:
-    payload = _status_payload(latest_runs=runs)
+def _quota_with_replan_runs(
+    runs: list[dict],
+    *,
+    extra_agent_items: list[dict] | None = None,
+) -> dict:
+    payload = _status_payload(
+        latest_runs=runs,
+        extra_agent_items=extra_agent_items,
+    )
     item = payload["attention_queue"]["items"][0]
     obligation = autonomous_replan_obligation_from_runs(
         runs,
@@ -206,6 +219,37 @@ def _quota_with_replan_runs(runs: list[dict]) -> dict:
         item["autonomous_replan_obligation"] = obligation
         item["project_asset"]["autonomous_replan_obligation"] = obligation
     return _quota(payload)
+
+
+def _monitor_blocked_advancement_items(
+    *,
+    next_due_at: str | None,
+    claimed_by: str = AGENT_ID,
+) -> list[dict]:
+    monitor_metadata = {
+        "target_key": "future-monitor-target",
+        "cadence": "10m",
+    }
+    if next_due_at is not None:
+        monitor_metadata["next_due_at"] = next_due_at
+    return [
+        quota_todo_item(
+            todo_id=MONITOR_ID,
+            index=3,
+            text="[P0] Monitor the pending external result.",
+            task_class="continuous_monitor",
+            claimed_by=claimed_by,
+            **monitor_metadata,
+        ),
+        quota_todo_item(
+            todo_id=MONITOR_BLOCKED_ID,
+            index=4,
+            text="[P0] Resume delivery after the monitor completes.",
+            status="deferred",
+            claimed_by=claimed_by,
+            resume_when=f"todo_done:{MONITOR_ID}",
+        ),
+    ]
 
 
 @pytest.mark.parametrize("waiting_status", ["open", "deferred"])
@@ -308,6 +352,59 @@ def test_two_identical_blocked_successor_waits_trigger_bounded_replan() -> None:
         "create_successor",
         "record_wait_continuation",
     ]
+
+
+def test_future_due_blocking_monitor_suppresses_predue_wait_replan() -> None:
+    compacted_polls = [compact_run(poll) for poll in _blocked_wait_polls()]
+    assert "next_due_at" not in compacted_polls[0]["monitor_target"]
+
+    guard = _quota_with_replan_runs(
+        [*compacted_polls, _vision_run()],
+        extra_agent_items=_monitor_blocked_advancement_items(
+            next_due_at="2099-01-01T00:00:00+00:00",
+        ),
+    )
+
+    assert guard["decision"] == "skip"
+    assert guard["effective_action"] == "monitor_quiet_skip"
+    assert guard.get("autonomous_replan_obligation") is None
+    assert guard["vision_wait_state"]["selected_todo_id"] == WAITING_ID
+
+
+@pytest.mark.parametrize(
+    "next_due_at",
+    [None, "2026-07-16T00:00:00+00:00"],
+    ids=["schedule-gap", "overdue"],
+)
+def test_unscheduled_or_overdue_monitor_preserves_wait_replan(
+    next_due_at: str | None,
+) -> None:
+    compacted_polls = [compact_run(poll) for poll in _blocked_wait_polls()]
+
+    guard = _quota_with_replan_runs(
+        [*compacted_polls, _vision_run()],
+        extra_agent_items=_monitor_blocked_advancement_items(
+            next_due_at=next_due_at,
+        ),
+    )
+
+    assert guard["decision"] == "autonomous_replan_required"
+    trigger = guard["autonomous_replan_obligation"]["triggers"][0]
+    assert trigger["kind"] == "blocked_successor_no_progress_repeat"
+
+
+def test_peer_future_due_monitor_does_not_suppress_wait_replan() -> None:
+    guard = _quota_with_replan_runs(
+        [*[compact_run(poll) for poll in _blocked_wait_polls()], _vision_run()],
+        extra_agent_items=_monitor_blocked_advancement_items(
+            next_due_at="2099-01-01T00:00:00+00:00",
+            claimed_by="peer-agent",
+        ),
+    )
+
+    assert guard["decision"] == "autonomous_replan_required"
+    trigger = guard["autonomous_replan_obligation"]["triggers"][0]
+    assert trigger["kind"] == "blocked_successor_no_progress_repeat"
 
 
 def test_interleaved_peer_monitor_does_not_reset_blocked_successor_replan() -> None:


### PR DESCRIPTION
## Summary

- suppress repeated blocked-successor replan while the exact current-agent continuous monitor is still future-due
- preserve autonomous replan for overdue, unscheduled, expired, or peer-owned monitor waits
- derive the decision from existing compact todo and run-history projections without adding protocol fields

## Validation

- `uv run --with ruff ruff check loopx/control_plane/work_items/autonomous_replan_obligation.py tests/control_plane/test_goal_vision_blocked_successor.py`
- `uv run --with pytest pytest -q tests/control_plane/test_goal_vision_blocked_successor.py tests/control_plane/test_monitor_replan_agent_scope.py tests/control_plane/test_goal_frontier_replan_rules.py` (42 passed)
- `loopx canary premerge --from-git-diff --tier standard --timeout-seconds 180 --no-progress` (gate passed; 4 direct checks and 16 selected checks, no failures, warnings, advisories, or manual holds)

No scheduler cadence, todo schema, monitor writeback, or benchmark behavior changes.