### PR TITLE
refactor(change-quality): remove v1 receipt reads

### DIFF
--- a/docs/capabilities/change-quality/README.md
+++ b/docs/capabilities/change-quality/README.md
@@ -70,8 +70,7 @@ Absence of this policy is equivalent to all three values being false.
    validation, skipped required validation, and unresolved blocker risks fail
    closed.
 6. `change-quality verify` checks the current exact scope and v2 protocol.
-   Existing v1 receipts remain read-only compatible for the exact scope they
-   already qualified.
+   Earlier experimental receipt schemas are invalid and must be requalified.
 7. `canary premerge --goal-id <goal-id>` enforces `strict_receipt`.
 
 ```bash

--- a/loopx/capabilities/change_quality/receipt.py
+++ b/loopx/capabilities/change_quality/receipt.py
@@ -14,20 +14,17 @@ from .context import build_change_quality_repository_context
 from .policy import change_quality_goal_policy
 from .result import (
     CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
-    LEGACY_CHANGE_QUALITY_RESULT_SCHEMA_VERSION,
     REVIEW_LENSES,
     SIMPLIFY_GUARDRAIL_LENS_IDS,
     change_quality_result_decision,
     derive_change_quality_guardrails,
     normalize_change_quality_result,
-    validate_legacy_change_quality_result_v1,
 )
 from .scope import build_change_quality_scope, resolve_git_root
 
 
 CHANGE_QUALITY_PREPARE_SCHEMA_VERSION = "change_quality_prepare_packet_v2"
 CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION = "change_quality_receipt_v2"
-LEGACY_CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION = "change_quality_receipt_v1"
 CHANGE_QUALITY_VERIFY_SCHEMA_VERSION = "change_quality_receipt_verification_v2"
 CHANGE_QUALITY_PR_EVIDENCE_SCHEMA_VERSION = "change_quality_pr_evidence_v0"
 
@@ -306,11 +303,7 @@ def _stored_receipt_is_valid(
 ) -> bool:
     if not (
         receipt
-        and receipt.get("schema_version")
-        in {
-            CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION,
-            LEGACY_CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION,
-        }
+        and receipt.get("schema_version") == CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION
         and receipt.get("decision") == "pass"
         and isinstance(receipt.get("result"), dict)
         and isinstance(receipt.get("scope"), dict)
@@ -319,34 +312,18 @@ def _stored_receipt_is_valid(
         return False
     result = receipt["result"]
     try:
-        if (
-            receipt.get("schema_version") == CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION
-            and result.get("schema_version") == CHANGE_QUALITY_RESULT_SCHEMA_VERSION
-        ):
-            normalized = normalize_change_quality_result(
-                result,
-                expected_fingerprint=scope_fingerprint,
-                safe_fix_allowed=safe_fix_allowed,
-                expected_changed_files=changed_files,
-                expected_instruction_refs=instruction_refs,
-            )
-            guardrails = derive_change_quality_guardrails(normalized)
-            decision, unresolved = change_quality_result_decision(normalized)
-            if receipt.get("guardrails") != guardrails:
-                return False
-        elif (
-            receipt.get("schema_version")
-            == LEGACY_CHANGE_QUALITY_RECEIPT_SCHEMA_VERSION
-            and result.get("schema_version")
-            == LEGACY_CHANGE_QUALITY_RESULT_SCHEMA_VERSION
-        ):
-            decision, unresolved = validate_legacy_change_quality_result_v1(
-                result,
-                expected_fingerprint=scope_fingerprint,
-                safe_fix_allowed=safe_fix_allowed,
-                expected_instruction_refs=instruction_refs,
-            )
-        else:
+        if result.get("schema_version") != CHANGE_QUALITY_RESULT_SCHEMA_VERSION:
+            return False
+        normalized = normalize_change_quality_result(
+            result,
+            expected_fingerprint=scope_fingerprint,
+            safe_fix_allowed=safe_fix_allowed,
+            expected_changed_files=changed_files,
+            expected_instruction_refs=instruction_refs,
+        )
+        guardrails = derive_change_quality_guardrails(normalized)
+        decision, unresolved = change_quality_result_decision(normalized)
+        if receipt.get("guardrails") != guardrails:
             return False
     except (TypeError, ValueError):
         return False
@@ -376,12 +353,11 @@ def _build_pr_evidence(
         status,
         _PR_EVIDENCE_BY_STATUS["invalid_receipt"],
     )
-    previous_scope = (
-        previous_receipt.get("scope")
-        if isinstance(previous_receipt, dict)
-        and isinstance(previous_receipt.get("scope"), dict)
-        else {}
-    )
+    previous_scope: dict[str, Any] = {}
+    if isinstance(previous_receipt, dict):
+        candidate_scope = previous_receipt.get("scope")
+        if isinstance(candidate_scope, dict):
+            previous_scope = candidate_scope
     return {
         "schema_version": CHANGE_QUALITY_PR_EVIDENCE_SCHEMA_VERSION,
         "state": state,

--- a/loopx/capabilities/change_quality/result.py
+++ b/loopx/capabilities/change_quality/result.py
@@ -7,7 +7,6 @@ from ...feedback import validate_public_safe_text
 
 
 CHANGE_QUALITY_RESULT_SCHEMA_VERSION = "change_quality_agent_result_v2"
-LEGACY_CHANGE_QUALITY_RESULT_SCHEMA_VERSION = "change_quality_agent_result_v1"
 CHANGE_QUALITY_GUARDRAIL_SCHEMA_VERSION = "change_quality_guardrail_summary_v0"
 
 RISK_SEVERITIES = frozenset({"blocker", "warning", "advisory"})
@@ -491,86 +490,4 @@ def change_quality_result_decision(
 ) -> tuple[str, list[str]]:
     guardrails = derive_change_quality_guardrails(result)
     unresolved = list(guardrails["blocking_codes"])
-    return ("fail", unresolved) if unresolved else ("pass", [])
-
-
-def validate_legacy_change_quality_result_v1(
-    value: Any,
-    *,
-    expected_fingerprint: str,
-    safe_fix_allowed: bool,
-    expected_instruction_refs: list[str] | None = None,
-) -> tuple[str, list[str]]:
-    """Validate decision-critical v1 fields for read-only receipt compatibility."""
-    if not isinstance(value, dict):
-        raise ValueError("legacy result root must be an object")
-    if value.get("schema_version") != LEGACY_CHANGE_QUALITY_RESULT_SCHEMA_VERSION:
-        raise ValueError("legacy result schema_version is invalid")
-    if str(value.get("scope_fingerprint") or "").strip() != expected_fingerprint:
-        raise ValueError("legacy result scope fingerprint is stale")
-    if value.get("reviewed_final_scope") is not True:
-        raise ValueError("legacy result did not review the final scope")
-    if value.get("safe_fix_applied") is True and not safe_fix_allowed:
-        raise ValueError("legacy result reports a forbidden safe fix")
-
-    principles = value.get("repository_principles")
-    if not isinstance(principles, list):
-        raise ValueError("legacy repository_principles must be an array")
-    principle_sources = {
-        str(item.get("source") or "").strip()
-        for item in principles
-        if isinstance(item, dict)
-    }
-    if expected_instruction_refs is not None and principle_sources != set(
-        expected_instruction_refs
-    ):
-        raise ValueError("legacy repository principles are incomplete")
-
-    findings = value.get("findings")
-    lenses = value.get("lens_reviews")
-    decisions = value.get("simplification_decisions")
-    validation = value.get("validation_evidence")
-    if not isinstance(findings, list) or len(findings) > 20:
-        raise ValueError("legacy findings are invalid")
-    if not isinstance(lenses, list):
-        raise ValueError("legacy lens reviews are invalid")
-    lens_ids = {
-        str(item.get("lens_id") or "")
-        for item in lenses
-        if isinstance(item, dict)
-    }
-    if lens_ids != set(REVIEW_LENS_IDS):
-        raise ValueError("legacy lens coverage is incomplete")
-    if not isinstance(decisions, list) or not decisions:
-        raise ValueError("legacy simplification decisions are missing")
-    if not isinstance(validation, list) or not validation:
-        raise ValueError("legacy validation evidence is missing")
-
-    unresolved: list[str] = []
-    for index, finding in enumerate(findings):
-        if not isinstance(finding, dict):
-            raise ValueError(f"legacy findings[{index}] must be an object")
-        severity = str(finding.get("severity") or "").strip().lower()
-        code = _bounded_text(
-            finding.get("code"),
-            field=f"legacy findings[{index}].code",
-            limit=80,
-        )
-        if severity not in RISK_SEVERITIES or not code:
-            raise ValueError(f"legacy findings[{index}] is invalid")
-        if severity == "blocker" and finding.get("resolved") is not True:
-            unresolved.append(code)
-    for index, evidence in enumerate(validation):
-        if not isinstance(evidence, dict):
-            raise ValueError(f"legacy validation_evidence[{index}] must be an object")
-        status = str(evidence.get("status") or "").strip().lower()
-        validator = _bounded_text(
-            evidence.get("validator"),
-            field=f"legacy validation_evidence[{index}].validator",
-            limit=120,
-        )
-        if status not in VALIDATION_STATUSES or not validator:
-            raise ValueError(f"legacy validation_evidence[{index}] is invalid")
-        if status == "failed":
-            unresolved.append(f"validator:{validator}")
     return ("fail", unresolved) if unresolved else ("pass", [])

--- a/skills/loopx-change-quality/SKILL.md
+++ b/skills/loopx-change-quality/SKILL.md
@@ -171,8 +171,8 @@ loopx --format json change-quality verify \
 
 A receipt with an unresolved blocker, failed validator, or skipped required
 validator is not passing. A receipt for an earlier fingerprint does not
-qualify a later diff. Existing v1 receipts may be verified read-only for their
-exact scope; new writes use v2.
+qualify a later diff. Earlier experimental receipt schemas are invalid and
+must be requalified with the current protocol.
 
 ## Premerge Enforcement
 

--- a/tests/capabilities/test_change_quality.py
+++ b/tests/capabilities/test_change_quality.py
@@ -21,7 +21,6 @@ from loopx.capabilities.change_quality.receipt import (
     verify_change_quality_receipt,
 )
 from loopx.capabilities.change_quality.result import (
-    REVIEW_LENS_IDS,
     SIMPLIFY_GUARDRAIL_LENS_IDS,
     derive_change_quality_guardrails,
     normalize_change_quality_result,
@@ -122,44 +121,6 @@ def _result(path: Path, fingerprint: str, **overrides: object) -> Path:
     }
     path.write_text(json.dumps(payload), encoding="utf-8")
     return path
-
-
-def _legacy_v1_result(fingerprint: str) -> dict[str, object]:
-    return {
-        "schema_version": "change_quality_agent_result_v1",
-        "scope_fingerprint": fingerprint,
-        "reviewed_final_scope": True,
-        "summary": "Legacy exact scope reviewed.",
-        "repository_principles": [],
-        "findings": [],
-        "lens_reviews": [
-            {
-                "lens_id": lens_id,
-                "status": "checked",
-                "summary": f"{lens_id} checked.",
-                "finding_codes": [],
-                "evidence_refs": ["path:app.py"],
-            }
-            for lens_id in REVIEW_LENS_IDS
-        ],
-        "simplification_decisions": [
-            {
-                "decision_id": "legacy",
-                "subject": "fixture",
-                "outcome": "retained",
-                "reason": "Already direct.",
-            }
-        ],
-        "safe_fix_applied": False,
-        "safe_fix_passes": 0,
-        "validation_evidence": [
-            {
-                "validator": "legacy-fixture",
-                "status": "passed",
-                "scope": "legacy receipt compatibility",
-            }
-        ],
-    }
 
 
 def test_policy_defaults_off_and_configures_independent_controls(
@@ -551,7 +512,7 @@ def test_verification_revalidates_stored_result_semantics(tmp_path: Path) -> Non
     assert verified["ok"] is False
 
 
-def test_verification_accepts_exact_v1_receipt_read_only(tmp_path: Path) -> None:
+def test_verification_rejects_v1_receipt(tmp_path: Path) -> None:
     repo, registry, runtime_root = _fixture(tmp_path)
     _enable(registry)
     (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
@@ -576,10 +537,7 @@ def test_verification_accepts_exact_v1_receipt_read_only(tmp_path: Path) -> None
     )
     legacy_receipt = dict(recorded["receipt"])
     legacy_receipt["schema_version"] = "change_quality_receipt_v1"
-    legacy_receipt["result"] = _legacy_v1_result(
-        prepared["scope"]["scope_fingerprint"]
-    )
-    legacy_receipt.pop("guardrails")
+    legacy_receipt["result"]["schema_version"] = "change_quality_agent_result_v1"
     Path(recorded["receipt_path"]).write_text(
         json.dumps(legacy_receipt),
         encoding="utf-8",
@@ -593,8 +551,8 @@ def test_verification_accepts_exact_v1_receipt_read_only(tmp_path: Path) -> None
         base_ref="HEAD",
     )
 
-    assert verified["status"] == "valid"
-    assert verified["ok"] is True
+    assert verified["status"] == "invalid_receipt"
+    assert verified["ok"] is False
 
 
 def test_exact_scope_receipt_becomes_stale_after_any_diff_change(


### PR DESCRIPTION
## Summary

- remove the experimental `change_quality_agent_result_v1` validator and receipt read path
- require v2 result and receipt schemas for every stored qualification receipt
- replace legacy acceptance coverage with an explicit v1 rejection test
- update public docs and the bundled skill to describe the v2-only contract

## Product and architecture judgment

The capability is still experimental, so retaining an unused read-only migration path adds more branching and test surface than user value. This change keeps one current protocol, one normalizer, and one derived guardrail path. Existing v1 receipts become invalid and must be requalified.

## Validation

- `19 passed` in `tests/capabilities/test_change_quality.py`
- Ruff passed on the changed Python files
- mypy passed on the changed production modules
- changed Python files compiled successfully
- exact-diff receipt `cqr_df22464e633e4c43d396` verified as valid
- risk-based premerge gate passed: 18 selected checks, 0 failures, 0 warnings
- public/private boundary scan passed for all 5 changed files

The full test suite was not run because the change is confined to the change-quality receipt protocol and its focused tests; the premerge selector covered the affected capability and adjacent public boundaries.
