### PR TITLE
fix(skillsbench): retry runtime apt setup via public mirrors

### DIFF
--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -8126,6 +8126,12 @@ def patch_dockerfile_codex_acp_runtime_tools(dockerfile: Path) -> bool:
     )
     block = (
         f"{DOCKER_CODEX_ACP_RUNTIME_TOOLS_BEGIN}\n"
+        "ARG LOOPX_SKILLSBENCH_RUNTIME_UBUNTU_APT_MIRROR="
+        f"{dockerfile_runtime.DEFAULT_UBUNTU_APT_MIRROR_BASE}\n"
+        "ARG LOOPX_SKILLSBENCH_RUNTIME_DEBIAN_APT_MIRROR="
+        f"{dockerfile_runtime.DEFAULT_DEBIAN_APT_MIRROR_BASE}\n"
+        "ARG LOOPX_SKILLSBENCH_RUNTIME_DEBIAN_SECURITY_MIRROR="
+        f"{dockerfile_runtime.DEFAULT_DEBIAN_SECURITY_MIRROR_BASE}\n"
         "RUN set -eux; \\\n"
         "    if command -v curl >/dev/null 2>&1 && \\\n"
         "       command -v tar >/dev/null 2>&1 && \\\n"
@@ -8144,7 +8150,19 @@ def patch_dockerfile_codex_acp_runtime_tools(dockerfile: Path) -> bool:
         "        'Acquire::https::No-Cache \"true\";' \\\n"
         "        'Acquire::Check-Valid-Until \"false\";' \\\n"
         "        > /etc/apt/apt.conf.d/80-loopx-retry; \\\n"
-        "      apt-get update -qq; \\\n"
+        "      if ! apt-get update -qq; then \\\n"
+        "        find /etc/apt -type f \\\n"
+        "          \\( -name '*.list' -o -name '*.sources' \\) \\\n"
+        "          -exec sed -i \\\n"
+        '            -e "s#https\\?://archive.ubuntu.com/ubuntu#${LOOPX_SKILLSBENCH_RUNTIME_UBUNTU_APT_MIRROR}#g" \\\n'
+        '            -e "s#https\\?://security.ubuntu.com/ubuntu#${LOOPX_SKILLSBENCH_RUNTIME_UBUNTU_APT_MIRROR}#g" \\\n'
+        '            -e "s#https\\?://deb.debian.org/debian-security#${LOOPX_SKILLSBENCH_RUNTIME_DEBIAN_SECURITY_MIRROR}#g" \\\n'
+        '            -e "s#https\\?://security.debian.org/debian-security#${LOOPX_SKILLSBENCH_RUNTIME_DEBIAN_SECURITY_MIRROR}#g" \\\n'
+        '            -e "s#https\\?://deb.debian.org/debian#${LOOPX_SKILLSBENCH_RUNTIME_DEBIAN_APT_MIRROR}#g" \\\n'
+        "            {} +; \\\n"
+        "        rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*.deb; \\\n"
+        "        apt-get update -qq; \\\n"
+        "      fi; \\\n"
         "      apt-get install -y -qq --no-install-recommends ca-certificates curl tar xz-utils; \\\n"
         "      rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*.deb; \\\n"
         "    elif command -v apk >/dev/null 2>&1; then \\\n"

--- a/tests/test_skillsbench_runtime_tools.py
+++ b/tests/test_skillsbench_runtime_tools.py
@@ -1,0 +1,35 @@
+from loopx.benchmark_adapters import skillsbench_dockerfile_runtime
+from scripts.skillsbench_automation_loop import (
+    DOCKER_CODEX_ACP_RUNTIME_TOOLS_BEGIN,
+    patch_dockerfile_codex_acp_runtime_tools,
+)
+
+
+def test_runtime_tools_retries_apt_with_public_mirrors(tmp_path) -> None:
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text("FROM ubuntu:24.04\n", encoding="utf-8")
+
+    assert patch_dockerfile_codex_acp_runtime_tools(dockerfile) is True
+
+    staged_text = dockerfile.read_text(encoding="utf-8")
+    assert DOCKER_CODEX_ACP_RUNTIME_TOOLS_BEGIN in staged_text
+    assert "if ! apt-get update -qq; then" in staged_text
+    assert (
+        skillsbench_dockerfile_runtime.DEFAULT_UBUNTU_APT_MIRROR_BASE
+        in staged_text
+    )
+    assert (
+        skillsbench_dockerfile_runtime.DEFAULT_DEBIAN_APT_MIRROR_BASE
+        in staged_text
+    )
+    assert (
+        skillsbench_dockerfile_runtime.DEFAULT_DEBIAN_SECURITY_MIRROR_BASE
+        in staged_text
+    )
+    assert staged_text.count("apt-get update -qq") == 2
+    assert (
+        staged_text.index("if ! apt-get update -qq; then")
+        < staged_text.index("apt-get install -y -qq")
+    )
+    assert patch_dockerfile_codex_acp_runtime_tools(dockerfile) is False
+    assert dockerfile.read_text(encoding="utf-8") == staged_text


### PR DESCRIPTION
## Summary
- retry runtime-tools apt metadata setup once after switching Debian/Ubuntu sources to the existing public mirror defaults
- keep the fallback local to the existing SkillsBench Dockerfile helper
- add focused coverage for mirror reuse, ordering, bounded retries, and idempotency

## Validation
- `python -m pytest -q tests/test_skillsbench_runtime_tools.py tests/test_skillsbench_setup_preflight.py` (50 passed)
- `python examples/skillsbench-benchmark-run-smoke.py`
- `ruff check tests/test_skillsbench_runtime_tools.py`
- `python -m py_compile scripts/skillsbench_automation_loop.py tests/test_skillsbench_runtime_tools.py`
- `loopx canary premerge --from-git-diff --goal-id loopx-meta --tier standard` (all selected checks passed; benchmark-sensitive manual review hold remains)
- change-quality receipt `cqr_949c08a339f8fe573f0a` verified against the exact committed scope

## Review boundaries
- no scoring, task semantics, submission, permissions, or benchmark launch behavior changes
- no raw benchmark evidence, credentials, private state, local paths, or generated logs
- repository-wide mypy remains unavailable for this script because optional BenchFlow modules are absent and the script is discovered under two module names
- whole-file ruff has 133 pre-existing findings in the legacy runner; the new test and changed behavior are covered by focused lint, tests, compilation, and risk-selected canaries

The owner has authorized self-merge for benchmark helper/runtime code after validation and self-review. This PR is limited to public runtime setup plumbing and does not launch benchmark jobs.