### PR TITLE
fix(quota): project explicit agent blockers

### DIFF
--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -1967,7 +1967,10 @@ def build_goal_frontier_projection(
     if replan_required:
         blockers.append("autonomous_replan_obligation")
     if isinstance(vision_wait_state, dict):
-        blockers.append("vision_blocked_successor_wait")
+        if vision_wait_state.get("reason_code") == "current_agent_blocker":
+            blockers.append("current_agent_blocker")
+        else:
+            blockers.append("vision_blocked_successor_wait")
 
     compact_acceptance_gaps = [
         item for item in (acceptance_gaps or []) if isinstance(item, dict)

--- a/loopx/control_plane/goals/goal_vision_wait.py
+++ b/loopx/control_plane/goals/goal_vision_wait.py
@@ -4,7 +4,12 @@ import hashlib
 import json
 from typing import Any
 
-from ..todos.contract import normalize_todo_id
+from ..todos.contract import (
+    TODO_TASK_CLASS_BLOCKER,
+    normalize_todo_claimed_by,
+    normalize_todo_id,
+    normalize_todo_status,
+)
 from ..todos.deferred_resume import todo_summary_blocked_successor_items
 
 
@@ -109,35 +114,87 @@ def build_goal_vision_wait_state(
         agent_todo_summary or {},
         agent_id=agent_id,
     )
-    if not candidates:
+    if candidates:
+        selected = candidates[0]
+        waiting_todo_ids = [
+            todo_id
+            for todo_id in (
+                normalize_todo_id(item.get("todo_id")) for item in candidates[:5]
+            )
+            if todo_id
+        ]
+        payload: dict[str, Any] = {
+            "schema_version": GOAL_VISION_WAIT_STATE_SCHEMA_VERSION,
+            "state": "waiting",
+            "reason_code": "exact_blocked_successor",
+            "agent_id": agent_id,
+            "waiting_todo_count": len(candidates),
+            "waiting_todo_ids": waiting_todo_ids,
+            "selected_todo_id": normalize_todo_id(selected.get("todo_id")),
+            "selected_todo_status": selected.get("status"),
+            "selected_todo_priority": selected.get("priority"),
+            "selected_todo_claimed_by": selected.get("claimed_by"),
+            "resume_when": selected.get("resume_when"),
+            "resume_condition": _compact_resume_condition(
+                selected.get("resume_condition")
+            ),
+            "deferred_acceptance_gap_count": len(gaps),
+            "deferred_acceptance_gap_kinds": [VISION_ACCEPTANCE_GAP_KIND],
+            "automatic_resume": True,
+            "resume_behavior": (
+                "when resume_ready becomes true, restore ordinary open-todo or "
+                "deferred-successor routing without closing the active vision"
+            ),
+        }
+        return {key: value for key, value in payload.items() if value is not None}
+
+    blocker_items = (
+        agent_todo_summary.get("current_agent_blocker_items")
+        if isinstance(agent_todo_summary, dict)
+        and isinstance(agent_todo_summary.get("current_agent_blocker_items"), list)
+        else []
+    )
+    safe_agent_id = normalize_todo_claimed_by(agent_id)
+    blocker_items = [
+        item
+        for item in blocker_items
+        if isinstance(item, dict)
+        and safe_agent_id is not None
+        and item.get("task_class") == TODO_TASK_CLASS_BLOCKER
+        and normalize_todo_status(item.get("status")) == "blocked"
+        and str(item.get("reason") or "").strip()
+        and normalize_todo_claimed_by(item.get("claimed_by"))
+        == safe_agent_id
+    ]
+    if not blocker_items:
         return None
 
-    selected = candidates[0]
+    selected = blocker_items[0]
     waiting_todo_ids = [
         todo_id
-        for todo_id in (normalize_todo_id(item.get("todo_id")) for item in candidates[:5])
+        for todo_id in (
+            normalize_todo_id(item.get("todo_id")) for item in blocker_items[:5]
+        )
         if todo_id
     ]
-    selected_todo_id = normalize_todo_id(selected.get("todo_id"))
-    payload: dict[str, Any] = {
+    payload = {
         "schema_version": GOAL_VISION_WAIT_STATE_SCHEMA_VERSION,
         "state": "waiting",
-        "reason_code": "exact_blocked_successor",
+        "reason_code": "current_agent_blocker",
         "agent_id": agent_id,
-        "waiting_todo_count": len(candidates),
+        "waiting_todo_count": len(blocker_items),
         "waiting_todo_ids": waiting_todo_ids,
-        "selected_todo_id": selected_todo_id,
+        "selected_todo_id": normalize_todo_id(selected.get("todo_id")),
         "selected_todo_status": selected.get("status"),
         "selected_todo_priority": selected.get("priority"),
         "selected_todo_claimed_by": selected.get("claimed_by"),
-        "resume_when": selected.get("resume_when"),
-        "resume_condition": _compact_resume_condition(selected.get("resume_condition")),
+        "blocker_reason": str(selected.get("reason") or "").strip(),
         "deferred_acceptance_gap_count": len(gaps),
         "deferred_acceptance_gap_kinds": [VISION_ACCEPTANCE_GAP_KIND],
-        "automatic_resume": True,
+        "automatic_resume": False,
         "resume_behavior": (
-            "when resume_ready becomes true, restore ordinary open-todo or "
-            "deferred-successor routing without closing the active vision"
+            "re-evaluate the active vision when the blocker is resolved or "
+            "superseded, or when runnable scoped advancement appears"
         ),
     }
     return {key: value for key, value in payload.items() if value is not None}

--- a/loopx/control_plane/quota/cli_projection.py
+++ b/loopx/control_plane/quota/cli_projection.py
@@ -27,6 +27,7 @@ _RETAINED_AGENT_ITEM_LANES = {
     "monitor_due_items": 1,
     "monitor_capability_blocked_due_items": 2,
     "monitor_schedule_gap_items": 1,
+    "current_agent_blocker_items": 2,
 }
 _RETAINED_USER_ITEM_LANES = {
     "first_open_items": 3,
@@ -62,6 +63,7 @@ _RETAINED_AGENT_ITEM_FIELDS = (
     "consecutive_no_change",
     "material_change",
     "result_hash",
+    "reason",
 )
 _RETAINED_SUCCESSION_WARNING_TODO_IDS = 3
 
@@ -128,7 +130,11 @@ def _compact_agent_todo_summary(summary: dict[str, Any]) -> dict[str, Any]:
 
     compact["payload_compaction"] = {
         "schema_version": QUOTA_CLI_TODO_SUMMARY_COMPACTION_SCHEMA_VERSION,
-        "retained_item_lanes": sorted(_RETAINED_AGENT_ITEM_LANES),
+        "retained_item_lanes": sorted(
+            lane
+            for lane in _RETAINED_AGENT_ITEM_LANES
+            if lane != "current_agent_blocker_items" or summary.get(lane)
+        ),
         "omitted_lanes": omitted_lanes,
         "full_detail_cold_path": QUOTA_CLI_TODO_SUMMARY_DETAIL_COMMAND,
     }

--- a/loopx/control_plane/todos/quota_summary.py
+++ b/loopx/control_plane/todos/quota_summary.py
@@ -7,6 +7,7 @@ from ..agents.agent_scope import (
     _agent_scope_filter_user_action_items,
     _agent_scope_filter_user_gate_items,
     _agent_scope_selectable_todo_item,
+    agent_scope_item_claimed_by,
 )
 from ..agents.capability_gate import missing_required_capabilities
 from .claim_visibility import (
@@ -15,6 +16,7 @@ from .claim_visibility import (
 )
 from .contract import (
     TODO_TASK_CLASS_ADVANCEMENT,
+    TODO_TASK_CLASS_BLOCKER,
     TODO_TASK_CLASS_MONITOR,
 )
 from .deferred_resume import (
@@ -91,6 +93,7 @@ QUOTA_PAYLOAD_ITEM_FIELDS = (
     "completed_at",
     "updated_at",
     "gate_state",
+    "reason",
 )
 QUOTA_PAYLOAD_LANE_LIMITS = {
     "monitor_due_items": MONITOR_DUE_ITEM_LIMIT,
@@ -110,6 +113,7 @@ QUOTA_PAYLOAD_LANE_LIMITS = {
     "current_agent_claimed_open_items": QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT,
     "current_agent_claimed_advancement_items": QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT,
     "current_agent_claimed_monitor_items": QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT,
+    "current_agent_blocker_items": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
     "claimed_by_others_items": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
     "other_agent_scoped_items": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
     "other_agent_bound_user_action_items": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
@@ -412,6 +416,19 @@ def summarize_user_todos_for_quota(
         for item in lanes.open_items
         if is_user_gate_todo_item(item)
     ]
+    blocker_items = [
+        item
+        for item in lanes.all_open_items
+        if todo_item_task_class(item) == TODO_TASK_CLASS_BLOCKER
+        and str(item.get("status") or "").strip().lower() == "blocked"
+        and str(item.get("reason") or "").strip()
+    ]
+    agent_id = str((agent_identity or {}).get("agent_id") or "").strip()
+    current_agent_blocker_items = [
+        item
+        for item in blocker_items
+        if agent_id and agent_scope_item_claimed_by(item) == agent_id
+    ]
     summary = {
         "schema_version": value.get("schema_version"),
         "source_section": value.get("source_section"),
@@ -439,6 +456,13 @@ def summarize_user_todos_for_quota(
         "backlog_items": lanes.display_open_items[:TODO_BACKLOG_ITEM_LIMIT],
         "executable_backlog_items": lanes.executable_items[:TODO_BACKLOG_ITEM_LIMIT],
     }
+    if blocker_items:
+        summary["blocker_open_count"] = len(blocker_items)
+    if current_agent_blocker_items:
+        summary["current_agent_blocker_count"] = len(current_agent_blocker_items)
+        summary["current_agent_blocker_items"] = current_agent_blocker_items[
+            :QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT
+        ]
     if closure_intent:
         summary["closure_intent"] = closure_intent
     monitor_writeback = todo_summary_monitor_writeback_contract(value)

--- a/loopx/control_plane/todos/summary_item.py
+++ b/loopx/control_plane/todos/summary_item.py
@@ -84,6 +84,7 @@ TODO_SUMMARY_SOURCE_KEYS = (
     "current_agent_claimed_open_items",
     "current_agent_claimed_advancement_items",
     "current_agent_claimed_monitor_items",
+    "blocker_items",
     "resume_blocked_items",
     "monitor_blocked_resume_candidates",
     "current_agent_monitor_blocked_resume_candidates",
@@ -153,6 +154,8 @@ def compact_todo_summary_item(
     else:
         compact.pop("removed_continuation_policy", None)
     compact["task_class"] = todo_item_task_class(compact)
+    if compact["task_class"] == "blocker" and str(item.get("reason") or "").strip():
+        compact["reason"] = str(item.get("reason") or "").strip()
     attach_todo_handoff_note(compact)
     return compact
 

--- a/loopx/control_plane/todos/todo_summary.py
+++ b/loopx/control_plane/todos/todo_summary.py
@@ -9,6 +9,7 @@ from .contract import (
     TODO_RESUME_KIND_PR_MERGED,
     TODO_RESUME_KIND_TODO_DONE,
     TODO_TASK_CLASS_ADVANCEMENT,
+    TODO_TASK_CLASS_BLOCKER,
     TODO_TASK_CLASS_MONITOR,
     TODO_TASK_CLASS_USER_ACTION,
     build_todo_id,
@@ -91,6 +92,7 @@ class _TodoGroupLanes:
     claimed_open_items: list[dict[str, Any]]
     unclaimed_open_items: list[dict[str, Any]]
     executable_items: list[dict[str, Any]]
+    blocker_items: list[dict[str, Any]]
     resume_blocked_items: list[dict[str, Any]]
     monitor_items: list[dict[str, Any]]
     monitor_due_items: list[dict[str, Any]]
@@ -1038,6 +1040,12 @@ def _todo_group_lanes(
         if todo_item_is_actionable_open(item)
         if todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
     ]
+    blocker_items = [
+        item
+        for item in projected_open_items
+        if normalize_todo_status(item.get("status")) == "blocked"
+        if todo_item_task_class(item) == TODO_TASK_CLASS_BLOCKER
+    ]
     resume_blocked_items = [
         item
         for item in projected_open_items
@@ -1094,6 +1102,7 @@ def _todo_group_lanes(
         claimed_open_items=claimed_open_items,
         unclaimed_open_items=unclaimed_open_items,
         executable_items=executable_items,
+        blocker_items=blocker_items,
         resume_blocked_items=resume_blocked_items,
         monitor_items=monitor_items,
         monitor_due_items=monitor_due_items,
@@ -1217,6 +1226,11 @@ def compact_todo_group(
         ][:MAX_DEFERRED_TODO_VISIBILITY_ITEMS],
         "items": lanes.budgeted_items if item_limit is None else lanes.budgeted_items[:item_limit],
     }
+    if lanes.blocker_items:
+        summary["blocker_open_count"] = len(lanes.blocker_items)
+        summary["blocker_items"] = [
+            compact_todo_item(item) for item in lanes.blocker_items
+        ]
     if not lanes.open_items and not lanes.deferred_items:
         summary["source_proof"] = {
             "schema_version": TODO_SOURCE_PROOF_SCHEMA_VERSION,

--- a/loopx/presentation/renderers/quota_markdown.py
+++ b/loopx/presentation/renderers/quota_markdown.py
@@ -306,13 +306,22 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
                 )
         vision_wait_state = as_dict(goal_frontier.get("vision_wait_state"))
         if vision_wait_state:
-            lines.append(
-                "- vision_wait_state: "
-                f"state={vision_wait_state.get('state')} "
-                f"todo_id={vision_wait_state.get('selected_todo_id')} "
-                f"resume_when={vision_wait_state.get('resume_when')} "
-                f"automatic_resume={vision_wait_state.get('automatic_resume')}"
-            )
+            if vision_wait_state.get("reason_code") == "current_agent_blocker":
+                lines.append(
+                    "- vision_wait_state: "
+                    f"state={vision_wait_state.get('state')} "
+                    f"todo_id={vision_wait_state.get('selected_todo_id')} "
+                    f"reason={vision_wait_state.get('blocker_reason')} "
+                    "automatic_resume=False"
+                )
+            else:
+                lines.append(
+                    "- vision_wait_state: "
+                    f"state={vision_wait_state.get('state')} "
+                    f"todo_id={vision_wait_state.get('selected_todo_id')} "
+                    f"resume_when={vision_wait_state.get('resume_when')} "
+                    f"automatic_resume={vision_wait_state.get('automatic_resume')}"
+                )
     task_orchestration = as_dict(payload.get("task_orchestration_contract"))
     if task_orchestration:
         peer_lanes = as_list(task_orchestration.get("eligible_peer_lanes"))
@@ -730,6 +739,10 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             summary_parts.append(
                 f"monitor_schedule_gap={summary.get('monitor_schedule_gap_count')}"
             )
+        if summary.get("current_agent_blocker_count"):
+            summary_parts.append(
+                f"current_agent_blocker={summary.get('current_agent_blocker_count')}"
+            )
         if summary.get("completed_without_successor_count"):
             summary_parts.append(
                 f"succession_warning={summary.get('completed_without_successor_count')}"
@@ -744,6 +757,7 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
                 2,
             ),
             ("monitor_schedule_gap_items", "monitor_schedule_gap", 1),
+            ("current_agent_blocker_items", "current_agent_blocker", 2),
         ):
             lane_items = (
                 summary.get(lane)
@@ -751,7 +765,13 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
                 else []
             )
             identities = [
-                compact_todo_identity(item)
+                (
+                    f"{compact_todo_identity(item)} "
+                    f"reason={str(item.get('reason') or '').strip()[:120]}"
+                    if lane == "current_agent_blocker_items"
+                    and str(item.get("reason") or "").strip()
+                    else compact_todo_identity(item)
+                )
                 for item in lane_items[:limit]
                 if isinstance(item, dict) and item.get("todo_id")
             ]

--- a/tests/control_plane/test_goal_vision_blocked_successor.py
+++ b/tests/control_plane/test_goal_vision_blocked_successor.py
@@ -40,6 +40,7 @@ CROSS_DOMAIN_WAITING_ID = "todo_cross_domain_waiting"
 CLAIMED_WAITING_ID = "todo_claimed_waiting"
 MONITOR_ID = "todo_future_monitor"
 MONITOR_BLOCKED_ID = "todo_monitor_blocked_advancement"
+PROJECTED_BLOCKER_ID = "todo_projected_agent_blocker"
 
 
 def _vision_run(
@@ -190,6 +191,48 @@ def _quota(payload: dict) -> dict:
     )
 
 
+def _current_agent_blocker_status_payload(
+    *,
+    claimed_by: str = AGENT_ID,
+    reason: str | None = "Candidate promotion requires controller assignment.",
+    latest_runs: list[dict] | None = None,
+) -> dict:
+    peer_items = [
+        quota_todo_item(
+            todo_id=f"todo_peer_{index}",
+            index=index + 1,
+            text=f"[P0] Peer advancement {index}.",
+            claimed_by=PRIMARY_AGENT,
+        )
+        for index in range(20)
+    ]
+    blocker = quota_todo_item(
+        todo_id=PROJECTED_BLOCKER_ID,
+        index=21,
+        text="[P2 blocker] Wait for a qualifying advancement assignment.",
+        status="blocked",
+        task_class="blocker",
+        priority="P2",
+        claimed_by=claimed_by,
+        reason=reason,
+    )
+    return quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        recommended_action="Wait for a qualifying advancement assignment.",
+        agent_todos=quota_todo_summary(
+            [*peer_items, blocker],
+            role="agent",
+            item_limit=12,
+        ),
+        coordination={
+            "agent_model": "peer_v1",
+            "registered_agents": [PRIMARY_AGENT, AGENT_ID],
+        },
+        latest_runs=latest_runs if latest_runs is not None else [_vision_run()],
+    )
+
+
 def _blocked_wait_polls() -> list[dict]:
     guard = _quota(_status_payload())
     return [
@@ -202,6 +245,103 @@ def _blocked_wait_polls() -> list[dict]:
             generated_at="2026-07-16T00:01:00+00:00",
         ),
     ]
+
+
+def test_current_agent_blocker_defers_open_vision_gap_without_hiding_reason() -> None:
+    guard = _quota(_current_agent_blocker_status_payload())
+
+    assert guard["decision"] == "reassignment_required"
+    assert guard["should_run"] is False
+    assert guard.get("autonomous_replan_obligation") is None
+    summary = guard["agent_todo_summary"]
+    assert summary["current_agent_blocker_count"] == 1
+    assert summary["current_agent_blocker_items"][0]["todo_id"] == (
+        PROJECTED_BLOCKER_ID
+    )
+    frontier = guard["goal_frontier_projection"]
+    assert frontier["acceptance_gaps"] == []
+    assert frontier["replan_required"] is False
+    assert "current_agent_blocker" in frontier["autonomy_blockers"]
+    wait = frontier["vision_wait_state"]
+    assert wait["reason_code"] == "current_agent_blocker"
+    assert wait["selected_todo_id"] == PROJECTED_BLOCKER_ID
+    assert wait["blocker_reason"] == (
+        "Candidate promotion requires controller assignment."
+    )
+    assert wait["automatic_resume"] is False
+
+    markdown = render_quota_should_run_markdown(guard)
+    assert (
+        "current_agent_blocker=1"
+    ) in markdown
+    assert (
+        f"todo_id={PROJECTED_BLOCKER_ID} "
+        "reason=Candidate promotion requires controller assignment."
+    ) in markdown
+
+
+@pytest.mark.parametrize(
+    ("claimed_by", "reason"),
+    [
+        (PRIMARY_AGENT, "Peer-owned blocker."),
+        (AGENT_ID, None),
+    ],
+    ids=["other-agent", "missing-reason"],
+)
+def test_unscoped_or_malformed_blocker_does_not_defer_open_vision_gap(
+    claimed_by: str,
+    reason: str | None,
+) -> None:
+    guard = _quota(
+        _current_agent_blocker_status_payload(
+            claimed_by=claimed_by,
+            reason=reason,
+        )
+    )
+
+    assert guard["decision"] == "autonomous_replan_required"
+    assert "vision_wait_state" not in guard["goal_frontier_projection"]
+    assert guard["goal_frontier_projection"]["replan_required"] is True
+
+
+def test_blocker_delta_ack_clears_existing_vision_replan_obligation() -> None:
+    obligation = {
+        "schema_version": "autonomous_replan_obligation_v0",
+        "required": True,
+        "agent_id": AGENT_ID,
+        "triggers": [{"kind": "vision_acceptance_gap"}],
+    }
+    ack = {
+        "classification": "autonomous_replan_recorded",
+        "generated_at": "2026-07-16T00:03:00+00:00",
+        "agent_id": AGENT_ID,
+        "autonomous_replan_ack": {
+            "schema_version": "autonomous_replan_ack_v0",
+            "recorded": True,
+            "source": "fixture",
+            "delta_contract": {
+                "schema_version": "repair_delta_contract_v0",
+                "delta_present": True,
+                "delta_kinds": ["blocker"],
+            },
+        },
+    }
+    payload = _current_agent_blocker_status_payload(
+        latest_runs=[ack, _vision_run()]
+    )
+    item = payload["attention_queue"]["items"][0]
+    item["autonomous_replan_obligation"] = obligation
+    item["project_asset"]["autonomous_replan_obligation"] = obligation
+
+    guard = _quota(payload)
+
+    assert guard["decision"] == "reassignment_required"
+    assert guard["should_run"] is False
+    assert guard.get("autonomous_replan_obligation") is None
+    assert guard["goal_frontier_projection"]["replan_required"] is False
+    assert guard["goal_frontier_projection"]["vision_wait_state"][
+        "reason_code"
+    ] == "current_agent_blocker"
 
 
 def _quota_with_replan_runs(

--- a/tests/control_plane/test_quota_cli_projection.py
+++ b/tests/control_plane/test_quota_cli_projection.py
@@ -39,6 +39,15 @@ def test_compact_quota_should_run_cli_payload_keeps_decision_lanes_and_counts() 
     monitor_due = _items(2, prefix="monitor")
     monitor_capability_blocked = _items(3, prefix="monitor-capability")
     monitor_schedule_gap = _items(2, prefix="monitor-gap")
+    current_agent_blockers = [
+        {
+            **item,
+            "status": "blocked",
+            "task_class": "blocker",
+            "reason": f"blocker reason {index}",
+        }
+        for index, item in enumerate(_items(3, prefix="blocker"))
+    ]
     payload = {
         "interaction_contract": {"mode": "bounded_delivery"},
         "selected_todo": first_executable[0],
@@ -55,6 +64,8 @@ def test_compact_quota_should_run_cli_payload_keeps_decision_lanes_and_counts() 
             "monitor_capability_blocked_due_items": monitor_capability_blocked,
             "monitor_schedule_gap_count": 2,
             "monitor_schedule_gap_items": monitor_schedule_gap,
+            "current_agent_blocker_count": 3,
+            "current_agent_blocker_items": current_agent_blockers,
             "backlog_items": backlog,
             "claimed_open_items": backlog,
             "claim_scope": {
@@ -98,6 +109,29 @@ def test_compact_quota_should_run_cli_payload_keeps_decision_lanes_and_counts() 
     assert [item["todo_id"] for item in summary["monitor_schedule_gap_items"]] == [
         "monitor-gap-0",
     ]
+    assert summary["current_agent_blocker_count"] == 3
+    assert summary["current_agent_blocker_items"] == [
+        {
+            "schema_version": "todo_item_v0",
+            "todo_id": "blocker-0",
+            "text": "blocker item 0",
+            "status": "blocked",
+            "priority": "P1",
+            "task_class": "blocker",
+            "action_kind": "blocker-action",
+            "reason": "blocker reason 0",
+        },
+        {
+            "schema_version": "todo_item_v0",
+            "todo_id": "blocker-1",
+            "text": "blocker item 1",
+            "status": "blocked",
+            "priority": "P1",
+            "task_class": "blocker",
+            "action_kind": "blocker-action",
+            "reason": "blocker reason 1",
+        },
+    ]
     assert "backlog_items" not in summary
     assert "claimed_open_items" not in summary
     assert "other_agent_claimed_items" not in summary["claim_scope"]
@@ -111,6 +145,7 @@ def test_compact_quota_should_run_cli_payload_keeps_decision_lanes_and_counts() 
         "backlog_items": 40,
         "claim_scope.other_agent_claimed_items": 40,
         "claimed_open_items": 40,
+        "current_agent_blocker_items": 1,
         "first_executable_items": 1,
         "first_open_items": 5,
         "monitor_due_items": 1,


### PR DESCRIPTION
## Summary

- preserve typed blocked `blocker` todos in the canonical todo read model even when they fall outside the generic item window
- project only current-agent blockers with an explicit reason into the quota hot path
- treat that blocker as an auditable vision wait so a recorded blocker delta clears repeated autonomous replan without closing the active vision
- keep other-agent and malformed blockers non-authoritative
- retain bounded JSON and Markdown blocker identity/reason output

## Validation

- `447 passed` for `tests/control_plane`
- `68 passed` for focused frontier, blocker, CLI projection, and todo consistency tests
- Ruff passed on all changed Python files
- `loopx check` passed with 0 errors and 0 warnings
- exact-head `loopx canary premerge --from-git-diff --tier standard` passed: 17/17 selected checks, no manual holds, self-merge allowed
- hot-path interface budget passed (`quota_should_run_json` remains within the existing bound)

The first premerge pass caught zero-blocker payload overhead; the projection now omits blocker fields when no authoritative blocker exists, and the final exact-head gate passed.

## Boundary

- no private state, credentials, local paths, raw logs, or generated evidence are included
- no production, permission, scheduler-host, or benchmark behavior changes
