### PR TITLE
fix(benchmarks): expose supervisor public liveness

### DIFF
--- a/scripts/skillsbench_reverse_tunnel_supervisor.py
+++ b/scripts/skillsbench_reverse_tunnel_supervisor.py
@@ -5,8 +5,9 @@ This helper is intentionally local-side: the remote benchmark host cannot
 create an ``ssh -R`` tunnel back to itself. The launcher owns the tunnel process,
 probes the remote loopback proxy through SSH, runs one remote command, and then
 cleans the tunnel up. Public output records only lifecycle status and compact
-counts; raw SSH destinations, remote commands, proxy URLs, and command output
-are private.
+counts. It is created when the supervisor starts, refreshed atomically while
+the remote command is running, and finalized on every exit path; raw SSH
+destinations, remote commands, proxy URLs, and command output are private.
 """
 
 from __future__ import annotations
@@ -21,6 +22,7 @@ import sys
 import tempfile
 import time
 from collections.abc import Mapping
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -29,13 +31,15 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from loopx.benchmark_core.remote_closeout import (
+from loopx.benchmark_core.remote_closeout import (  # noqa: E402
     build_remote_benchmark_closeout_contract,
     closeout_remote_benchmark_batch,
 )
 
 
 SCHEMA_VERSION = "skillsbench_reverse_tunnel_supervisor_v0"
+PUBLIC_LIVENESS_SCHEMA_VERSION = "skillsbench_supervisor_public_liveness_v0"
+PUBLIC_LIVENESS_INTERVAL_SEC = 30.0
 DEFAULT_REMOTE_FORWARD = "127.0.0.1:18180:127.0.0.1:18180"
 DEFAULT_TEST_HOST = "chatgpt.com"
 DEFAULT_TEST_PORT = 443
@@ -619,6 +623,57 @@ def _write_private_log(
     return True
 
 
+def _utc_timestamp(epoch_seconds: float) -> str:
+    return (
+        datetime.fromtimestamp(epoch_seconds, tz=timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _write_public_checkpoint(
+    path: str | None,
+    payload: dict[str, Any],
+    *,
+    state: str,
+    started_at: float,
+    heartbeat_count: int,
+    terminal: bool,
+    observed_at: float | None = None,
+) -> None:
+    now = time.time() if observed_at is None else observed_at
+    payload["duration_sec"] = round(max(0.0, now - started_at), 3)
+    payload["public_liveness"] = {
+        "schema_version": PUBLIC_LIVENESS_SCHEMA_VERSION,
+        "state": state,
+        "terminal": terminal,
+        "process_alive": not terminal,
+        "heartbeat_count": max(1, int(heartbeat_count)),
+        "update_interval_sec": PUBLIC_LIVENESS_INTERVAL_SEC,
+        "started_at": _utc_timestamp(started_at),
+        "observed_at": _utc_timestamp(now),
+        "elapsed_sec": payload["duration_sec"],
+        "raw_task_text_recorded": False,
+        "raw_logs_recorded": False,
+        "raw_trajectory_recorded": False,
+        "raw_verifier_output_recorded": False,
+        "local_paths_recorded": False,
+    }
+    if not path:
+        return
+    target = Path(path).expanduser()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary = target.with_name(f".{target.name}.{os.getpid()}.tmp")
+    try:
+        temporary.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(target)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
 def _public_artifact_sync_requested(args: argparse.Namespace) -> bool:
     return bool(
         args.remote_public_artifact_root
@@ -939,6 +994,21 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         ),
         "tunnel_liveness": _tunnel_liveness_public_contract(args),
     }
+    public_heartbeat_count = 0
+
+    def checkpoint(state: str, *, terminal: bool = False) -> None:
+        nonlocal public_heartbeat_count
+        public_heartbeat_count += 1
+        _write_public_checkpoint(
+            args.public_output_path,
+            payload,
+            state=state,
+            started_at=started_at,
+            heartbeat_count=public_heartbeat_count,
+            terminal=terminal,
+        )
+
+    checkpoint("starting")
 
     tunnel_proc: subprocess.Popen[Any] | None = None
     json_bridge_proc: subprocess.Popen[Any] | None = None
@@ -963,6 +1033,10 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
                 payload["json_bridge"]["server_exit_code"] = json_bridge_proc.returncode
         if runtime_dir_obj is not None:
             runtime_dir_obj.cleanup()
+        checkpoint(
+            "succeeded" if returncode == 0 and payload.get("ok") is True else "failed",
+            terminal=True,
+        )
         return returncode, payload
 
     try:
@@ -1133,6 +1207,10 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
             consecutive_inconclusive = 0
             if liveness["enabled"] and liveness["state"] != "reconnected":
                 liveness["state"] = "healthy"
+            checkpoint("running")
+            next_public_checkpoint = (
+                time.monotonic() + PUBLIC_LIVENESS_INTERVAL_SEC
+            )
 
             while remote_proc.poll() is None:
                 now = time.monotonic()
@@ -1152,6 +1230,11 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
                     if remote_proc.poll() is not None:
                         break
                     now = time.monotonic()
+                if now >= next_public_checkpoint:
+                    checkpoint("running")
+                    next_public_checkpoint = (
+                        time.monotonic() + PUBLIC_LIVENESS_INTERVAL_SEC
+                    )
                 if not liveness["enabled"] or now < next_health_probe:
                     time.sleep(0.1)
                     continue
@@ -1641,10 +1724,6 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     rc, payload = run_supervisor(args)
     text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
-    if args.public_output_path:
-        path = Path(args.public_output_path).expanduser()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(text, encoding="utf-8")
     sys.stdout.write(text)
     return rc
 

--- a/tests/test_skillsbench_reverse_tunnel_supervisor.py
+++ b/tests/test_skillsbench_reverse_tunnel_supervisor.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import stat
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SUPERVISOR_PATH = REPO_ROOT / "scripts" / "skillsbench_reverse_tunnel_supervisor.py"
+
+
+def _load_supervisor_module():
+    spec = importlib.util.spec_from_file_location(
+        "skillsbench_reverse_tunnel_supervisor_test",
+        SUPERVISOR_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_fake_ssh(path: Path) -> None:
+    path.write_text(
+        """#!/usr/bin/env python3
+import sys
+import time
+
+if "loopx_reverse_tunnel_keepalive" in sys.argv[-1]:
+    time.sleep(10)
+elif "# LOOPX_REVERSE_TUNNEL_PROBE" in sys.argv[-1]:
+    print("HTTP/1.1 200 OK")
+elif sys.argv[-1] == "run-benchmark":
+    time.sleep(0.2)
+raise SystemExit(0)
+""",
+        encoding="utf-8",
+    )
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def test_supervisor_writes_starting_periodic_and_terminal_public_liveness(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    supervisor = _load_supervisor_module()
+    supervisor.PUBLIC_LIVENESS_INTERVAL_SEC = 0.05
+    checkpoint_states: list[str] = []
+    write_checkpoint = supervisor._write_public_checkpoint
+
+    def record_checkpoint(*args, **kwargs) -> None:
+        checkpoint_states.append(kwargs["state"])
+        write_checkpoint(*args, **kwargs)
+
+    monkeypatch.setattr(supervisor, "_write_public_checkpoint", record_checkpoint)
+    fake_ssh = tmp_path / "fake-ssh"
+    public_output = tmp_path / "public" / "supervisor.public.json"
+    _write_fake_ssh(fake_ssh)
+
+    args = supervisor.parse_args(
+        [
+            "--ssh-bin",
+            str(fake_ssh),
+            "--ssh-destination",
+            "runner.example",
+            "--remote-command",
+            "run-benchmark",
+            "--public-output-path",
+            str(public_output),
+            "--probe-interval-sec",
+            "0.01",
+            "--probe-timeout-sec",
+            "1",
+            "--tunnel-ready-timeout-sec",
+            "1",
+            "--tunnel-health-interval-sec",
+            "0",
+            "--run-timeout-sec",
+            "2",
+        ]
+    )
+
+    returncode, payload = supervisor.run_supervisor(args)
+    persisted = json.loads(public_output.read_text(encoding="utf-8"))
+
+    assert returncode == 0
+    assert payload["ok"] is True
+    assert persisted == payload
+    assert checkpoint_states[0] == "starting"
+    assert checkpoint_states.count("running") >= 2
+    assert checkpoint_states[-1] == "succeeded"
+    assert persisted["public_liveness"]["state"] == "succeeded"
+    assert persisted["public_liveness"]["terminal"] is True
+    assert persisted["public_liveness"]["process_alive"] is False
+    assert persisted["public_liveness"]["heartbeat_count"] >= 4
+    assert persisted["public_liveness"]["elapsed_sec"] >= 0.2
+    assert persisted["public_liveness"]["raw_task_text_recorded"] is False
+    assert persisted["public_liveness"]["raw_logs_recorded"] is False
+    assert persisted["public_liveness"]["raw_trajectory_recorded"] is False
+    assert persisted["public_liveness"]["raw_verifier_output_recorded"] is False
+    assert persisted["public_liveness"]["local_paths_recorded"] is False
+
+
+def test_supervisor_finalizes_public_liveness_on_early_launch_failure(
+    tmp_path: Path,
+) -> None:
+    supervisor = _load_supervisor_module()
+    public_output = tmp_path / "public" / "supervisor.public.json"
+    args = supervisor.parse_args(
+        [
+            "--ssh-bin",
+            str(tmp_path / "missing-ssh"),
+            "--ssh-destination",
+            "runner.example",
+            "--remote-command",
+            "run-benchmark",
+            "--public-output-path",
+            str(public_output),
+        ]
+    )
+
+    returncode, payload = supervisor.run_supervisor(args)
+    persisted = json.loads(public_output.read_text(encoding="utf-8"))
+
+    assert returncode == 2
+    assert payload["first_blocker"] == "reverse_tunnel_launch_failed"
+    assert persisted == payload
+    assert persisted["public_liveness"]["state"] == "failed"
+    assert persisted["public_liveness"]["terminal"] is True
+    assert persisted["public_liveness"]["process_alive"] is False
+    assert persisted["public_liveness"]["heartbeat_count"] == 2


### PR DESCRIPTION
## Summary

- create the public supervisor receipt as soon as supervision starts
- refresh public-safe liveness state atomically while the remote command runs
- finalize the same receipt on successful and early-failure exit paths
- cover periodic success and early launch failure without retaining raw benchmark material

## Validation

- `ruff check scripts/skillsbench_reverse_tunnel_supervisor.py tests/test_skillsbench_reverse_tunnel_supervisor.py`
- `pytest -q tests/test_skillsbench_reverse_tunnel_supervisor.py tests/test_skillsbench_turn_launcher.py tests/test_skillsbench_setup_preflight.py` (`62 passed`)
- `loopx canary premerge --from-git-diff`
  - diff checks and changed-file compile passed
  - 4/4 selected catalog canaries passed
  - no check failures, skips, warnings, or tracked side effects

## Boundaries

- changes only benchmark supervisor lifecycle observation and its focused regression tests
- does not change scoring, task semantics, runner selection, leaderboard/submission behavior, or permission boundaries
- does not launch a benchmark job
- public receipt explicitly excludes raw task text, logs, trajectories, verifier output, credentials, and local paths

## Manual hold

Premerge correctly classified this as benchmark-sensitive and requires explicit maintainer review. The PR is intentionally left for that review before the owner-authorized self-merge decision.
