### PR TITLE
Fix Codex CLI paste message line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,26 +287,11 @@ cd /path/to/your-project
 codex
 ```
 
-Then paste one setup message:
+Then paste one setup message. The paste block is intentionally one source line
+so Codex CLI receives one TUI message; do not add manual line breaks:
 
 ```text
-Connect this repo to LoopX from this visible Codex CLI TUI. Do not clone the
-LoopX repository for ordinary use. If `loopx` is not on PATH, install or repair
-it with the official no-clone installer:
-curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
-export PATH="$HOME/.local/bin:$PATH"
-
-Then run `loopx doctor`. Work only from this project root: if LoopX state
-already exists, reuse it and do not create or overwrite a goal or the active objective; if the project
-is not connected, prefer `loopx connect`, and use `loopx bootstrap` only when
-project state clearly needs initialization. Ensure `.loopx/`, `.codex/goals/`,
-and `.local/` are ignored. Keep me in this TUI, do not use hidden headless
-execution. Then stop and report the project connection status, current user
-gate, top agent todo, and next safe action. After that I will start work with
-`$loopx <complex task>` or the `loopx` skill from `/skills`. When that task
-writes LoopX todos, generate the thin task body and set this visible TUI to
-`/goal <task_body>`; if you cannot mutate `/goal`, show me the exact text to
-paste instead of saying the loop is active.
+Connect this repo to LoopX from this visible Codex CLI TUI. Do not clone the LoopX repository for ordinary use. If `loopx` is not on PATH, install or repair it with the official no-clone installer: curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash; export PATH="$HOME/.local/bin:$PATH". Then run `loopx doctor`. Work only from this project root: if LoopX state already exists, reuse it and do not create or overwrite a goal or the active objective; if the project is not connected, prefer `loopx connect`, and use `loopx bootstrap` only when project state clearly needs initialization. Ensure `.loopx/`, `.codex/goals/`, and `.local/` are ignored. Keep me in this TUI, do not use hidden headless execution. Then stop and report the project connection status, current user gate, top agent todo, and next safe action. After that I will start work with `$loopx <complex task>` or the `loopx` skill from `/skills`. When that task writes LoopX todos, generate the thin task body and set this visible TUI to `/goal <task_body>`; if you cannot mutate `/goal`, show me the exact text to paste instead of saying the loop is active.
 ```
 
 That one message is the install, connect, and status check. The first useful

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -75,20 +75,11 @@ cd /path/to/your-project
 codex
 ```
 
-然后在 TUI 里粘贴一条消息：
+然后在 TUI 里粘贴一条消息。下面的粘贴块故意保持为源码单行，直接整行复制到
+TUI，不要手动加入换行：
 
 ```text
-请在这个可见 Codex CLI TUI 中把当前 repo 接入 LoopX。普通使用不要 clone LoopX
-仓库。若 `loopx` 不在 PATH，请使用官方 no-clone installer 安装或修复：
-curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
-
-然后运行 `loopx doctor`。只在当前项目根目录操作：如果项目已存在 LoopX 状态，
-请复用，不要新建或覆盖 goal；如果尚未接入，优先用 `loopx connect`，只有明确
-缺少 goal 状态且需要初始化时才用 `loopx bootstrap`。确保 `.loopx/`、
-`.codex/goals/`、`.local/` 不会被提交。请留在这个 TUI，不要使用隐藏 headless
-执行；项目连接后，生成 thin task body 并把当前 Codex CLI goal 设置为
-`/goal <thin task_body>`。然后停止，不要在接入这轮开始长任务，只汇报 goal id、
-当前 user gate、top agent todo 和下一步安全动作。
+请在这个可见 Codex CLI TUI 中把当前 repo 接入 LoopX。普通使用不要 clone LoopX 仓库。若 `loopx` 不在 PATH，请使用官方 no-clone installer 安装或修复：curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash; export PATH="$HOME/.local/bin:$PATH"。然后运行 `loopx doctor`。只在当前项目根目录操作：如果项目已存在 LoopX 状态，请复用，不要新建或覆盖 goal；如果尚未接入，优先用 `loopx connect`，只有明确缺少 goal 状态且需要初始化时才用 `loopx bootstrap`。确保 `.loopx/`、`.codex/goals/`、`.local/` 不会被提交。请留在这个 TUI，不要使用隐藏 headless 执行；项目连接后，生成 thin task body 并把当前 Codex CLI goal 设置为 `/goal <thin task_body>`。然后停止，不要在接入这轮开始长任务，只汇报 goal id、当前 user gate、top agent todo 和下一步安全动作。
 ```
 
 这条消息就是安装、连接、可见 `/goal` 设置和状态检查。更细的生成模板、idle/proof 边界见


### PR DESCRIPTION
## Summary

- Keep the README Codex CLI setup prompt as one source line so copying it into the TUI submits one message.
- Apply the same README-only wording to the English and Chinese quick-start sections.

## Issue Or Task

- Closes #
- Contributor task ID:

## Validation

- [x] README paste-block single-line check
- [x] `git diff --check`
- [x] `python -m loopx.cli check` (passed with one existing active-state warning)

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I kept the change scoped to the README Codex CLI install/paste section.
