### PR TITLE
Fix stale benchmark countability smokes

### DIFF
--- a/examples/benchmark-ledger-countability-smoke.py
+++ b/examples/benchmark-ledger-countability-smoke.py
@@ -93,7 +93,7 @@ def test_missing_verifier_reward_bool_does_not_override_uncountable_attempt() ->
     ), aggregate
 
 
-def test_real_bool_official_result_remains_countable_zero() -> None:
+def test_uncountable_bool_official_result_does_not_synthesize_zero() -> None:
     run = _setup_preflight_run()
     run["failure_class"] = "official_verifier_solution_failure"
     run["failure_scope"] = "case_or_solution"
@@ -102,9 +102,9 @@ def test_real_bool_official_result_remains_countable_zero() -> None:
     run["score_status"] = "missing"
 
     assert benchmark_run_official_score_countability(run) == {
-        "countable": True,
-        "reason": "countable_official_score",
-        "score": 0.0,
+        "countable": False,
+        "reason": "score_missing",
+        "score": None,
     }
 
 
@@ -243,7 +243,7 @@ def test_explicit_scored_attempt_precedes_coarse_verifier_attribution() -> None:
 
 def main() -> None:
     test_missing_verifier_reward_bool_does_not_override_uncountable_attempt()
-    test_real_bool_official_result_remains_countable_zero()
+    test_uncountable_bool_official_result_does_not_synthesize_zero()
     test_verifier_infrastructure_failure_zero_is_uncountable()
     test_verifier_dependency_failure_zero_is_uncountable()
     test_explicit_scored_attempt_precedes_coarse_verifier_attribution()

--- a/examples/skillsbench-current-ledger-aggregate-smoke.py
+++ b/examples/skillsbench-current-ledger-aggregate-smoke.py
@@ -461,14 +461,12 @@ def test_ledger_marks_uncountable_numeric_scores_noncountable() -> None:
         },
     }
     entry = build_benchmark_run_ledger_entry(passed_false_verifier_infra)
-    assert entry["official_score"] == 0.0, entry
-    assert entry["official_passed"] is False, entry
-    assert entry["score_status"] == "failed", entry
-    assert entry["official_score_attempt_countable"] is True, entry
+    assert "official_score" not in entry, entry
+    assert entry["official_score_bool_fallback_used"] is False, entry
+    assert entry["score_status"] == "missing", entry
+    assert entry["official_score_attempt_countable"] is False, entry
     assert entry["official_score_countable"] is False, entry
-    assert entry["official_score_countability_reason"] == (
-        "official_score_attempt_not_countable"
-    ), entry
+    assert entry["official_score_countability_reason"] == "score_missing", entry
     assert "countable_score" not in entry, entry
 
     completed_task_attempt_pass = {
@@ -506,7 +504,7 @@ def test_ledger_marks_uncountable_numeric_scores_noncountable() -> None:
     assert entry["countable_score"] == 1.0, entry
 
 
-def test_current_aggregate_keeps_setup_bool_fallback_uncountable() -> None:
+def test_current_aggregate_keeps_uncountable_setup_bool_result_missing() -> None:
     entry = build_benchmark_run_ledger_entry(
         {
             "schema_version": "benchmark_run_v0",
@@ -537,12 +535,10 @@ def test_current_aggregate_keeps_setup_bool_fallback_uncountable() -> None:
             },
         }
     )
-    assert entry["official_score"] == 0.0, entry
-    assert entry["official_score_bool_fallback_used"] is True, entry
+    assert "official_score" not in entry, entry
+    assert entry["official_score_bool_fallback_used"] is False, entry
     assert entry["official_score_countable"] is False, entry
-    assert entry["official_score_countability_reason"] == (
-        "official_score_attempt_not_countable"
-    ), entry
+    assert entry["official_score_countability_reason"] == "score_missing", entry
     assert "countable_score" not in entry, entry
     assert entry["case_attempt_countable"] is False, entry
     assert entry["solver_attempt_countable"] is False, entry
@@ -559,8 +555,9 @@ def test_current_aggregate_keeps_setup_bool_fallback_uncountable() -> None:
         canonical_case_ids=["setup-bool-fallback"],
     )
     case_best = aggregate["case_best"]["setup-bool-fallback"]
-    assert case_best["official_score"] == 0.0, case_best
+    assert "official_score" not in case_best, case_best
     assert case_best["official_score_countable"] is False, case_best
+    assert case_best["official_score_countability_reason"] == "score_missing", case_best
     assert case_best["bucket"] == "setup_runner_infra", case_best
     assert "countable_score" not in case_best, case_best
     assert aggregate["distribution"]["setup_runner_infra"] == 1, aggregate
@@ -573,9 +570,9 @@ def test_current_aggregate_keeps_setup_bool_fallback_uncountable() -> None:
         "pass_count": 0,
         "partial_count": 0,
         "official_zero_count": 0,
-        "uncountable_numeric_case_count": 1,
+        "uncountable_numeric_case_count": 0,
         "countable_case_ids": [],
-        "uncountable_numeric_case_ids": ["setup-bool-fallback"],
+        "uncountable_numeric_case_ids": [],
     }, aggregate["countable_score_summary"]
 
 
@@ -774,7 +771,7 @@ def test_current_aggregate_cli_writes_public_safe_json() -> None:
 if __name__ == "__main__":
     test_current_aggregate_prefers_countable_results()
     test_ledger_marks_uncountable_numeric_scores_noncountable()
-    test_current_aggregate_keeps_setup_bool_fallback_uncountable()
+    test_current_aggregate_keeps_uncountable_setup_bool_result_missing()
     test_current_aggregate_default_inference_excludes_sanity_sources()
     test_target_lane_aggregate_uses_current_then_full87_backfill()
     test_current_aggregate_cli_writes_public_safe_json()


### PR DESCRIPTION
## Summary

- align two Full Public smoke contracts with the missing-score behavior shipped by PR #2425
- require an explicitly uncountable, missing bool-only result to remain scoreless instead of synthesizing 0.0
- preserve setup/infra bucketing while excluding the missing result from numeric aggregate counts

This changes public validation only. It does not change scoring, runner, ledger, or benchmark execution behavior.

## Validation

- python3 examples/benchmark-ledger-countability-smoke.py
- python3 examples/skillsbench-current-ledger-aggregate-smoke.py
- python -m pytest -q tests/test_benchmark_ledger_countability.py (2 passed)
- Full Public shard 0: 100/100 passed
- Full Public shard 5: the changed countability smoke passed; the local macOS sweep was 99/100, with only the unrelated skillsbench-task-source-preflight-smoke.py failing a platform/preflight branch that is not failing in the latest hosted main run
- loopx canary premerge --from-git-diff: 10 selected checks passed, public-boundary scan passed, zero automated failures

## Hold

Premerge correctly retains the benchmark_sensitive manual-review hold. This PR must not be self-merged.
