### PR TITLE
fix(prompt): align Goal runtime skill routing

### DIFF
--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -33,11 +33,12 @@ two separate layers:
   --thin`, preferred as the local machine default when the target Codex agent is
   trusted to inspect LoopX registry/global quota truth, active state,
   status/run history, repo state, and project signals at wakeup time. It does
-  not paste command branches into the automation prompt; it may point the worker
-  to the installed `loopx-project` skill for procedural details, but the
-  runtime source of truth is still the CLI payload, especially
-  `quota should-run.interaction_contract`. This makes the Codex thread a
-  replaceable worker and leaves durable task truth in LoopX.
+  not paste command branches into the automation prompt. Normal execution uses
+  the LoopX CLI `interaction_contract`; use `loopx-project` only for project
+  lifecycle or registry diagnostics, and `loopx-self-repair` for runtime or
+  projection drift. The CLI payload remains the runtime source of truth. This
+  makes the Codex thread a replaceable worker and leaves durable task truth in
+  LoopX.
 
 Do not paste the full lifecycle protocol into the visible goal text, and do not
 use a short goal text such as "advance TODO" as the recurring automation body.

--- a/examples/control_plane/heartbeat-prompt-smoke.py
+++ b/examples/control_plane/heartbeat-prompt-smoke.py
@@ -322,7 +322,7 @@ def main() -> int:
         "todo continuation",
         "no cross-agent authority",
         "no scope in todo metadata",
-        "No runtime `loopx-project`",
+        "Normal: CLI contract; lifecycle/registry: `loopx-project`; drift: `loopx-self-repair`",
         "heartbeat-prequota",
         'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota should-run '
         "--goal-id loopx-meta --agent-id codex-product-capability --available-capability network "
@@ -421,9 +421,7 @@ def main() -> int:
     thin_task = normalized(str(thin_payload["task_body"]))
     for phrase in (
         "Advance `public-heartbeat-goal` from /tmp/public-heartbeat-goal/ACTIVE_GOAL_STATE.md",
-        "No runtime `loopx-project`",
-        "`loopx-self-repair`",
-        "LoopX CLI = truth",
+        "Normal: CLI contract; lifecycle/registry: `loopx-project`; drift: `loopx-self-repair`",
         "state/status/repo",
         "`quota should-run`; follow `interaction_contract`",
         "NOTIFY Chinese actions incl. non_blocking false/0",

--- a/loopx/heartbeat_prompt.py
+++ b/loopx/heartbeat_prompt.py
@@ -60,6 +60,10 @@ SCHEDULER_HINT_THIN_RULE = (
 RUNTIME_CAPABILITY_PROJECTION_THIN_RULE = (
     "Observed capabilities -> `--available-capability`; never user gates."
 )
+RUNTIME_EXECUTION_ROUTING_RULE = (
+    "Normal: CLI contract; lifecycle/registry: `loopx-project`; "
+    "drift: `loopx-self-repair`."
+)
 INTERFACE_BUDGET_CHARS = {
     "full": 12_000,
     "compact": 6_200,
@@ -1119,6 +1123,8 @@ def _render_goal_task_body(
     return f"""Advance LoopX goal `{goal_id}` from `{active_state}` {host_preamble}
 {scope_block}
 
+{RUNTIME_EXECUTION_ROUTING_RULE}
+
 At every continuation, inspect LoopX state/status and the repository. {prequota_block}Run
 `{quota_guard_command}` and follow its `interaction_contract`.
 
@@ -1243,8 +1249,7 @@ def render_thin_heartbeat_task_body(
     )
     return f"""Advance `{goal_id}` from {active_state}.
 
-No runtime `loopx-project`; repair: `loopx-self-repair`.
-LoopX CLI = truth.
+{RUNTIME_EXECUTION_ROUTING_RULE}
 {scope_sentence}
 
 Inspect state/status/repo; run

--- a/tests/test_ark_managed_agent_host.py
+++ b/tests/test_ark_managed_agent_host.py
@@ -44,6 +44,11 @@ def test_goal_prompt_is_one_transport_independent_activation() -> None:
     assert "Goal runtime owns continuation and inner iterations" in normalized
     assert "goal loop, not automation" in normalized
     assert "invoke LoopX Turn" in normalized
+    assert (
+        "Normal: CLI contract; lifecycle/registry: `loopx-project`; "
+        "drift: `loopx-self-repair`."
+        in normalized
+    )
     assert "choose the highest-priority in-scope unblocked agent todo" in normalized
     assert "Honor claims/leases, blocker-push and recovery obligations" in normalized
     assert (

--- a/tests/test_host_loop_activation.py
+++ b/tests/test_host_loop_activation.py
@@ -96,6 +96,27 @@ def test_goal_hosts_attribute_spend_to_current_progress_refresh(
     )
 
 
+@pytest.mark.parametrize(
+    "runtime_profile",
+    ("ark_managed_agent_goal", "codex_app_ssh_goal"),
+)
+def test_goal_hosts_share_narrow_runtime_skill_routing(
+    runtime_profile: str,
+) -> None:
+    payload = build_heartbeat_prompt(
+        goal_id="goal-runtime-routing-fixture",
+        thin=True,
+        runtime_profile=runtime_profile,
+    )
+    task_body = " ".join(payload["task_body"].split())
+
+    assert (
+        "Normal: CLI contract; lifecycle/registry: `loopx-project`; "
+        "drift: `loopx-self-repair`."
+        in task_body
+    )
+
+
 def test_accountable_refresh_preserves_explicit_validated_turn_semantics() -> None:
     command = render_accountable_progress_refresh_command(
         "validated-turn-fixture",


### PR DESCRIPTION
## Why

Thin automation prompts route normal execution through the LoopX CLI and point runtime drift to self-repair, while Goal prompts omitted that compact routing hint. A long-running Goal could therefore continue as a generic coding agent despite having the same installed skills.

## What

- share one compact routing line across thin automation, Codex visible Goal, and Ark Managed Agent Goal prompts
- keep `loopx-project` limited to lifecycle/registry work and `loopx-self-repair` to drift
- document the boundary and lock cross-host parity with focused tests

## Validation

- 33 focused Goal/host tests passed
- `heartbeat-prompt-smoke.py` passed
- `agent-onboard-host-loop-activation-smoke.py` passed
- premerge standard gate: 16/16 selected checks passed
- public-boundary scan: 5 files clean
- manual holds: none
- merge gate: passed; self-merge allowed

## Boundary

No heartbeat cadence, runtime capability reentry, host ownership, or quota semantics changed. Goal prompts remain below the 4,000-character budget; thin automation remains below 1,570 characters.