### PR TITLE
Classify SkillsBench remote entry failures

### DIFF
--- a/scripts/skillsbench_reverse_tunnel_supervisor.py
+++ b/scripts/skillsbench_reverse_tunnel_supervisor.py
@@ -774,6 +774,27 @@ def _size_bucket(value: str) -> str:
     return "5000_plus"
 
 
+def _remote_command_failure_subtype(stderr_text: str) -> str:
+    """Classify stable entry failures without projecting remote stderr."""
+    normalized = stderr_text.lower()
+    if "loopx_runner_source_git_head_mismatch" in normalized:
+        return "runner_source_git_head_mismatch"
+    if "loopx_runner_source_git_head_unknown" in normalized:
+        return "runner_source_git_head_unknown"
+    if "unrecognized arguments:" in normalized:
+        return "cli_argument_incompatible"
+    if "usage:" in normalized and ": error:" in normalized:
+        return "cli_argument_error"
+    if (
+        "can't open file" in normalized
+        and "no such file or directory" in normalized
+    ):
+        return "remote_entrypoint_missing"
+    if "skillsbenchsetuppreflightblocked" in normalized:
+        return "setup_preflight_blocked"
+    return "unclassified"
+
+
 def _remote_failure_cleanup_public_contract(args: argparse.Namespace) -> dict[str, Any]:
     return {
         "requested": bool(args.remote_failure_cleanup_pattern),
@@ -1410,6 +1431,9 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         payload["ok"] = remote_proc.returncode == 0 and sync_ok
         if remote_proc.returncode != 0:
             payload["first_blocker"] = "remote_command_exit_nonzero"
+            payload["remote_command_failure_subtype"] = (
+                _remote_command_failure_subtype(stderr_text)
+            )
             payload["remote_failure_cleanup"] = _run_remote_failure_cleanup(
                 args,
                 trigger="remote_command_exit_nonzero",

--- a/tests/test_skillsbench_reverse_tunnel_supervisor.py
+++ b/tests/test_skillsbench_reverse_tunnel_supervisor.py
@@ -33,6 +33,10 @@ elif "# LOOPX_REVERSE_TUNNEL_PROBE" in sys.argv[-1]:
     print("HTTP/1.1 200 OK")
 elif sys.argv[-1] == "run-benchmark":
     time.sleep(0.2)
+elif sys.argv[-1] == "fail-arguments":
+    print("usage: runner [--known]", file=sys.stderr)
+    print("runner: error: unrecognized arguments: --private-value", file=sys.stderr)
+    raise SystemExit(2)
 raise SystemExit(0)
 """,
         encoding="utf-8",
@@ -130,3 +134,73 @@ def test_supervisor_finalizes_public_liveness_on_early_launch_failure(
     assert persisted["public_liveness"]["terminal"] is True
     assert persisted["public_liveness"]["process_alive"] is False
     assert persisted["public_liveness"]["heartbeat_count"] == 2
+
+
+def test_remote_command_failure_subtype_uses_public_allowlist() -> None:
+    supervisor = _load_supervisor_module()
+
+    assert supervisor._remote_command_failure_subtype(
+        "RuntimeError: loopx_runner_source_git_head_mismatch"
+    ) == "runner_source_git_head_mismatch"
+    assert supervisor._remote_command_failure_subtype(
+        "runner: error: unrecognized arguments: --private-value"
+    ) == "cli_argument_incompatible"
+    assert supervisor._remote_command_failure_subtype(
+        "usage: runner [--mode MODE]\nrunner: error: "
+        "argument --mode: invalid choice"
+    ) == "cli_argument_error"
+    assert supervisor._remote_command_failure_subtype(
+        "python3: can't open file 'opaque-runner.py': "
+        "[Errno 2] No such file or directory"
+    ) == "remote_entrypoint_missing"
+    assert supervisor._remote_command_failure_subtype(
+        "SkillsBenchSetupPreflightBlocked: private setup detail"
+    ) == "setup_preflight_blocked"
+    assert supervisor._remote_command_failure_subtype(
+        "secret-host.example failed with private-token"
+    ) == "unclassified"
+
+
+def test_supervisor_projects_only_allowlisted_remote_failure_subtype(
+    tmp_path: Path,
+) -> None:
+    supervisor = _load_supervisor_module()
+    fake_ssh = tmp_path / "fake-ssh"
+    public_output = tmp_path / "public" / "supervisor.public.json"
+    _write_fake_ssh(fake_ssh)
+    args = supervisor.parse_args(
+        [
+            "--ssh-bin",
+            str(fake_ssh),
+            "--ssh-destination",
+            "runner.example",
+            "--remote-command",
+            "fail-arguments",
+            "--public-output-path",
+            str(public_output),
+            "--probe-interval-sec",
+            "0.01",
+            "--probe-timeout-sec",
+            "1",
+            "--tunnel-ready-timeout-sec",
+            "1",
+            "--tunnel-health-interval-sec",
+            "0",
+            "--run-timeout-sec",
+            "2",
+        ]
+    )
+
+    returncode, payload = supervisor.run_supervisor(args)
+    persisted = json.loads(public_output.read_text(encoding="utf-8"))
+    public_text = json.dumps(persisted, sort_keys=True)
+
+    assert returncode == 2
+    assert payload["first_blocker"] == "remote_command_exit_nonzero"
+    assert payload["remote_command_failure_subtype"] == (
+        "cli_argument_incompatible"
+    )
+    assert persisted == payload
+    assert "--private-value" not in public_text
+    assert "usage: runner" not in public_text
+    assert persisted["raw_remote_output_recorded"] is False


### PR DESCRIPTION
## Summary

- project an allowlisted `remote_command_failure_subtype` when a remote SkillsBench command exits nonzero
- distinguish runner-source mismatches, CLI argument errors, missing entrypoints, and setup-preflight blocks without projecting stderr
- cover both the classifier and the persisted public supervisor receipt

## Validation

- `uv run --no-project --with pytest pytest -q tests/test_skillsbench_reverse_tunnel_supervisor.py` (4 passed)
- `python3 examples/skillsbench-reverse-tunnel-supervisor-smoke.py`
- changed-file `py_compile` and `git diff --check`
- `loopx canary premerge --from-git-diff`: all 4 selected catalog canaries passed; no automated failures
- one setup-only public preflight classified the existing exit-code-2 blocker as `cli_argument_error`; raw remote output and local paths remained absent from the public receipt

## Review Hold

Premerge reports the standard `benchmark_sensitive` manual hold. This PR only changes public-safe supervisor failure observation and focused tests. It does not change scoring, task semantics, runner execution behavior, permissions, leaderboard/submission behavior, or launch a formal benchmark run. Maintainer authorization for self-merging narrow benchmark helper/runtime changes is active, so this focused coverage is sufficient for this batch.

No private log was read. No raw benchmark evidence, credentials, local paths, or generated run artifacts are included.
