### PR TITLE
feat(change-quality): require simplify evidence

### DIFF
--- a/docs/capabilities/change-quality/README.md
+++ b/docs/capabilities/change-quality/README.md
@@ -48,16 +48,24 @@ Absence of this policy is equivalent to all three values being false.
 ## Protocol
 
 1. `change-quality prepare` hashes the committed, staged, unstaged, and
-   untracked content relative to a base ref. It emits a self-contained
-   `change_quality_prepare_packet_v0`.
-2. A host or model reviews that exact scope using repository instructions and
-   project validators. The result uses `change_quality_agent_result_v0`.
-3. If policy allows it, the host may perform one bounded safe-fix pass. Any edit
+   untracked content relative to a base ref. It emits
+   `change_quality_prepare_packet_v1`.
+2. The packet projects path-only repository context: applicable instruction
+   files, ownership files, build manifests, language hints, and changed surface
+   roots. It does not copy file contents into the control plane.
+3. A host or model reviews that exact scope using ten required lenses: reuse,
+   type/API boundaries, configuration, runtime ownership,
+   quality/simplification, efficiency, error/supervision, test/validation,
+   documentation/comments, and security/release. The result uses
+   `change_quality_agent_result_v1`.
+4. If policy allows it, the host may perform one bounded safe-fix pass. Any edit
    invalidates the old fingerprint, so prepare and final review run again.
-4. `change-quality record --execute` validates the result against the current
-   fingerprint and writes a compact local runtime receipt.
-5. `change-quality verify` checks the current exact scope.
-6. `canary premerge --goal-id <goal-id>` enforces `strict_receipt`.
+5. `change-quality record --execute` requires complete per-lens conclusions,
+   an explicit simplification decision, and typed validation evidence. It
+   validates the result against the current fingerprint and writes a compact
+   local runtime receipt.
+6. `change-quality verify` checks the current exact scope and v1 protocol.
+7. `canary premerge --goal-id <goal-id>` enforces `strict_receipt`.
 
 ```bash
 loopx --format json change-quality prepare \
@@ -74,20 +82,25 @@ loopx canary premerge --from-git-diff --goal-id <goal-id>
 ```
 
 Receipts live under goal runtime state, not in the repository. They retain
-compact findings and validation labels, not raw model transcripts, credentials,
-private context, or validator logs.
+compact findings, per-lens conclusions, simplification decisions, and typed
+validation evidence, not raw model transcripts, credentials, private context,
+or validator logs.
 
 ## Provider Boundary
 
 The packet does not require a particular model, language, framework, or skill
-host. A custom runner may deliver the project-scoped `loopx-change-quality`
-skill or inject equivalent instructions from the same LoopX revision. The
-global installer intentionally skips project-scoped skills. The project still
-owns its tests, lint, type checking, security checks, and repository-specific
-rules.
+host. Its review lenses name engineering outcomes rather than tools. A custom
+runner may deliver the project-scoped `loopx-change-quality` skill or inject
+equivalent instructions from the same LoopX revision. The global installer
+intentionally skips project-scoped skills. The project still owns its tests,
+lint, type checking, security checks, build commands, and repository-specific
+rules; LoopX records which oracles ran and their outcomes instead of pretending
+that one universal checker understands every language.
 
 A blocking finding must be a concrete correctness, security, privacy, contract,
 or required-validation failure. Subjective style advice remains nonblocking.
+A failed validator is independently non-passing even when a reviewer forgot to
+repeat it as a blocker finding.
 
 Turn may carry the packet or receipt reference inside one bounded execution.
 It does not own policy or enforcement. The authoritative merge decision stays
@@ -95,7 +108,9 @@ in `canary premerge`.
 
 ## Initial Scope
 
-The first version deliberately qualifies one final diff with at most one
-safe-fix pass. It does not recursively review reviews, build a model hierarchy,
-or require several agents to reach consensus. Those mechanisms should be added
-only after single-level receipts show a concrete failure they can solve.
+This version deliberately qualifies one final diff with at most one safe-fix
+pass. It does not recursively review reviews, build a model hierarchy, or
+require several agents to reach consensus. Language and build-system hints are
+discovery inputs, not hardcoded validator policy. Repository-native oracle
+selection and cross-language calibration should evolve from observed receipts,
+not from a central list of guessed commands.

--- a/docs/capabilities/change-quality/README.md
+++ b/docs/capabilities/change-quality/README.md
@@ -61,9 +61,12 @@ Absence of this policy is equivalent to all three values being false.
 4. If policy allows it, the host may perform one bounded safe-fix pass. Any edit
    invalidates the old fingerprint, so prepare and final review run again.
 5. `change-quality record --execute` requires complete per-lens conclusions,
-   an explicit simplification decision, and typed validation evidence. It
-   validates the result against the current fingerprint and writes a compact
-   local runtime receipt.
+   the principles from every projected repository instruction file, an
+   explicit simplification decision, and typed validation evidence. Every
+   applicable lens must cite a changed path, instruction, finding, validator,
+   or simplification decision. Repeated generic all-clear summaries are
+   rejected. The command validates the result against the current fingerprint
+   and writes a compact local runtime receipt.
 6. `change-quality verify` checks the current exact scope and v1 protocol.
 7. `canary premerge --goal-id <goal-id>` enforces `strict_receipt`.
 
@@ -83,8 +86,9 @@ loopx canary premerge --from-git-diff --goal-id <goal-id>
 
 Receipts live under goal runtime state, not in the repository. They retain
 compact findings, per-lens conclusions, simplification decisions, and typed
-validation evidence, not raw model transcripts, credentials, private context,
-or validator logs.
+validation evidence. Lens evidence references are typed and cross-checked
+against the exact changed paths and receipt objects. Receipts do not retain raw
+model transcripts, credentials, private context, or validator logs.
 
 ## Provider Boundary
 
@@ -114,3 +118,10 @@ require several agents to reach consensus. Language and build-system hints are
 discovery inputs, not hardcoded validator policy. Repository-native oracle
 selection and cross-language calibration should evolve from observed receipts,
 not from a central list of guessed commands.
+
+The initial semantic calibration uses five public control-plane PRs covering a
+registry boundary extraction, benchmark read-model move, recoverable Turn
+stages, Vision replan repair, and capability-envelope propagation. The replay
+keeps the benchmark-sensitive manual hold independent from receipt success and
+proves that only one coherent safe-fix pass can be reported. These fixtures
+calibrate review behavior; they are not project-specific production policy.

--- a/examples/change-quality-qualification-smoke.py
+++ b/examples/change-quality-qualification-smoke.py
@@ -93,18 +93,31 @@ def main() -> int:
                     "scope_fingerprint": prepared["scope"]["scope_fingerprint"],
                     "reviewed_final_scope": True,
                     "summary": "Exact final scope reviewed.",
+                    "repository_principles": [],
                     "findings": [],
                     "lens_reviews": [
                         {
                             "lens_id": lens_id,
                             "status": "checked",
-                            "summary": "Reviewed with no finding.",
+                            "summary": (
+                                f"{lens_id} was checked against the fixture diff."
+                            ),
                             "finding_codes": [],
+                            "evidence_refs": (
+                                ["decision:fixture-simplification", "path:app.py"]
+                                if lens_id == "quality_simplification"
+                                else (
+                                    ["validator:fixture-smoke"]
+                                    if lens_id == "test_validation"
+                                    else ["path:app.py"]
+                                )
+                            ),
                         }
                         for lens_id in REVIEW_LENS_IDS
                     ],
                     "simplification_decisions": [
                         {
+                            "decision_id": "fixture-simplification",
                             "subject": "final fixture diff",
                             "outcome": "retained",
                             "reason": "The direct assignment is already minimal.",

--- a/examples/change-quality-qualification-smoke.py
+++ b/examples/change-quality-qualification-smoke.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.capabilities.change_quality.receipt import (  # noqa: E402
     CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
+    REVIEW_LENS_IDS,
     build_change_quality_prepare_packet,
     record_change_quality_receipt,
     verify_change_quality_receipt,
@@ -93,9 +94,31 @@ def main() -> int:
                     "reviewed_final_scope": True,
                     "summary": "Exact final scope reviewed.",
                     "findings": [],
+                    "lens_reviews": [
+                        {
+                            "lens_id": lens_id,
+                            "status": "checked",
+                            "summary": "Reviewed with no finding.",
+                            "finding_codes": [],
+                        }
+                        for lens_id in REVIEW_LENS_IDS
+                    ],
+                    "simplification_decisions": [
+                        {
+                            "subject": "final fixture diff",
+                            "outcome": "retained",
+                            "reason": "The direct assignment is already minimal.",
+                        }
+                    ],
                     "safe_fix_applied": False,
                     "safe_fix_passes": 0,
-                    "validations": ["smoke contract passed"],
+                    "validation_evidence": [
+                        {
+                            "validator": "fixture-smoke",
+                            "status": "passed",
+                            "scope": "exact receipt lifecycle",
+                        }
+                    ],
                 }
             ),
             encoding="utf-8",

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -82,22 +82,22 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "doc": "docs/capabilities/change-quality/README.md",
             },
             {
-                "schema_version": "change_quality_prepare_packet_v0",
+                "schema_version": "change_quality_prepare_packet_v1",
                 "module": "loopx.capabilities.change_quality.receipt",
                 "doc": "docs/capabilities/change-quality/README.md",
             },
             {
-                "schema_version": "change_quality_agent_result_v0",
+                "schema_version": "change_quality_agent_result_v1",
+                "module": "loopx.capabilities.change_quality.result",
+                "doc": "docs/capabilities/change-quality/README.md",
+            },
+            {
+                "schema_version": "change_quality_receipt_v1",
                 "module": "loopx.capabilities.change_quality.receipt",
                 "doc": "docs/capabilities/change-quality/README.md",
             },
             {
-                "schema_version": "change_quality_receipt_v0",
-                "module": "loopx.capabilities.change_quality.receipt",
-                "doc": "docs/capabilities/change-quality/README.md",
-            },
-            {
-                "schema_version": "change_quality_receipt_verification_v0",
+                "schema_version": "change_quality_receipt_verification_v1",
                 "module": "loopx.capabilities.change_quality.receipt",
                 "doc": "docs/capabilities/change-quality/README.md",
             },

--- a/loopx/capabilities/change_quality/cli.py
+++ b/loopx/capabilities/change_quality/cli.py
@@ -22,7 +22,9 @@ AddFormat = Callable[[argparse.ArgumentParser], None]
 
 
 def _add_scope_arguments(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--goal-id", required=True, help="Goal whose managed policy applies.")
+    parser.add_argument(
+        "--goal-id", required=True, help="Goal whose managed policy applies."
+    )
     parser.add_argument(
         "--repo-path",
         type=Path,
@@ -61,7 +63,7 @@ def register_change_quality_commands(
         "--result-json",
         type=Path,
         required=True,
-        help="Agent result conforming to change_quality_agent_result_v0.",
+        help="Agent result conforming to change_quality_agent_result_v1.",
     )
     record.add_argument(
         "--execute",

--- a/loopx/capabilities/change_quality/context.py
+++ b/loopx/capabilities/change_quality/context.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from .scope import resolve_git_root
+
+
+CHANGE_QUALITY_REPOSITORY_CONTEXT_SCHEMA_VERSION = (
+    "change_quality_repository_context_v0"
+)
+
+_DIRECTORY_INSTRUCTION_FILES = ("AGENTS.md", "CLAUDE.md")
+_ROOT_INSTRUCTION_FILES = (
+    "CONTRIBUTING.md",
+    ".github/copilot-instructions.md",
+)
+_OWNERSHIP_FILES = (
+    "CODEOWNERS",
+    ".github/CODEOWNERS",
+    ".gitlab/CODEOWNERS",
+)
+_MANIFEST_SIGNALS: dict[str, tuple[tuple[str, ...], str]] = {
+    "pyproject.toml": (("python",), "python-project"),
+    "setup.py": (("python",), "python-setuptools"),
+    "Cargo.toml": (("rust",), "cargo"),
+    "package.json": (("javascript", "typescript"), "node"),
+    "tsconfig.json": (("typescript",), "typescript"),
+    "go.mod": (("go",), "go-modules"),
+    "pom.xml": (("java",), "maven"),
+    "build.gradle": (("java", "kotlin"), "gradle"),
+    "build.gradle.kts": (("java", "kotlin"), "gradle"),
+    "Gemfile": (("ruby",), "bundler"),
+    "Makefile": ((), "make"),
+    "Justfile": ((), "just"),
+    "WORKSPACE": ((), "bazel"),
+    "MODULE.bazel": ((), "bazel"),
+}
+_SUFFIX_LANGUAGE_HINTS = {
+    ".c": "c",
+    ".cc": "cpp",
+    ".cpp": "cpp",
+    ".cs": "csharp",
+    ".go": "go",
+    ".java": "java",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".kt": "kotlin",
+    ".kts": "kotlin",
+    ".m": "objective-c",
+    ".mm": "objective-cpp",
+    ".php": "php",
+    ".py": "python",
+    ".rb": "ruby",
+    ".rs": "rust",
+    ".sh": "shell",
+    ".swift": "swift",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+}
+
+
+def _normalized_changed_paths(changed_files: list[str]) -> list[PurePosixPath]:
+    paths: list[PurePosixPath] = []
+    for value in changed_files:
+        path = PurePosixPath(str(value).replace("\\", "/"))
+        if path.is_absolute() or ".." in path.parts:
+            continue
+        paths.append(path)
+    return paths
+
+
+def _relevant_directories(changed_paths: list[PurePosixPath]) -> list[PurePosixPath]:
+    directories = {PurePosixPath(".")}
+    for path in changed_paths:
+        parent = path.parent
+        while parent != PurePosixPath("."):
+            directories.add(parent)
+            parent = parent.parent
+    return sorted(directories, key=lambda item: (len(item.parts), item.as_posix()))
+
+
+def _existing_repo_ref(repo_root: Path, path: PurePosixPath) -> str | None:
+    candidate = repo_root / path.as_posix()
+    if candidate.is_file():
+        return path.as_posix()
+    return None
+
+
+def build_change_quality_repository_context(
+    *,
+    repo_path: Path,
+    changed_files: list[str],
+) -> dict[str, Any]:
+    """Project safe, path-only repository context for provider-neutral reviewers."""
+    repo_root = resolve_git_root(repo_path)
+    changed_paths = _normalized_changed_paths(changed_files)
+    directories = _relevant_directories(changed_paths)
+
+    instruction_refs: set[str] = set()
+    for directory in directories:
+        for filename in _DIRECTORY_INSTRUCTION_FILES:
+            path = directory / filename
+            if ref := _existing_repo_ref(repo_root, path):
+                instruction_refs.add(ref)
+    for value in _ROOT_INSTRUCTION_FILES:
+        if ref := _existing_repo_ref(repo_root, PurePosixPath(value)):
+            instruction_refs.add(ref)
+
+    ownership_refs = sorted(
+        ref
+        for value in _OWNERSHIP_FILES
+        if (ref := _existing_repo_ref(repo_root, PurePosixPath(value)))
+    )
+
+    manifest_refs: set[str] = set()
+    language_hints = {
+        language
+        for path in changed_paths
+        if (language := _SUFFIX_LANGUAGE_HINTS.get(path.suffix.lower()))
+    }
+    build_system_hints: set[str] = set()
+    for directory in directories:
+        for filename, (languages, build_system) in _MANIFEST_SIGNALS.items():
+            path = directory / filename
+            if ref := _existing_repo_ref(repo_root, path):
+                manifest_refs.add(ref)
+                language_hints.update(languages)
+                build_system_hints.add(build_system)
+
+    changed_surface_roots = sorted(
+        {
+            path.parts[0]
+            for path in changed_paths
+            if path.parts and path.parts[0] not in {"", "."}
+        }
+    )
+    return {
+        "schema_version": CHANGE_QUALITY_REPOSITORY_CONTEXT_SCHEMA_VERSION,
+        "instruction_refs": sorted(instruction_refs),
+        "ownership_refs": ownership_refs,
+        "build_manifest_refs": sorted(manifest_refs),
+        "language_hints": sorted(language_hints),
+        "build_system_hints": sorted(build_system_hints),
+        "changed_surface_roots": changed_surface_roots,
+        "content_included": False,
+    }

--- a/loopx/capabilities/change_quality/receipt.py
+++ b/loopx/capabilities/change_quality/receipt.py
@@ -141,6 +141,10 @@ def build_change_quality_prepare_packet(
                 "scope_fingerprint": scope["scope_fingerprint"],
                 "reviewed_final_scope": True,
                 "summary": "",
+                "repository_principles": [
+                    {"source": path, "principle": ""}
+                    for path in repository_context["instruction_refs"]
+                ],
                 "findings": [],
                 "lens_reviews": [
                     {
@@ -148,11 +152,13 @@ def build_change_quality_prepare_packet(
                         "status": "checked",
                         "summary": "",
                         "finding_codes": [],
+                        "evidence_refs": [],
                     }
                     for lens_id in REVIEW_LENS_IDS
                 ],
                 "simplification_decisions": [
                     {
+                        "decision_id": "",
                         "subject": "",
                         "outcome": "retained",
                         "reason": "",
@@ -196,10 +202,16 @@ def record_change_quality_receipt(
     scope = build_change_quality_scope(repo_path=repo_path, base_ref=base_ref)
     if not scope["changed_files"]:
         raise ValueError("current scope has no changes and does not need a receipt")
+    repository_context = build_change_quality_repository_context(
+        repo_path=repo_path,
+        changed_files=list(scope["changed_files"]),
+    )
     result = normalize_change_quality_result(
         json.loads(result_path.expanduser().read_text(encoding="utf-8")),
         expected_fingerprint=str(scope["scope_fingerprint"]),
         safe_fix_allowed=bool(policy["safe_fix"]),
+        expected_changed_files=list(scope["changed_files"]),
+        expected_instruction_refs=list(repository_context["instruction_refs"]),
     )
     decision, unresolved_blockers = change_quality_result_decision(result)
     receipt_id = f"cqr_{str(scope['scope_fingerprint'])[:20]}"
@@ -241,6 +253,8 @@ def _stored_receipt_is_valid(
     *,
     scope_fingerprint: str,
     safe_fix_allowed: bool,
+    changed_files: list[str],
+    instruction_refs: list[str],
 ) -> bool:
     if not (
         receipt
@@ -256,6 +270,8 @@ def _stored_receipt_is_valid(
             receipt["result"],
             expected_fingerprint=scope_fingerprint,
             safe_fix_allowed=safe_fix_allowed,
+            expected_changed_files=changed_files,
+            expected_instruction_refs=instruction_refs,
         )
     except (TypeError, ValueError):
         return False
@@ -301,6 +317,10 @@ def verify_change_quality_receipt(
         scope_fingerprint=str(scope["scope_fingerprint"]),
     )
     receipt = None
+    repository_context = build_change_quality_repository_context(
+        repo_path=repo_path,
+        changed_files=list(scope["changed_files"]),
+    )
     if path.exists():
         try:
             receipt = read_json(path)
@@ -310,6 +330,8 @@ def verify_change_quality_receipt(
         receipt,
         scope_fingerprint=str(scope["scope_fingerprint"]),
         safe_fix_allowed=bool(policy["safe_fix"]),
+        changed_files=list(scope["changed_files"]),
+        instruction_refs=list(repository_context["instruction_refs"]),
     )
     if receipt_valid:
         status = "valid"

--- a/loopx/capabilities/change_quality/receipt.py
+++ b/loopx/capabilities/change_quality/receipt.py
@@ -5,21 +5,26 @@ import json
 import os
 import tempfile
 from datetime import datetime
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Any
 
-from ...feedback import validate_public_safe_text
 from ...history import validate_goal_id_path_segment
 from ...registry import read_json, registry_goals
+from .context import build_change_quality_repository_context
 from .policy import change_quality_goal_policy
+from .result import (
+    CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
+    REVIEW_LENSES,
+    REVIEW_LENS_IDS,
+    change_quality_result_decision,
+    normalize_change_quality_result,
+)
 from .scope import build_change_quality_scope, resolve_git_root
 
 
-CHANGE_QUALITY_PREPARE_SCHEMA_VERSION = "change_quality_prepare_packet_v0"
-CHANGE_QUALITY_RESULT_SCHEMA_VERSION = "change_quality_agent_result_v0"
-CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION = "change_quality_receipt_v0"
-CHANGE_QUALITY_VERIFY_SCHEMA_VERSION = "change_quality_receipt_verification_v0"
-FINDING_SEVERITIES = frozenset({"blocker", "warning", "advisory"})
+CHANGE_QUALITY_PREPARE_SCHEMA_VERSION = "change_quality_prepare_packet_v1"
+CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION = "change_quality_receipt_v1"
+CHANGE_QUALITY_VERIFY_SCHEMA_VERSION = "change_quality_receipt_verification_v1"
 
 
 def _goal_from_registry(registry_path: Path, goal_id: str) -> dict[str, Any]:
@@ -39,7 +44,13 @@ def _goal_from_registry(registry_path: Path, goal_id: str) -> dict[str, Any]:
 
 def _receipt_root(runtime_root: Path, goal_id: str) -> Path:
     validated_goal_id = validate_goal_id_path_segment(goal_id)
-    return runtime_root.expanduser() / "goals" / validated_goal_id / "change-quality" / "receipts"
+    return (
+        runtime_root.expanduser()
+        / "goals"
+        / validated_goal_id
+        / "change-quality"
+        / "receipts"
+    )
 
 
 def _repo_key(repo_path: Path) -> str:
@@ -78,128 +89,6 @@ def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
         temporary_path.unlink(missing_ok=True)
 
 
-def _bounded_text(value: Any, *, field: str, limit: int) -> str:
-    text = " ".join(str(value or "").strip().split())
-    validate_public_safe_text(field, text)
-    if len(text) > limit:
-        raise ValueError(f"{field} exceeds {limit} characters")
-    return text
-
-
-def _relative_path(value: Any, *, field: str) -> str | None:
-    text = str(value or "").strip().replace("\\", "/")
-    if not text:
-        return None
-    path = PurePosixPath(text)
-    if path.is_absolute() or ".." in path.parts:
-        raise ValueError(f"{field} must be a repo-relative path")
-    validate_public_safe_text(field, text)
-    return path.as_posix()
-
-
-def _normalize_finding(value: Any, *, index: int) -> dict[str, Any]:
-    if not isinstance(value, dict):
-        raise ValueError(f"findings[{index}] must be an object")
-    severity = str(value.get("severity") or "").strip().lower()
-    if severity not in FINDING_SEVERITIES:
-        raise ValueError(
-            f"findings[{index}].severity must be one of {sorted(FINDING_SEVERITIES)}"
-        )
-    code = _bounded_text(
-        value.get("code"),
-        field=f"findings[{index}].code",
-        limit=80,
-    )
-    message = _bounded_text(
-        value.get("message"),
-        field=f"findings[{index}].message",
-        limit=320,
-    )
-    if not code or not message:
-        raise ValueError(f"findings[{index}] requires code and message")
-    finding = {
-        "severity": severity,
-        "code": code,
-        "message": message,
-        "resolved": value.get("resolved") is True,
-    }
-    path = _relative_path(value.get("path"), field=f"findings[{index}].path")
-    if path:
-        finding["path"] = path
-    line = value.get("line")
-    if line is not None:
-        if not isinstance(line, int) or line < 1:
-            raise ValueError(f"findings[{index}].line must be a positive integer")
-        finding["line"] = line
-    return finding
-
-
-def _normalize_result(
-    value: Any,
-    *,
-    expected_fingerprint: str,
-    safe_fix_allowed: bool,
-) -> dict[str, Any]:
-    if not isinstance(value, dict):
-        raise ValueError("result JSON root must be an object")
-    if value.get("schema_version") != CHANGE_QUALITY_RESULT_SCHEMA_VERSION:
-        raise ValueError(
-            f"result schema_version must be {CHANGE_QUALITY_RESULT_SCHEMA_VERSION}"
-        )
-    fingerprint = str(value.get("scope_fingerprint") or "").strip()
-    if fingerprint != expected_fingerprint:
-        raise ValueError(
-            "result scope_fingerprint does not match the current exact diff; "
-            "rerun prepare after every safe fix"
-        )
-    if value.get("reviewed_final_scope") is not True:
-        raise ValueError("result must set reviewed_final_scope=true")
-    safe_fix_applied = value.get("safe_fix_applied") is True
-    if safe_fix_applied and not safe_fix_allowed:
-        raise ValueError("result reports safe_fix_applied but goal policy forbids safe fixes")
-    safe_fix_passes = value.get("safe_fix_passes", 0)
-    if not isinstance(safe_fix_passes, int) or safe_fix_passes not in {0, 1}:
-        raise ValueError("safe_fix_passes must be 0 or 1")
-    if safe_fix_applied and safe_fix_passes != 1:
-        raise ValueError("safe_fix_applied=true requires safe_fix_passes=1")
-    if not safe_fix_applied and safe_fix_passes != 0:
-        raise ValueError("safe_fix_passes=1 requires safe_fix_applied=true")
-    findings = [
-        _normalize_finding(item, index=index)
-        for index, item in enumerate(value.get("findings") or [])
-    ]
-    if len(findings) > 20:
-        raise ValueError("result supports at most 20 findings")
-    validations = [
-        _bounded_text(item, field="validations[]", limit=180)
-        for item in (value.get("validations") or [])[:20]
-    ]
-    validations = [item for item in validations if item]
-    return {
-        "schema_version": CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
-        "scope_fingerprint": fingerprint,
-        "reviewed_final_scope": True,
-        "summary": _bounded_text(value.get("summary"), field="summary", limit=500),
-        "findings": findings,
-        "safe_fix_applied": safe_fix_applied,
-        "safe_fix_passes": safe_fix_passes,
-        "validations": validations,
-    }
-
-
-def _decision(result: dict[str, Any]) -> tuple[str, list[str]]:
-    unresolved_blockers = [
-        str(item["code"])
-        for item in result["findings"]
-        if item["severity"] == "blocker" and item["resolved"] is not True
-    ]
-    return (
-        ("fail", unresolved_blockers)
-        if unresolved_blockers
-        else ("pass", [])
-    )
-
-
 def build_change_quality_prepare_packet(
     *,
     registry_path: Path,
@@ -210,6 +99,10 @@ def build_change_quality_prepare_packet(
     goal = _goal_from_registry(registry_path, goal_id)
     policy = change_quality_goal_policy(goal)
     scope = build_change_quality_scope(repo_path=repo_path, base_ref=base_ref)
+    repository_context = build_change_quality_repository_context(
+        repo_path=repo_path,
+        changed_files=list(scope["changed_files"]),
+    )
     if not policy["enabled"]:
         status = "disabled"
     elif not scope["changed_files"]:
@@ -224,13 +117,17 @@ def build_change_quality_prepare_packet(
         "review_required": status == "review_required",
         "policy": policy,
         "scope": scope,
+        "repository_context": repository_context,
         "agent_contract": {
             "provider_neutral": True,
             "max_safe_fix_passes": 1,
+            "review_lenses": [dict(item) for item in REVIEW_LENSES],
             "instructions": [
-                "Review only the exact changed scope and obey repository-local instructions.",
-                "Preserve intended behavior; prefer deletion, clarity, and established language idioms over new abstraction.",
+                "Review only the exact changed scope and resolve the projected repository instruction and ownership references.",
+                "Record a substantive conclusion for every required review lens; do not emit a generic all-clear.",
+                "Preserve intended behavior; prefer deletion, reuse, clarity, and established language idioms over new abstraction.",
                 "Use blocker only for concrete correctness, security, privacy, contract, or required-validation failures.",
+                "Use repository-native tests, linters, type checkers, and build tools as language-specific oracles.",
                 (
                     "One bounded safe-fix pass is allowed; rerun prepare after edits and review the final scope."
                     if policy["safe_fix"]
@@ -245,9 +142,31 @@ def build_change_quality_prepare_packet(
                 "reviewed_final_scope": True,
                 "summary": "",
                 "findings": [],
+                "lens_reviews": [
+                    {
+                        "lens_id": lens_id,
+                        "status": "checked",
+                        "summary": "",
+                        "finding_codes": [],
+                    }
+                    for lens_id in REVIEW_LENS_IDS
+                ],
+                "simplification_decisions": [
+                    {
+                        "subject": "",
+                        "outcome": "retained",
+                        "reason": "",
+                    }
+                ],
                 "safe_fix_applied": False,
                 "safe_fix_passes": 0,
-                "validations": [],
+                "validation_evidence": [
+                    {
+                        "validator": "",
+                        "status": "passed",
+                        "scope": "",
+                    }
+                ],
             },
         },
         "turn_boundary": {
@@ -277,12 +196,12 @@ def record_change_quality_receipt(
     scope = build_change_quality_scope(repo_path=repo_path, base_ref=base_ref)
     if not scope["changed_files"]:
         raise ValueError("current scope has no changes and does not need a receipt")
-    result = _normalize_result(
+    result = normalize_change_quality_result(
         json.loads(result_path.expanduser().read_text(encoding="utf-8")),
         expected_fingerprint=str(scope["scope_fingerprint"]),
         safe_fix_allowed=bool(policy["safe_fix"]),
     )
-    decision, unresolved_blockers = _decision(result)
+    decision, unresolved_blockers = change_quality_result_decision(result)
     receipt_id = f"cqr_{str(scope['scope_fingerprint'])[:20]}"
     receipt = {
         "schema_version": CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION,
@@ -315,6 +234,33 @@ def record_change_quality_receipt(
         "scope_fingerprint": scope["scope_fingerprint"],
         "receipt": receipt,
     }
+
+
+def _stored_receipt_is_valid(
+    receipt: dict[str, Any] | None,
+    *,
+    scope_fingerprint: str,
+    safe_fix_allowed: bool,
+) -> bool:
+    if not (
+        receipt
+        and receipt.get("schema_version") == CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION
+        and receipt.get("decision") == "pass"
+        and isinstance(receipt.get("result"), dict)
+        and isinstance(receipt.get("scope"), dict)
+        and receipt["scope"].get("scope_fingerprint") == scope_fingerprint
+    ):
+        return False
+    try:
+        normalized = normalize_change_quality_result(
+            receipt["result"],
+            expected_fingerprint=scope_fingerprint,
+            safe_fix_allowed=safe_fix_allowed,
+        )
+    except (TypeError, ValueError):
+        return False
+    decision, unresolved = change_quality_result_decision(normalized)
+    return decision == "pass" and receipt.get("unresolved_blockers") == unresolved
 
 
 def verify_change_quality_receipt(
@@ -360,12 +306,10 @@ def verify_change_quality_receipt(
             receipt = read_json(path)
         except (OSError, ValueError, TypeError, json.JSONDecodeError):
             receipt = None
-    receipt_valid = bool(
-        receipt
-        and receipt.get("schema_version") == CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION
-        and receipt.get("decision") == "pass"
-        and isinstance(receipt.get("scope"), dict)
-        and receipt["scope"].get("scope_fingerprint") == scope["scope_fingerprint"]
+    receipt_valid = _stored_receipt_is_valid(
+        receipt,
+        scope_fingerprint=str(scope["scope_fingerprint"]),
+        safe_fix_allowed=bool(policy["safe_fix"]),
     )
     if receipt_valid:
         status = "valid"

--- a/loopx/capabilities/change_quality/result.py
+++ b/loopx/capabilities/change_quality/result.py
@@ -11,6 +11,9 @@ FINDING_SEVERITIES = frozenset({"blocker", "warning", "advisory"})
 LENS_STATUSES = frozenset({"checked", "finding", "not_applicable"})
 SIMPLIFICATION_OUTCOMES = frozenset({"fixed", "retained", "deferred", "not_applicable"})
 VALIDATION_STATUSES = frozenset({"passed", "failed", "skipped"})
+EVIDENCE_REF_KINDS = frozenset(
+    {"path", "instruction", "finding", "validator", "decision"}
+)
 REVIEW_LENSES = (
     {
         "lens_id": "reuse",
@@ -163,6 +166,42 @@ def _bounded_text_list(
     return result
 
 
+def _normalize_evidence_ref(value: Any, *, field: str) -> str:
+    text = _bounded_text(value, field=field, limit=400)
+    kind, separator, target = text.partition(":")
+    if not separator or kind not in EVIDENCE_REF_KINDS:
+        raise ValueError(
+            f"{field} must use one of "
+            f"{[f'{item}:<ref>' for item in sorted(EVIDENCE_REF_KINDS)]}"
+        )
+    if kind in {"path", "instruction"}:
+        normalized_target = _relative_path(target, field=field)
+    else:
+        normalized_target = _bounded_text(target, field=field, limit=160)
+    if not normalized_target:
+        raise ValueError(f"{field} requires a non-empty reference target")
+    return f"{kind}:{normalized_target}"
+
+
+def _normalize_repository_principle(value: Any, *, index: int) -> dict[str, str]:
+    if not isinstance(value, dict):
+        raise ValueError(f"repository_principles[{index}] must be an object")
+    source = _relative_path(
+        value.get("source"),
+        field=f"repository_principles[{index}].source",
+    )
+    principle = _bounded_text(
+        value.get("principle"),
+        field=f"repository_principles[{index}].principle",
+        limit=320,
+    )
+    if not source or not principle:
+        raise ValueError(
+            f"repository_principles[{index}] requires source and principle"
+        )
+    return {"source": source, "principle": principle}
+
+
 def _normalize_lens_review(value: Any, *, index: int) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError(f"lens_reviews[{index}] must be an object")
@@ -195,11 +234,32 @@ def _normalize_lens_review(value: Any, *, index: int) -> dict[str, Any]:
         raise ValueError(
             f"lens_reviews[{index}] may reference findings only with status=finding"
         )
+    evidence_refs = [
+        _normalize_evidence_ref(
+            item,
+            field=f"lens_reviews[{index}].evidence_refs[]",
+        )
+        for item in _bounded_text_list(
+            value.get("evidence_refs"),
+            field=f"lens_reviews[{index}].evidence_refs",
+            item_limit=400,
+            count_limit=20,
+        )
+    ]
+    if status == "not_applicable" and evidence_refs:
+        raise ValueError(
+            f"lens_reviews[{index}] with status=not_applicable cannot cite evidence"
+        )
+    if status != "not_applicable" and not evidence_refs:
+        raise ValueError(
+            f"lens_reviews[{index}] with status={status} requires evidence_refs"
+        )
     return {
         "lens_id": lens_id,
         "status": status,
         "summary": summary,
         "finding_codes": finding_codes,
+        "evidence_refs": evidence_refs,
     }
 
 
@@ -210,6 +270,11 @@ def _normalize_simplification_decision(
 ) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError(f"simplification_decisions[{index}] must be an object")
+    decision_id = _bounded_text(
+        value.get("decision_id"),
+        field=f"simplification_decisions[{index}].decision_id",
+        limit=80,
+    )
     outcome = str(value.get("outcome") or "").strip().lower()
     if outcome not in SIMPLIFICATION_OUTCOMES:
         raise ValueError(
@@ -226,11 +291,16 @@ def _normalize_simplification_decision(
         field=f"simplification_decisions[{index}].reason",
         limit=320,
     )
-    if not subject or not reason:
+    if not decision_id or not subject or not reason:
         raise ValueError(
-            f"simplification_decisions[{index}] requires subject and reason"
+            f"simplification_decisions[{index}] requires decision_id, subject, and reason"
         )
-    decision = {"subject": subject, "outcome": outcome, "reason": reason}
+    decision = {
+        "decision_id": decision_id,
+        "subject": subject,
+        "outcome": outcome,
+        "reason": reason,
+    }
     path = _relative_path(
         value.get("path"),
         field=f"simplification_decisions[{index}].path",
@@ -295,6 +365,8 @@ def normalize_change_quality_result(
     *,
     expected_fingerprint: str,
     safe_fix_allowed: bool,
+    expected_changed_files: list[str] | None = None,
+    expected_instruction_refs: list[str] | None = None,
 ) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError("result JSON root must be an object")
@@ -322,6 +394,28 @@ def normalize_change_quality_result(
         raise ValueError("safe_fix_applied=true requires safe_fix_passes=1")
     if not safe_fix_applied and safe_fix_passes != 0:
         raise ValueError("safe_fix_passes=1 requires safe_fix_applied=true")
+    raw_principles = value.get("repository_principles")
+    if not isinstance(raw_principles, list):
+        raise ValueError("repository_principles must be an array")
+    if len(raw_principles) > 20:
+        raise ValueError("repository_principles supports at most 20 items")
+    repository_principles = [
+        _normalize_repository_principle(item, index=index)
+        for index, item in enumerate(raw_principles)
+    ]
+    principle_sources = [item["source"] for item in repository_principles]
+    if len(set(principle_sources)) != len(principle_sources):
+        raise ValueError("repository_principles must not repeat a source")
+    if expected_instruction_refs is not None:
+        expected_sources = set(expected_instruction_refs)
+        actual_sources = set(principle_sources)
+        if actual_sources != expected_sources:
+            missing_sources = sorted(expected_sources - actual_sources)
+            unknown_sources = sorted(actual_sources - expected_sources)
+            raise ValueError(
+                "repository_principles must cover the projected instruction refs; "
+                f"missing={missing_sources} unknown={unknown_sources}"
+            )
     findings = [
         _normalize_finding(item, index=index)
         for index, item in enumerate(value.get("findings") or [])
@@ -345,6 +439,13 @@ def normalize_change_quality_result(
     missing_lenses = [lens_id for lens_id in REVIEW_LENS_IDS if lens_id not in lens_map]
     if missing_lenses:
         raise ValueError(f"lens_reviews missing required lenses: {missing_lenses}")
+    summaries = [item["summary"] for item in lens_reviews]
+    if len(set(summaries)) != len(summaries):
+        raise ValueError(
+            "lens_reviews must contain lens-specific summaries, not a repeated generic all-clear"
+        )
+    if not any(item["status"] != "not_applicable" for item in lens_reviews):
+        raise ValueError("at least one review lens must be applicable")
     referenced_codes = {code for lens in lens_reviews for code in lens["finding_codes"]}
     unknown_codes = sorted(referenced_codes - set(finding_codes))
     if unknown_codes:
@@ -366,6 +467,9 @@ def normalize_change_quality_result(
         _normalize_simplification_decision(item, index=index)
         for index, item in enumerate(raw_decisions)
     ]
+    decision_ids = [item["decision_id"] for item in simplification_decisions]
+    if len(set(decision_ids)) != len(decision_ids):
+        raise ValueError("simplification decision ids must be unique")
     fixed_decisions = [
         item for item in simplification_decisions if item["outcome"] == "fixed"
     ]
@@ -387,6 +491,55 @@ def normalize_change_quality_result(
         _normalize_validation_evidence(item, index=index)
         for index, item in enumerate(raw_validation)
     ]
+    validator_ids = [item["validator"] for item in validation_evidence]
+    if len(set(validator_ids)) != len(validator_ids):
+        raise ValueError("validation_evidence validator ids must be unique")
+    evidence_targets = {
+        "path": set(expected_changed_files or []),
+        "instruction": set(principle_sources),
+        "finding": set(finding_codes),
+        "validator": set(validator_ids),
+        "decision": set(decision_ids),
+    }
+    for lens in lens_reviews:
+        refs_by_kind: dict[str, set[str]] = {}
+        for evidence_ref in lens["evidence_refs"]:
+            kind, target = evidence_ref.split(":", 1)
+            refs_by_kind.setdefault(kind, set()).add(target)
+            if kind != "path" and target not in evidence_targets[kind]:
+                raise ValueError(
+                    f"lens {lens['lens_id']} references unknown evidence: {evidence_ref}"
+                )
+            if (
+                kind == "path"
+                and expected_changed_files is not None
+                and target not in evidence_targets["path"]
+            ):
+                raise ValueError(
+                    f"lens {lens['lens_id']} references unchanged path: {target}"
+                )
+        if lens["status"] == "finding" and not set(lens["finding_codes"]).issubset(
+            refs_by_kind.get("finding", set())
+        ):
+            raise ValueError(
+                f"lens {lens['lens_id']} must anchor each finding_code with finding:<code>"
+            )
+        if (
+            lens["lens_id"] == "quality_simplification"
+            and lens["status"] != "not_applicable"
+            and not refs_by_kind.get("decision")
+        ):
+            raise ValueError(
+                "quality_simplification lens requires a decision:<decision_id> reference"
+            )
+        if (
+            lens["lens_id"] == "test_validation"
+            and lens["status"] != "not_applicable"
+            and not refs_by_kind.get("validator")
+        ):
+            raise ValueError(
+                "test_validation lens requires a validator:<validator> reference"
+            )
     summary = _bounded_text(value.get("summary"), field="summary", limit=500)
     if not summary:
         raise ValueError("summary is required")
@@ -395,6 +548,7 @@ def normalize_change_quality_result(
         "scope_fingerprint": fingerprint,
         "reviewed_final_scope": True,
         "summary": summary,
+        "repository_principles": repository_principles,
         "findings": findings,
         "lens_reviews": [lens_map[lens_id] for lens_id in REVIEW_LENS_IDS],
         "simplification_decisions": simplification_decisions,

--- a/loopx/capabilities/change_quality/result.py
+++ b/loopx/capabilities/change_quality/result.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+from typing import Any
+
+from ...feedback import validate_public_safe_text
+
+
+CHANGE_QUALITY_RESULT_SCHEMA_VERSION = "change_quality_agent_result_v1"
+FINDING_SEVERITIES = frozenset({"blocker", "warning", "advisory"})
+LENS_STATUSES = frozenset({"checked", "finding", "not_applicable"})
+SIMPLIFICATION_OUTCOMES = frozenset({"fixed", "retained", "deferred", "not_applicable"})
+VALIDATION_STATUSES = frozenset({"passed", "failed", "skipped"})
+REVIEW_LENSES = (
+    {
+        "lens_id": "reuse",
+        "question": (
+            "Does the change reuse established helpers and durable knowledge "
+            "instead of duplicating them?"
+        ),
+    },
+    {
+        "lens_id": "type_api_boundary",
+        "question": (
+            "Are types, schemas, compatibility windows, and caller-facing "
+            "contracts explicit and coherent?"
+        ),
+    },
+    {
+        "lens_id": "configuration",
+        "question": (
+            "Does configuration stay single-sourced, validated, and free of "
+            "hidden mode coupling?"
+        ),
+    },
+    {
+        "lens_id": "runtime_ownership",
+        "question": (
+            "Are lifecycle, concurrency, state, and side-effect ownership "
+            "placed in the correct runtime boundary?"
+        ),
+    },
+    {
+        "lens_id": "quality_simplification",
+        "question": (
+            "Can the final behavior be expressed with less indirection, "
+            "branching, duplication, or speculative abstraction?"
+        ),
+    },
+    {
+        "lens_id": "efficiency",
+        "question": (
+            "Does the change avoid unnecessary work, unbounded growth, and "
+            "avoidable hot-path cost?"
+        ),
+    },
+    {
+        "lens_id": "error_supervision",
+        "question": (
+            "Are failures observable, actionable, and supervised without "
+            "silent fallback or broad exception plumbing?"
+        ),
+    },
+    {
+        "lens_id": "test_validation",
+        "question": (
+            "Do tests and repository-native validators prove the intended "
+            "semantics, including important negative paths?"
+        ),
+    },
+    {
+        "lens_id": "documentation_comments",
+        "question": (
+            "Do names, comments, and docs explain the current contract without "
+            "stale narration or duplicated truth?"
+        ),
+    },
+    {
+        "lens_id": "security_release",
+        "question": (
+            "Are security, privacy, permissions, migrations, and release "
+            "compatibility handled at the changed boundaries?"
+        ),
+    },
+)
+REVIEW_LENS_IDS = tuple(item["lens_id"] for item in REVIEW_LENSES)
+
+
+def _bounded_text(value: Any, *, field: str, limit: int) -> str:
+    text = " ".join(str(value or "").strip().split())
+    validate_public_safe_text(field, text)
+    if len(text) > limit:
+        raise ValueError(f"{field} exceeds {limit} characters")
+    return text
+
+
+def _relative_path(value: Any, *, field: str) -> str | None:
+    text = str(value or "").strip().replace("\\", "/")
+    if not text:
+        return None
+    path = PurePosixPath(text)
+    if path.is_absolute() or ".." in path.parts:
+        raise ValueError(f"{field} must be a repo-relative path")
+    validate_public_safe_text(field, text)
+    return path.as_posix()
+
+
+def _normalize_finding(value: Any, *, index: int) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"findings[{index}] must be an object")
+    severity = str(value.get("severity") or "").strip().lower()
+    if severity not in FINDING_SEVERITIES:
+        raise ValueError(
+            f"findings[{index}].severity must be one of {sorted(FINDING_SEVERITIES)}"
+        )
+    code = _bounded_text(
+        value.get("code"),
+        field=f"findings[{index}].code",
+        limit=80,
+    )
+    message = _bounded_text(
+        value.get("message"),
+        field=f"findings[{index}].message",
+        limit=320,
+    )
+    if not code or not message:
+        raise ValueError(f"findings[{index}] requires code and message")
+    finding = {
+        "severity": severity,
+        "code": code,
+        "message": message,
+        "resolved": value.get("resolved") is True,
+    }
+    path = _relative_path(value.get("path"), field=f"findings[{index}].path")
+    if path:
+        finding["path"] = path
+    line = value.get("line")
+    if line is not None:
+        if not isinstance(line, int) or line < 1:
+            raise ValueError(f"findings[{index}].line must be a positive integer")
+        finding["line"] = line
+    return finding
+
+
+def _bounded_text_list(
+    value: Any,
+    *,
+    field: str,
+    item_limit: int,
+    count_limit: int,
+) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError(f"{field} must be an array")
+    if len(value) > count_limit:
+        raise ValueError(f"{field} supports at most {count_limit} items")
+    result = [
+        _bounded_text(item, field=f"{field}[]", limit=item_limit) for item in value
+    ]
+    if any(not item for item in result):
+        raise ValueError(f"{field} cannot contain empty values")
+    return result
+
+
+def _normalize_lens_review(value: Any, *, index: int) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"lens_reviews[{index}] must be an object")
+    lens_id = str(value.get("lens_id") or "").strip()
+    if lens_id not in REVIEW_LENS_IDS:
+        raise ValueError(f"lens_reviews[{index}].lens_id is not a required lens")
+    status = str(value.get("status") or "").strip().lower()
+    if status not in LENS_STATUSES:
+        raise ValueError(
+            f"lens_reviews[{index}].status must be one of {sorted(LENS_STATUSES)}"
+        )
+    summary = _bounded_text(
+        value.get("summary"),
+        field=f"lens_reviews[{index}].summary",
+        limit=320,
+    )
+    if not summary:
+        raise ValueError(f"lens_reviews[{index}].summary is required")
+    finding_codes = _bounded_text_list(
+        value.get("finding_codes"),
+        field=f"lens_reviews[{index}].finding_codes",
+        item_limit=80,
+        count_limit=10,
+    )
+    if status == "finding" and not finding_codes:
+        raise ValueError(
+            f"lens_reviews[{index}] with status=finding requires finding_codes"
+        )
+    if status != "finding" and finding_codes:
+        raise ValueError(
+            f"lens_reviews[{index}] may reference findings only with status=finding"
+        )
+    return {
+        "lens_id": lens_id,
+        "status": status,
+        "summary": summary,
+        "finding_codes": finding_codes,
+    }
+
+
+def _normalize_simplification_decision(
+    value: Any,
+    *,
+    index: int,
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"simplification_decisions[{index}] must be an object")
+    outcome = str(value.get("outcome") or "").strip().lower()
+    if outcome not in SIMPLIFICATION_OUTCOMES:
+        raise ValueError(
+            "simplification_decisions"
+            f"[{index}].outcome must be one of {sorted(SIMPLIFICATION_OUTCOMES)}"
+        )
+    subject = _bounded_text(
+        value.get("subject"),
+        field=f"simplification_decisions[{index}].subject",
+        limit=160,
+    )
+    reason = _bounded_text(
+        value.get("reason"),
+        field=f"simplification_decisions[{index}].reason",
+        limit=320,
+    )
+    if not subject or not reason:
+        raise ValueError(
+            f"simplification_decisions[{index}] requires subject and reason"
+        )
+    decision = {"subject": subject, "outcome": outcome, "reason": reason}
+    path = _relative_path(
+        value.get("path"),
+        field=f"simplification_decisions[{index}].path",
+    )
+    if path:
+        decision["path"] = path
+    line = value.get("line")
+    if line is not None:
+        if not isinstance(line, int) or line < 1:
+            raise ValueError(
+                f"simplification_decisions[{index}].line must be a positive integer"
+            )
+        decision["line"] = line
+    return decision
+
+
+def _normalize_validation_evidence(value: Any, *, index: int) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"validation_evidence[{index}] must be an object")
+    status = str(value.get("status") or "").strip().lower()
+    if status not in VALIDATION_STATUSES:
+        raise ValueError(
+            f"validation_evidence[{index}].status must be one of "
+            f"{sorted(VALIDATION_STATUSES)}"
+        )
+    validator = _bounded_text(
+        value.get("validator"),
+        field=f"validation_evidence[{index}].validator",
+        limit=120,
+    )
+    scope = _bounded_text(
+        value.get("scope"),
+        field=f"validation_evidence[{index}].scope",
+        limit=240,
+    )
+    if not validator or not scope:
+        raise ValueError(f"validation_evidence[{index}] requires validator and scope")
+    evidence = {"validator": validator, "status": status, "scope": scope}
+    command = _bounded_text(
+        value.get("command"),
+        field=f"validation_evidence[{index}].command",
+        limit=320,
+    )
+    reason = _bounded_text(
+        value.get("reason"),
+        field=f"validation_evidence[{index}].reason",
+        limit=320,
+    )
+    if command:
+        evidence["command"] = command
+    if reason:
+        evidence["reason"] = reason
+    if status in {"failed", "skipped"} and not reason:
+        raise ValueError(
+            f"validation_evidence[{index}] with status={status} requires reason"
+        )
+    return evidence
+
+
+def normalize_change_quality_result(
+    value: Any,
+    *,
+    expected_fingerprint: str,
+    safe_fix_allowed: bool,
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError("result JSON root must be an object")
+    if value.get("schema_version") != CHANGE_QUALITY_RESULT_SCHEMA_VERSION:
+        raise ValueError(
+            f"result schema_version must be {CHANGE_QUALITY_RESULT_SCHEMA_VERSION}"
+        )
+    fingerprint = str(value.get("scope_fingerprint") or "").strip()
+    if fingerprint != expected_fingerprint:
+        raise ValueError(
+            "result scope_fingerprint does not match the current exact diff; "
+            "rerun prepare after every safe fix"
+        )
+    if value.get("reviewed_final_scope") is not True:
+        raise ValueError("result must set reviewed_final_scope=true")
+    safe_fix_applied = value.get("safe_fix_applied") is True
+    if safe_fix_applied and not safe_fix_allowed:
+        raise ValueError(
+            "result reports safe_fix_applied but goal policy forbids safe fixes"
+        )
+    safe_fix_passes = value.get("safe_fix_passes", 0)
+    if not isinstance(safe_fix_passes, int) or safe_fix_passes not in {0, 1}:
+        raise ValueError("safe_fix_passes must be 0 or 1")
+    if safe_fix_applied and safe_fix_passes != 1:
+        raise ValueError("safe_fix_applied=true requires safe_fix_passes=1")
+    if not safe_fix_applied and safe_fix_passes != 0:
+        raise ValueError("safe_fix_passes=1 requires safe_fix_applied=true")
+    findings = [
+        _normalize_finding(item, index=index)
+        for index, item in enumerate(value.get("findings") or [])
+    ]
+    if len(findings) > 20:
+        raise ValueError("result supports at most 20 findings")
+    finding_codes = [str(item["code"]) for item in findings]
+    if len(set(finding_codes)) != len(finding_codes):
+        raise ValueError("finding codes must be unique")
+
+    lens_values = value.get("lens_reviews")
+    if not isinstance(lens_values, list):
+        raise ValueError("lens_reviews must be an array")
+    lens_reviews = [
+        _normalize_lens_review(item, index=index)
+        for index, item in enumerate(lens_values)
+    ]
+    lens_map = {item["lens_id"]: item for item in lens_reviews}
+    if len(lens_map) != len(lens_reviews):
+        raise ValueError("lens_reviews must not contain duplicate lens_id values")
+    missing_lenses = [lens_id for lens_id in REVIEW_LENS_IDS if lens_id not in lens_map]
+    if missing_lenses:
+        raise ValueError(f"lens_reviews missing required lenses: {missing_lenses}")
+    referenced_codes = {code for lens in lens_reviews for code in lens["finding_codes"]}
+    unknown_codes = sorted(referenced_codes - set(finding_codes))
+    if unknown_codes:
+        raise ValueError(
+            f"lens_reviews reference unknown finding codes: {unknown_codes}"
+        )
+    unclassified_codes = sorted(set(finding_codes) - referenced_codes)
+    if unclassified_codes:
+        raise ValueError(
+            f"findings must be classified by at least one lens: {unclassified_codes}"
+        )
+
+    raw_decisions = value.get("simplification_decisions")
+    if not isinstance(raw_decisions, list) or not raw_decisions:
+        raise ValueError("simplification_decisions must contain at least one item")
+    if len(raw_decisions) > 20:
+        raise ValueError("simplification_decisions supports at most 20 items")
+    simplification_decisions = [
+        _normalize_simplification_decision(item, index=index)
+        for index, item in enumerate(raw_decisions)
+    ]
+    fixed_decisions = [
+        item for item in simplification_decisions if item["outcome"] == "fixed"
+    ]
+    if safe_fix_applied and not fixed_decisions:
+        raise ValueError(
+            "safe_fix_applied=true requires a simplification decision with outcome=fixed"
+        )
+    if fixed_decisions and not safe_fix_applied:
+        raise ValueError(
+            "simplification decision outcome=fixed requires safe_fix_applied=true"
+        )
+
+    raw_validation = value.get("validation_evidence")
+    if not isinstance(raw_validation, list) or not raw_validation:
+        raise ValueError("validation_evidence must contain at least one item")
+    if len(raw_validation) > 20:
+        raise ValueError("validation_evidence supports at most 20 items")
+    validation_evidence = [
+        _normalize_validation_evidence(item, index=index)
+        for index, item in enumerate(raw_validation)
+    ]
+    summary = _bounded_text(value.get("summary"), field="summary", limit=500)
+    if not summary:
+        raise ValueError("summary is required")
+    return {
+        "schema_version": CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
+        "scope_fingerprint": fingerprint,
+        "reviewed_final_scope": True,
+        "summary": summary,
+        "findings": findings,
+        "lens_reviews": [lens_map[lens_id] for lens_id in REVIEW_LENS_IDS],
+        "simplification_decisions": simplification_decisions,
+        "safe_fix_applied": safe_fix_applied,
+        "safe_fix_passes": safe_fix_passes,
+        "validation_evidence": validation_evidence,
+    }
+
+
+def change_quality_result_decision(
+    result: dict[str, Any],
+) -> tuple[str, list[str]]:
+    unresolved_blockers = [
+        str(item["code"])
+        for item in result["findings"]
+        if item["severity"] == "blocker" and item["resolved"] is not True
+    ]
+    failed_validators = [
+        f"validator:{item['validator']}"
+        for item in result["validation_evidence"]
+        if item["status"] == "failed"
+    ]
+    unresolved = [*unresolved_blockers, *failed_validators]
+    return ("fail", unresolved) if unresolved else ("pass", [])

--- a/skills/loopx-change-quality/SKILL.md
+++ b/skills/loopx-change-quality/SKILL.md
@@ -47,15 +47,35 @@ preview an explicit project install; do not fall back to a global copy.
 
 ## Review Rules
 
-Review the final diff for:
+The prepare packet requires one substantive conclusion for each review lens:
 
-- correctness and behavioral regressions;
-- security, privacy, authority, and public/private boundary violations;
-- broken caller contracts, schemas, migrations, and state transitions;
-- missing validation required by the changed surface;
-- unnecessary complexity, duplication of durable knowledge, and abstractions
-  without a shipped call site;
-- language- and framework-specific issues reported by the project's own tools.
+- **reuse:** established helpers and durable knowledge are reused instead of
+  duplicated;
+- **type/API boundary:** types, schemas, compatibility windows, and caller
+  contracts remain explicit and coherent;
+- **configuration:** configuration stays single-sourced, validated, and free
+  of hidden mode coupling;
+- **runtime ownership:** lifecycle, concurrency, state, and side effects live
+  in the correct boundary;
+- **quality/simplification:** unnecessary indirection, branching, duplication,
+  and speculative abstraction are removed or explicitly justified;
+- **efficiency:** hot paths, repeated work, memory growth, and unbounded loops
+  are considered;
+- **error/supervision:** failures remain observable and actionable without
+  silent fallback or blanket exception handling;
+- **test/validation:** tests and repository-native validators prove intended
+  semantics and important negative paths;
+- **documentation/comments:** names, comments, and docs describe current
+  contracts without stale or duplicated narration;
+- **security/release:** security, privacy, permissions, migrations, and release
+  compatibility are handled at changed boundaries.
+
+The packet projects path-only references to applicable repository instructions,
+ownership files, build manifests, language hints, and changed surface roots.
+Resolve and obey those references before reviewing. The packet deliberately
+does not copy repository content or prescribe one language-specific checker.
+Repository tests, linters, type checkers, build tools, and security checks
+remain the language-specific oracles.
 
 Use `blocker` only for a concrete correctness, security, privacy, contract, or
 required-validation failure. Style preferences and speculative redesigns are
@@ -84,7 +104,10 @@ entire new final scope, not only the lines changed by the repair.
 ## Record The Receipt
 
 Write a compact result conforming to the packet's
-`change_quality_agent_result_v0` template. Keep raw transcripts, private paths,
+`change_quality_agent_result_v1` template. The result must include every
+required lens, at least one explicit simplification decision, and typed
+validation evidence. A skipped or failed validator needs a reason; a failed
+validator makes the receipt non-passing. Keep raw transcripts, private paths,
 credentials, and unbounded logs out of the result.
 
 Then record and read back the exact receipt:
@@ -103,8 +126,9 @@ loopx --format json change-quality verify \
   --base-ref origin/main
 ```
 
-A receipt with an unresolved blocker is not passing. A receipt for an earlier
-fingerprint does not qualify a later diff.
+A receipt with an unresolved blocker or failed validator is not passing. A
+receipt for an earlier fingerprint or an earlier receipt protocol does not
+qualify a later diff.
 
 ## Premerge Enforcement
 

--- a/skills/loopx-change-quality/SKILL.md
+++ b/skills/loopx-change-quality/SKILL.md
@@ -77,6 +77,13 @@ does not copy repository content or prescribe one language-specific checker.
 Repository tests, linters, type checkers, build tools, and security checks
 remain the language-specific oracles.
 
+Record one compact `repository_principles` item for every projected instruction
+reference. Every applicable lens must cite typed `evidence_refs` using
+`path:`, `instruction:`, `finding:`, `validator:`, or `decision:`. A
+`quality_simplification` conclusion cites its decision id, and a
+`test_validation` conclusion cites the repository-native validator. Do not
+repeat the same generic all-clear across lenses.
+
 Use `blocker` only for a concrete correctness, security, privacy, contract, or
 required-validation failure. Style preferences and speculative redesigns are
 `warning` or `advisory`, never blockers.
@@ -105,10 +112,11 @@ entire new final scope, not only the lines changed by the repair.
 
 Write a compact result conforming to the packet's
 `change_quality_agent_result_v1` template. The result must include every
-required lens, at least one explicit simplification decision, and typed
-validation evidence. A skipped or failed validator needs a reason; a failed
-validator makes the receipt non-passing. Keep raw transcripts, private paths,
-credentials, and unbounded logs out of the result.
+required lens, projected repository principles, at least one explicit
+simplification decision, typed evidence references, and typed validation
+evidence. A skipped or failed validator needs a reason; a failed validator
+makes the receipt non-passing. Keep raw transcripts, private paths, credentials,
+and unbounded logs out of the result.
 
 Then record and read back the exact receipt:
 

--- a/tests/capabilities/test_change_quality.py
+++ b/tests/capabilities/test_change_quality.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 from pathlib import Path
@@ -19,6 +20,7 @@ from loopx.capabilities.change_quality.receipt import (
     record_change_quality_receipt,
     verify_change_quality_receipt,
 )
+from loopx.capabilities.change_quality.result import normalize_change_quality_result
 from loopx.cli import main
 from loopx.configure_goal import configure_goal
 from loopx.project_skill_delivery import (
@@ -97,6 +99,14 @@ def _result(path: Path, fingerprint: str, **overrides: object) -> Path:
         if isinstance(findings, list)
         else []
     )
+    validation_evidence = overrides.get("validation_evidence")
+    validator_id = (
+        str(validation_evidence[0].get("validator"))
+        if isinstance(validation_evidence, list)
+        and validation_evidence
+        and isinstance(validation_evidence[0], dict)
+        else "fixture"
+    )
     lens_reviews = [
         {
             "lens_id": lens_id,
@@ -108,10 +118,23 @@ def _result(path: Path, fingerprint: str, **overrides: object) -> Path:
             "summary": (
                 "See the referenced findings."
                 if lens_id == "quality_simplification" and finding_codes
-                else "Reviewed with no finding."
+                else f"{lens_id} was reviewed against the exact fixture change."
             ),
             "finding_codes": (
                 finding_codes if lens_id == "quality_simplification" else []
+            ),
+            "evidence_refs": (
+                [
+                    "path:app.py",
+                    *[f"finding:{code}" for code in finding_codes],
+                    "decision:fixture-simplification",
+                ]
+                if lens_id == "quality_simplification"
+                else (
+                    [f"validator:{validator_id}"]
+                    if lens_id == "test_validation"
+                    else ["path:app.py"]
+                )
             ),
         }
         for lens_id in REVIEW_LENS_IDS
@@ -122,10 +145,12 @@ def _result(path: Path, fingerprint: str, **overrides: object) -> Path:
         "scope_fingerprint": fingerprint,
         "reviewed_final_scope": True,
         "summary": "Reviewed the exact final scope.",
+        "repository_principles": [],
         "findings": [],
         "lens_reviews": lens_reviews,
         "simplification_decisions": [
             {
+                "decision_id": "fixture-simplification",
                 "subject": "exact final scope",
                 "outcome": "fixed" if safe_fix_applied else "retained",
                 "reason": (
@@ -236,6 +261,7 @@ def test_result_requires_complete_substantive_lens_coverage(tmp_path: Path) -> N
                 "status": "checked",
                 "summary": "Only one lens was reviewed.",
                 "finding_codes": [],
+                "evidence_refs": ["path:app.py"],
             }
         ],
     )
@@ -266,8 +292,21 @@ def test_lens_findings_must_reference_recorded_findings(tmp_path: Path) -> None:
         {
             "lens_id": lens_id,
             "status": "finding" if lens_id == "reuse" else "checked",
-            "summary": "Review complete.",
+            "summary": f"{lens_id} review complete.",
             "finding_codes": ["missing-helper"] if lens_id == "reuse" else [],
+            "evidence_refs": (
+                ["path:app.py", "finding:missing-helper"]
+                if lens_id == "reuse"
+                else (
+                    ["decision:fixture-simplification", "path:app.py"]
+                    if lens_id == "quality_simplification"
+                    else (
+                        ["validator:fixture"]
+                        if lens_id == "test_validation"
+                        else ["path:app.py"]
+                    )
+                )
+            ),
         }
         for lens_id in REVIEW_LENS_IDS
     ]
@@ -287,6 +326,142 @@ def test_lens_findings_must_reference_recorded_findings(tmp_path: Path) -> None:
             base_ref="HEAD",
             execute=False,
         )
+
+
+def test_result_rejects_repeated_generic_lens_summaries(tmp_path: Path) -> None:
+    repo, registry, runtime_root = _fixture(tmp_path)
+    _enable(registry)
+    (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
+    prepared = build_change_quality_prepare_packet(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        base_ref="HEAD",
+    )
+    generic_reviews = [
+        {
+            "lens_id": lens_id,
+            "status": "checked",
+            "summary": "Reviewed with no finding.",
+            "finding_codes": [],
+            "evidence_refs": (
+                ["decision:fixture-simplification", "path:app.py"]
+                if lens_id == "quality_simplification"
+                else (
+                    ["validator:fixture"]
+                    if lens_id == "test_validation"
+                    else ["path:app.py"]
+                )
+            ),
+        }
+        for lens_id in REVIEW_LENS_IDS
+    ]
+    result_path = _result(
+        tmp_path / "generic.json",
+        prepared["scope"]["scope_fingerprint"],
+        lens_reviews=generic_reviews,
+    )
+
+    with pytest.raises(ValueError, match="generic all-clear"):
+        record_change_quality_receipt(
+            registry_path=registry,
+            runtime_root=runtime_root,
+            goal_id=GOAL_ID,
+            repo_path=repo,
+            result_path=result_path,
+            base_ref="HEAD",
+            execute=False,
+        )
+
+
+def test_result_requires_all_projected_repository_principles(tmp_path: Path) -> None:
+    repo, registry, runtime_root = _fixture(tmp_path)
+    _enable(registry)
+    (repo / "AGENTS.md").write_text("# Review the exact diff.\n", encoding="utf-8")
+    (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
+    prepared = build_change_quality_prepare_packet(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        base_ref="HEAD",
+    )
+    assert prepared["repository_context"]["instruction_refs"] == ["AGENTS.md"]
+    result_path = _result(
+        tmp_path / "missing-principle.json",
+        prepared["scope"]["scope_fingerprint"],
+    )
+
+    with pytest.raises(ValueError, match="projected instruction refs"):
+        record_change_quality_receipt(
+            registry_path=registry,
+            runtime_root=runtime_root,
+            goal_id=GOAL_ID,
+            repo_path=repo,
+            result_path=result_path,
+            base_ref="HEAD",
+            execute=False,
+        )
+
+
+def test_five_pr_calibration_replays_substantive_simplify_receipts() -> None:
+    fixture_path = (
+        Path(__file__).parents[1]
+        / "fixtures"
+        / "change_quality"
+        / "five_pr_calibration.json"
+    )
+    fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+    cases = fixture["cases"]
+
+    assert {case["source"]["pull_request"] for case in cases} == {
+        2590,
+        2593,
+        2594,
+        2597,
+        2602,
+    }
+    assert {
+        case["source"]["pull_request"] for case in cases if case["manual_holds"]
+    } == {2593}
+    assert [
+        case["source"]["pull_request"] for case in cases if case["safe_fix_applied"]
+    ] == [2594]
+
+    for case in cases:
+        fingerprint = hashlib.sha256(
+            json.dumps(case, sort_keys=True).encode("utf-8")
+        ).hexdigest()
+        result = {
+            "schema_version": CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
+            "scope_fingerprint": fingerprint,
+            "reviewed_final_scope": True,
+            "summary": (
+                f"Replayed public PR #{case['source']['pull_request']} "
+                "against the simplify contract."
+            ),
+            "repository_principles": case["repository_principles"],
+            "findings": [],
+            "lens_reviews": case["lens_reviews"],
+            "simplification_decisions": case["simplification_decisions"],
+            "safe_fix_applied": case["safe_fix_applied"],
+            "safe_fix_passes": case["safe_fix_passes"],
+            "validation_evidence": case["validation_evidence"],
+        }
+
+        normalized = normalize_change_quality_result(
+            result,
+            expected_fingerprint=fingerprint,
+            safe_fix_allowed=True,
+            expected_changed_files=case["changed_files"],
+            expected_instruction_refs=[
+                item["source"] for item in case["repository_principles"]
+            ],
+        )
+
+        assert [item["lens_id"] for item in normalized["lens_reviews"]] == list(
+            REVIEW_LENS_IDS
+        )
+        assert normalized["safe_fix_passes"] in {0, 1}
 
 
 def test_failed_validation_cannot_produce_passing_receipt(tmp_path: Path) -> None:

--- a/tests/capabilities/test_change_quality.py
+++ b/tests/capabilities/test_change_quality.py
@@ -14,6 +14,7 @@ from loopx.canary.premerge import (
 from loopx.capabilities.change_quality.policy import change_quality_goal_policy
 from loopx.capabilities.change_quality.receipt import (
     CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
+    REVIEW_LENS_IDS,
     build_change_quality_prepare_packet,
     record_change_quality_receipt,
     verify_change_quality_receipt,
@@ -86,15 +87,63 @@ def _enable(
 
 
 def _result(path: Path, fingerprint: str, **overrides: object) -> Path:
+    findings = overrides.get("findings")
+    finding_codes = (
+        [
+            str(item["code"])
+            for item in findings
+            if isinstance(item, dict) and item.get("code")
+        ]
+        if isinstance(findings, list)
+        else []
+    )
+    lens_reviews = [
+        {
+            "lens_id": lens_id,
+            "status": (
+                "finding"
+                if lens_id == "quality_simplification" and finding_codes
+                else "checked"
+            ),
+            "summary": (
+                "See the referenced findings."
+                if lens_id == "quality_simplification" and finding_codes
+                else "Reviewed with no finding."
+            ),
+            "finding_codes": (
+                finding_codes if lens_id == "quality_simplification" else []
+            ),
+        }
+        for lens_id in REVIEW_LENS_IDS
+    ]
+    safe_fix_applied = overrides.get("safe_fix_applied") is True
     payload = {
         "schema_version": CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
         "scope_fingerprint": fingerprint,
         "reviewed_final_scope": True,
         "summary": "Reviewed the exact final scope.",
         "findings": [],
+        "lens_reviews": lens_reviews,
+        "simplification_decisions": [
+            {
+                "subject": "exact final scope",
+                "outcome": "fixed" if safe_fix_applied else "retained",
+                "reason": (
+                    "Applied the one bounded simplification."
+                    if safe_fix_applied
+                    else "The direct implementation is already cohesive."
+                ),
+            }
+        ],
         "safe_fix_applied": False,
         "safe_fix_passes": 0,
-        "validations": ["fixture validation passed"],
+        "validation_evidence": [
+            {
+                "validator": "fixture",
+                "status": "passed",
+                "scope": "focused change-quality contract",
+            }
+        ],
         **overrides,
     }
     path.write_text(json.dumps(payload), encoding="utf-8")
@@ -126,6 +175,193 @@ def test_policy_defaults_off_and_configures_independent_controls(
         "safe_fix": False,
         "strict_receipt": True,
     }
+
+
+def test_prepare_projects_repository_context_and_required_review_lenses(
+    tmp_path: Path,
+) -> None:
+    repo, registry, _runtime_root = _fixture(tmp_path)
+    _enable(registry)
+    (repo / "AGENTS.md").write_text("# Rules\n", encoding="utf-8")
+    (repo / "pyproject.toml").write_text(
+        "[project]\nname='fixture'\n", encoding="utf-8"
+    )
+    (repo / ".github").mkdir()
+    (repo / ".github" / "CODEOWNERS").write_text("* @fixture\n", encoding="utf-8")
+    source = repo / "src"
+    source.mkdir()
+    (source / "AGENTS.md").write_text("# Source rules\n", encoding="utf-8")
+    (source / "app.py").write_text("value = 2\n", encoding="utf-8")
+
+    prepared = build_change_quality_prepare_packet(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        base_ref="HEAD",
+    )
+
+    context = prepared["repository_context"]
+    assert context["content_included"] is False
+    assert context["instruction_refs"] == ["AGENTS.md", "src/AGENTS.md"]
+    assert context["ownership_refs"] == [".github/CODEOWNERS"]
+    assert context["build_manifest_refs"] == ["pyproject.toml"]
+    assert context["language_hints"] == ["python"]
+    assert context["changed_surface_roots"] == [
+        ".github",
+        "AGENTS.md",
+        "pyproject.toml",
+        "src",
+    ]
+    assert [
+        item["lens_id"] for item in prepared["agent_contract"]["review_lenses"]
+    ] == list(REVIEW_LENS_IDS)
+
+
+def test_result_requires_complete_substantive_lens_coverage(tmp_path: Path) -> None:
+    repo, registry, runtime_root = _fixture(tmp_path)
+    _enable(registry)
+    (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
+    prepared = build_change_quality_prepare_packet(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        base_ref="HEAD",
+    )
+    result_path = _result(
+        tmp_path / "result.json",
+        prepared["scope"]["scope_fingerprint"],
+        lens_reviews=[
+            {
+                "lens_id": REVIEW_LENS_IDS[0],
+                "status": "checked",
+                "summary": "Only one lens was reviewed.",
+                "finding_codes": [],
+            }
+        ],
+    )
+
+    with pytest.raises(ValueError, match="missing required lenses"):
+        record_change_quality_receipt(
+            registry_path=registry,
+            runtime_root=runtime_root,
+            goal_id=GOAL_ID,
+            repo_path=repo,
+            result_path=result_path,
+            base_ref="HEAD",
+            execute=False,
+        )
+
+
+def test_lens_findings_must_reference_recorded_findings(tmp_path: Path) -> None:
+    repo, registry, runtime_root = _fixture(tmp_path)
+    _enable(registry)
+    (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
+    prepared = build_change_quality_prepare_packet(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        base_ref="HEAD",
+    )
+    lens_reviews = [
+        {
+            "lens_id": lens_id,
+            "status": "finding" if lens_id == "reuse" else "checked",
+            "summary": "Review complete.",
+            "finding_codes": ["missing-helper"] if lens_id == "reuse" else [],
+        }
+        for lens_id in REVIEW_LENS_IDS
+    ]
+    result_path = _result(
+        tmp_path / "result.json",
+        prepared["scope"]["scope_fingerprint"],
+        lens_reviews=lens_reviews,
+    )
+
+    with pytest.raises(ValueError, match="unknown finding codes"):
+        record_change_quality_receipt(
+            registry_path=registry,
+            runtime_root=runtime_root,
+            goal_id=GOAL_ID,
+            repo_path=repo,
+            result_path=result_path,
+            base_ref="HEAD",
+            execute=False,
+        )
+
+
+def test_failed_validation_cannot_produce_passing_receipt(tmp_path: Path) -> None:
+    repo, registry, runtime_root = _fixture(tmp_path)
+    _enable(registry)
+    (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
+    prepared = build_change_quality_prepare_packet(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        base_ref="HEAD",
+    )
+    result_path = _result(
+        tmp_path / "result.json",
+        prepared["scope"]["scope_fingerprint"],
+        validation_evidence=[
+            {
+                "validator": "pytest-focused",
+                "status": "failed",
+                "scope": "changed capability tests",
+                "reason": "One contract assertion failed.",
+            }
+        ],
+    )
+
+    recorded = record_change_quality_receipt(
+        registry_path=registry,
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        result_path=result_path,
+        base_ref="HEAD",
+        execute=False,
+    )
+    assert recorded["decision"] == "fail"
+    assert recorded["unresolved_blockers"] == ["validator:pytest-focused"]
+
+
+def test_verification_revalidates_stored_result_semantics(tmp_path: Path) -> None:
+    repo, registry, runtime_root = _fixture(tmp_path)
+    _enable(registry)
+    (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
+    prepared = build_change_quality_prepare_packet(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        base_ref="HEAD",
+    )
+    result_path = _result(
+        tmp_path / "result.json",
+        prepared["scope"]["scope_fingerprint"],
+    )
+    recorded = record_change_quality_receipt(
+        registry_path=registry,
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        result_path=result_path,
+        base_ref="HEAD",
+        execute=True,
+    )
+    receipt_path = Path(recorded["receipt_path"])
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    receipt["result"]["lens_reviews"] = receipt["result"]["lens_reviews"][:-1]
+    receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+
+    verified = verify_change_quality_receipt(
+        registry_path=registry,
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        base_ref="HEAD",
+    )
+    assert verified["status"] == "invalid_receipt"
+    assert verified["ok"] is False
 
 
 def test_exact_scope_receipt_becomes_stale_after_any_diff_change(

--- a/tests/fixtures/change_quality/five_pr_calibration.json
+++ b/tests/fixtures/change_quality/five_pr_calibration.json
@@ -1,0 +1,573 @@
+{
+  "schema_version": "change_quality_five_pr_calibration_v0",
+  "cases": [
+    {
+      "case_id": "pr-2590-registry-boundary-owner",
+      "source": {
+        "pull_request": 2590,
+        "head_oid": "0c05ecd25d51debffb81407c38b58702124d6888"
+      },
+      "changed_files": [
+        "loopx/canary/maintainability_ratchet.py",
+        "loopx/control_plane/quota/goal_boundary.py",
+        "tests/control_plane/test_goal_boundary_resolution.py"
+      ],
+      "repository_principles": [
+        {
+          "source": "AGENTS.md",
+          "principle": "Keep durable state rules in their bounded-context owner and test semantics rather than incidental output."
+        }
+      ],
+      "lens_reviews": [
+        {
+          "lens_id": "reuse",
+          "status": "checked",
+          "summary": "The extracted registry projection reuses the existing capability and checkpoint normalization helpers.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/control_plane/quota/goal_boundary.py"]
+        },
+        {
+          "lens_id": "type_api_boundary",
+          "status": "checked",
+          "summary": "The public goal_boundary signature and optional return contract remain unchanged.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/control_plane/quota/goal_boundary.py"]
+        },
+        {
+          "lens_id": "configuration",
+          "status": "checked",
+          "summary": "Registry coordination remains the single source for scope, capabilities, approvals, and guards.",
+          "finding_codes": [],
+          "evidence_refs": ["path:tests/control_plane/test_goal_boundary_resolution.py"]
+        },
+        {
+          "lens_id": "runtime_ownership",
+          "status": "checked",
+          "summary": "Registry-owned projection is separated from downstream runtime and integration augmentation.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/control_plane/quota/goal_boundary.py"]
+        },
+        {
+          "lens_id": "quality_simplification",
+          "status": "checked",
+          "summary": "One owner-local helper removes branch density without introducing a generic projection framework.",
+          "finding_codes": [],
+          "evidence_refs": [
+            "path:loopx/control_plane/quota/goal_boundary.py",
+            "decision:extract-registry-owner"
+          ]
+        },
+        {
+          "lens_id": "efficiency",
+          "status": "checked",
+          "summary": "The extraction preserves the existing bounded list normalization and adds no repeated I/O.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/control_plane/quota/goal_boundary.py"]
+        },
+        {
+          "lens_id": "error_supervision",
+          "status": "checked",
+          "summary": "Malformed optional registry fields continue to normalize to empty projections instead of broad fallback.",
+          "finding_codes": [],
+          "evidence_refs": ["path:tests/control_plane/test_goal_boundary_resolution.py"]
+        },
+        {
+          "lens_id": "test_validation",
+          "status": "checked",
+          "summary": "Precedence, deduplication, checkpoint activity, and policy fields have direct semantic assertions.",
+          "finding_codes": [],
+          "evidence_refs": ["validator:pr-2590-focused"]
+        },
+        {
+          "lens_id": "documentation_comments",
+          "status": "not_applicable",
+          "summary": "No public documentation contract changes in this internal behavior-preserving extraction.",
+          "finding_codes": [],
+          "evidence_refs": []
+        },
+        {
+          "lens_id": "security_release",
+          "status": "checked",
+          "summary": "Item-local values cannot override registry authority for write scope or capability grants.",
+          "finding_codes": [],
+          "evidence_refs": ["path:tests/control_plane/test_goal_boundary_resolution.py"]
+        }
+      ],
+      "simplification_decisions": [
+        {
+          "decision_id": "extract-registry-owner",
+          "subject": "registry-owned goal boundary fields",
+          "outcome": "retained",
+          "reason": "The helper is a cohesive bounded-context extraction with a shipped caller and direct parity tests.",
+          "path": "loopx/control_plane/quota/goal_boundary.py"
+        }
+      ],
+      "safe_fix_applied": false,
+      "safe_fix_passes": 0,
+      "validation_evidence": [
+        {
+          "validator": "pr-2590-focused",
+          "status": "passed",
+          "scope": "goal boundary precedence, checkpoint authority, and maintainability ratchet"
+        }
+      ],
+      "manual_holds": []
+    },
+    {
+      "case_id": "pr-2593-benchmark-read-model",
+      "source": {
+        "pull_request": 2593,
+        "head_oid": "8b6be03d9b57edc6464a6cd9c1c856e1f5f98ed8"
+      },
+      "changed_files": [
+        "loopx/benchmarks/read_models/benchmark_projection.py",
+        "loopx/canary/maintainability_ratchet.py",
+        "loopx/status.py",
+        "tests/benchmarks/read_models/test_benchmark_projection.py"
+      ],
+      "repository_principles": [
+        {
+          "source": "AGENTS.md",
+          "principle": "Move benchmark projection rules into the benchmark read-model owner while preserving public-safe boundaries and parity."
+        }
+      ],
+      "lens_reviews": [
+        {
+          "lens_id": "reuse",
+          "status": "checked",
+          "summary": "The read model reuses public-safe text, list, numeric, and environment-failure compactors.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/benchmarks/read_models/benchmark_projection.py"]
+        },
+        {
+          "lens_id": "type_api_boundary",
+          "status": "checked",
+          "summary": "The status compact_benchmark_run facade remains the caller-facing API while helpers become directly testable.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/status.py"]
+        },
+        {
+          "lens_id": "configuration",
+          "status": "checked",
+          "summary": "Validation field classes and trial bounds are single-sourced in the benchmark projection module.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/benchmarks/read_models/benchmark_projection.py"]
+        },
+        {
+          "lens_id": "runtime_ownership",
+          "status": "checked",
+          "summary": "Benchmark validation and trial compaction now live with the benchmark read model rather than the global status facade.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/benchmarks/read_models/benchmark_projection.py"]
+        },
+        {
+          "lens_id": "quality_simplification",
+          "status": "checked",
+          "summary": "The move reduces status branch density while keeping the validation and trial rule groups cohesive.",
+          "finding_codes": [],
+          "evidence_refs": [
+            "path:loopx/status.py",
+            "decision:move-benchmark-projection"
+          ]
+        },
+        {
+          "lens_id": "efficiency",
+          "status": "checked",
+          "summary": "Trial projection remains bounded by max_trials and max_list_items and stops once the bound is reached.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/benchmarks/read_models/benchmark_projection.py"]
+        },
+        {
+          "lens_id": "error_supervision",
+          "status": "checked",
+          "summary": "Neutral false flags and missing worker trace or setup failures remain explicit rather than silently disappearing.",
+          "finding_codes": [],
+          "evidence_refs": ["path:tests/benchmarks/read_models/test_benchmark_projection.py"]
+        },
+        {
+          "lens_id": "test_validation",
+          "status": "checked",
+          "summary": "Direct helper tests and facade integration assertions cover neutral, negative, bounded, and public-safe behavior.",
+          "finding_codes": [],
+          "evidence_refs": ["validator:pr-2593-focused"]
+        },
+        {
+          "lens_id": "documentation_comments",
+          "status": "checked",
+          "summary": "Named field groups document the projection contract next to the owning implementation.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/benchmarks/read_models/benchmark_projection.py"]
+        },
+        {
+          "lens_id": "security_release",
+          "status": "checked",
+          "summary": "Public-safe compaction and explicit trial bounds preserve the benchmark evidence boundary.",
+          "finding_codes": [],
+          "evidence_refs": ["path:tests/benchmarks/read_models/test_benchmark_projection.py"]
+        }
+      ],
+      "simplification_decisions": [
+        {
+          "decision_id": "move-benchmark-projection",
+          "subject": "benchmark validation and trial compaction",
+          "outcome": "retained",
+          "reason": "The move collapses one durable rule owner without changing the public facade or creating a universal compactor.",
+          "path": "loopx/benchmarks/read_models/benchmark_projection.py"
+        }
+      ],
+      "safe_fix_applied": false,
+      "safe_fix_passes": 0,
+      "validation_evidence": [
+        {
+          "validator": "pr-2593-focused",
+          "status": "passed",
+          "scope": "benchmark projection helpers, status facade parity, and neighboring benchmark behavior"
+        }
+      ],
+      "manual_holds": ["benchmark_sensitive"]
+    },
+    {
+      "case_id": "pr-2594-recoverable-turn-stages",
+      "source": {
+        "pull_request": 2594,
+        "head_oid": "e07717afca500eaa44139b87ffad2ac560f77026"
+      },
+      "changed_files": [
+        "loopx/canary/maintainability_ratchet.py",
+        "loopx/control_plane/turn_driver/executor.py",
+        "tests/test_loopx_turn_executor.py"
+      ],
+      "repository_principles": [
+        {
+          "source": "AGENTS.md",
+          "principle": "Make control-plane state transitions explicit, preserve recovery semantics, and validate ordered effects with focused tests."
+        }
+      ],
+      "lens_reviews": [
+        {
+          "lens_id": "reuse",
+          "status": "checked",
+          "summary": "The stage helpers retain existing journal, receipt, validation, callback, and execution-payload helpers.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/control_plane/turn_driver/executor.py"]
+        },
+        {
+          "lens_id": "type_api_boundary",
+          "status": "checked",
+          "summary": "run_loopx_turn_once keeps its external signature while internal stages return explicit typed tuples or payloads.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/control_plane/turn_driver/executor.py"]
+        },
+        {
+          "lens_id": "configuration",
+          "status": "not_applicable",
+          "summary": "This extraction changes no configuration source or execution mode selection.",
+          "finding_codes": [],
+          "evidence_refs": []
+        },
+        {
+          "lens_id": "runtime_ownership",
+          "status": "checked",
+          "summary": "Host result, task validation, and transaction closeout each own one ordered recoverable stage.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/control_plane/turn_driver/executor.py"]
+        },
+        {
+          "lens_id": "quality_simplification",
+          "status": "checked",
+          "summary": "Three cohesive stages replace one oversized orchestrator and the bounded repair preserves mutable callback results.",
+          "finding_codes": [],
+          "evidence_refs": [
+            "path:loopx/control_plane/turn_driver/executor.py",
+            "decision:preserve-callback-mutation"
+          ]
+        },
+        {
+          "lens_id": "efficiency",
+          "status": "checked",
+          "summary": "Recovery still skips completed phases and does not repeat host, writeback, or spend effects.",
+          "finding_codes": [],
+          "evidence_refs": ["path:tests/test_loopx_turn_executor.py"]
+        },
+        {
+          "lens_id": "error_supervision",
+          "status": "checked",
+          "summary": "Each stage records its failed phase, reason, receipt, and durable journal before returning.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/control_plane/turn_driver/executor.py"]
+        },
+        {
+          "lens_id": "test_validation",
+          "status": "checked",
+          "summary": "Interrupted writeback and spend recovery assert exact completed-phase prefixes and effect replay behavior.",
+          "finding_codes": [],
+          "evidence_refs": ["validator:pr-2594-focused"]
+        },
+        {
+          "lens_id": "documentation_comments",
+          "status": "checked",
+          "summary": "Stage helper names expose transaction boundaries without adding parallel prose truth.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/control_plane/turn_driver/executor.py"]
+        },
+        {
+          "lens_id": "security_release",
+          "status": "checked",
+          "summary": "Writeback still precedes quota spend and scheduler apply or acknowledgement on every resumed path.",
+          "finding_codes": [],
+          "evidence_refs": ["path:tests/test_loopx_turn_executor.py"]
+        }
+      ],
+      "simplification_decisions": [
+        {
+          "decision_id": "preserve-callback-mutation",
+          "subject": "transaction closeout callback payload handling",
+          "outcome": "fixed",
+          "reason": "The single safe-fix pass kept callback mutation semantics while retaining the three-stage extraction.",
+          "path": "loopx/control_plane/turn_driver/executor.py"
+        }
+      ],
+      "safe_fix_applied": true,
+      "safe_fix_passes": 1,
+      "validation_evidence": [
+        {
+          "validator": "pr-2594-focused",
+          "status": "passed",
+          "scope": "Turn executor and driver recovery semantics plus maintainability ratchet"
+        }
+      ],
+      "manual_holds": []
+    },
+    {
+      "case_id": "pr-2597-repeat-vision-replan",
+      "source": {
+        "pull_request": 2597,
+        "head_oid": "82d90a00b61c134850234b37711ede010d9a22f9"
+      },
+      "changed_files": [
+        "loopx/control_plane/goals/goal_frontier.py",
+        "tests/control_plane/test_goal_vision_blocked_successor.py"
+      ],
+      "repository_principles": [
+        {
+          "source": "AGENTS.md",
+          "principle": "Represent goal-frontier invariants once and test legal and illegal transitions instead of preserving contradictory guidance."
+        }
+      ],
+      "lens_reviews": [
+        {
+          "lens_id": "reuse",
+          "status": "checked",
+          "summary": "The same repeat-Vision predicate and satisfying delta-kind tuple drive ACK validation and guidance alignment.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/control_plane/goals/goal_frontier.py"]
+        },
+        {
+          "lens_id": "type_api_boundary",
+          "status": "checked",
+          "summary": "The obligation projection adds explicit satisfying delta kinds without changing the existing ACK schema.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/control_plane/goals/goal_frontier.py"]
+        },
+        {
+          "lens_id": "configuration",
+          "status": "not_applicable",
+          "summary": "The change is selected from persisted Vision advancement policy rather than a new configuration flag.",
+          "finding_codes": [],
+          "evidence_refs": []
+        },
+        {
+          "lens_id": "runtime_ownership",
+          "status": "checked",
+          "summary": "Goal-frontier projection owns both replan acceptance and the guidance exposed to agents.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/control_plane/goals/goal_frontier.py"]
+        },
+        {
+          "lens_id": "quality_simplification",
+          "status": "checked",
+          "summary": "A shared predicate removes duplicated trigger interpretation while preserving as-needed Vision behavior.",
+          "finding_codes": [],
+          "evidence_refs": [
+            "path:loopx/control_plane/goals/goal_frontier.py",
+            "decision:align-guidance-policy"
+          ]
+        },
+        {
+          "lens_id": "efficiency",
+          "status": "checked",
+          "summary": "The alignment operates on the already-built bounded obligation and acceptance-gap lists.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/control_plane/goals/goal_frontier.py"]
+        },
+        {
+          "lens_id": "error_supervision",
+          "status": "checked",
+          "summary": "Watch-only continuation is rejected explicitly instead of creating another silent no-progress cycle.",
+          "finding_codes": [],
+          "evidence_refs": ["path:tests/control_plane/test_goal_vision_blocked_successor.py"]
+        },
+        {
+          "lens_id": "test_validation",
+          "status": "checked",
+          "summary": "Tests cover repeat-until-closed rejection and the as-needed wait-continuation counterexample.",
+          "finding_codes": [],
+          "evidence_refs": ["validator:pr-2597-focused"]
+        },
+        {
+          "lens_id": "documentation_comments",
+          "status": "checked",
+          "summary": "The helper docstring names the advancement policy boundary and keeps projected guidance current.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/control_plane/goals/goal_frontier.py"]
+        },
+        {
+          "lens_id": "security_release",
+          "status": "checked",
+          "summary": "The repair changes no authority or write permission and only narrows what counts as a valid replan ACK.",
+          "finding_codes": [],
+          "evidence_refs": ["path:tests/control_plane/test_goal_vision_blocked_successor.py"]
+        }
+      ],
+      "simplification_decisions": [
+        {
+          "decision_id": "align-guidance-policy",
+          "subject": "repeat-Vision replan guidance and ACK acceptance",
+          "outcome": "retained",
+          "reason": "One shared predicate and one ordered delta-kind contract remove the contradictory watch-only route.",
+          "path": "loopx/control_plane/goals/goal_frontier.py"
+        }
+      ],
+      "safe_fix_applied": false,
+      "safe_fix_passes": 0,
+      "validation_evidence": [
+        {
+          "validator": "pr-2597-focused",
+          "status": "passed",
+          "scope": "repeat and as-needed Vision goal-frontier and interaction-contract behavior"
+        }
+      ],
+      "manual_holds": []
+    },
+    {
+      "case_id": "pr-2602-capability-envelope",
+      "source": {
+        "pull_request": 2602,
+        "head_oid": "b2c934e7a6b579d99ae0d6edd82ccfb19317f27b"
+      },
+      "changed_files": [
+        "docs/reference/protocols/agent-management-projection-v0.md",
+        "examples/control_plane/status-collection-readmodel-smoke.py",
+        "examples/control_plane/status-quota-review-packet-parity-smoke.py",
+        "loopx/cli_commands/quota.py",
+        "loopx/cli_commands/status.py",
+        "loopx/cli_commands/turn.py",
+        "loopx/control_plane/runtime/status_projection_cache.py",
+        "loopx/control_plane/status_collection.py",
+        "loopx/diagnose.py",
+        "loopx/status.py",
+        "tests/control_plane/test_status_collection_material_capability_wiring.py"
+      ],
+      "repository_principles": [
+        {
+          "source": "AGENTS.md",
+          "principle": "Capability-gated projections stay default-off, propagate through real callers, and partition caches by semantic request identity."
+        }
+      ],
+      "lens_reviews": [
+        {
+          "lens_id": "reuse",
+          "status": "checked",
+          "summary": "Cache identity reuses canonical capability normalization from the todo contract.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/control_plane/runtime/status_projection_cache.py"]
+        },
+        {
+          "lens_id": "type_api_boundary",
+          "status": "checked",
+          "summary": "Status-backed callers expose one repeatable available-capability envelope and preserve omitted defaults.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/cli_commands/status.py"]
+        },
+        {
+          "lens_id": "configuration",
+          "status": "checked",
+          "summary": "Material projection remains selected by the observed execution envelope rather than persisted user configuration.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/control_plane/status_collection.py"]
+        },
+        {
+          "lens_id": "runtime_ownership",
+          "status": "checked",
+          "summary": "Status collection transports the envelope and the agent-management projection remains the field owner.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/control_plane/status_collection.py"]
+        },
+        {
+          "lens_id": "quality_simplification",
+          "status": "checked",
+          "summary": "Explicit caller forwarding is retained because it preserves ownership without introducing a hidden ambient capability context.",
+          "finding_codes": [],
+          "evidence_refs": [
+            "path:loopx/control_plane/status_collection.py",
+            "decision:retain-explicit-envelope"
+          ]
+        },
+        {
+          "lens_id": "efficiency",
+          "status": "checked",
+          "summary": "Normalized capability sets participate in cache identity so gated and default projections cannot cross-hit.",
+          "finding_codes": [],
+          "evidence_refs": ["path:loopx/control_plane/runtime/status_projection_cache.py"]
+        },
+        {
+          "lens_id": "error_supervision",
+          "status": "checked",
+          "summary": "Absent capability declarations fail closed by omitting material fields rather than falling back to private material reads.",
+          "finding_codes": [],
+          "evidence_refs": ["path:tests/control_plane/test_status_collection_material_capability_wiring.py"]
+        },
+        {
+          "lens_id": "test_validation",
+          "status": "checked",
+          "summary": "Real status collection, cache identity, and status or quota or review parity paths are covered.",
+          "finding_codes": [],
+          "evidence_refs": ["validator:pr-2602-focused"]
+        },
+        {
+          "lens_id": "documentation_comments",
+          "status": "checked",
+          "summary": "The protocol reference now states default-off projection and explicit capability observation.",
+          "finding_codes": [],
+          "evidence_refs": ["path:docs/reference/protocols/agent-management-projection-v0.md"]
+        },
+        {
+          "lens_id": "security_release",
+          "status": "checked",
+          "summary": "The capability only reveals a prebuilt public-safe frontier and never grants access to material bodies.",
+          "finding_codes": [],
+          "evidence_refs": ["path:tests/control_plane/test_status_collection_material_capability_wiring.py"]
+        }
+      ],
+      "simplification_decisions": [
+        {
+          "decision_id": "retain-explicit-envelope",
+          "subject": "capability propagation through status-backed callers",
+          "outcome": "retained",
+          "reason": "Explicit forwarding is repetitive but keeps request identity and capability ownership visible at each public caller.",
+          "path": "loopx/control_plane/status_collection.py"
+        }
+      ],
+      "safe_fix_applied": false,
+      "safe_fix_passes": 0,
+      "validation_evidence": [
+        {
+          "validator": "pr-2602-focused",
+          "status": "passed",
+          "scope": "material capability projection, cache partitioning, CLI parity, and output budgets"
+        }
+      ],
+      "manual_holds": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- project path-only repository instructions, ownership, build manifests, language hints, and changed surface roots into the prepare packet
- require one substantive result for ten simplify-oriented review lenses
- require explicit simplification decisions and typed validation evidence
- ground applicable lenses in exact paths, repository principles, findings, validators, or simplification decisions
- reject repeated generic all-clear summaries and ungrounded receipts
- fail receipts for failed validators, incomplete lens coverage, unclassified findings, inconsistent safe-fix claims, or semantically invalid stored results
- keep language-specific tests, linters, type checkers, and build tools as repository-owned oracles
- calibrate the contract against public-safe representations of PRs #2590, #2593, #2594, #2597, and #2602

## Protocol and compatibility

This advances prepare, agent result, receipt, and verification from v0 to v1.
Strict verification intentionally rejects existing v0 receipts after this
change; affected diffs must be requalified. The scope fingerprint protocol
remains v0 and unchanged.

This remains a single-level reviewer contract. It does not introduce recursive
reviewers or a universal language-specific compactor. Repository-native oracle
discovery and cross-language calibration remain follow-up work.

## Validation

- Ruff check and format check on changed Python files
- `pytest -q tests/capabilities/test_change_quality.py tests/capabilities/test_capability_extension_registry.py` (`31 passed`)
- change-quality lifecycle smoke passed
- five-PR calibration JSON parsed successfully
- diff hygiene passed
- risk-based `loopx canary premerge --from-git-diff --goal-id loopx-meta`
  - standard tier
  - 18 selected checks passed
  - 0 failures, warnings, or manual holds
  - public boundary scan clean
- exact current-head v1 receipt `cqr_83ddc602a0ef6012805c` verified as valid
- GitHub Actions `pytest` passed

No full test suite was run. The focused suite and risk-selected canaries cover
the changed capability, catalog, receipt lifecycle, calibration semantics,
relevant product-entry surfaces, and public/private boundary.

## Review focus

- deliberate invalidation of v0 strict receipts
- ten stable provider-neutral review lenses
- typed evidence anchors and required repository principles
- path-only repository context without centralizing or leaking repository contents

No private state, raw logs, credentials, local paths, benchmark jobs, or
generated evidence are included.
