### PR TITLE
Project typed SkillsBench auth readiness

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -1085,6 +1085,13 @@ session. Keep one SSH multiplexed master warm for the benchmark slice and run
 remote commands through that connection. This is an operator workflow
 convention, not a LoopX protocol requirement.
 
+Use `python3 -m loopx.benchmark_adapters.skillsbench_runner_profile probe-ssh`
+as the task-free readiness receipt. Its typed fields distinguish local GSSAPI
+ticket presence from remote task-free SSH acceptance without recording command
+output or profile values. A present local ticket is not sufficient evidence to
+launch: `readiness_state` must be `ready`. Keep the benchmark blocked on
+`remote_task_free_acceptance_failed` while unrelated runnable work continues.
+
 For repeated benchmark work, prefer a host-local SSH config stanza instead of
 spelling the multiplexing flags on every command:
 

--- a/loopx/benchmark_adapters/skillsbench_runner_profile.py
+++ b/loopx/benchmark_adapters/skillsbench_runner_profile.py
@@ -199,6 +199,45 @@ def _gssapi_configured(ssh_options: Sequence[str]) -> bool:
     return False
 
 
+def _effective_gssapi_configured(
+    *,
+    ssh_options: Sequence[str],
+    destination: str,
+    timeout_seconds: int,
+) -> bool:
+    if _gssapi_configured(ssh_options):
+        return True
+    flattened_options = [
+        argument
+        for option in ssh_options
+        for argument in ("-o", option)
+    ]
+    try:
+        completed = subprocess.run(
+            ["ssh", "-G", *flattened_options, destination],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=min(timeout_seconds, 5),
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if completed.returncode != 0:
+        return False
+    effective_options = [
+        "gssapiauthentication="
+        + line.partition(" ")[2]
+        if line.lower().startswith("gssapiauthentication ")
+        else "preferredauthentications="
+        + line.partition(" ")[2]
+        if line.lower().startswith("preferredauthentications ")
+        else ""
+        for line in completed.stdout.splitlines()
+    ]
+    return _gssapi_configured([option for option in effective_options if option])
+
+
 def _local_gssapi_ticket_state(*, gssapi_configured: bool) -> str:
     if not gssapi_configured:
         return "not_checked"
@@ -227,13 +266,17 @@ def probe_skillsbench_runner_connectivity(
         raise SkillsBenchRunnerProfileError("ssh_options_invalid") from error
     for option in options:
         ssh_options.extend(["-o", option])
-    gssapi_configured = _gssapi_configured(options)
-    local_gssapi_ticket_state = _local_gssapi_ticket_state(
-        gssapi_configured=gssapi_configured
-    )
     destination = str(profile.get("SKILLSBENCH_SSH_DESTINATION") or "")
     if not destination:
         raise SkillsBenchRunnerProfileError("required_runner_environment_missing")
+    gssapi_configured = _effective_gssapi_configured(
+        ssh_options=options,
+        destination=destination,
+        timeout_seconds=timeout_seconds,
+    )
+    local_gssapi_ticket_state = _local_gssapi_ticket_state(
+        gssapi_configured=gssapi_configured
+    )
     try:
         completed = subprocess.run(
             [

--- a/loopx/benchmark_adapters/skillsbench_runner_profile.py
+++ b/loopx/benchmark_adapters/skillsbench_runner_profile.py
@@ -180,6 +180,41 @@ def skillsbench_runner_profile_summary(
     }
 
 
+def _gssapi_configured(ssh_options: Sequence[str]) -> bool:
+    for option in ssh_options:
+        key, separator, value = option.partition("=")
+        if not separator:
+            continue
+        normalized_key = key.strip().lower()
+        normalized_value = value.strip().lower()
+        if normalized_key == "gssapiauthentication":
+            if normalized_value in {"yes", "true"}:
+                return True
+        if normalized_key == "preferredauthentications":
+            if any(
+                method.strip().startswith("gssapi")
+                for method in normalized_value.split(",")
+            ):
+                return True
+    return False
+
+
+def _local_gssapi_ticket_state(*, gssapi_configured: bool) -> str:
+    if not gssapi_configured:
+        return "not_checked"
+    try:
+        completed = subprocess.run(
+            ["klist", "-s"],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return "probe_unavailable"
+    return "present" if completed.returncode == 0 else "missing"
+
+
 def probe_skillsbench_runner_connectivity(
     profile: Mapping[str, str],
     *,
@@ -192,6 +227,10 @@ def probe_skillsbench_runner_connectivity(
         raise SkillsBenchRunnerProfileError("ssh_options_invalid") from error
     for option in options:
         ssh_options.extend(["-o", option])
+    gssapi_configured = _gssapi_configured(options)
+    local_gssapi_ticket_state = _local_gssapi_ticket_state(
+        gssapi_configured=gssapi_configured
+    )
     destination = str(profile.get("SKILLSBENCH_SSH_DESTINATION") or "")
     if not destination:
         raise SkillsBenchRunnerProfileError("required_runner_environment_missing")
@@ -218,18 +257,37 @@ def probe_skillsbench_runner_connectivity(
             "schema_version": SKILLSBENCH_RUNNER_CONNECTIVITY_PROBE_SCHEMA_VERSION,
             "reachable": False,
             "result": "transport_unavailable",
+            "readiness_state": "transport_unavailable",
+            "gssapi_configured": gssapi_configured,
+            "local_gssapi_ticket_state": local_gssapi_ticket_state,
+            "remote_task_free_acceptance": False,
+            "task_free_connection_attempt_completed": False,
             "task_material_read": False,
             "benchmark_job_launched": False,
             "raw_output_recorded": False,
             "profile_values_recorded": False,
         }
+    reachable = completed.returncode == 0
+    if reachable:
+        readiness_state = "ready"
+    elif not gssapi_configured:
+        readiness_state = "transport_unavailable"
+    elif local_gssapi_ticket_state == "missing":
+        readiness_state = "local_gssapi_ticket_missing"
+    elif local_gssapi_ticket_state == "present":
+        readiness_state = "remote_task_free_acceptance_failed"
+    else:
+        readiness_state = "remote_task_free_acceptance_unverified"
     return {
         "ok": True,
         "schema_version": SKILLSBENCH_RUNNER_CONNECTIVITY_PROBE_SCHEMA_VERSION,
-        "reachable": completed.returncode == 0,
-        "result": (
-            "reachable" if completed.returncode == 0 else "transport_unavailable"
-        ),
+        "reachable": reachable,
+        "result": "reachable" if reachable else "transport_unavailable",
+        "readiness_state": readiness_state,
+        "gssapi_configured": gssapi_configured,
+        "local_gssapi_ticket_state": local_gssapi_ticket_state,
+        "remote_task_free_acceptance": reachable,
+        "task_free_connection_attempt_completed": True,
         "task_material_read": False,
         "benchmark_job_launched": False,
         "raw_output_recorded": False,

--- a/tests/test_skillsbench_runner_profile.py
+++ b/tests/test_skillsbench_runner_profile.py
@@ -196,3 +196,37 @@ def test_probe_ssh_distinguishes_local_ticket_from_remote_acceptance(
         assert probe["task_material_read"] is False
         assert probe["benchmark_job_launched"] is False
         assert probe["raw_output_recorded"] is False
+
+
+def test_probe_ssh_reads_gssapi_from_effective_host_config(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_ssh = fake_bin / "ssh"
+    fake_klist = fake_bin / "klist"
+    fake_ssh.write_text(
+        "#!/bin/sh\n"
+        "if [ \"$1\" = '-G' ]; then\n"
+        "  printf 'gssapiauthentication yes\\n'\n"
+        "  exit 0\n"
+        "fi\n"
+        "exit 255\n",
+        encoding="utf-8",
+    )
+    fake_ssh.chmod(0o755)
+    fake_klist.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_klist.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}{os.environ['PATH']}")
+
+    probe = probe_skillsbench_runner_connectivity(
+        {"SKILLSBENCH_SSH_DESTINATION": "runner.example.invalid"}
+    )
+
+    assert probe["reachable"] is False
+    assert probe["gssapi_configured"] is True
+    assert probe["local_gssapi_ticket_state"] == "present"
+    assert probe["remote_task_free_acceptance"] is False
+    assert probe["readiness_state"] == "remote_task_free_acceptance_failed"
+    assert probe["raw_output_recorded"] is False

--- a/tests/test_skillsbench_runner_profile.py
+++ b/tests/test_skillsbench_runner_profile.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from loopx.benchmark_adapters.skillsbench_runner_profile import (
     SKILLSBENCH_RUNNER_PROFILE_SCHEMA_VERSION,
     capture_skillsbench_runner_profile,
+    probe_skillsbench_runner_connectivity,
 )
 
 
@@ -35,6 +36,7 @@ def test_probe_ssh_reuses_launcher_option_semantics_without_output(
     fake_bin.mkdir()
     argv_path = tmp_path / "ssh-argv.json"
     fake_ssh = fake_bin / "ssh"
+    fake_klist = fake_bin / "klist"
     fake_ssh.write_text(
         "#!/bin/sh\n"
         "python3 - \"$@\" <<'PY'\n"
@@ -45,6 +47,8 @@ def test_probe_ssh_reuses_launcher_option_semantics_without_output(
         encoding="utf-8",
     )
     fake_ssh.chmod(0o755)
+    fake_klist.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_klist.chmod(0o755)
     environment = os.environ.copy()
     environment.update(
         {
@@ -72,12 +76,17 @@ def test_probe_ssh_reuses_launcher_option_semantics_without_output(
     assert completed.returncode == 0, completed.stderr
     assert json.loads(completed.stdout) == {
         "benchmark_job_launched": False,
+        "gssapi_configured": True,
+        "local_gssapi_ticket_state": "present",
         "ok": True,
         "profile_values_recorded": False,
         "raw_output_recorded": False,
         "reachable": True,
+        "readiness_state": "ready",
+        "remote_task_free_acceptance": True,
         "result": "reachable",
         "schema_version": "skillsbench_runner_connectivity_probe_v0",
+        "task_free_connection_attempt_completed": True,
         "task_material_read": False,
     }
     assert json.loads(argv_path.read_text(encoding="utf-8")) == [
@@ -136,11 +145,54 @@ def test_probe_ssh_reports_transport_failure_without_raw_output(
     assert completed.stderr == ""
     assert json.loads(completed.stdout) == {
         "benchmark_job_launched": False,
+        "gssapi_configured": False,
+        "local_gssapi_ticket_state": "not_checked",
         "ok": True,
         "profile_values_recorded": False,
         "raw_output_recorded": False,
         "reachable": False,
+        "readiness_state": "transport_unavailable",
+        "remote_task_free_acceptance": False,
         "result": "transport_unavailable",
         "schema_version": "skillsbench_runner_connectivity_probe_v0",
+        "task_free_connection_attempt_completed": True,
         "task_material_read": False,
     }
+
+
+def test_probe_ssh_distinguishes_local_ticket_from_remote_acceptance(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_ssh = fake_bin / "ssh"
+    fake_klist = fake_bin / "klist"
+    fake_ssh.write_text("#!/bin/sh\nexit 255\n", encoding="utf-8")
+    fake_ssh.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}{os.environ['PATH']}")
+    profile = {
+        "SKILLSBENCH_SSH_DESTINATION": "runner.example.invalid",
+        "SKILLSBENCH_SSH_OPTIONS": "GSSAPIAuthentication=yes",
+    }
+
+    for returncode, ticket_state, readiness_state in (
+        (0, "present", "remote_task_free_acceptance_failed"),
+        (1, "missing", "local_gssapi_ticket_missing"),
+    ):
+        fake_klist.write_text(
+            f"#!/bin/sh\nexit {returncode}\n",
+            encoding="utf-8",
+        )
+        fake_klist.chmod(0o755)
+        probe = probe_skillsbench_runner_connectivity(profile)
+
+        assert probe["reachable"] is False
+        assert probe["gssapi_configured"] is True
+        assert probe["local_gssapi_ticket_state"] == ticket_state
+        assert probe["remote_task_free_acceptance"] is False
+        assert probe["task_free_connection_attempt_completed"] is True
+        assert probe["readiness_state"] == readiness_state
+        assert probe["task_material_read"] is False
+        assert probe["benchmark_job_launched"] is False
+        assert probe["raw_output_recorded"] is False


### PR DESCRIPTION
## Summary

- distinguish local GSSAPI ticket presence from task-free remote SSH acceptance
- recognize GSSAPI from explicit runner options or the effective host-local SSH config
- add typed readiness fields while preserving the existing `reachable` and `result` contract
- document the task-free readiness receipt and keep benchmark launch gated on `readiness_state=ready`

## Boundary

- does not read task material or record SSH output/profile values
- does not launch a benchmark job
- does not change scoring, task semantics, submission behavior, or permission boundaries

## Validation

- `python -m pytest -q tests/test_skillsbench_runner_profile.py tests/test_skillsbench_reverse_tunnel_supervisor.py` (9 passed)
- `python -m mypy`
- `ruff check loopx/benchmark_adapters/skillsbench_runner_profile.py tests/test_skillsbench_runner_profile.py`
- `python -m py_compile loopx/benchmark_adapters/skillsbench_runner_profile.py tests/test_skillsbench_runner_profile.py`
- `loopx check` on all changed public surfaces
- `loopx canary premerge --from-git-diff`: all direct checks, 6 catalog canaries, 8 risk-profile smokes, and the public boundary check passed; the generic `benchmark_sensitive` manual hold remains and is covered by the standing owner authorization for narrow benchmark helper/runtime PR self-merge
