### PR TITLE
Project live SkillsBench worker phases

### DIFF
--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -86,7 +86,7 @@ Optional env:
   SKILLSBENCH_RUN_TIMEOUT_SEC          Supervisor timeout, default 28800
   SKILLSBENCH_PUBLIC_ARTIFACT_SYNC_INTERVAL_SEC
                                        Incremental public artifact sync interval;
-                                       defaults to 30 for setup-only and 0 otherwise
+                                       defaults to 30; set to 0 to disable
   SKILLSBENCH_TUNNEL_PROBE_TIMEOUT_SEC Reverse-tunnel CONNECT probe timeout,
                                        default 20
   SKILLSBENCH_TUNNEL_READY_TIMEOUT_SEC Reverse-tunnel readiness budget,
@@ -402,10 +402,8 @@ build_stall_timeout="${SKILLSBENCH_BUILD_STALL_TIMEOUT_SEC:-3600}"
 run_timeout="${SKILLSBENCH_RUN_TIMEOUT_SEC:-28800}"
 if [[ -n "${SKILLSBENCH_PUBLIC_ARTIFACT_SYNC_INTERVAL_SEC:-}" ]]; then
   public_artifact_sync_interval="$SKILLSBENCH_PUBLIC_ARTIFACT_SYNC_INTERVAL_SEC"
-elif [[ "$setup_only_public_preflight" == "1" ]]; then
-  public_artifact_sync_interval=30
 else
-  public_artifact_sync_interval=0
+  public_artifact_sync_interval=30
 fi
 tunnel_probe_timeout="${SKILLSBENCH_TUNNEL_PROBE_TIMEOUT_SEC:-20}"
 tunnel_ready_timeout="${SKILLSBENCH_TUNNEL_READY_TIMEOUT_SEC:-60}"

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -2691,6 +2691,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "schema_version",
         "agent_execution_mode",
         "benchflow_run_stage",
+        "benchflow_case_worker_status",
         "host_local_acp_launch_status",
         "host_local_acp_install_stage",
         "host_local_acp_install_failed_stage",
@@ -2899,6 +2900,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_setup_stall_raw_logs_read",
         "benchflow_setup_stall_before_agent_lifecycle",
         "benchflow_agent_install_started",
+        "benchflow_lifecycle_private_logs_read",
         "benchflow_setup_stall_task_cancel_requested",
         "benchflow_setup_stall_task_cancel_acknowledged",
         "benchflow_setup_stall_task_cancel_timeout",
@@ -2918,6 +2920,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         compact["benchmark_canonical_lifecycle"] = lifecycle
     for field in (
         "codex_acp_runtime_launch_preflight_rc",
+        "benchflow_lifecycle_receipt_sequence",
         "benchflow_agent_timeout_requested_sec",
         "benchflow_agent_timeout_original_sec",
         "benchflow_agent_timeout_effective_sec",
@@ -3151,11 +3154,40 @@ def _write_public_runner_prerequisites(plan: dict[str, Any]) -> Path | None:
     if path is None:
         return None
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
+    _write_text_atomic(
+        path,
         json.dumps(compact, indent=2, sort_keys=True, default=_json_default) + "\n",
-        encoding="utf-8",
     )
     return path
+
+
+def _write_public_runner_lifecycle_receipt(
+    plan: dict[str, Any],
+    *,
+    run_stage: str | None = None,
+    worker_status: str | None = None,
+    host_local_acp_status: str | None = None,
+    host_local_acp_install_stage: str | None = None,
+    agent_install_started: bool | None = None,
+) -> Path | None:
+    """Persist one public-safe live phase without inspecting private output."""
+
+    prerequisites = plan.setdefault("runner_prerequisites", {})
+    if run_stage is not None:
+        prerequisites["benchflow_run_stage"] = run_stage
+    if worker_status is not None:
+        prerequisites["benchflow_case_worker_status"] = worker_status
+    if host_local_acp_status is not None:
+        prerequisites["host_local_acp_launch_status"] = host_local_acp_status
+    if host_local_acp_install_stage is not None:
+        prerequisites["host_local_acp_install_stage"] = host_local_acp_install_stage
+    if agent_install_started is not None:
+        prerequisites["benchflow_agent_install_started"] = agent_install_started
+    prerequisites["benchflow_lifecycle_private_logs_read"] = False
+    prerequisites["benchflow_lifecycle_receipt_sequence"] = (
+        int(prerequisites.get("benchflow_lifecycle_receipt_sequence") or 0) + 1
+    )
+    return _write_public_runner_prerequisites(plan)
 
 
 def _read_public_runner_prerequisites(plan: dict[str, Any]) -> dict[str, Any]:
@@ -13967,7 +13999,11 @@ async def run_benchflow_case(
     if str(REPO_ROOT) not in sys.path:
         sys.path.insert(0, str(REPO_ROOT))
 
-    prerequisites["benchflow_run_stage"] = "benchflow_import"
+    _write_public_runner_lifecycle_receipt(
+        plan,
+        run_stage="benchflow_import",
+        worker_status="runtime_preparing",
+    )
     import benchflow.acp.runtime as benchflow_acp_runtime
     import benchflow.rollout as benchflow_rollout_module
     import benchflow.sandbox.setup as benchflow_sandbox_setup_module
@@ -13989,7 +14025,11 @@ async def run_benchflow_case(
         prerequisites["host_local_acp_connect_as_unpack_return_arity"] = (
             connect_as_return_arity
         )
-    prerequisites["benchflow_run_stage"] = "runtime_prepare"
+    _write_public_runner_lifecycle_receipt(
+        plan,
+        run_stage="runtime_prepare",
+        worker_status="runtime_preparing",
+    )
 
     host_local_acp_command = _host_local_acp_launch_command(args, plan)
     runtime_mounts = (
@@ -14032,7 +14072,11 @@ async def run_benchflow_case(
         from benchflow.acp.transport import StdioTransport
 
         prerequisites = plan.setdefault("runner_prerequisites", {})
-        prerequisites["host_local_acp_launch_status"] = "connecting"
+        _write_public_runner_lifecycle_receipt(
+            plan,
+            worker_status="acp_connecting",
+            host_local_acp_status="connecting",
+        )
         local_acp_command = list(host_local_acp_command)
         sandbox_bridge_command = _host_local_acp_docker_bridge_command(
             env,
@@ -14103,7 +14147,11 @@ async def run_benchflow_case(
             )
             if model:
                 await asyncio.wait_for(client.set_model(model), timeout=60)
-            prerequisites["host_local_acp_launch_status"] = "connected"
+            _write_public_runner_lifecycle_receipt(
+                plan,
+                worker_status="acp_connected",
+                host_local_acp_status="connected",
+            )
             if isinstance(controller_trace, dict):
                 controller_trace["native_goal_worker_route"] = (
                     args.route == "codex-app-server-goal-baseline"
@@ -14135,7 +14183,11 @@ async def run_benchflow_case(
                 return client, session, session_adapter, agent_name
             return client, session, agent_name
         except Exception:
-            prerequisites["host_local_acp_launch_status"] = "failed"
+            _write_public_runner_lifecycle_receipt(
+                plan,
+                worker_status="acp_connect_failed",
+                host_local_acp_status="failed",
+            )
             with contextlib.suppress(Exception):
                 await client.close()
             raise
@@ -14453,6 +14505,11 @@ async def run_benchflow_case(
         )
         prerequisites["codex_acp_runtime_launch_preflight_status"] = "skipped"
         prerequisites["codex_acp_runtime_launch_preflight_raw_logs_read"] = False
+        _write_public_runner_lifecycle_receipt(
+            plan,
+            worker_status="sandbox_installing",
+            host_local_acp_status="installing_sandbox",
+        )
         try:
             prerequisites["host_local_acp_install_stage"] = (
                 "docker_exec_capture_preflight"
@@ -14609,16 +14666,25 @@ async def run_benchflow_case(
             prerequisites["host_local_acp_install_failed_stage"] = str(
                 prerequisites.get("host_local_acp_install_stage") or "unknown"
             )
-            prerequisites["host_local_acp_launch_status"] = "sandbox_install_failed"
+            _write_public_runner_lifecycle_receipt(
+                plan,
+                worker_status="sandbox_install_failed",
+                host_local_acp_status="sandbox_install_failed",
+                host_local_acp_install_stage=str(
+                    prerequisites.get("host_local_acp_install_stage") or "unknown"
+                ),
+            )
             raise
-        prerequisites["host_local_acp_install_stage"] = "sandbox_installed"
-        prerequisites["host_local_acp_launch_status"] = "sandbox_installed"
+        _write_public_runner_lifecycle_receipt(
+            plan,
+            worker_status="sandbox_installed",
+            host_local_acp_status="sandbox_installed",
+            host_local_acp_install_stage="sandbox_installed",
+        )
         self._phase = "installed"
 
     async def install_agent_with_launch_preflight(self: Any) -> Any:
         prerequisites = plan.setdefault("runner_prerequisites", {})
-        prerequisites["benchflow_agent_install_started"] = True
-        prerequisites["benchflow_run_stage"] = "agent_install_started"
         original_timeout = getattr(self, "_timeout", None)
         requested_timeout = _effective_benchflow_agent_timeout_sec(args)
         prerequisites["benchflow_agent_timeout_requested_sec"] = requested_timeout
@@ -14644,6 +14710,12 @@ async def run_benchflow_case(
                 effective_timeout != original_timeout
             )
             self._timeout = effective_timeout
+        _write_public_runner_lifecycle_receipt(
+            plan,
+            run_stage="agent_install_started",
+            worker_status="agent_install_started",
+            agent_install_started=True,
+        )
         if args.host_local_acp_launch:
             return await install_agent_host_local_acp(self)
         result = await original_install_agent(self)
@@ -14784,7 +14856,11 @@ async def run_benchflow_case(
     )
     prerequisites["benchflow_setup_stall_timeout_sec"] = build_stall_timeout_sec
     prerequisites["benchflow_setup_stall_raw_logs_read"] = False
-    prerequisites["benchflow_run_stage"] = "before_benchflow_run"
+    _write_public_runner_lifecycle_receipt(
+        plan,
+        run_stage="before_benchflow_run",
+        worker_status="worker_prepared",
+    )
 
     def agent_lifecycle_started() -> bool:
         if prerequisites.get("benchflow_agent_install_started") is True:
@@ -14810,11 +14886,19 @@ async def run_benchflow_case(
         return False
 
     async def run_benchflow_with_setup_stall_watchdog() -> None:
-        prerequisites["benchflow_run_stage"] = "benchflow_run_started"
+        _write_public_runner_lifecycle_receipt(
+            plan,
+            run_stage="benchflow_run_started",
+            worker_status="worker_running",
+        )
         task = asyncio.create_task(benchflow_run(config))
         if build_stall_timeout_sec <= 0:
             await task
-            prerequisites["benchflow_run_stage"] = "benchflow_run_completed"
+            _write_public_runner_lifecycle_receipt(
+                plan,
+                run_stage="benchflow_run_completed",
+                worker_status="worker_completed",
+            )
             return
         done, _pending = await asyncio.wait(
             {task},
@@ -14823,18 +14907,32 @@ async def run_benchflow_case(
         )
         if done:
             await task
-            prerequisites["benchflow_run_stage"] = "benchflow_run_completed"
+            _write_public_runner_lifecycle_receipt(
+                plan,
+                run_stage="benchflow_run_completed",
+                worker_status="worker_completed",
+            )
             return
         if agent_lifecycle_started():
-            prerequisites["benchflow_run_stage"] = (
-                "benchflow_run_continues_after_agent_lifecycle_started"
+            _write_public_runner_lifecycle_receipt(
+                plan,
+                run_stage="benchflow_run_continues_after_agent_lifecycle_started",
+                worker_status="agent_active",
             )
             await task
-            prerequisites["benchflow_run_stage"] = "benchflow_run_completed"
+            _write_public_runner_lifecycle_receipt(
+                plan,
+                run_stage="benchflow_run_completed",
+                worker_status="worker_completed",
+            )
             return
         prerequisites["benchflow_setup_stall_timeout_triggered"] = True
         prerequisites["benchflow_setup_stall_before_agent_lifecycle"] = True
-        prerequisites["benchflow_run_stage"] = "build_or_setup_stall_before_agent"
+        _write_public_runner_lifecycle_receipt(
+            plan,
+            run_stage="build_or_setup_stall_before_agent",
+            worker_status="setup_stalled",
+        )
         prerequisites["benchflow_setup_stall_task_cancel_requested"] = True
         task.cancel()
         try:

--- a/tests/test_skillsbench_setup_preflight.py
+++ b/tests/test_skillsbench_setup_preflight.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import ast
 import asyncio
+import inspect
 import json
 import tempfile
+import textwrap
 from pathlib import Path
 from typing import Any
 
@@ -22,9 +25,11 @@ from scripts.skillsbench_automation_loop import (
     DOCKER_APT_RETRY_BEGIN,
     _effective_setup_only_stage_timeout_sec,
     _public_runner_config,
+    _write_public_runner_lifecycle_receipt,
     build_compose_setup_diagnostic,
     build_plan,
     parse_args,
+    run_benchflow_case,
     stage_task_for_sandbox,
 )
 
@@ -153,6 +158,88 @@ def test_setup_only_preflight_projects_incremental_public_stages() -> None:
     assert snapshots[-1]["status"] == "passed"
     assert snapshots[-1]["cleanup_status"] == "completed"
     assert all(snapshot["raw_logs_recorded"] is False for snapshot in snapshots)
+
+
+def test_formal_run_lifecycle_receipt_projects_live_worker_without_private_logs(
+    tmp_path: Path,
+) -> None:
+    plan = {
+        "jobs_dir": str(tmp_path / "jobs"),
+        "job_name": "skillsbench-public-live-phase",
+        "runner_prerequisites": {
+            "schema_version": "skillsbench_runner_prerequisites_v0",
+            "private_detail": "PRIVATE_RAW_RUN_DETAIL_SHOULD_NOT_PROJECT",
+        },
+    }
+
+    _write_public_runner_lifecycle_receipt(
+        plan,
+        run_stage="benchflow_run_started",
+        worker_status="worker_running",
+    )
+    path = _write_public_runner_lifecycle_receipt(
+        plan,
+        run_stage="agent_install_started",
+        worker_status="agent_install_started",
+        host_local_acp_status="connecting",
+        agent_install_started=True,
+    )
+
+    assert path is not None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["benchflow_run_stage"] == "agent_install_started"
+    assert payload["benchflow_case_worker_status"] == "agent_install_started"
+    assert payload["host_local_acp_launch_status"] == "connecting"
+    assert payload["benchflow_agent_install_started"] is True
+    assert payload["benchflow_lifecycle_receipt_sequence"] == 2
+    assert payload["benchflow_lifecycle_private_logs_read"] is False
+    assert "PRIVATE_RAW_RUN_DETAIL_SHOULD_NOT_PROJECT" not in json.dumps(
+        payload,
+        sort_keys=True,
+    )
+
+
+def test_host_local_acp_callsite_writes_live_phase_receipts() -> None:
+    tree = ast.parse(textwrap.dedent(inspect.getsource(run_benchflow_case)))
+    receipts: list[dict[str, Any]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not (
+            isinstance(node.func, ast.Name)
+            and node.func.id == "_write_public_runner_lifecycle_receipt"
+        ):
+            continue
+        receipts.append(
+            {
+                keyword.arg: keyword.value.value
+                for keyword in node.keywords
+                if keyword.arg
+                and isinstance(keyword.value, ast.Constant)
+                and isinstance(keyword.value.value, (str, bool))
+            }
+        )
+
+    for expected in (
+        {
+            "worker_status": "worker_running",
+            "run_stage": "benchflow_run_started",
+        },
+        {
+            "worker_status": "agent_install_started",
+            "run_stage": "agent_install_started",
+            "agent_install_started": True,
+        },
+        {
+            "worker_status": "acp_connecting",
+            "host_local_acp_status": "connecting",
+        },
+        {
+            "worker_status": "acp_connected",
+            "host_local_acp_status": "connected",
+        },
+    ):
+        assert expected in receipts
 
 
 def test_setup_only_runner_mode_bypasses_formal_round_budget() -> None:

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -435,3 +435,41 @@ def test_setup_only_launcher_enables_incremental_public_artifact_sync(
     assert "--public-artifact-sync-interval-sec 30" in proc.stdout
     assert "--setup-only-public-preflight" in proc.stdout
     assert "--append-history" not in proc.stdout
+
+
+def test_formal_launcher_enables_incremental_public_artifact_sync(
+    tmp_path: Path,
+) -> None:
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "live-progress"],
+        cwd=REPO_ROOT,
+        env=_base_env(tmp_path),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+
+    assert "setup_only_public_preflight=0" in proc.stdout
+    assert "public_artifact_sync_interval_sec=30" in proc.stdout
+    assert "--public-artifact-sync-interval-sec 30" in proc.stdout
+
+
+def test_formal_launcher_can_disable_incremental_public_artifact_sync(
+    tmp_path: Path,
+) -> None:
+    env = _base_env(tmp_path)
+    env["SKILLSBENCH_PUBLIC_ARTIFACT_SYNC_INTERVAL_SEC"] = "0"
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "no-live-progress"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+
+    assert "public_artifact_sync_interval_sec=0" in proc.stdout
+    assert "--public-artifact-sync-interval-sec 0" in proc.stdout


### PR DESCRIPTION
## Summary
- persist atomic public runner lifecycle receipts after base-image prewarm
- project the real host-local ACP worker through install, connect, active, failure, and completion phases
- sync bounded public artifacts every 30 seconds by default, with an explicit `0` opt-out

## Validation
- `65 passed` focused setup/launcher pytest
- `126 passed` all SkillsBench pytest
- `skillsbench-benchmark-run-smoke: ok`
- `skillsbench-reverse-tunnel-supervisor smoke ok`
- `loopx check`: public boundary clean for all 4 changed files
- LoopX premerge canary: 8/8 executed checks passed, 0 failures, 0 warnings

## Boundaries
- no benchmark jobs launched
- no scoring, task semantics, submission, leaderboard, permission, quota, or agent-prompt behavior changed
- no private logs, trajectories, verifier output, credentials, or local paths included
