### PR TITLE
release: LoopX v0.2.12

### DIFF
--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.11"
+__version__ = "0.2.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.2.11"
+version = "0.2.12"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
# LoopX v0.2.12

## More dependable agent control loops

LoopX now persists one quota receipt per heartbeat turn and keeps monitor/replan routing fresh, reducing duplicate work and stale continuation decisions ([#2473](https://github.com/huangruiteng/loopx/pull/2473), [#2478](https://github.com/huangruiteng/loopx/pull/2478), [#2460](https://github.com/huangruiteng/loopx/pull/2460), [#2464](https://github.com/huangruiteng/loopx/pull/2464)).

The shipped layer is the provider-neutral control-plane contract: heartbeat receipts, due-monitor routing, and bounded replan state. Host Automations still own scheduling; this release creates no background scheduler and grants no external-write authority.

## Review quality and maintainability

`loopx pr-review` now assesses whether a PR's code volume is necessary and identifies concrete simplification directions, alongside correctness and risk findings ([#2471](https://github.com/huangruiteng/loopx/pull/2471)). Review remains advisory: it does not automatically merge PRs or close issues.

## Benchmark-neutral live worker lifecycle

Adaptive multi-turn execution and public live-worker phase projection now preserve setup, agent, and verification phases through compact run and ledger views ([#2399](https://github.com/huangruiteng/loopx/pull/2399), [#2480](https://github.com/huangruiteng/loopx/pull/2480), [#2481](https://github.com/huangruiteng/loopx/pull/2481), [#2483](https://github.com/huangruiteng/loopx/pull/2483)).

This release does not change benchmark scoring, task semantics, permission boundaries, or submission behavior, and it makes no benchmark-uplift claim. Exact-host SkillsBench execution remains capability-gated.

## Optional capability activation

The co-located Finance Value Discovery sample is a deterministic reducer over caller-supplied frozen public evidence; it performs no network collection and emits no investment advice ([#2391](https://github.com/huangruiteng/loopx/pull/2391)).

```bash
python3 -m pip install ./packages/loopx-finance-value-discovery
loopx extension install \
  --manifest packages/loopx-finance-value-discovery/extension.toml \
  --execute \
  --format json
loopx extension run loopx-finance-value-discovery \
  --input-json packages/loopx-finance-value-discovery/examples/paypal-debeta-discovery.json \
  --execute \
  --format json
loopx extension disable loopx-finance-value-discovery --execute --format json
```

Lark Kanban heartbeat sync remains default-off and requires an authenticated `lark-cli` identity plus an existing local board binding ([#2437](https://github.com/huangruiteng/loopx/pull/2437)). Omit `--execute` to preview.

```bash
loopx configure-goal --goal-id <goal-id> --lark-kanban-heartbeat-sync
loopx configure-goal --goal-id <goal-id> --lark-kanban-heartbeat-sync --execute
loopx configure-goal --goal-id <goal-id> --no-lark-kanban-heartbeat-sync --execute
```

The built-in weekly report preset now localizes project-progress sections ([#2400](https://github.com/huangruiteng/loopx/pull/2400)). It needs no persistent switch:

```bash
loopx periodic-report inspect-profile --preset weekly --format json
```

The optional OpenViking archive sink remains separately activated and permission-gated:

```bash
loopx extension install --bundled openviking-periodic-report --execute --format json
loopx extension disable openviking-periodic-report --execute --format json
```

## Compatibility and validation

The package version is `0.2.12` and the public tag is `v0.2.12`. No persisted-state migration is required.

The latest pre-release `main` commit passed GitHub pytest and all seven Full Public Smoke shards. On the release branch, version consistency, release-readiness docs, package build, Python compile, diff hygiene, the public/private boundary scan, and the risk-based premerge canary passed. The low-frequency live-model gate and the complete release-qualification reducer were not rerun for this version-only commit. No matched benchmark outcome baseline was required because this release makes no outcome-uplift claim.

## Update

```bash
loopx update --check
loopx update --execute
loopx doctor
```

[Full changelog](https://github.com/huangruiteng/loopx/compare/v0.2.11...v0.2.12)

## 中文摘要

### 更可靠的 Agent 控制循环

每次 heartbeat 现在都会持久化独立 quota receipt，并保持 monitor/replan 路由新鲜，减少重复执行与陈旧续跑决策（[#2473](https://github.com/huangruiteng/loopx/pull/2473)、[#2478](https://github.com/huangruiteng/loopx/pull/2478)、[#2460](https://github.com/huangruiteng/loopx/pull/2460)、[#2464](https://github.com/huangruiteng/loopx/pull/2464)）。调度仍由宿主 Automation 管理；本版本不会自动创建后台调度，也不会授予外部写权限。

### Review 与代码精简

`loopx pr-review` 新增代码量必要性和潜在精简方向分析（[#2471](https://github.com/huangruiteng/loopx/pull/2471)）。Review 仍只提供建议，不会自动 merge PR 或关闭 issue。

### Benchmark-neutral worker 生命周期

Adaptive multi-turn 与 public live-worker phase projection 会在 compact run/ledger 中保留 setup、agent、verification 阶段（[#2399](https://github.com/huangruiteng/loopx/pull/2399)、[#2480](https://github.com/huangruiteng/loopx/pull/2480)、[#2481](https://github.com/huangruiteng/loopx/pull/2481)、[#2483](https://github.com/huangruiteng/loopx/pull/2483)）。本版本不改变评分、任务语义、权限或提交行为，也不宣称 benchmark 提升。

### 可选能力

Finance Value Discovery 是默认不启用的确定性 reducer 示例（[#2391](https://github.com/huangruiteng/loopx/pull/2391)）；安装、运行和停用命令见英文部分。Lark Kanban heartbeat sync 仍默认关闭，需要已认证的 `lark-cli` 和本地 board binding（[#2437](https://github.com/huangruiteng/loopx/pull/2437)）。周报 preset 的项目进展分节已本地化（[#2400](https://github.com/huangruiteng/loopx/pull/2400)），preset 本身不需要持久化开关；OpenViking archive sink 仍需单独安装并通过权限 gate。

### 兼容性与验证

包版本为 `0.2.12`，tag 为 `v0.2.12`，无需持久化状态迁移。发布前 `main` 的 GitHub pytest 和 7 个 Full Public Smoke 分片均通过；release 分支的版本一致性、文档 smoke、构建、编译、diff/public-private 检查及 risk-based premerge canary 通过。本次版本号提交未重跑低频 live-model gate 和完整 release-qualification reducer；由于不宣称 benchmark 提升，也不需要 matched outcome baseline。
