### PR TITLE
fix(skillsbench): preserve preflight retries in launcher

### DIFF
--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -73,6 +73,9 @@ Optional env:
                                        Optional positive per-prompt timeout for
                                        host-local Codex; unset preserves the
                                        runner default
+  SKILLSBENCH_HOST_LOCAL_ACP_CODEX_EXEC_PREFLIGHT_ATTEMPTS
+                                       Positive startup preflight attempts for
+                                       split-control Codex; default 3
   SKILLSBENCH_OUTER_TIMEOUT_SEC         Optional positive runner-wide timeout;
                                        unset preserves the runner default
   SKILLSBENCH_CLI_GOAL_THREAD_PREWARM  Set to 1 to prewarm the persisted Codex
@@ -242,6 +245,7 @@ local_codex_bin="${SKILLSBENCH_LOCAL_CODEX_BIN:-codex}"
 local_codex_sandbox="${SKILLSBENCH_LOCAL_CODEX_SANDBOX:-workspace-write}"
 exact_host_codex_sandbox_preflight_timeout="${SKILLSBENCH_EXACT_HOST_CODEX_SANDBOX_PREFLIGHT_TIMEOUT_SEC:-30}"
 local_codex_exec_timeout="${SKILLSBENCH_LOCAL_CODEX_EXEC_TIMEOUT_SEC:-}"
+host_local_acp_codex_exec_preflight_attempts="${SKILLSBENCH_HOST_LOCAL_ACP_CODEX_EXEC_PREFLIGHT_ATTEMPTS:-3}"
 outer_timeout="${SKILLSBENCH_OUTER_TIMEOUT_SEC:-}"
 codex_cli_goal_thread_prewarm="${SKILLSBENCH_CLI_GOAL_THREAD_PREWARM:-0}"
 if [[ "$codex_cli_goal_thread_prewarm" != "0" && "$codex_cli_goal_thread_prewarm" != "1" ]]; then
@@ -251,6 +255,10 @@ fi
 if [[ -n "$local_codex_exec_timeout" ]] &&
   [[ ! "$local_codex_exec_timeout" =~ ^[1-9][0-9]*$ ]]; then
   echo "SKILLSBENCH_LOCAL_CODEX_EXEC_TIMEOUT_SEC must be a positive integer" >&2
+  exit 2
+fi
+if [[ ! "$host_local_acp_codex_exec_preflight_attempts" =~ ^[1-9][0-9]*$ ]]; then
+  echo "SKILLSBENCH_HOST_LOCAL_ACP_CODEX_EXEC_PREFLIGHT_ATTEMPTS must be a positive integer" >&2
   exit 2
 fi
 if [[ ! "$exact_host_codex_sandbox_preflight_timeout" =~ ^[1-9][0-9]*$ ]]; then
@@ -658,7 +666,8 @@ if [[ "$local_codex_split_control" == "1" ]]; then
   extra_runner_args+=(
     --local-codex-provider reverse-channel
     --host-local-acp-codex-exec-preflight
-    --host-local-acp-codex-exec-preflight-attempts 1
+    --host-local-acp-codex-exec-preflight-attempts
+    "$host_local_acp_codex_exec_preflight_attempts"
   )
 fi
 if [[ -n "$local_codex_exec_timeout" ]]; then
@@ -923,6 +932,8 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'local_codex_sandbox=%s\n' "$local_codex_sandbox"
   printf 'local_codex_exec_timeout_sec=%s\n' \
     "${local_codex_exec_timeout:-runner-default}"
+  printf 'host_local_acp_codex_exec_preflight_attempts=%s\n' \
+    "$host_local_acp_codex_exec_preflight_attempts"
   printf 'outer_timeout_sec=%s\n' "${outer_timeout:-runner-default}"
   printf 'exact_host_codex_sandbox_preflight=%s\n' \
     "$exact_host_codex_sandbox_preflight"

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -397,6 +397,7 @@ def test_launcher_split_control_is_opt_in_and_redacts_provider_values(
     assert "local_codex_split_control=1" in output
     assert "local_codex_provider=reverse_channel" in output
     assert "local_codex_exec_timeout_sec=runner-default" in output
+    assert "host_local_acp_codex_exec_preflight_attempts=3" in output
     assert "outer_timeout_sec=runner-default" in output
     assert "remote_codex_bin_mode=split_control_client" in output
     assert (
@@ -420,6 +421,59 @@ def test_launcher_split_control_is_opt_in_and_redacts_provider_values(
     assert "codex_bridge_client" not in output
     assert "loopx-codex-" not in output
     assert "example.invalid" not in output
+
+
+def test_launcher_wires_explicit_host_local_preflight_attempts(
+    tmp_path: Path,
+) -> None:
+    env = _base_env(tmp_path)
+    env.update(
+        {
+            "SKILLSBENCH_LOCAL_CODEX_SPLIT_CONTROL": "1",
+            "SKILLSBENCH_HOST_LOCAL_ACP_CODEX_EXEC_PREFLIGHT_ATTEMPTS": "2",
+        }
+    )
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "preflight-attempts"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+
+    assert "host_local_acp_codex_exec_preflight_attempts=2" in proc.stdout
+    assert "--host-local-acp-codex-exec-preflight-attempts" in proc.stdout
+
+
+def test_launcher_rejects_invalid_host_local_preflight_attempts(
+    tmp_path: Path,
+) -> None:
+    env = _base_env(tmp_path)
+    env.update(
+        {
+            "SKILLSBENCH_LOCAL_CODEX_SPLIT_CONTROL": "1",
+            "SKILLSBENCH_HOST_LOCAL_ACP_CODEX_EXEC_PREFLIGHT_ATTEMPTS": "0",
+        }
+    )
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "preflight-attempts"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    assert (
+        "SKILLSBENCH_HOST_LOCAL_ACP_CODEX_EXEC_PREFLIGHT_ATTEMPTS must be "
+        "a positive integer"
+    ) in proc.stderr
 
 
 def test_launcher_wires_explicit_local_codex_exec_timeout(


### PR DESCRIPTION
## Summary

- stop collapsing split-control host-local ACP preflight retries to one attempt in the production launcher
- default the launcher to three attempts, matching the runner contract, with an explicit positive-integer environment override
- expose only the safe attempt count in dry-run output and add default, override, and invalid-value coverage

## Validation

- `pytest -q tests/test_skillsbench_turn_launcher.py` (35 passed)
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/skillsbench-loopx-turn-agent-cli-smoke.py`
- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`
- `ruff check tests/test_skillsbench_turn_launcher.py`
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` (4/4 selected canaries passed; expected `benchmark_sensitive` manual hold)
- LoopX change-quality receipt `cqr_05e42e0f2ad9c1b8a8f6` valid

This does not launch benchmark jobs or change scoring, task semantics, leaderboard/submission behavior, permission boundaries, or evidence policy.