### PR TITLE
feat: add Ark Managed Agent goal host

### DIFF
--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -43,6 +43,12 @@ Do not paste the full lifecycle protocol into the visible goal text, and do not
 use a short goal text such as "advance TODO" as the recurring automation body.
 The short text names the goal; the generated task body enforces quota, gates,
 steering audit, writeback, refresh, and spend accounting.
+
+Ark Managed Agent is not an automation profile. Its integration uses one
+transport-neutral goal prompt and lets the goal runtime own inner iteration;
+see the host integration protocol instead of adapting this recurring
+automation contract.
+
 For Codex App, the generated quota command carries the compact explicit runtime
 profile `--runtime-profile codex_app_heartbeat` (generated commands use the
 equivalent compact alias `--codex-app`). The prompt does not restate the

--- a/docs/reference/protocols/host-integration-surface-v0.md
+++ b/docs/reference/protocols/host-integration-surface-v0.md
@@ -51,6 +51,38 @@ copyable bootstrap message, but it must not silently switch to hidden
 `codex exec`, read session transcripts, or claim same-TUI automation without
 the visible proof and idle-detection contracts.
 
+## Ark Managed Agent host
+
+`ark-managed-agent` is a one-shot goal host, not a LoopX Turn driver. LoopX
+generates one short, transport-neutral goal prompt; the Managed Agent goal
+runtime owns all inner iteration and continuation.
+
+The prompt uses the same 4,000-character interface budget and the same guarded
+goal policy as the Codex App/CLI visible-goal hosts; only the host ownership
+preamble differs.
+
+Generate the prompt with:
+
+```bash
+loopx heartbeat-prompt --thin --goal-id <GOAL_ID> --agent-id <AGENT_ID> \
+  --runtime-profile ark_managed_agent_goal
+```
+
+The same contract is available through first-class onboarding with
+`--agent-type ark-managed-agent`.
+
+Local-development and cloud transports must send the exact same `task_body` as
+their goal prompt. They may differ in endpoint, authentication, session id, or
+wire envelope, but those fields do not change the prompt or become LoopX
+policy. The host has no automation mode, and it must not wrap every inner goal
+iteration in `loopx turn run-once`.
+
+The generated `host_contract` states that activation happens once, the goal
+runtime owns continuation, host session state is non-authoritative, and the
+LoopX Turn driver is not required. Durable policy remains in current
+`quota should-run.interaction_contract`, active state, todos, vision, and
+writeback.
+
 ## Lifecycle Reads
 
 Host integrations should expose read methods that map directly to CLI reads:

--- a/docs/reference/protocols/host-integration-surface-v0.md
+++ b/docs/reference/protocols/host-integration-surface-v0.md
@@ -69,7 +69,19 @@ loopx heartbeat-prompt --thin --goal-id <GOAL_ID> --agent-id <AGENT_ID> \
 ```
 
 The same contract is available through first-class onboarding with
-`--agent-type ark-managed-agent`.
+`--agent-type ark-managed-agent`. Because this host does not use a
+Codex-specific skill directory, onboarding requires host-managed delivery and
+readback of the LoopX workflow skills from the same LoopX revision as the CLI.
+The fixed installer is shared with Codex; only its target root changes:
+
+```bash
+LOOPX_SKILLS_DIR=<PROJECT_WORKSPACE>/.agents/skills \
+  LOOPX_INSTALL_SLASH_COMMANDS=0 \
+  <LOOPX_CHECKOUT>/scripts/install-local.sh
+```
+
+The installer owns filesystem mutation. Onboarding and doctor only report the
+required skill ids and require a host loaded-skill readback.
 
 Local-development and cloud transports must send the exact same `task_body` as
 their goal prompt. They may differ in endpoint, authentication, session id, or

--- a/loopx/agent_onboarding.py
+++ b/loopx/agent_onboarding.py
@@ -7,6 +7,7 @@ from .agent_registry import registered_agent_ids_from_registry
 from .bootstrap_command_pack import inspect_bootstrap_connection
 from .capabilities.change_quality.policy import change_quality_goal_policy
 from .host_loop_activation import (
+    agent_type_uses_host_managed_skills,
     build_host_loop_activation_packet,
     normalize_agent_type,
     render_agent_type_catalog_markdown,
@@ -125,7 +126,7 @@ def _skill_delivery_contract(
                     ),
                 }
             )
-    if agent_type != "other-agent":
+    if not agent_type_uses_host_managed_skills(agent_type):
         return {
             "schema_version": HOST_SKILL_DELIVERY_SCHEMA_VERSION,
             "mode": "surface_managed",
@@ -139,10 +140,11 @@ def _skill_delivery_contract(
         *REQUIRED_HOST_SKILL_IDS,
         *active_project_skills,
     ]
+    ark_managed_agent = agent_type == "ark-managed-agent"
     return {
         "schema_version": HOST_SKILL_DELIVERY_SCHEMA_VERSION,
         "mode": "host_managed",
-        "owner": "custom_agent_host",
+        "owner": "loopx_install_script" if ark_managed_agent else "custom_agent_host",
         "status": "pending_host_readback",
         "codex_skills_root_required": False,
         "required_for_cli_health": False,
@@ -150,9 +152,20 @@ def _skill_delivery_contract(
         "required_skill_ids": required_skill_ids,
         "active_project_skill_ids": active_project_skills,
         "delivery_options": [
+            *(["fixed_install_script"] if ark_managed_agent else []),
             "host_skill_manifest",
             "prompt_injection",
         ],
+        **(
+            {
+                "preferred_delivery": "fixed_install_script",
+                "install_script": "scripts/install-local.sh",
+                "skills_dir_env": "LOOPX_SKILLS_DIR",
+                "target_layout": f"{project}/.agents/skills",
+            }
+            if ark_managed_agent
+            else {}
+        ),
         "source_repository": "https://github.com/huangruiteng/loopx",
         "source_directories": [
             f"skills/{skill_id}" for skill_id in required_skill_ids
@@ -268,6 +281,12 @@ def build_agent_onboarding_packet(
         if change_quality_goal_policy(goal)["enabled"]
         else []
     )
+    skill_delivery = _skill_delivery_contract(
+        canonical_agent_type,
+        project=resolved_project,
+        cli_bin=cli_bin,
+        active_project_skill_ids=active_project_skill_ids,
+    )
     registered_agents = registered_agent_ids_from_registry(
         registry_path,
         resolved_goal_id,
@@ -351,12 +370,7 @@ def build_agent_onboarding_packet(
         "task_text": task_text,
         "project_connection": inspection,
         "host_loop_activation": host_loop_activation,
-        "skill_delivery": _skill_delivery_contract(
-            canonical_agent_type,
-            project=resolved_project,
-            cli_bin=cli_bin,
-            active_project_skill_ids=active_project_skill_ids,
-        ),
+        "skill_delivery": skill_delivery,
         "recommended_start": (
             "Select one registered agent lane from identity_selection_gate, then rerun onboarding."
             if not activation_allowed
@@ -382,9 +396,9 @@ def build_agent_onboarding_packet(
                 "ordered todos are written when task text was supplied",
                 *(
                     [
-                        "custom host loaded-skill readback satisfies skill_delivery.success_criteria"
+                        "host-managed loaded-skill readback satisfies skill_delivery.success_criteria"
                     ]
-                    if canonical_agent_type == "other-agent"
+                    if skill_delivery.get("host_readback_required") is True
                     else []
                 ),
                 "host_loop_activation success criteria are satisfied or a concrete gate is reported",

--- a/loopx/ark_managed_agent_host.py
+++ b/loopx/ark_managed_agent_host.py
@@ -1,0 +1,28 @@
+"""Thin one-shot goal activation contract for Ark Managed Agent."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+ARK_MANAGED_AGENT_HOST = "ark-managed-agent"
+ARK_MANAGED_AGENT_HOST_CONTRACT_SCHEMA_VERSION = (
+    "loopx_ark_managed_agent_goal_host_v0"
+)
+ARK_MANAGED_AGENT_PROMPT_FAMILY = "loopx_goal_prompt_v0"
+
+
+def build_ark_managed_agent_host_contract() -> dict[str, Any]:
+    """Describe transport-neutral ownership for one goal prompt activation."""
+
+    return {
+        "schema_version": ARK_MANAGED_AGENT_HOST_CONTRACT_SCHEMA_VERSION,
+        "host_kind": ARK_MANAGED_AGENT_HOST,
+        "activation_mode": "goal_once",
+        "prompt_family": ARK_MANAGED_AGENT_PROMPT_FAMILY,
+        "policy_source": "quota_should_run.interaction_contract",
+        "transport_contract": "goal_prompt_v0",
+        "goal_runtime_owns_continuation": True,
+        "loopx_turn_driver_required": False,
+        "session_state_authoritative": False,
+    }

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -272,13 +272,27 @@ def register_quota_command(subparsers: argparse._SubParsersAction) -> None:
     quota_parser.add_argument(
         "-H",
         "--host-surface",
-        choices=["codex_app", "codex_app_ssh", "codex_cli", "generic_cli", "claude_code", "local_scheduler"],
+        choices=[
+            "ark_managed_agent",
+            "codex_app",
+            "codex_app_ssh",
+            "codex_cli",
+            "generic_cli",
+            "claude_code",
+            "local_scheduler",
+        ],
         help="Host surface that will consume this scheduler projection.",
     )
     quota_parser.add_argument(
         "-O",
         "--scheduler-owner",
-        choices=["host_automation", "agent_cli_loop", "outer_controller", "none"],
+        choices=[
+            "host_automation",
+            "agent_cli_loop",
+            "goal_runtime",
+            "outer_controller",
+            "none",
+        ],
         help="Runtime that owns the next cadence decision.",
     )
     quota_parser.add_argument(

--- a/loopx/cli_commands/support_control.py
+++ b/loopx/cli_commands/support_control.py
@@ -190,13 +190,27 @@ def register_support_control_commands(
     heartbeat_prompt_parser.add_argument(
         "-H",
         "--host-surface",
-        choices=["codex_app", "codex_app_ssh", "codex_cli", "generic_cli", "claude_code", "local_scheduler"],
+        choices=[
+            "ark_managed_agent",
+            "codex_app",
+            "codex_app_ssh",
+            "codex_cli",
+            "generic_cli",
+            "claude_code",
+            "local_scheduler",
+        ],
         help="Host surface embedded in the generated quota guard.",
     )
     heartbeat_prompt_parser.add_argument(
         "-O",
         "--scheduler-owner",
-        choices=["host_automation", "agent_cli_loop", "outer_controller", "none"],
+        choices=[
+            "host_automation",
+            "agent_cli_loop",
+            "goal_runtime",
+            "outer_controller",
+            "none",
+        ],
         help="Cadence owner embedded in the generated quota guard.",
     )
     heartbeat_prompt_parser.add_argument(

--- a/loopx/control_plane/scheduler/execution_context.py
+++ b/loopx/control_plane/scheduler/execution_context.py
@@ -10,6 +10,7 @@ SCHEDULER_EXECUTION_CONTEXT_SCHEMA_VERSION = "scheduler_execution_context_v0"
 
 
 class HostSurface(str, Enum):
+    ARK_MANAGED_AGENT = "ark_managed_agent"
     CODEX_APP = "codex_app"
     CODEX_APP_SSH = "codex_app_ssh"
     CODEX_CLI = "codex_cli"
@@ -21,6 +22,7 @@ class HostSurface(str, Enum):
 class SchedulerOwner(str, Enum):
     HOST_AUTOMATION = "host_automation"
     AGENT_CLI_LOOP = "agent_cli_loop"
+    GOAL_RUNTIME = "goal_runtime"
     OUTER_CONTROLLER = "outer_controller"
     NONE = "none"
 
@@ -32,6 +34,7 @@ class ExecutionMode(str, Enum):
 
 
 class SchedulerRuntimeProfile(str, Enum):
+    ARK_MANAGED_AGENT_GOAL = "ark_managed_agent_goal"
     CODEX_APP_HEARTBEAT = "codex_app_heartbeat"
     CODEX_APP_SSH_VISIBLE = "codex_app_ssh_goal"
     CODEX_CLI_VISIBLE = "codex_cli"
@@ -41,6 +44,11 @@ class SchedulerRuntimeProfile(str, Enum):
 
 
 _SCHEDULER_RUNTIME_PROFILE_CONTEXTS = {
+    SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL: (
+        HostSurface.ARK_MANAGED_AGENT,
+        SchedulerOwner.GOAL_RUNTIME,
+        ExecutionMode.INTERACTIVE,
+    ),
     SchedulerRuntimeProfile.CODEX_APP_HEARTBEAT: (
         HostSurface.CODEX_APP,
         SchedulerOwner.HOST_AUTOMATION,
@@ -149,6 +157,11 @@ def _validation_errors(context: SchedulerExecutionContext) -> list[str]:
             errors.append("codex_app requires scheduler_owner=host_automation")
         if context.execution_mode is not ExecutionMode.HOSTED_AUTOMATION:
             errors.append("codex_app requires execution_mode=hosted_automation")
+    if context.host_surface is HostSurface.ARK_MANAGED_AGENT:
+        if context.scheduler_owner is not SchedulerOwner.GOAL_RUNTIME:
+            errors.append("ark_managed_agent requires scheduler_owner=goal_runtime")
+        if context.execution_mode is not ExecutionMode.INTERACTIVE:
+            errors.append("ark_managed_agent requires execution_mode=interactive")
     if context.host_surface is HostSurface.CODEX_APP_SSH:
         if context.scheduler_owner is not SchedulerOwner.AGENT_CLI_LOOP:
             errors.append("codex_app_ssh requires scheduler_owner=agent_cli_loop")
@@ -179,6 +192,11 @@ def _validation_errors(context: SchedulerExecutionContext) -> list[str]:
             errors.append("agent_cli_loop requires a CLI host surface")
         if context.execution_mode is ExecutionMode.HOSTED_AUTOMATION:
             errors.append("agent_cli_loop cannot use execution_mode=hosted_automation")
+    if context.scheduler_owner is SchedulerOwner.GOAL_RUNTIME:
+        if context.host_surface is not HostSurface.ARK_MANAGED_AGENT:
+            errors.append("goal_runtime requires host_surface=ark_managed_agent")
+        if context.execution_mode is not ExecutionMode.INTERACTIVE:
+            errors.append("goal_runtime requires execution_mode=interactive")
     if (
         context.execution_mode is ExecutionMode.HOSTED_AUTOMATION
         and context.scheduler_owner is not SchedulerOwner.HOST_AUTOMATION

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -630,7 +630,7 @@ def installed_skill_check(
         "detail": (
             detail
             if applicable
-            else "not applicable: other-agent skill delivery is owned by the custom host"
+            else "not applicable: skill delivery is owned by the selected host integration"
         ),
     }
 
@@ -706,10 +706,17 @@ def collect_doctor(
         collect_runtime_projection_route_diagnostics,
     )
 
-    from .host_loop_activation import normalize_agent_type
+    from .host_loop_activation import (
+        agent_type_uses_host_managed_skills,
+        normalize_agent_type,
+    )
 
     canonical_agent_type = normalize_agent_type(agent_type) if agent_type else None
-    installed_skills_required = canonical_agent_type != "other-agent"
+    host_managed_skill_delivery = bool(
+        canonical_agent_type
+        and agent_type_uses_host_managed_skills(canonical_agent_type)
+    )
+    installed_skills_required = not host_managed_skill_delivery
     loopx_path = resolve_command_path("loopx")
     invocation_path = current_script_invocation_path()
     loopx_canary_path = resolve_command_path("loopx-canary")
@@ -807,7 +814,15 @@ def collect_doctor(
     )
     skill_delivery = {
         "agent_type": canonical_agent_type,
-        "owner": "loopx_surface_installer" if installed_skills_required else "custom_agent_host",
+        "owner": (
+            "loopx_surface_installer"
+            if installed_skills_required
+            else (
+                "loopx_install_script"
+                if canonical_agent_type == "ark-managed-agent"
+                else "custom_agent_host"
+            )
+        ),
         "mode": "surface_managed" if installed_skills_required else "host_managed",
         "codex_skills_root_applicable": installed_skills_required,
         "installed_skills_required_for_freshness": installed_skills_required,
@@ -1026,7 +1041,8 @@ def collect_doctor(
         "fix": (
             "Do not infer custom-host skill delivery from `~/.codex/skills`; "
             "verify the host-managed loaded-skill readback from `loopx agent-onboard`."
-            if canonical_agent_type == "other-agent"
+            if canonical_agent_type
+            and agent_type_uses_host_managed_skills(canonical_agent_type)
             else (
                 f"Run `{repo_root / 'scripts' / 'install-local.sh'}` and start a new shell, "
                 f"or export PATH=\"{local_bin}:$PATH\". For no-clone repair, run "

--- a/loopx/heartbeat_prompt.py
+++ b/loopx/heartbeat_prompt.py
@@ -4,6 +4,7 @@ import shlex
 from pathlib import Path
 from typing import Any
 
+from .ark_managed_agent_host import build_ark_managed_agent_host_contract
 from .agent_registry import normalize_registered_agents
 from .project_prompt import (
     render_available_capability_args,
@@ -66,6 +67,7 @@ INTERFACE_BUDGET_CHARS = {
     "visible_goal": 4_000,
 }
 CODEX_VISIBLE_GOAL_MAX_CHARS = INTERFACE_BUDGET_CHARS["visible_goal"]
+ARK_MANAGED_AGENT_GOAL_MAX_CHARS = CODEX_VISIBLE_GOAL_MAX_CHARS
 
 
 def uses_visible_goal_host_loop(
@@ -79,6 +81,7 @@ def uses_visible_goal_host_loop(
         except ValueError:
             return False
         return profile in {
+            SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL,
             SchedulerRuntimeProfile.CODEX_APP_SSH_VISIBLE,
             SchedulerRuntimeProfile.CODEX_CLI_VISIBLE,
         }
@@ -88,10 +91,36 @@ def uses_visible_goal_host_loop(
     if not resolution.ok or resolution.context is None:
         return False
     context = resolution.context
+    if context.execution_mode is not ExecutionMode.INTERACTIVE:
+        return False
+    if context.host_surface is HostSurface.ARK_MANAGED_AGENT:
+        return context.scheduler_owner is SchedulerOwner.GOAL_RUNTIME
     return (
         context.host_surface in {HostSurface.CODEX_APP_SSH, HostSurface.CODEX_CLI}
         and context.scheduler_owner is SchedulerOwner.AGENT_CLI_LOOP
-        and context.execution_mode is ExecutionMode.INTERACTIVE
+    )
+
+
+def uses_ark_managed_agent_goal_host(
+    *,
+    runtime_profile: str | None,
+    scheduler_execution_context: dict[str, Any] | None,
+) -> bool:
+    if runtime_profile:
+        try:
+            return (
+                SchedulerRuntimeProfile(runtime_profile)
+                is SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL
+            )
+        except ValueError:
+            return False
+    if scheduler_execution_context is None:
+        return False
+    resolution = resolve_scheduler_execution_context(scheduler_execution_context)
+    return bool(
+        resolution.ok
+        and resolution.context is not None
+        and resolution.context.host_surface is HostSurface.ARK_MANAGED_AGENT
     )
 
 
@@ -337,6 +366,10 @@ def build_heartbeat_prompt(
         runtime_profile=runtime_profile,
         scheduler_execution_context=scheduler_execution_context,
     )
+    ark_managed_agent_goal = uses_ark_managed_agent_goal_host(
+        runtime_profile=runtime_profile,
+        scheduler_execution_context=scheduler_execution_context,
+    )
     effective_resolved_active_state = resolved_active_state or active_state
     active_state_text = str(active_state.expanduser()) if active_state else "the registry-declared active state"
     if active_state:
@@ -446,7 +479,9 @@ def build_heartbeat_prompt(
     compact_prompt_command = f"{cli_bin} heartbeat-prompt --compact --goal-id {goal_id}{active_state_arg}{agent_args}{capability_args}{scheduler_args}"
     brief_prompt_command = f"{cli_bin} heartbeat-prompt --brief --goal-id {goal_id}{active_state_arg}{agent_args}{capability_args}{scheduler_args}"
     thin_prompt_command = f"{cli_bin} heartbeat-prompt --thin --goal-id {goal_id}{active_state_arg}{agent_args}{capability_args}{scheduler_args}"
-    if visible_goal:
+    if ark_managed_agent_goal:
+        task_body_renderer = render_ark_managed_agent_goal_task_body
+    elif visible_goal:
         task_body_renderer = render_visible_goal_task_body
     elif thin:
         task_body_renderer = render_thin_heartbeat_task_body
@@ -479,6 +514,14 @@ def build_heartbeat_prompt(
             "generated visible /goal task body exceeds the Codex 4000-character "
             "limit; shorten agent scopes or project-specific prompt rules"
         )
+    if (
+        ark_managed_agent_goal
+        and len(task_body) > ARK_MANAGED_AGENT_GOAL_MAX_CHARS
+    ):
+        raise ValueError(
+            "generated Ark Managed Agent goal prompt exceeds the 4000-character "
+            "host budget; shorten agent scopes or project-specific prompt rules"
+        )
     payload = {
         "ok": True,
         "goal_id": goal_id,
@@ -499,6 +542,11 @@ def build_heartbeat_prompt(
         "registered_agents": normalized_registered_agents,
         "runtime_profile": runtime_profile,
         "scheduler_execution_context": scheduler_execution_context,
+        **(
+            {"host_contract": build_ark_managed_agent_host_contract()}
+            if ark_managed_agent_goal
+            else {}
+        ),
         "expanded_prompt_command": expanded_prompt_command,
         "compact_prompt_command": compact_prompt_command,
         "brief_prompt_command": brief_prompt_command,
@@ -1024,15 +1072,46 @@ def render_visible_goal_task_body(
         brief_prompt_command,
         thin_prompt_command,
     )
+    return _render_goal_task_body(
+        goal_id=goal_id,
+        active_state=active_state,
+        host_preamble=(
+            "in this visible\nCodex `/goal` task. This is an interactive goal "
+            "loop, not a heartbeat automation:\ndo not create/update an "
+            "automation, apply RRULE cadence, or invent `LOOPX_TURN`."
+        ),
+        completion_subject="visible\nGoal",
+        pr_review_pre_quota_command=pr_review_pre_quota_command,
+        quota_guard_command=quota_guard_command,
+        quota_spend_command=quota_spend_command,
+        progress_refresh_state_command=progress_refresh_state_command,
+        material_queue_rule=material_queue_rule,
+        permission_rule=permission_rule,
+        agent_scope_instruction=agent_scope_instruction,
+    )
+
+
+def _render_goal_task_body(
+    *,
+    goal_id: str,
+    active_state: str,
+    host_preamble: str,
+    completion_subject: str,
+    pr_review_pre_quota_command: str,
+    quota_guard_command: str,
+    quota_spend_command: str,
+    progress_refresh_state_command: str,
+    material_queue_rule: str,
+    permission_rule: str,
+    agent_scope_instruction: str,
+) -> str:
     scope_block = f"\n{agent_scope_instruction}\n" if agent_scope_instruction else ""
     prequota_block = (
         f"Run `{pr_review_pre_quota_command}` first.\n"
         if pr_review_pre_quota_command
         else ""
     )
-    return f"""Advance LoopX goal `{goal_id}` from `{active_state}` in this visible
-Codex `/goal` task. This is an interactive goal loop, not a heartbeat automation:
-do not create/update an automation, apply RRULE cadence, or invent `LOOPX_TURN`.
+    return f"""Advance LoopX goal `{goal_id}` from `{active_state}` {host_preamble}
 {scope_block}
 
 At every continuation, inspect LoopX state/status and the repository. {prequota_block}Run
@@ -1053,12 +1132,58 @@ explicit no-follow-up rationale. Spend exactly once after validated writeback:
 
 Do not spend for gates, waits, dry runs, failed preflight, no-op inspection, or
 duplicate accounting. Stop for private/company material, credentials, destructive
-git, unauthorized production, or repository review rules. Complete this visible
-Goal only when LoopX reports terminal success with no follow-up; otherwise keep the
+git, unauthorized production, or repository review rules. Complete this {completion_subject} only when LoopX reports terminal success with no follow-up; otherwise keep the
 current gate or next safe action explicit.
 
 {material_queue_rule}
 {permission_rule}"""
+
+
+def render_ark_managed_agent_goal_task_body(
+    *,
+    goal_id: str,
+    active_state: str,
+    cli_preflight: str,
+    pr_review_pre_quota_command: str,
+    quota_guard_command: str,
+    quota_spend_command: str,
+    refresh_state_command: str,
+    progress_refresh_state_command: str,
+    material_queue_rule: str,
+    permission_rule: str,
+    cli_bin: str,
+    agent_scope_instruction: str,
+    expanded_prompt_command: str,
+    compact_prompt_command: str,
+    brief_prompt_command: str,
+    thin_prompt_command: str,
+) -> str:
+    del (
+        cli_preflight,
+        refresh_state_command,
+        cli_bin,
+        expanded_prompt_command,
+        compact_prompt_command,
+        brief_prompt_command,
+        thin_prompt_command,
+    )
+    return _render_goal_task_body(
+        goal_id=goal_id,
+        active_state=active_state,
+        host_preamble=(
+            "in one Goal\nactivation. The Goal runtime owns continuation and "
+            "inner iterations. This is a\ngoal loop, not automation; do not "
+            "invoke LoopX Turn."
+        ),
+        completion_subject="Goal",
+        pr_review_pre_quota_command=pr_review_pre_quota_command,
+        quota_guard_command=quota_guard_command,
+        quota_spend_command=quota_spend_command,
+        progress_refresh_state_command=progress_refresh_state_command,
+        material_queue_rule=material_queue_rule,
+        permission_rule=permission_rule,
+        agent_scope_instruction=agent_scope_instruction,
+    )
 
 
 def render_thin_heartbeat_task_body(

--- a/loopx/host_loop_activation.py
+++ b/loopx/host_loop_activation.py
@@ -24,6 +24,7 @@ def scheduler_command_binding_for_agent_type(
 ) -> dict[str, Any]:
     canonical = normalize_agent_type(agent_type)
     runtime_profile = {
+        "ark-managed-agent": SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL,
         "codex-app": SchedulerRuntimeProfile.CODEX_APP_HEARTBEAT,
         "codex-app-ssh": SchedulerRuntimeProfile.CODEX_APP_SSH_VISIBLE,
         "codex-cli": SchedulerRuntimeProfile.CODEX_CLI_VISIBLE,
@@ -37,6 +38,7 @@ def scheduler_command_binding_for_agent_type(
 
 
 SUPPORTED_AGENT_TYPES = [
+    "ark-managed-agent",
     "codex-app",
     "codex-app-ssh",
     "codex-ide-plugin",
@@ -48,6 +50,19 @@ SUPPORTED_AGENT_TYPES = [
 ]
 
 AGENT_TYPE_CATALOG: dict[str, dict[str, Any]] = {
+    "ark-managed-agent": {
+        "display_name": "Ark Managed Agent",
+        "host_loop": "one-shot Goal activation owned by the Goal runtime",
+        "entry": "submit the generated task_body as one Goal",
+        "accepted_inputs": [
+            "ark-managed-agent",
+            "ark_managed_agent",
+            "ark managed agent",
+            "managed-agent",
+            "managed_agent",
+            "managed agent",
+        ],
+    },
     "codex-app": {
         "display_name": "Codex App",
         "host_loop": "Codex App heartbeat automation",
@@ -165,6 +180,8 @@ class AgentTypeError(ValueError):
 
 
 HOST_SURFACE_TO_AGENT_TYPE = {
+    "ark-managed-agent": "ark-managed-agent",
+    "ark_managed_agent": "ark-managed-agent",
     "codex-app": "codex-app",
     "codex-app-ssh": "codex-app-ssh",
     "chat-box": "codex-app",
@@ -291,6 +308,7 @@ def _heartbeat_commands(
     available_capabilities: list[str] | None = None,
 ) -> dict[str, str]:
     scope_by_type = {
+        "ark-managed-agent": "Ark Managed Agent one-shot Goal activation",
         "codex-app": "Codex App heartbeat automation",
         "codex-app-ssh": "Codex App SSH /goal visible task loop",
         "codex-ide-plugin": "Codex IDE plugin /goal visible task loop",
@@ -410,6 +428,35 @@ def _codex_app_activation(commands: dict[str, str]) -> dict[str, Any]:
         "success_criteria": [
             "A Codex App heartbeat automation exists for this goal and uses the generated task_body.",
             "The next wakeup starts from LoopX quota/status/state, not stale chat memory.",
+        ],
+    }
+
+
+def _ark_managed_agent_activation(commands: dict[str, str]) -> dict[str, Any]:
+    return {
+        "host_surface": "ark_managed_agent_goal_mode",
+        "entry_command_hint": "submit the generated task_body as one Goal",
+        "activation_method": "submit_goal_once",
+        "activation_input_command": commands["heartbeat_prompt_json"],
+        "host_mutation": {
+            "owner": "Ark Managed Agent Goal host",
+            "transport_contract": "goal_prompt_v0",
+            "prompt_field": "task_body",
+            "cli_can_mutate_directly": False,
+            "missing_host_tool_gate": (
+                "No Goal transport is available; surface the generated task_body "
+                "without claiming host activation."
+            ),
+        },
+        "activation_steps": [
+            "Run the heartbeat-prompt JSON command after project state and todos are written.",
+            "Read task_body from the JSON payload.",
+            "Submit that exact task_body once through either the local-development or cloud Goal transport.",
+            "Let the Goal runtime own inner iterations; do not wrap them in LoopX Turn.",
+        ],
+        "success_criteria": [
+            "The selected transport submitted the generated task_body exactly once.",
+            "The Goal runtime owns continuation while LoopX state remains authoritative.",
         ],
     }
 
@@ -594,7 +641,9 @@ def build_host_loop_activation_packet(
         if activation_allowed
         else {"heartbeat_prompt_json": None, "heartbeat_prompt": None}
     )
-    if canonical == "codex-app":
+    if canonical == "ark-managed-agent":
+        surface = _ark_managed_agent_activation(commands)
+    elif canonical == "codex-app":
         surface = _codex_app_activation(commands)
     elif canonical == "codex-app-ssh":
         surface = _codex_app_ssh_activation(commands)

--- a/loopx/host_loop_activation.py
+++ b/loopx/host_loop_activation.py
@@ -17,6 +17,12 @@ from .project_prompt import (
 SCHEMA_VERSION = "loopx_host_loop_activation_v1"
 AGENT_TYPE_CATALOG_SCHEMA_VERSION = "loopx_agent_type_catalog_v0"
 IDENTITY_SELECTION_SCHEMA_VERSION = "loopx_host_loop_identity_selection_v0"
+HOST_MANAGED_SKILL_AGENT_TYPES = frozenset(
+    {
+        "ark-managed-agent",
+        "other-agent",
+    }
+)
 
 
 def scheduler_command_binding_for_agent_type(
@@ -35,6 +41,10 @@ def scheduler_command_binding_for_agent_type(
     if runtime_profile is not None:
         return {"runtime_profile": runtime_profile.value}
     return {}
+
+
+def agent_type_uses_host_managed_skills(agent_type: str) -> bool:
+    return normalize_agent_type(agent_type) in HOST_MANAGED_SKILL_AGENT_TYPES
 
 
 SUPPORTED_AGENT_TYPES = [

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -15,7 +15,8 @@ Common environment variables:
   LOOPX_PYTHON=/path/to/python3.11  Use this supported Python for the release.
   LOOPX_PROMOTE_DEFAULT=1          Promote this checkout as the default loopx.
   LOOPX_INSTALL_CANARY=0           Skip the loopx-canary executable.
-  LOOPX_INSTALL_SKILL=0            Skip packaged Codex workflow skills.
+  LOOPX_INSTALL_SKILL=0            Skip packaged workflow skills.
+  LOOPX_SKILLS_DIR=/path           Install workflow skills into this host-native root.
   LOOPX_INSTALL_SLASH_COMMANDS=0   Skip Codex and Claude command skills.
   LOOPX_INSTALL_OPENCODE=0         Install the OpenCode goal bridge surface.
   CODEX_HOME=/path                 Override the Codex home directory.

--- a/tests/control_plane/test_scheduler_execution_context.py
+++ b/tests/control_plane/test_scheduler_execution_context.py
@@ -22,6 +22,7 @@ from loopx.control_plane.work_items.interaction_contract import (
 
 
 VALID_COMBINATIONS = {
+    ("ark_managed_agent", "goal_runtime", "interactive"),
     ("codex_app", "host_automation", "hosted_automation"),
     ("codex_app_ssh", "agent_cli_loop", "interactive"),
     ("local_scheduler", "host_automation", "hosted_automation"),
@@ -38,6 +39,11 @@ VALID_COMBINATIONS = {
 }
 
 FIRST_CLASS_RUNTIME_PROFILES = (
+    (
+        SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL,
+        ("ark_managed_agent", "goal_runtime", "interactive"),
+        " --runtime-profile ark_managed_agent_goal",
+    ),
     (
         SchedulerRuntimeProfile.CODEX_APP_HEARTBEAT,
         ("codex_app", "host_automation", "hosted_automation"),

--- a/tests/test_ark_managed_agent_host.py
+++ b/tests/test_ark_managed_agent_host.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from loopx.heartbeat_prompt import build_heartbeat_prompt
+from loopx.host_loop_activation import build_host_loop_activation_packet
+
+
+def _goal_prompt() -> dict:
+    return build_heartbeat_prompt(
+        goal_id="managed-agent-fixture",
+        active_state=Path("/workspace/ACTIVE_GOAL_STATE.md"),
+        thin=True,
+        runtime_profile="ark_managed_agent_goal",
+    )
+
+
+def test_goal_prompt_is_one_transport_independent_activation() -> None:
+    local_development = _goal_prompt()
+    cloud = _goal_prompt()
+    normalized = " ".join(local_development["task_body"].split())
+
+    assert local_development["task_body"] == cloud["task_body"]
+    assert len(local_development["task_body"]) <= 4_000
+    assert "in one Goal activation" in normalized
+    assert "Goal runtime owns continuation and inner iterations" in normalized
+    assert "goal loop, not automation" in normalized
+    assert "invoke LoopX Turn" in normalized
+    assert "choose the highest-priority in-scope unblocked agent todo" in normalized
+    assert "Honor claims/leases, blocker-push and recovery obligations" in normalized
+    assert "Spend exactly once after validated writeback" in normalized
+
+
+def test_goal_prompt_projects_goal_only_host_contract() -> None:
+    payload = _goal_prompt()
+
+    assert payload["runtime_profile"] == "ark_managed_agent_goal"
+    assert payload["host_contract"] == {
+        "schema_version": "loopx_ark_managed_agent_goal_host_v0",
+        "host_kind": "ark-managed-agent",
+        "activation_mode": "goal_once",
+        "prompt_family": "loopx_goal_prompt_v0",
+        "policy_source": "quota_should_run.interaction_contract",
+        "transport_contract": "goal_prompt_v0",
+        "goal_runtime_owns_continuation": True,
+        "loopx_turn_driver_required": False,
+        "session_state_authoritative": False,
+    }
+    assert "--runtime-profile ark_managed_agent_goal" in payload["task_body"]
+
+
+def test_host_activation_submits_one_goal_without_turn_or_automation() -> None:
+    packet = build_host_loop_activation_packet(
+        agent_type="ark-managed-agent",
+        goal_id="managed-agent-fixture",
+        agent_id="managed-agent",
+        registered_agents=["managed-agent"],
+    )
+
+    assert packet["activation_method"] == "submit_goal_once"
+    assert packet["host_surface"] == "ark_managed_agent_goal_mode"
+    assert packet["host_mutation"]["transport_contract"] == "goal_prompt_v0"
+    assert packet["host_mutation"]["prompt_field"] == "task_body"
+    assert packet["commands"]["heartbeat_prompt"].endswith(
+        "--runtime-profile ark_managed_agent_goal"
+    )
+    assert "automation_update" not in str(packet)
+    assert "loopx turn run-once" not in str(packet).lower()

--- a/tests/test_ark_managed_agent_host.py
+++ b/tests/test_ark_managed_agent_host.py
@@ -2,8 +2,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from loopx.agent_onboarding import (
+    REQUIRED_HOST_SKILL_IDS,
+    _skill_delivery_contract,
+)
+from loopx.doctor import collect_doctor
 from loopx.heartbeat_prompt import build_heartbeat_prompt
-from loopx.host_loop_activation import build_host_loop_activation_packet
+from loopx.host_loop_activation import (
+    agent_type_uses_host_managed_skills,
+    build_host_loop_activation_packet,
+)
 
 
 def _goal_prompt() -> dict:
@@ -66,3 +74,31 @@ def test_host_activation_submits_one_goal_without_turn_or_automation() -> None:
     )
     assert "automation_update" not in str(packet)
     assert "loopx turn run-once" not in str(packet).lower()
+
+
+def test_host_requires_host_managed_loopx_skill_delivery() -> None:
+    contract = _skill_delivery_contract("ark-managed-agent")
+
+    assert contract["mode"] == "host_managed"
+    assert contract["owner"] == "loopx_install_script"
+    assert contract["required_skill_ids"] == REQUIRED_HOST_SKILL_IDS
+    assert contract["host_readback_required"] is True
+    assert contract["codex_skills_root_required"] is False
+    assert contract["preferred_delivery"] == "fixed_install_script"
+    assert contract["install_script"] == "scripts/install-local.sh"
+    assert contract["skills_dir_env"] == "LOOPX_SKILLS_DIR"
+    assert contract["target_layout"] == "./.agents/skills"
+    assert agent_type_uses_host_managed_skills("ark-managed-agent") is True
+
+
+def test_doctor_checks_host_readback_instead_of_codex_skill_root() -> None:
+    payload = collect_doctor(agent_type="ark-managed-agent")
+
+    assert payload["skill_delivery"]["mode"] == "host_managed"
+    assert payload["skill_delivery"]["owner"] == "loopx_install_script"
+    assert payload["skill_delivery"]["codex_skills_root_applicable"] is False
+    skill_checks = {
+        item["id"]: item for item in payload["checks"] if item["id"].startswith("installed_")
+    }
+    assert skill_checks
+    assert all(item["applicable"] is False for item in skill_checks.values())

--- a/tests/test_host_loop_activation.py
+++ b/tests/test_host_loop_activation.py
@@ -47,6 +47,7 @@ def test_codex_ide_plugin_is_an_exact_host_type_with_visible_goal_activation() -
 @pytest.mark.parametrize(
     ("agent_type", "runtime_profile"),
     (
+        ("ark-managed-agent", "ark_managed_agent_goal"),
         ("codex-app", "codex_app_heartbeat"),
         ("codex-app-ssh", "codex_app_ssh_goal"),
         ("codex-cli", "codex_cli"),


### PR DESCRIPTION
## Summary

- add `ark-managed-agent` as a first-class, goal-only LoopX host and onboarding agent type
- generate one transport-neutral `task_body` for local-development and cloud Goal transports
- model the Goal runtime as the continuation owner; do not add automation mode or a LoopX Turn driver
- reuse the guarded visible-goal policy and 4,000-character budget used by Codex App/CLI while keeping their existing prompt output unchanged
- project a typed host contract and add focused scheduler, prompt, onboarding, and public-boundary coverage

## Why

The host boundary should submit one Goal prompt and then let the Goal runtime drive its inner iterations. Transport details such as endpoint, authentication, and session id must not become LoopX policy or durable state. A separate automation or per-iteration Turn wrapper would create a second lifecycle and make local/cloud behavior drift.

## User impact

Users can select `--agent-type ark-managed-agent` or generate the prompt directly with `--runtime-profile ark_managed_agent_goal`. Both local-development and cloud transports consume the exact same `task_body`.

## Validation

- `ruff check` on all changed Python files
- 167 focused tests passed
- pre-merge canary: 18/18 selected checks passed, 0 warnings
- LoopX contract and public/private boundary scans passed
- full suite: 1498 passed, 2 skipped; one unrelated environment-only failure because the system Python lacks `ensurepip` for the extension-scaffold venv test
- existing Codex visible-goal prompt output compared unchanged
