### PR TITLE
fix(benchmark): close SkillsBench source and termination gaps

### DIFF
--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -369,6 +369,15 @@ def _benchflow_rollout_planes_class(module: Any) -> type[Any] | None:
     return klass if isinstance(klass, type) else None
 
 
+def _benchflow_environment_name(
+    call_args: tuple[Any, ...],
+    call_kwargs: dict[str, Any],
+) -> str:
+    if call_args:
+        return str(call_args[0])
+    return str(call_kwargs.get("environment") or "")
+
+
 DOCKER_APP_SKILLS_MOUNT_BEGIN = "# BEGIN LOOPX_SKILLSBENCH_APP_SKILLS_MOUNT"
 DOCKER_APP_SKILLS_MOUNT_END = "# END LOOPX_SKILLSBENCH_APP_SKILLS_MOUNT"
 DOCKER_APP_SKILLS_MOUNT_KEEP_FILE = "loopx_app_skills_keep"
@@ -14862,7 +14871,7 @@ async def run_benchflow_case(
         if original_create_environment is None:
             raise RuntimeError("BenchFlow rollout planes create_environment missing")
         env = original_create_environment(self, *call_args, **call_kwargs)
-        environment = str(call_args[0]) if call_args else ""
+        environment = _benchflow_environment_name(call_args, call_kwargs)
         return _record_container_mount_injection(env, environment)
 
     def _record_container_mount_injection(env: Any, environment: str) -> Any:

--- a/scripts/skillsbench_reverse_tunnel_supervisor.py
+++ b/scripts/skillsbench_reverse_tunnel_supervisor.py
@@ -45,6 +45,7 @@ from loopx.benchmark_core.lifecycle import (  # noqa: E402
 SCHEMA_VERSION = "skillsbench_reverse_tunnel_supervisor_v0"
 PUBLIC_LIVENESS_SCHEMA_VERSION = "skillsbench_supervisor_public_liveness_v0"
 ACTIVE_PHASE_SCHEMA_VERSION = "skillsbench_supervisor_active_phase_v0"
+TERMINAL_CLOSEOUT_SCHEMA_VERSION = "skillsbench_supervisor_terminal_closeout_v0"
 PUBLIC_LIVENESS_INTERVAL_SEC = 30.0
 DEFAULT_REMOTE_FORWARD = "127.0.0.1:18180:127.0.0.1:18180"
 DEFAULT_TEST_HOST = "chatgpt.com"
@@ -1093,6 +1094,20 @@ def _write_public_checkpoint(
         temporary.replace(target)
     finally:
         temporary.unlink(missing_ok=True)
+    closeout = payload.get("terminal_closeout")
+    if isinstance(closeout, Mapping):
+        closeout_target = target.with_name("supervisor_closeout.compact.json")
+        closeout_temporary = closeout_target.with_name(
+            f".{closeout_target.name}.{os.getpid()}.tmp"
+        )
+        try:
+            closeout_temporary.write_text(
+                json.dumps(closeout, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            closeout_temporary.replace(closeout_target)
+        finally:
+            closeout_temporary.unlink(missing_ok=True)
 
 
 def _public_artifact_sync_requested(args: argparse.Namespace) -> bool:
@@ -1554,6 +1569,101 @@ def _last_public_liveness_contract(path: str | None) -> dict[str, Any]:
     return contract
 
 
+def _last_public_checkpoint(path: str | None) -> dict[str, Any]:
+    if not path:
+        return {}
+    try:
+        loaded = json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return {}
+    if not isinstance(loaded, Mapping):
+        return {}
+    if loaded.get("schema_version") != SCHEMA_VERSION:
+        return {}
+    return dict(loaded)
+
+
+def _terminal_artifact_presence(args: argparse.Namespace) -> dict[str, Any]:
+    contract = {
+        "status": "unavailable",
+        "benchmark_compact_present": False,
+        "controller_trace_present": False,
+        "public_artifact_read": False,
+        "raw_artifacts_read": False,
+        "local_paths_recorded": False,
+    }
+    if not args.local_public_artifact_dir:
+        return contract
+    root = Path(args.local_public_artifact_dir).expanduser()
+    if not root.is_dir() or root.is_symlink():
+        return contract
+    basenames: set[str] = set()
+    for path in root.rglob("*.json"):
+        if path.is_symlink() or not path.is_file():
+            continue
+        basenames.add(path.name)
+    contract.update(
+        status="observed",
+        benchmark_compact_present="benchmark_run.compact.json" in basenames,
+        controller_trace_present="loopx_controller_trace.public.json" in basenames,
+        public_artifact_read=True,
+    )
+    return contract
+
+
+def _terminal_closeout_contract(
+    args: argparse.Namespace,
+    *,
+    trigger: str,
+    signal_name: str = "",
+) -> dict[str, Any]:
+    artifacts = _terminal_artifact_presence(args)
+    benchmark_compact_present = bool(artifacts["benchmark_compact_present"])
+    contract = {
+        "schema_version": TERMINAL_CLOSEOUT_SCHEMA_VERSION,
+        "status": "complete",
+        "disposition": (
+            "defer_to_benchmark_compact"
+            if benchmark_compact_present
+            else "typed_exclusion"
+        ),
+        "reason_code": trigger,
+        "benchmark_compact_present": benchmark_compact_present,
+        "controller_trace_present": bool(artifacts["controller_trace_present"]),
+        "official_score_countable": None if benchmark_compact_present else False,
+        "retry_recommended": False,
+        "rotation_allowed": True,
+        "public_artifact_read": bool(artifacts["public_artifact_read"]),
+        "raw_artifacts_read": False,
+        "raw_task_text_read": False,
+        "raw_logs_read": False,
+        "raw_trajectory_read": False,
+        "raw_verifier_output_read": False,
+        "local_paths_recorded": False,
+    }
+    if signal_name:
+        contract["signal_name"] = signal_name
+    return contract
+
+
+def _termination_public_artifact_sync(
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    if not _public_artifact_sync_requested(args):
+        return _public_artifact_sync_contract(args)
+    try:
+        return _sync_remote_public_artifacts(args)
+    except Exception as exc:
+        contract = _public_artifact_sync_contract(args)
+        contract.update(
+            attempted=True,
+            ok=False,
+            first_blocker="termination_public_artifact_sync_failed",
+            error_type=type(exc).__name__[:80],
+        )
+        return contract
+
+
 def _finalize_unhandled_supervisor_failure(
     args: argparse.Namespace,
     exc: Exception,
@@ -1561,22 +1671,25 @@ def _finalize_unhandled_supervisor_failure(
     previous = _last_public_liveness_contract(args.public_output_path)
     now = time.time()
     started_at = now - float(previous["elapsed_sec"])
-    try:
-        payload = _initial_public_payload(args)
-    except Exception as payload_exc:
-        payload = {
-            "schema_version": SCHEMA_VERSION,
-            "ok": False,
-            "tunnel_started": False,
-            "tunnel_ready": False,
-            "remote_command_requested": bool(args.remote_command),
-            "raw_ssh_destination_recorded": False,
-            "raw_remote_command_recorded": False,
-            "raw_probe_output_recorded": False,
-            "raw_remote_output_recorded": False,
-            "private_log_written": False,
-            "fallback_payload_error_type": type(payload_exc).__name__[:80],
-        }
+    payload = _last_public_checkpoint(args.public_output_path)
+    if not payload:
+        try:
+            payload = _initial_public_payload(args)
+        except Exception as payload_exc:
+            payload = {
+                "schema_version": SCHEMA_VERSION,
+                "ok": False,
+                "tunnel_started": False,
+                "tunnel_ready": False,
+                "remote_command_requested": bool(args.remote_command),
+                "raw_ssh_destination_recorded": False,
+                "raw_remote_command_recorded": False,
+                "raw_probe_output_recorded": False,
+                "raw_remote_output_recorded": False,
+                "private_log_written": False,
+                "fallback_payload_error_type": type(payload_exc).__name__[:80],
+            }
+    payload["ok"] = False
     termination_signal = (
         exc.signum if isinstance(exc, _SupervisorTerminationSignal) else None
     )
@@ -1599,9 +1712,10 @@ def _finalize_unhandled_supervisor_failure(
         "local_paths_recorded": False,
     }
     if termination_signal is not None:
-        payload["public_terminal_fallback"]["signal_name"] = signal.Signals(
-            termination_signal
-        ).name
+        signal_name = signal.Signals(termination_signal).name
+        payload["public_terminal_fallback"]["signal_name"] = signal_name
+    else:
+        signal_name = ""
     try:
         payload["remote_failure_cleanup"] = _run_remote_failure_cleanup(
             args,
@@ -1613,6 +1727,12 @@ def _finalize_unhandled_supervisor_failure(
         cleanup["first_blocker"] = "remote_failure_cleanup_failed"
         cleanup["error_type"] = type(cleanup_exc).__name__[:80]
         payload["remote_failure_cleanup"] = cleanup
+    payload["public_artifact_sync"] = _termination_public_artifact_sync(args)
+    payload["terminal_closeout"] = _terminal_closeout_contract(
+        args,
+        trigger=str(payload["first_blocker"]),
+        signal_name=signal_name,
+    )
     _write_public_checkpoint(
         args.public_output_path,
         payload,
@@ -2217,6 +2337,42 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
             if remote_proc.returncode == 0 and sync_ok
             else remote_proc.returncode or 3
         )
+    except _SupervisorTerminationSignal as exc:
+        if remote_proc is not None:
+            _stop_process_group(remote_proc, grace_sec=1.0)
+        payload["ok"] = False
+        payload["first_blocker"] = "supervisor_termination_signal"
+        payload["supervisor_error_type"] = type(exc).__name__[:80]
+        try:
+            payload["remote_failure_cleanup"] = _run_remote_failure_cleanup(
+                args,
+                trigger="supervisor_termination_signal",
+            )
+        except Exception as cleanup_exc:
+            cleanup = _remote_failure_cleanup_public_contract(args)
+            cleanup["trigger"] = "supervisor_termination_signal"
+            cleanup["first_blocker"] = "remote_failure_cleanup_failed"
+            cleanup["error_type"] = type(cleanup_exc).__name__[:80]
+            payload["remote_failure_cleanup"] = cleanup
+        payload["public_artifact_sync"] = _termination_public_artifact_sync(args)
+        payload["terminal_closeout"] = _terminal_closeout_contract(
+            args,
+            trigger="supervisor_termination_signal",
+            signal_name=signal.Signals(exc.signum).name,
+        )
+        payload["public_terminal_fallback"] = {
+            "schema_version": "skillsbench_supervisor_terminal_fallback_v0",
+            "triggered": True,
+            "trigger": "supervisor_termination_signal",
+            "signal_name": signal.Signals(exc.signum).name,
+            "exception_message_recorded": False,
+            "raw_task_text_recorded": False,
+            "raw_logs_recorded": False,
+            "raw_trajectory_recorded": False,
+            "raw_verifier_output_recorded": False,
+            "local_paths_recorded": False,
+        }
+        return finish(128 + exc.signum)
     except (OSError, subprocess.TimeoutExpired) as exc:
         if remote_proc is not None:
             _stop_process_group(remote_proc, grace_sec=1.0)

--- a/tests/test_skillsbench_reverse_tunnel_supervisor.py
+++ b/tests/test_skillsbench_reverse_tunnel_supervisor.py
@@ -27,6 +27,8 @@ def _load_supervisor_module():
 def _write_fake_ssh(path: Path) -> None:
     path.write_text(
         """#!/usr/bin/env python3
+import os
+import signal
 import sys
 import time
 
@@ -36,6 +38,9 @@ elif "# LOOPX_REVERSE_TUNNEL_PROBE" in sys.argv[-1]:
     print("HTTP/1.1 200 OK")
 elif sys.argv[-1] == "run-benchmark":
     time.sleep(0.2)
+elif sys.argv[-1] == "terminate-supervisor":
+    time.sleep(0.1)
+    os.kill(os.getppid(), signal.SIGTERM)
 elif sys.argv[-1] == "fail-arguments":
     print("usage: runner [--known]", file=sys.stderr)
     print("runner: error: unrecognized arguments: --private-value", file=sys.stderr)
@@ -377,6 +382,26 @@ def test_main_finalizes_public_liveness_after_unhandled_supervisor_failure(
         )
     )
     previous_payload["tunnel_ready"] = True
+    previous_payload["active_phase"] = {
+        "schema_version": "skillsbench_supervisor_active_phase_v0",
+        "state": "observed",
+        "benchmark_live_worker_phase": {
+            "schema_version": "benchmark_live_worker_phase_v0",
+            "current_phase": "agent_active",
+            "next_required_phase": "",
+            "phase_ready": {
+                "runtime_preparing": True,
+                "worker_prepared": True,
+                "worker_running": True,
+                "agent_active": True,
+            },
+            "worker_live": True,
+            "agent_active_observed": True,
+            "terminal": False,
+            "terminal_disposition": "open",
+            "public_evidence_only": True,
+        },
+    }
     supervisor._write_public_checkpoint(
         str(public_output),
         previous_payload,
@@ -413,6 +438,11 @@ def test_main_finalizes_public_liveness_after_unhandled_supervisor_failure(
     assert persisted["public_liveness"]["terminal"] is True
     assert persisted["public_liveness"]["process_alive"] is False
     assert persisted["public_liveness"]["heartbeat_count"] == 5
+    phase = persisted["active_phase"]["benchmark_live_worker_phase"]
+    assert phase["agent_active_observed"] is True
+    assert phase["terminal"] is True
+    assert phase["worker_live"] is False
+    assert phase["terminal_disposition"] == "failed"
     fallback = persisted["public_terminal_fallback"]
     assert fallback["triggered"] is True
     assert fallback["exception_message_recorded"] is False
@@ -458,8 +488,61 @@ def test_main_finalizes_public_liveness_after_termination_signal(
     assert fallback["trigger"] == "supervisor_termination_signal"
     assert fallback["signal_name"] == "SIGTERM"
     assert fallback["exception_message_recorded"] is False
+    closeout = persisted["terminal_closeout"]
+    assert closeout["status"] == "complete"
+    assert closeout["disposition"] == "typed_exclusion"
+    assert closeout["official_score_countable"] is False
+    assert closeout["retry_recommended"] is False
+    assert closeout["rotation_allowed"] is True
+    closeout_path = public_output.with_name("supervisor_closeout.compact.json")
+    assert json.loads(closeout_path.read_text(encoding="utf-8")) == closeout
     assert '"signal_name": "SIGTERM"' in captured.out
     assert "_SupervisorTerminationSignal" in captured.err
+
+
+def test_runtime_termination_writes_closeout_and_cleans_local_processes(
+    tmp_path: Path,
+) -> None:
+    supervisor = _load_supervisor_module()
+    supervisor.PUBLIC_LIVENESS_INTERVAL_SEC = 0.05
+    fake_ssh = tmp_path / "fake-ssh"
+    public_output = tmp_path / "public" / "supervisor.public.json"
+    _write_fake_ssh(fake_ssh)
+
+    returncode = supervisor.main(
+        [
+            "--ssh-bin",
+            str(fake_ssh),
+            "--ssh-destination",
+            "runner.example",
+            "--remote-command",
+            "terminate-supervisor",
+            "--public-output-path",
+            str(public_output),
+            "--probe-interval-sec",
+            "0.01",
+            "--probe-timeout-sec",
+            "5",
+            "--tunnel-ready-timeout-sec",
+            "5",
+            "--tunnel-health-interval-sec",
+            "0",
+            "--run-timeout-sec",
+            "5",
+        ]
+    )
+    persisted = json.loads(public_output.read_text(encoding="utf-8"))
+
+    assert returncode == 128 + signal.SIGTERM
+    assert persisted["first_blocker"] == "supervisor_termination_signal"
+    assert persisted["public_liveness"]["terminal"] is True
+    assert persisted["tunnel_cleanup_status"] == "terminated"
+    assert persisted["terminal_closeout"]["disposition"] == "typed_exclusion"
+    assert persisted["terminal_closeout"]["signal_name"] == "SIGTERM"
+    assert (
+        persisted["public_terminal_fallback"]["trigger"]
+        == "supervisor_termination_signal"
+    )
 
 
 def test_remote_command_failure_subtype_uses_public_allowlist() -> None:

--- a/tests/test_skillsbench_runtime_tools.py
+++ b/tests/test_skillsbench_runtime_tools.py
@@ -2,9 +2,15 @@ from loopx.benchmark_adapters import skillsbench_dockerfile_runtime
 from scripts.skillsbench_automation_loop import (
     DOCKER_BENCHMARK_EGRESS_PROXY_BEGIN,
     DOCKER_CODEX_ACP_RUNTIME_TOOLS_BEGIN,
+    _benchflow_environment_name,
     patch_dockerfile_codex_acp_runtime_tools,
     stage_task_for_sandbox,
 )
+
+
+def test_benchflow_environment_name_preserves_keyword_environment() -> None:
+    assert _benchflow_environment_name((), {"environment": "docker"}) == "docker"
+    assert _benchflow_environment_name(("docker",), {}) == "docker"
 
 
 def test_runtime_tools_retries_apt_with_public_mirrors(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- recognize BenchFlow's keyword environment argument so the host-local LoopX source mount is actually injected
- preserve the last public supervisor checkpoint when termination occurs
- emit a public-safe terminal closeout and clean local and remote processes on runtime termination

## Validation

- `uv run --python 3.12 --with pytest pytest -q tests/test_skillsbench_runtime_tools.py tests/test_skillsbench_reverse_tunnel_supervisor.py` (17 passed)
- `uv run --python 3.12 python examples/skillsbench-reverse-tunnel-supervisor-smoke.py`
- `uv run --python 3.12 python examples/skillsbench-benchmark-run-smoke.py`
- `loopx canary premerge --from-git-diff` (changed-Python compile and 4 catalog canaries passed; benchmark-sensitive manual hold remains)
- `git diff --check` and diff-only public/private boundary scan

## Scope

This does not change benchmark scoring, task semantics, leaderboard or submission behavior, permissions, or launch any benchmark job.
