### PR TITLE
Fail fast on unsupported SkillsBench host sandbox

### DIFF
--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -292,6 +292,7 @@ remote_codex_bin_mode="path_lookup"
 if [[ -n "${SKILLSBENCH_REMOTE_CODEX_BIN:-}" ]]; then
   remote_codex_bin_mode="explicit"
 fi
+exact_host_codex_sandbox_preflight="not_required"
 if [[ "$dry_run" == "false" && "$setup_only_public_preflight" != "1" ]]; then
   if [[ "$remote_codex_bin" == */* ]]; then
     printf -v remote_codex_probe \
@@ -307,6 +308,59 @@ if [[ "$dry_run" == "false" && "$setup_only_public_preflight" != "1" ]]; then
     echo "remote Codex CLI unavailable; set SKILLSBENCH_REMOTE_CODEX_BIN" >&2
     exit 2
   fi
+  remote_codex_sandbox_probe_py='import shutil, subprocess, sys, tempfile
+codex_bin, sandbox_mode = sys.argv[1:]
+with tempfile.TemporaryDirectory(prefix="gh-skillsbench-codex-sandbox-") as tmp:
+    try:
+        proc = subprocess.run(
+            [
+                codex_bin,
+                "sandbox",
+                "-c",
+                f"sandbox_mode=\"{sandbox_mode}\"",
+                "--",
+                shutil.which("true") or "true",
+            ],
+            cwd=tmp,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        raise SystemExit(1) from None
+raise SystemExit(proc.returncode)'
+  printf -v remote_codex_sandbox_probe \
+    '%q -c %q %q %q' \
+    python3 "$remote_codex_sandbox_probe_py" \
+    "$remote_codex_bin" "$local_codex_sandbox"
+  if ! ssh "${ssh_command_options[@]}" "$SKILLSBENCH_SSH_DESTINATION" \
+    "$remote_codex_sandbox_probe" >/dev/null 2>&1; then
+    python3 - "$local_codex_sandbox" "$remote_codex_bin_mode" <<'PY' >&2
+import json
+import sys
+
+print(
+    json.dumps(
+        {
+            "ok": False,
+            "schema_version": "skillsbench_exact_host_codex_sandbox_preflight_v0",
+            "error": "skillsbench_exact_host_codex_sandbox_preflight_failed",
+            "sandbox_mode": sys.argv[1],
+            "remote_codex_bin_mode": sys.argv[2],
+            "raw_output_recorded": False,
+            "remote_path_recorded": False,
+            "ssh_destination_recorded": False,
+        },
+        sort_keys=True,
+    )
+)
+PY
+    exit 3
+  fi
+  exact_host_codex_sandbox_preflight="passed"
+elif [[ "$setup_only_public_preflight" != "1" ]]; then
+  exact_host_codex_sandbox_preflight="required"
 fi
 
 stamp="${SKILLSBENCH_RUN_STAMP:-$(date +%Y%m%dT%H%M%SCST)}"
@@ -647,6 +701,8 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'runner_profile_path_recorded=false\n'
   printf 'runner_profile_values_recorded=false\n'
   printf 'local_codex_sandbox=%s\n' "$local_codex_sandbox"
+  printf 'exact_host_codex_sandbox_preflight=%s\n' \
+    "$exact_host_codex_sandbox_preflight"
   printf 'codex_cli_goal_thread_prewarm=%s\n' "$codex_cli_goal_thread_prewarm"
   printf 'allow_staged_bootstrap_repair_run=%s\n' "$allow_staged_bootstrap_repair_run"
   printf 'setup_only_public_preflight=%s\n' "$setup_only_public_preflight"
@@ -751,5 +807,6 @@ local_codex_sandbox=${local_codex_sandbox}
 codex_cli_goal_thread_prewarm=${codex_cli_goal_thread_prewarm}
 allow_staged_bootstrap_repair_run=${allow_staged_bootstrap_repair_run}
 setup_only_public_preflight=${setup_only_public_preflight}
+exact_host_codex_sandbox_preflight=${exact_host_codex_sandbox_preflight}
 public_artifact_sync_interval_sec=${public_artifact_sync_interval}
 EOF

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -81,6 +82,7 @@ def test_turn_launcher_wires_private_commands_without_echoing_values(
     assert "docker_proxy_host=" not in output
     assert env["SKILLSBENCH_DOCKER_PROXY_HOST"] not in output
     assert "private_runner_command_values_redacted=true" in output
+    assert "exact_host_codex_sandbox_preflight=required" in output
     for arg_name in (
         "--remote-command-file-bridge-probe-command",
         "--remote-command-file-bridge-solver-command",
@@ -95,6 +97,54 @@ def test_turn_launcher_wires_private_commands_without_echoing_values(
     for private_value in private_values.values():
         assert private_value not in output
     assert "sentinel-" not in output
+
+
+def test_launcher_fails_before_batch_when_exact_host_sandbox_probe_fails(
+    tmp_path: Path,
+) -> None:
+    env = _base_env(tmp_path)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    call_count = tmp_path / "ssh-call-count"
+    fake_ssh = fake_bin / "ssh"
+    fake_ssh.write_text(
+        "#!/bin/sh\n"
+        f"count_file={call_count!s}\n"
+        'count=0\n'
+        'if [ -f "$count_file" ]; then count=$(cat "$count_file"); fi\n'
+        'count=$((count + 1))\n'
+        'printf "%s" "$count" > "$count_file"\n'
+        'if [ "$count" -eq 1 ]; then exit 0; fi\n'
+        'exit 1\n',
+        encoding="utf-8",
+    )
+    fake_ssh.chmod(0o755)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "public-smoke-case", "exact-host-preflight"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 3, proc
+    payload = json.loads(proc.stderr)
+    assert payload == {
+        "error": "skillsbench_exact_host_codex_sandbox_preflight_failed",
+        "ok": False,
+        "raw_output_recorded": False,
+        "remote_codex_bin_mode": "path_lookup",
+        "remote_path_recorded": False,
+        "sandbox_mode": "workspace-write",
+        "schema_version": "skillsbench_exact_host_codex_sandbox_preflight_v0",
+        "ssh_destination_recorded": False,
+    }
+    assert call_count.read_text(encoding="utf-8") == "2"
+    assert "pid=" not in proc.stdout
 
 
 def test_turn_launcher_accepts_stability_policy(tmp_path: Path) -> None:
@@ -381,6 +431,7 @@ def test_setup_only_launcher_enables_incremental_public_artifact_sync(
     )
 
     assert "public_artifact_sync_interval_sec=30" in proc.stdout
+    assert "exact_host_codex_sandbox_preflight=not_required" in proc.stdout
     assert "--public-artifact-sync-interval-sec 30" in proc.stdout
     assert "--setup-only-public-preflight" in proc.stdout
     assert "--append-history" not in proc.stdout


### PR DESCRIPTION
## Summary
- probe the configured remote Codex binary and sandbox mode once before starting a formal SkillsBench batch
- fail closed with a compact public-safe receipt when the exact host cannot run the requested sandbox
- expose required/passed/not-required status in launcher dry-run and launch output

## Validation
- `uv run --no-project --with pytest pytest -q tests/test_skillsbench_turn_launcher.py` (16 passed)
- `python3 examples/skillsbench-runner-profile-smoke.py`
- `python3 examples/skillsbench-benchmark-egress-policy-smoke.py`
- `uvx ruff check tests/test_skillsbench_turn_launcher.py`
- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`
- real task-free exact-host canary returned the typed fail-closed receipt before supervisor launch
- `loopx canary premerge --from-git-diff`: all direct checks and 4 catalog canaries passed; benchmark-sensitive manual hold remains

## Scope
No scoring, task semantics, solver/verifier, upload, leaderboard, credential, or permission behavior changes. The manual hold is covered by the focused launcher regression, two durable benchmark smokes, the exact product-path canary, and owner authorization for self-merging bounded benchmark helper/runtime changes.