### PR TITLE
fix(prompt): preserve accountable delivery semantics

### DIFF
--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -473,9 +473,12 @@ If the result says should_run=true:
 
    loopx refresh-state --goal-id <GOAL_ID> \
      --classification <PUBLIC_SAFE_PROGRESS_CLASSIFICATION> \
-     --delivery-batch-scale multi_surface \
-     --delivery-outcome outcome_progress
+     --delivery-batch-scale <ACTUAL_DELIVERY_BATCH_SCALE> \
+     --delivery-outcome <ACTUAL_DELIVERY_OUTCOME>
 
+   Replace all three placeholders with values proven by this validated turn.
+   Never default or upgrade smaller/preparatory work to
+   `multi_surface` / `outcome_progress`.
    This refresh is the causal delivery record consumed by `quota spend-slot`.
    A plain state-only refresh is quota-neutral and cannot replace it. Then, for
    a minute-based heartbeat, spend one slot:

--- a/docs/new-project-codex-prompt.md
+++ b/docs/new-project-codex-prompt.md
@@ -234,10 +234,12 @@ loopx new-project-prompt \
    ```bash
    loopx refresh-state --goal-id <STABLE_GOAL_ID> \
      --classification <PUBLIC_SAFE_PROGRESS_CLASSIFICATION> \
-     --delivery-batch-scale multi_surface \
-     --delivery-outcome outcome_progress
+     --delivery-batch-scale <ACTUAL_DELIVERY_BATCH_SCALE> \
+     --delivery-outcome <ACTUAL_DELIVERY_OUTCOME>
    ```
 
+   三个 placeholder 都必须替换为本轮实际验证过的值；不要把较小或仅准备性的
+   turn 默认、拔高成 `multi_surface` / `outcome_progress`。
    这是 `spend-slot` 将消费的因果记录；普通 state-only refresh 不能替代它。
    然后只 append 一次 quota spend：
 

--- a/examples/codex-cli-bootstrap-message-smoke.py
+++ b/examples/codex-cli-bootstrap-message-smoke.py
@@ -78,8 +78,10 @@ def assert_message_contract(payload: dict[str, object]) -> None:
     quota_spend = str(payload["quota_spend_command"])
     state_only_refresh = str(payload["refresh_command"])
     assert "--classification <PUBLIC_SAFE_PROGRESS_CLASSIFICATION>" in progress_refresh, payload
-    assert "--delivery-batch-scale multi_surface" in progress_refresh, payload
-    assert "--delivery-outcome outcome_progress" in progress_refresh, payload
+    assert "--delivery-batch-scale <ACTUAL_DELIVERY_BATCH_SCALE>" in progress_refresh, payload
+    assert "--delivery-outcome <ACTUAL_DELIVERY_OUTCOME>" in progress_refresh, payload
+    assert "--delivery-batch-scale multi_surface" not in progress_refresh, payload
+    assert "--delivery-outcome outcome_progress" not in progress_refresh, payload
     assert "--agent-id codex-side-bypass" in progress_refresh, payload
     assert "--progress-scope agent_lane" in progress_refresh, payload
     message = str(payload["message"])
@@ -97,6 +99,7 @@ def assert_message_contract(payload: dict[str, object]) -> None:
     assert message.index(quota_spend) < message.rindex(state_only_refresh), message
     assert "must not carry a delivery outcome" in normalized, message
     assert "Do not append another accountable progress refresh after spend" in normalized, message
+    assert "Never default or upgrade them to `multi_surface` / `outcome_progress`" in message, message
     assert "do not run `loopx bootstrap` for the same `goal_id`" in normalized, message
     assert "Only run bootstrap when the probe clearly says the goal is absent" in normalized, message
     assert "registry/quota identity alone" in normalized, message

--- a/examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
+++ b/examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
@@ -139,7 +139,9 @@ def main() -> None:
         assert "quota should-run" in bundle["quota_guard_command"], bundle
         assert "--agent-id codex-side-bypass" in bundle["quota_guard_command"], bundle
         assert "refresh-state --goal-id public-fresh-codex-cli-goal" in bundle["refresh_command"], bundle
-        assert "--delivery-outcome outcome_progress" in bundle["progress_refresh_command"], bundle
+        assert "--delivery-batch-scale <ACTUAL_DELIVERY_BATCH_SCALE>" in bundle["progress_refresh_command"], bundle
+        assert "--delivery-outcome <ACTUAL_DELIVERY_OUTCOME>" in bundle["progress_refresh_command"], bundle
+        assert "--delivery-outcome outcome_progress" not in bundle["progress_refresh_command"], bundle
         assert "--agent-id codex-side-bypass" in bundle["progress_refresh_command"], bundle
         assert "quota spend-slot" in bundle["quota_spend_command"], bundle
         assert "--source heartbeat --execute --agent-id codex-side-bypass" in bundle["quota_spend_command"], bundle

--- a/examples/control_plane/heartbeat-prompt-smoke.py
+++ b/examples/control_plane/heartbeat-prompt-smoke.py
@@ -238,7 +238,7 @@ def main() -> int:
         "loopx todo add --goal-id public-heartbeat-goal --role user --task-class user_gate|user_action",
         "owner todos and `--role agent` for agent todos, not prose",
         'loopx --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id public-heartbeat-goal --slots 1 --source heartbeat --execute',
-        "Accountable refresh, then spend",
+        "Account actual validated class/scale/outcome",
         "Optional state-only post-spend",
         "No spend for quiet skips",
     ):
@@ -335,7 +335,7 @@ def main() -> int:
         "Observed capabilities -> `--available-capability`; never user gates",
         "host_action=pause_or_delete_current_heartbeat->automation_update stop(no-spend)",
         "else RRULE/ack/fail",
-        "writeback: accountable refresh->spend; optional state-only after",
+        "writeback: actual class/scale/outcome accountable refresh->spend; no upgrade",
         "guard receipt; 2 stalls->replan",
         "`lark_event_inbox`: reply_due",
         "drain_command/reply-readback/ACK",
@@ -401,7 +401,7 @@ def main() -> int:
         "goal_boundary",
         "bounded segment/batch",
         "validate/writeback/todos",
-        "Progress refresh",
+        "Progress (actual values; no upgrade)",
         "Optional state-only post-spend",
         'loopx --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id public-heartbeat-goal --slots 1 --source heartbeat --execute',
         "No spend for quiet skips",
@@ -432,7 +432,7 @@ def main() -> int:
         "具体 user todo 未投影，需修复 LoopX 状态投影",
         "host_action=pause_or_delete_current_heartbeat->automation_update stop(no-spend)",
         "else RRULE/ack/fail",
-        "writeback: accountable refresh->spend; optional state-only after",
+        "writeback: actual class/scale/outcome accountable refresh->spend; no upgrade",
         "guard receipt; 2 stalls->replan",
         "P0 blocked: safe P1/P2",
         "monitor quiet/no-spend",
@@ -568,8 +568,9 @@ def main() -> int:
         'loopx --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id <GOAL_ID> --slots 1 --source heartbeat --execute',
         "loopx refresh-state --goal-id <GOAL_ID>",
         "--classification <PUBLIC_SAFE_PROGRESS_CLASSIFICATION>",
-        "--delivery-batch-scale multi_surface",
-        "--delivery-outcome outcome_progress",
+        "--delivery-batch-scale <ACTUAL_DELIVERY_BATCH_SCALE>",
+        "--delivery-outcome <ACTUAL_DELIVERY_OUTCOME>",
+        "Never default or upgrade smaller/preparatory work",
         "append exactly one",
         "Do not append spend for quiet should_run=false skips, preflight failures, pure dry-run previews, or duplicate accounting attempts",
         "safe_bypass_allowed=true and you actually completed a bounded safe-bypass step",
@@ -673,8 +674,9 @@ def main() -> int:
         'loopx --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id public-heartbeat-goal --slots 1 --source heartbeat --execute',
         "loopx refresh-state --goal-id public-heartbeat-goal",
         "--classification <PUBLIC_SAFE_PROGRESS_CLASSIFICATION>",
-        "--delivery-batch-scale multi_surface",
-        "--delivery-outcome outcome_progress",
+        "--delivery-batch-scale <ACTUAL_DELIVERY_BATCH_SCALE>",
+        "--delivery-outcome <ACTUAL_DELIVERY_OUTCOME>",
+        "never default or upgrade to `multi_surface` / `outcome_progress`",
         "Spend consumes this causal record",
         "Do not append spend for quiet `should_run=false` skips",
         "safe_bypass_kind=outcome_floor_recovery",
@@ -796,8 +798,9 @@ def main() -> int:
     assert "visible goal text short" in project_skill, project_skill
     assert "--source heartbeat --execute" in project_skill, project_skill
     assert "--classification <PUBLIC_SAFE_PROGRESS_CLASSIFICATION>" in project_skill, project_skill
-    assert "--delivery-batch-scale multi_surface" in project_skill, project_skill
-    assert "--delivery-outcome outcome_progress" in project_skill, project_skill
+    assert "--delivery-batch-scale <ACTUAL_DELIVERY_BATCH_SCALE>" in project_skill, project_skill
+    assert "--delivery-outcome <ACTUAL_DELIVERY_OUTCOME>" in project_skill, project_skill
+    assert "Never default or upgrade a smaller/preparatory turn" in normalized(project_skill), project_skill
     assert "do not infer scale/outcome from the classification name" in normalized(project_skill), project_skill
     assert "no-progress self-repair guard" in project_skill, project_skill
     assert "2 consecutive stalled turns" in normalized(project_skill), project_skill

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -340,8 +340,9 @@ def main() -> int:
             "This command is read-only",
             "JSON output returns a minimized handoff payload with `handoff_text` instead of the full operator packet",
             "--classification <PUBLIC_SAFE_PROGRESS_CLASSIFICATION>",
-            "--delivery-batch-scale multi_surface",
-            "--delivery-outcome outcome_progress",
+            "--delivery-batch-scale <ACTUAL_DELIVERY_BATCH_SCALE>",
+            "--delivery-outcome <ACTUAL_DELIVERY_OUTCOME>",
+            "Never default or upgrade a smaller/preparatory turn",
             "do not infer scale/outcome from the classification name",
         ):
             assert phrase in compact_skill_text, phrase
@@ -713,13 +714,15 @@ def main() -> int:
         assert payload["thin"] is True, payload
         assert payload["interface_budget"]["mode"] == "thin", payload
         assert payload["interface_budget"]["within_budget"] is True, payload
-        assert "--delivery-batch-scale multi_surface" in payload["progress_refresh_state_command"], payload
-        assert "--delivery-outcome outcome_progress" in payload["progress_refresh_state_command"], payload
+        assert "--delivery-batch-scale <ACTUAL_DELIVERY_BATCH_SCALE>" in payload["progress_refresh_state_command"], payload
+        assert "--delivery-outcome <ACTUAL_DELIVERY_OUTCOME>" in payload["progress_refresh_state_command"], payload
+        assert "--delivery-batch-scale multi_surface" not in payload["progress_refresh_state_command"], payload
+        assert "--delivery-outcome outcome_progress" not in payload["progress_refresh_state_command"], payload
         assert "<PUBLIC_SAFE_PROGRESS_CLASSIFICATION>" in payload["progress_refresh_state_command"], payload
         assert "follow `interaction_contract`" in payload["task_body"], payload
         assert "`LOOPX_TURN=<current_time_iso>`; reuse." in payload["task_body"], payload
         assert "guard receipt; 2 stalls->replan" in payload["task_body"], payload
-        assert "accountable refresh->spend" in payload["task_body"], payload
+        assert "actual class/scale/outcome accountable refresh->spend" in payload["task_body"], payload
         assert payload["cli_bin"] == "loopx", payload
 
         canary_cli = subprocess.run(

--- a/examples/project/project-prompt-smoke.py
+++ b/examples/project/project-prompt-smoke.py
@@ -65,7 +65,9 @@ MUST_HAVE = (
 )
 SPEND_MUST_HAVE = (
     "validation / writeback 完成后",
-    "先记录本轮 accountable delivery",
+    "三个 placeholder",
+    "`multi_surface` / `outcome_progress`",
+    "accountable delivery",
     "普通 state-only refresh 不能替代它",
     "然后只 append 一次 quota spend",
     'loopx --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id',
@@ -173,8 +175,8 @@ def main() -> int:
     assert payload["progress_refresh_command"] == (
         "loopx refresh-state --goal-id new-project-main-control "
         "--classification <PUBLIC_SAFE_PROGRESS_CLASSIFICATION> "
-        "--delivery-batch-scale multi_surface "
-        "--delivery-outcome outcome_progress"
+        "--delivery-batch-scale <ACTUAL_DELIVERY_BATCH_SCALE> "
+        "--delivery-outcome <ACTUAL_DELIVERY_OUTCOME>"
     ), payload
     prompt = str(payload["prompt"])
     progress_refresh = str(payload["progress_refresh_command"])
@@ -182,6 +184,7 @@ def main() -> int:
     state_only_refresh = str(payload["refresh_command"])
     assert prompt.index(progress_refresh) < prompt.index(quota_spend), prompt
     assert prompt.index(quota_spend) < prompt.rindex(state_only_refresh), prompt
+    assert "不要默认或拔高成 `multi_surface` / `outcome_progress`" in prompt, prompt
     assert_quota_guard(payload["prompt"])
     assert_quota_guard(DOC.read_text(encoding="utf-8"))
 

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -29,8 +29,8 @@ RELEASE_ID_TIMESTAMP_RE = re.compile(r"^\d{8}T\d{6}Z$")
 REQUIRED_INSTALLED_SKILL_PHRASES = {
     "loopx-project": (
         "--classification <PUBLIC_SAFE_PROGRESS_CLASSIFICATION>",
-        "--delivery-batch-scale multi_surface",
-        "--delivery-outcome outcome_progress",
+        "--delivery-batch-scale <ACTUAL_DELIVERY_BATCH_SCALE>",
+        "--delivery-outcome <ACTUAL_DELIVERY_OUTCOME>",
     ),
     "loopx-pr-review": (
         "loopx --format json pr-review --state all",

--- a/loopx/heartbeat_prompt.py
+++ b/loopx/heartbeat_prompt.py
@@ -830,7 +830,8 @@ If the result says `should_run=true`:
    a successor todo, or include a compact no-follow-up rationale.
    For the full field contract, see `docs/project-agent-todo-contract.md` in
    the LoopX checkout.
-8. After validation/writeback, record accountable delivery:
+8. After validation/writeback, use actual class/scale/outcome; never default or
+   upgrade to `multi_surface` / `outcome_progress`. Record accountable delivery:
 
    ```bash
    {progress_refresh_state_command}
@@ -922,7 +923,7 @@ Blocker-push first; obey
 `execution_obligation.must_attempt_work=true`; if recovery, run
 ranker/cross-domain evidence recovery or blocker writeback;
 validate/writeback/todos; done->successor/rationale.
-Progress refresh:
+Progress (actual values; no upgrade):
 `{progress_refresh_state_command}`
 Spend once:
 `{quota_spend_command}`
@@ -1030,7 +1031,8 @@ If `should_run=true`:
    use `{cli_bin} todo add --goal-id {goal_id} --role user --task-class user_gate|user_action`
    for owner todos and `--role agent` for agent todos, not prose. Nontrivial done ->
    successor todo or no-follow-up rationale.
-9. Accountable refresh, then spend:
+9. Account actual validated class/scale/outcome; never default/upgrade. Then
+   refresh and spend:
 
 ```bash
 {progress_refresh_state_command}
@@ -1129,8 +1131,11 @@ If `should_run=true`, choose the highest-priority in-scope unblocked agent todo.
 Honor claims/leases, blocker-push and recovery obligations. Complete one bounded,
 coherent delivery segment; validate it; write public-safe evidence, critic, and
 next action back to LoopX. A non-trivial completion needs a successor todo or an
-explicit no-follow-up rationale. After validated writeback, refresh the
-accountable progress record before spending:
+explicit no-follow-up rationale. After validated writeback, replace all three
+accountable-refresh placeholders with this turn's actual classification, batch
+scale, and outcome; never default or upgrade them to
+`multi_surface` / `outcome_progress`. Then refresh the accountable progress
+record before spending:
 `{progress_refresh_state_command}`. Then spend exactly once against that refresh:
 `{quota_spend_command}`.
 
@@ -1249,7 +1254,7 @@ missing -> "具体 user todo 未投影，需修复 LoopX 状态投影".
 DONT_NOTIFY+false/0 only: quiet.
 {RUNTIME_CAPABILITY_PROJECTION_THIN_RULE}
 {SCHEDULER_HINT_THIN_RULE}
-writeback: accountable refresh->spend; optional state-only after.
+writeback: actual class/scale/outcome accountable refresh->spend; no upgrade.
 Done->todo/rationale; guard receipt; 2 stalls->replan.
 `lark_event_inbox`: reply_due; drain_command/reply-readback/ACK.
 

--- a/loopx/project_prompt.py
+++ b/loopx/project_prompt.py
@@ -170,15 +170,18 @@ def render_accountable_progress_refresh_command(
     cli_bin: str = "loopx",
     agent_id: str | None = None,
     progress_scope: str | None = None,
+    classification: str = "<PUBLIC_SAFE_PROGRESS_CLASSIFICATION>",
+    delivery_batch_scale: str = "<ACTUAL_DELIVERY_BATCH_SCALE>",
+    delivery_outcome: str = "<ACTUAL_DELIVERY_OUTCOME>",
 ) -> str:
     return render_refresh_state_command(
         goal_id,
         cli_bin=cli_bin,
         agent_id=agent_id,
         progress_scope=progress_scope,
-        classification="<PUBLIC_SAFE_PROGRESS_CLASSIFICATION>",
-        delivery_batch_scale="multi_surface",
-        delivery_outcome="outcome_progress",
+        classification=classification,
+        delivery_batch_scale=delivery_batch_scale,
+        delivery_outcome=delivery_outcome,
     )
 
 
@@ -739,8 +742,10 @@ production artifacts in public docs or LoopX state.
 8. After setup writeback, refresh state if needed. Do not spend quota for a
 setup-only turn. The configured thin loop spends only after a later validated
 delivery writeback. If I explicitly asked you to do delivery in this same turn
-and you completed a validated delivery segment, first write one accountable
-progress refresh, then spend exactly once against that record:
+and you completed a validated delivery segment, replace all three placeholders
+with this turn's actual validated classification, batch scale, and outcome.
+Never default or upgrade them to `multi_surface` / `outcome_progress`. Then write
+one accountable progress refresh and spend exactly once against that record:
 
 ```bash
 {progress_refresh_command}
@@ -942,7 +947,9 @@ def render_prompt_text(
    - `{cli_bin} status`（在没有项目局部 registry 的目录里也应自动读共享全局 registry）
    - `{cli_bin} check --scan-path <PUBLIC_SAFE_FILE_OR_DIR>`
 11. 如果本轮实际花了 automatic delivery compute（例如 read-only map、adapter
-   tick、实现推进或验证推进），在 validation / writeback 完成后，先记录本轮
+   tick、实现推进或验证推进），在 validation / writeback 完成后，把命令中的
+   三个 placeholder 替换为本轮实际验证过的 classification、batch scale 和
+   outcome；不要默认或拔高成 `multi_surface` / `outcome_progress`。然后记录本轮
    accountable delivery：
 
 ```bash

--- a/skills/loopx-project/SKILL.md
+++ b/skills/loopx-project/SKILL.md
@@ -784,11 +784,15 @@ from the classification name:
 loopx refresh-state \
   --goal-id <STABLE_GOAL_ID> \
   --classification <PUBLIC_SAFE_PROGRESS_CLASSIFICATION> \
-  --delivery-batch-scale multi_surface \
-  --delivery-outcome outcome_progress \
+  --delivery-batch-scale <ACTUAL_DELIVERY_BATCH_SCALE> \
+  --delivery-outcome <ACTUAL_DELIVERY_OUTCOME> \
   --agent-id <REGISTERED_AGENT_ID> \
   --progress-scope goal
 ```
+
+Replace all three placeholders from the current validated turn. Never default
+or upgrade a smaller/preparatory turn to `multi_surface` / `outcome_progress`
+just because those values would satisfy a delivery floor.
 
 If the current run may write local LoopX state but its runtime boundary forbids
 configured external sink writes, keep `explore_graph.enabled` unchanged and add

--- a/tests/test_host_loop_activation.py
+++ b/tests/test_host_loop_activation.py
@@ -10,6 +10,7 @@ from loopx.host_loop_activation import (
     normalize_agent_type,
     scheduler_command_binding_for_agent_type,
 )
+from loopx.project_prompt import render_accountable_progress_refresh_command
 
 
 def test_codex_ide_plugin_is_an_exact_host_type_with_visible_goal_activation() -> None:
@@ -82,6 +83,31 @@ def test_goal_hosts_attribute_spend_to_current_progress_refresh(
     spend_command = f"`{payload['quota_spend_command']}`"
 
     assert task_body.index(refresh_command) < task_body.index(spend_command)
+    assert "<PUBLIC_SAFE_PROGRESS_CLASSIFICATION>" in refresh_command
+    assert "<ACTUAL_DELIVERY_BATCH_SCALE>" in refresh_command
+    assert "<ACTUAL_DELIVERY_OUTCOME>" in refresh_command
+    assert "--delivery-batch-scale multi_surface" not in refresh_command
+    assert "--delivery-outcome outcome_progress" not in refresh_command
+    normalized_task_body = " ".join(task_body.split())
+    assert (
+        "never default or upgrade them to `multi_surface` / `outcome_progress`"
+        in normalized_task_body
+    )
+
+
+def test_accountable_refresh_preserves_explicit_validated_turn_semantics() -> None:
+    command = render_accountable_progress_refresh_command(
+        "validated-turn-fixture",
+        classification="contract_only_preparation",
+        delivery_batch_scale="single_surface",
+        delivery_outcome="surface_only",
+    )
+
+    assert "--classification contract_only_preparation" in command
+    assert "--delivery-batch-scale single_surface" in command
+    assert "--delivery-outcome surface_only" in command
+    assert "multi_surface" not in command
+    assert "outcome_progress" not in command
 
 
 def test_codex_app_activation_uses_narrow_runtime_profile() -> None:


### PR DESCRIPTION
## Summary

- replace the generated accountable-refresh command's hard-coded `multi_surface` / `outcome_progress` values with explicit actual-value placeholders
- let callers pass validated classification, batch scale, and outcome through the existing refresh renderer
- propagate the no-default/no-upgrade contract across heartbeat, bootstrap, project skill, doctor, docs, and focused negative coverage

This is a follow-up to #2630. The causal refresh-before-spend ordering remains unchanged; the repair prevents a smaller or preparatory turn from manufacturing delivery-floor evidence.

## Change quality

- receipt: `cqr_e32b8cf46e59de812c31`
- exact scope: 12 files, 0 blockers
- reuse: existing refresh renderer and prompt surfaces
- simplification safe-fix: compressed the full heartbeat wording after the output-budget differential caught a 217-character increase; the budget was not raised

## Validation

- `37 passed` in the focused host/quota contract set
- heartbeat, project, bootstrap, local-install, and TUI-bundle smokes passed
- changed-file Ruff and accountable-renderer mypy checks passed
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 18/18 selected checks passed, public boundary clean, no manual holds

The repository-wide mypy candidate still reports the existing main-branch type backlog, so this PR uses the changed renderer check and does not broaden into unrelated type cleanup.
