### PR TITLE
refactor(quota): finish markdown boundary guards

### DIFF
--- a/loopx/presentation/renderers/quota_markdown.py
+++ b/loopx/presentation/renderers/quota_markdown.py
@@ -288,11 +288,7 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             )
         deferred_resume_candidates = as_list(agent_scope_frontier.get("deferred_resume_candidates"))
         if deferred_resume_candidates:
-            first_candidate = (
-                deferred_resume_candidates[0]
-                if isinstance(deferred_resume_candidates[0], dict)
-                else {}
-            )
+            first_candidate = as_dict(deferred_resume_candidates[0])
             lines.append(
                 "- agent_scope_deferred_resume_candidates: "
                 f"`{len(deferred_resume_candidates)}` "
@@ -302,11 +298,7 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             agent_scope_frontier.get("route_continuation_replan_candidates")
         )
         if route_continuation_candidates:
-            first_candidate = (
-                route_continuation_candidates[0]
-                if isinstance(route_continuation_candidates[0], dict)
-                else {}
-            )
+            first_candidate = as_dict(route_continuation_candidates[0])
             lines.append(
                 "- agent_scope_route_continuation_replan_candidates: "
                 f"`{len(route_continuation_candidates)}` "
@@ -409,18 +401,10 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
         )
         if capability_gate.get("decision_owner"):
             lines.append(f"- capability_gate_decision_owner: {capability_gate.get('decision_owner')}")
-        runnable_candidates = (
-            capability_gate.get("runnable_candidates")
-            if isinstance(capability_gate.get("runnable_candidates"), list)
-            else []
-        )
+        runnable_candidates = as_list(capability_gate.get("runnable_candidates"))
         if runnable_candidates:
             lines.append(f"- capability_gate_runnable_candidates: `{len(runnable_candidates)}`")
-        blocked_candidates = (
-            capability_gate.get("blocked_candidates")
-            if isinstance(capability_gate.get("blocked_candidates"), list)
-            else []
-        )
+        blocked_candidates = as_list(capability_gate.get("blocked_candidates"))
         if blocked_candidates:
             lines.append(f"- capability_gate_blocked_candidates: `{len(blocked_candidates)}`")
     workspace_guard = as_dict(payload.get("workspace_guard"))
@@ -563,11 +547,7 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             f"obligation={work_lane_contract.get('obligation')} "
             f"must_attempt_work={work_lane_contract.get('must_attempt_work')}"
         )
-        reason_codes = (
-            work_lane_contract.get("reason_codes")
-            if isinstance(work_lane_contract.get("reason_codes"), list)
-            else []
-        )
+        reason_codes = as_list(work_lane_contract.get("reason_codes"))
         if reason_codes:
             lines.append(f"- work_lane_reason_codes: {','.join(str(code) for code in reason_codes)}")
         if work_lane_contract.get("monitor_policy"):
@@ -590,11 +570,7 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             )
         if work_lane_contract.get("action"):
             lines.append(f"- work_lane_action: {work_lane_contract.get('action')}")
-        outcome_followthrough = (
-            work_lane_contract.get("outcome_followthrough")
-            if isinstance(work_lane_contract.get("outcome_followthrough"), dict)
-            else {}
-        )
+        outcome_followthrough = as_dict(work_lane_contract.get("outcome_followthrough"))
         if outcome_followthrough:
             lines.append(
                 "- work_lane_outcome_followthrough: "
@@ -668,11 +644,7 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             ("monitor_schedule_gap_items", "monitor_schedule_gap", 1),
             ("current_agent_blocker_items", "current_agent_blocker", 2),
         ):
-            lane_items = (
-                summary.get(lane)
-                if isinstance(summary.get(lane), list)
-                else []
-            )
+            lane_items = as_list(summary.get(lane))
             identities = [
                 (
                     f"{compact_todo_identity(item)} "
@@ -688,22 +660,10 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
                 lines.append(
                     f"- {label}_{suffix}: {'; '.join(identities)}"
                 )
-        succession_warning = (
-            summary.get("todo_succession_warning")
-            if isinstance(summary.get("todo_succession_warning"), dict)
-            else {}
-        )
+        succession_warning = as_dict(summary.get("todo_succession_warning"))
         if succession_warning:
-            projected_todo_ids = (
-                succession_warning.get("todo_ids")
-                if isinstance(succession_warning.get("todo_ids"), list)
-                else []
-            )
-            warning_items = (
-                succession_warning.get("items")
-                if isinstance(succession_warning.get("items"), list)
-                else []
-            )
+            projected_todo_ids = as_list(succession_warning.get("todo_ids"))
+            warning_items = as_list(succession_warning.get("items"))
             todo_ids = [
                 str(todo_id)
                 for todo_id in projected_todo_ids[:3]
@@ -726,11 +686,7 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             and isinstance(summary.get("first_executable_items"), list)
             else "first_open_items"
         )
-        first_open = list(
-            summary.get(first_open_key)
-            if isinstance(summary.get(first_open_key), list)
-            else []
-        )
+        first_open = list(as_list(summary.get(first_open_key)))
         if label == "user_todo" and isinstance(summary.get("user_action_items"), list):
             first_open.extend(
                 item
@@ -764,7 +720,7 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             for todo in first_open
             if isinstance(todo, dict)
         }
-        backlog = summary.get("backlog_items") if isinstance(summary.get("backlog_items"), list) else []
+        backlog = as_list(summary.get("backlog_items"))
         extra_count = 0
         for todo in backlog:
             if not isinstance(todo, dict):
@@ -805,11 +761,7 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             f"source={handoff_readiness.get('source')} "
             f"quota_state={handoff_readiness.get('quota_state')}"
         )
-        interface_budget = (
-            handoff_readiness.get("handoff_interface_budget")
-            if isinstance(handoff_readiness.get("handoff_interface_budget"), dict)
-            else {}
-        )
+        interface_budget = as_dict(handoff_readiness.get("handoff_interface_budget"))
         if interface_budget:
             lines.append(
                 "- handoff_interface_budget: "
@@ -823,11 +775,7 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             f"post_handoff_run_seen={handoff_readiness.get('post_handoff_run_seen')} "
             f"ready_at={handoff_readiness.get('handoff_ready_at') or ''}"
         )
-        latest_handoff_run = (
-            handoff_readiness.get("post_handoff_latest_run")
-            if isinstance(handoff_readiness.get("post_handoff_latest_run"), dict)
-            else {}
-        )
+        latest_handoff_run = as_dict(handoff_readiness.get("post_handoff_latest_run"))
         if latest_handoff_run:
             outcome_suffix = ""
             if latest_handoff_run.get("delivery_outcome"):
@@ -839,11 +787,7 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
                 f"scale={latest_handoff_run.get('delivery_batch_scale') or ''}"
                 f"{outcome_suffix}"
             )
-        recent_handoff_runs = (
-            handoff_readiness.get("post_handoff_recent_runs")
-            if isinstance(handoff_readiness.get("post_handoff_recent_runs"), list)
-            else []
-        )
+        recent_handoff_runs = as_list(handoff_readiness.get("post_handoff_recent_runs"))
         recent_scales = [
             str(run.get("delivery_batch_scale") or "")
             for run in recent_handoff_runs
@@ -989,11 +933,7 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
                 "- boundary_missing_write_scopes: "
                 f"{', '.join(str(value) for value in stall_self_repair.get('missing_write_scopes') or [])}"
             )
-        blockers = (
-            stall_self_repair.get("blocking_health_items")
-            if isinstance(stall_self_repair.get("blocking_health_items"), list)
-            else []
-        )
+        blockers = as_list(stall_self_repair.get("blocking_health_items"))
         for blocker in blockers[:3]:
             if not isinstance(blocker, dict):
                 continue
@@ -1022,11 +962,7 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
         )
         if decision_freshness_warning.get("message"):
             lines.append(f"- decision_freshness_action: {decision_freshness_warning.get('message')}")
-        freshness_items = (
-            decision_freshness_warning.get("items")
-            if isinstance(decision_freshness_warning.get("items"), list)
-            else []
-        )
+        freshness_items = as_list(decision_freshness_warning.get("items"))
         for item in freshness_items[:DECISION_FRESHNESS_WARNING_ITEM_LIMIT]:
             if not isinstance(item, dict):
                 continue
@@ -1079,23 +1015,19 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             )
     goal_boundary = as_dict(payload.get("goal_boundary"))
     if goal_boundary:
-        adapter = goal_boundary.get("adapter") if isinstance(goal_boundary.get("adapter"), dict) else {}
+        adapter = as_dict(goal_boundary.get("adapter"))
         if adapter:
             lines.append(
                 "- goal_boundary_adapter: "
                 f"{adapter.get('kind') or ''}:{adapter.get('status') or ''}"
             )
-        write_scope = goal_boundary.get("write_scope") if isinstance(goal_boundary.get("write_scope"), list) else []
+        write_scope = as_list(goal_boundary.get("write_scope"))
         if write_scope:
             lines.append(f"- goal_boundary_write_scope: {', '.join(str(value) for value in write_scope)}")
-        approvals = (
-            goal_boundary.get("requires_parent_approval")
-            if isinstance(goal_boundary.get("requires_parent_approval"), list)
-            else []
-        )
+        approvals = as_list(goal_boundary.get("requires_parent_approval"))
         if approvals:
             lines.append(f"- goal_boundary_requires_approval: {', '.join(str(value) for value in approvals)}")
-        guards = goal_boundary.get("guards") if isinstance(goal_boundary.get("guards"), list) else []
+        guards = as_list(goal_boundary.get("guards"))
         for guard in guards[:5]:
             lines.append(f"- goal_boundary_guard: {guard}")
         orchestration = (
@@ -1105,15 +1037,9 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
         )
         if orchestration:
             lines.append(f"- goal_boundary_orchestration: {orchestration_policy_summary(orchestration)}")
-        capabilities = (
-            goal_boundary.get("capabilities")
-            if isinstance(goal_boundary.get("capabilities"), dict)
-            else {}
-        )
-        lark_inbox = capabilities.get("lark_event_inbox")
-        lark_inbox = lark_inbox if isinstance(lark_inbox, dict) else {}
-        urgency = lark_inbox.get("urgency")
-        urgency = urgency if isinstance(urgency, dict) else {}
+        capabilities = as_dict(goal_boundary.get("capabilities"))
+        lark_inbox = as_dict(capabilities.get("lark_event_inbox"))
+        urgency = as_dict(lark_inbox.get("urgency"))
         if urgency:
             lines.append(
                 "- goal_boundary_lark_inbox_urgency: "
@@ -1176,7 +1102,7 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
     if payload.get("next_handoff_condition"):
         lines.append(f"- next_handoff_condition: {payload.get('next_handoff_condition')}")
     summary = as_dict(payload.get("plan_summary"))
-    states = summary.get("states") if isinstance(summary.get("states"), dict) else {}
+    states = as_dict(summary.get("states"))
     if summary:
         state_text = ", ".join(f"{state}={states.get(state, 0)}" for state in QUOTA_STATE_ORDER)
         lines.append(


### PR DESCRIPTION
## Summary

- reuse the existing `as_dict` and `as_list` renderer boundary helpers
- remove the final 25 measured empty-fallback `isinstance` expressions
- preserve malformed-input Markdown behavior while reducing the outer renderer from 426 to 424 statements and 246 to 221 decisions

## Validation

- 126 exact old/new renderer outcome parity cases
- 38 focused pytest cases
- repository-configured mypy
- Ruff lint on the changed renderer
- presentation Markdown primitives smoke
- CLI output budget regression smoke
- LoopX public/private scan
- LoopX premerge canary: 4/4 selected checks passed
- change-quality receipt `cqr_9dc0e492071c24763767` verified for the exact diff

The full test suite was not run because this is a single-renderer, behavior-preserving simplification with focused parity and quota/presentation coverage.
