### PR TITLE
fix(skillsbench): isolate reverse tunnel ports by run

### DIFF
--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -24,6 +24,8 @@ Optional env:
                                        python3 -m loopx.benchmark_adapters.skillsbench_runner_profile capture
   SKILLSBENCH_LOCAL_CODEX_PROXY_HOST   Local proxy host, default 127.0.0.1
   SKILLSBENCH_LOCAL_CODEX_PROXY_PORT   Local proxy port, default 18180
+  SKILLSBENCH_REMOTE_CODEX_PROXY_PORT  Remote proxy port override; default is
+                                       deterministic and scoped to the run id
   SKILLSBENCH_LOCAL_CODEX_PROXY_COMMAND
                                        Optional private foreground command that
                                        the supervisor owns and restarts when
@@ -172,7 +174,7 @@ fi
 task_id="${task_ids[0]}"
 task_count="${#task_ids[@]}"
 tag="${2:-${SKILLSBENCH_RUN_TAG:-manual}}"
-remote_proxy_port="${3:-${SKILLSBENCH_REMOTE_CODEX_PROXY_PORT:-18180}}"
+remote_proxy_port="${3:-${SKILLSBENCH_REMOTE_CODEX_PROXY_PORT:-}}"
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 runner_profile="${SKILLSBENCH_RUNNER_PROFILE:-}"
@@ -452,6 +454,27 @@ safe_task="${safe_task//_/-}"
 if ((task_count > 1)); then
   safe_task="batch-${task_count}"
 fi
+run_group="skillsbench-codex-cli-goal-xhigh-${safe_task}-${tag}-${stamp}"
+job_name="${safe_task}__codex_cli_goal_xhigh_${tag}_${stamp}"
+if [[ -z "$remote_proxy_port" ]]; then
+  remote_proxy_port="$(
+    python3 - "$run_group" <<'PY'
+import hashlib
+import sys
+
+digest = hashlib.sha256(sys.argv[1].encode("utf-8")).digest()
+print(20000 + (int.from_bytes(digest[:4], "big") % 40000))
+PY
+  )"
+  remote_proxy_port_mode="run_scoped"
+else
+  remote_proxy_port_mode="explicit"
+fi
+if [[ ! "$remote_proxy_port" =~ ^[1-9][0-9]{0,4}$ ]] ||
+  ((10#$remote_proxy_port > 65535)); then
+  echo "remote proxy port must be an integer from 1 through 65535" >&2
+  exit 2
+fi
 
 goal_id="${SKILLSBENCH_GOAL_ID:-loopx-meta}"
 local_run_ledger="${SKILLSBENCH_LOCAL_RUN_LEDGER_PATH:-.local/goals/${goal_id}/skillsbench-ledgers/live-standard-run-ledger.json}"
@@ -703,8 +726,6 @@ if [[ "$skip_current_aggregate_update" == "1" ]]; then
   extra_runner_args+=(--skip-current-aggregate-update)
 fi
 
-run_group="skillsbench-codex-cli-goal-xhigh-${safe_task}-${tag}-${stamp}"
-job_name="${safe_task}__codex_cli_goal_xhigh_${tag}_${stamp}"
 codex_channel_id="$(
   python3 - "$job_name" <<'PY'
 import hashlib
@@ -860,6 +881,7 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'public_output=%s/supervisor.public.json\n' "$public_dir"
   printf 'private_dir=%s\n' "$private_dir"
   printf 'remote_proxy_port=%s\n' "$remote_proxy_port"
+  printf 'remote_proxy_port_mode=%s\n' "$remote_proxy_port_mode"
   printf 'proxy_port_coherence_guard=enforced\n'
   printf 'docker_proxy_host_recorded=false\n'
   printf 'docker_proxy_endpoint_mode=%s\n' "$docker_proxy_endpoint_mode"
@@ -1001,6 +1023,7 @@ job_name=${job_name}
 public_output=${public_dir}/supervisor.public.json
 private_dir=${private_dir}
 remote_proxy_port=${remote_proxy_port}
+remote_proxy_port_mode=${remote_proxy_port_mode}
 docker_proxy_host=${docker_proxy_host}
 docker_proxy_endpoint_mode=${docker_proxy_endpoint_mode}
 docker_api_version=${docker_api_version}

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -10,10 +10,20 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 LAUNCHER = REPO_ROOT / "scripts" / "skillsbench-launch-goal-xhigh.sh"
 
 
+def _dry_run_value(output: str, key: str) -> str:
+    prefix = f"{key}="
+    return next(
+        line.removeprefix(prefix)
+        for line in output.splitlines()
+        if line.startswith(prefix)
+    )
+
+
 def _base_env(tmp_path: Path) -> dict[str, str]:
     env = os.environ.copy()
     env.pop("SKILLSBENCH_RUNNER_PROFILE", None)
     env.pop("SKILLSBENCH_LOCAL_CODEX_PROXY_COMMAND", None)
+    env.pop("SKILLSBENCH_REMOTE_CODEX_PROXY_PORT", None)
     env.update(
         {
             "XDG_STATE_HOME": str(tmp_path / "state"),
@@ -130,13 +140,67 @@ def test_launcher_dry_run_does_not_require_reachable_local_proxy(
     assert "skillsbench_local_proxy_endpoint_unreachable" not in proc.stderr
     assert "docker_proxy_host_recorded=false" in proc.stdout
     assert "proxy_port_coherence_guard=enforced" in proc.stdout
+    remote_port = int(_dry_run_value(proc.stdout, "remote_proxy_port"))
+    assert 20000 <= remote_port <= 59999
+    assert "remote_proxy_port_mode=run_scoped" in proc.stdout
     for expected_arg in (
-        "--remote-forward 127.0.0.1:18180:127.0.0.1:1",
-        "--codex-reverse-proxy-port 18180",
-        "--benchmark-egress-proxy-port 18180",
-        "--container-forwarder-port 18180",
+        f"--remote-forward 127.0.0.1:{remote_port}:127.0.0.1:1",
+        f"--codex-reverse-proxy-port {remote_port}",
+        f"--benchmark-egress-proxy-port {remote_port}",
+        f"--container-forwarder-port {remote_port}",
     ):
         assert expected_arg in proc.stdout
+
+
+def test_launcher_scopes_default_remote_proxy_port_to_run_identity(
+    tmp_path: Path,
+) -> None:
+    env = _base_env(tmp_path)
+
+    def launch(stamp: str) -> subprocess.CompletedProcess[str]:
+        run_env = env | {"SKILLSBENCH_RUN_STAMP": stamp}
+        return subprocess.run(
+            [str(LAUNCHER), "--dry-run", "public-smoke-case", "port-ownership"],
+            cwd=REPO_ROOT,
+            env=run_env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=True,
+        )
+
+    first = launch("20260716T000000CST")
+    repeated = launch("20260716T000000CST")
+    second = launch("20260716T000001CST")
+
+    first_port = _dry_run_value(first.stdout, "remote_proxy_port")
+    assert _dry_run_value(repeated.stdout, "remote_proxy_port") == first_port
+    assert _dry_run_value(second.stdout, "remote_proxy_port") != first_port
+    assert "remote_proxy_port_mode=run_scoped" in first.stdout
+
+
+def test_launcher_preserves_explicit_remote_proxy_port(tmp_path: Path) -> None:
+    env = _base_env(tmp_path)
+
+    proc = subprocess.run(
+        [
+            str(LAUNCHER),
+            "--dry-run",
+            "public-smoke-case",
+            "port-ownership",
+            "18181",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+
+    assert "remote_proxy_port=18181" in proc.stdout
+    assert "remote_proxy_port_mode=explicit" in proc.stdout
+    assert "--remote-forward 127.0.0.1:18181:127.0.0.1:18180" in proc.stdout
 
 
 def test_launcher_fails_before_batch_when_exact_host_sandbox_probe_fails(


### PR DESCRIPTION
## Summary

- derive the default SkillsBench remote proxy port from the run identity
- preserve positional and environment port overrides
- cover deterministic reuse, cross-run isolation, and explicit compatibility

## Motivation

Concurrent SkillsBench supervisors previously shared remote port `18180`. The
launcher's stale-forward cleanup matched that shared destination and forward,
so a new run could terminate a healthy tunnel owned by another run.

## Validation

- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`
- focused launcher tests: 31 passed
- standard LoopX premerge direct checks and four selected canaries passed
- exact-scope change-quality receipt: `cqr_fab9bb682b970da132ee`

## Boundary

The PR changes only public benchmark launcher behavior and focused tests. It
does not launch jobs or change scoring, task semantics, submission behavior,
permissions, or evidence policy. No private state, raw benchmark evidence,
credentials, local paths, or generated logs are included.
