### PR TITLE
fix(skillsbench): type exact-host sandbox preflight failures

### DIFF
--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -66,6 +66,9 @@ Optional env:
                                        control; default codex from local PATH
   SKILLSBENCH_LOCAL_CODEX_SANDBOX      Host Codex sandbox mode; default
                                        workspace-write
+  SKILLSBENCH_EXACT_HOST_CODEX_SANDBOX_PREFLIGHT_TIMEOUT_SEC
+                                       Exact-host sandbox probe timeout;
+                                       default 30
   SKILLSBENCH_LOCAL_CODEX_EXEC_TIMEOUT_SEC
                                        Optional positive per-prompt timeout for
                                        host-local Codex; unset preserves the
@@ -237,6 +240,7 @@ remote_codex_bin="${SKILLSBENCH_REMOTE_CODEX_BIN:-codex}"
 local_codex_split_control="${SKILLSBENCH_LOCAL_CODEX_SPLIT_CONTROL:-0}"
 local_codex_bin="${SKILLSBENCH_LOCAL_CODEX_BIN:-codex}"
 local_codex_sandbox="${SKILLSBENCH_LOCAL_CODEX_SANDBOX:-workspace-write}"
+exact_host_codex_sandbox_preflight_timeout="${SKILLSBENCH_EXACT_HOST_CODEX_SANDBOX_PREFLIGHT_TIMEOUT_SEC:-30}"
 local_codex_exec_timeout="${SKILLSBENCH_LOCAL_CODEX_EXEC_TIMEOUT_SEC:-}"
 outer_timeout="${SKILLSBENCH_OUTER_TIMEOUT_SEC:-}"
 codex_cli_goal_thread_prewarm="${SKILLSBENCH_CLI_GOAL_THREAD_PREWARM:-0}"
@@ -247,6 +251,10 @@ fi
 if [[ -n "$local_codex_exec_timeout" ]] &&
   [[ ! "$local_codex_exec_timeout" =~ ^[1-9][0-9]*$ ]]; then
   echo "SKILLSBENCH_LOCAL_CODEX_EXEC_TIMEOUT_SEC must be a positive integer" >&2
+  exit 2
+fi
+if [[ ! "$exact_host_codex_sandbox_preflight_timeout" =~ ^[1-9][0-9]*$ ]]; then
+  echo "SKILLSBENCH_EXACT_HOST_CODEX_SANDBOX_PREFLIGHT_TIMEOUT_SEC must be a positive integer" >&2
   exit 2
 fi
 if [[ -n "$outer_timeout" ]] &&
@@ -393,7 +401,7 @@ elif [[ "$dry_run" == "false" && "$setup_only_public_preflight" != "1" ]]; then
     exit 2
   fi
   remote_codex_sandbox_probe_py='import shutil, subprocess, sys, tempfile
-codex_bin, sandbox_mode = sys.argv[1:]
+codex_bin, sandbox_mode, timeout_raw = sys.argv[1:]
 with tempfile.TemporaryDirectory(prefix="gh-skillsbench-codex-sandbox-") as tmp:
     try:
         proc = subprocess.run(
@@ -408,19 +416,35 @@ with tempfile.TemporaryDirectory(prefix="gh-skillsbench-codex-sandbox-") as tmp:
             cwd=tmp,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
-            timeout=10,
+            timeout=int(timeout_raw),
             check=False,
         )
-    except (OSError, subprocess.TimeoutExpired):
-        raise SystemExit(1) from None
-raise SystemExit(proc.returncode)'
+    except subprocess.TimeoutExpired:
+        raise SystemExit(124) from None
+    except OSError:
+        raise SystemExit(125) from None
+raise SystemExit(0 if proc.returncode == 0 else 123)'
   printf -v remote_codex_sandbox_probe \
-    '%q -c %q %q %q' \
+    '%q -c %q %q %q %q' \
     python3 "$remote_codex_sandbox_probe_py" \
-    "$remote_codex_bin" "$local_codex_sandbox"
-  if ! ssh "${ssh_command_options[@]}" "$SKILLSBENCH_SSH_DESTINATION" \
+    "$remote_codex_bin" "$local_codex_sandbox" \
+    "$exact_host_codex_sandbox_preflight_timeout"
+  if ssh "${ssh_command_options[@]}" "$SKILLSBENCH_SSH_DESTINATION" \
     "$remote_codex_sandbox_probe" >/dev/null 2>&1; then
-    python3 - "$local_codex_sandbox" "$remote_codex_bin_mode" <<'PY' >&2
+    exact_host_codex_sandbox_preflight="passed"
+  else
+    remote_codex_sandbox_probe_status=$?
+    case "$remote_codex_sandbox_probe_status" in
+      123) remote_codex_sandbox_failure_category="sandbox_command_failed" ;;
+      124) remote_codex_sandbox_failure_category="timeout" ;;
+      125) remote_codex_sandbox_failure_category="execution_unavailable" ;;
+      *) remote_codex_sandbox_failure_category="transport_or_unknown" ;;
+    esac
+    python3 - \
+      "$local_codex_sandbox" \
+      "$remote_codex_bin_mode" \
+      "$remote_codex_sandbox_failure_category" \
+      "$exact_host_codex_sandbox_preflight_timeout" <<'PY' >&2
 import json
 import sys
 
@@ -432,6 +456,8 @@ print(
             "error": "skillsbench_exact_host_codex_sandbox_preflight_failed",
             "sandbox_mode": sys.argv[1],
             "remote_codex_bin_mode": sys.argv[2],
+            "failure_category": sys.argv[3],
+            "timeout_seconds": int(sys.argv[4]),
             "raw_output_recorded": False,
             "remote_path_recorded": False,
             "ssh_destination_recorded": False,
@@ -442,7 +468,6 @@ print(
 PY
     exit 3
   fi
-  exact_host_codex_sandbox_preflight="passed"
 elif [[ "$setup_only_public_preflight" != "1" ]]; then
   exact_host_codex_sandbox_preflight="required"
 fi
@@ -901,6 +926,8 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'outer_timeout_sec=%s\n' "${outer_timeout:-runner-default}"
   printf 'exact_host_codex_sandbox_preflight=%s\n' \
     "$exact_host_codex_sandbox_preflight"
+  printf 'exact_host_codex_sandbox_preflight_timeout_sec=%s\n' \
+    "$exact_host_codex_sandbox_preflight_timeout"
   printf 'codex_cli_goal_thread_prewarm=%s\n' "$codex_cli_goal_thread_prewarm"
   printf 'allow_staged_bootstrap_repair_run=%s\n' "$allow_staged_bootstrap_repair_run"
   printf 'setup_only_public_preflight=%s\n' "$setup_only_public_preflight"
@@ -1036,5 +1063,6 @@ codex_cli_goal_thread_prewarm=${codex_cli_goal_thread_prewarm}
 allow_staged_bootstrap_repair_run=${allow_staged_bootstrap_repair_run}
 setup_only_public_preflight=${setup_only_public_preflight}
 exact_host_codex_sandbox_preflight=${exact_host_codex_sandbox_preflight}
+exact_host_codex_sandbox_preflight_timeout_sec=${exact_host_codex_sandbox_preflight_timeout}
 public_artifact_sync_interval_sec=${public_artifact_sync_interval}
 EOF

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -240,6 +240,7 @@ def test_launcher_fails_before_batch_when_exact_host_sandbox_probe_fails(
     payload = json.loads(proc.stderr)
     assert payload == {
         "error": "skillsbench_exact_host_codex_sandbox_preflight_failed",
+        "failure_category": "transport_or_unknown",
         "ok": False,
         "raw_output_recorded": False,
         "remote_codex_bin_mode": "path_lookup",
@@ -247,9 +248,76 @@ def test_launcher_fails_before_batch_when_exact_host_sandbox_probe_fails(
         "sandbox_mode": "workspace-write",
         "schema_version": "skillsbench_exact_host_codex_sandbox_preflight_v0",
         "ssh_destination_recorded": False,
+        "timeout_seconds": 30,
     }
     assert call_count.read_text(encoding="utf-8") == "3"
     assert "pid=" not in proc.stdout
+
+
+def test_launcher_types_exact_host_sandbox_probe_timeout(tmp_path: Path) -> None:
+    env = _base_env(tmp_path)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    call_count = tmp_path / "ssh-call-count"
+    fake_ssh = fake_bin / "ssh"
+    fake_ssh.write_text(
+        "#!/bin/sh\n"
+        'if [ "$1" = "-G" ]; then exit 0; fi\n'
+        f"count_file={call_count!s}\n"
+        'count=0\n'
+        'if [ -f "$count_file" ]; then count=$(cat "$count_file"); fi\n'
+        'count=$((count + 1))\n'
+        'printf "%s" "$count" > "$count_file"\n'
+        'if [ "$count" -le 2 ]; then exit 0; fi\n'
+        'exit 124\n',
+        encoding="utf-8",
+    )
+    fake_ssh.chmod(0o755)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["SKILLSBENCH_EXACT_HOST_CODEX_SANDBOX_PREFLIGHT_TIMEOUT_SEC"] = "45"
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "public-smoke-case", "exact-host-timeout"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 3, proc
+    payload = json.loads(proc.stderr)
+    assert payload["failure_category"] == "timeout"
+    assert payload["timeout_seconds"] == 45
+    assert payload["raw_output_recorded"] is False
+    assert payload["remote_path_recorded"] is False
+    assert payload["ssh_destination_recorded"] is False
+    assert call_count.read_text(encoding="utf-8") == "3"
+    assert "pid=" not in proc.stdout
+
+
+def test_launcher_rejects_invalid_exact_host_sandbox_probe_timeout(
+    tmp_path: Path,
+) -> None:
+    env = _base_env(tmp_path)
+    env["SKILLSBENCH_EXACT_HOST_CODEX_SANDBOX_PREFLIGHT_TIMEOUT_SEC"] = "0"
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "invalid-timeout"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    assert (
+        "SKILLSBENCH_EXACT_HOST_CODEX_SANDBOX_PREFLIGHT_TIMEOUT_SEC "
+        "must be a positive integer"
+    ) in proc.stderr
 
 
 def test_launcher_fails_before_supervisor_when_runner_connectivity_is_not_ready(


### PR DESCRIPTION
## Summary
- make the exact-host Codex sandbox probe timeout configurable with a conservative 30-second default
- classify timeout, sandbox-command, execution-unavailable, and transport/unknown failures without recording raw output or remote paths
- cover timeout typing, invalid configuration, and existing fail-closed behavior

## Validation
- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`
- `uv run --no-project --with "pytest>=8,<9" pytest -q tests/test_skillsbench_turn_launcher.py` (33 passed)
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: direct checks and 4 selected canaries passed; benchmark-sensitive manual hold acknowledged under the owner-approved benchmark helper self-merge policy
- change-quality receipt `cqr_655854c97a7e869170e9` valid
- public/private boundary scan clean

## Boundary
No scoring, task semantics, submission behavior, permission boundary, or benchmark job launch changes. The probe remains fail-closed and records no raw remote output, remote path, SSH destination, or private benchmark evidence.