### PR TITLE
feat(change-quality): project receipt lifecycle evidence

### DIFF
--- a/loopx/canary/premerge.py
+++ b/loopx/canary/premerge.py
@@ -646,7 +646,9 @@ def apply_change_quality_verification(
 ) -> dict[str, Any]:
     """Attach goal policy evidence and fail the merge gate when strict receipt fails."""
 
-    payload["change_quality_qualification"] = verification
+    payload["change_quality_qualification"] = {
+        key: value for key, value in verification.items() if key != "receipt_path"
+    }
     enforced_failure = bool(
         verification.get("enforcement_applied")
         and verification.get("ok") is False
@@ -1089,18 +1091,35 @@ def render_premerge_validation_gate_markdown(payload: dict[str, Any]) -> str:
         else None
     )
     if quality is not None:
+        evidence = (
+            quality.get("pr_evidence")
+            if isinstance(quality.get("pr_evidence"), dict)
+            else {}
+        )
         lines.extend(
             [
                 "",
                 "## Change Quality Receipt",
                 f"- status: `{quality.get('status')}`",
+                f"- state: `{evidence.get('state')}`",
                 f"- ok: `{str(quality.get('ok')).lower()}`",
                 f"- enforcement_applied: `{str(quality.get('enforcement_applied')).lower()}`",
-                f"- receipt_id: `{quality.get('receipt_id')}`",
+                f"- blocking: `{str(evidence.get('blocking')).lower()}`",
+                (
+                    "- requalification_required: "
+                    f"`{str(evidence.get('requalification_required')).lower()}`"
+                ),
+                f"- summary: {evidence.get('summary')}",
             ]
         )
-        if quality.get("required_action"):
-            lines.append(f"- required_action: {quality.get('required_action')}")
+        if evidence.get("receipt_id"):
+            lines.append(f"- receipt_id: `{evidence.get('receipt_id')}`")
+        if evidence.get("previous_receipt_id"):
+            lines.append(
+                f"- previous_receipt_id: `{evidence.get('previous_receipt_id')}`"
+            )
+        if evidence.get("required_action"):
+            lines.append(f"- required_action: {evidence.get('required_action')}")
 
     manual_holds = classification.get("manual_holds") or []
     if manual_holds:

--- a/loopx/capabilities/change_quality/cli.py
+++ b/loopx/capabilities/change_quality/cli.py
@@ -84,6 +84,8 @@ def render_change_quality_markdown(payload: dict[str, object]) -> str:
     scope_value = payload.get("scope") or receipt.get("scope")
     policy = policy_value if isinstance(policy_value, dict) else {}
     scope = scope_value if isinstance(scope_value, dict) else {}
+    pr_evidence_value = payload.get("pr_evidence")
+    pr_evidence = pr_evidence_value if isinstance(pr_evidence_value, dict) else {}
     lines = [
         "# Change Quality Qualification",
         "",
@@ -98,6 +100,21 @@ def render_change_quality_markdown(payload: dict[str, object]) -> str:
     ]
     if payload.get("receipt_id"):
         lines.append(f"- receipt_id: `{payload.get('receipt_id')}`")
+    if pr_evidence:
+        lines.extend(
+            [
+                f"- receipt_state: `{pr_evidence.get('state')}`",
+                (
+                    "- requalification_required: "
+                    f"`{str(pr_evidence.get('requalification_required')).lower()}`"
+                ),
+                f"- summary: {pr_evidence.get('summary')}",
+            ]
+        )
+        if pr_evidence.get("previous_receipt_id"):
+            lines.append(
+                f"- previous_receipt_id: `{pr_evidence.get('previous_receipt_id')}`"
+            )
     if payload.get("required_action"):
         lines.append(f"- required_action: {payload.get('required_action')}")
     return "\n".join(lines).rstrip() + "\n"

--- a/loopx/capabilities/change_quality/receipt.py
+++ b/loopx/capabilities/change_quality/receipt.py
@@ -27,6 +27,52 @@ from .scope import build_change_quality_scope, resolve_git_root
 CHANGE_QUALITY_PREPARE_SCHEMA_VERSION = "change_quality_prepare_packet_v1"
 CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION = "change_quality_receipt_v1"
 CHANGE_QUALITY_VERIFY_SCHEMA_VERSION = "change_quality_receipt_verification_v1"
+CHANGE_QUALITY_PR_EVIDENCE_SCHEMA_VERSION = "change_quality_pr_evidence_v0"
+
+_PR_EVIDENCE_BY_STATUS = {
+    "disabled": (
+        "disabled",
+        "Change-quality qualification is disabled for this goal.",
+        None,
+    ),
+    "no_changes": (
+        "not_required",
+        "No changed files require a change-quality receipt.",
+        None,
+    ),
+    "valid": (
+        "valid",
+        "The receipt matches the exact current base and diff.",
+        None,
+    ),
+    "stale_receipt": (
+        "stale",
+        (
+            "A prior receipt exists, but the exact base or diff changed; "
+            "requalification is required."
+        ),
+        (
+            "rerun change-quality prepare against the current base and diff, "
+            "review that exact scope, and record a new passing receipt"
+        ),
+    ),
+    "receipt_missing": (
+        "missing",
+        "No receipt is recorded for the exact current base and diff.",
+        (
+            "run change-quality prepare, review the exact current scope, "
+            "and record a passing receipt"
+        ),
+    ),
+    "invalid_receipt": (
+        "invalid",
+        "The receipt for the exact current base and diff is invalid.",
+        (
+            "repair the recorded result, review the exact current scope, "
+            "and record a new passing receipt"
+        ),
+    ),
+}
 
 
 def _goal_from_registry(registry_path: Path, goal_id: str) -> dict[str, Any]:
@@ -284,6 +330,59 @@ def _stored_receipt_is_valid(
     return decision == "pass" and receipt.get("unresolved_blockers") == unresolved
 
 
+def _read_first_receipt(paths: list[Path]) -> dict[str, Any] | None:
+    for path in paths:
+        try:
+            receipt = read_json(path)
+        except (OSError, ValueError, TypeError, json.JSONDecodeError):
+            continue
+        if isinstance(receipt, dict):
+            return receipt
+    return None
+
+
+def _build_pr_evidence(
+    *,
+    status: str,
+    policy: dict[str, Any],
+    scope: dict[str, Any],
+    receipt: dict[str, Any] | None = None,
+    previous_receipt: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    state, summary, required_action = _PR_EVIDENCE_BY_STATUS.get(
+        status,
+        _PR_EVIDENCE_BY_STATUS["invalid_receipt"],
+    )
+    previous_scope = (
+        previous_receipt.get("scope")
+        if isinstance(previous_receipt, dict)
+        and isinstance(previous_receipt.get("scope"), dict)
+        else {}
+    )
+    return {
+        "schema_version": CHANGE_QUALITY_PR_EVIDENCE_SCHEMA_VERSION,
+        "state": state,
+        "summary": summary,
+        "blocking": bool(
+            policy.get("strict_receipt") and state in {"stale", "missing", "invalid"}
+        ),
+        "requalification_required": state == "stale",
+        "scope_fingerprint": scope.get("scope_fingerprint"),
+        "base_ref": scope.get("base_ref"),
+        "base_commit": scope.get("base_commit"),
+        "head_commit": scope.get("head_commit"),
+        "receipt_id": receipt.get("receipt_id") if isinstance(receipt, dict) else None,
+        "previous_receipt_id": (
+            previous_receipt.get("receipt_id")
+            if isinstance(previous_receipt, dict)
+            else None
+        ),
+        "previous_scope_fingerprint": previous_scope.get("scope_fingerprint"),
+        "previous_base_commit": previous_scope.get("base_commit"),
+        "required_action": required_action,
+    }
+
+
 def verify_change_quality_receipt(
     *,
     registry_path: Path,
@@ -296,24 +395,36 @@ def verify_change_quality_receipt(
     policy = change_quality_goal_policy(goal)
     scope = build_change_quality_scope(repo_path=repo_path, base_ref=base_ref)
     if not policy["enabled"]:
+        status = "disabled"
         return {
             "ok": True,
             "schema_version": CHANGE_QUALITY_VERIFY_SCHEMA_VERSION,
             "goal_id": goal_id,
-            "status": "disabled",
+            "status": status,
             "enforcement_applied": False,
             "policy": policy,
             "scope": scope,
+            "pr_evidence": _build_pr_evidence(
+                status=status,
+                policy=policy,
+                scope=scope,
+            ),
         }
     if not scope["changed_files"]:
+        status = "no_changes"
         return {
             "ok": True,
             "schema_version": CHANGE_QUALITY_VERIFY_SCHEMA_VERSION,
             "goal_id": goal_id,
-            "status": "no_changes",
+            "status": status,
             "enforcement_applied": bool(policy["strict_receipt"]),
             "policy": policy,
             "scope": scope,
+            "pr_evidence": _build_pr_evidence(
+                status=status,
+                policy=policy,
+                scope=scope,
+            ),
         }
     path = _receipt_path(
         runtime_root=runtime_root,
@@ -327,10 +438,7 @@ def verify_change_quality_receipt(
         changed_files=list(scope["changed_files"]),
     )
     if path.exists():
-        try:
-            receipt = read_json(path)
-        except (OSError, ValueError, TypeError, json.JSONDecodeError):
-            receipt = None
+        receipt = _read_first_receipt([path])
     receipt_valid = _stored_receipt_is_valid(
         receipt,
         scope_fingerprint=str(scope["scope_fingerprint"]),
@@ -338,6 +446,7 @@ def verify_change_quality_receipt(
         changed_files=list(scope["changed_files"]),
         instruction_refs=list(repository_context["instruction_refs"]),
     )
+    previous_receipt = None
     if receipt_valid:
         status = "valid"
     elif path.exists():
@@ -349,7 +458,15 @@ def verify_change_quality_receipt(
             reverse=True,
         )
         status = "stale_receipt" if repo_receipts else "receipt_missing"
+        previous_receipt = _read_first_receipt(repo_receipts)
     strict = bool(policy["strict_receipt"])
+    pr_evidence = _build_pr_evidence(
+        status=status,
+        policy=policy,
+        scope=scope,
+        receipt=receipt,
+        previous_receipt=previous_receipt,
+    )
     return {
         "ok": receipt_valid or not strict,
         "schema_version": CHANGE_QUALITY_VERIFY_SCHEMA_VERSION,
@@ -361,9 +478,6 @@ def verify_change_quality_receipt(
         "receipt_id": receipt.get("receipt_id") if receipt else None,
         "receipt_path": str(path),
         "receipt_valid": receipt_valid,
-        "required_action": (
-            "run change-quality prepare, review the exact scope, and record a passing receipt"
-            if strict and not receipt_valid
-            else None
-        ),
+        "required_action": pr_evidence["required_action"],
+        "pr_evidence": pr_evidence,
     }

--- a/tests/capabilities/test_change_quality.py
+++ b/tests/capabilities/test_change_quality.py
@@ -11,6 +11,7 @@ from loopx.agent_onboarding import _skill_delivery_contract
 from loopx.canary.premerge import (
     apply_change_quality_verification,
     build_premerge_validation_gate,
+    render_premerge_validation_gate_markdown,
 )
 from loopx.capabilities.change_quality.policy import change_quality_goal_policy
 from loopx.capabilities.change_quality.receipt import (
@@ -660,6 +661,9 @@ def test_exact_scope_receipt_becomes_stale_after_any_diff_change(
     assert recorded["decision"] == "pass"
     assert verified["status"] == "valid"
     assert verified["ok"] is True
+    assert verified["pr_evidence"]["state"] == "valid"
+    assert verified["pr_evidence"]["receipt_id"] == recorded["receipt_id"]
+    assert verified["pr_evidence"]["requalification_required"] is False
 
     (repo / "app.py").write_text("value = 3\n", encoding="utf-8")
     stale = verify_change_quality_receipt(
@@ -671,6 +675,81 @@ def test_exact_scope_receipt_becomes_stale_after_any_diff_change(
     )
     assert stale["status"] == "stale_receipt"
     assert stale["ok"] is False
+    assert stale["pr_evidence"] == {
+        "schema_version": "change_quality_pr_evidence_v0",
+        "state": "stale",
+        "summary": (
+            "A prior receipt exists, but the exact base or diff changed; "
+            "requalification is required."
+        ),
+        "blocking": True,
+        "requalification_required": True,
+        "scope_fingerprint": stale["scope"]["scope_fingerprint"],
+        "base_ref": "HEAD",
+        "base_commit": stale["scope"]["base_commit"],
+        "head_commit": stale["scope"]["head_commit"],
+        "receipt_id": None,
+        "previous_receipt_id": recorded["receipt_id"],
+        "previous_scope_fingerprint": prepared["scope"]["scope_fingerprint"],
+        "previous_base_commit": prepared["scope"]["base_commit"],
+        "required_action": (
+            "rerun change-quality prepare against the current base and diff, "
+            "review that exact scope, and record a new passing receipt"
+        ),
+    }
+
+
+def test_base_advance_projects_visible_requalification_prompt(tmp_path: Path) -> None:
+    repo, registry, runtime_root = _fixture(tmp_path)
+    _enable(registry)
+    base_branch = _git(repo, "branch", "--show-current")
+    _git(repo, "switch", "--detach", "HEAD")
+    (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
+    prepared = build_change_quality_prepare_packet(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        base_ref=base_branch,
+    )
+    result_path = _result(
+        tmp_path / "result.json",
+        prepared["scope"]["scope_fingerprint"],
+    )
+    recorded = record_change_quality_receipt(
+        registry_path=registry,
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        result_path=result_path,
+        base_ref=base_branch,
+        execute=True,
+    )
+
+    new_base = _git(
+        repo,
+        "commit-tree",
+        "HEAD^{tree}",
+        "-p",
+        "HEAD",
+        "-m",
+        "advance base",
+    )
+    _git(repo, "update-ref", f"refs/heads/{base_branch}", new_base)
+    stale = verify_change_quality_receipt(
+        registry_path=registry,
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        base_ref=base_branch,
+    )
+
+    assert stale["status"] == "stale_receipt"
+    assert stale["ok"] is False
+    assert stale["pr_evidence"]["state"] == "stale"
+    assert stale["pr_evidence"]["requalification_required"] is True
+    assert stale["pr_evidence"]["previous_receipt_id"] == recorded["receipt_id"]
+    assert stale["pr_evidence"]["previous_base_commit"] != new_base
+    assert "current base and diff" in stale["pr_evidence"]["required_action"]
 
 
 def test_receipt_identity_is_stable_from_repository_subdirectories(
@@ -810,6 +889,12 @@ def test_strict_verification_failure_overrides_premerge_gate(
     assert gate["gate"]["status"] == "quality_receipt_missing"
     assert gate["gate"]["merge_gate_passed"] is False
     assert gate["validation_summary"]["policy_failure_count"] == 1
+    assert "receipt_path" not in gate["change_quality_qualification"]
+    assert gate["change_quality_qualification"]["pr_evidence"]["state"] == "missing"
+    markdown = render_premerge_validation_gate_markdown(gate)
+    assert "- state: `missing`" in markdown
+    assert "- requalification_required: `false`" in markdown
+    assert str(runtime_root) not in markdown
 
 
 def test_premerge_cli_enforces_goal_receipt_policy(


### PR DESCRIPTION
## Summary
- project valid, stale, missing, and invalid receipt states into compact PR-facing evidence
- show a concrete requalification action when the exact base or diff moves
- omit local receipt paths from premerge output while preserving exact-base enforcement

## Validation
- `pytest -q tests/capabilities/test_change_quality.py` (19 passed)
- focused `ruff check` on the four changed Python files
- `python examples/change-quality-qualification-smoke.py`
- `loopx canary premerge --from-git-diff --goal-id loopx-meta --tier standard` (13 selected checks passed, no holds)
- exact-scope change-quality receipt `cqr_f6646bd25a8fff061130` verified valid after commit

## Risk
Low and bounded to receipt evidence projection. Strict receipt pass/fail semantics are unchanged; focused tests cover valid, missing, stale diff, base advance, and local-path redaction.