### PR TITLE
fix(benchmark): stage no-isolation build prerequisites

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -6222,7 +6222,8 @@ def test_skillsbench_docker_task_staging_adds_pip_bootstrap_patch() -> None:
         dockerfile.parent.mkdir(parents=True)
         original_text = (
             "FROM ubuntu:24.04 AS builder\n"
-            "RUN pip3 install numpy==1.26.4 pandas==2.2.2\n"
+            'RUN pip3 install "setuptools<81" numpy==1.26.4 '
+            "batman-package==2.5.2 pandas==2.2.2\n"
             "FROM python:3.12-slim\n"
             "RUN python3 -m pip install pyyaml==6.0.1\n"
         )
@@ -6262,6 +6263,10 @@ def test_skillsbench_docker_task_staging_adds_pip_bootstrap_patch() -> None:
         assert "PIP_RETRIES=10" in staged_text, staged_text
         assert "PIP_NO_BUILD_ISOLATION" not in staged_text, staged_text
         assert "--no-build-isolation" not in staged_text, staged_text
+        assert (
+            dockerfile_runtime.PIP_NO_ISOLATION_BUILD_PREREQUISITES_MARKER
+            not in staged_text
+        ), staged_text
         assert staged_text.index(DOCKER_PIP_BOOTSTRAP_BEGIN) < staged_text.index(
             "pip3 install"
         ), staged_text
@@ -6300,9 +6305,19 @@ def test_skillsbench_docker_task_staging_adds_pip_bootstrap_patch() -> None:
             "no-isolation"
         ), no_isolation_metadata
         assert "PIP_NO_BUILD_ISOLATION" not in no_isolation_text, no_isolation_text
-        assert "pip3 install --no-build-isolation numpy" in no_isolation_text, (
-            no_isolation_text
+        prerequisite_step = (
+            "RUN python3 -m pip install --no-cache-dir "
+            "'setuptools<81' wheel numpy==1.26.4"
         )
+        assert prerequisite_step in no_isolation_text, no_isolation_text
+        assert (
+            no_isolation_text.index(prerequisite_step)
+            < no_isolation_text.index("RUN pip3 install --no-build-isolation")
+        ), no_isolation_text
+        assert (
+            'pip3 install --no-build-isolation "setuptools<81"'
+            in no_isolation_text
+        ), no_isolation_text
         assert (
             "python3 -m pip install --no-build-isolation pyyaml"
             in no_isolation_text

--- a/loopx/benchmark_adapters/skillsbench_dockerfile_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_dockerfile_runtime.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 import os
 import re
+import shlex
 import tempfile
 from pathlib import Path
 
 VENV_PIP_INVOCATION_MARKER = "# LOOPX_SKILLSBENCH_VENV_PIP_INVOCATION"
+PIP_NO_ISOLATION_BUILD_PREREQUISITES_MARKER = (
+    "# LOOPX_SKILLSBENCH_PIP_NO_ISOLATION_BUILD_PREREQUISITES"
+)
 UBUNTU_APT_MIRROR_BEGIN = "# BEGIN LOOPX_SKILLSBENCH_UBUNTU_APT_MIRROR"
 UBUNTU_APT_MIRROR_END = "# END LOOPX_SKILLSBENCH_UBUNTU_APT_MIRROR"
 DEBIAN_APT_MIRROR_BEGIN = "# BEGIN LOOPX_SKILLSBENCH_DEBIAN_APT_MIRROR"
@@ -273,6 +277,97 @@ def add_pip_no_build_isolation_flags(text: str) -> tuple[str, int]:
         replaced += count
     suffix = "\n" if text.endswith("\n") else ""
     return "\n".join(lines) + suffix, replaced
+
+
+def _declared_requirement(tokens: list[str], package: str) -> str | None:
+    requirement = re.compile(
+        rf"^{re.escape(package)}(?:\[[^\]]+\])?"
+        r"(?:(?:===|==|~=|!=|<=|>=|<|>).+)?$",
+        re.IGNORECASE,
+    )
+    return next(
+        (
+            token
+            for token in tokens
+            if "$" not in token and requirement.fullmatch(token)
+        ),
+        None,
+    )
+
+
+def add_pip_no_isolation_build_prerequisite_steps(
+    text: str,
+) -> tuple[str, int]:
+    """Materialize declared build prerequisites before no-isolation installs."""
+
+    if PIP_NO_ISOLATION_BUILD_PREREQUISITES_MARKER in text:
+        return text, 0
+
+    lines = text.splitlines()
+    patched: list[str] = []
+    inserted = 0
+    index = 0
+    heredoc_delimiter: str | None = None
+    while index < len(lines):
+        line = lines[index]
+        if heredoc_delimiter is not None:
+            patched.append(line)
+            if line.strip() == heredoc_delimiter:
+                heredoc_delimiter = None
+            index += 1
+            continue
+        heredoc_delimiter = dockerfile_heredoc_delimiter(line)
+        if heredoc_delimiter is not None or not re.match(
+            r"^\s*RUN\s+", line, re.IGNORECASE
+        ):
+            patched.append(line)
+            index += 1
+            continue
+
+        end = index + 1
+        while lines[end - 1].rstrip().endswith("\\") and end < len(lines):
+            end += 1
+        command_lines = lines[index:end]
+        logical_command = " ".join(
+            command_line.rstrip().removesuffix("\\").strip()
+            for command_line in command_lines
+        )
+        try:
+            tokens = shlex.split(logical_command)
+        except ValueError:
+            tokens = []
+        setuptools_requirement = _declared_requirement(tokens, "setuptools")
+        numpy_requirement = _declared_requirement(tokens, "numpy")
+        wheel_requirement = _declared_requirement(tokens, "wheel") or "wheel"
+        if (
+            "--no-build-isolation" in tokens
+            and setuptools_requirement
+            and numpy_requirement
+        ):
+            indent = re.match(r"^\s*", line).group(0)
+            prerequisites = " ".join(
+                shlex.quote(requirement)
+                for requirement in (
+                    setuptools_requirement,
+                    wheel_requirement,
+                    numpy_requirement,
+                )
+            )
+            patched.extend(
+                [
+                    f"{indent}{PIP_NO_ISOLATION_BUILD_PREREQUISITES_MARKER}",
+                    (
+                        f"{indent}RUN python3 -m pip install --no-cache-dir "
+                        f"{prerequisites}"
+                    ),
+                ]
+            )
+            inserted += 1
+        patched.extend(command_lines)
+        index = end
+
+    suffix = "\n" if text.endswith("\n") else ""
+    return "\n".join(patched) + suffix, inserted
 
 
 def _rewrite_bare_pip_installs(text: str) -> tuple[str, int]:

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -8017,6 +8017,11 @@ def patch_dockerfile_pip_bootstrap(
     )
     if build_mode == "no-isolation":
         text, _ = dockerfile_runtime.add_pip_no_build_isolation_flags(text)
+        text, _ = (
+            dockerfile_runtime.add_pip_no_isolation_build_prerequisite_steps(
+                text
+            )
+        )
     block = (
         f"{DOCKER_PIP_BOOTSTRAP_BEGIN}\n"
         f"ARG LOOPX_SKILLSBENCH_PIP_INDEX_URL={index_url}\n"

--- a/tests/test_skillsbench_dockerfile_runtime.py
+++ b/tests/test_skillsbench_dockerfile_runtime.py
@@ -74,3 +74,46 @@ def test_pip_no_build_isolation_flags_are_explicit_and_heredoc_safe() -> None:
     assert 'echo "pip install remains documentation"' in patched
     assert "pip install not-a-docker-command" in patched
     assert runtime.add_pip_no_build_isolation_flags(patched) == (patched, 0)
+
+
+def test_no_isolation_materializes_declared_build_prerequisites() -> None:
+    original = (
+        "FROM python:3.12-slim\n"
+        "RUN pip install --no-cache-dir \\\n"
+        '    "setuptools<81" \\\n'
+        "    numpy==1.26.4 \\\n"
+        "    batman-package==2.5.2\n"
+    )
+    flagged, flag_count = runtime.add_pip_no_build_isolation_flags(original)
+
+    patched, prerequisite_count = (
+        runtime.add_pip_no_isolation_build_prerequisite_steps(flagged)
+    )
+
+    prerequisite_step = (
+        "RUN python3 -m pip install --no-cache-dir "
+        "'setuptools<81' wheel numpy==1.26.4"
+    )
+    assert flag_count == 1
+    assert prerequisite_count == 1
+    assert runtime.PIP_NO_ISOLATION_BUILD_PREREQUISITES_MARKER in patched
+    assert prerequisite_step in patched
+    assert patched.index(prerequisite_step) < patched.index(
+        "RUN pip install --no-build-isolation"
+    )
+    assert runtime.add_pip_no_isolation_build_prerequisite_steps(patched) == (
+        patched,
+        0,
+    )
+
+
+def test_no_isolation_prerequisite_step_requires_declared_numpy() -> None:
+    original = (
+        "FROM python:3.12-slim\n"
+        "RUN pip install --no-build-isolation 'setuptools<81' package==1.0\n"
+    )
+
+    assert runtime.add_pip_no_isolation_build_prerequisite_steps(original) == (
+        original,
+        0,
+    )


### PR DESCRIPTION
## Summary

- materialize Dockerfile-declared setuptools, wheel, and numpy before no-isolation aggregate installs
- limit the behavior to explicit no-isolation commands that already declare setuptools and numpy
- cover isolated/default parity, ordering, idempotence, and the public SkillsBench staging path

## Validation

- `76 passed` across focused Dockerfile runtime, setup preflight, and turn launcher tests
- `examples/skillsbench-benchmark-run-smoke.py`
- `examples/skillsbench-failure-attribution-smoke.py`
- changed-file `py_compile` and focused Ruff checks
- LoopX standard premerge canary: all 11 executed checks passed
- LoopX public/private boundary scan: clean

## Scope

This does not change benchmark scoring, task semantics, submission behavior, or the default isolated build path. It only orders already-declared build prerequisites for the explicit no-isolation staging mode.