### PR TITLE
Fix agent-lane projection smoke parity

### DIFF
--- a/examples/control_plane/status-neutral-run-window-smoke.py
+++ b/examples/control_plane/status-neutral-run-window-smoke.py
@@ -13,6 +13,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.diagnose import collect_diagnosis  # noqa: E402
+from loopx.control_plane.scheduler.execution_context import (  # noqa: E402
+    GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT,
+)
 from loopx.quota import (  # noqa: E402
     QUOTA_MONITOR_POLL_CLASSIFICATION,
     QUOTA_SLOT_SPENT_CLASSIFICATION,
@@ -295,7 +298,13 @@ def main() -> int:
         readiness = item["handoff_readiness"]
         assert readiness["post_handoff_latest_run"]["classification"] == REAL_CLASSIFICATION, readiness
 
-        quota = build_quota_should_run(status, goal_id=GOAL_ID)
+        quota = build_quota_should_run(
+            status,
+            goal_id=GOAL_ID,
+            scheduler_execution_context=(
+                GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT
+            ),
+        )
         assert quota["state"] != "operator_gate", quota
         assert quota["effective_action"] == "normal_run", quota
         assert quota["actionable_by_codex"] is True, quota
@@ -354,10 +363,18 @@ def main() -> int:
         assert item["agent_lane_recommendation"]["agent_id"] == AGENT_ID, item
         assert item["agent_lane_recommendation"]["recommended_action"] == AGENT_LANE_ACTION, item
 
-        quota = build_quota_should_run(status, goal_id=AGENT_LANE_GOAL_ID, agent_id=AGENT_ID)
+        quota = build_quota_should_run(
+            status,
+            goal_id=AGENT_LANE_GOAL_ID,
+            agent_id=AGENT_ID,
+            scheduler_execution_context=(
+                GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT
+            ),
+        )
         assert quota["recommended_action"] == AGENT_LANE_TODO, quota
-        assert quota["latest_run_recommended_action"] == STALE_GOAL_ACTION, quota
+        assert quota["latest_run_recommended_action"] == AGENT_LANE_ACTION, quota
         assert quota["agent_lane_next_action"]["todo_id"] == "todo_agent_lane_repair", quota
+        assert quota["next_action_projection_warning"]["severity"] == "info", quota
         assert quota["interaction_contract"]["agent_channel"]["must_attempt"] is True, quota
 
     print("status-neutral-run-window-smoke ok")

--- a/examples/control_plane/status_markdown_agent_lane_fixtures.py
+++ b/examples/control_plane/status_markdown_agent_lane_fixtures.py
@@ -151,11 +151,10 @@ def assert_status_agent_lane_next_action_projection() -> None:
     assert next_action["todo_id"] == "todo_side_tui", next_action
     assert next_action["agent_id"] == "codex-side-bypass", next_action
     assert next_action["preserves_goal_next_action"] is True, next_action
-    warning = item["next_action_projection_warning"]
-    assert warning["severity"] == "info", warning
-    assert warning["requires_state_writeback"] is False, warning
-    assert warning["agent_lane_next_action"] == side_action, warning
-    assert item["project_asset"]["next_action_projection_warning"] == warning, item
+    assert "latest_run_recommended_action" not in item, item
+    assert "next_action_projection_warning" not in item, item
+    assert "latest_run_recommended_action" not in item["project_asset"], item
+    assert "next_action_projection_warning" not in item["project_asset"], item
     goal_frontier = item["goal_frontier_projection"]
     assert goal_frontier["deferred_successors"]["ready_count"] == 0, goal_frontier
     assert goal_frontier["acceptance_gaps"] == [], goal_frontier
@@ -212,7 +211,7 @@ def assert_status_agent_lane_next_action_projection() -> None:
     assert "must_attempt=True delivery_allowed=True quiet_noop_allowed=False" in markdown, markdown
     assert "current_agent_todo: agent=codex-side-bypass todo_id=todo_side_tui" in markdown, markdown
     assert "source=agent_lane_next_action" in markdown, markdown
-    assert "next_action_projection_warning: requires_state_writeback=False severity=info" in markdown, markdown
+    assert "next_action_projection_warning:" not in markdown, markdown
     assert "goal_frontier_projection: replan_required=False" in markdown, markdown
     assert "deferred_ready=0 acceptance_gaps=0" in markdown, markdown
     assert side_action in markdown, markdown

--- a/examples/project/next-action-projection-contract-smoke.py
+++ b/examples/project/next-action-projection-contract-smoke.py
@@ -12,6 +12,9 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 import loopx.state_refresh as state_refresh
+from loopx.control_plane.scheduler.execution_context import (
+    GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT,
+)
 from loopx.presentation.renderers.status_markdown import render_status_markdown
 from loopx.quota import build_quota_should_run, render_quota_should_run_markdown
 from loopx.state_projection import (
@@ -28,6 +31,7 @@ RUN_RECOMMENDATION = "Inspect the vliw suite result before changing the durable 
 UPDATED_NEXT_ACTION = "Promote the vliw repair slice as the durable next action."
 UPDATED_RUN_RECOMMENDATION = "Validate the vliw repair slice and then write compact evidence."
 SIDE_AGENT_ACTION = "Polish the hosted frontstage public case card."
+SIDE_AGENT_RUN_RECOMMENDATION = "Continue the hosted frontstage public case card."
 
 
 def write_fixture(root: Path, *, include_next_action: bool = True) -> tuple[Path, Path, Path, Path]:
@@ -118,6 +122,9 @@ def collect_projection(registry_path: Path, runtime: Path, project: Path) -> dic
         status,
         goal_id=GOAL_ID,
         agent_id="codex-side-bypass",
+        scheduler_execution_context=(
+            GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT
+        ),
     )
     return {"status": status, "item": item, "decision": decision}
 
@@ -239,6 +246,22 @@ def main() -> None:
             assert_state_next_action(state_path, ACTIVE_NEXT_ACTION)
             assert RUN_RECOMMENDATION not in state_text(state_path), state_text(state_path)
 
+            state_refresh.now_local = lambda: "2026-06-22T00:01:30+00:00"
+            lane_payload = state_refresh.refresh_state_run(
+                registry_path=registry_path,
+                runtime_root_override=str(runtime),
+                goal_id=GOAL_ID,
+                project=project,
+                state_file=None,
+                classification="agent_lane_progress",
+                recommended_action=SIDE_AGENT_RUN_RECOMMENDATION,
+                agent_id="codex-side-bypass",
+                progress_scope="agent_lane",
+                dry_run=False,
+                sync_global=False,
+            )
+            assert lane_payload["recommended_action"] == SIDE_AGENT_RUN_RECOMMENDATION, lane_payload
+
             first_projection = collect_projection(registry_path, runtime, project)
             first_item = first_projection["item"]
             first_decision = first_projection["decision"]
@@ -246,7 +269,10 @@ def main() -> None:
             assert first_item["latest_run_recommended_action"] == RUN_RECOMMENDATION, first_item
             assert first_item["next_action_projection_warning"]["requires_state_writeback"] is True, first_item
             assert first_decision["active_state_next_action"] == ACTIVE_NEXT_ACTION, first_decision
-            assert first_decision["latest_run_recommended_action"] == RUN_RECOMMENDATION, first_decision
+            assert (
+                first_decision["latest_run_recommended_action"]
+                == SIDE_AGENT_RUN_RECOMMENDATION
+            ), first_decision
             first_agent_channel = first_decision["interaction_contract"]["agent_channel"]
             assert SIDE_AGENT_ACTION in first_agent_channel["primary_action"], first_decision
             first_trace = first_agent_channel["resolution_trace"]
@@ -288,7 +314,10 @@ def main() -> None:
             assert second_item["active_state_next_action"] == UPDATED_NEXT_ACTION, second_item
             assert second_item["latest_run_recommended_action"] == UPDATED_RUN_RECOMMENDATION, second_item
             assert second_decision["active_state_next_action"] == UPDATED_NEXT_ACTION, second_decision
-            assert second_decision["latest_run_recommended_action"] == UPDATED_RUN_RECOMMENDATION, second_decision
+            assert (
+                second_decision["latest_run_recommended_action"]
+                == SIDE_AGENT_RUN_RECOMMENDATION
+            ), second_decision
             second_agent_channel = second_decision["interaction_contract"]["agent_channel"]
             assert SIDE_AGENT_ACTION in second_agent_channel["primary_action"], second_decision
             second_trace = second_agent_channel["resolution_trace"]

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -668,12 +668,15 @@ def _sync_next_action_projection_warning_from_guard(
     guard: dict[str, object],
 ) -> None:
     warning = guard.get("next_action_projection_warning")
-    if not isinstance(warning, dict):
-        return
-    item["next_action_projection_warning"] = warning
     project_asset = item.get("project_asset")
-    if isinstance(project_asset, dict):
-        project_asset["next_action_projection_warning"] = warning
+    targets = (item, project_asset)
+    for target in targets:
+        if not isinstance(target, dict):
+            continue
+        if isinstance(warning, dict):
+            target["next_action_projection_warning"] = warning
+        else:
+            target.pop("next_action_projection_warning", None)
 
 
 def _agent_reward_memory_projection(


### PR DESCRIPTION
## Summary

- clear stale next-action projection warnings when agent-lane scoping removes the corresponding latest-run recommendation
- migrate projection smokes to assert current-agent run isolation
- provide explicit scheduler execution context in direct quota fixtures

## Validation

- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/status-neutral-run-window-smoke.py`
- `python3 examples/project/next-action-projection-contract-smoke.py`
- `pytest -q tests/control_plane/test_monitor_replan_agent_scope.py` (8 passed)
- `ruff check` on all changed Python files
- `loopx canary premerge --from-git-diff` (18/18 passed; no manual holds)
- full-public shard 4: 100/100 passed
- full-public shard 3: 98/100 passed in parallel; the two installer checks passed when rerun serially with explicit Python 3.12 (the parallel run used macOS Python 3.9 for fresh-clone and hit the 120-second timeout for install-local)

## Review

The runtime change stays in the existing status projection synchronization helper. It does not add a compatibility layer or a new abstraction.
