### PR TITLE
Fix SkillsBench timeout progress handoff

### DIFF
--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -101,6 +101,12 @@ SAFE_LOOPX_GOAL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,120}$")
 CODEX_EXEC_TRANSPORT_RETRY_LIMIT = 1
 CODEX_EXEC_SESSION_ROLLOVER_LIMIT = 1
 CODEX_EXEC_SAME_SESSION_CONTINUATION_LIMIT = 1
+CODEX_EXEC_PROGRESS_VALIDATION_HANDOFF_CATEGORIES = frozenset(
+    {
+        "codex_exec_timeout",
+        "codex_exec_bridge_idle_timeout",
+    }
+)
 
 
 def _loopx_turn_local_session_root(
@@ -504,13 +510,18 @@ def _codex_exec_progress_validation_handoff_allowed(
     final_message_present: bool,
     turn_deadline: float | None,
 ) -> bool:
+    turn_deadline_expired = bool(
+        turn_deadline is not None and time.monotonic() >= turn_deadline
+    )
     if (
-        category != "codex_exec_bridge_idle_timeout"
+        category not in CODEX_EXEC_PROGRESS_VALIDATION_HANDOFF_CATEGORIES
         or same_session_continuation_scheduled
         or final_message_present
         or bridge_summary_path is None
-        or turn_deadline is not None
-        and time.monotonic() >= turn_deadline
+        or (
+            turn_deadline_expired
+            and category != "codex_exec_timeout"
+        )
         or _bridge_summary_has_inflight_operation(bridge_summary_path)
     ):
         return False
@@ -1284,6 +1295,7 @@ class SkillsBenchLocalAcpRelay:
                             )
                         time.sleep(0.2)
             except subprocess.TimeoutExpired:
+                failure_category = "codex_exec_timeout"
                 stdout_text = (
                     stdout_path.read_text(encoding="utf-8", errors="replace")
                     if stdout_path.exists()
@@ -1293,6 +1305,17 @@ class SkillsBenchLocalAcpRelay:
                     stderr_path.read_text(encoding="utf-8", errors="replace")
                     if stderr_path.exists()
                     else ""
+                )
+                validation_handoff_scheduled = bool(
+                    _bypass_loopx_turn
+                    and self._config.loopx_turn_agent_cli
+                    and _codex_exec_progress_validation_handoff_allowed(
+                        category=failure_category,
+                        bridge_summary_path=bridge_summary_path,
+                        same_session_continuation_scheduled=False,
+                        final_message_present=output_path.exists(),
+                        turn_deadline=_turn_deadline,
+                    )
                 )
                 if bridge_summary_path is not None:
                     self._publish_remote_bridge_agent_operations_trace(
@@ -1307,8 +1330,17 @@ class SkillsBenchLocalAcpRelay:
                     final_message_bytes=(
                         output_path.stat().st_size if output_path.exists() else 0
                     ),
+                    failure_category=failure_category,
+                    independent_validation_handoff_scheduled=(
+                        validation_handoff_scheduled
+                    ),
                 )
-                return _recoverable_codex_turn_failure_message("codex_exec_timeout")
+                if validation_handoff_scheduled:
+                    self._latest_loopx_turn_agent_progress_receipt = (
+                        _bridge_summary_task_progress_receipt(bridge_summary_path)
+                    )
+                    return SKILLSBENCH_TURN_AGENT_VALIDATION_HANDOFF_RESPONSE
+                return _recoverable_codex_turn_failure_message(failure_category)
             finally:
                 self._terminate_bridge_server_process(bridge_server_proc)
             stdout_text = (

--- a/tests/test_skillsbench_turn_runtime.py
+++ b/tests/test_skillsbench_turn_runtime.py
@@ -1109,12 +1109,27 @@ def test_progress_validation_handoff_requires_no_scheduled_continuation(
         final_message_present=False,
         turn_deadline=time.monotonic() + 30,
     )
+    assert acp_relay._codex_exec_progress_validation_handoff_allowed(
+        category="codex_exec_timeout",
+        bridge_summary_path=summary_path,
+        same_session_continuation_scheduled=False,
+        final_message_present=False,
+        turn_deadline=time.monotonic() - 1,
+    )
     assert not acp_relay._codex_exec_progress_validation_handoff_allowed(
         category="codex_exec_bridge_idle_timeout",
         bridge_summary_path=summary_path,
         same_session_continuation_scheduled=True,
         final_message_present=False,
         turn_deadline=time.monotonic() + 30,
+    )
+    summary_path.write_text("{}\n", encoding="utf-8")
+    assert not acp_relay._codex_exec_progress_validation_handoff_allowed(
+        category="codex_exec_timeout",
+        bridge_summary_path=summary_path,
+        same_session_continuation_scheduled=False,
+        final_message_present=False,
+        turn_deadline=time.monotonic() - 1,
     )
 
 
@@ -1156,7 +1171,7 @@ pathlib.Path(sys.argv[output_index]).write_text("bounded turn complete", encodin
             loopx_turn_max_turns=1,
             remote_command_file_bridge_command="synthetic-bridge",
             worker_public_trace_dir=str(trace_dir),
-            bridge_idle_timeout_sec=0.5,
+            bridge_idle_timeout_sec=1,
             timeout_sec=30,
         )
     )
@@ -1298,7 +1313,7 @@ time.sleep(10)
             loopx_turn_max_turns=1,
             remote_command_file_bridge_command="synthetic-bridge",
             worker_public_trace_dir=str(trace_dir),
-            bridge_idle_timeout_sec=0.25,
+            bridge_idle_timeout_sec=1,
             timeout_sec=30,
         )
     )
@@ -1379,6 +1394,118 @@ time.sleep(10)
     )
     assert "private task fixture" not in json.dumps(traces, sort_keys=True)
     assert "private-thread" not in json.dumps(traces, sort_keys=True)
+
+
+def test_skillsbench_turn_timeout_hands_safe_progress_to_validator(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_codex = tmp_path / "fake-codex"
+    fake_codex.write_text(
+        """#!/usr/bin/env python3
+import json
+import time
+
+print(json.dumps({"type": "thread.started", "thread_id": "private-thread"}), flush=True)
+time.sleep(10)
+""",
+        encoding="utf-8",
+    )
+    fake_codex.chmod(0o755)
+    trace_dir = tmp_path / "public-traces"
+    trace_dir.mkdir()
+    relay = SkillsBenchLocalAcpRelay(
+        CodexExecConfig(
+            codex_bin=str(fake_codex),
+            loopx_turn_agent_cli=True,
+            loopx_turn_max_turns=1,
+            remote_command_file_bridge_command="synthetic-bridge",
+            worker_public_trace_dir=str(trace_dir),
+            bridge_idle_timeout_sec=0,
+            timeout_sec=30,
+        )
+    )
+    monkeypatch.setattr(
+        relay,
+        "_consume_remote_bridge_for_solver",
+        lambda: {"ready": True},
+    )
+    monkeypatch.setattr(
+        relay,
+        "_publish_remote_bridge_consumption_trace",
+        lambda _probe: None,
+    )
+    monkeypatch.setattr(
+        relay,
+        "_start_json_file_bridge_server",
+        lambda **_kwargs: ("synthetic-agent-bridge", None),
+    )
+
+    def write_progress_summary(**kwargs: Any) -> Path:
+        kwargs["summary_path"].write_text(
+            json.dumps(
+                {
+                    "record_phase": "complete",
+                    "operation": "run_command",
+                    "task_facing_operation": True,
+                    "success": True,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return kwargs["tmp_path"] / "synthetic-wrapper"
+
+    monkeypatch.setattr(
+        relay,
+        "_write_instrumented_bridge_wrapper",
+        write_progress_summary,
+    )
+    monkeypatch.setattr(
+        relay,
+        "_prompt_with_remote_bridge_packet",
+        lambda prompt, **_kwargs: prompt,
+    )
+    monkeypatch.setattr(
+        relay,
+        "_publish_remote_bridge_agent_operations_trace",
+        lambda **_kwargs: None,
+    )
+
+    result = relay._run_loopx_turn_agent_prompt(
+        "private timeout task fixture",
+        session={"cwd": str(tmp_path), "model": None},
+        session_id="fixture-session",
+        stdout=SimpleNamespace(write=lambda _value: None, flush=lambda: None),
+        turn_deadline=time.monotonic() + 1,
+    )
+
+    assert (
+        result.response_text
+        == runtime.SKILLSBENCH_TURN_AGENT_VALIDATION_HANDOFF_RESPONSE
+    )
+    assert result.progress_evidence["task_facing_operation_count"] == 1
+    assert result.progress_evidence["task_facing_success_count"] == 1
+    assert result.progress_evidence["raw_material_recorded"] is False
+    traces = [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in trace_dir.glob("*.compact.json")
+    ]
+    failure = next(
+        trace
+        for trace in traces
+        if trace.get("trace_kind") == "codex_exec_process_failure"
+    )
+    assert failure["codex_exec_process"]["failure_category"] == "codex_exec_timeout"
+    assert (
+        failure["codex_exec_process"][
+            "independent_validation_handoff_scheduled"
+        ]
+        is True
+    )
+    public_trace_text = json.dumps(traces, sort_keys=True)
+    assert "private timeout task fixture" not in public_trace_text
+    assert "private-thread" not in public_trace_text
 
 
 def test_skillsbench_progress_validation_handoff_is_not_host_completion() -> None:


### PR DESCRIPTION
## Summary
- hand safe task-facing progress from an exhausted Codex exec timeout to independent scored-workspace validation
- keep timeout handoff gated on no final message, no in-flight bridge operation, and public-safe progress evidence
- cover the deadline-expired path and stabilize the existing idle-timeout fixture timing

## Validation
- `python -m pytest tests/test_skillsbench_turn_runtime.py -q` (39 passed)
- `python examples/skillsbench-loopx-turn-agent-cli-smoke.py`
- `ruff check` on both changed files
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: all selected checks passed; benchmark-sensitive manual hold remains and is covered by the standing `benchmark_code_self_merge` / `benchmark_pr_self_merge` approval
- change-quality receipt `cqr_9f36407363200bd3788e` valid

No benchmark job was launched. No scoring, task semantics, submission behavior, permission boundary, raw evidence, or private state changes.