### PR TITLE
fix(agents): gate material projection by capability

### DIFF
--- a/docs/reference/protocols/agent-management-projection-v0.md
+++ b/docs/reference/protocols/agent-management-projection-v0.md
@@ -34,7 +34,8 @@ The projection is derived from:
 - compact run history and the agent-scoped evidence ledger;
 - task graph, handoff, and review-packet projections when present.
 - optional prebuilt `agent_material_frontier_v0` packets on the cold-path
-  `agent_material_frontiers` input.
+  `agent_material_frontiers` input, consumed only when the current execution
+  envelope declares the goal-scoped `material_lifecycle` capability.
 
 The projection is stale after any lifecycle event until recomputed. Consumers
 must tolerate missing fields and fall back to existing status/review-packet
@@ -190,8 +191,9 @@ does not create a chat stream, dispatcher queue, approval mechanism, or runtime
 task separate from the source todo.
 
 When the cold path also receives a full `agent_material_frontier_v0` for the
-same agent, the management projection may enrich the typed note as
-`handoff_note_v1`:
+same agent and the caller passes `material_lifecycle` in
+`available_capabilities`, the management projection may enrich the typed note
+as `handoff_note_v1`:
 
 ```json
 {
@@ -228,6 +230,12 @@ authority ownership, or source bodies. A successor rebuilds its own frontier
 from current goal authority and its own agent-scoped requirements and receipts.
 The optional cold-path input does not create an agent row, claim, or task by
 itself.
+
+Material projection is default-off. Without `material_lifecycle`, LoopX
+ignores `agent_material_frontiers` and omits `material_frontier`,
+`handoff_note_v1`, and `source_summary.material_frontier_count`. Capability
+absence is an observed runtime condition, not a user gate: it does not create
+a todo, notification, or authority request.
 
 The cold-path join is scoped by `(goal_id, agent_id)`, not agent identity alone.
 An explicit status goal filter takes precedence, followed by the current todo's
@@ -309,6 +317,9 @@ A valid implementation or fixture should prove:
   by this projection;
 - stale claim is rendered as a warning only;
 - handoff notes reference existing todo/history/evidence ids;
+- material frontier fields are absent without the observed
+  `material_lifecycle` capability and retain their bounded shape when it is
+  present;
 - public fixtures do not include credentials, raw logs, private docs, raw
   trajectories, local absolute paths, or internal-only source material;
 - dashboard consumers remain functional when the projection is absent.

--- a/docs/reference/protocols/agent-material-frontier-v0.md
+++ b/docs/reference/protocols/agent-material-frontier-v0.md
@@ -135,7 +135,11 @@ producer remains unchanged for rows without a frontier.
 The implementation includes the pure frontier builder, a bounded material
 handoff projector, and an optional agent-management cold-path consumer. The
 consumer reads prebuilt packets from `status.agent_material_frontiers`; it does
-not load canonical authority or material bodies by itself.
+not load canonical authority or material bodies by itself. The consumer emits
+material fields only when its current execution envelope declares the
+goal-scoped `material_lifecycle` capability. Missing capability silently keeps
+the material frontier off the agent projection; it does not become a user
+gate.
 
 The implementation intentionally does not add:
 

--- a/examples/control_plane/agent-material-handoff-projection-smoke.py
+++ b/examples/control_plane/agent-material-handoff-projection-smoke.py
@@ -30,6 +30,7 @@ SOURCE_AGENT = "agent-builder"
 SUCCESSOR_AGENT = "agent-reviewer"
 SOURCE_TODO = "todo_material_source"
 SUCCESSOR_TODO = "todo_material_successor"
+MATERIAL_CAPABILITIES = ["material_lifecycle"]
 
 
 def authority_registry() -> dict:
@@ -229,7 +230,14 @@ def management_payload(
 
 def assert_agent_management_cold_path(successor: dict) -> None:
     payload = management_payload(frontiers=[successor])
-    projection = build_agent_management_projection(payload)
+    default_row = build_agent_management_projection(payload)["agents"][0]
+    assert "material_frontier" not in default_row, default_row
+    assert "handoff_note" not in default_row, default_row
+
+    projection = build_agent_management_projection(
+        payload,
+        available_capabilities=MATERIAL_CAPABILITIES,
+    )
     row = projection["agents"][0]
     assert row["agent_id"] == SUCCESSOR_AGENT, row
     assert (
@@ -242,7 +250,8 @@ def assert_agent_management_cold_path(successor: dict) -> None:
 
     other = other_goal_frontier()
     exact = build_agent_management_projection(
-        management_payload(frontiers=[successor, other])
+        management_payload(frontiers=[successor, other]),
+        available_capabilities=MATERIAL_CAPABILITIES,
     )["agents"][0]
     exact_material_ids = {
         ref["material_id"] for ref in exact["material_frontier"]["material_refs"]
@@ -251,7 +260,8 @@ def assert_agent_management_cold_path(successor: dict) -> None:
     assert "other-goal-only" not in exact_material_ids, exact
 
     cross_goal = build_agent_management_projection(
-        management_payload(frontiers=[other])
+        management_payload(frontiers=[other]),
+        available_capabilities=MATERIAL_CAPABILITIES,
     )["agents"][0]
     assert "material_frontier" not in cross_goal, cross_goal
     assert "handoff_note" not in cross_goal, cross_goal
@@ -261,7 +271,8 @@ def assert_agent_management_cold_path(successor: dict) -> None:
             frontiers=[other, successor],
             goal_filter=None,
             goal_ids=[GOAL_ID, OTHER_GOAL_ID],
-        )
+        ),
+        available_capabilities=MATERIAL_CAPABILITIES,
     )["agents"][0]
     assert current_todo["material_frontier"]["summary"] == successor["summary"], current_todo
 
@@ -271,12 +282,16 @@ def assert_agent_management_cold_path(successor: dict) -> None:
             goal_filter=None,
             goal_ids=[GOAL_ID, OTHER_GOAL_ID],
             include_todo=False,
-        )
+        ),
+        available_capabilities=MATERIAL_CAPABILITIES,
     )["agents"][0]
     assert "material_frontier" not in ambiguous, ambiguous
 
     payload.pop("agent_material_frontiers")
-    legacy = build_agent_management_projection(payload)["agents"][0]
+    legacy = build_agent_management_projection(
+        payload,
+        available_capabilities=MATERIAL_CAPABILITIES,
+    )["agents"][0]
     assert "material_frontier" not in legacy, legacy
     assert "handoff_note" not in legacy, legacy
 

--- a/loopx/control_plane/agents/management_projection.py
+++ b/loopx/control_plane/agents/management_projection.py
@@ -4,7 +4,11 @@ from typing import Any, Iterable
 
 from ..runtime.public_safety import public_safe_compact_text
 from ..runtime.time import now_utc, now_utc_iso, parse_timestamp
-from ..todos.contract import normalize_todo_claimed_by, normalize_todo_id
+from ..todos.contract import (
+    normalize_required_capabilities,
+    normalize_todo_claimed_by,
+    normalize_todo_id,
+)
 from ..todos.summary_item import TODO_SUMMARY_SOURCE_KEYS
 from .material_frontier import AGENT_MATERIAL_FRONTIER_SCHEMA_VERSION
 from .material_handoff import (
@@ -21,6 +25,7 @@ MAX_AGENT_TODOS = 8
 MAX_REFS = 1
 MAX_WORKSPACE_SCOPES = 4
 STALE_CLAIM_THRESHOLD_HOURS = 36
+MATERIAL_LIFECYCLE_CAPABILITY = "material_lifecycle"
 
 _TODO_GROUP_LIST_KEYS = tuple(
     dict.fromkeys(
@@ -502,7 +507,11 @@ def _safe_next_action(todo: dict[str, Any] | None) -> str:
     return "Inspect projected todo."
 
 
-def build_agent_management_projection(status_payload: dict[str, Any]) -> dict[str, Any]:
+def build_agent_management_projection(
+    status_payload: dict[str, Any],
+    *,
+    available_capabilities: Any = None,
+) -> dict[str, Any]:
     """Build a read-only agent management view from a status payload.
 
     This is a projection over existing LoopX status/todo/history state. It does
@@ -511,7 +520,14 @@ def build_agent_management_projection(status_payload: dict[str, Any]) -> dict[st
     """
 
     rows_by_agent = _registered_agents(status_payload)
-    material_frontiers = _agent_material_frontiers(status_payload)
+    material_projection_enabled = MATERIAL_LIFECYCLE_CAPABILITY in set(
+        normalize_required_capabilities(available_capabilities)
+    )
+    material_frontiers = (
+        _agent_material_frontiers(status_payload)
+        if material_projection_enabled
+        else {}
+    )
     goal_filter = _compact(status_payload.get("goal_filter"), limit=180)
     seen_todos: set[tuple[str, str, str, str]] = set()
     for todo in _iter_status_todos(status_payload):

--- a/tests/control_plane/test_agent_management_material_capability_gate.py
+++ b/tests/control_plane/test_agent_management_material_capability_gate.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import pytest
+
+from loopx.control_plane.agents.management_projection import (
+    build_agent_management_projection,
+)
+
+
+GOAL_ID = "material-capability-fixture"
+AGENT_ID = "agent-reviewer"
+
+
+def _status_payload() -> dict[str, object]:
+    return {
+        "goal_filter": GOAL_ID,
+        "run_history": {
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "coordination": {"registered_agents": [AGENT_ID]},
+                }
+            ]
+        },
+        "todo_index": {
+            "items": [
+                {
+                    "role": "agent",
+                    "todo_id": "todo_material_review",
+                    "goal_id": GOAL_ID,
+                    "status": "open",
+                    "task_class": "advancement_task",
+                    "claimed_by": AGENT_ID,
+                    "text": "Review the material-aware handoff.",
+                    "handoff_note": {
+                        "schema_version": "handoff_note_v0",
+                        "handoff_id": "handoff_material_review",
+                        "todo_id": "todo_material_review",
+                        "goal_id": GOAL_ID,
+                        "from_agent": "agent-builder",
+                        "to_agent": AGENT_ID,
+                        "intent": "independent_review",
+                        "summary": "Review the bounded implementation evidence.",
+                    },
+                }
+            ]
+        },
+        "agent_material_frontiers": [
+            {
+                "schema_version": "agent_material_frontier_v0",
+                "goal_id": GOAL_ID,
+                "agent_id": AGENT_ID,
+                "items": [
+                    {
+                        "material_id": "runtime-contract",
+                        "state": "required_unread",
+                        "relation": "required",
+                        "purpose": "review the current contract",
+                    }
+                ],
+            }
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    "available_capabilities",
+    [None, [], ["network"], ["external_evidence_poll"]],
+)
+def test_material_frontier_is_not_projected_without_material_capability(
+    available_capabilities: object,
+) -> None:
+    projection = build_agent_management_projection(
+        _status_payload(),
+        available_capabilities=available_capabilities,
+    )
+
+    row = projection["agents"][0]
+    assert "material_frontier" not in row
+    assert "handoff_note" not in row
+    assert "material_frontier_count" not in projection["source_summary"]
+
+
+@pytest.mark.parametrize(
+    "available_capabilities",
+    [["material_lifecycle"], ["network", "material-lifecycle"]],
+)
+def test_material_frontier_is_projected_with_material_capability(
+    available_capabilities: object,
+) -> None:
+    projection = build_agent_management_projection(
+        _status_payload(),
+        available_capabilities=available_capabilities,
+    )
+
+    row = projection["agents"][0]
+    assert row["material_frontier"]["schema_version"] == (
+        "agent_material_handoff_projection_v0"
+    )
+    assert row["material_frontier"]["summary"]["required_unread_count"] == 1
+    assert row["handoff_note"]["schema_version"] == "handoff_note_v1"
+    assert projection["source_summary"]["material_frontier_count"] == 1


### PR DESCRIPTION
## Summary
- keep prebuilt agent material frontiers off the management projection by default
- project bounded material frontier and handoff fields only when `material_lifecycle` is present in the observed capability envelope
- treat a missing capability as silent omission, never a user gate or authority request
- document the contract and cover disabled, unrelated-capability, normalized-name, and enabled cases

## Validation
- focused pytest: 20 passed
- `agent-material-handoff-projection-smoke.py`: passed
- risk-selected `loopx canary premerge --from-git-diff`: 18/18 passed, public boundary clean

The first premerge attempt selected system Python 3.9 inside one nested smoke and failed the repository's Python 3.11+ preflight. Re-running with the repository Python 3.13 explicitly selected passed the failed peer-runtime smoke and the complete risk-selected premerge set.

## Review focus
This changes a control-plane visibility default. Please confirm that the existing goal-scoped, default-off `material_lifecycle` capability is the intended gate; the PR intentionally does not add a second material-read capability or alter material authority/lifecycle logic.