### PR TITLE
Fix host-local SkillsBench timeout floor

### DIFF
--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -209,6 +209,21 @@ def main() -> int:
         DEFAULT_HOST_LOCAL_CODEX_BRIDGE_IDLE_TIMEOUT_SEC
         + HOST_LOCAL_ACP_AGENT_TIMEOUT_MARGIN_SEC
     )
+    host_local_outer_timeout_args = SimpleNamespace(
+        agent_idle_timeout=900,
+        host_local_acp_launch=True,
+        local_codex_bridge_idle_timeout_sec=None,
+        local_codex_exec_timeout_sec=None,
+        outer_timeout_sec=10800,
+        route="loopx-product-mode",
+    )
+    assert (
+        _effective_local_codex_exec_timeout_sec(host_local_outer_timeout_args)
+        == 10800
+    )
+    assert _effective_benchflow_agent_timeout_sec(
+        host_local_outer_timeout_args
+    ) == (10800 + HOST_LOCAL_ACP_AGENT_TIMEOUT_MARGIN_SEC)
     non_host_local_timeout_args = SimpleNamespace(
         agent_idle_timeout=7200,
         host_local_acp_launch=False,

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -1151,15 +1151,18 @@ def _effective_local_codex_exec_timeout_sec(args: argparse.Namespace) -> int:
         configured_raw is None
         and bool(getattr(args, "host_local_acp_launch", False))
     ):
+        outer_timeout = max(0, int(getattr(args, "outer_timeout_sec", 0) or 0))
         if getattr(args, "route", "") == "codex-app-server-goal-baseline":
-            outer_timeout = max(0, int(getattr(args, "outer_timeout_sec", 0) or 0))
             return max(configured, outer_timeout)
         bridge_idle_timeout = _effective_local_codex_bridge_idle_timeout_sec(args)
         if bridge_idle_timeout > 0:
             return max(
                 1,
+                outer_timeout,
                 bridge_idle_timeout + HOST_LOCAL_ACP_AGENT_TIMEOUT_MARGIN_SEC,
             )
+        if outer_timeout > 0:
+            return outer_timeout
     if configured_raw is None and idle_timeout > 0:
         return min(configured, idle_timeout)
     return configured

--- a/tests/test_skillsbench_automation_loop_timeouts.py
+++ b/tests/test_skillsbench_automation_loop_timeouts.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+
+from scripts.skillsbench_automation_loop import (
+    DEFAULT_HOST_LOCAL_CODEX_BRIDGE_IDLE_TIMEOUT_SEC,
+    HOST_LOCAL_ACP_AGENT_TIMEOUT_MARGIN_SEC,
+    _effective_local_codex_exec_timeout_sec,
+)
+
+
+def _host_local_args(**overrides):
+    values = {
+        "agent_idle_timeout": 900,
+        "host_local_acp_launch": True,
+        "local_codex_bridge_idle_timeout_sec": None,
+        "local_codex_exec_timeout_sec": None,
+        "outer_timeout_sec": 0,
+        "route": "loopx-product-mode",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_host_local_exec_timeout_defaults_to_bridge_idle_margin() -> None:
+    assert _effective_local_codex_exec_timeout_sec(_host_local_args()) == (
+        DEFAULT_HOST_LOCAL_CODEX_BRIDGE_IDLE_TIMEOUT_SEC
+        + HOST_LOCAL_ACP_AGENT_TIMEOUT_MARGIN_SEC
+    )
+
+
+def test_host_local_exec_timeout_covers_outer_runner_timeout() -> None:
+    assert (
+        _effective_local_codex_exec_timeout_sec(
+            _host_local_args(outer_timeout_sec=10800)
+        )
+        == 10800
+    )
+
+
+def test_host_local_exec_timeout_preserves_explicit_override() -> None:
+    assert (
+        _effective_local_codex_exec_timeout_sec(
+            _host_local_args(
+                local_codex_exec_timeout_sec=3600,
+                outer_timeout_sec=10800,
+            )
+        )
+        == 3600
+    )
+
+
+def test_host_local_exec_timeout_uses_outer_floor_when_bridge_idle_disabled() -> None:
+    assert (
+        _effective_local_codex_exec_timeout_sec(
+            _host_local_args(
+                local_codex_bridge_idle_timeout_sec=0,
+                outer_timeout_sec=10800,
+            )
+        )
+        == 10800
+    )


### PR DESCRIPTION
## Summary
- floor default host-local Codex execution timeouts by the outer runner timeout on every route
- preserve explicit local timeout overrides
- cover the bridge-idle default, outer floor, explicit override, and disabled bridge-idle cases

## Validation
- `python3 examples/skillsbench-host-local-launch-plan-smoke.py`
- `uv run --with pytest python -m pytest -q tests/test_skillsbench_automation_loop_timeouts.py` (4 passed)
- Python compile for all changed modules
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 5/5 checks passed; benchmark-sensitive manual review hold remains
- public/private boundary scan clean
- change-quality receipt `cqr_5d59f8fc9114842c9c4b` valid

## Boundary
No benchmark jobs, scoring, task semantics, raw evidence, private state, credentials, local paths, uploads, or submissions are included.