### PR TITLE
docs: explain custom agent runner integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,10 @@ your agents can orchestrate external tools, devices, domain-specific runners,
 or peer agents, while LoopX keeps goals, gates, todos, evidence, quota, and
 handoff state reviewable.
 
+Read [Embed LoopX In Your Agent Runner](docs/guides/custom-agent-runner-integration.md)
+for the minimal CLI + lightweight skill + self-driven runner model, including
+the tick lifecycle, decentralized Agent handoff, and validation checklist.
+
 Clone-based install is only for contributors who want the live canary wrapper:
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -101,6 +101,11 @@ Cursor、其他终端 agent 或手动 shell 都走同一个 no-clone installer�
 或 heartbeat、或者自身有 loop/scheduler。否则 LoopX 仍可记录项目状态，但用户需要把
 下面的 shell 命令手动跑完。
 
+如果你已经有远端 Agent runner、custom CLI 或 workflow supervisor，直接阅读
+[把 LoopX 嵌入你的 Agent Runner](docs/guides/custom-agent-runner-integration.zh-CN.md)。
+它用一页讲清 CLI、轻量 skill/re-entry instruction、自驱动 tick、去中心化 Agent
+接力和验证边界。
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
 export PATH="$HOME/.local/bin:$PATH"

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,9 @@ incident report, or launch draft.
 - [Newcomer command path](guides/newcomer-command-path.md): the minimal product
   path for `/loopx`, `/loopx <goal>`, and one CLI quickstart before the full
   command catalog.
+- [Custom Agent runner integration](guides/custom-agent-runner-integration.md):
+  the concise CLI, lightweight skill, self-driven tick, and decentralized
+  handoff model for an existing remote runner or workflow supervisor.
 - [Auto-research command path](guides/auto-research-command-path.md): the
   shortest visible route from a clean workspace to an inspectable multi-agent
   auto-research rehearsal with stop and takeover controls.
@@ -99,6 +102,7 @@ incident report, or launch draft.
 
 - [Getting started](guides/getting-started.md)
 - [Newcomer command path](guides/newcomer-command-path.md)
+- [Custom Agent runner integration](guides/custom-agent-runner-integration.md)
 - [Auto-research command path](guides/auto-research-command-path.md)
 - [Multi-agent product recipe](guides/multi-agent-product-recipe.md)
 - [Integration guide](integration.md)

--- a/docs/development/control-plane-course/00-concept-primer.md
+++ b/docs/development/control-plane-course/00-concept-primer.md
@@ -116,6 +116,11 @@ CLI packet 不是第二份 canonical state，也不是把所有历史塞回 prom
 Host 中长期保留的是稳定的 re-entry body：它只说明怎样找到 goal、调用 LoopX CLI 并取得
 当前 packet，不承载某一轮的 packet 内容。
 
+> 已有远端 Agent runner、custom CLI 或 workflow supervisor 的读者，可以直接读
+> [把 LoopX 嵌入你的 Agent Runner](../../guides/custom-agent-runner-integration.zh-CN.md)：
+> CLI 是 truth，轻量 skill/re-entry instruction 约束 Agent 行为，现有 runner 继续拥有
+> wake、session 和 workspace；Agent 之间通过 todo/successor 接力，不依赖中央 leader。
+
 ## 先从数据面与控制面开始
 
 假设一个开源项目让 Agent 持续把公开 issue 推进成可审阅的修复 PR。它需要判断 issue 是否

--- a/docs/guides/custom-agent-runner-integration.md
+++ b/docs/guides/custom-agent-runner-integration.md
@@ -1,0 +1,169 @@
+# Embed LoopX In Your Agent Runner
+
+[简体中文](custom-agent-runner-integration.zh-CN.md)
+
+This guide is for developers who already run agents on a remote development
+machine, through a custom CLI, or behind an existing workflow supervisor.
+You do not need to replace that runtime or move domain orchestration into
+LoopX. Keep your runner, and use LoopX as the durable control-plane contract
+between turns.
+
+The shortest useful mental model has three pieces:
+
+| Piece | Owns | Does not own |
+| --- | --- | --- |
+| **LoopX CLI** | Durable goal, todo, claim, gate, quota, evidence, monitor, scheduler hint, and accepted writeback state | Agent reasoning, tools, or the external system |
+| **Lightweight skill or re-entry instruction** | How the Agent reads a fresh LoopX packet, obeys its boundary, validates work, and writes back | Current task state or another scheduler |
+| **Your runner** | Wakeups, workspace/session setup, Agent invocation, and applying the actual timer or scheduler value | LoopX policy, hidden authority, or domain truth |
+
+The CLI is the source of truth. The skill is a small behavior contract. Your
+runner is the loop driver.
+
+```mermaid
+flowchart LR
+  R["Your runner<br/>wake · session · workspace"] --> Q["loopx quota should-run"]
+  Q --> P["Fresh CLI packet<br/>interaction · boundary · next action"]
+  P --> A["Agent + lightweight skill"]
+  A --> X["Tools / external systems"]
+  X --> V["Independent validation / readback"]
+  V --> W["LoopX writeback<br/>todo · evidence · refresh · spend"]
+  W --> R
+```
+
+## What You Do Not Need
+
+You do not need a permanent leader Agent, a second orchestration database, or a
+LoopX capability for every task. An Agent may plan, split work, use tools, and
+create a successor todo from the facts it discovers.
+
+When Agent A finishes and Agent B should continue, A writes or links the
+successor todo through LoopX. The next host wake reads the new frontier and B
+claims it. No central model needs to remember or manually route the handoff.
+
+Add a Capability only when the caller needs a stable, provider-neutral outcome
+contract with reusable observation normalization, validation, and transition
+policy. Put an external implementation behind a Provider. Ordinary reasoning,
+repository edits, and one-off tool use can remain Agent work.
+
+## Bootstrap A Custom Host
+
+Install the CLI on the machine that owns the project workspace:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+loopx doctor --agent-type other-agent
+```
+
+Ask LoopX for the current custom-host packet instead of hard-coding commands:
+
+```bash
+loopx agent-onboard \
+  --agent-type other-agent \
+  --project . \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --task-text "<first task>" \
+  --available-capability shell
+```
+
+The packet returns the current doctor/install command, bootstrap command pack,
+quota guard, and recheck command. Declare only capabilities the current host
+actually has. `--available-capability` reports observed execution ability; it
+does not grant permission or satisfy a user gate.
+
+For `other-agent`, doctor intentionally does not inspect `~/.codex/skills`.
+CLI health and workflow delivery are separate checks. The custom host must
+deliver `loopx-project`, `loopx-pr-review`, `loopx-doc-registry`, and
+`loopx-self-repair` from the same LoopX revision through its own skill manifest
+or equivalent prompt injection, then read back the integration mode, loaded
+skill ids, and source revision. Do not assume a Codex, Claude, or OpenCode
+directory layout for an unknown host.
+
+If the host has no skill system, inject the equivalent `SKILL.md` instructions
+and keep one short re-entry instruction that tells the Agent to:
+
+1. read a fresh JSON quota packet for the current goal and Agent;
+2. follow `interaction_contract`, `goal_boundary`, and the selected todo;
+3. perform one bounded action and validate the real postcondition;
+4. write the result through LoopX; and
+5. apply and acknowledge any scheduler hint before the next wake.
+
+The re-entry instruction stays stable. It must not cache a previous CLI packet,
+todo list, cadence, or project policy.
+
+## Run One Self-Driven Tick
+
+Use JSON for the machine path:
+
+```bash
+loopx --format json \
+  --registry "$HOME/.codex/loopx/registry.global.json" \
+  quota should-run \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --available-capability shell
+```
+
+Then follow this loop:
+
+1. **Decide:** Treat `should-run` and `interaction_contract` as the gate. A
+   quiet, wait, or monitor-only result makes no model call and spends no quota.
+2. **Route:** If the user channel requires action, show the concrete user todo
+   or question. Do not substitute an owner gate for a missing payload.
+3. **Claim:** Claim the selected executable todo before write-capable work.
+   Keep independent handoffs unclaimed unless an explicit assignment is known.
+4. **Execute:** Give the Agent only the current objective, selected todo,
+   boundary, compact evidence references, and writeback contract. Let it
+   dynamically plan the bounded action.
+5. **Validate:** Read the real repository, test, CI, service, or Provider
+   result. The Agent's completion claim is not proof.
+6. **Write back:** Complete, update, block, defer, or add a successor todo;
+   record compact evidence; then run `refresh-state`.
+7. **Account:** Spend quota only after validated durable writeback. A failed
+   validator, cadence update, quiet monitor poll, or no-op retry does not spend.
+8. **Schedule:** Apply the current scheduler hint in the runner, read back the
+   value actually applied, and ACK it through the returned CLI command.
+
+Every new wake starts again at step 1. Do not resume from remembered model
+state or a cached packet.
+
+## Choose The Right Execution Boundary
+
+There are two valid integration depths. In both cases, your runner still owns
+the outer wake/schedule loop:
+
+```text
+outer runner: wake -> one bounded execution -> apply scheduler hint -> next wake
+LoopX Turn:             decide -> execute -> validate -> commit
+```
+
+| Path | Use it when | Boundary |
+| --- | --- | --- |
+| **Direct CLI orchestration** | Your runner already invokes Agents and validates their work | The runner consumes `quota should-run`, todo lifecycle, refresh, spend, and scheduler ACK contracts |
+| **LoopX Turn adapter** | You want one typed command to plan, invoke one bounded host segment, validate, and commit | Use `turn run-once` with the built-in `codex-cli` adapter or a thin `generic-cli` adapter |
+
+Direct CLI orchestration is the compatibility baseline. LoopX Turn is an
+optional transaction boundary inside the runner, not a permanent scheduler or
+multi-Agent coordinator. Choose one owner for decide, validate, writeback, and
+spend in each tick: do not run the direct sequence and `turn run-once` for the
+same logical action.
+
+## Acceptance Checklist
+
+Before calling the integration autonomous, prove that:
+
+- restarting the runner recovers from LoopX state without transcript replay;
+- a concrete user action is surfaced, while an unrelated safe todo may still
+  run;
+- two Agents cannot silently claim the same work;
+- validation failure cannot complete a todo or spend quota;
+- scheduler application and ACK are idempotent;
+- raw transcripts, credentials, private paths, and unbounded logs stay outside
+  LoopX state; and
+- the Agent can hand off through a successor todo without a permanent leader.
+
+For exact read/write contracts, see
+[Host Integration Surface v0](../reference/protocols/host-integration-surface-v0.md).
+For the optional typed Turn path, see
+[Run One LoopX Turn With Codex CLI](../product/loopx-turn-codex-cli-quickstart.md).

--- a/docs/guides/custom-agent-runner-integration.zh-CN.md
+++ b/docs/guides/custom-agent-runner-integration.zh-CN.md
@@ -1,0 +1,153 @@
+# 把 LoopX 嵌入你的 Agent Runner
+
+[English](custom-agent-runner-integration.md)
+
+这篇指南面向已经在远端开发机、自有 Agent CLI 或工作流 supervisor 中运行 Agent 的
+开发者。你不需要替换现有 runtime，也不需要把领域编排搬进 LoopX。保留自己的 runner，
+把 LoopX 作为跨 Turn 的持久控制面合同即可。
+
+最小心智模型只有三部分：
+
+| 部件 | 负责什么 | 不负责什么 |
+| --- | --- | --- |
+| **LoopX CLI** | 持久化 goal、todo、claim、gate、quota、evidence、monitor、scheduler hint 和已接受的 writeback | Agent 推理、工具或外部系统本身 |
+| **轻量 skill / re-entry instruction** | 教 Agent 每轮读取新鲜 LoopX packet、遵守边界、验证并写回 | 保存当前任务状态或再造一个 scheduler |
+| **你的 runner** | 唤醒、workspace/session、调用 Agent，以及应用真实 timer/scheduler 值 | LoopX policy、隐式授权或领域事实 |
+
+CLI 是事实源，skill 是小型行为合同，你的 runner 是 loop driver。
+
+```mermaid
+flowchart LR
+  R["你的 runner<br/>唤醒 · session · workspace"] --> Q["loopx quota should-run"]
+  Q --> P["新鲜 CLI packet<br/>interaction · boundary · next action"]
+  P --> A["Agent + 轻量 skill"]
+  A --> X["工具 / 外部系统"]
+  X --> V["独立验证 / readback"]
+  V --> W["LoopX writeback<br/>todo · evidence · refresh · spend"]
+  W --> R
+```
+
+## 不需要先建设什么
+
+不需要常驻的 leader Agent、第二套编排数据库，也不需要为每件事定义一个 LoopX
+Capability。Agent 可以根据目标做方案、拆任务、调用工具，并根据新事实创建 successor todo。
+
+Agent A 完成后若应由 Agent B 接力，A 通过 LoopX 写入或链接 successor todo；下一次 host
+唤醒重新读取 frontier，由 B 认领即可。无需一个中央模型记住并人工路由整个交接。
+
+只有当调用方需要稳定、provider-neutral 的结果合同，并且 observation 归一化、验证和
+transition policy 可复用时，才值得新增 Capability；外部实现放在 Provider 后面。普通推理、
+仓库修改和一次性工具使用仍然属于 Agent 工作。
+
+## 接入 Custom Host
+
+先在拥有项目 workspace 的机器上安装 CLI：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+loopx doctor --agent-type other-agent
+```
+
+不要自己猜一套固定命令，让 LoopX 生成当前 custom-host packet：
+
+```bash
+loopx agent-onboard \
+  --agent-type other-agent \
+  --project . \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --task-text "<第一个任务>" \
+  --available-capability shell
+```
+
+packet 会返回当前 doctor/install、bootstrap command pack、quota guard 和 recheck
+命令。只声明 host 真实具备的 capability。`--available-capability` 表示观察到的执行能力，
+不授予权限，也不能替代 user gate。
+
+对于 `other-agent`，doctor 会有意跳过 `~/.codex/skills` 检查。CLI 健康与 workflow
+交付是两件事：custom host 仍需通过自己的 skill manifest 或等价 prompt injection，
+从同一 LoopX revision 交付 `loopx-project`、`loopx-pr-review`、
+`loopx-doc-registry` 和 `loopx-self-repair`，再 readback integration mode、
+loaded skill ids 和 source revision。不要假设未知 host 采用 Codex、Claude 或 OpenCode
+的目录布局。
+
+如果 host 没有 skill 系统，就注入等价的 `SKILL.md` 指令，并保留一段短
+re-entry instruction，要求 Agent：
+
+1. 为当前 goal 与 Agent 读取新鲜 JSON quota packet；
+2. 遵守 `interaction_contract`、`goal_boundary` 和 selected todo；
+3. 只做一次有界动作，并验证真实 postcondition；
+4. 通过 LoopX 写回结果；
+5. 在下次唤醒前应用并 ACK scheduler hint。
+
+这段 re-entry instruction 应保持稳定，不能缓存上一轮 CLI packet、todo 列表、cadence 或
+项目 policy。
+
+## 跑一个自驱动 Tick
+
+机器路径使用 JSON：
+
+```bash
+loopx --format json \
+  --registry "$HOME/.codex/loopx/registry.global.json" \
+  quota should-run \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --available-capability shell
+```
+
+然后按以下闭环运行：
+
+1. **决策：** 把 `should-run` 和 `interaction_contract` 当作 gate。quiet、wait 或
+   monitor-only 不调用模型，也不花 quota。
+2. **路由：** user channel 要求动作时，展示具体 user todo 或问题；缺少 payload 时不要只说
+   “owner gate”。
+3. **认领：** 在可写执行前 claim selected executable todo。独立交接默认保持 unclaimed，
+   除非已有明确 assignment。
+4. **执行：** 只把当前 objective、selected todo、boundary、紧凑 evidence ref 和 writeback
+   contract 交给 Agent，让它动态规划本轮有界动作。
+5. **验证：** 读取真实 repository、测试、CI、服务或 Provider 结果。Agent 自称完成不是 proof。
+6. **写回：** complete、update、block、defer 或新增 successor todo，记录紧凑 evidence，
+   再运行 `refresh-state`。
+7. **计费：** 只有验证通过并完成持久 writeback 后才 spend。validator 失败、cadence 更新、
+   quiet monitor poll 和 no-op retry 都不 spend。
+8. **调度：** runner 应用当前 scheduler hint，readback 实际生效值，再执行 packet 返回的
+   ACK CLI。
+
+每次新唤醒都重新从第 1 步开始，不能依赖模型记忆或缓存 packet 续跑。
+
+## 选择合适的执行边界
+
+接入深度有两种，都合理；无论选择哪种，外层唤醒与调度循环仍由你的 runner 负责：
+
+```text
+outer runner: 唤醒 -> 一次有界执行 -> 应用 scheduler hint -> 下次唤醒
+LoopX Turn:              决策 -> 执行 -> 验证 -> 提交
+```
+
+| 路径 | 适用情况 | 边界 |
+| --- | --- | --- |
+| **直接编排 CLI** | 你的 runner 已经会调用 Agent，并能独立验证结果 | runner 消费 `quota should-run`、todo lifecycle、refresh、spend 和 scheduler ACK 合同 |
+| **LoopX Turn adapter** | 希望由一条 typed command 完成 plan、调用一次 bounded host、验证和 commit | 使用 `turn run-once` 的内置 `codex-cli` adapter，或薄 `generic-cli` adapter |
+
+直接编排 CLI 是兼容基线；LoopX Turn 是 runner 内部可选的 transaction boundary，
+不是常驻 scheduler 或多 Agent 调度中枢。每个 tick 只能有一个 decide、validate、
+writeback 和 spend owner；同一逻辑动作不能同时跑手工闭环与 `turn run-once`。
+
+## 验收清单
+
+在把集成称为“自主运行”前，至少证明：
+
+- runner 重启后能从 LoopX state 恢复，不依赖 transcript replay；
+- 具体 user action 会被投影，同时无关的安全 todo 仍可继续；
+- 两个 Agent 不会静默认领同一份工作；
+- 验证失败不能完成 todo 或 spend quota；
+- scheduler 应用和 ACK 幂等；
+- raw transcript、credentials、私有路径和无界日志不进入 LoopX state；
+- Agent 能通过 successor todo 接力，不依赖常驻 leader。
+
+精确读写合同见
+[Host Integration Surface v0](../reference/protocols/host-integration-surface-v0.md)；
+可选的 typed Turn 路径见
+[Run One LoopX Turn With Codex CLI](../product/loopx-turn-codex-cli-quickstart.md)。

--- a/docs/guides/newcomer-command-path.md
+++ b/docs/guides/newcomer-command-path.md
@@ -42,6 +42,10 @@ matches the surface you already use:
 | OpenCode | Install the OpenCode surface, then `/loopx <task text>` | The bridge writes commands, plugin, runtime, and pinned dependencies. After todos are written, call `loopx_goal_activate` to bind the quota-gated goal loop. |
 | Other agent or shell | `loopx start-goal --guided --project . --goal-text "<task text>" --host-surface <exact-host>` | The guided packet previews the same transaction an agent should execute: inspect or connect state, plan todos, refresh status, activate a host loop, run quota, and ack scheduler hints when needed. If the surface has no runner hook, LoopX can track state but the user drives it manually. |
 
+If you already own the Agent runner or workflow supervisor, use
+[Embed LoopX In Your Agent Runner](custom-agent-runner-integration.md) instead
+of reconstructing the lifecycle from the full CLI catalog.
+
 ## One CLI Quickstart
 
 Use this when an agent asks for the manual shell path, or when you are setting


### PR DESCRIPTION
## Summary

- add concise English and Chinese guides for developers embedding LoopX in an existing remote/custom Agent runner
- distinguish the LoopX CLI, host-managed workflow skills, the outer runner, and the optional LoopX Turn transaction boundary
- link the guide from README, docs index, newcomer path, and the control-plane concept primer

## Validation

- `git diff --cached --check`
- local-link resolution for all 7 changed Markdown files
- `loopx check` public-boundary scan: 7 files, 0 errors, 0 warnings
- `uv run --python 3.11 python examples/control_plane/agent-onboard-host-loop-activation-smoke.py`
- `loopx --format json canary premerge --from-git-diff`: 17/17 checks passed, no warnings or manual holds

The first onboarding-smoke attempt used macOS system Python 3.9 and stopped before test execution because the project requires Python >=3.11 (`tomllib` was unavailable). The same smoke passed under Python 3.11. No runtime behavior changes.