### PR TITLE
fix(skillsbench): preserve progress at timeout closeout

### DIFF
--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -101,6 +101,7 @@ SAFE_LOOPX_GOAL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,120}$")
 CODEX_EXEC_TRANSPORT_RETRY_LIMIT = 1
 CODEX_EXEC_SESSION_ROLLOVER_LIMIT = 1
 CODEX_EXEC_SAME_SESSION_CONTINUATION_LIMIT = 1
+CODEX_EXEC_PROGRESS_HANDOFF_SETTLE_TIMEOUT_SEC = 1.0
 CODEX_EXEC_PROGRESS_VALIDATION_HANDOFF_CATEGORIES = frozenset(
     {
         "codex_exec_timeout",
@@ -531,6 +532,25 @@ def _codex_exec_progress_validation_handoff_allowed(
         and receipt.get("task_facing_success_count", 0) > 0
         and receipt.get("raw_material_recorded") is False
     )
+
+
+def _wait_for_bridge_summary_quiescence(
+    bridge_summary_path: Path | None,
+    *,
+    timeout_sec: float = CODEX_EXEC_PROGRESS_HANDOFF_SETTLE_TIMEOUT_SEC,
+    poll_interval_sec: float = 0.05,
+) -> bool:
+    """Let a terminating bridge wrapper finish its final compact record."""
+
+    if bridge_summary_path is None:
+        return False
+    deadline = time.monotonic() + max(0.0, timeout_sec)
+    while _bridge_summary_has_inflight_operation(bridge_summary_path):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        time.sleep(min(max(0.001, poll_interval_sec), remaining))
+    return True
 
 
 def _codex_exec_session_rollover_allowed(
@@ -1306,9 +1326,13 @@ class SkillsBenchLocalAcpRelay:
                     if stderr_path.exists()
                     else ""
                 )
+                validation_handoff_eligible = bool(
+                    _bypass_loopx_turn and self._config.loopx_turn_agent_cli
+                )
+                if validation_handoff_eligible:
+                    _wait_for_bridge_summary_quiescence(bridge_summary_path)
                 validation_handoff_scheduled = bool(
-                    _bypass_loopx_turn
-                    and self._config.loopx_turn_agent_cli
+                    validation_handoff_eligible
                     and _codex_exec_progress_validation_handoff_allowed(
                         category=failure_category,
                         bridge_summary_path=bridge_summary_path,

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -16278,6 +16278,72 @@ def _recover_runner_failure_score_from_verifier_artifact(
     return True
 
 
+def _apply_runner_failure_attempt_accounting_from_public_activity(
+    compact: dict[str, Any],
+    runner_prerequisites: Mapping[str, Any],
+) -> None:
+    """Count a solver attempt when public bridge evidence proves task work."""
+
+    task_operation_count = _nonbool_int(
+        runner_prerequisites.get(
+            "remote_command_file_bridge_agent_task_facing_operation_count"
+        )
+    )
+    raw_task_success_count = runner_prerequisites.get(
+        "remote_command_file_bridge_agent_task_facing_success_count"
+    )
+    if isinstance(raw_task_success_count, int) and not isinstance(
+        raw_task_success_count, bool
+    ):
+        task_success_count = max(0, raw_task_success_count)
+    else:
+        raw_request_count = runner_prerequisites.get(
+            "remote_command_file_bridge_agent_request_count"
+        )
+        raw_success_count = runner_prerequisites.get(
+            "remote_command_file_bridge_agent_success_count"
+        )
+        if (
+            isinstance(raw_request_count, int)
+            and not isinstance(raw_request_count, bool)
+            and raw_request_count >= task_operation_count
+            and isinstance(raw_success_count, int)
+            and not isinstance(raw_success_count, bool)
+            and 0 <= raw_success_count <= raw_request_count
+        ):
+            non_task_operation_count = raw_request_count - task_operation_count
+            task_success_count = max(
+                0,
+                raw_success_count - non_task_operation_count,
+            )
+        else:
+            task_success_count = 0
+    if task_operation_count <= 0 or task_success_count <= 0:
+        return
+
+    from loopx.benchmark_core import (
+        BenchmarkFailureClass,
+        build_benchmark_attempt_accounting,
+        canonical_lifecycle,
+    )
+
+    failure_label = str(compact.get("score_failure_attribution") or "")
+    compact["attempt_accounting"] = build_benchmark_attempt_accounting(
+        lifecycle=canonical_lifecycle(
+            process_started=True,
+            runner_accepted_args=True,
+            job_root_materialized=True,
+            trial_started=True,
+            worker_started=True,
+        ),
+        failure_label=failure_label,
+        failure_class=BenchmarkFailureClass.SOLVER_FAILED,
+        solver_attempted=True,
+        verifier_attempted=False,
+        official_score_attempted=False,
+    )
+
+
 def build_runner_failure_compact(
     args: argparse.Namespace,
     plan: dict[str, Any],
@@ -16420,6 +16486,11 @@ def build_runner_failure_compact(
         "no_raw_trajectory_read": True,
         "no_leaderboard_upload_requested": True,
     }
+    if runner_prerequisites:
+        _apply_runner_failure_attempt_accounting_from_public_activity(
+            compact,
+            runner_prerequisites,
+        )
     reduced = compact_benchmark_run(compact)
     if reduced is None:
         raise RuntimeError("SkillsBench runner failure reducer produced non-compact run")

--- a/tests/test_skillsbench_automation_loop_timeouts.py
+++ b/tests/test_skillsbench_automation_loop_timeouts.py
@@ -9,10 +9,121 @@ from scripts.skillsbench_automation_loop import (
     DEFAULT_HOST_LOCAL_CODEX_BRIDGE_IDLE_TIMEOUT_SEC,
     HOST_LOCAL_ACP_AGENT_TIMEOUT_MARGIN_SEC,
     SkillsBenchLoopXTurnTerminalFailureStall,
+    _apply_runner_failure_attempt_accounting_from_public_activity,
     _await_benchflow_task_with_loopx_turn_closeout_watchdog,
     _effective_local_codex_exec_timeout_sec,
     _loopx_turn_terminal_failure_checkpoint,
+    build_plan,
+    build_runner_failure_compact,
+    parse_args,
 )
+
+
+def test_runner_failure_counts_public_task_activity_as_solver_attempt() -> None:
+    compact = {
+        "score_failure_attribution": (
+            "skillsbench_host_local_acp_codex_exec_failed_codex_exec_timeout"
+        ),
+        "validation": {},
+    }
+
+    _apply_runner_failure_attempt_accounting_from_public_activity(
+        compact,
+        {
+            "remote_command_file_bridge_agent_task_facing_operation_count": 53,
+            "remote_command_file_bridge_agent_task_facing_success_count": 48,
+        },
+    )
+
+    accounting = compact["attempt_accounting"]
+    assert accounting["lifecycle_phase"] == "worker_started"
+    assert accounting["failure_class"] == "solver_failed"
+    assert accounting["launcher_attempt_countable"] is True
+    assert accounting["case_attempt_countable"] is True
+    assert accounting["solver_attempt_countable"] is True
+    assert accounting["verifier_attempt_countable"] is False
+    assert accounting["official_score_attempt_countable"] is False
+
+
+def test_runner_failure_does_not_count_failed_task_activity_as_solver_attempt() -> None:
+    compact = {
+        "score_failure_attribution": (
+            "skillsbench_host_local_acp_codex_exec_failed_codex_exec_timeout"
+        ),
+        "attempt_accounting": {"failure_label": "not_run_adapter_skeleton"},
+    }
+
+    _apply_runner_failure_attempt_accounting_from_public_activity(
+        compact,
+        {
+            "remote_command_file_bridge_agent_request_count": 4,
+            "remote_command_file_bridge_agent_success_count": 3,
+            "remote_command_file_bridge_agent_task_facing_operation_count": 3,
+            "remote_command_file_bridge_agent_task_facing_success_count": 0,
+        },
+    )
+
+    assert compact["attempt_accounting"] == {
+        "failure_label": "not_run_adapter_skeleton"
+    }
+
+
+def test_runner_failure_derives_task_success_lower_bound_from_public_counts() -> None:
+    compact = {
+        "score_failure_attribution": (
+            "skillsbench_host_local_acp_codex_exec_failed_codex_exec_timeout"
+        ),
+    }
+
+    _apply_runner_failure_attempt_accounting_from_public_activity(
+        compact,
+        {
+            "remote_command_file_bridge_agent_request_count": 54,
+            "remote_command_file_bridge_agent_success_count": 49,
+            "remote_command_file_bridge_agent_task_facing_operation_count": 53,
+        },
+    )
+
+    accounting = compact["attempt_accounting"]
+    assert accounting["case_attempt_countable"] is True
+    assert accounting["solver_attempt_countable"] is True
+
+
+def test_runner_failure_compact_reconciles_public_task_activity(tmp_path) -> None:
+    args = parse_args(
+        [
+            "--task-id",
+            "exam-block-sequencing",
+            "--route",
+            "loopx-turn-agent-cli",
+            "--jobs-dir",
+            str(tmp_path / "jobs"),
+            "--job-name",
+            "skillsbench-timeout-countability-fixture",
+        ]
+    )
+    plan = build_plan(args)
+    plan["runner_prerequisites"].update(
+        {
+            "remote_command_file_bridge_agent_operation_trace_satisfied": True,
+            "remote_command_file_bridge_agent_request_count": 54,
+            "remote_command_file_bridge_agent_success_count": 49,
+            "remote_command_file_bridge_agent_task_facing_operation_count": 53,
+        }
+    )
+
+    compact = build_runner_failure_compact(
+        args,
+        plan,
+        TimeoutError("PRIVATE_TIMEOUT_DETAIL_SHOULD_NOT_ESCAPE"),
+    )
+
+    accounting = compact["attempt_accounting"]
+    assert accounting["case_attempt_countable"] is True
+    assert accounting["solver_attempt_countable"] is True
+    assert accounting["verifier_attempt_countable"] is False
+    assert accounting["official_score_attempt_countable"] is False
+    assert "PRIVATE_TIMEOUT_DETAIL_SHOULD_NOT_ESCAPE" not in json.dumps(compact)
 
 
 def _host_local_args(**overrides):

--- a/tests/test_skillsbench_turn_runtime.py
+++ b/tests/test_skillsbench_turn_runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -1125,6 +1126,68 @@ def test_progress_validation_handoff_requires_no_scheduled_continuation(
     )
     summary_path.write_text("{}\n", encoding="utf-8")
     assert not acp_relay._codex_exec_progress_validation_handoff_allowed(
+        category="codex_exec_timeout",
+        bridge_summary_path=summary_path,
+        same_session_continuation_scheduled=False,
+        final_message_present=False,
+        turn_deadline=time.monotonic() - 1,
+    )
+
+
+def test_timeout_handoff_waits_for_bridge_summary_quiescence(
+    tmp_path: Path,
+) -> None:
+    summary_path = tmp_path / "bridge-summary.jsonl"
+    summary_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "record_phase": "complete",
+                        "operation": "write_file",
+                        "task_facing_operation": True,
+                        "durable_task_write": True,
+                        "durable_task_content_changed": True,
+                        "success": True,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "record_phase": "start",
+                        "operation": "run_command",
+                        "task_facing_operation": True,
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    def finish_bridge_record() -> None:
+        time.sleep(0.03)
+        with summary_path.open("a", encoding="utf-8") as handle:
+            handle.write(
+                json.dumps(
+                    {
+                        "record_phase": "complete",
+                        "operation": "run_command",
+                        "task_facing_operation": True,
+                        "success": True,
+                    }
+                )
+                + "\n"
+            )
+
+    writer = threading.Thread(target=finish_bridge_record)
+    writer.start()
+    assert acp_relay._wait_for_bridge_summary_quiescence(
+        summary_path,
+        timeout_sec=0.5,
+        poll_interval_sec=0.005,
+    )
+    writer.join()
+    assert acp_relay._codex_exec_progress_validation_handoff_allowed(
         category="codex_exec_timeout",
         bridge_summary_path=summary_path,
         same_session_continuation_scheduled=False,


### PR DESCRIPTION
## Summary

- let eligible timeout closeout briefly wait for the final public bridge record before validation handoff
- reconcile runner-failure attempt accounting from public task activity without treating verifier or official score as complete

## Validation

- 53 focused pytest cases
- full `examples/skillsbench-benchmark-run-smoke.py`
- LoopX standard premerge: direct checks and all 6 selected canaries passed
- public compact replay against the observed timeout artifact
- change-quality receipt `cqr_0d33e3f8336b95e401ec`

## Boundaries

- no benchmark job launch
- no scoring, task semantics, submission, or permission changes
- no raw evidence, private state, credentials, internal links, or local paths
