### PR TITLE
feat(materials): add lossless ranked entry rebuild

### DIFF
--- a/docs/reference/protocols/material-lifecycle-architecture-v0.md
+++ b/docs/reference/protocols/material-lifecycle-architecture-v0.md
@@ -72,6 +72,27 @@ copying raw content into another queue.
 requires an owner-gate reference, validation reference, before/after revisions,
 and rollback reference for applied changes.
 
+`material_ranked_entry_rebuild_plan_v0` handles structural queue repair that a
+bounded rank move cannot express. A ranked entry that exceeds the configured
+member budget must become two or more independently sortable entries; overflow
+cannot be hidden in a supporting-only index. The caller supplies the semantic
+grouping after exact reads. The provider-neutral builder then enforces:
+
+- at most `max_materials_per_entry` references per rebuilt entry;
+- every source material reference appears exactly once;
+- child entries preserve exact source-entry membership while exact-read
+  semantic grouping may replace incidental legacy order;
+- target ranks are unique and contiguous across the complete ranked set;
+- unchanged entries retain their reference, while split children receive a
+  deterministic reference derived from their source entry and ordered members;
+- optional material-level rank anchors remain at their protected target rank.
+
+The complete ranked set may be larger than the active window. Entries below the
+window remain in an explicit ranked backlog, not outside the ranking system.
+`material_ranked_entry_rebuild_apply_receipt_v0` records the owner-gated
+cutover, validation, before/after revisions, counts, and rollback reference.
+Neither packet carries titles, content, source locations, or credentials.
+
 ## Migration Boundary
 
 Legacy Markdown, databases, inboxes, and other stores remain authoritative

--- a/docs/reference/protocols/material-lifecycle-architecture-v0.zh-CN.md
+++ b/docs/reference/protocols/material-lifecycle-architecture-v0.zh-CN.md
@@ -68,6 +68,24 @@ flowchart LR
 `material_rerank_apply_receipt_v0` 与 proposal 分离。真正 apply 必须记录
 owner gate、验证引用、前后 revision；发生修改时还必须有 rollback 引用。
 
+`material_ranked_entry_rebuild_plan_v0` 负责小范围 rank move 无法表达的结构
+修复。超过成员预算的 ranked entry 必须拆成两个或更多可以独立排序的条目，
+不能把 overflow 隐藏到 supporting-only index。调用方在 exact read 后提供语义
+分组，provider-neutral builder 统一执行以下硬门禁：
+
+- 每个重建条目最多包含 `max_materials_per_entry` 个素材引用；
+- 每个源素材引用在完整结果中恰好出现一次；
+- child entry 保留精确 source-entry 成员关系，但 exact-read 语义分组可以替换
+  旧存储中的偶然顺序；
+- 完整 ranked set 的 target rank 唯一且从 1 连续；
+- 未拆分条目保留原引用，拆分 child 根据 source entry 与有序成员生成确定性引用；
+- 可选的 material-level rank anchor 必须留在受保护的 target rank。
+
+完整 ranked set 可以大于活跃窗口。窗口外条目进入显式 ranked backlog，仍属于
+排序系统，而不是“隐藏材料”。`material_ranked_entry_rebuild_apply_receipt_v0`
+记录 owner-gated cutover、验证、前后 revision、数量与 rollback 引用。两个 packet
+均不携带标题、正文、来源位置或凭据。
+
 ## 迁移边界
 
 旧 Markdown、数据库、inbox 等存储在以下条件满足前始终是 authority：

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -407,7 +407,7 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
         "origin": "builtin",
         "visibility": "public",
         "provider_id": "loopx-core",
-        "title": "Backup-safe material inventory, archive, and bounded rerank contract",
+        "title": "Backup-safe material inventory, ranked-entry rebuild, and rerank",
         "status": "experimental",
         "default_enabled": False,
         "real_world_anchor": (
@@ -416,7 +416,8 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
         ),
         "user_value": (
             "Preserve raw source authority and stable material references while "
-            "making migration, archive transitions, and small reranks auditable."
+            "making migration, archive transitions, structural entry rebuilds, "
+            "and small reranks auditable."
         ),
         "entry_command": "loopx material-lifecycle architecture --format json",
         "commands": [
@@ -457,6 +458,16 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "module": "loopx.capabilities.material_lifecycle.ranking",
                 "doc": "docs/reference/protocols/material-lifecycle-architecture-v0.md",
             },
+            {
+                "schema_version": "material_ranked_entry_rebuild_plan_v0",
+                "module": "loopx.capabilities.material_lifecycle.rebuild",
+                "doc": "docs/reference/protocols/material-lifecycle-architecture-v0.md",
+            },
+            {
+                "schema_version": "material_ranked_entry_rebuild_apply_receipt_v0",
+                "module": "loopx.capabilities.material_lifecycle.rebuild",
+                "doc": "docs/reference/protocols/material-lifecycle-architecture-v0.md",
+            },
         ],
         "smokes": ["python3 examples/material-lifecycle-contract-smoke.py"],
         "docs": [
@@ -468,11 +479,12 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
             "Raw material, private locations, provider payloads, credentials, and source-store formats stay outside public packets.",
             "Snapshot and verified backup precede dual-read reconciliation; cutover and rollback remain owner-gated.",
             "Decision Context may supply revisioned evidence, but Material Lifecycle owns candidate, archive, and rerank receipts.",
+            "Oversized ranked entries are rebuilt into independently sortable entries; overflow cannot be hidden outside the ranked set.",
             "Concrete legacy adapters, exploration providers, source profiles, and material-store writes remain deferred to private dogfood.",
         ],
         "next_real_step": (
-            "Build one read-only legacy inventory and migration planner, then "
-            "validate a decision-driven bounded rerank without mutating raw sources."
+            "Dogfood one exact-read semantic rebuild through owner-gated apply "
+            "while preserving complete source bytes and canonical records."
         ),
     },
     {

--- a/loopx/capabilities/material_lifecycle/__init__.py
+++ b/loopx/capabilities/material_lifecycle/__init__.py
@@ -52,6 +52,13 @@ from .ranking import (
     build_material_rerank_apply_receipt,
     build_material_rerank_proposal,
 )
+from .rebuild import (
+    MATERIAL_RANKED_ENTRY_REBUILD_APPLY_RECEIPT_SCHEMA_VERSION,
+    MATERIAL_RANKED_ENTRY_REBUILD_PLAN_SCHEMA_VERSION,
+    build_material_ranked_entry_rebuild_apply_receipt,
+    build_material_ranked_entry_rebuild_plan,
+    derive_material_ranked_entry_ref,
+)
 
 __all__ = [
     "MATERIAL_EXPLORE_INTENT_SCHEMA_VERSION",
@@ -62,6 +69,8 @@ __all__ = [
     "MATERIAL_MIGRATION_APPLY_RECEIPT_SCHEMA_VERSION",
     "MATERIAL_MIGRATION_PLAN_SCHEMA_VERSION",
     "MATERIAL_MIGRATION_ROLLBACK_RECEIPT_SCHEMA_VERSION",
+    "MATERIAL_RANKED_ENTRY_REBUILD_APPLY_RECEIPT_SCHEMA_VERSION",
+    "MATERIAL_RANKED_ENTRY_REBUILD_PLAN_SCHEMA_VERSION",
     "MATERIAL_RERANK_APPLY_RECEIPT_SCHEMA_VERSION",
     "MATERIAL_RERANK_PROPOSAL_SCHEMA_VERSION",
     "MATERIAL_STORE_INVENTORY_SCHEMA_VERSION",
@@ -83,9 +92,12 @@ __all__ = [
     "build_material_lifecycle_architecture_packet",
     "build_material_lifecycle_receipt",
     "build_material_migration_plan",
+    "build_material_ranked_entry_rebuild_apply_receipt",
+    "build_material_ranked_entry_rebuild_plan",
     "build_material_rerank_apply_receipt",
     "build_material_rerank_proposal",
     "build_material_store_inventory",
+    "derive_material_ranked_entry_ref",
     "execute_material_explore_intent",
     "plan_material_decision_actions",
     "prepare_material_migration",

--- a/loopx/capabilities/material_lifecycle/architecture.py
+++ b/loopx/capabilities/material_lifecycle/architecture.py
@@ -12,6 +12,10 @@ from .ranking import (
     MATERIAL_RERANK_APPLY_RECEIPT_SCHEMA_VERSION,
     MATERIAL_RERANK_PROPOSAL_SCHEMA_VERSION,
 )
+from .rebuild import (
+    MATERIAL_RANKED_ENTRY_REBUILD_APPLY_RECEIPT_SCHEMA_VERSION,
+    MATERIAL_RANKED_ENTRY_REBUILD_PLAN_SCHEMA_VERSION,
+)
 
 MATERIAL_LIFECYCLE_ARCHITECTURE_SCHEMA_VERSION = "material_lifecycle_architecture_v0"
 
@@ -35,6 +39,8 @@ def build_material_lifecycle_architecture_packet() -> dict[str, object]:
             MATERIAL_LIFECYCLE_RECEIPT_SCHEMA_VERSION,
             MATERIAL_RERANK_PROPOSAL_SCHEMA_VERSION,
             MATERIAL_RERANK_APPLY_RECEIPT_SCHEMA_VERSION,
+            MATERIAL_RANKED_ENTRY_REBUILD_PLAN_SCHEMA_VERSION,
+            MATERIAL_RANKED_ENTRY_REBUILD_APPLY_RECEIPT_SCHEMA_VERSION,
             MATERIAL_EXPLORE_INTENT_SCHEMA_VERSION,
         ],
         "sibling_capabilities": {
@@ -63,6 +69,7 @@ def build_material_lifecycle_architecture_packet() -> dict[str, object]:
             "active",
             "archive_or_carryover",
             "bounded_rerank",
+            "lossless_ranked_entry_rebuild",
             "bounded_explore_intent",
             "audited_apply",
         ],
@@ -73,6 +80,9 @@ def build_material_lifecycle_architecture_packet() -> dict[str, object]:
             "legacy_and_new_stores_dual_read_before_owner_gated_cutover",
             "stable_material_refs_survive_archive_and_reactivation",
             "rerank_is_a_bounded_delta_with_protected_items_and_no_change",
+            "oversized_ranked_entries_split_instead_of_hiding_members",
+            "ranked_entry_rebuild_preserves_exact_coverage_and_unique_membership",
+            "ranked_entry_children_have_deterministic_stable_references",
             "decision_evidence_is_revision_bound_and_public_safe",
             "explore_intent_is_budgeted_analysis_only_and_has_a_stop_condition",
             "invalid_or_unavailable_policy_fails_open_to_no_change",

--- a/loopx/capabilities/material_lifecycle/rebuild.py
+++ b/loopx/capabilities/material_lifecycle/rebuild.py
@@ -1,0 +1,473 @@
+"""Lossless ranked-entry rebuild contracts for material queues."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from ._validation import (
+    capability_contract,
+    check_record_keys,
+    compact_text,
+    compact_token,
+    iso_timestamp,
+    packet_ref,
+    positive_int,
+    token_list,
+)
+
+MATERIAL_RANKED_ENTRY_REBUILD_PLAN_SCHEMA_VERSION = (
+    "material_ranked_entry_rebuild_plan_v0"
+)
+MATERIAL_RANKED_ENTRY_REBUILD_APPLY_RECEIPT_SCHEMA_VERSION = (
+    "material_ranked_entry_rebuild_apply_receipt_v0"
+)
+
+_SOURCE_ENTRY_FIELDS = {"entry_ref", "material_refs", "rank"}
+_REBUILT_ENTRY_FIELDS = {
+    "evidence_refs",
+    "material_refs",
+    "reason_code",
+    "source_entry_ref",
+    "target_rank",
+}
+_RANK_ANCHOR_FIELDS = {"material_ref", "rank"}
+_APPLY_STATUSES = {"applied", "no_change", "rejected", "rolled_back"}
+
+
+def _ordered_token_list(
+    values: Sequence[Any],
+    *,
+    field: str,
+    max_items: int = 100,
+) -> list[str]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise TypeError(f"{field} must be a sequence of compact tokens")
+    if not values:
+        raise ValueError(f"{field} must contain at least one item")
+    if len(values) > max_items:
+        raise ValueError(f"{field} must contain at most {max_items} items")
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        token = compact_token(value, field=f"{field}[]")
+        if token in seen:
+            raise ValueError(f"{field} values must be unique")
+        seen.add(token)
+        normalized.append(token)
+    return normalized
+
+
+def derive_material_ranked_entry_ref(
+    *,
+    source_entry_ref: str,
+    material_refs: Sequence[str],
+) -> str:
+    """Derive a stable child reference from its source entry and ordered members."""
+
+    source_ref = compact_token(source_entry_ref, field="source_entry_ref")
+    members = _ordered_token_list(material_refs, field="material_refs")
+    return packet_ref(
+        "material-ranked-entry",
+        {"source_entry_ref": source_ref, "material_refs": members},
+    )
+
+
+def _normalize_source_entries(
+    values: Sequence[Mapping[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]], set[str]]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise TypeError("source_entries must be a sequence of objects")
+    if not values:
+        raise ValueError("source_entries must contain at least one entry")
+
+    normalized: list[dict[str, Any]] = []
+    by_ref: dict[str, dict[str, Any]] = {}
+    all_material_refs: set[str] = set()
+    source_ranks: set[int] = set()
+    for index, value in enumerate(values):
+        field = f"source_entries[{index}]"
+        check_record_keys(
+            value,
+            field=field,
+            allowed=_SOURCE_ENTRY_FIELDS,
+            required=_SOURCE_ENTRY_FIELDS,
+        )
+        entry_ref = compact_token(value["entry_ref"], field=f"{field}.entry_ref")
+        if entry_ref in by_ref:
+            raise ValueError("source_entries entry_ref values must be unique")
+        rank = positive_int(value["rank"], field=f"{field}.rank")
+        if rank in source_ranks:
+            raise ValueError("source_entries rank values must be unique")
+        material_refs = _ordered_token_list(
+            value["material_refs"],
+            field=f"{field}.material_refs",
+        )
+        duplicates = all_material_refs.intersection(material_refs)
+        if duplicates:
+            raise ValueError(
+                "source material_refs must be globally unique: "
+                + ", ".join(sorted(duplicates))
+            )
+        source_ranks.add(rank)
+        all_material_refs.update(material_refs)
+        entry = {
+            "entry_ref": entry_ref,
+            "rank": rank,
+            "material_refs": material_refs,
+        }
+        by_ref[entry_ref] = entry
+        normalized.append(entry)
+
+    if sorted(source_ranks) != list(range(1, len(normalized) + 1)):
+        raise ValueError("source_entries ranks must be contiguous from 1")
+    return sorted(normalized, key=lambda item: item["rank"]), by_ref, all_material_refs
+
+
+def _normalize_rebuilt_entries(
+    values: Sequence[Mapping[str, Any]],
+    *,
+    source_by_ref: Mapping[str, Mapping[str, Any]],
+    source_material_refs: set[str],
+    max_materials_per_entry: int,
+) -> tuple[list[dict[str, Any]], set[str]]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise TypeError("rebuilt_entries must be a sequence of objects")
+    if not values:
+        raise ValueError("rebuilt_entries must contain at least one entry")
+
+    grouped_materials: dict[str, set[str]] = {}
+    normalized: list[dict[str, Any]] = []
+    output_entry_refs: set[str] = set()
+    output_material_refs: set[str] = set()
+    target_ranks: set[int] = set()
+    for index, value in enumerate(values):
+        field = f"rebuilt_entries[{index}]"
+        check_record_keys(
+            value,
+            field=field,
+            allowed=_REBUILT_ENTRY_FIELDS,
+            required={
+                "material_refs",
+                "reason_code",
+                "source_entry_ref",
+                "target_rank",
+            },
+        )
+        source_entry_ref = compact_token(
+            value["source_entry_ref"],
+            field=f"{field}.source_entry_ref",
+        )
+        if source_entry_ref not in source_by_ref:
+            raise ValueError(f"{field}.source_entry_ref is not in source_entries")
+        target_rank = positive_int(
+            value["target_rank"],
+            field=f"{field}.target_rank",
+        )
+        if target_rank in target_ranks:
+            raise ValueError("rebuilt_entries target_rank values must be unique")
+        material_refs = _ordered_token_list(
+            value["material_refs"],
+            field=f"{field}.material_refs",
+            max_items=max_materials_per_entry,
+        )
+        unknown = set(material_refs) - source_material_refs
+        if unknown:
+            raise ValueError(
+                f"{field}.material_refs contains unknown refs: "
+                + ", ".join(sorted(unknown))
+            )
+        duplicates = output_material_refs.intersection(material_refs)
+        if duplicates:
+            raise ValueError(
+                "rebuilt material_refs must be globally unique: "
+                + ", ".join(sorted(duplicates))
+            )
+
+        source_entry = source_by_ref[source_entry_ref]
+        source_members = list(source_entry["material_refs"])
+        if material_refs == source_members:
+            entry_ref = source_entry_ref
+        else:
+            entry_ref = derive_material_ranked_entry_ref(
+                source_entry_ref=source_entry_ref,
+                material_refs=material_refs,
+            )
+        if entry_ref in output_entry_refs:
+            raise ValueError("derived rebuilt entry_ref values must be unique")
+
+        grouped_materials.setdefault(source_entry_ref, set()).update(material_refs)
+        output_entry_refs.add(entry_ref)
+        output_material_refs.update(material_refs)
+        target_ranks.add(target_rank)
+        normalized.append(
+            {
+                "entry_ref": entry_ref,
+                "source_entry_ref": source_entry_ref,
+                "target_rank": target_rank,
+                "material_refs": material_refs,
+                "reason_code": compact_token(
+                    value["reason_code"],
+                    field=f"{field}.reason_code",
+                ),
+                "evidence_refs": token_list(
+                    value.get("evidence_refs"),
+                    field=f"{field}.evidence_refs",
+                    max_items=10,
+                ),
+            }
+        )
+
+    if sorted(target_ranks) != list(range(1, len(normalized) + 1)):
+        raise ValueError("rebuilt_entries target ranks must be contiguous from 1")
+    if output_material_refs != source_material_refs:
+        missing = sorted(source_material_refs - output_material_refs)
+        raise ValueError(
+            "rebuilt_entries must cover every source material_ref exactly once"
+            + (f"; missing: {', '.join(missing)}" if missing else "")
+        )
+    for source_entry_ref, source_entry in source_by_ref.items():
+        if grouped_materials[source_entry_ref] != set(source_entry["material_refs"]):
+            raise ValueError(
+                "rebuilt child entries must preserve exact source membership "
+                f"for {source_entry_ref}"
+            )
+    return sorted(normalized, key=lambda item: item["target_rank"]), output_entry_refs
+
+
+def _normalize_rank_anchors(
+    values: Sequence[Mapping[str, Any]] | None,
+    *,
+    source_material_refs: set[str],
+    rebuilt_entries: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    if values is None:
+        return []
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise TypeError("protected_rank_anchors must be a sequence of objects")
+
+    material_locations = {
+        str(material_ref): int(entry["target_rank"])
+        for entry in rebuilt_entries
+        for material_ref in entry["material_refs"]
+    }
+    normalized: list[dict[str, Any]] = []
+    material_refs: set[str] = set()
+    ranks: set[int] = set()
+    for index, value in enumerate(values):
+        field = f"protected_rank_anchors[{index}]"
+        check_record_keys(
+            value,
+            field=field,
+            allowed=_RANK_ANCHOR_FIELDS,
+            required=_RANK_ANCHOR_FIELDS,
+        )
+        material_ref = compact_token(
+            value["material_ref"],
+            field=f"{field}.material_ref",
+        )
+        rank = positive_int(value["rank"], field=f"{field}.rank")
+        if material_ref not in source_material_refs:
+            raise ValueError(f"{field}.material_ref is not in source_entries")
+        if material_ref in material_refs or rank in ranks:
+            raise ValueError("protected_rank_anchors materials and ranks must be unique")
+        if material_locations[material_ref] != rank:
+            raise ValueError(f"{field} does not match the rebuilt target rank")
+        material_refs.add(material_ref)
+        ranks.add(rank)
+        normalized.append({"material_ref": material_ref, "rank": rank})
+    return sorted(normalized, key=lambda item: item["rank"])
+
+
+def build_material_ranked_entry_rebuild_plan(
+    *,
+    goal_id: str,
+    plan_id: str,
+    inventory_ref: str,
+    source_revision: str,
+    observed_at: str,
+    source_entries: Sequence[Mapping[str, Any]],
+    rebuilt_entries: Sequence[Mapping[str, Any]],
+    max_materials_per_entry: int = 3,
+    top_window_size: int = 30,
+    protected_rank_anchors: Sequence[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Validate a lossless structural rebuild without applying store changes."""
+
+    entry_limit = positive_int(
+        max_materials_per_entry,
+        field="max_materials_per_entry",
+    )
+    window_size = positive_int(top_window_size, field="top_window_size")
+    normalized_source, source_by_ref, source_material_refs = (
+        _normalize_source_entries(source_entries)
+    )
+    normalized_rebuilt, output_entry_refs = _normalize_rebuilt_entries(
+        rebuilt_entries,
+        source_by_ref=source_by_ref,
+        source_material_refs=source_material_refs,
+        max_materials_per_entry=entry_limit,
+    )
+    if window_size > len(normalized_rebuilt):
+        raise ValueError("top_window_size cannot exceed rebuilt entry count")
+    anchors = _normalize_rank_anchors(
+        protected_rank_anchors,
+        source_material_refs=source_material_refs,
+        rebuilt_entries=normalized_rebuilt,
+    )
+
+    split_source_refs = sorted(
+        source_ref
+        for source_ref in source_by_ref
+        if sum(
+            entry["source_entry_ref"] == source_ref for entry in normalized_rebuilt
+        )
+        > 1
+    )
+    oversized_source_refs = sorted(
+        source_ref
+        for source_ref, source_entry in source_by_ref.items()
+        if len(source_entry["material_refs"]) > entry_limit
+    )
+    if not set(oversized_source_refs).issubset(split_source_refs):
+        raise ValueError("every oversized source entry must create child entries")
+
+    plan: dict[str, Any] = {
+        "schema_version": MATERIAL_RANKED_ENTRY_REBUILD_PLAN_SCHEMA_VERSION,
+        "goal_id": compact_token(goal_id, field="goal_id"),
+        "plan_id": compact_token(plan_id, field="plan_id"),
+        "inventory_ref": compact_token(inventory_ref, field="inventory_ref"),
+        "source_revision": compact_token(source_revision, field="source_revision"),
+        "observed_at": iso_timestamp(observed_at, field="observed_at"),
+        "visibility": "public_safe",
+        "capability": capability_contract(packet_role="ranked_entry_rebuild_plan"),
+        "constraints": {
+            "max_materials_per_entry": entry_limit,
+            "top_window_size": window_size,
+            "protected_rank_anchors": anchors,
+        },
+        "source_entries": normalized_source,
+        "rebuilt_entries": normalized_rebuilt,
+        "summary": {
+            "source_entry_count": len(normalized_source),
+            "rebuilt_entry_count": len(normalized_rebuilt),
+            "material_ref_count": len(source_material_refs),
+            "split_source_entry_count": len(split_source_refs),
+            "oversized_source_entry_count": len(oversized_source_refs),
+            "top_window_entry_count": window_size,
+            "ranked_backlog_entry_count": len(normalized_rebuilt) - window_size,
+        },
+        "verification": {
+            "complete_coverage_verified": True,
+            "unique_membership_verified": True,
+            "source_lineage_membership_verified": True,
+            "contiguous_rank_sequence_verified": True,
+            "entry_budget_verified": True,
+            "deterministic_entry_refs_verified": len(output_entry_refs)
+            == len(normalized_rebuilt),
+            "protected_rank_anchors_verified": True,
+        },
+        "apply_authorized": False,
+        "raw_content_captured": False,
+        "private_locations_captured": False,
+    }
+    plan["plan_ref"] = packet_ref("material-ranked-entry-rebuild", plan)
+    return plan
+
+
+def build_material_ranked_entry_rebuild_apply_receipt(
+    *,
+    goal_id: str,
+    receipt_id: str,
+    plan_ref: str,
+    observed_at: str,
+    status: str,
+    before_revision: str,
+    after_revision: str,
+    owner_gate_ref: str,
+    validation_ref: str,
+    source_entry_count: int,
+    rebuilt_entry_count: int,
+    material_ref_count: int,
+    top_window_size: int,
+    rollback_ref: str | None = None,
+    rejection_reason: str | None = None,
+) -> dict[str, Any]:
+    """Record an owner-gated structural rebuild result."""
+
+    normalized_status = compact_token(status, field="status")
+    if normalized_status not in _APPLY_STATUSES:
+        raise ValueError(f"unsupported status: {normalized_status}")
+    before = compact_token(before_revision, field="before_revision")
+    after = compact_token(after_revision, field="after_revision")
+    source_count = positive_int(source_entry_count, field="source_entry_count")
+    rebuilt_count = positive_int(rebuilt_entry_count, field="rebuilt_entry_count")
+    material_count = positive_int(material_ref_count, field="material_ref_count")
+    window_size = positive_int(top_window_size, field="top_window_size")
+    if rebuilt_count < source_count:
+        raise ValueError("rebuilt_entry_count cannot be smaller than source_entry_count")
+    if window_size > rebuilt_count:
+        raise ValueError("top_window_size cannot exceed rebuilt_entry_count")
+
+    if normalized_status in {"applied", "rolled_back"}:
+        if before == after:
+            raise ValueError(f"{normalized_status} status requires a new revision")
+        if rollback_ref is None:
+            raise ValueError(f"{normalized_status} status requires rollback_ref")
+    elif before != after:
+        raise ValueError(f"{normalized_status} status must preserve revision")
+    if normalized_status == "rejected" and rejection_reason is None:
+        raise ValueError("rejected status requires rejection_reason")
+    if normalized_status != "rejected" and rejection_reason is not None:
+        raise ValueError("rejection_reason is only valid for rejected status")
+
+    receipt: dict[str, Any] = {
+        "schema_version": (
+            MATERIAL_RANKED_ENTRY_REBUILD_APPLY_RECEIPT_SCHEMA_VERSION
+        ),
+        "goal_id": compact_token(goal_id, field="goal_id"),
+        "receipt_id": compact_token(receipt_id, field="receipt_id"),
+        "plan_ref": compact_token(plan_ref, field="plan_ref"),
+        "observed_at": iso_timestamp(observed_at, field="observed_at"),
+        "status": normalized_status,
+        "before_revision": before,
+        "after_revision": after,
+        "owner_gate_ref": compact_token(owner_gate_ref, field="owner_gate_ref"),
+        "validation_ref": compact_token(validation_ref, field="validation_ref"),
+        "summary": {
+            "source_entry_count": source_count,
+            "rebuilt_entry_count": rebuilt_count,
+            "material_ref_count": material_count,
+            "top_window_entry_count": window_size,
+            "ranked_backlog_entry_count": rebuilt_count - window_size,
+        },
+        "verification": {
+            "complete_coverage_verified": True,
+            "unique_membership_verified": True,
+            "contiguous_rank_sequence_verified": True,
+            "entry_budget_verified": True,
+            "deterministic_entry_refs_verified": True,
+        },
+        "visibility": "public_safe",
+        "capability": capability_contract(
+            packet_role="ranked_entry_rebuild_apply_receipt"
+        ),
+        "raw_content_captured": False,
+        "private_locations_captured": False,
+    }
+    if rollback_ref is not None:
+        receipt["rollback_ref"] = compact_token(
+            rollback_ref,
+            field="rollback_ref",
+        )
+    if rejection_reason is not None:
+        receipt["rejection_reason"] = compact_text(
+            rejection_reason,
+            field="rejection_reason",
+        )
+    receipt["receipt_ref"] = packet_ref(
+        "material-ranked-entry-rebuild-apply",
+        receipt,
+    )
+    return receipt

--- a/tests/capabilities/test_material_lifecycle_contracts.py
+++ b/tests/capabilities/test_material_lifecycle_contracts.py
@@ -6,6 +6,8 @@ from loopx.capabilities.material_lifecycle import (
     build_material_lifecycle_architecture_packet,
     build_material_lifecycle_receipt,
     build_material_migration_plan,
+    build_material_ranked_entry_rebuild_apply_receipt,
+    build_material_ranked_entry_rebuild_plan,
     build_material_rerank_apply_receipt,
     build_material_rerank_proposal,
     build_material_store_inventory,
@@ -316,3 +318,221 @@ def test_no_change_apply_receipt_preserves_revision() -> None:
 
     assert receipt["status"] == "no_change"
     assert receipt["applied_material_refs"] == []
+
+
+def test_ranked_entry_rebuild_splits_overflow_without_hiding_members() -> None:
+    plan = build_material_ranked_entry_rebuild_plan(
+        goal_id="goal:material-example",
+        plan_id="plan:entry-rebuild-1",
+        inventory_ref=str(inventory_packet()["inventory_ref"]),
+        source_revision="revision:42",
+        observed_at=OBSERVED_AT,
+        max_materials_per_entry=3,
+        top_window_size=3,
+        source_entries=[
+            {
+                "entry_ref": "entry:control-plane",
+                "rank": 1,
+                "material_refs": [
+                    "material:a",
+                    "material:b",
+                    "material:c",
+                    "material:d",
+                ],
+            },
+            {
+                "entry_ref": "entry:eval",
+                "rank": 2,
+                "material_refs": ["material:e", "material:f"],
+            },
+        ],
+        rebuilt_entries=[
+            {
+                "source_entry_ref": "entry:control-plane",
+                "target_rank": 1,
+                "material_refs": [
+                    "material:a",
+                    "material:b",
+                    "material:c",
+                ],
+                "reason_code": "split_oversized_entry",
+            },
+            {
+                "source_entry_ref": "entry:eval",
+                "target_rank": 2,
+                "material_refs": ["material:e", "material:f"],
+                "reason_code": "preserve_entry",
+            },
+            {
+                "source_entry_ref": "entry:control-plane",
+                "target_rank": 3,
+                "material_refs": ["material:d"],
+                "reason_code": "split_oversized_entry",
+            },
+        ],
+        protected_rank_anchors=[
+            {"material_ref": "material:a", "rank": 1},
+            {"material_ref": "material:e", "rank": 2},
+        ],
+    )
+
+    assert plan["summary"] == {
+        "source_entry_count": 2,
+        "rebuilt_entry_count": 3,
+        "material_ref_count": 6,
+        "split_source_entry_count": 1,
+        "oversized_source_entry_count": 1,
+        "top_window_entry_count": 3,
+        "ranked_backlog_entry_count": 0,
+    }
+    assert plan["rebuilt_entries"][1]["entry_ref"] == "entry:eval"
+    assert plan["rebuilt_entries"][2]["source_entry_ref"] == (
+        "entry:control-plane"
+    )
+    assert plan["verification"]["complete_coverage_verified"] is True
+    assert plan["apply_authorized"] is False
+
+
+def test_ranked_entry_rebuild_rejects_loss_duplication_and_hidden_overflow() -> None:
+    source_entries = [
+        {
+            "entry_ref": "entry:source",
+            "rank": 1,
+            "material_refs": [
+                "material:a",
+                "material:b",
+                "material:c",
+                "material:d",
+            ],
+        }
+    ]
+    with pytest.raises(ValueError, match="cover every source"):
+        build_material_ranked_entry_rebuild_plan(
+            goal_id="goal:material-example",
+            plan_id="plan:lossy",
+            inventory_ref=str(inventory_packet()["inventory_ref"]),
+            source_revision="revision:42",
+            observed_at=OBSERVED_AT,
+            source_entries=source_entries,
+            rebuilt_entries=[
+                {
+                    "source_entry_ref": "entry:source",
+                    "target_rank": 1,
+                    "material_refs": [
+                        "material:a",
+                        "material:b",
+                        "material:c",
+                    ],
+                    "reason_code": "hide_overflow",
+                }
+            ],
+            top_window_size=1,
+        )
+
+    with pytest.raises(ValueError, match="globally unique"):
+        build_material_ranked_entry_rebuild_plan(
+            goal_id="goal:material-example",
+            plan_id="plan:duplicate",
+            inventory_ref=str(inventory_packet()["inventory_ref"]),
+            source_revision="revision:42",
+            observed_at=OBSERVED_AT,
+            source_entries=source_entries,
+            rebuilt_entries=[
+                {
+                    "source_entry_ref": "entry:source",
+                    "target_rank": 1,
+                    "material_refs": [
+                        "material:a",
+                        "material:b",
+                        "material:c",
+                    ],
+                    "reason_code": "split",
+                },
+                {
+                    "source_entry_ref": "entry:source",
+                    "target_rank": 2,
+                    "material_refs": ["material:c", "material:d"],
+                    "reason_code": "split",
+                },
+            ],
+            top_window_size=2,
+        )
+
+
+def test_ranked_entry_rebuild_allows_exact_read_semantic_regrouping() -> None:
+    plan = build_material_ranked_entry_rebuild_plan(
+        goal_id="goal:material-example",
+        plan_id="plan:semantic-regroup",
+        inventory_ref=str(inventory_packet()["inventory_ref"]),
+        source_revision="revision:42",
+        observed_at=OBSERVED_AT,
+        source_entries=[
+            {
+                "entry_ref": "entry:source",
+                "rank": 1,
+                "material_refs": [
+                    "material:a",
+                    "material:b",
+                    "material:c",
+                    "material:d",
+                ],
+            }
+        ],
+        rebuilt_entries=[
+            {
+                "source_entry_ref": "entry:source",
+                "target_rank": 1,
+                "material_refs": ["material:a", "material:c"],
+                "reason_code": "semantic_regroup",
+            },
+            {
+                "source_entry_ref": "entry:source",
+                "target_rank": 2,
+                "material_refs": ["material:b", "material:d"],
+                "reason_code": "semantic_regroup",
+            },
+        ],
+        top_window_size=2,
+    )
+
+    assert plan["verification"]["source_lineage_membership_verified"] is True
+
+
+def test_ranked_entry_rebuild_apply_receipt_requires_rollback() -> None:
+    receipt = build_material_ranked_entry_rebuild_apply_receipt(
+        goal_id="goal:material-example",
+        receipt_id="receipt:entry-rebuild-1",
+        plan_ref="material-ranked-entry-rebuild-0123456789abcdef",
+        observed_at=OBSERVED_AT,
+        status="applied",
+        before_revision="revision:42",
+        after_revision="revision:43",
+        owner_gate_ref="gate:entry-rebuild-1",
+        validation_ref="validation:entry-rebuild-1",
+        source_entry_count=30,
+        rebuilt_entry_count=40,
+        material_ref_count=89,
+        top_window_size=30,
+        rollback_ref="rollback:revision-42",
+    )
+
+    assert receipt["summary"]["ranked_backlog_entry_count"] == 10
+    assert receipt["verification"]["entry_budget_verified"] is True
+    assert receipt["raw_content_captured"] is False
+
+    with pytest.raises(ValueError, match="rollback_ref"):
+        build_material_ranked_entry_rebuild_apply_receipt(
+            goal_id="goal:material-example",
+            receipt_id="receipt:entry-rebuild-2",
+            plan_ref="material-ranked-entry-rebuild-0123456789abcdef",
+            observed_at=OBSERVED_AT,
+            status="applied",
+            before_revision="revision:42",
+            after_revision="revision:43",
+            owner_gate_ref="gate:entry-rebuild-1",
+            validation_ref="validation:entry-rebuild-1",
+            source_entry_count=30,
+            rebuilt_entry_count=40,
+            material_ref_count=89,
+            top_window_size=30,
+        )


### PR DESCRIPTION
## Summary
- add provider-neutral ranked-entry rebuild plan and apply receipt contracts
- require oversized entries to split into independently ranked children instead of hiding overflow
- enforce exact coverage, unique membership, source lineage, contiguous ranks, protected anchors, and rollback metadata
- register and document the default-off Material Lifecycle capability surface

## Validation
- 42 focused Material Lifecycle tests passed
- Ruff passed
- git diff --check passed
- private dogfood rebuilt 30 source bundles into 40 entries with 89/89 exact coverage; canonical records and raw sources remained unchanged (private evidence only)