### PR TITLE
docs(capabilities): add Decision Context and Material Lifecycle guides

### DIFF
--- a/docs/capabilities/README.md
+++ b/docs/capabilities/README.md
@@ -22,12 +22,14 @@ propose a typed transition through the existing Kernel contract.
 
 Current capability paths:
 
-- [decision-context](../reference/protocols/decision-context-architecture-v0.md)
-  ([中文](../reference/protocols/decision-context-architecture-v0.zh-CN.md)):
+- [decision-context](decision-context/README.md)
+  ([中文](decision-context/README.zh-CN.md),
+  [architecture](../reference/protocols/decision-context-architecture-v0.md)):
   separate current evidence, advisory proposals, and verified outcomes through
   default-off provider-neutral packet and incremental source contracts.
-- [material-lifecycle](../reference/protocols/material-lifecycle-architecture-v0.md)
-  ([中文](../reference/protocols/material-lifecycle-architecture-v0.zh-CN.md)):
+- [material-lifecycle](material-lifecycle/README.md)
+  ([中文](material-lifecycle/README.zh-CN.md),
+  [architecture](../reference/protocols/material-lifecycle-architecture-v0.md)):
   preserve raw source authority while inventorying, archiving, migrating, and
   applying bounded material reranks.
 - [periodic-report](periodic-report/README.md): evaluate cadence and material

--- a/docs/capabilities/decision-context/README.md
+++ b/docs/capabilities/decision-context/README.md
@@ -1,0 +1,171 @@
+# Decision Context
+
+[中文](README.zh-CN.md) | [Architecture contract](../../reference/protocols/decision-context-architecture-v0.md)
+
+Status: experimental, built in, default off, goal scoped.
+
+Decision Context helps a long-running LoopX agent rebuild **what is currently
+true for one decision** before it acts. It combines revisioned authority
+sources, bounded provider recall, exact reads, freshness checks, and conflict
+handling into an auditable evidence packet. The agent may then produce a
+proposal, while LoopX Core remains the only lifecycle and action authority.
+
+It is useful when a goal spans days or weeks and the answer cannot safely come
+from the current prompt or model memory alone.
+
+## The Problem It Solves
+
+A long-running agent often has more context than it can keep in one session:
+
+- project state and source documents change independently;
+- previous judgments can become stale;
+- semantic recall can find useful clues but cannot prove current truth;
+- recommendations are easily mistaken for facts;
+- a decision is hard to improve if its later outcome is not linked back to the
+  evidence that produced it.
+
+Decision Context turns that loose context into a bounded decision cycle:
+
+```mermaid
+flowchart LR
+    SOURCES["Authority sources<br/>documents · repositories · messages · state"]
+    RECALL["Advisory recall<br/>OpenViking · local search · other providers"]
+    READ["Bounded scan + exact read<br/>freshness · revision · conflicts"]
+    EVIDENCE["Evidence packet<br/>accepted · rejected · stale · conflicting"]
+    PROPOSAL["Decision proposal<br/>recommendation · alternatives · stop list"]
+    CORE["LoopX lifecycle<br/>todo · gate · event · outcome"]
+    MEMORY["Reward Memory<br/>reviewed reusable experience"]
+
+    SOURCES --> READ
+    RECALL --> READ
+    READ --> EVIDENCE
+    EVIDENCE --> PROPOSAL
+    PROPOSAL --> CORE
+    CORE -. "verified outcome only" .-> MEMORY
+```
+
+## What It Owns
+
+Decision Context owns the decision-quality layer:
+
+1. **Incremental source profiles** declare which source classes matter, their
+   freshness policy, scan mode, and evidence weight.
+2. **Bounded scan and exact read** discover changes without copying raw source
+   bodies into LoopX packets.
+3. **Evidence rebase** promotes current facts and explicitly records stale,
+   rejected, or conflicting claims.
+4. **Decision proposals** keep recommendations, alternatives, next actions,
+   and stop lists separate from evidence.
+5. **Outcome receipts** link an accepted decision to observed outcomes and
+   invalidated assumptions.
+6. **Cursor commit** advances private source cursors only after the complete
+   packet chain and lifecycle writeback have been validated.
+
+## What It Does Not Own
+
+Decision Context does not:
+
+- replace LoopX Core todo, gate, quota, event, or authority semantics;
+- turn provider recall into trusted truth;
+- automatically capture chats, tool output, credentials, or raw provider
+  payloads;
+- grant permission to execute a recommendation;
+- automatically activate a Reward Memory candidate;
+- require OpenViking or any other single provider.
+
+If a provider is unavailable, the capability fails open to the remaining
+authority sources and records provider health. It does not block the Core
+lifecycle or silently advance source cursors.
+
+## Three Auditable Outputs
+
+| Output | Answers | Typical contents |
+|---|---|---|
+| `decision_evidence_packet_v0` | What should the decision trust now? | Changed facts, accepted recall, stale/rejected claims, conflicts, revisions, provider health |
+| `decision_proposal_v0` | What should happen next? | Objective scores, recommendation, alternatives, actions, stop list |
+| `decision_outcome_receipt_v0` | What happened after the decision? | Accepted decision, transitions, outcomes, invalidated assumptions, review time |
+
+The evidence packet is intended to be deterministic and auditable. The
+proposal is explicitly advisory. The outcome receipt is append-only evidence;
+only a verified outcome may later become a Reward Memory candidate, and that
+candidate still follows Reward Memory review and activation.
+
+## Typical Uses
+
+- Rebase a multi-week engineering or product decision against changed
+  repositories, documents, and owner communication.
+- Reject a previously recalled claim after an exact read shows that it is
+  stale.
+- Stop a planned action when the current source revision invalidates its
+  premise.
+- Keep a recurring decision review quiet when no material source changed.
+- Provide revision-bound evidence for another capability, such as Material
+  Lifecycle reranking.
+
+This capability is not needed for a one-off answer with one stable source.
+
+## Available Surfaces
+
+Inspect the provider-neutral architecture:
+
+```bash
+loopx decision-context architecture --format json
+```
+
+Prove the default-off route or inspect an explicitly enabled private profile:
+
+```bash
+loopx decision-context inspect-profile \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --format json
+```
+
+Project an enabled profile without accessing providers:
+
+```bash
+loopx decision-context source-manifest \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --profile <ignored-private-profile.json> \
+  --format json
+```
+
+Run bounded scans and exact reads without committing private cursors:
+
+```bash
+loopx decision-context prepare-evidence \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --profile <ignored-private-profile.json> \
+  --decision-id <stable-decision-id> \
+  --format json
+```
+
+`prepare-evidence` is deliberately read only. Semantic rebase, proposal,
+validated LoopX writeback, and cursor commit remain separate acceptance
+boundaries.
+
+## Relationship To Other Capabilities
+
+| Capability | Primary question | Relationship |
+|---|---|---|
+| LoopX Core | What work is authorized and what is its lifecycle state? | Decision Context consumes Core truth and proposes through existing lifecycle contracts. |
+| Reward Memory | What verified experience should be reusable later? | Decision Context may consume reviewed memory; verified outcomes may create review candidates. |
+| Material Lifecycle | Which materials should be active, archived, rebuilt, or reranked? | Decision Context can supply revision-bound evidence; Material Lifecycle owns the material transition. |
+| Context provider | What prior context may be relevant? | Advisory recall only; every promoted claim still needs authority and exact-read checks. |
+
+## Maturity And Adoption Boundary
+
+The public capability currently ships its packet contracts, default-off
+activation profile, provider-neutral source contract, bounded evidence
+assembly, public-safe projections, validated outcome feedback, and private
+cursor-commit boundary.
+
+It is still marked **experimental**. A production integration must provide its
+own private source adapters, profile, authority policy, proposal logic, and
+validated lifecycle writeback. Public packets must never contain private
+locators, source bodies, raw chats, provider payloads, or credentials.
+
+For implementation details and invariants, read the
+[Decision Context architecture contract](../../reference/protocols/decision-context-architecture-v0.md).

--- a/docs/capabilities/decision-context/README.zh-CN.md
+++ b/docs/capabilities/decision-context/README.zh-CN.md
@@ -1,0 +1,156 @@
+# Decision Context 能力介绍
+
+[English](README.md) | [架构协议](../../reference/protocols/decision-context-architecture-v0.zh-CN.md)
+
+状态：实验能力、内置、默认关闭、goal-scoped。
+
+Decision Context 帮助长程 LoopX Agent 在行动前重建：**针对当前这次决策，
+哪些事实仍然可信**。它把带 revision 的 authority source、有界召回、精确读取、
+新鲜度检查和冲突处理组装成可审计的证据包；Agent 再基于证据提出建议，而
+LoopX Core 仍是生命周期和动作权限的唯一 authority。
+
+当一个 goal 跨越数天或数周，且答案不能安全地只依赖当前 prompt 或模型记忆时，
+这项能力最有价值。
+
+## 它解决什么问题
+
+长程 Agent 的上下文通常分散在多个周期和系统中：
+
+- 项目状态和信源文档各自变化；
+- 旧判断可能已经过期；
+- 语义召回可以找到线索，但不能证明当前事实；
+- 模型建议容易被误当成事实；
+- 如果决策和后续结果没有关联，就难以校准下一次决策。
+
+Decision Context 把这些松散信息变成一个有边界的决策闭环：
+
+```mermaid
+flowchart LR
+    SOURCES["Authority sources<br/>文档 · 仓库 · 消息 · 状态"]
+    RECALL["Advisory recall<br/>OpenViking · 本地检索 · 其他 provider"]
+    READ["有界扫描 + exact read<br/>freshness · revision · conflict"]
+    EVIDENCE["Evidence packet<br/>采纳 · 拒绝 · 过期 · 冲突"]
+    PROPOSAL["Decision proposal<br/>建议 · 备选 · stop list"]
+    CORE["LoopX lifecycle<br/>todo · gate · event · outcome"]
+    MEMORY["Reward Memory<br/>经评审的可复用经验"]
+
+    SOURCES --> READ
+    RECALL --> READ
+    READ --> EVIDENCE
+    EVIDENCE --> PROPOSAL
+    PROPOSAL --> CORE
+    CORE -. "仅 verified outcome" .-> MEMORY
+```
+
+## 它负责什么
+
+Decision Context 负责“决策质量层”：
+
+1. **增量信源 profile**：声明需要关注的信源类型、新鲜度、扫描方式和证据权重。
+2. **有界扫描与 exact read**：发现变化，但不把原始正文复制进 LoopX packet。
+3. **证据 rebase**：提升当前事实，并明确记录过期、拒绝或冲突的 claim。
+4. **决策建议**：把 recommendation、alternatives、next actions 和 stop list
+   与事实证据分开。
+5. **结果回执**：把接受的决策与真实结果、失效假设关联起来。
+6. **cursor commit**：只有完整 packet 链和 lifecycle writeback 验证通过后，
+   才推进私有信源 cursor。
+
+## 它不负责什么
+
+Decision Context 不会：
+
+- 替代 LoopX Core 的 todo、gate、quota、event 或 authority 语义；
+- 把 provider 召回直接当成可信事实；
+- 自动采集聊天、tool output、凭据或原始 provider payload；
+- 因为给出建议就获得执行权限；
+- 自动激活 Reward Memory candidate；
+- 强绑定 OpenViking 或任何单一 provider。
+
+如果 provider 不可用，它会记录 provider health，并 fail open 到剩余 authority
+source；不会阻断 Core lifecycle，也不会静默推进 source cursor。
+
+## 三类可审计产物
+
+| 产物 | 回答的问题 | 典型内容 |
+|---|---|---|
+| `decision_evidence_packet_v0` | 这次决策现在应该相信什么？ | changed facts、采纳的召回、过期/拒绝 claim、冲突、revision、provider health |
+| `decision_proposal_v0` | 下一步建议做什么？ | objective score、推荐决策、备选方案、行动、stop list |
+| `decision_outcome_receipt_v0` | 决策之后实际发生了什么？ | 接受的决策、状态迁移、真实结果、失效假设、复核时间 |
+
+Evidence packet 尽量确定性和可审计；proposal 明确只是建议；outcome receipt
+是追加式证据。只有经过验证的 outcome 才可能生成 Reward Memory candidate，
+而 candidate 仍需走 Reward Memory 自己的 review 和 activation。
+
+## 典型场景
+
+- 在多周工程或产品决策前，重新核对发生变化的仓库、文档和 owner 沟通。
+- 语义召回命中旧信息后，通过 exact read 将其明确拒绝。
+- 当前 source revision 推翻原前提时，停止已经规划的动作。
+- 周期性决策复核中没有实质变化时，保持 quiet、no-spend。
+- 给 Material Lifecycle 等其他 capability 提供带 revision 的排序证据。
+
+如果只是基于一个稳定信源回答一次性问题，通常不需要启用这项能力。
+
+## 当前可用入口
+
+查看 provider-neutral 架构：
+
+```bash
+loopx decision-context architecture --format json
+```
+
+证明默认关闭，或检查显式启用的私有 profile：
+
+```bash
+loopx decision-context inspect-profile \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --format json
+```
+
+在不访问 provider 的情况下生成公开安全的 source manifest：
+
+```bash
+loopx decision-context source-manifest \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --profile <ignored-private-profile.json> \
+  --format json
+```
+
+执行有界 scan 和 exact read，但不提交私有 cursor：
+
+```bash
+loopx decision-context prepare-evidence \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --profile <ignored-private-profile.json> \
+  --decision-id <stable-decision-id> \
+  --format json
+```
+
+`prepare-evidence` 刻意保持只读。语义 rebase、proposal、经验证的 LoopX
+writeback 和 cursor commit 是彼此独立的验收边界。
+
+## 与其他能力的关系
+
+| 能力 | 核心问题 | 与 Decision Context 的关系 |
+|---|---|---|
+| LoopX Core | 哪些工作已获授权，生命周期状态是什么？ | Decision Context 消费 Core truth，并通过现有生命周期契约提出动作。 |
+| Reward Memory | 哪些已验证经验值得以后复用？ | Decision Context 可消费经评审的 memory；verified outcome 可产生待评审 candidate。 |
+| Material Lifecycle | 哪些素材应活跃、归档、重建或重排？ | Decision Context 提供带 revision 的证据；Material Lifecycle 拥有素材迁移。 |
+| Context provider | 哪些历史上下文可能相关？ | 只负责 advisory recall；claim 仍需 authority 和 exact-read 校验。 |
+
+## 当前成熟度与接入边界
+
+公开能力已经具备 packet 契约、默认关闭的 activation profile、
+provider-neutral source contract、有界 evidence assembly、公开安全投影、
+经验证的 outcome feedback 和私有 cursor commit 边界。
+
+它目前仍标记为 **experimental**。生产接入方需要提供自己的私有 source adapter、
+profile、authority policy、proposal logic 和经过验证的 lifecycle writeback。
+公开 packet 绝不能包含私有 locator、source body、原始聊天、provider payload
+或凭据。
+
+更完整的实现细节和不变量见
+[Decision Context 架构协议](../../reference/protocols/decision-context-architecture-v0.zh-CN.md)。

--- a/docs/capabilities/material-lifecycle/README.md
+++ b/docs/capabilities/material-lifecycle/README.md
@@ -1,0 +1,205 @@
+# Material Lifecycle
+
+[中文](README.zh-CN.md) | [Architecture contract](../../reference/protocols/material-lifecycle-architecture-v0.md)
+
+Status: experimental, built in, default off, goal scoped.
+
+Material Lifecycle helps a LoopX-managed project keep a large material store
+**lossless, ranked, readable, and reversible** while priorities change. It
+governs inventory, backup-safe migration, lifecycle transitions, ranked-entry
+rebuilds, bounded reranking, readable projections, owner-gated apply, and
+rollback.
+
+It does not own raw documents or private source locations. The project's
+existing store remains authority until a verified cutover.
+
+## The Problem It Solves
+
+Material collections grow across candidate lists, archives, documents,
+bookmarks, messages, and research tools. Over time:
+
+- a shortlist no longer reflects the current goal;
+- one ranked item becomes a bucket containing too many unrelated materials;
+- an archive or migration can silently lose content or references;
+- a readable Markdown view drifts away from the managed catalog;
+- a search provider can add candidates without a clear budget or stop
+  condition;
+- a rerank is applied without preserving the previous state or explaining why.
+
+Material Lifecycle makes these changes explicit and auditable:
+
+```mermaid
+flowchart LR
+    SOURCE["Project material authority<br/>documents · database · inbox"]
+    SNAPSHOT["Snapshot + verified backup"]
+    INVENTORY["Inventory + reconciliation<br/>ids · counts · digests · revisions"]
+    DECISION["Decision Context evidence"]
+    PLAN["Lifecycle / rebuild / rerank plan"]
+    GATE["Owner-gated apply"]
+    VIEW["Readable projection + ranked backlog"]
+    ROLLBACK["Verified rollback"]
+
+    SOURCE --> SNAPSHOT
+    SNAPSHOT --> INVENTORY
+    DECISION --> PLAN
+    INVENTORY --> PLAN
+    PLAN --> GATE
+    GATE --> VIEW
+    GATE --> ROLLBACK
+```
+
+## What It Owns
+
+1. **Snapshot and inventory**: source revision, digest, stable references,
+   lifecycle counts, parse errors, and verified backup.
+2. **Lifecycle receipts**: explicit transitions among `unread`, `candidate`,
+   `active`, `carryover`, and `archived`.
+3. **Ranked-entry rebuilds**: split oversized buckets into independently
+   sortable entries while preserving exact membership.
+4. **Bounded rerank proposals**: protect pinned entries, limit movement, and
+   emit a no-change result when evidence is insufficient.
+5. **Readable projections**: render an operator-friendly view from the managed
+   catalog without turning that view into authority.
+6. **Owner-gated apply and rollback**: compare-and-swap, atomic write, readback,
+   dual-read reconciliation, cutover receipt, and reversible recovery.
+7. **Bounded Explore intake**: only from a named evidence gap, provider budget,
+   candidate budget, and stop condition.
+
+## The Core Invariants
+
+- The original source remains authority until verified cutover.
+- Every migration starts from an immutable snapshot and verified backup.
+- Stable material references survive lifecycle and ranking changes.
+- Every selected material appears exactly once in the complete ranked set.
+- A ranked entry contains at most three primary materials by default.
+- Overflow becomes new independently ranked entries, not a hidden supporting
+  index.
+- The ranked set may extend beyond a visible Top-N through an explicit ranked
+  backlog.
+- Recall is advisory; ranking evidence must be promoted by exact read.
+- Proposal and apply receipt are separate.
+- Apply and rollback require explicit owner gates and revision checks.
+
+## Typical Uses
+
+- Rebuild a reading Top-N whose entries have become oversized topic buckets.
+- Migrate a legacy Markdown or database-backed queue without losing bytes,
+  records, references, or recoverability.
+- Rerank a small window after Decision Context proves that priorities changed.
+- Keep a complete ranked backlog while presenting a concise readable view.
+- Move a material from candidate to active or archive it with an auditable
+  reason and stable source reference.
+- Run bounded exploration for a specific evidence gap without turning search
+  into unbounded collection.
+
+Ordinary one-off reading, summarization, or web research does not require this
+capability unless the project has explicitly activated a managed material
+store.
+
+## Project-Local Skill Delivery
+
+LoopX ships the canonical `loopx-material` skill, but deliberately does not
+install it into a user's global skill directory. A connected project may
+install a managed project-local copy for one or more agent hosts:
+
+```bash
+loopx project-skill install \
+  --project . \
+  --skill loopx-material \
+  --surface codex \
+  --execute
+```
+
+Supported surfaces:
+
+- `codex` -> `.agents/skills/loopx-material/`
+- `claude-code` -> `.claude/skills/loopx-material/`
+- `opencode` -> `.opencode/skills/loopx-material/`
+
+Repeat `--surface` to install multiple host-native copies in one transaction.
+Inspect before or after installation:
+
+```bash
+loopx project-skill status \
+  --project . \
+  --skill loopx-material \
+  --surface codex \
+  --format json
+```
+
+A project-local skill makes the workflow discoverable. It does **not** activate
+material-store writes or expand goal authority. The selected goal still needs
+an explicit Material Lifecycle profile, source adapter, write scope, and owner
+gate.
+
+## End-To-End Workflow
+
+1. **Connect and authorize the goal.**
+   Confirm the goal, agent, source authority, write boundary, and project-local
+   skill.
+2. **Snapshot and inventory.**
+   Verify stable IDs, source digest, backup digest, counts, and parse health.
+3. **Exact-read decision evidence.**
+   Promote only current, authoritative evidence; reject stale or secondary-only
+   claims.
+4. **Choose the smallest valid change.**
+   Use lifecycle transition, bounded rerank, or structural rebuild as distinct
+   operations.
+5. **Preview and validate.**
+   Prove exact coverage, unique membership, protected ranks, readable
+   projection, and rollback readiness.
+6. **Apply through an owner gate.**
+   Recheck revisions, atomically write, read back, reconcile, and switch the
+   authority pointer.
+7. **Record the receipt.**
+   Preserve before/after revisions, counts, verification references, and
+   rollback reference.
+
+## Available Surfaces
+
+Inspect the provider-neutral contract:
+
+```bash
+loopx material-lifecycle architecture --format json
+```
+
+Inspect the managed project skill:
+
+```bash
+loopx material-lifecycle skill-status \
+  --project . \
+  --surface codex \
+  --format json
+```
+
+The public Python capability exposes deterministic builders and orchestration
+for inventory, migration preparation, lifecycle receipts, ranked-entry
+rebuild, bounded rerank, readable projection, Explore intent, apply, and
+rollback. Concrete legacy parsers, private storage adapters, source profiles,
+and provider credentials remain project owned.
+
+## Relationship To Other Capabilities
+
+| Capability | Primary question | Relationship |
+|---|---|---|
+| Decision Context | What current evidence justifies a priority change? | Supplies revision-bound evidence; does not mutate materials. |
+| Reward Memory | What verified ranking or workflow experience is reusable? | May inform policy after review; never overrides current source authority. |
+| Content/notes workflow | What artifact should be written or published? | Consumes selected materials; does not own lifecycle or ranking truth. |
+| Research provider | What new candidates may exist? | Supplies bounded candidates; cannot advance lifecycle, ranking, or cursor by itself. |
+| LoopX Core | What work and writes are authorized? | Keeps goal, todo, gate, event, quota, and write authority. |
+
+## Maturity And Adoption Boundary
+
+Material Lifecycle is currently **experimental**. Its generic contracts,
+project-local skill delivery, lossless rebuild rules, bounded decision planning,
+readable projection, and owner-gated apply/rollback orchestration are
+implemented and tested.
+
+A real project integration must still provide its private source parser or
+adapter, backup implementation, authority pointer, domain scoring, display
+records, and owner-approved cutover. Public LoopX packets and commits must not
+contain raw material, private paths, private URLs, provider payloads, or
+credentials.
+
+For packet schemas and detailed invariants, read the
+[Material Lifecycle architecture contract](../../reference/protocols/material-lifecycle-architecture-v0.md).

--- a/docs/capabilities/material-lifecycle/README.zh-CN.md
+++ b/docs/capabilities/material-lifecycle/README.zh-CN.md
@@ -1,0 +1,183 @@
+# Material Lifecycle 能力介绍
+
+[English](README.md) | [架构协议](../../reference/protocols/material-lifecycle-architecture-v0.zh-CN.md)
+
+状态：实验能力、内置、默认关闭、goal-scoped。
+
+Material Lifecycle 帮助受 LoopX 管理的项目，在优先级持续变化时，让大型素材库保持
+**无损、可排序、可阅读、可回滚**。它治理 inventory、备份安全迁移、生命周期流转、
+ranked-entry 重建、有界重排、可读投影、owner-gated apply 和 rollback。
+
+它不拥有原始文档或私有信源位置。完成验证过的 cutover 之前，项目已有素材库始终是
+authority。
+
+## 它解决什么问题
+
+素材会逐渐散落在候选列表、归档、文档、书签、消息和调研工具中。时间一长：
+
+- shortlist 不再反映当前 goal；
+- 一个排名条目变成装着许多无关素材的大桶；
+- 归档或迁移可能静默丢失正文、记录或引用；
+- 可读 Markdown 与受管 catalog 逐渐漂移；
+- 搜索 provider 不受预算和停止条件约束地持续加材料；
+- 重排被直接应用，却没有保留旧状态，也说不清为什么调整。
+
+Material Lifecycle 把这些变化变成显式、可审计的流程：
+
+```mermaid
+flowchart LR
+    SOURCE["项目素材 authority<br/>文档 · 数据库 · inbox"]
+    SNAPSHOT["Snapshot + 已验证备份"]
+    INVENTORY["Inventory + 对账<br/>id · count · digest · revision"]
+    DECISION["Decision Context evidence"]
+    PLAN["Lifecycle / rebuild / rerank plan"]
+    GATE["Owner-gated apply"]
+    VIEW["可读投影 + ranked backlog"]
+    ROLLBACK["已验证 rollback"]
+
+    SOURCE --> SNAPSHOT
+    SNAPSHOT --> INVENTORY
+    DECISION --> PLAN
+    INVENTORY --> PLAN
+    PLAN --> GATE
+    GATE --> VIEW
+    GATE --> ROLLBACK
+```
+
+## 它负责什么
+
+1. **Snapshot 与 inventory**：记录 source revision、digest、stable reference、
+   lifecycle count、parse error 和已验证备份。
+2. **生命周期 receipt**：显式记录 `unread`、`candidate`、`active`、
+   `carryover`、`archived` 之间的迁移。
+3. **Ranked-entry rebuild**：把过大的素材桶拆成可独立排序的条目，同时保持
+   exact membership。
+4. **有界 rerank proposal**：保护 pinned entry、限制移动范围；证据不足时输出
+   no-change。
+5. **可读投影**：从受管 catalog 生成便于人阅读的视图，但不把视图变成 authority。
+6. **Owner-gated apply 与 rollback**：执行 compare-and-swap、原子写入、读回、
+   双读对账、cutover receipt 和可逆恢复。
+7. **有界 Explore intake**：必须从明确的 evidence gap 出发，并声明 provider
+   预算、候选预算和 stop condition。
+
+## 核心不变量
+
+- 完成验证过的 cutover 前，原始 source 始终是 authority。
+- 每次迁移都从不可变 snapshot 和已验证备份开始。
+- Stable material reference 在生命周期和排序变化后仍然保留。
+- 完整 ranked set 中，每个入选素材恰好出现一次。
+- 默认每个 ranked entry 最多包含 3 条 primary material。
+- Overflow 必须变成新的、可独立排序的条目，不能藏入 supporting index。
+- 可见 Top-N 之外保留显式 ranked backlog。
+- Recall 只是线索；影响排序的证据必须经过 exact read。
+- Proposal 与 apply receipt 必须分离。
+- Apply 与 rollback 都需要显式 owner gate 和 revision 校验。
+
+## 典型场景
+
+- 重建已经膨胀成主题大桶的阅读 Top-N。
+- 在不丢字节、记录、引用和恢复能力的前提下，迁移旧 Markdown 或数据库队列。
+- Decision Context 证明优先级变化后，只重排一个小窗口。
+- 保留完整 ranked backlog，同时输出一份简洁、可读的视图。
+- 把素材从 candidate 提升到 active，或携带稳定来源引用进行归档。
+- 针对一个明确 evidence gap 做有预算的探索，而不是无限收集。
+
+普通的一次性阅读、摘要或网页调研不需要启用这项能力，除非项目已经显式激活了
+受管素材库。
+
+## 项目级 Skill 安装
+
+LoopX 发布 canonical `loopx-material` skill，但刻意不安装到用户的全局 skill
+目录。已连接的项目可以为一个或多个 Agent host 安装受管的项目级副本：
+
+```bash
+loopx project-skill install \
+  --project . \
+  --skill loopx-material \
+  --surface codex \
+  --execute
+```
+
+目前支持：
+
+- `codex` -> `.agents/skills/loopx-material/`
+- `claude-code` -> `.claude/skills/loopx-material/`
+- `opencode` -> `.opencode/skills/loopx-material/`
+
+重复传入 `--surface`，可以在一个 transaction 中安装多份 host-native 副本。
+安装前后可检查状态：
+
+```bash
+loopx project-skill status \
+  --project . \
+  --skill loopx-material \
+  --surface codex \
+  --format json
+```
+
+项目级 skill 只让工作流可发现，**不会**自动授权修改素材库，也不会扩大 goal
+authority。选中的 goal 仍需显式声明 Material Lifecycle profile、source adapter、
+write scope 和 owner gate。
+
+## 端到端工作流
+
+1. **连接并授权 goal。**
+   确认 goal、agent、source authority、写边界和项目级 skill。
+2. **Snapshot 与 inventory。**
+   验证 stable ID、source digest、backup digest、count 和 parse health。
+3. **Exact-read 决策证据。**
+   只提升当前且权威的证据；拒绝过期、不可读或只有二手来源的 claim。
+4. **选择最小有效变化。**
+   把 lifecycle transition、bounded rerank 和 structural rebuild 作为三种不同操作。
+5. **Preview 与验证。**
+   证明 exact coverage、unique membership、protected rank、可读投影和 rollback
+   readiness。
+6. **通过 owner gate apply。**
+   再次校验 revision，原子写入、读回、对账，然后切换 authority pointer。
+7. **记录 receipt。**
+   保留 before/after revision、count、verification ref 和 rollback ref。
+
+## 当前可用入口
+
+查看 provider-neutral 契约：
+
+```bash
+loopx material-lifecycle architecture --format json
+```
+
+检查项目级受管 skill：
+
+```bash
+loopx material-lifecycle skill-status \
+  --project . \
+  --surface codex \
+  --format json
+```
+
+公开 Python capability 已提供确定性的 builder 和编排逻辑，覆盖 inventory、
+migration preparation、lifecycle receipt、ranked-entry rebuild、bounded rerank、
+readable projection、Explore intent、apply 与 rollback。具体 legacy parser、私有
+storage adapter、source profile 和 provider credential 仍由项目拥有。
+
+## 与其他能力的关系
+
+| 能力 | 核心问题 | 与 Material Lifecycle 的关系 |
+|---|---|---|
+| Decision Context | 当前哪些证据足以支持优先级变化？ | 提供带 revision 的证据，但不修改素材。 |
+| Reward Memory | 哪些经过验证的排序或工作流经验值得复用？ | 经评审后可影响 policy，但不能覆盖当前 source authority。 |
+| Content / Notes workflow | 应该写作或发布什么 artifact？ | 消费选中的素材，不拥有 lifecycle 或 ranking truth。 |
+| Research provider | 可能有哪些新候选？ | 提供有界候选，不能自行推进 lifecycle、ranking 或 cursor。 |
+| LoopX Core | 哪些工作和写入已获授权？ | 保持 goal、todo、gate、event、quota 和 write authority。 |
+
+## 当前成熟度与接入边界
+
+Material Lifecycle 目前仍是 **experimental**。通用 contract、项目级 skill
+delivery、无损 rebuild 规则、有界 decision planning、readable projection，以及
+owner-gated apply/rollback 编排已经实现并有测试覆盖。
+
+真实项目仍需提供私有 source parser 或 adapter、备份实现、authority pointer、
+领域排序策略、display record 和 owner 批准的 cutover。公开 LoopX packet 和
+commit 不能包含原始素材、私有路径、私有链接、provider payload 或凭据。
+
+Packet schema 和详细不变量见
+[Material Lifecycle 架构协议](../../reference/protocols/material-lifecycle-architecture-v0.zh-CN.md)。


### PR DESCRIPTION
## Summary

- add user-facing English and Chinese guides for Decision Context
- add user-facing English and Chinese guides for Material Lifecycle
- route the capability index to the guides while preserving architecture links

## Product judgment

The existing bilingual architecture contracts are accurate but optimized for
protocol implementers. These guides give prospective users a clearer entry
point: problem, ownership boundary, workflow, available commands, maturity,
and explicit non-goals. Both capabilities remain labeled experimental,
default-off, and goal-scoped.

## Validation

- `git diff --check`
- `python3 examples/docs-governance-smoke.py`
- `python3 examples/decision-context-contract-smoke.py` under Python 3.13
- `python3 examples/material-lifecycle-contract-smoke.py` under Python 3.13
- local relative-link validation for all changed indexes and guides
- `python3 examples/control_plane/check-public-boundary-smoke.py`
- `loopx canary premerge --from-git-diff`: 16 checks passed, no failures or manual holds
