### PR TITLE
Add kernel-level SkillsBench local Codex split control

### DIFF
--- a/examples/skillsbench-reverse-channel-bridge-smoke.py
+++ b/examples/skillsbench-reverse-channel-bridge-smoke.py
@@ -116,26 +116,43 @@ def test_reverse_channel_clients_fail_closed_on_empty_response() -> None:
 
 def test_prompt_bridge_rejects_batched_loopx_commands() -> None:
     sys.path.insert(0, str(REPO_ROOT))
-    from scripts.skillsbench_reverse_channel_bridge import (
-        _write_instrumented_prompt_bridge,
-    )
+    from scripts.skillsbench_reverse_channel_bridge import _run_codex_payload
 
     with tempfile.TemporaryDirectory(prefix="loopx-prompt-bridge-batch-") as tmp:
         root = Path(tmp)
         marker = root / "bridge-invoked"
+        command_path = root / "command.txt"
+        fake_codex = root / "fake-codex"
+        fake_codex.write_text(
+            f"""#!/usr/bin/env python3
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+prompt = sys.stdin.read()
+bridge = re.search(r"Private bridge command:\\n([^\\n]+)", prompt).group(1)
+request = {{
+    "operation": "exec",
+    "cwd": "/app",
+    "command": Path({str(command_path)!r}).read_text(encoding="utf-8"),
+}}
+raise SystemExit(subprocess.run(
+    [bridge],
+    input=json.dumps(request),
+    text=True,
+).returncode)
+""",
+            encoding="utf-8",
+        )
+        fake_codex.chmod(0o700)
         fake_bridge = root / "fake-bridge.py"
         fake_bridge.write_text(
             "from pathlib import Path\n"
             f"Path({str(marker)!r}).write_text('invoked', encoding='utf-8')\n"
             "print('{}')\n",
             encoding="utf-8",
-        )
-        wrapper, summary_path = _write_instrumented_prompt_bridge(
-            tmp_path=root,
-            bridge_command=(
-                f"{shlex.quote(sys.executable)} {shlex.quote(str(fake_bridge))}"
-            ),
-            private_bridge_command=None,
         )
         commands = {
             "newline": (
@@ -165,23 +182,34 @@ def test_prompt_bridge_rejects_batched_loopx_commands() -> None:
             ),
         }
         for label, command in commands.items():
-            request = {"operation": "exec", "cwd": "/app", "command": command}
-            result = subprocess.run(
-                [str(wrapper)],
-                input=json.dumps(request),
-                check=False,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
+            command_path.write_text(command, encoding="utf-8")
+            marker.unlink(missing_ok=True)
+            result = _run_codex_payload(
+                {
+                    "args": ["exec"],
+                    "stdin": (
+                        "Your first tool action should call the private bridge.\n\n"
+                        "Private bridge command:\nfixture-bridge"
+                    ),
+                    "timeout_sec": 10,
+                },
+                codex_bin=str(fake_codex),
+                default_timeout_sec=10,
+                prompt_bridge_command=(
+                    f"{shlex.quote(sys.executable)} "
+                    f"{shlex.quote(str(fake_bridge))}"
+                ),
+                first_action_timeout_sec=5,
             )
             records = [
                 json.loads(line)
-                for line in summary_path.read_text(encoding="utf-8").splitlines()
+                for line in result["agent_operations_jsonl"].splitlines()
+                if line.strip()
             ]
-            assert result.returncode == 2, (label, result)
-            assert "exactly one LoopX CLI command" in result.stderr, (
+            assert result["exit_code"] == 2, (label, result)
+            assert "exactly one LoopX CLI command" in result["stderr"], (
                 label,
-                result.stderr,
+                result["stderr"],
             )
             assert marker.exists() is False, label
             completed = [
@@ -191,6 +219,90 @@ def test_prompt_bridge_rejects_batched_loopx_commands() -> None:
             assert completed[-1]["failure_category"] == (
                 "multiple_loopx_commands_per_bridge_request"
             ), (label, completed)
+
+
+def test_prompt_bridge_broker_rejects_direct_queue_bypass() -> None:
+    sys.path.insert(0, str(REPO_ROOT))
+    from scripts.skillsbench_reverse_channel_bridge import _run_codex_payload
+
+    with tempfile.TemporaryDirectory(prefix="loopx-prompt-broker-bypass-") as tmp:
+        root = Path(tmp)
+        marker = root / "bridge-invoked"
+        fake_codex = root / "fake-codex"
+        fake_codex.write_text(
+            """#!/usr/bin/env python3
+import json
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+
+args = sys.argv[1:]
+if "-C" in args:
+    os.chdir(args[args.index("-C") + 1])
+sys.stdin.read()
+queue = Path.cwd() / ".loopx-prompt-bridge-broker"
+deadline = time.monotonic() + 5
+while time.monotonic() < deadline and not (queue / "requests").exists():
+    time.sleep(0.02)
+request_id = uuid.uuid4().hex
+request_path = queue / "requests" / f"{request_id}.json"
+response_path = queue / "responses" / f"{request_id}.json"
+request_path.write_text(json.dumps({
+    "stdin": json.dumps({
+        "operation": "exec",
+        "command": "loopx status; loopx status",
+    }),
+}), encoding="utf-8")
+while time.monotonic() < deadline and not response_path.exists():
+    time.sleep(0.02)
+if not response_path.exists():
+    raise SystemExit(91)
+response = json.loads(response_path.read_text(encoding="utf-8"))
+raise SystemExit(int(response.get("exit_code", 92)))
+""",
+            encoding="utf-8",
+        )
+        fake_codex.chmod(0o700)
+        fake_bridge = root / "fake-bridge"
+        fake_bridge.write_text(
+            "#!/usr/bin/env python3\n"
+            "from pathlib import Path\n"
+            f"Path({str(marker)!r}).write_text('invoked', encoding='utf-8')\n",
+            encoding="utf-8",
+        )
+        fake_bridge.chmod(0o700)
+
+        response = _run_codex_payload(
+            {
+                "args": ["exec", "-C", "/remote/work"],
+                "stdin": (
+                    "Your first tool action should call the private bridge.\n\n"
+                    "Private bridge command:\nfixture-bridge"
+                ),
+                "timeout_sec": 10,
+            },
+            codex_bin=str(fake_codex),
+            default_timeout_sec=10,
+            prompt_bridge_command=str(fake_bridge),
+            first_action_timeout_sec=5,
+        )
+
+        records = [
+            json.loads(line)
+            for line in response["agent_operations_jsonl"].splitlines()
+            if line.strip()
+        ]
+        completed = [
+            record for record in records if record.get("record_phase") == "complete"
+        ]
+        assert response["exit_code"] == 2, response
+        assert marker.exists() is False
+        assert completed[-1]["loopx_invocation_count"] == 2, completed
+        assert completed[-1]["failure_category"] == (
+            "multiple_loopx_commands_per_bridge_request"
+        ), completed
 
 
 def test_prompt_bridge_host_broker_does_not_inherit_codex_sandbox_env() -> None:
@@ -1229,6 +1341,7 @@ def test_socket_probe_reports_missing_or_orphaned() -> None:
 
 def main() -> int:
     test_prompt_bridge_rejects_batched_loopx_commands()
+    test_prompt_bridge_broker_rejects_direct_queue_bypass()
     test_prompt_bridge_host_broker_does_not_inherit_codex_sandbox_env()
     test_codex_client_writes_last_message_and_rewrites_bridge()
     test_codex_bridge_template_preserves_dynamic_private_command()

--- a/examples/skillsbench-reverse-channel-bridge-smoke.py
+++ b/examples/skillsbench-reverse-channel-bridge-smoke.py
@@ -193,6 +193,79 @@ def test_prompt_bridge_rejects_batched_loopx_commands() -> None:
             ), (label, completed)
 
 
+def test_prompt_bridge_host_broker_does_not_inherit_codex_sandbox_env() -> None:
+    sys.path.insert(0, str(REPO_ROOT))
+    from scripts.skillsbench_reverse_channel_bridge import _run_codex_payload
+
+    with tempfile.TemporaryDirectory(prefix="loopx-prompt-bridge-broker-") as tmp:
+        root = Path(tmp)
+        fake_codex = root / "fake-codex"
+        fake_codex.write_text(
+            """#!/usr/bin/env python3
+import json
+import os
+import re
+import subprocess
+import sys
+
+prompt = sys.stdin.read()
+match = re.search(r"Private bridge command:\\n([^\\n]+)", prompt)
+assert match, prompt
+env = os.environ.copy()
+env["LOOPX_FAKE_CODEX_SANDBOX"] = "1"
+raise SystemExit(subprocess.run(
+    match.group(1),
+    input=json.dumps({"operation": "preflight"}),
+    text=True,
+    shell=True,
+    env=env,
+).returncode)
+""",
+            encoding="utf-8",
+        )
+        fake_codex.chmod(0o700)
+        host_bridge = root / "host-bridge"
+        host_bridge.write_text(
+            """#!/usr/bin/env python3
+import json
+import os
+import sys
+
+sys.stdin.read()
+if os.environ.get("LOOPX_FAKE_CODEX_SANDBOX"):
+    raise SystemExit(91)
+print(json.dumps({"ok": True}))
+""",
+            encoding="utf-8",
+        )
+        host_bridge.chmod(0o700)
+        response = _run_codex_payload(
+            {
+                "args": ["exec"],
+                "stdin": (
+                    "LoopX bridge action preflight. Your first tool action "
+                    "should call the private bridge.\n\n"
+                    "Private bridge command:\nfixture-bridge"
+                ),
+                "timeout_sec": 10,
+            },
+            codex_bin=str(fake_codex),
+            default_timeout_sec=10,
+            prompt_bridge_command=str(host_bridge),
+            first_action_timeout_sec=5,
+        )
+        assert response["exit_code"] == 0, response
+        records = [
+            json.loads(line)
+            for line in response["agent_operations_jsonl"].splitlines()
+            if line.strip()
+        ]
+        assert records[-1]["success"] is True, records
+        assert records[-1]["returncode"] == 0, records
+        assert response["raw_task_text_recorded"] is False
+        assert response["credential_values_recorded"] is False
+
+
 def test_codex_client_writes_last_message_and_rewrites_bridge() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-reverse-bridge-smoke-") as tmp:
         root = Path(tmp)
@@ -882,7 +955,7 @@ print(json.dumps({
             env["LOOPX_REVERSE_CONNECT_TIMEOUT_SEC"] = "0.1"
             env["LOOPX_REVERSE_RESPONSE_TIMEOUT_SEC"] = "5"
             env["LOOPX_PRIVATE_BRIDGE_COMMAND"] = (
-                f"{sys.executable} -c \"from pathlib import Path; "
+                f'{sys.executable} -c "from pathlib import Path; '
                 f"Path({str(marker)!r}).write_text('ok', encoding='utf-8'); "
                 "print('private-ok')\""
             )
@@ -1062,7 +1135,9 @@ print(json.dumps({
 
 
 def test_json_file_preflight_does_not_invoke_bridge_command() -> None:
-    with tempfile.TemporaryDirectory(prefix="loopx-reverse-json-file-preflight-") as tmp:
+    with tempfile.TemporaryDirectory(
+        prefix="loopx-reverse-json-file-preflight-"
+    ) as tmp:
         root = Path(tmp)
         queue_dir = root / "queue"
         fake_bridge = root / "fake-json-bridge"
@@ -1154,6 +1229,7 @@ def test_socket_probe_reports_missing_or_orphaned() -> None:
 
 def main() -> int:
     test_prompt_bridge_rejects_batched_loopx_commands()
+    test_prompt_bridge_host_broker_does_not_inherit_codex_sandbox_env()
     test_codex_client_writes_last_message_and_rewrites_bridge()
     test_codex_bridge_template_preserves_dynamic_private_command()
     test_codex_client_plain_prompt_does_not_require_bridge_action()

--- a/loopx/benchmark_adapters/skillsbench_runner_profile.py
+++ b/loopx/benchmark_adapters/skillsbench_runner_profile.py
@@ -5,6 +5,7 @@ import json
 import os
 import shlex
 import stat
+import subprocess
 import sys
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -12,6 +13,9 @@ from typing import Any
 
 
 SKILLSBENCH_RUNNER_PROFILE_SCHEMA_VERSION = "skillsbench_runner_profile_v0"
+SKILLSBENCH_RUNNER_CONNECTIVITY_PROBE_SCHEMA_VERSION = (
+    "skillsbench_runner_connectivity_probe_v0"
+)
 SKILLSBENCH_RUNNER_PROFILE_RELATIVE_PATH = Path(
     "loopx/skillsbench/runner-profile.json"
 )
@@ -175,6 +179,63 @@ def skillsbench_runner_profile_summary(
     }
 
 
+def probe_skillsbench_runner_connectivity(
+    profile: Mapping[str, str],
+    *,
+    timeout_seconds: int = 15,
+) -> dict[str, Any]:
+    ssh_options: list[str] = []
+    try:
+        options = shlex.split(str(profile.get("SKILLSBENCH_SSH_OPTIONS") or ""))
+    except ValueError as error:
+        raise SkillsBenchRunnerProfileError("ssh_options_invalid") from error
+    for option in options:
+        ssh_options.extend(["-o", option])
+    destination = str(profile.get("SKILLSBENCH_SSH_DESTINATION") or "")
+    if not destination:
+        raise SkillsBenchRunnerProfileError("required_runner_environment_missing")
+    try:
+        completed = subprocess.run(
+            [
+                "ssh",
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                f"ConnectTimeout={timeout_seconds}",
+                *ssh_options,
+                destination,
+                "true",
+            ],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=timeout_seconds + 5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return {
+            "ok": True,
+            "schema_version": SKILLSBENCH_RUNNER_CONNECTIVITY_PROBE_SCHEMA_VERSION,
+            "reachable": False,
+            "result": "transport_unavailable",
+            "task_material_read": False,
+            "benchmark_job_launched": False,
+            "raw_output_recorded": False,
+            "profile_values_recorded": False,
+        }
+    return {
+        "ok": True,
+        "schema_version": SKILLSBENCH_RUNNER_CONNECTIVITY_PROBE_SCHEMA_VERSION,
+        "reachable": completed.returncode == 0,
+        "result": (
+            "reachable" if completed.returncode == 0 else "transport_unavailable"
+        ),
+        "task_material_read": False,
+        "benchmark_job_launched": False,
+        "raw_output_recorded": False,
+        "profile_values_recorded": False,
+    }
+
+
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
@@ -183,11 +244,13 @@ def _parser() -> argparse.ArgumentParser:
         )
     )
     commands = parser.add_subparsers(dest="command", required=True)
-    for name in ("export-shell", "inspect"):
+    for name in ("export-shell", "inspect", "probe-ssh"):
         command = commands.add_parser(name)
         command.add_argument("--profile", type=Path)
         if name == "export-shell":
             command.add_argument("--if-present", action="store_true")
+        if name == "probe-ssh":
+            command.add_argument("--timeout-seconds", type=int, default=15)
     capture = commands.add_parser("capture")
     capture.add_argument("--profile", type=Path)
     capture.add_argument("--force", action="store_true")
@@ -216,6 +279,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.command == "inspect":
             print(json.dumps(skillsbench_runner_profile_summary(profile), sort_keys=True))
             return 0
+        if args.command == "probe-ssh":
+            if args.timeout_seconds < 1:
+                raise SkillsBenchRunnerProfileError("probe_timeout_invalid")
+            summary = probe_skillsbench_runner_connectivity(
+                profile,
+                timeout_seconds=args.timeout_seconds,
+            )
+            print(json.dumps(summary, sort_keys=True))
+            return 0 if summary["reachable"] else 3
         exports = skillsbench_runner_profile_shell_exports(profile)
         if exports:
             print(exports)

--- a/loopx/benchmark_adapters/skillsbench_setup_preflight.py
+++ b/loopx/benchmark_adapters/skillsbench_setup_preflight.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from typing import Any
 
 from .skillsbench_failure_signals import (
@@ -220,6 +220,9 @@ def _base_result(
         "job_root_materialized": False,
         "environment_object_materialized": False,
         "environment_started": False,
+        "environment_ready_hook_requested": False,
+        "environment_ready_hook_invoked": False,
+        "environment_ready_hook_status": "not_requested",
         "agent_install_invoked": False,
         "agent_execution_invoked": False,
         "verifier_invoked": False,
@@ -276,6 +279,7 @@ async def run_setup_only_public_preflight(
     stage_timeout_sec: float,
     cleanup_timeout_sec: float = 30.0,
     progress_callback: Callable[[Mapping[str, Any]], None] | None = None,
+    environment_ready_hook: Callable[[Any], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     """Materialize a BenchFlow environment without installing or running an agent."""
 
@@ -288,6 +292,9 @@ async def run_setup_only_public_preflight(
     rollout: Any | None = None
     restore_compose_boundary: Callable[[], None] | None = None
     failed = False
+    if environment_ready_hook is not None:
+        result["environment_ready_hook_requested"] = True
+        result["environment_ready_hook_status"] = "pending"
     _emit_progress(progress_callback, result)
     try:
         rollout = await asyncio.wait_for(
@@ -315,11 +322,23 @@ async def run_setup_only_public_preflight(
         _emit_progress(progress_callback, result)
         await asyncio.wait_for(rollout.start(), timeout=stage_timeout_sec)
         result["environment_started"] = True
+        if environment_ready_hook is not None:
+            result["stage"] = "environment_ready_hook"
+            result["environment_ready_hook_invoked"] = True
+            result["environment_ready_hook_status"] = "running"
+            _emit_progress(progress_callback, result)
+            await asyncio.wait_for(
+                environment_ready_hook(getattr(rollout, "env", None)),
+                timeout=stage_timeout_sec,
+            )
+            result["environment_ready_hook_status"] = "passed"
         result["status"] = "passed"
         result["stage"] = "environment_ready_before_agent"
         result["exit_category"] = "passed"
     except Exception as exc:
         failed = True
+        if result["environment_ready_hook_status"] == "running":
+            result["environment_ready_hook_status"] = "failed"
         if rollout is not None:
             result["job_root_materialized"] = (
                 getattr(rollout, "_rollout_dir", None) is not None

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -45,6 +45,10 @@ Optional env:
   SKILLSBENCH_REASONING_EFFORT         Reasoning effort, default xhigh
   SKILLSBENCH_REMOTE_CODEX_BIN          Codex CLI executable on remote runner;
                                        default codex from remote PATH
+  SKILLSBENCH_LOCAL_CODEX_SPLIT_CONTROL Set to 1 to run Codex locally through
+                                       the opt-in reverse-channel provider
+  SKILLSBENCH_LOCAL_CODEX_BIN           Local Codex executable for split
+                                       control; default codex from local PATH
   SKILLSBENCH_LOCAL_CODEX_SANDBOX      Host Codex sandbox mode; default
                                        workspace-write
   SKILLSBENCH_CLI_GOAL_THREAD_PREWARM  Set to 1 to prewarm the persisted Codex
@@ -209,6 +213,8 @@ if [[ -n "${SKILLSBENCH_SSH_OPTIONS:-}" ]]; then
 fi
 
 remote_codex_bin="${SKILLSBENCH_REMOTE_CODEX_BIN:-codex}"
+local_codex_split_control="${SKILLSBENCH_LOCAL_CODEX_SPLIT_CONTROL:-0}"
+local_codex_bin="${SKILLSBENCH_LOCAL_CODEX_BIN:-codex}"
 local_codex_sandbox="${SKILLSBENCH_LOCAL_CODEX_SANDBOX:-workspace-write}"
 codex_cli_goal_thread_prewarm="${SKILLSBENCH_CLI_GOAL_THREAD_PREWARM:-0}"
 if [[ "$codex_cli_goal_thread_prewarm" != "0" && "$codex_cli_goal_thread_prewarm" != "1" ]]; then
@@ -248,6 +254,13 @@ validate_bool_toggle \
   SKILLSBENCH_ALLOW_STAGED_BOOTSTRAP_REPAIR_RUN "$allow_staged_bootstrap_repair_run"
 validate_bool_toggle \
   SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT "$setup_only_public_preflight"
+validate_bool_toggle \
+  SKILLSBENCH_LOCAL_CODEX_SPLIT_CONTROL "$local_codex_split_control"
+if [[ "$local_codex_split_control" == "1" ]] &&
+  [[ "$local_codex_sandbox" != "workspace-write" ]]; then
+  echo "SKILLSBENCH_LOCAL_CODEX_SPLIT_CONTROL requires SKILLSBENCH_LOCAL_CODEX_SANDBOX=workspace-write" >&2
+  exit 2
+fi
 if [[ "$benchmark_egress_proxy_mode" != "require" ]] &&
   [[ "$benchmark_egress_proxy_mode" != "auto" ]] &&
   [[ "$benchmark_egress_proxy_mode" != "off" ]]; then
@@ -293,7 +306,10 @@ if [[ -n "${SKILLSBENCH_REMOTE_CODEX_BIN:-}" ]]; then
   remote_codex_bin_mode="explicit"
 fi
 exact_host_codex_sandbox_preflight="not_required"
-if [[ "$dry_run" == "false" && "$setup_only_public_preflight" != "1" ]]; then
+if [[ "$local_codex_split_control" == "1" ]]; then
+  remote_codex_bin_mode="split_control_client"
+  exact_host_codex_sandbox_preflight="split_control_not_applicable"
+elif [[ "$dry_run" == "false" && "$setup_only_public_preflight" != "1" ]]; then
   if [[ "$remote_codex_bin" == */* ]]; then
     printf -v remote_codex_probe \
       'test -x %q && %q --version >/dev/null 2>&1' \
@@ -502,6 +518,13 @@ while True:
     threading.Thread(target=pipe, args=(client, upstream), daemon=True).start()
 '
 extra_runner_args=()
+if [[ "$local_codex_split_control" == "1" ]]; then
+  extra_runner_args+=(
+    --local-codex-provider reverse-channel
+    --host-local-acp-codex-exec-preflight
+    --host-local-acp-codex-exec-preflight-attempts 1
+  )
+fi
 if [[ "$codex_cli_goal_thread_prewarm" == "1" ]]; then
   extra_runner_args+=(--codex-cli-goal-thread-prewarm)
 fi
@@ -579,6 +602,23 @@ fi
 
 run_group="skillsbench-codex-cli-goal-xhigh-${safe_task}-${tag}-${stamp}"
 job_name="${safe_task}__codex_cli_goal_xhigh_${tag}_${stamp}"
+codex_channel_id="$(
+  python3 - "$job_name" <<'PY'
+import hashlib
+import sys
+
+print(hashlib.sha256(sys.argv[1].encode("utf-8")).hexdigest()[:16])
+PY
+)"
+codex_remote_socket="/tmp/loopx-codex-${codex_channel_id}.sock"
+codex_remote_client="/tmp/loopx-codex-${codex_channel_id}"
+codex_prompt_bridge_command=$(
+  printf '%q ' ssh "${ssh_command_options[@]}" \
+    "$SKILLSBENCH_SSH_DESTINATION" env
+  printf '%s ' '{loopx_allowed_env}'
+  printf '%q ' bash -lc
+  printf '%s' '{private_bridge_command_sh}'
+)
 if [[ -n "${SKILLSBENCH_LEDGER_CATCHUP_GROUP:-}" ]]; then
   ledger_catchup_group="$SKILLSBENCH_LEDGER_CATCHUP_GROUP"
 elif [[ -n "${SKILLSBENCH_CANONICAL_CASE_IDS_FILE:-}" ]]; then
@@ -621,7 +661,13 @@ remote_command=$(
     --docker-pip-index-mode "$docker_pip_index_mode" \
     --docker-pip-build-mode "$docker_pip_build_mode" \
     --host-local-acp-launch \
-    --local-codex-bin "$remote_codex_bin" \
+    --local-codex-bin
+  if [[ "$local_codex_split_control" == "1" ]]; then
+    printf '%s ' '{codex_bridge_client}'
+  else
+    printf '%q ' "$remote_codex_bin"
+  fi
+  printf '%q ' \
     --local-codex-sandbox "$local_codex_sandbox" \
     --remote-command-file-bridge-probe \
     --run-group-id "$run_group" \
@@ -661,6 +707,17 @@ supervisor_cmd=(
   --public-output-path "${public_dir}/supervisor.public.json"
 )
 
+if [[ "$local_codex_split_control" == "1" ]]; then
+  supervisor_cmd+=(
+    --codex-bridge
+    --codex-bin "$local_codex_bin"
+    --codex-remote-socket "$codex_remote_socket"
+    --codex-remote-client-path "$codex_remote_client"
+    --codex-prompt-bridge-command "$codex_prompt_bridge_command"
+    --codex-participant-sandbox "$local_codex_sandbox"
+  )
+fi
+
 if [[ "$setup_only_public_preflight" != "1" ]]; then
   supervisor_cmd+=(
     --local-run-ledger-path "$local_run_ledger"
@@ -695,6 +752,9 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'docker_proxy_endpoint_mode=%s\n' "$docker_proxy_endpoint_mode"
   printf 'docker_api_version=%s\n' "$docker_api_version"
   printf 'remote_codex_bin_mode=%s\n' "$remote_codex_bin_mode"
+  printf 'local_codex_split_control=%s\n' "$local_codex_split_control"
+  printf 'local_codex_provider=%s\n' \
+    "$([[ "$local_codex_split_control" == "1" ]] && echo reverse_channel || echo exact_host)"
   printf 'runner_profile_loaded=%s\n' "$runner_profile_loaded"
   printf 'runner_profile_path_recorded=false\n'
   printf 'runner_profile_values_recorded=false\n'
@@ -733,12 +793,23 @@ if [[ "$dry_run" == "true" ]]; then
     printf 'standard_aggregate=%s\n' "$standard_aggregate"
   fi
   if [[ "$runner_profile_loaded" == "true" ]] ||
+    [[ "$local_codex_split_control" == "1" ]] ||
     [[ -n "$remote_command_file_bridge_probe_command" ]] ||
     [[ -n "$remote_command_file_bridge_solver_command" ]] ||
     [[ -n "$remote_command_file_bridge_agent_command" ]] ||
     [[ -n "$loopx_turn_validation_command" ]]; then
     printf 'private_runner_command_values_redacted=true\n'
     printf 'private_runner_arg_names='
+    [[ "$local_codex_split_control" == "1" ]] &&
+      printf '%s ' --codex-bridge --codex-bin --codex-remote-socket
+    [[ "$local_codex_split_control" == "1" ]] &&
+      printf '%s ' --codex-remote-client-path --codex-prompt-bridge-command
+    [[ "$local_codex_split_control" == "1" ]] &&
+      printf '%s ' --codex-participant-sandbox
+    [[ "$local_codex_split_control" == "1" ]] &&
+      printf '%s ' --local-codex-provider --host-local-acp-codex-exec-preflight
+    [[ "$local_codex_split_control" == "1" ]] &&
+      printf '%s ' --host-local-acp-codex-exec-preflight-attempts
     [[ -n "$remote_command_file_bridge_probe_command" ]] &&
       printf '%s ' --remote-command-file-bridge-probe-command
     [[ -n "$remote_command_file_bridge_solver_command" ]] &&
@@ -801,6 +872,8 @@ docker_proxy_host=${docker_proxy_host}
 docker_proxy_endpoint_mode=${docker_proxy_endpoint_mode}
 docker_api_version=${docker_api_version}
 remote_codex_bin_mode=${remote_codex_bin_mode}
+local_codex_split_control=${local_codex_split_control}
+local_codex_provider=$([[ "$local_codex_split_control" == "1" ]] && echo reverse_channel || echo exact_host)
 local_codex_sandbox=${local_codex_sandbox}
 codex_cli_goal_thread_prewarm=${codex_cli_goal_thread_prewarm}
 allow_staged_bootstrap_repair_run=${allow_staged_bootstrap_repair_run}

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -2094,6 +2094,8 @@ def install_benchflow_docker_exec_output_capture(
 def _host_local_acp_codex_exec_preflight_command(
     args: argparse.Namespace,
     plan: dict[str, Any],
+    *,
+    sandbox_bridge_command: str | None = None,
 ) -> list[str]:
     local_acp_relay_command = getattr(args, "local_acp_relay_command", None)
     if local_acp_relay_command:
@@ -2160,6 +2162,17 @@ def _host_local_acp_codex_exec_preflight_command(
         )
         if agent_command:
             command.extend(["--remote-command-file-bridge-agent-command", agent_command])
+    if sandbox_bridge_command:
+        command = _set_option_value(
+            command,
+            "--remote-command-file-bridge-command",
+            sandbox_bridge_command,
+        )
+        command = _set_option_value(
+            command,
+            "--remote-command-file-bridge-agent-command",
+            sandbox_bridge_command,
+        )
     return command
 
 
@@ -2168,8 +2181,6 @@ def _host_local_acp_codex_exec_preflight_should_run(
 ) -> bool:
     """Return whether the host-local Codex exec path must be probed first."""
 
-    if bool(getattr(args, "setup_only_public_preflight", False)):
-        return False
     route = str(getattr(args, "route", "") or "")
     local_codex_provider = str(
         getattr(args, "local_codex_provider", "exact-host") or "exact-host"
@@ -2353,6 +2364,8 @@ def _first_bridge_failure_category(bridge_summary: dict[str, Any]) -> str:
 def _run_host_local_acp_codex_exec_preflight(
     args: argparse.Namespace,
     plan: dict[str, Any],
+    *,
+    sandbox_bridge_command: str | None = None,
 ) -> None:
     prerequisites = plan.setdefault("runner_prerequisites", {})
     prerequisites["host_local_acp_codex_exec_preflight_requested"] = True
@@ -2367,7 +2380,11 @@ def _run_host_local_acp_codex_exec_preflight(
         1,
         int(getattr(args, "host_local_acp_codex_exec_preflight_attempts", 1) or 1),
     )
-    command = _host_local_acp_codex_exec_preflight_command(args, plan)
+    command = _host_local_acp_codex_exec_preflight_command(
+        args,
+        plan,
+        sandbox_bridge_command=sandbox_bridge_command,
+    )
     target_env = _host_local_acp_target_env({}, args=args)
     prerequisites["host_local_acp_target_env_forwarded"] = bool(target_env)
     prerequisites["host_local_acp_target_env_key_count"] = len(target_env)
@@ -2747,6 +2764,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "host_local_acp_pwd_probe_exception_type",
         "host_local_acp_pwd_probe_stdout_type",
         "host_local_acp_codex_exec_preflight_status",
+        "host_local_acp_codex_exec_preflight_placement",
         "host_local_acp_codex_exec_preflight_stage",
         "host_local_acp_codex_exec_preflight_first_blocker",
         "host_local_acp_codex_exec_failure_category",
@@ -14134,6 +14152,44 @@ async def run_benchflow_case(
         *verifier_dependency_cache_mounts,
     ]
 
+    async def run_host_local_acp_codex_exec_preflight_after_environment(
+        env: Any,
+    ) -> None:
+        prerequisites = plan.setdefault("runner_prerequisites", {})
+        prerequisites["host_local_acp_codex_exec_preflight_placement"] = (
+            "after_sandbox_setup_before_agent"
+        )
+        sandbox_bridge_command = _host_local_acp_docker_bridge_command(
+            env,
+            args,
+            plan,
+        )
+        if (
+            _host_local_acp_codex_exec_preflight_requires_bridge_action(args)
+            and not sandbox_bridge_command
+        ):
+            prerequisites["host_local_acp_codex_exec_preflight_status"] = "failed"
+            prerequisites["host_local_acp_codex_exec_preflight_ready"] = False
+            prerequisites["host_local_acp_codex_exec_preflight_first_blocker"] = (
+                "skillsbench_host_local_acp_sandbox_bridge_missing_after_setup"
+            )
+            prerequisites["host_local_acp_codex_exec_failure_category"] = (
+                "codex_sandbox_bridge_unavailable"
+            )
+            raise RuntimeError(
+                "host-local ACP sandbox bridge missing after environment setup"
+            )
+        try:
+            await asyncio.to_thread(
+                _run_host_local_acp_codex_exec_preflight,
+                args,
+                plan,
+                sandbox_bridge_command=sandbox_bridge_command,
+            )
+        finally:
+            _write_public_runner_config(plan)
+            _write_public_runner_prerequisites(plan)
+
     async def connect_host_local_acp(
         env: Any,
         agent: str,
@@ -14896,6 +14952,13 @@ async def run_benchflow_case(
     if _is_case_loopx_route(args.route) and not args.host_local_acp_launch:
         if not setup_only_public_preflight:
             pre_agent_hooks.append(seed_product_mode_case_state)
+    if (
+        not setup_only_public_preflight
+        and _host_local_acp_codex_exec_preflight_should_run(args)
+    ):
+        pre_agent_hooks.append(
+            run_host_local_acp_codex_exec_preflight_after_environment
+        )
 
     agent_env: dict[str, str] = {}
     if runtime_mounts:
@@ -15072,6 +15135,11 @@ async def run_benchflow_case(
                 progress_callback=lambda progress: _write_setup_only_public_preflight(
                     plan,
                     progress,
+                ),
+                environment_ready_hook=(
+                    run_host_local_acp_codex_exec_preflight_after_environment
+                    if _host_local_acp_codex_exec_preflight_should_run(args)
+                    else None
                 ),
             )
             plan["setup_only_public_preflight_result"] = setup_only_result
@@ -17440,14 +17508,6 @@ async def _async_main_with_observable_handle(
         finally:
             _write_public_runner_config(plan)
             _write_public_runner_prerequisites(plan)
-
-    if (
-        _host_local_acp_codex_exec_preflight_should_run(args)
-        and args.host_local_acp_launch
-        and not args.reduce_only
-        and not args.setup_only_public_preflight
-    ):
-        _run_host_local_acp_codex_exec_preflight(args, plan)
 
     if not args.reduce_only:
         _write_public_runner_config(plan)

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -2171,10 +2171,19 @@ def _host_local_acp_codex_exec_preflight_should_run(
     if bool(getattr(args, "setup_only_public_preflight", False)):
         return False
     route = str(getattr(args, "route", "") or "")
-    if bool(getattr(args, "host_local_acp_launch", False)) and route in {
-        CODEX_APP_SERVER_GOAL_BASELINE_ROUTE,
-        CODEX_CLI_GOAL_BASELINE_ROUTE,
-    }:
+    local_codex_provider = str(
+        getattr(args, "local_codex_provider", "exact-host") or "exact-host"
+    )
+    if (
+        bool(getattr(args, "host_local_acp_launch", False))
+        and route == CODEX_APP_SERVER_GOAL_BASELINE_ROUTE
+    ):
+        return False
+    if (
+        bool(getattr(args, "host_local_acp_launch", False))
+        and route == CODEX_CLI_GOAL_BASELINE_ROUTE
+        and local_codex_provider != "reverse-channel"
+    ):
         return False
     if bool(getattr(args, "host_local_acp_codex_exec_preflight", False)):
         return True
@@ -2188,10 +2197,19 @@ def _host_local_acp_codex_exec_preflight_should_run(
 def _host_local_acp_codex_exec_preflight_requires_bridge_action(
     args: argparse.Namespace,
 ) -> bool:
+    route = str(getattr(args, "route", "") or "")
+    local_codex_provider = str(
+        getattr(args, "local_codex_provider", "exact-host") or "exact-host"
+    )
     return bool(
         getattr(args, "host_local_acp_launch", False)
-        and str(getattr(args, "route", "") or "")
-        in HOST_LOCAL_BRIDGE_ROUTES
+        and (
+            route in HOST_LOCAL_BRIDGE_ROUTES
+            or (
+                route == CODEX_CLI_GOAL_BASELINE_ROUTE
+                and local_codex_provider == "reverse-channel"
+            )
+        )
         and str(getattr(args, "remote_command_file_bridge_solver_command", "") or "")
         and (
             bool(getattr(args, "remote_command_file_bridge_ready", False))
@@ -9021,6 +9039,9 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         ),
         "run_group_id": str(args.run_group_id or ""),
         "sandbox": args.sandbox,
+        "local_codex_provider": str(
+            getattr(args, "local_codex_provider", "exact-host") or "exact-host"
+        ),
         "docker_apt_source_mode": docker_apt_source_mode,
         "docker_apt_transport_mode": docker_apt_transport_mode,
         "docker_pip_index_mode": args.docker_pip_index_mode,
@@ -9603,6 +9624,7 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
         "app_server_reasoning_effort",
         "app_server_goal_prompt_style",
         "sandbox",
+        "local_codex_provider",
         "docker_apt_source_mode",
         "docker_apt_transport_mode",
         "docker_pip_index_mode",
@@ -16726,6 +16748,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "--local-codex-bin",
         default="codex",
         help="Codex CLI binary for --local-codex-participant-ping.",
+    )
+    parser.add_argument(
+        "--local-codex-provider",
+        choices=("exact-host", "reverse-channel"),
+        default="exact-host",
+        help=(
+            "Structured host placement for Codex. reverse-channel enables the "
+            "fixed pre-agent bridge receipt for split-control launches."
+        ),
     )
     parser.add_argument(
         "--local-codex-sandbox",

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -2134,7 +2134,10 @@ def _host_local_acp_codex_exec_preflight_command(
                 str(Path(relay_trace_dir) / "codex-exec-preflight"),
             ]
         )
-    if _host_local_acp_codex_exec_preflight_requires_bridge_action(args):
+    if _host_local_acp_codex_exec_preflight_requires_bridge_action(
+        args,
+        sandbox_bridge_command=sandbox_bridge_command,
+    ):
         command.extend(
             [
                 "--remote-command-file-bridge-command",
@@ -2207,6 +2210,9 @@ def _host_local_acp_codex_exec_preflight_should_run(
 
 def _host_local_acp_codex_exec_preflight_requires_bridge_action(
     args: argparse.Namespace,
+    *,
+    sandbox_bridge_command: str | None = None,
+    require_materialized_sandbox_bridge: bool = False,
 ) -> bool:
     route = str(getattr(args, "route", "") or "")
     local_codex_provider = str(
@@ -2221,7 +2227,13 @@ def _host_local_acp_codex_exec_preflight_requires_bridge_action(
                 and local_codex_provider == "reverse-channel"
             )
         )
-        and str(getattr(args, "remote_command_file_bridge_solver_command", "") or "")
+        and (
+            require_materialized_sandbox_bridge
+            or bool(sandbox_bridge_command)
+            or str(
+                getattr(args, "remote_command_file_bridge_solver_command", "") or ""
+            )
+        )
         and (
             bool(getattr(args, "remote_command_file_bridge_ready", False))
             or bool(getattr(args, "remote_command_file_bridge_probe", False))
@@ -2371,7 +2383,8 @@ def _run_host_local_acp_codex_exec_preflight(
     prerequisites["host_local_acp_codex_exec_preflight_requested"] = True
     prerequisites["host_local_acp_codex_exec_preflight_status"] = "running"
     bridge_action_required = _host_local_acp_codex_exec_preflight_requires_bridge_action(
-        args
+        args,
+        sandbox_bridge_command=sandbox_bridge_command,
     )
     prerequisites["host_local_acp_codex_exec_preflight_bridge_action_required"] = (
         bridge_action_required
@@ -14165,7 +14178,10 @@ async def run_benchflow_case(
             plan,
         )
         if (
-            _host_local_acp_codex_exec_preflight_requires_bridge_action(args)
+            _host_local_acp_codex_exec_preflight_requires_bridge_action(
+                args,
+                require_materialized_sandbox_bridge=True,
+            )
             and not sandbox_bridge_command
         ):
             prerequisites["host_local_acp_codex_exec_preflight_status"] = "failed"

--- a/scripts/skillsbench_reverse_channel_bridge.py
+++ b/scripts/skillsbench_reverse_channel_bridge.py
@@ -70,9 +70,7 @@ def _send_json_line(sock: socket.socket, payload: dict[str, Any]) -> None:
 
 def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = path.with_name(
-        f"{path.name}.{os.getpid()}.{time.monotonic_ns()}.tmp"
-    )
+    tmp_path = path.with_name(f"{path.name}.{os.getpid()}.{time.monotonic_ns()}.tmp")
     tmp_path.write_text(
         json.dumps(payload, separators=(",", ":"), sort_keys=True),
         encoding="utf-8",
@@ -439,7 +437,13 @@ complete_record["stdout_bytes"] = len((proc.stdout or "").encode("utf-8"))
 complete_record["stderr_bytes"] = len((proc.stderr or "").encode("utf-8"))
 if proc.returncode != 0:
     stderr_text = proc.stderr or ""
-    if int(proc.returncode) < 0:
+    category_match = re.search(
+        r"LOOPX_PROMPT_BRIDGE_FAILURE_CATEGORY=([a-z0-9_]+)",
+        stderr_text,
+    )
+    if category_match:
+        complete_record["failure_category"] = category_match.group(1)
+    elif int(proc.returncode) < 0:
         complete_record["failure_category"] = "bridge_operation_interrupted"
         complete_record["interrupted"] = True
         complete_record["controller_interrupted"] = True
@@ -459,6 +463,111 @@ raise SystemExit(proc.returncode)
     wrapper_path.write_text(script, encoding="utf-8")
     wrapper_path.chmod(0o700)
     return wrapper_path, summary_path
+
+
+def _run_prompt_bridge_broker_payload(
+    payload: dict[str, Any],
+    *,
+    bridge_command: str,
+    private_bridge_command: str,
+    default_timeout_sec: float,
+    stop_event: threading.Event,
+) -> dict[str, Any]:
+    """Execute a Codex-requested bridge outside the Codex sandbox."""
+
+    stdin_text = str(payload.get("stdin") or "")
+    broker_payload = dict(payload)
+    broker_payload["private_bridge_command"] = private_bridge_command
+    command = _bridge_command_with_payload_env(bridge_command, broker_payload)
+    env = _safe_env(payload.get("env"))
+    proc = subprocess.Popen(
+        command,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        shell=True,
+        env=env,
+        start_new_session=True,
+    )
+    _write_process_stdin_async(proc, stdin_text)
+    deadline = time.monotonic() + max(1.0, float(default_timeout_sec))
+    interrupted = False
+    while proc.poll() is None:
+        if stop_event.is_set() or time.monotonic() >= deadline:
+            interrupted = True
+            _stop_process_group(proc, sig=signal.SIGTERM)
+            break
+        time.sleep(0.05)
+    if interrupted:
+        stdout_text, stderr_text = _communicate_after_stop(proc)
+        return {
+            "schema_version": SERVER_RESPONSE_SCHEMA_VERSION,
+            "exit_code": 124,
+            "stdout": stdout_text,
+            "stderr": stderr_text or "prompt bridge broker interrupted\n",
+            "raw_stdout_recorded": False,
+            "raw_stderr_recorded": False,
+            "credential_values_recorded": False,
+        }
+    stdout_text, stderr_text = proc.communicate()
+    failure_category = ""
+    if proc.returncode != 0:
+        if "PermissionError" in stderr_text or "Operation not permitted" in stderr_text:
+            failure_category = "bridge_client_permission_error"
+        elif "No such file or directory" in stderr_text:
+            failure_category = "bridge_command_not_found"
+        elif proc.returncode == 255 and command.lstrip().startswith("ssh "):
+            failure_category = "bridge_ssh_unavailable"
+        else:
+            failure_category = "bridge_command_failed"
+    public_stderr = stderr_text or ""
+    if failure_category:
+        public_stderr = (
+            f"LOOPX_PROMPT_BRIDGE_FAILURE_CATEGORY={failure_category}\n{public_stderr}"
+        )
+    return {
+        "schema_version": SERVER_RESPONSE_SCHEMA_VERSION,
+        "exit_code": int(proc.returncode),
+        "stdout": stdout_text or "",
+        "stderr": public_stderr,
+        "raw_stdout_recorded": False,
+        "raw_stderr_recorded": False,
+        "credential_values_recorded": False,
+    }
+
+
+def _start_prompt_bridge_broker(
+    *,
+    local_cwd: Path,
+    bridge_command: str,
+    private_bridge_command: str,
+    default_timeout_sec: float,
+) -> tuple[Path, threading.Event, threading.Thread]:
+    queue_dir = local_cwd / ".loopx-prompt-bridge-broker"
+    client_path = local_cwd / "loopx-host-prompt-bridge"
+    _write_json_file_client(str(queue_dir), client_path)
+    stop_event = threading.Event()
+    thread = threading.Thread(
+        target=_serve_json_file_queue,
+        kwargs={
+            "queue_dir": queue_dir,
+            "once": False,
+            "poll_interval_sec": 0.02,
+            "handler": lambda payload: _run_prompt_bridge_broker_payload(
+                payload,
+                bridge_command=bridge_command,
+                private_bridge_command=private_bridge_command,
+                default_timeout_sec=default_timeout_sec,
+                stop_event=stop_event,
+            ),
+            "stop_event": stop_event,
+        },
+        name="loopx-prompt-bridge-broker",
+        daemon=True,
+    )
+    thread.start()
+    return client_path, stop_event, thread
 
 
 def _run_codex_payload(
@@ -493,14 +602,24 @@ def _run_codex_payload(
             if isinstance(payload_stdin, str) and payload_stdin:
                 stdin_prompt = payload_stdin
         agent_operations_summary_path: Path | None = None
+        prompt_bridge_stop_event: threading.Event | None = None
+        prompt_bridge_thread: threading.Thread | None = None
         if prompt_bridge_command and stdin_prompt is not None:
             private_bridge_command = _extract_private_bridge_command(stdin_prompt)
             if private_bridge_command:
+                broker_client, prompt_bridge_stop_event, prompt_bridge_thread = (
+                    _start_prompt_bridge_broker(
+                        local_cwd=local_cwd,
+                        bridge_command=prompt_bridge_command,
+                        private_bridge_command=private_bridge_command,
+                        default_timeout_sec=timeout,
+                    )
+                )
                 instrumented_bridge, agent_operations_summary_path = (
                     _write_instrumented_prompt_bridge(
                         tmp_path=tmp_path,
-                        bridge_command=prompt_bridge_command,
-                        private_bridge_command=private_bridge_command,
+                        bridge_command=shlex.quote(str(broker_client)),
+                        private_bridge_command=None,
                     )
                 )
                 stdin_prompt = _rewrite_private_bridge_command(
@@ -511,7 +630,9 @@ def _run_codex_payload(
         try:
             proc = subprocess.Popen(
                 cmd,
-                stdin=subprocess.PIPE if stdin_prompt is not None else subprocess.DEVNULL,
+                stdin=subprocess.PIPE
+                if stdin_prompt is not None
+                else subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
@@ -527,9 +648,9 @@ def _run_codex_payload(
                 and first_action_timeout_sec > 0
                 and _prompt_requires_bridge_first_action(stdin_prompt)
             ):
-                first_action_deadline = (
-                    time.monotonic() + max(1.0, float(first_action_timeout_sec))
-            )
+                first_action_deadline = time.monotonic() + max(
+                    1.0, float(first_action_timeout_sec)
+                )
             first_action_seen = not bool(first_action_deadline)
             bridge_idle_timeout_sec = max(0.0, float(bridge_idle_timeout_sec or 0.0))
             bridge_activity_seen = False
@@ -552,7 +673,11 @@ def _run_codex_payload(
                         first_action_seen = True
                     elif not first_action_seen and current_agent_operations_size > 0:
                         first_action_seen = True
-                if not first_action_seen and first_action_deadline and now >= first_action_deadline:
+                if (
+                    not first_action_seen
+                    and first_action_deadline
+                    and now >= first_action_deadline
+                ):
                     timeout_kind = "codex_exec_first_action_timeout"
                     _stop_process_group(proc, sig=signal.SIGTERM)
                     break
@@ -627,6 +752,11 @@ def _run_codex_payload(
                 "raw_task_text_recorded": False,
                 "credential_values_recorded": False,
             }
+        finally:
+            if prompt_bridge_stop_event is not None:
+                prompt_bridge_stop_event.set()
+            if prompt_bridge_thread is not None:
+                prompt_bridge_thread.join(timeout=5)
 
 
 def _run_json_bridge_payload(
@@ -761,6 +891,7 @@ def _serve_json_file_queue(
     once: bool,
     poll_interval_sec: float,
     handler: Any,
+    stop_event: threading.Event | None = None,
 ) -> int:
     requests_dir = queue_dir / "requests"
     processing_dir = queue_dir / "processing"
@@ -769,7 +900,7 @@ def _serve_json_file_queue(
     processing_dir.mkdir(parents=True, exist_ok=True)
     responses_dir.mkdir(parents=True, exist_ok=True)
     poll_interval_sec = max(0.01, float(poll_interval_sec or 0.05))
-    while True:
+    while stop_event is None or not stop_event.is_set():
         for request_path in sorted(requests_dir.glob("*.json")):
             processing_path = processing_dir / request_path.name
             try:
@@ -812,7 +943,11 @@ def _serve_json_file_queue(
                     pass
             if once:
                 return 0
-        time.sleep(poll_interval_sec)
+        if stop_event is None:
+            time.sleep(poll_interval_sec)
+        else:
+            stop_event.wait(poll_interval_sec)
+    return 0
 
 
 def _write_codex_client(socket_path: str, output_path: Path) -> None:
@@ -1123,7 +1258,12 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps({"ok": True, "kind": args.kind, "raw_path_recorded": False}))
         return 0
     if args.command == "probe-socket":
-        print(json.dumps(_probe_socket(Path(args.socket), timeout_sec=args.timeout_sec), sort_keys=True))
+        print(
+            json.dumps(
+                _probe_socket(Path(args.socket), timeout_sec=args.timeout_sec),
+                sort_keys=True,
+            )
+        )
         return 0
     return 2
 

--- a/scripts/skillsbench_reverse_channel_bridge.py
+++ b/scripts/skillsbench_reverse_channel_bridge.py
@@ -63,6 +63,17 @@ ALLOWED_PAYLOAD_ENV_KEYS = (
     "LOOPX_REMOTE_AGENT_OPS_SUMMARY_PATH",
 )
 
+_BRIDGE_GUARD_NAMESPACE: dict[str, Any] = {
+    "re": re,
+    "shlex": shlex,
+    "sys": sys,
+}
+# The generated sandbox wrapper and the host broker must apply the exact same
+# command parser. Load the trusted in-repo source once instead of duplicating it.
+exec(LOOPX_COMMAND_INSTRUMENTATION_SOURCE, _BRIDGE_GUARD_NAMESPACE)
+_loopx_invocation_count = _BRIDGE_GUARD_NAMESPACE["loopx_invocation_count"]
+_loopx_subcommands = _BRIDGE_GUARD_NAMESPACE["loopx_subcommands"]
+
 
 def _send_json_line(sock: socket.socket, payload: dict[str, Any]) -> None:
     sock.sendall(json.dumps(payload, separators=(",", ":")).encode() + b"\n")
@@ -321,148 +332,64 @@ def _split_codex_exec_prompt_for_stdin(args: list[str]) -> tuple[list[str], str 
     return args[:prompt_index] + args[prompt_index + 1 :], prompt
 
 
-def _write_instrumented_prompt_bridge(
-    *,
-    tmp_path: Path,
-    bridge_command: str,
-    private_bridge_command: str | None,
-) -> tuple[Path, Path]:
-    """Wrap a local prompt bridge and emit public-safe agent operation records."""
-
-    wrapper_path = tmp_path / "loopx-local-prompt-bridge"
-    summary_path = tmp_path / "agent-bridge-ops.jsonl"
-    script = f"""#!/usr/bin/env python3
-from __future__ import annotations
-
-import json
-import os
-import re
-import shlex
-import subprocess
-import sys
-from pathlib import Path
-
-SUMMARY_PATH = Path({str(summary_path)!r})
-BRIDGE_COMMAND_TEMPLATE = {bridge_command!r}
-PRIVATE_BRIDGE_COMMAND = {private_bridge_command!r}
-
-def allowed_env_assignments() -> str:
-    keys = (
-        "AI_ADDR",
-        "AI_PORT",
-        "GOAL_HARNESS_REMOTE_BENCH_ROOT",
-        "LOOPX_REMOTE_AGENT_OPS_SUMMARY_PATH",
-    )
-    return " ".join(
-        f"{{key}}={{shlex.quote(os.environ.get(key, ''))}}"
-        for key in keys
-        if os.environ.get(key)
-    )
-
-def bridge_command() -> str:
-    command = BRIDGE_COMMAND_TEMPLATE
-    private_bridge = PRIVATE_BRIDGE_COMMAND or ""
-    command = command.replace("{{private_bridge_command}}", private_bridge)
-    command = command.replace(
-        "{{private_bridge_command_sh}}",
-        shlex.quote(private_bridge),
-    )
-    command = command.replace("{{loopx_allowed_env}}", allowed_env_assignments())
-    return command
-
-{LOOPX_COMMAND_INSTRUMENTATION_SOURCE}
-
-raw = sys.stdin.read()
-record: dict[str, object] = {{
-    "schema_version": "skillsbench_remote_bridge_agent_operation_v0",
-    "raw_request_recorded": False,
-    "raw_stdout_recorded": False,
-    "raw_stderr_recorded": False,
-    "raw_task_text_recorded": False,
-    "credential_values_recorded": False,
-    "host_paths_recorded": False,
-    "remote_paths_recorded": False,
-}}
-try:
-    payload = json.loads(raw)
-except Exception:
-    payload = {{}}
-operation = payload.get("operation") if isinstance(payload, dict) else ""
-record["operation"] = operation if isinstance(operation, str) else "unknown"
-subcommands: list[str] = []
-loopx_invocations = 0
-if isinstance(payload, dict) and payload.get("operation") == "exec":
-    command_text = payload.get("command")
-    if isinstance(command_text, str):
-        loopx_invocations = loopx_invocation_count(command_text)
-        subcommands = loopx_subcommands(command_text)
-record["loopx_invocation_count"] = loopx_invocations
-record["loopx_cli_call"] = loopx_invocations > 0
-record["loopx_subcommands"] = subcommands[:2]
-record["loopx_state_read"] = subcommands[:2] in (["start-goal"], ["quota", "should-run"], ["status"], ["diagnose"])
-record["loopx_state_write"] = bool(subcommands and (
-    subcommands[0] in {{"todo", "refresh-state"}}
-    or subcommands[:2] == ["quota", "spend-slot"]
-))
-record["task_facing_operation"] = bool(
-    operation in {{"read_file", "write_file", "cleanup"}}
-    or (operation == "exec" and loopx_invocations == 0)
-)
-record["operation_observed"] = True
-
-def append_record(item: dict[str, object]) -> None:
+def _append_agent_operation_record(
+    summary_path: Path,
+    record: dict[str, Any],
+) -> None:
     try:
-        SUMMARY_PATH.parent.mkdir(parents=True, exist_ok=True)
-        with SUMMARY_PATH.open("a", encoding="utf-8") as fh:
-            fh.write(json.dumps(item, sort_keys=True) + "\\n")
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        with summary_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
     except OSError:
         pass
 
-record["record_phase"] = "start"
-append_record(record)
-enforce_single_loopx_invocation(loopx_invocations, record, append_record)
-proc = subprocess.run(
-    bridge_command(),
-    input=raw,
-    text=True,
-    stdout=subprocess.PIPE,
-    stderr=subprocess.PIPE,
-    shell=True,
-)
-complete_record = dict(record)
-complete_record["record_phase"] = "complete"
-complete_record["returncode"] = int(proc.returncode)
-complete_record["success"] = proc.returncode == 0
-complete_record["stdout_bytes"] = len((proc.stdout or "").encode("utf-8"))
-complete_record["stderr_bytes"] = len((proc.stderr or "").encode("utf-8"))
-if proc.returncode != 0:
-    stderr_text = proc.stderr or ""
-    category_match = re.search(
-        r"LOOPX_PROMPT_BRIDGE_FAILURE_CATEGORY=([a-z0-9_]+)",
-        stderr_text,
-    )
-    if category_match:
-        complete_record["failure_category"] = category_match.group(1)
-    elif int(proc.returncode) < 0:
-        complete_record["failure_category"] = "bridge_operation_interrupted"
-        complete_record["interrupted"] = True
-        complete_record["controller_interrupted"] = True
-    elif "PermissionError" in stderr_text or "Operation not permitted" in stderr_text:
-        complete_record["failure_category"] = "bridge_client_permission_error"
-    elif "No such file or directory" in stderr_text:
-        complete_record["failure_category"] = "bridge_command_not_found"
-    elif proc.returncode == 255 and bridge_command().lstrip().startswith("ssh "):
-        complete_record["failure_category"] = "bridge_ssh_unavailable"
-    else:
-        complete_record["failure_category"] = "bridge_command_failed"
-append_record(complete_record)
-sys.stdout.write(proc.stdout)
-sys.stderr.write(proc.stderr)
-raise SystemExit(proc.returncode)
-"""
-    wrapper_path.write_text(script, encoding="utf-8")
-    wrapper_path.chmod(0o700)
-    return wrapper_path, summary_path
+
+def _agent_operation_record(stdin_text: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(stdin_text)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        payload = {}
+    operation = payload.get("operation") if isinstance(payload, dict) else ""
+    subcommands: list[str] = []
+    loopx_invocations = 0
+    if isinstance(payload, dict) and operation == "exec":
+        command_text = payload.get("command")
+        if isinstance(command_text, str):
+            loopx_invocations = int(_loopx_invocation_count(command_text))
+            subcommands = list(_loopx_subcommands(command_text))
+    return {
+        "schema_version": "skillsbench_remote_bridge_agent_operation_v0",
+        "operation": operation if isinstance(operation, str) else "unknown",
+        "loopx_invocation_count": loopx_invocations,
+        "loopx_cli_call": loopx_invocations > 0,
+        "loopx_subcommands": subcommands[:2],
+        "loopx_state_read": subcommands[:2]
+        in (
+            ["start-goal"],
+            ["quota", "should-run"],
+            ["status"],
+            ["diagnose"],
+        ),
+        "loopx_state_write": bool(
+            subcommands
+            and (
+                subcommands[0] in {"todo", "refresh-state"}
+                or subcommands[:2] == ["quota", "spend-slot"]
+            )
+        ),
+        "task_facing_operation": bool(
+            operation in {"read_file", "write_file", "cleanup"}
+            or (operation == "exec" and loopx_invocations == 0)
+        ),
+        "operation_observed": True,
+        "raw_request_recorded": False,
+        "raw_stdout_recorded": False,
+        "raw_stderr_recorded": False,
+        "raw_task_text_recorded": False,
+        "credential_values_recorded": False,
+        "host_paths_recorded": False,
+        "remote_paths_recorded": False,
+    }
 
 
 def _run_prompt_bridge_broker_payload(
@@ -472,10 +399,43 @@ def _run_prompt_bridge_broker_payload(
     private_bridge_command: str,
     default_timeout_sec: float,
     stop_event: threading.Event,
+    summary_path: Path,
 ) -> dict[str, Any]:
     """Execute a Codex-requested bridge outside the Codex sandbox."""
 
     stdin_text = str(payload.get("stdin") or "")
+    operation_record = _agent_operation_record(stdin_text)
+    operation_record["record_phase"] = "start"
+    _append_agent_operation_record(summary_path, operation_record)
+    if int(operation_record["loopx_invocation_count"]) > 1:
+        stderr_text = (
+            "bridge request rejected: send exactly one LoopX CLI command per "
+            "operation=exec request\n"
+        )
+        complete_record = dict(operation_record)
+        complete_record.update(
+            {
+                "record_phase": "complete",
+                "returncode": 2,
+                "success": False,
+                "stdout_bytes": 0,
+                "stderr_bytes": len(stderr_text.encode("utf-8")),
+                "failure_category": (
+                    "multiple_loopx_commands_per_bridge_request"
+                ),
+            }
+        )
+        _append_agent_operation_record(summary_path, complete_record)
+        return {
+            "schema_version": SERVER_RESPONSE_SCHEMA_VERSION,
+            "exit_code": 2,
+            "stdout": "",
+            "stderr": stderr_text,
+            "raw_stdout_recorded": False,
+            "raw_stderr_recorded": False,
+            "credential_values_recorded": False,
+        }
+
     broker_payload = dict(payload)
     broker_payload["private_bridge_command"] = private_bridge_command
     command = _bridge_command_with_payload_env(bridge_command, broker_payload)
@@ -501,6 +461,20 @@ def _run_prompt_bridge_broker_payload(
         time.sleep(0.05)
     if interrupted:
         stdout_text, stderr_text = _communicate_after_stop(proc)
+        complete_record = dict(operation_record)
+        complete_record.update(
+            {
+                "record_phase": "complete",
+                "returncode": 124,
+                "success": False,
+                "stdout_bytes": len(stdout_text.encode("utf-8")),
+                "stderr_bytes": len(stderr_text.encode("utf-8")),
+                "failure_category": "bridge_operation_interrupted",
+                "interrupted": True,
+                "controller_interrupted": True,
+            }
+        )
+        _append_agent_operation_record(summary_path, complete_record)
         return {
             "schema_version": SERVER_RESPONSE_SCHEMA_VERSION,
             "exit_code": 124,
@@ -521,6 +495,19 @@ def _run_prompt_bridge_broker_payload(
             failure_category = "bridge_ssh_unavailable"
         else:
             failure_category = "bridge_command_failed"
+    complete_record = dict(operation_record)
+    complete_record.update(
+        {
+            "record_phase": "complete",
+            "returncode": int(proc.returncode),
+            "success": proc.returncode == 0,
+            "stdout_bytes": len((stdout_text or "").encode("utf-8")),
+            "stderr_bytes": len((stderr_text or "").encode("utf-8")),
+        }
+    )
+    if failure_category:
+        complete_record["failure_category"] = failure_category
+    _append_agent_operation_record(summary_path, complete_record)
     public_stderr = stderr_text or ""
     if failure_category:
         public_stderr = (
@@ -543,9 +530,10 @@ def _start_prompt_bridge_broker(
     bridge_command: str,
     private_bridge_command: str,
     default_timeout_sec: float,
+    summary_path: Path,
 ) -> tuple[Path, threading.Event, threading.Thread]:
     queue_dir = local_cwd / ".loopx-prompt-bridge-broker"
-    client_path = local_cwd / "loopx-host-prompt-bridge"
+    client_path = local_cwd / "loopx-local-prompt-bridge"
     _write_json_file_client(str(queue_dir), client_path)
     stop_event = threading.Event()
     thread = threading.Thread(
@@ -560,6 +548,7 @@ def _start_prompt_bridge_broker(
                 private_bridge_command=private_bridge_command,
                 default_timeout_sec=default_timeout_sec,
                 stop_event=stop_event,
+                summary_path=summary_path,
             ),
             "stop_event": stop_event,
         },
@@ -607,24 +596,19 @@ def _run_codex_payload(
         if prompt_bridge_command and stdin_prompt is not None:
             private_bridge_command = _extract_private_bridge_command(stdin_prompt)
             if private_bridge_command:
+                agent_operations_summary_path = tmp_path / "agent-bridge-ops.jsonl"
                 broker_client, prompt_bridge_stop_event, prompt_bridge_thread = (
                     _start_prompt_bridge_broker(
                         local_cwd=local_cwd,
                         bridge_command=prompt_bridge_command,
                         private_bridge_command=private_bridge_command,
                         default_timeout_sec=timeout,
-                    )
-                )
-                instrumented_bridge, agent_operations_summary_path = (
-                    _write_instrumented_prompt_bridge(
-                        tmp_path=tmp_path,
-                        bridge_command=shlex.quote(str(broker_client)),
-                        private_bridge_command=None,
+                        summary_path=agent_operations_summary_path,
                     )
                 )
                 stdin_prompt = _rewrite_private_bridge_command(
                     stdin_prompt,
-                    str(instrumented_bridge),
+                    str(broker_client),
                 )
         cmd = [codex_bin, *args]
         try:

--- a/scripts/skillsbench_reverse_tunnel_supervisor.py
+++ b/scripts/skillsbench_reverse_tunnel_supervisor.py
@@ -123,6 +123,35 @@ def _json_bridge_requested(args: argparse.Namespace) -> bool:
     )
 
 
+def _codex_bridge_requested(args: argparse.Namespace) -> bool:
+    return bool(
+        args.codex_bridge
+        or args.codex_remote_socket
+        or args.codex_remote_client_path
+        or args.codex_prompt_bridge_command
+    )
+
+
+def _codex_bridge_public_contract(args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        "enabled": _codex_bridge_requested(args),
+        "server_started": False,
+        "local_socket_ready": False,
+        "reverse_socket_forward_requested": bool(args.codex_remote_socket),
+        "remote_socket_ready": False,
+        "remote_client_materialized": False,
+        "participant_probe_requested": bool(args.codex_participant_sandbox),
+        "participant_probe_passed": False,
+        "participant_sandbox": args.codex_participant_sandbox or "not_requested",
+        "raw_codex_command_recorded": False,
+        "raw_prompt_bridge_command_recorded": False,
+        "raw_socket_paths_recorded": False,
+        "raw_client_path_recorded": False,
+        "raw_probe_output_recorded": False,
+        "remote_socket_cleanup": _remote_codex_socket_cleanup_public_contract(args),
+    }
+
+
 def _json_bridge_public_contract(args: argparse.Namespace) -> dict[str, Any]:
     return {
         "enabled": _json_bridge_requested(args),
@@ -155,6 +184,15 @@ def _resolved_json_local_socket(
     if args.json_local_socket:
         return Path(args.json_local_socket).expanduser()
     return runtime_dir / "json-bridge.sock"
+
+
+def _resolved_codex_local_socket(
+    args: argparse.Namespace,
+    runtime_dir: Path,
+) -> Path:
+    if args.codex_local_socket:
+        return Path(args.codex_local_socket).expanduser()
+    return runtime_dir / "codex-bridge.sock"
 
 
 def _cleanup_stale_local_forward(args: argparse.Namespace) -> dict[str, Any]:
@@ -234,13 +272,62 @@ def _start_json_bridge_server(
     )
 
 
-def _probe_local_json_socket(args: argparse.Namespace, socket_path: Path) -> bool:
-    deadline = time.monotonic() + max(1.0, float(args.json_socket_ready_timeout_sec))
+def _start_codex_bridge_server(
+    args: argparse.Namespace,
+    *,
+    socket_path: Path,
+) -> subprocess.Popen[Any]:
+    command = [
+        sys.executable,
+        str(BRIDGE_HELPER),
+        "serve-codex",
+        "--socket",
+        str(socket_path),
+        "--codex-bin",
+        args.codex_bin,
+        "--timeout-sec",
+        str(max(1.0, float(args.codex_server_timeout_sec))),
+        "--first-action-timeout-sec",
+        str(max(0.0, float(args.codex_first_action_timeout_sec))),
+        "--bridge-idle-timeout-sec",
+        str(max(0.0, float(args.codex_bridge_idle_timeout_sec))),
+    ]
+    if args.codex_prompt_bridge_command:
+        command.extend(["--prompt-bridge-command", args.codex_prompt_bridge_command])
+    return subprocess.Popen(
+        command,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        start_new_session=True,
+    )
+
+
+def _probe_local_socket(
+    socket_path: Path, *, timeout_sec: float, interval_sec: float
+) -> bool:
+    deadline = time.monotonic() + max(1.0, float(timeout_sec))
     while time.monotonic() < deadline:
         if socket_path.exists():
             return True
-        time.sleep(max(0.05, float(args.probe_interval_sec)))
+        time.sleep(max(0.05, float(interval_sec)))
     return False
+
+
+def _probe_local_json_socket(args: argparse.Namespace, socket_path: Path) -> bool:
+    return _probe_local_socket(
+        socket_path,
+        timeout_sec=args.json_socket_ready_timeout_sec,
+        interval_sec=args.probe_interval_sec,
+    )
+
+
+def _probe_local_codex_socket(args: argparse.Namespace, socket_path: Path) -> bool:
+    return _probe_local_socket(
+        socket_path,
+        timeout_sec=args.codex_socket_ready_timeout_sec,
+        interval_sec=args.probe_interval_sec,
+    )
 
 
 def _run_remote_shell_command(
@@ -272,6 +359,31 @@ def _probe_remote_json_socket(args: argparse.Namespace) -> bool:
     return proc.returncode == 0
 
 
+def _probe_remote_codex_socket(args: argparse.Namespace) -> bool:
+    command = "test -S " + shlex.quote(args.codex_remote_socket)
+    try:
+        proc = _run_remote_shell_command(
+            args,
+            command,
+            timeout_sec=args.codex_socket_ready_timeout_sec,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return proc.returncode == 0
+
+
+def _remote_codex_socket_cleanup_public_contract(
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    return {
+        "requested": bool(_codex_bridge_requested(args) and args.codex_remote_socket),
+        "attempted": False,
+        "ok": False,
+        "raw_socket_paths_recorded": False,
+        "raw_output_recorded": False,
+    }
+
+
 def _remote_json_socket_cleanup_public_contract(
     args: argparse.Namespace,
 ) -> dict[str, Any]:
@@ -284,12 +396,17 @@ def _remote_json_socket_cleanup_public_contract(
     }
 
 
-def _cleanup_remote_json_socket(args: argparse.Namespace) -> dict[str, Any]:
-    payload = _remote_json_socket_cleanup_public_contract(args)
+def _cleanup_remote_socket(
+    args: argparse.Namespace,
+    *,
+    socket_path: str,
+    payload: dict[str, Any],
+    blocker_prefix: str,
+) -> dict[str, Any]:
     if not payload["requested"]:
         return payload
     payload["attempted"] = True
-    command = "rm -f -- " + shlex.quote(args.json_remote_socket)
+    command = "rm -f -- " + shlex.quote(socket_path)
     try:
         proc = _run_remote_shell_command(
             args,
@@ -297,24 +414,47 @@ def _cleanup_remote_json_socket(args: argparse.Namespace) -> dict[str, Any]:
             timeout_sec=args.remote_setup_timeout_sec,
         )
     except subprocess.TimeoutExpired:
-        payload["first_blocker"] = "json_bridge_remote_socket_cleanup_timeout"
+        payload["first_blocker"] = f"{blocker_prefix}_timeout"
         return payload
     except OSError:
-        payload["first_blocker"] = "json_bridge_remote_socket_cleanup_launch_failed"
+        payload["first_blocker"] = f"{blocker_prefix}_launch_failed"
         return payload
     payload["exit_code"] = proc.returncode
     payload["stdout_size_bucket"] = _size_bucket(proc.stdout or "")
     payload["stderr_size_bucket"] = _size_bucket(proc.stderr or "")
     payload["ok"] = proc.returncode == 0
     if proc.returncode != 0:
-        payload["first_blocker"] = "json_bridge_remote_socket_cleanup_exit_nonzero"
+        payload["first_blocker"] = f"{blocker_prefix}_exit_nonzero"
     return payload
 
 
-def _materialize_remote_json_client(
-    args: argparse.Namespace, runtime_dir: Path
+def _cleanup_remote_codex_socket(args: argparse.Namespace) -> dict[str, Any]:
+    return _cleanup_remote_socket(
+        args,
+        socket_path=args.codex_remote_socket,
+        payload=_remote_codex_socket_cleanup_public_contract(args),
+        blocker_prefix="codex_bridge_remote_socket_cleanup",
+    )
+
+
+def _cleanup_remote_json_socket(args: argparse.Namespace) -> dict[str, Any]:
+    return _cleanup_remote_socket(
+        args,
+        socket_path=args.json_remote_socket,
+        payload=_remote_json_socket_cleanup_public_contract(args),
+        blocker_prefix="json_bridge_remote_socket_cleanup",
+    )
+
+
+def _materialize_remote_bridge_client(
+    args: argparse.Namespace,
+    runtime_dir: Path,
+    *,
+    kind: str,
+    remote_socket: str,
+    remote_path: str,
 ) -> bool:
-    local_client = runtime_dir / "json-bridge-client"
+    local_client = runtime_dir / f"{kind}-bridge-client"
     try:
         subprocess.run(
             [
@@ -322,9 +462,9 @@ def _materialize_remote_json_client(
                 str(BRIDGE_HELPER),
                 "write-client",
                 "--kind",
-                "json",
+                kind,
                 "--socket",
-                args.json_remote_socket,
+                remote_socket,
                 "--output",
                 str(local_client),
             ],
@@ -335,7 +475,6 @@ def _materialize_remote_json_client(
             check=True,
         )
         client_text = local_client.read_text(encoding="utf-8")
-        remote_path = args.json_remote_client_path
         remote_parent = os.path.dirname(remote_path) or "."
         remote_command = (
             "umask 077; mkdir -p "
@@ -359,8 +498,80 @@ def _materialize_remote_json_client(
     return proc.returncode == 0
 
 
+def _materialize_remote_json_client(
+    args: argparse.Namespace, runtime_dir: Path
+) -> bool:
+    return _materialize_remote_bridge_client(
+        args,
+        runtime_dir,
+        kind="json",
+        remote_socket=args.json_remote_socket,
+        remote_path=args.json_remote_client_path,
+    )
+
+
+def _materialize_remote_codex_client(
+    args: argparse.Namespace, runtime_dir: Path
+) -> bool:
+    return _materialize_remote_bridge_client(
+        args,
+        runtime_dir,
+        kind="codex",
+        remote_socket=args.codex_remote_socket,
+        remote_path=args.codex_remote_client_path,
+    )
+
+
+def _probe_remote_codex_participant(args: argparse.Namespace) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "requested": bool(args.codex_participant_sandbox),
+        "passed": False,
+        "sandbox": args.codex_participant_sandbox or "not_requested",
+        "raw_output_recorded": False,
+        "raw_command_recorded": False,
+        "raw_paths_recorded": False,
+        "credential_values_recorded": False,
+    }
+    if not payload["requested"]:
+        return payload
+    command = " ".join(
+        [
+            shlex.quote(args.codex_remote_client_path),
+            "sandbox",
+            "-c",
+            shlex.quote(f'sandbox_mode="{args.codex_participant_sandbox}"'),
+            "--",
+            "true",
+            ">/dev/null",
+            "2>&1",
+        ]
+    )
+    try:
+        proc = _run_remote_shell_command(
+            args,
+            command,
+            timeout_sec=args.codex_participant_probe_timeout_sec,
+        )
+    except subprocess.TimeoutExpired:
+        payload["first_blocker"] = "codex_bridge_participant_probe_timeout"
+        return payload
+    except OSError:
+        payload["first_blocker"] = "codex_bridge_participant_probe_launch_failed"
+        return payload
+    payload["exit_code"] = proc.returncode
+    payload["passed"] = proc.returncode == 0
+    if proc.returncode != 0:
+        payload["first_blocker"] = "codex_bridge_participant_probe_exit_nonzero"
+    return payload
+
+
 def _render_remote_command(args: argparse.Namespace) -> str:
     command = args.remote_command
+    if _codex_bridge_requested(args):
+        command = command.replace(
+            "{codex_bridge_client}",
+            shlex.quote(args.codex_remote_client_path),
+        )
     if _json_bridge_requested(args):
         command = command.replace(
             "{json_bridge_client}",
@@ -393,6 +604,7 @@ def _tunnel_command(
     args: argparse.Namespace,
     *,
     json_local_socket: Path | None = None,
+    codex_local_socket: Path | None = None,
 ) -> list[str]:
     keepalive = max(1, int(args.keepalive_interval_sec))
     remote_keepalive = (
@@ -411,6 +623,15 @@ def _tunnel_command(
                 "StreamLocalBindUnlink=yes",
                 "-R",
                 f"{args.json_remote_socket}:{json_local_socket}",
+            ]
+        )
+    if _codex_bridge_requested(args) and codex_local_socket is not None:
+        command.extend(
+            [
+                "-o",
+                "StreamLocalBindUnlink=yes",
+                "-R",
+                f"{args.codex_remote_socket}:{codex_local_socket}",
             ]
         )
     command.extend(
@@ -507,9 +728,14 @@ def _start_tunnel_process(
     args: argparse.Namespace,
     *,
     json_local_socket: Path | None = None,
+    codex_local_socket: Path | None = None,
 ) -> subprocess.Popen[Any]:
     return subprocess.Popen(
-        _tunnel_command(args, json_local_socket=json_local_socket),
+        _tunnel_command(
+            args,
+            json_local_socket=json_local_socket,
+            codex_local_socket=codex_local_socket,
+        ),
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         text=True,
@@ -1008,6 +1234,7 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         "private_log_written": False,
         "remote_forward": _forward_public_contract(args.remote_forward),
         "json_bridge": _json_bridge_public_contract(args),
+        "codex_bridge": _codex_bridge_public_contract(args),
         "remote_failure_cleanup": _remote_failure_cleanup_public_contract(args),
         "public_artifact_sync": _public_artifact_sync_contract(args),
         "incremental_public_artifact_sync": (
@@ -1033,8 +1260,10 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
 
     tunnel_proc: subprocess.Popen[Any] | None = None
     json_bridge_proc: subprocess.Popen[Any] | None = None
+    codex_bridge_proc: subprocess.Popen[Any] | None = None
     runtime_dir_obj: tempfile.TemporaryDirectory[str] | None = None
     json_local_socket: Path | None = None
+    codex_local_socket: Path | None = None
 
     def finish(returncode: int) -> tuple[int, dict[str, Any]]:
         payload["duration_sec"] = round(max(0.0, time.time() - started_at), 3)
@@ -1052,6 +1281,13 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
             )
             if json_bridge_proc.returncode is not None:
                 payload["json_bridge"]["server_exit_code"] = json_bridge_proc.returncode
+        if codex_bridge_proc is not None:
+            payload["codex_bridge"]["server_cleanup_status"] = _stop_process_group(
+                codex_bridge_proc,
+                grace_sec=1.0,
+            )
+            if codex_bridge_proc.returncode is not None:
+                payload["codex_bridge"]["server_exit_code"] = codex_bridge_proc.returncode
         if runtime_dir_obj is not None:
             runtime_dir_obj.cleanup()
         checkpoint(
@@ -1101,9 +1337,44 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
                 )
                 return finish(2)
 
+        if _codex_bridge_requested(args):
+            codex_bridge_payload = payload["codex_bridge"]
+            codex_local_socket = _resolved_codex_local_socket(args, runtime_dir)
+            try:
+                codex_bridge_proc = _start_codex_bridge_server(
+                    args,
+                    socket_path=codex_local_socket,
+                )
+                codex_bridge_payload["server_started"] = True
+            except OSError as exc:
+                payload["first_blocker"] = "codex_bridge_server_launch_failed"
+                codex_bridge_payload["server_error_type"] = type(exc).__name__[:80]
+                return finish(2)
+
+            if not _probe_local_codex_socket(args, codex_local_socket):
+                payload["first_blocker"] = "codex_bridge_local_socket_not_ready"
+                return finish(2)
+            if codex_bridge_proc.poll() is not None:
+                payload["first_blocker"] = "codex_bridge_server_exited_before_ready"
+                codex_bridge_payload["server_exit_code"] = codex_bridge_proc.returncode
+                return finish(2)
+            codex_bridge_payload["local_socket_ready"] = True
+            codex_bridge_payload["remote_socket_cleanup"] = (
+                _cleanup_remote_codex_socket(args)
+            )
+            if not codex_bridge_payload["remote_socket_cleanup"].get("ok"):
+                payload["first_blocker"] = codex_bridge_payload[
+                    "remote_socket_cleanup"
+                ].get(
+                    "first_blocker",
+                    "codex_bridge_remote_socket_cleanup_failed",
+                )
+                return finish(2)
+
         tunnel_proc = _start_tunnel_process(
             args,
             json_local_socket=json_local_socket,
+            codex_local_socket=codex_local_socket,
         )
         payload["tunnel_started"] = True
     except OSError as exc:
@@ -1129,6 +1400,7 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
                 tunnel_proc = _start_tunnel_process(
                     args,
                     json_local_socket=json_local_socket,
+                    codex_local_socket=codex_local_socket,
                 )
             except OSError as exc:
                 liveness["last_probe_status"] = (
@@ -1184,6 +1456,32 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         json_bridge_payload["remote_command_placeholder_supported"] = (
             "{json_bridge_client}" in args.remote_command
         )
+
+    if _codex_bridge_requested(args):
+        codex_bridge_payload = payload["codex_bridge"]
+        if not _probe_remote_codex_socket(args):
+            payload["first_blocker"] = "codex_bridge_remote_socket_not_ready"
+            return finish(2)
+        codex_bridge_payload["remote_socket_ready"] = True
+        assert runtime_dir_obj is not None
+        if not _materialize_remote_codex_client(args, Path(runtime_dir_obj.name)):
+            payload["first_blocker"] = "codex_bridge_remote_client_materialize_failed"
+            return finish(2)
+        codex_bridge_payload["remote_client_materialized"] = True
+        codex_bridge_payload["remote_command_placeholder_supported"] = (
+            "{codex_bridge_client}" in args.remote_command
+        )
+        participant_probe = _probe_remote_codex_participant(args)
+        codex_bridge_payload["participant_probe"] = participant_probe
+        codex_bridge_payload["participant_probe_passed"] = bool(
+            participant_probe["passed"]
+        )
+        if participant_probe["requested"] and not participant_probe["passed"]:
+            payload["first_blocker"] = participant_probe.get(
+                "first_blocker",
+                "codex_bridge_participant_probe_failed",
+            )
+            return finish(2)
 
     if args.preflight_only or not args.remote_command:
         payload["ok"] = True
@@ -1345,6 +1643,7 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
                         tunnel_proc = _start_tunnel_process(
                             args,
                             json_local_socket=json_local_socket,
+                            codex_local_socket=codex_local_socket,
                         )
                     except OSError as exc:
                         liveness["last_probe_status"] = (
@@ -1592,6 +1891,77 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "checks only the local/remote bridge socket and client lifecycle."
         ),
     )
+    parser.add_argument(
+        "--codex-bridge",
+        action="store_true",
+        help=(
+            "Hold an opt-in local Codex reverse-channel provider alongside the "
+            "TCP reverse tunnel."
+        ),
+    )
+    parser.add_argument(
+        "--codex-bin",
+        default="codex",
+        help="Local Codex executable used by the reverse-channel server.",
+    )
+    parser.add_argument(
+        "--codex-local-socket",
+        default="",
+        help=(
+            "Optional local Unix socket path for the Codex bridge server. "
+            "Omit to use a per-run temporary socket."
+        ),
+    )
+    parser.add_argument(
+        "--codex-remote-socket",
+        default="",
+        help=(
+            "Remote Unix socket exposed through ssh -R for the Codex bridge. "
+            "The raw path is not written to public output."
+        ),
+    )
+    parser.add_argument(
+        "--codex-remote-client-path",
+        default="",
+        help=(
+            "Remote path where the Codex bridge client is materialized. "
+            "Use {codex_bridge_client} inside --remote-command to inject it."
+        ),
+    )
+    parser.add_argument(
+        "--codex-prompt-bridge-command",
+        default="",
+        help=(
+            "Private local command used to execute scored sandbox operations "
+            "on the remote participant host. Not written to public output."
+        ),
+    )
+    parser.add_argument("--codex-server-timeout-sec", type=float, default=7200.0)
+    parser.add_argument("--codex-socket-ready-timeout-sec", type=float, default=15.0)
+    parser.add_argument(
+        "--codex-participant-sandbox",
+        choices=("read-only", "workspace-write"),
+        default="",
+        help=(
+            "Fixed sandbox used by the task-free participant probe. "
+            "Split-control benchmark launches must use workspace-write."
+        ),
+    )
+    parser.add_argument(
+        "--codex-participant-probe-timeout-sec",
+        type=float,
+        default=60.0,
+    )
+    parser.add_argument(
+        "--codex-first-action-timeout-sec",
+        type=float,
+        default=180.0,
+    )
+    parser.add_argument(
+        "--codex-bridge-idle-timeout-sec",
+        type=float,
+        default=0.0,
+    )
     parser.add_argument("--remote-command", default="")
     parser.add_argument("--preflight-only", action="store_true")
     parser.add_argument(
@@ -1708,6 +2078,23 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         if missing:
             parser.error(
                 "--json-bridge requires "
+                + ", ".join("--" + item.replace("_", "-") for item in missing)
+            )
+    if _codex_bridge_requested(args):
+        args.codex_bridge = True
+        missing = [
+            name
+            for name in (
+                "codex_remote_socket",
+                "codex_remote_client_path",
+                "codex_prompt_bridge_command",
+                "codex_participant_sandbox",
+            )
+            if not getattr(args, name)
+        ]
+        if missing:
+            parser.error(
+                "--codex-bridge requires "
                 + ", ".join("--" + item.replace("_", "-") for item in missing)
             )
     if _public_artifact_sync_requested(args):

--- a/tests/test_skillsbench_remote_codex_preflight.py
+++ b/tests/test_skillsbench_remote_codex_preflight.py
@@ -174,6 +174,32 @@ def test_explicit_danger_full_access_does_not_require_a_codex_sandbox_probe(
     )
 
 
+def test_reverse_channel_cli_goal_requires_fixed_pre_agent_bridge_receipt() -> None:
+    args = SimpleNamespace(
+        setup_only_public_preflight=False,
+        route="codex-cli-goal-baseline",
+        host_local_acp_launch=True,
+        local_codex_provider="reverse-channel",
+        host_local_acp_codex_exec_preflight=True,
+        remote_command_file_bridge_solver_command="private-solver-command",
+        remote_command_file_bridge_ready=True,
+        remote_command_file_bridge_probe=False,
+    )
+
+    assert skillsbench_loop._host_local_acp_codex_exec_preflight_should_run(args)
+    assert skillsbench_loop._host_local_acp_codex_exec_preflight_requires_bridge_action(
+        args
+    )
+
+    args.local_codex_provider = "exact-host"
+    assert not skillsbench_loop._host_local_acp_codex_exec_preflight_should_run(args)
+    assert not (
+        skillsbench_loop._host_local_acp_codex_exec_preflight_requires_bridge_action(
+            args
+        )
+    )
+
+
 def test_early_tui_failure_does_not_claim_goal_submission(tmp_path: Path) -> None:
     trace_dir = tmp_path / "traces"
     relay = SkillsBenchLocalAcpRelay(

--- a/tests/test_skillsbench_remote_codex_preflight.py
+++ b/tests/test_skillsbench_remote_codex_preflight.py
@@ -191,6 +191,9 @@ def test_reverse_channel_cli_goal_requires_fixed_pre_agent_bridge_receipt() -> N
         args
     )
 
+    args.setup_only_public_preflight = True
+    assert skillsbench_loop._host_local_acp_codex_exec_preflight_should_run(args)
+
     args.local_codex_provider = "exact-host"
     assert not skillsbench_loop._host_local_acp_codex_exec_preflight_should_run(args)
     assert not (
@@ -198,6 +201,36 @@ def test_reverse_channel_cli_goal_requires_fixed_pre_agent_bridge_receipt() -> N
             args
         )
     )
+
+
+def test_pre_agent_receipt_rebinds_to_materialized_sandbox_bridge() -> None:
+    args = skillsbench_loop.parse_args(
+        [
+            "--task-id",
+            "public-case-id",
+            "--route",
+            "codex-cli-goal-baseline",
+            "--host-local-acp-launch",
+            "--local-codex-provider",
+            "reverse-channel",
+            "--host-local-acp-codex-exec-preflight",
+            "--remote-command-file-bridge-probe",
+            "--remote-command-file-bridge-solver-command",
+            "task-free-placeholder",
+        ]
+    )
+
+    command = skillsbench_loop._host_local_acp_codex_exec_preflight_command(
+        args,
+        {"runner_prerequisites": {}},
+        sandbox_bridge_command="materialized-sandbox-bridge",
+    )
+
+    bridge_index = command.index("--remote-command-file-bridge-command")
+    agent_bridge_index = command.index("--remote-command-file-bridge-agent-command")
+    assert command[bridge_index + 1] == "materialized-sandbox-bridge"
+    assert command[agent_bridge_index + 1] == "materialized-sandbox-bridge"
+    assert "task-free-placeholder" not in command
 
 
 def test_early_tui_failure_does_not_claim_goal_submission(tmp_path: Path) -> None:

--- a/tests/test_skillsbench_remote_codex_preflight.py
+++ b/tests/test_skillsbench_remote_codex_preflight.py
@@ -203,6 +203,29 @@ def test_reverse_channel_cli_goal_requires_fixed_pre_agent_bridge_receipt() -> N
     )
 
 
+def test_materialized_sandbox_bridge_requires_successful_pre_agent_action() -> None:
+    args = SimpleNamespace(
+        route="codex-cli-goal-baseline",
+        host_local_acp_launch=True,
+        local_codex_provider="reverse-channel",
+        remote_command_file_bridge_solver_command="",
+        remote_command_file_bridge_ready=False,
+        remote_command_file_bridge_probe=True,
+    )
+
+    assert not skillsbench_loop._host_local_acp_codex_exec_preflight_requires_bridge_action(
+        args
+    )
+    assert skillsbench_loop._host_local_acp_codex_exec_preflight_requires_bridge_action(
+        args,
+        require_materialized_sandbox_bridge=True,
+    )
+    assert skillsbench_loop._host_local_acp_codex_exec_preflight_requires_bridge_action(
+        args,
+        sandbox_bridge_command="materialized-sandbox-bridge",
+    )
+
+
 def test_pre_agent_receipt_rebinds_to_materialized_sandbox_bridge() -> None:
     args = skillsbench_loop.parse_args(
         [

--- a/tests/test_skillsbench_reverse_tunnel_supervisor.py
+++ b/tests/test_skillsbench_reverse_tunnel_supervisor.py
@@ -44,6 +44,16 @@ raise SystemExit(0)
     path.chmod(path.stat().st_mode | stat.S_IXUSR)
 
 
+def _write_fake_codex(path: Path) -> None:
+    path.write_text(
+        """#!/bin/sh
+exit 0
+""",
+        encoding="utf-8",
+    )
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
 def test_supervisor_writes_starting_periodic_and_terminal_public_liveness(
     tmp_path: Path,
     monkeypatch,
@@ -204,3 +214,75 @@ def test_supervisor_projects_only_allowlisted_remote_failure_subtype(
     assert "--private-value" not in public_text
     assert "usage: runner" not in public_text
     assert persisted["raw_remote_output_recorded"] is False
+
+
+def test_supervisor_codex_bridge_preflight_is_task_free_and_public_safe(
+    tmp_path: Path,
+) -> None:
+    supervisor = _load_supervisor_module()
+    fake_ssh = tmp_path / "fake-ssh"
+    fake_codex = tmp_path / "fake-codex"
+    public_output = tmp_path / "public" / "supervisor.public.json"
+    _write_fake_ssh(fake_ssh)
+    _write_fake_codex(fake_codex)
+    private_socket = "/tmp/private-codex-socket"
+    private_client = "/tmp/private-codex-client"
+    private_prompt_bridge = "private-prompt-bridge sentinel-bridge"
+    args = supervisor.parse_args(
+        [
+            "--ssh-bin",
+            str(fake_ssh),
+            "--ssh-destination",
+            "runner.example",
+            "--codex-bridge",
+            "--codex-bin",
+            str(fake_codex),
+            "--codex-remote-socket",
+            private_socket,
+            "--codex-remote-client-path",
+            private_client,
+            "--codex-prompt-bridge-command",
+            private_prompt_bridge,
+            "--codex-participant-sandbox",
+            "workspace-write",
+            "--preflight-only",
+            "--public-output-path",
+            str(public_output),
+            "--probe-interval-sec",
+            "0.01",
+            "--probe-timeout-sec",
+            "1",
+            "--tunnel-ready-timeout-sec",
+            "1",
+            "--codex-socket-ready-timeout-sec",
+            "1",
+            "--codex-participant-probe-timeout-sec",
+            "1",
+        ]
+    )
+
+    returncode, payload = supervisor.run_supervisor(args)
+    persisted = json.loads(public_output.read_text(encoding="utf-8"))
+    public_text = json.dumps(persisted, sort_keys=True)
+
+    assert returncode == 0
+    assert payload["ok"] is True
+    assert persisted == payload
+    assert persisted["remote_command_requested"] is False
+    assert persisted["codex_bridge"]["enabled"] is True
+    assert persisted["codex_bridge"]["server_started"] is True
+    assert persisted["codex_bridge"]["local_socket_ready"] is True
+    assert persisted["codex_bridge"]["remote_socket_ready"] is True
+    assert persisted["codex_bridge"]["remote_client_materialized"] is True
+    assert persisted["codex_bridge"]["participant_probe_passed"] is True
+    assert persisted["codex_bridge"]["participant_probe"]["sandbox"] == (
+        "workspace-write"
+    )
+    assert persisted["codex_bridge"]["participant_probe"]["raw_output_recorded"] is (
+        False
+    )
+    assert private_socket not in public_text
+    assert private_client not in public_text
+    assert private_prompt_bridge not in public_text
+    assert "runner.example" not in public_text
+    assert "sentinel-bridge" not in public_text

--- a/tests/test_skillsbench_runner_profile.py
+++ b/tests/test_skillsbench_runner_profile.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from loopx.benchmark_adapters.skillsbench_runner_profile import (
+    SKILLSBENCH_RUNNER_PROFILE_SCHEMA_VERSION,
+    capture_skillsbench_runner_profile,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_probe_ssh_reuses_launcher_option_semantics_without_output(
+    tmp_path: Path,
+) -> None:
+    profile_path = tmp_path / "runner-profile.json"
+    capture_skillsbench_runner_profile(
+        profile_path,
+        environment={
+            "SKILLSBENCH_SSH_DESTINATION": "runner.example.invalid",
+            "SKILLSBENCH_REMOTE_ROOT": "/remote/loopx",
+            "SKILLSBENCH_ROOT": "/remote/skillsbench",
+            "SKILLSBENCH_EXPECTED_LOOPX_GIT_HEAD": "abc1234",
+            "SKILLSBENCH_SSH_OPTIONS": (
+                "GSSAPIAuthentication=yes ServerAliveInterval=30"
+            ),
+        },
+    )
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    argv_path = tmp_path / "ssh-argv.json"
+    fake_ssh = fake_bin / "ssh"
+    fake_ssh.write_text(
+        "#!/bin/sh\n"
+        "python3 - \"$@\" <<'PY'\n"
+        "import json, os, sys\n"
+        "from pathlib import Path\n"
+        "Path(os.environ['SSH_ARGV_PATH']).write_text(json.dumps(sys.argv[1:]))\n"
+        "PY\n",
+        encoding="utf-8",
+    )
+    fake_ssh.chmod(0o755)
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "PATH": f"{fake_bin}{os.pathsep}{environment['PATH']}",
+            "SSH_ARGV_PATH": str(argv_path),
+        }
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.benchmark_adapters.skillsbench_runner_profile",
+            "probe-ssh",
+            "--profile",
+            str(profile_path),
+        ],
+        cwd=REPO_ROOT,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert json.loads(completed.stdout) == {
+        "benchmark_job_launched": False,
+        "ok": True,
+        "profile_values_recorded": False,
+        "raw_output_recorded": False,
+        "reachable": True,
+        "result": "reachable",
+        "schema_version": "skillsbench_runner_connectivity_probe_v0",
+        "task_material_read": False,
+    }
+    assert json.loads(argv_path.read_text(encoding="utf-8")) == [
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ConnectTimeout=15",
+        "-o",
+        "GSSAPIAuthentication=yes",
+        "-o",
+        "ServerAliveInterval=30",
+        "runner.example.invalid",
+        "true",
+    ]
+    assert SKILLSBENCH_RUNNER_PROFILE_SCHEMA_VERSION == "skillsbench_runner_profile_v0"
+
+
+def test_probe_ssh_reports_transport_failure_without_raw_output(
+    tmp_path: Path,
+) -> None:
+    profile_path = tmp_path / "runner-profile.json"
+    capture_skillsbench_runner_profile(
+        profile_path,
+        environment={
+            "SKILLSBENCH_SSH_DESTINATION": "runner.example.invalid",
+            "SKILLSBENCH_REMOTE_ROOT": "/remote/loopx",
+            "SKILLSBENCH_ROOT": "/remote/skillsbench",
+            "SKILLSBENCH_EXPECTED_LOOPX_GIT_HEAD": "abc1234",
+        },
+    )
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_ssh = fake_bin / "ssh"
+    fake_ssh.write_text("#!/bin/sh\nexit 255\n", encoding="utf-8")
+    fake_ssh.chmod(0o755)
+    environment = os.environ.copy()
+    environment["PATH"] = f"{fake_bin}{os.pathsep}{environment['PATH']}"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.benchmark_adapters.skillsbench_runner_profile",
+            "probe-ssh",
+            "--profile",
+            str(profile_path),
+        ],
+        cwd=REPO_ROOT,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 3
+    assert completed.stderr == ""
+    assert json.loads(completed.stdout) == {
+        "benchmark_job_launched": False,
+        "ok": True,
+        "profile_values_recorded": False,
+        "raw_output_recorded": False,
+        "reachable": False,
+        "result": "transport_unavailable",
+        "schema_version": "skillsbench_runner_connectivity_probe_v0",
+        "task_material_read": False,
+    }

--- a/tests/test_skillsbench_setup_preflight.py
+++ b/tests/test_skillsbench_setup_preflight.py
@@ -160,6 +160,61 @@ def test_setup_only_preflight_projects_incremental_public_stages() -> None:
     assert all(snapshot["raw_logs_recorded"] is False for snapshot in snapshots)
 
 
+def test_setup_only_preflight_runs_environment_hook_before_cleanup() -> None:
+    async def environment_ready_hook(environment: object) -> None:
+        assert environment is not None
+        FakeRollout.events.append("environment_ready_hook")
+
+    result = asyncio.run(
+        run_setup_only_public_preflight(
+            rollout_type=FakeRollout,
+            config=object(),
+            stage_timeout_sec=1,
+            environment_ready_hook=environment_ready_hook,
+        )
+    )
+
+    assert result["status"] == "passed"
+    assert result["stage"] == "environment_ready_before_agent"
+    assert result["environment_ready_hook_requested"] is True
+    assert result["environment_ready_hook_invoked"] is True
+    assert result["environment_ready_hook_status"] == "passed"
+    assert result["agent_install_invoked"] is False
+    assert result["agent_execution_invoked"] is False
+    assert result["verifier_invoked"] is False
+    assert FakeRollout.events == [
+        "create",
+        "setup",
+        "start",
+        "environment_ready_hook",
+        "cleanup",
+    ]
+
+
+def test_setup_only_preflight_cleans_up_after_environment_hook_failure() -> None:
+    async def failing_environment_ready_hook(_environment: object) -> None:
+        FakeRollout.events.append("environment_ready_hook")
+        raise RuntimeError("private callback detail")
+
+    result = asyncio.run(
+        run_setup_only_public_preflight(
+            rollout_type=FakeRollout,
+            config=object(),
+            stage_timeout_sec=1,
+            environment_ready_hook=failing_environment_ready_hook,
+        )
+    )
+
+    assert result["status"] == "failed"
+    assert result["failure_stage"] == "environment_ready_hook"
+    assert result["environment_ready_hook_status"] == "failed"
+    assert result["cleanup_status"] == "completed"
+    assert result["agent_install_invoked"] is False
+    assert result["verifier_invoked"] is False
+    assert FakeRollout.events[-1] == "cleanup"
+    assert "private callback detail" not in json.dumps(result, sort_keys=True)
+
+
 def test_formal_run_lifecycle_receipt_projects_live_worker_without_private_logs(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -147,6 +147,82 @@ def test_launcher_fails_before_batch_when_exact_host_sandbox_probe_fails(
     assert "pid=" not in proc.stdout
 
 
+def test_launcher_split_control_is_opt_in_and_redacts_provider_values(
+    tmp_path: Path,
+) -> None:
+    env = _base_env(tmp_path)
+    private_local_codex = "/private/local/codex-sentinel"
+    env.update(
+        {
+            "SKILLSBENCH_LOCAL_CODEX_SPLIT_CONTROL": "1",
+            "SKILLSBENCH_LOCAL_CODEX_BIN": private_local_codex,
+        }
+    )
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "split-control"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+
+    output = proc.stdout
+    assert "local_codex_split_control=1" in output
+    assert "local_codex_provider=reverse_channel" in output
+    assert "remote_codex_bin_mode=split_control_client" in output
+    assert (
+        "exact_host_codex_sandbox_preflight=split_control_not_applicable"
+        in output
+    )
+    assert "private_runner_command_values_redacted=true" in output
+    for arg_name in (
+        "--codex-bridge",
+        "--codex-bin",
+        "--codex-remote-socket",
+        "--codex-remote-client-path",
+        "--codex-prompt-bridge-command",
+        "--codex-participant-sandbox",
+        "--local-codex-provider",
+        "--host-local-acp-codex-exec-preflight",
+        "--host-local-acp-codex-exec-preflight-attempts",
+    ):
+        assert arg_name in output
+    assert private_local_codex not in output
+    assert "codex_bridge_client" not in output
+    assert "loopx-codex-" not in output
+    assert "example.invalid" not in output
+
+
+def test_launcher_split_control_requires_workspace_write(tmp_path: Path) -> None:
+    env = _base_env(tmp_path)
+    env.update(
+        {
+            "SKILLSBENCH_LOCAL_CODEX_SPLIT_CONTROL": "1",
+            "SKILLSBENCH_LOCAL_CODEX_SANDBOX": "danger-full-access",
+        }
+    )
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "split-control"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    assert (
+        "SKILLSBENCH_LOCAL_CODEX_SPLIT_CONTROL requires "
+        "SKILLSBENCH_LOCAL_CODEX_SANDBOX=workspace-write"
+    ) in proc.stderr
+    assert "supervisor_command=" not in proc.stdout
+
+
 def test_turn_launcher_accepts_stability_policy(tmp_path: Path) -> None:
     env = _base_env(tmp_path)
     validator = "private-validator-command sentinel-validator"


### PR DESCRIPTION
## Summary
- add an opt-in reverse-channel Codex provider to the existing SkillsBench tunnel supervisor
- bind the provider structurally in runner config and require a fixed pre-agent bridge receipt for split-control CLI Goal launches
- keep exact-host behavior as the default, require `workspace-write`, and redact socket, client, command, and probe details from public output

## Validation
- `python3 -m py_compile` on changed Python files
- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`
- 31 focused pytest cases
- `skillsbench-reverse-channel-bridge-smoke.py`
- `skillsbench-reverse-tunnel-supervisor-smoke.py`
- `skillsbench-benchmark-run-smoke.py`
- `loopx canary premerge --from-git-diff --tier standard`: all automatic checks passed; benchmark-sensitive manual review hold remains

## Boundary
- no benchmark scoring, task semantics, leaderboard, upload, submission, or permission boundary changes
- no benchmark job launched by this PR validation
- no raw task text, trajectory, verifier output, credentials, private command values, or local paths are projected
- benchmark-sensitive runtime change: maintainer review required; do not self-merge