### PR TITLE
Pin Ruff below 0.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ test = [
   "pytest>=8,<9",
   "pytest-cov>=5,<7",
   "pytest-xdist>=3,<4",
-  "ruff>=0.12,<1",
+  "ruff>=0.12,<0.16",
   "mypy>=1.18,<2",
 ]
 


### PR DESCRIPTION
## Summary
- cap the test extra at Ruff 0.15.x
- keep the repository on the lint behavior its current code and CI qualify
- unblock PR checks after Ruff 0.16 introduced repository-wide findings unrelated to the candidate diffs

## Validation
- Ruff 0.15.22: exact CI lint surface passed
- mypy: passed
- CLI output-budget smoke: passed
- pytest: 1124 passed, 2 skipped; one macOS-only nested-venv dylib failure remains local (Linux CI is authoritative)
- coverage: 48.43% (threshold 19.6%)

## Scope
Single dependency-bound change. No benchmark task, scoring, runner, submission, permission, or runtime behavior changes.