### PR TITLE
release: LoopX v0.2.13

### DIFF
--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.12"
+__version__ = "0.2.13"

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -1,4 +1,4 @@
-.TH LOOPX 1 "" "LoopX 0.2.12" "User Commands"
+.TH LOOPX 1 "" "LoopX 0.2.13" "User Commands"
 .SH NAME
 loopx \- control-plane helper for long-running agent work
 .SH SYNOPSIS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.2.12"
+version = "0.2.13"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- bump `loopx.__version__` and `pyproject.toml` to `0.2.13`
- regenerate the canonical manpage so its header reports LoopX 0.2.13
- prepare the matching `v0.2.13` GitHub release after merge

## Release baseline

The exact pre-release `main` commit is `5d273024`. GitHub Python Tests passed, and all seven Full Public Smoke shards plus smoke-fleet-health passed.

This release includes monitor transition follow-through, direct migration away from invalid continuous-monitor `resume_when` state, exact agent-lane recommendation isolation, durable vision/replan hardening, host-neutral acknowledged PR-review reconciliation, scoped onboarding refresh commands, and the opt-in SkillsBench reverse-channel provider.

## Validation

- release version contract
- canonical CLI help/manpage smoke and renderer check
- release-readiness documentation smoke
- update smoke
- fresh-clone quickstart smoke
- no-clone Codex CLI release verification smoke
- Python compile
- sdist and wheel build
- Twine checks for both artifacts
- public/private boundary scan
- standard diff-driven premerge canary
- diff hygiene

## Failures or skips

No required check failed. The low-frequency live-model gate and complete exact-release qualification reducer were not rerun for this version-only commit. No matched benchmark outcome baseline is required because this release makes no benchmark-uplift claim.

## Scope

Three generated or version-source lines change. There is no new compatibility layer, scoring change, task-semantics change, permission expansion, upload, submission, or benchmark launch.
