### PR TITLE
refactor(quota): order heartbeat recommendation rules

### DIFF
--- a/loopx/canary/maintainability_ratchet.py
+++ b/loopx/canary/maintainability_ratchet.py
@@ -51,9 +51,6 @@ _OVERSIZED_DECISION_RETIREMENT_PLANS = {
     "loopx.control_plane.quota.goal_boundary:goal_boundary": (
         "Split registry boundary resolution from capability and write-scope projection."
     ),
-    "loopx.control_plane.quota.heartbeat_recommendation:build_heartbeat_recommendation": (
-        "Move recommendation modes into ordered policy rules with one projection assembler."
-    ),
     "loopx.control_plane.todos.contract:parse_todo_metadata_line": (
         "Replace branch-heavy field parsing with the canonical todo field schema."
     ),
@@ -81,10 +78,6 @@ _OVERSIZED_DECISION_METRIC_CEILINGS = {
     "loopx.control_plane.quota.goal_boundary:goal_boundary": {
         "statements": 96,
         "decision_points": 66,
-    },
-    "loopx.control_plane.quota.heartbeat_recommendation:build_heartbeat_recommendation": {
-        "statements": 63,
-        "decision_points": 64,
     },
     "loopx.control_plane.todos.contract:parse_todo_metadata_line": {
         "statements": 119,

--- a/loopx/control_plane/quota/heartbeat_recommendation.py
+++ b/loopx/control_plane/quota/heartbeat_recommendation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 from .. import compact_control_plane_policy
@@ -138,6 +140,469 @@ def _control_plane_post_handoff_observation_hint(item: dict[str, Any]) -> dict[s
     }
 
 
+_BASE_RECOMMENDATION: dict[str, Any] = {
+    "source": "quota.should-run",
+    "recommended_mode": "skip",
+    "notify": "DONT_NOTIFY",
+    "spend_policy": (
+        "do not append quota spend unless a completed bounded progress segment "
+        "produced substantive progress"
+    ),
+}
+
+
+@dataclass(frozen=True)
+class _HeartbeatRecommendationFacts:
+    item: dict[str, Any]
+    goal_id: str
+    state: str
+    should_run: bool
+    status: str
+    waiting_on: str
+    adapter_kind: str
+    lifecycle_phase: Any
+    lifecycle_flags: Any
+    quota: dict[str, Any]
+    replan_obligation: dict[str, Any] | None
+    has_user_todos: bool
+    has_agent_todos: bool
+    work_lane_contract: dict[str, Any]
+    stall_self_repair: dict[str, Any] | None
+
+
+_HeartbeatRecommendationRule = Callable[
+    [_HeartbeatRecommendationFacts],
+    Any,
+]
+
+
+def _recommendation(*parts: dict[str, Any]) -> dict[str, Any]:
+    payload = dict(_BASE_RECOMMENDATION)
+    for part in parts:
+        payload.update(part)
+    return payload
+
+
+def _stall_self_repair_rule(
+    facts: _HeartbeatRecommendationFacts,
+) -> dict[str, Any] | None:
+    repair = facts.stall_self_repair
+    if not repair or not repair.get("allowed"):
+        return None
+    if (
+        facts.state == "operator_gate"
+        and repair.get("trigger") != "user_gate_scope_projection_drift"
+    ):
+        return None
+    return _recommendation(
+        {
+            "recommended_mode": repair.get("recommended_mode")
+            or "repair_control_plane_stall",
+            "notify": repair.get("notify") or "DONT_NOTIFY",
+            "spend_policy": repair.get("spend_policy")
+            or _BASE_RECOMMENDATION["spend_policy"],
+            "reason": repair.get("reason")
+            or "control-plane stall requires bounded repair",
+            "repair_focus": repair.get("repair_focus"),
+        }
+    )
+
+
+def _operator_gate_rule(
+    facts: _HeartbeatRecommendationFacts,
+) -> dict[str, Any] | None:
+    if facts.state != "operator_gate":
+        return None
+    return _recommendation(
+        {
+            "recommended_mode": "ask_operator_gate",
+            "notify": "NOTIFY",
+            "spend_policy": "do not append quota spend while asking the operator gate",
+            "reason": "operator gate blocks the gated delivery path",
+        }
+    )
+
+
+def _autonomous_replan_rule(
+    facts: _HeartbeatRecommendationFacts,
+) -> dict[str, Any] | None:
+    obligation = facts.replan_obligation
+    if (
+        not facts.should_run
+        or not obligation
+        or not obligation.get("required")
+    ):
+        return None
+    return _recommendation(build_autonomous_replan_recommendation(obligation))
+
+
+def _waiting_user_todo_rule(
+    facts: _HeartbeatRecommendationFacts,
+) -> dict[str, Any] | None:
+    if facts.state not in {"focus_wait", "waiting"} or not facts.has_user_todos:
+        return None
+    return _recommendation(
+        {
+            "recommended_mode": "blocker_push_notify",
+            "notify": "NOTIFY",
+            "repeat_notification_required": True,
+            "spend_policy": "do not append quota spend for the blocker-push turn",
+            "reason": open_todo_notify_reason(
+                state=facts.state,
+                waiting_on=facts.waiting_on,
+            ),
+        }
+    )
+
+
+def _outcome_floor_rule(
+    facts: _HeartbeatRecommendationFacts,
+) -> dict[str, Any] | None:
+    quota = facts.quota
+    if facts.state != "focus_wait" or not quota.get("handoff_outcome_floor_block"):
+        return None
+    if quota.get("outcome_floor_blocker_projected"):
+        return _recommendation(
+            {
+                "recommended_mode": "outcome_floor_blocker_projected_noop",
+                "notify": "DONT_NOTIFY",
+                "spend_policy": (
+                    "do not append quota spend while the same concrete outcome-floor "
+                    "blocker is already projected and no executable agent todo exists"
+                ),
+                "reason": str(
+                    quota.get("reason")
+                    or "outcome-floor blocker is already projected; wait for fresh outcome evidence"
+                ),
+            }
+        )
+    if quota.get("safe_bypass_allowed"):
+        return _recommendation(
+            {
+                "recommended_mode": "outcome_floor_recovery",
+                "notify": "DONT_NOTIFY",
+                "spend_policy": (
+                    "append exactly one quota spend only after a validated "
+                    "ranker/cross-domain evidence artifact or concrete blocker writeback; "
+                    "do not spend for another surface-only report"
+                ),
+                "reason": str(
+                    quota.get("reason") or "handoff outcome floor is not met"
+                ),
+            }
+        )
+    return _recommendation(
+        {
+            "recommended_mode": "report_handoff_outcome_blocker",
+            "notify": "NOTIFY",
+            "spend_policy": (
+                "do not append quota spend while reporting the handoff "
+                "outcome-floor blocker"
+            ),
+            "reason": str(quota.get("reason") or "handoff outcome floor is not met"),
+        }
+    )
+
+
+def _quota_skip_rule(
+    facts: _HeartbeatRecommendationFacts,
+) -> dict[str, Any] | None:
+    if facts.should_run:
+        return None
+    return _recommendation(
+        {
+            "recommended_mode": "quota_skip",
+            "reason": f"quota state is {facts.state}; skip delivery compute",
+        }
+    )
+
+
+def _agent_command_rule(
+    facts: _HeartbeatRecommendationFacts,
+) -> dict[str, Any] | None:
+    command = facts.item.get("agent_command")
+    if not command:
+        return None
+    return _recommendation(
+        {
+            "recommended_mode": "run_agent_command",
+            "command": str(command),
+            "notify": "DONT_NOTIFY",
+            "spend_policy": (
+                "append exactly one heartbeat spend after the command completes "
+                "and validation/writeback are saved"
+            ),
+            "reason": "current status exposes an approved project-agent command",
+        }
+    )
+
+
+def _monitor_lane_rule(
+    facts: _HeartbeatRecommendationFacts,
+) -> dict[str, Any] | None:
+    lane = facts.work_lane_contract
+    if lane.get("lane") != "continuous_monitor":
+        return None
+    must_attempt_work = lane.get("must_attempt_work")
+    if must_attempt_work is False:
+        if facts.has_user_todos:
+            return _recommendation(
+                {
+                    "recommended_mode": "monitor_quiet_until_material_transition",
+                    "spend_policy": (
+                        "do not append quota spend or repeat a blocker notification "
+                        "for a monitor-only poll; keep the open user todo visible in "
+                        "the payload and wait for a material monitor transition"
+                    ),
+                    "reason": (
+                        "monitor-only polling has no material transition to write "
+                        "back; the current open user todo is already part of the "
+                        "durable active state"
+                    ),
+                }
+            )
+        return _recommendation(
+            {
+                "recommended_mode": "monitor_quiet_until_material_transition",
+                "spend_policy": (
+                    "do not append quota spend until a material monitor transition, "
+                    "regression, or concrete blocker is validated and written back"
+                ),
+                "reason": (
+                    "all visible open agent todos are monitor-class work with no "
+                    "material transition to record"
+                ),
+            }
+        )
+    if must_attempt_work is not True or facts.has_user_todos:
+        return None
+
+    latest_run: dict[str, Any] = {}
+    handoff_readiness = (
+        facts.item.get("handoff_readiness")
+        if isinstance(facts.item.get("handoff_readiness"), dict)
+        else {}
+    )
+    latest_handoff_run = (
+        handoff_readiness.get("post_handoff_latest_run")
+        if isinstance(handoff_readiness.get("post_handoff_latest_run"), dict)
+        else {}
+    )
+    if latest_handoff_run:
+        latest_run = _compact_latest_run(latest_handoff_run)
+        latest_run["progress_scope"] = latest_run_progress_scope(latest_handoff_run)
+    payload = _recommendation(
+        {
+            "recommended_mode": "follow_work_lane_contract",
+            "spend_policy": (
+                "follow work_lane_contract.obligation; spend only after validated "
+                "advancement, concrete blocker writeback, or a material monitor transition"
+            ),
+            "reason": (
+                "work_lane_contract is the machine contract for "
+                "monitor-vs-advancement routing"
+            ),
+        }
+    )
+    if latest_run:
+        payload["latest_run"] = latest_run
+    return payload
+
+
+def _first_read_only_map_rule(
+    facts: _HeartbeatRecommendationFacts,
+) -> dict[str, Any] | None:
+    if facts.status != "connected_without_run" or not _supports_read_only_project_map(
+        facts.adapter_kind
+    ):
+        return None
+    return _recommendation(
+        {
+            "recommended_mode": "run_first_read_only_map",
+            "command": f"loopx read-only-map --goal-id {facts.goal_id}",
+            "notify": "NOTIFY",
+            "spend_policy": (
+                "append exactly one heartbeat spend after the read-only map "
+                "run is saved and validated"
+            ),
+            "reason": "connected read-only project has no saved compact run yet",
+        }
+    )
+
+
+def _mapped_noop_rule(
+    facts: _HeartbeatRecommendationFacts,
+) -> dict[str, Any] | None:
+    mapped = facts.status == "read_only_project_map" or _has_lifecycle_marker(
+        facts.lifecycle_phase,
+        facts.lifecycle_flags,
+        marker="mapped",
+    )
+    if (
+        not mapped
+        or facts.has_user_todos
+        or facts.has_agent_todos
+        or facts.item.get("agent_command")
+    ):
+        return None
+    return _recommendation(
+        {
+            "recommended_mode": "mapped_noop_if_unchanged",
+            "stop_if_unchanged": True,
+            "spend_policy": (
+                "do not run another dry-run or append quota spend when the latest "
+                "read-only map is still current and there is no new user instruction, "
+                "owner evidence, agent todo, stale source, or safe handoff"
+            ),
+            "reason": (
+                "latest compact read-only map already exists; wait for new "
+                "evidence or a concrete safe action"
+            ),
+        }
+    )
+
+
+def _post_handoff_observation_rule(
+    facts: _HeartbeatRecommendationFacts,
+) -> dict[str, Any] | None:
+    post_handoff = _control_plane_post_handoff_observation_hint(facts.item)
+    if not post_handoff or facts.has_user_todos:
+        return None
+    latest_run = (
+        post_handoff.get("latest_run")
+        if isinstance(post_handoff.get("latest_run"), dict)
+        else {}
+    )
+    progress_scope = latest_run_progress_scope(latest_run)
+    if latest_run:
+        latest_run.setdefault("progress_scope", progress_scope)
+    active_observation = {
+        key: value for key, value in post_handoff.items() if key != "stop_if_unchanged"
+    }
+    if facts.has_agent_todos and progress_scope == "dependency_observation":
+        return _recommendation(
+            active_observation,
+            {
+                "recommended_mode": "follow_work_lane_contract",
+                "spend_policy": (
+                    "follow work_lane_contract.obligation; spend only after validated "
+                    "advancement, concrete blocker writeback, or a material monitor transition"
+                ),
+                "reason": (
+                    "latest post-handoff run was dependency observation; the work "
+                    "lane contract decides whether to advance backlog or record a "
+                    "material transition"
+                ),
+            },
+        )
+    if facts.has_agent_todos:
+        return _recommendation(
+            active_observation,
+            {
+                "recommended_mode": "post_handoff_observe_then_backlog_step",
+                "spend_policy": (
+                    "observe registry/status/run history/repo state first; if unchanged, "
+                    "advance exactly one bounded agent-todo backlog segment and append "
+                    "quota spend only after validation and durable writeback"
+                ),
+                "reason": (
+                    "latest post-handoff implementation reached the primary outcome, "
+                    "but an open agent todo remains; observe for new blockers first, "
+                    "then advance one bounded backlog step instead of quiet idling"
+                ),
+            },
+        )
+    return _recommendation(post_handoff)
+
+
+def _default_rule(
+    facts: _HeartbeatRecommendationFacts,
+) -> dict[str, Any] | None:
+    return _recommendation(
+        {
+            "recommended_mode": "steering_audit_then_one_step",
+            "spend_policy": (
+                "append exactly one heartbeat spend only after a bounded progress "
+                "segment is validated and written back"
+            ),
+            "reason": (
+                "eligible Codex-ready goal requires the standard steering audit "
+                "before delivery"
+            ),
+        }
+    )
+
+
+_HEARTBEAT_RECOMMENDATION_RULES: tuple[_HeartbeatRecommendationRule, ...] = (
+    _stall_self_repair_rule,
+    _operator_gate_rule,
+    _autonomous_replan_rule,
+    _waiting_user_todo_rule,
+    _outcome_floor_rule,
+    _quota_skip_rule,
+    _agent_command_rule,
+    _monitor_lane_rule,
+    _first_read_only_map_rule,
+    _mapped_noop_rule,
+    _post_handoff_observation_rule,
+    _default_rule,
+)
+
+
+def _build_recommendation_facts(
+    item: dict[str, Any],
+    *,
+    goal_id: str,
+    state: str,
+    should_run: bool,
+    user_todo_summary: dict[str, Any] | None,
+    agent_todo_summary: dict[str, Any] | None,
+    work_lane_contract: dict[str, Any] | None,
+    stall_self_repair: dict[str, Any] | None,
+    replan_obligation: dict[str, Any] | None,
+    select_replan_obligation: bool,
+    monitor_due_item_limit: int,
+) -> _HeartbeatRecommendationFacts:
+    project_asset = (
+        item.get("project_asset")
+        if isinstance(item.get("project_asset"), dict)
+        else {}
+    )
+    resolved_replan_obligation = (
+        replan_obligation
+        if isinstance(replan_obligation, dict)
+        else select_autonomous_replan_obligation(item, project_asset)
+        if select_replan_obligation
+        else None
+    )
+    resolved_work_lane = (
+        work_lane_contract
+        or build_work_lane_context_contract(
+            item,
+            agent_todo_summary=agent_todo_summary,
+            monitor_due_item_limit=monitor_due_item_limit,
+        )
+        or {}
+    )
+    return _HeartbeatRecommendationFacts(
+        item=item,
+        goal_id=goal_id,
+        state=state,
+        should_run=should_run,
+        status=str(item.get("status") or ""),
+        waiting_on=str(item.get("waiting_on") or ""),
+        adapter_kind=str(item.get("adapter_kind") or ""),
+        lifecycle_phase=item.get("lifecycle_phase"),
+        lifecycle_flags=item.get("lifecycle_flags"),
+        quota=item.get("quota") if isinstance(item.get("quota"), dict) else {},
+        replan_obligation=resolved_replan_obligation,
+        has_user_todos=_open_todo_count(user_todo_summary) > 0,
+        has_agent_todos=_open_todo_count(agent_todo_summary) > 0,
+        work_lane_contract=resolved_work_lane,
+        stall_self_repair=stall_self_repair,
+    )
+
+
 def build_heartbeat_recommendation(
     item: dict[str, Any],
     *,
@@ -152,278 +617,21 @@ def build_heartbeat_recommendation(
     select_replan_obligation: bool = True,
     monitor_due_item_limit: int = 1,
 ) -> dict[str, Any]:
-    status = str(item.get("status") or "")
-    waiting_on = str(item.get("waiting_on") or "")
-    adapter_kind = str(item.get("adapter_kind") or "")
-    lifecycle_phase = item.get("lifecycle_phase")
-    lifecycle_flags = item.get("lifecycle_flags")
-    quota = item.get("quota") if isinstance(item.get("quota"), dict) else {}
-    project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
-    replan_obligation = (
-        replan_obligation
-        if isinstance(replan_obligation, dict)
-        else select_autonomous_replan_obligation(item, project_asset)
-        if select_replan_obligation
-        else None
-    )
-    has_user_todos = _open_todo_count(user_todo_summary) > 0
-    has_agent_todos = _open_todo_count(agent_todo_summary) > 0
-    work_lane_contract = work_lane_contract or build_work_lane_context_contract(
+    facts = _build_recommendation_facts(
         item,
+        goal_id=goal_id,
+        state=state,
+        should_run=should_run,
+        user_todo_summary=user_todo_summary,
         agent_todo_summary=agent_todo_summary,
+        work_lane_contract=work_lane_contract,
+        stall_self_repair=stall_self_repair,
+        replan_obligation=replan_obligation,
+        select_replan_obligation=select_replan_obligation,
         monitor_due_item_limit=monitor_due_item_limit,
     )
-
-    base: dict[str, Any] = {
-        "source": "quota.should-run",
-        "recommended_mode": "skip",
-        "notify": "DONT_NOTIFY",
-        "spend_policy": "do not append quota spend unless a completed bounded progress segment produced substantive progress",
-    }
-
-    if (
-        stall_self_repair
-        and stall_self_repair.get("allowed")
-        and (
-            state != "operator_gate"
-            or stall_self_repair.get("trigger") == "user_gate_scope_projection_drift"
-        )
-    ):
-        return {
-            **base,
-            "recommended_mode": stall_self_repair.get("recommended_mode") or "repair_control_plane_stall",
-            "notify": stall_self_repair.get("notify") or "DONT_NOTIFY",
-            "spend_policy": stall_self_repair.get("spend_policy") or base["spend_policy"],
-            "reason": stall_self_repair.get("reason") or "control-plane stall requires bounded repair",
-            "repair_focus": stall_self_repair.get("repair_focus"),
-        }
-    if state == "operator_gate":
-        return {
-            **base,
-            "recommended_mode": "ask_operator_gate",
-            "notify": "NOTIFY",
-            "spend_policy": "do not append quota spend while asking the operator gate",
-            "reason": "operator gate blocks the gated delivery path",
-        }
-    if should_run and replan_obligation and replan_obligation.get("required"):
-        return {
-            **base,
-            **build_autonomous_replan_recommendation(replan_obligation),
-        }
-    if state in {"focus_wait", "waiting"} and has_user_todos:
-        return {
-            **base,
-            "recommended_mode": "blocker_push_notify",
-            "notify": "NOTIFY",
-            "repeat_notification_required": True,
-            "spend_policy": "do not append quota spend for the blocker-push turn",
-            "reason": open_todo_notify_reason(state=state, waiting_on=waiting_on),
-        }
-    if state == "focus_wait" and quota.get("handoff_outcome_floor_block"):
-        if quota.get("outcome_floor_blocker_projected"):
-            return {
-                **base,
-                "recommended_mode": "outcome_floor_blocker_projected_noop",
-                "notify": "DONT_NOTIFY",
-                "spend_policy": (
-                    "do not append quota spend while the same concrete outcome-floor "
-                    "blocker is already projected and no executable agent todo exists"
-                ),
-                "reason": str(
-                    quota.get("reason")
-                    or "outcome-floor blocker is already projected; wait for fresh outcome evidence"
-                ),
-            }
-        if quota.get("safe_bypass_allowed"):
-            return {
-                **base,
-                "recommended_mode": "outcome_floor_recovery",
-                "notify": "DONT_NOTIFY",
-                "spend_policy": (
-                    "append exactly one quota spend only after a validated "
-                    "ranker/cross-domain evidence artifact or concrete blocker writeback; "
-                    "do not spend for another surface-only report"
-                ),
-                "reason": str(quota.get("reason") or "handoff outcome floor is not met"),
-            }
-        return {
-            **base,
-            "recommended_mode": "report_handoff_outcome_blocker",
-            "notify": "NOTIFY",
-            "spend_policy": "do not append quota spend while reporting the handoff outcome-floor blocker",
-            "reason": str(quota.get("reason") or "handoff outcome floor is not met"),
-        }
-    if not should_run:
-        return {
-            **base,
-            "recommended_mode": "quota_skip",
-            "reason": f"quota state is {state}; skip delivery compute",
-        }
-
-    if item.get("agent_command"):
-        return {
-            **base,
-            "recommended_mode": "run_agent_command",
-            "command": str(item.get("agent_command")),
-            "notify": "DONT_NOTIFY",
-            "spend_policy": "append exactly one heartbeat spend after the command completes and validation/writeback are saved",
-            "reason": "current status exposes an approved project-agent command",
-        }
-
-    if (
-        work_lane_contract
-        and work_lane_contract.get("lane") == "continuous_monitor"
-        and work_lane_contract.get("must_attempt_work") is False
-        and has_user_todos
-    ):
-        return {
-            **base,
-            "recommended_mode": "monitor_quiet_until_material_transition",
-            "spend_policy": (
-                "do not append quota spend or repeat a blocker notification for a "
-                "monitor-only poll; keep the open user todo visible in the payload and "
-                "wait for a material monitor transition"
-            ),
-            "reason": (
-                "monitor-only polling has no material transition to write back; the "
-                "current open user todo is already part of the durable active state"
-            ),
-        }
-
-    if (
-        work_lane_contract
-        and work_lane_contract.get("lane") == "continuous_monitor"
-        and work_lane_contract.get("must_attempt_work") is False
-        and not has_user_todos
-    ):
-        return {
-            **base,
-            "recommended_mode": "monitor_quiet_until_material_transition",
-            "spend_policy": (
-                "do not append quota spend until a material monitor transition, regression, "
-                "or concrete blocker is validated and written back"
-            ),
-            "reason": "all visible open agent todos are monitor-class work with no material transition to record",
-        }
-
-    if (
-        work_lane_contract
-        and work_lane_contract.get("lane") == "continuous_monitor"
-        and work_lane_contract.get("must_attempt_work") is True
-        and not has_user_todos
-    ):
-        latest_run: dict[str, Any] = {}
-        handoff_readiness = (
-            item.get("handoff_readiness")
-            if isinstance(item.get("handoff_readiness"), dict)
-            else {}
-        )
-        latest_handoff_run = (
-            handoff_readiness.get("post_handoff_latest_run")
-            if isinstance(handoff_readiness.get("post_handoff_latest_run"), dict)
-            else {}
-        )
-        if latest_handoff_run:
-            latest_run = _compact_latest_run(latest_handoff_run)
-            latest_run["progress_scope"] = latest_run_progress_scope(latest_handoff_run)
-        payload = {
-            **base,
-            "recommended_mode": "follow_work_lane_contract",
-            "spend_policy": (
-                "follow work_lane_contract.obligation; spend only after validated "
-                "advancement, concrete blocker writeback, or a material monitor transition"
-            ),
-            "reason": (
-                "work_lane_contract is the machine contract for monitor-vs-advancement routing"
-            ),
-        }
-        if latest_run:
-            payload["latest_run"] = latest_run
-        return payload
-
-    if status == "connected_without_run" and _supports_read_only_project_map(adapter_kind):
-        return {
-            **base,
-            "recommended_mode": "run_first_read_only_map",
-            "command": f"loopx read-only-map --goal-id {goal_id}",
-            "notify": "NOTIFY",
-            "spend_policy": "append exactly one heartbeat spend after the read-only map run is saved and validated",
-            "reason": "connected read-only project has no saved compact run yet",
-        }
-
-    mapped = (
-        status == "read_only_project_map"
-        or _has_lifecycle_marker(lifecycle_phase, lifecycle_flags, marker="mapped")
-    )
-    if mapped and not any([has_user_todos, has_agent_todos, item.get("agent_command")]):
-        return {
-            **base,
-            "recommended_mode": "mapped_noop_if_unchanged",
-            "stop_if_unchanged": True,
-            "spend_policy": (
-                "do not run another dry-run or append quota spend when the latest read-only map is still current "
-                "and there is no new user instruction, owner evidence, agent todo, stale source, or safe handoff"
-            ),
-            "reason": "latest compact read-only map already exists; wait for new evidence or a concrete safe action",
-        }
-
-    post_handoff_observation = _control_plane_post_handoff_observation_hint(item)
-    if post_handoff_observation and not has_user_todos:
-        latest_observed_run = (
-            post_handoff_observation.get("latest_run")
-            if isinstance(post_handoff_observation.get("latest_run"), dict)
-            else {}
-        )
-        progress_scope = latest_run_progress_scope(latest_observed_run)
-        if isinstance(latest_observed_run, dict) and latest_observed_run:
-            latest_observed_run.setdefault("progress_scope", progress_scope)
-        if has_agent_todos and progress_scope == "dependency_observation":
-            return {
-                **base,
-                **{
-                    key: value
-                    for key, value in post_handoff_observation.items()
-                    if key != "stop_if_unchanged"
-                },
-                "recommended_mode": "follow_work_lane_contract",
-                "spend_policy": (
-                    "follow work_lane_contract.obligation; spend only after validated "
-                    "advancement, concrete blocker writeback, or a material monitor transition"
-                ),
-                "reason": (
-                    "latest post-handoff run was dependency observation; the work lane "
-                    "contract decides whether to advance backlog or record a material transition"
-                ),
-            }
-        if has_agent_todos:
-            active_observation = {
-                key: value
-                for key, value in post_handoff_observation.items()
-                if key != "stop_if_unchanged"
-            }
-            return {
-                **base,
-                **active_observation,
-                "recommended_mode": "post_handoff_observe_then_backlog_step",
-                "spend_policy": (
-                    "observe registry/status/run history/repo state first; if unchanged, "
-                    "advance exactly one bounded agent-todo backlog segment and append quota "
-                    "spend only after validation and durable writeback"
-                ),
-                "reason": (
-                    "latest post-handoff implementation reached the primary outcome, but "
-                    "an open agent todo remains; observe for new blockers first, then "
-                    "advance one bounded backlog step instead of quiet idling"
-                ),
-            }
-        return {
-            **base,
-            **post_handoff_observation,
-        }
-
-    return {
-        **base,
-        "recommended_mode": "steering_audit_then_one_step",
-        "spend_policy": "append exactly one heartbeat spend only after a bounded progress segment is validated and written back",
-        "reason": "eligible Codex-ready goal requires the standard steering audit before delivery",
-    }
+    for rule in _HEARTBEAT_RECOMMENDATION_RULES:
+        recommendation = rule(facts)
+        if recommendation is not None:
+            return recommendation
+    raise AssertionError("heartbeat recommendation rule table requires a fallback")

--- a/tests/control_plane/test_heartbeat_recommendation_rules.py
+++ b/tests/control_plane/test_heartbeat_recommendation_rules.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from typing import Any
+
+from loopx.control_plane.quota.heartbeat_recommendation import (
+    build_heartbeat_recommendation,
+)
+from loopx.control_plane.work_items.delivery_outcome import DeliveryOutcome
+
+
+GOAL_ID = "heartbeat-recommendation-rules"
+
+
+def _todo_summary(*, role: str, open_count: int) -> dict[str, Any]:
+    task_class = "user_gate" if role == "user" else "advancement_task"
+    return {
+        "schema_version": "todo_summary_v0",
+        "source_section": f"{role.title()} Todo",
+        "open_count": open_count,
+        "first_open_items": [
+            {
+                "todo_id": f"todo_{role}_{index}",
+                "status": "open",
+                "task_class": task_class,
+                "text": f"[P0] {role} work",
+            }
+            for index in range(open_count)
+        ],
+    }
+
+
+def _recommend(
+    item: dict[str, Any] | None = None,
+    *,
+    state: str = "eligible",
+    should_run: bool = True,
+    user_open: int = 0,
+    agent_open: int = 0,
+    lane: str = "advancement",
+    must_attempt_work: bool = True,
+    stall_self_repair: dict[str, Any] | None = None,
+    replan_obligation: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return build_heartbeat_recommendation(
+        item or {},
+        goal_id=GOAL_ID,
+        state=state,
+        should_run=should_run,
+        user_todo_summary=_todo_summary(role="user", open_count=user_open),
+        agent_todo_summary=_todo_summary(role="agent", open_count=agent_open),
+        work_lane_contract={
+            "schema_version": "work_lane_contract_v0",
+            "lane": lane,
+            "must_attempt_work": must_attempt_work,
+        },
+        stall_self_repair=stall_self_repair,
+        replan_obligation=replan_obligation,
+        select_replan_obligation=False,
+    )
+
+
+def _required_replan() -> dict[str, Any]:
+    return {
+        "schema_version": "autonomous_replan_obligation_v0",
+        "required": True,
+        "stall_threshold": 2,
+        "trigger_count": 1,
+        "triggers": [{"kind": "dead_monitor_repeat"}],
+        "stop_condition": "stop at a real owner boundary",
+    }
+
+
+def test_scope_projection_repair_preempts_operator_gate() -> None:
+    recommendation = _recommend(
+        state="operator_gate",
+        stall_self_repair={
+            "allowed": True,
+            "trigger": "user_gate_scope_projection_drift",
+            "recommended_mode": "repair_user_gate_scope",
+            "repair_focus": "restore the exact blocked lane",
+        },
+    )
+
+    assert recommendation["recommended_mode"] == "repair_user_gate_scope"
+    assert recommendation["notify"] == "DONT_NOTIFY"
+    assert recommendation["repair_focus"] == "restore the exact blocked lane"
+
+
+def test_operator_gate_preempts_unrelated_stall_repair_and_replan() -> None:
+    recommendation = _recommend(
+        state="operator_gate",
+        stall_self_repair={
+            "allowed": True,
+            "trigger": "small_scale_streak",
+            "recommended_mode": "expand_delivery",
+        },
+        replan_obligation=_required_replan(),
+    )
+
+    assert recommendation["recommended_mode"] == "ask_operator_gate"
+    assert recommendation["notify"] == "NOTIFY"
+
+
+def test_required_replan_preempts_waiting_user_todo() -> None:
+    recommendation = _recommend(
+        state="waiting",
+        user_open=1,
+        replan_obligation=_required_replan(),
+    )
+
+    assert recommendation["recommended_mode"] == "autonomous_replan_required"
+    assert recommendation["notify"] == "DONT_NOTIFY"
+    assert recommendation["replan_obligation"]["trigger_count"] == 1
+
+
+def test_waiting_user_todo_preempts_quota_skip() -> None:
+    recommendation = _recommend(
+        {"waiting_on": "external_evidence"},
+        state="waiting",
+        should_run=False,
+        user_open=1,
+    )
+
+    assert recommendation["recommended_mode"] == "blocker_push_notify"
+    assert recommendation["notify"] == "NOTIFY"
+    assert recommendation["repeat_notification_required"] is True
+
+
+def test_outcome_floor_blocker_preempts_quota_skip() -> None:
+    recommendation = _recommend(
+        {
+            "quota": {
+                "handoff_outcome_floor_block": True,
+                "reason": "primary outcome evidence is missing",
+            }
+        },
+        state="focus_wait",
+        should_run=False,
+    )
+
+    assert recommendation["recommended_mode"] == "report_handoff_outcome_blocker"
+    assert recommendation["notify"] == "NOTIFY"
+    assert recommendation["reason"] == "primary outcome evidence is missing"
+
+
+def test_quota_skip_preempts_agent_command() -> None:
+    recommendation = _recommend(
+        {"agent_command": "loopx bounded-command"},
+        state="throttled",
+        should_run=False,
+    )
+
+    assert recommendation["recommended_mode"] == "quota_skip"
+    assert "throttled" in recommendation["reason"]
+
+
+def test_agent_command_preempts_monitor_lane() -> None:
+    recommendation = _recommend(
+        {"agent_command": "loopx bounded-command"},
+        lane="continuous_monitor",
+        must_attempt_work=False,
+    )
+
+    assert recommendation["recommended_mode"] == "run_agent_command"
+    assert recommendation["command"] == "loopx bounded-command"
+
+
+def test_quiet_monitor_keeps_user_todo_non_blocking() -> None:
+    recommendation = _recommend(
+        lane="continuous_monitor",
+        must_attempt_work=False,
+        user_open=1,
+    )
+
+    assert (
+        recommendation["recommended_mode"]
+        == "monitor_quiet_until_material_transition"
+    )
+    assert recommendation["notify"] == "DONT_NOTIFY"
+    assert "open user todo" in recommendation["spend_policy"]
+
+
+def test_due_monitor_lane_preempts_first_read_only_map() -> None:
+    recommendation = _recommend(
+        {
+            "status": "connected_without_run",
+            "adapter_kind": "docs_read_only_map_v0",
+        },
+        lane="continuous_monitor",
+        must_attempt_work=True,
+    )
+
+    assert recommendation["recommended_mode"] == "follow_work_lane_contract"
+    assert "machine contract" in recommendation["reason"]
+
+
+def test_first_read_only_map_preempts_mapped_noop() -> None:
+    recommendation = _recommend(
+        {
+            "status": "connected_without_run",
+            "adapter_kind": "docs_read_only_map_v0",
+            "lifecycle_flags": ["mapped"],
+        }
+    )
+
+    assert recommendation["recommended_mode"] == "run_first_read_only_map"
+    assert recommendation["command"] == f"loopx read-only-map --goal-id {GOAL_ID}"
+
+
+def test_post_handoff_primary_outcome_preserves_observation_contract() -> None:
+    recommendation = _recommend(
+        {
+            "status": "post_handoff_run_seen",
+            "adapter_kind": "harness_self_improvement",
+            "control_plane": {"self_repair": {"enabled": True}},
+            "handoff_readiness": {
+                "post_handoff_run_seen": True,
+                "handoff_status": "post_handoff_run_seen",
+                "post_handoff_latest_run": {
+                    "classification": "implementation_merged",
+                    "delivery_outcome": DeliveryOutcome.PRIMARY_GOAL_OUTCOME.value,
+                },
+            },
+        }
+    )
+
+    assert recommendation["recommended_mode"] == "post_handoff_observe_if_unchanged"
+    assert recommendation["stop_if_unchanged"] is True
+    assert recommendation["latest_run"]["progress_scope"] == "primary_goal"
+
+
+def test_default_mode_requires_bounded_steering_audit() -> None:
+    recommendation = _recommend(
+        {"status": "active-read-only"},
+        agent_open=1,
+    )
+
+    assert recommendation["recommended_mode"] == "steering_audit_then_one_step"
+    assert "bounded progress segment" in recommendation["spend_policy"]


### PR DESCRIPTION
## Summary

- characterize the semantic precedence of 12 heartbeat recommendation decisions
- replace the oversized branch ladder with normalized facts plus an ordered first-match rule table
- retire the now-stale maintainability exception without changing public payloads or routing order

## Validation

- `tests/control_plane`: 491 passed
- focused precedence, scheduler, CLI budget, and ratchet tests: 47 passed
- system Python 3.9 recommendation state-machine smoke: passed
- Ruff on all changed files: passed
- maintainability ratchet: 11 reviewed findings, 0 stale, 0 unreviewed, 0 regressions
- deterministic old/new parity: 331,776 combinations matched
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 15/15 selected checks passed
- exact-diff change-quality receipt: valid, no findings

## Risk and review hold

This changes a quota control-plane decision owner, so I am leaving it open for owner review even though the automated gate reports no manual hold. The intended behavior is preservation: rule order, truthiness, emitted strings, and payload assembly were checked against the previous implementation.

The first canary invocation omitted the global registry path: all 15 checks passed, then receipt lookup failed because the independent worktree has no local registry. Rerunning with the authoritative global registry/runtime passed cleanly. No validation was skipped.