### PR TITLE
refactor(quota): bound agent lane next-action output

### DIFF
--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -238,6 +238,14 @@ def register_quota_command(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
     quota_parser.add_argument(
+        "--include-agent-lane-next-action-detail",
+        action="store_true",
+        help=(
+            "Include the full agent-lane next-action todo and handoff note in "
+            "`quota should-run`. The default keeps a typed action and lineage anchor."
+        ),
+    )
+    quota_parser.add_argument(
         "--include-vision-audit-detail",
         action="store_true",
         help=(
@@ -421,6 +429,14 @@ def handle_quota_command(
         ):
             raise ValueError(
                 "--include-capability-gate-detail is only valid with "
+                "`quota should-run`"
+            )
+        if (
+            bool(getattr(args, "include_agent_lane_next_action_detail", False))
+            and args.quota_command != "should-run"
+        ):
+            raise ValueError(
+                "--include-agent-lane-next-action-detail is only valid with "
                 "`quota should-run`"
             )
         if (
@@ -935,6 +951,9 @@ def handle_quota_command(
             ),
             include_capability_gate_detail=bool(
                 getattr(args, "include_capability_gate_detail", False)
+            ),
+            include_agent_lane_next_action_detail=bool(
+                getattr(args, "include_agent_lane_next_action_detail", False)
             ),
             include_vision_audit_detail=bool(
                 getattr(args, "include_vision_audit_detail", False)

--- a/loopx/control_plane/quota/cli_projection.py
+++ b/loopx/control_plane/quota/cli_projection.py
@@ -21,6 +21,12 @@ QUOTA_CLI_CAPABILITY_GATE_COMPACTION_SCHEMA_VERSION = (
 QUOTA_CLI_CAPABILITY_GATE_DETAIL_COMMAND = (
     "quota should-run --include-capability-gate-detail"
 )
+QUOTA_CLI_AGENT_LANE_NEXT_ACTION_COMPACTION_SCHEMA_VERSION = (
+    "quota_cli_agent_lane_next_action_compaction_v0"
+)
+QUOTA_CLI_AGENT_LANE_NEXT_ACTION_DETAIL_COMMAND = (
+    "quota should-run --include-agent-lane-next-action-detail"
+)
 QUOTA_CLI_VISION_AUDIT_COMPACTION_SCHEMA_VERSION = (
     "quota_cli_vision_audit_compaction_v0"
 )
@@ -66,6 +72,44 @@ _CAPABILITY_GATE_CANDIDATE_ANCHOR_FIELDS = (
     "route_key",
 )
 _CAPABILITY_GATE_CANDIDATE_TITLE_MAX_CHARS = 240
+_AGENT_LANE_NEXT_ACTION_ANCHOR_FIELDS = (
+    "todo_id",
+    "task_class",
+    "action_kind",
+    "task_repository",
+    "continuation_policy",
+    "required_capabilities",
+    "target_capabilities",
+    "missing_capabilities",
+    "capability_action",
+    "claimed_by",
+    "required_decision_scopes",
+    "unblocks_todo_id",
+    "successor_todo_ids",
+    "agent_id",
+    "source",
+    "selected_by",
+    "confidence",
+    "preserves_goal_next_action",
+    "route_id",
+    "route_key",
+)
+_HANDOFF_LINEAGE_FIELDS = (
+    "schema_version",
+    "handoff_id",
+    "todo_id",
+    "goal_id",
+    "from_agent",
+    "to_agent",
+    "intent",
+    "evidence_refs",
+    "unresolved_decisions",
+    "blocked_on",
+    "source",
+    "successor_todo_ids",
+    "unblocks_todo_id",
+    "excluded_agents",
+)
 _VISION_AUDIT_ANCHOR_FIELDS = (
     "required",
     "agent_id",
@@ -198,7 +242,7 @@ def _compact_user_todo_summary(summary: dict[str, Any]) -> dict[str, Any]:
     return compact
 
 
-def _bounded_candidate_title(item: dict[str, Any]) -> tuple[str | None, bool]:
+def _bounded_projection_title(item: dict[str, Any]) -> tuple[str | None, bool]:
     title = str(item.get("title") or item.get("text") or "").strip()
     if not title:
         return None, False
@@ -215,7 +259,7 @@ def _capability_gate_candidate_anchor(item: dict[str, Any]) -> dict[str, Any]:
     for field in _CAPABILITY_GATE_CANDIDATE_ANCHOR_FIELDS:
         if item.get(field) is not None:
             anchor[field] = item[field]
-    title, title_truncated = _bounded_candidate_title(item)
+    title, title_truncated = _bounded_projection_title(item)
     if title:
         anchor["title"] = title
     if title_truncated:
@@ -250,6 +294,33 @@ def _compact_capability_gate(gate: dict[str, Any]) -> dict[str, Any]:
         "full_detail_cold_path": QUOTA_CLI_CAPABILITY_GATE_DETAIL_COMMAND,
     }
     return compact
+
+
+def _handoff_lineage_anchor(value: object) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    anchor = {
+        field: value[field]
+        for field in _HANDOFF_LINEAGE_FIELDS
+        if value.get(field) is not None
+    }
+    return anchor or None
+
+
+def _agent_lane_next_action_anchor(item: dict[str, Any]) -> dict[str, Any]:
+    anchor: dict[str, Any] = {
+        "schema_version": QUOTA_CLI_AGENT_LANE_NEXT_ACTION_COMPACTION_SCHEMA_VERSION,
+        "source_schema_version": item.get("schema_version"),
+    }
+    for field in _AGENT_LANE_NEXT_ACTION_ANCHOR_FIELDS:
+        if item.get(field) is not None:
+            anchor[field] = item[field]
+    handoff_lineage = _handoff_lineage_anchor(item.get("handoff_note"))
+    if handoff_lineage:
+        anchor["handoff_lineage"] = handoff_lineage
+    anchor["instruction_ref"] = "#/selected_todo"
+    anchor["detail_ref"] = QUOTA_CLI_AGENT_LANE_NEXT_ACTION_DETAIL_COMMAND
+    return anchor
 
 
 def _vision_audit_anchor(
@@ -328,6 +399,7 @@ def compact_quota_should_run_cli_payload(
     include_todo_summary_detail: bool = False,
     include_user_todo_summary_detail: bool = False,
     include_capability_gate_detail: bool = False,
+    include_agent_lane_next_action_detail: bool = False,
     include_vision_audit_detail: bool = False,
 ) -> dict[str, Any]:
     """Bound CLI-only diagnostics after the full decision is computed."""
@@ -366,6 +438,15 @@ def compact_quota_should_run_cli_payload(
             "mode": "compact_hot_path",
             "detail_ref": QUOTA_CLI_CAPABILITY_GATE_DETAIL_COMMAND,
         }
+    agent_lane_next_action = payload.get("agent_lane_next_action")
+    if not include_agent_lane_next_action_detail and isinstance(
+        agent_lane_next_action,
+        dict,
+    ):
+        compact = dict(compact)
+        compact["agent_lane_next_action"] = _agent_lane_next_action_anchor(
+            agent_lane_next_action
+        )
     if not include_vision_audit_detail:
         compact = _compact_vision_audit_copies(compact)
     return compact

--- a/loopx/control_plane/testing/cli_output_budget.py
+++ b/loopx/control_plane/testing/cli_output_budget.py
@@ -129,7 +129,9 @@ CLI_OUTPUT_BUDGET_SPECS: tuple[CliOutputBudgetSpec, ...] = (
         cold_path=(
             "status, history, active state, --include-scheduler-detail, and "
             "--include-todo-summary-detail, --include-user-todo-summary-detail, "
-            "--include-capability-gate-detail, or --include-vision-audit-detail"
+            "--include-capability-gate-detail, "
+            "--include-agent-lane-next-action-detail, or "
+            "--include-vision-audit-detail"
         ),
         semantic_json_keys=("interaction_contract", "scheduler_hint", "selected_todo"),
         markdown_anchor="# LoopX Quota Should Run",
@@ -398,6 +400,16 @@ CLI_OUTPUT_MODE_VARIANT_SPECS: tuple[CliOutputModeVariantSpec, ...] = (
         variant_id="quota_should_run_capability_gate_detail",
         parent_surface_id="quota_should_run",
         command="quota should-run --include-capability-gate-detail",
+        output_formats=("json", "markdown"),
+        semantic_json_keys=("interaction_contract", "scheduler_hint", "selected_todo"),
+        markdown_anchor="# LoopX Quota Should Run",
+        max_chars={"json": 40_000, "markdown": 7_800},
+        max_lines={"json": 1_000, "markdown": 78},
+    ),
+    CliOutputModeVariantSpec(
+        variant_id="quota_should_run_agent_lane_next_action_detail",
+        parent_surface_id="quota_should_run",
+        command="quota should-run --include-agent-lane-next-action-detail",
         output_formats=("json", "markdown"),
         semantic_json_keys=("interaction_contract", "scheduler_hint", "selected_todo"),
         markdown_anchor="# LoopX Quota Should Run",

--- a/tests/control_plane/test_cli_output_budget.py
+++ b/tests/control_plane/test_cli_output_budget.py
@@ -521,6 +521,18 @@ def _mode_variant_commands(
             str(project),
             "--include-capability-gate-detail",
         ],
+        "quota_should_run_agent_lane_next_action_detail": common
+        + [
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_IDS[0],
+            "--scan-root",
+            str(project),
+            "--include-agent-lane-next-action-detail",
+        ],
         "quota_should_run_vision_audit_detail": common
         + [
             "quota",
@@ -648,6 +660,7 @@ def test_manifest_covers_the_declared_agent_facing_surface_set() -> None:
         "quota_should_run_todo_summary_detail",
         "quota_should_run_user_todo_summary_detail",
         "quota_should_run_capability_gate_detail",
+        "quota_should_run_agent_lane_next_action_detail",
         "quota_should_run_vision_audit_detail",
         "quota_should_run_turn_envelope",
         "loopx_turn_plan_transaction_detail",
@@ -873,6 +886,63 @@ def test_quota_cli_keeps_full_capability_gate_on_explicit_cold_path(
         "owner_action",
     ):
         assert default_gate[key] == detail_gate[key]
+    for key in ("interaction_contract", "scheduler_hint", "selected_todo"):
+        assert default_payload[key] == detail_payload[key]
+
+
+def test_quota_cli_keeps_full_agent_lane_next_action_on_explicit_cold_path(
+    tmp_path: Path,
+) -> None:
+    with _stable_budget_fixture_root(
+        tmp_path / "quota-agent-lane-next-action-detail"
+    ) as stable_root:
+        project, runtime, registry_path, state_file = _write_fixture(
+            stable_root,
+            SCENARIOS[1],
+        )
+        default_command = _surface_commands(
+            project=project,
+            runtime=runtime,
+            registry_path=registry_path,
+            state_file=state_file,
+            output_format="json",
+        )["quota_should_run"]
+        detail_command = _mode_variant_commands(
+            project=project,
+            runtime=runtime,
+            registry_path=registry_path,
+            state_file=state_file,
+            output_format="json",
+        )["quota_should_run_agent_lane_next_action_detail"]
+
+        default_exit_code, default_text = _invoke_cli(default_command)
+        detail_exit_code, detail_text = _invoke_cli(detail_command)
+
+    assert default_exit_code == 0, default_text
+    assert detail_exit_code == 0, detail_text
+    default_payload = json.loads(default_text)
+    detail_payload = json.loads(detail_text)
+    default_lane = default_payload["agent_lane_next_action"]
+    detail_lane = detail_payload["agent_lane_next_action"]
+    assert default_lane["schema_version"] == (
+        "quota_cli_agent_lane_next_action_compaction_v0"
+    )
+    assert default_lane["detail_ref"] == (
+        "quota should-run --include-agent-lane-next-action-detail"
+    )
+    assert default_lane["instruction_ref"] == "#/selected_todo"
+    assert "text" not in default_lane
+    assert "title" not in default_lane
+    assert detail_lane["text"]
+    for key in (
+        "todo_id",
+        "agent_id",
+        "source",
+        "selected_by",
+        "confidence",
+        "preserves_goal_next_action",
+    ):
+        assert default_lane[key] == detail_lane[key]
     for key in ("interaction_contract", "scheduler_hint", "selected_todo"):
         assert default_payload[key] == detail_payload[key]
 

--- a/tests/control_plane/test_quota_cli_projection.py
+++ b/tests/control_plane/test_quota_cli_projection.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 
 from loopx.control_plane.quota.cli_projection import (
+    QUOTA_CLI_AGENT_LANE_NEXT_ACTION_DETAIL_COMMAND,
     QUOTA_CLI_CAPABILITY_GATE_DETAIL_COMMAND,
     QUOTA_CLI_TODO_SUMMARY_DETAIL_COMMAND,
     QUOTA_CLI_USER_TODO_SUMMARY_DETAIL_COMMAND,
@@ -319,6 +320,101 @@ def test_compact_quota_should_run_cli_payload_bounds_capability_gate_candidates(
         include_todo_summary_detail=True,
         include_user_todo_summary_detail=True,
         include_capability_gate_detail=True,
+        include_vision_audit_detail=True,
+    )
+    assert full == payload
+
+
+def test_compact_quota_should_run_cli_payload_keeps_agent_lane_handoff_lineage() -> None:
+    payload = {
+        "interaction_contract": {"mode": "bounded_delivery"},
+        "selected_todo": {"todo_id": "quality-0"},
+        "scheduler_hint": {"action": "run_now"},
+        "agent_lane_next_action": {
+            "schema_version": "agent_lane_next_action_v0",
+            "todo_id": "quality-0",
+            "index": 12,
+            "text": "continue the bounded quality slice " * 30,
+            "title": "continue the bounded quality slice " * 30,
+            "role": "agent",
+            "status": "open",
+            "priority": "P1",
+            "archive_state": "active",
+            "source_section": "Agent Todo",
+            "task_class": "advancement_task",
+            "action_kind": "qualify_output",
+            "task_repository": "git:github.com/example/loopx",
+            "continuation_policy": "independent_handoff",
+            "required_capabilities": ["shell", "filesystem_write"],
+            "claimed_by": "quality-agent",
+            "updated_at": "2026-07-24T00:00:00Z",
+            "agent_id": "quality-agent",
+            "source": "capability_gate.runnable_candidates",
+            "selected_by": "current_agent_claimed_todo",
+            "confidence": "selected",
+            "preserves_goal_next_action": True,
+            "handoff_note": {
+                "schema_version": "handoff_note_v0",
+                "handoff_id": "handoff_quality_0",
+                "todo_id": "quality-0",
+                "from_agent": "planner-agent",
+                "to_agent": "quality-agent",
+                "intent": "qualify_output",
+                "summary": "duplicated handoff summary " * 30,
+                "evidence_refs": ["todo:quality-0:evidence"],
+                "blocked_on": "todo:design-0",
+                "suggested_next_action": "duplicated next action " * 30,
+                "unblocks_todo_id": "design-0",
+            },
+        },
+    }
+
+    compact = compact_quota_should_run_cli_payload(
+        payload,
+        include_todo_summary_detail=True,
+        include_user_todo_summary_detail=True,
+        include_capability_gate_detail=True,
+        include_vision_audit_detail=True,
+    )
+
+    lane = compact["agent_lane_next_action"]
+    assert lane["schema_version"] == (
+        "quota_cli_agent_lane_next_action_compaction_v0"
+    )
+    assert lane["source_schema_version"] == "agent_lane_next_action_v0"
+    assert lane["todo_id"] == "quality-0"
+    assert lane["agent_id"] == "quality-agent"
+    assert lane["source"] == "capability_gate.runnable_candidates"
+    assert "text" not in lane
+    assert "title" not in lane
+    assert "index" not in lane
+    assert "status" not in lane
+    assert "updated_at" not in lane
+    assert "archive_state" not in lane
+    assert lane["handoff_lineage"] == {
+        "schema_version": "handoff_note_v0",
+        "handoff_id": "handoff_quality_0",
+        "todo_id": "quality-0",
+        "from_agent": "planner-agent",
+        "to_agent": "quality-agent",
+        "intent": "qualify_output",
+        "evidence_refs": ["todo:quality-0:evidence"],
+        "blocked_on": "todo:design-0",
+        "unblocks_todo_id": "design-0",
+    }
+    assert lane["detail_ref"] == (
+        QUOTA_CLI_AGENT_LANE_NEXT_ACTION_DETAIL_COMMAND
+    )
+    assert lane["instruction_ref"] == "#/selected_todo"
+    for key in ("interaction_contract", "scheduler_hint", "selected_todo"):
+        assert compact[key] == payload[key]
+
+    full = compact_quota_should_run_cli_payload(
+        payload,
+        include_todo_summary_detail=True,
+        include_user_todo_summary_detail=True,
+        include_capability_gate_detail=True,
+        include_agent_lane_next_action_detail=True,
         include_vision_audit_detail=True,
     )
     assert full == payload


### PR DESCRIPTION
## Summary
- keep `selected_todo` as the canonical human instruction in default `quota should-run` output
- compact `agent_lane_next_action` to typed route, capability, and handoff-lineage anchors with explicit instruction/detail references
- add `--include-agent-lane-next-action-detail` and qualify both modes in the CLI output budget manifest

Stacked on #2515.

## Validation
- `ruff check` on all five changed Python files
- `pytest -q tests/control_plane/test_quota_cli_projection.py tests/control_plane/test_cli_output_budget.py` (17 passed)
- `loopx canary premerge --from-git-diff` (17/17 checks passed; no failures, skips, tracked side effects, or manual holds)
- live-registry structural comparison: default 42,820 bytes vs detail 43,418 bytes (598 bytes removed); interaction contract, scheduler hint, selected todo, todo id, and agent id unchanged

## Boundary
Public runtime, CLI projection, and focused validation only. No scheduler, permission, benchmark, scoring, private evidence, credential, or production-action changes.

## Merge decision
Ready for maintainer review after the stacked base lands; not self-merging because this changes recurring runtime output.