### PR TITLE
Fail fast when SkillsBench local proxy is unavailable

### DIFF
--- a/examples/skillsbench-benchmark-egress-policy-smoke.py
+++ b/examples/skillsbench-benchmark-egress-policy-smoke.py
@@ -3,11 +3,14 @@
 
 from __future__ import annotations
 
+import atexit
 import json
 import os
+import socketserver
 import subprocess
 import sys
 import tempfile
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
@@ -20,11 +23,32 @@ from loopx.benchmark_adapters import skillsbench_dockerfile_runtime as dockerfil
 from loopx.benchmark_adapters import skillsbench_proxy_runtime as proxy_runtime
 
 
+class _LocalProxyProbeHandler(socketserver.BaseRequestHandler):
+    def handle(self) -> None:
+        return
+
+
+_LOCAL_PROXY_SERVER = socketserver.ThreadingTCPServer(
+    ("127.0.0.1", 0),
+    _LocalProxyProbeHandler,
+)
+_LOCAL_PROXY_SERVER.daemon_threads = True
+threading.Thread(
+    target=_LOCAL_PROXY_SERVER.serve_forever,
+    daemon=True,
+).start()
+atexit.register(_LOCAL_PROXY_SERVER.server_close)
+atexit.register(_LOCAL_PROXY_SERVER.shutdown)
+
+
 def _launcher_env_without_profile() -> dict[str, str]:
     env = os.environ.copy()
     env.pop("SKILLSBENCH_RUNNER_PROFILE", None)
     env["XDG_STATE_HOME"] = str(
         Path(tempfile.gettempdir()) / f"loopx-skillsbench-smoke-{os.getpid()}"
+    )
+    env["SKILLSBENCH_LOCAL_CODEX_PROXY_PORT"] = str(
+        _LOCAL_PROXY_SERVER.server_address[1]
     )
     return env
 
@@ -243,6 +267,44 @@ def test_public_launcher_rejects_invalid_product_mode_soft_verify_policy() -> No
         "SKILLSBENCH_PRODUCT_MODE_SOFT_VERIFY_POLICY must be "
         "every-round or final-only" in proc.stderr
     ), proc.stderr
+
+
+def test_public_launcher_rejects_unreachable_local_proxy_before_remote_work() -> None:
+    with socketserver.ThreadingTCPServer(
+        ("127.0.0.1", 0),
+        _LocalProxyProbeHandler,
+    ) as unavailable:
+        unavailable_port = unavailable.server_address[1]
+    env = _launcher_env_without_profile()
+    env.update(
+        {
+            "SKILLSBENCH_SSH_DESTINATION": "example.invalid",
+            "SKILLSBENCH_REMOTE_ROOT": "/remote/loopx",
+            "SKILLSBENCH_ROOT": "/remote/skillsbench",
+            "SKILLSBENCH_EXPECTED_LOOPX_GIT_HEAD": "abc1234",
+            "SKILLSBENCH_DOCKER_PROXY_HOST": "host.docker.internal",
+            "SKILLSBENCH_DOCKER_API_VERSION": "1.43",
+            "SKILLSBENCH_LOCAL_CODEX_PROXY_PORT": str(unavailable_port),
+        }
+    )
+    proc = subprocess.run(
+        [
+            str(REPO_ROOT / "scripts" / "skillsbench-launch-goal-xhigh.sh"),
+            "--dry-run",
+            "citation-check",
+            "local-proxy-unreachable-smoke",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 2, proc
+    assert proc.stdout == "", proc.stdout
+    assert proc.stderr.strip() == "skillsbench_local_proxy_endpoint_unreachable"
+    assert str(unavailable_port) not in proc.stderr
 
 
 def test_public_launcher_batches_three_cases_with_closeout_sync() -> None:

--- a/examples/skillsbench-runner-profile-smoke.py
+++ b/examples/skillsbench-runner-profile-smoke.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import socketserver
 import stat
 import subprocess
 import sys
 import tempfile
+import threading
 from pathlib import Path
 
 
@@ -33,6 +35,11 @@ PROFILE_MODULE = (
     / "benchmark_adapters"
     / "skillsbench_runner_profile.py"
 )
+
+
+class _LocalProxyProbeHandler(socketserver.BaseRequestHandler):
+    def handle(self) -> None:
+        return
 
 
 def _environment() -> dict[str, str]:
@@ -168,21 +175,35 @@ def main() -> None:
         )
         default_profile_path.parent.mkdir(parents=True)
         shutil.copy2(profile_path, default_profile_path)
-        completed = subprocess.run(
-            [
-                "bash",
-                str(launcher),
-                "--dry-run",
-                "fixture-task",
-                "runner-profile-smoke",
-                "18181",
-            ],
-            cwd=launcher.parents[1],
-            env=launch_environment,
-            text=True,
-            capture_output=True,
-            check=False,
-        )
+        with socketserver.ThreadingTCPServer(
+            ("127.0.0.1", 0),
+            _LocalProxyProbeHandler,
+        ) as local_proxy:
+            local_proxy.daemon_threads = True
+            thread = threading.Thread(
+                target=local_proxy.serve_forever,
+                daemon=True,
+            )
+            thread.start()
+            launch_environment["SKILLSBENCH_LOCAL_CODEX_PROXY_PORT"] = str(
+                local_proxy.server_address[1]
+            )
+            completed = subprocess.run(
+                [
+                    "bash",
+                    str(launcher),
+                    "--dry-run",
+                    "fixture-task",
+                    "runner-profile-smoke",
+                    "18181",
+                ],
+                cwd=launcher.parents[1],
+                env=launch_environment,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            local_proxy.shutdown()
         assert completed.returncode == 0, completed.stderr
         output = completed.stdout
         assert "runner_profile_loaded=true" in output

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -433,6 +433,24 @@ fi
 batch_case_start_gap="${SKILLSBENCH_BATCH_CASE_START_GAP_SEC:-3}"
 local_proxy_host="${SKILLSBENCH_LOCAL_CODEX_PROXY_HOST:-127.0.0.1}"
 local_proxy_port="${SKILLSBENCH_LOCAL_CODEX_PROXY_PORT:-18180}"
+if ! python3 - "$local_proxy_host" "$local_proxy_port" <<'PY'
+import socket
+import sys
+
+host = sys.argv[1]
+try:
+    port = int(sys.argv[2])
+    if not 1 <= port <= 65535:
+        raise ValueError
+    with socket.create_connection((host, port), timeout=1.0):
+        pass
+except (OSError, ValueError):
+    raise SystemExit(1)
+PY
+then
+  echo "skillsbench_local_proxy_endpoint_unreachable" >&2
+  exit 2
+fi
 docker_api_version="${SKILLSBENCH_DOCKER_API_VERSION:-auto}"
 if [[ -z "$docker_api_version" || "$docker_api_version" == "auto" ]]; then
   docker_api_probe_py='import json, sys; print(json.load(sys.stdin)["ApiVersion"])'


### PR DESCRIPTION
## Summary
- validate the launcher local proxy endpoint before SSH and benchmark setup
- return a stable public-safe blocker without recording the endpoint
- keep launcher and runner-profile dry-run coverage on ephemeral loopback listeners

## Validation
- `python3 examples/skillsbench-runner-profile-smoke.py`
- `python3 examples/skillsbench-benchmark-egress-policy-smoke.py`
- `python3 -m py_compile examples/skillsbench-benchmark-egress-policy-smoke.py examples/skillsbench-runner-profile-smoke.py`
- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`
- `loopx canary premerge --from-git-diff --no-progress`: all 4 direct checks, 6 catalog checks, and the public-boundary scan passed; the generic benchmark-sensitive manual hold is covered by the owner standing authorization for validated benchmark helper PRs

No benchmark job is launched, and scoring, task semantics, verifier behavior, upload, and submission behavior are unchanged.