### PR TITLE
fix(benchmark): expose host Codex exec timeout

### DIFF
--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -54,6 +54,10 @@ Optional env:
                                        control; default codex from local PATH
   SKILLSBENCH_LOCAL_CODEX_SANDBOX      Host Codex sandbox mode; default
                                        workspace-write
+  SKILLSBENCH_LOCAL_CODEX_EXEC_TIMEOUT_SEC
+                                       Optional positive per-prompt timeout for
+                                       host-local Codex; unset preserves the
+                                       runner default
   SKILLSBENCH_CLI_GOAL_THREAD_PREWARM  Set to 1 to prewarm the persisted Codex
                                        TUI thread before submitting /goal
   SKILLSBENCH_ALLOW_STAGED_BOOTSTRAP_REPAIR_RUN
@@ -219,9 +223,15 @@ remote_codex_bin="${SKILLSBENCH_REMOTE_CODEX_BIN:-codex}"
 local_codex_split_control="${SKILLSBENCH_LOCAL_CODEX_SPLIT_CONTROL:-0}"
 local_codex_bin="${SKILLSBENCH_LOCAL_CODEX_BIN:-codex}"
 local_codex_sandbox="${SKILLSBENCH_LOCAL_CODEX_SANDBOX:-workspace-write}"
+local_codex_exec_timeout="${SKILLSBENCH_LOCAL_CODEX_EXEC_TIMEOUT_SEC:-}"
 codex_cli_goal_thread_prewarm="${SKILLSBENCH_CLI_GOAL_THREAD_PREWARM:-0}"
 if [[ "$codex_cli_goal_thread_prewarm" != "0" && "$codex_cli_goal_thread_prewarm" != "1" ]]; then
   echo "SKILLSBENCH_CLI_GOAL_THREAD_PREWARM must be 0 or 1" >&2
+  exit 2
+fi
+if [[ -n "$local_codex_exec_timeout" ]] &&
+  [[ ! "$local_codex_exec_timeout" =~ ^[1-9][0-9]*$ ]]; then
+  echo "SKILLSBENCH_LOCAL_CODEX_EXEC_TIMEOUT_SEC must be a positive integer" >&2
   exit 2
 fi
 skip_global_ledger_sync="${SKILLSBENCH_SKIP_GLOBAL_LEDGER_SYNC:-0}"
@@ -548,6 +558,11 @@ if [[ "$local_codex_split_control" == "1" ]]; then
     --host-local-acp-codex-exec-preflight-attempts 1
   )
 fi
+if [[ -n "$local_codex_exec_timeout" ]]; then
+  extra_runner_args+=(
+    --local-codex-exec-timeout-sec "$local_codex_exec_timeout"
+  )
+fi
 if [[ "$codex_cli_goal_thread_prewarm" == "1" ]]; then
   extra_runner_args+=(--codex-cli-goal-thread-prewarm)
 fi
@@ -787,6 +802,8 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'runner_profile_path_recorded=false\n'
   printf 'runner_profile_values_recorded=false\n'
   printf 'local_codex_sandbox=%s\n' "$local_codex_sandbox"
+  printf 'local_codex_exec_timeout_sec=%s\n' \
+    "${local_codex_exec_timeout:-runner-default}"
   printf 'exact_host_codex_sandbox_preflight=%s\n' \
     "$exact_host_codex_sandbox_preflight"
   printf 'codex_cli_goal_thread_prewarm=%s\n' "$codex_cli_goal_thread_prewarm"
@@ -842,6 +859,8 @@ if [[ "$dry_run" == "true" ]]; then
       printf '%s ' --local-codex-provider --host-local-acp-codex-exec-preflight
     [[ "$local_codex_split_control" == "1" ]] &&
       printf '%s ' --host-local-acp-codex-exec-preflight-attempts
+    [[ -n "$local_codex_exec_timeout" ]] &&
+      printf '%s ' --local-codex-exec-timeout-sec
     [[ -n "$remote_command_file_bridge_probe_command" ]] &&
       printf '%s ' --remote-command-file-bridge-probe-command
     [[ -n "$remote_command_file_bridge_solver_command" ]] &&

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -197,6 +197,7 @@ def test_launcher_split_control_is_opt_in_and_redacts_provider_values(
     output = proc.stdout
     assert "local_codex_split_control=1" in output
     assert "local_codex_provider=reverse_channel" in output
+    assert "local_codex_exec_timeout_sec=runner-default" in output
     assert "remote_codex_bin_mode=split_control_client" in output
     assert (
         "exact_host_codex_sandbox_preflight=split_control_not_applicable"
@@ -219,6 +220,55 @@ def test_launcher_split_control_is_opt_in_and_redacts_provider_values(
     assert "codex_bridge_client" not in output
     assert "loopx-codex-" not in output
     assert "example.invalid" not in output
+
+
+def test_launcher_wires_explicit_local_codex_exec_timeout(
+    tmp_path: Path,
+) -> None:
+    env = _base_env(tmp_path)
+    env.update(
+        {
+            "SKILLSBENCH_LOCAL_CODEX_SPLIT_CONTROL": "1",
+            "SKILLSBENCH_LOCAL_CODEX_EXEC_TIMEOUT_SEC": "14400",
+        }
+    )
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "exec-timeout"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+
+    assert "local_codex_exec_timeout_sec=14400" in proc.stdout
+    assert "--local-codex-exec-timeout-sec" in proc.stdout
+
+
+def test_launcher_rejects_invalid_local_codex_exec_timeout(
+    tmp_path: Path,
+) -> None:
+    env = _base_env(tmp_path)
+    env["SKILLSBENCH_LOCAL_CODEX_EXEC_TIMEOUT_SEC"] = "0"
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "exec-timeout"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    assert (
+        "SKILLSBENCH_LOCAL_CODEX_EXEC_TIMEOUT_SEC must be a positive integer"
+        in proc.stderr
+    )
+    assert "supervisor_command=" not in proc.stdout
 
 
 def test_launcher_split_control_requires_workspace_write(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- expose the existing runner `--local-codex-exec-timeout-sec` through the goal-xhigh launcher as an opt-in environment setting
- preserve the current runner default when the setting is absent
- validate positive integers and record only the resolved timeout in dry-run output

## Motivation

A matched SkillsBench run reached the host-local Codex worker and completed substantial task-facing operations, but the default per-prompt bridge timeout ended the turn before the Turn commit could be produced. The launcher already forwards other host-local controls, while the runner already owns the timeout contract; this patch connects those existing surfaces without changing defaults.

## Validation

- `uv run --no-project --python 3.13 --with pytest pytest -q tests/test_skillsbench_turn_launcher.py` (23 passed)
- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`
- `python3 -m py_compile tests/test_skillsbench_turn_launcher.py`
- `uvx ruff check --select E,F --output-format concise tests/test_skillsbench_turn_launcher.py`
- `loopx check --scan-path scripts/skillsbench-launch-goal-xhigh.sh --scan-path tests/test_skillsbench_turn_launcher.py`
- `loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard --timeout-seconds 300`

The standard canary executed four catalog checks with no failures. Its only hold is the generic benchmark-sensitive maintainer gate; standing owner authorization permits benchmark code and PR self-merge for this lane.

## Scope

This does not change benchmark scoring, task semantics, runner defaults, permission boundaries, upload/submission behavior, or launch any benchmark job.
