### PR TITLE
refactor(quota): reference next-action projection sources

### DIFF
--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -246,6 +246,14 @@ def register_quota_command(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
     quota_parser.add_argument(
+        "--include-next-action-projection-detail",
+        action="store_true",
+        help=(
+            "Include repeated next-action mismatch text in `quota should-run`. "
+            "The default keeps warning semantics and references canonical actions."
+        ),
+    )
+    quota_parser.add_argument(
         "--include-vision-audit-detail",
         action="store_true",
         help=(
@@ -437,6 +445,14 @@ def handle_quota_command(
         ):
             raise ValueError(
                 "--include-agent-lane-next-action-detail is only valid with "
+                "`quota should-run`"
+            )
+        if (
+            bool(getattr(args, "include_next_action_projection_detail", False))
+            and args.quota_command != "should-run"
+        ):
+            raise ValueError(
+                "--include-next-action-projection-detail is only valid with "
                 "`quota should-run`"
             )
         if (
@@ -954,6 +970,9 @@ def handle_quota_command(
             ),
             include_agent_lane_next_action_detail=bool(
                 getattr(args, "include_agent_lane_next_action_detail", False)
+            ),
+            include_next_action_projection_detail=bool(
+                getattr(args, "include_next_action_projection_detail", False)
             ),
             include_vision_audit_detail=bool(
                 getattr(args, "include_vision_audit_detail", False)

--- a/loopx/control_plane/quota/cli_projection.py
+++ b/loopx/control_plane/quota/cli_projection.py
@@ -27,6 +27,12 @@ QUOTA_CLI_AGENT_LANE_NEXT_ACTION_COMPACTION_SCHEMA_VERSION = (
 QUOTA_CLI_AGENT_LANE_NEXT_ACTION_DETAIL_COMMAND = (
     "quota should-run --include-agent-lane-next-action-detail"
 )
+QUOTA_CLI_NEXT_ACTION_PROJECTION_COMPACTION_SCHEMA_VERSION = (
+    "quota_cli_next_action_projection_compaction_v0"
+)
+QUOTA_CLI_NEXT_ACTION_PROJECTION_DETAIL_COMMAND = (
+    "quota should-run --include-next-action-projection-detail"
+)
 QUOTA_CLI_VISION_AUDIT_COMPACTION_SCHEMA_VERSION = (
     "quota_cli_vision_audit_compaction_v0"
 )
@@ -109,6 +115,13 @@ _HANDOFF_LINEAGE_FIELDS = (
     "successor_todo_ids",
     "unblocks_todo_id",
     "excluded_agents",
+)
+_NEXT_ACTION_PROJECTION_WARNING_ANCHOR_FIELDS = (
+    "kind",
+    "severity",
+    "requires_state_writeback",
+    "reason",
+    "recommended_action",
 )
 _VISION_AUDIT_ANCHOR_FIELDS = (
     "required",
@@ -323,6 +336,36 @@ def _agent_lane_next_action_anchor(item: dict[str, Any]) -> dict[str, Any]:
     return anchor
 
 
+def _next_action_projection_warning_anchor(
+    warning: dict[str, Any],
+    *,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    anchor: dict[str, Any] = {
+        "schema_version": QUOTA_CLI_NEXT_ACTION_PROJECTION_COMPACTION_SCHEMA_VERSION,
+        "source_schema_version": warning.get("schema_version"),
+    }
+    for field in _NEXT_ACTION_PROJECTION_WARNING_ANCHOR_FIELDS:
+        if warning.get(field) is not None:
+            anchor[field] = warning[field]
+    if isinstance(payload.get("goal_route_hint"), dict):
+        anchor["goal_route_hint_ref"] = "#/goal_route_hint"
+    if payload.get("active_state_next_action") is not None:
+        anchor["active_state_next_action_ref"] = "#/active_state_next_action"
+    if payload.get("latest_run_recommended_action") is not None:
+        anchor["latest_run_recommended_action_ref"] = (
+            "#/latest_run_recommended_action"
+        )
+    if warning.get("agent_lane_next_action") is not None:
+        anchor["agent_lane_next_action_ref"] = (
+            "#/selected_todo/text"
+            if isinstance(payload.get("selected_todo"), dict)
+            else "#/agent_lane_next_action"
+        )
+    anchor["detail_ref"] = QUOTA_CLI_NEXT_ACTION_PROJECTION_DETAIL_COMMAND
+    return anchor
+
+
 def _vision_audit_anchor(
     audit: dict[str, Any],
     *,
@@ -400,6 +443,7 @@ def compact_quota_should_run_cli_payload(
     include_user_todo_summary_detail: bool = False,
     include_capability_gate_detail: bool = False,
     include_agent_lane_next_action_detail: bool = False,
+    include_next_action_projection_detail: bool = False,
     include_vision_audit_detail: bool = False,
 ) -> dict[str, Any]:
     """Bound CLI-only diagnostics after the full decision is computed."""
@@ -446,6 +490,18 @@ def compact_quota_should_run_cli_payload(
         compact = dict(compact)
         compact["agent_lane_next_action"] = _agent_lane_next_action_anchor(
             agent_lane_next_action
+        )
+    next_action_projection_warning = payload.get("next_action_projection_warning")
+    if not include_next_action_projection_detail and isinstance(
+        next_action_projection_warning,
+        dict,
+    ):
+        compact = dict(compact)
+        compact["next_action_projection_warning"] = (
+            _next_action_projection_warning_anchor(
+                next_action_projection_warning,
+                payload=payload,
+            )
         )
     if not include_vision_audit_detail:
         compact = _compact_vision_audit_copies(compact)

--- a/loopx/control_plane/testing/cli_output_budget.py
+++ b/loopx/control_plane/testing/cli_output_budget.py
@@ -130,7 +130,8 @@ CLI_OUTPUT_BUDGET_SPECS: tuple[CliOutputBudgetSpec, ...] = (
             "status, history, active state, --include-scheduler-detail, and "
             "--include-todo-summary-detail, --include-user-todo-summary-detail, "
             "--include-capability-gate-detail, "
-            "--include-agent-lane-next-action-detail, or "
+            "--include-agent-lane-next-action-detail, "
+            "--include-next-action-projection-detail, or "
             "--include-vision-audit-detail"
         ),
         semantic_json_keys=("interaction_contract", "scheduler_hint", "selected_todo"),
@@ -410,6 +411,16 @@ CLI_OUTPUT_MODE_VARIANT_SPECS: tuple[CliOutputModeVariantSpec, ...] = (
         variant_id="quota_should_run_agent_lane_next_action_detail",
         parent_surface_id="quota_should_run",
         command="quota should-run --include-agent-lane-next-action-detail",
+        output_formats=("json", "markdown"),
+        semantic_json_keys=("interaction_contract", "scheduler_hint", "selected_todo"),
+        markdown_anchor="# LoopX Quota Should Run",
+        max_chars={"json": 40_000, "markdown": 7_800},
+        max_lines={"json": 1_000, "markdown": 78},
+    ),
+    CliOutputModeVariantSpec(
+        variant_id="quota_should_run_next_action_projection_detail",
+        parent_surface_id="quota_should_run",
+        command="quota should-run --include-next-action-projection-detail",
         output_formats=("json", "markdown"),
         semantic_json_keys=("interaction_contract", "scheduler_hint", "selected_todo"),
         markdown_anchor="# LoopX Quota Should Run",

--- a/tests/control_plane/test_cli_output_budget.py
+++ b/tests/control_plane/test_cli_output_budget.py
@@ -6,6 +6,7 @@ import io
 import json
 import shlex
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from loopx.cli import main as cli_main
@@ -208,6 +209,52 @@ def _write_agent_vision(runtime: Path, *, agent_id: str) -> None:
     run = json.loads(run_path.read_text(encoding="utf-8"))
     run["agent_vision"] = vision
     run_path.write_text(json.dumps(run) + "\n", encoding="utf-8")
+    index_path.write_text(
+        "".join(json.dumps(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def _seed_goal_and_agent_lane_runs(
+    runtime: Path,
+    *,
+    recommended_action: str,
+) -> None:
+    runs_dir = runtime / "goals" / GOAL_ID / "runs"
+    index_path = runs_dir / "index.jsonl"
+    rows = [
+        json.loads(line)
+        for line in index_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    if len(rows) < 2:
+        raise ValueError("next-action projection fixture requires two runs")
+    lane_generated_at = datetime.now(UTC)
+    status_generated_at = lane_generated_at - timedelta(seconds=1)
+    run_updates = (
+        (
+            rows[-2],
+            {
+                "generated_at": status_generated_at.isoformat(timespec="seconds"),
+                "progress_scope": "goal",
+                "recommended_action": "Preserve the latest goal status route.",
+            },
+        ),
+        (
+            rows[-1],
+            {
+                "generated_at": lane_generated_at.isoformat(timespec="seconds"),
+                "progress_scope": "agent_lane",
+                "recommended_action": recommended_action,
+            },
+        ),
+    )
+    for row, updates in run_updates:
+        row.update(updates)
+        run_path = Path(row["json_path"])
+        run = json.loads(run_path.read_text(encoding="utf-8"))
+        run.update(updates)
+        run_path.write_text(json.dumps(run) + "\n", encoding="utf-8")
     index_path.write_text(
         "".join(json.dumps(row) + "\n" for row in rows),
         encoding="utf-8",
@@ -533,6 +580,18 @@ def _mode_variant_commands(
             str(project),
             "--include-agent-lane-next-action-detail",
         ],
+        "quota_should_run_next_action_projection_detail": common
+        + [
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_IDS[0],
+            "--scan-root",
+            str(project),
+            "--include-next-action-projection-detail",
+        ],
         "quota_should_run_vision_audit_detail": common
         + [
             "quota",
@@ -661,6 +720,7 @@ def test_manifest_covers_the_declared_agent_facing_surface_set() -> None:
         "quota_should_run_user_todo_summary_detail",
         "quota_should_run_capability_gate_detail",
         "quota_should_run_agent_lane_next_action_detail",
+        "quota_should_run_next_action_projection_detail",
         "quota_should_run_vision_audit_detail",
         "quota_should_run_turn_envelope",
         "loopx_turn_plan_transaction_detail",
@@ -944,6 +1004,87 @@ def test_quota_cli_keeps_full_agent_lane_next_action_on_explicit_cold_path(
     ):
         assert default_lane[key] == detail_lane[key]
     for key in ("interaction_contract", "scheduler_hint", "selected_todo"):
+        assert default_payload[key] == detail_payload[key]
+
+
+def test_quota_cli_keeps_full_next_action_projection_on_explicit_cold_path(
+    tmp_path: Path,
+) -> None:
+    with _stable_budget_fixture_root(
+        tmp_path / "quota-next-action-projection-detail"
+    ) as stable_root:
+        project, runtime, registry_path, state_file = _write_fixture(
+            stable_root,
+            SCENARIOS[1],
+        )
+        state_file.write_text(
+            state_file.read_text(encoding="utf-8").replace(
+                "## Agent Todo",
+                (
+                    "## Next Action\n\n"
+                    "- Preserve the durable public fixture route.\n\n"
+                    "## Agent Todo"
+                ),
+                1,
+            ),
+            encoding="utf-8",
+        )
+        _seed_goal_and_agent_lane_runs(
+            runtime,
+            recommended_action="Continue the agent-lane fixture diagnostics.",
+        )
+        default_command = _surface_commands(
+            project=project,
+            runtime=runtime,
+            registry_path=registry_path,
+            state_file=state_file,
+            output_format="json",
+        )["quota_should_run"]
+        detail_command = _mode_variant_commands(
+            project=project,
+            runtime=runtime,
+            registry_path=registry_path,
+            state_file=state_file,
+            output_format="json",
+        )["quota_should_run_next_action_projection_detail"]
+
+        default_exit_code, default_text = _invoke_cli(default_command)
+        detail_exit_code, detail_text = _invoke_cli(detail_command)
+
+    assert default_exit_code == 0, default_text
+    assert detail_exit_code == 0, detail_text
+    default_payload = json.loads(default_text)
+    detail_payload = json.loads(detail_text)
+    default_warning = default_payload["next_action_projection_warning"]
+    detail_warning = detail_payload["next_action_projection_warning"]
+    assert default_warning["schema_version"] == (
+        "quota_cli_next_action_projection_compaction_v0"
+    )
+    assert default_warning["detail_ref"] == (
+        "quota should-run --include-next-action-projection-detail"
+    )
+    assert default_warning["goal_route_hint_ref"] == "#/goal_route_hint"
+    assert default_warning["active_state_next_action_ref"] == (
+        "#/active_state_next_action"
+    )
+    assert default_warning["latest_run_recommended_action_ref"] == (
+        "#/latest_run_recommended_action"
+    )
+    assert default_warning["agent_lane_next_action_ref"] == "#/selected_todo/text"
+    assert "active_state_next_action" not in default_warning
+    assert "latest_run_recommended_action" not in default_warning
+    assert "agent_lane_next_action" not in default_warning
+    assert detail_warning["active_state_next_action"]
+    assert detail_warning["latest_run_recommended_action"]
+    assert detail_warning["agent_lane_next_action"]
+    for key in ("kind", "severity", "requires_state_writeback", "reason"):
+        assert default_warning[key] == detail_warning[key]
+    for key in (
+        "goal_route_hint",
+        "interaction_contract",
+        "scheduler_hint",
+        "selected_todo",
+    ):
         assert default_payload[key] == detail_payload[key]
 
 

--- a/tests/control_plane/test_quota_cli_projection.py
+++ b/tests/control_plane/test_quota_cli_projection.py
@@ -5,6 +5,7 @@ import json
 from loopx.control_plane.quota.cli_projection import (
     QUOTA_CLI_AGENT_LANE_NEXT_ACTION_DETAIL_COMMAND,
     QUOTA_CLI_CAPABILITY_GATE_DETAIL_COMMAND,
+    QUOTA_CLI_NEXT_ACTION_PROJECTION_DETAIL_COMMAND,
     QUOTA_CLI_TODO_SUMMARY_DETAIL_COMMAND,
     QUOTA_CLI_USER_TODO_SUMMARY_DETAIL_COMMAND,
     QUOTA_CLI_VISION_AUDIT_DETAIL_COMMAND,
@@ -415,6 +416,87 @@ def test_compact_quota_should_run_cli_payload_keeps_agent_lane_handoff_lineage()
         include_user_todo_summary_detail=True,
         include_capability_gate_detail=True,
         include_agent_lane_next_action_detail=True,
+        include_vision_audit_detail=True,
+    )
+    assert full == payload
+
+
+def test_compact_quota_should_run_cli_payload_references_next_action_sources() -> None:
+    payload = {
+        "active_state_next_action": "durable goal route",
+        "latest_run_recommended_action": "agent-lane run recommendation",
+        "selected_todo": {
+            "todo_id": "quality-0",
+            "text": "continue the bounded quality slice",
+        },
+        "goal_route_hint": {
+            "schema_version": "goal_route_hint_v0",
+            "route_decision": "run_current_agent_lane",
+            "preserves_goal_next_action": True,
+        },
+        "next_action_projection_warning": {
+            "schema_version": "next_action_projection_warning_v0",
+            "kind": "next_action_projection_mismatch",
+            "severity": "info",
+            "requires_state_writeback": False,
+            "active_state_next_action": "durable goal route",
+            "latest_run_recommended_action": "agent-lane run recommendation",
+            "reason": "the selected lane preserves the durable route",
+            "recommended_action": "run the selected agent lane",
+            "agent_lane_next_action": "continue the bounded quality slice",
+        },
+        "interaction_contract": {"mode": "bounded_delivery"},
+        "scheduler_hint": {"action": "run_now"},
+    }
+
+    compact = compact_quota_should_run_cli_payload(
+        payload,
+        include_todo_summary_detail=True,
+        include_user_todo_summary_detail=True,
+        include_capability_gate_detail=True,
+        include_agent_lane_next_action_detail=True,
+        include_vision_audit_detail=True,
+    )
+
+    warning = compact["next_action_projection_warning"]
+    assert warning["schema_version"] == (
+        "quota_cli_next_action_projection_compaction_v0"
+    )
+    assert warning["source_schema_version"] == (
+        "next_action_projection_warning_v0"
+    )
+    assert warning["kind"] == "next_action_projection_mismatch"
+    assert warning["severity"] == "info"
+    assert warning["requires_state_writeback"] is False
+    assert warning["goal_route_hint_ref"] == "#/goal_route_hint"
+    assert warning["active_state_next_action_ref"] == (
+        "#/active_state_next_action"
+    )
+    assert warning["latest_run_recommended_action_ref"] == (
+        "#/latest_run_recommended_action"
+    )
+    assert warning["agent_lane_next_action_ref"] == "#/selected_todo/text"
+    assert warning["detail_ref"] == (
+        QUOTA_CLI_NEXT_ACTION_PROJECTION_DETAIL_COMMAND
+    )
+    assert "active_state_next_action" not in warning
+    assert "latest_run_recommended_action" not in warning
+    assert "agent_lane_next_action" not in warning
+    for key in (
+        "goal_route_hint",
+        "interaction_contract",
+        "scheduler_hint",
+        "selected_todo",
+    ):
+        assert compact[key] == payload[key]
+
+    full = compact_quota_should_run_cli_payload(
+        payload,
+        include_todo_summary_detail=True,
+        include_user_todo_summary_detail=True,
+        include_capability_gate_detail=True,
+        include_agent_lane_next_action_detail=True,
+        include_next_action_projection_detail=True,
         include_vision_audit_detail=True,
     )
     assert full == payload


### PR DESCRIPTION
## Summary
- keep next-action mismatch warning semantics on the default `quota should-run` path while replacing repeated action text with JSON Pointer lineage
- add `--include-next-action-projection-detail` as the explicit cold path for the full diagnostic payload
- register and test the new output-budget mode without changing goal routing, todo selection, scheduler, permission, or benchmark behavior

## Qualification
- focused tests: `19 passed`
- focused Ruff: `--select F,UP017` passed
- `loopx canary premerge --from-git-diff`: 17/17 passed, 0 failures, 0 warnings, 0 manual holds
- live comparison: default 44,103 bytes vs detail 44,429 bytes; 326 bytes removed from the recurring path
- semantic equality verified for `goal_route_hint`, `interaction_contract`, `selected_todo`, scheduler projection, and user summary
- public/private scan: no private links, local paths, credentials, raw benchmark evidence, or generated logs

## Delivery Notes
- stacked on #2516 so the diff remains single-purpose
- no self-merge: this changes recurring control-plane CLI output and should merge after the stack base and CI are green
- no failures or skipped canaries; a latest-version broad Ruff probe also surfaced unrelated pre-existing import/E501/exception-style debt outside this PR
