### PR TITLE
refine(prompt): preserve runtime routing clarity within budget

### DIFF
--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -33,12 +33,11 @@ two separate layers:
   --thin`, preferred as the local machine default when the target Codex agent is
   trusted to inspect LoopX registry/global quota truth, active state,
   status/run history, repo state, and project signals at wakeup time. It does
-  not paste command branches into the automation prompt. Normal execution uses
-  the LoopX CLI `interaction_contract`; use `loopx-project` only for project
-  lifecycle or registry diagnostics, and `loopx-self-repair` for runtime or
-  projection drift. The CLI payload remains the runtime source of truth. This
-  makes the Codex thread a replaceable worker and leaves durable task truth in
-  LoopX.
+  not paste command branches into the automation prompt. Normal turns use CLI
+  `interaction_contract`; use `loopx-project` for lifecycle/registry and
+  `loopx-self-repair` for runtime/projection drift. The CLI payload remains the
+  runtime source of truth. This makes the Codex thread a replaceable worker and
+  leaves durable task truth in LoopX.
 
 Do not paste the full lifecycle protocol into the visible goal text, and do not
 use a short goal text such as "advance TODO" as the recurring automation body.

--- a/examples/control_plane/heartbeat-prompt-smoke.py
+++ b/examples/control_plane/heartbeat-prompt-smoke.py
@@ -93,8 +93,9 @@ def main() -> int:
             "schema_version": "agent_profile_v1",
             "agent_id": "codex-product-capability",
             "scope_summary": (
-                "Peer task claims, task leases, agent profile routing, and related "
-                "control-plane correctness."
+                "Agent-facing CLI output budgets, deterministic control-plane "
+                "qualification, model-behavior shadow evaluation, and release "
+                "outcome baseline correctness."
             ),
         },
         registered_agents=["codex-main-control", "codex-product-capability"],
@@ -313,21 +314,25 @@ def main() -> int:
     assert live_peer_budget["budget_char_count"] <= live_peer_budget["max_chars"], live_peer_budget
     assert live_peer_budget["within_budget"] is True, live_peer_budget
     assert len(str(live_peer_payload["task_body"])) <= int(live_peer_budget["max_chars"]), live_peer_budget
-    assert "control-plane correctness.." not in live_peer_task, live_peer_task
+    assert "correctness.." not in live_peer_task, live_peer_task
+    assert live_peer_task.index("`LOOPX_TURN=<current_time_iso>`") < live_peer_task.index(
+        "quota should-run"
+    ), live_peer_task
     for phrase in (
         "Equal peer `codex-product-capability` (peer_v1)",
-        "Peer task claims, task leases, agent profile routing, and related control-plane correctness",
+        "Agent-facing CLI output budgets, deterministic control-plane qualification, "
+        "model-behavior shadow evaluation, and release outcome baseline correctness",
         "Claim/lease first",
         "independent repo worktree",
         "todo continuation",
         "no cross-agent authority",
         "no scope in todo metadata",
-        "Normal: CLI contract; lifecycle/registry: `loopx-project`; drift: `loopx-self-repair`",
+        "Normal turns use CLI `interaction_contract`; use `loopx-project` for "
+        "lifecycle/registry and `loopx-self-repair` for runtime/projection drift",
         "heartbeat-prequota",
         'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota should-run '
         "--goal-id loopx-meta --agent-id codex-product-capability --available-capability network "
         "--available-capability external_evidence_poll",
-        "follow `interaction_contract`",
         "NOTIFY Chinese actions incl. non_blocking false/0",
         'not only "owner gate"',
         "具体 user todo 未投影，需修复 LoopX 状态投影",
@@ -421,9 +426,10 @@ def main() -> int:
     thin_task = normalized(str(thin_payload["task_body"]))
     for phrase in (
         "Advance `public-heartbeat-goal` from /tmp/public-heartbeat-goal/ACTIVE_GOAL_STATE.md",
-        "Normal: CLI contract; lifecycle/registry: `loopx-project`; drift: `loopx-self-repair`",
+        "Normal turns use CLI `interaction_contract`; use `loopx-project` for "
+        "lifecycle/registry and `loopx-self-repair` for runtime/projection drift",
         "state/status/repo",
-        "`quota should-run`; follow `interaction_contract`",
+        "`quota should-run`",
         "NOTIFY Chinese actions incl. non_blocking false/0",
         'not only "owner gate"',
         "DONT_NOTIFY+false/0 only: quiet",

--- a/loopx/heartbeat_prompt.py
+++ b/loopx/heartbeat_prompt.py
@@ -61,14 +61,14 @@ RUNTIME_CAPABILITY_PROJECTION_THIN_RULE = (
     "Observed capabilities -> `--available-capability`; never user gates."
 )
 RUNTIME_EXECUTION_ROUTING_RULE = (
-    "Normal: CLI contract; lifecycle/registry: `loopx-project`; "
-    "drift: `loopx-self-repair`."
+    "Normal turns use CLI `interaction_contract`; use `loopx-project` for "
+    "lifecycle/registry and `loopx-self-repair` for runtime/projection drift."
 )
 INTERFACE_BUDGET_CHARS = {
     "full": 12_000,
     "compact": 6_200,
     "brief": 3_500,
-    "thin": 1_570,
+    "thin": 1_750,
     "visible_goal": 4_000,
 }
 CODEX_VISIBLE_GOAL_MAX_CHARS = INTERFACE_BUDGET_CHARS["visible_goal"]
@@ -1243,7 +1243,7 @@ def render_thin_heartbeat_task_body(
         else "`quota should-run`"
     )
     pr_review_pre_quota_instruction = (
-        f"Pre: `{pr_review_pre_quota_command}`\n"
+        f"`{pr_review_pre_quota_command}`\n"
         if pr_review_pre_quota_command
         else ""
     )
@@ -1252,9 +1252,9 @@ def render_thin_heartbeat_task_body(
 {RUNTIME_EXECUTION_ROUTING_RULE}
 {scope_sentence}
 
-Inspect state/status/repo; run
-{pr_review_pre_quota_instruction}{quota_guard_instruction}; follow `interaction_contract`.
+Inspect state/status/repo.
 `LOOPX_TURN=<current_time_iso>`; reuse.
+{pr_review_pre_quota_instruction}{quota_guard_instruction}.
 NOTIFY Chinese actions incl. non_blocking false/0; not only "owner gate";
 missing -> "具体 user todo 未投影，需修复 LoopX 状态投影".
 DONT_NOTIFY+false/0 only: quiet.

--- a/tests/test_ark_managed_agent_host.py
+++ b/tests/test_ark_managed_agent_host.py
@@ -45,8 +45,8 @@ def test_goal_prompt_is_one_transport_independent_activation() -> None:
     assert "goal loop, not automation" in normalized
     assert "invoke LoopX Turn" in normalized
     assert (
-        "Normal: CLI contract; lifecycle/registry: `loopx-project`; "
-        "drift: `loopx-self-repair`."
+        "Normal turns use CLI `interaction_contract`; use `loopx-project` for "
+        "lifecycle/registry and `loopx-self-repair` for runtime/projection drift."
         in normalized
     )
     assert "choose the highest-priority in-scope unblocked agent todo" in normalized

--- a/tests/test_host_loop_activation.py
+++ b/tests/test_host_loop_activation.py
@@ -111,8 +111,8 @@ def test_goal_hosts_share_narrow_runtime_skill_routing(
     task_body = " ".join(payload["task_body"].split())
 
     assert (
-        "Normal: CLI contract; lifecycle/registry: `loopx-project`; "
-        "drift: `loopx-self-repair`."
+        "Normal turns use CLI `interaction_contract`; use `loopx-project` for "
+        "lifecycle/registry and `loopx-self-repair` for runtime/projection drift."
         in task_body
     )
 


### PR DESCRIPTION
## Summary

Follow up #2646 with a clearer, still-bounded runtime routing contract:

- keep one shared sentence across thin heartbeat, Codex-visible Goal, and Ark Managed Agent Goal prompts;
- state the three owners explicitly: normal turns use the CLI `interaction_contract`, lifecycle/registry work uses `loopx-project`, and runtime/projection drift uses `loopx-self-repair`;
- define `LOOPX_TURN` before the quota command that consumes it;
- cover a representative long agent scope and raise the thin absolute ceiling to 1750 without widening the global base-to-head growth allowance.

The current representative prompt is 1650 characters (1627 budget characters), and the base-to-head hot-path differential remains within policy.

## Validation

- `39 passed` across host-routing and CLI output-budget tests
- focused Ruff and changed-Python compile checks
- `heartbeat-prompt-smoke.py`
- `agent-onboard-host-loop-activation-smoke.py`
- `hot-path-interface-budget-smoke.py`
- `cli-output-budget-regression-smoke.py`
- risk-based premerge: 16/16 selected checks passed, no manual holds
- public/private boundary scan clean
- exact-scope change-quality receipt: `cqr_8e43a45cf185c93b789f`

Full pytest was not run because the repository's risk-based gate selected the relevant control-plane, output-budget, canary, and public-boundary coverage for this five-file prompt refinement.
