### PR TITLE
test(quota): isolate fixture git config

### DIFF
--- a/examples/control_plane/quota-spend-workspace-causality-smoke.py
+++ b/examples/control_plane/quota-spend-workspace-causality-smoke.py
@@ -27,6 +27,10 @@ GOAL_ID = "quota-spend-workspace-causality"
 AGENT_ID = "codex-peer"
 DELIVERY_REPOSITORY = "git:example.invalid/loopx/delivery"
 
+# Keep fixture repositories isolated from user-global Git integrations that
+# may write into .git asynchronously during temporary-directory cleanup.
+os.environ["GIT_CONFIG_GLOBAL"] = os.devnull
+
 
 def run_git(cwd: Path, *args: str) -> None:
     subprocess.run(


### PR DESCRIPTION
## Summary

- isolate the quota workspace smoke's temporary repositories from user-global Git integrations
- prevent asynchronous Trace2 consumers from recreating `.git/ai` during `TemporaryDirectory` cleanup
- keep strict cleanup behavior instead of ignoring deletion failures

## Validation

- direct quota workspace smoke: 20/20 passed
- parent peer-agent runtime suite: 5/5 passed
- Ruff, mypy, py_compile, `git diff --check`: passed
- public boundary: 1 path, 0 errors, 0 warnings
- risk-based premerge: 5/5 selected checks passed, 0 holds
- Change Quality: `cqr_23f9abcfc6589a076af4`, exact diff verified

## Risk

Test-only environment isolation. No runtime, quota policy, persisted-state, benchmark, or release behavior changes.
