### PR TITLE
Route agent-recoverable runtime gates to self-repair

### DIFF
--- a/loopx/control_plane/quota/stall_repair.py
+++ b/loopx/control_plane/quota/stall_repair.py
@@ -126,7 +126,7 @@ def _source_todo_items(
     source_items: list[dict[str, Any]] | None,
 ) -> list[dict[str, Any]]:
     candidates = list(source_items or [])
-    if isinstance(summary, dict):
+    if source_items is None and isinstance(summary, dict):
         for key in (
             "items",
             "first_open_items",
@@ -174,11 +174,9 @@ def build_runtime_capability_user_gate_repair_hint(
         for todo_id in [normalize_todo_id(item.get("todo_id"))]
         if todo_id
     }
-    user_summary = dict(user_todo_summary or {})
-    user_summary["items"] = _source_todo_items(
-        user_todo_summary,
-        user_todo_source_items,
-    )
+    user_summary = {
+        "items": _source_todo_items(user_todo_summary, user_todo_source_items)
+    }
     for gate in open_user_gate_todo_items(user_summary):
         if normalize_todo_global_gate(gate.get("global_gate")):
             continue

--- a/loopx/control_plane/quota/stall_repair.py
+++ b/loopx/control_plane/quota/stall_repair.py
@@ -3,12 +3,25 @@ from __future__ import annotations
 from typing import Any
 
 from .. import compact_control_plane_policy, control_plane_self_repair_allows
+from ..agents.capability_gate import (
+    CAPABILITY_OWNER_GATE_HINTS,
+    missing_required_capabilities,
+)
+from ..todos.contract import (
+    normalize_required_capabilities,
+    normalize_todo_blocks_agent,
+    normalize_todo_claimed_by,
+    normalize_todo_decision_scope,
+    normalize_todo_global_gate,
+    normalize_todo_id,
+    normalize_todo_required_decision_scopes,
+)
 from ..todos.decision_scope import (
     build_required_decision_scope_consistency,
     build_required_decision_scope_repair_hint,
     standing_decision_authority_for_agent,
 )
-from ..todos.user_gate import open_todo_count
+from ..todos.user_gate import open_todo_count, open_user_gate_todo_items
 
 STALL_HEALTH_ITEM_COMPACT_FIELDS = (
     "goal_id",
@@ -20,8 +33,28 @@ STALL_HEALTH_ITEM_COMPACT_FIELDS = (
 )
 DECISION_SCOPE_REPAIR_TRIGGER = "required_decision_scope_projection_drift"
 USER_GATE_SCOPE_REPAIR_TRIGGER = "user_gate_scope_projection_drift"
+RUNTIME_CAPABILITY_USER_GATE_REPAIR_TRIGGER = "runtime_capability_user_gate_overreach"
 TODO_PROJECTION_REPAIR_TRIGGERS = frozenset(
-    {DECISION_SCOPE_REPAIR_TRIGGER, USER_GATE_SCOPE_REPAIR_TRIGGER}
+    {
+        DECISION_SCOPE_REPAIR_TRIGGER,
+        USER_GATE_SCOPE_REPAIR_TRIGGER,
+        RUNTIME_CAPABILITY_USER_GATE_REPAIR_TRIGGER,
+    }
+)
+RUNTIME_RECOVERY_ACTION_TOKENS = frozenset(
+    {
+        "configure",
+        "execute",
+        "install",
+        "launch",
+        "materialize",
+        "rebuild",
+        "repair",
+        "restore",
+        "retry",
+        "run",
+        "start",
+    }
 )
 
 
@@ -79,6 +112,137 @@ def _compact_health_items(
     return compact
 
 
+def _runtime_recovery_action(action_kind: Any) -> bool:
+    tokens = {
+        token
+        for token in str(action_kind or "").strip().lower().replace("-", "_").split("_")
+        if token
+    }
+    return bool(tokens & RUNTIME_RECOVERY_ACTION_TOKENS)
+
+
+def _source_todo_items(
+    summary: dict[str, Any] | None,
+    source_items: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    candidates = list(source_items or [])
+    if isinstance(summary, dict):
+        for key in (
+            "items",
+            "first_open_items",
+            "backlog_items",
+            "executable_backlog_items",
+        ):
+            values = summary.get(key)
+            if isinstance(values, list):
+                candidates.extend(item for item in values if isinstance(item, dict))
+    result: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for item in candidates:
+        identity = (
+            str(item.get("todo_id") or "").strip(),
+            str(item.get("text") or "").strip(),
+        )
+        if identity in seen:
+            continue
+        seen.add(identity)
+        result.append(item)
+    return result
+
+
+def build_runtime_capability_user_gate_repair_hint(
+    *,
+    user_todo_summary: dict[str, Any] | None,
+    agent_todo_summary: dict[str, Any] | None,
+    user_todo_source_items: list[dict[str, Any]] | None,
+    agent_todo_source_items: list[dict[str, Any]] | None,
+    agent_id: str | None,
+    available_capabilities: Any,
+) -> dict[str, Any] | None:
+    """Detect an execution request misclassified as an owner decision gate."""
+
+    normalized_agent_id = normalize_todo_claimed_by(agent_id)
+    if not normalized_agent_id:
+        return None
+    agent_items = _source_todo_items(
+        agent_todo_summary,
+        agent_todo_source_items,
+    )
+    agent_items_by_id = {
+        todo_id: item
+        for item in agent_items
+        for todo_id in [normalize_todo_id(item.get("todo_id"))]
+        if todo_id
+    }
+    user_summary = dict(user_todo_summary or {})
+    user_summary["items"] = _source_todo_items(
+        user_todo_summary,
+        user_todo_source_items,
+    )
+    for gate in open_user_gate_todo_items(user_summary):
+        if normalize_todo_global_gate(gate.get("global_gate")):
+            continue
+        blocks_agent = normalize_todo_blocks_agent(gate.get("blocks_agent"))
+        if blocks_agent and blocks_agent != normalized_agent_id:
+            continue
+        if normalize_todo_decision_scope(gate.get("decision_scope")):
+            continue
+        if not _runtime_recovery_action(gate.get("action_kind")):
+            continue
+        target_todo_id = normalize_todo_id(gate.get("unblocks_todo_id"))
+        target = agent_items_by_id.get(target_todo_id)
+        if not target:
+            continue
+        target_owner = normalize_todo_claimed_by(target.get("claimed_by"))
+        if target_owner and target_owner != normalized_agent_id:
+            continue
+        if normalize_todo_required_decision_scopes(
+            target.get("required_decision_scopes")
+        ):
+            continue
+        required_capabilities = normalize_required_capabilities(
+            target.get("required_capabilities")
+        )
+        if not required_capabilities:
+            continue
+        if set(required_capabilities) & CAPABILITY_OWNER_GATE_HINTS:
+            continue
+        if missing_required_capabilities(
+            target,
+            available_capabilities=available_capabilities,
+        ):
+            continue
+        gate_todo_id = normalize_todo_id(gate.get("todo_id"))
+        return {
+            "source": "quota.should-run",
+            "trigger": RUNTIME_CAPABILITY_USER_GATE_REPAIR_TRIGGER,
+            "schema_version": "runtime_capability_user_gate_repair_v0",
+            "recommended_mode": "repair_user_gate_projection",
+            "effective_action": "runtime_user_gate_projection_repair",
+            "blocked_action_scope": "user_gate_projection",
+            "allowed": True,
+            "notify": "DONT_NOTIFY",
+            "reason": (
+                "an execution-shaped user_gate without decision scope links to "
+                "this agent's capability-runnable todo"
+            ),
+            "repair_focus": (
+                "attempt the runtime recovery; on success complete or reclassify "
+                "the user_gate and resume the linked agent todo, otherwise write "
+                "the concrete capability blocker"
+            ),
+            "spend_policy": (
+                "append exactly one heartbeat spend only after the gate projection "
+                "repair or concrete blocker writeback is validated"
+            ),
+            "gate_todo_id": gate_todo_id,
+            "target_todo_id": target_todo_id,
+            "required_capabilities": required_capabilities,
+            "decision_scope_present": False,
+        }
+    return None
+
+
 def build_quota_stall_self_repair_hint(
     item: dict[str, Any],
     *,
@@ -91,8 +255,11 @@ def build_quota_stall_self_repair_hint(
     user_todo_source_items: list[dict[str, Any]] | None = None,
     agent_todo_source_items: list[dict[str, Any]] | None = None,
     standing_decision_authority: dict[str, Any] | None = None,
+    available_capabilities: Any = None,
 ) -> dict[str, Any] | None:
-    coordination = item.get("coordination") if isinstance(item.get("coordination"), dict) else {}
+    coordination = (
+        item.get("coordination") if isinstance(item.get("coordination"), dict) else {}
+    )
     decision_scope_consistency = build_required_decision_scope_consistency(
         agent_todo_summary,
         user_todo_summary,
@@ -107,6 +274,16 @@ def build_quota_stall_self_repair_hint(
     )
     if decision_scope_repair:
         return decision_scope_repair
+    runtime_user_gate_repair = build_runtime_capability_user_gate_repair_hint(
+        user_todo_summary=user_todo_summary,
+        agent_todo_summary=agent_todo_summary,
+        user_todo_source_items=user_todo_source_items,
+        agent_todo_source_items=agent_todo_source_items,
+        agent_id=agent_id,
+        available_capabilities=available_capabilities,
+    )
+    if runtime_user_gate_repair:
+        return runtime_user_gate_repair
 
     control_plane = compact_control_plane_policy(item.get("control_plane"))
     if not control_plane:
@@ -212,4 +389,11 @@ def stall_repair_payload(repair: dict[str, Any] | None) -> dict[str, Any]:
 def stall_repair_suppresses_user_gate_notification(
     repair: dict[str, Any] | None,
 ) -> bool:
-    return bool(repair and repair.get("trigger") == USER_GATE_SCOPE_REPAIR_TRIGGER)
+    return bool(
+        repair
+        and repair.get("trigger")
+        in {
+            USER_GATE_SCOPE_REPAIR_TRIGGER,
+            RUNTIME_CAPABILITY_USER_GATE_REPAIR_TRIGGER,
+        }
+    )

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -130,7 +130,11 @@ def _user_gate_scope_projection_repair_active(payload: dict[str, Any]) -> bool:
     repair = payload.get("stall_self_repair")
     return bool(
         isinstance(repair, dict)
-        and repair.get("trigger") == "user_gate_scope_projection_drift"
+        and repair.get("trigger")
+        in {
+            "user_gate_scope_projection_drift",
+            "runtime_capability_user_gate_overreach",
+        }
     )
 
 
@@ -892,6 +896,12 @@ def _interaction_spend_after_validation(mode: str) -> bool:
 def _interaction_user_reason(payload: dict[str, Any]) -> Any:
     return (
         (
+            payload.get("stall_self_repair", {}).get("reason")
+            if _user_gate_scope_projection_repair_active(payload)
+            and isinstance(payload.get("stall_self_repair"), dict)
+            else None
+        )
+        or (
             payload.get("user_gate_notification_cooldown", {}).get("reason")
             if _user_gate_notification_suppressed(payload)
             else None
@@ -968,7 +978,10 @@ def _build_interaction_user_channel(
         "notify": "NOTIFY"
         if user_required or non_blocking_notice
         else "DONT_NOTIFY"
-        if _user_gate_notification_suppressed(payload)
+        if (
+            _user_gate_notification_suppressed(payload)
+            or _user_gate_scope_projection_repair_active(payload)
+        )
         else heartbeat_recommendation.get("notify", "DONT_NOTIFY"),
     }
     if actions:

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -1568,6 +1568,7 @@ def build_quota_should_run(
                     (agent_identity or {}).get("agent_id")
                 ),
             ),
+            available_capabilities=effective_available_capabilities,
         )
         self_repair_allowed = bool(stall_self_repair and stall_self_repair.get("allowed"))
         normal_delivery_allowed, recovery_allowed, reason = apply_stall_repair_delivery_guard(

--- a/tests/control_plane/test_user_gate_lane_progress.py
+++ b/tests/control_plane/test_user_gate_lane_progress.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+from loopx.control_plane.quota.stall_repair import (
+    build_runtime_capability_user_gate_repair_hint,
+)
+from loopx.control_plane.quota.turn_envelope import build_turn_envelope
 from loopx.control_plane.scheduler import scheduler_hint as scheduler_hint_module
 from loopx.control_plane.scheduler.ack import build_codex_app_scheduler_ack_event
-from loopx.control_plane.quota.turn_envelope import build_turn_envelope
-from loopx.control_plane.scheduler.scheduler_hint import build_scheduler_hint
 from loopx.control_plane.scheduler.execution_context import (
     scheduler_execution_context_for_runtime_profile,
 )
+from loopx.control_plane.scheduler.scheduler_hint import build_scheduler_hint
 from loopx.control_plane.scheduler.state import (
     SCHEDULER_HOST_UPDATE_FAILURE_SCHEMA_VERSION,
 )
@@ -294,6 +297,27 @@ def test_capability_runnable_runtime_recovery_gate_routes_to_agent_repair() -> N
     }
     assert payload["interaction_contract"]["agent_channel"]["must_attempt"] is True
     assert "response_plan" not in payload["interaction_contract"]
+
+
+def test_empty_authoritative_user_source_ignores_stale_summary_gate() -> None:
+    status = _runtime_recovery_gate_status()
+    item = status["attention_queue"]["items"][0]
+
+    repair = build_runtime_capability_user_gate_repair_hint(
+        user_todo_summary=item["user_todos"],
+        agent_todo_summary=item["agent_todos"],
+        user_todo_source_items=[],
+        agent_todo_source_items=item["agent_todos"]["items"],
+        agent_id=AGENT_ID,
+        available_capabilities=[
+            "shell",
+            "filesystem_write",
+            "network",
+            "benchmark_runner",
+        ],
+    )
+
+    assert repair is None
 
 
 def test_runtime_recovery_gate_with_decision_scope_remains_owner_gate() -> None:

--- a/tests/control_plane/test_user_gate_lane_progress.py
+++ b/tests/control_plane/test_user_gate_lane_progress.py
@@ -218,6 +218,122 @@ def test_blocking_user_gate_backs_off_instead_of_polling_as_active_work() -> Non
     assert next_hint["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=60"
 
 
+def _runtime_recovery_gate_status(
+    *,
+    decision_scope: str | None = None,
+    required_capabilities: list[str] | None = None,
+) -> dict:
+    target = quota_todo_item(
+        todo_id="todo_runtime_recovery",
+        status="blocked",
+        text="[P0] Restore the benchmark runtime and continue.",
+        claimed_by=AGENT_ID,
+        action_kind="repair_benchmark_runtime",
+        required_capabilities=required_capabilities
+        or ["shell", "filesystem_write", "network", "benchmark_runner"],
+    )
+    gate_metadata = {
+        "unblocks_todo_id": target["todo_id"],
+    }
+    if decision_scope:
+        gate_metadata["decision_scope"] = decision_scope
+    gate = quota_todo_item(
+        todo_id="todo_restore_runtime",
+        role="user",
+        status="open",
+        task_class="user_gate",
+        text="[P0-user] Restore the local runtime endpoint.",
+        action_kind="restore_local_runtime_endpoint",
+        blocks_agent=AGENT_ID,
+        **gate_metadata,
+    )
+    return quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        recommended_action="Restore the benchmark runtime and continue.",
+        agent_todos=quota_todo_summary(
+            [target],
+            role="agent",
+            claim_scope_agent_id=AGENT_ID,
+        ),
+        user_todos=quota_todo_summary([gate], role="user"),
+        quota_state="operator_gate",
+        coordination={
+            "agent_model": "peer_v1",
+            "registered_agents": [AGENT_ID],
+        },
+    )
+
+
+def test_capability_runnable_runtime_recovery_gate_routes_to_agent_repair() -> None:
+    payload = build_quota_should_run(
+        _runtime_recovery_gate_status(),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        available_capabilities=[
+            "shell",
+            "filesystem_write",
+            "network",
+            "benchmark_runner",
+        ],
+        scheduler_execution_context=APP_CONTEXT,
+    )
+
+    repair = payload["stall_self_repair"]
+    assert repair["trigger"] == "runtime_capability_user_gate_overreach"
+    assert repair["gate_todo_id"] == "todo_restore_runtime"
+    assert repair["target_todo_id"] == "todo_runtime_recovery"
+    assert payload["decision"] == "self_repair"
+    assert payload["self_repair_allowed"] is True
+    assert payload["requires_user_action"] is False
+    assert payload["interaction_contract"]["mode"] == "control_plane_self_repair"
+    assert payload["interaction_contract"]["user_channel"] == {
+        "action_required": False,
+        "notify": "DONT_NOTIFY",
+        "reason": repair["reason"],
+    }
+    assert payload["interaction_contract"]["agent_channel"]["must_attempt"] is True
+    assert "response_plan" not in payload["interaction_contract"]
+
+
+def test_runtime_recovery_gate_with_decision_scope_remains_owner_gate() -> None:
+    payload = build_quota_should_run(
+        _runtime_recovery_gate_status(
+            decision_scope="direction:action:runtime_recovery",
+        ),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        available_capabilities=[
+            "shell",
+            "filesystem_write",
+            "network",
+            "benchmark_runner",
+        ],
+        scheduler_execution_context=APP_CONTEXT,
+    )
+
+    assert "stall_self_repair" not in payload
+    assert payload["interaction_contract"]["mode"] == "user_gate"
+    assert payload["interaction_contract"]["user_channel"]["action_required"] is True
+    assert (
+        payload["interaction_contract"]["response_plan"]["kind"] == "surface_user_gate"
+    )
+
+
+def test_runtime_recovery_gate_with_owner_capability_remains_owner_gate() -> None:
+    payload = build_quota_should_run(
+        _runtime_recovery_gate_status(required_capabilities=["credentials"]),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        available_capabilities=["credentials"],
+        scheduler_execution_context=APP_CONTEXT,
+    )
+
+    assert "stall_self_repair" not in payload
+    assert payload["interaction_contract"]["mode"] == "user_gate"
+    assert payload["interaction_contract"]["user_channel"]["action_required"] is True
+
+
 def test_acked_human_gate_advances_despite_unrelated_historical_host_failure(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- detect execution-shaped user gates that lack decision scope and link to the current agent's capability-runnable todo
- route only those malformed gates to bounded control-plane self-repair without notifying the user
- preserve owner routing for scoped decisions, global gates, owner-held capabilities, and unavailable runtime capabilities

## Validation
- `pytest -q tests/control_plane/test_user_gate_lane_progress.py tests/control_plane/test_capability_gate.py` (18 passed)
- focused decision-scope, monitor-replan, scheduler-interaction, and quota projection suite (53 passed)
- `loopx canary premerge --from-git-diff` (17 selected checks passed; no failures, skips, warnings, or manual holds)
- `ruff check` on changed Python surfaces
- public/private boundary scan clean

## Scope
Built-in `control_plane/quota` repair classification only. This does not grant capabilities or authority; it consumes observed capabilities and keeps credentials/production access owner-held.