### PR TITLE
docs: refresh LoopX 0.2.12 manpage

### DIFF
--- a/man/loopx.1
+++ b/man/loopx.1
@@ -1,4 +1,4 @@
-.TH LOOPX 1 "" "LoopX 0.2.11" "User Commands"
+.TH LOOPX 1 "" "LoopX 0.2.12" "User Commands"
 .SH NAME
 loopx \- control-plane helper for long-running agent work
 .SH SYNOPSIS


### PR DESCRIPTION
## Summary

- regenerate the canonical `man/loopx.1` from the current CLI help surface
- update the generated header from LoopX 0.2.11 to 0.2.12

## Scope and code volume

This is the minimum complete repair: one generated line changes (`+1/-1`). There is no runtime, parser, API, compatibility, capability, or provider change, and no new abstraction or migration path.

## Validation

- `python scripts/render-manpage.py --check man/loopx.1`
- `python examples/cli-help-manpage-smoke.py`
- Full Public shard 1: 100/100 passed with the same 100-check selection and 4 jobs, using a 180s local timeout
- default 120s run had one local timeout in `canary-promotion-readiness-smoke.py`; the same check passed in isolation in 109s, and the full 180s shard completed without failures or timeouts
- `python -m loopx.cli check --scan-path man/loopx.1` (public boundary clean)
- `python -m loopx.cli canary premerge --from-git-diff --timeout-seconds 180` (passed; no manual holds)
- `git diff --check`

## Merge decision

Ready for review. The diff is generated documentation only; no runtime semantics change.
