### PR TITLE
fix(ci): align quota smoke and manpage

### DIFF
--- a/examples/control_plane/quota-plan-smoke.py
+++ b/examples/control_plane/quota-plan-smoke.py
@@ -1374,7 +1374,7 @@ def main() -> int:
         assert_throttled_cli_should_run(run_cli_throttled_should_run(Path(tmp)))
     with tempfile.TemporaryDirectory(prefix="loopx-quota-slot-smoke-") as tmp:
         slot_preview, should_run_after_preview = run_cli_slot_preview(Path(tmp))
-    assert_slot_preview(slot_preview)
+    assert_slot_preview(slot_preview, goal_scoped=True)
     assert_dry_run_left_cli_fixture_unchanged(should_run_after_preview)
     with tempfile.TemporaryDirectory(prefix="loopx-quota-slot-execute-smoke-") as tmp:
         assert_slot_spend_execute(*run_cli_slot_spend_execute(Path(tmp)))

--- a/examples/control_plane/quota_plan_fixtures.py
+++ b/examples/control_plane/quota_plan_fixtures.py
@@ -472,6 +472,8 @@ def run_cli_throttled_should_run(root: Path) -> dict:
             "should-run",
             "--goal-id",
             "throttled-half",
+            "--runtime-profile",
+            "outer_controller",
             "--scan-path",
             str(project),
         ],
@@ -519,6 +521,8 @@ def run_cli_slot_preview(root: Path) -> tuple[dict, dict]:
             "should-run",
             "--goal-id",
             "near-limit-half",
+            "--runtime-profile",
+            "outer_controller",
             "--scan-path",
             str(project),
         ],
@@ -572,6 +576,8 @@ def run_cli_slot_spend_execute(root: Path) -> tuple[dict, dict, str, str]:
             "should-run",
             "--goal-id",
             "near-limit-half",
+            "--runtime-profile",
+            "outer_controller",
             "--agent-id",
             SCOPED_AGENT_ID,
             "--scan-path",
@@ -656,6 +662,8 @@ def run_cli_slot_void_execute(root: Path) -> tuple[dict, dict, dict, str, str]:
             "should-run",
             "--goal-id",
             "near-limit-half",
+            "--runtime-profile",
+            "outer_controller",
             "--agent-id",
             SCOPED_AGENT_ID,
             "--scan-path",
@@ -675,6 +683,14 @@ def run_cli_slot_void_execute(root: Path) -> tuple[dict, dict, dict, str, str]:
     )
 
 
+def assert_outer_controller_scheduler_context(payload: dict) -> None:
+    scheduler_context = payload["scheduler_hint"]["execution_context"]
+    assert scheduler_context["valid"] is True, payload
+    assert scheduler_context["host_surface"] == "generic_cli", payload
+    assert scheduler_context["scheduler_owner"] == "outer_controller", payload
+    assert scheduler_context["execution_mode"] == "isolated_headless", payload
+
+
 def assert_throttled_cli_should_run(payload: dict) -> None:
     quota = payload["quota"]
 
@@ -684,7 +700,9 @@ def assert_throttled_cli_should_run(payload: dict) -> None:
     assert payload["should_run"] is False, payload
     assert payload["state"] == "throttled", payload
     assert payload["waiting_on"] == "codex", payload
-    assert payload["plan_summary"]["next_automatic_turn"] == "full-speed", payload
+    assert payload["plan_summary"]["registered_goals"] == 1, payload
+    assert payload["plan_summary"]["next_automatic_turn"] is None, payload
+    assert_outer_controller_scheduler_context(payload)
     assert quota["compute"] == 0.5, payload
     assert quota["spent_slots"] == 12, payload
     assert quota["allowed_slots"] == 12, payload
@@ -692,7 +710,7 @@ def assert_throttled_cli_should_run(payload: dict) -> None:
     assert "agent_command" not in payload, payload
 
 
-def assert_slot_preview(payload: dict) -> None:
+def assert_slot_preview(payload: dict, *, goal_scoped: bool = False) -> None:
     before = payload["before"]
     after = payload["after"]
     markdown = render_quota_slot_preview_markdown(payload)
@@ -713,7 +731,11 @@ def assert_slot_preview(payload: dict) -> None:
     assert after["decision"] == "skip", payload
     assert after["quota"]["spent_slots"] == 12, payload
     assert after["quota"]["allowed_slots"] == 12, payload
-    assert after["plan_summary"]["next_automatic_turn"] == "full-speed", payload
+    if goal_scoped:
+        assert after["plan_summary"]["registered_goals"] == 1, payload
+        assert after["plan_summary"]["next_automatic_turn"] is None, payload
+    else:
+        assert after["plan_summary"]["next_automatic_turn"] == "full-speed", payload
     assert "rolling_window_note" in payload, payload
     assert "same-status-payload projection" in payload["rolling_window_note"], payload
     assert "rolling_window_note" in markdown, markdown
@@ -725,6 +747,7 @@ def assert_dry_run_left_cli_fixture_unchanged(payload: dict) -> None:
     assert payload["should_run"] is True, payload
     assert payload["quota"]["spent_slots"] == 11, payload
     assert payload["quota"]["allowed_slots"] == 12, payload
+    assert_outer_controller_scheduler_context(payload)
 
 
 def assert_slot_spend_execute(payload: dict, next_should_run: dict, registry_before: str, registry_after: str) -> None:
@@ -772,6 +795,7 @@ def assert_slot_spend_execute(payload: dict, next_should_run: dict, registry_bef
     assert next_should_run["state"] == "throttled", next_should_run
     assert next_should_run["quota"]["spent_slots"] == 12, next_should_run
     assert next_should_run["quota"]["allowed_slots"] == 12, next_should_run
+    assert_outer_controller_scheduler_context(next_should_run)
 
 
 def assert_slot_void_execute(
@@ -821,6 +845,7 @@ def assert_slot_void_execute(
     assert next_should_run["state"] == "eligible", next_should_run
     assert next_should_run["quota"]["spent_slots"] == 11, next_should_run
     assert next_should_run["quota"]["allowed_slots"] == 12, next_should_run
+    assert_outer_controller_scheduler_context(next_should_run)
 
 
 def assert_quota_void_event_net_ledger() -> None:

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -47,6 +47,9 @@ Preview the shell fallback for the same agent\-safe `/loopx <goal>` path.
 \fBloopx agent\-onboard \-\-agent\-type codex\-cli \-\-project .\fR
 Generate the exact host\-loop activation packet for one agent runtime.
 .TP
+\fBloopx agent\-onboard \-\-agent\-type codex\-app\-ssh \-\-project .\fR
+Use visible /goal when Codex App runs over SSH without automation tools.
+.TP
 \fBloopx bootstrap\-command\-pack \-\-project .\fR
 Generate the lower\-level host handoff packet.
 .SH DAILY OPERATOR COMMANDS


### PR DESCRIPTION
## Summary

- align quota CLI smoke fixtures with selected-goal plan visibility
- make automated `should-run` calls declare the `outer_controller` runtime profile and verify the typed scheduler context
- regenerate the canonical manpage for the `codex-app-ssh` onboarding example

## Validation

- `examples/cli-help-manpage-smoke.py`
- `examples/control_plane/quota-plan-smoke.py`
- full-public shard 2 (offset 200): 100/100 passed
- full-public shard 1 (offset 100): 99/100 passed; the only suite failure was a local 120s timeout in `canary-promotion-readiness-smoke.py`
- timed-out canary rerun directly with `--no-write-evidence`: passed; dashboard demo check skipped because local npm dependencies are unavailable
- `loopx canary premerge --from-git-diff`: passed, 5/5 selected checks, no manual holds
- public/private boundary scan: clean for all 3 changed files
- `git diff --check`

## Scope

This is a validation and generated-documentation repair. It does not change quota runtime behavior. The smoke keeps global visibility for pure plan fixtures while explicitly asserting selected-goal visibility for CLI projections.
