### PR TITLE
release: LoopX v0.3.0

### DIFF
--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.13"
+__version__ = "0.3.0"

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -1,4 +1,4 @@
-.TH LOOPX 1 "" "LoopX 0.2.13" "User Commands"
+.TH LOOPX 1 "" "LoopX 0.3.0" "User Commands"
 .SH NAME
 loopx \- control-plane helper for long-running agent work
 .SH SYNOPSIS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.2.13"
+version = "0.3.0"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- bump `loopx.__version__` and `pyproject.toml` from `0.2.13` to `0.3.0`
- update the canonical manpage header to the same version
- prepare the matching `v0.3.0` tag, GitHub release, and stable-channel promotion

## Why a minor release

Since `v0.2.13`, `main` has accumulated 180 commits across 371 files, including
new Change Quality, Decision Context, Material Lifecycle, managed-project
delivery, and Ark Managed Agent host surfaces. The range also intentionally
removes change-quality v1 receipt reads and changes selected CLI/default
projection contracts. For a v0.x project this is a capability and contract
cut, not a patch-only bugfix.

## Release baseline

The exact pre-release `main` commit is `a874d298`. The release makes no
benchmark-uplift or long-horizon outcome-improvement claim.

## Validation

- release version contract
- release-readiness documentation contract
- fresh-clone quickstart with supported Python 3.12
- no-clone Codex CLI release verification
- update smoke
- changed Python compile
- sdist and wheel build
- Twine checks for both artifacts
- public/private boundary scan
- risk-based premerge canary
- diff hygiene

GitHub checks on this exact commit remain the merge gate. The first local
fresh-clone invocation inherited the host's unsupported Python 3.9 and exited
at installer preflight; rerunning with the repository-supported Python 3.12
passed. This was an environment qualification failure, not a product failure.

## Pending release-only gates

- create the local and public `v0.3.0` tag on the merged clean commit
- bind exact-commit release qualification receipts
- fast-forward `stable`
- publish and read back the bilingual GitHub release

The low-frequency live-model gate is not rerun by this version-only PR. No
matched benchmark outcome baseline is required because the release makes no
outcome-uplift claim.

## Scope

Only three version identity lines change. There is no runtime behavior,
benchmark scoring, task-semantics, permission, upload, submission, or
production adapter change in this PR.
