### PR TITLE
fix(skillsbench): resume interrupted single turns

### DIFF
--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -99,6 +99,7 @@ SAFE_LOOPX_TODO_ID_RE = re.compile(r"^todo_[A-Za-z0-9_-]{6,80}$")
 SAFE_LOOPX_GOAL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,120}$")
 CODEX_EXEC_TRANSPORT_RETRY_LIMIT = 1
 CODEX_EXEC_SESSION_ROLLOVER_LIMIT = 1
+CODEX_EXEC_SAME_SESSION_CONTINUATION_LIMIT = 1
 
 
 def _loopx_turn_local_session_root(
@@ -466,6 +467,34 @@ def _codex_exec_transport_retry_allowed(
     )
 
 
+def _codex_exec_same_session_continuation_allowed(
+    *,
+    category: str,
+    bridge_summary_path: Path | None,
+    continuation_count: int,
+    thread_present: bool,
+    final_message_present: bool,
+    turn_deadline: float | None,
+) -> bool:
+    if (
+        continuation_count >= CODEX_EXEC_SAME_SESSION_CONTINUATION_LIMIT
+        or category not in RECOVERABLE_CODEX_TURN_FAILURE_CATEGORIES
+        or not thread_present
+        or final_message_present
+        or bridge_summary_path is None
+        or turn_deadline is not None
+        and time.monotonic() >= turn_deadline
+        or _bridge_summary_has_inflight_operation(bridge_summary_path)
+    ):
+        return False
+    receipt = _bridge_summary_task_progress_receipt(bridge_summary_path)
+    return bool(
+        receipt.get("task_facing_operation_count", 0) > 0
+        and receipt.get("task_facing_success_count", 0) > 0
+        and receipt.get("raw_material_recorded") is False
+    )
+
+
 def _codex_exec_session_rollover_allowed(
     *,
     category: str,
@@ -484,6 +513,21 @@ def _codex_exec_session_rollover_allowed(
             final_message_present=final_message_present,
             turn_deadline=turn_deadline,
         )
+    )
+
+
+def _codex_exec_same_session_continuation_prompt() -> str:
+    return (
+        "Continue the same bounded task in this thread after the recoverable "
+        "host interruption.\n"
+        "- Preserve and inspect the progress already made in this thread and "
+        "the current workspace.\n"
+        "- Do not replay completed operations or restart the task from its "
+        "original prompt.\n"
+        "- Complete the next necessary task-facing work, validate it from "
+        "visible task context, then finish this Turn.\n"
+        "- Do not use or request official verifier, reward, pass/fail, hidden-test, "
+        "or gold-answer feedback."
     )
 
 
@@ -728,6 +772,7 @@ class SkillsBenchLocalAcpRelay:
         _turn_deadline: float | None = None,
         _transport_retry_count: int = 0,
         _session_rollover_index: int = 0,
+        _same_session_continuation_count: int = 0,
     ) -> str:
         if self._config.dry_run_response is not None:
             return self._config.dry_run_response
@@ -787,7 +832,6 @@ class SkillsBenchLocalAcpRelay:
             resumable_loopx_turn = bool(
                 _bypass_loopx_turn
                 and self._config.loopx_turn_agent_cli
-                and self._config.loopx_turn_max_turns > 1
             )
             resume_session_id = (
                 str(session.get("_loopx_turn_codex_thread_id") or "")
@@ -1054,14 +1098,50 @@ class SkillsBenchLocalAcpRelay:
                             and now - last_bridge_activity_at >= bridge_idle_timeout_sec
                         ):
                             self._terminate_codex_process(proc)
+                            stdout_text = (
+                                stdout_path.read_text(
+                                    encoding="utf-8", errors="replace"
+                                )
+                                if stdout_path.exists()
+                                else ""
+                            )
+                            stderr_text = (
+                                stderr_path.read_text(
+                                    encoding="utf-8", errors="replace"
+                                )
+                                if stderr_path.exists()
+                                else ""
+                            )
+                            if resumable_loopx_turn and not resume_session_id:
+                                observed_session_id = (
+                                    codex_cli_session_id_from_jsonl(stdout_text)
+                                )
+                                if observed_session_id:
+                                    session["_loopx_turn_codex_thread_id"] = (
+                                        observed_session_id
+                                    )
+                            continuation_scheduled = (
+                                _codex_exec_same_session_continuation_allowed(
+                                    category="codex_exec_bridge_idle_timeout",
+                                    bridge_summary_path=bridge_summary_path,
+                                    continuation_count=(
+                                        _same_session_continuation_count
+                                    ),
+                                    thread_present=bool(
+                                        session.get("_loopx_turn_codex_thread_id")
+                                    ),
+                                    final_message_present=output_path.exists(),
+                                    turn_deadline=_turn_deadline,
+                                )
+                            )
                             self._publish_remote_bridge_agent_operations_trace(
                                 bridge_summary_path=bridge_summary_path,
                             )
                             self._publish_codex_exec_failure_trace(
                                 stage="bridge_idle_timeout",
                                 returncode=124,
-                                stdout_text="",
-                                stderr_text="codex_exec_bridge_idle_timeout\n",
+                                stdout_text=stdout_text,
+                                stderr_text=stderr_text,
                                 final_message_present=output_path.exists(),
                                 final_message_bytes=(
                                     output_path.stat().st_size
@@ -1069,7 +1149,65 @@ class SkillsBenchLocalAcpRelay:
                                     else 0
                                 ),
                                 failure_category="codex_exec_bridge_idle_timeout",
+                                same_session_continuation_index=(
+                                    _same_session_continuation_count
+                                ),
+                                same_session_continuation_scheduled=(
+                                    continuation_scheduled
+                                ),
                             )
+                            if continuation_scheduled:
+                                self._terminate_bridge_server_process(
+                                    bridge_server_proc
+                                )
+                                bridge_server_proc = None
+                                next_continuation_index = (
+                                    _same_session_continuation_count + 1
+                                )
+                                try:
+                                    response = self._run_codex(
+                                        _codex_exec_same_session_continuation_prompt(),
+                                        session=session,
+                                        session_id=session_id,
+                                        stdout=stdout,
+                                        _bypass_loopx_turn=_bypass_loopx_turn,
+                                        _turn_deadline=_turn_deadline,
+                                        _transport_retry_count=0,
+                                        _session_rollover_index=(
+                                            _session_rollover_index
+                                        ),
+                                        _same_session_continuation_count=(
+                                            next_continuation_index
+                                        ),
+                                    )
+                                except (RuntimeError, TimeoutError):
+                                    self._publish_codex_exec_same_session_continuation_trace(
+                                        stage="failed",
+                                        continuation_index=(
+                                            next_continuation_index
+                                        ),
+                                        thread_present=bool(
+                                            session.get(
+                                                "_loopx_turn_codex_thread_id"
+                                            )
+                                        ),
+                                    )
+                                    raise
+                                continuation_succeeded = not response.startswith(
+                                    RECOVERABLE_CODEX_TURN_FAILURE_PREFIX
+                                )
+                                self._publish_codex_exec_same_session_continuation_trace(
+                                    stage=(
+                                        "completed"
+                                        if continuation_succeeded
+                                        else "failed"
+                                    ),
+                                    continuation_index=next_continuation_index,
+                                    thread_present=bool(
+                                        session.get("_loopx_turn_codex_thread_id")
+                                    ),
+                                )
+                                return response
                             return _recoverable_codex_turn_failure_message(
                                 "codex_exec_bridge_idle_timeout"
                             )
@@ -1200,6 +1338,9 @@ class SkillsBenchLocalAcpRelay:
                         _turn_deadline=_turn_deadline,
                         _transport_retry_count=_transport_retry_count + 1,
                         _session_rollover_index=_session_rollover_index,
+                        _same_session_continuation_count=(
+                            _same_session_continuation_count
+                        ),
                     )
                 if session_rollover_scheduled:
                     original_prompt = str(
@@ -1228,6 +1369,9 @@ class SkillsBenchLocalAcpRelay:
                                 CODEX_EXEC_TRANSPORT_RETRY_LIMIT
                             ),
                             _session_rollover_index=next_rollover_index,
+                            _same_session_continuation_count=(
+                                _same_session_continuation_count
+                            ),
                         )
                     except (RuntimeError, TimeoutError):
                         self._publish_codex_exec_session_rollover_trace(
@@ -3255,6 +3399,8 @@ raise SystemExit(proc.returncode)
         retry_scheduled: bool = False,
         session_rollover_index: int = 0,
         session_rollover_scheduled: bool = False,
+        same_session_continuation_index: int = 0,
+        same_session_continuation_scheduled: bool = False,
     ) -> None:
         if not self._config.worker_public_trace_dir:
             return
@@ -3291,6 +3437,12 @@ raise SystemExit(proc.returncode)
                     0, int(session_rollover_index or 0)
                 ),
                 "session_rollover_scheduled": bool(session_rollover_scheduled),
+                "same_session_continuation_index": max(
+                    0, int(same_session_continuation_index or 0)
+                ),
+                "same_session_continuation_scheduled": bool(
+                    same_session_continuation_scheduled
+                ),
                 "returncode": (
                     returncode
                     if isinstance(returncode, int)
@@ -3307,6 +3459,53 @@ raise SystemExit(proc.returncode)
                 "raw_trajectory_recorded": False,
                 "credential_values_recorded": False,
                 "host_paths_recorded": False,
+            },
+            "boundary": {
+                "raw_command_recorded": False,
+                "raw_stdout_recorded": False,
+                "raw_stderr_recorded": False,
+                "raw_task_text_recorded": False,
+                "raw_logs_recorded": False,
+                "raw_trajectory_recorded": False,
+                "credential_values_recorded": False,
+                "host_paths_recorded": False,
+                "remote_paths_recorded": False,
+                "upload_performed": False,
+                "submit_performed": False,
+            },
+        }
+        self._write_worker_public_trace(trace)
+
+    def _publish_codex_exec_same_session_continuation_trace(
+        self,
+        *,
+        stage: str,
+        continuation_index: int,
+        thread_present: bool,
+    ) -> None:
+        if not self._config.worker_public_trace_dir:
+            return
+        safe_stage = str(stage or "failed").strip().lower()
+        if safe_stage not in {"completed", "failed"}:
+            safe_stage = "failed"
+        trace = {
+            "schema_version": "skillsbench_host_local_acp_relay_public_trace_v0",
+            "ok": safe_stage == "completed",
+            "route": self._config.route,
+            "trace_kind": "codex_exec_same_session_continuation",
+            "benchmark_id": self._config.dataset,
+            "task_id": self._config.task_id,
+            "codex_exec_same_session_continuation": {
+                "schema_version": (
+                    "skillsbench_codex_exec_same_session_continuation_v0"
+                ),
+                "stage": safe_stage,
+                "continuation_index": max(1, int(continuation_index or 1)),
+                "thread_present": bool(thread_present),
+                "shared_sequence_deadline_preserved": True,
+                "original_prompt_replayed": False,
+                "thread_ids_recorded": False,
+                "raw_task_text_recorded": False,
             },
             "boundary": {
                 "raw_command_recorded": False,

--- a/tests/test_skillsbench_turn_runtime.py
+++ b/tests/test_skillsbench_turn_runtime.py
@@ -1004,6 +1004,232 @@ print(json.dumps({"type": "thread.started", "thread_id": "thread-fixture-001"}))
     assert not private_cwd_root.exists()
 
 
+def test_codex_exec_same_session_continuation_requires_safe_progress(
+    tmp_path: Path,
+) -> None:
+    summary_path = tmp_path / "bridge-summary.jsonl"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "record_phase": "complete",
+                "operation": "run_command",
+                "task_facing_operation": True,
+                "success": True,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert acp_relay._codex_exec_same_session_continuation_allowed(
+        category="codex_exec_bridge_idle_timeout",
+        bridge_summary_path=summary_path,
+        continuation_count=0,
+        thread_present=True,
+        final_message_present=False,
+        turn_deadline=time.monotonic() + 30,
+    )
+    assert not acp_relay._codex_exec_same_session_continuation_allowed(
+        category="codex_exec_bridge_idle_timeout",
+        bridge_summary_path=summary_path,
+        continuation_count=acp_relay.CODEX_EXEC_SAME_SESSION_CONTINUATION_LIMIT,
+        thread_present=True,
+        final_message_present=False,
+        turn_deadline=time.monotonic() + 30,
+    )
+    assert not acp_relay._codex_exec_same_session_continuation_allowed(
+        category="codex_exec_bridge_idle_timeout",
+        bridge_summary_path=summary_path,
+        continuation_count=0,
+        thread_present=False,
+        final_message_present=False,
+        turn_deadline=time.monotonic() + 30,
+    )
+    assert not acp_relay._codex_exec_same_session_continuation_allowed(
+        category="codex_exec_bridge_idle_timeout",
+        bridge_summary_path=summary_path,
+        continuation_count=0,
+        thread_present=True,
+        final_message_present=True,
+        turn_deadline=time.monotonic() + 30,
+    )
+    assert not acp_relay._codex_exec_same_session_continuation_allowed(
+        category="codex_exec_bridge_idle_timeout",
+        bridge_summary_path=summary_path,
+        continuation_count=0,
+        thread_present=True,
+        final_message_present=False,
+        turn_deadline=time.monotonic() - 1,
+    )
+
+    summary_path.write_text(
+        json.dumps(
+            {
+                "record_phase": "start",
+                "operation": "run_command",
+                "task_facing_operation": True,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    assert not acp_relay._codex_exec_same_session_continuation_allowed(
+        category="codex_exec_bridge_idle_timeout",
+        bridge_summary_path=summary_path,
+        continuation_count=0,
+        thread_present=True,
+        final_message_present=False,
+        turn_deadline=time.monotonic() + 30,
+    )
+
+
+def test_skillsbench_single_turn_codex_exec_resumes_progressful_idle_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    invocation_log = tmp_path / "invocations.jsonl"
+    fake_codex = tmp_path / "fake-codex"
+    fake_codex.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import sys
+import time
+
+log_path = pathlib.Path(os.environ["FAKE_CODEX_INVOCATION_LOG"])
+attempt = len(log_path.read_text().splitlines()) + 1 if log_path.exists() else 1
+prompt = sys.stdin.read()
+with log_path.open("a", encoding="utf-8") as handle:
+    handle.write(json.dumps({"argv": sys.argv[1:], "prompt": prompt}) + "\\n")
+if attempt == 1:
+    print(json.dumps({"type": "thread.started", "thread_id": "thread-single-001"}), flush=True)
+    time.sleep(10)
+output_index = sys.argv.index("--output-last-message") + 1
+pathlib.Path(sys.argv[output_index]).write_text("bounded turn complete", encoding="utf-8")
+""",
+        encoding="utf-8",
+    )
+    fake_codex.chmod(0o755)
+    monkeypatch.setenv("FAKE_CODEX_INVOCATION_LOG", str(invocation_log))
+    trace_dir = tmp_path / "public-traces"
+    trace_dir.mkdir()
+    relay = SkillsBenchLocalAcpRelay(
+        CodexExecConfig(
+            codex_bin=str(fake_codex),
+            loopx_turn_agent_cli=True,
+            loopx_turn_max_turns=1,
+            remote_command_file_bridge_command="synthetic-bridge",
+            worker_public_trace_dir=str(trace_dir),
+            bridge_idle_timeout_sec=0.5,
+            timeout_sec=30,
+        )
+    )
+    monkeypatch.setattr(
+        relay,
+        "_consume_remote_bridge_for_solver",
+        lambda: {"ready": True},
+    )
+    monkeypatch.setattr(
+        relay,
+        "_publish_remote_bridge_consumption_trace",
+        lambda _probe: None,
+    )
+    monkeypatch.setattr(
+        relay,
+        "_start_json_file_bridge_server",
+        lambda **_kwargs: ("synthetic-agent-bridge", None),
+    )
+
+    def write_progress_summary(**kwargs: Any) -> Path:
+        kwargs["summary_path"].write_text(
+            json.dumps(
+                {
+                    "record_phase": "complete",
+                    "operation": "run_command",
+                    "task_facing_operation": True,
+                    "success": True,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return kwargs["tmp_path"] / "synthetic-wrapper"
+
+    monkeypatch.setattr(
+        relay,
+        "_write_instrumented_bridge_wrapper",
+        write_progress_summary,
+    )
+    monkeypatch.setattr(
+        relay,
+        "_prompt_with_remote_bridge_packet",
+        lambda prompt, **_kwargs: prompt,
+    )
+    monkeypatch.setattr(
+        relay,
+        "_publish_remote_bridge_agent_operations_trace",
+        lambda **_kwargs: None,
+    )
+    session: dict[str, Any] = {"cwd": str(tmp_path), "model": None}
+    private_original_prompt = "private original task prompt fixture"
+
+    response = relay._run_codex(
+        private_original_prompt,
+        session=session,
+        session_id="fixture-session",
+        stdout=SimpleNamespace(write=lambda _value: None, flush=lambda: None),
+        _bypass_loopx_turn=True,
+        _turn_deadline=time.monotonic() + 20,
+    )
+
+    invocations = [json.loads(line) for line in invocation_log.read_text().splitlines()]
+    assert response == "bounded turn complete"
+    assert len(invocations) == 2
+    assert invocations[0]["argv"][:2] == ["exec", "--skip-git-repo-check"]
+    assert "--ephemeral" not in invocations[0]["argv"]
+    assert invocations[1]["argv"][:3] == [
+        "exec",
+        "resume",
+        "--skip-git-repo-check",
+    ]
+    assert "thread-single-001" in invocations[1]["argv"]
+    assert private_original_prompt in invocations[0]["prompt"]
+    assert private_original_prompt not in invocations[1]["prompt"]
+    assert "Continue the same bounded task in this thread" in invocations[1]["prompt"]
+
+    traces = [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in trace_dir.glob("*.compact.json")
+    ]
+    failure = next(
+        trace
+        for trace in traces
+        if trace.get("trace_kind") == "codex_exec_process_failure"
+    )
+    assert (
+        failure["codex_exec_process"]["same_session_continuation_scheduled"] is True
+    )
+    continuation = next(
+        trace
+        for trace in traces
+        if trace.get("trace_kind") == "codex_exec_same_session_continuation"
+    )
+    assert continuation["codex_exec_same_session_continuation"] == {
+        "schema_version": "skillsbench_codex_exec_same_session_continuation_v0",
+        "stage": "completed",
+        "continuation_index": 1,
+        "thread_present": True,
+        "shared_sequence_deadline_preserved": True,
+        "original_prompt_replayed": False,
+        "thread_ids_recorded": False,
+        "raw_task_text_recorded": False,
+    }
+    public_trace_text = json.dumps(traces, sort_keys=True)
+    assert private_original_prompt not in public_trace_text
+    assert "thread-single-001" not in public_trace_text
+
+
 def test_codex_exec_transport_retry_requires_no_task_facing_operation(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- make SkillsBench single-Turn Codex execution session-backed
- continue the same Codex thread once after a progressful bridge-idle interruption
- preserve the shared Turn deadline and avoid replaying the original task prompt
- publish only compact public-safe continuation receipts

## Validation

- pytest: 58 passed across Turn runtime and launcher tests
- ruff: passed for both changed Python files
- py_compile: passed for both changed Python files
- LoopX contract check: 9 checks, zero errors or warnings, public boundary clean
- premerge: all 4 direct checks and 6 selected canaries passed

## Premerge Review

Changed surfaces: benchmark-sensitive Python runtime and focused validation. The generic benchmark-sensitive manual hold was reviewed against the active owner authorization for validated benchmark-code self-merge after self-review, premerge, and public/private boundary checks.

No failed or skipped executable check remains. This PR does not launch a benchmark job and does not change scoring, task semantics, submission, permissions, credentials, raw-evidence handling, or leaderboard behavior.
