### PR TITLE
fix(status): bound agent todo index output

### DIFF
--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -120,6 +120,26 @@ def _compact_agent_lane_todos_for_status_display(payload: dict[str, object]) -> 
         }
 
 
+def _compact_agent_lane_todo_index_for_status_display(payload: dict[str, object]) -> None:
+    todo_index = payload.get("todo_index")
+    if not isinstance(todo_index, dict):
+        return
+    items = todo_index.get("items")
+    if not isinstance(items, list) or not items:
+        return
+    omitted_item_count = len(items)
+    todo_index["items"] = []
+    todo_index["payload_compaction"] = {
+        "schema_version": "agent_lane_status_todo_index_compaction_v0",
+        "omitted_item_count": omitted_item_count,
+        "reason": (
+            "status --agent-id uses the attention queue for current work and "
+            "keeps the whole-goal todo index on a cold path"
+        ),
+        "full_detail_cold_path": "status without --agent-id or todo list",
+    }
+
+
 def register_status_commands(
     subparsers: argparse._SubParsersAction,
     add_subcommand_format: Callable[[argparse.ArgumentParser], None],
@@ -409,6 +429,7 @@ def handle_status_command(
                 collection_limit=collection_limit,
             )
             _compact_agent_lane_todos_for_status_display(payload)
+            _compact_agent_lane_todo_index_for_status_display(payload)
     except Exception as exc:
         payload = {
             "ok": False,

--- a/loopx/control_plane/testing/cli_output_budget.py
+++ b/loopx/control_plane/testing/cli_output_budget.py
@@ -173,21 +173,24 @@ CLI_OUTPUT_BUDGET_SPECS: tuple[CliOutputBudgetSpec, ...] = (
         owner="operator and agent status",
         consumer_action="locate the current goal and attention state",
         qualification_policy="absolute_hot_path",
-        cold_path="--include-task-graph, history, and run artifacts",
+        cold_path=(
+            "status without --agent-id or todo list for whole-goal todo index "
+            "detail; --include-task-graph, history, and run artifacts"
+        ),
         semantic_json_keys=("status_contract", "attention_queue", "todo_index"),
         markdown_anchor="# LoopX Status",
         max_chars={
             "small": {"json": 42_000, "markdown": 7_000},
-            "crowded": {"json": 70_000, "markdown": 7_800},
-            "multi_agent": {"json": 70_000, "markdown": 7_800},
+            "crowded": {"json": 58_000, "markdown": 7_800},
+            "multi_agent": {"json": 58_000, "markdown": 7_800},
         },
         max_lines={
             "small": {"json": 1_120, "markdown": 85},
-            "crowded": {"json": 1_850, "markdown": 90},
-            "multi_agent": {"json": 1_850, "markdown": 90},
+            "crowded": {"json": 1_550, "markdown": 90},
+            "multi_agent": {"json": 1_550, "markdown": 90},
         },
         scale_axis="todo_count",
-        max_json_growth_chars_per_unit=750,
+        max_json_growth_chars_per_unit=550,
     ),
     CliOutputBudgetSpec(
         surface_id="diagnose",

--- a/tests/control_plane/test_cli_output_budget.py
+++ b/tests/control_plane/test_cli_output_budget.py
@@ -606,6 +606,50 @@ def test_real_cli_output_stays_inside_the_characterized_baseline(
             assert formats["markdown"]["json_parseable"] is False
 
 
+def test_agent_scoped_status_keeps_whole_goal_todo_index_on_cold_path(
+    tmp_path: Path,
+) -> None:
+    with _stable_budget_fixture_root(tmp_path / "agent-status") as stable_root:
+        project, runtime, registry_path, state_file = _write_fixture(
+            stable_root,
+            SCENARIOS[1],
+        )
+        command = _surface_commands(
+            project=project,
+            runtime=runtime,
+            registry_path=registry_path,
+            state_file=state_file,
+            output_format="json",
+        )["status"]
+        agent_flag = command.index("--agent-id")
+        operator_command = command[:agent_flag] + command[agent_flag + 2 :]
+
+        exit_code, text = _invoke_cli(command)
+        operator_exit_code, operator_text = _invoke_cli(operator_command)
+
+    assert exit_code == 0, text
+    payload = json.loads(text)
+    todo_index = payload["todo_index"]
+    assert todo_index["total_count"] > 0
+    assert todo_index["items"] == []
+    assert todo_index["payload_compaction"] == {
+        "schema_version": "agent_lane_status_todo_index_compaction_v0",
+        "omitted_item_count": todo_index["total_count"],
+        "reason": (
+            "status --agent-id uses the attention queue for current work and "
+            "keeps the whole-goal todo index on a cold path"
+        ),
+        "full_detail_cold_path": "status without --agent-id or todo list",
+    }
+    assert payload["attention_queue"]["items"][0]["agent_todos"]["open_count"] == (
+        SCENARIOS[1].todo_count
+    )
+    assert operator_exit_code == 0, operator_text
+    operator_todo_index = json.loads(operator_text)["todo_index"]
+    assert len(operator_todo_index["items"]) == operator_todo_index["total_count"]
+    assert "payload_compaction" not in operator_todo_index
+
+
 def test_status_and_quota_json_ignore_compatibility_reexport_bindings(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- keep the whole-goal `todo_index.items` detail off the `status --agent-id` hot path while preserving the index schema, counts, and a cold-path read hint
- retain full todo-index detail for operator status without `--agent-id` and for `todo list`
- tighten the characterized status JSON size, line, and per-todo growth ceilings

## Evidence
- real `loopx-meta` agent-scoped status: 269,923 -> 176,592 bytes (34.6% reduction); 5,570 -> 3,535 lines
- CLI output budget suite: 8 passed
- Ruff 0.12-0.15 policy: passed
- risk-based premerge: 17/17 selected checks passed, 0 failures, 0 manual holds

## Boundary
Public control-plane code and deterministic fixture coverage only. No private state, raw run evidence, credentials, local paths, or generated logs are included.
