### PR TITLE
feat(material-lifecycle): add owner-gated cutover

### DIFF
--- a/docs/reference/protocols/material-lifecycle-architecture-v0.md
+++ b/docs/reference/protocols/material-lifecycle-architecture-v0.md
@@ -110,6 +110,32 @@ capability. A host adapter may parse Markdown, a database, or another source,
 but it must prove the same read-only and backup invariants before LoopX will
 prepare migration.
 
+## Owner-Gated Apply and Rollback
+
+`MaterialMigrationApplyProvider` is the private write adapter boundary. The
+generic capability never receives raw material or a private location. It
+orchestrates five explicit steps:
+
+1. compare-and-swap the current authority revision against the prepared source;
+2. stage the target store with an atomic write and verified readback;
+3. recheck the source authority revision after staging;
+4. reconcile stable IDs, item counts, lifecycle counts, and content parity
+   under dual read;
+5. atomically switch the authority pointer with an explicit owner-gate
+   reference.
+
+`material_migration_apply_receipt_v0` records the before/after revisions,
+target digest, item and lifecycle counts, reconciliation reference, authority
+reference, rollback reference, and the verified CAS/atomic-write/readback
+invariants. It remains public-safe and content-free.
+
+Rollback uses the same authority-pointer CAS. It only proceeds while the
+currently authoritative revision still equals the applied target revision,
+requires a separate owner-gate reference, and emits
+`material_migration_rollback_receipt_v0`. The provider owns filesystem,
+database, or object-store mechanics; the capability owns ordering, validation,
+and auditable receipts.
+
 ## Decision-Driven Ranking and Exploration
 
 The provider-neutral decision-planning path accepts a validated, public-safe
@@ -136,10 +162,11 @@ validated receipts, not in an automation prompt.
 ## Stage Boundary
 
 The capability now ships deterministic contracts, a provider-neutral read-only
-preparation path, bounded decision planning, catalog visibility, an
-architecture CLI, focused tests, and a public smoke. It does not ship:
+preparation path, owner-gated apply/rollback orchestration, bounded decision
+planning, catalog visibility, an architecture CLI, focused tests, and a public
+smoke. It does not ship:
 
-- a built-in legacy material parser or migration apply path;
+- a built-in legacy material parser or private write adapter;
 - raw-material persistence;
 - a built-in decision policy;
 - an exploration provider;

--- a/docs/reference/protocols/material-lifecycle-architecture-v0.zh-CN.md
+++ b/docs/reference/protocols/material-lifecycle-architecture-v0.zh-CN.md
@@ -102,6 +102,26 @@ digest、生命周期计数、解析错误引用，以及三个显式验证结�
 解析 Markdown、数据库或其他来源，但必须证明同一组只读与 backup invariant，
 LoopX 才会准备迁移。
 
+## Owner-Gated Apply 与回滚
+
+`MaterialMigrationApplyProvider` 是私有写 adapter 边界。通用 capability 不接收原始
+材料或私有位置，只编排五个显式步骤：
+
+1. 用准备阶段的 source revision 对当前 authority 做 compare-and-swap；
+2. 以原子写入和读回验证生成 staged store；
+3. staging 后再次检查 source authority revision；
+4. 双读对账 stable ID、item count、lifecycle count 与 content parity；
+5. 携带显式 owner-gate reference，原子切换 authority pointer。
+
+`material_migration_apply_receipt_v0` 记录 before/after revision、target digest、item 与
+lifecycle count、reconciliation reference、authority reference、rollback reference，
+以及已验证的 CAS、原子写入和读回不变量。Receipt 仍保持 public-safe，不携带正文。
+
+回滚复用同一个 authority-pointer CAS。只有当前 authority 仍等于已应用的 target
+revision 时才继续，且需要独立 owner-gate reference，最终生成
+`material_migration_rollback_receipt_v0`。Provider 负责文件系统、数据库或对象存储的
+具体机制；capability 负责顺序、不变量和可审计 receipt。
+
 ## 决策驱动的排序与探索
 
 provider-neutral 的决策规划路径接收 Decision Context 产出的、经过验证且
@@ -122,10 +142,11 @@ provider 调用数、新增候选数与显式 stop condition。它仅用于分�
 
 ## 本阶段不做什么
 
-当前 capability 交付确定性契约、provider-neutral 的只读准备路径、受限决策
-规划、catalog、架构 CLI、聚焦测试和公开 smoke，不交付：
+当前 capability 交付确定性契约、provider-neutral 的只读准备路径、owner-gated
+apply/rollback 编排、受限决策规划、catalog、架构 CLI、聚焦测试和公开 smoke，
+不交付：
 
-- 内置 legacy 素材 parser 或迁移 apply；
+- 内置 legacy 素材 parser 或私有写 adapter；
 - 原始素材持久化；
 - 内置决策 policy；
 - 联网探索 provider；

--- a/loopx/capabilities/material_lifecycle/__init__.py
+++ b/loopx/capabilities/material_lifecycle/__init__.py
@@ -1,5 +1,16 @@
 """Goal-scoped Material Lifecycle capability contracts."""
 
+from .apply import (
+    MATERIAL_MIGRATION_APPLY_RECEIPT_SCHEMA_VERSION,
+    MATERIAL_MIGRATION_ROLLBACK_RECEIPT_SCHEMA_VERSION,
+    MaterialAuthoritySnapshot,
+    MaterialAuthorityTransition,
+    MaterialDualReadReconciliation,
+    MaterialMigrationApplyProvider,
+    MaterialStagedStore,
+    apply_material_migration,
+    rollback_material_migration,
+)
 from .architecture import (
     MATERIAL_LIFECYCLE_ARCHITECTURE_SCHEMA_VERSION,
     build_material_lifecycle_architecture_packet,
@@ -37,27 +48,36 @@ from .ranking import (
 )
 
 __all__ = [
+    "MATERIAL_EXPLORE_INTENT_SCHEMA_VERSION",
     "MATERIAL_LIFECYCLE_ARCHITECTURE_SCHEMA_VERSION",
     "MATERIAL_LIFECYCLE_RECEIPT_SCHEMA_VERSION",
     "MATERIAL_LIFECYCLE_STATES",
-    "MATERIAL_EXPLORE_INTENT_SCHEMA_VERSION",
+    "MATERIAL_MIGRATION_APPLY_RECEIPT_SCHEMA_VERSION",
     "MATERIAL_MIGRATION_PLAN_SCHEMA_VERSION",
+    "MATERIAL_MIGRATION_ROLLBACK_RECEIPT_SCHEMA_VERSION",
     "MATERIAL_RERANK_APPLY_RECEIPT_SCHEMA_VERSION",
     "MATERIAL_RERANK_PROPOSAL_SCHEMA_VERSION",
     "MATERIAL_STORE_INVENTORY_SCHEMA_VERSION",
-    "MaterialInventoryProvider",
+    "MaterialAuthoritySnapshot",
+    "MaterialAuthorityTransition",
     "MaterialDecisionPlanning",
     "MaterialDecisionPolicy",
     "MaterialDecisionPolicyResult",
+    "MaterialDualReadReconciliation",
+    "MaterialInventoryProvider",
+    "MaterialMigrationApplyProvider",
     "MaterialMigrationPreparation",
+    "MaterialStagedStore",
     "MaterialStoreSnapshot",
+    "apply_material_migration",
+    "build_material_explore_intent",
     "build_material_lifecycle_architecture_packet",
     "build_material_lifecycle_receipt",
-    "build_material_explore_intent",
     "build_material_migration_plan",
     "build_material_rerank_apply_receipt",
     "build_material_rerank_proposal",
     "build_material_store_inventory",
     "plan_material_decision_actions",
     "prepare_material_migration",
+    "rollback_material_migration",
 ]

--- a/loopx/capabilities/material_lifecycle/apply.py
+++ b/loopx/capabilities/material_lifecycle/apply.py
@@ -1,0 +1,672 @@
+"""Owner-gated apply and rollback orchestration for material migrations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from ._validation import (
+    capability_contract,
+    check_record_keys,
+    compact_token,
+    iso_timestamp,
+    nonnegative_int,
+    packet_ref,
+)
+from .inventory import (
+    MATERIAL_LIFECYCLE_STATES,
+    MATERIAL_MIGRATION_PLAN_SCHEMA_VERSION,
+)
+
+MATERIAL_MIGRATION_APPLY_RECEIPT_SCHEMA_VERSION = "material_migration_apply_receipt_v0"
+MATERIAL_MIGRATION_ROLLBACK_RECEIPT_SCHEMA_VERSION = (
+    "material_migration_rollback_receipt_v0"
+)
+
+
+class MaterialMigrationApplyProvider(Protocol):
+    """Private adapter boundary for staged writes and authority-pointer CAS."""
+
+    provider_id: str
+
+    def inspect_authority(
+        self,
+        *,
+        store_id: str,
+        observed_at: str,
+    ) -> MaterialAuthoritySnapshot: ...
+
+    def stage(
+        self,
+        *,
+        store_id: str,
+        plan_ref: str,
+        source_revision: str,
+        target_schema: str,
+        owner_gate_ref: str,
+        observed_at: str,
+    ) -> MaterialStagedStore: ...
+
+    def reconcile(
+        self,
+        *,
+        store_id: str,
+        source_revision: str,
+        target_revision: str,
+        observed_at: str,
+    ) -> MaterialDualReadReconciliation: ...
+
+    def switch_authority(
+        self,
+        *,
+        store_id: str,
+        expected_revision: str,
+        target_revision: str,
+        owner_gate_ref: str,
+        observed_at: str,
+    ) -> MaterialAuthorityTransition: ...
+
+
+@dataclass(frozen=True)
+class MaterialAuthoritySnapshot:
+    """Current authority pointer observed by a private provider."""
+
+    provider_id: str
+    store_id: str
+    authority_revision: str
+    observed_at: str
+
+
+@dataclass(frozen=True)
+class MaterialStagedStore:
+    """Validated staging result without raw content or private locations."""
+
+    provider_id: str
+    store_id: str
+    source_revision: str
+    target_revision: str
+    target_schema: str
+    target_store_ref: str
+    target_digest: str
+    item_count: int
+    lifecycle_counts: Mapping[str, int] = field(repr=False)
+    atomic_write_verified: bool = False
+    readback_verified: bool = False
+
+
+@dataclass(frozen=True)
+class MaterialDualReadReconciliation:
+    """Source/target parity result produced before authority cutover."""
+
+    provider_id: str
+    store_id: str
+    source_revision: str
+    target_revision: str
+    item_count: int
+    lifecycle_counts: Mapping[str, int] = field(repr=False)
+    validation_ref: str = ""
+    stable_ids_verified: bool = False
+    content_mismatches: int = 0
+
+
+@dataclass(frozen=True)
+class MaterialAuthorityTransition:
+    """Atomic authority-pointer transition with verified readback."""
+
+    provider_id: str
+    store_id: str
+    before_revision: str
+    after_revision: str
+    authority_ref: str
+    rollback_ref: str
+    atomic_write_verified: bool = False
+    readback_verified: bool = False
+
+
+def _provider_identity(
+    provider: MaterialMigrationApplyProvider,
+    *,
+    provider_id: str,
+) -> str:
+    expected = compact_token(provider_id, field="provider_id")
+    actual = compact_token(
+        getattr(provider, "provider_id", ""),
+        field="provider.provider_id",
+    )
+    if actual != expected:
+        raise ValueError("material apply provider identity does not match")
+    return expected
+
+
+def _validate_identity(
+    value: Any,
+    *,
+    expected_provider_id: str,
+    expected_store_id: str,
+    field: str,
+) -> None:
+    if compact_token(value.provider_id, field=f"{field}.provider_id") != (
+        expected_provider_id
+    ):
+        raise ValueError(f"{field} provider identity does not match")
+    if compact_token(value.store_id, field=f"{field}.store_id") != expected_store_id:
+        raise ValueError(f"{field} store identity does not match")
+
+
+def _lifecycle_counts(
+    value: Mapping[str, int],
+    *,
+    field: str,
+) -> dict[str, int]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{field} must be an object")
+    unexpected = sorted(set(value) - MATERIAL_LIFECYCLE_STATES)
+    if unexpected:
+        raise ValueError(
+            f"{field} contains unsupported states: {', '.join(unexpected)}"
+        )
+    return {
+        state: nonnegative_int(value.get(state, 0), field=f"{field}.{state}")
+        for state in sorted(MATERIAL_LIFECYCLE_STATES)
+    }
+
+
+def _verified_boolean(value: Any, *, field: str) -> bool:
+    if not isinstance(value, bool):
+        raise TypeError(f"{field} must be a boolean")
+    if not value:
+        raise ValueError(f"{field} must be verified")
+    return value
+
+
+def _migration_plan(plan: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(plan, Mapping):
+        raise TypeError("migration_plan must be an object")
+    check_record_keys(
+        plan,
+        field="migration_plan",
+        allowed={
+            "backup_ref",
+            "capability",
+            "cutover_mode",
+            "expected_item_count",
+            "goal_id",
+            "inventory_ref",
+            "observed_at",
+            "owner_gate_required",
+            "phases",
+            "plan_id",
+            "plan_ref",
+            "private_locations_captured",
+            "protected_material_refs",
+            "raw_content_captured",
+            "rollback_ref",
+            "schema_version",
+            "source_mutation_authorized",
+            "source_revision",
+            "target_schema",
+            "visibility",
+        },
+        required={
+            "backup_ref",
+            "expected_item_count",
+            "goal_id",
+            "inventory_ref",
+            "owner_gate_required",
+            "plan_ref",
+            "rollback_ref",
+            "schema_version",
+            "source_mutation_authorized",
+            "source_revision",
+            "target_schema",
+        },
+    )
+    if plan.get("schema_version") != MATERIAL_MIGRATION_PLAN_SCHEMA_VERSION:
+        raise ValueError("migration_plan has an unsupported schema_version")
+    if plan.get("owner_gate_required") is not True:
+        raise ValueError("migration_plan must require an owner gate")
+    if plan.get("source_mutation_authorized") is not False:
+        raise ValueError("migration_plan must not authorize source mutation")
+    if plan.get("raw_content_captured") is not False:
+        raise ValueError("migration_plan must not capture raw content")
+    if plan.get("private_locations_captured") is not False:
+        raise ValueError("migration_plan must not capture private locations")
+    return {
+        "goal_id": compact_token(plan.get("goal_id"), field="migration_plan.goal_id"),
+        "plan_ref": compact_token(
+            plan.get("plan_ref"),
+            field="migration_plan.plan_ref",
+        ),
+        "inventory_ref": compact_token(
+            plan.get("inventory_ref"),
+            field="migration_plan.inventory_ref",
+        ),
+        "source_revision": compact_token(
+            plan.get("source_revision"),
+            field="migration_plan.source_revision",
+        ),
+        "target_schema": compact_token(
+            plan.get("target_schema"),
+            field="migration_plan.target_schema",
+        ),
+        "expected_item_count": nonnegative_int(
+            plan.get("expected_item_count"),
+            field="migration_plan.expected_item_count",
+        ),
+        "backup_ref": compact_token(
+            plan.get("backup_ref"),
+            field="migration_plan.backup_ref",
+        ),
+        "rollback_ref": compact_token(
+            plan.get("rollback_ref"),
+            field="migration_plan.rollback_ref",
+        ),
+    }
+
+
+def _authority_snapshot(
+    provider: MaterialMigrationApplyProvider,
+    *,
+    provider_id: str,
+    store_id: str,
+    observed_at: str,
+) -> MaterialAuthoritySnapshot:
+    snapshot = provider.inspect_authority(
+        store_id=store_id,
+        observed_at=observed_at,
+    )
+    if not isinstance(snapshot, MaterialAuthoritySnapshot):
+        raise TypeError("material apply provider must return MaterialAuthoritySnapshot")
+    _validate_identity(
+        snapshot,
+        expected_provider_id=provider_id,
+        expected_store_id=store_id,
+        field="authority_snapshot",
+    )
+    iso_timestamp(snapshot.observed_at, field="authority_snapshot.observed_at")
+    compact_token(
+        snapshot.authority_revision,
+        field="authority_snapshot.authority_revision",
+    )
+    return snapshot
+
+
+def apply_material_migration(
+    *,
+    provider: MaterialMigrationApplyProvider,
+    provider_id: str,
+    store_id: str,
+    migration_plan: Mapping[str, Any],
+    owner_gate_ref: str,
+    receipt_id: str,
+    observed_at: str,
+) -> dict[str, Any]:
+    """Apply a prepared migration only after CAS, parity, and owner validation."""
+
+    expected_provider_id = _provider_identity(provider, provider_id=provider_id)
+    normalized_plan = _migration_plan(migration_plan)
+    expected_store_id = compact_token(store_id, field="store_id")
+    source_revision = normalized_plan["source_revision"]
+    normalized_observed_at = iso_timestamp(observed_at, field="observed_at")
+    normalized_owner_gate_ref = compact_token(
+        owner_gate_ref,
+        field="owner_gate_ref",
+    )
+
+    before = _authority_snapshot(
+        provider,
+        provider_id=expected_provider_id,
+        store_id=expected_store_id,
+        observed_at=normalized_observed_at,
+    )
+    if before.authority_revision != source_revision:
+        raise ValueError("source revision CAS failed before staging")
+
+    staged = provider.stage(
+        store_id=expected_store_id,
+        plan_ref=normalized_plan["plan_ref"],
+        source_revision=source_revision,
+        target_schema=normalized_plan["target_schema"],
+        owner_gate_ref=normalized_owner_gate_ref,
+        observed_at=normalized_observed_at,
+    )
+    if not isinstance(staged, MaterialStagedStore):
+        raise TypeError("material apply provider must return MaterialStagedStore")
+    _validate_identity(
+        staged,
+        expected_provider_id=expected_provider_id,
+        expected_store_id=expected_store_id,
+        field="staged_store",
+    )
+    if compact_token(staged.source_revision, field="staged_store.source_revision") != (
+        source_revision
+    ):
+        raise ValueError("staged store source revision does not match")
+    target_revision = compact_token(
+        staged.target_revision,
+        field="staged_store.target_revision",
+    )
+    if target_revision == source_revision:
+        raise ValueError("target revision must differ from source revision")
+    if (
+        compact_token(staged.target_schema, field="staged_store.target_schema")
+        != (normalized_plan["target_schema"])
+    ):
+        raise ValueError("staged store target schema does not match")
+    target_store_ref = compact_token(
+        staged.target_store_ref,
+        field="staged_store.target_store_ref",
+    )
+    target_digest = compact_token(
+        staged.target_digest,
+        field="staged_store.target_digest",
+    )
+    staged_item_count = nonnegative_int(
+        staged.item_count,
+        field="staged_store.item_count",
+    )
+    staged_counts = _lifecycle_counts(
+        staged.lifecycle_counts,
+        field="staged_store.lifecycle_counts",
+    )
+    if staged_item_count != normalized_plan["expected_item_count"]:
+        raise ValueError("staged store item count does not match migration plan")
+    if sum(staged_counts.values()) != staged_item_count:
+        raise ValueError("staged lifecycle counts do not match item count")
+    _verified_boolean(
+        staged.atomic_write_verified,
+        field="staged_store.atomic_write_verified",
+    )
+    _verified_boolean(
+        staged.readback_verified,
+        field="staged_store.readback_verified",
+    )
+
+    before_cutover = _authority_snapshot(
+        provider,
+        provider_id=expected_provider_id,
+        store_id=expected_store_id,
+        observed_at=normalized_observed_at,
+    )
+    if before_cutover.authority_revision != source_revision:
+        raise ValueError("source revision CAS failed after staging")
+
+    reconciliation = provider.reconcile(
+        store_id=expected_store_id,
+        source_revision=source_revision,
+        target_revision=target_revision,
+        observed_at=normalized_observed_at,
+    )
+    if not isinstance(reconciliation, MaterialDualReadReconciliation):
+        raise TypeError(
+            "material apply provider must return MaterialDualReadReconciliation"
+        )
+    _validate_identity(
+        reconciliation,
+        expected_provider_id=expected_provider_id,
+        expected_store_id=expected_store_id,
+        field="reconciliation",
+    )
+    if (
+        compact_token(
+            reconciliation.source_revision,
+            field="reconciliation.source_revision",
+        )
+        != source_revision
+    ):
+        raise ValueError("reconciliation source revision does not match")
+    if (
+        compact_token(
+            reconciliation.target_revision,
+            field="reconciliation.target_revision",
+        )
+        != target_revision
+    ):
+        raise ValueError("reconciliation target revision does not match")
+    reconciled_item_count = nonnegative_int(
+        reconciliation.item_count,
+        field="reconciliation.item_count",
+    )
+    reconciled_counts = _lifecycle_counts(
+        reconciliation.lifecycle_counts,
+        field="reconciliation.lifecycle_counts",
+    )
+    if reconciled_item_count != staged_item_count:
+        raise ValueError("dual-read item count does not match staged store")
+    if reconciled_counts != staged_counts:
+        raise ValueError("dual-read lifecycle counts do not match staged store")
+    _verified_boolean(
+        reconciliation.stable_ids_verified,
+        field="reconciliation.stable_ids_verified",
+    )
+    if nonnegative_int(
+        reconciliation.content_mismatches,
+        field="reconciliation.content_mismatches",
+    ):
+        raise ValueError("dual-read reconciliation contains content mismatches")
+    validation_ref = compact_token(
+        reconciliation.validation_ref,
+        field="reconciliation.validation_ref",
+    )
+
+    transition = provider.switch_authority(
+        store_id=expected_store_id,
+        expected_revision=source_revision,
+        target_revision=target_revision,
+        owner_gate_ref=normalized_owner_gate_ref,
+        observed_at=normalized_observed_at,
+    )
+    if not isinstance(transition, MaterialAuthorityTransition):
+        raise TypeError(
+            "material apply provider must return MaterialAuthorityTransition"
+        )
+    _validate_identity(
+        transition,
+        expected_provider_id=expected_provider_id,
+        expected_store_id=expected_store_id,
+        field="authority_transition",
+    )
+    if (
+        compact_token(
+            transition.before_revision,
+            field="authority_transition.before_revision",
+        )
+        != source_revision
+    ):
+        raise ValueError("authority transition before revision does not match")
+    if (
+        compact_token(
+            transition.after_revision,
+            field="authority_transition.after_revision",
+        )
+        != target_revision
+    ):
+        raise ValueError("authority transition after revision does not match")
+    authority_ref = compact_token(
+        transition.authority_ref,
+        field="authority_transition.authority_ref",
+    )
+    rollback_ref = compact_token(
+        transition.rollback_ref,
+        field="authority_transition.rollback_ref",
+    )
+    if rollback_ref != normalized_plan["rollback_ref"]:
+        raise ValueError("authority transition rollback reference does not match")
+    _verified_boolean(
+        transition.atomic_write_verified,
+        field="authority_transition.atomic_write_verified",
+    )
+    _verified_boolean(
+        transition.readback_verified,
+        field="authority_transition.readback_verified",
+    )
+
+    receipt: dict[str, Any] = {
+        "schema_version": MATERIAL_MIGRATION_APPLY_RECEIPT_SCHEMA_VERSION,
+        "goal_id": normalized_plan["goal_id"],
+        "receipt_id": compact_token(receipt_id, field="receipt_id"),
+        "plan_ref": normalized_plan["plan_ref"],
+        "inventory_ref": normalized_plan["inventory_ref"],
+        "provider_id": expected_provider_id,
+        "store_id": expected_store_id,
+        "observed_at": normalized_observed_at,
+        "status": "applied",
+        "owner_gate_ref": normalized_owner_gate_ref,
+        "before_revision": source_revision,
+        "after_revision": target_revision,
+        "target_schema": normalized_plan["target_schema"],
+        "target_store_ref": target_store_ref,
+        "target_digest": target_digest,
+        "item_count": staged_item_count,
+        "lifecycle_counts": staged_counts,
+        "backup_ref": normalized_plan["backup_ref"],
+        "validation_ref": validation_ref,
+        "authority_ref": authority_ref,
+        "rollback_ref": rollback_ref,
+        "source_revision_cas_verified": True,
+        "atomic_write_verified": True,
+        "readback_verified": True,
+        "dual_read_verified": True,
+        "visibility": "public_safe",
+        "capability": capability_contract(packet_role="migration_apply_receipt"),
+        "raw_content_captured": False,
+        "private_locations_captured": False,
+    }
+    receipt["receipt_ref"] = packet_ref("material-migration-apply", receipt)
+    return receipt
+
+
+def rollback_material_migration(
+    *,
+    provider: MaterialMigrationApplyProvider,
+    provider_id: str,
+    apply_receipt: Mapping[str, Any],
+    owner_gate_ref: str,
+    receipt_id: str,
+    observed_at: str,
+) -> dict[str, Any]:
+    """Roll back one applied migration through the same authority-pointer CAS."""
+
+    if not isinstance(apply_receipt, Mapping):
+        raise TypeError("apply_receipt must be an object")
+    if (
+        apply_receipt.get("schema_version")
+        != MATERIAL_MIGRATION_APPLY_RECEIPT_SCHEMA_VERSION
+    ):
+        raise ValueError("apply_receipt has an unsupported schema_version")
+    if apply_receipt.get("status") != "applied":
+        raise ValueError("apply_receipt must record an applied migration")
+
+    expected_provider_id = _provider_identity(provider, provider_id=provider_id)
+    receipt_provider_id = compact_token(
+        apply_receipt.get("provider_id"),
+        field="apply_receipt.provider_id",
+    )
+    if receipt_provider_id != expected_provider_id:
+        raise ValueError("apply receipt provider identity does not match")
+    store_id = compact_token(
+        apply_receipt.get("store_id"),
+        field="apply_receipt.store_id",
+    )
+    source_revision = compact_token(
+        apply_receipt.get("before_revision"),
+        field="apply_receipt.before_revision",
+    )
+    current_revision = compact_token(
+        apply_receipt.get("after_revision"),
+        field="apply_receipt.after_revision",
+    )
+    normalized_observed_at = iso_timestamp(observed_at, field="observed_at")
+    normalized_owner_gate_ref = compact_token(
+        owner_gate_ref,
+        field="owner_gate_ref",
+    )
+
+    current = _authority_snapshot(
+        provider,
+        provider_id=expected_provider_id,
+        store_id=store_id,
+        observed_at=normalized_observed_at,
+    )
+    if current.authority_revision != current_revision:
+        raise ValueError("rollback authority revision CAS failed")
+
+    transition = provider.switch_authority(
+        store_id=store_id,
+        expected_revision=current_revision,
+        target_revision=source_revision,
+        owner_gate_ref=normalized_owner_gate_ref,
+        observed_at=normalized_observed_at,
+    )
+    if not isinstance(transition, MaterialAuthorityTransition):
+        raise TypeError(
+            "material apply provider must return MaterialAuthorityTransition"
+        )
+    _validate_identity(
+        transition,
+        expected_provider_id=expected_provider_id,
+        expected_store_id=store_id,
+        field="rollback_transition",
+    )
+    if (
+        compact_token(
+            transition.before_revision,
+            field="rollback_transition.before_revision",
+        )
+        != current_revision
+    ):
+        raise ValueError("rollback transition before revision does not match")
+    if (
+        compact_token(
+            transition.after_revision,
+            field="rollback_transition.after_revision",
+        )
+        != source_revision
+    ):
+        raise ValueError("rollback transition after revision does not match")
+    _verified_boolean(
+        transition.atomic_write_verified,
+        field="rollback_transition.atomic_write_verified",
+    )
+    _verified_boolean(
+        transition.readback_verified,
+        field="rollback_transition.readback_verified",
+    )
+
+    receipt: dict[str, Any] = {
+        "schema_version": MATERIAL_MIGRATION_ROLLBACK_RECEIPT_SCHEMA_VERSION,
+        "goal_id": compact_token(
+            apply_receipt.get("goal_id"),
+            field="apply_receipt.goal_id",
+        ),
+        "receipt_id": compact_token(receipt_id, field="receipt_id"),
+        "apply_receipt_ref": compact_token(
+            apply_receipt.get("receipt_ref"),
+            field="apply_receipt.receipt_ref",
+        ),
+        "provider_id": expected_provider_id,
+        "store_id": store_id,
+        "observed_at": normalized_observed_at,
+        "status": "rolled_back",
+        "owner_gate_ref": normalized_owner_gate_ref,
+        "before_revision": current_revision,
+        "after_revision": source_revision,
+        "authority_ref": compact_token(
+            transition.authority_ref,
+            field="rollback_transition.authority_ref",
+        ),
+        "rollback_ref": compact_token(
+            transition.rollback_ref,
+            field="rollback_transition.rollback_ref",
+        ),
+        "source_revision_cas_verified": True,
+        "atomic_write_verified": True,
+        "readback_verified": True,
+        "visibility": "public_safe",
+        "capability": capability_contract(packet_role="migration_rollback_receipt"),
+        "raw_content_captured": False,
+        "private_locations_captured": False,
+    }
+    receipt["receipt_ref"] = packet_ref("material-migration-rollback", receipt)
+    return receipt

--- a/tests/capabilities/test_material_lifecycle_apply.py
+++ b/tests/capabilities/test_material_lifecycle_apply.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from loopx.capabilities.material_lifecycle import (
+    MaterialAuthoritySnapshot,
+    MaterialAuthorityTransition,
+    MaterialDualReadReconciliation,
+    MaterialStagedStore,
+    apply_material_migration,
+    build_material_migration_plan,
+    build_material_store_inventory,
+    rollback_material_migration,
+)
+
+OBSERVED_AT = "2026-07-26T04:30:00+00:00"
+
+
+def migration_plan() -> dict[str, object]:
+    inventory = build_material_store_inventory(
+        goal_id="goal:material-example",
+        store_id="store:learning-materials",
+        store_revision="revision:42",
+        observed_at=OBSERVED_AT,
+        source_snapshot_ref="snapshot:revision-42",
+        backup_ref="backup:revision-42",
+        source_digest="sha256:0123456789abcdef",
+        lifecycle_counts={"candidate": 30, "archived": 217},
+        stable_ids_verified=True,
+        backup_verified=True,
+    )
+    plan = build_material_migration_plan(
+        goal_id="goal:material-example",
+        plan_id="plan:migrate-v0",
+        inventory_ref=str(inventory["inventory_ref"]),
+        source_revision="revision:42",
+        target_schema="material_store_v0",
+        observed_at=OBSERVED_AT,
+        backup_ref="backup:revision-42",
+        rollback_ref="rollback:revision-42",
+        expected_item_count=247,
+    )
+    return plan
+
+
+class FakeApplyProvider:
+    provider_id = "private-legacy-store"
+
+    def __init__(self) -> None:
+        self.authority_revision = "revision:42"
+        self.calls: list[str] = []
+        self.staged = MaterialStagedStore(
+            provider_id=self.provider_id,
+            store_id="store:learning-materials",
+            source_revision="revision:42",
+            target_revision="revision:43",
+            target_schema="material_store_v0",
+            target_store_ref="store-snapshot:revision-43",
+            target_digest="sha256:fedcba9876543210",
+            item_count=247,
+            lifecycle_counts={"candidate": 30, "archived": 217},
+            atomic_write_verified=True,
+            readback_verified=True,
+        )
+        self.reconciliation = MaterialDualReadReconciliation(
+            provider_id=self.provider_id,
+            store_id="store:learning-materials",
+            source_revision="revision:42",
+            target_revision="revision:43",
+            item_count=247,
+            lifecycle_counts={"candidate": 30, "archived": 217},
+            validation_ref="validation:dual-read-42-43",
+            stable_ids_verified=True,
+            content_mismatches=0,
+        )
+
+    def inspect_authority(
+        self,
+        *,
+        store_id: str,
+        observed_at: str,
+    ) -> MaterialAuthoritySnapshot:
+        self.calls.append("inspect")
+        return MaterialAuthoritySnapshot(
+            provider_id=self.provider_id,
+            store_id=store_id,
+            authority_revision=self.authority_revision,
+            observed_at=observed_at,
+        )
+
+    def stage(
+        self,
+        *,
+        store_id: str,
+        plan_ref: str,
+        source_revision: str,
+        target_schema: str,
+        owner_gate_ref: str,
+        observed_at: str,
+    ) -> MaterialStagedStore:
+        self.calls.append("stage")
+        return self.staged
+
+    def reconcile(
+        self,
+        *,
+        store_id: str,
+        source_revision: str,
+        target_revision: str,
+        observed_at: str,
+    ) -> MaterialDualReadReconciliation:
+        self.calls.append("reconcile")
+        return self.reconciliation
+
+    def switch_authority(
+        self,
+        *,
+        store_id: str,
+        expected_revision: str,
+        target_revision: str,
+        owner_gate_ref: str,
+        observed_at: str,
+    ) -> MaterialAuthorityTransition:
+        self.calls.append("switch")
+        if self.authority_revision != expected_revision:
+            raise ValueError("provider CAS failed")
+        before_revision = self.authority_revision
+        self.authority_revision = target_revision
+        return MaterialAuthorityTransition(
+            provider_id=self.provider_id,
+            store_id=store_id,
+            before_revision=before_revision,
+            after_revision=target_revision,
+            authority_ref=f"authority:{target_revision}",
+            rollback_ref=f"rollback:{before_revision.replace(':', '-')}",
+            atomic_write_verified=True,
+            readback_verified=True,
+        )
+
+
+def apply(provider: FakeApplyProvider) -> dict[str, object]:
+    return apply_material_migration(
+        provider=provider,
+        provider_id=provider.provider_id,
+        store_id="store:learning-materials",
+        migration_plan=migration_plan(),
+        owner_gate_ref="owner-gate:material-cutover",
+        receipt_id="receipt:material-cutover",
+        observed_at=OBSERVED_AT,
+    )
+
+
+def test_apply_orders_cas_stage_reconcile_and_atomic_cutover() -> None:
+    provider = FakeApplyProvider()
+
+    receipt = apply(provider)
+
+    assert provider.calls == ["inspect", "stage", "inspect", "reconcile", "switch"]
+    assert provider.authority_revision == "revision:43"
+    assert receipt["status"] == "applied"
+    assert receipt["before_revision"] == "revision:42"
+    assert receipt["after_revision"] == "revision:43"
+    assert receipt["item_count"] == 247
+    assert receipt["source_revision_cas_verified"] is True
+    assert receipt["dual_read_verified"] is True
+    assert receipt["atomic_write_verified"] is True
+    assert receipt["readback_verified"] is True
+    assert receipt["raw_content_captured"] is False
+    assert receipt["private_locations_captured"] is False
+
+
+def test_apply_fails_before_staging_when_source_revision_drifted() -> None:
+    provider = FakeApplyProvider()
+    provider.authority_revision = "revision:99"
+
+    with pytest.raises(ValueError, match="CAS failed before staging"):
+        apply(provider)
+
+    assert provider.calls == ["inspect"]
+
+
+def test_apply_does_not_cut_over_when_staging_or_reconciliation_is_unsafe() -> None:
+    provider = FakeApplyProvider()
+    provider.staged = replace(provider.staged, readback_verified=False)
+    with pytest.raises(ValueError, match="readback_verified must be verified"):
+        apply(provider)
+    assert "switch" not in provider.calls
+    assert provider.authority_revision == "revision:42"
+
+    provider = FakeApplyProvider()
+    provider.reconciliation = replace(
+        provider.reconciliation,
+        content_mismatches=1,
+    )
+    with pytest.raises(ValueError, match="content mismatches"):
+        apply(provider)
+    assert "switch" not in provider.calls
+    assert provider.authority_revision == "revision:42"
+
+
+def test_apply_rechecks_source_revision_after_staging() -> None:
+    class DriftAfterStageProvider(FakeApplyProvider):
+        def stage(self, **kwargs: str) -> MaterialStagedStore:
+            result = super().stage(**kwargs)
+            self.authority_revision = "revision:concurrent"
+            return result
+
+    provider = DriftAfterStageProvider()
+
+    with pytest.raises(ValueError, match="CAS failed after staging"):
+        apply(provider)
+
+    assert provider.calls == ["inspect", "stage", "inspect"]
+    assert "switch" not in provider.calls
+
+
+def test_rollback_uses_owner_gated_authority_cas() -> None:
+    provider = FakeApplyProvider()
+    applied = apply(provider)
+    provider.calls.clear()
+
+    receipt = rollback_material_migration(
+        provider=provider,
+        provider_id=provider.provider_id,
+        apply_receipt=applied,
+        owner_gate_ref="owner-gate:material-rollback",
+        receipt_id="receipt:material-rollback",
+        observed_at=OBSERVED_AT,
+    )
+
+    assert provider.calls == ["inspect", "switch"]
+    assert provider.authority_revision == "revision:42"
+    assert receipt["status"] == "rolled_back"
+    assert receipt["before_revision"] == "revision:43"
+    assert receipt["after_revision"] == "revision:42"
+    assert receipt["source_revision_cas_verified"] is True
+    assert receipt["atomic_write_verified"] is True
+    assert receipt["readback_verified"] is True
+
+
+def test_rollback_rejects_authority_drift() -> None:
+    provider = FakeApplyProvider()
+    applied = apply(provider)
+    provider.authority_revision = "revision:44"
+    provider.calls.clear()
+
+    with pytest.raises(ValueError, match="rollback authority revision CAS failed"):
+        rollback_material_migration(
+            provider=provider,
+            provider_id=provider.provider_id,
+            apply_receipt=applied,
+            owner_gate_ref="owner-gate:material-rollback",
+            receipt_id="receipt:material-rollback",
+            observed_at=OBSERVED_AT,
+        )
+
+    assert provider.calls == ["inspect"]
+
+
+def test_apply_rejects_private_refs_and_provider_identity_drift() -> None:
+    provider = FakeApplyProvider()
+    provider.staged = replace(
+        provider.staged,
+        target_store_ref="/Users/example/private-store",
+    )
+    with pytest.raises(ValueError, match="local path"):
+        apply(provider)
+
+    provider = FakeApplyProvider()
+    provider.provider_id = "other-provider"
+    with pytest.raises(ValueError, match="provider identity"):
+        apply_material_migration(
+            provider=provider,
+            provider_id="private-legacy-store",
+            store_id="store:learning-materials",
+            migration_plan=migration_plan(),
+            owner_gate_ref="owner-gate:material-cutover",
+            receipt_id="receipt:material-cutover",
+            observed_at=OBSERVED_AT,
+        )
+
+
+def test_apply_rejects_unsafe_or_unprepared_plan_payloads() -> None:
+    provider = FakeApplyProvider()
+    unsafe = migration_plan()
+    unsafe["raw_content"] = "private source body"
+    with pytest.raises(ValueError, match="unsafe fields"):
+        apply_material_migration(
+            provider=provider,
+            provider_id=provider.provider_id,
+            store_id="store:learning-materials",
+            migration_plan=unsafe,
+            owner_gate_ref="owner-gate:material-cutover",
+            receipt_id="receipt:material-cutover",
+            observed_at=OBSERVED_AT,
+        )
+
+    unprepared = migration_plan()
+    unprepared["owner_gate_required"] = False
+    with pytest.raises(ValueError, match="must require an owner gate"):
+        apply_material_migration(
+            provider=provider,
+            provider_id=provider.provider_id,
+            store_id="store:learning-materials",
+            migration_plan=unprepared,
+            owner_gate_ref="owner-gate:material-cutover",
+            receipt_id="receipt:material-cutover",
+            observed_at=OBSERVED_AT,
+        )


### PR DESCRIPTION
## Summary
- add a provider-neutral owner-gated material migration apply/rollback contract
- enforce source revision CAS, staged readback, dual-read reconciliation, atomic authority switching, and auditable receipts
- document the private adapter boundary in English and Chinese

## Validation
- `34 passed` across material lifecycle contract/preparation/planning/apply tests
- full suite: `1325 passed, 2 skipped`; one unrelated timing test passed on isolated rerun
- standard premerge canary: 10/10 checks passed
- public boundary scan: clean
