### PR TITLE
fix(skillsbench): canary provider install before scoring

### DIFF
--- a/loopx/benchmark_adapters/skillsbench_setup_preflight.py
+++ b/loopx/benchmark_adapters/skillsbench_setup_preflight.py
@@ -325,6 +325,8 @@ def _base_result(
         "environment_ready_hook_requested": False,
         "environment_ready_hook_invoked": False,
         "environment_ready_hook_status": "not_requested",
+        "agent_install_canary_requested": False,
+        "agent_install_canary_status": "not_requested",
         "agent_install_invoked": False,
         "agent_execution_invoked": False,
         "verifier_invoked": False,
@@ -382,8 +384,9 @@ async def run_setup_only_public_preflight(
     cleanup_timeout_sec: float = 30.0,
     progress_callback: Callable[[Mapping[str, Any]], None] | None = None,
     environment_ready_hook: Callable[[Any], Awaitable[None]] | None = None,
+    agent_install_canary: bool = False,
 ) -> dict[str, Any]:
-    """Materialize a BenchFlow environment without installing or running an agent."""
+    """Materialize a BenchFlow environment and optionally canary agent install."""
 
     result = _base_result(
         task_staging=task_staging,
@@ -397,6 +400,9 @@ async def run_setup_only_public_preflight(
     if environment_ready_hook is not None:
         result["environment_ready_hook_requested"] = True
         result["environment_ready_hook_status"] = "pending"
+    if agent_install_canary:
+        result["agent_install_canary_requested"] = True
+        result["agent_install_canary_status"] = "pending"
     _emit_progress(progress_callback, result)
     try:
         rollout = await asyncio.wait_for(
@@ -434,13 +440,29 @@ async def run_setup_only_public_preflight(
                 timeout=stage_timeout_sec,
             )
             result["environment_ready_hook_status"] = "passed"
+        if agent_install_canary:
+            result["stage"] = "agent_install_canary"
+            result["agent_install_invoked"] = True
+            result["agent_install_canary_status"] = "running"
+            _emit_progress(progress_callback, result)
+            await asyncio.wait_for(
+                rollout.install_agent(),
+                timeout=stage_timeout_sec,
+            )
+            result["agent_install_canary_status"] = "passed"
         result["status"] = "passed"
-        result["stage"] = "environment_ready_before_agent"
+        result["stage"] = (
+            "agent_install_ready_before_execution"
+            if agent_install_canary
+            else "environment_ready_before_agent"
+        )
         result["exit_category"] = "passed"
     except Exception as exc:
         failed = True
         if result["environment_ready_hook_status"] == "running":
             result["environment_ready_hook_status"] = "failed"
+        if result["agent_install_canary_status"] == "running":
+            result["agent_install_canary_status"] = "failed"
         if rollout is not None:
             result["job_root_materialized"] = (
                 getattr(rollout, "_rollout_dir", None) is not None

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -88,6 +88,10 @@ Optional env:
                                        Set to 1 to stop after real job-root and
                                        environment materialization, before any
                                        agent or verifier lifecycle
+  SKILLSBENCH_SETUP_ONLY_AGENT_INSTALL_CANARY
+                                       With setup-only preflight, set to 1 to
+                                       exercise agent install and stop before
+                                       agent execution or verification
   SKILLSBENCH_PRODUCT_MODE_SOFT_VERIFY_POLICY
                                        Optional product-mode intermediate
                                        verifier policy: every-round or
@@ -274,6 +278,7 @@ skip_global_ledger_sync="${SKILLSBENCH_SKIP_GLOBAL_LEDGER_SYNC:-0}"
 skip_current_aggregate_update="${SKILLSBENCH_SKIP_CURRENT_AGGREGATE_UPDATE:-0}"
 allow_staged_bootstrap_repair_run="${SKILLSBENCH_ALLOW_STAGED_BOOTSTRAP_REPAIR_RUN:-0}"
 setup_only_public_preflight="${SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT:-0}"
+setup_only_agent_install_canary="${SKILLSBENCH_SETUP_ONLY_AGENT_INSTALL_CANARY:-0}"
 benchmark_egress_proxy_mode="${SKILLSBENCH_BENCHMARK_EGRESS_PROXY_MODE:-require}"
 benchmark_egress_no_proxy="${SKILLSBENCH_BENCHMARK_EGRESS_NO_PROXY:-}"
 docker_apt_source_mode="${SKILLSBENCH_DOCKER_APT_SOURCE_MODE:-}"
@@ -325,6 +330,13 @@ validate_bool_toggle \
   SKILLSBENCH_ALLOW_STAGED_BOOTSTRAP_REPAIR_RUN "$allow_staged_bootstrap_repair_run"
 validate_bool_toggle \
   SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT "$setup_only_public_preflight"
+validate_bool_toggle \
+  SKILLSBENCH_SETUP_ONLY_AGENT_INSTALL_CANARY "$setup_only_agent_install_canary"
+if [[ "$setup_only_agent_install_canary" == "1" ]] &&
+  [[ "$setup_only_public_preflight" != "1" ]]; then
+  echo "SKILLSBENCH_SETUP_ONLY_AGENT_INSTALL_CANARY requires SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT=1" >&2
+  exit 2
+fi
 validate_bool_toggle \
   SKILLSBENCH_LOCAL_CODEX_SPLIT_CONTROL "$local_codex_split_control"
 if [[ "$local_codex_split_control" == "1" ]] &&
@@ -689,6 +701,9 @@ fi
 if [[ "$setup_only_public_preflight" == "1" ]]; then
   extra_runner_args+=(--setup-only-public-preflight)
 fi
+if [[ "$setup_only_agent_install_canary" == "1" ]]; then
+  extra_runner_args+=(--setup-only-agent-install-canary)
+fi
 if [[ -n "$benchmark_egress_no_proxy" ]]; then
   extra_runner_args+=(
     --benchmark-egress-no-proxy "$benchmark_egress_no_proxy"
@@ -942,6 +957,8 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'codex_cli_goal_thread_prewarm=%s\n' "$codex_cli_goal_thread_prewarm"
   printf 'allow_staged_bootstrap_repair_run=%s\n' "$allow_staged_bootstrap_repair_run"
   printf 'setup_only_public_preflight=%s\n' "$setup_only_public_preflight"
+  printf 'setup_only_agent_install_canary=%s\n' \
+    "$setup_only_agent_install_canary"
   printf 'public_artifact_sync_interval_sec=%s\n' \
     "$public_artifact_sync_interval"
   printf 'benchmark_egress_proxy_mode=%s\n' "$benchmark_egress_proxy_mode"
@@ -1073,6 +1090,7 @@ local_codex_sandbox=${local_codex_sandbox}
 codex_cli_goal_thread_prewarm=${codex_cli_goal_thread_prewarm}
 allow_staged_bootstrap_repair_run=${allow_staged_bootstrap_repair_run}
 setup_only_public_preflight=${setup_only_public_preflight}
+setup_only_agent_install_canary=${setup_only_agent_install_canary}
 exact_host_codex_sandbox_preflight=${exact_host_codex_sandbox_preflight}
 exact_host_codex_sandbox_preflight_timeout_sec=${exact_host_codex_sandbox_preflight_timeout}
 public_artifact_sync_interval_sec=${public_artifact_sync_interval}

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -2793,6 +2793,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "host_local_acp_launch_status",
         "host_local_acp_install_stage",
         "host_local_acp_install_failed_stage",
+        "host_local_acp_install_failure_exception_type",
         "codex_acp_runtime_launch_preflight_stage",
         "codex_acp_runtime_launch_preflight_status",
         "benchflow_agent_runtime_layer_status",
@@ -4768,6 +4769,19 @@ def _runner_prerequisite_failure_attribution(
             label = f"{label}_{category}"
         return label, label, [label, "skillsbench_runner_setup_error"]
 
+    if value.get("host_local_acp_launch_status") == "sandbox_install_failed":
+        label = "skillsbench_host_local_acp_sandbox_install_failed"
+        labels = [label]
+        failed_stage = re.sub(
+            r"[^a-z0-9]+",
+            "_",
+            str(value.get("host_local_acp_install_failed_stage") or "").lower(),
+        ).strip("_")
+        if failed_stage:
+            labels.append(f"{label}_{failed_stage[:80]}")
+        labels.append("skillsbench_runner_setup_error")
+        return label, label, labels
+
     if (
         value.get("remote_command_file_bridge_agent_operation_trace_required") is True
         and not orchestrated_driver_counts_as_product_mode
@@ -4856,10 +4870,6 @@ def _runner_prerequisite_failure_attribution(
                 "skillsbench_runner_setup_error",
             ],
         )
-
-    if value.get("host_local_acp_launch_status") == "sandbox_install_failed":
-        label = "skillsbench_host_local_acp_sandbox_install_failed"
-        return label, label, [label, "skillsbench_runner_setup_error"]
 
     if value.get("host_local_acp_launch_status") == "installing_sandbox":
         label = "skillsbench_host_local_acp_sandbox_install_incomplete"
@@ -9224,6 +9234,9 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         "setup_only_public_preflight": bool(
             getattr(args, "setup_only_public_preflight", False)
         ),
+        "setup_only_agent_install_canary": bool(
+            getattr(args, "setup_only_agent_install_canary", False)
+        ),
         "setup_only_stage_timeout_sec": (
             _effective_setup_only_stage_timeout_sec(args)
         ),
@@ -9780,6 +9793,7 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
         "verifier_bootstrap_fail_fast_defaulted",
         "bootstrap_light_fail_fast_defaulted",
         "setup_only_public_preflight",
+        "setup_only_agent_install_canary",
         "global_ledger_sync_enabled",
         "ledger_inherit_enabled",
     ):
@@ -15080,10 +15094,13 @@ async def run_benchflow_case(
                         "host_local_acp_after_sandbox_install"
                     )
                 await seed_product_mode_case_state(self._env)
-        except Exception:
+        except Exception as exc:
             prerequisites["host_local_acp_install_failed_stage"] = str(
                 prerequisites.get("host_local_acp_install_stage") or "unknown"
             )
+            prerequisites["host_local_acp_install_failure_exception_type"] = type(
+                exc
+            ).__name__
             _write_public_runner_lifecycle_receipt(
                 plan,
                 worker_status="sandbox_install_failed",
@@ -15417,6 +15434,9 @@ async def run_benchflow_case(
                     run_host_local_acp_codex_exec_preflight_after_environment
                     if _host_local_acp_codex_exec_preflight_should_run(args)
                     else None
+                ),
+                agent_install_canary=bool(
+                    getattr(args, "setup_only_agent_install_canary", False)
                 ),
             )
             plan["setup_only_public_preflight_result"] = setup_only_result
@@ -17142,8 +17162,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         action="store_true",
         help=(
             "Materialize the BenchFlow job root and environment, then stop "
-            "before agent install, agent execution, and verification. Emit only "
-            "a compact public-safe setup classification."
+            "before agent execution and verification. By default this also "
+            "stops before agent install. Emit only a compact public-safe setup "
+            "classification."
+        ),
+    )
+    parser.add_argument(
+        "--setup-only-agent-install-canary",
+        action="store_true",
+        help=(
+            "With --setup-only-public-preflight, exercise the configured agent "
+            "install path and stop before agent execution and verification."
         ),
     )
     parser.add_argument(
@@ -17589,6 +17618,14 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         parser.error(
             "--setup-only-public-preflight is incompatible with --plan-only "
             "and --reduce-only"
+        )
+    if (
+        args.setup_only_agent_install_canary
+        and not args.setup_only_public_preflight
+    ):
+        parser.error(
+            "--setup-only-agent-install-canary requires "
+            "--setup-only-public-preflight"
         )
     if args.setup_only_public_preflight and (args.append_history or args.update_ledger):
         parser.error(

--- a/tests/test_skillsbench_remote_codex_preflight.py
+++ b/tests/test_skillsbench_remote_codex_preflight.py
@@ -87,6 +87,28 @@ def test_missing_codex_cli_has_precise_runner_attribution(tmp_path: Path) -> Non
     )
 
 
+def test_sandbox_install_failure_precedes_missing_bridge_trace() -> None:
+    attribution = skillsbench_loop._runner_prerequisite_failure_attribution(
+        {
+            "host_local_acp_launch_status": "sandbox_install_failed",
+            "host_local_acp_install_failed_stage": "snapshot_build_config",
+            "remote_command_file_bridge_agent_operation_trace_required": True,
+            "remote_command_file_bridge_agent_operation_trace_satisfied": False,
+            "remote_command_file_bridge_agent_operation_trace_status": (
+                "agent_operation_trace_missing"
+            ),
+        }
+    )
+
+    assert attribution is not None
+    assert attribution[0] == "skillsbench_host_local_acp_sandbox_install_failed"
+    assert attribution[2] == [
+        "skillsbench_host_local_acp_sandbox_install_failed",
+        "skillsbench_host_local_acp_sandbox_install_failed_snapshot_build_config",
+        "skillsbench_runner_setup_error",
+    ]
+
+
 def test_host_local_codex_cli_preflight_fails_when_selected_sandbox_cannot_run(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_skillsbench_setup_preflight.py
+++ b/tests/test_skillsbench_setup_preflight.py
@@ -62,6 +62,11 @@ class FakeRollout:
         if self.failure_stage == "environment_start" and self.failure is not None:
             raise self.failure
 
+    async def install_agent(self) -> None:
+        self.events.append("install_agent")
+        if self.failure_stage == "agent_install" and self.failure is not None:
+            raise self.failure
+
     async def cleanup(self) -> None:
         self.events.append("cleanup")
         if self.failure_stage == "cleanup" and self.failure is not None:
@@ -216,6 +221,54 @@ def test_setup_only_preflight_cleans_up_after_environment_hook_failure() -> None
     assert "private callback detail" not in json.dumps(result, sort_keys=True)
 
 
+def test_setup_only_preflight_canaries_agent_install_without_execution() -> None:
+    result = asyncio.run(
+        run_setup_only_public_preflight(
+            rollout_type=FakeRollout,
+            config=object(),
+            stage_timeout_sec=1,
+            agent_install_canary=True,
+        )
+    )
+
+    assert result["status"] == "passed"
+    assert result["stage"] == "agent_install_ready_before_execution"
+    assert result["agent_install_canary_requested"] is True
+    assert result["agent_install_canary_status"] == "passed"
+    assert result["agent_install_invoked"] is True
+    assert result["agent_execution_invoked"] is False
+    assert result["verifier_invoked"] is False
+    assert FakeRollout.events == [
+        "create",
+        "setup",
+        "start",
+        "install_agent",
+        "cleanup",
+    ]
+
+
+def test_setup_only_preflight_classifies_agent_install_canary_failure() -> None:
+    FakeRollout.failure_stage = "agent_install"
+    FakeRollout.failure = RuntimeError("private provider install detail")
+
+    result = asyncio.run(
+        run_setup_only_public_preflight(
+            rollout_type=FakeRollout,
+            config=object(),
+            stage_timeout_sec=1,
+            agent_install_canary=True,
+        )
+    )
+
+    assert result["status"] == "failed"
+    assert result["failure_stage"] == "agent_install_canary"
+    assert result["agent_install_canary_status"] == "failed"
+    assert result["cleanup_status"] == "completed"
+    assert result["agent_execution_invoked"] is False
+    assert result["verifier_invoked"] is False
+    assert "private provider install detail" not in json.dumps(result, sort_keys=True)
+
+
 def test_formal_run_lifecycle_receipt_projects_live_worker_without_private_logs(
     tmp_path: Path,
 ) -> None:
@@ -340,6 +393,35 @@ def test_setup_only_runner_mode_bypasses_formal_round_budget() -> None:
     assert plan["setup_only_public_preflight_json"].endswith(
         "setup_only_preflight.public.json"
     )
+
+
+def test_setup_only_agent_install_canary_is_publicly_projected() -> None:
+    args = parse_args(
+        [
+            "--task-id",
+            "flink-query",
+            "--route",
+            "loopx-goal-start-product-mode",
+            "--setup-only-public-preflight",
+            "--setup-only-agent-install-canary",
+        ]
+    )
+
+    plan = build_plan(args)
+    assert args.setup_only_agent_install_canary is True
+    assert plan["setup_only_agent_install_canary"] is True
+    assert _public_runner_config(plan)["setup_only_agent_install_canary"] is True
+
+
+def test_setup_only_agent_install_canary_requires_setup_only_mode() -> None:
+    with pytest.raises(SystemExit):
+        parse_args(
+            [
+                "--task-id",
+                "flink-query",
+                "--setup-only-agent-install-canary",
+            ]
+        )
 
 
 def test_primary_pip_index_mode_is_publicly_attributable() -> None:

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -941,6 +941,7 @@ def test_setup_only_launcher_enables_incremental_public_artifact_sync(
 ) -> None:
     env = _base_env(tmp_path)
     env["SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT"] = "1"
+    env["SKILLSBENCH_SETUP_ONLY_AGENT_INSTALL_CANARY"] = "1"
     env["SKILLSBENCH_APPEND_HISTORY"] = "1"
 
     proc = subprocess.run(
@@ -957,7 +958,32 @@ def test_setup_only_launcher_enables_incremental_public_artifact_sync(
     assert "exact_host_codex_sandbox_preflight=not_required" in proc.stdout
     assert "--public-artifact-sync-interval-sec 30" in proc.stdout
     assert "--setup-only-public-preflight" in proc.stdout
+    assert "--setup-only-agent-install-canary" in proc.stdout
+    assert "setup_only_agent_install_canary=1" in proc.stdout
     assert "--append-history" not in proc.stdout
+
+
+def test_launcher_rejects_agent_install_canary_without_setup_only(
+    tmp_path: Path,
+) -> None:
+    env = _base_env(tmp_path)
+    env["SKILLSBENCH_SETUP_ONLY_AGENT_INSTALL_CANARY"] = "1"
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "--dry-run", "public-smoke-case", "invalid-canary"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    assert (
+        "SKILLSBENCH_SETUP_ONLY_AGENT_INSTALL_CANARY requires "
+        "SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT=1"
+    ) in proc.stderr
 
 
 def test_formal_launcher_enables_incremental_public_artifact_sync(


### PR DESCRIPTION
## Summary

- classify host-local ACP sandbox install failures before downstream missing bridge traces
- add an opt-in setup-only agent-install canary that stops before agent execution and verification
- project the canary through the public runner config and launch wrapper

## Scope

This is a narrow benchmark helper/runtime change. It does not alter scoring, task semantics, permissions, submission behavior, or launch a scored benchmark job.

## Validation

- `python -m pytest -q tests/test_skillsbench_setup_preflight.py tests/test_skillsbench_remote_codex_preflight.py tests/test_skillsbench_turn_launcher.py` (103 passed)
- `python examples/skillsbench-benchmark-run-smoke.py`
- `python -m py_compile` for all changed Python files
- repository-configured `mypy` (15 source files)
- focused `ruff check` for the changed adapter and tests
- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`
- LoopX standard premerge canaries (6 selected, all passed)
- change-quality receipt `cqr_4ce5fa5fc442a8e2626f`
- public/private boundary scan clean for all 6 changed files

## Known Baseline Limits

- Whole-file Ruff on the legacy automation script reports 134 pre-existing diagnostics; the changed adapter and tests are Ruff-clean.
- The repository-wide boundary command also reports an unrelated existing global registry fixture error; its candidate-path boundary scan is clean.

## Manual Hold

The premerge gate retains its generic benchmark-sensitive maintainer hold. The repository policy and standing owner authorization permit self-merge for this limited benchmark helper/runtime scope after focused validation and boundary review.
