### PR TITLE
Project SkillsBench active worker phase

### DIFF
--- a/scripts/skillsbench_reverse_tunnel_supervisor.py
+++ b/scripts/skillsbench_reverse_tunnel_supervisor.py
@@ -36,10 +36,14 @@ from loopx.benchmark_core.remote_closeout import (  # noqa: E402
     build_remote_benchmark_closeout_contract,
     closeout_remote_benchmark_batch,
 )
+from loopx.benchmark_core.lifecycle import (  # noqa: E402
+    compact_benchmark_live_worker_phase,
+)
 
 
 SCHEMA_VERSION = "skillsbench_reverse_tunnel_supervisor_v0"
 PUBLIC_LIVENESS_SCHEMA_VERSION = "skillsbench_supervisor_public_liveness_v0"
+ACTIVE_PHASE_SCHEMA_VERSION = "skillsbench_supervisor_active_phase_v0"
 PUBLIC_LIVENESS_INTERVAL_SEC = 30.0
 DEFAULT_REMOTE_FORWARD = "127.0.0.1:18180:127.0.0.1:18180"
 DEFAULT_TEST_HOST = "chatgpt.com"
@@ -1041,6 +1045,65 @@ def _incremental_public_artifact_sync_contract(
     }
 
 
+def _active_phase_public_contract(args: argparse.Namespace) -> dict[str, Any]:
+    contract: dict[str, Any] = {
+        "schema_version": ACTIVE_PHASE_SCHEMA_VERSION,
+        "state": "not_observed",
+        "receipt_count": 0,
+        "public_artifact_read": False,
+        "raw_artifacts_read": False,
+        "raw_task_text_read": False,
+        "raw_logs_read": False,
+        "raw_trajectory_read": False,
+        "raw_verifier_output_read": False,
+        "local_paths_recorded": False,
+    }
+    if not args.local_public_artifact_dir:
+        return contract
+
+    root = Path(args.local_public_artifact_dir).expanduser()
+    if not root.is_dir() or root.is_symlink():
+        return contract
+
+    selected_phase: dict[str, Any] = {}
+    selected_sequence = -1
+    receipt_count = 0
+    for path in sorted(root.rglob("runner_prerequisites.public.json")):
+        if path.is_symlink() or not path.is_file():
+            continue
+        try:
+            if path.stat().st_size > int(args.public_artifact_max_bytes):
+                continue
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, Mapping):
+            continue
+        phase = compact_benchmark_live_worker_phase(
+            payload.get("benchmark_live_worker_phase")
+        )
+        if not phase:
+            continue
+        receipt_count += 1
+        sequence = payload.get("benchflow_lifecycle_receipt_sequence")
+        if not isinstance(sequence, int) or isinstance(sequence, bool) or sequence < 0:
+            sequence = 0
+        if sequence >= selected_sequence:
+            selected_phase = phase
+            selected_sequence = sequence
+
+    contract["receipt_count"] = receipt_count
+    if not selected_phase:
+        return contract
+    contract.update(
+        state="observed",
+        receipt_sequence=selected_sequence,
+        benchmark_live_worker_phase=selected_phase,
+        public_artifact_read=True,
+    )
+    return contract
+
+
 def _record_incremental_public_artifact_sync(
     contract: dict[str, Any],
     result: Mapping[str, Any],
@@ -1358,6 +1421,7 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     def checkpoint(state: str, *, terminal: bool = False) -> None:
         nonlocal public_heartbeat_count
         public_heartbeat_count += 1
+        payload["active_phase"] = _active_phase_public_contract(args)
         _write_public_checkpoint(
             args.public_output_path,
             payload,

--- a/tests/test_skillsbench_reverse_tunnel_supervisor.py
+++ b/tests/test_skillsbench_reverse_tunnel_supervisor.py
@@ -114,6 +114,81 @@ def test_supervisor_writes_starting_periodic_and_terminal_public_liveness(
     assert persisted["public_liveness"]["raw_trajectory_recorded"] is False
     assert persisted["public_liveness"]["raw_verifier_output_recorded"] is False
     assert persisted["public_liveness"]["local_paths_recorded"] is False
+    assert persisted["active_phase"] == {
+        "schema_version": "skillsbench_supervisor_active_phase_v0",
+        "state": "not_observed",
+        "receipt_count": 0,
+        "public_artifact_read": False,
+        "raw_artifacts_read": False,
+        "raw_task_text_read": False,
+        "raw_logs_read": False,
+        "raw_trajectory_read": False,
+        "raw_verifier_output_read": False,
+        "local_paths_recorded": False,
+    }
+
+
+def test_supervisor_projects_existing_public_live_worker_phase(
+    tmp_path: Path,
+) -> None:
+    supervisor = _load_supervisor_module()
+    public_dir = tmp_path / "public"
+    receipt_dir = public_dir / "opaque-job"
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / "runner_prerequisites.public.json").write_text(
+        json.dumps(
+            {
+                "benchflow_lifecycle_receipt_sequence": 7,
+                "benchmark_live_worker_phase": {
+                    "schema_version": "benchmark_live_worker_phase_v0",
+                    "current_phase": "worker_running",
+                    "next_required_phase": "agent_active",
+                    "phase_ready": {
+                        "runtime_preparing": True,
+                        "worker_prepared": True,
+                        "worker_running": True,
+                        "agent_active": False,
+                    },
+                    "worker_live": True,
+                    "agent_active_observed": False,
+                    "terminal": False,
+                    "terminal_disposition": "open",
+                    "public_evidence_only": True,
+                    "private_detail": "PRIVATE_DETAIL_MUST_NOT_PROJECT",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    args = supervisor.parse_args(
+        [
+            "--ssh-destination",
+            "runner.example",
+            "--remote-public-artifact-root",
+            "/opaque/public-jobs",
+            "--remote-public-artifact-glob",
+            "*/runner_prerequisites.public.json",
+            "--local-public-artifact-dir",
+            str(public_dir),
+        ]
+    )
+
+    projected = supervisor._active_phase_public_contract(args)
+
+    assert projected["state"] == "observed"
+    assert projected["receipt_count"] == 1
+    assert projected["receipt_sequence"] == 7
+    assert projected["public_artifact_read"] is True
+    assert projected["benchmark_live_worker_phase"]["current_phase"] == (
+        "worker_running"
+    )
+    assert projected["benchmark_live_worker_phase"]["worker_live"] is True
+    assert projected["raw_artifacts_read"] is False
+    assert projected["local_paths_recorded"] is False
+    serialized = json.dumps(projected, sort_keys=True)
+    assert "PRIVATE_DETAIL_MUST_NOT_PROJECT" not in serialized
+    assert str(tmp_path) not in serialized
 
 
 def test_supervisor_finalizes_public_liveness_on_early_launch_failure(


### PR DESCRIPTION
## Summary

- project the existing public `benchmark_live_worker_phase_v0` receipt into SkillsBench supervisor checkpoints
- keep missing or invalid evidence explicit as `not_observed`
- preserve the public/private boundary by compacting only public receipt fields and recording no paths

## Validation

- `uv run --extra test pytest -q tests/test_skillsbench_reverse_tunnel_supervisor.py`
- `uv run --extra test ruff check scripts/skillsbench_reverse_tunnel_supervisor.py tests/test_skillsbench_reverse_tunnel_supervisor.py`
- `python3 -m py_compile scripts/skillsbench_reverse_tunnel_supervisor.py tests/test_skillsbench_reverse_tunnel_supervisor.py`
- `uv run --extra test python examples/skillsbench-reverse-tunnel-supervisor-smoke.py`
- `loopx check --scan-path scripts/skillsbench_reverse_tunnel_supervisor.py --scan-path tests/test_skillsbench_reverse_tunnel_supervisor.py`
- `loopx canary premerge --from-git-diff` (all selected checks passed; benchmark-sensitive maintainer review remains required)

## Boundaries

- does not launch benchmark jobs
- does not change scoring, task semantics, runner execution, submission behavior, or permission boundaries
- does not read raw task text, logs, trajectories, verifier output, or private artifacts
