### PR TITLE
Install host workflow skills through the fixed installer

### DIFF
--- a/docs/reference/protocols/host-integration-surface-v0.md
+++ b/docs/reference/protocols/host-integration-surface-v0.md
@@ -80,8 +80,18 @@ LOOPX_SKILLS_DIR=<PROJECT_WORKSPACE>/.agents/skills \
   <LOOPX_CHECKOUT>/scripts/install-local.sh
 ```
 
-The installer owns filesystem mutation. Onboarding and doctor only report the
-required skill ids and require a host loaded-skill readback.
+This is also the supported canary path for an untrusted or dirty checkout.
+With an explicit `LOOPX_SKILLS_DIR`, the script materializes the release-owned
+workflow skills and writes `.loopx-skill-install.json` without promoting the
+checkout as the default `loopx` executable. Without that explicit target, a
+canary-only install leaves the existing default skill root unchanged.
+
+The installer is the sole owner of filesystem mutation. The manifest records
+the materialized skill ids, source revision, and per-skill content digests so
+read-only host checks can verify delivery without becoming a second installer.
+Filesystem materialization is distinct from the host's runtime loaded-skill
+readback; the latter is still required before claiming that the skills were
+injected into an active agent context.
 
 Local-development and cloud transports must send the exact same `task_body` as
 their goal prompt. They may differ in endpoint, authentication, session id, or

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -301,6 +301,19 @@ def main() -> int:
 
         skill = codex_home / "skills" / "loopx-project" / "SKILL.md"
         assert not skill.parent.is_symlink(), skill.parent
+        skill_readback = json.loads(
+            (codex_home / "skills" / ".loopx-skill-install.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert skill_readback["integration_mode"] == "fixed_install_script"
+        assert skill_readback["source"]["revision"] == source_commit
+        assert set(skill_readback["materialized_skill_ids"]) == {
+            "loopx-doc-registry",
+            "loopx-pr-review",
+            "loopx-project",
+            "loopx-self-repair",
+        }
         skill_text = skill.read_text(encoding="utf-8")
         compact_skill_text = " ".join(skill_text.split())
         for phrase in (

--- a/examples/release/local-install-promotion-boundary-smoke.py
+++ b/examples/release/local-install-promotion-boundary-smoke.py
@@ -53,6 +53,12 @@ def base_env(root: Path) -> tuple[dict[str, str], Path, Path]:
 def assert_untrusted_checkout_is_canary_only() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-promotion-canary-only-") as tmp:
         env, bin_dir, releases_dir = base_env(Path(tmp))
+        skills_dir = Path(tmp) / "workspace" / ".agents" / "skills"
+        env["LOOPX_INSTALL_SKILL"] = "1"
+        env["LOOPX_SKILLS_DIR"] = str(skills_dir)
+        stale_lock = skills_dir / ".loopx-install-lock"
+        stale_lock.mkdir(parents=True)
+        (stale_lock / "pid").write_text("999999999\n", encoding="utf-8")
         default = bin_dir / "loopx"
         default.write_text("#!/usr/bin/env bash\nexit 41\n", encoding="utf-8")
         default.chmod(0o755)
@@ -67,6 +73,45 @@ def assert_untrusted_checkout_is_canary_only() -> None:
         assert canary.is_symlink(), canary
         assert canary.resolve() == REPO_ROOT / "scripts" / "loopx", canary.resolve()
         assert not releases_dir.exists(), releases_dir
+        expected_skill_ids = {
+            "loopx-doc-registry",
+            "loopx-pr-review",
+            "loopx-project",
+            "loopx-self-repair",
+        }
+        assert {
+            path.parent.name for path in skills_dir.glob("*/SKILL.md")
+        } == expected_skill_ids
+        assert not (skills_dir / "loopx-change-quality").exists()
+        assert not (skills_dir / "loopx-material").exists()
+        readback = json.loads(
+            (skills_dir / ".loopx-skill-install.json").read_text(encoding="utf-8")
+        )
+        assert readback["integration_mode"] == "fixed_install_script", readback
+        assert set(readback["materialized_skill_ids"]) == expected_skill_ids, readback
+        assert readback["source"]["revision"], readback
+        assert not stale_lock.exists()
+        assert (
+            f"- skill readback: {skills_dir}/.loopx-skill-install.json"
+            in install.stdout
+        )
+
+
+def assert_untrusted_checkout_preserves_implicit_default_skill_root() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-promotion-skill-root-") as tmp:
+        env, _bin_dir, _releases_dir = base_env(Path(tmp))
+        env["LOOPX_INSTALL_SKILL"] = "1"
+        implicit_skill = (
+            Path(env["CODEX_HOME"]) / "skills" / "loopx-project" / "SKILL.md"
+        )
+        implicit_skill.parent.mkdir(parents=True)
+        implicit_skill.write_text("existing default skill\n", encoding="utf-8")
+
+        install = run_install(env, release_id="guarded-implicit-skills")
+
+        assert "skill: unchanged (set LOOPX_SKILLS_DIR" in install.stdout
+        assert implicit_skill.read_text(encoding="utf-8") == "existing default skill\n"
+        assert not (implicit_skill.parents[1] / ".loopx-skill-install.json").exists()
 
 
 def assert_explicit_promotion_is_auditable() -> None:
@@ -98,6 +143,7 @@ def assert_explicit_promotion_is_auditable() -> None:
 
 def main() -> int:
     assert_untrusted_checkout_is_canary_only()
+    assert_untrusted_checkout_preserves_implicit_default_skill_root()
     assert_explicit_promotion_is_auditable()
     print("local-install-promotion-boundary-smoke ok")
     return 0

--- a/loopx/skill_install_readback.py
+++ b/loopx/skill_install_readback.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+from typing import Any, Mapping, Sequence
+
+
+SKILL_INSTALL_READBACK_SCHEMA_VERSION = "loopx_skill_install_readback_v0"
+SKILL_INSTALL_READBACK_FILENAME = ".loopx-skill-install.json"
+SKILL_INSTALL_OWNER = "loopx_install_script"
+SKILL_INSTALL_INTEGRATION_MODE = "fixed_install_script"
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def hash_skill_tree(root: Path) -> dict[str, Any]:
+    if not root.is_dir():
+        return {
+            "available": False,
+            "sha256": None,
+            "file_count": 0,
+        }
+    digest = hashlib.sha256()
+    file_count = 0
+    for path in sorted(item for item in root.rglob("*") if item.is_file()):
+        relative = path.relative_to(root).as_posix()
+        file_hash = _sha256_file(path)
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(file_hash.encode("ascii"))
+        digest.update(b"\n")
+        file_count += 1
+    return {
+        "available": True,
+        "sha256": digest.hexdigest(),
+        "file_count": file_count,
+    }
+
+
+def _git_value(root: Path, *args: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), *args],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def _source_readback(source_root: Path) -> dict[str, Any]:
+    release_manifest_path = source_root / "release.json"
+    try:
+        release_manifest = json.loads(release_manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        release_manifest = {}
+    release_source = (
+        release_manifest.get("source")
+        if isinstance(release_manifest.get("source"), dict)
+        else {}
+    )
+    if release_source:
+        revision_kind, revision = next(
+            (
+                (kind, release_source.get(field))
+                for kind, field in (
+                    ("git_commit", "git_commit"),
+                    ("archive_sha256", "archive_sha256"),
+                    ("source_ref", "ref"),
+                )
+                if release_source.get(field)
+            ),
+            (None, None),
+        )
+        return {
+            "kind": "release_snapshot",
+            "revision": revision,
+            "revision_kind": revision_kind,
+            "git_dirty": release_source.get("git_dirty"),
+        }
+
+    commit = _git_value(source_root, "rev-parse", "HEAD")
+    status = _git_value(source_root, "status", "--porcelain")
+    return {
+        "kind": "local_checkout",
+        "revision": commit,
+        "revision_kind": "git_commit" if commit else None,
+        "git_dirty": bool(status) if commit is not None else None,
+    }
+
+
+def _skills_digest(items: Mapping[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(items, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+
+
+def build_skill_install_readback(
+    *,
+    skills_dir: Path,
+    skill_ids: Sequence[str],
+    source_root: Path,
+    installed_at: str | None = None,
+) -> dict[str, Any]:
+    normalized_ids = sorted(
+        {skill_id.strip() for skill_id in skill_ids if skill_id.strip()}
+    )
+    items = {
+        skill_id: hash_skill_tree(skills_dir / skill_id) for skill_id in normalized_ids
+    }
+    skills_digest = _skills_digest(items)
+    source = _source_readback(source_root)
+    if not source.get("revision"):
+        source["revision"] = skills_digest
+        source["revision_kind"] = "skills_digest"
+    return {
+        "schema_version": SKILL_INSTALL_READBACK_SCHEMA_VERSION,
+        "owner": SKILL_INSTALL_OWNER,
+        "integration_mode": SKILL_INSTALL_INTEGRATION_MODE,
+        "installed_at": installed_at
+        or datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "source": source,
+        "materialized_skill_ids": normalized_ids,
+        "skills": {
+            "digest": skills_digest,
+            "items": items,
+        },
+    }
+
+
+def write_skill_install_readback(
+    *,
+    skills_dir: Path,
+    skill_ids: Sequence[str],
+    source_root: Path,
+    installed_at: str | None = None,
+) -> Path:
+    skills_dir.mkdir(parents=True, exist_ok=True)
+    payload = build_skill_install_readback(
+        skills_dir=skills_dir,
+        skill_ids=skill_ids,
+        source_root=source_root,
+        installed_at=installed_at,
+    )
+    target = skills_dir / SKILL_INSTALL_READBACK_FILENAME
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=skills_dir,
+        prefix=f"{SKILL_INSTALL_READBACK_FILENAME}.",
+        suffix=".tmp",
+        delete=False,
+    ) as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+        handle.write("\n")
+        temporary = Path(handle.name)
+    os.replace(temporary, target)
+    return target

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -48,6 +48,14 @@ repo_root="$(cd "$script_dir/.." && pwd)"
 bin_dir="${LOOPX_BIN_DIR:-$HOME/.local/bin}"
 shell_profile="${LOOPX_SHELL_PROFILE:-}"
 codex_home="${CODEX_HOME:-$HOME/.codex}"
+skills_dir_explicit=0
+if [[ "${LOOPX_SKILLS_DIR+x}" == "x" ]]; then
+  if [[ -z "$LOOPX_SKILLS_DIR" ]]; then
+    echo "loopx installer error: LOOPX_SKILLS_DIR cannot be empty" >&2
+    exit 2
+  fi
+  skills_dir_explicit=1
+fi
 skills_dir="${LOOPX_SKILLS_DIR:-$codex_home/skills}"
 man_root="${LOOPX_MAN_ROOT:-$HOME/.local/share/man}"
 man_dir="${LOOPX_MAN_DIR:-$man_root/man1}"
@@ -61,6 +69,8 @@ release_dir=""
 release_tmp=""
 install_lock=""
 install_lock_owned=0
+skill_install_lock=""
+skill_install_lock_owned=0
 legacy_line=""
 installed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
@@ -97,6 +107,9 @@ cleanup_install_lock() {
   fi
   if [[ "$install_lock_owned" == "1" && -n "$install_lock" && -d "$install_lock" ]]; then
     rm -rf "$install_lock"
+  fi
+  if [[ "$skill_install_lock_owned" == "1" && -n "$skill_install_lock" && -d "$skill_install_lock" ]]; then
+    rm -rf "$skill_install_lock"
   fi
 }
 
@@ -270,6 +283,88 @@ os.replace(os.environ["LOOPX_LINK_TMP"], os.environ["LOOPX_LINK_TARGET"])
 PY
 }
 
+install_workflow_skills() {
+  local skills_source="$1"
+  local source_root="$2"
+  local skill_source skill_name skill_scope_file skill_target skill_tmp
+  local -a installed_skill_ids=()
+  skill_line="- skill: skipped"
+  if [[ "$install_skill" == "0" || ! -d "$skills_source" ]]; then
+    return 0
+  fi
+
+  mkdir -p "$skills_dir"
+  skill_install_lock="$skills_dir/.loopx-install-lock"
+  local lock_attempt=0
+  until mkdir "$skill_install_lock" 2>/dev/null; do
+    local owner_pid=""
+    if [[ -f "$skill_install_lock/pid" ]]; then
+      owner_pid="$(cat "$skill_install_lock/pid" 2>/dev/null || true)"
+    fi
+    if [[ "$owner_pid" =~ ^[0-9]+$ ]] && ! kill -0 "$owner_pid" 2>/dev/null; then
+      local stale_lock="$skill_install_lock.stale.$$"
+      if mv "$skill_install_lock" "$stale_lock" 2>/dev/null; then
+        rm -rf "$stale_lock"
+        continue
+      fi
+    fi
+    lock_attempt=$((lock_attempt + 1))
+    if [[ "$lock_attempt" -ge 600 ]]; then
+      echo "loopx installer error: timed out waiting for workflow skill installation" >&2
+      return 1
+    fi
+    sleep 0.1
+  done
+  skill_install_lock_owned=1
+  printf '%s\n' "$$" >"$skill_install_lock/pid"
+
+  skill_line=""
+  while IFS= read -r skill_source; do
+    skill_name="$(basename "$skill_source")"
+    skill_scope_file="$skill_source/.loopx-skill-scope"
+    if [[ -f "$skill_scope_file" ]] && [[ "$(tr -d '[:space:]' <"$skill_scope_file")" == "project" ]]; then
+      skill_line="${skill_line}- project skill source: $skill_source (install explicitly per project)"$'\n'
+      continue
+    fi
+    skill_target="$skills_dir/$skill_name"
+    skill_tmp="$(mktemp -d "$skills_dir/.${skill_name}.tmp.XXXXXX")"
+    if ! cp -R "$skill_source"/. "$skill_tmp"/; then
+      rm -rf "$skill_tmp"
+      return 1
+    fi
+    rm -rf "$skill_target"
+    mv "$skill_tmp" "$skill_target"
+    installed_skill_ids+=("$skill_name")
+    skill_line="${skill_line}- skill: $skill_target"$'\n'
+  done < <(find "$skills_source" -mindepth 1 -maxdepth 1 -type d -print | sort)
+
+  if [[ "${#installed_skill_ids[@]}" -gt 0 ]]; then
+    LOOPX_SKILL_INSTALL_DIR="$skills_dir" \
+      LOOPX_SKILL_INSTALL_SOURCE_ROOT="$source_root" \
+      LOOPX_SKILL_INSTALL_IDS="$(printf '%s\n' "${installed_skill_ids[@]}")" \
+      LOOPX_SKILL_INSTALLED_AT="$installed_at" \
+      PYTHONPATH="$source_root${PYTHONPATH:+:$PYTHONPATH}" \
+      "${LOOPX_PYTHON:-python3}" - <<'PY'
+import os
+from pathlib import Path
+
+from loopx.skill_install_readback import write_skill_install_readback
+
+write_skill_install_readback(
+    skills_dir=Path(os.environ["LOOPX_SKILL_INSTALL_DIR"]),
+    skill_ids=os.environ["LOOPX_SKILL_INSTALL_IDS"].splitlines(),
+    source_root=Path(os.environ["LOOPX_SKILL_INSTALL_SOURCE_ROOT"]),
+    installed_at=os.environ["LOOPX_SKILL_INSTALLED_AT"],
+)
+PY
+    skill_line="${skill_line}- skill readback: $skills_dir/.loopx-skill-install.json"$'\n'
+  fi
+  skill_line="${skill_line%$'\n'}"
+  rm -rf "$skill_install_lock"
+  skill_install_lock_owned=0
+  skill_install_lock=""
+}
+
 verify_default_promotion() {
   LOOPX_VERIFY_LINK="$bin_dir/loopx" \
     LOOPX_VERIFY_RELEASE_DIR="$release_dir" \
@@ -430,11 +525,16 @@ if [[ "$promote_default" == "0" ]]; then
   install_symlink "$repo_root/scripts/loopx" "$bin_dir/loopx-canary"
   export PATH="$bin_dir:$PATH"
   "$bin_dir/loopx-canary" doctor >/dev/null
+  skill_line="- skill: unchanged (set LOOPX_SKILLS_DIR to install canary workflow skills)"
+  if [[ "$skills_dir_explicit" == "1" ]]; then
+    install_workflow_skills "$repo_root/skills" "$repo_root"
+  fi
   cat <<EOF
 loopx checkout installed as canary only
 - default executable: unchanged
 - canary executable: $bin_dir/loopx-canary
 - promotion mode: $promotion_mode
+$skill_line
 - promote explicitly: LOOPX_PROMOTE_DEFAULT=1 $repo_root/scripts/install-local.sh
 
 Current shell can use the canary with:
@@ -558,26 +658,7 @@ if [[ "$install_canary" != "0" ]]; then
   "$bin_dir/loopx-canary" doctor >/dev/null
 fi
 
-skill_line="- skill: skipped"
-skills_source="$release_dir/skills"
-if [[ "$install_skill" != "0" && -d "$skills_source" ]]; then
-  mkdir -p "$skills_dir"
-  skill_line=""
-  while IFS= read -r skill_source; do
-    skill_name="$(basename "$skill_source")"
-    skill_scope_file="$skill_source/.loopx-skill-scope"
-    if [[ -f "$skill_scope_file" ]] && [[ "$(tr -d '[:space:]' <"$skill_scope_file")" == "project" ]]; then
-      skill_line="${skill_line}- project skill source: $skill_source (install explicitly per project)"$'\n'
-      continue
-    fi
-    skill_target="$skills_dir/$skill_name"
-    rm -rf "$skill_target"
-    mkdir -p "$skill_target"
-    cp -R "$skill_source"/. "$skill_target"/
-    skill_line="${skill_line}- skill: $skill_target"$'\n'
-  done < <(find "$skills_source" -mindepth 1 -maxdepth 1 -type d -print | sort)
-  skill_line="${skill_line%$'\n'}"
-fi
+install_workflow_skills "$release_dir/skills" "$release_dir"
 
 slash_line="- slash commands: skipped"
 install_slash_commands="${LOOPX_INSTALL_SLASH_COMMANDS:-1}"


### PR DESCRIPTION
## What changed

- Reuse one `install_workflow_skills` path for promoted releases and explicit canary targets.
- Allow an untrusted or dirty checkout to materialize release-owned workflow skills only when `LOOPX_SKILLS_DIR` is explicitly set; the default `loopx` executable and implicit Codex skill root remain unchanged.
- Write an atomic `.loopx-skill-install.json` receipt with materialized skill ids, source revision, and per-skill content digests.
- Serialize target-directory updates with stale-lock recovery.
- Keep project-scoped skills excluded from global workflow delivery.

## Why

Codex and the Ark Managed Agent host should use the same fixed installation script, differing only in the target skill root. Previously the canary-only branch exited before skill delivery, which forced host onboarding or ad-hoc copying to become a second filesystem mutator.

## Validation

- `python3 examples/release/local-install-promotion-boundary-smoke.py`
- `python3 examples/install-local-smoke.py`
- Ruff checks for changed Python files
- `loopx canary premerge --from-git-diff --tier standard`: 18/18 selected checks passed, including public-boundary and install/release profiles

A small stacked follow-up will make doctor/onboarding consume this receipt read-only; this PR intentionally contains only installation ownership and evidence generation.