### PR TITLE
Project goal-scoped agent task visibility

### DIFF
--- a/docs/state-interaction-model.md
+++ b/docs/state-interaction-model.md
@@ -188,6 +188,13 @@ Capabilities describe observed execution support; they do not grant authority
 or replace user, repository-policy, or production gates. Owner-held authority
 labels such as credentials and production access are excluded from this CLI
 projection.
+The adjacent `task_scope=goal_all_read_claimed_run_global_read_v0`
+contract defines task discovery without turning visibility into authority. A
+peer reads the current goal's ordinary todo backlog, selects only its own
+claimed or an eligible unclaimed candidate, and claims before execution.
+Other-agent claims remain diagnostic. Cross-goal inventory is available only
+through an explicit read-only global-manager command and cannot enter the
+goal-local execution queue.
 Legacy Markdown parsing is even lower authority: it is a deterministic lint for
 unprojected prose in `Next Action`, not a source of gate truth. The hot path
 should not call an LLM to decide whether the user is gated, because that adds

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -981,6 +981,17 @@ Item fields:
   what it may execute. A current-agent claimed todo may be selected even when
   the active state's global `Next Action` names another peer's lane; that is not
   a state projection mismatch.
+- Agent-scoped quota payloads also expose the versioned `task_scope` enum
+  `goal_all_read_claimed_run_global_read_v0`. It means the peer may
+  read all ordinary todos in the current goal, may consider its own claimed or
+  an eligible unclaimed candidate, must claim before execution, and may execute
+  only its claimed eligible todo. Other-agent claims are diagnostic only.
+  Cross-goal reads stay outside goal-local routing and require an explicit
+  read-only global-manager inventory such as `loopx global-summary`; they never
+  grant cross-goal execution. Existing goal, agent, and cold-path command
+  fields supply the binding parameters without duplicating them. TurnEnvelope
+  retains this compact enum so the model sees the same boundary as the full
+  quota decision.
 - `dependency_blockers`: optional compact summary of unfinished user todos from
   other current attention-queue goals. This lets dashboards and heartbeat
   dispatchers show sibling/project dependency gates separately from the current

--- a/loopx/control_plane/agents/agent_scope.py
+++ b/loopx/control_plane/agents/agent_scope.py
@@ -86,12 +86,26 @@ _ACTION_SCOPE_STOPWORDS = {
     "with",
 }
 
+AGENT_TASK_SCOPE = "goal_all_read_claimed_run_global_read_v0"
+
 
 def _agent_identity_has_scoped_lane(agent_identity: dict[str, Any] | None) -> bool:
     return bool(
         isinstance(agent_identity, dict)
         and normalize_todo_claimed_by(agent_identity.get("agent_id"))
     )
+
+
+def _attach_agent_identity_contracts(
+    *,
+    payload: dict[str, Any],
+    agent_identity: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if not agent_identity:
+        return payload
+    payload["agent_identity"] = agent_identity
+    payload["task_scope"] = AGENT_TASK_SCOPE
+    return payload
 
 
 def _todo_task_class(item: dict[str, Any]) -> str:

--- a/loopx/control_plane/quota/turn_envelope.py
+++ b/loopx/control_plane/quota/turn_envelope.py
@@ -532,6 +532,9 @@ def _contract_capsule(
         )
         if compact:
             capsule[source_key] = compact
+    task_scope = _text(payload.get("task_scope"), limit=80)
+    if task_scope:
+        capsule["task_scope"] = task_scope
 
     work_lane = _mapping(payload.get("work_lane_contract"))
     work_lane_compact = _mapping(capsule.get("work_lane_contract"))

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -14,6 +14,7 @@ from .control_plane.agents.agent_scope import (
     _agent_scope_frontier_action,
     _agent_scope_no_candidate_frontier,
     _agent_scoped_user_todo_override,
+    _attach_agent_identity_contracts,
     _scoped_user_gate_fallback,
 )
 from .control_plane.agents.agent_lane_recommendation import (
@@ -2155,8 +2156,10 @@ def build_quota_should_run(
                 payload[key] = value
         if replan_scope.get("required"):
             payload["autonomous_replan_scope"] = replan_scope
-        if agent_identity:
-            payload["agent_identity"] = agent_identity
+        payload = _attach_agent_identity_contracts(
+            payload=payload,
+            agent_identity=agent_identity,
+        )
         if agent_lane_next_action:
             payload["agent_lane_next_action"] = agent_lane_next_action
         selected_todo_projection = _selected_todo_projection(

--- a/tests/control_plane/test_agent_task_visibility.py
+++ b/tests/control_plane/test_agent_task_visibility.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any
+
+from loopx.control_plane.quota.turn_envelope import build_turn_envelope
+from loopx.control_plane.testing.quota_fixtures import (
+    quota_status_payload,
+    quota_todo_item,
+    quota_todo_summary,
+)
+from loopx.quota import build_quota_should_run
+
+
+GOAL_ID = "agent-task-visibility-fixture"
+AGENT_ID = "codex-current-peer"
+OTHER_AGENT_ID = "codex-other-peer"
+
+
+def _decision() -> dict[str, Any]:
+    items = [
+        quota_todo_item(
+            todo_id="todo_current",
+            index=1,
+            title="Advance current peer work.",
+            claimed_by=AGENT_ID,
+            required_capabilities=["shell"],
+        ),
+        quota_todo_item(
+            todo_id="todo_unclaimed",
+            index=2,
+            title="Advance unclaimed work.",
+            required_capabilities=["shell"],
+        ),
+        quota_todo_item(
+            todo_id="todo_other",
+            index=3,
+            title="Advance other peer work.",
+            claimed_by=OTHER_AGENT_ID,
+            required_capabilities=["shell"],
+        ),
+    ]
+    status = quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        recommended_action="Advance the current goal.",
+        agent_todos=quota_todo_summary(items),
+        coordination={
+            "agent_model": "peer_v1",
+            "registered_agents": [AGENT_ID, OTHER_AGENT_ID],
+        },
+    )
+    decision: dict[str, Any] = build_quota_should_run(
+        status,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+    return decision
+
+
+def test_quota_projects_goal_scoped_read_and_execution_boundary() -> None:
+    decision = _decision()
+
+    assert (
+        decision["task_scope"]
+        == "goal_all_read_claimed_run_global_read_v0"
+    )
+    assert [
+        item["todo_id"]
+        for item in decision["agent_todo_summary"]["executable_backlog_items"]
+    ] == ["todo_current", "todo_unclaimed"]
+    assert [
+        item["todo_id"]
+        for item in decision["agent_todo_summary"]["claimed_by_others_items"]
+    ] == ["todo_other"]
+    assert decision["selected_todo"]["todo_id"] == "todo_current"
+
+
+def test_turn_envelope_retains_agent_task_visibility_contract() -> None:
+    decision = _decision()
+
+    envelope = build_turn_envelope(decision)
+
+    assert (
+        envelope["contract_capsule"]["task_scope"]
+        == decision["task_scope"]
+    )


### PR DESCRIPTION
## Summary

- project a compact versioned `task_scope` on agent-scoped quota decisions
- preserve the same task authority boundary in TurnEnvelope
- document goal-local visibility, claim-before-run, and read-only global inventory semantics

## Validation

- 52 focused pytest cases passed
- `loopx canary premerge --from-git-diff --tier standard`: 18/18 selected checks passed
- CLI output budget and maintainability ratchet passed
- public/private boundary scan passed with 0 findings

## Boundaries

- additive projection only; no todo selection or execution rule changes
- no scoring, benchmark runner, permission, production, or destructive-git changes
- no private state, raw benchmark evidence, credentials, local paths, or generated logs