### PR TITLE
feat(decision-context): add audited outcome feedback

### DIFF
--- a/docs/reference/protocols/decision-context-architecture-v0.md
+++ b/docs/reference/protocols/decision-context-architecture-v0.md
@@ -79,6 +79,16 @@ transitions, observed outcomes, invalidated assumptions, and review time. Only
 a verified receipt with outcome evidence is eligible to create a Reward Memory
 candidate.
 
+`decision_outcome_feedback_v0` closes the boundary without making either
+capability authoritative. It accepts only canonical, untampered evidence and
+outcome packets, records aggregate retrieval telemetry, and may emit one
+`procedural_experience` candidate when an exact-read-promoted claim has a
+verified outcome linked to the same evidence packet. Rejected recall is
+telemetry only. The adapter never ingests, reviews, persists, or activates the
+candidate. A caller may pass the canonical public retrieval receipt to preserve
+the distinction between aggregate rejection records and the actual number of
+provider results rejected by exact read.
+
 ## Incremental source plane
 
 Decision Context must not depend on a domain-specific automation prompt to know

--- a/docs/reference/protocols/decision-context-architecture-v0.zh-CN.md
+++ b/docs/reference/protocols/decision-context-architecture-v0.zh-CN.md
@@ -111,6 +111,14 @@ receipt 可由既有 event/run history 承载。只有
 `verification_status=verified` 且有 outcome evidence 时，才可成为 Reward Memory
 candidate；candidate 仍需经过 Reward Memory 自己的 review/activation 流程。
 
+`decision_outcome_feedback_v0` 只接收 canonical、未被篡改的 evidence/outcome
+packet，并输出聚合后的 retrieval telemetry。只有 exact read 提升的 claim 与同一
+evidence packet 下的 verified outcome 直接关联时，才可生成一个
+`procedural_experience` candidate。被拒绝的召回只进入 telemetry，不进入记忆；
+适配层不会自动 ingest、review、persist 或 activate candidate。调用方可额外传入
+canonical 的公开 retrieval receipt，以区分聚合后的 rejection record 数和被 exact
+read 拒绝的真实 provider result 数。
+
 ## 增量信源层
 
 Decision Context 不应依赖某个领域专用的 automation prompt，来记住应该读哪些群聊、

--- a/loopx/capabilities/decision_context/__init__.py
+++ b/loopx/capabilities/decision_context/__init__.py
@@ -57,6 +57,10 @@ from .private_state import load_private_decision_cursors
 from .runtime import (
     assemble_profile_decision_evidence,
 )
+from .outcome_feedback import (
+    DECISION_OUTCOME_FEEDBACK_SCHEMA_VERSION,
+    build_decision_outcome_feedback,
+)
 
 __all__ = [
     "DECISION_CONTEXT_ASSEMBLY_SCHEMA_VERSION",
@@ -66,6 +70,7 @@ __all__ = [
     "DECISION_CURSOR_COMMIT_RECEIPT_SCHEMA_VERSION",
     "DECISION_EVIDENCE_PACKET_SCHEMA_VERSION",
     "DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION",
+    "DECISION_OUTCOME_FEEDBACK_SCHEMA_VERSION",
     "DECISION_PROPOSAL_SCHEMA_VERSION",
     "DECISION_CONTEXT_PROFILE_SCHEMA_VERSION",
     "DECISION_SOURCE_MANIFEST_SCHEMA_VERSION",
@@ -90,6 +95,7 @@ __all__ = [
     "build_decision_context_architecture_packet",
     "build_decision_evidence_packet",
     "build_decision_outcome_receipt",
+    "build_decision_outcome_feedback",
     "build_decision_proposal",
     "build_decision_source_item_refs",
     "build_decision_source_manifest",

--- a/loopx/capabilities/decision_context/outcome_feedback.py
+++ b/loopx/capabilities/decision_context/outcome_feedback.py
@@ -1,0 +1,352 @@
+"""Audited feedback from Decision Context outcomes into Reward Memory."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from collections.abc import Mapping
+from typing import Any
+
+from ..context_providers.base import CONTEXT_PROVIDER_RETRIEVAL_SCHEMA_VERSION
+from ..reward_memory.candidate_review import build_reward_memory_candidate
+from .packets import (
+    DECISION_EVIDENCE_PACKET_SCHEMA_VERSION,
+    DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION,
+    build_decision_evidence_packet,
+    build_decision_outcome_receipt,
+)
+
+
+DECISION_OUTCOME_FEEDBACK_SCHEMA_VERSION = "decision_outcome_feedback_v0"
+_RETRIEVAL_RECEIPT_FIELDS = {
+    "schema_version",
+    "ok",
+    "provider",
+    "namespace",
+    "visibility",
+    "status",
+    "reason_code",
+    "provider_version",
+    "query_summary",
+    "observed_at",
+    "search_performed",
+    "read_performed",
+    "requested_limit",
+    "result_count",
+    "results",
+    "telemetry",
+    "fail_open",
+    "external_writes_performed",
+    "raw_provider_payload_captured",
+    "raw_content_captured",
+    "credentials_captured",
+}
+_RETRIEVAL_RESULT_FIELDS = {"provider_ref", "summary", "score"}
+_RETRIEVAL_TELEMETRY_FIELDS = {"latency_ms", "result_cap_applied"}
+
+
+def _canonical_evidence_packet(packet: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(packet, Mapping):
+        raise TypeError("evidence_packet must be an object")
+    if packet.get("schema_version") != DECISION_EVIDENCE_PACKET_SCHEMA_VERSION:
+        raise ValueError(
+            f"evidence_packet must use {DECISION_EVIDENCE_PACKET_SCHEMA_VERSION}"
+        )
+    canonical = build_decision_evidence_packet(
+        goal_id=packet.get("goal_id"),
+        decision_id=packet.get("decision_id"),
+        observed_at=packet.get("observed_at"),
+        changed_facts=packet.get("changed_facts"),
+        recalled_claims=packet.get("recalled_claims"),
+        stale_or_rejected_claims=packet.get("stale_or_rejected_claims"),
+        conflicts=packet.get("conflicts"),
+        source_revisions=packet.get("source_revisions"),
+        provider_health=packet.get("provider_health"),
+    )
+    if dict(packet) != canonical:
+        raise ValueError("evidence_packet must be canonical and untampered")
+    return canonical
+
+
+def _canonical_outcome_receipt(packet: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(packet, Mapping):
+        raise TypeError("outcome_receipt must be an object")
+    if packet.get("schema_version") != DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION:
+        raise ValueError(
+            f"outcome_receipt must use {DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION}"
+        )
+    canonical = build_decision_outcome_receipt(
+        goal_id=packet.get("goal_id"),
+        decision_id=packet.get("decision_id"),
+        proposal_packet_ref=packet.get("proposal_packet_ref"),
+        recorded_at=packet.get("recorded_at"),
+        verification_status=packet.get("verification_status"),
+        accepted_decision=packet.get("accepted_decision"),
+        resulting_transitions=packet.get("resulting_transitions"),
+        observed_outcomes=packet.get("observed_outcomes"),
+        invalidated_assumptions=packet.get("invalidated_assumptions"),
+        review_at=packet.get("review_at"),
+    )
+    if dict(packet) != canonical:
+        raise ValueError("outcome_receipt must be canonical and untampered")
+    return canonical
+
+
+def _packet_ref(packet: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(
+        json.dumps(
+            packet,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:20]
+    return f"decision-feedback-{digest}"
+
+
+def _reason_counts(records: list[dict[str, Any]]) -> dict[str, int]:
+    return dict(
+        sorted(Counter(str(record["reason_code"]) for record in records).items())
+    )
+
+
+def _retrieval_counts(
+    packet: Mapping[str, Any] | None,
+    *,
+    promoted_count: int,
+    rejected_record_count: int,
+) -> tuple[int, int, str]:
+    if packet is None:
+        result_count = promoted_count + rejected_record_count
+        return result_count, rejected_record_count, "evidence_records"
+    if not isinstance(packet, Mapping):
+        raise TypeError("retrieval_receipt must be an object")
+    if packet.get("schema_version") != CONTEXT_PROVIDER_RETRIEVAL_SCHEMA_VERSION:
+        raise ValueError(
+            f"retrieval_receipt must use {CONTEXT_PROVIDER_RETRIEVAL_SCHEMA_VERSION}"
+        )
+    if set(packet) != _RETRIEVAL_RECEIPT_FIELDS:
+        raise ValueError("retrieval_receipt must be a canonical public packet")
+    required_false_flags = (
+        "external_writes_performed",
+        "raw_provider_payload_captured",
+        "raw_content_captured",
+        "credentials_captured",
+    )
+    if any(packet.get(field) is not False for field in required_false_flags):
+        raise ValueError("retrieval_receipt violates the public read-only boundary")
+    if packet.get("fail_open") is not True:
+        raise ValueError("retrieval_receipt must preserve fail-open behavior")
+    if packet.get("visibility") != "public":
+        raise ValueError("retrieval_receipt visibility must be public")
+    if packet.get("ok") is not (packet.get("status") == "completed"):
+        raise ValueError("retrieval_receipt ok must match completed status")
+    result_count = packet.get("result_count")
+    results = packet.get("results")
+    requested_limit = packet.get("requested_limit")
+    if (
+        isinstance(result_count, bool)
+        or not isinstance(result_count, int)
+        or result_count < 0
+        or not isinstance(results, list)
+        or len(results) != result_count
+        or isinstance(requested_limit, bool)
+        or not isinstance(requested_limit, int)
+        or requested_limit < 0
+    ):
+        raise ValueError("retrieval_receipt result_count must match its result list")
+    if requested_limit and result_count > requested_limit:
+        raise ValueError("retrieval_receipt exceeds its requested result limit")
+    if any(
+        not isinstance(result, Mapping)
+        or set(result) != _RETRIEVAL_RESULT_FIELDS
+        for result in results
+    ):
+        raise ValueError("retrieval_receipt results must use the canonical projection")
+    telemetry = packet.get("telemetry")
+    if not isinstance(telemetry, Mapping) or set(telemetry) != (
+        _RETRIEVAL_TELEMETRY_FIELDS
+    ):
+        raise ValueError("retrieval_receipt telemetry must use the canonical projection")
+    if result_count and (
+        packet.get("search_performed") is not True
+        or packet.get("read_performed") is not True
+    ):
+        raise ValueError("retrieval_receipt results require search and read")
+    if result_count < promoted_count:
+        raise ValueError(
+            "retrieval_receipt result_count cannot be smaller than promoted claims"
+        )
+    return result_count, result_count - promoted_count, "retrieval_receipt"
+
+
+def build_decision_outcome_feedback(
+    *,
+    evidence_packet: Mapping[str, Any],
+    outcome_receipt: Mapping[str, Any],
+    workspace_ref: str,
+    project_ref: str,
+    surface_id: str = "decision_context.outcome_review",
+    retrieval_receipt: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build retrieval telemetry and, when eligible, one review-only candidate.
+
+    Rejected recall contributes telemetry only. A Reward Memory candidate requires
+    an exact-read-promoted claim plus a verified outcome linked to the same evidence
+    packet. This function never persists, ingests, reviews, or activates memory.
+    """
+
+    evidence = _canonical_evidence_packet(evidence_packet)
+    outcome = _canonical_outcome_receipt(outcome_receipt)
+    if evidence["goal_id"] != outcome["goal_id"]:
+        raise ValueError("evidence_packet and outcome_receipt goal_id must match")
+    if evidence["decision_id"] != outcome["decision_id"]:
+        raise ValueError("evidence_packet and outcome_receipt decision_id must match")
+
+    promoted = list(evidence["recalled_claims"])
+    rejected = list(evidence["stale_or_rejected_claims"])
+    conflicts = list(evidence["conflicts"])
+    unresolved_conflicts = [
+        conflict
+        for conflict in conflicts
+        if conflict["status"] not in {"clear", "resolved"}
+    ]
+    linked_verified_outcomes = [
+        item
+        for item in outcome["observed_outcomes"]
+        if item["status"] == "verified"
+        and item["evidence_ref"] == evidence["packet_ref"]
+    ]
+    current_source_revisions = sum(
+        revision["freshness"] == "current"
+        for revision in evidence["source_revisions"]
+    )
+    (
+        discovered_result_count,
+        rejected_result_count,
+        retrieval_count_mode,
+    ) = _retrieval_counts(
+        retrieval_receipt,
+        promoted_count=len(promoted),
+        rejected_record_count=len(rejected),
+    )
+
+    ineligible_reasons: list[str] = []
+    if outcome["verification_status"] != "verified":
+        ineligible_reasons.append("outcome_not_verified")
+    if outcome["reward_memory_candidate_eligible"] is not True:
+        ineligible_reasons.append("outcome_not_candidate_eligible")
+    if not promoted:
+        ineligible_reasons.append("no_exact_read_promoted_claim")
+    if not linked_verified_outcomes:
+        ineligible_reasons.append("verified_outcome_not_linked_to_evidence")
+    if unresolved_conflicts:
+        ineligible_reasons.append("unresolved_authority_conflict")
+    if not current_source_revisions:
+        ineligible_reasons.append("no_current_source_revision")
+
+    candidate = None
+    if not ineligible_reasons:
+        accepted = outcome["accepted_decision"]
+        verified_outcome = linked_verified_outcomes[0]
+        candidate = build_reward_memory_candidate(
+            {
+                "target_class": "procedural_experience",
+                "content_summary": (
+                    f"Decision: {accepted['summary']} "
+                    f"Verified outcome: {verified_outcome['summary']}"
+                ),
+                "source": {
+                    "source_kind": "verified_decision_outcome",
+                    "source_ref": outcome["packet_ref"],
+                    "actor_ref": accepted["accepted_by"],
+                    "actor_role": "verified_decision_owner",
+                },
+                "scope": {
+                    "workspace_ref": workspace_ref,
+                    "project_ref": project_ref,
+                    "surface_ids": [surface_id],
+                    "revision_ref": evidence["packet_ref"],
+                },
+                "reasoning": {
+                    "summary": (
+                        "An exact-read-promoted claim and a verified outcome are "
+                        "linked to the same canonical evidence packet."
+                    ),
+                    "confidence": "high",
+                },
+                "guard_context": {
+                    "source_freshness": "current",
+                    "conflict_state": "clear",
+                    "current_artifact_verified": True,
+                },
+                "requested_action_scopes": [],
+                "raw_content_captured": False,
+            }
+        )
+
+    feedback: dict[str, Any] = {
+        "schema_version": DECISION_OUTCOME_FEEDBACK_SCHEMA_VERSION,
+        "goal_id": evidence["goal_id"],
+        "decision_id": evidence["decision_id"],
+        "evidence_packet_ref": evidence["packet_ref"],
+        "outcome_receipt_ref": outcome["packet_ref"],
+        "observed_at": outcome["recorded_at"],
+        "visibility": "public_safe",
+        "capability": {
+            "capability_id": "decision_context",
+            "scope": "goal",
+            "default_enabled": False,
+            "packet_role": "audited_outcome_feedback",
+            "creates_authority": False,
+            "mutates_core_state": False,
+        },
+        "retrieval_telemetry": {
+            "discovered_result_count": discovered_result_count,
+            "exact_read_promoted_count": len(promoted),
+            "rejected_result_count": rejected_result_count,
+            "rejected_recall_record_count": len(rejected),
+            "rejection_reason_counts": _reason_counts(rejected),
+            "provider_health_status_counts": dict(
+                sorted(
+                    Counter(
+                        str(item["status"]) for item in evidence["provider_health"]
+                    ).items()
+                )
+            ),
+            "current_source_revision_count": current_source_revisions,
+            "count_mode": retrieval_count_mode,
+        },
+        "outcome_telemetry": {
+            "verification_status": outcome["verification_status"],
+            "linked_verified_outcome_count": len(linked_verified_outcomes),
+            "invalidated_assumption_count": len(
+                outcome["invalidated_assumptions"]
+            ),
+            "resulting_transition_count": len(outcome["resulting_transitions"]),
+        },
+        "reward_memory": {
+            "candidate_created": candidate is not None,
+            "candidate_status": (
+                candidate["status"] if candidate is not None else "ineligible"
+            ),
+            "candidate_ref": (
+                candidate["candidate"]["candidate_ref"]
+                if candidate is not None
+                else None
+            ),
+            "ineligible_reason_codes": sorted(ineligible_reasons),
+            "review_required": candidate is not None,
+            "automatic_ingest_performed": False,
+            "automatic_activation_performed": False,
+        },
+        "reward_memory_candidate": candidate,
+        "external_writes_performed": False,
+        "raw_context_captured": False,
+        "raw_provider_payload_captured": False,
+        "private_locators_captured": False,
+        "credentials_captured": False,
+    }
+    feedback["feedback_ref"] = _packet_ref(feedback)
+    return feedback

--- a/tests/capabilities/test_decision_context_outcome_feedback.py
+++ b/tests/capabilities/test_decision_context_outcome_feedback.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+
+from loopx.capabilities.context_providers.base import (
+    ContextProviderItem,
+    ContextProviderRetrieval,
+)
+from loopx.capabilities.decision_context import (
+    build_decision_evidence_packet,
+    build_decision_outcome_feedback,
+    build_decision_outcome_receipt,
+)
+
+
+OBSERVED_AT = "2026-07-26T05:08:48+00:00"
+REVIEW_AT = "2026-07-29T05:08:48+00:00"
+
+
+def evidence_packet(*, promoted: bool = True) -> dict[str, object]:
+    return build_decision_evidence_packet(
+        goal_id="goal:decision-advisor",
+        decision_id="decision:openviking-fusion",
+        observed_at=OBSERVED_AT,
+        recalled_claims=(
+            [
+                {
+                    "claim_id": "claim:current-authority",
+                    "summary": "The current authority supports bounded fusion.",
+                    "provider_ref": "provider:semantic-recall",
+                    "source_ref": "source:decision-ledger",
+                    "source_revision": "revision:current",
+                    "observed_at": OBSERVED_AT,
+                    "exact_read_verified": True,
+                    "confidence": 0.95,
+                }
+            ]
+            if promoted
+            else []
+        ),
+        stale_or_rejected_claims=[
+            {
+                "claim_id": "claim:stale-route",
+                "summary": "The old route no longer matches current authority.",
+                "observed_at": OBSERVED_AT,
+                "reason_code": "stale_authority_revision",
+            }
+        ],
+        conflicts=[
+            {
+                "conflict_id": "conflict:priority",
+                "summary": "The latest owner direction supersedes the old route.",
+                "source_refs": ["source:decision-ledger", "source:legacy-route"],
+                "conflict_rule": "latest_explicit_authority_wins",
+                "status": "resolved",
+            }
+        ],
+        source_revisions=[
+            {
+                "source_ref": "source:decision-ledger",
+                "revision": "revision:current",
+                "observed_at": OBSERVED_AT,
+                "freshness": "current",
+            }
+        ],
+        provider_health=[
+            {
+                "provider": "semantic-provider",
+                "status": "healthy",
+                "observed_at": OBSERVED_AT,
+                "fail_open": True,
+            }
+        ],
+    )
+
+
+def outcome_receipt(
+    evidence: dict[str, object],
+    *,
+    verification_status: str = "verified",
+) -> dict[str, object]:
+    observed_outcomes = (
+        [
+            {
+                "outcome_id": "outcome:bounded-fusion",
+                "summary": "The promoted evidence changed the selected action.",
+                "evidence_ref": evidence["packet_ref"],
+                "status": "verified",
+                "observed_at": OBSERVED_AT,
+            }
+        ]
+        if verification_status == "verified"
+        else []
+    )
+    return build_decision_outcome_receipt(
+        goal_id=str(evidence["goal_id"]),
+        decision_id=str(evidence["decision_id"]),
+        proposal_packet_ref="decision-proposal:example",
+        recorded_at=OBSERVED_AT,
+        verification_status=verification_status,
+        accepted_decision={
+            "option_id": "option:bounded-fusion",
+            "summary": "Use semantic recall under exact-read authority.",
+            "accepted_by": "agent:decision-advisor",
+            "accepted_at": OBSERVED_AT,
+        },
+        resulting_transitions=[
+            {
+                "transition_id": "transition:activate-provider",
+                "summary": "The advisory provider entered bounded dogfood.",
+                "event_ref": "event:provider-dogfood",
+                "status": "committed",
+            }
+        ],
+        observed_outcomes=observed_outcomes,
+        invalidated_assumptions=[],
+        review_at=REVIEW_AT,
+    )
+
+
+def build_feedback(
+    evidence: dict[str, object],
+    outcome: dict[str, object],
+    *,
+    retrieval_receipt: dict[str, object] | None = None,
+) -> dict[str, object]:
+    return build_decision_outcome_feedback(
+        evidence_packet=evidence,
+        outcome_receipt=outcome,
+        workspace_ref="workspace:example",
+        project_ref="project:decision-advisor",
+        retrieval_receipt=retrieval_receipt,
+    )
+
+
+def test_verified_promoted_recall_creates_review_only_candidate() -> None:
+    evidence = evidence_packet()
+    feedback = build_feedback(evidence, outcome_receipt(evidence))
+
+    assert feedback["schema_version"] == "decision_outcome_feedback_v0"
+    assert feedback["retrieval_telemetry"] == {
+        "discovered_result_count": 2,
+        "exact_read_promoted_count": 1,
+        "rejected_result_count": 1,
+        "rejected_recall_record_count": 1,
+        "rejection_reason_counts": {"stale_authority_revision": 1},
+        "provider_health_status_counts": {"healthy": 1},
+        "current_source_revision_count": 1,
+        "count_mode": "evidence_records",
+    }
+    assert feedback["outcome_telemetry"]["linked_verified_outcome_count"] == 1
+    assert feedback["reward_memory"] == {
+        "candidate_created": True,
+        "candidate_status": "review_ready",
+        "candidate_ref": feedback["reward_memory_candidate"]["candidate"][
+            "candidate_ref"
+        ],
+        "ineligible_reason_codes": [],
+        "review_required": True,
+        "automatic_ingest_performed": False,
+        "automatic_activation_performed": False,
+    }
+    candidate = feedback["reward_memory_candidate"]
+    assert candidate["candidate"]["lifecycle"]["state"] == "candidate"
+    assert candidate["candidate_persisted"] is False
+    assert candidate["provider_write_performed"] is False
+    assert candidate["external_writes_performed"] is False
+
+
+def test_rejected_recall_is_telemetry_only() -> None:
+    evidence = evidence_packet(promoted=False)
+    feedback = build_feedback(evidence, outcome_receipt(evidence))
+
+    assert feedback["retrieval_telemetry"]["exact_read_promoted_count"] == 0
+    assert feedback["retrieval_telemetry"]["rejected_result_count"] == 1
+    assert feedback["reward_memory_candidate"] is None
+    assert feedback["reward_memory"]["candidate_created"] is False
+    assert feedback["reward_memory"]["ineligible_reason_codes"] == [
+        "no_exact_read_promoted_claim"
+    ]
+
+
+def test_pending_outcome_does_not_create_candidate() -> None:
+    evidence = evidence_packet()
+    feedback = build_feedback(
+        evidence,
+        outcome_receipt(evidence, verification_status="pending"),
+    )
+
+    assert feedback["reward_memory_candidate"] is None
+    assert feedback["reward_memory"]["ineligible_reason_codes"] == [
+        "outcome_not_candidate_eligible",
+        "outcome_not_verified",
+        "verified_outcome_not_linked_to_evidence",
+    ]
+
+
+def test_retrieval_receipt_preserves_real_result_rejection_count() -> None:
+    evidence = evidence_packet()
+    receipt = ContextProviderRetrieval(
+        provider="semantic-provider",
+        namespace="decision-context",
+        status="completed",
+        query_summary="bounded decision recall",
+        observed_at=OBSERVED_AT,
+        search_performed=True,
+        read_performed=True,
+        items=tuple(
+            ContextProviderItem(
+                resource_ref=f"resource:{index}",
+                summary=f"Result {index}",
+                content=f"Transient result {index}",
+                score=0.9,
+            )
+            for index in range(6)
+        ),
+        requested_limit=6,
+    ).public_packet()
+    feedback = build_feedback(
+        evidence,
+        outcome_receipt(evidence),
+        retrieval_receipt=receipt,
+    )
+
+    assert feedback["retrieval_telemetry"]["discovered_result_count"] == 6
+    assert feedback["retrieval_telemetry"]["exact_read_promoted_count"] == 1
+    assert feedback["retrieval_telemetry"]["rejected_result_count"] == 5
+    assert feedback["retrieval_telemetry"]["rejected_recall_record_count"] == 1
+    assert feedback["retrieval_telemetry"]["count_mode"] == "retrieval_receipt"
+
+
+def test_feedback_rejects_tampered_packets() -> None:
+    evidence = evidence_packet()
+    tampered = copy.deepcopy(evidence)
+    tampered["recalled_claims"][0]["summary"] = "Tampered after packet hashing."
+
+    with pytest.raises(ValueError, match="canonical and untampered"):
+        build_feedback(tampered, outcome_receipt(evidence))
+
+
+def test_feedback_projection_contains_no_raw_provider_or_activation_state() -> None:
+    evidence = evidence_packet()
+    serialized = json.dumps(
+        build_feedback(evidence, outcome_receipt(evidence)),
+        sort_keys=True,
+    )
+
+    assert '"provider_payload":' not in serialized
+    assert '"raw_chat":' not in serialized
+    assert '"private_locator":' not in serialized
+    assert '"state": "active"' not in serialized


### PR DESCRIPTION
## Summary

- add a default-off, provider-neutral Decision Context outcome-feedback adapter
- emit aggregate retrieval telemetry while keeping rejected recall out of memory
- create a review-only procedural-experience candidate only when exact-read evidence and a linked verified outcome agree
- preserve real provider result counts through an optional canonical public retrieval receipt

## Product / architecture judgment

This closes the existing Decision Context -> Reward Memory contract without
moving decision semantics into Core. The adapter accepts only canonical,
untampered packets, does not create authority, and performs no persistence,
ingestion, review, or activation. Existing goals and hot paths remain unchanged.

The primary risk is accidentally promoting stale recall or leaking transient
provider material. The implementation requires exact-read-promoted evidence,
current source revision, resolved conflicts, and a verified linked outcome;
public output retains counts and opaque refs rather than provider content.

## Validation

- `29 passed`: Decision Context packet/feedback and Reward Memory ingestion tests
- Ruff passed on all changed Python files
- standard `loopx canary premerge --from-git-diff` passed
- 13 selected canary/risk/boundary checks passed, 0 failures, 0 warnings
- public boundary scan clean across all 5 changed files
- no manual holds; premerge gate reports self-merge allowed
