### PR TITLE
Add validated Decision Context cursor commits

### DIFF
--- a/docs/reference/protocols/decision-context-architecture-v0.md
+++ b/docs/reference/protocols/decision-context-architecture-v0.md
@@ -176,9 +176,22 @@ semantic rebase: changed-source cursors remain at `preserve`, so merely scanning
 or reading a source can never mark it absorbed. Sources marked `on_demand` are
 excluded from automatic collection and require explicit source selection.
 
-Private cursor commit remains a separate acceptance boundary. It may occur only
-after the evidence/proposal and existing LoopX lifecycle writeback have been
-validated.
+Private cursor commit remains a separate acceptance boundary. The host API
+`commit_profile_decision_cursors(...)` now performs that boundary explicitly:
+
+- it verifies the assembly, evidence, proposal, outcome, and cursor-checkpoint
+  packet chain;
+- it exact-reads an existing LoopX rollout event whose `decision_id` and
+  artifact refs bind the same packet chain;
+- it rejects a changed private profile or a cursor value that no longer matches
+  the assembly snapshot;
+- it writes the private cursor file with a file lock, atomic replace, fsync, and
+  readback verification;
+- it returns only opaque cursor refs in a public-safe commit receipt.
+
+Scanning, evidence preparation, and proposal construction still perform no
+cursor write. A missing or generic boolean "writeback succeeded" assertion is
+not sufficient to commit.
 
 ### P1: first dogfood
 

--- a/docs/reference/protocols/decision-context-architecture-v0.zh-CN.md
+++ b/docs/reference/protocols/decision-context-architecture-v0.zh-CN.md
@@ -201,8 +201,18 @@ health、evidence 和 cursor checkpoint 记录。host API 通过领域 rebase ca
 `preserve`，避免把“扫描/读过”误记成“已吸收”。`on_demand` source 不进入自动
 扫描，只有显式选择后才会读取。
 
-私有 cursor commit 仍是独立验收边界：只有 evidence/proposal 与既有 LoopX
-lifecycle writeback 验证通过后，才允许显式提交。
+私有 cursor commit 仍是独立验收边界。host API
+`commit_profile_decision_cursors(...)` 现在显式执行这条边界：
+
+- 验证 assembly、evidence、proposal、outcome 与 cursor checkpoint 的完整引用链；
+- 精确回读既有 LoopX rollout event，并校验其 `decision_id` 与 artifact refs
+  绑定同一组 packet；
+- profile 已变化或当前 cursor 不再等于 assembly 快照时拒绝提交；
+- 通过文件锁、原子替换、fsync 与回读校验写入私有 cursor 文件；
+- public receipt 只包含不透明 cursor ref，不包含原始 cursor 或私有路径。
+
+source scan、evidence preparation 和 proposal 构建仍不会写 cursor；调用方只传
+一个“writeback 成功”的布尔值，不足以触发提交。
 
 ### P1：首个 dogfood
 

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -380,6 +380,11 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "module": "loopx.capabilities.decision_context.profile",
                 "doc": "docs/reference/protocols/decision-context-architecture-v0.md",
             },
+            {
+                "schema_version": "decision_cursor_commit_receipt_v0",
+                "module": "loopx.capabilities.decision_context.cursor_commit",
+                "doc": "docs/reference/protocols/decision-context-architecture-v0.md",
+            },
         ],
         "smokes": ["python3 examples/decision-context-contract-smoke.py"],
         "docs": [
@@ -390,11 +395,11 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
             "The capability is default-off and cannot create action authority or mutate Core state.",
             "Private source locators, cursors, raw content, provider payloads, tool output, and credentials stay outside public packets.",
             "DecisionSourceProvider rebases current authority; ContextProvider supplies advisory recall only.",
-            "The built-in local-file adapter and prepare-evidence route are read-only; domain adapters and validated cursor commit remain deferred.",
+            "The built-in local-file adapter and prepare-evidence route are read-only; cursor commit requires packet-chain validation, exact lifecycle-event readback, private-state CAS, and atomic verified write.",
         ],
         "next_real_step": (
-            "Validate explicit cursor commit after lifecycle writeback, then "
-            "produce the first outcome receipt in private dogfood."
+            "Exercise the first private incremental source profile and produce "
+            "an outcome receipt that changes or stops a real decision."
         ),
     },
     {

--- a/loopx/capabilities/decision_context/__init__.py
+++ b/loopx/capabilities/decision_context/__init__.py
@@ -49,9 +49,13 @@ from .providers import (
     decision_source_provider_registered,
     register_decision_source_provider,
 )
+from .cursor_commit import (
+    DECISION_CURSOR_COMMIT_RECEIPT_SCHEMA_VERSION,
+    commit_profile_decision_cursors,
+)
+from .private_state import load_private_decision_cursors
 from .runtime import (
     assemble_profile_decision_evidence,
-    load_private_decision_cursors,
 )
 
 __all__ = [
@@ -59,6 +63,7 @@ __all__ = [
     "DECISION_CONTEXT_ARCHITECTURE_SCHEMA_VERSION",
     "DECISION_CONTEXT_ACTIVATION_STATUS_SCHEMA_VERSION",
     "DECISION_CURSOR_CHECKPOINT_SCHEMA_VERSION",
+    "DECISION_CURSOR_COMMIT_RECEIPT_SCHEMA_VERSION",
     "DECISION_EVIDENCE_PACKET_SCHEMA_VERSION",
     "DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION",
     "DECISION_PROPOSAL_SCHEMA_VERSION",
@@ -81,6 +86,7 @@ __all__ = [
     "LocalFileDecisionSourceProvider",
     "assemble_decision_evidence",
     "assemble_profile_decision_evidence",
+    "commit_profile_decision_cursors",
     "build_decision_context_architecture_packet",
     "build_decision_evidence_packet",
     "build_decision_outcome_receipt",

--- a/loopx/capabilities/decision_context/architecture.py
+++ b/loopx/capabilities/decision_context/architecture.py
@@ -11,6 +11,7 @@ from .packets import (
     DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION,
     DECISION_PROPOSAL_SCHEMA_VERSION,
 )
+from .cursor_commit import DECISION_CURSOR_COMMIT_RECEIPT_SCHEMA_VERSION
 from .sources import (
     DECISION_SOURCE_MANIFEST_SCHEMA_VERSION,
     DECISION_SOURCE_SCAN_RECEIPT_SCHEMA_VERSION,
@@ -44,6 +45,7 @@ def build_decision_context_architecture_packet() -> dict[str, object]:
         "assembly_schemas": [
             DECISION_CONTEXT_ASSEMBLY_SCHEMA_VERSION,
             DECISION_CURSOR_CHECKPOINT_SCHEMA_VERSION,
+            DECISION_CURSOR_COMMIT_RECEIPT_SCHEMA_VERSION,
         ],
         "provider_boundaries": {
             "decision_source_provider": (
@@ -58,15 +60,17 @@ def build_decision_context_architecture_packet() -> dict[str, object]:
             "rebase",
             "propose",
             "outcome",
+            "commit_cursor",
         ],
         "invariants": [
             "evidence_and_proposal_remain_separate",
             "accepted_recalled_claims_require_exact_read_and_revision",
             "changed_facts_require_exact_read_authority_revisions",
             "incremental_cursors_advance_only_after_rebase_and_writeback",
+            "cursor_commit_exact_reads_a_matching_lifecycle_event",
             "raw_provider_content_never_enters_public_packets",
             "proposals_require_existing_authority_confirmation",
             "verified_outcomes_precede_reward_memory_candidates",
         ],
-        "next_stage": "validated_cursor_commit_then_private_dogfood",
+        "next_stage": "private_incremental_source_profile_then_dogfood",
     }

--- a/loopx/capabilities/decision_context/assembler.py
+++ b/loopx/capabilities/decision_context/assembler.py
@@ -119,6 +119,11 @@ class DecisionContextAssembly:
 
     packet: Mapping[str, Any]
     proposed_cursors: Mapping[str, str] = field(repr=False)
+    expected_cursors: Mapping[str, str | None] = field(
+        default_factory=dict,
+        repr=False,
+    )
+    profile_digest: str | None = field(default=None, repr=False)
 
     def public_packet(self) -> dict[str, Any]:
         return dict(self.packet)
@@ -729,4 +734,8 @@ def assemble_decision_evidence(
     return DecisionContextAssembly(
         packet=packet,
         proposed_cursors=proposed_cursors,
+        expected_cursors={
+            source.source_id: cursors.get(source.source_id)
+            for source in enabled_sources
+        },
     )

--- a/loopx/capabilities/decision_context/cursor_commit.py
+++ b/loopx/capabilities/decision_context/cursor_commit.py
@@ -1,0 +1,362 @@
+"""Validated private cursor commit for Decision Context."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Collection, Mapping
+from pathlib import Path
+from typing import Any
+
+from ...file_lock import exclusive_file_lock
+from ...rollout_event_log import (
+    ROLLOUT_EVENT_SCHEMA_VERSION,
+    load_rollout_events,
+)
+from .assembler import (
+    DECISION_CONTEXT_ASSEMBLY_SCHEMA_VERSION,
+    DECISION_CURSOR_CHECKPOINT_SCHEMA_VERSION,
+    DecisionContextAssembly,
+)
+from .packets import (
+    DECISION_EVIDENCE_PACKET_SCHEMA_VERSION,
+    DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION,
+    DECISION_PROPOSAL_SCHEMA_VERSION,
+)
+from .private_state import (
+    load_private_decision_cursors,
+    private_file_digest,
+    write_private_decision_cursors_atomic,
+)
+from .profile import DecisionContextProfile, resolve_decision_context_activation
+
+DECISION_CURSOR_COMMIT_RECEIPT_SCHEMA_VERSION = "decision_cursor_commit_receipt_v0"
+
+_LIFECYCLE_WRITEBACK_EVENT_KINDS = {
+    "refresh_state",
+    "todo_add",
+    "todo_complete",
+    "todo_update",
+    "validation",
+}
+_LIFECYCLE_WRITEBACK_READ_LIMIT = 1000
+
+
+def _opaque_ref(prefix: str, *values: str) -> str:
+    digest = hashlib.sha256("\n".join(values).encode("utf-8")).hexdigest()[:20]
+    return f"{prefix}-{digest}"
+
+
+def _new_packet_ref(prefix: str, packet: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(
+        json.dumps(
+            packet,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:20]
+    return f"{prefix}-{digest}"
+
+
+def _validated_packet_ref(
+    prefix: str,
+    packet: Mapping[str, Any],
+    *,
+    field: str,
+) -> str:
+    body = dict(packet)
+    actual = str(body.pop(field, "") or "").strip()
+    if actual != _new_packet_ref(prefix, body):
+        raise ValueError(f"decision-context {field} is invalid")
+    return actual
+
+
+def _event_id(event: Mapping[str, Any]) -> str:
+    body = {key: value for key, value in event.items() if key != "event_id"}
+    return hashlib.sha256(
+        json.dumps(body, ensure_ascii=True, sort_keys=True).encode("utf-8")
+    ).hexdigest()[:16]
+
+
+def _load_current_cursors(
+    path: Path,
+    *,
+    profile: DecisionContextProfile,
+) -> dict[str, str]:
+    return load_private_decision_cursors(
+        path if path.expanduser().exists() else None,
+        profile=profile,
+    )
+
+
+def _validate_decision_packet_chain(
+    *,
+    assembly: DecisionContextAssembly,
+    proposal: Mapping[str, Any],
+    outcome_receipt: Mapping[str, Any],
+) -> tuple[str, str, str, Mapping[str, Any]]:
+    packet = assembly.public_packet()
+    if packet.get("schema_version") != DECISION_CONTEXT_ASSEMBLY_SCHEMA_VERSION:
+        raise ValueError("decision-context assembly schema is invalid")
+    _validated_packet_ref(
+        "decision-context-assembly",
+        packet,
+        field="assembly_ref",
+    )
+
+    evidence = packet.get("evidence_packet")
+    if (
+        not isinstance(evidence, Mapping)
+        or evidence.get("schema_version") != DECISION_EVIDENCE_PACKET_SCHEMA_VERSION
+    ):
+        raise ValueError("decision-context evidence packet is invalid")
+    evidence_ref = _validated_packet_ref(
+        "decision-evidence",
+        evidence,
+        field="packet_ref",
+    )
+
+    checkpoint = packet.get("cursor_checkpoint")
+    if (
+        not isinstance(checkpoint, Mapping)
+        or checkpoint.get("schema_version") != DECISION_CURSOR_CHECKPOINT_SCHEMA_VERSION
+    ):
+        raise ValueError("decision-context cursor checkpoint is invalid")
+    _validated_packet_ref(
+        "decision-cursor-checkpoint",
+        checkpoint,
+        field="checkpoint_ref",
+    )
+    if (
+        checkpoint.get("evidence_packet_ref") != evidence_ref
+        or checkpoint.get("apply_requires_validated_decision_writeback") is not True
+        or checkpoint.get("applied") is not False
+    ):
+        raise ValueError("decision-context cursor checkpoint is not committable")
+
+    if proposal.get("schema_version") != DECISION_PROPOSAL_SCHEMA_VERSION:
+        raise ValueError("decision-context proposal schema is invalid")
+    proposal_ref = _validated_packet_ref(
+        "decision-proposal",
+        proposal,
+        field="packet_ref",
+    )
+    if (
+        proposal.get("goal_id") != packet.get("goal_id")
+        or proposal.get("decision_id") != packet.get("decision_id")
+        or proposal.get("evidence_packet_ref") != evidence_ref
+    ):
+        raise ValueError("decision-context proposal does not match evidence")
+
+    if outcome_receipt.get("schema_version") != DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION:
+        raise ValueError("decision-context outcome receipt schema is invalid")
+    outcome_ref = _validated_packet_ref(
+        "decision-outcome",
+        outcome_receipt,
+        field="packet_ref",
+    )
+    if (
+        outcome_receipt.get("goal_id") != packet.get("goal_id")
+        or outcome_receipt.get("decision_id") != packet.get("decision_id")
+        or outcome_receipt.get("proposal_packet_ref") != proposal_ref
+    ):
+        raise ValueError("decision-context outcome receipt does not match proposal")
+    return evidence_ref, proposal_ref, outcome_ref, checkpoint
+
+
+def _validate_lifecycle_writeback(
+    *,
+    event_log_path: Path,
+    event_id: str,
+    goal_id: str,
+    decision_id: str,
+    required_artifact_refs: Collection[str],
+) -> Mapping[str, Any]:
+    matches = [
+        event
+        for event in load_rollout_events(
+            event_log_path.expanduser(),
+            limit=_LIFECYCLE_WRITEBACK_READ_LIMIT,
+        )
+        if event.get("event_id") == event_id
+    ]
+    if len(matches) != 1:
+        raise ValueError("validated lifecycle writeback event was not found")
+    event = matches[0]
+    if (
+        event.get("schema_version") != ROLLOUT_EVENT_SCHEMA_VERSION
+        or _event_id(event) != event_id
+    ):
+        raise ValueError("validated lifecycle writeback event is invalid")
+    causality = event.get("causality")
+    artifacts = event.get("artifact_refs")
+    boundary = event.get("boundary")
+    if (
+        event.get("goal_id") != goal_id
+        or event.get("event_kind") not in _LIFECYCLE_WRITEBACK_EVENT_KINDS
+        or event.get("status") != "committed"
+        or not isinstance(causality, Mapping)
+        or causality.get("decision_id") != decision_id
+        or not isinstance(artifacts, list)
+        or any(not isinstance(ref, str) for ref in artifacts)
+        or not set(required_artifact_refs).issubset(set(artifacts))
+        or not isinstance(boundary, Mapping)
+        or not boundary
+        or any(value is not False for value in boundary.values())
+    ):
+        raise ValueError("validated lifecycle writeback does not match decision")
+    return event
+
+
+def commit_profile_decision_cursors(
+    *,
+    goal_id: str,
+    agent_id: str,
+    profile_path: Path,
+    cursor_path: Path,
+    assembly: DecisionContextAssembly,
+    proposal: Mapping[str, Any],
+    outcome_receipt: Mapping[str, Any],
+    lifecycle_event_log_path: Path,
+    lifecycle_event_id: str,
+) -> dict[str, Any]:
+    """CAS-commit private cursors after exact-read lifecycle writeback validation."""
+
+    profile_digest_before = private_file_digest(profile_path)
+    activation, profile = resolve_decision_context_activation(
+        goal_id=goal_id,
+        agent_id=agent_id,
+        profile_path=profile_path,
+    )
+    profile_digest_after = private_file_digest(profile_path)
+    if (
+        activation.get("available") is not True
+        or profile is None
+        or profile_digest_before != profile_digest_after
+        or assembly.profile_digest != profile_digest_after
+    ):
+        raise ValueError("decision-context profile changed since evidence assembly")
+
+    evidence_ref, proposal_ref, outcome_ref, checkpoint = (
+        _validate_decision_packet_chain(
+            assembly=assembly,
+            proposal=proposal,
+            outcome_receipt=outcome_receipt,
+        )
+    )
+    packet = assembly.public_packet()
+    if packet.get("goal_id") != goal_id:
+        raise ValueError("decision-context assembly goal does not match profile")
+    decision_id = str(packet.get("decision_id") or "")
+    event = _validate_lifecycle_writeback(
+        event_log_path=lifecycle_event_log_path,
+        event_id=lifecycle_event_id,
+        goal_id=goal_id,
+        decision_id=decision_id,
+        required_artifact_refs={evidence_ref, proposal_ref, outcome_ref},
+    )
+
+    proposals = dict(assembly.proposed_cursors)
+    if not proposals:
+        raise ValueError("decision-context assembly has no cursor proposals")
+    expected = dict(assembly.expected_cursors)
+    source_specs = {source.source_id: source for source in profile.sources}
+    checkpoint_rows = checkpoint.get("sources")
+    if not isinstance(checkpoint_rows, list):
+        raise ValueError("decision-context cursor checkpoint sources are invalid")
+    rows = {
+        str(row.get("source_id")): row
+        for row in checkpoint_rows
+        if isinstance(row, Mapping)
+    }
+    if set(proposals) - set(source_specs):
+        raise ValueError("decision-context cursor proposal source is unavailable")
+
+    commit_rows: list[dict[str, Any]] = []
+    for source_id, proposed_cursor in sorted(proposals.items()):
+        row = rows.get(source_id)
+        spec = source_specs[source_id]
+        expected_cursor = expected.get(source_id)
+        expected_before_ref = (
+            _opaque_ref(
+                "source-cursor",
+                spec.provider_id,
+                source_id,
+                expected_cursor,
+            )
+            if expected_cursor
+            else None
+        )
+        expected_after_ref = _opaque_ref(
+            "source-cursor",
+            spec.provider_id,
+            source_id,
+            proposed_cursor,
+        )
+        if (
+            not isinstance(row, Mapping)
+            or row.get("disposition") != "ready_after_writeback"
+            or row.get("cursor_before_ref") != expected_before_ref
+            or row.get("cursor_after_ref") != expected_after_ref
+        ):
+            raise ValueError(
+                "decision-context cursor proposal does not match checkpoint"
+            )
+        commit_rows.append(
+            {
+                "source_id": source_id,
+                "cursor_before_ref": expected_before_ref,
+                "cursor_after_ref": expected_after_ref,
+            }
+        )
+
+    cursor_state_mutated = False
+    with exclusive_file_lock(cursor_path.expanduser()):
+        current = _load_current_cursors(cursor_path, profile=profile)
+        statuses: dict[str, str] = {}
+        updated = dict(current)
+        for source_id, proposed_cursor in sorted(proposals.items()):
+            current_cursor = current.get(source_id)
+            if current_cursor == proposed_cursor:
+                statuses[source_id] = "replayed"
+                continue
+            if current_cursor != expected.get(source_id):
+                raise ValueError(
+                    "decision-context cursor state changed since evidence assembly"
+                )
+            updated[source_id] = proposed_cursor
+            statuses[source_id] = "advanced"
+            cursor_state_mutated = True
+        if cursor_state_mutated:
+            write_private_decision_cursors_atomic(cursor_path, updated)
+        readback = _load_current_cursors(cursor_path, profile=profile)
+        if any(readback.get(key) != value for key, value in proposals.items()):
+            raise ValueError("decision-context cursor readback verification failed")
+
+    for row in commit_rows:
+        row["status"] = statuses[str(row["source_id"])]
+    receipt: dict[str, Any] = {
+        "schema_version": DECISION_CURSOR_COMMIT_RECEIPT_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "decision_id": decision_id,
+        "checkpoint_ref": checkpoint["checkpoint_ref"],
+        "evidence_packet_ref": evidence_ref,
+        "proposal_packet_ref": proposal_ref,
+        "outcome_receipt_ref": outcome_ref,
+        "lifecycle_event_id": event["event_id"],
+        "status": "committed" if cursor_state_mutated else "replayed",
+        "source_count": len(commit_rows),
+        "sources": commit_rows,
+        "cursor_state_mutated": cursor_state_mutated,
+        "readback_verified": True,
+        "visibility": "public_safe",
+        "core_state_mutated": False,
+        "private_cursor_state_written": cursor_state_mutated,
+        "raw_cursors_captured": False,
+        "private_paths_captured": False,
+        "raw_context_captured": False,
+        "credentials_captured": False,
+    }
+    receipt["receipt_ref"] = _new_packet_ref("decision-cursor-commit", receipt)
+    return receipt

--- a/loopx/capabilities/decision_context/private_state.py
+++ b/loopx/capabilities/decision_context/private_state.py
@@ -1,0 +1,90 @@
+"""Private cursor-state IO for Decision Context."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+
+from .profile import DecisionContextProfile
+
+
+def load_private_decision_cursors(
+    path: Path | None,
+    *,
+    profile: DecisionContextProfile,
+) -> dict[str, str]:
+    """Load private cursors without projecting their values into public output."""
+
+    if path is None or not path.expanduser().exists():
+        return {}
+    try:
+        with path.expanduser().open(encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("decision-context cursor state is unavailable") from exc
+    if not isinstance(payload, Mapping):
+        raise ValueError("decision-context cursor state must be an object")
+
+    source_ids = {source.source_id for source in profile.sources}
+    unexpected = sorted(str(key) for key in payload if str(key) not in source_ids)
+    if unexpected:
+        raise ValueError(
+            "decision-context cursor state contains unknown source ids: "
+            + ", ".join(unexpected)
+        )
+
+    cursors: dict[str, str] = {}
+    for source_id, value in payload.items():
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError("decision-context cursor values must be non-empty strings")
+        cursors[str(source_id)] = value.strip()
+    return cursors
+
+
+def private_file_digest(path: Path) -> str:
+    try:
+        payload = path.expanduser().read_bytes()
+    except OSError as exc:
+        raise ValueError("decision-context private state is unavailable") from exc
+    return hashlib.sha256(payload).hexdigest()
+
+
+def write_private_decision_cursors_atomic(
+    path: Path,
+    cursors: Mapping[str, str],
+) -> None:
+    destination = path.expanduser()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+        dir=destination.parent,
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(
+                dict(sorted(cursors.items())),
+                handle,
+                ensure_ascii=True,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, destination)
+        directory_fd = os.open(
+            destination.parent,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+        )
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        temporary.unlink(missing_ok=True)

--- a/loopx/capabilities/decision_context/runtime.py
+++ b/loopx/capabilities/decision_context/runtime.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Collection, Mapping, Sequence
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +14,7 @@ from .assembler import (
     DecisionEvidenceRebaser,
     assemble_decision_evidence,
 )
+from .private_state import load_private_decision_cursors, private_file_digest
 from .profile import (
     DecisionContextProfile,
     resolve_decision_context_activation,
@@ -62,42 +63,6 @@ class _UnavailableDecisionSourceProvider:
 
     def exact_read(self, **_: Any) -> Any:
         raise RuntimeError("decision source provider is unavailable")
-
-
-def load_private_decision_cursors(
-    path: Path | None,
-    *,
-    profile: DecisionContextProfile,
-) -> dict[str, str]:
-    """Load private cursors without projecting their values into public output."""
-
-    if path is None:
-        return {}
-    try:
-        with path.expanduser().open(encoding="utf-8") as handle:
-            payload = json.load(handle)
-    except (OSError, json.JSONDecodeError) as exc:
-        raise ValueError("decision-context cursor state is unavailable") from exc
-    if not isinstance(payload, Mapping):
-        raise ValueError("decision-context cursor state must be an object")
-
-    source_ids = {source.source_id for source in profile.sources}
-    unexpected = sorted(str(key) for key in payload if str(key) not in source_ids)
-    if unexpected:
-        raise ValueError(
-            "decision-context cursor state contains unknown source ids: "
-            + ", ".join(unexpected)
-        )
-
-    cursors: dict[str, str] = {}
-    for source_id, value in payload.items():
-        if not isinstance(value, str) or not value.strip():
-            raise ValueError(
-                "decision-context cursor values must be non-empty strings"
-            )
-        cursor = value.strip()
-        cursors[str(source_id)] = cursor
-    return cursors
 
 
 def _build_source_providers(
@@ -182,6 +147,12 @@ def assemble_profile_decision_evidence(
     and must not be persisted until the caller validates lifecycle writeback.
     """
 
+    try:
+        profile_digest_before = (
+            private_file_digest(profile_path) if profile_path is not None else None
+        )
+    except ValueError:
+        profile_digest_before = None
     activation, profile = resolve_decision_context_activation(
         goal_id=goal_id,
         agent_id=agent_id,
@@ -209,13 +180,16 @@ def assemble_profile_decision_evidence(
         cursors=cursors,
         rebase=rebase,
         context_provider=_build_advisory_context_provider(profile),
-        context_namespace=str(
-            context_config.get("namespace") or "decision-context"
-        ),
+        context_namespace=str(context_config.get("namespace") or "decision-context"),
         context_scope_ref=str(context_config.get("scope_ref") or "goal"),
         recall_query=recall_query,
         recall_query_summary=recall_query_summary,
         recall_limit=int(context_config.get("max_results", 5)),
         timeout_seconds=effective_timeout,
     )
-    return activation, assembly
+    if profile_path is None or profile_digest_before is None:
+        raise ValueError("decision-context profile became unavailable")
+    profile_digest_after = private_file_digest(profile_path)
+    if profile_digest_before != profile_digest_after:
+        raise ValueError("decision-context profile changed during evidence assembly")
+    return activation, replace(assembly, profile_digest=profile_digest_after)

--- a/tests/capabilities/test_decision_context_assembler.py
+++ b/tests/capabilities/test_decision_context_assembler.py
@@ -446,9 +446,10 @@ def test_architecture_projects_assembler_and_checkpoint_stage() -> None:
     assert packet["assembly_schemas"] == [
         "decision_context_assembly_v0",
         "decision_cursor_checkpoint_v0",
+        "decision_cursor_commit_receipt_v0",
     ]
     assert (
         "incremental_cursors_advance_only_after_rebase_and_writeback"
         in packet["invariants"]
     )
-    assert packet["next_stage"] == ("validated_cursor_commit_then_private_dogfood")
+    assert packet["next_stage"] == "private_incremental_source_profile_then_dogfood"

--- a/tests/capabilities/test_decision_context_runtime.py
+++ b/tests/capabilities/test_decision_context_runtime.py
@@ -9,8 +9,12 @@ import pytest
 from loopx.capabilities.decision_context import (
     DecisionEvidenceRecords,
     assemble_profile_decision_evidence,
+    build_decision_outcome_receipt,
+    build_decision_proposal,
+    commit_profile_decision_cursors,
 )
 from loopx.cli import main
+from loopx.rollout_event_log import append_rollout_event, build_rollout_event
 
 OBSERVED_AT = "2100-01-01T00:00:00+00:00"
 BEFORE = "2100-01-01T00:01:00+00:00"
@@ -61,6 +65,85 @@ def write_profile(
     }
     path.write_text(json.dumps(payload), encoding="utf-8")
     return path
+
+
+def semantic_rebase(collection: Any) -> DecisionEvidenceRecords:
+    current = collection.authority[0]
+    return DecisionEvidenceRecords(
+        changed_facts=(
+            {
+                "fact_id": "fact:pilot",
+                "summary": "Current authority keeps adoption at pilot.",
+                "source_ref": current.source_ref,
+                "source_revision": current.source_revision,
+                "observed_at": current.observed_at,
+                "freshness": "current",
+                "authority": "first_party",
+            },
+        )
+    )
+
+
+def decision_chain(assembly: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+    packet = assembly.public_packet()
+    proposal = build_decision_proposal(
+        goal_id="example-decision-goal",
+        decision_id="decision:adoption",
+        evidence_packet_ref=packet["evidence_packet"]["packet_ref"],
+        observed_at=OBSERVED_AT,
+        objective_scores=[
+            {
+                "objective_id": "adoption",
+                "score": 0.8,
+                "rationale": "The current authority supports a bounded pilot.",
+            }
+        ],
+        recommended_decision={
+            "option_id": "bounded-pilot",
+            "summary": "Continue the bounded pilot.",
+            "rationale": "Current first-party evidence remains positive.",
+            "confidence": 0.8,
+        },
+        review_at="2100-01-02T00:00:00+00:00",
+    )
+    outcome = build_decision_outcome_receipt(
+        goal_id="example-decision-goal",
+        decision_id="decision:adoption",
+        proposal_packet_ref=proposal["packet_ref"],
+        recorded_at=OBSERVED_AT,
+        verification_status="pending",
+        accepted_decision={
+            "option_id": "bounded-pilot",
+            "summary": "Continue the bounded pilot.",
+            "accepted_by": "example-owner",
+            "accepted_at": OBSERVED_AT,
+        },
+        review_at="2100-01-02T00:00:00+00:00",
+    )
+    return proposal, outcome
+
+
+def append_decision_writeback(
+    path: Path,
+    assembly: Any,
+    proposal: dict[str, Any],
+    outcome: dict[str, Any],
+) -> dict[str, Any]:
+    packet = assembly.public_packet()
+    event = build_rollout_event(
+        goal_id="example-decision-goal",
+        event_kind="validation",
+        decision_id="decision:adoption",
+        status="committed",
+        summary="Decision packets were written through the existing lifecycle.",
+        artifact_refs=[
+            packet["evidence_packet"]["packet_ref"],
+            proposal["packet_ref"],
+            outcome["packet_ref"],
+        ],
+        recorded_at=OBSERVED_AT,
+    )
+    return append_rollout_event(path, event)
 
 
 def test_profile_runtime_builds_providers_and_returns_private_cursor_proposal(
@@ -278,3 +361,238 @@ def test_on_demand_source_requires_explicit_selection(tmp_path: Path) -> None:
     assert explicit is not None
     assert explicit.public_packet()["source_manifest"]["source_count"] == 1
     assert explicit.public_packet()["source_scan_receipts"][0]["status"] == "completed"
+
+
+def test_cursor_commit_requires_exact_read_lifecycle_writeback(
+    tmp_path: Path,
+) -> None:
+    authority = tmp_path / "authority.md"
+    authority.write_text(PRIVATE_CONTENT, encoding="utf-8")
+    profile = write_profile(tmp_path / "profile.json", authority)
+    cursors = tmp_path / "cursors.json"
+    event_log = tmp_path / "rollout-events.jsonl"
+    _activation, assembly = assemble_profile_decision_evidence(
+        goal_id="example-decision-goal",
+        agent_id="example-agent",
+        profile_path=profile,
+        decision_id="decision:adoption",
+        observed_at=OBSERVED_AT,
+        before=BEFORE,
+        cursor_path=cursors,
+        rebase=semantic_rebase,
+    )
+    assert assembly is not None
+    proposal, outcome = decision_chain(assembly)
+
+    with pytest.raises(ValueError, match="writeback event was not found"):
+        commit_profile_decision_cursors(
+            goal_id="example-decision-goal",
+            agent_id="example-agent",
+            profile_path=profile,
+            cursor_path=cursors,
+            assembly=assembly,
+            proposal=proposal,
+            outcome_receipt=outcome,
+            lifecycle_event_log_path=event_log,
+            lifecycle_event_id="missing-event",
+        )
+
+    assert not cursors.exists()
+
+
+def test_thin_host_callsite_commits_cursor_after_lifecycle_writeback(
+    tmp_path: Path,
+) -> None:
+    authority = tmp_path / "authority.md"
+    authority.write_text(PRIVATE_CONTENT, encoding="utf-8")
+    profile = write_profile(tmp_path / "profile.json", authority)
+    cursors = tmp_path / "cursors.json"
+    event_log = tmp_path / "rollout-events.jsonl"
+    _activation, assembly = assemble_profile_decision_evidence(
+        goal_id="example-decision-goal",
+        agent_id="example-agent",
+        profile_path=profile,
+        decision_id="decision:adoption",
+        observed_at=OBSERVED_AT,
+        before=BEFORE,
+        cursor_path=cursors,
+        rebase=semantic_rebase,
+    )
+    assert assembly is not None
+    proposal, outcome = decision_chain(assembly)
+    event = append_decision_writeback(event_log, assembly, proposal, outcome)
+
+    receipt = commit_profile_decision_cursors(
+        goal_id="example-decision-goal",
+        agent_id="example-agent",
+        profile_path=profile,
+        cursor_path=cursors,
+        assembly=assembly,
+        proposal=proposal,
+        outcome_receipt=outcome,
+        lifecycle_event_log_path=event_log,
+        lifecycle_event_id=event["event_id"],
+    )
+
+    assert receipt["status"] == "committed"
+    assert receipt["cursor_state_mutated"] is True
+    assert receipt["readback_verified"] is True
+    assert receipt["sources"][0]["status"] == "advanced"
+    assert json.loads(cursors.read_text(encoding="utf-8")) == dict(
+        assembly.proposed_cursors
+    )
+    serialized = json.dumps(receipt, sort_keys=True)
+    for private_value in (
+        PRIVATE_CONTENT,
+        str(authority),
+        str(profile),
+        str(cursors),
+        next(iter(assembly.proposed_cursors.values())),
+    ):
+        assert private_value not in serialized
+
+    replay = commit_profile_decision_cursors(
+        goal_id="example-decision-goal",
+        agent_id="example-agent",
+        profile_path=profile,
+        cursor_path=cursors,
+        assembly=assembly,
+        proposal=proposal,
+        outcome_receipt=outcome,
+        lifecycle_event_log_path=event_log,
+        lifecycle_event_id=event["event_id"],
+    )
+    assert replay["status"] == "replayed"
+    assert replay["cursor_state_mutated"] is False
+    assert replay["sources"][0]["status"] == "replayed"
+
+
+def test_cursor_commit_rejects_concurrent_cursor_change(tmp_path: Path) -> None:
+    authority = tmp_path / "authority.md"
+    authority.write_text(PRIVATE_CONTENT, encoding="utf-8")
+    profile = write_profile(tmp_path / "profile.json", authority)
+    cursors = tmp_path / "cursors.json"
+    cursors.write_text(
+        json.dumps({"source:authority": "sha256:previous"}),
+        encoding="utf-8",
+    )
+    event_log = tmp_path / "rollout-events.jsonl"
+    _activation, assembly = assemble_profile_decision_evidence(
+        goal_id="example-decision-goal",
+        agent_id="example-agent",
+        profile_path=profile,
+        decision_id="decision:adoption",
+        observed_at=OBSERVED_AT,
+        before=BEFORE,
+        cursor_path=cursors,
+        rebase=semantic_rebase,
+    )
+    assert assembly is not None
+    proposal, outcome = decision_chain(assembly)
+    event = append_decision_writeback(event_log, assembly, proposal, outcome)
+    concurrent = {"source:authority": "sha256:concurrent"}
+    cursors.write_text(json.dumps(concurrent), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="changed since evidence assembly"):
+        commit_profile_decision_cursors(
+            goal_id="example-decision-goal",
+            agent_id="example-agent",
+            profile_path=profile,
+            cursor_path=cursors,
+            assembly=assembly,
+            proposal=proposal,
+            outcome_receipt=outcome,
+            lifecycle_event_log_path=event_log,
+            lifecycle_event_id=event["event_id"],
+        )
+
+    assert json.loads(cursors.read_text(encoding="utf-8")) == concurrent
+
+
+def test_cursor_commit_rejects_profile_change_after_assembly(tmp_path: Path) -> None:
+    authority = tmp_path / "authority.md"
+    authority.write_text(PRIVATE_CONTENT, encoding="utf-8")
+    profile = write_profile(tmp_path / "profile.json", authority)
+    cursors = tmp_path / "cursors.json"
+    event_log = tmp_path / "rollout-events.jsonl"
+    _activation, assembly = assemble_profile_decision_evidence(
+        goal_id="example-decision-goal",
+        agent_id="example-agent",
+        profile_path=profile,
+        decision_id="decision:adoption",
+        observed_at=OBSERVED_AT,
+        before=BEFORE,
+        cursor_path=cursors,
+        rebase=semantic_rebase,
+    )
+    assert assembly is not None
+    proposal, outcome = decision_chain(assembly)
+    event = append_decision_writeback(event_log, assembly, proposal, outcome)
+    changed_profile = json.loads(profile.read_text(encoding="utf-8"))
+    changed_profile["sources"][0]["max_changes"] = 5
+    profile.write_text(json.dumps(changed_profile), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="profile changed since evidence assembly"):
+        commit_profile_decision_cursors(
+            goal_id="example-decision-goal",
+            agent_id="example-agent",
+            profile_path=profile,
+            cursor_path=cursors,
+            assembly=assembly,
+            proposal=proposal,
+            outcome_receipt=outcome,
+            lifecycle_event_log_path=event_log,
+            lifecycle_event_id=event["event_id"],
+        )
+
+    assert not cursors.exists()
+
+
+def test_cursor_commit_rejects_writeback_without_full_packet_chain(
+    tmp_path: Path,
+) -> None:
+    authority = tmp_path / "authority.md"
+    authority.write_text(PRIVATE_CONTENT, encoding="utf-8")
+    profile = write_profile(tmp_path / "profile.json", authority)
+    cursors = tmp_path / "cursors.json"
+    event_log = tmp_path / "rollout-events.jsonl"
+    _activation, assembly = assemble_profile_decision_evidence(
+        goal_id="example-decision-goal",
+        agent_id="example-agent",
+        profile_path=profile,
+        decision_id="decision:adoption",
+        observed_at=OBSERVED_AT,
+        before=BEFORE,
+        cursor_path=cursors,
+        rebase=semantic_rebase,
+    )
+    assert assembly is not None
+    proposal, outcome = decision_chain(assembly)
+    packet = assembly.public_packet()
+    event = build_rollout_event(
+        goal_id="example-decision-goal",
+        event_kind="validation",
+        decision_id="decision:adoption",
+        status="committed",
+        artifact_refs=[
+            packet["evidence_packet"]["packet_ref"],
+            proposal["packet_ref"],
+        ],
+        recorded_at=OBSERVED_AT,
+    )
+    append_rollout_event(event_log, event)
+
+    with pytest.raises(ValueError, match="does not match decision"):
+        commit_profile_decision_cursors(
+            goal_id="example-decision-goal",
+            agent_id="example-agent",
+            profile_path=profile,
+            cursor_path=cursors,
+            assembly=assembly,
+            proposal=proposal,
+            outcome_receipt=outcome,
+            lifecycle_event_log_path=event_log,
+            lifecycle_event_id=event["event_id"],
+        )
+
+    assert not cursors.exists()


### PR DESCRIPTION
## Summary

- add an explicit Decision Context cursor commit API after semantic rebase
- validate the assembly, evidence, proposal, outcome, and checkpoint reference chain
- exact-read a matching existing LoopX lifecycle event before any cursor write
- CAS-check private profile and cursor revisions, then use lock, atomic replace, fsync, and readback
- emit only opaque cursor references in the public-safe commit receipt

## Commit grouping

1. Runtime/API behavior and focused tests
2. Public architecture, capability catalog, and bilingual protocol notes

## Validation

- `61 passed` across Decision Context and catalog-focused tests
- full suite: `1295 passed, 2 skipped`
- Decision Context contract smoke passed
- Ruff lint and format checks passed
- standard premerge canary: 16 checks passed, 0 failures, 0 warnings
- public/private boundary scan clean across 11 changed files
- premerge gate: `self_merge_allowed=true`, no manual holds

## Boundary

- no private profiles, cursor values, source locators, raw provider payloads, credentials, internal links, or local paths are committed
- `prepare-evidence` remains read-only
- the new write updates only capability-owned private cursor state and does not change Core authority semantics

## Residual risk

- lifecycle-event readback is intentionally bounded to the latest 1000 events; an older event fails closed and requires a fresh writeback event
