### PR TITLE
feat(decision-context): add Stage-0 capability contracts

### DIFF
--- a/docs/capabilities/README.md
+++ b/docs/capabilities/README.md
@@ -22,6 +22,10 @@ propose a typed transition through the existing Kernel contract.
 
 Current capability paths:
 
+- [decision-context](../reference/protocols/decision-context-architecture-v0.md)
+  ([中文](../reference/protocols/decision-context-architecture-v0.zh-CN.md)):
+  separate current evidence, advisory proposals, and verified outcomes through
+  default-off provider-neutral packet and incremental source contracts.
 - [periodic-report](periodic-report/README.md): evaluate cadence and material
   progress triggers, then compose deterministic provider-neutral report runs
   with source, artifact, archive, and delivery receipts.

--- a/docs/reference/protocols/decision-context-architecture-v0.md
+++ b/docs/reference/protocols/decision-context-architecture-v0.md
@@ -1,0 +1,193 @@
+# Decision Context Architecture v0
+
+Status: experimental contract
+
+## Position
+
+Decision Context is a built-in, default-off, goal-scoped LoopX capability. It
+runs above LoopX Core, consumes Core truth, and does not enter
+`loopx/control_plane/` or alter todo, gate, quota, or authority semantics.
+
+```mermaid
+flowchart TD
+    CORE["LoopX Core<br/>goal · state · todo · gate · quota · event · vision"]
+    AUTH["Authority Sources<br/>canonical files · revisions · conflict rules"]
+    PROVIDER["Context Provider<br/>OpenViking / local search / others"]
+    RM["Reward Memory Capability<br/>learn reusable experience and policy"]
+    DC["Decision Context Capability<br/>rebuild current decision context"]
+    AGENT["Controller / Agent / Human<br/>decide and confirm"]
+    WRITEBACK["Core Lifecycle Writeback<br/>todo · next action · event · outcome"]
+
+    CORE --> DC
+    AUTH --> DC
+    PROVIDER --> DC
+    RM -. "optional experience source" .-> DC
+    DC --> AGENT
+    AGENT --> WRITEBACK
+    WRITEBACK --> CORE
+    WRITEBACK -. "reviewed verified experience" .-> RM
+```
+
+The capability lives under `loopx/capabilities/decision_context/` and reuses
+`loopx/capabilities/context_providers/`. OpenViking is one replaceable context
+provider, never a global dependency or action authority.
+
+## Boundary
+
+LoopX Core owns cross-domain lifecycle and permission invariants: registry,
+goal, state, todo, gate, quota, event, run, vision, scope, and validated
+writeback. Decision Context improves decision quality through bounded recall,
+exact read, freshness and conflict rebase, objective scoring, recommendations,
+alternatives, stop lists, and provider fail-open.
+
+This capability remains outside the default hot path and cannot create
+authority. A goal owner must explicitly select the scenario, provider, and
+agent lane.
+
+## Relationship to Reward Memory
+
+Reward Memory asks what reusable experience was learned in the past. Decision
+Context asks which facts should be trusted for the current decision.
+
+- Reward Memory follows candidate → review → activate → apply/retire.
+- Decision Context follows recall → exact read → rebase → propose → outcome.
+- Reward Memory may be one optional input to Decision Context.
+- A verified Decision Context outcome may create a Reward Memory candidate, but
+  the candidate still follows Reward Memory review and activation.
+- Neither capability creates action authority.
+
+## Three packets
+
+### `decision_evidence_packet_v0`
+
+The deterministic evidence layer contains changed facts, recalled claims,
+stale or rejected claims, conflicts, source revisions, and provider health. It
+contains no recommendation, objective score, or next action. Accepted recalled
+claims must retain exact-read and revision evidence. Provider failure produces
+a health receipt and fails open to authority sources.
+
+### `decision_proposal_v0`
+
+The advisory reasoning layer contains objective scores, a recommended decision,
+alternatives, next actions, and a stop list. It references the stable evidence
+packet fingerprint and requires authority confirmation. It is not Core truth.
+
+### `decision_outcome_receipt_v0`
+
+The append-only result layer records the accepted decision, resulting
+transitions, observed outcomes, invalidated assumptions, and review time. Only
+a verified receipt with outcome evidence is eligible to create a Reward Memory
+candidate.
+
+## Incremental source plane
+
+Decision Context must not depend on a domain-specific automation prompt to know
+which inboxes, people, documents, repositories, or external signals matter.
+Instead, each goal owns a private source registry and exposes only a
+`decision_source_manifest_v0` public projection:
+
+- source id, kind, priority, evidence level, caller-defined objective tokens,
+  freshness, and scan policy are explicit;
+- provider locators and cursors stay in private goal state;
+- a `DecisionSourceProvider` detects bounded changes and performs exact reads;
+- `decision_source_scan_receipt_v0` retains opaque refs, revision refs, counts,
+  health, and cursor fingerprints, never raw content or provider payloads;
+- source-provider failure is fail-open and cannot create authority.
+
+`DecisionSourceProvider` is distinct from `ContextProvider`. The former rebases
+current authority from systems such as Lark, GitHub, documents, or mail. The
+latter recalls advisory context from systems such as OpenViking. The evidence
+assembler may consume both, but current authority wins conflicts.
+
+```mermaid
+flowchart LR
+    THIN["Thin host wake-up"]
+    REG["Private goal source registry<br/>locator · cursor · policy"]
+    SOURCE["DecisionSourceProvider<br/>scan · exact read"]
+    RECEIPT["Public-safe scan receipt<br/>opaque refs · health · counts"]
+    RECALL["ContextProvider<br/>advisory recall"]
+    EVIDENCE["Decision evidence packet"]
+    AGENT["Agent proposal"]
+    OUTCOME["Outcome receipt"]
+
+    THIN --> REG
+    REG --> SOURCE
+    SOURCE --> RECEIPT
+    RECEIPT --> EVIDENCE
+    RECALL --> EVIDENCE
+    EVIDENCE --> AGENT
+    AGENT --> OUTCOME
+```
+
+This lets the steady-state automation prompt become generic: wake the goal,
+follow the active capability route, and respect quota. Source selection,
+incremental windows, exact-read policy, and writeback live in the capability
+and goal configuration.
+
+## Invariants
+
+1. Every packet is goal-scoped, public-safe, structured, and fingerprinted.
+2. Evidence and proposal remain separate.
+3. Providers never create authority.
+4. Raw provider payloads, raw chat, tool output, and credentials never enter a
+   packet.
+5. Recall is bounded; accepted claims retain exact-read, revision, and conflict
+   receipts.
+6. Proposals remain advisory; transitions use existing todo, gate, quota, and
+   writeback.
+7. Provider failure is fail-open and does not block the Core lifecycle.
+8. Verified outcomes are recorded before any Reward Memory distillation.
+
+## Delivery stages
+
+### P0: contract
+
+Define the three packets, stable fingerprints, public-safe field allowlists,
+the provider-neutral incremental source contract, focused tests, and this
+boundary document. Do not wire a concrete provider, CLI, or Core writeback.
+
+### P0: evidence assembler
+
+Read authority revisions, freshness, and conflict rules. Reuse
+the private source registry and bounded incremental scan receipts. Reuse
+`ContextProvider` for bounded retrieval and advisory recall. Emit
+stale/rejected claims and provider fail-open receipts without capturing raw
+context.
+
+### P1: experimental entry point
+
+Add default-off goal config, status, catalog, source-provider adapters, and a
+thin CLI that orchestrates source scans, evidence, and proposals without
+changing Core semantics. Domain adapters such as Lark remain optional and
+credential-free in public state.
+
+### P1: first dogfood
+
+Use one private, redacted decision-assistant scenario. Write an outcome receipt
+through existing event/run history. Measure decision changes, observed
+outcomes, and invalidated assumptions rather than retrieval volume.
+
+### P2: cross-domain validation and Core promotion gate
+
+Validate a second independent domain and measure authority-source hits, stale
+claim rejection, evidence-driven decision changes, and outcome calibration.
+Only then consider promoting narrow generic mechanisms:
+
+- decision-to-todo/outcome event links;
+- compact source revision, freshness, and conflict read models;
+- the generic decision outcome receipt;
+- provider health and fail-open projection.
+
+Objective scoring, cross-repository scanning, semantic recall, and decision
+recommendations stay in the capability.
+
+## Stop conditions
+
+- Stop provider expansion when it raises retrieval volume without changing a
+  decision or producing an outcome receipt.
+- Revisit the capability boundary if integration requires changing Core
+  authority semantics.
+- Reject writes when raw or private context cannot be compacted and redacted
+  before packet construction.
+- Do not propose Core promotion until one scenario proves stale rejection and
+  decision-to-outcome linkage, then a second domain reproduces the result.

--- a/docs/reference/protocols/decision-context-architecture-v0.zh-CN.md
+++ b/docs/reference/protocols/decision-context-architecture-v0.zh-CN.md
@@ -1,0 +1,220 @@
+# Decision Context 架构 v0
+
+状态：实验契约
+
+## 定位
+
+Decision Context 是 LoopX 内置、默认关闭、goal-scoped 的高层决策 capability。
+它运行在 LoopX Core 之上，消费 Core truth，但不进入
+`loopx/control_plane/`，也不改变 todo、gate、quota、authority 的语义。
+
+```mermaid
+flowchart TD
+    CORE["LoopX Core<br/>goal · state · todo · gate · quota · event · vision"]
+    AUTH["Authority Sources<br/>canonical files · revisions · conflict rules"]
+    PROVIDER["Context Provider<br/>OpenViking / local search / others"]
+    RM["Reward Memory Capability<br/>学习可复用经验与策略"]
+    DC["Decision Context Capability<br/>重建当前决策上下文"]
+    AGENT["Controller / Agent / Human<br/>作出并确认决策"]
+    WRITEBACK["Core Lifecycle Writeback<br/>todo · next action · event · outcome"]
+
+    CORE --> DC
+    AUTH --> DC
+    PROVIDER --> DC
+    RM -. "可选经验来源" .-> DC
+    DC --> AGENT
+    AGENT --> WRITEBACK
+    WRITEBACK --> CORE
+    WRITEBACK -. "经验证、评审后的经验" .-> RM
+```
+
+代码位置：
+
+- capability contract：`loopx/capabilities/decision_context/`
+- provider contract：复用 `loopx/capabilities/context_providers/`
+- lifecycle truth：继续由现有 Core 管理
+- OpenViking：可替换的 context provider，不是全局依赖或 action authority
+
+## 为什么不是 Core
+
+LoopX Core 拥有跨领域的生命周期与权限边界：
+
+- registry、goal、state、todo、gate、quota；
+- event、run、vision 与 restartable next action；
+- authority、scope 和 validated writeback。
+
+Decision Context 负责的是决策质量：
+
+- 跨源 bounded recall 与 exact read；
+- freshness、revision 与 conflict rebase；
+- objective scoring；
+- recommendation、alternatives、next actions 与 stop list；
+- provider health 与 fail-open。
+
+这些能力不应进入每个 goal 的默认热路径，也不能自行创造权限。默认关闭使
+goal owner 可以显式选择场景、provider 和 agent lane。
+
+## 与 Reward Memory 的关系
+
+二者是同级 intelligence capability，但解决不同问题：
+
+| | Reward Memory | Decision Context |
+|---|---|---|
+| 核心问题 | 过去学到了什么可复用经验？ | 此刻决策需要相信哪些事实？ |
+| 生命周期 | candidate → review → activate → apply/retire | recall → exact read → rebase → propose → outcome |
+| 主要对象 | policy、preference、procedural experience | fact、judgment、assumption、conflict、decision、outcome |
+| 写入条件 | 经过验证和 authority review | 决策与结果作为可审计记录追加 |
+| 动作权限 | 不创造 authority | 不创造 authority |
+| 连接方式 | 可作为 Decision Context 的可选经验来源 | verified outcome 可产生 Reward Memory candidate |
+
+## 三层 packet
+
+### `decision_evidence_packet_v0`
+
+确定性、可审计的证据层：
+
+- `changed_facts`
+- `recalled_claims`
+- `stale_or_rejected_claims`
+- `conflicts`
+- `source_revisions`
+- `provider_health`
+
+它不包含 recommendation、objective score 或 next action。provider 返回内容必须
+经过 exact read 和 source revision 校验后，才能成为 accepted recalled claim。
+语义召回失败时保留 provider health receipt，并 fail open 到 authority sources。
+
+### `decision_proposal_v0`
+
+允许 Agent 推理的建议层：
+
+- `objective_scores`
+- `recommended_decision`
+- `alternatives`
+- `next_actions`
+- `stop_list`
+
+proposal 必须引用 evidence packet 的稳定指纹，并显式标记
+`authority_confirmation_required=true`。它不能写成 Core truth。
+
+### `decision_outcome_receipt_v0`
+
+追加式结果层：
+
+- `accepted_decision`
+- `resulting_transitions`
+- `observed_outcomes`
+- `invalidated_assumptions`
+- `review_at`
+
+receipt 可由既有 event/run history 承载。只有
+`verification_status=verified` 且有 outcome evidence 时，才可成为 Reward Memory
+candidate；candidate 仍需经过 Reward Memory 自己的 review/activation 流程。
+
+## 增量信源层
+
+Decision Context 不应依赖某个领域专用的 automation prompt，来记住应该读哪些群聊、
+关键人、文档、仓库或外部信号。每个 goal 应维护一份私有 source registry，对外只投影
+`decision_source_manifest_v0`：
+
+- source id、类型、优先级、证据等级、调用方自定义 objective token、freshness
+  和扫描策略显式声明；
+- provider locator 和原始 cursor 只保留在 goal 私有状态；
+- `DecisionSourceProvider` 负责 bounded change scan 和 exact read；
+- `decision_source_scan_receipt_v0` 只保留 opaque ref、revision ref、计数、health 和
+  cursor fingerprint，不保留正文或 provider 原始返回；
+- provider 失败时 fail open，且不能创造 authority。
+
+`DecisionSourceProvider` 与 `ContextProvider` 职责不同。前者从飞书、GitHub、文档、
+邮箱等系统增量重建当前 authority；后者从 OpenViking 等系统召回 advisory context。
+evidence assembler 可以同时消费两者，但冲突时当前 authority 优先。
+
+```mermaid
+flowchart LR
+    THIN["通用 thin host 唤醒"]
+    REG["Goal 私有 source registry<br/>locator · cursor · policy"]
+    SOURCE["DecisionSourceProvider<br/>scan · exact read"]
+    RECEIPT["Public-safe scan receipt<br/>opaque refs · health · counts"]
+    RECALL["ContextProvider<br/>advisory recall"]
+    EVIDENCE["Decision evidence packet"]
+    AGENT["Agent proposal"]
+    OUTCOME["Outcome receipt"]
+
+    THIN --> REG
+    REG --> SOURCE
+    SOURCE --> RECEIPT
+    RECEIPT --> EVIDENCE
+    RECALL --> EVIDENCE
+    EVIDENCE --> AGENT
+    AGENT --> OUTCOME
+```
+
+这样 steady-state automation prompt 可以退化为通用唤醒：启动 goal、遵循 active
+capability route、服从 quota。信源选择、增量窗口、exact-read 策略和写回全部由
+capability 与 goal 配置承担。
+
+## 不变量
+
+1. 三类 packet 都是 goal-scoped、public-safe、稳定指纹化的结构化记录。
+2. evidence 与 proposal 分离，模型建议不能伪装成事实。
+3. provider 不创造 authority；provider payload、raw chat、tool output、credentials
+   不进入 packet。
+4. recall 必须有界；accepted claim 必须保留 exact-read、revision 与 conflict receipt。
+5. proposal 只能建议，真实迁移继续经现有 todo、gate、quota 和 writeback。
+6. provider 不可用时 fail open，不阻断 Core lifecycle。
+7. verified outcome 先进入可审计 receipt，再决定是否提炼为 Reward Memory。
+
+## 分阶段交付
+
+### P0：contract
+
+- 固化三类 packet、稳定指纹、公共安全字段白名单和 provider-neutral
+  增量信源契约；
+- 建立能力边界文档与聚焦测试；
+- 不接具体 provider、CLI 或 control-plane writeback。
+
+### P0：evidence assembler
+
+- 读取 authority revision、freshness 和 conflict rule；
+- 加载私有 source registry，消费 bounded incremental scan receipt；
+- 复用 `ContextProvider` 做 bounded retrieval 和 advisory recall；
+- 输出 stale/rejected claim 和 provider fail-open receipt；
+- 不采集 raw context。
+
+### P1：实验入口
+
+- 增加默认关闭、goal-scoped 的 config/status/catalog；
+- 增加 source-provider adapter，提供薄 CLI 编排 source scan、evidence 与 proposal；
+- 飞书等领域 adapter 保持可选，公开状态不含凭据和私有 locator；
+- 不修改 Core todo、gate、quota 或 authority 语义。
+
+### P1：首个 dogfood
+
+- 在一个私有、脱敏的决策助手场景生成 evidence/proposal；
+- 通过既有 event/run history 写入 outcome receipt；
+- 以“决策改变、真实结果、失效假设”而非召回条数验收。
+
+### P2：跨域验证与下沉门槛
+
+在第二个独立领域复用，测量：
+
+- authority source 命中；
+- stale claim rejection；
+- 因新证据发生的决策改变；
+- outcome 校准质量。
+
+双场景验证后，才考虑把以下窄机制下沉 Core：
+
+- `decision_id → todo/next_action → outcome` 的通用事件关联；
+- source revision、freshness 与 conflict 的紧凑 read model；
+- 通用 `decision_outcome_receipt_v0`；
+- provider health/fail-open 公共投影。
+
+目标评分、跨仓扫描、语义召回和推荐决策继续留在 capability。
+
+## 停止条件
+
+- 若只能提高召回数量，不能改变决策或产生 outcome receipt，停止扩展 provider。
+- 若需要修改 Core authority 语义才能接入，回退并重新划分 capability 边界。
+- 若 raw context 或私有来源无法在 packet 前被压缩和脱敏，拒绝写入。
+- 若单场景无法证明 stale rejection 与 decision-to-outcome 关联，不推进 Core 下沉。

--- a/examples/capability-extension-registry-smoke.py
+++ b/examples/capability-extension-registry-smoke.py
@@ -59,6 +59,7 @@ next_real_step = "Keep explicit enablement bounded."
     baseline = run_cli(runtime_root, "capability", "list")
     assert [item["id"] for item in baseline["capabilities"]] == [
         "issue-fix",
+        "decision-context",
         "semantic-preference",
         "reward-memory",
         "periodic-report",

--- a/examples/decision-context-contract-smoke.py
+++ b/examples/decision-context-contract-smoke.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Smoke-test the public Decision Context Stage-0 contract."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.decision_context import (
+    DecisionSourceSpec,
+    build_decision_context_architecture_packet,
+    build_decision_evidence_packet,
+    build_decision_outcome_receipt,
+    build_decision_proposal,
+    build_decision_source_manifest,
+)
+
+OBSERVED_AT = "2026-07-25T13:30:00+00:00"
+REVIEW_AT = "2026-07-28T13:30:00+00:00"
+
+
+def run_cli(*args: str) -> dict[str, object]:
+    completed = subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--format", "json", *args],
+        cwd=REPO_ROOT,
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    return json.loads(completed.stdout)
+
+
+def main() -> int:
+    architecture = build_decision_context_architecture_packet()
+    assert architecture["capability"]["default_enabled"] is False
+    assert architecture["capability"]["creates_authority"] is False
+    assert architecture["provider_boundaries"]["provider_failure_policy"] == (
+        "fail_open_to_current_authority"
+    )
+    assert run_cli("decision-context", "architecture") == architecture
+
+    source = DecisionSourceSpec(
+        source_id="source:repository:signals",
+        provider_id="repository-provider",
+        source_kind="repository",
+        priority="p0",
+        evidence_level="s1",
+        objectives=("adoption",),
+        scan_mode="incremental",
+        exact_read_policy="material_change",
+        freshness_seconds=3600,
+        private_locator="private-repository-locator",
+    )
+    manifest = build_decision_source_manifest(
+        goal_id="goal:example",
+        observed_at=OBSERVED_AT,
+        sources=[source],
+    )
+    assert "private-repository-locator" not in json.dumps(manifest)
+
+    evidence = build_decision_evidence_packet(
+        goal_id="goal:example",
+        decision_id="decision:priority",
+        observed_at=OBSERVED_AT,
+        changed_facts=[
+            {
+                "fact_id": "fact:pilot",
+                "summary": "One bounded pilot produced a current authority receipt.",
+                "source_ref": "source:repository:signals",
+                "source_revision": "revision:1",
+                "observed_at": OBSERVED_AT,
+            }
+        ],
+        provider_health=[
+            {
+                "provider": "repository-provider",
+                "status": "healthy",
+                "observed_at": OBSERVED_AT,
+                "fail_open": True,
+            }
+        ],
+    )
+    proposal = build_decision_proposal(
+        goal_id="goal:example",
+        decision_id="decision:priority",
+        evidence_packet_ref=str(evidence["packet_ref"]),
+        observed_at=OBSERVED_AT,
+        review_at=REVIEW_AT,
+        objective_scores=[
+            {
+                "objective_id": "objective:adoption",
+                "score": 0.8,
+                "rationale": "Current outcome evidence supports closing the pilot.",
+            }
+        ],
+        recommended_decision={
+            "option_id": "option:close-pilot",
+            "summary": "Close the pilot before expanding the protocol.",
+            "rationale": "Verified adoption compounds more than another surface.",
+            "confidence": 0.8,
+        },
+    )
+    outcome = build_decision_outcome_receipt(
+        goal_id="goal:example",
+        decision_id="decision:priority",
+        proposal_packet_ref=str(proposal["packet_ref"]),
+        recorded_at=REVIEW_AT,
+        review_at="2026-08-01T13:30:00+00:00",
+        verification_status="verified",
+        accepted_decision={
+            "option_id": "option:close-pilot",
+            "summary": "Close the pilot before expanding the protocol.",
+            "accepted_by": "owner:goal",
+            "accepted_at": OBSERVED_AT,
+        },
+        observed_outcomes=[
+            {
+                "outcome_id": "outcome:pilot",
+                "summary": "The pilot owner verified one realized outcome.",
+                "evidence_ref": "evidence:pilot",
+                "status": "verified",
+                "observed_at": REVIEW_AT,
+            }
+        ],
+    )
+    assert outcome["reward_memory_candidate_eligible"] is True
+    assert outcome["capability"]["mutates_core_state"] is False
+
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "schema_version": architecture["schema_version"],
+                "manifest_ref": manifest["manifest_ref"],
+                "evidence_ref": evidence["packet_ref"],
+                "proposal_ref": proposal["packet_ref"],
+                "outcome_ref": outcome["packet_ref"],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -5,8 +5,8 @@ from pathlib import Path
 from typing import Any
 
 from .registry import CapabilityRegistry
-from ..extensions.runtime import extension_catalog_entries
 
+from ..extensions.runtime import extension_catalog_entries
 
 CAPABILITY_CATALOG_SCHEMA_VERSION = "loopx_capability_catalog_v0"
 CAPABILITY_DETAIL_SCHEMA_VERSION = "loopx_capability_detail_v0"
@@ -261,6 +261,77 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
         "next_real_step": (
             "Exercise route selection and continuation on a public issue-fix pilot, "
             "while keeping external PR/comment actions explicit."
+        ),
+    },
+    {
+        "id": "decision-context",
+        "origin": "builtin",
+        "visibility": "public",
+        "provider_id": "loopx-core",
+        "title": "Goal-scoped decision evidence and outcome contract",
+        "status": "experimental",
+        "default_enabled": False,
+        "real_world_anchor": (
+            "incremental authority rebase before long-running agent decisions"
+        ),
+        "user_value": (
+            "Separate current evidence, advisory proposals, and verified outcomes "
+            "while keeping source providers replaceable and Core authority unchanged."
+        ),
+        "entry_command": "loopx decision-context architecture --format json",
+        "commands": [
+            {
+                "command": "loopx decision-context architecture --format json",
+                "purpose": "Render the default-off Stage-0 packet, source, provider, and lifecycle boundaries.",
+                "write_boundary": "stateless contract output only; no provider, source, goal state, or external write",
+            }
+        ],
+        "implemented_protocols": [
+            {
+                "schema_version": "decision_context_architecture_v0",
+                "module": "loopx.capabilities.decision_context.architecture",
+                "doc": "docs/reference/protocols/decision-context-architecture-v0.md",
+            },
+            {
+                "schema_version": "decision_evidence_packet_v0",
+                "module": "loopx.capabilities.decision_context.packets",
+                "doc": "docs/reference/protocols/decision-context-architecture-v0.md",
+            },
+            {
+                "schema_version": "decision_proposal_v0",
+                "module": "loopx.capabilities.decision_context.packets",
+                "doc": "docs/reference/protocols/decision-context-architecture-v0.md",
+            },
+            {
+                "schema_version": "decision_outcome_receipt_v0",
+                "module": "loopx.capabilities.decision_context.packets",
+                "doc": "docs/reference/protocols/decision-context-architecture-v0.md",
+            },
+            {
+                "schema_version": "decision_source_manifest_v0",
+                "module": "loopx.capabilities.decision_context.sources",
+                "doc": "docs/reference/protocols/decision-context-architecture-v0.md",
+            },
+            {
+                "schema_version": "decision_source_scan_receipt_v0",
+                "module": "loopx.capabilities.decision_context.sources",
+                "doc": "docs/reference/protocols/decision-context-architecture-v0.md",
+            },
+        ],
+        "smokes": ["python3 examples/decision-context-contract-smoke.py"],
+        "docs": [
+            "docs/reference/protocols/decision-context-architecture-v0.md",
+            "docs/reference/protocols/decision-context-architecture-v0.zh-CN.md",
+        ],
+        "boundaries": [
+            "The capability is default-off and cannot create action authority or mutate Core state.",
+            "Private source locators, cursors, raw content, provider payloads, tool output, and credentials stay outside public packets.",
+            "DecisionSourceProvider rebases current authority; ContextProvider supplies advisory recall only.",
+            "Concrete provider adapters and goal writeback remain deferred until the evidence assembler and private dogfood are validated.",
+        ],
+        "next_real_step": (
+            "Build the deterministic evidence assembler, then validate one "
+            "default-off provider adapter and outcome receipt in private dogfood."
         ),
     },
     {

--- a/loopx/capabilities/decision_context/__init__.py
+++ b/loopx/capabilities/decision_context/__init__.py
@@ -1,0 +1,43 @@
+"""Goal-scoped Decision Context capability contracts."""
+
+from .architecture import (
+    DECISION_CONTEXT_ARCHITECTURE_SCHEMA_VERSION,
+    build_decision_context_architecture_packet,
+)
+from .packets import (
+    DECISION_EVIDENCE_PACKET_SCHEMA_VERSION,
+    DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION,
+    DECISION_PROPOSAL_SCHEMA_VERSION,
+    build_decision_evidence_packet,
+    build_decision_outcome_receipt,
+    build_decision_proposal,
+)
+from .sources import (
+    DECISION_SOURCE_MANIFEST_SCHEMA_VERSION,
+    DECISION_SOURCE_SCAN_RECEIPT_SCHEMA_VERSION,
+    DecisionSourceExactRead,
+    DecisionSourceItem,
+    DecisionSourceProvider,
+    DecisionSourceScan,
+    DecisionSourceSpec,
+    build_decision_source_manifest,
+)
+
+__all__ = [
+    "DECISION_CONTEXT_ARCHITECTURE_SCHEMA_VERSION",
+    "DECISION_EVIDENCE_PACKET_SCHEMA_VERSION",
+    "DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION",
+    "DECISION_PROPOSAL_SCHEMA_VERSION",
+    "DECISION_SOURCE_MANIFEST_SCHEMA_VERSION",
+    "DECISION_SOURCE_SCAN_RECEIPT_SCHEMA_VERSION",
+    "DecisionSourceExactRead",
+    "DecisionSourceItem",
+    "DecisionSourceProvider",
+    "DecisionSourceScan",
+    "DecisionSourceSpec",
+    "build_decision_context_architecture_packet",
+    "build_decision_evidence_packet",
+    "build_decision_outcome_receipt",
+    "build_decision_proposal",
+    "build_decision_source_manifest",
+]

--- a/loopx/capabilities/decision_context/architecture.py
+++ b/loopx/capabilities/decision_context/architecture.py
@@ -1,0 +1,64 @@
+"""Provider-neutral architecture projection for Decision Context."""
+
+from __future__ import annotations
+
+from .packets import (
+    DECISION_EVIDENCE_PACKET_SCHEMA_VERSION,
+    DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION,
+    DECISION_PROPOSAL_SCHEMA_VERSION,
+)
+from .sources import (
+    DECISION_SOURCE_MANIFEST_SCHEMA_VERSION,
+    DECISION_SOURCE_SCAN_RECEIPT_SCHEMA_VERSION,
+)
+
+DECISION_CONTEXT_ARCHITECTURE_SCHEMA_VERSION = "decision_context_architecture_v0"
+
+
+def build_decision_context_architecture_packet() -> dict[str, object]:
+    """Render the default-off Stage-0 capability contract."""
+
+    return {
+        "schema_version": DECISION_CONTEXT_ARCHITECTURE_SCHEMA_VERSION,
+        "status": "experimental",
+        "capability": {
+            "capability_id": "decision_context",
+            "scope": "goal",
+            "default_enabled": False,
+            "creates_authority": False,
+            "mutates_core_state": False,
+        },
+        "packet_schemas": [
+            DECISION_EVIDENCE_PACKET_SCHEMA_VERSION,
+            DECISION_PROPOSAL_SCHEMA_VERSION,
+            DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION,
+        ],
+        "source_schemas": [
+            DECISION_SOURCE_MANIFEST_SCHEMA_VERSION,
+            DECISION_SOURCE_SCAN_RECEIPT_SCHEMA_VERSION,
+        ],
+        "provider_boundaries": {
+            "decision_source_provider": (
+                "bounded_authority_change_detection_and_exact_read"
+            ),
+            "context_provider": "bounded_advisory_recall",
+            "provider_failure_policy": "fail_open_to_current_authority",
+        },
+        "lifecycle": [
+            "recall",
+            "exact_read",
+            "rebase",
+            "propose",
+            "outcome",
+        ],
+        "invariants": [
+            "evidence_and_proposal_remain_separate",
+            "accepted_recalled_claims_require_exact_read_and_revision",
+            "raw_provider_content_never_enters_public_packets",
+            "proposals_require_existing_authority_confirmation",
+            "verified_outcomes_precede_reward_memory_candidates",
+        ],
+        "next_stage": (
+            "evidence_assembler_then_default_off_provider_adapter_and_dogfood"
+        ),
+    }

--- a/loopx/capabilities/decision_context/cli.py
+++ b/loopx/capabilities/decision_context/cli.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+from .architecture import build_decision_context_architecture_packet
+
+
+def _render(payload: dict[str, object]) -> str:
+    capability = payload.get("capability")
+    capability_id = (
+        capability.get("capability_id")
+        if isinstance(capability, dict)
+        else "decision_context"
+    )
+    return "\n".join(
+        [
+            "# Decision Context",
+            "",
+            f"- status: `{payload.get('status')}`",
+            f"- capability_id: `{capability_id}`",
+            f"- packet_schemas: `{len(payload.get('packet_schemas') or [])}`",
+            f"- source_schemas: `{len(payload.get('source_schemas') or [])}`",
+            "",
+        ]
+    )
+
+
+def register_decision_context_commands(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    parser = subparsers.add_parser(
+        "decision-context",
+        help="Inspect the provider-neutral decision evidence and outcome contract.",
+    )
+    commands = parser.add_subparsers(dest="decision_context_command", required=True)
+    architecture = commands.add_parser(
+        "architecture",
+        help="Render the default-off Stage-0 Decision Context contract.",
+    )
+    add_subcommand_format(architecture)
+
+
+def handle_decision_context_command(
+    args: argparse.Namespace,
+    *,
+    output_format: Callable[..., str],
+    print_payload: Callable[[dict[str, object], str, Callable], None],
+) -> int | None:
+    if args.command != "decision-context":
+        return None
+    payload = build_decision_context_architecture_packet()
+    print_payload(payload, output_format(args), _render)
+    return 0

--- a/loopx/capabilities/decision_context/packets.py
+++ b/loopx/capabilities/decision_context/packets.py
@@ -1,0 +1,556 @@
+"""Deterministic, public-safe packet contracts for Decision Context."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from typing import Any
+
+DECISION_EVIDENCE_PACKET_SCHEMA_VERSION = "decision_evidence_packet_v0"
+DECISION_PROPOSAL_SCHEMA_VERSION = "decision_proposal_v0"
+DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION = "decision_outcome_receipt_v0"
+
+DECISION_CONTEXT_CAPABILITY_ID = "decision_context"
+DECISION_OUTCOME_VERIFICATION_STATUSES = {
+    "pending",
+    "verified",
+    "refuted",
+    "inconclusive",
+}
+
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+_LOCAL_PATH_RE = re.compile(r"(^|[\s:=])(?:/Users/|/private/|/tmp/|~/)")
+_RAW_LOCATION_RE = re.compile(r"(?i)\b(?:https?|file|s3|gs|tos|hdfs)://")
+_CREDENTIAL_RE = re.compile(
+    "(?i)("
+    + "|".join(
+        [
+            "Author" + "ization:",
+            "Bear" + r"er\s+[A-Za-z0-9._-]+",
+            "api" + r"[_-]?key",
+            "pass" + "word",
+            "sec" + "ret",
+            "begin " + r"(?:rsa |open)?private key",
+        ]
+    )
+    + ")"
+)
+_UNSAFE_FIELDS = {
+    "api_key",
+    "content",
+    "credential",
+    "credentials",
+    "provider_payload",
+    "raw_chat",
+    "raw_content",
+    "raw_provider_payload",
+    "token",
+    "tool_output",
+}
+
+
+def _compact_text(value: Any, *, field: str, max_len: int = 320) -> str:
+    text = " ".join(str(value or "").strip().split())
+    if not text:
+        raise ValueError(f"{field} must be non-empty")
+    if len(text) > max_len:
+        raise ValueError(f"{field} must be at most {max_len} characters")
+    if _LOCAL_PATH_RE.search(text):
+        raise ValueError(f"{field} must not contain a local path")
+    if _RAW_LOCATION_RE.search(text):
+        raise ValueError(f"{field} must use an opaque source reference, not a raw URL")
+    if _CREDENTIAL_RE.search(text):
+        raise ValueError(f"{field} contains a credential-like value")
+    return text
+
+
+def _compact_token(value: Any, *, field: str) -> str:
+    token = _compact_text(value, field=field, max_len=128)
+    if not _TOKEN_RE.fullmatch(token):
+        raise ValueError(
+            f"{field} must contain only letters, digits, dot, colon, dash, or underscore"
+        )
+    return token
+
+
+def _iso_timestamp(value: Any, *, field: str) -> str:
+    timestamp = _compact_text(value, field=field, max_len=64)
+    try:
+        parsed = datetime.fromisoformat(timestamp)
+    except ValueError as exc:
+        raise ValueError(f"{field} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field} must include a timezone")
+    return timestamp
+
+
+def _score(value: Any, *, field: str) -> float:
+    try:
+        score = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field} must be a number") from exc
+    if not math.isfinite(score) or not 0.0 <= score <= 1.0:
+        raise ValueError(f"{field} must be finite and between 0 and 1")
+    return score
+
+
+def _normalize_value(value: Any, *, field: str, kind: str) -> Any:
+    if kind == "token":
+        return _compact_token(value, field=field)
+    if kind == "text":
+        return _compact_text(value, field=field)
+    if kind == "timestamp":
+        return _iso_timestamp(value, field=field)
+    if kind == "bool":
+        if not isinstance(value, bool):
+            raise ValueError(f"{field} must be a boolean")
+        return value
+    if kind == "score":
+        return _score(value, field=field)
+    if kind == "tokens":
+        if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+            raise ValueError(f"{field} must be a sequence of compact tokens")
+        return sorted({_compact_token(item, field=f"{field}[]") for item in value})
+    raise ValueError(f"unsupported field kind: {kind}")
+
+
+def _normalize_record(
+    value: Mapping[str, Any],
+    *,
+    field: str,
+    spec: Mapping[str, str],
+    required: set[str],
+) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{field} must be an object")
+    keys = {str(key) for key in value}
+    unsafe = sorted(keys & _UNSAFE_FIELDS)
+    if unsafe:
+        raise ValueError(f"{field} contains unsafe fields: {', '.join(unsafe)}")
+    unexpected = sorted(keys - set(spec))
+    if unexpected:
+        raise ValueError(
+            f"{field} contains unsupported fields: {', '.join(unexpected)}"
+        )
+    missing = sorted(key for key in required if value.get(key) is None)
+    if missing:
+        raise ValueError(f"{field} is missing required fields: {', '.join(missing)}")
+    normalized: dict[str, Any] = {}
+    for key, kind in spec.items():
+        item = value.get(key)
+        if item is None:
+            continue
+        normalized[key] = _normalize_value(
+            item,
+            field=f"{field}.{key}",
+            kind=kind,
+        )
+    return normalized
+
+
+def _normalize_records(
+    values: Sequence[Mapping[str, Any]] | None,
+    *,
+    field: str,
+    spec: Mapping[str, str],
+    required: set[str],
+) -> list[dict[str, Any]]:
+    if values is None:
+        return []
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise TypeError(f"{field} must be a sequence of objects")
+    records = [
+        _normalize_record(
+            value,
+            field=f"{field}[{index}]",
+            spec=spec,
+            required=required,
+        )
+        for index, value in enumerate(values)
+    ]
+    return sorted(
+        records,
+        key=lambda item: json.dumps(
+            item,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+    )
+
+
+def _packet_ref(prefix: str, packet: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(
+        json.dumps(
+            packet,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:20]
+    return f"{prefix}-{digest}"
+
+
+def _capability_contract(*, packet_role: str) -> dict[str, Any]:
+    return {
+        "capability_id": DECISION_CONTEXT_CAPABILITY_ID,
+        "scope": "goal",
+        "default_enabled": False,
+        "packet_role": packet_role,
+        "creates_authority": False,
+        "mutates_core_state": False,
+    }
+
+
+_CHANGED_FACT_SPEC = {
+    "fact_id": "token",
+    "summary": "text",
+    "source_ref": "token",
+    "source_revision": "token",
+    "observed_at": "timestamp",
+    "freshness": "token",
+    "authority": "token",
+}
+_RECALLED_CLAIM_SPEC = {
+    "claim_id": "token",
+    "summary": "text",
+    "provider_ref": "token",
+    "source_ref": "token",
+    "source_revision": "token",
+    "observed_at": "timestamp",
+    "exact_read_verified": "bool",
+    "confidence": "score",
+}
+_REJECTED_CLAIM_SPEC = {
+    "claim_id": "token",
+    "summary": "text",
+    "source_ref": "token",
+    "source_revision": "token",
+    "observed_at": "timestamp",
+    "reason_code": "token",
+}
+_CONFLICT_SPEC = {
+    "conflict_id": "token",
+    "summary": "text",
+    "source_refs": "tokens",
+    "conflict_rule": "token",
+    "status": "token",
+}
+_SOURCE_REVISION_SPEC = {
+    "source_ref": "token",
+    "revision": "token",
+    "observed_at": "timestamp",
+    "freshness": "token",
+}
+_PROVIDER_HEALTH_SPEC = {
+    "provider": "token",
+    "status": "token",
+    "observed_at": "timestamp",
+    "reason_code": "token",
+    "fail_open": "bool",
+}
+
+
+def build_decision_evidence_packet(
+    *,
+    goal_id: str,
+    decision_id: str,
+    observed_at: str,
+    changed_facts: Sequence[Mapping[str, Any]] | None = None,
+    recalled_claims: Sequence[Mapping[str, Any]] | None = None,
+    stale_or_rejected_claims: Sequence[Mapping[str, Any]] | None = None,
+    conflicts: Sequence[Mapping[str, Any]] | None = None,
+    source_revisions: Sequence[Mapping[str, Any]] | None = None,
+    provider_health: Sequence[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build an evidence-only packet without recommendations or raw context."""
+
+    normalized_recalled_claims = _normalize_records(
+        recalled_claims,
+        field="recalled_claims",
+        spec=_RECALLED_CLAIM_SPEC,
+        required={
+            "claim_id",
+            "summary",
+            "provider_ref",
+            "source_ref",
+            "source_revision",
+            "observed_at",
+            "exact_read_verified",
+        },
+    )
+    if any(not claim["exact_read_verified"] for claim in normalized_recalled_claims):
+        raise ValueError(
+            "recalled_claims must be exact-read verified; reject stale or "
+            "unverified claims instead"
+        )
+    normalized_provider_health = _normalize_records(
+        provider_health,
+        field="provider_health",
+        spec=_PROVIDER_HEALTH_SPEC,
+        required={"provider", "status", "observed_at", "fail_open"},
+    )
+    if any(not health["fail_open"] for health in normalized_provider_health):
+        raise ValueError("provider_health must preserve fail-open behavior")
+
+    packet: dict[str, Any] = {
+        "schema_version": DECISION_EVIDENCE_PACKET_SCHEMA_VERSION,
+        "goal_id": _compact_token(goal_id, field="goal_id"),
+        "decision_id": _compact_token(decision_id, field="decision_id"),
+        "observed_at": _iso_timestamp(observed_at, field="observed_at"),
+        "visibility": "public_safe",
+        "capability": _capability_contract(packet_role="evidence"),
+        "changed_facts": _normalize_records(
+            changed_facts,
+            field="changed_facts",
+            spec=_CHANGED_FACT_SPEC,
+            required={"fact_id", "summary", "source_ref", "observed_at"},
+        ),
+        "recalled_claims": normalized_recalled_claims,
+        "stale_or_rejected_claims": _normalize_records(
+            stale_or_rejected_claims,
+            field="stale_or_rejected_claims",
+            spec=_REJECTED_CLAIM_SPEC,
+            required={"claim_id", "summary", "observed_at", "reason_code"},
+        ),
+        "conflicts": _normalize_records(
+            conflicts,
+            field="conflicts",
+            spec=_CONFLICT_SPEC,
+            required={
+                "conflict_id",
+                "summary",
+                "source_refs",
+                "conflict_rule",
+                "status",
+            },
+        ),
+        "source_revisions": _normalize_records(
+            source_revisions,
+            field="source_revisions",
+            spec=_SOURCE_REVISION_SPEC,
+            required={"source_ref", "revision", "observed_at", "freshness"},
+        ),
+        "provider_health": normalized_provider_health,
+        "provider_fail_open": True,
+        "external_writes_performed": False,
+        "raw_context_captured": False,
+        "credentials_captured": False,
+    }
+    packet["packet_ref"] = _packet_ref("decision-evidence", packet)
+    return packet
+
+
+_OBJECTIVE_SCORE_SPEC = {
+    "objective_id": "token",
+    "score": "score",
+    "rationale": "text",
+}
+_RECOMMENDED_DECISION_SPEC = {
+    "option_id": "token",
+    "summary": "text",
+    "rationale": "text",
+    "confidence": "score",
+}
+_ALTERNATIVE_SPEC = {
+    "alternative_id": "token",
+    "summary": "text",
+    "tradeoff": "text",
+}
+_NEXT_ACTION_SPEC = {
+    "action_id": "token",
+    "owner_ref": "token",
+    "summary": "text",
+    "acceptance": "text",
+    "stop_condition": "text",
+}
+_STOP_ITEM_SPEC = {
+    "stop_id": "token",
+    "summary": "text",
+    "condition": "text",
+}
+
+
+def build_decision_proposal(
+    *,
+    goal_id: str,
+    decision_id: str,
+    evidence_packet_ref: str,
+    observed_at: str,
+    objective_scores: Sequence[Mapping[str, Any]],
+    recommended_decision: Mapping[str, Any],
+    alternatives: Sequence[Mapping[str, Any]] | None = None,
+    next_actions: Sequence[Mapping[str, Any]] | None = None,
+    stop_list: Sequence[Mapping[str, Any]] | None = None,
+    review_at: str,
+) -> dict[str, Any]:
+    """Build an advisory proposal that references, but cannot replace, evidence."""
+
+    normalized_scores = _normalize_records(
+        objective_scores,
+        field="objective_scores",
+        spec=_OBJECTIVE_SCORE_SPEC,
+        required={"objective_id", "score", "rationale"},
+    )
+    if not normalized_scores:
+        raise ValueError("objective_scores must contain at least one objective")
+    packet: dict[str, Any] = {
+        "schema_version": DECISION_PROPOSAL_SCHEMA_VERSION,
+        "goal_id": _compact_token(goal_id, field="goal_id"),
+        "decision_id": _compact_token(decision_id, field="decision_id"),
+        "evidence_packet_ref": _compact_token(
+            evidence_packet_ref,
+            field="evidence_packet_ref",
+        ),
+        "observed_at": _iso_timestamp(observed_at, field="observed_at"),
+        "review_at": _iso_timestamp(review_at, field="review_at"),
+        "visibility": "public_safe",
+        "capability": _capability_contract(packet_role="advisory_proposal"),
+        "objective_scores": normalized_scores,
+        "recommended_decision": _normalize_record(
+            recommended_decision,
+            field="recommended_decision",
+            spec=_RECOMMENDED_DECISION_SPEC,
+            required={"option_id", "summary", "rationale", "confidence"},
+        ),
+        "alternatives": _normalize_records(
+            alternatives,
+            field="alternatives",
+            spec=_ALTERNATIVE_SPEC,
+            required={"alternative_id", "summary", "tradeoff"},
+        ),
+        "next_actions": _normalize_records(
+            next_actions,
+            field="next_actions",
+            spec=_NEXT_ACTION_SPEC,
+            required={
+                "action_id",
+                "owner_ref",
+                "summary",
+                "acceptance",
+                "stop_condition",
+            },
+        ),
+        "stop_list": _normalize_records(
+            stop_list,
+            field="stop_list",
+            spec=_STOP_ITEM_SPEC,
+            required={"stop_id", "summary", "condition"},
+        ),
+        "authority_confirmation_required": True,
+        "external_writes_performed": False,
+        "raw_context_captured": False,
+    }
+    packet["packet_ref"] = _packet_ref("decision-proposal", packet)
+    return packet
+
+
+_ACCEPTED_DECISION_SPEC = {
+    "option_id": "token",
+    "summary": "text",
+    "accepted_by": "token",
+    "accepted_at": "timestamp",
+}
+_TRANSITION_SPEC = {
+    "transition_id": "token",
+    "summary": "text",
+    "event_ref": "token",
+    "status": "token",
+}
+_OUTCOME_SPEC = {
+    "outcome_id": "token",
+    "summary": "text",
+    "evidence_ref": "token",
+    "status": "token",
+    "observed_at": "timestamp",
+}
+_INVALIDATED_ASSUMPTION_SPEC = {
+    "assumption_id": "token",
+    "summary": "text",
+    "evidence_ref": "token",
+    "invalidated_at": "timestamp",
+}
+
+
+def build_decision_outcome_receipt(
+    *,
+    goal_id: str,
+    decision_id: str,
+    proposal_packet_ref: str,
+    recorded_at: str,
+    verification_status: str,
+    accepted_decision: Mapping[str, Any],
+    resulting_transitions: Sequence[Mapping[str, Any]] | None = None,
+    observed_outcomes: Sequence[Mapping[str, Any]] | None = None,
+    invalidated_assumptions: Sequence[Mapping[str, Any]] | None = None,
+    review_at: str,
+) -> dict[str, Any]:
+    """Build an append-only receipt suitable for existing event/run history."""
+
+    status = _compact_token(verification_status, field="verification_status")
+    if status not in DECISION_OUTCOME_VERIFICATION_STATUSES:
+        raise ValueError(
+            "verification_status must be pending, verified, refuted, or inconclusive"
+        )
+    normalized_outcomes = _normalize_records(
+        observed_outcomes,
+        field="observed_outcomes",
+        spec=_OUTCOME_SPEC,
+        required={"outcome_id", "summary", "evidence_ref", "status", "observed_at"},
+    )
+    has_verified_outcome = any(
+        outcome["status"] == "verified" for outcome in normalized_outcomes
+    )
+    if status == "verified" and not has_verified_outcome:
+        raise ValueError(
+            "verified receipts require at least one verified observed outcome"
+        )
+    packet: dict[str, Any] = {
+        "schema_version": DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION,
+        "goal_id": _compact_token(goal_id, field="goal_id"),
+        "decision_id": _compact_token(decision_id, field="decision_id"),
+        "proposal_packet_ref": _compact_token(
+            proposal_packet_ref,
+            field="proposal_packet_ref",
+        ),
+        "recorded_at": _iso_timestamp(recorded_at, field="recorded_at"),
+        "review_at": _iso_timestamp(review_at, field="review_at"),
+        "verification_status": status,
+        "visibility": "public_safe",
+        "capability": _capability_contract(packet_role="append_only_outcome_receipt"),
+        "accepted_decision": _normalize_record(
+            accepted_decision,
+            field="accepted_decision",
+            spec=_ACCEPTED_DECISION_SPEC,
+            required={"option_id", "summary", "accepted_by", "accepted_at"},
+        ),
+        "resulting_transitions": _normalize_records(
+            resulting_transitions,
+            field="resulting_transitions",
+            spec=_TRANSITION_SPEC,
+            required={"transition_id", "summary", "event_ref", "status"},
+        ),
+        "observed_outcomes": normalized_outcomes,
+        "invalidated_assumptions": _normalize_records(
+            invalidated_assumptions,
+            field="invalidated_assumptions",
+            spec=_INVALIDATED_ASSUMPTION_SPEC,
+            required={
+                "assumption_id",
+                "summary",
+                "evidence_ref",
+                "invalidated_at",
+            },
+        ),
+        "reward_memory_candidate_eligible": (
+            status == "verified" and has_verified_outcome
+        ),
+        "external_writes_performed": False,
+        "raw_context_captured": False,
+    }
+    packet["packet_ref"] = _packet_ref("decision-outcome", packet)
+    return packet

--- a/loopx/capabilities/decision_context/sources.py
+++ b/loopx/capabilities/decision_context/sources.py
@@ -1,0 +1,394 @@
+"""Provider-neutral incremental source contracts for Decision Context."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Protocol
+
+DECISION_SOURCE_MANIFEST_SCHEMA_VERSION = "decision_source_manifest_v0"
+DECISION_SOURCE_SCAN_RECEIPT_SCHEMA_VERSION = "decision_source_scan_receipt_v0"
+
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+_SOURCE_KINDS = {
+    "artifact",
+    "conversation",
+    "document",
+    "external_signal",
+    "person",
+    "repository",
+}
+_PRIORITIES = {"p0", "p1", "p2"}
+_EVIDENCE_LEVELS = {"s0", "s1", "s2", "s3", "s4"}
+_SCAN_MODES = {"incremental", "on_demand", "snapshot"}
+_EXACT_READ_POLICIES = {"always", "material_change", "never"}
+_SCAN_STATUSES = {"completed", "failed", "no_change", "unavailable"}
+
+
+def _token(value: str, *, field_name: str) -> str:
+    text = str(value).strip()
+    if not _TOKEN_RE.fullmatch(text):
+        raise ValueError(
+            f"{field_name} must be a compact token containing only letters, "
+            "digits, dot, colon, dash, or underscore"
+        )
+    return text
+
+
+def _timestamp(value: str, *, field_name: str) -> str:
+    text = str(value).strip()
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field_name} must include a timezone")
+    return text
+
+
+def _positive_int(value: int, *, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{field_name} must be a positive integer")
+    return value
+
+
+def _non_negative_int(value: int, *, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field_name} must be a non-negative integer")
+    return value
+
+
+def _optional_token(value: str | None, *, field_name: str) -> str | None:
+    if value is None:
+        return None
+    return _token(value, field_name=field_name)
+
+
+def _opaque_ref(prefix: str, *values: str) -> str:
+    digest = hashlib.sha256("\n".join(values).encode("utf-8")).hexdigest()[:20]
+    return f"{prefix}-{digest}"
+
+
+def _packet_ref(prefix: str, packet: dict[str, object]) -> str:
+    payload = json.dumps(
+        packet,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return _opaque_ref(prefix, payload)
+
+
+@dataclass(frozen=True)
+class DecisionSourceSpec:
+    """Private provider configuration with a public-safe manifest projection."""
+
+    source_id: str
+    provider_id: str
+    source_kind: str
+    priority: str
+    evidence_level: str
+    objectives: tuple[str, ...]
+    scan_mode: str
+    exact_read_policy: str
+    freshness_seconds: int
+    private_locator: str = field(repr=False)
+    max_changes: int = 20
+    enabled: bool = True
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "source_id", _token(self.source_id, field_name="source_id")
+        )
+        object.__setattr__(
+            self, "provider_id", _token(self.provider_id, field_name="provider_id")
+        )
+        if self.source_kind not in _SOURCE_KINDS:
+            raise ValueError(f"source_kind must be one of {sorted(_SOURCE_KINDS)}")
+        if self.priority not in _PRIORITIES:
+            raise ValueError(f"priority must be one of {sorted(_PRIORITIES)}")
+        if self.evidence_level not in _EVIDENCE_LEVELS:
+            raise ValueError(
+                f"evidence_level must be one of {sorted(_EVIDENCE_LEVELS)}"
+            )
+        objectives = tuple(
+            sorted(
+                {
+                    _token(objective, field_name="objectives[]")
+                    for objective in self.objectives
+                }
+            )
+        )
+        if not objectives:
+            raise ValueError("objectives must contain at least one compact token")
+        object.__setattr__(self, "objectives", objectives)
+        if self.scan_mode not in _SCAN_MODES:
+            raise ValueError(f"scan_mode must be one of {sorted(_SCAN_MODES)}")
+        if self.exact_read_policy not in _EXACT_READ_POLICIES:
+            raise ValueError(
+                f"exact_read_policy must be one of {sorted(_EXACT_READ_POLICIES)}"
+            )
+        object.__setattr__(
+            self,
+            "freshness_seconds",
+            _positive_int(self.freshness_seconds, field_name="freshness_seconds"),
+        )
+        object.__setattr__(
+            self,
+            "max_changes",
+            _positive_int(self.max_changes, field_name="max_changes"),
+        )
+        if not isinstance(self.enabled, bool):
+            raise TypeError("enabled must be a boolean")
+        if not str(self.private_locator).strip():
+            raise ValueError("private_locator must be non-empty")
+
+    def public_record(self) -> dict[str, object]:
+        return {
+            "source_id": self.source_id,
+            "provider_id": self.provider_id,
+            "source_kind": self.source_kind,
+            "priority": self.priority,
+            "evidence_level": self.evidence_level,
+            "objectives": list(self.objectives),
+            "scan_mode": self.scan_mode,
+            "exact_read_policy": self.exact_read_policy,
+            "freshness_seconds": self.freshness_seconds,
+            "max_changes": self.max_changes,
+            "enabled": self.enabled,
+            "private_locator_captured": False,
+        }
+
+
+@dataclass(frozen=True)
+class DecisionSourceItem:
+    """One transient changed item returned by a source provider."""
+
+    resource_ref: str = field(repr=False)
+    revision: str = field(repr=False)
+    observed_at: str
+
+    def __post_init__(self) -> None:
+        if not str(self.resource_ref).strip():
+            raise ValueError("resource_ref must be non-empty")
+        if not str(self.revision).strip():
+            raise ValueError("revision must be non-empty")
+        _timestamp(self.observed_at, field_name="observed_at")
+
+
+@dataclass(frozen=True)
+class DecisionSourceExactRead:
+    """Transient exact content used by the agent, never by public packets."""
+
+    resource_ref: str = field(repr=False)
+    revision: str = field(repr=False)
+    observed_at: str
+    content: str = field(repr=False)
+    verified: bool = True
+
+    def __post_init__(self) -> None:
+        if not str(self.resource_ref).strip():
+            raise ValueError("resource_ref must be non-empty")
+        if not str(self.revision).strip():
+            raise ValueError("revision must be non-empty")
+        _timestamp(self.observed_at, field_name="observed_at")
+        if not str(self.content).strip():
+            raise ValueError("content must be non-empty")
+        if not isinstance(self.verified, bool):
+            raise TypeError("verified must be a boolean")
+
+
+@dataclass(frozen=True)
+class DecisionSourceScan:
+    """One bounded source scan with private cursors and transient items."""
+
+    provider_id: str
+    source_id: str
+    status: str
+    observed_at: str
+    requested_limit: int
+    cursor_before: str | None = field(default=None, repr=False)
+    cursor_after: str | None = field(default=None, repr=False)
+    items: tuple[DecisionSourceItem, ...] = ()
+    reason_code: str | None = None
+    provider_version: str | None = None
+    latency_ms: int = 0
+
+    def public_receipt(
+        self,
+        *,
+        exact_reads: Sequence[DecisionSourceExactRead] = (),
+    ) -> dict[str, object]:
+        provider_id = _token(self.provider_id, field_name="provider_id")
+        source_id = _token(self.source_id, field_name="source_id")
+        observed_at = _timestamp(self.observed_at, field_name="observed_at")
+        requested_limit = _positive_int(
+            self.requested_limit, field_name="requested_limit"
+        )
+        reason_code = _optional_token(self.reason_code, field_name="reason_code")
+        provider_version = _optional_token(
+            self.provider_version,
+            field_name="provider_version",
+        )
+        latency_ms = _non_negative_int(self.latency_ms, field_name="latency_ms")
+        if self.status not in _SCAN_STATUSES:
+            raise ValueError(f"status must be one of {sorted(_SCAN_STATUSES)}")
+        if self.status in {"failed", "unavailable"} and reason_code is None:
+            raise ValueError("failed or unavailable scans require reason_code")
+        if self.status in {"failed", "no_change", "unavailable"} and (
+            self.items or exact_reads
+        ):
+            raise ValueError(
+                "failed, no-change, or unavailable scans cannot contain "
+                "items or exact reads"
+            )
+        if len(self.items) > requested_limit:
+            raise ValueError("scan items cannot exceed requested_limit")
+
+        read_keys = {
+            (read.resource_ref, read.revision) for read in exact_reads if read.verified
+        }
+        item_keys = {(item.resource_ref, item.revision) for item in self.items}
+        if len(item_keys) != len(self.items):
+            raise ValueError("scan items must have unique resource and revision pairs")
+        if not read_keys <= item_keys:
+            raise ValueError("exact reads must reference an item from this scan")
+
+        changes = []
+        for item in self.items:
+            item_observed_at = _timestamp(
+                item.observed_at, field_name="item.observed_at"
+            )
+            changes.append(
+                {
+                    "change_ref": _opaque_ref(
+                        "source-change",
+                        provider_id,
+                        source_id,
+                        item.resource_ref,
+                    ),
+                    "revision_ref": _opaque_ref(
+                        "source-revision",
+                        provider_id,
+                        source_id,
+                        item.resource_ref,
+                        item.revision,
+                    ),
+                    "observed_at": item_observed_at,
+                    "exact_read_verified": (
+                        item.resource_ref,
+                        item.revision,
+                    )
+                    in read_keys,
+                }
+            )
+        changes.sort(key=lambda record: str(record["change_ref"]))
+
+        packet: dict[str, object] = {
+            "schema_version": DECISION_SOURCE_SCAN_RECEIPT_SCHEMA_VERSION,
+            "capability_id": "decision_context",
+            "scope": "goal",
+            "default_enabled": False,
+            "provider_id": provider_id,
+            "source_id": source_id,
+            "status": self.status,
+            "reason_code": reason_code,
+            "provider_version": provider_version,
+            "observed_at": observed_at,
+            "requested_limit": requested_limit,
+            "changed_count": len(changes),
+            "exact_read_count": len(read_keys),
+            "changes": changes,
+            "cursor_before_ref": (
+                _opaque_ref("source-cursor", provider_id, source_id, self.cursor_before)
+                if self.cursor_before
+                else None
+            ),
+            "cursor_after_ref": (
+                _opaque_ref("source-cursor", provider_id, source_id, self.cursor_after)
+                if self.cursor_after
+                else None
+            ),
+            "provider_fail_open": True,
+            "external_writes_performed": False,
+            "raw_content_captured": False,
+            "raw_provider_payload_captured": False,
+            "private_locator_captured": False,
+            "private_cursor_captured": False,
+            "credentials_captured": False,
+            "telemetry": {
+                "latency_ms": latency_ms,
+                "result_cap_applied": len(changes) == requested_limit,
+            },
+        }
+        packet["receipt_ref"] = _packet_ref("decision-source-scan", packet)
+        return packet
+
+
+class DecisionSourceProvider(Protocol):
+    """Change detection and exact read for an authority source.
+
+    This is intentionally separate from ``ContextProvider``: source providers
+    rebase current authority, while context providers recall advisory memory.
+    """
+
+    provider_id: str
+
+    def scan(
+        self,
+        *,
+        source: DecisionSourceSpec,
+        after_cursor: str | None,
+        before: str,
+        limit: int,
+        timeout_seconds: float,
+        observed_at: str,
+    ) -> DecisionSourceScan: ...
+
+    def exact_read(
+        self,
+        *,
+        source: DecisionSourceSpec,
+        item: DecisionSourceItem,
+        timeout_seconds: float,
+        observed_at: str,
+    ) -> DecisionSourceExactRead: ...
+
+
+def build_decision_source_manifest(
+    *,
+    goal_id: str,
+    observed_at: str,
+    sources: Sequence[DecisionSourceSpec],
+) -> dict[str, object]:
+    """Build a deterministic public projection of private source config."""
+
+    goal_id = _token(goal_id, field_name="goal_id")
+    observed_at = _timestamp(observed_at, field_name="observed_at")
+    records = [source.public_record() for source in sources]
+    records.sort(key=lambda record: str(record["source_id"]))
+    source_ids = [str(record["source_id"]) for record in records]
+    if len(source_ids) != len(set(source_ids)):
+        raise ValueError("source_id values must be unique")
+
+    packet: dict[str, object] = {
+        "schema_version": DECISION_SOURCE_MANIFEST_SCHEMA_VERSION,
+        "capability_id": "decision_context",
+        "scope": "goal",
+        "default_enabled": False,
+        "goal_id": goal_id,
+        "observed_at": observed_at,
+        "sources": records,
+        "source_count": len(records),
+        "creates_authority": False,
+        "mutates_core_state": False,
+        "external_writes_performed": False,
+        "private_locators_captured": False,
+        "private_cursors_captured": False,
+    }
+    packet["manifest_ref"] = _packet_ref("decision-source-manifest", packet)
+    return packet

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -10,6 +10,10 @@ from .capabilities.content_ops.cli import (
     handle_content_ops_command,
     register_content_ops_commands,
 )
+from .capabilities.decision_context.cli import (
+    handle_decision_context_command,
+    register_decision_context_commands,
+)
 from .capabilities.issue_fix.cli import (
     handle_issue_fix_command,
     register_issue_fix_commands,
@@ -191,6 +195,8 @@ def build_parser() -> LoopXArgumentParser:
     register_extension_commands(sub, add_subcommand_format)
 
     register_content_ops_commands(sub, add_subcommand_format)
+
+    register_decision_context_commands(sub, add_subcommand_format)
 
     register_issue_fix_commands(sub, add_subcommand_format)
 
@@ -456,6 +462,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     if reward_memory_result is not None:
         return reward_memory_result
+
+    decision_context_result = handle_decision_context_command(
+        args,
+        output_format=output_format,
+        print_payload=print_payload,
+    )
+    if decision_context_result is not None:
+        return decision_context_result
 
     review_batch_result = handle_review_batch_command(
         args,

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -216,6 +216,7 @@ MANPAGE_COMMAND_HELP_ONLY = frozenset(
         "codex-cli-visible-session-proof",
         "configure-goal",
         "content-ops",
+        "decision-context",
         "demo",
         "dreaming",
         "global-summary",

--- a/tests/capabilities/test_capability_extension_registry.py
+++ b/tests/capabilities/test_capability_extension_registry.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -22,9 +22,9 @@ from loopx.extensions.runtime import (
     install_extension,
 )
 
-
 BUILTIN_IDS = [
     "issue-fix",
+    "decision-context",
     "semantic-preference",
     "reward-memory",
     "periodic-report",

--- a/tests/capabilities/test_decision_context_packets.py
+++ b/tests/capabilities/test_decision_context_packets.py
@@ -1,0 +1,417 @@
+from __future__ import annotations
+
+import pytest
+
+from loopx.capabilities.decision_context import (
+    build_decision_evidence_packet,
+    build_decision_outcome_receipt,
+    build_decision_proposal,
+)
+
+OBSERVED_AT = "2026-07-25T13:30:00+00:00"
+REVIEW_AT = "2026-07-28T13:30:00+00:00"
+
+
+def evidence_packet() -> dict[str, object]:
+    return build_decision_evidence_packet(
+        goal_id="goal:decision-advisor",
+        decision_id="decision:20260725:priority",
+        observed_at=OBSERVED_AT,
+        changed_facts=[
+            {
+                "fact_id": "fact:adoption-stage",
+                "summary": "One lead advanced from discussion to a bounded pilot.",
+                "source_ref": "authority:collaboration-ledger",
+                "source_revision": "revision:42",
+                "observed_at": OBSERVED_AT,
+                "freshness": "current",
+                "authority": "first_party_receipt",
+            }
+        ],
+        recalled_claims=[
+            {
+                "claim_id": "claim:old-priority",
+                "summary": "The previous priority favored protocol expansion.",
+                "provider_ref": "provider-0123456789abcdef",
+                "source_ref": "authority:decision-ledger",
+                "source_revision": "revision:41",
+                "observed_at": OBSERVED_AT,
+                "exact_read_verified": True,
+                "confidence": 0.8,
+            }
+        ],
+        stale_or_rejected_claims=[
+            {
+                "claim_id": "claim:stale-user-count",
+                "summary": "The recalled user count predates the current ledger.",
+                "source_ref": "authority:traction-ledger",
+                "source_revision": "revision:39",
+                "observed_at": OBSERVED_AT,
+                "reason_code": "superseded_revision",
+            }
+        ],
+        conflicts=[
+            {
+                "conflict_id": "conflict:traction-stage",
+                "summary": "A semantic memory says adopted while the ledger says pilot.",
+                "source_refs": [
+                    "provider:semantic-memory",
+                    "authority:traction-ledger",
+                ],
+                "conflict_rule": "canonical_revision_wins",
+                "status": "resolved",
+            }
+        ],
+        source_revisions=[
+            {
+                "source_ref": "authority:traction-ledger",
+                "revision": "revision:42",
+                "observed_at": OBSERVED_AT,
+                "freshness": "current",
+            }
+        ],
+        provider_health=[
+            {
+                "provider": "openviking",
+                "status": "healthy",
+                "observed_at": OBSERVED_AT,
+                "fail_open": True,
+            }
+        ],
+    )
+
+
+def proposal_packet(evidence_ref: str) -> dict[str, object]:
+    return build_decision_proposal(
+        goal_id="goal:decision-advisor",
+        decision_id="decision:20260725:priority",
+        evidence_packet_ref=evidence_ref,
+        observed_at=OBSERVED_AT,
+        review_at=REVIEW_AT,
+        objective_scores=[
+            {
+                "objective_id": "objective:external-adoption",
+                "score": 0.8,
+                "rationale": "A bounded pilot can produce a real outcome receipt.",
+            }
+        ],
+        recommended_decision={
+            "option_id": "option:finish-pilot",
+            "summary": "Close one pilot before adding another protocol.",
+            "rationale": "Observed adoption compounds more than additional surface area.",
+            "confidence": 0.85,
+        },
+        alternatives=[
+            {
+                "alternative_id": "option:add-protocol",
+                "summary": "Add another protocol first.",
+                "tradeoff": "More breadth but no new adoption evidence.",
+            }
+        ],
+        next_actions=[
+            {
+                "action_id": "action:pilot-receipt",
+                "owner_ref": "agent:decision-advisor",
+                "summary": "Collect the pilot outcome receipt.",
+                "acceptance": "One first-party outcome is revision-stamped.",
+                "stop_condition": "Stop if the pilot owner does not confirm scope.",
+            }
+        ],
+        stop_list=[
+            {
+                "stop_id": "stop:new-protocol",
+                "summary": "Do not add another protocol during this window.",
+                "condition": "Resume only after the pilot receipt is reviewed.",
+            }
+        ],
+    )
+
+
+def test_evidence_packet_is_evidence_only_and_public_safe() -> None:
+    packet = evidence_packet()
+
+    assert packet["schema_version"] == "decision_evidence_packet_v0"
+    assert packet["capability"] == {
+        "capability_id": "decision_context",
+        "scope": "goal",
+        "default_enabled": False,
+        "packet_role": "evidence",
+        "creates_authority": False,
+        "mutates_core_state": False,
+    }
+    assert "recommended_decision" not in packet
+    assert packet["provider_fail_open"] is True
+    assert packet["raw_context_captured"] is False
+    assert str(packet["packet_ref"]).startswith("decision-evidence-")
+
+
+def test_evidence_packet_fingerprint_is_order_independent() -> None:
+    first = build_decision_evidence_packet(
+        goal_id="goal:example",
+        decision_id="decision:example",
+        observed_at=OBSERVED_AT,
+        changed_facts=[
+            {
+                "fact_id": "fact:b",
+                "summary": "Second fact.",
+                "source_ref": "source:b",
+                "observed_at": OBSERVED_AT,
+            },
+            {
+                "fact_id": "fact:a",
+                "summary": "First fact.",
+                "source_ref": "source:a",
+                "observed_at": OBSERVED_AT,
+            },
+        ],
+    )
+    second = build_decision_evidence_packet(
+        goal_id="goal:example",
+        decision_id="decision:example",
+        observed_at=OBSERVED_AT,
+        changed_facts=list(reversed(first["changed_facts"])),
+    )
+
+    assert first == second
+
+
+def test_evidence_packet_rejects_raw_context_fields() -> None:
+    with pytest.raises(ValueError, match="unsafe fields: raw_content"):
+        build_decision_evidence_packet(
+            goal_id="goal:example",
+            decision_id="decision:example",
+            observed_at=OBSERVED_AT,
+            changed_facts=[
+                {
+                    "fact_id": "fact:a",
+                    "summary": "Compact fact.",
+                    "source_ref": "source:a",
+                    "observed_at": OBSERVED_AT,
+                    "raw_content": "private transcript",
+                }
+            ],
+        )
+
+
+def test_evidence_packet_rejects_raw_source_urls() -> None:
+    with pytest.raises(ValueError, match="opaque source reference"):
+        build_decision_evidence_packet(
+            goal_id="goal:example",
+            decision_id="decision:example",
+            observed_at=OBSERVED_AT,
+            changed_facts=[
+                {
+                    "fact_id": "fact:a",
+                    "summary": "See https://example.invalid/document for details.",
+                    "source_ref": "source:a",
+                    "observed_at": OBSERVED_AT,
+                }
+            ],
+        )
+
+
+@pytest.mark.parametrize(
+    "sensitive_summary",
+    [
+        "Author" + "ization: sample-value",
+        "Bear" + "er sample-value",
+        "api" + "_key=sample-value",
+    ],
+)
+def test_evidence_packet_rejects_secret_bearing_text(
+    sensitive_summary: str,
+) -> None:
+    with pytest.raises(ValueError, match="credential-like value"):
+        build_decision_evidence_packet(
+            goal_id="goal:example",
+            decision_id="decision:example",
+            observed_at=OBSERVED_AT,
+            changed_facts=[
+                {
+                    "fact_id": "fact:a",
+                    "summary": sensitive_summary,
+                    "source_ref": "source:a",
+                    "observed_at": OBSERVED_AT,
+                }
+            ],
+        )
+
+
+def test_evidence_packet_rejects_unverified_recalled_claims() -> None:
+    with pytest.raises(ValueError, match="must be exact-read verified"):
+        build_decision_evidence_packet(
+            goal_id="goal:example",
+            decision_id="decision:example",
+            observed_at=OBSERVED_AT,
+            recalled_claims=[
+                {
+                    "claim_id": "claim:unverified",
+                    "summary": "The provider returned a claim without exact read.",
+                    "provider_ref": "provider:memory",
+                    "source_ref": "source:authority",
+                    "source_revision": "revision:1",
+                    "observed_at": OBSERVED_AT,
+                    "exact_read_verified": False,
+                }
+            ],
+        )
+
+
+def test_evidence_packet_rejects_non_fail_open_provider_health() -> None:
+    with pytest.raises(ValueError, match="must preserve fail-open"):
+        build_decision_evidence_packet(
+            goal_id="goal:example",
+            decision_id="decision:example",
+            observed_at=OBSERVED_AT,
+            provider_health=[
+                {
+                    "provider": "memory-provider",
+                    "status": "unavailable",
+                    "observed_at": OBSERVED_AT,
+                    "fail_open": False,
+                }
+            ],
+        )
+
+
+def test_proposal_is_advisory_and_references_evidence() -> None:
+    evidence = evidence_packet()
+    proposal = proposal_packet(str(evidence["packet_ref"]))
+
+    assert proposal["schema_version"] == "decision_proposal_v0"
+    assert proposal["evidence_packet_ref"] == evidence["packet_ref"]
+    assert proposal["capability"]["creates_authority"] is False
+    assert proposal["authority_confirmation_required"] is True
+    assert "changed_facts" not in proposal
+    assert str(proposal["packet_ref"]).startswith("decision-proposal-")
+
+
+def test_proposal_requires_at_least_one_objective_score() -> None:
+    with pytest.raises(ValueError, match="at least one objective"):
+        build_decision_proposal(
+            goal_id="goal:example",
+            decision_id="decision:example",
+            evidence_packet_ref="decision-evidence-example",
+            observed_at=OBSERVED_AT,
+            review_at=REVIEW_AT,
+            objective_scores=[],
+            recommended_decision={
+                "option_id": "option:a",
+                "summary": "Choose A.",
+                "rationale": "A has evidence.",
+                "confidence": 0.7,
+            },
+        )
+
+
+def test_verified_outcome_receipt_can_create_reward_memory_candidate() -> None:
+    evidence = evidence_packet()
+    proposal = proposal_packet(str(evidence["packet_ref"]))
+    receipt = build_decision_outcome_receipt(
+        goal_id="goal:decision-advisor",
+        decision_id="decision:20260725:priority",
+        proposal_packet_ref=str(proposal["packet_ref"]),
+        recorded_at=REVIEW_AT,
+        review_at="2026-08-01T13:30:00+00:00",
+        verification_status="verified",
+        accepted_decision={
+            "option_id": "option:finish-pilot",
+            "summary": "Close one pilot before adding another protocol.",
+            "accepted_by": "owner:goal",
+            "accepted_at": OBSERVED_AT,
+        },
+        resulting_transitions=[
+            {
+                "transition_id": "transition:todo-to-complete",
+                "summary": "The pilot todo reached a verified terminal state.",
+                "event_ref": "event:pilot-complete",
+                "status": "completed",
+            }
+        ],
+        observed_outcomes=[
+            {
+                "outcome_id": "outcome:first-party-receipt",
+                "summary": "The pilot owner confirmed one realized workflow gain.",
+                "evidence_ref": "evidence:pilot-owner-receipt",
+                "status": "verified",
+                "observed_at": REVIEW_AT,
+            }
+        ],
+        invalidated_assumptions=[
+            {
+                "assumption_id": "assumption:protocol-first",
+                "summary": "Another protocol was not required to close the pilot.",
+                "evidence_ref": "evidence:pilot-owner-receipt",
+                "invalidated_at": REVIEW_AT,
+            }
+        ],
+    )
+
+    assert receipt["schema_version"] == "decision_outcome_receipt_v0"
+    assert receipt["proposal_packet_ref"] == proposal["packet_ref"]
+    assert receipt["reward_memory_candidate_eligible"] is True
+    assert receipt["capability"]["creates_authority"] is False
+
+
+def test_unverified_outcome_receipt_is_not_reward_memory_eligible() -> None:
+    receipt = build_decision_outcome_receipt(
+        goal_id="goal:example",
+        decision_id="decision:example",
+        proposal_packet_ref="decision-proposal-example",
+        recorded_at=OBSERVED_AT,
+        review_at=REVIEW_AT,
+        verification_status="pending",
+        accepted_decision={
+            "option_id": "option:a",
+            "summary": "Choose A.",
+            "accepted_by": "owner:goal",
+            "accepted_at": OBSERVED_AT,
+        },
+    )
+
+    assert receipt["reward_memory_candidate_eligible"] is False
+
+
+def test_verified_outcome_requires_observed_evidence() -> None:
+    with pytest.raises(ValueError, match="at least one verified observed outcome"):
+        build_decision_outcome_receipt(
+            goal_id="goal:example",
+            decision_id="decision:example",
+            proposal_packet_ref="decision-proposal-example",
+            recorded_at=OBSERVED_AT,
+            review_at=REVIEW_AT,
+            verification_status="verified",
+            accepted_decision={
+                "option_id": "option:a",
+                "summary": "Choose A.",
+                "accepted_by": "owner:goal",
+                "accepted_at": OBSERVED_AT,
+            },
+        )
+
+
+def test_verified_outcome_rejects_only_pending_evidence() -> None:
+    with pytest.raises(ValueError, match="at least one verified observed outcome"):
+        build_decision_outcome_receipt(
+            goal_id="goal:example",
+            decision_id="decision:example",
+            proposal_packet_ref="decision-proposal-example",
+            recorded_at=OBSERVED_AT,
+            review_at=REVIEW_AT,
+            verification_status="verified",
+            accepted_decision={
+                "option_id": "option:a",
+                "summary": "Choose A.",
+                "accepted_by": "owner:goal",
+                "accepted_at": OBSERVED_AT,
+            },
+            observed_outcomes=[
+                {
+                    "outcome_id": "outcome:pending",
+                    "summary": "The outcome has not been verified yet.",
+                    "evidence_ref": "evidence:pending",
+                    "status": "pending",
+                    "observed_at": OBSERVED_AT,
+                }
+            ],
+        )

--- a/tests/capabilities/test_decision_context_sources.py
+++ b/tests/capabilities/test_decision_context_sources.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from loopx.capabilities.decision_context import (
+    DecisionSourceExactRead,
+    DecisionSourceItem,
+    DecisionSourceScan,
+    DecisionSourceSpec,
+    build_decision_source_manifest,
+)
+
+OBSERVED_AT = "2026-07-25T13:30:00+00:00"
+
+
+def messaging_source() -> DecisionSourceSpec:
+    return DecisionSourceSpec(
+        source_id="source:messaging:owner",
+        provider_id="messaging-provider",
+        source_kind="person",
+        priority="p0",
+        evidence_level="s2",
+        objectives=("product-adoption",),
+        scan_mode="incremental",
+        exact_read_policy="material_change",
+        freshness_seconds=3 * 24 * 60 * 60,
+        private_locator="private_conversation_locator",
+        max_changes=20,
+    )
+
+
+def test_manifest_is_deterministic_and_omits_private_locator() -> None:
+    owner = messaging_source()
+    ecosystem = DecisionSourceSpec(
+        source_id="source:repository:ecosystem",
+        provider_id="repository-provider",
+        source_kind="repository",
+        priority="p1",
+        evidence_level="s2",
+        objectives=("ecosystem-adoption", "product-adoption"),
+        scan_mode="incremental",
+        exact_read_policy="material_change",
+        freshness_seconds=3 * 24 * 60 * 60,
+        private_locator="private_repository_locator",
+    )
+
+    first = build_decision_source_manifest(
+        goal_id="goal:decision-advisor",
+        observed_at=OBSERVED_AT,
+        sources=[owner, ecosystem],
+    )
+    second = build_decision_source_manifest(
+        goal_id="goal:decision-advisor",
+        observed_at=OBSERVED_AT,
+        sources=[ecosystem, owner],
+    )
+
+    assert first == second
+    serialized = json.dumps(first, sort_keys=True)
+    assert "private_conversation_locator" not in serialized
+    assert "private_repository_locator" not in serialized
+    ecosystem_record = next(
+        record
+        for record in first["sources"]
+        if record["source_id"] == "source:repository:ecosystem"
+    )
+    assert ecosystem_record["objectives"] == [
+        "ecosystem-adoption",
+        "product-adoption",
+    ]
+    assert first["private_locators_captured"] is False
+
+
+def test_manifest_rejects_duplicate_source_ids() -> None:
+    with pytest.raises(ValueError, match="source_id values must be unique"):
+        build_decision_source_manifest(
+            goal_id="goal:decision-advisor",
+            observed_at=OBSERVED_AT,
+            sources=[messaging_source(), messaging_source()],
+        )
+
+
+def test_scan_receipt_hides_cursor_item_revision_and_content() -> None:
+    item = DecisionSourceItem(
+        resource_ref="om_private_message_id",
+        revision="private_message_revision",
+        observed_at=OBSERVED_AT,
+    )
+    exact_read = DecisionSourceExactRead(
+        resource_ref=item.resource_ref,
+        revision=item.revision,
+        observed_at=OBSERVED_AT,
+        content="private conversation content",
+    )
+    scan = DecisionSourceScan(
+        provider_id="messaging-provider",
+        source_id="source:messaging:owner",
+        status="completed",
+        observed_at=OBSERVED_AT,
+        requested_limit=20,
+        cursor_before="private_cursor_before",
+        cursor_after="private_cursor_after",
+        items=(item,),
+        latency_ms=15,
+    )
+
+    receipt = scan.public_receipt(exact_reads=[exact_read])
+    serialized = json.dumps(receipt, sort_keys=True)
+
+    for private_value in (
+        "private_cursor_before",
+        "private_cursor_after",
+        "om_private_message_id",
+        "private_message_revision",
+        "private conversation content",
+    ):
+        assert private_value not in serialized
+    assert receipt["changed_count"] == 1
+    assert receipt["exact_read_count"] == 1
+    assert receipt["changes"][0]["exact_read_verified"] is True
+    assert receipt["private_cursor_captured"] is False
+    assert receipt["raw_content_captured"] is False
+
+
+def test_scan_receipt_rejects_exact_read_from_another_scan() -> None:
+    scan = DecisionSourceScan(
+        provider_id="messaging-provider",
+        source_id="source:messaging:owner",
+        status="completed",
+        observed_at=OBSERVED_AT,
+        requested_limit=20,
+        items=(
+            DecisionSourceItem(
+                resource_ref="message:a",
+                revision="revision:a",
+                observed_at=OBSERVED_AT,
+            ),
+        ),
+    )
+    unrelated = DecisionSourceExactRead(
+        resource_ref="message:b",
+        revision="revision:b",
+        observed_at=OBSERVED_AT,
+        content="transient",
+    )
+
+    with pytest.raises(ValueError, match="must reference an item"):
+        scan.public_receipt(exact_reads=[unrelated])
+
+
+def test_unavailable_provider_fails_open_without_changes() -> None:
+    receipt = DecisionSourceScan(
+        provider_id="messaging-provider",
+        source_id="source:messaging:owner",
+        status="unavailable",
+        observed_at=OBSERVED_AT,
+        requested_limit=20,
+        reason_code="provider_auth_unavailable",
+    ).public_receipt()
+
+    assert receipt["provider_fail_open"] is True
+    assert receipt["changed_count"] == 0
+    assert receipt["exact_read_count"] == 0
+    assert receipt["status"] == "unavailable"
+
+
+def test_scan_receipt_rejects_unbounded_or_unsafe_public_metadata() -> None:
+    item = DecisionSourceItem(
+        resource_ref="resource:a",
+        revision="revision:a",
+        observed_at=OBSERVED_AT,
+    )
+
+    with pytest.raises(ValueError, match="cannot exceed requested_limit"):
+        DecisionSourceScan(
+            provider_id="repository-provider",
+            source_id="source:repository:signals",
+            status="completed",
+            observed_at=OBSERVED_AT,
+            requested_limit=1,
+            items=(item, item),
+        ).public_receipt()
+
+    with pytest.raises(ValueError, match="compact token"):
+        DecisionSourceScan(
+            provider_id="repository-provider",
+            source_id="source:repository:signals",
+            status="unavailable",
+            observed_at=OBSERVED_AT,
+            requested_limit=1,
+            reason_code="see https://example.invalid/error",
+        ).public_receipt()
+
+
+def test_no_change_scan_cannot_smuggle_items() -> None:
+    with pytest.raises(ValueError, match="no-change"):
+        DecisionSourceScan(
+            provider_id="repository-provider",
+            source_id="source:repository:signals",
+            status="no_change",
+            observed_at=OBSERVED_AT,
+            requested_limit=1,
+            items=(
+                DecisionSourceItem(
+                    resource_ref="resource:a",
+                    revision="revision:a",
+                    observed_at=OBSERVED_AT,
+                ),
+            ),
+        ).public_receipt()


### PR DESCRIPTION
## Summary

- add default-off, goal-scoped Decision Context contracts for evidence, advisory proposals, verified outcome receipts, and incremental source manifests/scan receipts
- add `loopx decision-context architecture`, capability catalog registration, and a durable end-to-end smoke
- document the boundary with Reward Memory, ContextProvider, authority sources, and Core lifecycle writeback in English and Chinese

## Boundaries

- no concrete provider adapter, private source config, raw context capture, or Core authority/state mutation
- source providers rebase current authority; context providers only supply advisory recall
- verified outcome evidence is required before Reward Memory candidate eligibility

## Validation

- 35 targeted packet/source/import-boundary tests passed
- Decision Context contract, capability registry, placement-doc, and CLI help/manpage smokes passed
- Ruff check and format checks passed
- premerge canary passed: 18/18 selected checks, including public/private boundary validation

## Excluded

- no private goal state, chat data, provider credentials, local paths, or generated run artifacts