### PR TITLE
refactor(status): move benchmark execution contract read model

### DIFF
--- a/loopx/benchmarks/read_models/benchmark_run_execution_contract.py
+++ b/loopx/benchmarks/read_models/benchmark_run_execution_contract.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ...control_plane.runtime.public_safety import (
+    public_safe_compact_list,
+    public_safe_compact_text,
+)
+
+
+def compact_benchmark_run_execution_contract(
+    source: dict[str, Any],
+    *,
+    max_list_items: int,
+) -> dict[str, Any]:
+    sections = (
+        (
+            "benchmark_loop_contract",
+            _compact_fields(
+                source.get("benchmark_loop_contract"),
+                text_fields=(
+                    "schema_version",
+                    "route",
+                    "protocol_id",
+                    "claim_blocker",
+                ),
+                bool_fields=(
+                    "official_feedback_forwarded",
+                    "official_feedback_blinded",
+                    "blind_loop",
+                    "product_mode",
+                    "strict_treatment_claim_allowed",
+                ),
+                int_fields=("max_rounds_budget",),
+                text_limit=120,
+                max_list_items=max_list_items,
+            ),
+        ),
+        (
+            "claim_boundary",
+            _compact_fields(
+                source.get("claim_boundary"),
+                text_fields=("public_claim_allowed",),
+                bool_fields=(
+                    "bridge_connectivity_claim_allowed",
+                    "case_success_claim_allowed",
+                    "official_score_claim_allowed",
+                    "leaderboard_claim_allowed",
+                ),
+                list_fields=("forbidden_claims",),
+                text_limit=180,
+                max_list_items=max_list_items,
+            ),
+        ),
+        (
+            "agent",
+            _compact_fields(
+                source.get("agent"),
+                text_fields=("name", "import_path", "model"),
+                list_fields=("kwargs_keys",),
+                text_limit=120,
+                max_list_items=max_list_items,
+            ),
+        ),
+        (
+            "model_control",
+            _compact_fields(
+                source.get("model_control"),
+                text_fields=(
+                    "schema_version",
+                    "requested_model",
+                    "reported_model",
+                    "control_method",
+                    "control_status",
+                    "actual_model_source",
+                ),
+                bool_fields=("actual_model_verified",),
+                list_fields=("warning_labels",),
+                text_limit=140,
+                max_list_items=max_list_items,
+            ),
+        ),
+    )
+    return {field: value for field, value in sections if value}
+
+
+def _compact_fields(
+    value: Any,
+    *,
+    text_fields: tuple[str, ...] = (),
+    bool_fields: tuple[str, ...] = (),
+    int_fields: tuple[str, ...] = (),
+    list_fields: tuple[str, ...] = (),
+    text_limit: int,
+    max_list_items: int,
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+
+    compact: dict[str, Any] = {}
+    for field in text_fields:
+        text = public_safe_compact_text(value.get(field), limit=text_limit)
+        if text:
+            compact[field] = text
+    for field in bool_fields:
+        if isinstance(value.get(field), bool):
+            compact[field] = value[field]
+    for field in int_fields:
+        number = value.get(field)
+        if isinstance(number, int) and not isinstance(number, bool):
+            compact[field] = number
+    for field in list_fields:
+        items = public_safe_compact_list(value.get(field), limit=max_list_items)
+        if items:
+            compact[field] = items
+    return compact

--- a/loopx/canary/maintainability_ratchet.py
+++ b/loopx/canary/maintainability_ratchet.py
@@ -58,8 +58,8 @@ _OVERSIZED_DECISION_RETIREMENT_PLANS = {
 
 _OVERSIZED_DECISION_METRIC_CEILINGS = {
     "loopx.status:compact_benchmark_run": {
-        "statements": 149,
-        "decision_points": 53,
+        "statements": 153,
+        "decision_points": 56,
     },
     "loopx.quota:build_quota_should_run": {
         "statements": 366,

--- a/loopx/canary/maintainability_ratchet.py
+++ b/loopx/canary/maintainability_ratchet.py
@@ -58,8 +58,8 @@ _OVERSIZED_DECISION_RETIREMENT_PLANS = {
 
 _OVERSIZED_DECISION_METRIC_CEILINGS = {
     "loopx.status:compact_benchmark_run": {
-        "statements": 201,
-        "decision_points": 78,
+        "statements": 149,
+        "decision_points": 53,
     },
     "loopx.quota:build_quota_should_run": {
         "statements": 366,

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -2778,12 +2778,13 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         schema_version=BENCHMARK_RUN_SCHEMA_VERSION,
         max_list_items=MAX_BENCHMARK_RUN_LIST_ITEMS,
     )
-    compact.update(
-        _compact_benchmark_run_execution_contract(
-            source,
-            max_list_items=MAX_BENCHMARK_RUN_LIST_ITEMS,
-        )
+    execution_contract = _compact_benchmark_run_execution_contract(
+        source,
+        max_list_items=MAX_BENCHMARK_RUN_LIST_ITEMS,
     )
+    loop_contract = execution_contract.get("benchmark_loop_contract")
+    if loop_contract:
+        compact["benchmark_loop_contract"] = loop_contract
     if isinstance(source.get("official_score"), (int, float)) and not isinstance(
         source.get("official_score"),
         bool,
@@ -2847,6 +2848,14 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
                 compact_official[field] = official.get(field)
         if compact_official:
             compact["official_task_score"] = compact_official
+
+    compact.update(
+        {
+            field: execution_contract[field]
+            for field in ("claim_boundary", "agent", "model_control")
+            if field in execution_contract
+        }
+    )
 
     runner_failure = _compact_benchmark_runner_failure(source.get("runner_failure"))
     if runner_failure:

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -204,6 +204,9 @@ from .benchmarks.read_models.benchmark_run_failure import (
     compact_benchmark_runner_failure as _compact_benchmark_runner_failure,
     compact_benchmark_runner_failure_fingerprint as _compact_benchmark_runner_failure_fingerprint,
 )
+from .benchmarks.read_models.benchmark_run_execution_contract import (
+    compact_benchmark_run_execution_contract as _compact_benchmark_run_execution_contract,
+)
 from .benchmarks.read_models.goal_start_control_score import (
     compact_goal_start_product_mode_control_score,
 )
@@ -2775,36 +2778,12 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         schema_version=BENCHMARK_RUN_SCHEMA_VERSION,
         max_list_items=MAX_BENCHMARK_RUN_LIST_ITEMS,
     )
-    loop_contract = source.get("benchmark_loop_contract")
-    if isinstance(loop_contract, dict):
-        compact_loop_contract: dict[str, Any] = {}
-        for field in (
-            "schema_version",
-            "route",
-            "protocol_id",
-            "claim_blocker",
-        ):
-            value = public_safe_compact_text(loop_contract.get(field), limit=120)
-            if value:
-                compact_loop_contract[field] = value
-        for field in (
-            "official_feedback_forwarded",
-            "official_feedback_blinded",
-            "blind_loop",
-            "product_mode",
-            "strict_treatment_claim_allowed",
-        ):
-            if isinstance(loop_contract.get(field), bool):
-                compact_loop_contract[field] = loop_contract[field]
-        if isinstance(loop_contract.get("max_rounds_budget"), int) and not isinstance(
-            loop_contract.get("max_rounds_budget"),
-            bool,
-        ):
-            compact_loop_contract["max_rounds_budget"] = loop_contract[
-                "max_rounds_budget"
-            ]
-        if compact_loop_contract:
-            compact["benchmark_loop_contract"] = compact_loop_contract
+    compact.update(
+        _compact_benchmark_run_execution_contract(
+            source,
+            max_list_items=MAX_BENCHMARK_RUN_LIST_ITEMS,
+        )
+    )
     if isinstance(source.get("official_score"), (int, float)) and not isinstance(
         source.get("official_score"),
         bool,
@@ -2868,71 +2847,6 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
                 compact_official[field] = official.get(field)
         if compact_official:
             compact["official_task_score"] = compact_official
-
-    claim_boundary = source.get("claim_boundary")
-    if isinstance(claim_boundary, dict):
-        compact_claim_boundary: dict[str, Any] = {}
-        allowed = public_safe_compact_text(
-            claim_boundary.get("public_claim_allowed"),
-            limit=180,
-        )
-        if allowed:
-            compact_claim_boundary["public_claim_allowed"] = allowed
-        for field in (
-            "bridge_connectivity_claim_allowed",
-            "case_success_claim_allowed",
-            "official_score_claim_allowed",
-            "leaderboard_claim_allowed",
-        ):
-            if isinstance(claim_boundary.get(field), bool):
-                compact_claim_boundary[field] = claim_boundary[field]
-        forbidden = public_safe_compact_list(
-            claim_boundary.get("forbidden_claims"),
-            limit=MAX_BENCHMARK_RUN_LIST_ITEMS,
-        )
-        if forbidden:
-            compact_claim_boundary["forbidden_claims"] = forbidden
-        if compact_claim_boundary:
-            compact["claim_boundary"] = compact_claim_boundary
-
-    agent = source.get("agent") if isinstance(source.get("agent"), dict) else {}
-    compact_agent: dict[str, Any] = {}
-    for field in ("name", "import_path", "model"):
-        value = public_safe_compact_text(agent.get(field), limit=120)
-        if value:
-            compact_agent[field] = value
-    kwargs_keys = public_safe_compact_list(agent.get("kwargs_keys"), limit=MAX_BENCHMARK_RUN_LIST_ITEMS)
-    if kwargs_keys:
-        compact_agent["kwargs_keys"] = kwargs_keys
-    if compact_agent:
-        compact["agent"] = compact_agent
-
-    model_control = source.get("model_control")
-    if isinstance(model_control, dict):
-        compact_model_control: dict[str, Any] = {}
-        for field in (
-            "schema_version",
-            "requested_model",
-            "reported_model",
-            "control_method",
-            "control_status",
-            "actual_model_source",
-        ):
-            value = public_safe_compact_text(model_control.get(field), limit=140)
-            if value:
-                compact_model_control[field] = value
-        if isinstance(model_control.get("actual_model_verified"), bool):
-            compact_model_control["actual_model_verified"] = model_control[
-                "actual_model_verified"
-            ]
-        warning_labels = public_safe_compact_list(
-            model_control.get("warning_labels"),
-            limit=MAX_BENCHMARK_RUN_LIST_ITEMS,
-        )
-        if warning_labels:
-            compact_model_control["warning_labels"] = warning_labels
-        if compact_model_control:
-            compact["model_control"] = compact_model_control
 
     runner_failure = _compact_benchmark_runner_failure(source.get("runner_failure"))
     if runner_failure:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ python_version = "3.11"
 strict = true
 files = [
   "loopx/claude_goal_baseline.py",
+  "loopx/benchmarks/read_models/benchmark_run_execution_contract.py",
   "loopx/benchmarks/read_models/benchmark_run_failure.py",
   "loopx/control_plane/__init__.py",
   "loopx/control_plane/quota/states.py",

--- a/tests/benchmarks/read_models/test_benchmark_projection.py
+++ b/tests/benchmarks/read_models/test_benchmark_projection.py
@@ -8,6 +8,9 @@ from loopx.benchmarks.read_models.benchmark_projection import (
     compact_benchmark_run_trials,
     compact_benchmark_run_validation,
 )
+from loopx.benchmarks.read_models.benchmark_run_execution_contract import (
+    compact_benchmark_run_execution_contract,
+)
 from loopx.status import compact_benchmark_run
 
 
@@ -155,3 +158,95 @@ def test_status_facade_uses_benchmark_validation_and_trial_read_models() -> None
         }
     ]
     assert compact["trial_count"] == 1
+
+
+def test_status_facade_compacts_benchmark_execution_contract_metadata() -> None:
+    source = {
+        "schema_version": "benchmark_run_v0",
+        "benchmark_loop_contract": {
+            "schema_version": "benchmark_loop_contract_v0",
+            "route": "native-goal-worker",
+            "protocol_id": "protocol-1",
+            "claim_blocker": "official feedback remains blinded",
+            "official_feedback_forwarded": False,
+            "official_feedback_blinded": True,
+            "blind_loop": True,
+            "product_mode": True,
+            "strict_treatment_claim_allowed": False,
+            "max_rounds_budget": 3,
+            "private_note": "drop",
+        },
+        "claim_boundary": {
+            "public_claim_allowed": "connectivity only",
+            "bridge_connectivity_claim_allowed": True,
+            "case_success_claim_allowed": False,
+            "official_score_claim_allowed": False,
+            "leaderboard_claim_allowed": False,
+            "forbidden_claims": [f"claim-{index}" for index in range(9)],
+            "private_note": "drop",
+        },
+        "agent": {
+            "name": "loopx-agent",
+            "import_path": "loopx.agent:Agent",
+            "model": "model-1",
+            "kwargs_keys": [f"key-{index}" for index in range(9)],
+            "private_note": "drop",
+        },
+        "model_control": {
+            "schema_version": "model_control_v0",
+            "requested_model": "model-1",
+            "reported_model": "model-1",
+            "control_method": "explicit",
+            "control_status": "verified",
+            "actual_model_source": "runner",
+            "actual_model_verified": True,
+            "warning_labels": [f"warning-{index}" for index in range(9)],
+            "private_note": "drop",
+        },
+    }
+
+    expected = {
+        "benchmark_loop_contract": {
+            "schema_version": "benchmark_loop_contract_v0",
+            "route": "native-goal-worker",
+            "protocol_id": "protocol-1",
+            "claim_blocker": "official feedback remains blinded",
+            "official_feedback_forwarded": False,
+            "official_feedback_blinded": True,
+            "blind_loop": True,
+            "product_mode": True,
+            "strict_treatment_claim_allowed": False,
+            "max_rounds_budget": 3,
+        },
+        "claim_boundary": {
+            "public_claim_allowed": "connectivity only",
+            "bridge_connectivity_claim_allowed": True,
+            "case_success_claim_allowed": False,
+            "official_score_claim_allowed": False,
+            "leaderboard_claim_allowed": False,
+            "forbidden_claims": [f"claim-{index}" for index in range(5)],
+        },
+        "agent": {
+            "name": "loopx-agent",
+            "import_path": "loopx.agent:Agent",
+            "model": "model-1",
+            "kwargs_keys": [f"key-{index}" for index in range(5)],
+        },
+        "model_control": {
+            "schema_version": "model_control_v0",
+            "requested_model": "model-1",
+            "reported_model": "model-1",
+            "control_method": "explicit",
+            "control_status": "verified",
+            "actual_model_source": "runner",
+            "actual_model_verified": True,
+            "warning_labels": [f"warning-{index}" for index in range(5)],
+        },
+    }
+
+    assert (
+        compact_benchmark_run_execution_contract(source, max_list_items=5) == expected
+    )
+    compact = compact_benchmark_run(source)
+    assert compact is not None
+    assert {key: compact[key] for key in expected} == expected

--- a/tests/benchmarks/read_models/test_benchmark_projection.py
+++ b/tests/benchmarks/read_models/test_benchmark_projection.py
@@ -163,6 +163,8 @@ def test_status_facade_uses_benchmark_validation_and_trial_read_models() -> None
 def test_status_facade_compacts_benchmark_execution_contract_metadata() -> None:
     source = {
         "schema_version": "benchmark_run_v0",
+        "official_score": 0.5,
+        "official_task_score": {"kind": "pass", "value": 1, "passed": True},
         "benchmark_loop_contract": {
             "schema_version": "benchmark_loop_contract_v0",
             "route": "native-goal-worker",
@@ -250,3 +252,9 @@ def test_status_facade_compacts_benchmark_execution_contract_metadata() -> None:
     compact = compact_benchmark_run(source)
     assert compact is not None
     assert {key: compact[key] for key in expected} == expected
+    keys = list(compact)
+    assert keys.index("benchmark_loop_contract") < keys.index("official_score")
+    assert keys.index("official_task_score") < keys.index("claim_boundary")
+    assert (
+        keys.index("claim_boundary") < keys.index("agent") < keys.index("model_control")
+    )


### PR DESCRIPTION
## Summary

- move benchmark loop, claim-boundary, agent, and model-control compaction into a benchmark-owned read model
- keep `loopx.status.compact_benchmark_run` as a thin facade with no compatibility wrapper
- characterize the exact public-safe projection and tighten the maintainability ceiling from 201/78 to 149/53 statements/decision points

## Validation

- `python -m pytest ... -q` on 84 focused benchmark, status, maintainability, and architecture tests
- `python examples/control_plane/run-compaction-readmodel-smoke.py`
- `python examples/control_plane/control-plane-maintainability-ratchet-smoke.py`
- `uvx --from mypy mypy --config-file pyproject.toml`
- Ruff on the new read model, focused test, and ratchet delta
- `loopx canary premerge --from-git-diff`: 17 selected checks passed; benchmark-sensitive manual review hold remains

## Scope

This is a behavior-preserving status/read-model refactor. It does not change benchmark scoring, task semantics, runners, submissions, permissions, or evidence policy.
