### PR TITLE
fix(todo): close capability gaps on completion

### DIFF
--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -152,16 +152,18 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
         action="append",
         help=(
             "For todo add/update, declare a capability this todo is building, "
-            "repairing, materializing, or parity-checking. This is not a hard "
-            "execution prerequisite."
+            "repairing, materializing, or parity-checking. On complete, pair it "
+            "with --capability-gap-status to close that lifecycle. This is not a "
+            "hard execution prerequisite."
         ),
     )
     todo_parser.add_argument(
         "--capability-gap-status",
         choices=["found", "fixed", "real_callsite_verified"],
         help=(
-            "For agent todo add/update, append an auditable capability-gap lifecycle "
-            "event. Requires --target-capability; the todo_id is the stable gap id."
+            "For agent todo add/update/complete, append an auditable capability-gap "
+            "lifecycle event. Requires --target-capability; the todo_id is the "
+            "stable gap id."
         ),
     )
     todo_parser.add_argument(

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -271,8 +271,10 @@ def validate_shared_todo_options(args: argparse.Namespace) -> None:
 def validate_capability_gap_options(args: argparse.Namespace) -> None:
     if not args.capability_gap_status:
         return
-    if args.todo_command not in {"add", "update"}:
-        raise ValueError("--capability-gap-status is supported only by todo add/update")
+    if args.todo_command not in {"add", "update", "complete"}:
+        raise ValueError(
+            "--capability-gap-status is supported only by todo add/update/complete"
+        )
     if args.role != "agent":
         raise ValueError("--capability-gap-status requires --role agent")
     if not args.target_capabilities:

--- a/tests/control_plane/test_todo_capability_gap_cli_validation.py
+++ b/tests/control_plane/test_todo_capability_gap_cli_validation.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from loopx.control_plane.testing.canary_harness import (
+    run_json_cli,
+    write_fixture_registry,
+)
+
+
+GOAL_ID = "todo-capability-gap-cli-validation"
+AGENT_ID = "codex-quality"
+TARGET_CAPABILITY = "change_quality_qualification"
+
+
+def _write_fixture(tmp_path: Path) -> Path:
+    project = tmp_path / "project"
+    runtime = tmp_path / "runtime"
+    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".loopx" / "registry.json"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(
+        "---\n"
+        "status: active\n"
+        "---\n\n"
+        "# Active Goal State\n\n"
+        "## Objective\n\n"
+        "Keep capability-gap lifecycle evidence coherent.\n\n"
+        "## Next Action\n\n"
+        "- Close the validated capability gap.\n",
+        encoding="utf-8",
+    )
+    write_fixture_registry(
+        project=project,
+        runtime_root=runtime,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        domain="todo-capability-gap-cli-validation",
+        adapter_kind="generic_project_goal_v0",
+    )
+    payload = json.loads(registry_path.read_text(encoding="utf-8"))
+    payload["goals"][0]["coordination"] = {
+        "agent_model": "peer_v1",
+        "registered_agents": [AGENT_ID],
+    }
+    registry_path.write_text(json.dumps(payload), encoding="utf-8")
+    return registry_path
+
+
+def test_todo_complete_records_fixed_capability_gap_with_completion(
+    tmp_path: Path,
+) -> None:
+    registry_path = _write_fixture(tmp_path)
+    added = run_json_cli(
+        "todo",
+        "add",
+        "--goal-id",
+        GOAL_ID,
+        "--role",
+        "agent",
+        "--task-class",
+        "advancement_task",
+        "--text",
+        "Repair the capability gap.",
+        "--target-capability",
+        TARGET_CAPABILITY,
+        "--capability-gap-status",
+        "found",
+        "--claimed-by",
+        AGENT_ID,
+        registry_path=registry_path,
+    )
+
+    completed = run_json_cli(
+        "todo",
+        "complete",
+        "--goal-id",
+        GOAL_ID,
+        "--role",
+        "agent",
+        "--todo-id",
+        added["todo_id"],
+        "--target-capability",
+        TARGET_CAPABILITY,
+        "--capability-gap-status",
+        "fixed",
+        "--evidence",
+        "focused test passed",
+        "--no-follow-up",
+        "--agent-id",
+        AGENT_ID,
+        registry_path=registry_path,
+    )
+
+    assert completed["status"] == "done", completed
+    assert completed["capability_gap_event"]["status"] == "fixed", completed
+    assert completed["capability_gap_event"]["event_kind"] == "capability_gap"
+


### PR DESCRIPTION
## Summary

- allow agent `todo complete` to record `fixed` or `real_callsite_verified` capability-gap evidence in the same CLI operation
- keep the existing validator and rollout-event writer as the single lifecycle path
- add focused end-to-end coverage for the formerly impossible update-after-done closeout

## Validation

- 11 focused todo CLI tests passed
- targeted mypy passed for the changed validator/event path and new test
- risk-based premerge quick tier passed with receipt `cqr_8e4dae9db45120549c18`

LoopX todo: `todo_033b9799a901`