### PR TITLE
Add runtime-bound Decision Context providers

### DIFF
--- a/docs/reference/protocols/decision-context-architecture-v0.md
+++ b/docs/reference/protocols/decision-context-architecture-v0.md
@@ -193,6 +193,16 @@ Scanning, evidence preparation, and proposal construction still perform no
 cursor write. A missing or generic boolean "writeback succeeded" assertion is
 not sufficient to commit.
 
+Private hosts may bind a provider instance at runtime through
+`source_provider_overrides`. The provider id must already be declared by the
+private goal profile, and the instance identity must match that declaration.
+This lets an MCP, inbox, document, or repository integration use the same
+health, bounded scan, exact-read, rebase, and cursor-checkpoint path without
+registering a private adapter in the public package. Activation projects only
+`runtime-bound`; the adapter name, config, locator, payload, and cursor remain
+private. Missing or mismatched runtime providers fail open without advancing a
+cursor.
+
 ### P1: first dogfood
 
 Use one private, redacted decision-assistant scenario. Write an outcome receipt

--- a/docs/reference/protocols/decision-context-architecture-v0.zh-CN.md
+++ b/docs/reference/protocols/decision-context-architecture-v0.zh-CN.md
@@ -214,6 +214,13 @@ health、evidence 和 cursor checkpoint 记录。host API 通过领域 rebase ca
 source scan、evidence preparation 和 proposal 构建仍不会写 cursor；调用方只传
 一个“writeback 成功”的布尔值，不足以触发提交。
 
+私有宿主可以通过 `source_provider_overrides` 在运行时绑定 provider 实例。provider
+id 必须先由私有 goal profile 声明，实例身份也必须与声明一致。这样 MCP、收件箱、
+文档或仓库集成可以复用同一套 health、bounded scan、exact-read、rebase 与 cursor
+checkpoint 路径，而不必把私有 adapter 注册进公开包。activation 只投影
+`runtime-bound`；adapter 名称、配置、locator、payload 和 cursor 均留在私有边界。
+provider 缺失或身份不匹配时 fail open，且不会推进 cursor。
+
 ### P1：首个 dogfood
 
 - 在一个私有、脱敏的决策助手场景生成 evidence/proposal；

--- a/loopx/capabilities/decision_context/profile.py
+++ b/loopx/capabilities/decision_context/profile.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import re
-from collections.abc import Mapping, Sequence
+from collections.abc import Collection, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -137,11 +137,18 @@ class DecisionSourceProviderBinding:
     adapter: str
     config: Mapping[str, Any] = field(repr=False)
 
-    def public_record(self) -> dict[str, object]:
+    def public_record(self, *, runtime_bound: bool = False) -> dict[str, object]:
         adapter_registered = decision_source_provider_registered(self.adapter)
         return {
-            "adapter": self.adapter if adapter_registered else "unregistered",
+            "adapter": (
+                "runtime-bound"
+                if runtime_bound
+                else self.adapter
+                if adapter_registered
+                else "unregistered"
+            ),
             "adapter_registered": adapter_registered,
+            "runtime_bound": runtime_bound,
             "private_config_captured": False,
         }
 
@@ -357,9 +364,16 @@ def resolve_decision_context_activation(
     goal_id: str,
     agent_id: str,
     profile_path: Path | None,
+    available_source_provider_ids: Collection[str] | None = None,
 ) -> tuple[dict[str, Any], DecisionContextProfile | None]:
     normalized_goal = _token(goal_id, field_name="goal_id")
     normalized_agent = _token(agent_id, field_name="agent_id")
+    if isinstance(available_source_provider_ids, (str, bytes)):
+        raise TypeError("available_source_provider_ids must be a collection")
+    runtime_provider_ids = {
+        _token(provider_id, field_name="available_source_provider_ids[]")
+        for provider_id in (available_source_provider_ids or ())
+    }
     base: dict[str, Any] = {
         "ok": True,
         "schema_version": DECISION_CONTEXT_ACTIVATION_STATUS_SCHEMA_VERSION,
@@ -374,6 +388,7 @@ def resolve_decision_context_activation(
         "available": False,
         "source_count": 0,
         "source_provider_count": 0,
+        "runtime_bound_provider_count": 0,
         "context_provider_configured": False,
         "automatic_capture": False,
         "fail_open": True,
@@ -398,15 +413,30 @@ def resolve_decision_context_activation(
         }, None
 
     configured_for_agent = normalized_agent in config.enabled_agents
-    provider_records = [binding.public_record() for binding in config.provider_bindings]
+    declared_provider_ids = {
+        binding.provider_id for binding in config.provider_bindings
+    }
+    if not runtime_provider_ids <= declared_provider_ids:
+        return base | {
+            "status": "profile_invalid",
+            "reason_code": "runtime_provider_scope_mismatch",
+        }, config
+    provider_records = [
+        binding.public_record(
+            runtime_bound=binding.provider_id in runtime_provider_ids,
+        )
+        for binding in config.provider_bindings
+    ]
     unavailable_adapter_count = sum(
-        not bool(record["adapter_registered"]) for record in provider_records
+        not bool(record["adapter_registered"]) and not bool(record["runtime_bound"])
+        for record in provider_records
     )
     status = base | {
         "enabled": config.enabled,
         "configured_for_agent": configured_for_agent,
         "source_count": len(config.sources),
         "source_provider_count": len(config.provider_bindings),
+        "runtime_bound_provider_count": len(runtime_provider_ids),
         "source_providers": provider_records,
         "context_provider_configured": config.context_provider is not None,
     }

--- a/loopx/capabilities/decision_context/runtime.py
+++ b/loopx/capabilities/decision_context/runtime.py
@@ -38,8 +38,14 @@ class _UnavailableContextProvider:
 class _UnavailableDecisionSourceProvider:
     """Report a configured-but-invalid binding without exposing its config."""
 
-    def __init__(self, provider_id: str) -> None:
+    def __init__(
+        self,
+        provider_id: str,
+        *,
+        reason_code: str = "provider_configuration_failed",
+    ) -> None:
         self.provider_id = provider_id
+        self.reason_code = reason_code
 
     def scan(
         self,
@@ -58,7 +64,7 @@ class _UnavailableDecisionSourceProvider:
             status="unavailable",
             observed_at=observed_at,
             requested_limit=source.max_changes,
-            reason_code="provider_configuration_failed",
+            reason_code=self.reason_code,
         )
 
     def exact_read(self, **_: Any) -> Any:
@@ -69,11 +75,22 @@ def _build_source_providers(
     profile: DecisionContextProfile,
     *,
     sources: Sequence[DecisionSourceSpec],
+    source_provider_overrides: Mapping[str, DecisionSourceProvider],
 ) -> dict[str, DecisionSourceProvider]:
     enabled_provider_ids = {source.provider_id for source in sources}
     providers: dict[str, DecisionSourceProvider] = {}
     for provider_id, binding in profile.provider_binding_map().items():
         if provider_id not in enabled_provider_ids:
+            continue
+        runtime_provider = source_provider_overrides.get(provider_id)
+        if runtime_provider is not None:
+            if str(getattr(runtime_provider, "provider_id", "") or "") != provider_id:
+                providers[provider_id] = _UnavailableDecisionSourceProvider(
+                    provider_id,
+                    reason_code="runtime_provider_identity_mismatch",
+                )
+            else:
+                providers[provider_id] = runtime_provider
             continue
         try:
             providers[provider_id] = build_decision_source_provider(binding)
@@ -138,6 +155,7 @@ def assemble_profile_decision_evidence(
     recall_query: str = "current decision evidence",
     recall_query_summary: str = "current decision evidence",
     timeout_seconds: float | None = None,
+    source_provider_overrides: Mapping[str, DecisionSourceProvider] | None = None,
 ) -> tuple[dict[str, Any], DecisionContextAssembly | None]:
     """Resolve one enabled profile and assemble evidence without applying cursors.
 
@@ -153,10 +171,17 @@ def assemble_profile_decision_evidence(
         )
     except ValueError:
         profile_digest_before = None
+    if source_provider_overrides is None:
+        provider_overrides: Mapping[str, DecisionSourceProvider] = {}
+    elif not isinstance(source_provider_overrides, Mapping):
+        raise TypeError("source_provider_overrides must be a mapping")
+    else:
+        provider_overrides = source_provider_overrides
     activation, profile = resolve_decision_context_activation(
         goal_id=goal_id,
         agent_id=agent_id,
         profile_path=profile_path,
+        available_source_provider_ids=provider_overrides,
     )
     if activation["available"] is not True or profile is None:
         return activation, None
@@ -176,7 +201,11 @@ def assemble_profile_decision_evidence(
         observed_at=observed_at,
         before=before,
         sources=sources,
-        source_providers=_build_source_providers(profile, sources=sources),
+        source_providers=_build_source_providers(
+            profile,
+            sources=sources,
+            source_provider_overrides=provider_overrides,
+        ),
         cursors=cursors,
         rebase=rebase,
         context_provider=_build_advisory_context_provider(profile),

--- a/tests/capabilities/test_decision_context_profile.py
+++ b/tests/capabilities/test_decision_context_profile.py
@@ -182,6 +182,61 @@ def test_scope_and_provider_routes_fail_closed_without_private_leaks(
         assert status["unavailable_adapter_count"] == 1
 
 
+def test_private_host_provider_can_satisfy_activation_without_adapter_registration(
+    tmp_path: Path,
+) -> None:
+    authority = tmp_path / "private-authority.md"
+    authority.write_text(PRIVATE_CONTENT, encoding="utf-8")
+    profile_path = write_profile(
+        tmp_path / "private-profile.json",
+        profile_payload(authority, adapter="private-host-adapter"),
+    )
+
+    status, _profile = resolve_decision_context_activation(
+        goal_id="example-decision-goal",
+        agent_id="example-agent",
+        profile_path=profile_path,
+        available_source_provider_ids={"local-authority"},
+    )
+    serialized = json.dumps(status, sort_keys=True)
+
+    assert status["status"] == "available"
+    assert status["available"] is True
+    assert status["runtime_bound_provider_count"] == 1
+    assert status["source_providers"] == [
+        {
+            "adapter": "runtime-bound",
+            "adapter_registered": False,
+            "runtime_bound": True,
+            "private_config_captured": False,
+        }
+    ]
+    assert "private-host-adapter" not in serialized
+    assert str(authority) not in serialized
+
+
+def test_runtime_provider_binding_must_be_declared_by_private_profile(
+    tmp_path: Path,
+) -> None:
+    authority = tmp_path / "private-authority.md"
+    authority.write_text(PRIVATE_CONTENT, encoding="utf-8")
+    profile_path = write_profile(
+        tmp_path / "private-profile.json",
+        profile_payload(authority),
+    )
+
+    status, _profile = resolve_decision_context_activation(
+        goal_id="example-decision-goal",
+        agent_id="example-agent",
+        profile_path=profile_path,
+        available_source_provider_ids={"another-provider"},
+    )
+
+    assert status["status"] == "profile_invalid"
+    assert status["reason_code"] == "runtime_provider_scope_mismatch"
+    assert status["available"] is False
+
+
 @pytest.mark.parametrize(
     ("field_name", "value", "expected_message"),
     [

--- a/tests/capabilities/test_decision_context_runtime.py
+++ b/tests/capabilities/test_decision_context_runtime.py
@@ -8,6 +8,7 @@ import pytest
 
 from loopx.capabilities.decision_context import (
     DecisionEvidenceRecords,
+    LocalFileDecisionSourceProvider,
     assemble_profile_decision_evidence,
     build_decision_outcome_receipt,
     build_decision_proposal,
@@ -28,6 +29,7 @@ def write_profile(
     enabled: bool = True,
     max_bytes: int = 4096,
     scan_mode: str = "incremental",
+    adapter: str = "local-file",
 ) -> Path:
     payload = {
         "schema_version": "decision_context_profile_v0",
@@ -37,7 +39,7 @@ def write_profile(
         "source_provider_bindings": [
             {
                 "provider_id": "local-authority",
-                "adapter": "local-file",
+                "adapter": adapter,
                 "config": {"max_bytes": max_bytes},
             }
         ],
@@ -192,6 +194,80 @@ def test_profile_runtime_builds_providers_and_returns_private_cursor_proposal(
     )
     assert PRIVATE_CONTENT not in json.dumps(packet, sort_keys=True)
     assert str(authority) not in json.dumps(packet, sort_keys=True)
+
+
+def test_private_host_provider_drives_generic_scan_exact_read_and_checkpoint(
+    tmp_path: Path,
+) -> None:
+    authority = tmp_path / "authority.md"
+    authority.write_text(PRIVATE_CONTENT, encoding="utf-8")
+    profile = write_profile(
+        tmp_path / "profile.json",
+        authority,
+        adapter="private-host-adapter",
+    )
+    provider = LocalFileDecisionSourceProvider(
+        provider_id="local-authority",
+        max_bytes=4096,
+    )
+
+    activation, assembly = assemble_profile_decision_evidence(
+        goal_id="example-decision-goal",
+        agent_id="example-agent",
+        profile_path=profile,
+        decision_id="decision:adoption",
+        observed_at=OBSERVED_AT,
+        before=BEFORE,
+        rebase=semantic_rebase,
+        source_provider_overrides={"local-authority": provider},
+    )
+
+    assert activation["status"] == "available"
+    assert activation["runtime_bound_provider_count"] == 1
+    assert assembly is not None
+    packet = assembly.public_packet()
+    assert packet["source_scan_receipts"][0]["status"] == "completed"
+    assert packet["source_scan_receipts"][0]["exact_read_count"] == 1
+    assert packet["evidence_packet"]["provider_health"][0]["status"] == "healthy"
+    assert packet["cursor_checkpoint"]["sources"][0]["disposition"] == (
+        "ready_after_writeback"
+    )
+    assert PRIVATE_CONTENT not in json.dumps(packet, sort_keys=True)
+    assert str(authority) not in json.dumps(packet, sort_keys=True)
+
+
+def test_runtime_provider_identity_mismatch_fails_open(
+    tmp_path: Path,
+) -> None:
+    authority = tmp_path / "authority.md"
+    authority.write_text(PRIVATE_CONTENT, encoding="utf-8")
+    profile = write_profile(
+        tmp_path / "profile.json",
+        authority,
+        adapter="private-host-adapter",
+    )
+    provider = LocalFileDecisionSourceProvider(
+        provider_id="another-provider",
+        max_bytes=4096,
+    )
+
+    activation, assembly = assemble_profile_decision_evidence(
+        goal_id="example-decision-goal",
+        agent_id="example-agent",
+        profile_path=profile,
+        decision_id="decision:adoption",
+        observed_at=OBSERVED_AT,
+        before=BEFORE,
+        rebase=lambda _collection: DecisionEvidenceRecords(),
+        source_provider_overrides={"local-authority": provider},
+    )
+
+    assert activation["status"] == "available"
+    assert assembly is not None
+    receipt = assembly.public_packet()["source_scan_receipts"][0]
+    assert receipt["status"] == "unavailable"
+    assert receipt["reason_code"] == "runtime_provider_identity_mismatch"
+    assert assembly.proposed_cursors == {}
 
 
 def test_prepare_evidence_cli_preserves_private_cursor_until_semantic_rebase(


### PR DESCRIPTION
## Summary
- allow private hosts to inject declared Decision Context source providers at runtime
- keep adapter/config/locator/payload/cursor details outside public activation projections
- fail open on undeclared or identity-mismatched runtime providers without advancing cursors
- document the private-host boundary in English and Chinese architecture references

## Validation
- `uvx ruff format --check ...`
- `uvx ruff check --ignore TRY004,BLE001 ...`
- `pytest` focused Decision Context suite: 59 passed
- `uv run --extra test pytest -q`: 1299 passed, 2 skipped
- public diff sensitive-string scan: clean

## Boundary
No private provider implementation, locator, source registry, chat content, internal link, or credential is included. Private hosts bind in-process provider instances whose ids were already declared by the private goal profile.
