### PR TITLE
Run SkillsBench task-free preflights before launch gates

### DIFF
--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -17902,6 +17902,40 @@ async def async_independent_goal_retry_main(args: argparse.Namespace) -> dict[st
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     logging.getLogger().setLevel(logging.WARNING)
+    if args.local_codex_participant_ping:
+        payload = codex_runtime.materialize_local_codex_participant(
+            codex_bin=args.local_codex_bin,
+            timeout_sec=args.local_codex_ping_timeout_sec,
+        )
+        print(json.dumps(payload, indent=2, sort_keys=True, default=_json_default))
+        return 0 if payload.get("codex_cli_invoked") is True else 1
+    if args.local_driver_worker_handshake_preflight:
+        ensure_skillsbench_dependency_python(args)
+        payload = inspect_skillsbench_worker_handshake(
+            skillsbench_root=args.skillsbench_root,
+            dataset=args.dataset,
+            task_id=args.task_id,
+            local_codex_cli_participant_ready=args.local_codex_cli_participant_ready,
+            local_acp_relay_command=args.local_acp_relay_command,
+            probe_local_acp_relay=args.local_acp_relay_probe,
+            local_acp_relay_probe_timeout_sec=args.local_acp_relay_probe_timeout_sec,
+            probe_host_local_acp_transport=args.host_local_acp_transport_probe,
+            host_local_acp_transport_probe_timeout_sec=(
+                args.host_local_acp_transport_probe_timeout_sec
+            ),
+            probe_remote_command_file_bridge=args.remote_command_file_bridge_probe,
+            remote_command_file_bridge_probe_command=(
+                args.remote_command_file_bridge_probe_command
+            ),
+            remote_command_file_bridge_probe_timeout_sec=(
+                args.remote_command_file_bridge_probe_timeout_sec
+            ),
+            remote_command_file_bridge_ready=args.remote_command_file_bridge_ready,
+            remote_executor_ready=True,
+            remote_task_data_ready=True,
+        )
+        print(json.dumps(payload, indent=2, sort_keys=True, default=_json_default))
+        return 0
     if (
         args.route == CODEX_APP_SERVER_GOAL_BASELINE_ROUTE
         and not args.plan_only
@@ -18176,40 +18210,6 @@ def main(argv: list[str] | None = None) -> int:
         }
         print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
         return 2
-    if args.local_codex_participant_ping:
-        payload = codex_runtime.materialize_local_codex_participant(
-            codex_bin=args.local_codex_bin,
-            timeout_sec=args.local_codex_ping_timeout_sec,
-        )
-        print(json.dumps(payload, indent=2, sort_keys=True, default=_json_default))
-        return 0 if payload.get("codex_cli_invoked") is True else 1
-    if args.local_driver_worker_handshake_preflight:
-        ensure_skillsbench_dependency_python(args)
-        payload = inspect_skillsbench_worker_handshake(
-            skillsbench_root=args.skillsbench_root,
-            dataset=args.dataset,
-            task_id=args.task_id,
-            local_codex_cli_participant_ready=args.local_codex_cli_participant_ready,
-            local_acp_relay_command=args.local_acp_relay_command,
-            probe_local_acp_relay=args.local_acp_relay_probe,
-            local_acp_relay_probe_timeout_sec=args.local_acp_relay_probe_timeout_sec,
-            probe_host_local_acp_transport=args.host_local_acp_transport_probe,
-            host_local_acp_transport_probe_timeout_sec=(
-                args.host_local_acp_transport_probe_timeout_sec
-            ),
-            probe_remote_command_file_bridge=args.remote_command_file_bridge_probe,
-            remote_command_file_bridge_probe_command=(
-                args.remote_command_file_bridge_probe_command
-            ),
-            remote_command_file_bridge_probe_timeout_sec=(
-                args.remote_command_file_bridge_probe_timeout_sec
-            ),
-            remote_command_file_bridge_ready=args.remote_command_file_bridge_ready,
-            remote_executor_ready=True,
-            remote_task_data_ready=True,
-        )
-        print(json.dumps(payload, indent=2, sort_keys=True, default=_json_default))
-        return 0
     task_ids = _batch_task_ids(args)
     batch_mode = len(task_ids) > 1
     independent_retry_mode = _independent_goal_retry_enabled(args) and not args.plan_only

--- a/tests/test_skillsbench_task_free_preflight_cli.py
+++ b/tests/test_skillsbench_task_free_preflight_cli.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+
+from scripts import skillsbench_automation_loop as automation_loop
+
+
+def test_local_codex_participant_ping_bypasses_launch_route_guards(
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(
+        automation_loop.codex_runtime,
+        "materialize_local_codex_participant",
+        lambda **_kwargs: {
+            "schema_version": "skillsbench_local_codex_participant_v0",
+            "codex_cli_invoked": True,
+            "ready": True,
+        },
+    )
+
+    assert automation_loop.main(["--local-codex-participant-ping"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ready"] is True
+
+
+def test_worker_handshake_preflight_bypasses_launch_route_guards(
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(
+        automation_loop,
+        "ensure_skillsbench_dependency_python",
+        lambda _args: None,
+    )
+    monkeypatch.setattr(
+        automation_loop,
+        "inspect_skillsbench_worker_handshake",
+        lambda **_kwargs: {
+            "schema_version": "skillsbench_worker_handshake_preflight_v0",
+            "ready": True,
+        },
+    )
+
+    assert (
+        automation_loop.main(["--local-driver-worker-handshake-preflight"]) == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ready"] is True


### PR DESCRIPTION
## Summary
- dispatch the local Codex participant ping before scored launch route validation
- dispatch the local-driver worker handshake preflight before scored launch route validation
- add focused CLI regressions for both task-free entry points

## Validation
- `67 passed` across the focused task-free, Turn launcher, and setup-preflight tests
- changed Python compile and `git diff --check` passed
- premerge catalog canaries passed: maintainability ratchet, Terminal-Bench adapter readiness, benchmark core adapter contract, artifact path filter
- real task-free local Codex `workspace-write` participant ping returned ready without `--plan-only`

## Boundary
- no benchmark task launched
- no scoring, runner, Turn policy, quota, upload, or submission semantics changed
- no raw task text, trajectory, verifier output, credentials, host paths, or private runner values recorded

## Manual hold
The premerge gate classifies this as benchmark-sensitive and requires maintainer review; this PR is not self-merge eligible.