### PR TITLE
Fix SkillsBench proxy port coherence

### DIFF
--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -787,6 +787,9 @@ supervisor_cmd=(
   "${ssh_options[@]}"
   --cleanup-stale-local-forward
   --remote-forward "127.0.0.1:${remote_proxy_port}:${local_proxy_host}:${local_proxy_port}"
+  --codex-reverse-proxy-port "$remote_proxy_port"
+  --benchmark-egress-proxy-port "$remote_proxy_port"
+  --container-forwarder-port "$remote_proxy_port"
   --probe-timeout-sec "$tunnel_probe_timeout"
   --tunnel-ready-timeout-sec "$tunnel_ready_timeout"
   --tunnel-health-interval-sec "$tunnel_health_interval"
@@ -857,6 +860,7 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'public_output=%s/supervisor.public.json\n' "$public_dir"
   printf 'private_dir=%s\n' "$private_dir"
   printf 'remote_proxy_port=%s\n' "$remote_proxy_port"
+  printf 'proxy_port_coherence_guard=enforced\n'
   printf 'docker_proxy_host_recorded=false\n'
   printf 'docker_proxy_endpoint_mode=%s\n' "$docker_proxy_endpoint_mode"
   printf 'docker_api_version=%s\n' "$docker_api_version"

--- a/scripts/skillsbench_reverse_tunnel_supervisor.py
+++ b/scripts/skillsbench_reverse_tunnel_supervisor.py
@@ -51,6 +51,11 @@ DEFAULT_TEST_PORT = 443
 BRIDGE_HELPER = (
     Path(__file__).resolve().with_name("skillsbench_reverse_channel_bridge.py")
 )
+PROXY_PORT_FIELDS = (
+    "codex_reverse_proxy_port",
+    "benchmark_egress_proxy_port",
+    "container_forwarder_port",
+)
 
 
 def _host_kind(value: str) -> str:
@@ -94,6 +99,56 @@ def _forward_public_contract(remote_forward: str) -> dict[str, Any]:
         "local_port": parsed["local_port"],
         "raw_forward_recorded": False,
     }
+
+
+def _proxy_port_coherence_public_contract(
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    declared = {
+        field: getattr(args, field, None)
+        for field in PROXY_PORT_FIELDS
+        if getattr(args, field, None) is not None
+    }
+    contract: dict[str, Any] = {
+        "schema_version": "skillsbench_proxy_port_coherence_v0",
+        "state": "not_requested",
+        "guard_enforced": False,
+        "declared_surface_count": len(declared),
+        "expected_surface_count": len(PROXY_PORT_FIELDS),
+        "raw_command_read": False,
+        "raw_command_recorded": False,
+    }
+    if not declared:
+        return contract
+    if len(declared) != len(PROXY_PORT_FIELDS):
+        missing = [
+            "--" + field.replace("_", "-")
+            for field in PROXY_PORT_FIELDS
+            if field not in declared
+        ]
+        raise ValueError(
+            "proxy port coherence declarations are all-or-none; missing "
+            + ", ".join(missing)
+        )
+
+    remote_port = _parse_remote_forward(args.remote_forward)["remote_port"]
+    ports = [remote_port, *(int(declared[field]) for field in PROXY_PORT_FIELDS)]
+    if any(port < 1 or port > 65535 for port in ports):
+        raise ValueError("proxy port coherence declarations must be valid TCP ports")
+    if len(set(ports)) != 1:
+        raise ValueError(
+            "--remote-forward remote port, --codex-reverse-proxy-port, "
+            "--benchmark-egress-proxy-port, and --container-forwarder-port "
+            "must match"
+        )
+    contract.update(
+        {
+            "state": "coherent",
+            "guard_enforced": True,
+            "coherent_port": remote_port,
+        }
+    )
+    return contract
 
 
 def _local_forward_dependency_public_contract(
@@ -1404,6 +1459,7 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         "raw_remote_output_recorded": False,
         "private_log_written": False,
         "remote_forward": _forward_public_contract(args.remote_forward),
+        "proxy_port_coherence": dict(args.proxy_port_coherence),
         "local_forward_dependency": (
             _local_forward_dependency_public_contract(args)
         ),
@@ -2031,6 +2087,33 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--server-alive-count-max", type=int, default=3)
     parser.add_argument("--remote-forward", default=DEFAULT_REMOTE_FORWARD)
     parser.add_argument(
+        "--codex-reverse-proxy-port",
+        type=int,
+        default=None,
+        help=(
+            "Structured declaration of the remote Codex reverse-proxy port. "
+            "Must match the other proxy port declarations and --remote-forward."
+        ),
+    )
+    parser.add_argument(
+        "--benchmark-egress-proxy-port",
+        type=int,
+        default=None,
+        help=(
+            "Structured declaration of the benchmark egress-proxy port. "
+            "Must match the other proxy port declarations and --remote-forward."
+        ),
+    )
+    parser.add_argument(
+        "--container-forwarder-port",
+        type=int,
+        default=None,
+        help=(
+            "Structured declaration of the container forwarder listen port. "
+            "Must match the other proxy port declarations and --remote-forward."
+        ),
+    )
+    parser.add_argument(
         "--local-forward-managed-command",
         default="",
         help=(
@@ -2350,6 +2433,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Optional path for compact public-safe supervisor JSON.",
     )
     args = parser.parse_args(argv)
+    try:
+        args.proxy_port_coherence = _proxy_port_coherence_public_contract(args)
+    except ValueError as exc:
+        parser.error(str(exc))
     if _json_bridge_requested(args):
         args.json_bridge = True
         missing = [

--- a/tests/test_skillsbench_reverse_tunnel_supervisor.py
+++ b/tests/test_skillsbench_reverse_tunnel_supervisor.py
@@ -5,6 +5,7 @@ import json
 import stat
 from pathlib import Path
 
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SUPERVISOR_PATH = REPO_ROOT / "scripts" / "skillsbench_reverse_tunnel_supervisor.py"
@@ -52,6 +53,89 @@ exit 0
         encoding="utf-8",
     )
     path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def test_proxy_port_coherence_guard_allows_shared_forward_reuse() -> None:
+    supervisor = _load_supervisor_module()
+
+    args = supervisor.parse_args(
+        [
+            "--ssh-destination",
+            "runner.example",
+            "--remote-forward",
+            "127.0.0.1:18184:127.0.0.1:18184",
+            "--codex-reverse-proxy-port",
+            "18184",
+            "--benchmark-egress-proxy-port",
+            "18184",
+            "--container-forwarder-port",
+            "18184",
+        ]
+    )
+
+    assert args.proxy_port_coherence == {
+        "schema_version": "skillsbench_proxy_port_coherence_v0",
+        "state": "coherent",
+        "guard_enforced": True,
+        "declared_surface_count": 3,
+        "expected_surface_count": 3,
+        "raw_command_read": False,
+        "raw_command_recorded": False,
+        "coherent_port": 18184,
+    }
+
+
+@pytest.mark.parametrize(
+    "extra_args",
+    [
+        [
+            "--codex-reverse-proxy-port",
+            "18184",
+            "--benchmark-egress-proxy-port",
+            "18184",
+        ],
+        [
+            "--codex-reverse-proxy-port",
+            "18184",
+            "--benchmark-egress-proxy-port",
+            "18185",
+            "--container-forwarder-port",
+            "18184",
+        ],
+    ],
+)
+def test_proxy_port_coherence_guard_rejects_incomplete_or_mismatched_ports(
+    extra_args: list[str],
+) -> None:
+    supervisor = _load_supervisor_module()
+
+    with pytest.raises(SystemExit) as exc_info:
+        supervisor.parse_args(
+            [
+                "--ssh-destination",
+                "runner.example",
+                "--remote-forward",
+                "127.0.0.1:18184:127.0.0.1:18184",
+                *extra_args,
+            ]
+        )
+
+    assert exc_info.value.code == 2
+
+
+def test_proxy_port_coherence_guard_is_compatible_when_not_requested() -> None:
+    supervisor = _load_supervisor_module()
+
+    args = supervisor.parse_args(
+        [
+            "--ssh-destination",
+            "runner.example",
+        ]
+    )
+
+    assert args.proxy_port_coherence["state"] == "not_requested"
+    assert args.proxy_port_coherence["guard_enforced"] is False
+    assert args.proxy_port_coherence["declared_surface_count"] == 0
 
 
 def test_supervisor_writes_starting_periodic_and_terminal_public_liveness(
@@ -114,6 +198,9 @@ def test_supervisor_writes_starting_periodic_and_terminal_public_liveness(
     assert persisted["public_liveness"]["raw_trajectory_recorded"] is False
     assert persisted["public_liveness"]["raw_verifier_output_recorded"] is False
     assert persisted["public_liveness"]["local_paths_recorded"] is False
+    assert persisted["proxy_port_coherence"]["state"] == "not_requested"
+    assert persisted["proxy_port_coherence"]["raw_command_read"] is False
+    assert persisted["proxy_port_coherence"]["raw_command_recorded"] is False
     assert persisted["active_phase"] == {
         "schema_version": "skillsbench_supervisor_active_phase_v0",
         "state": "not_observed",

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -129,6 +129,14 @@ def test_launcher_dry_run_does_not_require_reachable_local_proxy(
 
     assert "skillsbench_local_proxy_endpoint_unreachable" not in proc.stderr
     assert "docker_proxy_host_recorded=false" in proc.stdout
+    assert "proxy_port_coherence_guard=enforced" in proc.stdout
+    for expected_arg in (
+        "--remote-forward 127.0.0.1:18180:127.0.0.1:1",
+        "--codex-reverse-proxy-port 18180",
+        "--benchmark-egress-proxy-port 18180",
+        "--container-forwarder-port 18180",
+    ):
+        assert expected_arg in proc.stdout
 
 
 def test_launcher_fails_before_batch_when_exact_host_sandbox_probe_fails(


### PR DESCRIPTION
## Summary
- add structured proxy-port declarations to the reverse-tunnel supervisor
- reject incomplete or mismatched declarations before SSH or benchmark launch
- wire the canonical SkillsBench launcher to declare one coherent port across all proxy surfaces

## Validation
- `uv run --with pytest pytest -q tests/test_skillsbench_reverse_tunnel_supervisor.py tests/test_skillsbench_turn_launcher.py` (39 passed)
- `python3 examples/skillsbench-reverse-tunnel-supervisor-smoke.py`
- `python3 examples/skillsbench-benchmark-egress-policy-smoke.py`
- changed-scope Ruff F/E/import checks
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` (all selected checks passed; benchmark-sensitive manual hold recorded)

No benchmark jobs, scoring, task semantics, uploads, or submissions are changed.