### PR TITLE
Test degraded tunnel success closeout

### DIFF
--- a/examples/skillsbench-reverse-tunnel-supervisor-smoke.py
+++ b/examples/skillsbench-reverse-tunnel-supervisor-smoke.py
@@ -572,6 +572,11 @@ def test_supervisor_preserves_live_tunnel_until_remote_completion() -> None:
         assert liveness["last_probe_status"] == (
             "new_connect_admission_inconclusive_tunnel_preserved"
         ), liveness
+        public_liveness = payload["public_liveness"]
+        assert public_liveness["state"] == "succeeded", public_liveness
+        assert public_liveness["terminal"] is True, public_liveness
+        assert public_liveness["process_alive"] is False, public_liveness
+        assert "first_blocker" not in payload, payload
         ssh_log_text = ssh_log.read_text(encoding="utf-8")
         assert ssh_log_text.count("'-R'") == 1, ssh_log_text
         assert "benchmark_remote_public_artifact_collection_v0" not in ssh_log_text


### PR DESCRIPTION
## Summary

- lock the existing supervisor contract that a degraded tunnel-health history does not override a successful terminal closeout
- assert the terminal public liveness projection is `succeeded`, terminal, and no longer alive
- assert no blocker is projected when the remote command and public artifact closeout succeed

## Scope

This is a focused validation-only change. It does not launch a benchmark, change scoring or task semantics, alter runner behavior, or widen permissions.

## Validation

- `python3 examples/skillsbench-reverse-tunnel-supervisor-smoke.py`
- `.venv/bin/python -m pytest -q tests/test_skillsbench_reverse_tunnel_supervisor.py` (5 passed)
- `.venv/bin/ruff check examples/skillsbench-reverse-tunnel-supervisor-smoke.py --ignore E402`
- `loopx check --scan-path examples/skillsbench-reverse-tunnel-supervisor-smoke.py`
- `loopx canary premerge --from-git-diff`

The risk-based canary passed all direct checks, Python compile, four selected catalog canaries, and the public-boundary scan. It retained the generic `benchmark_sensitive` manual hold; this validation-only benchmark smoke is covered by the owner's standing self-merge authorization.

## Boundary

No private state, raw benchmark evidence, task text, trajectories, verifier output, credentials, local paths, generated logs, uploads, or submissions are included.
