### PR TITLE
fix(quota): honor explicit blocker precedence

### DIFF
--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -1436,6 +1436,9 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                     delta_kind="watch_lane_continuation",
                 )
             ),
+            current_agent_blocker_count=safe_non_negative_int(
+                (agent_todo_summary or {}).get("current_agent_blocker_count")
+            ),
             monitor_no_change_streak_triggered=(
                 monitor_no_change_trigger is not None
             ),

--- a/loopx/control_plane/goals/goal_frontier_replan_rules.py
+++ b/loopx/control_plane/goals/goal_frontier_replan_rules.py
@@ -19,6 +19,7 @@ class GoalFrontierReplanRule(str, Enum):
     LONG_TODO_CHAIN = "long_todo_chain"
     LONG_TODO_CHAIN_ACKNOWLEDGED = "long_todo_chain_acknowledged"
     WATCH_LANE_CONTINUATION_ACKNOWLEDGED = "watch_lane_continuation_acknowledged"
+    CURRENT_AGENT_BLOCKER = "current_agent_blocker"
     MONITOR_NO_CHANGE_STREAK = "monitor_no_change_streak"
     NOT_MONITOR_ONLY = "not_monitor_only"
     NO_OPEN_MONITOR = "no_open_monitor"
@@ -45,6 +46,7 @@ class GoalFrontierReplanFacts:
     long_todo_chain_triggered: bool = False
     long_todo_chain_acknowledged: bool = False
     watch_lane_continuation_acknowledged: bool = False
+    current_agent_blocker_count: int = 0
     monitor_no_change_streak_triggered: bool = False
     monitor_only_lane: bool = False
     monitor_count: int = 0
@@ -134,6 +136,12 @@ def select_goal_frontier_replan_rule(
             facts.watch_lane_continuation_acknowledged,
             False,
             "an explicit watch-lane continuation covers the empty frontier",
+        ),
+        (
+            GoalFrontierReplanRule.CURRENT_AGENT_BLOCKER,
+            facts.current_agent_blocker_count > 0,
+            False,
+            "an explicit current-agent blocker owns the empty frontier",
         ),
         (
             GoalFrontierReplanRule.MONITOR_NO_CHANGE_STREAK,

--- a/loopx/control_plane/goals/goal_vision_wait.py
+++ b/loopx/control_plane/goals/goal_vision_wait.py
@@ -98,7 +98,7 @@ def build_goal_vision_wait_state(
     acceptance_gaps: list[dict[str, Any]] | None,
     selectable_advancement_count: int,
 ) -> dict[str, Any] | None:
-    """Project a temporary vision wait over an exact blocked successor.
+    """Project a temporary vision wait over an authoritative blocked frontier.
 
     This is deliberately a read model, not a new todo or vision lifecycle
     state. It may defer only ordinary open-vision acceptance gaps. Missing
@@ -110,9 +110,32 @@ def build_goal_vision_wait_state(
         return None
     if selectable_advancement_count > 0:
         return None
-    candidates = todo_summary_blocked_successor_items(
-        agent_todo_summary or {},
-        agent_id=agent_id,
+
+    blocker_items = (
+        agent_todo_summary.get("current_agent_blocker_items")
+        if isinstance(agent_todo_summary, dict)
+        and isinstance(agent_todo_summary.get("current_agent_blocker_items"), list)
+        else []
+    )
+    safe_agent_id = normalize_todo_claimed_by(agent_id)
+    blocker_items = [
+        item
+        for item in blocker_items
+        if isinstance(item, dict)
+        and safe_agent_id is not None
+        and item.get("task_class") == TODO_TASK_CLASS_BLOCKER
+        and normalize_todo_status(item.get("status")) == "blocked"
+        and str(item.get("reason") or "").strip()
+        and normalize_todo_claimed_by(item.get("claimed_by"))
+        == safe_agent_id
+    ]
+    candidates = (
+        todo_summary_blocked_successor_items(
+            agent_todo_summary or {},
+            agent_id=agent_id,
+        )
+        if not blocker_items
+        else []
     )
     if candidates:
         selected = candidates[0]
@@ -148,27 +171,8 @@ def build_goal_vision_wait_state(
         }
         return {key: value for key, value in payload.items() if value is not None}
 
-    blocker_items = (
-        agent_todo_summary.get("current_agent_blocker_items")
-        if isinstance(agent_todo_summary, dict)
-        and isinstance(agent_todo_summary.get("current_agent_blocker_items"), list)
-        else []
-    )
-    safe_agent_id = normalize_todo_claimed_by(agent_id)
-    blocker_items = [
-        item
-        for item in blocker_items
-        if isinstance(item, dict)
-        and safe_agent_id is not None
-        and item.get("task_class") == TODO_TASK_CLASS_BLOCKER
-        and normalize_todo_status(item.get("status")) == "blocked"
-        and str(item.get("reason") or "").strip()
-        and normalize_todo_claimed_by(item.get("claimed_by"))
-        == safe_agent_id
-    ]
     if not blocker_items:
         return None
-
     selected = blocker_items[0]
     waiting_todo_ids = [
         todo_id

--- a/tests/control_plane/test_goal_frontier_replan_rules.py
+++ b/tests/control_plane/test_goal_frontier_replan_rules.py
@@ -76,6 +76,16 @@ from loopx.control_plane.goals.goal_frontier_replan_rules import (
         ),
         (
             {
+                "current_agent_blocker_count": 1,
+                "monitor_no_change_streak_triggered": True,
+                "monitor_only_lane": True,
+                "monitor_count": 1,
+            },
+            GoalFrontierReplanRule.CURRENT_AGENT_BLOCKER,
+            False,
+        ),
+        (
+            {
                 "monitor_no_change_streak_triggered": True,
                 "monitor_only_lane": True,
                 "monitor_count": 1,

--- a/tests/control_plane/test_goal_vision_blocked_successor.py
+++ b/tests/control_plane/test_goal_vision_blocked_successor.py
@@ -280,6 +280,29 @@ def test_current_agent_blocker_defers_open_vision_gap_without_hiding_reason() ->
     ) in markdown
 
 
+def test_current_agent_blocker_outranks_exact_blocked_successor() -> None:
+    blocker = quota_todo_item(
+        todo_id=PROJECTED_BLOCKER_ID,
+        index=3,
+        text="[P2 blocker] Wait for a qualifying advancement assignment.",
+        status="blocked",
+        task_class="blocker",
+        priority="P2",
+        claimed_by=AGENT_ID,
+        reason="Candidate promotion requires controller assignment.",
+    )
+
+    guard = _quota(_status_payload(extra_agent_items=[blocker]))
+
+    wait = guard["goal_frontier_projection"]["vision_wait_state"]
+    assert wait["reason_code"] == "current_agent_blocker"
+    assert wait["selected_todo_id"] == PROJECTED_BLOCKER_ID
+    assert wait["automatic_resume"] is False
+    assert guard["agent_scope_frontier"]["blocked_successor_wait_candidates"][0][
+        "todo_id"
+    ] == WAITING_ID
+
+
 @pytest.mark.parametrize(
     ("claimed_by", "reason"),
     [


### PR DESCRIPTION
## Summary
- let an explicit, reasoned blocker claimed by the current agent own the vision-wait read model ahead of an unrelated deferred successor
- treat the authoritative current-agent blocker as a no-replan frontier rule after a blocker delta ACK clears an existing obligation
- keep the exact deferred successor visible in the agent-scope diagnostic projection and add precedence regressions

## Why
PR #2530 made blocker identity and reason visible, but the live quality-qualification lane still selected an older exact deferred successor first and immediately re-derived a stalled-monitor replan. That contradicted the documented blocker transition: the repair existed in state but could not own the frontier.

## Validation
- `449 passed` in `tests/control_plane`
- focused blocker/vision/rule tests: `45 passed`
- Ruff and Python compile checks passed
- `loopx check`: 0 errors, 0 warnings, public boundary clean
- exact committed diff `loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard`: 17/17 checks passed, no manual holds, self-merge allowed
- live registry shadow with this head no longer emits `autonomous_replan_required`; the repair todo becomes the selected normal-run advancement while it is open

## Boundaries
No private state, raw logs, credentials, local paths, benchmark semantics, permissions, or production actions are included.
