### PR TITLE
refactor(quota): canonicalize read model projection

### DIFF
--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -1005,6 +1005,12 @@ def build_quota_plan(status_payload: dict[str, Any], *, mode: str = "status") ->
             "active_state_next_action",
             "active_state_next_action_entries",
             "standing_decision_authority",
+            "long_task_cadence_hint",
+            "stale_latest_run_warning",
+            "backlog_hygiene_warning",
+            "completed_todo_archive_warning",
+            "dreaming_proposal",
+            "dreaming_lane_badge",
         ):
             if optional_field in attention:
                 if optional_field == "handoff_readiness":
@@ -1975,13 +1981,9 @@ def build_quota_should_run(
             if project_asset
             else None,
             "long_task_cadence_hint": (
-                project_asset.get("long_task_cadence_hint")
-                if project_asset and isinstance(project_asset.get("long_task_cadence_hint"), dict)
-                else (
-                    item.get("long_task_cadence_hint")
-                    if isinstance(item.get("long_task_cadence_hint"), dict)
-                    else None
-                )
+                item.get("long_task_cadence_hint")
+                if isinstance(item.get("long_task_cadence_hint"), dict)
+                else None
             ),
             "handoff_readiness": item.get("handoff_readiness"),
             "heartbeat_recommendation": heartbeat_recommendation,
@@ -2146,8 +2148,6 @@ def build_quota_should_run(
         projection_warning = (
             item.get("stale_latest_run_warning")
             if isinstance(item.get("stale_latest_run_warning"), dict)
-            else project_asset.get("stale_latest_run_warning")
-            if isinstance(project_asset.get("stale_latest_run_warning"), dict)
             else None
         )
         if projection_warning:
@@ -2159,8 +2159,6 @@ def build_quota_should_run(
         backlog_warning = (
             item.get("backlog_hygiene_warning")
             if isinstance(item.get("backlog_hygiene_warning"), dict)
-            else project_asset.get("backlog_hygiene_warning")
-            if isinstance(project_asset.get("backlog_hygiene_warning"), dict)
             else None
         )
         if backlog_warning:
@@ -2168,8 +2166,6 @@ def build_quota_should_run(
         archive_warning = (
             item.get("completed_todo_archive_warning")
             if isinstance(item.get("completed_todo_archive_warning"), dict)
-            else project_asset.get("completed_todo_archive_warning")
-            if isinstance(project_asset.get("completed_todo_archive_warning"), dict)
             else None
         )
         if archive_warning:
@@ -2179,8 +2175,6 @@ def build_quota_should_run(
         dreaming_proposal = (
             item.get("dreaming_proposal")
             if isinstance(item.get("dreaming_proposal"), dict)
-            else project_asset.get("dreaming_proposal")
-            if isinstance(project_asset.get("dreaming_proposal"), dict)
             else None
         )
         if dreaming_proposal:
@@ -2188,8 +2182,6 @@ def build_quota_should_run(
         dreaming_lane_badge = (
             item.get("dreaming_lane_badge")
             if isinstance(item.get("dreaming_lane_badge"), dict)
-            else project_asset.get("dreaming_lane_badge")
-            if isinstance(project_asset.get("dreaming_lane_badge"), dict)
             else None
         )
         if dreaming_lane_badge:

--- a/tests/control_plane/test_quota_plan_policy.py
+++ b/tests/control_plane/test_quota_plan_policy.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from loopx.quota import FOCUS_WAIT_REASON, build_quota_plan
+import pytest
+
+from loopx.quota import FOCUS_WAIT_REASON, build_quota_plan, build_quota_should_run
 
 
 def _goal(goal_id: str, *, quota: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -97,6 +99,35 @@ def test_attention_quota_receives_focus_wait_override() -> None:
     assert item["quota"]["reason"] == FOCUS_WAIT_REASON
     assert item["quota"]["blocked_action_scope"] == "delivery_focus"
     assert item["quota"]["focus_wait"] is True
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "long_task_cadence_hint",
+        "stale_latest_run_warning",
+        "backlog_hygiene_warning",
+        "completed_todo_archive_warning",
+        "dreaming_proposal",
+        "dreaming_lane_badge",
+    ],
+)
+def test_quota_plan_keeps_attention_read_models_at_the_top_level(field: str) -> None:
+    goal_id = f"attention-{field}"
+    value = {"source": field}
+    attention = {
+        "goal_id": goal_id,
+        "waiting_on": "codex",
+        "quota": {"state": "eligible"},
+        field: value,
+        "project_asset": {field: {"source": "duplicate"}},
+    }
+
+    payload = _status_payload(goal=_goal(goal_id), attention=attention)
+    _, item = _only_plan_item(payload)
+
+    assert item[field] == value
+    assert build_quota_should_run(payload, goal_id=goal_id)[field] == value
 
 
 def test_goal_quota_projection_is_reused_without_recomputing_state() -> None:


### PR DESCRIPTION
## Summary
- make `build_quota_plan` the single owner for six attention read-model fields
- remove duplicate `project_asset` fallback branches from `build_quota_should_run`
- verify top-level precedence when the duplicate nested value diverges

## Simplification
- production diff: +6/-18
- `build_quota_should_run` decision points: 198 -> 191
- no new helper, compactor, or compatibility alias

## Validation
- focused pytest: 40 passed
- `backlog-hygiene-smoke.py` passed
- `status-markdown-smoke.py` passed
- risk-based premerge: 17/17 selected checks passed, no manual holds
- change-quality receipt: `cqr_08c6d00fbe81c52d0462` (valid)
- mypy/ruff not installed in the active environment; both were non-required and focused pytest plus premerge covered the changed Python surfaces