### PR TITLE
feat(finance): add unified gate, attribution, and metric-pack replay

### DIFF
--- a/packages/loopx-finance-value-discovery/CONTRACT.md
+++ b/packages/loopx-finance-value-discovery/CONTRACT.md
@@ -1,0 +1,64 @@
+# Unified Finance Gate Contract
+
+`finance_case_contract_v1` is the common, provider-neutral contract for
+research cases evaluated by this extension. It does not collect market data or
+calculate a finance metric. Collectors and metric providers produce frozen
+typed observations; the gate engine compares those values with contract-owned
+rules and thresholds.
+
+## Ownership
+
+| Surface | Owner | Responsibility |
+| --- | --- | --- |
+| Contract | Finance extension | Revision, cutoff, frozen identities and thresholds, gate order, safety boundaries |
+| Observation | Collector or metric provider | Public evidence references and a typed value, missing marker, or conflict marker |
+| Gate engine | Finance extension | Typed comparison, deterministic short-circuiting, and disposition |
+| Replay harness | Finance extension | Canonical hashes and byte-identical re-evaluation |
+| Revision promotion | Human owner | Approval after historical, walk-forward, and shadow review |
+
+The contract is intentionally smaller than any individual method. A de-beta,
+quality, valuation, or market-regime method may choose different gate ids, but
+all must use the same typed comparisons and transition rules. Boolean and
+string gates support equality. Numeric gates support equality and ordered
+comparisons. Providers cannot declare their own pass or fail result.
+
+## Gate States
+
+| Result state | Meaning | Disposition |
+| --- | --- | --- |
+| `passed` | Evidence satisfies the frozen gate | Continue |
+| `failed` | Evidence falsifies the frozen gate | `rejected` |
+| `missing` | Required evidence is absent | `insufficient_evidence` |
+| `conflict` | Valid evidence disagrees | `insufficient_evidence` |
+| `not_run` | An earlier gate already blocked evaluation | No new conclusion |
+
+Observations must exactly match the ordered `gates` list. An `observed` value is
+typed and compared with the frozen rule to produce `passed` or `failed`.
+Providers may instead report `missing` or `conflict`. The first `failed`,
+`missing`, or `conflict` result blocks the case, and every later observation
+must be `not_run`.
+Running a later gate after a blocker is rejected as an invalid input rather
+than silently accepted.
+
+Passing every gate means only `eligible_for_research_successor`. It never means
+method promotion, investment advice, or permission to trade.
+
+## Replay
+
+The replay receipt binds three SHA-256 values:
+
+- the normalized contract;
+- the complete input, including evidence references;
+- the evaluation before the receipt is attached.
+
+Canonicalization uses compact ASCII JSON with sorted keys. Replay recomputes
+the evaluation and requires matching hashes plus byte-identical canonical
+output. Changing a threshold, cutoff, observation, reason, or result fails
+closed.
+
+## Compatibility
+
+The existing `finance_value_discovery_input_v0` reducer and
+`finance_value_discovery_extension_v0` provider protocol remain supported.
+`finance_case_gate_input_v1` is an additive input schema. Existing packets are
+not reclassified and gain no new fields.

--- a/packages/loopx-finance-value-discovery/CONTRACT.md
+++ b/packages/loopx-finance-value-discovery/CONTRACT.md
@@ -22,6 +22,21 @@ all must use the same typed comparisons and transition rules. Boolean and
 string gates support equality. Numeric gates support equality and ordered
 comparisons. Providers cannot declare their own pass or fail result.
 
+## Attribution And Industry Overlays
+
+Layered beta attribution is deterministic arithmetic over caller-supplied,
+point-in-time observations. The explained order is frozen as market, rate,
+sector, narrow peer, cycle, and event. Residual is computed as total move minus
+all six explained components only when every component is observed. Attribution
+does not estimate a factor, select a source, or execute a gate.
+
+Industry metric packs are semantic overlays on the same case contract. A pack
+may require metric ids, value types, and allowed operator directions. It cannot
+provide a threshold, reorder common source or cutoff gates, reinterpret missing
+or conflicting evidence, or alter promotion authority. Thresholds remain
+inside the frozen case contract, and observations still pass through the common
+gate engine.
+
 ## Gate States
 
 | Result state | Meaning | Disposition |

--- a/packages/loopx-finance-value-discovery/CONTRACT.md
+++ b/packages/loopx-finance-value-discovery/CONTRACT.md
@@ -30,6 +30,14 @@ sector, narrow peer, cycle, and event. Residual is computed as total move minus
 all six explained components only when every component is observed. Attribution
 does not estimate a factor, select a source, or execute a gate.
 
+An attribution is bound to one gated case identity. The gate input carries the
+`case_id` and `subject_ref` of the case it evaluates, and the attribution's
+`case_reference` must match both. A passing gate therefore cannot be reused to
+present an attribution for a different case or a different security as
+research-complete. The `observation_window` must be real ISO-8601 dates that sit
+inside the contract's frozen `[point_in_time, evaluation_as_of]` window, so a
+malformed or future window cannot be presented as complete.
+
 Industry metric packs are semantic overlays on the same case contract. A pack
 may require metric ids, value types, and allowed operator directions. It cannot
 provide a threshold, reorder common source or cutoff gates, reinterpret missing
@@ -75,5 +83,7 @@ closed.
 
 The existing `finance_value_discovery_input_v0` reducer and
 `finance_value_discovery_extension_v0` provider protocol remain supported.
-`finance_case_gate_input_v1` is an additive input schema. Existing packets are
-not reclassified and gain no new fields.
+`finance_case_gate_input_v1` now requires a `subject_ref` naming the case
+subject, so a gate input packet must declare the subject it evaluates; this
+binds the case identity end to end. The `finance_value_discovery_input_v0`
+packets are not reclassified and gain no new fields.

--- a/packages/loopx-finance-value-discovery/CONTRACT.md
+++ b/packages/loopx-finance-value-discovery/CONTRACT.md
@@ -28,7 +28,9 @@ Layered beta attribution is deterministic arithmetic over caller-supplied,
 point-in-time observations. The explained order is frozen as market, rate,
 sector, narrow peer, cycle, and event. Residual is computed as total move minus
 all six explained components only when every component is observed. Attribution
-does not estimate a factor, select a source, or execute a gate.
+does not estimate a factor or select a source. It does execute the bound gate
+input and requires the observation window to satisfy the contract cutoff before
+it can report a complete result.
 
 An attribution is bound to one gated case identity. The gate input carries the
 `case_id` and `subject_ref` of the case it evaluates, and the attribution's

--- a/packages/loopx-finance-value-discovery/CONTRACT.md
+++ b/packages/loopx-finance-value-discovery/CONTRACT.md
@@ -27,10 +27,14 @@ comparisons. Providers cannot declare their own pass or fail result.
 Layered beta attribution is deterministic arithmetic over caller-supplied,
 point-in-time observations. The explained order is frozen as market, rate,
 sector, narrow peer, cycle, and event. Residual is computed as total move minus
-all six explained components only when every component is observed. Attribution
-does not estimate a factor or select a source. It does execute the bound gate
-input and requires the observation window to satisfy the contract cutoff before
-it can report a complete result.
+all six explained components only when every component is observed. The
+`de_beta_residual` gate must use that computed value; an independent or
+contradictory residual observation is rejected. Attribution does not estimate a
+factor or select a source. It does execute the bound gate input and requires the
+observation window to satisfy the contract cutoff before it can report a
+complete result. Top-level `disposition` preserves the gate decision, including
+`rejected`, while `completeness` independently reports whether the gate evidence
+and all six components are complete.
 
 An attribution is bound to one gated case identity. The gate input carries the
 `case_id` and `subject_ref` of the case it evaluates, and the attribution's
@@ -43,7 +47,10 @@ malformed or future window cannot be presented as complete.
 Industry metric packs are semantic overlays on the same case contract. A pack
 may require metric ids, value types, and allowed operator directions. It cannot
 provide a threshold, reorder common source or cutoff gates, reinterpret missing
-or conflicting evidence, or alter promotion authority. Thresholds remain
+or conflicting evidence, or alter promotion authority. The required
+`source_lineage` and `point_in_time` gates are provider-neutral
+`boolean eq true` authority gates; a pack input cannot preserve their ids while
+changing their type, operator, or reference semantics. Metric thresholds remain
 inside the frozen case contract, and observations still pass through the common
 gate engine.
 

--- a/packages/loopx-finance-value-discovery/README.md
+++ b/packages/loopx-finance-value-discovery/README.md
@@ -20,6 +20,13 @@ emits `finance_value_discovery_packet_v0`. It performs no network request. A
 separate collector may prepare public evidence cards, but connector output is
 input evidence, not accepted truth.
 
+The additive [`finance_case_contract_v1`](CONTRACT.md) surface separates a
+method's frozen contract from provider observations. Its deterministic gate
+engine stops at the first failed, missing, or conflicting gate. The replay
+harness binds the contract, input, and result with canonical SHA-256 receipts.
+Passing every gate means only that a case is eligible for a bounded research
+successor; it cannot promote a revision, advise, or trade.
+
 The packet enforces:
 
 - a cross-sectional screen before a named candidate is selected;
@@ -92,6 +99,25 @@ loopx extension run loopx-finance-value-discovery \
   --input-json packages/loopx-finance-value-discovery/examples/paypal-debeta-discovery.json \
   --execute \
   --format json
+```
+
+The same managed entrypoint accepts a `finance_case_gate_input_v1` object:
+
+```bash
+loopx extension run loopx-finance-value-discovery \
+  --input-json packages/loopx-finance-value-discovery/examples/finance-case-gates-v1.json \
+  --execute \
+  --format json
+```
+
+Developers can inspect or replay a frozen evaluation directly:
+
+```bash
+loopx-finance-value-discovery evaluate \
+  --input-json packages/loopx-finance-value-discovery/examples/finance-case-gates-v1.json
+loopx-finance-value-discovery replay \
+  --input-json packages/loopx-finance-value-discovery/examples/finance-case-gates-v1.json \
+  --expected-json evaluation.json
 ```
 
 The manifest declares no permissions: this workflow is a deterministic reducer

--- a/packages/loopx-finance-value-discovery/README.md
+++ b/packages/loopx-finance-value-discovery/README.md
@@ -27,6 +27,17 @@ harness binds the contract, input, and result with canonical SHA-256 receipts.
 Passing every gate means only that a case is eligible for a bounded research
 successor; it cannot promote a revision, advise, or trade.
 
+Two P1 overlays reuse that contract without weakening it:
+
+- `finance_beta_attribution_input_v1` decomposes a frozen total move into
+  market, rate, sector, narrow-peer, cycle, event, and computed residual
+  layers. If any explained component is missing or conflicting, the residual
+  is not computed.
+- `finance_metric_pack_input_v1` selects a bundled industry metric vocabulary.
+  Packs define required metric ids, value types, and allowed comparison
+  directions. They do not contain thresholds or evaluate provider-declared
+  pass/fail states.
+
 The packet enforces:
 
 - a cross-sectional screen before a named candidate is selected;
@@ -110,6 +121,19 @@ loopx extension run loopx-finance-value-discovery \
   --format json
 ```
 
+Layered attribution and industry packs use the same managed entrypoint:
+
+```bash
+loopx extension run loopx-finance-value-discovery \
+  --input-json packages/loopx-finance-value-discovery/examples/beta-attribution-v1.json \
+  --execute \
+  --format json
+loopx extension run loopx-finance-value-discovery \
+  --input-json packages/loopx-finance-value-discovery/examples/software-metric-pack-v1.json \
+  --execute \
+  --format json
+```
+
 Developers can inspect or replay a frozen evaluation directly:
 
 ```bash
@@ -118,6 +142,11 @@ loopx-finance-value-discovery evaluate \
 loopx-finance-value-discovery replay \
   --input-json packages/loopx-finance-value-discovery/examples/finance-case-gates-v1.json \
   --expected-json evaluation.json
+loopx-finance-value-discovery list-packs
+loopx-finance-value-discovery attribute-beta \
+  --input-json packages/loopx-finance-value-discovery/examples/beta-attribution-v1.json
+loopx-finance-value-discovery evaluate-pack \
+  --input-json packages/loopx-finance-value-discovery/examples/software-metric-pack-v1.json
 ```
 
 The manifest declares no permissions: this workflow is a deterministic reducer

--- a/packages/loopx-finance-value-discovery/examples/beta-attribution-v1.json
+++ b/packages/loopx-finance-value-discovery/examples/beta-attribution-v1.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": "finance_beta_attribution_input_v1",
+  "attribution_id": "illustrative-layered-beta",
+  "attribution_model_id": "frozen-public-observation-model-v1",
+  "component_order_frozen": true,
+  "unit": "return_fraction",
+  "contract": {
+    "schema_version": "finance_case_contract_v1",
+    "contract_id": "illustrative-beta-contract-v1",
+    "method_revision": "candidate-v1",
+    "point_in_time": "2026-07-23",
+    "universe_id": "illustrative-us-cross-section",
+    "universe_frozen": true,
+    "identities_frozen": true,
+    "thresholds_frozen": true,
+    "outcome_blind": true,
+    "public_evidence_only": true,
+    "gates": [
+      {
+        "gate_id": "de_beta_residual",
+        "value_type": "number",
+        "operator": "gte",
+        "reference_value": 0
+      }
+    ],
+    "investment_advice_allowed": false,
+    "trading_allowed": false,
+    "automatic_promotion_allowed": false
+  },
+  "total_move": -0.12,
+  "components": [
+    {
+      "component_id": "market",
+      "observation_state": "observed",
+      "contribution": -0.04,
+      "evidence_refs": ["broad-market-return"],
+      "reason": "Frozen broad-market contribution."
+    },
+    {
+      "component_id": "rate",
+      "observation_state": "observed",
+      "contribution": -0.01,
+      "evidence_refs": ["rate-factor-return"],
+      "reason": "Frozen rate-factor contribution."
+    },
+    {
+      "component_id": "sector",
+      "observation_state": "observed",
+      "contribution": -0.03,
+      "evidence_refs": ["sector-return"],
+      "reason": "Frozen sector contribution."
+    },
+    {
+      "component_id": "narrow_peer",
+      "observation_state": "observed",
+      "contribution": -0.01,
+      "evidence_refs": ["peer-panel-return"],
+      "reason": "Frozen narrow-peer contribution."
+    },
+    {
+      "component_id": "cycle",
+      "observation_state": "observed",
+      "contribution": -0.015,
+      "evidence_refs": ["cycle-observation"],
+      "reason": "Frozen cycle contribution."
+    },
+    {
+      "component_id": "event",
+      "observation_state": "observed",
+      "contribution": -0.005,
+      "evidence_refs": ["event-observation"],
+      "reason": "Frozen event contribution."
+    }
+  ]
+}

--- a/packages/loopx-finance-value-discovery/examples/beta-attribution-v1.json
+++ b/packages/loopx-finance-value-discovery/examples/beta-attribution-v1.json
@@ -4,72 +4,184 @@
   "attribution_model_id": "frozen-public-observation-model-v1",
   "component_order_frozen": true,
   "unit": "return_fraction",
-  "contract": {
-    "schema_version": "finance_case_contract_v1",
-    "contract_id": "illustrative-beta-contract-v1",
-    "method_revision": "candidate-v1",
-    "point_in_time": "2026-07-23",
-    "universe_id": "illustrative-us-cross-section",
-    "universe_frozen": true,
-    "identities_frozen": true,
-    "thresholds_frozen": true,
-    "outcome_blind": true,
-    "public_evidence_only": true,
-    "gates": [
-      {
-        "gate_id": "de_beta_residual",
-        "value_type": "number",
-        "operator": "gte",
-        "reference_value": 0
-      }
-    ],
-    "investment_advice_allowed": false,
-    "trading_allowed": false,
-    "automatic_promotion_allowed": false
-  },
   "total_move": -0.12,
   "components": [
     {
       "component_id": "market",
       "observation_state": "observed",
       "contribution": -0.04,
-      "evidence_refs": ["broad-market-return"],
+      "evidence_refs": [
+        "broad-market-return"
+      ],
       "reason": "Frozen broad-market contribution."
     },
     {
       "component_id": "rate",
       "observation_state": "observed",
       "contribution": -0.01,
-      "evidence_refs": ["rate-factor-return"],
+      "evidence_refs": [
+        "rate-factor-return"
+      ],
       "reason": "Frozen rate-factor contribution."
     },
     {
       "component_id": "sector",
       "observation_state": "observed",
       "contribution": -0.03,
-      "evidence_refs": ["sector-return"],
+      "evidence_refs": [
+        "sector-return"
+      ],
       "reason": "Frozen sector contribution."
     },
     {
       "component_id": "narrow_peer",
       "observation_state": "observed",
       "contribution": -0.01,
-      "evidence_refs": ["peer-panel-return"],
+      "evidence_refs": [
+        "peer-panel-return"
+      ],
       "reason": "Frozen narrow-peer contribution."
     },
     {
       "component_id": "cycle",
       "observation_state": "observed",
       "contribution": -0.015,
-      "evidence_refs": ["cycle-observation"],
+      "evidence_refs": [
+        "cycle-observation"
+      ],
       "reason": "Frozen cycle contribution."
     },
     {
       "component_id": "event",
       "observation_state": "observed",
       "contribution": -0.005,
-      "evidence_refs": ["event-observation"],
+      "evidence_refs": [
+        "event-observation"
+      ],
       "reason": "Frozen event contribution."
     }
-  ]
+  ],
+  "case_reference": {
+    "case_id": "illustrative-debeta-case",
+    "subject_ref": "illustrative-us-cross-section",
+    "observation_window": {
+      "start": "2026-07-23",
+      "end": "2026-07-27"
+    }
+  },
+  "gate_evaluation_input": {
+    "schema_version": "finance_case_gate_input_v1",
+    "case_id": "illustrative-debeta-case",
+    "contract": {
+      "schema_version": "finance_case_contract_v1",
+      "contract_id": "us-debeta-public-research-v1",
+      "method_revision": "candidate-v1",
+      "point_in_time": "2026-07-23",
+      "universe_id": "illustrative-us-cross-section",
+      "universe_frozen": true,
+      "identities_frozen": true,
+      "thresholds_frozen": true,
+      "outcome_blind": true,
+      "public_evidence_only": true,
+      "gates": [
+        {
+          "gate_id": "universe",
+          "value_type": "boolean",
+          "operator": "eq",
+          "reference_value": true
+        },
+        {
+          "gate_id": "point_in_time",
+          "value_type": "boolean",
+          "operator": "eq",
+          "reference_value": true
+        },
+        {
+          "gate_id": "evidence_quality",
+          "value_type": "number",
+          "operator": "gte",
+          "reference_value": 2
+        },
+        {
+          "gate_id": "de_beta_residual",
+          "value_type": "number",
+          "operator": "gte",
+          "reference_value": 0
+        },
+        {
+          "gate_id": "valuation",
+          "value_type": "boolean",
+          "operator": "eq",
+          "reference_value": true
+        },
+        {
+          "gate_id": "terminal_risk",
+          "value_type": "boolean",
+          "operator": "eq",
+          "reference_value": true
+        }
+      ],
+      "investment_advice_allowed": false,
+      "trading_allowed": false,
+      "automatic_promotion_allowed": false,
+      "evaluation_as_of": "2026-07-27"
+    },
+    "observations": [
+      {
+        "gate_id": "universe",
+        "observation_state": "observed",
+        "value": true,
+        "evidence_refs": [
+          "universe-snapshot"
+        ],
+        "reason": "Universe and identities were frozen before candidate scoring."
+      },
+      {
+        "gate_id": "point_in_time",
+        "observation_state": "observed",
+        "value": true,
+        "evidence_refs": [
+          "cutoff-ledger"
+        ],
+        "reason": "All observations are at or before the declared cutoff."
+      },
+      {
+        "gate_id": "evidence_quality",
+        "observation_state": "observed",
+        "value": 2,
+        "evidence_refs": [
+          "filing-primary",
+          "market-independent"
+        ],
+        "reason": "Primary evidence and an independent market source agree."
+      },
+      {
+        "gate_id": "de_beta_residual",
+        "observation_state": "observed",
+        "value": 0.18,
+        "evidence_refs": [
+          "peer-control-panel"
+        ],
+        "reason": "The residual is candidate-specific under frozen peer controls."
+      },
+      {
+        "gate_id": "valuation",
+        "observation_state": "observed",
+        "value": true,
+        "evidence_refs": [
+          "diluted-valuation-bridge"
+        ],
+        "reason": "Fully diluted valuation is reproducible from frozen inputs."
+      },
+      {
+        "gate_id": "terminal_risk",
+        "observation_state": "observed",
+        "value": true,
+        "evidence_refs": [
+          "terminal-risk-bridge"
+        ],
+        "reason": "The terminal-loss path is bounded by frozen evidence."
+      }
+    ]
+  }
 }

--- a/packages/loopx-finance-value-discovery/examples/beta-attribution-v1.json
+++ b/packages/loopx-finance-value-discovery/examples/beta-attribution-v1.json
@@ -4,7 +4,7 @@
   "attribution_model_id": "frozen-public-observation-model-v1",
   "component_order_frozen": true,
   "unit": "return_fraction",
-  "total_move": -0.12,
+  "total_move": -0.1,
   "components": [
     {
       "component_id": "market",
@@ -159,7 +159,7 @@
       {
         "gate_id": "de_beta_residual",
         "observation_state": "observed",
-        "value": 0.18,
+        "value": 0.01,
         "evidence_refs": [
           "peer-control-panel"
         ],

--- a/packages/loopx-finance-value-discovery/examples/beta-attribution-v1.json
+++ b/packages/loopx-finance-value-discovery/examples/beta-attribution-v1.json
@@ -72,6 +72,7 @@
   "gate_evaluation_input": {
     "schema_version": "finance_case_gate_input_v1",
     "case_id": "illustrative-debeta-case",
+    "subject_ref": "illustrative-us-cross-section",
     "contract": {
       "schema_version": "finance_case_contract_v1",
       "contract_id": "us-debeta-public-research-v1",

--- a/packages/loopx-finance-value-discovery/examples/finance-case-gates-v1.json
+++ b/packages/loopx-finance-value-discovery/examples/finance-case-gates-v1.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "finance_case_gate_input_v1",
+  "case_id": "illustrative-debeta-case",
+  "contract": {
+    "schema_version": "finance_case_contract_v1",
+    "contract_id": "us-debeta-public-research-v1",
+    "method_revision": "candidate-v1",
+    "point_in_time": "2026-07-23",
+    "universe_id": "illustrative-us-cross-section",
+    "universe_frozen": true,
+    "identities_frozen": true,
+    "thresholds_frozen": true,
+    "outcome_blind": true,
+    "public_evidence_only": true,
+    "gates": [
+      {
+        "gate_id": "universe",
+        "value_type": "boolean",
+        "operator": "eq",
+        "reference_value": true
+      },
+      {
+        "gate_id": "point_in_time",
+        "value_type": "boolean",
+        "operator": "eq",
+        "reference_value": true
+      },
+      {
+        "gate_id": "evidence_quality",
+        "value_type": "number",
+        "operator": "gte",
+        "reference_value": 2
+      },
+      {
+        "gate_id": "de_beta_residual",
+        "value_type": "number",
+        "operator": "gte",
+        "reference_value": 0
+      },
+      {
+        "gate_id": "valuation",
+        "value_type": "boolean",
+        "operator": "eq",
+        "reference_value": true
+      },
+      {
+        "gate_id": "terminal_risk",
+        "value_type": "boolean",
+        "operator": "eq",
+        "reference_value": true
+      }
+    ],
+    "investment_advice_allowed": false,
+    "trading_allowed": false,
+    "automatic_promotion_allowed": false
+  },
+  "observations": [
+    {
+      "gate_id": "universe",
+      "observation_state": "observed",
+      "value": true,
+      "evidence_refs": ["universe-snapshot"],
+      "reason": "Universe and identities were frozen before candidate scoring."
+    },
+    {
+      "gate_id": "point_in_time",
+      "observation_state": "observed",
+      "value": true,
+      "evidence_refs": ["cutoff-ledger"],
+      "reason": "All observations are at or before the declared cutoff."
+    },
+    {
+      "gate_id": "evidence_quality",
+      "observation_state": "observed",
+      "value": 2,
+      "evidence_refs": ["filing-primary", "market-independent"],
+      "reason": "Primary evidence and an independent market source agree."
+    },
+    {
+      "gate_id": "de_beta_residual",
+      "observation_state": "observed",
+      "value": 0.18,
+      "evidence_refs": ["peer-control-panel"],
+      "reason": "The residual is candidate-specific under frozen peer controls."
+    },
+    {
+      "gate_id": "valuation",
+      "observation_state": "observed",
+      "value": true,
+      "evidence_refs": ["diluted-valuation-bridge"],
+      "reason": "Fully diluted valuation is reproducible from frozen inputs."
+    },
+    {
+      "gate_id": "terminal_risk",
+      "observation_state": "missing",
+      "value": null,
+      "evidence_refs": [],
+      "reason": "A complete terminal-loss path is not yet supported."
+    }
+  ]
+}

--- a/packages/loopx-finance-value-discovery/examples/finance-case-gates-v1.json
+++ b/packages/loopx-finance-value-discovery/examples/finance-case-gates-v1.json
@@ -52,42 +52,54 @@
     ],
     "investment_advice_allowed": false,
     "trading_allowed": false,
-    "automatic_promotion_allowed": false
+    "automatic_promotion_allowed": false,
+    "evaluation_as_of": "2026-07-27"
   },
   "observations": [
     {
       "gate_id": "universe",
       "observation_state": "observed",
       "value": true,
-      "evidence_refs": ["universe-snapshot"],
+      "evidence_refs": [
+        "universe-snapshot"
+      ],
       "reason": "Universe and identities were frozen before candidate scoring."
     },
     {
       "gate_id": "point_in_time",
       "observation_state": "observed",
       "value": true,
-      "evidence_refs": ["cutoff-ledger"],
+      "evidence_refs": [
+        "cutoff-ledger"
+      ],
       "reason": "All observations are at or before the declared cutoff."
     },
     {
       "gate_id": "evidence_quality",
       "observation_state": "observed",
       "value": 2,
-      "evidence_refs": ["filing-primary", "market-independent"],
+      "evidence_refs": [
+        "filing-primary",
+        "market-independent"
+      ],
       "reason": "Primary evidence and an independent market source agree."
     },
     {
       "gate_id": "de_beta_residual",
       "observation_state": "observed",
       "value": 0.18,
-      "evidence_refs": ["peer-control-panel"],
+      "evidence_refs": [
+        "peer-control-panel"
+      ],
       "reason": "The residual is candidate-specific under frozen peer controls."
     },
     {
       "gate_id": "valuation",
       "observation_state": "observed",
       "value": true,
-      "evidence_refs": ["diluted-valuation-bridge"],
+      "evidence_refs": [
+        "diluted-valuation-bridge"
+      ],
       "reason": "Fully diluted valuation is reproducible from frozen inputs."
     },
     {

--- a/packages/loopx-finance-value-discovery/examples/finance-case-gates-v1.json
+++ b/packages/loopx-finance-value-discovery/examples/finance-case-gates-v1.json
@@ -1,6 +1,7 @@
 {
   "schema_version": "finance_case_gate_input_v1",
   "case_id": "illustrative-debeta-case",
+  "subject_ref": "illustrative-us-cross-section",
   "contract": {
     "schema_version": "finance_case_contract_v1",
     "contract_id": "us-debeta-public-research-v1",

--- a/packages/loopx-finance-value-discovery/examples/software-metric-pack-v1.json
+++ b/packages/loopx-finance-value-discovery/examples/software-metric-pack-v1.json
@@ -1,0 +1,105 @@
+{
+  "schema_version": "finance_metric_pack_input_v1",
+  "pack_id": "software_platforms_v1",
+  "case_input": {
+    "schema_version": "finance_case_gate_input_v1",
+    "case_id": "illustrative-software-case",
+    "contract": {
+      "schema_version": "finance_case_contract_v1",
+      "contract_id": "illustrative-software-contract-v1",
+      "method_revision": "candidate-v1",
+      "point_in_time": "2026-07-23",
+      "universe_id": "illustrative-software-universe",
+      "universe_frozen": true,
+      "identities_frozen": true,
+      "thresholds_frozen": true,
+      "outcome_blind": true,
+      "public_evidence_only": true,
+      "gates": [
+        {
+          "gate_id": "source_lineage",
+          "value_type": "boolean",
+          "operator": "eq",
+          "reference_value": true
+        },
+        {
+          "gate_id": "point_in_time",
+          "value_type": "boolean",
+          "operator": "eq",
+          "reference_value": true
+        },
+        {
+          "gate_id": "recurring_revenue_growth",
+          "value_type": "number",
+          "operator": "gte",
+          "reference_value": 0.1
+        },
+        {
+          "gate_id": "gross_margin",
+          "value_type": "number",
+          "operator": "gte",
+          "reference_value": 0.7
+        },
+        {
+          "gate_id": "free_cash_flow_conversion",
+          "value_type": "number",
+          "operator": "gte",
+          "reference_value": 0.8
+        },
+        {
+          "gate_id": "sbc_dilution",
+          "value_type": "number",
+          "operator": "lte",
+          "reference_value": 0.04
+        }
+      ],
+      "investment_advice_allowed": false,
+      "trading_allowed": false,
+      "automatic_promotion_allowed": false
+    },
+    "observations": [
+      {
+        "gate_id": "source_lineage",
+        "observation_state": "observed",
+        "value": true,
+        "evidence_refs": ["filing-lineage"],
+        "reason": "Issuer and filing lineage are frozen."
+      },
+      {
+        "gate_id": "point_in_time",
+        "observation_state": "observed",
+        "value": true,
+        "evidence_refs": ["cutoff-ledger"],
+        "reason": "Evidence is available at the declared cutoff."
+      },
+      {
+        "gate_id": "recurring_revenue_growth",
+        "observation_state": "observed",
+        "value": 0.14,
+        "evidence_refs": ["revenue-filing"],
+        "reason": "Recurring revenue growth from frozen filing facts."
+      },
+      {
+        "gate_id": "gross_margin",
+        "observation_state": "observed",
+        "value": 0.76,
+        "evidence_refs": ["margin-filing"],
+        "reason": "Gross margin from frozen filing facts."
+      },
+      {
+        "gate_id": "free_cash_flow_conversion",
+        "observation_state": "observed",
+        "value": 0.87,
+        "evidence_refs": ["cash-flow-filing"],
+        "reason": "Free-cash-flow conversion from frozen filing facts."
+      },
+      {
+        "gate_id": "sbc_dilution",
+        "observation_state": "observed",
+        "value": 0.05,
+        "evidence_refs": ["dilution-filing"],
+        "reason": "Dilution exceeds the contract-owned ceiling."
+      }
+    ]
+  }
+}

--- a/packages/loopx-finance-value-discovery/examples/software-metric-pack-v1.json
+++ b/packages/loopx-finance-value-discovery/examples/software-metric-pack-v1.json
@@ -4,6 +4,7 @@
   "case_input": {
     "schema_version": "finance_case_gate_input_v1",
     "case_id": "illustrative-software-case",
+    "subject_ref": "illustrative-software-universe",
     "contract": {
       "schema_version": "finance_case_contract_v1",
       "contract_id": "illustrative-software-contract-v1",

--- a/packages/loopx-finance-value-discovery/examples/software-metric-pack-v1.json
+++ b/packages/loopx-finance-value-discovery/examples/software-metric-pack-v1.json
@@ -55,49 +55,62 @@
       ],
       "investment_advice_allowed": false,
       "trading_allowed": false,
-      "automatic_promotion_allowed": false
+      "automatic_promotion_allowed": false,
+      "evaluation_as_of": "2026-07-27"
     },
     "observations": [
       {
         "gate_id": "source_lineage",
         "observation_state": "observed",
         "value": true,
-        "evidence_refs": ["filing-lineage"],
+        "evidence_refs": [
+          "filing-lineage"
+        ],
         "reason": "Issuer and filing lineage are frozen."
       },
       {
         "gate_id": "point_in_time",
         "observation_state": "observed",
         "value": true,
-        "evidence_refs": ["cutoff-ledger"],
+        "evidence_refs": [
+          "cutoff-ledger"
+        ],
         "reason": "Evidence is available at the declared cutoff."
       },
       {
         "gate_id": "recurring_revenue_growth",
         "observation_state": "observed",
         "value": 0.14,
-        "evidence_refs": ["revenue-filing"],
+        "evidence_refs": [
+          "revenue-filing"
+        ],
         "reason": "Recurring revenue growth from frozen filing facts."
       },
       {
         "gate_id": "gross_margin",
         "observation_state": "observed",
         "value": 0.76,
-        "evidence_refs": ["margin-filing"],
+        "evidence_refs": [
+          "margin-filing"
+        ],
         "reason": "Gross margin from frozen filing facts."
       },
       {
         "gate_id": "free_cash_flow_conversion",
         "observation_state": "observed",
         "value": 0.87,
-        "evidence_refs": ["cash-flow-filing"],
+        "evidence_refs": [
+          "cash-flow-filing"
+        ],
         "reason": "Free-cash-flow conversion from frozen filing facts."
       },
       {
         "gate_id": "sbc_dilution",
         "observation_state": "observed",
         "value": 0.05,
-        "evidence_refs": ["dilution-filing"],
+        "evidence_refs": [
+          "dilution-filing"
+        ],
         "reason": "Dilution exceeds the contract-owned ceiling."
       }
     ]

--- a/packages/loopx-finance-value-discovery/extension.toml
+++ b/packages/loopx-finance-value-discovery/extension.toml
@@ -1,6 +1,6 @@
 schema_version = "loopx_extension_manifest_v0"
 id = "loopx-finance-value-discovery"
-version = "0.2.0"
+version = "0.3.0"
 requires_loopx_api = ">=1,<2"
 permissions = []
 

--- a/packages/loopx-finance-value-discovery/extension.toml
+++ b/packages/loopx-finance-value-discovery/extension.toml
@@ -1,6 +1,6 @@
 schema_version = "loopx_extension_manifest_v0"
 id = "loopx-finance-value-discovery"
-version = "0.3.0"
+version = "0.4.0"
 requires_loopx_api = ">=1,<2"
 permissions = []
 

--- a/packages/loopx-finance-value-discovery/pyproject.toml
+++ b/packages/loopx-finance-value-discovery/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx-finance-value-discovery"
-version = "0.2.0"
+version = "0.3.0"
 description = "Public-safe finance value-discovery extension for LoopX."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/loopx-finance-value-discovery/pyproject.toml
+++ b/packages/loopx-finance-value-discovery/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx-finance-value-discovery"
-version = "0.3.0"
+version = "0.4.0"
 description = "Public-safe finance value-discovery extension for LoopX."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/__init__.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/__init__.py
@@ -1,5 +1,13 @@
 """Finance value-discovery extension."""
 
+from .attribution import (
+    EXPLAINED_BETA_COMPONENTS,
+    FINANCE_BETA_ATTRIBUTION_INPUT_SCHEMA_VERSION,
+    FINANCE_BETA_ATTRIBUTION_REPLAY_SCHEMA_VERSION,
+    FINANCE_BETA_ATTRIBUTION_SCHEMA_VERSION,
+    build_finance_beta_attribution,
+    replay_finance_beta_attribution,
+)
 from .contract import (
     FINANCE_CASE_CONTRACT_SCHEMA_VERSION,
     FINANCE_CASE_EVALUATION_SCHEMA_VERSION,
@@ -7,35 +15,55 @@ from .contract import (
     validate_finance_case_contract,
 )
 from .gates import evaluate_finance_case_gates
+from .metric_packs import (
+    FINANCE_METRIC_PACK_EVALUATION_SCHEMA_VERSION,
+    FINANCE_METRIC_PACK_INPUT_SCHEMA_VERSION,
+    FINANCE_METRIC_PACK_REPLAY_SCHEMA_VERSION,
+    build_finance_metric_pack_evaluation,
+    list_finance_metric_packs,
+    replay_finance_metric_pack_evaluation,
+)
+from .reducer import (
+    EVIDENCE_AXES,
+    FINANCE_VALUE_DISCOVERY_CARD_SCHEMA_VERSION,
+    FINANCE_VALUE_DISCOVERY_EXTENSION_PROTOCOL,
+    FINANCE_VALUE_DISCOVERY_INPUT_SCHEMA_VERSION,
+    FINANCE_VALUE_DISCOVERY_PACKET_SCHEMA_VERSION,
+    build_finance_value_discovery_packet,
+    render_finance_value_discovery_markdown,
+)
 from .replay import (
     FINANCE_CASE_REPLAY_RECEIPT_SCHEMA_VERSION,
     build_finance_case_evaluation,
     replay_finance_case_evaluation,
 )
-from .reducer import (
-    EVIDENCE_AXES,
-    FINANCE_VALUE_DISCOVERY_CARD_SCHEMA_VERSION,
-    FINANCE_VALUE_DISCOVERY_INPUT_SCHEMA_VERSION,
-    FINANCE_VALUE_DISCOVERY_PACKET_SCHEMA_VERSION,
-    FINANCE_VALUE_DISCOVERY_EXTENSION_PROTOCOL,
-    build_finance_value_discovery_packet,
-    render_finance_value_discovery_markdown,
-)
 
 __all__ = [
     "EVIDENCE_AXES",
+    "EXPLAINED_BETA_COMPONENTS",
+    "FINANCE_BETA_ATTRIBUTION_INPUT_SCHEMA_VERSION",
+    "FINANCE_BETA_ATTRIBUTION_REPLAY_SCHEMA_VERSION",
+    "FINANCE_BETA_ATTRIBUTION_SCHEMA_VERSION",
     "FINANCE_CASE_CONTRACT_SCHEMA_VERSION",
     "FINANCE_CASE_EVALUATION_SCHEMA_VERSION",
     "FINANCE_CASE_INPUT_SCHEMA_VERSION",
     "FINANCE_CASE_REPLAY_RECEIPT_SCHEMA_VERSION",
+    "FINANCE_METRIC_PACK_EVALUATION_SCHEMA_VERSION",
+    "FINANCE_METRIC_PACK_INPUT_SCHEMA_VERSION",
+    "FINANCE_METRIC_PACK_REPLAY_SCHEMA_VERSION",
     "FINANCE_VALUE_DISCOVERY_CARD_SCHEMA_VERSION",
+    "FINANCE_VALUE_DISCOVERY_EXTENSION_PROTOCOL",
     "FINANCE_VALUE_DISCOVERY_INPUT_SCHEMA_VERSION",
     "FINANCE_VALUE_DISCOVERY_PACKET_SCHEMA_VERSION",
-    "FINANCE_VALUE_DISCOVERY_EXTENSION_PROTOCOL",
-    "build_finance_value_discovery_packet",
+    "build_finance_beta_attribution",
     "build_finance_case_evaluation",
+    "build_finance_metric_pack_evaluation",
+    "build_finance_value_discovery_packet",
     "evaluate_finance_case_gates",
-    "replay_finance_case_evaluation",
+    "list_finance_metric_packs",
     "render_finance_value_discovery_markdown",
+    "replay_finance_beta_attribution",
+    "replay_finance_case_evaluation",
+    "replay_finance_metric_pack_evaluation",
     "validate_finance_case_contract",
 ]

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/__init__.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/__init__.py
@@ -1,5 +1,17 @@
 """Finance value-discovery extension."""
 
+from .contract import (
+    FINANCE_CASE_CONTRACT_SCHEMA_VERSION,
+    FINANCE_CASE_EVALUATION_SCHEMA_VERSION,
+    FINANCE_CASE_INPUT_SCHEMA_VERSION,
+    validate_finance_case_contract,
+)
+from .gates import evaluate_finance_case_gates
+from .replay import (
+    FINANCE_CASE_REPLAY_RECEIPT_SCHEMA_VERSION,
+    build_finance_case_evaluation,
+    replay_finance_case_evaluation,
+)
 from .reducer import (
     EVIDENCE_AXES,
     FINANCE_VALUE_DISCOVERY_CARD_SCHEMA_VERSION,
@@ -12,10 +24,18 @@ from .reducer import (
 
 __all__ = [
     "EVIDENCE_AXES",
+    "FINANCE_CASE_CONTRACT_SCHEMA_VERSION",
+    "FINANCE_CASE_EVALUATION_SCHEMA_VERSION",
+    "FINANCE_CASE_INPUT_SCHEMA_VERSION",
+    "FINANCE_CASE_REPLAY_RECEIPT_SCHEMA_VERSION",
     "FINANCE_VALUE_DISCOVERY_CARD_SCHEMA_VERSION",
     "FINANCE_VALUE_DISCOVERY_INPUT_SCHEMA_VERSION",
     "FINANCE_VALUE_DISCOVERY_PACKET_SCHEMA_VERSION",
     "FINANCE_VALUE_DISCOVERY_EXTENSION_PROTOCOL",
     "build_finance_value_discovery_packet",
+    "build_finance_case_evaluation",
+    "evaluate_finance_case_gates",
+    "replay_finance_case_evaluation",
     "render_finance_value_discovery_markdown",
+    "validate_finance_case_contract",
 ]

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/attribution.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/attribution.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from .boundary import reject_forbidden_material
+from .contract import validate_finance_case_contract
+from .replay import canonical_json_bytes, canonical_sha256
+
+FINANCE_BETA_ATTRIBUTION_INPUT_SCHEMA_VERSION = "finance_beta_attribution_input_v1"
+FINANCE_BETA_ATTRIBUTION_SCHEMA_VERSION = "finance_beta_attribution_v1"
+FINANCE_BETA_ATTRIBUTION_REPLAY_SCHEMA_VERSION = "finance_beta_attribution_replay_v1"
+
+EXPLAINED_BETA_COMPONENTS = (
+    "market",
+    "rate",
+    "sector",
+    "narrow_peer",
+    "cycle",
+    "event",
+)
+ATTRIBUTION_STATES = {"observed", "missing", "conflict"}
+
+
+def _text(value: object, *, field: str, limit: int = 320) -> str:
+    result = " ".join(str(value or "").split())
+    if not result:
+        raise ValueError(f"{field} is required")
+    if len(result) > limit:
+        raise ValueError(f"{field} exceeds {limit} characters")
+    reject_forbidden_material(result, path=field)
+    return result
+
+
+def _decimal(value: object, *, field: str) -> Decimal:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise ValueError(f"{field} must be a finite number")
+    try:
+        result = Decimal(str(value))
+    except InvalidOperation as exc:
+        raise ValueError(f"{field} must be a finite number") from exc
+    if not result.is_finite():
+        raise ValueError(f"{field} must be a finite number")
+    return result
+
+
+def _decimal_text(value: Decimal) -> str:
+    if value == 0:
+        return "0"
+    return format(value.normalize(), "f")
+
+
+def _evidence_refs(value: object, *, field: str) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise ValueError(f"{field} must be a list")
+    if len(value) > 12:
+        raise ValueError(f"{field} must contain at most 12 items")
+    refs = [
+        _text(item, field=f"{field}[{index}]", limit=120)
+        for index, item in enumerate(value)
+    ]
+    if len(refs) != len(set(refs)):
+        raise ValueError(f"{field} must use unique evidence refs")
+    return refs
+
+
+def _component(value: object, *, index: int) -> dict[str, Any]:
+    field = f"components[{index}]"
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field} must be an object")
+    allowed = {
+        "component_id",
+        "observation_state",
+        "contribution",
+        "evidence_refs",
+        "reason",
+    }
+    if set(value) - allowed:
+        raise ValueError(f"{field} has unsupported fields")
+    state = _text(
+        value.get("observation_state"),
+        field=f"{field}.observation_state",
+        limit=24,
+    )
+    if state not in ATTRIBUTION_STATES:
+        raise ValueError(
+            f"{field}.observation_state must be one of {sorted(ATTRIBUTION_STATES)}"
+        )
+    contribution = value.get("contribution")
+    if state == "observed":
+        normalized_contribution = _decimal(contribution, field=f"{field}.contribution")
+    else:
+        if contribution is not None:
+            raise ValueError(f"{field}.contribution is only valid when state=observed")
+        normalized_contribution = None
+    refs = _evidence_refs(value.get("evidence_refs"), field=f"{field}.evidence_refs")
+    if state == "observed" and not refs:
+        raise ValueError(f"{field} observed contributions require evidence_refs")
+    if state == "conflict" and len(refs) < 2:
+        raise ValueError(f"{field} conflicts require at least two evidence_refs")
+    return {
+        "component_id": _text(
+            value.get("component_id"), field=f"{field}.component_id", limit=40
+        ),
+        "observation_state": state,
+        "contribution": (
+            _decimal_text(normalized_contribution)
+            if normalized_contribution is not None
+            else None
+        ),
+        "evidence_refs": refs,
+        "reason": _text(value.get("reason"), field=f"{field}.reason"),
+    }
+
+
+def build_finance_beta_attribution(value: object) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError("finance beta attribution input must be an object")
+    reject_forbidden_material(value)
+    allowed = {
+        "schema_version",
+        "attribution_id",
+        "attribution_model_id",
+        "component_order_frozen",
+        "unit",
+        "contract",
+        "total_move",
+        "components",
+    }
+    if set(value) - allowed:
+        raise ValueError("finance beta attribution input has unsupported fields")
+    if value.get("schema_version") != FINANCE_BETA_ATTRIBUTION_INPUT_SCHEMA_VERSION:
+        raise ValueError(
+            f"schema_version must be {FINANCE_BETA_ATTRIBUTION_INPUT_SCHEMA_VERSION}"
+        )
+    if value.get("component_order_frozen") is not True:
+        raise ValueError("component_order_frozen must be true")
+    if value.get("unit") != "return_fraction":
+        raise ValueError("unit must be return_fraction")
+    contract = validate_finance_case_contract(value.get("contract"))
+    total_move = _decimal(value.get("total_move"), field="total_move")
+    raw_components = value.get("components")
+    if not isinstance(raw_components, Sequence) or isinstance(
+        raw_components, (str, bytes, bytearray)
+    ):
+        raise ValueError("components must be a list")
+    components = [
+        _component(item, index=index) for index, item in enumerate(raw_components)
+    ]
+    component_ids = [item["component_id"] for item in components]
+    if component_ids != list(EXPLAINED_BETA_COMPONENTS):
+        raise ValueError(
+            "components must exactly match the frozen market/rate/sector/"
+            "narrow_peer/cycle/event order"
+        )
+
+    missing = [
+        item["component_id"]
+        for item in components
+        if item["observation_state"] == "missing"
+    ]
+    conflicts = [
+        item["component_id"]
+        for item in components
+        if item["observation_state"] == "conflict"
+    ]
+    complete = not missing and not conflicts
+    explained = (
+        sum(
+            (
+                Decimal(str(item["contribution"]))
+                for item in components
+                if item["contribution"] is not None
+            ),
+            Decimal(0),
+        )
+        if complete
+        else None
+    )
+    residual = total_move - explained if explained is not None else None
+    attribution = {
+        "ok": True,
+        "schema_version": FINANCE_BETA_ATTRIBUTION_SCHEMA_VERSION,
+        "attribution_id": _text(
+            value.get("attribution_id"), field="attribution_id", limit=96
+        ),
+        "attribution_model_id": _text(
+            value.get("attribution_model_id"),
+            field="attribution_model_id",
+            limit=96,
+        ),
+        "contract": contract,
+        "unit": "return_fraction",
+        "total_move": _decimal_text(total_move),
+        "components": components
+        + [
+            {
+                "component_id": "residual",
+                "observation_state": "computed" if complete else "not_computable",
+                "contribution": _decimal_text(residual)
+                if residual is not None
+                else None,
+                "evidence_refs": [],
+                "reason": (
+                    "Computed as total_move minus all six explained components."
+                    if complete
+                    else (
+                        "Residual is unavailable while an explained component "
+                        "is missing or conflicting."
+                    )
+                ),
+            }
+        ],
+        "explained_sum": _decimal_text(explained) if explained is not None else None,
+        "residual": _decimal_text(residual) if residual is not None else None,
+        "disposition": "complete" if complete else "insufficient_evidence",
+        "missing_component_ids": missing,
+        "conflicting_component_ids": conflicts,
+        "boundary": {
+            "public_evidence_only": True,
+            "outcome_blind": True,
+            "investment_advice": False,
+            "trading_allowed": False,
+            "automatic_promotion_allowed": False,
+        },
+    }
+    replay = {
+        "schema_version": FINANCE_BETA_ATTRIBUTION_REPLAY_SCHEMA_VERSION,
+        "contract_sha256": canonical_sha256(contract),
+        "input_sha256": canonical_sha256(value),
+        "attribution_sha256": canonical_sha256(attribution),
+        "canonicalization": "json_sort_keys_compact_ascii_v1",
+    }
+    return {**attribution, "replay": replay}
+
+
+def replay_finance_beta_attribution(
+    value: object,
+    expected: object,
+) -> dict[str, Any]:
+    if not isinstance(expected, Mapping):
+        raise ValueError("expected attribution must be an object")
+    replayed = build_finance_beta_attribution(value)
+    expected_replay = expected.get("replay")
+    if not isinstance(expected_replay, Mapping):
+        raise ValueError("expected attribution requires a replay receipt")
+    for field in ("contract_sha256", "input_sha256", "attribution_sha256"):
+        if expected_replay.get(field) != replayed["replay"][field]:
+            raise ValueError(f"replay {field} mismatch")
+    if canonical_json_bytes(expected) != canonical_json_bytes(replayed):
+        raise ValueError("replay attribution bytes mismatch")
+    return {
+        "ok": True,
+        "schema_version": FINANCE_BETA_ATTRIBUTION_REPLAY_SCHEMA_VERSION,
+        "replay_verified": True,
+        "contract_sha256": replayed["replay"]["contract_sha256"],
+        "input_sha256": replayed["replay"]["input_sha256"],
+        "attribution_sha256": replayed["replay"]["attribution_sha256"],
+    }

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/attribution.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/attribution.py
@@ -5,7 +5,7 @@ from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from .boundary import reject_forbidden_material
-from .contract import validate_finance_case_contract
+from .gates import evaluate_finance_case_gates
 from .replay import canonical_json_bytes, canonical_sha256
 
 FINANCE_BETA_ATTRIBUTION_INPUT_SCHEMA_VERSION = "finance_beta_attribution_input_v1"
@@ -114,6 +114,36 @@ def _component(value: object, *, index: int) -> dict[str, Any]:
     }
 
 
+def _case_reference(value: object) -> dict[str, Any]:
+    """Validate the case/subject identity an attribution claims to explain."""
+    if not isinstance(value, Mapping):
+        raise ValueError("case_reference must be an object")
+    allowed = {"case_id", "subject_ref", "observation_window"}
+    if set(value) - allowed:
+        raise ValueError("case_reference has unsupported fields")
+    window = value.get("observation_window")
+    if not isinstance(window, Mapping) or set(window) - {"start", "end"}:
+        raise ValueError("case_reference.observation_window must have start and end")
+    return {
+        "case_id": _text(value.get("case_id"), field="case_reference.case_id", limit=96),
+        "subject_ref": _text(
+            value.get("subject_ref"), field="case_reference.subject_ref", limit=96
+        ),
+        "observation_window": {
+            "start": _text(
+                window.get("start"),
+                field="case_reference.observation_window.start",
+                limit=40,
+            ),
+            "end": _text(
+                window.get("end"),
+                field="case_reference.observation_window.end",
+                limit=40,
+            ),
+        },
+    }
+
+
 def build_finance_beta_attribution(value: object) -> dict[str, Any]:
     if not isinstance(value, Mapping):
         raise ValueError("finance beta attribution input must be an object")
@@ -124,7 +154,8 @@ def build_finance_beta_attribution(value: object) -> dict[str, Any]:
         "attribution_model_id",
         "component_order_frozen",
         "unit",
-        "contract",
+        "case_reference",
+        "gate_evaluation_input",
         "total_move",
         "components",
     }
@@ -138,7 +169,18 @@ def build_finance_beta_attribution(value: object) -> dict[str, Any]:
         raise ValueError("component_order_frozen must be true")
     if value.get("unit") != "return_fraction":
         raise ValueError("unit must be return_fraction")
-    contract = validate_finance_case_contract(value.get("contract"))
+    case_reference = _case_reference(value.get("case_reference"))
+    # Evaluate the gate contract this attribution is bound to, so a failing or
+    # missing gate cannot be presented as a research-complete attribution.
+    gate_evaluation = evaluate_finance_case_gates(value.get("gate_evaluation_input"))
+    contract = gate_evaluation["contract"]
+    if gate_evaluation["case_id"] != case_reference["case_id"]:
+        raise ValueError(
+            "case_reference.case_id must match gate_evaluation_input.case_id"
+        )
+    gate_eligible = (
+        gate_evaluation["disposition"] == "eligible_for_research_successor"
+    )
     total_move = _decimal(value.get("total_move"), field="total_move")
     raw_components = value.get("components")
     if not isinstance(raw_components, Sequence) or isinstance(
@@ -165,7 +207,7 @@ def build_finance_beta_attribution(value: object) -> dict[str, Any]:
         for item in components
         if item["observation_state"] == "conflict"
     ]
-    complete = not missing and not conflicts
+    complete = not missing and not conflicts and gate_eligible
     explained = (
         sum(
             (
@@ -191,6 +233,14 @@ def build_finance_beta_attribution(value: object) -> dict[str, Any]:
             limit=96,
         ),
         "contract": contract,
+        "case_reference": case_reference,
+        "gate_evaluation_receipt": {
+            "case_id": gate_evaluation["case_id"],
+            "disposition": gate_evaluation["disposition"],
+            "gate_eligible": gate_eligible,
+            "first_blocking_gate": gate_evaluation["first_blocking_gate"],
+            "evaluation_sha256": canonical_sha256(gate_evaluation),
+        },
         "unit": "return_fraction",
         "total_move": _decimal_text(total_move),
         "components": components
@@ -207,7 +257,7 @@ def build_finance_beta_attribution(value: object) -> dict[str, Any]:
                     if complete
                     else (
                         "Residual is unavailable while an explained component "
-                        "is missing or conflicting."
+                        "is missing/conflicting or the bound gate did not clear."
                     )
                 ),
             }
@@ -215,11 +265,12 @@ def build_finance_beta_attribution(value: object) -> dict[str, Any]:
         "explained_sum": _decimal_text(explained) if explained is not None else None,
         "residual": _decimal_text(residual) if residual is not None else None,
         "disposition": "complete" if complete else "insufficient_evidence",
+        "gate_eligible": gate_eligible,
         "missing_component_ids": missing,
         "conflicting_component_ids": conflicts,
         "boundary": {
-            "public_evidence_only": True,
-            "outcome_blind": True,
+            "public_evidence_only_state": contract["public_evidence_only_state"],
+            "outcome_blind_state": contract["outcome_blind_state"],
             "investment_advice": False,
             "trading_allowed": False,
             "automatic_promotion_allowed": False,

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/attribution.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/attribution.py
@@ -138,7 +138,11 @@ def _case_reference(value: object) -> dict[str, Any]:
             "case_reference.observation_window.start must not be after end"
         )
     return {
-        "case_id": _text(value.get("case_id"), field="case_reference.case_id", limit=96),
+        "case_id": _text(
+            value.get("case_id"),
+            field="case_reference.case_id",
+            limit=96,
+        ),
         "subject_ref": _text(
             value.get("subject_ref"), field="case_reference.subject_ref", limit=96
         ),
@@ -206,9 +210,8 @@ def build_finance_beta_attribution(value: object) -> dict[str, Any]:
             "case_reference.observation_window.end must not exceed "
             "contract.evaluation_as_of"
         )
-    gate_eligible = (
-        gate_evaluation["disposition"] == "eligible_for_research_successor"
-    )
+    gate_disposition = gate_evaluation["disposition"]
+    gate_eligible = gate_disposition == "eligible_for_research_successor"
     total_move = _decimal(value.get("total_move"), field="total_move")
     raw_components = value.get("components")
     if not isinstance(raw_components, Sequence) or isinstance(
@@ -235,7 +238,7 @@ def build_finance_beta_attribution(value: object) -> dict[str, Any]:
         for item in components
         if item["observation_state"] == "conflict"
     ]
-    complete = not missing and not conflicts and gate_eligible
+    components_complete = not missing and not conflicts
     explained = (
         sum(
             (
@@ -245,10 +248,38 @@ def build_finance_beta_attribution(value: object) -> dict[str, Any]:
             ),
             Decimal(0),
         )
-        if complete
+        if components_complete
         else None
     )
     residual = total_move - explained if explained is not None else None
+    residual_gate = next(
+        (
+            item
+            for item in gate_evaluation["gate_results"]
+            if item["gate_id"] == "de_beta_residual"
+        ),
+        None,
+    )
+    if residual_gate is None:
+        raise ValueError("gate_evaluation_input must include the de_beta_residual gate")
+    if residual_gate["observation_state"] == "observed":
+        if residual is None:
+            raise ValueError(
+                "de_beta_residual cannot be observed while components are incomplete"
+            )
+        observed_residual = _decimal(
+            residual_gate["value"],
+            field="de_beta_residual observation",
+        )
+        if observed_residual != residual:
+            raise ValueError(
+                "de_beta_residual observation must match the computed residual"
+            )
+    completeness = (
+        "complete"
+        if components_complete and gate_disposition != "insufficient_evidence"
+        else "insufficient_evidence"
+    )
     attribution = {
         "ok": True,
         "schema_version": FINANCE_BETA_ATTRIBUTION_SCHEMA_VERSION,
@@ -275,24 +306,27 @@ def build_finance_beta_attribution(value: object) -> dict[str, Any]:
         + [
             {
                 "component_id": "residual",
-                "observation_state": "computed" if complete else "not_computable",
+                "observation_state": (
+                    "computed" if components_complete else "not_computable"
+                ),
                 "contribution": _decimal_text(residual)
                 if residual is not None
                 else None,
                 "evidence_refs": [],
                 "reason": (
                     "Computed as total_move minus all six explained components."
-                    if complete
+                    if components_complete
                     else (
                         "Residual is unavailable while an explained component "
-                        "is missing/conflicting or the bound gate did not clear."
+                        "is missing or conflicting."
                     )
                 ),
             }
         ],
         "explained_sum": _decimal_text(explained) if explained is not None else None,
         "residual": _decimal_text(residual) if residual is not None else None,
-        "disposition": "complete" if complete else "insufficient_evidence",
+        "disposition": gate_disposition,
+        "completeness": completeness,
         "gate_eligible": gate_eligible,
         "missing_component_ids": missing,
         "conflicting_component_ids": conflicts,

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/attribution.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/attribution.py
@@ -5,6 +5,7 @@ from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from .boundary import reject_forbidden_material
+from .contract import iso_comparable_datetime, validate_iso_date
 from .gates import evaluate_finance_case_gates
 from .replay import canonical_json_bytes, canonical_sha256
 
@@ -124,22 +125,26 @@ def _case_reference(value: object) -> dict[str, Any]:
     window = value.get("observation_window")
     if not isinstance(window, Mapping) or set(window) - {"start", "end"}:
         raise ValueError("case_reference.observation_window must have start and end")
+    start = validate_iso_date(
+        window.get("start"),
+        field="case_reference.observation_window.start",
+    )
+    end = validate_iso_date(
+        window.get("end"),
+        field="case_reference.observation_window.end",
+    )
+    if iso_comparable_datetime(start) > iso_comparable_datetime(end):
+        raise ValueError(
+            "case_reference.observation_window.start must not be after end"
+        )
     return {
         "case_id": _text(value.get("case_id"), field="case_reference.case_id", limit=96),
         "subject_ref": _text(
             value.get("subject_ref"), field="case_reference.subject_ref", limit=96
         ),
         "observation_window": {
-            "start": _text(
-                window.get("start"),
-                field="case_reference.observation_window.start",
-                limit=40,
-            ),
-            "end": _text(
-                window.get("end"),
-                field="case_reference.observation_window.end",
-                limit=40,
-            ),
+            "start": start,
+            "end": end,
         },
     }
 
@@ -177,6 +182,29 @@ def build_finance_beta_attribution(value: object) -> dict[str, Any]:
     if gate_evaluation["case_id"] != case_reference["case_id"]:
         raise ValueError(
             "case_reference.case_id must match gate_evaluation_input.case_id"
+        )
+    if gate_evaluation["subject_ref"] != case_reference["subject_ref"]:
+        raise ValueError(
+            "case_reference.subject_ref must match gate_evaluation_input.subject_ref"
+        )
+    # Bind the observation window to the contract's frozen evaluation window so a
+    # not-a-date or future window cannot be presented as research-complete. The
+    # window must sit within [point_in_time, evaluation_as_of].
+    window_start = iso_comparable_datetime(
+        case_reference["observation_window"]["start"]
+    )
+    window_end = iso_comparable_datetime(case_reference["observation_window"]["end"])
+    contract_start = iso_comparable_datetime(contract["point_in_time"])
+    contract_cutoff = iso_comparable_datetime(contract["evaluation_as_of"])
+    if window_start < contract_start:
+        raise ValueError(
+            "case_reference.observation_window.start must not precede "
+            "contract.point_in_time"
+        )
+    if window_end > contract_cutoff:
+        raise ValueError(
+            "case_reference.observation_window.end must not exceed "
+            "contract.evaluation_as_of"
         )
     gate_eligible = (
         gate_evaluation["disposition"] == "eligible_for_research_successor"

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/boundary.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/boundary.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+
+
+FORBIDDEN_KEY_TOKENS = {
+    "account",
+    "auth",
+    "body",
+    "cookie",
+    "credential",
+    "holding",
+    "local",
+    "password",
+    "portfolio",
+    "private",
+    "raw",
+    "secret",
+    "token",
+    "trade",
+    "transcript",
+}
+FORBIDDEN_VALUE_PATTERNS = (
+    re.compile(r"\bBearer\s+", re.IGNORECASE),
+    re.compile(r"/Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\", re.IGNORECASE),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+)
+
+
+def _key_tokens(value: object) -> set[str]:
+    return {part for part in re.split(r"[^a-z0-9]+", str(value).lower()) if part}
+
+
+def reject_forbidden_material(value: object, *, path: str = "input") -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            forbidden = _key_tokens(key) & FORBIDDEN_KEY_TOKENS
+            if forbidden:
+                raise ValueError(
+                    f"{path} contains forbidden key token(s): "
+                    + ", ".join(sorted(forbidden))
+                )
+            reject_forbidden_material(item, path=f"{path}.{key}")
+        return
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for index, item in enumerate(value):
+            reject_forbidden_material(item, path=f"{path}[{index}]")
+        return
+    if isinstance(value, str) and any(
+        pattern.search(value) for pattern in FORBIDDEN_VALUE_PATTERNS
+    ):
+        raise ValueError(
+            f"{path} contains private path, auth material, or credential-like text"
+        )

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/cli.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/cli.py
@@ -7,15 +7,26 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
+from .attribution import (
+    FINANCE_BETA_ATTRIBUTION_INPUT_SCHEMA_VERSION,
+    build_finance_beta_attribution,
+    replay_finance_beta_attribution,
+)
 from .contract import FINANCE_CASE_INPUT_SCHEMA_VERSION
-from .replay import (
-    build_finance_case_evaluation,
-    replay_finance_case_evaluation,
+from .metric_packs import (
+    FINANCE_METRIC_PACK_INPUT_SCHEMA_VERSION,
+    build_finance_metric_pack_evaluation,
+    list_finance_metric_packs,
+    replay_finance_metric_pack_evaluation,
 )
 from .reducer import (
     FINANCE_VALUE_DISCOVERY_ERROR_SCHEMA_VERSION,
     build_finance_value_discovery_packet,
     render_finance_value_discovery_markdown,
+)
+from .replay import (
+    build_finance_case_evaluation,
+    replay_finance_case_evaluation,
 )
 
 
@@ -83,6 +94,29 @@ def _direct_parser() -> argparse.ArgumentParser:
     )
     replay_parser.add_argument("--input-json", required=True)
     replay_parser.add_argument("--expected-json", required=True)
+    beta_parser = sub.add_parser(
+        "attribute-beta",
+        help="Decompose a frozen total move into six explained layers and residual.",
+    )
+    beta_parser.add_argument("--input-json", required=True)
+    beta_replay_parser = sub.add_parser(
+        "replay-beta",
+        help="Verify a prior beta attribution byte-for-byte.",
+    )
+    beta_replay_parser.add_argument("--input-json", required=True)
+    beta_replay_parser.add_argument("--expected-json", required=True)
+    pack_parser = sub.add_parser(
+        "evaluate-pack",
+        help="Evaluate a case against an installed industry metric pack.",
+    )
+    pack_parser.add_argument("--input-json", required=True)
+    pack_replay_parser = sub.add_parser(
+        "replay-pack",
+        help="Verify a prior metric-pack evaluation byte-for-byte.",
+    )
+    pack_replay_parser.add_argument("--input-json", required=True)
+    pack_replay_parser.add_argument("--expected-json", required=True)
+    sub.add_parser("list-packs", help="List bundled industry metric packs.")
     return parser
 
 
@@ -93,11 +127,15 @@ def run(argv: Sequence[str] | None = None) -> int:
             payload = json.load(sys.stdin)
             if not isinstance(payload, Mapping):
                 raise ValueError("provider input must be a JSON object")
-            packet = (
-                build_finance_case_evaluation(payload)
-                if payload.get("schema_version") == FINANCE_CASE_INPUT_SCHEMA_VERSION
-                else build_finance_value_discovery_packet(payload)
-            )
+            schema_version = payload.get("schema_version")
+            if schema_version == FINANCE_CASE_INPUT_SCHEMA_VERSION:
+                packet = build_finance_case_evaluation(payload)
+            elif schema_version == FINANCE_BETA_ATTRIBUTION_INPUT_SCHEMA_VERSION:
+                packet = build_finance_beta_attribution(payload)
+            elif schema_version == FINANCE_METRIC_PACK_INPUT_SCHEMA_VERSION:
+                packet = build_finance_metric_pack_evaluation(payload)
+            else:
+                packet = build_finance_value_discovery_packet(payload)
         except Exception as exc:
             print(json.dumps(_error_packet(exc), sort_keys=True))
             return 1
@@ -109,9 +147,7 @@ def run(argv: Sequence[str] | None = None) -> int:
         return 0
     try:
         if args.command == "reduce":
-            packet = build_finance_value_discovery_packet(
-                _load_json(args.input_json)
-            )
+            packet = build_finance_value_discovery_packet(_load_json(args.input_json))
         elif args.command == "evaluate":
             packet = build_finance_case_evaluation(_load_json(args.input_json))
         elif args.command == "replay":
@@ -119,8 +155,27 @@ def run(argv: Sequence[str] | None = None) -> int:
                 _load_json(args.input_json),
                 _load_json(args.expected_json),
             )
+        elif args.command == "attribute-beta":
+            packet = build_finance_beta_attribution(_load_json(args.input_json))
+        elif args.command == "replay-beta":
+            packet = replay_finance_beta_attribution(
+                _load_json(args.input_json),
+                _load_json(args.expected_json),
+            )
+        elif args.command == "evaluate-pack":
+            packet = build_finance_metric_pack_evaluation(_load_json(args.input_json))
+        elif args.command == "replay-pack":
+            packet = replay_finance_metric_pack_evaluation(
+                _load_json(args.input_json),
+                _load_json(args.expected_json),
+            )
+        elif args.command == "list-packs":
+            packet = list_finance_metric_packs()
         else:
-            raise ValueError("use --doctor, reduce, evaluate, or replay")
+            raise ValueError(
+                "use --doctor, reduce, evaluate, replay, attribute-beta, "
+                "replay-beta, evaluate-pack, replay-pack, or list-packs"
+            )
     except Exception as exc:
         print(json.dumps(_error_packet(exc), indent=2, sort_keys=True))
         return 1

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/cli.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/cli.py
@@ -7,6 +7,11 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
+from .contract import FINANCE_CASE_INPUT_SCHEMA_VERSION
+from .replay import (
+    build_finance_case_evaluation,
+    replay_finance_case_evaluation,
+)
 from .reducer import (
     FINANCE_VALUE_DISCOVERY_ERROR_SCHEMA_VERSION,
     build_finance_value_discovery_packet,
@@ -63,6 +68,21 @@ def _direct_parser() -> argparse.ArgumentParser:
     reduce_parser.add_argument(
         "--format", choices=("json", "markdown"), default="markdown"
     )
+    evaluate_parser = sub.add_parser(
+        "evaluate",
+        help="Evaluate ordered finance gates over frozen public evidence.",
+    )
+    evaluate_parser.add_argument(
+        "--input-json",
+        required=True,
+        help=f"Path to a {FINANCE_CASE_INPUT_SCHEMA_VERSION} object, or '-' for stdin.",
+    )
+    replay_parser = sub.add_parser(
+        "replay",
+        help="Verify a prior finance gate evaluation byte-for-byte.",
+    )
+    replay_parser.add_argument("--input-json", required=True)
+    replay_parser.add_argument("--expected-json", required=True)
     return parser
 
 
@@ -73,7 +93,11 @@ def run(argv: Sequence[str] | None = None) -> int:
             payload = json.load(sys.stdin)
             if not isinstance(payload, Mapping):
                 raise ValueError("provider input must be a JSON object")
-            packet = build_finance_value_discovery_packet(payload)
+            packet = (
+                build_finance_case_evaluation(payload)
+                if payload.get("schema_version") == FINANCE_CASE_INPUT_SCHEMA_VERSION
+                else build_finance_value_discovery_packet(payload)
+            )
         except Exception as exc:
             print(json.dumps(_error_packet(exc), sort_keys=True))
             return 1
@@ -83,14 +107,24 @@ def run(argv: Sequence[str] | None = None) -> int:
     args = _direct_parser().parse_args(arguments)
     if args.doctor:
         return 0
-    if args.command != "reduce":
-        raise ValueError("use --doctor or the reduce command")
     try:
-        packet = build_finance_value_discovery_packet(_load_json(args.input_json))
+        if args.command == "reduce":
+            packet = build_finance_value_discovery_packet(
+                _load_json(args.input_json)
+            )
+        elif args.command == "evaluate":
+            packet = build_finance_case_evaluation(_load_json(args.input_json))
+        elif args.command == "replay":
+            packet = replay_finance_case_evaluation(
+                _load_json(args.input_json),
+                _load_json(args.expected_json),
+            )
+        else:
+            raise ValueError("use --doctor, reduce, evaluate, or replay")
     except Exception as exc:
         print(json.dumps(_error_packet(exc), indent=2, sort_keys=True))
         return 1
-    if args.format == "json":
+    if args.command != "reduce" or args.format == "json":
         print(json.dumps(packet, indent=2, sort_keys=True))
     else:
         print(render_finance_value_discovery_markdown(packet), end="")

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/contract.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/contract.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import date, datetime
+from typing import Any
+
+from .boundary import reject_forbidden_material
+
+
+FINANCE_CASE_CONTRACT_SCHEMA_VERSION = "finance_case_contract_v1"
+FINANCE_CASE_INPUT_SCHEMA_VERSION = "finance_case_gate_input_v1"
+FINANCE_CASE_EVALUATION_SCHEMA_VERSION = "finance_case_gate_evaluation_v1"
+
+MIN_GATE_COUNT = 1
+MAX_GATE_COUNT = 16
+VALUE_TYPES = {"boolean", "number", "string"}
+OPERATORS_BY_VALUE_TYPE = {
+    "boolean": {"eq"},
+    "number": {"eq", "gt", "gte", "lt", "lte"},
+    "string": {"eq"},
+}
+
+
+def _text(value: object, *, field: str, limit: int = 160) -> str:
+    result = " ".join(str(value or "").split())
+    if not result:
+        raise ValueError(f"{field} is required")
+    if len(result) > limit:
+        raise ValueError(f"{field} exceeds {limit} characters")
+    reject_forbidden_material(result, path=field)
+    return result
+
+
+def _iso_date(value: object, *, field: str) -> str:
+    result = _text(value, field=field, limit=40)
+    try:
+        if "T" in result:
+            datetime.fromisoformat(result.replace("Z", "+00:00"))
+        else:
+            date.fromisoformat(result)
+    except ValueError as exc:
+        raise ValueError(f"{field} must be an ISO-8601 date or datetime") from exc
+    return result
+
+
+def _required_boolean(
+    payload: Mapping[str, Any],
+    field: str,
+    *,
+    expected: bool,
+) -> bool:
+    if payload.get(field) is not expected:
+        raise ValueError(f"{field} must be {str(expected).lower()}")
+    return expected
+
+
+def _gate_rule(value: object, *, index: int) -> dict[str, Any]:
+    field = f"contract.gates[{index}]"
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field} must be an object")
+    allowed = {"gate_id", "value_type", "operator", "reference_value"}
+    if set(value) - allowed:
+        raise ValueError(f"{field} has unsupported fields")
+    value_type = _text(
+        value.get("value_type"), field=f"{field}.value_type", limit=24
+    )
+    if value_type not in VALUE_TYPES:
+        raise ValueError(f"{field}.value_type must be one of {sorted(VALUE_TYPES)}")
+    operator = _text(value.get("operator"), field=f"{field}.operator", limit=16)
+    if operator not in OPERATORS_BY_VALUE_TYPE[value_type]:
+        raise ValueError(
+            f"{field}.operator must be one of "
+            f"{sorted(OPERATORS_BY_VALUE_TYPE[value_type])}"
+        )
+    reference = value.get("reference_value")
+    if value_type == "boolean" and not isinstance(reference, bool):
+        raise ValueError(f"{field}.reference_value must be a boolean")
+    if value_type == "number" and (
+        not isinstance(reference, (int, float)) or isinstance(reference, bool)
+    ):
+        raise ValueError(f"{field}.reference_value must be a number")
+    if value_type == "string":
+        reference = _text(
+            reference, field=f"{field}.reference_value", limit=120
+        )
+    return {
+        "gate_id": _text(value.get("gate_id"), field=f"{field}.gate_id", limit=80),
+        "value_type": value_type,
+        "operator": operator,
+        "reference_value": reference,
+    }
+
+
+def validate_finance_case_contract(value: object) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError("contract must be an object")
+    reject_forbidden_material(value, path="contract")
+    allowed = {
+        "schema_version",
+        "contract_id",
+        "method_revision",
+        "point_in_time",
+        "universe_id",
+        "universe_frozen",
+        "identities_frozen",
+        "thresholds_frozen",
+        "outcome_blind",
+        "public_evidence_only",
+        "gates",
+        "investment_advice_allowed",
+        "trading_allowed",
+        "automatic_promotion_allowed",
+    }
+    if set(value) - allowed:
+        raise ValueError("contract has unsupported fields")
+    if value.get("schema_version") != FINANCE_CASE_CONTRACT_SCHEMA_VERSION:
+        raise ValueError(
+            f"contract.schema_version must be {FINANCE_CASE_CONTRACT_SCHEMA_VERSION}"
+        )
+    raw_gates = value.get("gates")
+    if not isinstance(raw_gates, Sequence) or isinstance(
+        raw_gates, (str, bytes, bytearray)
+    ):
+        raise ValueError("contract.gates must be a list")
+    if not MIN_GATE_COUNT <= len(raw_gates) <= MAX_GATE_COUNT:
+        raise ValueError(
+            f"contract.gates must contain between {MIN_GATE_COUNT} "
+            f"and {MAX_GATE_COUNT} gates"
+        )
+    gates = [
+        _gate_rule(item, index=index)
+        for index, item in enumerate(raw_gates)
+    ]
+    gate_ids = [item["gate_id"] for item in gates]
+    if len(gate_ids) != len(set(gate_ids)):
+        raise ValueError("contract.gates must use unique gate ids")
+    return {
+        "schema_version": FINANCE_CASE_CONTRACT_SCHEMA_VERSION,
+        "contract_id": _text(
+            value.get("contract_id"), field="contract.contract_id", limit=96
+        ),
+        "method_revision": _text(
+            value.get("method_revision"),
+            field="contract.method_revision",
+            limit=96,
+        ),
+        "point_in_time": _iso_date(
+            value.get("point_in_time"), field="contract.point_in_time"
+        ),
+        "universe_id": _text(
+            value.get("universe_id"), field="contract.universe_id", limit=96
+        ),
+        "universe_frozen": _required_boolean(
+            value, "universe_frozen", expected=True
+        ),
+        "identities_frozen": _required_boolean(
+            value, "identities_frozen", expected=True
+        ),
+        "thresholds_frozen": _required_boolean(
+            value, "thresholds_frozen", expected=True
+        ),
+        "outcome_blind": _required_boolean(value, "outcome_blind", expected=True),
+        "public_evidence_only": _required_boolean(
+            value, "public_evidence_only", expected=True
+        ),
+        "gates": gates,
+        "investment_advice_allowed": _required_boolean(
+            value, "investment_advice_allowed", expected=False
+        ),
+        "trading_allowed": _required_boolean(
+            value, "trading_allowed", expected=False
+        ),
+        "automatic_promotion_allowed": _required_boolean(
+            value, "automatic_promotion_allowed", expected=False
+        ),
+    }
+
+
+def validate_finance_case_input(value: object) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError("finance case input must be an object")
+    reject_forbidden_material(value)
+    allowed = {"schema_version", "case_id", "contract", "observations"}
+    if set(value) - allowed:
+        raise ValueError("finance case input has unsupported fields")
+    if value.get("schema_version") != FINANCE_CASE_INPUT_SCHEMA_VERSION:
+        raise ValueError(
+            f"schema_version must be {FINANCE_CASE_INPUT_SCHEMA_VERSION}"
+        )
+    observations = value.get("observations")
+    if not isinstance(observations, Sequence) or isinstance(
+        observations, (str, bytes, bytearray)
+    ):
+        raise ValueError("observations must be a list")
+    return {
+        "schema_version": FINANCE_CASE_INPUT_SCHEMA_VERSION,
+        "case_id": _text(value.get("case_id"), field="case_id", limit=96),
+        "contract": validate_finance_case_contract(value.get("contract")),
+        "observations": list(observations),
+    }

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/contract.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/contract.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from datetime import date, datetime
+from math import isfinite
 from typing import Any
 
 from .boundary import reject_forbidden_material
-
 
 FINANCE_CASE_CONTRACT_SCHEMA_VERSION = "finance_case_contract_v1"
 FINANCE_CASE_INPUT_SCHEMA_VERSION = "finance_case_gate_input_v1"
@@ -75,10 +75,11 @@ def _gate_rule(value: object, *, index: int) -> dict[str, Any]:
     reference = value.get("reference_value")
     if value_type == "boolean" and not isinstance(reference, bool):
         raise ValueError(f"{field}.reference_value must be a boolean")
-    if value_type == "number" and (
-        not isinstance(reference, (int, float)) or isinstance(reference, bool)
-    ):
-        raise ValueError(f"{field}.reference_value must be a number")
+    if value_type == "number":
+        if not isinstance(reference, (int, float)) or isinstance(reference, bool):
+            raise ValueError(f"{field}.reference_value must be a number")
+        if isinstance(reference, float) and not isfinite(reference):
+            raise ValueError(f"{field}.reference_value must be a finite number")
     if value_type == "string":
         reference = _text(
             reference, field=f"{field}.reference_value", limit=120

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/contract.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/contract.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 from math import isfinite
 from typing import Any
 
@@ -47,7 +47,7 @@ def iso_comparable_datetime(value: str) -> datetime:
     """Parse an ISO date or datetime into a comparable datetime (UTC-naive)."""
     if "T" in value:
         parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-        return parsed.replace(tzinfo=None) if parsed.tzinfo else parsed
+        return parsed.astimezone(UTC).replace(tzinfo=None) if parsed.tzinfo else parsed
     return datetime.combine(date.fromisoformat(value), datetime.min.time())
 
 

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/contract.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/contract.py
@@ -43,6 +43,14 @@ def _iso_date(value: object, *, field: str) -> str:
     return result
 
 
+def _as_datetime(value: str) -> datetime:
+    """Parse an ISO date or datetime into a comparable datetime (UTC-naive)."""
+    if "T" in value:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return parsed.replace(tzinfo=None) if parsed.tzinfo else parsed
+    return datetime.combine(date.fromisoformat(value), datetime.min.time())
+
+
 def _required_boolean(
     payload: Mapping[str, Any],
     field: str,
@@ -101,6 +109,7 @@ def validate_finance_case_contract(value: object) -> dict[str, Any]:
         "contract_id",
         "method_revision",
         "point_in_time",
+        "evaluation_as_of",
         "universe_id",
         "universe_frozen",
         "identities_frozen",
@@ -135,6 +144,16 @@ def validate_finance_case_contract(value: object) -> dict[str, Any]:
     gate_ids = [item["gate_id"] for item in gates]
     if len(gate_ids) != len(set(gate_ids)):
         raise ValueError("contract.gates must use unique gate ids")
+    point_in_time = _iso_date(
+        value.get("point_in_time"), field="contract.point_in_time"
+    )
+    evaluation_as_of = _iso_date(
+        value.get("evaluation_as_of"), field="contract.evaluation_as_of"
+    )
+    if _as_datetime(point_in_time) > _as_datetime(evaluation_as_of):
+        raise ValueError(
+            "contract.point_in_time must not be after contract.evaluation_as_of"
+        )
     return {
         "schema_version": FINANCE_CASE_CONTRACT_SCHEMA_VERSION,
         "contract_id": _text(
@@ -145,9 +164,8 @@ def validate_finance_case_contract(value: object) -> dict[str, Any]:
             field="contract.method_revision",
             limit=96,
         ),
-        "point_in_time": _iso_date(
-            value.get("point_in_time"), field="contract.point_in_time"
-        ),
+        "point_in_time": point_in_time,
+        "evaluation_as_of": evaluation_as_of,
         "universe_id": _text(
             value.get("universe_id"), field="contract.universe_id", limit=96
         ),
@@ -160,9 +178,18 @@ def validate_finance_case_contract(value: object) -> dict[str, Any]:
         "thresholds_frozen": _required_boolean(
             value, "thresholds_frozen", expected=True
         ),
-        "outcome_blind": _required_boolean(value, "outcome_blind", expected=True),
-        "public_evidence_only": _required_boolean(
-            value, "public_evidence_only", expected=True
+        # These two remain caller assertions until a public lineage contract can
+        # verify them; the engine records the assertion state rather than
+        # projecting an unverified guarantee as fact.
+        "outcome_blind_state": (
+            "caller_asserted"
+            if _required_boolean(value, "outcome_blind", expected=True)
+            else "unset"
+        ),
+        "public_evidence_only_state": (
+            "caller_asserted"
+            if _required_boolean(value, "public_evidence_only", expected=True)
+            else "unset"
         ),
         "gates": gates,
         "investment_advice_allowed": _required_boolean(

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/contract.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/contract.py
@@ -31,7 +31,7 @@ def _text(value: object, *, field: str, limit: int = 160) -> str:
     return result
 
 
-def _iso_date(value: object, *, field: str) -> str:
+def validate_iso_date(value: object, *, field: str) -> str:
     result = _text(value, field=field, limit=40)
     try:
         if "T" in result:
@@ -43,7 +43,7 @@ def _iso_date(value: object, *, field: str) -> str:
     return result
 
 
-def _as_datetime(value: str) -> datetime:
+def iso_comparable_datetime(value: str) -> datetime:
     """Parse an ISO date or datetime into a comparable datetime (UTC-naive)."""
     if "T" in value:
         parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
@@ -144,13 +144,13 @@ def validate_finance_case_contract(value: object) -> dict[str, Any]:
     gate_ids = [item["gate_id"] for item in gates]
     if len(gate_ids) != len(set(gate_ids)):
         raise ValueError("contract.gates must use unique gate ids")
-    point_in_time = _iso_date(
+    point_in_time = validate_iso_date(
         value.get("point_in_time"), field="contract.point_in_time"
     )
-    evaluation_as_of = _iso_date(
+    evaluation_as_of = validate_iso_date(
         value.get("evaluation_as_of"), field="contract.evaluation_as_of"
     )
-    if _as_datetime(point_in_time) > _as_datetime(evaluation_as_of):
+    if iso_comparable_datetime(point_in_time) > iso_comparable_datetime(evaluation_as_of):
         raise ValueError(
             "contract.point_in_time must not be after contract.evaluation_as_of"
         )
@@ -208,7 +208,7 @@ def validate_finance_case_input(value: object) -> dict[str, Any]:
     if not isinstance(value, Mapping):
         raise ValueError("finance case input must be an object")
     reject_forbidden_material(value)
-    allowed = {"schema_version", "case_id", "contract", "observations"}
+    allowed = {"schema_version", "case_id", "subject_ref", "contract", "observations"}
     if set(value) - allowed:
         raise ValueError("finance case input has unsupported fields")
     if value.get("schema_version") != FINANCE_CASE_INPUT_SCHEMA_VERSION:
@@ -223,6 +223,12 @@ def validate_finance_case_input(value: object) -> dict[str, Any]:
     return {
         "schema_version": FINANCE_CASE_INPUT_SCHEMA_VERSION,
         "case_id": _text(value.get("case_id"), field="case_id", limit=96),
+        # The subject the gated case is about. Binding it here makes it part of
+        # the canonical case identity, so a passing gate cannot be reused to
+        # present an attribution for a different security as research-complete.
+        "subject_ref": _text(
+            value.get("subject_ref"), field="subject_ref", limit=96
+        ),
         "contract": validate_finance_case_contract(value.get("contract")),
         "observations": list(observations),
     }

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/gates.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/gates.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from math import isfinite
 from typing import Any
 
 from .boundary import reject_forbidden_material
@@ -8,7 +9,6 @@ from .contract import (
     FINANCE_CASE_EVALUATION_SCHEMA_VERSION,
     validate_finance_case_input,
 )
-
 
 OBSERVATION_STATES = {"observed", "missing", "conflict", "not_run"}
 BLOCKING_GATE_STATES = {"failed", "missing", "conflict"}
@@ -95,6 +95,8 @@ def _observed_value_matches(rule: Mapping[str, Any], value: object) -> bool:
     elif value_type == "number":
         if not isinstance(value, (int, float)) or isinstance(value, bool):
             raise ValueError(f"gate {rule['gate_id']} value must be a number")
+        if isinstance(value, float) and not isfinite(value):
+            raise ValueError(f"gate {rule['gate_id']} value must be a finite number")
     elif value_type == "string":
         if not isinstance(value, str):
             raise ValueError(f"gate {rule['gate_id']} value must be a string")

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/gates.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/gates.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from .boundary import reject_forbidden_material
+from .contract import (
+    FINANCE_CASE_EVALUATION_SCHEMA_VERSION,
+    validate_finance_case_input,
+)
+
+
+OBSERVATION_STATES = {"observed", "missing", "conflict", "not_run"}
+BLOCKING_GATE_STATES = {"failed", "missing", "conflict"}
+DISPOSITION_BY_BLOCKING_STATE = {
+    "failed": "rejected",
+    "missing": "insufficient_evidence",
+    "conflict": "insufficient_evidence",
+}
+
+
+def _text(value: object, *, field: str, limit: int = 320) -> str:
+    result = " ".join(str(value or "").split())
+    if not result:
+        raise ValueError(f"{field} is required")
+    if len(result) > limit:
+        raise ValueError(f"{field} exceeds {limit} characters")
+    reject_forbidden_material(result, path=field)
+    return result
+
+
+def _evidence_refs(value: object, *, field: str) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise ValueError(f"{field} must be a list")
+    if len(value) > 12:
+        raise ValueError(f"{field} must contain at most 12 items")
+    refs = [
+        _text(item, field=f"{field}[{index}]", limit=120)
+        for index, item in enumerate(value)
+    ]
+    if len(refs) != len(set(refs)):
+        raise ValueError(f"{field} must use unique evidence refs")
+    return refs
+
+
+def _observation(value: object, *, index: int) -> dict[str, Any]:
+    field = f"observations[{index}]"
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field} must be an object")
+    allowed = {
+        "gate_id",
+        "observation_state",
+        "value",
+        "evidence_refs",
+        "reason",
+    }
+    if set(value) - allowed:
+        raise ValueError(f"{field} has unsupported fields")
+    observation_state = _text(
+        value.get("observation_state"),
+        field=f"{field}.observation_state",
+        limit=24,
+    )
+    if observation_state not in OBSERVATION_STATES:
+        raise ValueError(
+            f"{field}.observation_state must be one of "
+            f"{sorted(OBSERVATION_STATES)}"
+        )
+    refs = _evidence_refs(value.get("evidence_refs"), field=f"{field}.evidence_refs")
+    if observation_state == "observed" and not refs:
+        raise ValueError(f"{field} observed values require evidence_refs")
+    if observation_state == "conflict" and len(refs) < 2:
+        raise ValueError(f"{field} conflicts require at least two evidence_refs")
+    if observation_state == "not_run" and refs:
+        raise ValueError(f"{field} not_run cannot include evidence_refs")
+    observed_value = value.get("value")
+    if observation_state == "observed" and observed_value is None:
+        raise ValueError(f"{field} observed values require value")
+    if observation_state != "observed" and observed_value is not None:
+        raise ValueError(f"{field} value is only valid when observed")
+    return {
+        "gate_id": _text(value.get("gate_id"), field=f"{field}.gate_id", limit=80),
+        "observation_state": observation_state,
+        "value": observed_value,
+        "evidence_refs": refs,
+        "reason": _text(value.get("reason"), field=f"{field}.reason"),
+    }
+
+
+def _observed_value_matches(rule: Mapping[str, Any], value: object) -> bool:
+    value_type = rule["value_type"]
+    if value_type == "boolean":
+        if not isinstance(value, bool):
+            raise ValueError(f"gate {rule['gate_id']} value must be a boolean")
+    elif value_type == "number":
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            raise ValueError(f"gate {rule['gate_id']} value must be a number")
+    elif value_type == "string":
+        if not isinstance(value, str):
+            raise ValueError(f"gate {rule['gate_id']} value must be a string")
+        reject_forbidden_material(value, path=f"gate {rule['gate_id']} value")
+
+    reference = rule["reference_value"]
+    operator = rule["operator"]
+    if operator == "eq":
+        return value == reference
+    if operator == "gt":
+        return value > reference
+    if operator == "gte":
+        return value >= reference
+    if operator == "lt":
+        return value < reference
+    if operator == "lte":
+        return value <= reference
+    raise ValueError(f"gate {rule['gate_id']} has unsupported operator")
+
+
+def evaluate_finance_case_gates(value: object) -> dict[str, Any]:
+    payload = validate_finance_case_input(value)
+    contract = payload["contract"]
+    observations = [
+        _observation(item, index=index)
+        for index, item in enumerate(payload["observations"])
+    ]
+    gate_order = [item["gate_id"] for item in contract["gates"]]
+    observed_order = [item["gate_id"] for item in observations]
+    if observed_order != gate_order:
+        raise ValueError("observations must exactly match contract.gates order")
+
+    blocking_gate: dict[str, Any] | None = None
+    gate_results: list[dict[str, Any]] = []
+    for rule, observation in zip(contract["gates"], observations, strict=True):
+        observation_state = observation["observation_state"]
+        if blocking_gate is not None:
+            if observation_state != "not_run":
+                raise ValueError(
+                    "gates after the first blocking gate must use state=not_run"
+                )
+            state = "not_run"
+            gate_results.append({**observation, "rule": rule, "state": state})
+            continue
+        if observation_state == "not_run":
+            raise ValueError("state=not_run requires an earlier blocking gate")
+        state = observation_state
+        if observation_state == "observed":
+            state = (
+                "passed"
+                if _observed_value_matches(rule, observation["value"])
+                else "failed"
+            )
+        gate_result = {**observation, "rule": rule, "state": state}
+        gate_results.append(gate_result)
+        if state in BLOCKING_GATE_STATES:
+            blocking_gate = gate_result
+
+    if blocking_gate is None:
+        disposition = "eligible_for_research_successor"
+    else:
+        disposition = DISPOSITION_BY_BLOCKING_STATE[blocking_gate["state"]]
+    return {
+        "ok": True,
+        "schema_version": FINANCE_CASE_EVALUATION_SCHEMA_VERSION,
+        "case_id": payload["case_id"],
+        "contract": contract,
+        "gate_results": gate_results,
+        "disposition": disposition,
+        "first_blocking_gate": (
+            {
+                "gate_id": blocking_gate["gate_id"],
+                "state": blocking_gate["state"],
+                "reason": blocking_gate["reason"],
+            }
+            if blocking_gate is not None
+            else None
+        ),
+        "boundary": {
+            "public_evidence_only": True,
+            "outcome_blind": True,
+            "investment_advice": False,
+            "trading_allowed": False,
+            "automatic_promotion_allowed": False,
+            "human_decision_owner": True,
+        },
+    }

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/gates.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/gates.py
@@ -163,6 +163,7 @@ def evaluate_finance_case_gates(value: object) -> dict[str, Any]:
         "ok": True,
         "schema_version": FINANCE_CASE_EVALUATION_SCHEMA_VERSION,
         "case_id": payload["case_id"],
+        "subject_ref": payload["subject_ref"],
         "contract": contract,
         "gate_results": gate_results,
         "disposition": disposition,

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/gates.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/gates.py
@@ -176,8 +176,8 @@ def evaluate_finance_case_gates(value: object) -> dict[str, Any]:
             else None
         ),
         "boundary": {
-            "public_evidence_only": True,
-            "outcome_blind": True,
+            "public_evidence_only_state": contract["public_evidence_only_state"],
+            "outcome_blind_state": contract["outcome_blind_state"],
             "investment_advice": False,
             "trading_allowed": False,
             "automatic_promotion_allowed": False,

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/metric_packs.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/metric_packs.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+from typing import Any
+
+from .boundary import reject_forbidden_material
+from .contract import validate_finance_case_input
+from .replay import (
+    build_finance_case_evaluation,
+    canonical_json_bytes,
+    canonical_sha256,
+)
+
+FINANCE_METRIC_PACK_INPUT_SCHEMA_VERSION = "finance_metric_pack_input_v1"
+FINANCE_METRIC_PACK_EVALUATION_SCHEMA_VERSION = "finance_metric_pack_evaluation_v1"
+FINANCE_METRIC_PACK_REPLAY_SCHEMA_VERSION = "finance_metric_pack_replay_v1"
+
+COMMON_GATE_IDS = {
+    "source_lineage",
+    "point_in_time",
+    "identity",
+    "evidence_quality",
+    "valuation",
+    "terminal_risk",
+}
+
+_METRIC_PACKS: dict[str, dict[str, Any]] = {
+    "software_platforms_v1": {
+        "pack_id": "software_platforms_v1",
+        "description": "Recurring software and platform economics.",
+        "metrics": [
+            {
+                "metric_id": "recurring_revenue_growth",
+                "value_type": "number",
+                "allowed_operators": ["gt", "gte"],
+            },
+            {
+                "metric_id": "gross_margin",
+                "value_type": "number",
+                "allowed_operators": ["gt", "gte"],
+            },
+            {
+                "metric_id": "free_cash_flow_conversion",
+                "value_type": "number",
+                "allowed_operators": ["gt", "gte"],
+            },
+            {
+                "metric_id": "sbc_dilution",
+                "value_type": "number",
+                "allowed_operators": ["lt", "lte"],
+            },
+        ],
+    },
+    "cyclical_industrials_v1": {
+        "pack_id": "cyclical_industrials_v1",
+        "description": "Cyclical industrial operating and balance-sheet quality.",
+        "metrics": [
+            {
+                "metric_id": "organic_revenue_growth",
+                "value_type": "number",
+                "allowed_operators": ["gt", "gte"],
+            },
+            {
+                "metric_id": "incremental_margin",
+                "value_type": "number",
+                "allowed_operators": ["gt", "gte"],
+            },
+            {
+                "metric_id": "free_cash_flow_conversion",
+                "value_type": "number",
+                "allowed_operators": ["gt", "gte"],
+            },
+            {
+                "metric_id": "net_debt_to_ebitda",
+                "value_type": "number",
+                "allowed_operators": ["lt", "lte"],
+            },
+        ],
+    },
+}
+
+
+def list_finance_metric_packs() -> dict[str, Any]:
+    return {
+        "ok": True,
+        "schema_version": "finance_metric_pack_catalog_v1",
+        "packs": [
+            deepcopy(_METRIC_PACKS[pack_id]) for pack_id in sorted(_METRIC_PACKS)
+        ],
+        "truth_contract": {
+            "packs_define_metric_semantics": True,
+            "case_contract_owns_thresholds": True,
+            "common_engine_owns_missing_and_conflict": True,
+            "human_owns_promotion": True,
+        },
+    }
+
+
+def _metric_pack(pack_id: object) -> dict[str, Any]:
+    if not isinstance(pack_id, str) or pack_id not in _METRIC_PACKS:
+        raise ValueError(f"pack_id must be one of {sorted(_METRIC_PACKS)}")
+    return deepcopy(_METRIC_PACKS[pack_id])
+
+
+def _validate_pack_contract(
+    pack: Mapping[str, Any],
+    case_input: Mapping[str, Any],
+) -> None:
+    metrics = {
+        str(item["metric_id"]): item
+        for item in pack["metrics"]
+        if isinstance(item, Mapping)
+    }
+    gates = case_input["contract"]["gates"]
+    gate_ids = {str(item["gate_id"]) for item in gates}
+    unknown = gate_ids - COMMON_GATE_IDS - set(metrics)
+    if unknown:
+        raise ValueError(
+            "metric pack contract has unsupported gate ids: "
+            + ", ".join(sorted(unknown))
+        )
+    missing = set(metrics) - gate_ids
+    if missing:
+        raise ValueError(
+            "metric pack contract is missing required metrics: "
+            + ", ".join(sorted(missing))
+        )
+    for gate in gates:
+        metric = metrics.get(str(gate["gate_id"]))
+        if metric is None:
+            continue
+        if gate["value_type"] != metric["value_type"]:
+            raise ValueError(
+                f"metric {gate['gate_id']} must use value_type={metric['value_type']}"
+            )
+        if gate["operator"] not in metric["allowed_operators"]:
+            raise ValueError(
+                f"metric {gate['gate_id']} operator must be one of "
+                f"{metric['allowed_operators']}"
+            )
+
+
+def build_finance_metric_pack_evaluation(value: object) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError("finance metric pack input must be an object")
+    reject_forbidden_material(value)
+    allowed = {"schema_version", "pack_id", "case_input"}
+    if set(value) - allowed:
+        raise ValueError("finance metric pack input has unsupported fields")
+    if value.get("schema_version") != FINANCE_METRIC_PACK_INPUT_SCHEMA_VERSION:
+        raise ValueError(
+            f"schema_version must be {FINANCE_METRIC_PACK_INPUT_SCHEMA_VERSION}"
+        )
+    pack = _metric_pack(value.get("pack_id"))
+    raw_case_input = value.get("case_input")
+    case_input = validate_finance_case_input(raw_case_input)
+    _validate_pack_contract(pack, case_input)
+    gate_evaluation = build_finance_case_evaluation(raw_case_input)
+    evaluation = {
+        "ok": True,
+        "schema_version": FINANCE_METRIC_PACK_EVALUATION_SCHEMA_VERSION,
+        "pack": pack,
+        "case_evaluation": gate_evaluation,
+        "disposition": gate_evaluation["disposition"],
+        "boundary": gate_evaluation["boundary"],
+    }
+    replay = {
+        "schema_version": FINANCE_METRIC_PACK_REPLAY_SCHEMA_VERSION,
+        "input_sha256": canonical_sha256(value),
+        "pack_sha256": canonical_sha256(pack),
+        "evaluation_sha256": canonical_sha256(evaluation),
+        "canonicalization": "json_sort_keys_compact_ascii_v1",
+    }
+    return {**evaluation, "replay": replay}
+
+
+def replay_finance_metric_pack_evaluation(
+    value: object,
+    expected: object,
+) -> dict[str, Any]:
+    if not isinstance(expected, Mapping):
+        raise ValueError("expected metric pack evaluation must be an object")
+    replayed = build_finance_metric_pack_evaluation(value)
+    expected_replay = expected.get("replay")
+    if not isinstance(expected_replay, Mapping):
+        raise ValueError("expected metric pack evaluation requires replay")
+    for field in ("input_sha256", "pack_sha256", "evaluation_sha256"):
+        if expected_replay.get(field) != replayed["replay"][field]:
+            raise ValueError(f"replay {field} mismatch")
+    if canonical_json_bytes(expected) != canonical_json_bytes(replayed):
+        raise ValueError("replay metric pack evaluation bytes mismatch")
+    return {
+        "ok": True,
+        "schema_version": FINANCE_METRIC_PACK_REPLAY_SCHEMA_VERSION,
+        "replay_verified": True,
+        "input_sha256": replayed["replay"]["input_sha256"],
+        "pack_sha256": replayed["replay"]["pack_sha256"],
+        "evaluation_sha256": replayed["replay"]["evaluation_sha256"],
+    }

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/metric_packs.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/metric_packs.py
@@ -24,6 +24,7 @@ COMMON_GATE_IDS = {
     "valuation",
     "terminal_risk",
 }
+REQUIRED_COMMON_GATE_PREFIX = ("source_lineage", "point_in_time")
 
 _METRIC_PACKS: dict[str, dict[str, Any]] = {
     "software_platforms_v1": {
@@ -113,6 +114,13 @@ def _validate_pack_contract(
         if isinstance(item, Mapping)
     }
     gates = case_input["contract"]["gates"]
+    gate_order = [str(item["gate_id"]) for item in gates]
+    if gate_order[: len(REQUIRED_COMMON_GATE_PREFIX)] != list(
+        REQUIRED_COMMON_GATE_PREFIX
+    ):
+        raise ValueError(
+            "metric pack contract must begin with source_lineage then point_in_time"
+        )
     gate_ids = {str(item["gate_id"]) for item in gates}
     unknown = gate_ids - COMMON_GATE_IDS - set(metrics)
     if unknown:

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/metric_packs.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/metric_packs.py
@@ -24,7 +24,20 @@ COMMON_GATE_IDS = {
     "valuation",
     "terminal_risk",
 }
-REQUIRED_COMMON_GATE_PREFIX = ("source_lineage", "point_in_time")
+REQUIRED_COMMON_GATE_RULES = (
+    {
+        "gate_id": "source_lineage",
+        "value_type": "boolean",
+        "operator": "eq",
+        "reference_value": True,
+    },
+    {
+        "gate_id": "point_in_time",
+        "value_type": "boolean",
+        "operator": "eq",
+        "reference_value": True,
+    },
+)
 
 _METRIC_PACKS: dict[str, dict[str, Any]] = {
     "software_platforms_v1": {
@@ -115,11 +128,15 @@ def _validate_pack_contract(
     }
     gates = case_input["contract"]["gates"]
     gate_order = [str(item["gate_id"]) for item in gates]
-    if gate_order[: len(REQUIRED_COMMON_GATE_PREFIX)] != list(
-        REQUIRED_COMMON_GATE_PREFIX
-    ):
+    required_gate_order = [str(item["gate_id"]) for item in REQUIRED_COMMON_GATE_RULES]
+    if gate_order[: len(required_gate_order)] != required_gate_order:
         raise ValueError(
             "metric pack contract must begin with source_lineage then point_in_time"
+        )
+    if tuple(gates[: len(REQUIRED_COMMON_GATE_RULES)]) != REQUIRED_COMMON_GATE_RULES:
+        raise ValueError(
+            "metric pack source_lineage and point_in_time gates must use "
+            "provider-neutral semantics"
         )
     gate_ids = {str(item["gate_id"]) for item in gates}
     unknown = gate_ids - COMMON_GATE_IDS - set(metrics)

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/reducer.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/reducer.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-import re
 from collections import Counter
 from collections.abc import Mapping, Sequence
 from datetime import date, datetime
 from ipaddress import ip_address
 from typing import Any
 from urllib.parse import urlsplit
+
+from .boundary import reject_forbidden_material
 
 
 FINANCE_VALUE_DISCOVERY_INPUT_SCHEMA_VERSION = "finance_value_discovery_input_v0"
@@ -47,59 +48,6 @@ EVIDENCE_AXES = (
     "price_implied_expectations",
 )
 
-FORBIDDEN_KEY_TOKENS = {
-    "account",
-    "auth",
-    "body",
-    "cookie",
-    "credential",
-    "holding",
-    "local",
-    "password",
-    "portfolio",
-    "private",
-    "raw",
-    "secret",
-    "token",
-    "trade",
-    "transcript",
-}
-FORBIDDEN_VALUE_PATTERNS = (
-    re.compile(r"\bBearer\s+", re.IGNORECASE),
-    re.compile(r"/Users/[A-Za-z0-9._-]+/"),
-    re.compile(r"/home/[A-Za-z0-9._-]+/"),
-    re.compile(r"[A-Za-z]:\\\\Users\\\\", re.IGNORECASE),
-    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
-)
-
-
-def _key_tokens(value: object) -> set[str]:
-    return {part for part in re.split(r"[^a-z0-9]+", str(value).lower()) if part}
-
-
-def _reject_forbidden_material(value: object, *, path: str = "input") -> None:
-    if isinstance(value, Mapping):
-        for key, item in value.items():
-            forbidden = _key_tokens(key) & FORBIDDEN_KEY_TOKENS
-            if forbidden:
-                raise ValueError(
-                    f"{path} contains forbidden key token(s): "
-                    + ", ".join(sorted(forbidden))
-                )
-            _reject_forbidden_material(item, path=f"{path}.{key}")
-        return
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        for index, item in enumerate(value):
-            _reject_forbidden_material(item, path=f"{path}[{index}]")
-        return
-    if isinstance(value, str) and any(
-        pattern.search(value) for pattern in FORBIDDEN_VALUE_PATTERNS
-    ):
-        raise ValueError(
-            f"{path} contains private path, auth material, or credential-like text"
-        )
-
-
 def _mapping(value: object, *, field: str) -> Mapping[str, Any]:
     if not isinstance(value, Mapping):
         raise ValueError(f"{field} must be an object")
@@ -112,7 +60,7 @@ def _text(value: object, *, field: str, limit: int = 320) -> str:
         raise ValueError(f"{field} is required")
     if len(result) > limit:
         raise ValueError(f"{field} exceeds {limit} characters")
-    _reject_forbidden_material(result, path=field)
+    reject_forbidden_material(result, path=field)
     return result
 
 
@@ -376,7 +324,7 @@ def _card(value: object, *, index: int) -> dict[str, Any]:
 
 
 def build_finance_value_discovery_packet(payload: Mapping[str, Any]) -> dict[str, Any]:
-    _reject_forbidden_material(payload)
+    reject_forbidden_material(payload)
     allowed = {
         "schema_version",
         "as_of",

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/replay.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/replay.py
@@ -7,13 +7,13 @@ from typing import Any
 
 from .gates import evaluate_finance_case_gates
 
-
 FINANCE_CASE_REPLAY_RECEIPT_SCHEMA_VERSION = "finance_case_replay_receipt_v1"
 
 
 def canonical_json_bytes(value: object) -> bytes:
     return json.dumps(
         value,
+        allow_nan=False,
         ensure_ascii=True,
         separators=(",", ":"),
         sort_keys=True,

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/replay.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/replay.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from .gates import evaluate_finance_case_gates
+
+
+FINANCE_CASE_REPLAY_RECEIPT_SCHEMA_VERSION = "finance_case_replay_receipt_v1"
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def canonical_sha256(value: object) -> str:
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def build_finance_case_evaluation(value: object) -> dict[str, Any]:
+    evaluation = evaluate_finance_case_gates(value)
+    receipt = {
+        "schema_version": FINANCE_CASE_REPLAY_RECEIPT_SCHEMA_VERSION,
+        "contract_sha256": canonical_sha256(evaluation["contract"]),
+        "input_sha256": canonical_sha256(value),
+        "evaluation_sha256": canonical_sha256(evaluation),
+        "canonicalization": "json_sort_keys_compact_ascii_v1",
+    }
+    return {**evaluation, "replay": receipt}
+
+
+def replay_finance_case_evaluation(
+    value: object,
+    expected: object,
+) -> dict[str, Any]:
+    if not isinstance(expected, Mapping):
+        raise ValueError("expected evaluation must be an object")
+    replayed = build_finance_case_evaluation(value)
+    expected_replay = expected.get("replay")
+    if not isinstance(expected_replay, Mapping):
+        raise ValueError("expected evaluation requires a replay receipt")
+    for field in ("contract_sha256", "input_sha256", "evaluation_sha256"):
+        if expected_replay.get(field) != replayed["replay"][field]:
+            raise ValueError(f"replay {field} mismatch")
+    if canonical_json_bytes(expected) != canonical_json_bytes(replayed):
+        raise ValueError("replay evaluation bytes mismatch")
+    return {
+        "ok": True,
+        "schema_version": FINANCE_CASE_REPLAY_RECEIPT_SCHEMA_VERSION,
+        "replay_verified": True,
+        "contract_sha256": replayed["replay"]["contract_sha256"],
+        "input_sha256": replayed["replay"]["input_sha256"],
+        "evaluation_sha256": replayed["replay"]["evaluation_sha256"],
+    }

--- a/tests/extensions/test_finance_beta_and_metric_packs.py
+++ b/tests/extensions/test_finance_beta_and_metric_packs.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+EXTENSION_ROOT = ROOT / "packages" / "loopx-finance-value-discovery"
+EXTENSION_SRC = EXTENSION_ROOT / "src"
+BETA_EXAMPLE = EXTENSION_ROOT / "examples" / "beta-attribution-v1.json"
+PACK_EXAMPLE = EXTENSION_ROOT / "examples" / "software-metric-pack-v1.json"
+sys.path.insert(0, str(EXTENSION_SRC))
+
+from loopx_finance_value_discovery.attribution import (  # noqa: E402
+    build_finance_beta_attribution,
+    replay_finance_beta_attribution,
+)
+from loopx_finance_value_discovery.cli import run  # noqa: E402
+from loopx_finance_value_discovery.metric_packs import (  # noqa: E402
+    build_finance_metric_pack_evaluation,
+    list_finance_metric_packs,
+    replay_finance_metric_pack_evaluation,
+)
+
+
+def _json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_complete_beta_attribution_computes_residual_and_replays() -> None:
+    payload = _json(BETA_EXAMPLE)
+    attribution = build_finance_beta_attribution(payload)
+
+    assert attribution["schema_version"] == "finance_beta_attribution_v1"
+    assert attribution["disposition"] == "complete"
+    assert attribution["explained_sum"] == "-0.11"
+    assert attribution["residual"] == "-0.01"
+    assert [item["component_id"] for item in attribution["components"]] == [
+        "market",
+        "rate",
+        "sector",
+        "narrow_peer",
+        "cycle",
+        "event",
+        "residual",
+    ]
+    assert attribution["components"][-1]["observation_state"] == "computed"
+    assert attribution["boundary"]["trading_allowed"] is False
+    assert attribution["boundary"]["automatic_promotion_allowed"] is False
+    assert (
+        replay_finance_beta_attribution(payload, attribution)["replay_verified"] is True
+    )
+
+
+@pytest.mark.parametrize("state", ["missing", "conflict"])
+def test_incomplete_beta_components_never_fabricate_a_residual(state: str) -> None:
+    payload = _json(BETA_EXAMPLE)
+    component = payload["components"][3]
+    component["observation_state"] = state
+    component["contribution"] = None
+    component["evidence_refs"] = (
+        [] if state == "missing" else ["peer-source-a", "peer-source-b"]
+    )
+    component["reason"] = "The narrow-peer contribution is not resolved."
+
+    attribution = build_finance_beta_attribution(payload)
+
+    assert attribution["disposition"] == "insufficient_evidence"
+    assert attribution["explained_sum"] is None
+    assert attribution["residual"] is None
+    assert attribution["components"][-1]["observation_state"] == "not_computable"
+    field = (
+        "missing_component_ids" if state == "missing" else "conflicting_component_ids"
+    )
+    assert attribution[field] == ["narrow_peer"]
+
+
+def test_beta_component_order_and_replay_input_are_frozen() -> None:
+    payload = _json(BETA_EXAMPLE)
+    expected = build_finance_beta_attribution(payload)
+
+    reordered = deepcopy(payload)
+    reordered["components"][0], reordered["components"][1] = (
+        reordered["components"][1],
+        reordered["components"][0],
+    )
+    with pytest.raises(ValueError, match="exactly match"):
+        build_finance_beta_attribution(reordered)
+
+    mutated = deepcopy(payload)
+    mutated["components"][0]["contribution"] = -0.05
+    with pytest.raises(ValueError, match="replay"):
+        replay_finance_beta_attribution(mutated, expected)
+
+
+def test_software_pack_adds_semantics_but_contract_owns_thresholds() -> None:
+    payload = _json(PACK_EXAMPLE)
+    evaluation = build_finance_metric_pack_evaluation(payload)
+
+    assert evaluation["schema_version"] == "finance_metric_pack_evaluation_v1"
+    assert evaluation["pack"]["pack_id"] == "software_platforms_v1"
+    assert evaluation["disposition"] == "rejected"
+    assert (
+        evaluation["case_evaluation"]["first_blocking_gate"]["gate_id"]
+        == "sbc_dilution"
+    )
+    contract_gate = evaluation["case_evaluation"]["contract"]["gates"][-1]
+    assert contract_gate["reference_value"] == 0.04
+    assert "reference_value" not in evaluation["pack"]["metrics"][-1]
+    assert evaluation["boundary"]["automatic_promotion_allowed"] is False
+    assert (
+        replay_finance_metric_pack_evaluation(payload, evaluation)["replay_verified"]
+        is True
+    )
+
+
+def test_metric_pack_catalog_is_deterministic_and_not_mutable_by_callers() -> None:
+    first = list_finance_metric_packs()
+    assert [item["pack_id"] for item in first["packs"]] == [
+        "cyclical_industrials_v1",
+        "software_platforms_v1",
+    ]
+    first["packs"][0]["metrics"][0]["metric_id"] = "tampered"
+
+    second = list_finance_metric_packs()
+    assert second["packs"][0]["metrics"][0]["metric_id"] == ("organic_revenue_growth")
+
+
+@pytest.mark.parametrize(
+    ("mutator", "message"),
+    [
+        (
+            lambda payload: payload["case_input"]["contract"]["gates"].append(
+                {
+                    "gate_id": "provider_owned_threshold",
+                    "value_type": "number",
+                    "operator": "gte",
+                    "reference_value": 1,
+                }
+            ),
+            "unsupported gate ids",
+        ),
+        (
+            lambda payload: (
+                payload["case_input"]["contract"]["gates"].pop(2),
+                payload["case_input"]["observations"].pop(2),
+            ),
+            "missing required metrics",
+        ),
+        (
+            lambda payload: payload["case_input"]["contract"]["gates"][2].update(
+                {"operator": "lte"}
+            ),
+            "operator must be one of",
+        ),
+    ],
+)
+def test_metric_pack_rejects_contract_drift(mutator, message: str) -> None:
+    payload = _json(PACK_EXAMPLE)
+    mutator(payload)
+    with pytest.raises(ValueError, match=message):
+        build_finance_metric_pack_evaluation(payload)
+
+
+def test_cyclical_industrials_pack_uses_the_common_gate_engine() -> None:
+    payload = _json(PACK_EXAMPLE)
+    payload["pack_id"] = "cyclical_industrials_v1"
+    metrics = [
+        ("organic_revenue_growth", "gte", 0.03, 0.05),
+        ("incremental_margin", "gte", 0.1, 0.12),
+        ("free_cash_flow_conversion", "gte", 0.7, 0.8),
+        ("net_debt_to_ebitda", "lte", 2.5, 1.9),
+    ]
+    payload["case_input"]["contract"]["gates"] = payload["case_input"]["contract"][
+        "gates"
+    ][:2]
+    payload["case_input"]["observations"] = payload["case_input"]["observations"][:2]
+    for metric_id, operator, threshold, observed_value in metrics:
+        payload["case_input"]["contract"]["gates"].append(
+            {
+                "gate_id": metric_id,
+                "value_type": "number",
+                "operator": operator,
+                "reference_value": threshold,
+            }
+        )
+        payload["case_input"]["observations"].append(
+            {
+                "gate_id": metric_id,
+                "observation_state": "observed",
+                "value": observed_value,
+                "evidence_refs": [f"{metric_id}-filing"],
+                "reason": "Frozen public filing observation.",
+            }
+        )
+
+    evaluation = build_finance_metric_pack_evaluation(payload)
+
+    assert evaluation["disposition"] == "eligible_for_research_successor"
+    assert evaluation["case_evaluation"]["first_blocking_gate"] is None
+
+
+def test_direct_cli_beta_pack_and_catalog(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert run(["attribute-beta", "--input-json", str(BETA_EXAMPLE)]) == 0
+    beta = json.loads(capsys.readouterr().out)
+    expected_beta = tmp_path / "beta.json"
+    expected_beta.write_text(json.dumps(beta), encoding="utf-8")
+    assert (
+        run(
+            [
+                "replay-beta",
+                "--input-json",
+                str(BETA_EXAMPLE),
+                "--expected-json",
+                str(expected_beta),
+            ]
+        )
+        == 0
+    )
+    assert json.loads(capsys.readouterr().out)["replay_verified"] is True
+
+    assert run(["evaluate-pack", "--input-json", str(PACK_EXAMPLE)]) == 0
+    pack = json.loads(capsys.readouterr().out)
+    expected_pack = tmp_path / "pack.json"
+    expected_pack.write_text(json.dumps(pack), encoding="utf-8")
+    assert (
+        run(
+            [
+                "replay-pack",
+                "--input-json",
+                str(PACK_EXAMPLE),
+                "--expected-json",
+                str(expected_pack),
+            ]
+        )
+        == 0
+    )
+    assert json.loads(capsys.readouterr().out)["replay_verified"] is True
+
+    assert run(["list-packs"]) == 0
+    assert (
+        json.loads(capsys.readouterr().out)["truth_contract"][
+            "case_contract_owns_thresholds"
+        ]
+        is True
+    )

--- a/tests/extensions/test_finance_beta_and_metric_packs.py
+++ b/tests/extensions/test_finance_beta_and_metric_packs.py
@@ -165,6 +165,24 @@ def test_metric_pack_rejects_contract_drift(mutator, message: str) -> None:
         build_finance_metric_pack_evaluation(payload)
 
 
+def test_metric_pack_requires_frozen_source_and_cutoff_prefix() -> None:
+    missing_source = _json(PACK_EXAMPLE)
+    missing_source["case_input"]["contract"]["gates"].pop(0)
+    missing_source["case_input"]["observations"].pop(0)
+    with pytest.raises(ValueError, match="must begin with source_lineage"):
+        build_finance_metric_pack_evaluation(missing_source)
+
+    reordered = _json(PACK_EXAMPLE)
+    reordered["case_input"]["contract"]["gates"][0:2] = reversed(
+        reordered["case_input"]["contract"]["gates"][0:2]
+    )
+    reordered["case_input"]["observations"][0:2] = reversed(
+        reordered["case_input"]["observations"][0:2]
+    )
+    with pytest.raises(ValueError, match="must begin with source_lineage"):
+        build_finance_metric_pack_evaluation(reordered)
+
+
 def test_cyclical_industrials_pack_uses_the_common_gate_engine() -> None:
     payload = _json(PACK_EXAMPLE)
     payload["pack_id"] = "cyclical_industrials_v1"

--- a/tests/extensions/test_finance_beta_and_metric_packs.py
+++ b/tests/extensions/test_finance_beta_and_metric_packs.py
@@ -335,6 +335,23 @@ def test_attribution_rejects_invalid_or_out_of_window_observation(
         build_finance_beta_attribution(payload)
 
 
+def test_attribution_rejects_offset_aware_observation_after_cutoff() -> None:
+    payload = _json(BETA_EXAMPLE)
+    payload["case_reference"]["observation_window"] = {
+        "start": "2026-07-27T23:00:00-04:00",
+        "end": "2026-07-27T23:30:00-04:00",
+    }
+    payload["gate_evaluation_input"]["contract"]["point_in_time"] = (
+        "2026-07-28T03:00:00Z"
+    )
+    payload["gate_evaluation_input"]["contract"]["evaluation_as_of"] = (
+        "2026-07-28T03:15:00Z"
+    )
+
+    with pytest.raises(ValueError, match="end must not exceed"):
+        build_finance_beta_attribution(payload)
+
+
 def test_gate_input_requires_subject_ref() -> None:
     payload = _json(BETA_EXAMPLE)
     del payload["gate_evaluation_input"]["subject_ref"]

--- a/tests/extensions/test_finance_beta_and_metric_packs.py
+++ b/tests/extensions/test_finance_beta_and_metric_packs.py
@@ -268,3 +268,61 @@ def test_direct_cli_beta_pack_and_catalog(
         ]
         is True
     )
+
+
+def _fail_gate_evaluation_input(payload: dict) -> dict:
+    """Flip the bound gate case into a failing/blocking disposition.
+
+    evidence_quality becomes the first blocking gate; every gate after it must
+    be not_run, while earlier gates keep their passing observation.
+    """
+    gei = payload["gate_evaluation_input"]
+    blocked = False
+    for obs in gei["observations"]:
+        if obs["gate_id"] == "evidence_quality":
+            obs.update(
+                {
+                    "observation_state": "missing",
+                    "value": None,
+                    "evidence_refs": [],
+                    "reason": "Evidence quality gate is unresolved.",
+                }
+            )
+            blocked = True
+        elif blocked:
+            obs.update(
+                {"observation_state": "not_run", "value": None, "evidence_refs": []}
+            )
+    return payload
+
+
+def test_attribution_cannot_be_reused_under_another_case() -> None:
+    payload = _json(BETA_EXAMPLE)
+    payload["case_reference"]["case_id"] = "some-other-case"
+    with pytest.raises(ValueError, match="case_id must match"):
+        build_finance_beta_attribution(payload)
+
+
+def test_failed_gate_cannot_be_presented_as_research_complete() -> None:
+    payload = _fail_gate_evaluation_input(_json(BETA_EXAMPLE))
+    attribution = build_finance_beta_attribution(payload)
+
+    # even with all six components observed, a non-eligible gate forces
+    # insufficient_evidence and refuses to fabricate a residual
+    assert attribution["gate_eligible"] is False
+    assert attribution["disposition"] == "insufficient_evidence"
+    assert attribution["residual"] is None
+    assert attribution["gate_evaluation_receipt"]["disposition"] != (
+        "eligible_for_research_successor"
+    )
+
+
+def test_attribution_binds_case_reference_and_gate_receipt() -> None:
+    payload = _json(BETA_EXAMPLE)
+    attribution = build_finance_beta_attribution(payload)
+
+    assert attribution["case_reference"]["case_id"] == (
+        payload["gate_evaluation_input"]["case_id"]
+    )
+    assert attribution["gate_evaluation_receipt"]["gate_eligible"] is True
+    assert attribution["gate_evaluation_receipt"]["evaluation_sha256"]

--- a/tests/extensions/test_finance_beta_and_metric_packs.py
+++ b/tests/extensions/test_finance_beta_and_metric_packs.py
@@ -303,6 +303,45 @@ def test_attribution_cannot_be_reused_under_another_case() -> None:
         build_finance_beta_attribution(payload)
 
 
+def test_attribution_cannot_be_reused_for_another_subject() -> None:
+    # Keeping the passing case_id but swapping the subject to a different
+    # security must not reuse the gate pass as research-complete.
+    payload = _json(BETA_EXAMPLE)
+    payload["case_reference"]["subject_ref"] = "unrelated-security-XYZ"
+    with pytest.raises(ValueError, match="subject_ref must match"):
+        build_finance_beta_attribution(payload)
+
+
+@pytest.mark.parametrize(
+    ("window", "match"),
+    [
+        ({"start": "not-a-date", "end": "2026-07-27"}, "start must be an ISO-8601"),
+        ({"start": "2026-07-23", "end": "still-not-a-date"}, "end must be an ISO-8601"),
+        ({"start": "2999-01-01", "end": "2999-12-31"}, "end must not exceed"),
+        ({"start": "2020-01-01", "end": "2026-07-27"}, "start must not precede"),
+        ({"start": "2026-07-27", "end": "2026-07-23"}, "start must not be after end"),
+    ],
+)
+def test_attribution_rejects_invalid_or_out_of_window_observation(
+    window: dict[str, str],
+    match: str,
+) -> None:
+    # observation_window must be real ISO dates inside the contract's frozen
+    # [point_in_time, evaluation_as_of] window; not-a-date and future windows
+    # cannot be presented as research-complete.
+    payload = _json(BETA_EXAMPLE)
+    payload["case_reference"]["observation_window"] = window
+    with pytest.raises(ValueError, match=match):
+        build_finance_beta_attribution(payload)
+
+
+def test_gate_input_requires_subject_ref() -> None:
+    payload = _json(BETA_EXAMPLE)
+    del payload["gate_evaluation_input"]["subject_ref"]
+    with pytest.raises(ValueError, match="subject_ref is required"):
+        build_finance_beta_attribution(payload)
+
+
 def test_failed_gate_cannot_be_presented_as_research_complete() -> None:
     payload = _fail_gate_evaluation_input(_json(BETA_EXAMPLE))
     attribution = build_finance_beta_attribution(payload)

--- a/tests/extensions/test_finance_beta_and_metric_packs.py
+++ b/tests/extensions/test_finance_beta_and_metric_packs.py
@@ -35,9 +35,10 @@ def test_complete_beta_attribution_computes_residual_and_replays() -> None:
     attribution = build_finance_beta_attribution(payload)
 
     assert attribution["schema_version"] == "finance_beta_attribution_v1"
-    assert attribution["disposition"] == "complete"
+    assert attribution["disposition"] == "eligible_for_research_successor"
+    assert attribution["completeness"] == "complete"
     assert attribution["explained_sum"] == "-0.11"
-    assert attribution["residual"] == "-0.01"
+    assert attribution["residual"] == "0.01"
     assert [item["component_id"] for item in attribution["components"]] == [
         "market",
         "rate",
@@ -65,10 +66,36 @@ def test_incomplete_beta_components_never_fabricate_a_residual(state: str) -> No
         [] if state == "missing" else ["peer-source-a", "peer-source-b"]
     )
     component["reason"] = "The narrow-peer contribution is not resolved."
+    blocked = False
+    for observation in payload["gate_evaluation_input"]["observations"]:
+        if observation["gate_id"] == "de_beta_residual":
+            observation.update(
+                {
+                    "observation_state": state,
+                    "value": None,
+                    "evidence_refs": (
+                        []
+                        if state == "missing"
+                        else ["residual-source-a", "residual-source-b"]
+                    ),
+                    "reason": "The residual is not resolved.",
+                }
+            )
+            blocked = True
+        elif blocked:
+            observation.update(
+                {
+                    "observation_state": "not_run",
+                    "value": None,
+                    "evidence_refs": [],
+                    "reason": "Not run after the unresolved residual gate.",
+                }
+            )
 
     attribution = build_finance_beta_attribution(payload)
 
     assert attribution["disposition"] == "insufficient_evidence"
+    assert attribution["completeness"] == "insufficient_evidence"
     assert attribution["explained_sum"] is None
     assert attribution["residual"] is None
     assert attribution["components"][-1]["observation_state"] == "not_computable"
@@ -92,6 +119,12 @@ def test_beta_component_order_and_replay_input_are_frozen() -> None:
 
     mutated = deepcopy(payload)
     mutated["components"][0]["contribution"] = -0.05
+    residual_observation = next(
+        observation
+        for observation in mutated["gate_evaluation_input"]["observations"]
+        if observation["gate_id"] == "de_beta_residual"
+    )
+    residual_observation["value"] = 0.02
     with pytest.raises(ValueError, match="replay"):
         replay_finance_beta_attribution(mutated, expected)
 
@@ -181,6 +214,56 @@ def test_metric_pack_requires_frozen_source_and_cutoff_prefix() -> None:
     )
     with pytest.raises(ValueError, match="must begin with source_lineage"):
         build_finance_metric_pack_evaluation(reordered)
+
+
+@pytest.mark.parametrize(
+    ("gate_id", "rule", "observed_value"),
+    [
+        (
+            "source_lineage",
+            {
+                "value_type": "string",
+                "operator": "eq",
+                "reference_value": "provider-verified",
+            },
+            "provider-verified",
+        ),
+        (
+            "point_in_time",
+            {
+                "value_type": "number",
+                "operator": "gte",
+                "reference_value": 1,
+            },
+            1,
+        ),
+        (
+            "point_in_time",
+            {
+                "value_type": "boolean",
+                "operator": "eq",
+                "reference_value": False,
+            },
+            False,
+        ),
+    ],
+)
+def test_metric_pack_common_gates_reject_provider_semantic_drift(
+    gate_id: str,
+    rule: dict[str, object],
+    observed_value: object,
+) -> None:
+    payload = _json(PACK_EXAMPLE)
+    gate_index = next(
+        index
+        for index, gate in enumerate(payload["case_input"]["contract"]["gates"])
+        if gate["gate_id"] == gate_id
+    )
+    payload["case_input"]["contract"]["gates"][gate_index].update(rule)
+    payload["case_input"]["observations"][gate_index]["value"] = observed_value
+
+    with pytest.raises(ValueError, match="provider-neutral semantics"):
+        build_finance_metric_pack_evaluation(payload)
 
 
 def test_cyclical_industrials_pack_uses_the_common_gate_engine() -> None:
@@ -359,17 +442,59 @@ def test_gate_input_requires_subject_ref() -> None:
         build_finance_beta_attribution(payload)
 
 
-def test_failed_gate_cannot_be_presented_as_research_complete() -> None:
+def test_attribution_rejects_residual_gate_value_that_disagrees_with_arithmetic() -> (
+    None
+):
+    payload = _json(BETA_EXAMPLE)
+    payload["total_move"] = -0.1
+    residual_observation = next(
+        observation
+        for observation in payload["gate_evaluation_input"]["observations"]
+        if observation["gate_id"] == "de_beta_residual"
+    )
+    residual_observation["value"] = 0.18
+
+    with pytest.raises(ValueError, match="must match the computed residual"):
+        build_finance_beta_attribution(payload)
+
+
+def test_failed_gate_preserves_rejection_separate_from_component_completeness() -> None:
+    payload = _json(BETA_EXAMPLE)
+    blocked = False
+    for observation in payload["gate_evaluation_input"]["observations"]:
+        if observation["gate_id"] == "evidence_quality":
+            observation["value"] = 1
+            observation["reason"] = "Observed evidence fails the frozen threshold."
+            blocked = True
+        elif blocked:
+            observation.update(
+                {
+                    "observation_state": "not_run",
+                    "value": None,
+                    "evidence_refs": [],
+                    "reason": "Not run after the failed evidence-quality gate.",
+                }
+            )
+
+    attribution = build_finance_beta_attribution(payload)
+
+    assert attribution["disposition"] == "rejected"
+    assert attribution["completeness"] == "complete"
+    assert attribution["residual"] == "0.01"
+
+
+def test_missing_gate_cannot_be_presented_as_research_complete() -> None:
     payload = _fail_gate_evaluation_input(_json(BETA_EXAMPLE))
     attribution = build_finance_beta_attribution(payload)
 
-    # even with all six components observed, a non-eligible gate forces
-    # insufficient_evidence and refuses to fabricate a residual
+    # Even with all six components observed, missing gate evidence keeps the
+    # attribution incomplete without hiding the deterministic arithmetic.
     assert attribution["gate_eligible"] is False
     assert attribution["disposition"] == "insufficient_evidence"
-    assert attribution["residual"] is None
-    assert attribution["gate_evaluation_receipt"]["disposition"] != (
-        "eligible_for_research_successor"
+    assert attribution["completeness"] == "insufficient_evidence"
+    assert attribution["residual"] == "0.01"
+    assert (
+        attribution["gate_evaluation_receipt"]["disposition"] == "insufficient_evidence"
     )
 
 
@@ -377,8 +502,9 @@ def test_attribution_binds_case_reference_and_gate_receipt() -> None:
     payload = _json(BETA_EXAMPLE)
     attribution = build_finance_beta_attribution(payload)
 
-    assert attribution["case_reference"]["case_id"] == (
-        payload["gate_evaluation_input"]["case_id"]
+    assert (
+        attribution["case_reference"]["case_id"]
+        == (payload["gate_evaluation_input"]["case_id"])
     )
     assert attribution["gate_evaluation_receipt"]["gate_eligible"] is True
     assert attribution["gate_evaluation_receipt"]["evaluation_sha256"]

--- a/tests/extensions/test_finance_contract_gate_replay.py
+++ b/tests/extensions/test_finance_contract_gate_replay.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+EXTENSION_ROOT = ROOT / "packages" / "loopx-finance-value-discovery"
+EXTENSION_SRC = EXTENSION_ROOT / "src"
+EXAMPLE = EXTENSION_ROOT / "examples" / "finance-case-gates-v1.json"
+sys.path.insert(0, str(EXTENSION_SRC))
+
+from loopx_finance_value_discovery.cli import run  # noqa: E402
+from loopx_finance_value_discovery.replay import (  # noqa: E402
+    build_finance_case_evaluation,
+    canonical_json_bytes,
+    replay_finance_case_evaluation,
+)
+
+
+def _example() -> dict[str, object]:
+    return json.loads(EXAMPLE.read_text(encoding="utf-8"))
+
+
+def test_missing_gate_short_circuits_to_insufficient_evidence() -> None:
+    payload = _example()
+    evaluation = build_finance_case_evaluation(payload)
+
+    assert evaluation["schema_version"] == "finance_case_gate_evaluation_v1"
+    assert evaluation["disposition"] == "insufficient_evidence"
+    assert evaluation["first_blocking_gate"] == {
+        "gate_id": "terminal_risk",
+        "state": "missing",
+        "reason": "A complete terminal-loss path is not yet supported.",
+    }
+    assert evaluation["boundary"] == {
+        "public_evidence_only": True,
+        "outcome_blind": True,
+        "investment_advice": False,
+        "trading_allowed": False,
+        "automatic_promotion_allowed": False,
+        "human_decision_owner": True,
+    }
+
+
+def test_all_passed_only_allows_a_research_successor() -> None:
+    payload = _example()
+    payload["observations"][-1] = {
+        "gate_id": "terminal_risk",
+        "observation_state": "observed",
+        "value": True,
+        "evidence_refs": ["terminal-risk-bridge"],
+        "reason": "The terminal-loss path is bounded by frozen evidence.",
+    }
+
+    evaluation = build_finance_case_evaluation(payload)
+
+    assert evaluation["disposition"] == "eligible_for_research_successor"
+    assert evaluation["first_blocking_gate"] is None
+    assert evaluation["boundary"]["automatic_promotion_allowed"] is False
+    assert evaluation["boundary"]["trading_allowed"] is False
+
+
+@pytest.mark.parametrize("state", ["failed", "missing", "conflict"])
+def test_first_blocker_controls_disposition_and_later_gates_do_not_run(
+    state: str,
+) -> None:
+    payload = _example()
+    observation_state = "observed" if state == "failed" else state
+    payload["observations"][2] = {
+        "gate_id": "evidence_quality",
+        "observation_state": observation_state,
+        "value": 1 if state == "failed" else None,
+        "evidence_refs": (
+            []
+            if state == "missing"
+            else ["filing-primary", "market-independent"]
+            if state == "conflict"
+            else ["filing-primary"]
+        ),
+        "reason": "The evidence-quality gate blocks this case.",
+    }
+    for observation in payload["observations"][3:]:
+        observation["observation_state"] = "not_run"
+        observation["value"] = None
+        observation["evidence_refs"] = []
+        observation["reason"] = "Not run after the evidence-quality blocker."
+
+    evaluation = build_finance_case_evaluation(payload)
+
+    assert evaluation["disposition"] == (
+        "rejected" if state == "failed" else "insufficient_evidence"
+    )
+    assert evaluation["first_blocking_gate"]["gate_id"] == "evidence_quality"
+    assert evaluation["first_blocking_gate"]["state"] == state
+
+
+def test_gate_order_and_short_circuit_are_enforced() -> None:
+    out_of_order = _example()
+    out_of_order["observations"][0], out_of_order["observations"][1] = (
+        out_of_order["observations"][1],
+        out_of_order["observations"][0],
+    )
+    with pytest.raises(ValueError, match="exactly match"):
+        build_finance_case_evaluation(out_of_order)
+
+    post_blocker_execution = _example()
+    post_blocker_execution["observations"][2]["observation_state"] = "missing"
+    post_blocker_execution["observations"][2]["value"] = None
+    post_blocker_execution["observations"][2]["evidence_refs"] = []
+    with pytest.raises(ValueError, match="after the first blocking gate"):
+        build_finance_case_evaluation(post_blocker_execution)
+
+    premature_not_run = _example()
+    premature_not_run["observations"][0]["observation_state"] = "not_run"
+    premature_not_run["observations"][0]["value"] = None
+    premature_not_run["observations"][0]["evidence_refs"] = []
+    with pytest.raises(ValueError, match="requires an earlier blocking gate"):
+        build_finance_case_evaluation(premature_not_run)
+
+
+def test_provider_cannot_declare_pass_fail_or_change_value_type() -> None:
+    declared_result = _example()
+    declared_result["observations"][0]["state"] = "passed"
+    with pytest.raises(ValueError, match="unsupported fields"):
+        build_finance_case_evaluation(declared_result)
+
+    wrong_type = _example()
+    wrong_type["observations"][2]["value"] = "two"
+    with pytest.raises(ValueError, match="must be a number"):
+        build_finance_case_evaluation(wrong_type)
+
+
+@pytest.mark.parametrize(
+    "mutator",
+    [
+        lambda payload: payload["contract"].update(
+            {"thresholds_frozen": False}
+        ),
+        lambda payload: payload["contract"].update(
+            {"point_in_time": "2026-07-24"}
+        ),
+        lambda payload: payload["observations"][0].update(
+            {"reason": "Mutated after the original evaluation."}
+        ),
+    ],
+)
+def test_replay_rejects_contract_or_input_mutation(mutator) -> None:
+    payload = _example()
+    expected = build_finance_case_evaluation(payload)
+    mutated = deepcopy(payload)
+    mutator(mutated)
+
+    with pytest.raises(ValueError):
+        replay_finance_case_evaluation(mutated, expected)
+
+
+def test_replay_requires_byte_identical_evaluation() -> None:
+    payload = _example()
+    expected = build_finance_case_evaluation(payload)
+    verified = replay_finance_case_evaluation(payload, expected)
+    assert verified["replay_verified"] is True
+
+    tampered = deepcopy(expected)
+    tampered["first_blocking_gate"]["reason"] = "Changed result text."
+    with pytest.raises(ValueError, match="bytes mismatch"):
+        replay_finance_case_evaluation(payload, tampered)
+
+    reordered = json.loads(
+        json.dumps(expected, sort_keys=False),
+        object_pairs_hook=dict,
+    )
+    assert canonical_json_bytes(reordered) == canonical_json_bytes(expected)
+
+
+def test_direct_cli_evaluate_and_replay(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert run(["evaluate", "--input-json", str(EXAMPLE)]) == 0
+    evaluation = json.loads(capsys.readouterr().out)
+    assert evaluation["disposition"] == "insufficient_evidence"
+
+    expected = tmp_path / "evaluation.json"
+    expected.write_text(json.dumps(evaluation), encoding="utf-8")
+    assert (
+        run(
+            [
+                "replay",
+                "--input-json",
+                str(EXAMPLE),
+                "--expected-json",
+                str(expected),
+            ]
+        )
+        == 0
+    )
+    verified = json.loads(capsys.readouterr().out)
+    assert verified["replay_verified"] is True

--- a/tests/extensions/test_finance_contract_gate_replay.py
+++ b/tests/extensions/test_finance_contract_gate_replay.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import pytest
 
-
 ROOT = Path(__file__).resolve().parents[2]
 EXTENSION_ROOT = ROOT / "packages" / "loopx-finance-value-discovery"
 EXTENSION_SRC = EXTENSION_ROOT / "src"
@@ -133,6 +132,21 @@ def test_provider_cannot_declare_pass_fail_or_change_value_type() -> None:
     wrong_type["observations"][2]["value"] = "two"
     with pytest.raises(ValueError, match="must be a number"):
         build_finance_case_evaluation(wrong_type)
+
+
+@pytest.mark.parametrize("invalid", [float("nan"), float("inf"), float("-inf")])
+def test_numeric_gate_rejects_non_finite_thresholds_and_observations(
+    invalid: float,
+) -> None:
+    invalid_threshold = _example()
+    invalid_threshold["contract"]["gates"][2]["reference_value"] = invalid
+    with pytest.raises(ValueError, match="finite number"):
+        build_finance_case_evaluation(invalid_threshold)
+
+    invalid_observation = _example()
+    invalid_observation["observations"][2]["value"] = invalid
+    with pytest.raises(ValueError, match="finite number"):
+        build_finance_case_evaluation(invalid_observation)
 
 
 @pytest.mark.parametrize(

--- a/tests/extensions/test_finance_contract_gate_replay.py
+++ b/tests/extensions/test_finance_contract_gate_replay.py
@@ -177,6 +177,45 @@ def test_replay_requires_byte_identical_evaluation() -> None:
     assert canonical_json_bytes(reordered) == canonical_json_bytes(expected)
 
 
+def test_historical_positive_and_rejection_replay_under_one_contract() -> None:
+    positive = _example()
+    positive["case_id"] = "historical-paypal-bounded-successor"
+    positive["contract"]["point_in_time"] = "2026-07-06"
+    positive["contract"]["universe_id"] = "historical-legacy-payments-screen"
+    positive["contract"]["gates"] = positive["contract"]["gates"][:4]
+    positive["observations"] = positive["observations"][:4]
+    positive["observations"][2]["evidence_refs"] = [
+        "pypl-filing-facts",
+        "pypl-adjusted-history",
+    ]
+    positive["observations"][3]["evidence_refs"] = [
+        "pypl-adjusted-history",
+        "legacy-payments-controls",
+    ]
+
+    positive_evaluation = build_finance_case_evaluation(positive)
+    assert positive_evaluation["disposition"] == "eligible_for_research_successor"
+    assert replay_finance_case_evaluation(
+        positive, positive_evaluation
+    )["replay_verified"]
+
+    rejected = deepcopy(positive)
+    rejected["case_id"] = "historical-groupwide-derating-rejection"
+    rejected["observations"][3]["value"] = -0.12
+    rejected["observations"][3]["reason"] = (
+        "The residual does not clear the frozen idiosyncratic threshold."
+    )
+
+    rejected_evaluation = build_finance_case_evaluation(rejected)
+    assert rejected_evaluation["disposition"] == "rejected"
+    assert rejected_evaluation["first_blocking_gate"]["gate_id"] == (
+        "de_beta_residual"
+    )
+    assert replay_finance_case_evaluation(
+        rejected, rejected_evaluation
+    )["replay_verified"]
+
+
 def test_direct_cli_evaluate_and_replay(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/tests/extensions/test_finance_contract_gate_replay.py
+++ b/tests/extensions/test_finance_contract_gate_replay.py
@@ -264,6 +264,15 @@ def test_point_in_time_after_evaluation_as_of_is_rejected() -> None:
         build_finance_case_evaluation(payload)
 
 
+def test_offset_aware_point_in_time_after_cutoff_is_rejected() -> None:
+    payload = _example()
+    payload["contract"]["point_in_time"] = "2026-07-27T23:30:00-04:00"
+    payload["contract"]["evaluation_as_of"] = "2026-07-28T03:00:00Z"
+
+    with pytest.raises(ValueError, match="must not be after"):
+        build_finance_case_evaluation(payload)
+
+
 def test_evaluation_as_of_is_required() -> None:
     payload = _example()
     del payload["contract"]["evaluation_as_of"]

--- a/tests/extensions/test_finance_contract_gate_replay.py
+++ b/tests/extensions/test_finance_contract_gate_replay.py
@@ -37,8 +37,8 @@ def test_missing_gate_short_circuits_to_insufficient_evidence() -> None:
         "reason": "A complete terminal-loss path is not yet supported.",
     }
     assert evaluation["boundary"] == {
-        "public_evidence_only": True,
-        "outcome_blind": True,
+        "public_evidence_only_state": "caller_asserted",
+        "outcome_blind_state": "caller_asserted",
         "investment_advice": False,
         "trading_allowed": False,
         "automatic_promotion_allowed": False,
@@ -254,3 +254,30 @@ def test_direct_cli_evaluate_and_replay(
     )
     verified = json.loads(capsys.readouterr().out)
     assert verified["replay_verified"] is True
+
+
+def test_point_in_time_after_evaluation_as_of_is_rejected() -> None:
+    payload = _example()
+    # future cutoff: point_in_time later than evaluation_as_of must fail closed
+    payload["contract"]["point_in_time"] = "2999-12-31"
+    with pytest.raises(ValueError, match="must not be after"):
+        build_finance_case_evaluation(payload)
+
+
+def test_evaluation_as_of_is_required() -> None:
+    payload = _example()
+    del payload["contract"]["evaluation_as_of"]
+    with pytest.raises(ValueError, match="evaluation_as_of"):
+        build_finance_case_evaluation(payload)
+
+
+def test_unverified_guarantees_are_recorded_as_caller_asserted() -> None:
+    payload = _example()
+    evaluation = build_finance_case_evaluation(payload)
+    # the engine records the caller's assertion state, not an unverified fact
+    assert evaluation["boundary"]["outcome_blind_state"] == "caller_asserted"
+    assert evaluation["boundary"]["public_evidence_only_state"] == "caller_asserted"
+    assert evaluation["contract"]["outcome_blind_state"] == "caller_asserted"
+    assert evaluation["contract"]["public_evidence_only_state"] == "caller_asserted"
+    assert "outcome_blind" not in evaluation["boundary"]
+    assert "public_evidence_only" not in evaluation["boundary"]

--- a/tests/extensions/test_finance_value_discovery_extension.py
+++ b/tests/extensions/test_finance_value_discovery_extension.py
@@ -22,6 +22,7 @@ EXTENSION_ROOT = ROOT / "packages" / "loopx-finance-value-discovery"
 EXTENSION_SRC = EXTENSION_ROOT / "src"
 MANIFEST = EXTENSION_ROOT / "extension.toml"
 EXAMPLE = EXTENSION_ROOT / "examples" / "paypal-debeta-discovery.json"
+CASE_EXAMPLE = EXTENSION_ROOT / "examples" / "finance-case-gates-v1.json"
 sys.path.insert(0, str(EXTENSION_SRC))
 
 from loopx_finance_value_discovery.cli import run  # noqa: E402
@@ -255,3 +256,34 @@ def test_standalone_extension_runs_through_verified_runtime(
     packet = receipt["provider_result"]
     assert packet["schema_version"] == "finance_value_discovery_packet_v0"
     assert packet["projection"]["next_targets"] == ["PYPL"]
+
+
+def test_unified_gate_contract_runs_through_verified_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _, runtime_root = _installed_manifest(tmp_path, monkeypatch)
+    assert (
+        main(
+            [
+                "--runtime-root",
+                str(runtime_root),
+                "--format",
+                "json",
+                "extension",
+                "run",
+                "loopx-finance-value-discovery",
+                "--input-json",
+                str(CASE_EXAMPLE),
+                "--execute",
+            ]
+        )
+        == 0
+    )
+    receipt = json.loads(capsys.readouterr().out)
+    assert receipt["status"] == "succeeded"
+    evaluation = receipt["provider_result"]
+    assert evaluation["schema_version"] == "finance_case_gate_evaluation_v1"
+    assert evaluation["disposition"] == "insufficient_evidence"
+    assert evaluation["replay"]["evaluation_sha256"]

--- a/tests/extensions/test_finance_value_discovery_extension.py
+++ b/tests/extensions/test_finance_value_discovery_extension.py
@@ -16,13 +16,14 @@ from loopx.extensions.runtime import (
     install_extension,
 )
 
-
 ROOT = Path(__file__).resolve().parents[2]
 EXTENSION_ROOT = ROOT / "packages" / "loopx-finance-value-discovery"
 EXTENSION_SRC = EXTENSION_ROOT / "src"
 MANIFEST = EXTENSION_ROOT / "extension.toml"
 EXAMPLE = EXTENSION_ROOT / "examples" / "paypal-debeta-discovery.json"
 CASE_EXAMPLE = EXTENSION_ROOT / "examples" / "finance-case-gates-v1.json"
+BETA_EXAMPLE = EXTENSION_ROOT / "examples" / "beta-attribution-v1.json"
+PACK_EXAMPLE = EXTENSION_ROOT / "examples" / "software-metric-pack-v1.json"
 sys.path.insert(0, str(EXTENSION_SRC))
 
 from loopx_finance_value_discovery.cli import run  # noqa: E402
@@ -287,3 +288,41 @@ def test_unified_gate_contract_runs_through_verified_runtime(
     assert evaluation["schema_version"] == "finance_case_gate_evaluation_v1"
     assert evaluation["disposition"] == "insufficient_evidence"
     assert evaluation["replay"]["evaluation_sha256"]
+
+
+@pytest.mark.parametrize(
+    ("example", "schema_version"),
+    [
+        (BETA_EXAMPLE, "finance_beta_attribution_v1"),
+        (PACK_EXAMPLE, "finance_metric_pack_evaluation_v1"),
+    ],
+)
+def test_p1_finance_layers_run_through_verified_runtime(
+    example: Path,
+    schema_version: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _, runtime_root = _installed_manifest(tmp_path, monkeypatch)
+    assert (
+        main(
+            [
+                "--runtime-root",
+                str(runtime_root),
+                "--format",
+                "json",
+                "extension",
+                "run",
+                "loopx-finance-value-discovery",
+                "--input-json",
+                str(example),
+                "--execute",
+            ]
+        )
+        == 0
+    )
+    receipt = json.loads(capsys.readouterr().out)
+    assert receipt["status"] == "succeeded"
+    assert receipt["provider_result"]["schema_version"] == schema_version
+    assert receipt["provider_result"]["boundary"]["trading_allowed"] is False


### PR DESCRIPTION
## Summary

- add a provider-neutral typed finance case contract, deterministic gate engine, and byte-identical replay receipts
- add six-layer beta attribution with fail-closed residual handling
- add software-platform and cyclical-industrial metric packs while keeping thresholds in the frozen case contract
- preserve the existing `finance_value_discovery_input_v0` reducer and managed extension runtime
- keep promotion human-only and prohibit advice, trading, and automatic activation

## Review findings addressed

- reject non-finite numeric thresholds and observations, and require strict JSON replay canonicalization
- require metric-pack contracts to begin with frozen `source_lineage` and `point_in_time` gates

## Validation

- 43 focused extension tests passed
- Ruff E/F/I/RUF022 passed
- LoopX standard premerge passed: 18/18 selected checks, 0 warnings, 0 manual holds
- public/private boundary scan passed
