### PR TITLE
Guard setup-only SkillsBench history forwarding

### DIFF
--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -514,7 +514,8 @@ if ((task_count > 1)); then
 else
   extra_runner_args+=(--task-id "$task_id")
 fi
-if [[ "${SKILLSBENCH_APPEND_HISTORY:-0}" == "1" ]]; then
+if [[ "${SKILLSBENCH_APPEND_HISTORY:-0}" == "1" ]] &&
+  [[ "$setup_only_public_preflight" != "1" ]]; then
   extra_runner_args+=(--append-history)
 fi
 if [[ "$skip_global_ledger_sync" == "1" ]]; then

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -368,6 +368,7 @@ def test_setup_only_launcher_enables_incremental_public_artifact_sync(
 ) -> None:
     env = _base_env(tmp_path)
     env["SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT"] = "1"
+    env["SKILLSBENCH_APPEND_HISTORY"] = "1"
 
     proc = subprocess.run(
         [str(LAUNCHER), "--dry-run", "public-smoke-case", "setup-progress"],
@@ -381,3 +382,5 @@ def test_setup_only_launcher_enables_incremental_public_artifact_sync(
 
     assert "public_artifact_sync_interval_sec=30" in proc.stdout
     assert "--public-artifact-sync-interval-sec 30" in proc.stdout
+    assert "--setup-only-public-preflight" in proc.stdout
+    assert "--append-history" not in proc.stdout


### PR DESCRIPTION
## Summary

- suppress `--append-history` when the launcher is running a setup-only public preflight
- preserve history forwarding for normal benchmark runs
- cover the conflicting environment combination in the launcher test

## Validation

- `uv run --no-project --with pytest pytest -q tests/test_skillsbench_turn_launcher.py` (15 passed)
- `python3 examples/skillsbench-benchmark-egress-policy-smoke.py`
- `bash -n scripts/skillsbench-launch-goal-xhigh.sh` and `git diff --check`
- `loopx canary premerge --from-git-diff`: all 4 selected catalog canaries passed; no automated failures
- real setup-only public canary with history requested: CLI parsing passed, runner source matched exact main, job root and environment object materialized, and the next typed blocker was the existing apt repository failure

## Review Hold

Premerge reports the standard `benchmark_sensitive` manual hold. This is a narrow launcher compatibility guard: it does not change scoring, task semantics, normal-run history behavior, permissions, submissions, or formal benchmark launch behavior. Maintainer authorization for self-merging narrow benchmark helper/runtime fixes is active, so the focused tests and real setup-only canary are sufficient.

No private log was read. No raw benchmark evidence, credentials, local paths, or generated run artifacts are included.
