### PR TITLE
Fix SkillsBench pip no-isolation staging

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -6261,6 +6261,7 @@ def test_skillsbench_docker_task_staging_adds_pip_bootstrap_patch() -> None:
         ), staged_text
         assert "PIP_RETRIES=10" in staged_text, staged_text
         assert "PIP_NO_BUILD_ISOLATION" not in staged_text, staged_text
+        assert "--no-build-isolation" not in staged_text, staged_text
         assert staged_text.index(DOCKER_PIP_BOOTSTRAP_BEGIN) < staged_text.index(
             "pip3 install"
         ), staged_text
@@ -6298,7 +6299,14 @@ def test_skillsbench_docker_task_staging_adds_pip_bootstrap_patch() -> None:
         assert no_isolation_metadata["dockerfile_pip_build_mode"] == (
             "no-isolation"
         ), no_isolation_metadata
-        assert "PIP_NO_BUILD_ISOLATION=1" in no_isolation_text, no_isolation_text
+        assert "PIP_NO_BUILD_ISOLATION" not in no_isolation_text, no_isolation_text
+        assert "pip3 install --no-build-isolation numpy" in no_isolation_text, (
+            no_isolation_text
+        )
+        assert (
+            "python3 -m pip install --no-build-isolation pyyaml"
+            in no_isolation_text
+        ), no_isolation_text
 
 
 def test_skillsbench_docker_pip_bootstrap_skips_python_heredoc_imports() -> None:

--- a/loopx/benchmark_adapters/skillsbench_dockerfile_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_dockerfile_runtime.py
@@ -21,6 +21,12 @@ _BARE_PIP_INSTALL_RE = re.compile(
     r"(?P<prefix>^\s*(?:RUN\s+)?|(?:&&|\|\||;|\|)\s*)pip3?\s+install\b",
     re.IGNORECASE,
 )
+_PIP_INSTALL_RE = re.compile(
+    r"(?P<prefix>^\s*(?:RUN\s+)?|(?:&&|\|\||;|\|)\s*)"
+    r"(?P<command>(?:(?:python3?|python)\s+-m\s+pip|pip3?)\s+install)\b"
+    r"(?!\s+--no-build-isolation\b)",
+    re.IGNORECASE,
+)
 
 
 def _write_text_atomic(path: Path, text: str) -> None:
@@ -241,6 +247,32 @@ def patch_debian_apt_mirror(dockerfile: Path) -> bool:
 def dockerfile_heredoc_delimiter(line: str) -> str | None:
     match = re.search(r"<<-?\s*['\"]?([A-Za-z_][A-Za-z0-9_]*)['\"]?", line)
     return match.group(1) if match else None
+
+
+def add_pip_no_build_isolation_flags(text: str) -> tuple[str, int]:
+    """Add pip's explicit no-isolation flag outside Dockerfile heredocs."""
+
+    lines: list[str] = []
+    replaced = 0
+    heredoc_delimiter: str | None = None
+    for line in text.splitlines():
+        if heredoc_delimiter is not None:
+            lines.append(line)
+            if line.strip() == heredoc_delimiter:
+                heredoc_delimiter = None
+            continue
+        heredoc_delimiter = dockerfile_heredoc_delimiter(line)
+        if line.lstrip().startswith("#"):
+            lines.append(line)
+            continue
+        rewritten, count = _PIP_INSTALL_RE.subn(
+            r"\g<prefix>\g<command> --no-build-isolation",
+            line,
+        )
+        lines.append(rewritten)
+        replaced += count
+    suffix = "\n" if text.endswith("\n") else ""
+    return "\n".join(lines) + suffix, replaced
 
 
 def _rewrite_bare_pip_installs(text: str) -> tuple[str, int]:

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -8015,18 +8015,14 @@ def patch_dockerfile_pip_bootstrap(
         DOCKER_PIP_BOOTSTRAP_BEGIN,
         DOCKER_PIP_BOOTSTRAP_END,
     )
-    build_mode_env = (
-        "    PIP_NO_BUILD_ISOLATION=1 \\\n"
-        if build_mode == "no-isolation"
-        else ""
-    )
+    if build_mode == "no-isolation":
+        text, _ = dockerfile_runtime.add_pip_no_build_isolation_flags(text)
     block = (
         f"{DOCKER_PIP_BOOTSTRAP_BEGIN}\n"
         f"ARG LOOPX_SKILLSBENCH_PIP_INDEX_URL={index_url}\n"
         "ENV PIP_INDEX_URL=${LOOPX_SKILLSBENCH_PIP_INDEX_URL} \\\n"
         "    PIP_DEFAULT_TIMEOUT=120 \\\n"
         "    PIP_RETRIES=10 \\\n"
-        f"{build_mode_env}"
         "    PIP_DISABLE_PIP_VERSION_CHECK=1\n"
         f"{DOCKER_PIP_BOOTSTRAP_END}"
     )

--- a/tests/test_skillsbench_dockerfile_runtime.py
+++ b/tests/test_skillsbench_dockerfile_runtime.py
@@ -52,3 +52,25 @@ def test_ubuntu_apt_mirror_patch_ignores_from_inside_heredoc(tmp_path: Path) -> 
     patched = dockerfile.read_text(encoding="utf-8")
     assert patched.count(runtime.UBUNTU_APT_MIRROR_BEGIN) == 1
     assert patched.index(runtime.UBUNTU_APT_MIRROR_BEGIN) < patched.index("RUN python3")
+
+
+def test_pip_no_build_isolation_flags_are_explicit_and_heredoc_safe() -> None:
+    original = (
+        "FROM python:3.12-slim\n"
+        "RUN pip3 install numpy && python3 -m pip install cython\n"
+        "RUN python -m pip install --no-build-isolation pandas\n"
+        'RUN echo "pip install remains documentation"\n'
+        "RUN python3 - <<'PY'\n"
+        "pip install not-a-docker-command\n"
+        "PY\n"
+    )
+
+    patched, count = runtime.add_pip_no_build_isolation_flags(original)
+
+    assert count == 2
+    assert "pip3 install --no-build-isolation numpy" in patched
+    assert "python3 -m pip install --no-build-isolation cython" in patched
+    assert patched.count("python -m pip install --no-build-isolation pandas") == 1
+    assert 'echo "pip install remains documentation"' in patched
+    assert "pip install not-a-docker-command" in patched
+    assert runtime.add_pip_no_build_isolation_flags(patched) == (patched, 0)


### PR DESCRIPTION
## Summary
- replace the ineffective `PIP_NO_BUILD_ISOLATION=1` staging environment variable with pip's explicit `--no-build-isolation` CLI flag
- apply the rewrite only when `docker_pip_build_mode=no-isolation` is explicitly selected
- keep isolated mode unchanged and avoid rewriting heredocs, comments, or documentation strings

## Root cause
Pip exposes `--no-build-isolation` as a `store_false` option for `build_isolation`. The staged `PIP_NO_BUILD_ISOLATION=1` value was parsed as a truthy value, so the fallback mode did not actually disable build isolation. The explicit CLI flag is the supported, unambiguous contract.

## Validation
- 74 focused pytest cases passed
- targeted pip-staging and heredoc smokes passed
- full `skillsbench-benchmark-run-smoke.py` passed
- full `skillsbench-benchmark-egress-policy-smoke.py` passed
- changed-file py_compile passed
- focused Ruff and `git diff --check` passed
- premerge catalog: 7/7 checks passed, maintainability magnitude regressions 0, public boundary clean

## Boundaries
- no benchmark job launched
- no scoring, task, verifier, submission, or ordinary quota behavior changed
- no raw task text, trajectories, logs, verifier output, credentials, or local paths included
- generic canary reports the expected benchmark-sensitive manual hold; owner standing authorization permits self-review and self-merge of validated benchmark PRs
