### PR TITLE
Classify SkillsBench sandbox namespace failures

### DIFF
--- a/loopx/benchmark_adapters/skillsbench_codex_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_codex_runtime.py
@@ -21,6 +21,7 @@ _STRING_FIELDS = (
     "host_local_codex_cli_preflight_failure_category",
     "host_local_codex_cli_preflight_sandbox_mode",
     "host_local_codex_cli_preflight_sandbox_probe_status",
+    "host_local_codex_cli_preflight_sandbox_failure_subtype",
 )
 _BOOL_FIELDS = (
     "host_local_codex_cli_preflight_requested",
@@ -170,6 +171,20 @@ def _fail(prerequisites: dict[str, Any], blocker: str, category: str) -> None:
     prerequisites["host_local_codex_cli_preflight_failure_category"] = category
 
 
+def _sandbox_failure_subtype(stdout: str, stderr: str) -> str:
+    text = f"{stdout}\n{stderr}".casefold()
+    namespace_markers = (
+        "no permissions to create new namespace",
+        "cannot create user namespace",
+        "failed to create user namespace",
+    )
+    if ("bwrap" in text or "bubblewrap" in text) and any(
+        marker in text for marker in namespace_markers
+    ):
+        return "linux_user_namespace_unavailable"
+    return "unclassified"
+
+
 def run_preflight(args: Any, plan: dict[str, Any]) -> None:
     prerequisites = plan.setdefault("runner_prerequisites", {})
     sandbox_mode = str(
@@ -194,6 +209,7 @@ def run_preflight(args: Any, plan: dict[str, Any]) -> None:
             "host_local_codex_cli_preflight_sandbox_probe_status": (
                 "pending" if sandbox_probe_required else "not_required"
             ),
+            "host_local_codex_cli_preflight_sandbox_failure_subtype": "",
             "host_local_codex_cli_preflight_raw_output_recorded": False,
             "host_local_codex_cli_preflight_path_recorded": False,
         }
@@ -243,14 +259,22 @@ def run_preflight(args: Any, plan: dict[str, Any]) -> None:
                         sandbox_probe_command,
                     ],
                     cwd=tmp,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
                     timeout=10,
                     check=False,
                 )
         except (OSError, subprocess.TimeoutExpired):
             proc = None
         if proc is None or proc.returncode != 0:
+            prerequisites[
+                "host_local_codex_cli_preflight_sandbox_failure_subtype"
+            ] = (
+                "sandbox_probe_process_error"
+                if proc is None
+                else _sandbox_failure_subtype(proc.stdout or "", proc.stderr or "")
+            )
             prerequisites[
                 "host_local_codex_cli_preflight_sandbox_probe_status"
             ] = "failed"

--- a/tests/test_skillsbench_remote_codex_preflight.py
+++ b/tests/test_skillsbench_remote_codex_preflight.py
@@ -90,13 +90,18 @@ def test_missing_codex_cli_has_precise_runner_attribution(tmp_path: Path) -> Non
 def test_host_local_codex_cli_preflight_fails_when_selected_sandbox_cannot_run(
     tmp_path: Path,
 ) -> None:
+    raw_failure = (
+        "bwrap: No permissions to create new namespace at "
+        "/private/runner/workspace\n"
+    )
     codex = tmp_path / "codex"
     codex.write_text(
         "#!/bin/sh\n"
         "if [ \"$1\" = \"--version\" ]; then exit 0; fi\n"
         "if [ \"$1\" = \"sandbox\" ] && "
         "[ \"$2\" = \"-c\" ] && "
-        "[ \"$3\" = 'sandbox_mode=\"workspace-write\"' ]; then exit 101; fi\n"
+        "[ \"$3\" = 'sandbox_mode=\"workspace-write\"' ]; then "
+        f"printf '%s' '{raw_failure}' >&2; exit 101; fi\n"
         "exit 0\n",
         encoding="utf-8",
     )
@@ -119,6 +124,17 @@ def test_host_local_codex_cli_preflight_fails_when_selected_sandbox_cannot_run(
     assert prerequisites["host_local_codex_cli_preflight_first_blocker"] == (
         "skillsbench_host_local_codex_cli_sandbox_probe_failed"
     )
+    assert prerequisites[
+        "host_local_codex_cli_preflight_sandbox_failure_subtype"
+    ] == "linux_user_namespace_unavailable"
+    serialized = json.dumps(prerequisites, sort_keys=True)
+    assert raw_failure.strip() not in serialized
+    assert "/private/runner/workspace" not in serialized
+    public = skillsbench_loop._public_runner_prerequisites(prerequisites)
+    assert public[
+        "host_local_codex_cli_preflight_sandbox_failure_subtype"
+    ] == "linux_user_namespace_unavailable"
+    assert "/private/runner/workspace" not in json.dumps(public, sort_keys=True)
     attribution = skillsbench_loop._runner_prerequisite_failure_attribution(
         prerequisites
     )


### PR DESCRIPTION
## Summary
- fingerprint host-local Codex sandbox probe output in memory
- project `linux_user_namespace_unavailable` as a bounded public subtype
- preserve fail-closed behavior and exclude raw output and paths

## Validation
- `uv run --no-project --with pytest pytest -q tests/test_skillsbench_remote_codex_preflight.py tests/test_skillsbench_setup_preflight.py` (50 passed)
- `python3 -m py_compile ...`
- `loopx check` on both changed files (0 errors, 0 warnings)
- `loopx canary premerge --from-git-diff` (all direct checks and 6 selected canaries passed; benchmark-sensitive manual hold remains)

## Boundary
This changes attribution only. It does not change sandbox selection, permissions, runner execution, scoring, task semantics, uploads, or evidence publicness.