### PR TITLE
refactor(quota): bound capability gate CLI candidates

### DIFF
--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -230,6 +230,14 @@ def register_quota_command(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
     quota_parser.add_argument(
+        "--include-capability-gate-detail",
+        action="store_true",
+        help=(
+            "Include full capability gate todo candidates in `quota should-run`. "
+            "The default keeps bounded typed candidate anchors and gate decisions."
+        ),
+    )
+    quota_parser.add_argument(
         "--include-vision-audit-detail",
         action="store_true",
         help=(
@@ -405,6 +413,14 @@ def handle_quota_command(
         ):
             raise ValueError(
                 "--include-user-todo-summary-detail is only valid with "
+                "`quota should-run`"
+            )
+        if (
+            bool(getattr(args, "include_capability_gate_detail", False))
+            and args.quota_command != "should-run"
+        ):
+            raise ValueError(
+                "--include-capability-gate-detail is only valid with "
                 "`quota should-run`"
             )
         if (
@@ -916,6 +932,9 @@ def handle_quota_command(
             ),
             include_user_todo_summary_detail=bool(
                 getattr(args, "include_user_todo_summary_detail", False)
+            ),
+            include_capability_gate_detail=bool(
+                getattr(args, "include_capability_gate_detail", False)
             ),
             include_vision_audit_detail=bool(
                 getattr(args, "include_vision_audit_detail", False)

--- a/loopx/control_plane/quota/cli_projection.py
+++ b/loopx/control_plane/quota/cli_projection.py
@@ -15,6 +15,12 @@ QUOTA_CLI_USER_TODO_SUMMARY_COMPACTION_SCHEMA_VERSION = (
 QUOTA_CLI_USER_TODO_SUMMARY_DETAIL_COMMAND = (
     "quota should-run --include-user-todo-summary-detail"
 )
+QUOTA_CLI_CAPABILITY_GATE_COMPACTION_SCHEMA_VERSION = (
+    "quota_cli_capability_gate_compaction_v0"
+)
+QUOTA_CLI_CAPABILITY_GATE_DETAIL_COMMAND = (
+    "quota should-run --include-capability-gate-detail"
+)
 QUOTA_CLI_VISION_AUDIT_COMPACTION_SCHEMA_VERSION = (
     "quota_cli_vision_audit_compaction_v0"
 )
@@ -33,6 +39,33 @@ _RETAINED_USER_ITEM_LANES = {
     "gate_open_items": 3,
     "active_next_action_items": 3,
 }
+_RETAINED_CAPABILITY_GATE_CANDIDATES = 3
+_CAPABILITY_GATE_CANDIDATE_ANCHOR_FIELDS = (
+    "schema_version",
+    "todo_id",
+    "index",
+    "role",
+    "status",
+    "priority",
+    "task_class",
+    "action_kind",
+    "task_repository",
+    "continuation_policy",
+    "required_capabilities",
+    "target_capabilities",
+    "missing_capabilities",
+    "missing_target_capabilities",
+    "capability_action",
+    "capability_repair_mode",
+    "claimed_by",
+    "required_decision_scopes",
+    "unblocks_todo_id",
+    "target_key",
+    "next_due_at",
+    "route_id",
+    "route_key",
+)
+_CAPABILITY_GATE_CANDIDATE_TITLE_MAX_CHARS = 240
 _VISION_AUDIT_ANCHOR_FIELDS = (
     "required",
     "agent_id",
@@ -165,6 +198,60 @@ def _compact_user_todo_summary(summary: dict[str, Any]) -> dict[str, Any]:
     return compact
 
 
+def _bounded_candidate_title(item: dict[str, Any]) -> tuple[str | None, bool]:
+    title = str(item.get("title") or item.get("text") or "").strip()
+    if not title:
+        return None, False
+    if len(title) <= _CAPABILITY_GATE_CANDIDATE_TITLE_MAX_CHARS:
+        return title, False
+    return (
+        title[: _CAPABILITY_GATE_CANDIDATE_TITLE_MAX_CHARS - 3].rstrip() + "...",
+        True,
+    )
+
+
+def _capability_gate_candidate_anchor(item: dict[str, Any]) -> dict[str, Any]:
+    anchor: dict[str, Any] = {}
+    for field in _CAPABILITY_GATE_CANDIDATE_ANCHOR_FIELDS:
+        if item.get(field) is not None:
+            anchor[field] = item[field]
+    title, title_truncated = _bounded_candidate_title(item)
+    if title:
+        anchor["title"] = title
+    if title_truncated:
+        anchor["title_truncated"] = True
+    return anchor
+
+
+def _compact_capability_gate(gate: dict[str, Any]) -> dict[str, Any]:
+    compact = dict(gate)
+    omitted_candidates: dict[str, int] = {}
+    for lane in ("runnable_candidates", "blocked_candidates"):
+        candidates = gate.get(lane)
+        if not isinstance(candidates, list):
+            continue
+        typed_candidates = [
+            _capability_gate_candidate_anchor(item)
+            for item in candidates
+            if isinstance(item, dict)
+        ]
+        compact[lane] = typed_candidates[:_RETAINED_CAPABILITY_GATE_CANDIDATES]
+        if len(typed_candidates) > _RETAINED_CAPABILITY_GATE_CANDIDATES:
+            omitted_candidates[lane] = (
+                len(typed_candidates) - _RETAINED_CAPABILITY_GATE_CANDIDATES
+            )
+        if lane == "blocked_candidates":
+            compact["blocked_count"] = len(typed_candidates)
+
+    compact["payload_compaction"] = {
+        "schema_version": QUOTA_CLI_CAPABILITY_GATE_COMPACTION_SCHEMA_VERSION,
+        "retained_candidate_limit": _RETAINED_CAPABILITY_GATE_CANDIDATES,
+        "omitted_candidates": omitted_candidates,
+        "full_detail_cold_path": QUOTA_CLI_CAPABILITY_GATE_DETAIL_COMMAND,
+    }
+    return compact
+
+
 def _vision_audit_anchor(
     audit: dict[str, Any],
     *,
@@ -240,6 +327,7 @@ def compact_quota_should_run_cli_payload(
     *,
     include_todo_summary_detail: bool = False,
     include_user_todo_summary_detail: bool = False,
+    include_capability_gate_detail: bool = False,
     include_vision_audit_detail: bool = False,
 ) -> dict[str, Any]:
     """Bound CLI-only diagnostics after the full decision is computed."""
@@ -268,6 +356,15 @@ def compact_quota_should_run_cli_payload(
             "compacted_roles": compacted_roles,
             "detail_ref": role_detail_refs[compacted_roles[0]],
             "role_detail_refs": role_detail_refs,
+        }
+    capability_gate = payload.get("capability_gate")
+    if not include_capability_gate_detail and isinstance(capability_gate, dict):
+        compact = dict(compact)
+        compact["capability_gate"] = _compact_capability_gate(capability_gate)
+        compact["capability_gate_projection"] = {
+            "schema_version": QUOTA_CLI_CAPABILITY_GATE_COMPACTION_SCHEMA_VERSION,
+            "mode": "compact_hot_path",
+            "detail_ref": QUOTA_CLI_CAPABILITY_GATE_DETAIL_COMMAND,
         }
     if not include_vision_audit_detail:
         compact = _compact_vision_audit_copies(compact)

--- a/loopx/control_plane/testing/cli_output_budget.py
+++ b/loopx/control_plane/testing/cli_output_budget.py
@@ -129,7 +129,7 @@ CLI_OUTPUT_BUDGET_SPECS: tuple[CliOutputBudgetSpec, ...] = (
         cold_path=(
             "status, history, active state, --include-scheduler-detail, and "
             "--include-todo-summary-detail, --include-user-todo-summary-detail, "
-            "or --include-vision-audit-detail"
+            "--include-capability-gate-detail, or --include-vision-audit-detail"
         ),
         semantic_json_keys=("interaction_contract", "scheduler_hint", "selected_todo"),
         markdown_anchor="# LoopX Quota Should Run",
@@ -393,6 +393,16 @@ CLI_OUTPUT_MODE_VARIANT_SPECS: tuple[CliOutputModeVariantSpec, ...] = (
         markdown_anchor="# LoopX Quota Should Run",
         max_chars={"json": 35_000, "markdown": 7_800},
         max_lines={"json": 900, "markdown": 78},
+    ),
+    CliOutputModeVariantSpec(
+        variant_id="quota_should_run_capability_gate_detail",
+        parent_surface_id="quota_should_run",
+        command="quota should-run --include-capability-gate-detail",
+        output_formats=("json", "markdown"),
+        semantic_json_keys=("interaction_contract", "scheduler_hint", "selected_todo"),
+        markdown_anchor="# LoopX Quota Should Run",
+        max_chars={"json": 40_000, "markdown": 7_800},
+        max_lines={"json": 1_000, "markdown": 78},
     ),
     CliOutputModeVariantSpec(
         variant_id="quota_should_run_vision_audit_detail",

--- a/tests/control_plane/test_cli_output_budget.py
+++ b/tests/control_plane/test_cli_output_budget.py
@@ -509,6 +509,18 @@ def _mode_variant_commands(
             str(project),
             "--include-user-todo-summary-detail",
         ],
+        "quota_should_run_capability_gate_detail": common
+        + [
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_IDS[0],
+            "--scan-root",
+            str(project),
+            "--include-capability-gate-detail",
+        ],
         "quota_should_run_vision_audit_detail": common
         + [
             "quota",
@@ -635,6 +647,7 @@ def test_manifest_covers_the_declared_agent_facing_surface_set() -> None:
         "quota_should_run_scheduler_detail",
         "quota_should_run_todo_summary_detail",
         "quota_should_run_user_todo_summary_detail",
+        "quota_should_run_capability_gate_detail",
         "quota_should_run_vision_audit_detail",
         "quota_should_run_turn_envelope",
         "loopx_turn_plan_transaction_detail",
@@ -791,6 +804,75 @@ def test_quota_cli_keeps_full_user_todo_diagnostics_on_explicit_cold_path(
     assert detail_summary["other_agent_bound_user_action_items"][0]["todo_id"] == (
         "todo_user_action_001"
     )
+    for key in ("interaction_contract", "scheduler_hint", "selected_todo"):
+        assert default_payload[key] == detail_payload[key]
+
+
+def test_quota_cli_keeps_full_capability_gate_on_explicit_cold_path(
+    tmp_path: Path,
+) -> None:
+    with _stable_budget_fixture_root(
+        tmp_path / "quota-capability-gate-detail"
+    ) as stable_root:
+        project, runtime, registry_path, state_file = _write_fixture(
+            stable_root,
+            SCENARIOS[1],
+        )
+        state_text = state_file.read_text(encoding="utf-8")
+        state_file.write_text(
+            state_text.replace(
+                "todo_id=todo_fixture_000 status=open ",
+                (
+                    "todo_id=todo_fixture_000 status=open "
+                    "required_capabilities=shell,filesystem_write "
+                ),
+                1,
+            ),
+            encoding="utf-8",
+        )
+        default_command = _surface_commands(
+            project=project,
+            runtime=runtime,
+            registry_path=registry_path,
+            state_file=state_file,
+            output_format="json",
+        )["quota_should_run"]
+        detail_command = _mode_variant_commands(
+            project=project,
+            runtime=runtime,
+            registry_path=registry_path,
+            state_file=state_file,
+            output_format="json",
+        )["quota_should_run_capability_gate_detail"]
+
+        default_exit_code, default_text = _invoke_cli(default_command)
+        detail_exit_code, detail_text = _invoke_cli(detail_command)
+
+    assert default_exit_code == 0, default_text
+    assert detail_exit_code == 0, detail_text
+    default_payload = json.loads(default_text)
+    detail_payload = json.loads(detail_text)
+    default_gate = default_payload["capability_gate"]
+    detail_gate = detail_payload["capability_gate"]
+    assert default_gate["payload_compaction"]["schema_version"] == (
+        "quota_cli_capability_gate_compaction_v0"
+    )
+    assert default_payload["capability_gate_projection"]["detail_ref"] == (
+        "quota should-run --include-capability-gate-detail"
+    )
+    assert "text" not in default_gate["runnable_candidates"][0]
+    assert "handoff_note" not in default_gate["runnable_candidates"][0]
+    assert detail_gate["runnable_candidates"][0]["text"]
+    assert "capability_gate_projection" not in detail_payload
+    for key in (
+        "action",
+        "decision_owner",
+        "required",
+        "available",
+        "missing",
+        "owner_action",
+    ):
+        assert default_gate[key] == detail_gate[key]
     for key in ("interaction_contract", "scheduler_hint", "selected_todo"):
         assert default_payload[key] == detail_payload[key]
 

--- a/tests/control_plane/test_quota_cli_projection.py
+++ b/tests/control_plane/test_quota_cli_projection.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 
 from loopx.control_plane.quota.cli_projection import (
+    QUOTA_CLI_CAPABILITY_GATE_DETAIL_COMMAND,
     QUOTA_CLI_TODO_SUMMARY_DETAIL_COMMAND,
     QUOTA_CLI_USER_TODO_SUMMARY_DETAIL_COMMAND,
     QUOTA_CLI_VISION_AUDIT_DETAIL_COMMAND,
@@ -203,6 +204,121 @@ def test_compact_quota_should_run_cli_payload_keeps_active_user_work_and_gate_sc
         payload,
         include_todo_summary_detail=True,
         include_user_todo_summary_detail=True,
+        include_vision_audit_detail=True,
+    )
+    assert full == payload
+
+
+def test_compact_quota_should_run_cli_payload_bounds_capability_gate_candidates() -> None:
+    runnable = [
+        {
+            **item,
+            "priority": "P1",
+            "action_kind": "run_quality_slice",
+            "task_repository": "git:github.com/example/loopx",
+            "required_capabilities": ["shell", "filesystem_write"],
+            "missing_capabilities": [],
+            "capability_action": "run",
+            "claimed_by": "quality-agent",
+            "handoff_note": {
+                "summary": "duplicated handoff detail " * 40,
+            },
+        }
+        for item in _items(5, prefix="runnable")
+    ]
+    runnable[0]["text"] = "candidate " * 80
+    runnable[0]["title"] = runnable[0]["text"]
+    blocked = [
+        {
+            **item,
+            "priority": "P0",
+            "required_capabilities": ["credentials"],
+            "missing_capabilities": ["credentials"],
+            "capability_action": "ask_owner",
+        }
+        for item in _items(4, prefix="blocked")
+    ]
+    payload = {
+        "interaction_contract": {"mode": "bounded_delivery"},
+        "selected_todo": {"todo_id": "runnable-0"},
+        "scheduler_hint": {"action": "run_now"},
+        "capability_gate": {
+            "schema_version": "capability_gate_v0",
+            "action": "run",
+            "decision_owner": "agent",
+            "selection_policy": "agent_steering_audit_over_runnable_candidates",
+            "candidate_order_policy": "claim_then_priority",
+            "required": ["shell", "filesystem_write"],
+            "available": ["shell", "filesystem_write"],
+            "missing": [],
+            "runnable_count": 5,
+            "runnable_candidates": runnable,
+            "blocked_candidates": blocked,
+            "blocked_missing": ["credentials"],
+            "owner_missing": ["credentials"],
+            "owner_action": "provide or authorize credentials for blocked-0",
+            "resolution_bindings": [
+                {
+                    "owner": "user",
+                    "capability": "credentials",
+                    "primary_blocked_todo_id": "blocked-0",
+                }
+            ],
+        },
+    }
+
+    compact = compact_quota_should_run_cli_payload(
+        payload,
+        include_todo_summary_detail=True,
+        include_user_todo_summary_detail=True,
+        include_vision_audit_detail=True,
+    )
+
+    gate = compact["capability_gate"]
+    assert gate["action"] == "run"
+    assert gate["decision_owner"] == "agent"
+    assert gate["owner_missing"] == ["credentials"]
+    assert gate["owner_action"] == "provide or authorize credentials for blocked-0"
+    assert gate["resolution_bindings"] == payload["capability_gate"][
+        "resolution_bindings"
+    ]
+    assert gate["runnable_count"] == 5
+    assert gate["blocked_count"] == 4
+    assert [item["todo_id"] for item in gate["runnable_candidates"]] == [
+        "runnable-0",
+        "runnable-1",
+        "runnable-2",
+    ]
+    assert [item["todo_id"] for item in gate["blocked_candidates"]] == [
+        "blocked-0",
+        "blocked-1",
+        "blocked-2",
+    ]
+    assert gate["runnable_candidates"][0]["title_truncated"] is True
+    assert len(gate["runnable_candidates"][0]["title"]) == 240
+    assert "text" not in gate["runnable_candidates"][0]
+    assert "handoff_note" not in gate["runnable_candidates"][0]
+    assert gate["blocked_candidates"][0]["missing_capabilities"] == [
+        "credentials"
+    ]
+    assert gate["payload_compaction"]["omitted_candidates"] == {
+        "blocked_candidates": 1,
+        "runnable_candidates": 2,
+    }
+    assert gate["payload_compaction"]["full_detail_cold_path"] == (
+        QUOTA_CLI_CAPABILITY_GATE_DETAIL_COMMAND
+    )
+    assert compact["capability_gate_projection"]["detail_ref"] == (
+        QUOTA_CLI_CAPABILITY_GATE_DETAIL_COMMAND
+    )
+    for key in ("interaction_contract", "scheduler_hint", "selected_todo"):
+        assert compact[key] == payload[key]
+
+    full = compact_quota_should_run_cli_payload(
+        payload,
+        include_todo_summary_detail=True,
+        include_user_todo_summary_detail=True,
+        include_capability_gate_detail=True,
         include_vision_audit_detail=True,
     )
     assert full == payload


### PR DESCRIPTION
## Summary
- compact default `quota should-run` capability-gate candidates into bounded typed anchors after the full decision is computed
- retain candidate identity/order, missing-capability diagnostics, owner action, and gate decision fields
- add `--include-capability-gate-detail` as the explicit full-candidate cold path and register its output-budget variant

## Stack
- base: #2512 (`codex/quota-user-summary-budget-20260724`)
- this PR contains only the capability-gate output-budget slice

## Validation
- `pytest -q tests/control_plane/test_quota_cli_projection.py tests/control_plane/test_cli_output_budget.py` (15 passed)
- `ruff check` on all five changed Python files
- `loopx canary premerge --from-git-diff` (17/17 passed)
- real `loopx-meta` default/detail comparison: 46,066 -> 44,493 bytes; `interaction_contract`, `scheduler_hint`, `selected_todo`, and gate action/owner/missing fields remained equal
- `git diff --check` and public/private boundary scan passed

No failures or skips. No benchmark launch, scoring change, permission change, scheduler mutation, or private evidence is included. The coverage exercises the pure projection contract, CLI flag round trip, budget manifest, and risk-matched control-plane smokes.