### PR TITLE
test(install): preserve supported bootstrap Python

### DIFF
--- a/examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
+++ b/examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 import tarfile
 import tempfile
 from pathlib import Path
@@ -102,6 +103,7 @@ def main() -> None:
                 "LOOPX_SHELL_PROFILE": str(home / ".profile"),
                 "LOOPX_ARCHIVE_URL": f"file://{archive}",
                 "LOOPX_INSTALL_CANARY": "0",
+                "LOOPX_PYTHON": sys.executable,
                 "CODEX_CALLED_MARKER": str(codex_called_marker),
                 "PATH": f"{fake_bin}:{host_path_without_loopx}",
             }


### PR DESCRIPTION
## Summary

- preserve the supported test interpreter through the Codex CLI TUI bootstrap install smoke
- continue removing pre-existing LoopX wrapper directories from `PATH`
- reuse the installer's existing `LOOPX_PYTHON` contract instead of changing installer behavior

## Root cause

The smoke invokes a supported Python interpreter, then sanitizes `PATH` by removing every directory that contains a `loopx` executable. In an editable test environment that also removes the active venv, so `install-from-github.sh` falls back to macOS system Python 3.9 and fails its supported-version preflight.

Passing `sys.executable` through `LOOPX_PYTHON` keeps the test's no-existing-wrapper boundary while making the interpreter requirement explicit and portable.

## Validation

- Codex CLI TUI bootstrap smoke bundle: passed twice
- the 13 initially failing full-public smokes, rerun with supported Python and serial cleanup: 12 passed; this smoke was the only remaining failure before the fix
- Ruff, Python compile, and diff hygiene: passed
- public/private boundary: 9 checks, 0 errors, 0 warnings
- LoopX premerge: 2 selected checks, 0 failures, 0 manual holds
- change-quality receipt: `cqr_22d64ef0b52312357ef4`, exact scope valid

## Scope

One public smoke file, two added lines. No product runtime, installer protocol, benchmark behavior, credentials, local paths, or compatibility fallback changes.
