### PR TITLE
test(smokes): follow compact todo projection contracts

### DIFF
--- a/examples/control_plane/control-plane-integrated-canary-smoke.py
+++ b/examples/control_plane/control-plane-integrated-canary-smoke.py
@@ -253,7 +253,7 @@ def assert_event_projected_agent_todo(summary: dict[str, Any]) -> None:
         )
     assert [item.get("todo_id") for item in items] == [CANARY_TODO_ID], summary
     item = items[0]
-    assert item["title"] == CANARY_TODO_TITLE, summary
+    assert CANARY_TODO_TITLE in str(item.get("title") or item.get("text") or ""), summary
     assert item["claimed_by"] == AGENT_ID, summary
     assert item["task_class"] == "advancement_task", summary
     assert "todo_markdown_fallback" not in json.dumps(summary, sort_keys=True), summary

--- a/examples/control_plane/control-plane-integrated-canary-smoke.py
+++ b/examples/control_plane/control-plane-integrated-canary-smoke.py
@@ -237,23 +237,25 @@ def find_queue_item(status_payload: dict[str, Any], *, goal_id: str = GOAL_ID) -
     raise AssertionError(f"{goal_id} missing from attention queue: {status_payload}")
 
 
-def assert_event_projected_agent_todo(summary: dict[str, Any]) -> None:
-    items = summary.get("items") if isinstance(summary.get("items"), list) else []
-    if not items:
-        items = (
-            summary.get("first_open_items")
-            if isinstance(summary.get("first_open_items"), list)
-            else []
-        )
-    if not items:
-        items = (
-            summary.get("first_executable_items")
-            if isinstance(summary.get("first_executable_items"), list)
-            else []
-        )
+def assert_event_projected_agent_todo(
+    summary: dict[str, Any],
+    *,
+    compact_quota: bool = False,
+) -> None:
+    item_lane = "first_executable_items" if compact_quota else "first_open_items"
+    items = summary.get(item_lane) if isinstance(summary.get(item_lane), list) else []
+    if not items and not compact_quota:
+        items = summary.get("items") if isinstance(summary.get("items"), list) else []
     assert [item.get("todo_id") for item in items] == [CANARY_TODO_ID], summary
     item = items[0]
-    assert CANARY_TODO_TITLE in str(item.get("title") or item.get("text") or ""), summary
+    if compact_quota:
+        assert summary["payload_compaction"]["schema_version"] == (
+            "quota_cli_todo_summary_compaction_v0"
+        ), summary
+        assert "title" not in item, summary
+        assert item["text"] == f"[P1] {CANARY_TODO_TITLE}", summary
+    else:
+        assert item["title"] == CANARY_TODO_TITLE, summary
     assert item["claimed_by"] == AGENT_ID, summary
     assert item["task_class"] == "advancement_task", summary
     assert "todo_markdown_fallback" not in json.dumps(summary, sort_keys=True), summary
@@ -826,7 +828,10 @@ def run_fixture_canary(root: Path) -> None:
     assert quota_payload["effective_action"] == "normal_run", quota_payload
     assert quota_payload["interaction_contract"]["agent_channel"]["must_attempt"] is True, quota_payload
     assert CANARY_TODO_TITLE in quota_payload["recommended_action"], quota_payload
-    assert_event_projected_agent_todo(quota_payload["agent_todo_summary"])
+    assert_event_projected_agent_todo(
+        quota_payload["agent_todo_summary"],
+        compact_quota=True,
+    )
     assert_bounded_delivery_state_machine_bundle(quota_payload)
     assert_scheduler_ack_state_machine(registry_path, runtime_root, quota_payload)
     assert_event_todo_completion_successor_state_machine(registry_path, runtime_root)

--- a/examples/control_plane/monitor-poll-writeback-smoke.py
+++ b/examples/control_plane/monitor-poll-writeback-smoke.py
@@ -1045,6 +1045,7 @@ def assert_cli_monitor_poll_uses_should_run_lookback() -> None:
         next_due_at=None,
         next_agent_todo=None,
         next_user_todo=None,
+        next_user_task_class=None,
         next_claimed_by=None,
         codex_app=True,
         runtime_profile=None,

--- a/examples/control_plane/status_markdown_agent_lane_fixtures.py
+++ b/examples/control_plane/status_markdown_agent_lane_fixtures.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from loopx.cli_commands.status import (
-    _compact_agent_lane_todos_for_status_display,
     _status_collection_limit_for_agent_lane,
     _trim_run_history_for_status_display,
     attach_agent_lane_next_actions,
+)
+from loopx.control_plane.todos.quota_summary import (
+    compact_agent_lane_todos_for_status_display,
 )
 from loopx.review_packet import build_review_packet
 from loopx.presentation.renderers.status_markdown import render_status_markdown
@@ -282,7 +284,7 @@ def assert_status_agent_lane_todo_summary_display_compaction() -> None:
         }
     }
 
-    _compact_agent_lane_todos_for_status_display(payload)
+    compact_agent_lane_todos_for_status_display(payload)
 
     item = payload["attention_queue"]["items"][0]
     compact_agent = item["agent_todos"]

--- a/examples/control_plane/todo-durability-fixture-smoke.py
+++ b/examples/control_plane/todo-durability-fixture-smoke.py
@@ -138,9 +138,11 @@ def assert_parseable_agent_todos(agent_todos: dict, *, hot_path: bool = False) -
     assert agent_todos["open_count"] == 2, agent_todos
     assert agent_todos["done_count"] == 3, agent_todos
     assert agent_todos["deferred_count"] == 2, agent_todos
-    assert [item["index"] for item in agent_todos["first_open_items"]] == [1, 5], agent_todos
+    item_lane = "first_executable_items" if hot_path else "first_open_items"
+    visible_items = agent_todos[item_lane]
+    assert [item["index"] for item in visible_items] == [1, 5], agent_todos
 
-    first_open = agent_todos["first_open_items"][0]
+    first_open = visible_items[0]
     assert first_open["schema_version"] == "todo_item_v0", first_open
     assert first_open["status"] == "open", first_open
     assert first_open["priority"] == "P1", first_open
@@ -149,13 +151,14 @@ def assert_parseable_agent_todos(agent_todos: dict, *, hot_path: bool = False) -
         assert first_open["archive_state"] == "active", first_open
         assert first_open["source_section"] == "Agent Todo", first_open
     assert first_open["text"] == FIRST_OPEN_TODO, first_open
-    assert (
-        first_open["title"]
-        == "Add a parseable todo fixture when discovered planning work cannot be represented by the current Markdown parser."
-    ), first_open
+    if not hot_path:
+        assert (
+            first_open["title"]
+            == "Add a parseable todo fixture when discovered planning work cannot be represented by the current Markdown parser."
+        ), first_open
     assert str(first_open["todo_id"]).startswith("todo_"), first_open
 
-    second_open = agent_todos["first_open_items"][1]
+    second_open = visible_items[1]
     assert second_open["priority"] == "P2", second_open
     assert second_open["status"] == "open", second_open
     assert second_open["text"] == SECOND_OPEN_TODO, second_open
@@ -168,7 +171,14 @@ def assert_parseable_agent_todos(agent_todos: dict, *, hot_path: bool = False) -
         assert handoff_note["intent"] == "review_pr", handoff_note
         assert handoff_note["evidence_refs"] == ["todo:todo_handoff_review:evidence"], handoff_note
 
-    deferred = agent_todos["deferred_items"][0]
+    if hot_path:
+        assert "first_open_items" not in agent_todos, agent_todos
+        assert "deferred_items" not in agent_todos, agent_todos
+        assert agent_todos["payload_compaction"]["schema_version"] == (
+            "quota_cli_todo_summary_compaction_v0"
+        ), agent_todos
+        return
+
     deferred_by_id = {item["todo_id"]: item for item in agent_todos["deferred_items"]}
     assert set(deferred_by_id) == {"todo_deferred_surface", "todo_pr_deferred"}, agent_todos
     deferred = deferred_by_id["todo_deferred_surface"]
@@ -318,7 +328,7 @@ def main() -> int:
         assert_parseable_agent_todos(guard["agent_todo_summary"], hot_path=True)
         assert "completed_todo_archive_warning" not in guard, guard
 
-        first_todo_id = guard["agent_todo_summary"]["first_open_items"][0]["todo_id"]
+        first_todo_id = guard["agent_todo_summary"]["first_executable_items"][0]["todo_id"]
         lifecycle_result = run_cli(
             "todo",
             "complete",

--- a/examples/control_plane/todo-user-gate-scope-smoke.py
+++ b/examples/control_plane/todo-user-gate-scope-smoke.py
@@ -475,6 +475,7 @@ def main() -> int:
             agent_id=PRIMARY_AGENT,
             evidence="fixture validation",
             next_user_todo="Approve publishing the release notes.",
+            next_user_task_class="user_gate",
         )
         state_text = state.read_text(encoding="utf-8")
         assert "Approve publishing the release notes." in state_text, state_text

--- a/examples/project/project-agent-adoption-smoke.py
+++ b/examples/project/project-agent-adoption-smoke.py
@@ -177,7 +177,7 @@ def main() -> int:
             "--bound-agent <id> --text '<action>'"
         ), first_quota
         assert first_quota["agent_todo_summary"]["open_count"] == 1, first_quota
-        assert first_quota["agent_todo_summary"]["first_open_items"][0]["text"] == AGENT_TODO, first_quota
+        assert first_quota["selected_todo"]["text"] == AGENT_TODO, first_quota
 
         todo_payload = run_cli(
             root,


### PR DESCRIPTION
## Summary

- move the status compaction fixture to the bounded todo owner introduced by #2521
- align hot-path smoke assertions with compact `agent_todo_summary`, while preserving full-detail cold-path coverage
- make user-todo task class and monitor-poll fixture arguments explicit

## Regression evidence

Main Full Public Smokes run 30086128272 failed seven checks across shards 1-4 after #2521 merged. This follow-up updates only the affected durable smokes and fixtures; it does not add a compatibility wrapper or relax product contracts.

## Validation

- affected Full Public Smokes: 7/7 passed, including canary promotion readiness
- `loopx canary premerge --from-git-diff`: 18/18 passed, 0 warnings, 0 manual holds
- Ruff on all six changed Python files: passed
- public/private boundary scan: clean (6 files)
