### PR TITLE
refactor(quota): isolate recommended action precedence

### DIFF
--- a/loopx/canary/maintainability_ratchet.py
+++ b/loopx/canary/maintainability_ratchet.py
@@ -55,8 +55,8 @@ _OVERSIZED_DECISION_RETIREMENT_PLANS = {
 
 _OVERSIZED_DECISION_METRIC_CEILINGS = {
     "loopx.quota:build_quota_should_run": {
-        "statements": 316,
-        "decision_points": 221,
+        "statements": 304,
+        "decision_points": 201,
     },
 }
 

--- a/loopx/control_plane/quota/decision_summary.py
+++ b/loopx/control_plane/quota/decision_summary.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from ...state_projection import actions_are_projection_aligned
 from ..goals.contract_health import project_contract_health_for_goal
 from ..goals.goal_frontier import (
     AUTONOMOUS_REPLAN_REQUIRED_MODE,
@@ -10,6 +11,7 @@ from ..goals.goal_frontier import (
     goal_frontier_is_terminal_no_followup,
 )
 from ..todos.contract import normalize_todo_claimed_by
+from ..work_items.work_lane import work_lane_contract_is_due_monitor_attempt
 
 
 def compact_quota_decision(decision: dict[str, Any]) -> dict[str, Any]:
@@ -78,6 +80,87 @@ class QuotaRunDecision:
     state: str
     quota: dict[str, Any]
     replan_decision_allowed: bool
+
+
+def refine_quota_recommended_action(
+    selected_action: Any,
+    *,
+    task_orchestration_contract: dict[str, Any] | None,
+    capability_gate: dict[str, Any] | None,
+    capability_monitor_fallback: dict[str, Any] | None,
+    work_lane_contract: dict[str, Any] | None,
+    workspace_guard: dict[str, Any] | None,
+    automation_prompt_upgrade: dict[str, Any] | None,
+    automation_prompt_upgrade_required: bool,
+    replan_obligation: dict[str, Any] | None,
+    replan_decision_allowed: bool,
+) -> Any:
+    """Apply ordered quota guards before agent-lane frontier refinement."""
+
+    refined = (
+        str(
+            task_orchestration_contract.get("coordinator_obligation")
+            or selected_action
+            or ""
+        )
+        if task_orchestration_contract
+        else selected_action
+    )
+    if (
+        capability_monitor_fallback
+        and isinstance(work_lane_contract, dict)
+        and work_lane_contract.get("action")
+    ):
+        refined = work_lane_contract["action"]
+
+    due_monitor_attempt = work_lane_contract_is_due_monitor_attempt(work_lane_contract)
+    if capability_gate and not due_monitor_attempt and not capability_monitor_fallback:
+        if capability_gate.get("action") in {"repair_bridge", "ask_owner", "skip"}:
+            refined = (
+                capability_gate.get("owner_action")
+                or capability_gate.get("reason")
+                or refined
+            )
+        elif capability_gate.get("action") == "run":
+            blocked = capability_gate.get("blocked_candidates")
+            blocked = blocked if isinstance(blocked, list) else []
+            runnable = capability_gate.get("runnable_candidates")
+            runnable = runnable if isinstance(runnable, list) else []
+            if any(
+                isinstance(item, dict)
+                and actions_are_projection_aligned(refined, item.get("text"))
+                for item in blocked
+            ):
+                refined = next(
+                    (
+                        text
+                        for item in runnable
+                        if isinstance(item, dict)
+                        and (text := str(item.get("text") or "").strip())
+                    ),
+                    refined,
+                )
+
+    if workspace_guard:
+        refined = (
+            workspace_guard.get("required_action")
+            or workspace_guard.get("reason")
+            or refined
+        )
+    if automation_prompt_upgrade_required:
+        upgrade = automation_prompt_upgrade or {}
+        refined = upgrade.get("recommended_action") or upgrade.get("reason") or refined
+    if replan_decision_allowed:
+        obligation = replan_obligation or {}
+        refined = (
+            str(obligation.get("recommended_action") or "").strip()
+            or str(obligation.get("stop_condition") or "").strip()
+            or (
+                "Run one bounded autonomous replan slice and write back the "
+                "selected todo/frontier changes."
+            )
+        )
+    return refined
 
 
 def resolve_quota_run_decision(

--- a/loopx/control_plane/quota/task_orchestration.py
+++ b/loopx/control_plane/quota/task_orchestration.py
@@ -91,15 +91,6 @@ def apply_task_orchestration_contract(
     return contract, _task_orchestration_work_lane_contract(contract)
 
 
-def task_selected_recommended_action(
-    contract: dict[str, Any] | None,
-    fallback: str | None,
-) -> str | None:
-    if not contract:
-        return fallback
-    return str(contract.get("coordinator_obligation") or fallback or "")
-
-
 def task_goal_route_hint(
     goal_route_hint: dict[str, Any] | None,
     contract: dict[str, Any] | None,

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -67,6 +67,7 @@ from .control_plane.quota.stall_repair import (
 from .control_plane.quota.decision_summary import (
     goal_status_health_ok as _goal_status_health_ok,
     quota_decision_agent_id,
+    refine_quota_recommended_action,
     resolve_quota_run_decision,
 )
 from .control_plane.quota.goal_boundary import effective_available_capabilities as _effective_available_capabilities, goal_boundary as _goal_boundary, quota_execution_profile_summary as _quota_execution_profile_summary
@@ -98,7 +99,6 @@ from .control_plane.quota.task_orchestration import (
     build_quota_work_lane_contract,
     payload_work_lane_contract as _payload_work_lane_contract,
     task_goal_route_hint,
-    task_selected_recommended_action,
 )
 from .control_plane.quota.slot_accounting import (
     QUOTA_SLOT_SPENT_CLASSIFICATION,
@@ -141,7 +141,6 @@ from .control_plane.scheduler.state import (
     load_scheduler_state,
 )
 from .state_projection import (
-    actions_are_projection_aligned,
     next_action_projection_warning,
     state_action_projection_warning as build_state_action_projection_warning,
 )
@@ -625,38 +624,6 @@ def _blocked_priority_fallback(
             "continue the fallback only if it still matches the latest user priority."
         ),
     }
-
-
-def _selected_action_with_capability_gate(
-    selected_action: Any,
-    *,
-    capability_gate: dict[str, Any] | None,
-) -> Any:
-    if not isinstance(capability_gate, dict) or capability_gate.get("action") != "run":
-        return selected_action
-    blocked = (
-        capability_gate.get("blocked_candidates")
-        if isinstance(capability_gate.get("blocked_candidates"), list)
-        else []
-    )
-    if not any(
-        isinstance(item, dict)
-        and actions_are_projection_aligned(selected_action, item.get("text"))
-        for item in blocked
-    ):
-        return selected_action
-    runnable = (
-        capability_gate.get("runnable_candidates")
-        if isinstance(capability_gate.get("runnable_candidates"), list)
-        else []
-    )
-    for item in runnable:
-        if not isinstance(item, dict):
-            continue
-        text = str(item.get("text") or "").strip()
-        if text:
-            return text
-    return selected_action
 
 
 def _compact_handoff_readiness(value: Any) -> dict[str, Any] | None:
@@ -1808,43 +1775,19 @@ def build_quota_should_run(
             agent_lane_recommendation=agent_lane_recommendation,
             prefer_agent_lane_recommendation=monitor_quiet_skip,
         )
-        selected_recommended_action = task_selected_recommended_action(
-            task_orchestration_contract,
+        selected_recommended_action = refine_quota_recommended_action(
             selected_recommended_action,
+            task_orchestration_contract=task_orchestration_contract,
+            capability_gate=capability_gate,
+            capability_monitor_fallback=capability_monitor_fallback,
+            work_lane_contract=work_lane_contract,
+            workspace_guard=workspace_guard,
+            automation_prompt_upgrade=automation_prompt_upgrade,
+            automation_prompt_upgrade_required=automation_prompt_upgrade_required,
+            replan_obligation=replan_obligation,
+            replan_decision_allowed=replan_decision_allowed,
         )
-        if capability_monitor_fallback and isinstance(work_lane_contract, dict) and work_lane_contract.get("action"):
-            selected_recommended_action = work_lane_contract["action"]
         due_monitor_attempt = work_lane_contract_is_due_monitor_attempt(work_lane_contract)
-        if capability_gate and not due_monitor_attempt and not capability_monitor_fallback:
-            if capability_gate.get("action") in {"repair_bridge", "ask_owner", "skip"}:
-                selected_recommended_action = (
-                    capability_gate.get("owner_action")
-                    or capability_gate.get("reason")
-                    or selected_recommended_action
-                )
-            else:
-                selected_recommended_action = _selected_action_with_capability_gate(
-                    selected_recommended_action,
-                    capability_gate=capability_gate,
-                )
-        if workspace_guard:
-            selected_recommended_action = (
-                workspace_guard.get("required_action")
-                or workspace_guard.get("reason")
-                or selected_recommended_action
-            )
-        if automation_prompt_upgrade_required:
-            selected_recommended_action = (
-                automation_prompt_upgrade.get("recommended_action")
-                or automation_prompt_upgrade.get("reason")
-                or selected_recommended_action
-            )
-        if replan_decision_allowed:
-            selected_recommended_action = (
-                str(replan_obligation.get("recommended_action") or "").strip()
-                or str(replan_obligation.get("stop_condition") or "").strip()
-                or "Run one bounded autonomous replan slice and write back the selected todo/frontier changes."
-            )
         agent_lane_next_action = None
         if not due_monitor_attempt and not inbox_reply_due and not task_orchestration_contract and not capability_monitor_fallback:
             agent_lane_next_action = build_agent_lane_next_action(

--- a/tests/control_plane/test_quota_recommended_action_refinement.py
+++ b/tests/control_plane/test_quota_recommended_action_refinement.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from loopx.control_plane.quota.decision_summary import (
+    refine_quota_recommended_action,
+)
+
+
+def _refine(selected_action: str = "base action", **overrides: Any) -> Any:
+    values: dict[str, Any] = {
+        "task_orchestration_contract": None,
+        "capability_gate": None,
+        "capability_monitor_fallback": None,
+        "work_lane_contract": None,
+        "workspace_guard": None,
+        "automation_prompt_upgrade": None,
+        "automation_prompt_upgrade_required": False,
+        "replan_obligation": None,
+        "replan_decision_allowed": False,
+    }
+    values.update(overrides)
+    return refine_quota_recommended_action(selected_action, **values)
+
+
+def test_task_orchestration_precedes_base_action() -> None:
+    selected = _refine(
+        task_orchestration_contract={
+            "coordinator_obligation": "coordinate eligible peers",
+        },
+    )
+
+    assert selected == "coordinate eligible peers"
+
+
+def test_capability_monitor_fallback_precedes_task_orchestration() -> None:
+    selected = _refine(
+        task_orchestration_contract={
+            "coordinator_obligation": "coordinate eligible peers",
+        },
+        capability_monitor_fallback={"selected": True},
+        work_lane_contract={"action": "repair monitor metadata"},
+    )
+
+    assert selected == "repair monitor metadata"
+
+
+@pytest.mark.parametrize("action", ["repair_bridge", "ask_owner", "skip"])
+def test_non_run_capability_gate_uses_owner_action(action: str) -> None:
+    selected = _refine(
+        capability_gate={
+            "action": action,
+            "owner_action": f"{action} owner action",
+            "reason": f"{action} reason",
+        },
+    )
+
+    assert selected == f"{action} owner action"
+
+
+def test_due_monitor_attempt_suppresses_capability_gate_override() -> None:
+    selected = _refine(
+        capability_gate={
+            "action": "ask_owner",
+            "owner_action": "ask for capability",
+        },
+        work_lane_contract={
+            "monitor_kind": "todo_monitor_due",
+            "must_attempt_work": True,
+        },
+    )
+
+    assert selected == "base action"
+
+
+def test_run_capability_gate_replaces_a_blocked_selected_action() -> None:
+    selected = _refine(
+        selected_action="blocked task",
+        capability_gate={
+            "action": "run",
+            "blocked_candidates": [{"text": "blocked task"}],
+            "runnable_candidates": [{"text": "runnable task"}],
+        },
+    )
+
+    assert selected == "runnable task"
+
+
+def test_unknown_capability_action_preserves_selected_action() -> None:
+    selected = _refine(
+        capability_gate={
+            "action": "unknown",
+            "blocked_candidates": [{"text": "base action"}],
+            "runnable_candidates": [{"text": "runnable task"}],
+        },
+    )
+
+    assert selected == "base action"
+
+
+def test_workspace_guard_precedes_capability_gate() -> None:
+    selected = _refine(
+        capability_gate={
+            "action": "ask_owner",
+            "owner_action": "ask for capability",
+        },
+        workspace_guard={"required_action": "move to independent worktree"},
+    )
+
+    assert selected == "move to independent worktree"
+
+
+def test_automation_upgrade_precedes_workspace_guard() -> None:
+    selected = _refine(
+        workspace_guard={"required_action": "move to independent worktree"},
+        automation_prompt_upgrade={
+            "recommended_action": "upgrade automation prompt",
+        },
+        automation_prompt_upgrade_required=True,
+    )
+
+    assert selected == "upgrade automation prompt"
+
+
+def test_replan_precedes_other_recommendation_refinements() -> None:
+    selected = _refine(
+        automation_prompt_upgrade={
+            "recommended_action": "upgrade automation prompt",
+        },
+        automation_prompt_upgrade_required=True,
+        replan_obligation={"recommended_action": "replan the frontier"},
+        replan_decision_allowed=True,
+    )
+
+    assert selected == "replan the frontier"


### PR DESCRIPTION
## Summary

- move the ordered quota recommended-action refinement into the existing decision-summary owner
- keep agent-lane frontier resolution separate and delete two single-call compatibility-free helpers
- ratchet `build_quota_should_run` from 316 statements / 221 decision points to 304 / 201

## Design

The helper encodes the existing precedence across task orchestration, capability fallback and gate handling, workspace requirements, automation prompt upgrades, and autonomous replan. It does not combine their underlying domain logic or introduce a generic context object.

## Validation

- 38 focused pytest cases
- 6 selected-action and control-plane smokes
- repository-configured `mypy`
- new-test Ruff check and format check
- `loopx check` public/private boundary scan
- change-quality receipt `cqr_b84274f7705dc19029dd`
- risk-based premerge: 17/17 selected checks passed, no manual holds

The initial premerge invocation used the macOS system Python 3.9 and reproduced an unrelated baseline type-syntax failure in `peer-agent-runtime-v1-smoke.py`. Rerunning with the workspace Python 3.12 passed the standalone smoke and the complete premerge gate.
