### PR TITLE
feat(material-lifecycle): add read-only migration preparation

### DIFF
--- a/docs/reference/protocols/material-lifecycle-architecture-v0.md
+++ b/docs/reference/protocols/material-lifecycle-architecture-v0.md
@@ -87,6 +87,29 @@ until a provider-specific adapter proves:
 The generic capability never embeds a legacy parser or a private file layout.
 Adapters may coexist with the old store for as long as reconciliation requires.
 
+## Read-Only Preparation Path
+
+`MaterialInventoryProvider` is the private adapter boundary for legacy stores.
+It returns transient metadata as `MaterialStoreSnapshot`: opaque snapshot and
+backup references, revision and digest, lifecycle counts, parse-error
+references, and three explicit verification results:
+
+- stable material IDs were verified;
+- the backup was verified;
+- the source digest remained unchanged across inspection.
+
+`prepare_material_migration` converts that transient snapshot into the existing
+`material_store_inventory_v0` packet. It creates
+`material_migration_plan_v0` only when all three verifications pass and no parse
+errors remain. Otherwise it returns deterministic readiness blockers and no
+plan. The provider contract has no apply method, and both emitted packets keep
+`source_mutation_authorized=false`.
+
+Provider implementations and private file layouts stay outside the generic
+capability. A host adapter may parse Markdown, a database, or another source,
+but it must prove the same read-only and backup invariants before LoopX will
+prepare migration.
+
 ## Decision-Driven Ranking and Exploration
 
 Stage 0 accepts an opaque `decision_evidence_ref` from Decision Context. A
@@ -102,14 +125,15 @@ validated receipts, not in an automation prompt.
 
 ## Stage Boundary
 
-Stage 0 ships deterministic contracts, catalog visibility, a read-only
-architecture CLI, focused tests, and a public smoke. It does not ship:
+The capability now ships deterministic contracts, a provider-neutral read-only
+preparation path, catalog visibility, an architecture CLI, focused tests, and
+a public smoke. It does not ship:
 
-- a legacy material parser or migration apply path;
+- a built-in legacy material parser or migration apply path;
 - raw-material persistence;
 - an exploration provider;
 - a messaging or contact source profile;
 - automatic reranking, archive moves, or cursor advancement.
 
-Those require a read-only adapter, private dogfood, exact reconciliation, and an
-explicit owner gate.
+Those require a private read-only adapter, exact dual-read reconciliation, and
+an explicit owner gate.

--- a/docs/reference/protocols/material-lifecycle-architecture-v0.zh-CN.md
+++ b/docs/reference/protocols/material-lifecycle-architecture-v0.zh-CN.md
@@ -82,6 +82,26 @@ owner gate、验证引用、前后 revision；发生修改时还必须有 rollba
 通用 capability 不内置某种 Markdown parser 或私有目录结构。provider
 adapter 可以与旧存储长期共存，直到完成对账。
 
+## 只读准备路径
+
+`MaterialInventoryProvider` 是 legacy store 的私有 adapter 边界。它只返回
+瞬态元数据 `MaterialStoreSnapshot`：不透明 snapshot/backup 引用、revision、
+digest、生命周期计数、解析错误引用，以及三个显式验证结果：
+
+- stable material ID 已验证；
+- backup 已验证；
+- 清点前后的 source digest 一致。
+
+`prepare_material_migration` 把瞬态 snapshot 转成既有的
+`material_store_inventory_v0`。只有三个验证均通过且没有解析错误时，才生成
+`material_migration_plan_v0`；否则只返回确定性的 readiness blocker，不生成
+计划。provider contract 没有 apply 方法，两个 packet 也始终保持
+`source_mutation_authorized=false`。
+
+具体 provider 与私有文件布局留在通用 capability 之外。本地 host adapter 可以
+解析 Markdown、数据库或其他来源，但必须证明同一组只读与 backup invariant，
+LoopX 才会准备迁移。
+
 ## 决策驱动的排序与探索
 
 Stage 0 接收 Decision Context 产生的不透明 `decision_evidence_ref`。后续
@@ -95,13 +115,13 @@ provider-neutral 阶段可以据此生成小范围重排或探索意图。搜索
 
 ## 本阶段不做什么
 
-Stage 0 只交付确定性契约、catalog、只读架构 CLI、聚焦测试和公开 smoke，
-不交付：
+当前 capability 交付确定性契约、provider-neutral 的只读准备路径、catalog、
+架构 CLI、聚焦测试和公开 smoke，不交付：
 
-- legacy 素材 parser 或迁移 apply；
+- 内置 legacy 素材 parser 或迁移 apply；
 - 原始素材持久化；
 - 联网探索 provider；
 - 群聊/关键联系人 source profile；
 - 自动重排、自动归档或自动推进 cursor。
 
-这些能力必须经过只读 adapter、私有 dogfood、精确对账和显式 owner gate。
+这些能力必须经过私有只读 adapter、精确双读对账和显式 owner gate。

--- a/loopx/capabilities/material_lifecycle/__init__.py
+++ b/loopx/capabilities/material_lifecycle/__init__.py
@@ -15,6 +15,12 @@ from .lifecycle import (
     MATERIAL_LIFECYCLE_RECEIPT_SCHEMA_VERSION,
     build_material_lifecycle_receipt,
 )
+from .preparation import (
+    MaterialInventoryProvider,
+    MaterialMigrationPreparation,
+    MaterialStoreSnapshot,
+    prepare_material_migration,
+)
 from .ranking import (
     MATERIAL_RERANK_APPLY_RECEIPT_SCHEMA_VERSION,
     MATERIAL_RERANK_PROPOSAL_SCHEMA_VERSION,
@@ -30,10 +36,14 @@ __all__ = [
     "MATERIAL_RERANK_APPLY_RECEIPT_SCHEMA_VERSION",
     "MATERIAL_RERANK_PROPOSAL_SCHEMA_VERSION",
     "MATERIAL_STORE_INVENTORY_SCHEMA_VERSION",
+    "MaterialInventoryProvider",
+    "MaterialMigrationPreparation",
+    "MaterialStoreSnapshot",
     "build_material_lifecycle_architecture_packet",
     "build_material_lifecycle_receipt",
     "build_material_migration_plan",
     "build_material_rerank_apply_receipt",
     "build_material_rerank_proposal",
     "build_material_store_inventory",
+    "prepare_material_migration",
 ]

--- a/loopx/capabilities/material_lifecycle/architecture.py
+++ b/loopx/capabilities/material_lifecycle/architecture.py
@@ -65,6 +65,7 @@ def build_material_lifecycle_architecture_packet() -> dict[str, object]:
         "invariants": [
             "raw_material_and_private_locations_never_enter_public_packets",
             "source_snapshot_and_backup_precede_migration",
+            "source_digest_is_unchanged_across_read_only_inspection",
             "legacy_and_new_stores_dual_read_before_owner_gated_cutover",
             "stable_material_refs_survive_archive_and_reactivation",
             "rerank_is_a_bounded_delta_with_protected_items_and_no_change",
@@ -72,7 +73,7 @@ def build_material_lifecycle_architecture_packet() -> dict[str, object]:
             "automation_prompts_do_not_own_source_lists_or_ranking_rules",
         ],
         "next_stage": (
-            "read_only_legacy_inventory_and_migration_planner_then_"
-            "decision_driven_rerank_and_source_profile_dogfood"
+            "private_legacy_provider_dogfood_and_dual_read_reconciliation_"
+            "then_decision_driven_rerank"
         ),
     }

--- a/loopx/capabilities/material_lifecycle/preparation.py
+++ b/loopx/capabilities/material_lifecycle/preparation.py
@@ -1,0 +1,147 @@
+"""Read-only provider orchestration for backup-safe material migration."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from ._validation import compact_token
+from .inventory import (
+    build_material_migration_plan,
+    build_material_store_inventory,
+)
+
+
+class MaterialInventoryProvider(Protocol):
+    """Private adapter boundary for one read-only legacy material store."""
+
+    provider_id: str
+
+    def inspect(
+        self,
+        *,
+        store_id: str,
+        observed_at: str,
+    ) -> MaterialStoreSnapshot: ...
+
+
+@dataclass(frozen=True)
+class MaterialStoreSnapshot:
+    """Transient provider result; it carries metadata but never raw material."""
+
+    provider_id: str
+    store_id: str
+    store_revision: str
+    observed_at: str
+    source_snapshot_ref: str
+    backup_ref: str
+    source_digest: str
+    lifecycle_counts: Mapping[str, int] = field(repr=False)
+    parse_error_refs: tuple[str, ...] = ()
+    stable_ids_verified: bool = False
+    backup_verified: bool = False
+    source_unchanged_verified: bool = False
+
+
+@dataclass(frozen=True)
+class MaterialMigrationPreparation:
+    """Runtime result built from existing inventory and migration packets."""
+
+    inventory: Mapping[str, Any]
+    migration_plan: Mapping[str, Any] | None
+    readiness_blockers: tuple[str, ...]
+
+    @property
+    def ready(self) -> bool:
+        return self.migration_plan is not None and not self.readiness_blockers
+
+
+def prepare_material_migration(
+    *,
+    provider: MaterialInventoryProvider,
+    provider_id: str,
+    goal_id: str,
+    store_id: str,
+    plan_id: str,
+    target_schema: str,
+    observed_at: str,
+    rollback_ref: str,
+    protected_material_refs: Sequence[str] | None = None,
+) -> MaterialMigrationPreparation:
+    """Inspect one legacy store and build a plan only after safety checks pass."""
+
+    expected_provider_id = compact_token(provider_id, field="provider_id")
+    actual_provider_id = compact_token(
+        getattr(provider, "provider_id", ""),
+        field="provider.provider_id",
+    )
+    if actual_provider_id != expected_provider_id:
+        raise ValueError("material inventory provider identity does not match")
+
+    expected_store_id = compact_token(store_id, field="store_id")
+    snapshot = provider.inspect(
+        store_id=expected_store_id,
+        observed_at=observed_at,
+    )
+    if not isinstance(snapshot, MaterialStoreSnapshot):
+        raise TypeError("material inventory provider must return MaterialStoreSnapshot")
+    if compact_token(snapshot.provider_id, field="snapshot.provider_id") != (
+        expected_provider_id
+    ):
+        raise ValueError("material snapshot provider identity does not match")
+    if compact_token(snapshot.store_id, field="snapshot.store_id") != (
+        expected_store_id
+    ):
+        raise ValueError("material snapshot store identity does not match")
+    if not isinstance(snapshot.source_unchanged_verified, bool):
+        raise ValueError("source_unchanged_verified must be a boolean")
+
+    inventory = build_material_store_inventory(
+        goal_id=goal_id,
+        store_id=snapshot.store_id,
+        store_revision=snapshot.store_revision,
+        observed_at=snapshot.observed_at,
+        source_snapshot_ref=snapshot.source_snapshot_ref,
+        backup_ref=snapshot.backup_ref,
+        source_digest=snapshot.source_digest,
+        lifecycle_counts=snapshot.lifecycle_counts,
+        parse_error_refs=snapshot.parse_error_refs,
+        stable_ids_verified=snapshot.stable_ids_verified,
+        backup_verified=snapshot.backup_verified,
+    )
+
+    blockers: list[str] = []
+    if not snapshot.source_unchanged_verified:
+        blockers.append("source_unchanged_unverified")
+    if not snapshot.backup_verified:
+        blockers.append("backup_unverified")
+    if not snapshot.stable_ids_verified:
+        blockers.append("stable_ids_unverified")
+    if snapshot.parse_error_refs:
+        blockers.append("parse_errors_present")
+
+    if blockers:
+        return MaterialMigrationPreparation(
+            inventory=inventory,
+            migration_plan=None,
+            readiness_blockers=tuple(blockers),
+        )
+
+    plan = build_material_migration_plan(
+        goal_id=goal_id,
+        plan_id=plan_id,
+        inventory_ref=str(inventory["inventory_ref"]),
+        source_revision=snapshot.store_revision,
+        target_schema=target_schema,
+        observed_at=snapshot.observed_at,
+        backup_ref=snapshot.backup_ref,
+        rollback_ref=rollback_ref,
+        expected_item_count=int(inventory["item_count"]),
+        protected_material_refs=protected_material_refs,
+    )
+    return MaterialMigrationPreparation(
+        inventory=inventory,
+        migration_plan=plan,
+        readiness_blockers=(),
+    )

--- a/tests/capabilities/test_material_lifecycle_preparation.py
+++ b/tests/capabilities/test_material_lifecycle_preparation.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from loopx.capabilities.material_lifecycle import (
+    MaterialMigrationPreparation,
+    MaterialStoreSnapshot,
+    prepare_material_migration,
+)
+
+OBSERVED_AT = "2026-07-25T22:55:00+00:00"
+
+
+class FakeInventoryProvider:
+    provider_id = "private-legacy-store"
+
+    def __init__(self, snapshot: MaterialStoreSnapshot) -> None:
+        self.snapshot = snapshot
+        self.calls: list[tuple[str, str]] = []
+
+    def inspect(
+        self,
+        *,
+        store_id: str,
+        observed_at: str,
+    ) -> MaterialStoreSnapshot:
+        self.calls.append((store_id, observed_at))
+        return self.snapshot
+
+
+def ready_snapshot() -> MaterialStoreSnapshot:
+    return MaterialStoreSnapshot(
+        provider_id="private-legacy-store",
+        store_id="store:learning-materials",
+        store_revision="revision:42",
+        observed_at=OBSERVED_AT,
+        source_snapshot_ref="snapshot:revision-42",
+        backup_ref="backup:revision-42",
+        source_digest="sha256:0123456789abcdef",
+        lifecycle_counts={
+            "candidate": 30,
+            "active": 10,
+            "archived": 200,
+            "unread": 5,
+            "carryover": 2,
+        },
+        stable_ids_verified=True,
+        backup_verified=True,
+        source_unchanged_verified=True,
+    )
+
+
+def prepare(provider: FakeInventoryProvider) -> MaterialMigrationPreparation:
+    return prepare_material_migration(
+        provider=provider,
+        provider_id="private-legacy-store",
+        goal_id="goal:material-example",
+        store_id="store:learning-materials",
+        plan_id="plan:migrate-v0",
+        target_schema="material_store_v0",
+        observed_at=OBSERVED_AT,
+        rollback_ref="rollback:revision-42",
+        protected_material_refs=["material:pinned"],
+    )
+
+
+def test_preparation_builds_existing_packets_without_source_write_surface() -> None:
+    provider = FakeInventoryProvider(ready_snapshot())
+
+    first = prepare(provider)
+    second = prepare(provider)
+
+    assert first == second
+    assert first.ready is True
+    assert first.readiness_blockers == ()
+    assert first.inventory["item_count"] == 247
+    assert first.inventory["source_mutation_authorized"] is False
+    assert first.migration_plan is not None
+    assert first.migration_plan["expected_item_count"] == 247
+    assert first.migration_plan["source_mutation_authorized"] is False
+    assert provider.calls == [
+        ("store:learning-materials", OBSERVED_AT),
+        ("store:learning-materials", OBSERVED_AT),
+    ]
+    assert not hasattr(provider, "apply")
+
+
+@pytest.mark.parametrize(
+    ("snapshot", "expected_blockers"),
+    [
+        (
+            replace(ready_snapshot(), source_unchanged_verified=False),
+            ("source_unchanged_unverified",),
+        ),
+        (
+            replace(ready_snapshot(), backup_verified=False),
+            ("backup_unverified",),
+        ),
+        (
+            replace(ready_snapshot(), stable_ids_verified=False),
+            ("stable_ids_unverified",),
+        ),
+        (
+            replace(
+                ready_snapshot(),
+                parse_error_refs=("parse-error:duplicate-id",),
+            ),
+            ("parse_errors_present",),
+        ),
+    ],
+)
+def test_preparation_fails_closed_before_plan(
+    snapshot: MaterialStoreSnapshot,
+    expected_blockers: tuple[str, ...],
+) -> None:
+    result = prepare(FakeInventoryProvider(snapshot))
+
+    assert result.ready is False
+    assert result.migration_plan is None
+    assert result.readiness_blockers == expected_blockers
+    assert result.inventory["source_mutation_authorized"] is False
+
+
+def test_preparation_reports_all_readiness_blockers_deterministically() -> None:
+    snapshot = replace(
+        ready_snapshot(),
+        source_unchanged_verified=False,
+        backup_verified=False,
+        stable_ids_verified=False,
+        parse_error_refs=("parse-error:1",),
+    )
+
+    result = prepare(FakeInventoryProvider(snapshot))
+
+    assert result.readiness_blockers == (
+        "source_unchanged_unverified",
+        "backup_unverified",
+        "stable_ids_unverified",
+        "parse_errors_present",
+    )
+
+
+def test_preparation_rejects_provider_and_store_identity_drift() -> None:
+    provider = FakeInventoryProvider(ready_snapshot())
+    provider.provider_id = "other-provider"
+    with pytest.raises(ValueError, match="provider identity"):
+        prepare(provider)
+
+    wrong_snapshot = replace(ready_snapshot(), store_id="store:other")
+    with pytest.raises(ValueError, match="store identity"):
+        prepare(FakeInventoryProvider(wrong_snapshot))
+
+
+def test_preparation_rejects_private_locations_before_plan() -> None:
+    snapshot = replace(
+        ready_snapshot(),
+        source_snapshot_ref="/Users/example/private-materials.md",
+    )
+
+    with pytest.raises(ValueError, match="local path"):
+        prepare(FakeInventoryProvider(snapshot))
+
+
+def test_preparation_rejects_non_boolean_source_verification() -> None:
+    snapshot = replace(
+        ready_snapshot(),
+        source_unchanged_verified="yes",  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(ValueError, match="must be a boolean"):
+        prepare(FakeInventoryProvider(snapshot))


### PR DESCRIPTION
## Summary

- add a provider-neutral, read-only preparation path for legacy material stores
- reuse the existing inventory and migration-plan packets instead of adding a new serialized protocol
- fail closed unless backup, stable IDs, unchanged source digest, and parse health are verified

## Boundary

- no built-in legacy parser or private file layout
- no raw material persistence
- no apply or source mutation surface
- provider-specific adapters remain private and replaceable

## Validation

- `19 passed` across Material Lifecycle contract and preparation tests
- Material Lifecycle public contract smoke passed
- capability-extension registry smoke passed
- standard premerge canary passed, including public/private boundary scan

## Architecture judgment

This is a narrow runtime bridge from provider metadata to existing public-safe packets. It keeps migration authority outside the capability and only exposes a deterministic readiness decision.
