### PR TITLE
test(install): assert heartbeat authority semantically

### DIFF
--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -36,6 +36,20 @@ def git_output(args: list[str]) -> str | None:
     return result.stdout.strip() or None
 
 
+def normal_turns_use_cli_interaction_contract(task_body: str) -> bool:
+    clauses = " ".join(task_body.split()).replace(";", ".").split(".")
+    for clause in clauses:
+        normalized = clause.lower()
+        if (
+            "`interaction_contract`" in normalized
+            and "cli" in normalized
+            and ("normal turn" in normalized or "normal-turn" in normalized)
+            and any(marker in normalized for marker in (" use ", " follow ", " authority"))
+        ):
+            return True
+    return False
+
+
 def source_git_commit(root: Path = REPO_ROOT) -> str:
     if root == REPO_ROOT:
         commit = git_output(["rev-parse", "HEAD"])
@@ -721,7 +735,13 @@ def main() -> int:
         assert "--delivery-batch-scale multi_surface" not in payload["progress_refresh_state_command"], payload
         assert "--delivery-outcome outcome_progress" not in payload["progress_refresh_state_command"], payload
         assert "<PUBLIC_SAFE_PROGRESS_CLASSIFICATION>" in payload["progress_refresh_state_command"], payload
-        assert "follow `interaction_contract`" in payload["task_body"], payload
+        assert normal_turns_use_cli_interaction_contract(payload["task_body"]), payload
+        assert not normal_turns_use_cli_interaction_contract(
+            "Normal turns use the runtime skill; recovery may inspect CLI `interaction_contract`."
+        )
+        assert not normal_turns_use_cli_interaction_contract(
+            "Normal turns use the runtime skill and repair contract."
+        )
         assert "`LOOPX_TURN=<current_time_iso>`; reuse." in payload["task_body"], payload
         assert "guard receipt; 2 stalls->replan" in payload["task_body"], payload
         assert "actual class/scale/outcome accountable refresh->spend" in payload["task_body"], payload


### PR DESCRIPTION
## Summary

- replace the installer smoke's obsolete exact heartbeat wording check with a semantic normal-turn CLI `interaction_contract` predicate
- add negative examples proving that a recovery-only mention or a completely omitted contract does not satisfy the invariant
- keep production heartbeat copy unchanged
- apply one simplify-first safe fix to remove an unnecessary regex dependency from the test predicate

## Validation

- `python3 -m py_compile examples/install-local-smoke.py`
- `uv run --no-project --python 3.11 python examples/install-local-smoke.py`
- `uv run --no-project --python 3.11 python examples/canary/canary-promotion-readiness-smoke.py --goal-id loopx-meta --agent-id codex-quality-qualification --agent-lane quality_qualification` (passed; dashboard browser smoke skipped because npm dependencies were unavailable)
- `loopx --registry "$HOME/.codex/loopx/registry.global.json" canary premerge --from-git-diff --goal-id loopx-meta` (passed: 5 selected checks, no failures or manual holds)
- change-quality receipt `cqr_93be79c1fe9f7b877067` verified valid for the final committed diff

## Notes

An initial direct system-Python invocation failed in the installer wrapper before reaching the changed assertion; the Python 3.11 focused run and the premerge gate's system-Python installer canary both subsequently passed. The first premerge invocation omitted the global registry route and exited after checks passed; rerunning with the registry bound passed the full gate.