### PR TITLE
docs: explain LoopX as an agent-native Kanban

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ stable while Codex, Claude Code, Cursor, or another runtime executes each
 bounded turn. It does not replace your agent runtime; it makes long-running
 agent work reviewable, restartable, and easier to hand off.
 
+A useful mental model is an
+**[agent-native Kanban for long-running work](docs/development/control-plane-course/00-concept-primer.md)**.
+Its cards carry identity, authority, evidence, and continuation; moves are
+validated operators such as claim, gate, monitor, and writeback rather than UI
+gestures; capabilities add domain lanes without creating a second control plane.
+The board is a projection; LoopX state remains the source of truth.
+
 Registered agents are peers. Claims and leases, task boundaries, capabilities,
 and typed continuation decide who acts next; no durable leader identity is
 required.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,6 +17,12 @@ loop 状态：目标、用户决策、agent todo、认领关系、scope、schedu
 quota、证据、run history 和 handoff 留在同一层轻量状态里。该等人的地方明确等人，
 不该空等的安全侧路继续推进，每一次自动执行都留下边界、验证面和写回轨迹。
 
+一个形象化理解是：LoopX 是
+**[面向长程 Agent 的可执行看板](docs/development/control-plane-course/00-concept-primer.md)**。
+卡片带有稳定身份、权限、证据和 continuation；移动卡片要经过 claim、gate、monitor、
+validate、writeback 等 typed operator；Capability 可以增加 Issue Fix、Auto Research
+等领域泳道，但不会再造一套控制面。看板是 projection，LoopX state 才是事实源。
+
 注册 agent 彼此平级：由 todo claim / lease、任务边界、能力门和 typed
 continuation 决定下一步谁执行，不需要一个长期拥有全局权限的 leader agent。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,6 +70,22 @@ Kernel authority. This boundary is represented directly by
 `CapabilityRegistry`, which registers providers, capability contracts, and
 their implementations separately.
 
+### Agent-Native Kanban Is A Projection
+
+LoopX state can be rendered as an agent-native Kanban: todos are cards, logical
+lanes are derived views, and card moves are validated transitions. The metaphor
+does not introduce another state owner. Canonical todo/event/state contracts
+remain authoritative; dashboards and collaboration boards consume public-safe
+projections.
+
+Capabilities may project domain lanes such as Issue Fix
+`feasibility -> patch -> checks -> review -> merge` without adding those labels
+to the Kernel lifecycle. Providers supply the external facts behind the lane,
+capabilities validate them and propose typed transitions, and the Kernel owns
+claim, gate, monitor, quota, writeback, recovery, and terminal closure. See the
+[concept primer](development/control-plane-course/00-concept-primer.md) and
+[state substrate lecture](development/control-plane-course/02-state-substrate.md).
+
 ## Current Dependency Budget
 
 Dependency direction is enforced incrementally while large compatibility

--- a/docs/capabilities/README.md
+++ b/docs/capabilities/README.md
@@ -4,6 +4,22 @@ This directory groups LoopX product capabilities by real usage path. Keep kernel
 control-plane code generic; put scenario-specific protocols, implementation
 modules, CLI entrypoints, and smokes under the capability they serve.
 
+## Capabilities Add Domain Lanes, Not Kernel Columns
+
+An operator surface may render LoopX as an agent-native Kanban. In that view,
+the Kernel supplies generic lifecycle operators such as claim, gate, monitor,
+complete, supersede, quota, and writeback. A capability may add a domain lane
+that interprets provider observations, but it must not create a parallel todo
+or scheduling authority.
+
+For example, Issue Fix can project
+`feasibility -> patch -> checks -> review -> merge`, while an experiment pack
+can project `hypothesis -> execute -> evaluate -> promote/retire`. These labels
+are derived from capability-owned domain state and accepted Kernel transitions.
+They are not new core lifecycle statuses. If a domain stage changes permission,
+claim eligibility, quota, a user gate, or terminal closure, the capability must
+propose a typed transition through the existing Kernel contract.
+
 Current capability paths:
 
 - [periodic-report](periodic-report/README.md): evaluate cadence and material

--- a/docs/development/control-plane-course/00-concept-primer.md
+++ b/docs/development/control-plane-course/00-concept-primer.md
@@ -44,6 +44,32 @@ LoopX 面向两种同时存在的运行状态：
 scoped decision、vision patch、todo、reward 或可复用经验。二者共用同一状态内核，否则人工
 干预越多，系统反而越难恢复。
 
+## 一个有用但不完整的比喻：面向 Agent 的可执行看板
+
+可以先把 LoopX 理解成面向长程 Agent 的 Kanban。不同之处在于，普通看板主要帮助人
+整理卡片，LoopX 还要让 Agent 在无人值守、跨 session 和多人接力时正确推进卡片。因此，
+卡片、列和移动都必须对应可验证的状态合同：
+
+| 看板直觉 | LoopX 对应对象 | 增加的工程约束 |
+| --- | --- | --- |
+| Card | Todo | 稳定 `todo_id`、owner、依赖、scope、evidence 与 continuation |
+| Column | 从 canonical state 派生的 lane/view | 列由 lifecycle、task class、routing、proof/time 等维度组合，不是单个字符串 |
+| Move card | Typed transition | 每次移动都检查 authority、前置条件、验证结果和 writeback |
+| WIP limit | Claim、lease、quota、workspace guard | 限制谁能领取、何时运行、在哪里写以及可以消耗多少资源 |
+| Waiting | User gate、monitor、deferred 与 `resume_when` | 等待对象、恢复条件和下一次观察时间都必须明确 |
+| Done | Accepted writeback、receipt 与 terminal audit | 勾选卡片不能替代验收、外部 readback 或 goal closure |
+| Domain swimlane | Capability Pack + Domain State projection | Issue Fix、Auto Research 等领域可以增加泳道，但不能创建第二套 Kernel |
+
+这组映射提供产品直觉，不改变事实归属。Dashboard、Lark Kanban 和其他看板是 projection；
+canonical todo/event/state contract 才能接受 transition。领域泳道也不是新增 Kernel
+枚举：`feasibility -> patch -> CI -> review -> merge` 可以是 Issue Fix 的领域视图，
+`hypothesis -> execute -> evaluate -> promote/retire` 可以是 Auto Research 的领域视图，
+而 claim、gate、monitor、quota、writeback 和 recovery 仍由同一 Kernel 管理。
+
+```text
+Kanban is the picture; the control plane is the contract.
+```
+
 ## 从普通对话、原生 Goal 到 LoopX
 
 理解 LoopX 最容易的方法，不是先背模块，而是看控制信息逐层外置：

--- a/docs/development/control-plane-course/02-state-substrate.md
+++ b/docs/development/control-plane-course/02-state-substrate.md
@@ -43,6 +43,44 @@
 状态展示出来。判断 owner 后，再决定它应进入 registry、event、Domain State 还是只留在
 runtime artifact。
 
+## 看板列是多轴状态的 Projection
+
+面向操作者的界面可以把 todo 渲染成 Kanban，但 canonical state 不能退化成一个
+`column` 字段。同一张卡片至少同时具有四组状态：
+
+| 维度 | 典型字段或对象 | 回答的问题 |
+| --- | --- | --- |
+| Lifecycle | `open`、`blocked`、`deferred`、`done` | 工作是否仍在生命周期中？ |
+| Task class | advancement、user gate/action、monitor、blocker | 这是什么类型的工作或等待？ |
+| Routing and authority | claim、lease、dependency、scope、capability | 谁能执行，前置条件和权限是否满足？ |
+| Proof and time | evidence、receipt、freshness、cadence、`resume_when` | 什么证明变化成立，何时应再次观察？ |
+
+看板可以把这些事实投影成便于操作的逻辑列：
+
+```text
+Runnable | Claimed | Waiting on user | Monitoring | Blocked | Review | Done
+```
+
+这些列不是新的事实源。“Waiting on user”来自 scoped user gate，“Monitoring”来自
+带 cadence 和 target key 的 monitor，“Review”可以来自领域状态与当前 acceptance，
+而不是把每个展示名称写进 Kernel lifecycle enum。
+
+看板上的移动也对应结构化算子，而不是任意拖拽：
+
+| 操作 | 必须保持的约束 |
+| --- | --- |
+| Claim / release | 注册身份、executor exclusion、lease 和 workspace 仍然有效 |
+| Gate / decide | decision scope、阻塞对象和授权结果明确绑定 |
+| Monitor / resume | target、cadence、fresh observation 和恢复条件可重放 |
+| Complete / supersede | evidence、successor 或 no-follow-up rationale 完整 |
+| Writeback / replay / repair | 已提交 transition 可验证，projection 可重建，失败后可恢复 |
+
+Capability Pack 可以在同一组通用算子上增加领域泳道。例如 Issue Fix 展示
+`feasibility -> patch -> CI -> review -> merge`，Auto Research 展示
+`hypothesis -> execute -> evaluate -> promote/retire`。这些阶段来自 Domain State 和
+capability proposal；只要它们涉及 claim、gate、quota、permission 或 terminal closure，
+最终 transition 仍由 Kernel 接受或拒绝。
+
 ## Goal 不是聊天线程
 
 LoopX 的 durable identity 是 goal，不是某个 Codex thread：

--- a/docs/development/control-plane-course/README.md
+++ b/docs/development/control-plane-course/README.md
@@ -9,6 +9,10 @@
 状态投影、调度或扩展能力的开发者。它先从模型上下文为什么不能承担长期状态讲起，再用
 两个端到端 Showcase 推导 ownership，最后沿真实 transition 进入状态机、CLI、核心函数和测试。
 
+贯穿全课的形象化理解是“面向长程 Agent 的可执行看板”：Todo 是带身份、权限和证据的
+卡片，claim、gate、monitor、writeback 等 Kernel operator 决定卡片能否移动，Capability
+Pack 增加领域泳道。看板只是 projection；canonical state 和 typed transition 才是控制合同。
+
 ## 课程先建立一个递进
 
 普通 Agent 对话主要依赖当前 transcript。Codex 原生 Goal 再向外走一步：通过持久 goal object

--- a/docs/product/domain-capability-packs.md
+++ b/docs/product/domain-capability-packs.md
@@ -25,6 +25,34 @@ domain work." It also keeps LoopX useful for ordinary engineering todos
 that do not have experiment boards, primary metrics, guardrails, or production
 job handles.
 
+## Domain Lanes Over One Control Plane
+
+The agent-native Kanban metaphor provides a practical placement rule:
+
+| Surface | Owner | Example |
+| --- | --- | --- |
+| Generic card lifecycle | LoopX Kernel | claim, gate, monitor, defer, complete, supersede, quota, recovery |
+| Domain lane and stage | Capability Pack | Issue Fix review stage or experiment evaluation stage |
+| External fact and effect | Provider | check status, review state, metric result, job readback |
+| Visible board column | Projection | runnable, waiting, monitoring, review, done |
+
+A domain lane is a read model over domain state plus accepted Kernel state. It
+may explain that an issue moved from patching to CI review, or that a hypothesis
+moved from execution to holdout evaluation. It does not own the underlying
+todo, claim, gate, quota, or schedule.
+
+This keeps two different kinds of change separate:
+
+- adding a new domain stage usually changes the pack's Domain State schema,
+  transition proposal, and projection;
+- adding a new cross-domain lifecycle rule changes the Kernel only when the
+  rule has a provider-neutral contract and real callers outside one pack.
+
+Do not add `ci_review`, `holdout`, or `promotion_candidate` to a generic Kernel
+status enum merely to draw a useful board. The pack should derive those labels,
+then submit any consequential claim, gate, monitor, successor, or closeout
+through the existing typed transition boundary.
+
 ## Contract Shape
 
 `domain_pack_contract_v0` is a registry-owned goal-boundary extension:


### PR DESCRIPTION
## Summary

- introduce an agent-native Kanban mental model in the English and Chinese README entry paths
- map cards, lanes, moves, waiting, WIP, domain swimlanes, and done states to LoopX contracts in the concept primer
- explain in Lecture 02 why board columns are projections over lifecycle, task class, routing, authority, proof, and time
- define domain lanes as capability-owned projections over one Kernel rather than new core lifecycle statuses

## Product and architecture judgment

The change gives first-time users a familiar picture for long-running agent work while preserving the control-plane boundary. Kanban is the presentation model; canonical todo/event/state contracts and typed transitions remain authoritative. Providers supply external facts, capabilities interpret domain stages, and the Kernel continues to own claims, gates, monitors, quota, writeback, recovery, and terminal closure.

This is a public-docs-only change. It adds no runtime behavior, protocol field, capability, provider, benchmark adapter, permission, or production action.

## Validation

- `loopx canary premerge --from-git-diff --timeout-seconds 180`: passed, 18/18 selected checks
- `python3 examples/docs-governance-smoke.py`: passed
- diff hygiene: passed for committed, staged, and unstaged views
- public/private boundary: clean across all 8 changed files
- failures or skips: none
- manual holds: none

## Merge decision

Self-merge is appropriate under the repository policy: the PR is single-purpose, public-docs-only, owner-authorized, and the standard premerge gate reports `self_merge_allowed=true`.
