### PR TITLE
fix(onboarding): qualify custom agent skill delivery

### DIFF
--- a/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
+++ b/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
@@ -29,13 +29,18 @@ from loopx.host_loop_activation import (  # noqa: E402
 )
 
 
-def run_cli(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+def run_cli(
+    *args: str,
+    check: bool = True,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, "-m", "loopx.cli", "--format", "json", *args],
         cwd=REPO_ROOT,
         check=check,
         text=True,
         capture_output=True,
+        env=env,
     )
 
 
@@ -300,6 +305,71 @@ def main() -> int:
         assert opencode_onboarding["host_loop_activation"]["host_mutation"]["host_tool"] == (
             "loopx_goal_activate"
         )
+
+        other_agent_onboarding = build_agent_onboarding_packet(
+            project=project,
+            agent_type="other-agent",
+            goal_id="multi-agent-goal",
+            agent_id="codex-product-capability",
+            cli_bin=cli_bin,
+        )
+        other_commands = other_agent_onboarding["commands"]
+        assert "install_command_facade" not in other_commands
+        assert "doctor --agent-type other-agent" in other_commands["doctor_or_install"]
+        delivery = other_agent_onboarding["skill_delivery"]
+        assert delivery["mode"] == "host_managed", delivery
+        assert delivery["owner"] == "custom_agent_host", delivery
+        assert delivery["status"] == "pending_host_readback", delivery
+        assert delivery["codex_skills_root_required"] is False, delivery
+        assert delivery["required_for_cli_health"] is False, delivery
+        assert delivery["required_for_loopx_workflow"] is True, delivery
+        assert set(delivery["required_skill_ids"]) == {
+            "loopx-project",
+            "loopx-pr-review",
+            "loopx-doc-registry",
+            "loopx-self-repair",
+        }, delivery
+        assert delivery["delivery_options"] == [
+            "host_skill_manifest",
+            "prompt_injection",
+        ], delivery
+        assert delivery["source_directories"] == [
+            f"skills/{skill_id}" for skill_id in delivery["required_skill_ids"]
+        ], delivery
+        assert delivery["host_readback_required"] is True, delivery
+        assert set(delivery["readback_fields"]) == {
+            "integration_mode",
+            "loaded_skill_ids",
+            "source_revision",
+        }, delivery
+        assert any(
+            "loaded-skill readback" in item
+            for item in other_agent_onboarding["slash_command_contract"][
+                "setup_complete_requires"
+            ]
+        ), other_agent_onboarding
+
+        doctor_home = root / "doctor-home"
+        doctor_home.mkdir()
+        doctor_env = {
+            **os.environ,
+            "HOME": str(doctor_home),
+            "PATH": f"{REPO_ROOT / 'scripts'}{os.pathsep}{os.environ.get('PATH', '')}",
+        }
+        other_agent_doctor = json.loads(
+            run_cli(
+                "doctor",
+                "--agent-type",
+                "other-agent",
+                env=doctor_env,
+            ).stdout
+        )
+        assert other_agent_doctor["install_freshness"]["requires_upgrade"] is False
+        assert other_agent_doctor["skill_delivery"]["mode"] == "host_managed"
+        for check in other_agent_doctor["checks"]:
+            if str(check.get("id", "")).startswith("installed_"):
+                assert check["ok"] is True, check
+                assert check["applicable"] is False, check
 
     return 0
 

--- a/loopx/agent_onboarding.py
+++ b/loopx/agent_onboarding.py
@@ -20,6 +20,13 @@ from .project_prompt import (
 
 
 SCHEMA_VERSION = "loopx_agent_onboarding_v0"
+HOST_SKILL_DELIVERY_SCHEMA_VERSION = "loopx_host_skill_delivery_v0"
+REQUIRED_HOST_SKILL_IDS = [
+    "loopx-project",
+    "loopx-pr-review",
+    "loopx-doc-registry",
+    "loopx-self-repair",
+]
 
 
 def _surface_install_command(agent_type: str, cli_bin: str) -> str | None:
@@ -33,6 +40,52 @@ def _surface_install_command(agent_type: str, cli_bin: str) -> str | None:
             "--with-goal-bridge"
         )
     return None
+
+
+def _skill_delivery_contract(agent_type: str) -> dict[str, Any]:
+    if agent_type != "other-agent":
+        return {
+            "schema_version": HOST_SKILL_DELIVERY_SCHEMA_VERSION,
+            "mode": "surface_managed",
+            "owner": "loopx_surface_installer",
+            "codex_skills_root_required": agent_type.startswith("codex-"),
+            "host_readback_required": False,
+        }
+    return {
+        "schema_version": HOST_SKILL_DELIVERY_SCHEMA_VERSION,
+        "mode": "host_managed",
+        "owner": "custom_agent_host",
+        "status": "pending_host_readback",
+        "codex_skills_root_required": False,
+        "required_for_cli_health": False,
+        "required_for_loopx_workflow": True,
+        "required_skill_ids": REQUIRED_HOST_SKILL_IDS,
+        "delivery_options": [
+            "host_skill_manifest",
+            "prompt_injection",
+        ],
+        "source_repository": "https://github.com/huangruiteng/loopx",
+        "source_directories": [
+            f"skills/{skill_id}" for skill_id in REQUIRED_HOST_SKILL_IDS
+        ],
+        "source_contract": (
+            "Use the same LoopX release or repository revision as the CLI when "
+            "materializing skills or injecting equivalent SKILL.md instructions "
+            "through the custom host."
+        ),
+        "host_readback_required": True,
+        "readback_fields": [
+            "integration_mode",
+            "loaded_skill_ids",
+            "source_revision",
+        ],
+        "success_criteria": [
+            "the host reports which integration mode it selected",
+            "the host reports every required LoopX skill id as loaded",
+            "the host reports the source revision or digest used for delivery",
+            "no Codex-specific skill directory is assumed",
+        ],
+    }
 
 
 def _bootstrap_pack_command(
@@ -86,7 +139,11 @@ def _start_instruction(agent_type: str) -> str:
         return "Run `/loopx <task>`; after todo writeback, call `loopx_goal_activate` with the generated heartbeat task body."
     if agent_type == "manual":
         return "Use the CLI packet and wire an external scheduler, or run quota/status/todo commands manually."
-    return "Use the host's explicit LoopX command facade such as `@loopx <task>` or `$loopx <task>`, then wire its scheduler through this packet."
+    return (
+        "Deliver the required LoopX skills through the custom host and verify its "
+        "loaded-skill readback; then use the host's explicit LoopX command facade "
+        "and wire its scheduler through this packet."
+    )
 
 
 def build_agent_onboarding_packet(
@@ -132,7 +189,10 @@ def build_agent_onboarding_packet(
         available_capabilities=normalized_available_capabilities,
     )
     commands: dict[str, Any] = {
-        "doctor_or_install": render_codex_cli_no_clone_preflight(cli_bin=cli_bin),
+        "doctor_or_install": render_codex_cli_no_clone_preflight(
+            cli_bin=cli_bin,
+            doctor_agent_type=canonical_agent_type,
+        ),
         "bootstrap_command_pack": bootstrap_pack_command,
         "quota_guard": (
             render_quota_guard_command(
@@ -184,6 +244,7 @@ def build_agent_onboarding_packet(
         "task_text": task_text,
         "project_connection": inspection,
         "host_loop_activation": host_loop_activation,
+        "skill_delivery": _skill_delivery_contract(canonical_agent_type),
         "recommended_start": (
             "Select one registered agent lane from identity_selection_gate, then rerun onboarding."
             if not activation_allowed
@@ -207,6 +268,13 @@ def build_agent_onboarding_packet(
             "setup_complete_requires": [
                 "project-local LoopX state exists or was intentionally previewed",
                 "ordered todos are written when task text was supplied",
+                *(
+                    [
+                        "custom host loaded-skill readback satisfies skill_delivery.success_criteria"
+                    ]
+                    if canonical_agent_type == "other-agent"
+                    else []
+                ),
                 "host_loop_activation success criteria are satisfied or a concrete gate is reported",
             ],
         },
@@ -230,6 +298,11 @@ def render_agent_onboarding_markdown(payload: dict[str, Any]) -> str:
     )
     identity_gate = payload.get("identity_selection_gate")
     identity_gate = identity_gate if isinstance(identity_gate, dict) else {}
+    skill_delivery = (
+        payload.get("skill_delivery")
+        if isinstance(payload.get("skill_delivery"), dict)
+        else {}
+    )
     lines = [
         "# LoopX Agent Onboarding",
         "",
@@ -247,6 +320,24 @@ def render_agent_onboarding_markdown(payload: dict[str, Any]) -> str:
     ]
     if commands.get("install_command_facade"):
         lines.extend(["", "```bash", str(commands.get("install_command_facade")), "```"])
+    if skill_delivery.get("mode") == "host_managed":
+        lines.extend(
+            [
+                "",
+                "## Host-Managed Skill Delivery",
+                "",
+                f"- owner: `{skill_delivery.get('owner')}`",
+                f"- required_for_cli_health: `{skill_delivery.get('required_for_cli_health')}`",
+                f"- required_for_loopx_workflow: `{skill_delivery.get('required_for_loopx_workflow')}`",
+                f"- delivery_options: `{','.join(skill_delivery.get('delivery_options') or [])}`",
+                f"- required_skill_ids: `{','.join(skill_delivery.get('required_skill_ids') or [])}`",
+                f"- source_repository: `{skill_delivery.get('source_repository')}`",
+                f"- source_directories: `{','.join(skill_delivery.get('source_directories') or [])}`",
+                f"- host_readback_required: `{skill_delivery.get('host_readback_required')}`",
+                f"- readback_fields: `{','.join(skill_delivery.get('readback_fields') or [])}`",
+                f"- source_contract: {skill_delivery.get('source_contract')}",
+            ]
+        )
     lines.extend(["", "```bash", str(commands.get("bootstrap_command_pack") or ""), "```"])
     if commands.get("codex_cli_bootstrap_message"):
         lines.extend(["", "```bash", str(commands.get("codex_cli_bootstrap_message")), "```"])

--- a/loopx/cli_commands/doctor.py
+++ b/loopx/cli_commands/doctor.py
@@ -4,6 +4,7 @@ import argparse
 from collections.abc import Callable
 
 from ..doctor import collect_doctor, render_doctor_markdown
+from ..host_loop_activation import SUPPORTED_AGENT_TYPES
 
 
 PrintPayload = Callable[
@@ -22,10 +23,21 @@ def register_doctor_command(subparsers: argparse._SubParsersAction) -> argparse.
         action="store_true",
         help="Run slower representative release-candidate checks.",
     )
+    parser.add_argument(
+        "--agent-type",
+        choices=SUPPORTED_AGENT_TYPES,
+        help=(
+            "Evaluate host-specific integration checks. For other-agent, custom-host "
+            "skill delivery replaces the Codex skill-directory check."
+        ),
+    )
     return parser
 
 
 def handle_doctor_command(args: argparse.Namespace, print_payload: PrintPayload) -> int:
-    payload = collect_doctor(deep=bool(args.deep))
+    payload = collect_doctor(
+        deep=bool(args.deep),
+        agent_type=args.agent_type,
+    )
     print_payload(payload, args.format, render_doctor_markdown)
     return 0 if payload.get("ok") else 1

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -61,9 +61,18 @@ class GitRevisionRelation(str, Enum):
     UNKNOWN = "unknown"
 
 
-def no_clone_upgrade_command(source_ref: Any = None) -> str:
+def no_clone_upgrade_command(
+    source_ref: Any = None,
+    *,
+    doctor_agent_type: str | None = None,
+) -> str:
     ref = str(source_ref or "").strip()
     installer = f"curl -fsSL {NO_CLONE_INSTALL_URL}"
+    doctor_agent_arg = (
+        f" --agent-type {shlex.quote(doctor_agent_type)}"
+        if doctor_agent_type
+        else ""
+    )
     if ref and ref != "stable":
         installer = f"{installer} | env LOOPX_REF={shlex.quote(ref)} bash"
     else:
@@ -71,7 +80,7 @@ def no_clone_upgrade_command(source_ref: Any = None) -> str:
     return (
         f"{installer}\n"
         'export PATH="$HOME/.local/bin:$PATH"\n'
-        "loopx doctor"
+        f"loopx doctor{doctor_agent_arg}"
     )
 
 
@@ -337,6 +346,8 @@ def build_install_freshness(
     release_manifest: dict[str, Any] | None = None,
     comparison_source: dict[str, Any] | None = None,
     freshness_source: dict[str, Any] | None = None,
+    require_installed_skills: bool = True,
+    doctor_agent_type: str | None = None,
     now: datetime | None = None,
 ) -> dict[str, Any]:
     reference = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
@@ -346,9 +357,8 @@ def build_install_freshness(
     if release_time:
         age_hours = round(max(0, (reference - release_time.astimezone(timezone.utc)).total_seconds()) / 3600, 2)
 
-    skill_problem = any(
-        not skill.get("exists") or not skill.get("required_phrases")
-        for skill in skills.values()
+    skill_problem = require_installed_skills and any(
+        not skill.get("exists") or not skill.get("required_phrases") for skill in skills.values()
     )
     if command_path is None:
         status = "missing"
@@ -395,8 +405,19 @@ def build_install_freshness(
     manifest_source = (
         manifest_body.get("source") if isinstance(manifest_body.get("source"), dict) else {}
     )
-    upgrade_command = no_clone_upgrade_command(manifest_source.get("ref"))
-    contributor_upgrade_command = f"{repo_root / 'scripts' / 'install-local.sh'}\nloopx doctor"
+    upgrade_command = no_clone_upgrade_command(
+        manifest_source.get("ref"),
+        doctor_agent_type=doctor_agent_type,
+    )
+    doctor_agent_arg = (
+        f" --agent-type {shlex.quote(doctor_agent_type)}"
+        if doctor_agent_type
+        else ""
+    )
+    contributor_upgrade_command = (
+        f"{repo_root / 'scripts' / 'install-local.sh'}\n"
+        f"loopx doctor{doctor_agent_arg}"
+    )
     manifest_source_git_commit = manifest_source.get("git_commit")
     manifest_source_revision = (
         manifest_source_git_commit
@@ -456,7 +477,8 @@ def build_install_freshness(
         "upgrade_command": upgrade_command,
         "no_clone_upgrade_command": upgrade_command,
         "contributor_upgrade_command": contributor_upgrade_command,
-        "doctor_after_upgrade": "loopx doctor",
+        "doctor_after_upgrade": f"loopx doctor{doctor_agent_arg}",
+        "installed_skills_required": require_installed_skills,
         "release_manifest_available": manifest.get("available"),
         "release_manifest_path": manifest.get("path"),
         "release_manifest_reason": manifest.get("reason"),
@@ -592,6 +614,26 @@ def installed_skill_summary(skills_root: Path) -> dict[str, dict[str, Any]]:
     return summaries
 
 
+def installed_skill_check(
+    check_id: str,
+    *,
+    actual_ok: bool,
+    detail: str,
+    applicable: bool,
+) -> dict[str, Any]:
+    return {
+        "id": check_id,
+        "required": False,
+        "ok": actual_ok if applicable else True,
+        "applicable": applicable,
+        "detail": (
+            detail
+            if applicable
+            else "not applicable: other-agent skill delivery is owned by the custom host"
+        ),
+    }
+
+
 def latest_promotion_readiness_event(runtime_root: Path, goal_id: str | None = None) -> dict[str, Any]:
     goals_dir = runtime_root / "goals"
     if not goals_dir.exists():
@@ -654,11 +696,19 @@ def latest_promotion_readiness_event(runtime_root: Path, goal_id: str | None = N
     return latest
 
 
-def collect_doctor(*, deep: bool = False) -> dict[str, Any]:
+def collect_doctor(
+    *,
+    deep: bool = False,
+    agent_type: str | None = None,
+) -> dict[str, Any]:
     from .control_plane.runtime.runtime_projection_route import (
         collect_runtime_projection_route_diagnostics,
     )
 
+    from .host_loop_activation import normalize_agent_type
+
+    canonical_agent_type = normalize_agent_type(agent_type) if agent_type else None
+    installed_skills_required = canonical_agent_type != "other-agent"
     loopx_path = resolve_command_path("loopx")
     invocation_path = current_script_invocation_path()
     loopx_canary_path = resolve_command_path("loopx-canary")
@@ -743,7 +793,27 @@ def collect_doctor(*, deep: bool = False) -> dict[str, Any]:
         release_manifest=release_manifest,
         comparison_source=comparison_source,
         freshness_source=freshness_source,
+        require_installed_skills=installed_skills_required,
+        doctor_agent_type=canonical_agent_type,
     )
+    skill_delivery = {
+        "agent_type": canonical_agent_type,
+        "owner": "loopx_surface_installer" if installed_skills_required else "custom_agent_host",
+        "mode": "surface_managed" if installed_skills_required else "host_managed",
+        "codex_skills_root_applicable": installed_skills_required,
+        "installed_skills_required_for_freshness": installed_skills_required,
+        "status": (
+            "ready"
+            if installed_skills_required
+            and all(
+                skill.get("exists") and skill.get("required_phrases")
+                for skill in skills.values()
+            )
+            else "repair_recommended"
+            if installed_skills_required
+            else "external_readback_required"
+        ),
+    }
     default_global_registry = global_registry_path(DEFAULT_RUNTIME_ROOT)
     global_registry_writability = probe_registry_write_path(default_global_registry, create_parent=True)
     runtime_projection_routes = (
@@ -843,32 +913,33 @@ def collect_doctor(*, deep: bool = False) -> dict[str, Any]:
             "ok": str(local_bin) in path_entries,
             "detail": str(local_bin),
         },
-        {
-            "id": "installed_skill_exists",
-            "required": False,
-            "ok": skill_path.exists(),
-            "detail": str(skill_path),
-        },
-        {
-            "id": "installed_skill_delivery_hints",
-            "required": False,
-            "ok": skill_has_delivery_hints(skill_path),
-            "detail": str(skill_path),
-        },
-        {
-            "id": "installed_required_skills",
-            "required": False,
-            "ok": all(skill.get("exists") for skill in skills.values()),
-            "detail": ",".join(sorted(skills)),
-        },
-        {
-            "id": "installed_required_skill_routes",
-            "required": False,
-            "ok": all(skill.get("required_phrases") for skill in skills.values()),
-            "detail": ",".join(
-                f"{name}={skill.get('required_phrases')}" for name, skill in sorted(skills.items())
+        installed_skill_check(
+            "installed_skill_exists",
+            actual_ok=skill_path.exists(),
+            detail=str(skill_path),
+            applicable=installed_skills_required,
+        ),
+        installed_skill_check(
+            "installed_skill_delivery_hints",
+            actual_ok=skill_has_delivery_hints(skill_path),
+            detail=str(skill_path),
+            applicable=installed_skills_required,
+        ),
+        installed_skill_check(
+            "installed_required_skills",
+            actual_ok=all(skill.get("exists") for skill in skills.values()),
+            detail=",".join(sorted(skills)),
+            applicable=installed_skills_required,
+        ),
+        installed_skill_check(
+            "installed_required_skill_routes",
+            actual_ok=all(skill.get("required_phrases") for skill in skills.values()),
+            detail=",".join(
+                f"{name}={skill.get('required_phrases')}"
+                for name, skill in sorted(skills.items())
             ),
-        },
+            applicable=installed_skills_required,
+        ),
         {
             "id": "global_registry_writable",
             "required": True,
@@ -893,6 +964,7 @@ def collect_doctor(*, deep: bool = False) -> dict[str, Any]:
     payload = {
         "ok": all(check["ok"] for check in checks if check["required"]),
         "mode": "deep" if deep else "standard",
+        "agent_type": canonical_agent_type,
         "python": {
             "executable": sys.executable,
             "version": sys.version.split()[0],
@@ -927,12 +999,18 @@ def collect_doctor(*, deep: bool = False) -> dict[str, Any]:
             "exists": skill_path.exists(),
             "delivery_hints": skill_has_delivery_hints(skill_path),
         },
+        "skill_delivery": skill_delivery,
         "skills": skills,
         "checks": checks,
         "fix": (
-            f"Run `{repo_root / 'scripts' / 'install-local.sh'}` and start a new shell, "
-            f"or export PATH=\"{local_bin}:$PATH\". For no-clone repair, run "
-            f"`curl -fsSL {NO_CLONE_INSTALL_URL} | bash`."
+            "Do not infer custom-host skill delivery from `~/.codex/skills`; "
+            "verify the host-managed loaded-skill readback from `loopx agent-onboard`."
+            if canonical_agent_type == "other-agent"
+            else (
+                f"Run `{repo_root / 'scripts' / 'install-local.sh'}` and start a new shell, "
+                f"or export PATH=\"{local_bin}:$PATH\". For no-clone repair, run "
+                f"`curl -fsSL {NO_CLONE_INSTALL_URL} | bash`."
+            )
         ),
     }
     if deep_validation:
@@ -947,6 +1025,7 @@ def render_doctor_markdown(payload: dict[str, Any]) -> str:
         "# LoopX Doctor",
         "",
         f"- ok: `{payload.get('ok')}`",
+        f"- agent_type: `{payload.get('agent_type')}`",
         f"- loopx: `{(payload.get('path') or {}).get('loopx')}`",
         f"- loopx_realpath: `{(payload.get('path') or {}).get('loopx_realpath')}`",
         f"- loopx_canary: `{(payload.get('path') or {}).get('loopx_canary')}`",
@@ -957,6 +1036,8 @@ def render_doctor_markdown(payload: dict[str, Any]) -> str:
         f"- installed_skill: `{(payload.get('skill') or {}).get('path')}`",
         f"- installed_skill_delivery_hints: `{(payload.get('skill') or {}).get('delivery_hints')}`",
         f"- installed_required_skills: `{','.join(sorted((payload.get('skills') or {}).keys()))}`",
+        f"- skill_delivery_mode: `{(payload.get('skill_delivery') or {}).get('mode')}`",
+        f"- skill_delivery_status: `{(payload.get('skill_delivery') or {}).get('status')}`",
         f"- global_registry_writable: `{(payload.get('global_registry_writability') or {}).get('ok')}`",
         f"- runtime_projection_routes_healthy: `{(payload.get('runtime_projection_routes') or {}).get('healthy')}`",
         f"- user_local_bin_on_path: `{(payload.get('path') or {}).get('user_local_bin_on_path')}`",

--- a/loopx/project_prompt.py
+++ b/loopx/project_prompt.py
@@ -59,8 +59,17 @@ fi
 {cli_bin_arg} doctor >/dev/null"""
 
 
-def render_codex_cli_no_clone_preflight(*, cli_bin: str = "loopx") -> str:
+def render_codex_cli_no_clone_preflight(
+    *,
+    cli_bin: str = "loopx",
+    doctor_agent_type: str | None = None,
+) -> str:
     cli_bin_arg = shell_arg(cli_bin)
+    doctor_agent_arg = (
+        f" --agent-type {shell_arg(doctor_agent_type)}"
+        if doctor_agent_type
+        else ""
+    )
     return f"""export PATH="$HOME/.local/bin:$PATH"
 if ! command -v {cli_bin_arg} >/dev/null 2>&1; then
   if command -v curl >/dev/null 2>&1; then
@@ -71,7 +80,7 @@ if ! command -v {cli_bin_arg} >/dev/null 2>&1; then
     exit 1
   fi
 fi
-{cli_bin_arg} doctor >/dev/null"""
+{cli_bin_arg} doctor{doctor_agent_arg} >/dev/null"""
 
 
 def render_quota_guard_command(

--- a/tests/test_doctor_install_freshness.py
+++ b/tests/test_doctor_install_freshness.py
@@ -207,6 +207,32 @@ def test_unknown_canary_relation_does_not_stale_current_default_release(tmp_path
     assert freshness["manifest_source_freshness_relation"] == "same"
 
 
+def test_other_agent_freshness_does_not_require_codex_skill_directory(
+    tmp_path: Path,
+) -> None:
+    freshness = build_install_freshness(
+        command_path=tmp_path / "loopx",
+        release_root=None,
+        repo_root=tmp_path,
+        skills={
+            "loopx-project": {
+                "exists": False,
+                "required_phrases": False,
+            }
+        },
+        require_installed_skills=False,
+        doctor_agent_type="other-agent",
+    )
+
+    assert freshness["status"] == "live_checkout"
+    assert freshness["requires_upgrade"] is False
+    assert freshness["installed_skills_required"] is False
+    assert freshness["doctor_after_upgrade"] == "loopx doctor --agent-type other-agent"
+    assert str(freshness["upgrade_command"]).endswith(
+        "loopx doctor --agent-type other-agent"
+    )
+
+
 def test_trusted_release_ref_matches_manifest_repository(tmp_path: Path) -> None:
     _git(tmp_path, "init")
     _git(tmp_path, "config", "user.email", "loopx@example.invalid")


### PR DESCRIPTION
## Summary

- add an explicit `doctor --agent-type other-agent` boundary so missing Codex skills do not mark a custom-agent CLI install as stale
- require custom hosts to deliver the four LoopX workflow skills through their own manifest or prompt-injection mechanism and return loaded-skill/source readback
- make `agent-onboard` carry the host-managed skill contract and keep existing untyped/Codex doctor behavior compatible

## Validation

- `pytest -q tests/test_doctor_install_freshness.py tests/test_host_loop_activation.py` (18 passed)
- `python examples/control_plane/agent-onboard-host-loop-activation-smoke.py`
- Ruff on all changed Python files
- `loopx check` on all six changed public files (0 errors, 0 warnings)
- `loopx canary premerge --from-git-diff --tier standard` (4 direct checks + 8 selected checks, 0 failures, 0 warnings, 0 holds; self-merge allowed)
- full suite: 1172 passed, 2 skipped; one unrelated local-runtime failure while a test-created venv loads relocatable `libpython.dylib`
