### PR TITLE
Fix agent-scoped recommendation isolation

### DIFF
--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -739,7 +739,11 @@ def attach_agent_lane_next_actions(payload: dict[str, object], *, agent_id: str)
         if not goal_id:
             continue
         try:
-            guard = build_quota_should_run(payload, goal_id=goal_id, agent_id=safe_agent_id)
+            guard = build_quota_should_run(
+                payload,
+                goal_id=goal_id,
+                agent_id=safe_agent_id,
+            )
         except Exception:
             continue
         next_action = guard.get("agent_lane_next_action")
@@ -811,6 +815,43 @@ def attach_agent_lane_next_actions(payload: dict[str, object], *, agent_id: str)
                 project_asset["agent_reward_memory"] = reward_memory_projection
             reward_memory_attached += 1
             changed = True
+        latest_action = guard.get("latest_run_recommended_action")
+        for target in (item, project_asset):
+            if not isinstance(target, dict):
+                continue
+            existing_recommendation = target.get("agent_lane_recommendation")
+            had_latest_action = bool(
+                target.get("latest_run_recommended_action")
+                or target.get("latest_run_recommended_action_source")
+            )
+            for field in (
+                "agent_lane_recommendation",
+                "latest_run_recommended_action",
+                "latest_run_recommended_action_source",
+            ):
+                target.pop(field, None)
+            if isinstance(existing_recommendation, dict):
+                existing_agent_id = normalize_todo_claimed_by(
+                    existing_recommendation.get("agent_id")
+                )
+                if existing_agent_id == safe_agent_id:
+                    target["agent_lane_recommendation"] = existing_recommendation
+                elif latest_action:
+                    target["agent_lane_recommendation"] = {
+                        "schema_version": existing_recommendation.get(
+                            "schema_version"
+                        )
+                        or "agent_lane_recommendation_v0",
+                        "progress_scope": "agent_lane",
+                        "agent_id": safe_agent_id,
+                        "recommended_action": latest_action,
+                    }
+            if had_latest_action and latest_action:
+                target["latest_run_recommended_action"] = latest_action
+                target["latest_run_recommended_action_source"] = (
+                    "agent_lane_recommendation"
+                )
+        changed = True
         if not changed:
             continue
     if (

--- a/loopx/control_plane/agents/agent_lane_recommendation.py
+++ b/loopx/control_plane/agents/agent_lane_recommendation.py
@@ -27,6 +27,7 @@ PublicSafeText = Callable[..., Optional[str]]
 ActionAlignment = Callable[[Any, Any], bool]
 TimestampParser = Callable[[Any], Any]
 AGENT_LANE_NEXT_ACTION_SCHEMA_VERSION = "agent_lane_next_action_v0"
+AGENT_LANE_PROGRESS_SCOPE = "agent_lane"
 
 
 def is_status_neutral_run(
@@ -45,15 +46,23 @@ def latest_agent_lane_run(
     goal: dict[str, Any],
     *,
     agent_lane_progress_scope: str,
+    preferred_agent_id: str | None = None,
 ) -> dict[str, Any] | None:
     runs = goal.get("latest_runs")
     if not isinstance(runs, list):
         return None
+    preferred_agent = normalize_todo_claimed_by(preferred_agent_id)
     for run in runs:
         if not isinstance(run, dict):
             continue
-        if str(run.get("progress_scope") or "") == agent_lane_progress_scope:
-            return run
+        if str(run.get("progress_scope") or "") != agent_lane_progress_scope:
+            continue
+        if (
+            preferred_agent
+            and normalize_todo_claimed_by(run.get("agent_id")) != preferred_agent
+        ):
+            continue
+        return run
     return None
 
 
@@ -84,6 +93,81 @@ def compact_agent_lane_recommendation(
         if run.get(field) is not None:
             compact[field] = run.get(field)
     return compact
+
+
+def scope_status_item_to_agent_lane(
+    item: dict[str, Any],
+    *,
+    latest_runs: list[dict[str, Any]],
+    agent_id: str | None,
+    public_safe_compact_text: PublicSafeText,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any] | None]:
+    scoped_item = dict(item)
+    project_asset = (
+        dict(scoped_item.get("project_asset"))
+        if isinstance(scoped_item.get("project_asset"), dict)
+        else {}
+    )
+    safe_agent_id = normalize_todo_claimed_by(agent_id)
+    if not safe_agent_id:
+        return scoped_item, project_asset, None
+    item_had_recommendation = isinstance(
+        scoped_item.get("agent_lane_recommendation"), dict
+    )
+    item_had_latest_action = bool(
+        scoped_item.get("latest_run_recommended_action")
+        or scoped_item.get("latest_run_recommended_action_source")
+    )
+    asset_had_recommendation = isinstance(
+        project_asset.get("agent_lane_recommendation"), dict
+    )
+    asset_had_latest_action = bool(
+        project_asset.get("latest_run_recommended_action")
+        or project_asset.get("latest_run_recommended_action_source")
+    )
+    for field in (
+        "agent_lane_recommendation",
+        "latest_run_recommended_action",
+        "latest_run_recommended_action_source",
+    ):
+        scoped_item.pop(field, None)
+        project_asset.pop(field, None)
+
+    lane_run = latest_agent_lane_run(
+        {"latest_runs": latest_runs},
+        agent_lane_progress_scope=AGENT_LANE_PROGRESS_SCOPE,
+        preferred_agent_id=safe_agent_id,
+    )
+    recommendation = compact_agent_lane_recommendation(
+        lane_run,
+        agent_lane_progress_scope=AGENT_LANE_PROGRESS_SCOPE,
+        public_safe_compact_text=public_safe_compact_text,
+    )
+    lane_action = public_safe_compact_text(
+        recommendation.get("recommended_action")
+        if isinstance(recommendation, dict)
+        else None,
+        limit=320,
+    )
+    if recommendation and lane_action:
+        if item_had_recommendation:
+            scoped_item["agent_lane_recommendation"] = recommendation
+        if item_had_latest_action:
+            scoped_item["latest_run_recommended_action"] = lane_action
+            scoped_item["latest_run_recommended_action_source"] = (
+                "agent_lane_recommendation"
+            )
+        if asset_had_recommendation:
+            project_asset["agent_lane_recommendation"] = recommendation
+        if asset_had_latest_action:
+            project_asset["latest_run_recommended_action"] = lane_action
+            project_asset["latest_run_recommended_action_source"] = (
+                "agent_lane_recommendation"
+            )
+
+    if project_asset:
+        scoped_item["project_asset"] = project_asset
+    return scoped_item, project_asset, recommendation
 
 
 def latest_run_recommended_action_for_projection(
@@ -174,8 +258,18 @@ def selected_recommended_action_from_work_lane(
     *,
     agent_todo_summary: dict[str, Any] | None,
     work_lane_contract: dict[str, Any] | None,
+    agent_lane_recommendation: dict[str, Any] | None = None,
+    prefer_agent_lane_recommendation: bool = False,
 ) -> Any:
     raw_action = item.get("recommended_action")
+    if prefer_agent_lane_recommendation:
+        if isinstance(agent_lane_recommendation, dict):
+            lane_action = agent_lane_recommendation.get("recommended_action")
+            if lane_action:
+                return lane_action
+        if isinstance(work_lane_contract, dict):
+            return work_lane_contract.get("action")
+        return None
     if work_lane_contract_is_lark_inbox_reply_due(work_lane_contract):
         return work_lane_contract.get("action") or raw_action
     if work_lane_contract_is_due_monitor_attempt(work_lane_contract):

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -18,6 +18,7 @@ from .control_plane.agents.agent_scope import (
 )
 from .control_plane.agents.agent_lane_recommendation import (
     build_agent_lane_next_action,
+    scope_status_item_to_agent_lane as _scope_status_item_to_agent_lane,
     selected_action_with_agent_lane,
     selected_recommended_action_from_work_lane,
 )
@@ -1445,8 +1446,15 @@ def build_quota_should_run(
         reason = str(quota.get("reason") or "quota state is not eligible")
         if not plan.get("ok"):
             reason = "status or contract health is not ok; skip automatic compute"
-        project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
         agent_identity = build_quota_agent_identity(item, agent_id=agent_id)
+        item, project_asset, agent_lane_recommendation = (
+            _scope_status_item_to_agent_lane(
+                item=item,
+                latest_runs=_goal_latest_runs(status_payload, goal_id=safe_goal_id),
+                agent_id=agent_id,
+                public_safe_compact_text=_protocol_action_text,
+            )
+        )
         effective_available_capabilities = _effective_available_capabilities(
             available_capabilities,
             item=item,
@@ -1878,6 +1886,8 @@ def build_quota_should_run(
             item,
             agent_todo_summary=agent_todo_summary,
             work_lane_contract=work_lane_contract,
+            agent_lane_recommendation=agent_lane_recommendation,
+            prefer_agent_lane_recommendation=monitor_quiet_skip,
         )
         selected_recommended_action = task_selected_recommended_action(
             task_orchestration_contract,

--- a/tests/control_plane/test_monitor_replan_agent_scope.py
+++ b/tests/control_plane/test_monitor_replan_agent_scope.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+from loopx.cli_commands.status import attach_agent_lane_next_actions
+from loopx.control_plane.agents.agent_lane_recommendation import (
+    scope_status_item_to_agent_lane,
+    selected_recommended_action_from_work_lane,
+)
+from loopx.control_plane.quota.monitor_poll import build_quota_monitor_poll_event
 from loopx.control_plane.scheduler.execution_context import (
     GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT,
 )
@@ -14,6 +20,7 @@ from loopx.quota import build_quota_should_run
 GOAL_ID = "monitor-replan-agent-scope-fixture"
 AGENT_ID = "codex-quality-agent"
 PEER_AGENT_ID = "codex-delivery-peer"
+SECOND_PEER_AGENT_ID = "codex-main-control"
 
 
 def _guard(
@@ -178,6 +185,181 @@ def test_interleaved_monitors_keep_independent_no_change_streaks() -> None:
     assert guard["agent_todo_summary"]["payload_compaction"]["compacted_lanes"][
         "monitor_open_items"
     ] == {"shown": 2, "total": 3}
+
+
+def test_three_peer_status_quota_and_monitor_recommendations_stay_agent_scoped() -> None:
+    current_action = "Wait for the quality lane's own material evidence."
+    peer_action = "Advance the delivery peer's unrelated adapter."
+    main_action = "Continue the main-control provider rollout."
+    monitor = quota_todo_item(
+        todo_id="todo_quality_monitor",
+        index=1,
+        title="Watch the quality qualification evidence.",
+        task_class="continuous_monitor",
+        claimed_by=AGENT_ID,
+        target_key="quality-evidence",
+        consecutive_no_change="0",
+        cadence="30m",
+        next_due_at="2099-01-01T00:00:00+00:00",
+    )
+    blocker = quota_todo_item(
+        todo_id="todo_quality_prerequisite",
+        index=2,
+        title="Complete the quality baseline prerequisite.",
+        task_class="advancement_task",
+        claimed_by=SECOND_PEER_AGENT_ID,
+        successor_todo_ids=["todo_quality_baseline"],
+    )
+    blocked_successor = quota_todo_item(
+        todo_id="todo_quality_baseline",
+        index=3,
+        status="deferred",
+        title="Run the release outcome baseline.",
+        task_class="advancement_task",
+        claimed_by=AGENT_ID,
+        resume_when="todo_done:todo_quality_prerequisite",
+    )
+    peer_recommendation = {
+        "schema_version": "agent_lane_recommendation_v0",
+        "progress_scope": "agent_lane",
+        "agent_id": PEER_AGENT_ID,
+        "recommended_action": peer_action,
+        "generated_at": "2026-07-24T03:20:00+00:00",
+    }
+    payload = quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        recommended_action=main_action,
+        agent_todos=quota_todo_summary([monitor, blocker, blocked_successor]),
+        coordination={
+            "agent_model": "peer_v1",
+            "registered_agents": [
+                AGENT_ID,
+                PEER_AGENT_ID,
+                SECOND_PEER_AGENT_ID,
+            ],
+        },
+        latest_runs=[
+            {
+                "classification": "main_control_progress",
+                "generated_at": "2026-07-24T03:30:00+00:00",
+                "agent_id": SECOND_PEER_AGENT_ID,
+                "progress_scope": "goal",
+                "recommended_action": main_action,
+                "delivery_outcome": "outcome_progress",
+            },
+            {
+                "classification": "delivery_peer_progress",
+                "generated_at": "2026-07-24T03:20:00+00:00",
+                "agent_id": PEER_AGENT_ID,
+                "progress_scope": "agent_lane",
+                "recommended_action": peer_action,
+                "delivery_outcome": "outcome_progress",
+            },
+            {
+                "classification": "quality_lane_progress",
+                "generated_at": "2026-07-24T03:10:00+00:00",
+                "agent_id": AGENT_ID,
+                "progress_scope": "agent_lane",
+                "recommended_action": current_action,
+                "delivery_outcome": "outcome_progress",
+                "agent_vision": {
+                    "schema_version": "goal_vision_replan_contract_v0",
+                    "agent_id": AGENT_ID,
+                    "state": "vision_active",
+                    "vision_patch": {
+                        "acceptance_summary": (
+                            "Keep quality qualification advancing until closed."
+                        ),
+                        "advancement_policy": "repeat_until_closed",
+                        "replan_trigger_summary": (
+                            "Replan when the quality baseline remains unavailable."
+                        ),
+                    },
+                },
+            },
+        ],
+        item_extra={
+            "agent_lane_recommendation": peer_recommendation,
+            "latest_run_recommended_action": main_action,
+            "latest_run_recommended_action_source": "latest_status_run",
+        },
+        project_asset_extra={
+            "agent_lane_recommendation": peer_recommendation,
+            "latest_run_recommended_action": main_action,
+            "latest_run_recommended_action_source": "latest_status_run",
+        },
+    )
+
+    guard = build_quota_should_run(
+        payload,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        scheduler_execution_context=(
+            GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT
+        ),
+    )
+
+    assert guard["effective_action"] == "monitor_quiet_skip"
+    assert guard["recommended_action"] == current_action
+    assert guard["latest_run_recommended_action"] == current_action
+    event = build_quota_monitor_poll_event(guard)
+    assert event["agent_id"] == AGENT_ID
+    assert event["recommended_action"] == current_action
+
+    attach_agent_lane_next_actions(payload, agent_id=AGENT_ID)
+    item = payload["attention_queue"]["items"][0]
+    assert item["recommended_action"] == main_action
+    assert item["latest_run_recommended_action"] == current_action
+    assert item["agent_lane_recommendation"]["agent_id"] == AGENT_ID
+    assert item["project_asset"]["next_action"] == main_action
+    assert item["project_asset"]["latest_run_recommended_action"] == current_action
+
+
+def test_monitor_quiet_without_own_lane_run_drops_peer_recommendation() -> None:
+    peer_action = "Advance the delivery peer's unrelated adapter."
+    monitor_action = "wait quietly for material monitor evidence"
+    item, project_asset, recommendation = scope_status_item_to_agent_lane(
+        {
+            "recommended_action": peer_action,
+            "agent_lane_recommendation": {
+                "agent_id": PEER_AGENT_ID,
+                "recommended_action": peer_action,
+            },
+            "latest_run_recommended_action": peer_action,
+            "project_asset": {
+                "agent_lane_recommendation": {
+                    "agent_id": PEER_AGENT_ID,
+                    "recommended_action": peer_action,
+                },
+                "latest_run_recommended_action": peer_action,
+            },
+        },
+        latest_runs=[
+            {
+                "agent_id": PEER_AGENT_ID,
+                "progress_scope": "agent_lane",
+                "recommended_action": peer_action,
+            }
+        ],
+        agent_id=AGENT_ID,
+        public_safe_compact_text=lambda value, **_: str(value) if value else None,
+    )
+
+    assert recommendation is None
+    assert "agent_lane_recommendation" not in item
+    assert "latest_run_recommended_action" not in item
+    assert "agent_lane_recommendation" not in project_asset
+    assert (
+        selected_recommended_action_from_work_lane(
+            item,
+            agent_todo_summary=None,
+            work_lane_contract={"action": monitor_action},
+            agent_lane_recommendation=recommendation,
+            prefer_agent_lane_recommendation=True,
+        )
+        == monitor_action
+    )
 
 
 def _combined_user_frontier_guard(*, user_task_class: str) -> dict:


### PR DESCRIPTION
## Summary

- select agent-lane run recommendations by the exact `--agent-id` instead of the newest peer run
- keep goal-level status actions separate while preventing quota monitor polls from inheriting another peer's recommendation
- add three-peer and missing-own-lane regressions without changing the existing two-newer-stalls replan contract

## Validation

- `50 passed`: monitor/replan agent scope, blocked-successor vision, monitor followthrough, quota slot accounting, and CLI output budget tests
- `loopx canary premerge --from-git-diff --tier standard`: 4 direct checks and 17 selected canaries passed; no failures, advisories, warnings, or manual holds
- CLI base/head differential, hot-path interface budget, runtime-handoff status read path, and maintainability ratchet passed
- public/private and credential scans on the four changed paths found no matches
