### PR TITLE
Add Decision Context profile orchestration

### DIFF
--- a/docs/reference/protocols/decision-context-architecture-v0.md
+++ b/docs/reference/protocols/decision-context-architecture-v0.md
@@ -154,7 +154,7 @@ the private source registry and bounded incremental scan receipts. Reuse
 stale/rejected claims and provider fail-open receipts without capturing raw
 context.
 
-### P1: experimental entry point
+### P1: default-off entry point
 
 Add a default-off goal profile, activation status, catalog, source-provider
 adapters, and a thin CLI that orchestrates source scans, evidence, and proposals
@@ -163,9 +163,22 @@ and credential-free in public state.
 
 The first entry-point slice implements strict private profile loading,
 goal-and-agent activation status, public-safe source manifests, and an explicitly
-configured read-only `local-file` source adapter. It does not yet orchestrate
-source scans into evidence/proposal packets or apply private cursor
-checkpoints. Those remain the acceptance boundary for completing P1.
+configured read-only `local-file` source adapter. That slice intentionally
+stopped before source orchestration and private cursor checkpoints.
+
+The second slice adds `assemble_profile_decision_evidence(...)` as the thin
+host API and `decision-context prepare-evidence` as its read-only CLI preview.
+The profile now resolves enabled source providers, performs bounded scans and
+exact reads, and emits public-safe scan, revision, health, evidence, and cursor
+checkpoint records. The host API accepts a domain rebase callback and returns
+raw cursor proposals only in-process. The CLI intentionally performs no
+semantic rebase: changed-source cursors remain at `preserve`, so merely scanning
+or reading a source can never mark it absorbed. Sources marked `on_demand` are
+excluded from automatic collection and require explicit source selection.
+
+Private cursor commit remains a separate acceptance boundary. It may occur only
+after the evidence/proposal and existing LoopX lifecycle writeback have been
+validated.
 
 ### P1: first dogfood
 

--- a/docs/reference/protocols/decision-context-architecture-v0.zh-CN.md
+++ b/docs/reference/protocols/decision-context-architecture-v0.zh-CN.md
@@ -181,7 +181,7 @@ capability 与 goal 配置承担。
 - 输出 stale/rejected claim 和 provider fail-open receipt；
 - 不采集 raw context。
 
-### P1：实验入口
+### P1：默认关闭入口
 
 - 增加默认关闭、goal-scoped 的 profile/activation status/catalog；
 - 增加 source-provider adapter，提供薄 CLI 编排 source scan、evidence 与 proposal；
@@ -189,9 +189,20 @@ capability 与 goal 配置承担。
 - 不修改 Core todo、gate、quota 或 authority 语义。
 
 首个入口切片已实现严格的私有 profile 加载、goal/agent activation 状态、公开安全的
-source manifest，以及显式配置、只读的 `local-file` source adapter。该切片
-尚不把 source scan 编排为 evidence/proposal packet，也不应用私有 cursor
-checkpoint；这两项仍是 P1 完成前的验收边界。
+source manifest，以及显式配置、只读的 `local-file` source adapter。该切片刻意
+停在 source 编排和私有 cursor checkpoint 之前。
+
+第二个切片增加薄 host API `assemble_profile_decision_evidence(...)`，以及只读的
+CLI 预览 `decision-context prepare-evidence`。profile 会解析已启用的 source
+provider，执行 bounded scan 与 exact read，并输出公开安全的 scan、revision、
+health、evidence 和 cursor checkpoint 记录。host API 通过领域 rebase callback
+消费瞬时正文，原始 cursor proposal 只留在进程内。CLI 则刻意不做语义 rebase：
+只要 changed source 尚未被事实、拒绝项或冲突记录完整解释，cursor 就保持
+`preserve`，避免把“扫描/读过”误记成“已吸收”。`on_demand` source 不进入自动
+扫描，只有显式选择后才会读取。
+
+私有 cursor commit 仍是独立验收边界：只有 evidence/proposal 与既有 LoopX
+lifecycle writeback 验证通过后，才允许显式提交。
 
 ### P1：首个 dogfood
 

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -318,6 +318,26 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
                     "goal mutation, or external action"
                 ),
             },
+            {
+                "command": (
+                    "loopx decision-context prepare-evidence "
+                    "--goal-id <goal-id> --agent-id <agent-id> "
+                    "--profile <private-local-profile> "
+                    "--decision-id <decision-id> "
+                    "[--cursor-state <private-cursor-json>] "
+                    "[--source-id <on-demand-source>] --format json"
+                ),
+                "purpose": (
+                    "Resolve enabled profile providers, run bounded scans and "
+                    "exact reads, and emit a public-safe evidence preparation "
+                    "packet for domain rebase."
+                ),
+                "write_boundary": (
+                    "read-only provider access; changed-source cursors remain "
+                    "preserved until semantic rebase and validated lifecycle "
+                    "writeback"
+                ),
+            },
         ],
         "implemented_protocols": [
             {
@@ -370,11 +390,11 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
             "The capability is default-off and cannot create action authority or mutate Core state.",
             "Private source locators, cursors, raw content, provider payloads, tool output, and credentials stay outside public packets.",
             "DecisionSourceProvider rebases current authority; ContextProvider supplies advisory recall only.",
-            "The built-in local-file adapter is read-only and explicitly configured; domain adapters and cursor writeback remain deferred.",
+            "The built-in local-file adapter and prepare-evidence route are read-only; domain adapters and validated cursor commit remain deferred.",
         ],
         "next_real_step": (
-            "Compose bounded source scans and the evidence assembler behind this "
-            "entry point, then validate an outcome receipt in private dogfood."
+            "Validate explicit cursor commit after lifecycle writeback, then "
+            "produce the first outcome receipt in private dogfood."
         ),
     },
     {

--- a/loopx/capabilities/decision_context/__init__.py
+++ b/loopx/capabilities/decision_context/__init__.py
@@ -49,6 +49,10 @@ from .providers import (
     decision_source_provider_registered,
     register_decision_source_provider,
 )
+from .runtime import (
+    assemble_profile_decision_evidence,
+    load_private_decision_cursors,
+)
 
 __all__ = [
     "DECISION_CONTEXT_ASSEMBLY_SCHEMA_VERSION",
@@ -76,6 +80,7 @@ __all__ = [
     "LOCAL_FILE_SOURCE_ADAPTER",
     "LocalFileDecisionSourceProvider",
     "assemble_decision_evidence",
+    "assemble_profile_decision_evidence",
     "build_decision_context_architecture_packet",
     "build_decision_evidence_packet",
     "build_decision_outcome_receipt",
@@ -85,6 +90,7 @@ __all__ = [
     "build_decision_source_provider",
     "decision_source_provider_registered",
     "load_decision_context_profile",
+    "load_private_decision_cursors",
     "normalize_decision_context_profile",
     "register_decision_source_provider",
     "resolve_decision_context_activation",

--- a/loopx/capabilities/decision_context/architecture.py
+++ b/loopx/capabilities/decision_context/architecture.py
@@ -68,5 +68,5 @@ def build_decision_context_architecture_packet() -> dict[str, object]:
             "proposals_require_existing_authority_confirmation",
             "verified_outcomes_precede_reward_memory_candidates",
         ],
-        "next_stage": "default_off_provider_adapter_then_private_dogfood",
+        "next_stage": "validated_cursor_commit_then_private_dogfood",
     }

--- a/loopx/capabilities/decision_context/cli.py
+++ b/loopx/capabilities/decision_context/cli.py
@@ -5,8 +5,10 @@ from collections.abc import Callable, Collection
 from datetime import datetime, timezone
 from pathlib import Path
 
+from .assembler import DecisionEvidenceRecords
 from .architecture import build_decision_context_architecture_packet
 from .profile import resolve_decision_context_activation
+from .runtime import assemble_profile_decision_evidence
 from .sources import build_decision_source_manifest
 
 PrintPayload = Callable[
@@ -82,6 +84,43 @@ def register_decision_context_commands(
         "--observed-at",
         help="Optional timezone-aware ISO-8601 time for a reproducible manifest.",
     )
+    prepare = commands.add_parser(
+        "prepare-evidence",
+        help=(
+            "Run bounded source scans and exact reads without applying private "
+            "cursor proposals."
+        ),
+    )
+    add_subcommand_format(prepare)
+    prepare.add_argument("--goal-id", required=True)
+    prepare.add_argument("--agent-id", required=True)
+    prepare.add_argument("--profile", required=True)
+    prepare.add_argument("--decision-id", required=True)
+    prepare.add_argument(
+        "--cursor-state",
+        help="Optional private JSON object mapping source ids to opaque cursors.",
+    )
+    prepare.add_argument(
+        "--source-id",
+        action="append",
+        help=(
+            "Explicit enabled source to scan. Repeat to include on-demand "
+            "sources; omit to scan automatic sources only."
+        ),
+    )
+    prepare.add_argument(
+        "--observed-at",
+        help="Optional timezone-aware ISO-8601 assembly time.",
+    )
+    prepare.add_argument(
+        "--before",
+        help="Optional timezone-aware upper bound for source changes.",
+    )
+    prepare.add_argument(
+        "--timeout-seconds",
+        type=float,
+        help="Optional bounded provider timeout override.",
+    )
 
 
 def handle_decision_context_command(
@@ -94,6 +133,37 @@ def handle_decision_context_command(
         return None
     if args.decision_context_command == "architecture":
         payload = build_decision_context_architecture_packet()
+    elif args.decision_context_command == "prepare-evidence":
+        now = datetime.now(timezone.utc).isoformat()
+        observed_at = str(getattr(args, "observed_at", None) or "").strip() or now
+        before = str(getattr(args, "before", None) or "").strip() or observed_at
+        activation, assembly = assemble_profile_decision_evidence(
+            goal_id=args.goal_id,
+            agent_id=args.agent_id,
+            profile_path=Path(args.profile),
+            decision_id=args.decision_id,
+            observed_at=observed_at,
+            before=before,
+            cursor_path=(
+                Path(args.cursor_state)
+                if str(getattr(args, "cursor_state", None) or "").strip()
+                else None
+            ),
+            source_ids=(
+                tuple(args.source_id)
+                if getattr(args, "source_id", None) is not None
+                else None
+            ),
+            rebase=lambda _collection: DecisionEvidenceRecords(),
+            timeout_seconds=getattr(args, "timeout_seconds", None),
+        )
+        payload = activation | {
+            "assembly": assembly.public_packet() if assembly is not None else None,
+            "semantic_rebase_performed": False,
+            "validated_writeback_required": assembly is not None,
+            "cursor_commit_allowed": False,
+            "cursor_state_mutated": False,
+        }
     elif args.decision_context_command in {"inspect-profile", "source-manifest"}:
         profile_value = str(getattr(args, "profile", None) or "").strip()
         status, profile = resolve_decision_context_activation(

--- a/loopx/capabilities/decision_context/runtime.py
+++ b/loopx/capabilities/decision_context/runtime.py
@@ -1,0 +1,190 @@
+"""Thin profile-to-evidence orchestration for Decision Context."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Collection, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from ..context_providers import build_context_provider
+from ..context_providers.base import ContextProvider
+from .assembler import (
+    DecisionContextAssembly,
+    DecisionEvidenceRebaser,
+    assemble_decision_evidence,
+)
+from .profile import (
+    DecisionContextProfile,
+    resolve_decision_context_activation,
+)
+from .providers import build_decision_source_provider
+from .sources import DecisionSourceProvider, DecisionSourceSpec
+
+
+class _UnavailableContextProvider:
+    """Preserve a public fail-open receipt when provider construction fails."""
+
+    provider_id = "context-provider"
+
+    def retrieve(self, **_: Any) -> Any:
+        raise RuntimeError("context provider is unavailable")
+
+    def sync(self, **_: Any) -> Any:
+        raise RuntimeError("context provider is unavailable")
+
+
+def load_private_decision_cursors(
+    path: Path | None,
+    *,
+    profile: DecisionContextProfile,
+) -> dict[str, str]:
+    """Load private cursors without projecting their values into public output."""
+
+    if path is None:
+        return {}
+    try:
+        with path.expanduser().open(encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("decision-context cursor state is unavailable") from exc
+    if not isinstance(payload, Mapping):
+        raise ValueError("decision-context cursor state must be an object")
+
+    source_ids = {source.source_id for source in profile.sources}
+    unexpected = sorted(str(key) for key in payload if str(key) not in source_ids)
+    if unexpected:
+        raise ValueError(
+            "decision-context cursor state contains unknown source ids: "
+            + ", ".join(unexpected)
+        )
+
+    cursors: dict[str, str] = {}
+    for source_id, value in payload.items():
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(
+                "decision-context cursor values must be non-empty strings"
+            )
+        cursor = value.strip()
+        cursors[str(source_id)] = cursor
+    return cursors
+
+
+def _build_source_providers(
+    profile: DecisionContextProfile,
+    *,
+    sources: Sequence[DecisionSourceSpec],
+) -> dict[str, DecisionSourceProvider]:
+    enabled_provider_ids = {source.provider_id for source in sources}
+    providers: dict[str, DecisionSourceProvider] = {}
+    for provider_id, binding in profile.provider_binding_map().items():
+        if provider_id not in enabled_provider_ids:
+            continue
+        try:
+            providers[provider_id] = build_decision_source_provider(binding)
+        except Exception:
+            # The assembler turns an absent provider into a public fail-open receipt.
+            continue
+    return providers
+
+
+def _selected_sources(
+    profile: DecisionContextProfile,
+    *,
+    source_ids: Collection[str] | None,
+) -> tuple[DecisionSourceSpec, ...]:
+    enabled = {source.source_id: source for source in profile.sources if source.enabled}
+    if source_ids is None:
+        return tuple(
+            source
+            for source in profile.sources
+            if source.enabled and source.scan_mode != "on_demand"
+        )
+    selected_ids = {str(source_id).strip() for source_id in source_ids}
+    unavailable = sorted(
+        source_id for source_id in selected_ids if source_id not in enabled
+    )
+    if unavailable:
+        raise ValueError(
+            "requested decision sources are unknown or disabled: "
+            + ", ".join(unavailable)
+        )
+    return tuple(enabled[source_id] for source_id in sorted(selected_ids))
+
+
+def _build_advisory_context_provider(
+    profile: DecisionContextProfile,
+) -> ContextProvider | None:
+    if profile.context_provider is None:
+        return None
+    private_config = profile.context_provider.get("config", {})
+    binding = {
+        "provider": profile.context_provider["provider"],
+        **(dict(private_config) if isinstance(private_config, Mapping) else {}),
+    }
+    try:
+        return build_context_provider(binding)
+    except Exception:
+        return _UnavailableContextProvider()
+
+
+def assemble_profile_decision_evidence(
+    *,
+    goal_id: str,
+    agent_id: str,
+    profile_path: Path | None,
+    decision_id: str,
+    observed_at: str,
+    before: str,
+    rebase: DecisionEvidenceRebaser,
+    cursor_path: Path | None = None,
+    source_ids: Collection[str] | None = None,
+    recall_query: str = "current decision evidence",
+    recall_query_summary: str = "current decision evidence",
+    timeout_seconds: float | None = None,
+) -> tuple[dict[str, Any], DecisionContextAssembly | None]:
+    """Resolve one enabled profile and assemble evidence without applying cursors.
+
+    The caller owns domain reasoning through ``rebase``. Raw exact reads and
+    advisory recall stay in-process, while the returned public packet contains
+    only opaque refs and compact evidence. ``proposed_cursors`` remain private
+    and must not be persisted until the caller validates lifecycle writeback.
+    """
+
+    activation, profile = resolve_decision_context_activation(
+        goal_id=goal_id,
+        agent_id=agent_id,
+        profile_path=profile_path,
+    )
+    if activation["available"] is not True or profile is None:
+        return activation, None
+
+    context_config = profile.context_provider or {}
+    configured_timeout = context_config.get("timeout_seconds", 10.0)
+    effective_timeout = (
+        float(timeout_seconds)
+        if timeout_seconds is not None
+        else float(configured_timeout)
+    )
+    cursors = load_private_decision_cursors(cursor_path, profile=profile)
+    sources = _selected_sources(profile, source_ids=source_ids)
+    assembly = assemble_decision_evidence(
+        goal_id=goal_id,
+        decision_id=decision_id,
+        observed_at=observed_at,
+        before=before,
+        sources=sources,
+        source_providers=_build_source_providers(profile, sources=sources),
+        cursors=cursors,
+        rebase=rebase,
+        context_provider=_build_advisory_context_provider(profile),
+        context_namespace=str(
+            context_config.get("namespace") or "decision-context"
+        ),
+        context_scope_ref=str(context_config.get("scope_ref") or "goal"),
+        recall_query=recall_query,
+        recall_query_summary=recall_query_summary,
+        recall_limit=int(context_config.get("max_results", 5)),
+        timeout_seconds=effective_timeout,
+    )
+    return activation, assembly

--- a/loopx/capabilities/decision_context/runtime.py
+++ b/loopx/capabilities/decision_context/runtime.py
@@ -19,7 +19,7 @@ from .profile import (
     resolve_decision_context_activation,
 )
 from .providers import build_decision_source_provider
-from .sources import DecisionSourceProvider, DecisionSourceSpec
+from .sources import DecisionSourceProvider, DecisionSourceScan, DecisionSourceSpec
 
 
 class _UnavailableContextProvider:
@@ -32,6 +32,36 @@ class _UnavailableContextProvider:
 
     def sync(self, **_: Any) -> Any:
         raise RuntimeError("context provider is unavailable")
+
+
+class _UnavailableDecisionSourceProvider:
+    """Report a configured-but-invalid binding without exposing its config."""
+
+    def __init__(self, provider_id: str) -> None:
+        self.provider_id = provider_id
+
+    def scan(
+        self,
+        *,
+        source: DecisionSourceSpec,
+        after_cursor: str | None,
+        before: str,
+        limit: int,
+        timeout_seconds: float,
+        observed_at: str,
+    ) -> DecisionSourceScan:
+        del after_cursor, before, limit, timeout_seconds
+        return DecisionSourceScan(
+            provider_id=self.provider_id,
+            source_id=source.source_id,
+            status="unavailable",
+            observed_at=observed_at,
+            requested_limit=source.max_changes,
+            reason_code="provider_configuration_failed",
+        )
+
+    def exact_read(self, **_: Any) -> Any:
+        raise RuntimeError("decision source provider is unavailable")
 
 
 def load_private_decision_cursors(
@@ -83,8 +113,7 @@ def _build_source_providers(
         try:
             providers[provider_id] = build_decision_source_provider(binding)
         except Exception:
-            # The assembler turns an absent provider into a public fail-open receipt.
-            continue
+            providers[provider_id] = _UnavailableDecisionSourceProvider(provider_id)
     return providers
 
 
@@ -100,6 +129,8 @@ def _selected_sources(
             for source in profile.sources
             if source.enabled and source.scan_mode != "on_demand"
         )
+    if isinstance(source_ids, (str, bytes)):
+        raise TypeError("source_ids must be a collection of source ids")
     selected_ids = {str(source_id).strip() for source_id in source_ids}
     unavailable = sorted(
         source_id for source_id in selected_ids if source_id not in enabled

--- a/tests/capabilities/test_decision_context_assembler.py
+++ b/tests/capabilities/test_decision_context_assembler.py
@@ -451,4 +451,4 @@ def test_architecture_projects_assembler_and_checkpoint_stage() -> None:
         "incremental_cursors_advance_only_after_rebase_and_writeback"
         in packet["invariants"]
     )
-    assert packet["next_stage"] == ("default_off_provider_adapter_then_private_dogfood")
+    assert packet["next_stage"] == ("validated_cursor_commit_then_private_dogfood")

--- a/tests/capabilities/test_decision_context_runtime.py
+++ b/tests/capabilities/test_decision_context_runtime.py
@@ -198,7 +198,7 @@ def test_profile_runtime_fails_open_when_provider_config_cannot_build(
     assert assembly is not None
     receipt = assembly.public_packet()["source_scan_receipts"][0]
     assert receipt["status"] == "unavailable"
-    assert receipt["reason_code"] == "provider_not_configured"
+    assert receipt["reason_code"] == "provider_configuration_failed"
     assert assembly.proposed_cursors == {}
 
 

--- a/tests/capabilities/test_decision_context_runtime.py
+++ b/tests/capabilities/test_decision_context_runtime.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from loopx.capabilities.decision_context import (
+    DecisionEvidenceRecords,
+    assemble_profile_decision_evidence,
+)
+from loopx.cli import main
+
+OBSERVED_AT = "2100-01-01T00:00:00+00:00"
+BEFORE = "2100-01-01T00:01:00+00:00"
+PRIVATE_CONTENT = "Current authority keeps adoption at a bounded pilot."
+
+
+def write_profile(
+    path: Path,
+    authority_path: Path,
+    *,
+    enabled: bool = True,
+    max_bytes: int = 4096,
+    scan_mode: str = "incremental",
+) -> Path:
+    payload = {
+        "schema_version": "decision_context_profile_v0",
+        "goal_id": "example-decision-goal",
+        "enabled": enabled,
+        "enabled_agents": ["example-agent"],
+        "source_provider_bindings": [
+            {
+                "provider_id": "local-authority",
+                "adapter": "local-file",
+                "config": {"max_bytes": max_bytes},
+            }
+        ],
+        "sources": [
+            {
+                "source_id": "source:authority",
+                "provider_id": "local-authority",
+                "source_kind": "artifact",
+                "priority": "p0",
+                "evidence_level": "s3",
+                "objectives": ["adoption"],
+                "scan_mode": scan_mode,
+                "exact_read_policy": "material_change",
+                "freshness_seconds": 3600,
+                "private_locator": str(authority_path),
+                "max_changes": 4,
+                "enabled": True,
+            }
+        ],
+        "context_provider": None,
+        "automation": {
+            "automatic_capture": False,
+            "fail_open": True,
+        },
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_profile_runtime_builds_providers_and_returns_private_cursor_proposal(
+    tmp_path: Path,
+) -> None:
+    authority = tmp_path / "authority.md"
+    authority.write_text(PRIVATE_CONTENT, encoding="utf-8")
+    profile = write_profile(tmp_path / "profile.json", authority)
+    callback_contents: list[str] = []
+
+    def rebase(collection: Any) -> DecisionEvidenceRecords:
+        current = collection.authority[0]
+        callback_contents.append(current.content)
+        return DecisionEvidenceRecords(
+            changed_facts=(
+                {
+                    "fact_id": "fact:pilot",
+                    "summary": "Current authority keeps adoption at pilot.",
+                    "source_ref": current.source_ref,
+                    "source_revision": current.source_revision,
+                    "observed_at": current.observed_at,
+                    "freshness": "current",
+                    "authority": "first_party",
+                },
+            )
+        )
+
+    activation, assembly = assemble_profile_decision_evidence(
+        goal_id="example-decision-goal",
+        agent_id="example-agent",
+        profile_path=profile,
+        decision_id="decision:adoption",
+        observed_at=OBSERVED_AT,
+        before=BEFORE,
+        rebase=rebase,
+    )
+
+    assert activation["status"] == "available"
+    assert assembly is not None
+    assert callback_contents == [PRIVATE_CONTENT]
+    assert assembly.proposed_cursors["source:authority"].startswith("sha256:")
+    packet = assembly.public_packet()
+    assert packet["evidence_packet"]["changed_facts"][0]["fact_id"] == "fact:pilot"
+    assert packet["cursor_checkpoint"]["sources"][0]["disposition"] == (
+        "ready_after_writeback"
+    )
+    assert PRIVATE_CONTENT not in json.dumps(packet, sort_keys=True)
+    assert str(authority) not in json.dumps(packet, sort_keys=True)
+
+
+def test_prepare_evidence_cli_preserves_private_cursor_until_semantic_rebase(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    authority = tmp_path / "authority.md"
+    authority.write_text(PRIVATE_CONTENT, encoding="utf-8")
+    profile = write_profile(tmp_path / "profile.json", authority)
+    cursors = tmp_path / "cursors.json"
+    cursor_payload = {"source:authority": "sha256:previous"}
+    cursors.write_text(json.dumps(cursor_payload), encoding="utf-8")
+    cursor_before = cursors.read_bytes()
+
+    assert (
+        main(
+            [
+                "--format",
+                "json",
+                "decision-context",
+                "prepare-evidence",
+                "--goal-id",
+                "example-decision-goal",
+                "--agent-id",
+                "example-agent",
+                "--profile",
+                str(profile),
+                "--decision-id",
+                "decision:adoption",
+                "--cursor-state",
+                str(cursors),
+                "--observed-at",
+                OBSERVED_AT,
+                "--before",
+                BEFORE,
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    serialized = json.dumps(payload, sort_keys=True)
+    assembly = payload["assembly"]
+
+    assert payload["status"] == "available"
+    assert payload["semantic_rebase_performed"] is False
+    assert payload["validated_writeback_required"] is True
+    assert payload["cursor_commit_allowed"] is False
+    assert payload["cursor_state_mutated"] is False
+    assert assembly["source_scan_receipts"][0]["exact_read_count"] == 1
+    assert assembly["cursor_checkpoint"]["sources"][0]["disposition"] == "preserve"
+    assert assembly["cursor_checkpoint"]["sources"][0]["reason_code"] == (
+        "rebase_incomplete"
+    )
+    assert cursors.read_bytes() == cursor_before
+    for private_value in (
+        PRIVATE_CONTENT,
+        str(authority),
+        str(profile),
+        str(cursors),
+        "sha256:previous",
+    ):
+        assert private_value not in serialized
+
+
+def test_profile_runtime_fails_open_when_provider_config_cannot_build(
+    tmp_path: Path,
+) -> None:
+    authority = tmp_path / "authority.md"
+    authority.write_text(PRIVATE_CONTENT, encoding="utf-8")
+    profile = write_profile(
+        tmp_path / "profile.json",
+        authority,
+        max_bytes=-1,
+    )
+
+    activation, assembly = assemble_profile_decision_evidence(
+        goal_id="example-decision-goal",
+        agent_id="example-agent",
+        profile_path=profile,
+        decision_id="decision:adoption",
+        observed_at=OBSERVED_AT,
+        before=BEFORE,
+        rebase=lambda _collection: DecisionEvidenceRecords(),
+    )
+
+    assert activation["status"] == "available"
+    assert assembly is not None
+    receipt = assembly.public_packet()["source_scan_receipts"][0]
+    assert receipt["status"] == "unavailable"
+    assert receipt["reason_code"] == "provider_not_configured"
+    assert assembly.proposed_cursors == {}
+
+
+def test_disabled_profile_does_not_touch_authority_provider(tmp_path: Path) -> None:
+    missing_authority = tmp_path / "missing.md"
+    profile = write_profile(
+        tmp_path / "profile.json",
+        missing_authority,
+        enabled=False,
+    )
+
+    activation, assembly = assemble_profile_decision_evidence(
+        goal_id="example-decision-goal",
+        agent_id="example-agent",
+        profile_path=profile,
+        decision_id="decision:adoption",
+        observed_at=OBSERVED_AT,
+        before=BEFORE,
+        rebase=lambda _collection: DecisionEvidenceRecords(),
+    )
+
+    assert activation["status"] == "disabled"
+    assert assembly is None
+
+
+def test_private_cursor_state_rejects_unknown_source_ids(tmp_path: Path) -> None:
+    authority = tmp_path / "authority.md"
+    authority.write_text(PRIVATE_CONTENT, encoding="utf-8")
+    profile = write_profile(tmp_path / "profile.json", authority)
+    cursors = tmp_path / "cursors.json"
+    cursors.write_text(json.dumps({"source:unknown": "cursor"}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unknown source ids"):
+        assemble_profile_decision_evidence(
+            goal_id="example-decision-goal",
+            agent_id="example-agent",
+            profile_path=profile,
+            decision_id="decision:adoption",
+            observed_at=OBSERVED_AT,
+            before=BEFORE,
+            cursor_path=cursors,
+            rebase=lambda _collection: DecisionEvidenceRecords(),
+        )
+
+
+def test_on_demand_source_requires_explicit_selection(tmp_path: Path) -> None:
+    authority = tmp_path / "authority.md"
+    authority.write_text(PRIVATE_CONTENT, encoding="utf-8")
+    profile = write_profile(
+        tmp_path / "profile.json",
+        authority,
+        scan_mode="on_demand",
+    )
+
+    _activation, automatic = assemble_profile_decision_evidence(
+        goal_id="example-decision-goal",
+        agent_id="example-agent",
+        profile_path=profile,
+        decision_id="decision:adoption",
+        observed_at=OBSERVED_AT,
+        before=BEFORE,
+        rebase=lambda _collection: DecisionEvidenceRecords(),
+    )
+    _activation, explicit = assemble_profile_decision_evidence(
+        goal_id="example-decision-goal",
+        agent_id="example-agent",
+        profile_path=profile,
+        decision_id="decision:adoption",
+        observed_at=OBSERVED_AT,
+        before=BEFORE,
+        source_ids={"source:authority"},
+        rebase=lambda _collection: DecisionEvidenceRecords(),
+    )
+
+    assert automatic is not None
+    assert automatic.public_packet()["source_manifest"]["source_count"] == 0
+    assert explicit is not None
+    assert explicit.public_packet()["source_manifest"]["source_count"] == 1
+    assert explicit.public_packet()["source_scan_receipts"][0]["status"] == "completed"


### PR DESCRIPTION
## Summary

- add a thin profile-to-evidence host API that resolves enabled source and context providers
- add a read-only `decision-context prepare-evidence` CLI preview with bounded scans, exact reads, and public-safe receipts
- keep on-demand sources explicit and preserve changed-source cursors until semantic rebase plus validated lifecycle writeback

## Validation

- `python -m pytest tests/capabilities/test_decision_context_runtime.py tests/capabilities/test_decision_context_profile.py tests/capabilities/test_decision_context_assembler.py tests/capabilities/test_decision_context_packets.py tests/capabilities/test_decision_context_sources.py -q` (`50 passed`)
- `python -m pytest -q` (`1290 passed, 2 skipped`)
- `python examples/decision-context-contract-smoke.py`
- scoped mypy with skipped imports (`3 source files`, no issues)
- `loopx canary premerge --from-git-diff` (`16/16` selected checks passed; public boundary clean)

## Boundaries

- no Core authority, todo, gate, quota, or permission semantics changed
- no cursor state is written by the CLI
- raw exact-read content, provider payloads, locators, cursors, credentials, and local paths stay outside public packets
- concrete domain adapters and validated cursor commit remain follow-up work
