### PR TITLE
test(extensions): support relocatable Python venvs

### DIFF
--- a/tests/extensions/test_extension_scaffold.py
+++ b/tests/extensions/test_extension_scaffold.py
@@ -187,7 +187,12 @@ def test_generated_starter_installs_and_runs_through_managed_lifecycle(
         execute=True,
     )
     environment = tmp_path / "venv"
-    venv.EnvBuilder(with_pip=True, system_site_packages=True).create(environment)
+    # Match `python -m venv` so relocatable POSIX runtimes keep their libpython path.
+    venv.EnvBuilder(
+        with_pip=True,
+        system_site_packages=True,
+        symlinks=os.name != "nt",
+    ).create(environment)
     binary_dir = environment / ("Scripts" if os.name == "nt" else "bin")
     python = binary_dir / ("python.exe" if os.name == "nt" else "python")
     wheel_dir = tmp_path / "wheelhouse"


### PR DESCRIPTION
## Summary

- create generated-extension test venvs with symlinks on POSIX, matching `python -m venv` behavior
- preserve copied executables on Windows
- keep the change test-only; LoopX extension runtime behavior is unchanged

## Why

Relocatable macOS CPython resolves `libpython` relative to the executable. `venv.EnvBuilder` defaults to copying the executable, so the nested test venv aborts before exercising LoopX. Symlinking on POSIX preserves the base runtime path and makes the lifecycle test portable.

## Validation

- reproduced the pre-change `@rpath/libpython3.13.dylib` failure
- exact managed-lifecycle test passes on relocatable CPython 3.13
- POSIX symlink venv boots on relocatable CPython 3.12
- full `tests/extensions/test_extension_scaffold.py`: 10 passed
- Ruff and LoopX public-boundary check passed
- standard premerge gate passed; self-merge allowed