### PR TITLE
fix(skillsbench): update verifier attribution call sites

### DIFF
--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -183,6 +183,9 @@ from loopx.benchmarks.read_models.goal_start_control_score import (
     goal_start_public_text_list as _goal_start_public_text_list,
     goal_start_public_todo_id_list as _goal_start_public_todo_id_list,
 )
+from loopx.benchmarks.read_models.skillsbench_verifier_attribution import (
+    apply_skillsbench_verifier_bootstrap_missing_score_attribution,
+)
 from loopx.control_plane.turn_driver import (
     loopx_turn_execution_committed,
     loopx_turn_execution_has_durable_effects,
@@ -15562,7 +15565,7 @@ def reduce_result(
                         if item not in existing_labels:
                             existing_labels.append(item)
                     compact["failure_attribution_labels"] = existing_labels
-    verifier_bootstrap.apply_skillsbench_verifier_bootstrap_missing_score_attribution(
+    apply_skillsbench_verifier_bootstrap_missing_score_attribution(
         compact,
         task_staging=task_staging,
         setup_preflight=_public_task_setup_preflight(
@@ -16561,7 +16564,7 @@ def build_runner_failure_compact(
     if not recovered:
         _recover_runner_failure_score_from_verifier_artifact(reduced, plan)
     _apply_codex_cli_goal_countability_guard_attribution(reduced)
-    verifier_bootstrap.apply_skillsbench_verifier_bootstrap_missing_score_attribution(
+    apply_skillsbench_verifier_bootstrap_missing_score_attribution(
         reduced,
         task_staging=_effective_public_task_staging(plan),
         setup_preflight=_public_task_setup_preflight(


### PR DESCRIPTION
## Summary
- update the two active SkillsBench reducer/closeout call sites to use the new verifier attribution read-model owner
- keep the old bootstrap adapter free of a compatibility alias
- repair the full-CI regression exposed after #2618 merged

## Validation
- 40 focused SkillsBench runtime, attribution, architecture, and maintainability tests passed
- exact previously failing CI regression passed
- SkillsBench missing-score smoke passed
- Python compile check and `git diff --check` passed
- LoopX public boundary scan passed
- risk-selected canary checks all passed; its benchmark-sensitive manual hold is covered by the owner authorization for this quality/refactor repair and the change does not launch jobs or alter scoring
- strict change-quality receipt: `cqr_dd93b4cbc92b86fd463a`

Follow-up to #2618.