### PR TITLE
refactor(status): move assisted pilot read model

### DIFF
--- a/examples/control_plane/run-compaction-readmodel-smoke.py
+++ b/examples/control_plane/run-compaction-readmodel-smoke.py
@@ -18,6 +18,9 @@ from loopx.benchmarks.read_models import (  # noqa: E402
 from loopx.control_plane.runtime import (  # noqa: E402
     run_compaction as run_compaction_read_model,
 )
+from loopx.control_plane.runtime.active_user_assisted_pilot import (  # noqa: E402
+    compact_active_user_assisted_pilot,
+)
 from loopx.control_plane.runtime.run_ingest_health import (  # noqa: E402
     worker_bridge_ingest_health_note,
 )
@@ -141,7 +144,7 @@ def _direct_compact_run(run: dict[str, object]) -> dict[str, object]:
         benchmark_experiment_report_replay_decision=(
             status_module.benchmark_experiment_report_replay_decision
         ),
-        compact_active_user_assisted_pilot=status_module.compact_active_user_assisted_pilot,
+        compact_active_user_assisted_pilot=compact_active_user_assisted_pilot,
         compact_session_runtime_projection_from_run=(
             status_module.compact_session_runtime_projection_from_run
         ),

--- a/loopx/canary/maintainability_ratchet.py
+++ b/loopx/canary/maintainability_ratchet.py
@@ -51,9 +51,6 @@ _OVERSIZED_DECISION_RETIREMENT_PLANS = {
     "loopx.status:compact_benchmark_run": (
         "Move benchmark run compaction into bounded runtime read-model modules."
     ),
-    "loopx.status:compact_active_user_assisted_pilot": (
-        "Move assisted-pilot compaction into a bounded runtime read model."
-    ),
     "loopx.quota:build_quota_should_run": (
         "Continue decomposing the public quota facade into bounded decision stages."
     ),
@@ -63,10 +60,6 @@ _OVERSIZED_DECISION_METRIC_CEILINGS = {
     "loopx.status:compact_benchmark_run": {
         "statements": 271,
         "decision_points": 118,
-    },
-    "loopx.status:compact_active_user_assisted_pilot": {
-        "statements": 124,
-        "decision_points": 71,
     },
     "loopx.quota:build_quota_should_run": {
         "statements": 366,

--- a/loopx/cli_commands/history.py
+++ b/loopx/cli_commands/history.py
@@ -21,6 +21,9 @@ from ..benchmarks.read_models.benchmark_learning_ledger import (
 from ..benchmarks.read_models.benchmark_result import compact_benchmark_result
 from ..control_plane.work_items.delivery_batch_scale import DELIVERY_BATCH_SCALE_CHOICES
 from ..control_plane.work_items.delivery_outcome import DELIVERY_OUTCOME_CHOICES
+from ..control_plane.runtime.active_user_assisted_pilot import (
+    compact_active_user_assisted_pilot,
+)
 from ..control_plane.runtime.trajectory_hygiene import build_trajectory_hygiene_summary
 from ..global_registry import sync_project_registry_to_global
 from ..history import (
@@ -50,10 +53,7 @@ from ..paths import resolve_runtime_root
 from ..presentation.renderers.trajectory_hygiene_markdown import (
     render_trajectory_hygiene_markdown,
 )
-from ..status import (
-    compact_active_user_assisted_pilot,
-    compact_benchmark_run,
-)
+from ..status import compact_benchmark_run
 
 
 PrintPayload = Callable[

--- a/loopx/control_plane/runtime/active_user_assisted_pilot.py
+++ b/loopx/control_plane/runtime/active_user_assisted_pilot.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .public_safety import (
+    compact_numeric_map,
+    public_safe_compact_list,
+    public_safe_compact_text,
+)
+
+
+ACTIVE_USER_ASSISTED_PILOT_SCHEMA_VERSION = "active_user_assisted_pilot_v0"
+OPERATOR_SIMULATOR_RUN_SCHEMA_VERSION = "operator_simulator_run_v0"
+MAX_ACTIVE_USER_ASSISTED_PILOT_LIST_ITEMS = 5
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _source(run: dict[str, Any]) -> dict[str, Any] | None:
+    nested = run.get("active_user_assisted_pilot")
+    if (
+        isinstance(nested, dict)
+        and nested.get("schema_version")
+        == ACTIVE_USER_ASSISTED_PILOT_SCHEMA_VERSION
+    ):
+        return nested
+    if run.get("schema_version") == ACTIVE_USER_ASSISTED_PILOT_SCHEMA_VERSION:
+        return run
+    return None
+
+
+def _compact_trigger(value: Any) -> dict[str, Any]:
+    trigger = _dict(value)
+    compact: dict[str, Any] = {}
+    for field in ("kind", "assisted_score_kind"):
+        text = public_safe_compact_text(trigger.get(field), limit=120)
+        if text:
+            compact[field] = text
+    if isinstance(trigger.get("both_autonomous_modes_failed"), bool):
+        compact["both_autonomous_modes_failed"] = trigger[
+            "both_autonomous_modes_failed"
+        ]
+
+    failed_modes = trigger.get("failed_autonomous_modes")
+    if not isinstance(failed_modes, list) or not failed_modes:
+        return compact
+
+    compact["failed_autonomous_mode_count"] = len(failed_modes)
+    names: list[str] = []
+    for item in failed_modes:
+        raw_mode = item if isinstance(item, str) else _dict(item).get("mode")
+        mode = public_safe_compact_text(raw_mode, limit=100)
+        if mode:
+            names.append(mode)
+        if len(names) >= MAX_ACTIVE_USER_ASSISTED_PILOT_LIST_ITEMS:
+            break
+    if names:
+        compact["failed_autonomous_modes"] = names
+    return compact
+
+
+def _compact_active_injection_contract(value: Any) -> dict[str, Any]:
+    contract = _dict(value)
+    compact: dict[str, Any] = {}
+    for field in ("schema_version", "simulator_setting"):
+        text = public_safe_compact_text(contract.get(field), limit=120)
+        if text:
+            compact[field] = text
+    for field in (
+        "proactive_intervention_allowed",
+        "directive_feedback_allowed",
+        "artificial_mildness_required",
+    ):
+        if isinstance(contract.get(field), bool):
+            compact[field] = contract[field]
+    return compact
+
+
+def _compact_visibility_policy(value: Any) -> dict[str, Any]:
+    policy = _dict(value)
+    compact: dict[str, Any] = {}
+    policy_id = public_safe_compact_text(policy.get("policy_id"), limit=140)
+    if policy_id:
+        compact["policy_id"] = policy_id
+    allowed_source = policy.get("allowed")
+    if allowed_source is None:
+        allowed_source = policy.get("allowed_visibility")
+    allowed = public_safe_compact_list(
+        allowed_source,
+        limit=MAX_ACTIVE_USER_ASSISTED_PILOT_LIST_ITEMS,
+    )
+    if allowed:
+        compact["allowed_visibility"] = allowed
+    return compact
+
+
+def _compact_operator_simulator_run(value: Any) -> dict[str, Any]:
+    operator_run = _dict(value)
+    compact: dict[str, Any] = {}
+    if (
+        operator_run.get("schema_version")
+        == OPERATOR_SIMULATOR_RUN_SCHEMA_VERSION
+    ):
+        compact["schema_version"] = OPERATOR_SIMULATOR_RUN_SCHEMA_VERSION
+
+    raw_simulator_identity = operator_run.get("simulator_identity")
+    simulator_identity = (
+        raw_simulator_identity
+        if isinstance(raw_simulator_identity, dict)
+        else operator_run
+    )
+    for field in ("setting", "model_family", "seed"):
+        text = public_safe_compact_text(simulator_identity.get(field), limit=140)
+        if text:
+            compact[field] = text
+
+    interventions = operator_run.get("interventions")
+    if isinstance(interventions, list) and interventions:
+        compact["intervention_count"] = len(interventions)
+        compact["proactive_intervention_count"] = sum(
+            1
+            for item in interventions
+            if isinstance(item, dict) and item.get("proactive") is True
+        )
+        compact["no_oracle_audit_passed"] = all(
+            isinstance(item, dict)
+            and isinstance(item.get("no_oracle_audit"), dict)
+            and not any(bool(audit) for audit in item["no_oracle_audit"].values())
+            for item in interventions
+        )
+    else:
+        for field in ("intervention_count", "proactive_intervention_count"):
+            if isinstance(operator_run.get(field), int):
+                compact[field] = operator_run[field]
+        if isinstance(operator_run.get("no_oracle_audit_passed"), bool):
+            compact["no_oracle_audit_passed"] = operator_run[
+                "no_oracle_audit_passed"
+            ]
+
+    official_kind = public_safe_compact_text(
+        _dict(operator_run.get("official_task_score_reference")).get("kind"),
+        limit=100,
+    )
+    if not official_kind:
+        official_kind = public_safe_compact_text(
+            operator_run.get("official_task_score_kind"),
+            limit=100,
+        )
+    if official_kind:
+        compact["official_task_score_kind"] = official_kind
+
+    if isinstance(operator_run.get("simulator_induced_error_count"), int):
+        compact["simulator_induced_error_count"] = operator_run[
+            "simulator_induced_error_count"
+        ]
+
+    frequency_audit = _dict(operator_run.get("frequency_budget_audit"))
+    frequency_satisfied = frequency_audit.get(
+        "min_worker_events_between_proactive_satisfied"
+    )
+    if not isinstance(frequency_satisfied, bool):
+        frequency_satisfied = operator_run.get("frequency_budget_satisfied")
+    if isinstance(frequency_satisfied, bool):
+        compact["frequency_budget_satisfied"] = frequency_satisfied
+
+    side_effect_audit = _dict(operator_run.get("side_effect_audit"))
+    if side_effect_audit:
+        compact["side_effect_audit_passed"] = not any(
+            bool(effect) for effect in side_effect_audit.values()
+        )
+    elif isinstance(operator_run.get("side_effect_audit_passed"), bool):
+        compact["side_effect_audit_passed"] = operator_run[
+            "side_effect_audit_passed"
+        ]
+    return compact
+
+
+def _compact_claim_boundary(value: Any) -> dict[str, Any]:
+    boundary = _dict(value)
+    return {
+        field: boundary[field]
+        for field in (
+            "official_score_claim_allowed",
+            "assisted_collaboration_claim_allowed",
+            "leaderboard_claim_allowed",
+        )
+        if isinstance(boundary.get(field), bool)
+    }
+
+
+def _compact_next_run_decision(
+    value: Any,
+    *,
+    operator_run: dict[str, Any],
+) -> dict[str, Any]:
+    decision = _dict(value) or _dict(operator_run.get("next_run_decision"))
+    compact: dict[str, Any] = {}
+    for field in ("decision", "minimum_next_evidence"):
+        text = public_safe_compact_text(decision.get(field), limit=180)
+        if text:
+            compact[field] = text
+    for field in (
+        "requires_real_runner_approval",
+        "keep_official_scores_separate",
+    ):
+        if isinstance(decision.get(field), bool):
+            compact[field] = decision[field]
+    return compact
+
+
+def compact_active_user_assisted_pilot(
+    run: dict[str, Any],
+) -> dict[str, Any] | None:
+    source = _source(run)
+    if not source:
+        return None
+
+    compact: dict[str, Any] = {
+        "schema_version": ACTIVE_USER_ASSISTED_PILOT_SCHEMA_VERSION
+    }
+    for field in ("pilot_id", "benchmark_id", "task_id"):
+        text = public_safe_compact_text(source.get(field), limit=140)
+        if text:
+            compact[field] = text
+
+    sections = (
+        ("trigger", _compact_trigger(source.get("trigger"))),
+        (
+            "active_injection_contract",
+            _compact_active_injection_contract(
+                source.get("active_injection_contract")
+            ),
+        ),
+        (
+            "frequency_budget",
+            compact_numeric_map(
+                source.get("frequency_budget"),
+                keys=(
+                    "max_interventions",
+                    "max_proactive_interventions",
+                    "min_worker_events_between_proactive",
+                    "max_chars_per_intervention",
+                ),
+            ),
+        ),
+        (
+            "visibility_policy",
+            _compact_visibility_policy(source.get("visibility_policy")),
+        ),
+    )
+    for field, value in sections:
+        if value:
+            compact[field] = value
+
+    operator_run = _dict(source.get("operator_simulator_run"))
+    compact_operator = _compact_operator_simulator_run(operator_run)
+    if compact_operator:
+        compact["operator_simulator_run"] = compact_operator
+
+    claim_boundary = _compact_claim_boundary(source.get("claim_boundary"))
+    if claim_boundary:
+        compact["claim_boundary"] = claim_boundary
+
+    next_decision = _compact_next_run_decision(
+        source.get("next_run_decision"),
+        operator_run=operator_run,
+    )
+    if next_decision:
+        compact["next_run_decision"] = next_decision
+
+    if set(compact) == {"schema_version"}:
+        return None
+    return compact

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -209,6 +209,9 @@ from .control_plane.runtime.public_safety import (
     public_safe_compact_list,
     public_safe_compact_text,
 )
+from .control_plane.runtime.active_user_assisted_pilot import (
+    compact_active_user_assisted_pilot as _compact_active_user_assisted_pilot_read_model,
+)
 from .control_plane.runtime.run_ingest_health import (
     compact_environment_setup_failure_context,
     compact_worker_bridge_outcome,
@@ -411,8 +414,6 @@ BLOCKING_CLASSIFICATIONS = {
     "blocked_by_safety",
 }
 BENCHMARK_RUN_SCHEMA_VERSION = "benchmark_run_v0"
-ACTIVE_USER_ASSISTED_PILOT_SCHEMA_VERSION = "active_user_assisted_pilot_v0"
-OPERATOR_SIMULATOR_RUN_SCHEMA_VERSION = "operator_simulator_run_v0"
 MAX_BENCHMARK_RUN_TRIALS = 3
 MAX_BENCHMARK_RUN_LIST_ITEMS = 5
 STATUS_CONTRACT_SCHEMA_VERSION = 2
@@ -3279,186 +3280,6 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
     return compact
 
 
-def _active_user_assisted_pilot_source(run: dict[str, Any]) -> dict[str, Any] | None:
-    nested = run.get("active_user_assisted_pilot")
-    if isinstance(nested, dict) and nested.get("schema_version") == ACTIVE_USER_ASSISTED_PILOT_SCHEMA_VERSION:
-        return nested
-    if run.get("schema_version") == ACTIVE_USER_ASSISTED_PILOT_SCHEMA_VERSION:
-        return run
-    return None
-
-
-def compact_active_user_assisted_pilot(run: dict[str, Any]) -> dict[str, Any] | None:
-    source = _active_user_assisted_pilot_source(run)
-    if not source:
-        return None
-
-    compact: dict[str, Any] = {"schema_version": ACTIVE_USER_ASSISTED_PILOT_SCHEMA_VERSION}
-    for field in ("pilot_id", "benchmark_id", "task_id"):
-        value = public_safe_compact_text(source.get(field), limit=140)
-        if value:
-            compact[field] = value
-
-    trigger = source.get("trigger") if isinstance(source.get("trigger"), dict) else {}
-    compact_trigger: dict[str, Any] = {}
-    for field in ("kind", "assisted_score_kind"):
-        value = public_safe_compact_text(trigger.get(field), limit=120)
-        if value:
-            compact_trigger[field] = value
-    if isinstance(trigger.get("both_autonomous_modes_failed"), bool):
-        compact_trigger["both_autonomous_modes_failed"] = trigger.get("both_autonomous_modes_failed")
-    failed_modes = trigger.get("failed_autonomous_modes") if isinstance(trigger.get("failed_autonomous_modes"), list) else []
-    if failed_modes:
-        compact_trigger["failed_autonomous_mode_count"] = len(failed_modes)
-        mode_names = []
-        for item in failed_modes:
-            if isinstance(item, str):
-                mode = public_safe_compact_text(item, limit=100)
-            elif isinstance(item, dict):
-                mode = public_safe_compact_text(item.get("mode"), limit=100)
-            else:
-                continue
-            if mode:
-                mode_names.append(mode)
-            if len(mode_names) >= MAX_BENCHMARK_RUN_LIST_ITEMS:
-                break
-        if mode_names:
-            compact_trigger["failed_autonomous_modes"] = mode_names
-    if compact_trigger:
-        compact["trigger"] = compact_trigger
-
-    active = source.get("active_injection_contract") if isinstance(source.get("active_injection_contract"), dict) else {}
-    compact_active: dict[str, Any] = {}
-    for field in ("schema_version", "simulator_setting"):
-        value = public_safe_compact_text(active.get(field), limit=120)
-        if value:
-            compact_active[field] = value
-    for field in ("proactive_intervention_allowed", "directive_feedback_allowed", "artificial_mildness_required"):
-        if isinstance(active.get(field), bool):
-            compact_active[field] = active.get(field)
-    if compact_active:
-        compact["active_injection_contract"] = compact_active
-
-    budget = source.get("frequency_budget") if isinstance(source.get("frequency_budget"), dict) else {}
-    compact_budget = _compact_numeric_map(
-        budget,
-        keys=(
-            "max_interventions",
-            "max_proactive_interventions",
-            "min_worker_events_between_proactive",
-            "max_chars_per_intervention",
-        ),
-    )
-    if compact_budget:
-        compact["frequency_budget"] = compact_budget
-
-    visibility = source.get("visibility_policy") if isinstance(source.get("visibility_policy"), dict) else {}
-    compact_visibility: dict[str, Any] = {}
-    policy_id = public_safe_compact_text(visibility.get("policy_id"), limit=140)
-    if policy_id:
-        compact_visibility["policy_id"] = policy_id
-    visibility_allowed_source = visibility.get("allowed")
-    if visibility_allowed_source is None:
-        visibility_allowed_source = visibility.get("allowed_visibility")
-    allowed_visibility = public_safe_compact_list(visibility_allowed_source, limit=MAX_BENCHMARK_RUN_LIST_ITEMS)
-    if allowed_visibility:
-        compact_visibility["allowed_visibility"] = allowed_visibility
-    if compact_visibility:
-        compact["visibility_policy"] = compact_visibility
-
-    operator_run = source.get("operator_simulator_run") if isinstance(source.get("operator_simulator_run"), dict) else {}
-    compact_operator: dict[str, Any] = {}
-    if operator_run.get("schema_version") == OPERATOR_SIMULATOR_RUN_SCHEMA_VERSION:
-        compact_operator["schema_version"] = OPERATOR_SIMULATOR_RUN_SCHEMA_VERSION
-    simulator_identity = (
-        operator_run.get("simulator_identity")
-        if isinstance(operator_run.get("simulator_identity"), dict)
-        else operator_run
-    )
-    for field in ("setting", "model_family", "seed"):
-        value = public_safe_compact_text(simulator_identity.get(field), limit=140)
-        if value:
-            compact_operator[field] = value
-    interventions = operator_run.get("interventions") if isinstance(operator_run.get("interventions"), list) else []
-    if interventions:
-        compact_operator["intervention_count"] = len(interventions)
-        compact_operator["proactive_intervention_count"] = sum(
-            1 for item in interventions if isinstance(item, dict) and item.get("proactive") is True
-        )
-        compact_operator["no_oracle_audit_passed"] = all(
-            isinstance(item, dict)
-            and isinstance(item.get("no_oracle_audit"), dict)
-            and not any(bool(value) for value in item["no_oracle_audit"].values())
-            for item in interventions
-        )
-    else:
-        for field in ("intervention_count", "proactive_intervention_count"):
-            if isinstance(operator_run.get(field), int):
-                compact_operator[field] = operator_run.get(field)
-        if isinstance(operator_run.get("no_oracle_audit_passed"), bool):
-            compact_operator["no_oracle_audit_passed"] = operator_run.get("no_oracle_audit_passed")
-    official = (
-        operator_run.get("official_task_score_reference")
-        if isinstance(operator_run.get("official_task_score_reference"), dict)
-        else {}
-    )
-    official_kind = public_safe_compact_text(official.get("kind"), limit=100)
-    if not official_kind:
-        official_kind = public_safe_compact_text(operator_run.get("official_task_score_kind"), limit=100)
-    if official_kind:
-        compact_operator["official_task_score_kind"] = official_kind
-    if isinstance(operator_run.get("simulator_induced_error_count"), int):
-        compact_operator["simulator_induced_error_count"] = operator_run.get("simulator_induced_error_count")
-    frequency_audit = (
-        operator_run.get("frequency_budget_audit")
-        if isinstance(operator_run.get("frequency_budget_audit"), dict)
-        else {}
-    )
-    if isinstance(frequency_audit.get("min_worker_events_between_proactive_satisfied"), bool):
-        compact_operator["frequency_budget_satisfied"] = frequency_audit.get(
-            "min_worker_events_between_proactive_satisfied"
-        )
-    elif isinstance(operator_run.get("frequency_budget_satisfied"), bool):
-        compact_operator["frequency_budget_satisfied"] = operator_run.get("frequency_budget_satisfied")
-    side_effect_audit = (
-        operator_run.get("side_effect_audit")
-        if isinstance(operator_run.get("side_effect_audit"), dict)
-        else {}
-    )
-    if side_effect_audit:
-        compact_operator["side_effect_audit_passed"] = not any(bool(value) for value in side_effect_audit.values())
-    elif isinstance(operator_run.get("side_effect_audit_passed"), bool):
-        compact_operator["side_effect_audit_passed"] = operator_run.get("side_effect_audit_passed")
-    if compact_operator:
-        compact["operator_simulator_run"] = compact_operator
-
-    claim_boundary = source.get("claim_boundary") if isinstance(source.get("claim_boundary"), dict) else {}
-    compact_boundary: dict[str, Any] = {}
-    for field in ("official_score_claim_allowed", "assisted_collaboration_claim_allowed", "leaderboard_claim_allowed"):
-        if isinstance(claim_boundary.get(field), bool):
-            compact_boundary[field] = claim_boundary.get(field)
-    if compact_boundary:
-        compact["claim_boundary"] = compact_boundary
-
-    next_decision = source.get("next_run_decision") if isinstance(source.get("next_run_decision"), dict) else {}
-    if not next_decision and isinstance(operator_run.get("next_run_decision"), dict):
-        next_decision = operator_run.get("next_run_decision")  # type: ignore[assignment]
-    compact_next: dict[str, Any] = {}
-    for field in ("decision", "minimum_next_evidence"):
-        value = public_safe_compact_text(next_decision.get(field), limit=180)
-        if value:
-            compact_next[field] = value
-    for field in ("requires_real_runner_approval", "keep_official_scores_separate"):
-        if isinstance(next_decision.get(field), bool):
-            compact_next[field] = next_decision.get(field)
-    if compact_next:
-        compact["next_run_decision"] = compact_next
-
-    if set(compact.keys()) == {"schema_version"}:
-        return None
-    return compact
-
-
 def state_event_log_candidates(goal: dict[str, Any], *, state_path: Path) -> list[Path]:
     return _state_event_log_candidates_read_model(
         goal,
@@ -3792,7 +3613,7 @@ def compact_post_handoff_run(run: dict[str, Any], profile: dict[str, Any] | None
         benchmark_experiment_report_replay_decision=(
             benchmark_experiment_report_replay_decision
         ),
-        compact_active_user_assisted_pilot=compact_active_user_assisted_pilot,
+        compact_active_user_assisted_pilot=_compact_active_user_assisted_pilot_read_model,
         compact_session_runtime_projection_from_run=(
             compact_session_runtime_projection_from_run
         ),
@@ -4354,7 +4175,7 @@ def compact_run(run: dict[str, Any]) -> dict[str, Any]:
         compact_benchmark_experiment_report=compact_benchmark_experiment_report,
         benchmark_experiment_report_readiness_note=benchmark_experiment_report_readiness_note,
         benchmark_experiment_report_replay_decision=benchmark_experiment_report_replay_decision,
-        compact_active_user_assisted_pilot=compact_active_user_assisted_pilot,
+        compact_active_user_assisted_pilot=_compact_active_user_assisted_pilot_read_model,
         compact_session_runtime_projection_from_run=compact_session_runtime_projection_from_run,
     )
 
@@ -4387,7 +4208,7 @@ def build_status_runtime_summary_context() -> StatusRuntimeSummaryContext:
         compact_benchmark_comparison=_compact_benchmark_comparison_read_model,
         compact_benchmark_learning_ledger=compact_benchmark_learning_ledger,
         compact_benchmark_experiment_report=compact_benchmark_experiment_report,
-        compact_active_user_assisted_pilot=compact_active_user_assisted_pilot,
+        compact_active_user_assisted_pilot=_compact_active_user_assisted_pilot_read_model,
         run_has_external_evidence_watch_signal=run_has_external_evidence_watch_signal,
         decision_classifications=EVENT_LEDGER_DECISION_CLASSIFICATIONS,
         evidence_classifications=EVENT_LEDGER_EVIDENCE_CLASSIFICATIONS,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ files = [
   "loopx/claude_goal_baseline.py",
   "loopx/control_plane/__init__.py",
   "loopx/control_plane/quota/states.py",
+  "loopx/control_plane/runtime/active_user_assisted_pilot.py",
   "loopx/control_plane/runtime/event_store_migration_bridge.py",
   "loopx/control_plane/runtime/time.py",
   "loopx/control_plane/runtime/trajectory_hygiene.py",

--- a/tests/control_plane/runtime/test_active_user_assisted_pilot.py
+++ b/tests/control_plane/runtime/test_active_user_assisted_pilot.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from loopx.control_plane.runtime.active_user_assisted_pilot import (
+    compact_active_user_assisted_pilot,
+)
+
+
+def test_compacts_nested_active_user_assisted_pilot_contract() -> None:
+    run = {
+        "active_user_assisted_pilot": {
+            "schema_version": "active_user_assisted_pilot_v0",
+            "pilot_id": "pilot-1",
+            "benchmark_id": "terminal-bench@2.0",
+            "task_id": "train-fasttext",
+            "trigger": {
+                "kind": "previous_compact_negative_result",
+                "assisted_score_kind": "not_run",
+                "both_autonomous_modes_failed": True,
+                "failed_autonomous_modes": [
+                    "baseline",
+                    {"mode": "codex_loopx"},
+                    {"ignored": "missing mode"},
+                ],
+            },
+            "active_injection_contract": {
+                "schema_version": "active_user_simulator_injection_v0",
+                "simulator_setting": "deterministic_scripted_user",
+                "proactive_intervention_allowed": True,
+                "directive_feedback_allowed": False,
+                "artificial_mildness_required": True,
+            },
+            "frequency_budget": {
+                "max_interventions": "3",
+                "max_proactive_interventions": 2,
+                "min_worker_events_between_proactive": 2,
+                "max_chars_per_intervention": 800,
+            },
+            "visibility_policy": {
+                "policy_id": "compact-only",
+                "allowed": ["public_task_statement", "compact_failure_summary"],
+            },
+            "operator_simulator_run": {
+                "schema_version": "operator_simulator_run_v0",
+                "simulator_identity": {
+                    "setting": "deterministic_scripted_user",
+                    "model_family": "scripted",
+                    "seed": "seed-1",
+                },
+                "interventions": [
+                    {
+                        "proactive": True,
+                        "no_oracle_audit": {"hidden_tests_seen": False},
+                    },
+                    {
+                        "proactive": False,
+                        "no_oracle_audit": {"hidden_tests_seen": False},
+                    },
+                ],
+                "official_task_score_reference": {"kind": "not_run"},
+                "simulator_induced_error_count": 0,
+                "frequency_budget_audit": {
+                    "min_worker_events_between_proactive_satisfied": True,
+                },
+                "side_effect_audit": {"model_api": False, "docker": False},
+                "next_run_decision": {
+                    "decision": "eligible_for_private_assisted_treatment",
+                    "minimum_next_evidence": "one reviewed runner attempt",
+                    "requires_real_runner_approval": True,
+                    "keep_official_scores_separate": True,
+                },
+            },
+            "claim_boundary": {
+                "official_score_claim_allowed": False,
+                "assisted_collaboration_claim_allowed": True,
+                "leaderboard_claim_allowed": False,
+            },
+        }
+    }
+
+    assert compact_active_user_assisted_pilot(run) == {
+        "schema_version": "active_user_assisted_pilot_v0",
+        "pilot_id": "pilot-1",
+        "benchmark_id": "terminal-bench@2.0",
+        "task_id": "train-fasttext",
+        "trigger": {
+            "kind": "previous_compact_negative_result",
+            "assisted_score_kind": "not_run",
+            "both_autonomous_modes_failed": True,
+            "failed_autonomous_mode_count": 3,
+            "failed_autonomous_modes": ["baseline", "codex_loopx"],
+        },
+        "active_injection_contract": {
+            "schema_version": "active_user_simulator_injection_v0",
+            "simulator_setting": "deterministic_scripted_user",
+            "proactive_intervention_allowed": True,
+            "directive_feedback_allowed": False,
+            "artificial_mildness_required": True,
+        },
+        "frequency_budget": {
+            "max_interventions": 3,
+            "max_proactive_interventions": 2,
+            "min_worker_events_between_proactive": 2,
+            "max_chars_per_intervention": 800,
+        },
+        "visibility_policy": {
+            "policy_id": "compact-only",
+            "allowed_visibility": [
+                "public_task_statement",
+                "compact_failure_summary",
+            ],
+        },
+        "operator_simulator_run": {
+            "schema_version": "operator_simulator_run_v0",
+            "setting": "deterministic_scripted_user",
+            "model_family": "scripted",
+            "seed": "seed-1",
+            "intervention_count": 2,
+            "proactive_intervention_count": 1,
+            "no_oracle_audit_passed": True,
+            "official_task_score_kind": "not_run",
+            "simulator_induced_error_count": 0,
+            "frequency_budget_satisfied": True,
+            "side_effect_audit_passed": True,
+        },
+        "claim_boundary": {
+            "official_score_claim_allowed": False,
+            "assisted_collaboration_claim_allowed": True,
+            "leaderboard_claim_allowed": False,
+        },
+        "next_run_decision": {
+            "decision": "eligible_for_private_assisted_treatment",
+            "minimum_next_evidence": "one reviewed runner attempt",
+            "requires_real_runner_approval": True,
+            "keep_official_scores_separate": True,
+        },
+    }
+
+
+def test_rejects_unknown_or_empty_pilot_contracts() -> None:
+    assert compact_active_user_assisted_pilot({}) is None
+    assert (
+        compact_active_user_assisted_pilot(
+            {"schema_version": "active_user_assisted_pilot_v0"}
+        )
+        is None
+    )
+    assert (
+        compact_active_user_assisted_pilot(
+            {
+                "active_user_assisted_pilot": {
+                    "schema_version": "active_user_assisted_pilot_v1",
+                    "pilot_id": "future",
+                }
+            }
+        )
+        is None
+    )
+
+
+def test_preserves_compact_operator_fallback_fields() -> None:
+    assert compact_active_user_assisted_pilot(
+        {
+            "schema_version": "active_user_assisted_pilot_v0",
+            "pilot_id": "pilot-fallback",
+            "visibility_policy": {"allowed_visibility": ["public_task_statement"]},
+            "operator_simulator_run": {
+                "simulator_identity": {},
+                "setting": "must-not-replace-empty-identity",
+                "intervention_count": 4,
+                "proactive_intervention_count": 2,
+                "no_oracle_audit_passed": False,
+                "official_task_score_kind": "separate_assisted_score",
+                "frequency_budget_satisfied": False,
+                "side_effect_audit_passed": True,
+            },
+            "next_run_decision": {
+                "decision": "prefer-top-level-decision",
+                "keep_official_scores_separate": True,
+            },
+        }
+    ) == {
+        "schema_version": "active_user_assisted_pilot_v0",
+        "pilot_id": "pilot-fallback",
+        "visibility_policy": {
+            "allowed_visibility": ["public_task_statement"],
+        },
+        "operator_simulator_run": {
+            "intervention_count": 4,
+            "proactive_intervention_count": 2,
+            "no_oracle_audit_passed": False,
+            "official_task_score_kind": "separate_assisted_score",
+            "frequency_budget_satisfied": False,
+            "side_effect_audit_passed": True,
+        },
+        "next_run_decision": {
+            "decision": "prefer-top-level-decision",
+            "keep_official_scores_separate": True,
+        },
+    }


### PR DESCRIPTION
## Summary
- move active-user assisted-pilot compaction from the status facade into its bounded runtime read model
- update active callers directly and remove the retired oversized-decision exception without a compatibility wrapper
- characterize nested, fallback, and invalid contracts and add the new owner to the strict mypy set

## Validation
- `python -m mypy --config-file pyproject.toml` (13 source files)
- focused pytest: 21 passed
- changed-scope ruff: passed
- assisted-pilot append, run-compaction parity, and maintainability smokes: passed
- standard premerge canary: 18 selected checks passed; no manual holds
- committed-scope quick premerge gate: passed, self-merge allowed
- change-quality receipt: `cqr_c07a84265a3c5a7de65e` (valid)

## Risk
Behavior-preserving read-model move. The main risk is caller drift; all in-repo callers now import the canonical owner and focused parity/CLI coverage passed.