### PR TITLE
refactor(quota): isolate plan quota selection

### DIFF
--- a/loopx/canary/maintainability_ratchet.py
+++ b/loopx/canary/maintainability_ratchet.py
@@ -66,9 +66,6 @@ _OVERSIZED_DECISION_RETIREMENT_PLANS = {
     "loopx.status:compact_active_user_assisted_pilot": (
         "Move assisted-pilot compaction into a bounded runtime read model."
     ),
-    "loopx.quota:build_quota_plan": (
-        "Move quota-plan policy selection behind focused control-plane rule helpers."
-    ),
     "loopx.quota:build_quota_should_run": (
         "Continue decomposing the public quota facade into bounded decision stages."
     ),
@@ -98,10 +95,6 @@ _OVERSIZED_DECISION_METRIC_CEILINGS = {
     "loopx.status:compact_active_user_assisted_pilot": {
         "statements": 124,
         "decision_points": 71,
-    },
-    "loopx.quota:build_quota_plan": {
-        "statements": 61,
-        "decision_points": 69,
     },
     "loopx.quota:build_quota_should_run": {
         "statements": 366,

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -869,6 +869,56 @@ def _execution_obligation(
     )
 
 
+def _quota_plan_goal_quota(
+    *,
+    attention: dict[str, Any],
+    project_asset: dict[str, Any],
+    goal: dict[str, Any],
+    waiting_on: str,
+    lifecycle_phase: Any,
+    lifecycle_flags: Any,
+    status: Any,
+) -> dict[str, Any]:
+    project_asset_quota = (
+        project_asset.get("quota")
+        if isinstance(project_asset.get("quota"), dict)
+        else {}
+    )
+    raw_quota = (
+        attention.get("quota")
+        if isinstance(attention.get("quota"), dict)
+        else goal.get("quota")
+    )
+    if project_asset_quota:
+        raw_quota_base = raw_quota if isinstance(raw_quota, dict) else {}
+        quota = {**raw_quota_base, **project_asset_quota}
+    elif isinstance(raw_quota, dict):
+        quota = _quota_with_focus_wait_override(
+            raw_quota,
+            waiting_on=waiting_on,
+            lifecycle_phase=lifecycle_phase,
+            lifecycle_flags=lifecycle_flags,
+            status=status,
+        )
+    else:
+        quota = quota_status(
+            goal,
+            waiting_on=waiting_on,
+            severity=str(attention.get("severity") or ""),
+            lifecycle_phase=lifecycle_phase,
+            lifecycle_flags=lifecycle_flags,
+            status=status,
+        )
+    return quota_with_handoff_outcome_floor(
+        quota,
+        waiting_on=waiting_on,
+        project_asset=project_asset,
+        handoff_readiness=attention.get("handoff_readiness")
+        if isinstance(attention.get("handoff_readiness"), dict)
+        else None,
+    )
+
+
 def build_quota_plan(status_payload: dict[str, Any], *, mode: str = "status") -> dict[str, Any]:
     queue = status_payload.get("attention_queue") if isinstance(status_payload.get("attention_queue"), dict) else {}
     queue_items = queue.get("items") if isinstance(queue.get("items"), list) else []
@@ -910,11 +960,6 @@ def build_quota_plan(status_payload: dict[str, Any], *, mode: str = "status") ->
             if isinstance(attention.get("project_asset"), dict)
             else {}
         )
-        project_asset_quota = (
-            project_asset.get("quota")
-            if isinstance(project_asset.get("quota"), dict)
-            else {}
-        )
         latest = _latest_run(goal)
         waiting_on = attention.get("waiting_on") or "none"
         lifecycle_phase = attention.get("lifecycle_phase") or goal.get("lifecycle_phase")
@@ -925,35 +970,14 @@ def build_quota_plan(status_payload: dict[str, Any], *, mode: str = "status") ->
             or compact_control_plane_policy(project_asset.get("control_plane"))
             or compact_control_plane_policy(goal.get("control_plane"))
         )
-        raw_quota = attention.get("quota") if isinstance(attention.get("quota"), dict) else goal.get("quota")
-        if project_asset_quota:
-            raw_quota_base = raw_quota if isinstance(raw_quota, dict) else {}
-            quota = {**raw_quota_base, **project_asset_quota}
-        elif isinstance(raw_quota, dict):
-            quota = raw_quota
-            quota = _quota_with_focus_wait_override(
-                quota,
-                waiting_on=str(waiting_on or ""),
-                lifecycle_phase=lifecycle_phase,
-                lifecycle_flags=lifecycle_flags,
-                status=status,
-            )
-        else:
-            quota = quota_status(
-                goal,
-                waiting_on=str(waiting_on or ""),
-                severity=str(attention.get("severity") or ""),
-                lifecycle_phase=lifecycle_phase,
-                lifecycle_flags=lifecycle_flags,
-                status=status,
-            )
-        quota = quota_with_handoff_outcome_floor(
-            quota,
-            waiting_on=str(waiting_on or ""),
+        quota = _quota_plan_goal_quota(
+            attention=attention,
             project_asset=project_asset,
-            handoff_readiness=attention.get("handoff_readiness")
-            if isinstance(attention.get("handoff_readiness"), dict)
-            else None,
+            goal=goal,
+            waiting_on=str(waiting_on or ""),
+            lifecycle_phase=lifecycle_phase,
+            lifecycle_flags=lifecycle_flags,
+            status=status,
         )
         state = str(quota.get("state") or "waiting")
         item: dict[str, Any] = {

--- a/tests/control_plane/test_quota_plan_policy.py
+++ b/tests/control_plane/test_quota_plan_policy.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from typing import Any
+
+from loopx.quota import FOCUS_WAIT_REASON, build_quota_plan
+
+
+def _goal(goal_id: str, *, quota: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "id": goal_id,
+        "registry_member": True,
+        **({"quota": quota} if quota is not None else {}),
+    }
+
+
+def _status_payload(
+    *,
+    goal: dict[str, Any],
+    attention: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "registry": None,
+        "runtime_root": "/tmp/loopx-runtime",
+        "goal_count": 1,
+        "run_count": 0,
+        "attention_queue": {"items": [attention]},
+        "run_history": {"goals": [goal]},
+    }
+
+
+def _only_plan_item(payload: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    plan = build_quota_plan(payload, mode="plan")
+    populated_groups = [
+        (state, items)
+        for state, items in plan["groups"].items()
+        if items
+    ]
+    assert len(populated_groups) == 1, plan
+    state, items = populated_groups[0]
+    assert len(items) == 1, plan
+    return state, items[0]
+
+
+def test_project_asset_quota_is_authoritative_over_focus_wait_markers() -> None:
+    goal_id = "asset-quota"
+    attention = {
+        "goal_id": goal_id,
+        "waiting_on": "codex",
+        "lifecycle_phase": "focus_wait",
+        "quota": {
+            "compute": 0.8,
+            "state": "eligible",
+            "reason": "attention quota",
+        },
+        "project_asset": {
+            "quota": {
+                "compute": 0.4,
+                "state": "eligible",
+                "reason": "project asset quota",
+            }
+        },
+    }
+
+    state, item = _only_plan_item(
+        _status_payload(goal=_goal(goal_id), attention=attention)
+    )
+
+    assert state == "eligible"
+    assert item["quota"] == {
+        "compute": 0.4,
+        "state": "eligible",
+        "reason": "project asset quota",
+    }
+    assert item["project_asset_source"] == "project_asset"
+
+
+def test_attention_quota_receives_focus_wait_override() -> None:
+    goal_id = "attention-quota"
+    attention = {
+        "goal_id": goal_id,
+        "waiting_on": "codex",
+        "lifecycle_flags": ["continuation_boundary"],
+        "quota": {
+            "compute": 0.8,
+            "state": "eligible",
+            "reason": "attention quota",
+        },
+    }
+
+    state, item = _only_plan_item(
+        _status_payload(goal=_goal(goal_id), attention=attention)
+    )
+
+    assert state == "focus_wait"
+    assert item["quota"]["compute"] == 0.8
+    assert item["quota"]["reason"] == FOCUS_WAIT_REASON
+    assert item["quota"]["blocked_action_scope"] == "delivery_focus"
+    assert item["quota"]["focus_wait"] is True
+
+
+def test_goal_quota_projection_is_reused_without_recomputing_state() -> None:
+    goal_id = "goal-quota"
+    attention = {
+        "goal_id": goal_id,
+        "waiting_on": "codex",
+        "severity": "info",
+    }
+
+    state, item = _only_plan_item(
+        _status_payload(
+            goal=_goal(
+                goal_id,
+                quota={
+                    "compute": 0.3,
+                    "window_hours": 2,
+                    "slot_minutes": 10,
+                    "spent_slots": 1,
+                },
+            ),
+            attention=attention,
+        )
+    )
+
+    assert state == "waiting"
+    assert item["quota"] == {
+        "compute": 0.3,
+        "window_hours": 2,
+        "slot_minutes": 10,
+        "spent_slots": 1,
+    }
+
+
+def test_quota_status_fallback_runs_when_no_quota_projection_exists() -> None:
+    goal_id = "default-quota"
+    attention = {
+        "goal_id": goal_id,
+        "waiting_on": "codex",
+        "severity": "info",
+    }
+
+    state, item = _only_plan_item(
+        _status_payload(goal=_goal(goal_id), attention=attention)
+    )
+
+    assert state == "eligible"
+    assert item["quota"]["compute"] == 1.0
+    assert item["quota"]["allowed_slots"] == 1440
+    assert item["quota"]["spent_slots"] == 0
+    assert item["quota"]["reason"] == (
+        "1 compute quota; eligible for the next automatic agent turn"
+    )


### PR DESCRIPTION
## Summary
- extract quota source precedence, focus-wait override, and handoff outcome-floor application from `build_quota_plan` into one private rule helper
- add focused semantic tests for project-asset, attention, run-history, and fallback quota paths
- retire the measured `build_quota_plan` oversized-decision exception (8 -> 7)

## Validation
- `pytest -q tests/control_plane/test_quota_plan_policy.py tests/canary/test_maintainability_ratchet.py` (9 passed)
- `python examples/control_plane/quota-plan-smoke.py` under Python 3.13
- maintainability ratchet: passed, no unreviewed/stale/magnitude regressions
- focused Ruff and `git diff --check`
- risk-based premerge: 17/17 passed, no failures, skips, warnings, or manual holds
- exact receipt: `cqr_07b934990b43846f6786`

## Review focus
This preserves a subtle existing contract: a projected `run_history.goal.quota` is reused without recomputing `state`; only the absence of both attention and goal quota projections calls `quota_status()`. Please confirm that compatibility boundary before merge.

## Merge decision
Owner review requested because this changes quota control-plane structure. The agent will not self-merge this PR.