### PR TITLE
feat(decision-context): assemble rebased evidence

### DIFF
--- a/loopx/capabilities/decision_context/__init__.py
+++ b/loopx/capabilities/decision_context/__init__.py
@@ -1,5 +1,15 @@
 """Goal-scoped Decision Context capability contracts."""
 
+from .assembler import (
+    DECISION_CONTEXT_ASSEMBLY_SCHEMA_VERSION,
+    DECISION_CURSOR_CHECKPOINT_SCHEMA_VERSION,
+    DecisionAuthorityEvidence,
+    DecisionContextAssembly,
+    DecisionEvidenceCollection,
+    DecisionEvidenceRecords,
+    DecisionRecallEvidence,
+    assemble_decision_evidence,
+)
 from .architecture import (
     DECISION_CONTEXT_ARCHITECTURE_SCHEMA_VERSION,
     build_decision_context_architecture_packet,
@@ -20,24 +30,34 @@ from .sources import (
     DecisionSourceProvider,
     DecisionSourceScan,
     DecisionSourceSpec,
+    build_decision_source_item_refs,
     build_decision_source_manifest,
 )
 
 __all__ = [
+    "DECISION_CONTEXT_ASSEMBLY_SCHEMA_VERSION",
     "DECISION_CONTEXT_ARCHITECTURE_SCHEMA_VERSION",
+    "DECISION_CURSOR_CHECKPOINT_SCHEMA_VERSION",
     "DECISION_EVIDENCE_PACKET_SCHEMA_VERSION",
     "DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION",
     "DECISION_PROPOSAL_SCHEMA_VERSION",
     "DECISION_SOURCE_MANIFEST_SCHEMA_VERSION",
     "DECISION_SOURCE_SCAN_RECEIPT_SCHEMA_VERSION",
+    "DecisionAuthorityEvidence",
+    "DecisionContextAssembly",
+    "DecisionEvidenceCollection",
+    "DecisionEvidenceRecords",
+    "DecisionRecallEvidence",
     "DecisionSourceExactRead",
     "DecisionSourceItem",
     "DecisionSourceProvider",
     "DecisionSourceScan",
     "DecisionSourceSpec",
+    "assemble_decision_evidence",
     "build_decision_context_architecture_packet",
     "build_decision_evidence_packet",
     "build_decision_outcome_receipt",
     "build_decision_proposal",
+    "build_decision_source_item_refs",
     "build_decision_source_manifest",
 ]

--- a/loopx/capabilities/decision_context/architecture.py
+++ b/loopx/capabilities/decision_context/architecture.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from .assembler import (
+    DECISION_CONTEXT_ASSEMBLY_SCHEMA_VERSION,
+    DECISION_CURSOR_CHECKPOINT_SCHEMA_VERSION,
+)
 from .packets import (
     DECISION_EVIDENCE_PACKET_SCHEMA_VERSION,
     DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION,
@@ -37,6 +41,10 @@ def build_decision_context_architecture_packet() -> dict[str, object]:
             DECISION_SOURCE_MANIFEST_SCHEMA_VERSION,
             DECISION_SOURCE_SCAN_RECEIPT_SCHEMA_VERSION,
         ],
+        "assembly_schemas": [
+            DECISION_CONTEXT_ASSEMBLY_SCHEMA_VERSION,
+            DECISION_CURSOR_CHECKPOINT_SCHEMA_VERSION,
+        ],
         "provider_boundaries": {
             "decision_source_provider": (
                 "bounded_authority_change_detection_and_exact_read"
@@ -54,11 +62,11 @@ def build_decision_context_architecture_packet() -> dict[str, object]:
         "invariants": [
             "evidence_and_proposal_remain_separate",
             "accepted_recalled_claims_require_exact_read_and_revision",
+            "changed_facts_require_exact_read_authority_revisions",
+            "incremental_cursors_advance_only_after_rebase_and_writeback",
             "raw_provider_content_never_enters_public_packets",
             "proposals_require_existing_authority_confirmation",
             "verified_outcomes_precede_reward_memory_candidates",
         ],
-        "next_stage": (
-            "evidence_assembler_then_default_off_provider_adapter_and_dogfood"
-        ),
+        "next_stage": "default_off_provider_adapter_then_private_dogfood",
     }

--- a/loopx/capabilities/decision_context/assembler.py
+++ b/loopx/capabilities/decision_context/assembler.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from ..context_providers.base import (
     ContextProvider,
+    ContextProviderItem,
     ContextProviderRetrieval,
     canonical_context_matches,
     opaque_provider_ref,
@@ -212,6 +213,16 @@ def _collect_source(
             (),
             False,
         )
+    if not isinstance(scan, DecisionSourceScan):
+        return (
+            _unavailable_source_scan(
+                source=source,
+                observed_at=observed_at,
+                reason_code="provider_contract_invalid",
+            ),
+            (),
+            False,
+        )
 
     exact_reads: list[DecisionSourceExactRead] = []
     exact_read_failed = False
@@ -224,12 +235,13 @@ def _collect_source(
                     timeout_seconds=timeout_seconds,
                     observed_at=observed_at,
                 )
+                if not isinstance(exact_read, DecisionSourceExactRead):
+                    raise TypeError("exact_read must return DecisionSourceExactRead")
+                if exact_read.verified:
+                    exact_reads.append(exact_read)
+                else:
+                    exact_read_failed = True
             except Exception:
-                exact_read_failed = True
-                continue
-            if exact_read.verified:
-                exact_reads.append(exact_read)
-            else:
                 exact_read_failed = True
     return scan, tuple(exact_reads), exact_read_failed
 
@@ -248,7 +260,7 @@ def _collect_recall(
     if provider is None:
         return None
     try:
-        return provider.retrieve(
+        retrieval = provider.retrieve(
             namespace=namespace,
             scope_ref=scope_ref,
             query=query,
@@ -259,13 +271,42 @@ def _collect_recall(
         )
     except Exception:
         return _unavailable_context_retrieval(
-            provider=str(getattr(provider, "provider_id", "context-provider")),
+            provider="context-provider",
             namespace=namespace,
             observed_at=observed_at,
             query_summary=query_summary,
             requested_limit=max_results,
             reason_code="provider_retrieval_failed",
         )
+    provider_id = str(getattr(provider, "provider_id", ""))
+    contract_valid = (
+        isinstance(retrieval, ContextProviderRetrieval)
+        and retrieval.provider == provider_id
+        and retrieval.namespace == namespace
+        and len(retrieval.items) <= max_results
+        and all(isinstance(item, ContextProviderItem) for item in retrieval.items)
+    )
+    if not contract_valid:
+        return _unavailable_context_retrieval(
+            provider="context-provider",
+            namespace=namespace,
+            observed_at=observed_at,
+            query_summary=query_summary,
+            requested_limit=max_results,
+            reason_code="provider_contract_invalid",
+        )
+    try:
+        retrieval.public_packet()
+    except Exception:
+        return _unavailable_context_retrieval(
+            provider="context-provider",
+            namespace=namespace,
+            observed_at=observed_at,
+            query_summary=query_summary,
+            requested_limit=max_results,
+            reason_code="provider_contract_invalid",
+        )
+    return retrieval
 
 
 def _freshness(

--- a/loopx/capabilities/decision_context/assembler.py
+++ b/loopx/capabilities/decision_context/assembler.py
@@ -1,0 +1,691 @@
+"""Deterministic authority rebase and advisory recall assembly."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from ..context_providers.base import (
+    ContextProvider,
+    ContextProviderRetrieval,
+    canonical_context_matches,
+    opaque_provider_ref,
+)
+from .packets import build_decision_evidence_packet
+from .sources import (
+    DecisionSourceExactRead,
+    DecisionSourceProvider,
+    DecisionSourceScan,
+    DecisionSourceSpec,
+    build_decision_source_item_refs,
+    build_decision_source_manifest,
+)
+
+DECISION_CONTEXT_ASSEMBLY_SCHEMA_VERSION = "decision_context_assembly_v0"
+DECISION_CURSOR_CHECKPOINT_SCHEMA_VERSION = "decision_cursor_checkpoint_v0"
+
+
+def _packet_ref(prefix: str, packet: Mapping[str, Any]) -> str:
+    payload = json.dumps(
+        packet,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:20]
+    return f"{prefix}-{digest}"
+
+
+def _timestamp(value: str, *, field_name: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(str(value).strip())
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field_name} must include a timezone")
+    return parsed
+
+
+def _positive_number(value: float, *, field_name: str) -> float:
+    if isinstance(value, bool):
+        raise TypeError(f"{field_name} must be a positive number")
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"{field_name} must be a positive number") from exc
+    if number <= 0:
+        raise ValueError(f"{field_name} must be a positive number")
+    return number
+
+
+@dataclass(frozen=True)
+class DecisionAuthorityEvidence:
+    """One exact-read authority item with public-safe linkage refs."""
+
+    source_id: str
+    source_ref: str
+    source_revision: str
+    observed_at: str
+    resource_ref: str = field(repr=False)
+    revision: str = field(repr=False)
+    content: str = field(repr=False)
+
+
+@dataclass(frozen=True)
+class DecisionRecallEvidence:
+    """One advisory recall item whose content remains transient."""
+
+    provider_ref: str
+    summary: str
+    score: float | None
+    resource_ref: str = field(repr=False)
+    content: str = field(repr=False)
+
+
+@dataclass(frozen=True)
+class DecisionEvidenceRecords:
+    """Domain rebase result consumed by the deterministic assembler."""
+
+    changed_facts: tuple[Mapping[str, Any], ...] = ()
+    recalled_claims: tuple[Mapping[str, Any], ...] = ()
+    stale_or_rejected_claims: tuple[Mapping[str, Any], ...] = ()
+    conflicts: tuple[Mapping[str, Any], ...] = ()
+
+
+@dataclass(frozen=True)
+class DecisionEvidenceCollection:
+    """Transient collection exposed to a domain-specific rebase callback."""
+
+    authority: tuple[DecisionAuthorityEvidence, ...]
+    recall: tuple[DecisionRecallEvidence, ...]
+    source_scan_receipts: tuple[Mapping[str, Any], ...]
+    context_retrieval_receipt: Mapping[str, Any] | None
+
+
+DecisionEvidenceRebaser = Callable[
+    [DecisionEvidenceCollection],
+    DecisionEvidenceRecords,
+]
+
+
+@dataclass(frozen=True)
+class DecisionContextAssembly:
+    """Public-safe assembly plus private proposed cursor updates."""
+
+    packet: Mapping[str, Any]
+    proposed_cursors: Mapping[str, str] = field(repr=False)
+
+    def public_packet(self) -> dict[str, Any]:
+        return dict(self.packet)
+
+
+@dataclass(frozen=True)
+class _CollectedSource:
+    source: DecisionSourceSpec
+    scan: DecisionSourceScan
+    exact_reads: tuple[DecisionSourceExactRead, ...]
+    exact_read_failed: bool
+    receipt: Mapping[str, Any]
+
+
+def _unavailable_source_scan(
+    *,
+    source: DecisionSourceSpec,
+    observed_at: str,
+    reason_code: str,
+) -> DecisionSourceScan:
+    return DecisionSourceScan(
+        provider_id=source.provider_id,
+        source_id=source.source_id,
+        status="unavailable",
+        observed_at=observed_at,
+        requested_limit=source.max_changes,
+        reason_code=reason_code,
+    )
+
+
+def _unavailable_context_retrieval(
+    *,
+    provider: str,
+    namespace: str,
+    observed_at: str,
+    query_summary: str,
+    requested_limit: int,
+    reason_code: str,
+) -> ContextProviderRetrieval:
+    return ContextProviderRetrieval(
+        provider=provider,
+        namespace=namespace,
+        status="unavailable",
+        query_summary=query_summary,
+        observed_at=observed_at,
+        search_performed=False,
+        read_performed=False,
+        reason_code=reason_code,
+        requested_limit=requested_limit,
+    )
+
+
+def _collect_source(
+    *,
+    source: DecisionSourceSpec,
+    provider: DecisionSourceProvider | None,
+    cursor: str | None,
+    before: str,
+    timeout_seconds: float,
+    observed_at: str,
+) -> tuple[
+    DecisionSourceScan,
+    tuple[DecisionSourceExactRead, ...],
+    bool,
+]:
+    if provider is None:
+        return (
+            _unavailable_source_scan(
+                source=source,
+                observed_at=observed_at,
+                reason_code="provider_not_configured",
+            ),
+            (),
+            False,
+        )
+    try:
+        scan = provider.scan(
+            source=source,
+            after_cursor=cursor,
+            before=before,
+            limit=source.max_changes,
+            timeout_seconds=timeout_seconds,
+            observed_at=observed_at,
+        )
+    except Exception:
+        return (
+            _unavailable_source_scan(
+                source=source,
+                observed_at=observed_at,
+                reason_code="provider_scan_failed",
+            ),
+            (),
+            False,
+        )
+
+    exact_reads: list[DecisionSourceExactRead] = []
+    exact_read_failed = False
+    if scan.status == "completed" and source.exact_read_policy != "never":
+        for item in scan.items:
+            try:
+                exact_read = provider.exact_read(
+                    source=source,
+                    item=item,
+                    timeout_seconds=timeout_seconds,
+                    observed_at=observed_at,
+                )
+            except Exception:
+                exact_read_failed = True
+                continue
+            if exact_read.verified:
+                exact_reads.append(exact_read)
+            else:
+                exact_read_failed = True
+    return scan, tuple(exact_reads), exact_read_failed
+
+
+def _collect_recall(
+    *,
+    provider: ContextProvider | None,
+    namespace: str,
+    scope_ref: str,
+    query: str,
+    query_summary: str,
+    max_results: int,
+    timeout_seconds: float,
+    observed_at: str,
+) -> ContextProviderRetrieval | None:
+    if provider is None:
+        return None
+    try:
+        return provider.retrieve(
+            namespace=namespace,
+            scope_ref=scope_ref,
+            query=query,
+            query_summary=query_summary,
+            max_results=max_results,
+            timeout_seconds=timeout_seconds,
+            observed_at=observed_at,
+        )
+    except Exception:
+        return _unavailable_context_retrieval(
+            provider=str(getattr(provider, "provider_id", "context-provider")),
+            namespace=namespace,
+            observed_at=observed_at,
+            query_summary=query_summary,
+            requested_limit=max_results,
+            reason_code="provider_retrieval_failed",
+        )
+
+
+def _freshness(
+    *,
+    item_observed_at: str,
+    assembly_observed_at: datetime,
+    freshness_seconds: int,
+) -> str:
+    item_time = _timestamp(item_observed_at, field_name="item.observed_at")
+    age_seconds = max(0.0, (assembly_observed_at - item_time).total_seconds())
+    return "current" if age_seconds <= freshness_seconds else "stale"
+
+
+def _verified_recalled_claims(
+    *,
+    claims: Sequence[Mapping[str, Any]],
+    authority: Sequence[DecisionAuthorityEvidence],
+    recall: Sequence[DecisionRecallEvidence],
+) -> list[dict[str, Any]]:
+    authority_by_ref = {
+        (item.source_ref, item.source_revision): item for item in authority
+    }
+    recall_by_ref = {item.provider_ref: item for item in recall}
+    verified: list[dict[str, Any]] = []
+    for claim in claims:
+        provider_ref = str(claim.get("provider_ref") or "")
+        source_ref = str(claim.get("source_ref") or "")
+        source_revision = str(claim.get("source_revision") or "")
+        recalled_item = recall_by_ref.get(provider_ref)
+        authority_item = authority_by_ref.get((source_ref, source_revision))
+        if (
+            recalled_item is None
+            or authority_item is None
+            or not canonical_context_matches(
+                recalled_item.content,
+                authority_item.content,
+            )
+        ):
+            raise ValueError(
+                "recalled_claims must match an exact-read authority revision; "
+                "reject stale or conflicting recall instead"
+            )
+        record = dict(claim)
+        record["exact_read_verified"] = True
+        verified.append(record)
+    return verified
+
+
+def _verified_changed_facts(
+    *,
+    facts: Sequence[Mapping[str, Any]],
+    authority: Sequence[DecisionAuthorityEvidence],
+) -> list[dict[str, Any]]:
+    authority_keys = {(item.source_ref, item.source_revision) for item in authority}
+    verified: list[dict[str, Any]] = []
+    for fact in facts:
+        source_ref = str(fact.get("source_ref") or "")
+        source_revision = str(fact.get("source_revision") or "")
+        if not source_revision or (source_ref, source_revision) not in authority_keys:
+            raise ValueError(
+                "changed_facts must reference an exact-read authority revision"
+            )
+        verified.append(dict(fact))
+    return verified
+
+
+def _accounted_authority(
+    evidence: Mapping[str, Any],
+) -> tuple[set[tuple[str, str]], set[str]]:
+    accounted_pairs: set[tuple[str, str]] = set()
+    for field_name in (
+        "changed_facts",
+        "recalled_claims",
+        "stale_or_rejected_claims",
+    ):
+        for record in evidence[field_name]:
+            source_ref = str(record.get("source_ref") or "")
+            source_revision = str(record.get("source_revision") or "")
+            if source_ref and source_revision:
+                accounted_pairs.add((source_ref, source_revision))
+
+    conflict_refs = {
+        str(source_ref)
+        for conflict in evidence["conflicts"]
+        for source_ref in conflict["source_refs"]
+    }
+    return accounted_pairs, conflict_refs
+
+
+def _checkpoint_disposition(
+    *,
+    collected: _CollectedSource,
+    accounted_pairs: set[tuple[str, str]],
+    conflict_refs: set[str],
+) -> tuple[bool, str]:
+    scan = collected.scan
+    if scan.cursor_after is None:
+        return False, "cursor_after_missing"
+    if scan.status == "no_change":
+        return True, "no_change"
+    if scan.status != "completed":
+        return False, "scan_incomplete"
+    if not scan.items:
+        return True, "no_change"
+    if collected.source.exact_read_policy == "never":
+        return False, "exact_read_disabled"
+    if collected.exact_read_failed or len(collected.exact_reads) != len(scan.items):
+        return False, "exact_read_incomplete"
+
+    changed_refs = []
+    for item in scan.items:
+        refs = build_decision_source_item_refs(
+            provider_id=collected.source.provider_id,
+            source_id=collected.source.source_id,
+            item=item,
+        )
+        changed_refs.append((refs["source_ref"], refs["source_revision"]))
+    if any(
+        pair not in accounted_pairs and pair[0] not in conflict_refs
+        for pair in changed_refs
+    ):
+        return False, "rebase_incomplete"
+    return True, "validated_rebase"
+
+
+def _cursor_checkpoint(
+    *,
+    goal_id: str,
+    decision_id: str,
+    observed_at: str,
+    evidence_packet_ref: str,
+    source_rows: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    packet: dict[str, Any] = {
+        "schema_version": DECISION_CURSOR_CHECKPOINT_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "decision_id": decision_id,
+        "observed_at": observed_at,
+        "evidence_packet_ref": evidence_packet_ref,
+        "visibility": "public_safe",
+        "sources": sorted(
+            [dict(row) for row in source_rows],
+            key=lambda row: str(row["source_id"]),
+        ),
+        "apply_requires_validated_decision_writeback": True,
+        "applied": False,
+        "raw_cursors_captured": False,
+        "external_writes_performed": False,
+    }
+    packet["checkpoint_ref"] = _packet_ref("decision-cursor-checkpoint", packet)
+    return packet
+
+
+def assemble_decision_evidence(
+    *,
+    goal_id: str,
+    decision_id: str,
+    observed_at: str,
+    before: str,
+    sources: Sequence[DecisionSourceSpec],
+    source_providers: Mapping[str, DecisionSourceProvider],
+    cursors: Mapping[str, str | None],
+    rebase: DecisionEvidenceRebaser,
+    context_provider: ContextProvider | None = None,
+    context_namespace: str = "decision-context",
+    context_scope_ref: str = "goal",
+    recall_query: str = "current decision evidence",
+    recall_query_summary: str = "current decision evidence",
+    recall_limit: int = 5,
+    timeout_seconds: float = 10.0,
+) -> DecisionContextAssembly:
+    """Collect, rebase, and assemble one public-safe decision evidence packet.
+
+    Cursor values are returned only as private proposals. A caller may persist
+    them after the decision ledger and outcome receipt have been validated.
+    """
+
+    assembly_time = _timestamp(observed_at, field_name="observed_at")
+    _timestamp(before, field_name="before")
+    timeout_seconds = _positive_number(
+        timeout_seconds,
+        field_name="timeout_seconds",
+    )
+    if (
+        isinstance(recall_limit, bool)
+        or not isinstance(recall_limit, int)
+        or recall_limit <= 0
+    ):
+        raise ValueError("recall_limit must be a positive integer")
+
+    enabled_sources = sorted(
+        (source for source in sources if source.enabled),
+        key=lambda source: source.source_id,
+    )
+    manifest = build_decision_source_manifest(
+        goal_id=goal_id,
+        observed_at=observed_at,
+        sources=enabled_sources,
+    )
+
+    authority_items: list[DecisionAuthorityEvidence] = []
+    source_scan_receipts: list[Mapping[str, Any]] = []
+    source_revisions: list[dict[str, Any]] = []
+    provider_health: list[dict[str, Any]] = []
+    collected_sources: list[_CollectedSource] = []
+
+    for source in enabled_sources:
+        provider = source_providers.get(source.provider_id)
+        scan, exact_reads, exact_read_failed = _collect_source(
+            source=source,
+            provider=provider,
+            cursor=cursors.get(source.source_id),
+            before=before,
+            timeout_seconds=timeout_seconds,
+            observed_at=observed_at,
+        )
+        try:
+            if (
+                scan.provider_id != source.provider_id
+                or scan.source_id != source.source_id
+            ):
+                raise ValueError("provider scan identity does not match source")
+            receipt = scan.public_receipt(exact_reads=exact_reads)
+        except (TypeError, ValueError):
+            scan = _unavailable_source_scan(
+                source=source,
+                observed_at=observed_at,
+                reason_code="provider_contract_invalid",
+            )
+            exact_reads = ()
+            exact_read_failed = False
+            receipt = scan.public_receipt()
+        source_scan_receipts.append(receipt)
+        collected_sources.append(
+            _CollectedSource(
+                source=source,
+                scan=scan,
+                exact_reads=exact_reads,
+                exact_read_failed=exact_read_failed,
+                receipt=receipt,
+            )
+        )
+
+        exact_by_key = {
+            (item.resource_ref, item.revision): item for item in exact_reads
+        }
+        for item in scan.items:
+            refs = build_decision_source_item_refs(
+                provider_id=source.provider_id,
+                source_id=source.source_id,
+                item=item,
+            )
+            freshness = _freshness(
+                item_observed_at=item.observed_at,
+                assembly_observed_at=assembly_time,
+                freshness_seconds=source.freshness_seconds,
+            )
+            source_revisions.append(
+                {
+                    "source_ref": refs["source_ref"],
+                    "revision": refs["source_revision"],
+                    "observed_at": item.observed_at,
+                    "freshness": freshness,
+                }
+            )
+            exact_read = exact_by_key.get((item.resource_ref, item.revision))
+            if exact_read is not None:
+                authority_items.append(
+                    DecisionAuthorityEvidence(
+                        source_id=source.source_id,
+                        source_ref=refs["source_ref"],
+                        source_revision=refs["source_revision"],
+                        observed_at=item.observed_at,
+                        resource_ref=item.resource_ref,
+                        revision=item.revision,
+                        content=exact_read.content,
+                    )
+                )
+
+        provider_health.append(
+            {
+                "provider": source.provider_id,
+                "status": (
+                    "healthy"
+                    if scan.status in {"completed", "no_change"}
+                    and not exact_read_failed
+                    else "degraded"
+                    if scan.status == "completed"
+                    else "unavailable"
+                ),
+                "observed_at": observed_at,
+                "reason_code": scan.reason_code
+                or ("exact_read_failed" if exact_read_failed else None),
+                "fail_open": True,
+            }
+        )
+
+    retrieval = _collect_recall(
+        provider=context_provider,
+        namespace=context_namespace,
+        scope_ref=context_scope_ref,
+        query=recall_query,
+        query_summary=recall_query_summary,
+        max_results=recall_limit,
+        timeout_seconds=timeout_seconds,
+        observed_at=observed_at,
+    )
+    recall_items: list[DecisionRecallEvidence] = []
+    retrieval_receipt: Mapping[str, Any] | None = None
+    if retrieval is not None:
+        retrieval_receipt = retrieval.public_packet()
+        for retrieved_item in retrieval.items:
+            recall_items.append(
+                DecisionRecallEvidence(
+                    provider_ref=opaque_provider_ref(
+                        provider=retrieval.provider,
+                        namespace=retrieval.namespace,
+                        resource_ref=retrieved_item.resource_ref,
+                    ),
+                    summary=retrieved_item.summary,
+                    score=retrieved_item.score,
+                    resource_ref=retrieved_item.resource_ref,
+                    content=retrieved_item.content,
+                )
+            )
+        provider_health.append(
+            {
+                "provider": retrieval.provider,
+                "status": "healthy"
+                if retrieval.status == "completed" and retrieval.read_performed
+                else "degraded"
+                if retrieval.status == "completed"
+                else "unavailable",
+                "observed_at": observed_at,
+                "reason_code": retrieval.reason_code,
+                "fail_open": True,
+            }
+        )
+
+    collection = DecisionEvidenceCollection(
+        authority=tuple(authority_items),
+        recall=tuple(recall_items),
+        source_scan_receipts=tuple(source_scan_receipts),
+        context_retrieval_receipt=retrieval_receipt,
+    )
+    records = rebase(collection)
+    if not isinstance(records, DecisionEvidenceRecords):
+        raise TypeError("rebase must return DecisionEvidenceRecords")
+
+    verified_facts = _verified_changed_facts(
+        facts=records.changed_facts,
+        authority=authority_items,
+    )
+    verified_claims = _verified_recalled_claims(
+        claims=records.recalled_claims,
+        authority=authority_items,
+        recall=recall_items,
+    )
+    evidence = build_decision_evidence_packet(
+        goal_id=goal_id,
+        decision_id=decision_id,
+        observed_at=observed_at,
+        changed_facts=verified_facts,
+        recalled_claims=verified_claims,
+        stale_or_rejected_claims=records.stale_or_rejected_claims,
+        conflicts=records.conflicts,
+        source_revisions=source_revisions,
+        provider_health=provider_health,
+    )
+    accounted_pairs, conflict_refs = _accounted_authority(evidence)
+    cursor_rows: list[dict[str, Any]] = []
+    proposed_cursors: dict[str, str] = {}
+    for collected in collected_sources:
+        checkpoint_ready, reason_code = _checkpoint_disposition(
+            collected=collected,
+            accounted_pairs=accounted_pairs,
+            conflict_refs=conflict_refs,
+        )
+        if checkpoint_ready and collected.scan.cursor_after is not None:
+            proposed_cursors[collected.source.source_id] = collected.scan.cursor_after
+        cursor_rows.append(
+            {
+                "source_id": collected.source.source_id,
+                "scan_receipt_ref": collected.receipt["receipt_ref"],
+                "cursor_before_ref": collected.receipt["cursor_before_ref"],
+                "cursor_after_ref": collected.receipt["cursor_after_ref"],
+                "disposition": (
+                    "ready_after_writeback" if checkpoint_ready else "preserve"
+                ),
+                "reason_code": reason_code,
+            }
+        )
+
+    checkpoint = _cursor_checkpoint(
+        goal_id=str(evidence["goal_id"]),
+        decision_id=str(evidence["decision_id"]),
+        observed_at=observed_at,
+        evidence_packet_ref=str(evidence["packet_ref"]),
+        source_rows=cursor_rows,
+    )
+    packet: dict[str, Any] = {
+        "schema_version": DECISION_CONTEXT_ASSEMBLY_SCHEMA_VERSION,
+        "goal_id": evidence["goal_id"],
+        "decision_id": evidence["decision_id"],
+        "observed_at": evidence["observed_at"],
+        "visibility": "public_safe",
+        "source_manifest": manifest,
+        "source_scan_receipts": source_scan_receipts,
+        "context_retrieval_receipt": retrieval_receipt,
+        "evidence_packet": evidence,
+        "cursor_checkpoint": checkpoint,
+        "provider_fail_open": True,
+        "raw_context_captured": False,
+        "raw_provider_payload_captured": False,
+        "private_locators_captured": False,
+        "private_cursors_captured": False,
+        "external_writes_performed": False,
+    }
+    packet["assembly_ref"] = _packet_ref("decision-context-assembly", packet)
+    return DecisionContextAssembly(
+        packet=packet,
+        proposed_cursors=proposed_cursors,
+    )

--- a/loopx/capabilities/decision_context/sources.py
+++ b/loopx/capabilities/decision_context/sources.py
@@ -83,6 +83,33 @@ def _packet_ref(prefix: str, packet: dict[str, object]) -> str:
     return _opaque_ref(prefix, payload)
 
 
+def build_decision_source_item_refs(
+    *,
+    provider_id: str,
+    source_id: str,
+    item: DecisionSourceItem,
+) -> dict[str, str]:
+    """Build stable public-safe refs for one transient authority item."""
+
+    provider_id = _token(provider_id, field_name="provider_id")
+    source_id = _token(source_id, field_name="source_id")
+    return {
+        "source_ref": _opaque_ref(
+            "source-change",
+            provider_id,
+            source_id,
+            item.resource_ref,
+        ),
+        "source_revision": _opaque_ref(
+            "source-revision",
+            provider_id,
+            source_id,
+            item.resource_ref,
+            item.revision,
+        ),
+    }
+
+
 @dataclass(frozen=True)
 class DecisionSourceSpec:
     """Private provider configuration with a public-safe manifest projection."""
@@ -263,21 +290,15 @@ class DecisionSourceScan:
             item_observed_at = _timestamp(
                 item.observed_at, field_name="item.observed_at"
             )
+            refs = build_decision_source_item_refs(
+                provider_id=provider_id,
+                source_id=source_id,
+                item=item,
+            )
             changes.append(
                 {
-                    "change_ref": _opaque_ref(
-                        "source-change",
-                        provider_id,
-                        source_id,
-                        item.resource_ref,
-                    ),
-                    "revision_ref": _opaque_ref(
-                        "source-revision",
-                        provider_id,
-                        source_id,
-                        item.resource_ref,
-                        item.revision,
-                    ),
+                    "change_ref": refs["source_ref"],
+                    "revision_ref": refs["source_revision"],
                     "observed_at": item_observed_at,
                     "exact_read_verified": (
                         item.resource_ref,

--- a/tests/capabilities/test_decision_context_assembler.py
+++ b/tests/capabilities/test_decision_context_assembler.py
@@ -147,6 +147,21 @@ class InvalidSourceProvider(SourceProvider):
         )
 
 
+class InvalidScanTypeProvider(SourceProvider):
+    def scan(self, **kwargs: Any) -> Any:
+        return {"status": "completed", "private": "provider payload"}
+
+
+class InvalidExactReadTypeProvider(SourceProvider):
+    def exact_read(self, **kwargs: Any) -> Any:
+        return {"verified": True, "private": "provider payload"}
+
+
+class InvalidRecallTypeProvider(RecallProvider):
+    def retrieve(self, **kwargs: Any) -> Any:
+        return {"status": "completed", "private": "provider payload"}
+
+
 def accepted_rebase(collection: Any) -> DecisionEvidenceRecords:
     authority = collection.authority[0]
     recall = collection.recall[0]
@@ -325,6 +340,56 @@ def test_invalid_source_provider_contract_fails_open() -> None:
     )
     assert packet["cursor_checkpoint"]["sources"][0]["disposition"] == "preserve"
     assert assembly.proposed_cursors == {}
+
+
+@pytest.mark.parametrize(
+    ("source_provider", "expected_reason"),
+    [
+        (InvalidScanTypeProvider(), "provider_contract_invalid"),
+        (InvalidExactReadTypeProvider(), None),
+    ],
+)
+def test_invalid_source_provider_return_type_fails_open(
+    source_provider: SourceProvider,
+    expected_reason: str | None,
+) -> None:
+    assembly = assemble_decision_evidence(
+        goal_id="goal:decision-advisor",
+        decision_id="decision:priority",
+        observed_at=OBSERVED_AT,
+        before=BEFORE,
+        sources=[authority_source()],
+        source_providers={"source-provider": source_provider},
+        cursors={"source:owner": "private-cursor-before"},
+        rebase=lambda _: DecisionEvidenceRecords(),
+    )
+
+    packet = assembly.public_packet()
+    receipt = packet["source_scan_receipts"][0]
+    row = packet["cursor_checkpoint"]["sources"][0]
+    assert receipt["reason_code"] == expected_reason
+    assert row["disposition"] == "preserve"
+    assert assembly.proposed_cursors == {}
+    assert "provider payload" not in json.dumps(packet, sort_keys=True)
+
+
+def test_invalid_recall_provider_return_type_fails_open() -> None:
+    assembly = assemble_decision_evidence(
+        goal_id="goal:decision-advisor",
+        decision_id="decision:priority",
+        observed_at=OBSERVED_AT,
+        before=BEFORE,
+        sources=[authority_source()],
+        source_providers={"source-provider": SourceProvider(status="no_change")},
+        cursors={},
+        context_provider=InvalidRecallTypeProvider(),
+        rebase=lambda _: DecisionEvidenceRecords(),
+    )
+
+    receipt = assembly.public_packet()["context_retrieval_receipt"]
+    assert receipt["status"] == "unavailable"
+    assert receipt["reason_code"] == "provider_contract_invalid"
+    assert "provider payload" not in json.dumps(receipt, sort_keys=True)
 
 
 def test_exact_read_failure_does_not_advance_cursor() -> None:

--- a/tests/capabilities/test_decision_context_assembler.py
+++ b/tests/capabilities/test_decision_context_assembler.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from loopx.capabilities.context_providers import (
+    ContextProviderItem,
+    ContextProviderRetrieval,
+)
+from loopx.capabilities.decision_context import (
+    DecisionEvidenceRecords,
+    DecisionSourceExactRead,
+    DecisionSourceItem,
+    DecisionSourceScan,
+    DecisionSourceSpec,
+    assemble_decision_evidence,
+    build_decision_context_architecture_packet,
+)
+
+OBSERVED_AT = "2026-07-25T17:30:00+00:00"
+BEFORE = "2026-07-25T17:31:00+00:00"
+AUTHORITY_CONTENT = (
+    "Current authority says adoption is still a bounded pilot.\n"
+    "A first-party owner and acceptance receipt remain required.\n"
+    "Protocol breadth does not replace a verified outcome."
+)
+
+
+def authority_source(
+    *,
+    source_id: str = "source:owner",
+    provider_id: str = "source-provider",
+    exact_read_policy: str = "material_change",
+) -> DecisionSourceSpec:
+    return DecisionSourceSpec(
+        source_id=source_id,
+        provider_id=provider_id,
+        source_kind="person",
+        priority="p0",
+        evidence_level="s2",
+        objectives=("adoption",),
+        scan_mode="incremental",
+        exact_read_policy=exact_read_policy,
+        freshness_seconds=3600,
+        private_locator="private-owner-locator",
+        max_changes=3,
+    )
+
+
+class SourceProvider:
+    provider_id = "source-provider"
+
+    def __init__(
+        self,
+        *,
+        status: str = "completed",
+        fail_scan: bool = False,
+        fail_read: bool = False,
+    ) -> None:
+        self.status = status
+        self.fail_scan = fail_scan
+        self.fail_read = fail_read
+
+    def scan(self, **kwargs: Any) -> DecisionSourceScan:
+        if self.fail_scan:
+            raise RuntimeError("private scan failure detail")
+        source = kwargs["source"]
+        items = (
+            DecisionSourceItem(
+                resource_ref="private-resource",
+                revision="private-revision",
+                observed_at=OBSERVED_AT,
+            ),
+        )
+        if self.status != "completed":
+            items = ()
+        return DecisionSourceScan(
+            provider_id=self.provider_id,
+            source_id=source.source_id,
+            status=self.status,
+            observed_at=OBSERVED_AT,
+            requested_limit=source.max_changes,
+            cursor_before="private-cursor-before",
+            cursor_after="private-cursor-after",
+            items=items,
+        )
+
+    def exact_read(self, **kwargs: Any) -> DecisionSourceExactRead:
+        if self.fail_read:
+            raise RuntimeError("private exact-read failure detail")
+        item = kwargs["item"]
+        return DecisionSourceExactRead(
+            resource_ref=item.resource_ref,
+            revision=item.revision,
+            observed_at=OBSERVED_AT,
+            content=AUTHORITY_CONTENT,
+        )
+
+
+class RecallProvider:
+    provider_id = "recall-provider"
+
+    def __init__(self, *, content: str = AUTHORITY_CONTENT, fail: bool = False) -> None:
+        self.content = content
+        self.fail = fail
+
+    def retrieve(self, **kwargs: Any) -> ContextProviderRetrieval:
+        if self.fail:
+            raise RuntimeError("private recall failure detail")
+        return ContextProviderRetrieval(
+            provider=self.provider_id,
+            namespace=kwargs["namespace"],
+            status="completed",
+            query_summary=kwargs["query_summary"],
+            observed_at=kwargs["observed_at"],
+            search_performed=True,
+            read_performed=True,
+            items=(
+                ContextProviderItem(
+                    resource_ref="private-memory-resource",
+                    summary="A prior decision claim.",
+                    content=self.content,
+                    score=0.8,
+                ),
+            ),
+            requested_limit=kwargs["max_results"],
+        )
+
+    def sync(self, **kwargs: Any) -> Any:
+        raise AssertionError("assembler must not sync advisory memory")
+
+
+class InvalidSourceProvider(SourceProvider):
+    def scan(self, **kwargs: Any) -> DecisionSourceScan:
+        scan = super().scan(**kwargs)
+        return DecisionSourceScan(
+            provider_id="unexpected-provider",
+            source_id=scan.source_id,
+            status=scan.status,
+            observed_at=scan.observed_at,
+            requested_limit=scan.requested_limit,
+            cursor_before=scan.cursor_before,
+            cursor_after=scan.cursor_after,
+            items=scan.items,
+        )
+
+
+def accepted_rebase(collection: Any) -> DecisionEvidenceRecords:
+    authority = collection.authority[0]
+    recall = collection.recall[0]
+    return DecisionEvidenceRecords(
+        changed_facts=(
+            {
+                "fact_id": "fact:pilot-stage",
+                "summary": "Current authority keeps the adoption stage at pilot.",
+                "source_ref": authority.source_ref,
+                "source_revision": authority.source_revision,
+                "observed_at": OBSERVED_AT,
+                "freshness": "current",
+                "authority": "first_party",
+            },
+        ),
+        recalled_claims=(
+            {
+                "claim_id": "claim:prior-priority",
+                "summary": "The prior decision also required an outcome receipt.",
+                "provider_ref": recall.provider_ref,
+                "source_ref": authority.source_ref,
+                "source_revision": authority.source_revision,
+                "observed_at": OBSERVED_AT,
+                "exact_read_verified": False,
+                "confidence": 0.8,
+            },
+        ),
+    )
+
+
+def test_assembler_rebases_authority_recall_and_cursor_without_raw_capture() -> None:
+    assembly = assemble_decision_evidence(
+        goal_id="goal:decision-advisor",
+        decision_id="decision:priority",
+        observed_at=OBSERVED_AT,
+        before=BEFORE,
+        sources=[authority_source()],
+        source_providers={"source-provider": SourceProvider()},
+        cursors={"source:owner": "private-cursor-before"},
+        context_provider=RecallProvider(),
+        rebase=accepted_rebase,
+    )
+
+    packet = assembly.public_packet()
+    serialized = json.dumps(packet, sort_keys=True)
+
+    assert packet["schema_version"] == "decision_context_assembly_v0"
+    assert (
+        packet["evidence_packet"]["recalled_claims"][0]["exact_read_verified"] is True
+    )
+    assert packet["cursor_checkpoint"]["sources"][0]["disposition"] == (
+        "ready_after_writeback"
+    )
+    assert (
+        packet["cursor_checkpoint"]["apply_requires_validated_decision_writeback"]
+        is True
+    )
+    assert packet["cursor_checkpoint"]["applied"] is False
+    assert assembly.proposed_cursors == {"source:owner": "private-cursor-after"}
+    for private_value in (
+        "private-owner-locator",
+        "private-resource",
+        "private-revision",
+        "private-cursor-before",
+        "private-cursor-after",
+        "private-memory-resource",
+        AUTHORITY_CONTENT,
+    ):
+        assert private_value not in serialized
+
+
+def test_assembler_rejects_recalled_claim_that_does_not_match_authority() -> None:
+    with pytest.raises(ValueError, match="reject stale or conflicting recall"):
+        assemble_decision_evidence(
+            goal_id="goal:decision-advisor",
+            decision_id="decision:priority",
+            observed_at=OBSERVED_AT,
+            before=BEFORE,
+            sources=[authority_source()],
+            source_providers={"source-provider": SourceProvider()},
+            cursors={},
+            context_provider=RecallProvider(
+                content="A stale memory claims the work is already adopted."
+            ),
+            rebase=accepted_rebase,
+        )
+
+
+def test_assembler_rejects_changed_fact_without_exact_authority_revision() -> None:
+    def fabricated_rebase(_: Any) -> DecisionEvidenceRecords:
+        return DecisionEvidenceRecords(
+            changed_facts=(
+                {
+                    "fact_id": "fact:fabricated",
+                    "summary": "This fact has no exact authority revision.",
+                    "source_ref": "source-change-fabricated",
+                    "source_revision": "source-revision-fabricated",
+                    "observed_at": OBSERVED_AT,
+                    "freshness": "current",
+                    "authority": "first_party",
+                },
+            )
+        )
+
+    with pytest.raises(ValueError, match="exact-read authority revision"):
+        assemble_decision_evidence(
+            goal_id="goal:decision-advisor",
+            decision_id="decision:priority",
+            observed_at=OBSERVED_AT,
+            before=BEFORE,
+            sources=[authority_source()],
+            source_providers={"source-provider": SourceProvider()},
+            cursors={},
+            rebase=fabricated_rebase,
+        )
+
+
+def test_changed_item_must_be_dispositioned_before_cursor_can_advance() -> None:
+    assembly = assemble_decision_evidence(
+        goal_id="goal:decision-advisor",
+        decision_id="decision:priority",
+        observed_at=OBSERVED_AT,
+        before=BEFORE,
+        sources=[authority_source()],
+        source_providers={"source-provider": SourceProvider()},
+        cursors={"source:owner": "private-cursor-before"},
+        rebase=lambda _: DecisionEvidenceRecords(),
+    )
+
+    row = assembly.public_packet()["cursor_checkpoint"]["sources"][0]
+    assert row["disposition"] == "preserve"
+    assert row["reason_code"] == "rebase_incomplete"
+    assert assembly.proposed_cursors == {}
+
+
+def test_source_failure_fails_open_and_preserves_cursor() -> None:
+    assembly = assemble_decision_evidence(
+        goal_id="goal:decision-advisor",
+        decision_id="decision:priority",
+        observed_at=OBSERVED_AT,
+        before=BEFORE,
+        sources=[authority_source()],
+        source_providers={"source-provider": SourceProvider(fail_scan=True)},
+        cursors={"source:owner": "private-cursor-before"},
+        context_provider=RecallProvider(fail=True),
+        rebase=lambda _: DecisionEvidenceRecords(),
+    )
+
+    packet = assembly.public_packet()
+    serialized = json.dumps(packet, sort_keys=True)
+
+    assert packet["source_scan_receipts"][0]["status"] == "unavailable"
+    assert packet["context_retrieval_receipt"]["status"] == "unavailable"
+    assert packet["cursor_checkpoint"]["sources"][0]["disposition"] == "preserve"
+    assert assembly.proposed_cursors == {}
+    assert "private scan failure detail" not in serialized
+    assert "private recall failure detail" not in serialized
+
+
+def test_invalid_source_provider_contract_fails_open() -> None:
+    assembly = assemble_decision_evidence(
+        goal_id="goal:decision-advisor",
+        decision_id="decision:priority",
+        observed_at=OBSERVED_AT,
+        before=BEFORE,
+        sources=[authority_source()],
+        source_providers={"source-provider": InvalidSourceProvider()},
+        cursors={"source:owner": "private-cursor-before"},
+        rebase=lambda _: DecisionEvidenceRecords(),
+    )
+
+    packet = assembly.public_packet()
+    assert packet["source_scan_receipts"][0]["status"] == "unavailable"
+    assert packet["source_scan_receipts"][0]["reason_code"] == (
+        "provider_contract_invalid"
+    )
+    assert packet["cursor_checkpoint"]["sources"][0]["disposition"] == "preserve"
+    assert assembly.proposed_cursors == {}
+
+
+def test_exact_read_failure_does_not_advance_cursor() -> None:
+    assembly = assemble_decision_evidence(
+        goal_id="goal:decision-advisor",
+        decision_id="decision:priority",
+        observed_at=OBSERVED_AT,
+        before=BEFORE,
+        sources=[authority_source()],
+        source_providers={"source-provider": SourceProvider(fail_read=True)},
+        cursors={"source:owner": "private-cursor-before"},
+        rebase=lambda collection: DecisionEvidenceRecords(
+            stale_or_rejected_claims=(
+                {
+                    "claim_id": "claim:unread-authority",
+                    "summary": "The changed authority item could not be read exactly.",
+                    "observed_at": OBSERVED_AT,
+                    "reason_code": "exact_read_failed",
+                },
+            )
+        ),
+    )
+
+    packet = assembly.public_packet()
+    assert packet["source_scan_receipts"][0]["changed_count"] == 1
+    assert packet["source_scan_receipts"][0]["exact_read_count"] == 0
+    assert packet["cursor_checkpoint"]["sources"][0]["disposition"] == "preserve"
+    assert assembly.proposed_cursors == {}
+
+
+def test_no_change_scan_can_checkpoint_after_validated_writeback() -> None:
+    assembly = assemble_decision_evidence(
+        goal_id="goal:decision-advisor",
+        decision_id="decision:priority",
+        observed_at=OBSERVED_AT,
+        before=BEFORE,
+        sources=[authority_source()],
+        source_providers={"source-provider": SourceProvider(status="no_change")},
+        cursors={"source:owner": "private-cursor-before"},
+        rebase=lambda _: DecisionEvidenceRecords(),
+    )
+
+    packet = assembly.public_packet()
+    assert packet["source_scan_receipts"][0]["status"] == "no_change"
+    assert packet["cursor_checkpoint"]["sources"][0]["disposition"] == (
+        "ready_after_writeback"
+    )
+    assert assembly.proposed_cursors == {"source:owner": "private-cursor-after"}
+
+
+def test_architecture_projects_assembler_and_checkpoint_stage() -> None:
+    packet = build_decision_context_architecture_packet()
+
+    assert packet["assembly_schemas"] == [
+        "decision_context_assembly_v0",
+        "decision_cursor_checkpoint_v0",
+    ]
+    assert (
+        "incremental_cursors_advance_only_after_rebase_and_writeback"
+        in packet["invariants"]
+    )
+    assert packet["next_stage"] == ("default_off_provider_adapter_then_private_dogfood")


### PR DESCRIPTION
## Summary
- add a deterministic Decision Context evidence assembler over authority source scans and optional advisory recall
- require changed facts and accepted recall to resolve to exact-read authority revisions
- gate incremental cursor proposals on explicit rebase disposition and validated downstream writeback
- fail open on unavailable or invalid source providers without serializing raw content, locators, cursors, or provider errors
- project the assembler/checkpoint schemas and advance the capability stage to the default-off adapter + private dogfood slice

## Validation
- `ruff format --check` and `ruff check` on changed capability/tests
- `mypy --strict --follow-imports=skip loopx/capabilities/decision_context/assembler.py`
- `pytest -q`: 1244 passed, 2 skipped
- `loopx canary premerge --from-git-diff --tier standard`: passed (compile, maintainability, evidence lifecycle, artifact path boundary)
- staged marker scan: no credentials, internal URLs, local paths, or runtime/private-state files

## Review focus
- authority/revision verification is intentionally conservative: recall is advisory and only exact-read-matched claims may be accepted
- proposed raw cursors remain private and cannot be applied by this capability; the next slice must bind them to validated decision/outcome writeback
- no source-specific adapter or external write path is introduced here

## Excluded
- private decision-advisor state and source locators
- material migration/reranking work
- Core event projection, which remains a successor concern rather than being disguised as an operator gate