### PR TITLE
fix(change-quality): require full shadow matrix for promotion

### DIFF
--- a/docs/capabilities/change-quality/README.md
+++ b/docs/capabilities/change-quality/README.md
@@ -177,4 +177,7 @@ runner retains only result digests, bounded scores, usage, and latency; prompts,
 model responses, stderr, command logs, and temporary worktrees are discarded.
 A passing shadow may recommend strict-receipt promotion, but the receipt
 explicitly sets `automatic_policy_mutation_allowed=false`. Repository policy
-still changes through its normal owner and control-plane path.
+still changes through its normal owner and control-plane path. `--case-id`
+runs remain useful diagnostics, but only a run over the complete currently
+declared matrix may emit that promotion recommendation; an older receipt also
+becomes ineligible when the matrix grows.

--- a/loopx/capabilities/change_quality/shadow.py
+++ b/loopx/capabilities/change_quality/shadow.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from pathlib import Path, PurePosixPath
 from typing import Any
 
@@ -550,11 +550,15 @@ def grade_change_quality_shadow_result(
 def build_change_quality_shadow_receipt(
     *,
     matrix: Mapping[str, Any],
-    runs: list[Mapping[str, Any]],
+    declared_matrix: Mapping[str, Any],
+    runs: Sequence[Mapping[str, Any]],
     model_ref: str,
     source_commit: str,
 ) -> dict[str, Any]:
     case_count = len(matrix["cases"])
+    expected_case_ids = sorted(case["case_id"] for case in matrix["cases"])
+    matrix_digest = _digest(dict(matrix))
+    declared_matrix_digest = _digest(dict(declared_matrix))
     arms: dict[str, dict[str, Any]] = {}
     for version in CHANGE_QUALITY_SHADOW_CONTRACT_VERSIONS:
         selected = [dict(item) for item in runs if item["contract_version"] == version]
@@ -618,8 +622,19 @@ def build_change_quality_shadow_receipt(
     latency_ratio = (
         round(v1["latency_ms"] / v0["latency_ms"], 4) if v0["latency_ms"] else None
     )
+    exact_valid_arms = {
+        version: sorted(
+            item["case_id"]
+            for item in runs
+            if item["contract_version"] == version and item.get("valid") is True
+        )
+        == expected_case_ids
+        for version in CHANGE_QUALITY_SHADOW_CONTRACT_VERSIONS
+    }
     acceptance = {
-        "all_v1_runs_valid": v1["valid_count"] == case_count,
+        "full_declared_matrix_evaluated": matrix_digest == declared_matrix_digest,
+        "all_v0_runs_valid": exact_valid_arms["v0"],
+        "all_v1_runs_valid": exact_valid_arms["v1"],
         "v1_primary_lenses_complete": v1["primary_lens_completeness"] == 1.0,
         "v1_simplify_precision_at_least_0_8": v1["precision"] >= 0.8,
         "v1_simplify_recall_at_least_0_8": v1["recall"] >= 0.8,
@@ -643,9 +658,11 @@ def build_change_quality_shadow_receipt(
             field="source_commit",
             limit=64,
         ),
-        "matrix_digest": _digest(dict(matrix)),
+        "matrix_digest": matrix_digest,
+        "declared_matrix_digest": declared_matrix_digest,
         "evaluation_focus": "simplify_first",
         "case_count": case_count,
+        "declared_case_count": len(declared_matrix["cases"]),
         "arms": arms,
         "budget_comparison": {
             "v1_to_v0_output_token_ratio": token_ratio,

--- a/scripts/qualify-change-quality-model-shadow.py
+++ b/scripts/qualify-change-quality-model-shadow.py
@@ -360,6 +360,7 @@ def main() -> int:
     runs.sort(key=lambda item: (item["case_id"], item["contract_version"]))
     receipt = build_change_quality_shadow_receipt(
         matrix=selected_matrix,
+        declared_matrix=matrix,
         runs=runs,
         model_ref=f"{args.model}:{args.reasoning_effort}",
         source_commit=source_commit,

--- a/tests/capabilities/test_change_quality_shadow.py
+++ b/tests/capabilities/test_change_quality_shadow.py
@@ -73,6 +73,37 @@ def _finding(*, finding_class: str, path: str, code: str = "known-complexity") -
     }
 
 
+def _passing_runs(matrix: dict) -> list[dict]:
+    runs = []
+    for case in matrix["cases"]:
+        expected_count = len(case["gold"]["findings"])
+        for version in ("v0", "v1"):
+            runs.append(
+                {
+                    "case_id": case["case_id"],
+                    "contract_version": version,
+                    "valid": True,
+                    "expected_finding_count": expected_count,
+                    "predicted_finding_count": expected_count,
+                    "matched_finding_count": expected_count,
+                    "false_positive_count": 0,
+                    "false_negative_count": 0,
+                    "lens_coverage_count": (
+                        len(SIMPLIFY_PRIMARY_LENS_IDS) if version == "v1" else 1
+                    ),
+                    "lens_required_count": len(SIMPLIFY_PRIMARY_LENS_IDS),
+                    "safe_fix_match": True,
+                    "simplification_match": True,
+                    "tracked_files_modified": False,
+                    "input_tokens": 100,
+                    "output_tokens": 100 if version == "v0" else 120,
+                    "latency_ms": 1000 if version == "v0" else 1100,
+                    "result_digest": f"sha256:{case['case_id']}-{version}",
+                }
+            )
+    return runs
+
+
 def test_shadow_matrix_covers_clean_and_adversarial_prs_and_three_languages() -> None:
     matrix = _matrix()
 
@@ -226,37 +257,11 @@ def test_normalizer_rejects_local_paths_and_mismatched_identity() -> None:
 
 def test_receipt_promotes_only_complete_accurate_bounded_v1() -> None:
     matrix = _matrix()
-    runs = []
-    for case in matrix["cases"]:
-        expected_count = len(case["gold"]["findings"])
-        for version in ("v0", "v1"):
-            runs.append(
-                {
-                    "case_id": case["case_id"],
-                    "contract_version": version,
-                    "valid": True,
-                    "expected_finding_count": expected_count,
-                    "predicted_finding_count": expected_count,
-                    "matched_finding_count": expected_count,
-                    "false_positive_count": 0,
-                    "false_negative_count": 0,
-                    "lens_coverage_count": (
-                        len(SIMPLIFY_PRIMARY_LENS_IDS) if version == "v1" else 1
-                    ),
-                    "lens_required_count": len(SIMPLIFY_PRIMARY_LENS_IDS),
-                    "safe_fix_match": True,
-                    "simplification_match": True,
-                    "tracked_files_modified": False,
-                    "input_tokens": 100,
-                    "output_tokens": 100 if version == "v0" else 120,
-                    "latency_ms": 1000 if version == "v0" else 1100,
-                    "result_digest": f"sha256:{case['case_id']}-{version}",
-                }
-            )
 
     receipt = build_change_quality_shadow_receipt(
         matrix=matrix,
-        runs=runs,
+        declared_matrix=matrix,
+        runs=_passing_runs(matrix),
         model_ref="test-model:medium",
         source_commit="a" * 40,
     )
@@ -270,6 +275,58 @@ def test_receipt_promotes_only_complete_accurate_bounded_v1() -> None:
         "raw_model_responses_persisted": False,
         "stderr_persisted": False,
     }
+
+
+@pytest.mark.parametrize("evaluated_case_count", [1, 8])
+def test_partial_or_stale_matrix_cannot_recommend_strict_promotion(
+    evaluated_case_count: int,
+) -> None:
+    declared_matrix = _matrix()
+    evaluated_matrix = {
+        **declared_matrix,
+        "cases": declared_matrix["cases"][:evaluated_case_count],
+    }
+
+    receipt = build_change_quality_shadow_receipt(
+        matrix=evaluated_matrix,
+        declared_matrix=declared_matrix,
+        runs=_passing_runs(evaluated_matrix),
+        model_ref="test-model:medium",
+        source_commit="c" * 40,
+    )
+
+    assert receipt["case_count"] == evaluated_case_count
+    assert receipt["declared_case_count"] == len(declared_matrix["cases"])
+    assert receipt["matrix_digest"] != receipt["declared_matrix_digest"]
+    assert receipt["acceptance"]["full_declared_matrix_evaluated"] is False
+    assert receipt["strict_receipt_promotion_recommended"] is False
+
+
+def test_duplicate_valid_run_cannot_hide_a_missing_case() -> None:
+    matrix = _matrix()
+    runs = _passing_runs(matrix)
+    missing_case_id = matrix["cases"][-1]["case_id"]
+    runs = [
+        run
+        for run in runs
+        if not (
+            run["case_id"] == missing_case_id and run["contract_version"] == "v1"
+        )
+    ]
+    duplicate = next(run for run in runs if run["contract_version"] == "v1")
+    runs.append(dict(duplicate))
+
+    receipt = build_change_quality_shadow_receipt(
+        matrix=matrix,
+        declared_matrix=matrix,
+        runs=runs,
+        model_ref="test-model:medium",
+        source_commit="d" * 40,
+    )
+
+    assert receipt["arms"]["v1"]["valid_count"] == len(matrix["cases"])
+    assert receipt["acceptance"]["all_v1_runs_valid"] is False
+    assert receipt["strict_receipt_promotion_recommended"] is False
 
 
 def test_receipt_fails_promotion_below_precision_floor() -> None:
@@ -306,6 +363,7 @@ def test_receipt_fails_promotion_below_precision_floor() -> None:
 
     receipt = build_change_quality_shadow_receipt(
         matrix=matrix,
+        declared_matrix=matrix,
         runs=runs,
         model_ref="test-model:medium",
         source_commit="b" * 40,


### PR DESCRIPTION
## Summary

- keep `--case-id` useful for diagnostics but prevent subset runs from recommending strict-receipt promotion
- bind promotion to the currently declared matrix digest and exact per-arm case identities
- reject stale pre-growth matrices and duplicate-run substitutions with focused negative coverage

## Validation

- `uvx --from pytest pytest -q tests/capabilities/test_change_quality_shadow.py` (13 passed)
- `uvx --from mypy mypy --follow-imports=skip loopx/capabilities/change_quality/shadow.py scripts/qualify-change-quality-model-shadow.py`
- `loopx --registry "$HOME/.codex/loopx/registry.global.json" canary premerge --from-git-diff --goal-id loopx-meta --tier quick`
- exact-scope change-quality receipt `cqr_244a138a6904c62af3d3`

LoopX todo: `todo_ccf82ba45d7b`