### PR TITLE
fix(onboarding): emit scoped refresh-state commands

### DIFF
--- a/examples/bootstrap-command-pack-smoke.py
+++ b/examples/bootstrap-command-pack-smoke.py
@@ -238,6 +238,10 @@ def test_goal_text_invocation_plans_ranked_todos_before_activation() -> None:
         assert "--repo-path <approved-repo>" in reviewer_request_template
         assert "--execute" in reviewer_request_template
         assert "--agent-id codex-test-agent" in str(commands["goal_start_quota_should_run"])
+        refresh_command = str(commands["goal_start_refresh_state"])
+        assert "--agent-id codex-test-agent" in refresh_command
+        assert "--progress-scope agent_lane" in refresh_command
+        assert "--health-check" not in refresh_command
         assert "Same-priority items use that write order as the tie-breaker" in str(payload["message"])
         assert "preview the issue-fix route before todo writeback" in str(payload["message"])
         assert "PR lifecycle monitor" in str(payload["message"])

--- a/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
+++ b/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
@@ -21,6 +21,7 @@ from loopx.bootstrap_command_pack import (  # noqa: E402
     build_loopx_bootstrap_command_pack,
     build_start_goal_guided_packet,
 )
+from loopx.cli import build_parser  # noqa: E402
 from loopx.host_loop_activation import (  # noqa: E402
     agent_type_for_host_surface,
     build_agent_type_catalog,
@@ -246,6 +247,14 @@ def main() -> int:
             available_capabilities=["network", "external_evidence_poll"],
         )
         assert selected_pack["host_loop_activation"]["activation_allowed"] is True
+        refresh_command = selected_pack["commands"]["goal_start_refresh_state"]
+        assert "--agent-id codex-product-capability" in refresh_command, refresh_command
+        assert "--progress-scope agent_lane" in refresh_command, refresh_command
+        assert "--health-check" not in refresh_command, refresh_command
+        refresh_args = build_parser().parse_args(shlex.split(refresh_command)[1:])
+        assert refresh_args.command == "refresh-state", refresh_args
+        assert refresh_args.agent_id == "codex-product-capability", refresh_args
+        assert refresh_args.progress_scope == "agent_lane", refresh_args
         for key in (
             "heartbeat_prompt_json",
             "quota_guard",

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -17,6 +17,7 @@ from .project_prompt import (
     DEFAULT_HANDOFF_ADAPTER_STATUS,
     render_available_capability_args,
     render_quota_guard_command,
+    render_refresh_state_command,
     render_scheduler_execution_args,
     shell_arg,
 )
@@ -863,7 +864,12 @@ def build_loopx_bootstrap_command_pack(
             "bootstrap_after_user_confirmation": bootstrap_after_confirmation_command,
             "goal_start_connect_if_needed": goal_start_bootstrap_command,
             "goal_start_plan_prompt": goal_start_plan_prompt,
-            "goal_start_refresh_state": f"{shell_arg(cli_bin)} refresh-state --goal-id {shell_arg(resolved_goal_id)}",
+            "goal_start_refresh_state": render_refresh_state_command(
+                resolved_goal_id,
+                cli_bin=cli_bin,
+                agent_id=str(selected_agent_id) if selected_agent_id else None,
+                progress_scope="agent_lane" if selected_agent_id else None,
+            ),
             "goal_start_host_loop_activation": host_loop_activation.get("activation_input_command"),
             "goal_start_agent_onboard_recheck": (
                 f"{shell_arg(cli_bin)} agent-onboard "

--- a/loopx/project_prompt.py
+++ b/loopx/project_prompt.py
@@ -391,6 +391,7 @@ def build_codex_cli_bootstrap_message(
         resolved_goal_id,
         cli_bin=cli_bin,
         agent_id=agent_id,
+        progress_scope="agent_lane" if agent_id else None,
     )
     first_run_validation_checklist = [
         f"{cli_bin} doctor passed after no-clone install repair or existing install",


### PR DESCRIPTION
## Summary
- generate bootstrap `refresh-state` commands through the existing shared renderer
- include the selected agent identity and explicit `agent_lane` scope in agent-bound startup guidance
- keep `health_check` derived/output-only and guard against exposing it as a caller argument

## Root cause
The executable CLI contract was already correct: multi-agent refreshes require a registered `--agent-id`, and an agent-bound refresh is scoped to `agent_lane`. The bootstrap command pack bypassed the shared renderer and hand-built only `refresh-state --goal-id ...`, while the Codex CLI bootstrap relied on an implicit scope default. This PR fixes the guidance generators instead of adding a redundant or forgeable `--health-check` input.

## Validation
- `git diff --check`
- Ruff on all four changed files
- changed-file Python 3.11 compile
- `examples/bootstrap-command-pack-smoke.py`
- `examples/control_plane/agent-onboard-host-loop-activation-smoke.py`
- `examples/codex-cli-bootstrap-message-smoke.py`
- 11 focused onboarding model-behavior tests
- `loopx canary premerge --from-git-diff --no-progress`: passed; 3/3 selected checks, public/private boundary clean, no warnings or manual holds

## Scope
No CLI option or state semantics changed. The generated command is also parsed by the real LoopX argparse parser in the focused smoke.