### PR TITLE
Select proxy-compatible package sources for proxied SkillsBench runs

### DIFF
--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -39,12 +39,18 @@ Optional env:
   SKILLSBENCH_DOCKER_API_VERSION       Remote Docker daemon API version passed
                                        to Docker CLI/Compose; default auto
   SKILLSBENCH_DOCKER_APT_SOURCE_MODE   Staged Dockerfile apt sources: mirror
-                                       (default) or primary
+                                       or primary. When unset, proxy egress
+                                       selects primary and an explicit
+                                       no-proxy run selects mirror.
   SKILLSBENCH_DOCKER_APT_TRANSPORT_MODE
                                        Staged apt transport: default or
-                                       proxy-compatible
-  SKILLSBENCH_DOCKER_PIP_INDEX_MODE    Staged Dockerfile pip index: mirror
-                                       (default) or primary
+                                       proxy-compatible. When unset, proxy
+                                       egress selects proxy-compatible and an
+                                       explicit no-proxy run selects default.
+  SKILLSBENCH_DOCKER_PIP_INDEX_MODE    Staged Dockerfile pip index: mirror or
+                                       primary. When unset, proxy egress
+                                       selects primary and an explicit
+                                       no-proxy run selects mirror.
   SKILLSBENCH_DOCKER_PIP_BUILD_MODE    Staged Dockerfile pip build mode:
                                        isolated (default) or no-isolation
   SKILLSBENCH_ROUTE                    Route, default codex-cli-goal-baseline
@@ -244,9 +250,30 @@ allow_staged_bootstrap_repair_run="${SKILLSBENCH_ALLOW_STAGED_BOOTSTRAP_REPAIR_R
 setup_only_public_preflight="${SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT:-0}"
 benchmark_egress_proxy_mode="${SKILLSBENCH_BENCHMARK_EGRESS_PROXY_MODE:-require}"
 benchmark_egress_no_proxy="${SKILLSBENCH_BENCHMARK_EGRESS_NO_PROXY:-}"
-docker_apt_source_mode="${SKILLSBENCH_DOCKER_APT_SOURCE_MODE:-mirror}"
-docker_apt_transport_mode="${SKILLSBENCH_DOCKER_APT_TRANSPORT_MODE:-default}"
-docker_pip_index_mode="${SKILLSBENCH_DOCKER_PIP_INDEX_MODE:-mirror}"
+docker_apt_source_mode="${SKILLSBENCH_DOCKER_APT_SOURCE_MODE:-}"
+docker_apt_transport_mode="${SKILLSBENCH_DOCKER_APT_TRANSPORT_MODE:-}"
+docker_pip_index_mode="${SKILLSBENCH_DOCKER_PIP_INDEX_MODE:-}"
+if [[ -z "$docker_apt_source_mode" ]]; then
+  if [[ "$benchmark_egress_proxy_mode" == "off" ]]; then
+    docker_apt_source_mode="mirror"
+  else
+    docker_apt_source_mode="primary"
+  fi
+fi
+if [[ -z "$docker_apt_transport_mode" ]]; then
+  if [[ "$benchmark_egress_proxy_mode" == "off" ]]; then
+    docker_apt_transport_mode="default"
+  else
+    docker_apt_transport_mode="proxy-compatible"
+  fi
+fi
+if [[ -z "$docker_pip_index_mode" ]]; then
+  if [[ "$benchmark_egress_proxy_mode" == "off" ]]; then
+    docker_pip_index_mode="mirror"
+  else
+    docker_pip_index_mode="primary"
+  fi
+fi
 docker_pip_build_mode="${SKILLSBENCH_DOCKER_PIP_BUILD_MODE:-isolated}"
 product_mode_soft_verify_policy="${SKILLSBENCH_PRODUCT_MODE_SOFT_VERIFY_POLICY:-}"
 remote_command_file_bridge_probe_command="${SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_COMMAND:-}"

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -470,6 +470,82 @@ def test_launcher_wires_bounded_proxy_compatible_apt_transport(
     assert "--docker-apt-transport-mode proxy-compatible" in proc.stdout
 
 
+def test_launcher_defaults_to_proxy_compatible_primary_sources_with_required_proxy(
+    tmp_path: Path,
+) -> None:
+    env = _base_env(tmp_path)
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "default-proxy-apt"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+
+    assert "benchmark_egress_proxy_mode=require" in proc.stdout
+    assert "docker_apt_source_mode=primary" in proc.stdout
+    assert "docker_apt_transport_mode=proxy-compatible" in proc.stdout
+    assert "docker_pip_index_mode=primary" in proc.stdout
+    assert "--docker-apt-source-mode primary" in proc.stdout
+    assert "--docker-apt-transport-mode proxy-compatible" in proc.stdout
+    assert "--docker-pip-index-mode primary" in proc.stdout
+
+
+def test_launcher_defaults_to_mirror_sources_and_standard_apt_when_proxy_is_off(
+    tmp_path: Path,
+) -> None:
+    env = _base_env(tmp_path)
+    env["SKILLSBENCH_BENCHMARK_EGRESS_PROXY_MODE"] = "off"
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "no-proxy-apt"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+
+    assert "benchmark_egress_proxy_mode=off" in proc.stdout
+    assert "docker_apt_source_mode=mirror" in proc.stdout
+    assert "docker_apt_transport_mode=default" in proc.stdout
+    assert "docker_pip_index_mode=mirror" in proc.stdout
+    assert "--docker-apt-source-mode mirror" in proc.stdout
+    assert "--docker-apt-transport-mode default" in proc.stdout
+    assert "--docker-pip-index-mode mirror" in proc.stdout
+
+
+def test_launcher_preserves_explicit_package_source_overrides_with_required_proxy(
+    tmp_path: Path,
+) -> None:
+    env = _base_env(tmp_path)
+    env["SKILLSBENCH_DOCKER_APT_SOURCE_MODE"] = "mirror"
+    env["SKILLSBENCH_DOCKER_APT_TRANSPORT_MODE"] = "default"
+    env["SKILLSBENCH_DOCKER_PIP_INDEX_MODE"] = "mirror"
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "explicit-apt"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+
+    assert "benchmark_egress_proxy_mode=require" in proc.stdout
+    assert "docker_apt_source_mode=mirror" in proc.stdout
+    assert "docker_apt_transport_mode=default" in proc.stdout
+    assert "docker_pip_index_mode=mirror" in proc.stdout
+    assert "--docker-apt-source-mode mirror" in proc.stdout
+    assert "--docker-apt-transport-mode default" in proc.stdout
+    assert "--docker-pip-index-mode mirror" in proc.stdout
+
+
 def test_launcher_rejects_unbounded_apt_transport_mode(tmp_path: Path) -> None:
     env = _base_env(tmp_path)
     env["SKILLSBENCH_DOCKER_APT_TRANSPORT_MODE"] = "private-mode"


### PR DESCRIPTION
## Summary
- when benchmark egress proxying is enabled and no explicit override is supplied, select primary apt/pip sources plus the existing proxy-compatible apt transport
- keep explicit no-proxy launches on mirror apt/pip sources plus the standard apt transport
- preserve explicit operator overrides in every mode

## Validation
- focused launcher/setup/Dockerfile tests: 81 passed
- exact-source official14 setup-only preflight with proxied primary apt/pip sources: passed after environment materialization; no agent or verifier invoked; cleanup completed
- mirror-source preflight reproduced the prior apt HTTP 403
- primary apt advanced beyond apt and isolated the subsequent mirror pip HTTP 403
- public/private boundary scan clean

## Boundary
No task text, raw benchmark output, trajectories, verifier material, credentials, private endpoints, local paths, or generated logs are included.