### PR TITLE
fix(heartbeat): reconcile acknowledged PR reviews before quota

### DIFF
--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -432,6 +432,20 @@ again before completion, then closes the reminder only for the exact terminal
 PR. A missing receipt, stale revision, unavailable provider, or unsupported
 forge leaves the reminder open. Quota projection has no provider side effects.
 
+Heartbeat hosts with `external_evidence_poll` may run the bounded batch form
+before quota:
+
+```bash
+loopx heartbeat-prequota -g <goal-id> -a <bound-agent>
+```
+
+The batch reads only persisted exact acknowledgement bindings, skips stale or
+already reconciled todos before provider access, and performs no quota spend.
+Provider failures are reported as degraded results and do not block the
+subsequent quota guard. Binding, acknowledgement, and reconciliation are kernel
+contracts; `loopx-project` may document the workflow but is not a runtime
+dependency.
+
 If an agent takes ownership at completion time, include the claim in the same
 locked lifecycle write:
 

--- a/examples/control_plane/heartbeat-prompt-smoke.py
+++ b/examples/control_plane/heartbeat-prompt-smoke.py
@@ -286,6 +286,10 @@ def main() -> int:
     assert "--available-capability external_evidence_poll" in capability_task_body, (
         capability_task_body
     )
+    assert "heartbeat-prequota" in capability_task_body, capability_task_body
+    assert capability_scoped_payload["pr_review_pre_quota_command"] == (
+        "loopx heartbeat-prequota -g public-heartbeat-goal -a codex-side-bypass"
+    ), capability_scoped_payload
     assert "productization showcase docs lane" in normalized(str(profile_scoped_payload["task_body"])), (
         profile_scoped_payload
     )
@@ -306,6 +310,8 @@ def main() -> int:
         "todo continuation",
         "no cross-agent authority",
         "no scope in todo metadata",
+        "No runtime `loopx-project`",
+        "heartbeat-prequota",
         'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota should-run '
         "--goal-id loopx-meta --agent-id codex-product-capability --available-capability network "
         "--available-capability external_evidence_poll",
@@ -402,7 +408,7 @@ def main() -> int:
     thin_task = normalized(str(thin_payload["task_body"]))
     for phrase in (
         "Advance `public-heartbeat-goal` from /tmp/public-heartbeat-goal/ACTIVE_GOAL_STATE.md",
-        "Skills: `loopx-project`; surprise/conflict",
+        "No runtime `loopx-project`",
         "`loopx-self-repair`",
         "LoopX CLI = truth",
         "state/status/repo",

--- a/examples/issue-fix-pr-review-reconcile-smoke.py
+++ b/examples/issue-fix-pr-review-reconcile-smoke.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -16,11 +18,13 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from loopx.capabilities.issue_fix.pr_gate_reconcile import (  # noqa: E402
+    reconcile_acknowledged_issue_fix_pr_reviews,
     reconcile_issue_fix_pr_review,
 )
 from loopx.capabilities.issue_fix.pr_review_ack import (  # noqa: E402
     record_issue_fix_pr_review_ack,
 )
+from loopx.heartbeat_prequota import run_heartbeat_pre_quota  # noqa: E402
 from loopx.status import parse_active_state_todos  # noqa: E402
 from loopx.todos import update_goal_todo  # noqa: E402
 
@@ -207,34 +211,123 @@ def main() -> int:
         assert current_ack["binding"]["todo_revision"] != (
             first_ack["binding"]["todo_revision"]
         )
-        reconciled = reconcile_issue_fix_pr_review(
+        with patch(
+            "loopx.capabilities.issue_fix.pr_gate_reconcile."
+            "build_issue_fix_pr_lifecycle_monitor_packet",
+            side_effect=ValueError("private provider detail"),
+        ):
+            degraded = reconcile_acknowledged_issue_fix_pr_reviews(
+                registry_path=registry_path,
+                runtime_root_arg=str(runtime_root),
+                goal_id="example-goal",
+                agent_id="codex-test",
+                project=project,
+                fetch_metadata=True,
+                execute=True,
+            )
+        assert degraded["degraded"] is True, degraded
+        assert degraded["failure_count"] == 1, degraded
+        assert degraded["results"][0]["error_category"] == (
+            "provider_observation_failed"
+        ), degraded
+        assert "error" not in degraded["results"][0], degraded
+
+        with patch(
+            "loopx.capabilities.issue_fix.pr_gate_reconcile."
+            "build_issue_fix_pr_lifecycle_monitor_packet",
+            return_value={
+                "observation": {
+                    "repo": "huangruiteng/loopx",
+                    "number": 1716,
+                    "permalink": PR_URL,
+                    "state": "MERGED",
+                    "merged_at": "2026-07-24T01:02:00Z",
+                },
+                "external_reads_performed": True,
+            },
+        ):
+            batch = reconcile_acknowledged_issue_fix_pr_reviews(
+                registry_path=registry_path,
+                runtime_root_arg=str(runtime_root),
+                goal_id="example-goal",
+                agent_id="codex-test",
+                project=project,
+                fetch_metadata=True,
+                execute=True,
+            )
+        assert batch["ok"] is True, batch
+        assert batch["ack_receipt_count"] == 1, batch
+        assert batch["external_read_count"] == 1, batch
+        assert batch["terminal_count"] == 1, batch
+        assert batch["reconciled_count"] == 1, batch
+        assert batch["quota_spend_required"] is False, batch
+        assert todo(state_file, "todo_github_review")["status"] == "done"
+
+        with patch(
+            "loopx.capabilities.issue_fix.pr_gate_reconcile."
+            "build_issue_fix_pr_lifecycle_monitor_packet",
+            side_effect=AssertionError(
+                "completed acknowledgement must not read provider"
+            ),
+        ):
+            repeated = reconcile_acknowledged_issue_fix_pr_reviews(
+                registry_path=registry_path,
+                runtime_root_arg=str(runtime_root),
+                goal_id="example-goal",
+                agent_id="codex-test",
+                project=project,
+                fetch_metadata=True,
+                execute=True,
+            )
+        assert repeated["already_reconciled_count"] == 1, repeated
+        assert repeated["external_read_count"] == 0, repeated
+        assert repeated["reconciled_count"] == 0, repeated
+
+        prequota = run_heartbeat_pre_quota(
             registry_path=registry_path,
             runtime_root_arg=str(runtime_root),
             goal_id="example-goal",
-            todo_id="todo_github_review",
             agent_id="codex-test",
-            project=project,
-            url=PR_URL,
-            ack_receipt=current_ack["ack_receipt"],
-            provider_payload={
-                "state": "MERGED",
-                "mergedAt": "2026-07-24T01:02:00Z",
-            },
-            execute=True,
         )
-        assert reconciled["reconciled"] is True, reconciled
-        assert reconciled["write_performed"] is True, reconciled
-        assert todo(state_file, "todo_github_review")["status"] == "done"
+        assert prequota["ok"] is True, prequota
+        assert prequota["continue_to_quota"] is True, prequota
+        assert prequota["quota_spend_required"] is False, prequota
+        assert prequota["degraded"] is False, prequota
 
-        repeated = reconcile_without_provider(
-            registry_path=registry_path,
-            runtime_root=runtime_root,
-            project=project,
-            todo_id="todo_github_review",
-            ack_receipt=current_ack["ack_receipt"],
+        home = project / "home"
+        global_registry = home / ".codex" / "loopx" / "registry.global.json"
+        global_registry.parent.mkdir(parents=True)
+        global_registry.write_text(
+            registry_path.read_text(encoding="utf-8"),
+            encoding="utf-8",
         )
-        assert repeated["already_reconciled"] is True, repeated
-        assert repeated["external_read_performed"] is False, repeated
+        cli_env = dict(os.environ)
+        cli_env["HOME"] = str(home)
+        cli_env["PYTHONPATH"] = str(ROOT)
+        cli = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--format",
+                "json",
+                "heartbeat-prequota",
+                "-g",
+                "example-goal",
+                "-a",
+                "codex-test",
+            ],
+            cwd=project,
+            env=cli_env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert cli.returncode == 0, cli.stderr
+        cli_payload = json.loads(cli.stdout)
+        assert cli_payload["schema_version"] == "heartbeat_pre_quota_v0", cli_payload
+        assert cli_payload["continue_to_quota"] is True, cli_payload
+        assert cli_payload["quota_spend_required"] is False, cli_payload
 
         assert todo(state_file, "todo_other_provider")["status"] == "open"
 

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -214,6 +214,11 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "module": "loopx.capabilities.issue_fix.pr_review_ack",
                 "doc": "docs/project-agent-todo-contract.md",
             },
+            {
+                "schema_version": "issue_fix_pr_review_acked_reconciliation_v0",
+                "module": "loopx.capabilities.issue_fix.pr_gate_reconcile",
+                "doc": "docs/project-agent-todo-contract.md",
+            },
         ],
         "smokes": [
             "python3 examples/value-connectors-github-public-probe-smoke.py",

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -1074,6 +1074,7 @@ def handle_issue_fix_command(
             "pr-gate-reconcile",
             "pr-review-ack",
             "pr-review-reconcile",
+            "pr-review-reconcile-acked",
         }:
             if args.issue_fix_command == "pr-gate-reconcile":
                 payload = (
@@ -1090,6 +1091,15 @@ def handle_issue_fix_command(
                 )
                 renderer = (
                     pr_gate_reconcile_cli.render_issue_fix_pr_review_ack_markdown
+                )
+            elif args.issue_fix_command == "pr-review-reconcile-acked":
+                payload = (
+                    pr_gate_reconcile_cli.build_acked_pr_review_reconciliation_from_args(
+                        args, registry_path, runtime_root_arg, generated_at
+                    )
+                )
+                renderer = (
+                    pr_gate_reconcile_cli.render_issue_fix_acked_pr_review_reconciliation_markdown
                 )
             else:
                 payload = (

--- a/loopx/capabilities/issue_fix/pr_gate_reconcile.py
+++ b/loopx/capabilities/issue_fix/pr_gate_reconcile.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Mapping
 
+from ...history import load_registry
+from ...paths import resolve_runtime_root
 from ...control_plane.todos.contract import (
     normalize_todo_decision_scope,
 )
@@ -10,11 +12,17 @@ from ...control_plane.todos.projection import todo_item_task_class
 from ...todos import complete_goal_todo, list_goal_todos
 from .pr_lifecycle import build_issue_fix_pr_lifecycle_monitor_packet
 from .pr_lifecycle_rollout import append_pr_merge_rollout_event
-from .pr_review_ack import resolve_issue_fix_pr_review_context
+from .pr_review_ack import (
+    load_issue_fix_pr_review_ack_receipts,
+    resolve_issue_fix_pr_review_context,
+)
 
 
 PR_GATE_RECONCILIATION_SCHEMA_VERSION = "issue_fix_pr_gate_reconciliation_v0"
 PR_REVIEW_RECONCILIATION_SCHEMA_VERSION = "issue_fix_pr_review_reconciliation_v0"
+PR_REVIEW_ACKED_RECONCILIATION_SCHEMA_VERSION = (
+    "issue_fix_pr_review_acked_reconciliation_v0"
+)
 TERMINAL_PR_STATES = {"MERGED", "CLOSED"}
 
 
@@ -340,6 +348,113 @@ def reconcile_issue_fix_pr_review(
         )
     receipt["reconciled"] = True
     return receipt
+
+
+def reconcile_acknowledged_issue_fix_pr_reviews(
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    goal_id: str,
+    agent_id: str,
+    project: Path | None,
+    fetch_metadata: bool = False,
+    fetch_timeout_seconds: int = 10,
+    execute: bool = False,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    """Reconcile current review todos from their persisted acknowledgement bindings."""
+
+    runtime_root = (
+        Path(runtime_root_arg).expanduser()
+        if runtime_root_arg
+        else resolve_runtime_root(load_registry(registry_path.expanduser()), None)
+    )
+    receipts = load_issue_fix_pr_review_ack_receipts(
+        runtime_root=runtime_root,
+        goal_id=goal_id,
+        agent_id=agent_id,
+    )
+    results: list[dict[str, Any]] = []
+    for ack_receipt in receipts:
+        binding = ack_receipt.get("binding")
+        if not isinstance(binding, Mapping):
+            results.append(
+                {
+                    "ok": False,
+                    "ack_receipt_id": ack_receipt.get("receipt_id"),
+                    "skip_reason": "ack_receipt_binding_missing",
+                    "external_read_performed": False,
+                    "write_performed": False,
+                }
+            )
+            continue
+        todo_id = str(binding.get("todo_id") or "").strip()
+        url = str(binding.get("permalink") or "").strip()
+        if not todo_id or not url:
+            results.append(
+                {
+                    "ok": False,
+                    "ack_receipt_id": ack_receipt.get("receipt_id"),
+                    "todo_id": todo_id or None,
+                    "skip_reason": "ack_receipt_binding_incomplete",
+                    "external_read_performed": False,
+                    "write_performed": False,
+                }
+            )
+            continue
+        try:
+            result = reconcile_issue_fix_pr_review(
+                registry_path=registry_path,
+                runtime_root_arg=str(runtime_root),
+                goal_id=goal_id,
+                todo_id=todo_id,
+                agent_id=agent_id,
+                project=project,
+                url=url,
+                ack_receipt=ack_receipt,
+                fetch_metadata=fetch_metadata,
+                fetch_timeout_seconds=fetch_timeout_seconds,
+                execute=execute,
+                generated_at=generated_at,
+            )
+        except ValueError:
+            result = {
+                "ok": False,
+                "todo_id": todo_id,
+                "ack_receipt_id": ack_receipt.get("receipt_id"),
+                "skip_reason": "provider_observation_failed",
+                "error_category": "provider_observation_failed",
+                "external_read_performed": fetch_metadata,
+                "write_performed": False,
+            }
+        results.append(result)
+
+    failure_count = sum(result.get("ok") is False for result in results)
+    return {
+        "ok": True,
+        "schema_version": PR_REVIEW_ACKED_RECONCILIATION_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "agent_id": agent_id,
+        "execute": execute,
+        "degraded": failure_count > 0,
+        "ack_receipt_count": len(receipts),
+        "result_count": len(results),
+        "terminal_count": sum(result.get("terminal") is True for result in results),
+        "reconciled_count": sum(
+            result.get("write_performed") is True for result in results
+        ),
+        "already_reconciled_count": sum(
+            result.get("already_reconciled") is True for result in results
+        ),
+        "external_read_count": sum(
+            result.get("external_read_performed") is True for result in results
+        ),
+        "failure_count": failure_count,
+        "private_material_read": False,
+        "external_write_performed": False,
+        "quota_spend_required": False,
+        "results": results,
+    }
 
 
 def render_issue_fix_pr_gate_reconciliation_markdown(payload: dict[str, Any]) -> str:

--- a/loopx/capabilities/issue_fix/pr_gate_reconcile_cli.py
+++ b/loopx/capabilities/issue_fix/pr_gate_reconcile_cli.py
@@ -7,6 +7,7 @@ import sys
 from typing import Any
 
 from .pr_gate_reconcile import (
+    reconcile_acknowledged_issue_fix_pr_reviews,
     reconcile_issue_fix_pr_gate,
     reconcile_issue_fix_pr_review,
     render_issue_fix_pr_gate_reconciliation_markdown,
@@ -167,6 +168,55 @@ def register_pr_gate_reconciliation_command(
         default=None,
         help="Public-safe reconciliation timestamp; defaults to current UTC.",
     )
+    acked_parser = issue_fix_sub.add_parser(
+        "pr-review-reconcile-acked",
+        help=(
+            "Reconcile current PR review user_actions from persisted exact "
+            "owner acknowledgement bindings."
+        ),
+    )
+    acked_parser.add_argument(
+        "--format",
+        dest="subcommand_format",
+        choices=["markdown", "json"],
+        help="Output format for this subcommand.",
+    )
+    acked_parser.add_argument(
+        "--goal-id",
+        required=True,
+        help="Goal whose persisted review acknowledgement receipts are read.",
+    )
+    acked_parser.add_argument(
+        "--agent-id",
+        required=True,
+        help="Registered lifecycle actor bound by each acknowledgement receipt.",
+    )
+    acked_parser.add_argument(
+        "--project",
+        default=None,
+        help="Optional project root; defaults to the registry-declared project.",
+    )
+    acked_parser.add_argument(
+        "--fetch-metadata",
+        action="store_true",
+        help="Fetch compact public PR state for each current matching receipt.",
+    )
+    acked_parser.add_argument(
+        "--fetch-timeout-seconds",
+        type=int,
+        default=10,
+        help="Timeout for each compact public PR metadata fetch.",
+    )
+    acked_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Complete exact acknowledged review actions whose PR is terminal.",
+    )
+    acked_parser.add_argument(
+        "--generated-at",
+        default=None,
+        help="Public-safe reconciliation timestamp; defaults to current UTC.",
+    )
     ack_parser = issue_fix_sub.add_parser(
         "pr-review-ack",
         help=(
@@ -313,6 +363,27 @@ def build_pr_review_reconciliation_from_args(
     )
 
 
+def build_acked_pr_review_reconciliation_from_args(
+    args: argparse.Namespace,
+    registry_path: Path | None,
+    runtime_root_arg: str | None,
+    generated_at: str,
+) -> dict[str, Any]:
+    if registry_path is None:
+        raise ValueError("pr-review-reconcile-acked requires a LoopX registry")
+    return reconcile_acknowledged_issue_fix_pr_reviews(
+        registry_path=registry_path,
+        runtime_root_arg=runtime_root_arg,
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        project=Path(args.project).expanduser() if args.project else None,
+        fetch_metadata=args.fetch_metadata,
+        fetch_timeout_seconds=args.fetch_timeout_seconds,
+        execute=args.execute,
+        generated_at=generated_at,
+    )
+
+
 def build_pr_review_ack_from_args(
     args: argparse.Namespace,
     registry_path: Path | None,
@@ -359,11 +430,34 @@ def render_issue_fix_pr_review_ack_markdown(payload: dict[str, Any]) -> str:
     )
 
 
+def render_issue_fix_acked_pr_review_reconciliation_markdown(
+    payload: dict[str, Any],
+) -> str:
+    return "\n".join(
+        [
+            "# LoopX Acknowledged PR Review Reconciliation",
+            "",
+            f"- ok: `{payload.get('ok')}`",
+            f"- degraded: `{payload.get('degraded')}`",
+            f"- ack_receipt_count: `{payload.get('ack_receipt_count')}`",
+            f"- result_count: `{payload.get('result_count')}`",
+            f"- terminal_count: `{payload.get('terminal_count')}`",
+            f"- reconciled_count: `{payload.get('reconciled_count')}`",
+            f"- already_reconciled_count: `{payload.get('already_reconciled_count')}`",
+            f"- external_read_count: `{payload.get('external_read_count')}`",
+            f"- failure_count: `{payload.get('failure_count')}`",
+            "- quota_spend_required: `False`",
+        ]
+    )
+
+
 __all__ = [
+    "build_acked_pr_review_reconciliation_from_args",
     "build_pr_gate_reconciliation_from_args",
     "build_pr_review_ack_from_args",
     "build_pr_review_reconciliation_from_args",
     "register_pr_gate_reconciliation_command",
+    "render_issue_fix_acked_pr_review_reconciliation_markdown",
     "render_issue_fix_pr_gate_reconciliation_markdown",
     "render_issue_fix_pr_review_ack_markdown",
     "render_issue_fix_pr_review_reconciliation_markdown",

--- a/loopx/cli_commands/support_control.py
+++ b/loopx/cli_commands/support_control.py
@@ -15,6 +15,10 @@ from ..heartbeat_prompt import (
     build_heartbeat_prompt_error_payload,
     render_heartbeat_prompt_markdown,
 )
+from ..heartbeat_prequota import (
+    render_heartbeat_pre_quota_markdown,
+    run_heartbeat_pre_quota,
+)
 from ..control_plane.scheduler.execution_context import SchedulerRuntimeProfile
 from ..history import load_registry
 from ..paths import resolve_runtime_root
@@ -66,6 +70,7 @@ AddFormat = Callable[[argparse.ArgumentParser], None]
 
 SUPPORT_CONTROL_COMMANDS = {
     "backup-state",
+    "heartbeat-prequota",
     "heartbeat-prompt",
     "promotion-gate",
     "upgrade-plan",
@@ -220,6 +225,33 @@ def register_support_control_commands(
         "--thin",
         action="store_true",
         help="Generate the thinnest generic dispatcher body for trusted agents that inspect LoopX state themselves.",
+    )
+
+    heartbeat_prequota_parser = subparsers.add_parser(
+        "heartbeat-prequota",
+        help=(
+            "Run best-effort kernel reconciliation hooks before heartbeat quota "
+            "selection without spending quota."
+        ),
+    )
+    add_subcommand_format(heartbeat_prequota_parser)
+    heartbeat_prequota_parser.add_argument(
+        "-g",
+        "--goal-id",
+        required=True,
+        help="Stable LoopX goal id.",
+    )
+    heartbeat_prequota_parser.add_argument(
+        "-a",
+        "--agent-id",
+        required=True,
+        help="Registered heartbeat lifecycle actor.",
+    )
+    heartbeat_prequota_parser.add_argument(
+        "--fetch-timeout-seconds",
+        type=int,
+        default=10,
+        help="Timeout for each bounded compact external metadata fetch.",
     )
 
     register_supervisor_control_commands(subparsers, add_subcommand_format)
@@ -390,6 +422,26 @@ def handle_support_control_command(
             }
         print_payload(payload, output_format(args), render_state_backup_markdown)
         return 0 if payload.get("ok") else 1
+
+    if args.command == "heartbeat-prequota":
+        prequota_registry = (
+            registry_path
+            if registry_was_supplied
+            else explicit_global_registry(args.runtime_root)
+        )
+        payload = run_heartbeat_pre_quota(
+            registry_path=prequota_registry,
+            runtime_root_arg=args.runtime_root,
+            goal_id=args.goal_id,
+            agent_id=args.agent_id,
+            fetch_timeout_seconds=args.fetch_timeout_seconds,
+        )
+        print_payload(
+            payload,
+            output_format(args),
+            render_heartbeat_pre_quota_markdown,
+        )
+        return 0
 
     if args.command == "heartbeat-prompt":
         active_state = None

--- a/loopx/heartbeat_prequota.py
+++ b/loopx/heartbeat_prequota.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .capabilities.issue_fix.pr_gate_reconcile import (
+    reconcile_acknowledged_issue_fix_pr_reviews,
+)
+
+
+HEARTBEAT_PRE_QUOTA_SCHEMA_VERSION = "heartbeat_pre_quota_v0"
+
+
+def run_heartbeat_pre_quota(
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    goal_id: str,
+    agent_id: str,
+    fetch_timeout_seconds: int = 10,
+) -> dict[str, Any]:
+    try:
+        review_reconciliation = reconcile_acknowledged_issue_fix_pr_reviews(
+            registry_path=registry_path,
+            runtime_root_arg=runtime_root_arg,
+            goal_id=goal_id,
+            agent_id=agent_id,
+            project=None,
+            fetch_metadata=True,
+            fetch_timeout_seconds=fetch_timeout_seconds,
+            execute=True,
+        )
+        degraded = bool(review_reconciliation.get("degraded"))
+        failure_count = int(review_reconciliation.get("failure_count") or 0)
+    except Exception as exc:
+        degraded = True
+        failure_count = 1
+        review_reconciliation = {
+            "ok": True,
+            "degraded": True,
+            "failure_count": 1,
+            "failure_categories": [type(exc).__name__],
+            "external_read_count": 0,
+            "write_count": 0,
+        }
+
+    return {
+        "ok": True,
+        "schema_version": HEARTBEAT_PRE_QUOTA_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "agent_id": agent_id,
+        "degraded": degraded,
+        "failure_count": failure_count,
+        "checks": {
+            "acknowledged_pr_reviews": review_reconciliation,
+        },
+        "quota_spend_required": False,
+        "continue_to_quota": True,
+    }
+
+
+def render_heartbeat_pre_quota_markdown(payload: dict[str, Any]) -> str:
+    checks = payload.get("checks") if isinstance(payload.get("checks"), dict) else {}
+    review = (
+        checks.get("acknowledged_pr_reviews")
+        if isinstance(checks.get("acknowledged_pr_reviews"), dict)
+        else {}
+    )
+    return "\n".join(
+        [
+            "# LoopX Heartbeat Pre-Quota",
+            "",
+            f"- ok: `{payload.get('ok')}`",
+            f"- degraded: `{payload.get('degraded')}`",
+            f"- reconciled_count: `{review.get('reconciled_count', 0)}`",
+            f"- failure_count: `{payload.get('failure_count')}`",
+            f"- continue_to_quota: `{payload.get('continue_to_quota')}`",
+            "- quota_spend_required: `False`",
+        ]
+    )

--- a/loopx/heartbeat_prompt.py
+++ b/loopx/heartbeat_prompt.py
@@ -378,6 +378,13 @@ def build_heartbeat_prompt(
         delivery_outcome="outcome_progress",
     )
     cli_preflight = render_cli_preflight(cli_bin=cli_bin)
+    pr_review_pre_quota_command = (
+        f"{cli_bin} heartbeat-prequota -g {shlex.quote(goal_id)} "
+        f"-a {shlex.quote(normalized_agent_id)}"
+        if normalized_agent_id
+        and "external_evidence_poll" in normalized_available_capabilities
+        else ""
+    )
     scheduler_args = render_scheduler_execution_args(
         runtime_profile=runtime_profile,
         scheduler_execution_context=scheduler_execution_context,
@@ -398,6 +405,7 @@ def build_heartbeat_prompt(
         goal_id=goal_id,
         active_state=active_state_text,
         cli_preflight=cli_preflight,
+        pr_review_pre_quota_command=pr_review_pre_quota_command,
         quota_guard_command=quota_guard_command,
         quota_spend_command=quota_spend_command,
         refresh_state_command=refresh_state_command,
@@ -435,6 +443,7 @@ def build_heartbeat_prompt(
         "compact_prompt_command": compact_prompt_command,
         "brief_prompt_command": brief_prompt_command,
         "thin_prompt_command": thin_prompt_command,
+        "pr_review_pre_quota_command": pr_review_pre_quota_command or None,
         "quota_guard_command": quota_guard_command,
         "quota_spend_command": quota_spend_command,
         "refresh_state_command": refresh_state_command,
@@ -542,6 +551,7 @@ def render_heartbeat_task_body(
     goal_id: str,
     active_state: str,
     cli_preflight: str,
+    pr_review_pre_quota_command: str,
     quota_guard_command: str,
     quota_spend_command: str,
     refresh_state_command: str,
@@ -556,6 +566,9 @@ def render_heartbeat_task_body(
     thin_prompt_command: str,
 ) -> str:
     scope_block = f"\n{agent_scope_instruction}\n" if agent_scope_instruction else ""
+    pr_review_pre_quota_block = (
+        f"{pr_review_pre_quota_command}\n" if pr_review_pre_quota_command else ""
+    )
     return f"""Advance `{goal_id}` using `{active_state}`.
 
 Generic LoopX lifecycle. Keep project-specific branching out of the
@@ -569,7 +582,7 @@ Before spending delivery compute, make the CLI reachable; set
 
 ```bash
 {cli_preflight}
-{quota_guard_command}
+{pr_review_pre_quota_block}{quota_guard_command}
 ```
 
 If that preflight still fails: no work/spend; quiet `DONT_NOTIFY`.
@@ -747,6 +760,7 @@ def render_brief_heartbeat_task_body(
     goal_id: str,
     active_state: str,
     cli_preflight: str,
+    pr_review_pre_quota_command: str,
     quota_guard_command: str,
     quota_spend_command: str,
     refresh_state_command: str,
@@ -761,6 +775,9 @@ def render_brief_heartbeat_task_body(
     thin_prompt_command: str,
 ) -> str:
     scope_block = f"\n{agent_scope_instruction}\n" if agent_scope_instruction else ""
+    pr_review_pre_quota_block = (
+        f"{pr_review_pre_quota_command}\n" if pr_review_pre_quota_command else ""
+    )
     return f"""Advance `{goal_id}` using `{active_state}`.
 
 Brief installed LoopX heartbeat. Thin dispatcher; detail:
@@ -771,7 +788,7 @@ Guard/retry; `LOOPX_TURN=<current_time_iso>`:
 
 ```bash
 {cli_preflight}
-{quota_guard_command}
+{pr_review_pre_quota_block}{quota_guard_command}
 ```
 
 Fail: quiet.
@@ -814,6 +831,7 @@ def render_compact_heartbeat_task_body(
     goal_id: str,
     active_state: str,
     cli_preflight: str,
+    pr_review_pre_quota_command: str,
     quota_guard_command: str,
     quota_spend_command: str,
     refresh_state_command: str,
@@ -828,6 +846,9 @@ def render_compact_heartbeat_task_body(
     thin_prompt_command: str,
 ) -> str:
     scope_block = f"\n{agent_scope_instruction}\n" if agent_scope_instruction else ""
+    pr_review_pre_quota_block = (
+        f"{pr_review_pre_quota_command}\n" if pr_review_pre_quota_command else ""
+    )
     return f"""Advance `{goal_id}` using `{active_state}`.
 
 This compact LoopX heartbeat body stays generic; local policy:
@@ -839,7 +860,7 @@ Preflight/guard; `LOOPX_TURN=<current_time_iso>`; reuse:
 
 ```bash
 {cli_preflight}
-{quota_guard_command}
+{pr_review_pre_quota_block}{quota_guard_command}
 ```
 
 Preflight fail: quiet; no work/spend.
@@ -921,6 +942,7 @@ def render_thin_heartbeat_task_body(
     goal_id: str,
     active_state: str,
     cli_preflight: str,
+    pr_review_pre_quota_command: str,
     quota_guard_command: str,
     quota_spend_command: str,
     refresh_state_command: str,
@@ -955,14 +977,19 @@ def render_thin_heartbeat_task_body(
         )
         else "`quota should-run`"
     )
+    pr_review_pre_quota_instruction = (
+        f"Pre: `{pr_review_pre_quota_command}`\n"
+        if pr_review_pre_quota_command
+        else ""
+    )
     return f"""Advance `{goal_id}` from {active_state}.
 
-Skills: `loopx-project`; surprise/conflict: `loopx-self-repair`.
+No runtime `loopx-project`; repair: `loopx-self-repair`.
 LoopX CLI = truth.
 {scope_sentence}
 
 Inspect state/status/repo; run
-{quota_guard_instruction}; follow `interaction_contract`.
+{pr_review_pre_quota_instruction}{quota_guard_instruction}; follow `interaction_contract`.
 `LOOPX_TURN=<current_time_iso>`; reuse.
 NOTIFY Chinese actions incl. non_blocking false/0; not only "owner gate";
 missing -> "具体 user todo 未投影，需修复 LoopX 状态投影".
@@ -1003,6 +1030,8 @@ def render_heartbeat_generator_inputs_markdown(payload: dict[str, Any]) -> str:
             f"- compact_prompt_command: `{payload.get('compact_prompt_command')}`",
             f"- brief_prompt_command: `{payload.get('brief_prompt_command')}`",
             f"- thin_prompt_command: `{payload.get('thin_prompt_command')}`",
+            "- pr_review_pre_quota_command: "
+            f"`{payload.get('pr_review_pre_quota_command')}`",
             f"- quota_guard_command: `{payload.get('quota_guard_command')}`",
             f"- quota_spend_command: `{payload.get('quota_spend_command')}`",
             f"- cli_preflight: `{payload.get('cli_preflight')}`",


### PR DESCRIPTION
## Summary
- add a kernel-owned `heartbeat-prequota` hook for exact acknowledged PR review reconciliation
- batch persisted acknowledgement receipts and skip stale/completed todos before provider access
- keep the hook best-effort, no-spend, and non-blocking for quota selection
- remove the runtime dependency on `loopx-project` from generated thin heartbeat prompts

## Validation
- focused heartbeat prompt, CLI output budget, PR reconciliation, and PR lifecycle smokes
- `ruff check` and changed Python compile checks
- `loopx check` public/private boundary scan: clean
- `loopx canary premerge --from-git-diff --tier standard`: 18/18 checks passed, no warnings or manual holds

## Boundaries
- no benchmark launch, scoring, task, or submission behavior changes
- no external writes except exact local todo reconciliation already authorized by persisted acknowledgement receipts
- provider failures degrade to stable public-safe categories and continue to quota