### PR TITLE
refactor(quota): isolate final run decision

### DIFF
--- a/loopx/canary/maintainability_ratchet.py
+++ b/loopx/canary/maintainability_ratchet.py
@@ -62,8 +62,8 @@ _OVERSIZED_DECISION_METRIC_CEILINGS = {
         "decision_points": 40,
     },
     "loopx.quota:build_quota_should_run": {
-        "statements": 366,
-        "decision_points": 264,
+        "statements": 329,
+        "decision_points": 241,
     },
 }
 

--- a/loopx/control_plane/quota/decision_summary.py
+++ b/loopx/control_plane/quota/decision_summary.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from ..goals.contract_health import project_contract_health_for_goal
+from ..goals.goal_frontier import (
+    AUTONOMOUS_REPLAN_REQUIRED_MODE,
+    autonomous_replan_decision_allowed,
+    goal_frontier_is_terminal_no_followup,
+)
 from ..todos.contract import normalize_todo_claimed_by
 
 
@@ -57,3 +63,242 @@ def goal_status_health_ok(
         return False
     scoped = project_contract_health_for_goal(contract, goal_id=goal_id)
     return scoped.get("ok") is True
+
+
+@dataclass(frozen=True)
+class QuotaRunDecision:
+    normal_delivery_allowed: bool
+    recovery_delivery_allowed: bool
+    self_repair_allowed: bool
+    capability_repair_allowed: bool
+    workspace_repair_allowed: bool
+    should_run: bool
+    effective_action: str
+    reason: str
+    state: str
+    quota: dict[str, Any]
+    replan_decision_allowed: bool
+
+
+def resolve_quota_run_decision(
+    *,
+    normal_delivery_allowed: bool,
+    recovery_delivery_allowed: bool,
+    self_repair_allowed: bool,
+    stall_self_repair: dict[str, Any] | None,
+    state: str,
+    quota: dict[str, Any],
+    reason: str,
+    capability_gate: dict[str, Any] | None,
+    capability_monitor_fallback: dict[str, Any] | None,
+    workspace_guard: dict[str, Any] | None,
+    automation_prompt_upgrade: dict[str, Any] | None,
+    automation_prompt_upgrade_required: bool,
+    replan_obligation: dict[str, Any] | None,
+    goal_health_ok: bool,
+    inbox_reply_due: bool,
+    agent_frontier_id: str | None,
+    registered_agent_ids: list[str],
+    goal_frontier_projection: dict[str, Any] | None,
+    task_orchestration_contract: dict[str, Any] | None,
+) -> QuotaRunDecision:
+    """Apply the ordered final guards for one quota run decision."""
+
+    capability_repair_allowed = False
+    workspace_repair_allowed = False
+    if (
+        capability_gate
+        and capability_gate.get("action") != "run"
+        and not capability_monitor_fallback
+    ):
+        normal_delivery_allowed = False
+        recovery_delivery_allowed = False
+        if capability_gate.get("action") == "repair_bridge":
+            capability_repair_allowed = True
+            reason = str(
+                capability_gate.get("reason") or "capability bridge repair required"
+            )
+        else:
+            reason = str(
+                capability_gate.get("reason")
+                or "selected todo capability is unavailable"
+            )
+    if workspace_guard:
+        normal_delivery_allowed = False
+        recovery_delivery_allowed = False
+        self_repair_allowed = False
+        capability_repair_allowed = False
+        workspace_repair_allowed = True
+        reason = str(
+            workspace_guard.get("reason") or "agent workspace guard blocks delivery"
+        )
+    if automation_prompt_upgrade_required:
+        normal_delivery_allowed = False
+        recovery_delivery_allowed = False
+        self_repair_allowed = False
+        capability_repair_allowed = False
+        workspace_repair_allowed = False
+        reason = str(
+            (automation_prompt_upgrade or {}).get("reason")
+            or "identity-aware automation prompt upgrade is required"
+        )
+
+    should_run = bool(
+        normal_delivery_allowed
+        or recovery_delivery_allowed
+        or self_repair_allowed
+        or capability_repair_allowed
+        or workspace_repair_allowed
+    )
+    effective_action = quota_effective_action(
+        normal_delivery_allowed=normal_delivery_allowed,
+        recovery_delivery_allowed=recovery_delivery_allowed,
+        self_repair_allowed=self_repair_allowed,
+        capability_repair_allowed=capability_repair_allowed,
+        workspace_repair_allowed=workspace_repair_allowed,
+        stall_self_repair=stall_self_repair,
+        state=state,
+        quota=quota,
+    )
+    replan_decision_allowed = (
+        not inbox_reply_due
+        and autonomous_replan_decision_allowed(
+            replan_obligation=replan_obligation,
+            plan_ok=goal_health_ok,
+            workspace_blocked=bool(workspace_guard),
+            automation_prompt_upgrade_required=automation_prompt_upgrade_required,
+            agent_id=agent_frontier_id,
+            registered_agent_ids=registered_agent_ids,
+        )
+    )
+    if replan_decision_allowed:
+        normal_delivery_allowed = False
+        recovery_delivery_allowed = False
+        should_run = True
+        effective_action = AUTONOMOUS_REPLAN_REQUIRED_MODE
+        reason = (
+            "autonomous replan obligation is selected before monitor quiet "
+            "or agent-scope wait classification"
+        )
+
+    terminal_no_followup = goal_frontier_is_terminal_no_followup(
+        projection=goal_frontier_projection
+    )
+    if terminal_no_followup and not inbox_reply_due:
+        quota = {
+            **quota,
+            "state": "terminal_no_followup",
+            "reason": (
+                "derived terminal no-follow-up is confirmed by complete todo "
+                "sources and an empty frontier"
+            ),
+        }
+        state = "terminal_no_followup"
+        normal_delivery_allowed = False
+        recovery_delivery_allowed = False
+        self_repair_allowed = False
+        capability_repair_allowed = False
+        workspace_repair_allowed = False
+        should_run = False
+        effective_action = "terminal_no_followup"
+        reason = (
+            "validated closure evidence derives terminal no-follow-up from "
+            "complete todo sources and an empty frontier; stop recurring "
+            "automation until an explicit resume"
+        )
+
+    if automation_prompt_upgrade_required and not terminal_no_followup:
+        should_run = False
+        effective_action = "automation_prompt_upgrade_required"
+    elif inbox_reply_due:
+        should_run = True
+        normal_delivery_allowed = True
+        recovery_delivery_allowed = False
+        self_repair_allowed = False
+        capability_repair_allowed = False
+        workspace_repair_allowed = False
+        effective_action = "lark_inbox_reply_due"
+        reason = (
+            "a direct Lark question, bot mention, or verified reply to the bot "
+            "is pending reply"
+        )
+
+    effective_action, reason = _task_orchestration_effective_action(
+        task_orchestration_contract,
+        should_run=should_run,
+        normal_delivery_allowed=normal_delivery_allowed,
+        effective_action=effective_action,
+        reason=reason,
+    )
+    return QuotaRunDecision(
+        normal_delivery_allowed=normal_delivery_allowed,
+        recovery_delivery_allowed=recovery_delivery_allowed,
+        self_repair_allowed=self_repair_allowed,
+        capability_repair_allowed=capability_repair_allowed,
+        workspace_repair_allowed=workspace_repair_allowed,
+        should_run=should_run,
+        effective_action=effective_action,
+        reason=reason,
+        state=state,
+        quota=quota,
+        replan_decision_allowed=replan_decision_allowed,
+    )
+
+
+def quota_effective_action(
+    *,
+    normal_delivery_allowed: bool,
+    recovery_delivery_allowed: bool,
+    self_repair_allowed: bool,
+    capability_repair_allowed: bool,
+    workspace_repair_allowed: bool,
+    stall_self_repair: dict[str, Any] | None,
+    state: str,
+    quota: dict[str, Any],
+) -> str:
+    if normal_delivery_allowed:
+        return "normal_run"
+    if recovery_delivery_allowed:
+        return "outcome_floor_recovery"
+    if workspace_repair_allowed:
+        return "agent_workspace_repair"
+    if self_repair_allowed:
+        repair_action = (
+            stall_self_repair.get("effective_action")
+            if isinstance(stall_self_repair, dict)
+            else None
+        )
+        return str(repair_action or "control_plane_repair")
+    if capability_repair_allowed:
+        return "capability_bridge_repair"
+    if state == "operator_gate":
+        return "operator_gate_notify"
+    if state == "blocked_health":
+        return "blocked_health"
+    if state == "throttled":
+        return "throttled_skip"
+    if state in {"focus_wait", "waiting"} or quota.get("focus_wait"):
+        return "blocked_wait"
+    return "quota_skip"
+
+
+def _task_orchestration_effective_action(
+    contract: dict[str, Any] | None,
+    *,
+    should_run: bool,
+    normal_delivery_allowed: bool,
+    effective_action: str,
+    reason: str,
+) -> tuple[str, str]:
+    if (
+        contract
+        and should_run
+        and normal_delivery_allowed
+        and effective_action == "normal_run"
+    ):
+        return (
+            "coordinate_task_bundle",
+            "the deterministic task coordinator must activate or resume eligible "
+            "peer lanes before doing its own worker-lane delivery",
+        )
+    return effective_action, reason

--- a/loopx/control_plane/quota/task_orchestration.py
+++ b/loopx/control_plane/quota/task_orchestration.py
@@ -91,28 +91,6 @@ def apply_task_orchestration_contract(
     return contract, _task_orchestration_work_lane_contract(contract)
 
 
-def task_orchestration_effective_action(
-    contract: dict[str, Any] | None,
-    *,
-    should_run: bool,
-    normal_delivery_allowed: bool,
-    effective_action: str,
-    reason: str,
-) -> tuple[str, str]:
-    if (
-        contract
-        and should_run
-        and normal_delivery_allowed
-        and effective_action == "normal_run"
-    ):
-        return (
-            "coordinate_task_bundle",
-            "the deterministic task coordinator must activate or resume eligible "
-            "peer lanes before doing its own worker-lane delivery",
-        )
-    return effective_action, reason
-
-
 def task_selected_recommended_action(
     contract: dict[str, Any] | None,
     fallback: str | None,
@@ -280,9 +258,9 @@ def _task_orchestration_contract(
     )
     if not coordinator or agent_id != coordinator:
         return None
-    peer_lanes = [
-        lane for lane in candidate_lanes if lane["agent_id"] != coordinator
-    ][:max_peers]
+    peer_lanes = [lane for lane in candidate_lanes if lane["agent_id"] != coordinator][
+        :max_peers
+    ]
     if not peer_lanes:
         return None
     return {

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -42,9 +42,7 @@ from .control_plane.work_items.primary_action import (
 )
 from .control_plane.goals.goal_frontier import (
     AUTONOMOUS_REPLAN_REQUIRED_MODE,
-    autonomous_replan_decision_allowed,
     build_goal_frontier_projection_context_from_status,
-    goal_frontier_is_terminal_no_followup,
 )
 from .control_plane.quota.heartbeat_recommendation import (
     HEARTBEAT_HANDOFF_READINESS_COMPACT_FIELDS as HANDOFF_READINESS_COMPACT_FIELDS,
@@ -68,6 +66,7 @@ from .control_plane.quota.stall_repair import (
 from .control_plane.quota.decision_summary import (
     goal_status_health_ok as _goal_status_health_ok,
     quota_decision_agent_id,
+    resolve_quota_run_decision,
 )
 from .control_plane.quota.goal_boundary import effective_available_capabilities as _effective_available_capabilities, goal_boundary as _goal_boundary, quota_execution_profile_summary as _quota_execution_profile_summary
 from .control_plane.quota.monitor_poll import (
@@ -98,7 +97,6 @@ from .control_plane.quota.task_orchestration import (
     build_quota_work_lane_contract,
     payload_work_lane_contract as _payload_work_lane_contract,
     task_goal_route_hint,
-    task_orchestration_effective_action,
     task_selected_recommended_action,
 )
 from .control_plane.quota.slot_accounting import (
@@ -1189,45 +1187,6 @@ def _recovery_delivery_allowed(quota: dict[str, Any], *, plan_ok: bool) -> bool:
     )
 
 
-def _effective_action(
-    *,
-    normal_delivery_allowed: bool,
-    recovery_delivery_allowed: bool,
-    self_repair_allowed: bool,
-    capability_repair_allowed: bool = False,
-    workspace_repair_allowed: bool = False,
-    stall_self_repair: dict[str, Any] | None,
-    state: str,
-    quota: dict[str, Any],
-) -> str:
-    if normal_delivery_allowed:
-        return "normal_run"
-    if recovery_delivery_allowed:
-        return "outcome_floor_recovery"
-    if workspace_repair_allowed:
-        return "agent_workspace_repair"
-    if self_repair_allowed:
-        repair_action = (
-            stall_self_repair.get("effective_action")
-            if isinstance(stall_self_repair, dict)
-            else None
-        )
-        return str(repair_action or "control_plane_repair")
-    if capability_repair_allowed:
-        return "capability_bridge_repair"
-    if state == "operator_gate":
-        return "operator_gate_notify"
-    if state == "blocked_health":
-        return "blocked_health"
-    if state == "throttled":
-        return "throttled_skip"
-    if state in {"focus_wait", "waiting"}:
-        return "blocked_wait"
-    if quota.get("focus_wait"):
-        return "blocked_wait"
-    return "quota_skip"
-
-
 def _quota_agent_profile(agent_identity: dict[str, Any] | None) -> dict[str, Any] | None:
     if not isinstance(agent_identity, dict):
         return None
@@ -1691,8 +1650,6 @@ def build_quota_should_run(
             if isinstance(goal_frontier_context.get("goal_frontier_projection"), dict)
             else {}
         )
-        capability_repair_allowed = False
-        workspace_repair_allowed = False
         projection_gap = build_state_projection_gap(item, project_asset)
         projection_gap_repair = build_state_projection_gap_repair_hint(
             projection_gap,
@@ -1723,81 +1680,38 @@ def build_quota_should_run(
             normal_delivery_allowed = False
             recovery_allowed = False
             reason = str(boundary_projection_repair.get("reason") or reason)
-        if capability_gate and capability_gate.get("action") != "run" and not capability_monitor_fallback:
-            normal_delivery_allowed = False
-            recovery_allowed = False
-            if capability_gate.get("action") == "repair_bridge":
-                capability_repair_allowed = True
-                reason = str(capability_gate.get("reason") or "capability bridge repair required")
-            else:
-                reason = str(capability_gate.get("reason") or "selected todo capability is unavailable")
-        if workspace_guard:
-            normal_delivery_allowed = False
-            recovery_allowed = False
-            self_repair_allowed = False
-            capability_repair_allowed = False
-            workspace_repair_allowed = True
-            reason = str(workspace_guard.get("reason") or "agent workspace guard blocks delivery")
-        if automation_prompt_upgrade_required:
-            normal_delivery_allowed = False
-            recovery_allowed = False
-            self_repair_allowed = False
-            capability_repair_allowed = False
-            workspace_repair_allowed = False
-            reason = str(
-                automation_prompt_upgrade.get("reason")
-                or "identity-aware automation prompt upgrade is required"
-            )
-        should_run = bool(normal_delivery_allowed or recovery_allowed or self_repair_allowed
-                          or capability_repair_allowed or workspace_repair_allowed)
-        effective_action = _effective_action(
-            normal_delivery_allowed=normal_delivery_allowed, recovery_delivery_allowed=recovery_allowed,
-            self_repair_allowed=self_repair_allowed, capability_repair_allowed=capability_repair_allowed,
-            workspace_repair_allowed=workspace_repair_allowed, stall_self_repair=stall_self_repair,
-            state=state, quota=quota,
-        )
-        replan_decision_allowed = not inbox_reply_due and autonomous_replan_decision_allowed(
-            replan_obligation=replan_obligation, plan_ok=goal_health_ok,
-            workspace_blocked=bool(workspace_guard),
-            automation_prompt_upgrade_required=automation_prompt_upgrade_required,
-            agent_id=agent_frontier_id, registered_agent_ids=registered_agent_ids,
-        )
-        if replan_decision_allowed:
-            normal_delivery_allowed = False
-            recovery_allowed = False
-            should_run = True
-            effective_action = AUTONOMOUS_REPLAN_REQUIRED_MODE
-            reason = (
-                "autonomous replan obligation is selected before monitor quiet "
-                "or agent-scope wait classification"
-            )
-        terminal_no_followup = goal_frontier_is_terminal_no_followup(projection=goal_frontier_projection)
-        if terminal_no_followup and not inbox_reply_due:
-            quota = {**quota, "state": "terminal_no_followup", "reason": (
-                "derived terminal no-follow-up is confirmed by complete todo sources and an empty frontier")}
-            state = "terminal_no_followup"
-            normal_delivery_allowed = recovery_allowed = self_repair_allowed = False
-            capability_repair_allowed = workspace_repair_allowed = should_run = False
-            effective_action = "terminal_no_followup"
-            reason = ("validated closure evidence derives terminal no-follow-up from complete todo sources "
-                      "and an empty frontier; stop recurring automation until an explicit resume")
-        if automation_prompt_upgrade_required and not terminal_no_followup:
-            should_run = False
-            effective_action = "automation_prompt_upgrade_required"
-        elif inbox_reply_due:
-            should_run, normal_delivery_allowed = True, True
-            recovery_allowed = self_repair_allowed = capability_repair_allowed = workspace_repair_allowed = False
-            effective_action, reason = "lark_inbox_reply_due", (
-                "a direct Lark question, bot mention, or verified reply to the bot "
-                "is pending reply"
-            )
-        effective_action, reason = task_orchestration_effective_action(
-            task_orchestration_contract,
-            should_run=should_run,
+        run_decision = resolve_quota_run_decision(
             normal_delivery_allowed=normal_delivery_allowed,
-            effective_action=effective_action,
+            recovery_delivery_allowed=recovery_allowed,
+            self_repair_allowed=self_repair_allowed,
+            stall_self_repair=stall_self_repair,
+            state=state,
+            quota=quota,
             reason=reason,
+            capability_gate=capability_gate,
+            capability_monitor_fallback=capability_monitor_fallback,
+            workspace_guard=workspace_guard,
+            automation_prompt_upgrade=automation_prompt_upgrade,
+            automation_prompt_upgrade_required=automation_prompt_upgrade_required,
+            replan_obligation=replan_obligation,
+            goal_health_ok=goal_health_ok,
+            inbox_reply_due=inbox_reply_due,
+            agent_frontier_id=agent_frontier_id,
+            registered_agent_ids=registered_agent_ids,
+            goal_frontier_projection=goal_frontier_projection,
+            task_orchestration_contract=task_orchestration_contract,
         )
+        normal_delivery_allowed = run_decision.normal_delivery_allowed
+        recovery_allowed = run_decision.recovery_delivery_allowed
+        self_repair_allowed = run_decision.self_repair_allowed
+        capability_repair_allowed = run_decision.capability_repair_allowed
+        workspace_repair_allowed = run_decision.workspace_repair_allowed
+        should_run = run_decision.should_run
+        effective_action = run_decision.effective_action
+        reason = run_decision.reason
+        state = run_decision.state
+        quota = run_decision.quota
+        replan_decision_allowed = run_decision.replan_decision_allowed
         recommendation_item = {**item, "quota": quota}
         heartbeat_recommendation = build_heartbeat_recommendation(
             recommendation_item,

--- a/tests/control_plane/test_quota_run_decision.py
+++ b/tests/control_plane/test_quota_run_decision.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from typing import Any
+
+from loopx.control_plane.goals.goal_frontier import (
+    GOAL_TERMINAL_SOURCE_COMPLETENESS_SCHEMA_VERSION,
+    GOAL_TERMINAL_STATE_SCHEMA_VERSION,
+)
+from loopx.control_plane.quota.decision_summary import (
+    QuotaRunDecision,
+    resolve_quota_run_decision,
+)
+
+
+def _resolve(**overrides: Any) -> QuotaRunDecision:
+    values: dict[str, Any] = {
+        "normal_delivery_allowed": True,
+        "recovery_delivery_allowed": False,
+        "self_repair_allowed": False,
+        "stall_self_repair": None,
+        "state": "eligible",
+        "quota": {"state": "eligible"},
+        "reason": "eligible",
+        "capability_gate": None,
+        "capability_monitor_fallback": None,
+        "workspace_guard": None,
+        "automation_prompt_upgrade": None,
+        "automation_prompt_upgrade_required": False,
+        "replan_obligation": None,
+        "goal_health_ok": True,
+        "inbox_reply_due": False,
+        "agent_frontier_id": "agent-a",
+        "registered_agent_ids": ["agent-a"],
+        "goal_frontier_projection": None,
+        "task_orchestration_contract": None,
+    }
+    values.update(overrides)
+    return resolve_quota_run_decision(**values)
+
+
+def test_base_eligible_decision_runs_normally() -> None:
+    decision = _resolve()
+
+    assert decision.should_run is True
+    assert decision.normal_delivery_allowed is True
+    assert decision.effective_action == "normal_run"
+
+
+def test_workspace_guard_overrides_capability_repair() -> None:
+    decision = _resolve(
+        capability_gate={"action": "repair_bridge", "reason": "repair capability"},
+        workspace_guard={"reason": "use independent worktree"},
+    )
+
+    assert decision.should_run is True
+    assert decision.capability_repair_allowed is False
+    assert decision.workspace_repair_allowed is True
+    assert decision.effective_action == "agent_workspace_repair"
+    assert decision.reason == "use independent worktree"
+
+
+def test_automation_upgrade_precedes_inbox_reply() -> None:
+    decision = _resolve(
+        automation_prompt_upgrade={"reason": "refresh prompt identity"},
+        automation_prompt_upgrade_required=True,
+        inbox_reply_due=True,
+    )
+
+    assert decision.should_run is False
+    assert decision.normal_delivery_allowed is False
+    assert decision.effective_action == "automation_prompt_upgrade_required"
+    assert decision.reason == "refresh prompt identity"
+
+
+def test_inbox_reply_prevents_replan_and_precedes_normal_delivery() -> None:
+    decision = _resolve(
+        replan_obligation={"required": True, "agent_id": "agent-a"},
+        inbox_reply_due=True,
+    )
+
+    assert decision.replan_decision_allowed is False
+    assert decision.should_run is True
+    assert decision.normal_delivery_allowed is True
+    assert decision.effective_action == "lark_inbox_reply_due"
+
+
+def test_replan_precedes_normal_delivery() -> None:
+    decision = _resolve(
+        replan_obligation={"required": True, "agent_id": "agent-a"},
+    )
+
+    assert decision.replan_decision_allowed is True
+    assert decision.should_run is True
+    assert decision.normal_delivery_allowed is False
+    assert decision.effective_action == "autonomous_replan_required"
+
+
+def test_terminal_closure_precedes_automation_upgrade() -> None:
+    projection = {
+        "terminal_state": {
+            "schema_version": GOAL_TERMINAL_STATE_SCHEMA_VERSION,
+            "kind": "no_followup",
+            "derived": True,
+            "source": "validated_goal_closure",
+        },
+        "source_completeness": {
+            "schema_version": GOAL_TERMINAL_SOURCE_COMPLETENESS_SCHEMA_VERSION,
+            "user_todos": "valid",
+            "agent_todos": "valid",
+        },
+        "normalized_progress": {
+            "user_open_count": 0,
+            "agent_open_count": 0,
+            "agent_advancement_open_count": 0,
+            "agent_monitor_open_count": 0,
+            "agent_monitor_due_count": 0,
+        },
+        "remaining_advancement_frontier": {
+            "current_agent_claimed_advancement_count": 0,
+            "unclaimed_advancement_count": 0,
+            "other_agent_claimed_advancement_count": 0,
+        },
+        "monitor_only_lanes": {
+            "present": False,
+            "quiet_until_material_transition": False,
+        },
+        "deferred_successors": {
+            "ready_count": 0,
+            "blocked_count": 0,
+            "current_agent_ready_count": 0,
+        },
+        "acceptance_gaps": [],
+        "autonomy_blockers": [],
+        "replan_required": False,
+    }
+    decision = _resolve(
+        automation_prompt_upgrade={"reason": "refresh prompt identity"},
+        automation_prompt_upgrade_required=True,
+        goal_frontier_projection=projection,
+    )
+
+    assert decision.should_run is False
+    assert decision.state == "terminal_no_followup"
+    assert decision.effective_action == "terminal_no_followup"
+    assert decision.quota["state"] == "terminal_no_followup"
+
+
+def test_task_orchestration_refines_normal_run_action() -> None:
+    decision = _resolve(
+        task_orchestration_contract={
+            "coordinator_obligation": "coordinate eligible peers"
+        }
+    )
+
+    assert decision.should_run is True
+    assert decision.normal_delivery_allowed is True
+    assert decision.effective_action == "coordinate_task_bundle"


### PR DESCRIPTION
## Summary

- extract the ordered final quota run decision into the existing quota decision owner
- return a typed result while preserving the current guard precedence
- add direct precedence tests and tighten the maintainability ratchet

## Simplification

`build_quota_should_run` drops from 366 to 329 statements and from 264 to 241 decision points. The extracted stage reuses the existing goal-frontier predicates and keeps each policy source single-owned.

## Validation

- `python -m mypy`: passed
- `ruff check`: passed on all changed files
- focused pytest: 113 passed
- maintainability ratchet smoke: passed
- CLI output budget regression smoke: passed
- risk-based premerge: 17/17 canaries passed
- change-quality receipt: `cqr_5f8d7e937f25cd859de6` valid

The first premerge attempt exposed only a local interpreter-routing mismatch; rerunning with the repository's Python 3.11 environment passed. No full suite was run because the focused decision, quota, scheduler, architecture, and agent-facing CLI coverage matches the changed surfaces.
