### PR TITLE
feat(change-quality): discover repository quality oracles

### DIFF
--- a/docs/capabilities/change-quality/README.md
+++ b/docs/capabilities/change-quality/README.md
@@ -51,8 +51,9 @@ Absence of this policy is equivalent to all three values being false.
    untracked content relative to a base ref. It emits
    `change_quality_prepare_packet_v1`.
 2. The packet projects path-only repository context: applicable instruction
-   files, ownership files, build manifests, language hints, and changed surface
-   roots. It does not copy file contents into the control plane.
+   files, ownership files, build manifests, language hints, changed surface
+   roots, and a provider-neutral validation plan. It does not copy instruction
+   text, task bodies, or manifest contents into the control plane.
 3. A host or model reviews that exact scope using ten required lenses: reuse,
    type/API boundaries, configuration, runtime ownership,
    quality/simplification, efficiency, error/supervision, test/validation,
@@ -101,6 +102,18 @@ lint, type checking, security checks, build commands, and repository-specific
 rules; LoopX records which oracles ran and their outcomes instead of pretending
 that one universal checker understands every language.
 
+The validation plan discovers only repository-declared task identities from
+structured manifests. Initial adapters understand Poe and Hatch task names in
+`pyproject.toml`, Cargo aliases in `.cargo/config.toml`, and package scripts in
+`package.json`. Each candidate carries a category, runner kind, task name, and
+source reference; script bodies stay in the repository and execution remains a
+host decision. Missing format, lint, typecheck, or test categories stay
+explicitly unresolved instead of being filled with guessed commands. Applicable
+`AGENTS.md` and `CLAUDE.md` files are projected as required reads, not parsed as
+shell input. Manifests under fixture, testdata, vendor, third-party, or
+dependency directories are reported as ignored references and never promoted
+to project oracle candidates.
+
 A blocking finding must be a concrete correctness, security, privacy, contract,
 or required-validation failure. Subjective style advice remains nonblocking.
 A failed validator is independently non-passing even when a reviewer forgot to
@@ -115,9 +128,10 @@ in `canary premerge`.
 This version deliberately qualifies one final diff with at most one safe-fix
 pass. It does not recursively review reviews, build a model hierarchy, or
 require several agents to reach consensus. Language and build-system hints are
-discovery inputs, not hardcoded validator policy. Repository-native oracle
-selection and cross-language calibration should evolve from observed receipts,
-not from a central list of guessed commands.
+discovery inputs, not hardcoded validator policy. The initial matrix proves the
+same output contract for Python, Rust, and TypeScript while preserving distinct
+Poe, Cargo, and package-script runner identities. It does not invent a shared
+compactor or silently execute any task.
 
 The initial semantic calibration uses five public control-plane PRs covering a
 registry boundary extraction, benchmark read-model move, recoverable Turn

--- a/loopx/capabilities/change_quality/context.py
+++ b/loopx/capabilities/change_quality/context.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+from .oracles import build_change_quality_validation_plan
 from .scope import resolve_git_root
 
 
@@ -24,6 +25,7 @@ _MANIFEST_SIGNALS: dict[str, tuple[tuple[str, ...], str]] = {
     "pyproject.toml": (("python",), "python-project"),
     "setup.py": (("python",), "python-setuptools"),
     "Cargo.toml": (("rust",), "cargo"),
+    ".cargo/config.toml": (("rust",), "cargo"),
     "package.json": (("javascript", "typescript"), "node"),
     "tsconfig.json": (("typescript",), "typescript"),
     "go.mod": (("go",), "go-modules"),
@@ -135,13 +137,20 @@ def build_change_quality_repository_context(
             if path.parts and path.parts[0] not in {"", "."}
         }
     )
+    sorted_instruction_refs = sorted(instruction_refs)
+    sorted_manifest_refs = sorted(manifest_refs)
     return {
         "schema_version": CHANGE_QUALITY_REPOSITORY_CONTEXT_SCHEMA_VERSION,
-        "instruction_refs": sorted(instruction_refs),
+        "instruction_refs": sorted_instruction_refs,
         "ownership_refs": ownership_refs,
-        "build_manifest_refs": sorted(manifest_refs),
+        "build_manifest_refs": sorted_manifest_refs,
         "language_hints": sorted(language_hints),
         "build_system_hints": sorted(build_system_hints),
         "changed_surface_roots": changed_surface_roots,
+        "validation_plan": build_change_quality_validation_plan(
+            repo_root=repo_root,
+            instruction_refs=sorted_instruction_refs,
+            manifest_refs=sorted_manifest_refs,
+        ),
         "content_included": False,
     }

--- a/loopx/capabilities/change_quality/oracles.py
+++ b/loopx/capabilities/change_quality/oracles.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import tomllib
+from pathlib import Path, PurePosixPath
+from typing import Any, Callable
+
+
+CHANGE_QUALITY_VALIDATION_PLAN_SCHEMA_VERSION = "change_quality_validation_plan_v0"
+
+VALIDATION_CATEGORIES = ("format", "lint", "typecheck", "test")
+
+_CATEGORY_TOKENS = {
+    "format": {"fmt", "format", "formatting"},
+    "lint": {"lint", "linter", "clippy"},
+    "test": {"test", "tests", "pytest"},
+}
+_TASK_LIMIT = 64
+_SAFE_TASK_NAME = re.compile(r"^[A-Za-z0-9@][A-Za-z0-9@._:-]{0,127}$")
+_NON_ORACLE_PATH_PARTS = {
+    "fixtures",
+    "node_modules",
+    "testdata",
+    "third_party",
+    "vendor",
+}
+
+
+def _task_category(task_name: str) -> str | None:
+    tokens = [token for token in re.split(r"[^a-z0-9]+", task_name.lower()) if token]
+    token_set = set(tokens)
+    compact = "".join(tokens)
+    if token_set & _CATEGORY_TOKENS["format"]:
+        return "format"
+    if token_set & _CATEGORY_TOKENS["lint"]:
+        return "lint"
+    if (
+        token_set & {"typecheck", "typechecking"}
+        or compact in {"typecheck", "checktypes", "typechecking"}
+        or {
+            "type",
+            "check",
+        }.issubset(token_set)
+    ):
+        return "typecheck"
+    if token_set & _CATEGORY_TOKENS["test"]:
+        return "test"
+    return None
+
+
+def _source_ref(path: str, *parts: str) -> str:
+    fragment = ".".join(parts)
+    return f"{path}#{fragment}" if fragment else path
+
+
+def _oracle_id(*, source_ref: str, runner: str, task: str) -> str:
+    digest = hashlib.sha256(
+        f"{source_ref}\0{runner}\0{task}".encode("utf-8")
+    ).hexdigest()[:16]
+    return f"oracle_{digest}"
+
+
+def _candidate(
+    *,
+    source_ref: str,
+    runner: str,
+    task: str,
+    languages: tuple[str, ...],
+) -> dict[str, Any] | None:
+    if not _SAFE_TASK_NAME.fullmatch(task):
+        return None
+    category = _task_category(task)
+    if category is None:
+        return None
+    return {
+        "oracle_id": _oracle_id(
+            source_ref=source_ref,
+            runner=runner,
+            task=task,
+        ),
+        "category": category,
+        "runner": runner,
+        "task": task,
+        "source_ref": source_ref,
+        "language_hints": list(languages),
+        "origin": "repository_declared_task",
+        "execution_mode": "host_resolved",
+    }
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _python_candidates(path: str, payload: dict[str, Any]) -> list[dict[str, Any]]:
+    candidates: list[dict[str, Any]] = []
+    tool = _mapping(payload.get("tool"))
+
+    poe_tasks = _mapping(_mapping(tool.get("poe")).get("tasks"))
+    for task in sorted(poe_tasks):
+        candidate = _candidate(
+            source_ref=_source_ref(path, "tool", "poe", "tasks", task),
+            runner="poe_task",
+            task=task,
+            languages=("python",),
+        )
+        if candidate is not None:
+            candidates.append(candidate)
+
+    hatch_envs = _mapping(_mapping(tool.get("hatch")).get("envs"))
+    for environment in sorted(hatch_envs):
+        scripts = _mapping(_mapping(hatch_envs[environment]).get("scripts"))
+        for task in sorted(scripts):
+            candidate = _candidate(
+                source_ref=_source_ref(
+                    path,
+                    "tool",
+                    "hatch",
+                    "envs",
+                    environment,
+                    "scripts",
+                    task,
+                ),
+                runner="hatch_script",
+                task=task,
+                languages=("python",),
+            )
+            if candidate is not None:
+                candidates.append(candidate)
+
+    configured_tools = (
+        ("mypy", "typecheck"),
+        ("pyright", "typecheck"),
+        ("pytest", "test"),
+    )
+    for tool_name, category in configured_tools:
+        config_key = "pytest.ini_options" if tool_name == "pytest" else tool_name
+        current: Any = tool
+        for part in config_key.split("."):
+            current = _mapping(current).get(part)
+        if current is None:
+            continue
+        source_ref = _source_ref(path, "tool", *config_key.split("."))
+        candidates.append(
+            {
+                "oracle_id": _oracle_id(
+                    source_ref=source_ref,
+                    runner=f"{tool_name}_config",
+                    task=tool_name,
+                ),
+                "category": category,
+                "runner": f"{tool_name}_config",
+                "task": tool_name,
+                "source_ref": source_ref,
+                "language_hints": ["python"],
+                "origin": "repository_tool_config",
+                "execution_mode": "host_resolved",
+            }
+        )
+    return candidates
+
+
+def _node_candidates(path: str, payload: dict[str, Any]) -> list[dict[str, Any]]:
+    candidates: list[dict[str, Any]] = []
+    scripts = _mapping(payload.get("scripts"))
+    for task in sorted(scripts):
+        candidate = _candidate(
+            source_ref=_source_ref(path, "scripts", task),
+            runner="package_script",
+            task=task,
+            languages=("javascript", "typescript"),
+        )
+        if candidate is not None:
+            candidates.append(candidate)
+    return candidates
+
+
+def _cargo_candidates(path: str, payload: dict[str, Any]) -> list[dict[str, Any]]:
+    candidates: list[dict[str, Any]] = []
+    aliases = _mapping(payload.get("alias"))
+    for task in sorted(aliases):
+        candidate = _candidate(
+            source_ref=_source_ref(path, "alias", task),
+            runner="cargo_alias",
+            task=task,
+            languages=("rust",),
+        )
+        if candidate is not None:
+            candidates.append(candidate)
+    return candidates
+
+
+def _read_manifest(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        content = path.read_text(encoding="utf-8")
+        if path.name == "package.json":
+            parsed = json.loads(content)
+        else:
+            parsed = tomllib.loads(content)
+    except (OSError, UnicodeError, json.JSONDecodeError, tomllib.TOMLDecodeError):
+        return None, "manifest_unreadable"
+    if not isinstance(parsed, dict):
+        return None, "manifest_root_not_object"
+    return parsed, None
+
+
+def _is_non_oracle_manifest(relative: PurePosixPath) -> bool:
+    return bool({part.lower() for part in relative.parts} & _NON_ORACLE_PATH_PARTS)
+
+
+def build_change_quality_validation_plan(
+    *,
+    repo_root: Path,
+    instruction_refs: list[str],
+    manifest_refs: list[str],
+) -> dict[str, Any]:
+    """Discover repository-declared quality tasks without copying task bodies."""
+    candidates: list[dict[str, Any]] = []
+    warnings: list[dict[str, str]] = []
+    ignored_manifest_refs: list[str] = []
+    for ref in sorted(set(manifest_refs)):
+        relative = PurePosixPath(ref)
+        if relative.is_absolute() or ".." in relative.parts:
+            continue
+        if _is_non_oracle_manifest(relative):
+            ignored_manifest_refs.append(ref)
+            continue
+        parser: Callable[[str, dict[str, Any]], list[dict[str, Any]]]
+        if relative.name == "pyproject.toml":
+            parser = _python_candidates
+        elif relative.name == "package.json":
+            parser = _node_candidates
+        elif relative.as_posix().endswith(".cargo/config.toml"):
+            parser = _cargo_candidates
+        else:
+            continue
+        payload, warning = _read_manifest(repo_root / relative.as_posix())
+        if warning is not None:
+            warnings.append({"source_ref": ref, "code": warning})
+            continue
+        assert payload is not None
+        candidates.extend(parser(ref, payload))
+
+    deduplicated = {
+        candidate["oracle_id"]: candidate for candidate in candidates[:_TASK_LIMIT]
+    }
+    ordered_candidates = sorted(
+        deduplicated.values(),
+        key=lambda item: (
+            VALIDATION_CATEGORIES.index(item["category"]),
+            item["source_ref"],
+        ),
+    )
+    covered = {item["category"] for item in ordered_candidates}
+    return {
+        "schema_version": CHANGE_QUALITY_VALIDATION_PLAN_SCHEMA_VERSION,
+        "selection_policy": "repository_declared_only",
+        "required_reads": sorted(set(instruction_refs)),
+        "candidates": ordered_candidates,
+        "unresolved_categories": [
+            category for category in VALIDATION_CATEGORIES if category not in covered
+        ],
+        "ignored_manifest_refs": ignored_manifest_refs,
+        "discovery_warnings": warnings,
+        "auto_execute": False,
+        "task_bodies_included": False,
+    }

--- a/skills/loopx-change-quality/SKILL.md
+++ b/skills/loopx-change-quality/SKILL.md
@@ -72,10 +72,16 @@ The prepare packet requires one substantive conclusion for each review lens:
 
 The packet projects path-only references to applicable repository instructions,
 ownership files, build manifests, language hints, and changed surface roots.
-Resolve and obey those references before reviewing. The packet deliberately
-does not copy repository content or prescribe one language-specific checker.
-Repository tests, linters, type checkers, build tools, and security checks
-remain the language-specific oracles.
+It also projects a provider-neutral validation plan discovered from structured
+repository task declarations. This is discovery context, not copied repository
+content: instruction text, task bodies, and manifest contents remain in the
+worktree. Read every `required_reads` entry, inspect each candidate's
+`source_ref`, and let the host resolve the named Poe, Hatch, Cargo, or package
+task. Never execute a candidate merely because it was discovered. Unresolved
+format, lint, typecheck, or test categories require reviewer judgment or a
+repository-native instruction; do not fill them with guessed commands. Treat
+`ignored_manifest_refs` as non-executable context, especially fixtures and
+vendored projects.
 
 Record one compact `repository_principles` item for every projected instruction
 reference. Every applicable lens must cite typed `evidence_refs` using

--- a/tests/capabilities/test_change_quality.py
+++ b/tests/capabilities/test_change_quality.py
@@ -209,7 +209,16 @@ def test_prepare_projects_repository_context_and_required_review_lenses(
     _enable(registry)
     (repo / "AGENTS.md").write_text("# Rules\n", encoding="utf-8")
     (repo / "pyproject.toml").write_text(
-        "[project]\nname='fixture'\n", encoding="utf-8"
+        (
+            "[project]\n"
+            "name='fixture'\n"
+            "[tool.poe.tasks]\n"
+            "format='ruff format --check .'\n"
+            "lint='ruff check .'\n"
+            "typecheck='mypy src'\n"
+            "test='pytest -q'\n"
+        ),
+        encoding="utf-8",
     )
     (repo / ".github").mkdir()
     (repo / ".github" / "CODEOWNERS").write_text("* @fixture\n", encoding="utf-8")
@@ -231,6 +240,21 @@ def test_prepare_projects_repository_context_and_required_review_lenses(
     assert context["ownership_refs"] == [".github/CODEOWNERS"]
     assert context["build_manifest_refs"] == ["pyproject.toml"]
     assert context["language_hints"] == ["python"]
+    assert context["validation_plan"]["required_reads"] == [
+        "AGENTS.md",
+        "src/AGENTS.md",
+    ]
+    assert {item["category"] for item in context["validation_plan"]["candidates"]} == {
+        "format",
+        "lint",
+        "typecheck",
+        "test",
+    }
+    assert {item["runner"] for item in context["validation_plan"]["candidates"]} == {
+        "poe_task"
+    }
+    assert context["validation_plan"]["unresolved_categories"] == []
+    assert context["validation_plan"]["auto_execute"] is False
     assert context["changed_surface_roots"] == [
         ".github",
         "AGENTS.md",

--- a/tests/capabilities/test_change_quality_oracles.py
+++ b/tests/capabilities/test_change_quality_oracles.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from loopx.capabilities.change_quality.oracles import (
+    VALIDATION_CATEGORIES,
+    build_change_quality_validation_plan,
+)
+
+
+FIXTURE_ROOT = Path(__file__).parents[1] / "fixtures" / "change_quality" / "oracles"
+
+
+@pytest.mark.parametrize(
+    (
+        "fixture_name",
+        "manifest_refs",
+        "expected_runner",
+        "expected_languages",
+        "task_body_marker",
+    ),
+    [
+        (
+            "python",
+            ["pyproject.toml"],
+            "poe_task",
+            {"python"},
+            "ruff format --check",
+        ),
+        (
+            "rust",
+            ["Cargo.toml", ".cargo/config.toml"],
+            "cargo_alias",
+            {"rust"},
+            "clippy --all-targets",
+        ),
+        (
+            "typescript",
+            ["package.json", "tsconfig.json"],
+            "package_script",
+            {"javascript", "typescript"},
+            "prettier --check",
+        ),
+    ],
+)
+def test_repository_native_oracle_matrix_covers_core_categories(
+    fixture_name: str,
+    manifest_refs: list[str],
+    expected_runner: str,
+    expected_languages: set[str],
+    task_body_marker: str,
+) -> None:
+    fixture = FIXTURE_ROOT / fixture_name
+
+    plan = build_change_quality_validation_plan(
+        repo_root=fixture,
+        instruction_refs=["AGENTS.md"],
+        manifest_refs=manifest_refs,
+    )
+
+    assert plan["selection_policy"] == "repository_declared_only"
+    assert plan["required_reads"] == ["AGENTS.md"]
+    assert plan["unresolved_categories"] == []
+    assert plan["ignored_manifest_refs"] == []
+    assert plan["discovery_warnings"] == []
+    assert plan["auto_execute"] is False
+    assert plan["task_bodies_included"] is False
+    assert {item["category"] for item in plan["candidates"]} == set(
+        VALIDATION_CATEGORIES
+    )
+    assert {item["runner"] for item in plan["candidates"]} == {expected_runner}
+    assert {
+        language for item in plan["candidates"] for language in item["language_hints"]
+    } == expected_languages
+    assert all(item["execution_mode"] == "host_resolved" for item in plan["candidates"])
+    assert all(" " not in item["task"] for item in plan["candidates"])
+    assert task_body_marker not in str(plan)
+
+
+def test_oracle_discovery_does_not_infer_commands_from_language_alone(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\nname = 'no-quality-tasks'\nversion = '0.0.0'\n",
+        encoding="utf-8",
+    )
+
+    plan = build_change_quality_validation_plan(
+        repo_root=tmp_path,
+        instruction_refs=[],
+        manifest_refs=["pyproject.toml"],
+    )
+
+    assert plan["candidates"] == []
+    assert plan["unresolved_categories"] == list(VALIDATION_CATEGORIES)
+
+
+def test_oracle_discovery_reports_malformed_manifest_without_copying_content(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "package.json").write_text(
+        '{"scripts": {"lint": "secret command"',
+        encoding="utf-8",
+    )
+
+    plan = build_change_quality_validation_plan(
+        repo_root=tmp_path,
+        instruction_refs=[],
+        manifest_refs=["package.json"],
+    )
+
+    assert plan["candidates"] == []
+    assert plan["discovery_warnings"] == [
+        {"source_ref": "package.json", "code": "manifest_unreadable"}
+    ]
+    assert "secret command" not in str(plan)
+
+
+def test_oracle_discovery_does_not_promote_fixture_manifest_tasks(
+    tmp_path: Path,
+) -> None:
+    fixture = tmp_path / "tests" / "fixtures" / "nested"
+    fixture.mkdir(parents=True)
+    (fixture / "package.json").write_text(
+        '{"scripts": {"lint": "must not become a project oracle"}}',
+        encoding="utf-8",
+    )
+
+    plan = build_change_quality_validation_plan(
+        repo_root=tmp_path,
+        instruction_refs=[],
+        manifest_refs=["tests/fixtures/nested/package.json"],
+    )
+
+    assert plan["candidates"] == []
+    assert plan["ignored_manifest_refs"] == ["tests/fixtures/nested/package.json"]
+    assert "must not become a project oracle" not in str(plan)

--- a/tests/fixtures/change_quality/oracles/python/AGENTS.md
+++ b/tests/fixtures/change_quality/oracles/python/AGENTS.md
@@ -1,0 +1,3 @@
+# Python fixture
+
+Use the repository-declared quality tasks.

--- a/tests/fixtures/change_quality/oracles/python/pyproject.toml
+++ b/tests/fixtures/change_quality/oracles/python/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "change-quality-python-fixture"
+version = "0.0.0"
+
+[tool.poe.tasks]
+format = "ruff format --check ."
+lint = "ruff check ."
+typecheck = "mypy src"
+test = "pytest -q"

--- a/tests/fixtures/change_quality/oracles/python/src/app.py
+++ b/tests/fixtures/change_quality/oracles/python/src/app.py
@@ -1,0 +1,1 @@
+VALUE: int = 1

--- a/tests/fixtures/change_quality/oracles/rust/.cargo/config.toml
+++ b/tests/fixtures/change_quality/oracles/rust/.cargo/config.toml
@@ -1,0 +1,5 @@
+[alias]
+quality-format = "fmt --check"
+quality-lint = "clippy --all-targets -- -D warnings"
+quality-typecheck = "check --all-targets"
+quality-test = "test"

--- a/tests/fixtures/change_quality/oracles/rust/AGENTS.md
+++ b/tests/fixtures/change_quality/oracles/rust/AGENTS.md
@@ -1,0 +1,3 @@
+# Rust fixture
+
+Use the repository-declared Cargo aliases.

--- a/tests/fixtures/change_quality/oracles/rust/Cargo.toml
+++ b/tests/fixtures/change_quality/oracles/rust/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "change-quality-rust-fixture"
+version = "0.0.0"
+edition = "2021"

--- a/tests/fixtures/change_quality/oracles/rust/src/lib.rs
+++ b/tests/fixtures/change_quality/oracles/rust/src/lib.rs
@@ -1,0 +1,1 @@
+pub const VALUE: usize = 1;

--- a/tests/fixtures/change_quality/oracles/typescript/AGENTS.md
+++ b/tests/fixtures/change_quality/oracles/typescript/AGENTS.md
@@ -1,0 +1,3 @@
+# TypeScript fixture
+
+Use the repository-declared package scripts.

--- a/tests/fixtures/change_quality/oracles/typescript/package.json
+++ b/tests/fixtures/change_quality/oracles/typescript/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "change-quality-typescript-fixture",
+  "private": true,
+  "scripts": {
+    "format:check": "prettier --check .",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  }
+}

--- a/tests/fixtures/change_quality/oracles/typescript/src/index.ts
+++ b/tests/fixtures/change_quality/oracles/typescript/src/index.ts
@@ -1,0 +1,1 @@
+export const value: number = 1;

--- a/tests/fixtures/change_quality/oracles/typescript/tsconfig.json
+++ b/tests/fixtures/change_quality/oracles/typescript/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}


### PR DESCRIPTION
## Summary

- discover repository-declared quality task identities from structured manifests
- project a provider-neutral validation plan with category, runner, task, source, and unresolved coverage
- keep task bodies, parser details, and execution authority outside LoopX state
- exclude fixture, testdata, vendored, third-party, and dependency manifests from executable candidates
- prove one output contract across Python Poe tasks, Rust Cargo aliases, and TypeScript package scripts

## Design

The capability remains owned by `change_quality_qualification`. LoopX performs
bounded discovery and emits host-resolved task identities; repositories retain
their tests, linters, type checkers, build tools, and execution policy.

`AGENTS.md` and `CLAUDE.md` references remain required reads. They are not
parsed as shell input. Missing format, lint, typecheck, or test categories are
reported explicitly rather than filled with guessed commands.

This is not a universal compactor and does not automatically run discovered
tasks.

## Validation

- 37 focused capability, oracle-matrix, and extension-registry tests passed
- changed Python Ruff check and format check passed
- change-quality lifecycle smoke passed
- standard risk-based premerge:
  - 4 direct checks passed
  - 15 selected checks passed
  - 0 failures, warnings, or manual holds
  - public/private boundary scan clean
  - self-merge allowed
- exact receipt `cqr_a0030ee726b6d1b07f9d` verified for fingerprint `a0030ee726b6d1b07f9d7895e5349c762c632f2a8f6e0b87988b5799cdd48208`

No full test suite was run. Focused semantics and risk-selected canaries cover
the changed discovery, prepare-packet, capability lifecycle, and public
boundary surfaces.
