### PR TITLE
feat(quality): add exact-scope change qualification

### DIFF
--- a/docs/capabilities/change-quality/README.md
+++ b/docs/capabilities/change-quality/README.md
@@ -1,0 +1,101 @@
+# Change Quality Qualification
+
+Change Quality Qualification gives a LoopX-managed goal a provider-neutral
+final-diff review contract. It is default-off. A project opts in through goal
+policy and chooses two independent controls:
+
+| Policy | Meaning |
+| --- | --- |
+| `safe_fix` | Permit one bounded repair pass before the final review receipt |
+| `strict_receipt` | Require a passing receipt for the exact current diff at premerge |
+
+`safe_fix` grants limited mutation authority; `strict_receipt` grants none.
+Projects may enable either, both, or neither after enabling the capability.
+
+## Configure A Goal
+
+Install the release-owned workflow into each connected project and host that
+should discover it:
+
+```bash
+loopx project-skill install \
+  --project . \
+  --skill loopx-change-quality \
+  --surface codex \
+  --execute
+```
+
+Use `claude-code` or `opencode` for those surfaces. This controls discovery,
+not activation. Preview goal policy before applying:
+
+```bash
+loopx configure-goal \
+  --goal-id <goal-id> \
+  --change-quality-enabled \
+  --change-quality-safe-fix \
+  --change-quality-strict-receipt
+
+loopx configure-goal \
+  --goal-id <goal-id> \
+  --change-quality-enabled \
+  --change-quality-safe-fix \
+  --change-quality-strict-receipt \
+  --execute
+```
+
+Absence of this policy is equivalent to all three values being false.
+
+## Protocol
+
+1. `change-quality prepare` hashes the committed, staged, unstaged, and
+   untracked content relative to a base ref. It emits a self-contained
+   `change_quality_prepare_packet_v0`.
+2. A host or model reviews that exact scope using repository instructions and
+   project validators. The result uses `change_quality_agent_result_v0`.
+3. If policy allows it, the host may perform one bounded safe-fix pass. Any edit
+   invalidates the old fingerprint, so prepare and final review run again.
+4. `change-quality record --execute` validates the result against the current
+   fingerprint and writes a compact local runtime receipt.
+5. `change-quality verify` checks the current exact scope.
+6. `canary premerge --goal-id <goal-id>` enforces `strict_receipt`.
+
+```bash
+loopx --format json change-quality prepare \
+  --goal-id <goal-id> --repo-path .
+
+loopx --format json change-quality record \
+  --goal-id <goal-id> --repo-path . \
+  --result-json <ignored-or-temporary-result.json> --execute
+
+loopx --format json change-quality verify \
+  --goal-id <goal-id> --repo-path .
+
+loopx canary premerge --from-git-diff --goal-id <goal-id>
+```
+
+Receipts live under goal runtime state, not in the repository. They retain
+compact findings and validation labels, not raw model transcripts, credentials,
+private context, or validator logs.
+
+## Provider Boundary
+
+The packet does not require a particular model, language, framework, or skill
+host. A custom runner may deliver the project-scoped `loopx-change-quality`
+skill or inject equivalent instructions from the same LoopX revision. The
+global installer intentionally skips project-scoped skills. The project still
+owns its tests, lint, type checking, security checks, and repository-specific
+rules.
+
+A blocking finding must be a concrete correctness, security, privacy, contract,
+or required-validation failure. Subjective style advice remains nonblocking.
+
+Turn may carry the packet or receipt reference inside one bounded execution.
+It does not own policy or enforcement. The authoritative merge decision stays
+in `canary premerge`.
+
+## Initial Scope
+
+The first version deliberately qualifies one final diff with at most one
+safe-fix pass. It does not recursively review reviews, build a model hierarchy,
+or require several agents to reach consensus. Those mechanisms should be added
+only after single-level receipts show a concrete failure they can solve.

--- a/docs/guides/custom-agent-runner-integration.md
+++ b/docs/guides/custom-agent-runner-integration.md
@@ -74,11 +74,15 @@ does not grant permission or satisfy a user gate.
 
 For `other-agent`, doctor intentionally does not inspect `~/.codex/skills`.
 CLI health and workflow delivery are separate checks. The custom host must
-deliver `loopx-project`, `loopx-pr-review`, `loopx-doc-registry`, and
-`loopx-self-repair` from the same LoopX revision through its own skill manifest
-or equivalent prompt injection, then read back the integration mode, loaded
-skill ids, and source revision. Do not assume a Codex, Claude, or OpenCode
-directory layout for an unknown host.
+deliver `loopx-project`, `loopx-pr-review`, `loopx-doc-registry`,
+and `loopx-self-repair` from the same LoopX revision through its own skill
+manifest or equivalent prompt injection. When the current goal enables
+`change_quality_qualification`, the onboarding packet also lists
+`loopx-change-quality` as an active project skill; deliver that workflow or its
+equivalent self-contained prepare-packet instructions. Then read back the
+integration mode, loaded skill ids, and source revision. Do not assume a Codex,
+Claude, or OpenCode directory layout for an unknown host. Loading the quality
+skill does not activate it; the current goal policy controls activation.
 
 If the host has no skill system, inject the equivalent `SKILL.md` instructions
 and keep one short re-entry instruction that tells the Agent to:
@@ -124,6 +128,13 @@ Then follow this loop:
    validator, cadence update, quiet monitor poll, or no-op retry does not spend.
 8. **Schedule:** Apply the current scheduler hint in the runner, read back the
    value actually applied, and ACK it through the returned CLI command.
+
+Before a non-trivial delivery, inspect the goal's change-quality policy. When
+enabled, run `change-quality prepare`, review the exact final diff, and record
+its receipt. A custom host without a skill system can consume the self-contained
+prepare packet directly. `safe_fix` allows one bounded repair pass;
+`strict_receipt` makes `canary premerge --goal-id <goal-id>` reject a missing or
+stale receipt.
 
 Every new wake starts again at step 1. Do not resume from remembered model
 state or a cached packet.

--- a/docs/guides/custom-agent-runner-integration.zh-CN.md
+++ b/docs/guides/custom-agent-runner-integration.zh-CN.md
@@ -68,9 +68,12 @@ packet 会返回当前 doctor/install、bootstrap command pack、quota guard 和
 对于 `other-agent`，doctor 会有意跳过 `~/.codex/skills` 检查。CLI 健康与 workflow
 交付是两件事：custom host 仍需通过自己的 skill manifest 或等价 prompt injection，
 从同一 LoopX revision 交付 `loopx-project`、`loopx-pr-review`、
-`loopx-doc-registry` 和 `loopx-self-repair`，再 readback integration mode、
-loaded skill ids 和 source revision。不要假设未知 host 采用 Codex、Claude 或 OpenCode
-的目录布局。
+`loopx-doc-registry` 和 `loopx-self-repair`。当当前 goal 启用
+`change_quality_qualification` 时，onboarding packet 会额外把
+`loopx-change-quality` 列为 active project skill；host 需要交付该 workflow，
+或注入等价的自包含 prepare packet 指令。随后 readback integration mode、
+loaded skill ids 和 source revision。不要假设未知 host 采用 Codex、Claude 或
+OpenCode 的目录布局。加载质量 skill 不代表启用，是否生效由当前 goal policy 决定。
 
 如果 host 没有 skill 系统，就注入等价的 `SKILL.md` 指令，并保留一段短
 re-entry instruction，要求 Agent：
@@ -114,6 +117,12 @@ loopx --format json \
    quiet monitor poll 和 no-op retry 都不 spend。
 8. **调度：** runner 应用当前 scheduler hint，readback 实际生效值，再执行 packet 返回的
    ACK CLI。
+
+非平凡交付前，先读取 goal 的 change-quality policy。启用后运行
+`change-quality prepare`，review 精确 final diff，并记录 receipt。没有 skill 系统的
+custom host 可以直接消费自包含的 prepare packet。`safe_fix` 允许一次有界修复；
+`strict_receipt` 会让 `canary premerge --goal-id <goal-id>` 拒绝缺失或已失效的
+receipt。
 
 每次新唤醒都重新从第 1 步开始，不能依赖模型记忆或缓存 packet 续跑。
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -459,6 +459,7 @@ The reusable skills have intentionally narrow jobs:
 | `loopx-pr-review` | Running `/loopx-pr-review`, preserving the `loopx pr-review` packet, and guiding per-PR five-block reviews. | Approving, commenting on, merging, self-merging, or admin-bypassing a PR. |
 | `loopx-doc-registry` | Registering durable project material and redacted authority-source metadata. | Copying raw doc bodies, internal URLs, or private comments into public repo docs. |
 | `loopx-material` | Operating an explicitly activated project's lossless material inventory, lifecycle, ranked-entry rebuild, bounded rerank, owner-gated apply, and rollback. | Ordinary one-off reading, project-specific source discovery, or mutating a material store merely because the project skill is discoverable. |
+| `loopx-change-quality` | Reviewing one exact final diff, optionally applying one bounded safe fix, and recording a policy-enforced receipt. | Acting when the goal policy is disabled, recursively reviewing reviewers, or replacing project-native validators. |
 | `loopx-self-repair` | Repairing surprising control-plane behavior, stale projection, tiny turns, or contradictory guard payloads. | Lowering gates, guessing around missing authority, or committing private runtime state. |
 
 Auto-research role guidance is worker-local: the visible worker launcher owns
@@ -476,10 +477,10 @@ Keep three layers separate:
   docs. They can constrain contributors and agents in this repository, but they
   should not silently become global skill policy for every project.
 
-`loopx-material` follows **release-owned source, project-managed delivery, and
-goal-scoped activation**. The global installer keeps its canonical source in
-the LoopX release but does not publish it under `~/.codex/skills`. The generic
-lifecycle and host-surface contract is documented in
+`loopx-material` and `loopx-change-quality` follow **release-owned source,
+project-managed delivery, and goal-scoped activation**. The global installer
+keeps their canonical source in the LoopX release but does not publish either
+skill under `~/.codex/skills`. The generic lifecycle and host-surface contract is documented in
 [Project Skill Delivery](../project-skill-delivery.md). Enable discovery only
 for a connected project:
 
@@ -493,6 +494,13 @@ loopx project-skill status \
   --project . \
   --skill loopx-material \
   --surface codex
+
+# Install only when the goal enables change_quality_qualification.
+loopx project-skill install \
+  --project . \
+  --skill loopx-change-quality \
+  --surface codex \
+  --execute
 ```
 
 Host-native project roots are:
@@ -511,9 +519,9 @@ and [OpenCode](https://opencode.ai/docs/skills/#place-files).
 
 Installing a project skill does not grant domain write authority; the current
 goal/profile/todo must still activate the capability. Use
-`loopx project-skill uninstall --project . --skill loopx-material --surface
-codex --execute` to remove a managed copy. Unmanaged or locally modified copies
-fail closed.
+`loopx project-skill uninstall --project . --skill <skill-id> --surface codex
+--execute` to remove a managed copy. Unmanaged or locally modified copies fail
+closed.
 
 To disconnect only the current project from LoopX, use the project-local
 uninstall command from that project root. It defaults to a dry-run preview and

--- a/examples/change-quality-qualification-smoke.py
+++ b/examples/change-quality-qualification-smoke.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Smoke-test default-off policy, exact receipts, and strict stale-diff rejection."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.change_quality.receipt import (  # noqa: E402
+    CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
+    build_change_quality_prepare_packet,
+    record_change_quality_receipt,
+    verify_change_quality_receipt,
+)
+from loopx.configure_goal import configure_goal  # noqa: E402
+
+
+def git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-change-quality-") as temporary:
+        root = Path(temporary)
+        repo = root / "repo"
+        repo.mkdir()
+        git(repo, "init")
+        git(repo, "config", "user.email", "quality-smoke@example.invalid")
+        git(repo, "config", "user.name", "Quality Smoke")
+        (repo / "app.py").write_text("value = 1\n", encoding="utf-8")
+        git(repo, "add", "app.py")
+        git(repo, "commit", "-m", "fixture")
+        runtime = root / "runtime"
+        registry = root / "registry.json"
+        registry.write_text(
+            json.dumps(
+                {
+                    "common_runtime_root": str(runtime),
+                    "goals": [
+                        {
+                            "id": "quality-smoke",
+                            "repo": str(repo),
+                            "control_plane": {},
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        disabled = build_change_quality_prepare_packet(
+            registry_path=registry,
+            goal_id="quality-smoke",
+            repo_path=repo,
+            base_ref="HEAD",
+        )
+        assert disabled["status"] == "disabled", disabled
+
+        configure_goal(
+            registry_path=registry,
+            goal_id="quality-smoke",
+            change_quality_enabled=True,
+            change_quality_safe_fix=True,
+            change_quality_strict_receipt=True,
+            execute=True,
+        )
+        (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
+        prepared = build_change_quality_prepare_packet(
+            registry_path=registry,
+            goal_id="quality-smoke",
+            repo_path=repo,
+            base_ref="HEAD",
+        )
+        result = root / "result.json"
+        result.write_text(
+            json.dumps(
+                {
+                    "schema_version": CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
+                    "scope_fingerprint": prepared["scope"]["scope_fingerprint"],
+                    "reviewed_final_scope": True,
+                    "summary": "Exact final scope reviewed.",
+                    "findings": [],
+                    "safe_fix_applied": False,
+                    "safe_fix_passes": 0,
+                    "validations": ["smoke contract passed"],
+                }
+            ),
+            encoding="utf-8",
+        )
+        recorded = record_change_quality_receipt(
+            registry_path=registry,
+            runtime_root=runtime,
+            goal_id="quality-smoke",
+            repo_path=repo,
+            result_path=result,
+            base_ref="HEAD",
+            execute=True,
+        )
+        assert recorded["ok"] is True, recorded
+        valid = verify_change_quality_receipt(
+            registry_path=registry,
+            runtime_root=runtime,
+            goal_id="quality-smoke",
+            repo_path=repo,
+            base_ref="HEAD",
+        )
+        assert valid["status"] == "valid", valid
+
+        (repo / "app.py").write_text("value = 3\n", encoding="utf-8")
+        stale = verify_change_quality_receipt(
+            registry_path=registry,
+            runtime_root=runtime,
+            goal_id="quality-smoke",
+            repo_path=repo,
+            base_ref="HEAD",
+        )
+        assert stale["ok"] is False, stale
+        assert stale["status"] == "stale_receipt", stale
+
+    print(
+        json.dumps(
+            {
+                "schema_version": "change_quality_qualification_smoke_v0",
+                "ok": True,
+                "default_off": True,
+                "exact_receipt_verified": True,
+                "stale_diff_rejected": True,
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/codex-cli-packaged-install-smoke.py
+++ b/examples/codex-cli-packaged-install-smoke.py
@@ -123,6 +123,9 @@ def main() -> None:
             "loopx-self-repair",
         ):
             assert (home / ".codex" / "skills" / skill / "SKILL.md").exists(), skill
+        assert not (
+            home / ".codex" / "skills" / "loopx-change-quality"
+        ).exists()
 
         assert not (home / ".local" / "bin" / "loopx-canary").exists()
         assert not (home / ".local" / "bin" / "goal-harness-canary").exists()

--- a/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
+++ b/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
@@ -449,6 +449,43 @@ def main() -> int:
             ]
         ), other_agent_onboarding
 
+        registry["goals"][0]["control_plane"] = {
+            "change_quality_qualification": {
+                "enabled": True,
+                "safe_fix": True,
+                "strict_receipt": True,
+            }
+        }
+        serialized_registry = json.dumps(registry)
+        project_registry.write_text(serialized_registry, encoding="utf-8")
+        global_registry.write_text(serialized_registry, encoding="utf-8")
+        quality_other_agent = build_agent_onboarding_packet(
+            project=project,
+            agent_type="other-agent",
+            goal_id="multi-agent-goal",
+            agent_id="codex-product-capability",
+            cli_bin=cli_bin,
+        )
+        quality_delivery = quality_other_agent["skill_delivery"]
+        assert "loopx-change-quality" in quality_delivery["active_project_skill_ids"]
+        assert "loopx-change-quality" in quality_delivery["required_skill_ids"]
+        assert "skills/loopx-change-quality" in quality_delivery["source_directories"]
+
+        quality_codex = build_agent_onboarding_packet(
+            project=project,
+            agent_type="codex-cli",
+            goal_id="multi-agent-goal",
+            agent_id="codex-product-capability",
+            cli_bin=cli_bin,
+        )
+        quality_commands = quality_codex["skill_delivery"][
+            "project_skill_commands"
+        ]
+        assert len(quality_commands) == 1, quality_codex
+        assert "project-skill status" in quality_commands[0]["status"]
+        assert "project-skill install" in quality_commands[0]["apply_install"]
+        assert quality_commands[0]["apply_install"].endswith("--execute")
+
         doctor_home = root / "doctor-home"
         doctor_home.mkdir()
         doctor_env = {

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -357,6 +357,8 @@ def main() -> int:
         assert not auto_research_skill.exists(), auto_research_skill
         material_skill = codex_home / "skills" / "loopx-material" / "SKILL.md"
         assert not material_skill.exists(), material_skill
+        quality_skill = codex_home / "skills" / "loopx-change-quality" / "SKILL.md"
+        assert not quality_skill.exists(), quality_skill
         loopx_prompt = codex_home / "prompts" / "loopx.md"
         assert not loopx_prompt.exists(), loopx_prompt
         loopx_command_skill = codex_home / "skills" / "loopx" / "SKILL.md"
@@ -499,6 +501,11 @@ def main() -> int:
         assert doctor_payload["skill"]["delivery_hints"] is True, doctor_payload
         assert "loopx-auto-research" not in doctor_payload["skills"], doctor_payload
         assert "loopx-material" not in doctor_payload["skills"], doctor_payload
+        assert "loopx-change-quality" not in doctor_payload["skills"], doctor_payload
+        assert {
+            "loopx-material",
+            "loopx-change-quality",
+        }.issubset(set(doctor_payload["project_scoped_skill_ids"])), doctor_payload
         assert doctor_payload["globally_visible_project_skills"] == [], doctor_payload
         assert doctor_payload["skills"]["loopx-project"]["exists"] is True, doctor_payload
         assert doctor_payload["skills"]["loopx-project"]["required_phrases"] is True, doctor_payload

--- a/examples/project/configure-goal-smoke.py
+++ b/examples/project/configure-goal-smoke.py
@@ -210,12 +210,21 @@ def main() -> int:
             "multi_subagent",
             "explore_graph",
             "explore_harness",
+            "change_quality_qualification",
             "reward_memory",
             "lark_event_inbox",
             "lark_kanban_heartbeat_sync",
         }
         assert features["multi_subagent"]["current"]["enabled"] is True
         assert features["explore_graph"]["current"]["enabled"] is False
+        assert features["change_quality_qualification"]["current"] == {
+            "enabled": False,
+            "safe_fix": False,
+            "strict_receipt": False,
+        }
+        assert "--change-quality-enabled" in features[
+            "change_quality_qualification"
+        ]["commands"]["preview_enable"]
         assert "--execute" not in features["explore_harness"]["commands"]["preview_enable"]
         assert "--execute" in features["explore_harness"]["commands"]["apply_enable"]
         assert "--execute" not in features["explore_graph"]["commands"]["preview_disable"]

--- a/loopx/agent_onboarding.py
+++ b/loopx/agent_onboarding.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from .agent_registry import registered_agent_ids_from_registry
 from .bootstrap_command_pack import inspect_bootstrap_connection
+from .capabilities.change_quality.policy import change_quality_goal_policy
 from .host_loop_activation import (
     build_host_loop_activation_packet,
     normalize_agent_type,
@@ -17,6 +18,7 @@ from .project_prompt import (
     render_quota_guard_command,
     shell_arg,
 )
+from .registry import read_json, registry_goals
 
 
 SCHEMA_VERSION = "loopx_agent_onboarding_v0"
@@ -27,6 +29,7 @@ REQUIRED_HOST_SKILL_IDS = [
     "loopx-doc-registry",
     "loopx-self-repair",
 ]
+CHANGE_QUALITY_SKILL_ID = "loopx-change-quality"
 
 
 def _surface_install_command(agent_type: str, cli_bin: str) -> str | None:
@@ -42,7 +45,86 @@ def _surface_install_command(agent_type: str, cli_bin: str) -> str | None:
     return None
 
 
-def _skill_delivery_contract(agent_type: str) -> dict[str, Any]:
+def _project_skill_surface(agent_type: str) -> str | None:
+    if agent_type in {
+        "codex-app",
+        "codex-app-ssh",
+        "codex-ide-plugin",
+        "codex-cli",
+    }:
+        return "codex"
+    if agent_type == "claude-code":
+        return "claude-code"
+    if agent_type == "opencode":
+        return "opencode"
+    return None
+
+
+def _project_skill_command(
+    command: str,
+    *,
+    project: str,
+    skill_id: str,
+    surface: str,
+    cli_bin: str,
+    execute: bool = False,
+) -> str:
+    parts = [
+        shell_arg(cli_bin),
+        "project-skill",
+        command,
+        "--project",
+        shell_arg(project),
+        "--skill",
+        shell_arg(skill_id),
+        "--surface",
+        shell_arg(surface),
+    ]
+    if execute:
+        parts.append("--execute")
+    return " ".join(parts)
+
+
+def _skill_delivery_contract(
+    agent_type: str,
+    *,
+    project: str = ".",
+    cli_bin: str = "loopx",
+    active_project_skill_ids: list[str] | None = None,
+) -> dict[str, Any]:
+    active_project_skills = list(dict.fromkeys(active_project_skill_ids or []))
+    project_surface = _project_skill_surface(agent_type)
+    project_skill_commands = []
+    if project_surface:
+        for skill_id in active_project_skills:
+            project_skill_commands.append(
+                {
+                    "skill_id": skill_id,
+                    "surface": project_surface,
+                    "status": _project_skill_command(
+                        "status",
+                        project=project,
+                        skill_id=skill_id,
+                        surface=project_surface,
+                        cli_bin=cli_bin,
+                    ),
+                    "preview_install": _project_skill_command(
+                        "install",
+                        project=project,
+                        skill_id=skill_id,
+                        surface=project_surface,
+                        cli_bin=cli_bin,
+                    ),
+                    "apply_install": _project_skill_command(
+                        "install",
+                        project=project,
+                        skill_id=skill_id,
+                        surface=project_surface,
+                        cli_bin=cli_bin,
+                        execute=True,
+                    ),
+                }
+            )
     if agent_type != "other-agent":
         return {
             "schema_version": HOST_SKILL_DELIVERY_SCHEMA_VERSION,
@@ -50,7 +132,13 @@ def _skill_delivery_contract(agent_type: str) -> dict[str, Any]:
             "owner": "loopx_surface_installer",
             "codex_skills_root_required": agent_type.startswith("codex-"),
             "host_readback_required": False,
+            "active_project_skill_ids": active_project_skills,
+            "project_skill_commands": project_skill_commands,
         }
+    required_skill_ids = [
+        *REQUIRED_HOST_SKILL_IDS,
+        *active_project_skills,
+    ]
     return {
         "schema_version": HOST_SKILL_DELIVERY_SCHEMA_VERSION,
         "mode": "host_managed",
@@ -59,14 +147,15 @@ def _skill_delivery_contract(agent_type: str) -> dict[str, Any]:
         "codex_skills_root_required": False,
         "required_for_cli_health": False,
         "required_for_loopx_workflow": True,
-        "required_skill_ids": REQUIRED_HOST_SKILL_IDS,
+        "required_skill_ids": required_skill_ids,
+        "active_project_skill_ids": active_project_skills,
         "delivery_options": [
             "host_skill_manifest",
             "prompt_injection",
         ],
         "source_repository": "https://github.com/huangruiteng/loopx",
         "source_directories": [
-            f"skills/{skill_id}" for skill_id in REQUIRED_HOST_SKILL_IDS
+            f"skills/{skill_id}" for skill_id in required_skill_ids
         ],
         "source_contract": (
             "Use the same LoopX release or repository revision as the CLI when "
@@ -82,6 +171,7 @@ def _skill_delivery_contract(agent_type: str) -> dict[str, Any]:
         "success_criteria": [
             "the host reports which integration mode it selected",
             "the host reports every required LoopX skill id as loaded",
+            "the host reports every active project skill id as loaded or injects its equivalent instructions",
             "the host reports the source revision or digest used for delivery",
             "no Codex-specific skill directory is assumed",
         ],
@@ -164,6 +254,20 @@ def build_agent_onboarding_packet(
     resolved_project = str(inspection["project"])
     resolved_goal_id = str(inspection["goal_id"])
     registry_path = Path(str(inspection["registry"]))
+    registry = read_json(registry_path)
+    goal = next(
+        (
+            item
+            for item in registry_goals(registry)
+            if str(item.get("id") or "") == resolved_goal_id
+        ),
+        {},
+    )
+    active_project_skill_ids = (
+        [CHANGE_QUALITY_SKILL_ID]
+        if change_quality_goal_policy(goal)["enabled"]
+        else []
+    )
     registered_agents = registered_agent_ids_from_registry(
         registry_path,
         resolved_goal_id,
@@ -247,7 +351,12 @@ def build_agent_onboarding_packet(
         "task_text": task_text,
         "project_connection": inspection,
         "host_loop_activation": host_loop_activation,
-        "skill_delivery": _skill_delivery_contract(canonical_agent_type),
+        "skill_delivery": _skill_delivery_contract(
+            canonical_agent_type,
+            project=resolved_project,
+            cli_bin=cli_bin,
+            active_project_skill_ids=active_project_skill_ids,
+        ),
         "recommended_start": (
             "Select one registered agent lane from identity_selection_gate, then rerun onboarding."
             if not activation_allowed
@@ -323,6 +432,33 @@ def render_agent_onboarding_markdown(payload: dict[str, Any]) -> str:
     ]
     if commands.get("install_command_facade"):
         lines.extend(["", "```bash", str(commands.get("install_command_facade")), "```"])
+    project_skill_commands = (
+        skill_delivery.get("project_skill_commands")
+        if isinstance(skill_delivery.get("project_skill_commands"), list)
+        else []
+    )
+    if project_skill_commands:
+        lines.extend(
+            [
+                "",
+                "## Active Project Skills",
+                "",
+                f"- skill_ids: `{','.join(skill_delivery.get('active_project_skill_ids') or [])}`",
+            ]
+        )
+        for item in project_skill_commands:
+            if not isinstance(item, dict):
+                continue
+            lines.extend(
+                [
+                    "",
+                    "```bash",
+                    str(item.get("status") or ""),
+                    str(item.get("preview_install") or ""),
+                    str(item.get("apply_install") or ""),
+                    "```",
+                ]
+            )
     if skill_delivery.get("mode") == "host_managed":
         lines.extend(
             [

--- a/loopx/canary/premerge.py
+++ b/loopx/canary/premerge.py
@@ -78,6 +78,13 @@ LARK_KANBAN_TOKENS = (
     "loopx/cli_commands/lark_kanban.py",
     "examples/lark-kanban",
 )
+CHANGE_QUALITY_TOKENS = (
+    "loopx/capabilities/change_quality/",
+    "skills/loopx-change-quality/",
+    "tests/capabilities/test_change_quality.py",
+    "examples/change-quality-qualification-smoke.py",
+    "docs/capabilities/change-quality/",
+)
 INHERITED_BASELINE_COMMANDS = (
     "control-plane-maintainability-ratchet-smoke.py",
 )
@@ -304,6 +311,8 @@ def classify_premerge_surfaces(
         )
     if any(_path_matches(path, LARK_KANBAN_TOKENS) for path in files):
         mark("lark_kanban")
+    if any(_path_matches(path, CHANGE_QUALITY_TOKENS) for path in files):
+        mark("change_quality", "change-quality-exact-receipt")
     if python_files:
         mark("python")
     if not surfaces and files:
@@ -629,6 +638,44 @@ def build_validation_summary(
         "failed_commands": [command for command in failed_commands if command],
         "runs": run_summaries,
     }
+
+
+def apply_change_quality_verification(
+    payload: dict[str, Any],
+    verification: dict[str, Any],
+) -> dict[str, Any]:
+    """Attach goal policy evidence and fail the merge gate when strict receipt fails."""
+
+    payload["change_quality_qualification"] = verification
+    enforced_failure = bool(
+        verification.get("enforcement_applied")
+        and verification.get("ok") is False
+    )
+    gate = payload.get("gate") if isinstance(payload.get("gate"), dict) else {}
+    summary = (
+        payload.get("validation_summary")
+        if isinstance(payload.get("validation_summary"), dict)
+        else {}
+    )
+    gate["quality_receipt_failure_count"] = 1 if enforced_failure else 0
+    summary["policy_failure_count"] = 1 if enforced_failure else 0
+    if enforced_failure:
+        status = str(verification.get("status") or "receipt_invalid")
+        gate.update(
+            {
+                "status": f"quality_{status}",
+                "merge_gate_passed": False,
+                "self_merge_allowed": False,
+            }
+        )
+        summary["failure_count"] = int(summary.get("failure_count") or 0) + 1
+        payload["ok"] = False
+    payload["gate"] = gate
+    payload["validation_summary"] = summary
+    fields = payload.get("recommended_pr_comment_fields")
+    if isinstance(fields, list) and "change_quality_receipt" not in fields:
+        fields.append("change_quality_receipt")
+    return payload
 
 
 def _recompute_smoke_run_status(run: dict[str, Any]) -> None:
@@ -1035,6 +1082,25 @@ def render_premerge_validation_gate_markdown(payload: dict[str, Any]) -> str:
     append_run("Catalog Canaries", payload.get("catalog_run"))
     append_run("Risk Profile Smokes", payload.get("risk_profile_run"))
     append_run("Public Boundary", payload.get("boundary_run"))
+
+    quality = (
+        payload.get("change_quality_qualification")
+        if isinstance(payload.get("change_quality_qualification"), dict)
+        else None
+    )
+    if quality is not None:
+        lines.extend(
+            [
+                "",
+                "## Change Quality Receipt",
+                f"- status: `{quality.get('status')}`",
+                f"- ok: `{str(quality.get('ok')).lower()}`",
+                f"- enforcement_applied: `{str(quality.get('enforcement_applied')).lower()}`",
+                f"- receipt_id: `{quality.get('receipt_id')}`",
+            ]
+        )
+        if quality.get("required_action"):
+            lines.append(f"- required_action: {quality.get('required_action')}")
 
     manual_holds = classification.get("manual_holds") or []
     if manual_holds:

--- a/loopx/canary/qualification_profiles.py
+++ b/loopx/canary/qualification_profiles.py
@@ -5,6 +5,39 @@ from typing import Any
 
 CONTROL_PLANE_QUALIFICATION_PROFILES: tuple[dict[str, Any], ...] = (
     {
+        "id": "change-quality-exact-receipt",
+        "title": "Change-quality exact-scope receipt integrity",
+        "quality_risk": "high",
+        "purpose": (
+            "Qualify default-off policy, exact diff identity, bounded safe-fix "
+            "authority, stale receipt rejection, and strict premerge enforcement."
+        ),
+        "catalog_families": [
+            "State And Boundary",
+            "Planning Governance",
+        ],
+        "trigger_hints": (
+            "change quality",
+            "change-quality",
+            "change_quality_qualification",
+            "loopx/capabilities/change_quality/",
+            "skills/loopx-change-quality/",
+            "tests/capabilities/test_change_quality.py",
+            "examples/change-quality-qualification-smoke.py",
+            "docs/capabilities/change-quality/",
+        ),
+        "checks": [
+            {
+                "command": "python3 examples/change-quality-qualification-smoke.py",
+                "tier": "default",
+                "reason": (
+                    "guards default-off activation, exact-scope receipt readback, "
+                    "and stale-diff rejection through the public capability contract"
+                ),
+            },
+        ],
+    },
+    {
         "id": "control-plane-state-machine",
         "title": "Control-plane state-machine composition",
         "quality_risk": "high",

--- a/loopx/canary/quality_surface_catalog.py
+++ b/loopx/canary/quality_surface_catalog.py
@@ -46,6 +46,44 @@ def _deferred(*, owner: str, rationale: str) -> dict[str, Any]:
 
 QUALITY_SURFACE_CATALOG: tuple[dict[str, Any], ...] = (
     {
+        "surface_id": "change-quality-exact-receipt",
+        "title": "Change-quality exact-scope receipt integrity",
+        "risk": "high",
+        "canary_profile_id": "change-quality-exact-receipt",
+        "owner_paths": [
+            "loopx/capabilities/change_quality/policy.py",
+            "loopx/capabilities/change_quality/receipt.py",
+            "loopx/capabilities/change_quality/scope.py",
+        ],
+        "semantic_oracle": {
+            "source_kind": "specification",
+            "refs": ["docs/capabilities/change-quality/README.md"],
+            "independence_rationale": (
+                "The public policy defines independent safe-fix and strict-receipt "
+                "controls plus exact final-diff identity before implementation hashing "
+                "and receipt validation are exercised."
+            ),
+        },
+        "layers": {
+            "unit_contract": _covered(
+                "tests/capabilities/test_change_quality.py"
+            ),
+            "durable_smoke": _covered(
+                "examples/change-quality-qualification-smoke.py"
+            ),
+            "catalog_canary": _covered("change-quality-exact-receipt"),
+            "host_upgrade": _covered("examples/install-local-smoke.py"),
+            "model_behavior": _not_applicable(
+                "This catalogued surface proves deterministic scope and receipt integrity; "
+                "reviewer competence remains a provider responsibility and a receipt is "
+                "not proof that every defect was found."
+            ),
+            "release_gate": _covered(
+                "loopx canary premerge --profile change-quality-exact-receipt"
+            ),
+        },
+    },
+    {
         "surface_id": "interaction-scheduler-authority",
         "title": "Interaction contract and scheduler authority",
         "risk": "high",

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -14,6 +14,112 @@ CAPABILITY_DETAIL_SCHEMA_VERSION = "loopx_capability_detail_v0"
 
 BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
     {
+        "id": "change-quality-qualification",
+        "origin": "builtin",
+        "visibility": "public",
+        "provider_id": "loopx-core",
+        "title": "Exact-scope change quality qualification",
+        "status": "active-preview",
+        "default_enabled": False,
+        "real_world_anchor": (
+            "provider-neutral final-diff review with bounded repair and merge evidence"
+        ),
+        "user_value": (
+            "Give every managed project the same compact engineering-quality "
+            "contract without assuming its language, framework, or agent host."
+        ),
+        "entry_command": (
+            "loopx change-quality prepare --goal-id <goal-id> "
+            "--repo-path <repo> --format json"
+        ),
+        "workflow_skill": {
+            "name": "loopx-change-quality",
+            "delivery": "project_managed_copy",
+            "activation": "explicit_project_install_plus_goal_policy",
+            "project_copy_required": True,
+            "install_command": (
+                "loopx project-skill install --project . --skill "
+                "loopx-change-quality --surface codex --execute"
+            ),
+        },
+        "commands": [
+            {
+                "command": (
+                    "loopx change-quality prepare --goal-id <goal-id> "
+                    "--repo-path <repo> --format json"
+                ),
+                "purpose": "Build a self-contained review contract for the exact final diff.",
+                "write_boundary": "read-only git and registry projection; no code or receipt write",
+            },
+            {
+                "command": (
+                    "loopx change-quality record --goal-id <goal-id> "
+                    "--repo-path <repo> --result-json <result.json> --execute --format json"
+                ),
+                "purpose": "Validate a provider result against the exact diff and store its receipt.",
+                "write_boundary": "atomic goal-runtime receipt only; no repository or external write",
+            },
+            {
+                "command": (
+                    "loopx change-quality verify --goal-id <goal-id> "
+                    "--repo-path <repo> --format json"
+                ),
+                "purpose": "Verify goal policy and the current exact-diff receipt.",
+                "write_boundary": "read-only registry, git, and runtime receipt verification",
+            },
+            {
+                "command": (
+                    "loopx canary premerge --from-git-diff --goal-id <goal-id>"
+                ),
+                "purpose": "Apply strict receipt policy inside the authoritative premerge gate.",
+                "write_boundary": "validation only; no merge, push, or external action",
+            },
+        ],
+        "implemented_protocols": [
+            {
+                "schema_version": "change_quality_scope_v0",
+                "module": "loopx.capabilities.change_quality.scope",
+                "doc": "docs/capabilities/change-quality/README.md",
+            },
+            {
+                "schema_version": "change_quality_prepare_packet_v0",
+                "module": "loopx.capabilities.change_quality.receipt",
+                "doc": "docs/capabilities/change-quality/README.md",
+            },
+            {
+                "schema_version": "change_quality_agent_result_v0",
+                "module": "loopx.capabilities.change_quality.receipt",
+                "doc": "docs/capabilities/change-quality/README.md",
+            },
+            {
+                "schema_version": "change_quality_receipt_v0",
+                "module": "loopx.capabilities.change_quality.receipt",
+                "doc": "docs/capabilities/change-quality/README.md",
+            },
+            {
+                "schema_version": "change_quality_receipt_verification_v0",
+                "module": "loopx.capabilities.change_quality.receipt",
+                "doc": "docs/capabilities/change-quality/README.md",
+            },
+        ],
+        "smokes": ["python3 examples/change-quality-qualification-smoke.py"],
+        "docs": ["docs/capabilities/change-quality/README.md"],
+        "boundaries": [
+            "The capability is default-off and activates only through explicit per-goal policy; managed skill discovery is a separate project-level choice.",
+            "safe_fix permits at most one bounded repair pass; it grants no destructive git, permission expansion, or unrelated refactor authority.",
+            "strict_receipt is an exact-diff premerge evidence gate and does not itself permit code mutation.",
+            "Subjective style advice stays nonblocking; only concrete correctness, security, privacy, contract, or required-validation failures may block.",
+            "Turn may transport a packet or receipt reference, but premerge remains the enforcement authority.",
+            "The canonical workflow skill is release-owned and project-delivered; the global installer does not publish it into every agent configuration.",
+            "Receipts stay in local runtime state; raw model transcripts, private context, and credentials are not persisted.",
+            "The first version is single-level: it qualifies one final diff and does not recursively review reviews.",
+        ],
+        "next_real_step": (
+            "Enable it on an explicit goal, qualify one final diff, and verify "
+            "that safe-fix and strict-receipt policies remain independently enforced."
+        ),
+    },
+    {
         "id": "issue-fix",
         "origin": "builtin",
         "visibility": "public",

--- a/loopx/capabilities/change_quality/__init__.py
+++ b/loopx/capabilities/change_quality/__init__.py
@@ -1,0 +1,19 @@
+from .policy import (
+    CHANGE_QUALITY_POLICY_SCHEMA_VERSION,
+    change_quality_goal_policy,
+    change_quality_goal_policy_summary,
+)
+from .receipt import (
+    build_change_quality_prepare_packet,
+    record_change_quality_receipt,
+    verify_change_quality_receipt,
+)
+
+__all__ = [
+    "CHANGE_QUALITY_POLICY_SCHEMA_VERSION",
+    "build_change_quality_prepare_packet",
+    "change_quality_goal_policy",
+    "change_quality_goal_policy_summary",
+    "record_change_quality_receipt",
+    "verify_change_quality_receipt",
+]

--- a/loopx/capabilities/change_quality/cli.py
+++ b/loopx/capabilities/change_quality/cli.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+from ...paths import resolve_runtime_root
+from ...registry import read_json
+from .receipt import (
+    build_change_quality_prepare_packet,
+    record_change_quality_receipt,
+    verify_change_quality_receipt,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+FormatSelector = Callable[..., str]
+AddFormat = Callable[[argparse.ArgumentParser], None]
+
+
+def _add_scope_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--goal-id", required=True, help="Goal whose managed policy applies.")
+    parser.add_argument(
+        "--repo-path",
+        type=Path,
+        default=Path("."),
+        help="Git worktree to qualify. Defaults to the current directory.",
+    )
+    parser.add_argument(
+        "--base-ref",
+        default="origin/main",
+        help="Git base ref for committed diff identity. Defaults to origin/main.",
+    )
+
+
+def register_change_quality_commands(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: AddFormat,
+) -> None:
+    parser = subparsers.add_parser(
+        "change-quality",
+        help="Prepare, record, and verify exact-scope change-quality receipts.",
+    )
+    commands = parser.add_subparsers(dest="change_quality_command", required=True)
+    prepare = commands.add_parser(
+        "prepare",
+        help="Build a provider-neutral review packet for the exact current diff.",
+    )
+    add_subcommand_format(prepare)
+    _add_scope_arguments(prepare)
+    record = commands.add_parser(
+        "record",
+        help="Validate an agent result against the exact current diff and store its receipt.",
+    )
+    add_subcommand_format(record)
+    _add_scope_arguments(record)
+    record.add_argument(
+        "--result-json",
+        type=Path,
+        required=True,
+        help="Agent result conforming to change_quality_agent_result_v0.",
+    )
+    record.add_argument(
+        "--execute",
+        action="store_true",
+        help="Write the exact-scope receipt under the LoopX runtime.",
+    )
+    verify = commands.add_parser(
+        "verify",
+        help="Verify the current exact diff against goal policy and stored receipt.",
+    )
+    add_subcommand_format(verify)
+    _add_scope_arguments(verify)
+
+
+def render_change_quality_markdown(payload: dict[str, object]) -> str:
+    receipt = payload.get("receipt") if isinstance(payload.get("receipt"), dict) else {}
+    policy_value = payload.get("policy") or receipt.get("policy")
+    scope_value = payload.get("scope") or receipt.get("scope")
+    policy = policy_value if isinstance(policy_value, dict) else {}
+    scope = scope_value if isinstance(scope_value, dict) else {}
+    lines = [
+        "# Change Quality Qualification",
+        "",
+        f"- ok: `{str(payload.get('ok')).lower()}`",
+        f"- status: `{payload.get('status') or payload.get('decision')}`",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- enabled: `{str(policy.get('enabled')).lower()}`",
+        f"- safe_fix: `{str(policy.get('safe_fix')).lower()}`",
+        f"- strict_receipt: `{str(policy.get('strict_receipt')).lower()}`",
+        f"- scope_fingerprint: `{scope.get('scope_fingerprint') or payload.get('scope_fingerprint')}`",
+        f"- changed_files: `{scope.get('changed_file_count')}`",
+    ]
+    if payload.get("receipt_id"):
+        lines.append(f"- receipt_id: `{payload.get('receipt_id')}`")
+    if payload.get("required_action"):
+        lines.append(f"- required_action: {payload.get('required_action')}")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def handle_change_quality_command(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    output_format: FormatSelector,
+    print_payload: PrintPayload,
+) -> int | None:
+    if args.command != "change-quality":
+        return None
+    registry = read_json(registry_path)
+    runtime_root = resolve_runtime_root(
+        registry,
+        runtime_root_arg,
+        registry_path=registry_path,
+    )
+    common = {
+        "registry_path": registry_path,
+        "goal_id": str(args.goal_id),
+        "repo_path": Path(args.repo_path),
+        "base_ref": str(args.base_ref),
+    }
+    try:
+        if args.change_quality_command == "prepare":
+            payload = build_change_quality_prepare_packet(**common)
+        elif args.change_quality_command == "record":
+            payload = record_change_quality_receipt(
+                **common,
+                runtime_root=runtime_root,
+                result_path=Path(args.result_json),
+                execute=bool(args.execute),
+            )
+        elif args.change_quality_command == "verify":
+            payload = verify_change_quality_receipt(
+                **common,
+                runtime_root=runtime_root,
+            )
+        else:
+            raise ValueError("change-quality requires prepare, record, or verify")
+    except (OSError, ValueError, TypeError) as exc:
+        payload = {
+            "ok": False,
+            "schema_version": "change_quality_error_v0",
+            "goal_id": str(args.goal_id),
+            "status": "error",
+            "error": str(exc),
+        }
+    print_payload(payload, output_format(args), render_change_quality_markdown)
+    return 0 if payload.get("ok") else 1

--- a/loopx/capabilities/change_quality/policy.py
+++ b/loopx/capabilities/change_quality/policy.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+CHANGE_QUALITY_POLICY_SCHEMA_VERSION = "change_quality_qualification_policy_v0"
+
+
+def change_quality_goal_policy(goal: dict[str, Any]) -> dict[str, Any]:
+    control_plane = (
+        goal.get("control_plane")
+        if isinstance(goal.get("control_plane"), dict)
+        else {}
+    )
+    raw = (
+        control_plane.get("change_quality_qualification")
+        if isinstance(control_plane.get("change_quality_qualification"), dict)
+        else {}
+    )
+    return {
+        "schema_version": CHANGE_QUALITY_POLICY_SCHEMA_VERSION,
+        "enabled": raw.get("enabled") is True,
+        "safe_fix": raw.get("safe_fix") is True,
+        "strict_receipt": raw.get("strict_receipt") is True,
+    }
+
+
+def change_quality_goal_policy_summary(goal: dict[str, Any]) -> dict[str, Any]:
+    policy = change_quality_goal_policy(goal)
+    return {
+        "enabled": policy["enabled"],
+        "safe_fix": policy["safe_fix"],
+        "strict_receipt": policy["strict_receipt"],
+    }

--- a/loopx/capabilities/change_quality/receipt.py
+++ b/loopx/capabilities/change_quality/receipt.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from ...feedback import validate_public_safe_text
+from ...history import validate_goal_id_path_segment
+from ...registry import read_json, registry_goals
+from .policy import change_quality_goal_policy
+from .scope import build_change_quality_scope, resolve_git_root
+
+
+CHANGE_QUALITY_PREPARE_SCHEMA_VERSION = "change_quality_prepare_packet_v0"
+CHANGE_QUALITY_RESULT_SCHEMA_VERSION = "change_quality_agent_result_v0"
+CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION = "change_quality_receipt_v0"
+CHANGE_QUALITY_VERIFY_SCHEMA_VERSION = "change_quality_receipt_verification_v0"
+FINDING_SEVERITIES = frozenset({"blocker", "warning", "advisory"})
+
+
+def _goal_from_registry(registry_path: Path, goal_id: str) -> dict[str, Any]:
+    registry = read_json(registry_path)
+    goal = next(
+        (
+            item
+            for item in registry_goals(registry)
+            if str(item.get("id") or "") == goal_id
+        ),
+        None,
+    )
+    if goal is None:
+        raise ValueError(f"goal_id not found in registry: {goal_id}")
+    return goal
+
+
+def _receipt_root(runtime_root: Path, goal_id: str) -> Path:
+    validated_goal_id = validate_goal_id_path_segment(goal_id)
+    return runtime_root.expanduser() / "goals" / validated_goal_id / "change-quality" / "receipts"
+
+
+def _repo_key(repo_path: Path) -> str:
+    repo_root = resolve_git_root(repo_path)
+    return hashlib.sha256(str(repo_root).encode("utf-8")).hexdigest()[:16]
+
+
+def _receipt_path(
+    *,
+    runtime_root: Path,
+    goal_id: str,
+    repo_path: Path,
+    scope_fingerprint: str,
+) -> Path:
+    return _receipt_root(runtime_root, goal_id) / (
+        f"{_repo_key(repo_path)}-{scope_fingerprint}.json"
+    )
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    temporary_path = Path(temporary)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def _bounded_text(value: Any, *, field: str, limit: int) -> str:
+    text = " ".join(str(value or "").strip().split())
+    validate_public_safe_text(field, text)
+    if len(text) > limit:
+        raise ValueError(f"{field} exceeds {limit} characters")
+    return text
+
+
+def _relative_path(value: Any, *, field: str) -> str | None:
+    text = str(value or "").strip().replace("\\", "/")
+    if not text:
+        return None
+    path = PurePosixPath(text)
+    if path.is_absolute() or ".." in path.parts:
+        raise ValueError(f"{field} must be a repo-relative path")
+    validate_public_safe_text(field, text)
+    return path.as_posix()
+
+
+def _normalize_finding(value: Any, *, index: int) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"findings[{index}] must be an object")
+    severity = str(value.get("severity") or "").strip().lower()
+    if severity not in FINDING_SEVERITIES:
+        raise ValueError(
+            f"findings[{index}].severity must be one of {sorted(FINDING_SEVERITIES)}"
+        )
+    code = _bounded_text(
+        value.get("code"),
+        field=f"findings[{index}].code",
+        limit=80,
+    )
+    message = _bounded_text(
+        value.get("message"),
+        field=f"findings[{index}].message",
+        limit=320,
+    )
+    if not code or not message:
+        raise ValueError(f"findings[{index}] requires code and message")
+    finding = {
+        "severity": severity,
+        "code": code,
+        "message": message,
+        "resolved": value.get("resolved") is True,
+    }
+    path = _relative_path(value.get("path"), field=f"findings[{index}].path")
+    if path:
+        finding["path"] = path
+    line = value.get("line")
+    if line is not None:
+        if not isinstance(line, int) or line < 1:
+            raise ValueError(f"findings[{index}].line must be a positive integer")
+        finding["line"] = line
+    return finding
+
+
+def _normalize_result(
+    value: Any,
+    *,
+    expected_fingerprint: str,
+    safe_fix_allowed: bool,
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError("result JSON root must be an object")
+    if value.get("schema_version") != CHANGE_QUALITY_RESULT_SCHEMA_VERSION:
+        raise ValueError(
+            f"result schema_version must be {CHANGE_QUALITY_RESULT_SCHEMA_VERSION}"
+        )
+    fingerprint = str(value.get("scope_fingerprint") or "").strip()
+    if fingerprint != expected_fingerprint:
+        raise ValueError(
+            "result scope_fingerprint does not match the current exact diff; "
+            "rerun prepare after every safe fix"
+        )
+    if value.get("reviewed_final_scope") is not True:
+        raise ValueError("result must set reviewed_final_scope=true")
+    safe_fix_applied = value.get("safe_fix_applied") is True
+    if safe_fix_applied and not safe_fix_allowed:
+        raise ValueError("result reports safe_fix_applied but goal policy forbids safe fixes")
+    safe_fix_passes = value.get("safe_fix_passes", 0)
+    if not isinstance(safe_fix_passes, int) or safe_fix_passes not in {0, 1}:
+        raise ValueError("safe_fix_passes must be 0 or 1")
+    if safe_fix_applied and safe_fix_passes != 1:
+        raise ValueError("safe_fix_applied=true requires safe_fix_passes=1")
+    if not safe_fix_applied and safe_fix_passes != 0:
+        raise ValueError("safe_fix_passes=1 requires safe_fix_applied=true")
+    findings = [
+        _normalize_finding(item, index=index)
+        for index, item in enumerate(value.get("findings") or [])
+    ]
+    if len(findings) > 20:
+        raise ValueError("result supports at most 20 findings")
+    validations = [
+        _bounded_text(item, field="validations[]", limit=180)
+        for item in (value.get("validations") or [])[:20]
+    ]
+    validations = [item for item in validations if item]
+    return {
+        "schema_version": CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
+        "scope_fingerprint": fingerprint,
+        "reviewed_final_scope": True,
+        "summary": _bounded_text(value.get("summary"), field="summary", limit=500),
+        "findings": findings,
+        "safe_fix_applied": safe_fix_applied,
+        "safe_fix_passes": safe_fix_passes,
+        "validations": validations,
+    }
+
+
+def _decision(result: dict[str, Any]) -> tuple[str, list[str]]:
+    unresolved_blockers = [
+        str(item["code"])
+        for item in result["findings"]
+        if item["severity"] == "blocker" and item["resolved"] is not True
+    ]
+    return (
+        ("fail", unresolved_blockers)
+        if unresolved_blockers
+        else ("pass", [])
+    )
+
+
+def build_change_quality_prepare_packet(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    repo_path: Path,
+    base_ref: str = "origin/main",
+) -> dict[str, Any]:
+    goal = _goal_from_registry(registry_path, goal_id)
+    policy = change_quality_goal_policy(goal)
+    scope = build_change_quality_scope(repo_path=repo_path, base_ref=base_ref)
+    if not policy["enabled"]:
+        status = "disabled"
+    elif not scope["changed_files"]:
+        status = "no_changes"
+    else:
+        status = "review_required"
+    return {
+        "ok": True,
+        "schema_version": CHANGE_QUALITY_PREPARE_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "status": status,
+        "review_required": status == "review_required",
+        "policy": policy,
+        "scope": scope,
+        "agent_contract": {
+            "provider_neutral": True,
+            "max_safe_fix_passes": 1,
+            "instructions": [
+                "Review only the exact changed scope and obey repository-local instructions.",
+                "Preserve intended behavior; prefer deletion, clarity, and established language idioms over new abstraction.",
+                "Use blocker only for concrete correctness, security, privacy, contract, or required-validation failures.",
+                (
+                    "One bounded safe-fix pass is allowed; rerun prepare after edits and review the final scope."
+                    if policy["safe_fix"]
+                    else "Do not modify files; report findings only."
+                ),
+                "Record a result only after reviewing the final scope fingerprint.",
+            ],
+            "result_schema_version": CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
+            "result_template": {
+                "schema_version": CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
+                "scope_fingerprint": scope["scope_fingerprint"],
+                "reviewed_final_scope": True,
+                "summary": "",
+                "findings": [],
+                "safe_fix_applied": False,
+                "safe_fix_passes": 0,
+                "validations": [],
+            },
+        },
+        "turn_boundary": {
+            "role": "transport_only",
+            "rule": (
+                "Turn may carry this packet or a receipt reference, but canary "
+                "premerge remains the enforcement authority."
+            ),
+        },
+    }
+
+
+def record_change_quality_receipt(
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    goal_id: str,
+    repo_path: Path,
+    result_path: Path,
+    base_ref: str = "origin/main",
+    execute: bool = False,
+) -> dict[str, Any]:
+    goal = _goal_from_registry(registry_path, goal_id)
+    policy = change_quality_goal_policy(goal)
+    if not policy["enabled"]:
+        raise ValueError("change-quality qualification is disabled for this goal")
+    scope = build_change_quality_scope(repo_path=repo_path, base_ref=base_ref)
+    if not scope["changed_files"]:
+        raise ValueError("current scope has no changes and does not need a receipt")
+    result = _normalize_result(
+        json.loads(result_path.expanduser().read_text(encoding="utf-8")),
+        expected_fingerprint=str(scope["scope_fingerprint"]),
+        safe_fix_allowed=bool(policy["safe_fix"]),
+    )
+    decision, unresolved_blockers = _decision(result)
+    receipt_id = f"cqr_{str(scope['scope_fingerprint'])[:20]}"
+    receipt = {
+        "schema_version": CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION,
+        "receipt_id": receipt_id,
+        "goal_id": goal_id,
+        "recorded_at": datetime.now().astimezone().replace(microsecond=0).isoformat(),
+        "policy": policy,
+        "scope": scope,
+        "result": result,
+        "decision": decision,
+        "unresolved_blockers": unresolved_blockers,
+    }
+    path = _receipt_path(
+        runtime_root=runtime_root,
+        goal_id=goal_id,
+        repo_path=repo_path,
+        scope_fingerprint=str(scope["scope_fingerprint"]),
+    )
+    if execute:
+        _atomic_write_json(path, receipt)
+    return {
+        "ok": decision == "pass",
+        "schema_version": CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION,
+        "dry_run": not execute,
+        "written": execute,
+        "receipt_id": receipt_id,
+        "decision": decision,
+        "unresolved_blockers": unresolved_blockers,
+        "receipt_path": str(path),
+        "scope_fingerprint": scope["scope_fingerprint"],
+        "receipt": receipt,
+    }
+
+
+def verify_change_quality_receipt(
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    goal_id: str,
+    repo_path: Path,
+    base_ref: str = "origin/main",
+) -> dict[str, Any]:
+    goal = _goal_from_registry(registry_path, goal_id)
+    policy = change_quality_goal_policy(goal)
+    scope = build_change_quality_scope(repo_path=repo_path, base_ref=base_ref)
+    if not policy["enabled"]:
+        return {
+            "ok": True,
+            "schema_version": CHANGE_QUALITY_VERIFY_SCHEMA_VERSION,
+            "goal_id": goal_id,
+            "status": "disabled",
+            "enforcement_applied": False,
+            "policy": policy,
+            "scope": scope,
+        }
+    if not scope["changed_files"]:
+        return {
+            "ok": True,
+            "schema_version": CHANGE_QUALITY_VERIFY_SCHEMA_VERSION,
+            "goal_id": goal_id,
+            "status": "no_changes",
+            "enforcement_applied": bool(policy["strict_receipt"]),
+            "policy": policy,
+            "scope": scope,
+        }
+    path = _receipt_path(
+        runtime_root=runtime_root,
+        goal_id=goal_id,
+        repo_path=repo_path,
+        scope_fingerprint=str(scope["scope_fingerprint"]),
+    )
+    receipt = None
+    if path.exists():
+        try:
+            receipt = read_json(path)
+        except (OSError, ValueError, TypeError, json.JSONDecodeError):
+            receipt = None
+    receipt_valid = bool(
+        receipt
+        and receipt.get("schema_version") == CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION
+        and receipt.get("decision") == "pass"
+        and isinstance(receipt.get("scope"), dict)
+        and receipt["scope"].get("scope_fingerprint") == scope["scope_fingerprint"]
+    )
+    if receipt_valid:
+        status = "valid"
+    elif path.exists():
+        status = "invalid_receipt"
+    else:
+        repo_receipts = sorted(
+            path.parent.glob(f"{_repo_key(repo_path)}-*.json"),
+            key=lambda candidate: candidate.stat().st_mtime,
+            reverse=True,
+        )
+        status = "stale_receipt" if repo_receipts else "receipt_missing"
+    strict = bool(policy["strict_receipt"])
+    return {
+        "ok": receipt_valid or not strict,
+        "schema_version": CHANGE_QUALITY_VERIFY_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "status": status,
+        "enforcement_applied": strict,
+        "policy": policy,
+        "scope": scope,
+        "receipt_id": receipt.get("receipt_id") if receipt else None,
+        "receipt_path": str(path),
+        "receipt_valid": receipt_valid,
+        "required_action": (
+            "run change-quality prepare, review the exact scope, and record a passing receipt"
+            if strict and not receipt_valid
+            else None
+        ),
+    }

--- a/loopx/capabilities/change_quality/scope.py
+++ b/loopx/capabilities/change_quality/scope.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+CHANGE_QUALITY_SCOPE_SCHEMA_VERSION = "change_quality_scope_v0"
+
+
+def _git(
+    repo_root: Path,
+    *args: str,
+    text: bool = False,
+) -> subprocess.CompletedProcess[Any]:
+    return subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=False,
+        text=text,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def resolve_git_root(repo_path: Path) -> Path:
+    candidate = repo_path.expanduser().resolve()
+    result = _git(candidate, "rev-parse", "--show-toplevel", text=True)
+    root = str(result.stdout or "").strip()
+    if result.returncode != 0 or not root:
+        detail = str(result.stderr or "").strip()
+        raise ValueError(f"repo_path is not a git worktree: {candidate}; {detail}")
+    return Path(root).resolve()
+
+
+def _required_git_text(repo_root: Path, *args: str) -> str:
+    result = _git(repo_root, *args, text=True)
+    value = str(result.stdout or "").strip()
+    if result.returncode != 0 or not value:
+        detail = str(result.stderr or "").strip()
+        raise ValueError(f"git {' '.join(args)} failed: {detail}")
+    return value
+
+
+def _name_only(repo_root: Path, *args: str) -> list[str]:
+    result = _git(repo_root, *args, text=True)
+    if result.returncode != 0:
+        detail = str(result.stderr or "").strip()
+        raise ValueError(f"git {' '.join(args)} failed: {detail}")
+    return [
+        line.strip().replace("\\", "/")
+        for line in str(result.stdout or "").splitlines()
+        if line.strip()
+    ]
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def _hash_command_output(
+    digest: Any,
+    repo_root: Path,
+    label: str,
+    args: tuple[str, ...],
+) -> None:
+    result = _git(repo_root, *args)
+    if result.returncode != 0:
+        detail = bytes(result.stderr or b"").decode("utf-8", errors="replace").strip()
+        raise ValueError(f"git {' '.join(args)} failed: {detail}")
+    digest.update(label.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(bytes(result.stdout or b""))
+    digest.update(b"\0")
+
+
+def _hash_untracked_file(digest: Any, repo_root: Path, relative_path: str) -> None:
+    path = repo_root / relative_path
+    digest.update(relative_path.encode("utf-8"))
+    digest.update(b"\0")
+    if path.is_symlink():
+        digest.update(b"symlink\0")
+        digest.update(path.readlink().as_posix().encode("utf-8"))
+        digest.update(b"\0")
+        return
+    digest.update(b"file\0")
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    digest.update(b"\0")
+
+
+def build_change_quality_scope(
+    *,
+    repo_path: Path,
+    base_ref: str = "origin/main",
+) -> dict[str, Any]:
+    repo_root = resolve_git_root(repo_path)
+    normalized_base_ref = str(base_ref or "origin/main").strip() or "origin/main"
+    if normalized_base_ref.startswith("-"):
+        raise ValueError("base_ref cannot start with '-'")
+    base_commit = _required_git_text(
+        repo_root,
+        "rev-parse",
+        "--verify",
+        "--end-of-options",
+        f"{normalized_base_ref}^{{commit}}",
+    )
+    head_commit = _required_git_text(repo_root, "rev-parse", "--verify", "HEAD^{commit}")
+    committed_range = f"{base_commit}...{head_commit}"
+    committed = _name_only(
+        repo_root,
+        "diff",
+        "--name-only",
+        committed_range,
+        "--",
+    )
+    staged = _name_only(repo_root, "diff", "--name-only", "--cached")
+    unstaged = _name_only(repo_root, "diff", "--name-only")
+    untracked = _name_only(repo_root, "ls-files", "--others", "--exclude-standard")
+    changed_files = _dedupe([*committed, *staged, *unstaged, *untracked])
+
+    digest = hashlib.sha256()
+    digest.update(CHANGE_QUALITY_SCOPE_SCHEMA_VERSION.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(base_commit.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(head_commit.encode("utf-8"))
+    digest.update(b"\0")
+    _hash_command_output(
+        digest,
+        repo_root,
+        "committed",
+        ("diff", "--binary", "--full-index", committed_range, "--"),
+    )
+    _hash_command_output(
+        digest,
+        repo_root,
+        "staged",
+        ("diff", "--binary", "--full-index", "--cached"),
+    )
+    _hash_command_output(
+        digest,
+        repo_root,
+        "unstaged",
+        ("diff", "--binary", "--full-index"),
+    )
+    for relative_path in sorted(untracked):
+        _hash_untracked_file(digest, repo_root, relative_path)
+
+    return {
+        "schema_version": CHANGE_QUALITY_SCOPE_SCHEMA_VERSION,
+        "base_ref": normalized_base_ref,
+        "base_commit": base_commit,
+        "head_commit": head_commit,
+        "scope_fingerprint": digest.hexdigest(),
+        "changed_files": changed_files,
+        "changed_file_count": len(changed_files),
+        "sources": {
+            "committed": committed,
+            "staged": staged,
+            "unstaged": unstaged,
+            "untracked": untracked,
+        },
+    }

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -10,6 +10,10 @@ from .capabilities.content_ops.cli import (
     handle_content_ops_command,
     register_content_ops_commands,
 )
+from .capabilities.change_quality.cli import (
+    handle_change_quality_command,
+    register_change_quality_commands,
+)
 from .capabilities.decision_context.cli import (
     handle_decision_context_command,
     register_decision_context_commands,
@@ -210,6 +214,8 @@ def build_parser() -> LoopXArgumentParser:
 
     register_extension_commands(sub, add_subcommand_format)
 
+    register_change_quality_commands(sub, add_subcommand_format)
+
     register_content_ops_commands(sub, add_subcommand_format)
 
     register_decision_context_commands(sub, add_subcommand_format)
@@ -368,6 +374,8 @@ def main(argv: list[str] | None = None) -> int:
 
     canary_result = handle_canary_command(
         args,
+        registry_path=registry_path,
+        runtime_root_arg=args.runtime_root,
         output_format=output_format,
         print_payload=print_payload,
     )
@@ -391,6 +399,16 @@ def main(argv: list[str] | None = None) -> int:
     )
     if extension_result is not None:
         return extension_result
+
+    change_quality_result = handle_change_quality_command(
+        args,
+        registry_path=registry_path,
+        runtime_root_arg=args.runtime_root,
+        output_format=output_format,
+        print_payload=print_payload,
+    )
+    if change_quality_result is not None:
+        return change_quality_result
 
     if args.command == "ml-experiment":
         return handle_ml_experiment_command(args, output_format=output_format, print_payload=print_payload)

--- a/loopx/cli_commands/canary.py
+++ b/loopx/cli_commands/canary.py
@@ -6,6 +6,7 @@ import sys
 from collections.abc import Callable
 from pathlib import Path
 
+from ..capabilities.change_quality.receipt import verify_change_quality_receipt
 from ..canary.planner import (
     build_catalog_canary_coverage_audit,
     build_catalog_canary_plan,
@@ -20,6 +21,7 @@ from ..canary.quality_surface_catalog import (
 )
 from ..canary.premerge import (
     PREMERGE_TIERS,
+    apply_change_quality_verification,
     build_premerge_validation_gate,
     render_premerge_validation_gate_markdown,
 )
@@ -38,6 +40,8 @@ from ..canary.smoke_health import (
 from ..control_plane.testing.release_commit_qualification import (
     render_exact_release_commit_qualification_markdown,
 )
+from ..paths import resolve_runtime_root
+from ..registry import read_json
 from .canary_release_qualification import (
     build_canary_release_qualification_payload,
     register_canary_release_qualification_command,
@@ -523,6 +527,13 @@ def register_canary_commands(
         help="Validation depth. standard runs bounded catalog and risk-profile checks.",
     )
     premerge_parser.add_argument(
+        "--goal-id",
+        help=(
+            "Apply this goal's change-quality policy and exact-scope receipt gate. "
+            "Omit only when no managed goal policy applies."
+        ),
+    )
+    premerge_parser.add_argument(
         "--no-execute",
         action="store_true",
         help="Preview the selected merge gate without running checks.",
@@ -548,6 +559,8 @@ def register_canary_commands(
 def handle_canary_command(
     args: argparse.Namespace,
     *,
+    registry_path: Path | None = None,
+    runtime_root_arg: str | None = None,
     output_format: FormatSelector,
     print_payload: PrintPayload,
 ) -> int | None:
@@ -659,6 +672,27 @@ def handle_canary_command(
             ),
         )
         _attach_selector_sources(payload, git_diff_selector=git_diff_selector)
+        goal_id = str(args.goal_id or "").strip()
+        if goal_id:
+            if registry_path is None:
+                raise ValueError("--goal-id receipt verification requires a registry path")
+            registry = read_json(registry_path)
+            runtime_root = resolve_runtime_root(
+                registry,
+                runtime_root_arg,
+                registry_path=registry_path,
+            )
+            verification = verify_change_quality_receipt(
+                registry_path=registry_path,
+                runtime_root=runtime_root,
+                goal_id=goal_id,
+                repo_path=target_repo_root,
+                base_ref=str(
+                    getattr(args, "git_diff_base", "origin/main")
+                    or "origin/main"
+                ),
+            )
+            apply_change_quality_verification(payload, verification)
         renderer = render_premerge_validation_gate_markdown
     else:
         raise ValueError(

--- a/loopx/cli_commands/registry_admin.py
+++ b/loopx/cli_commands/registry_admin.py
@@ -269,6 +269,24 @@ def register_registry_admin_commands(subparsers: argparse._SubParsersAction) -> 
         help="Enable or disable waiting-projection repair for this goal.",
     )
     configure_goal_parser.add_argument(
+        "--change-quality-enabled",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Enable or disable exact-scope change-quality qualification for this goal.",
+    )
+    configure_goal_parser.add_argument(
+        "--change-quality-safe-fix",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Allow or forbid one bounded safe-fix pass during change qualification.",
+    )
+    configure_goal_parser.add_argument(
+        "--change-quality-strict-receipt",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Require a valid exact-scope quality receipt at premerge.",
+    )
+    configure_goal_parser.add_argument(
         "--multi-subagent-feature",
         choices=["off", "enabled"],
         help=(
@@ -720,6 +738,9 @@ def handle_registry_admin_command(
                 self_repair_enabled=args.self_repair_enabled,
                 self_repair_health=args.self_repair_health,
                 self_repair_waiting_projection=args.self_repair_waiting_projection,
+                change_quality_enabled=args.change_quality_enabled,
+                change_quality_safe_fix=args.change_quality_safe_fix,
+                change_quality_strict_receipt=args.change_quality_strict_receipt,
                 multi_subagent_feature=args.multi_subagent_feature,
                 orchestration_mode=args.orchestration_mode,
                 spawn_allowed=args.spawn_allowed,

--- a/loopx/configuration_catalog.py
+++ b/loopx/configuration_catalog.py
@@ -56,6 +56,13 @@ def build_goal_configuration_catalog(
         if isinstance(feature_summary.get("reward_memory"), Mapping)
         else {}
     )
+    change_quality = (
+        feature_summary.get("change_quality_qualification")
+        if isinstance(
+            feature_summary.get("change_quality_qualification"), Mapping
+        )
+        else {}
+    )
     inspect_command = _configure_command(goal_id)
     multi_enable_args = (
         "--multi-subagent-feature",
@@ -238,6 +245,89 @@ def build_goal_configuration_catalog(
                     "url": (
                         "https://github.com/huangruiteng/loopx/blob/main/"
                         "docs/capabilities/explore/README.md"
+                    ),
+                },
+            },
+            {
+                "feature_id": "change_quality_qualification",
+                "display_name": "Change quality qualification",
+                "availability": "supported_opt_in",
+                "default": {
+                    "enabled": False,
+                    "safe_fix": False,
+                    "strict_receipt": False,
+                },
+                "current": {
+                    "enabled": change_quality.get("enabled") is True,
+                    "safe_fix": change_quality.get("safe_fix") is True,
+                    "strict_receipt": change_quality.get("strict_receipt") is True,
+                },
+                "consider_when": (
+                    "A goal should review every non-trivial final diff and optionally "
+                    "require exact-scope evidence before merge."
+                ),
+                "effect": (
+                    "Prepares a provider-neutral review packet, permits at most one "
+                    "policy-authorized safe-fix pass, and can enforce an exact-diff receipt."
+                ),
+                "does_not": [
+                    "change files unless safe_fix is explicitly enabled",
+                    "make subjective style preferences blocking findings",
+                    "grant authority, expand permissions, or bypass repository validation",
+                    "delegate merge authority to Turn or the reviewing model",
+                ],
+                "commands": {
+                    "preview_skill_install": (
+                        "loopx project-skill install --project . --skill "
+                        "loopx-change-quality --surface codex"
+                    ),
+                    "apply_skill_install": (
+                        "loopx project-skill install --project . --skill "
+                        "loopx-change-quality --surface codex --execute"
+                    ),
+                    "preview_enable": _configure_command(
+                        goal_id,
+                        "--change-quality-enabled",
+                        "--change-quality-safe-fix",
+                        "--change-quality-strict-receipt",
+                    ),
+                    "apply_enable": _configure_command(
+                        goal_id,
+                        "--change-quality-enabled",
+                        "--change-quality-safe-fix",
+                        "--change-quality-strict-receipt",
+                        execute=True,
+                    ),
+                    "preview_disable": _configure_command(
+                        goal_id, "--no-change-quality-enabled"
+                    ),
+                    "apply_disable": _configure_command(
+                        goal_id, "--no-change-quality-enabled", execute=True
+                    ),
+                    "verify": [
+                        inspect_command,
+                        (
+                            "loopx project-skill status --project . --skill "
+                            "loopx-change-quality --surface codex"
+                        ),
+                        shlex.join(
+                            [
+                                "loopx",
+                                "change-quality",
+                                "prepare",
+                                "--goal-id",
+                                goal_id,
+                                "--repo-path",
+                                ".",
+                            ]
+                        ),
+                    ],
+                },
+                "documentation": {
+                    "path": "docs/capabilities/change-quality/README.md",
+                    "url": (
+                        "https://github.com/huangruiteng/loopx/blob/main/"
+                        "docs/capabilities/change-quality/README.md"
                     ),
                 },
             },

--- a/loopx/configure_goal.py
+++ b/loopx/configure_goal.py
@@ -16,6 +16,10 @@ from .boundary_authority import (
     checkpointed_boundary_authority_summary,
 )
 from .agent_registry import normalize_registered_agents
+from .capabilities.change_quality.policy import (
+    CHANGE_QUALITY_POLICY_SCHEMA_VERSION,
+    change_quality_goal_policy_summary,
+)
 from .control_plane import compact_control_plane_policy, control_plane_policy_summary
 from .configuration_catalog import build_goal_configuration_catalog
 from .explore_graph import compact_explore_graph_policy
@@ -221,6 +225,7 @@ def _settings_summary(goal: dict[str, Any]) -> dict[str, Any]:
         "lark_event_inbox": _lark_event_inbox_config_summary(goal),
         "lark_kanban_heartbeat_sync": _lark_kanban_heartbeat_config_summary(goal),
         "reward_memory": reward_memory_goal_policy_summary(goal),
+        "change_quality_qualification": change_quality_goal_policy_summary(goal),
         "explore_graph": compact_explore_graph_policy(goal.get("explore_graph")),
         "orchestration": orchestration,
         "waiting_on": goal.get("waiting_on"),
@@ -408,6 +413,9 @@ def configure_goal(
     self_repair_enabled: bool | None = None,
     self_repair_health: bool | None = None,
     self_repair_waiting_projection: bool | None = None,
+    change_quality_enabled: bool | None = None,
+    change_quality_safe_fix: bool | None = None,
+    change_quality_strict_receipt: bool | None = None,
     multi_subagent_feature: str | None = None,
     orchestration_mode: str | None = None,
     spawn_allowed: bool | None = None,
@@ -730,6 +738,38 @@ def configure_goal(
         if self_repair_waiting_projection is not None:
             self_repair["allow_waiting_projection_repair"] = self_repair_waiting_projection
         control_plane["self_repair"] = self_repair
+        goal["control_plane"] = control_plane
+
+    if (
+        change_quality_enabled is not None
+        or change_quality_safe_fix is not None
+        or change_quality_strict_receipt is not None
+    ):
+        control_plane = (
+            goal.get("control_plane")
+            if isinstance(goal.get("control_plane"), dict)
+            else {}
+        )
+        current = change_quality_goal_policy_summary(goal)
+        change_quality = {
+            "schema_version": CHANGE_QUALITY_POLICY_SCHEMA_VERSION,
+            "enabled": (
+                change_quality_enabled
+                if change_quality_enabled is not None
+                else current["enabled"]
+            ),
+            "safe_fix": (
+                change_quality_safe_fix
+                if change_quality_safe_fix is not None
+                else current["safe_fix"]
+            ),
+            "strict_receipt": (
+                change_quality_strict_receipt
+                if change_quality_strict_receipt is not None
+                else current["strict_receipt"]
+            ),
+        }
+        control_plane["change_quality_qualification"] = change_quality
         goal["control_plane"] = control_plane
 
     if (
@@ -1096,6 +1136,7 @@ def configure_goal(
         "lark_event_inbox": _lark_event_inbox_config_summary(goal),
         "lark_kanban_heartbeat_sync": _lark_kanban_heartbeat_config_summary(goal),
         "reward_memory": reward_memory_goal_policy_summary(goal),
+        "change_quality_qualification": change_quality_goal_policy_summary(goal),
         "default": "off",
         "configuration_entry": "multi_subagent_feature",
     }

--- a/skills/loopx-change-quality/.loopx-skill-scope
+++ b/skills/loopx-change-quality/.loopx-skill-scope
@@ -1,0 +1,1 @@
+project

--- a/skills/loopx-change-quality/SKILL.md
+++ b/skills/loopx-change-quality/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: loopx-change-quality
+description: Qualify the exact final diff for a LoopX-managed goal. Use when goal policy enables change_quality_qualification, before a non-trivial delivery or merge, and when producing or repairing an exact-scope quality receipt. The workflow is language-neutral, permits at most one policy-authorized safe-fix pass, and never grants merge or repository authority.
+---
+
+# LoopX Change Quality
+
+Use this skill only when the selected goal's
+`change_quality_qualification.enabled` policy is true. LoopX owns the canonical
+source but does not install it globally. Install a managed copy in a connected
+project for the relevant host:
+
+```bash
+loopx project-skill install \
+  --project . \
+  --skill loopx-change-quality \
+  --surface codex \
+  --execute
+```
+
+Use `--surface claude-code` or `--surface opencode` for those hosts. Skill
+discovery does not activate the capability; product behavior remains
+default-off until goal policy enables it.
+
+The CLI is the contract authority. This skill supplies a host-neutral review
+workflow. Repository instructions, tests, linters, type checkers, and security
+checks remain the project's quality oracles.
+
+## Prepare The Exact Scope
+
+From the repository worktree, run:
+
+```bash
+loopx --format json change-quality prepare \
+  --goal-id <goal-id> \
+  --repo-path . \
+  --base-ref origin/main
+```
+
+Stop when the packet says `disabled` or `no_changes`. When it says
+`review_required`, review only the files and exact fingerprint in the packet.
+Read repository-local instructions before judging the change.
+
+Run `loopx project-skill status --project . --skill loopx-change-quality` when
+the host depends on skill discovery. If the managed copy is absent or stale,
+preview an explicit project install; do not fall back to a global copy.
+
+## Review Rules
+
+Review the final diff for:
+
+- correctness and behavioral regressions;
+- security, privacy, authority, and public/private boundary violations;
+- broken caller contracts, schemas, migrations, and state transitions;
+- missing validation required by the changed surface;
+- unnecessary complexity, duplication of durable knowledge, and abstractions
+  without a shipped call site;
+- language- and framework-specific issues reported by the project's own tools.
+
+Use `blocker` only for a concrete correctness, security, privacy, contract, or
+required-validation failure. Style preferences and speculative redesigns are
+`warning` or `advisory`, never blockers.
+
+This first version is single-level. Review one final diff; do not recursively
+review the review, spawn a hierarchy of quality agents, or require agreement
+between several models.
+
+## Safe Fix
+
+`safe_fix` and `strict_receipt` are independent:
+
+- `safe_fix=true` permits at most one bounded repair pass.
+- `strict_receipt=true` requires exact-scope evidence before merge and grants
+  no permission to edit.
+
+When `safe_fix` is false, report findings without modifying files. When it is
+true, one repair pass may address clear findings inside the selected todo and
+goal boundary. Do not use destructive git, broaden permissions, change product
+intent, add unrelated refactors, or conceal a failing validator.
+
+After any edit, rerun `prepare`. The old fingerprint is invalid. Review the
+entire new final scope, not only the lines changed by the repair.
+
+## Record The Receipt
+
+Write a compact result conforming to the packet's
+`change_quality_agent_result_v0` template. Keep raw transcripts, private paths,
+credentials, and unbounded logs out of the result.
+
+Then record and read back the exact receipt:
+
+```bash
+loopx --format json change-quality record \
+  --goal-id <goal-id> \
+  --repo-path . \
+  --base-ref origin/main \
+  --result-json <ignored-or-temporary-result.json> \
+  --execute
+
+loopx --format json change-quality verify \
+  --goal-id <goal-id> \
+  --repo-path . \
+  --base-ref origin/main
+```
+
+A receipt with an unresolved blocker is not passing. A receipt for an earlier
+fingerprint does not qualify a later diff.
+
+## Premerge Enforcement
+
+Run the authoritative merge gate with the goal identity:
+
+```bash
+loopx canary premerge \
+  --from-git-diff \
+  --goal-id <goal-id>
+```
+
+Turn may transport the prepare packet or receipt reference as part of one
+bounded transaction. Turn does not own quality policy and may not manufacture
+or waive a receipt. `canary premerge` remains the enforcement authority.
+
+## Completion Evidence
+
+Report:
+
+- final scope fingerprint and changed-file count;
+- safe-fix allowed/applied and pass count;
+- blocker, warning, and advisory counts;
+- project validations run and their real results;
+- receipt id and exact verification status;
+- premerge status, failures or skips, and manual holds.
+
+Stop before delivery when strict policy requires a receipt and the receipt is
+missing, invalid, stale, or contains an unresolved blocker.

--- a/skills/loopx-change-quality/agents/openai.yaml
+++ b/skills/loopx-change-quality/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "LoopX Change Quality"
+  short_description: "Qualify an exact final diff and receipt"
+  default_prompt: "Use the goal policy and LoopX exact-scope packet to review the final diff, apply at most one allowed safe fix, record the receipt, and enforce it at premerge."

--- a/skills/loopx-project/SKILL.md
+++ b/skills/loopx-project/SKILL.md
@@ -738,6 +738,28 @@ creates an `operator_gate_*` compact run so `loopx status` and the
 dashboard can tell whether the project agent may run the approved command. This
 is not a human reward signal and does not grant write-control.
 
+## Qualify Non-Trivial Final Diffs
+
+Before a non-trivial delivery or merge, inspect the current goal configuration.
+When `change_quality_qualification.enabled` is true, load
+`loopx-change-quality` and follow its exact-scope workflow:
+
+```bash
+loopx --format json change-quality prepare \
+  --goal-id <STABLE_GOAL_ID> \
+  --repo-path .
+```
+
+The policy keeps two decisions separate: `safe_fix` permits at most one bounded
+repair pass, while `strict_receipt` requires a passing receipt for the exact
+final diff. Any edit invalidates the old fingerprint. Record and verify the
+final receipt, then pass `--goal-id <STABLE_GOAL_ID>` to `canary premerge`.
+
+If the host cannot load skills, use the self-contained prepare packet as the
+review contract. Turn may carry the packet or receipt reference, but it does
+not own policy or enforcement. Do not invent a receipt, reuse one from an older
+diff, or turn subjective style advice into a blocker.
+
 ## Refresh State After Non-Adapter Work
 
 If the agent updated `ACTIVE_GOAL_STATE.md`, a progress ledger, a planning doc,

--- a/tests/capabilities/test_capability_extension_registry.py
+++ b/tests/capabilities/test_capability_extension_registry.py
@@ -23,6 +23,7 @@ from loopx.extensions.runtime import (
 )
 
 BUILTIN_IDS = [
+    "change-quality-qualification",
     "issue-fix",
     "decision-context",
     "project-skill-delivery",
@@ -127,6 +128,27 @@ def test_material_lifecycle_catalog_exposes_managed_project_skill() -> None:
             "loopx-material --surface codex --execute"
         ),
     }
+
+
+def test_change_quality_catalog_exposes_default_off_managed_workflow() -> None:
+    capability = build_capability_detail_packet("change-quality-qualification")[
+        "capability"
+    ]
+
+    assert capability["default_enabled"] is False
+    assert capability["workflow_skill"] == {
+        "name": "loopx-change-quality",
+        "delivery": "project_managed_copy",
+        "activation": "explicit_project_install_plus_goal_policy",
+        "project_copy_required": True,
+        "install_command": (
+            "loopx project-skill install --project . --skill "
+            "loopx-change-quality --surface codex --execute"
+        ),
+    }
+    assert "safe_fix permits at most one bounded repair pass" in "\n".join(
+        capability["boundaries"]
+    )
 
 
 def test_project_skill_delivery_catalog_is_host_neutral() -> None:

--- a/tests/capabilities/test_change_quality.py
+++ b/tests/capabilities/test_change_quality.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from loopx.agent_onboarding import _skill_delivery_contract
+from loopx.canary.premerge import (
+    apply_change_quality_verification,
+    build_premerge_validation_gate,
+)
+from loopx.capabilities.change_quality.policy import change_quality_goal_policy
+from loopx.capabilities.change_quality.receipt import (
+    CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
+    build_change_quality_prepare_packet,
+    record_change_quality_receipt,
+    verify_change_quality_receipt,
+)
+from loopx.cli import main
+from loopx.configure_goal import configure_goal
+from loopx.project_skill_delivery import (
+    install_project_skill,
+    inspect_project_skill,
+)
+
+
+GOAL_ID = "change-quality-fixture"
+
+
+def _git(repo: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return completed.stdout.strip()
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "change-quality@example.invalid")
+    _git(repo, "config", "user.name", "Change Quality Fixture")
+    (repo / "app.py").write_text("value = 1\n", encoding="utf-8")
+    _git(repo, "add", "app.py")
+    _git(repo, "commit", "-m", "fixture")
+    runtime_root = tmp_path / "runtime"
+    registry = tmp_path / "registry.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "common_runtime_root": str(runtime_root),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "repo": str(repo),
+                        "control_plane": {},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return repo, registry, runtime_root
+
+
+def _enable(
+    registry: Path,
+    *,
+    safe_fix: bool = True,
+    strict_receipt: bool = True,
+) -> None:
+    configure_goal(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        change_quality_enabled=True,
+        change_quality_safe_fix=safe_fix,
+        change_quality_strict_receipt=strict_receipt,
+        execute=True,
+    )
+
+
+def _result(path: Path, fingerprint: str, **overrides: object) -> Path:
+    payload = {
+        "schema_version": CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
+        "scope_fingerprint": fingerprint,
+        "reviewed_final_scope": True,
+        "summary": "Reviewed the exact final scope.",
+        "findings": [],
+        "safe_fix_applied": False,
+        "safe_fix_passes": 0,
+        "validations": ["fixture validation passed"],
+        **overrides,
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_policy_defaults_off_and_configures_independent_controls(
+    tmp_path: Path,
+) -> None:
+    _repo, registry, _runtime = _fixture(tmp_path)
+    stored = json.loads(registry.read_text(encoding="utf-8"))["goals"][0]
+    assert change_quality_goal_policy(stored) == {
+        "schema_version": "change_quality_qualification_policy_v0",
+        "enabled": False,
+        "safe_fix": False,
+        "strict_receipt": False,
+    }
+
+    preview = configure_goal(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        change_quality_enabled=True,
+        change_quality_strict_receipt=True,
+        execute=False,
+    )
+
+    assert preview["after"]["change_quality_qualification"] == {
+        "enabled": True,
+        "safe_fix": False,
+        "strict_receipt": True,
+    }
+
+
+def test_exact_scope_receipt_becomes_stale_after_any_diff_change(
+    tmp_path: Path,
+) -> None:
+    repo, registry, runtime_root = _fixture(tmp_path)
+    _enable(registry)
+    (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
+    prepared = build_change_quality_prepare_packet(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        base_ref="HEAD",
+    )
+    result_path = _result(
+        tmp_path / "result.json",
+        prepared["scope"]["scope_fingerprint"],
+    )
+
+    recorded = record_change_quality_receipt(
+        registry_path=registry,
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        result_path=result_path,
+        base_ref="HEAD",
+        execute=True,
+    )
+    verified = verify_change_quality_receipt(
+        registry_path=registry,
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        base_ref="HEAD",
+    )
+    assert recorded["decision"] == "pass"
+    assert verified["status"] == "valid"
+    assert verified["ok"] is True
+
+    (repo / "app.py").write_text("value = 3\n", encoding="utf-8")
+    stale = verify_change_quality_receipt(
+        registry_path=registry,
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        base_ref="HEAD",
+    )
+    assert stale["status"] == "stale_receipt"
+    assert stale["ok"] is False
+
+
+def test_receipt_identity_is_stable_from_repository_subdirectories(
+    tmp_path: Path,
+) -> None:
+    repo, registry, runtime_root = _fixture(tmp_path)
+    _enable(registry)
+    nested = repo / "src"
+    nested.mkdir()
+    (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
+    prepared = build_change_quality_prepare_packet(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        base_ref="HEAD",
+    )
+    result_path = _result(
+        tmp_path / "result.json",
+        prepared["scope"]["scope_fingerprint"],
+    )
+    record_change_quality_receipt(
+        registry_path=registry,
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        result_path=result_path,
+        base_ref="HEAD",
+        execute=True,
+    )
+
+    verified = verify_change_quality_receipt(
+        registry_path=registry,
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        repo_path=nested,
+        base_ref="HEAD",
+    )
+    assert verified["status"] == "valid"
+    assert verified["ok"] is True
+
+
+def test_safe_fix_result_is_rejected_when_policy_forbids_mutation(
+    tmp_path: Path,
+) -> None:
+    repo, registry, runtime_root = _fixture(tmp_path)
+    _enable(registry, safe_fix=False, strict_receipt=False)
+    (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
+    prepared = build_change_quality_prepare_packet(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        base_ref="HEAD",
+    )
+    result_path = _result(
+        tmp_path / "result.json",
+        prepared["scope"]["scope_fingerprint"],
+        safe_fix_applied=True,
+        safe_fix_passes=1,
+    )
+
+    with pytest.raises(ValueError, match="policy forbids safe fixes"):
+        record_change_quality_receipt(
+            registry_path=registry,
+            runtime_root=runtime_root,
+            goal_id=GOAL_ID,
+            repo_path=repo,
+            result_path=result_path,
+            base_ref="HEAD",
+            execute=False,
+        )
+
+
+def test_unresolved_blocker_cannot_produce_passing_receipt(
+    tmp_path: Path,
+) -> None:
+    repo, registry, runtime_root = _fixture(tmp_path)
+    _enable(registry)
+    (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
+    prepared = build_change_quality_prepare_packet(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        base_ref="HEAD",
+    )
+    result_path = _result(
+        tmp_path / "result.json",
+        prepared["scope"]["scope_fingerprint"],
+        findings=[
+            {
+                "severity": "blocker",
+                "code": "required-validation-failed",
+                "message": "The required fixture validation failed.",
+                "resolved": False,
+                "path": "app.py",
+                "line": 1,
+            }
+        ],
+    )
+
+    recorded = record_change_quality_receipt(
+        registry_path=registry,
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        result_path=result_path,
+        base_ref="HEAD",
+        execute=True,
+    )
+    assert recorded["ok"] is False
+    assert recorded["decision"] == "fail"
+    assert recorded["unresolved_blockers"] == ["required-validation-failed"]
+
+
+def test_strict_verification_failure_overrides_premerge_gate(
+    tmp_path: Path,
+) -> None:
+    repo, registry, runtime_root = _fixture(tmp_path)
+    _enable(registry)
+    (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
+    verification = verify_change_quality_receipt(
+        registry_path=registry,
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        base_ref="HEAD",
+    )
+    gate = build_premerge_validation_gate(
+        changed_files=["app.py"],
+        base_ref="HEAD",
+        execute=False,
+        repo_root=repo,
+    )
+
+    apply_change_quality_verification(gate, verification)
+
+    assert gate["ok"] is False
+    assert gate["gate"]["status"] == "quality_receipt_missing"
+    assert gate["gate"]["merge_gate_passed"] is False
+    assert gate["validation_summary"]["policy_failure_count"] == 1
+
+
+def test_premerge_cli_enforces_goal_receipt_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo, registry, runtime_root = _fixture(tmp_path)
+    _enable(registry)
+    (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
+    monkeypatch.chdir(repo)
+
+    exit_code = main(
+        [
+            "--registry",
+            str(registry),
+            "--runtime-root",
+            str(runtime_root),
+            "--format",
+            "json",
+            "canary",
+            "premerge",
+            "--from-git-diff",
+            "--git-diff-base",
+            "HEAD",
+            "--goal-id",
+            GOAL_ID,
+            "--no-execute",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["change_quality_qualification"]["status"] == "receipt_missing"
+    assert payload["gate"]["merge_gate_passed"] is False
+    assert payload["gate"]["self_merge_allowed"] is False
+
+
+def test_quality_skill_delivery_is_policy_conditional_and_host_neutral(
+    tmp_path: Path,
+) -> None:
+    inactive = _skill_delivery_contract("other-agent")
+    assert inactive["required_skill_ids"] == [
+        "loopx-project",
+        "loopx-pr-review",
+        "loopx-doc-registry",
+        "loopx-self-repair",
+    ]
+
+    active_custom = _skill_delivery_contract(
+        "other-agent",
+        active_project_skill_ids=["loopx-change-quality"],
+    )
+    assert "loopx-change-quality" in active_custom["required_skill_ids"]
+    assert "skills/loopx-change-quality" in active_custom["source_directories"]
+
+    active_codex = _skill_delivery_contract(
+        "codex-cli",
+        project=str(tmp_path / "project"),
+        active_project_skill_ids=["loopx-change-quality"],
+    )
+    commands = active_codex["project_skill_commands"][0]
+    assert commands["status"].startswith("loopx project-skill status ")
+    assert commands["preview_install"].startswith("loopx project-skill install ")
+    assert commands["apply_install"].endswith(" --execute")
+
+
+def test_quality_skill_uses_managed_project_delivery(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    registry = project / ".loopx" / "registry.json"
+    registry.parent.mkdir(parents=True)
+    registry.write_text("{}\n", encoding="utf-8")
+
+    preview = install_project_skill(
+        project,
+        "loopx-change-quality",
+        surfaces=("codex",),
+        execute=False,
+    )
+    assert preview["status"] == "missing"
+    assert preview["changed"] is True
+
+    applied = install_project_skill(
+        project,
+        "loopx-change-quality",
+        surfaces=("codex",),
+        execute=True,
+    )
+    assert applied["status"] == "current"
+    readback = inspect_project_skill(
+        project,
+        "loopx-change-quality",
+        surfaces=("codex",),
+    )
+    assert readback["status"] == "current"
+    assert readback["managed"] is True


### PR DESCRIPTION
## Summary

- add a default-off, provider-neutral `change-quality` capability for exact final-diff review
- keep `safe_fix` and `strict_receipt` independent, with strict receipt enforcement in `canary premerge --goal-id`
- ship `loopx-change-quality` as a release-owned, project-managed skill and project it conditionally through agent onboarding

## Product And Architecture

The user problem is inconsistent engineering-quality discipline across LoopX-managed projects without a language-specific or model-specific kernel dependency. The implementation keeps policy and exact-scope receipt enforcement in LoopX core, while repository-native tests, linters, type checkers, security tools, and reviewer competence remain provider responsibilities.

The capability is disabled by default. Project skill discovery is separate from goal activation. The first version is deliberately single-level and allows at most one policy-authorized safe-fix pass; it does not recursively review reviewers or treat a receipt as proof that every defect was found.

## Validation

- `9 passed` in the focused change-quality unit and CLI suite
- `31 passed` across capability catalog, project-skill CLI, and doctor/install freshness tests
- change-quality, configure-goal, onboarding, quality-surface, and premerge smokes passed
- packaged installer and local installer smokes passed
- Ruff 0.12.12 changed-path check passed
- public-boundary scan passed with zero warnings
- final exact-scope receipt after rebasing onto latest `main`: `cqr_461207537a15a9389301`
- final risk-based premerge: 4 direct checks and 18 selected checks executed, 0 failures, 0 warnings, 0 advisory failures, no manual holds

## Risk

The main behavior risk is callers omitting `--goal-id` from premerge and therefore not applying goal policy. The managed workflow and onboarding contract explicitly require the goal identity. Existing premerge calls without a goal remain behavior-compatible.
