### PR TITLE
Forward SkillsBench runner outer timeout

### DIFF
--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -68,6 +68,8 @@ Optional env:
                                        Optional positive per-prompt timeout for
                                        host-local Codex; unset preserves the
                                        runner default
+  SKILLSBENCH_OUTER_TIMEOUT_SEC         Optional positive runner-wide timeout;
+                                       unset preserves the runner default
   SKILLSBENCH_CLI_GOAL_THREAD_PREWARM  Set to 1 to prewarm the persisted Codex
                                        TUI thread before submitting /goal
   SKILLSBENCH_ALLOW_STAGED_BOOTSTRAP_REPAIR_RUN
@@ -234,6 +236,7 @@ local_codex_split_control="${SKILLSBENCH_LOCAL_CODEX_SPLIT_CONTROL:-0}"
 local_codex_bin="${SKILLSBENCH_LOCAL_CODEX_BIN:-codex}"
 local_codex_sandbox="${SKILLSBENCH_LOCAL_CODEX_SANDBOX:-workspace-write}"
 local_codex_exec_timeout="${SKILLSBENCH_LOCAL_CODEX_EXEC_TIMEOUT_SEC:-}"
+outer_timeout="${SKILLSBENCH_OUTER_TIMEOUT_SEC:-}"
 codex_cli_goal_thread_prewarm="${SKILLSBENCH_CLI_GOAL_THREAD_PREWARM:-0}"
 if [[ "$codex_cli_goal_thread_prewarm" != "0" && "$codex_cli_goal_thread_prewarm" != "1" ]]; then
   echo "SKILLSBENCH_CLI_GOAL_THREAD_PREWARM must be 0 or 1" >&2
@@ -242,6 +245,11 @@ fi
 if [[ -n "$local_codex_exec_timeout" ]] &&
   [[ ! "$local_codex_exec_timeout" =~ ^[1-9][0-9]*$ ]]; then
   echo "SKILLSBENCH_LOCAL_CODEX_EXEC_TIMEOUT_SEC must be a positive integer" >&2
+  exit 2
+fi
+if [[ -n "$outer_timeout" ]] &&
+  [[ ! "$outer_timeout" =~ ^[1-9][0-9]*$ ]]; then
+  echo "SKILLSBENCH_OUTER_TIMEOUT_SEC must be a positive integer" >&2
   exit 2
 fi
 skip_global_ledger_sync="${SKILLSBENCH_SKIP_GLOBAL_LEDGER_SYNC:-0}"
@@ -610,6 +618,11 @@ if [[ -n "$local_codex_exec_timeout" ]]; then
     --local-codex-exec-timeout-sec "$local_codex_exec_timeout"
   )
 fi
+if [[ -n "$outer_timeout" ]]; then
+  extra_runner_args+=(
+    --outer-timeout-sec "$outer_timeout"
+  )
+fi
 if [[ "$codex_cli_goal_thread_prewarm" == "1" ]]; then
   extra_runner_args+=(--codex-cli-goal-thread-prewarm)
 fi
@@ -859,6 +872,7 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'local_codex_sandbox=%s\n' "$local_codex_sandbox"
   printf 'local_codex_exec_timeout_sec=%s\n' \
     "${local_codex_exec_timeout:-runner-default}"
+  printf 'outer_timeout_sec=%s\n' "${outer_timeout:-runner-default}"
   printf 'exact_host_codex_sandbox_preflight=%s\n' \
     "$exact_host_codex_sandbox_preflight"
   printf 'codex_cli_goal_thread_prewarm=%s\n' "$codex_cli_goal_thread_prewarm"
@@ -919,6 +933,8 @@ if [[ "$dry_run" == "true" ]]; then
       printf '%s ' --host-local-acp-codex-exec-preflight-attempts
     [[ -n "$local_codex_exec_timeout" ]] &&
       printf '%s ' --local-codex-exec-timeout-sec
+    [[ -n "$outer_timeout" ]] &&
+      printf '%s ' --outer-timeout-sec
     [[ -n "$remote_command_file_bridge_probe_command" ]] &&
       printf '%s ' --remote-command-file-bridge-probe-command
     [[ -n "$remote_command_file_bridge_solver_command" ]] &&

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -257,6 +257,7 @@ def test_launcher_split_control_is_opt_in_and_redacts_provider_values(
     assert "local_codex_split_control=1" in output
     assert "local_codex_provider=reverse_channel" in output
     assert "local_codex_exec_timeout_sec=runner-default" in output
+    assert "outer_timeout_sec=runner-default" in output
     assert "remote_codex_bin_mode=split_control_client" in output
     assert (
         "exact_host_codex_sandbox_preflight=split_control_not_applicable"
@@ -306,6 +307,29 @@ def test_launcher_wires_explicit_local_codex_exec_timeout(
     assert "--local-codex-exec-timeout-sec" in proc.stdout
 
 
+def test_launcher_wires_explicit_outer_timeout(tmp_path: Path) -> None:
+    env = _base_env(tmp_path)
+    env.update(
+        {
+            "SKILLSBENCH_LOCAL_CODEX_SPLIT_CONTROL": "1",
+            "SKILLSBENCH_OUTER_TIMEOUT_SEC": "21600",
+        }
+    )
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "outer-timeout"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+
+    assert "outer_timeout_sec=21600" in proc.stdout
+    assert "--outer-timeout-sec" in proc.stdout
+
+
 def test_launcher_rejects_invalid_local_codex_exec_timeout(
     tmp_path: Path,
 ) -> None:
@@ -327,6 +351,25 @@ def test_launcher_rejects_invalid_local_codex_exec_timeout(
         "SKILLSBENCH_LOCAL_CODEX_EXEC_TIMEOUT_SEC must be a positive integer"
         in proc.stderr
     )
+    assert "supervisor_command=" not in proc.stdout
+
+
+def test_launcher_rejects_invalid_outer_timeout(tmp_path: Path) -> None:
+    env = _base_env(tmp_path)
+    env["SKILLSBENCH_OUTER_TIMEOUT_SEC"] = "0"
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "outer-timeout"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    assert "SKILLSBENCH_OUTER_TIMEOUT_SEC must be a positive integer" in proc.stderr
     assert "supervisor_command=" not in proc.stdout
 
 


### PR DESCRIPTION
## Summary
- add an explicit `SKILLSBENCH_OUTER_TIMEOUT_SEC` launcher setting
- forward it to the existing runner `--outer-timeout-sec` contract
- keep the current runner default when unset and fail fast on invalid values
- cover default, explicit, and invalid dry-run behavior

## Validation
- `29 passed` in `tests/test_skillsbench_turn_launcher.py`
- Ruff and `bash -n` passed
- `loopx check` passed with 0 errors/warnings and a clean two-file public boundary scan
- standard premerge selected 4/4 catalog canaries; all passed

## Boundary
This changes only benchmark helper timeout plumbing. It does not change runner defaults, scoring, task or verifier semantics, permissions, uploads, submissions, or launch a benchmark job. The benchmark-sensitive canary hold is retained for maintainer review under the standing benchmark-helper self-merge authorization.