### PR TITLE
Fix SkillsBench typed plan-repair closeout

### DIFF
--- a/loopx/benchmarks/read_models/skillsbench_post_run_debug.py
+++ b/loopx/benchmarks/read_models/skillsbench_post_run_debug.py
@@ -15,6 +15,7 @@ from ...control_plane.runtime.public_safety import (
 from ...control_plane.turn_driver.transaction import (
     loopx_turn_execution_committed,
     loopx_turn_execution_has_durable_effects,
+    loopx_turn_execution_recovery_required,
 )
 from ...benchmark_adapters.skillsbench_acp_failure_policy import (
     nonrecoverable_codex_turn_failure_category,
@@ -57,6 +58,7 @@ def _skillsbench_turn_transaction_outcome(run: dict[str, Any]) -> dict[str, Any]
 
     committed_count = 0
     validation_failed_count = 0
+    recovery_required_count = 0
     repair_required_count = 0
     replan_required_count = 0
     state_written_count = 0
@@ -92,17 +94,22 @@ def _skillsbench_turn_transaction_outcome(run: dict[str, Any]) -> dict[str, Any]
             and receipt.get("failed_phase") == "host_execute"
         )
         recovery_kind = public_safe_compact_text(
-            validation.get("recovery_kind"),
+            validation.get("recovery_kind")
+            or receipt.get("result_kind")
+            or execution.get("result_kind"),
             limit=80,
         )
+        recovery_required = loopx_turn_execution_recovery_required(execution)
         committed_count += int(committed)
         validation_failed_count += int(validation_failed)
+        recovery_required_count += int(recovery_required)
         repair_required_count += int(recovery_kind == "repair_required")
         replan_required_count += int(recovery_kind == "replan_required")
         state_written_count += int(state_written)
         quota_spent_count += int(quota_spent)
         failed_transaction_with_durable_effect_count += int(
-            validation_failed and loopx_turn_execution_has_durable_effects(execution)
+            (validation_failed or recovery_required)
+            and loopx_turn_execution_has_durable_effects(execution)
         )
         host_failure_count += int(host_failure)
 
@@ -120,7 +127,7 @@ def _skillsbench_turn_transaction_outcome(run: dict[str, Any]) -> dict[str, Any]
         limit=120,
     )
     typed_repair_exhausted = bool(
-        validation_failed_count > 0
+        recovery_required_count > 0
         and committed_count < execution_count
         and failed_transaction_with_durable_effect_count == 0
         # Committed prefixes own their effects; later uncommitted Turns must not.
@@ -163,9 +170,14 @@ def _skillsbench_turn_transaction_outcome(run: dict[str, Any]) -> dict[str, Any]
         causal_consistency = "committed_effects_observed"
         first_blocker = "none"
     elif typed_repair_exhausted:
-        status = "validation_failed_typed_repair_exhausted"
-        causal_consistency = "validation_failure_effects_not_committed"
-        first_blocker = "loopx_turn_validation_failed"
+        if validation_failed_count:
+            status = "validation_failed_typed_repair_exhausted"
+            causal_consistency = "validation_failure_effects_not_committed"
+            first_blocker = "loopx_turn_validation_failed"
+        else:
+            status = "recovery_required_typed_repair_exhausted"
+            causal_consistency = "recovery_required_effects_not_committed"
+            first_blocker = "loopx_turn_repair_required"
     elif validation_failed_count:
         status = "validation_failed"
         causal_consistency = "validation_failure_effects_not_committed"
@@ -213,6 +225,7 @@ def _skillsbench_turn_transaction_outcome(run: dict[str, Any]) -> dict[str, Any]
         "committed_count": committed_count,
         "uncommitted_count": execution_count - committed_count,
         "validation_failed_count": validation_failed_count,
+        "recovery_required_count": recovery_required_count,
         "repair_required_count": repair_required_count,
         "replan_required_count": replan_required_count,
         "state_written_count": state_written_count,

--- a/tests/benchmarks/read_models/test_skillsbench_post_run_debug.py
+++ b/tests/benchmarks/read_models/test_skillsbench_post_run_debug.py
@@ -94,6 +94,46 @@ def _typed_repair_exhausted_compact() -> dict[str, object]:
     }
 
 
+def _turn_plan_repair_exhausted_compact() -> dict[str, object]:
+    compact = _typed_repair_exhausted_compact()
+    executions = compact["loopx_turn_executions"]
+    assert isinstance(executions, list)
+    executions[:] = [
+        {
+            "schema_version": "loopx_turn_execution_v0",
+            "mode": "run_once",
+            "status": "committed",
+            "result_kind": "validated_progress",
+            "validation": {"status": "passed"},
+            "receipt": {"status": "committed"},
+            "effects": {
+                "host_invoked": True,
+                "state_written": True,
+                "quota_spent": True,
+                "scheduler_acknowledged": False,
+            },
+        },
+        {
+            "schema_version": "loopx_turn_execution_v0",
+            "mode": "run_once",
+            "status": "failed",
+            "result_kind": "repair_required",
+            "receipt": {
+                "status": "failed",
+                "result_kind": "repair_required",
+                "failed_phase": "turn_plan",
+            },
+            "effects": {
+                "host_invoked": False,
+                "state_written": False,
+                "quota_spent": False,
+                "scheduler_acknowledged": False,
+            },
+        },
+    ]
+    return compact
+
+
 def test_status_preserves_skillsbench_post_run_debug_import() -> None:
     assert (
         status.build_skillsbench_post_run_debug_gate
@@ -231,6 +271,47 @@ def test_committed_prefix_does_not_hide_effect_free_typed_repair_exhaustion() ->
     assert transaction["next_case_blocked"] is False
     assert gate["next_case_gate"] == "open_with_exclusion"
     assert gate["normal_progress_allowed"] is True
+
+
+def test_effect_free_turn_plan_repair_exhaustion_opens_rotation() -> None:
+    gate = build_skillsbench_post_run_debug_gate(
+        _turn_plan_repair_exhausted_compact()
+    )
+
+    transaction = gate["loopx_turn_transaction"]
+    assert transaction["status"] == "recovery_required_typed_repair_exhausted"
+    assert transaction["validation_failed_count"] == 0
+    assert transaction["recovery_required_count"] == 1
+    assert transaction["repair_required_count"] == 1
+    assert transaction["typed_repair_exhausted"] is True
+    assert transaction["case_exclusion_required"] is True
+    assert transaction["first_blocker"] == "loopx_turn_repair_required"
+    assert transaction["next_case_blocked"] is False
+    assert gate["next_case_gate"] == "open_with_exclusion"
+    assert gate["normal_progress_allowed"] is True
+
+
+def test_turn_plan_repair_with_durable_effects_keeps_rotation_blocked() -> None:
+    compact = _turn_plan_repair_exhausted_compact()
+    executions = compact["loopx_turn_executions"]
+    assert isinstance(executions, list)
+    failed_execution = executions[-1]
+    assert isinstance(failed_execution, dict)
+    effects = failed_execution["effects"]
+    assert isinstance(effects, dict)
+    effects["state_written"] = True
+
+    gate = build_skillsbench_post_run_debug_gate(compact)
+
+    transaction = gate["loopx_turn_transaction"]
+    assert transaction["status"] == (
+        "inconsistent_failed_transaction_has_durable_effects"
+    )
+    assert transaction["failed_transaction_with_durable_effect_count"] == 1
+    assert transaction["typed_repair_exhausted"] is False
+    assert transaction["next_case_blocked"] is True
+    assert gate["next_case_gate"] == "blocked_turn_transaction_repair"
+    assert gate["normal_progress_allowed"] is False
 
 
 def test_unrecognized_typed_repair_terminal_reason_keeps_rotation_blocked() -> None:


### PR DESCRIPTION
## Summary
- classify effect-free turn-plan repair receipts with the shared Turn recovery contract
- preserve safety by blocking repair failures that wrote state or spent quota
- open case rotation with an explicit infrastructure exclusion after the bounded typed-repair policy is exhausted

## Validation
- 65 focused pytest tests passed
- skillsbench post-run debug gate smoke passed
- skillsbench typed-repair smoke passed
- Python compile passed
- exact reserve20 public compact re-reduced to packet_complete=true, next_case_gate=open_with_exclusion
- premerge canary: all direct checks and 6 selected canaries passed; benchmark_sensitive manual hold acknowledged under standing owner authorization
- public/private boundary scan clean

## Scope
This changes public benchmark closeout/read-model routing only. It does not change task semantics, scoring, leaderboard behavior, permissions, launch benchmark jobs, or include private evidence.