### PR TITLE
Keep SkillsBench dry-run independent of local proxy

### DIFF
--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -433,7 +433,8 @@ fi
 batch_case_start_gap="${SKILLSBENCH_BATCH_CASE_START_GAP_SEC:-3}"
 local_proxy_host="${SKILLSBENCH_LOCAL_CODEX_PROXY_HOST:-127.0.0.1}"
 local_proxy_port="${SKILLSBENCH_LOCAL_CODEX_PROXY_PORT:-18180}"
-if ! python3 - "$local_proxy_host" "$local_proxy_port" <<'PY'
+if [[ "$dry_run" == "false" ]] &&
+  ! python3 - "$local_proxy_host" "$local_proxy_port" <<'PY'
 import socket
 import sys
 

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -99,6 +99,31 @@ def test_turn_launcher_wires_private_commands_without_echoing_values(
     assert "sentinel-" not in output
 
 
+def test_launcher_dry_run_does_not_require_reachable_local_proxy(
+    tmp_path: Path,
+) -> None:
+    env = _base_env(tmp_path)
+    env.update(
+        {
+            "SKILLSBENCH_LOCAL_CODEX_PROXY_HOST": "127.0.0.1",
+            "SKILLSBENCH_LOCAL_CODEX_PROXY_PORT": "1",
+        }
+    )
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "proxy-contract"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+
+    assert "skillsbench_local_proxy_endpoint_unreachable" not in proc.stderr
+    assert "docker_proxy_host_recorded=false" in proc.stdout
+
+
 def test_launcher_fails_before_batch_when_exact_host_sandbox_probe_fails(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- keep the local proxy reachability preflight on executable launcher runs
- let `--dry-run` remain a side-effect-free command projection that does not require local infrastructure
- add a focused regression test for an unreachable proxy during dry-run

## Root cause
PR #2497 correctly moved proxy failure ahead of SSH and benchmark materialization, but the probe ran before the launcher branched on `--dry-run`. Existing launcher dry-run tests do not start a local proxy, so the merged change broke the repository's GitHub test suite.

## Validation
- `uv run --extra test pytest -q tests/test_skillsbench_turn_launcher.py`: 21 passed
- `python3 examples/skillsbench-runner-profile-smoke.py`
- `python3 examples/skillsbench-benchmark-egress-policy-smoke.py`
- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`
- `loopx canary premerge --from-git-diff --no-progress`: all direct checks and 4 selected catalog checks passed; the benchmark-sensitive manual hold is covered by the owner's standing authorization for benchmark PR self-merge
- full local suite: 1137 passed, 2 skipped, with 3 unrelated macOS/Python 3.13 environment failures; the changed launcher test file passed completely

No benchmark job is launched. Scoring, task semantics, verifier behavior, uploads, and submissions are unchanged.
