### PR TITLE
fix(quota): preserve strict replan guidance

### DIFF
--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -30,6 +30,8 @@ from .primary_action import (
     protocol_action_text,
     protocol_first_candidate_action as _protocol_first_candidate_action,
     protocol_monitor_action as _protocol_monitor_action,
+    protocol_replan_requires_runnable_todo as _protocol_replan_requires_runnable_todo,
+    protocol_strict_replan_action as _protocol_strict_replan_action,
 )
 from .runtime_capability_reentry import build_runtime_capability_reentry_packet
 
@@ -692,30 +694,32 @@ def interaction_next_cli_actions(
             typed_quota_guard,
         ]
     if mode == "autonomous_replan":
-        replan_obligation = (
-            payload.get("autonomous_replan_obligation")
-            if isinstance(payload.get("autonomous_replan_obligation"), dict)
-            else {}
+        runnable_todo_writeback_required = (
+            _protocol_replan_requires_runnable_todo(payload)
         )
-        agent_todo_writeback_required = (
-            replan_obligation.get("agent_todo_writeback_required") is True
-        )
+        strict_replan_action = _protocol_strict_replan_action(payload)
         lane_action = _protocol_first_candidate_action(payload)
-        first_action = (
-            "run one bounded autonomous replan slice around "
-            f"{lane_action}; write back the selected todo/frontier changes"
-            if lane_action
-            else "run one bounded autonomous replan slice and write back the selected next action/todo changes"
-        )
+        if strict_replan_action:
+            first_action = strict_replan_action
+        elif lane_action:
+            first_action = (
+                "run one bounded autonomous replan slice around "
+                f"{lane_action}; write back the selected todo/frontier changes"
+            )
+        else:
+            first_action = (
+                "run one bounded autonomous replan slice and write back the "
+                "selected next action/todo changes"
+            )
         actions = [
             first_action,
         ]
-        if agent_todo_writeback_required:
+        if runnable_todo_writeback_required:
             actor_id = str(agent_identity.get("agent_id") or "").strip()
             actor_args = (
-                f" --agent-id {shlex.quote(actor_id)} --claimed-by {shlex.quote(actor_id)}"
+                f" --claimed-by {shlex.quote(actor_id)}"
                 if actor_id
-                else " --agent-id <agent-id> --claimed-by <agent-id>"
+                else " --claimed-by <agent-id>"
             )
             actions.append(
                 f"loopx todo add --goal-id {goal_id} --role agent "
@@ -723,7 +727,9 @@ def interaction_next_cli_actions(
                 f"{actor_args}"
             )
         delta_kind = (
-            "runnable_todo_set" if agent_todo_writeback_required else "<delta_kind>"
+            "runnable_todo_set"
+            if runnable_todo_writeback_required
+            else "<delta_kind>"
         )
         actions.extend([
             f"loopx refresh-state --goal-id {goal_id} --classification autonomous_replan_recorded --autonomous-replan-recorded --repair-delta-kind {delta_kind} --delivery-batch-scale <scale> --delivery-outcome <outcome>{scoped_cli_args}",

--- a/loopx/control_plane/work_items/primary_action.py
+++ b/loopx/control_plane/work_items/primary_action.py
@@ -148,6 +148,33 @@ def protocol_first_candidate_action(payload: dict[str, Any]) -> str | None:
     return protocol_action_text(payload.get("recommended_action"))
 
 
+def protocol_replan_requires_runnable_todo(payload: dict[str, Any]) -> bool:
+    replan_obligation = (
+        payload.get("autonomous_replan_obligation")
+        if isinstance(payload.get("autonomous_replan_obligation"), dict)
+        else {}
+    )
+    satisfying_delta_kinds = {
+        str(item or "").strip()
+        for item in (replan_obligation.get("satisfying_repair_delta_kinds") or [])
+        if str(item or "").strip()
+    }
+    return (
+        "runnable_todo_set" in satisfying_delta_kinds
+        or replan_obligation.get("agent_todo_writeback_required") is True
+    )
+
+
+def protocol_strict_replan_action(payload: dict[str, Any]) -> str | None:
+    if not protocol_replan_requires_runnable_todo(payload):
+        return None
+    replan_obligation = payload["autonomous_replan_obligation"]
+    return protocol_action_text(
+        replan_obligation.get("recommended_action"),
+        limit=320,
+    )
+
+
 def protocol_monitor_action(payload: dict[str, Any]) -> str | None:
     goal_id = str(payload.get("goal_id") or "")
     work_lane = (
@@ -197,6 +224,9 @@ def resolve_canonical_primary_action(payload: dict[str, Any], *, mode: str) -> s
             "write a compact blocker when it is absent"
         )
     if mode == "autonomous_replan":
+        strict_replan_action = protocol_strict_replan_action(payload)
+        if strict_replan_action:
+            return strict_replan_action
         lane_action = protocol_first_candidate_action(payload)
         if lane_action:
             return f"run one bounded autonomous replan slice around {lane_action}"

--- a/tests/control_plane/test_goal_vision_blocked_successor.py
+++ b/tests/control_plane/test_goal_vision_blocked_successor.py
@@ -503,7 +503,20 @@ def test_two_identical_blocked_successor_waits_trigger_bounded_replan() -> None:
         "frontier_identity"
     ]
 
-    guard = _quota_with_replan_runs([*polls, _vision_run()])
+    quiet_monitor = quota_todo_item(
+        todo_id=MONITOR_ID,
+        index=3,
+        text="[P2] Wait quietly for material monitor evidence.",
+        task_class="continuous_monitor",
+        claimed_by=AGENT_ID,
+        target_key="future-monitor-target",
+        cadence="1d",
+        next_due_at="2099-01-01T00:00:00+00:00",
+    )
+    guard = _quota_with_replan_runs(
+        [*polls, _vision_run()],
+        extra_agent_items=[quiet_monitor],
+    )
 
     assert guard["decision"] == "autonomous_replan_required"
     assert guard["should_run"] is True
@@ -528,7 +541,16 @@ def test_two_identical_blocked_successor_waits_trigger_bounded_replan() -> None:
     assert "watch-lane continuation" not in obligation["todo_actions"][-1]["text"]
     primary_action = guard["interaction_contract"]["agent_channel"]["primary_action"]
     assert "watch-lane continuation alone" in primary_action
+    assert "wait quietly for material monitor evidence" not in primary_action
     assert "otherwise record a no-spend wait continuation" not in primary_action
+    cli_actions = guard["interaction_contract"]["cli_channel"]["next_cli_actions"]
+    todo_add = next(action for action in cli_actions if "todo add" in action)
+    assert f"--claimed-by {AGENT_ID}" in todo_add
+    assert "--agent-id" not in todo_add
+    assert any(
+        "--repair-delta-kind runnable_todo_set" in action
+        for action in cli_actions
+    )
 
 
 def test_as_needed_blocked_successor_guidance_keeps_wait_continuation() -> None:

--- a/tests/control_plane/test_monitor_replan_agent_scope.py
+++ b/tests/control_plane/test_monitor_replan_agent_scope.py
@@ -548,6 +548,7 @@ def test_nonblocking_user_action_does_not_suppress_empty_frontier_replan() -> No
         "todo add" in action
         and "--task-class advancement_task" in action
         and f"--claimed-by {AGENT_ID}" in action
+        and "--agent-id" not in action
         for action in cli_actions
     ), cli_actions
     assert any(


### PR DESCRIPTION
## Summary

- make strict autonomous-replan obligations outrank generic quiet monitor actions
- project runnable todo writeback when either the obligation flag or its accepted repair delta requires it
- emit valid agent todo creation guidance using `--claimed-by` without the unsupported `--agent-id`
- cover the production-shaped conflict between a repeat-until-closed vision and a future-due quiet monitor

## Motivation

After repeated blocked successor waits, LoopX can require a runnable advancement todo. The quota decision already contained that obligation, but the interaction contract could still present an unrelated quiet monitor action first. That let the strongest control-plane requirement disappear at the agent-facing boundary.

This change keeps the existing obligation as the source of truth and makes both primary-action and CLI projections honor it.

## Validation

- 35 focused control-plane tests
- Ruff on the four changed files
- repository MyPy configuration
- primary-action resolution parity smoke
- quota/replan decision-plane smoke
- `loopx check` on the changed files
- risk-based premerge gate: 17 selected canaries, all passed
- `git diff --check`

No full test suite was run locally; focused tests and the risk-selected canary set cover the changed quota/interaction surfaces.

Change-quality receipt: `cqr_1ca195ac578fcdfa587b` (pass).
