### PR TITLE
fix(quota): preserve as-needed watch acknowledgements

### DIFF
--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -52,6 +52,18 @@ SIDE_AGENT_REPLAN_OBLIGATION = {
     ],
 }
 
+SIDE_AGENT_DEAD_MONITOR_REPLAN_OBLIGATION = {
+    **GLOBAL_REPLAN_OBLIGATION,
+    "triggers": [
+        {
+            "kind": "dead_monitor_repeat",
+            "source": "run_history",
+            "agent_id": SIDE_AGENT,
+            "monitor_target_id": "fixture-monitor-target",
+        }
+    ],
+}
+
 
 def monitor_item(
     *,
@@ -366,6 +378,30 @@ def watch_lane_continuation_ack_run(
             },
         },
     }
+
+
+def unchanged_heartbeat_monitor_runs() -> list[dict]:
+    return [
+        {
+            "classification": "quota_monitor_poll",
+            "generated_at": generated_at,
+            "agent_id": SIDE_AGENT,
+            "turn_instance_id": turn_instance_id,
+            "recommended_action": "Keep the as-needed watch lane quiet.",
+            "delivery_outcome": "surface_only",
+            "monitor_target": {
+                "schema_version": "quota_monitor_target_v0",
+                "target_id": "fixture-monitor-target",
+                "monitor_mode": "monitor_quiet_until_material_transition",
+                "effective_action": "monitor_quiet_skip",
+                "agent_id": SIDE_AGENT,
+            },
+        }
+        for generated_at, turn_instance_id in (
+            ("2026-07-04T00:03:00+00:00", "heartbeat-turn-2"),
+            ("2026-07-04T00:02:00+00:00", "heartbeat-turn-1"),
+        )
+    ]
 
 
 def material_progress_runs_after_replan_ack(count: int) -> list[dict]:
@@ -1619,6 +1655,64 @@ def assert_explicit_as_needed_vision_gap_uses_watch_lane_continuation_ack() -> N
     assert "autonomous_replan_ack_alone" in guard["vision_continuation_audit"]["not_satisfied_by"], guard
 
 
+def assert_as_needed_watch_ack_covers_repeated_heartbeat_receipts() -> None:
+    latest_runs = [
+        *unchanged_heartbeat_monitor_runs(),
+        watch_lane_continuation_ack_run(),
+        agent_vision_gap_run(),
+    ]
+    guard = build_quota_should_run(
+        status_payload(
+            [monitor_item()],
+            replan_obligation=SIDE_AGENT_DEAD_MONITOR_REPLAN_OBLIGATION,
+            latest_runs=latest_runs,
+        ),
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert guard["decision"] == "skip", guard
+    assert guard["effective_action"] == "monitor_quiet_skip", guard
+    assert guard["goal_frontier_projection"]["replan_required"] is False, guard
+    assert guard.get("autonomous_replan_obligation") is None, guard
+
+    due_guard = build_quota_should_run(
+        status_payload(
+            [monitor_item(next_due_at="2000-01-01T00:00:00+00:00")],
+            replan_obligation=SIDE_AGENT_DEAD_MONITOR_REPLAN_OBLIGATION,
+            latest_runs=latest_runs,
+        ),
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert due_guard["decision"] == "run", due_guard
+    assert due_guard["effective_action"] == "normal_run", due_guard
+    assert due_guard["work_lane_contract"]["obligation"] == "attempt_due_monitor", due_guard
+    assert due_guard.get("autonomous_replan_obligation") is None, due_guard
+
+
+def assert_repeat_vision_keeps_repeated_heartbeat_replan() -> None:
+    guard = build_quota_should_run(
+        status_payload(
+            [monitor_item()],
+            replan_obligation=SIDE_AGENT_DEAD_MONITOR_REPLAN_OBLIGATION,
+            latest_runs=[
+                *unchanged_heartbeat_monitor_runs(),
+                watch_lane_continuation_ack_run(),
+                agent_vision_acceptance_only_run(
+                    advancement_policy="repeat_until_closed"
+                ),
+            ],
+        ),
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert guard["decision"] == "autonomous_replan_required", guard
+    assert guard["effective_action"] == "autonomous_replan_required", guard
+    assert guard["goal_frontier_projection"]["replan_required"] is True, guard
+    obligation = guard["autonomous_replan_obligation"]
+    assert obligation["triggers"][0]["kind"] == "dead_monitor_repeat", guard
+
+
 def assert_blocking_handoff_gate_beats_derived_monitor_replan() -> None:
     guard = build_quota_should_run(
         status_payload([monitor_item(), blocking_handoff_review()], replan_obligation=None),
@@ -1670,6 +1764,8 @@ def main() -> None:
     assert_non_frontier_replan_ack_does_not_clear_monitor_replan()
     assert_projected_replan_ack_is_agent_scoped()
     assert_explicit_as_needed_vision_gap_uses_watch_lane_continuation_ack()
+    assert_as_needed_watch_ack_covers_repeated_heartbeat_receipts()
+    assert_repeat_vision_keeps_repeated_heartbeat_replan()
     assert_blocking_handoff_gate_beats_derived_monitor_replan()
     print("quota-replan-decision-plane-smoke ok")
 

--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -305,6 +305,41 @@ def _autonomous_replan_ack_has_delta_kind(
     }
 
 
+def _watch_lane_ack_covers_dead_monitor_repeat(
+    ack: dict[str, Any] | None,
+    *,
+    replan_obligation: dict[str, Any] | None,
+    acceptance_gaps: list[dict[str, Any]],
+) -> bool:
+    """Keep an as-needed watch ACK valid across unchanged heartbeat receipts."""
+
+    trigger_kinds = {
+        str(trigger.get("kind") or "").strip()
+        for trigger in (
+            replan_obligation.get("triggers") or []
+            if isinstance(replan_obligation, dict)
+            else []
+        )
+        if isinstance(trigger, dict)
+    }
+    if trigger_kinds != {"dead_monitor_repeat"}:
+        return False
+    if not _autonomous_replan_ack_has_delta_kind(
+        ack,
+        delta_kind="watch_lane_continuation",
+    ):
+        return False
+    if not acceptance_gaps or any(
+        gap.get("kind") != "vision_acceptance_gap"
+        for gap in acceptance_gaps
+    ):
+        return False
+    return not any(
+        goal_vision_repeats_advancement_until_closed(gap.get("advancement_policy"))
+        for gap in acceptance_gaps
+    )
+
+
 def autonomous_replan_decision_allowed(
     *,
     replan_obligation: dict[str, Any] | None,
@@ -1823,6 +1858,13 @@ def build_goal_frontier_projection_context_from_status(
         agent_id=agent_id,
     )
     effective_replan_ack = latest_agent_replan_ack or projected_replan_ack
+    watch_lane_ack_covers_dead_monitor_repeat = (
+        _watch_lane_ack_covers_dead_monitor_repeat(
+            effective_replan_ack,
+            replan_obligation=replan_obligation,
+            acceptance_gaps=acceptance_gaps,
+        )
+    )
     if (
         autonomous_replan_is_required(replan_obligation)
         and autonomous_replan_ack_satisfies_obligation(
@@ -1834,7 +1876,10 @@ def build_goal_frontier_projection_context_from_status(
             effective_replan_ack,
             replan_obligation,
         )
-        and not acceptance_gaps
+        and (
+            not acceptance_gaps
+            or watch_lane_ack_covers_dead_monitor_repeat
+        )
     ):
         replan_obligation = None
         replan_scope = autonomous_replan_scope_decision(


### PR DESCRIPTION
## Summary

- keep a valid `watch_lane_continuation` acknowledgement authoritative across repeated unchanged heartbeat receipts when the remaining vision gap is explicitly as-needed
- continue to wake due monitors normally
- preserve replan behavior for `repeat_until_closed`, missing vision checkpoints, mixed triggers, and non-watch acknowledgements

## Root cause

Distinct heartbeat receipts intentionally lower the dead-monitor threshold to two polls. The resulting `dead_monitor_repeat` obligation was evaluated before the goal-frontier reducer, which refused to clear any obligation while an acceptance gap remained. That made an already-acknowledged as-needed watch lane replan again after every two unchanged receipts.

## Validation

Changed surfaces: goal-frontier quota reduction and the focused quota decision-plane smoke.

- `python3 examples/control_plane/quota-replan-decision-plane-smoke.py`
- `python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `python3 examples/control_plane/autonomous-replan-obligation-readmodel-smoke.py`
- `python3 examples/control_plane/goal-frontier-replan-rules-smoke.py`
- Ruff check on both changed files
- `git diff --check`
- `loopx canary premerge --from-git-diff`: 18/18 selected checks passed, including control-plane composition, heartbeat quota flow, goal-frontier rules, canary runner profiles, and the public/private boundary scan

Failures/skips: none. Manual holds: none. This coverage exercises the positive as-needed path plus the due-monitor, repeat-until-closed, and missing-vision negative boundaries without changing scheduler or persisted ACK schemas.

## Merge decision

Ready for independent review. This changes core quota behavior, so it is not self-merged despite the local canary gate passing.
