### PR TITLE
Preserve live worker phases in benchmark ledger

### DIFF
--- a/examples/benchmark-run-ledger-smoke.py
+++ b/examples/benchmark-run-ledger-smoke.py
@@ -26,6 +26,7 @@ from loopx.benchmark_ledger import (  # noqa: E402
     update_benchmark_run_ledger,
     upsert_benchmark_run_ledger_entry,
 )
+from loopx.benchmark_core import build_benchmark_live_worker_phase  # noqa: E402
 from loopx.status import compact_benchmark_run  # noqa: E402
 
 
@@ -228,6 +229,55 @@ def test_ledger_entry_upsert_from_compact_run() -> None:
         assert "blocked_model=gpt-5.1-codex-max" in rendered, rendered
         assert "rerun_model=gpt-5.5" in rendered, rendered
         assert (root / "ledger.md").exists(), "markdown view should be rendered"
+
+
+def test_skillsbench_live_worker_phase_survives_compact_run_and_ledger() -> None:
+    phase = build_benchmark_live_worker_phase(
+        agent_active=True,
+        terminal_disposition="completed",
+    )
+    source = {
+        "schema_version": "benchmark_run_v0",
+        "benchmark_id": "skillsbench@1.1",
+        "case_id": "live-worker-phase-smoke",
+        "job_name": "skillsbench-live-worker-phase-smoke",
+        "mode": "skillsbench_codex_app_server_goal_baseline",
+        "runner_return_status": "completed",
+        "runner_prerequisites": {
+            "benchmark_live_worker_phase": {
+                **phase,
+                "private_detail": "PRIVATE_DETAIL_MUST_NOT_PROJECT",
+            }
+        },
+    }
+
+    compact = compact_benchmark_run(source)
+    assert compact is not None
+    assert compact["benchmark_live_worker_phase"] == phase, compact
+    assert "PRIVATE_DETAIL_MUST_NOT_PROJECT" not in json.dumps(
+        compact,
+        sort_keys=True,
+    )
+    entry = build_benchmark_run_ledger_entry(
+        compact,
+        run_group_id="skillsbench-live-worker-phase-smoke",
+    )
+    assert entry["benchmark_live_worker_phase"] == phase, entry
+
+    with tempfile.TemporaryDirectory(prefix="benchmark-live-worker-ledger-") as tmp:
+        root = Path(tmp)
+        ledger_path = root / "ledger.json"
+        update_benchmark_run_ledger(
+            ledger_path=ledger_path,
+            benchmark_run=compact,
+            run_group_id="skillsbench-live-worker-phase-smoke",
+            cwd=root,
+        )
+        ledger = load_benchmark_run_ledger(ledger_path)
+        persisted = ledger["benchmarks"]["skillsbench@1.1"]["cases"][
+            "live-worker-phase-smoke"
+        ]["runs"][0]
+        assert persisted["benchmark_live_worker_phase"] == phase, persisted
 
 
 def test_ledger_classifies_compact_trial_exception_failure() -> None:
@@ -1356,6 +1406,10 @@ def test_raw_max5_baseline_does_not_force_product_pair_without_product_treatment
 def stale_active_post_launch() -> dict[str, Any]:
     return {
         "schema_version": "terminal_bench_post_launch_materialization_v0",
+        "benchmark_live_worker_phase": build_benchmark_live_worker_phase(
+            worker_running=True,
+            terminal_disposition="failed",
+        ),
         "checked": True,
         "ready_for_launch_state": True,
         "ready_for_compact_result_ingest": False,
@@ -1492,6 +1546,10 @@ def test_ledger_ingests_post_launch_stale_active_marker() -> None:
     assert entry["attempt_failure_class"] == "job_materialization_failed", entry
     assert entry["launcher_attempt_countable"] is True, entry
     assert entry["official_score_attempt_countable"] is False, entry
+    assert entry["benchmark_live_worker_phase"]["current_phase"] == (
+        "worker_running"
+    ), entry
+    assert entry["benchmark_live_worker_phase"]["terminal_disposition"] == "failed", entry
 
     with tempfile.TemporaryDirectory(prefix="benchmark-run-ledger-stale-active-") as tmp:
         root = Path(tmp)
@@ -1511,6 +1569,13 @@ def test_ledger_ingests_post_launch_stale_active_marker() -> None:
             "runner_result_finalization"
         ), update
         ledger = load_benchmark_run_ledger(ledger_path)
+        persisted = ledger["benchmarks"]["terminal-bench@2.0"]["cases"][
+            "multi-source-data-merger"
+        ]["runs"][0]
+        assert (
+            persisted["benchmark_live_worker_phase"]
+            == compact["benchmark_live_worker_phase"]
+        ), persisted
         rendered = render_benchmark_run_ledger_markdown(ledger)
         assert "runner_result_finalization" in rendered, rendered
         assert "stale_active_job_without_trial_result" in rendered, rendered
@@ -2081,6 +2146,7 @@ def test_ledger_merge_combines_run_group_ledgers_without_source_paths() -> None:
 
 if __name__ == "__main__":
     test_ledger_entry_upsert_from_compact_run()
+    test_skillsbench_live_worker_phase_survives_compact_run_and_ledger()
     test_ledger_classifies_compact_trial_exception_failure()
     test_ledger_classifies_setup_timeout_before_generic_timeout()
     test_ledger_routes_environment_setup_before_worker_separately()

--- a/loopx/benchmark_core/__init__.py
+++ b/loopx/benchmark_core/__init__.py
@@ -49,7 +49,6 @@ from .lifecycle import (
     canonical_lifecycle,
     compact_benchmark_canonical_lifecycle,
     compact_benchmark_live_worker_phase,
-    compact_benchmark_live_worker_phase_from_run,
 )
 from .loop_protocol import (
     BENCHMARK_LOOP_CONTROLLER_TRACE_SCHEMA_VERSION,
@@ -224,7 +223,6 @@ __all__ = [
     "canonical_lifecycle",
     "compact_benchmark_canonical_lifecycle",
     "compact_benchmark_live_worker_phase",
-    "compact_benchmark_live_worker_phase_from_run",
     "compact_run_permission_policy_for_quota",
     "compact_round_rewards",
     "compact_round_artifact_snapshots",

--- a/loopx/benchmark_core/__init__.py
+++ b/loopx/benchmark_core/__init__.py
@@ -49,6 +49,7 @@ from .lifecycle import (
     canonical_lifecycle,
     compact_benchmark_canonical_lifecycle,
     compact_benchmark_live_worker_phase,
+    compact_benchmark_live_worker_phase_from_run,
 )
 from .loop_protocol import (
     BENCHMARK_LOOP_CONTROLLER_TRACE_SCHEMA_VERSION,
@@ -223,6 +224,7 @@ __all__ = [
     "canonical_lifecycle",
     "compact_benchmark_canonical_lifecycle",
     "compact_benchmark_live_worker_phase",
+    "compact_benchmark_live_worker_phase_from_run",
     "compact_run_permission_policy_for_quota",
     "compact_round_rewards",
     "compact_round_artifact_snapshots",

--- a/loopx/benchmark_core/lifecycle.py
+++ b/loopx/benchmark_core/lifecycle.py
@@ -124,6 +124,24 @@ def compact_benchmark_live_worker_phase(value: Any) -> dict[str, Any]:
     )
 
 
+def compact_benchmark_live_worker_phase_from_run(value: Any) -> dict[str, Any]:
+    """Read the shared live worker phase from a run or runner prerequisites."""
+
+    if not isinstance(value, dict):
+        return {}
+    phase = compact_benchmark_live_worker_phase(
+        value.get("benchmark_live_worker_phase")
+    )
+    if phase:
+        return phase
+    runner_prerequisites = value.get("runner_prerequisites")
+    if not isinstance(runner_prerequisites, dict):
+        return {}
+    return compact_benchmark_live_worker_phase(
+        runner_prerequisites.get("benchmark_live_worker_phase")
+    )
+
+
 def _coerce_flags(flags: dict[str, Any]) -> dict[str, bool]:
     coerced: dict[str, bool] = {}
     previous = True

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -12,6 +12,7 @@ from .benchmark_core import (
     LEGACY_NONPRODUCT_PROMPT_POLLING_ROUTES,
     classify_benchmark_artifact_path,
     classify_product_mode_main_table_pair,
+    compact_benchmark_live_worker_phase_from_run,
 )
 from .benchmark_adapters.skillsbench_signals import (
     build_skillsbench_solution_quality_signals,
@@ -53,6 +54,7 @@ LEDGER_LOGICAL_BACKFILL_FIELDS = (
     "native_goal_verifier_output_forwarded_to_worker",
     "official_feedback_blinded",
     "reward_feedback_forwarded",
+    "benchmark_live_worker_phase",
     "task_setup_preflight",
     "task_staging",
 )
@@ -2164,6 +2166,9 @@ def build_benchmark_run_ledger_entry(
     )
     if operator_simulator_run:
         entry["operator_simulator_run"] = operator_simulator_run
+    live_worker_phase = compact_benchmark_live_worker_phase_from_run(benchmark_run)
+    if live_worker_phase:
+        entry["benchmark_live_worker_phase"] = live_worker_phase
     attempt_accounting = (
         benchmark_run.get("attempt_accounting")
         if isinstance(benchmark_run.get("attempt_accounting"), dict)
@@ -2431,6 +2436,11 @@ def _normalize_ledger_run(run: dict[str, Any], *, fallback_benchmark_id: str) ->
     else:
         for key in ("archive_state", "archive_reason", "archive_batch_id", "archived_at"):
             normalized.pop(key, None)
+    live_worker_phase = compact_benchmark_live_worker_phase_from_run(normalized)
+    if live_worker_phase:
+        normalized["benchmark_live_worker_phase"] = live_worker_phase
+    else:
+        normalized.pop("benchmark_live_worker_phase", None)
     refs = normalized.get("artifact_refs")
     if isinstance(refs, dict):
         safe_refs: dict[str, str] = {}

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -12,8 +12,8 @@ from .benchmark_core import (
     LEGACY_NONPRODUCT_PROMPT_POLLING_ROUTES,
     classify_benchmark_artifact_path,
     classify_product_mode_main_table_pair,
-    compact_benchmark_live_worker_phase_from_run,
 )
+from .benchmark_core.lifecycle import compact_benchmark_live_worker_phase_from_run
 from .benchmark_adapters.skillsbench_signals import (
     build_skillsbench_solution_quality_signals,
 )

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -7,10 +7,7 @@ from typing import Any
 from .benchmark_adapters.skillsbench_verifier_bootstrap import (
     apply_skillsbench_verifier_bootstrap_missing_score_attribution,
 )
-from .benchmark_core import (
-    compact_benchmark_canonical_lifecycle,
-    compact_benchmark_live_worker_phase_from_run,
-)
+from .benchmark_core import lifecycle as _benchmark_lifecycle
 from .control_plane import compact_control_plane_policy
 from .control_plane.status_collection import (
     StatusCollectionContext,
@@ -1260,7 +1257,7 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
-    lifecycle = compact_benchmark_canonical_lifecycle(
+    lifecycle = _benchmark_lifecycle.compact_benchmark_canonical_lifecycle(
         value.get("benchmark_canonical_lifecycle")
     )
     if lifecycle:
@@ -1351,6 +1348,23 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
             "remote_command_file_bridge_agent_successful_loopx_command_records"
         ] = command_records
     return compact
+
+
+def _project_benchmark_runner_prerequisites(
+    compact: dict[str, Any],
+    source: dict[str, Any],
+) -> None:
+    runner_prerequisites = _compact_benchmark_runner_prerequisites(
+        source.get("runner_prerequisites")
+    )
+    if runner_prerequisites:
+        compact["runner_prerequisites"] = runner_prerequisites
+    live_worker_phase = _benchmark_lifecycle.compact_benchmark_live_worker_phase_from_run(
+        source
+    )
+    if live_worker_phase:
+        compact["benchmark_live_worker_phase"] = live_worker_phase
+
 
 def _compact_benchmark_task_staging(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
@@ -2834,14 +2848,7 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
     )
     if runner_warning_labels:
         compact["runner_warning_labels"] = runner_warning_labels
-    runner_prerequisites = _compact_benchmark_runner_prerequisites(
-        source.get("runner_prerequisites")
-    )
-    if runner_prerequisites:
-        compact["runner_prerequisites"] = runner_prerequisites
-    live_worker_phase = compact_benchmark_live_worker_phase_from_run(source)
-    if live_worker_phase:
-        compact["benchmark_live_worker_phase"] = live_worker_phase
+    _project_benchmark_runner_prerequisites(compact, source)
     result_discovery = _compact_benchmark_result_discovery(
         source.get("result_discovery")
     )

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -7,7 +7,10 @@ from typing import Any
 from .benchmark_adapters.skillsbench_verifier_bootstrap import (
     apply_skillsbench_verifier_bootstrap_missing_score_attribution,
 )
-from .benchmark_core import compact_benchmark_canonical_lifecycle
+from .benchmark_core import (
+    compact_benchmark_canonical_lifecycle,
+    compact_benchmark_live_worker_phase_from_run,
+)
 from .control_plane import compact_control_plane_policy
 from .control_plane.status_collection import (
     StatusCollectionContext,
@@ -2836,6 +2839,9 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
     )
     if runner_prerequisites:
         compact["runner_prerequisites"] = runner_prerequisites
+    live_worker_phase = compact_benchmark_live_worker_phase_from_run(source)
+    if live_worker_phase:
+        compact["benchmark_live_worker_phase"] = live_worker_phase
     result_discovery = _compact_benchmark_result_discovery(
         source.get("result_discovery")
     )

--- a/tests/benchmarks/test_benchmark_live_worker_phase.py
+++ b/tests/benchmarks/test_benchmark_live_worker_phase.py
@@ -12,8 +12,8 @@ from loopx.benchmark_ledger import build_benchmark_run_ledger_entry
 from loopx.benchmark_core import (
     build_benchmark_live_worker_phase,
     compact_benchmark_live_worker_phase,
-    compact_benchmark_live_worker_phase_from_run,
 )
+from loopx.benchmark_core.lifecycle import compact_benchmark_live_worker_phase_from_run
 from loopx.status import compact_benchmark_run
 
 

--- a/tests/benchmarks/test_benchmark_live_worker_phase.py
+++ b/tests/benchmarks/test_benchmark_live_worker_phase.py
@@ -8,10 +8,13 @@ import pytest
 from loopx.benchmark_adapters.terminal_bench import (
     summarize_terminal_bench_post_launch_materialization,
 )
+from loopx.benchmark_ledger import build_benchmark_run_ledger_entry
 from loopx.benchmark_core import (
     build_benchmark_live_worker_phase,
     compact_benchmark_live_worker_phase,
+    compact_benchmark_live_worker_phase_from_run,
 )
+from loopx.status import compact_benchmark_run
 
 
 def test_live_worker_phase_closes_sparse_higher_phase_evidence() -> None:
@@ -86,3 +89,47 @@ def test_terminal_bench_public_fixture_projects_running_worker_phase(
     assert summary["raw_logs_read"] is False
     assert summary["raw_task_text_read"] is False
     assert str(tmp_path) not in json.dumps(summary, sort_keys=True)
+
+    entry = build_benchmark_run_ledger_entry(
+        summary,
+        run_group_id="terminal-bench-live-worker-phase",
+        arm_id="codex_goal_mode_baseline",
+    )
+    assert entry["benchmark_live_worker_phase"] == phase
+
+
+def test_skillsbench_live_worker_phase_survives_compact_run_and_ledger() -> None:
+    phase = build_benchmark_live_worker_phase(
+        agent_active=True,
+        terminal_disposition="completed",
+    )
+    source = {
+        "schema_version": "benchmark_run_v0",
+        "benchmark_id": "skillsbench@1.1",
+        "case_id": "public-live-worker-phase",
+        "job_name": "skillsbench-public-live-worker-phase",
+        "mode": "skillsbench_codex_app_server_goal_baseline",
+        "runner_return_status": "completed",
+        "runner_prerequisites": {
+            "benchmark_live_worker_phase": {
+                **phase,
+                "private_detail": "PRIVATE_DETAIL_MUST_NOT_PROJECT",
+            },
+            "private_runner_detail": "PRIVATE_RUNNER_DETAIL_MUST_NOT_PROJECT",
+        },
+    }
+
+    assert compact_benchmark_live_worker_phase_from_run(source) == phase
+    compact = compact_benchmark_run(source)
+    assert compact is not None
+    assert compact["benchmark_live_worker_phase"] == phase
+    assert "PRIVATE_DETAIL_MUST_NOT_PROJECT" not in json.dumps(
+        compact,
+        sort_keys=True,
+    )
+
+    entry = build_benchmark_run_ledger_entry(
+        compact,
+        run_group_id="skillsbench-live-worker-phase",
+    )
+    assert entry["benchmark_live_worker_phase"] == phase


### PR DESCRIPTION
## Summary
- normalize `benchmark_live_worker_phase_v0` from top-level runs or runner prerequisites
- preserve the public-safe phase through compact status and benchmark ledger normalization
- prove SkillsBench and Terminal-Bench parity without changing scoring, task, permission, runner, or launch semantics

## Validation
- `pytest -q tests/benchmarks tests/test_benchmark_ledger_countability.py tests/test_skillsbench_setup_preflight.py` (90 passed)
- `python examples/benchmark-run-ledger-smoke.py`
- `python examples/benchmark-core-adapter-contract-smoke.py`
- changed-file `py_compile`, Ruff, and `git diff --check`
- `loopx check` on all six changed paths (0 findings)
- `loopx canary premerge --from-git-diff --no-progress` (0 direct/catalog/risk/boundary failures; benchmark-sensitive manual review hold only)

## Scope
Public benchmark helper/status/ledger projection and focused durable validation only. No benchmark launch, scoring, task, leaderboard, submission, permission, or runner behavior changes.