### PR TITLE
fix(quota): deduplicate vision audit output

### DIFF
--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -222,6 +222,14 @@ def register_quota_command(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
     quota_parser.add_argument(
+        "--include-vision-audit-detail",
+        action="store_true",
+        help=(
+            "Include repeated full vision continuation audit diagnostics in "
+            "`quota should-run`. The default keeps decision anchors and refs."
+        ),
+    )
+    quota_parser.add_argument(
         "--codex-app-current-rrule",
         help=(
             "Current RRULE observed from the active Codex App heartbeat. For "
@@ -382,6 +390,14 @@ def handle_quota_command(
         ):
             raise ValueError(
                 "--include-todo-summary-detail is only valid with `quota should-run`"
+            )
+        if (
+            bool(getattr(args, "include_vision_audit_detail", False))
+            and args.quota_command != "should-run"
+        ):
+            raise ValueError(
+                "--include-vision-audit-detail is only valid with "
+                "`quota should-run`"
             )
         raw_heartbeat_turn_id = getattr(args, "turn_instance_id", None)
         heartbeat_turn_id = normalize_turn_instance_id(raw_heartbeat_turn_id)
@@ -876,11 +892,16 @@ def handle_quota_command(
             payload,
             scheduler_execution_context=scheduler_context,
         )
-    elif (
-        args.quota_command == "should-run"
-        and not bool(getattr(args, "include_todo_summary_detail", False))
-    ):
-        payload = compact_quota_should_run_cli_payload(payload)
+    elif args.quota_command == "should-run":
+        payload = compact_quota_should_run_cli_payload(
+            payload,
+            include_todo_summary_detail=bool(
+                getattr(args, "include_todo_summary_detail", False)
+            ),
+            include_vision_audit_detail=bool(
+                getattr(args, "include_vision_audit_detail", False)
+            ),
+        )
     renderer = (
         render_turn_envelope_markdown
         if bool(getattr(args, "turn_envelope", False))

--- a/loopx/control_plane/quota/cli_projection.py
+++ b/loopx/control_plane/quota/cli_projection.py
@@ -9,12 +9,29 @@ QUOTA_CLI_TODO_SUMMARY_COMPACTION_SCHEMA_VERSION = (
 QUOTA_CLI_TODO_SUMMARY_DETAIL_COMMAND = (
     "quota should-run --include-todo-summary-detail"
 )
+QUOTA_CLI_VISION_AUDIT_COMPACTION_SCHEMA_VERSION = (
+    "quota_cli_vision_audit_compaction_v0"
+)
+QUOTA_CLI_VISION_AUDIT_DETAIL_COMMAND = (
+    "quota should-run --include-vision-audit-detail"
+)
+QUOTA_CLI_VISION_AUDIT_ROOT_REF = "#/vision_continuation_audit"
 _RETAINED_AGENT_ITEM_LANES = {
     "first_open_items": 3,
     "first_executable_items": 3,
     "monitor_due_items": 1,
     "monitor_capability_blocked_due_items": 2,
 }
+_VISION_AUDIT_ANCHOR_FIELDS = (
+    "required",
+    "agent_id",
+    "decision",
+    "selected_todo_is_goal_completion",
+    "closeout_allowed_without_evidence",
+    "trigger_count",
+    "trigger_kinds",
+    "recommended_action",
+)
 
 
 def _compact_nested_item_lists(
@@ -65,20 +82,95 @@ def _compact_agent_todo_summary(summary: dict[str, Any]) -> dict[str, Any]:
     return compact
 
 
+def _vision_audit_anchor(
+    audit: dict[str, Any],
+    *,
+    detail_ref: str,
+) -> dict[str, Any]:
+    anchor = {
+        "schema_version": QUOTA_CLI_VISION_AUDIT_COMPACTION_SCHEMA_VERSION,
+        "source_schema_version": audit.get("schema_version"),
+    }
+    for field in _VISION_AUDIT_ANCHOR_FIELDS:
+        if field in audit:
+            anchor[field] = audit[field]
+    anchor["detail_ref"] = detail_ref
+    anchor["full_detail_cold_path"] = QUOTA_CLI_VISION_AUDIT_DETAIL_COMMAND
+    return anchor
+
+
+def _compact_vision_audit_copies(payload: dict[str, Any]) -> dict[str, Any]:
+    root_audit = payload.get("vision_continuation_audit")
+    if not isinstance(root_audit, dict):
+        return payload
+
+    compact = dict(payload)
+    compact["vision_continuation_audit"] = _vision_audit_anchor(
+        root_audit,
+        detail_ref=QUOTA_CLI_VISION_AUDIT_DETAIL_COMMAND,
+    )
+
+    frontier = payload.get("goal_frontier_projection")
+    if isinstance(frontier, dict) and isinstance(
+        frontier.get("vision_continuation_audit"),
+        dict,
+    ):
+        compact_frontier = dict(frontier)
+        compact_frontier["vision_continuation_audit"] = _vision_audit_anchor(
+            frontier["vision_continuation_audit"],
+            detail_ref=QUOTA_CLI_VISION_AUDIT_ROOT_REF,
+        )
+        compact["goal_frontier_projection"] = compact_frontier
+
+    interaction = payload.get("interaction_contract")
+    if isinstance(interaction, dict):
+        compact_interaction = dict(interaction)
+        changed = False
+        for channel_name in ("agent_channel", "cli_channel"):
+            channel = interaction.get(channel_name)
+            if not isinstance(channel, dict) or not isinstance(
+                channel.get("vision_continuation_audit"),
+                dict,
+            ):
+                continue
+            compact_channel = dict(channel)
+            compact_channel["vision_continuation_audit"] = _vision_audit_anchor(
+                channel["vision_continuation_audit"],
+                detail_ref=QUOTA_CLI_VISION_AUDIT_ROOT_REF,
+            )
+            compact_interaction[channel_name] = compact_channel
+            changed = True
+        if changed:
+            compact["interaction_contract"] = compact_interaction
+
+    compact["vision_audit_projection"] = {
+        "schema_version": QUOTA_CLI_VISION_AUDIT_COMPACTION_SCHEMA_VERSION,
+        "mode": "compact_hot_path",
+        "canonical_ref": QUOTA_CLI_VISION_AUDIT_ROOT_REF,
+        "detail_ref": QUOTA_CLI_VISION_AUDIT_DETAIL_COMMAND,
+    }
+    return compact
+
+
 def compact_quota_should_run_cli_payload(
     payload: dict[str, Any],
+    *,
+    include_todo_summary_detail: bool = False,
+    include_vision_audit_detail: bool = False,
 ) -> dict[str, Any]:
-    """Bound CLI-only todo diagnostics after the full decision is computed."""
+    """Bound CLI-only diagnostics after the full decision is computed."""
 
+    compact = payload
     summary = payload.get("agent_todo_summary")
-    if not isinstance(summary, dict):
-        return payload
-    compact = dict(payload)
-    compact["agent_todo_summary"] = _compact_agent_todo_summary(summary)
-    compact["todo_summary_projection"] = {
-        "schema_version": QUOTA_CLI_TODO_SUMMARY_COMPACTION_SCHEMA_VERSION,
-        "mode": "compact_hot_path",
-        "compacted_roles": ["agent"],
-        "detail_ref": QUOTA_CLI_TODO_SUMMARY_DETAIL_COMMAND,
-    }
+    if not include_todo_summary_detail and isinstance(summary, dict):
+        compact = dict(compact)
+        compact["agent_todo_summary"] = _compact_agent_todo_summary(summary)
+        compact["todo_summary_projection"] = {
+            "schema_version": QUOTA_CLI_TODO_SUMMARY_COMPACTION_SCHEMA_VERSION,
+            "mode": "compact_hot_path",
+            "compacted_roles": ["agent"],
+            "detail_ref": QUOTA_CLI_TODO_SUMMARY_DETAIL_COMMAND,
+        }
+    if not include_vision_audit_detail:
+        compact = _compact_vision_audit_copies(compact)
     return compact

--- a/loopx/control_plane/testing/cli_output_budget.py
+++ b/loopx/control_plane/testing/cli_output_budget.py
@@ -128,7 +128,7 @@ CLI_OUTPUT_BUDGET_SPECS: tuple[CliOutputBudgetSpec, ...] = (
         qualification_policy="absolute_hot_path",
         cold_path=(
             "status, history, active state, --include-scheduler-detail, and "
-            "--include-todo-summary-detail"
+            "--include-todo-summary-detail or --include-vision-audit-detail"
         ),
         semantic_json_keys=("interaction_contract", "scheduler_hint", "selected_todo"),
         markdown_anchor="# LoopX Quota Should Run",
@@ -382,6 +382,16 @@ CLI_OUTPUT_MODE_VARIANT_SPECS: tuple[CliOutputModeVariantSpec, ...] = (
         markdown_anchor="# LoopX Quota Should Run",
         max_chars={"json": 55_000, "markdown": 7_800},
         max_lines={"json": 1_350, "markdown": 78},
+    ),
+    CliOutputModeVariantSpec(
+        variant_id="quota_should_run_vision_audit_detail",
+        parent_surface_id="quota_should_run",
+        command="quota should-run --include-vision-audit-detail",
+        output_formats=("json", "markdown"),
+        semantic_json_keys=("scheduler_hint", "selected_todo"),
+        markdown_anchor="# LoopX Quota Should Run",
+        max_chars={"json": 45_000, "markdown": 7_800},
+        max_lines={"json": 1_050, "markdown": 78},
     ),
     CliOutputModeVariantSpec(
         variant_id="quota_should_run_turn_envelope",

--- a/tests/control_plane/test_cli_output_budget.py
+++ b/tests/control_plane/test_cli_output_budget.py
@@ -182,6 +182,38 @@ def _write_rollout_event(runtime: Path, *, agent_id: str) -> None:
     )
 
 
+def _write_agent_vision(runtime: Path, *, agent_id: str) -> None:
+    runs_dir = runtime / "goals" / GOAL_ID / "runs"
+    index_path = runs_dir / "index.jsonl"
+    rows = [
+        json.loads(line)
+        for line in index_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    vision = {
+        "schema_version": "goal_vision_replan_contract_v0",
+        "goal_id": GOAL_ID,
+        "agent_id": agent_id,
+        "state": "vision_replanned",
+        "vision_patch": {
+            "vision_summary": "Keep qualifying the CLI output contract.",
+            "acceptance_summary": "The active output budget gap is closed.",
+            "advancement_policy": "repeat_until_closed",
+            "replan_trigger_summary": "The output budget remains above its target.",
+        },
+        "todo_delta": ["continue_quality_qualification"],
+    }
+    rows[-1]["agent_vision"] = vision
+    run_path = Path(rows[-1]["json_path"])
+    run = json.loads(run_path.read_text(encoding="utf-8"))
+    run["agent_vision"] = vision
+    run_path.write_text(json.dumps(run) + "\n", encoding="utf-8")
+    index_path.write_text(
+        "".join(json.dumps(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
 def _invoke_cli(args: list[str]) -> tuple[int, str]:
     output = io.StringIO()
     with contextlib.redirect_stdout(output):
@@ -465,6 +497,18 @@ def _mode_variant_commands(
             str(project),
             "--include-todo-summary-detail",
         ],
+        "quota_should_run_vision_audit_detail": common
+        + [
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_IDS[0],
+            "--scan-root",
+            str(project),
+            "--include-vision-audit-detail",
+        ],
         "quota_should_run_turn_envelope": common
         + [
             "quota",
@@ -578,6 +622,7 @@ def test_manifest_covers_the_declared_agent_facing_surface_set() -> None:
         "bootstrap_command_pack_message_only",
         "quota_should_run_scheduler_detail",
         "quota_should_run_todo_summary_detail",
+        "quota_should_run_vision_audit_detail",
         "quota_should_run_turn_envelope",
         "loopx_turn_plan_transaction_detail",
         "loopx_turn_run_once_preview",
@@ -661,6 +706,54 @@ def test_quota_cli_keeps_full_agent_todo_diagnostics_on_explicit_cold_path(
     assert detail_summary["backlog_items"]
     assert "todo_summary_projection" not in detail_payload
     for key in ("interaction_contract", "scheduler_hint", "selected_todo"):
+        assert default_payload[key] == detail_payload[key]
+
+
+def test_quota_cli_keeps_full_vision_audit_on_explicit_cold_path(
+    tmp_path: Path,
+) -> None:
+    with _stable_budget_fixture_root(tmp_path / "quota-vision-detail") as stable_root:
+        project, runtime, registry_path, state_file = _write_fixture(
+            stable_root,
+            SCENARIOS[1],
+        )
+        _write_agent_vision(runtime, agent_id=AGENT_IDS[0])
+        default_command = _surface_commands(
+            project=project,
+            runtime=runtime,
+            registry_path=registry_path,
+            state_file=state_file,
+            output_format="json",
+        )["quota_should_run"]
+        detail_command = _mode_variant_commands(
+            project=project,
+            runtime=runtime,
+            registry_path=registry_path,
+            state_file=state_file,
+            output_format="json",
+        )["quota_should_run_vision_audit_detail"]
+
+        default_exit_code, default_text = _invoke_cli(default_command)
+        detail_exit_code, detail_text = _invoke_cli(detail_command)
+
+    assert default_exit_code == 0, default_text
+    assert detail_exit_code == 0, detail_text
+    default_payload = json.loads(default_text)
+    detail_payload = json.loads(detail_text)
+    default_audit = default_payload["vision_continuation_audit"]
+    detail_audit = detail_payload["vision_continuation_audit"]
+    assert default_audit["schema_version"] == (
+        "quota_cli_vision_audit_compaction_v0"
+    )
+    assert default_payload["vision_audit_projection"]["detail_ref"] == (
+        "quota should-run --include-vision-audit-detail"
+    )
+    assert "acceptance_gaps" not in default_audit
+    assert detail_audit["acceptance_gaps"]
+    assert "vision_audit_projection" not in detail_payload
+    for key in ("required", "decision", "recommended_action"):
+        assert default_audit[key] == detail_audit[key]
+    for key in ("scheduler_hint", "selected_todo"):
         assert default_payload[key] == detail_payload[key]
 
 

--- a/tests/control_plane/test_quota_cli_projection.py
+++ b/tests/control_plane/test_quota_cli_projection.py
@@ -4,6 +4,8 @@ import json
 
 from loopx.control_plane.quota.cli_projection import (
     QUOTA_CLI_TODO_SUMMARY_DETAIL_COMMAND,
+    QUOTA_CLI_VISION_AUDIT_DETAIL_COMMAND,
+    QUOTA_CLI_VISION_AUDIT_ROOT_REF,
     compact_quota_should_run_cli_payload,
 )
 
@@ -102,3 +104,81 @@ def test_compact_quota_should_run_cli_payload_keeps_decision_lanes_and_counts() 
     larger_compact_chars = len(json.dumps(larger_compact, sort_keys=True))
     assert compact_chars < 10_000
     assert larger_compact_chars - compact_chars < 200
+
+
+def test_compact_quota_should_run_cli_payload_deduplicates_vision_audit() -> None:
+    audit = {
+        "schema_version": "vision_continuation_audit_v0",
+        "required": True,
+        "agent_id": "quality-agent",
+        "decision": "acceptance_gap_open",
+        "selected_todo_is_goal_completion": False,
+        "closeout_allowed_without_evidence": False,
+        "trigger_count": 1,
+        "trigger_kinds": ["vision_acceptance_gap"],
+        "acceptance_gaps": _items(30, prefix="gap"),
+        "required_before_closeout": [f"requirement-{index}" for index in range(30)],
+        "recommended_action": "continue one bounded quality slice",
+        "vision_gap_judge": {
+            "done": False,
+            "decision": "continue",
+            "agent_judge_instruction": "inspect authoritative evidence",
+        },
+    }
+    payload = {
+        "selected_todo": {"todo_id": "quality-0"},
+        "scheduler_hint": {"action": "run_now"},
+        "vision_continuation_audit": audit,
+        "goal_frontier_projection": {
+            "vision_continuation_audit": audit,
+        },
+        "interaction_contract": {
+            "mode": "bounded_delivery",
+            "agent_channel": {
+                "must_attempt": True,
+                "vision_continuation_audit": audit,
+            },
+            "cli_channel": {
+                "next_cli_actions": ["continue"],
+                "vision_continuation_audit": audit,
+            },
+        },
+    }
+
+    compact = compact_quota_should_run_cli_payload(
+        payload,
+        include_todo_summary_detail=True,
+    )
+
+    root = compact["vision_continuation_audit"]
+    assert root["required"] is True
+    assert root["decision"] == "acceptance_gap_open"
+    assert root["recommended_action"] == "continue one bounded quality slice"
+    assert root["detail_ref"] == QUOTA_CLI_VISION_AUDIT_DETAIL_COMMAND
+    assert "acceptance_gaps" not in root
+    assert "vision_gap_judge" not in root
+    for nested in (
+        compact["goal_frontier_projection"]["vision_continuation_audit"],
+        compact["interaction_contract"]["agent_channel"][
+            "vision_continuation_audit"
+        ],
+        compact["interaction_contract"]["cli_channel"][
+            "vision_continuation_audit"
+        ],
+    ):
+        assert nested["required"] is True
+        assert nested["decision"] == "acceptance_gap_open"
+        assert nested["recommended_action"] == "continue one bounded quality slice"
+        assert nested["detail_ref"] == QUOTA_CLI_VISION_AUDIT_ROOT_REF
+        assert "acceptance_gaps" not in nested
+    assert payload["vision_continuation_audit"]["acceptance_gaps"]
+
+    full = compact_quota_should_run_cli_payload(
+        payload,
+        include_todo_summary_detail=True,
+        include_vision_audit_detail=True,
+    )
+    assert full == payload
+    compact_chars = len(json.dumps(compact, sort_keys=True))
+    full_chars = len(json.dumps(full, sort_keys=True))
+    assert compact_chars < full_chars * 0.45


### PR DESCRIPTION
## Summary
- replace four repeated full vision continuation audits in default `quota should-run` output with bounded decision anchors
- preserve `required`, `decision`, `recommended_action`, closure flags, and deterministic JSON refs
- expose the original repeated payload through `--include-vision-audit-detail`

## Real-scale result
- PR #2510 default: 65,702 bytes / 1,384 lines
- this PR default: 51,256 bytes / 1,169 lines
- reduction: 14,446 bytes (22.0%)
- combined full-detail mode remains available at 102,878 bytes
- `selected_todo`, `scheduler_hint`, and the required/decision/recommended-action anchors are exactly equal across default and detail modes

## Qualification
- focused pytest: 11 passed
- pinned Ruff: passed
- risk-based premerge: 17/17 checks passed, no failures or manual holds
- public/private boundary scan: clean

## Dependency
This is intentionally stacked on #2510 so the preceding todo-summary compaction stays reviewable. Retarget to `main` after #2510 merges; do not merge this PR first.