### PR TITLE
fix(skillsbench): stage proxy before runtime setup

### DIFF
--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -8669,10 +8669,6 @@ def stage_task_for_sandbox(
                 staged_path / "environment" / "Dockerfile"
             )
         )
-    dockerfile_proxy_metadata = patch_dockerfile_benchmark_egress_proxy_env(
-        staged_path / "environment" / "Dockerfile",
-        proxy_env=benchmark_egress_proxy_env,
-    )
     apt_retry_patched = patch_dockerfile_apt_retry(
         staged_path / "environment" / "Dockerfile",
         transport_mode=docker_apt_transport_mode,
@@ -8721,6 +8717,10 @@ def stage_task_for_sandbox(
     )
     runtime_tools_patched = patch_dockerfile_codex_acp_runtime_tools(
         staged_path / "environment" / "Dockerfile"
+    )
+    dockerfile_proxy_metadata = patch_dockerfile_benchmark_egress_proxy_env(
+        staged_path / "environment" / "Dockerfile",
+        proxy_env=benchmark_egress_proxy_env,
     )
     staged_verifier_script = proxy_runtime.skillsbench_verifier_script(staged_path)
     uv_mirror_metadata = verifier_bootstrap.patch_verifier_uv_bootstrap_mirror(

--- a/tests/test_skillsbench_runtime_tools.py
+++ b/tests/test_skillsbench_runtime_tools.py
@@ -1,7 +1,9 @@
 from loopx.benchmark_adapters import skillsbench_dockerfile_runtime
 from scripts.skillsbench_automation_loop import (
+    DOCKER_BENCHMARK_EGRESS_PROXY_BEGIN,
     DOCKER_CODEX_ACP_RUNTIME_TOOLS_BEGIN,
     patch_dockerfile_codex_acp_runtime_tools,
+    stage_task_for_sandbox,
 )
 
 
@@ -33,3 +35,34 @@ def test_runtime_tools_retries_apt_with_public_mirrors(tmp_path) -> None:
     )
     assert patch_dockerfile_codex_acp_runtime_tools(dockerfile) is False
     assert dockerfile.read_text(encoding="utf-8") == staged_text
+
+
+def test_staging_places_proxy_before_runtime_network_steps(tmp_path) -> None:
+    task_path = tmp_path / "task"
+    environment_path = task_path / "environment"
+    environment_path.mkdir(parents=True)
+    (environment_path / "Dockerfile").write_text(
+        "FROM ubuntu:24.04\n",
+        encoding="utf-8",
+    )
+
+    staged_path, metadata = stage_task_for_sandbox(
+        task_path=task_path,
+        jobs_dir=tmp_path / "jobs",
+        job_name="proxy-order",
+        sandbox="docker",
+        benchmark_egress_proxy_env={
+            "HTTP_PROXY": "http://127.0.0.1:18080",
+            "HTTPS_PROXY": "http://127.0.0.1:18080",
+        },
+    )
+
+    staged_text = (staged_path / "environment" / "Dockerfile").read_text(
+        encoding="utf-8"
+    )
+    assert metadata["benchmark_egress_proxy_dockerfile_env_patch_applied"] is True
+    assert metadata["codex_acp_runtime_tools_patch_applied"] is True
+    assert (
+        staged_text.index(DOCKER_BENCHMARK_EGRESS_PROXY_BEGIN)
+        < staged_text.index(DOCKER_CODEX_ACP_RUNTIME_TOOLS_BEGIN)
+    )


### PR DESCRIPTION
## Summary
- apply the existing Docker benchmark-egress proxy block after the other stage patchers so its `ARG`/`ENV` block is rendered before injected network setup
- preserve all existing patch metadata and call counts
- add synthetic coverage that the proxy block precedes runtime-tools apt setup

## Validation
- `python -m pytest -q tests/test_skillsbench_runtime_tools.py tests/test_skillsbench_setup_preflight.py` (51 passed)
- `python examples/skillsbench-benchmark-run-smoke.py`
- `ruff check tests/test_skillsbench_runtime_tools.py`
- changed-file compilation passed
- risk-selected canaries passed: maintainability, adapter readiness, core adapter contract, and artifact-path boundary
- exact-scope quality receipt `cqr_354593571d6d598587f3` passed

## Boundaries
- no scoring, task semantics, submission, permissions, or benchmark launch behavior changes
- no raw benchmark material, credentials, private endpoints, local paths, or generated logs
- repository mypy remains unavailable because optional BenchFlow modules are absent and the legacy script is discovered under two module names
- whole-file legacy runner lint has pre-existing findings; focused lint, semantic tests, compilation, and canaries cover this change

Owner authorization permits benchmark helper/runtime self-merge after validation and self-review.