### PR TITLE
Fix line-local SkillsBench pip network attribution

### DIFF
--- a/examples/skillsbench-failure-attribution-smoke.py
+++ b/examples/skillsbench-failure-attribution-smoke.py
@@ -40,6 +40,39 @@ def test_pip_bootstrap_failure_attribution() -> None:
     assert "pip_bootstrap_failure" in fingerprint["matched_patterns"], fingerprint
 
 
+def test_injected_pip_retry_env_does_not_imply_network_failure() -> None:
+    error_text = (
+        "Docker compose command failed.\n"
+        "ENV PIP_RETRIES=10\n"
+        "RUN pip install transitleastsquares==1.32\n"
+        "pip._vendor.packaging.requirements.InvalidRequirement: bad metadata"
+    )
+
+    fingerprint = skillsbench_runner_error_fingerprint(error_text)
+    assert fingerprint["pip_failure_subtype"] == "pip_internal_error", fingerprint
+    assert fingerprint["failure_reason_codes"] == [], fingerprint
+
+
+def test_line_local_pip_vendor_retry_remains_network_failure() -> None:
+    error_text = (
+        "Docker compose command failed. RUN pip install numpy==1.26.4.\n"
+        "pip._vendor.urllib3 MaxRetryError from pypi.org: max retries exceeded"
+    )
+
+    fingerprint = skillsbench_runner_error_fingerprint(error_text)
+    assert fingerprint["pip_failure_subtype"] == (
+        "package_index_network_failure"
+    ), fingerprint
+    assert fingerprint["terminal_failure_reason_codes"] == [
+        "retry_exhausted",
+        "pip_vendor_network",
+    ], fingerprint
+    assert fingerprint["terminal_failure_dependency_endpoints"] == [
+        "pypi_primary"
+    ], fingerprint
+    assert fingerprint["retryability"] == "retryable", fingerprint
+
+
 def test_task_skills_context_does_not_shadow_pip_failure() -> None:
     error_text = (
         "Docker compose command failed while task skills metadata references "
@@ -254,6 +287,8 @@ def test_full_score_without_completed_verifier_evidence_is_uncountable() -> None
 
 if __name__ == "__main__":
     test_pip_bootstrap_failure_attribution()
+    test_injected_pip_retry_env_does_not_imply_network_failure()
+    test_line_local_pip_vendor_retry_remains_network_failure()
     test_task_skills_context_does_not_shadow_pip_failure()
     test_docker_api_version_mismatch_attribution()
     test_docker_compose_plugin_unavailable_attribution()

--- a/loopx/benchmark_adapters/skillsbench_failure_signals.py
+++ b/loopx/benchmark_adapters/skillsbench_failure_signals.py
@@ -545,8 +545,10 @@ def skillsbench_pip_bootstrap_failure_subtype(error_text: str) -> str:
         "protocolerror",
         "proxyerror",
     )
-    if "pip._vendor." in text and any(
-        marker in text for marker in pip_vendor_network_markers
+    if any(
+        "pip._vendor." in line
+        and any(marker in line for marker in pip_vendor_network_markers)
+        for line in text.splitlines()
     ):
         return "package_index_network_failure"
     if "subprocess-exited-with-error" in text:


### PR DESCRIPTION
## Summary
- require pip vendor network markers to occur on the same line
- avoid treating injected `PIP_RETRIES` metadata as package-index failure evidence
- preserve retryable PyPI endpoint attribution with focused positive/negative smokes

## Validation
- `uv run --no-project --python 3.13 python examples/skillsbench-failure-attribution-smoke.py`
- `uv run --no-project --python 3.13 python examples/skillsbench-benchmark-run-smoke.py`
- `uvx --from "ruff>=0.12,<0.16" ruff check --ignore E402 ...`
- `loopx canary premerge --from-git-diff --no-progress` (all automatic checks passed; benchmark-sensitive manual hold covered by standing owner self-merge authorization)
- `loopx check --scan-path ...` (0 errors, 0 warnings; public boundary clean)

No benchmark scoring, task semantics, upload, submission, raw-log, or runner launch behavior changes.