### PR TITLE
fix(skillsbench): scope typed repair effects to uncommitted turns

### DIFF
--- a/loopx/benchmarks/read_models/skillsbench_post_run_debug.py
+++ b/loopx/benchmarks/read_models/skillsbench_post_run_debug.py
@@ -123,8 +123,9 @@ def _skillsbench_turn_transaction_outcome(run: dict[str, Any]) -> dict[str, Any]
         validation_failed_count > 0
         and committed_count < execution_count
         and failed_transaction_with_durable_effect_count == 0
-        and state_written_count == 0
-        and quota_spent_count == 0
+        # Committed prefixes own their effects; later uncommitted Turns must not.
+        and state_written_count == committed_count
+        and quota_spent_count == committed_count
         and counters.get("product_mode_typed_repair_terminal") is True
         and counters.get(
             "product_mode_typed_repair_terminal_receipt_consistent"

--- a/tests/benchmarks/read_models/test_skillsbench_post_run_debug.py
+++ b/tests/benchmarks/read_models/test_skillsbench_post_run_debug.py
@@ -197,6 +197,42 @@ def test_typed_repair_exhaustion_opens_rotation_without_qualifying_turn() -> Non
     )
 
 
+def test_committed_prefix_does_not_hide_effect_free_typed_repair_exhaustion() -> None:
+    compact = _typed_repair_exhausted_compact()
+    executions = compact["loopx_turn_executions"]
+    assert isinstance(executions, list)
+    executions.insert(
+        0,
+        {
+            "schema_version": "loopx_turn_execution_v0",
+            "mode": "run_once",
+            "status": "committed",
+            "result_kind": "validated_progress",
+            "validation": {"status": "progress"},
+            "receipt": {"status": "committed"},
+            "effects": {
+                "host_invoked": True,
+                "state_written": True,
+                "quota_spent": True,
+                "scheduler_acknowledged": False,
+            },
+        },
+    )
+
+    gate = build_skillsbench_post_run_debug_gate(compact)
+
+    transaction = gate["loopx_turn_transaction"]
+    assert transaction["committed_count"] == 1
+    assert transaction["validation_failed_count"] == 2
+    assert transaction["state_written_count"] == 1
+    assert transaction["quota_spent_count"] == 1
+    assert transaction["failed_transaction_with_durable_effect_count"] == 0
+    assert transaction["typed_repair_exhausted"] is True
+    assert transaction["next_case_blocked"] is False
+    assert gate["next_case_gate"] == "open_with_exclusion"
+    assert gate["normal_progress_allowed"] is True
+
+
 def test_unrecognized_typed_repair_terminal_reason_keeps_rotation_blocked() -> None:
     compact = _typed_repair_exhausted_compact()
     counters = compact["interaction_counters"]


### PR DESCRIPTION
## Summary
- allow a committed progress prefix before effect-free typed-repair exhaustion
- keep any durable effect from an uncommitted Turn fail-closed
- add focused committed-prefix regression coverage

## Validation
- `pytest -q tests/benchmarks/read_models`: 35 passed
- `python examples/skillsbench-post-run-debug-gate-smoke.py`: passed
- touched-module `py_compile`: passed
- public compact replay: committed=1, validation-failed=2, no failed durable effects, gate opens with exclusion
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: all direct checks and 6 selected canaries passed; generic benchmark-sensitive manual hold recorded
- change-quality receipt `cqr_150511493d7cb866e081`: valid

## Boundaries
No scoring, task semantics, runner launch, permission, upload, submission, raw benchmark evidence, credentials, local paths, or generated logs changed.