### PR TITLE
Gate SkillsBench launch on runner readiness

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -1091,6 +1091,9 @@ ticket presence from remote task-free SSH acceptance without recording command
 output or profile values. A present local ticket is not sufficient evidence to
 launch: `readiness_state` must be `ready`. Keep the benchmark blocked on
 `remote_task_free_acceptance_failed` while unrelated runnable work continues.
+The non-dry-run launcher consumes the same receipt before any remote preflight
+or supervisor start. A rejected receipt exits as the compact public blocker;
+dry-run reports the gate as required without probing the host.
 
 For repeated benchmark work, prefer a host-local SSH config stanza instead of
 spelling the multiplexing flags on every command:

--- a/loopx/benchmark_adapters/skillsbench_runner_profile.py
+++ b/loopx/benchmark_adapters/skillsbench_runner_profile.py
@@ -353,6 +353,7 @@ def _parser() -> argparse.ArgumentParser:
             command.add_argument("--if-present", action="store_true")
         if name == "probe-ssh":
             command.add_argument("--timeout-seconds", type=int, default=15)
+            command.add_argument("--current-environment", action="store_true")
     capture = commands.add_parser("capture")
     capture.add_argument("--profile", type=Path)
     capture.add_argument("--force", action="store_true")
@@ -362,6 +363,25 @@ def _parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     try:
+        if args.command == "probe-ssh" and args.current_environment:
+            if args.profile:
+                raise SkillsBenchRunnerProfileError("probe_source_conflict")
+            if args.timeout_seconds < 1:
+                raise SkillsBenchRunnerProfileError("probe_timeout_invalid")
+            profile = {
+                key: os.environ[key]
+                for key in (
+                    "SKILLSBENCH_SSH_DESTINATION",
+                    "SKILLSBENCH_SSH_OPTIONS",
+                )
+                if os.environ.get(key)
+            }
+            summary = probe_skillsbench_runner_connectivity(
+                profile,
+                timeout_seconds=args.timeout_seconds,
+            )
+            print(json.dumps(summary, sort_keys=True))
+            return 0 if summary["reachable"] else 3
         profile_path = args.profile or default_skillsbench_runner_profile_path()
         if args.command == "capture":
             summary = capture_skillsbench_runner_profile(

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -350,6 +350,19 @@ remote_codex_bin_mode="path_lookup"
 if [[ -n "${SKILLSBENCH_REMOTE_CODEX_BIN:-}" ]]; then
   remote_codex_bin_mode="explicit"
 fi
+runner_connectivity_preflight="required"
+if [[ "$dry_run" == "false" ]]; then
+  if ! runner_connectivity_receipt="$(
+    PYTHONPATH="${repo_root}${PYTHONPATH:+:${PYTHONPATH}}" \
+      python3 -m loopx.benchmark_adapters.skillsbench_runner_profile \
+      probe-ssh --current-environment --timeout-seconds 10
+  )"; then
+    printf '%s\n' "$runner_connectivity_receipt" >&2
+    exit 3
+  fi
+  unset runner_connectivity_receipt
+  runner_connectivity_preflight="passed"
+fi
 exact_host_codex_sandbox_preflight="not_required"
 if [[ "$local_codex_split_control" == "1" ]]; then
   remote_codex_bin_mode="split_control_client"
@@ -841,6 +854,8 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'runner_profile_loaded=%s\n' "$runner_profile_loaded"
   printf 'runner_profile_path_recorded=false\n'
   printf 'runner_profile_values_recorded=false\n'
+  printf 'runner_connectivity_preflight=%s\n' \
+    "$runner_connectivity_preflight"
   printf 'local_codex_sandbox=%s\n' "$local_codex_sandbox"
   printf 'local_codex_exec_timeout_sec=%s\n' \
     "${local_codex_exec_timeout:-runner-default}"
@@ -972,6 +987,7 @@ docker_api_version=${docker_api_version}
 remote_codex_bin_mode=${remote_codex_bin_mode}
 local_codex_split_control=${local_codex_split_control}
 local_codex_provider=$([[ "$local_codex_split_control" == "1" ]] && echo reverse_channel || echo exact_host)
+runner_connectivity_preflight=${runner_connectivity_preflight}
 local_codex_sandbox=${local_codex_sandbox}
 codex_cli_goal_thread_prewarm=${codex_cli_goal_thread_prewarm}
 allow_staged_bootstrap_repair_run=${allow_staged_bootstrap_repair_run}

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -87,6 +87,7 @@ def test_turn_launcher_wires_private_commands_without_echoing_values(
     assert "docker_proxy_host=" not in output
     assert env["SKILLSBENCH_DOCKER_PROXY_HOST"] not in output
     assert "private_runner_command_values_redacted=true" in output
+    assert "runner_connectivity_preflight=required" in output
     assert "exact_host_codex_sandbox_preflight=required" in output
     for arg_name in (
         "--remote-command-file-bridge-probe-command",
@@ -140,12 +141,13 @@ def test_launcher_fails_before_batch_when_exact_host_sandbox_probe_fails(
     fake_ssh = fake_bin / "ssh"
     fake_ssh.write_text(
         "#!/bin/sh\n"
+        'if [ "$1" = "-G" ]; then exit 0; fi\n'
         f"count_file={call_count!s}\n"
         'count=0\n'
         'if [ -f "$count_file" ]; then count=$(cat "$count_file"); fi\n'
         'count=$((count + 1))\n'
         'printf "%s" "$count" > "$count_file"\n'
-        'if [ "$count" -eq 1 ]; then exit 0; fi\n'
+        'if [ "$count" -le 2 ]; then exit 0; fi\n'
         'exit 1\n',
         encoding="utf-8",
     )
@@ -174,7 +176,58 @@ def test_launcher_fails_before_batch_when_exact_host_sandbox_probe_fails(
         "schema_version": "skillsbench_exact_host_codex_sandbox_preflight_v0",
         "ssh_destination_recorded": False,
     }
-    assert call_count.read_text(encoding="utf-8") == "2"
+    assert call_count.read_text(encoding="utf-8") == "3"
+    assert "pid=" not in proc.stdout
+
+
+def test_launcher_fails_before_supervisor_when_runner_connectivity_is_not_ready(
+    tmp_path: Path,
+) -> None:
+    env = _base_env(tmp_path)
+    env["SKILLSBENCH_SSH_OPTIONS"] = "GSSAPIAuthentication=yes"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    call_count = tmp_path / "ssh-call-count"
+    fake_ssh = fake_bin / "ssh"
+    fake_klist = fake_bin / "klist"
+    fake_ssh.write_text(
+        "#!/bin/sh\n"
+        f"printf x >> {call_count!s}\n"
+        "exit 255\n",
+        encoding="utf-8",
+    )
+    fake_ssh.chmod(0o755)
+    fake_klist.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_klist.chmod(0o755)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "public-smoke-case", "connectivity-preflight"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 3, proc
+    assert json.loads(proc.stderr) == {
+        "benchmark_job_launched": False,
+        "gssapi_configured": True,
+        "local_gssapi_ticket_state": "present",
+        "ok": True,
+        "profile_values_recorded": False,
+        "raw_output_recorded": False,
+        "reachable": False,
+        "readiness_state": "remote_task_free_acceptance_failed",
+        "remote_task_free_acceptance": False,
+        "result": "transport_unavailable",
+        "schema_version": "skillsbench_runner_connectivity_probe_v0",
+        "task_free_connection_attempt_completed": True,
+        "task_material_read": False,
+    }
+    assert call_count.read_text(encoding="utf-8") == "x"
     assert "pid=" not in proc.stdout
 
 


### PR DESCRIPTION
## Summary

- let the existing runner-profile CLI probe task-free SSH from the launcher's current environment
- require a ready connectivity receipt before any non-dry-run remote preflight or supervisor start
- preserve dry-run as a no-network plan while reporting the pending readiness gate

## Boundary

- emits only the existing compact public connectivity receipt on failure
- reads no task material and records no SSH output, destination, or profile values
- validation launches no benchmark job
- does not change scoring, task semantics, submissions, uploads, or permission boundaries

## Validation

- `pytest -q tests/test_skillsbench_turn_launcher.py tests/test_skillsbench_runner_profile.py tests/test_skillsbench_reverse_tunnel_supervisor.py` (36 passed)
- `python examples/skillsbench-runner-profile-smoke.py`
- `python -m mypy`
- `ruff check`
- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`
- `loopx check` on all changed public surfaces
- `loopx canary premerge --from-git-diff`: all direct checks, 6 catalog canaries, 8 risk-profile smokes, and the public boundary check passed; the generic `benchmark_sensitive` hold is covered by the standing owner authorization for narrow benchmark helper/runtime PR self-merge
