### PR TITLE
refactor(status): move benchmark failure read model

### DIFF
--- a/loopx/benchmarks/read_models/benchmark_run_failure.py
+++ b/loopx/benchmarks/read_models/benchmark_run_failure.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ...control_plane.runtime.public_safety import (
+    public_safe_compact_list,
+    public_safe_compact_text,
+)
+
+
+def compact_benchmark_runner_failure(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+
+    compact = _compact_fields(
+        value,
+        text_fields=("schema_version", "exception_type", "failure_class"),
+        bool_fields=(
+            "raw_error_recorded",
+            "raw_logs_read",
+            "raw_task_text_read",
+            "raw_trajectory_read",
+        ),
+    )
+    for field, compactor in (
+        ("controller_cutoff", _compact_controller_cutoff),
+        ("user_loop_recovery", _compact_user_loop_recovery),
+        ("native_goal_worker", _compact_native_goal_worker),
+    ):
+        nested = compactor(value.get(field))
+        if nested:
+            compact[field] = nested
+    return compact
+
+
+def compact_benchmark_runner_failure_fingerprint(
+    value: Any,
+    *,
+    max_list_items: int,
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+
+    compact = _compact_fields(
+        value,
+        text_fields=(
+            "schema_version",
+            "error_len_bucket",
+            "fingerprint_confidence",
+            "apt_failure_subtype",
+            "pip_failure_subtype",
+            "retryability",
+        ),
+        int_fields=("line_count",),
+        text_limit=100,
+    )
+    for field, limit in (
+        ("matched_patterns", max_list_items * 4),
+        ("failure_line_dependency_classes", max_list_items * 2),
+        ("failure_reason_codes", max_list_items * 2),
+        ("terminal_failure_dependency_classes", max_list_items * 2),
+        ("terminal_failure_reason_codes", max_list_items * 2),
+        ("failure_dependency_endpoints", max_list_items * 2),
+        ("terminal_failure_dependency_endpoints", max_list_items * 2),
+    ):
+        items = public_safe_compact_list(value.get(field), limit=limit)
+        if items:
+            compact[field] = items
+    compact.update(
+        _compact_fields(
+            value,
+            bool_fields=(
+                "error_present",
+                "has_host_paths",
+                "has_urls",
+                "has_secret_like_tokens",
+                "raw_error_recorded",
+            ),
+        )
+    )
+    return compact
+
+
+def _compact_controller_cutoff(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    return _compact_fields(
+        value,
+        text_fields=("schema_version", "reason"),
+        bool_fields=("cutoff_before_followup",),
+        int_fields=(
+            "max_rounds_budget",
+            "initial_prompt_count",
+            "followup_prompt_count",
+            "stop_decision_count",
+        ),
+    )
+
+
+def _compact_user_loop_recovery(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    return _compact_fields(
+        value,
+        text_fields=("schema_version", "stage", "exception_type"),
+        bool_fields=("preserved_final_verify", "raw_error_recorded"),
+        int_fields=("round", "delta_events", "delta_tool_calls"),
+    )
+
+
+def _compact_native_goal_worker(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    compact = _compact_fields(
+        value,
+        text_fields=(
+            "schema_version",
+            "trace_status",
+            "failure_label",
+            "failure_category",
+            "first_blocker",
+        ),
+        int_fields=("trace_count",),
+    )
+    compact.update(
+        _compact_fields(
+            value,
+            bool_fields=(
+                "raw_transcript_recorded",
+                "raw_assistant_message_recorded",
+            ),
+        )
+    )
+    return compact
+
+
+def _compact_fields(
+    value: dict[str, Any],
+    *,
+    text_fields: tuple[str, ...] = (),
+    bool_fields: tuple[str, ...] = (),
+    int_fields: tuple[str, ...] = (),
+    text_limit: int = 140,
+) -> dict[str, Any]:
+    compact: dict[str, Any] = {}
+    for field in text_fields:
+        text = public_safe_compact_text(value.get(field), limit=text_limit)
+        if text:
+            compact[field] = text
+    for field in bool_fields:
+        if isinstance(value.get(field), bool):
+            compact[field] = value[field]
+    for field in int_fields:
+        number = value.get(field)
+        if isinstance(number, int) and not isinstance(number, bool):
+            compact[field] = number
+    return compact

--- a/loopx/canary/maintainability_ratchet.py
+++ b/loopx/canary/maintainability_ratchet.py
@@ -58,8 +58,8 @@ _OVERSIZED_DECISION_RETIREMENT_PLANS = {
 
 _OVERSIZED_DECISION_METRIC_CEILINGS = {
     "loopx.status:compact_benchmark_run": {
-        "statements": 271,
-        "decision_points": 118,
+        "statements": 201,
+        "decision_points": 78,
     },
     "loopx.quota:build_quota_should_run": {
         "statements": 366,

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -200,6 +200,10 @@ from .benchmarks.read_models.benchmark_run_metrics import (
     compact_benchmark_overhead_attribution_counters as _compact_benchmark_overhead_attribution_counters,
     compact_benchmark_round_reward_trace as _compact_benchmark_round_reward_trace,
 )
+from .benchmarks.read_models.benchmark_run_failure import (
+    compact_benchmark_runner_failure as _compact_benchmark_runner_failure,
+    compact_benchmark_runner_failure_fingerprint as _compact_benchmark_runner_failure_fingerprint,
+)
 from .benchmarks.read_models.goal_start_control_score import (
     compact_goal_start_product_mode_control_score,
 )
@@ -2930,148 +2934,16 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         if compact_model_control:
             compact["model_control"] = compact_model_control
 
-    runner_failure = source.get("runner_failure")
-    if isinstance(runner_failure, dict):
-        compact_runner_failure: dict[str, Any] = {}
-        for field in ("schema_version", "exception_type", "failure_class"):
-            value = public_safe_compact_text(runner_failure.get(field), limit=140)
-            if value:
-                compact_runner_failure[field] = value
-        for field in (
-            "raw_error_recorded",
-            "raw_logs_read",
-            "raw_task_text_read",
-            "raw_trajectory_read",
-        ):
-            if isinstance(runner_failure.get(field), bool):
-                compact_runner_failure[field] = runner_failure[field]
-        controller_cutoff = runner_failure.get("controller_cutoff")
-        if isinstance(controller_cutoff, dict):
-            compact_cutoff: dict[str, Any] = {}
-            for field in ("schema_version", "reason"):
-                value = public_safe_compact_text(
-                    controller_cutoff.get(field),
-                    limit=140,
-                )
-                if value:
-                    compact_cutoff[field] = value
-            if isinstance(controller_cutoff.get("cutoff_before_followup"), bool):
-                compact_cutoff["cutoff_before_followup"] = controller_cutoff[
-                    "cutoff_before_followup"
-                ]
-            for field in (
-                "max_rounds_budget",
-                "initial_prompt_count",
-                "followup_prompt_count",
-                "stop_decision_count",
-            ):
-                if isinstance(controller_cutoff.get(field), int) and not isinstance(
-                    controller_cutoff.get(field),
-                    bool,
-                ):
-                    compact_cutoff[field] = controller_cutoff[field]
-            if compact_cutoff:
-                compact_runner_failure["controller_cutoff"] = compact_cutoff
-        user_loop_recovery = runner_failure.get("user_loop_recovery")
-        if isinstance(user_loop_recovery, dict):
-            compact_recovery: dict[str, Any] = {}
-            for field in ("schema_version", "stage", "exception_type"):
-                value = public_safe_compact_text(
-                    user_loop_recovery.get(field),
-                    limit=140,
-                )
-                if value:
-                    compact_recovery[field] = value
-            for field in ("preserved_final_verify", "raw_error_recorded"):
-                if isinstance(user_loop_recovery.get(field), bool):
-                    compact_recovery[field] = user_loop_recovery[field]
-            for field in ("round", "delta_events", "delta_tool_calls"):
-                if isinstance(user_loop_recovery.get(field), int) and not isinstance(
-                    user_loop_recovery.get(field),
-                    bool,
-                ):
-                    compact_recovery[field] = user_loop_recovery[field]
-            if compact_recovery:
-                compact_runner_failure["user_loop_recovery"] = compact_recovery
-        native_goal_worker = runner_failure.get("native_goal_worker")
-        if isinstance(native_goal_worker, dict):
-            compact_native_worker: dict[str, Any] = {}
-            for field in (
-                "schema_version",
-                "trace_status",
-                "failure_label",
-                "failure_category",
-                "first_blocker",
-            ):
-                value = public_safe_compact_text(
-                    native_goal_worker.get(field),
-                    limit=140,
-                )
-                if value:
-                    compact_native_worker[field] = value
-            for field in (
-                "trace_count",
-            ):
-                value = native_goal_worker.get(field)
-                if isinstance(value, int) and not isinstance(value, bool):
-                    compact_native_worker[field] = value
-            for field in (
-                "raw_transcript_recorded",
-                "raw_assistant_message_recorded",
-            ):
-                if isinstance(native_goal_worker.get(field), bool):
-                    compact_native_worker[field] = native_goal_worker[field]
-            if compact_native_worker:
-                compact_runner_failure["native_goal_worker"] = compact_native_worker
-        if compact_runner_failure:
-            compact["runner_failure"] = compact_runner_failure
+    runner_failure = _compact_benchmark_runner_failure(source.get("runner_failure"))
+    if runner_failure:
+        compact["runner_failure"] = runner_failure
 
-    fingerprint = source.get("runner_failure_fingerprint")
-    if isinstance(fingerprint, dict):
-        compact_fingerprint: dict[str, Any] = {}
-        for field in (
-            "schema_version",
-            "error_len_bucket",
-            "fingerprint_confidence",
-            "apt_failure_subtype",
-            "pip_failure_subtype",
-            "retryability",
-        ):
-            value = public_safe_compact_text(fingerprint.get(field), limit=100)
-            if value:
-                compact_fingerprint[field] = value
-        line_count = fingerprint.get("line_count")
-        if isinstance(line_count, int) and not isinstance(line_count, bool):
-            compact_fingerprint["line_count"] = line_count
-        for field, limit in (
-            ("matched_patterns", MAX_BENCHMARK_RUN_LIST_ITEMS * 4),
-            ("failure_line_dependency_classes", MAX_BENCHMARK_RUN_LIST_ITEMS * 2),
-            ("failure_reason_codes", MAX_BENCHMARK_RUN_LIST_ITEMS * 2),
-            (
-                "terminal_failure_dependency_classes",
-                MAX_BENCHMARK_RUN_LIST_ITEMS * 2,
-            ),
-            ("terminal_failure_reason_codes", MAX_BENCHMARK_RUN_LIST_ITEMS * 2),
-            ("failure_dependency_endpoints", MAX_BENCHMARK_RUN_LIST_ITEMS * 2),
-            (
-                "terminal_failure_dependency_endpoints",
-                MAX_BENCHMARK_RUN_LIST_ITEMS * 2,
-            ),
-        ):
-            values = public_safe_compact_list(fingerprint.get(field), limit=limit)
-            if values:
-                compact_fingerprint[field] = values
-        for field in (
-            "error_present",
-            "has_host_paths",
-            "has_urls",
-            "has_secret_like_tokens",
-            "raw_error_recorded",
-        ):
-            if isinstance(fingerprint.get(field), bool):
-                compact_fingerprint[field] = fingerprint[field]
-        if compact_fingerprint:
-            compact["runner_failure_fingerprint"] = compact_fingerprint
+    fingerprint = _compact_benchmark_runner_failure_fingerprint(
+        source.get("runner_failure_fingerprint"),
+        max_list_items=MAX_BENCHMARK_RUN_LIST_ITEMS,
+    )
+    if fingerprint:
+        compact["runner_failure_fingerprint"] = fingerprint
 
     compose_setup_diagnostic = _compact_benchmark_compose_setup_diagnostic(
         source.get("compose_setup_diagnostic")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ python_version = "3.11"
 strict = true
 files = [
   "loopx/claude_goal_baseline.py",
+  "loopx/benchmarks/read_models/benchmark_run_failure.py",
   "loopx/control_plane/__init__.py",
   "loopx/control_plane/quota/states.py",
   "loopx/control_plane/runtime/active_user_assisted_pilot.py",

--- a/tests/benchmarks/read_models/test_benchmark_run_failure.py
+++ b/tests/benchmarks/read_models/test_benchmark_run_failure.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from loopx.status import compact_benchmark_run
+
+
+def test_status_facade_compacts_benchmark_runner_failure_diagnostics() -> None:
+    compact = compact_benchmark_run(
+        {
+            "schema_version": "benchmark_run_v0",
+            "runner_failure": {
+                "schema_version": "runner_failure_v0",
+                "exception_type": "RuntimeError",
+                "failure_class": "runner_timeout",
+                "raw_error_recorded": False,
+                "raw_logs_read": False,
+                "raw_task_text_read": False,
+                "raw_trajectory_read": False,
+                "controller_cutoff": {
+                    "schema_version": "controller_cutoff_v0",
+                    "reason": "followup_budget_exhausted",
+                    "cutoff_before_followup": True,
+                    "max_rounds_budget": 3,
+                    "initial_prompt_count": 1,
+                    "followup_prompt_count": 2,
+                    "stop_decision_count": 1,
+                    "private_detail": "drop",
+                },
+                "user_loop_recovery": {
+                    "schema_version": "user_loop_recovery_v0",
+                    "stage": "soft_verify",
+                    "exception_type": "TimeoutError",
+                    "preserved_final_verify": True,
+                    "raw_error_recorded": False,
+                    "round": 2,
+                    "delta_events": 4,
+                    "delta_tool_calls": 3,
+                    "private_detail": "drop",
+                },
+                "native_goal_worker": {
+                    "schema_version": "native_goal_worker_failure_v0",
+                    "trace_status": "worker_failed",
+                    "failure_label": "first_action_timeout",
+                    "failure_category": "codex_exec_timeout",
+                    "first_blocker": "task_output_quiet_timeout",
+                    "trace_count": 4,
+                    "raw_transcript_recorded": False,
+                    "raw_assistant_message_recorded": False,
+                    "private_detail": "drop",
+                },
+                "private_detail": "drop",
+            },
+            "runner_failure_fingerprint": {
+                "schema_version": "runner_failure_fingerprint_v0",
+                "error_len_bucket": "short",
+                "fingerprint_confidence": "high",
+                "apt_failure_subtype": "repository_unreachable",
+                "pip_failure_subtype": "index_unreachable",
+                "retryability": "retryable",
+                "line_count": 7,
+                "matched_patterns": ["timeout", "network"],
+                "failure_line_dependency_classes": ["apt", "pip"],
+                "failure_reason_codes": ["egress_blocked"],
+                "terminal_failure_dependency_classes": ["network"],
+                "terminal_failure_reason_codes": ["timeout"],
+                "failure_dependency_endpoints": ["package-index"],
+                "terminal_failure_dependency_endpoints": ["package-index"],
+                "error_present": True,
+                "has_host_paths": False,
+                "has_urls": False,
+                "has_secret_like_tokens": False,
+                "raw_error_recorded": False,
+                "private_detail": "drop",
+            },
+        }
+    )
+
+    assert compact is not None
+    assert compact["runner_failure"] == {
+        "schema_version": "runner_failure_v0",
+        "exception_type": "RuntimeError",
+        "failure_class": "runner_timeout",
+        "raw_error_recorded": False,
+        "raw_logs_read": False,
+        "raw_task_text_read": False,
+        "raw_trajectory_read": False,
+        "controller_cutoff": {
+            "schema_version": "controller_cutoff_v0",
+            "reason": "followup_budget_exhausted",
+            "cutoff_before_followup": True,
+            "max_rounds_budget": 3,
+            "initial_prompt_count": 1,
+            "followup_prompt_count": 2,
+            "stop_decision_count": 1,
+        },
+        "user_loop_recovery": {
+            "schema_version": "user_loop_recovery_v0",
+            "stage": "soft_verify",
+            "exception_type": "TimeoutError",
+            "preserved_final_verify": True,
+            "raw_error_recorded": False,
+            "round": 2,
+            "delta_events": 4,
+            "delta_tool_calls": 3,
+        },
+        "native_goal_worker": {
+            "schema_version": "native_goal_worker_failure_v0",
+            "trace_status": "worker_failed",
+            "failure_label": "first_action_timeout",
+            "failure_category": "codex_exec_timeout",
+            "first_blocker": "task_output_quiet_timeout",
+            "trace_count": 4,
+            "raw_transcript_recorded": False,
+            "raw_assistant_message_recorded": False,
+        },
+    }
+    assert compact["runner_failure_fingerprint"] == {
+        "schema_version": "runner_failure_fingerprint_v0",
+        "error_len_bucket": "short",
+        "fingerprint_confidence": "high",
+        "apt_failure_subtype": "repository_unreachable",
+        "pip_failure_subtype": "index_unreachable",
+        "retryability": "retryable",
+        "line_count": 7,
+        "matched_patterns": ["timeout", "network"],
+        "failure_line_dependency_classes": ["apt", "pip"],
+        "failure_reason_codes": ["egress_blocked"],
+        "terminal_failure_dependency_classes": ["network"],
+        "terminal_failure_reason_codes": ["timeout"],
+        "failure_dependency_endpoints": ["package-index"],
+        "terminal_failure_dependency_endpoints": ["package-index"],
+        "error_present": True,
+        "has_host_paths": False,
+        "has_urls": False,
+        "has_secret_like_tokens": False,
+        "raw_error_recorded": False,
+    }
+
+
+def test_status_facade_rejects_invalid_runner_failure_diagnostic_types() -> None:
+    compact = compact_benchmark_run(
+        {
+            "schema_version": "benchmark_run_v0",
+            "runner_failure": {
+                "raw_error_recorded": "false",
+                "controller_cutoff": {"max_rounds_budget": True},
+                "user_loop_recovery": {"round": False},
+                "native_goal_worker": {"trace_count": True},
+            },
+            "runner_failure_fingerprint": {
+                "line_count": False,
+                "error_present": 1,
+            },
+        }
+    )
+
+    assert compact is not None
+    assert "runner_failure" not in compact
+    assert "runner_failure_fingerprint" not in compact


### PR DESCRIPTION
## Summary
- move benchmark runner-failure and fingerprint compaction into the benchmark read-model owner
- keep `status.compact_benchmark_run` as a direct facade with no compatibility wrapper
- tighten its maintainability ceiling from 271/118 to 201/78 statements/decision points

## Validation
- 77 focused pytest checks passed
- 2 focused SkillsBench failure-attribution smokes passed
- run-compaction and maintainability smokes passed
- strict mypy passed; changed-scope Ruff passed
- standard premerge canary: 17/17 checks passed, no failures; `benchmark_sensitive` manual hold noted
- change-quality receipt `cqr_91d91d00a020789cebd6` is valid for the committed diff

## Review note
The benchmark-sensitive hold comes from the path classifier. This change only relocates public-safe read-model compaction, preserves exact field selection and ordering, does not alter scoring, runner execution, task semantics, or evidence policy, and is covered by the owner-authorized quality/refactor self-merge policy.