### PR TITLE
refactor(quota): own scoped user gate fallback projection

### DIFF
--- a/loopx/canary/maintainability_ratchet.py
+++ b/loopx/canary/maintainability_ratchet.py
@@ -55,8 +55,8 @@ _OVERSIZED_DECISION_RETIREMENT_PLANS = {
 
 _OVERSIZED_DECISION_METRIC_CEILINGS = {
     "loopx.quota:build_quota_should_run": {
-        "statements": 291,
-        "decision_points": 185,
+        "statements": 278,
+        "decision_points": 180,
     },
 }
 

--- a/loopx/control_plane/todos/user_gate.py
+++ b/loopx/control_plane/todos/user_gate.py
@@ -145,6 +145,52 @@ def build_user_todo_notification(
     }
 
 
+def apply_scoped_user_gate_fallback_projection(
+    payload: dict[str, Any],
+    *,
+    fallback: dict[str, Any] | None,
+    replan_decision_allowed: bool,
+) -> dict[str, Any]:
+    if not fallback or replan_decision_allowed:
+        return payload
+
+    projected = dict(payload)
+    projected["scoped_user_gate_fallback"] = fallback
+    projected["should_run"] = True
+    if projected.get("decision") == "skip":
+        projected["decision"] = "safe_bypass_user_gate_fallback"
+    if projected.get("effective_action") in {"skip", "monitor_quiet_skip", None}:
+        projected["effective_action"] = "scoped_user_gate_fallback"
+
+    execution_obligation = (
+        dict(projected.get("execution_obligation"))
+        if isinstance(projected.get("execution_obligation"), dict)
+        else {}
+    )
+    execution_obligation.update(
+        {
+            "must_attempt_work": True,
+            "kind": "scoped_user_gate_fallback",
+            "minimum": "one_non_gated_fallback_segment_after_user_gate_notice",
+            "delivery_allowed": True,
+            "notify_is_execution_gate": False,
+            "contract": "scoped_user_gate_fallback",
+            "contract_obligation": fallback.get("recommended_action"),
+            "reason": fallback.get("reason"),
+        }
+    )
+    projected["execution_obligation"] = execution_obligation
+    projected["safe_bypass_allowed"] = True
+    projected["safe_bypass_kind"] = "scoped_user_gate_fallback"
+    projected["safe_bypass_policy"] = (
+        "The user gate blocks only the matched agent action scope. Surface "
+        "that gate, then advance the selected non-gated fallback; spend only "
+        "after validated writeback."
+    )
+    projected["actionable_by_codex"] = True
+    return projected
+
+
 def build_gate_prompt(
     item: dict[str, Any],
     *,

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -173,6 +173,7 @@ from .control_plane.todos.quota_summary import (
     select_quota_todo_summary,
 )
 from .control_plane.todos.user_gate import (
+    apply_scoped_user_gate_fallback_projection as _apply_scoped_user_gate_fallback_projection,
     build_gate_prompt as _build_gate_prompt,
     build_user_todo_notification as _build_user_todo_notification,
     open_todo_count as _open_todo_count,
@@ -2070,41 +2071,11 @@ def build_quota_should_run(
                     repeat_notification_reason=heartbeat_recommendation.get("reason"),
                 )
             )
-        if scoped_user_gate_fallback and not replan_decision_allowed:
-            payload["scoped_user_gate_fallback"] = scoped_user_gate_fallback
-            payload["should_run"] = True
-            if payload.get("decision") == "skip":
-                payload["decision"] = "safe_bypass_user_gate_fallback"
-            if payload.get("effective_action") in {"skip", "monitor_quiet_skip", None}:
-                payload["effective_action"] = "scoped_user_gate_fallback"
-            execution_obligation_payload = (
-                dict(payload.get("execution_obligation"))
-                if isinstance(payload.get("execution_obligation"), dict)
-                else {}
-            )
-            execution_obligation_payload.update(
-                {
-                    "must_attempt_work": True,
-                    "kind": "scoped_user_gate_fallback",
-                    "minimum": "one_non_gated_fallback_segment_after_user_gate_notice",
-                    "delivery_allowed": True,
-                    "notify_is_execution_gate": False,
-                    "contract": "scoped_user_gate_fallback",
-                    "contract_obligation": scoped_user_gate_fallback.get(
-                        "recommended_action"
-                    ),
-                    "reason": scoped_user_gate_fallback.get("reason"),
-                }
-            )
-            payload["execution_obligation"] = execution_obligation_payload
-            payload["safe_bypass_allowed"] = True
-            payload["safe_bypass_kind"] = "scoped_user_gate_fallback"
-            payload["safe_bypass_policy"] = (
-                "The user gate blocks only the matched agent action scope. Surface "
-                "that gate, then advance the selected non-gated fallback; spend only "
-                "after validated writeback."
-            )
-            payload["actionable_by_codex"] = True
+        payload = _apply_scoped_user_gate_fallback_projection(
+            payload,
+            fallback=scoped_user_gate_fallback,
+            replan_decision_allowed=replan_decision_allowed,
+        )
         payload["requires_user_action"] = bool(
             state == "operator_gate"
             or payload.get("notify_user_on_gate") is True

--- a/tests/control_plane/test_user_gate_lane_progress.py
+++ b/tests/control_plane/test_user_gate_lane_progress.py
@@ -111,6 +111,7 @@ def test_unrelated_user_gate_allows_ready_deferred_successor_replan() -> None:
     assert payload["interaction_contract"]["mode"] == "scoped_user_gate_fallback"
     assert payload["interaction_contract"]["agent_channel"]["must_attempt"] is True
     assert payload["interaction_contract"]["agent_channel"]["delivery_allowed"] is True
+    assert payload["requires_user_action"] is True
     assert "response_plan" not in payload["interaction_contract"]
     assert "replan ready deferred successor" in payload["interaction_contract"][
         "agent_channel"

--- a/tests/control_plane/test_user_todo_notification.py
+++ b/tests/control_plane/test_user_todo_notification.py
@@ -1,4 +1,7 @@
-from loopx.control_plane.todos.user_gate import build_user_todo_notification
+from loopx.control_plane.todos.user_gate import (
+    apply_scoped_user_gate_fallback_projection,
+    build_user_todo_notification,
+)
 
 
 def test_user_gate_notification_repeats_until_resolved() -> None:
@@ -60,3 +63,59 @@ def test_closed_user_todo_summary_has_no_notification() -> None:
         )
         == {}
     )
+
+
+def test_scoped_user_gate_fallback_projects_executable_bypass() -> None:
+    payload = {
+        "decision": "skip",
+        "effective_action": "monitor_quiet_skip",
+        "should_run": False,
+        "execution_obligation": {"source": "base"},
+    }
+    fallback = {
+        "recommended_action": "advance the non-gated todo",
+        "reason": "the user gate has a narrower action scope",
+    }
+
+    projected = apply_scoped_user_gate_fallback_projection(
+        payload,
+        fallback=fallback,
+        replan_decision_allowed=False,
+    )
+
+    assert payload["decision"] == "skip"
+    assert projected["decision"] == "safe_bypass_user_gate_fallback"
+    assert projected["effective_action"] == "scoped_user_gate_fallback"
+    assert projected["should_run"] is True
+    assert projected["scoped_user_gate_fallback"] == fallback
+    assert projected["safe_bypass_allowed"] is True
+    assert projected["safe_bypass_kind"] == "scoped_user_gate_fallback"
+    assert projected["actionable_by_codex"] is True
+    assert projected["execution_obligation"] == {
+        "source": "base",
+        "must_attempt_work": True,
+        "kind": "scoped_user_gate_fallback",
+        "minimum": "one_non_gated_fallback_segment_after_user_gate_notice",
+        "delivery_allowed": True,
+        "notify_is_execution_gate": False,
+        "contract": "scoped_user_gate_fallback",
+        "contract_obligation": "advance the non-gated todo",
+        "reason": "the user gate has a narrower action scope",
+    }
+
+
+def test_scoped_user_gate_fallback_does_not_override_replan() -> None:
+    payload = {
+        "decision": "autonomous_replan_required",
+        "effective_action": "autonomous_replan_required",
+        "should_run": True,
+    }
+
+    projected = apply_scoped_user_gate_fallback_projection(
+        payload,
+        fallback={"recommended_action": "advance the non-gated todo"},
+        replan_decision_allowed=True,
+    )
+
+    assert projected is payload
+    assert "scoped_user_gate_fallback" not in projected


### PR DESCRIPTION
## Summary
- move scoped user-gate fallback payload transitions from the quota facade into the existing todo user-gate owner
- preserve skip/action, execution-obligation, safe-bypass, and requires-user-action semantics
- lower the measured `build_quota_should_run` ratchet from 291/185 to 278 statements/180 decisions

## Validation
- 19 focused pytest cases
- repository mypy configuration
- Ruff on changed files
- maintainability ratchet smoke
- public/private boundary scan for `loopx/` and `tests/`
- risk-based premerge gate: 17/17 selected checks passed, no manual holds
- change-quality receipt `cqr_971fe7551e397eb6de51` valid for the committed diff

## Scope
- No benchmark execution, scoring, permissions, production action, private state, generated logs, or compatibility wrapper.