### PR TITLE
Fix release smoke archive cache race

### DIFF
--- a/examples/codex-cli-packaged-install-smoke.py
+++ b/examples/codex-cli-packaged-install-smoke.py
@@ -19,7 +19,11 @@ def add_tree(tar: tarfile.TarFile, root: Path, name: str) -> None:
         for child in sorted(path.rglob("*")):
             if ".git" in child.parts or "__pycache__" in child.parts:
                 continue
-            tar.add(child, arcname=str(Path("loopx-main") / child.relative_to(root)))
+            tar.add(
+                child,
+                arcname=str(Path("loopx-main") / child.relative_to(root)),
+                recursive=False,
+            )
     else:
         tar.add(path, arcname=str(Path("loopx-main") / name))
 

--- a/examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
+++ b/examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
@@ -22,7 +22,11 @@ def add_tree(tar: tarfile.TarFile, root: Path, name: str) -> None:
         for child in sorted(path.rglob("*")):
             if ".git" in child.parts or "__pycache__" in child.parts:
                 continue
-            tar.add(child, arcname=str(Path("loopx-main") / child.relative_to(root)))
+            tar.add(
+                child,
+                arcname=str(Path("loopx-main") / child.relative_to(root)),
+                recursive=False,
+            )
     else:
         tar.add(path, arcname=str(Path("loopx-main") / name))
 

--- a/examples/release/codex-cli-no-clone-release-verification-smoke.py
+++ b/examples/release/codex-cli-no-clone-release-verification-smoke.py
@@ -64,7 +64,11 @@ def add_tree(tar: tarfile.TarFile, root: Path, name: str) -> None:
         for child in sorted(path.rglob("*")):
             if ".git" in child.parts or "__pycache__" in child.parts:
                 continue
-            tar.add(child, arcname=str(Path("loopx-main") / child.relative_to(root)))
+            tar.add(
+                child,
+                arcname=str(Path("loopx-main") / child.relative_to(root)),
+                recursive=False,
+            )
     else:
         tar.add(path, arcname=str(Path("loopx-main") / name))
 

--- a/tests/test_release_smoke_archive_helpers.py
+++ b/tests/test_release_smoke_archive_helpers.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import runpy
+import tarfile
+from pathlib import Path
+
+import pytest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+ARCHIVE_SMOKES = (
+    Path("examples/codex-cli-packaged-install-smoke.py"),
+    Path("examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py"),
+    Path("examples/release/codex-cli-no-clone-release-verification-smoke.py"),
+)
+
+
+@pytest.mark.parametrize("script_path", ARCHIVE_SMOKES)
+def test_add_tree_excludes_nested_python_cache(
+    script_path: Path,
+    tmp_path: Path,
+) -> None:
+    add_tree = runpy.run_path(str(REPOSITORY_ROOT / script_path))["add_tree"]
+    source_root = tmp_path / "source"
+    nested = source_root / "package" / "nested"
+    cache = nested / "__pycache__"
+    cache.mkdir(parents=True)
+    (nested / "kept.txt").write_text("kept\n", encoding="utf-8")
+    (cache / "volatile.pyc").write_bytes(b"volatile")
+
+    archive_path = tmp_path / "release.tar"
+    with tarfile.open(archive_path, "w") as archive:
+        add_tree(archive, source_root, "package")
+
+    with tarfile.open(archive_path) as archive:
+        archived_names = archive.getnames()
+
+    assert "loopx-main/package/nested/kept.txt" in archived_names
+    assert all("__pycache__" not in Path(name).parts for name in archived_names)


### PR DESCRIPTION
## Summary

- stop the three release archive smoke helpers from recursively re-traversing directories already selected by their filtered `rglob` walk
- keep `__pycache__` and transient `.pyc` files out of generated release fixtures
- add a parameterized regression test covering all three helpers

## Root cause

[Full Public Smokes run 30068072844](https://github.com/huangruiteng/loopx/actions/runs/30068072844) failed on main because `tarfile.add()` recursively entered a nested `__pycache__` directory after the outer walk had filtered it. A temporary `.pyc` file disappeared between directory enumeration and `lstat`, raising `FileNotFoundError`. The smoke-fleet-health failure was downstream of that shard failure.

## Validation

- `pytest -q tests/test_release_smoke_archive_helpers.py`: 3 passed
- Ruff on all four changed files: passed
- no-clone release verification smoke: passed
- packaged install smoke: passed
- Codex CLI TUI bootstrap bundle smoke: passed
- standard premerge gate: 18/18 passed, 0 manual holds, public boundary clean
- Full Public shard 500: the repaired no-clone smoke passed; one unrelated concurrency smoke hit the local 120-second limit and passed when rerun standalone

No runtime product behavior, release metadata, credentials, private state, or generated logs are included.