### PR TITLE
test(change-quality): replay adversarial PR findings

### DIFF
--- a/loopx/capabilities/change_quality/shadow.py
+++ b/loopx/capabilities/change_quality/shadow.py
@@ -20,6 +20,7 @@ CHANGE_QUALITY_SHADOW_RECEIPT_SCHEMA_VERSION = "change_quality_shadow_receipt_v0
 CHANGE_QUALITY_SHADOW_CONTRACT_VERSIONS = ("v0", "v1")
 CHANGE_QUALITY_SHADOW_CASE_KINDS = (
     "real_pr_clean",
+    "real_pr_adversarial",
     "synthetic_simplification",
 )
 CHANGE_QUALITY_SHADOW_FINDING_CLASSES = (
@@ -142,7 +143,7 @@ def load_change_quality_shadow_matrix(path: Path) -> dict[str, Any]:
         if not isinstance(source, Mapping):
             raise ValueError(f"cases[{index}].source must be an object")
         normalized_source: dict[str, Any]
-        if kind == "real_pr_clean":
+        if kind.startswith("real_pr_"):
             pull_request = source.get("pull_request")
             if not isinstance(pull_request, int) or pull_request < 1:
                 raise ValueError(f"cases[{index}].source.pull_request must be positive")
@@ -338,7 +339,7 @@ def build_change_quality_shadow_prompt(
     if contract_version not in CHANGE_QUALITY_SHADOW_CONTRACT_VERSIONS:
         raise ValueError("unknown change-quality shadow contract version")
     source = dict(case["source"])
-    if case["kind"] == "real_pr_clean":
+    if case["kind"].startswith("real_pr_"):
         scope = (
             f"Review commit range {source['base_ref']}..{source['head_ref']}. "
             "Use git diff and repository files to inspect the exact change."

--- a/tests/capabilities/test_change_quality_shadow.py
+++ b/tests/capabilities/test_change_quality_shadow.py
@@ -62,22 +62,23 @@ def _result(
     }
 
 
-def _finding(*, finding_class: str, path: str) -> dict:
+def _finding(*, finding_class: str, path: str, code: str = "known-complexity") -> dict:
     return {
         "finding_class": finding_class,
         "severity": "warning",
-        "code": "known-complexity",
+        "code": code,
         "path": path,
         "line": 1,
         "message": "The changed implementation violates the fixture contract.",
     }
 
 
-def test_shadow_matrix_covers_five_real_prs_and_three_languages() -> None:
+def test_shadow_matrix_covers_clean_and_adversarial_prs_and_three_languages() -> None:
     matrix = _matrix()
 
-    assert len(matrix["cases"]) == 8
+    assert len(matrix["cases"]) == 9
     assert sum(case["kind"] == "real_pr_clean" for case in matrix["cases"]) == 5
+    assert sum(case["kind"] == "real_pr_adversarial" for case in matrix["cases"]) == 1
     synthetic = [
         case for case in matrix["cases"] if case["kind"] == "synthetic_simplification"
     ]
@@ -87,6 +88,39 @@ def test_shadow_matrix_covers_five_real_prs_and_three_languages() -> None:
         "typescript",
     }
     assert all(len(case["gold"]["findings"]) == 1 for case in synthetic)
+
+
+def test_pr_2578_replay_grades_sparse_simplify_and_boundary_findings() -> None:
+    case = _case("pr-2578-adversarial")
+    raw = _result(
+        case,
+        findings=[
+            _finding(
+                finding_class="complexity",
+                path="loopx/planner_worker.py",
+                code="duplicate-readiness-truth",
+            ),
+            _finding(
+                finding_class="security_privacy",
+                path="loopx/extensions/traex_planner_worker.py",
+                code="workspace-symlink-escape",
+            ),
+        ],
+    )
+
+    normalized = normalize_change_quality_shadow_result(
+        raw,
+        case=case,
+        contract_version="v1",
+    )
+    grade = grade_change_quality_shadow_result(normalized, case=case)
+
+    assert len(normalized["findings"]) == 2
+    assert grade["matched_finding_count"] == 2
+    assert grade["false_positive_count"] == 0
+    assert grade["false_negative_count"] == 0
+    assert grade["simplification_match"] is True
+    assert grade["safe_fix_match"] is True
 
 
 def test_v0_prompt_does_not_smuggle_in_v1_lens_ids() -> None:
@@ -238,13 +272,16 @@ def test_receipt_promotes_only_complete_accurate_bounded_v1() -> None:
     }
 
 
-def test_receipt_fails_promotion_on_one_false_positive() -> None:
+def test_receipt_fails_promotion_below_precision_floor() -> None:
     matrix = _matrix()
     runs = []
     for case in matrix["cases"]:
         expected_count = len(case["gold"]["findings"])
         for version in ("v0", "v1"):
-            false_positive = version == "v1" and case["case_id"] == "pr-2590-clean"
+            false_positive = version == "v1" and case["case_id"] in {
+                "pr-2590-clean",
+                "pr-2593-clean",
+            }
             runs.append(
                 {
                     "case_id": case["case_id"],
@@ -274,7 +311,7 @@ def test_receipt_fails_promotion_on_one_false_positive() -> None:
         source_commit="b" * 40,
     )
 
-    assert receipt["arms"]["v1"]["precision"] == 0.75
+    assert receipt["arms"]["v1"]["precision"] == 0.7143
     assert receipt["acceptance"]["v1_simplify_precision_at_least_0_8"] is False
     assert receipt["strict_receipt_promotion_recommended"] is False
 

--- a/tests/fixtures/change_quality/model_shadow_matrix.json
+++ b/tests/fixtures/change_quality/model_shadow_matrix.json
@@ -110,6 +110,41 @@
       }
     },
     {
+      "case_id": "pr-2578-adversarial",
+      "kind": "real_pr_adversarial",
+      "language": "python",
+      "changed_files": [
+        "examples/planner-worker-contract-smoke.py",
+        "examples/planner-worker-runtime-smoke.py",
+        "examples/traex-planner-worker-probe-smoke.py",
+        "loopx/extensions/traex_planner_worker.py",
+        "loopx/planner_worker.py",
+        "loopx/planner_worker_runtime.py",
+        "scripts/traex_planner_worker_probe.py",
+        "tests/test_planner_worker.py",
+        "tests/test_planner_worker_runtime.py"
+      ],
+      "source": {
+        "pull_request": 2578,
+        "base_ref": "17842deaa029dbc787f6e2a5397cb4ffc685d1be",
+        "head_ref": "5d13709996e6a0b7f397908766b631f40071639b"
+      },
+      "gold": {
+        "findings": [
+          {
+            "finding_class": "complexity",
+            "path": "loopx/planner_worker.py"
+          },
+          {
+            "finding_class": "security_privacy",
+            "path": "loopx/extensions/traex_planner_worker.py"
+          }
+        ],
+        "safe_fix_action": "manual",
+        "simplification_outcome": "simplify"
+      }
+    },
+    {
       "case_id": "python-one-use-wrapper",
       "kind": "synthetic_simplification",
       "language": "python",


### PR DESCRIPTION
## Summary

- add PR #2578 as a real adversarial shadow case
- require sparse detection of duplicated readiness truth and workspace symlink escape
- keep the ordinary change-quality result/receipt contract unchanged

## Validation

- `python -m pytest -q tests/capabilities/test_change_quality_shadow.py` (10 passed)
- `uv run --with ruff ruff check loopx/capabilities/change_quality/shadow.py tests/capabilities/test_change_quality_shadow.py`
- `python -m py_compile loopx/capabilities/change_quality/shadow.py tests/capabilities/test_change_quality_shadow.py`
- `loopx --registry "$HOME/.codex/loopx/registry.global.json" canary premerge --from-git-diff --goal-id loopx-meta`
- exact change-quality receipt: `cqr_6f1ccd47f6efdf3bf9be`

## Boundaries

No live model evaluation, benchmark launch, policy mutation, provider-specific evaluator, private evidence, or ordinary receipt expansion.