### PR TITLE
fix(todos): bound agent lane list projection

### DIFF
--- a/loopx/control_plane/todos/list_projection.py
+++ b/loopx/control_plane/todos/list_projection.py
@@ -35,6 +35,7 @@ _ITEM_FIELDS = (
     "priority",
     "text",
     "title",
+    "note",
     "task_class",
     "action_kind",
     "task_repository",
@@ -74,7 +75,9 @@ def _compact_item(value: Any) -> Any:
         child = value.get(key)
         if child is None:
             continue
-        compact[key] = _compact_text(child) if key in {"text", "title"} else child
+        compact[key] = (
+            _compact_text(child) if key in {"text", "title", "note"} else child
+        )
     return compact
 
 

--- a/loopx/control_plane/todos/list_projection.py
+++ b/loopx/control_plane/todos/list_projection.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from typing import Any
+
+AGENT_LANE_TODO_LIST_PROJECTION_SCHEMA_VERSION = "agent_lane_todo_list_projection_v0"
+AGENT_LANE_TODO_LIST_SUMMARY_SCHEMA_VERSION = (
+    "agent_lane_todo_list_summary_compaction_v0"
+)
+AGENT_LANE_TODO_LIST_ITEM_LIMIT = 12
+AGENT_LANE_TODO_LIST_TEXT_LIMIT = 180
+
+_RETAINED_LANE_LIMITS = {
+    "items": AGENT_LANE_TODO_LIST_ITEM_LIMIT,
+    "first_open_items": 3,
+    "first_executable_items": 3,
+    "deferred_items": 3,
+    "monitor_due_items": 2,
+    "monitor_schedule_gap_items": 2,
+    "blocker_items": 2,
+    "resume_blocked_items": 2,
+    "active_next_action_items": 3,
+    "active_next_action_executable_items": 3,
+}
+_RETAINED_DICTS = {
+    "monitor_writeback",
+    "source_proof",
+    "terminal_closure_proof",
+}
+_ITEM_FIELDS = (
+    "schema_version",
+    "index",
+    "todo_id",
+    "role",
+    "status",
+    "priority",
+    "text",
+    "title",
+    "task_class",
+    "action_kind",
+    "task_repository",
+    "continuation_policy",
+    "required_capabilities",
+    "target_capabilities",
+    "claimed_by",
+    "bound_agent",
+    "goal_bound",
+    "blocks_agent",
+    "global_gate",
+    "unblocks_todo_id",
+    "successor_todo_ids",
+    "resume_when",
+    "resume_ready",
+    "target_key",
+    "cadence",
+    "next_due_at",
+    "expires_at",
+)
+
+
+def _compact_text(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    text = value.strip()
+    if len(text) <= AGENT_LANE_TODO_LIST_TEXT_LIMIT:
+        return text
+    return text[: AGENT_LANE_TODO_LIST_TEXT_LIMIT - 3].rstrip() + "..."
+
+
+def _compact_item(value: Any) -> Any:
+    if not isinstance(value, dict):
+        return value
+    compact: dict[str, Any] = {}
+    for key in _ITEM_FIELDS:
+        child = value.get(key)
+        if child is None:
+            continue
+        compact[key] = _compact_text(child) if key in {"text", "title"} else child
+    return compact
+
+
+def compact_agent_lane_todo_summary(
+    summary: dict[str, Any],
+    *,
+    role: str,
+) -> dict[str, Any]:
+    """Bound one agent-lane list summary while retaining actionable identities."""
+    compact: dict[str, Any] = {}
+    compacted_lanes: dict[str, dict[str, int]] = {}
+    omitted_nonempty_lane_count = 0
+    omitted_nonempty_dict_count = 0
+    for key, value in summary.items():
+        if isinstance(value, list):
+            limit = _RETAINED_LANE_LIMITS.get(key)
+            if limit is None:
+                omitted_nonempty_lane_count += bool(value)
+                continue
+            if key == "items":
+                retained = [
+                    item
+                    for item in value
+                    if not isinstance(item, dict) or item.get("status") != "done"
+                ]
+            else:
+                retained = value
+            compact[key] = [_compact_item(item) for item in retained[:limit]]
+            if len(retained) > limit:
+                compacted_lanes[key] = {"shown": limit, "total": len(retained)}
+            continue
+        if isinstance(value, dict):
+            if key in _RETAINED_DICTS:
+                compact[key] = value
+            else:
+                omitted_nonempty_dict_count += bool(value)
+            continue
+        compact[key] = value
+    compact["payload_compaction"] = {
+        "schema_version": AGENT_LANE_TODO_LIST_SUMMARY_SCHEMA_VERSION,
+        "role": role,
+        "item_limit": AGENT_LANE_TODO_LIST_ITEM_LIMIT,
+        "item_text_limit": AGENT_LANE_TODO_LIST_TEXT_LIMIT,
+        "terminal_items_in_hot_path": False,
+        "compacted_lanes": compacted_lanes,
+        "omitted_nonempty_lane_count": omitted_nonempty_lane_count,
+        "omitted_nonempty_dict_count": omitted_nonempty_dict_count,
+        "full_detail_cold_path": (
+            "todo list with --role, --status, or --todo-id; "
+            "todo list without --agent-id; or active state"
+        ),
+    }
+    return compact
+
+
+def compact_todo_projection_overlay(value: Any) -> Any:
+    if not isinstance(value, dict):
+        return value
+    compact = {
+        key: child for key, child in value.items() if not isinstance(child, list)
+    }
+    for key, child in value.items():
+        if isinstance(child, list):
+            compact[f"{key.removesuffix('_todo_ids')}_count"] = len(child)
+    compact["full_detail_cold_path"] = "todo list without --agent-id or active state"
+    return compact
+
+
+def todo_list_projection_contract(
+    *,
+    matched_todo_count: int,
+    returned_todo_count: int,
+) -> dict[str, Any]:
+    return {
+        "schema_version": AGENT_LANE_TODO_LIST_PROJECTION_SCHEMA_VERSION,
+        "view": "agent_lane_hot_path",
+        "matched_todo_count": matched_todo_count,
+        "returned_todo_count": returned_todo_count,
+        "item_limit_per_role": AGENT_LANE_TODO_LIST_ITEM_LIMIT,
+        "counts_cover_full_match": True,
+        "full_detail_cold_paths": [
+            "todo list with --role, --status, or --todo-id",
+            "todo list without --agent-id",
+            "active state",
+        ],
+    }

--- a/loopx/control_plane/todos/markdown.py
+++ b/loopx/control_plane/todos/markdown.py
@@ -23,17 +23,28 @@ def render_todo_markdown(payload: dict[str, Any]) -> str:
             lines.extend(
                 [
                     f"- agent_id_filter: `{payload.get('agent_id_filter')}`",
-                    f"- unfiltered_todo_count: `{payload.get('unfiltered_todo_count')}`",
+                    (
+                        "- unfiltered_todo_count: `"
+                        f"{payload.get('unfiltered_todo_count')}`"
+                    ),
                     f"- filter_semantics: `{payload.get('filter_semantics')}`",
                 ]
             )
-        projection = payload.get("state_event_projection")
+        projection = payload.get("todo_list_projection")
         if isinstance(projection, dict):
+            lines.append(
+                f"- returned_todo_count: `{payload.get('returned_todo_count')}`"
+            )
+        state_event_projection = payload.get("state_event_projection")
+        if isinstance(state_event_projection, dict):
             lines.extend(
                 [
-                    f"- event_log: `{projection.get('event_log')}`",
-                    f"- source_event_count: `{projection.get('source_event_count')}`",
-                    f"- last_event_id: `{projection.get('last_event_id')}`",
+                    f"- event_log: `{state_event_projection.get('event_log')}`",
+                    (
+                        "- source_event_count: `"
+                        f"{state_event_projection.get('source_event_count')}`"
+                    ),
+                    f"- last_event_id: `{state_event_projection.get('last_event_id')}`",
                 ]
             )
         for key, heading in (

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -76,6 +76,11 @@ from .control_plane.todos.line_update import (
     apply_todo_update_to_lines,
     upsert_todo_metadata,
 )
+from .control_plane.todos.list_projection import (
+    compact_agent_lane_todo_summary,
+    compact_todo_projection_overlay,
+    todo_list_projection_contract,
+)
 from .control_plane.todos.monitor_metadata import require_monitor_metadata_scope
 from .control_plane.todos.mutation_authority import authorize_todo_lifecycle_mutation, todo_update_authority_action
 from .control_plane.todos.todo_summary import compact_todo_group, normalize_todo_text
@@ -188,6 +193,18 @@ def empty_todo_summary(*, role: str) -> dict[str, Any]:
     }
 
 
+def _user_todo_visible_to_agent(item: dict[str, Any], agent_id: str) -> bool:
+    if bool(item.get("global_gate")):
+        return True
+    blocks_agent = normalize_todo_blocks_agent(item.get("blocks_agent"))
+    if blocks_agent:
+        return blocks_agent == agent_id
+    bound_agent = normalize_todo_bound_agent(item.get("bound_agent"))
+    if bound_agent:
+        return bound_agent == agent_id
+    return True
+
+
 def filtered_todo_summary(
     summary: dict[str, Any] | None,
     *,
@@ -227,9 +244,7 @@ def filtered_todo_summary(
             items = [
                 item
                 for item in items
-                if bool(item.get("global_gate"))
-                or not normalize_todo_blocks_agent(item.get("blocks_agent"))
-                or normalize_todo_blocks_agent(item.get("blocks_agent")) == normalized_agent_id
+                if _user_todo_visible_to_agent(item, normalized_agent_id)
             ]
     source_section = str((summary or {}).get("source_section") or TODO_SECTION_HEADINGS[role])
     return (
@@ -453,6 +468,28 @@ def list_goal_todos(
         summaries[key] = summary
         todos.extend(summary.get("items") or [])
 
+    matched_todo_count = len(todos)
+    agent_lane_hot_path = bool(
+        normalized_agent_id
+        and role is None
+        and status is None
+        and normalized_todo_id is None
+    )
+    if agent_lane_hot_path:
+        summaries = {
+            key: compact_agent_lane_todo_summary(
+                summary,
+                role=key.removesuffix("_todos"),
+            )
+            for key, summary in summaries.items()
+        }
+        todos = [
+            item
+            for key in ("user_todos", "agent_todos")
+            for item in summaries.get(key, {}).get("items") or []
+            if isinstance(item, dict)
+        ]
+
     matched_todo = todos[0] if len(todos) == 1 else None
     payload: dict[str, Any] = {
         "ok": True,
@@ -463,7 +500,7 @@ def list_goal_todos(
         "role": role or "all",
         "status_filter": normalize_todo_status(status) if status else None,
         "source": source,
-        "todo_count": len(todos),
+        "todo_count": matched_todo_count,
         "todos": todos,
         "state_file": str(resolved_state_file),
         "project": str(resolved_project) if resolved_project else None,
@@ -473,7 +510,14 @@ def list_goal_todos(
         payload["unfiltered_todo_count"] = unfiltered_count
         payload["filter_semantics"] = (
             "agent todos include unclaimed items plus claimed_by=<agent>; "
-            "user todos include global, unscoped legacy, and blocks_agent=<agent> gates"
+            "user todos include global, unscoped legacy, blocks_agent=<agent> gates, "
+            "and bound_agent=<agent> actions"
+        )
+    if agent_lane_hot_path:
+        payload["returned_todo_count"] = len(todos)
+        payload["todo_list_projection"] = todo_list_projection_contract(
+            matched_todo_count=matched_todo_count,
+            returned_todo_count=len(todos),
         )
     if normalized_todo_id:
         payload["todo_id_filter"] = normalized_todo_id
@@ -490,7 +534,11 @@ def list_goal_todos(
     if source == "event_projection_with_markdown_overlay":
         if projection_fields.get("state_event_projection"):
             payload["state_event_projection"] = projection_fields["state_event_projection"]
-        payload["projection_overlay"] = projection_overlay
+        payload["projection_overlay"] = (
+            compact_todo_projection_overlay(projection_overlay)
+            if agent_lane_hot_path
+            else projection_overlay
+        )
     if projection_fields.get("state_event_projection_warning"):
         payload["state_event_projection_warning"] = projection_fields["state_event_projection_warning"]
     return payload

--- a/tests/control_plane/test_todo_list_agent_lane_projection.py
+++ b/tests/control_plane/test_todo_list_agent_lane_projection.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from loopx.control_plane.todos.contract import encode_metadata_value
 from loopx.control_plane.todos.markdown import render_todo_markdown
 from loopx.todos import list_goal_todos
 
@@ -120,7 +121,13 @@ def _write_fixture(tmp_path: Path) -> tuple[Path, Path]:
             text="Execute the current agent advancement.",
             status="open",
             task_class="advancement_task",
-            metadata=f"claimed_by={AGENT_ID} action_kind=current_work",
+            metadata=(
+                f"claimed_by={AGENT_ID} action_kind=current_work "
+                "note="
+                + encode_metadata_value(
+                    "phase A validated; resume from durable state"
+                )
+            ),
         )
     )
     lines.extend(
@@ -226,6 +233,12 @@ def test_agent_lane_default_is_bounded_and_keeps_active_identity(
         "todo_agent_unclaimed",
         "todo_agent_deferred",
     }
+    current = next(
+        item
+        for item in payload["agent_todos"]["items"]
+        if item["todo_id"] == "todo_agent_current"
+    )
+    assert current["note"] == "phase A validated; resume from durable state"
     assert payload["user_todos"]["done_count"] == 50
     assert payload["agent_todos"]["done_count"] == 221
     assert all(item["status"] != "done" for item in payload["todos"])

--- a/tests/control_plane/test_todo_list_agent_lane_projection.py
+++ b/tests/control_plane/test_todo_list_agent_lane_projection.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from loopx.control_plane.todos.markdown import render_todo_markdown
+from loopx.todos import list_goal_todos
+
+GOAL_ID = "todo-list-agent-lane-goal"
+AGENT_ID = "codex-quality-qualification"
+OTHER_AGENT_ID = "codex-other-agent"
+
+
+def _todo_line(
+    *,
+    todo_id: str,
+    text: str,
+    status: str,
+    task_class: str,
+    metadata: str,
+) -> list[str]:
+    marker = " " if status in {"open", "blocked"} else "x"
+    return [
+        f"- [{marker}] {text}",
+        (
+            "  <!-- loopx:todo "
+            f"todo_id={todo_id} status={status} task_class={task_class} "
+            f"{metadata} -->"
+        ),
+    ]
+
+
+def _write_fixture(tmp_path: Path) -> tuple[Path, Path]:
+    project = tmp_path / "project"
+    runtime = tmp_path / "runtime"
+    state_relative = Path(".local/goals") / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    state_file = project / state_relative
+    state_file.parent.mkdir(parents=True)
+
+    lines = [
+        "---",
+        "status: active",
+        "updated_at: 2026-01-01T00:00:00+00:00",
+        "---",
+        "",
+        "# Todo List Agent Lane Fixture",
+        "",
+        "## User Todo",
+        "",
+    ]
+    lines.extend(
+        _todo_line(
+            todo_id="todo_user_done_000",
+            text="Completed current-agent user action 0.",
+            status="done",
+            task_class="user_action",
+            metadata=f"bound_agent={AGENT_ID}",
+        )
+    )
+    lines.extend(
+        _todo_line(
+            todo_id="todo_user_current_action",
+            text="Review the current agent result.",
+            status="open",
+            task_class="user_action",
+            metadata=f"bound_agent={AGENT_ID} action_kind=review_current",
+        )
+    )
+    lines.extend(
+        _todo_line(
+            todo_id="todo_user_other_action",
+            text="Review another agent result.",
+            status="open",
+            task_class="user_action",
+            metadata=f"bound_agent={OTHER_AGENT_ID} action_kind=review_other",
+        )
+    )
+    lines.extend(
+        _todo_line(
+            todo_id="todo_user_current_gate",
+            text="Approve the current agent decision.",
+            status="open",
+            task_class="user_gate",
+            metadata=f"blocks_agent={AGENT_ID} action_kind=approve_current",
+        )
+    )
+    lines.extend(
+        _todo_line(
+            todo_id="todo_user_other_gate",
+            text="Approve another agent decision.",
+            status="open",
+            task_class="user_gate",
+            metadata=f"blocks_agent={OTHER_AGENT_ID} action_kind=approve_other",
+        )
+    )
+    lines.extend(
+        _todo_line(
+            todo_id="todo_user_legacy",
+            text="Resolve one legacy unscoped user item.",
+            status="open",
+            task_class="user_action",
+            metadata="action_kind=legacy_unscoped",
+        )
+    )
+    for index in range(1, 50):
+        lines.extend(
+            _todo_line(
+                todo_id=f"todo_user_done_{index:03d}",
+                text=f"Completed current-agent user action {index}.",
+                status="done",
+                task_class="user_action",
+                metadata=f"bound_agent={AGENT_ID}",
+            )
+        )
+
+    lines.extend(["", "## Agent Todo", ""])
+    lines.extend(
+        _todo_line(
+            todo_id="todo_agent_current",
+            text="Execute the current agent advancement.",
+            status="open",
+            task_class="advancement_task",
+            metadata=f"claimed_by={AGENT_ID} action_kind=current_work",
+        )
+    )
+    lines.extend(
+        _todo_line(
+            todo_id="todo_agent_unclaimed",
+            text="Execute one unclaimed advancement.",
+            status="open",
+            task_class="advancement_task",
+            metadata="action_kind=unclaimed_work",
+        )
+    )
+    lines.extend(
+        _todo_line(
+            todo_id="todo_agent_other",
+            text="Execute another agent advancement.",
+            status="open",
+            task_class="advancement_task",
+            metadata=f"claimed_by={OTHER_AGENT_ID} action_kind=other_work",
+        )
+    )
+    lines.extend(
+        _todo_line(
+            todo_id="todo_agent_deferred",
+            text="Resume the current agent work when network capacity returns.",
+            status="deferred",
+            task_class="advancement_task",
+            metadata=(f"claimed_by={AGENT_ID} resume_when=capacity_available:network"),
+        )
+    )
+    long_done_text = "Completed historical detail " + ("that stays cold " * 20)
+    for index in range(220):
+        lines.extend(
+            _todo_line(
+                todo_id=f"todo_agent_done_{index:03d}",
+                text=f"{long_done_text}{index}.",
+                status="done",
+                task_class="advancement_task",
+                metadata=f"claimed_by={AGENT_ID} action_kind=historical_work",
+            )
+        )
+    state_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    registry_path = project / ".loopx/registry.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": str(state_relative),
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": [AGENT_ID, OTHER_AGENT_ID],
+                        },
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path, state_file
+
+
+def test_agent_lane_default_is_bounded_and_keeps_active_identity(
+    tmp_path: Path,
+) -> None:
+    registry_path, _ = _write_fixture(tmp_path)
+
+    payload = list_goal_todos(
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+
+    assert payload["todo_count"] == 276
+    assert payload["returned_todo_count"] == 6
+    assert payload["todo_list_projection"] == {
+        "schema_version": "agent_lane_todo_list_projection_v0",
+        "view": "agent_lane_hot_path",
+        "matched_todo_count": 276,
+        "returned_todo_count": 6,
+        "item_limit_per_role": 12,
+        "counts_cover_full_match": True,
+        "full_detail_cold_paths": [
+            "todo list with --role, --status, or --todo-id",
+            "todo list without --agent-id",
+            "active state",
+        ],
+    }
+    assert {item["todo_id"] for item in payload["user_todos"]["items"]} == {
+        "todo_user_current_action",
+        "todo_user_current_gate",
+        "todo_user_legacy",
+    }
+    assert {item["todo_id"] for item in payload["agent_todos"]["items"]} == {
+        "todo_agent_current",
+        "todo_agent_unclaimed",
+        "todo_agent_deferred",
+    }
+    assert payload["user_todos"]["done_count"] == 50
+    assert payload["agent_todos"]["done_count"] == 221
+    assert all(item["status"] != "done" for item in payload["todos"])
+    assert len(json.dumps(payload, ensure_ascii=False, indent=2)) < 30_000
+    assert len(render_todo_markdown(payload)) < 8_500
+
+
+def test_explicit_done_filter_remains_a_full_detail_cold_path(
+    tmp_path: Path,
+) -> None:
+    registry_path, _ = _write_fixture(tmp_path)
+
+    payload = list_goal_todos(
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        role="agent",
+        status="done",
+        agent_id=AGENT_ID,
+    )
+
+    assert payload["todo_count"] == 220
+    assert len(payload["todos"]) == 220
+    assert len(payload["agent_todos"]["items"]) == 220
+    assert "returned_todo_count" not in payload
+    assert "todo_list_projection" not in payload


### PR DESCRIPTION
## Summary

- keep the default `todo list --agent-id` path focused on active current-lane identities while preserving full scalar counts
- retain full todo detail behind existing role, status, todo-id, and operator cold paths
- exclude user actions bound to other agents and add a production-scale regression fixture

## Validation

- `22 passed` for agent-lane projection, monitor followthrough, and todo decision-scope tests
- `todo-cli-smoke ok`
- `cli-output-budget-regression-smoke ok`
- repository-declared strict mypy: passed (15 files)
- focused Ruff undefined-name/import safety: passed
- changed-path public/private scan: 0 errors, 0 warnings
- branch-local `loopx-meta` readback: JSON 21,468 bytes and Markdown 3,472 bytes, down from about 1.09 MB and 143 KB
- premerge: 17/17 selected canaries passed, 0 failures, 0 manual holds, self-merge allowed
- change-quality receipt `cqr_e5371f3a7e405dbd7f74`: valid; one safe fix removed redundant Markdown projection narration after the first budget smoke exposed a 36-character ceiling overrun

The first premerge invocation omitted the global registry and exited after all selected checks passed because this clean worktree has no repo-local registry. The authoritative rerun supplied the global registry and passed. No full pytest suite was run; the focused todo tests plus the risk-selected premerge canaries cover the changed contract.