### PR TITLE
fix(install): verify fixed-installer skill readback

### DIFF
--- a/docs/reference/protocols/host-integration-surface-v0.md
+++ b/docs/reference/protocols/host-integration-surface-v0.md
@@ -95,10 +95,12 @@ target, a canary-only install leaves the existing default skill root unchanged.
 
 The installer is the sole owner of filesystem mutation. The manifest records
 the materialized skill ids, source revision, and per-skill content digests so
-read-only host checks can verify delivery without becoming a second installer.
-Filesystem materialization is distinct from the host's runtime loaded-skill
-readback; the latter is still required before claiming that the skills were
-injected into an active agent context.
+onboarding and doctor can verify delivery read-only without becoming a second
+installer. Run both with the same `LOOPX_SKILLS_DIR`; they report the
+filesystem readback status and source revision. Filesystem materialization is
+distinct from the host's runtime loaded-skill readback; the latter is still
+required before claiming that the skills were injected into an active agent
+context.
 
 Local-development and cloud transports must send the exact same `task_body` as
 their goal prompt. They may differ in endpoint, authentication, session id, or

--- a/docs/reference/protocols/host-integration-surface-v0.md
+++ b/docs/reference/protocols/host-integration-surface-v0.md
@@ -68,11 +68,22 @@ loopx heartbeat-prompt --thin --goal-id <GOAL_ID> --agent-id <AGENT_ID> \
   --runtime-profile ark_managed_agent_goal
 ```
 
-The same contract is available through first-class onboarding with
-`--agent-type ark-managed-agent`. Because this host does not use a
-Codex-specific skill directory, onboarding requires host-managed delivery and
-readback of the LoopX workflow skills from the same LoopX revision as the CLI.
-The fixed installer is shared with Codex; only its target root changes:
+The same contract is visible through first-class onboarding with
+`--agent-type ark-managed-agent`. Onboarding is a read-only verifier, not an
+installer or an installation prerequisite. Because this host does not use a
+Codex-specific skill directory, the fixed installer shared with Codex writes
+the LoopX workflow skills into a host-native target root. The packaged
+no-clone path is:
+
+```bash
+curl -fsSL \
+  https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh \
+  | env LOOPX_SKILLS_DIR=<PROJECT_WORKSPACE>/.agents/skills \
+      LOOPX_ENTRY_HOST_SURFACE=ark-managed-agent \
+      LOOPX_INSTALL_SLASH_COMMANDS=0 bash
+```
+
+For a contributor checkout, the equivalent command is:
 
 ```bash
 LOOPX_SKILLS_DIR=<PROJECT_WORKSPACE>/.agents/skills \
@@ -93,14 +104,17 @@ install time, and its start-goal transaction preserves that host, task text,
 and declared capabilities across bootstrap inspection. Without an explicit
 target, a canary-only install leaves the existing default skill root unchanged.
 
-The installer is the sole owner of filesystem mutation. The manifest records
-the materialized skill ids, source revision, and per-skill content digests so
-onboarding and doctor can verify delivery read-only without becoming a second
-installer. Run both with the same `LOOPX_SKILLS_DIR`; they report the
-filesystem readback status and source revision. Filesystem materialization is
-distinct from the host's runtime loaded-skill readback; the latter is still
-required before claiming that the skills were injected into an active agent
-context.
+The installer is the sole owner of filesystem mutation for both Codex and Ark
+Managed Agent. Its default target is the Codex skill root; Ark Managed Agent
+supplies a host-native `LOOPX_SKILLS_DIR` and binds the generated entry with
+`LOOPX_ENTRY_HOST_SURFACE`. The manifest records the materialized skill ids,
+source revision, and per-skill content digests so `doctor` and onboarding can
+verify delivery read-only without becoming second installers. Running either
+check is optional for installation. Run a check with the same
+`LOOPX_SKILLS_DIR` to report the filesystem readback status and source
+revision. Filesystem materialization is distinct from the host's runtime
+loaded-skill readback; the latter is still required before claiming that the
+skills were injected into an active agent context.
 
 Local-development and cloud transports must send the exact same `task_body` as
 their goal prompt. They may differ in endpoint, authentication, session id, or

--- a/loopx/agent_onboarding.py
+++ b/loopx/agent_onboarding.py
@@ -27,7 +27,6 @@ from .skill_install_readback import (
     inspect_skill_install_readback,
 )
 
-
 SCHEMA_VERSION = "loopx_agent_onboarding_v0"
 HOST_SKILL_DELIVERY_SCHEMA_VERSION = "loopx_host_skill_delivery_v0"
 REQUIRED_HOST_SKILL_IDS = ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS
@@ -173,7 +172,18 @@ def _skill_delivery_contract(
         **(
             {
                 "preferred_delivery": "fixed_install_script",
+                "onboarding_role": "read_only_verifier",
+                "onboarding_required_for_install": False,
                 "install_script": "scripts/install-local.sh",
+                "no_clone_install_command": (
+                    "curl -fsSL "
+                    "https://raw.githubusercontent.com/huangruiteng/loopx/main/"
+                    "scripts/install-from-github.sh"
+                    " | env "
+                    f"LOOPX_SKILLS_DIR={shell_arg(f'{project}/.agents/skills')} "
+                    "LOOPX_ENTRY_HOST_SURFACE=ark-managed-agent "
+                    "LOOPX_INSTALL_SLASH_COMMANDS=0 bash"
+                ),
                 "skills_dir_env": "LOOPX_SKILLS_DIR",
                 "entry_host_surface_env": "LOOPX_ENTRY_HOST_SURFACE",
                 "entry_host_surface": "ark-managed-agent",
@@ -508,6 +518,11 @@ def render_agent_onboarding_markdown(payload: dict[str, Any]) -> str:
                 "## Host-Managed Skill Delivery",
                 "",
                 f"- owner: `{skill_delivery.get('owner')}`",
+                f"- onboarding_role: `{skill_delivery.get('onboarding_role')}`",
+                (
+                    "- onboarding_required_for_install: "
+                    f"`{skill_delivery.get('onboarding_required_for_install')}`"
+                ),
                 f"- required_for_cli_health: `{skill_delivery.get('required_for_cli_health')}`",
                 f"- required_for_loopx_workflow: `{skill_delivery.get('required_for_loopx_workflow')}`",
                 f"- delivery_options: `{','.join(skill_delivery.get('delivery_options') or [])}`",
@@ -519,6 +534,15 @@ def render_agent_onboarding_markdown(payload: dict[str, Any]) -> str:
                 f"- source_contract: {skill_delivery.get('source_contract')}",
             ]
         )
+        if skill_delivery.get("no_clone_install_command"):
+            lines.extend(
+                [
+                    "",
+                    "```bash",
+                    str(skill_delivery["no_clone_install_command"]),
+                    "```",
+                ]
+            )
         filesystem_readback = skill_delivery.get("filesystem_readback")
         if isinstance(filesystem_readback, dict):
             lines.extend(

--- a/loopx/agent_onboarding.py
+++ b/loopx/agent_onboarding.py
@@ -146,6 +146,7 @@ def _skill_delivery_contract(
         inspect_skill_install_readback(
             skills_dir=host_skills_dir,
             required_skill_ids=REQUIRED_HOST_SKILL_IDS,
+            source_root=Path(__file__).resolve().parents[1],
         )
         if ark_managed_agent
         else None
@@ -551,6 +552,10 @@ def render_agent_onboarding_markdown(payload: dict[str, Any]) -> str:
                     f"- filesystem_readback_ready: `{filesystem_readback.get('ready')}`",
                     f"- filesystem_readback_skills_dir: `{filesystem_readback.get('skills_dir')}`",
                     f"- filesystem_readback_source_revision: `{filesystem_readback.get('source_revision')}`",
+                    (
+                        "- filesystem_readback_source_revision_matches: "
+                        f"`{filesystem_readback.get('source_revision_matches')}`"
+                    ),
                     (
                         "- filesystem_readback_materialized_skill_ids: "
                         f"`{','.join(filesystem_readback.get('materialized_skill_ids') or [])}`"

--- a/loopx/agent_onboarding.py
+++ b/loopx/agent_onboarding.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -20,17 +21,16 @@ from .project_prompt import (
     shell_arg,
 )
 from .registry import read_json, registry_goals
+from .skill_install_readback import (
+    ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS,
+    configured_host_skills_dir,
+    inspect_skill_install_readback,
+)
 
 
 SCHEMA_VERSION = "loopx_agent_onboarding_v0"
 HOST_SKILL_DELIVERY_SCHEMA_VERSION = "loopx_host_skill_delivery_v0"
-REQUIRED_HOST_SKILL_IDS = [
-    "loopx",
-    "loopx-project",
-    "loopx-pr-review",
-    "loopx-doc-registry",
-    "loopx-self-repair",
-]
+REQUIRED_HOST_SKILL_IDS = ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS
 CHANGE_QUALITY_SKILL_ID = "loopx-change-quality"
 
 
@@ -93,6 +93,7 @@ def _skill_delivery_contract(
     project: str = ".",
     cli_bin: str = "loopx",
     active_project_skill_ids: list[str] | None = None,
+    host_skills_dir: Path | None = None,
 ) -> dict[str, Any]:
     active_project_skills = list(dict.fromkeys(active_project_skill_ids or []))
     project_surface = _project_skill_surface(agent_type)
@@ -142,11 +143,23 @@ def _skill_delivery_contract(
         *active_project_skills,
     ]
     ark_managed_agent = agent_type == "ark-managed-agent"
+    filesystem_readback = (
+        inspect_skill_install_readback(
+            skills_dir=host_skills_dir,
+            required_skill_ids=REQUIRED_HOST_SKILL_IDS,
+        )
+        if ark_managed_agent
+        else None
+    )
     return {
         "schema_version": HOST_SKILL_DELIVERY_SCHEMA_VERSION,
         "mode": "host_managed",
         "owner": "loopx_install_script" if ark_managed_agent else "custom_agent_host",
-        "status": "pending_host_readback",
+        "status": (
+            str(filesystem_readback["status"])
+            if filesystem_readback
+            else "pending_host_readback"
+        ),
         "codex_skills_root_required": False,
         "required_for_cli_health": False,
         "required_for_loopx_workflow": True,
@@ -165,6 +178,8 @@ def _skill_delivery_contract(
                 "entry_host_surface_env": "LOOPX_ENTRY_HOST_SURFACE",
                 "entry_host_surface": "ark-managed-agent",
                 "target_layout": f"{project}/.agents/skills",
+                "fixed_installer_skill_ids": REQUIRED_HOST_SKILL_IDS,
+                "filesystem_readback": filesystem_readback,
             }
             if ark_managed_agent
             else {}
@@ -298,6 +313,7 @@ def build_agent_onboarding_packet(
         project=resolved_project,
         cli_bin=cli_bin,
         active_project_skill_ids=active_project_skill_ids,
+        host_skills_dir=configured_host_skills_dir(os.environ),
     )
     registered_agents = registered_agent_ids_from_registry(
         registry_path,
@@ -503,6 +519,20 @@ def render_agent_onboarding_markdown(payload: dict[str, Any]) -> str:
                 f"- source_contract: {skill_delivery.get('source_contract')}",
             ]
         )
+        filesystem_readback = skill_delivery.get("filesystem_readback")
+        if isinstance(filesystem_readback, dict):
+            lines.extend(
+                [
+                    f"- filesystem_readback_status: `{filesystem_readback.get('status')}`",
+                    f"- filesystem_readback_ready: `{filesystem_readback.get('ready')}`",
+                    f"- filesystem_readback_skills_dir: `{filesystem_readback.get('skills_dir')}`",
+                    f"- filesystem_readback_source_revision: `{filesystem_readback.get('source_revision')}`",
+                    (
+                        "- filesystem_readback_materialized_skill_ids: "
+                        f"`{','.join(filesystem_readback.get('materialized_skill_ids') or [])}`"
+                    ),
+                ]
+            )
     lines.extend(["", "```bash", str(commands.get("bootstrap_command_pack") or ""), "```"])
     if commands.get("codex_cli_bootstrap_message"):
         lines.extend(["", "```bash", str(commands.get("codex_cli_bootstrap_message")), "```"])

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -17,6 +17,11 @@ from .paths import DEFAULT_RUNTIME_ROOT, global_registry_path
 from .project_skill_delivery import discover_project_scoped_skill_ids
 from .registry_writability import probe_registry_write_path
 from .release_manifest import load_release_manifest, release_version_tag
+from .skill_install_readback import (
+    ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS,
+    configured_host_skills_dir,
+    inspect_skill_install_readback,
+)
 
 
 PROMOTION_READINESS_CLASSIFICATIONS = {
@@ -717,6 +722,14 @@ def collect_doctor(
         and agent_type_uses_host_managed_skills(canonical_agent_type)
     )
     installed_skills_required = not host_managed_skill_delivery
+    host_skill_install_readback = (
+        inspect_skill_install_readback(
+            skills_dir=configured_host_skills_dir(os.environ),
+            required_skill_ids=ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS,
+        )
+        if canonical_agent_type == "ark-managed-agent"
+        else None
+    )
     loopx_path = resolve_command_path("loopx")
     invocation_path = current_script_invocation_path()
     loopx_canary_path = resolve_command_path("loopx-canary")
@@ -812,6 +825,19 @@ def collect_doctor(
         require_installed_skills=installed_skills_required,
         doctor_agent_type=canonical_agent_type,
     )
+    if installed_skills_required:
+        skill_delivery_status = (
+            "ready"
+            if all(
+                skill.get("exists") and skill.get("required_phrases")
+                for skill in skills.values()
+            )
+            else "repair_recommended"
+        )
+    elif host_skill_install_readback:
+        skill_delivery_status = str(host_skill_install_readback["status"])
+    else:
+        skill_delivery_status = "external_readback_required"
     skill_delivery = {
         "agent_type": canonical_agent_type,
         "owner": (
@@ -826,16 +852,11 @@ def collect_doctor(
         "mode": "surface_managed" if installed_skills_required else "host_managed",
         "codex_skills_root_applicable": installed_skills_required,
         "installed_skills_required_for_freshness": installed_skills_required,
-        "status": (
-            "ready"
-            if installed_skills_required
-            and all(
-                skill.get("exists") and skill.get("required_phrases")
-                for skill in skills.values()
-            )
-            else "repair_recommended"
-            if installed_skills_required
-            else "external_readback_required"
+        "status": skill_delivery_status,
+        **(
+            {"filesystem_readback": host_skill_install_readback}
+            if host_skill_install_readback
+            else {}
         ),
     }
     default_global_registry = global_registry_path(DEFAULT_RUNTIME_ROOT)
@@ -974,6 +995,19 @@ def collect_doctor(
                 else ",".join(globally_visible_project_skills)
             ),
         },
+        *(
+            [
+                {
+                    "id": "host_skill_installation_readback",
+                    "required": False,
+                    "ok": bool(host_skill_install_readback.get("ready")),
+                    "applicable": True,
+                    "detail": str(host_skill_install_readback.get("reason")),
+                }
+            ]
+            if host_skill_install_readback
+            else []
+        ),
         {
             "id": "global_registry_writable",
             "required": True,
@@ -1039,8 +1073,15 @@ def collect_doctor(
         "globally_visible_project_skills": globally_visible_project_skills,
         "checks": checks,
         "fix": (
-            "Do not infer custom-host skill delivery from `~/.codex/skills`; "
-            "verify the host-managed loaded-skill readback from `loopx agent-onboard`."
+            "Set `LOOPX_SKILLS_DIR=<PROJECT_WORKSPACE>/.agents/skills` and rerun "
+            f"`{repo_root / 'scripts' / 'install-local.sh'}`; then rerun doctor "
+            "with the same environment. Filesystem readback proves materialization; "
+            "the host must still report its runtime loaded-skill readback."
+            if canonical_agent_type == "ark-managed-agent"
+            else (
+                "Do not infer custom-host skill delivery from `~/.codex/skills`; "
+                "verify the host-managed loaded-skill readback from `loopx agent-onboard`."
+            )
             if canonical_agent_type
             and agent_type_uses_host_managed_skills(canonical_agent_type)
             else (

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -726,6 +726,7 @@ def collect_doctor(
         inspect_skill_install_readback(
             skills_dir=configured_host_skills_dir(os.environ),
             required_skill_ids=ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS,
+            source_root=Path(__file__).resolve().parents[1],
         )
         if canonical_agent_type == "ark-managed-agent"
         else None

--- a/loopx/skill_install_readback.py
+++ b/loopx/skill_install_readback.py
@@ -14,6 +14,16 @@ SKILL_INSTALL_READBACK_SCHEMA_VERSION = "loopx_skill_install_readback_v0"
 SKILL_INSTALL_READBACK_FILENAME = ".loopx-skill-install.json"
 SKILL_INSTALL_OWNER = "loopx_install_script"
 SKILL_INSTALL_INTEGRATION_MODE = "fixed_install_script"
+PACKAGED_HOST_SKILL_IDS = [
+    "loopx-project",
+    "loopx-pr-review",
+    "loopx-doc-registry",
+    "loopx-self-repair",
+]
+ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS = [
+    "loopx",
+    *PACKAGED_HOST_SKILL_IDS,
+]
 
 
 def _sha256_file(path: Path) -> str:
@@ -171,3 +181,124 @@ def write_skill_install_readback(
         temporary = Path(handle.name)
     os.replace(temporary, target)
     return target
+
+
+def configured_host_skills_dir(env: Mapping[str, str]) -> Path | None:
+    value = env.get("LOOPX_SKILLS_DIR")
+    return Path(value).expanduser() if value and value.strip() else None
+
+
+def inspect_skill_install_readback(
+    *,
+    skills_dir: Path | None,
+    required_skill_ids: Sequence[str],
+) -> dict[str, Any]:
+    required_ids = sorted(
+        {skill_id.strip() for skill_id in required_skill_ids if skill_id.strip()}
+    )
+    if skills_dir is None:
+        return {
+            "schema_version": SKILL_INSTALL_READBACK_SCHEMA_VERSION,
+            "status": "skills_dir_not_configured",
+            "ready": False,
+            "skills_dir": None,
+            "manifest_path": None,
+            "required_skill_ids": required_ids,
+            "materialized_skill_ids": [],
+            "missing_skill_ids": required_ids,
+            "digest_mismatches": [],
+            "integrity_ok": False,
+            "integration_mode": None,
+            "source_revision": None,
+            "source_dirty": None,
+            "reason": "LOOPX_SKILLS_DIR is not configured for this host check",
+        }
+
+    root = skills_dir.expanduser()
+    manifest_path = root / SKILL_INSTALL_READBACK_FILENAME
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        manifest = None
+        manifest_error = "install readback manifest is missing"
+    except (OSError, json.JSONDecodeError) as error:
+        manifest = None
+        manifest_error = f"install readback manifest is unreadable: {error}"
+    else:
+        manifest_error = None
+
+    materialized_ids = sorted(
+        skill_id
+        for skill_id in required_ids
+        if (root / skill_id / "SKILL.md").is_file()
+    )
+    missing_ids = sorted(set(required_ids) - set(materialized_ids))
+    manifest_skills = (
+        manifest.get("skills")
+        if isinstance(manifest, dict) and isinstance(manifest.get("skills"), dict)
+        else {}
+    )
+    manifest_items = (
+        manifest_skills.get("items")
+        if isinstance(manifest_skills.get("items"), dict)
+        else {}
+    )
+    digest_mismatches = [
+        skill_id
+        for skill_id in materialized_ids
+        if manifest_items.get(skill_id) != hash_skill_tree(root / skill_id)
+    ]
+    manifest_ids = (
+        {str(skill_id) for skill_id in manifest.get("materialized_skill_ids")}
+        if isinstance(manifest, dict)
+        and isinstance(manifest.get("materialized_skill_ids"), list)
+        else set()
+    )
+    source = (
+        manifest.get("source")
+        if isinstance(manifest, dict) and isinstance(manifest.get("source"), dict)
+        else {}
+    )
+    manifest_valid = bool(
+        isinstance(manifest, dict)
+        and manifest.get("schema_version") == SKILL_INSTALL_READBACK_SCHEMA_VERSION
+        and manifest.get("owner") == SKILL_INSTALL_OWNER
+        and manifest.get("integration_mode") == SKILL_INSTALL_INTEGRATION_MODE
+        and set(required_ids).issubset(manifest_ids)
+        and source.get("revision")
+    )
+    integrity_ok = manifest_valid and not digest_mismatches
+    ready = not missing_ids and integrity_ok
+    if ready:
+        status = "ready_for_host_load"
+        reason = "required workflow skills match the fixed-installer readback"
+    elif manifest_error:
+        status, reason = "manifest_missing_or_invalid", manifest_error
+    elif missing_ids:
+        status = "required_skills_missing"
+        reason = f"missing required workflow skills: {','.join(missing_ids)}"
+    elif digest_mismatches:
+        status = "skill_digest_mismatch"
+        reason = f"skill content differs from install readback: {','.join(digest_mismatches)}"
+    else:
+        status = "manifest_contract_invalid"
+        reason = "install readback does not satisfy the fixed-installer contract"
+
+    return {
+        "schema_version": SKILL_INSTALL_READBACK_SCHEMA_VERSION,
+        "status": status,
+        "ready": ready,
+        "skills_dir": str(root),
+        "manifest_path": str(manifest_path),
+        "required_skill_ids": required_ids,
+        "materialized_skill_ids": materialized_ids,
+        "missing_skill_ids": missing_ids,
+        "digest_mismatches": digest_mismatches,
+        "integrity_ok": integrity_ok,
+        "integration_mode": manifest.get("integration_mode")
+        if isinstance(manifest, dict)
+        else None,
+        "source_revision": source.get("revision"),
+        "source_dirty": source.get("git_dirty"),
+        "reason": reason,
+    }

--- a/loopx/skill_install_readback.py
+++ b/loopx/skill_install_readback.py
@@ -73,7 +73,21 @@ def _git_value(root: Path, *args: str) -> str | None:
     return result.stdout.strip() or None
 
 
-def _source_readback(source_root: Path) -> dict[str, Any]:
+def _source_readback(
+    source_root: Path,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    source_env = os.environ if env is None else env
+    resolved_commit = source_env.get("LOOPX_RESOLVED_SOURCE_GIT_COMMIT")
+    if resolved_commit:
+        return {
+            "kind": "github_archive",
+            "revision": resolved_commit,
+            "revision_kind": "git_commit",
+            "git_dirty": False,
+        }
+
     release_manifest_path = source_root / "release.json"
     try:
         release_manifest = json.loads(release_manifest_path.read_text(encoding="utf-8"))
@@ -112,6 +126,11 @@ def _source_readback(source_root: Path) -> dict[str, Any]:
         "revision_kind": "git_commit" if commit else None,
         "git_dirty": bool(status) if commit is not None else None,
     }
+
+
+def _source_revision_for_root(source_root: Path) -> str | None:
+    revision = _source_readback(source_root, env={}).get("revision")
+    return str(revision) if revision else None
 
 
 def _skills_digest(items: Mapping[str, Any]) -> str:
@@ -192,7 +211,11 @@ def inspect_skill_install_readback(
     *,
     skills_dir: Path | None,
     required_skill_ids: Sequence[str],
+    source_root: Path | None = None,
 ) -> dict[str, Any]:
+    expected_source_revision = (
+        _source_revision_for_root(source_root) if source_root else None
+    )
     required_ids = sorted(
         {skill_id.strip() for skill_id in required_skill_ids if skill_id.strip()}
     )
@@ -208,8 +231,11 @@ def inspect_skill_install_readback(
             "missing_skill_ids": required_ids,
             "digest_mismatches": [],
             "integrity_ok": False,
+            "manifest_digest_valid": False,
             "integration_mode": None,
             "source_revision": None,
+            "expected_source_revision": expected_source_revision,
+            "source_revision_matches": None,
             "source_dirty": None,
             "reason": "LOOPX_SKILLS_DIR is not configured for this host check",
         }
@@ -259,15 +285,30 @@ def inspect_skill_install_readback(
         if isinstance(manifest, dict) and isinstance(manifest.get("source"), dict)
         else {}
     )
+    source_revision = source.get("revision")
+    source_revision_matches = (
+        source_revision == expected_source_revision
+        if source_revision and expected_source_revision
+        else None
+    )
     manifest_valid = bool(
         isinstance(manifest, dict)
         and manifest.get("schema_version") == SKILL_INSTALL_READBACK_SCHEMA_VERSION
         and manifest.get("owner") == SKILL_INSTALL_OWNER
         and manifest.get("integration_mode") == SKILL_INSTALL_INTEGRATION_MODE
         and set(required_ids).issubset(manifest_ids)
-        and source.get("revision")
+        and source_revision
     )
-    integrity_ok = manifest_valid and not digest_mismatches
+    manifest_digest_valid = bool(
+        isinstance(manifest_skills.get("digest"), str)
+        and manifest_skills.get("digest") == _skills_digest(manifest_items)
+    )
+    integrity_ok = (
+        manifest_valid
+        and manifest_digest_valid
+        and not digest_mismatches
+        and source_revision_matches is not False
+    )
     ready = not missing_ids and integrity_ok
     if ready:
         status = "ready_for_host_load"
@@ -277,9 +318,21 @@ def inspect_skill_install_readback(
     elif missing_ids:
         status = "required_skills_missing"
         reason = f"missing required workflow skills: {','.join(missing_ids)}"
+    elif not manifest_valid:
+        status = "manifest_contract_invalid"
+        reason = "install readback does not satisfy the fixed-installer contract"
+    elif not manifest_digest_valid:
+        status = "manifest_digest_mismatch"
+        reason = "install readback skill manifest digest does not match its items"
     elif digest_mismatches:
         status = "skill_digest_mismatch"
         reason = f"skill content differs from install readback: {','.join(digest_mismatches)}"
+    elif source_revision_matches is False:
+        status = "source_revision_mismatch"
+        reason = (
+            "installed workflow skills came from a different LoopX revision "
+            "than the active CLI"
+        )
     else:
         status = "manifest_contract_invalid"
         reason = "install readback does not satisfy the fixed-installer contract"
@@ -295,10 +348,13 @@ def inspect_skill_install_readback(
         "missing_skill_ids": missing_ids,
         "digest_mismatches": digest_mismatches,
         "integrity_ok": integrity_ok,
+        "manifest_digest_valid": manifest_digest_valid,
         "integration_mode": manifest.get("integration_mode")
         if isinstance(manifest, dict)
         else None,
-        "source_revision": source.get("revision"),
+        "source_revision": source_revision,
+        "expected_source_revision": expected_source_revision,
+        "source_revision_matches": source_revision_matches,
         "source_dirty": source.get("git_dirty"),
         "reason": reason,
     }

--- a/tests/test_ark_managed_agent_host.py
+++ b/tests/test_ark_managed_agent_host.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 from loopx.agent_onboarding import (
@@ -17,6 +18,31 @@ from loopx.host_loop_activation import (
     agent_type_uses_host_managed_skills,
     build_host_loop_activation_packet,
 )
+from loopx.skill_install_readback import (
+    PACKAGED_HOST_SKILL_IDS,
+    inspect_skill_install_readback,
+    write_skill_install_readback,
+)
+from loopx.slash_command_install import materialize_loopx_entry_skill
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _materialize_workflow_skills(skills_dir: Path) -> None:
+    for skill_id in PACKAGED_HOST_SKILL_IDS:
+        shutil.copytree(REPO_ROOT / "skills" / skill_id, skills_dir / skill_id)
+    entry = materialize_loopx_entry_skill(
+        skills_dir=skills_dir,
+        execute=True,
+        host_surface="ark-managed-agent",
+    )
+    assert entry["status"] == "created"
+    write_skill_install_readback(
+        skills_dir=skills_dir,
+        skill_ids=REQUIRED_HOST_SKILL_IDS,
+        source_root=REPO_ROOT,
+    )
 
 
 CONTINUITY_GOAL_ID = "managed-agent-continuity-fixture"
@@ -114,7 +140,8 @@ def test_host_activation_submits_one_goal_without_turn_or_automation() -> None:
     assert "loopx turn run-once" not in str(packet).lower()
 
 
-def test_host_requires_host_managed_loopx_skill_delivery() -> None:
+def test_host_requires_host_managed_loopx_skill_delivery(monkeypatch) -> None:
+    monkeypatch.delenv("LOOPX_SKILLS_DIR", raising=False)
     contract = _skill_delivery_contract("ark-managed-agent")
 
     assert contract["mode"] == "host_managed"
@@ -130,6 +157,8 @@ def test_host_requires_host_managed_loopx_skill_delivery() -> None:
     assert contract["target_layout"] == "./.agents/skills"
     assert contract["generated_skill_ids"] == ["loopx"]
     assert "skills/loopx" not in contract["source_directories"]
+    assert contract["fixed_installer_skill_ids"] == REQUIRED_HOST_SKILL_IDS
+    assert contract["filesystem_readback"]["status"] == "skills_dir_not_configured"
     assert agent_type_uses_host_managed_skills("ark-managed-agent") is True
 
 
@@ -143,17 +172,70 @@ def test_host_onboarding_starts_from_loopx_skill_before_goal_submission() -> Non
     assert "submit the generated Goal task body exactly once" in instruction
 
 
-def test_doctor_checks_host_readback_instead_of_codex_skill_root() -> None:
+def test_doctor_checks_host_installation_readback_instead_of_codex_skill_root(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    skills_dir = tmp_path / "workspace" / ".agents" / "skills"
+    _materialize_workflow_skills(skills_dir)
+    monkeypatch.setenv("LOOPX_SKILLS_DIR", str(skills_dir))
+
     payload = collect_doctor(agent_type="ark-managed-agent")
 
     assert payload["skill_delivery"]["mode"] == "host_managed"
     assert payload["skill_delivery"]["owner"] == "loopx_install_script"
     assert payload["skill_delivery"]["codex_skills_root_applicable"] is False
+    readback = payload["skill_delivery"]["filesystem_readback"]
+    assert readback["status"] == "ready_for_host_load"
+    assert readback["ready"] is True
+    assert readback["source_revision"]
     skill_checks = {
         item["id"]: item for item in payload["checks"] if item["id"].startswith("installed_")
     }
     assert skill_checks
     assert all(item["applicable"] is False for item in skill_checks.values())
+    host_check = next(
+        item
+        for item in payload["checks"]
+        if item["id"] == "host_skill_installation_readback"
+    )
+    assert host_check["ok"] is True
+    assert host_check["required"] is False
+
+
+def test_onboarding_projects_verified_filesystem_readback(
+    tmp_path: Path,
+) -> None:
+    skills_dir = tmp_path / ".agents" / "skills"
+    _materialize_workflow_skills(skills_dir)
+
+    contract = _skill_delivery_contract(
+        "ark-managed-agent",
+        host_skills_dir=skills_dir,
+    )
+
+    assert contract["status"] == "ready_for_host_load"
+    assert contract["filesystem_readback"]["ready"] is True
+    assert contract["host_readback_required"] is True
+
+
+def test_skill_readback_rejects_content_changed_after_install(tmp_path: Path) -> None:
+    skills_dir = tmp_path / ".agents" / "skills"
+    _materialize_workflow_skills(skills_dir)
+    skill_path = skills_dir / REQUIRED_HOST_SKILL_IDS[0] / "SKILL.md"
+    skill_path.write_text(
+        skill_path.read_text(encoding="utf-8") + "\npost-install mutation\n",
+        encoding="utf-8",
+    )
+
+    readback = inspect_skill_install_readback(
+        skills_dir=skills_dir,
+        required_skill_ids=REQUIRED_HOST_SKILL_IDS,
+    )
+
+    assert readback["ready"] is False
+    assert readback["status"] == "skill_digest_mismatch"
+    assert readback["digest_mismatches"] == [REQUIRED_HOST_SKILL_IDS[0]]
 
 
 def _write_continuity_fixture(tmp_path: Path) -> tuple[Path, Path, Path]:

--- a/tests/test_ark_managed_agent_host.py
+++ b/tests/test_ark_managed_agent_host.py
@@ -25,7 +25,6 @@ from loopx.skill_install_readback import (
 )
 from loopx.slash_command_install import materialize_loopx_entry_skill
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -150,7 +149,17 @@ def test_host_requires_host_managed_loopx_skill_delivery(monkeypatch) -> None:
     assert contract["host_readback_required"] is True
     assert contract["codex_skills_root_required"] is False
     assert contract["preferred_delivery"] == "fixed_install_script"
+    assert contract["onboarding_role"] == "read_only_verifier"
+    assert contract["onboarding_required_for_install"] is False
     assert contract["install_script"] == "scripts/install-local.sh"
+    assert (
+        contract["no_clone_install_command"] == "curl -fsSL "
+        "https://raw.githubusercontent.com/huangruiteng/loopx/main/"
+        "scripts/install-from-github.sh"
+        " | env LOOPX_SKILLS_DIR=./.agents/skills "
+        "LOOPX_ENTRY_HOST_SURFACE=ark-managed-agent "
+        "LOOPX_INSTALL_SLASH_COMMANDS=0 bash"
+    )
     assert contract["skills_dir_env"] == "LOOPX_SKILLS_DIR"
     assert contract["entry_host_surface_env"] == "LOOPX_ENTRY_HOST_SURFACE"
     assert contract["entry_host_surface"] == "ark-managed-agent"

--- a/tests/test_ark_managed_agent_host.py
+++ b/tests/test_ark_managed_agent_host.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import shutil
 from pathlib import Path
 
@@ -20,6 +21,7 @@ from loopx.host_loop_activation import (
 )
 from loopx.skill_install_readback import (
     PACKAGED_HOST_SKILL_IDS,
+    SKILL_INSTALL_READBACK_FILENAME,
     inspect_skill_install_readback,
     write_skill_install_readback,
 )
@@ -245,6 +247,61 @@ def test_skill_readback_rejects_content_changed_after_install(tmp_path: Path) ->
     assert readback["ready"] is False
     assert readback["status"] == "skill_digest_mismatch"
     assert readback["digest_mismatches"] == [REQUIRED_HOST_SKILL_IDS[0]]
+
+
+def test_skill_readback_rejects_a_different_cli_source_revision(
+    tmp_path: Path,
+) -> None:
+    skills_dir = tmp_path / ".agents" / "skills"
+    _materialize_workflow_skills(skills_dir)
+    manifest_path = skills_dir / SKILL_INSTALL_READBACK_FILENAME
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["source"]["revision"] = "0" * 40
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    readback = inspect_skill_install_readback(
+        skills_dir=skills_dir,
+        required_skill_ids=REQUIRED_HOST_SKILL_IDS,
+        source_root=REPO_ROOT,
+    )
+
+    assert readback["ready"] is False
+    assert readback["status"] == "source_revision_mismatch"
+    assert readback["source_revision_matches"] is False
+
+
+def test_skill_readback_records_the_resolved_archive_revision(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    skills_dir = tmp_path / ".agents" / "skills"
+    _materialize_workflow_skills(skills_dir)
+    archive_root = tmp_path / "archive"
+    archive_root.mkdir()
+    resolved_commit = "a" * 40
+    monkeypatch.setenv("LOOPX_RESOLVED_SOURCE_GIT_COMMIT", resolved_commit)
+    write_skill_install_readback(
+        skills_dir=skills_dir,
+        skill_ids=REQUIRED_HOST_SKILL_IDS,
+        source_root=archive_root,
+    )
+    (archive_root / "release.json").write_text(
+        json.dumps({"source": {"git_commit": resolved_commit}}) + "\n",
+        encoding="utf-8",
+    )
+
+    readback = inspect_skill_install_readback(
+        skills_dir=skills_dir,
+        required_skill_ids=REQUIRED_HOST_SKILL_IDS,
+        source_root=archive_root,
+    )
+
+    assert readback["ready"] is True
+    assert readback["source_revision"] == resolved_commit
+    assert readback["source_revision_matches"] is True
 
 
 def _write_continuity_fixture(tmp_path: Path) -> tuple[Path, Path, Path]:


### PR DESCRIPTION
## What changed

- Verify the fixed installer manifest, required skill presence, source revision, and per-skill content digests.
- Make Ark Managed Agent onboarding and doctor project the filesystem readback without becoming a second installer.
- Include the generated loopx entry plus the four packaged workflow skills in the required set.
- Preserve the exact host surface in the no-clone install command and document the ownership boundary.

## Why

The already-reviewed #2625 stack was merged into its parent branch rather than main. After #2624 landed, the readback changes remained absent from main, so host checks could describe expected skills without proving the exact installed revision and contents. Rebasing the commits also exposed a newer compatibility requirement: #2645 generates a host-bound loopx entry skill, so readback and install guidance must cover that fifth skill.

The installer remains the sole filesystem writer. Onboarding and doctor are read-only verifiers, and filesystem materialization remains distinct from runtime loaded-skill readback.

## Validation

- Focused pytest: 29 passed.
- Agent onboarding host activation smoke: passed.
- Standard premerge canary: 13/13 selected checks passed; public boundary passed; no manual holds.
- Full pytest: 1622 passed, 2 skipped, 3 environment failures also reproduced on clean main. Two subprocess-import cases pass with an absolute PYTHONPATH; the remaining case requires unavailable system python3.11-venv/ensurepip.