### PR TITLE
Stop SkillsBench turns on fatal provider failures

### DIFF
--- a/examples/skillsbench-post-run-debug-gate-smoke.py
+++ b/examples/skillsbench-post-run-debug-gate-smoke.py
@@ -212,9 +212,145 @@ def test_failed_turn_receipts_qualify_direct_lifecycle_success() -> None:
     )
 
 
+def test_fatal_provider_turn_has_complete_capacity_blocked_closeout() -> None:
+    compact = {
+        "benchmark_id": "skillsbench@1.1",
+        "product_mode": True,
+        "official_score_status": "missing",
+        "score_failure_attribution": (
+            "skillsbench_host_local_acp_codex_exec_failed_codex_usage_limit"
+        ),
+        "failure_attribution_labels": [
+            "skillsbench_host_local_acp_codex_exec_failed_codex_usage_limit"
+        ],
+        "product_mode_lifecycle_contract": {
+            "required": True,
+            "satisfied": False,
+            "closeout_satisfied": False,
+            "state_read_count": 0,
+            "state_write_count": 0,
+        },
+        "loopx_turn_executions": [
+            {
+                "schema_version": "loopx_turn_execution_v0",
+                "mode": "run_once",
+                "status": "failed",
+                "result_kind": "host_failure",
+                "validation": {},
+                "receipt": {
+                    "status": "failed",
+                    "failed_phase": "host_execute",
+                },
+                "effects": {
+                    "host_invoked": True,
+                    "state_written": False,
+                    "quota_spent": False,
+                    "scheduler_acknowledged": False,
+                },
+            }
+        ],
+        "interaction_counters": {
+            "host_local_acp_codex_exec_failure_trace_present": True,
+            "host_local_acp_codex_exec_failure_trace_count": 1,
+            "host_local_acp_codex_exec_fatal_failure_trace_count": 1,
+            "host_local_acp_codex_exec_recoverable_failure_trace_count": 0,
+            "host_local_acp_codex_exec_failure_categories": [
+                "codex_usage_limit"
+            ],
+            "host_local_acp_codex_exec_failure_category": "codex_usage_limit",
+            "product_mode_typed_repair_terminal": True,
+            "product_mode_typed_repair_terminal_receipt_consistent": True,
+            "product_mode_typed_repair_terminal_reason": (
+                "nonrecoverable_turn_host_failure"
+            ),
+        },
+        "case_event_timeline": {
+            "schema_version": "skillsbench_case_event_timeline_v0",
+            "source": "compact_public_signals",
+            "raw_material_recorded": False,
+            "events": [
+                {
+                    "phase": "goal_init",
+                    "event": "case_goal_state_init",
+                    "status": "satisfied",
+                },
+                {
+                    "phase": "controller",
+                    "event": "controller_decision_loop",
+                    "status": "stopped_after_fatal_provider_failure",
+                    "action_decision_count": 2,
+                    "initial_prompt_count": 1,
+                    "followup_prompt_count": 0,
+                    "stop_decision_count": 1,
+                },
+                {
+                    "phase": "lifecycle",
+                    "event": "orchestrated_loopx_lifecycle",
+                    "status": "not_started",
+                    "state_read_count": 0,
+                    "state_write_count": 0,
+                },
+                {
+                    "phase": "bridge",
+                    "event": "remote_command_bridge_consumption",
+                    "status": "satisfied",
+                },
+                {
+                    "phase": "activity",
+                    "event": "task_facing_activity",
+                    "status": "missing_agent_operation_trace",
+                    "agent_bridge_task_facing_operation_count": 0,
+                },
+                {
+                    "phase": "closeout",
+                    "event": "agent_bridge_closeout",
+                    "status": "missing",
+                },
+                {
+                    "phase": "scoring",
+                    "event": "official_score_closeout",
+                    "status": "missing",
+                    "official_score_passed": None,
+                },
+            ],
+        },
+    }
+
+    gate = build_skillsbench_post_run_debug_gate(compact)
+
+    assert gate["packet_complete"] is True, gate
+    assert gate["case_closeout_complete"] is True, gate
+    assert gate["normal_progress_allowed"] is False, gate
+    assert gate["next_case_gate"] == "blocked_external_provider_capacity", gate
+    assert gate["next_action"] == (
+        "retry_same_case_after_host_provider_capacity"
+    ), gate
+    assert gate["attribution_layer"] == "host_provider", gate
+    assert gate["first_blocker"] == (
+        "skillsbench_host_local_acp_codex_exec_failed_codex_usage_limit"
+    ), gate
+    assert gate["loopx_lifecycle"]["direct_lifecycle_satisfied"] is False, gate
+    assert gate["loopx_lifecycle"]["satisfied"] is True, gate
+    assert gate["loopx_lifecycle"]["closeout_status"] == (
+        "host_provider_failure_terminal"
+    ), gate
+    transaction = gate["loopx_turn_transaction"]
+    assert transaction["status"] == "host_failure_terminal", transaction
+    assert transaction["progress_blocked"] is False, transaction
+    assert transaction["recovery_status"] == (
+        "retry_after_provider_capacity"
+    ), transaction
+    assert transaction["execution_count"] == 1, transaction
+    assert transaction["host_failure_count"] == 1, transaction
+    assert transaction["committed_count"] == 0, transaction
+    assert transaction["state_written_count"] == 0, transaction
+    assert transaction["quota_spent_count"] == 0, transaction
+
+
 def main() -> None:
     test_countable_zero_keeps_solution_attribution()
     test_failed_turn_receipts_qualify_direct_lifecycle_success()
+    test_fatal_provider_turn_has_complete_capacity_blocked_closeout()
     print("skillsbench-post-run-debug-gate-smoke: ok")
 
 

--- a/examples/skillsbench-typed-repair-smoke.py
+++ b/examples/skillsbench-typed-repair-smoke.py
@@ -74,6 +74,21 @@ def committed_turn_execution() -> dict[str, object]:
     }
 
 
+def fatal_host_turn_execution() -> dict[str, object]:
+    return {
+        "status": "failed",
+        "validation": {},
+        "receipt": {
+            "status": "failed",
+            "failed_phase": "host_execute",
+        },
+        "effects": {
+            "state_written": False,
+            "quota_spent": False,
+        },
+    }
+
+
 def write_turn_trace(
     trace_dir: Path,
     index: int,
@@ -97,6 +112,32 @@ def write_turn_trace(
         },
     }
     (trace_dir / f"turn-{index}.compact.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+
+def write_fatal_codex_trace(trace_dir: Path, index: int) -> None:
+    payload = {
+        "schema_version": "skillsbench_host_local_acp_relay_public_trace_v0",
+        "trace_kind": "codex_exec_process_failure",
+        "codex_exec_process": {
+            "failure_category": "codex_usage_limit",
+            "recoverable_turn_failure": False,
+        },
+        "boundary": {
+            key: False
+            for key in (
+                "raw_task_text_recorded",
+                "raw_trajectory_recorded",
+                "raw_stdout_recorded",
+                "raw_stderr_recorded",
+                "credential_values_recorded",
+                "host_paths_recorded",
+                "remote_paths_recorded",
+            )
+        },
+    }
+    (trace_dir / f"codex-failure-{index}.compact.json").write_text(
         json.dumps(payload), encoding="utf-8"
     )
 
@@ -321,6 +362,61 @@ def test_turn_recovery_controller_stops_or_continues_from_receipts() -> None:
         "failed_turn_transaction_has_durable_effects"
     )
 
+    fatal_trace = base_trace()
+    fatal_trace["loopx_turn_executions"] = [fatal_host_turn_execution()]
+    fatal_trace.update(
+        {
+            "host_local_acp_codex_exec_failure_trace_present": True,
+            "host_local_acp_codex_exec_failure_trace_count": 1,
+            "host_local_acp_codex_exec_fatal_failure_trace_count": 1,
+            "host_local_acp_codex_exec_recoverable_failure_trace_count": 0,
+            "host_local_acp_codex_exec_failure_categories": [
+                "codex_usage_limit"
+            ],
+            "host_local_acp_codex_exec_failure_category": "codex_usage_limit",
+        }
+    )
+    checkpoint = skillsbench_turn_recovery_checkpoint(fatal_trace)
+    assert checkpoint["nonrecoverable_host_failure"] is True, checkpoint
+    assert checkpoint["nonrecoverable_failure_category"] == "codex_usage_limit"
+    decision = advance_skillsbench_typed_repair_controller(
+        fatal_trace,
+        agent_round=1,
+        scheduled_round=2,
+        max_rounds=8,
+        task_instruction_sent=True,
+    )
+    assert decision == {
+        "action": "stop",
+        "last_decision": "stop_after_nonrecoverable_turn_host_failure",
+    }, decision
+    assert fatal_trace["product_mode_typed_repair_terminal_reason"] == (
+        "nonrecoverable_turn_host_failure"
+    )
+    assert fatal_trace[
+        "product_mode_typed_repair_terminal_failure_category"
+    ] == "codex_usage_limit"
+
+    recoverable_trace = base_trace()
+    recoverable_trace["loopx_turn_executions"] = [fatal_host_turn_execution()]
+    recoverable_trace.update(
+        {
+            "host_local_acp_codex_exec_failure_trace_present": True,
+            "host_local_acp_codex_exec_failure_trace_count": 1,
+            "host_local_acp_codex_exec_fatal_failure_trace_count": 0,
+            "host_local_acp_codex_exec_recoverable_failure_trace_count": 1,
+            "host_local_acp_codex_exec_failure_categories": [
+                "transport_interrupted"
+            ],
+            "host_local_acp_codex_exec_failure_category": (
+                "transport_interrupted"
+            ),
+        }
+    )
+    checkpoint = skillsbench_turn_recovery_checkpoint(recoverable_trace)
+    assert checkpoint["nonrecoverable_host_failure"] is False, checkpoint
+    assert checkpoint["nonrecoverable_failure_category"] == "", checkpoint
+
 
 def test_turn_blind_controller_consumes_recovery_receipts() -> None:
     trace = {
@@ -393,6 +489,36 @@ def test_turn_blind_controller_consumes_recovery_receipts() -> None:
                 "stop_after_loopx_turn_commit"
             ), committed_trace
             assert committed_trace.get("product_mode_typed_repair_pending") is not True
+
+        fatal_trace = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0",
+            "route": "loopx-turn-agent-cli",
+            "round_rewards": [],
+        }
+        with tempfile.TemporaryDirectory(prefix="turn-fatal-controller-") as tmp:
+            trace_dir = Path(tmp)
+            user = _build_blind_loop_user(
+                route="loopx-turn-agent-cli",
+                max_rounds=16,
+                trace=fatal_trace,
+                plan={
+                    "route": "loopx-turn-agent-cli",
+                    "host_local_acp_relay_trace_dir": str(trace_dir),
+                    "runner_prerequisites": {},
+                },
+            )
+            assert asyncio.run(user.run(0, "Fix the workbook.")) is not None
+            write_fatal_codex_trace(trace_dir, 1)
+            write_turn_trace(trace_dir, 1, fatal_host_turn_execution())
+            assert asyncio.run(
+                user.run(1, "Fix the workbook.", round_result)
+            ) is None
+            assert fatal_trace["last_decision"] == (
+                "stop_after_nonrecoverable_turn_host_failure"
+            ), fatal_trace
+            assert fatal_trace["controller_action_decisions"] == 2, fatal_trace
+            assert fatal_trace.get("followup_prompt_count", 0) == 0, fatal_trace
+            assert len(fatal_trace["loopx_turn_executions"]) == 1, fatal_trace
 
 
 def test_unchanged_frontier_has_typed_terminal_receipt() -> None:

--- a/loopx/benchmark_adapters/skillsbench_acp_failure_policy.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_failure_policy.py
@@ -43,6 +43,52 @@ def recoverable_codex_turn_failure_message(category: str) -> str:
     )
 
 
+def nonrecoverable_codex_turn_failure_category(
+    counters: Mapping[str, Any],
+) -> str:
+    """Return the first typed fatal Codex category from public relay evidence."""
+
+    failure_count = _count(
+        counters,
+        "host_local_acp_codex_exec_failure_trace_count",
+    )
+    fatal_count = _count(
+        counters,
+        "host_local_acp_codex_exec_fatal_failure_trace_count",
+    )
+    if (
+        counters.get("host_local_acp_codex_exec_failure_trace_present") is not True
+        or failure_count == 0
+        or fatal_count == 0
+    ):
+        return ""
+
+    categories: list[str] = []
+    raw_categories = counters.get(
+        "host_local_acp_codex_exec_failure_categories"
+    )
+    if isinstance(raw_categories, list):
+        categories.extend(
+            str(category)[:120]
+            for category in raw_categories
+            if isinstance(category, str) and category
+        )
+    first_category = counters.get(
+        "host_local_acp_codex_exec_failure_category"
+    )
+    if (
+        isinstance(first_category, str)
+        and first_category
+        and first_category not in categories
+    ):
+        categories.insert(0, first_category[:120])
+
+    for category in categories:
+        if category not in RECOVERABLE_CODEX_TURN_FAILURE_CATEGORIES:
+            return category
+    return ""
+
+
 def recoverable_transport_after_bridge_attempt(
     counters: Mapping[str, Any],
     *,

--- a/loopx/benchmark_adapters/skillsbench_typed_repair.py
+++ b/loopx/benchmark_adapters/skillsbench_typed_repair.py
@@ -10,6 +10,10 @@ from loopx.control_plane.turn_driver.transaction import (
     loopx_turn_execution_recovery_required,
 )
 
+from .skillsbench_acp_failure_policy import (
+    nonrecoverable_codex_turn_failure_category,
+)
+
 
 SKILLSBENCH_TYPED_REPAIR_POLICY_ID = "one_typed_repair_per_frontier_v0"
 SKILLSBENCH_TYPED_REPAIR_SNAPSHOT_SCHEMA_VERSION = (
@@ -47,6 +51,7 @@ _TYPED_REPAIR_TEXT_FIELDS = (
     "product_mode_typed_repair_policy_id",
     "product_mode_typed_repair_trigger_kind",
     "product_mode_typed_repair_terminal_reason",
+    "product_mode_typed_repair_terminal_failure_category",
 )
 
 
@@ -106,11 +111,30 @@ def skillsbench_turn_recovery_checkpoint(
         if isinstance(latest.get("validation"), Mapping)
         else {}
     )
+    receipt = (
+        latest.get("receipt")
+        if isinstance(latest.get("receipt"), Mapping)
+        else {}
+    )
+    nonrecoverable_category = nonrecoverable_codex_turn_failure_category(
+        trace
+    )
+    nonrecoverable_host_failure = bool(
+        latest
+        and latest.get("status") == "failed"
+        and receipt.get("failed_phase") == "host_execute"
+        and nonrecoverable_category
+        and not loopx_turn_execution_has_durable_effects(latest)
+    )
     counts = _turn_outcome_counts(trace)
     return {
         "schema_version": "skillsbench_turn_recovery_checkpoint_v0",
         "observed": bool(latest),
         "repair_required": recovery_required,
+        "nonrecoverable_host_failure": nonrecoverable_host_failure,
+        "nonrecoverable_failure_category": (
+            nonrecoverable_category if nonrecoverable_host_failure else ""
+        ),
         "failed_transaction_with_durable_effects": (
             failed_transaction_with_durable_effects
         ),
@@ -451,6 +475,19 @@ def advance_skillsbench_typed_repair_controller(
             "action": "stop",
             "last_decision": "stop_after_failed_turn_transaction_with_durable_effects",
         }
+    if checkpoint.get("nonrecoverable_host_failure") is True:
+        record_skillsbench_typed_repair_terminal(
+            trace,
+            agent_round=agent_round,
+            reason="nonrecoverable_turn_host_failure",
+            failure_category=str(
+                checkpoint.get("nonrecoverable_failure_category") or ""
+            ),
+        )
+        return {
+            "action": "stop",
+            "last_decision": "stop_after_nonrecoverable_turn_host_failure",
+        }
     if checkpoint.get("repair_required") is not True:
         return {}
     if not begin_skillsbench_typed_repair(
@@ -585,6 +622,7 @@ def record_skillsbench_typed_repair_terminal(
     *,
     agent_round: int,
     reason: str,
+    failure_category: str = "",
 ) -> dict[str, Any]:
     receipt = {
         "schema_version": SKILLSBENCH_TYPED_REPAIR_TERMINAL_RECEIPT_SCHEMA_VERSION,
@@ -607,10 +645,19 @@ def record_skillsbench_typed_repair_terminal(
         "terminal_receipt_consistent": True,
         "raw_material_recorded": False,
     }
+    compact_failure_category = public_safe_compact_text(
+        failure_category,
+        limit=120,
+    )
+    if compact_failure_category:
+        receipt["failure_category"] = compact_failure_category
     trace["product_mode_typed_repair_pending"] = False
     trace["product_mode_typed_repair_terminal"] = True
     trace["product_mode_typed_repair_terminal_round"] = agent_round
     trace["product_mode_typed_repair_terminal_reason"] = reason[:120]
+    trace["product_mode_typed_repair_terminal_failure_category"] = (
+        compact_failure_category
+    )
     trace["product_mode_typed_repair_terminal_receipt"] = receipt
     trace["product_mode_typed_repair_terminal_receipt_consistent"] = True
     return receipt

--- a/loopx/benchmarks/read_models/skillsbench_post_run_debug.py
+++ b/loopx/benchmarks/read_models/skillsbench_post_run_debug.py
@@ -16,6 +16,9 @@ from ...control_plane.turn_driver.transaction import (
     loopx_turn_execution_committed,
     loopx_turn_execution_has_durable_effects,
 )
+from ...benchmark_adapters.skillsbench_acp_failure_policy import (
+    nonrecoverable_codex_turn_failure_category,
+)
 
 MAX_SKILLSBENCH_DEBUG_LIST_ITEMS = 5
 
@@ -56,6 +59,7 @@ def _skillsbench_turn_transaction_outcome(run: dict[str, Any]) -> dict[str, Any]
     state_written_count = 0
     quota_spent_count = 0
     failed_transaction_with_durable_effect_count = 0
+    host_failure_count = 0
     for execution in executions:
         validation = (
             execution.get("validation")
@@ -80,6 +84,10 @@ def _skillsbench_turn_transaction_outcome(run: dict[str, Any]) -> dict[str, Any]
             or receipt.get("failed_phase") == "validation"
             or execution.get("status") == "validation_failed"
         )
+        host_failure = bool(
+            execution.get("status") == "failed"
+            and receipt.get("failed_phase") == "host_execute"
+        )
         recovery_kind = public_safe_compact_text(
             validation.get("recovery_kind"),
             limit=80,
@@ -93,12 +101,41 @@ def _skillsbench_turn_transaction_outcome(run: dict[str, Any]) -> dict[str, Any]
         failed_transaction_with_durable_effect_count += int(
             validation_failed and loopx_turn_execution_has_durable_effects(execution)
         )
+        host_failure_count += int(host_failure)
 
     execution_count = len(executions)
+    counters = (
+        run.get("interaction_counters")
+        if isinstance(run.get("interaction_counters"), dict)
+        else {}
+    )
+    nonrecoverable_failure_category = (
+        nonrecoverable_codex_turn_failure_category(counters)
+    )
+    terminal_host_failure = bool(
+        host_failure_count > 0
+        and nonrecoverable_failure_category
+        and state_written_count == 0
+        and quota_spent_count == 0
+        and counters.get("product_mode_typed_repair_terminal") is True
+        and counters.get(
+            "product_mode_typed_repair_terminal_receipt_consistent"
+        )
+        is True
+        and counters.get("product_mode_typed_repair_terminal_reason")
+        == "nonrecoverable_turn_host_failure"
+    )
     if failed_transaction_with_durable_effect_count:
         status = "inconsistent_failed_transaction_has_durable_effects"
         causal_consistency = "violated"
         first_blocker = "failed_turn_transaction_has_durable_effects"
+    elif terminal_host_failure:
+        status = "host_failure_terminal"
+        causal_consistency = "terminal_host_failure_without_durable_effects"
+        first_blocker = (
+            "skillsbench_host_local_acp_codex_exec_failed_"
+            f"{nonrecoverable_failure_category}"
+        )
     elif committed_count == execution_count:
         status = "committed"
         causal_consistency = "committed_effects_observed"
@@ -112,7 +149,13 @@ def _skillsbench_turn_transaction_outcome(run: dict[str, Any]) -> dict[str, Any]
         causal_consistency = "uncommitted_result_requires_recovery"
         first_blocker = "loopx_turn_uncommitted"
 
-    if repair_required_count:
+    if terminal_host_failure:
+        recovery_status = (
+            "retry_after_provider_capacity"
+            if nonrecoverable_failure_category == "codex_usage_limit"
+            else "terminal_host_failure"
+        )
+    elif repair_required_count:
         recovery_status = "repair_required"
     elif replan_required_count:
         recovery_status = "replan_required"
@@ -127,7 +170,9 @@ def _skillsbench_turn_transaction_outcome(run: dict[str, Any]) -> dict[str, Any]
         "status": status,
         "causal_consistency": causal_consistency,
         "recovery_status": recovery_status,
-        "progress_blocked": committed_count != execution_count,
+        "progress_blocked": (
+            committed_count != execution_count and not terminal_host_failure
+        ),
         "first_blocker": first_blocker,
         "execution_count": execution_count,
         "committed_count": committed_count,
@@ -139,6 +184,11 @@ def _skillsbench_turn_transaction_outcome(run: dict[str, Any]) -> dict[str, Any]
         "quota_spent_count": quota_spent_count,
         "failed_transaction_with_durable_effect_count": (
             failed_transaction_with_durable_effect_count
+        ),
+        "host_failure_count": host_failure_count,
+        "terminal_host_failure": terminal_host_failure,
+        "nonrecoverable_host_failure_category": (
+            nonrecoverable_failure_category
         ),
     }
 
@@ -281,14 +331,19 @@ def build_skillsbench_post_run_debug_gate(
     turn_transaction_blocks_progress = bool(
         turn_transaction.get("progress_blocked") is True
     )
+    terminal_host_provider_failure = bool(
+        turn_transaction.get("terminal_host_failure") is True
+    )
     qualified_lifecycle_satisfied = bool(
-        effective_lifecycle_satisfied and not turn_transaction_blocks_progress
+        (effective_lifecycle_satisfied or terminal_host_provider_failure)
+        and not turn_transaction_blocks_progress
     )
-    qualified_closeout_status = (
-        "turn_transaction_repair_required"
-        if turn_transaction_blocks_progress
-        else closeout_status
-    )
+    if turn_transaction_blocks_progress:
+        qualified_closeout_status = "turn_transaction_repair_required"
+    elif terminal_host_provider_failure:
+        qualified_closeout_status = "host_provider_failure_terminal"
+    else:
+        qualified_closeout_status = closeout_status
     case_closeout_complete = bool(
         (not missing_fields and official_passed is True and verifier_artifact_success)
         or (
@@ -298,6 +353,10 @@ def build_skillsbench_post_run_debug_gate(
             and not agent_operation_trace_missing
             and not (official_status == "missing" and runner_recovery_blocked)
         )
+        or (
+            not missing_fields
+            and terminal_host_provider_failure
+        )
     )
 
     first_blocker = "none"
@@ -305,6 +364,15 @@ def build_skillsbench_post_run_debug_gate(
     if missing_fields:
         attribution_layer = "incomplete_public_debug_packet"
         first_blocker = missing_fields[0]
+    elif terminal_host_provider_failure:
+        attribution_layer = "host_provider"
+        first_blocker = (
+            public_safe_compact_text(
+                turn_transaction.get("first_blocker"),
+                limit=140,
+            )
+            or "skillsbench_host_provider_failure"
+        )
     elif turn_transaction_blocks_progress:
         attribution_layer = "loopx_turn_transaction"
         first_blocker = (
@@ -375,6 +443,16 @@ def build_skillsbench_post_run_debug_gate(
     elif not case_closeout_complete:
         next_case_gate = "blocked_incomplete_case_closeout"
         next_action = "record_or_repair_case_closeout_before_next_case"
+    elif terminal_host_provider_failure:
+        if (
+            turn_transaction.get("nonrecoverable_host_failure_category")
+            == "codex_usage_limit"
+        ):
+            next_case_gate = "blocked_external_provider_capacity"
+            next_action = "retry_same_case_after_host_provider_capacity"
+        else:
+            next_case_gate = "open_with_attribution"
+            next_action = "repair_host_provider_before_rerunning_same_case"
     elif turn_transaction_blocks_progress:
         next_case_gate = "blocked_turn_transaction_repair"
         next_action = "repair_loopx_turn_transaction_before_next_matched_case"
@@ -400,6 +478,7 @@ def build_skillsbench_post_run_debug_gate(
             packet_complete
             and case_closeout_complete
             and not turn_transaction_blocks_progress
+            and not terminal_host_provider_failure
         ),
         "first_blocker": first_blocker,
         "next_action": next_action,


### PR DESCRIPTION
## Summary

- stop the SkillsBench blind-loop after one Turn when public ACP relay evidence identifies a fatal, nonrecoverable provider failure
- record a typed terminal receipt and preserve zero-write, zero-spend semantics when the agent never starts
- qualify post-run closeout as an external host-provider capacity block instead of an incomplete LoopX lifecycle

## Product and architecture

This extends the existing typed repair controller and public failure policy. It does not add a benchmark-only runner path. The reusable contract is that a failed host execution with typed fatal relay evidence and no durable effects is terminal for the current run, while recoverable transport categories keep their existing continuation behavior.

The change does not alter benchmark scoring, task semantics, leaderboard or submission behavior, permissions, or benchmark launch behavior.

## Validation

- python3 examples/skillsbench-typed-repair-smoke.py
- python3 examples/skillsbench-post-run-debug-gate-smoke.py
- python3 examples/skillsbench-acp-recoverable-transport-smoke.py
- uv run --extra test pytest -q tests/test_loopx_turn_transaction.py tests/test_skillsbench_turn_runtime.py
- uv run --extra test ruff check --ignore E402 on the five changed files
- loopx canary premerge --from-git-diff --format json --no-progress

The premerge canary ran four direct checks, nine catalog checks, and the public-boundary scan with zero failures. It reported the generic benchmark-sensitive maintainer-review hold; this PR is being self-reviewed under the owner-authorized benchmark helper/runtime policy.
