### PR TITLE
docs: qualify Ark Managed Agent issue-fix evidence

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -5,6 +5,7 @@
 [Workflow contract](protocols/issue-fix-workflow-contract-v0.md) ·
 [Discovered issue promotion](protocols/issue-fix-discovered-issue-promotion-v0.md) ·
 [Acceptance loop](protocols/issue-fix-acceptance-loop-v0.md) ·
+[Ark Managed Agent qualification](../../reference/protocols/ark-managed-agent-issue-fix-qualification-v0.md) ·
 [Reviewer recommendation](protocols/issue-fix-reviewer-recommendation-v0.md) ·
 [Reviewer request](protocols/issue-fix-reviewer-request-v0.md) ·
 [Reviewer notification sinks](protocols/issue-fix-reviewer-notification-sinks-v0.md) ·

--- a/docs/reference/protocols/ark-managed-agent-issue-fix-qualification-v0.md
+++ b/docs/reference/protocols/ark-managed-agent-issue-fix-qualification-v0.md
@@ -1,0 +1,91 @@
+# Ark Managed Agent Issue-Fix Qualification v0
+
+This protocol qualifies LoopX issue-fix work when one LoopX goal prompt is
+submitted to an Ark Managed Agent Goal host. It composes existing issue-fix
+and host contracts; it does not introduce another runtime or another prompt
+family.
+
+The qualification is deliberately staged. A repaired file is useful evidence,
+but it is not proof that the Goal host reached a durable terminal state.
+
+## Evidence stages
+
+| Stage | Required evidence | Pass condition |
+| --- | --- | --- |
+| 1. Intake and route | Public-safe issue metadata and an `issue_fix_feasibility_v0` packet | Exactly one route is selected. A `fix_pr` route has a named repro, bounded scope, and named validation. |
+| 2. Worker repair | Repro-before, minimal patch, focused validation-after, and changed-file summary | The repro fails before the patch, validation passes after it, and the artifact is review-ready without claiming an external write. |
+| 3. Durable LoopX closure | Validated todo writeback plus explicit successor or `no_followup` | The selected todo is durably closed and a new `quota should-run` no longer asks the worker to repeat the repair. |
+| 4. Goal host closure | Host events for Goal evaluation and terminal session state | Evaluation ends satisfied, the Goal becomes achieved, and the session returns idle without a provider, evaluator, or transport error. |
+| 5. Review handoff | Review packet and explicit authority state | The packet is ready for review. PR creation, review request, merge, and publish remain false until separately authorized. |
+
+Stages 1–3 qualify the issue-fix worker path. Stages 1–4 qualify the one-shot
+Goal host path end to end. Stage 5 qualifies the handoff boundary; it does not
+grant publication authority.
+
+## Verdict rules
+
+Use these verdicts instead of one overloaded success bit:
+
+| Observed result | Worker verdict | Goal-host verdict | Meaning |
+| --- | --- | --- | --- |
+| Repro, patch, validation, and durable todo closure all pass; Goal evaluation ends satisfied | pass | pass | End-to-end host case passed. |
+| Worker evidence passes; Goal evaluator or provider fails before satisfied | pass | fail | The repair is real, but the host case is not complete. Diagnose the evaluator/provider boundary. |
+| Code changes, but focused validation or durable writeback is missing | fail | not reached | Do not treat a plausible diff as a completed issue fix. |
+| Goal reports satisfied without a validated repair artifact | fail | invalid | The evaluator result is insufficient and the case must be rejected. |
+| Review packet is ready but external-write authority is absent | pass | pass or not applicable | Stop at draft/review handoff; do not publish. |
+
+`issue_fix_validated_fix_artifact_v0` intentionally owns worker evidence only.
+It does not contain a Goal terminal-state field. Goal satisfaction must come
+from the host event stream or an equivalent host readback, never from the
+presence of a patch.
+
+## Representative matrix
+
+An L2 qualification run should cover more than one happy-path issue:
+
+1. a bounded issue that selects `fix_pr`, reproduces locally, applies a minimal
+   patch, and passes focused validation;
+2. an issue with useful diagnosis but insufficient repair evidence that routes
+   to `comment_only` and remains externally gated;
+3. an issue with neither a safe repair nor useful comment payload that routes
+   to `triage_only` with no fabricated follow-up;
+4. a one-shot Goal-host run using the same generated `task_body` as the cloud
+   host, including durable todo closure and terminal Goal readback; and
+5. a review-ready handoff that proves no comment, PR, merge, or publish action
+   occurred without authority.
+
+The deterministic repository fixture covers the repair mechanics. At least
+one authenticated host run is still required for stage 4; a mock provider or a
+successful patch alone cannot close that requirement.
+
+## Current live finding
+
+A local Goal-host parity replay submitted one generated task body and reached
+the real issue-fix worker. The worker reproduced the calculator defect,
+applied the one-line repair, validated it, inspected the diff, and marked its
+LoopX todo closed. The model exchanges used by the repair completed
+successfully.
+
+The host-side writeback did not preserve the requested explicit
+`no_followup`, so the next quota read rejected the closure as unhealthy. The
+later Goal evaluator also failed at the provider protocol boundary before a
+satisfied terminal event was emitted. The correct classification is therefore
+`repair=pass, durable_closure=fail, goal_host=fail`, not a worker-qualified or
+end-to-end pass. This finding validates the staged model and leaves both an
+exact-version writeback readback and an authenticated terminal-readback case
+open.
+
+Private prompts, credentials, provider payloads, local paths, and raw traces
+are intentionally excluded from this public protocol.
+
+## Durable checks
+
+Run the focused contract:
+
+```bash
+python -m pytest -q tests/test_ark_managed_agent_issue_fix_matrix.py
+```
+
+The test composes the current feasibility, deterministic repair, Goal-host,
+and review-handoff contracts. It also prevents the validated repair artifact
+from silently acquiring or implying Goal terminal-state authority.

--- a/docs/reference/protocols/ark-managed-agent-issue-fix-qualification-v0.md
+++ b/docs/reference/protocols/ark-managed-agent-issue-fix-qualification-v0.md
@@ -60,20 +60,19 @@ successful patch alone cannot close that requirement.
 
 ## Current live finding
 
-A local Goal-host parity replay submitted one generated task body and reached
-the real issue-fix worker. The worker reproduced the calculator defect,
-applied the one-line repair, validated it, inspected the diff, and marked its
-LoopX todo closed. The model exchanges used by the repair completed
-successfully.
+A fresh Goal-host parity replay installed the CLI and workflow skills from one
+clean revision, then submitted one generated task body. The real issue-fix
+worker reproduced the retry-delay defect, applied the one-line repair, passed
+all four focused tests, wrote the review handoff, and closed its LoopX todo
+with explicit `no_followup`.
 
-The host-side writeback did not preserve the requested explicit
-`no_followup`, so the next quota read rejected the closure as unhealthy. The
-later Goal evaluator also failed at the provider protocol boundary before a
-satisfied terminal event was emitted. The correct classification is therefore
-`repair=pass, durable_closure=fail, goal_host=fail`, not a worker-qualified or
-end-to-end pass. This finding validates the staged model and leaves both an
-exact-version writeback readback and an authenticated terminal-readback case
-open.
+The next quota read returned `terminal_no_followup` with complete user and
+agent todo sources and no acceptance gaps. A state-aware Goal evaluator then
+observed that durable terminal state, emitted a satisfied evaluation, and the
+session returned idle. The run completed 14 authenticated provider exchanges.
+The correct classification is therefore
+`repair=pass, durable_closure=pass, goal_host=pass`; publication remains a
+separate gated handoff.
 
 Private prompts, credentials, provider payloads, local paths, and raw traces
 are intentionally excluded from this public protocol.

--- a/docs/reference/protocols/host-integration-surface-v0.md
+++ b/docs/reference/protocols/host-integration-surface-v0.md
@@ -95,6 +95,11 @@ LoopX Turn driver is not required. Durable policy remains in current
 `quota should-run.interaction_contract`, active state, todos, vision, and
 writeback.
 
+Issue-fix qualification on this host uses a staged evidence contract. A
+validated patch proves the worker path, while Goal satisfaction must be read
+from the host separately. See
+[`ark-managed-agent-issue-fix-qualification-v0`](ark-managed-agent-issue-fix-qualification-v0.md).
+
 ## Lifecycle Reads
 
 Host integrations should expose read methods that map directly to CLI reads:

--- a/tests/test_ark_managed_agent_issue_fix_matrix.py
+++ b/tests/test_ark_managed_agent_issue_fix_matrix.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from loopx.capabilities.issue_fix.acceptance_loop import (
+    build_issue_fix_acceptance_fixture_packet,
+)
+from loopx.capabilities.issue_fix.feasibility import (
+    build_issue_fix_feasibility_packet,
+)
+from loopx.heartbeat_prompt import build_heartbeat_prompt
+from loopx.host_loop_activation import build_host_loop_activation_packet
+
+
+@pytest.mark.parametrize(
+    ("reproduction_status", "scope_class", "comment_value", "expected_route"),
+    [
+        ("confirmed", "bounded", "none", "fix_pr"),
+        ("blocked", "uncertain", "diagnosis", "comment_only"),
+        ("missing", "uncertain", "none", "triage_only"),
+    ],
+)
+def test_representative_intake_routes_remain_public_safe_and_exclusive(
+    reproduction_status: str,
+    scope_class: str,
+    comment_value: str,
+    expected_route: str,
+) -> None:
+    packet = build_issue_fix_feasibility_packet(
+        reproduction_status=reproduction_status,
+        scope_class=scope_class,
+        reproduction_label=(
+            "python test_calculator.py"
+            if reproduction_status in {"confirmed", "planned"}
+            else None
+        ),
+        validation_label=(
+            "python test_calculator.py"
+            if reproduction_status in {"confirmed", "planned"}
+            else None
+        ),
+        comment_value=comment_value,
+    )
+
+    assert packet["ok"] is True
+    assert packet["decision"]["route"] == expected_route
+    assert packet["external_writes_performed"] is False
+    assert packet["issue_body_captured"] is False
+    assert packet["comment_bodies_captured"] is False
+    assert packet["raw_logs_captured"] is False
+    assert packet["local_paths_captured"] is False
+
+
+def test_validated_worker_artifact_does_not_claim_goal_host_closure() -> None:
+    packet = build_issue_fix_acceptance_fixture_packet()
+    artifact = packet["validated_fix_artifact"]
+    review_packet = artifact["review_packet"]
+
+    assert packet["ok"] is True
+    assert artifact["repro_before"]["passed"] is False
+    assert artifact["patch"]["patch_applied"] is True
+    assert artifact["validation_after"]["passed"] is True
+    assert artifact["fix_artifact_ready"] is True
+    assert artifact["pr_review_packet_ready"] is True
+
+    # Worker evidence and host terminal evidence have different owners. A
+    # successful repair must never imply that a Goal evaluator reached
+    # Satisfied or that the host reached an achieved terminal state.
+    assert "goal_terminal_state" not in artifact
+    assert "goal_evaluation" not in artifact
+
+    assert review_packet["external_issue_comment_performed"] is False
+    assert review_packet["external_pr_created"] is False
+    assert review_packet["merge_performed"] is False
+
+
+def test_one_shot_host_contract_keeps_goal_closure_with_the_host() -> None:
+    prompt = build_heartbeat_prompt(
+        goal_id="managed-agent-issue-fix-matrix",
+        active_state=Path("/workspace/ACTIVE_GOAL_STATE.md"),
+        thin=True,
+        runtime_profile="ark_managed_agent_goal",
+    )
+    activation = build_host_loop_activation_packet(
+        agent_type="ark-managed-agent",
+        goal_id="managed-agent-issue-fix-matrix",
+        agent_id="managed-agent",
+        registered_agents=["managed-agent"],
+    )
+
+    assert prompt["host_contract"]["activation_mode"] == "goal_once"
+    assert prompt["host_contract"]["goal_runtime_owns_continuation"] is True
+    assert prompt["host_contract"]["loopx_turn_driver_required"] is False
+    assert prompt["host_contract"]["session_state_authoritative"] is False
+    assert len(prompt["task_body"]) <= 4_000
+    assert "Spend exactly once after validated writeback" in prompt["task_body"]
+
+    assert activation["activation_method"] == "submit_goal_once"
+    assert activation["host_mutation"]["prompt_field"] == "task_body"
+    assert activation["host_mutation"]["transport_contract"] == "goal_prompt_v0"
+    assert "loopx turn run-once" not in str(activation).lower()


### PR DESCRIPTION
## Summary

- define a five-stage Ark Managed Agent issue-fix qualification contract
- keep repair evidence, durable LoopX closure, Goal-host terminal evidence, and publication authority separate
- add focused contract tests for fix/comment/triage routes, deterministic repair evidence, one-shot Goal ownership, and no implicit external writes

## Live finding

A fresh one-shot Goal-host parity run installed the CLI and workflow skills from one clean revision, submitted one generated task body, repaired the fixture, passed all four fixture tests, and closed the durable LoopX frontier with explicit no-follow-up. The state-aware evaluator then observed `terminal_no_followup`, emitted a satisfied evaluation, and the session returned idle. The run used 14 authenticated provider exchanges. No private prompts, credentials, paths, payloads, or raw traces are included.

Classification: `repair=pass, durable_closure=pass, goal_host=pass`; publication remains separately gated.

## Validation

- fresh authenticated one-shot Goal-host e2e passed in 129.44s
- 10 focused contract tests passed
- Ruff check and format passed
- LoopX document/public-boundary check passed: 6 checks, 0 errors, 0 warnings
- standard premerge passed: 17 selected checks, 0 failures

Draft for maintainer review; no self-merge.
