### PR TITLE
test(extensions): stabilize timeout termination regression

### DIFF
--- a/tests/extensions/test_extension_runtime.py
+++ b/tests/extensions/test_extension_runtime.py
@@ -447,7 +447,7 @@ def test_extension_run_terminates_provider_on_timeout(tmp_path: Path) -> None:
     provider = tmp_path / "timeout-provider"
     child_code = (
         "from pathlib import Path; import time; "
-        "time.sleep(1.2); "
+        "time.sleep(3.5); "
         f"Path({str(marker)!r}).write_text('completed', encoding='utf-8')"
     )
     provider.write_text(
@@ -459,7 +459,7 @@ import time
 if "--doctor" in sys.argv:
     raise SystemExit(0)
 subprocess.Popen([sys.executable, "-c", {json.dumps(child_code)}])
-time.sleep(5)
+time.sleep(10)
 """,
         encoding="utf-8",
     )
@@ -471,7 +471,9 @@ time.sleep(5)
     manifest.write_text(
         manifest.read_text(encoding="utf-8").replace(
             "timeout_seconds = 5",
-            "timeout_seconds = 1",
+            # The same timeout gates the install-time doctor subprocess. Keep
+            # enough startup headroom for loaded parallel test hosts.
+            "timeout_seconds = 3",
         ),
         encoding="utf-8",
     )
@@ -489,7 +491,7 @@ time.sleep(5)
     assert receipt["status"] == "provider_failed"
     assert receipt["failure_kind"] == "timeout"
     assert receipt["exit_code"] is None
-    time.sleep(0.5)
+    time.sleep(0.75)
     assert not marker.exists()
 
 


### PR DESCRIPTION
## Summary

- give the extension timeout-termination regression enough install-time doctor startup headroom on loaded parallel hosts
- preserve the same negative contract: a timed-out provider and its child process must terminate before the child writes its completion marker
- change no production runtime, extension protocol, or compatibility behavior

## Root cause

The test changed the manifest's shared `timeout_seconds` from five seconds to one second. That value governs both the install-time provider doctor and the runtime invocation under test. Under load, the doctor subprocess could exceed one second, so setup failed with `provider_unavailable` before the process-tree timeout behavior was exercised.

The revised test uses a three-second timeout, a child marker at 3.5 seconds, and a longer parent sleep. This preserves the failure signal while separating doctor startup variance from the runtime assertion.

## Validation

- target regression repeated 5 times: passed
- `pytest -q tests/extensions/test_extension_runtime.py`: 32 passed
- Ruff on the changed file: passed
- repository mypy: passed, 15 source files
- public/private scan on the changed file: 9 checks, 0 errors, 0 warnings
- `git diff --check`: passed
- LoopX premerge: passed; 4 direct checks, 0 failures, 0 manual holds
- change-quality receipt: `cqr_6405fd05d6ae9b5a7b9e`, exact scope valid

## Scope

One test file, 6 insertions and 4 deletions. No runtime behavior, benchmark semantics, credentials, local paths, or generated artifacts are included.
