### PR TITLE
refactor(quota): centralize user todo notifications

### DIFF
--- a/loopx/canary/maintainability_ratchet.py
+++ b/loopx/canary/maintainability_ratchet.py
@@ -55,8 +55,8 @@ _OVERSIZED_DECISION_RETIREMENT_PLANS = {
 
 _OVERSIZED_DECISION_METRIC_CEILINGS = {
     "loopx.quota:build_quota_should_run": {
-        "statements": 302,
-        "decision_points": 198,
+        "statements": 291,
+        "decision_points": 185,
     },
 }
 

--- a/loopx/control_plane/quota/heartbeat_recommendation.py
+++ b/loopx/control_plane/quota/heartbeat_recommendation.py
@@ -14,7 +14,10 @@ from ..work_items.work_lane_context import (
     build_work_lane_context_contract,
     latest_run_progress_scope,
 )
-from ..todos.user_gate import open_todo_count as _open_todo_count
+from ..todos.user_gate import (
+    open_todo_count as _open_todo_count,
+    open_todo_notify_reason,
+)
 
 
 HEARTBEAT_READ_ONLY_MAP_ADAPTER_SUFFIX = "_read_only_map_v0"
@@ -40,16 +43,6 @@ HEARTBEAT_POST_HANDOFF_RUN_COMPACT_FIELDS = (
     "json_exists",
     "markdown_exists",
 )
-
-
-def open_todo_notify_reason(*, state: str, waiting_on: str) -> str:
-    if state == "focus_wait":
-        return "open user todo can unblock focus_wait after owner evidence, external eval, or a clean baseline changes"
-    if waiting_on == "external_evidence":
-        return "open user todo can provide or defer the external-evidence checkpoint"
-    if waiting_on in {"user_or_controller", "controller"}:
-        return "open user todo can resolve the user/controller blocker"
-    return "open user todo can resolve the current waiting lane"
 
 
 def _supports_read_only_project_map(adapter_kind: Any) -> bool:

--- a/loopx/control_plane/todos/user_gate.py
+++ b/loopx/control_plane/todos/user_gate.py
@@ -96,6 +96,55 @@ def should_notify_user_on_open_todo(
     return waiting_on in {"user_or_controller", "controller", "external_evidence"}
 
 
+def open_todo_notify_reason(*, state: str, waiting_on: str) -> str:
+    if state == "focus_wait":
+        return "open user todo can unblock focus_wait after owner evidence, external eval, or a clean baseline changes"
+    if waiting_on == "external_evidence":
+        return "open user todo can provide or defer the external-evidence checkpoint"
+    if waiting_on in {"user_or_controller", "controller"}:
+        return "open user todo can resolve the user/controller blocker"
+    return "open user todo can resolve the current waiting lane"
+
+
+def build_user_todo_notification(
+    summary: dict[str, Any] | None,
+    *,
+    state: str,
+    waiting_on: str,
+    repeat_notification_required: bool = False,
+    repeat_notification_reason: Any = None,
+) -> dict[str, Any]:
+    if not isinstance(summary, dict):
+        return {}
+    if has_open_user_gate_todo(summary):
+        return {
+            "notify_user_on_gate": True,
+            "open_todo_notify_reason": user_gate_todo_notify_reason(summary),
+            "open_todo_notification_policy": "repeat_until_resolved",
+        }
+    if not repeat_notification_required and not should_notify_user_on_open_todo(
+        state=state,
+        waiting_on=waiting_on,
+        user_todo_summary=summary,
+    ):
+        return {}
+    reason = open_todo_notify_reason(state=state, waiting_on=waiting_on)
+    if repeat_notification_required:
+        reason = (
+            repeat_notification_reason
+            or "no-work polling should ask the current open user todo"
+        )
+    return {
+        "notify_user_on_open_todo": True,
+        "open_todo_notify_reason": reason,
+        **(
+            {"open_todo_notification_policy": "repeat_until_resolved"}
+            if repeat_notification_required
+            else {}
+        ),
+    }
+
+
 def build_gate_prompt(
     item: dict[str, Any],
     *,

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -48,7 +48,6 @@ from .control_plane.quota.heartbeat_recommendation import (
     HEARTBEAT_HANDOFF_READINESS_COMPACT_FIELDS as HANDOFF_READINESS_COMPACT_FIELDS,
     HEARTBEAT_POST_HANDOFF_RUN_COMPACT_FIELDS as POST_HANDOFF_RUN_COMPACT_FIELDS,
     build_heartbeat_recommendation,
-    open_todo_notify_reason,
     refine_heartbeat_recommendation,
 )
 from .control_plane.quota.projection_repair import (
@@ -175,10 +174,8 @@ from .control_plane.todos.quota_summary import (
 )
 from .control_plane.todos.user_gate import (
     build_gate_prompt as _build_gate_prompt,
-    has_open_user_gate_todo as _has_open_user_gate_todo,
+    build_user_todo_notification as _build_user_todo_notification,
     open_todo_count as _open_todo_count,
-    should_notify_user_on_open_todo as _should_notify_user_on_open_todo,
-    user_gate_todo_notify_reason as _user_gate_todo_notify_reason,
 )
 from .control_plane.todos.write_hint import build_todo_write_hint
 
@@ -2061,32 +2058,18 @@ def build_quota_should_run(
             payload["missing_gates"] = item.get("missing_gates")
         if user_todo_summary:
             payload["user_todo_summary"] = compact_quota_todo_summary_for_payload(user_todo_summary)
-            repeat_open_todo_notification = (
-                heartbeat_recommendation.get("repeat_notification_required") is True
-            )
-            user_gate_todo_open = _has_open_user_gate_todo(user_todo_summary)
-            if user_gate_todo_open:
-                payload["notify_user_on_gate"] = True
-                payload["open_todo_notify_reason"] = _user_gate_todo_notify_reason(
-                    user_todo_summary
-                )
-                payload["open_todo_notification_policy"] = "repeat_until_resolved"
-            elif _should_notify_user_on_open_todo(
-                state=state,
-                waiting_on=str(item.get("waiting_on") or ""),
-                user_todo_summary=user_todo_summary,
-            ) or repeat_open_todo_notification:
-                payload["notify_user_on_open_todo"] = True
-                payload["open_todo_notify_reason"] = open_todo_notify_reason(
+            payload.update(
+                _build_user_todo_notification(
+                    user_todo_summary,
                     state=state,
                     waiting_on=str(item.get("waiting_on") or ""),
+                    repeat_notification_required=(
+                        heartbeat_recommendation.get("repeat_notification_required")
+                        is True
+                    ),
+                    repeat_notification_reason=heartbeat_recommendation.get("reason"),
                 )
-                if repeat_open_todo_notification:
-                    payload["open_todo_notify_reason"] = (
-                        heartbeat_recommendation.get("reason")
-                        or "no-work polling should ask the current open user todo"
-                    )
-                    payload["open_todo_notification_policy"] = "repeat_until_resolved"
+            )
         if scoped_user_gate_fallback and not replan_decision_allowed:
             payload["scoped_user_gate_fallback"] = scoped_user_gate_fallback
             payload["should_run"] = True

--- a/tests/control_plane/test_user_todo_notification.py
+++ b/tests/control_plane/test_user_todo_notification.py
@@ -1,0 +1,62 @@
+from loopx.control_plane.todos.user_gate import build_user_todo_notification
+
+
+def test_user_gate_notification_repeats_until_resolved() -> None:
+    summary = {
+        "open_count": 1,
+        "gate_open_items": [
+            {
+                "todo_id": "todo_gate",
+                "task_class": "user_gate",
+                "action_kind": "approve_release",
+            }
+        ],
+    }
+
+    assert build_user_todo_notification(
+        summary,
+        state="operator_gate",
+        waiting_on="controller",
+    ) == {
+        "notify_user_on_gate": True,
+        "open_todo_notify_reason": (
+            "open user_gate todo requires owner decision before approve_release"
+        ),
+        "open_todo_notification_policy": "repeat_until_resolved",
+    }
+
+
+def test_waiting_user_todo_notification_does_not_force_repeat_policy() -> None:
+    assert build_user_todo_notification(
+        {"open_count": 1},
+        state="waiting",
+        waiting_on="controller",
+    ) == {
+        "notify_user_on_open_todo": True,
+        "open_todo_notify_reason": "open user todo can resolve the user/controller blocker",
+    }
+
+
+def test_heartbeat_repeat_reason_owns_repeat_notification_policy() -> None:
+    assert build_user_todo_notification(
+        {"open_count": 1},
+        state="eligible",
+        waiting_on="",
+        repeat_notification_required=True,
+        repeat_notification_reason="repeat this owner action",
+    ) == {
+        "notify_user_on_open_todo": True,
+        "open_todo_notify_reason": "repeat this owner action",
+        "open_todo_notification_policy": "repeat_until_resolved",
+    }
+
+
+def test_closed_user_todo_summary_has_no_notification() -> None:
+    assert (
+        build_user_todo_notification(
+            {"open_count": 0},
+            state="waiting",
+            waiting_on="",
+        )
+        == {}
+    )


### PR DESCRIPTION
## Summary

- centralize open user-todo notification policy in the existing user-gate owner
- make the quota facade consume one notification projection instead of assembling gate, waiting, and repeat branches itself
- tighten the `build_quota_should_run` ratchet from 302 statements / 198 decisions to 291 statements / 185 decisions

## Simplification

This is a distinct post-#2637 slice: it does not revisit facade exports or payload source precedence. It removes 11 statements and 6 decisions from `build_quota_should_run`, gives notification reasons and repeat policy one owner, and avoids a generic compactor or compatibility wrapper.

## Validation

- 50 focused pytest cases passed
- `todo-user-gate-readmodel-smoke.py` passed
- `quota-plan-smoke.py` passed
- `protocol-action-packet-smoke.py` passed
- `blocker-push-runtime-smoke.py` passed
- premerge selected 17/17 catalog and risk-profile checks; no failures, warnings, or manual holds
- exact change-quality receipt `cqr_7ec515054c5af80d7c4e` is valid
- Ruff and mypy were unavailable in the current environment and were recorded as non-required skips
