### PR TITLE
Stabilize live tunnel supervisor smoke

### DIFF
--- a/examples/skillsbench-reverse-tunnel-supervisor-smoke.py
+++ b/examples/skillsbench-reverse-tunnel-supervisor-smoke.py
@@ -569,9 +569,6 @@ def test_supervisor_preserves_live_tunnel_until_remote_completion() -> None:
         assert liveness["health_probe_failure_count"] >= 2, liveness
         assert liveness["health_probe_inconclusive_count"] >= 1, liveness
         assert liveness["max_consecutive_failure_count"] == 2, liveness
-        assert liveness["last_probe_status"] == (
-            "new_connect_admission_inconclusive_tunnel_preserved"
-        ), liveness
         public_liveness = payload["public_liveness"]
         assert public_liveness["state"] == "succeeded", public_liveness
         assert public_liveness["terminal"] is True, public_liveness


### PR DESCRIPTION
## Summary

- remove an incidental assertion that required the admission-preservation event to remain the final health-probe status
- keep the semantic assertions that the failure threshold was observed, admission became inconclusive, no reconnect occurred, one tunnel stayed live, and terminal closeout succeeded without a blocker

## Motivation

The remote command may complete after another periodic probe updates `last_probe_status`. That ordering does not change whether the supervisor preserved the live tunnel, so the final-probe assertion made the durable end-to-end smoke timing-sensitive.

## Scope

This is a three-line validation cleanup. It changes no runtime, scoring, task semantics, permissions, uploads, submissions, or benchmark launch behavior.

## Validation

- full `skillsbench-reverse-tunnel-supervisor` smoke repeated successfully after reproducing the timing failure
- `.venv/bin/python -m pytest -q tests/test_skillsbench_reverse_tunnel_supervisor.py` (5 passed)
- `.venv/bin/ruff check examples/skillsbench-reverse-tunnel-supervisor-smoke.py --ignore E402`
- `loopx check --scan-path examples/skillsbench-reverse-tunnel-supervisor-smoke.py`
- `loopx canary premerge --from-git-diff`

The risk-based canary passed all direct checks, Python compilation, four selected catalog canaries, and the public-boundary scan. It retained only the generic `benchmark_sensitive` manual hold, covered here by the owner's standing benchmark self-merge authorization.

## Boundary

No private state, raw benchmark evidence, task text, trajectories, verifier output, credentials, local paths, generated logs, uploads, or submissions are included.
