### PR TITLE
fix(skillsbench): gate scoring on lifecycle parity

### DIFF
--- a/loopx/benchmark_adapters/skillsbench_setup_preflight.py
+++ b/loopx/benchmark_adapters/skillsbench_setup_preflight.py
@@ -10,7 +10,11 @@ from .skillsbench_failure_signals import (
 )
 
 
-SCHEMA_VERSION = "skillsbench_setup_only_public_preflight_v0"
+SCHEMA_VERSION = "skillsbench_setup_only_public_preflight_v1"
+SCORED_LIFECYCLE_READINESS_GATE_SCHEMA_VERSION = (
+    "skillsbench_scored_lifecycle_readiness_gate_v0"
+)
+MAX_SCORED_LIFECYCLE_TERMINAL_BUDGET_SEC = 300
 COMPOSE_TYPED_CAUSE_SCHEMA_VERSION = "skillsbench_compose_typed_cause_v0"
 APT_TRANSPORT_RECEIPT_SCHEMA_VERSION = "skillsbench_apt_transport_failure_receipt_v0"
 _PATCH_SUFFIX = "_patch_applied"
@@ -328,6 +332,21 @@ def _base_result(
         "agent_install_canary_requested": False,
         "agent_install_canary_status": "not_requested",
         "agent_install_invoked": False,
+        "scored_lifecycle_canary_requested": False,
+        "scored_lifecycle_canary_status": "not_requested",
+        "scored_lifecycle_terminal_budget_sec": 0,
+        "case_goal_state_initialized_before_agent": False,
+        "acp_session_initialized": False,
+        "agent_active_observed": False,
+        "loopx_state_read_count": 0,
+        "loopx_state_write_count": 0,
+        "task_prompt_sent": False,
+        "benchmark_task_launched": False,
+        "scored_launch_allowed": False,
+        "scored_launch_blocker": "scored_lifecycle_canary_not_requested",
+        "loopx_runner_source_git_head": "",
+        "loopx_runner_source_expected_git_head": "",
+        "loopx_runner_source_matches_expected": False,
         "agent_execution_invoked": False,
         "verifier_invoked": False,
         "dependency_classes": [],
@@ -366,6 +385,107 @@ def _base_result(
     }
 
 
+def skillsbench_scored_lifecycle_readiness_gate(
+    receipt: Mapping[str, Any],
+    *,
+    expected_git_head: str,
+) -> dict[str, Any]:
+    """Validate the public task-free receipt required before scored launch."""
+
+    expected = str(expected_git_head or "").strip()
+    observed = str(receipt.get("loopx_runner_source_git_head") or "").strip()
+    blockers: list[str] = []
+    read_count = receipt.get("loopx_state_read_count")
+    write_count = receipt.get("loopx_state_write_count")
+    terminal_budget = receipt.get("scored_lifecycle_terminal_budget_sec")
+    required = (
+        (
+            receipt.get("schema_version") == SCHEMA_VERSION,
+            "receipt_schema_mismatch",
+        ),
+        (receipt.get("status") == "passed", "preflight_not_passed"),
+        (
+            receipt.get("cleanup_status") == "completed",
+            "preflight_cleanup_incomplete",
+        ),
+        (
+            receipt.get("scored_lifecycle_canary_status") == "passed",
+            "scored_lifecycle_canary_not_passed",
+        ),
+        (
+            isinstance(terminal_budget, int)
+            and not isinstance(terminal_budget, bool)
+            and 1 <= terminal_budget <= MAX_SCORED_LIFECYCLE_TERMINAL_BUDGET_SEC,
+            "scored_lifecycle_terminal_budget_invalid",
+        ),
+        (
+            receipt.get("case_goal_state_initialized_before_agent") is True,
+            "case_state_seed_not_observed",
+        ),
+        (
+            receipt.get("acp_session_initialized") is True,
+            "acp_session_not_initialized",
+        ),
+        (
+            receipt.get("agent_active_observed") is True,
+            "agent_active_not_observed",
+        ),
+        (
+            isinstance(read_count, int)
+            and not isinstance(read_count, bool)
+            and read_count >= 1,
+            "loopx_state_read_not_observed",
+        ),
+        (
+            isinstance(write_count, int)
+            and not isinstance(write_count, bool)
+            and write_count >= 1,
+            "loopx_state_write_not_observed",
+        ),
+        (
+            receipt.get("task_prompt_sent") is False,
+            "task_prompt_boundary_not_proven",
+        ),
+        (
+            receipt.get("benchmark_task_launched") is False,
+            "benchmark_task_boundary_not_proven",
+        ),
+        (
+            receipt.get("agent_execution_invoked") is False,
+            "agent_execution_boundary_not_proven",
+        ),
+        (
+            receipt.get("verifier_invoked") is False,
+            "verifier_boundary_not_proven",
+        ),
+        (
+            receipt.get("scored_launch_allowed") is True,
+            "receipt_does_not_allow_scored_launch",
+        ),
+    )
+    blockers.extend(reason for passed, reason in required if not passed)
+    if not expected:
+        blockers.append("expected_loopx_git_head_missing")
+    elif not observed or not observed.startswith(expected):
+        blockers.append("loopx_runner_source_git_head_mismatch")
+    if receipt.get("loopx_runner_source_matches_expected") is not True:
+        blockers.append("loopx_runner_source_match_not_proven")
+
+    return {
+        "schema_version": SCORED_LIFECYCLE_READINESS_GATE_SCHEMA_VERSION,
+        "allowed": not blockers,
+        "blockers": blockers,
+        "expected_git_head": expected[:40],
+        "observed_git_head": observed[:40],
+        "raw_logs_read": False,
+        "raw_task_text_read": False,
+        "raw_trajectory_read": False,
+        "raw_verifier_output_read": False,
+        "host_paths_recorded": False,
+        "secret_values_recorded": False,
+    }
+
+
 def _emit_progress(
     callback: Callable[[Mapping[str, Any]], None] | None,
     result: Mapping[str, Any],
@@ -385,8 +505,12 @@ async def run_setup_only_public_preflight(
     progress_callback: Callable[[Mapping[str, Any]], None] | None = None,
     environment_ready_hook: Callable[[Any], Awaitable[None]] | None = None,
     agent_install_canary: bool = False,
+    scored_lifecycle_canary: (
+        Callable[[Any], Awaitable[Mapping[str, Any]]] | None
+    ) = None,
+    scored_lifecycle_timeout_sec: float = 180.0,
 ) -> dict[str, Any]:
-    """Materialize a BenchFlow environment and optionally canary agent install."""
+    """Materialize a BenchFlow environment and optionally canary scored readiness."""
 
     result = _base_result(
         task_staging=task_staging,
@@ -394,8 +518,10 @@ async def run_setup_only_public_preflight(
     )
     stage_timeout_sec = max(1.0, stage_timeout_sec)
     cleanup_timeout_sec = max(1.0, cleanup_timeout_sec)
+    scored_lifecycle_timeout_sec = max(0.01, scored_lifecycle_timeout_sec)
     rollout: Any | None = None
     restore_compose_boundary: Callable[[], None] | None = None
+    scored_lifecycle_started_at: float | None = None
     failed = False
     if environment_ready_hook is not None:
         result["environment_ready_hook_requested"] = True
@@ -403,6 +529,15 @@ async def run_setup_only_public_preflight(
     if agent_install_canary:
         result["agent_install_canary_requested"] = True
         result["agent_install_canary_status"] = "pending"
+    if scored_lifecycle_canary is not None:
+        if not agent_install_canary:
+            raise ValueError("scored lifecycle canary requires agent install canary")
+        result["scored_lifecycle_canary_requested"] = True
+        result["scored_lifecycle_canary_status"] = "pending"
+        result["scored_lifecycle_terminal_budget_sec"] = int(
+            scored_lifecycle_timeout_sec
+        )
+        result["scored_launch_blocker"] = "scored_lifecycle_canary_not_passed"
     _emit_progress(progress_callback, result)
     try:
         rollout = await asyncio.wait_for(
@@ -441,20 +576,90 @@ async def run_setup_only_public_preflight(
             )
             result["environment_ready_hook_status"] = "passed"
         if agent_install_canary:
+            scored_lifecycle_started_at = (
+                asyncio.get_running_loop().time()
+                if scored_lifecycle_canary is not None
+                else None
+            )
             result["stage"] = "agent_install_canary"
             result["agent_install_invoked"] = True
             result["agent_install_canary_status"] = "running"
             _emit_progress(progress_callback, result)
             await asyncio.wait_for(
                 rollout.install_agent(),
-                timeout=stage_timeout_sec,
+                timeout=(
+                    scored_lifecycle_timeout_sec
+                    if scored_lifecycle_canary is not None
+                    else stage_timeout_sec
+                ),
             )
             result["agent_install_canary_status"] = "passed"
+        if scored_lifecycle_canary is not None:
+            if scored_lifecycle_started_at is None:
+                raise RuntimeError("scored lifecycle canary budget did not start")
+            result["stage"] = "scored_lifecycle_canary"
+            result["scored_lifecycle_canary_status"] = "running"
+            _emit_progress(progress_callback, result)
+            remaining_timeout_sec = max(
+                0.001,
+                scored_lifecycle_timeout_sec
+                - (
+                    asyncio.get_running_loop().time()
+                    - scored_lifecycle_started_at
+                ),
+            )
+            lifecycle = await asyncio.wait_for(
+                scored_lifecycle_canary(rollout),
+                timeout=remaining_timeout_sec,
+            )
+            for field in (
+                "case_goal_state_initialized_before_agent",
+                "acp_session_initialized",
+                "agent_active_observed",
+                "task_prompt_sent",
+                "benchmark_task_launched",
+                "loopx_runner_source_matches_expected",
+            ):
+                result[field] = lifecycle.get(field) is True
+            for field in ("loopx_state_read_count", "loopx_state_write_count"):
+                value = lifecycle.get(field)
+                result[field] = (
+                    max(0, int(value))
+                    if isinstance(value, int) and not isinstance(value, bool)
+                    else 0
+                )
+            for field in (
+                "loopx_runner_source_git_head",
+                "loopx_runner_source_expected_git_head",
+            ):
+                value = lifecycle.get(field)
+                result[field] = str(value or "")[:40]
+            readiness = skillsbench_scored_lifecycle_readiness_gate(
+                {
+                    **result,
+                    "status": "passed",
+                    "cleanup_status": "completed",
+                    "scored_lifecycle_canary_status": "passed",
+                    "scored_launch_allowed": True,
+                },
+                expected_git_head=result[
+                    "loopx_runner_source_expected_git_head"
+                ],
+            )
+            if readiness["allowed"] is not True:
+                raise RuntimeError("scored lifecycle canary did not prove readiness")
+            result["scored_lifecycle_canary_status"] = "passed"
+            result["scored_launch_allowed"] = True
+            result["scored_launch_blocker"] = "none"
         result["status"] = "passed"
         result["stage"] = (
-            "agent_install_ready_before_execution"
-            if agent_install_canary
-            else "environment_ready_before_agent"
+            "scored_runtime_ready"
+            if scored_lifecycle_canary is not None
+            else (
+                "agent_install_ready_before_execution"
+                if agent_install_canary
+                else "environment_ready_before_agent"
+            )
         )
         result["exit_category"] = "passed"
     except Exception as exc:
@@ -463,6 +668,15 @@ async def run_setup_only_public_preflight(
             result["environment_ready_hook_status"] = "failed"
         if result["agent_install_canary_status"] == "running":
             result["agent_install_canary_status"] = "failed"
+        if result["scored_lifecycle_canary_status"] == "running":
+            result["scored_lifecycle_canary_status"] = "failed"
+        elif (
+            result["scored_lifecycle_canary_requested"] is True
+            and result["scored_lifecycle_canary_status"] == "pending"
+        ):
+            result["scored_lifecycle_canary_status"] = "blocked_before_start"
+        result["scored_launch_allowed"] = False
+        result["scored_launch_blocker"] = "scored_lifecycle_canary_not_passed"
         if rollout is not None:
             result["job_root_materialized"] = (
                 getattr(rollout, "_rollout_dir", None) is not None
@@ -544,6 +758,8 @@ async def run_setup_only_public_preflight(
                 result["cleanup_status"] = "completed"
             except Exception:
                 result["cleanup_status"] = "failed"
+                result["scored_launch_allowed"] = False
+                result["scored_launch_blocker"] = "preflight_cleanup_incomplete"
                 if not failed:
                     result["status"] = "failed"
                     result["failure_stage"] = "cleanup"

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -92,6 +92,15 @@ Optional env:
                                        With setup-only preflight, set to 1 to
                                        exercise agent install and stop before
                                        agent execution or verification
+  SKILLSBENCH_SETUP_ONLY_SCORED_LIFECYCLE_CANARY
+                                       With setup-only agent install, set to 1
+                                       to initialize a task-free ACP session and
+                                       prove one LoopX state read/write lifecycle
+  SKILLSBENCH_SCORED_LIFECYCLE_CANARY_TIMEOUT_SEC
+                                       Strict canary terminal budget, default 180
+  SKILLSBENCH_SCORED_LIFECYCLE_READINESS_RECEIPT
+                                       Local public canary receipt required for
+                                       every non-setup scored launch
   SKILLSBENCH_PRODUCT_MODE_SOFT_VERIFY_POLICY
                                        Optional product-mode intermediate
                                        verifier policy: every-round or
@@ -279,6 +288,9 @@ skip_current_aggregate_update="${SKILLSBENCH_SKIP_CURRENT_AGGREGATE_UPDATE:-0}"
 allow_staged_bootstrap_repair_run="${SKILLSBENCH_ALLOW_STAGED_BOOTSTRAP_REPAIR_RUN:-0}"
 setup_only_public_preflight="${SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT:-0}"
 setup_only_agent_install_canary="${SKILLSBENCH_SETUP_ONLY_AGENT_INSTALL_CANARY:-0}"
+setup_only_scored_lifecycle_canary="${SKILLSBENCH_SETUP_ONLY_SCORED_LIFECYCLE_CANARY:-0}"
+scored_lifecycle_canary_timeout="${SKILLSBENCH_SCORED_LIFECYCLE_CANARY_TIMEOUT_SEC:-180}"
+scored_lifecycle_readiness_receipt="${SKILLSBENCH_SCORED_LIFECYCLE_READINESS_RECEIPT:-}"
 benchmark_egress_proxy_mode="${SKILLSBENCH_BENCHMARK_EGRESS_PROXY_MODE:-require}"
 benchmark_egress_no_proxy="${SKILLSBENCH_BENCHMARK_EGRESS_NO_PROXY:-}"
 docker_apt_source_mode="${SKILLSBENCH_DOCKER_APT_SOURCE_MODE:-}"
@@ -332,9 +344,22 @@ validate_bool_toggle \
   SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT "$setup_only_public_preflight"
 validate_bool_toggle \
   SKILLSBENCH_SETUP_ONLY_AGENT_INSTALL_CANARY "$setup_only_agent_install_canary"
+validate_bool_toggle \
+  SKILLSBENCH_SETUP_ONLY_SCORED_LIFECYCLE_CANARY \
+  "$setup_only_scored_lifecycle_canary"
 if [[ "$setup_only_agent_install_canary" == "1" ]] &&
   [[ "$setup_only_public_preflight" != "1" ]]; then
   echo "SKILLSBENCH_SETUP_ONLY_AGENT_INSTALL_CANARY requires SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT=1" >&2
+  exit 2
+fi
+if [[ "$setup_only_scored_lifecycle_canary" == "1" ]] &&
+  [[ "$setup_only_agent_install_canary" != "1" ]]; then
+  echo "SKILLSBENCH_SETUP_ONLY_SCORED_LIFECYCLE_CANARY requires SKILLSBENCH_SETUP_ONLY_AGENT_INSTALL_CANARY=1" >&2
+  exit 2
+fi
+if [[ ! "$scored_lifecycle_canary_timeout" =~ ^[1-9][0-9]*$ ]] ||
+  ((10#$scored_lifecycle_canary_timeout > 300)); then
+  echo "SKILLSBENCH_SCORED_LIFECYCLE_CANARY_TIMEOUT_SEC must be between 1 and 300" >&2
   exit 2
 fi
 validate_bool_toggle \
@@ -383,6 +408,49 @@ if [[ -n "$product_mode_soft_verify_policy" ]] &&
   [[ "$product_mode_soft_verify_policy" != "final-only" ]]; then
   echo "SKILLSBENCH_PRODUCT_MODE_SOFT_VERIFY_POLICY must be every-round or final-only" >&2
   exit 2
+fi
+scored_lifecycle_readiness="not_required_for_setup_only"
+if [[ "$setup_only_public_preflight" == "1" ]]; then
+  if [[ "$setup_only_scored_lifecycle_canary" == "1" ]]; then
+    scored_lifecycle_readiness="canary_will_generate_receipt"
+  fi
+elif [[ "$dry_run" == "true" ]]; then
+  scored_lifecycle_readiness="required_at_live_launch"
+else
+  if [[ -z "$scored_lifecycle_readiness_receipt" ]]; then
+    echo "SKILLSBENCH_SCORED_LIFECYCLE_READINESS_RECEIPT is required before scored launch" >&2
+    exit 3
+  fi
+  if ! scored_lifecycle_gate="$(
+    PYTHONPATH="${repo_root}${PYTHONPATH:+:${PYTHONPATH}}" \
+      python3 - \
+      "$scored_lifecycle_readiness_receipt" \
+      "$SKILLSBENCH_EXPECTED_LOOPX_GIT_HEAD" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+from loopx.benchmark_adapters.skillsbench_setup_preflight import (
+    skillsbench_scored_lifecycle_readiness_gate,
+)
+
+try:
+    receipt = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError):
+    receipt = {}
+gate = skillsbench_scored_lifecycle_readiness_gate(
+    receipt if isinstance(receipt, dict) else {},
+    expected_git_head=sys.argv[2],
+)
+print(json.dumps(gate, sort_keys=True))
+raise SystemExit(0 if gate["allowed"] else 1)
+PY
+  )"; then
+    printf '%s\n' "$scored_lifecycle_gate" >&2
+    exit 3
+  fi
+  unset scored_lifecycle_gate
+  scored_lifecycle_readiness="passed"
 fi
 remote_codex_bin_mode="path_lookup"
 if [[ -n "${SKILLSBENCH_REMOTE_CODEX_BIN:-}" ]]; then
@@ -524,6 +592,15 @@ fi
 goal_id="${SKILLSBENCH_GOAL_ID:-loopx-meta}"
 local_run_ledger="${SKILLSBENCH_LOCAL_RUN_LEDGER_PATH:-.local/goals/${goal_id}/skillsbench-ledgers/live-standard-run-ledger.json}"
 route="${SKILLSBENCH_ROUTE:-codex-cli-goal-baseline}"
+if [[ "$setup_only_scored_lifecycle_canary" == "1" ]]; then
+  case "$route" in
+    loopx-product-mode|loopx-goal-start-product-mode|loopx-turn-agent-cli) ;;
+    *)
+      echo "SKILLSBENCH_SETUP_ONLY_SCORED_LIFECYCLE_CANARY requires a case-local LoopX route" >&2
+      exit 2
+      ;;
+  esac
+fi
 if [[ "$route" == "loopx-turn-agent-cli" ]] &&
   [[ -z "$loopx_turn_validation_command" ]]; then
   echo "SKILLSBENCH_LOOPX_TURN_VALIDATION_COMMAND is required for loopx-turn-agent-cli" >&2
@@ -703,6 +780,13 @@ if [[ "$setup_only_public_preflight" == "1" ]]; then
 fi
 if [[ "$setup_only_agent_install_canary" == "1" ]]; then
   extra_runner_args+=(--setup-only-agent-install-canary)
+fi
+if [[ "$setup_only_scored_lifecycle_canary" == "1" ]]; then
+  extra_runner_args+=(
+    --setup-only-scored-lifecycle-canary
+    --scored-lifecycle-canary-timeout-sec
+    "$scored_lifecycle_canary_timeout"
+  )
 fi
 if [[ -n "$benchmark_egress_no_proxy" ]]; then
   extra_runner_args+=(
@@ -959,6 +1043,13 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'setup_only_public_preflight=%s\n' "$setup_only_public_preflight"
   printf 'setup_only_agent_install_canary=%s\n' \
     "$setup_only_agent_install_canary"
+  printf 'setup_only_scored_lifecycle_canary=%s\n' \
+    "$setup_only_scored_lifecycle_canary"
+  printf 'scored_lifecycle_canary_timeout_sec=%s\n' \
+    "$scored_lifecycle_canary_timeout"
+  printf 'scored_lifecycle_readiness=%s\n' \
+    "$scored_lifecycle_readiness"
+  printf 'scored_lifecycle_readiness_receipt_path_recorded=false\n'
   printf 'public_artifact_sync_interval_sec=%s\n' \
     "$public_artifact_sync_interval"
   printf 'benchmark_egress_proxy_mode=%s\n' "$benchmark_egress_proxy_mode"
@@ -1091,6 +1182,10 @@ codex_cli_goal_thread_prewarm=${codex_cli_goal_thread_prewarm}
 allow_staged_bootstrap_repair_run=${allow_staged_bootstrap_repair_run}
 setup_only_public_preflight=${setup_only_public_preflight}
 setup_only_agent_install_canary=${setup_only_agent_install_canary}
+setup_only_scored_lifecycle_canary=${setup_only_scored_lifecycle_canary}
+scored_lifecycle_canary_timeout_sec=${scored_lifecycle_canary_timeout}
+scored_lifecycle_readiness=${scored_lifecycle_readiness}
+scored_lifecycle_readiness_receipt_path_recorded=false
 exact_host_codex_sandbox_preflight=${exact_host_codex_sandbox_preflight}
 exact_host_codex_sandbox_preflight_timeout_sec=${exact_host_codex_sandbox_preflight_timeout}
 public_artifact_sync_interval_sec=${public_artifact_sync_interval}

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -9246,6 +9246,12 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         "setup_only_agent_install_canary": bool(
             getattr(args, "setup_only_agent_install_canary", False)
         ),
+        "setup_only_scored_lifecycle_canary": bool(
+            getattr(args, "setup_only_scored_lifecycle_canary", False)
+        ),
+        "scored_lifecycle_canary_timeout_sec": int(
+            getattr(args, "scored_lifecycle_canary_timeout_sec", 180) or 180
+        ),
         "setup_only_stage_timeout_sec": (
             _effective_setup_only_stage_timeout_sec(args)
         ),
@@ -9783,6 +9789,7 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
         "build_stall_timeout_requested_sec",
         "build_stall_timeout_sec",
         "setup_only_stage_timeout_sec",
+        "scored_lifecycle_canary_timeout_sec",
         "local_codex_task_output_quiet_timeout_sec",
     )
     for field in int_fields:
@@ -9803,6 +9810,7 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
         "bootstrap_light_fail_fast_defaulted",
         "setup_only_public_preflight",
         "setup_only_agent_install_canary",
+        "setup_only_scored_lifecycle_canary",
         "global_ledger_sync_enabled",
         "ledger_inherit_enabled",
     ):
@@ -15177,6 +15185,9 @@ async def run_benchflow_case(
     setup_only_public_preflight = bool(
         getattr(args, "setup_only_public_preflight", False)
     )
+    setup_only_scored_lifecycle_canary = bool(
+        getattr(args, "setup_only_scored_lifecycle_canary", False)
+    )
     controller_user = None
     controller_trace: dict[str, Any] | None = None
     product_mode_case_payload: dict[str, Any] | None = None
@@ -15189,6 +15200,11 @@ async def run_benchflow_case(
             max_rounds=args.max_rounds,
             case_loopx_source_path=_loopx_case_source_path_for_container(args),
             goal_start_product_mode=_is_goal_start_product_mode_route(args.route),
+        )
+    if setup_only_scored_lifecycle_canary:
+        controller_trace = _new_controller_trace(args.route, max_rounds=args.max_rounds)
+        controller_trace["last_decision"] = (
+            "task_free_scored_lifecycle_canary_selected"
         )
     if not setup_only_public_preflight and args.route in {
         CODEX_ACP_BLIND_LOOP_BASELINE_ROUTE,
@@ -15295,6 +15311,95 @@ async def run_benchflow_case(
     config = RolloutConfig(
         **_filter_kwargs_for_signature(RolloutConfig, rollout_config_kwargs)
     )
+
+    async def run_task_free_scored_lifecycle_canary(
+        rollout: Any,
+    ) -> Mapping[str, Any]:
+        env = getattr(rollout, "env", None)
+        if env is None:
+            raise RuntimeError("scored lifecycle canary rollout env missing")
+        payload = benchmark_case_loopx_install_payload(
+            benchmark_id="skillsbench",
+            case_id=args.task_id,
+            arm_id=_loopx_case_arm_id_for_route(args.route),
+            route=args.route,
+            max_rounds=args.max_rounds,
+            case_loopx_source_path=_loopx_case_source_path_for_container(args),
+            goal_start_product_mode=_is_goal_start_product_mode_route(args.route),
+        )
+        goal_id = str(payload["benchmark_case_goal_id"])
+        cli_prefix = benchmark_case_loopx_command_prefix(
+            case_cli_path=str(payload["case_cli_path"]),
+            case_registry_path=str(payload["case_registry_path"]),
+            case_runtime_root=str(payload["case_runtime_root"]),
+        )
+        connected = await connect_host_local_acp(
+            env,
+            "codex-acp",
+            "",
+            agent_env,
+            args.sandbox_user,
+            args.model,
+            Path(getattr(rollout, "_rollout_dir", None) or plan["jobs_dir"]),
+            args.sandbox,
+            str(getattr(rollout, "_agent_cwd", None) or "/app"),
+            reasoning_effort=_effective_reasoning_effort(args),
+            mcp_servers=None,
+        )
+        client = connected[0]
+        try:
+            _write_public_runner_lifecycle_receipt(
+                plan,
+                run_stage="task_free_scored_lifecycle_canary_active",
+                worker_status="agent_active",
+            )
+            read_result = await env.exec(
+                f"{cli_prefix} status --goal-id {shlex.quote(goal_id)} --limit 5",
+                timeout_sec=60,
+            )
+            if int(read_result.return_code) != 0:
+                raise RuntimeError("scored lifecycle canary state read failed")
+            write_result = await env.exec(
+                f"{cli_prefix} refresh-state "
+                f"--goal-id {shlex.quote(goal_id)} "
+                "--classification benchmark_case_scored_lifecycle_canary "
+                "--delivery-batch-scale single_surface "
+                "--delivery-outcome surface_only "
+                "--no-global-sync",
+                timeout_sec=60,
+            )
+            if int(write_result.return_code) != 0:
+                raise RuntimeError("scored lifecycle canary state write failed")
+        finally:
+            with contextlib.suppress(Exception):
+                await client.close()
+
+        source = plan.get("loopx_runner_source_fingerprint")
+        if not isinstance(source, Mapping):
+            source = {}
+        return {
+            "case_goal_state_initialized_before_agent": bool(
+                isinstance(controller_trace, dict)
+                and controller_trace.get(
+                    "case_goal_state_initialized_before_agent"
+                )
+                is True
+            ),
+            "acp_session_initialized": True,
+            "agent_active_observed": True,
+            "loopx_state_read_count": 1,
+            "loopx_state_write_count": 1,
+            "task_prompt_sent": False,
+            "benchmark_task_launched": False,
+            "loopx_runner_source_git_head": str(source.get("git_head") or ""),
+            "loopx_runner_source_expected_git_head": str(
+                source.get("expected_git_head") or ""
+            ),
+            "loopx_runner_source_matches_expected": (
+                source.get("matches_expected") is True
+            ),
+        }
+
     result_path: Path | None = None
     prerequisites = plan.setdefault("runner_prerequisites", {})
     requested_build_stall_timeout_sec = _requested_build_stall_timeout_sec(args)
@@ -15446,6 +15551,15 @@ async def run_benchflow_case(
                 ),
                 agent_install_canary=bool(
                     getattr(args, "setup_only_agent_install_canary", False)
+                ),
+                scored_lifecycle_canary=(
+                    run_task_free_scored_lifecycle_canary
+                    if setup_only_scored_lifecycle_canary
+                    else None
+                ),
+                scored_lifecycle_timeout_sec=float(
+                    getattr(args, "scored_lifecycle_canary_timeout_sec", 180)
+                    or 180
                 ),
             )
             plan["setup_only_public_preflight_result"] = setup_only_result
@@ -17185,6 +17299,21 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--setup-only-scored-lifecycle-canary",
+        action="store_true",
+        help=(
+            "With setup-only agent install, initialize a task-free ACP session "
+            "and prove one case-local LoopX state read/write lifecycle before "
+            "allowing later scored launches."
+        ),
+    )
+    parser.add_argument(
+        "--scored-lifecycle-canary-timeout-sec",
+        type=int,
+        default=180,
+        help="Strict terminal budget for the task-free scored lifecycle canary.",
+    )
+    parser.add_argument(
         "--reduce-only",
         action="store_true",
         help="Reduce an existing result.json for the selected job without rerunning the task.",
@@ -17635,6 +17764,30 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         parser.error(
             "--setup-only-agent-install-canary requires "
             "--setup-only-public-preflight"
+        )
+    if (
+        args.setup_only_scored_lifecycle_canary
+        and not args.setup_only_agent_install_canary
+    ):
+        parser.error(
+            "--setup-only-scored-lifecycle-canary requires "
+            "--setup-only-agent-install-canary"
+        )
+    if args.setup_only_scored_lifecycle_canary and not args.host_local_acp_launch:
+        parser.error(
+            "--setup-only-scored-lifecycle-canary requires "
+            "--host-local-acp-launch"
+        )
+    if args.setup_only_scored_lifecycle_canary and not _is_case_loopx_route(
+        args.route
+    ):
+        parser.error(
+            "--setup-only-scored-lifecycle-canary requires a case-local "
+            "LoopX route"
+        )
+    if not 1 <= args.scored_lifecycle_canary_timeout_sec <= 300:
+        parser.error(
+            "--scored-lifecycle-canary-timeout-sec must be between 1 and 300"
         )
     if args.setup_only_public_preflight and (args.append_history or args.update_ledger):
         parser.error(

--- a/tests/test_skillsbench_setup_preflight.py
+++ b/tests/test_skillsbench_setup_preflight.py
@@ -19,6 +19,7 @@ from loopx.benchmark_adapters.skillsbench_setup_preflight import (
     SkillsBenchComposeCommandFailure,
     install_skillsbench_compose_typed_cause_boundary,
     run_setup_only_public_preflight,
+    skillsbench_scored_lifecycle_readiness_gate,
 )
 from loopx.status import compact_benchmark_run
 from scripts.skillsbench_automation_loop import (
@@ -37,6 +38,7 @@ from scripts.skillsbench_automation_loop import (
 class FakeRollout:
     failure_stage = ""
     failure: Exception | None = None
+    install_delay_sec = 0.0
     events: list[str] = []
 
     def __init__(self) -> None:
@@ -64,6 +66,8 @@ class FakeRollout:
 
     async def install_agent(self) -> None:
         self.events.append("install_agent")
+        if self.install_delay_sec:
+            await asyncio.sleep(self.install_delay_sec)
         if self.failure_stage == "agent_install" and self.failure is not None:
             raise self.failure
 
@@ -77,6 +81,7 @@ class FakeRollout:
 def reset_fake_rollout() -> None:
     FakeRollout.failure_stage = ""
     FakeRollout.failure = None
+    FakeRollout.install_delay_sec = 0.0
     FakeRollout.events = []
 
 
@@ -269,6 +274,110 @@ def test_setup_only_preflight_classifies_agent_install_canary_failure() -> None:
     assert "private provider install detail" not in json.dumps(result, sort_keys=True)
 
 
+def test_setup_only_preflight_proves_task_free_scored_lifecycle() -> None:
+    async def scored_lifecycle_canary(_rollout: object) -> dict[str, object]:
+        FakeRollout.events.append("scored_lifecycle_canary")
+        return {
+            "case_goal_state_initialized_before_agent": True,
+            "acp_session_initialized": True,
+            "agent_active_observed": True,
+            "loopx_state_read_count": 1,
+            "loopx_state_write_count": 1,
+            "task_prompt_sent": False,
+            "benchmark_task_launched": False,
+            "loopx_runner_source_git_head": "abc123def456",
+            "loopx_runner_source_expected_git_head": "abc123",
+            "loopx_runner_source_matches_expected": True,
+        }
+
+    result = asyncio.run(
+        run_setup_only_public_preflight(
+            rollout_type=FakeRollout,
+            config=object(),
+            stage_timeout_sec=1,
+            agent_install_canary=True,
+            scored_lifecycle_canary=scored_lifecycle_canary,
+            scored_lifecycle_timeout_sec=2,
+        )
+    )
+
+    assert result["status"] == "passed"
+    assert result["stage"] == "scored_runtime_ready"
+    assert result["scored_lifecycle_canary_status"] == "passed"
+    assert result["scored_lifecycle_terminal_budget_sec"] == 2
+    assert result["agent_active_observed"] is True
+    assert result["loopx_state_read_count"] == 1
+    assert result["loopx_state_write_count"] == 1
+    assert result["scored_launch_allowed"] is True
+    assert result["scored_launch_blocker"] == "none"
+    assert result["task_prompt_sent"] is False
+    assert result["benchmark_task_launched"] is False
+    assert result["agent_execution_invoked"] is False
+    assert result["verifier_invoked"] is False
+    assert FakeRollout.events == [
+        "create",
+        "setup",
+        "start",
+        "install_agent",
+        "scored_lifecycle_canary",
+        "cleanup",
+    ]
+
+
+def test_scored_lifecycle_gate_fails_closed_without_state_write() -> None:
+    receipt = {
+        "schema_version": "skillsbench_setup_only_public_preflight_v1",
+        "status": "passed",
+        "cleanup_status": "completed",
+        "scored_lifecycle_canary_status": "passed",
+        "scored_lifecycle_terminal_budget_sec": 180,
+        "case_goal_state_initialized_before_agent": True,
+        "acp_session_initialized": True,
+        "agent_active_observed": True,
+        "loopx_state_read_count": 1,
+        "loopx_state_write_count": 0,
+        "task_prompt_sent": False,
+        "benchmark_task_launched": False,
+        "agent_execution_invoked": False,
+        "verifier_invoked": False,
+        "scored_launch_allowed": True,
+        "loopx_runner_source_git_head": "abc123def456",
+        "loopx_runner_source_matches_expected": True,
+    }
+
+    gate = skillsbench_scored_lifecycle_readiness_gate(
+        receipt,
+        expected_git_head="abc123",
+    )
+
+    assert gate["allowed"] is False
+    assert gate["blockers"] == ["loopx_state_write_not_observed"]
+
+
+def test_scored_lifecycle_budget_includes_agent_install() -> None:
+    async def unreachable_canary(_rollout: object) -> dict[str, object]:
+        raise AssertionError("canary must not run after install budget expires")
+
+    FakeRollout.install_delay_sec = 0.03
+    result = asyncio.run(
+        run_setup_only_public_preflight(
+            rollout_type=FakeRollout,
+            config=object(),
+            stage_timeout_sec=1,
+            agent_install_canary=True,
+            scored_lifecycle_canary=unreachable_canary,
+            scored_lifecycle_timeout_sec=0.01,
+        )
+    )
+
+    assert result["status"] == "failed"
+    assert result["failure_stage"] == "agent_install_canary"
+    assert result["agent_install_canary_status"] == "failed"
+    assert result["scored_lifecycle_canary_status"] == "blocked_before_start"
+    assert result["scored_launch_allowed"] is False
+    assert result["cleanup_status"] == "completed"
+
+
 def test_formal_run_lifecycle_receipt_projects_live_worker_without_private_logs(
     tmp_path: Path,
 ) -> None:
@@ -420,6 +529,45 @@ def test_setup_only_agent_install_canary_requires_setup_only_mode() -> None:
                 "--task-id",
                 "flink-query",
                 "--setup-only-agent-install-canary",
+            ]
+        )
+
+
+def test_setup_only_scored_lifecycle_canary_is_publicly_projected() -> None:
+    args = parse_args(
+        [
+            "--task-id",
+            "flink-query",
+            "--route",
+            "loopx-goal-start-product-mode",
+            "--host-local-acp-launch",
+            "--setup-only-public-preflight",
+            "--setup-only-agent-install-canary",
+            "--setup-only-scored-lifecycle-canary",
+            "--scored-lifecycle-canary-timeout-sec",
+            "90",
+        ]
+    )
+
+    plan = build_plan(args)
+    public = _public_runner_config(plan)
+    assert args.setup_only_scored_lifecycle_canary is True
+    assert plan["setup_only_scored_lifecycle_canary"] is True
+    assert public["setup_only_scored_lifecycle_canary"] is True
+    assert public["scored_lifecycle_canary_timeout_sec"] == 90
+
+
+def test_setup_only_scored_lifecycle_canary_requires_agent_install() -> None:
+    with pytest.raises(SystemExit):
+        parse_args(
+            [
+                "--task-id",
+                "flink-query",
+                "--route",
+                "loopx-goal-start-product-mode",
+                "--host-local-acp-launch",
+                "--setup-only-public-preflight",
+                "--setup-only-scored-lifecycle-canary",
             ]
         )
 

--- a/tests/test_skillsbench_turn_launcher.py
+++ b/tests/test_skillsbench_turn_launcher.py
@@ -24,6 +24,33 @@ def _base_env(tmp_path: Path) -> dict[str, str]:
     env.pop("SKILLSBENCH_RUNNER_PROFILE", None)
     env.pop("SKILLSBENCH_LOCAL_CODEX_PROXY_COMMAND", None)
     env.pop("SKILLSBENCH_REMOTE_CODEX_PROXY_PORT", None)
+    readiness_receipt = tmp_path / "scored-lifecycle-readiness.public.json"
+    readiness_receipt.write_text(
+        json.dumps(
+            {
+                "schema_version": "skillsbench_setup_only_public_preflight_v1",
+                "status": "passed",
+                "cleanup_status": "completed",
+                "scored_lifecycle_canary_status": "passed",
+                "scored_lifecycle_terminal_budget_sec": 180,
+                "case_goal_state_initialized_before_agent": True,
+                "acp_session_initialized": True,
+                "agent_active_observed": True,
+                "loopx_state_read_count": 1,
+                "loopx_state_write_count": 1,
+                "task_prompt_sent": False,
+                "benchmark_task_launched": False,
+                "agent_execution_invoked": False,
+                "verifier_invoked": False,
+                "scored_launch_allowed": True,
+                "loopx_runner_source_git_head": "abc1234def5678",
+                "loopx_runner_source_matches_expected": True,
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     env.update(
         {
             "XDG_STATE_HOME": str(tmp_path / "state"),
@@ -31,6 +58,9 @@ def _base_env(tmp_path: Path) -> dict[str, str]:
             "SKILLSBENCH_REMOTE_ROOT": "/remote/loopx",
             "SKILLSBENCH_ROOT": "/remote/skillsbench",
             "SKILLSBENCH_EXPECTED_LOOPX_GIT_HEAD": "abc1234",
+            "SKILLSBENCH_SCORED_LIFECYCLE_READINESS_RECEIPT": str(
+                readiness_receipt
+            ),
             "SKILLSBENCH_DOCKER_PROXY_HOST": "host.docker.internal",
             "SKILLSBENCH_DOCKER_API_VERSION": "1.43",
             "SKILLSBENCH_RUN_STAMP": "20260716T000000CST",
@@ -942,6 +972,9 @@ def test_setup_only_launcher_enables_incremental_public_artifact_sync(
     env = _base_env(tmp_path)
     env["SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT"] = "1"
     env["SKILLSBENCH_SETUP_ONLY_AGENT_INSTALL_CANARY"] = "1"
+    env["SKILLSBENCH_SETUP_ONLY_SCORED_LIFECYCLE_CANARY"] = "1"
+    env["SKILLSBENCH_SCORED_LIFECYCLE_CANARY_TIMEOUT_SEC"] = "90"
+    env["SKILLSBENCH_ROUTE"] = "loopx-goal-start-product-mode"
     env["SKILLSBENCH_APPEND_HISTORY"] = "1"
 
     proc = subprocess.run(
@@ -959,7 +992,11 @@ def test_setup_only_launcher_enables_incremental_public_artifact_sync(
     assert "--public-artifact-sync-interval-sec 30" in proc.stdout
     assert "--setup-only-public-preflight" in proc.stdout
     assert "--setup-only-agent-install-canary" in proc.stdout
+    assert "--setup-only-scored-lifecycle-canary" in proc.stdout
+    assert "--scored-lifecycle-canary-timeout-sec 90" in proc.stdout
     assert "setup_only_agent_install_canary=1" in proc.stdout
+    assert "setup_only_scored_lifecycle_canary=1" in proc.stdout
+    assert "scored_lifecycle_readiness=canary_will_generate_receipt" in proc.stdout
     assert "--append-history" not in proc.stdout
 
 
@@ -984,6 +1021,30 @@ def test_launcher_rejects_agent_install_canary_without_setup_only(
         "SKILLSBENCH_SETUP_ONLY_AGENT_INSTALL_CANARY requires "
         "SKILLSBENCH_SETUP_ONLY_PUBLIC_PREFLIGHT=1"
     ) in proc.stderr
+
+
+def test_launcher_blocks_live_scored_launch_without_lifecycle_receipt(
+    tmp_path: Path,
+) -> None:
+    env = _base_env(tmp_path)
+    env.pop("SKILLSBENCH_SCORED_LIFECYCLE_READINESS_RECEIPT")
+
+    proc = subprocess.run(
+        [str(LAUNCHER), "public-smoke-case", "missing-lifecycle-receipt"],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 3
+    assert (
+        "SKILLSBENCH_SCORED_LIFECYCLE_READINESS_RECEIPT is required before "
+        "scored launch"
+    ) in proc.stderr
+    assert "pid=" not in proc.stdout
 
 
 def test_formal_launcher_enables_incremental_public_artifact_sync(


### PR DESCRIPTION
## Summary
- add a task-free, scored-equivalent ACP lifecycle canary that reuses the scored install and case-state seed path
- require `agent_active` plus one case-local LoopX state read/write under a strict 300-second maximum budget
- gate every live scored launch on a cleanup-complete, revision-pinned public receipt

## Validation
- `python -m mypy`
- 125 focused SkillsBench tests
- `python examples/skillsbench-benchmark-run-smoke.py`
- six risk-selected premerge catalog canaries
- changed-file Ruff checks and public/private boundary scan

No benchmark task or verifier was launched.