### PR TITLE
fix(skillsbench): close validation-failed turns

### DIFF
--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -12058,15 +12058,27 @@ def _loopx_turn_terminal_failure_checkpoint(
         return None
     receipt = latest.get("receipt")
     receipt = receipt if isinstance(receipt, Mapping) else {}
+    validation = latest.get("validation")
+    validation = validation if isinstance(validation, Mapping) else {}
+    result_kind = receipt.get("result_kind") or latest.get("result_kind")
+    failed_phase = receipt.get("failed_phase")
     terminal_failure = bool(
         latest.get("status") in {"failed", "validation_failed"}
         or receipt.get("status") == "failed"
-        or receipt.get("failed_phase")
+        or failed_phase
+    )
+    validation_terminal_failure = bool(
+        failed_phase == "validation"
+        or result_kind == "validation_failed"
+        or validation.get("status") == "failed"
     )
     if (
         not terminal_failure
         or loopx_turn_execution_has_durable_effects(latest)
-        or trace.get("host_local_acp_codex_exec_failure_trace_present") is not True
+        or (
+            trace.get("host_local_acp_codex_exec_failure_trace_present") is not True
+            and not validation_terminal_failure
+        )
     ):
         return None
 
@@ -12080,15 +12092,20 @@ def _loopx_turn_terminal_failure_checkpoint(
         "schema_version": "skillsbench_loopx_turn_terminal_failure_checkpoint_v0",
         "status": safe_label(latest.get("status"), default="failed"),
         "result_kind": safe_label(
-            receipt.get("result_kind") or latest.get("result_kind"),
+            result_kind,
             default="unknown",
         ),
         "failed_phase": safe_label(
-            receipt.get("failed_phase"),
+            failed_phase,
             default="unknown",
         ),
         "failure_category": safe_label(
-            trace.get("host_local_acp_codex_exec_failure_category"),
+            trace.get("host_local_acp_codex_exec_failure_category")
+            or (
+                "loopx_turn_validation_failed"
+                if validation_terminal_failure
+                else None
+            ),
             default="unknown",
         ),
         "durable_effects_observed": False,

--- a/scripts/skillsbench_reverse_tunnel_supervisor.py
+++ b/scripts/skillsbench_reverse_tunnel_supervisor.py
@@ -37,6 +37,7 @@ from loopx.benchmark_core.remote_closeout import (  # noqa: E402
     closeout_remote_benchmark_batch,
 )
 from loopx.benchmark_core.lifecycle import (  # noqa: E402
+    build_benchmark_live_worker_phase,
     compact_benchmark_live_worker_phase,
 )
 
@@ -1042,6 +1043,27 @@ def _write_public_checkpoint(
 ) -> None:
     now = time.time() if observed_at is None else observed_at
     payload["duration_sec"] = round(max(0.0, now - started_at), 3)
+    if terminal:
+        active_phase = payload.get("active_phase")
+        active_phase = active_phase if isinstance(active_phase, dict) else {}
+        live_worker_phase = compact_benchmark_live_worker_phase(
+            active_phase.get("benchmark_live_worker_phase")
+        )
+        phase_ready = live_worker_phase.get("phase_ready")
+        if live_worker_phase and isinstance(phase_ready, dict):
+            terminal_disposition = {
+                "succeeded": "completed",
+                "failed": "failed",
+            }.get(state, "ended_unresolved")
+            active_phase["benchmark_live_worker_phase"] = (
+                build_benchmark_live_worker_phase(
+                    runtime_preparing=phase_ready.get("runtime_preparing") is True,
+                    worker_prepared=phase_ready.get("worker_prepared") is True,
+                    worker_running=phase_ready.get("worker_running") is True,
+                    agent_active=phase_ready.get("agent_active") is True,
+                    terminal_disposition=terminal_disposition,
+                )
+            )
     payload["public_liveness"] = {
         "schema_version": PUBLIC_LIVENESS_SCHEMA_VERSION,
         "state": state,

--- a/tests/test_skillsbench_automation_loop_timeouts.py
+++ b/tests/test_skillsbench_automation_loop_timeouts.py
@@ -184,6 +184,7 @@ def _terminal_turn_plan(
     *,
     committed: bool = False,
     process_failure: bool = True,
+    failed_phase: str = "host_execute",
 ):
     boundary = {
         "raw_command_recorded": False,
@@ -225,17 +226,31 @@ def _terminal_turn_plan(
                     "schema_version": "loopx_turn_execution_v0",
                     "status": "committed" if committed else "failed",
                     "result_kind": (
-                        "validated_completion" if committed else "repair_required"
+                        "validated_completion"
+                        if committed
+                        else "validation_failed"
+                        if failed_phase == "validation"
+                        else "repair_required"
                     ),
                     "validation": {
-                        "status": "passed" if committed else "not_attempted"
+                        "status": (
+                            "passed"
+                            if committed
+                            else "failed"
+                            if failed_phase == "validation"
+                            else "not_attempted"
+                        )
                     },
                     "receipt": {
                         "status": "committed" if committed else "failed",
                         "result_kind": (
-                            "validated_completion" if committed else "repair_required"
+                            "validated_completion"
+                            if committed
+                            else "validation_failed"
+                            if failed_phase == "validation"
+                            else "repair_required"
                         ),
-                        "failed_phase": "" if committed else "host_execute",
+                        "failed_phase": "" if committed else failed_phase,
                     },
                     "effects": {
                         "host_invoked": True,
@@ -245,7 +260,13 @@ def _terminal_turn_plan(
                     },
                 },
                 "scored_workspace_validation": {
-                    "status": "passed" if committed else "not_attempted",
+                    "status": (
+                        "passed"
+                        if committed
+                        else "failed"
+                        if failed_phase == "validation"
+                        else "not_attempted"
+                    ),
                     "independent": True,
                 },
                 "boundary": boundary,
@@ -297,11 +318,37 @@ def test_loopx_turn_terminal_failure_checkpoint_waits_without_process_failure(
     assert _loopx_turn_terminal_failure_checkpoint(plan) is None
 
 
+def test_loopx_turn_terminal_failure_checkpoint_closes_validation_failure(
+    tmp_path,
+) -> None:
+    plan = _terminal_turn_plan(
+        tmp_path,
+        process_failure=False,
+        failed_phase="validation",
+    )
+
+    checkpoint = _loopx_turn_terminal_failure_checkpoint(plan)
+
+    assert checkpoint == {
+        "schema_version": "skillsbench_loopx_turn_terminal_failure_checkpoint_v0",
+        "status": "failed",
+        "result_kind": "validation_failed",
+        "failed_phase": "validation",
+        "failure_category": "loopx_turn_validation_failed",
+        "durable_effects_observed": False,
+        "raw_material_recorded": False,
+    }
+
+
 def test_loopx_turn_terminal_failure_watchdog_cancels_stranded_benchflow(
     tmp_path,
     monkeypatch,
 ) -> None:
-    plan = _terminal_turn_plan(tmp_path)
+    plan = _terminal_turn_plan(
+        tmp_path,
+        process_failure=False,
+        failed_phase="validation",
+    )
     cleanup_calls = []
 
     def fake_cleanup(plan_arg):
@@ -345,7 +392,7 @@ def test_loopx_turn_terminal_failure_watchdog_cancels_stranded_benchflow(
     assert public["benchflow_loopx_turn_terminal_failure_triggered"] is True
     assert public["benchflow_loopx_turn_terminal_failure_grace_sec"] == 0
     assert public["benchflow_loopx_turn_terminal_failure_category"] == (
-        "codex_exec_bridge_idle_timeout"
+        "loopx_turn_validation_failed"
     )
     assert cleanup_calls == [plan["job_name"]]
 

--- a/tests/test_skillsbench_reverse_tunnel_supervisor.py
+++ b/tests/test_skillsbench_reverse_tunnel_supervisor.py
@@ -280,6 +280,53 @@ def test_supervisor_projects_existing_public_live_worker_phase(
     assert str(tmp_path) not in serialized
 
 
+def test_terminal_checkpoint_closes_projected_live_worker_phase(
+    tmp_path: Path,
+) -> None:
+    supervisor = _load_supervisor_module()
+    public_output = tmp_path / "public" / "supervisor.public.json"
+    payload = {
+        "active_phase": {
+            "schema_version": "skillsbench_supervisor_active_phase_v0",
+            "state": "observed",
+            "benchmark_live_worker_phase": {
+                "schema_version": "benchmark_live_worker_phase_v0",
+                "current_phase": "agent_active",
+                "next_required_phase": "",
+                "phase_ready": {
+                    "runtime_preparing": True,
+                    "worker_prepared": True,
+                    "worker_running": True,
+                    "agent_active": True,
+                },
+                "worker_live": True,
+                "agent_active_observed": True,
+                "terminal": False,
+                "terminal_disposition": "open",
+                "public_evidence_only": True,
+            },
+        }
+    }
+
+    supervisor._write_public_checkpoint(
+        str(public_output),
+        payload,
+        state="failed",
+        started_at=time.time() - 10,
+        heartbeat_count=3,
+        terminal=True,
+    )
+
+    persisted = json.loads(public_output.read_text(encoding="utf-8"))
+    phase = persisted["active_phase"]["benchmark_live_worker_phase"]
+    assert persisted["public_liveness"]["terminal"] is True
+    assert phase["current_phase"] == "agent_active"
+    assert phase["agent_active_observed"] is True
+    assert phase["worker_live"] is False
+    assert phase["terminal"] is True
+    assert phase["terminal_disposition"] == "failed"
+
+
 def test_supervisor_finalizes_public_liveness_on_early_launch_failure(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- Close a stranded SkillsBench BenchFlow task when its latest LoopX Turn has a terminal validation failure, even without a separate host process-failure trace.
- Terminalize the projected benchmark live-worker phase whenever the reverse-tunnel supervisor writes a terminal checkpoint.
- Add focused regression coverage for validation-failure closeout and terminal phase truth.

## Validation
- Focused timeout and reverse-tunnel supervisor tests: 27 passed.
- Reverse-tunnel supervisor smoke: passed.
- Post-run debug gate smoke: passed.
- Python compile checks: passed on all changed Python files.
- LoopX premerge canary: all direct checks and four selected catalog canaries passed; expected benchmark-sensitive manual hold remains.
- Public/private boundary scan reviewed; no private state, raw benchmark evidence, credentials, local paths, or generated logs added.

## Self-merge authorization
The owner has standing authorization for benchmark helper/runtime self-merge after validation. This change does not alter scoring, task semantics, leaderboard or submission behavior, permission boundaries, or launch benchmark jobs.