### PR TITLE
feat(material-lifecycle): add Stage-0 contracts

### DIFF
--- a/docs/capabilities/README.md
+++ b/docs/capabilities/README.md
@@ -26,6 +26,10 @@ Current capability paths:
   ([中文](../reference/protocols/decision-context-architecture-v0.zh-CN.md)):
   separate current evidence, advisory proposals, and verified outcomes through
   default-off provider-neutral packet and incremental source contracts.
+- [material-lifecycle](../reference/protocols/material-lifecycle-architecture-v0.md)
+  ([中文](../reference/protocols/material-lifecycle-architecture-v0.zh-CN.md)):
+  preserve raw source authority while inventorying, archiving, migrating, and
+  applying bounded material reranks.
 - [periodic-report](periodic-report/README.md): evaluate cadence and material
   progress triggers, then compose deterministic provider-neutral report runs
   with source, artifact, archive, and delivery receipts.

--- a/docs/reference/protocols/material-lifecycle-architecture-v0.md
+++ b/docs/reference/protocols/material-lifecycle-architecture-v0.md
@@ -1,0 +1,115 @@
+# Material Lifecycle Architecture v0
+
+## Position
+
+Material Lifecycle is a built-in, default-off, goal-scoped LoopX capability.
+It owns the auditable lifecycle of material references: inventory, backup-safe
+migration, candidate/archive transitions, and bounded rerank proposals. It does
+not own raw documents, private source locations, provider credentials, or Core
+goal authority.
+
+```mermaid
+flowchart LR
+    RAW["Private raw material store<br/>files, messages, web captures"]
+    BACKUP["Immutable snapshot + backup"]
+    ML["Material Lifecycle<br/>inventory, lifecycle, bounded rerank"]
+    DC["Decision Context<br/>revisioned evidence"]
+    RM["Reward Memory<br/>reviewed reusable lessons"]
+    CO["Content Ops / other consumers"]
+    CORE["LoopX Core<br/>goal, todo, gate, event, vision"]
+
+    RAW --> BACKUP
+    BACKUP --> ML
+    DC -->|"decision_evidence_ref"| ML
+    RM -. "optional ranking lesson" .-> ML
+    ML -->|"material refs + receipts"| CO
+    ML -->|"audited refs only"| CORE
+```
+
+The capability is a sibling of Decision Context and Reward Memory:
+
+- Decision Context answers which current facts should influence a decision.
+- Material Lifecycle answers which material references are candidates, active,
+  archived, carried over, or eligible for a bounded rerank.
+- Reward Memory stores reviewed reusable policies or lessons.
+- Content Ops and other domain capabilities consume selected material; they do
+  not own the candidate/archive source of truth.
+
+## Stage-0 Contracts
+
+`material_store_inventory_v0` is a read-only, public-safe inventory. It records
+opaque snapshot, backup, digest, revision, count, parse-error, and verification
+references. Raw material and private locations are excluded.
+
+`material_migration_plan_v0` fixes the migration order:
+
+1. snapshot;
+2. inventory;
+3. dual read;
+4. reconcile;
+5. owner gate;
+6. apply;
+7. keep rollback ready.
+
+The plan never authorizes source mutation by itself.
+
+`material_lifecycle_receipt_v0` records authority-referenced transitions among
+`unread`, `candidate`, `active`, `carryover`, and `archived`. The authority may
+be a reviewed goal policy, Decision Context outcome, or human gate. Archive and
+reactivation preserve the stable material and archive references instead of
+copying raw content into another queue.
+
+`material_rerank_proposal_v0` carries only a bounded delta:
+
+- one target window;
+- maximum moved items;
+- maximum rank displacement;
+- protected material references;
+- revisioned Decision Context evidence;
+- an explicit no-change result.
+
+`material_rerank_apply_receipt_v0` remains separate from the proposal and
+requires an owner-gate reference, validation reference, before/after revisions,
+and rollback reference for applied changes.
+
+## Migration Boundary
+
+Legacy Markdown, databases, inboxes, and other stores remain authoritative
+until a provider-specific adapter proves:
+
+- an immutable source snapshot and verified backup;
+- stable material IDs and source references;
+- parse-error accounting;
+- equal item counts and lifecycle state under dual read;
+- deterministic rerank proposal readback;
+- owner-gated cutover and rollback.
+
+The generic capability never embeds a legacy parser or a private file layout.
+Adapters may coexist with the old store for as long as reconciliation requires.
+
+## Decision-Driven Ranking and Exploration
+
+Stage 0 accepts an opaque `decision_evidence_ref` from Decision Context. A
+later provider-neutral stage may derive a bounded rerank or exploration intent
+from that evidence. Search engines, web clients, messaging providers, and
+repository scanners remain replaceable providers; their raw output cannot enter
+public packets.
+
+This keeps recurring automation thin. A scheduler should wake the goal and
+invoke the configured capability. Source lists, incremental cursors, ranking
+rules, and exploration budgets belong in ignored goal-scoped configuration and
+validated receipts, not in an automation prompt.
+
+## Stage Boundary
+
+Stage 0 ships deterministic contracts, catalog visibility, a read-only
+architecture CLI, focused tests, and a public smoke. It does not ship:
+
+- a legacy material parser or migration apply path;
+- raw-material persistence;
+- an exploration provider;
+- a messaging or contact source profile;
+- automatic reranking, archive moves, or cursor advancement.
+
+Those require a read-only adapter, private dogfood, exact reconciliation, and an
+explicit owner gate.

--- a/docs/reference/protocols/material-lifecycle-architecture-v0.zh-CN.md
+++ b/docs/reference/protocols/material-lifecycle-architecture-v0.zh-CN.md
@@ -1,0 +1,107 @@
+# Material Lifecycle 架构 v0
+
+## 定位
+
+Material Lifecycle 是 LoopX 内置、默认关闭、goal-scoped 的素材生命周期
+capability。它管理可审计的素材引用状态：清点、备份安全迁移、候选/归档
+流转和小范围重排；不拥有原始文档、私有来源位置、provider 凭据，也不创造
+Core goal authority。
+
+```mermaid
+flowchart LR
+    RAW["私有原始素材库<br/>文件、消息、网页抓取"]
+    BACKUP["不可变快照与备份"]
+    ML["Material Lifecycle<br/>清点、流转、小范围重排"]
+    DC["Decision Context<br/>带 revision 的决策证据"]
+    RM["Reward Memory<br/>经评审的可复用经验"]
+    CO["Content Ops / 其他消费者"]
+    CORE["LoopX Core<br/>goal、todo、gate、event、vision"]
+
+    RAW --> BACKUP
+    BACKUP --> ML
+    DC -->|"decision_evidence_ref"| ML
+    RM -. "可选排序经验" .-> ML
+    ML -->|"素材引用与 receipt"| CO
+    ML -->|"仅审计引用"| CORE
+```
+
+它与 Decision Context、Reward Memory 同级，但职责不同：
+
+- Decision Context 判断当前决策应相信哪些事实；
+- Material Lifecycle 判断哪些素材处于候选、活跃、归档、carryover 状态，
+  以及哪些条目可以被小范围重排；
+- Reward Memory 保存经过评审、可复用的策略和经验；
+- Content Ops 等能力消费选中的素材，不拥有候选/归档真值。
+
+## Stage-0 契约
+
+`material_store_inventory_v0` 是只读、公开安全的素材库清点结果，只记录
+不透明的快照、备份、digest、revision、数量、解析错误和验证引用，不携带
+原始素材或私有位置。
+
+`material_migration_plan_v0` 固定迁移顺序：
+
+1. 建快照；
+2. 清点；
+3. 双读；
+4. 对账；
+5. owner gate；
+6. apply；
+7. 保持 rollback 可用。
+
+迁移计划本身不授权修改原始素材库。
+
+`material_lifecycle_receipt_v0` 记录 `unread`、`candidate`、`active`、
+`carryover`、`archived` 之间带 authority 引用的流转。authority 可以是经
+评审的 goal policy、Decision Context outcome 或人工 gate。归档和重新激活
+都保留稳定的 material/archive 引用，不把原始内容复制回新队列。
+
+`material_rerank_proposal_v0` 只表达受限增量：
+
+- 一个目标窗口；
+- 最大移动条数；
+- 最大位移；
+- 受保护条目；
+- 带 revision 的 Decision Context 证据；
+- 显式 no-change。
+
+`material_rerank_apply_receipt_v0` 与 proposal 分离。真正 apply 必须记录
+owner gate、验证引用、前后 revision；发生修改时还必须有 rollback 引用。
+
+## 迁移边界
+
+旧 Markdown、数据库、inbox 等存储在以下条件满足前始终是 authority：
+
+- 已建立不可变快照和可验证备份；
+- material ID 与来源引用稳定；
+- 解析错误可计数；
+- 新旧双读的总量和生命周期状态一致；
+- rerank proposal 可确定性回读；
+- cutover 与 rollback 都经过 owner gate。
+
+通用 capability 不内置某种 Markdown parser 或私有目录结构。provider
+adapter 可以与旧存储长期共存，直到完成对账。
+
+## 决策驱动的排序与探索
+
+Stage 0 接收 Decision Context 产生的不透明 `decision_evidence_ref`。后续
+provider-neutral 阶段可以据此生成小范围重排或探索意图。搜索引擎、联网
+客户端、消息和仓库 scanner 都是可替换 provider；其 raw output 不进入
+公开 packet。
+
+因此 recurring automation 最终只负责唤醒 goal 和调用 capability。
+来源清单、增量 cursor、排序规则与探索预算应位于 ignored 的 goal-scoped
+配置和受验证 receipt 中，而不是写进 automation prompt。
+
+## 本阶段不做什么
+
+Stage 0 只交付确定性契约、catalog、只读架构 CLI、聚焦测试和公开 smoke，
+不交付：
+
+- legacy 素材 parser 或迁移 apply；
+- 原始素材持久化；
+- 联网探索 provider；
+- 群聊/关键联系人 source profile；
+- 自动重排、自动归档或自动推进 cursor。
+
+这些能力必须经过只读 adapter、私有 dogfood、精确对账和显式 owner gate。

--- a/examples/capability-extension-registry-smoke.py
+++ b/examples/capability-extension-registry-smoke.py
@@ -60,6 +60,7 @@ next_real_step = "Keep explicit enablement bounded."
     assert [item["id"] for item in baseline["capabilities"]] == [
         "issue-fix",
         "decision-context",
+        "material-lifecycle",
         "semantic-preference",
         "reward-memory",
         "periodic-report",

--- a/examples/material-lifecycle-contract-smoke.py
+++ b/examples/material-lifecycle-contract-smoke.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Smoke-test the public Material Lifecycle Stage-0 contract."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.material_lifecycle import (  # noqa: E402
+    build_material_lifecycle_architecture_packet,
+    build_material_lifecycle_receipt,
+    build_material_migration_plan,
+    build_material_rerank_apply_receipt,
+    build_material_rerank_proposal,
+    build_material_store_inventory,
+)
+
+OBSERVED_AT = "2026-07-25T16:30:00+00:00"
+
+
+def run_cli(*args: str) -> dict[str, object]:
+    completed = subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--format", "json", *args],
+        cwd=REPO_ROOT,
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    return json.loads(completed.stdout)
+
+
+def main() -> int:
+    architecture = build_material_lifecycle_architecture_packet()
+    assert architecture["capability"]["default_enabled"] is False
+    assert architecture["provider_boundaries"]["raw_material_store"] == (
+        "private_external_authority"
+    )
+    assert run_cli("material-lifecycle", "architecture") == architecture
+
+    inventory = build_material_store_inventory(
+        goal_id="goal:material-example",
+        store_id="store:materials",
+        store_revision="revision:1",
+        observed_at=OBSERVED_AT,
+        source_snapshot_ref="snapshot:1",
+        backup_ref="backup:1",
+        source_digest="sha256:0123456789abcdef",
+        lifecycle_counts={"candidate": 3, "archived": 7},
+        stable_ids_verified=True,
+        backup_verified=True,
+    )
+    migration = build_material_migration_plan(
+        goal_id="goal:material-example",
+        plan_id="plan:migrate-1",
+        inventory_ref=str(inventory["inventory_ref"]),
+        source_revision="revision:1",
+        target_schema="material_store_v0",
+        observed_at=OBSERVED_AT,
+        backup_ref="backup:1",
+        rollback_ref="rollback:1",
+        expected_item_count=10,
+    )
+    lifecycle = build_material_lifecycle_receipt(
+        goal_id="goal:material-example",
+        receipt_id="receipt:archive-1",
+        material_ref="material:1",
+        from_state="active",
+        to_state="archived",
+        observed_at=OBSERVED_AT,
+        source_ref="source:1",
+        source_revision="revision:1",
+        transition_authority_ref="decision-outcome:archive-1",
+        archive_ref="archive:1",
+    )
+    proposal = build_material_rerank_proposal(
+        goal_id="goal:material-example",
+        proposal_id="proposal:rerank-1",
+        inventory_ref=str(inventory["inventory_ref"]),
+        decision_evidence_ref="decision-evidence-0123456789abcdef",
+        observed_at=OBSERVED_AT,
+        target_window_size=10,
+        max_moved_items=2,
+        max_rank_displacement=3,
+        moves=[
+            {
+                "material_ref": "material:2",
+                "from_rank": 5,
+                "to_rank": 2,
+                "reason_code": "current_objective_fit",
+            }
+        ],
+    )
+    apply_receipt = build_material_rerank_apply_receipt(
+        goal_id="goal:material-example",
+        receipt_id="receipt:rerank-1",
+        proposal_ref=str(proposal["proposal_ref"]),
+        observed_at=OBSERVED_AT,
+        status="applied",
+        before_revision="revision:1",
+        after_revision="revision:2",
+        owner_gate_ref="gate:rerank-1",
+        validation_ref="validation:rerank-1",
+        applied_material_refs=["material:2"],
+        rollback_ref="rollback:revision-1",
+    )
+
+    serialized = json.dumps(
+        {
+            "architecture": architecture,
+            "inventory": inventory,
+            "migration": migration,
+            "lifecycle": lifecycle,
+            "proposal": proposal,
+            "apply_receipt": apply_receipt,
+        },
+        sort_keys=True,
+    )
+    for forbidden in (
+        "private material body",
+        "private_locator",
+        "/Users/",
+        "https://",
+    ):
+        assert forbidden not in serialized
+    assert inventory["raw_content_captured"] is False
+    assert lifecycle["raw_content_captured"] is False
+    assert proposal["raw_content_captured"] is False
+    assert apply_receipt["raw_content_captured"] is False
+
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "schema_version": architecture["schema_version"],
+                "inventory_ref": inventory["inventory_ref"],
+                "plan_ref": migration["plan_ref"],
+                "lifecycle_ref": lifecycle["receipt_ref"],
+                "proposal_ref": proposal["proposal_ref"],
+                "apply_ref": apply_receipt["receipt_ref"],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -335,6 +335,79 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
         ),
     },
     {
+        "id": "material-lifecycle",
+        "origin": "builtin",
+        "visibility": "public",
+        "provider_id": "loopx-core",
+        "title": "Backup-safe material inventory, archive, and bounded rerank contract",
+        "status": "experimental",
+        "default_enabled": False,
+        "real_world_anchor": (
+            "large local candidate and archive stores that must remain "
+            "recoverable while decisions change their short-list"
+        ),
+        "user_value": (
+            "Preserve raw source authority and stable material references while "
+            "making migration, archive transitions, and small reranks auditable."
+        ),
+        "entry_command": "loopx material-lifecycle architecture --format json",
+        "commands": [
+            {
+                "command": "loopx material-lifecycle architecture --format json",
+                "purpose": "Render the default-off Stage-0 inventory, migration, lifecycle, and bounded-rerank boundaries.",
+                "write_boundary": "stateless contract output only; no source store, backup, goal state, provider, or external write",
+            }
+        ],
+        "implemented_protocols": [
+            {
+                "schema_version": "material_lifecycle_architecture_v0",
+                "module": "loopx.capabilities.material_lifecycle.architecture",
+                "doc": "docs/reference/protocols/material-lifecycle-architecture-v0.md",
+            },
+            {
+                "schema_version": "material_store_inventory_v0",
+                "module": "loopx.capabilities.material_lifecycle.inventory",
+                "doc": "docs/reference/protocols/material-lifecycle-architecture-v0.md",
+            },
+            {
+                "schema_version": "material_migration_plan_v0",
+                "module": "loopx.capabilities.material_lifecycle.inventory",
+                "doc": "docs/reference/protocols/material-lifecycle-architecture-v0.md",
+            },
+            {
+                "schema_version": "material_lifecycle_receipt_v0",
+                "module": "loopx.capabilities.material_lifecycle.lifecycle",
+                "doc": "docs/reference/protocols/material-lifecycle-architecture-v0.md",
+            },
+            {
+                "schema_version": "material_rerank_proposal_v0",
+                "module": "loopx.capabilities.material_lifecycle.ranking",
+                "doc": "docs/reference/protocols/material-lifecycle-architecture-v0.md",
+            },
+            {
+                "schema_version": "material_rerank_apply_receipt_v0",
+                "module": "loopx.capabilities.material_lifecycle.ranking",
+                "doc": "docs/reference/protocols/material-lifecycle-architecture-v0.md",
+            },
+        ],
+        "smokes": ["python3 examples/material-lifecycle-contract-smoke.py"],
+        "docs": [
+            "docs/reference/protocols/material-lifecycle-architecture-v0.md",
+            "docs/reference/protocols/material-lifecycle-architecture-v0.zh-CN.md",
+        ],
+        "boundaries": [
+            "The capability is default-off and cannot create action authority or mutate Core state.",
+            "Raw material, private locations, provider payloads, credentials, and source-store formats stay outside public packets.",
+            "Snapshot and verified backup precede dual-read reconciliation; cutover and rollback remain owner-gated.",
+            "Decision Context may supply revisioned evidence, but Material Lifecycle owns candidate, archive, and rerank receipts.",
+            "Concrete legacy adapters, exploration providers, source profiles, and material-store writes remain deferred to private dogfood.",
+        ],
+        "next_real_step": (
+            "Build one read-only legacy inventory and migration planner, then "
+            "validate a decision-driven bounded rerank without mutating raw sources."
+        ),
+    },
+    {
         "id": "semantic-preference",
         "origin": "builtin",
         "visibility": "public",

--- a/loopx/capabilities/material_lifecycle/__init__.py
+++ b/loopx/capabilities/material_lifecycle/__init__.py
@@ -1,0 +1,39 @@
+"""Goal-scoped Material Lifecycle capability contracts."""
+
+from .architecture import (
+    MATERIAL_LIFECYCLE_ARCHITECTURE_SCHEMA_VERSION,
+    build_material_lifecycle_architecture_packet,
+)
+from .inventory import (
+    MATERIAL_LIFECYCLE_STATES,
+    MATERIAL_MIGRATION_PLAN_SCHEMA_VERSION,
+    MATERIAL_STORE_INVENTORY_SCHEMA_VERSION,
+    build_material_migration_plan,
+    build_material_store_inventory,
+)
+from .lifecycle import (
+    MATERIAL_LIFECYCLE_RECEIPT_SCHEMA_VERSION,
+    build_material_lifecycle_receipt,
+)
+from .ranking import (
+    MATERIAL_RERANK_APPLY_RECEIPT_SCHEMA_VERSION,
+    MATERIAL_RERANK_PROPOSAL_SCHEMA_VERSION,
+    build_material_rerank_apply_receipt,
+    build_material_rerank_proposal,
+)
+
+__all__ = [
+    "MATERIAL_LIFECYCLE_ARCHITECTURE_SCHEMA_VERSION",
+    "MATERIAL_LIFECYCLE_RECEIPT_SCHEMA_VERSION",
+    "MATERIAL_LIFECYCLE_STATES",
+    "MATERIAL_MIGRATION_PLAN_SCHEMA_VERSION",
+    "MATERIAL_RERANK_APPLY_RECEIPT_SCHEMA_VERSION",
+    "MATERIAL_RERANK_PROPOSAL_SCHEMA_VERSION",
+    "MATERIAL_STORE_INVENTORY_SCHEMA_VERSION",
+    "build_material_lifecycle_architecture_packet",
+    "build_material_lifecycle_receipt",
+    "build_material_migration_plan",
+    "build_material_rerank_apply_receipt",
+    "build_material_rerank_proposal",
+    "build_material_store_inventory",
+]

--- a/loopx/capabilities/material_lifecycle/_validation.py
+++ b/loopx/capabilities/material_lifecycle/_validation.py
@@ -1,0 +1,152 @@
+"""Shared validation helpers for public-safe Material Lifecycle contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from typing import Any
+
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+_LOCAL_PATH_RE = re.compile(r"(^|[\s:=])(?:/Users/|/private/|/tmp/|~/)")
+_RAW_LOCATION_RE = re.compile(r"(?i)\b(?:https?|file|s3|gs|tos|hdfs)://")
+_CREDENTIAL_RE = re.compile(
+    "(?i)("
+    + "|".join(
+        [
+            "Author" + "ization:",
+            "Bear" + r"er\s+[A-Za-z0-9._-]+",
+            "api" + r"[_-]?key",
+            "pass" + "word",
+            "sec" + "ret",
+            "begin " + r"(?:rsa |open)?private key",
+        ]
+    )
+    + ")"
+)
+UNSAFE_FIELDS = {
+    "api_key",
+    "content",
+    "credential",
+    "credentials",
+    "private_locator",
+    "provider_payload",
+    "raw_chat",
+    "raw_content",
+    "raw_provider_payload",
+    "token",
+    "tool_output",
+}
+
+
+def compact_text(value: Any, *, field: str, max_len: int = 320) -> str:
+    text = " ".join(str(value or "").strip().split())
+    if not text:
+        raise ValueError(f"{field} must be non-empty")
+    if len(text) > max_len:
+        raise ValueError(f"{field} must be at most {max_len} characters")
+    if _LOCAL_PATH_RE.search(text):
+        raise ValueError(f"{field} must not contain a local path")
+    if _RAW_LOCATION_RE.search(text):
+        raise ValueError(f"{field} must use an opaque reference, not a raw URL")
+    if _CREDENTIAL_RE.search(text):
+        raise ValueError(f"{field} contains a credential-like value")
+    return text
+
+
+def compact_token(value: Any, *, field: str) -> str:
+    token = compact_text(value, field=field, max_len=128)
+    if not _TOKEN_RE.fullmatch(token):
+        raise ValueError(
+            f"{field} must contain only letters, digits, dot, colon, dash, or underscore"
+        )
+    return token
+
+
+def iso_timestamp(value: Any, *, field: str) -> str:
+    timestamp = compact_text(value, field=field, max_len=64)
+    try:
+        parsed = datetime.fromisoformat(timestamp)
+    except ValueError as exc:
+        raise ValueError(f"{field} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field} must include a timezone")
+    return timestamp
+
+
+def nonnegative_int(value: Any, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field} must be a non-negative integer")
+    if value < 0:
+        raise ValueError(f"{field} must be a non-negative integer")
+    return value
+
+
+def positive_int(value: Any, *, field: str) -> int:
+    normalized = nonnegative_int(value, field=field)
+    if normalized == 0:
+        raise ValueError(f"{field} must be positive")
+    return normalized
+
+
+def token_list(
+    values: Sequence[Any] | None,
+    *,
+    field: str,
+    max_items: int = 100,
+) -> list[str]:
+    if values is None:
+        return []
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise TypeError(f"{field} must be a sequence of compact tokens")
+    if len(values) > max_items:
+        raise ValueError(f"{field} must contain at most {max_items} items")
+    return sorted({compact_token(value, field=f"{field}[]") for value in values})
+
+
+def check_record_keys(
+    value: Mapping[str, Any],
+    *,
+    field: str,
+    allowed: set[str],
+    required: set[str],
+) -> None:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{field} must be an object")
+    keys = {str(key) for key in value}
+    unsafe = sorted(keys & UNSAFE_FIELDS)
+    if unsafe:
+        raise ValueError(f"{field} contains unsafe fields: {', '.join(unsafe)}")
+    unexpected = sorted(keys - allowed)
+    if unexpected:
+        raise ValueError(
+            f"{field} contains unsupported fields: {', '.join(unexpected)}"
+        )
+    missing = sorted(key for key in required if value.get(key) is None)
+    if missing:
+        raise ValueError(f"{field} is missing required fields: {', '.join(missing)}")
+
+
+def packet_ref(prefix: str, packet: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(
+        json.dumps(
+            packet,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:20]
+    return f"{prefix}-{digest}"
+
+
+def capability_contract(*, packet_role: str) -> dict[str, Any]:
+    return {
+        "capability_id": "material_lifecycle",
+        "scope": "goal",
+        "default_enabled": False,
+        "packet_role": packet_role,
+        "creates_authority": False,
+        "mutates_core_state": False,
+    }

--- a/loopx/capabilities/material_lifecycle/architecture.py
+++ b/loopx/capabilities/material_lifecycle/architecture.py
@@ -1,0 +1,78 @@
+"""Provider-neutral architecture projection for Material Lifecycle."""
+
+from __future__ import annotations
+
+from .inventory import (
+    MATERIAL_MIGRATION_PLAN_SCHEMA_VERSION,
+    MATERIAL_STORE_INVENTORY_SCHEMA_VERSION,
+)
+from .lifecycle import MATERIAL_LIFECYCLE_RECEIPT_SCHEMA_VERSION
+from .ranking import (
+    MATERIAL_RERANK_APPLY_RECEIPT_SCHEMA_VERSION,
+    MATERIAL_RERANK_PROPOSAL_SCHEMA_VERSION,
+)
+
+MATERIAL_LIFECYCLE_ARCHITECTURE_SCHEMA_VERSION = "material_lifecycle_architecture_v0"
+
+
+def build_material_lifecycle_architecture_packet() -> dict[str, object]:
+    """Render the default-off Stage-0 capability contract."""
+
+    return {
+        "schema_version": MATERIAL_LIFECYCLE_ARCHITECTURE_SCHEMA_VERSION,
+        "status": "experimental",
+        "capability": {
+            "capability_id": "material_lifecycle",
+            "scope": "goal",
+            "default_enabled": False,
+            "creates_authority": False,
+            "mutates_core_state": False,
+        },
+        "contract_schemas": [
+            MATERIAL_STORE_INVENTORY_SCHEMA_VERSION,
+            MATERIAL_MIGRATION_PLAN_SCHEMA_VERSION,
+            MATERIAL_LIFECYCLE_RECEIPT_SCHEMA_VERSION,
+            MATERIAL_RERANK_PROPOSAL_SCHEMA_VERSION,
+            MATERIAL_RERANK_APPLY_RECEIPT_SCHEMA_VERSION,
+        ],
+        "sibling_capabilities": {
+            "decision_context": (
+                "supplies revisioned evidence for bounded rerank proposals"
+            ),
+            "reward_memory": (
+                "stores reviewed reusable lessons, not current material queues"
+            ),
+            "content_ops": (
+                "consumes selected materials for creation, but does not own "
+                "candidate or archive truth"
+            ),
+        },
+        "provider_boundaries": {
+            "raw_material_store": "private_external_authority",
+            "inventory_provider": "read_only_snapshot_and_parse_metadata",
+            "migration_adapter": "owner_gated_dual_read_apply_and_rollback",
+            "exploration_provider": "deferred_provider_neutral_candidate_intake",
+        },
+        "lifecycle": [
+            "snapshot",
+            "inventory",
+            "candidate",
+            "active",
+            "archive_or_carryover",
+            "bounded_rerank",
+            "audited_apply",
+        ],
+        "invariants": [
+            "raw_material_and_private_locations_never_enter_public_packets",
+            "source_snapshot_and_backup_precede_migration",
+            "legacy_and_new_stores_dual_read_before_owner_gated_cutover",
+            "stable_material_refs_survive_archive_and_reactivation",
+            "rerank_is_a_bounded_delta_with_protected_items_and_no_change",
+            "proposal_and_apply_receipt_remain_separate",
+            "automation_prompts_do_not_own_source_lists_or_ranking_rules",
+        ],
+        "next_stage": (
+            "read_only_legacy_inventory_and_migration_planner_then_"
+            "decision_driven_rerank_and_source_profile_dogfood"
+        ),
+    }

--- a/loopx/capabilities/material_lifecycle/cli.py
+++ b/loopx/capabilities/material_lifecycle/cli.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+from .architecture import build_material_lifecycle_architecture_packet
+
+
+def _render(payload: dict[str, object]) -> str:
+    capability = payload.get("capability")
+    capability_id = (
+        capability.get("capability_id")
+        if isinstance(capability, dict)
+        else "material_lifecycle"
+    )
+    return "\n".join(
+        [
+            "# Material Lifecycle",
+            "",
+            f"- status: `{payload.get('status')}`",
+            f"- capability_id: `{capability_id}`",
+            f"- contract_schemas: `{len(payload.get('contract_schemas') or [])}`",
+            "",
+        ]
+    )
+
+
+def register_material_lifecycle_commands(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    parser = subparsers.add_parser(
+        "material-lifecycle",
+        help="Inspect the backup-safe material inventory and rerank contract.",
+    )
+    commands = parser.add_subparsers(
+        dest="material_lifecycle_command",
+        required=True,
+    )
+    architecture = commands.add_parser(
+        "architecture",
+        help="Render the default-off Stage-0 Material Lifecycle contract.",
+    )
+    add_subcommand_format(architecture)
+
+
+def handle_material_lifecycle_command(
+    args: argparse.Namespace,
+    *,
+    output_format: Callable[..., str],
+    print_payload: Callable[[dict[str, object], str, Callable], None],
+) -> int | None:
+    if args.command != "material-lifecycle":
+        return None
+    payload = build_material_lifecycle_architecture_packet()
+    print_payload(payload, output_format(args), _render)
+    return 0

--- a/loopx/capabilities/material_lifecycle/inventory.py
+++ b/loopx/capabilities/material_lifecycle/inventory.py
@@ -1,0 +1,147 @@
+"""Inventory and backup-safe migration contracts for material stores."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from ._validation import (
+    capability_contract,
+    compact_token,
+    iso_timestamp,
+    nonnegative_int,
+    packet_ref,
+    token_list,
+)
+
+MATERIAL_STORE_INVENTORY_SCHEMA_VERSION = "material_store_inventory_v0"
+MATERIAL_MIGRATION_PLAN_SCHEMA_VERSION = "material_migration_plan_v0"
+
+MATERIAL_LIFECYCLE_STATES = {
+    "active",
+    "archived",
+    "candidate",
+    "carryover",
+    "unread",
+}
+
+
+def build_material_store_inventory(
+    *,
+    goal_id: str,
+    store_id: str,
+    store_revision: str,
+    observed_at: str,
+    source_snapshot_ref: str,
+    backup_ref: str,
+    source_digest: str,
+    lifecycle_counts: Mapping[str, int],
+    parse_error_refs: Sequence[str] | None = None,
+    stable_ids_verified: bool,
+    backup_verified: bool,
+) -> dict[str, Any]:
+    """Build a read-only inventory without copying material content or locations."""
+
+    if not isinstance(lifecycle_counts, Mapping):
+        raise TypeError("lifecycle_counts must be an object")
+    unexpected_states = sorted(set(lifecycle_counts) - MATERIAL_LIFECYCLE_STATES)
+    if unexpected_states:
+        raise ValueError(
+            "lifecycle_counts contains unsupported states: "
+            + ", ".join(unexpected_states)
+        )
+    counts = {
+        state: nonnegative_int(lifecycle_counts.get(state, 0), field=f"counts.{state}")
+        for state in sorted(MATERIAL_LIFECYCLE_STATES)
+    }
+    if not isinstance(stable_ids_verified, bool):
+        raise ValueError("stable_ids_verified must be a boolean")
+    if not isinstance(backup_verified, bool):
+        raise ValueError("backup_verified must be a boolean")
+
+    inventory: dict[str, Any] = {
+        "schema_version": MATERIAL_STORE_INVENTORY_SCHEMA_VERSION,
+        "goal_id": compact_token(goal_id, field="goal_id"),
+        "store_id": compact_token(store_id, field="store_id"),
+        "store_revision": compact_token(store_revision, field="store_revision"),
+        "observed_at": iso_timestamp(observed_at, field="observed_at"),
+        "source_snapshot_ref": compact_token(
+            source_snapshot_ref,
+            field="source_snapshot_ref",
+        ),
+        "backup_ref": compact_token(backup_ref, field="backup_ref"),
+        "source_digest": compact_token(source_digest, field="source_digest"),
+        "visibility": "public_safe",
+        "capability": capability_contract(packet_role="inventory"),
+        "lifecycle_counts": counts,
+        "item_count": sum(counts.values()),
+        "parse_error_refs": token_list(
+            parse_error_refs,
+            field="parse_error_refs",
+        ),
+        "stable_ids_verified": stable_ids_verified,
+        "backup_verified": backup_verified,
+        "dual_read_required": True,
+        "source_mutation_authorized": False,
+        "raw_content_captured": False,
+        "private_locations_captured": False,
+    }
+    inventory["inventory_ref"] = packet_ref("material-inventory", inventory)
+    return inventory
+
+
+def build_material_migration_plan(
+    *,
+    goal_id: str,
+    plan_id: str,
+    inventory_ref: str,
+    source_revision: str,
+    target_schema: str,
+    observed_at: str,
+    backup_ref: str,
+    rollback_ref: str,
+    expected_item_count: int,
+    protected_material_refs: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """Plan a reversible migration while keeping the source store authoritative."""
+
+    plan: dict[str, Any] = {
+        "schema_version": MATERIAL_MIGRATION_PLAN_SCHEMA_VERSION,
+        "goal_id": compact_token(goal_id, field="goal_id"),
+        "plan_id": compact_token(plan_id, field="plan_id"),
+        "inventory_ref": compact_token(inventory_ref, field="inventory_ref"),
+        "source_revision": compact_token(
+            source_revision,
+            field="source_revision",
+        ),
+        "target_schema": compact_token(target_schema, field="target_schema"),
+        "observed_at": iso_timestamp(observed_at, field="observed_at"),
+        "backup_ref": compact_token(backup_ref, field="backup_ref"),
+        "rollback_ref": compact_token(rollback_ref, field="rollback_ref"),
+        "expected_item_count": nonnegative_int(
+            expected_item_count,
+            field="expected_item_count",
+        ),
+        "protected_material_refs": token_list(
+            protected_material_refs,
+            field="protected_material_refs",
+        ),
+        "visibility": "public_safe",
+        "capability": capability_contract(packet_role="migration_plan"),
+        "phases": [
+            "snapshot",
+            "inventory",
+            "dual_read",
+            "reconcile",
+            "owner_gate",
+            "apply",
+            "rollback_ready",
+        ],
+        "owner_gate_required": True,
+        "source_mutation_authorized": False,
+        "cutover_mode": "dual_read_then_owner_gated_apply",
+        "raw_content_captured": False,
+        "private_locations_captured": False,
+    }
+    plan["plan_ref"] = packet_ref("material-migration-plan", plan)
+    return plan

--- a/loopx/capabilities/material_lifecycle/lifecycle.py
+++ b/loopx/capabilities/material_lifecycle/lifecycle.py
@@ -1,0 +1,98 @@
+"""Auditable material candidate and archive lifecycle receipts."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from ._validation import (
+    capability_contract,
+    compact_token,
+    iso_timestamp,
+    packet_ref,
+    token_list,
+)
+from .inventory import MATERIAL_LIFECYCLE_STATES
+
+MATERIAL_LIFECYCLE_RECEIPT_SCHEMA_VERSION = "material_lifecycle_receipt_v0"
+
+_ALLOWED_TRANSITIONS = {
+    ("unread", "candidate"),
+    ("candidate", "active"),
+    ("candidate", "archived"),
+    ("active", "archived"),
+    ("active", "carryover"),
+    ("carryover", "active"),
+    ("archived", "active"),
+}
+
+
+def build_material_lifecycle_receipt(
+    *,
+    goal_id: str,
+    receipt_id: str,
+    material_ref: str,
+    from_state: str,
+    to_state: str,
+    observed_at: str,
+    source_ref: str,
+    source_revision: str,
+    transition_authority_ref: str,
+    evidence_refs: Sequence[str] | None = None,
+    artifact_ref: str | None = None,
+    archive_ref: str | None = None,
+    decision_evidence_ref: str | None = None,
+) -> dict[str, Any]:
+    """Record a validated lifecycle transition without carrying source content."""
+
+    normalized_from = compact_token(from_state, field="from_state")
+    normalized_to = compact_token(to_state, field="to_state")
+    if normalized_from not in MATERIAL_LIFECYCLE_STATES:
+        raise ValueError(f"unsupported from_state: {normalized_from}")
+    if normalized_to not in MATERIAL_LIFECYCLE_STATES:
+        raise ValueError(f"unsupported to_state: {normalized_to}")
+    if (normalized_from, normalized_to) not in _ALLOWED_TRANSITIONS:
+        raise ValueError(
+            f"unsupported material lifecycle transition: "
+            f"{normalized_from}->{normalized_to}"
+        )
+    if (
+        normalized_from == "archived" or normalized_to == "archived"
+    ) and not archive_ref:
+        raise ValueError("archive_ref is required for archived transitions")
+
+    receipt: dict[str, Any] = {
+        "schema_version": MATERIAL_LIFECYCLE_RECEIPT_SCHEMA_VERSION,
+        "goal_id": compact_token(goal_id, field="goal_id"),
+        "receipt_id": compact_token(receipt_id, field="receipt_id"),
+        "material_ref": compact_token(material_ref, field="material_ref"),
+        "from_state": normalized_from,
+        "to_state": normalized_to,
+        "observed_at": iso_timestamp(observed_at, field="observed_at"),
+        "source_ref": compact_token(source_ref, field="source_ref"),
+        "source_revision": compact_token(
+            source_revision,
+            field="source_revision",
+        ),
+        "transition_authority_ref": compact_token(
+            transition_authority_ref,
+            field="transition_authority_ref",
+        ),
+        "evidence_refs": token_list(evidence_refs, field="evidence_refs"),
+        "visibility": "public_safe",
+        "capability": capability_contract(packet_role="lifecycle_receipt"),
+        "source_reference_preserved": True,
+        "raw_content_captured": False,
+        "private_locations_captured": False,
+    }
+    if artifact_ref is not None:
+        receipt["artifact_ref"] = compact_token(artifact_ref, field="artifact_ref")
+    if archive_ref is not None:
+        receipt["archive_ref"] = compact_token(archive_ref, field="archive_ref")
+    if decision_evidence_ref is not None:
+        receipt["decision_evidence_ref"] = compact_token(
+            decision_evidence_ref,
+            field="decision_evidence_ref",
+        )
+    receipt["receipt_ref"] = packet_ref("material-lifecycle", receipt)
+    return receipt

--- a/loopx/capabilities/material_lifecycle/ranking.py
+++ b/loopx/capabilities/material_lifecycle/ranking.py
@@ -1,0 +1,267 @@
+"""Bounded material rerank proposal and apply receipt contracts."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from ._validation import (
+    capability_contract,
+    check_record_keys,
+    compact_text,
+    compact_token,
+    iso_timestamp,
+    packet_ref,
+    positive_int,
+    token_list,
+)
+
+MATERIAL_RERANK_PROPOSAL_SCHEMA_VERSION = "material_rerank_proposal_v0"
+MATERIAL_RERANK_APPLY_RECEIPT_SCHEMA_VERSION = "material_rerank_apply_receipt_v0"
+
+_MOVE_FIELDS = {
+    "evidence_refs",
+    "from_rank",
+    "material_ref",
+    "reason_code",
+    "to_rank",
+}
+_REQUIRED_MOVE_FIELDS = {
+    "from_rank",
+    "material_ref",
+    "reason_code",
+    "to_rank",
+}
+_APPLY_STATUSES = {"applied", "no_change", "rejected", "rolled_back"}
+
+
+def _normalize_moves(
+    values: Sequence[Mapping[str, Any]] | None,
+    *,
+    protected_material_refs: set[str],
+    max_moved_items: int,
+    max_rank_displacement: int,
+    target_window_size: int,
+) -> list[dict[str, Any]]:
+    if values is None:
+        return []
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise TypeError("moves must be a sequence of objects")
+    if len(values) > max_moved_items:
+        raise ValueError("moves exceeds max_moved_items")
+
+    normalized: list[dict[str, Any]] = []
+    material_refs: set[str] = set()
+    source_ranks: set[int] = set()
+    target_ranks: set[int] = set()
+    for index, value in enumerate(values):
+        field = f"moves[{index}]"
+        check_record_keys(
+            value,
+            field=field,
+            allowed=_MOVE_FIELDS,
+            required=_REQUIRED_MOVE_FIELDS,
+        )
+        material_ref = compact_token(
+            value["material_ref"],
+            field=f"{field}.material_ref",
+        )
+        if material_ref in protected_material_refs:
+            raise ValueError(f"{field}.material_ref is protected")
+        if material_ref in material_refs:
+            raise ValueError("moves material_ref values must be unique")
+        from_rank = positive_int(value["from_rank"], field=f"{field}.from_rank")
+        to_rank = positive_int(value["to_rank"], field=f"{field}.to_rank")
+        if from_rank > target_window_size or to_rank > target_window_size:
+            raise ValueError(f"{field} ranks must stay within target_window_size")
+        if abs(from_rank - to_rank) > max_rank_displacement:
+            raise ValueError(f"{field} exceeds max_rank_displacement")
+        if from_rank == to_rank:
+            raise ValueError(f"{field} must change rank")
+        if from_rank in source_ranks:
+            raise ValueError("moves from_rank values must be unique")
+        if to_rank in target_ranks:
+            raise ValueError("moves to_rank values must be unique")
+        material_refs.add(material_ref)
+        source_ranks.add(from_rank)
+        target_ranks.add(to_rank)
+        normalized.append(
+            {
+                "material_ref": material_ref,
+                "from_rank": from_rank,
+                "to_rank": to_rank,
+                "reason_code": compact_token(
+                    value["reason_code"],
+                    field=f"{field}.reason_code",
+                ),
+                "evidence_refs": token_list(
+                    value.get("evidence_refs"),
+                    field=f"{field}.evidence_refs",
+                    max_items=10,
+                ),
+            }
+        )
+    return sorted(
+        normalized,
+        key=lambda item: json.dumps(
+            item,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+    )
+
+
+def build_material_rerank_proposal(
+    *,
+    goal_id: str,
+    proposal_id: str,
+    inventory_ref: str,
+    decision_evidence_ref: str,
+    observed_at: str,
+    target_window_size: int,
+    max_moved_items: int,
+    max_rank_displacement: int,
+    moves: Sequence[Mapping[str, Any]] | None = None,
+    protected_material_refs: Sequence[str] | None = None,
+    no_change_reason: str | None = None,
+) -> dict[str, Any]:
+    """Propose a bounded delta; never rewrite or apply a whole material queue."""
+
+    window = positive_int(target_window_size, field="target_window_size")
+    max_moved = positive_int(max_moved_items, field="max_moved_items")
+    max_displacement = positive_int(
+        max_rank_displacement,
+        field="max_rank_displacement",
+    )
+    protected = token_list(
+        protected_material_refs,
+        field="protected_material_refs",
+    )
+    normalized_moves = _normalize_moves(
+        moves,
+        protected_material_refs=set(protected),
+        max_moved_items=max_moved,
+        max_rank_displacement=max_displacement,
+        target_window_size=window,
+    )
+    if not normalized_moves and no_change_reason is None:
+        raise ValueError("no_change_reason is required when moves is empty")
+    if normalized_moves and no_change_reason is not None:
+        raise ValueError("no_change_reason is only valid when moves is empty")
+
+    proposal: dict[str, Any] = {
+        "schema_version": MATERIAL_RERANK_PROPOSAL_SCHEMA_VERSION,
+        "goal_id": compact_token(goal_id, field="goal_id"),
+        "proposal_id": compact_token(proposal_id, field="proposal_id"),
+        "inventory_ref": compact_token(inventory_ref, field="inventory_ref"),
+        "decision_evidence_ref": compact_token(
+            decision_evidence_ref,
+            field="decision_evidence_ref",
+        ),
+        "observed_at": iso_timestamp(observed_at, field="observed_at"),
+        "visibility": "public_safe",
+        "capability": capability_contract(packet_role="rerank_proposal"),
+        "constraints": {
+            "target_window_size": window,
+            "max_moved_items": max_moved,
+            "max_rank_displacement": max_displacement,
+            "protected_material_refs": protected,
+        },
+        "moves": normalized_moves,
+        "no_change": not normalized_moves,
+        "apply_authorized": False,
+        "raw_content_captured": False,
+    }
+    if no_change_reason is not None:
+        proposal["no_change_reason"] = compact_text(
+            no_change_reason,
+            field="no_change_reason",
+        )
+    proposal["proposal_ref"] = packet_ref("material-rerank", proposal)
+    return proposal
+
+
+def build_material_rerank_apply_receipt(
+    *,
+    goal_id: str,
+    receipt_id: str,
+    proposal_ref: str,
+    observed_at: str,
+    status: str,
+    before_revision: str,
+    after_revision: str,
+    owner_gate_ref: str,
+    validation_ref: str,
+    applied_material_refs: Sequence[str] | None = None,
+    rollback_ref: str | None = None,
+    rejection_reason: str | None = None,
+) -> dict[str, Any]:
+    """Record the result of an owner-gated apply, rejection, no-op, or rollback."""
+
+    normalized_status = compact_token(status, field="status")
+    if normalized_status not in _APPLY_STATUSES:
+        raise ValueError(f"unsupported status: {normalized_status}")
+    before = compact_token(before_revision, field="before_revision")
+    after = compact_token(after_revision, field="after_revision")
+    applied_refs = token_list(
+        applied_material_refs,
+        field="applied_material_refs",
+    )
+
+    if normalized_status == "applied":
+        if not applied_refs:
+            raise ValueError("applied status requires applied_material_refs")
+        if before == after:
+            raise ValueError("applied status requires a new after_revision")
+        if rollback_ref is None:
+            raise ValueError("applied status requires rollback_ref")
+    elif normalized_status == "rolled_back":
+        if before == after:
+            raise ValueError("rolled_back status requires a new after_revision")
+        if rollback_ref is None:
+            raise ValueError("rolled_back status requires rollback_ref")
+    else:
+        if applied_refs:
+            raise ValueError(
+                f"{normalized_status} status cannot include applied_material_refs"
+            )
+        if before != after:
+            raise ValueError(
+                f"{normalized_status} status must preserve the store revision"
+            )
+    if normalized_status == "rejected" and rejection_reason is None:
+        raise ValueError("rejected status requires rejection_reason")
+    if normalized_status != "rejected" and rejection_reason is not None:
+        raise ValueError("rejection_reason is only valid for rejected status")
+
+    receipt: dict[str, Any] = {
+        "schema_version": MATERIAL_RERANK_APPLY_RECEIPT_SCHEMA_VERSION,
+        "goal_id": compact_token(goal_id, field="goal_id"),
+        "receipt_id": compact_token(receipt_id, field="receipt_id"),
+        "proposal_ref": compact_token(proposal_ref, field="proposal_ref"),
+        "observed_at": iso_timestamp(observed_at, field="observed_at"),
+        "status": normalized_status,
+        "before_revision": before,
+        "after_revision": after,
+        "owner_gate_ref": compact_token(owner_gate_ref, field="owner_gate_ref"),
+        "validation_ref": compact_token(validation_ref, field="validation_ref"),
+        "applied_material_refs": applied_refs,
+        "visibility": "public_safe",
+        "capability": capability_contract(packet_role="rerank_apply_receipt"),
+        "raw_content_captured": False,
+        "private_locations_captured": False,
+    }
+    if rollback_ref is not None:
+        receipt["rollback_ref"] = compact_token(
+            rollback_ref,
+            field="rollback_ref",
+        )
+    if rejection_reason is not None:
+        receipt["rejection_reason"] = compact_text(
+            rejection_reason,
+            field="rejection_reason",
+        )
+    receipt["receipt_ref"] = packet_ref("material-rerank-apply", receipt)
+    return receipt

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -14,6 +14,10 @@ from .capabilities.decision_context.cli import (
     handle_decision_context_command,
     register_decision_context_commands,
 )
+from .capabilities.material_lifecycle.cli import (
+    handle_material_lifecycle_command,
+    register_material_lifecycle_commands,
+)
 from .capabilities.issue_fix.cli import (
     handle_issue_fix_command,
     register_issue_fix_commands,
@@ -197,6 +201,8 @@ def build_parser() -> LoopXArgumentParser:
     register_content_ops_commands(sub, add_subcommand_format)
 
     register_decision_context_commands(sub, add_subcommand_format)
+
+    register_material_lifecycle_commands(sub, add_subcommand_format)
 
     register_issue_fix_commands(sub, add_subcommand_format)
 
@@ -470,6 +476,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     if decision_context_result is not None:
         return decision_context_result
+
+    material_lifecycle_result = handle_material_lifecycle_command(
+        args,
+        output_format=output_format,
+        print_payload=print_payload,
+    )
+    if material_lifecycle_result is not None:
+        return material_lifecycle_result
 
     review_batch_result = handle_review_batch_command(
         args,

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -217,6 +217,7 @@ MANPAGE_COMMAND_HELP_ONLY = frozenset(
         "configure-goal",
         "content-ops",
         "decision-context",
+        "material-lifecycle",
         "demo",
         "dreaming",
         "global-summary",

--- a/tests/capabilities/test_capability_extension_registry.py
+++ b/tests/capabilities/test_capability_extension_registry.py
@@ -25,6 +25,7 @@ from loopx.extensions.runtime import (
 BUILTIN_IDS = [
     "issue-fix",
     "decision-context",
+    "material-lifecycle",
     "semantic-preference",
     "reward-memory",
     "periodic-report",

--- a/tests/capabilities/test_material_lifecycle_contracts.py
+++ b/tests/capabilities/test_material_lifecycle_contracts.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import pytest
+
+from loopx.capabilities.material_lifecycle import (
+    build_material_lifecycle_architecture_packet,
+    build_material_lifecycle_receipt,
+    build_material_migration_plan,
+    build_material_rerank_apply_receipt,
+    build_material_rerank_proposal,
+    build_material_store_inventory,
+)
+
+OBSERVED_AT = "2026-07-25T16:30:00+00:00"
+
+
+def inventory_packet() -> dict[str, object]:
+    return build_material_store_inventory(
+        goal_id="goal:material-example",
+        store_id="store:learning-materials",
+        store_revision="revision:42",
+        observed_at=OBSERVED_AT,
+        source_snapshot_ref="snapshot:revision-42",
+        backup_ref="backup:revision-42",
+        source_digest="sha256:0123456789abcdef",
+        lifecycle_counts={
+            "candidate": 30,
+            "active": 10,
+            "archived": 200,
+            "unread": 5,
+            "carryover": 2,
+        },
+        parse_error_refs=["parse-error:1"],
+        stable_ids_verified=True,
+        backup_verified=True,
+    )
+
+
+def test_architecture_positions_material_lifecycle_as_default_off_sibling() -> None:
+    packet = build_material_lifecycle_architecture_packet()
+
+    assert packet["schema_version"] == "material_lifecycle_architecture_v0"
+    assert packet["capability"] == {
+        "capability_id": "material_lifecycle",
+        "scope": "goal",
+        "default_enabled": False,
+        "creates_authority": False,
+        "mutates_core_state": False,
+    }
+    assert packet["sibling_capabilities"]["decision_context"].startswith(
+        "supplies revisioned evidence"
+    )
+    assert packet["provider_boundaries"]["raw_material_store"] == (
+        "private_external_authority"
+    )
+
+
+def test_inventory_is_deterministic_read_only_and_content_free() -> None:
+    first = inventory_packet()
+    second = inventory_packet()
+
+    assert first == second
+    assert first["item_count"] == 247
+    assert first["source_mutation_authorized"] is False
+    assert first["raw_content_captured"] is False
+    assert str(first["inventory_ref"]).startswith("material-inventory-")
+
+
+def test_inventory_rejects_raw_locations_and_unknown_states() -> None:
+    with pytest.raises(ValueError, match="opaque reference"):
+        build_material_store_inventory(
+            goal_id="goal:material-example",
+            store_id="store:learning-materials",
+            store_revision="revision:42",
+            observed_at=OBSERVED_AT,
+            source_snapshot_ref="https://example.invalid/private",
+            backup_ref="backup:revision-42",
+            source_digest="sha256:0123456789abcdef",
+            lifecycle_counts={"candidate": 1},
+            stable_ids_verified=True,
+            backup_verified=True,
+        )
+    with pytest.raises(ValueError, match="unsupported states"):
+        build_material_store_inventory(
+            goal_id="goal:material-example",
+            store_id="store:learning-materials",
+            store_revision="revision:42",
+            observed_at=OBSERVED_AT,
+            source_snapshot_ref="snapshot:revision-42",
+            backup_ref="backup:revision-42",
+            source_digest="sha256:0123456789abcdef",
+            lifecycle_counts={"raw_content": 1},
+            stable_ids_verified=True,
+            backup_verified=True,
+        )
+
+
+def test_migration_plan_requires_dual_read_owner_gate_and_rollback() -> None:
+    inventory = inventory_packet()
+    plan = build_material_migration_plan(
+        goal_id="goal:material-example",
+        plan_id="plan:migrate-v0",
+        inventory_ref=str(inventory["inventory_ref"]),
+        source_revision="revision:42",
+        target_schema="material_store_v0",
+        observed_at=OBSERVED_AT,
+        backup_ref="backup:revision-42",
+        rollback_ref="rollback:revision-42",
+        expected_item_count=247,
+        protected_material_refs=["material:pinned"],
+    )
+
+    assert plan["phases"] == [
+        "snapshot",
+        "inventory",
+        "dual_read",
+        "reconcile",
+        "owner_gate",
+        "apply",
+        "rollback_ready",
+    ]
+    assert plan["owner_gate_required"] is True
+    assert plan["source_mutation_authorized"] is False
+
+
+def test_archive_and_reactivation_preserve_stable_references() -> None:
+    archived = build_material_lifecycle_receipt(
+        goal_id="goal:material-example",
+        receipt_id="receipt:archive-1",
+        material_ref="material:42",
+        from_state="active",
+        to_state="archived",
+        observed_at=OBSERVED_AT,
+        source_ref="source:42",
+        source_revision="revision:42",
+        transition_authority_ref="decision-outcome:archive-1",
+        evidence_refs=["evidence:artifact-created"],
+        artifact_ref="artifact:note-42",
+        archive_ref="archive:42",
+        decision_evidence_ref="decision-evidence-0123456789abcdef",
+    )
+    reactivated = build_material_lifecycle_receipt(
+        goal_id="goal:material-example",
+        receipt_id="receipt:reactivate-1",
+        material_ref="material:42",
+        from_state="archived",
+        to_state="active",
+        observed_at=OBSERVED_AT,
+        source_ref="source:42",
+        source_revision="revision:43",
+        transition_authority_ref="policy:reactivate-reviewed-archive",
+        archive_ref="archive:42",
+    )
+
+    assert archived["source_reference_preserved"] is True
+    assert reactivated["material_ref"] == archived["material_ref"]
+    assert reactivated["archive_ref"] == archived["archive_ref"]
+    assert reactivated["raw_content_captured"] is False
+
+
+def test_lifecycle_rejects_invalid_or_unreferenced_archive_transitions() -> None:
+    with pytest.raises(ValueError, match="archive_ref is required"):
+        build_material_lifecycle_receipt(
+            goal_id="goal:material-example",
+            receipt_id="receipt:archive-1",
+            material_ref="material:42",
+            from_state="active",
+            to_state="archived",
+            observed_at=OBSERVED_AT,
+            source_ref="source:42",
+            source_revision="revision:42",
+            transition_authority_ref="decision-outcome:archive-1",
+        )
+    with pytest.raises(ValueError, match="unsupported material lifecycle transition"):
+        build_material_lifecycle_receipt(
+            goal_id="goal:material-example",
+            receipt_id="receipt:skip-1",
+            material_ref="material:42",
+            from_state="unread",
+            to_state="archived",
+            observed_at=OBSERVED_AT,
+            source_ref="source:42",
+            source_revision="revision:42",
+            transition_authority_ref="decision-outcome:skip-1",
+            archive_ref="archive:42",
+        )
+
+
+def test_rerank_proposal_is_bounded_and_decision_referenced() -> None:
+    proposal = build_material_rerank_proposal(
+        goal_id="goal:material-example",
+        proposal_id="proposal:rerank-1",
+        inventory_ref=str(inventory_packet()["inventory_ref"]),
+        decision_evidence_ref="decision-evidence-0123456789abcdef",
+        observed_at=OBSERVED_AT,
+        target_window_size=30,
+        max_moved_items=3,
+        max_rank_displacement=5,
+        protected_material_refs=["material:pinned"],
+        moves=[
+            {
+                "material_ref": "material:42",
+                "from_rank": 8,
+                "to_rank": 4,
+                "reason_code": "current_objective_fit",
+                "evidence_refs": ["evidence:decision-1"],
+            }
+        ],
+    )
+
+    assert proposal["no_change"] is False
+    assert proposal["apply_authorized"] is False
+    assert proposal["constraints"]["max_moved_items"] == 3
+    assert proposal["moves"][0]["material_ref"] == "material:42"
+
+
+def test_rerank_supports_no_change_and_rejects_unbounded_moves() -> None:
+    no_change = build_material_rerank_proposal(
+        goal_id="goal:material-example",
+        proposal_id="proposal:no-change",
+        inventory_ref=str(inventory_packet()["inventory_ref"]),
+        decision_evidence_ref="decision-evidence-0123456789abcdef",
+        observed_at=OBSERVED_AT,
+        target_window_size=30,
+        max_moved_items=3,
+        max_rank_displacement=5,
+        no_change_reason="Current evidence does not justify changing the shortlist.",
+    )
+    assert no_change["no_change"] is True
+
+    with pytest.raises(ValueError, match="protected"):
+        build_material_rerank_proposal(
+            goal_id="goal:material-example",
+            proposal_id="proposal:protected",
+            inventory_ref=str(inventory_packet()["inventory_ref"]),
+            decision_evidence_ref="decision-evidence-0123456789abcdef",
+            observed_at=OBSERVED_AT,
+            target_window_size=30,
+            max_moved_items=3,
+            max_rank_displacement=5,
+            protected_material_refs=["material:pinned"],
+            moves=[
+                {
+                    "material_ref": "material:pinned",
+                    "from_rank": 2,
+                    "to_rank": 1,
+                    "reason_code": "move_protected",
+                }
+            ],
+        )
+    with pytest.raises(ValueError, match="max_rank_displacement"):
+        build_material_rerank_proposal(
+            goal_id="goal:material-example",
+            proposal_id="proposal:too-far",
+            inventory_ref=str(inventory_packet()["inventory_ref"]),
+            decision_evidence_ref="decision-evidence-0123456789abcdef",
+            observed_at=OBSERVED_AT,
+            target_window_size=30,
+            max_moved_items=3,
+            max_rank_displacement=5,
+            moves=[
+                {
+                    "material_ref": "material:42",
+                    "from_rank": 20,
+                    "to_rank": 1,
+                    "reason_code": "unbounded_move",
+                }
+            ],
+        )
+
+
+def test_apply_receipt_requires_owner_gate_validation_and_rollback() -> None:
+    applied = build_material_rerank_apply_receipt(
+        goal_id="goal:material-example",
+        receipt_id="receipt:apply-1",
+        proposal_ref="material-rerank-0123456789abcdef",
+        observed_at=OBSERVED_AT,
+        status="applied",
+        before_revision="revision:42",
+        after_revision="revision:43",
+        owner_gate_ref="gate:rerank-1",
+        validation_ref="validation:rerank-1",
+        applied_material_refs=["material:42"],
+        rollback_ref="rollback:revision-42",
+    )
+    assert applied["status"] == "applied"
+    assert applied["raw_content_captured"] is False
+
+    with pytest.raises(ValueError, match="rollback_ref"):
+        build_material_rerank_apply_receipt(
+            goal_id="goal:material-example",
+            receipt_id="receipt:apply-2",
+            proposal_ref="material-rerank-0123456789abcdef",
+            observed_at=OBSERVED_AT,
+            status="applied",
+            before_revision="revision:42",
+            after_revision="revision:43",
+            owner_gate_ref="gate:rerank-1",
+            validation_ref="validation:rerank-1",
+            applied_material_refs=["material:42"],
+        )
+
+
+def test_no_change_apply_receipt_preserves_revision() -> None:
+    receipt = build_material_rerank_apply_receipt(
+        goal_id="goal:material-example",
+        receipt_id="receipt:no-change",
+        proposal_ref="material-rerank-0123456789abcdef",
+        observed_at=OBSERVED_AT,
+        status="no_change",
+        before_revision="revision:42",
+        after_revision="revision:42",
+        owner_gate_ref="gate:rerank-1",
+        validation_ref="validation:rerank-1",
+    )
+
+    assert receipt["status"] == "no_change"
+    assert receipt["applied_material_refs"] == []


### PR DESCRIPTION
## Summary

- add a built-in, default-off, goal-scoped Material Lifecycle capability
- define public-safe inventory, backup-safe migration plan, lifecycle receipt, bounded rerank proposal, and apply receipt contracts
- connect bounded rerank proposals to revisioned Decision Context evidence without coupling to a provider
- expose a read-only architecture CLI, capability catalog entry, bilingual protocol docs, and focused public smokes

## Boundary

- raw material, private locations, provider payloads, credentials, and source-store formats never enter public packets
- source snapshots and backups precede dual-read reconciliation; cutover and rollback stay owner-gated
- recurring automation is kept thin: source profiles, cursors, ranking rules, and exploration providers remain deferred
- this PR does not include a legacy parser, migration apply path, web exploration, messaging adapter, or private dogfood data

## Validation

- `pytest tests/capabilities/test_material_lifecycle_contracts.py tests/capabilities/test_capability_extension_registry.py -q` (21 passed)
- `python examples/material-lifecycle-contract-smoke.py`
- `python examples/capability-extension-registry-smoke.py`
- Ruff check and format check for the new package/tests/smoke
- risk-based `canary premerge --from-git-diff --tier standard`: 18/18 selected checks passed, no warnings or manual holds
- public/private boundary scan: 17 files clean

## Residual risk

The contracts intentionally precede real storage adapters. The next slice must prove a read-only legacy inventory, stable IDs, exact count reconciliation, and rollback before any source mutation is considered.