### PR TITLE
fix(quota): bound user todo diagnostics

### DIFF
--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -222,6 +222,14 @@ def register_quota_command(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
     quota_parser.add_argument(
+        "--include-user-todo-summary-detail",
+        action="store_true",
+        help=(
+            "Include cold-path user todo diagnostic lanes in `quota should-run`. "
+            "The default keeps counts and current-agent user actions or gates only."
+        ),
+    )
+    quota_parser.add_argument(
         "--codex-app-current-rrule",
         help=(
             "Current RRULE observed from the active Codex App heartbeat. For "
@@ -391,6 +399,14 @@ def handle_quota_command(
         ):
             raise ValueError(
                 "--include-todo-summary-detail is only valid with `quota should-run`"
+            )
+        if (
+            bool(getattr(args, "include_user_todo_summary_detail", False))
+            and args.quota_command != "should-run"
+        ):
+            raise ValueError(
+                "--include-user-todo-summary-detail is only valid with "
+                "`quota should-run`"
             )
         raw_heartbeat_turn_id = getattr(args, "turn_instance_id", None)
         heartbeat_turn_id = normalize_turn_instance_id(raw_heartbeat_turn_id)
@@ -886,11 +902,16 @@ def handle_quota_command(
             payload,
             scheduler_execution_context=scheduler_context,
         )
-    elif (
-        args.quota_command == "should-run"
-        and not bool(getattr(args, "include_todo_summary_detail", False))
-    ):
-        payload = compact_quota_should_run_cli_payload(payload)
+    elif args.quota_command == "should-run":
+        payload = compact_quota_should_run_cli_payload(
+            payload,
+            include_todo_summary_detail=bool(
+                getattr(args, "include_todo_summary_detail", False)
+            ),
+            include_user_todo_summary_detail=bool(
+                getattr(args, "include_user_todo_summary_detail", False)
+            ),
+        )
     renderer = (
         render_turn_envelope_markdown
         if bool(getattr(args, "turn_envelope", False))

--- a/loopx/control_plane/quota/cli_projection.py
+++ b/loopx/control_plane/quota/cli_projection.py
@@ -9,12 +9,23 @@ QUOTA_CLI_TODO_SUMMARY_COMPACTION_SCHEMA_VERSION = (
 QUOTA_CLI_TODO_SUMMARY_DETAIL_COMMAND = (
     "quota should-run --include-todo-summary-detail"
 )
+QUOTA_CLI_USER_TODO_SUMMARY_COMPACTION_SCHEMA_VERSION = (
+    "quota_cli_user_todo_summary_compaction_v0"
+)
+QUOTA_CLI_USER_TODO_SUMMARY_DETAIL_COMMAND = (
+    "quota should-run --include-user-todo-summary-detail"
+)
 _RETAINED_AGENT_ITEM_LANES = {
     "first_executable_items": 3,
     "unclaimed_priority_open_items": 3,
     "monitor_due_items": 1,
     "monitor_capability_blocked_due_items": 2,
     "monitor_schedule_gap_items": 1,
+}
+_RETAINED_USER_ITEM_LANES = {
+    "first_open_items": 3,
+    "gate_open_items": 3,
+    "active_next_action_items": 3,
 }
 _RETAINED_AGENT_ITEM_FIELDS = (
     "schema_version",
@@ -118,20 +129,69 @@ def _compact_agent_todo_summary(summary: dict[str, Any]) -> dict[str, Any]:
     return compact
 
 
+def _compact_user_todo_summary(summary: dict[str, Any]) -> dict[str, Any]:
+    compact: dict[str, Any] = {}
+    omitted_lanes: dict[str, int] = {}
+    for key, value in summary.items():
+        if isinstance(value, list):
+            limit = _RETAINED_USER_ITEM_LANES.get(key)
+            if limit is None:
+                if value:
+                    omitted_lanes[key] = len(value)
+                continue
+            compact[key] = value[:limit]
+            if len(value) > limit:
+                omitted_lanes[key] = len(value) - limit
+            continue
+        if isinstance(value, dict):
+            compact[key] = _compact_nested_item_lists(
+                value,
+                omitted_lanes=omitted_lanes,
+                path=key,
+            )
+            continue
+        compact[key] = value
+
+    compact["payload_compaction"] = {
+        "schema_version": QUOTA_CLI_USER_TODO_SUMMARY_COMPACTION_SCHEMA_VERSION,
+        "retained_item_lanes": sorted(_RETAINED_USER_ITEM_LANES),
+        "omitted_lanes": omitted_lanes,
+        "full_detail_cold_path": QUOTA_CLI_USER_TODO_SUMMARY_DETAIL_COMMAND,
+    }
+    return compact
+
+
 def compact_quota_should_run_cli_payload(
     payload: dict[str, Any],
+    *,
+    include_todo_summary_detail: bool = False,
+    include_user_todo_summary_detail: bool = False,
 ) -> dict[str, Any]:
     """Bound CLI-only todo diagnostics after the full decision is computed."""
 
+    compact = payload
+    compacted_roles: list[str] = []
     summary = payload.get("agent_todo_summary")
-    if not isinstance(summary, dict):
-        return payload
-    compact = dict(payload)
-    compact["agent_todo_summary"] = _compact_agent_todo_summary(summary)
-    compact["todo_summary_projection"] = {
-        "schema_version": QUOTA_CLI_TODO_SUMMARY_COMPACTION_SCHEMA_VERSION,
-        "mode": "compact_hot_path",
-        "compacted_roles": ["agent"],
-        "detail_ref": QUOTA_CLI_TODO_SUMMARY_DETAIL_COMMAND,
-    }
+    if not include_todo_summary_detail and isinstance(summary, dict):
+        compact = dict(compact)
+        compact["agent_todo_summary"] = _compact_agent_todo_summary(summary)
+        compacted_roles.append("agent")
+
+    user_summary = payload.get("user_todo_summary")
+    if not include_user_todo_summary_detail and isinstance(user_summary, dict):
+        compact = dict(compact)
+        compact["user_todo_summary"] = _compact_user_todo_summary(user_summary)
+        compacted_roles.append("user")
+
+    if compacted_roles:
+        compact["todo_summary_projection"] = {
+            "schema_version": QUOTA_CLI_TODO_SUMMARY_COMPACTION_SCHEMA_VERSION,
+            "mode": "compact_hot_path",
+            "compacted_roles": compacted_roles,
+            "detail_ref": (
+                QUOTA_CLI_TODO_SUMMARY_DETAIL_COMMAND
+                if compacted_roles[0] == "agent"
+                else QUOTA_CLI_USER_TODO_SUMMARY_DETAIL_COMMAND
+            ),
+        }
     return compact

--- a/loopx/control_plane/testing/cli_output_budget.py
+++ b/loopx/control_plane/testing/cli_output_budget.py
@@ -128,7 +128,7 @@ CLI_OUTPUT_BUDGET_SPECS: tuple[CliOutputBudgetSpec, ...] = (
         qualification_policy="absolute_hot_path",
         cold_path=(
             "status, history, active state, --include-scheduler-detail, and "
-            "--include-todo-summary-detail"
+            "--include-todo-summary-detail or --include-user-todo-summary-detail"
         ),
         semantic_json_keys=("interaction_contract", "scheduler_hint", "selected_todo"),
         markdown_anchor="# LoopX Quota Should Run",
@@ -385,6 +385,16 @@ CLI_OUTPUT_MODE_VARIANT_SPECS: tuple[CliOutputModeVariantSpec, ...] = (
         markdown_anchor="# LoopX Quota Should Run",
         max_chars={"json": 55_000, "markdown": 7_800},
         max_lines={"json": 1_350, "markdown": 78},
+    ),
+    CliOutputModeVariantSpec(
+        variant_id="quota_should_run_user_todo_summary_detail",
+        parent_surface_id="quota_should_run",
+        command="quota should-run --include-user-todo-summary-detail",
+        output_formats=("json", "markdown"),
+        semantic_json_keys=("interaction_contract", "scheduler_hint", "selected_todo"),
+        markdown_anchor="# LoopX Quota Should Run",
+        max_chars={"json": 35_000, "markdown": 7_800},
+        max_lines={"json": 900, "markdown": 78},
     ),
     CliOutputModeVariantSpec(
         variant_id="quota_should_run_turn_envelope",

--- a/tests/control_plane/test_cli_output_budget.py
+++ b/tests/control_plane/test_cli_output_budget.py
@@ -465,6 +465,18 @@ def _mode_variant_commands(
             str(project),
             "--include-todo-summary-detail",
         ],
+        "quota_should_run_user_todo_summary_detail": common
+        + [
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_IDS[0],
+            "--scan-root",
+            str(project),
+            "--include-user-todo-summary-detail",
+        ],
         "quota_should_run_turn_envelope": common
         + [
             "quota",
@@ -578,6 +590,7 @@ def test_manifest_covers_the_declared_agent_facing_surface_set() -> None:
         "bootstrap_command_pack_message_only",
         "quota_should_run_scheduler_detail",
         "quota_should_run_todo_summary_detail",
+        "quota_should_run_user_todo_summary_detail",
         "quota_should_run_turn_envelope",
         "loopx_turn_plan_transaction_detail",
         "loopx_turn_run_once_preview",
@@ -660,6 +673,83 @@ def test_quota_cli_keeps_full_agent_todo_diagnostics_on_explicit_cold_path(
     assert "backlog_items" not in default_summary
     assert detail_summary["backlog_items"]
     assert "todo_summary_projection" not in detail_payload
+    for key in ("interaction_contract", "scheduler_hint", "selected_todo"):
+        assert default_payload[key] == detail_payload[key]
+
+
+def test_quota_cli_keeps_full_user_todo_diagnostics_on_explicit_cold_path(
+    tmp_path: Path,
+) -> None:
+    with _stable_budget_fixture_root(tmp_path / "quota-user-todo-detail") as stable_root:
+        project, runtime, registry_path, state_file = _write_fixture(
+            stable_root,
+            SCENARIOS[2],
+        )
+        state_text = state_file.read_text(encoding="utf-8")
+        user_section = "\n".join(
+            [
+                "## User Todo",
+                "",
+                "- [ ] [P0-user] Approve the scoped output release.",
+                (
+                    "  <!-- loopx:todo todo_id=todo_user_gate_001 status=open "
+                    "task_class=user_gate action_kind=approve_output_release "
+                    "blocks_agent=codex-alpha "
+                    "decision_scope=release:action:quota-output priority=P0-USER -->"
+                ),
+                "- [ ] [P1] Review the other agent output notes.",
+                (
+                    "  <!-- loopx:todo todo_id=todo_user_action_001 status=open "
+                    "task_class=user_action action_kind=review_output_notes "
+                    "bound_agent=codex-beta priority=P1 -->"
+                ),
+                "",
+            ]
+        )
+        state_file.write_text(
+            state_text.replace("## Agent Todo", f"{user_section}\n## Agent Todo"),
+            encoding="utf-8",
+        )
+        default_command = _surface_commands(
+            project=project,
+            runtime=runtime,
+            registry_path=registry_path,
+            state_file=state_file,
+            output_format="json",
+        )["quota_should_run"]
+        detail_command = _mode_variant_commands(
+            project=project,
+            runtime=runtime,
+            registry_path=registry_path,
+            state_file=state_file,
+            output_format="json",
+        )["quota_should_run_user_todo_summary_detail"]
+
+        default_exit_code, default_text = _invoke_cli(default_command)
+        detail_exit_code, detail_text = _invoke_cli(detail_command)
+
+    assert default_exit_code == 0, default_text
+    assert detail_exit_code == 0, detail_text
+    default_payload = json.loads(default_text)
+    detail_payload = json.loads(detail_text)
+    default_summary = default_payload["user_todo_summary"]
+    detail_summary = detail_payload["user_todo_summary"]
+    assert default_summary["payload_compaction"]["schema_version"] == (
+        "quota_cli_user_todo_summary_compaction_v0"
+    )
+    assert default_summary["payload_compaction"]["full_detail_cold_path"] == (
+        "quota should-run --include-user-todo-summary-detail"
+    )
+    assert default_summary["gate_open_items"][0]["todo_id"] == "todo_user_gate_001"
+    assert default_summary["gate_open_items"][0]["blocks_agent"] == "codex-alpha"
+    assert "other_agent_bound_user_action_items" not in default_summary
+    assert detail_summary["other_agent_bound_user_action_items"][0]["todo_id"] == (
+        "todo_user_action_001"
+    )
+    assert detail_summary["payload_compaction"]["schema_version"] == (
+        "quota_todo_summary_payload_compaction_v0"
+    )
+    assert detail_payload["todo_summary_projection"]["compacted_roles"] == ["agent"]
     for key in ("interaction_contract", "scheduler_hint", "selected_todo"):
         assert default_payload[key] == detail_payload[key]
 

--- a/tests/control_plane/test_quota_cli_projection.py
+++ b/tests/control_plane/test_quota_cli_projection.py
@@ -4,6 +4,7 @@ import json
 
 from loopx.control_plane.quota.cli_projection import (
     QUOTA_CLI_TODO_SUMMARY_DETAIL_COMMAND,
+    QUOTA_CLI_USER_TODO_SUMMARY_DETAIL_COMMAND,
     compact_quota_should_run_cli_payload,
 )
 from loopx.presentation.renderers.quota_markdown import (
@@ -144,6 +145,98 @@ def test_compact_quota_should_run_cli_payload_keeps_decision_lanes_and_counts() 
     larger_compact_chars = len(json.dumps(larger_compact, sort_keys=True))
     assert compact_chars < 7_000
     assert larger_compact_chars - compact_chars < 200
+
+
+def test_compact_quota_should_run_cli_payload_keeps_active_user_work_and_gate_scope() -> None:
+    active_user_actions = [
+        {
+            **item,
+            "task_class": "user_action",
+            "bound_agent": "quality-agent",
+        }
+        for item in _items(4, prefix="user-action")
+    ]
+    active_gates = [
+        {
+            **item,
+            "task_class": "user_gate",
+            "blocks_agent": "quality-agent",
+            "decision_scope": "release:action:quota-output",
+        }
+        for item in _items(2, prefix="user-gate")
+    ]
+    other_agent_actions = [
+        {
+            **item,
+            "task_class": "user_action",
+            "bound_agent": "other-agent",
+        }
+        for item in _items(20, prefix="other-user-action")
+    ]
+    payload = {
+        "interaction_contract": {
+            "user_channel": {
+                "action_required": True,
+                "items": active_user_actions[:1],
+            }
+        },
+        "selected_todo": {"todo_id": "quality-0"},
+        "scheduler_hint": {"action": "wait"},
+        "user_todo_summary": {
+            "schema_version": "todo_summary_v0",
+            "total_count": 30,
+            "open_count": 6,
+            "all_open_count": 26,
+            "first_open_items": active_user_actions,
+            "gate_open_items": active_gates,
+            "active_next_action_items": active_user_actions[:2],
+            "deferred_items": other_agent_actions,
+            "other_agent_bound_user_action_items": other_agent_actions,
+            "claim_scope": {
+                "schema_version": "agent_claim_scope_v0",
+                "blocked_claimed_open_count": 2,
+                "blocked_claimed_items": other_agent_actions,
+            },
+        },
+    }
+
+    compact = compact_quota_should_run_cli_payload(
+        payload,
+        include_todo_summary_detail=True,
+    )
+
+    summary = compact["user_todo_summary"]
+    assert summary["total_count"] == 30
+    assert summary["open_count"] == 6
+    assert len(summary["first_open_items"]) == 3
+    assert summary["gate_open_items"] == active_gates
+    assert summary["active_next_action_items"] == active_user_actions[:2]
+    assert summary["gate_open_items"][0]["blocks_agent"] == "quality-agent"
+    assert summary["gate_open_items"][0]["decision_scope"] == (
+        "release:action:quota-output"
+    )
+    assert "deferred_items" not in summary
+    assert "other_agent_bound_user_action_items" not in summary
+    assert "blocked_claimed_items" not in summary["claim_scope"]
+    assert summary["payload_compaction"]["omitted_lanes"] == {
+        "claim_scope.blocked_claimed_items": 20,
+        "deferred_items": 20,
+        "first_open_items": 1,
+        "other_agent_bound_user_action_items": 20,
+    }
+    assert summary["payload_compaction"]["full_detail_cold_path"] == (
+        QUOTA_CLI_USER_TODO_SUMMARY_DETAIL_COMMAND
+    )
+    assert compact["todo_summary_projection"]["compacted_roles"] == ["user"]
+    assert compact["interaction_contract"] == payload["interaction_contract"]
+    assert compact["selected_todo"] == payload["selected_todo"]
+
+    full = compact_quota_should_run_cli_payload(
+        payload,
+        include_todo_summary_detail=True,
+        include_user_todo_summary_detail=True,
+    )
+    assert full == payload
 
 
 def test_compact_quota_should_run_cli_payload_keeps_succession_warning_identity_in_markdown() -> None:


### PR DESCRIPTION
## Summary
- compact default `quota should-run` user todo diagnostics while retaining counts and up to three current user actions, gates, and next actions
- preserve gate identity, `blocks_agent`, and `decision_scope`; move deferred and other-agent diagnostic lists behind an explicit cold path
- add `--include-user-todo-summary-detail` independently from the existing agent todo detail flag

## Scope
- rebuilt directly on `main`; no dependency on closed PR #2511
- no vision-audit compaction, agent monitor alias handling, scheduler semantics, permission changes, or production actions

## Validation
- `ruff check` on all five changed Python files
- `pytest -q` across quota projection, quota accounting, Markdown boundary/renderers, and CLI output budget tests: 30 passed
- `python -m loopx.cli canary premerge --from-git-diff`: 17/17 selected checks passed, no manual holds
- CLI base/head differential and output budget regression passed
- `git diff --check` and public/private boundary scan passed

## Review focus
- default projection keeps actionable user todo identity and gate scope
- agent and user detail flags reveal only their own diagnostic role
- compact output remains inside the qualified hot-path budget