### PR TITLE
fix(quota): expire replan ACK at newer stalls

### DIFF
--- a/loopx/control_plane/work_items/autonomous_replan_ack.py
+++ b/loopx/control_plane/work_items/autonomous_replan_ack.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from ..runtime.time import parse_timestamp
+
 
 AUTONOMOUS_REPLAN_ACK_MATERIAL_RUN_WINDOW = 20
 
@@ -44,6 +46,9 @@ def compact_autonomous_replan_ack(run: dict[str, Any] | None) -> dict[str, Any] 
     frontier_identity = str(ack.get("frontier_identity") or "").strip()
     if frontier_identity:
         result["frontier_identity"] = frontier_identity
+    generated_at = str(run.get("generated_at") or "").strip()
+    if generated_at:
+        result["generated_at"] = generated_at
     return result
 
 
@@ -96,7 +101,26 @@ def autonomous_replan_ack_matches_frontier(
         return True
     if not isinstance(ack, dict):
         return False
-    return str(ack.get("frontier_identity") or "").strip() == frontier_identity
+    if str(ack.get("frontier_identity") or "").strip() != frontier_identity:
+        return False
+
+    ack_generated_at = parse_timestamp(
+        ack.get("generated_at") or ack.get("recorded_at")
+    )
+    trigger_times = [
+        parsed
+        for trigger in obligation.get("triggers") or []
+        if isinstance(trigger, dict)
+        if (
+            parsed := parse_timestamp(
+                trigger.get("latest_generated_at") or trigger.get("generated_at")
+            )
+        )
+        is not None
+    ]
+    if ack_generated_at is not None and trigger_times:
+        return ack_generated_at >= max(trigger_times)
+    return True
 
 
 def autonomous_replan_ack_matches_agent(

--- a/tests/control_plane/test_goal_vision_blocked_successor.py
+++ b/tests/control_plane/test_goal_vision_blocked_successor.py
@@ -482,7 +482,7 @@ def test_replan_ack_dedupes_only_the_same_blocked_successor_frontier() -> None:
     frontier_identity = polls[0]["monitor_target"]["frontier_identity"]
     ack = {
         "classification": "autonomous_replan_recorded",
-        "generated_at": "2026-07-16T00:00:30+00:00",
+        "generated_at": "2026-07-16T00:03:00+00:00",
         "agent_id": AGENT_ID,
         "autonomous_replan_ack": {
             "schema_version": "autonomous_replan_ack_v0",
@@ -507,6 +507,35 @@ def test_replan_ack_dedupes_only_the_same_blocked_successor_frontier() -> None:
     assert changed_frontier["autonomous_replan_obligation"][
         "frontier_identity"
     ] == frontier_identity
+
+
+def test_replan_ack_does_not_cover_newer_same_frontier_stalls() -> None:
+    polls = _blocked_wait_polls()
+    frontier_identity = polls[0]["monitor_target"]["frontier_identity"]
+    older_ack = {
+        "classification": "autonomous_replan_recorded",
+        "generated_at": "2026-07-16T00:00:30+00:00",
+        "agent_id": AGENT_ID,
+        "autonomous_replan_ack": {
+            "schema_version": "autonomous_replan_ack_v0",
+            "recorded": True,
+            "source": "fixture",
+            "frontier_identity": frontier_identity,
+            "delta_contract": {
+                "schema_version": "repair_delta_contract_v0",
+                "delta_present": True,
+                "delta_kinds": ["watch_lane_continuation"],
+            },
+        },
+    }
+
+    replanned = _quota_with_replan_runs([*polls, older_ack, _vision_run()])
+
+    assert replanned["decision"] == "autonomous_replan_required"
+    assert replanned["goal_frontier_projection"]["replan_required"] is True
+    assert replanned["autonomous_replan_obligation"]["frontier_identity"] == (
+        frontier_identity
+    )
 
 
 def test_refresh_ack_preserves_the_observed_blocked_successor_identity(


### PR DESCRIPTION
## Summary
- preserve the durable replan ACK timestamp in the compact projection
- let an ACK suppress only same-frontier stall evidence observed at or before that ACK
- add regression coverage for newer same-frontier stalls after an older watch-lane continuation

## Validation
- `uv run --extra test python -m pytest -q tests/control_plane/test_goal_vision_blocked_successor.py tests/control_plane/test_monitor_replan_agent_scope.py tests/control_plane/test_goal_frontier_replan_rules.py` (43 passed)
- `uv run --extra test ruff check loopx/control_plane/work_items/autonomous_replan_ack.py tests/control_plane/test_goal_vision_blocked_successor.py`
- autonomous replan obligation/read-model smokes and both no-progress regression contracts
- `loopx canary premerge --from-git-diff` (4 direct checks and 16 risk-selected checks passed; no warnings or manual holds)
- live public-safe quota projection changed from `monitor_quiet_skip` to `autonomous_replan_required` for newer post-ACK stalls

## Boundaries
- no benchmark jobs launched
- no scoring, runner, task semantics, permission, or submission behavior changed
- no private state, local paths, raw evidence, credentials, or generated logs included
- no authoritative check failures or skips; `uv` supplied the repository test environment

## Merge decision
The change is a narrow control-plane reducer fix with focused regression coverage. The standard premerge gate reports `self_merge_allowed=true`; coverage exercises quota/status consistency and the known no-progress contract.