### PR TITLE
refactor(quota): isolate heartbeat guard guidance

### DIFF
--- a/loopx/canary/maintainability_ratchet.py
+++ b/loopx/canary/maintainability_ratchet.py
@@ -55,8 +55,8 @@ _OVERSIZED_DECISION_RETIREMENT_PLANS = {
 
 _OVERSIZED_DECISION_METRIC_CEILINGS = {
     "loopx.quota:build_quota_should_run": {
-        "statements": 329,
-        "decision_points": 241,
+        "statements": 316,
+        "decision_points": 221,
     },
 }
 

--- a/loopx/control_plane/quota/heartbeat_recommendation.py
+++ b/loopx/control_plane/quota/heartbeat_recommendation.py
@@ -150,6 +150,94 @@ _BASE_RECOMMENDATION: dict[str, Any] = {
     ),
 }
 
+_CAPABILITY_GATE_RECOMMENDATION_OVERRIDES: dict[str, dict[str, Any]] = {
+    "repair_bridge": {
+        "recommended_mode": "repair_capability_bridge",
+        "notify": "DONT_NOTIFY",
+        "spend_policy": (
+            "append exactly one quota spend only after a validated bridge "
+            "repair, todo rewrite, or compact blocker writeback"
+        ),
+    },
+    "ask_owner": {
+        "recommended_mode": "ask_owner_for_capability",
+        "notify": "NOTIFY",
+        "spend_policy": "do not append quota spend while asking for missing capability",
+    },
+    "skip": {
+        "recommended_mode": "capability_skip",
+        "notify": "DONT_NOTIFY",
+        "spend_policy": (
+            "do not append quota spend while all executable todos lack "
+            "current capabilities"
+        ),
+    },
+}
+
+
+def refine_heartbeat_recommendation(
+    recommendation: dict[str, Any],
+    *,
+    should_run: bool,
+    capability_gate: dict[str, Any] | None,
+    capability_monitor_fallback: dict[str, Any] | None,
+    workspace_guard: dict[str, Any] | None,
+    automation_prompt_upgrade: dict[str, Any] | None,
+    automation_prompt_upgrade_required: bool,
+    blocked_priority_fallback: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Apply the ordered execution-guard refinements to heartbeat guidance."""
+
+    refined = dict(recommendation)
+    capability_action = (
+        str(capability_gate.get("action") or "")
+        if capability_gate and not capability_monitor_fallback
+        else ""
+    )
+    capability_override = _CAPABILITY_GATE_RECOMMENDATION_OVERRIDES.get(
+        capability_action
+    )
+    if capability_override:
+        refined.update(capability_override)
+        refined["reason"] = capability_gate.get("reason") or refined.get("reason")
+
+    if workspace_guard:
+        refined.update(
+            {
+                "recommended_mode": "repair_agent_workspace",
+                "notify": "DONT_NOTIFY",
+                "reason": workspace_guard.get("reason") or refined.get("reason"),
+                "spend_policy": (
+                    "do not append quota spend for workspace relocation; rerun quota "
+                    "from the independent worktree before delivery"
+                ),
+            }
+        )
+
+    if automation_prompt_upgrade_required:
+        upgrade = automation_prompt_upgrade or {}
+        refined.update(
+            {
+                "recommended_mode": "automation_prompt_upgrade",
+                "notify": "DONT_NOTIFY",
+                "reason": upgrade.get("reason") or refined.get("reason"),
+                "spend_policy": (
+                    "do not append quota spend for stale/unscoped automation; "
+                    "rerun quota should-run from an identity-scoped prompt"
+                ),
+            }
+        )
+
+    if blocked_priority_fallback and should_run:
+        refined["blocked_priority_fallback"] = blocked_priority_fallback
+        if blocked_priority_fallback.get("notify_user") is True:
+            refined["notify"] = "NOTIFY"
+            refined["reason"] = (
+                blocked_priority_fallback.get("reason") or refined.get("reason")
+            )
+
+    return refined
+
 
 @dataclass(frozen=True)
 class _HeartbeatRecommendationFacts:

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -49,6 +49,7 @@ from .control_plane.quota.heartbeat_recommendation import (
     HEARTBEAT_POST_HANDOFF_RUN_COMPACT_FIELDS as POST_HANDOFF_RUN_COMPACT_FIELDS,
     build_heartbeat_recommendation,
     open_todo_notify_reason,
+    refine_heartbeat_recommendation,
 )
 from .control_plane.quota.projection_repair import (
     build_boundary_projection_repair_hint,
@@ -1726,68 +1727,16 @@ def build_quota_should_run(
             select_replan_obligation=False,
             monitor_due_item_limit=MONITOR_DUE_ITEM_LIMIT,
         )
-        if capability_gate and not capability_monitor_fallback and capability_gate.get("action") == "repair_bridge":
-            heartbeat_recommendation = {
-                **heartbeat_recommendation,
-                "recommended_mode": "repair_capability_bridge",
-                "notify": "DONT_NOTIFY",
-                "reason": capability_gate.get("reason") or heartbeat_recommendation.get("reason"),
-                "spend_policy": (
-                    "append exactly one quota spend only after a validated bridge "
-                    "repair, todo rewrite, or compact blocker writeback"
-                ),
-            }
-        elif capability_gate and not capability_monitor_fallback and capability_gate.get("action") == "ask_owner":
-            heartbeat_recommendation = {
-                **heartbeat_recommendation,
-                "recommended_mode": "ask_owner_for_capability",
-                "notify": "NOTIFY",
-                "reason": capability_gate.get("reason") or heartbeat_recommendation.get("reason"),
-                "spend_policy": "do not append quota spend while asking for missing capability",
-            }
-        elif capability_gate and not capability_monitor_fallback and capability_gate.get("action") == "skip":
-            heartbeat_recommendation = {
-                **heartbeat_recommendation,
-                "recommended_mode": "capability_skip",
-                "notify": "DONT_NOTIFY",
-                "reason": capability_gate.get("reason") or heartbeat_recommendation.get("reason"),
-                "spend_policy": "do not append quota spend while all executable todos lack current capabilities",
-            }
-        if workspace_guard:
-            heartbeat_recommendation = {
-                **heartbeat_recommendation,
-                "recommended_mode": "repair_agent_workspace",
-                "notify": "DONT_NOTIFY",
-                "reason": workspace_guard.get("reason") or heartbeat_recommendation.get("reason"),
-                "spend_policy": (
-                    "do not append quota spend for workspace relocation; rerun quota "
-                    "from the independent worktree before delivery"
-                ),
-            }
-        if automation_prompt_upgrade_required:
-            heartbeat_recommendation = {
-                **heartbeat_recommendation,
-                "recommended_mode": "automation_prompt_upgrade",
-                "notify": "DONT_NOTIFY",
-                "reason": automation_prompt_upgrade.get("reason")
-                or heartbeat_recommendation.get("reason"),
-                "spend_policy": (
-                    "do not append quota spend for stale/unscoped automation; "
-                    "rerun quota should-run from an identity-scoped prompt"
-                ),
-            }
-        if blocked_priority_fallback and should_run:
-            heartbeat_recommendation = {
-                **heartbeat_recommendation,
-                "blocked_priority_fallback": blocked_priority_fallback,
-            }
-            if blocked_priority_fallback.get("notify_user") is True:
-                heartbeat_recommendation = {
-                    **heartbeat_recommendation,
-                    "notify": "NOTIFY",
-                    "reason": blocked_priority_fallback.get("reason")
-                    or heartbeat_recommendation.get("reason"),
-                }
+        heartbeat_recommendation = refine_heartbeat_recommendation(
+            heartbeat_recommendation,
+            should_run=should_run,
+            capability_gate=capability_gate,
+            capability_monitor_fallback=capability_monitor_fallback,
+            workspace_guard=workspace_guard,
+            automation_prompt_upgrade=automation_prompt_upgrade,
+            automation_prompt_upgrade_required=automation_prompt_upgrade_required,
+            blocked_priority_fallback=blocked_priority_fallback,
+        )
         external_evidence_observation = build_external_evidence_observation_obligation(
             item,
             state=state,

--- a/tests/control_plane/test_heartbeat_recommendation_refinement.py
+++ b/tests/control_plane/test_heartbeat_recommendation_refinement.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import pytest
+
+from loopx.control_plane.quota.heartbeat_recommendation import (
+    refine_heartbeat_recommendation,
+)
+
+BASE_RECOMMENDATION = {
+    "source": "quota.should-run",
+    "recommended_mode": "steering_audit_then_one_step",
+    "notify": "DONT_NOTIFY",
+    "reason": "base recommendation",
+    "spend_policy": "spend after validated writeback",
+}
+
+
+def _refine(**overrides: object) -> dict[str, object]:
+    values: dict[str, object] = {
+        "recommendation": BASE_RECOMMENDATION,
+        "should_run": True,
+        "capability_gate": None,
+        "capability_monitor_fallback": None,
+        "workspace_guard": None,
+        "automation_prompt_upgrade": None,
+        "automation_prompt_upgrade_required": False,
+        "blocked_priority_fallback": None,
+    }
+    values.update(overrides)
+    return refine_heartbeat_recommendation(**values)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("action", "mode", "notify"),
+    [
+        ("repair_bridge", "repair_capability_bridge", "DONT_NOTIFY"),
+        ("ask_owner", "ask_owner_for_capability", "NOTIFY"),
+        ("skip", "capability_skip", "DONT_NOTIFY"),
+    ],
+)
+def test_capability_gate_refines_recommendation(
+    action: str,
+    mode: str,
+    notify: str,
+) -> None:
+    recommendation = _refine(
+        capability_gate={"action": action, "reason": f"{action} reason"},
+    )
+
+    assert recommendation["recommended_mode"] == mode
+    assert recommendation["notify"] == notify
+    assert recommendation["reason"] == f"{action} reason"
+
+
+def test_monitor_fallback_preserves_base_recommendation() -> None:
+    recommendation = _refine(
+        capability_gate={"action": "skip", "reason": "missing capability"},
+        capability_monitor_fallback={"selected": True},
+    )
+
+    assert recommendation == BASE_RECOMMENDATION
+
+
+def test_automation_upgrade_overrides_workspace_and_capability_guidance() -> None:
+    recommendation = _refine(
+        capability_gate={"action": "repair_bridge", "reason": "repair capability"},
+        workspace_guard={"reason": "repair workspace"},
+        automation_prompt_upgrade={"reason": "upgrade automation"},
+        automation_prompt_upgrade_required=True,
+    )
+
+    assert recommendation["recommended_mode"] == "automation_prompt_upgrade"
+    assert recommendation["notify"] == "DONT_NOTIFY"
+    assert recommendation["reason"] == "upgrade automation"
+
+
+def test_workspace_guard_overrides_capability_guidance() -> None:
+    recommendation = _refine(
+        capability_gate={"action": "ask_owner", "reason": "ask owner"},
+        workspace_guard={"reason": "repair workspace"},
+    )
+
+    assert recommendation["recommended_mode"] == "repair_agent_workspace"
+    assert recommendation["notify"] == "DONT_NOTIFY"
+    assert recommendation["reason"] == "repair workspace"
+
+
+def test_blocked_priority_fallback_only_notifies_for_runnable_turn() -> None:
+    fallback = {
+        "notify_user": True,
+        "reason": "blocked priority requires notice",
+    }
+
+    runnable = _refine(blocked_priority_fallback=fallback)
+    skipped = _refine(should_run=False, blocked_priority_fallback=fallback)
+
+    assert runnable["blocked_priority_fallback"] == fallback
+    assert runnable["notify"] == "NOTIFY"
+    assert runnable["reason"] == "blocked priority requires notice"
+    assert "blocked_priority_fallback" not in skipped
+    assert skipped["notify"] == "DONT_NOTIFY"


### PR DESCRIPTION
## Summary

- move ordered capability, workspace, automation, and blocked-priority recommendation refinements into the existing heartbeat recommendation owner
- keep the quota facade focused on orchestration while preserving the current precedence
- tighten the `build_quota_should_run` maintainability ratchet from 329 statements / 241 decisions to 316 / 221

## Validation

- 19 focused pytest cases
- capability, recommendation, plan, monitor-fallback, and blocked-priority smokes
- repository mypy configuration
- focused Ruff check and format check for the new test
- `loopx check` public-boundary scan
- `loopx canary premerge --from-git-diff`: 17/17 selected checks passed, no manual holds
- change-quality receipt `cqr_6a76b3ebcf18462caf0e` valid for the exact committed scope