### PR TITLE
refactor(cli): default quota should-run to json

### DIFF
--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -150,7 +150,15 @@ def output_format(args: argparse.Namespace, *local_dests: str) -> str:
         value = getattr(args, dest, None)
         if value:
             return str(value)
-    return str(args.format)
+    return str(getattr(args, "format", None) or "markdown")
+
+
+def resolve_global_output_format(args: argparse.Namespace) -> str:
+    if getattr(args, "format", None):
+        return str(args.format)
+    if args.command == "quota" and getattr(args, "quota_command", None) == "should-run":
+        return "json"
+    return "markdown"
 
 
 def user_supplied_registry(argv: list[str] | None) -> bool:
@@ -163,7 +171,7 @@ def build_parser() -> LoopXArgumentParser:
     parser.add_argument("--version", action="version", version=f"loopx {__version__}")
     parser.add_argument("--registry", default=str(default_registry_path()), help="Path to a project-local registry.")
     parser.add_argument("--runtime-root", help="Override registry common_runtime_root.")
-    parser.add_argument("--format", choices=["markdown", "json"], default="markdown")
+    parser.add_argument("--format", choices=["markdown", "json"])
     sub = parser.add_subparsers(dest="command", required=True)
 
     register_version_command(sub, add_subcommand_format)
@@ -248,6 +256,7 @@ def main(argv: list[str] | None = None) -> int:
 
     parser = build_parser()
     args = parser.parse_args(raw_argv)
+    args.format = resolve_global_output_format(args)
     registry_path = Path(args.registry).expanduser()
     if (
         args.command

--- a/tests/control_plane/test_cli_output_budget.py
+++ b/tests/control_plane/test_cli_output_budget.py
@@ -665,6 +665,42 @@ def test_real_cli_output_stays_inside_the_characterized_baseline(
             assert formats["markdown"]["json_parseable"] is False
 
 
+def test_quota_should_run_no_format_uses_machine_contract_json(
+    tmp_path: Path,
+) -> None:
+    with _stable_budget_fixture_root(tmp_path / "quota-default-json") as stable_root:
+        project, runtime, registry_path, state_file = _write_fixture(
+            stable_root,
+            SCENARIOS[0],
+        )
+        explicit_json_command = _surface_commands(
+            project=project,
+            runtime=runtime,
+            registry_path=registry_path,
+            state_file=state_file,
+            output_format="json",
+        )["quota_should_run"]
+        no_format_command = list(explicit_json_command)
+        format_index = no_format_command.index("--format")
+        del no_format_command[format_index : format_index + 2]
+        explicit_markdown_command = _surface_commands(
+            project=project,
+            runtime=runtime,
+            registry_path=registry_path,
+            state_file=state_file,
+            output_format="markdown",
+        )["quota_should_run"]
+
+        no_format_exit_code, no_format_text = _invoke_cli(no_format_command)
+        markdown_exit_code, markdown_text = _invoke_cli(explicit_markdown_command)
+
+    assert no_format_exit_code == 0, no_format_text
+    assert json.loads(no_format_text)["goal_id"] == GOAL_ID
+    assert markdown_exit_code == 0, markdown_text
+    assert markdown_text.startswith("# LoopX Quota Should Run")
+    assert not markdown_text.lstrip().startswith("{")
+
+
 def test_quota_cli_keeps_full_agent_todo_diagnostics_on_explicit_cold_path(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from loopx.cli import main
+from loopx.cli import build_parser, main, output_format, resolve_global_output_format
 
 
 @pytest.mark.parametrize(
@@ -24,3 +24,40 @@ def test_unsupported_project_option_is_not_misparsed_as_projection_cache_ttl(
     assert "unrecognized arguments: --project ." in stderr
     assert "projection-cache-ttl-seconds" not in stderr
     assert "invalid int value" not in stderr
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (["quota", "should-run"], "json"),
+        (["quota", "status"], "markdown"),
+        (["status"], "markdown"),
+        (["diagnose"], "markdown"),
+        (["review-packet", "--goal-id", "example-goal"], "markdown"),
+    ],
+)
+def test_only_quota_should_run_defaults_to_json(
+    argv: list[str],
+    expected: str,
+) -> None:
+    args = build_parser().parse_args(argv)
+
+    assert resolve_global_output_format(args) == expected
+
+
+@pytest.mark.parametrize("explicit_format", ["markdown", "json"])
+def test_explicit_global_format_overrides_quota_should_run_default(
+    explicit_format: str,
+) -> None:
+    args = build_parser().parse_args(
+        ["--format", explicit_format, "quota", "should-run"]
+    )
+
+    assert resolve_global_output_format(args) == explicit_format
+
+
+def test_subcommand_format_keeps_precedence_over_resolved_global_default() -> None:
+    args = build_parser().parse_args(["status", "--format", "json"])
+    args.format = resolve_global_output_format(args)
+
+    assert output_format(args) == "json"


### PR DESCRIPTION
## Summary

- default only `loopx quota should-run` to JSON when no format is specified
- preserve explicit global `--format` and subcommand-local format precedence
- keep other no-format CLI commands on Markdown without TTY-dependent behavior

## Validation

- `pytest -q tests/test_cli_argument_diagnostics.py tests/control_plane/test_cli_output_budget.py` (22 passed)
- `ruff check` on changed Python and tests
- `loopx canary premerge --from-git-diff` (standard tier, 4/4 selected canaries passed)
- public/private boundary scan on changed paths (clean)
