### PR TITLE
Preserve durable vision across local waits

### DIFF
--- a/docs/reference/protocols/goal-vision-replan-contract-v0.md
+++ b/docs/reference/protocols/goal-vision-replan-contract-v0.md
@@ -432,9 +432,20 @@ self-repair fallback. Agents should write a bounded vision patch when:
   it.
 
 The inline flags keep the common path small. A role can update only the fields
-it knows, while the CLI still enforces field budgets and projects the resulting
-`agent_vision` through status/quota. JSON packets are for generated patches,
-tests, or multi-field updates where a file is clearer than a long command.
+it knows: inline writes merge those fields into that agent's latest active
+vision, preserving omitted durable mainline fields and the current state. A
+todo, PR, capability, or monitor wait should normally update its own todo plus
+`replan_trigger_summary` or `last_patch_summary`; it must not replace the
+role's broader `vision_summary` merely because that dependency is current.
+
+JSON packets are complete generated updates. During
+`--autonomous-replan-recorded`, changing an existing `vision_summary`,
+`role_scope`, `acceptance_summary`, or `advancement_policy` requires a
+`goal_path_delta_v0` with `outcome=replan`, regardless of whether the update
+arrived through JSON or inline flags. This keeps a real mainline change
+possible while making the prior assumption, observed reality, and
+retained/changed/stopped route machine-auditable. Unchanged full packets,
+non-replan inline edits, and initial baselines do not need a path delta.
 
 When no patch is needed, the agent should still close a required checkpoint with
 `--vision-unchanged-reason`. That reason is per-agent and must explain why the

--- a/examples/project/goal-vision-refresh-state-budget-smoke.py
+++ b/examples/project/goal-vision-refresh-state-budget-smoke.py
@@ -81,6 +81,7 @@ def run_cli(
     extra_args: list[str] | None = None,
     dry_run: bool = True,
     include_agent_id: bool = True,
+    autonomous_replan_recorded: bool = True,
 ) -> subprocess.CompletedProcess[str]:
     command = [
         sys.executable,
@@ -101,9 +102,10 @@ def run_cli(
         "single_surface",
         "--delivery-outcome",
         "outcome_progress",
-        "--autonomous-replan-recorded",
         "--no-global-sync",
     ]
+    if autonomous_replan_recorded:
+        command.append("--autonomous-replan-recorded")
     if include_agent_id:
         command.extend(["--agent-id", AGENT_ID])
     if vision_path is not None:
@@ -188,6 +190,8 @@ def main() -> int:
         registry_path, runtime, project = write_fixture(root)
         valid_path = root / "valid-vision.json"
         invalid_path = root / "invalid-vision.json"
+        drift_path = root / "drift-vision.json"
+        explained_drift_path = root / "explained-drift-vision.json"
 
         write_json(
             valid_path,
@@ -324,6 +328,83 @@ def main() -> int:
             "autonomous_replan_recorded"
         ), latest_status_checkpoint
 
+        partial_inline = payload(
+            run_cli(
+                registry_path,
+                runtime,
+                inline_vision_args=[
+                    "--vision-replan-trigger",
+                    "The current dependency remains blocked; preserve the research mainline.",
+                ],
+                check=True,
+            )
+        )
+        partial_patch = partial_inline["agent_vision"]["vision_patch"]
+        assert partial_patch["vision_summary"] == (
+            "Map the next evidence frontier and hand off one runnable claim."
+        ), partial_inline
+        assert partial_patch["acceptance_summary"] == (
+            "One successor todo plus evidence references."
+        ), partial_inline
+        assert partial_patch["advancement_policy"] == (
+            "repeat_until_closed"
+        ), partial_inline
+        assert partial_patch["replan_trigger_summary"] == (
+            "The current dependency remains blocked; preserve the research mainline."
+        ), partial_inline
+
+        unexplained_inline_drift = run_cli(
+            registry_path,
+            runtime,
+            inline_vision_args=[
+                "--vision-summary",
+                "Wait for one supporting pull request.",
+            ],
+            check=False,
+        )
+        assert unexplained_inline_drift.returncode == 1, unexplained_inline_drift
+        assert "provide goal_path_delta_v0 with outcome=replan" in payload(
+            unexplained_inline_drift
+        )["error"], unexplained_inline_drift.stdout
+
+        drift_packet = json.loads(valid_path.read_text(encoding="utf-8"))
+        drift_packet["vision_patch"]["vision_summary"] = (
+            "Wait for one supporting pull request."
+        )
+        write_json(drift_path, drift_packet)
+        unexplained_drift = run_cli(
+            registry_path,
+            runtime,
+            vision_path=drift_path,
+            check=False,
+        )
+        assert unexplained_drift.returncode == 1, unexplained_drift
+        assert "provide goal_path_delta_v0 with outcome=replan" in payload(
+            unexplained_drift
+        )["error"], unexplained_drift.stdout
+
+        explained_drift_packet = dict(drift_packet)
+        explained_drift_packet["path_delta"] = {
+            "schema_version": "goal_path_delta_v0",
+            "outcome": "replan",
+            "prior_assumption": "The research mainline remained directly runnable.",
+            "observed_reality": "A required dependency now blocks the next experiment.",
+            "retained": ["Keep the experiment acceptance and evidence boundary."],
+            "changed": ["Wait on the dependency before the next experiment."],
+        }
+        write_json(explained_drift_path, explained_drift_packet)
+        explained_drift = payload(
+            run_cli(
+                registry_path,
+                runtime,
+                vision_path=explained_drift_path,
+                check=True,
+            )
+        )
+        assert explained_drift["agent_vision"]["path_delta"]["outcome"] == (
+            "replan"
+        ), explained_drift
+
         inline = payload(
             run_cli(
                 registry_path,
@@ -345,6 +426,7 @@ def main() -> int:
                     "create_successor",
                 ],
                 check=True,
+                autonomous_replan_recorded=False,
             )
         )
         assert inline["ok"] is True, inline
@@ -370,6 +452,7 @@ def main() -> int:
                     "Close the bounded research route after authoritative validation.",
                 ],
                 check=True,
+                autonomous_replan_recorded=False,
             )
         )
         assert closed_alias["agent_vision"]["state"] == "vision_closed", (

--- a/loopx/cli_commands/project_lifecycle.py
+++ b/loopx/cli_commands/project_lifecycle.py
@@ -119,12 +119,14 @@ def _inline_agent_vision_packet(args: argparse.Namespace) -> dict[str, object] |
         raise ValueError("inline agent vision requires --agent-id")
     if not patch:
         raise ValueError("inline agent vision requires at least one --vision-* patch field")
-    return {
+    packet: dict[str, object] = {
         "schema_version": "goal_vision_replan_contract_v0",
-        "state": state or "vision_patch_proposed",
         "vision_patch": patch,
         "todo_delta": todo_delta,
     }
+    if state:
+        packet["state"] = state
+    return packet
 
 
 def register_project_lifecycle_commands(
@@ -210,8 +212,9 @@ def register_project_lifecycle_commands(
     refresh_state_parser.add_argument(
         "--agent-vision-json",
         help=(
-            "Path to a goal_vision_replan_contract_v0 JSON packet. The CLI enforces "
-            "per-field and total vision budgets before recording it."
+            "Path to a complete generated goal_vision_replan_contract_v0 update. "
+            "The CLI enforces budgets; any autonomous replan that changes durable "
+            "mainline fields requires goal_path_delta_v0."
         ),
     )
     refresh_state_parser.add_argument(
@@ -225,7 +228,10 @@ def register_project_lifecycle_commands(
     )
     refresh_state_parser.add_argument(
         "--vision-summary",
-        help="Inline bounded vision_summary for a normal refresh-state vision patch.",
+        help=(
+            "Inline bounded vision_summary for a field-level patch merged into the "
+            "current agent's latest active vision."
+        ),
     )
     refresh_state_parser.add_argument(
         "--vision-role-scope",
@@ -463,6 +469,7 @@ def handle_project_lifecycle_command(
     fmt = output_format(args)
     if args.command == "refresh-state":
         agent_vision_packet: dict[str, object] | None = None
+        merge_agent_vision_patch = False
         try:
             inline_agent_vision_packet = _inline_agent_vision_packet(args)
             if args.agent_vision_json and inline_agent_vision_packet:
@@ -475,6 +482,7 @@ def handle_project_lifecycle_command(
                 )
             elif inline_agent_vision_packet:
                 agent_vision_packet = inline_agent_vision_packet
+                merge_agent_vision_patch = True
         except Exception as exc:
             payload = {
                 "ok": False,
@@ -511,6 +519,7 @@ def handle_project_lifecycle_command(
                 autonomous_replan_recorded=bool(args.autonomous_replan_recorded),
                 repair_delta_kinds=args.repair_delta_kinds,
                 agent_vision_packet=agent_vision_packet,
+                merge_agent_vision_patch=merge_agent_vision_patch,
                 vision_unchanged_reason=args.vision_unchanged_reason,
                 dry_run=bool(args.dry_run),
                 sync_global=not bool(args.no_global_sync),

--- a/loopx/control_plane/goals/goal_vision.py
+++ b/loopx/control_plane/goals/goal_vision.py
@@ -25,6 +25,12 @@ GOAL_VISION_FIELD_LIMITS: dict[str, int] = {
     "last_patch_summary": 240,
 }
 GOAL_VISION_TOTAL_LIMIT = 1200
+GOAL_VISION_DURABLE_FIELDS = (
+    "vision_summary",
+    "role_scope",
+    "acceptance_summary",
+    "advancement_policy",
+)
 GOAL_PATH_DELTA_OUTCOMES = frozenset(
     {"continue", "replan", "wait", "no_change", "ask_human", "stop"}
 )
@@ -368,4 +374,70 @@ def normalize_goal_vision_packet(
     }
     if path_delta:
         normalized["path_delta"] = path_delta
+    return normalized
+
+
+def normalize_goal_vision_update(
+    packet: dict[str, Any],
+    *,
+    goal_id: str,
+    agent_id: str | None,
+    existing_agent_vision: dict[str, Any] | None,
+    merge_patch: bool,
+    require_path_delta_for_durable_change: bool,
+) -> dict[str, Any]:
+    """Normalize one full replacement or field-level vision patch."""
+
+    update_packet = dict(packet)
+    existing = (
+        existing_agent_vision if isinstance(existing_agent_vision, dict) else {}
+    )
+    if merge_patch and existing:
+        existing_patch = (
+            existing.get("vision_patch")
+            if isinstance(existing.get("vision_patch"), dict)
+            else {}
+        )
+        incoming_patch = (
+            packet.get("vision_patch")
+            if isinstance(packet.get("vision_patch"), dict)
+            else packet
+        )
+        update_packet["vision_patch"] = {
+            **existing_patch,
+            **incoming_patch,
+        }
+        if not str(packet.get("state") or "").strip():
+            update_packet["state"] = existing.get("state")
+
+    normalized = normalize_goal_vision_packet(
+        update_packet,
+        goal_id=goal_id,
+        agent_id=agent_id,
+    )
+    if not require_path_delta_for_durable_change or not existing:
+        return normalized
+
+    existing_patch = (
+        existing.get("vision_patch")
+        if isinstance(existing.get("vision_patch"), dict)
+        else {}
+    )
+    normalized_patch = normalized["vision_patch"]
+    changed_fields = [
+        field
+        for field in GOAL_VISION_DURABLE_FIELDS
+        if existing_patch.get(field) != normalized_patch.get(field)
+    ]
+    path_delta = (
+        normalized.get("path_delta")
+        if isinstance(normalized.get("path_delta"), dict)
+        else {}
+    )
+    if changed_fields and path_delta.get("outcome") != "replan":
+        raise ValueError(
+            "autonomous agent vision replan changes durable fields "
+            f"{', '.join(changed_fields)}; provide goal_path_delta_v0 with "
+            "outcome=replan so the mainline change is explicit"
+        )
     return normalized

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -43,7 +43,7 @@ from .history import (
 )
 from .control_plane.runtime.local_state_write_correctness import build_local_state_write_correctness_dry_run_packet
 from .paths import resolve_runtime_root
-from .control_plane.goals.goal_vision import normalize_goal_vision_packet
+from .control_plane.goals.goal_vision import normalize_goal_vision_update
 from .control_plane.goals.goal_frontier import latest_agent_vision_from_runs
 from .registry import registry_goals, resolve_state_file
 from .runtime import validate_goal_id_path_segment
@@ -822,6 +822,7 @@ def refresh_state_run(
     autonomous_replan_recorded: bool = False,
     repair_delta_kinds: list[str] | None = None,
     agent_vision_packet: dict[str, Any] | None = None,
+    merge_agent_vision_patch: bool = False,
     vision_unchanged_reason: str | None = None,
     dry_run: bool,
     sync_global: bool = True,
@@ -919,21 +920,20 @@ def refresh_state_run(
     if normalized_progress_scope == GOAL_PROGRESS_SCOPE:
         if normalized_agent_lane:
             raise ValueError("--agent-lane requires --progress-scope agent_lane")
-    agent_vision: dict[str, Any] | None = None
     if (agent_vision_packet is not None or vision_unchanged_reason) and not normalized_agent_id:
         raise ValueError("vision writeback requires --agent-id")
-    if agent_vision_packet is not None:
-        agent_vision = normalize_goal_vision_packet(
-            agent_vision_packet,
-            goal_id=safe_goal_id,
-            agent_id=normalized_agent_id or None,
-        )
     normalized_vision_unchanged_reason = normalize_vision_unchanged_reason(
         vision_unchanged_reason
     )
+    agent_vision: dict[str, Any] | None = None
     existing_agent_vision: dict[str, Any] | None = None
     autonomous_replan_frontier_identity: str | None = None
-    if normalized_agent_id and normalized_vision_unchanged_reason:
+    existing_runs: list[dict[str, Any]] = []
+    if normalized_agent_id and (
+        agent_vision_packet is not None
+        or normalized_vision_unchanged_reason
+        or autonomous_replan_recorded
+    ):
         existing_runs, _ = load_index(
             runtime_root / "goals" / safe_goal_id / "runs" / "index.jsonl"
         )
@@ -950,10 +950,16 @@ def refresh_state_run(
             goal_id=safe_goal_id,
             agent_id=normalized_agent_id,
         )
-    if autonomous_replan_recorded:
-        existing_runs, _ = load_index(
-            runtime_root / "goals" / safe_goal_id / "runs" / "index.jsonl"
+    if agent_vision_packet is not None:
+        agent_vision = normalize_goal_vision_update(
+            agent_vision_packet,
+            goal_id=safe_goal_id,
+            agent_id=normalized_agent_id or None,
+            existing_agent_vision=existing_agent_vision,
+            merge_patch=merge_agent_vision_patch,
+            require_path_delta_for_durable_change=autonomous_replan_recorded,
         )
+    if autonomous_replan_recorded:
         newest_first_runs = [
             run
             for _, run in sorted(


### PR DESCRIPTION
## Summary
- merge inline agent-vision fields into the latest same-agent vision so omitted durable fields survive local waits
- require an explicit `goal_path_delta_v0` replan whenever an autonomous update changes durable vision, independent of JSON or inline transport
- document the write contract and add positive/negative CLI regression coverage

## Validation
- `python examples/project/goal-vision-refresh-state-budget-smoke.py`
- `pytest -q tests/control_plane/test_goal_frontier_replan_rules.py tests/control_plane/test_goal_vision_blocked_successor.py tests/control_plane/test_goal_vision_succession.py` (52 passed)
- ruff, py_compile, and `git diff --check`
- `loopx canary premerge --from-git-diff --no-progress` (4 direct checks + 18 selected checks, no failures or warnings)
- public/private boundary scan clean across all 5 changed files

## Boundaries
- no quota scoring, scheduler, benchmark runner, task semantics, or launch behavior changed
- no benchmark job launched
- no private state, raw benchmark material, credentials, local paths, or generated logs included

## Merge decision
Separate review requested because this changes core goal-vision write behavior. The premerge gate passed, but this PR is not self-merged.