### PR TITLE
refactor(change-quality): derive sparse guardrails

### DIFF
--- a/docs/capabilities/change-quality/README.md
+++ b/docs/capabilities/change-quality/README.md
@@ -49,28 +49,29 @@ Absence of this policy is equivalent to all three values being false.
 
 1. `change-quality prepare` hashes the committed, staged, unstaged, and
    untracked content relative to a base ref. It emits
-   `change_quality_prepare_packet_v1`.
+   `change_quality_prepare_packet_v2`.
 2. The packet projects path-only repository context: applicable instruction
    files, ownership files, build manifests, language hints, changed surface
    roots, and a provider-neutral validation plan. It does not copy instruction
    text, task bodies, or manifest contents into the control plane.
-3. A host or model reviews that exact scope simplify-first. `reuse` and
-   `quality_simplification` are primary; type/API boundaries, configuration,
-   runtime ownership, efficiency, error/supervision, test/validation,
-   documentation/comments, and security/release are guardrails activated by
-   the changed surface or repository evidence. The result uses
-   `change_quality_agent_result_v1`.
+3. A host or model reviews that exact scope simplify-first. It writes one
+   grounded `reuse` conclusion, one grounded `simplification` conclusion,
+   sparse triggered `risks[]`, and selected `validation[]`. Type/API
+   boundaries, configuration, runtime ownership, efficiency,
+   error/supervision, test/validation, documentation/comments, and
+   security/release remain guardrail categories, but the Agent does not fill
+   an all-clear row for each one. The result uses
+   `change_quality_agent_result_v2`.
 4. If policy allows it, the host may perform one bounded safe-fix pass. Any edit
    invalidates the old fingerprint, so prepare and final review run again.
-5. `change-quality record --execute` requires complete per-lens conclusions,
-   the principles from every projected repository instruction file, an
-   explicit simplification decision, and typed validation evidence. Every
-   applicable lens must cite a changed path, instruction, finding, validator,
-   or simplification decision. The two primary lenses require distinct
-   substantive conclusions; inactive guardrails may share a compact
-   `not_applicable` reason. The command validates the result against the
-   current fingerprint and writes a compact local runtime receipt.
-6. `change-quality verify` checks the current exact scope and v1 protocol.
+5. `change-quality record --execute` validates those four result blocks against
+   the current fingerprint, derives guardrail states from sparse risks and
+   validation outcomes, and writes a compact local runtime receipt. Failed
+   validation, skipped required validation, and unresolved blocker risks fail
+   closed.
+6. `change-quality verify` checks the current exact scope and v2 protocol.
+   Existing v1 receipts remain read-only compatible for the exact scope they
+   already qualified.
 7. `canary premerge --goal-id <goal-id>` enforces `strict_receipt`.
 
 ```bash
@@ -87,11 +88,12 @@ loopx --format json change-quality verify \
 loopx canary premerge --from-git-diff --goal-id <goal-id>
 ```
 
-Receipts live under goal runtime state, not in the repository. They retain
-compact findings, per-lens conclusions, simplification decisions, and typed
-validation evidence. Lens evidence references are typed and cross-checked
-against the exact changed paths and receipt objects. Receipts do not retain raw
-model transcripts, credentials, private context, or validator logs.
+Receipts live under goal runtime state, not in the repository. They retain the
+two primary conclusions, sparse risks, typed validation evidence, and the
+system-derived guardrail summary. Evidence references are typed and
+cross-checked against exact changed paths, projected instructions, and
+validators. Receipts do not retain raw model transcripts, credentials, private
+context, or validator logs.
 
 ## Provider Boundary
 
@@ -135,12 +137,14 @@ same output contract for Python, Rust, and TypeScript while preserving distinct
 Poe, Cargo, and package-script runner identities. It does not invent a shared
 compactor or silently execute any task.
 
-The initial semantic calibration uses five public control-plane PRs covering a
+The semantic calibration uses five public control-plane PRs covering a
 registry boundary extraction, benchmark read-model move, recoverable Turn
 stages, Vision replan repair, and capability-envelope propagation. The replay
 keeps the benchmark-sensitive manual hold independent from receipt success and
-proves that only one coherent safe-fix pass can be reported. These fixtures
-calibrate review behavior; they are not project-specific production policy.
+proves that only one coherent safe-fix pass can be reported. The v2 fixture
+also demonstrates the output-budget change directly: five cases no longer
+carry fifty authored lens rows. These fixtures calibrate review behavior; they
+are not project-specific production policy.
 
 ## Model-Behavior Shadow
 
@@ -154,9 +158,10 @@ separate `change_quality_shadow_matrix_v0` therefore pairs:
   still pass but whose implementation adds one-use wrappers or low-value
   helpers.
 
-The live runner compares the former v0 review instructions with the v1
-simplify contract using the same model and exact case. It scores result-schema
-validity, primary simplify-lens coverage, simplify finding precision and
+The live runner compares its historical v0 and simplify-first v1 shadow
+prompts using the same model and exact case; those labels version the shadow
+experiment, not the receipt protocol. It scores result-schema validity,
+primary simplify coverage, simplify finding precision and
 recall, false positives on accepted PRs, simplification decisions, safe-fix
 eligibility, tracked-file mutation, output tokens, and latency:
 

--- a/examples/change-quality-qualification-smoke.py
+++ b/examples/change-quality-qualification-smoke.py
@@ -15,7 +15,6 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.capabilities.change_quality.receipt import (  # noqa: E402
     CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
-    REVIEW_LENS_IDS,
     build_change_quality_prepare_packet,
     record_change_quality_receipt,
     verify_change_quality_receipt,
@@ -92,44 +91,24 @@ def main() -> int:
                     "schema_version": CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
                     "scope_fingerprint": prepared["scope"]["scope_fingerprint"],
                     "reviewed_final_scope": True,
-                    "summary": "Exact final scope reviewed.",
-                    "repository_principles": [],
-                    "findings": [],
-                    "lens_reviews": [
-                        {
-                            "lens_id": lens_id,
-                            "status": "checked",
-                            "summary": (
-                                f"{lens_id} was checked against the fixture diff."
-                            ),
-                            "finding_codes": [],
-                            "evidence_refs": (
-                                ["decision:fixture-simplification", "path:app.py"]
-                                if lens_id == "quality_simplification"
-                                else (
-                                    ["validator:fixture-smoke"]
-                                    if lens_id == "test_validation"
-                                    else ["path:app.py"]
-                                )
-                            ),
-                        }
-                        for lens_id in REVIEW_LENS_IDS
-                    ],
-                    "simplification_decisions": [
-                        {
-                            "decision_id": "fixture-simplification",
-                            "subject": "final fixture diff",
-                            "outcome": "retained",
-                            "reason": "The direct assignment is already minimal.",
-                        }
-                    ],
-                    "safe_fix_applied": False,
-                    "safe_fix_passes": 0,
-                    "validation_evidence": [
+                    "reuse": {
+                        "outcome": "retained",
+                        "summary": "The fixture already uses its direct owner.",
+                        "evidence_refs": ["path:app.py"],
+                    },
+                    "simplification": {
+                        "outcome": "retained",
+                        "summary": "The direct assignment is already minimal.",
+                        "evidence_refs": ["path:app.py"],
+                        "safe_fix_applied": False,
+                    },
+                    "risks": [],
+                    "validation": [
                         {
                             "validator": "fixture-smoke",
                             "status": "passed",
                             "scope": "exact receipt lifecycle",
+                            "required": True,
                         }
                     ],
                 }

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -82,22 +82,22 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "doc": "docs/capabilities/change-quality/README.md",
             },
             {
-                "schema_version": "change_quality_prepare_packet_v1",
+                "schema_version": "change_quality_prepare_packet_v2",
                 "module": "loopx.capabilities.change_quality.receipt",
                 "doc": "docs/capabilities/change-quality/README.md",
             },
             {
-                "schema_version": "change_quality_agent_result_v1",
+                "schema_version": "change_quality_agent_result_v2",
                 "module": "loopx.capabilities.change_quality.result",
                 "doc": "docs/capabilities/change-quality/README.md",
             },
             {
-                "schema_version": "change_quality_receipt_v1",
+                "schema_version": "change_quality_receipt_v2",
                 "module": "loopx.capabilities.change_quality.receipt",
                 "doc": "docs/capabilities/change-quality/README.md",
             },
             {
-                "schema_version": "change_quality_receipt_verification_v1",
+                "schema_version": "change_quality_receipt_verification_v2",
                 "module": "loopx.capabilities.change_quality.receipt",
                 "doc": "docs/capabilities/change-quality/README.md",
             },
@@ -112,6 +112,8 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
             "Turn may transport a packet or receipt reference, but premerge remains the enforcement authority.",
             "The canonical workflow skill is release-owned and project-delivered; the global installer does not publish it into every agent configuration.",
             "Receipts stay in local runtime state; raw model transcripts, private context, and credentials are not persisted.",
+            "Agents write only grounded reuse and simplification conclusions, sparse triggered risks, and validation evidence; LoopX derives guardrail states.",
+            "Existing v1 receipts remain verifiable read-only for their exact scope; new receipts use v2.",
             "The first version is single-level: it qualifies one final diff and does not recursively review reviews.",
         ],
         "next_real_step": (

--- a/loopx/capabilities/change_quality/cli.py
+++ b/loopx/capabilities/change_quality/cli.py
@@ -63,7 +63,7 @@ def register_change_quality_commands(
         "--result-json",
         type=Path,
         required=True,
-        help="Agent result conforming to change_quality_agent_result_v1.",
+        help="Agent result conforming to change_quality_agent_result_v2.",
     )
     record.add_argument(
         "--execute",

--- a/loopx/capabilities/change_quality/receipt.py
+++ b/loopx/capabilities/change_quality/receipt.py
@@ -14,19 +14,21 @@ from .context import build_change_quality_repository_context
 from .policy import change_quality_goal_policy
 from .result import (
     CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
+    LEGACY_CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
     REVIEW_LENSES,
-    REVIEW_LENS_IDS,
     SIMPLIFY_GUARDRAIL_LENS_IDS,
-    SIMPLIFY_PRIMARY_LENS_IDS,
     change_quality_result_decision,
+    derive_change_quality_guardrails,
     normalize_change_quality_result,
+    validate_legacy_change_quality_result_v1,
 )
 from .scope import build_change_quality_scope, resolve_git_root
 
 
-CHANGE_QUALITY_PREPARE_SCHEMA_VERSION = "change_quality_prepare_packet_v1"
-CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION = "change_quality_receipt_v1"
-CHANGE_QUALITY_VERIFY_SCHEMA_VERSION = "change_quality_receipt_verification_v1"
+CHANGE_QUALITY_PREPARE_SCHEMA_VERSION = "change_quality_prepare_packet_v2"
+CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION = "change_quality_receipt_v2"
+LEGACY_CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION = "change_quality_receipt_v1"
+CHANGE_QUALITY_VERIFY_SCHEMA_VERSION = "change_quality_receipt_verification_v2"
 CHANGE_QUALITY_PR_EVIDENCE_SCHEMA_VERSION = "change_quality_pr_evidence_v0"
 
 _PR_EVIDENCE_BY_STATUS = {
@@ -169,14 +171,20 @@ def build_change_quality_prepare_packet(
         "agent_contract": {
             "provider_neutral": True,
             "max_safe_fix_passes": 1,
-            "review_lenses": [dict(item) for item in REVIEW_LENSES],
-            "primary_review_lenses": list(SIMPLIFY_PRIMARY_LENS_IDS),
-            "guardrail_review_lenses": list(SIMPLIFY_GUARDRAIL_LENS_IDS),
+            "primary_result_fields": ["reuse", "simplification"],
+            "sparse_result_fields": ["risks", "validation"],
+            "guardrail_catalog": [
+                dict(item)
+                for item in REVIEW_LENSES
+                if item["lens_id"] in SIMPLIFY_GUARDRAIL_LENS_IDS
+            ],
+            "guardrail_status_owner": "loopx_derived",
             "instructions": [
                 "Review only the exact changed scope and resolve the projected repository instruction and ownership references.",
-                "Spend review effort first on reuse and quality_simplification; record distinct, evidence-backed conclusions for both.",
+                "Write one grounded reuse conclusion and one grounded simplification conclusion.",
                 "Prefer deletion, reuse, direct control flow, and established language idioms over redundant state, parameters, branches, wrappers, or speculative abstraction.",
-                "Treat the remaining lenses as guardrails: expand them only when the changed surface, a repository instruction, a native validator, or a simplify proposal raises a concrete risk; otherwise mark them not_applicable concisely.",
+                "Emit a risks[] item only when a guardrail has a concrete triggered risk; do not write all-clear rows for inactive guardrails.",
+                "LoopX derives guardrail status from sparse risks[] and validation[]; the Agent does not author guardrail states.",
                 "Use blocker only for concrete correctness, security, privacy, contract, or required-validation failures.",
                 "Use repository-native tests, linters, type checkers, and build tools as language-specific oracles.",
                 (
@@ -191,37 +199,24 @@ def build_change_quality_prepare_packet(
                 "schema_version": CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
                 "scope_fingerprint": scope["scope_fingerprint"],
                 "reviewed_final_scope": True,
-                "summary": "",
-                "repository_principles": [
-                    {"source": path, "principle": ""}
-                    for path in repository_context["instruction_refs"]
-                ],
-                "findings": [],
-                "lens_reviews": [
-                    {
-                        "lens_id": lens_id,
-                        "status": "checked",
-                        "summary": "",
-                        "finding_codes": [],
-                        "evidence_refs": [],
-                    }
-                    for lens_id in REVIEW_LENS_IDS
-                ],
-                "simplification_decisions": [
-                    {
-                        "decision_id": "",
-                        "subject": "",
-                        "outcome": "retained",
-                        "reason": "",
-                    }
-                ],
-                "safe_fix_applied": False,
-                "safe_fix_passes": 0,
-                "validation_evidence": [
+                "reuse": {
+                    "outcome": "retained",
+                    "summary": "",
+                    "evidence_refs": [],
+                },
+                "simplification": {
+                    "outcome": "retained",
+                    "summary": "",
+                    "evidence_refs": [],
+                    "safe_fix_applied": False,
+                },
+                "risks": [],
+                "validation": [
                     {
                         "validator": "",
                         "status": "passed",
                         "scope": "",
+                        "required": True,
                     }
                 ],
             },
@@ -264,6 +259,7 @@ def record_change_quality_receipt(
         expected_changed_files=list(scope["changed_files"]),
         expected_instruction_refs=list(repository_context["instruction_refs"]),
     )
+    guardrails = derive_change_quality_guardrails(result)
     decision, unresolved_blockers = change_quality_result_decision(result)
     receipt_id = f"cqr_{str(scope['scope_fingerprint'])[:20]}"
     receipt = {
@@ -274,6 +270,7 @@ def record_change_quality_receipt(
         "policy": policy,
         "scope": scope,
         "result": result,
+        "guardrails": guardrails,
         "decision": decision,
         "unresolved_blockers": unresolved_blockers,
     }
@@ -309,24 +306,50 @@ def _stored_receipt_is_valid(
 ) -> bool:
     if not (
         receipt
-        and receipt.get("schema_version") == CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION
+        and receipt.get("schema_version")
+        in {
+            CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION,
+            LEGACY_CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION,
+        }
         and receipt.get("decision") == "pass"
         and isinstance(receipt.get("result"), dict)
         and isinstance(receipt.get("scope"), dict)
         and receipt["scope"].get("scope_fingerprint") == scope_fingerprint
     ):
         return False
+    result = receipt["result"]
     try:
-        normalized = normalize_change_quality_result(
-            receipt["result"],
-            expected_fingerprint=scope_fingerprint,
-            safe_fix_allowed=safe_fix_allowed,
-            expected_changed_files=changed_files,
-            expected_instruction_refs=instruction_refs,
-        )
+        if (
+            receipt.get("schema_version") == CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION
+            and result.get("schema_version") == CHANGE_QUALITY_RESULT_SCHEMA_VERSION
+        ):
+            normalized = normalize_change_quality_result(
+                result,
+                expected_fingerprint=scope_fingerprint,
+                safe_fix_allowed=safe_fix_allowed,
+                expected_changed_files=changed_files,
+                expected_instruction_refs=instruction_refs,
+            )
+            guardrails = derive_change_quality_guardrails(normalized)
+            decision, unresolved = change_quality_result_decision(normalized)
+            if receipt.get("guardrails") != guardrails:
+                return False
+        elif (
+            receipt.get("schema_version")
+            == LEGACY_CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION
+            and result.get("schema_version")
+            == LEGACY_CHANGE_QUALITY_RESULT_SCHEMA_VERSION
+        ):
+            decision, unresolved = validate_legacy_change_quality_result_v1(
+                result,
+                expected_fingerprint=scope_fingerprint,
+                safe_fix_allowed=safe_fix_allowed,
+                expected_instruction_refs=instruction_refs,
+            )
+        else:
+            return False
     except (TypeError, ValueError):
         return False
-    decision, unresolved = change_quality_result_decision(normalized)
     return decision == "pass" and receipt.get("unresolved_blockers") == unresolved
 
 

--- a/loopx/capabilities/change_quality/result.py
+++ b/loopx/capabilities/change_quality/result.py
@@ -6,14 +6,18 @@ from typing import Any
 from ...feedback import validate_public_safe_text
 
 
-CHANGE_QUALITY_RESULT_SCHEMA_VERSION = "change_quality_agent_result_v1"
-FINDING_SEVERITIES = frozenset({"blocker", "warning", "advisory"})
-LENS_STATUSES = frozenset({"checked", "finding", "not_applicable"})
-SIMPLIFICATION_OUTCOMES = frozenset({"fixed", "retained", "deferred", "not_applicable"})
-VALIDATION_STATUSES = frozenset({"passed", "failed", "skipped"})
-EVIDENCE_REF_KINDS = frozenset(
-    {"path", "instruction", "finding", "validator", "decision"}
+CHANGE_QUALITY_RESULT_SCHEMA_VERSION = "change_quality_agent_result_v2"
+LEGACY_CHANGE_QUALITY_RESULT_SCHEMA_VERSION = "change_quality_agent_result_v1"
+CHANGE_QUALITY_GUARDRAIL_SCHEMA_VERSION = "change_quality_guardrail_summary_v0"
+
+RISK_SEVERITIES = frozenset({"blocker", "warning", "advisory"})
+REUSE_OUTCOMES = frozenset({"reused", "retained", "deferred", "not_applicable"})
+SIMPLIFICATION_OUTCOMES = frozenset(
+    {"fixed", "retained", "deferred", "not_applicable"}
 )
+VALIDATION_STATUSES = frozenset({"passed", "failed", "skipped"})
+EVIDENCE_REF_KINDS = frozenset({"path", "instruction", "validator"})
+
 REVIEW_LENSES = (
     {
         "lens_id": "reuse",
@@ -112,43 +116,6 @@ def _relative_path(value: Any, *, field: str) -> str | None:
     return path.as_posix()
 
 
-def _normalize_finding(value: Any, *, index: int) -> dict[str, Any]:
-    if not isinstance(value, dict):
-        raise ValueError(f"findings[{index}] must be an object")
-    severity = str(value.get("severity") or "").strip().lower()
-    if severity not in FINDING_SEVERITIES:
-        raise ValueError(
-            f"findings[{index}].severity must be one of {sorted(FINDING_SEVERITIES)}"
-        )
-    code = _bounded_text(
-        value.get("code"),
-        field=f"findings[{index}].code",
-        limit=80,
-    )
-    message = _bounded_text(
-        value.get("message"),
-        field=f"findings[{index}].message",
-        limit=320,
-    )
-    if not code or not message:
-        raise ValueError(f"findings[{index}] requires code and message")
-    finding = {
-        "severity": severity,
-        "code": code,
-        "message": message,
-        "resolved": value.get("resolved") is True,
-    }
-    path = _relative_path(value.get("path"), field=f"findings[{index}].path")
-    if path:
-        finding["path"] = path
-    line = value.get("line")
-    if line is not None:
-        if not isinstance(line, int) or line < 1:
-            raise ValueError(f"findings[{index}].line must be a positive integer")
-        finding["line"] = line
-    return finding
-
-
 def _bounded_text_list(
     value: Any,
     *,
@@ -187,181 +154,141 @@ def _normalize_evidence_ref(value: Any, *, field: str) -> str:
     return f"{kind}:{normalized_target}"
 
 
-def _normalize_repository_principle(value: Any, *, index: int) -> dict[str, str]:
-    if not isinstance(value, dict):
-        raise ValueError(f"repository_principles[{index}] must be an object")
-    source = _relative_path(
-        value.get("source"),
-        field=f"repository_principles[{index}].source",
-    )
-    principle = _bounded_text(
-        value.get("principle"),
-        field=f"repository_principles[{index}].principle",
-        limit=320,
-    )
-    if not source or not principle:
-        raise ValueError(
-            f"repository_principles[{index}] requires source and principle"
-        )
-    return {"source": source, "principle": principle}
-
-
-def _normalize_lens_review(value: Any, *, index: int) -> dict[str, Any]:
-    if not isinstance(value, dict):
-        raise ValueError(f"lens_reviews[{index}] must be an object")
-    lens_id = str(value.get("lens_id") or "").strip()
-    if lens_id not in REVIEW_LENS_IDS:
-        raise ValueError(f"lens_reviews[{index}].lens_id is not a required lens")
-    status = str(value.get("status") or "").strip().lower()
-    if status not in LENS_STATUSES:
-        raise ValueError(
-            f"lens_reviews[{index}].status must be one of {sorted(LENS_STATUSES)}"
-        )
-    summary = _bounded_text(
-        value.get("summary"),
-        field=f"lens_reviews[{index}].summary",
-        limit=320,
-    )
-    if not summary:
-        raise ValueError(f"lens_reviews[{index}].summary is required")
-    finding_codes = _bounded_text_list(
-        value.get("finding_codes"),
-        field=f"lens_reviews[{index}].finding_codes",
-        item_limit=80,
-        count_limit=10,
-    )
-    if status == "finding" and not finding_codes:
-        raise ValueError(
-            f"lens_reviews[{index}] with status=finding requires finding_codes"
-        )
-    if status != "finding" and finding_codes:
-        raise ValueError(
-            f"lens_reviews[{index}] may reference findings only with status=finding"
-        )
-    evidence_refs = [
-        _normalize_evidence_ref(
-            item,
-            field=f"lens_reviews[{index}].evidence_refs[]",
-        )
+def _normalize_evidence_refs(value: Any, *, field: str) -> list[str]:
+    refs = [
+        _normalize_evidence_ref(item, field=f"{field}[]")
         for item in _bounded_text_list(
-            value.get("evidence_refs"),
-            field=f"lens_reviews[{index}].evidence_refs",
+            value,
+            field=field,
             item_limit=400,
             count_limit=20,
         )
     ]
-    if status == "not_applicable" and evidence_refs:
-        raise ValueError(
-            f"lens_reviews[{index}] with status=not_applicable cannot cite evidence"
-        )
-    if status != "not_applicable" and not evidence_refs:
-        raise ValueError(
-            f"lens_reviews[{index}] with status={status} requires evidence_refs"
-        )
+    if len(set(refs)) != len(refs):
+        raise ValueError(f"{field} must not contain duplicates")
+    return refs
+
+
+def _normalize_conclusion(
+    value: Any,
+    *,
+    field: str,
+    allowed_outcomes: frozenset[str],
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{field} must be an object")
+    outcome = str(value.get("outcome") or "").strip().lower()
+    if outcome not in allowed_outcomes:
+        raise ValueError(f"{field}.outcome must be one of {sorted(allowed_outcomes)}")
+    summary = _bounded_text(value.get("summary"), field=f"{field}.summary", limit=400)
+    if not summary:
+        raise ValueError(f"{field}.summary is required")
+    evidence_refs = _normalize_evidence_refs(
+        value.get("evidence_refs"),
+        field=f"{field}.evidence_refs",
+    )
+    if not evidence_refs:
+        raise ValueError(f"{field}.evidence_refs must contain grounded evidence")
     return {
-        "lens_id": lens_id,
-        "status": status,
+        "outcome": outcome,
         "summary": summary,
-        "finding_codes": finding_codes,
         "evidence_refs": evidence_refs,
     }
 
 
-def _normalize_simplification_decision(
-    value: Any,
-    *,
-    index: int,
-) -> dict[str, Any]:
+def _normalize_risk(value: Any, *, index: int) -> dict[str, Any]:
+    field = f"risks[{index}]"
     if not isinstance(value, dict):
-        raise ValueError(f"simplification_decisions[{index}] must be an object")
-    decision_id = _bounded_text(
-        value.get("decision_id"),
-        field=f"simplification_decisions[{index}].decision_id",
-        limit=80,
-    )
-    outcome = str(value.get("outcome") or "").strip().lower()
-    if outcome not in SIMPLIFICATION_OUTCOMES:
+        raise ValueError(f"{field} must be an object")
+    category = str(value.get("category") or "").strip()
+    if category not in SIMPLIFY_GUARDRAIL_LENS_IDS:
         raise ValueError(
-            "simplification_decisions"
-            f"[{index}].outcome must be one of {sorted(SIMPLIFICATION_OUTCOMES)}"
+            f"{field}.category must be one of {sorted(SIMPLIFY_GUARDRAIL_LENS_IDS)}"
         )
-    subject = _bounded_text(
-        value.get("subject"),
-        field=f"simplification_decisions[{index}].subject",
-        limit=160,
-    )
-    reason = _bounded_text(
-        value.get("reason"),
-        field=f"simplification_decisions[{index}].reason",
-        limit=320,
-    )
-    if not decision_id or not subject or not reason:
+    severity = str(value.get("severity") or "").strip().lower()
+    if severity not in RISK_SEVERITIES:
         raise ValueError(
-            f"simplification_decisions[{index}] requires decision_id, subject, and reason"
+            f"{field}.severity must be one of {sorted(RISK_SEVERITIES)}"
         )
-    decision = {
-        "decision_id": decision_id,
-        "subject": subject,
-        "outcome": outcome,
-        "reason": reason,
+    code = _bounded_text(value.get("code"), field=f"{field}.code", limit=80)
+    message = _bounded_text(value.get("message"), field=f"{field}.message", limit=320)
+    if not code or not message:
+        raise ValueError(f"{field} requires code and message")
+    evidence_refs = _normalize_evidence_refs(
+        value.get("evidence_refs"),
+        field=f"{field}.evidence_refs",
+    )
+    if not evidence_refs:
+        raise ValueError(f"{field}.evidence_refs must contain grounded evidence")
+    risk = {
+        "category": category,
+        "severity": severity,
+        "code": code,
+        "message": message,
+        "resolved": value.get("resolved") is True,
+        "evidence_refs": evidence_refs,
     }
-    path = _relative_path(
-        value.get("path"),
-        field=f"simplification_decisions[{index}].path",
-    )
+    path = _relative_path(value.get("path"), field=f"{field}.path")
     if path:
-        decision["path"] = path
+        risk["path"] = path
     line = value.get("line")
     if line is not None:
         if not isinstance(line, int) or line < 1:
-            raise ValueError(
-                f"simplification_decisions[{index}].line must be a positive integer"
-            )
-        decision["line"] = line
-    return decision
+            raise ValueError(f"{field}.line must be a positive integer")
+        risk["line"] = line
+    return risk
 
 
-def _normalize_validation_evidence(value: Any, *, index: int) -> dict[str, Any]:
+def _normalize_validation(value: Any, *, index: int) -> dict[str, Any]:
+    field = f"validation[{index}]"
     if not isinstance(value, dict):
-        raise ValueError(f"validation_evidence[{index}] must be an object")
+        raise ValueError(f"{field} must be an object")
     status = str(value.get("status") or "").strip().lower()
     if status not in VALIDATION_STATUSES:
-        raise ValueError(
-            f"validation_evidence[{index}].status must be one of "
-            f"{sorted(VALIDATION_STATUSES)}"
-        )
+        raise ValueError(f"{field}.status must be one of {sorted(VALIDATION_STATUSES)}")
     validator = _bounded_text(
         value.get("validator"),
-        field=f"validation_evidence[{index}].validator",
+        field=f"{field}.validator",
         limit=120,
     )
-    scope = _bounded_text(
-        value.get("scope"),
-        field=f"validation_evidence[{index}].scope",
-        limit=240,
-    )
+    scope = _bounded_text(value.get("scope"), field=f"{field}.scope", limit=240)
     if not validator or not scope:
-        raise ValueError(f"validation_evidence[{index}] requires validator and scope")
-    evidence = {"validator": validator, "status": status, "scope": scope}
-    command = _bounded_text(
-        value.get("command"),
-        field=f"validation_evidence[{index}].command",
-        limit=320,
-    )
-    reason = _bounded_text(
-        value.get("reason"),
-        field=f"validation_evidence[{index}].reason",
-        limit=320,
-    )
+        raise ValueError(f"{field} requires validator and scope")
+    required = value.get("required") is not False
+    evidence: dict[str, Any] = {
+        "validator": validator,
+        "status": status,
+        "scope": scope,
+        "required": required,
+    }
+    command = _bounded_text(value.get("command"), field=f"{field}.command", limit=320)
+    reason = _bounded_text(value.get("reason"), field=f"{field}.reason", limit=320)
     if command:
         evidence["command"] = command
     if reason:
         evidence["reason"] = reason
     if status in {"failed", "skipped"} and not reason:
-        raise ValueError(
-            f"validation_evidence[{index}] with status={status} requires reason"
-        )
+        raise ValueError(f"{field} with status={status} requires reason")
     return evidence
+
+
+def _validate_evidence_targets(
+    refs: list[str],
+    *,
+    field: str,
+    changed_files: set[str],
+    instruction_refs: set[str],
+    validator_ids: set[str],
+) -> None:
+    targets = {
+        "path": changed_files,
+        "instruction": instruction_refs,
+        "validator": validator_ids,
+    }
+    for evidence_ref in refs:
+        kind, target = evidence_ref.split(":", 1)
+        if target not in targets[kind]:
+            raise ValueError(f"{field} references unknown evidence: {evidence_ref}")
 
 
 def normalize_change_quality_result(
@@ -378,6 +305,18 @@ def normalize_change_quality_result(
         raise ValueError(
             f"result schema_version must be {CHANGE_QUALITY_RESULT_SCHEMA_VERSION}"
         )
+    allowed_fields = {
+        "schema_version",
+        "scope_fingerprint",
+        "reviewed_final_scope",
+        "reuse",
+        "simplification",
+        "risks",
+        "validation",
+    }
+    unsupported = sorted(set(value) - allowed_fields)
+    if unsupported:
+        raise ValueError(f"result contains unsupported fields: {unsupported}")
     fingerprint = str(value.get("scope_fingerprint") or "").strip()
     if fingerprint != expected_fingerprint:
         raise ValueError(
@@ -386,197 +325,240 @@ def normalize_change_quality_result(
         )
     if value.get("reviewed_final_scope") is not True:
         raise ValueError("result must set reviewed_final_scope=true")
-    safe_fix_applied = value.get("safe_fix_applied") is True
+
+    reuse = _normalize_conclusion(
+        value.get("reuse"),
+        field="reuse",
+        allowed_outcomes=REUSE_OUTCOMES,
+    )
+    simplification = _normalize_conclusion(
+        value.get("simplification"),
+        field="simplification",
+        allowed_outcomes=SIMPLIFICATION_OUTCOMES,
+    )
+    safe_fix_applied = bool(
+        isinstance(value.get("simplification"), dict)
+        and value["simplification"].get("safe_fix_applied") is True
+    )
     if safe_fix_applied and not safe_fix_allowed:
         raise ValueError(
-            "result reports safe_fix_applied but goal policy forbids safe fixes"
+            "result reports simplification.safe_fix_applied but goal policy "
+            "forbids safe fixes"
         )
-    safe_fix_passes = value.get("safe_fix_passes", 0)
-    if not isinstance(safe_fix_passes, int) or safe_fix_passes not in {0, 1}:
-        raise ValueError("safe_fix_passes must be 0 or 1")
-    if safe_fix_applied and safe_fix_passes != 1:
-        raise ValueError("safe_fix_applied=true requires safe_fix_passes=1")
-    if not safe_fix_applied and safe_fix_passes != 0:
-        raise ValueError("safe_fix_passes=1 requires safe_fix_applied=true")
-    raw_principles = value.get("repository_principles")
-    if not isinstance(raw_principles, list):
-        raise ValueError("repository_principles must be an array")
-    if len(raw_principles) > 20:
-        raise ValueError("repository_principles supports at most 20 items")
-    repository_principles = [
-        _normalize_repository_principle(item, index=index)
-        for index, item in enumerate(raw_principles)
-    ]
-    principle_sources = [item["source"] for item in repository_principles]
-    if len(set(principle_sources)) != len(principle_sources):
-        raise ValueError("repository_principles must not repeat a source")
-    if expected_instruction_refs is not None:
-        expected_sources = set(expected_instruction_refs)
-        actual_sources = set(principle_sources)
-        if actual_sources != expected_sources:
-            missing_sources = sorted(expected_sources - actual_sources)
-            unknown_sources = sorted(actual_sources - expected_sources)
-            raise ValueError(
-                "repository_principles must cover the projected instruction refs; "
-                f"missing={missing_sources} unknown={unknown_sources}"
-            )
-    findings = [
-        _normalize_finding(item, index=index)
-        for index, item in enumerate(value.get("findings") or [])
-    ]
-    if len(findings) > 20:
-        raise ValueError("result supports at most 20 findings")
-    finding_codes = [str(item["code"]) for item in findings]
-    if len(set(finding_codes)) != len(finding_codes):
-        raise ValueError("finding codes must be unique")
+    if safe_fix_applied != (simplification["outcome"] == "fixed"):
+        raise ValueError(
+            "simplification.outcome=fixed and safe_fix_applied=true must agree"
+        )
+    simplification["safe_fix_applied"] = safe_fix_applied
 
-    lens_values = value.get("lens_reviews")
-    if not isinstance(lens_values, list):
-        raise ValueError("lens_reviews must be an array")
-    lens_reviews = [
-        _normalize_lens_review(item, index=index)
-        for index, item in enumerate(lens_values)
-    ]
-    lens_map = {item["lens_id"]: item for item in lens_reviews}
-    if len(lens_map) != len(lens_reviews):
-        raise ValueError("lens_reviews must not contain duplicate lens_id values")
-    missing_lenses = [lens_id for lens_id in REVIEW_LENS_IDS if lens_id not in lens_map]
-    if missing_lenses:
-        raise ValueError(f"lens_reviews missing required lenses: {missing_lenses}")
-    primary_summaries = [
-        lens_map[lens_id]["summary"] for lens_id in SIMPLIFY_PRIMARY_LENS_IDS
-    ]
-    if len(set(primary_summaries)) != len(primary_summaries):
-        raise ValueError(
-            "primary simplify lenses must contain lens-specific summaries, "
-            "not a repeated generic all-clear"
-        )
-    if not any(item["status"] != "not_applicable" for item in lens_reviews):
-        raise ValueError("at least one review lens must be applicable")
-    referenced_codes = {code for lens in lens_reviews for code in lens["finding_codes"]}
-    unknown_codes = sorted(referenced_codes - set(finding_codes))
-    if unknown_codes:
-        raise ValueError(
-            f"lens_reviews reference unknown finding codes: {unknown_codes}"
-        )
-    unclassified_codes = sorted(set(finding_codes) - referenced_codes)
-    if unclassified_codes:
-        raise ValueError(
-            f"findings must be classified by at least one lens: {unclassified_codes}"
-        )
+    raw_risks = value.get("risks")
+    if not isinstance(raw_risks, list):
+        raise ValueError("risks must be an array")
+    if len(raw_risks) > 20:
+        raise ValueError("risks supports at most 20 items")
+    risks = [_normalize_risk(item, index=index) for index, item in enumerate(raw_risks)]
+    risk_codes = [item["code"] for item in risks]
+    if len(set(risk_codes)) != len(risk_codes):
+        raise ValueError("risk codes must be unique")
 
-    raw_decisions = value.get("simplification_decisions")
-    if not isinstance(raw_decisions, list) or not raw_decisions:
-        raise ValueError("simplification_decisions must contain at least one item")
-    if len(raw_decisions) > 20:
-        raise ValueError("simplification_decisions supports at most 20 items")
-    simplification_decisions = [
-        _normalize_simplification_decision(item, index=index)
-        for index, item in enumerate(raw_decisions)
-    ]
-    decision_ids = [item["decision_id"] for item in simplification_decisions]
-    if len(set(decision_ids)) != len(decision_ids):
-        raise ValueError("simplification decision ids must be unique")
-    fixed_decisions = [
-        item for item in simplification_decisions if item["outcome"] == "fixed"
-    ]
-    if safe_fix_applied and not fixed_decisions:
-        raise ValueError(
-            "safe_fix_applied=true requires a simplification decision with outcome=fixed"
-        )
-    if fixed_decisions and not safe_fix_applied:
-        raise ValueError(
-            "simplification decision outcome=fixed requires safe_fix_applied=true"
-        )
-
-    raw_validation = value.get("validation_evidence")
+    raw_validation = value.get("validation")
     if not isinstance(raw_validation, list) or not raw_validation:
-        raise ValueError("validation_evidence must contain at least one item")
+        raise ValueError("validation must contain at least one item")
     if len(raw_validation) > 20:
-        raise ValueError("validation_evidence supports at most 20 items")
-    validation_evidence = [
-        _normalize_validation_evidence(item, index=index)
+        raise ValueError("validation supports at most 20 items")
+    validation = [
+        _normalize_validation(item, index=index)
         for index, item in enumerate(raw_validation)
     ]
-    validator_ids = [item["validator"] for item in validation_evidence]
+    validator_ids = [item["validator"] for item in validation]
     if len(set(validator_ids)) != len(validator_ids):
-        raise ValueError("validation_evidence validator ids must be unique")
-    evidence_targets = {
-        "path": set(expected_changed_files or []),
-        "instruction": set(principle_sources),
-        "finding": set(finding_codes),
-        "validator": set(validator_ids),
-        "decision": set(decision_ids),
-    }
-    for lens in lens_reviews:
-        refs_by_kind: dict[str, set[str]] = {}
-        for evidence_ref in lens["evidence_refs"]:
-            kind, target = evidence_ref.split(":", 1)
-            refs_by_kind.setdefault(kind, set()).add(target)
-            if kind != "path" and target not in evidence_targets[kind]:
-                raise ValueError(
-                    f"lens {lens['lens_id']} references unknown evidence: {evidence_ref}"
-                )
-            if (
-                kind == "path"
-                and expected_changed_files is not None
-                and target not in evidence_targets["path"]
-            ):
-                raise ValueError(
-                    f"lens {lens['lens_id']} references unchanged path: {target}"
-                )
-        if lens["status"] == "finding" and not set(lens["finding_codes"]).issubset(
-            refs_by_kind.get("finding", set())
-        ):
-            raise ValueError(
-                f"lens {lens['lens_id']} must anchor each finding_code with finding:<code>"
-            )
+        raise ValueError("validation validator ids must be unique")
+
+    changed_files = set(expected_changed_files or [])
+    instruction_refs = set(expected_instruction_refs or [])
+    validators = set(validator_ids)
+    _validate_evidence_targets(
+        reuse["evidence_refs"],
+        field="reuse",
+        changed_files=changed_files,
+        instruction_refs=instruction_refs,
+        validator_ids=validators,
+    )
+    _validate_evidence_targets(
+        simplification["evidence_refs"],
+        field="simplification",
+        changed_files=changed_files,
+        instruction_refs=instruction_refs,
+        validator_ids=validators,
+    )
+    for index, risk in enumerate(risks):
+        _validate_evidence_targets(
+            risk["evidence_refs"],
+            field=f"risks[{index}]",
+            changed_files=changed_files,
+            instruction_refs=instruction_refs,
+            validator_ids=validators,
+        )
         if (
-            lens["lens_id"] == "quality_simplification"
-            and lens["status"] != "not_applicable"
-            and not refs_by_kind.get("decision")
+            "path" in risk
+            and expected_changed_files is not None
+            and risk["path"] not in changed_files
         ):
-            raise ValueError(
-                "quality_simplification lens requires a decision:<decision_id> reference"
-            )
-        if (
-            lens["lens_id"] == "test_validation"
-            and lens["status"] != "not_applicable"
-            and not refs_by_kind.get("validator")
-        ):
-            raise ValueError(
-                "test_validation lens requires a validator:<validator> reference"
-            )
-    summary = _bounded_text(value.get("summary"), field="summary", limit=500)
-    if not summary:
-        raise ValueError("summary is required")
+            raise ValueError(f"risks[{index}].path must name a changed file")
+
     return {
         "schema_version": CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
         "scope_fingerprint": fingerprint,
         "reviewed_final_scope": True,
-        "summary": summary,
-        "repository_principles": repository_principles,
-        "findings": findings,
-        "lens_reviews": [lens_map[lens_id] for lens_id in REVIEW_LENS_IDS],
-        "simplification_decisions": simplification_decisions,
-        "safe_fix_applied": safe_fix_applied,
-        "safe_fix_passes": safe_fix_passes,
-        "validation_evidence": validation_evidence,
+        "reuse": reuse,
+        "simplification": simplification,
+        "risks": risks,
+        "validation": validation,
+    }
+
+
+def derive_change_quality_guardrails(result: dict[str, Any]) -> dict[str, Any]:
+    risks = result["risks"]
+    validation = result["validation"]
+    states: list[dict[str, Any]] = []
+    blocking_codes: list[str] = []
+    for guardrail_id in SIMPLIFY_GUARDRAIL_LENS_IDS:
+        category_risks = [item for item in risks if item["category"] == guardrail_id]
+        unresolved_blockers = [
+            item["code"]
+            for item in category_risks
+            if item["severity"] == "blocker" and item["resolved"] is not True
+        ]
+        validation_blockers: list[str] = []
+        optional_skips: list[str] = []
+        if guardrail_id == "test_validation":
+            validation_blockers = [
+                f"validator:{item['validator']}"
+                for item in validation
+                if item["status"] == "failed"
+                or (item["status"] == "skipped" and item["required"])
+            ]
+            optional_skips = [
+                f"validator:{item['validator']}"
+                for item in validation
+                if item["status"] == "skipped" and not item["required"]
+            ]
+        current_blockers = [*unresolved_blockers, *validation_blockers]
+        blocking_codes.extend(current_blockers)
+        unresolved_risks = [
+            item["code"] for item in category_risks if item["resolved"] is not True
+        ]
+        if current_blockers:
+            status = "blocked"
+        elif unresolved_risks or optional_skips:
+            status = "risk"
+        elif category_risks:
+            status = "resolved"
+        elif guardrail_id == "test_validation" and validation:
+            status = "satisfied"
+        else:
+            status = "not_triggered"
+        states.append(
+            {
+                "guardrail_id": guardrail_id,
+                "status": status,
+                "risk_codes": [item["code"] for item in category_risks],
+                "blocking_codes": current_blockers,
+            }
+        )
+    return {
+        "schema_version": CHANGE_QUALITY_GUARDRAIL_SCHEMA_VERSION,
+        "derived": True,
+        "states": states,
+        "blocking_codes": blocking_codes,
     }
 
 
 def change_quality_result_decision(
     result: dict[str, Any],
 ) -> tuple[str, list[str]]:
-    unresolved_blockers = [
-        str(item["code"])
-        for item in result["findings"]
-        if item["severity"] == "blocker" and item["resolved"] is not True
-    ]
-    failed_validators = [
-        f"validator:{item['validator']}"
-        for item in result["validation_evidence"]
-        if item["status"] == "failed"
-    ]
-    unresolved = [*unresolved_blockers, *failed_validators]
+    guardrails = derive_change_quality_guardrails(result)
+    unresolved = list(guardrails["blocking_codes"])
+    return ("fail", unresolved) if unresolved else ("pass", [])
+
+
+def validate_legacy_change_quality_result_v1(
+    value: Any,
+    *,
+    expected_fingerprint: str,
+    safe_fix_allowed: bool,
+    expected_instruction_refs: list[str] | None = None,
+) -> tuple[str, list[str]]:
+    """Validate decision-critical v1 fields for read-only receipt compatibility."""
+    if not isinstance(value, dict):
+        raise ValueError("legacy result root must be an object")
+    if value.get("schema_version") != LEGACY_CHANGE_QUALITY_RESULT_SCHEMA_VERSION:
+        raise ValueError("legacy result schema_version is invalid")
+    if str(value.get("scope_fingerprint") or "").strip() != expected_fingerprint:
+        raise ValueError("legacy result scope fingerprint is stale")
+    if value.get("reviewed_final_scope") is not True:
+        raise ValueError("legacy result did not review the final scope")
+    if value.get("safe_fix_applied") is True and not safe_fix_allowed:
+        raise ValueError("legacy result reports a forbidden safe fix")
+
+    principles = value.get("repository_principles")
+    if not isinstance(principles, list):
+        raise ValueError("legacy repository_principles must be an array")
+    principle_sources = {
+        str(item.get("source") or "").strip()
+        for item in principles
+        if isinstance(item, dict)
+    }
+    if expected_instruction_refs is not None and principle_sources != set(
+        expected_instruction_refs
+    ):
+        raise ValueError("legacy repository principles are incomplete")
+
+    findings = value.get("findings")
+    lenses = value.get("lens_reviews")
+    decisions = value.get("simplification_decisions")
+    validation = value.get("validation_evidence")
+    if not isinstance(findings, list) or len(findings) > 20:
+        raise ValueError("legacy findings are invalid")
+    if not isinstance(lenses, list):
+        raise ValueError("legacy lens reviews are invalid")
+    lens_ids = {
+        str(item.get("lens_id") or "")
+        for item in lenses
+        if isinstance(item, dict)
+    }
+    if lens_ids != set(REVIEW_LENS_IDS):
+        raise ValueError("legacy lens coverage is incomplete")
+    if not isinstance(decisions, list) or not decisions:
+        raise ValueError("legacy simplification decisions are missing")
+    if not isinstance(validation, list) or not validation:
+        raise ValueError("legacy validation evidence is missing")
+
+    unresolved: list[str] = []
+    for index, finding in enumerate(findings):
+        if not isinstance(finding, dict):
+            raise ValueError(f"legacy findings[{index}] must be an object")
+        severity = str(finding.get("severity") or "").strip().lower()
+        code = _bounded_text(
+            finding.get("code"),
+            field=f"legacy findings[{index}].code",
+            limit=80,
+        )
+        if severity not in RISK_SEVERITIES or not code:
+            raise ValueError(f"legacy findings[{index}] is invalid")
+        if severity == "blocker" and finding.get("resolved") is not True:
+            unresolved.append(code)
+    for index, evidence in enumerate(validation):
+        if not isinstance(evidence, dict):
+            raise ValueError(f"legacy validation_evidence[{index}] must be an object")
+        status = str(evidence.get("status") or "").strip().lower()
+        validator = _bounded_text(
+            evidence.get("validator"),
+            field=f"legacy validation_evidence[{index}].validator",
+            limit=120,
+        )
+        if status not in VALIDATION_STATUSES or not validator:
+            raise ValueError(f"legacy validation_evidence[{index}] is invalid")
+        if status == "failed":
+            unresolved.append(f"validator:{validator}")
     return ("fail", unresolved) if unresolved else ("pass", [])

--- a/skills/loopx-change-quality/SKILL.md
+++ b/skills/loopx-change-quality/SKILL.md
@@ -61,12 +61,12 @@ Spend the review budget on simplification before broad quality analysis:
 4. Prefer the smallest coherent edit that leaves ownership and intent clearer.
    Do not create churn when the current shape is already direct and cohesive.
 
-`reuse` and `quality_simplification` are the two primary lenses. Give each a
-distinct, evidence-backed conclusion. The remaining lenses are guardrails:
-expand one only when the changed surface, repository instructions, a native
-validator, or the proposed simplification raises a concrete risk. Otherwise
-mark it `not_applicable` with the same short standard reason; do not spend
-tokens inventing lens-specific prose.
+Write one evidence-backed `reuse` conclusion and one evidence-backed
+`simplification` conclusion. Do not emit a row for every remaining lens.
+Those dimensions are guardrail categories for sparse `risks[]`: add an item
+only when the changed surface, repository instructions, a native validator, or
+the proposed simplification raises a concrete risk. LoopX derives each
+guardrail's status from `risks[]` and `validation[]`.
 
 The available review lenses are:
 
@@ -104,12 +104,12 @@ repository-native instruction; do not fill them with guessed commands. Treat
 `ignored_manifest_refs` as non-executable context, especially fixtures and
 vendored projects.
 
-Record one compact `repository_principles` item for every projected instruction
-reference. Every applicable lens must cite typed `evidence_refs` using
-`path:`, `instruction:`, `finding:`, `validator:`, or `decision:`. A
-`quality_simplification` conclusion cites its decision id, and a
-`test_validation` conclusion cites the repository-native validator. Do not
-repeat the same generic all-clear across the two primary lenses.
+Read every projected instruction reference, but do not copy its prose into the
+result. Ground `reuse`, `simplification`, and each emitted risk with typed
+`evidence_refs` using `path:`, `instruction:`, or `validator:`. Keep
+`risks[]` empty when no guardrail is triggered. Record only validators that
+were selected or required; failed validation and skipped required validation
+are independently blocking.
 
 Use `blocker` only for a concrete correctness, security, privacy, contract, or
 required-validation failure. Style preferences and speculative redesigns are
@@ -119,9 +119,10 @@ This first version is single-level. Review one final diff; do not recursively
 review the review, spawn a hierarchy of quality agents, or require agreement
 between several models.
 
-The required lenses are a review discipline, not evidence that a particular
-model applies them well. Maintainers qualify model behavior separately against
-the public clean-PR and seeded Python, Rust, and TypeScript shadow matrix.
+The guardrail catalog is review guidance, not an Agent output checklist or
+evidence that a particular model applies it well. Maintainers qualify model
+behavior separately against the public clean-PR and seeded Python, Rust, and
+TypeScript shadow matrix.
 Normal delivery does not launch that low-frequency evaluation, and a model
 shadow result cannot mutate goal policy or grant merge authority.
 
@@ -133,10 +134,11 @@ shadow result cannot mutate goal policy or grant merge authority.
 - `strict_receipt=true` requires exact-scope evidence before merge and grants
   no permission to edit.
 
-When `safe_fix` is false, report findings without modifying files. When it is
-true, one repair pass may address clear findings inside the selected todo and
-goal boundary. Do not use destructive git, broaden permissions, change product
-intent, add unrelated refactors, or conceal a failing validator.
+When `safe_fix` is false, report risks without modifying files. When it is
+true, one repair pass may address a clear simplify opportunity or risk inside
+the selected todo and goal boundary. Do not use destructive git, broaden
+permissions, change product intent, add unrelated refactors, or conceal a
+failing validator.
 
 After any edit, rerun `prepare`. The old fingerprint is invalid. Review the
 entire new final scope, not only the lines changed by the repair.
@@ -144,12 +146,12 @@ entire new final scope, not only the lines changed by the repair.
 ## Record The Receipt
 
 Write a compact result conforming to the packet's
-`change_quality_agent_result_v1` template. The result must include every
-required lens, projected repository principles, at least one explicit
-simplification decision, typed evidence references, and typed validation
-evidence. A skipped or failed validator needs a reason; a failed validator
-makes the receipt non-passing. Keep raw transcripts, private paths, credentials,
-and unbounded logs out of the result.
+`change_quality_agent_result_v2` template. Beyond exact-scope metadata, the
+Agent writes only `reuse`, `simplification`, sparse `risks[]`, and
+`validation[]`. `simplification.safe_fix_applied` records the one permitted
+repair pass. A skipped or failed validator needs a reason; failed validation or
+skipped required validation makes the receipt non-passing. Keep raw
+transcripts, private paths, credentials, and unbounded logs out of the result.
 
 Then record and read back the exact receipt:
 
@@ -167,9 +169,10 @@ loopx --format json change-quality verify \
   --base-ref origin/main
 ```
 
-A receipt with an unresolved blocker or failed validator is not passing. A
-receipt for an earlier fingerprint or an earlier receipt protocol does not
-qualify a later diff.
+A receipt with an unresolved blocker, failed validator, or skipped required
+validator is not passing. A receipt for an earlier fingerprint does not
+qualify a later diff. Existing v1 receipts may be verified read-only for their
+exact scope; new writes use v2.
 
 ## Premerge Enforcement
 

--- a/tests/capabilities/test_change_quality.py
+++ b/tests/capabilities/test_change_quality.py
@@ -16,14 +16,14 @@ from loopx.canary.premerge import (
 from loopx.capabilities.change_quality.policy import change_quality_goal_policy
 from loopx.capabilities.change_quality.receipt import (
     CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
-    REVIEW_LENS_IDS,
     build_change_quality_prepare_packet,
     record_change_quality_receipt,
     verify_change_quality_receipt,
 )
 from loopx.capabilities.change_quality.result import (
+    REVIEW_LENS_IDS,
     SIMPLIFY_GUARDRAIL_LENS_IDS,
-    SIMPLIFY_PRIMARY_LENS_IDS,
+    derive_change_quality_guardrails,
     normalize_change_quality_result,
 )
 from loopx.cli import main
@@ -94,90 +94,72 @@ def _enable(
 
 
 def _result(path: Path, fingerprint: str, **overrides: object) -> Path:
-    findings = overrides.get("findings")
-    finding_codes = (
-        [
-            str(item["code"])
-            for item in findings
-            if isinstance(item, dict) and item.get("code")
-        ]
-        if isinstance(findings, list)
-        else []
-    )
-    validation_evidence = overrides.get("validation_evidence")
-    validator_id = (
-        str(validation_evidence[0].get("validator"))
-        if isinstance(validation_evidence, list)
-        and validation_evidence
-        and isinstance(validation_evidence[0], dict)
-        else "fixture"
-    )
-    lens_reviews = [
-        {
-            "lens_id": lens_id,
-            "status": (
-                "finding"
-                if lens_id == "quality_simplification" and finding_codes
-                else "checked"
-            ),
-            "summary": (
-                "See the referenced findings."
-                if lens_id == "quality_simplification" and finding_codes
-                else f"{lens_id} was reviewed against the exact fixture change."
-            ),
-            "finding_codes": (
-                finding_codes if lens_id == "quality_simplification" else []
-            ),
-            "evidence_refs": (
-                [
-                    "path:app.py",
-                    *[f"finding:{code}" for code in finding_codes],
-                    "decision:fixture-simplification",
-                ]
-                if lens_id == "quality_simplification"
-                else (
-                    [f"validator:{validator_id}"]
-                    if lens_id == "test_validation"
-                    else ["path:app.py"]
-                )
-            ),
-        }
-        for lens_id in REVIEW_LENS_IDS
-    ]
-    safe_fix_applied = overrides.get("safe_fix_applied") is True
     payload = {
         "schema_version": CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
         "scope_fingerprint": fingerprint,
         "reviewed_final_scope": True,
-        "summary": "Reviewed the exact final scope.",
-        "repository_principles": [],
-        "findings": [],
-        "lens_reviews": lens_reviews,
-        "simplification_decisions": [
-            {
-                "decision_id": "fixture-simplification",
-                "subject": "exact final scope",
-                "outcome": "fixed" if safe_fix_applied else "retained",
-                "reason": (
-                    "Applied the one bounded simplification."
-                    if safe_fix_applied
-                    else "The direct implementation is already cohesive."
-                ),
-            }
-        ],
-        "safe_fix_applied": False,
-        "safe_fix_passes": 0,
-        "validation_evidence": [
+        "reuse": {
+            "outcome": "retained",
+            "summary": "The exact fixture already uses its direct owner.",
+            "evidence_refs": ["path:app.py"],
+        },
+        "simplification": {
+            "outcome": "retained",
+            "summary": "The direct assignment is already cohesive.",
+            "evidence_refs": ["path:app.py"],
+            "safe_fix_applied": False,
+        },
+        "risks": [],
+        "validation": [
             {
                 "validator": "fixture",
                 "status": "passed",
                 "scope": "focused change-quality contract",
+                "required": True,
             }
         ],
         **overrides,
     }
     path.write_text(json.dumps(payload), encoding="utf-8")
     return path
+
+
+def _legacy_v1_result(fingerprint: str) -> dict[str, object]:
+    return {
+        "schema_version": "change_quality_agent_result_v1",
+        "scope_fingerprint": fingerprint,
+        "reviewed_final_scope": True,
+        "summary": "Legacy exact scope reviewed.",
+        "repository_principles": [],
+        "findings": [],
+        "lens_reviews": [
+            {
+                "lens_id": lens_id,
+                "status": "checked",
+                "summary": f"{lens_id} checked.",
+                "finding_codes": [],
+                "evidence_refs": ["path:app.py"],
+            }
+            for lens_id in REVIEW_LENS_IDS
+        ],
+        "simplification_decisions": [
+            {
+                "decision_id": "legacy",
+                "subject": "fixture",
+                "outcome": "retained",
+                "reason": "Already direct.",
+            }
+        ],
+        "safe_fix_applied": False,
+        "safe_fix_passes": 0,
+        "validation_evidence": [
+            {
+                "validator": "legacy-fixture",
+                "status": "passed",
+                "scope": "legacy receipt compatibility",
+            }
+        ],
+    }
 
 
 def test_policy_defaults_off_and_configures_independent_controls(
@@ -266,18 +248,25 @@ def test_prepare_projects_repository_context_and_required_review_lenses(
         "pyproject.toml",
         "src",
     ]
-    assert [
-        item["lens_id"] for item in prepared["agent_contract"]["review_lenses"]
-    ] == list(REVIEW_LENS_IDS)
-    assert prepared["agent_contract"]["primary_review_lenses"] == list(
-        SIMPLIFY_PRIMARY_LENS_IDS
-    )
-    assert prepared["agent_contract"]["guardrail_review_lenses"] == list(
+    contract = prepared["agent_contract"]
+    assert contract["primary_result_fields"] == ["reuse", "simplification"]
+    assert contract["sparse_result_fields"] == ["risks", "validation"]
+    assert contract["guardrail_status_owner"] == "loopx_derived"
+    assert [item["lens_id"] for item in contract["guardrail_catalog"]] == list(
         SIMPLIFY_GUARDRAIL_LENS_IDS
     )
+    assert set(contract["result_template"]) == {
+        "schema_version",
+        "scope_fingerprint",
+        "reviewed_final_scope",
+        "reuse",
+        "simplification",
+        "risks",
+        "validation",
+    }
 
 
-def test_result_requires_complete_substantive_lens_coverage(tmp_path: Path) -> None:
+def test_result_rejects_legacy_lens_table(tmp_path: Path) -> None:
     repo, registry, runtime_root = _fixture(tmp_path)
     _enable(registry)
     (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
@@ -288,20 +277,12 @@ def test_result_requires_complete_substantive_lens_coverage(tmp_path: Path) -> N
         base_ref="HEAD",
     )
     result_path = _result(
-        tmp_path / "result.json",
+        tmp_path / "legacy-table.json",
         prepared["scope"]["scope_fingerprint"],
-        lens_reviews=[
-            {
-                "lens_id": REVIEW_LENS_IDS[0],
-                "status": "checked",
-                "summary": "Only one lens was reviewed.",
-                "finding_codes": [],
-                "evidence_refs": ["path:app.py"],
-            }
-        ],
+        lens_reviews=[],
     )
 
-    with pytest.raises(ValueError, match="missing required lenses"):
+    with pytest.raises(ValueError, match="unsupported fields"):
         record_change_quality_receipt(
             registry_path=registry,
             runtime_root=runtime_root,
@@ -313,7 +294,9 @@ def test_result_requires_complete_substantive_lens_coverage(tmp_path: Path) -> N
         )
 
 
-def test_lens_findings_must_reference_recorded_findings(tmp_path: Path) -> None:
+def test_sparse_result_derives_inactive_guardrails_without_agent_rows(
+    tmp_path: Path,
+) -> None:
     repo, registry, runtime_root = _fixture(tmp_path)
     _enable(registry)
     (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
@@ -323,130 +306,10 @@ def test_lens_findings_must_reference_recorded_findings(tmp_path: Path) -> None:
         repo_path=repo,
         base_ref="HEAD",
     )
-    lens_reviews = [
-        {
-            "lens_id": lens_id,
-            "status": "finding" if lens_id == "reuse" else "checked",
-            "summary": f"{lens_id} review complete.",
-            "finding_codes": ["missing-helper"] if lens_id == "reuse" else [],
-            "evidence_refs": (
-                ["path:app.py", "finding:missing-helper"]
-                if lens_id == "reuse"
-                else (
-                    ["decision:fixture-simplification", "path:app.py"]
-                    if lens_id == "quality_simplification"
-                    else (
-                        ["validator:fixture"]
-                        if lens_id == "test_validation"
-                        else ["path:app.py"]
-                    )
-                )
-            ),
-        }
-        for lens_id in REVIEW_LENS_IDS
-    ]
     result_path = _result(
-        tmp_path / "result.json",
+        tmp_path / "sparse.json",
         prepared["scope"]["scope_fingerprint"],
-        lens_reviews=lens_reviews,
     )
-
-    with pytest.raises(ValueError, match="unknown finding codes"):
-        record_change_quality_receipt(
-            registry_path=registry,
-            runtime_root=runtime_root,
-            goal_id=GOAL_ID,
-            repo_path=repo,
-            result_path=result_path,
-            base_ref="HEAD",
-            execute=False,
-        )
-
-
-def test_result_rejects_repeated_generic_lens_summaries(tmp_path: Path) -> None:
-    repo, registry, runtime_root = _fixture(tmp_path)
-    _enable(registry)
-    (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
-    prepared = build_change_quality_prepare_packet(
-        registry_path=registry,
-        goal_id=GOAL_ID,
-        repo_path=repo,
-        base_ref="HEAD",
-    )
-    generic_reviews = [
-        {
-            "lens_id": lens_id,
-            "status": "checked",
-            "summary": "Reviewed with no finding.",
-            "finding_codes": [],
-            "evidence_refs": (
-                ["decision:fixture-simplification", "path:app.py"]
-                if lens_id == "quality_simplification"
-                else (
-                    ["validator:fixture"]
-                    if lens_id == "test_validation"
-                    else ["path:app.py"]
-                )
-            ),
-        }
-        for lens_id in REVIEW_LENS_IDS
-    ]
-    result_path = _result(
-        tmp_path / "generic.json",
-        prepared["scope"]["scope_fingerprint"],
-        lens_reviews=generic_reviews,
-    )
-
-    with pytest.raises(ValueError, match="generic all-clear"):
-        record_change_quality_receipt(
-            registry_path=registry,
-            runtime_root=runtime_root,
-            goal_id=GOAL_ID,
-            repo_path=repo,
-            result_path=result_path,
-            base_ref="HEAD",
-            execute=False,
-        )
-
-
-def test_result_allows_compact_repeated_inactive_guardrails(tmp_path: Path) -> None:
-    repo, registry, runtime_root = _fixture(tmp_path)
-    _enable(registry)
-    (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
-    prepared = build_change_quality_prepare_packet(
-        registry_path=registry,
-        goal_id=GOAL_ID,
-        repo_path=repo,
-        base_ref="HEAD",
-    )
-    reviews = [
-        {
-            "lens_id": lens_id,
-            "status": "checked"
-            if lens_id in SIMPLIFY_PRIMARY_LENS_IDS
-            else "not_applicable",
-            "summary": (
-                f"{lens_id} was reviewed against the exact fixture change."
-                if lens_id in SIMPLIFY_PRIMARY_LENS_IDS
-                else "No changed-surface or validator trigger."
-            ),
-            "finding_codes": [],
-            "evidence_refs": (
-                ["decision:fixture-simplification", "path:app.py"]
-                if lens_id == "quality_simplification"
-                else ["path:app.py"]
-                if lens_id == "reuse"
-                else []
-            ),
-        }
-        for lens_id in REVIEW_LENS_IDS
-    ]
-    result_path = _result(
-        tmp_path / "compact-guardrails.json",
-        prepared["scope"]["scope_fingerprint"],
-        lens_reviews=reviews,
-    )
-
     recorded = record_change_quality_receipt(
         registry_path=registry,
         runtime_root=runtime_root,
@@ -458,9 +321,24 @@ def test_result_allows_compact_repeated_inactive_guardrails(tmp_path: Path) -> N
     )
 
     assert recorded["decision"] == "pass"
+    guardrails = recorded["receipt"]["guardrails"]
+    assert guardrails["derived"] is True
+    assert guardrails["blocking_codes"] == []
+    assert {
+        item["guardrail_id"]: item["status"] for item in guardrails["states"]
+    } == {
+        "type_api_boundary": "not_triggered",
+        "configuration": "not_triggered",
+        "runtime_ownership": "not_triggered",
+        "efficiency": "not_triggered",
+        "error_supervision": "not_triggered",
+        "test_validation": "satisfied",
+        "documentation_comments": "not_triggered",
+        "security_release": "not_triggered",
+    }
 
 
-def test_result_requires_all_projected_repository_principles(tmp_path: Path) -> None:
+def test_result_evidence_must_reference_projected_scope(tmp_path: Path) -> None:
     repo, registry, runtime_root = _fixture(tmp_path)
     _enable(registry)
     (repo / "AGENTS.md").write_text("# Review the exact diff.\n", encoding="utf-8")
@@ -471,13 +349,17 @@ def test_result_requires_all_projected_repository_principles(tmp_path: Path) -> 
         repo_path=repo,
         base_ref="HEAD",
     )
-    assert prepared["repository_context"]["instruction_refs"] == ["AGENTS.md"]
     result_path = _result(
-        tmp_path / "missing-principle.json",
+        tmp_path / "unknown-evidence.json",
         prepared["scope"]["scope_fingerprint"],
+        reuse={
+            "outcome": "retained",
+            "summary": "Grounded in an instruction outside the projected scope.",
+            "evidence_refs": ["instruction:docs/UNKNOWN.md"],
+        },
     )
 
-    with pytest.raises(ValueError, match="projected instruction refs"):
+    with pytest.raises(ValueError, match="unknown evidence"):
         record_change_quality_receipt(
             registry_path=registry,
             runtime_root=runtime_root,
@@ -510,7 +392,9 @@ def test_five_pr_calibration_replays_substantive_simplify_receipts() -> None:
         case["source"]["pull_request"] for case in cases if case["manual_holds"]
     } == {2593}
     assert [
-        case["source"]["pull_request"] for case in cases if case["safe_fix_applied"]
+        case["source"]["pull_request"]
+        for case in cases
+        if case["simplification"]["safe_fix_applied"]
     ] == [2594]
 
     for case in cases:
@@ -521,17 +405,10 @@ def test_five_pr_calibration_replays_substantive_simplify_receipts() -> None:
             "schema_version": CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
             "scope_fingerprint": fingerprint,
             "reviewed_final_scope": True,
-            "summary": (
-                f"Replayed public PR #{case['source']['pull_request']} "
-                "against the simplify contract."
-            ),
-            "repository_principles": case["repository_principles"],
-            "findings": [],
-            "lens_reviews": case["lens_reviews"],
-            "simplification_decisions": case["simplification_decisions"],
-            "safe_fix_applied": case["safe_fix_applied"],
-            "safe_fix_passes": case["safe_fix_passes"],
-            "validation_evidence": case["validation_evidence"],
+            "reuse": case["reuse"],
+            "simplification": case["simplification"],
+            "risks": case["risks"],
+            "validation": case["validation"],
         }
 
         normalized = normalize_change_quality_result(
@@ -539,15 +416,19 @@ def test_five_pr_calibration_replays_substantive_simplify_receipts() -> None:
             expected_fingerprint=fingerprint,
             safe_fix_allowed=True,
             expected_changed_files=case["changed_files"],
-            expected_instruction_refs=[
-                item["source"] for item in case["repository_principles"]
-            ],
+            expected_instruction_refs=[],
         )
 
-        assert [item["lens_id"] for item in normalized["lens_reviews"]] == list(
-            REVIEW_LENS_IDS
-        )
-        assert normalized["safe_fix_passes"] in {0, 1}
+        assert set(normalized) == {
+            "schema_version",
+            "scope_fingerprint",
+            "reviewed_final_scope",
+            "reuse",
+            "simplification",
+            "risks",
+            "validation",
+        }
+        assert derive_change_quality_guardrails(normalized)["derived"] is True
 
 
 def test_failed_validation_cannot_produce_passing_receipt(tmp_path: Path) -> None:
@@ -563,12 +444,13 @@ def test_failed_validation_cannot_produce_passing_receipt(tmp_path: Path) -> Non
     result_path = _result(
         tmp_path / "result.json",
         prepared["scope"]["scope_fingerprint"],
-        validation_evidence=[
+        validation=[
             {
                 "validator": "pytest-focused",
                 "status": "failed",
                 "scope": "changed capability tests",
                 "reason": "One contract assertion failed.",
+                "required": True,
             }
         ],
     )
@@ -584,6 +466,50 @@ def test_failed_validation_cannot_produce_passing_receipt(tmp_path: Path) -> Non
     )
     assert recorded["decision"] == "fail"
     assert recorded["unresolved_blockers"] == ["validator:pytest-focused"]
+
+
+def test_skipped_required_validation_is_derived_as_blocking(tmp_path: Path) -> None:
+    repo, registry, runtime_root = _fixture(tmp_path)
+    _enable(registry)
+    (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
+    prepared = build_change_quality_prepare_packet(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        base_ref="HEAD",
+    )
+    result_path = _result(
+        tmp_path / "result.json",
+        prepared["scope"]["scope_fingerprint"],
+        validation=[
+            {
+                "validator": "required-typecheck",
+                "status": "skipped",
+                "scope": "changed public schema",
+                "required": True,
+                "reason": "The checker was unavailable.",
+            }
+        ],
+    )
+
+    recorded = record_change_quality_receipt(
+        registry_path=registry,
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        result_path=result_path,
+        base_ref="HEAD",
+        execute=False,
+    )
+
+    assert recorded["decision"] == "fail"
+    assert recorded["unresolved_blockers"] == ["validator:required-typecheck"]
+    validation_guardrail = next(
+        item
+        for item in recorded["receipt"]["guardrails"]["states"]
+        if item["guardrail_id"] == "test_validation"
+    )
+    assert validation_guardrail["status"] == "blocked"
 
 
 def test_verification_revalidates_stored_result_semantics(tmp_path: Path) -> None:
@@ -611,7 +537,7 @@ def test_verification_revalidates_stored_result_semantics(tmp_path: Path) -> Non
     )
     receipt_path = Path(recorded["receipt_path"])
     receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
-    receipt["result"]["lens_reviews"] = receipt["result"]["lens_reviews"][:-1]
+    del receipt["result"]["reuse"]
     receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
 
     verified = verify_change_quality_receipt(
@@ -623,6 +549,52 @@ def test_verification_revalidates_stored_result_semantics(tmp_path: Path) -> Non
     )
     assert verified["status"] == "invalid_receipt"
     assert verified["ok"] is False
+
+
+def test_verification_accepts_exact_v1_receipt_read_only(tmp_path: Path) -> None:
+    repo, registry, runtime_root = _fixture(tmp_path)
+    _enable(registry)
+    (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
+    prepared = build_change_quality_prepare_packet(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        base_ref="HEAD",
+    )
+    result_path = _result(
+        tmp_path / "result.json",
+        prepared["scope"]["scope_fingerprint"],
+    )
+    recorded = record_change_quality_receipt(
+        registry_path=registry,
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        result_path=result_path,
+        base_ref="HEAD",
+        execute=True,
+    )
+    legacy_receipt = dict(recorded["receipt"])
+    legacy_receipt["schema_version"] = "change_quality_receipt_v1"
+    legacy_receipt["result"] = _legacy_v1_result(
+        prepared["scope"]["scope_fingerprint"]
+    )
+    legacy_receipt.pop("guardrails")
+    Path(recorded["receipt_path"]).write_text(
+        json.dumps(legacy_receipt),
+        encoding="utf-8",
+    )
+
+    verified = verify_change_quality_receipt(
+        registry_path=registry,
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        repo_path=repo,
+        base_ref="HEAD",
+    )
+
+    assert verified["status"] == "valid"
+    assert verified["ok"] is True
 
 
 def test_exact_scope_receipt_becomes_stale_after_any_diff_change(
@@ -806,8 +778,12 @@ def test_safe_fix_result_is_rejected_when_policy_forbids_mutation(
     result_path = _result(
         tmp_path / "result.json",
         prepared["scope"]["scope_fingerprint"],
-        safe_fix_applied=True,
-        safe_fix_passes=1,
+        simplification={
+            "outcome": "fixed",
+            "summary": "Applied one bounded simplification.",
+            "evidence_refs": ["path:app.py"],
+            "safe_fix_applied": True,
+        },
     )
 
     with pytest.raises(ValueError, match="policy forbids safe fixes"):
@@ -837,12 +813,14 @@ def test_unresolved_blocker_cannot_produce_passing_receipt(
     result_path = _result(
         tmp_path / "result.json",
         prepared["scope"]["scope_fingerprint"],
-        findings=[
+        risks=[
             {
+                "category": "test_validation",
                 "severity": "blocker",
                 "code": "required-validation-failed",
                 "message": "The required fixture validation failed.",
                 "resolved": False,
+                "evidence_refs": ["path:app.py"],
                 "path": "app.py",
                 "line": 1,
             }

--- a/tests/fixtures/change_quality/five_pr_calibration.json
+++ b/tests/fixtures/change_quality/five_pr_calibration.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "change_quality_five_pr_calibration_v0",
+  "schema_version": "change_quality_five_pr_calibration_v1",
   "cases": [
     {
       "case_id": "pr-2590-registry-boundary-owner",
@@ -12,103 +12,24 @@
         "loopx/control_plane/quota/goal_boundary.py",
         "tests/control_plane/test_goal_boundary_resolution.py"
       ],
-      "repository_principles": [
-        {
-          "source": "AGENTS.md",
-          "principle": "Keep durable state rules in their bounded-context owner and test semantics rather than incidental output."
-        }
-      ],
-      "lens_reviews": [
-        {
-          "lens_id": "reuse",
-          "status": "checked",
-          "summary": "The extracted registry projection reuses the existing capability and checkpoint normalization helpers.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/control_plane/quota/goal_boundary.py"]
-        },
-        {
-          "lens_id": "type_api_boundary",
-          "status": "checked",
-          "summary": "The public goal_boundary signature and optional return contract remain unchanged.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/control_plane/quota/goal_boundary.py"]
-        },
-        {
-          "lens_id": "configuration",
-          "status": "checked",
-          "summary": "Registry coordination remains the single source for scope, capabilities, approvals, and guards.",
-          "finding_codes": [],
-          "evidence_refs": ["path:tests/control_plane/test_goal_boundary_resolution.py"]
-        },
-        {
-          "lens_id": "runtime_ownership",
-          "status": "checked",
-          "summary": "Registry-owned projection is separated from downstream runtime and integration augmentation.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/control_plane/quota/goal_boundary.py"]
-        },
-        {
-          "lens_id": "quality_simplification",
-          "status": "checked",
-          "summary": "One owner-local helper removes branch density without introducing a generic projection framework.",
-          "finding_codes": [],
-          "evidence_refs": [
-            "path:loopx/control_plane/quota/goal_boundary.py",
-            "decision:extract-registry-owner"
-          ]
-        },
-        {
-          "lens_id": "efficiency",
-          "status": "checked",
-          "summary": "The extraction preserves the existing bounded list normalization and adds no repeated I/O.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/control_plane/quota/goal_boundary.py"]
-        },
-        {
-          "lens_id": "error_supervision",
-          "status": "checked",
-          "summary": "Malformed optional registry fields continue to normalize to empty projections instead of broad fallback.",
-          "finding_codes": [],
-          "evidence_refs": ["path:tests/control_plane/test_goal_boundary_resolution.py"]
-        },
-        {
-          "lens_id": "test_validation",
-          "status": "checked",
-          "summary": "Precedence, deduplication, checkpoint activity, and policy fields have direct semantic assertions.",
-          "finding_codes": [],
-          "evidence_refs": ["validator:pr-2590-focused"]
-        },
-        {
-          "lens_id": "documentation_comments",
-          "status": "not_applicable",
-          "summary": "No public documentation contract changes in this internal behavior-preserving extraction.",
-          "finding_codes": [],
-          "evidence_refs": []
-        },
-        {
-          "lens_id": "security_release",
-          "status": "checked",
-          "summary": "Item-local values cannot override registry authority for write scope or capability grants.",
-          "finding_codes": [],
-          "evidence_refs": ["path:tests/control_plane/test_goal_boundary_resolution.py"]
-        }
-      ],
-      "simplification_decisions": [
-        {
-          "decision_id": "extract-registry-owner",
-          "subject": "registry-owned goal boundary fields",
-          "outcome": "retained",
-          "reason": "The helper is a cohesive bounded-context extraction with a shipped caller and direct parity tests.",
-          "path": "loopx/control_plane/quota/goal_boundary.py"
-        }
-      ],
-      "safe_fix_applied": false,
-      "safe_fix_passes": 0,
-      "validation_evidence": [
+      "reuse": {
+        "outcome": "reused",
+        "summary": "The extraction reuses existing capability and checkpoint normalization helpers.",
+        "evidence_refs": ["path:loopx/control_plane/quota/goal_boundary.py"]
+      },
+      "simplification": {
+        "outcome": "retained",
+        "summary": "One owner-local helper reduces branch density without creating a generic projection framework.",
+        "evidence_refs": ["path:loopx/control_plane/quota/goal_boundary.py"],
+        "safe_fix_applied": false
+      },
+      "risks": [],
+      "validation": [
         {
           "validator": "pr-2590-focused",
           "status": "passed",
-          "scope": "goal boundary precedence, checkpoint authority, and maintainability ratchet"
+          "scope": "goal boundary precedence, checkpoint authority, and maintainability ratchet",
+          "required": true
         }
       ],
       "manual_holds": []
@@ -125,103 +46,24 @@
         "loopx/status.py",
         "tests/benchmarks/read_models/test_benchmark_projection.py"
       ],
-      "repository_principles": [
-        {
-          "source": "AGENTS.md",
-          "principle": "Move benchmark projection rules into the benchmark read-model owner while preserving public-safe boundaries and parity."
-        }
-      ],
-      "lens_reviews": [
-        {
-          "lens_id": "reuse",
-          "status": "checked",
-          "summary": "The read model reuses public-safe text, list, numeric, and environment-failure compactors.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/benchmarks/read_models/benchmark_projection.py"]
-        },
-        {
-          "lens_id": "type_api_boundary",
-          "status": "checked",
-          "summary": "The status compact_benchmark_run facade remains the caller-facing API while helpers become directly testable.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/status.py"]
-        },
-        {
-          "lens_id": "configuration",
-          "status": "checked",
-          "summary": "Validation field classes and trial bounds are single-sourced in the benchmark projection module.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/benchmarks/read_models/benchmark_projection.py"]
-        },
-        {
-          "lens_id": "runtime_ownership",
-          "status": "checked",
-          "summary": "Benchmark validation and trial compaction now live with the benchmark read model rather than the global status facade.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/benchmarks/read_models/benchmark_projection.py"]
-        },
-        {
-          "lens_id": "quality_simplification",
-          "status": "checked",
-          "summary": "The move reduces status branch density while keeping the validation and trial rule groups cohesive.",
-          "finding_codes": [],
-          "evidence_refs": [
-            "path:loopx/status.py",
-            "decision:move-benchmark-projection"
-          ]
-        },
-        {
-          "lens_id": "efficiency",
-          "status": "checked",
-          "summary": "Trial projection remains bounded by max_trials and max_list_items and stops once the bound is reached.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/benchmarks/read_models/benchmark_projection.py"]
-        },
-        {
-          "lens_id": "error_supervision",
-          "status": "checked",
-          "summary": "Neutral false flags and missing worker trace or setup failures remain explicit rather than silently disappearing.",
-          "finding_codes": [],
-          "evidence_refs": ["path:tests/benchmarks/read_models/test_benchmark_projection.py"]
-        },
-        {
-          "lens_id": "test_validation",
-          "status": "checked",
-          "summary": "Direct helper tests and facade integration assertions cover neutral, negative, bounded, and public-safe behavior.",
-          "finding_codes": [],
-          "evidence_refs": ["validator:pr-2593-focused"]
-        },
-        {
-          "lens_id": "documentation_comments",
-          "status": "checked",
-          "summary": "Named field groups document the projection contract next to the owning implementation.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/benchmarks/read_models/benchmark_projection.py"]
-        },
-        {
-          "lens_id": "security_release",
-          "status": "checked",
-          "summary": "Public-safe compaction and explicit trial bounds preserve the benchmark evidence boundary.",
-          "finding_codes": [],
-          "evidence_refs": ["path:tests/benchmarks/read_models/test_benchmark_projection.py"]
-        }
-      ],
-      "simplification_decisions": [
-        {
-          "decision_id": "move-benchmark-projection",
-          "subject": "benchmark validation and trial compaction",
-          "outcome": "retained",
-          "reason": "The move collapses one durable rule owner without changing the public facade or creating a universal compactor.",
-          "path": "loopx/benchmarks/read_models/benchmark_projection.py"
-        }
-      ],
-      "safe_fix_applied": false,
-      "safe_fix_passes": 0,
-      "validation_evidence": [
+      "reuse": {
+        "outcome": "reused",
+        "summary": "The read model reuses existing public-safe compactors and the status facade.",
+        "evidence_refs": ["path:loopx/benchmarks/read_models/benchmark_projection.py"]
+      },
+      "simplification": {
+        "outcome": "retained",
+        "summary": "The move gives benchmark projection one owner without introducing a universal compactor.",
+        "evidence_refs": ["path:loopx/benchmarks/read_models/benchmark_projection.py"],
+        "safe_fix_applied": false
+      },
+      "risks": [],
+      "validation": [
         {
           "validator": "pr-2593-focused",
           "status": "passed",
-          "scope": "benchmark projection helpers, status facade parity, and neighboring benchmark behavior"
+          "scope": "benchmark projection helpers, status facade parity, and neighboring behavior",
+          "required": true
         }
       ],
       "manual_holds": ["benchmark_sensitive"]
@@ -237,103 +79,24 @@
         "loopx/control_plane/turn_driver/executor.py",
         "tests/test_loopx_turn_executor.py"
       ],
-      "repository_principles": [
-        {
-          "source": "AGENTS.md",
-          "principle": "Make control-plane state transitions explicit, preserve recovery semantics, and validate ordered effects with focused tests."
-        }
-      ],
-      "lens_reviews": [
-        {
-          "lens_id": "reuse",
-          "status": "checked",
-          "summary": "The stage helpers retain existing journal, receipt, validation, callback, and execution-payload helpers.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/control_plane/turn_driver/executor.py"]
-        },
-        {
-          "lens_id": "type_api_boundary",
-          "status": "checked",
-          "summary": "run_loopx_turn_once keeps its external signature while internal stages return explicit typed tuples or payloads.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/control_plane/turn_driver/executor.py"]
-        },
-        {
-          "lens_id": "configuration",
-          "status": "not_applicable",
-          "summary": "This extraction changes no configuration source or execution mode selection.",
-          "finding_codes": [],
-          "evidence_refs": []
-        },
-        {
-          "lens_id": "runtime_ownership",
-          "status": "checked",
-          "summary": "Host result, task validation, and transaction closeout each own one ordered recoverable stage.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/control_plane/turn_driver/executor.py"]
-        },
-        {
-          "lens_id": "quality_simplification",
-          "status": "checked",
-          "summary": "Three cohesive stages replace one oversized orchestrator and the bounded repair preserves mutable callback results.",
-          "finding_codes": [],
-          "evidence_refs": [
-            "path:loopx/control_plane/turn_driver/executor.py",
-            "decision:preserve-callback-mutation"
-          ]
-        },
-        {
-          "lens_id": "efficiency",
-          "status": "checked",
-          "summary": "Recovery still skips completed phases and does not repeat host, writeback, or spend effects.",
-          "finding_codes": [],
-          "evidence_refs": ["path:tests/test_loopx_turn_executor.py"]
-        },
-        {
-          "lens_id": "error_supervision",
-          "status": "checked",
-          "summary": "Each stage records its failed phase, reason, receipt, and durable journal before returning.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/control_plane/turn_driver/executor.py"]
-        },
-        {
-          "lens_id": "test_validation",
-          "status": "checked",
-          "summary": "Interrupted writeback and spend recovery assert exact completed-phase prefixes and effect replay behavior.",
-          "finding_codes": [],
-          "evidence_refs": ["validator:pr-2594-focused"]
-        },
-        {
-          "lens_id": "documentation_comments",
-          "status": "checked",
-          "summary": "Stage helper names expose transaction boundaries without adding parallel prose truth.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/control_plane/turn_driver/executor.py"]
-        },
-        {
-          "lens_id": "security_release",
-          "status": "checked",
-          "summary": "Writeback still precedes quota spend and scheduler apply or acknowledgement on every resumed path.",
-          "finding_codes": [],
-          "evidence_refs": ["path:tests/test_loopx_turn_executor.py"]
-        }
-      ],
-      "simplification_decisions": [
-        {
-          "decision_id": "preserve-callback-mutation",
-          "subject": "transaction closeout callback payload handling",
-          "outcome": "fixed",
-          "reason": "The single safe-fix pass kept callback mutation semantics while retaining the three-stage extraction.",
-          "path": "loopx/control_plane/turn_driver/executor.py"
-        }
-      ],
-      "safe_fix_applied": true,
-      "safe_fix_passes": 1,
-      "validation_evidence": [
+      "reuse": {
+        "outcome": "retained",
+        "summary": "The executor keeps the existing callback contract instead of adding another adapter.",
+        "evidence_refs": ["path:loopx/control_plane/turn_driver/executor.py"]
+      },
+      "simplification": {
+        "outcome": "fixed",
+        "summary": "One bounded fix preserved callback mutation semantics inside the three-stage extraction.",
+        "evidence_refs": ["path:loopx/control_plane/turn_driver/executor.py"],
+        "safe_fix_applied": true
+      },
+      "risks": [],
+      "validation": [
         {
           "validator": "pr-2594-focused",
           "status": "passed",
-          "scope": "Turn executor and driver recovery semantics plus maintainability ratchet"
+          "scope": "Turn executor and driver recovery semantics plus maintainability ratchet",
+          "required": true
         }
       ],
       "manual_holds": []
@@ -348,103 +111,24 @@
         "loopx/control_plane/goals/goal_frontier.py",
         "tests/control_plane/test_goal_vision_blocked_successor.py"
       ],
-      "repository_principles": [
-        {
-          "source": "AGENTS.md",
-          "principle": "Represent goal-frontier invariants once and test legal and illegal transitions instead of preserving contradictory guidance."
-        }
-      ],
-      "lens_reviews": [
-        {
-          "lens_id": "reuse",
-          "status": "checked",
-          "summary": "The same repeat-Vision predicate and satisfying delta-kind tuple drive ACK validation and guidance alignment.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/control_plane/goals/goal_frontier.py"]
-        },
-        {
-          "lens_id": "type_api_boundary",
-          "status": "checked",
-          "summary": "The obligation projection adds explicit satisfying delta kinds without changing the existing ACK schema.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/control_plane/goals/goal_frontier.py"]
-        },
-        {
-          "lens_id": "configuration",
-          "status": "not_applicable",
-          "summary": "The change is selected from persisted Vision advancement policy rather than a new configuration flag.",
-          "finding_codes": [],
-          "evidence_refs": []
-        },
-        {
-          "lens_id": "runtime_ownership",
-          "status": "checked",
-          "summary": "Goal-frontier projection owns both replan acceptance and the guidance exposed to agents.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/control_plane/goals/goal_frontier.py"]
-        },
-        {
-          "lens_id": "quality_simplification",
-          "status": "checked",
-          "summary": "A shared predicate removes duplicated trigger interpretation while preserving as-needed Vision behavior.",
-          "finding_codes": [],
-          "evidence_refs": [
-            "path:loopx/control_plane/goals/goal_frontier.py",
-            "decision:align-guidance-policy"
-          ]
-        },
-        {
-          "lens_id": "efficiency",
-          "status": "checked",
-          "summary": "The alignment operates on the already-built bounded obligation and acceptance-gap lists.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/control_plane/goals/goal_frontier.py"]
-        },
-        {
-          "lens_id": "error_supervision",
-          "status": "checked",
-          "summary": "Watch-only continuation is rejected explicitly instead of creating another silent no-progress cycle.",
-          "finding_codes": [],
-          "evidence_refs": ["path:tests/control_plane/test_goal_vision_blocked_successor.py"]
-        },
-        {
-          "lens_id": "test_validation",
-          "status": "checked",
-          "summary": "Tests cover repeat-until-closed rejection and the as-needed wait-continuation counterexample.",
-          "finding_codes": [],
-          "evidence_refs": ["validator:pr-2597-focused"]
-        },
-        {
-          "lens_id": "documentation_comments",
-          "status": "checked",
-          "summary": "The helper docstring names the advancement policy boundary and keeps projected guidance current.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/control_plane/goals/goal_frontier.py"]
-        },
-        {
-          "lens_id": "security_release",
-          "status": "checked",
-          "summary": "The repair changes no authority or write permission and only narrows what counts as a valid replan ACK.",
-          "finding_codes": [],
-          "evidence_refs": ["path:tests/control_plane/test_goal_vision_blocked_successor.py"]
-        }
-      ],
-      "simplification_decisions": [
-        {
-          "decision_id": "align-guidance-policy",
-          "subject": "repeat-Vision replan guidance and ACK acceptance",
-          "outcome": "retained",
-          "reason": "One shared predicate and one ordered delta-kind contract remove the contradictory watch-only route.",
-          "path": "loopx/control_plane/goals/goal_frontier.py"
-        }
-      ],
-      "safe_fix_applied": false,
-      "safe_fix_passes": 0,
-      "validation_evidence": [
+      "reuse": {
+        "outcome": "reused",
+        "summary": "The fix reuses one shared readiness predicate and the existing ordered delta contract.",
+        "evidence_refs": ["path:loopx/control_plane/goals/goal_frontier.py"]
+      },
+      "simplification": {
+        "outcome": "retained",
+        "summary": "The shared predicate removes the contradictory watch-only route without extra state.",
+        "evidence_refs": ["path:loopx/control_plane/goals/goal_frontier.py"],
+        "safe_fix_applied": false
+      },
+      "risks": [],
+      "validation": [
         {
           "validator": "pr-2597-focused",
           "status": "passed",
-          "scope": "repeat and as-needed Vision goal-frontier and interaction-contract behavior"
+          "scope": "repeat and as-needed Vision replan behavior",
+          "required": true
         }
       ],
       "manual_holds": []
@@ -468,103 +152,24 @@
         "loopx/status.py",
         "tests/control_plane/test_status_collection_material_capability_wiring.py"
       ],
-      "repository_principles": [
-        {
-          "source": "AGENTS.md",
-          "principle": "Capability-gated projections stay default-off, propagate through real callers, and partition caches by semantic request identity."
-        }
-      ],
-      "lens_reviews": [
-        {
-          "lens_id": "reuse",
-          "status": "checked",
-          "summary": "Cache identity reuses canonical capability normalization from the todo contract.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/control_plane/runtime/status_projection_cache.py"]
-        },
-        {
-          "lens_id": "type_api_boundary",
-          "status": "checked",
-          "summary": "Status-backed callers expose one repeatable available-capability envelope and preserve omitted defaults.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/cli_commands/status.py"]
-        },
-        {
-          "lens_id": "configuration",
-          "status": "checked",
-          "summary": "Material projection remains selected by the observed execution envelope rather than persisted user configuration.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/control_plane/status_collection.py"]
-        },
-        {
-          "lens_id": "runtime_ownership",
-          "status": "checked",
-          "summary": "Status collection transports the envelope and the agent-management projection remains the field owner.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/control_plane/status_collection.py"]
-        },
-        {
-          "lens_id": "quality_simplification",
-          "status": "checked",
-          "summary": "Explicit caller forwarding is retained because it preserves ownership without introducing a hidden ambient capability context.",
-          "finding_codes": [],
-          "evidence_refs": [
-            "path:loopx/control_plane/status_collection.py",
-            "decision:retain-explicit-envelope"
-          ]
-        },
-        {
-          "lens_id": "efficiency",
-          "status": "checked",
-          "summary": "Normalized capability sets participate in cache identity so gated and default projections cannot cross-hit.",
-          "finding_codes": [],
-          "evidence_refs": ["path:loopx/control_plane/runtime/status_projection_cache.py"]
-        },
-        {
-          "lens_id": "error_supervision",
-          "status": "checked",
-          "summary": "Absent capability declarations fail closed by omitting material fields rather than falling back to private material reads.",
-          "finding_codes": [],
-          "evidence_refs": ["path:tests/control_plane/test_status_collection_material_capability_wiring.py"]
-        },
-        {
-          "lens_id": "test_validation",
-          "status": "checked",
-          "summary": "Real status collection, cache identity, and status or quota or review parity paths are covered.",
-          "finding_codes": [],
-          "evidence_refs": ["validator:pr-2602-focused"]
-        },
-        {
-          "lens_id": "documentation_comments",
-          "status": "checked",
-          "summary": "The protocol reference now states default-off projection and explicit capability observation.",
-          "finding_codes": [],
-          "evidence_refs": ["path:docs/reference/protocols/agent-management-projection-v0.md"]
-        },
-        {
-          "lens_id": "security_release",
-          "status": "checked",
-          "summary": "The capability only reveals a prebuilt public-safe frontier and never grants access to material bodies.",
-          "finding_codes": [],
-          "evidence_refs": ["path:tests/control_plane/test_status_collection_material_capability_wiring.py"]
-        }
-      ],
-      "simplification_decisions": [
-        {
-          "decision_id": "retain-explicit-envelope",
-          "subject": "capability propagation through status-backed callers",
-          "outcome": "retained",
-          "reason": "Explicit forwarding is repetitive but keeps request identity and capability ownership visible at each public caller.",
-          "path": "loopx/control_plane/status_collection.py"
-        }
-      ],
-      "safe_fix_applied": false,
-      "safe_fix_passes": 0,
-      "validation_evidence": [
+      "reuse": {
+        "outcome": "retained",
+        "summary": "Explicit forwarding preserves the existing public caller boundaries and request identity.",
+        "evidence_refs": ["path:loopx/control_plane/status_collection.py"]
+      },
+      "simplification": {
+        "outcome": "retained",
+        "summary": "The repeated forwarding is direct and cheaper than a hidden universal context carrier.",
+        "evidence_refs": ["path:loopx/control_plane/status_collection.py"],
+        "safe_fix_applied": false
+      },
+      "risks": [],
+      "validation": [
         {
           "validator": "pr-2602-focused",
           "status": "passed",
-          "scope": "material capability projection, cache partitioning, CLI parity, and output budgets"
+          "scope": "capability projection, cache partitioning, CLI parity, and budgets",
+          "required": true
         }
       ],
       "manual_holds": []


### PR DESCRIPTION
## Summary

- replace the authored ten-lens result table with four content blocks: `reuse`, `simplification`, sparse `risks[]`, and `validation[]`
- derive all eight guardrail states inside LoopX from risks and validation outcomes
- fail closed for unresolved blocker risks, failed validation, and skipped required validation
- keep exact-scope fingerprints, strict receipt enforcement, and one-pass safe-fix policy unchanged
- verify existing v1 receipts read-only for their already-qualified exact scope; all new writes use v2
- compress the five-PR calibration fixture from fifty authored lens rows to ten primary conclusions plus sparse arrays

## Motivation

#2604 made simplify evidence mandatory, but its ten required lens rows turned a
review discipline into repetitive Agent output. #2606 made the prompt
simplify-first, yet the persisted contract still paid the old table cost.

This change makes simplification the actual protocol shape. The Agent spends
tokens on reuse, simplification, concrete risks, and real validators. LoopX,
not the Agent, owns deterministic guardrail status and merge enforcement.

## Protocol

- `change_quality_prepare_packet_v2`
- `change_quality_agent_result_v2`
- `change_quality_receipt_v2`
- `change_quality_receipt_verification_v2`
- `change_quality_guardrail_summary_v0`

The v1 write contract is removed. Exact existing v1 receipts remain verifiable
read-only so unrelated open diffs are not forced through immediate
requalification.

## Validation

- focused change-quality, oracle, shadow, and catalog tests: 48 passed
- change-quality lifecycle smoke passed
- changed Python compilation passed
- exact v2 receipt `cqr_f1b0156b4df42979d8ab` verified as valid
- risk-based premerge: standard tier, 18 selected checks passed
- public/private boundary scan clean across all 9 changed files
- 0 failures, warnings, or manual holds

The full test suite was intentionally not run. Focused semantic tests and the
risk-selected premerge set cover the changed result, receipt, capability
catalog, lifecycle, and public-boundary surfaces.

## Design judgment

This is a net deletion of 423 lines. The core runtime modules are slightly
smaller, and the calibration fixture drops 395 lines. No universal compactor,
recursive reviewer, language-specific policy, or new merge authority is added.
