### PR TITLE
refactor(quota): reuse fallback Markdown rendering

### DIFF
--- a/loopx/presentation/renderers/quota_markdown.py
+++ b/loopx/presentation/renderers/quota_markdown.py
@@ -13,6 +13,44 @@ from ...control_plane.runtime.decision_freshness import (
 from ..markdown import as_dict, as_list, markdown_scalar
 
 
+def _append_fallback_projection_markdown(
+    lines: list[str],
+    fallback: dict[str, Any],
+    *,
+    label: str,
+    blocked_items_key: str,
+    blocked_item_label: str,
+    blocked_gate_key: str | None = None,
+) -> None:
+    if not fallback:
+        return
+    selected = as_dict(fallback.get("selected_executable"))
+    blocked_items = as_list(fallback.get(blocked_items_key))
+    lines.append(
+        f"- {label}_fallback: "
+        f"notify_user={fallback.get('notify_user')} "
+        f"blocked_count={len(blocked_items)} "
+        f"selected_index={selected.get('index')} "
+        f"reason={fallback.get('reason')}"
+    )
+    blocked_gate = as_dict(fallback.get(blocked_gate_key)) if blocked_gate_key else {}
+    if blocked_gate.get("text"):
+        lines.append(f"- {label}: {blocked_gate.get('text')}")
+    for blocked in blocked_items[:3]:
+        if not isinstance(blocked, dict):
+            continue
+        text = str(blocked.get("text") or "").strip()
+        if not text:
+            continue
+        index = blocked.get("index")
+        suffix = f"[{index}]" if index is not None else ""
+        lines.append(f"- {blocked_item_label}{suffix}: {text}")
+    if selected.get("text"):
+        lines.append(f"- {label}_selected: {selected.get('text')}")
+    if fallback.get("recommended_action"):
+        lines.append(f"- {label}_action: {fallback.get('recommended_action')}")
+
+
 def render_quota_markdown(payload: dict[str, Any]) -> str:
     title = "Quota Plan" if payload.get("mode") == "plan" else "Quota Status"
     lines = [
@@ -496,89 +534,21 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
         )
         if projection_gap.get("recommended_action"):
             lines.append(f"- state_projection_gap_action: {projection_gap.get('recommended_action')}")
-    blocked_priority_fallback = (
-        payload.get("blocked_priority_fallback")
-        if isinstance(payload.get("blocked_priority_fallback"), dict)
-        else {}
+    _append_fallback_projection_markdown(
+        lines,
+        as_dict(payload.get("blocked_priority_fallback")),
+        label="blocked_priority",
+        blocked_items_key="blocked_items",
+        blocked_item_label="blocked_priority_item",
     )
-    if blocked_priority_fallback:
-        selected = (
-            blocked_priority_fallback.get("selected_executable")
-            if isinstance(blocked_priority_fallback.get("selected_executable"), dict)
-            else {}
-        )
-        blocked_items = (
-            blocked_priority_fallback.get("blocked_items")
-            if isinstance(blocked_priority_fallback.get("blocked_items"), list)
-            else []
-        )
-        lines.append(
-            "- blocked_priority_fallback: "
-            f"notify_user={blocked_priority_fallback.get('notify_user')} "
-            f"blocked_count={len(blocked_items)} "
-            f"selected_index={selected.get('index')} "
-            f"reason={blocked_priority_fallback.get('reason')}"
-        )
-        for blocked in blocked_items[:3]:
-            if not isinstance(blocked, dict):
-                continue
-            text = str(blocked.get("text") or "").strip()
-            if not text:
-                continue
-            index = blocked.get("index")
-            suffix = f"[{index}]" if index is not None else ""
-            lines.append(f"- blocked_priority_item{suffix}: {text}")
-        if selected.get("text"):
-            lines.append(f"- blocked_priority_selected: {selected.get('text')}")
-        if blocked_priority_fallback.get("recommended_action"):
-            lines.append(
-                f"- blocked_priority_action: {blocked_priority_fallback.get('recommended_action')}"
-            )
-    scoped_user_gate_fallback = (
-        payload.get("scoped_user_gate_fallback")
-        if isinstance(payload.get("scoped_user_gate_fallback"), dict)
-        else {}
+    _append_fallback_projection_markdown(
+        lines,
+        as_dict(payload.get("scoped_user_gate_fallback")),
+        label="scoped_user_gate",
+        blocked_items_key="blocked_agent_items",
+        blocked_item_label="scoped_user_gate_blocked_item",
+        blocked_gate_key="blocked_user_gate",
     )
-    if scoped_user_gate_fallback:
-        selected = (
-            scoped_user_gate_fallback.get("selected_executable")
-            if isinstance(scoped_user_gate_fallback.get("selected_executable"), dict)
-            else {}
-        )
-        blocked_gate = (
-            scoped_user_gate_fallback.get("blocked_user_gate")
-            if isinstance(scoped_user_gate_fallback.get("blocked_user_gate"), dict)
-            else {}
-        )
-        blocked_items = (
-            scoped_user_gate_fallback.get("blocked_agent_items")
-            if isinstance(scoped_user_gate_fallback.get("blocked_agent_items"), list)
-            else []
-        )
-        lines.append(
-            "- scoped_user_gate_fallback: "
-            f"notify_user={scoped_user_gate_fallback.get('notify_user')} "
-            f"blocked_count={len(blocked_items)} "
-            f"selected_index={selected.get('index')} "
-            f"reason={scoped_user_gate_fallback.get('reason')}"
-        )
-        if blocked_gate.get("text"):
-            lines.append(f"- scoped_user_gate: {blocked_gate.get('text')}")
-        for blocked in blocked_items[:3]:
-            if not isinstance(blocked, dict):
-                continue
-            text = str(blocked.get("text") or "").strip()
-            if not text:
-                continue
-            index = blocked.get("index")
-            suffix = f"[{index}]" if index is not None else ""
-            lines.append(f"- scoped_user_gate_blocked_item{suffix}: {text}")
-        if selected.get("text"):
-            lines.append(f"- scoped_user_gate_selected: {selected.get('text')}")
-        if scoped_user_gate_fallback.get("recommended_action"):
-            lines.append(
-                f"- scoped_user_gate_action: {scoped_user_gate_fallback.get('recommended_action')}"
-            )
     completed_todo_archive_warning = (
         payload.get("completed_todo_archive_warning")
         if isinstance(payload.get("completed_todo_archive_warning"), dict)

--- a/tests/presentation/test_quota_markdown_boundary.py
+++ b/tests/presentation/test_quota_markdown_boundary.py
@@ -39,3 +39,44 @@ def test_quota_rendering_preserves_the_decision_payload() -> None:
     assert "# LoopX Quota Should Run" in markdown
     assert "- decision: `run`" in markdown
     assert payload == original
+
+
+def test_quota_rendering_reuses_the_fallback_projection_contract() -> None:
+    payload = {
+        "blocked_priority_fallback": {
+            "notify_user": False,
+            "reason": "higher priority work is blocked",
+            "blocked_items": [
+                {"index": 1, "text": "repair primary"},
+                {"index": 2, "text": "repair secondary"},
+            ],
+            "selected_executable": {"index": 3, "text": "run safe fallback"},
+            "recommended_action": "continue safe work",
+        },
+        "scoped_user_gate_fallback": {
+            "notify_user": True,
+            "reason": "another agent owns the gate",
+            "blocked_user_gate": {"text": "approve another lane"},
+            "blocked_agent_items": [{"index": 4, "text": "wait for approval"}],
+            "selected_executable": {"index": 5, "text": "run independent work"},
+            "recommended_action": "continue independent work",
+        },
+    }
+
+    markdown = render_quota_should_run_markdown(payload)
+
+    expected_lines = [
+        "- blocked_priority_fallback: notify_user=False blocked_count=2 "
+        "selected_index=3 reason=higher priority work is blocked",
+        "- blocked_priority_item[1]: repair primary",
+        "- blocked_priority_item[2]: repair secondary",
+        "- blocked_priority_selected: run safe fallback",
+        "- blocked_priority_action: continue safe work",
+        "- scoped_user_gate_fallback: notify_user=True blocked_count=1 "
+        "selected_index=5 reason=another agent owns the gate",
+        "- scoped_user_gate: approve another lane",
+        "- scoped_user_gate_blocked_item[4]: wait for approval",
+        "- scoped_user_gate_selected: run independent work",
+        "- scoped_user_gate_action: continue independent work",
+    ]
+    assert all(line in markdown for line in expected_lines)


### PR DESCRIPTION
## Summary
- consolidate blocked-priority and scoped-user-gate fallback Markdown under one renderer-owned contract
- preserve schema-specific labels and exact rendered output
- reduce `render_quota_should_run_markdown` from 399 statements / 264 decisions to 362 / 240; production diff is 51 additions and 81 deletions
- add focused contract coverage for both fallback shapes

## Validation
- 30 focused presentation and vision-wait tests passed
- 14 CLI output-budget tests passed
- exact base-to-head parity passed for 5 valid and malformed fallback shapes
- blocked-priority and scoped-user-gate public smokes passed
- CLI output-budget regression smoke passed
- focused Ruff and public-boundary scan passed
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` passed 7 selected canaries, no manual holds
- change-quality receipt `cqr_db8e69f36d909178b6cc` verified against the committed diff

## Scope
Only the quota Markdown renderer and its focused presentation contract test are included. No local state, credentials, raw logs, private paths, benchmark runs, or generated artifacts are committed.

LoopX todo: `todo_c51a471e525a`.