### PR TITLE
Project benchmark egress bypasses through SkillsBench launcher

### DIFF
--- a/examples/skillsbench-benchmark-egress-policy-smoke.py
+++ b/examples/skillsbench-benchmark-egress-policy-smoke.py
@@ -210,6 +210,9 @@ def test_public_launcher_uses_container_reachable_benchmark_proxy() -> None:
     assert "DOCKER_API_VERSION=1.43" in output, output
     assert "--codex-api-reverse-tunnel-proxy http://127.0.0.1:18186" in output, output
     assert "--benchmark-egress-proxy-mode require" in output, output
+    assert "benchmark_egress_no_proxy_configured=0" in output, output
+    assert "benchmark_egress_no_proxy_raw_value_recorded=false" in output, output
+    assert "--benchmark-egress-no-proxy" not in output, output
     assert "--local-codex-bin /remote/bin/codex" in output, output
     assert "--local-codex-sandbox danger-full-access" in output, output
     assert "local_codex_sandbox=danger-full-access" in output, output
@@ -236,6 +239,45 @@ def test_public_launcher_uses_container_reachable_benchmark_proxy() -> None:
     assert "skip_current_aggregate_update=1" in output, output
     assert "--skip-global-ledger-sync" in output, output
     assert "--skip-current-aggregate-update" in output, output
+
+
+def test_public_launcher_projects_private_benchmark_no_proxy_binding() -> None:
+    env = _launcher_env_without_profile()
+    env.update(
+        {
+            "SKILLSBENCH_SSH_DESTINATION": "example.invalid",
+            "SKILLSBENCH_REMOTE_ROOT": "/remote/loopx",
+            "SKILLSBENCH_ROOT": "/remote/skillsbench",
+            "SKILLSBENCH_EXPECTED_LOOPX_GIT_HEAD": "abc1234",
+            "SKILLSBENCH_DOCKER_PROXY_HOST": "host.docker.internal",
+            "SKILLSBENCH_DOCKER_API_VERSION": "1.43",
+            "SKILLSBENCH_BENCHMARK_EGRESS_NO_PROXY": (
+                "pypi.org,files.pythonhosted.org,"
+                "private-egress-sentinel.example.invalid"
+            ),
+        }
+    )
+    proc = subprocess.run(
+        [
+            str(REPO_ROOT / "scripts" / "skillsbench-launch-goal-xhigh.sh"),
+            "--dry-run",
+            "citation-check",
+            "egress-no-proxy-smoke",
+            "18186",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+    output = proc.stdout
+    assert "benchmark_egress_no_proxy_configured=1" in output, output
+    assert "benchmark_egress_no_proxy_raw_value_recorded=false" in output, output
+    assert "--benchmark-egress-no-proxy" in output, output
+    assert "private_runner_command_values_redacted=true" in output, output
+    assert "private-egress-sentinel.example.invalid" not in output, output
 
 
 def test_public_launcher_rejects_invalid_product_mode_soft_verify_policy() -> None:
@@ -679,6 +721,7 @@ if __name__ == "__main__":
     test_formal_cli_goal_auto_requires_benchmark_egress_proxy()
     test_formal_cli_goal_proxy_env_is_forwarded_without_public_url()
     test_public_launcher_uses_container_reachable_benchmark_proxy()
+    test_public_launcher_projects_private_benchmark_no_proxy_binding()
     test_public_launcher_batches_three_cases_with_closeout_sync()
     test_public_launcher_rejects_aggregate_without_explicit_ledger()
     test_public_launcher_applies_ssh_options_to_remote_discovery()

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -29,6 +29,9 @@ Optional env:
   SKILLSBENCH_BENCHMARK_EGRESS_PROXY_MODE
                                        Benchmark setup/verifier egress mode:
                                        require (default), auto, or off
+  SKILLSBENCH_BENCHMARK_EGRESS_NO_PROXY
+                                       Comma-separated benchmark setup/verifier
+                                       hosts that bypass the egress proxy
   SKILLSBENCH_DOCKER_API_VERSION       Remote Docker daemon API version passed
                                        to Docker CLI/Compose; default auto
   SKILLSBENCH_DOCKER_APT_SOURCE_MODE   Staged Dockerfile apt sources: mirror
@@ -226,6 +229,7 @@ skip_current_aggregate_update="${SKILLSBENCH_SKIP_CURRENT_AGGREGATE_UPDATE:-0}"
 allow_staged_bootstrap_repair_run="${SKILLSBENCH_ALLOW_STAGED_BOOTSTRAP_REPAIR_RUN:-0}"
 setup_only_public_preflight="${SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT:-0}"
 benchmark_egress_proxy_mode="${SKILLSBENCH_BENCHMARK_EGRESS_PROXY_MODE:-require}"
+benchmark_egress_no_proxy="${SKILLSBENCH_BENCHMARK_EGRESS_NO_PROXY:-}"
 docker_apt_source_mode="${SKILLSBENCH_DOCKER_APT_SOURCE_MODE:-mirror}"
 docker_apt_transport_mode="${SKILLSBENCH_DOCKER_APT_TRANSPORT_MODE:-default}"
 docker_pip_index_mode="${SKILLSBENCH_DOCKER_PIP_INDEX_MODE:-mirror}"
@@ -553,6 +557,11 @@ fi
 if [[ "$setup_only_public_preflight" == "1" ]]; then
   extra_runner_args+=(--setup-only-public-preflight)
 fi
+if [[ -n "$benchmark_egress_no_proxy" ]]; then
+  extra_runner_args+=(
+    --benchmark-egress-no-proxy "$benchmark_egress_no_proxy"
+  )
+fi
 if [[ -n "$product_mode_soft_verify_policy" ]]; then
   extra_runner_args+=(
     --product-mode-soft-verify-policy "$product_mode_soft_verify_policy"
@@ -786,6 +795,9 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'public_artifact_sync_interval_sec=%s\n' \
     "$public_artifact_sync_interval"
   printf 'benchmark_egress_proxy_mode=%s\n' "$benchmark_egress_proxy_mode"
+  printf 'benchmark_egress_no_proxy_configured=%s\n' \
+    "$([[ -n "$benchmark_egress_no_proxy" ]] && echo 1 || echo 0)"
+  printf 'benchmark_egress_no_proxy_raw_value_recorded=false\n'
   printf 'docker_apt_source_mode=%s\n' "$docker_apt_source_mode"
   printf 'docker_apt_transport_mode=%s\n' "$docker_apt_transport_mode"
   printf 'docker_pip_index_mode=%s\n' "$docker_pip_index_mode"
@@ -816,7 +828,8 @@ if [[ "$dry_run" == "true" ]]; then
     [[ -n "$remote_command_file_bridge_probe_command" ]] ||
     [[ -n "$remote_command_file_bridge_solver_command" ]] ||
     [[ -n "$remote_command_file_bridge_agent_command" ]] ||
-    [[ -n "$loopx_turn_validation_command" ]]; then
+    [[ -n "$loopx_turn_validation_command" ]] ||
+    [[ -n "$benchmark_egress_no_proxy" ]]; then
     printf 'private_runner_command_values_redacted=true\n'
     printf 'private_runner_arg_names='
     [[ "$local_codex_split_control" == "1" ]] &&
@@ -839,6 +852,8 @@ if [[ "$dry_run" == "true" ]]; then
       printf '%s ' --remote-command-file-bridge-agent-command-instrumented
     [[ -n "$loopx_turn_validation_command" ]] &&
       printf '%s ' --loopx-turn-validation-command
+    [[ -n "$benchmark_egress_no_proxy" ]] &&
+      printf '%s ' --benchmark-egress-no-proxy
     [[ "$route" == "loopx-turn-agent-cli" ]] &&
       printf '%s ' --loopx-turn-max-turns --loopx-turn-progress-exit-code
     [[ "$route" == "loopx-turn-agent-cli" ]] &&


### PR DESCRIPTION
## Summary
- bind `SKILLSBENCH_BENCHMARK_EGRESS_NO_PROXY` to the existing runner `--benchmark-egress-no-proxy` contract
- keep the value private in launcher dry-run output while exposing configuration presence and the argument name
- preserve default launcher behavior when the variable is unset

## Validation
- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`
- `ruff check --ignore E402 examples/skillsbench-benchmark-egress-policy-smoke.py`
- `python examples/skillsbench-benchmark-egress-policy-smoke.py`
- `python examples/skillsbench-runner-profile-smoke.py`
- `python examples/skillsbench-benchmark-run-smoke.py`
- `loopx canary premerge --from-git-diff --no-progress`: 11 checks passed; no failures or warnings; public-boundary scan clean
- `loopx check --scan-path ...`: 0 errors, 0 warnings

## Gate
The generic canary reports the expected `benchmark_sensitive` manual hold. Standing owner authorization `benchmark_pr_self_merge=approve` applies. This change does not launch jobs or alter scoring, task semantics, verifier policy, submission behavior, or permission boundaries.