### PR TITLE
fix(status): bound agent-lane hot path

### DIFF
--- a/examples/control_plane/runtime-handoff-status-read-path-smoke.py
+++ b/examples/control_plane/runtime-handoff-status-read-path-smoke.py
@@ -212,7 +212,10 @@ def assert_status_read_path(
     assert item["project_asset"]["active_state_next_action"] == GOAL_NEXT_ACTION, item
     assert item["project_asset"]["latest_validation"]["classification"] == POST_HANDOFF_CLASSIFICATION, item
     assert item["project_asset"]["latest_validation"]["summary"] == POST_HANDOFF_ACTION, item
-    assert item["project_asset"]["agent_todos"]["items"][0]["todo_id"] == TODO_ID, item
+    assert item["agent_todos"]["items"][0]["todo_id"] == TODO_ID, item
+    assert item["project_asset"]["agent_todos"]["payload_reference"]["canonical_path"] == (
+        "attention_queue.items[].agent_todos"
+    ), item
     assert_handoff_readiness(item["handoff_readiness"])
     assert str(project) not in json.dumps(item, sort_keys=True), item
     assert str(runtime_root) not in json.dumps(item, sort_keys=True), item

--- a/examples/control_plane/status_markdown_agent_lane_fixtures.py
+++ b/examples/control_plane/status_markdown_agent_lane_fixtures.py
@@ -291,16 +291,22 @@ def assert_status_agent_lane_todo_summary_display_compaction() -> None:
     compact_user = item["user_todos"]
     assert compact_agent["open_count"] == 7, compact_agent
     assert compact_agent["done_count"] == 3, compact_agent
-    assert len(compact_agent["items"]) == 2, compact_agent
+    assert len(compact_agent["items"]) == 1, compact_agent
     assert compact_agent["payload_compaction"]["compacted_lanes"]["items"] == {
-        "shown": 2,
+        "shown": 1,
         "total": 7,
     }, compact_agent
     assert compact_user["open_count"] == 1, compact_user
-    assert len(compact_user["handoff_gates"]) == 2, compact_user
-    assert item["project_asset"]["agent_todos"] == project_asset_agent_summary, item
+    assert "handoff_gates" not in compact_user, compact_user
+    project_asset_reference = item["project_asset"]["agent_todos"]
+    assert project_asset_reference["open"] == 7, project_asset_reference
+    assert "items" not in project_asset_reference, project_asset_reference
+    assert project_asset_reference["payload_reference"]["canonical_path"] == (
+        "attention_queue.items[].agent_todos"
+    ), project_asset_reference
     marker = payload["agent_lane_todo_summary_compaction"]
-    assert marker["schema_version"] == "agent_lane_status_todo_summary_compaction_v0", marker
+    assert marker["schema_version"] == "agent_lane_status_todo_summary_compaction_v1", marker
+    assert marker["project_asset_reference_count"] == 1, marker
 
     markdown = render_status_markdown(payload)
     assert "agent_todos: open=7" in markdown, markdown

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -11,6 +11,9 @@ from ..control_plane.runtime.status_projection_cache import (
     resolve_status_projection_cache_runtime_root,
     write_status_projection_cache,
 )
+from ..control_plane.status_agent_lane_projection import (
+    compact_agent_lane_status_payload_for_display,
+)
 from ..control_plane.todos.contract import normalize_todo_claimed_by
 from ..control_plane.todos.quota_summary import (
     compact_agent_lane_todos_for_status_display,
@@ -402,6 +405,10 @@ def handle_status_command(
                 collection_limit=collection_limit,
             )
             compact_agent_lane_todos_for_status_display(payload)
+            compact_agent_lane_status_payload_for_display(
+                payload,
+                agent_id=args.agent_id,
+            )
             compact_agent_lane_todo_index_for_status_display(payload)
     except Exception as exc:
         payload = {

--- a/loopx/control_plane/status_agent_lane_projection.py
+++ b/loopx/control_plane/status_agent_lane_projection.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+AGENT_LANE_STATUS_PAYLOAD_COMPACTION_SCHEMA_VERSION = (
+    "agent_lane_status_payload_compaction_v0"
+)
+AGENT_LANE_STATUS_FRONTIER_COMPACTION_SCHEMA_VERSION = (
+    "agent_lane_goal_frontier_compaction_v0"
+)
+AGENT_LANE_STATUS_HISTORY_COMPACTION_SCHEMA_VERSION = (
+    "agent_lane_run_history_compaction_v0"
+)
+AGENT_LANE_STATUS_MANAGEMENT_COMPACTION_SCHEMA_VERSION = (
+    "agent_lane_management_compaction_v0"
+)
+AGENT_LANE_STATUS_GOAL_CHANNEL_COMPACTION_SCHEMA_VERSION = (
+    "agent_lane_goal_channel_compaction_v0"
+)
+
+_PROJECT_ASSET_CANONICAL_FIELDS = (
+    "active_state_next_action",
+    "agent_interaction_summary",
+    "agent_lane_frontier_hint",
+    "agent_lane_next_action",
+    "agent_lane_recommendation",
+    "agent_member",
+    "agent_reward_memory",
+    "autonomous_replan_ack",
+    "autonomous_replan_obligation",
+    "completed_todo_archive_warning",
+    "control_plane",
+    "goal_frontier_projection",
+    "latest_run_recommended_action",
+    "latest_run_recommended_action_source",
+    "next_action_projection_warning",
+    "stale_latest_run_warning",
+)
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _compact_run(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    compact = {
+        key: value[key]
+        for key in (
+            "goal_id",
+            "agent_id",
+            "classification",
+            "generated_at",
+            "lifecycle_phase",
+            "lifecycle_flags",
+        )
+        if value.get(key) is not None
+    }
+    recommendation = str(value.get("recommended_action") or "").strip()
+    if recommendation:
+        compact["recommended_action"] = (
+            recommendation
+            if len(recommendation) <= 240
+            else recommendation[:237].rstrip() + "..."
+        )
+    return compact or None
+
+
+def _compact_run_history(payload: dict[str, object], *, agent_id: str) -> bool:
+    history = payload.get("run_history")
+    if not isinstance(history, dict):
+        return False
+    recent_runs = history.get("recent_runs")
+    visible_runs = recent_runs if isinstance(recent_runs, list) else []
+    agent_runs = [
+        run
+        for run in visible_runs
+        if isinstance(run, dict) and str(run.get("agent_id") or "").strip() == agent_id
+    ]
+    compact = {
+        key: history[key]
+        for key in ("available", "run_count", "goal_count")
+        if history.get(key) is not None
+    }
+    latest_agent_run = _compact_run(agent_runs[0]) if agent_runs else None
+    if latest_agent_run:
+        compact["latest_agent_run"] = latest_agent_run
+    compact["payload_compaction"] = {
+        "schema_version": AGENT_LANE_STATUS_HISTORY_COMPACTION_SCHEMA_VERSION,
+        "agent_id": agent_id,
+        "visible_agent_run_count": len(agent_runs),
+        "omitted_visible_run_count": max(
+            0,
+            len(visible_runs) - int(latest_agent_run is not None),
+        ),
+        "full_detail_cold_path": "status without --agent-id or history",
+    }
+    payload["run_history"] = compact
+    return True
+
+
+def _compact_agent_management(payload: dict[str, object], *, agent_id: str) -> bool:
+    projection = payload.get("agent_management_projection")
+    if not isinstance(projection, dict):
+        return False
+    agents = projection.get("agents")
+    visible_agents = agents if isinstance(agents, list) else []
+    current_agents = [
+        agent
+        for agent in visible_agents
+        if isinstance(agent, dict)
+        and str(agent.get("agent_id") or "").strip() == agent_id
+    ]
+    compact = {
+        key: projection[key]
+        for key in (
+            "schema_version",
+            "generated_at",
+            "goal_id",
+            "mode",
+            "source_summary",
+            "truth_contract",
+        )
+        if projection.get(key) is not None
+    }
+    compact["agents"] = current_agents[:1]
+    compact["payload_compaction"] = {
+        "schema_version": AGENT_LANE_STATUS_MANAGEMENT_COMPACTION_SCHEMA_VERSION,
+        "agent_id": agent_id,
+        "visible_agent_count": len(visible_agents),
+        "omitted_other_agent_count": max(0, len(visible_agents) - len(current_agents)),
+        "full_detail_cold_path": "status without --agent-id",
+    }
+    payload["agent_management_projection"] = compact
+    return True
+
+
+def _compact_vision_audit(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    compact = {
+        key: value[key]
+        for key in (
+            "schema_version",
+            "agent_id",
+            "required",
+            "decision",
+            "trigger_count",
+            "trigger_kinds",
+            "selected_todo_is_goal_completion",
+            "closeout_allowed_without_evidence",
+            "recommended_action",
+        )
+        if value.get(key) is not None
+    }
+    judge = value.get("vision_gap_judge")
+    if isinstance(judge, dict):
+        compact["vision_gap_judge"] = {
+            key: judge[key]
+            for key in (
+                "schema_version",
+                "goal_id",
+                "agent_id",
+                "done",
+                "decision",
+                "reason",
+            )
+            if judge.get(key) is not None
+        }
+    for key in (
+        "acceptance_requirements",
+        "authoritative_evidence_kinds",
+        "required_before_closeout",
+    ):
+        items = value.get(key)
+        if isinstance(items, list):
+            compact[f"{key}_count"] = len(items)
+    return compact
+
+
+def _compact_goal_frontier(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    compact = {
+        key: value[key]
+        for key in (
+            "schema_version",
+            "goal_id",
+            "agent_id",
+            "source",
+            "replan_required",
+            "remaining_advancement_frontier",
+            "deferred_successors",
+            "monitor_only_lanes",
+            "normalized_progress",
+            "vision_wait_state",
+            "autonomy_blockers",
+        )
+        if value.get(key) is not None
+    }
+    acceptance_gaps = value.get("acceptance_gaps")
+    if isinstance(acceptance_gaps, list):
+        compact["acceptance_gap_count"] = len(acceptance_gaps)
+        compact["acceptance_gaps"] = [
+            {
+                key: gap[key]
+                for key in (
+                    "kind",
+                    "state",
+                    "source",
+                    "agent_id",
+                    "replan_trigger_source",
+                )
+                if gap.get(key) is not None
+            }
+            for gap in acceptance_gaps[:1]
+            if isinstance(gap, dict)
+        ]
+    vision_audit = _compact_vision_audit(value.get("vision_continuation_audit"))
+    if vision_audit:
+        compact["vision_continuation_audit"] = vision_audit
+    compact["payload_compaction"] = {
+        "schema_version": AGENT_LANE_STATUS_FRONTIER_COMPACTION_SCHEMA_VERSION,
+        "full_detail_cold_path": "status without --agent-id or quota should-run",
+    }
+    return compact
+
+
+def _compact_goal_channel(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    omitted_fields = (
+        "agent_todos",
+        "user_todos",
+        "recent_events",
+        "active_leases",
+        "source_warnings",
+    )
+    compact = {key: child for key, child in value.items() if key not in omitted_fields}
+    compact["payload_compaction"] = {
+        "schema_version": AGENT_LANE_STATUS_GOAL_CHANNEL_COMPACTION_SCHEMA_VERSION,
+        **{
+            f"omitted_{key[:-1] if key.endswith('s') else key}_count": len(
+                value.get(key) or []
+            )
+            for key in omitted_fields
+        },
+        "canonical_todo_path": "attention_queue.items[].{agent_todos,user_todos}",
+        "full_detail_cold_path": "status without --agent-id",
+    }
+    return compact
+
+
+def _compact_attention_item(item: dict[str, Any]) -> tuple[int, bool]:
+    project_asset = _as_dict(item.get("project_asset"))
+    removed_duplicates = 0
+    if project_asset:
+        item_frontier = item.get("goal_frontier_projection")
+        asset_frontier = project_asset.get("goal_frontier_projection")
+        if item_frontier is not None and item_frontier == asset_frontier:
+            item.pop("goal_frontier_projection")
+            removed_duplicates += 1
+        frontier = _compact_goal_frontier(asset_frontier or item_frontier)
+        if frontier:
+            project_asset["goal_frontier_projection"] = frontier
+        next_action = project_asset.get("next_action")
+        for key in ("active_state_next_action", "latest_run_recommended_action"):
+            if next_action and project_asset.get(key) == next_action:
+                if item.get(key) == next_action:
+                    item.pop(key)
+                    removed_duplicates += 1
+                project_asset.pop(key)
+        for key in _PROJECT_ASSET_CANONICAL_FIELDS:
+            if key in item and key in project_asset and item[key] == project_asset[key]:
+                item.pop(key)
+                removed_duplicates += 1
+    goal_channel = _compact_goal_channel(item.get("goal_channel_projection"))
+    if goal_channel:
+        item["goal_channel_projection"] = goal_channel
+    return removed_duplicates, bool(goal_channel)
+
+
+def compact_agent_lane_status_payload_for_display(
+    payload: dict[str, object],
+    *,
+    agent_id: str,
+) -> None:
+    safe_agent_id = str(agent_id or "").strip()
+    if not safe_agent_id:
+        return
+    queue = payload.get("attention_queue")
+    items = queue.get("items") if isinstance(queue, dict) else None
+    compacted_items = 0
+    removed_duplicates = 0
+    compacted_goal_channels = 0
+    if isinstance(items, list):
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            removed, channel_compacted = _compact_attention_item(item)
+            removed_duplicates += removed
+            compacted_goal_channels += int(channel_compacted)
+            compacted_items += 1
+    history_compacted = _compact_run_history(payload, agent_id=safe_agent_id)
+    management_compacted = _compact_agent_management(
+        payload,
+        agent_id=safe_agent_id,
+    )
+    if compacted_items or history_compacted or management_compacted:
+        payload["agent_lane_status_payload_compaction"] = {
+            "schema_version": AGENT_LANE_STATUS_PAYLOAD_COMPACTION_SCHEMA_VERSION,
+            "agent_id": safe_agent_id,
+            "compacted_attention_item_count": compacted_items,
+            "removed_project_asset_duplicate_count": removed_duplicates,
+            "compacted_goal_channel_count": compacted_goal_channels,
+            "run_history_compacted": history_compacted,
+            "agent_management_compacted": management_compacted,
+            "reason": (
+                "status --agent-id keeps current-agent control semantics hot "
+                "and moves whole-goal diagnostics to explicit cold paths"
+            ),
+        }

--- a/loopx/control_plane/todos/quota_summary.py
+++ b/loopx/control_plane/todos/quota_summary.py
@@ -48,6 +48,12 @@ QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT = 2
 QUOTA_PAYLOAD_USER_ACTION_ITEM_LIMIT = 3
 QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT = 2
 QUOTA_PAYLOAD_COMPACTION_SCHEMA_VERSION = "quota_todo_summary_payload_compaction_v0"
+AGENT_LANE_STATUS_TODO_COMPACTION_SCHEMA_VERSION = (
+    "agent_lane_status_todo_summary_compaction_v1"
+)
+AGENT_LANE_STATUS_TODO_REFERENCE_SCHEMA_VERSION = (
+    "agent_lane_status_todo_reference_v0"
+)
 QUOTA_PAYLOAD_ITEM_FIELDS = (
     "schema_version",
     "index",
@@ -122,6 +128,42 @@ QUOTA_PAYLOAD_LANE_LIMITS = {
     "handoff_gates": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
     "current_agent_handoff_gates": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
     "current_agent_cleared_without_successor_handoff_gates": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
+}
+AGENT_LANE_STATUS_TODO_ITEM_FIELDS = (
+    "schema_version",
+    "index",
+    "todo_id",
+    "text",
+    "title",
+    "status",
+    "priority",
+    "task_class",
+    "action_kind",
+    "claimed_by",
+    "bound_agent",
+    "blocks_agent",
+    "global_gate",
+    "unblocks_todo_id",
+    "required_capabilities",
+    "missing_capabilities",
+    "resume_ready",
+    "next_due_at",
+)
+AGENT_LANE_STATUS_TODO_LANES = {
+    "agent": (
+        "items",
+        "current_agent_blocker_items",
+    ),
+    "user": (
+        "items",
+        "gate_open_items",
+        "user_action_items",
+        "current_agent_blocker_items",
+    ),
+}
+AGENT_LANE_STATUS_TODO_LANE_LIMITS = {
+    "gate_open_items": 3,
+    "user_action_items": 3,
 }
 
 
@@ -666,6 +708,100 @@ def compact_quota_todo_summary_for_payload(summary: dict[str, Any]) -> dict[str,
     return compact
 
 
+def _compact_agent_lane_status_todo_item(item: Any) -> Any:
+    if not isinstance(item, dict):
+        return item
+    compact: dict[str, Any] = {}
+    for key in AGENT_LANE_STATUS_TODO_ITEM_FIELDS:
+        value = item.get(key)
+        if value is None:
+            continue
+        if key in {"text", "title"}:
+            value = _truncate_quota_payload_text(
+                value,
+                limit=QUOTA_PAYLOAD_ITEM_TEXT_LIMIT,
+            )
+        compact[key] = value
+    return compact
+
+
+def _compact_agent_lane_status_todo_summary(
+    summary: dict[str, Any],
+    *,
+    role: str,
+) -> dict[str, Any]:
+    retained_lanes = set(AGENT_LANE_STATUS_TODO_LANES[role])
+    compact: dict[str, Any] = {}
+    omitted_lanes: list[str] = []
+    compacted_lanes: dict[str, dict[str, int]] = {}
+    for key, value in summary.items():
+        if key == "payload_compaction":
+            continue
+        if isinstance(value, list):
+            if key not in retained_lanes:
+                if value:
+                    omitted_lanes.append(key)
+                continue
+            limit = AGENT_LANE_STATUS_TODO_LANE_LIMITS.get(key, 1)
+            compact[key] = [
+                _compact_agent_lane_status_todo_item(item)
+                for item in value[:limit]
+            ]
+            if len(value) > limit:
+                compacted_lanes[key] = {
+                    "shown": limit,
+                    "total": len(value),
+                }
+            continue
+        if isinstance(value, dict):
+            if key == "monitor_writeback":
+                compact[key] = _compact_quota_payload_nested_warning(value)
+            continue
+        compact[key] = value
+    compact["payload_compaction"] = {
+        "schema_version": AGENT_LANE_STATUS_TODO_COMPACTION_SCHEMA_VERSION,
+        "item_text_limit": QUOTA_PAYLOAD_ITEM_TEXT_LIMIT,
+        "retained_lanes": sorted(retained_lanes),
+        "omitted_nonempty_lane_count": len(omitted_lanes),
+        "compacted_lanes": compacted_lanes,
+        "full_detail_cold_path": (
+            "status without --agent-id, todo list, or active state"
+        ),
+    }
+    return compact
+
+
+def _agent_lane_status_project_asset_todo_reference(
+    summary: dict[str, Any],
+    *,
+    role: str,
+) -> dict[str, Any]:
+    reference: dict[str, Any] = {}
+    for key in (
+        "schema_version",
+        "source_section",
+        "open",
+        "done",
+        "total",
+        "deferred_count",
+        "claimed_open_count",
+        "unclaimed_open_count",
+        "projection_view",
+        "detail_pointer",
+    ):
+        value = summary.get(key)
+        if value is not None:
+            reference[key] = value
+    reference["payload_reference"] = {
+        "schema_version": AGENT_LANE_STATUS_TODO_REFERENCE_SCHEMA_VERSION,
+        "canonical_path": f"attention_queue.items[].{role}_todos",
+        "full_detail_cold_path": (
+            "status without --agent-id, todo list, or active state"
+        ),
+    }
+    return reference
+
+
 def compact_agent_lane_todos_for_status_display(payload: dict[str, object]) -> None:
     queue = payload.get("attention_queue")
     if not isinstance(queue, dict):
@@ -674,28 +810,39 @@ def compact_agent_lane_todos_for_status_display(payload: dict[str, object]) -> N
     if not isinstance(items, list):
         return
     compacted = 0
+    references = 0
     for item in items:
         if not isinstance(item, dict):
             continue
-        for key in ("user_todos", "agent_todos"):
+        for key, role in (("user_todos", "user"), ("agent_todos", "agent")):
             summary = item.get(key)
             if not isinstance(summary, dict):
                 continue
-            compact = compact_quota_todo_summary_for_payload(summary)
-            compaction = compact.get("payload_compaction")
-            if isinstance(compaction, dict):
-                compaction["full_detail_cold_path"] = (
-                    "status without --agent-id, todo list, or active state"
-                )
-            item[key] = compact
+            item[key] = _compact_agent_lane_status_todo_summary(
+                summary,
+                role=role,
+            )
             compacted += 1
+        project_asset = item.get("project_asset")
+        if not isinstance(project_asset, dict):
+            continue
+        for key, role in (("user_todos", "user"), ("agent_todos", "agent")):
+            summary = project_asset.get(key)
+            if not isinstance(summary, dict):
+                continue
+            project_asset[key] = _agent_lane_status_project_asset_todo_reference(
+                summary,
+                role=role,
+            )
+            references += 1
     if compacted:
         payload["agent_lane_todo_summary_compaction"] = {
-            "schema_version": "agent_lane_status_todo_summary_compaction_v0",
+            "schema_version": AGENT_LANE_STATUS_TODO_COMPACTION_SCHEMA_VERSION,
             "compacted_summary_count": compacted,
+            "project_asset_reference_count": references,
             "reason": (
-                "status --agent-id keeps agent-lane display payloads bounded; "
-                "full todo detail remains on cold paths"
+                "status --agent-id keeps one compact todo summary per role and "
+                "replaces nested project-asset duplicates with references"
             ),
         }
 

--- a/tests/control_plane/test_status_agent_lane_projection.py
+++ b/tests/control_plane/test_status_agent_lane_projection.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import json
+
+from loopx.control_plane.status_agent_lane_projection import (
+    compact_agent_lane_status_payload_for_display,
+)
+from loopx.control_plane.todos.quota_summary import (
+    compact_agent_lane_todos_for_status_display,
+)
+
+
+AGENT_ID = "codex-quality"
+GOAL_ID = "status-budget-goal"
+
+
+def _todo(index: int, *, role: str, task_class: str = "advancement_task") -> dict:
+    reason = "measured simplification evidence " * 24
+    return {
+        "schema_version": "todo_item_v0",
+        "index": index,
+        "todo_id": f"todo_{role}_{index:03d}",
+        "text": f"[P1] {role} action {index}: {reason}",
+        "status": "open",
+        "priority": "P1",
+        "task_class": task_class,
+        "action_kind": "production_shaped_status_budget_fixture",
+        "claimed_by": AGENT_ID if role == "agent" else None,
+        "blocks_agent": AGENT_ID if task_class == "user_gate" else None,
+        "required_capabilities": ["network", "filesystem_write"],
+        "reason": reason,
+    }
+
+
+def _todo_summary(items: list[dict], *, role: str) -> dict:
+    user_gate = items[0] if role == "user" else None
+    return {
+        "schema_version": "todo_summary_v0",
+        "source_section": f"{role.title()} Todo",
+        "total_count": len(items) + 80,
+        "open_count": len(items),
+        "done_count": 60,
+        "deferred_count": 20,
+        "claimed_open_count": len(items) if role == "agent" else 0,
+        "unclaimed_open_count": 0 if role == "agent" else len(items),
+        "items": items,
+        "first_open_items": items,
+        "first_executable_items": items,
+        "backlog_items": items,
+        "executable_backlog_items": items,
+        "deferred_items": items,
+        "claimed_open_items": items,
+        "claimed_advancement_open_items": items,
+        "monitor_open_items": items,
+        "monitor_due_items": items,
+        "active_next_action_items": items,
+        "gate_open_items": [user_gate] if user_gate else [],
+        "user_action_items": items if role == "user" else [],
+    }
+
+
+def _project_asset_todo_summary(items: list[dict]) -> dict:
+    return {
+        "schema_version": "todo_summary_v0",
+        "source_section": "project_asset",
+        "open": len(items),
+        "done": 60,
+        "total": len(items) + 80,
+        "items": items,
+        "next": items[0]["text"],
+        "next_index": items[0]["index"],
+        "next_claimed_by": items[0].get("claimed_by"),
+        "deferred_items": items,
+        "first_executable_items": items,
+        "projection_view": {"kind": "bounded"},
+        "detail_pointer": {"command": "loopx todo list"},
+    }
+
+
+def test_agent_lane_status_bounds_production_shaped_duplicate_projection() -> None:
+    reason = "measured simplification evidence " * 24
+    agent_items = [_todo(index, role="agent") for index in range(120)]
+    user_items = [
+        _todo(1, role="user", task_class="user_gate"),
+        *[_todo(index, role="user") for index in range(2, 42)],
+    ]
+    frontier = {
+        "schema_version": "goal_frontier_projection_v0",
+        "goal_id": GOAL_ID,
+        "agent_id": AGENT_ID,
+        "replan_required": True,
+        "remaining_advancement_frontier": {
+            "current_agent_claimed_advancement_count": 1,
+            "unclaimed_advancement_count": 0,
+        },
+        "acceptance_gaps": [
+            {
+                "kind": "acceptance_gap",
+                "state": "open",
+                "agent_id": AGENT_ID,
+                "acceptance_summary": reason,
+                "replan_trigger_summary": reason,
+            }
+        ],
+        "vision_continuation_audit": {
+            "schema_version": "vision_continuation_audit_v0",
+            "agent_id": AGENT_ID,
+            "required": True,
+            "decision": "acceptance_gap_open",
+            "trigger_count": 1,
+            "required_before_closeout": [reason] * 12,
+            "vision_gap_judge": {
+                "schema_version": "vision_gap_judge_v0",
+                "goal_id": GOAL_ID,
+                "agent_id": AGENT_ID,
+                "done": False,
+                "decision": "continue",
+                "reason": reason,
+                "agent_judge_instruction": reason * 8,
+            },
+        },
+    }
+    interaction = {
+        "agent_id": AGENT_ID,
+        "mode": "bounded_delivery",
+        "user_action_required": False,
+        "agent_must_attempt": True,
+    }
+    item = {
+        "goal_id": GOAL_ID,
+        "status": "active_state_agent_todo",
+        "waiting_on": "codex",
+        "recommended_action": agent_items[0]["text"],
+        "agent_todos": _todo_summary(agent_items, role="agent"),
+        "user_todos": _todo_summary(user_items, role="user"),
+        "goal_frontier_projection": frontier,
+        "goal_channel_projection": {
+            "schema_version": "goal_channel_projection_v0",
+            "goal_id": GOAL_ID,
+            "next_action": agent_items[0]["text"],
+            "agent_todos": agent_items,
+            "user_todos": user_items,
+            "recent_events": [{"summary": reason}] * 40,
+            "active_leases": [{"agent_id": AGENT_ID}] * 20,
+            "source_warnings": [reason] * 20,
+        },
+        "agent_interaction_summary": interaction,
+        "project_asset": {
+            "owner": "codex",
+            "next_action": agent_items[0]["text"],
+            "agent_todos": _project_asset_todo_summary(agent_items),
+            "user_todos": _project_asset_todo_summary(user_items),
+            "goal_frontier_projection": frontier,
+            "agent_interaction_summary": interaction,
+        },
+    }
+    payload = {
+        "attention_queue": {"items": [item]},
+        "run_history": {
+            "available": True,
+            "run_count": 400,
+            "goal_count": 1,
+            "recent_runs": [
+                {
+                    "goal_id": GOAL_ID,
+                    "agent_id": AGENT_ID if index % 2 == 0 else "codex-other",
+                    "classification": "status_fixture",
+                    "generated_at": f"2026-01-01T00:{index:02d}:00+00:00",
+                    "recommended_action": reason,
+                    "detail": reason * 4,
+                }
+                for index in range(20)
+            ],
+            "goals": [{"id": GOAL_ID, "latest_runs": [{"detail": reason}] * 20}],
+        },
+        "agent_management_projection": {
+            "schema_version": "agent_management_projection_v0",
+            "goal_id": GOAL_ID,
+            "agents": [
+                {
+                    "agent_id": f"codex-{index}",
+                    "current_todo": {"text": reason},
+                    "evidence_refs": [reason] * 8,
+                }
+                for index in range(12)
+            ]
+            + [{"agent_id": AGENT_ID, "current_todo": agent_items[0]}],
+        },
+    }
+
+    compact_agent_lane_todos_for_status_display(payload)
+    compact_agent_lane_status_payload_for_display(payload, agent_id=AGENT_ID)
+
+    compact_item = payload["attention_queue"]["items"][0]
+    assert compact_item["agent_todos"]["items"][0]["todo_id"] == "todo_agent_000"
+    assert compact_item["agent_todos"]["open_count"] == 120
+    assert compact_item["user_todos"]["gate_open_items"][0]["blocks_agent"] == AGENT_ID
+    assert (
+        compact_item["project_asset"]["agent_todos"]["payload_reference"][
+            "canonical_path"
+        ]
+        == "attention_queue.items[].agent_todos"
+    )
+    assert "goal_frontier_projection" not in compact_item
+    compact_frontier = compact_item["project_asset"]["goal_frontier_projection"]
+    assert compact_frontier["replan_required"] is True
+    assert (
+        compact_frontier["vision_continuation_audit"]["vision_gap_judge"]["decision"]
+        == "continue"
+    )
+    assert (
+        compact_item["project_asset"]["agent_interaction_summary"]["agent_must_attempt"]
+        is True
+    )
+    assert payload["run_history"]["latest_agent_run"]["agent_id"] == AGENT_ID
+    assert payload["agent_management_projection"]["agents"][0]["agent_id"] == AGENT_ID
+    assert len(json.dumps(payload, ensure_ascii=False, indent=2)) < 30_000


### PR DESCRIPTION
## Summary

- collapse agent-scoped status todo lanes to one compact role summary and replace nested project-asset todo copies with typed references
- keep current-agent run history, management, goal frontier, user-gate, and interaction semantics hot while moving whole-goal diagnostics to explicit cold paths
- add production-shaped size/semantic regression coverage and update the runtime-handoff read-path smoke

## Validation

- focused pytest: 2 passed
- status markdown smoke: passed
- runtime handoff status read-path smoke: passed
- ruff check: passed
- mypy: passed
- public/private scan: clean
- live `loopx-meta status --agent-id`: 41,126 chars, below the 58,000-char budget
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: passed, 18 selected checks, no failures or holds
- change-quality receipt: `cqr_718cada6665d9eb2dc82` (valid)

Full pytest was not selected: focused CLI, production-shaped, renderer, handoff, lint, type, boundary, and premerge canaries cover the changed read-model contracts.