### PR TITLE
test: align heartbeat prompt parity smokes

### DIFF
--- a/examples/blocker-push-runtime-smoke.py
+++ b/examples/blocker-push-runtime-smoke.py
@@ -209,10 +209,12 @@ def main() -> int:
         compact_prompt = " ".join(prompt.split())
         assert "state=operator_gate" not in compact_prompt, prompt
         assert "follow `interaction_contract`" in compact_prompt, prompt
-        assert "User NOTIFY: concrete Chinese actions even non_blocking false/0" in compact_prompt, prompt
-        assert 'never only "owner gate"' in compact_prompt, prompt
+        assert "NOTIFY Chinese actions incl. non_blocking false/0" in compact_prompt, prompt
+        assert 'not only "owner gate"' in compact_prompt, prompt
         assert "具体 user todo 未投影，需修复 LoopX 状态投影" in compact_prompt, prompt
-        assert "Quiet only if DONT_NOTIFY+false/0" in compact_prompt, prompt
+        assert "DONT_NOTIFY+false/0 only: quiet" in compact_prompt, prompt
+        assert "`LOOPX_TURN=<current_time_iso>`; reuse." in compact_prompt, prompt
+        assert "guard receipt; 2 stalls->replan" in compact_prompt, prompt
         assert "spend post-writeback" in compact_prompt, prompt
 
     print("blocker-push-runtime-smoke ok")

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -676,7 +676,8 @@ def main() -> int:
         assert payload["ok"] is True, payload
         assert payload["quota_guard_command"] == (
             'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" '
-            "quota should-run --goal-id installer-smoke-goal"
+            'quota should-run --goal-id installer-smoke-goal '
+            '--turn-instance-id "${LOOPX_TURN:?}"'
         ), payload
         assert payload["quota_spend_command"] == (
             'loopx --registry "$HOME/.codex/loopx/registry.global.json" '
@@ -689,6 +690,8 @@ def main() -> int:
         assert "--delivery-outcome outcome_progress" in payload["progress_refresh_state_command"], payload
         assert "<PUBLIC_SAFE_PROGRESS_CLASSIFICATION>" in payload["progress_refresh_state_command"], payload
         assert "follow `interaction_contract`" in payload["task_body"], payload
+        assert "`LOOPX_TURN=<current_time_iso>`; reuse." in payload["task_body"], payload
+        assert "guard receipt; 2 stalls->replan" in payload["task_body"], payload
         assert "spend post-writeback" in payload["task_body"], payload
         assert payload["cli_bin"] == "loopx", payload
 


### PR DESCRIPTION
## Summary
- align blocker-push runtime assertions with the compact heartbeat interaction contract
- require the turn-scoped quota guard in installed heartbeat snapshots
- retain explicit coverage for turn receipt reuse and stall-driven replanning

## Validation
- focused blocker-push, install-local, and canonical heartbeat-prompt smokes pass
- canary promotion readiness passes
- Full Public shard 3 passes 100/100 with serial execution
- Full Public shard 1 target checks pass; the shard remains 99/100 locally because the unrelated codex CLI TUI bootstrap bundle's external GitHub installer exits 2
- `loopx canary premerge --from-git-diff` passes with no manual holds