### PR TITLE
Fix SkillsBench rotation after exhausted Turn repair

### DIFF
--- a/examples/skillsbench-post-run-debug-gate-smoke.py
+++ b/examples/skillsbench-post-run-debug-gate-smoke.py
@@ -347,10 +347,109 @@ def test_fatal_provider_turn_has_complete_capacity_blocked_closeout() -> None:
     assert transaction["quota_spent_count"] == 0, transaction
 
 
+def test_exhausted_typed_repair_opens_case_rotation_with_exclusion() -> None:
+    failed_turn = {
+        "schema_version": "loopx_turn_execution_v0",
+        "mode": "run_once",
+        "status": "failed",
+        "result_kind": "validation_failed",
+        "validation": {
+            "status": "failed",
+            "recovery_kind": "repair_required",
+        },
+        "receipt": {
+            "status": "failed",
+            "failed_phase": "validation",
+        },
+        "effects": {
+            "host_invoked": True,
+            "state_written": False,
+            "quota_spent": False,
+            "scheduler_acknowledged": False,
+        },
+    }
+    compact = {
+        "benchmark_id": "skillsbench@1.1",
+        "product_mode": True,
+        "official_score_status": "missing",
+        "official_task_score": {"passed": False},
+        "score_failure_attribution": "verifier_infrastructure_failure",
+        "product_mode_lifecycle_contract": {
+            "required": False,
+            "satisfied": True,
+            "closeout_satisfied": False,
+            "state_read_count": 0,
+            "state_write_count": 0,
+        },
+        "loopx_turn_executions": [failed_turn, dict(failed_turn)],
+        "interaction_counters": {
+            "product_mode_typed_repair_terminal": True,
+            "product_mode_typed_repair_terminal_receipt_consistent": True,
+            "product_mode_typed_repair_terminal_reason": (
+                "turn_repair_round_without_todo_or_committed_validation_delta"
+            ),
+        },
+        "case_event_timeline": {
+            "schema_version": "skillsbench_case_event_timeline_v0",
+            "source": "compact_public_signals",
+            "raw_material_recorded": False,
+            "events": [
+                {
+                    "phase": "goal_init",
+                    "event": "case_goal_state_init",
+                    "status": "passed",
+                },
+                {
+                    "phase": "lifecycle",
+                    "event": "orchestrated_loopx_lifecycle",
+                    "status": "not_observed",
+                },
+                {
+                    "phase": "bridge",
+                    "event": "remote_command_bridge_consumption",
+                    "status": "consumed",
+                },
+                {
+                    "phase": "activity",
+                    "event": "task_facing_activity",
+                    "status": "task_activity_observed",
+                },
+                {
+                    "phase": "controller",
+                    "event": "controller_decision_loop",
+                    "status": "typed_repair_terminal",
+                },
+                {
+                    "phase": "scoring",
+                    "event": "official_score_closeout",
+                    "status": "missing",
+                    "official_score_passed": False,
+                },
+                {
+                    "phase": "closeout",
+                    "event": "agent_bridge_closeout",
+                    "status": "missing",
+                },
+            ],
+        },
+    }
+
+    gate = build_skillsbench_post_run_debug_gate(compact)
+
+    assert gate["normal_progress_allowed"] is True, gate
+    assert gate["next_case_gate"] == "open_with_exclusion", gate
+    assert gate["loopx_lifecycle"]["satisfied"] is False, gate
+    transaction = gate["loopx_turn_transaction"]
+    assert transaction["progress_blocked"] is True, transaction
+    assert transaction["next_case_blocked"] is False, transaction
+    assert transaction["case_exclusion_required"] is True, transaction
+
+
 def main() -> None:
     test_countable_zero_keeps_solution_attribution()
     test_failed_turn_receipts_qualify_direct_lifecycle_success()
     test_fatal_provider_turn_has_complete_capacity_blocked_closeout()
+    test_exhausted_typed_repair_opens_case_rotation_with_exclusion()
     print("skillsbench-post-run-debug-gate-smoke: ok")
 
 

--- a/loopx/benchmark_adapters/skillsbench_typed_repair.py
+++ b/loopx/benchmark_adapters/skillsbench_typed_repair.py
@@ -16,6 +16,12 @@ from .skillsbench_acp_failure_policy import (
 
 
 SKILLSBENCH_TYPED_REPAIR_POLICY_ID = "one_typed_repair_per_frontier_v0"
+SKILLSBENCH_TYPED_REPAIR_EXHAUSTED_REASONS = frozenset(
+    {
+        "turn_repair_round_without_todo_or_committed_validation_delta",
+        "unchanged_turn_recovery_frontier_already_repaired",
+    }
+)
 SKILLSBENCH_TYPED_REPAIR_SNAPSHOT_SCHEMA_VERSION = (
     "skillsbench_typed_repair_frontier_snapshot_v0"
 )

--- a/loopx/benchmarks/read_models/skillsbench_post_run_debug.py
+++ b/loopx/benchmarks/read_models/skillsbench_post_run_debug.py
@@ -19,6 +19,9 @@ from ...control_plane.turn_driver.transaction import (
 from ...benchmark_adapters.skillsbench_acp_failure_policy import (
     nonrecoverable_codex_turn_failure_category,
 )
+from ...benchmark_adapters.skillsbench_typed_repair import (
+    SKILLSBENCH_TYPED_REPAIR_EXHAUSTED_REASONS,
+)
 
 MAX_SKILLSBENCH_DEBUG_LIST_ITEMS = 5
 
@@ -112,6 +115,24 @@ def _skillsbench_turn_transaction_outcome(run: dict[str, Any]) -> dict[str, Any]
     nonrecoverable_failure_category = (
         nonrecoverable_codex_turn_failure_category(counters)
     )
+    typed_repair_terminal_reason = public_safe_compact_text(
+        counters.get("product_mode_typed_repair_terminal_reason"),
+        limit=120,
+    )
+    typed_repair_exhausted = bool(
+        validation_failed_count > 0
+        and committed_count < execution_count
+        and failed_transaction_with_durable_effect_count == 0
+        and state_written_count == 0
+        and quota_spent_count == 0
+        and counters.get("product_mode_typed_repair_terminal") is True
+        and counters.get(
+            "product_mode_typed_repair_terminal_receipt_consistent"
+        )
+        is True
+        and typed_repair_terminal_reason
+        in SKILLSBENCH_TYPED_REPAIR_EXHAUSTED_REASONS
+    )
     terminal_host_failure = bool(
         host_failure_count > 0
         and nonrecoverable_failure_category
@@ -140,6 +161,10 @@ def _skillsbench_turn_transaction_outcome(run: dict[str, Any]) -> dict[str, Any]
         status = "committed"
         causal_consistency = "committed_effects_observed"
         first_blocker = "none"
+    elif typed_repair_exhausted:
+        status = "validation_failed_typed_repair_exhausted"
+        causal_consistency = "validation_failure_effects_not_committed"
+        first_blocker = "loopx_turn_validation_failed"
     elif validation_failed_count:
         status = "validation_failed"
         causal_consistency = "validation_failure_effects_not_committed"
@@ -155,6 +180,8 @@ def _skillsbench_turn_transaction_outcome(run: dict[str, Any]) -> dict[str, Any]
             if nonrecoverable_failure_category == "codex_usage_limit"
             else "terminal_host_failure"
         )
+    elif typed_repair_exhausted:
+        recovery_status = "case_exclusion_required"
     elif repair_required_count:
         recovery_status = "repair_required"
     elif replan_required_count:
@@ -173,6 +200,13 @@ def _skillsbench_turn_transaction_outcome(run: dict[str, Any]) -> dict[str, Any]
         "progress_blocked": (
             committed_count != execution_count and not terminal_host_failure
         ),
+        "next_case_blocked": (
+            committed_count != execution_count
+            and not terminal_host_failure
+            and not typed_repair_exhausted
+        ),
+        "typed_repair_exhausted": typed_repair_exhausted,
+        "case_exclusion_required": typed_repair_exhausted,
         "first_blocker": first_blocker,
         "execution_count": execution_count,
         "committed_count": committed_count,
@@ -190,6 +224,7 @@ def _skillsbench_turn_transaction_outcome(run: dict[str, Any]) -> dict[str, Any]
         "nonrecoverable_host_failure_category": (
             nonrecoverable_failure_category
         ),
+        "typed_repair_terminal_reason": typed_repair_terminal_reason,
     }
 
 
@@ -331,6 +366,16 @@ def build_skillsbench_post_run_debug_gate(
     turn_transaction_blocks_progress = bool(
         turn_transaction.get("progress_blocked") is True
     )
+    turn_transaction_blocks_next_case = bool(
+        turn_transaction.get(
+            "next_case_blocked",
+            turn_transaction_blocks_progress,
+        )
+        is True
+    )
+    typed_repair_exhausted = bool(
+        turn_transaction.get("typed_repair_exhausted") is True
+    )
     terminal_host_provider_failure = bool(
         turn_transaction.get("terminal_host_failure") is True
     )
@@ -338,7 +383,9 @@ def build_skillsbench_post_run_debug_gate(
         (effective_lifecycle_satisfied or terminal_host_provider_failure)
         and not turn_transaction_blocks_progress
     )
-    if turn_transaction_blocks_progress:
+    if turn_transaction_blocks_progress and typed_repair_exhausted:
+        qualified_closeout_status = "turn_transaction_unqualified_case_excluded"
+    elif turn_transaction_blocks_progress:
         qualified_closeout_status = "turn_transaction_repair_required"
     elif terminal_host_provider_failure:
         qualified_closeout_status = "host_provider_failure_terminal"
@@ -453,9 +500,14 @@ def build_skillsbench_post_run_debug_gate(
         else:
             next_case_gate = "open_with_attribution"
             next_action = "repair_host_provider_before_rerunning_same_case"
-    elif turn_transaction_blocks_progress:
+    elif turn_transaction_blocks_next_case:
         next_case_gate = "blocked_turn_transaction_repair"
         next_action = "repair_loopx_turn_transaction_before_next_matched_case"
+    elif typed_repair_exhausted:
+        next_case_gate = "open_with_exclusion"
+        next_action = (
+            "record_unqualified_case_arm_and_continue_after_protocol_rerun"
+        )
     elif attribution_layer == "clean_pass":
         next_case_gate = "open"
         next_action = "upsert_ledger_and_continue_or_compare_pair"
@@ -477,7 +529,7 @@ def build_skillsbench_post_run_debug_gate(
         "normal_progress_allowed": bool(
             packet_complete
             and case_closeout_complete
-            and not turn_transaction_blocks_progress
+            and not turn_transaction_blocks_next_case
             and not terminal_host_provider_failure
         ),
         "first_blocker": first_blocker,

--- a/tests/benchmarks/read_models/test_skillsbench_post_run_debug.py
+++ b/tests/benchmarks/read_models/test_skillsbench_post_run_debug.py
@@ -6,6 +6,94 @@ from loopx.benchmarks.read_models.skillsbench_post_run_debug import (
 )
 
 
+def _typed_repair_exhausted_compact() -> dict[str, object]:
+    failed_turn = {
+        "schema_version": "loopx_turn_execution_v0",
+        "mode": "run_once",
+        "status": "failed",
+        "result_kind": "validation_failed",
+        "validation": {
+            "status": "failed",
+            "recovery_kind": "repair_required",
+        },
+        "receipt": {
+            "status": "failed",
+            "failed_phase": "validation",
+        },
+        "effects": {
+            "host_invoked": True,
+            "state_written": False,
+            "quota_spent": False,
+            "scheduler_acknowledged": False,
+        },
+    }
+    return {
+        "benchmark_id": "skillsbench@1.1",
+        "product_mode": True,
+        "official_score_status": "missing",
+        "official_task_score": {"passed": False},
+        "score_failure_attribution": "verifier_infrastructure_failure",
+        "product_mode_lifecycle_contract": {
+            "required": False,
+            "satisfied": True,
+            "closeout_satisfied": False,
+            "state_read_count": 0,
+            "state_write_count": 0,
+        },
+        "loopx_turn_executions": [failed_turn, dict(failed_turn)],
+        "interaction_counters": {
+            "product_mode_typed_repair_terminal": True,
+            "product_mode_typed_repair_terminal_receipt_consistent": True,
+            "product_mode_typed_repair_terminal_reason": (
+                "turn_repair_round_without_todo_or_committed_validation_delta"
+            ),
+        },
+        "case_event_timeline": {
+            "schema_version": "skillsbench_case_event_timeline_v0",
+            "source": "compact_public_signals",
+            "raw_material_recorded": False,
+            "events": [
+                {
+                    "phase": "goal_init",
+                    "event": "case_goal_state_init",
+                    "status": "passed",
+                },
+                {
+                    "phase": "lifecycle",
+                    "event": "orchestrated_loopx_lifecycle",
+                    "status": "not_observed",
+                },
+                {
+                    "phase": "bridge",
+                    "event": "remote_command_bridge_consumption",
+                    "status": "consumed",
+                },
+                {
+                    "phase": "activity",
+                    "event": "task_facing_activity",
+                    "status": "task_activity_observed",
+                },
+                {
+                    "phase": "controller",
+                    "event": "controller_decision_loop",
+                    "status": "typed_repair_terminal",
+                },
+                {
+                    "phase": "scoring",
+                    "event": "official_score_closeout",
+                    "status": "missing",
+                    "official_score_passed": False,
+                },
+                {
+                    "phase": "closeout",
+                    "event": "agent_bridge_closeout",
+                    "status": "missing",
+                },
+            ],
+        },
+    }
+
+
 def test_status_preserves_skillsbench_post_run_debug_import() -> None:
     assert (
         status.build_skillsbench_post_run_debug_gate
@@ -82,3 +170,65 @@ def test_countable_zero_keeps_solution_level_attribution() -> None:
     assert gate["next_case_gate"] == "open_with_attribution"
     assert gate["attribution_layer"] == "solution_level_unknown"
     assert gate["first_blocker"] == "official_verifier_solution_failure"
+
+
+def test_typed_repair_exhaustion_opens_rotation_without_qualifying_turn() -> None:
+    gate = build_skillsbench_post_run_debug_gate(
+        _typed_repair_exhausted_compact()
+    )
+
+    transaction = gate["loopx_turn_transaction"]
+    assert transaction["status"] == "validation_failed_typed_repair_exhausted"
+    assert transaction["progress_blocked"] is True
+    assert transaction["next_case_blocked"] is False
+    assert transaction["typed_repair_exhausted"] is True
+    assert transaction["case_exclusion_required"] is True
+    assert transaction["recovery_status"] == "case_exclusion_required"
+    assert gate["loopx_lifecycle"]["satisfied"] is False
+    assert gate["loopx_lifecycle"]["closeout_status"] == (
+        "turn_transaction_unqualified_case_excluded"
+    )
+    assert gate["attribution_layer"] == "loopx_turn_transaction"
+    assert gate["first_blocker"] == "loopx_turn_validation_failed"
+    assert gate["next_case_gate"] == "open_with_exclusion"
+    assert gate["normal_progress_allowed"] is True
+    assert gate["next_action"] == (
+        "record_unqualified_case_arm_and_continue_after_protocol_rerun"
+    )
+
+
+def test_unrecognized_typed_repair_terminal_reason_keeps_rotation_blocked() -> None:
+    compact = _typed_repair_exhausted_compact()
+    counters = compact["interaction_counters"]
+    assert isinstance(counters, dict)
+    counters["product_mode_typed_repair_terminal_reason"] = "repair_pending"
+
+    gate = build_skillsbench_post_run_debug_gate(compact)
+
+    transaction = gate["loopx_turn_transaction"]
+    assert transaction["typed_repair_exhausted"] is False
+    assert transaction["next_case_blocked"] is True
+    assert gate["next_case_gate"] == "blocked_turn_transaction_repair"
+    assert gate["normal_progress_allowed"] is False
+
+
+def test_failed_turn_durable_effect_keeps_rotation_blocked() -> None:
+    compact = _typed_repair_exhausted_compact()
+    executions = compact["loopx_turn_executions"]
+    assert isinstance(executions, list)
+    execution = executions[0]
+    assert isinstance(execution, dict)
+    effects = execution["effects"]
+    assert isinstance(effects, dict)
+    effects["state_written"] = True
+
+    gate = build_skillsbench_post_run_debug_gate(compact)
+
+    transaction = gate["loopx_turn_transaction"]
+    assert transaction["status"] == (
+        "inconsistent_failed_transaction_has_durable_effects"
+    )
+    assert transaction["typed_repair_exhausted"] is False
+    assert transaction["next_case_blocked"] is True
+    assert gate["next_case_gate"] == "blocked_turn_transaction_repair"
+    assert gate["normal_progress_allowed"] is False


### PR DESCRIPTION
## Summary
- distinguish an unqualified failed Turn from whether the next benchmark case must remain blocked
- allow case rotation only after a receipt-consistent typed-repair terminal with zero durable effects
- preserve exclusion and failed-Turn attribution, with negative coverage for unknown terminal reasons and durable effects

## Validation
- `python -m pytest tests/benchmarks/read_models/test_skillsbench_post_run_debug.py` (7 passed)
- `python examples/skillsbench-post-run-debug-gate-smoke.py`
- `python examples/skillsbench-typed-repair-smoke.py`
- exact public compact replay against the updated read model
- standard LoopX premerge canary: all 10 executed checks passed; public boundary clean
- change-quality receipt `cqr_92399b280c7762a8e6b1` valid

## Merge hold
The premerge gate classifies this as benchmark-sensitive and requires maintainer review; this PR is intentionally not self-merged.