### PR TITLE
feat(skillsbench): add cooperative supervisor stop control

### DIFF
--- a/examples/skillsbench-benchmark-egress-policy-smoke.py
+++ b/examples/skillsbench-benchmark-egress-policy-smoke.py
@@ -397,6 +397,7 @@ def test_public_launcher_batches_three_cases_with_closeout_sync() -> None:
     ), output
     assert "--remote-failure-cleanup-pattern" in output, output
     assert "--remote-failure-cleanup-include-docker" in output, output
+    assert "--owner-control-id skillsbench-codex-cli-goal-xhigh-" in output, output
     assert "--update-ledger" not in output, output
     assert "--codex-cli-goal-thread-prewarm" not in output, output
     assert "--allow-staged-bootstrap-repair-run" not in output, output

--- a/examples/skillsbench-supervisor-owner-control-smoke.py
+++ b/examples/skillsbench-supervisor-owner-control-smoke.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Smoke-test public run-id owner control for SkillsBench supervisors."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "skillsbench_reverse_tunnel_supervisor.py"
+
+
+def load_supervisor() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "skillsbench_reverse_tunnel_supervisor",
+        SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def public_payload(
+    supervisor: ModuleType,
+    control_id: str,
+    *,
+    terminal: bool = False,
+) -> dict[str, object]:
+    return {
+        "schema_version": supervisor.SCHEMA_VERSION,
+        "owner_control": {
+            "schema_version": supervisor.OWNER_CONTROL_SCHEMA_VERSION,
+            "enabled": True,
+            "state": "listening",
+            "control_id": control_id,
+            "request_basename": supervisor.OWNER_STOP_REQUEST_BASENAME,
+            "raw_request_recorded": False,
+            "raw_path_recorded": False,
+            "pid_read": False,
+            "process_table_read": False,
+        },
+        "public_liveness": {
+            "terminal": terminal,
+            "process_alive": not terminal,
+        },
+    }
+
+
+def write_public(
+    supervisor: ModuleType,
+    root: Path,
+    run_name: str,
+    control_id: str,
+    *,
+    terminal: bool = False,
+) -> Path:
+    run_dir = root / run_name
+    run_dir.mkdir(parents=True)
+    public_path = run_dir / "supervisor.public.json"
+    public_path.write_text(
+        json.dumps(
+            public_payload(supervisor, control_id, terminal=terminal),
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return public_path
+
+
+def assert_receipt_boundary(receipt: dict[str, object], root: Path) -> None:
+    assert receipt["raw_path_recorded"] is False, receipt
+    assert receipt["raw_request_recorded"] is False, receipt
+    assert receipt["pid_read"] is False, receipt
+    assert receipt["process_table_read"] is False, receipt
+    assert str(root) not in json.dumps(receipt, sort_keys=True), receipt
+
+
+def write_fake_ssh(path: Path) -> None:
+    path.write_text(
+        """#!/usr/bin/env python3
+import signal
+import sys
+import time
+
+args = sys.argv[1:]
+if "-R" in args:
+    running = True
+    def stop(_sig, _frame):
+        global running
+        running = False
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+    while running:
+        time.sleep(0.05)
+    raise SystemExit(0)
+
+remote_command = args[-1] if args else ""
+if "LOOPX_REVERSE_TUNNEL_PROBE" in remote_command:
+    print("HTTP/1.1 200 Connection Established")
+    raise SystemExit(0)
+if "owner-stop-long-run" in remote_command:
+    running = True
+    def stop(_sig, _frame):
+        global running
+        running = False
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+    while running:
+        time.sleep(0.05)
+    raise SystemExit(0)
+print('{"ok": true}')
+""",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def assert_live_stop_integration(supervisor: ModuleType) -> None:
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        run_dir = root / "integration-run"
+        run_dir.mkdir()
+        public_path = run_dir / "supervisor.public.json"
+        fake_ssh = root / "ssh"
+        write_fake_ssh(fake_ssh)
+        supervisor_proc = subprocess.Popen(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--ssh-bin",
+                str(fake_ssh),
+                "--ssh-destination",
+                "opaque-host.example",
+                "--remote-command",
+                "owner-stop-long-run",
+                "--public-output-path",
+                str(public_path),
+                "--owner-control-id",
+                "integration-run",
+                "--tunnel-ready-timeout-sec",
+                "5",
+                "--probe-interval-sec",
+                "0.05",
+                "--tunnel-health-interval-sec",
+                "0",
+                "--run-timeout-sec",
+                "30",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            if public_path.exists():
+                public = json.loads(public_path.read_text(encoding="utf-8"))
+                liveness = public.get("public_liveness", {})
+                if liveness.get("state") == "running":
+                    break
+            time.sleep(0.05)
+        else:
+            supervisor_proc.terminate()
+            supervisor_proc.wait(timeout=5)
+            raise AssertionError("supervisor did not reach running state")
+
+        stop_proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "stop",
+                "--run-root",
+                str(root),
+                "--control-id",
+                "integration-run",
+                "--wait-timeout-sec",
+                "10",
+            ],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=15,
+        )
+        stdout, stderr = supervisor_proc.communicate(timeout=10)
+        assert stop_proc.returncode == 0, stop_proc.stderr or stop_proc.stdout
+        receipt = json.loads(stop_proc.stdout)
+        assert receipt["status"] == "terminal_observed", receipt
+        assert_receipt_boundary(receipt, root)
+        assert supervisor_proc.returncode == 128 + signal.SIGTERM, stderr or stdout
+
+        public = json.loads(public_path.read_text(encoding="utf-8"))
+        assert public["first_blocker"] == "supervisor_owner_stop_requested", public
+        assert public["owner_control"]["state"] == "accepted", public
+        assert public["owner_control"]["accepted_request_count"] == 1, public
+        assert public["public_liveness"]["terminal"] is True, public
+        assert public["public_liveness"]["process_alive"] is False, public
+        assert public["terminal_closeout"]["reason_code"] == (
+            "supervisor_owner_stop_requested"
+        ), public
+        assert "signal_name" not in public["terminal_closeout"], public
+        assert str(root) not in json.dumps(public, sort_keys=True), public
+
+
+def main() -> None:
+    supervisor = load_supervisor()
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        public_path = write_public(supervisor, root, "run-a", "run-a")
+
+        rc, receipt = supervisor.request_owner_stop(
+            [
+                "--run-root",
+                str(root),
+                "--control-id",
+                "run-a",
+                "--wait-timeout-sec",
+                "0",
+            ]
+        )
+        assert rc == 0, receipt
+        assert receipt["status"] == "requested", receipt
+        assert receipt["matched_supervisor_count"] == 1, receipt
+        assert receipt["active_supervisor_count"] == 1, receipt
+        assert receipt["request_written"] is True, receipt
+        assert_receipt_boundary(receipt, root)
+
+        request_path = public_path.with_name(
+            supervisor.OWNER_STOP_REQUEST_BASENAME
+        )
+        request = json.loads(request_path.read_text(encoding="utf-8"))
+        assert request == {
+            "schema_version": supervisor.OWNER_STOP_REQUEST_SCHEMA_VERSION,
+            "control_id": "run-a",
+            "action": "terminate",
+            "requested_at": request["requested_at"],
+        }, request
+
+        args = SimpleNamespace(
+            owner_control_id="run-a",
+            public_output_path=str(public_path),
+        )
+        contract = supervisor._owner_control_public_contract(args)
+        assert supervisor._poll_owner_stop_request(args, contract) is True
+        assert contract["state"] == "accepted", contract
+        assert contract["accepted_request_count"] == 1, contract
+        assert request_path.exists() is False
+
+        public_path.write_text(
+            json.dumps(
+                public_payload(supervisor, "run-a", terminal=True),
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        rc, receipt = supervisor.request_owner_stop(
+            [
+                "--run-root",
+                str(root),
+                "--control-id",
+                "run-a",
+            ]
+        )
+        assert rc == 0, receipt
+        assert receipt["status"] == "already_terminal", receipt
+        assert receipt["request_written"] is False, receipt
+        assert_receipt_boundary(receipt, root)
+
+        invalid_path = write_public(supervisor, root, "run-b", "run-b")
+        invalid_args = SimpleNamespace(
+            owner_control_id="run-b",
+            public_output_path=str(invalid_path),
+        )
+        invalid_contract = supervisor._owner_control_public_contract(invalid_args)
+        invalid_request = invalid_path.with_name(
+            supervisor.OWNER_STOP_REQUEST_BASENAME
+        )
+        invalid_request.write_text(
+            json.dumps(
+                {
+                    "schema_version": supervisor.OWNER_STOP_REQUEST_SCHEMA_VERSION,
+                    "control_id": "another-run",
+                    "action": "terminate",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        assert (
+            supervisor._poll_owner_stop_request(invalid_args, invalid_contract)
+            is False
+        )
+        assert invalid_contract["state"] == "invalid_request_ignored"
+        assert invalid_contract["invalid_request_count"] == 1
+        assert invalid_request.exists() is False
+
+        write_public(supervisor, root, "collision-a", "collision")
+        write_public(supervisor, root, "collision-b", "collision")
+        rc, receipt = supervisor.request_owner_stop(
+            [
+                "--run-root",
+                str(root),
+                "--control-id",
+                "collision",
+                "--wait-timeout-sec",
+                "0",
+            ]
+        )
+        assert rc == 3, receipt
+        assert receipt["status"] == "ambiguous_active_supervisor", receipt
+        assert receipt["active_supervisor_count"] == 2, receipt
+        assert_receipt_boundary(receipt, root)
+
+        write_public(supervisor, root, "cli-run", "cli-run")
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "stop",
+                "--run-root",
+                str(root),
+                "--control-id",
+                "cli-run",
+                "--wait-timeout-sec",
+                "0",
+            ],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert proc.returncode == 0, proc.stderr
+        cli_receipt = json.loads(proc.stdout)
+        assert cli_receipt["status"] == "requested", cli_receipt
+        assert_receipt_boundary(cli_receipt, root)
+
+    assert_live_stop_integration(supervisor)
+    print("skillsbench supervisor owner control smoke: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -965,6 +965,7 @@ supervisor_cmd=(
   --local-public-artifact-dir "$public_dir"
   --private-log-path "${private_dir}/remote-command.log"
   --public-output-path "${public_dir}/supervisor.public.json"
+  --owner-control-id "$run_group"
 )
 
 if [[ -n "$local_proxy_command" ]]; then

--- a/scripts/skillsbench_reverse_tunnel_supervisor.py
+++ b/scripts/skillsbench_reverse_tunnel_supervisor.py
@@ -46,6 +46,10 @@ SCHEMA_VERSION = "skillsbench_reverse_tunnel_supervisor_v0"
 PUBLIC_LIVENESS_SCHEMA_VERSION = "skillsbench_supervisor_public_liveness_v0"
 ACTIVE_PHASE_SCHEMA_VERSION = "skillsbench_supervisor_active_phase_v0"
 TERMINAL_CLOSEOUT_SCHEMA_VERSION = "skillsbench_supervisor_terminal_closeout_v0"
+OWNER_CONTROL_SCHEMA_VERSION = "skillsbench_supervisor_owner_control_v0"
+OWNER_STOP_REQUEST_SCHEMA_VERSION = "skillsbench_supervisor_owner_stop_request_v0"
+OWNER_STOP_RECEIPT_SCHEMA_VERSION = "skillsbench_supervisor_owner_stop_receipt_v0"
+OWNER_STOP_REQUEST_BASENAME = "supervisor.stop.request.json"
 PUBLIC_LIVENESS_INTERVAL_SEC = 30.0
 DEFAULT_REMOTE_FORWARD = "127.0.0.1:18180:127.0.0.1:18180"
 DEFAULT_TEST_HOST = "chatgpt.com"
@@ -64,6 +68,110 @@ class _SupervisorTerminationSignal(Exception):
     def __init__(self, signum: int) -> None:
         self.signum = signum
         super().__init__(signal.Signals(signum).name)
+
+
+def _valid_owner_control_id(value: str) -> bool:
+    return bool(
+        value
+        and len(value) <= 240
+        and all(character.isalnum() or character in "._:-" for character in value)
+    )
+
+
+def _owner_stop_request_path(public_output_path: str | None) -> Path | None:
+    if not public_output_path:
+        return None
+    return Path(public_output_path).expanduser().with_name(
+        OWNER_STOP_REQUEST_BASENAME
+    )
+
+
+def _owner_control_public_contract(args: argparse.Namespace) -> dict[str, Any]:
+    control_id = str(getattr(args, "owner_control_id", "") or "")
+    enabled = bool(control_id and args.public_output_path)
+    return {
+        "schema_version": OWNER_CONTROL_SCHEMA_VERSION,
+        "enabled": enabled,
+        "state": "listening" if enabled else "disabled",
+        "control_id": control_id if enabled else None,
+        "request_basename": OWNER_STOP_REQUEST_BASENAME if enabled else None,
+        "request_poll_count": 0,
+        "accepted_request_count": 0,
+        "invalid_request_count": 0,
+        "raw_request_recorded": False,
+        "raw_path_recorded": False,
+        "pid_read": False,
+        "process_table_read": False,
+    }
+
+
+def _prepare_owner_control(
+    args: argparse.Namespace,
+    contract: dict[str, Any],
+) -> None:
+    if contract.get("enabled") is not True:
+        return
+    request_path = _owner_stop_request_path(args.public_output_path)
+    if request_path is None:
+        return
+    try:
+        request_path.unlink(missing_ok=True)
+    except OSError:
+        contract["state"] = "request_cleanup_failed"
+        contract["request_cleanup_error"] = True
+
+
+def _poll_owner_stop_request(
+    args: argparse.Namespace,
+    contract: dict[str, Any],
+) -> bool:
+    if contract.get("enabled") is not True:
+        return False
+    request_path = _owner_stop_request_path(args.public_output_path)
+    if request_path is None:
+        return False
+    contract["request_poll_count"] = int(contract["request_poll_count"]) + 1
+    if not request_path.exists():
+        return False
+
+    request: Any = None
+    try:
+        if request_path.is_symlink() or request_path.stat().st_size > 4096:
+            raise ValueError("unsafe owner stop request")
+        request = json.loads(request_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, ValueError, json.JSONDecodeError):
+        contract["state"] = "invalid_request_ignored"
+        contract["invalid_request_count"] = int(contract["invalid_request_count"]) + 1
+        try:
+            request_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return False
+
+    valid = (
+        isinstance(request, Mapping)
+        and request.get("schema_version") == OWNER_STOP_REQUEST_SCHEMA_VERSION
+        and request.get("action") == "terminate"
+        and request.get("control_id") == contract.get("control_id")
+    )
+    if not valid:
+        contract["state"] = "invalid_request_ignored"
+        contract["invalid_request_count"] = int(contract["invalid_request_count"]) + 1
+        try:
+            request_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return False
+
+    contract["state"] = "accepted"
+    contract["accepted_request_count"] = int(contract["accepted_request_count"]) + 1
+    contract["accepted_action"] = "terminate"
+    contract["accepted_at"] = _utc_timestamp(time.time())
+    try:
+        request_path.unlink(missing_ok=True)
+    except OSError:
+        contract["accepted_request_cleanup_error"] = True
+    return True
 
 
 def _host_kind(value: str) -> str:
@@ -1513,7 +1621,164 @@ def _initial_public_payload(args: argparse.Namespace) -> dict[str, Any]:
             _incremental_public_artifact_sync_contract(args)
         ),
         "tunnel_liveness": _tunnel_liveness_public_contract(args),
+        "owner_control": _owner_control_public_contract(args),
     }
+
+
+def _owner_stop_receipt(
+    *,
+    control_id: str,
+    status: str,
+    matched_supervisor_count: int,
+    active_supervisor_count: int,
+    terminal_supervisor_count: int,
+    request_written: bool = False,
+    terminal_observed: bool = False,
+) -> dict[str, Any]:
+    return {
+        "schema_version": OWNER_STOP_RECEIPT_SCHEMA_VERSION,
+        "ok": status in {"requested", "already_terminal", "terminal_observed"},
+        "status": status,
+        "control_id": control_id,
+        "matched_supervisor_count": matched_supervisor_count,
+        "active_supervisor_count": active_supervisor_count,
+        "terminal_supervisor_count": terminal_supervisor_count,
+        "request_written": request_written,
+        "terminal_observed": terminal_observed,
+        "raw_path_recorded": False,
+        "raw_request_recorded": False,
+        "pid_read": False,
+        "process_table_read": False,
+    }
+
+
+def request_owner_stop(argv: list[str]) -> tuple[int, dict[str, Any]]:
+    parser = argparse.ArgumentParser(
+        prog="skillsbench_reverse_tunnel_supervisor.py stop",
+        description=(
+            "Request cooperative terminal closeout for one owned SkillsBench "
+            "supervisor by public control id."
+        ),
+    )
+    parser.add_argument("--run-root", required=True)
+    parser.add_argument("--control-id", required=True)
+    parser.add_argument("--wait-timeout-sec", type=float, default=30.0)
+    args = parser.parse_args(argv)
+    control_id = str(args.control_id)
+    if not _valid_owner_control_id(control_id):
+        parser.error("--control-id must be a bounded public-safe identifier")
+
+    run_root = Path(args.run_root).expanduser()
+    if not run_root.is_dir() or run_root.is_symlink():
+        return 2, _owner_stop_receipt(
+            control_id=control_id,
+            status="run_root_unavailable",
+            matched_supervisor_count=0,
+            active_supervisor_count=0,
+            terminal_supervisor_count=0,
+        )
+
+    matches: list[tuple[Path, dict[str, Any]]] = []
+    for public_path in run_root.rglob("supervisor.public.json"):
+        if public_path.is_symlink() or not public_path.is_file():
+            continue
+        try:
+            loaded = json.loads(public_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            continue
+        if not isinstance(loaded, dict):
+            continue
+        owner_control = loaded.get("owner_control")
+        if (
+            isinstance(owner_control, Mapping)
+            and owner_control.get("schema_version") == OWNER_CONTROL_SCHEMA_VERSION
+            and owner_control.get("enabled") is True
+            and owner_control.get("control_id") == control_id
+        ):
+            matches.append((public_path, loaded))
+
+    active = [
+        item
+        for item in matches
+        if isinstance(item[1].get("public_liveness"), Mapping)
+        and item[1]["public_liveness"].get("terminal") is not True
+        and item[1]["public_liveness"].get("process_alive") is True
+    ]
+    terminal = [
+        item
+        for item in matches
+        if isinstance(item[1].get("public_liveness"), Mapping)
+        and item[1]["public_liveness"].get("terminal") is True
+    ]
+    counts = {
+        "matched_supervisor_count": len(matches),
+        "active_supervisor_count": len(active),
+        "terminal_supervisor_count": len(terminal),
+    }
+    if not active:
+        status = "already_terminal" if terminal else "supervisor_not_found"
+        return (0 if terminal else 2), _owner_stop_receipt(
+            control_id=control_id,
+            status=status,
+            **counts,
+        )
+    if len(active) != 1:
+        return 3, _owner_stop_receipt(
+            control_id=control_id,
+            status="ambiguous_active_supervisor",
+            **counts,
+        )
+
+    public_path = active[0][0]
+    request_path = public_path.with_name(OWNER_STOP_REQUEST_BASENAME)
+    request = {
+        "schema_version": OWNER_STOP_REQUEST_SCHEMA_VERSION,
+        "control_id": control_id,
+        "action": "terminate",
+        "requested_at": _utc_timestamp(time.time()),
+    }
+    temporary = request_path.with_name(f".{request_path.name}.{os.getpid()}.tmp")
+    try:
+        temporary.write_text(
+            json.dumps(request, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(request_path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+    wait_timeout_sec = max(0.0, float(args.wait_timeout_sec))
+    if wait_timeout_sec == 0.0:
+        return 0, _owner_stop_receipt(
+            control_id=control_id,
+            status="requested",
+            request_written=True,
+            **counts,
+        )
+
+    deadline = time.monotonic() + wait_timeout_sec
+    while time.monotonic() < deadline:
+        try:
+            latest = json.loads(public_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            latest = {}
+        liveness = latest.get("public_liveness") if isinstance(latest, dict) else {}
+        if isinstance(liveness, Mapping) and liveness.get("terminal") is True:
+            return 0, _owner_stop_receipt(
+                control_id=control_id,
+                status="terminal_observed",
+                request_written=True,
+                terminal_observed=True,
+                **counts,
+            )
+        time.sleep(0.1)
+
+    return 4, _owner_stop_receipt(
+        control_id=control_id,
+        status="request_pending",
+        request_written=True,
+        **counts,
+    )
 
 
 def _last_public_liveness_contract(path: str | None) -> dict[str, Any]:
@@ -1748,6 +2013,7 @@ def _finalize_unhandled_supervisor_failure(
 def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     started_at = time.time()
     payload = _initial_public_payload(args)
+    _prepare_owner_control(args, payload["owner_control"])
     public_heartbeat_count = 0
 
     def checkpoint(state: str, *, terminal: bool = False) -> None:
@@ -2069,6 +2335,9 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
             )
 
             while remote_proc.poll() is None:
+                if _poll_owner_stop_request(args, payload["owner_control"]):
+                    checkpoint("running")
+                    raise _SupervisorTerminationSignal(signal.SIGTERM)
                 now = time.monotonic()
                 if now >= run_deadline:
                     remote_command_timed_out = True
@@ -2340,31 +2609,40 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     except _SupervisorTerminationSignal as exc:
         if remote_proc is not None:
             _stop_process_group(remote_proc, grace_sec=1.0)
+        owner_stop_requested = (
+            payload.get("owner_control", {}).get("state") == "accepted"
+        )
+        trigger = (
+            "supervisor_owner_stop_requested"
+            if owner_stop_requested
+            else "supervisor_termination_signal"
+        )
         payload["ok"] = False
-        payload["first_blocker"] = "supervisor_termination_signal"
+        payload["first_blocker"] = trigger
         payload["supervisor_error_type"] = type(exc).__name__[:80]
         try:
             payload["remote_failure_cleanup"] = _run_remote_failure_cleanup(
                 args,
-                trigger="supervisor_termination_signal",
+                trigger=trigger,
             )
         except Exception as cleanup_exc:
             cleanup = _remote_failure_cleanup_public_contract(args)
-            cleanup["trigger"] = "supervisor_termination_signal"
+            cleanup["trigger"] = trigger
             cleanup["first_blocker"] = "remote_failure_cleanup_failed"
             cleanup["error_type"] = type(cleanup_exc).__name__[:80]
             payload["remote_failure_cleanup"] = cleanup
         payload["public_artifact_sync"] = _termination_public_artifact_sync(args)
         payload["terminal_closeout"] = _terminal_closeout_contract(
             args,
-            trigger="supervisor_termination_signal",
-            signal_name=signal.Signals(exc.signum).name,
+            trigger=trigger,
+            signal_name=(
+                "" if owner_stop_requested else signal.Signals(exc.signum).name
+            ),
         )
         payload["public_terminal_fallback"] = {
             "schema_version": "skillsbench_supervisor_terminal_fallback_v0",
             "triggered": True,
-            "trigger": "supervisor_termination_signal",
-            "signal_name": signal.Signals(exc.signum).name,
+            "trigger": trigger,
             "exception_message_recorded": False,
             "raw_task_text_recorded": False,
             "raw_logs_recorded": False,
@@ -2372,6 +2650,10 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
             "raw_verifier_output_recorded": False,
             "local_paths_recorded": False,
         }
+        if not owner_stop_requested:
+            payload["public_terminal_fallback"]["signal_name"] = signal.Signals(
+                exc.signum
+            ).name
         return finish(128 + exc.signum)
     except (OSError, subprocess.TimeoutExpired) as exc:
         if remote_proc is not None:
@@ -2744,7 +3026,20 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="Optional path for compact public-safe supervisor JSON.",
     )
+    parser.add_argument(
+        "--owner-control-id",
+        default="",
+        help=(
+            "Public-safe run id that enables cooperative owner stop requests "
+            "through the supervisor public-output directory."
+        ),
+    )
     args = parser.parse_args(argv)
+    if args.owner_control_id:
+        if not _valid_owner_control_id(args.owner_control_id):
+            parser.error("--owner-control-id must be a bounded public-safe identifier")
+        if not args.public_output_path:
+            parser.error("--owner-control-id requires --public-output-path")
     try:
         args.proxy_port_coherence = _proxy_port_coherence_public_contract(args)
     except ValueError as exc:
@@ -2817,7 +3112,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = parse_args(argv)
+    resolved_argv = list(sys.argv[1:] if argv is None else argv)
+    if resolved_argv[:1] == ["stop"]:
+        rc, receipt = request_owner_stop(resolved_argv[1:])
+        sys.stdout.write(json.dumps(receipt, indent=2, sort_keys=True) + "\n")
+        return rc
+
+    args = parse_args(resolved_argv)
     previous_signal_handlers: dict[int, Any] = {}
 
     def request_terminal_closeout(signum: int, _frame: Any) -> None:


### PR DESCRIPTION
## Summary
- add a public run-id owner-control contract to the SkillsBench reverse-tunnel supervisor
- add a cooperative `stop` command that writes a bounded request file and waits for terminal public liveness without reading PIDs or the process table
- wire launch run groups into the control id and add focused live closeout plus launcher coverage

## Validation
- `python3 examples/skillsbench-supervisor-owner-control-smoke.py`
- `python3 examples/skillsbench-reverse-tunnel-supervisor-smoke.py`
- `python3.13 examples/skillsbench-benchmark-egress-policy-smoke.py`
- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`
- `loopx canary premerge --from-git-diff` (all direct, catalog, and public-boundary checks passed; benchmark-sensitive policy reported the expected manual hold)
- `git diff --check`

## Boundary
- no raw PID, process-table, command, task, log, trajectory, verifier, credential, or local-path values are emitted
- the stop receipt and supervisor contract expose only the public control id, bounded counts, and lifecycle state
- no benchmark scoring, task semantics, submission behavior, or benchmark launch is changed