### PR TITLE
refactor(quota): bound goal boundary authority detail

### DIFF
--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -230,6 +230,14 @@ def register_quota_command(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
     quota_parser.add_argument(
+        "--include-goal-boundary-detail",
+        action="store_true",
+        help=(
+            "Include checkpointed goal-boundary authority entries in "
+            "`quota should-run`. The default keeps effective scope and counts."
+        ),
+    )
+    quota_parser.add_argument(
         "--codex-app-current-rrule",
         help=(
             "Current RRULE observed from the active Codex App heartbeat. For "
@@ -406,6 +414,14 @@ def handle_quota_command(
         ):
             raise ValueError(
                 "--include-user-todo-summary-detail is only valid with "
+                "`quota should-run`"
+            )
+        if (
+            bool(getattr(args, "include_goal_boundary_detail", False))
+            and args.quota_command != "should-run"
+        ):
+            raise ValueError(
+                "--include-goal-boundary-detail is only valid with "
                 "`quota should-run`"
             )
         raw_heartbeat_turn_id = getattr(args, "turn_instance_id", None)
@@ -910,6 +926,9 @@ def handle_quota_command(
             ),
             include_user_todo_summary_detail=bool(
                 getattr(args, "include_user_todo_summary_detail", False)
+            ),
+            include_goal_boundary_detail=bool(
+                getattr(args, "include_goal_boundary_detail", False)
             ),
         )
     renderer = (

--- a/loopx/control_plane/quota/cli_projection.py
+++ b/loopx/control_plane/quota/cli_projection.py
@@ -15,6 +15,12 @@ QUOTA_CLI_USER_TODO_SUMMARY_COMPACTION_SCHEMA_VERSION = (
 QUOTA_CLI_USER_TODO_SUMMARY_DETAIL_COMMAND = (
     "quota should-run --include-user-todo-summary-detail"
 )
+QUOTA_CLI_GOAL_BOUNDARY_COMPACTION_SCHEMA_VERSION = (
+    "quota_cli_goal_boundary_compaction_v0"
+)
+QUOTA_CLI_GOAL_BOUNDARY_DETAIL_COMMAND = (
+    "quota should-run --include-goal-boundary-detail"
+)
 _RETAINED_AGENT_ITEM_LANES = {
     "first_executable_items": 3,
     "unclaimed_priority_open_items": 3,
@@ -161,13 +167,34 @@ def _compact_user_todo_summary(summary: dict[str, Any]) -> dict[str, Any]:
     return compact
 
 
+def _compact_goal_boundary(boundary: dict[str, Any]) -> dict[str, Any]:
+    authority = boundary.get("checkpointed_boundary_authority")
+    if not isinstance(authority, dict) or not isinstance(
+        authority.get("entries"),
+        list,
+    ):
+        return boundary
+
+    compact_authority = dict(authority)
+    entries = compact_authority.pop("entries")
+    compact_authority["payload_compaction"] = {
+        "schema_version": QUOTA_CLI_GOAL_BOUNDARY_COMPACTION_SCHEMA_VERSION,
+        "omitted_entry_count": len(entries),
+        "full_detail_cold_path": QUOTA_CLI_GOAL_BOUNDARY_DETAIL_COMMAND,
+    }
+    compact = dict(boundary)
+    compact["checkpointed_boundary_authority"] = compact_authority
+    return compact
+
+
 def compact_quota_should_run_cli_payload(
     payload: dict[str, Any],
     *,
     include_todo_summary_detail: bool = False,
     include_user_todo_summary_detail: bool = False,
+    include_goal_boundary_detail: bool = False,
 ) -> dict[str, Any]:
-    """Bound CLI-only todo diagnostics after the full decision is computed."""
+    """Bound CLI-only diagnostics after the full decision is computed."""
 
     compact = payload
     compacted_roles: list[str] = []
@@ -194,4 +221,10 @@ def compact_quota_should_run_cli_payload(
                 else QUOTA_CLI_USER_TODO_SUMMARY_DETAIL_COMMAND
             ),
         }
+    goal_boundary = payload.get("goal_boundary")
+    if not include_goal_boundary_detail and isinstance(goal_boundary, dict):
+        compact_goal_boundary = _compact_goal_boundary(goal_boundary)
+        if compact_goal_boundary is not goal_boundary:
+            compact = dict(compact)
+            compact["goal_boundary"] = compact_goal_boundary
     return compact

--- a/loopx/control_plane/testing/cli_output_budget.py
+++ b/loopx/control_plane/testing/cli_output_budget.py
@@ -128,7 +128,8 @@ CLI_OUTPUT_BUDGET_SPECS: tuple[CliOutputBudgetSpec, ...] = (
         qualification_policy="absolute_hot_path",
         cold_path=(
             "status, history, active state, --include-scheduler-detail, and "
-            "--include-todo-summary-detail or --include-user-todo-summary-detail"
+            "--include-todo-summary-detail, --include-user-todo-summary-detail, "
+            "or --include-goal-boundary-detail"
         ),
         semantic_json_keys=("interaction_contract", "scheduler_hint", "selected_todo"),
         markdown_anchor="# LoopX Quota Should Run",
@@ -390,6 +391,16 @@ CLI_OUTPUT_MODE_VARIANT_SPECS: tuple[CliOutputModeVariantSpec, ...] = (
         variant_id="quota_should_run_user_todo_summary_detail",
         parent_surface_id="quota_should_run",
         command="quota should-run --include-user-todo-summary-detail",
+        output_formats=("json", "markdown"),
+        semantic_json_keys=("interaction_contract", "scheduler_hint", "selected_todo"),
+        markdown_anchor="# LoopX Quota Should Run",
+        max_chars={"json": 35_000, "markdown": 7_800},
+        max_lines={"json": 900, "markdown": 78},
+    ),
+    CliOutputModeVariantSpec(
+        variant_id="quota_should_run_goal_boundary_detail",
+        parent_surface_id="quota_should_run",
+        command="quota should-run --include-goal-boundary-detail",
         output_formats=("json", "markdown"),
         semantic_json_keys=("interaction_contract", "scheduler_hint", "selected_todo"),
         markdown_anchor="# LoopX Quota Should Run",

--- a/tests/control_plane/test_cli_output_budget.py
+++ b/tests/control_plane/test_cli_output_budget.py
@@ -182,6 +182,26 @@ def _write_rollout_event(runtime: Path, *, agent_id: str) -> None:
     )
 
 
+def _write_checkpointed_boundary_authority(registry_path: Path) -> None:
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    coordination = registry["goals"][0]["coordination"]
+    coordination["checkpointed_boundary_authority"] = [
+        {
+            "schema_version": "checkpointed_boundary_authority_v0",
+            "status": "active",
+            "decision": "approve",
+            "write_scope": ["docs/**"],
+            "source": "public_fixture_owner_approval",
+            "recorded_at": "2026-01-01T00:00:00+00:00",
+            "decision_id": "todo_fixture_boundary_001",
+        }
+    ]
+    registry_path.write_text(
+        json.dumps(registry, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
 def _invoke_cli(args: list[str]) -> tuple[int, str]:
     output = io.StringIO()
     with contextlib.redirect_stdout(output):
@@ -477,6 +497,18 @@ def _mode_variant_commands(
             str(project),
             "--include-user-todo-summary-detail",
         ],
+        "quota_should_run_goal_boundary_detail": common
+        + [
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_IDS[0],
+            "--scan-root",
+            str(project),
+            "--include-goal-boundary-detail",
+        ],
         "quota_should_run_turn_envelope": common
         + [
             "quota",
@@ -591,6 +623,7 @@ def test_manifest_covers_the_declared_agent_facing_surface_set() -> None:
         "quota_should_run_scheduler_detail",
         "quota_should_run_todo_summary_detail",
         "quota_should_run_user_todo_summary_detail",
+        "quota_should_run_goal_boundary_detail",
         "quota_should_run_turn_envelope",
         "loopx_turn_plan_transaction_detail",
         "loopx_turn_run_once_preview",
@@ -750,6 +783,64 @@ def test_quota_cli_keeps_full_user_todo_diagnostics_on_explicit_cold_path(
         "quota_todo_summary_payload_compaction_v0"
     )
     assert detail_payload["todo_summary_projection"]["compacted_roles"] == ["agent"]
+    for key in ("interaction_contract", "scheduler_hint", "selected_todo"):
+        assert default_payload[key] == detail_payload[key]
+
+
+def test_quota_cli_keeps_goal_boundary_authority_on_explicit_cold_path(
+    tmp_path: Path,
+) -> None:
+    with _stable_budget_fixture_root(
+        tmp_path / "quota-goal-boundary-detail"
+    ) as stable_root:
+        project, runtime, registry_path, state_file = _write_fixture(
+            stable_root,
+            SCENARIOS[1],
+        )
+        _write_checkpointed_boundary_authority(registry_path)
+        default_command = _surface_commands(
+            project=project,
+            runtime=runtime,
+            registry_path=registry_path,
+            state_file=state_file,
+            output_format="json",
+        )["quota_should_run"]
+        detail_command = _mode_variant_commands(
+            project=project,
+            runtime=runtime,
+            registry_path=registry_path,
+            state_file=state_file,
+            output_format="json",
+        )["quota_should_run_goal_boundary_detail"]
+
+        default_exit_code, default_text = _invoke_cli(default_command)
+        detail_exit_code, detail_text = _invoke_cli(detail_command)
+
+    assert default_exit_code == 0, default_text
+    assert detail_exit_code == 0, detail_text
+    default_payload = json.loads(default_text)
+    detail_payload = json.loads(detail_text)
+    default_boundary = default_payload["goal_boundary"]
+    detail_boundary = detail_payload["goal_boundary"]
+    default_authority = default_boundary["checkpointed_boundary_authority"]
+    detail_authority = detail_boundary["checkpointed_boundary_authority"]
+    assert default_authority["payload_compaction"] == {
+        "schema_version": "quota_cli_goal_boundary_compaction_v0",
+        "omitted_entry_count": 1,
+        "full_detail_cold_path": "quota should-run --include-goal-boundary-detail",
+    }
+    assert "entries" not in default_authority
+    assert detail_authority["entries"]
+    for key in ("active_count", "inactive_count", "active_write_scope"):
+        assert default_authority[key] == detail_authority[key]
+    expected_boundary = dict(detail_boundary)
+    expected_authority = dict(detail_authority)
+    expected_authority.pop("entries")
+    expected_authority["payload_compaction"] = default_authority[
+        "payload_compaction"
+    ]
+    expected_boundary["checkpointed_boundary_authority"] = expected_authority
+    assert default_boundary == expected_boundary
     for key in ("interaction_contract", "scheduler_hint", "selected_todo"):
         assert default_payload[key] == detail_payload[key]
 

--- a/tests/control_plane/test_quota_cli_projection.py
+++ b/tests/control_plane/test_quota_cli_projection.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 
 from loopx.control_plane.quota.cli_projection import (
+    QUOTA_CLI_GOAL_BOUNDARY_DETAIL_COMMAND,
     QUOTA_CLI_TODO_SUMMARY_DETAIL_COMMAND,
     QUOTA_CLI_USER_TODO_SUMMARY_DETAIL_COMMAND,
     compact_quota_should_run_cli_payload,
@@ -235,6 +236,69 @@ def test_compact_quota_should_run_cli_payload_keeps_active_user_work_and_gate_sc
         payload,
         include_todo_summary_detail=True,
         include_user_todo_summary_detail=True,
+    )
+    assert full == payload
+
+
+def test_compact_quota_should_run_cli_payload_bounds_boundary_authority_entries() -> None:
+    payload = {
+        "goal_boundary": {
+            "checkpointed_boundary_authority": {
+                "schema_version": "checkpointed_boundary_authority_v0",
+                "active_count": 1,
+                "inactive_count": 0,
+                "active_write_scope": ["docs/**"],
+                "entries": [
+                    {
+                        "status": "active",
+                        "decision": "approve",
+                        "write_scope": ["docs/**"],
+                        "source": "public_fixture_owner_approval",
+                    }
+                ],
+            },
+            "write_scope": ["docs/**"],
+            "requires_parent_approval": ["publish"],
+            "guards": ["keep private state out of public changes"],
+            "stop_condition": "stop when owner approval is required",
+        },
+        "interaction_contract": {"mode": "bounded_delivery"},
+        "scheduler_hint": {"action": "run_now"},
+        "selected_todo": {"todo_id": "quality-0"},
+    }
+
+    compact = compact_quota_should_run_cli_payload(
+        payload,
+        include_todo_summary_detail=True,
+        include_user_todo_summary_detail=True,
+    )
+
+    boundary = compact["goal_boundary"]
+    authority = boundary["checkpointed_boundary_authority"]
+    assert "entries" not in authority
+    assert authority["active_count"] == 1
+    assert authority["inactive_count"] == 0
+    assert authority["active_write_scope"] == ["docs/**"]
+    assert authority["payload_compaction"] == {
+        "schema_version": "quota_cli_goal_boundary_compaction_v0",
+        "omitted_entry_count": 1,
+        "full_detail_cold_path": QUOTA_CLI_GOAL_BOUNDARY_DETAIL_COMMAND,
+    }
+    for key in (
+        "write_scope",
+        "requires_parent_approval",
+        "guards",
+        "stop_condition",
+    ):
+        assert boundary[key] == payload["goal_boundary"][key]
+    for key in ("interaction_contract", "scheduler_hint", "selected_todo"):
+        assert compact[key] == payload[key]
+
+    full = compact_quota_should_run_cli_payload(
+        payload,
+        include_todo_summary_detail=True,
+        include_user_todo_summary_detail=True,
+        include_goal_boundary_detail=True,
     )
     assert full == payload
 


### PR DESCRIPTION
## Summary
- keep `goal_boundary` authority computation unchanged while omitting repeated checkpoint history entries from the default `quota should-run` CLI projection
- preserve effective write scopes, active/inactive counts, guards, approval requirements, stop condition, and all other boundary fields
- add `--include-goal-boundary-detail` as the explicit cold path for full checkpoint lineage and qualify it in the output-budget manifest

## Live Qualification
- default JSON: 44,086 -> 42,358 bytes (1,728 bytes removed)
- full boundary detail remains available at 44,086 bytes
- all three checkpoint entries are present on the detail path
- default and detail modes are identical outside the entries/detail-compaction substitution
- exact equality verified for root write scope, guards, approval requirements, stop condition, `interaction_contract`, `scheduler_hint`, and `selected_todo`

## Validation
- focused pytest: 21 passed
- pinned Ruff (`>=0.12,<0.16`): passed
- `loopx canary premerge --from-git-diff`: 17/17 passed, 0 failures, 0 warnings, 0 manual holds
- `git diff --check` and public/private boundary scan passed

## Stack And Boundary
- stacked on #2518; this PR contains only the goal-boundary CLI projection slice
- no authority, permission, scheduler, benchmark, scoring, production, or state-write behavior changes
- no private state, credentials, local paths, raw evidence, or generated logs
- not self-merging because recurring agent-facing control-plane output should merge in stack order after CI and maintainer review
