### PR TITLE
fix(skillsbench): validate progress after idle timeout

### DIFF
--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -32,6 +32,7 @@ from loopx.benchmark_adapters.skillsbench_remote_bridge import (
     run_skillsbench_remote_command_file_bridge_probe,
 )
 from loopx.benchmark_adapters.skillsbench_turn_runtime import (
+    SKILLSBENCH_TURN_AGENT_VALIDATION_HANDOFF_RESPONSE,
     SkillsBenchTurnAgentResult,
     run_skillsbench_loopx_turn_relay,
 )
@@ -480,6 +481,32 @@ def _codex_exec_same_session_continuation_allowed(
         continuation_count >= CODEX_EXEC_SAME_SESSION_CONTINUATION_LIMIT
         or category not in RECOVERABLE_CODEX_TURN_FAILURE_CATEGORIES
         or not thread_present
+        or final_message_present
+        or bridge_summary_path is None
+        or turn_deadline is not None
+        and time.monotonic() >= turn_deadline
+        or _bridge_summary_has_inflight_operation(bridge_summary_path)
+    ):
+        return False
+    receipt = _bridge_summary_task_progress_receipt(bridge_summary_path)
+    return bool(
+        receipt.get("task_facing_operation_count", 0) > 0
+        and receipt.get("task_facing_success_count", 0) > 0
+        and receipt.get("raw_material_recorded") is False
+    )
+
+
+def _codex_exec_progress_validation_handoff_allowed(
+    *,
+    category: str,
+    bridge_summary_path: Path | None,
+    continuation_count: int,
+    final_message_present: bool,
+    turn_deadline: float | None,
+) -> bool:
+    if (
+        category != "codex_exec_bridge_idle_timeout"
+        or continuation_count < CODEX_EXEC_SAME_SESSION_CONTINUATION_LIMIT
         or final_message_present
         or bridge_summary_path is None
         or turn_deadline is not None
@@ -1134,6 +1161,19 @@ class SkillsBenchLocalAcpRelay:
                                     turn_deadline=_turn_deadline,
                                 )
                             )
+                            validation_handoff_scheduled = (
+                                _bypass_loopx_turn
+                                and self._config.loopx_turn_agent_cli
+                                and _codex_exec_progress_validation_handoff_allowed(
+                                    category="codex_exec_bridge_idle_timeout",
+                                    bridge_summary_path=bridge_summary_path,
+                                    continuation_count=(
+                                        _same_session_continuation_count
+                                    ),
+                                    final_message_present=output_path.exists(),
+                                    turn_deadline=_turn_deadline,
+                                )
+                            )
                             self._publish_remote_bridge_agent_operations_trace(
                                 bridge_summary_path=bridge_summary_path,
                             )
@@ -1154,6 +1194,9 @@ class SkillsBenchLocalAcpRelay:
                                 ),
                                 same_session_continuation_scheduled=(
                                     continuation_scheduled
+                                ),
+                                independent_validation_handoff_scheduled=(
+                                    validation_handoff_scheduled
                                 ),
                             )
                             if continuation_scheduled:
@@ -1208,6 +1251,15 @@ class SkillsBenchLocalAcpRelay:
                                     ),
                                 )
                                 return response
+                            if validation_handoff_scheduled:
+                                self._latest_loopx_turn_agent_progress_receipt = (
+                                    _bridge_summary_task_progress_receipt(
+                                        bridge_summary_path
+                                    )
+                                )
+                                return (
+                                    SKILLSBENCH_TURN_AGENT_VALIDATION_HANDOFF_RESPONSE
+                                )
                             return _recoverable_codex_turn_failure_message(
                                 "codex_exec_bridge_idle_timeout"
                             )
@@ -3401,6 +3453,7 @@ raise SystemExit(proc.returncode)
         session_rollover_scheduled: bool = False,
         same_session_continuation_index: int = 0,
         same_session_continuation_scheduled: bool = False,
+        independent_validation_handoff_scheduled: bool = False,
     ) -> None:
         if not self._config.worker_public_trace_dir:
             return
@@ -3442,6 +3495,9 @@ raise SystemExit(proc.returncode)
                 ),
                 "same_session_continuation_scheduled": bool(
                     same_session_continuation_scheduled
+                ),
+                "independent_validation_handoff_scheduled": bool(
+                    independent_validation_handoff_scheduled
                 ),
                 "returncode": (
                     returncode

--- a/loopx/benchmark_adapters/skillsbench_turn_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_turn_runtime.py
@@ -41,6 +41,9 @@ SKILLSBENCH_TURN_SEQUENCE_BASELINE_ENV = "LOOPX_TURN_SEQUENCE_BASELINE_FILE"
 SKILLSBENCH_LOOPX_TURN_TERMINAL_POLICIES = frozenset(
     {"validator", "fixed-n", "stability"}
 )
+SKILLSBENCH_TURN_AGENT_VALIDATION_HANDOFF_RESPONSE = (
+    "bounded task-facing progress awaits independent scored-workspace validation"
+)
 
 
 @dataclass(frozen=True)
@@ -274,18 +277,29 @@ def _host_result(request: Mapping[str, Any], response: str) -> dict[str, Any]:
     recoverable_failure = response.startswith(RECOVERABLE_CODEX_TURN_FAILURE_PREFIX)
     if recoverable_failure:
         raise SkillsBenchTurnAgentFailure("agent CLI execution requires repair")
+    validation_handoff = (
+        response == SKILLSBENCH_TURN_AGENT_VALIDATION_HANDOFF_RESPONSE
+    )
     return {
         "schema_version": "loopx_turn_result_v0",
         "turn_key": turn_key,
         "result_kind": "validated_progress",
         "completed_phases": ["host_execute", "typed_result"],
-        "classification": "skillsbench_loopx_turn_agent_cli_progress",
+        "classification": (
+            "skillsbench_loopx_turn_agent_cli_validation_handoff"
+            if validation_handoff
+            else "skillsbench_loopx_turn_agent_cli_progress"
+        ),
         "recommended_action": "continue from the case-local LoopX frontier if work remains",
         "next_action": "use the next typed Turn rather than an ungoverned prompt poll",
         "delivery_batch_scale": "single_surface",
         "delivery_outcome": "outcome_progress",
         "vision_unchanged_reason": "the benchmark case objective is unchanged",
-        "summary": "agent CLI completed one bounded scored-workspace turn",
+        "summary": (
+            "agent CLI yielded bounded task-facing progress for independent validation"
+            if validation_handoff
+            else "agent CLI completed one bounded scored-workspace turn"
+        ),
     }
 
 

--- a/tests/test_skillsbench_turn_runtime.py
+++ b/tests/test_skillsbench_turn_runtime.py
@@ -1230,6 +1230,135 @@ pathlib.Path(sys.argv[output_index]).write_text("bounded turn complete", encodin
     assert "thread-single-001" not in public_trace_text
 
 
+def test_skillsbench_single_turn_codex_exec_hands_exhausted_progress_to_validator(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    invocation_log = tmp_path / "invocations.jsonl"
+    fake_codex = tmp_path / "fake-codex"
+    fake_codex.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import sys
+import time
+
+log_path = pathlib.Path(os.environ["FAKE_CODEX_INVOCATION_LOG"])
+with log_path.open("a", encoding="utf-8") as handle:
+    handle.write(json.dumps({"argv": sys.argv[1:]}) + "\\n")
+print(json.dumps({"type": "thread.started", "thread_id": "private-thread"}), flush=True)
+time.sleep(10)
+""",
+        encoding="utf-8",
+    )
+    fake_codex.chmod(0o755)
+    monkeypatch.setenv("FAKE_CODEX_INVOCATION_LOG", str(invocation_log))
+    trace_dir = tmp_path / "public-traces"
+    trace_dir.mkdir()
+    relay = SkillsBenchLocalAcpRelay(
+        CodexExecConfig(
+            codex_bin=str(fake_codex),
+            loopx_turn_agent_cli=True,
+            loopx_turn_max_turns=1,
+            remote_command_file_bridge_command="synthetic-bridge",
+            worker_public_trace_dir=str(trace_dir),
+            bridge_idle_timeout_sec=0.25,
+            timeout_sec=30,
+        )
+    )
+    monkeypatch.setattr(
+        relay,
+        "_consume_remote_bridge_for_solver",
+        lambda: {"ready": True},
+    )
+    monkeypatch.setattr(
+        relay,
+        "_publish_remote_bridge_consumption_trace",
+        lambda _probe: None,
+    )
+    monkeypatch.setattr(
+        relay,
+        "_start_json_file_bridge_server",
+        lambda **_kwargs: ("synthetic-agent-bridge", None),
+    )
+
+    def write_progress_summary(**kwargs: Any) -> Path:
+        kwargs["summary_path"].write_text(
+            json.dumps(
+                {
+                    "record_phase": "complete",
+                    "operation": "run_command",
+                    "task_facing_operation": True,
+                    "success": True,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return kwargs["tmp_path"] / "synthetic-wrapper"
+
+    monkeypatch.setattr(
+        relay,
+        "_write_instrumented_bridge_wrapper",
+        write_progress_summary,
+    )
+    monkeypatch.setattr(
+        relay,
+        "_prompt_with_remote_bridge_packet",
+        lambda prompt, **_kwargs: prompt,
+    )
+    monkeypatch.setattr(
+        relay,
+        "_publish_remote_bridge_agent_operations_trace",
+        lambda **_kwargs: None,
+    )
+
+    result = relay._run_loopx_turn_agent_prompt(
+        "private task fixture",
+        session={"cwd": str(tmp_path), "model": None},
+        session_id="fixture-session",
+        stdout=SimpleNamespace(write=lambda _value: None, flush=lambda: None),
+        turn_deadline=time.monotonic() + 20,
+    )
+
+    assert (
+        result.response_text
+        == runtime.SKILLSBENCH_TURN_AGENT_VALIDATION_HANDOFF_RESPONSE
+    )
+    assert result.progress_evidence["task_facing_operation_count"] == 1
+    assert result.progress_evidence["task_facing_success_count"] == 1
+    assert result.progress_evidence["raw_material_recorded"] is False
+    assert len(invocation_log.read_text(encoding="utf-8").splitlines()) == 2
+    traces = [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in trace_dir.glob("*.compact.json")
+    ]
+    assert any(
+        trace.get("trace_kind") == "codex_exec_process_failure"
+        and trace["codex_exec_process"][
+            "independent_validation_handoff_scheduled"
+        ]
+        is True
+        for trace in traces
+    )
+    assert "private task fixture" not in json.dumps(traces, sort_keys=True)
+    assert "private-thread" not in json.dumps(traces, sort_keys=True)
+
+
+def test_skillsbench_progress_validation_handoff_is_not_host_completion() -> None:
+    result = runtime._host_result(
+        {"turn_key": "synthetic-turn"},
+        runtime.SKILLSBENCH_TURN_AGENT_VALIDATION_HANDOFF_RESPONSE,
+    )
+
+    assert (
+        result["classification"]
+        == "skillsbench_loopx_turn_agent_cli_validation_handoff"
+    )
+    assert "independent validation" in result["summary"]
+
+
 def test_codex_exec_transport_retry_requires_no_task_facing_operation(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- hand exhausted, progressful Codex bridge-idle recovery to the existing independent scored-workspace validator
- preserve a compact public-safe bridge progress receipt without treating the host interruption as completion
- record the handoff in compact public traces and cover the continuation-exhaustion path

## Validation
- `uv run --with pytest python -m pytest tests/test_skillsbench_turn_runtime.py -q` (37 passed)
- `uv run --with ruff ruff check ...`
- `loopx canary premerge --from-git-diff` (all 6 selected canaries passed; expected benchmark-sensitive manual hold reviewed under owner-authorized benchmark helper self-merge policy)
- boundary scan: no raw tasks, trajectories, verifier output, credentials, local paths, uploads, submissions, scoring changes, or benchmark launches